### PR TITLE
refactor(webui): rename residual camelCase allowedTools → tools

### DIFF
--- a/packages/library/src/components/LibraryEditModal.tsx
+++ b/packages/library/src/components/LibraryEditModal.tsx
@@ -124,7 +124,7 @@ export default function LibraryEditModal({
   const [codeBody, setCodeBody] = useState(
     pickString(forkSource?.definition, "code_body"),
   );
-  const [allowedTools, setAllowedTools] = useState(
+  const [tools, setTools] = useState(
     pickStringArray(forkSource?.definition, "tools").join(", "),
   );
   const [agentSkills, setAgentSkills] = useState(
@@ -219,7 +219,7 @@ export default function LibraryEditModal({
   const [skillBody, setSkillBody] = useState<string>(
     pickString(forkSource?.definition, "body"),
   );
-  const [skillAllowedTools, setSkillAllowedTools] = useState<string>(
+  const [skillTools, setSkillTools] = useState<string>(
     pickStringArray(forkSource?.definition, "tools").join(", "),
   );
 
@@ -391,8 +391,8 @@ export default function LibraryEditModal({
       // hash-significant). Omit when empty so a fork of an LLM agent
       // doesn't write a "" body.
       if (codeBody.trim()) ov.code_body = codeBody;
-      const tools = parseCommaList(allowedTools);
-      if (tools.length > 0) ov.tools = tools;
+      const toolsList = parseCommaList(tools);
+      if (toolsList.length > 0) ov.tools = toolsList;
       const sk = parseCommaList(agentSkills);
       if (sk.length > 0) ov.skills = sk;
       const provs = parseCommaList(agentProviders);
@@ -466,8 +466,8 @@ export default function LibraryEditModal({
     if (kind === "skill") {
       const ov: Record<string, unknown> = { body: skillBody };
       if (description.trim()) ov.description = description.trim();
-      const tools = parseCommaList(skillAllowedTools);
-      if (tools.length > 0) ov.tools = tools;
+      const toolsList = parseCommaList(skillTools);
+      if (toolsList.length > 0) ov.tools = toolsList;
       return ov;
     }
     // mcp-server
@@ -615,8 +615,8 @@ export default function LibraryEditModal({
             setSystemPrompt={setSystemPrompt}
             codeBody={codeBody}
             setCodeBody={setCodeBody}
-            allowedTools={allowedTools}
-            setAllowedTools={setAllowedTools}
+            tools={tools}
+            setTools={setTools}
             agentSkills={agentSkills}
             setAgentSkills={setAgentSkills}
             maxTokens={maxTokens}
@@ -671,8 +671,8 @@ export default function LibraryEditModal({
 
         {kind === "skill" && (
           <SkillFields
-            allowedTools={skillAllowedTools}
-            setAllowedTools={setSkillAllowedTools}
+            tools={skillTools}
+            setTools={setSkillTools}
             body={skillBody}
             setBody={setSkillBody}
             submitting={submitting}
@@ -749,8 +749,8 @@ interface AgentFieldsProps {
   setSystemPrompt: (v: string) => void;
   codeBody: string;
   setCodeBody: (v: string) => void;
-  allowedTools: string;
-  setAllowedTools: (v: string) => void;
+  tools: string;
+  setTools: (v: string) => void;
   agentSkills: string;
   setAgentSkills: (v: string) => void;
   maxTokens: string;
@@ -909,17 +909,17 @@ function AgentFields(props: AgentFieldsProps) {
       )}
 
       <div className="library-form-row">
-        <label htmlFor="lib-allowed-tools">
+        <label htmlFor="lib-tools">
           tools
           <span className="library-modal-field-hint">
             {" "}— comma-separated tool names (Read, WebFetch, Memory…)
           </span>
         </label>
         <input
-          id="lib-allowed-tools"
+          id="lib-tools"
           type="text"
-          value={props.allowedTools}
-          onChange={(e) => props.setAllowedTools(e.target.value)}
+          value={props.tools}
+          onChange={(e) => props.setTools(e.target.value)}
           disabled={props.submitting}
           placeholder="Read, WebFetch, Memory, Channel"
         />
@@ -1306,8 +1306,8 @@ function AgentAdvancedOverlay(props: {
 }
 
 function SkillFields(props: {
-  allowedTools: string;
-  setAllowedTools: (v: string) => void;
+  tools: string;
+  setTools: (v: string) => void;
   body: string;
   setBody: (v: string) => void;
   submitting: boolean;
@@ -1324,8 +1324,8 @@ function SkillFields(props: {
         <input
           id="lib-skill-tools"
           type="text"
-          value={props.allowedTools}
-          onChange={(e) => props.setAllowedTools(e.target.value)}
+          value={props.tools}
+          onChange={(e) => props.setTools(e.target.value)}
           disabled={props.submitting}
           placeholder="WebFetch, Read"
         />

--- a/packages/library/src/lib/claudeImport.ts
+++ b/packages/library/src/lib/claudeImport.ts
@@ -154,11 +154,11 @@ export function parseSkillMarkdown(
     warnings.push("body is large (>100KB) — may exceed the operator's LOOMCYCLE_SKILL_DEF_MAX_BODY_BYTES cap.");
   }
 
-  const allowedTools = coerceStringList(fm["allowed-tools"] ?? fm.tools);
+  const tools = coerceStringList(fm["allowed-tools"] ?? fm.tools);
   const overlay: Record<string, unknown> = { body };
   const description = typeof fm.description === "string" ? fm.description.trim() : "";
   if (description) overlay.description = description;
-  if (allowedTools.length > 0) overlay.tools = allowedTools;
+  if (tools.length > 0) overlay.tools = tools;
 
   return {
     candidate: {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,7 +11,7 @@
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
         "@fontsource-variable/outfit": "^5.2.8",
-        "@loomcycle/client": "^1.12.1",
+        "@loomcycle/client": "^1.13.0",
         "js-yaml": "^4.2.0",
         "lucide-react": "^0.460.0",
         "react": "^19.0.0",
@@ -831,9 +831,9 @@
       }
     },
     "node_modules/@loomcycle/client": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@loomcycle/client/-/client-1.12.1.tgz",
-      "integrity": "sha512-ErfNc6pE1vXdJMkCx7AsqZYpoNm3fYg+EiIvAO9k4tqtj95525V+C9lMGdss+z78oXQl4liSs9AEF2HNmE/D2g==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@loomcycle/client/-/client-1.13.0.tgz",
+      "integrity": "sha512-gmnRBdb00f8QyVRi0EXkD3HF/6KHkXDua+dqN7IWqJSHGnG/SqJKs+Sr6x13G4BiePLNN8XXIpYceNTAG4VFmw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"

--- a/web/package.json
+++ b/web/package.json
@@ -15,7 +15,7 @@
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@fontsource-variable/outfit": "^5.2.8",
-    "@loomcycle/client": "^1.12.1",
+    "@loomcycle/client": "^1.13.0",
     "js-yaml": "^4.2.0",
     "lucide-react": "^0.460.0",
     "react": "^19.0.0",

--- a/web/src/lib/claudeImport.ts
+++ b/web/src/lib/claudeImport.ts
@@ -154,11 +154,11 @@ export function parseSkillMarkdown(
     warnings.push("body is large (>100KB) — may exceed the operator's LOOMCYCLE_SKILL_DEF_MAX_BODY_BYTES cap.");
   }
 
-  const allowedTools = coerceStringList(fm["allowed-tools"] ?? fm.tools);
+  const tools = coerceStringList(fm["allowed-tools"] ?? fm.tools);
   const overlay: Record<string, unknown> = { body };
   const description = typeof fm.description === "string" ? fm.description.trim() : "";
   if (description) overlay.description = description;
-  if (allowedTools.length > 0) overlay.tools = allowedTools;
+  if (tools.length > 0) overlay.tools = tools;
 
   return {
     candidate: {


### PR DESCRIPTION
## Why

The v1.13.0 `allowed_tools`→`tools` rename covered the wire/YAML/adapter but left **internal camelCase `allowedTools` identifiers** in the WebUI. These aren't user-visible (the field **label already reads "tools"** since RFC AY), but they're inconsistent with the canonical name — the residual flagged after the rename.

## What

- `packages/library/src/components/LibraryEditModal.tsx`: state/props/setters `allowedTools`→`tools`, `setAllowedTools`→`setTools`, `skillAllowedTools`→`skillTools`, and the DOM id `lib-allowed-tools`→`lib-tools`.
- `packages/library/src/lib/claudeImport.ts` + `web/src/lib/claudeImport.ts`: local var `allowedTools`→`tools` (the kebab `allowed-tools` frontmatter read stays — Claude Code skill-import alias).
- Collision fix: the block-local `const tools = parseCommaList(...)` renamed to `toolsList` to avoid shadowing the new `tools` state.

## Tested
- `packages/library` build + **7/7** tests; `web` `tsc --noEmit` clean.
- Grep: no `allowedTools`/`allowed_tools` residual remains (only the intentional kebab `allowed-tools` reads).

No public-API change (LibraryEditModal is internal to `<Library>`), so no `@loomcycle/library` version bump needed — web picks it up from source on next build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)