### PR TITLE
fix(webui): reset default button chrome on Library sub-tabs

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2655,7 +2655,15 @@ button.primary:disabled {
   padding: 10px 16px;
   color: var(--fg-soft);
   text-decoration: none;
+  /* The @loomcycle/library <Library> renders these tabs as <button>s (they
+   * used to be anchors). Without these resets the browser's default button
+   * chrome (grey fill + border) leaks through — web styles the library from
+   * this global sheet, NOT the package's scoped styles.css, so it must carry
+   * the same resets the package's `.loomcycle-library .library-subtab` does. */
+  border: 0;
   border-bottom: 2px solid transparent;
+  background: transparent;
+  cursor: pointer;
   font-size: 13px;
 }
 .library-subtab:hover {


### PR DESCRIPTION
## Problem

The Library sub-tabs (Agents / Skills / MCP Servers) render with the browser's default grey button fill on the **inactive** tabs — only the active tab looks styled (accent underline).

## Cause

A package↔web CSS drift from the RFC AY extraction. The `@loomcycle/library` `<Library>` component renders these tabs as `<button>` elements (they were anchors before extraction). Web styles the library from its **global** `web/src/styles.css` — **not** the package's scoped `styles.css` (the deliberate AY "reuse global class names" approach) — and the global `.library-subtab` rule was never updated for the button markup: it lacked `border: 0`, `background: transparent`, and `cursor: pointer`. With no global `button` reset (only `* { box-sizing }`), the default button chrome leaked through.

## Fix

Add the three resets to the global `.library-subtab`, matching the package's `.loomcycle-library .library-subtab` rule exactly. One-rule, web-only change.

## Tested

Playwright render-smoke on `/ui/library/agents` in **both light and dark** themes: inactive tabs now render transparent, the active tab keeps its accent underline. `web` build clean.

## Note

This is the drift risk the AY "web reuses global CSS instead of importing the package sheet" approach carries — the same latent risk exists for `@loomcycle/explorer`. A drift-proof follow-up would be to have web `import "@loomcycle/library/styles.css"` (+ explorer's) and drop the duplicated global rules; flagging, not doing it here to keep this fix surgical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)