### PR TITLE
feat(search): first-class search providers — connector + fallback circuit (RFC BB Phase 1)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -64,6 +64,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/providers/ollama"
 	"github.com/denn-gubsky/loomcycle/internal/providers/openai"
 	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
+	"github.com/denn-gubsky/loomcycle/internal/search"
 	// Deterministic stub embedder for runtime tests; its init() registers the
 	// "stub" provider ONLY when LOOMCYCLE_EMBEDDER_STUB=1, so it is invisible
 	// to a production binary that never sets the flag.
@@ -766,6 +767,11 @@ func main() {
 		log.Printf("user_tiers: configured %d — %s", len(names), strings.Join(names, " / "))
 	}
 
+	// RFC BB: build the search-provider registry + resolver + operator host-key
+	// map for the WebSearch fallback circuit. Nil (no providers configured, and
+	// no BRAVE_API_KEY back-compat default) → WebSearch refuses "not configured".
+	searchRegistry, searchResolver, searchHostKeys := buildSearchProviders(cfg)
+
 	allTools := []tools.Tool{
 		// The file/exec tools resolve their sandbox root per-call from the
 		// run's VolumePolicy (RFC AH); an agent bound to no volume is refused
@@ -779,7 +785,7 @@ func main() {
 		&builtin.NotebookEdit{},
 		httpTool,
 		&builtin.WebFetch{HTTP: httpTool},
-		&builtin.WebSearch{APIKey: cfg.Env.BraveAPIKey},
+		&builtin.WebSearch{Registry: searchRegistry, Resolver: searchResolver, HostKeys: searchHostKeys},
 		&builtin.Bash{Enabled: cfg.Env.BashEnabled},
 		// Bashbox — a TRUE in-process sandbox (gbash): no OS process, paths
 		// rooted at the volume, no network, and read-only volumes are honored
@@ -990,8 +996,10 @@ func main() {
 	if len(cfg.Env.HTTPPrivateHostAllowlist) > 0 {
 		log.Printf("note: HTTP_PRIVATE_HOST_ALLOWLIST=%v — these hosts may resolve to private IPs (e.g. localhost callbacks)", cfg.Env.HTTPPrivateHostAllowlist)
 	}
-	if cfg.Env.BraveAPIKey == "" {
-		log.Printf("note: WebSearch tool is registered but disabled — set BRAVE_API_KEY to enable")
+	if searchRegistry == nil {
+		log.Printf("note: WebSearch tool is registered but disabled — configure search_providers (or set BRAVE_API_KEY for the default Brave provider)")
+	} else {
+		log.Printf("search: %d provider(s) configured; priority %v", len(searchRegistry.IDs()), searchResolver.Cascade(nil))
 	}
 	if cfg.Env.BashEnabled {
 		log.Printf("WARNING: Bash tool is enabled (LOOMCYCLE_BASH_ENABLED=1). This is NOT a true sandbox — run loomcycle inside a container or VM if you expose this to untrusted prompts.")
@@ -3484,4 +3492,49 @@ func bootstrapMemoryEntries(ctx context.Context, cfg *config.Config, st store.St
 	}
 	log.Printf("memory.entries: bootstrap complete — loaded=%d skipped=%d failed=%d elapsed=%s",
 		loaded, skipped, failed, time.Since(t0).Round(time.Millisecond))
+}
+
+// buildSearchProviders assembles the RFC BB search catalog from config: the
+// provider registry, the fallback resolver (explicit search_priority, else the
+// enabled set sorted for determinism), and the operator host-key map. Returns
+// (nil, nil, nil) when no providers are configured — WebSearch then refuses with
+// "not configured". config.Validate has already checked the enabled set, so a
+// BuildRegistry error here is a bug (logged, WebSearch disabled).
+//
+// Back-compat: pre-RFC-BB, WebSearch worked on BRAVE_API_KEY alone. With no
+// explicit search_providers, default to a single Brave provider when its key is
+// set so existing deployments keep working with no config change.
+func buildSearchProviders(cfg *config.Config) (*search.Registry, *search.Resolver, map[string]string) {
+	hostKeys := map[string]string{}
+	var specs []search.ProviderSpec
+	var ids []string
+	if len(cfg.SearchProviders) == 0 {
+		if cfg.Env.BraveAPIKey != "" {
+			specs = []search.ProviderSpec{{ID: "brave"}}
+			hostKeys["brave"] = cfg.Env.BraveAPIKey
+			ids = []string{"brave"}
+		}
+	} else {
+		for id, spc := range cfg.SearchProviders {
+			specs = append(specs, search.ProviderSpec{ID: id, BaseURL: spc.BaseURL})
+			if k := cfg.SearchHostKey(id); k != "" {
+				hostKeys[id] = k
+			}
+			ids = append(ids, id)
+		}
+	}
+	if len(specs) == 0 {
+		return nil, nil, nil
+	}
+	reg, err := search.BuildRegistry(specs)
+	if err != nil {
+		log.Printf("search: registry build error: %v (WebSearch disabled)", err)
+		return nil, nil, nil
+	}
+	priority := cfg.SearchPriority
+	if len(priority) == 0 {
+		sort.Strings(ids)
+		priority = ids
+	}
+	return reg, search.NewResolver(priority), hostKeys
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/agents"
 	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/search"
 	"github.com/denn-gubsky/loomcycle/internal/skillmatch"
 )
 
@@ -64,6 +65,19 @@ type Config struct {
 	// stall. Empty = use the hardcoded default in
 	// internal/resolve/. Per-agent `providers:` fully replaces this.
 	ProviderPriority []string `yaml:"provider_priority"`
+
+	// SearchProviders declares the enabled web-search providers (RFC BB) +
+	// their per-provider settings (SearXNG base_url). A provider must be
+	// listed here to be usable; its operator API key comes from the env var
+	// the driver names (BRAVE_API_KEY / SERPER_API_KEY / EXA_API_KEY /
+	// TAVILY_API_KEY), overridable per-tenant via CredentialDef.
+	SearchProviders map[string]SearchProviderConfig `yaml:"search_providers"`
+
+	// SearchPriority is the global default fallback order the WebSearch tool
+	// walks when an agent declares no per-agent `search_providers:` list.
+	// Every entry must be an enabled SearchProviders key. Empty = the enabled
+	// set in map order (non-deterministic — set this for a stable cascade).
+	SearchPriority []string `yaml:"search_priority"`
 
 	// Tiers is the library-wide tier → ordered candidate list.
 	// Operator-editable so model wire aliases stay out of the
@@ -550,6 +564,30 @@ type TierCandidate struct {
 	Model    string `json:"model"    yaml:"model"`
 }
 
+// SearchProviderConfig is the per-provider settings block under
+// `search_providers:` (RFC BB). Most providers need no settings (the key comes
+// from the env var the driver names); SearXNG needs its self-hosted base_url.
+type SearchProviderConfig struct {
+	BaseURL string `json:"base_url,omitempty" yaml:"base_url"` // SearXNG only, e.g. http://searxng:8080
+}
+
+// SearchHostKey returns the operator host API key for a search-provider id
+// (from the env), or "" for a keyless (searxng) or unknown provider. The single
+// place the id → env-field mapping lives; the WebSearch tool wiring reads it.
+func (c *Config) SearchHostKey(id string) string {
+	switch id {
+	case "brave":
+		return c.Env.BraveAPIKey
+	case "serper":
+		return c.Env.SerperAPIKey
+	case "exa":
+		return c.Env.ExaAPIKey
+	case "tavily":
+		return c.Env.TavilyAPIKey
+	}
+	return ""
+}
+
 // UnmarshalYAML accepts a tier candidate written EITHER as a mapping
 // ({provider: X, model: Y}) or as a bare scalar string. A bare string is
 // taken as the model with an empty provider — the natural way to name a
@@ -812,6 +850,13 @@ type AgentDef struct {
 	// for this agent and ignores the library default. Has no
 	// effect on agents using the explicit Provider+Model pin.
 	Providers []string `yaml:"providers"`
+
+	// SearchProviders is the per-agent web-search fallback list (RFC BB) —
+	// the ordered providers the WebSearch tool tries. Empty = the library
+	// SearchPriority default. Full replacement, like Providers. Every entry
+	// must be an enabled top-level SearchProviders key. Content-identifying
+	// (kept in content_sha256, like Providers — it changes behaviour).
+	SearchProviders []string `yaml:"search_providers"`
 
 	// Models is the per-agent override of the library Tiers map
 	// (per-tier candidate lists). Same semantics as the library
@@ -2018,6 +2063,12 @@ type Env struct {
 	// BraveAPIKey enables the WebSearch tool. Empty = WebSearch refuses
 	// every call. Lives at https://api.search.brave.com/.
 	BraveAPIKey string
+	// Serper/Exa/Tavily host keys for the RFC BB search-provider catalog.
+	// Empty = that provider is unusable unless a tenant supplies its own via
+	// CredentialDef. All are auto-redacted by the *_API_KEY suffix rule.
+	SerperAPIKey string
+	ExaAPIKey    string
+	TavilyAPIKey string
 	// BashEnabled gates the Bash tool. Defaults to false. Even when
 	// true the tool is NOT a true sandbox — it restricts cwd, scrubs
 	// env, bounds output, and times out, but cannot prevent the spawned
@@ -2823,6 +2874,9 @@ func LoadLayers(layers ...Layer) (*Config, error) {
 		HTTPCallerAuthoritative:   os.Getenv("LOOMCYCLE_HTTP_CALLER_AUTHORITATIVE") == "1",
 		ResumeFanout:              os.Getenv("LOOMCYCLE_RESUME_FANOUT") == "1",
 		BraveAPIKey:               os.Getenv("BRAVE_API_KEY"),
+		SerperAPIKey:              os.Getenv("SERPER_API_KEY"),
+		ExaAPIKey:                 os.Getenv("EXA_API_KEY"),
+		TavilyAPIKey:              os.Getenv("TAVILY_API_KEY"),
 		BashEnabled:               os.Getenv("LOOMCYCLE_BASH_ENABLED") == "1",
 		BashboxEnabled:            os.Getenv("LOOMCYCLE_BASHBOX_ENABLED") == "1",
 		BashboxFallbackCommands:   splitCSV(os.Getenv("LOOMCYCLE_BASHBOX_FALLBACK_COMMANDS")),
@@ -3897,6 +3951,9 @@ func ExpandEnvAllowed(name string) bool {
 	}
 	switch name {
 	case "BRAVE_API_KEY",
+		"SERPER_API_KEY",
+		"EXA_API_KEY",
+		"TAVILY_API_KEY",
 		"GITHUB_TOKEN",
 		"SLACK_BOT_TOKEN",
 		"REDIS_URL":
@@ -4664,6 +4721,28 @@ func validate(c *Config) error {
 			return fmt.Errorf("provider_priority[%d]: unknown provider %q (want one of anthropic/openai/deepseek/gemini/ollama)", i, p)
 		}
 	}
+	// Search providers (RFC BB): validate the enabled set against the known
+	// drivers + SearXNG's required base_url, then the global priority. The
+	// enabled set is reused below to validate each agent's search_providers.
+	knownSearch := map[string]bool{}
+	for _, id := range search.KnownProviderIDs() {
+		knownSearch[id] = true
+	}
+	enabledSearch := map[string]bool{}
+	for id, spc := range c.SearchProviders {
+		if !knownSearch[id] {
+			return fmt.Errorf("search_providers: unknown provider %q (want one of %v)", id, search.KnownProviderIDs())
+		}
+		if id == "searxng" && strings.TrimSpace(spc.BaseURL) == "" {
+			return fmt.Errorf("search_providers.searxng: base_url is required for the self-hosted SearXNG provider")
+		}
+		enabledSearch[id] = true
+	}
+	for i, id := range c.SearchPriority {
+		if !enabledSearch[id] {
+			return fmt.Errorf("search_priority[%d]: %q is not an enabled search_providers entry", i, id)
+		}
+	}
 	// Library-level tier definitions.
 	for tierName, candidates := range c.Tiers {
 		if !validTierNames[tierName] {
@@ -4790,6 +4869,13 @@ func validate(c *Config) error {
 		for i, p := range agent.Providers {
 			if !validProviderIDs[p] {
 				return fmt.Errorf("agent %q: providers[%d]: unknown provider %q", name, i, p)
+			}
+		}
+		// Per-agent web-search fallback list (RFC BB) — every entry must be an
+		// enabled top-level search_providers key.
+		for i, id := range agent.SearchProviders {
+			if !enabledSearch[id] {
+				return fmt.Errorf("agent %q: search_providers[%d]: %q is not an enabled search_providers entry", name, i, id)
 			}
 		}
 		// Per-agent tier-candidate override.

--- a/internal/config/search_test.go
+++ b/internal/config/search_test.go
@@ -1,0 +1,72 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidate_SearchProviders covers the RFC BB config surface: the enabled
+// set is checked against the known drivers, SearXNG needs a base_url, and both
+// the global search_priority and each agent's search_providers must reference
+// only enabled providers.
+func TestValidate_SearchProviders(t *testing.T) {
+	base := func(sp map[string]SearchProviderConfig, prio []string, agents map[string]AgentDef) *Config {
+		return &Config{
+			Defaults:        Defaults{Provider: "anthropic", Model: "x"},
+			Concurrency:     Concurrency{MaxConcurrentRuns: 1},
+			SearchProviders: sp,
+			SearchPriority:  prio,
+			Agents:          agents,
+		}
+	}
+
+	if err := validate(base(
+		map[string]SearchProviderConfig{"brave": {}, "serper": {}, "searxng": {BaseURL: "http://sx:8080"}},
+		[]string{"serper", "brave", "searxng"}, nil)); err != nil {
+		t.Errorf("valid search config rejected: %v", err)
+	}
+
+	cases := []struct {
+		name    string
+		cfg     *Config
+		wantSub string
+	}{
+		{"unknown provider",
+			base(map[string]SearchProviderConfig{"bing": {}}, nil, nil), "unknown provider"},
+		{"searxng missing base_url",
+			base(map[string]SearchProviderConfig{"searxng": {}}, nil, nil), "base_url is required"},
+		{"priority references unconfigured",
+			base(map[string]SearchProviderConfig{"brave": {}}, []string{"serper"}, nil), "not an enabled"},
+		{"agent references unconfigured",
+			base(map[string]SearchProviderConfig{"brave": {}}, nil,
+				map[string]AgentDef{"r": {Tier: "middle", Tools: []string{"WebSearch"}, SearchProviders: []string{"exa"}}}),
+			"not an enabled"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validate(tc.cfg)
+			if err == nil || !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("got %v, want error containing %q", err, tc.wantSub)
+			}
+		})
+	}
+
+	// An agent that lists only enabled providers passes.
+	ok := base(map[string]SearchProviderConfig{"brave": {}, "exa": {}}, []string{"brave"},
+		map[string]AgentDef{"r": {Tier: "middle", Tools: []string{"WebSearch"}, SearchProviders: []string{"exa", "brave"}}})
+	if err := validate(ok); err != nil {
+		t.Errorf("agent with configured providers rejected: %v", err)
+	}
+}
+
+// TestSearchHostKey maps each provider id to its env-derived operator key;
+// keyless/unknown → "".
+func TestSearchHostKey(t *testing.T) {
+	c := &Config{Env: Env{BraveAPIKey: "b", SerperAPIKey: "s", ExaAPIKey: "e", TavilyAPIKey: "t"}}
+	want := map[string]string{"brave": "b", "serper": "s", "exa": "e", "tavily": "t", "searxng": "", "nope": ""}
+	for id, w := range want {
+		if got := c.SearchHostKey(id); got != w {
+			t.Errorf("SearchHostKey(%q) = %q, want %q", id, got, w)
+		}
+	}
+}

--- a/internal/search/brave.go
+++ b/internal/search/brave.go
@@ -1,0 +1,61 @@
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+)
+
+const braveDefaultEndpoint = "https://api.search.brave.com/res/v1/web/search"
+
+// braveDriver is the Brave Search API driver (lifted from the pre-RFC-BB
+// WebSearch). GET with the key in the X-Subscription-Token header; results under
+// web.results[]. Titles/descriptions carry <strong> highlight tags — the
+// WebSearch render path strips them, so the normalized Snippet keeps them raw.
+type braveDriver struct{ base }
+
+// NewBrave constructs the Brave driver.
+func NewBrave(opts ...Option) Provider {
+	d := &braveDriver{}
+	for _, o := range opts {
+		o(&d.base)
+	}
+	return d
+}
+
+func (d *braveDriver) ID() string                  { return "brave" }
+func (d *braveDriver) KeyEnvName() string          { return "BRAVE_API_KEY" }
+func (d *braveDriver) Probe(context.Context) error { return nil }
+
+func (d *braveDriver) Search(ctx context.Context, q Query, apiKey string) (Results, error) {
+	v := url.Values{}
+	v.Set("q", q.Text)
+	v.Set("count", fmt.Sprint(q.MaxResults))
+	body, status, err := d.doJSON(ctx, "GET",
+		firstNonEmpty(d.endpoint, braveDefaultEndpoint)+"?"+v.Encode(),
+		map[string]string{"Accept": "application/json", "X-Subscription-Token": apiKey}, nil)
+	if err != nil {
+		return Results{}, err
+	}
+	if status != 200 {
+		return Results{}, fmt.Errorf("brave: status %d: %s", status, truncate(body))
+	}
+	var parsed struct {
+		Web struct {
+			Results []struct {
+				Title       string `json:"title"`
+				URL         string `json:"url"`
+				Description string `json:"description"`
+			} `json:"results"`
+		} `json:"web"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return Results{}, fmt.Errorf("brave: parse: %w", err)
+	}
+	out := make([]Result, 0, len(parsed.Web.Results))
+	for _, r := range parsed.Web.Results {
+		out = append(out, Result{Title: r.Title, URL: r.URL, Snippet: r.Description})
+	}
+	return Results{Provider: "brave", Results: out, Raw: body}, nil
+}

--- a/internal/search/exa.go
+++ b/internal/search/exa.go
@@ -1,0 +1,72 @@
+package search
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const exaDefaultEndpoint = "https://api.exa.ai/search"
+
+// exaDriver is the Exa neural-search driver. POST with the key in the x-api-key
+// header + a JSON body {query, numResults, contents}. We request a short text
+// snippet via contents.text so the normalized Snippet is populated; the snippet
+// falls back to the first highlight when text is absent.
+//
+// ASSUMPTION: Exa returns results[] with title/url plus text (and/or
+// highlights[]) when contents is requested. Validated against captured fixtures;
+// the live shape is exercised by the E2E smoke, not unit tests.
+type exaDriver struct{ base }
+
+// NewExa constructs the Exa driver.
+func NewExa(opts ...Option) Provider {
+	d := &exaDriver{}
+	for _, o := range opts {
+		o(&d.base)
+	}
+	return d
+}
+
+func (d *exaDriver) ID() string                  { return "exa" }
+func (d *exaDriver) KeyEnvName() string          { return "EXA_API_KEY" }
+func (d *exaDriver) Probe(context.Context) error { return nil }
+
+func (d *exaDriver) Search(ctx context.Context, q Query, apiKey string) (Results, error) {
+	reqBody, _ := json.Marshal(map[string]any{
+		"query":      q.Text,
+		"numResults": q.MaxResults,
+		"contents":   map[string]any{"text": map[string]any{"maxCharacters": 300}},
+	})
+	body, status, err := d.doJSON(ctx, "POST",
+		firstNonEmpty(d.endpoint, exaDefaultEndpoint),
+		map[string]string{"x-api-key": apiKey, "Content-Type": "application/json"},
+		bytes.NewReader(reqBody))
+	if err != nil {
+		return Results{}, err
+	}
+	if status != 200 {
+		return Results{}, fmt.Errorf("exa: status %d: %s", status, truncate(body))
+	}
+	var parsed struct {
+		Results []struct {
+			Title      string   `json:"title"`
+			URL        string   `json:"url"`
+			Text       string   `json:"text"`
+			Highlights []string `json:"highlights"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return Results{}, fmt.Errorf("exa: parse: %w", err)
+	}
+	out := make([]Result, 0, len(parsed.Results))
+	for _, r := range parsed.Results {
+		snippet := strings.TrimSpace(r.Text)
+		if snippet == "" && len(r.Highlights) > 0 {
+			snippet = strings.TrimSpace(r.Highlights[0])
+		}
+		out = append(out, Result{Title: r.Title, URL: r.URL, Snippet: snippet})
+	}
+	return Results{Provider: "exa", Results: out, Raw: body}, nil
+}

--- a/internal/search/provider.go
+++ b/internal/search/provider.go
@@ -1,0 +1,129 @@
+// Package search is loomcycle's first-class, config-declared catalog of
+// web-search providers behind one interface — the search analog of
+// internal/providers (RFC BB). Each driver normalizes its provider's JSON to a
+// common []Result shape so the WebSearch tool can fall over from one provider to
+// the next transparently, with a per-agent priority list and a routing view.
+//
+// Design boundary: drivers are PURE HTTP clients. They take an already-resolved
+// apiKey and never touch credential/ctx machinery — key resolution, the RFC AR
+// tenant-override, and the RFC AX operator-key restriction are the WebSearch
+// tool's job. That keeps this package free of internal/providers + internal/tools
+// imports and makes each driver testable with a plain key + a fake HTTP client.
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+// maxResponseBytes caps a provider response the same way the legacy WebSearch
+// did (1 MiB) — a runaway body can never blow the process or the context window.
+const maxResponseBytes = 1 << 20
+
+// Query is a normalized search request. Host narrowing + result rendering are
+// the WebSearch tool's concern (applied to the normalized Results, provider-
+// agnostic), NOT a driver's — so every driver stays a thin "text → SERP" client.
+type Query struct {
+	Text       string
+	MaxResults int
+}
+
+// Result is one normalized hit — the lowest-common-denominator "web discovery"
+// shape (title/url/snippet) every provider maps onto, so the fallback circuit
+// can swap providers without the agent seeing a different shape (RFC BB). A
+// provider's richer output rides Results.Raw, out of the fallback circuit.
+type Result struct {
+	Title   string
+	URL     string
+	Snippet string
+}
+
+// Results is a provider's normalized response.
+type Results struct {
+	Provider string
+	Results  []Result
+	Raw      json.RawMessage // the provider's original body, for future power-ops
+}
+
+// Provider is one search backend (brave/serper/exa/tavily/searxng). Mirrors the
+// shape of providers.Provider but search-flavored.
+type Provider interface {
+	ID() string
+	// Search runs the query with the already-resolved apiKey ("" for keyless
+	// providers like SearXNG). Key resolution + the operator-key restriction
+	// are the caller's job — the driver is a pure HTTP client.
+	Search(ctx context.Context, q Query, apiKey string) (Results, error)
+	// KeyEnvName is the well-known env-var name the provider's key resolves
+	// from (e.g. "SERPER_API_KEY"); "" for a keyless provider. Used by the
+	// WebSearch tool + routing view to test tenant/operator keyability without
+	// spending a paid query.
+	KeyEnvName() string
+	// Probe is a cheap reachability check. Most paid search APIs have no free
+	// probe, so their Probe is a no-op returning nil (availability is tracked
+	// by last-outcome instead); SearXNG implements a real /healthz probe.
+	Probe(ctx context.Context) error
+}
+
+// base carries the test-injectable endpoint + client shared by every driver.
+type base struct {
+	endpoint string       // "" → the driver's default
+	client   *http.Client // nil → http.DefaultClient (relies on the ctx deadline)
+}
+
+// Option customizes a driver at construction — the seam tests use to point a
+// driver at a fake server + client.
+type Option func(*base)
+
+// WithEndpoint overrides a driver's default upstream URL (tests).
+func WithEndpoint(url string) Option { return func(b *base) { b.endpoint = url } }
+
+// WithHTTPClient injects an *http.Client (tests control dialing).
+func WithHTTPClient(c *http.Client) Option { return func(b *base) { b.client = c } }
+
+func (b base) httpClient() *http.Client {
+	if b.client != nil {
+		return b.client
+	}
+	return http.DefaultClient
+}
+
+// doJSON issues one request and returns the (byte-capped) body + status code.
+// The caller sets the ctx deadline; drivers don't own timeout policy.
+func (b base) doJSON(ctx context.Context, method, url string, headers map[string]string, body io.Reader) ([]byte, int, error) {
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return nil, 0, err
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := b.httpClient().Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return nil, resp.StatusCode, err
+	}
+	return data, resp.StatusCode, nil
+}
+
+// firstNonEmpty returns a if non-empty, else b — used for endpoint defaulting.
+func firstNonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}
+
+// truncate bounds an upstream error body so a driver's error stays log-friendly.
+func truncate(b []byte) string {
+	const n = 200
+	if len(b) > n {
+		return string(b[:n]) + "…"
+	}
+	return string(b)
+}

--- a/internal/search/provider_test.go
+++ b/internal/search/provider_test.go
@@ -1,0 +1,191 @@
+package search
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// captured records what a driver actually sent, so a test can assert the wire
+// contract (method, auth header, params) as well as the normalized output.
+type captured struct {
+	method string
+	header http.Header
+	rawURL string
+	body   string
+}
+
+func serve(t *testing.T, status int, body string, cap *captured) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if cap != nil {
+			cap.method = r.Method
+			cap.header = r.Header.Clone()
+			cap.rawURL = r.URL.String()
+			b, _ := io.ReadAll(r.Body)
+			cap.body = string(b)
+		}
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestDrivers_Normalize: each driver maps its provider's JSON to the common
+// []Result{Title,URL,Snippet} shape and carries the resolved key on the wire.
+func TestDrivers_Normalize(t *testing.T) {
+	cases := []struct {
+		name     string
+		newP     func(url string) Provider
+		resp     string
+		wantID   string
+		wantRes  []Result
+		checkReq func(t *testing.T, c *captured)
+	}{
+		{
+			name:    "brave",
+			newP:    func(u string) Provider { return NewBrave(WithEndpoint(u)) },
+			resp:    `{"web":{"results":[{"title":"T1","url":"https://a","description":"D1"},{"title":"T2","url":"https://b","description":"D2"}]}}`,
+			wantID:  "brave",
+			wantRes: []Result{{"T1", "https://a", "D1"}, {"T2", "https://b", "D2"}},
+			checkReq: func(t *testing.T, c *captured) {
+				if c.method != "GET" {
+					t.Errorf("brave method = %s, want GET", c.method)
+				}
+				if c.header.Get("X-Subscription-Token") != "KEY" {
+					t.Errorf("brave missing X-Subscription-Token; got %q", c.header.Get("X-Subscription-Token"))
+				}
+				if !strings.Contains(c.rawURL, "q=hi") || !strings.Contains(c.rawURL, "count=3") {
+					t.Errorf("brave query = %q, want q=hi & count=3", c.rawURL)
+				}
+			},
+		},
+		{
+			name:    "serper",
+			newP:    func(u string) Provider { return NewSerper(WithEndpoint(u)) },
+			resp:    `{"organic":[{"title":"T1","link":"https://a","snippet":"S1"}]}`,
+			wantID:  "serper",
+			wantRes: []Result{{"T1", "https://a", "S1"}},
+			checkReq: func(t *testing.T, c *captured) {
+				if c.method != "POST" {
+					t.Errorf("serper method = %s, want POST", c.method)
+				}
+				if c.header.Get("X-API-KEY") != "KEY" {
+					t.Errorf("serper missing X-API-KEY; got %q", c.header.Get("X-API-KEY"))
+				}
+				if !strings.Contains(c.body, `"q":"hi"`) {
+					t.Errorf("serper body = %q, want q=hi", c.body)
+				}
+			},
+		},
+		{
+			name:    "exa",
+			newP:    func(u string) Provider { return NewExa(WithEndpoint(u)) },
+			resp:    `{"results":[{"title":"T1","url":"https://a","text":"X1"},{"title":"T2","url":"https://b","highlights":["H2"]}]}`,
+			wantID:  "exa",
+			wantRes: []Result{{"T1", "https://a", "X1"}, {"T2", "https://b", "H2"}}, // text preferred; highlights fallback
+			checkReq: func(t *testing.T, c *captured) {
+				if c.header.Get("x-api-key") != "KEY" {
+					t.Errorf("exa missing x-api-key; got %q", c.header.Get("x-api-key"))
+				}
+			},
+		},
+		{
+			name:    "tavily",
+			newP:    func(u string) Provider { return NewTavily(WithEndpoint(u)) },
+			resp:    `{"results":[{"title":"T1","url":"https://a","content":"C1"}]}`,
+			wantID:  "tavily",
+			wantRes: []Result{{"T1", "https://a", "C1"}},
+			checkReq: func(t *testing.T, c *captured) {
+				if c.header.Get("Authorization") != "Bearer KEY" {
+					t.Errorf("tavily Authorization = %q, want Bearer KEY", c.header.Get("Authorization"))
+				}
+			},
+		},
+		{
+			name:    "searxng",
+			newP:    func(u string) Provider { return NewSearXNG(u) },
+			resp:    `{"results":[{"title":"T1","url":"https://a","content":"C1"}]}`,
+			wantID:  "searxng",
+			wantRes: []Result{{"T1", "https://a", "C1"}},
+			checkReq: func(t *testing.T, c *captured) {
+				if !strings.Contains(c.rawURL, "format=json") {
+					t.Errorf("searxng query = %q, want format=json", c.rawURL)
+				}
+				if !strings.HasPrefix(c.rawURL, "/search") {
+					t.Errorf("searxng path = %q, want /search", c.rawURL)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := &captured{}
+			srv := serve(t, 200, tc.resp, cap)
+			p := tc.newP(srv.URL)
+			if p.ID() != tc.wantID {
+				t.Fatalf("ID() = %q, want %q", p.ID(), tc.wantID)
+			}
+			res, err := p.Search(context.Background(), Query{Text: "hi", MaxResults: 3}, "KEY")
+			if err != nil {
+				t.Fatalf("Search: %v", err)
+			}
+			if res.Provider != tc.wantID {
+				t.Errorf("Results.Provider = %q, want %q", res.Provider, tc.wantID)
+			}
+			if len(res.Results) != len(tc.wantRes) {
+				t.Fatalf("got %d results, want %d (%+v)", len(res.Results), len(tc.wantRes), res.Results)
+			}
+			for i, want := range tc.wantRes {
+				if res.Results[i] != want {
+					t.Errorf("result[%d] = %+v, want %+v", i, res.Results[i], want)
+				}
+			}
+			if len(res.Raw) == 0 {
+				t.Error("Results.Raw should carry the original body")
+			}
+			tc.checkReq(t, cap)
+		})
+	}
+}
+
+// TestDrivers_ErrorPaths: a non-200 and malformed JSON both surface as errors so
+// the WebSearch fallback circuit cascades to the next provider.
+func TestDrivers_ErrorPaths(t *testing.T) {
+	t.Run("non-200", func(t *testing.T) {
+		srv := serve(t, 429, "rate limited", nil)
+		_, err := NewBrave(WithEndpoint(srv.URL)).Search(context.Background(), Query{Text: "x", MaxResults: 1}, "K")
+		if err == nil {
+			t.Fatal("want error on 429")
+		}
+		if !strings.Contains(err.Error(), "429") {
+			t.Errorf("error = %v, want it to mention 429", err)
+		}
+	})
+	t.Run("bad-json", func(t *testing.T) {
+		srv := serve(t, 200, "not json", nil)
+		_, err := NewSerper(WithEndpoint(srv.URL)).Search(context.Background(), Query{Text: "x", MaxResults: 1}, "K")
+		if err == nil {
+			t.Fatal("want parse error on bad JSON")
+		}
+	})
+}
+
+// TestKeyEnvName: keyed providers advertise their env-var; SearXNG is keyless.
+func TestKeyEnvName(t *testing.T) {
+	want := map[string]string{
+		"brave": "BRAVE_API_KEY", "serper": "SERPER_API_KEY", "exa": "EXA_API_KEY",
+		"tavily": "TAVILY_API_KEY", "searxng": "",
+	}
+	ps := []Provider{NewBrave(), NewSerper(), NewExa(), NewTavily(), NewSearXNG("http://x")}
+	for _, p := range ps {
+		if got := p.KeyEnvName(); got != want[p.ID()] {
+			t.Errorf("%s KeyEnvName() = %q, want %q", p.ID(), got, want[p.ID()])
+		}
+	}
+}

--- a/internal/search/registry.go
+++ b/internal/search/registry.go
@@ -1,0 +1,82 @@
+package search
+
+import "fmt"
+
+// Registry is the set of constructed search providers, keyed by ID.
+type Registry struct {
+	byID map[string]Provider
+}
+
+// ProviderSpec is the minimal per-provider config the registry builder needs,
+// decoupling internal/search from internal/config. BaseURL is SearXNG-only;
+// Options is the test-injection seam (endpoint/client).
+type ProviderSpec struct {
+	ID      string
+	BaseURL string
+	Options []Option
+}
+
+// BuildRegistry constructs a Registry from specs, dispatching each ID to its
+// driver constructor. An unknown ID is an error — config-load validates the set
+// against KnownProviderIDs first, so this is a defense-in-depth backstop.
+func BuildRegistry(specs []ProviderSpec) (*Registry, error) {
+	byID := make(map[string]Provider, len(specs))
+	for _, sp := range specs {
+		var p Provider
+		switch sp.ID {
+		case "brave":
+			p = NewBrave(sp.Options...)
+		case "serper":
+			p = NewSerper(sp.Options...)
+		case "exa":
+			p = NewExa(sp.Options...)
+		case "tavily":
+			p = NewTavily(sp.Options...)
+		case "searxng":
+			if sp.BaseURL == "" {
+				return nil, fmt.Errorf("search provider %q requires a base_url", sp.ID)
+			}
+			p = NewSearXNG(sp.BaseURL, sp.Options...)
+		default:
+			return nil, fmt.Errorf("unknown search provider %q", sp.ID)
+		}
+		byID[sp.ID] = p
+	}
+	return &Registry{byID: byID}, nil
+}
+
+// Get returns the provider for id.
+func (r *Registry) Get(id string) (Provider, bool) {
+	if r == nil {
+		return nil, false
+	}
+	p, ok := r.byID[id]
+	return p, ok
+}
+
+// IDs returns the registered provider IDs (unordered).
+func (r *Registry) IDs() []string {
+	if r == nil {
+		return nil
+	}
+	out := make([]string, 0, len(r.byID))
+	for id := range r.byID {
+		out = append(out, id)
+	}
+	return out
+}
+
+// KnownProviderIDs is the set of provider IDs this build supports — config
+// validation rejects any search_providers entry outside it.
+func KnownProviderIDs() []string {
+	return []string{"brave", "serper", "exa", "tavily", "searxng"}
+}
+
+// Ensure the interface is satisfied at compile time for each driver.
+var (
+	_ Provider = (*braveDriver)(nil)
+	_ Provider = (*serperDriver)(nil)
+	_ Provider = (*exaDriver)(nil)
+	_ Provider = (*tavilyDriver)(nil)
+	_ Provider = (*searxngDriver)(nil)
+)

--- a/internal/search/registry_test.go
+++ b/internal/search/registry_test.go
@@ -1,0 +1,50 @@
+package search
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestBuildRegistry(t *testing.T) {
+	reg, err := BuildRegistry([]ProviderSpec{
+		{ID: "brave"}, {ID: "serper"}, {ID: "searxng", BaseURL: "http://searxng:8080"},
+	})
+	if err != nil {
+		t.Fatalf("BuildRegistry: %v", err)
+	}
+	for _, id := range []string{"brave", "serper", "searxng"} {
+		p, ok := reg.Get(id)
+		if !ok || p.ID() != id {
+			t.Errorf("Get(%q) missing or wrong id", id)
+		}
+	}
+	ids := reg.IDs()
+	sort.Strings(ids)
+	if !equal(ids, []string{"brave", "searxng", "serper"}) {
+		t.Errorf("IDs() = %v", ids)
+	}
+}
+
+func TestBuildRegistry_Errors(t *testing.T) {
+	if _, err := BuildRegistry([]ProviderSpec{{ID: "searxng"}}); err == nil {
+		t.Error("searxng without base_url should error")
+	}
+	if _, err := BuildRegistry([]ProviderSpec{{ID: "nope"}}); err == nil {
+		t.Error("unknown provider id should error")
+	}
+}
+
+func TestKnownProviderIDs(t *testing.T) {
+	got := KnownProviderIDs()
+	sort.Strings(got)
+	if !equal(got, []string{"brave", "exa", "searxng", "serper", "tavily"}) {
+		t.Errorf("KnownProviderIDs() = %v", got)
+	}
+}
+
+func TestGet_NilRegistry(t *testing.T) {
+	var r *Registry
+	if _, ok := r.Get("brave"); ok {
+		t.Error("nil registry Get should be (nil,false)")
+	}
+}

--- a/internal/search/resolver.go
+++ b/internal/search/resolver.go
@@ -1,0 +1,65 @@
+package search
+
+import (
+	"sync"
+	"time"
+)
+
+// DefaultCooldown is how long a provider is skipped after a failed call.
+// Short — availability is advisory + per-replica, and search failures are
+// usually transient (rate-limit, upstream blip); a long cooldown would strand a
+// provider on one blip.
+const DefaultCooldown = 60 * time.Second
+
+// Resolver is the search analog of resolve.Resolver, minus the tier/model
+// matrix: a single flat priority order + a per-provider last-outcome cooldown
+// (RFC BB — no active probing of paid providers). Safe for concurrent use.
+type Resolver struct {
+	mu       sync.RWMutex
+	priority []string
+	cooldown time.Duration
+	stalled  map[string]time.Time // provider id → cooldown expiry
+}
+
+// NewResolver builds a resolver over the global default priority order.
+func NewResolver(priority []string) *Resolver {
+	return &Resolver{
+		priority: append([]string(nil), priority...),
+		cooldown: DefaultCooldown,
+		stalled:  map[string]time.Time{},
+	}
+}
+
+// Cascade returns the effective ordered provider IDs to try: the per-agent list
+// when non-empty (a full override, mirroring AgentDef.Providers), else the
+// global default priority. The caller skips IDs that aren't registered.
+func (r *Resolver) Cascade(agentList []string) []string {
+	if len(agentList) > 0 {
+		return append([]string(nil), agentList...)
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return append([]string(nil), r.priority...)
+}
+
+// Available reports whether a provider is outside its failure cooldown.
+func (r *Resolver) Available(id string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	until, ok := r.stalled[id]
+	return !ok || !time.Now().Before(until)
+}
+
+// MarkOutcome records the result of a Search call: nil clears any cooldown
+// (success), a non-nil error opens a cooldown window (last-outcome
+// availability). NOT called for ErrNotKeyable or empty-but-ok results — those
+// aren't provider failures.
+func (r *Resolver) MarkOutcome(id string, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if err == nil {
+		delete(r.stalled, id)
+		return
+	}
+	r.stalled[id] = time.Now().Add(r.cooldown)
+}

--- a/internal/search/resolver_test.go
+++ b/internal/search/resolver_test.go
@@ -1,0 +1,59 @@
+package search
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestResolver_Cascade(t *testing.T) {
+	r := NewResolver([]string{"brave", "serper", "exa"})
+	// No per-agent list → global default order.
+	if got := r.Cascade(nil); !equal(got, []string{"brave", "serper", "exa"}) {
+		t.Errorf("Cascade(nil) = %v, want global order", got)
+	}
+	// Per-agent list is a full override, in the agent's order.
+	if got := r.Cascade([]string{"serper", "brave"}); !equal(got, []string{"serper", "brave"}) {
+		t.Errorf("Cascade(agent) = %v, want the agent override", got)
+	}
+	// Cascade returns a copy — mutating it must not corrupt the resolver.
+	c := r.Cascade(nil)
+	c[0] = "TAMPERED"
+	if r.Cascade(nil)[0] != "brave" {
+		t.Error("Cascade must return a defensive copy")
+	}
+}
+
+func TestResolver_MarkOutcomeAvailability(t *testing.T) {
+	r := NewResolver([]string{"brave"})
+	if !r.Available("brave") {
+		t.Fatal("fresh provider should be available")
+	}
+	// A failure opens a cooldown → unavailable.
+	r.MarkOutcome("brave", errors.New("boom"))
+	if r.Available("brave") {
+		t.Error("provider should be in cooldown after a failure")
+	}
+	// A success clears it → available again.
+	r.MarkOutcome("brave", nil)
+	if !r.Available("brave") {
+		t.Error("provider should be available after a success clears the cooldown")
+	}
+	// A zero cooldown expires immediately (proves it's time-gated, not a hard flag).
+	r.cooldown = 0
+	r.MarkOutcome("brave", errors.New("boom"))
+	if !r.Available("brave") {
+		t.Error("a zero-cooldown failure should not linger")
+	}
+}
+
+func equal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/search/searxng.go
+++ b/internal/search/searxng.go
@@ -1,0 +1,71 @@
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// searxngDriver is the self-hosted SearXNG meta-search driver — KEYLESS. GET
+// {base}/search?q=&format=json; results under results[] with the snippet in the
+// "content" field. Because it's operator-hosted (no paid query), it implements a
+// real Probe against {base}/healthz for the routing view's availability.
+type searxngDriver struct {
+	base
+	baseURL string // e.g. http://searxng:8080 (no trailing slash)
+}
+
+// NewSearXNG constructs the SearXNG driver against the operator's base URL.
+func NewSearXNG(baseURL string, opts ...Option) Provider {
+	d := &searxngDriver{baseURL: strings.TrimRight(baseURL, "/")}
+	for _, o := range opts {
+		o(&d.base)
+	}
+	return d
+}
+
+func (d *searxngDriver) ID() string         { return "searxng" }
+func (d *searxngDriver) KeyEnvName() string { return "" } // keyless
+
+func (d *searxngDriver) Probe(ctx context.Context) error {
+	_, status, err := d.doJSON(ctx, "GET", d.baseURL+"/healthz", nil, nil)
+	if err != nil {
+		return err
+	}
+	if status != 200 {
+		return fmt.Errorf("searxng: healthz status %d", status)
+	}
+	return nil
+}
+
+func (d *searxngDriver) Search(ctx context.Context, q Query, _ string) (Results, error) {
+	v := url.Values{}
+	v.Set("q", q.Text)
+	v.Set("format", "json")
+	body, status, err := d.doJSON(ctx, "GET",
+		firstNonEmpty(d.endpoint, d.baseURL+"/search")+"?"+v.Encode(),
+		map[string]string{"Accept": "application/json"}, nil)
+	if err != nil {
+		return Results{}, err
+	}
+	if status != 200 {
+		return Results{}, fmt.Errorf("searxng: status %d: %s", status, truncate(body))
+	}
+	var parsed struct {
+		Results []struct {
+			Title   string `json:"title"`
+			URL     string `json:"url"`
+			Content string `json:"content"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return Results{}, fmt.Errorf("searxng: parse: %w", err)
+	}
+	out := make([]Result, 0, len(parsed.Results))
+	for _, r := range parsed.Results {
+		out = append(out, Result{Title: r.Title, URL: r.URL, Snippet: r.Content})
+	}
+	return Results{Provider: "searxng", Results: out, Raw: body}, nil
+}

--- a/internal/search/serper.go
+++ b/internal/search/serper.go
@@ -1,0 +1,57 @@
+package search
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+const serperDefaultEndpoint = "https://google.serper.dev/search"
+
+// serperDriver is the Serper.dev driver — cheap Google SERP JSON. POST with the
+// key in the X-API-KEY header + a JSON body {q, num}; organic results under
+// organic[] with the URL in the "link" field.
+type serperDriver struct{ base }
+
+// NewSerper constructs the Serper driver.
+func NewSerper(opts ...Option) Provider {
+	d := &serperDriver{}
+	for _, o := range opts {
+		o(&d.base)
+	}
+	return d
+}
+
+func (d *serperDriver) ID() string                  { return "serper" }
+func (d *serperDriver) KeyEnvName() string          { return "SERPER_API_KEY" }
+func (d *serperDriver) Probe(context.Context) error { return nil }
+
+func (d *serperDriver) Search(ctx context.Context, q Query, apiKey string) (Results, error) {
+	reqBody, _ := json.Marshal(map[string]any{"q": q.Text, "num": q.MaxResults})
+	body, status, err := d.doJSON(ctx, "POST",
+		firstNonEmpty(d.endpoint, serperDefaultEndpoint),
+		map[string]string{"X-API-KEY": apiKey, "Content-Type": "application/json"},
+		bytes.NewReader(reqBody))
+	if err != nil {
+		return Results{}, err
+	}
+	if status != 200 {
+		return Results{}, fmt.Errorf("serper: status %d: %s", status, truncate(body))
+	}
+	var parsed struct {
+		Organic []struct {
+			Title   string `json:"title"`
+			Link    string `json:"link"`
+			Snippet string `json:"snippet"`
+		} `json:"organic"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return Results{}, fmt.Errorf("serper: parse: %w", err)
+	}
+	out := make([]Result, 0, len(parsed.Organic))
+	for _, r := range parsed.Organic {
+		out = append(out, Result{Title: r.Title, URL: r.Link, Snippet: r.Snippet})
+	}
+	return Results{Provider: "serper", Results: out, Raw: body}, nil
+}

--- a/internal/search/tavily.go
+++ b/internal/search/tavily.go
@@ -1,0 +1,57 @@
+package search
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+const tavilyDefaultEndpoint = "https://api.tavily.com/search"
+
+// tavilyDriver is the Tavily driver — a RAG-purpose-built search API. POST with
+// the key as a Bearer token + a JSON body {query, max_results}; results under
+// results[] with the snippet in the "content" field.
+type tavilyDriver struct{ base }
+
+// NewTavily constructs the Tavily driver.
+func NewTavily(opts ...Option) Provider {
+	d := &tavilyDriver{}
+	for _, o := range opts {
+		o(&d.base)
+	}
+	return d
+}
+
+func (d *tavilyDriver) ID() string                  { return "tavily" }
+func (d *tavilyDriver) KeyEnvName() string          { return "TAVILY_API_KEY" }
+func (d *tavilyDriver) Probe(context.Context) error { return nil }
+
+func (d *tavilyDriver) Search(ctx context.Context, q Query, apiKey string) (Results, error) {
+	reqBody, _ := json.Marshal(map[string]any{"query": q.Text, "max_results": q.MaxResults})
+	body, status, err := d.doJSON(ctx, "POST",
+		firstNonEmpty(d.endpoint, tavilyDefaultEndpoint),
+		map[string]string{"Authorization": "Bearer " + apiKey, "Content-Type": "application/json"},
+		bytes.NewReader(reqBody))
+	if err != nil {
+		return Results{}, err
+	}
+	if status != 200 {
+		return Results{}, fmt.Errorf("tavily: status %d: %s", status, truncate(body))
+	}
+	var parsed struct {
+		Results []struct {
+			Title   string `json:"title"`
+			URL     string `json:"url"`
+			Content string `json:"content"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return Results{}, fmt.Errorf("tavily: parse: %w", err)
+	}
+	out := make([]Result, 0, len(parsed.Results))
+	for _, r := range parsed.Results {
+		out = append(out, Result{Title: r.Title, URL: r.URL, Snippet: r.Content})
+	}
+	return Results{Provider: "tavily", Results: out, Raw: body}, nil
+}

--- a/internal/tools/builtin/narrowing_test.go
+++ b/internal/tools/builtin/narrowing_test.go
@@ -84,7 +84,7 @@ func TestNarrowHostsWebFetchInheritsNarrowing(t *testing.T) {
 // (WebFetch, which shares HTTP, is what the model uses to follow up).
 func TestNarrowHostsWebSearchDropDefault(t *testing.T) {
 	httpTool := &HTTP{HostAllowlist: []string{"x.example", "y.example"}}
-	ws := &WebSearch{APIKey: "k"}
+	ws := &WebSearch{}
 	out := NarrowHosts([]tools.Tool{httpTool, ws}, []string{"x.example"}, "", false)
 	// out[0] is the wrapped HTTP, out[1] is the wrapped WebSearch.
 	wrapped := out[1].(*WebSearch)
@@ -101,7 +101,7 @@ func TestNarrowHostsWebSearchDropDefault(t *testing.T) {
 
 func TestNarrowHostsWebSearchKeepExplicit(t *testing.T) {
 	httpTool := &HTTP{HostAllowlist: []string{"x.example"}}
-	ws := &WebSearch{APIKey: "k"}
+	ws := &WebSearch{}
 	out := NarrowHosts([]tools.Tool{httpTool, ws}, []string{"x.example"}, WebSearchFilterKeep, false)
 	wrapped := out[1].(*WebSearch)
 	if wrapped.FilterMode != WebSearchFilterKeep {
@@ -115,7 +115,7 @@ func TestNarrowHostsWebSearchKeepExplicit(t *testing.T) {
 // isn't there. The model couldn't fetch anything anyway (no WebFetch),
 // so this is the right answer.
 func TestNarrowHostsWebSearchWithoutHTTPGetsEmpty(t *testing.T) {
-	ws := &WebSearch{APIKey: "k"}
+	ws := &WebSearch{}
 	out := NarrowHosts([]tools.Tool{ws}, []string{"x.example"}, "", false)
 	wrapped := out[0].(*WebSearch)
 	if len(wrapped.AllowedHosts) != 0 {

--- a/internal/tools/builtin/websearch.go
+++ b/internal/tools/builtin/websearch.go
@@ -4,53 +4,53 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
+	"log"
 	"net/url"
 	"strings"
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/search"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
 
 // WebSearch is a lightweight discovery tool: query → ranked list of
-// (title, URL, snippet). The model uses it to find pages, then follows
-// up with WebFetch for actual content. Capped at 25 results and 256
-// chars per snippet so a search call can never blow the context window.
+// (title, URL, snippet). The model uses it to find pages, then follows up with
+// WebFetch for actual content. Capped at 25 results and 256 chars per snippet so
+// a search call can never blow the context window.
 //
-// Backend: Brave Search API at https://api.search.brave.com/.
-// Required: BRAVE_API_KEY (free tier 2k queries/month). The plan also
-// listed a DuckDuckGo HTML scraping fallback; we deferred that to a
-// later release because HTML scraping is fragile (DDG can change markup
-// any day) and would need its own test infrastructure.
+// RFC BB: WebSearch is now a multi-provider FALLBACK CIRCUIT over the
+// internal/search catalog (brave/serper/exa/tavily/searxng). It walks the
+// resolver's cascade, resolves each provider's key (a tenant CredentialDef
+// overrides the operator host key; RFC AR/AX), and on error/empty falls over to
+// the next provider — the model sees the same title/URL/snippet text regardless
+// of which provider answered.
 type WebSearch struct {
-	// APIKey for Brave. Required: empty key refuses every call.
-	APIKey string
-	// Endpoint overrides Brave's URL — for tests. Default uses Brave.
-	Endpoint string
+	// Registry is the constructed set of search providers; Resolver holds the
+	// fallback order + last-outcome availability. Both nil = WebSearch refuses
+	// (no providers configured).
+	Registry *search.Registry
+	Resolver *search.Resolver
+	// HostKeys maps provider id → operator host API key (from cfg.Env). Each
+	// is passed to ResolveKeyOrOperator so a tenant CredentialDef of the same
+	// env-var name overrides it; a keyless provider (searxng) has no entry.
+	HostKeys map[string]string
+
 	// MaxResultsDefault is the default for max_results when unspecified.
 	// Plan default is 5. Hard ceiling 25 regardless of caller value.
 	MaxResultsDefault int
-	// Timeout per call. Default 15s.
+	// Timeout per provider attempt. Default 15s.
 	Timeout time.Duration
-	// HTTPClient overrides the default. Tests inject one to control
-	// dialing; in production the default *http.Client is used.
-	HTTPClient *http.Client
-	// AllowedHosts narrows the result set to URLs whose host suffix-
-	// matches one of these entries. nil = no narrowing (return what
-	// Brave returned). The per-run wrapper in narrowing.go sets this.
+	// AllowedHosts narrows results to URLs whose host suffix-matches one of
+	// these. nil = no narrowing. The per-run wrapper in narrowing.go sets it.
 	AllowedHosts []string
-	// FilterMode selects what happens to results whose URL host isn't
-	// in AllowedHosts. WebSearchFilterDrop (default when AllowedHosts
-	// is set) omits non-matching results entirely; WebSearchFilterKeep
-	// returns everything Brave returned and lets the caller filter
-	// downstream. Ignored when AllowedHosts is nil.
+	// FilterMode: WebSearchFilterDrop (default when AllowedHosts is set) omits
+	// non-matching results; WebSearchFilterKeep returns everything. Ignored
+	// when AllowedHosts is nil.
 	FilterMode string
 }
 
-// FilterMode constants for WebSearch.FilterMode. The wire form
-// (carried in the HTTP request body) uses these exact strings.
+// FilterMode constants for WebSearch.FilterMode.
 const (
 	WebSearchFilterDrop = "drop"
 	WebSearchFilterKeep = "keep"
@@ -62,14 +62,13 @@ func (s *WebSearch) Description() string {
 }
 
 func (s *WebSearch) InputSchema() json.RawMessage {
-	// max_results: model-facing cap is wide enough that overshoot
-	// (model trained on WebSearch APIs that allow up to 100) does
-	// not produce a schema-violation error round-trip; the runtime
-	// silently clamps to maxResultsHard = 25 in Execute(). Without
-	// this widening, a single overshoot like max_results=30 made
-	// the agent believe the tool itself was broken and cascade
-	// into elaborate-query retry loops (see job-searcher prod
-	// failure 2026-05-05).
+	// max_results: model-facing cap is wide enough that overshoot (model
+	// trained on WebSearch APIs that allow up to 100) does not produce a
+	// schema-violation error round-trip; the runtime silently clamps to
+	// maxResultsHard = 25 in Execute(). Without this widening, a single
+	// overshoot like max_results=30 made the agent believe the tool itself was
+	// broken and cascade into elaborate-query retry loops (see job-searcher
+	// prod failure 2026-05-05).
 	return json.RawMessage(`{
 		"type": "object",
 		"properties": {
@@ -83,7 +82,6 @@ func (s *WebSearch) InputSchema() json.RawMessage {
 const (
 	maxResultsHard    = 25
 	maxSnippetChars   = 256
-	defaultEndpoint   = "https://api.search.brave.com/res/v1/web/search"
 	defaultMaxResults = 5
 )
 
@@ -98,17 +96,10 @@ func (s *WebSearch) Execute(ctx context.Context, input json.RawMessage) (tools.R
 	if strings.TrimSpace(args.Query) == "" {
 		return tools.Result{Text: "query is required", IsError: true}, nil
 	}
-	// RFC AR: a tenant/user credential named BRAVE_API_KEY overrides the
-	// operator host key for that run (scope precedence agent > user > tenant),
-	// so a tenant can search on its own Brave quota; the host key is the
-	// fallback. RFC AX: a RESTRICTED run with no override gets
-	// ErrOperatorKeyForbidden (never the host key) — treated here as the
-	// existing empty-key refusal, so a restricted WebSearch call refuses
-	// cleanly. The key stays runtime-side — never surfaced to the model.
-	apiKey, _, _, err := providers.ResolveKeyOrOperator(ctx, "BRAVE_API_KEY", s.APIKey)
-	if err != nil || apiKey == "" {
-		return tools.Result{Text: "WebSearch requires BRAVE_API_KEY; refusing", IsError: true}, nil
+	if s.Registry == nil || s.Resolver == nil {
+		return tools.Result{Text: "WebSearch is not configured (no search providers)", IsError: true}, nil
 	}
+
 	max := args.MaxResults
 	if max <= 0 {
 		max = s.MaxResultsDefault
@@ -119,94 +110,99 @@ func (s *WebSearch) Execute(ctx context.Context, input json.RawMessage) (tools.R
 	if max > maxResultsHard {
 		max = maxResultsHard
 	}
-
-	endpoint := s.Endpoint
-	if endpoint == "" {
-		endpoint = defaultEndpoint
-	}
 	timeout := s.Timeout
 	if timeout == 0 {
 		timeout = 15 * time.Second
 	}
 	reqCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
+	q := search.Query{Text: args.Query, MaxResults: max}
 
-	q := url.Values{}
-	q.Set("q", args.Query)
-	q.Set("count", fmt.Sprint(max))
-	httpReq, err := http.NewRequestWithContext(reqCtx, "GET", endpoint+"?"+q.Encode(), nil)
-	if err != nil {
-		return tools.Result{Text: "build request: " + err.Error(), IsError: true}, nil
-	}
-	httpReq.Header.Set("Accept", "application/json")
-	httpReq.Header.Set("X-Subscription-Token", apiKey)
-
-	client := s.HTTPClient
-	if client == nil {
-		client = &http.Client{Timeout: timeout}
-	}
-	resp, err := client.Do(httpReq)
-	if err != nil {
-		return tools.Result{Text: "search request: " + err.Error(), IsError: true}, nil
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-	if err != nil {
-		return tools.Result{Text: "read search response: " + err.Error(), IsError: true}, nil
-	}
-	if resp.StatusCode != 200 {
-		return tools.Result{Text: fmt.Sprintf("brave search returned %d: %s", resp.StatusCode, string(body)), IsError: true}, nil
-	}
-
-	var parsed struct {
-		Web struct {
-			Results []struct {
-				Title       string `json:"title"`
-				URL         string `json:"url"`
-				Description string `json:"description"`
-			} `json:"results"`
-		} `json:"web"`
-	}
-	if err := json.Unmarshal(body, &parsed); err != nil {
-		return tools.Result{Text: "parse brave response: " + err.Error(), IsError: true}, nil
-	}
-	if len(parsed.Web.Results) == 0 {
-		return tools.Result{Text: "no results", IsError: false}, nil
-	}
-
-	// Per-run host narrowing — applied here so the filter is the LAST
-	// thing to touch the result list, after Brave's count and the
-	// hard-25 cap. Drop mode is the default when AllowedHosts is set;
-	// keep mode is opt-in for callers that want to see everything and
-	// filter downstream.
-	results := parsed.Web.Results
-	if s.AllowedHosts != nil && s.FilterMode != WebSearchFilterKeep {
-		filtered := results[:0]
-		for _, r := range results {
-			if u, err := url.Parse(r.URL); err == nil && hostAllowed(u.Hostname(), s.AllowedHosts) {
-				filtered = append(filtered, r)
-			}
+	// The fallback circuit: walk the cascade, skip un-keyable / cooled-down
+	// providers, and fall over on a failed or empty result. Phase 1 uses the
+	// global cascade; Phase 3 threads the per-agent search_providers list.
+	var lastErr error
+	sawSuccess := false
+	attempted := 0
+	for _, id := range s.Resolver.Cascade(nil) {
+		p, ok := s.Registry.Get(id)
+		if !ok {
+			continue // in the priority list but not built (shouldn't happen post-validate)
 		}
-		results = filtered
-	}
-	if len(results) == 0 {
-		return tools.Result{Text: "no results"}, nil
+		if !s.Resolver.Available(id) {
+			continue // in a failure cooldown from an earlier call this process
+		}
+		apiKey := ""
+		if env := p.KeyEnvName(); env != "" {
+			// RFC AR: a tenant/user CredentialDef of this env-var name overrides
+			// the operator host key. RFC AX: a restricted run with no override
+			// gets ErrOperatorKeyForbidden. Either "no key" case → skip this
+			// provider silently (it isn't a failure, so no cooldown).
+			k, _, _, err := providers.ResolveKeyOrOperator(reqCtx, env, s.HostKeys[id])
+			if err != nil || k == "" {
+				continue
+			}
+			apiKey = k
+		}
+		attempted++
+		res, err := p.Search(reqCtx, q, apiKey)
+		if err != nil {
+			s.Resolver.MarkOutcome(id, err)
+			lastErr = err
+			log.Printf("websearch: provider %q failed: %v (falling over)", id, err)
+			continue
+		}
+		s.Resolver.MarkOutcome(id, nil)
+		sawSuccess = true
+		results := filterSearchHosts(res.Results, s.AllowedHosts, s.FilterMode)
+		if len(results) == 0 {
+			continue // empty (or filtered to empty) → try the next provider
+		}
+		return tools.Result{Text: renderSearchResults(results, max)}, nil
 	}
 
+	switch {
+	case attempted == 0:
+		return tools.Result{Text: "WebSearch: no keyable search provider is available; configure a search provider (search_providers/search_priority) and its API key", IsError: true}, nil
+	case sawSuccess:
+		return tools.Result{Text: "no results"}, nil
+	default:
+		return tools.Result{Text: "WebSearch: all providers failed; last error: " + lastErr.Error(), IsError: true}, nil
+	}
+}
+
+// filterSearchHosts applies the per-run host narrowing to the normalized
+// results — provider-agnostic, so it's the last thing to touch the list.
+func filterSearchHosts(in []search.Result, allowed []string, mode string) []search.Result {
+	if allowed == nil || mode == WebSearchFilterKeep {
+		return in
+	}
+	out := make([]search.Result, 0, len(in))
+	for _, r := range in {
+		if u, err := url.Parse(r.URL); err == nil && hostAllowed(u.Hostname(), allowed) {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// renderSearchResults renders normalized results as the numbered text list the
+// model has always seen. stripHTML handles Brave's <strong> highlight tags (a
+// no-op on the other providers' plain text).
+func renderSearchResults(results []search.Result, max int) string {
 	var b strings.Builder
 	rendered := 0
 	for _, r := range results {
 		if rendered >= max {
 			break
 		}
-		title := stripHTML(r.Title) // brave returns title with <strong> highlighting
-		desc := stripHTML(r.Description)
+		title := stripHTML(r.Title)
+		desc := stripHTML(r.Snippet)
 		if len(desc) > maxSnippetChars {
 			desc = desc[:maxSnippetChars] + "…"
 		}
 		rendered++
 		fmt.Fprintf(&b, "[%d] %s — %s\n   %s\n", rendered, title, r.URL, desc)
 	}
-	return tools.Result{Text: strings.TrimRight(b.String(), "\n")}, nil
+	return strings.TrimRight(b.String(), "\n")
 }

--- a/internal/tools/builtin/websearch_credkey_test.go
+++ b/internal/tools/builtin/websearch_credkey_test.go
@@ -24,7 +24,7 @@ func TestWebSearch_BraveKeyOverride(t *testing.T) {
 	input := json.RawMessage(`{"query":"hello"}`)
 
 	// (1) No override → host key on the wire.
-	ws := &WebSearch{APIKey: "host-key", Endpoint: srv.URL}
+	ws := braveWS(t, srv.URL, "host-key")
 	if res, err := ws.Execute(context.Background(), input); err != nil || res.IsError {
 		t.Fatalf("host-key call failed: err=%v res=%+v", err, res)
 	}
@@ -58,7 +58,7 @@ func TestWebSearch_RestrictedRunRefusesHostKey(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	ws := &WebSearch{APIKey: "host-key", Endpoint: srv.URL}
+	ws := braveWS(t, srv.URL, "host-key")
 	input := json.RawMessage(`{"query":"x"}`)
 
 	restricted := providers.WithOperatorKeyAllowed(context.Background(), false)
@@ -95,7 +95,7 @@ func TestWebSearch_TenantKeyEnablesWithNoHostKey(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	ws := &WebSearch{APIKey: "", Endpoint: srv.URL} // operator set no key
+	ws := braveWS(t, srv.URL, "") // operator set no key
 
 	// Without a tenant key the tool refuses (unchanged behavior).
 	if res, _ := ws.Execute(context.Background(), json.RawMessage(`{"query":"x"}`)); !res.IsError {

--- a/internal/tools/builtin/websearch_fallback_test.go
+++ b/internal/tools/builtin/websearch_fallback_test.go
@@ -1,0 +1,106 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/search"
+)
+
+// TestWebSearch_FallbackCircuit is the RFC BB headline: the primary provider
+// errors, so WebSearch falls over to the next provider in the cascade and
+// returns ITS results — and marks the failed provider stalled. Fail-before:
+// change Execute's "continue" on a provider error to "return the error" and
+// this test fails (it would surface brave's 500 instead of serper's results).
+func TestWebSearch_FallbackCircuit(t *testing.T) {
+	braveHit, serperHit := 0, 0
+	brave := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		braveHit++
+		w.WriteHeader(500)
+		_, _ = w.Write([]byte("boom"))
+	}))
+	defer brave.Close()
+	serper := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		serperHit++
+		_, _ = w.Write([]byte(`{"organic":[{"title":"S","link":"https://s.example","snippet":"snip"}]}`))
+	}))
+	defer serper.Close()
+
+	reg, err := search.BuildRegistry([]search.ProviderSpec{
+		{ID: "brave", Options: []search.Option{search.WithEndpoint(brave.URL)}},
+		{ID: "serper", Options: []search.Option{search.WithEndpoint(serper.URL)}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver := search.NewResolver([]string{"brave", "serper"})
+	ws := &WebSearch{Registry: reg, Resolver: resolver, HostKeys: map[string]string{"brave": "bk", "serper": "sk"}}
+
+	res, err := ws.Execute(context.Background(), json.RawMessage(`{"query":"x"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("fallback should have produced serper results, got error: %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "https://s.example") {
+		t.Errorf("expected serper's result on the wire, got %q", res.Text)
+	}
+	if braveHit != 1 || serperHit != 1 {
+		t.Errorf("expected brave once (failed) then serper once; braveHit=%d serperHit=%d", braveHit, serperHit)
+	}
+	if resolver.Available("brave") {
+		t.Error("brave should be stalled after its failure")
+	}
+	if !resolver.Available("serper") {
+		t.Error("serper should remain available after success")
+	}
+}
+
+// TestWebSearch_AllProvidersFail: when every provider errors, the tool surfaces
+// the last error (IsError) rather than a silent "no results".
+func TestWebSearch_AllProvidersFail(t *testing.T) {
+	fail := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(503)
+	}))
+	defer fail.Close()
+	reg, _ := search.BuildRegistry([]search.ProviderSpec{
+		{ID: "brave", Options: []search.Option{search.WithEndpoint(fail.URL)}},
+		{ID: "serper", Options: []search.Option{search.WithEndpoint(fail.URL)}},
+	})
+	ws := &WebSearch{Registry: reg, Resolver: search.NewResolver([]string{"brave", "serper"}), HostKeys: map[string]string{"brave": "k", "serper": "k"}}
+	res, _ := ws.Execute(context.Background(), json.RawMessage(`{"query":"x"}`))
+	if !res.IsError || !strings.Contains(res.Text, "all providers failed") {
+		t.Errorf("expected all-failed error, got %q", res.Text)
+	}
+}
+
+// TestWebSearch_SkipsUnkeyedProvider: a keyed provider with no key is skipped
+// (not a failure), and the cascade lands on the keyless provider that works.
+func TestWebSearch_SkipsUnkeyedProvider(t *testing.T) {
+	hit := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit++
+		_, _ = w.Write([]byte(`{"results":[{"title":"SX","url":"https://sx.example","content":"c"}]}`))
+	}))
+	defer srv.Close()
+	reg, _ := search.BuildRegistry([]search.ProviderSpec{
+		{ID: "serper", Options: []search.Option{search.WithEndpoint(srv.URL)}}, // no key → skipped
+		{ID: "searxng", BaseURL: srv.URL},                                      // keyless → runs
+	})
+	ws := &WebSearch{Registry: reg, Resolver: search.NewResolver([]string{"serper", "searxng"}), HostKeys: map[string]string{}}
+	res, _ := ws.Execute(context.Background(), json.RawMessage(`{"query":"x"}`))
+	if res.IsError {
+		t.Fatalf("expected searxng result, got error %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "sx.example") {
+		t.Errorf("expected searxng result, got %q", res.Text)
+	}
+	if hit != 1 {
+		t.Errorf("only searxng should have been hit (serper skipped, no key); hit=%d", hit)
+	}
+}

--- a/internal/tools/builtin/websearch_live_test.go
+++ b/internal/tools/builtin/websearch_live_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/search"
 )
 
 // TestWebSearch_Live exercises the real Brave Search API through
@@ -29,9 +31,15 @@ func TestWebSearch_Live(t *testing.T) {
 		t.Skip("BRAVE_API_KEY not set; skipping live Brave call")
 	}
 
+	reg, err := search.BuildRegistry([]search.ProviderSpec{{ID: "brave"}}) // real Brave endpoint
+	if err != nil {
+		t.Fatalf("BuildRegistry: %v", err)
+	}
 	tool := &WebSearch{
-		APIKey:  apiKey,
-		Timeout: 20 * time.Second,
+		Registry: reg,
+		Resolver: search.NewResolver([]string{"brave"}),
+		HostKeys: map[string]string{"brave": apiKey},
+		Timeout:  20 * time.Second,
 	}
 
 	// Three queries chosen to mirror what job-searcher actually

--- a/internal/tools/builtin/websearch_test.go
+++ b/internal/tools/builtin/websearch_test.go
@@ -8,21 +8,57 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/search"
 )
 
-func TestWebSearchRefusesWithoutAPIKey(t *testing.T) {
-	s := &WebSearch{}
+// braveWS builds a WebSearch whose only provider is Brave, pointed at a test
+// server — the single-provider shape that exercises the render/clamp/filter
+// behaviour the pre-RFC-BB tests covered. hostKey is the operator Brave key
+// (resolved via ResolveKeyOrOperator, so a ctx CredentialDef can override it).
+func braveWS(t *testing.T, endpoint, hostKey string) *WebSearch {
+	t.Helper()
+	reg, err := search.BuildRegistry([]search.ProviderSpec{
+		{ID: "brave", Options: []search.Option{search.WithEndpoint(endpoint)}},
+	})
+	if err != nil {
+		t.Fatalf("BuildRegistry: %v", err)
+	}
+	return &WebSearch{
+		Registry: reg,
+		Resolver: search.NewResolver([]string{"brave"}),
+		HostKeys: map[string]string{"brave": hostKey},
+	}
+}
+
+func TestWebSearchRefusesWhenUnconfigured(t *testing.T) {
+	s := &WebSearch{} // nil registry
 	res, err := s.Execute(context.Background(), json.RawMessage(`{"query":"x"}`))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !res.IsError || !strings.Contains(res.Text, "BRAVE_API_KEY") {
-		t.Errorf("expected api-key refusal, got %q", res.Text)
+	if !res.IsError || !strings.Contains(res.Text, "not configured") {
+		t.Errorf("expected not-configured refusal, got %q", res.Text)
+	}
+}
+
+func TestWebSearchRefusesWithoutKey(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"web":{"results":[]}}`)
+	}))
+	defer srv.Close()
+	s := braveWS(t, srv.URL, "") // configured, but no operator key + no tenant cred
+	res, err := s.Execute(context.Background(), json.RawMessage(`{"query":"x"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError || !strings.Contains(res.Text, "no keyable") {
+		t.Errorf("expected no-keyable refusal, got %q", res.Text)
 	}
 }
 
 func TestWebSearchRefusesEmptyQuery(t *testing.T) {
-	s := &WebSearch{APIKey: "k"}
+	s := &WebSearch{} // the empty-query check precedes the registry check
 	res, err := s.Execute(context.Background(), json.RawMessage(`{"query":"   "}`))
 	if err != nil {
 		t.Fatal(err)
@@ -32,9 +68,9 @@ func TestWebSearchRefusesEmptyQuery(t *testing.T) {
 	}
 }
 
-// Plumb a fake Brave server. Verifies: token header is sent, count
-// comes from max_results, response is rendered in the documented
-// "[N] Title — URL\n   snippet" shape.
+// Plumb a fake Brave server. Verifies: token header is sent (resolved from the
+// operator key), count comes from max_results, response is rendered in the
+// documented "[N] Title — URL\n   snippet" shape.
 func TestWebSearchSuccessfulQuery(t *testing.T) {
 	var seenToken, seenQuery, seenCount string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -49,7 +85,7 @@ func TestWebSearchSuccessfulQuery(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	s := &WebSearch{APIKey: "secret123", Endpoint: srv.URL}
+	s := braveWS(t, srv.URL, "secret123")
 	body, _ := json.Marshal(map[string]any{"query": "what is foo", "max_results": 2})
 	res, err := s.Execute(context.Background(), body)
 	if err != nil {
@@ -58,7 +94,6 @@ func TestWebSearchSuccessfulQuery(t *testing.T) {
 	if res.IsError {
 		t.Fatalf("unexpected error: %q", res.Text)
 	}
-
 	if seenToken != "secret123" {
 		t.Errorf("token header = %q, want secret123", seenToken)
 	}
@@ -68,7 +103,6 @@ func TestWebSearchSuccessfulQuery(t *testing.T) {
 	if seenCount != "2" {
 		t.Errorf("count = %q, want 2", seenCount)
 	}
-
 	want := "[1] Foo — https://foo.example/\n   about foo\n[2] Bar — https://bar.example/\n   about bar"
 	if res.Text != want {
 		t.Errorf("rendered output mismatch:\n got: %q\nwant: %q", res.Text, want)
@@ -84,7 +118,7 @@ func TestWebSearchHardMaxResultsCeiling(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	s := &WebSearch{APIKey: "k", Endpoint: srv.URL}
+	s := braveWS(t, srv.URL, "k")
 	body, _ := json.Marshal(map[string]any{"query": "x", "max_results": 999})
 	_, _ = s.Execute(context.Background(), body)
 	if seenCount != "25" {
@@ -92,14 +126,9 @@ func TestWebSearchHardMaxResultsCeiling(t *testing.T) {
 	}
 }
 
-// Snippet truncation at 256 chars so a long Brave description can't blow
-// the model's context window.
-// Defence in depth: even if Brave returns more results than we asked
-// for (server bug or unexpected response shape), the rendering loop
-// must still cap at max. Without this clamp a misbehaving search
-// backend could blow the model's context window.
-func TestWebSearchClampsBraveOverflow(t *testing.T) {
-	// Hand-craft a response with 30 results.
+// Defence in depth: even if the provider returns more results than asked, the
+// rendering loop must still cap at max.
+func TestWebSearchClampsProviderOverflow(t *testing.T) {
 	var sb strings.Builder
 	sb.WriteString(`{"web":{"results":[`)
 	for i := 0; i < 30; i++ {
@@ -116,7 +145,7 @@ func TestWebSearchClampsBraveOverflow(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	s := &WebSearch{APIKey: "k", Endpoint: srv.URL}
+	s := braveWS(t, srv.URL, "k")
 	body, _ := json.Marshal(map[string]any{"query": "x", "max_results": 9999})
 	res, err := s.Execute(context.Background(), body)
 	if err != nil {
@@ -125,16 +154,13 @@ func TestWebSearchClampsBraveOverflow(t *testing.T) {
 	if res.IsError {
 		t.Fatalf("unexpected error: %q", res.Text)
 	}
-	// The rendered output should have exactly 25 lines that start with "[" —
-	// one per result.
 	count := strings.Count(res.Text, "\n[")
-	// Number of [N] markers = newline-prefixed [ + the very first one.
 	if !strings.HasPrefix(res.Text, "[") {
 		t.Fatalf("output should start with [1] marker; got %q", res.Text[:min(len(res.Text), 80)])
 	}
 	count++
 	if count != 25 {
-		t.Errorf("rendered %d result blocks, want 25 (hard cap on Brave-side overflow)", count)
+		t.Errorf("rendered %d result blocks, want 25 (hard cap on provider-side overflow)", count)
 	}
 }
 
@@ -152,7 +178,7 @@ func TestWebSearchTruncatesLongSnippet(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	s := &WebSearch{APIKey: "k", Endpoint: srv.URL}
+	s := braveWS(t, srv.URL, "k")
 	body, _ := json.Marshal(map[string]string{"query": "x"})
 	res, err := s.Execute(context.Background(), body)
 	if err != nil {
@@ -163,6 +189,7 @@ func TestWebSearchTruncatesLongSnippet(t *testing.T) {
 	}
 }
 
+// A provider error is surfaced (after the fallback circuit exhausts the cascade).
 func TestWebSearchSurfacesUpstreamError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(429)
@@ -170,7 +197,7 @@ func TestWebSearchSurfacesUpstreamError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	s := &WebSearch{APIKey: "k", Endpoint: srv.URL}
+	s := braveWS(t, srv.URL, "k")
 	body, _ := json.Marshal(map[string]string{"query": "x"})
 	res, err := s.Execute(context.Background(), body)
 	if err != nil {
@@ -182,9 +209,6 @@ func TestWebSearchSurfacesUpstreamError(t *testing.T) {
 }
 
 // Per-run host narrowing — drop mode (default when AllowedHosts is set).
-// Brave returns three results across two hosts; AllowedHosts permits
-// only one host. The other host's result must be omitted, and indices
-// must renumber so the model sees [1] not [3].
 func TestWebSearchAllowedHostsDropMode(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, `{"web":{"results":[
@@ -195,12 +219,8 @@ func TestWebSearchAllowedHostsDropMode(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	s := &WebSearch{
-		APIKey:       "k",
-		Endpoint:     srv.URL,
-		AllowedHosts: []string{"allowed.example"},
-		// FilterMode unset → defaults to drop.
-	}
+	s := braveWS(t, srv.URL, "k")
+	s.AllowedHosts = []string{"allowed.example"} // FilterMode unset → drop
 	body, _ := json.Marshal(map[string]string{"query": "x"})
 	res, err := s.Execute(context.Background(), body)
 	if err != nil {
@@ -215,7 +235,6 @@ func TestWebSearchAllowedHostsDropMode(t *testing.T) {
 	if !strings.Contains(res.Text, "allowed.example/a") || !strings.Contains(res.Text, "allowed.example/c") {
 		t.Errorf("allowed hosts missing: %q", res.Text)
 	}
-	// Renumbering: only two results survive — should be [1] and [2], not [1] and [3].
 	if !strings.HasPrefix(res.Text, "[1]") {
 		t.Errorf("first result should be [1]; got prefix %q", res.Text[:min(len(res.Text), 50)])
 	}
@@ -228,9 +247,6 @@ func TestWebSearchAllowedHostsDropMode(t *testing.T) {
 }
 
 // Per-run host narrowing — keep mode (caller filters downstream).
-// Brave's full result set comes through unchanged; the model receives
-// every URL so it can reason about them. The contract: AllowedHosts
-// is informational here, NOT enforced.
 func TestWebSearchAllowedHostsKeepMode(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, `{"web":{"results":[
@@ -240,12 +256,9 @@ func TestWebSearchAllowedHostsKeepMode(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	s := &WebSearch{
-		APIKey:       "k",
-		Endpoint:     srv.URL,
-		AllowedHosts: []string{"allowed.example"},
-		FilterMode:   WebSearchFilterKeep,
-	}
+	s := braveWS(t, srv.URL, "k")
+	s.AllowedHosts = []string{"allowed.example"}
+	s.FilterMode = WebSearchFilterKeep
 	body, _ := json.Marshal(map[string]string{"query": "x"})
 	res, err := s.Execute(context.Background(), body)
 	if err != nil {
@@ -262,8 +275,7 @@ func TestWebSearchAllowedHostsKeepMode(t *testing.T) {
 	}
 }
 
-// Edge: AllowedHosts set, drop mode, ALL Brave results filtered out.
-// Should return "no results" (matching the empty-Brave-response shape).
+// AllowedHosts set, drop mode, ALL results filtered out → "no results".
 func TestWebSearchAllowedHostsDropAllFiltered(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, `{"web":{"results":[
@@ -272,7 +284,8 @@ func TestWebSearchAllowedHostsDropAllFiltered(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	s := &WebSearch{APIKey: "k", Endpoint: srv.URL, AllowedHosts: []string{"only.example"}}
+	s := braveWS(t, srv.URL, "k")
+	s.AllowedHosts = []string{"only.example"}
 	body, _ := json.Marshal(map[string]string{"query": "x"})
 	res, err := s.Execute(context.Background(), body)
 	if err != nil {
@@ -292,7 +305,7 @@ func TestWebSearchEmptyResults(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	s := &WebSearch{APIKey: "k", Endpoint: srv.URL}
+	s := braveWS(t, srv.URL, "k")
 	body, _ := json.Marshal(map[string]string{"query": "obscure"})
 	res, err := s.Execute(context.Background(), body)
 	if err != nil {


### PR DESCRIPTION
Phase 1 of **RFC BB** (`/loomcycle/rfcs/search-providers-firstclass`): make web search first-class like LLM providers — a provider connector, a fallback circuit, and the config surface. No wire change; the `WebSearch` output is byte-identical.

## What

**`internal/search`** — the search analog of `internal/providers`:
- `Provider` interface (`ID`/`Search`/`KeyEnvName`/`Probe`) + `Query`/`Result`/`Results`.
- Five pure-HTTP drivers — **brave** (lifted from WebSearch), **serper**, **exa**, **tavily**, **searxng** — each normalizing its JSON to a common `{Title,URL,Snippet}`.
- A flat `Resolver` (`Cascade` over a global priority or per-agent override + a last-outcome cooldown — no active probing of paid providers) and a `Registry`.
- Drivers are deliberately pure HTTP clients (take an already-resolved key), so the package imports neither `internal/providers` nor `internal/tools`.

**Config** (`internal/config`) — `search_providers:` (enabled drivers + SearXNG `base_url`), `search_priority:` (global fallback order), `AgentDef.search_providers` (per-agent list), and `cfg.Env` SERPER/EXA/TAVILY keys (BRAVE existed; all `*_API_KEY` auto-redacted). Validation mirrors `provider_priority`: unknown provider / missing SearXNG base_url / priority + agent lists referencing unconfigured providers all fail at load.

**`WebSearch`** — generalized into the **fallback circuit**: walks the cascade, resolves each provider's key via `ResolveKeyOrOperator` (tenant CredentialDef overrides the operator host key; RFC AR/AX restriction honored), and on a provider error/empty falls over to the next — same numbered text output. A failed provider is marked stalled; an un-keyable provider is skipped silently. `main.go` builds the registry from config with a **back-compat default**: pre-RFC-BB WebSearch worked on `BRAVE_API_KEY` alone, so with no explicit `search_providers` it defaults to Brave when that key is set.

## Scope boundary
Phase 1 uses the **global** cascade. Per-agent `search_providers` is parsed + validated here but **consumed** (ctx threading), hashed (`content_sha256`), and exposed on adapters in **Phase 3**; the **routing view + Web UI + fallback SSE event** are **Phase 2**.

## What was tested
- `go test ./...` — clean.
- `internal/search`: per-driver normalization + wire contract (method/auth header/params) via httptest; error paths; resolver + registry.
- `internal/config`: search validation + `SearchHostKey`.
- `internal/tools/builtin`: render/clamp/truncate/host-filter/empty behaviours on a single-Brave registry; the RFC AR/AX credential tests preserved; **NEW fallback regression** (provider #1 errors → returns provider #2 + marks #1 stalled — **verified fail-before**), all-providers-fail surfaces the error, unkeyed provider skipped.
- Build + `validate` smoke: a config with `search_providers` + an agent list loads; an agent referencing an unconfigured provider fails with a clear error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)