### PR TITLE
feat(auth): providers:operator-key scope — gate operator-API-key fallback (RFC AX)

### DIFF
--- a/.env.insecure.example
+++ b/.env.insecure.example
@@ -557,6 +557,12 @@ LOOMCYCLE_DATA_DIR=./data
 # LOOMCYCLE_AUTH_CACHE_TTL_SECONDS=60                 # operator-token lookup cache TTL
 # LOOMCYCLE_OPERATOR_TOKEN_ROTATION_GRACE_SECONDS=300 # accept a rotated-out token this long
 # LOOMCYCLE_AUTH_VERBOSE=1                             # log auth decisions (debug)
+# RFC AX operator-key restriction (default OFF). When ON, a run whose principal
+# lacks the `providers:operator-key` scope may NOT fall back to the operator's
+# host provider key — it routes only to providers the tenant can key itself (an
+# RFC AR CredentialDef) and is refused 403 if none. Off ⇒ byte-identical for
+# every existing token. NON-secret feature flag.
+# LOOMCYCLE_OPERATOR_KEY_RESTRICTION=1
 
 # ─── MCP tuning ──────────────────────────────────────────────────────
 # (MCP_ALLOW_PRIVILEGED_TOOLS / MCP_ALLOW_DYNAMIC_STDIO are documented above;

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1355,6 +1355,25 @@ func main() {
 		// (operator vs tenant/user spend) from the same resolve it uses for the key.
 		return providers.CredentialResolution{Value: res.Value, Scope: res.Scope, ScopeID: res.ScopeID}, true
 	})
+	// RFC AX Layer 1: a metadata-only keyability probe — does (tenant, agent,
+	// user) have its OWN CredentialDef for env-var `name`? Reuses Engine.Resolve's
+	// agent>user>tenant precedence but NEVER decrypts (no backend.Resolve), so
+	// building a restricted run's keyable-provider set costs at most three store
+	// metadata reads and touches no plaintext. Fast-path false when nothing can
+	// resolve (no KEK) — with no resolvable credentials no provider is
+	// tenant-keyable, the correct restricted-run posture. Wired onto the Server
+	// beside credResolver; consulted in the server BEFORE the lock-free resolver.
+	credKeyable := func(ctx context.Context, tenantID, agentName, userID, name string) bool {
+		if !credEngine.CanResolve() {
+			return false
+		}
+		ok, err := credEngine.HasKey(ctx, tenantID, agentName, userID, name)
+		if err != nil {
+			log.Printf("credential: keyable check %q failed for tenant=%s: %v", name, tenantID, err)
+			return false
+		}
+		return ok
+	}
 	pathTool.Store = storeIface
 	documentTool.Store = storeIface
 	skillTool.Store = storeIface
