### PR TITLE
feat(webui): tenant routing availability + credential key-name combobox

### DIFF
--- a/internal/api/http/routing.go
+++ b/internal/api/http/routing.go
@@ -14,16 +14,17 @@ import (
 // provider/model cascade a consumer would hit (top → fallbacks), so an operator
 // can see which providers/models runs resolve to right now.
 //
-// Two views by principal (RFC AS posture):
-//   - admin: live availability per candidate (reachable/stalled/rate-limited),
-//     which entry is currently SELECTED (first available = what runs now), plus
-//     an active-providers header.
-//   - substrate:tenant: the config cascade only (provider/model per tier,
-//     `primary` = the configured top). No provider reachability / infra detail.
+// Both principals get live availability per candidate + an active-providers
+// header — a tenant needs to see which of its providers are actually up right
+// now (RFC AX bring-your-own-key visibility). They differ in two ways:
+//   - admin: the FULL provider set, with the raw last_error string per provider.
+//   - substrate:tenant: last_error is redacted (it can leak operator infra
+//     detail), and when the operator-key gate restricts this tenant the cascade
+//     and header are filtered to providers the tenant can key itself.
 type routingResponse struct {
 	GeneratedAt time.Time         `json:"generated_at"`
 	Admin       bool              `json:"admin"`
-	Providers   []routingProvider `json:"providers,omitempty"` // admin-only
+	Providers   []routingProvider `json:"providers,omitempty"`
 	UserTiers   []routingUserTier `json:"user_tiers"`
 	// OperatorKeyRestricted is true when the RFC AX operator-key gate
 	// (LOOMCYCLE_OPERATOR_KEY_RESTRICTION) is ON and this caller is a restricted
@@ -37,6 +38,8 @@ type routingProvider struct {
 	Provider  string `json:"provider"`
 	Reachable bool   `json:"reachable"`
 	Excluded  bool   `json:"excluded"`
+	// LastError is the raw provider probe error — admin-only (redacted to "" for
+	// a tenant, since it can leak operator infra detail).
 	LastError string `json:"last_error,omitempty"`
 }
 
@@ -55,7 +58,7 @@ type routingCandidate struct {
 	Provider string `json:"provider"`
 	Model    string `json:"model"`
 	Primary  bool   `json:"primary"` // first in config order (the configured top)
-	// Admin-only live-availability fields (nil/omitted for a tenant view).
+	// Live-availability fields — populated for ALL principals (admin + tenant).
 	Available   *bool `json:"available,omitempty"`
 	Selected    *bool `json:"selected,omitempty"` // first AVAILABLE — what runs now
 	Stalled     *bool `json:"stalled,omitempty"`
@@ -64,17 +67,18 @@ type routingCandidate struct {
 }
 
 // handleRouting serves GET /v1/_routing. Tenant-readable (see requiredScopeFor):
-// a substrate:tenant operator gets the config cascade; an admin (or legacy/open)
-// additionally gets live availability + the active-providers header.
+// every principal gets the cascade + live availability + the active-providers
+// header; a non-admin has last_error redacted, and a gate-restricted tenant sees
+// only the providers it can key itself.
 func (s *Server) handleRouting(w http.ResponseWriter, r *http.Request) {
 	if s.resolver == nil {
 		writeJSONError(w, http.StatusServiceUnavailable, "resolver_unavailable",
 			"resolver not configured; the server is in degraded startup mode")
 		return
 	}
-	// Admin ⇒ full view (availability + infra). A non-admin principal
-	// (substrate:tenant) ⇒ config cascade only. Open mode (no principal stamped)
-	// is dev/admin, so it gets the full view.
+	// admin gates last_error exposure (raw provider errors can leak infra detail)
+	// and disables the operator-key keyable filter. Open mode (no principal
+	// stamped) is dev/admin, so it gets the full view.
 	admin := true
 	if p, ok := auth.PrincipalFromContext(r.Context()); ok {
 		admin = auth.HasScope(p.Scopes, auth.ScopeAdmin)
@@ -116,6 +120,13 @@ func (s *Server) handleRouting(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := routingResponse{GeneratedAt: time.Now().UTC(), Admin: admin, OperatorKeyRestricted: restricted}
+	// When restricted, the active-providers header is filtered to the union of
+	// the tenant's keyable providers across all tiers (never advertise a provider
+	// it can't use). nil ⇒ unrestricted (the header lists every snapshot provider).
+	var keyableUnion map[string]bool
+	if restricted {
+		keyableUnion = map[string]bool{}
+	}
 	for _, ut := range utNames {
 		overlay := s.userTierOverlay(ut)
 		rut := routingUserTier{Name: ut}
@@ -131,6 +142,9 @@ func (s *Server) handleRouting(w http.ResponseWriter, r *http.Request) {
 			var keyable map[string]bool
 			if restricted {
 				keyable = s.keyableProvidersFor(r.Context(), req, restrictTenant, "", restrictUser)
+				for p := range keyable {
+					keyableUnion[p] = true
+				}
 			}
 			rt := routingTier{Tier: tier}
 			selectedMarked := false
@@ -139,21 +153,21 @@ func (s *Server) handleRouting(w http.ResponseWriter, r *http.Request) {
 					continue
 				}
 				// Primary = first entry in the (post-filter) displayed cascade. For
-				// an unrestricted caller nothing is filtered, so this equals the
-				// old i==0 (byte-identical response).
+				// an unrestricted caller nothing is filtered, so this equals i==0.
 				rc := routingCandidate{Provider: c.Provider, Model: c.Model, Primary: len(rt.Cascade) == 0}
-				if admin {
-					av, stalled, rateLimited, reachable := availStatus(snap, c.Provider, c.Model)
-					sel := av && !selectedMarked
-					if sel {
-						selectedMarked = true
-					}
-					rc.Available = &av
-					rc.Selected = &sel
-					rc.Stalled = &stalled
-					rc.RateLimited = &rateLimited
-					rc.Reachable = &reachable
+				// WHY availability for all principals: a tenant needs to see which
+				// of its (keyable) providers are up right now (RFC AX). Only the raw
+				// last_error string stays admin-only — redacted in the header below.
+				av, stalled, rateLimited, reachable := availStatus(snap, c.Provider, c.Model)
+				sel := av && !selectedMarked
+				if sel {
+					selectedMarked = true
 				}
+				rc.Available = &av
+				rc.Selected = &sel
+				rc.Stalled = &stalled
+				rc.RateLimited = &rateLimited
+				rc.Reachable = &reachable
 				rt.Cascade = append(rt.Cascade, rc)
 			}
 			rut.Tiers = append(rut.Tiers, rt)
@@ -161,21 +175,26 @@ func (s *Server) handleRouting(w http.ResponseWriter, r *http.Request) {
 		resp.UserTiers = append(resp.UserTiers, rut)
 	}
 
-	if admin {
-		provNames := make([]string, 0, len(snap))
-		for p := range snap {
-			provNames = append(provNames, p)
+	// Active-providers header — shown to every principal. WHY the admin split:
+	// reachable/excluded status is tenant-safe visibility, but the raw last_error
+	// string can leak operator infra detail (DSNs, internal hostnames, upstream
+	// bodies), so it is populated for admins only. Restricted ⇒ list only the
+	// tenant's keyable providers.
+	provNames := make([]string, 0, len(snap))
+	for p := range snap {
+		if restricted && !keyableUnion[p] {
+			continue
 		}
-		sort.Strings(provNames)
-		for _, p := range provNames {
-			a := snap[p]
-			resp.Providers = append(resp.Providers, routingProvider{
-				Provider:  p,
-				Reachable: a.Reachable,
-				Excluded:  a.Excluded,
-				LastError: a.LastError,
-			})
+		provNames = append(provNames, p)
+	}
+	sort.Strings(provNames)
+	for _, p := range provNames {
+		a := snap[p]
+		rp := routingProvider{Provider: p, Reachable: a.Reachable, Excluded: a.Excluded}
+		if admin {
+			rp.LastError = a.LastError
 		}
+		resp.Providers = append(resp.Providers, rp)
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/api/http/routing_test.go
+++ b/internal/api/http/routing_test.go
@@ -98,7 +98,17 @@ func TestRouting_AdminSeesCascadeAndAvailability(t *testing.T) {
 		t.Errorf("cascade[1] (anthropic, down) should be unavailable + not selected; got %+v", mid.Cascade[1])
 	}
 	if len(resp.Providers) == 0 {
-		t.Error("admin response must include the active-providers header")
+		t.Fatal("admin response must include the active-providers header")
+	}
+	// Admin sees the raw provider probe error (anthropic was seeded "probe failed").
+	var anthropic *routingProvider
+	for i := range resp.Providers {
+		if resp.Providers[i].Provider == "anthropic" {
+			anthropic = &resp.Providers[i]
+		}
+	}
+	if anthropic == nil || anthropic.LastError != "probe failed" {
+		t.Errorf("admin providers header must carry the raw last_error; got %+v", anthropic)
 	}
 }
 
@@ -159,12 +169,27 @@ func TestRouting_RestrictedTenantFilteredToKeyableProviders(t *testing.T) {
 		t.Errorf("middle cascade = %+v, want 0 candidates (tenant can key nothing)", mid.Cascade)
 	}
 
-	// (b) tenant CAN key the provider → it survives the filter.
+	// (b) tenant CAN key the provider → it survives the filter AND carries live
+	// availability (RFC AX visibility). The keyed provider is seeded reachable +
+	// listed, so it reads available + selected.
 	keyable := func(_ context.Context, _, _, _, name string) bool { return name == "KEYED_API_KEY" }
 	srvKey, _ := operatorKeyTierServer(t, completingKeyed("KEYED_API_KEY", "", ""), true, keyable)
 	respKey := routingForPrincipal(t, srvKey, tenant)
-	if mid := middleTier(t, respKey); len(mid.Cascade) != 1 || mid.Cascade[0].Provider != "keyed" {
-		t.Errorf("middle cascade = %+v, want the keyed provider kept", mid.Cascade)
+	mid := middleTier(t, respKey)
+	if len(mid.Cascade) != 1 || mid.Cascade[0].Provider != "keyed" {
+		t.Fatalf("middle cascade = %+v, want the keyed provider kept", mid.Cascade)
+	}
+	if mid.Cascade[0].Available == nil || !*mid.Cascade[0].Available ||
+		mid.Cascade[0].Selected == nil || !*mid.Cascade[0].Selected {
+		t.Errorf("restricted-tenant kept candidate must carry availability; got %+v", mid.Cascade[0])
+	}
+	// The (filtered) active-providers header is shown to the tenant with
+	// last_error redacted, and lists only the keyable provider.
+	if len(respKey.Providers) != 1 || respKey.Providers[0].Provider != "keyed" {
+		t.Fatalf("providers header = %+v, want just the keyable provider", respKey.Providers)
+	}
+	if respKey.Providers[0].LastError != "" {
+		t.Errorf("tenant provider header must redact last_error; got %q", respKey.Providers[0].LastError)
 	}
 }
 
@@ -182,35 +207,40 @@ func TestRouting_AdminUnaffectedByOperatorKeyGate(t *testing.T) {
 	}
 }
 
-// TestRouting_TenantGetsStrippedView: a substrate:tenant principal sees the
-// config cascade (provider/model per tier) but NOT the live availability fields
-// or the active-providers infra header.
-func TestRouting_TenantGetsStrippedView(t *testing.T) {
+// TestRouting_TenantSeesAvailabilityWithRedactedError: a substrate:tenant
+// principal now gets the SAME live availability an admin does (per-candidate
+// fields + the active-providers header), so it can see which providers are up —
+// but the raw last_error string is redacted, since it can leak operator infra
+// detail. Fails on the pre-change handler, which withheld availability + the
+// header from a tenant entirely.
+func TestRouting_TenantSeesAvailabilityWithRedactedError(t *testing.T) {
 	srv := routingTestServer(t)
 	resp := routingFor(t, srv, []string{auth.ScopeTenant})
 
 	if resp.Admin {
 		t.Error("admin=true for a tenant principal")
 	}
-	if len(resp.Providers) != 0 {
-		t.Errorf("tenant must not see the active-providers header; got %+v", resp.Providers)
+	mid := middleTier(t, resp)
+	if len(mid.Cascade) != 2 {
+		t.Fatalf("middle cascade = %+v, want 2 candidates", mid.Cascade)
 	}
-	var mid *routingTier
-	for i := range resp.UserTiers[0].Tiers {
-		if resp.UserTiers[0].Tiers[i].Tier == "middle" {
-			mid = &resp.UserTiers[0].Tiers[i]
-		}
-	}
-	if mid == nil || len(mid.Cascade) != 2 {
-		t.Fatalf("middle cascade = %+v, want 2 candidates", mid)
-	}
-	// Cascade (provider/model + primary) is present...
 	if mid.Cascade[0].Provider != "deepseek" || mid.Cascade[0].Model != "deepseek-v4-pro" {
 		t.Errorf("cascade[0] = %+v, want deepseek/deepseek-v4-pro", mid.Cascade[0])
 	}
-	// ...but the live-availability/infra fields are stripped.
-	if mid.Cascade[0].Available != nil || mid.Cascade[0].Selected != nil ||
-		mid.Cascade[0].Stalled != nil || mid.Cascade[0].Reachable != nil {
-		t.Errorf("tenant cascade must NOT carry availability/infra fields; got %+v", mid.Cascade[0])
+	// Cascade now carries live availability for a tenant too (deepseek is
+	// reachable + listed → available + selected).
+	if mid.Cascade[0].Available == nil || !*mid.Cascade[0].Available ||
+		mid.Cascade[0].Selected == nil || !*mid.Cascade[0].Selected {
+		t.Errorf("tenant cascade[0] (deepseek) should be available + selected; got %+v", mid.Cascade[0])
+	}
+	// The active-providers header is shown to the tenant...
+	if len(resp.Providers) == 0 {
+		t.Fatal("tenant response must include the active-providers header")
+	}
+	// ...but every last_error is redacted, even anthropic's real "probe failed".
+	for _, p := range resp.Providers {
+		if p.LastError != "" {
+			t.Errorf("tenant provider %q must have last_error redacted; got %q", p.Provider, p.LastError)
+		}
 	}
 }

--- a/web/src/pages/RoutingView.tsx
+++ b/web/src/pages/RoutingView.tsx
@@ -14,12 +14,11 @@ import {
 // their provider_priority / tier config before a consumer discovers it the
 // hard way.
 //
-// Two shapes, driven by the API (not a client-side role check): an admin
-// response carries live availability per candidate (which one is SELECTED —
-// the first reachable = what runs now) plus an active-providers header; a
-// substrate:tenant response is the config cascade only. The UI keys the
-// availability rendering off `resp.admin` AND field presence, so a stripped
-// tenant payload simply renders the cascade without dots.
+// Every principal gets live availability per candidate (which one is SELECTED
+// — the first reachable = what runs now) plus an active-providers header. The
+// UI renders those purely by FIELD PRESENCE, not a client-side role check: a
+// tenant's payload has last_error redacted and, under the operator-key gate, is
+// filtered to the providers it can key — the same fields, fewer rows.
 
 // tierOrder gives low/middle/high a stable visual rank; anything else sorts
 // after, preserving server order.
@@ -48,6 +47,15 @@ export default function RoutingView() {
   useEffect(() => {
     void fetchRouting();
   }, [fetchRouting]);
+
+  // Availability is present for every principal now (the backend populates it
+  // for admin + tenant alike). Render the dots + legend purely by field
+  // presence — a redacted/filtered tenant payload still shows what it has.
+  const hasAvailability =
+    (!!resp?.providers && resp.providers.length > 0) ||
+    !!resp?.user_tiers.some((ut) =>
+      ut.tiers.some((t) => t.cascade.some((c) => c.available !== undefined)),
+    );
 
   return (
     <div className="routing-view">
@@ -78,7 +86,7 @@ export default function RoutingView() {
 
       {err && <div className="err">{err}</div>}
 
-      {resp && resp.admin && resp.providers && resp.providers.length > 0 && (
+      {resp && resp.providers && resp.providers.length > 0 && (
         <div className="routing-providers">
           <span className="routing-providers-label">providers</span>
           {resp.providers.map((p) => {
@@ -104,7 +112,7 @@ export default function RoutingView() {
         </div>
       )}
 
-      {resp && resp.admin && (
+      {hasAvailability && (
         <div className="routing-legend">
           <span>
             <span className="routing-dot up" /> available
@@ -117,9 +125,10 @@ export default function RoutingView() {
         </div>
       )}
 
-      {resp && !resp.admin && (
+      {resp && resp.operator_key_restricted && (
         <p className="routing-tenant-note">
-          Configured cascade. Live provider reachability is available to admins.
+          Operator API keys are not available to your tenant — only providers you
+          have your own credentials for are shown.
         </p>
       )}
 
@@ -139,7 +148,7 @@ export default function RoutingView() {
               {[...ut.tiers]
                 .sort((a, b) => tierRank(a.tier) - tierRank(b.tier))
                 .map((t) => (
-                  <TierCard key={t.tier} tier={t} admin={resp.admin} />
+                  <TierCard key={t.tier} tier={t} />
                 ))}
             </div>
           </section>
@@ -152,7 +161,7 @@ export default function RoutingView() {
   );
 }
 
-function TierCard({ tier, admin }: { tier: RoutingTier; admin: boolean }) {
+function TierCard({ tier }: { tier: RoutingTier }) {
   return (
     <div className="routing-tier-card">
       <div className="routing-tier-title">{tier.tier}</div>
@@ -161,11 +170,7 @@ function TierCard({ tier, admin }: { tier: RoutingTier; admin: boolean }) {
       ) : (
         <ol className="routing-cascade">
           {tier.cascade.map((c, i) => (
-            <CandidateRow
-              key={`${c.provider}/${c.model}/${i}`}
-              c={c}
-              admin={admin}
-            />
+            <CandidateRow key={`${c.provider}/${c.model}/${i}`} c={c} />
           ))}
         </ol>
       )}
@@ -173,9 +178,10 @@ function TierCard({ tier, admin }: { tier: RoutingTier; admin: boolean }) {
   );
 }
 
-function CandidateRow({ c, admin }: { c: RoutingCandidate; admin: boolean }) {
-  // Availability dots only render when the field is present (admin payload).
-  const hasAvail = admin && c.available !== undefined;
+function CandidateRow({ c }: { c: RoutingCandidate }) {
+  // Availability dots render purely by field presence — the backend populates
+  // these for a tenant too now (admin only differs by seeing last_error).
+  const hasAvail = c.available !== undefined;
   const selected = c.selected === true;
   const rowClass = [
     "routing-cand",

--- a/web/src/pages/SettingsView.tsx
+++ b/web/src/pages/SettingsView.tsx
@@ -117,6 +117,17 @@ function isCredStoreDisabled(msg: string): boolean {
 // API groups by scope; we merge tenant + user into one table).
 type CredentialRow = CredentialMeta & { _scope: CredentialScope };
 
+// well-known provider/tool key env-var names (mirror docs/CREDENTIALS.md);
+// free-form custom names (e.g. $cred: labels) are still allowed.
+const KNOWN_KEY_NAMES = [
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "DEEPSEEK_API_KEY",
+  "GEMINI_API_KEY",
+  "OLLAMA_API_KEY",
+  "BRAVE_API_KEY",
+];
+
 function CredentialsSection() {
   const [rows, setRows] = useState<CredentialRow[]>([]);
   const [err, setErr] = useState<string | null>(null);
@@ -222,12 +233,18 @@ function CredentialsSection() {
       <form className="cred-create" onSubmit={onCreate}>
         <input
           type="text"
+          list="cred-key-names"
           placeholder="name (e.g. ANTHROPIC_API_KEY)"
           value={name}
           onChange={(e) => setName(e.target.value)}
           autoComplete="off"
           spellCheck={false}
         />
+        <datalist id="cred-key-names">
+          {KNOWN_KEY_NAMES.map((n) => (
+            <option key={n} value={n} />
+          ))}
+        </datalist>
         <input
           type="password"
           placeholder="value (secret — write-only)"


### PR DESCRIPTION
Two Settings improvements requested by the operator.

## 1. Settings → Routing shows active providers to tenants (filtered when operator-key-restricted)

Previously the routing view computed live availability **only for admins** (an `if admin` guard); tenants saw the config cascade with no availability, and the UI gated rendering on `resp.admin`. The RFC AX credential-aware *filtering* already existed (#652 drops non-keyable candidates for restricted tenants) — this adds the availability layer.

**Backend (`internal/api/http/routing.go`):**
- Per-candidate availability (`available/selected/stalled/rate_limited/reachable`) is now computed for **all** principals, so a tenant sees which providers are live — exactly what runs for them.
- The active-providers header is built for tenants too; **when restricted**, it's filtered to the tenant's keyable providers (union of the per-tier keyable sets) so it never lists a provider they can't use.
- **Security:** the raw provider `last_error` string stays **admin-only** (redacted to `""` for non-admins) — it can leak operator infra detail. Tenants still get the reachable/excluded *status*.
- `operator_key_restricted` stays on the response.

**Web UI (`RoutingView.tsx`):** renders availability by **field-presence** (not the `admin` flag); the providers header + legend render whenever availability is present; a "operator API keys aren't available to your tenant — only providers you have credentials for are shown" note renders when `operator_key_restricted`.

**Behavior (matches the request):** a non-restricted tenant sees all providers' availability ("like admin"); a restricted tenant sees only its keyable providers + fallbacks, with availability.

## 2. Settings → Credentials key-name combobox

The credential name `<input>` is now an editable `<datalist>` combobox (same idiom as the Audit page), seeded from the canonical `docs/CREDENTIALS.md` keys — `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `DEEPSEEK_API_KEY`, `GEMINI_API_KEY`, `OLLAMA_API_KEY`, `BRAVE_API_KEY` — while still allowing any custom name (e.g. `$cred:` labels). Hardcoded WebUI list (house style; no new endpoint).

## Tested
- `go build`/`go vet` clean; `go test ./internal/api/http/...` clean — routing tests rewritten/extended: a tenant gets availability + **empty `last_error`**; a restricted tenant is filtered to keyable + availability; an admin still gets `last_error`.
- `web` typecheck + build clean.
- **Playwright render-smoke** (screenshots attached in chat): routing view renders the provider chips + per-candidate availability dots + legend (0 console errors); the credential name field is a combobox exposing all 6 known keys, free-form preserved (0 console errors).

## Note
The `last_error` redaction is a deliberate security default — tenants see *which* providers are up/down but not the raw error text. Easy to widen to full parity if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)