### PR TITLE
feat(skills)!: /-grouping, on-demand discovery, per-agent access control (RFC BA)

### DIFF
--- a/REVISIONS.md
+++ b/REVISIONS.md
@@ -8,6 +8,40 @@ For pre-v0.4 history (single-tool runtime, library milestone, security patch), s
 
 ---
 
+## Unreleased
+
+**⚠️ Breaking — RFC BA: skills go on-demand + one `skills:` pattern allowlist.**
+The skills model changed: skill bodies are **no longer bundled** into the system
+prompt at config-load. Instead every agent that may use a skill gets the `Skill`
+tool auto-added (mirror of the `Context` auto-add) and loads bodies **on demand**
+(`Skill(op=list)` to discover, `Skill(name=…)` to load). The `Skill` tool is now
+op-discriminated (`{op?: invoke|list, name?, pattern?}`; a bare `{name}` still
+invokes).
+
+- **`skills:` is now a pattern ALLOWLIST**, not an exact-name bundle list. It
+  governs listing, use (invoke), AND authoring (SkillDef create/fork) uniformly.
+  Entries are `/`-globs with an optional `+`/`-` sign (`doc/*`, `-doc/secret`,
+  `-*`). Empty/absent = allow all; `-*` = allow nothing. `skills: [a, b]` that
+  used to bundle `a` and `b` now *limits* the agent to authoring/using `a` and
+  `b` and loads their bodies on demand.
+- **Skill names may be `/`-grouped** (`doc/redactor`) — nested `SkillsRoot`
+  dirs, inline `skills:` keys, and SkillDef create/fork targets all share the
+  grammar (segments of `[A-Za-z0-9_-]+`, no `.`/`..`).
+- **`skill_def_scopes` is REMOVED.** A config with `skill_def_scopes:` on any
+  agent now **fails to load** with a migration error — re-express the intent as
+  `skills:` patterns (`skills: [doc/*]` to author only `doc/*`, `skills: [-*]` to
+  forbid all authoring). Pre-production clean cutover, no deprecation shim
+  (mirrors the recent `allowed_tools`→`tools` rename).
+- **`skills:` leaves `content_sha256`.** It is now authority (an ACL), not
+  authored content — like the `*_def_scopes` gates. Existing agents that declared
+  `skills:` get a new content hash on next boot (re-hashed; pre-production).
+
+`Context op=permissions` now reports the effective `skills` allowlist (was
+`skill_def_scopes`). The `skills:` wire shape (`string[]` in the AgentDef
+overlay) is unchanged, so the TS/Python adapters need no bump; only the field's
+*meaning* changed. The bundled `document-agent` is unaffected in behavior — its
+four skills are the on-demand catalog and it gets the auto-added `Skill` tool.
+
 ## What's in v1.13.1
 
 **🩹 WebUI patch — `allowed_tools` residual cleanup + tenant routing/credentials

--- a/cmd/loomcycle/embedded/bundles/document-agent.yaml
+++ b/cmd/loomcycle/embedded/bundles/document-agent.yaml
@@ -5,6 +5,10 @@
 # bundle is just a config layer that defines an agent AND its skills — no skills
 # directory, no LOOMCYCLE_SKILLS_ROOT. Selected via `LOOMCYCLE_PRESETS=…,document-agent`.
 #