@@ -1459,6 +1478,9 @@ func main() {
 	// RFC AR: stamp the credential resolver onto each run so a tenant/user's own
 	// provider key (ANTHROPIC_API_KEY, BRAVE_API_KEY, …) overrides the host key.
 	srv.SetCredentialResolver(credResolver)
+	// RFC AX: the keyability probe backs credential-aware routing for a
+	// restricted run (resolves only to providers the tenant can key itself).
+	srv.SetCredKeyable(credKeyable)
 
 	// RFC AA SQL Memory (Phase 1). Off by default; constructed only when the
 	// operator enables it. The manager hosts per-scope sqlite databases that
@@ -1811,7 +1833,9 @@ func main() {
 		// decision, evaluated per request. Previously this was gated on the
 		// legacy token alone, so an operator-token-only deployment left A2A
 		// unauthenticated (deps.Auth nil → anonymous-but-authenticated).
-		a2aAuth := a2aapi.FrontierAuthenticator(srv.AuthConfigured, srv.ResolvePrincipal)
+		// RFC AX: pass the deployment gate so the frontier derives each peer's
+		// operator-key restriction from its own scopes (anti-bypass for A2A).
+		a2aAuth := a2aapi.FrontierAuthenticator(srv.AuthConfigured, srv.ResolvePrincipal, cfg.Env.OperatorKeyRestriction)
 		a2aServer, err = a2aapi.New(context.Background(), a2aapi.Deps{
 			Cfg:   cfg,
 			Store: storeIface,

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -848,6 +848,7 @@ Config knobs (full reference: `loomcycle context help operator-tokens` or the `C
 | `LOOMCYCLE_OPERATOR_TOKEN_ROTATION_GRACE_SECONDS` | Default rotation grace window (default 24h). |
 | `LOOMCYCLE_AUDIT_LOG_PATH` | JSONL audit of every create/rotate/retire (never a token or hash). |
 | `LOOMCYCLE_AUTH_VERBOSE` | `1` logs a server-side reason on a rejected bearer (the wire 401 stays opaque). |
+| `LOOMCYCLE_OPERATOR_KEY_RESTRICTION` | **RFC AX** deployment gate (default OFF). When `1`, a run whose principal lacks `providers:operator-key` may not use the operator's host provider key — resolution routes it only to providers the tenant can key itself (an RFC AR CredentialDef) and refuses `403 operator_key_restricted` if none; the LLM-gateway + embeddings shims refuse a restricted principal outright. OFF ⇒ byte-identical for every existing token. |
 
 Routes enforce a scope from a closed catalog; an under-scoped token gets `403` + `WWW-Authenticate: Bearer scope="…"`. The legacy `LOOMCYCLE_AUTH_TOKEN` is disabled only once an admin-scoped token exists (the no-lockout gate). The catalog:
 
@@ -857,6 +858,7 @@ Routes enforce a scope from a closed catalog; an under-scoped token gets `403` +
 | `substrate:tenant` | **Tenant operator (RFC AF/AG)** — FULL power WITHIN the token's own tenant: runs, channels, authoring all 8 substrate Def families (incl. `_mcpserverdef`, the dynamic-MCP-ingestion surface), registering tool-use hooks, and opening a **tenant-confined** loomcycle-as-MCP-server session (`/v1/_mcp`, RFC AG) — but NOT the operator plane (no minting, no runtime admin, no cross-tenant access). Lets a self-provisioning tenant author its own surface without admin. |
 | `runs:create` / `runs:read` | Create/continue runs · read runs, agents, sessions. |
 | `channel:publish` / `channel:read` | Publish/ack · subscribe/peek on the per-user + system channel surface. |
+| `providers:operator-key` | **RFC AX** — permits a run to fall back to the operator's HOST provider key. **Tenant-implied** (`substrate:tenant` and `substrate:admin` already have it), and **inert unless** `LOOMCYCLE_OPERATOR_KEY_RESTRICTION=1`. To make a tenant pay its own way: set the gate, mint that tenant's principals with granular scopes that OMIT this one (e.g. `runs:create,runs:read`), and give the tenant its own key (an RFC AR CredentialDef). |
 
 `substrate:tenant` satisfies the within-tenant scopes (`runs:*`, `channel:*`, and the def/hook gate) but never `substrate:admin` — so a tenant operator passes the def + hook routes yet is refused minting/runtime-admin. Mint one with `--scopes substrate:tenant`. Confinement is automatic: a non-admin principal's def writes are stamped with its authoritative tenant, cross-tenant reads return an opaque `404`, and a tenant-registered hook fires only on that tenant's runs.
 

--- a/internal/a2a/auth.go
+++ b/internal/a2a/auth.go
@@ -69,6 +69,30 @@ func RoutedTenantFrom(ctx context.Context) (string, bool) {
 	return t, ok
 }
 
+// operatorKeyRestrictedKeyType keys the RFC AX operator-key restriction bit the
+// A2A frontier interceptor derived from the authenticated peer's OWN scopes. The
+// interceptor stamps it on the request ctx (WithOperatorKeyRestricted); the
+// executor reads it in buildRunInput and copies it onto RunInput so a restricted
+// A2A peer can't launder an unrestricted run through the A2A trigger. Kept off
+// the SDK's CallContext.User (which carries only name/authenticated) — it's a
+// loomcycle policy bit, not an SDK auth attribute.
+type operatorKeyRestrictedKeyType struct{}
+
+// WithOperatorKeyRestricted stamps the RFC AX restriction bit onto ctx. The A2A
+// principal interceptor calls this from its Before with the value it derived
+// from the peer's resolved scopes; the returned ctx flows to the executor.
+func WithOperatorKeyRestricted(ctx context.Context, restricted bool) context.Context {
+	return context.WithValue(ctx, operatorKeyRestrictedKeyType{}, restricted)
+}
+
+// OperatorKeyRestrictedFrom returns the RFC AX restriction bit the interceptor
+// stamped, or false when absent (fail-open — matching the negative-bit posture:
+// an un-stamped path keeps operator-key access).
+func OperatorKeyRestrictedFrom(ctx context.Context) bool {
+	v, _ := ctx.Value(operatorKeyRestrictedKeyType{}).(bool)
+	return v
+}
+
 // principalFromContext extracts the authenticated principal from the
 // SDK CallContext on ctx, combined with the request tenant. The tenant
 // argument is the SDK-carried value (SendMessageRequest.Tenant /

--- a/internal/a2a/executor.go
+++ b/internal/a2a/executor.go
@@ -435,6 +435,10 @@ func (e *Executor) buildRunInput(ctx context.Context, execCtx *a2asrv.ExecutorCo
 		TenantID: p.TenantID,
 		UserID:   p.UserID,
 		Segments: []loop.PromptSegment{{Role: "user", Content: blocks}},
+		// RFC AX anti-bypass: carry the operator-key restriction the frontier
+		// interceptor derived from THIS peer's own scopes, so a restricted A2A
+		// peer's run is restricted at admission (RunOnce reads this off RunInput).
+		OperatorKeyRestricted: OperatorKeyRestrictedFrom(ctx),
 	}, nil
 }
 

--- a/internal/api/a2a/auth.go
+++ b/internal/api/a2a/auth.go
@@ -35,32 +35,39 @@ import (
 func FrontierAuthenticator(
 	authConfigured func(context.Context) bool,
 	resolve func(context.Context, string) (auth.Principal, bool),
+	operatorKeyGateOn bool,
 ) Authenticator {
-	return func(h http.Header) (string, bool) {
+	return func(h http.Header) (string, bool, bool) {
 		ctx := context.Background()
 		// Per-request open-mode check: no auth configured ⇒ anonymous, matching
 		// HTTP. Evaluated every call so a runtime-minted admin token flips A2A
-		// closed without a restart.
+		// closed without a restart. Open mode is never restricted (fail-open).
 		if authConfigured == nil || !authConfigured(ctx) {
-			return "anonymous", true
+			return "anonymous", false, true
 		}
 		got := h.Get("Authorization")
 		const pfx = "Bearer "
 		if len(got) <= len(pfx) || !strings.EqualFold(got[:len(pfx)], pfx) {
-			return "", false
+			return "", false, false
 		}
 		if resolve == nil {
-			return "", false
+			return "", false, false
 		}
 		p, ok := resolve(ctx, got[len(pfx):])
 		if !ok {
-			return "", false
+			return "", false, false
 		}
+		// RFC AX: derive the operator-key restriction from the peer's OWN
+		// resolved scopes — the SAME auth.OperatorKeyRestricted used on the
+		// HTTP/gRPC planes, so there's one source of truth. A granular A2A peer
+		// that lacks providers:operator-key is restricted; a legacy peer / one
+		// holding the scope / the gate-off case all fail open (false).
+		restricted := auth.OperatorKeyRestricted(p, ok, operatorKeyGateOn)
 		// Attribution name only. Preserve the legacy peer's historical
 		// "a2a-peer" name; attribute operator-token peers by their subject.
 		if p.Legacy || p.Subject == "" {
-			return "a2a-peer", true
+			return "a2a-peer", restricted, true
 		}
-		return p.Subject, true
+		return p.Subject, restricted, true
 	}
 }

--- a/internal/api/a2a/auth_test.go
+++ b/internal/api/a2a/auth_test.go
@@ -21,22 +21,56 @@ func TestFrontierAuthenticator_OperatorTokenOnlyIsGated(t *testing.T) {
 		}
 		return auth.Principal{}, false
 	}
-	authn := FrontierAuthenticator(authConfigured, resolve)
+	authn := FrontierAuthenticator(authConfigured, resolve, false)
 
 	// No credential → rejected (the interceptor turns this into ErrUnauthenticated).
-	if _, ok := authn(http.Header{}); ok {
+	if _, _, ok := authn(http.Header{}); ok {
 		t.Error("operator-token-only mode: missing bearer must be rejected, got ok=true (A2A open!)")
 	}
 	// Wrong credential → rejected.
 	bad := http.Header{"Authorization": []string{"Bearer nope"}}
-	if _, ok := authn(bad); ok {
+	if _, _, ok := authn(bad); ok {
 		t.Error("operator-token-only mode: invalid bearer must be rejected")
 	}
 	// Valid operator token → accepted, attributed by subject.
 	good := http.Header{"Authorization": []string{"Bearer lct_alice"}}
-	name, ok := authn(good)
+	name, _, ok := authn(good)
 	if !ok || name != "alice" {
 		t.Errorf("valid operator token: name=%q ok=%v, want (\"alice\", true)", name, ok)
+	}
+}
+
+// TestFrontierAuthenticator_RestrictionDerivedFromScopes pins the RFC AX
+// anti-bypass: with the gate ON, the frontier derives each peer's operator-key
+// restriction from its OWN resolved scopes — a granular peer lacking
+// providers:operator-key is restricted; a peer holding it (or the whole
+// substrate:tenant scope) is not. With the gate OFF nobody is restricted.
+func TestFrontierAuthenticator_RestrictionDerivedFromScopes(t *testing.T) {
+	resolve := func(_ context.Context, bearer string) (auth.Principal, bool) {
+		switch bearer {
+		case "granular": // runs:create only — no operator-key scope
+			return auth.Principal{TenantID: "acme", Subject: "bob", Scopes: []string{auth.ScopeRunsCreate}}, true
+		case "keyed": // explicitly granted the operator-key scope
+			return auth.Principal{TenantID: "acme", Subject: "cara", Scopes: []string{auth.ScopeRunsCreate, auth.ScopeProvidersOperatorKey}}, true
+		}
+		return auth.Principal{}, false
+	}
+	hdr := func(b string) http.Header { return http.Header{"Authorization": []string{"Bearer " + b}} }
+	authConfigured := func(context.Context) bool { return true }
+
+	// Gate ON: granular peer is restricted; keyed peer is not.
+	on := FrontierAuthenticator(authConfigured, resolve, true)
+	if _, restricted, ok := on(hdr("granular")); !ok || !restricted {
+		t.Errorf("gate on, granular peer: (restricted=%v, ok=%v), want (true, true)", restricted, ok)
+	}
+	if _, restricted, ok := on(hdr("keyed")); !ok || restricted {
+		t.Errorf("gate on, keyed peer: (restricted=%v, ok=%v), want (false, true)", restricted, ok)
+	}
+
+	// Gate OFF: nobody is restricted (byte-identical to pre-RFC-AX).
+	off := FrontierAuthenticator(authConfigured, resolve, false)
+	if _, restricted, ok := off(hdr("granular")); !ok || restricted {
+		t.Errorf("gate off, granular peer: (restricted=%v, ok=%v), want (false, true)", restricted, ok)
 	}
 }
 
@@ -44,10 +78,10 @@ func TestFrontierAuthenticator_OperatorTokenOnlyIsGated(t *testing.T) {
 // open dev mode), the authenticator passes requests through as anonymous,
 // mirroring the HTTP authMiddleware.
 func TestFrontierAuthenticator_OpenModeAnonymous(t *testing.T) {
-	authn := FrontierAuthenticator(func(context.Context) bool { return false }, nil)
-	name, ok := authn(http.Header{})
-	if !ok || name != "anonymous" {
-		t.Errorf("open mode: name=%q ok=%v, want (\"anonymous\", true)", name, ok)
+	authn := FrontierAuthenticator(func(context.Context) bool { return false }, nil, true)
+	name, restricted, ok := authn(http.Header{})
+	if !ok || name != "anonymous" || restricted {
+		t.Errorf("open mode: name=%q restricted=%v ok=%v, want (\"anonymous\", false, true)", name, restricted, ok)
 	}
 }
 
@@ -62,9 +96,10 @@ func TestFrontierAuthenticator_LegacyPeerKeepsName(t *testing.T) {
 		}
 		return auth.Principal{}, false
 	}
-	authn := FrontierAuthenticator(func(context.Context) bool { return true }, resolve)
-	name, ok := authn(http.Header{"Authorization": []string{"Bearer legacy-secret"}})
-	if !ok || name != "a2a-peer" {
-		t.Errorf("legacy peer: name=%q ok=%v, want (\"a2a-peer\", true)", name, ok)
+	// Gate ON to also prove a legacy peer is never restricted (fail-open).
+	authn := FrontierAuthenticator(func(context.Context) bool { return true }, resolve, true)
+	name, restricted, ok := authn(http.Header{"Authorization": []string{"Bearer legacy-secret"}})
+	if !ok || name != "a2a-peer" || restricted {
+		t.Errorf("legacy peer: name=%q restricted=%v ok=%v, want (\"a2a-peer\", false, true)", name, restricted, ok)
 	}
 }

--- a/internal/api/a2a/routing.go
+++ b/internal/api/a2a/routing.go
@@ -36,7 +36,7 @@ func (p *principalInterceptor) Before(ctx context.Context, callCtx *a2asrv.CallC
 		callCtx.User = a2asrv.NewAuthenticatedUser("anonymous", nil)
 		return ctx, nil, nil
 	}
-	name, ok := p.auth(serviceParamsToHeader(callCtx.ServiceParams()))
+	name, restricted, ok := p.auth(serviceParamsToHeader(callCtx.ServiceParams()))
 	if !ok {
 		// Auth is configured but the request carried no valid credential.
 		// REJECT at the frontier: returning a non-nil error from a
@@ -52,7 +52,9 @@ func (p *principalInterceptor) Before(ctx context.Context, callCtx *a2asrv.CallC
 		return ctx, nil, a2asdk.ErrUnauthenticated
 	}
 	callCtx.User = a2asrv.NewAuthenticatedUser(name, nil)
-	return ctx, nil, nil
+	// RFC AX: thread the peer-derived operator-key restriction to the executor
+	// (the returned ctx propagates to the handler → buildRunInput → RunInput).
+	return bridge.WithOperatorKeyRestricted(ctx, restricted), nil, nil
 }
 
 // serviceParamsToHeader projects the SDK ServiceParams (request headers,

--- a/internal/api/a2a/routing_auth_test.go
+++ b/internal/api/a2a/routing_auth_test.go
@@ -8,6 +8,8 @@ import (
 
 	a2asdk "github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/a2asrv"
+
+	bridge "github.com/denn-gubsky/loomcycle/internal/a2a"
 )
 
 // TestPrincipalInterceptor_RejectsUnauthenticated pins the auth-enforcement
@@ -25,7 +27,7 @@ func TestPrincipalInterceptor_RejectsUnauthenticated(t *testing.T) {
 
 	// Auth configured but the credential is rejected → ErrUnauthenticated,
 	// principal left unauthenticated.
-	denied := principalInterceptor{auth: func(http.Header) (string, bool) { return "", false }}
+	denied := principalInterceptor{auth: func(http.Header) (string, bool, bool) { return "", false, false }}
 	cc := newCtx()
 	if _, _, err := denied.Before(context.Background(), cc, &a2asrv.Request{}); !errors.Is(err, a2asdk.ErrUnauthenticated) {
 		t.Fatalf("Before err = %v, want ErrUnauthenticated", err)
@@ -36,13 +38,29 @@ func TestPrincipalInterceptor_RejectsUnauthenticated(t *testing.T) {
 
 	// Auth configured and the credential is accepted → no error, principal
 	// stamped with the resolved name.
-	ok := principalInterceptor{auth: func(http.Header) (string, bool) { return "alice", true }}
+	ok := principalInterceptor{auth: func(http.Header) (string, bool, bool) { return "alice", false, true }}
 	cc = newCtx()
-	if _, _, err := ok.Before(context.Background(), cc, &a2asrv.Request{}); err != nil {
+	newCtxOut, _, err := ok.Before(context.Background(), cc, &a2asrv.Request{})
+	if err != nil {
 		t.Fatalf("Before err = %v, want nil on accepted auth", err)
 	}
 	if cc.User == nil || !cc.User.Authenticated || cc.User.Name != "alice" {
 		t.Errorf("User = %#v, want authenticated alice", cc.User)
+	}
+	// RFC AX: a non-restricted peer stamps restricted=false on the returned ctx.
+	if bridge.OperatorKeyRestrictedFrom(newCtxOut) {
+		t.Error("non-restricted peer must stamp OperatorKeyRestricted=false")
+	}
+
+	// A RESTRICTED peer → the returned ctx carries the bit for the executor.
+	restricted := principalInterceptor{auth: func(http.Header) (string, bool, bool) { return "bob", true, true }}
+	cc = newCtx()
+	rctx, _, err := restricted.Before(context.Background(), cc, &a2asrv.Request{})
+	if err != nil {
+		t.Fatalf("Before err = %v, want nil on accepted (restricted) auth", err)
+	}
+	if !bridge.OperatorKeyRestrictedFrom(rctx) {
+		t.Error("restricted peer must stamp OperatorKeyRestricted=true on the ctx")
 	}
 
 	// No authenticator (open/dev mode) → anonymous authenticated, no error.

--- a/internal/api/a2a/server.go
+++ b/internal/api/a2a/server.go
@@ -20,16 +20,23 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/runner"
 )
 
-// Authenticator authenticates an inbound A2A request from its headers
-// and returns the principal name to attach to the SDK CallContext. It
-// returns ("", false) for an unauthenticated request — the default-deny
+// Authenticator authenticates an inbound A2A request from its headers and
+// returns the principal name to attach to the SDK CallContext, plus the RFC AX
+// operator-key restriction derived from the peer's OWN resolved scopes. It
+// returns ("", _, false) for an unauthenticated request — the default-deny
 // posture is the caller's (the bridge treats an unauthenticated User as
 // anonymous run ownership; it does NOT widen any allowlist).
+//
+// restricted is meaningful only when ok is true; it is the single-resolve
+// derivation of "may this peer spend the operator's key" (fail-open: false in
+// open mode, for a legacy peer, when the gate is off, or when the peer holds
+// providers:operator-key). The interceptor stamps it on ctx so the executor's
+// buildRunInput can copy it onto RunInput — anti-bypass for the A2A trigger.
 //
 // This is the bearer-header check at the A2A frontier, reusing the same
 // constant-time comparison loomcycle's HTTP authMiddleware uses. It is
 // injected so tests can supply a deterministic fake.
-type Authenticator func(h http.Header) (name string, ok bool)
+type Authenticator func(h http.Header) (name string, restricted bool, ok bool)
 
 // CardAndRunStore is the narrow store surface the A2A server needs: the
 // active-server-card resolver path (lookup), the run-table reader the
@@ -413,6 +420,6 @@ func (s *Server) adminAuthed(r *http.Request) bool {
 		// authorized, matching authMiddleware's open-mode behaviour.
 		return true
 	}
-	_, ok := s.deps.Auth(r.Header)
+	_, _, ok := s.deps.Auth(r.Header)
 	return ok
 }

--- a/internal/api/grpc/server.go
+++ b/internal/api/grpc/server.go
@@ -38,6 +38,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/connector"
 	"github.com/denn-gubsky/loomcycle/internal/loop"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/resolve"
 	"github.com/denn-gubsky/loomcycle/internal/runner"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 )
@@ -1254,6 +1255,13 @@ func mapRunnerErr(err error) error {
 		// Per-scope token budget hard cap reached (RFC AW). ResourceExhausted
 		// mirrors the HTTP 429 refusal + the backpressure/quota flavors above.
 		return status.Error(codes.ResourceExhausted, err.Error())
+	case errors.Is(err, resolve.ErrOperatorKeyRestricted),
+		errors.Is(err, providers.ErrOperatorKeyForbidden):
+		// RFC AX: the run's principal may not spend the operator's provider key
+		// and has no keyable provider of its own (routing refusal) or reached
+		// the driver backstop on a pinned agent. PermissionDenied mirrors the
+		// HTTP 403; the message names the way out (own key / the scope).
+		return status.Error(codes.PermissionDenied, err.Error())
 	default:
 		return status.Errorf(codes.Internal, "runner: %v", err)
 	}

--- a/internal/api/http/agent_subagent_test.go
+++ b/internal/api/http/agent_subagent_test.go
@@ -30,6 +30,11 @@ type scriptedProvider struct {
 	calls    atomic.Int32
 	scripts  [][]providers.Event
 	defaultS []providers.Event // returned for any call past len(scripts)
+	// lastOpKeyAllowed records providers.OperatorKeyAllowed(ctx) from the most
+	// recent Call — RFC AX regression: a restricted run's provider calls (incl.
+	// the compaction summary call, which runs outside the loop) must execute under
+	// a ctx where this is false, so the driver backstop denies the operator key.
+	lastOpKeyAllowed atomic.Bool
 }
 
 func (s *scriptedProvider) ID() string                    { return "scripted" }
@@ -40,7 +45,8 @@ func (s *scriptedProvider) ListModels(_ context.Context) ([]string, error) {
 func (s *scriptedProvider) Capabilities() providers.Capabilities {
 	return providers.Capabilities{Streaming: true}
 }
-func (s *scriptedProvider) Call(_ context.Context, _ providers.Request) (<-chan providers.Event, error) {
+func (s *scriptedProvider) Call(ctx context.Context, _ providers.Request) (<-chan providers.Event, error) {
+	s.lastOpKeyAllowed.Store(providers.OperatorKeyAllowed(ctx))
 	idx := int(s.calls.Add(1)) - 1
 	var events []providers.Event
 	if idx < len(s.scripts) {

--- a/internal/api/http/alias_expansion_test.go
+++ b/internal/api/http/alias_expansion_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"testing"
 
 	"github.com/denn-gubsky/loomcycle/internal/config"
@@ -60,7 +61,7 @@ func TestResolveAgentDef_TierCandidateAliasExpands(t *testing.T) {
 			"low": {{Provider: "ollama-local", Model: "local-gemma"}},
 		},
 	}
-	prov, model, _, err := s.resolveAgentDef(def, "code-reviewer", "")
+	prov, model, _, err := s.resolveAgentDef(context.Background(), def, "", "", "code-reviewer", "", false)
 	if err != nil {
 		t.Fatalf("resolveAgentDef returned error: %v", err)
 	}

--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -304,6 +304,28 @@ func (s *Server) applyPrincipal(ctx context.Context, wireTenant, wireUser string
 	return tenant, subject
 }
 
+// operatorKeyRestrictedForCtx computes the RFC AX restriction bit from the LIVE
+// principal on ctx and the deployment gate — the run-start path for surfaces
+// that carry an auth.Principal (HTTP, and gRPC/MCP/connector via applyPrincipal).
+// Fail-open: no principal (open mode) / legacy / gate-off / scope-present all
+// yield false (operator key allowed). See auth.OperatorKeyRestricted.
+func (s *Server) operatorKeyRestrictedForCtx(ctx context.Context) bool {
+	p, ok := auth.PrincipalFromContext(ctx)
+	return auth.OperatorKeyRestricted(p, ok, s.cfg.Env.OperatorKeyRestriction)
+}
+
+// operatorKeyRestrictedOrCaptured is the RunOnce variant: use the live principal
+// when one is on ctx (gRPC/MCP/connector), else fall back to the bit CAPTURED on
+// a trigger def by a non-principal path (scheduler/webhook/A2A supply it via
+// RunInput.OperatorKeyRestricted). RFC AX §2 anti-bypass: a restricted tenant's
+// captured grant must ride the trigger def since no token is present at fire time.
+func (s *Server) operatorKeyRestrictedOrCaptured(ctx context.Context, captured bool) bool {
+	if p, ok := auth.PrincipalFromContext(ctx); ok {
+		return auth.OperatorKeyRestricted(p, ok, s.cfg.Env.OperatorKeyRestriction)
+	}
+	return captured
+}
+
 // sessionOwnershipOK reports whether the ctx principal may continue or read
 // sess. A continuation runs under / a transcript read exposes the SESSION'S
 // history, so the gate keeps a caller from acting on a session OUTSIDE ITS

--- a/internal/api/http/compact_test.go
+++ b/internal/api/http/compact_test.go
@@ -241,6 +241,54 @@ func TestHandleCompactRun_TerminalPersistsMarker(t *testing.T) {
 	}
 }
 
+// TestCompact_RestrictedRunDeniesOperatorKey (RFC AX): a restricted run's
+// compaction summary is a provider.Call made OUTSIDE the run loop; it must run
+// under a ctx where OperatorKeyAllowed is false, so the driver backstop denies
+// the operator's key. Fail-before: compactRunWithSource called loop.Summarize
+// with an unstamped ctx → OperatorKeyAllowed defaulted TRUE → the summary spent
+// the operator's key (a full bypass for a pinned restricted run).
+func TestCompact_RestrictedRunDeniesOperatorKey(t *testing.T) {
+	srv, prov := compactFixture(t)
+	ctx := context.Background()
+	sess, err := srv.store.CreateSession(ctx, "", "compactor", "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The RESTRICTED bit rides the run row (set at run-start under the gate); the
+	// compaction path reads it back from the row, so set it directly here.
+	run, err := srv.store.CreateRun(ctx, sess.ID, store.RunIdentity{
+		AgentID: "a_r", UserID: "alice", Model: "stub-model", OperatorKeyRestricted: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	uinput := func(text string) []loop.PromptSegment {
+		return []loop.PromptSegment{{Role: "user", Content: []loop.PromptContentBlock{{Type: "trusted-text", Text: text}}}}
+	}
+	for i := 1; i <= 8; i++ {
+		appendResumeEvent(t, srv, run.ID, "user_input", uinput(fmt.Sprintf("question %d", i)))
+		appendResumeEvent(t, srv, run.ID, "text", providers.Event{Type: providers.EventText, Text: fmt.Sprintf("answer %d", i)})
+		appendResumeEvent(t, srv, run.ID, "done", providers.Event{Type: providers.EventDone, StopReason: "end_turn"})
+	}
+	if err := srv.store.FinishRun(ctx, run.ID, store.RunCompleted, "end_turn", store.Usage{}, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := srv.CompactRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("CompactRun: %v", err)
+	}
+	if !res.Compacted {
+		t.Fatalf("expected compaction to run (marker); got %+v", res)
+	}
+	if prov.calls.Load() == 0 {
+		t.Fatal("summary provider was never called")
+	}
+	if prov.lastOpKeyAllowed.Load() {
+		t.Error("compaction summary ran with OperatorKeyAllowed=true; a restricted run must deny the operator's key (Layer-2 backstop would be inert)")
+	}
+}
+
 // TestHandleCompactRun_NoopWhenShort: a conversation below the threshold is a
 // no-op (no model call, no marker).
 func TestHandleCompactRun_NoopWhenShort(t *testing.T) {

--- a/internal/api/http/embeddings_compat.go
+++ b/internal/api/http/embeddings_compat.go
@@ -64,6 +64,17 @@ func (s *Server) handleEmbeddings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// RFC AX (fail-closed): the embedder authenticates with the operator's HOST
+	// key at construction and never consults the per-run operator-key bit (unlike
+	// the LLM drivers' ResolveKeyOrOperator backstop), so stamping the ctx would
+	// be inert here. Refuse a restricted principal outright rather than spend the
+	// operator's embedding budget. Gate-off ⇒ operatorKeyRestrictedForCtx is
+	// always false ⇒ byte-identical. BYO-embedder-key is a future enhancement.
+	if s.operatorKeyRestrictedForCtx(r.Context()) {
+		writeJSONError(w, http.StatusForbidden, "operator_key_restricted", operatorKeyRestrictedMsg)
+		return
+	}
+
 	texts, err := parseEmbeddingsInput(req.Input)
 	if err != nil {
 		writeJSONError(w, http.StatusBadRequest, "bad_request", err.Error())

--- a/internal/api/http/llm_gateway.go
+++ b/internal/api/http/llm_gateway.go
@@ -111,6 +111,21 @@ func (s *Server) prepareGatewayDispatch(w http.ResponseWriter, r *http.Request, 
 		req.MaxTokens = llmGatewayDefaultMaxTokens
 	}
 
+	// RFC AX (fail-closed): the gateway calls provider.Call directly and does NOT
+	// wire the RFC AR credential-override path, so a restricted principal has no
+	// way to bring its own key here — it would spend the operator's key. Both run
+	// enforcement layers (credential-aware routing + the driver backstop) are on
+	// the agent-run path, not this bypass, so refuse at the choke point shared by
+	// /v1/_llm/chat + /v1/chat/completions, both stream and non-stream, before any
+	// bytes are written (a proper 403, which a mid-stream SSE refusal can't give).
+	// Gate-off ⇒ operatorKeyRestrictedForCtx is always false ⇒ byte-identical for
+	// every existing token. BYO-key gateway support (a restricted tenant presenting
+	// its own CredentialDef on the gateway) is a separate future enhancement.
+	if s.operatorKeyRestrictedForCtx(r.Context()) {
+		writeJSONError(w, http.StatusForbidden, "operator_key_restricted", operatorKeyRestrictedMsg)
+		return gatewayDispatch{}, false
+	}
+
 	requestID := newRequestID()
 	startedAt := time.Now()
 

--- a/internal/api/http/operator_key_scope_test.go
+++ b/internal/api/http/operator_key_scope_test.go
@@ -1,0 +1,381 @@
+package http
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/loop"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/resolve"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// keyedScriptedProvider is a scriptedProvider that ALSO advertises a key
+// env-var (implements providers.KeyedProvider). keyableProvidersFor keeps a
+// provider only when it needs no operator key OR the tenant can key it, so a
+// keyed provider with no tenant credential is filtered out of a restricted
+// run's viable set — the exact path RFC AX Layer-1 routing refuses on.
+type keyedScriptedProvider struct {
+	*scriptedProvider
+	env string
+}
+
+func (k *keyedScriptedProvider) KeyEnvName() string { return k.env }
+
+// operatorKeyTierServer builds a resolver-backed server whose one tier ("middle")
+// resolves to the keyed provider, so the RFC AX credential-aware routing path
+// (resolveAgentDef → keyableProvidersFor → resolver.Resolve) actually fires. The
+// registry's Get returns prov for every id (stubResolver), matching the tier's
+// "keyed" provider. gateOn sets the deployment gate; credKeyable (nil = tenant
+// can key nothing) decides whether the keyed provider survives the filter.
+func operatorKeyTierServer(t *testing.T, prov providers.Provider, gateOn bool, credKeyable func(ctx context.Context, tenantID, agentName, userID, name string) bool) (*Server, store.Store) {
+	t.Helper()
+	cfg := &config.Config{
+		ProviderPriority: []string{"keyed"},
+		Tiers: map[string][]config.TierCandidate{
+			"middle": {{Provider: "keyed", Model: "km"}},
+		},
+		Agents: map[string]config.AgentDef{
+			"tiered": {Tier: "middle", SystemPrompt: "you are tiered"},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+		Pricing: config.PricingConfig{
+			Currency: "USD",
+			Models:   map[string]config.ModelPrice{"keyed/km": {Input: 3, Output: 15}},
+		},
+	}
+	cfg.Env.AuthToken = ""
+	cfg.Env.OperatorKeyRestriction = gateOn
+
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "opkey.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	srv := New(cfg, &stubResolver{p: prov}, []tools.Tool{}, concurrency.New(4, 4, time.Second), st)
+	res := resolve.NewResolver([]string{"keyed"}, map[string][]resolve.Candidate{
+		"middle": {{Provider: "keyed", Model: "km"}},
+	})
+	res.SetReachable("keyed", true, []string{"km"}, "")
+	srv.SetResolver(res)
+	if credKeyable != nil {
+		srv.SetCredKeyable(credKeyable)
+	}
+	return srv, st
+}
+
+// completingKeyed returns a keyed provider that finishes a run in one iteration,
+// stamping the given credential source on its Usage (as a real driver would after
+// ResolveKeyOrOperator). model must match the tier candidate for pricing.
+func completingKeyed(env, credSource, credScopeID string) *keyedScriptedProvider {
+	return &keyedScriptedProvider{
+		env: env,
+		scriptedProvider: &scriptedProvider{scripts: [][]providers.Event{{
+			{Type: providers.EventText, Text: "hi"},
+			{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{
+				InputTokens: 1000, OutputTokens: 500, Model: "km",
+				CredentialSource: credSource, CredentialScopeID: credScopeID,
+			}},
+		}}},
+	}
+}
+
+// restrictedPrincipal is a granular, non-admin, non-legacy token that OMITS
+// providers:operator-key — the shape an operator mints to make a tenant pay its
+// own way (RFC AX §1).
+func restrictedPrincipal() auth.Principal {
+	return auth.Principal{TenantID: "acme", Subject: "alice", Scopes: []string{auth.ScopeRunsCreate}}
+}
+
+func postRun(srv *Server, p auth.Principal, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/v1/runs", strings.NewReader(body))
+	req = req.WithContext(auth.WithPrincipal(req.Context(), p))
+	rr := httptest.NewRecorder()
+	srv.handleRuns(rr, req)
+	return rr
+}
+
+const opKeyRunBody = `{"agent":"tiered","agent_id":"%s","segments":[{"role":"user","content":[{"type":"trusted-text","text":"go"}]}]}`
+
+// TestOperatorKeyScope_AdmissionRefusesWhenNoKeyableProvider is the RFC AX §5
+// admission regression: gate on + a granular token lacking providers:operator-key
+// + no tenant credential for the tier's keyed provider ⇒ the resolver's viable
+// set is empty ⇒ 403 with the typed code operator_key_restricted. Fails on the
+// stage-2 code, where resolveErrorToStatus mapped ErrOperatorKeyRestricted to the
+// 400 default and handleRuns wrote plain text (no typed code).
+func TestOperatorKeyScope_AdmissionRefusesWhenNoKeyableProvider(t *testing.T) {
+	prov := completingKeyed("KEYED_API_KEY", "", "")
+	srv, _ := operatorKeyTierServer(t, prov, true, nil) // nil credKeyable ⇒ nothing keyable
+
+	rr := postRun(srv, restrictedPrincipal(),
+		`{"agent":"tiered","agent_id":"a_refused","segments":[{"role":"user","content":[{"type":"trusted-text","text":"go"}]}]}`)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "operator_key_restricted") {
+		t.Fatalf("body missing typed code operator_key_restricted: %s", rr.Body.String())
+	}
+	if prov.scriptedProvider.calls.Load() != 0 {
+		t.Errorf("provider was called %d times; a refused run must never touch the operator key", prov.scriptedProvider.calls.Load())
+	}
+}
+
+// TestOperatorKeyScope_RoutesToTenantKeyableProvider: a restricted run whose
+// tenant CAN key the provider (credKeyable true) routes to it and succeeds — the
+// credential-aware-routing happy path (RFC AX §3). The RFC AV attribution is
+// unchanged: the per-run + ledger credential_source stays "tenant".
+func TestOperatorKeyScope_RoutesToTenantKeyableProvider(t *testing.T) {
+	prov := completingKeyed("KEYED_API_KEY", "tenant", "acme")
+	keyable := func(_ context.Context, _, _, _, name string) bool { return name == "KEYED_API_KEY" }
+	srv, st := operatorKeyTierServer(t, prov, true, keyable)
+
+	rr := postRun(srv, restrictedPrincipal(),
+		`{"agent":"tiered","agent_id":"a_routed","segments":[{"role":"user","content":[{"type":"trusted-text","text":"go"}]}]}`)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	run, err := st.GetRunByAgentID(context.Background(), "a_routed")
+	if err != nil {
+		t.Fatalf("GetRunByAgentID: %v", err)
+	}
+	if !run.OperatorKeyRestricted {
+		t.Errorf("run.OperatorKeyRestricted = false, want true (a restricted run that routed to its own key)")
+	}
+	// RFC AV attribution survives restriction: the tenant key paid.
+	rows, err := st.TokenUsageForRun(context.Background(), run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || rows[0].CredentialSource != "tenant" {
+		t.Fatalf("ledger rows = %+v, want 1 row with source tenant", rows)
+	}
+	if run.CredentialSource != "tenant" {
+		t.Errorf("run summary source = %q, want tenant", run.CredentialSource)
+	}
+}
+
+// TestOperatorKeyScope_GateOffRunsNormally: with the gate OFF, a token lacking
+// providers:operator-key runs exactly as before — no restriction, no keyable
+// filter, the run resolves and completes even though the tenant has no credential.
+// The byte-identical-when-off invariant (RFC AX §1).
+func TestOperatorKeyScope_GateOffRunsNormally(t *testing.T) {
+	prov := completingKeyed("KEYED_API_KEY", "", "")
+	srv, st := operatorKeyTierServer(t, prov, false, nil) // gate off
+
+	rr := postRun(srv, restrictedPrincipal(),
+		`{"agent":"tiered","agent_id":"a_gateoff","segments":[{"role":"user","content":[{"type":"trusted-text","text":"go"}]}]}`)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	run, err := st.GetRunByAgentID(context.Background(), "a_gateoff")
+	if err != nil {
+		t.Fatalf("GetRunByAgentID: %v", err)
+	}
+	if run.OperatorKeyRestricted {
+		t.Errorf("run.OperatorKeyRestricted = true with the gate OFF; must fail open")
+	}
+}
+
+// TestOperatorKeyScope_ScopedPrincipalNotRestricted: with the gate ON, a token
+// that HOLDS providers:operator-key runs normally — proving the scope is the grant
+// that lifts the restriction.
+func TestOperatorKeyScope_ScopedPrincipalNotRestricted(t *testing.T) {
+	prov := completingKeyed("KEYED_API_KEY", "", "")
+	srv, _ := operatorKeyTierServer(t, prov, true, nil) // gate on, nothing keyable
+
+	scoped := auth.Principal{TenantID: "acme", Subject: "alice",
+		Scopes: []string{auth.ScopeRunsCreate, auth.ScopeProvidersOperatorKey}}
+	rr := postRun(srv, scoped,
+		`{"agent":"tiered","agent_id":"a_scoped","segments":[{"role":"user","content":[{"type":"trusted-text","text":"go"}]}]}`)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (holder of providers:operator-key is unrestricted); body: %s",
+			rr.Code, rr.Body.String())
+	}
+}
+
+// TestOperatorKeyScope_SubAgentInheritsRestriction is the anti-escape regression
+// (RFC AX §2): a restricted parent's sub-agent inherits the restriction on its own
+// run row — a child can't launder an unrestricted run out of a restricted parent.
+// Uses pin-path agents (no resolver) so the assertion isolates the RunIdentity
+// threading through runSubAgent, independent of routing.
+func TestOperatorKeyScope_SubAgentInheritsRestriction(t *testing.T) {
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "scripted", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			"parent": {Model: "stub-model", AllowedTools: []string{"Agent"}, SystemPrompt: "parent"},
+			"child":  {Model: "stub-model", SystemPrompt: "child"},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+	}
+	cfg.Env.AuthToken = ""
+	cfg.Env.OperatorKeyRestriction = true
+
+	prov := &scriptedProvider{scripts: [][]providers.Event{
+		{ // parent iter 1: spawn child
+			{Type: providers.EventToolCall, ToolUse: &providers.ToolUse{
+				ID: "tu1", Name: "Agent", Input: []byte(`{"name":"child","prompt":"hi"}`)}},
+			{Type: providers.EventDone, StopReason: "tool_use", Usage: &providers.Usage{}},
+		},
+		{ // child
+			{Type: providers.EventText, Text: "child ran"},
+			{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{}},
+		},
+		{ // parent iter 2: wrap up
+			{Type: providers.EventText, Text: "parent done"},
+			{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{}},
+		},
+	}}
+
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "opkey_sub.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	srv := New(cfg, &stubResolver{p: prov}, []tools.Tool{}, concurrency.New(4, 4, time.Second), st)
+
+	rr := postRun(srv, restrictedPrincipal(),
+		`{"agent":"parent","agent_id":"a_parent","segments":[{"role":"user","content":[{"type":"trusted-text","text":"start"}]}]}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+
+	ctx := context.Background()
+	parent, err := st.GetRunByAgentID(ctx, "a_parent")
+	if err != nil {
+		t.Fatalf("GetRunByAgentID(parent): %v", err)
+	}
+	if !parent.OperatorKeyRestricted {
+		t.Fatalf("parent.OperatorKeyRestricted = false, want true")
+	}
+	children, err := st.ListRunsByParentAgentID(ctx, "a_parent")
+	if err != nil {
+		t.Fatalf("ListRunsByParentAgentID: %v", err)
+	}
+	if len(children) == 0 {
+		t.Fatalf("no sub-agent run found for parent a_parent")
+	}
+	for _, c := range children {
+		if !c.OperatorKeyRestricted {
+			t.Errorf("sub-agent run %q OperatorKeyRestricted = false; a child must inherit the parent's restriction", c.AgentID)
+		}
+	}
+}
+
+// TestOperatorKeyScope_ResumeReRestrictsFromRow is the RFC AX §2 resume
+// regression: the operator-key restriction is restored from the runs column, not
+// re-derived from a principal/gate (the background resume sweep has neither). A
+// paused run stamped OperatorKeyRestricted=true whose tenant can key nothing is
+// flagged unresumable with the restriction error — proving resume honors the row.
+// The deployment gate is OFF here, so the ONLY source of the restriction is the
+// persisted bit: if resume ignored it, resolveAgentDef would route and the run
+// would re-dispatch (n=1) instead.
+func TestOperatorKeyScope_ResumeReRestrictsFromRow(t *testing.T) {
+	prov := completingKeyed("KEYED_API_KEY", "", "")
+	srv, st := operatorKeyTierServer(t, prov, false, nil) // gate OFF, nothing keyable
+	ctx := context.Background()
+
+	sess, err := st.CreateSession(ctx, "", "tiered", "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := st.CreateRun(ctx, sess.ID, store.RunIdentity{
+		AgentID: "a_paused", UserID: "alice", Model: "km", OperatorKeyRestricted: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !run.OperatorKeyRestricted {
+		t.Fatalf("setup: run did not persist OperatorKeyRestricted=true")
+	}
+	appendResumeEvent(t, srv, run.ID, "user_input", []loop.PromptSegment{
+		{Role: "user", Content: []loop.PromptContentBlock{{Type: "trusted-text", Text: "resume me"}}},
+	})
+	if err := st.SetRunPauseState(ctx, run.ID, store.PauseStatePaused); err != nil {
+		t.Fatal(err)
+	}
+
+	n, warnings := srv.ResumePausedRuns(ctx)
+	if n != 0 {
+		t.Fatalf("re-dispatched %d, want 0 (a restricted run with no keyable provider is unresumable)", n)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "restricted") {
+		t.Fatalf("warnings = %v, want 1 mentioning the operator-key restriction", warnings)
+	}
+	got, err := st.GetRun(ctx, run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != store.RunFailed {
+		t.Errorf("resumed run status = %q, want failed (flagged unresumable)", got.Status)
+	}
+}
+
+// TestOperatorKeyScope_GatewayRefusesRestrictedPrincipal is the fail-closed
+// closure of the LLM-gateway hole (RFC AX): /v1/chat/completions calls provider
+// .Call directly and does not wire BYO-key, so a restricted principal must be
+// refused 403 there rather than spend the operator's key. Fails on the stage-2
+// code, where the gateway had no restriction check and the run returned 200.
+func TestOperatorKeyScope_GatewayRefusesRestrictedPrincipal(t *testing.T) {
+	prov := &scriptedProvider{scripts: [][]providers.Event{{
+		{Type: providers.EventText, Text: "hi"},
+		{Type: providers.EventUsage, Usage: &providers.Usage{InputTokens: 1, OutputTokens: 1}, StopReason: "end_turn"},
+		{Type: providers.EventDone, StopReason: "end_turn"},
+	}}}
+	srv, _ := makeServer(t, prov, makeBaseConfig())
+	srv.cfg.Env.OperatorKeyRestriction = true
+
+	body := `{"model":"km","messages":[{"role":"user","content":"hi"}],"loomcycle_provider":"scripted"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req = req.WithContext(auth.WithPrincipal(req.Context(), restrictedPrincipal()))
+	rr := httptest.NewRecorder()
+	srv.handleOpenAICompatChat(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("gateway status = %d, want 403; body: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "operator_key_restricted") {
+		t.Fatalf("gateway body missing operator_key_restricted: %s", rr.Body.String())
+	}
+	if prov.calls.Load() != 0 {
+		t.Errorf("provider called %d times; a refused gateway request must never reach provider.Call", prov.calls.Load())
+	}
+}
+
+// TestOperatorKeyScope_GatewayAllowsScopedPrincipal: a principal holding
+// providers:operator-key (or any unrestricted principal) uses the gateway
+// normally — proving the closure refuses ONLY the restricted principal.
+func TestOperatorKeyScope_GatewayAllowsScopedPrincipal(t *testing.T) {
+	prov := &scriptedProvider{scripts: [][]providers.Event{{
+		{Type: providers.EventText, Text: "hi"},
+		{Type: providers.EventUsage, Usage: &providers.Usage{InputTokens: 1, OutputTokens: 1}, StopReason: "end_turn"},
+		{Type: providers.EventDone, StopReason: "end_turn"},
+	}}}
+	srv, _ := makeServer(t, prov, makeBaseConfig())
+	srv.cfg.Env.OperatorKeyRestriction = true
+
+	scoped := auth.Principal{TenantID: "acme", Subject: "alice",
+		Scopes: []string{auth.ScopeRunsCreate, auth.ScopeProvidersOperatorKey}}
+	body := `{"model":"km","messages":[{"role":"user","content":"hi"}],"loomcycle_provider":"scripted"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req = req.WithContext(auth.WithPrincipal(req.Context(), scoped))
+	rr := httptest.NewRecorder()
+	srv.handleOpenAICompatChat(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("gateway status = %d, want 200 for a scoped principal; body: %s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/api/http/resume.go
+++ b/internal/api/http/resume.go
@@ -93,7 +93,9 @@ func (s *Server) resumePausedRun(ctx context.Context, run store.Run) error {
 		s.flagRunUnresumable(run, fmt.Sprintf("agent %q no longer exists", run.Agent))
 		return fmt.Errorf("agent %q not found", run.Agent)
 	}
-	providerID, model, effort, rerr := s.resolveAgentDef(agentDef, run.Agent, run.UserTier)
+	// RFC AX: restore the operator-key restriction from the runs row so a resumed
+	// run's credential-aware routing matches the original admission.
+	providerID, model, effort, rerr := s.resolveAgentDef(ctx, agentDef, run.TenantID, run.UserID, run.Agent, run.UserTier, run.OperatorKeyRestricted)
 	if rerr != nil {
 		s.flagRunUnresumable(run, fmt.Sprintf("resolve provider/model: %v", rerr))
 		return fmt.Errorf("resolve agent: %w", rerr)
@@ -238,6 +240,10 @@ func (s *Server) resumePausedRun(ctx context.Context, run store.Run) error {
 		ParentContext: run.ParentContext,
 		// UserBearer / UserCredentials are intentionally absent — secrets are
 		// never snapshotted, so a resumed run cannot restore them.
+		// RFC AX: RESTORE the operator-key restriction from the persisted runs
+		// column — the original principal isn't on ctx for a resumed/crash-
+		// recovered run, so the durable bit is the authority.
+		OperatorKeyRestricted: run.OperatorKeyRestricted,
 	}
 	// Store-only emit (no live client to forward to) — the resumed turns
 	// append to the same run's transcript so a re-attaching operator tails them.
@@ -247,6 +253,9 @@ func (s *Server) resumePausedRun(ctx context.Context, run store.Run) error {
 	loopCtx := tools.WithAgentTools(runCtx, toolNames(allowedTools))
 	// RFC AR: honor a tenant/user provider-key override on the resumed run too.
 	loopCtx = providers.WithCredentialResolver(loopCtx, s.credResolver)
+	// RFC AX: mirror the restored negative permission bit onto ctx for the
+	// stage-2 driver backstop (drivers import providers, not auth/tools).
+	loopCtx = providers.WithOperatorKeyAllowed(loopCtx, !run.OperatorKeyRestricted)
 	loopCtx = tools.WithRunIdentity(loopCtx, rid)
 	loopCtx = tools.WithHostPolicy(loopCtx, tools.HostPolicyValue{}) // no caller narrowing snapshotted; operator floor applies
 	loopCtx = tools.WithAgentName(loopCtx, run.Agent)
@@ -292,7 +301,7 @@ func (s *Server) resumePausedRun(ctx context.Context, run store.Run) error {
 	loopCtx = tools.WithDispatcher(loopCtx, dispatcher)
 
 	heartbeat := s.makeHeartbeat(run.ID)
-	fbPolicy, fbReResolve := s.fallbackForRun(run.TenantID, run.Agent, run.UserTier)
+	fbPolicy, fbReResolve := s.fallbackForRun(run.TenantID, run.UserID, run.Agent, run.UserTier, run.OperatorKeyRestricted)
 	gate, deregGate := s.newPauseGate(run.ID)
 	// RFC X Phase 3: a re-dispatched run that itself fans out can park too.
 	loopCtx = tools.WithPauseGate(loopCtx, gate)

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -125,6 +125,15 @@ type Server struct {
 	// after construction. Reads run identity from the ctx it's given.
 	credResolver providers.CredentialResolver
 
+	// credKeyable is the RFC AX Layer-1 metadata-only keyability probe: does
+	// (tenant, agent, user) have its OWN CredentialDef for env-var name? It backs
+	// the credential-aware routing filter built for a restricted run in
+	// resolveAgentDef. Wired via SetCredKeyable (mirrors credResolver); nil ⇒ no
+	// provider is tenant-keyable (so a restricted run refuses unless it routes to
+	// a keyless provider). Called in the SERVER before Resolve — the lock-free
+	// resolver never does credential-store I/O.
+	credKeyable func(ctx context.Context, tenantID, agentName, userID, name string) bool
+
 	// limits is the RFC AW per-scope token-budget tracker: month-to-date
 	// counters + cached soft/hard ceilings, checked at admission and
 	// incremented from recordCallUsage. Always non-nil after New() (a nil store
@@ -811,6 +820,14 @@ func (s *Server) SetResolver(r *resolve.Resolver) { s.resolver = r }
 // key over the operator host key. Nil ⇒ overrides disabled.
 func (s *Server) SetCredentialResolver(r providers.CredentialResolver) { s.credResolver = r }
 
+// SetCredKeyable wires the RFC AX Layer-1 keyability probe (metadata-only:
+// does (tenant, agent, user) have its OWN CredentialDef for env-var name?). The
+// Server uses it to build a restricted run's credential-aware routing filter
+// before resolution. Nil ⇒ no provider is tenant-keyable.
+func (s *Server) SetCredKeyable(fn func(ctx context.Context, tenantID, agentName, userID, name string) bool) {
+	s.credKeyable = fn
+}
+
 // markStalledFn returns a closure suitable for loop.RunOptions.MarkStalled.
 // The loop invokes the closure with the LIVE (provider, model) for the
 // current iteration — which is meaningful when v0.8.2 fallback switched
@@ -893,6 +910,14 @@ func resolveErrorToStatus(err error) int {
 	case errors.Is(err, resolve.ErrTierUnavailable),
 		errors.Is(err, resolve.ErrPinUnavailable):
 		return http.StatusServiceUnavailable
+	case errors.Is(err, resolve.ErrOperatorKeyRestricted),
+		errors.Is(err, resolve.ErrTierAgentNotAvailable):
+		// RFC AX §5: the operator-key restriction is a POLICY refusal (the
+		// principal may not spend the operator's key). ErrTierAgentNotAvailable
+		// is the sibling tier-policy refusal ("agent not available for this
+		// user_tier") — its docstring always said 403 but it silently fell to
+		// the 400 default here; folded in so both policy refusals return 403.
+		return http.StatusForbidden
 	case errors.Is(err, resolve.ErrUnknownAgent),
 		errors.Is(err, runner.ErrUnknownAgent):
 		return http.StatusBadRequest
@@ -902,6 +927,24 @@ func resolveErrorToStatus(err error) int {
 		// config issues that deserve to surface as bad-request.
 		return http.StatusBadRequest
 	}
+}
+
+// operatorKeyRestrictedMsg is the operator-facing refusal (RFC AX §5) shared by
+// every surface that denies a restricted principal the operator's provider key.
+// It names the two ways out — bring your own key or hold the scope — without
+// leaking any config detail.
+const operatorKeyRestrictedMsg = "this principal may not use the operator's provider API keys; bring your own provider key (RFC AR CredentialDef) or grant the providers:operator-key scope"
+
+// writeResolveError surfaces a resolver error to the HTTP client. The RFC AX
+// operator-key refusal gets a typed JSON body (code operator_key_restricted) so
+// adapters can branch on it — mirroring the token_limit_exceeded shape. Every
+// other resolver error keeps the historical plain-text http.Error surface.
+func writeResolveError(w http.ResponseWriter, err error) {
+	if errors.Is(err, resolve.ErrOperatorKeyRestricted) {
+		writeJSONError(w, http.StatusForbidden, "operator_key_restricted", operatorKeyRestrictedMsg)
+		return
+	}
+	http.Error(w, err.Error(), resolveErrorToStatus(err))
 }
 
 // writeQuotaError maps a concurrency semaphore error to HTTP 429. Two
@@ -958,7 +1001,7 @@ func writeQuotaError(w http.ResponseWriter, err error) {
 // has a user_tiers block; otherwise the resolver operates without an
 // overlay (v0.7.x behaviour). Unknown names are rejected upstream
 // before this is called.
-func (s *Server) resolveAgent(ctx context.Context, tenantID, agentName, userTier string) (providerID, model, effort string, err error) {
+func (s *Server) resolveAgent(ctx context.Context, tenantID, userID, agentName, userTier string, restricted bool) (providerID, model, effort string, err error) {
 	// RFC N: resolve at the RUN's authoritative tenant (threaded by the
 	// caller — effectiveTenantID / req.TenantID / sess.TenantID), NOT a
 	// ctx-derived or empty tenant. This is the provider/model resolution +
@@ -970,7 +1013,7 @@ func (s *Server) resolveAgent(ctx context.Context, tenantID, agentName, userTier
 	if !ok {
 		return "", "", "", fmt.Errorf("%w: %s", runner.ErrUnknownAgent, agentName)
 	}
-	return s.resolveAgentDef(def, agentName, userTier)
+	return s.resolveAgentDef(ctx, def, tenantID, userID, agentName, userTier, restricted)
 }
 
 // lookupAgent delegates to internal/lookup.Agent — the canonical
@@ -1012,7 +1055,7 @@ func (s *Server) lookupAgent(ctx context.Context, tenantID, name string) (config
 // static yaml. Without this, a forked sub-agent runs against the
 // static model — silently defeating the whole point of def_id
 // pinning.
-func (s *Server) resolveAgentDef(def config.AgentDef, agentName, userTier string) (providerID, model, effort string, err error) {
+func (s *Server) resolveAgentDef(ctx context.Context, def config.AgentDef, tenantID, userID, agentName, userTier string, restricted bool) (providerID, model, effort string, err error) {
 	hasPin := def.Provider != "" || def.Model != ""
 	hasTier := def.Tier != ""
 
@@ -1035,6 +1078,15 @@ func (s *Server) resolveAgentDef(def config.AgentDef, agentName, userTier string
 			Models:    convertConfigCandidates(def.Models, s.cfg.Models),
 			UserTier:  s.userTierOverlay(userTier),
 		}
+		// RFC AX Layer 1: a restricted run resolves only to providers the tenant
+		// can key itself. Build the filter HERE (credential-store I/O in the
+		// server, not the lock-free resolver), then hand it to Resolve. An
+		// UNRESTRICTED run leaves KeyableProviders nil — zero overhead, unchanged
+		// path (gate-off ⇒ byte-identical). The pin path below never filters (a
+		// pinned agent bypasses routing; the driver backstop guards it).
+		if restricted {
+			req.KeyableProviders = s.keyableProvidersFor(ctx, req, tenantID, agentName, userID)
+		}
 		dec, rerr := s.resolver.Resolve(req)
 		if rerr != nil {
 			return "", "", "", rerr
@@ -1055,6 +1107,37 @@ func (s *Server) resolveAgentDef(def config.AgentDef, agentName, userTier string
 	// agent can declare effort and the driver will translate it
 	// where supported. Empty when not declared.
 	return providerID, model, def.Effort, nil
+}
+
+// keyableProvidersFor builds the RFC AX Layer-1 credential-aware routing filter
+// for a restricted run: the set of provider IDs the run's tenant/user can key
+// itself. It walks req's config cascade (resolver.Cascade — req carries NO
+// filter yet, so this sees every candidate) and, per unique provider, keeps it
+// when it needs no operator key (KeyEnvName "" — ollama-local/code-js/mock) OR
+// the tenant/user has an own CredentialDef for its key env-var (credKeyable, a
+// metadata-only check). Returns a non-nil map even when empty — Resolve reads
+// non-nil as "restricted", so an empty set yields ErrOperatorKeyRestricted
+// rather than an availability outage. All credential-store I/O happens here, in
+// the server, keeping internal/resolve lock-free + credential-agnostic.
+func (s *Server) keyableProvidersFor(ctx context.Context, req resolve.AgentRequest, tenantID, agentName, userID string) map[string]bool {
+	set := map[string]bool{}
+	seen := map[string]bool{}
+	for _, c := range s.resolver.Cascade(req) {
+		if seen[c.Provider] {
+			continue
+		}
+		seen[c.Provider] = true
+		env := ""
+		if p, perr := s.providers.Get(c.Provider); perr == nil {
+			if kp, ok := p.(providers.KeyedProvider); ok {
+				env = kp.KeyEnvName()
+			}
+		}
+		if env == "" || (s.credKeyable != nil && s.credKeyable(ctx, tenantID, agentName, userID, env)) {
+			set[c.Provider] = true
+		}
+	}
+	return set
 }
 
 // userTierOverlay builds the resolver's UserTierOverlay from
@@ -1678,7 +1761,7 @@ func (s *Server) ResolveChannelScope(ctx context.Context, channel string) (strin
 // On no-more-candidates the closure returns an error — the loop
 // then surfaces the ORIGINAL provider error to the caller (the
 // fallback path is terminal for this run).
-func (s *Server) fallbackForRun(tenantID, agentName, userTier string) (loop.FallbackPolicy, func(ctx context.Context, failedProvider, failedModel string, cause error) (providers.Provider, string, string, error)) {
+func (s *Server) fallbackForRun(tenantID, userID, agentName, userTier string, restricted bool) (loop.FallbackPolicy, func(ctx context.Context, failedProvider, failedModel string, cause error) (providers.Provider, string, string, error)) {
 	overlay := s.userTierOverlay(userTier)
 	if overlay == nil || !overlay.FallbackOnError {
 		return loop.FallbackPolicy{}, nil
@@ -1701,8 +1784,9 @@ func (s *Server) fallbackForRun(tenantID, agentName, userTier string) (loop.Fall
 		// (RFC N — captured tenantID, not a ctx-derived/empty tenant). The
 		// resolver's stall flag we just set excludes the failed pair; the
 		// next non-stalled candidate in the user_tier's priority is what
-		// we get back.
-		newProviderID, newModel, newEffort, err := s.resolveAgent(ctx, tenantID, agentName, userTier)
+		// we get back. RFC AX: carry the SAME restriction so a restricted run
+		// can't fall back to a provider it can't key.
+		newProviderID, newModel, newEffort, err := s.resolveAgent(ctx, tenantID, userID, agentName, userTier, restricted)
 		if err != nil {
 			return nil, "", "", err
 		}
@@ -1809,6 +1893,13 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 		defer releaseLock()
 	}
 
+	// RFC AX: use the live principal when one is on ctx (gRPC/MCP/connector);
+	// else fall back to the bit CAPTURED on the trigger def and supplied via
+	// RunInput (scheduler/webhook/A2A have no principal at fire time). A
+	// continuation recomputes from the presenting principal (current token is
+	// authority), matching handleMessages.
+	operatorKeyRestricted := s.operatorKeyRestrictedOrCaptured(ctx, in.OperatorKeyRestricted)
+
 	if effectiveAgentName == "" {
 		return fmt.Errorf("%w: agent is required", runner.ErrInvalidArgument)
 	}
@@ -1824,7 +1915,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	// from the v0.8.15 fallback above are NOT in that map. Pass the
 	// already-resolved AgentDef through resolveAgentDef instead (same
 	// path the v0.8.5 sub-agent overlay uses).
-	providerID, model, effort, err := s.resolveAgentDef(agentDef, effectiveAgentName, in.UserTier)
+	providerID, model, effort, err := s.resolveAgentDef(ctx, agentDef, effectiveTenantID, effectiveUserID, effectiveAgentName, in.UserTier, operatorKeyRestricted)
 	if err != nil {
 		return err // already wrapped with runner.Err* sentinel
 	}
@@ -1921,7 +2012,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	}
 
 	// ---- Session+run creation ----
-	identity := store.RunIdentity{AgentID: agentID, UserID: effectiveUserID, TenantID: effectiveTenantID, UserTier: in.UserTier, Model: model, ReplicaID: s.replicaID, ParentContext: in.ParentContext, IdempotencyKey: in.IdempotencyKey, Interactive: in.Interactive}
+	identity := store.RunIdentity{AgentID: agentID, UserID: effectiveUserID, TenantID: effectiveTenantID, UserTier: in.UserTier, Model: model, ReplicaID: s.replicaID, ParentContext: in.ParentContext, IdempotencyKey: in.IdempotencyKey, Interactive: in.Interactive, OperatorKeyRestricted: operatorKeyRestricted}
 	sessionID, runID, sessErr := s.openOrCreateSessionAndRun(ctx, in.SessionID, effectiveAgentName, effectiveTenantID, effectiveUserID, identity)
 	if sessErr != nil {
 		var nf *store.ErrNotFound
@@ -2023,14 +2114,15 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	// identity (makeRecordingEmit is built before WithRunIdentity below) and
 	// both consumers stamp the SAME value.
 	rid := tools.RunIdentityValue{
-		UserID:          effectiveUserID,
-		TenantID:        effectiveTenantID, // RFC L: authoritative tenant (memory tenancy key)
-		AgentID:         agentID,
-		RootRunID:       runID, // RFC AH Phase 2b: top-level run roots its own spawn tree
-		UserTier:        in.UserTier,
-		UserBearer:      in.UserBearer,      // v0.8.x: per-run MCP bearer
-		UserCredentials: in.UserCredentials, // v1.x RFC F: per-tool named credentials
-		ParentContext:   in.ParentContext,   // v0.12.x: opaque tracking lineage, inherited by sub-agents
+		UserID:                effectiveUserID,
+		TenantID:              effectiveTenantID, // RFC L: authoritative tenant (memory tenancy key)
+		AgentID:               agentID,
+		RootRunID:             runID, // RFC AH Phase 2b: top-level run roots its own spawn tree
+		UserTier:              in.UserTier,
+		UserBearer:            in.UserBearer,      // v0.8.x: per-run MCP bearer
+		UserCredentials:       in.UserCredentials, // v1.x RFC F: per-tool named credentials
+		ParentContext:         in.ParentContext,   // v0.12.x: opaque tracking lineage, inherited by sub-agents
+		OperatorKeyRestricted: operatorKeyRestricted,
 	}
 	emit := s.makeRecordingEmit(ctx, runID, rid, sessionID, func(ev providers.Event) {
 		if cb.OnEvent != nil {
@@ -2052,6 +2144,9 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	// RFC AR: honor a tenant/user provider-key override (ANTHROPIC_API_KEY,
 	// BRAVE_API_KEY, …) for this run. Sub-agents inherit it via subRunCtx←ctx.
 	loopCtx = providers.WithCredentialResolver(loopCtx, s.credResolver)
+	// RFC AX: mirror the negative permission bit onto ctx for the stage-2
+	// driver backstop (drivers import providers, not auth/tools).
+	loopCtx = providers.WithOperatorKeyAllowed(loopCtx, !operatorKeyRestricted)
 	loopCtx = tools.WithRunIdentity(loopCtx, rid)
 	loopCtx = tools.WithHostPolicy(loopCtx, hostPolicy)
 	// Memory tool policy: agent name + per-agent scope allowlist +
@@ -2105,7 +2200,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	// fan-out parent can park mid-tool-call (no-op unless LOOMCYCLE_RESUME_FANOUT).
 	loopCtx = tools.WithPauseGate(loopCtx, gate)
 
-	fbPolicy, fbReResolve := s.fallbackForRun(effectiveTenantID, effectiveAgentName, in.UserTier)
+	fbPolicy, fbReResolve := s.fallbackForRun(effectiveTenantID, effectiveUserID, effectiveAgentName, in.UserTier, operatorKeyRestricted)
 	res, runErr := loop.Run(loopCtx, loop.RunOptions{
 		Provider:               provider,
 		Model:                  model,
@@ -3103,6 +3198,12 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	// tenant-scoped dynamic agent as "unknown agent" (RFC N runtime QA BUG-1).
 	req.TenantID, req.UserID = s.applyPrincipal(r.Context(), req.TenantID, req.UserID)
 
+	// RFC AX: compute the operator-key restriction from the live principal +
+	// the deployment gate, once, so the run identity / row / ctx all agree.
+	// Fail-open when the gate is off or no principal is present (stage 1 threads
+	// it; enforcement is stage 2).
+	operatorKeyRestricted := s.operatorKeyRestrictedForCtx(r.Context())
+
 	// Existence-check the agent at the run's authoritative tenant.
 	agentDef, ok := s.lookupAgent(r.Context(), req.TenantID, req.Agent)
 	if !ok {
@@ -3143,9 +3244,9 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	// (req.TenantID / req.UserID were made authoritative above via
 	// applyPrincipal — fairness key, session tenant, run-row attribution,
 	// and threaded RunIdentity all derive from them.)
-	providerID, model, effort, err := s.resolveAgent(r.Context(), req.TenantID, req.Agent, req.UserTier)
+	providerID, model, effort, err := s.resolveAgent(r.Context(), req.TenantID, req.UserID, req.Agent, req.UserTier, operatorKeyRestricted)
 	if err != nil {
-		http.Error(w, err.Error(), resolveErrorToStatus(err))
+		writeResolveError(w, err)
 		return
 	}
 	provider, err := s.providers.Get(providerID)
@@ -3280,7 +3381,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	// emitted event through the store before forwarding to SSE. With
 	// s.store == nil the recording becomes a no-op so v0.2 callers see no
 	// behaviour change.
-	identity := store.RunIdentity{AgentID: agentID, UserID: req.UserID, TenantID: req.TenantID, UserTier: req.UserTier, Model: model, ReplicaID: s.replicaID, ParentContext: req.ParentContext, Interactive: req.Interactive}
+	identity := store.RunIdentity{AgentID: agentID, UserID: req.UserID, TenantID: req.TenantID, UserTier: req.UserTier, Model: model, ReplicaID: s.replicaID, ParentContext: req.ParentContext, Interactive: req.Interactive, OperatorKeyRestricted: operatorKeyRestricted}
 	sessionID, runID, sessErr := s.openOrCreateSessionAndRun(r.Context(), req.SessionID, req.Agent, req.TenantID, req.UserID, identity)
 	if sessErr != nil {
 		var nf *store.ErrNotFound
@@ -3443,14 +3544,15 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	// Hoisted above the recording emit so usage is attributed under the run's
 	// true identity (see makeRecordingEmit) and WithRunIdentity below reuses it.
 	rid := tools.RunIdentityValue{
-		UserID:          req.UserID,
-		TenantID:        req.TenantID, // RFC L: authoritative tenant (memory tenancy key)
-		AgentID:         agentID,
-		RootRunID:       runID, // RFC AH Phase 2b: top-level run roots its own spawn tree
-		UserTier:        req.UserTier,
-		UserBearer:      req.UserBearer,      // v0.8.x: per-run MCP bearer
-		UserCredentials: req.UserCredentials, // v1.x RFC F: per-tool named credentials
-		ParentContext:   req.ParentContext,   // v0.12.x: opaque tracking lineage, inherited by sub-agents
+		UserID:                req.UserID,
+		TenantID:              req.TenantID, // RFC L: authoritative tenant (memory tenancy key)
+		AgentID:               agentID,
+		RootRunID:             runID, // RFC AH Phase 2b: top-level run roots its own spawn tree
+		UserTier:              req.UserTier,
+		UserBearer:            req.UserBearer,      // v0.8.x: per-run MCP bearer
+		UserCredentials:       req.UserCredentials, // v1.x RFC F: per-tool named credentials
+		ParentContext:         req.ParentContext,   // v0.12.x: opaque tracking lineage, inherited by sub-agents
+		OperatorKeyRestricted: operatorKeyRestricted,
 	}
 	// Persist under runCtx so events survive a client disconnect on an
 	// interactive run (runCtx tracks the request for a normal run).
@@ -3478,6 +3580,9 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	// RFC AR: honor a tenant/user provider-key override (ANTHROPIC_API_KEY,
 	// BRAVE_API_KEY, …) for this run. Sub-agents inherit it via subRunCtx←ctx.
 	loopCtx = providers.WithCredentialResolver(loopCtx, s.credResolver)
+	// RFC AX: mirror the negative permission bit onto ctx (drivers import
+	// providers, not auth/tools) so the stage-2 driver backstop can read it.
+	loopCtx = providers.WithOperatorKeyAllowed(loopCtx, !operatorKeyRestricted)
 	loopCtx = tools.WithRunIdentity(loopCtx, rid)
 	// Stash the caller's host policy so any sub-agents spawned by the
 	// Agent tool inherit the same allowed_hosts / WebSearchFilter
@@ -3519,7 +3624,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	// minutes → presumed dead). Cheap (~10–100 calls per run).
 	heartbeat := s.makeHeartbeat(runID)
 
-	fbPolicy, fbReResolve := s.fallbackForRun(req.TenantID, req.Agent, req.UserTier)
+	fbPolicy, fbReResolve := s.fallbackForRun(req.TenantID, req.UserID, req.Agent, req.UserTier, operatorKeyRestricted)
 	runOpts := loop.RunOptions{
 		Provider:               provider,
 		Model:                  model,
@@ -3775,9 +3880,14 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	if body.ParentContext.IsZero() {
 		body.ParentContext = nil
 	}
-	providerID, model, effort, err := s.resolveAgent(r.Context(), sess.TenantID, sess.Agent, body.UserTier)
+	// RFC AX: recompute the operator-key restriction from the PRESENTING
+	// principal (the current token is authority on a continuation — a documented
+	// decision, not the original run's bit). Computed here so credential-aware
+	// routing (resolveAgent) and the fallback cascade both honor it.
+	operatorKeyRestricted := s.operatorKeyRestrictedForCtx(r.Context())
+	providerID, model, effort, err := s.resolveAgent(r.Context(), sess.TenantID, sess.UserID, sess.Agent, body.UserTier, operatorKeyRestricted)
 	if err != nil {
-		http.Error(w, err.Error(), resolveErrorToStatus(err))
+		writeResolveError(w, err)
 		return
 	}
 	provider, err := s.providers.Get(providerID)
@@ -3877,14 +3987,16 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	// inherited from the session (set at original creation). user_tier
 	// is per-request (v0.8.2) — a user upgrading mid-session sees
 	// the new tier applied immediately on this continuation.
+	// operatorKeyRestricted was computed above from the presenting principal.
 	run, err := s.store.CreateRun(r.Context(), id, store.RunIdentity{
-		AgentID:       agentID,
-		UserID:        sess.UserID,
-		TenantID:      sess.TenantID, // RFC L: continuation inherits the session's authoritative tenant
-		UserTier:      body.UserTier,
-		Model:         model,
-		ReplicaID:     s.replicaID,
-		ParentContext: body.ParentContext, // v0.12.x: tracking lineage for this continuation + its sub-agents
+		AgentID:               agentID,
+		UserID:                sess.UserID,
+		TenantID:              sess.TenantID, // RFC L: continuation inherits the session's authoritative tenant
+		UserTier:              body.UserTier,
+		Model:                 model,
+		ReplicaID:             s.replicaID,
+		ParentContext:         body.ParentContext, // v0.12.x: tracking lineage for this continuation + its sub-agents
+		OperatorKeyRestricted: operatorKeyRestricted,
 	})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -3976,14 +4088,15 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	// Hoisted above the recording emit so usage is attributed under the run's
 	// true identity (see makeRecordingEmit) and WithRunIdentity below reuses it.
 	rid := tools.RunIdentityValue{
-		UserID:          sess.UserID,
-		TenantID:        sess.TenantID, // RFC L: tenant from the session (authoritative at creation)
-		AgentID:         agentID,
-		RootRunID:       run.ID, // RFC AH Phase 2b: continuation roots its own spawn tree
-		UserTier:        body.UserTier,
-		UserBearer:      body.UserBearer,      // v0.8.x: per-run MCP bearer
-		UserCredentials: body.UserCredentials, // v1.x RFC F: per-tool named credentials
-		ParentContext:   body.ParentContext,   // v0.12.x: opaque tracking lineage, inherited by sub-agents
+		UserID:                sess.UserID,
+		TenantID:              sess.TenantID, // RFC L: tenant from the session (authoritative at creation)
+		AgentID:               agentID,
+		RootRunID:             run.ID, // RFC AH Phase 2b: continuation roots its own spawn tree
+		UserTier:              body.UserTier,
+		UserBearer:            body.UserBearer,      // v0.8.x: per-run MCP bearer
+		UserCredentials:       body.UserCredentials, // v1.x RFC F: per-tool named credentials
+		ParentContext:         body.ParentContext,   // v0.12.x: opaque tracking lineage, inherited by sub-agents
+		OperatorKeyRestricted: operatorKeyRestricted,
 	}
 	emit := s.makeRecordingEmit(r.Context(), run.ID, rid, id, stream.send)
 	// RFC AW: emit any soft budget crossings found at admission so the warning
@@ -4001,6 +4114,9 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	// RFC AR: honor a tenant/user provider-key override (ANTHROPIC_API_KEY,
 	// BRAVE_API_KEY, …) for this run. Sub-agents inherit it via subRunCtx←ctx.
 	loopCtx = providers.WithCredentialResolver(loopCtx, s.credResolver)
+	// RFC AX: mirror the negative permission bit onto ctx for the stage-2
+	// driver backstop (drivers import providers, not auth/tools).
+	loopCtx = providers.WithOperatorKeyAllowed(loopCtx, !operatorKeyRestricted)
 	loopCtx = tools.WithRunIdentity(loopCtx, rid)
 	// Sub-agents spawned by this continuation must inherit the
 	// caller-authoritative host narrowing, same as runRequest +
@@ -4044,7 +4160,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	defer deregGate()
 	// RFC X Phase 3: expose the gate to the Agent tool (parallel_spawn parent park).
 	loopCtx = tools.WithPauseGate(loopCtx, gate)
-	fbPolicy, fbReResolve := s.fallbackForRun(sess.TenantID, sess.Agent, body.UserTier)
+	fbPolicy, fbReResolve := s.fallbackForRun(sess.TenantID, sess.UserID, sess.Agent, body.UserTier, operatorKeyRestricted)
 	loopRes, runErr := loop.Run(loopCtx, loop.RunOptions{
 		Provider:               provider,
 		Model:                  model,
@@ -4827,16 +4943,21 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 		def = applyAgentDefOverlay(def, row.Definition)
 	}
 
-	// v0.8.2: inherit parent's user_tier via ctx. The Agent built-in
-	// tool can't pass it explicitly (the tool's input schema is
-	// caller-authoritative). Reading from ctx keeps the same tier
+	// Read parent's identity from ctx to inherit user_id, tenant, user_tier, and
+	// the RFC AX operator-key restriction, and to pin parent_agent_id on the
+	// sub-run. tools.RunIdentity returns zero value if the parent didn't set it —
+	// sub-agents spawned from callers that didn't supply user_id naturally
+	// inherit empty. v0.8.2: reading user_tier from ctx keeps the same tier
 	// policy + fallback posture applied to the whole sub-run tree.
-	parentTier := tools.RunIdentity(ctx).UserTier
+	parentIdentity := tools.RunIdentity(ctx)
+	parentTier := parentIdentity.UserTier
 
 	// Route through resolveAgentDef so an overlay's Model/Tier/Provider/
 	// Effort actually take effect. resolveAgent re-reads cfg.Agents and
-	// would silently discard the fork's values.
-	providerID, model, effort, err := s.resolveAgentDef(def, name, parentTier)
+	// would silently discard the fork's values. RFC AX: a child INHERITS the
+	// parent's operator-key restriction — it can't escape by spawning, so
+	// credential-aware routing applies to the sub-run too.
+	providerID, model, effort, err := s.resolveAgentDef(ctx, def, parentIdentity.TenantID, parentIdentity.UserID, name, parentTier, parentIdentity.OperatorKeyRestricted)
 	if err != nil {
 		return "", "", fmt.Errorf("resolve sub-agent %q model: %w", name, err)
 	}
@@ -4844,12 +4965,6 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 	if err != nil {
 		return "", "", fmt.Errorf("provider for sub-agent %q: %w", name, err)
 	}
-
-	// Read parent's identity from ctx to inherit user_id and pin
-	// parent_agent_id on the sub-run. tools.RunIdentity returns zero
-	// value if the parent didn't set it — sub-agents spawned from
-	// callers that didn't supply user_id naturally inherit empty.
-	parentIdentity := tools.RunIdentity(ctx)
 
 	// Generate a fresh agent_id for the sub-run. Always generated;
 	// callers can't override (the sub is loomcycle-controlled).
@@ -4879,6 +4994,9 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 		// the propagation seam — remove it and child run rows lose their
 		// link back to the user-initiated request.
 		ParentContext: parentIdentity.ParentContext.Clone(),
+		// RFC AX: a child INHERITS the parent's operator-key restriction — it
+		// cannot escape by spawning. Persisted so a resumed sub-run keeps it.
+		OperatorKeyRestricted: parentIdentity.OperatorKeyRestricted,
 	}
 	subSessionID, subRunID, err := s.openOrCreateSessionAndRun(ctx, "", name, parentIdentity.TenantID, parentIdentity.UserID, subIdentity)
 	if err != nil {
@@ -5042,6 +5160,10 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 		UserBearer:      parentIdentity.UserBearer,            // v0.8.x: bearer inherited identically (same end-user)
 		UserCredentials: parentIdentity.UserCredentials,       // v1.x RFC F: credentials map inherited identically
 		ParentContext:   parentIdentity.ParentContext.Clone(), // v0.12.x: tracking lineage flows to grandchildren too
+		// RFC AX: inherit the parent's operator-key restriction (a child cannot
+		// escape). The providers ctx value inherits automatically via
+		// subRunCtx←ctx (same as WithCredentialResolver), so no re-stamp needed.
+		OperatorKeyRestricted: parentIdentity.OperatorKeyRestricted,
 	}
 	// Sub-emit records to the sub's transcript only — the parent's SSE
 	// stream is fwd=no-op so sub events don't bleed into the parent's
@@ -5137,7 +5259,7 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 	// that itself parallel_spawns) can park mid-tool-call too.
 	subCtx = tools.WithPauseGate(subCtx, subGate)
 
-	fbPolicy, fbReResolve := s.fallbackForRun(tenantFromCtx(ctx), name, parentTier)
+	fbPolicy, fbReResolve := s.fallbackForRun(tenantFromCtx(ctx), parentIdentity.UserID, name, parentTier, parentIdentity.OperatorKeyRestricted)
 	res, runErr := loop.Run(subCtx, loop.RunOptions{
 		Provider:            provider,
 		Model:               model,
@@ -5868,7 +5990,9 @@ func (s *Server) compactRunWithSource(ctx context.Context, runID, source string)
 	if !ok {
 		return connector.CompactResult{}, &compactErr{status: http.StatusConflict, code: "agent_gone", msg: "the run's agent no longer exists"}
 	}
-	providerID, model, _, rerr := s.resolveAgentDef(agentDef, run.Agent, run.UserTier)
+	// RFC AX: a restricted run's compaction summary call must also route only to
+	// tenant-keyable providers (never the operator's key).
+	providerID, model, _, rerr := s.resolveAgentDef(ctx, agentDef, run.TenantID, run.UserID, run.Agent, run.UserTier, run.OperatorKeyRestricted)
 	if rerr != nil {
 		return connector.CompactResult{}, &compactErr{status: http.StatusInternalServerError, msg: "resolve provider/model: " + rerr.Error()}
 	}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -6025,7 +6025,18 @@ func (s *Server) compactRunWithSource(ctx context.Context, runID, source string)
 	if !splitOK {
 		return connector.CompactResult{RunID: runID, Compacted: false, BeforeTokens: before, AfterTokens: before, Applied: "noop"}, nil
 	}
-	summary, serr := loop.Summarize(ctx, provider, summaryModel, msgs[firstIdx:cut], targetPct)
+	// RFC AX: compaction summarizes via a provider.Call made OUTSIDE the run loop,
+	// so the summary ctx must carry the same credential context a run's loopCtx does
+	// (mirrors resume.go). Without WithOperatorKeyAllowed the driver backstop is
+	// inert (fail-open) and a restricted run's summary would spend the operator's
+	// key — Layer-1 routing above skips PINNED agents, so this Layer-2 stamp is the
+	// guarantee; and without the resolver/identity a restricted tenant's OWN key
+	// would be ignored (mis-attributed + wrongly refused).
+	summCtx := providers.WithCredentialResolver(ctx, s.credResolver)
+	summCtx = providers.WithOperatorKeyAllowed(summCtx, !run.OperatorKeyRestricted)
+	summCtx = tools.WithRunIdentity(summCtx, tools.RunIdentityValue{TenantID: run.TenantID, UserID: run.UserID})
+	summCtx = tools.WithAgentName(summCtx, run.Agent)
+	summary, serr := loop.Summarize(summCtx, provider, summaryModel, msgs[firstIdx:cut], targetPct)
 	if serr != nil {
 		return connector.CompactResult{}, &compactErr{status: http.StatusBadGateway, msg: "summarize: " + serr.Error()}
 	}

--- a/internal/api/webhook/runinput.go
+++ b/internal/api/webhook/runinput.go
@@ -174,6 +174,9 @@ func buildRunInput(w config.Webhook, proj projectResult, envAllowlist map[string
 		// attacker-influenceable payload). There is deliberately no
 		// payload_mapping / run_metadata path for tenant (RFC N follow-up).
 		TenantID: w.TenantID,
+		// RFC AX: the captured operator-key restriction — no principal is on ctx
+		// at delivery time, so the def's captured bit is authority (anti-bypass).
+		OperatorKeyRestricted: w.OperatorKeyRestricted,
 		// IdempotencyKey is set by the caller (deliverSpawn) to the
 		// delivery id, keeping this builder's signature focused on the
 		// Def + projected payload. See RFC H Decision 10 "Layer 2".

--- a/internal/auth/scopes.go
+++ b/internal/auth/scopes.go
@@ -27,6 +27,14 @@ const (
 	ScopeChannelPublish = "channel:publish"
 	ScopeChannelRead    = "channel:read"
 
+	// ScopeProvidersOperatorKey (RFC AX) gates whether a run may fall back to
+	// the operator's HOST provider API key. It is tenant-implied (below), so
+	// substrate:admin and substrate:tenant retain operator-key access. It exists
+	// so an operator running LOOMCYCLE_OPERATOR_KEY_RESTRICTION can mint granular
+	// tokens that OMIT this scope, forcing that tenant to bring its own key
+	// (RFC AR CredentialDef). Absent the deployment gate the scope is inert.
+	ScopeProvidersOperatorKey = "providers:operator-key"
+
 	// NOTE: memory:read / memory:write are intentionally NOT in the
 	// catalog. They were inert — grantable but enforced by no route: the
 	// HTTP memory surface (/v1/_memory/*) is operator-admin, and
@@ -41,12 +49,13 @@ const (
 // scopeCatalog is the closed set — every entry is enforced by at least
 // one route in requiredScopeFor. A map for O(1) validation.
 var scopeCatalog = map[string]struct{}{
-	ScopeAdmin:          {},
-	ScopeTenant:         {},
-	ScopeRunsCreate:     {},
-	ScopeRunsRead:       {},
-	ScopeChannelPublish: {},
-	ScopeChannelRead:    {},
+	ScopeAdmin:                {},
+	ScopeTenant:               {},
+	ScopeRunsCreate:           {},
+	ScopeRunsRead:             {},
+	ScopeChannelPublish:       {},
+	ScopeChannelRead:          {},
+	ScopeProvidersOperatorKey: {},
 }
 
 // tenantImplied is the set ScopeTenant satisfies. A tenant operator covers
@@ -55,11 +64,12 @@ var scopeCatalog = map[string]struct{}{
 // plane: minting, runtime admin, cross-tenant). Confinement to the principal's
 // tenant is enforced per-handler, NOT here.
 var tenantImplied = map[string]struct{}{
-	ScopeTenant:         {},
-	ScopeRunsCreate:     {},
-	ScopeRunsRead:       {},
-	ScopeChannelPublish: {},
-	ScopeChannelRead:    {},
+	ScopeTenant:               {},
+	ScopeRunsCreate:           {},
+	ScopeRunsRead:             {},
+	ScopeChannelPublish:       {},
+	ScopeChannelRead:          {},
+	ScopeProvidersOperatorKey: {},
 }
 
 // ValidScope reports whether s is in the closed catalog.
@@ -99,4 +109,23 @@ func HasScope(granted []string, want string) bool {
 		}
 	}
 	return false
+}
+
+// OperatorKeyRestricted reports whether a run under principal p must be denied
+// the operator's host provider key (RFC AX §2). It is a NEGATIVE bit stored as
+// false = allowed, so every unstamped / default path fails OPEN — the deliberate
+// backward-safety trade (a granular token minted before the scope existed must
+// not silently lose operator-key access on upgrade).
+//
+// "Restricted" ≝ gate on ∧ principal present ∧ non-legacy ∧ non-admin ∧
+// ¬HasScope(providers:operator-key). Admin is covered because HasScope treats
+// substrate:admin as satisfying every scope; substrate:tenant is covered because
+// the scope is tenant-implied — so both pass (not restricted). ok is the
+// PrincipalFromContext presence bool (false = open mode → never restricted);
+// gateOn is cfg.Env.OperatorKeyRestriction.
+func OperatorKeyRestricted(p Principal, ok bool, gateOn bool) bool {
+	if !ok || !gateOn || p.Legacy || HasScope(p.Scopes, ScopeProvidersOperatorKey) {
+		return false
+	}
+	return true
 }

--- a/internal/auth/scopes_test.go
+++ b/internal/auth/scopes_test.go
@@ -45,3 +45,65 @@ func TestValidScope_Tenant(t *testing.T) {
 		t.Errorf("UnknownScopes flagged valid scopes: %v", bad)
 	}
 }
+
+// TestHasScope_ProvidersOperatorKey locks RFC AX's scope semantics: the new
+// providers:operator-key scope is tenant-implied, so substrate:admin AND
+// substrate:tenant satisfy it, an explicit grant satisfies it, and a narrow
+// runs-only token does NOT. It is also in the closed catalog (grantable).
+func TestHasScope_ProvidersOperatorKey(t *testing.T) {
+	if !ValidScope(ScopeProvidersOperatorKey) {
+		t.Fatal("providers:operator-key must be a valid catalog scope (grantable)")
+	}
+	if !HasScope([]string{ScopeAdmin}, ScopeProvidersOperatorKey) {
+		t.Error("substrate:admin should satisfy providers:operator-key (superuser)")
+	}
+	if !HasScope([]string{ScopeTenant}, ScopeProvidersOperatorKey) {
+		t.Error("substrate:tenant should satisfy providers:operator-key (tenant-implied)")
+	}
+	if !HasScope([]string{ScopeProvidersOperatorKey}, ScopeProvidersOperatorKey) {
+		t.Error("an explicit providers:operator-key grant should satisfy itself")
+	}
+	if HasScope([]string{ScopeRunsCreate}, ScopeProvidersOperatorKey) {
+		t.Error("runs:create must NOT satisfy providers:operator-key")
+	}
+}
+
+// TestOperatorKeyRestricted_Matrix pins the RFC AX helper: restricted only when
+// the gate is on AND a real (non-legacy, non-admin, un-scoped) principal is
+// present AND lacks the scope. Every other combination is fail-OPEN (false =
+// operator key allowed) — the deliberate backward-safety posture.
+func TestOperatorKeyRestricted_Matrix(t *testing.T) {
+	granular := Principal{TenantID: "acme", Subject: "bot", Scopes: []string{ScopeRunsCreate, ScopeRunsRead}}
+	tenantOp := Principal{TenantID: "acme", Subject: "op", Scopes: []string{ScopeTenant}}
+	adminP := Principal{TenantID: "", Subject: "root", Scopes: []string{ScopeAdmin}}
+	legacyP := Principal{TenantID: "default", Subject: "default", Legacy: true}
+	explicitP := Principal{TenantID: "acme", Subject: "bot", Scopes: []string{ScopeRunsCreate, ScopeProvidersOperatorKey}}
+
+	cases := []struct {
+		name   string
+		p      Principal
+		ok     bool
+		gateOn bool
+		want   bool
+	}{
+		// The ONLY restricted case: gate on + present + granular w/o the scope.
+		{"gate_on_granular_restricted", granular, true, true, true},
+		// Gate off ⇒ byte-identical old behavior for every token.
+		{"gate_off_granular", granular, true, false, false},
+		// Open mode (no principal) never restricts.
+		{"open_mode", Principal{}, false, true, false},
+		// Legacy LOOMCYCLE_AUTH_TOKEN is never restricted.
+		{"legacy", legacyP, true, true, false},
+		// tenant-implied ⇒ substrate:tenant passes (RFC AX documented trade-off).
+		{"tenant_operator", tenantOp, true, true, false},
+		// Admin is covered because HasScope treats substrate:admin as universal.
+		{"admin", adminP, true, true, false},
+		// An explicit grant passes even when the gate is on.
+		{"explicit_grant", explicitP, true, true, false},
+	}
+	for _, c := range cases {
+		if got := OperatorKeyRestricted(c.p, c.ok, c.gateOn); got != c.want {
+			t.Errorf("%s: OperatorKeyRestricted = %v, want %v", c.name, got, c.want)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1733,6 +1733,13 @@ type Webhook struct {
 	PayloadMapping map[string]string   `json:"payload_mapping,omitempty" yaml:"payload_mapping"`
 	SyncResponse   WebhookSyncResponse `json:"sync_response,omitempty" yaml:"sync_response"`
 	OnComplete     []ScheduledRunHook  `json:"on_complete,omitempty" yaml:"on_complete"`
+	// OperatorKeyRestricted is the RFC AX negative permission bit. For a DYNAMIC
+	// WebhookDef it is CAPTURED from the authoring principal (server authority);
+	// the receiver copies it into RunInput so the fired run keeps its creator's
+	// operator-key restriction. A static operator-authored yaml webhook leaves it
+	// false (the operator is unrestricted). Flows write→read→consumer alongside
+	// TenantID; drift-tested against mergedWebhookDef / SubstrateWebhookDef.
+	OperatorKeyRestricted bool `json:"operator_key_restricted,omitempty" yaml:"operator_key_restricted"`
 }
 
 // WebhookAuth declares how inbound webhook requests are authenticated.
@@ -1969,7 +1976,14 @@ type Env struct {
 	// when a bearer is rejected. Off by default; the wire 401 stays
 	// opaque regardless (no oracle) — this only affects local logs.
 	AuthVerbose bool
-	DataDir     string
+	// OperatorKeyRestriction (LOOMCYCLE_OPERATOR_KEY_RESTRICTION=1) is the
+	// RFC AX deployment gate. Default OFF ⇒ byte-identical behavior for every
+	// existing token (a granular token minted before providers:operator-key
+	// existed keeps operator-key access). When ON, a run whose principal lacks
+	// the scope is restricted from the operator's host provider key. Stage 1
+	// only THREADS the resulting bit; enforcement lands in stage 2.
+	OperatorKeyRestriction bool
+	DataDir                string
 	// HTTPHostAllowlist is the comma-separated list of hostnames the
 	// HTTP and WebFetch tools may reach. Empty = both tools refuse all
 	// calls. Suffix-matched: an entry "example.com" matches both
@@ -2808,6 +2822,7 @@ func LoadLayers(layers ...Layer) (*Config, error) {
 		SecretKeyPrevious:         os.Getenv("LOOMCYCLE_SECRET_KEY_PREVIOUS"),
 		AuditLogPath:              os.Getenv("LOOMCYCLE_AUDIT_LOG_PATH"),
 		AuthVerbose:               os.Getenv("LOOMCYCLE_AUTH_VERBOSE") == "1",
+		OperatorKeyRestriction:    os.Getenv("LOOMCYCLE_OPERATOR_KEY_RESTRICTION") == "1",
 		DataDir:                   getenvDefault("LOOMCYCLE_DATA_DIR", "./data"),
 		HTTPHostAllowlist:         splitCSV(os.Getenv("LOOMCYCLE_HTTP_HOST_ALLOWLIST")),
 		HTTPPrivateHostAllowlist:  splitCSV(os.Getenv("LOOMCYCLE_HTTP_PRIVATE_HOST_ALLOWLIST")),

--- a/internal/credential/engine.go
+++ b/internal/credential/engine.go
@@ -135,6 +135,41 @@ func (e *Engine) Resolve(ctx context.Context, tenantID, agentName, userID, name 
 	return Resolved{}, false, nil
 }
 
+// HasKey reports whether a credential named `name` exists in ANY scope visible
+// to (tenantID, agentName, userID), using the SAME agent > user > tenant
+// precedence as Resolve — but a METADATA-ONLY presence check: it calls
+// CredentialDefGet and NEVER decrypts (no backend.Resolve), so RFC AX Layer-1
+// credential-aware routing can test provider keyability without touching any
+// plaintext. Respects CanResolve (no KEK ⇒ false ⇒ nothing is tenant-keyable,
+// the correct restricted-run default). agentName / userID may be "" (that scope
+// is skipped). Returns (false, nil) when absent from every visible scope; a
+// store fault other than not-found propagates.
+func (e *Engine) HasKey(ctx context.Context, tenantID, agentName, userID, name string) (bool, error) {
+	if !e.CanResolve() {
+		return false, nil
+	}
+	buckets := []struct{ scope, id string }{
+		{"agent", agentName},
+		{"user", userID},
+		{"tenant", ""},
+	}
+	for _, b := range buckets {
+		if b.scope != "tenant" && b.id == "" {
+			continue // no identity for this scope on the run
+		}
+		_, err := e.store.CredentialDefGet(ctx, tenantID, b.scope, b.id, name)
+		if err != nil {
+			var nf *store.ErrNotFound
+			if errors.As(err, &nf) {
+				continue // not in this scope — try the next
+			}
+			return false, err
+		}
+		return true, nil // present in this scope — no decrypt needed
+	}
+	return false, nil
+}
+
 func (e *Engine) backendFor(name string) (Backend, error) {
 	switch name {
 	case BackendInline:

--- a/internal/credential/engine_test.go
+++ b/internal/credential/engine_test.go
@@ -96,6 +96,50 @@ func TestEngine_MissAndFailClosed(t *testing.T) {
 	}
 }
 
+// RFC AX: HasKey is a metadata-only presence check reusing Resolve's
+// agent>user>tenant precedence — it reports whether a credential named `name`
+// exists in ANY scope visible to (tenant, agent, user), WITHOUT decrypting.
+func TestEngine_HasKey_PrecedenceAndFastPath(t *testing.T) {
+	e := newEngine(t, testKey(1))
+	ctx := context.Background()
+	put := func(scope, scopeID string) {
+		if _, err := e.PutInline(ctx, Identity{TenantID: "t", Scope: scope, ScopeID: scopeID, Name: "ANTHROPIC_API_KEY"}, "sk-x", nil); err != nil {
+			t.Fatalf("put %s/%s: %v", scope, scopeID, err)
+		}
+	}
+
+	// (1) Tenant-scope credential is visible to any user of the tenant.
+	put("tenant", "")
+	if ok, err := e.HasKey(ctx, "t", "some-agent", "some-user", "ANTHROPIC_API_KEY"); err != nil || !ok {
+		t.Errorf("tenant-scope key: HasKey = (%v, %v), want (true, nil)", ok, err)
+	}
+	// A different tenant sees nothing (isolation).
+	if ok, _ := e.HasKey(ctx, "other", "", "", "ANTHROPIC_API_KEY"); ok {
+		t.Error("HasKey leaked a credential across tenants")
+	}
+	// An absent name is false.
+	if ok, _ := e.HasKey(ctx, "t", "", "", "OPENAI_API_KEY"); ok {
+		t.Error("HasKey reported an absent credential as present")
+	}
+
+	// (2) Agent/user-scoped credential is detected under the specific scope only.
+	put("user", "alice")
+	if ok, _ := e.HasKey(ctx, "t", "", "alice", "ANTHROPIC_API_KEY"); !ok {
+		t.Error("user-scope key not detected for its own user")
+	}
+	put("agent", "breeder")
+	if ok, _ := e.HasKey(ctx, "t", "breeder", "", "ANTHROPIC_API_KEY"); !ok {
+		t.Error("agent-scope key not detected for its own agent")
+	}
+
+	// (3) CanResolve fast-path: a KEK-less engine can key nothing (the correct
+	// restricted-run default) — returns false without touching the store.
+	disabled := newEngine(t, "")
+	if ok, err := disabled.HasKey(ctx, "t", "", "", "ANTHROPIC_API_KEY"); err != nil || ok {
+		t.Errorf("no-KEK engine: HasKey = (%v, %v), want (false, nil)", ok, err)
+	}
+}
+
 func TestEngine_ResolveIsTenantIsolated(t *testing.T) {
 	e := newEngine(t, testKey(1))
 	ctx := context.Background()

--- a/internal/help/builtin/operator-tokens.md
+++ b/internal/help/builtin/operator-tokens.md
@@ -36,7 +36,8 @@ user/tenant by editing the request body.
 
 `substrate:admin` (superuser — satisfies every scope), `substrate:tenant`
 (tenant operator — RFC AF), `runs:create`, `runs:read`, `channel:publish`,
-`channel:read`. Every catalog scope is enforced by at least one route —
+`channel:read`, `providers:operator-key` (RFC AX — may spend the operator's
+host provider key; tenant-implied). Every catalog scope is enforced by at least one route —
 operators can't invent scope names, and the catalog intentionally excludes
 scopes no route checks (a scope that enforces nothing is a false
 limitation). The default at create is `["substrate:admin"]`, so a first
@@ -59,6 +60,20 @@ at boot) with `--scopes substrate:tenant` instead of handing it admin.
 Confinement is automatic — a non-admin principal's def writes are stamped
 with its authoritative tenant, cross-tenant reads return an opaque 404, and
 a tenant-registered hook fires only on that tenant's runs.
+
+**`providers:operator-key`** (RFC AX) gates whether a run may fall back to the
+operator's HOST provider API key. It is **tenant-implied** — `substrate:admin`
+and `substrate:tenant` (and the legacy `LOOMCYCLE_AUTH_TOKEN`) already have it —
+and **inert unless** the deployment sets `LOOMCYCLE_OPERATOR_KEY_RESTRICTION=1`.
+To make a tenant pay its own way on a restricting deployment: (1) set the gate;
+(2) mint that tenant's principals with granular scopes that OMIT this one (and
+`substrate:*`), e.g. `--scopes runs:create,runs:read`; (3) give the tenant its
+own provider key (an RFC AR CredentialDef named after the key env-var). A
+restricted run then routes only to providers the tenant can key itself and is
+refused **403** `operator_key_restricted` (gRPC `PermissionDenied`) if none —
+never touching the operator's key. Because it's tenant-implied, a
+`substrate:tenant` token can't itself be restricted; restriction is expressed
+with granular tokens (the confined-API-consumer shape anyway).
 
 ## Managing tokens
 

--- a/internal/lookup/schedule.go
+++ b/internal/lookup/schedule.go
@@ -114,6 +114,12 @@ type SubstrateScheduleDef struct {
 	OnComplete             []SubstrateScheduleHook `json:"on_complete,omitempty"`
 	Metadata               map[string]any          `json:"metadata,omitempty"`
 	TenantID               string                  `json:"tenant_id,omitempty"`
+	// OperatorKeyRestricted (RFC AX) mirrors mergedScheduleDef so the def
+	// round-trips losslessly through the lookup. NOTE: the scheduler fire path
+	// reads it via scheduler.scheduleDef (unmarshalDef → buildRunInput), NOT via
+	// ToConfigDef — so config.ScheduledRun deliberately carries no such field.
+	// Present here only to keep the three JSON mirrors drift-parity-clean.
+	OperatorKeyRestricted bool `json:"operator_key_restricted,omitempty"`
 }
 
 // SubstratePromptSegment mirrors config.ScheduledRunSegment with

--- a/internal/lookup/schedule_test.go
+++ b/internal/lookup/schedule_test.go
@@ -199,6 +199,10 @@ func TestSchedule_DriftDetection(t *testing.T) {
 		"on_complete":               true,
 		"metadata":                  true, // non-secret agent metadata (PR 2/2)
 		"tenant_id":                 true, // tenant the fired run executes as (RFC N follow-up)
+		// RFC AX: captured operator-key restriction (anti-bypass). Deliberately
+		// NOT on config.ScheduledRun — the scheduler fire path reads it via
+		// scheduler.scheduleDef (unmarshalDef→buildRunInput), not ToConfigDef.
+		"operator_key_restricted": true,
 	}
 	have := scheduleJsonTagsOf(reflect.TypeOf(lookup.SubstrateScheduleDef{}))
 	for tag := range want {

--- a/internal/lookup/webhook.go
+++ b/internal/lookup/webhook.go
@@ -109,6 +109,9 @@ type SubstrateWebhookDef struct {
 	PayloadMapping         map[string]string         `json:"payload_mapping,omitempty"`
 	SyncResponse           SubstrateWebhookSyncResp  `json:"sync_response,omitempty"`
 	OnComplete             []config.ScheduledRunHook `json:"on_complete,omitempty"`
+	// OperatorKeyRestricted (RFC AX) mirrors mergedWebhookDef — captured from the
+	// authoring principal, projected onto config.Webhook for the receiver.
+	OperatorKeyRestricted bool `json:"operator_key_restricted,omitempty"`
 }
 
 // SubstrateWebhookAuth mirrors config.WebhookAuth.
@@ -167,6 +170,7 @@ func (s SubstrateWebhookDef) ToConfigDef() config.Webhook {
 			Enabled:   s.SyncResponse.Enabled,
 			TimeoutMs: s.SyncResponse.TimeoutMs,
 		},
-		OnComplete: s.OnComplete,
+		OnComplete:            s.OnComplete,
+		OperatorKeyRestricted: s.OperatorKeyRestricted,
 	}
 }

--- a/internal/lookup/webhook_test.go
+++ b/internal/lookup/webhook_test.go
@@ -155,6 +155,7 @@ func TestWebhook_DriftDetection(t *testing.T) {
 		"payload_mapping":           true,
 		"sync_response":             true,
 		"on_complete":               true,
+		"operator_key_restricted":   true, // RFC AX: captured operator-key restriction (anti-bypass)
 	}
 	have := a2aJSONTagsOf(reflect.TypeOf(lookup.SubstrateWebhookDef{}))
 	assertTagSetsEqual(t, "SubstrateWebhookDef", want, have)

--- a/internal/loop/fallback_test.go
+++ b/internal/loop/fallback_test.go
@@ -265,6 +265,39 @@ func TestFallback_PermanentError_PropagatesRegardlessOfPolicy(t *testing.T) {
 	}
 }
 
+// TestFallback_OperatorKeyForbidden_NotCascaded pins the RFC AX Layer-2
+// invariant at the loop: a restricted run's driver refusal
+// (providers.ErrOperatorKeyForbidden) is classified non-retryable, so
+// tryProviderFallback must NOT cascade it across providers (which would burn the
+// identical refusal on each). The error propagates as the run's terminal error.
+func TestFallback_OperatorKeyForbidden_NotCascaded(t *testing.T) {
+	failing := &tieredProvider{
+		id:     "anthropic",
+		errors: []error{providers.ErrOperatorKeyForbidden},
+	}
+	reResolveCalls := 0
+	opts := RunOptions{
+		Provider:       failing,
+		Model:          "claude-sonnet-4-6",
+		MaxIterations:  5,
+		Segments:       []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "hi"}}}},
+		OnEvent:        func(ev providers.Event) {},
+		FallbackPolicy: FallbackPolicy{Enabled: true, MaxAttempts: 3, UserTierName: "high"},
+		ReResolve: func(_ context.Context, _, _ string, _ error) (providers.Provider, string, string, error) {
+			reResolveCalls++
+			t.Error("ReResolve was called for an operator-key refusal — should NOT happen")
+			return nil, "", "", nil
+		},
+	}
+	_, err := Run(context.Background(), opts)
+	if !errors.Is(err, providers.ErrOperatorKeyForbidden) {
+		t.Fatalf("err = %v, want ErrOperatorKeyForbidden to propagate", err)
+	}
+	if reResolveCalls != 0 {
+		t.Errorf("ReResolve called %d times; want 0 (policy refusal, not retryable)", reResolveCalls)
+	}
+}
+
 // TestFallback_AnthropicToOther_EmitsCacheInvalidated — when the
 // failing provider is anthropic and the new one isn't, the loop
 // must emit EventCacheInvalidated alongside EventProviderFallback.

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -1463,8 +1463,13 @@ outerLoop:
 			// to the right method.
 			//
 			// ctx errors are user-side cancellation, not provider
-			// faults — don't pollute the matrix on either path.
-			if ctx.Err() == nil {
+			// faults — don't pollute the matrix on either path. RFC AX: an
+			// operator-key refusal is a PER-RUN policy decision (this restricted
+			// run may not use the operator key), not a model outage — marking the
+			// (provider, model) stalled would poison the shared availability
+			// matrix and wrongly exclude the model from OTHER (non-restricted)
+			// runs for the probe interval. Skip matrix feedback for it.
+			if ctx.Err() == nil && !errors.Is(err, providers.ErrOperatorKeyForbidden) {
 				if providers.IsRateLimit(err) {
 					if opts.MarkRateLimited != nil {
 						opts.MarkRateLimited(opts.Provider.ID(), opts.Model, 0)

--- a/internal/providers/anthropic/credkey_test.go
+++ b/internal/providers/anthropic/credkey_test.go
@@ -2,6 +2,7 @@ package anthropic
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
@@ -13,8 +14,8 @@ import (
 func TestResolveKey_OverridesHostKey(t *testing.T) {
 	d := &Driver{apiKey: "host-key"}
 
-	if key, source, _ := d.resolveKey(context.Background()); key != "host-key" || source != "operator" {
-		t.Errorf("no resolver: (%q, %q), want (host-key, operator)", key, source)
+	if key, source, _, err := d.resolveKey(context.Background()); err != nil || key != "host-key" || source != "operator" {
+		t.Errorf("no resolver: (%q, %q, %v), want (host-key, operator, nil)", key, source, err)
 	}
 
 	ctx := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (providers.CredentialResolution, bool) {
@@ -23,15 +24,42 @@ func TestResolveKey_OverridesHostKey(t *testing.T) {
 		}
 		return providers.CredentialResolution{}, false
 	})
-	if key, source, _ := d.resolveKey(ctx); key != "tenant-key" || source != "tenant" {
-		t.Errorf("with override: (%q, %q), want (tenant-key, tenant)", key, source)
+	if key, source, _, err := d.resolveKey(ctx); err != nil || key != "tenant-key" || source != "tenant" {
+		t.Errorf("with override: (%q, %q, %v), want (tenant-key, tenant, nil)", key, source, err)
 	}
 
 	// A resolver that only knows a DIFFERENT provider's key leaves us on the host key.
 	ctxOther := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (providers.CredentialResolution, bool) {
 		return providers.CredentialResolution{Value: "openai-key"}, name == "OPENAI_API_KEY"
 	})
-	if key, source, _ := d.resolveKey(ctxOther); key != "host-key" || source != "operator" {
-		t.Errorf("unrelated override: (%q, %q), want (host-key, operator)", key, source)
+	if key, source, _, err := d.resolveKey(ctxOther); err != nil || key != "host-key" || source != "operator" {
+		t.Errorf("unrelated override: (%q, %q, %v), want (host-key, operator, nil)", key, source, err)
+	}
+}
+
+// RFC AX: a RESTRICTED run (operator-key not allowed) with no own override must
+// refuse with ErrOperatorKeyForbidden — never leak the operator host key. An
+// override still wins regardless of the restriction; an allowed run uses the
+// host key as before.
+func TestResolveKey_RestrictedRefusesHostKey(t *testing.T) {
+	d := &Driver{apiKey: "host-key"}
+
+	restricted := providers.WithOperatorKeyAllowed(context.Background(), false)
+	if key, _, _, err := d.resolveKey(restricted); !errors.Is(err, providers.ErrOperatorKeyForbidden) || key != "" {
+		t.Errorf("restricted, no override: (%q, %v), want (\"\", ErrOperatorKeyForbidden)", key, err)
+	}
+
+	// Override present → used regardless of the restriction (the tenant pays).
+	withOverride := providers.WithCredentialResolver(restricted, func(_ context.Context, name string) (providers.CredentialResolution, bool) {
+		return providers.CredentialResolution{Value: "tenant-key", Scope: "tenant"}, name == "ANTHROPIC_API_KEY"
+	})
+	if key, source, _, err := d.resolveKey(withOverride); err != nil || key != "tenant-key" || source != "tenant" {
+		t.Errorf("restricted, with override: (%q, %q, %v), want (tenant-key, tenant, nil)", key, source, err)
+	}
+
+	// Allowed run (default) uses the host key.
+	allowed := providers.WithOperatorKeyAllowed(context.Background(), true)
+	if key, source, _, err := d.resolveKey(allowed); err != nil || key != "host-key" || source != "operator" {
+		t.Errorf("allowed, no override: (%q, %q, %v), want (host-key, operator, nil)", key, source, err)
 	}
 }

--- a/internal/providers/anthropic/driver.go
+++ b/internal/providers/anthropic/driver.go
@@ -56,14 +56,17 @@ func (d *Driver) ID() string { return "anthropic" }
 // credential scope it came from. A tenant/user credential named
 // ANTHROPIC_API_KEY overrides the operator's host key (RFC AR); source is
 // "operator" when none did. The source/scopeID ride the per-call Usage so the
-// server can attribute spend (RFC AV). Model-availability probes (fetchModels)
-// stay on the operator key — which models are reachable is an operator concern.
-func (d *Driver) resolveKey(ctx context.Context) (key, source, scopeID string) {
-	if r, ok := providers.ResolveCredentialFull(ctx, "ANTHROPIC_API_KEY"); ok {
-		return r.Value, r.Scope, r.ScopeID
-	}
-	return d.apiKey, "operator", ""
+// server can attribute spend (RFC AV). RFC AX: a RESTRICTED run with no override
+// gets ErrOperatorKeyForbidden instead of the host key — Call aborts on it.
+// Model-availability probes (fetchModels) stay on the operator key — which
+// models are reachable is an operator concern.
+func (d *Driver) resolveKey(ctx context.Context) (key, source, scopeID string, err error) {
+	return providers.ResolveKeyOrOperator(ctx, "ANTHROPIC_API_KEY", d.apiKey)
 }
+
+// KeyEnvName reports the env-var name whose tenant/user credential can key this
+// provider (RFC AX Layer-1 routing). Same literal resolveKey resolves.
+func (d *Driver) KeyEnvName() string { return "ANTHROPIC_API_KEY" }
 
 func (d *Driver) Capabilities() providers.Capabilities {
 	return providers.Capabilities{
@@ -101,7 +104,12 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 
 	// RFC AR/AV: resolve the key + its owning scope ONCE per call (not per retry
 	// attempt) so the header uses it and the source rides the per-call Usage.
-	apiKey, credSource, credScopeID := d.resolveKey(ctx)
+	// RFC AX: a restricted run with no override refuses here (never the host key).
+	apiKey, credSource, credScopeID, err := d.resolveKey(ctx)
+	if err != nil {
+		cancelStream()
+		return nil, err
+	}
 
 	attempt := func(attemptCtx context.Context) (*http.Response, error) {
 		// v0.10.0 OTEL: one loomcycle.provider.call span per attempt.

--- a/internal/providers/credresolver.go
+++ b/internal/providers/credresolver.go
@@ -1,6 +1,23 @@
 package providers
 
-import "context"
+import (
+	"context"
+	"errors"
+)
+
+// ErrOperatorKeyForbidden is the RFC AX Layer-2 backstop refusal: a RESTRICTED
+// run (OperatorKeyAllowed(ctx)==false) reached a driver's key-fallback with no
+// own credential override for the requested key, so it must NOT touch the
+// operator's host key. Returned by ResolveKeyOrOperator and propagated by each
+// driver's Call as a fatal, NON-retryable error (classified permanent in
+// errclass.go so tryProviderFallback treats it as terminal rather than
+// cascading the same refusal across providers).
+//
+// This backstop is MANDATORY, not optional hardening: the restriction bit fails
+// open (WithOperatorKeyAllowed defaults true when absent), and credential-aware
+// routing (Layer 1) skips pinned agents, so only this driver-level refusal
+// guarantees a restricted run never spends the operator's key.
+var ErrOperatorKeyForbidden = errors.New("operator key forbidden for restricted run (RFC AX)")
 
 // credResolverKey is the ctx key for the per-run credential resolver.
 type credResolverKey struct{}
@@ -65,4 +82,54 @@ func ResolveCredential(ctx context.Context, name string) (string, bool) {
 		return "", false
 	}
 	return res.Value, true
+}
+
+// operatorKeyAllowedKey is the ctx key for the RFC AX operator-key permission,
+// mirrored here (drivers import providers, not auth/tools) as a ctx value so a
+// driver's key-fallback path can consult it without an import cycle.
+type operatorKeyAllowedKey struct{}
+
+// WithOperatorKeyAllowed stamps whether the run on this ctx may fall back to the
+// operator's host provider key (RFC AX). The run-launch sites set it from the
+// negative permission bit (allowed = !OperatorKeyRestricted) right beside
+// WithCredentialResolver, so it flows to every provider Call + tool Execute.
+// Stage 1 only threads it; the driver backstop that reads it lands in stage 2.
+func WithOperatorKeyAllowed(ctx context.Context, allowed bool) context.Context {
+	return context.WithValue(ctx, operatorKeyAllowedKey{}, allowed)
+}
+
+// OperatorKeyAllowed reports whether the run may use the operator's host key. It
+// DEFAULTS TO TRUE when absent (fail-open) — the same backward-safety posture as
+// the negative bit itself: an un-stamped path (open mode, legacy, a missed
+// stamp) keeps operator-key access.
+func OperatorKeyAllowed(ctx context.Context) bool {
+	allowed, ok := ctx.Value(operatorKeyAllowedKey{}).(bool)
+	if !ok {
+		return true
+	}
+	return allowed
+}
+
+// ResolveKeyOrOperator is the single choke point every LLM driver + WebSearch
+// uses to pick the API key for a call under RFC AR (tenant override) + RFC AX
+// (operator-key restriction). name is the well-known env-var name of the key
+// (e.g. "ANTHROPIC_API_KEY"); operatorKey is the driver's host key. Precedence:
+//
+//   - a tenant/user override for name exists  → use it (source = its scope);
+//   - no override + the run may use the operator key → the operator's host key
+//     (source "operator");
+//   - no override + the run is RESTRICTED → ErrOperatorKeyForbidden (never the
+//     operator key).
+//
+// The returned source/scopeID ride the per-call Usage so the server can
+// attribute spend (RFC AV). It reads the run identity + the operator-key
+// permission from ctx, so it works uniformly across every transport.
+func ResolveKeyOrOperator(ctx context.Context, name, operatorKey string) (key, source, scopeID string, err error) {
+	if r, ok := ResolveCredentialFull(ctx, name); ok {
+		return r.Value, r.Scope, r.ScopeID, nil
+	}
+	if OperatorKeyAllowed(ctx) {
+		return operatorKey, "operator", "", nil
+	}
+	return "", "", "", ErrOperatorKeyForbidden
 }

--- a/internal/providers/deepseek/driver.go
+++ b/internal/providers/deepseek/driver.go
@@ -70,6 +70,12 @@ func New(apiKey, baseURL string, streamOpts streamhttp.Options, httpClient *http
 // — that's what makes the wrapper worth its weight.
 func (d *Driver) ID() string { return "deepseek" }
 
+// KeyEnvName reports the env-var name whose tenant/user credential can key this
+// provider (RFC AX Layer-1 routing). Delegates to the inner OpenAI driver, whose
+// SetKeyEnvName was pointed at "DEEPSEEK_API_KEY" in New — the same literal the
+// inner driver's resolveKey resolves.
+func (d *Driver) KeyEnvName() string { return d.inner.KeyEnvName() }
+
 // Capabilities reports the provider's MAXIMUM surface — what at
 // least one model on DeepSeek can do — not the per-model details.
 // The interface contract is per-provider, not per-model (see

--- a/internal/providers/errclass.go
+++ b/internal/providers/errclass.go
@@ -116,6 +116,14 @@ func ClassifyError(err error) ErrorClass {
 	if err == nil {
 		return ErrorClassUnknown
 	}
+	// RFC AX Layer-2: a restricted run's operator-key refusal is a policy
+	// decision, not a transient outage. Classify it Permanent so
+	// tryProviderFallback (which cascades only Retryable/Deprecated) treats it
+	// as the run's terminal error rather than burning the identical refusal
+	// against every other provider in the cascade.
+	if errors.Is(err, ErrOperatorKeyForbidden) {
+		return ErrorClassPermanent
+	}
 	// Stream-idle deadline (v0.8.1 per-byte idle wrap) surfaces as
 	// "stream read: context deadline exceeded ...". errors.Is on the
 	// outer err DOES report DeadlineExceeded (the wrap chain), but

--- a/internal/providers/gemini/credkey_test.go
+++ b/internal/providers/gemini/credkey_test.go
@@ -2,6 +2,7 @@ package gemini
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
@@ -9,13 +10,22 @@ import (
 
 func TestCallKey_OverridesHostKey(t *testing.T) {
 	d := &Driver{apiKey: "host-key"}
-	if got, _, _ := d.resolveKey(context.Background()); got != "host-key" {
-		t.Errorf("no resolver: resolveKey = %q, want host-key", got)
+	if got, _, _, err := d.resolveKey(context.Background()); err != nil || got != "host-key" {
+		t.Errorf("no resolver: resolveKey = (%q, %v), want (host-key, nil)", got, err)
 	}
 	ctx := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (providers.CredentialResolution, bool) {
 		return providers.CredentialResolution{Value: "tenant-gemini"}, name == "GEMINI_API_KEY"
 	})
-	if got, _, _ := d.resolveKey(ctx); got != "tenant-gemini" {
-		t.Errorf("with override: resolveKey = %q, want tenant-gemini", got)
+	if got, _, _, err := d.resolveKey(ctx); err != nil || got != "tenant-gemini" {
+		t.Errorf("with override: resolveKey = (%q, %v), want (tenant-gemini, nil)", got, err)
+	}
+}
+
+// RFC AX: a restricted run with no override refuses with ErrOperatorKeyForbidden.
+func TestResolveKey_RestrictedRefusesHostKey(t *testing.T) {
+	d := &Driver{apiKey: "host-key"}
+	restricted := providers.WithOperatorKeyAllowed(context.Background(), false)
+	if got, _, _, err := d.resolveKey(restricted); !errors.Is(err, providers.ErrOperatorKeyForbidden) || got != "" {
+		t.Errorf("restricted, no override: (%q, %v), want (\"\", ErrOperatorKeyForbidden)", got, err)
 	}
 }

--- a/internal/providers/gemini/driver.go
+++ b/internal/providers/gemini/driver.go
@@ -82,14 +82,17 @@ func (d *Driver) ID() string { return "gemini" }
 // credential scope it came from. A tenant/user credential named GEMINI_API_KEY
 // overrides the operator's host key (RFC AR); source is "operator" when none
 // did. The source/scopeID ride the per-call Usage so the server can attribute
-// spend (RFC AV). Model-availability probes (fetchModels) stay on the host key
-// — which models are reachable is an operator concern.
-func (d *Driver) resolveKey(ctx context.Context) (key, source, scopeID string) {
-	if r, ok := providers.ResolveCredentialFull(ctx, "GEMINI_API_KEY"); ok {
-		return r.Value, r.Scope, r.ScopeID
-	}
-	return d.apiKey, "operator", ""
+// spend (RFC AV). RFC AX: a RESTRICTED run with no override gets
+// ErrOperatorKeyForbidden instead of the host key — Call aborts on it.
+// Model-availability probes (fetchModels) stay on the host key — which models
+// are reachable is an operator concern.
+func (d *Driver) resolveKey(ctx context.Context) (key, source, scopeID string, err error) {
+	return providers.ResolveKeyOrOperator(ctx, "GEMINI_API_KEY", d.apiKey)
 }
+
+// KeyEnvName reports the env-var name whose tenant/user credential can key this
+// provider (RFC AX Layer-1 routing). Same literal resolveKey resolves.
+func (d *Driver) KeyEnvName() string { return "GEMINI_API_KEY" }
 
 func (d *Driver) Capabilities() providers.Capabilities {
 	return providers.Capabilities{
@@ -131,7 +134,12 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 
 	// RFC AR/AV: resolve the key + its owning scope ONCE per call (not per retry
 	// attempt) so the header uses it and the source rides the per-call Usage.
-	apiKey, credSource, credScopeID := d.resolveKey(ctx)
+	// RFC AX: a restricted run with no override refuses here (never the host key).
+	apiKey, credSource, credScopeID, err := d.resolveKey(ctx)
+	if err != nil {
+		cancelStream()
+		return nil, err
+	}
 
 	url := d.baseURL + "/models/" + req.Model + ":streamGenerateContent?alt=sse"
 	attempt := func(attemptCtx context.Context) (*http.Response, error) {

--- a/internal/providers/ollama/credkey_test.go
+++ b/internal/providers/ollama/credkey_test.go
@@ -2,6 +2,7 @@ package ollama
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
@@ -15,15 +16,32 @@ func TestCallKey_HostedOverride_LocalNever(t *testing.T) {
 	})
 
 	hosted := &Driver{providerID: "ollama", apiKey: "host-key"}
-	if got, _, _ := hosted.resolveKey(ctx); got != "tenant-ollama" {
-		t.Errorf("hosted with override: resolveKey = %q, want tenant-ollama", got)
+	if got, _, _, err := hosted.resolveKey(ctx); err != nil || got != "tenant-ollama" {
+		t.Errorf("hosted with override: resolveKey = (%q, %v), want (tenant-ollama, nil)", got, err)
 	}
-	if got, _, _ := hosted.resolveKey(context.Background()); got != "host-key" {
-		t.Errorf("hosted no resolver: resolveKey = %q, want host-key", got)
+	if got, _, _, err := hosted.resolveKey(context.Background()); err != nil || got != "host-key" {
+		t.Errorf("hosted no resolver: resolveKey = (%q, %v), want (host-key, nil)", got, err)
 	}
 
 	local := &Driver{providerID: "ollama-local", apiKey: ""}
-	if got, _, _ := local.resolveKey(ctx); got != "" {
-		t.Errorf("ollama-local must never take an override: resolveKey = %q, want empty", got)
+	if got, _, _, err := local.resolveKey(ctx); err != nil || got != "" {
+		t.Errorf("ollama-local must never take an override: resolveKey = (%q, %v), want (\"\", nil)", got, err)
+	}
+}
+
+// RFC AX: a RESTRICTED run refuses on hosted ollama (never the host key) but
+// ollama-local is NEVER restricted — it has no operator key to protect, so it
+// returns its (empty) key directly even when operator-key access is withheld.
+func TestResolveKey_RestrictedHostedRefuses_LocalUnaffected(t *testing.T) {
+	restricted := providers.WithOperatorKeyAllowed(context.Background(), false)
+
+	hosted := &Driver{providerID: "ollama", apiKey: "host-key"}
+	if got, _, _, err := hosted.resolveKey(restricted); !errors.Is(err, providers.ErrOperatorKeyForbidden) || got != "" {
+		t.Errorf("hosted restricted: (%q, %v), want (\"\", ErrOperatorKeyForbidden)", got, err)
+	}
+
+	local := &Driver{providerID: "ollama-local", apiKey: ""}
+	if got, _, _, err := local.resolveKey(restricted); err != nil || got != "" {
+		t.Errorf("ollama-local restricted must NOT refuse: (%q, %v), want (\"\", nil)", got, err)
 	}
 }

--- a/internal/providers/ollama/driver.go
+++ b/internal/providers/ollama/driver.go
@@ -225,18 +225,30 @@ func (d *Driver) ID() string { return d.providerID }
 
 // resolveKey returns the Bearer key to authenticate an inference request AND
 // which credential scope it came from. On hosted "ollama" a tenant/user
-// credential named OLLAMA_API_KEY overrides the operator's host key (RFC AR);
-// "ollama-local" is unauthenticated local-network, so no override applies and
-// the source stays "operator". The source/scopeID ride the per-call Usage so
-// the server can attribute spend (RFC AV). Model-availability probes
-// (queryLoadedContext) stay on the operator key.
-func (d *Driver) resolveKey(ctx context.Context) (key, source, scopeID string) {
+// credential named OLLAMA_API_KEY overrides the operator's host key (RFC AR),
+// and a RESTRICTED run with no override gets ErrOperatorKeyForbidden instead of
+// the host key (RFC AX) — Call aborts on it. "ollama-local" is unauthenticated
+// local-network: it has NO operator key to protect, so it is NEVER restricted —
+// it returns its (empty) key directly, bypassing the RFC AX backstop. The
+// source/scopeID ride the per-call Usage so the server can attribute spend
+// (RFC AV). Model-availability probes (queryLoadedContext) stay on the operator
+// key.
+func (d *Driver) resolveKey(ctx context.Context) (key, source, scopeID string, err error) {
 	if d.providerID == "ollama" {
-		if r, ok := providers.ResolveCredentialFull(ctx, "OLLAMA_API_KEY"); ok {
-			return r.Value, r.Scope, r.ScopeID
-		}
+		return providers.ResolveKeyOrOperator(ctx, "OLLAMA_API_KEY", d.apiKey)
 	}
-	return d.apiKey, "operator", ""
+	return d.apiKey, "operator", "", nil
+}
+
+// KeyEnvName reports the env-var name whose tenant/user credential can key this
+// provider (RFC AX Layer-1 routing). Only the hosted "ollama" registration has
+// an operator key to protect; "ollama-local" returns "" so it is always keyable
+// (a restricted run may always route to a keyless local endpoint).
+func (d *Driver) KeyEnvName() string {
+	if d.providerID == "ollama" {
+		return "OLLAMA_API_KEY"
+	}
+	return ""
 }
 
 func (d *Driver) Capabilities() providers.Capabilities {
@@ -283,7 +295,13 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 
 	// RFC AR/AV: resolve the key + its owning scope ONCE per call (not per retry
 	// attempt) so the header uses it and the source rides the per-call Usage.
-	apiKey, credSource, credScopeID := d.resolveKey(ctx)
+	// RFC AX: a restricted hosted-ollama run with no override refuses here
+	// (never the host key); ollama-local never refuses (no key to protect).
+	apiKey, credSource, credScopeID, err := d.resolveKey(ctx)
+	if err != nil {
+		cancelStream()
+		return nil, err
+	}
 
 	attempt := func(attemptCtx context.Context) (*http.Response, error) {
 		// v0.10.0 OTEL: one loomcycle.provider.call span per attempt.

--- a/internal/providers/openai/credkey_test.go
+++ b/internal/providers/openai/credkey_test.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
@@ -17,8 +18,26 @@ func TestCallKey_DefaultEnvName(t *testing.T) {
 	ctx := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (providers.CredentialResolution, bool) {
 		return providers.CredentialResolution{Value: "tenant-openai"}, name == "OPENAI_API_KEY"
 	})
-	if got, _, _ := d.resolveKey(ctx); got != "tenant-openai" {
-		t.Errorf("resolveKey = %q, want tenant-openai", got)
+	if got, _, _, err := d.resolveKey(ctx); err != nil || got != "tenant-openai" {
+		t.Errorf("resolveKey = (%q, %v), want (tenant-openai, nil)", got, err)
+	}
+}
+
+// RFC AX: a restricted run with no override refuses with ErrOperatorKeyForbidden
+// (never the host key); an override still wins under restriction.
+func TestResolveKey_RestrictedRefusesHostKey(t *testing.T) {
+	d := New("host-key", "", streamhttp.Options{}, nil)
+
+	restricted := providers.WithOperatorKeyAllowed(context.Background(), false)
+	if got, _, _, err := d.resolveKey(restricted); !errors.Is(err, providers.ErrOperatorKeyForbidden) || got != "" {
+		t.Errorf("restricted, no override: (%q, %v), want (\"\", ErrOperatorKeyForbidden)", got, err)
+	}
+
+	withOverride := providers.WithCredentialResolver(restricted, func(_ context.Context, name string) (providers.CredentialResolution, bool) {
+		return providers.CredentialResolution{Value: "tenant-openai", Scope: "user"}, name == "OPENAI_API_KEY"
+	})
+	if got, source, _, err := d.resolveKey(withOverride); err != nil || got != "tenant-openai" || source != "user" {
+		t.Errorf("restricted, with override: (%q, %q, %v), want (tenant-openai, user, nil)", got, source, err)
 	}
 }
 
@@ -32,15 +51,15 @@ func TestCallKey_SetKeyEnvName_DeepSeek(t *testing.T) {
 	deepseekOnly := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (providers.CredentialResolution, bool) {
 		return providers.CredentialResolution{Value: "tenant-deepseek"}, name == "DEEPSEEK_API_KEY"
 	})
-	if got, _, _ := d.resolveKey(deepseekOnly); got != "tenant-deepseek" {
-		t.Errorf("resolveKey = %q, want tenant-deepseek", got)
+	if got, _, _, err := d.resolveKey(deepseekOnly); err != nil || got != "tenant-deepseek" {
+		t.Errorf("resolveKey = (%q, %v), want (tenant-deepseek, nil)", got, err)
 	}
 
 	// A stored OPENAI_API_KEY is the wrong name for a DeepSeek driver → host key.
 	openaiOnly := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (providers.CredentialResolution, bool) {
 		return providers.CredentialResolution{Value: "tenant-openai"}, name == "OPENAI_API_KEY"
 	})
-	if got, _, _ := d.resolveKey(openaiOnly); got != "host-key" {
-		t.Errorf("resolveKey = %q, want host-key (OPENAI name must not apply to DeepSeek)", got)
+	if got, _, _, err := d.resolveKey(openaiOnly); err != nil || got != "host-key" {
+		t.Errorf("resolveKey = (%q, %v), want (host-key, nil) (OPENAI name must not apply to DeepSeek)", got, err)
 	}
 }

--- a/internal/providers/openai/driver.go
+++ b/internal/providers/openai/driver.go
@@ -69,14 +69,18 @@ func (d *Driver) SetKeyEnvName(name string) { d.keyEnvName = name }
 // (default "OPENAI_API_KEY"; the DeepSeek wrapper sets "DEEPSEEK_API_KEY")
 // overrides the operator's host key (RFC AR); source is "operator" when none
 // did. The source/scopeID ride the per-call Usage so the server can attribute
-// spend (RFC AV). Model-availability probes (fetchModels) stay on the host key
-// — which models are reachable is an operator concern.
-func (d *Driver) resolveKey(ctx context.Context) (key, source, scopeID string) {
-	if r, ok := providers.ResolveCredentialFull(ctx, d.keyEnvName); ok {
-		return r.Value, r.Scope, r.ScopeID
-	}
-	return d.apiKey, "operator", ""
+// spend (RFC AV). RFC AX: a RESTRICTED run with no override gets
+// ErrOperatorKeyForbidden instead of the host key — Call aborts on it.
+// Model-availability probes (fetchModels) stay on the host key — which models
+// are reachable is an operator concern.
+func (d *Driver) resolveKey(ctx context.Context) (key, source, scopeID string, err error) {
+	return providers.ResolveKeyOrOperator(ctx, d.keyEnvName, d.apiKey)
 }
+
+// KeyEnvName reports the env-var name whose tenant/user credential can key this
+// provider (RFC AX Layer-1 routing). Same literal resolveKey resolves — the
+// DeepSeek wrapper's SetKeyEnvName reflows this to "DEEPSEEK_API_KEY".
+func (d *Driver) KeyEnvName() string { return d.keyEnvName }
 
 func (d *Driver) ID() string { return "openai" }
 
@@ -116,7 +120,12 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 
 	// RFC AR/AV: resolve the key + its owning scope ONCE per call (not per retry
 	// attempt) so the header uses it and the source rides the per-call Usage.
-	apiKey, credSource, credScopeID := d.resolveKey(ctx)
+	// RFC AX: a restricted run with no override refuses here (never the host key).
+	apiKey, credSource, credScopeID, err := d.resolveKey(ctx)
+	if err != nil {
+		cancelStream()
+		return nil, err
+	}
 
 	attempt := func(attemptCtx context.Context) (*http.Response, error) {
 		// v0.10.0 OTEL: one loomcycle.provider.call span per attempt.

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -48,6 +48,23 @@ type Provider interface {
 	ListModels(ctx context.Context) ([]string, error)
 }
 
+// KeyedProvider is an OPTIONAL interface an LLM provider implements when it
+// authenticates inference with an operator API key that a tenant can override
+// via its own CredentialDef (RFC AR) — and that a restricted run (RFC AX)
+// therefore must be able to key itself. KeyEnvName returns the well-known
+// env-var NAME the driver's key resolution uses (the SAME literal its resolveKey
+// passes to ResolveKeyOrOperator, e.g. "ANTHROPIC_API_KEY").
+//
+// RFC AX Layer-1 credential-aware routing tests, per candidate provider, whether
+// the tenant/user has a CredentialDef for this name. A provider that needs no
+// operator key (ollama-local / code-js / mock) does NOT implement this interface
+// (type-assert miss → "" → always keyable): a restricted run may always route to
+// a keyless provider. The hosted ollama driver returns "" for its ollama-local
+// registration for the same reason.
+type KeyedProvider interface {
+	KeyEnvName() string
+}
+
 // ThinkingDowngrader is an OPTIONAL interface a Provider implements when its
 // thinking-class models require provider-produced reasoning state
 // (reasoning_content) on every assistant turn of the input history. DeepSeek's

--- a/internal/resolve/keyable_test.go
+++ b/internal/resolve/keyable_test.go
@@ -1,0 +1,153 @@
+package resolve
+
+import (
+	"errors"
+	"testing"
+)
+
+// RFC AX Layer 1: a restricted run whose only keyable provider is deepseek must
+// resolve to deepseek even though the tier's priority puts other providers
+// ahead of it — the KeyableProviders filter skips the un-keyable candidates.
+func TestResolve_KeyableFilter_RoutesToTheOnlyKeyableProvider(t *testing.T) {
+	priority, tiers := fixtureLibrary()
+	r := NewResolver(priority, tiers)
+	seedAll(t, r, tiers)
+
+	dec, err := r.Resolve(AgentRequest{
+		Name:             "ats-filter",
+		Tier:             "low",
+		KeyableProviders: map[string]bool{"deepseek": true},
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if dec.Provider != "deepseek" {
+		t.Errorf("decision.Provider = %q, want deepseek (the only keyable provider)", dec.Provider)
+	}
+}
+
+// When the KeyableProviders filter removes EVERY candidate, Resolve returns the
+// ErrOperatorKeyRestricted policy sentinel — distinct from a transient
+// availability outage (ErrTierUnavailable).
+func TestResolve_KeyableFilter_EmptyViableSetIsRestricted(t *testing.T) {
+	priority, tiers := fixtureLibrary()
+	r := NewResolver(priority, tiers)
+	seedAll(t, r, tiers)
+
+	_, err := r.Resolve(AgentRequest{
+		Name:             "ats-filter",
+		Tier:             "low",
+		KeyableProviders: map[string]bool{"nonexistent": true}, // none of the tier's providers
+	})
+	if !errors.Is(err, ErrOperatorKeyRestricted) {
+		t.Fatalf("err = %v, want ErrOperatorKeyRestricted", err)
+	}
+	if errors.Is(err, ErrTierUnavailable) {
+		t.Error("restriction must be distinct from an availability outage")
+	}
+}
+
+// An EMPTY (non-nil) filter — a restricted run whose tenant can key nothing — is
+// also a restriction refusal, not an outage.
+func TestResolve_KeyableFilter_EmptyMapIsRestricted(t *testing.T) {
+	priority, tiers := fixtureLibrary()
+	r := NewResolver(priority, tiers)
+	seedAll(t, r, tiers)
+
+	_, err := r.Resolve(AgentRequest{
+		Name:             "ats-filter",
+		Tier:             "low",
+		KeyableProviders: map[string]bool{}, // non-nil + empty ⇒ nothing keyable
+	})
+	if !errors.Is(err, ErrOperatorKeyRestricted) {
+		t.Fatalf("err = %v, want ErrOperatorKeyRestricted", err)
+	}
+}
+
+// A keyless provider (e.g. ollama-local) is always keyable: a restricted run
+// with ollama-local in its set routes there when priority reaches it.
+func TestResolve_KeyableFilter_KeylessProviderRoutable(t *testing.T) {
+	priority, tiers := fixtureLibrary()
+	r := NewResolver(priority, tiers)
+	seedAll(t, r, tiers)
+
+	dec, err := r.Resolve(AgentRequest{
+		Name:             "ats-filter",
+		Tier:             "low",
+		KeyableProviders: map[string]bool{"ollama-local": true},
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if dec.Provider != "ollama-local" {
+		t.Errorf("decision.Provider = %q, want ollama-local", dec.Provider)
+	}
+}
+
+// A PINNED agent bypasses the KeyableProviders filter entirely (resolvePin skips
+// candidate selection). This documents the Layer-2 requirement: a restricted
+// pinned agent's guarantee lives in the driver backstop, NOT in routing — so
+// resolution still returns the pin even for an un-keyable provider.
+func TestResolve_KeyableFilter_PinNotFiltered(t *testing.T) {
+	priority, tiers := fixtureLibrary()
+	r := NewResolver(priority, tiers)
+	seedAll(t, r, tiers)
+
+	dec, err := r.Resolve(AgentRequest{
+		Name:             "cv-generator",
+		PinProvider:      "anthropic",
+		PinModel:         "claude-opus-4-7",
+		KeyableProviders: map[string]bool{"deepseek": true}, // anthropic NOT keyable
+	})
+	if err != nil {
+		t.Fatalf("pinned agent must not be filtered by KeyableProviders: %v", err)
+	}
+	if dec.Provider != "anthropic" || dec.Model != "claude-opus-4-7" {
+		t.Errorf("decision = %+v, want anthropic/claude-opus-4-7 (pin bypasses routing)", dec)
+	}
+}
+
+// A nil KeyableProviders (the unrestricted / gate-off path) is byte-identical to
+// pre-RFC-AX resolution — the top library-priority candidate wins.
+func TestResolve_KeyableFilter_NilIsUnrestricted(t *testing.T) {
+	priority, tiers := fixtureLibrary()
+	r := NewResolver(priority, tiers)
+	seedAll(t, r, tiers)
+
+	dec, err := r.Resolve(AgentRequest{Name: "ats-filter", Tier: "low"}) // KeyableProviders nil
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if dec.Provider != "deepseek" { // deepseek is first in fixture priority
+		t.Errorf("decision.Provider = %q, want deepseek (unrestricted top priority)", dec.Provider)
+	}
+}
+
+// Cascade MUST apply the IDENTICAL filter so the routing view a restricted
+// consumer sees matches what actually runs.
+func TestCascade_AppliesKeyableFilter(t *testing.T) {
+	priority, tiers := fixtureLibrary()
+	r := NewResolver(priority, tiers)
+	seedAll(t, r, tiers)
+
+	// Unfiltered cascade lists every low-tier provider in priority order.
+	full := r.Cascade(AgentRequest{Name: "ats-filter", Tier: "low"})
+	if len(full) < 2 {
+		t.Fatalf("unfiltered cascade too short: %+v", full)
+	}
+
+	// Filtered cascade lists ONLY the keyable providers.
+	filtered := r.Cascade(AgentRequest{
+		Name:             "ats-filter",
+		Tier:             "low",
+		KeyableProviders: map[string]bool{"deepseek": true},
+	})
+	for _, c := range filtered {
+		if c.Provider != "deepseek" {
+			t.Errorf("filtered cascade contains un-keyable provider %q", c.Provider)
+		}
+	}
+	if len(filtered) == 0 {
+		t.Error("filtered cascade should still contain the keyable deepseek candidate")
+	}
+}

--- a/internal/resolve/matrix.go
+++ b/internal/resolve/matrix.go
@@ -61,6 +61,15 @@ var (
 	// this to 403 Forbidden with a typed error code so the client
 	// can render an "upgrade your tier to use this agent" message.
 	ErrTierAgentNotAvailable = errors.New("agent not available for user_tier")
+
+	// ErrOperatorKeyRestricted is returned by Resolve (RFC AX) when a
+	// restricted run's KeyableProviders filter removes EVERY tier candidate —
+	// the run's principal may not use the operator's key AND the tenant/user has
+	// no own credential for any provider in the tier's cascade. Like
+	// ErrTierAgentNotAvailable it is a POLICY refusal (not a transient outage),
+	// so the wire layer maps it to 403; distinct so the client can render a
+	// "bring your own key" message rather than "upgrade your tier".
+	ErrOperatorKeyRestricted = errors.New("run restricted: no provider the tenant can key")
 )
 
 // Decision is the resolver's output: which (provider, model) the loop
@@ -113,6 +122,21 @@ type AgentRequest struct {
 	// Empty intersection → ErrTierAgentNotAvailable (operator policy
 	// refusal — not a transient outage).
 	UserTier *UserTierOverlay
+
+	// KeyableProviders is the RFC AX Layer-1 credential-aware routing filter for
+	// a RESTRICTED run: the set of provider IDs the run's tenant/user can key
+	// itself (a keyless provider, OR one whose key env-var has a tenant/user
+	// CredentialDef). NIL = unrestricted (the common path — zero overhead, no
+	// filtering). Non-nil: Resolve / Cascade SKIP any candidate whose provider
+	// is absent from the set; when the filter removes every candidate, Resolve
+	// returns ErrOperatorKeyRestricted (a policy refusal). The server
+	// pre-computes this (all credential-store I/O stays OUT of the lock-free
+	// resolver) by walking Cascade + testing each candidate's KeyEnvName.
+	//
+	// The pin path (resolvePin) does NOT consult this filter — a pinned agent
+	// bypasses candidate selection, so its restricted-run guarantee lives in the
+	// driver backstop (providers.ErrOperatorKeyForbidden), not here.
+	KeyableProviders map[string]bool
 }
 
 // UserTierOverlay carries the per-request user-tier policy. Built by
@@ -412,11 +436,22 @@ func (r *Resolver) Resolve(req AgentRequest) (Decision, error) {
 
 	r.mu.RLock()
 	defer r.mu.RUnlock()
+	// sawKeyable tracks whether ANY candidate survived the RFC AX Layer-1
+	// KeyableProviders filter — used to distinguish "restricted run has no
+	// tenant-keyable provider" (a policy refusal) from a plain availability
+	// outage below.
+	sawKeyable := false
 	for _, providerID := range priority {
 		for _, cand := range candidates {
 			if cand.Provider != providerID {
 				continue
 			}
+			// RFC AX Layer 1: a restricted run skips any provider it can't key
+			// itself, so resolution never lands on the operator's key.
+			if !keyable(req, cand.Provider) {
+				continue
+			}
+			sawKeyable = true
 			if r.isAvailableLocked(cand.Provider, cand.Model) {
 				return Decision{
 					Provider: cand.Provider,
@@ -426,8 +461,22 @@ func (r *Resolver) Resolve(req AgentRequest) (Decision, error) {
 			}
 		}
 	}
+	// RFC AX: a non-nil filter that removed EVERY candidate is a policy refusal
+	// (the tenant can key none of the tier's providers), not a transient outage.
+	if req.KeyableProviders != nil && !sawKeyable {
+		return Decision{}, fmt.Errorf("%w: agent %q tier %q (none of the tier's providers are tenant-keyable)",
+			ErrOperatorKeyRestricted, req.Name, req.Tier)
+	}
 	return Decision{}, fmt.Errorf("%w: agent %q tier %q (no reachable provider with a non-stalled model)",
 		ErrTierUnavailable, req.Name, req.Tier)
+}
+
+// keyable reports whether provider passes req's RFC AX Layer-1 filter: always
+// true when KeyableProviders is nil (unrestricted — the common path), else true
+// only when the precomputed keyable set contains provider. Pure (reads only the
+// immutable request), so it needs no lock.
+func keyable(req AgentRequest, provider string) bool {
+	return req.KeyableProviders == nil || req.KeyableProviders[provider]
 }
 
 // resolvePin consults the matrix for the explicit pin and returns
@@ -470,6 +519,11 @@ func (r *Resolver) Cascade(req AgentRequest) []Candidate {
 	}
 	out := make([]Candidate, 0, len(candidates))
 	for _, p := range priority {
+		// RFC AX: apply the IDENTICAL Layer-1 filter Resolve uses, so the routing
+		// view a restricted consumer sees can't diverge from what actually runs.
+		if !keyable(req, p) {
+			continue
+		}
 		for _, c := range candidates {
 			if c.Provider == p {
 				out = append(out, c)

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -265,6 +265,14 @@ type RunInput struct {
 	// Compaction is an optional per-RUN context-compaction override, merged PER
 	// FIELD over the agent's own Compaction. nil = inherit the agent's entirely.
 	Compaction *config.Compaction
+
+	// OperatorKeyRestricted is the RFC AX negative permission bit for the
+	// NON-principal trigger paths (scheduler / webhook / A2A), which have no
+	// auth.Principal on ctx. Those paths capture the creating principal's grant
+	// on the trigger def and pass it here so RunOnce can stamp the run without a
+	// live token. false = allowed (fail-open); the principal-on-ctx paths ignore
+	// this field and compute restriction from the live principal instead.
+	OperatorKeyRestricted bool
 }
 
 // RunCallbacks is how the wire surfaces observe the run.

--- a/internal/scheduler/runinput.go
+++ b/internal/scheduler/runinput.go
@@ -39,6 +39,9 @@ type scheduleDef struct {
 	OnComplete             []scheduleHook      `json:"on_complete,omitempty"`
 	Metadata               map[string]any      `json:"metadata,omitempty"`
 	TenantID               string              `json:"tenant_id,omitempty"`
+	// OperatorKeyRestricted is the RFC AX bit captured on the def at authoring;
+	// copied into RunInput so the fired run keeps the creator's restriction.
+	OperatorKeyRestricted bool `json:"operator_key_restricted,omitempty"`
 }
 
 type schedulePromptSeg struct {
@@ -142,5 +145,8 @@ func buildRunInput(def scheduleDef, envAllowlist map[string]bool, logf func(form
 		// executes as this tenant, resolving its agents/skills/MCP and
 		// isolating memory/runs. "" = shared/default (RFC N follow-up).
 		TenantID: def.TenantID,
+		// RFC AX: carry the captured operator-key restriction into the run — no
+		// principal is on ctx at fire time, so the def's captured bit is authority.
+		OperatorKeyRestricted: def.OperatorKeyRestricted,
 	}
 }

--- a/internal/store/postgres/migrations/0055_runs_operator_key_restricted.down.sql
+++ b/internal/store/postgres/migrations/0055_runs_operator_key_restricted.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE runs DROP COLUMN IF EXISTS operator_key_restricted;

--- a/internal/store/postgres/migrations/0055_runs_operator_key_restricted.up.sql
+++ b/internal/store/postgres/migrations/0055_runs_operator_key_restricted.up.sql
@@ -1,0 +1,9 @@
+-- RFC AX: persist whether a run is RESTRICTED from the operator's host provider
+-- API key. The permission is a NEGATIVE bit (false = allowed) computed at
+-- run-start from the principal + the LOOMCYCLE_OPERATOR_KEY_RESTRICTION gate; it
+-- rides the run row so a resumed / snapshot-restored / crash-recovered run
+-- reconstructs its restriction without the original principal on ctx (the same
+-- reason `interactive` and `tenant_id` are denormalised here). Additive
+-- default-false column; legacy rows + every gate-off deployment read false
+-- (fail-open — the deliberate backward-safety trade). CreateRun stamps it.
+ALTER TABLE runs ADD COLUMN IF NOT EXISTS operator_key_restricted BOOLEAN NOT NULL DEFAULT FALSE;

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -297,8 +297,8 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 		_, err := s.pool.Exec(ctx,
 			`INSERT INTO runs (
 				id, session_id, status, started_at,
-				agent_id, parent_agent_id, parent_run_id, user_id, tenant_id, user_tier, agent_def_id, model, replica_id, parent_context, idempotency_key, interactive
-			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`,
+				agent_id, parent_agent_id, parent_run_id, user_id, tenant_id, user_tier, agent_def_id, model, replica_id, parent_context, idempotency_key, interactive, operator_key_restricted
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
 			id, sessionID, string(store.RunRunning), now,
 			nullableText(identity.AgentID),
 			nullableText(identity.ParentAgentID),
@@ -312,6 +312,7 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 			pcVal,
 			nullableText(identity.IdempotencyKey),
 			identity.Interactive,
+			identity.OperatorKeyRestricted,
 		)
 		return err
 	}); err != nil {
@@ -330,22 +331,23 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 		return store.Run{}, fmt.Errorf("create run: %w", err)
 	}
 	return store.Run{
-		ID:             id,
-		SessionID:      sessionID,
-		Status:         store.RunRunning,
-		StartedAt:      now,
-		AgentID:        identity.AgentID,
-		ParentAgentID:  identity.ParentAgentID,
-		ParentRunID:    identity.ParentRunID,
-		UserID:         identity.UserID,
-		TenantID:       identity.TenantID,
-		UserTier:       identity.UserTier,
-		AgentDefID:     identity.AgentDefID,
-		Model:          identity.Model,
-		ReplicaID:      identity.ReplicaID,
-		ParentContext:  identity.ParentContext.Clone(),
-		IdempotencyKey: identity.IdempotencyKey,
-		Interactive:    identity.Interactive,
+		ID:                    id,
+		SessionID:             sessionID,
+		Status:                store.RunRunning,
+		StartedAt:             now,
+		AgentID:               identity.AgentID,
+		ParentAgentID:         identity.ParentAgentID,
+		ParentRunID:           identity.ParentRunID,
+		UserID:                identity.UserID,
+		TenantID:              identity.TenantID,
+		UserTier:              identity.UserTier,
+		AgentDefID:            identity.AgentDefID,
+		Model:                 identity.Model,
+		ReplicaID:             identity.ReplicaID,
+		ParentContext:         identity.ParentContext.Clone(),
+		IdempotencyKey:        identity.IdempotencyKey,
+		Interactive:           identity.Interactive,
+		OperatorKeyRestricted: identity.OperatorKeyRestricted,
 	}, nil
 }
 
@@ -760,7 +762,7 @@ func (s *Store) RunsForSession(ctx context.Context, sessionID string) ([]store.R
 		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 		        r.model, r.provider, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive,
+		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive, r.operator_key_restricted,
 		        r.cost, r.cost_currency, r.credential_source, r.credential_scope_id,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
@@ -981,7 +983,7 @@ func (s *Store) GetRunByAgentID(ctx context.Context, agentID string) (store.Run,
 		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 		        r.model, r.provider, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive,
+		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive, r.operator_key_restricted,
 		        r.cost, r.cost_currency, r.credential_source, r.credential_scope_id,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
@@ -1011,7 +1013,7 @@ func (s *Store) RunByIdempotencyKey(ctx context.Context, key string) (store.Run,
 		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 		        r.model, r.provider, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive,
+		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive, r.operator_key_restricted,
 		        r.cost, r.cost_currency, r.credential_source, r.credential_scope_id,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
@@ -1037,7 +1039,7 @@ func (s *Store) GetRun(ctx context.Context, runID string) (store.Run, error) {
 		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 		        r.model, r.provider, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive,
+		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive, r.operator_key_restricted,
 		        r.cost, r.cost_currency, r.credential_source, r.credential_scope_id,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
@@ -1110,7 +1112,7 @@ func (s *Store) ListActiveRunsByUser(ctx context.Context, userID string, status 
 			        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 			        r.model, r.provider, r.error,
 			        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-			        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive,
+			        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive, r.operator_key_restricted,
 		        r.cost, r.cost_currency, r.credential_source, r.credential_scope_id,
 			        s.agent
 			 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
@@ -1122,7 +1124,7 @@ func (s *Store) ListActiveRunsByUser(ctx context.Context, userID string, status 
 			        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 			        r.model, r.provider, r.error,
 			        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-			        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive,
+			        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive, r.operator_key_restricted,
 		        r.cost, r.cost_currency, r.credential_source, r.credential_scope_id,
 			        s.agent
 			 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
@@ -1148,7 +1150,7 @@ func (s *Store) ListRunsByParentAgentID(ctx context.Context, parentAgentID strin
 		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 		        r.model, r.provider, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive,
+		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive, r.operator_key_restricted,
 		        r.cost, r.cost_currency, r.credential_source, r.credential_scope_id,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
@@ -1250,7 +1252,7 @@ func (s *Store) ListPausedRuns(ctx context.Context) ([]store.Run, error) {
 		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 		        r.model, r.provider, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive,
+		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive, r.operator_key_restricted,
 		        r.cost, r.cost_currency, r.credential_source, r.credential_scope_id,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
@@ -1927,15 +1929,15 @@ func (s *Store) SnapshotRestoreRun(ctx context.Context, r store.Run) (bool, erro
 			input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
 			model, provider, error,
 			agent_id, parent_agent_id, parent_run_id, user_id, last_heartbeat_at,
-			user_tier, agent_def_id, pause_state, parent_context, interactive
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23)
+			user_tier, agent_def_id, pause_state, parent_context, interactive, operator_key_restricted
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24)
 		 ON CONFLICT (id) DO NOTHING`,
 		r.ID, r.SessionID, status, startedAt, completedAt, nullIfEmpty(r.StopReason),
 		r.InputTokens, r.OutputTokens, r.CacheCreationTokens, r.CacheReadTokens,
 		nullIfEmpty(r.Model), nullIfEmpty(r.Provider), nullIfEmpty(r.ErrorMsg),
 		nullIfEmpty(r.AgentID), nullIfEmpty(r.ParentAgentID), nullIfEmpty(r.ParentRunID),
 		nullIfEmpty(r.UserID), lastHbAt,
-		nullIfEmpty(r.UserTier), nullIfEmpty(r.AgentDefID), pauseState, pcVal, r.Interactive,
+		nullIfEmpty(r.UserTier), nullIfEmpty(r.AgentDefID), pauseState, pcVal, r.Interactive, r.OperatorKeyRestricted,
 	)
 	if err != nil {
 		return false, fmt.Errorf("snapshot restore run: %w", err)
@@ -6281,8 +6283,9 @@ func scanRun(r rowScanner) (store.Run, error) {
 		cost                                              *float64
 		costCurrency, credentialSource, credentialScopeID *string
 
-		interactive bool
-		statusStr   string
+		interactive           bool
+		operatorKeyRestricted bool
+		statusStr             string
 	)
 	if err := r.Scan(
 		&out.ID, &out.SessionID, &statusStr, &started, &completed, &stopReason,
@@ -6291,7 +6294,7 @@ func scanRun(r rowScanner) (store.Run, error) {
 		&agentID, &parentAgentID, &parentRunID, &userID, &lastHeartbeatAt,
 		&userTier,
 		&agentDefID, &pauseState, &replicaID, &parentContext, &idempotencyKey, &tenantID,
-		&interactive,
+		&interactive, &operatorKeyRestricted,
 		&cost, &costCurrency, &credentialSource, &credentialScopeID,
 		&sessAgent,
 	); err != nil {
@@ -6355,6 +6358,7 @@ func scanRun(r rowScanner) (store.Run, error) {
 		out.TenantID = *tenantID
 	}
 	out.Interactive = interactive
+	out.OperatorKeyRestricted = operatorKeyRestricted
 	if cost != nil {
 		out.Cost = cost
 	}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -926,6 +926,10 @@ func (s *Store) migrate(ctx context.Context) error {
 		`ALTER TABLE runs ADD COLUMN cost_currency TEXT`,
 		`ALTER TABLE runs ADD COLUMN credential_source TEXT`,
 		`ALTER TABLE runs ADD COLUMN credential_scope_id TEXT`,
+		// RFC AX — the negative operator-key permission bit (0 = allowed). Stamped
+		// at CreateRun from the principal + gate; read back on resume/restore so a
+		// re-dispatched run keeps its restriction. 0 on legacy rows (fail-open).
+		`ALTER TABLE runs ADD COLUMN operator_key_restricted INTEGER NOT NULL DEFAULT 0`,
 	}
 	for _, q := range addColumns {
 		if _, err := s.db.ExecContext(ctx, q); err != nil {
@@ -1163,8 +1167,8 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 		pcVal = pcJSON
 	}
 	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO runs(id, session_id, status, started_at, agent_id, parent_agent_id, parent_run_id, user_id, tenant_id, user_tier, agent_def_id, model, parent_context, idempotency_key, interactive)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO runs(id, session_id, status, started_at, agent_id, parent_agent_id, parent_run_id, user_id, tenant_id, user_tier, agent_def_id, model, parent_context, idempotency_key, interactive, operator_key_restricted)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		id, sessionID, store.RunRunning, now.UnixNano(),
 		nilIfEmpty(identity.AgentID),
 		nilIfEmpty(identity.ParentAgentID),
@@ -1177,6 +1181,7 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 		pcVal,
 		nilIfEmpty(identity.IdempotencyKey),
 		boolToInt(identity.Interactive),
+		boolToInt(identity.OperatorKeyRestricted),
 	)
 	if err != nil {
 		// RFC H Decision 10: a collision on the runs_idempotency_key
@@ -1193,21 +1198,22 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 		return store.Run{}, err
 	}
 	return store.Run{
-		ID:             id,
-		SessionID:      sessionID,
-		Status:         store.RunRunning,
-		StartedAt:      now,
-		AgentID:        identity.AgentID,
-		ParentAgentID:  identity.ParentAgentID,
-		ParentRunID:    identity.ParentRunID,
-		UserID:         identity.UserID,
-		TenantID:       identity.TenantID,
-		UserTier:       identity.UserTier,
-		AgentDefID:     identity.AgentDefID,
-		Model:          identity.Model,
-		ParentContext:  identity.ParentContext.Clone(),
-		IdempotencyKey: identity.IdempotencyKey,
-		Interactive:    identity.Interactive,
+		ID:                    id,
+		SessionID:             sessionID,
+		Status:                store.RunRunning,
+		StartedAt:             now,
+		AgentID:               identity.AgentID,
+		ParentAgentID:         identity.ParentAgentID,
+		ParentRunID:           identity.ParentRunID,
+		UserID:                identity.UserID,
+		TenantID:              identity.TenantID,
+		UserTier:              identity.UserTier,
+		AgentDefID:            identity.AgentDefID,
+		Model:                 identity.Model,
+		ParentContext:         identity.ParentContext.Clone(),
+		IdempotencyKey:        identity.IdempotencyKey,
+		Interactive:           identity.Interactive,
+		OperatorKeyRestricted: identity.OperatorKeyRestricted,
 	}, nil
 }
 
@@ -1815,6 +1821,7 @@ func scanRun(scanner interface{ Scan(...any) error }) (store.Run, error) {
 	var idempotencyKey sql.NullString
 	var tenantID sql.NullString
 	var interactive sql.NullInt64
+	var operatorKeyRestricted sql.NullInt64
 	var cost sql.NullFloat64
 	var costCurrency, credentialSource, credentialScopeID sql.NullString
 	var sessAgent sql.NullString
@@ -1827,7 +1834,7 @@ func scanRun(scanner interface{ Scan(...any) error }) (store.Run, error) {
 		&agentID, &parentAgentID, &parentRunID, &userID, &lastHbNs,
 		&userTier,
 		&agentDefID, &pauseState, &parentContext, &idempotencyKey, &tenantID,
-		&interactive,
+		&interactive, &operatorKeyRestricted,
 		&cost, &costCurrency, &credentialSource, &credentialScopeID,
 		&sessAgent,
 	); err != nil {
@@ -1890,6 +1897,7 @@ func scanRun(scanner interface{ Scan(...any) error }) (store.Run, error) {
 		r.TenantID = tenantID.String
 	}
 	r.Interactive = interactive.Valid && interactive.Int64 != 0
+	r.OperatorKeyRestricted = operatorKeyRestricted.Valid && operatorKeyRestricted.Int64 != 0
 	if cost.Valid {
 		v := cost.Float64
 		r.Cost = &v
@@ -1924,7 +1932,7 @@ const runColumns = `r.id, r.session_id, r.status, r.started_at, r.completed_at,
 		r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at,
 		r.user_tier,
 		r.agent_def_id, r.pause_state, r.parent_context, r.idempotency_key, r.tenant_id,
-		r.interactive,
+		r.interactive, r.operator_key_restricted,
 		r.cost, r.cost_currency, r.credential_source, r.credential_scope_id,
 		s.agent`
 
@@ -2877,15 +2885,15 @@ func (s *Store) SnapshotRestoreRun(ctx context.Context, r store.Run) (bool, erro
 			input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
 			model, provider, error,
 			agent_id, parent_agent_id, parent_run_id, user_id, last_heartbeat_at,
-			user_tier, agent_def_id, pause_state, parent_context, interactive
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			user_tier, agent_def_id, pause_state, parent_context, interactive, operator_key_restricted
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		r.ID, r.SessionID, status, startedNs, completedNs, nilIfEmpty(r.StopReason),
 		r.InputTokens, r.OutputTokens, r.CacheCreationTokens, r.CacheReadTokens,
 		nilIfEmpty(r.Model), nilIfEmpty(r.Provider), nilIfEmpty(r.ErrorMsg),
 		nilIfEmpty(r.AgentID), nilIfEmpty(r.ParentAgentID), nilIfEmpty(r.ParentRunID),
 		nilIfEmpty(r.UserID), lastHbNs,
 		nilIfEmpty(r.UserTier), nilIfEmpty(r.AgentDefID), pauseState, pcVal,
-		boolToInt(r.Interactive),
+		boolToInt(r.Interactive), boolToInt(r.OperatorKeyRestricted),
 	)
 	if err != nil {
 		return false, fmt.Errorf("snapshot restore run: %w", err)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -258,6 +258,12 @@ type Run struct {
 	// semantics. false on legacy rows + batch runs.
 	Interactive bool `json:"interactive,omitempty"`
 
+	// OperatorKeyRestricted is the RFC AX negative permission bit (RFC AX §2):
+	// true = this run may NOT use the operator's host provider key. Persisted to
+	// runs.operator_key_restricted and restored on resume. false = allowed (the
+	// zero value), so legacy rows + every unstamped path fail OPEN.
+	OperatorKeyRestricted bool `json:"operator_key_restricted,omitempty"`
+
 	// --- RFC AV: per-run cost + credential-source summary. ---
 	// Cost is nil when the run was never priced (legacy rows, or an unknown
 	// model absent from the pricing table). CredentialSource is the primary key
@@ -571,6 +577,13 @@ type RunIdentity struct {
 	// re-dispatches with the correct park-at-end_turn (vs run-to-completion)
 	// semantics. false = batch run (the default).
 	Interactive bool
+
+	// OperatorKeyRestricted is the RFC AX negative permission bit captured on
+	// the run at creation and persisted to runs.operator_key_restricted, so a
+	// resumed / snapshot-restored run reconstructs its restriction without the
+	// original principal on ctx. Additive; false on legacy rows + every path
+	// that doesn't stamp it (fail-open, matching the scope's default-off gate).
+	OperatorKeyRestricted bool
 }
 
 // ParentContext is the typed caller-tracking lineage attached to a run

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -98,6 +98,7 @@ func Run(t *testing.T, factory Factory) {
 		// before resume re-dispatches it). Plus runs.interactive round-trips.
 		{"SweepStaleRunsSkipsPaused", testSweepStaleRunsSkipsPaused},
 		{"CreateRunInteractiveRoundTrip", testCreateRunInteractiveRoundTrip},
+		{"CreateRunOperatorKeyRestrictedRoundTrip", testCreateRunOperatorKeyRestrictedRoundTrip},
 		{"SetRunPauseStateRoundTrip", testSetRunPauseStateRoundTrip},
 		{"SetRunPauseStateUnknownStateRefused", testSetRunPauseStateUnknownStateRefused},
 		{"SetRunPauseStateMissingRunReturnsNotFound", testSetRunPauseStateMissingRunReturnsNotFound},
@@ -1900,6 +1901,31 @@ func testCreateRunInteractiveRoundTrip(t *testing.T, s store.Store) {
 	got, _ := s.GetRun(ctx, inter.ID)
 	if !got.Interactive {
 		t.Errorf("interactive run Interactive=false on read-back (did not persist)")
+	}
+}
+
+// RFC AX: the operator_key_restricted column round-trips on both backends —
+// false by default (fail-open), true when stamped, and it survives a fresh read
+// (so a resumed / snapshot-restored run reconstructs its restriction).
+func testCreateRunOperatorKeyRestrictedRoundTrip(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	sess, _ := s.CreateSession(ctx, "t", "a", "u")
+
+	allowed, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_ok_default"})
+	if allowed.OperatorKeyRestricted {
+		t.Errorf("default OperatorKeyRestricted = true, want false (fail-open)")
+	}
+	if got, _ := s.GetRun(ctx, allowed.ID); got.OperatorKeyRestricted {
+		t.Errorf("default run OperatorKeyRestricted = true on read-back, want false")
+	}
+
+	restricted, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_ok_restricted", OperatorKeyRestricted: true})
+	if !restricted.OperatorKeyRestricted {
+		t.Errorf("CreateRun returned OperatorKeyRestricted=false for a restricted run")
+	}
+	got, _ := s.GetRun(ctx, restricted.ID)
+	if !got.OperatorKeyRestricted {
+		t.Errorf("restricted run OperatorKeyRestricted=false on read-back (did not persist)")
 	}
 }
 

--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -181,6 +181,21 @@ func defCallerIsAdmin(ctx context.Context) bool {
 	return ok && auth.HasScope(p.Scopes, auth.ScopeAdmin)
 }
 
+// operatorKeyRestrictedFromCtx computes the RFC AX operator-key restriction for
+// the principal AUTHORING a trigger def, from the live ctx principal + the
+// deployment gate. It is SERVER authority — a run-triggering def (Schedule /
+// Webhook / A2A) captures it so the scheduler/webhook/A2A executor can stamp the
+// fired run without a token on ctx (anti-bypass: a restricted principal can't
+// launder an unrestricted run through a trigger). The model must NOT be able to
+// set this via the overlay, so write sites stamp it unconditionally after
+// applying the overlay. Fail-open (false) when the gate is off / no principal /
+// legacy / scope-present, matching auth.OperatorKeyRestricted.
+func operatorKeyRestrictedFromCtx(ctx context.Context, cfg *config.Config) bool {
+	p, ok := auth.PrincipalFromContext(ctx)
+	gate := cfg != nil && cfg.Env.OperatorKeyRestriction
+	return auth.OperatorKeyRestricted(p, ok, gate)
+}
+
 func (a *AgentDef) execCreate(ctx context.Context, policy tools.AgentDefPolicyValue, in agentDefInput) (tools.Result, error) {
 	if in.Name == "" {
 		return errResult("create: missing required field: name"), nil

--- a/internal/tools/builtin/scheduledef.go
+++ b/internal/tools/builtin/scheduledef.go
@@ -185,6 +185,10 @@ func (s *ScheduleDef) execCreate(ctx context.Context, policy tools.ScheduleDefPo
 	if def.TenantID == "" {
 		def.TenantID = ident.TenantID
 	}
+	// RFC AX: capture the authoring principal's operator-key restriction (server
+	// authority — unconditional so the overlay can't set it) so the scheduler
+	// stamps the fired run with the creator's grant.
+	def.OperatorKeyRestricted = operatorKeyRestrictedFromCtx(ctx, s.Cfg)
 	if err := validateScheduleDef(def); err != nil {
 		return errResult(fmt.Sprintf("create: %s", err)), nil
 	}
@@ -331,6 +335,9 @@ func (s *ScheduleDef) execFork(ctx context.Context, policy tools.ScheduleDefPoli
 	if def.TenantID == "" {
 		def.TenantID = ident.TenantID
 	}
+	// RFC AX: re-capture the forking principal's operator-key restriction (server
+	// authority) — a fork is a new version, its authority is the forker's grant.
+	def.OperatorKeyRestricted = operatorKeyRestrictedFromCtx(ctx, s.Cfg)
 	if err := validateScheduleDef(def); err != nil {
 		return errResult(fmt.Sprintf("fork: %s", err)), nil
 	}
@@ -916,6 +923,12 @@ type mergedScheduleDef struct {
 	// TenantID is the tenant the fired run EXECUTES as (RFC N follow-up).
 	// Flows to RunInput.TenantID. Per-fork tenant falls out of the overlay.
 	TenantID string `json:"tenant_id,omitempty"`
+	// OperatorKeyRestricted is the RFC AX negative permission bit CAPTURED from
+	// the authoring principal at create/fork (server authority, NOT overlay-set).
+	// The scheduler copies it into RunInput so a fired run keeps its creator's
+	// restriction (anti-bypass). NOT part of any content hash (schedules have no
+	// content_sha256); omitempty keeps gate-off def bodies byte-identical.
+	OperatorKeyRestricted bool `json:"operator_key_restricted,omitempty"`
 }
 
 // mergedSchedulePromptSeg mirrors config.ScheduledRunSegment with JSON tags.

--- a/internal/tools/builtin/webhookdef.go
+++ b/internal/tools/builtin/webhookdef.go
@@ -158,6 +158,10 @@ func (s *WebhookDef) execCreate(ctx context.Context, policy tools.WebhookDefPoli
 	if def.TenantID == "" {
 		def.TenantID = ident.TenantID
 	}
+	// RFC AX: capture the authoring principal's operator-key restriction (server
+	// authority — unconditional so the payload/overlay can't set it) so the
+	// webhook receiver stamps the fired run with the creator's grant.
+	def.OperatorKeyRestricted = operatorKeyRestrictedFromCtx(ctx, s.Cfg)
 	defJSON, err := json.Marshal(def)
 	if err != nil {
 		return errResult(fmt.Sprintf("create: marshal: %s", err)), nil
@@ -298,6 +302,9 @@ func (s *WebhookDef) execFork(ctx context.Context, policy tools.WebhookDefPolicy
 	if def.TenantID == "" {
 		def.TenantID = ident.TenantID
 	}
+	// RFC AX: re-capture the forking principal's operator-key restriction (server
+	// authority) — a fork is a new version, its authority is the forker's grant.
+	def.OperatorKeyRestricted = operatorKeyRestrictedFromCtx(ctx, s.Cfg)
 	defJSON, err := json.Marshal(def)
 	if err != nil {
 		return errResult(fmt.Sprintf("fork: marshal: %s", err)), nil
@@ -707,6 +714,12 @@ type mergedWebhookDef struct {
 	PayloadMapping         map[string]string         `json:"payload_mapping,omitempty"`
 	SyncResponse           mergedWebhookSyncResp     `json:"sync_response,omitempty"`
 	OnComplete             []config.ScheduledRunHook `json:"on_complete,omitempty"`
+	// OperatorKeyRestricted is the RFC AX bit CAPTURED from the authoring
+	// principal at create/fork (server authority, NOT payload/overlay-set); the
+	// webhook receiver copies it into RunInput so a fired run keeps its creator's
+	// restriction. No content_sha256 for webhooks; omitempty keeps gate-off
+	// bodies byte-identical.
+	OperatorKeyRestricted bool `json:"operator_key_restricted,omitempty"`
 }
 
 // mergedWebhookAuth mirrors config.WebhookAuth.

--- a/internal/tools/builtin/websearch.go
+++ b/internal/tools/builtin/websearch.go
@@ -101,12 +101,12 @@ func (s *WebSearch) Execute(ctx context.Context, input json.RawMessage) (tools.R
 	// RFC AR: a tenant/user credential named BRAVE_API_KEY overrides the
 	// operator host key for that run (scope precedence agent > user > tenant),
 	// so a tenant can search on its own Brave quota; the host key is the
-	// fallback. The key stays runtime-side — never surfaced to the model.
-	apiKey := s.APIKey
-	if k, ok := providers.ResolveCredential(ctx, "BRAVE_API_KEY"); ok {
-		apiKey = k
-	}
-	if apiKey == "" {
+	// fallback. RFC AX: a RESTRICTED run with no override gets
+	// ErrOperatorKeyForbidden (never the host key) — treated here as the
+	// existing empty-key refusal, so a restricted WebSearch call refuses
+	// cleanly. The key stays runtime-side — never surfaced to the model.
+	apiKey, _, _, err := providers.ResolveKeyOrOperator(ctx, "BRAVE_API_KEY", s.APIKey)
+	if err != nil || apiKey == "" {
 		return tools.Result{Text: "WebSearch requires BRAVE_API_KEY; refusing", IsError: true}, nil
 	}
 	max := args.MaxResults

--- a/internal/tools/builtin/websearch_credkey_test.go
+++ b/internal/tools/builtin/websearch_credkey_test.go
@@ -44,6 +44,47 @@ func TestWebSearch_BraveKeyOverride(t *testing.T) {
 	}
 }
 
+// RFC AX: a RESTRICTED run must NOT spend the operator's Brave key. With a host
+// key configured but no tenant override, a restricted WebSearch refuses cleanly
+// (the existing empty-key refusal) and never puts the host key on the wire; a
+// tenant override still enables the call under restriction.
+func TestWebSearch_RestrictedRunRefusesHostKey(t *testing.T) {
+	var gotToken string
+	sent := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sent = true
+		gotToken = r.Header.Get("X-Subscription-Token")
+		_, _ = w.Write([]byte(`{"web":{"results":[]}}`))
+	}))
+	defer srv.Close()
+
+	ws := &WebSearch{APIKey: "host-key", Endpoint: srv.URL}
+	input := json.RawMessage(`{"query":"x"}`)
+
+	restricted := providers.WithOperatorKeyAllowed(context.Background(), false)
+	res, err := ws.Execute(restricted, input)
+	if err != nil {
+		t.Fatalf("unexpected transport error: %v", err)
+	}
+	if !res.IsError {
+		t.Errorf("restricted, no override: expected refusal, got %+v", res)
+	}
+	if sent {
+		t.Errorf("restricted run must not reach Brave with the operator key (sent token=%q)", gotToken)
+	}
+
+	// A tenant override still enables the call under restriction.
+	withOverride := providers.WithCredentialResolver(restricted, func(_ context.Context, name string) (providers.CredentialResolution, bool) {
+		return providers.CredentialResolution{Value: "tenant-brave"}, name == "BRAVE_API_KEY"
+	})
+	if res, err := ws.Execute(withOverride, input); err != nil || res.IsError {
+		t.Fatalf("restricted, with override should succeed: err=%v res=%+v", err, res)
+	}
+	if gotToken != "tenant-brave" {
+		t.Errorf("override under restriction: X-Subscription-Token = %q, want tenant-brave", gotToken)
+	}
+}
+
 // A tenant may search on its own Brave quota even when the operator set no host
 // key: the tenant BRAVE_API_KEY both enables the call and is what's sent.
 func TestWebSearch_TenantKeyEnablesWithNoHostKey(t *testing.T) {

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -427,6 +427,15 @@ type RunIdentityValue struct {
 	// to keep this struct cycle-free — same reason RunIdentityValue and
 	// store.RunIdentity are separate structs.
 	ParentContext *store.ParentContext
+
+	// OperatorKeyRestricted is the RFC AX negative permission bit: true =
+	// this run may NOT fall back to the operator's host provider key. false
+	// (the zero value) = allowed, so every unstamped path fails OPEN. Computed
+	// once at run-start from the principal + the deployment gate, carried here
+	// so it survives to resolution/drivers and INHERITS to sub-agents unchanged
+	// (a child cannot escape its parent's restriction). Stage 1 only threads
+	// it; enforcement (resolver routing + driver backstop) lands in stage 2.
+	OperatorKeyRestricted bool
 }
 
 // WithRunIdentity attaches the current run's identity to ctx. The

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -2266,6 +2266,12 @@ export const TOKEN_SCOPES = [
   "runs:read",
   "channel:publish",
   "channel:read",
+  // RFC AX: grants the run the operator's HOST provider API key. Tenant-implied
+  // (substrate:tenant already covers it), so it only matters on a GRANULAR token
+  // when the deployment sets LOOMCYCLE_OPERATOR_KEY_RESTRICTION — OMIT it there to
+  // force that tenant to bring its own key (an RFC AR CredentialDef). Inert when
+  // the gate is off.
+  "providers:operator-key",
 ] as const;
 
 // ---- Routing view (GET /v1/_routing) ----

--- a/web/src/components/TokenManager.tsx
+++ b/web/src/components/TokenManager.tsx
@@ -218,6 +218,12 @@ export default function TokenManager() {
         </div>
         <fieldset className="token-scopes">
           <legend>scopes</legend>
+          <p className="settings-muted">
+            <code>providers:operator-key</code> lets the token spend the operator's
+            provider API keys. It only bites when the deployment runs{" "}
+            <code>LOOMCYCLE_OPERATOR_KEY_RESTRICTION=1</code>: omit it on a granular
+            token to force that tenant to bring its own key (an RFC AR credential).
+          </p>
           {TOKEN_SCOPES.map((s) => (
             <label key={s} className="scope-check">
               <input


### PR DESCRIPTION
Implements **RFC AX** (`~/work/loomcycle-internal/doc-internal/rfcs/operator-key-scope.md`). RFC AR let a tenant *override* with its own provider key; the fallback to the operator's host key on a miss was **unconditional**, so any tenant could spend the operator's LLM/search budget by not bringing a key. This adds a scope `providers:operator-key` that gates that fallback.

## Why
An operator running a multi-tenant instance needs cost-isolated, bring-your-own-key tenants. Behind a **default-off gate `LOOMCYCLE_OPERATOR_KEY_RESTRICTION`**, a run whose principal lacks the (tenant-implied) scope is *restricted* — it may use only providers it can key itself. **Gate-off ⇒ byte-identical behavior** (safe on stable v1.11).

## Two-layer enforcement
- **Layer 1 — credential-aware routing (admission).** The server precomputes the providers a restricted tenant can key (metadata-only `credential.Engine.HasKey`, no decrypt) and passes a `KeyableProviders` filter into the lock-free resolver (`internal/resolve/matrix.go` — `Resolve`/`priorityFor`/`Cascade` skip un-keyable providers; empty viable set → `ErrOperatorKeyRestricted`). The fallback cascade honors the same filter. All credEngine I/O stays in the server (resolver stays lock-free).
- **Layer 2 — driver backstop (mandatory).** A shared `providers.ResolveKeyOrOperator` returns `ErrOperatorKeyForbidden` (non-retryable) when a restricted run hits a driver's operator-key fallback — covering **pinned agents** (which skip routing) and any fail-open gap. Provider→key-env via a new `KeyedProvider` interface.

## Backward-safe + universal across run paths
The permission is a **negative** `OperatorKeyRestricted` bit (fail-open) on `RunIdentityValue` + a `providers` ctx value + an additive `runs.operator_key_restricted` column (**migration 0055**, both backends). Stamped at every run-start (handleRuns/handleMessages/RunOnce), **inherited** by sub-agents, **restored** on resume, **captured** on Schedule/Webhook trigger defs (anti-bypass, F40 pattern, excluded from `content_sha256`), and **derived from the authenticated peer's operator-token scopes** for A2A. The **LLM gateway + embeddings** refuse a restricted principal fail-closed (a raw operator-key passthrough with no BYO-key path).

## Refusal shape
`ErrOperatorKeyRestricted` + `ErrTierAgentNotAvailable` → **HTTP 403** (typed code `operator_key_restricted`; the latter is a pre-existing latent 400 fix) / gRPC `PermissionDenied`. Grantable at token mint (Web UI scope list + helptext); documented in `docs/CONFIGURATION.md`, the operator-tokens help topic, and `.env.insecure.example` (non-secret flag).

## Post-merge code review (high-effort, 3 finder angles) → 1 fix
All three angles independently confirmed one **HIGH** fail-open gap: `compactRunWithSource` → `loop.Summarize` made a provider call with an **unstamped ctx**, so a restricted run's **compaction summary** spent the operator's key (a full bypass for a pinned restricted run). **Fixed** (`0921a478`) by stamping the summary ctx (resolver + operator-key + identity), mirroring `resume.go`; regression `TestCompact_RestrictedRunDeniesOperatorKey` verified fail-before.

**Documented carve-outs (not fixed — out of RFC AX's declared scope of provider LLM keys + WebSearch):**
- In-run **Memory semantic-embed** uses the operator's *embedder* key (BYO-embedder-key is a documented future enhancement; the `/v1/embeddings` gateway endpoint conservatively refuses restricted principals).
- A **broken/rotated** tenant credential makes Layer 1 keep the provider while Layer 2 hard-refuses → the run errors (informative) rather than falling back.
- `/v1/_routing` is agent-agnostic, so it doesn't apply the per-agent keyable filter (observability only).

## Tested
`go test ./...` clean; `make build-all` clean. New: auth scope + helper matrix; resolver keyable filter (routes to only-keyable, empty→refuse, **pin NOT filtered**, nil unchanged, Cascade filtered); credential `HasKey` precedence; per-driver + websearch backstop (restricted+no override → `ErrOperatorKeyForbidden`, never the operator key; ollama-local exempt); loop non-cascade + no matrix-poison; http admission 403 + typed code, sub-agent inheritance, resume restore, gate-off byte-identical, RFC AV attribution unchanged, gateway 403, compaction denial; store round-trip both backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)