### PR TITLE
feat(help): add the `skills` help topic + forgiving topic lookup

### DIFF
--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1336,7 +1336,8 @@ func (s *Server) resolveSkillBodiesForRun(_ context.Context, _ string, agentDef 
 		allow = append(allow, strings.TrimPrefix(t, "+"))
 	}
 	note := "Skills available on demand (matching: " + strings.Join(allow, ", ") +
-		"). Use the `Skill` tool: `{\"op\":\"list\"}` to discover them (optional `pattern`), `{\"name\":\"<skill>\"}` to load one into context."
+		"). Use the `Skill` tool: `{\"op\":\"list\"}` to discover them (optional `pattern`), `{\"name\":\"<skill>\"}` to load one into context. " +
+		"For how skills work, call `Context` `{\"op\":\"help\",\"topic\":\"skills\"}`."
 	rebuilt := agentDef
 	if rebuilt.SystemPrompt != "" {
 		rebuilt.SystemPrompt += "\n\n---\n\n"

--- a/internal/help/builtin/skills-evolution.md
+++ b/internal/help/builtin/skills-evolution.md
@@ -108,6 +108,9 @@ allows the whole `doc/` group, `-doc/secret` carves one out.
 
 ## Cross-references
 
+- `help(topic="skills")` — how to USE skills (the `Skill` tool:
+  discover + load on demand + the `skills:` allowlist). Start there
+  if you just want to run a skill, not author one.
 - `help(topic="experimentation")` — the AgentDef + Evaluation
   cousin for whole-agent evolution.
 - `help(topic="scopes")` — agent vs user scope across Memory +

--- a/internal/help/builtin/skills.md
+++ b/internal/help/builtin/skills.md
@@ -1,0 +1,96 @@
+---
+name: skills
+description: "The Skill tool — discover and load domain-specific instruction sets on demand, governed by the agent's skills: pattern allowlist (RFC BA)."
+aliases: [skill]
+---
+A **skill** is a named, reusable block of instructions (a `SKILL.md`
+body) you load into context **only when you need it**. Since RFC BA
+skills are **on demand** — they are NOT baked into your system prompt.
+You hold the `Skill` tool; you call it to discover what's available
+and to pull a skill's body in as a `tool_result` at the moment it's
+relevant. This keeps the base prompt small and lets one agent carry a
+large library it uses a slice of per run.
+
+If you have the `Skill` tool, you use skills through it. There is no
+other step.
+
+## The two operations
+
+```
+{"op":"list"}                 discover the skills you may use.
+{"op":"list","pattern":"doc/*"}  ...filtered by a /-glob.
+{"op":"invoke","name":"doc/redactor"}  load a skill's body.
+{"name":"doc/redactor"}       shorthand — op defaults to invoke.
+```
+
+- **`list`** returns `[{name, description}]` for every skill visible to
+  you (the catalog ∩ your allowlist ∩ the optional `pattern`), sorted.
+  Start here when you don't know the exact name.
+- **`invoke`** (the default when you pass only `name`) returns the
+  skill's markdown body. Read it, then act on it — the body is
+  guidance for the current task, not something you echo back.
+
+## What you may access — the `skills:` allowlist
+
+Each agent has a `skills:` field: an **ordered pattern allowlist** that
+governs listing, use (invoke), AND authoring (see below) uniformly.
+Entries are `/`-globs with an optional sign:
+
+```
+doc/*          allow the whole doc/ group (one segment)
+marketing/**   allow doc/ and all nested groups (many segments)
+seo            allow exactly the skill named "seo"
+-doc/secret    deny one name (carve-out)
+-*             deny everything (no skills at all)
+```
+
+Evaluation: if any **positive** entry is present it's a whitelist —
+a name is allowed iff it matches ≥1 positive and no negative. With
+only negatives it's a blacklist — allowed unless a negative matches.
+**Empty or absent `skills:` = allow all** (and the `Skill` tool is
+still auto-added, so on-demand access is the default). `-*` = nothing,
+and then the `Skill` tool is not added at all.
+
+`Context op=permissions` shows the effective `skills` allowlist for
+the calling agent, so you can see your own limits.
+
+## Grouping with `/`
+
+Skill names may be `/`-grouped — `doc/semantic-chunking`,
+`marketing/seo`. A group is just a name prefix; `skills: [doc/*]`
+admits the whole `doc/` domain and picks up any new `doc/…` skill
+without restating names. Nested `LOOMCYCLE_SKILLS_ROOT` directories
+map to grouped names (`SkillsRoot/doc/redactor/SKILL.md` →
+`doc/redactor`).
+
+## The tools-subset rule
+
+A skill declares its own `tools:` — the tool ceiling for work done
+under it. That set must be a **subset** of your effective `tools`.
+A skill can narrow, never widen. If a skill needs a tool you don't
+hold, the invoke is refused (surfaced as `is_error`) — request the
+tool from the operator, or use a different skill.
+
+## The run-start note
+
+When your `skills:` is a whitelist, a short note is appended to your
+prompt at run start naming the permitted patterns and telling you to
+call the `Skill` tool. For the allow-all / blacklist cases there's no
+note — you still have the `Skill` tool; call `{"op":"list"}` to see
+what's there.
+
+## Authoring skills
+
+Creating or revising a skill body at runtime is a separate tool,
+`SkillDef`, gated by the **same** `skills:` allowlist (you may author
+only names your allowlist admits; `-*` = author nothing) and requiring
+you to also hold the `SkillDef` tool. See `help(topic="skills-evolution")`
+for the create / fork / promote loop.
+
+## Cross-references
+
+- `help(topic="skills-evolution")` — author + version skill bodies at
+  runtime (the `SkillDef` substrate).
+- `help(topic="scopes")` — agent vs user vs tenant scope.
+- `Context op=permissions` — your effective `skills` allowlist + tools.
+- `Context op=tools` — confirm you actually hold the `Skill` tool.

--- a/internal/help/loader.go
+++ b/internal/help/loader.go
@@ -56,21 +56,67 @@ type Topic struct {
 	// Path is the absolute path of the source .md for filesystem
 	// topics; empty for bundled.
 	Path string
+	// Aliases are extra lookup names that resolve to this topic
+	// (frontmatter `aliases:`). Lets a topic be found under the
+	// tool's own name when they differ — e.g. the `skills` topic
+	// aliased as `skill` so an agent probing `topic=Skill` (the
+	// Skill tool's name) resolves it. Canonical names always win
+	// over an alias.
+	Aliases []string
 }
 
 // Set is a name→Topic registry.
 type Set struct {
+	// topics is the canonical name→Topic map (case as authored),
+	// the source of truth for Names()/All() and override semantics.
 	topics map[string]*Topic
+	// index is a case-insensitive lookup over canonical names AND
+	// aliases (both lowercased), built once after load. Used only
+	// by Get for forgiving resolution; never iterated for listing.
+	index map[string]*Topic
 }
 
 // Get returns the named topic, or (nil, false) if absent. Safe on
-// nil receiver.
+// nil receiver. Resolution: exact canonical match first (fast path,
+// preserves historical behaviour), then a case-insensitive lookup
+// over canonical names and aliases — so `Skill`, `skill`, `Skills`
+// all resolve the `skills` topic.
 func (s *Set) Get(name string) (*Topic, bool) {
 	if s == nil {
 		return nil, false
 	}
-	t, ok := s.topics[name]
-	return t, ok
+	if t, ok := s.topics[name]; ok {
+		return t, true
+	}
+	if t, ok := s.index[strings.ToLower(strings.TrimSpace(name))]; ok {
+		return t, true
+	}
+	return nil, false
+}
+
+// reindex rebuilds the case-insensitive alias index from topics.
+// Called at the end of LoadSet, after any filesystem overlay, so
+// the index reflects the final topic set. Canonical names take
+// precedence over aliases (an alias never shadows a real topic).
+func (s *Set) reindex() {
+	idx := make(map[string]*Topic, len(s.topics)*2)
+	// Canonical names first so they win on any collision.
+	for name, t := range s.topics {
+		idx[strings.ToLower(name)] = t
+	}
+	for _, t := range s.topics {
+		for _, a := range t.Aliases {
+			key := strings.ToLower(strings.TrimSpace(a))
+			if key == "" {
+				continue
+			}
+			if _, taken := idx[key]; taken {
+				continue // don't let an alias shadow a canonical name
+			}
+			idx[key] = t
+		}
+	}
+	s.index = idx
 }
 
 // Names returns all topic names sorted lexicographically. Used by
@@ -153,6 +199,7 @@ func LoadSet(root string) (*Set, error) {
 
 	// Optionally overlay filesystem topics.
 	if root == "" {
+		set.reindex()
 		return set, nil
 	}
 	st, err := os.Stat(root)
@@ -204,6 +251,7 @@ func LoadSet(root string) (*Set, error) {
 		t.Source = "filesystem"
 		set.topics[t.Name] = t // override bundled if name matches
 	}
+	set.reindex()
 	return set, nil
 }
 
@@ -240,8 +288,9 @@ func parseTopic(data []byte, nameFromFile, path string) (*Topic, error) {
 	}
 
 	var fm struct {
-		Name        string `yaml:"name"`
-		Description string `yaml:"description"`
+		Name        string   `yaml:"name"`
+		Description string   `yaml:"description"`
+		Aliases     []string `yaml:"aliases"`
 	}
 	if err := yaml.Unmarshal([]byte(fmText), &fm); err != nil {
 		return nil, fmt.Errorf("frontmatter yaml: %w", err)
@@ -260,5 +309,6 @@ func parseTopic(data []byte, nameFromFile, path string) (*Topic, error) {
 		Description: fm.Description,
 		Content:     body,
 		Path:        path,
+		Aliases:     fm.Aliases,
 	}, nil
 }

--- a/internal/help/loader_test.go
+++ b/internal/help/loader_test.go
@@ -49,6 +49,7 @@ func TestLoadSet_BundledOnly(t *testing.T) {
 		"path",
 		"pause-resume-snapshot",
 		"scopes",
+		"skills",
 		"skills-evolution",
 		"sqlite-vec",
 		"subagents",
@@ -77,6 +78,64 @@ func TestLoadSet_BundledOnly(t *testing.T) {
 		if topic.Path != "" {
 			t.Errorf("bundled topic %q has Path=%q, want empty", n, topic.Path)
 		}
+	}
+}
+
+// TestGet_SkillsCaseInsensitiveAndAlias: RFC BA gave every agent the
+// `Skill` tool on demand, so agents probe `Context op=help topic=Skill`
+// (the tool's own name). Get must resolve the `skills` topic under the
+// tool name, any case, and the `skill` alias — the reported gap was
+// `topic="Skill"` → "not found".
+func TestGet_SkillsCaseInsensitiveAndAlias(t *testing.T) {
+	set, err := LoadSet("")
+	if err != nil {
+		t.Fatalf("LoadSet: %v", err)
+	}
+	for _, q := range []string{"skills", "Skills", "SKILLS", "Skill", "skill", " skill "} {
+		topic, ok := set.Get(q)
+		if !ok {
+			t.Errorf("Get(%q) not found; want the skills topic", q)
+			continue
+		}
+		if topic.Name != "skills" {
+			t.Errorf("Get(%q) resolved %q, want canonical \"skills\"", q, topic.Name)
+		}
+	}
+	// A miss is still a miss (the forgiving lookup must not become a
+	// fuzzy match that resolves anything).
+	if _, ok := set.Get("skillz"); ok {
+		t.Error("Get(\"skillz\") resolved; forgiving lookup must not fuzzy-match")
+	}
+	// An exact canonical name with a hyphen is unaffected.
+	if _, ok := set.Get("skills-evolution"); !ok {
+		t.Error("Get(\"skills-evolution\") should still resolve exactly")
+	}
+}
+
+// TestGet_AliasCanonicalPrecedence: an operator topic whose alias
+// collides with a real canonical name must NOT shadow that topic —
+// canonical always wins.
+func TestGet_AliasCanonicalPrecedence(t *testing.T) {
+	dir := t.TempDir()
+	// Alias `scopes` (a bundled canonical name) from a different topic.
+	body := "---\nname: shadower\ndescription: tries to hijack `scopes`.\naliases: [scopes]\n---\nbody\n"
+	if err := os.WriteFile(filepath.Join(dir, "shadower.md"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	set, err := LoadSet(dir)
+	if err != nil {
+		t.Fatalf("LoadSet: %v", err)
+	}
+	topic, ok := set.Get("scopes")
+	if !ok {
+		t.Fatal("Get(\"scopes\") not found")
+	}
+	if topic.Name != "scopes" {
+		t.Errorf("Get(\"scopes\") resolved %q — an alias shadowed the canonical topic", topic.Name)
+	}
+	// The aliasing topic still resolves under its own name.
+	if _, ok := set.Get("shadower"); !ok {
+		t.Error("Get(\"shadower\") should resolve its own canonical name")
 	}
 }
 

--- a/internal/tools/builtin/skill.go
+++ b/internal/tools/builtin/skill.go
@@ -83,7 +83,8 @@ const skillInputSchema = `{
 const skillDescription = `Discover and load domain-specific instruction sets (skills) on demand. ` +
 	`op=list enumerates the skills you may use (optionally filtered by a /-glob pattern); ` +
 	`op=invoke (the default when only a name is given) loads a named skill's body as the tool_result. ` +
-	`Skills you may access are governed by the agent's skills: allowlist; a skill's tools must be a subset of yours (refusals are surfaced as is_error).`
+	`Skills you may access are governed by the agent's skills: allowlist; a skill's tools must be a subset of yours (refusals are surfaced as is_error). ` +
+	`Full guide (on-demand model, skills: allowlist, /-grouping, authoring): call Context op=help topic=skills.`
 
 type skillInput struct {
 	Op      string `json:"op"`


### PR DESCRIPTION
## Why

RFC BA (v1.14.0) made skills **on demand**: every agent gets the `Skill` tool auto-added and loads skill bodies through it, with a `skills:` pattern allowlist governing list / use / author. But there was **no help topic for it** — an agent (or operator) doing `Context op=help topic=Skill` got:

```
help: topic "Skill" not found (available: …, skills-evolution, …)
```

So an agent handed the `Skill` tool had no way to learn how to use it. The adjacent `skills-evolution` topic covers only *authoring* (the `SkillDef` substrate), not *using* the tool. Reported directly:

> There is no Skill topic in the context help and agents have no idea how to use it.

## What

Three-part fix:

1. **New bundled topic `skills`** (`internal/help/builtin/skills.md`) — the on-demand model, `op=list` / `op=invoke` (+ the `{name}` shorthand), the `skills:` allowlist grammar (whitelist/blacklist, `/`-globs, `-*`, empty=all), `/`-grouping, the tools-subset rule, and the run-start note; cross-links to `skills-evolution` for authoring.

2. **Forgiving topic lookup** so the *reported* query resolves, not just a differently-spelled one. `help.Set.Get` keeps its exact-match fast path, then falls back to a case-insensitive index over canonical names **and** a new frontmatter `aliases:` field. `skills` is aliased `[skill]`, so `Skill` (the tool's own name), `skill`, `Skills`, `SKILLS` all resolve it. Canonical names always win over an alias — an operator alias can't shadow a real topic.

3. **Point agents at it from what they actually read** — the `Skill` tool's description now ends with `call Context op=help topic=skills`, and the RFC BA whitelist run-start note appends the same pointer. This is transport-agnostic (HTTP / gRPC / MCP all dispatch to the same `Context` builtin), so the MCP `context` tool the report came from is covered.

## What was tested

- `go test ./...` — clean.
- New regression tests (`internal/help/loader_test.go`): `Get` resolves `Skill` / `skill` / `Skills` / `SKILLS` / `" skill "` to canonical `skills`; a genuine miss still misses (the forgiving lookup is **not** a fuzzy match); an alias can't shadow a canonical name; `skills` added to the bundled-topic sentinel list.
- Smoke on the real embedded content: `help.LoadSet("").Get("Skill")` → `name="skills"` (the exact reported call, now resolving).

🤖 Generated with [Claude Code](https://claude.com/claude-code)