+# RFC BA: the agent's `skills:` list is a pattern allowlist (it may list/use/author
+# exactly these four). Skills load ON DEMAND via the `Skill` tool (auto-added) — the
+# bodies below are the catalog, not baked into the system prompt.
+#
 # This bundle carries NO provider matrix: the agent declares `tier: middle`, so a
 # `middle` tier must come from another layer (select `base` alongside it, or your
 # own config). It also needs SQL Memory (LOOMCYCLE_SQLMEM_ENABLED=1) — Documents

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -872,9 +872,10 @@ func main() {
 	allTools = append(allTools, agentDefTool)
 
 	// SkillDef tool (v0.8.22). Mirror of AgentDef for runtime skill
-	// mutation. Same default-deny gate (skill_def_scopes yaml). Set
-	// is shared with the SkillTool above so static-name guard +
-	// fork-bootstrap see the same static skills.
+	// mutation. Authoring is gated by the agent's RFC BA `skills:`
+	// pattern allowlist (via SkillPolicy). Set is shared with the
+	// SkillTool above so static-name guard + fork-bootstrap see the
+	// same static skills.
 	skillDefTool := &builtin.SkillDef{
 		Set:                 skillSet,
 		MaxBodyBytes:        cfg.Env.SkillDefMaxBodyBytes,

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -719,6 +719,15 @@ func main() {
 	if cfg.Env.SkillsRoot != "" {
 		log.Printf("skills: loaded %d from %s", len(skillSet.Names()), cfg.Env.SkillsRoot)
 	}
+	// RFC BA: fold inline `skills:` yaml defs into the runtime set so they are
+	// invokable + listable on demand via the Skill tool. Before RFC BA the
+	// config-load resolveSkills bundled their bodies into prompts (and merged
+	// them into a throwaway set); now that bundling is gone, they must live in
+	// the runtime set the Skill/SkillDef tools + Library share. Inline wins on
+	// a name collision with a SkillsRoot skill (config is authoritative).
+	for name, spec := range cfg.Skills {
+		skillSet.Add(&skills.Skill{Name: name, Description: spec.Description, Tools: spec.Tools, Body: spec.Body})
+	}
 	// v0.8.8 help topics — bundled defaults overlaid with operator
 	// .md files from LOOMCYCLE_HELP_ROOT. Always non-nil after this
 	// load; bundled-only deployments get the default topic set.

--- a/cmd/loomcycle/presets_integration_test.go
+++ b/cmd/loomcycle/presets_integration_test.go
@@ -24,9 +24,11 @@ func layersFor(t *testing.T, names ...string) []config.Layer {
 }
 
 // TestEmbedded_DocumentAgentResolvesWithInlineSkills is the RFC AQ §7 Phase-1
-// headline: selecting `base,document-agent` registers doc-manager AND bakes its
-// four inline skills into the system prompt with NO LOOMCYCLE_SKILLS_ROOT set —
-// the bundle is a pure config layer.
+// headline, updated for RFC BA on-demand skills: selecting `base,document-agent`
+// registers doc-manager AND carries its four inline skills in cfg.Skills (the
+// on-demand catalog) with NO LOOMCYCLE_SKILLS_ROOT — the bundle is a pure config
+// layer. The bodies are loaded via the Skill tool at runtime, NOT baked into the
+// prompt; the agent gets the auto-added Skill tool.
 func TestEmbedded_DocumentAgentResolvesWithInlineSkills(t *testing.T) {
 	t.Setenv("LOOMCYCLE_SKILLS_ROOT", "") // no skills directory — inline only
 
@@ -38,11 +40,27 @@ func TestEmbedded_DocumentAgentResolvesWithInlineSkills(t *testing.T) {
 	if !ok {
 		t.Fatalf("doc-manager not registered (agents: %v)", agentNames(cfg))
 	}
-	// All four skill bodies must be baked into the prompt.
-	for _, marker := range []string{"Semantic chunking", "Edge linking", "Restructuring", "Markdown import"} {
-		if !strings.Contains(dm.SystemPrompt, marker) {
-			t.Errorf("doc-manager system prompt missing skill content %q", marker)
+	// All four skills are registered in the on-demand catalog (cfg.Skills),
+	// with their bodies intact for the Skill tool to load.
+	for _, name := range []string{"semantic-chunking", "edge-linking", "restructuring", "md-import"} {
+		sk, ok := cfg.Skills[name]
+		if !ok {
+			t.Errorf("inline skill %q missing from cfg.Skills", name)
+			continue
 		}
+		if strings.TrimSpace(sk.Body) == "" {
+			t.Errorf("inline skill %q has an empty body", name)
+		}
+	}
+	// On-demand: the skill bodies are NOT baked into the agent prompt.
+	for _, marker := range []string{"Semantic chunking", "Edge linking", "Markdown import"} {
+		if strings.Contains(dm.SystemPrompt, marker) {
+			t.Errorf("skill body %q must not be baked into the prompt (RFC BA on-demand)", marker)
+		}
+	}
+	// The agent's whitelist gets the auto-added Skill tool for on-demand loading.
+	if !hasToolPreset(dm.Tools, "Skill") {
+		t.Errorf("doc-manager should get the auto-added Skill tool; tools=%v", dm.Tools)
 	}
 	// base supplied the middle tier the agent declares.
 	if _, ok := cfg.Tiers["middle"]; !ok {
@@ -51,8 +69,8 @@ func TestEmbedded_DocumentAgentResolvesWithInlineSkills(t *testing.T) {
 }
 
 // TestEmbedded_OperatorOverridesBundleSkill: an operator's later inline skill of
-// the same name wins (RFC AN merge-by-key), so the override is just re-declaring
-// the key — no skills root, no fork.
+// the same name wins (RFC AN merge-by-key) in the on-demand catalog cfg.Skills,
+// so the override is just re-declaring the key — no skills root, no fork.
 func TestEmbedded_OperatorOverridesBundleSkill(t *testing.T) {
 	t.Setenv("LOOMCYCLE_SKILLS_ROOT", "")
 
@@ -68,13 +86,26 @@ skills:
 	if err != nil {
 		t.Fatalf("LoadLayers with override: %v", err)
 	}
-	dm := cfg.Agents["doc-manager"]
-	if !strings.Contains(dm.SystemPrompt, "OVERRIDDEN RESTRUCTURING BODY") {
-		t.Errorf("operator override of the restructuring skill did not win")
+	sk, ok := cfg.Skills["restructuring"]
+	if !ok {
+		t.Fatalf("restructuring skill missing from cfg.Skills")
 	}
-	if strings.Contains(dm.SystemPrompt, "deliberately has no drag-edit") {
-		t.Errorf("the original restructuring body should be gone after override")
+	if !strings.Contains(sk.Body, "OVERRIDDEN RESTRUCTURING BODY") {
+		t.Errorf("operator override of the restructuring skill did not win; body=%q", sk.Body)
 	}
+	if strings.Contains(sk.Body, "deliberately has no drag-edit") {
+		t.Errorf("the original restructuring body should be gone after override; body=%q", sk.Body)
+	}
+}
+
+// hasToolPreset reports whether tools contains name.
+func hasToolPreset(tools []string, name string) bool {
+	for _, t := range tools {
+		if t == name {
+			return true
+		}
+	}
+	return false
 }
 
 // TestEmbedded_BundleAloneDegradesGracefully: document-agent WITHOUT base still

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -308,15 +308,15 @@ Recursion is depth-capped at 16 by default (`MaxAgentDepth` on the `AgentTool`).
 
 References: `internal/tools/builtin/agent.go` (the tool), `internal/api/http/server.go runSubAgent` (the runner), `internal/tools/tool.go` (`HostPolicy` / `RunIdentity` ctx helpers).
 
-## Skills (Approach A + SkillDef substrate)
+## Skills (on-demand, RFC BA)
 
-`internal/skills/` — at config-load, every directory under `LOOMCYCLE_SKILLS_ROOT` named `<skill>/SKILL.md` is read and parsed. Agents that list a skill in their YAML `skills: [voice-applier, position-relevance-filtering]` block get the skill's body **concatenated into their system prompt** — cacheable, baked into the agent's runtime view of the world. The skill's `allowed-tools` declared in its frontmatter must be a subset of the agent's `tools`; mismatches are rejected at config-load.
+`internal/skills/` — at boot, every directory under `LOOMCYCLE_SKILLS_ROOT` named `<skill>/SKILL.md` (including nested `/`-grouped dirs like `doc/redactor/SKILL.md`) is read and parsed into a shared registry, joined by inline per-agent `skills:` YAML and the `skill_defs` substrate. Skills are loaded **on demand** via the `Skill` tool — NOT concatenated into the system prompt (RFC BA retired the config-load bundling of "Approach A").
 
-This is "Approach A" in the skills design — static bundling at config-load.
+An agent's `skills:` field is a **pattern allowlist** (`internal/skillmatch/`), not a bundle list: an ordered set of `/`-globs with an optional `+`/`-` sign that governs which skills the agent may **list, use, and author** (empty = allow all, `-*` = deny all). Every agent that may use a skill gets the `Skill` tool auto-added; a whitelist also injects a short per-run "skills available" note. The `Skill` tool enforces the allowlist on `op=list`/`op=invoke`, plus the invariant that a skill's `allowed-tools`/`tools` must be a subset of the invoking agent's `tools`.
 
-**SkillDef substrate (v0.8.22)** adds the dynamic counterpart: versioned skill definitions stored in `skill_defs` with active-pointer overlay (parallel to AgentDef). The model can author / fork / promote skills via the `SkillDef` built-in (`set`, `get`, `list`, `activate`, `fork`); the resolver overlay (`server.go resolveSkillBodiesForRun`) prefers an active DB row over the on-disk SKILL.md when one exists. The v0.9.1 `system_prompt` event carries a `skill_def_ids` map (skill name → resolved def_id) so operators can audit exactly which version of each skill the agent received.
+**SkillDef substrate (v0.8.22)** is the runtime-mutable counterpart: versioned skill definitions stored in `skill_defs` with an active-pointer overlay (parallel to AgentDef). The model authors / forks / promotes skills via the `SkillDef` built-in, gated by the same `skills:` allowlist; the `Skill` tool prefers an active DB row over the on-disk SKILL.md when one exists.
 
-References: `internal/skills/` (loader), `internal/tools/builtin/skill.go` (static-bundle dispatcher), `internal/tools/builtin/skilldef.go` (5-op dynamic tool), `internal/api/http/server.go resolveSkillBodiesForRun` (overlay resolution).
+References: `internal/skills/` (loader), `internal/skillmatch/` (allowlist + name/pattern grammar), `internal/tools/builtin/skill.go` (list/invoke), `internal/tools/builtin/skilldef.go` (authoring), `internal/config/config.go addSkillToolDefaults` (auto-add).
 
 ## LocalAPI gateway (scaffolded; not the v0.4 integration vehicle)
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -619,7 +619,7 @@ Parsed at `internal/agents/loader.go:199` (the `frontmatter` struct):
 | **Tool fields** | | | |
 | `tools` | `[]string` | Tool allowlist (loomcycle form) | Empty list = zero tools. Always wins over `tools:`. |
 | `tools` | string OR `[]string` | Claude-Code-compatible form | Comma-string or list. Tolerated for Claude-Code compatibility; `tools` takes precedence when both are set. |
-| `skills` | `[]string` | Skill bundle | Skills bundle a system-prompt fragment + tool allowlist contribution; skill's tools must be a subset of the agent's `tools`. |
+| `skills` | `[]string` | Skill access allowlist (RFC BA) | Pattern allowlist governing which skills the agent may list / use / author (on-demand via the `Skill` tool — NOT bundled into the prompt). Entries are `/`-globs with an optional `+`/`-` sign: `doc/*` allow, `-doc/secret` deny, `-*` deny all. Empty/absent = allow all. The `Skill` tool is auto-added unless `skills: [-*]`. |
 | **System prompt** | | | |
 | (body) | string | Inline system prompt | Everything after the closing `---` line. |
 | `system_prompt_file` | string | External prompt path | Mutually exclusive with body. Useful for sharing prompts across agents. |
@@ -688,17 +688,17 @@ No `tier:` — uses pin path. `model: sonnet` expands via `models:` alias to `(a
 skills:
   voice-applier:
     description: Apply the house voice to drafted copy.   # informational
-    tools: [Read]     # must be a SUBSET of the bundling agent's tools
+    tools: [Read]     # must be a SUBSET of the invoking agent's tools (enforced at invoke)
     body: |
       When rewriting, prefer active voice and short sentences …
 agents:
   cv-rewriter:
-    tools: [Read, Skill]
-    skills: [voice-applier]   # references the inline skill by name (same field as before)
+    tools: [Read]              # `Skill` is auto-added (RFC BA)
+    skills: [voice-applier]    # allowlist: this agent may list/use/author `voice-applier`
     model: sonnet
 ```
 
-An agent's `skills: [name]` resolves against the inline `skills:` map **first**, then `LOOMCYCLE_SKILLS_ROOT` (inline wins on a name collision); either source alone is fine — **no skills root is required** when every referenced skill is defined inline. Inline skills **merge by key across config layers** (§9e), exactly like `agents:` — so a bundled config layer can ship an agent *and* its skills together, and a later layer can override a skill by re-declaring its key. The same security invariant holds: a skill's `tools` must be ⊆ the bundling agent's, or config-load fails. (`SKILL.md` frontmatter uses the hyphenated `allowed-tools`; the inline map uses `tools` to match the rest of the loomcycle YAML.)
+Inline skills join the on-demand catalog alongside `LOOMCYCLE_SKILLS_ROOT` (inline wins on a name collision); either source alone is fine — **no skills root is required** when every skill is defined inline. Inline skills **merge by key across config layers** (§9e), exactly like `agents:` — so a bundled config layer can ship an agent *and* its skills together, and a later layer can override a skill by re-declaring its key. The agent's `skills:` field is a **pattern allowlist** (RFC BA), not a bundle list: it governs which skills the agent may list / use / author. Bodies are loaded on demand via the `Skill` tool, never baked into the prompt. The security invariant holds at **invoke time**: a skill's `tools` must be ⊆ the invoking agent's, or the load is refused. (`SKILL.md` frontmatter uses the hyphenated `allowed-tools`; the inline map uses `tools` to match the rest of the loomcycle YAML.)
 
 **Multi-tool research agent**:
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -48,8 +48,8 @@ Each built-in is registered into the dispatcher at process startup but **refuses
 | `Bash`      | `LOOMCYCLE_BASH_ENABLED=1` + a bound **rw** volume    |
 | `Bashbox`   | `LOOMCYCLE_BASHBOX_ENABLED=1` + a bound volume (**ro or rw** — a true in-process sandbox) |
 | `Agent`     | Always registered (server-internal); per-agent `tools` controls who can spawn. |
-| `Skill`     | `LOOMCYCLE_SKILLS_ROOT=/path/to/skills` (or skills inlined per-agent via YAML `skills:` list). v0.8.22+ also consults the `skill_defs` store for DB-active overrides. |
-| `SkillDef`  | Always registered (v0.8.22). Per-agent `skill_def_scopes:` YAML gate (default-deny); no extra env var. Storage shared with the rest of the substrate. |
+| `Skill`     | `LOOMCYCLE_SKILLS_ROOT=/path/to/skills` (or skills inlined per-agent via YAML `skills:` map, or the `skill_defs` substrate). Auto-added to every agent that may use a skill (RFC BA); loads bodies on demand. Gated by the agent's `skills:` pattern allowlist. |
+| `SkillDef`  | Always registered (v0.8.22). Authoring gated by the agent's `skills:` pattern allowlist (RFC BA — empty = allow all, `-*` = deny all); no extra env var. Storage shared with the rest of the substrate. |
 | `VolumeDef` | Always registered (RFC AH Phase 2a/2b). Per-agent `volume_def_scopes:` YAML gate (default-deny) for create/delete/purge; get/list are tenant-scoped reads. `create {ephemeral:true}` provisions a run-scoped volume auto-purged at top-level-run completion. Requires a static volume marked `dynamic_root: true`. Storage shared with the rest of the substrate. |
 | `Memory`    | Storage backend (SQLite default; Postgres opt-in) + per-agent `memory_scopes:` allowlist. |
 | `Document`  | Always registered (RFC AK Phase 1). Per-agent `tools:[Document]`. **Requires SQL Memory** (`LOOMCYCLE_SQLMEM_ENABLED=1`). Chunked-graph documents: chunk **bodies+fields** in Memory (keyed by UUID), **structure** (hierarchy/type/status/edges/type-schemas) in SQL Memory (4 tables). 13 ops (document/chunk lifecycle, edges, `query_chunks` with structured filters + `under_path` Path join + a validator-gated `sql:` escape hatch, type defs). Optimistic `revision` on update; delete cascades descendants + their Memory bodies. Names documents in the Path tree (`create_document path:`). Scope **agent/user** (tenant deferred); tenant-isolated via the SQL Memory scope key. |
@@ -264,28 +264,53 @@ The `Agent` built-in lets a parent agent spawn a child run by name:
 
 References: `internal/tools/builtin/agent.go`, `internal/api/http/server.go runSubAgent`, `internal/api/http/agent_subagent_test.go`.
 
-## The `Skill` tool — Approach A (static bundling, shipped) and Approach B (dynamic, scaffolded)
+## The `Skill` tool — on-demand skills with a per-agent allowlist (RFC BA)
 
-**Approach A — static bundling (active in v0.4.0).**
+Skills are loaded **on demand** via the `Skill` tool, not bundled into the
+system prompt. Skill sources are the filesystem (`LOOMCYCLE_SKILLS_ROOT`, with
+nested `/`-grouped dirs like `<root>/doc/redactor/SKILL.md`), inline per-agent
+YAML (`skills:` map), and the runtime `skill_defs` substrate — assembled into one
+catalog the tool serves.
 
-At config-load, every directory under `LOOMCYCLE_SKILLS_ROOT` named `<skill>/SKILL.md` is read. Agents that list a skill in their YAML get the skill's body **concatenated into their system prompt** as a cacheable trusted-text block:
+**`skills:` is a pattern ALLOWLIST**, not a bundle list. It governs which skills
+the agent may **list, use (invoke), and author (SkillDef)** — one policy for all
+three. Entry forms: `pat`/`+pat` (allow), `-pat` (deny), where `pat` is a
+`/`-segmented glob (`doc/*`, `marketing/**`, exact `seo`). Evaluation: a name is
+allowed iff (there is a positive entry it matches, or there are none) AND no
+negative matches. **Empty/absent `skills:` = allow all**; `-*` = allow nothing.
 
 ```yaml
 agents:
-  cv-adapter:
+  doc-manager:
     model: smart
-    tools: [Read, Write]
-    skills: [voice-applier, cv-voice-applier]   # bodies merged into system prompt at config-load
-    system_prompt_file: prompts/cv-adapter.md
+    tools: [Document]          # `Skill` is auto-added unless skills: [-*]
+    skills: [doc/*, -doc/secret]   # may list/use/author doc/* except doc/secret
 ```
 
-Constraint: each skill's frontmatter declares its own `allowed-tools`; this list must be a **subset** of the agent's `tools`. Mismatches are rejected at config-load with a clear error. This prevents skills from advertising tools the agent can't actually invoke.
+Every agent that may use any skill gets the `Skill` tool auto-added (mirror of
+the `Context` auto-add); only `skills: [-*]` skips it. When `skills:` is a
+whitelist, a short per-run note names the permitted patterns.
 
-**Approach B — dynamic Skill tool (placeholder).**
+Wire shape (op-discriminated; `op` defaults to `invoke` for back-compat):
 
-The `Skill` built-in is registered when `LOOMCYCLE_SKILLS_ROOT` is set; the model can call it with `{"name": "voice-applier"}` to load a skill mid-conversation. In v0.4.0 the tool returns "unknown skill" — full Approach B implementation is v1.0 work. The hook is in place so prompts that reference the dynamic Skill tool can be authored today; they degrade gracefully (the tool reports the skill isn't available, the model continues without).
+```jsonc
+{
+  "op":      "invoke" | "list",   // default invoke
+  "name":    "doc/redactor",       // op=invoke: the skill to load
+  "pattern": "doc/*"               // op=list: optional /-glob filter
+}
+```
 
-References: `internal/skills/`, `internal/tools/builtin/skill.go`.
+- `op=list` → the catalog **visible to this agent** = assembled catalog ∩ the
+  agent's `skills:` allowlist ∩ optional `pattern`, as `[{name, description}]`.
+- `op=invoke` (or a bare `{name}`) → the skill body as a tool_result, refused if
+  the name is outside the allowlist.
+
+Constraint (unchanged): a skill's own `allowed-tools`/`tools` must be a **subset**
+of the invoking agent's `tools`; a widening skill is refused at invoke time.
+
+References: `internal/skills/` (loader), `internal/skillmatch/` (allowlist +
+name/pattern validation), `internal/tools/builtin/skill.go`.
 
 ## The `Memory` tool — persistent agent-scoped storage (v0.8.0)
 
@@ -661,7 +686,7 @@ What works with what (Gemini added in v0.7.2 alongside the existing four backend
 | `WebSearch`                | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `Bash`                     | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `Agent` (sub-agents)       | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `Skill` (Approach A)       | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `Skill` (on-demand)        | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `LocalAPI` (OpenAPI gateway) | ⏳ | ⏳ | ⏳ | ⏳ | ⏳ | (scaffolded — for future OpenAPI-without-MCP-server consumers) |
 | MCP tools (stdio + HTTP)   | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Native cache_control       | ✅ | ❌ | ❌ | ❌ | ❌ |
@@ -887,7 +912,7 @@ agents:
       max_pending: 1         # per-run cap; 0 = use operator default
 ```
 
-Default-deny: missing the `interruption` block means every op returns `is_error` with a clear "not enabled" refusal. Same shape as `memory_scopes` / `agent_def_scopes` / `skill_def_scopes` / `evaluation_scopes`.
+Default-deny: missing the `interruption` block means every op returns `is_error` with a clear "not enabled" refusal. Same shape as `memory_scopes` / `agent_def_scopes` / `evaluation_scopes`.
 
 ### Operator config
 

--- a/internal/agents/loader.go
+++ b/internal/agents/loader.go
@@ -96,10 +96,8 @@ type Agent struct {
 	// Closed set: "self" / "descendants" / "named:<name>" / "any".
 	// Empty = default-deny.
 	AgentDefScopes []string
-	// SkillDefScopes is the v0.8.22 SkillDef-tool capability gate.
-	// Closed set: "descendants" / "named:<skill-name>" / "any".
-	// Empty = default-deny. No "self" (skills have no agent identity).
-	SkillDefScopes []string
+	// (The SkillDef def-scope gate was removed in RFC BA — skill authoring is
+	// governed by the unified `skills:` pattern allowlist, not a def-scope gate.)
 	// VolumeDefScopes is the RFC AH Phase 2a VolumeDef-tool capability
 	// gate. Closed set: "named:<volume-name>" / "any". Empty =
 	// default-deny. No "self" (volumes have no agent identity).
@@ -306,7 +304,6 @@ type frontmatter struct {
 	MemoryBackend         string                     `yaml:"memory_backend"`
 	Channels              AgentChannelACL            `yaml:"channels"`
 	AgentDefScopes        []string                   `yaml:"agent_def_scopes"`
-	SkillDefScopes        []string                   `yaml:"skill_def_scopes"`
 	VolumeDefScopes       []string                   `yaml:"volume_def_scopes"`
 	EvaluationScopes      []string                   `yaml:"evaluation_scopes"`
 	Interruption          AgentInterruptionACL       `yaml:"interruption"` // F14: round-trips like channels
@@ -375,7 +372,6 @@ func parseAgent(raw []byte) (*Agent, error) {
 	a.MemoryBackend = fm.MemoryBackend
 	a.Channels = fm.Channels
 	a.AgentDefScopes = fm.AgentDefScopes
-	a.SkillDefScopes = fm.SkillDefScopes
 	a.VolumeDefScopes = fm.VolumeDefScopes
 	a.EvaluationScopes = fm.EvaluationScopes
 	a.Interruption = fm.Interruption

--- a/internal/agents/sign.go
+++ b/internal/agents/sign.go
@@ -12,11 +12,18 @@
 //
 // What gets hashed (content-only — NOT metadata or identity):
 //
-//	name, description, system_prompt, tools, skills, model,
+//	name, description, system_prompt, tools, model,
 //	provider, tier, effort, sampling, max_tokens, max_iterations,
 //	max_concurrent_children, code_body, providers, models, memory_scopes,
 //	memory_quota_bytes, memory_backend, channels, evaluation_scopes,
 //	interruption
+//
+// RFC BA — `skills:` is EXCLUDED. It was repurposed from an exact-name
+// bundle list (content) into a per-agent pattern ALLOWLIST (authority: an
+// ACL governing which skills the agent may list/use/author). Authority is
+// not content — hashing it would make two agents that differ only in their
+// skill-access policy mint distinct content hashes, and it does not describe
+// the agent's authored behavior. This matches the *_def_scopes exclusion.
 //
 // Explicitly excluded (would defeat the "did the content change?"
 // question): def_id, version, parent_def_id, created_at,
@@ -47,8 +54,8 @@
 //     (since Go 1.12) — these two properties give us a deterministic
 //     byte sequence without an external JCS library.
 //   - Empty slices and maps normalise to nil before encoding so the
-//     `omitempty` tags collapse them out. An agent with `skills: []`
-//     hashes identically to one with no `skills` key at all.
+//     `omitempty` tags collapse them out. An agent with `tools: []`
+//     hashes identically to one with no `tools` key at all.
 //   - system_prompt is trimmed of trailing whitespace; CR/LF line
 //     endings normalise to LF. (Editor drift is the biggest unforced-
 //     error source — operators who edit MDs in Windows-line-ending
@@ -129,9 +136,11 @@ type AgentContent struct {
 	// content_sha256. Pointer + omitempty so a no-sampling agent omits the key
 	// and hashes byte-identical to pre-feature rows; normalize() collapses an
 	// all-nil pointer back to nil. Tag "sampling" sorts between providers and
-	// skills.
+	// system_prompt.
+	//
+	// (RFC BA: `skills:` is deliberately NOT a field here — it is the agent's
+	// pattern-allowlist ACL, excluded from the hash. See the package doc.)
 	Sampling     *Sampling `json:"sampling,omitempty"`
-	Skills       []string  `json:"skills,omitempty"`
 	SystemPrompt string    `json:"system_prompt,omitempty"`
 	Tier         string    `json:"tier,omitempty"`
 	// Tools is the agent's tool allowlist (the capability ceiling). Tag
@@ -183,9 +192,6 @@ func normalize(c *AgentContent) {
 	}
 	if len(c.Providers) == 0 {
 		c.Providers = nil
-	}
-	if len(c.Skills) == 0 {
-		c.Skills = nil
 	}
 	if len(c.Models) == 0 {
 		c.Models = nil
@@ -265,7 +271,6 @@ func FromYAMLAgent(a *Agent) AgentContent {
 		MaxIterations:         a.MaxIterations,
 		MaxConcurrentChildren: a.MaxConcurrentChildren,
 		Tools:                 a.Tools,
-		Skills:                a.Skills,
 		SystemPrompt:          a.SystemPrompt,
 		Providers:             a.Providers,
 		Models:                a.Models,

--- a/internal/agents/sign.go
+++ b/internal/agents/sign.go
@@ -26,7 +26,7 @@
 // Also excluded — the *tool-capability* ACLs that gate which substrate
 // tools an agent may CALL but are NOT part of its authored definition:
 //
-//	agent_def_scopes, skill_def_scopes
+//	agent_def_scopes (and the other *_def_scopes gates)
 //
 // These are operator-yaml-only declarations resolved at boot; the in-DB
 // agent_defs row never stores them, so hashing them would make a
@@ -244,8 +244,8 @@ func normalizeText(s string) string {
 // load + CLI `hash agent` subcommand path). F14: channels /
 // evaluation_scopes / interruption now DO round-trip through `AgentDef
 // set` (they live in mergedDef → the agent_defs.definition JSONB), so they
-// are part of the hash on both paths. The *Scopes ACLs
-// (agent_def_scopes / skill_def_scopes) and Path still do not round-trip
+// are part of the hash on both paths. The *_def_scopes ACLs
+// (agent_def_scopes, …) and Path still do not round-trip
 // and stay excluded — see the package doc. The channels/interruption
 // pointers are nil when empty so a no-ACL agent hashes exactly as before
 // (normalize() also collapses an all-empty pointer defensively).

--- a/internal/agents/sign_test.go
+++ b/internal/agents/sign_test.go
@@ -41,7 +41,6 @@ func TestSign_DeterministicAcrossCalls(t *testing.T) {
 		Name:         "researcher",
 		SystemPrompt: "be thorough",
 		Tools:        []string{"WebFetch", "Read"},
-		Skills:       []string{"summariser"},
 		MaxTokens:    8192,
 	}
 	h1 := Sign(c)
@@ -264,6 +263,32 @@ func TestFromYAMLAgent_ToolCapabilityScopesStillIgnored(t *testing.T) {
 	})
 	if Sign(bare) != Sign(withScopes) {
 		t.Error("agent_def_scopes leaked into hash — yaml vs substrate would falsely report drift")
+	}
+}
+
+// RFC BA: `skills:` is a pattern ALLOWLIST (authority, not content) and is
+// EXCLUDED from the content hash — two agents differing ONLY in their skills:
+// allowlist must hash identically. Reverting the AgentContent.Skills removal
+// (re-adding it to the hash basis + FromYAMLAgent) breaks this.
+func TestFromYAMLAgent_SkillsAllowlistExcludedFromHash(t *testing.T) {
+	bare := FromYAMLAgent(&Agent{Name: "x", SystemPrompt: "do the thing"})
+	withSkills := FromYAMLAgent(&Agent{
+		Name:         "x",
+		SystemPrompt: "do the thing",
+		Skills:       []string{"doc/*", "-secret/*"},
+	})
+	if Sign(bare) != Sign(withSkills) {
+		t.Error("skills: allowlist leaked into the content hash — it is authority (an ACL), not content")
+	}
+	// And a DIFFERENT allowlist must also hash identically (the field never
+	// contributes, regardless of value).
+	other := FromYAMLAgent(&Agent{
+		Name:         "x",
+		SystemPrompt: "do the thing",
+		Skills:       []string{"-*"},
+	})
+	if Sign(bare) != Sign(other) {
+		t.Error("a different skills: allowlist changed the hash — skills must not be hashed at all")
 	}
 }
 

--- a/internal/agents/sign_test.go
+++ b/internal/agents/sign_test.go
@@ -253,18 +253,17 @@ func TestFromYAMLAgent_EvaluationScopesAndInterruptionAffectHash(t *testing.T) {
 }
 
 func TestFromYAMLAgent_ToolCapabilityScopesStillIgnored(t *testing.T) {
-	// agent_def_scopes / skill_def_scopes gate which substrate tools the
-	// agent may CALL; they are NOT part of its authored definition and do
+	// The *_def_scopes gates (agent_def_scopes, …) govern which substrate tools
+	// the agent may CALL; they are NOT part of its authored definition and do
 	// NOT round-trip through AgentDef set, so they MUST stay out of the hash
 	// (else a yaml-loaded agent and its substrate copy diverge).
 	bare := FromYAMLAgent(&Agent{Name: "x"})
 	withScopes := FromYAMLAgent(&Agent{
 		Name:           "x",
 		AgentDefScopes: []string{"self"},
-		SkillDefScopes: []string{"descendants"},
 	})
 	if Sign(bare) != Sign(withScopes) {
-		t.Error("agent_def_scopes/skill_def_scopes leaked into hash — yaml vs substrate would falsely report drift")
+		t.Error("agent_def_scopes leaked into hash — yaml vs substrate would falsely report drift")
 	}
 }
 

--- a/internal/api/grpc/substrate.go
+++ b/internal/api/grpc/substrate.go
@@ -65,9 +65,7 @@ func substrateGRPCCtx(ctx context.Context) context.Context {
 		Scopes:   []string{"any"},
 		SelfName: grpcSubstrateAdminAgentName,
 	})
-	ctx = tools.WithSkillDefPolicy(ctx, tools.SkillDefPolicyValue{
-		Scopes: []string{"any"},
-	})
+	ctx = tools.WithSkillPolicy(ctx, tools.SkillPolicyValue{}) // RFC BA: nil patterns = allow all skills
 	ctx = tools.WithScheduleDefPolicy(ctx, tools.ScheduleDefPolicyValue{
 		Scopes:   []string{"any"},
 		SelfName: grpcSubstrateAdminAgentName,

--- a/internal/api/http/resume.go
+++ b/internal/api/http/resume.go
@@ -292,7 +292,7 @@ func (s *Server) resumePausedRun(ctx context.Context, run store.Run) error {
 	loopCtx = tools.WithEventEmitter(loopCtx, emit)
 	adPolicy, evPolicy := s.substratePoliciesForAgent(agentDef, run.Agent)
 	loopCtx = tools.WithAgentDefPolicy(loopCtx, adPolicy)
-	loopCtx = tools.WithSkillDefPolicy(loopCtx, s.skillDefPolicyForAgent(agentDef))
+	loopCtx = tools.WithSkillPolicy(loopCtx, s.skillPolicyForAgent(agentDef))
 	loopCtx = tools.WithVolumeDefPolicy(loopCtx, s.volumeDefPolicyForAgent(agentDef))
 	loopCtx = tools.WithEvaluationPolicy(loopCtx, evPolicy)
 	loopCtx = tools.WithHistoryPolicy(loopCtx, s.historyPolicyForAgent(agentDef))

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1266,10 +1266,10 @@ func (s *Server) substratePoliciesForAgent(agentDef config.AgentDef, selfName st
 		}
 }
 
-// skillDefPolicyForAgent returns the v0.8.22 SkillDef policy for
+// skillPolicyForAgent returns the v0.8.22 SkillDef policy for
 // one agent. Default-deny: empty SkillDefScopes → no SkillDef ops.
-func (s *Server) skillDefPolicyForAgent(agentDef config.AgentDef) tools.SkillDefPolicyValue {
-	return tools.SkillDefPolicyValue{Scopes: agentDef.SkillDefScopes}
+func (s *Server) skillPolicyForAgent(agentDef config.AgentDef) tools.SkillPolicyValue {
+	return tools.SkillPolicyValue{Patterns: agentDef.Skills}
 }
 
 // volumeDefPolicyForAgent returns the RFC AH Phase 2a VolumeDef policy
@@ -2157,7 +2157,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	loopCtx = tools.WithEventEmitter(loopCtx, emit)
 	adPolicy, evPolicy := s.substratePoliciesForAgent(agentDef, effectiveAgentName)
 	loopCtx = tools.WithAgentDefPolicy(loopCtx, adPolicy)
-	loopCtx = tools.WithSkillDefPolicy(loopCtx, s.skillDefPolicyForAgent(agentDef))
+	loopCtx = tools.WithSkillPolicy(loopCtx, s.skillPolicyForAgent(agentDef))
 	loopCtx = tools.WithVolumeDefPolicy(loopCtx, s.volumeDefPolicyForAgent(agentDef))
 	loopCtx = tools.WithEvaluationPolicy(loopCtx, evPolicy)
 	loopCtx = tools.WithHistoryPolicy(loopCtx, s.historyPolicyForAgent(agentDef))
@@ -3594,7 +3594,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	loopCtx = tools.WithEventEmitter(loopCtx, emit)
 	adPolicy, evPolicy := s.substratePoliciesForAgent(agentDef, req.Agent)
 	loopCtx = tools.WithAgentDefPolicy(loopCtx, adPolicy)
-	loopCtx = tools.WithSkillDefPolicy(loopCtx, s.skillDefPolicyForAgent(agentDef))
+	loopCtx = tools.WithSkillPolicy(loopCtx, s.skillPolicyForAgent(agentDef))
 	loopCtx = tools.WithVolumeDefPolicy(loopCtx, s.volumeDefPolicyForAgent(agentDef))
 	loopCtx = tools.WithEvaluationPolicy(loopCtx, evPolicy)
 	loopCtx = tools.WithHistoryPolicy(loopCtx, s.historyPolicyForAgent(agentDef))
@@ -4131,7 +4131,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	loopCtx = tools.WithEventEmitter(loopCtx, emit)
 	adPolicy, evPolicy := s.substratePoliciesForAgent(agentDef, sess.Agent)
 	loopCtx = tools.WithAgentDefPolicy(loopCtx, adPolicy)
-	loopCtx = tools.WithSkillDefPolicy(loopCtx, s.skillDefPolicyForAgent(agentDef))
+	loopCtx = tools.WithSkillPolicy(loopCtx, s.skillPolicyForAgent(agentDef))
 	loopCtx = tools.WithVolumeDefPolicy(loopCtx, s.volumeDefPolicyForAgent(agentDef))
 	loopCtx = tools.WithEvaluationPolicy(loopCtx, evPolicy)
 	loopCtx = tools.WithHistoryPolicy(loopCtx, s.historyPolicyForAgent(agentDef))
@@ -5223,7 +5223,7 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 	// parent's.
 	subADPolicy, subEvPolicy := s.substratePoliciesForAgent(def, name)
 	subCtx = tools.WithAgentDefPolicy(subCtx, subADPolicy)
-	subCtx = tools.WithSkillDefPolicy(subCtx, s.skillDefPolicyForAgent(def))
+	subCtx = tools.WithSkillPolicy(subCtx, s.skillPolicyForAgent(def))
 	subCtx = tools.WithVolumeDefPolicy(subCtx, s.volumeDefPolicyForAgent(def))
 	subCtx = tools.WithEvaluationPolicy(subCtx, subEvPolicy)
 	subCtx = tools.WithHistoryPolicy(subCtx, s.historyPolicyForAgent(def))

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1266,8 +1266,10 @@ func (s *Server) substratePoliciesForAgent(agentDef config.AgentDef, selfName st
 		}
 }
 
-// skillPolicyForAgent returns the v0.8.22 SkillDef policy for
-// one agent. Default-deny: empty SkillDefScopes → no SkillDef ops.
+// skillPolicyForAgent returns the RFC BA skill-access policy for one agent —
+// its `skills:` pattern allowlist, which governs listing, use (Skill invoke),
+// and authoring (SkillDef create/fork). Empty patterns = allow all (the RFC BA
+// default); `-*` = deny all.
 func (s *Server) skillPolicyForAgent(agentDef config.AgentDef) tools.SkillPolicyValue {
 	return tools.SkillPolicyValue{Patterns: agentDef.Skills}
 }

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -38,6 +38,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/resolve"
 	"github.com/denn-gubsky/loomcycle/internal/runner"
 	"github.com/denn-gubsky/loomcycle/internal/runstate"
+	"github.com/denn-gubsky/loomcycle/internal/skillmatch"
 	"github.com/denn-gubsky/loomcycle/internal/skills"
 	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
 	"github.com/denn-gubsky/loomcycle/internal/steer"
@@ -1311,60 +1312,34 @@ type runPromptProvenance struct {
 // Second return value is the per-run provenance (skillName → active
 // SkillDef def_id) for callers emitting the v0.9.x `system_prompt`
 // transcript event. Empty when no DB-active rows were used.
-func (s *Server) resolveSkillBodiesForRun(ctx context.Context, tenantID string, agentDef config.AgentDef) (config.AgentDef, runPromptProvenance) {
+func (s *Server) resolveSkillBodiesForRun(_ context.Context, _ string, agentDef config.AgentDef) (config.AgentDef, runPromptProvenance) {
+	// RFC BA: skills are on-demand (loaded via the Skill tool), no longer
+	// baked into the prompt. This function no longer resolves/bakes bodies; it
+	// injects only the ephemeral (per-run, never persisted) "skills available"
+	// note when `skills:` is a WHITELIST (names specific permitted patterns).
+	// For the absent/empty (all) or blacklist cases no note is added — the
+	// Skill tool is in the agent's tool list, so the model discovers via
+	// Skill(op=list). The provenance return is retained for the system_prompt
+	// transcript event but is always empty now (no substrate body baking).
 	var prov runPromptProvenance
-	if len(agentDef.Skills) == 0 || s.store == nil {
+	if !skillmatch.HasPositive(agentDef.Skills) {
 		return agentDef, prov
 	}
-	// Resolve each skill via the canonical lookup chain (substrate →
-	// static). lookup.Skill returns Source="substrate" when a DB-active
-	// row resolved + Source="static" when falling back to the boot
-	// SkillsRoot bundle.
-	resolutions := make(map[string]lookup.SkillResolution, len(agentDef.Skills))
-	activeDefIDs := make(map[string]string, len(agentDef.Skills))
-	anySubstrate := false
-	// RFC N: tenant is an EXPLICIT argument, not ctx-derived — mirrors
-	// lookupAgent (FIX 2). At the run-creation entry sites the run's
-	// authoritative tenant (effectiveTenantID / sess.TenantID) is already
-	// computed BEFORE WithRunIdentity is stamped on ctx, so deriving it
-	// from tenantFromCtx(ctx) here would resolve skills at the WRONG tenant
-	// for non-HTTP-principal spawn surfaces (A2A / scheduler / webhook /
-	// MCP spawn_run / gRPC-legacy) while memory + sub-agents use the run's
-	// tenant. The sub-agent call (runSubAgent) passes tenantFromCtx(ctx)
-	// since the parent's RunIdentity already carries the tenant. A token
-	// only sees its own tenant's promotions + the shared base. "" = shared.
-	for _, skillName := range agentDef.Skills {
-		sr, ok := lookup.Skill(ctx, s.store, s.skillSet, tenantID, skillName)
-		if !ok {
+	allow := make([]string, 0, len(agentDef.Skills))
+	for _, e := range agentDef.Skills {
+		t := strings.TrimSpace(e)
+		if t == "" || strings.HasPrefix(t, "-") {
 			continue
 		}
-		resolutions[skillName] = sr
-		if sr.Source == "substrate" {
-			activeDefIDs[skillName] = sr.DefID
-			anySubstrate = true
-		}
+		allow = append(allow, strings.TrimPrefix(t, "+"))
 	}
-	// Fast path: when no substrate-active row contributed, the
-	// boot-time bake of agentDef.SystemPrompt already reflects the
-	// static skill bodies — return unchanged.
-	if !anySubstrate {
-		return agentDef, prov
-	}
-	prov.SkillDefIDs = activeDefIDs
-	// Slow path: rebuild SystemPrompt from base + per-skill body so
-	// substrate overrides land in place of the static bake.
+	note := "Skills available on demand (matching: " + strings.Join(allow, ", ") +
+		"). Use the `Skill` tool: `{\"op\":\"list\"}` to discover them (optional `pattern`), `{\"name\":\"<skill>\"}` to load one into context."
 	rebuilt := agentDef
-	rebuilt.SystemPrompt = agentDef.SystemPromptBase
-	for _, skillName := range agentDef.Skills {
-		sr, ok := resolutions[skillName]
-		if !ok || strings.TrimSpace(sr.Body) == "" {
-			continue
-		}
-		if rebuilt.SystemPrompt != "" {
-			rebuilt.SystemPrompt += "\n\n---\n\n"
-		}
-		rebuilt.SystemPrompt += sr.Body
+	if rebuilt.SystemPrompt != "" {
+		rebuilt.SystemPrompt += "\n\n---\n\n"
 	}
+	rebuilt.SystemPrompt += note
 	return rebuilt, prov
 }
 

--- a/internal/api/http/skilldef_resolution_test.go
+++ b/internal/api/http/skilldef_resolution_test.go
@@ -2,238 +2,75 @@ package http
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/config"
-	"github.com/denn-gubsky/loomcycle/internal/store"
-	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
 )
 
-// TestResolveSkillBodiesForRun_NoSkillsIsNoop verifies the helper's
-// fast path: an agent with no `skills` list returns unchanged.
-func TestResolveSkillBodiesForRun_NoSkillsIsNoop(t *testing.T) {
-	s, err := sqlite.Open(":memory:")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer s.Close()
+// RFC BA: resolveSkillBodiesForRun no longer bakes SkillDef bodies into the
+// prompt (skills are on-demand via the Skill tool). It now only injects the
+// ephemeral (per-run, never persisted) "skills available" NOTE, and ONLY when
+// `skills:` is a WHITELIST (names positive patterns). For no-skills, an
+// empty/absent allowlist, or a blacklist-only allowlist it is a no-op — the
+// Skill tool is in the agent's tool list and the model discovers via
+// Skill(op=list). These tests replace the old DB-active-body resolution suite.
 
-	srv := &Server{store: s}
-	def := config.AgentDef{SystemPrompt: "base prompt", SystemPromptBase: "base prompt"}
-	got, _ := srv.resolveSkillBodiesForRun(context.Background(), "", def)
+// No `skills:` list at all → no note, prompt unchanged.
+func TestResolveSkillBodiesForRun_NoSkillsIsNoop(t *testing.T) {
+	srv := &Server{}
+	def := config.AgentDef{SystemPrompt: "base prompt"}
+	got, prov := srv.resolveSkillBodiesForRun(context.Background(), "", def)
 	if got.SystemPrompt != "base prompt" {
 		t.Errorf("got %q, want unchanged base prompt", got.SystemPrompt)
 	}
+	if len(prov.SkillDefIDs) != 0 {
+		t.Errorf("provenance should be empty (no substrate baking); got %v", prov.SkillDefIDs)
+	}
 }
 
-// TestResolveSkillBodiesForRun_NoActiveRowsIsNoop verifies the
-// fast path: an agent with skills but no DB-active rows returns
-// the already-baked SystemPrompt unchanged.
-func TestResolveSkillBodiesForRun_NoActiveRowsIsNoop(t *testing.T) {
-	s, err := sqlite.Open(":memory:")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer s.Close()
-
-	srv := &Server{store: s}
-	const baked = "base prompt\n\n---\n\nSTATIC SKILL BODY"
-	def := config.AgentDef{
-		Skills:           []string{"karpathy-guidelines"},
-		SystemPrompt:     baked,
-		SystemPromptBase: "base prompt",
-	}
+// A blacklist-only allowlist (`skills: [-secret/*]`) has no positive pattern →
+// no note. The agent may use every non-secret skill on demand via the tool.
+func TestResolveSkillBodiesForRun_BlacklistIsNoop(t *testing.T) {
+	srv := &Server{}
+	def := config.AgentDef{Skills: []string{"-secret/*"}, SystemPrompt: "base prompt"}
 	got, _ := srv.resolveSkillBodiesForRun(context.Background(), "", def)
-	if got.SystemPrompt != baked {
-		t.Errorf("no DB-active row should leave baked prompt unchanged; got %q", got.SystemPrompt)
+	if got.SystemPrompt != "base prompt" {
+		t.Errorf("a blacklist should not inject a note; got %q", got.SystemPrompt)
 	}
 }
 
-// TestResolveSkillBodiesForRun_DBActiveOverrides verifies the slow
-// path: a DB-active SkillDef row rebuilds SystemPrompt from base +
-// the DB body.
-func TestResolveSkillBodiesForRun_DBActiveOverrides(t *testing.T) {
-	s, err := sqlite.Open(":memory:")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer s.Close()
-	ctx := context.Background()
-
-	// Seed a v1 SkillDef row + active pointer for "karpathy-guidelines".
-	defJSON, _ := json.Marshal(map[string]string{"body": "DB BODY"})
-	row, err := s.SkillDefCreate(ctx, store.SkillDefRow{
-		DefID:      "sdf_test1",
-		Name:       "karpathy-guidelines",
-		Definition: defJSON,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := s.SkillDefSetActive(ctx, "", "karpathy-guidelines", row.DefID, ""); err != nil {
-		t.Fatal(err)
-	}
-
-	srv := &Server{store: s}
-	def := config.AgentDef{
-		Skills: []string{"karpathy-guidelines"},
-		// Baked SystemPrompt from config-load contains the STATIC body.
-		// The helper should replace it with the DB body.
-		SystemPrompt:     "base prompt\n\n---\n\nSTATIC BODY",
-		SystemPromptBase: "base prompt",
-	}
-	got, _ := srv.resolveSkillBodiesForRun(ctx, "", def)
-	if !strings.Contains(got.SystemPrompt, "DB BODY") {
-		t.Errorf("DB body should be substituted into SystemPrompt; got %q", got.SystemPrompt)
-	}
-	if strings.Contains(got.SystemPrompt, "STATIC BODY") {
-		t.Errorf("STATIC BODY should be replaced; got %q", got.SystemPrompt)
-	}
+// A whitelist (`skills: [doc/*]`) appends a per-run note naming the permitted
+// patterns + how to use the Skill tool. The note lands AFTER the agent's own
+// prompt, separated by a rule.
+func TestResolveSkillBodiesForRun_WhitelistAppendsNote(t *testing.T) {
+	srv := &Server{}
+	def := config.AgentDef{Skills: []string{"doc/*", "-doc/secret"}, SystemPrompt: "base prompt"}
+	got, _ := srv.resolveSkillBodiesForRun(context.Background(), "", def)
 	if !strings.HasPrefix(got.SystemPrompt, "base prompt") {
-		t.Errorf("rebuild should start from base; got %q", got.SystemPrompt)
+		t.Errorf("note must append after the agent's own prompt; got %q", got.SystemPrompt)
+	}
+	if !strings.Contains(got.SystemPrompt, "doc/*") {
+		t.Errorf("note should name the permitted patterns; got %q", got.SystemPrompt)
+	}
+	if !strings.Contains(got.SystemPrompt, "Skill") {
+		t.Errorf("note should point at the Skill tool; got %q", got.SystemPrompt)
+	}
+	// The negative pattern is not a permitted target, so it must not be listed.
+	if strings.Contains(got.SystemPrompt, "-doc/secret") {
+		t.Errorf("note should list only positive patterns; got %q", got.SystemPrompt)
 	}
 }
 
-// TestResolveSkillBodiesForRun_StaleRowIsIgnored verifies that a
-// SkillDef row with an empty body is ignored (defends against
-// hand-mucked DB rows).
-func TestResolveSkillBodiesForRun_StaleRowIsIgnored(t *testing.T) {
-	s, err := sqlite.Open(":memory:")
-	if err != nil {
-		t.Fatal(err)
+// A whitelist agent with no base prompt still gets the note (no leading rule).
+func TestResolveSkillBodiesForRun_WhitelistNoteWithEmptyPrompt(t *testing.T) {
+	srv := &Server{}
+	def := config.AgentDef{Skills: []string{"marketing/**"}}
+	got, _ := srv.resolveSkillBodiesForRun(context.Background(), "", def)
+	if !strings.Contains(got.SystemPrompt, "marketing/**") {
+		t.Errorf("note should name the whitelist pattern even with no base prompt; got %q", got.SystemPrompt)
 	}
-	defer s.Close()
-	ctx := context.Background()
-
-	// Seed with an empty body — should be treated as "no DB-active body."
-	defJSON, _ := json.Marshal(map[string]string{"body": ""})
-	row, err := s.SkillDefCreate(ctx, store.SkillDefRow{
-		DefID:      "sdf_empty",
-		Name:       "empty-skill",
-		Definition: defJSON,
-		CreatedAt:  time.Now(),
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := s.SkillDefSetActive(ctx, "", "empty-skill", row.DefID, ""); err != nil {
-		t.Fatal(err)
-	}
-
-	srv := &Server{store: s}
-	const baked = "base prompt\n\n---\n\nSTATIC BODY"
-	def := config.AgentDef{
-		Skills:           []string{"empty-skill"},
-		SystemPrompt:     baked,
-		SystemPromptBase: "base prompt",
-	}
-	got, _ := srv.resolveSkillBodiesForRun(ctx, "", def)
-	if got.SystemPrompt != baked {
-		t.Errorf("empty-body DB row should NOT trigger rebuild; got %q", got.SystemPrompt)
-	}
-}
-
-// TestResolveSkillBodiesForRun_OneSkillResolvesEvenIfAnotherIsMissing
-// pins the per-skill-error fallback. With skill-a active in DB and
-// skill-b having no DB row, the rebuild includes the DB body for
-// skill-a AND the static fallback chain (or no body) for skill-b —
-// it does NOT abort the whole agent.
-func TestResolveSkillBodiesForRun_OneSkillResolvesEvenIfAnotherIsMissing(t *testing.T) {
-	s, err := sqlite.Open(":memory:")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer s.Close()
-	ctx := context.Background()
-
-	// skill-a has a DB-active row; skill-b does not.
-	defJSON, _ := json.Marshal(map[string]string{"body": "DB BODY A"})
-	row, err := s.SkillDefCreate(ctx, store.SkillDefRow{
-		DefID:      "sdf_a",
-		Name:       "skill-a",
-		Definition: defJSON,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := s.SkillDefSetActive(ctx, "", "skill-a", row.DefID, ""); err != nil {
-		t.Fatal(err)
-	}
-
-	srv := &Server{store: s}
-	def := config.AgentDef{
-		Skills:           []string{"skill-a", "skill-b"},
-		SystemPrompt:     "base prompt\n\n---\n\nstatic A\n\n---\n\nstatic B",
-		SystemPromptBase: "base prompt",
-	}
-	got, _ := srv.resolveSkillBodiesForRun(ctx, "", def)
-	if !strings.Contains(got.SystemPrompt, "DB BODY A") {
-		t.Errorf("DB body for skill-a should be substituted; got %q", got.SystemPrompt)
-	}
-}
-
-// TestResolveSkillBodiesForRun_ResolvesExplicitTenantWithoutPrincipalOnCtx
-// — RFC N FIX 2-skills regression, the skill analogue of
-// TestLookupAgent_ResolvesExplicitTenantWithoutPrincipalOnCtx. A
-// non-HTTP-principal spawn surface (A2A / scheduler / webhook / MCP
-// spawn_run / gRPC-legacy) computes the run's authoritative tenant as
-// effectiveTenantID and passes it EXPLICITLY to resolveSkillBodiesForRun,
-// with NO auth.Principal on ctx and WithRunIdentity not yet stamped. The
-// agent's skills MUST resolve at the run's tenant T, not at "".
-//
-// Pre-fix, resolveSkillBodiesForRun derived the tenant from
-// tenantFromCtx(ctx) which — with no principal and no RunIdentity —
-// returns "", so the run resolved its skills at the SHARED tenant while
-// memory + sub-agents used T. This test fails on the unfixed signature
-// (it wouldn't compile against the old ctx-only helper, and semantically
-// would resolve "" not T's promoted body).
-func TestResolveSkillBodiesForRun_ResolvesExplicitTenantWithoutPrincipalOnCtx(t *testing.T) {
-	s, err := sqlite.Open(":memory:")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer s.Close()
-	ctx := context.Background() // NO principal, NO RunIdentity (A2A/scheduler shape)
-
-	// Promote a SkillDef body for "tenant-skill" ONLY under tenant "acme"
-	// — not the shared "" tenant.
-	defJSON, _ := json.Marshal(map[string]string{"body": "ACME DB BODY"})
-	row, err := s.SkillDefCreate(ctx, store.SkillDefRow{
-		DefID:      "sdf_acme",
-		Name:       "tenant-skill",
-		Definition: defJSON,
-		TenantID:   "acme",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := s.SkillDefSetActive(ctx, "acme", "tenant-skill", row.DefID, ""); err != nil {
-		t.Fatal(err)
-	}
-
-	srv := &Server{store: s}
-	def := config.AgentDef{
-		Skills:           []string{"tenant-skill"},
-		SystemPrompt:     "base prompt\n\n---\n\nSTATIC BODY",
-		SystemPromptBase: "base prompt",
-	}
-
-	// Explicit tenant "acme" resolves acme's promoted body even with no
-	// principal/RunIdentity on ctx.
-	got, _ := srv.resolveSkillBodiesForRun(ctx, "acme", def)
-	if !strings.Contains(got.SystemPrompt, "ACME DB BODY") {
-		t.Errorf("the run's authoritative tenant must resolve its own promoted skill body even with no principal on ctx; got %q", got.SystemPrompt)
-	}
-
-	// The same agent resolved at the SHARED tenant "" must NOT see acme's
-	// promotion — proving the tenant argument (not a ctx default) selects
-	// the row. With no shared-tenant active row, the baked static prompt
-	// stays unchanged (fast path).
-	gotShared, _ := srv.resolveSkillBodiesForRun(ctx, "", def)
-	if strings.Contains(gotShared.SystemPrompt, "ACME DB BODY") {
-		t.Error("resolving at the shared tenant \"\" surfaced an acme-only promotion; tenant isolation breached")
+	if strings.HasPrefix(got.SystemPrompt, "\n") || strings.HasPrefix(got.SystemPrompt, "---") {
+		t.Errorf("note with no base prompt should not carry a leading separator; got %q", got.SystemPrompt)
 	}
 }

--- a/internal/api/http/substrate_admin.go
+++ b/internal/api/http/substrate_admin.go
@@ -259,9 +259,7 @@ func substrateAdminCtx(ctx context.Context) context.Context {
 		Scopes:   []string{"any"},
 		SelfName: substrateAdminAgentName,
 	})
-	ctx = tools.WithSkillDefPolicy(ctx, tools.SkillDefPolicyValue{
-		Scopes: []string{"any"},
-	})
+	ctx = tools.WithSkillPolicy(ctx, tools.SkillPolicyValue{}) // RFC BA: nil patterns = allow all skills
 	// VolumeDef (RFC AH Phase 2a): "any" scope so the HTTP-admin caller can
 	// create/delete/purge any dynamic volume name (operator trust).
 	ctx = tools.WithVolumeDefPolicy(ctx, tools.VolumeDefPolicyValue{

--- a/internal/api/mcp/context.go
+++ b/internal/api/mcp/context.go
@@ -116,7 +116,7 @@ func grantOperatorPolicies(ctx context.Context, agentName string, isAdmin bool) 
 	// Def families: "any" name within the stamped tenant (same for admin +
 	// tenant; the tenant filter at the lookup confines a tenant principal).
 	ctx = tools.WithAgentDefPolicy(ctx, tools.AgentDefPolicyValue{Scopes: []string{"any"}, SelfName: agentName})
-	ctx = tools.WithSkillDefPolicy(ctx, tools.SkillDefPolicyValue{Scopes: []string{"any"}})
+	ctx = tools.WithSkillPolicy(ctx, tools.SkillPolicyValue{})
 	ctx = tools.WithScheduleDefPolicy(ctx, tools.ScheduleDefPolicyValue{Scopes: []string{"any"}, SelfName: agentName})
 	ctx = tools.WithA2AServerCardDefPolicy(ctx, tools.A2AServerCardDefPolicyValue{Scopes: []string{"any"}, SelfName: agentName})
 	ctx = tools.WithA2AAgentDefPolicy(ctx, tools.A2AAgentDefPolicyValue{Scopes: []string{"any"}, SelfName: agentName})

--- a/internal/api/mcp/context_test.go
+++ b/internal/api/mcp/context_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/skillmatch"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
 
@@ -90,11 +91,13 @@ func TestOperatorCtx_AttachesAllRequiredPolicies(t *testing.T) {
 		t.Errorf("HistoryPolicy.Scopes empty; Context.history would refuse")
 	}
 
-	// SkillDefPolicy: empty Scopes ⇒ MCP `skilldef` meta-tool refuses
-	// every op.
-	skp := tools.SkillDefPolicy(ctx)
-	if len(skp.Scopes) == 0 {
-		t.Errorf("SkillDefPolicy.Scopes empty; all SkillDef ops via MCP would fail")
+	// SkillPolicy (RFC BA): the operator ctx grants FULL skill authority,
+	// which is now an EMPTY pattern allowlist (empty = allow all). The old
+	// semantics were inverted — empty used to mean default-deny. Assert the
+	// stamped policy allows an arbitrary name (i.e. it is not a deny-all).
+	skp := tools.SkillPolicy(ctx)
+	if skillmatch.DeniesAll(skp.Patterns) || !skillmatch.Allowed(skp.Patterns, "any-skill") {
+		t.Errorf("operator SkillPolicy must allow all skills; got patterns %v", skp.Patterns)
 	}
 
 	// ScheduleDefPolicy: empty Scopes ⇒ MCP `scheduledef` meta-tool

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -917,24 +917,18 @@ type AgentDef struct {
 	// per-agent webhook_def_scopes yaml field was parsed but never read. Per
 	// CLAUDE.md "no backward-compat shims for unused code", deleted.)
 
-	// SkillDefScopes is the v0.8.22 SkillDef tool capability gate.
-	// Default-deny when empty. Mirrors AgentDefScopes minus the
-	// "self" scope (skills have no agent identity, so "self" is
-	// meaningless for them). Closed set:
-	//
-	//   - "named:<skill-name>" → may operate on the specified single
-	//                            skill name (multi-entry)
-	//   - "descendants"        → may operate on any skill def whose
-	//                            lineage chain traces back to one
-	//                            the agent created (TODO v0.9.x —
-	//                            currently equivalent to "any")
-	//   - "any"                → unrestricted (operator-blessed
-	//                            orchestrator privilege)
+	// SkillDefScopes is a REMOVED-field tombstone (RFC BA). The old
+	// `skill_def_scopes` SkillDef capability gate (v0.8.22) is gone —
+	// skill authoring is now governed by the unified `skills:` pattern
+	// allowlist (see internal/skillmatch). This field exists ONLY so
+	// config-load can DETECT a stale `skill_def_scopes:` key and reject
+	// it with a migration error (validate()); it is never consumed at
+	// runtime and is deliberately absent from merge/overlay/hash.
 	SkillDefScopes []string `yaml:"skill_def_scopes"`
 
 	// VolumeDefScopes is the RFC AH Phase 2a VolumeDef tool capability
-	// gate. Default-deny when empty. Mirrors SkillDefScopes (no "self" —
-	// a volume has no agent identity). Closed set:
+	// gate. Default-deny when empty. No "self" (a volume has no agent
+	// identity). Closed set:
 	//
 	//   - "named:<volume-name>" → may create/delete/purge the named
 	//                             single volume (multi-entry)
@@ -4066,7 +4060,6 @@ func agentFromDiscovered(d *agents.Agent) AgentDef {
 			Subscribe: d.Channels.Subscribe,
 		},
 		AgentDefScopes:   d.AgentDefScopes,
-		SkillDefScopes:   d.SkillDefScopes,
 		VolumeDefScopes:  d.VolumeDefScopes,
 		EvaluationScopes: d.EvaluationScopes,
 		// F14: an MD-declared `interruption:` block now flows to config
@@ -4185,9 +4178,6 @@ func mergeAgentDef(base, override AgentDef) AgentDef {
 	}
 	if override.AgentDefScopes != nil {
 		out.AgentDefScopes = override.AgentDefScopes
-	}
-	if override.SkillDefScopes != nil {
-		out.SkillDefScopes = override.SkillDefScopes
 	}
 	if override.VolumeDefScopes != nil {
 		out.VolumeDefScopes = override.VolumeDefScopes
@@ -4479,26 +4469,9 @@ func validateAgentDefScope(sc string) error {
 	return fmt.Errorf("unknown scope %q (want one of: self, descendants, any, or \"named:<name>\")", sc)
 }
 
-// validateSkillDefScope mirrors validateAgentDefScope minus "self"
-// (skills have no agent identity).
-func validateSkillDefScope(sc string) error {
-	switch sc {
-	case "descendants", "any":
-		return nil
-	}
-	if strings.HasPrefix(sc, "named:") {
-		ref := strings.TrimPrefix(sc, "named:")
-		if ref == "" {
-			return fmt.Errorf("skill_def_scopes: \"named:\" requires a non-empty skill name (e.g. \"named:karpathy-guidelines\")")
-		}
-		return nil
-	}
-	return fmt.Errorf("unknown scope %q (want one of: descendants, any, or \"named:<skill-name>\")", sc)
-}
-
 // validateVolumeDefScope checks one entry in an agent's
-// volume_def_scopes list (RFC AH Phase 2a). Closed set, mirroring
-// skill_def_scopes minus "descendants" (volumes have no lineage):
+// volume_def_scopes list (RFC AH Phase 2a). Closed set (volumes have
+// no lineage, so no "descendants"):
 //
 //   - "any"
 //   - "named:<volume-name>" where <volume-name> is non-empty
@@ -4919,13 +4892,11 @@ func validate(c *Config) error {
 				return fmt.Errorf("agent %q: agent_def_scopes[%d]: %w", name, i, err)
 			}
 		}
-		// SkillDef tool (v0.8.22): validate skill_def_scopes entries.
-		// Closed set: "descendants" / "named:<skill-name>" / "any".
-		// No "self" — skills have no agent identity.
-		for i, sc := range agent.SkillDefScopes {
-			if err := validateSkillDefScope(sc); err != nil {
-				return fmt.Errorf("agent %q: skill_def_scopes[%d]: %w", name, i, err)
-			}
+		// RFC BA: `skill_def_scopes` is REMOVED — skill authoring is now
+		// governed by the unified `skills:` pattern allowlist. Reject a stale
+		// key loudly rather than silently ignoring an operator's intended gate.
+		if len(agent.SkillDefScopes) > 0 {
+			return fmt.Errorf("agent %q: `skill_def_scopes` was removed (RFC BA) — express skill-authoring limits as `skills:` patterns instead (e.g. skills: [doc/*] to allow authoring only doc/* skills, skills: [-*] to forbid all)", name)
 		}
 		// RFC BA: validate the `skills:` pattern allowlist (globs + optional
 		// +/- sign). A malformed entry (bad char, `..`, empty) fails loud at

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,8 +18,6 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/skillmatch"
-	"github.com/denn-gubsky/loomcycle/internal/skills"
-	"github.com/denn-gubsky/loomcycle/internal/tools/policy"
 )
 
 // Config is the top-level YAML structure plus env-derived fields.
@@ -3594,17 +3592,15 @@ func LoadLayers(layers ...Layer) (*Config, error) {
 		}
 	}
 
-	// resolveSkills MUST come after env loading (it needs SkillsRoot)
-	// AND after resolveSystemPromptFiles (skill bodies append onto
-	// SystemPrompt — file-loaded prompts have to land first).
-	if err := resolveSkills(cfg); err != nil {
-		return nil, err
-	}
+	// RFC BA: skills are on-demand (loaded via the Skill tool), not bundled
+	// into the prompt. Auto-add the Skill tool to every agent that may use a
+	// skill so on-demand access is the default. No skills-root/prompt work
+	// here anymore — the SkillsRoot registry is loaded once at boot in
+	// cmd/loomcycle (shared with the Skill/SkillDef tools + the Library).
+	addSkillToolDefaults(cfg)
 
-	// v0.8.7 default-add: every agent gets Context auto-appended to
-	// its tools unless `disable_context: true` is set. Runs
-	// after resolveSkills so skill-driven Tools widening has
-	// already taken effect.
+	// v0.8.7 default-add: every agent gets Context auto-appended to its tools
+	// unless `disable_context: true` is set.
 	addContextToolDefaults(cfg)
 
 	if err := validate(cfg); err != nil {
@@ -4274,89 +4270,41 @@ type SkillSpec struct {
 	Body        string   `yaml:"body"`
 }
 
-// resolveSkills bundles skill bodies into agent system prompts and
-// validates each skill's allowed-tools is a subset of the bundling
-// agent's tools. Static bundling — see Approach A in
-// doc-internal/skills-design.md.
+// addSkillToolDefaults auto-appends the "Skill" tool to every agent that may
+// use any skill, so RFC BA on-demand skill access is the default — an agent
+// with NO `skills:` field (the default = all allowed), a whitelist, or a
+// blacklist all get the tool. Mirror of addContextToolDefaults. Skipped ONLY
+// for `skills: [-*]` (a deny-all allowlist → no skill access at all). No-op
+// when "Skill" is already listed (case-insensitive, so a lowercase typo
+// doesn't double-add and confuse the case-sensitive per-run dispatcher).
 //
-// Errors:
-//   - an agent references a skill defined in NEITHER the top-level `skills:`
-//     map NOR LOOMCYCLE_SKILLS_ROOT (silent drop would produce agents whose
-//     prompts reference skills the runtime never loaded; loud failure forces
-//     the operator to fix the config). An unset/empty skills root is NOT an
-//     error on its own — inline `skills:` can satisfy an agent entirely.
-//   - skills root set but unreadable / not a directory
-//   - skill demands a tool the agent doesn't grant (security invariant)
-//
-// SECURITY: the subset check uses internal/tools/policy.matches so
-// glob rules on either side compose correctly. Examples:
-//   - skill `[Read]`, agent `[Read, HTTP]` → OK (literal match)
-//   - skill `[mcp__brave__search]`, agent `[mcp__brave__*]` → OK
-//     (skill literal matched by agent glob, narrowing is fine)
-//   - skill `[mcp__brave__*]`, agent `[mcp__brave__search]` → ERROR
-//     (skill demands broader access than agent grants)
-//   - skill `[Edit]`, agent `[Read]` → ERROR (skill widens)
-func resolveSkills(cfg *Config) error {
-	// Build the skill registry from two sources: the LOOMCYCLE_SKILLS_ROOT
-	// directory (file-backed SKILL.md; an empty root yields an empty set, no
-	// error) and the top-level `skills:` map (inline, merged across config
-	// layers by key like `agents:`). Inline definitions OVERLAY the root on a
-	// name collision — config is authoritative. An agent's skills may thus be
-	// satisfied entirely from inline defs with no skills root set.
-	set, err := skills.LoadSet(cfg.Env.SkillsRoot)
-	if err != nil {
-		return fmt.Errorf("load skills: %w", err)
-	}
-	for skillName, spec := range cfg.Skills {
-		set.Add(&skills.Skill{
-			Name:        skillName,
-			Description: spec.Description,
-			Tools:       spec.Tools,
-			Body:        spec.Body,
-		})
-	}
+// RFC BA changed `skills:` from an exact-name BUNDLE list (whose bodies were
+// concatenated onto SystemPrompt here) into a pattern ALLOWLIST that is
+// authority, not content: it is EXCLUDED from the content hash and NOT baked
+// into the prompt. Skill bodies are loaded on demand via the Skill tool; the
+// optional whitelist NOTE is injected at run-start (api/http applySkillNote),
+// never persisted — so two agents differing only in their skills: patterns
+// hash identically. Per-skill tool-subset enforcement moved to Skill invoke +
+// SkillDef authorship (a pattern allowlist can't be resolved to a concrete
+// skill set at config-load).
+func addSkillToolDefaults(cfg *Config) {
 	for name, def := range cfg.Agents {
-		if len(def.Skills) == 0 {
+		if skillmatch.DeniesAll(def.Skills) {
 			continue
 		}
-		// Capture the base (pre-skill-bake) prompt so v0.8.22 SkillDef
-		// per-run resolution can rebuild from it when a DB-active row
-		// shadows the static body.
-		def.SystemPromptBase = def.SystemPrompt
-		// Build agent rule set once per agent.
-		agentSet := make(map[string]bool, len(def.Tools))
+		already := false
 		for _, t := range def.Tools {
-			agentSet[t] = true
+			if strings.EqualFold(t, "Skill") {
+				already = true
+				break
+			}
 		}
-		for _, skillName := range def.Skills {
-			sk, ok := set.Get(skillName)
-			if !ok {
-				return fmt.Errorf("agent %q: unknown skill %q — define it under the top-level `skills:` map or as a SKILL.md under LOOMCYCLE_SKILLS_ROOT (%q)", name, skillName, cfg.Env.SkillsRoot)
-			}
-			// SECURITY: enforce skill.allowed-tools ⊆ agent.tools.
-			var widening []string
-			for _, t := range sk.Tools {
-				if !policy.Matches(t, agentSet) {
-					widening = append(widening, t)
-				}
-			}
-			if len(widening) > 0 {
-				return fmt.Errorf(
-					"agent %q: skill %q requires tools %v not granted by the agent's tools — skills may not widen the agent's tool set",
-					name, skillName, widening,
-				)
-			}
-			// Append. Use a separator only if there is already content
-			// in the system prompt; first skill on a prompt-less agent
-			// becomes the prompt without a leading "---".
-			if def.SystemPrompt != "" {
-				def.SystemPrompt += "\n\n---\n\n"
-			}
-			def.SystemPrompt += sk.Body
+		if already {
+			continue
 		}
+		def.Tools = append(def.Tools, "Skill")
 		cfg.Agents[name] = def
 	}
-	return nil
 }
 
 // splitCSV trims whitespace and drops empties from a comma-separated env value.
@@ -4977,6 +4925,14 @@ func validate(c *Config) error {
 		for i, sc := range agent.SkillDefScopes {
 			if err := validateSkillDefScope(sc); err != nil {
 				return fmt.Errorf("agent %q: skill_def_scopes[%d]: %w", name, i, err)
+			}
+		}
+		// RFC BA: validate the `skills:` pattern allowlist (globs + optional
+		// +/- sign). A malformed entry (bad char, `..`, empty) fails loud at
+		// load rather than silently mis-gating skill access at runtime.
+		for i, sc := range agent.Skills {
+			if err := skillmatch.ValidatePattern(sc); err != nil {
+				return fmt.Errorf("agent %q: skills[%d]: %w", name, i, err)
 			}
 		}
 		// VolumeDef tool (RFC AH Phase 2a): validate volume_def_scopes

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/agents"
 	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/skillmatch"
 	"github.com/denn-gubsky/loomcycle/internal/skills"
 	"github.com/denn-gubsky/loomcycle/internal/tools/policy"
 )
@@ -4724,6 +4725,15 @@ func validate(c *Config) error {
 	}
 	if c.Concurrency.MaxQueueDepth < 0 {
 		return fmt.Errorf("concurrency.max_queue_depth must be >= 0")
+	}
+	// RFC BA: inline skill names (top-level `skills:` map keys) share the
+	// `/`-grouped grammar with SkillsRoot dir names + SkillDef create/fork
+	// targets. Validate here so a malformed inline key (glob char, `..`,
+	// leading/trailing slash) fails loud at load, not at first Skill call.
+	for name := range c.Skills {
+		if err := skillmatch.ValidateName(name); err != nil {
+			return fmt.Errorf("skills: inline skill %q: %w", name, err)
+		}
 	}
 	// Library-level provider priority — validate every entry is a
 	// known provider name. Empty list is fine (resolver falls back

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -294,31 +294,23 @@ agents:
 	}
 }
 
-// Skills support — Approach A.
+// Skills support — RFC BA on-demand model.
 //
-// The bundling path is operator-driven: each agent's `skills:` YAML
-// field names skills under LOOMCYCLE_SKILLS_ROOT, and config-load
-// concatenates the parsed bodies onto SystemPrompt. The security
-// invariant is that skill `allowed-tools` ⊆ agent `tools` —
-// a skill may never widen the agent's tool set.
+// `skills:` is a pattern ALLOWLIST (not a bundle list). Config-load no longer
+// resolves skill names against LOOMCYCLE_SKILLS_ROOT nor bakes bodies into the
+// prompt — bodies are loaded on demand via the Skill tool (auto-added by
+// addSkillToolDefaults). Config-load's only skills job is to VALIDATE each
+// allowlist entry is a well-formed pattern. The old bundling / widening / no-
+// root / unknown-skill config-load tests were removed with that behavior; the
+// tool-subset (widening) check now lives at Skill invoke (see
+// internal/tools/builtin/skill_test.go) and the auto-add + on-demand semantics
+// in skills_inline_test.go.
 
-// Happy path: agent lists two skills; both bodies land in the agent's
-// system prompt in declaration order, separated by "---" markers. The
-// agent's existing system_prompt comes first, skills append after.
-func TestSkillsBundledIntoSystemPrompt(t *testing.T) {
-	root := t.TempDir()
-	skillsRoot := filepath.Join(root, "skills")
-	for _, sk := range []struct{ name, body string }{
-		{"voice-applier", "VOICE BODY"},
-		{"cv-voice-applier", "CV VOICE BODY"},
-	} {
-		dir := filepath.Join(skillsRoot, sk.name)
-		os.MkdirAll(dir, 0o755)
-		os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(
-			"---\nname: "+sk.name+"\nallowed-tools:\n  - Read\n---\n"+sk.body,
-		), 0o600)
-	}
-	yamlPath := filepath.Join(root, "c.yaml")
+// A bare `skills:` allowlist of valid patterns loads clean AND yields the
+// auto-added Skill tool (no SkillsRoot needed — the field is authority, not a
+// bundle to resolve).
+func TestSkillsAllowlistLoadsAndAutoAddsSkillTool(t *testing.T) {
+	yamlPath := filepath.Join(t.TempDir(), "c.yaml")
 	os.WriteFile(yamlPath, []byte(`
 defaults: { provider: anthropic, model: claude-sonnet-4-6 }
 agents:
@@ -326,225 +318,44 @@ agents:
     model: claude-sonnet-4-6
     system_prompt: "You are CV adapter."
     tools: [Read, HTTP]
-    skills: [voice-applier, cv-voice-applier]
+    skills: [doc/*, -secret/*]
 `), 0o600)
 
-	t.Setenv("LOOMCYCLE_SKILLS_ROOT", skillsRoot)
+	t.Setenv("LOOMCYCLE_SKILLS_ROOT", "")
 	cfg, err := Load(yamlPath)
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	prompt := cfg.Agents["cv-adapter"].SystemPrompt
-	wantPrefix := "You are CV adapter."
-	if !strings.HasPrefix(prompt, wantPrefix) {
-		t.Errorf("prompt should start with the agent's own prompt: %q", prompt)
+	def := cfg.Agents["cv-adapter"]
+	// On-demand: the prompt is the agent's own; no skill bodies baked in.
+	if def.SystemPrompt != "You are CV adapter." {
+		t.Errorf("SystemPrompt = %q, want the agent's own prompt (no baking)", def.SystemPrompt)
 	}
-	if !strings.Contains(prompt, "VOICE BODY") {
-		t.Error("voice-applier body missing")
-	}
-	if !strings.Contains(prompt, "CV VOICE BODY") {
-		t.Error("cv-voice-applier body missing")
-	}
-	// Order: voice-applier before cv-voice-applier (declaration order).
-	if strings.Index(prompt, "VOICE BODY") > strings.Index(prompt, "CV VOICE BODY") {
-		t.Error("skills should append in declaration order")
+	if !hasTool(def.Tools, "Skill") {
+		t.Errorf("a whitelisting agent should get the auto-added Skill tool; tools=%v", def.Tools)
 	}
 }
 
-// SECURITY: a skill demanding a tool the agent doesn't have must fail
-// config-load. This is the core "skill cannot widen agent's tool set"
-// guarantee — silent acceptance would let an operator drop in a skill
-// that the agent's prompt now references but that the runtime can't
-// satisfy, leading to either tool-not-found errors mid-run or worse,
-// the model trying alternative paths to accomplish what the skill
-// prescribed.
-func TestSkillCannotWidenAgentTools(t *testing.T) {
-	root := t.TempDir()
-	skillsRoot := filepath.Join(root, "skills")
-	dir := filepath.Join(skillsRoot, "writer-skill")
-	os.MkdirAll(dir, 0o755)
-	// Skill demands Write; agent only grants Read.
-	os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(
-		"---\nname: writer-skill\nallowed-tools:\n  - Read\n  - Write\n---\nbody",
-	), 0o600)
-	yamlPath := filepath.Join(root, "c.yaml")
-	os.WriteFile(yamlPath, []byte(`
-defaults: { provider: anthropic, model: claude-sonnet-4-6 }
-agents:
-  reader:
-    model: claude-sonnet-4-6
-    tools: [Read]
-    skills: [writer-skill]
-`), 0o600)
-
-	t.Setenv("LOOMCYCLE_SKILLS_ROOT", skillsRoot)
-	_, err := Load(yamlPath)
-	if err == nil {
-		t.Fatal("expected error when skill demands a tool the agent doesn't have")
-	}
-	if !strings.Contains(err.Error(), "Write") || !strings.Contains(err.Error(), "may not widen") {
-		t.Errorf("error should name the offending tool and explain the rule: %v", err)
-	}
-}
-
-// EMPIRICAL PROOF that the security check is load-bearing: rebuild the
-// same config with the agent ALSO granted Write, and the skill is
-// accepted. If this test starts passing while TestSkillCannotWidenAgentTools
-// still fails, the rule is being enforced.
-func TestSkillToolsAcceptedWhenAgentGrants(t *testing.T) {
-	root := t.TempDir()
-	skillsRoot := filepath.Join(root, "skills")
-	dir := filepath.Join(skillsRoot, "writer-skill")
-	os.MkdirAll(dir, 0o755)
-	os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(
-		"---\nname: writer-skill\nallowed-tools:\n  - Read\n  - Write\n---\nbody",
-	), 0o600)
-	yamlPath := filepath.Join(root, "c.yaml")
-	os.WriteFile(yamlPath, []byte(`
-defaults: { provider: anthropic, model: claude-sonnet-4-6 }
-agents:
-  writer:
-    model: claude-sonnet-4-6
-    tools: [Read, Write, Edit]
-    skills: [writer-skill]
-`), 0o600)
-
-	t.Setenv("LOOMCYCLE_SKILLS_ROOT", skillsRoot)
-	if _, err := Load(yamlPath); err != nil {
-		t.Fatalf("Load: %v", err)
-	}
-}
-
-// Glob handling: skill demands a literal MCP tool covered by the
-// agent's wildcard. policy.Matches handles the literal-vs-glob check.
-func TestSkillLiteralToolCoveredByAgentGlob(t *testing.T) {
-	root := t.TempDir()
-	skillsRoot := filepath.Join(root, "skills")
-	dir := filepath.Join(skillsRoot, "search-skill")
-	os.MkdirAll(dir, 0o755)
-	os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(
-		"---\nname: search-skill\nallowed-tools:\n  - mcp__brave__search\n---\nbody",
-	), 0o600)
-	yamlPath := filepath.Join(root, "c.yaml")
-	os.WriteFile(yamlPath, []byte(`
-defaults: { provider: anthropic, model: claude-sonnet-4-6 }
-agents:
-  searcher:
-    model: claude-sonnet-4-6
-    tools: ["mcp__brave__*"]
-    skills: [search-skill]
-`), 0o600)
-
-	t.Setenv("LOOMCYCLE_SKILLS_ROOT", skillsRoot)
-	if _, err := Load(yamlPath); err != nil {
-		t.Errorf("agent glob should cover skill literal: %v", err)
-	}
-}
-
-// Reverse case: skill claims a wildcard the agent has not declared.
-// The agent's narrower-than-wildcard literals shouldn't match the
-// skill's broader glob. This is the "skill widens via glob" attempt.
-func TestSkillBroadGlobNotCoveredByAgentLiterals(t *testing.T) {
-	root := t.TempDir()
-	skillsRoot := filepath.Join(root, "skills")
-	dir := filepath.Join(skillsRoot, "broad-skill")
-	os.MkdirAll(dir, 0o755)
-	os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(
-		"---\nname: broad-skill\nallowed-tools:\n  - \"mcp__brave__*\"\n---\nbody",
-	), 0o600)
-	yamlPath := filepath.Join(root, "c.yaml")
-	os.WriteFile(yamlPath, []byte(`
-defaults: { provider: anthropic, model: claude-sonnet-4-6 }
-agents:
-  narrow:
-    model: claude-sonnet-4-6
-    tools: [mcp__brave__search]
-    skills: [broad-skill]
-`), 0o600)
-
-	t.Setenv("LOOMCYCLE_SKILLS_ROOT", skillsRoot)
-	if _, err := Load(yamlPath); err == nil {
-		t.Fatal("agent literal should NOT cover skill's broader glob")
-	}
-}
-
-// Misconfiguration: agent lists skills but LOOMCYCLE_SKILLS_ROOT is
-// unset. Silent drop would produce an agent whose prompt references
-// a skill that was never loaded — exactly the failure mode this whole
-// feature exists to fix. Fail loudly.
-func TestSkillsListedWithoutRootErrors(t *testing.T) {
+// A malformed `skills:` allowlist entry (glob grammar violation — a `..`
+// segment) fails config-load loudly. Reverting the skillmatch.ValidatePattern
+// loop in validate() lets this through.
+func TestSkillsAllowlistRejectsBadPattern(t *testing.T) {
 	yamlPath := filepath.Join(t.TempDir(), "c.yaml")
 	os.WriteFile(yamlPath, []byte(`
 defaults: { provider: anthropic, model: claude-sonnet-4-6 }
 agents:
-  cv-adapter:
+  bad:
     model: claude-sonnet-4-6
-    tools: [Read]
-    skills: [voice-applier]
+    skills: ["doc/../escape"]
 `), 0o600)
 
-	// Explicitly clear the env (other tests may have set it).
 	t.Setenv("LOOMCYCLE_SKILLS_ROOT", "")
 	_, err := Load(yamlPath)
-	if err == nil || !strings.Contains(err.Error(), "LOOMCYCLE_SKILLS_ROOT") {
-		t.Errorf("expected LOOMCYCLE_SKILLS_ROOT-not-set error, got %v", err)
-	}
-}
-
-// Unknown skill name: surface the agent and the missing name so the
-// operator knows exactly what to fix.
-func TestUnknownSkillErrors(t *testing.T) {
-	root := t.TempDir()
-	skillsRoot := filepath.Join(root, "skills")
-	os.MkdirAll(skillsRoot, 0o755)
-	yamlPath := filepath.Join(root, "c.yaml")
-	os.WriteFile(yamlPath, []byte(`
-defaults: { provider: anthropic, model: claude-sonnet-4-6 }
-agents:
-  cv-adapter:
-    model: claude-sonnet-4-6
-    tools: [Read]
-    skills: [does-not-exist]
-`), 0o600)
-
-	t.Setenv("LOOMCYCLE_SKILLS_ROOT", skillsRoot)
-	_, err := Load(yamlPath)
 	if err == nil {
-		t.Fatal("expected unknown-skill error")
+		t.Fatal("expected error for a malformed skills: pattern")
 	}
-	if !strings.Contains(err.Error(), "does-not-exist") {
-		t.Errorf("error should name the missing skill: %v", err)
-	}
-}
-
-// Skills with empty allowed-tools (a body-only "guidance" skill that
-// makes no tool demands) attach to any agent regardless of the agent's
-// tools — there's nothing to intersect.
-func TestSkillWithNoToolsAttachesToAnyAgent(t *testing.T) {
-	root := t.TempDir()
-	skillsRoot := filepath.Join(root, "skills")
-	dir := filepath.Join(skillsRoot, "guidance")
-	os.MkdirAll(dir, 0o755)
-	os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(
-		"---\nname: guidance\ndescription: just guidance\n---\nGUIDANCE BODY",
-	), 0o600)
-	yamlPath := filepath.Join(root, "c.yaml")
-	os.WriteFile(yamlPath, []byte(`
-defaults: { provider: anthropic, model: claude-sonnet-4-6 }
-agents:
-  toolless:
-    model: claude-sonnet-4-6
-    tools: []
-    skills: [guidance]
-`), 0o600)
-
-	t.Setenv("LOOMCYCLE_SKILLS_ROOT", skillsRoot)
-	cfg, err := Load(yamlPath)
-	if err != nil {
-		t.Fatalf("Load: %v", err)
-	}
-	if !strings.Contains(cfg.Agents["toolless"].SystemPrompt, "GUIDANCE BODY") {
-		t.Error("guidance skill body should attach")
+	if !strings.Contains(err.Error(), "skills") {
+		t.Errorf("error should name the skills field: %v", err)
 	}
 }
 
@@ -1045,10 +856,11 @@ agents:
 	if def.MaxTokens != 24576 {
 		t.Errorf("MaxTokens = %d, want 24576 (yaml override)", def.MaxTokens)
 	}
-	// v0.8.7 default-add: Context appended automatically.
-	wantTools := []string{"Read", "Edit", "Context"}
-	if len(def.Tools) != 3 || def.Tools[0] != "Read" || def.Tools[1] != "Edit" || def.Tools[2] != "Context" {
-		t.Errorf("Tools = %v, want %v (yaml override + Context auto-add)", def.Tools, wantTools)
+	// Auto-adds: Skill (RFC BA on-demand default) then Context (v0.8.7), in
+	// that pipeline order, appended after the yaml-override tools.
+	wantTools := []string{"Read", "Edit", "Skill", "Context"}
+	if len(def.Tools) != 4 || def.Tools[0] != "Read" || def.Tools[1] != "Edit" || def.Tools[2] != "Skill" || def.Tools[3] != "Context" {
+		t.Errorf("Tools = %v, want %v (yaml override + Skill + Context auto-add)", def.Tools, wantTools)
 	}
 	if def.SystemPrompt != "prompt body\n" {
 		t.Errorf("SystemPrompt = %q, want body from MD", def.SystemPrompt)
@@ -1316,7 +1128,10 @@ agents:
 // body. Confirms ordering — discovery happens before
 // resolveSystemPromptFiles + resolveSkills, so the discovered prompt
 // + the skill body both feed into the same downstream pipeline.
-func TestDiscoverAgents_DiscoveredSkillsBundleCorrectly(t *testing.T) {
+// RFC BA: a discovered MD agent's `skills:` allowlist round-trips as authority
+// (not a bundle). The skill body is NOT baked into the prompt; instead the
+// agent gets the auto-added Skill tool and loads the body on demand at runtime.
+func TestDiscoverAgents_SkillsAllowlistRoundTripsOnDemand(t *testing.T) {
 	tmp := t.TempDir()
 	agentsDir := filepath.Join(tmp, "agents")
 	if err := os.Mkdir(agentsDir, 0o755); err != nil {
@@ -1354,12 +1169,20 @@ defaults: { provider: anthropic, model: claude-sonnet-4-6 }
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	prompt := cfg.Agents["uses-skill"].SystemPrompt
-	if !strings.Contains(prompt, "agent prompt body") {
-		t.Errorf("merged prompt missing agent body: %q", prompt)
+	def := cfg.Agents["uses-skill"]
+	if !strings.Contains(def.SystemPrompt, "agent prompt body") {
+		t.Errorf("prompt missing agent body: %q", def.SystemPrompt)
 	}
-	if !strings.Contains(prompt, "SKILL HELPER BODY") {
-		t.Errorf("merged prompt missing skill body: %q", prompt)
+	// On-demand: the skill body must NOT be baked into the config-load prompt.
+	if strings.Contains(def.SystemPrompt, "SKILL HELPER BODY") {
+		t.Errorf("skill body must not be baked at config-load (RFC BA on-demand): %q", def.SystemPrompt)
+	}
+	// The allowlist round-trips and the Skill tool is auto-added.
+	if len(def.Skills) != 1 || def.Skills[0] != "helper" {
+		t.Errorf("skills allowlist = %v, want [helper]", def.Skills)
+	}
+	if !hasTool(def.Tools, "Skill") {
+		t.Errorf("agent should get the auto-added Skill tool; tools=%v", def.Tools)
 	}
 }
 
@@ -1435,11 +1258,11 @@ agents:
 		t.Fatalf("Load: %v", err)
 	}
 	got := cfg.Agents["narrow"].Tools
-	// v0.8.7 default-add: empty-list yaml override clears the
-	// discovered list, then Context is appended by the default-add
-	// pass — so [Context] is the expected post-load shape, not [].
-	if len(got) != 1 || got[0] != "Context" {
-		t.Errorf("Tools = %v; expected [Context] (yaml [] cleared discovered + Context auto-added)", got)
+	// Default-adds: empty-list yaml override clears the discovered list, then
+	// the auto-add passes append Skill (RFC BA — no `skills:` = allow all) then
+	// Context — so [Skill, Context] is the expected post-load shape, not [].
+	if len(got) != 2 || got[0] != "Skill" || got[1] != "Context" {
+		t.Errorf("Tools = %v; expected [Skill, Context] (yaml [] cleared discovered + Skill/Context auto-added)", got)
 	}
 }
 

--- a/internal/config/skills_inline_test.go
+++ b/internal/config/skills_inline_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -137,5 +138,28 @@ skills:
 `)}
 	if _, err := LoadLayers(layer); err == nil {
 		t.Fatalf("a `..` inline skill name should fail config-load")
+	}
+}
+
+// RFC BA removed `skill_def_scopes`. A stale key in an agent must fail config-
+// load with a migration message pointing at `skills:` — NOT be silently
+// ignored (which would drop the operator's intended authoring gate). Reverting
+// the tombstone reject in validate() lets this load, breaking the test.
+func TestLoadLayers_RejectsRemovedSkillDefScopes(t *testing.T) {
+	t.Setenv("LOOMCYCLE_SKILLS_ROOT", "")
+	layer := Layer{Name: "test", Data: []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  breeder:
+    model: claude-sonnet-4-6
+    tools: [SkillDef]
+    skill_def_scopes: [any]
+`)}
+	_, err := LoadLayers(layer)
+	if err == nil {
+		t.Fatalf("a stale `skill_def_scopes:` key must fail config-load")
+	}
+	if !strings.Contains(err.Error(), "skill_def_scopes") || !strings.Contains(err.Error(), "skills:") {
+		t.Errorf("error should name the removed key + point at `skills:`; got: %v", err)
 	}
 }

--- a/internal/config/skills_inline_test.go
+++ b/internal/config/skills_inline_test.go
@@ -1,101 +1,141 @@
 package config
 
 import (
-	"os"
-	"path/filepath"
-	"strings"
 	"testing"
 )
 
-// agentWithSkills builds a minimal Config for resolveSkills: one agent that
-// lists the given skills, with the given tools + base prompt.
-func agentWithSkills(skillsRoot string, inline map[string]SkillSpec, agentAllowed, agentSkills []string) *Config {
-	return &Config{
-		Skills: inline,
-		Agents: map[string]AgentDef{
-			"a": {SystemPrompt: "BASE", Tools: agentAllowed, Skills: agentSkills},
-		},
-		Env: Env{SkillsRoot: skillsRoot},
+// hasTool reports whether tools contains name (case-insensitive, matching
+// addSkillToolDefaults' dedupe).
+func hasTool(tools []string, name string) bool {
+	for _, t := range tools {
+		if t == name {
+			return true
+		}
+	}
+	return false
+}
+
+// RFC BA: skills are on-demand — config-load no longer bakes skill bodies into
+// the prompt. Instead addSkillToolDefaults auto-adds the `Skill` tool to every
+// agent that may use ANY skill, so on-demand access is the default. It is
+// skipped ONLY for `skills: [-*]` (deny-all). These tests replace the old
+// resolveSkills bundling suite.
+func TestAddSkillToolDefaults_AutoAddsForAllowingAllowlists(t *testing.T) {
+	cases := []struct {
+		name   string
+		skills []string
+		want   bool // want the Skill tool auto-added
+	}{
+		{"absent (nil) = allow all", nil, true},
+		{"empty = allow all", []string{}, true},
+		{"whitelist", []string{"doc/*"}, true},
+		{"blacklist (only negatives)", []string{"-secret/*"}, true},
+		{"deny-all -*", []string{"-*"}, false},
+		{"deny-all -** ", []string{"-**"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{Agents: map[string]AgentDef{
+				"a": {Tools: []string{"Read"}, Skills: tc.skills},
+			}}
+			addSkillToolDefaults(cfg)
+			got := hasTool(cfg.Agents["a"].Tools, "Skill")
+			if got != tc.want {
+				t.Errorf("Skill auto-added = %v, want %v (tools=%v)", got, tc.want, cfg.Agents["a"].Tools)
+			}
+		})
 	}
 }
 
-func TestResolveSkills_InlineNoRoot(t *testing.T) {
-	// An inline skill with NO LOOMCYCLE_SKILLS_ROOT set must resolve (the
-	// fast-fail relaxation) and bake its body onto the agent prompt.
-	cfg := agentWithSkills("", map[string]SkillSpec{
-		"chunker": {Description: "split prose", Tools: []string{"Read"}, Body: "CHUNK GUIDANCE"},
-	}, []string{"Read"}, []string{"chunker"})
-	if err := resolveSkills(cfg); err != nil {
-		t.Fatalf("resolveSkills: %v", err)
-	}
-	got := cfg.Agents["a"]
-	if got.SystemPromptBase != "BASE" {
-		t.Errorf("SystemPromptBase = %q, want BASE (captured pre-bake)", got.SystemPromptBase)
-	}
-	if !strings.Contains(got.SystemPrompt, "CHUNK GUIDANCE") {
-		t.Errorf("skill body not bundled into the prompt: %q", got.SystemPrompt)
+// A deny-all agent (`skills: [-*]`) gets NO skill access, so the Skill tool must
+// NOT be auto-added — the one case the auto-add skips. Reverting the
+// skillmatch.DeniesAll guard in addSkillToolDefaults breaks this.
+func TestAddSkillToolDefaults_SkipsDenyAll(t *testing.T) {
+	cfg := &Config{Agents: map[string]AgentDef{
+		"locked": {Tools: []string{"Read"}, Skills: []string{"-*"}},
+	}}
+	addSkillToolDefaults(cfg)
+	if hasTool(cfg.Agents["locked"].Tools, "Skill") {
+		t.Errorf("`skills: [-*]` must not get the Skill tool; tools=%v", cfg.Agents["locked"].Tools)
 	}
 }
 
-func TestResolveSkills_InlineWideningRefused(t *testing.T) {
-	// A skill may not widen the agent's tool set — even inline.
-	cfg := agentWithSkills("", map[string]SkillSpec{
-		"writer": {Tools: []string{"Edit"}, Body: "x"},
-	}, []string{"Read"}, []string{"writer"})
-	if err := resolveSkills(cfg); err == nil || !strings.Contains(err.Error(), "not granted") {
-		t.Errorf("err = %v, want a tool-widening refusal", err)
+// No double-add when the agent already lists Skill (case-insensitive dedupe so a
+// lowercase typo doesn't add a second confusing entry).
+func TestAddSkillToolDefaults_NoDoubleAdd(t *testing.T) {
+	cfg := &Config{Agents: map[string]AgentDef{
+		"a": {Tools: []string{"Read", "Skill"}},
+		"b": {Tools: []string{"Read", "skill"}}, // lowercase typo
+	}}
+	addSkillToolDefaults(cfg)
+	if n := countTool(cfg.Agents["a"].Tools, "Skill"); n != 1 {
+		t.Errorf("agent a: Skill count = %d, want 1 (no double-add); tools=%v", n, cfg.Agents["a"].Tools)
+	}
+	// The lowercase variant is treated as already-present → no capital-S add.
+	if hasTool(cfg.Agents["b"].Tools, "Skill") {
+		t.Errorf("agent b: a lowercase `skill` must suppress the auto-add; tools=%v", cfg.Agents["b"].Tools)
 	}
 }
 
-func TestResolveSkills_InlineOverlaysRoot(t *testing.T) {
-	// A name defined in BOTH the root dir and inline → inline wins.
-	root := t.TempDir()
-	skillDir := filepath.Join(root, "dup")
-	if err := os.MkdirAll(skillDir, 0o755); err != nil {
-		t.Fatal(err)
+func countTool(tools []string, name string) int {
+	n := 0
+	for _, t := range tools {
+		if t == name {
+			n++
+		}
 	}
-	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: dup\n---\nFROM ROOT"), 0o644); err != nil {
-		t.Fatal(err)
+	return n
+}
+
+// Inline `skills:` map bodies survive config-load into cfg.Skills (they are the
+// on-demand catalog now — loaded via the Skill tool, not baked into the prompt).
+// A whitelisting agent additionally gets the Skill tool.
+func TestLoadLayers_InlineSkillsSurviveAndAgentGetsSkillTool(t *testing.T) {
+	t.Setenv("LOOMCYCLE_SKILLS_ROOT", "")
+	layer := Layer{Name: "test", Data: []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  writer:
+    model: claude-sonnet-4-6
+    tools: [Read]
+    skills: [chunker]
+skills:
+  chunker:
+    description: split prose
+    tools: [Read]
+    body: CHUNK GUIDANCE
+`)}
+	cfg, err := LoadLayers(layer)
+	if err != nil {
+		t.Fatalf("LoadLayers: %v", err)
 	}
-	cfg := agentWithSkills(root, map[string]SkillSpec{
-		"dup": {Body: "FROM INLINE"},
-	}, nil, []string{"dup"})
-	if err := resolveSkills(cfg); err != nil {
-		t.Fatalf("resolveSkills: %v", err)
+	sk, ok := cfg.Skills["chunker"]
+	if !ok {
+		t.Fatalf("inline skill `chunker` dropped from cfg.Skills")
 	}
-	sp := cfg.Agents["a"].SystemPrompt
-	if !strings.Contains(sp, "FROM INLINE") || strings.Contains(sp, "FROM ROOT") {
-		t.Errorf("inline must overlay the root; got %q", sp)
+	if sk.Body != "CHUNK GUIDANCE" {
+		t.Errorf("chunker body = %q, want CHUNK GUIDANCE", sk.Body)
+	}
+	w := cfg.Agents["writer"]
+	if !hasTool(w.Tools, "Skill") {
+		t.Errorf("whitelisting agent should get the auto-added Skill tool; tools=%v", w.Tools)
+	}
+	// On-demand: the body is NOT baked into the config-load system prompt.
+	if w.SystemPrompt != "" {
+		t.Errorf("skill body/note must not be baked at config-load; SystemPrompt=%q", w.SystemPrompt)
 	}
 }
 
-func TestResolveSkills_UnknownSkillErrors(t *testing.T) {
-	// A skill in neither source → a clear error naming both.
-	cfg := agentWithSkills("", nil, []string{"Read"}, []string{"nope"})
-	err := resolveSkills(cfg)
-	if err == nil || !strings.Contains(err.Error(), "unknown skill") {
-		t.Fatalf("err = %v, want an unknown-skill error", err)
-	}
-	if !strings.Contains(err.Error(), "skills:") || !strings.Contains(err.Error(), "LOOMCYCLE_SKILLS_ROOT") {
-		t.Errorf("error should name both sources; got %v", err)
-	}
-}
-
-func TestResolveSkills_RootStillWorks(t *testing.T) {
-	// Back-compat: a root-only skill (no inline) still resolves.
-	root := t.TempDir()
-	skillDir := filepath.Join(root, "rooted")
-	if err := os.MkdirAll(skillDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("ROOT BODY"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	cfg := agentWithSkills(root, nil, nil, []string{"rooted"})
-	if err := resolveSkills(cfg); err != nil {
-		t.Fatalf("resolveSkills: %v", err)
-	}
-	if !strings.Contains(cfg.Agents["a"].SystemPrompt, "ROOT BODY") {
-		t.Errorf("root skill body not bundled: %q", cfg.Agents["a"].SystemPrompt)
+// A malformed inline skill name (RFC BA `/`-grammar) fails config-load loudly
+// rather than silently mis-registering.
+func TestLoadLayers_RejectsBadInlineSkillName(t *testing.T) {
+	t.Setenv("LOOMCYCLE_SKILLS_ROOT", "")
+	layer := Layer{Name: "test", Data: []byte(`
+skills:
+  "../escape":
+    body: X
+`)}
+	if _, err := LoadLayers(layer); err == nil {
+		t.Fatalf("a `..` inline skill name should fail config-load")
 	}
 }

--- a/internal/help/builtin/content-signatures.md
+++ b/internal/help/builtin/content-signatures.md
@@ -42,14 +42,15 @@ Excluded from both (would defeat the "did the content change?" point):
 `def_id`, `version`, `parent_def_id`, `created_at`, `created_by_*`,
 `retired`, `bootstrapped_from_static`.
 
-Also explicitly excluded from the AgentDef hash: `channels`,
-`agent_def_scopes`, `skill_def_scopes`, `evaluation_scopes`. These
-exist on the operator-yaml loader path but DO NOT round-trip through
-`AgentDef set` / `fork` — they're operator-yaml-only ACL declarations
-the substrate doesn't persist in the `agent_defs` row. If they
-participated in the hash, a YAML-loaded agent and the same agent
-pushed via the substrate would hash differently and the whole
-comparison would falsely report drift.
+Also excluded from the AgentDef hash: the `*_def_scopes` gates
+(`agent_def_scopes`, …) — operator-yaml-only ACL declarations the
+substrate doesn't persist in the `agent_defs` row, so hashing them
+would make a YAML-loaded agent and the same agent pushed via the
+substrate falsely report drift. The `skills:` field is likewise
+excluded (RFC BA): even though it round-trips through `AgentDef set`,
+it is a per-agent skill-access ACL (authority) — not authored content
+— so two agents differing only in their `skills:` allowlist hash
+identically.
 
 ## Hash format
 

--- a/internal/help/builtin/skills-evolution.md
+++ b/internal/help/builtin/skills-evolution.md
@@ -50,21 +50,14 @@ may NARROW but never widen, same rule as `AgentDef`.
 
 ## How the body lands in the model
 
-Two consumption paths:
-
-**Approach A — baked into the system prompt.** When the skill
-name is in the agent's `skills:` yaml list, the loomcycle
-run-creation handler resolves `SkillDefGetActive(name)` at
-session start. A DB-active row's body OVERRIDES the static
-SKILL.md body for the duration of that run. The next run picks
-up the latest active row; existing in-flight runs keep their
-locked system prompt — there is no mid-run skill body swap.
-
-**Approach B — via the `Skill` tool.** When the agent calls
-`Skill({"name": "..."})`, the tool consults
-`SkillDefGetActive(name)` first; falls back to the static
-SKILL.md body on miss. Same DB-first semantics as Approach A,
-but per-call.
+Skills are loaded **on demand** (RFC BA) — never baked into the
+system prompt. When the agent calls `Skill({"name": "..."})`
+(or `Skill({"op":"list"})` to discover), the tool consults
+`SkillDefGetActive(name)` first and falls back to the static
+SKILL.md body on miss (DB-first). The `Skill` tool is auto-added
+to every agent whose `skills:` allowlist permits any skill. A
+promoted new version is picked up by the next `Skill` invoke; an
+in-flight call already loaded keeps the body it read.
 
 ## The fork-and-promote loop
 
@@ -83,37 +76,35 @@ promotion). When satisfied:
 {"op":"promote", "def_id":"sdf_v2_abc..."}
 ```
 
-New runs of any agent that lists `voice-applier` in its `skills:`
-now get the v2 body baked into their system prompt.
+Any agent that lists `voice-applier` in its `skills:` allowlist
+now loads the v2 body when it next invokes the `Skill` tool.
 
-## Scope policy
+## Authoring gate
 
-The yaml gate is `skill_def_scopes` (mirror of
-`agent_def_scopes`). Default-deny:
+Authoring is gated by the same `skills:` **pattern allowlist**
+(RFC BA) that governs listing + use — one policy for all three.
+The agent must also hold the `SkillDef` tool. Empty/absent
+`skills:` = author anywhere; `-*` = author nothing.
 
 ```yaml
 agents:
   curator:
-    skills: [voice-applier, cv-voice-applier]
     tools: [Read, Skill, SkillDef]
-    skill_def_scopes:
-      - named:voice-applier      # may fork/promote this skill
-      - named:cv-voice-applier   # ...and this one
+    skills:
+      - voice-applier      # may list/use/author exactly these two
+      - cv-voice-applier
 ```
 
-Closed set: `any` / `named:<skill-name>` / `descendants`. No
-`self` scope — skills have no agent identity, so a "self"
-constraint is meaningless.
+Entries are `/`-globs with an optional `+`/`-` sign: `doc/*`
+allows the whole `doc/` group, `-doc/secret` carves one out.
 
 ## When NOT to use SkillDef
 
 - The skill body is stable. Plain `SKILL.md` checked into the
   operator's repo is simpler than a versioned DB row.
-- You want to A/B test the skill across agents in the SAME run.
-  Approach A locks the body at session start, so two sub-agents
-  spawned in the same call would both see the same active body.
-  For mid-run A/B, use Approach B and pass the desired version
-  as an explicit parameter.
+- You want to A/B test two versions in the SAME run. The active
+  pointer is per-name, so both branches see the same active body.
+  Fork both, then have each sub-agent load its intended `def_id`.
 
 ## Cross-references
 
@@ -121,5 +112,5 @@ constraint is meaningless.
   cousin for whole-agent evolution.
 - `help(topic="scopes")` — agent vs user scope across Memory +
   Channel + DefScopes.
-- `Context.permissions` — surfaces the active `skill_def_scopes`
+- `Context.permissions` — surfaces the active `skills` allowlist
   for the calling agent.

--- a/internal/lookup/agent.go
+++ b/internal/lookup/agent.go
@@ -233,9 +233,10 @@ type SubstrateAgentDef struct {
 	// F14 closure, so a runtime-authored meta-agent's fork/schedule/etc.
 	// authority survives the round-trip instead of defaulting to deny. The
 	// drift test pins parity with builtin.mergedDef.
+	// (The SkillDef def-scope gate was removed in RFC BA — see builtin.mergedDef;
+	// the drift test pins that this struct stays in parity.)
 	AgentDefScopes         []string `json:"agent_def_scopes,omitempty"`
 	ScheduleDefScopes      []string `json:"schedule_def_scopes,omitempty"`
-	SkillDefScopes         []string `json:"skill_def_scopes,omitempty"`
 	A2AServerCardDefScopes []string `json:"a2a_server_card_def_scopes,omitempty"`
 	A2AAgentDefScopes      []string `json:"a2a_agent_def_scopes,omitempty"`
 	// VolumeDefScopes (RFC AH Phase 2a) — the dynamic-volume slice of the
@@ -278,7 +279,6 @@ func (s SubstrateAgentDef) ToConfigDef() config.AgentDef {
 		// runtime-authored meta-agent's AgentDef/Schedule/etc. scopes apply.
 		AgentDefScopes:         s.AgentDefScopes,
 		ScheduleDefScopes:      s.ScheduleDefScopes,
-		SkillDefScopes:         s.SkillDefScopes,
 		A2AServerCardDefScopes: s.A2AServerCardDefScopes,
 		A2AAgentDefScopes:      s.A2AAgentDefScopes,
 		VolumeDefScopes:        s.VolumeDefScopes,

--- a/internal/lookup/agent_test.go
+++ b/internal/lookup/agent_test.go
@@ -307,7 +307,6 @@ func TestAgent_DriftDetection(t *testing.T) {
 		// F14 closure) so a runtime-authored meta-agent can fork/schedule others.
 		"agent_def_scopes":           true,
 		"schedule_def_scopes":        true,
-		"skill_def_scopes":           true,
 		"a2a_server_card_def_scopes": true,
 		"a2a_agent_def_scopes":       true,
 		// RFC AH Phase 2a — the dynamic-volume slice of the F40 closure.

--- a/internal/skillmatch/skillmatch.go
+++ b/internal/skillmatch/skillmatch.go
@@ -1,0 +1,196 @@
+// Package skillmatch implements the RFC BA ordered pattern allowlist that
+// governs an agent's skill access — listing, using (invoking), and authoring
+// (SkillDef create/fork). It also validates `/`-grouped skill names and the
+// allowlist entries themselves.
+//
+// An allowlist is the agent's `skills:` YAML field (repurposed by RFC BA from
+// an exact-name bundle list into a pattern allowlist). Each entry is:
+//
+//	pat  or  +pat   — a POSITIVE rule (allow names matching pat)
+//	-pat            — a NEGATIVE rule (deny names matching pat)
+//
+// where pat is a `/`-segmented glob (`doc/*`, `marketing/**`, exact `seo`).
+//
+// Evaluation (order-independent — negatives always win):
+//   - hasPositive = the list contains at least one positive entry.
+//   - If hasPositive (WHITELIST mode): a name is allowed iff it matches ≥1
+//     positive AND no negative.
+//   - Else (only negatives, or empty — BLACKLIST mode): allowed iff it matches
+//     no negative.
+//   - An empty/absent list allows everything (the RFC BA default = all).
+//   - `-*` (or `-**`) denies everything.
+//
+// Glob semantics: a lone `*` (or `**`) means "every name, including grouped
+// ones" — so `-*` is deny-all and a bare `*`/`+*` is allow-all. WITHIN a path,
+// `*` matches exactly one segment (`doc/*` matches `doc/redactor` but not
+// `doc/a/b`) and `**` matches zero or more segments (`marketing/**` matches
+// `marketing/seo` and `marketing/x/y`).
+package skillmatch
+
+import "strings"
+
+// Allowed reports whether the given skill name is permitted by the ordered
+// pattern allowlist. See the package doc for the exact semantics. An empty
+// list allows every name.
+func Allowed(patterns []string, name string) bool {
+	hasPositive := false
+	matchedPositive := false
+	matchedNegative := false
+	for _, entry := range patterns {
+		neg, pat, ok := splitEntry(entry)
+		if !ok {
+			// Malformed entry (empty after sign strip). Config-load
+			// validation rejects these; skip defensively here.
+			continue
+		}
+		if neg {
+			if matchPattern(pat, name) {
+				matchedNegative = true
+			}
+			continue
+		}
+		hasPositive = true
+		if matchPattern(pat, name) {
+			matchedPositive = true
+		}
+	}
+	// A negative match denies regardless of position or any positive match —
+	// the deny rule is a hard floor.
+	if matchedNegative {
+		return false
+	}
+	if hasPositive {
+		return matchedPositive
+	}
+	return true
+}
+
+// HasPositive reports whether the allowlist contains at least one positive
+// (whitelist) entry. Used to decide whether to inject the system-prompt note
+// naming the permitted patterns.
+func HasPositive(patterns []string) bool {
+	for _, entry := range patterns {
+		neg, pat, ok := splitEntry(entry)
+		if ok && !neg && pat != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// DeniesAll reports whether the allowlist denies EVERY possible name — the one
+// case (`skills: [-*]`) where the agent gets no skill access at all, so the
+// Skill tool is NOT auto-added. A deny-all is any negative entry whose pattern
+// matches everything (`-*` or `-**`). A whitelist that merely happens to match
+// no existing skill (`[+doc/none]`) does NOT deny all — the policy still
+// permits that name pattern, so the agent keeps the Skill tool.
+func DeniesAll(patterns []string) bool {
+	for _, entry := range patterns {
+		neg, pat, ok := splitEntry(entry)
+		if ok && neg && isMatchAll(pat) {
+			return true
+		}
+	}
+	return false
+}
+
+// splitEntry trims an allowlist entry, strips a leading sign, and returns
+// (negative, pattern, ok). ok is false for an empty/sign-only entry.
+func splitEntry(entry string) (neg bool, pat string, ok bool) {
+	entry = strings.TrimSpace(entry)
+	if entry == "" {
+		return false, "", false
+	}
+	switch entry[0] {
+	case '-':
+		neg, pat = true, entry[1:]
+	case '+':
+		neg, pat = false, entry[1:]
+	default:
+		neg, pat = false, entry
+	}
+	if pat == "" {
+		return false, "", false
+	}
+	return neg, pat, true
+}
+
+// isMatchAll reports whether a (sign-stripped) pattern matches every name.
+func isMatchAll(pat string) bool { return pat == "*" || pat == "**" }
+
+// matchPattern matches a `/`-segmented glob pattern against a `/`-segmented
+// skill name. A lone `*`/`**` matches every name (including grouped ones);
+// otherwise `**` matches zero+ segments and any other segment is a single-
+// segment glob.
+func matchPattern(pat, name string) bool {
+	if isMatchAll(pat) {
+		return true
+	}
+	return doublestarMatch(strings.Split(pat, "/"), strings.Split(name, "/"))
+}
+
+// doublestarMatch matches a `/`-split pattern against a `/`-split path. `**`
+// matches zero or more segments; every other segment is matched with segMatch
+// (a single-segment `*`/`?`/literal glob). Backtracking DP over
+// (pattern-index, path-index) — small enough for skill names (few segments).
+// Reimplemented here (rather than importing internal/tools/builtin) to keep
+// this package dependency-free.
+func doublestarMatch(pat, path []string) bool {
+	if len(pat) == 0 {
+		return len(path) == 0
+	}
+	if pat[0] == "**" {
+		for i := 0; i <= len(path); i++ {
+			if doublestarMatch(pat[1:], path[i:]) {
+				return true
+			}
+		}
+		return false
+	}
+	if len(path) == 0 {
+		return false
+	}
+	if !segMatch(pat[0], path[0]) {
+		return false
+	}
+	return doublestarMatch(pat[1:], path[1:])
+}
+
+// segMatch matches one glob segment against one path segment. Supports `*`
+// (any run, including empty) and `?` (any single char); every other char is a
+// literal. No character classes — skill names are `[A-Za-z0-9_-]/`, so `*`
+// and `?` are the only metacharacters worth supporting.
+func segMatch(pat, seg string) bool {
+	// Fast path: no metacharacters → literal compare.
+	if !strings.ContainsAny(pat, "*?") {
+		return pat == seg
+	}
+	return globSeg(pat, seg)
+}
+
+// globSeg is a small backtracking glob over a single segment.
+func globSeg(pat, s string) bool {
+	pi, si := 0, 0
+	star, mark := -1, 0
+	for si < len(s) {
+		switch {
+		case pi < len(pat) && (pat[pi] == '?' || pat[pi] == s[si]):
+			pi++
+			si++
+		case pi < len(pat) && pat[pi] == '*':
+			star = pi
+			mark = si
+			pi++
+		case star != -1:
+			pi = star + 1
+			mark++
+			si = mark
+		default:
+			return false
+		}
+	}
+	for pi < len(pat) && pat[pi] == '*' {
+		pi++
+	}
+	return pi == len(pat)
+}

--- a/internal/skillmatch/skillmatch_test.go
+++ b/internal/skillmatch/skillmatch_test.go
@@ -1,0 +1,154 @@
+package skillmatch
+
+import "testing"
+
+func TestAllowed_EmptyListAllowsEverything(t *testing.T) {
+	for _, name := range []string{"seo", "doc/redactor", "marketing/x/y"} {
+		if !Allowed(nil, name) {
+			t.Errorf("Allowed(nil, %q) = false, want true (empty = allow all)", name)
+		}
+		if !Allowed([]string{}, name) {
+			t.Errorf("Allowed([], %q) = false, want true (empty = allow all)", name)
+		}
+	}
+}
+
+func TestAllowed_DenyAllStarDeniesEverything(t *testing.T) {
+	for _, deny := range [][]string{{"-*"}, {"-**"}} {
+		for _, name := range []string{"seo", "doc/redactor", "marketing/x/y"} {
+			if Allowed(deny, name) {
+				t.Errorf("Allowed(%v, %q) = true, want false (deny all)", deny, name)
+			}
+		}
+	}
+}
+
+func TestAllowed_WhitelistMode(t *testing.T) {
+	patterns := []string{"doc/*"}
+	tests := map[string]bool{
+		"doc/redactor":  true, // matches doc/* (one level)
+		"doc/summary":   true,
+		"doc/a/b":       false, // doc/* is one level only
+		"marketing/seo": false, // not under doc
+		"seo":           false, // not under doc
+	}
+	for name, want := range tests {
+		if got := Allowed(patterns, name); got != want {
+			t.Errorf("Allowed(%v, %q) = %v, want %v", patterns, name, got, want)
+		}
+	}
+}
+
+func TestAllowed_DoubleStarRecurses(t *testing.T) {
+	patterns := []string{"marketing/**"}
+	tests := map[string]bool{
+		"marketing/seo": true,
+		"marketing/x/y": true,
+		// `**` matches zero+ segments, so `marketing/**` also matches the bare
+		// group name — consistent with the existing glob.go doublestar matcher.
+		"marketing":    true,
+		"doc/redactor": false,
+	}
+	for name, want := range tests {
+		if got := Allowed(patterns, name); got != want {
+			t.Errorf("Allowed(%v, %q) = %v, want %v", patterns, name, got, want)
+		}
+	}
+}
+
+func TestAllowed_ExactNameWhitelist(t *testing.T) {
+	patterns := []string{"seo"}
+	if !Allowed(patterns, "seo") {
+		t.Errorf("Allowed(%v, seo) = false, want true", patterns)
+	}
+	if Allowed(patterns, "seo/x") {
+		t.Errorf("Allowed(%v, seo/x) = true, want false", patterns)
+	}
+}
+
+func TestAllowed_PlusPrefixIsPositive(t *testing.T) {
+	patterns := []string{"+doc/*"}
+	if !Allowed(patterns, "doc/redactor") {
+		t.Errorf("Allowed(%v, doc/redactor) = false, want true (+ is positive)", patterns)
+	}
+	if Allowed(patterns, "marketing/seo") {
+		t.Errorf("Allowed(%v, marketing/seo) = true, want false", patterns)
+	}
+}
+
+func TestAllowed_BlacklistMode(t *testing.T) {
+	// Only-negative list = blacklist: allow everything except matches.
+	patterns := []string{"-marketing/*"}
+	tests := map[string]bool{
+		"doc/redactor":  true,  // not denied
+		"seo":           true,  // not denied
+		"marketing/seo": false, // denied
+	}
+	for name, want := range tests {
+		if got := Allowed(patterns, name); got != want {
+			t.Errorf("Allowed(%v, %q) = %v, want %v", patterns, name, got, want)
+		}
+	}
+}
+
+func TestAllowed_NegativeOverridesPositive(t *testing.T) {
+	// Negatives always win regardless of order.
+	for _, patterns := range [][]string{
+		{"doc/*", "-doc/secret"},
+		{"-doc/secret", "doc/*"},
+	} {
+		if Allowed(patterns, "doc/secret") {
+			t.Errorf("Allowed(%v, doc/secret) = true, want false (negative wins)", patterns)
+		}
+		if !Allowed(patterns, "doc/redactor") {
+			t.Errorf("Allowed(%v, doc/redactor) = false, want true", patterns)
+		}
+	}
+}
+
+func TestAllowed_PositiveWithDenyAll(t *testing.T) {
+	// A deny-all negative shuts down even an explicit positive.
+	patterns := []string{"doc/*", "-*"}
+	if Allowed(patterns, "doc/redactor") {
+		t.Errorf("Allowed(%v, doc/redactor) = true, want false (-* denies all)", patterns)
+	}
+}
+
+func TestHasPositive(t *testing.T) {
+	tests := map[string]struct {
+		patterns []string
+		want     bool
+	}{
+		"empty":         {nil, false},
+		"only negative": {[]string{"-marketing/*"}, false},
+		"bare positive": {[]string{"doc/*"}, true},
+		"plus positive": {[]string{"+seo"}, true},
+		"mixed":         {[]string{"-x", "doc/*"}, true},
+		"deny all only": {[]string{"-*"}, false},
+	}
+	for name, tc := range tests {
+		if got := HasPositive(tc.patterns); got != tc.want {
+			t.Errorf("%s: HasPositive(%v) = %v, want %v", name, tc.patterns, got, tc.want)
+		}
+	}
+}
+
+func TestDeniesAll(t *testing.T) {
+	tests := map[string]struct {
+		patterns []string
+		want     bool
+	}{
+		"empty":              {nil, false},
+		"deny star":          {[]string{"-*"}, true},
+		"deny double star":   {[]string{"-**"}, true},
+		"deny star with pos": {[]string{"doc/*", "-*"}, true},
+		"blacklist group":    {[]string{"-marketing/*"}, false},
+		"whitelist":          {[]string{"doc/*"}, false},
+		"nonexistent pos":    {[]string{"+doc/none"}, false}, // policy permits it; not a deny-all
+	}
+	for name, tc := range tests {
+		if got := DeniesAll(tc.patterns); got != tc.want {
+			t.Errorf("%s: DeniesAll(%v) = %v, want %v", name, tc.patterns, got, tc.want)
+		}
+	}
+}

--- a/internal/skillmatch/validate.go
+++ b/internal/skillmatch/validate.go
@@ -1,0 +1,84 @@
+package skillmatch
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ValidateName checks a concrete `/`-grouped skill name (RFC BA). Grammar:
+// one-or-more segments of [A-Za-z0-9_-]+ joined by `/`; no leading/trailing
+// slash, no empty segment (`//`), no `.`/`..`. This is the name an operator
+// gives a SKILL.md directory, an inline `skills:` map key, or a SkillDef
+// create/fork target — NOT an allowlist pattern (use ValidatePattern for the
+// agent's `skills:` entries, which may carry globs + a `+`/`-` sign).
+func ValidateName(name string) error {
+	if name == "" {
+		return fmt.Errorf("empty skill name")
+	}
+	if strings.ContainsAny(name, "*?") {
+		return fmt.Errorf("skill name %q must not contain glob characters (* ?)", name)
+	}
+	segs := strings.Split(name, "/")
+	for _, seg := range segs {
+		if err := validateNameSegment(seg, name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateNameSegment(seg, full string) error {
+	if seg == "" {
+		return fmt.Errorf("skill name %q has an empty segment (no leading/trailing/double slash)", full)
+	}
+	if seg == "." || seg == ".." {
+		return fmt.Errorf("skill name %q must not contain %q segments", full, seg)
+	}
+	for _, r := range seg {
+		if !isNameRune(r) {
+			return fmt.Errorf("skill name %q: segment %q has invalid character %q (allowed: A-Z a-z 0-9 _ -)", full, seg, r)
+		}
+	}
+	return nil
+}
+
+// ValidatePattern checks one entry of an agent's `skills:` allowlist (RFC BA).
+// An entry may carry a leading `+`/`-` sign; the remaining pattern is a
+// `/`-segmented glob whose segments are `*`, `**`, or a single-segment glob of
+// [A-Za-z0-9_-*?]. No empty entry/pattern/segment, no `.`/`..`.
+func ValidatePattern(entry string) error {
+	trimmed := strings.TrimSpace(entry)
+	if trimmed == "" {
+		return fmt.Errorf("empty skills entry")
+	}
+	pat := trimmed
+	if pat[0] == '+' || pat[0] == '-' {
+		pat = pat[1:]
+	}
+	if pat == "" {
+		return fmt.Errorf("skills entry %q: missing pattern after the sign", entry)
+	}
+	for _, seg := range strings.Split(pat, "/") {
+		if seg == "" {
+			return fmt.Errorf("skills entry %q has an empty segment (no leading/trailing/double slash)", entry)
+		}
+		if seg == "." || seg == ".." {
+			return fmt.Errorf("skills entry %q must not contain %q segments", entry, seg)
+		}
+		for _, r := range seg {
+			if !isPatternRune(r) {
+				return fmt.Errorf("skills entry %q: segment %q has invalid character %q (allowed: A-Z a-z 0-9 _ - * ?)", entry, seg, r)
+			}
+		}
+	}
+	return nil
+}
+
+func isNameRune(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') ||
+		(r >= '0' && r <= '9') || r == '_' || r == '-'
+}
+
+func isPatternRune(r rune) bool {
+	return isNameRune(r) || r == '*' || r == '?'
+}

--- a/internal/skillmatch/validate_test.go
+++ b/internal/skillmatch/validate_test.go
@@ -1,0 +1,61 @@
+package skillmatch
+
+import "testing"
+
+func TestValidateName(t *testing.T) {
+	valid := []string{"seo", "doc/redactor", "marketing/social/x", "a-b_c/d1"}
+	for _, n := range valid {
+		if err := ValidateName(n); err != nil {
+			t.Errorf("ValidateName(%q) = %v, want nil", n, err)
+		}
+	}
+	invalid := []string{
+		"",              // empty
+		"/seo",          // leading slash
+		"seo/",          // trailing slash
+		"doc//redactor", // double slash
+		"..",            // parent
+		"doc/..",        // parent segment
+		"doc/../etc",    // traversal
+		".",             // dot
+		"doc/*",         // glob not allowed in a concrete name
+		"doc/red actor", // space
+		"doc/red.actor", // dot char
+	}
+	for _, n := range invalid {
+		if err := ValidateName(n); err == nil {
+			t.Errorf("ValidateName(%q) = nil, want error", n)
+		}
+	}
+}
+
+func TestValidatePattern(t *testing.T) {
+	valid := []string{
+		"seo", "+seo", "-seo",
+		"doc/*", "+doc/*", "-doc/*",
+		"marketing/**", "*", "**", "-*",
+		"doc/red?ctor",
+	}
+	for _, p := range valid {
+		if err := ValidatePattern(p); err != nil {
+			t.Errorf("ValidatePattern(%q) = %v, want nil", p, err)
+		}
+	}
+	invalid := []string{
+		"",        // empty
+		"+",       // sign only
+		"-",       // sign only
+		"doc//x",  // double slash
+		"/doc",    // leading slash
+		"doc/",    // trailing slash
+		"doc/..",  // parent segment
+		"..",      // parent
+		"doc/x y", // space
+		"doc/x.y", // dot char
+	}
+	for _, p := range invalid {
+		if err := ValidatePattern(p); err == nil {
+			t.Errorf("ValidatePattern(%q) = nil, want error", p)
+		}
+	}
+}

--- a/internal/skills/loader.go
+++ b/internal/skills/loader.go
@@ -34,6 +34,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/denn-gubsky/loomcycle/internal/skillmatch"
 	"gopkg.in/yaml.v3"
 )
 
@@ -107,14 +108,18 @@ func (s *Set) Names() []string {
 	return out
 }
 
-// LoadSet walks root, parses every <name>/SKILL.md, and returns the
-// populated registry. Empty root returns a non-nil empty Set so callers
-// can always Get(); a missing root directory is an error (it almost
-// certainly means the operator misconfigured LOOMCYCLE_SKILLS_ROOT).
+// LoadSet walks root recursively, parses every SKILL.md it finds, and
+// returns the populated registry keyed by the skill's `/`-grouped name.
+// Empty root returns a non-nil empty Set so callers can always Get(); a
+// missing root directory is an error (it almost certainly means the operator
+// misconfigured LOOMCYCLE_SKILLS_ROOT).
 //
-// Subdirectories without a SKILL.md are skipped silently — they may be
-// auxiliary content (e.g. a `references/` folder a skill body links to)
-// that operators stage alongside the skill itself.
+// RFC BA `/`-grouping: a skill's name is the directory path of its SKILL.md
+// RELATIVE to root (`root/doc/redactor/SKILL.md` → `doc/redactor`). Nested
+// dirs let operators namespace skills (`doc/*`, `marketing/*`); the flat
+// `root/foo/SKILL.md` → `foo` layout still works unchanged. Directories
+// without a SKILL.md are traversed (their descendants may hold skills) or
+// skipped as auxiliary content (e.g. a `references/` folder a skill links to).
 func LoadSet(root string) (*Set, error) {
 	set := &Set{skills: map[string]*Skill{}}
 	if root == "" {
@@ -127,44 +132,50 @@ func LoadSet(root string) (*Set, error) {
 	if !st.IsDir() {
 		return nil, fmt.Errorf("skills root %s: not a directory", root)
 	}
-	entries, err := os.ReadDir(root)
-	if err != nil {
-		return nil, fmt.Errorf("read skills root %s: %w", root, err)
-	}
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		name := e.Name()
-		// Reject names that could escape the root if a future caller
-		// constructs a path from them. Belt-and-braces — ReadDir
-		// doesn't return entries with "/" in the name, but nothing
-		// stops a creative filename so we sanity-check.
-		if strings.ContainsAny(name, "/\\") || name == "." || name == ".." {
-			return nil, fmt.Errorf("invalid skill name %q under %s", name, root)
-		}
-		path := filepath.Join(root, name, "SKILL.md")
-		fi, err := os.Stat(path)
-		if err != nil || fi.IsDir() {
-			continue
-		}
-		raw, err := os.ReadFile(path)
+	walkErr := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
-			return nil, fmt.Errorf("read %s: %w", path, err)
+			return err
 		}
-		sk, err := parseSkill(raw)
-		if err != nil {
-			return nil, fmt.Errorf("parse %s: %w", path, err)
+		if d.IsDir() || d.Name() != "SKILL.md" {
+			return nil
+		}
+		// name = the SKILL.md's parent directory relative to root, `/`-joined.
+		rel, rerr := filepath.Rel(root, filepath.Dir(path))
+		if rerr != nil {
+			return fmt.Errorf("skills root %s: relativize %s: %w", root, path, rerr)
+		}
+		if rel == "." {
+			// A SKILL.md directly at root has no name — skip.
+			return nil
+		}
+		name := filepath.ToSlash(rel)
+		// Escape-prevention + `/`-grammar. rel from a real path under root
+		// can't traverse out, but validate anyway so a hand-crafted symlink
+		// or odd filename fails loud rather than minting a weird name.
+		if verr := skillmatch.ValidateName(name); verr != nil {
+			return fmt.Errorf("skills root %s: %w", root, verr)
+		}
+		raw, rderr := os.ReadFile(path)
+		if rderr != nil {
+			return fmt.Errorf("read %s: %w", path, rderr)
+		}
+		sk, perr := parseSkill(raw)
+		if perr != nil {
+			return fmt.Errorf("parse %s: %w", path, perr)
 		}
 		sk.Path = path
-		// The directory name is the canonical address. If frontmatter
-		// declares a different name, that's drift the operator should
-		// notice and fix; refusing to load is loud and unambiguous.
+		// The relative directory path is the canonical address. If frontmatter
+		// declares a different name, that's drift the operator should notice
+		// and fix; refusing to load is loud and unambiguous.
 		if sk.Name != "" && sk.Name != name {
-			return nil, fmt.Errorf("skill %s: frontmatter name %q != directory name %q", path, sk.Name, name)
+			return fmt.Errorf("skill %s: frontmatter name %q != directory path %q", path, sk.Name, name)
 		}
 		sk.Name = name
 		set.skills[name] = sk
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
 	}
 	return set, nil
 }

--- a/internal/skills/loader_test.go
+++ b/internal/skills/loader_test.go
@@ -247,6 +247,58 @@ func TestLoadSet_CRLFLineEndings(t *testing.T) {
 	}
 }
 
+// RFC BA: a SKILL.md nested under a group directory loads with its
+// `/`-grouped name = the path relative to root. A flat sibling still loads
+// with its bare name, so grouped + flat coexist.
+func TestLoadSet_NestedGroupedName(t *testing.T) {
+	root := t.TempDir()
+	nested := filepath.Join(root, "doc", "redactor")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "SKILL.md"), []byte("redactor body\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	flat := filepath.Join(root, "seo")
+	os.MkdirAll(flat, 0o755)
+	os.WriteFile(filepath.Join(flat, "SKILL.md"), []byte("seo body\n"), 0o600)
+
+	set, err := LoadSet(root)
+	if err != nil {
+		t.Fatalf("LoadSet: %v", err)
+	}
+	if sk, ok := set.Get("doc/redactor"); !ok {
+		t.Error("doc/redactor not loaded under its grouped name")
+	} else if !strings.Contains(sk.Body, "redactor body") {
+		t.Errorf("doc/redactor body = %q", sk.Body)
+	}
+	if _, ok := set.Get("seo"); !ok {
+		t.Error("flat seo not loaded alongside the grouped skill")
+	}
+	// The intermediate group dir itself has no SKILL.md → not a skill.
+	if _, ok := set.Get("doc"); ok {
+		t.Error("group dir doc must not be a skill (no SKILL.md)")
+	}
+}
+
+// RFC BA: a nested SKILL.md whose frontmatter name disagrees with its
+// relative directory path is a loud drift error, now compared against the
+// full `/`-grouped path (not just the leaf dir).
+func TestLoadSet_NestedFrontmatterNameMismatch(t *testing.T) {
+	root := t.TempDir()
+	nested := filepath.Join(root, "doc", "redactor")
+	os.MkdirAll(nested, 0o755)
+	// Frontmatter says "redactor" but the path is "doc/redactor".
+	content := "---\nname: redactor\n---\nbody\n"
+	os.WriteFile(filepath.Join(nested, "SKILL.md"), []byte(content), 0o600)
+
+	if _, err := LoadSet(root); err == nil {
+		t.Fatal("expected frontmatter-name != directory-path error")
+	} else if !strings.Contains(err.Error(), "doc/redactor") {
+		t.Errorf("error should cite the grouped path, got %v", err)
+	}
+}
+
 // Get() and Names() are safe on a nil receiver. The config layer holds
 // a *Set that may be nil when LOOMCYCLE_SKILLS_ROOT is unset; callers
 // shouldn't have to check before every lookup.

--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -890,9 +890,10 @@ type mergedDef struct {
 	// forks/promotes/schedules other agents) comes back default-deny and can't
 	// author anything. NOT part of content_sha256 (the *Scopes ACLs are
 	// deliberately excluded from agents.AgentContent — authority, not content).
+	// (The SkillDef def-scope gate was removed in RFC BA — skill authoring is
+	// governed by the unified `skills:` pattern allowlist, not a def-scope gate.)
 	AgentDefScopes         []string `json:"agent_def_scopes,omitempty"`
 	ScheduleDefScopes      []string `json:"schedule_def_scopes,omitempty"`
-	SkillDefScopes         []string `json:"skill_def_scopes,omitempty"`
 	A2AServerCardDefScopes []string `json:"a2a_server_card_def_scopes,omitempty"`
 	A2AAgentDefScopes      []string `json:"a2a_agent_def_scopes,omitempty"`
 	// VolumeDefScopes is the RFC AH Phase 2a slice of the F40 closure —
@@ -1000,9 +1001,6 @@ func (d *mergedDef) applyOverlay(ov mergedDef) {
 	if ov.ScheduleDefScopes != nil {
 		d.ScheduleDefScopes = ov.ScheduleDefScopes
 	}
-	if ov.SkillDefScopes != nil {
-		d.SkillDefScopes = ov.SkillDefScopes
-	}
 	if ov.A2AServerCardDefScopes != nil {
 		d.A2AServerCardDefScopes = ov.A2AServerCardDefScopes
 	}
@@ -1069,7 +1067,6 @@ func staticToMergedDef(s config.AgentDef) mergedDef {
 		// capability gates, so a fork of it inherits them.
 		AgentDefScopes:         s.AgentDefScopes,
 		ScheduleDefScopes:      s.ScheduleDefScopes,
-		SkillDefScopes:         s.SkillDefScopes,
 		A2AServerCardDefScopes: s.A2AServerCardDefScopes,
 		A2AAgentDefScopes:      s.A2AAgentDefScopes,
 		VolumeDefScopes:        s.VolumeDefScopes,

--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -1136,13 +1136,13 @@ func signFromMergedDef(name string, def mergedDef) string {
 		Tools:                 def.Tools,
 		// RFC BA: skills: is the agent's pattern-allowlist ACL (authority, not
 		// content) — excluded from content_sha256 like the *_def_scopes gates.
-		SystemPrompt: def.SystemPrompt,
-		Providers:             def.Providers,
-		Models:                models,
-		MemoryScopes:          def.MemoryScopes,
-		MemoryQuotaBytes:      def.MemoryQuotaBytes,
-		MemoryBackend:         def.MemoryBackend,
-		EvaluationScopes:      def.EvaluationScopes,
+		SystemPrompt:     def.SystemPrompt,
+		Providers:        def.Providers,
+		Models:           models,
+		MemoryScopes:     def.MemoryScopes,
+		MemoryQuotaBytes: def.MemoryQuotaBytes,
+		MemoryBackend:    def.MemoryBackend,
+		EvaluationScopes: def.EvaluationScopes,
 	}
 	// F14: include the interactive/multi-agent ACLs in the hash so a fork
 	// that changes ONLY channels/interruption/evaluation_scopes mints a new

--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -1134,8 +1134,9 @@ func signFromMergedDef(name string, def mergedDef) string {
 		UnboundedIterations:   def.UnboundedIterations,
 		MaxConcurrentChildren: def.MaxConcurrentChildren,
 		Tools:                 def.Tools,
-		Skills:                def.Skills,
-		SystemPrompt:          def.SystemPrompt,
+		// RFC BA: skills: is the agent's pattern-allowlist ACL (authority, not
+		// content) — excluded from content_sha256 like the *_def_scopes gates.
+		SystemPrompt: def.SystemPrompt,
 		Providers:             def.Providers,
 		Models:                models,
 		MemoryScopes:          def.MemoryScopes,

--- a/internal/tools/builtin/agentdef_test.go
+++ b/internal/tools/builtin/agentdef_test.go
@@ -78,7 +78,7 @@ func TestAgentDefTool_CreateRoundTripsDefScopes(t *testing.T) {
 	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"breeder","overlay":{`+
 		`"system_prompt":"breed agents",`+
 		`"agent_def_scopes":["named:foo"],"schedule_def_scopes":["any"],`+
-		`"skill_def_scopes":["named:s"],"a2a_server_card_def_scopes":["any"],`+
+		`"a2a_server_card_def_scopes":["any"],`+
 		`"a2a_agent_def_scopes":["any"],"volume_def_scopes":["named:vol"]}}`))
 	if res.IsError {
 		t.Fatalf("create: %s", res.Text)
@@ -94,9 +94,6 @@ func TestAgentDefTool_CreateRoundTripsDefScopes(t *testing.T) {
 	if got := def.ScheduleDefScopes; len(got) != 1 || got[0] != "any" {
 		t.Errorf("ScheduleDefScopes = %v, want [any]", got)
 	}
-	if got := def.SkillDefScopes; len(got) != 1 || got[0] != "named:s" {
-		t.Errorf("SkillDefScopes = %v, want [named:s]", got)
-	}
 	if len(def.A2AServerCardDefScopes) != 1 || len(def.A2AAgentDefScopes) != 1 {
 		t.Errorf("a2a def scopes dropped: server=%v agent=%v", def.A2AServerCardDefScopes, def.A2AAgentDefScopes)
 	}
@@ -111,7 +108,6 @@ func TestAgentDefTool_CreateRoundTripsDefScopes(t *testing.T) {
 func TestStaticToMergedDef_PreservesVolumeDefScopes(t *testing.T) {
 	md := staticToMergedDef(config.AgentDef{
 		AgentDefScopes:  []string{"any"},
-		SkillDefScopes:  []string{"any"},
 		VolumeDefScopes: []string{"named:repo"},
 	})
 	if len(md.VolumeDefScopes) != 1 || md.VolumeDefScopes[0] != "named:repo" {

--- a/internal/tools/builtin/context.go
+++ b/internal/tools/builtin/context.go
@@ -532,7 +532,7 @@ func (c *Context) execPermissions(ctx context.Context) (tools.Result, error) {
 			"subscribe": chPol.Subscribe,
 		},
 		"agent_def_scopes":  adPol.Scopes,
-		"skills":           sdPol.Patterns,
+		"skills":            sdPol.Patterns,
 		"evaluation_scopes": evPol.Scopes,
 		"history_scope":     histPol.Scopes,
 	}

--- a/internal/tools/builtin/context.go
+++ b/internal/tools/builtin/context.go
@@ -512,7 +512,7 @@ func (c *Context) execPermissions(ctx context.Context) (tools.Result, error) {
 	memPol := tools.MemoryPolicy(ctx)
 	chPol := tools.ChannelPolicy(ctx)
 	adPol := tools.AgentDefPolicy(ctx)
-	sdPol := tools.SkillDefPolicy(ctx)
+	sdPol := tools.SkillPolicy(ctx)
 	evPol := tools.EvaluationPolicy(ctx)
 
 	histPol := tools.HistoryPolicy(ctx)
@@ -532,7 +532,7 @@ func (c *Context) execPermissions(ctx context.Context) (tools.Result, error) {
 			"subscribe": chPol.Subscribe,
 		},
 		"agent_def_scopes":  adPol.Scopes,
-		"skill_def_scopes":  sdPol.Scopes,
+		"skills":           sdPol.Patterns,
 		"evaluation_scopes": evPol.Scopes,
 		"history_scope":     histPol.Scopes,
 	}

--- a/internal/tools/builtin/context_test.go
+++ b/internal/tools/builtin/context_test.go
@@ -501,8 +501,8 @@ func TestContextTool_PermissionsBundle(t *testing.T) {
 		Scopes:   []string{"self"},
 		SelfName: "researcher",
 	})
-	ctx = tools.WithSkillDefPolicy(ctx, tools.SkillDefPolicyValue{
-		Scopes: []string{"named:karpathy-guidelines"},
+	ctx = tools.WithSkillPolicy(ctx, tools.SkillPolicyValue{
+		Patterns: []string{"doc/*"},
 	})
 	ctx = tools.WithEvaluationPolicy(ctx, tools.EvaluationPolicyValue{
 		Scopes: []string{"submit_self", "read_any"},
@@ -528,8 +528,8 @@ func TestContextTool_PermissionsBundle(t *testing.T) {
 	if adScopes := out["agent_def_scopes"].([]any); adScopes[0] != "self" {
 		t.Errorf("agent_def_scopes[0] = %v, want self", adScopes[0])
 	}
-	if sdScopes := out["skill_def_scopes"].([]any); sdScopes[0] != "named:karpathy-guidelines" {
-		t.Errorf("skill_def_scopes[0] = %v, want named:karpathy-guidelines", sdScopes[0])
+	if skills := out["skills"].([]any); skills[0] != "doc/*" {
+		t.Errorf("skills[0] = %v, want doc/* (RFC BA allowlist)", skills[0])
 	}
 }
 

--- a/internal/tools/builtin/skill.go
+++ b/internal/tools/builtin/skill.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
+	"github.com/denn-gubsky/loomcycle/internal/skillmatch"
 	"github.com/denn-gubsky/loomcycle/internal/skills"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
@@ -71,19 +73,22 @@ type SkillTool struct {
 const skillInputSchema = `{
   "type": "object",
   "properties": {
-    "name": {"type": "string", "description": "Skill name (a directory under LOOMCYCLE_SKILLS_ROOT containing SKILL.md)."}
+    "op": {"type": "string", "enum": ["invoke", "list"], "description": "invoke (default) loads a skill body by name; list enumerates the skills this agent may use."},
+    "name": {"type": "string", "description": "op=invoke: the skill name to load (supports /-grouped names like doc/redactor)."},
+    "pattern": {"type": "string", "description": "op=list: optional /-glob filter (e.g. doc/*, marketing/**)."}
   },
-  "required": ["name"],
   "additionalProperties": false
 }`
 
-const skillDescription = `Load a named skill's body and return it as the tool_result. ` +
-	`Skills are domain-specific instruction sets stored under LOOMCYCLE_SKILLS_ROOT (frontmatter + markdown). ` +
-	`Use when the model needs a specific extension that wasn't pre-bundled into its system prompt. ` +
-	`The skill's allowed-tools must be a subset of the calling agent's tools — refusals are surfaced as is_error.`
+const skillDescription = `Discover and load domain-specific instruction sets (skills) on demand. ` +
+	`op=list enumerates the skills you may use (optionally filtered by a /-glob pattern); ` +
+	`op=invoke (the default when only a name is given) loads a named skill's body as the tool_result. ` +
+	`Skills you may access are governed by the agent's skills: allowlist; a skill's tools must be a subset of yours (refusals are surfaced as is_error).`
 
 type skillInput struct {
-	Name string `json:"name"`
+	Op      string `json:"op"`
+	Name    string `json:"name"`
+	Pattern string `json:"pattern"`
 }
 
 // Name implements tools.Tool.
@@ -110,32 +115,93 @@ func (s *SkillTool) Execute(ctx context.Context, input json.RawMessage) (tools.R
 	if err := json.Unmarshal(input, &in); err != nil {
 		return tools.Result{IsError: true, Text: fmt.Sprintf("invalid input JSON: %s", err)}, nil
 	}
-	in.Name = strings.TrimSpace(in.Name)
-	if in.Name == "" {
+	op := strings.TrimSpace(in.Op)
+	if op == "" {
+		op = "invoke" // back-compat: {"name": ...} with no op invokes.
+	}
+	policy := tools.SkillPolicy(ctx)
+	switch op {
+	case "list":
+		return s.execList(ctx, policy, strings.TrimSpace(in.Pattern))
+	case "invoke":
+		return s.execInvoke(ctx, policy, strings.TrimSpace(in.Name))
+	default:
+		return tools.Result{IsError: true, Text: fmt.Sprintf("Skill: unknown op %q (want \"invoke\" or \"list\")", op)}, nil
+	}
+}
+
+// execInvoke loads a named skill's body, gated by the agent's RFC BA `skills:`
+// allowlist and the skill-tools ⊆ agent-tools invariant.
+func (s *SkillTool) execInvoke(ctx context.Context, policy tools.SkillPolicyValue, name string) (tools.Result, error) {
+	if name == "" {
 		return tools.Result{IsError: true, Text: "missing required field: name"}, nil
 	}
-
-	body, allowedTools, source, err := s.resolveSkill(ctx, in.Name)
+	// RFC BA: the agent's `skills:` allowlist gates WHICH skills it may load.
+	if !skillmatch.Allowed(policy.Patterns, name) {
+		return tools.Result{IsError: true, Text: fmt.Sprintf("skill %q is not permitted by this agent's `skills:` allowlist", name)}, nil
+	}
+	body, allowedTools, source, err := s.resolveSkill(ctx, name)
 	if err != nil {
 		return tools.Result{IsError: true, Text: err.Error()}, nil
 	}
-
-	// SECURITY: enforce skill.allowed-tools ⊆ agent.tools at
-	// tool-call time. Mirrors the config-load check in resolveSkills.
-	// Agent tools are pulled from ctx (see tools.WithAgentTools) so
-	// the SkillTool struct stays per-server, not per-run.
+	// SECURITY: enforce skill.tools ⊆ agent.tools at tool-call time. Agent
+	// tools are read from ctx so the SkillTool struct stays per-server.
 	agentTools := tools.AgentTools(ctx)
 	if widening := skillToolsExceedingAgent(allowedTools, agentTools); len(widening) > 0 {
 		return tools.Result{
 			IsError: true,
 			Text: fmt.Sprintf(
 				"skill %q (%s) requires tools %v not granted by this agent's tools — skills cannot widen the agent's tool set",
-				in.Name, source, widening,
+				name, source, widening,
 			),
 		}, nil
 	}
-
 	return tools.Result{Text: body}, nil
+}
+
+// execList enumerates the skills this agent may use — the assembled catalog
+// (static Set + inline skills + the caller's tenant substrate SkillDefs)
+// filtered by the agent's `skills:` allowlist and an optional /-glob pattern.
+func (s *SkillTool) execList(ctx context.Context, policy tools.SkillPolicyValue, pattern string) (tools.Result, error) {
+	catalog := map[string]string{} // name → description
+	if s.Set != nil {
+		for _, n := range s.Set.Names() {
+			desc := ""
+			if sk, ok := s.Set.Get(n); ok {
+				desc = sk.Description
+			}
+			catalog[n] = desc
+		}
+	}
+	if s.Store != nil {
+		if rows, err := s.Store.SkillDefListNames(ctx); err == nil {
+			tid := tools.RunIdentity(ctx).TenantID
+			for _, r := range rows {
+				if r.TenantID != "" && r.TenantID != tid {
+					continue // RFC N: only the caller's tenant + the shared "" base.
+				}
+				if _, ok := catalog[r.Name]; !ok {
+					catalog[r.Name] = ""
+				}
+			}
+		}
+	}
+	type skillEntry struct {
+		Name        string `json:"name"`
+		Description string `json:"description,omitempty"`
+	}
+	out := make([]skillEntry, 0, len(catalog))
+	for n, d := range catalog {
+		if !skillmatch.Allowed(policy.Patterns, n) {
+			continue
+		}
+		if pattern != "" && !skillmatch.Allowed([]string{pattern}, n) {
+			continue
+		}
+		out = append(out, skillEntry{Name: n, Description: d})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return okJSON(map[string]any{"skills": out})
 }
 
 // resolveSkill looks up a skill by name. Returns (body, tools,

--- a/internal/tools/builtin/skill_test.go
+++ b/internal/tools/builtin/skill_test.go
@@ -378,3 +378,118 @@ func TestSkillTool_NoSourcesConfigured(t *testing.T) {
 		t.Errorf("error should also keep the static-path hint for legacy operators, got: %s", res.Text)
 	}
 }
+
+// ---- RFC BA: Skill tool allowlist gating (list + invoke) ----
+
+// listNames decodes a Skill op=list result into the sorted set of skill names.
+func listNames(t *testing.T, res tools.Result) []string {
+	t.Helper()
+	if res.IsError {
+		t.Fatalf("list returned IsError: %s", res.Text)
+	}
+	var out struct {
+		Skills []struct {
+			Name string `json:"name"`
+		} `json:"skills"`
+	}
+	if err := json.Unmarshal([]byte(res.Text), &out); err != nil {
+		t.Fatalf("decode list result %q: %v", res.Text, err)
+	}
+	names := make([]string, 0, len(out.Skills))
+	for _, s := range out.Skills {
+		names = append(names, s.Name)
+	}
+	return names
+}
+
+func groupedSet(t *testing.T) *skills.Set {
+	return loadSetWithSkills(t, []struct {
+		Name  string
+		Tools []string
+		Body  string
+	}{
+		{Name: "doc/redactor", Body: "R"},
+		{Name: "doc/summarizer", Body: "S"},
+		{Name: "marketing/seo", Body: "M"},
+	})
+}
+
+// A whitelist (`skills: [doc/*]`) lists only the matching grouped skills — the
+// catalog ∩ allowlist. Reverting the allowlist filter in execList surfaces
+// marketing/seo, breaking this.
+func TestSkillTool_ListReturnsAllowlistIntersection(t *testing.T) {
+	tool := &SkillTool{Set: groupedSet(t)}
+	ctx := tools.WithSkillPolicy(context.Background(), tools.SkillPolicyValue{Patterns: []string{"doc/*"}})
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"list"}`))
+	got := listNames(t, res)
+	want := []string{"doc/redactor", "doc/summarizer"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("list = %v, want %v (only doc/* permitted)", got, want)
+	}
+}
+
+// A deny-all allowlist (`skills: [-*]`) lists nothing.
+func TestSkillTool_ListDenyAllReturnsEmpty(t *testing.T) {
+	tool := &SkillTool{Set: groupedSet(t)}
+	ctx := tools.WithSkillPolicy(context.Background(), tools.SkillPolicyValue{Patterns: []string{"-*"}})
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"list"}`))
+	if got := listNames(t, res); len(got) != 0 {
+		t.Errorf("list under -* = %v, want empty", got)
+	}
+}
+
+// An empty allowlist (allow all) plus an op=list `pattern` filters to the
+// pattern — catalog ∩ allowlist ∩ pattern.
+func TestSkillTool_ListPatternFilter(t *testing.T) {
+	tool := &SkillTool{Set: groupedSet(t)}
+	ctx := tools.WithSkillPolicy(context.Background(), tools.SkillPolicyValue{}) // allow all
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"list","pattern":"marketing/*"}`))
+	got := listNames(t, res)
+	want := []string{"marketing/seo"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("list pattern=marketing/* = %v, want %v", got, want)
+	}
+}
+
+// Invoke refuses a name outside the agent's allowlist, before resolving/loading
+// its body. Reverting the skillmatch.Allowed gate in execInvoke lets the body
+// through.
+func TestSkillTool_InvokeRefusesNonAllowedName(t *testing.T) {
+	tool := &SkillTool{Set: groupedSet(t)}
+	ctx := tools.WithAgentTools(context.Background(), nil)
+	ctx = tools.WithSkillPolicy(ctx, tools.SkillPolicyValue{Patterns: []string{"doc/*"}})
+
+	// doc/redactor is permitted → loads.
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"name":"doc/redactor"}`))
+	if res.IsError {
+		t.Errorf("doc/redactor is in the allowlist and should load: %s", res.Text)
+	}
+	// marketing/seo is NOT permitted → refused with an allowlist message, even
+	// though it exists in the catalog.
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"name":"marketing/seo"}`))
+	if !res.IsError {
+		t.Errorf("marketing/seo is outside the allowlist and must be refused; got %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "allowlist") {
+		t.Errorf("refusal should mention the allowlist; got %s", res.Text)
+	}
+}
+
+// Back-compat: a bare `{name}` (no op) invokes, and an empty allowlist permits
+// any name — so a pre-RFC-BA caller with no skills: field keeps working.
+func TestSkillTool_InvokeBackCompatEmptyAllowlist(t *testing.T) {
+	tool := &SkillTool{Set: groupedSet(t)}
+	ctx := tools.WithAgentTools(context.Background(), nil)
+	ctx = tools.WithSkillPolicy(ctx, tools.SkillPolicyValue{}) // empty = allow all
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"name":"marketing/seo"}`))
+	if res.IsError {
+		t.Errorf("empty allowlist should permit any name via bare {name}; got %s", res.Text)
+	}
+	if res.Text != "M" {
+		t.Errorf("body = %q, want M", res.Text)
+	}
+}

--- a/internal/tools/builtin/skill_test.go
+++ b/internal/tools/builtin/skill_test.go
@@ -268,7 +268,8 @@ func TestSkillTool_ResolvesDBActiveOverStatic(t *testing.T) {
 	ctx := tools.WithAgentTools(context.Background(), []string{"Read"})
 
 	skillDefTool := &SkillDef{Store: s, Set: set}
-	dctx := tools.WithSkillDefPolicy(ctx, tools.SkillDefPolicyValue{Scopes: []string{"any"}})
+	// RFC BA: an empty allowlist = allow all (create-anywhere), the old ["any"].
+	dctx := tools.WithSkillPolicy(ctx, tools.SkillPolicyValue{})
 	dctx = tools.WithRunIdentity(dctx, tools.RunIdentityValue{AgentID: "a_seed"})
 	res, _ := skillDefTool.Execute(dctx, json.RawMessage(`{"op":"fork","name":"shared-skill","overlay":{"body":"DB BODY"},"promote":true}`))
 	if res.IsError {
@@ -317,7 +318,8 @@ func TestSkillTool_SubstrateOnlyHintsAtAvailable(t *testing.T) {
 	// Seed two skills via SkillDef create + promote. Mirrors the
 	// substrate write path JobEmber uses on first boot.
 	ctx := tools.WithAgentTools(context.Background(), []string{"Read"})
-	dctx := tools.WithSkillDefPolicy(ctx, tools.SkillDefPolicyValue{Scopes: []string{"any"}})
+	// RFC BA: an empty allowlist = allow all (create-anywhere), the old ["any"].
+	dctx := tools.WithSkillPolicy(ctx, tools.SkillPolicyValue{})
 	dctx = tools.WithRunIdentity(dctx, tools.RunIdentityValue{AgentID: "a_seed"})
 	skillDefTool := &SkillDef{Store: store, Set: emptySet}
 	for _, name := range []string{"position-relevance-filtering", "voice-applier"} {

--- a/internal/tools/builtin/skilldef.go
+++ b/internal/tools/builtin/skilldef.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/denn-gubsky/loomcycle/internal/skillmatch"
 	"github.com/denn-gubsky/loomcycle/internal/skills"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
@@ -186,6 +187,11 @@ func (s *SkillDef) execCreate(ctx context.Context, policy tools.SkillDefPolicyVa
 	if in.Name == "" {
 		return errResult("create: missing required field: name"), nil
 	}
+	// RFC BA: enforce the `/`-grouped name grammar (rejects `..`, glob chars,
+	// leading/trailing/double slash) before the allowlist gate + store write.
+	if err := skillmatch.ValidateName(in.Name); err != nil {
+		return errResult(fmt.Sprintf("create: %s", err)), nil
+	}
 	if err := s.checkScopeForName(policy, in.Name, ""); err != nil {
 		return errResult(err.Error()), nil
 	}
@@ -259,6 +265,10 @@ func (s *SkillDef) execCreate(ctx context.Context, policy tools.SkillDefPolicyVa
 func (s *SkillDef) execFork(ctx context.Context, policy tools.SkillDefPolicyValue, in skillDefInput) (tools.Result, error) {
 	if in.Name == "" {
 		return errResult("fork: missing required field: name"), nil
+	}
+	// RFC BA: same `/`-grouped name grammar as create.
+	if err := skillmatch.ValidateName(in.Name); err != nil {
+		return errResult(fmt.Sprintf("fork: %s", err)), nil
 	}
 
 	// Resolve the parent. Three paths, mirroring AgentDef:

--- a/internal/tools/builtin/skilldef.go
+++ b/internal/tools/builtin/skilldef.go
@@ -157,7 +157,7 @@ func (s *SkillDef) Execute(ctx context.Context, raw json.RawMessage) (tools.Resu
 	if err := json.Unmarshal(raw, &in); err != nil {
 		return errResult(fmt.Sprintf("invalid input JSON: %s", err)), nil
 	}
-	policy := tools.SkillDefPolicy(ctx)
+	policy := tools.SkillPolicy(ctx)
 
 	switch in.Op {
 	case "create":
@@ -183,7 +183,7 @@ func (s *SkillDef) Execute(ctx context.Context, raw json.RawMessage) (tools.Resu
 
 // ---- create ----
 
-func (s *SkillDef) execCreate(ctx context.Context, policy tools.SkillDefPolicyValue, in skillDefInput) (tools.Result, error) {
+func (s *SkillDef) execCreate(ctx context.Context, policy tools.SkillPolicyValue, in skillDefInput) (tools.Result, error) {
 	if in.Name == "" {
 		return errResult("create: missing required field: name"), nil
 	}
@@ -262,7 +262,7 @@ func (s *SkillDef) execCreate(ctx context.Context, policy tools.SkillDefPolicyVa
 
 // ---- fork ----
 
-func (s *SkillDef) execFork(ctx context.Context, policy tools.SkillDefPolicyValue, in skillDefInput) (tools.Result, error) {
+func (s *SkillDef) execFork(ctx context.Context, policy tools.SkillPolicyValue, in skillDefInput) (tools.Result, error) {
 	if in.Name == "" {
 		return errResult("fork: missing required field: name"), nil
 	}
@@ -412,7 +412,7 @@ func (s *SkillDef) execFork(ctx context.Context, policy tools.SkillDefPolicyValu
 
 // ---- get / list ----
 
-func (s *SkillDef) execGet(ctx context.Context, policy tools.SkillDefPolicyValue, in skillDefInput) (tools.Result, error) {
+func (s *SkillDef) execGet(ctx context.Context, policy tools.SkillPolicyValue, in skillDefInput) (tools.Result, error) {
 	if in.DefID == "" {
 		return errResult("get: missing required field: def_id"), nil
 	}
@@ -438,7 +438,7 @@ func (s *SkillDef) execGet(ctx context.Context, policy tools.SkillDefPolicyValue
 	return okJSON(skillDefRowResponse(row, false))
 }
 
-func (s *SkillDef) execList(ctx context.Context, policy tools.SkillDefPolicyValue, in skillDefInput) (tools.Result, error) {
+func (s *SkillDef) execList(ctx context.Context, policy tools.SkillPolicyValue, in skillDefInput) (tools.Result, error) {
 	if in.Name == "" {
 		return errResult("list: missing required field: name"), nil
 	}
@@ -465,7 +465,7 @@ func (s *SkillDef) execList(ctx context.Context, policy tools.SkillDefPolicyValu
 
 // ---- retire / promote ----
 
-func (s *SkillDef) execRetire(ctx context.Context, policy tools.SkillDefPolicyValue, in skillDefInput) (tools.Result, error) {
+func (s *SkillDef) execRetire(ctx context.Context, policy tools.SkillPolicyValue, in skillDefInput) (tools.Result, error) {
 	if in.DefID == "" {
 		return errResult("retire: missing required field: def_id"), nil
 	}
@@ -495,7 +495,7 @@ func (s *SkillDef) execRetire(ctx context.Context, policy tools.SkillDefPolicyVa
 	return okJSON(map[string]any{"def_id": in.DefID, "retired": *in.Retired})
 }
 
-func (s *SkillDef) execPromote(ctx context.Context, policy tools.SkillDefPolicyValue, in skillDefInput) (tools.Result, error) {
+func (s *SkillDef) execPromote(ctx context.Context, policy tools.SkillPolicyValue, in skillDefInput) (tools.Result, error) {
 	if in.DefID == "" {
 		return errResult("promote: missing required field: def_id"), nil
 	}
@@ -524,7 +524,7 @@ func (s *SkillDef) execPromote(ctx context.Context, policy tools.SkillDefPolicyV
 // execVerify — see agentdef.go execVerify for full doc. Same shape
 // for skills: caller passes name + content_sha256 from a local
 // hash, tool reads the active row + answers matches.
-func (s *SkillDef) execVerify(ctx context.Context, policy tools.SkillDefPolicyValue, in skillDefInput) (tools.Result, error) {
+func (s *SkillDef) execVerify(ctx context.Context, policy tools.SkillPolicyValue, in skillDefInput) (tools.Result, error) {
 	if in.Name == "" {
 		return errResult("verify: missing required field: name"), nil
 	}
@@ -559,32 +559,17 @@ func (s *SkillDef) execVerify(ctx context.Context, policy tools.SkillDefPolicyVa
 
 // ---- helpers ----
 
-// checkScopeForName enforces the agent's skill_def_scopes against a
-// proposed (name, def_id) target. Default-deny when policy.Scopes
-// is empty. Same shape as AgentDef.checkScopeForName minus the
-// "self" branch.
-func (s *SkillDef) checkScopeForName(policy tools.SkillDefPolicyValue, name, _ string) error {
-	if len(policy.Scopes) == 0 {
-		return fmt.Errorf("SkillDef tool: agent has no skill_def_scopes (default-deny); add `skill_def_scopes: [...]` to the agent yaml")
+// checkScopeForName enforces the agent's RFC BA `skills:` pattern allowlist
+// against a proposed skill name (used by create/fork/get/list/retire/promote/
+// verify). Empty allowlist = ALLOW (the RFC BA default: create-anywhere /
+// list-all); `-*` denies everything; a whitelist permits only matching names.
+// Authoring additionally requires the agent to hold the SkillDef tool + the
+// tools ⊆ subset check (assertToolsSubset).
+func (s *SkillDef) checkScopeForName(policy tools.SkillPolicyValue, name, _ string) error {
+	if skillmatch.Allowed(policy.Patterns, name) {
+		return nil
 	}
-	for _, sc := range policy.Scopes {
-		switch sc {
-		case "any":
-			return nil
-		case "descendants":
-			// KNOWN GAP (TODO v0.9.x): equivalent to "any" pending
-			// lineage-walk implementation. Mirror of the AgentDef
-			// caveat — same defer for the same reason.
-			return nil
-		default:
-			if strings.HasPrefix(sc, "named:") {
-				if strings.TrimPrefix(sc, "named:") == name {
-					return nil
-				}
-			}
-		}
-	}
-	return fmt.Errorf("SkillDef tool: name %q not in this agent's skill_def_scopes (%v)", name, policy.Scopes)
+	return fmt.Errorf("SkillDef tool: skill %q is not permitted by this agent's `skills:` allowlist (%v)", name, policy.Patterns)
 }
 
 // buildDefinition takes the base definition (parent's JSON for

--- a/internal/tools/builtin/skilldef_test.go
+++ b/internal/tools/builtin/skilldef_test.go
@@ -12,8 +12,9 @@ import (
 
 // skillDefFixture builds a SkillDef tool over in-memory SQLite +
 // a skills.Set with one static skill ("karpathy-guidelines"). The
-// ctx carries a permissive policy (scopes=["any"]); per-test code
-// overrides for scope-specific cases.
+// ctx carries a permissive RFC BA allowlist (empty patterns = allow
+// all — create-anywhere); per-test code overrides for allowlist-
+// specific cases.
 func skillDefFixture(t *testing.T) (*SkillDef, context.Context, func()) {
 	t.Helper()
 	s, err := sqlite.Open(":memory:")
@@ -36,7 +37,7 @@ func skillDefFixture(t *testing.T) (*SkillDef, context.Context, func()) {
 	ctx := tools.WithAgentName(context.Background(), "researcher")
 	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a_test"})
 	ctx = tools.WithAgentTools(ctx, []string{"Read", "WebFetch", "SkillDef"})
-	ctx = tools.WithSkillDefPolicy(ctx, tools.SkillDefPolicyValue{Scopes: []string{"any"}})
+	ctx = tools.WithSkillPolicy(ctx, tools.SkillPolicyValue{}) // empty = allow all
 	return tool, ctx, func() { _ = s.Close() }
 }
 
@@ -138,61 +139,90 @@ func TestSkillDefTool_ToolsCannotWiden(t *testing.T) {
 	}
 }
 
-func TestSkillDefTool_ScopeNamedGrant(t *testing.T) {
+// RFC BA: a WHITELIST allowlist (a positive pattern) permits only matching
+// names. Authoring the whitelisted name is allowed; a non-matching name is
+// refused. Replaces the old exact `named:` scope grant.
+func TestSkillDefTool_WhitelistGrant(t *testing.T) {
 	tool, _, cleanup := skillDefFixture(t)
 	defer cleanup()
 
-	// Override the policy: only named:karpathy-guidelines.
+	// Whitelist exactly karpathy-guidelines.
 	ctx := tools.WithAgentName(context.Background(), "researcher")
 	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a_test"})
 	ctx = tools.WithAgentTools(ctx, []string{"Read", "WebFetch"})
-	ctx = tools.WithSkillDefPolicy(ctx, tools.SkillDefPolicyValue{Scopes: []string{"named:karpathy-guidelines"}})
+	ctx = tools.WithSkillPolicy(ctx, tools.SkillPolicyValue{Patterns: []string{"karpathy-guidelines"}})
 
-	// In-scope: fork the named skill.
+	// In-allowlist: fork the whitelisted skill.
 	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"fork","name":"karpathy-guidelines","overlay":{"body":"forked"}}`))
 	if res.IsError {
-		t.Errorf("named scope grant should permit; got %s", res.Text)
+		t.Errorf("whitelist should permit the matching name; got %s", res.Text)
 	}
-	// Out of scope: create a new name.
+	// Out of allowlist: create a non-matching name.
 	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"different-skill","overlay":{"body":"x"}}`))
 	if !res.IsError {
-		t.Errorf("named scope should deny different name; got %s", res.Text)
+		t.Errorf("whitelist should deny a non-matching name; got %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "allowlist") {
+		t.Errorf("refusal should mention the allowlist; got %s", res.Text)
 	}
 }
 
-func TestSkillDefTool_DefaultDenyWithNoScopes(t *testing.T) {
+// RFC BA: a glob whitelist (`doc/*`) permits only matching grouped names.
+func TestSkillDefTool_WhitelistGlobGrant(t *testing.T) {
 	tool, _, cleanup := skillDefFixture(t)
 	defer cleanup()
 
-	// ctx WITHOUT WithSkillDefPolicy → empty scopes → default-deny.
+	ctx := tools.WithAgentName(context.Background(), "researcher")
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a_test"})
+	ctx = tools.WithAgentTools(ctx, []string{"Read"})
+	ctx = tools.WithSkillPolicy(ctx, tools.SkillPolicyValue{Patterns: []string{"doc/*"}})
+
+	// Matching group → create allowed.
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"doc/summarizer","overlay":{"body":"x"}}`))
+	if res.IsError {
+		t.Errorf("doc/* should permit doc/summarizer; got %s", res.Text)
+	}
+	// Different group → refused.
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"marketing/seo","overlay":{"body":"x"}}`))
+	if !res.IsError {
+		t.Errorf("doc/* should deny marketing/seo; got %s", res.Text)
+	}
+}
+
+// RFC BA: an EMPTY allowlist = allow all (create-anywhere) — the inverse of the
+// old default-deny-when-no-scopes behaviour. This is the documented default so
+// an agent with no `skills:` field can still author.
+func TestSkillDefTool_NoPolicyAllowsCreate(t *testing.T) {
+	tool, _, cleanup := skillDefFixture(t)
+	defer cleanup()
+
+	// ctx WITHOUT WithSkillPolicy → zero-value policy → empty patterns → allow.
 	ctx := tools.WithAgentName(context.Background(), "researcher")
 	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a_test"})
 	ctx = tools.WithAgentTools(ctx, []string{"Read"})
 
 	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"any-skill","overlay":{"body":"x"}}`))
-	if !res.IsError {
-		t.Fatalf("no scopes should refuse; got %s", res.Text)
-	}
-	if !strings.Contains(res.Text, "default-deny") {
-		t.Errorf("refusal should mention default-deny; got %s", res.Text)
+	if res.IsError {
+		t.Fatalf("empty allowlist should allow create-anywhere; got %s", res.Text)
 	}
 }
 
-func TestSkillDefTool_DescendantsScopeIsCurrentlyEquivalentToAny(t *testing.T) {
+// RFC BA: `skills: [-*]` denies EVERY name, so no authoring is permitted.
+func TestSkillDefTool_DenyAllRefusesCreate(t *testing.T) {
 	tool, _, cleanup := skillDefFixture(t)
 	defer cleanup()
 
-	// "descendants" is documented as equivalent to "any" pending
-	// lineage-walk implementation (TODO v0.9.x). Pin the current
-	// behaviour so a future tightening doesn't accidentally regress.
 	ctx := tools.WithAgentName(context.Background(), "researcher")
 	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a_test"})
-	ctx = tools.WithAgentTools(ctx, []string{"Read", "WebFetch"})
-	ctx = tools.WithSkillDefPolicy(ctx, tools.SkillDefPolicyValue{Scopes: []string{"descendants"}})
+	ctx = tools.WithAgentTools(ctx, []string{"Read"})
+	ctx = tools.WithSkillPolicy(ctx, tools.SkillPolicyValue{Patterns: []string{"-*"}})
 
-	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"unrelated-skill","overlay":{"body":"x"}}`))
-	if res.IsError {
-		t.Errorf("descendants scope should grant (currently == any); got %s", res.Text)
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"any-skill","overlay":{"body":"x"}}`))
+	if !res.IsError {
+		t.Fatalf("`-*` deny-all should refuse create; got %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "allowlist") {
+		t.Errorf("refusal should mention the allowlist; got %s", res.Text)
 	}
 }
 

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -1180,34 +1180,29 @@ func OperatorTokenDefPolicy(ctx context.Context) OperatorTokenDefPolicyValue {
 	return v
 }
 
-// ctxKeySkillDefPolicy carries the v0.8.22 SkillDef-tool capability
-// gate. Mirrors AgentDefPolicy shape, sans the SelfName field —
-// skills have no agent identity so a "self" scope is meaningless.
-type ctxKeySkillDefPolicy struct{}
+// ctxKeySkillPolicy carries the RFC BA per-agent skill access policy — the
+// agent's `skills:` pattern allowlist, governing skill listing, use (Skill
+// invoke), and authoring (SkillDef create/fork/list/get) uniformly.
+type ctxKeySkillPolicy struct{}
 
-// SkillDefPolicyValue is the per-agent SkillDef-tool access policy.
+// SkillPolicyValue is the per-agent skill access policy (RFC BA).
 //
-//   - Scopes is the operator-yaml skill_def_scopes list. Closed set:
-//     "any" / "descendants" / "named:<skill-name>". Empty =
-//     default-deny.
-//
-// `descendants` is reserved for symmetry with AgentDefPolicy and
-// currently behaves equivalent to "any" pending lineage-walk
-// implementation (same v0.9.x TODO as AgentDef).
-type SkillDefPolicyValue struct {
-	Scopes []string
+//   - Patterns is the operator-yaml `skills:` pattern allowlist evaluated by
+//     internal/skillmatch (`doc/*`/`+doc/*` allow, `-doc/*`/`-*` deny). Empty =
+//     allow ALL (the RFC BA default); `-*` = deny all.
+type SkillPolicyValue struct {
+	Patterns []string
 }
 
-// WithSkillDefPolicy attaches the policy to ctx.
-func WithSkillDefPolicy(ctx context.Context, p SkillDefPolicyValue) context.Context {
-	return context.WithValue(ctx, ctxKeySkillDefPolicy{}, p)
+// WithSkillPolicy attaches the policy to ctx.
+func WithSkillPolicy(ctx context.Context, p SkillPolicyValue) context.Context {
+	return context.WithValue(ctx, ctxKeySkillPolicy{}, p)
 }
 
-// SkillDefPolicy returns the policy from ctx. Zero value = no
-// access (default-deny — the tool refuses every mutation op until
-// scopes are explicitly granted via yaml).
-func SkillDefPolicy(ctx context.Context) SkillDefPolicyValue {
-	v, _ := ctx.Value(ctxKeySkillDefPolicy{}).(SkillDefPolicyValue)
+// SkillPolicy returns the policy from ctx. Zero value (nil Patterns) = allow
+// all — the RFC BA default when nothing was stamped (open mode / admin paths).
+func SkillPolicy(ctx context.Context) SkillPolicyValue {
+	v, _ := ctx.Value(ctxKeySkillPolicy{}).(SkillPolicyValue)
 	return v
 }
 

--- a/packages/library/src/components/LibraryEditModal.tsx
+++ b/packages/library/src/components/LibraryEditModal.tsx
@@ -929,7 +929,9 @@ function AgentFields(props: AgentFieldsProps) {
         <label htmlFor="lib-skills">
           skills
           <span className="library-modal-field-hint">
-            {" "}— comma-separated skill names to bake into system_prompt
+            {" "}— pattern allowlist for on-demand skills (governs list / use /
+            author): e.g. <code>doc/*</code> allows only doc/* skills,{" "}
+            <code>-*</code> forbids all. Empty = allow all.
           </span>
         </label>
         <input
@@ -938,7 +940,7 @@ function AgentFields(props: AgentFieldsProps) {
           value={props.agentSkills}
           onChange={(e) => props.setAgentSkills(e.target.value)}
           disabled={props.submitting}
-          placeholder="briefing-format, citation-style"
+          placeholder="doc/*, -doc/secret"
         />
       </div>
 


### PR DESCRIPTION
Implements **RFC BA** — closes three Skill/SkillDef gaps: no discovery, no grouping namespace, no per-agent limit on skill *use*. Also shifts skills from **bundled-into-the-prompt** to **on-demand via the `Skill` tool** (small prompt). ⚠️ **Breaking** — see below.

## What changed
1. **`/`-grouped names** — `doc/redactor`, `marketing/seo`. Nested `SkillsRoot` dirs (`SkillsRoot/doc/redactor/SKILL.md`), plus name-grammar validation. `internal/skillmatch` is a new ordered `+`/`-` allowlist evaluator over `/`-globs.
2. **`Skill` tool `list` op** — `{op:"list", pattern?}` returns the agent-visible catalog (SkillsRoot + inline `skills:` + tenant substrate) ∩ the agent's allowlist ∩ pattern. `{name}` (no op) still invokes (back-compat).
3. **`skills:` is now a pattern allowlist** (was an exact-name bundle list) governing **list + use + create**: `doc/*`/`+doc/*` allow, `-doc/*`/`-*` deny; empty = allow all; whitelist vs blacklist mode. Kept **out of `content_sha256`** (authority ≠ content).
4. **On-demand model** — skill bodies are no longer concatenated into the system prompt. The `Skill` tool is **auto-added to every agent that may use a skill** (incl. no `skills:` field = the default), skipped only for `skills:[-*]`; a whitelist gets a short run-start note. Inline `skills:` yaml is merged into the runtime set so it's invokable/listable.
5. **Unified authoring** — the `skills:` allowlist gates SkillDef create/fork/list/get; **`skill_def_scopes` is removed** (config-load rejects it with a migration message). Authoring still requires the `SkillDef` tool + tools ⊆ subset.

## ⚠️ Breaking (pre-production clean cutover)
- `skills:` semantics change (bundle list → pattern allowlist) and it leaves the content hash.
- `skill_def_scopes` removed → config-load error; re-express as `skills:` patterns.
- Skill bodies are no longer bundled — agents load them on demand (the auto-added `Skill` tool + note preserve access).
- `document-agent` bundle updated for on-demand.

## Tested
- `go build`/`go vet`/`go test ./...` — **all clean** (79 pkgs, 0 failures). Fail-before-verified: config reject, hash-exclusion, invoke gate.
- **E2E** (booted binary, nested SkillsRoot): grouped names load (`doc/redactor`, `marketing/seo`); `Skill` tool auto-added to `skills:[doc/*]` **and** a no-`skills:` agent; `skill_def_scopes` config rejected with the migration error.
- Enforcement coverage verified: `WithSkillPolicy` stamped at every run-loop entry.

## Security-review note
The `SkillPolicy` zero-value = allow-all is a deliberate default-deny→default-allow flip — the RFC decision ("empty = all / create-anywhere", gated by holding the `SkillDef` tool). Full stamping coverage means an agent's `skills:` restriction is never bypassed on a run path.

## Follow-ups (doc-only)
`adapters/ts/README.md` has a stale `skill_def_scopes` mention → next adapter-doc pass. Adapters/MCP wire shape unchanged (Skill is an in-loop tool; `skills` stays `string[]`, only its meaning changed).

RFC BA recorded in loomcycle-internal. Coordinated breaking release; next tag decided at release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)