### PR TITLE
feat(routing): search-provider availability on Settings → Routing (RFC BB Phase 2)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1499,6 +1499,10 @@ func main() {
 	// RFC AX: the keyability probe backs credential-aware routing for a
 	// restricted run (resolves only to providers the tenant can key itself).
 	srv.SetCredKeyable(credKeyable)
+	// RFC BB: the search catalog for the routing view (GET /v1/_routing search
+	// block). Same registry/resolver the WebSearch tool uses; nil when no search
+	// providers are configured.
+	srv.SetSearchRouting(searchRegistry, searchResolver, searchHostKeys)
 
 	// RFC AA SQL Memory (Phase 1). Off by default; constructed only when the
 	// operator enables it. The manager hosts per-scope sqlite databases that

--- a/internal/api/http/routing.go
+++ b/internal/api/http/routing.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"sort"
@@ -32,6 +33,26 @@ type routingResponse struct {
 	// the tenant can key itself (needs no operator key, or has an own
 	// CredentialDef for it). Lets the UI show a "bring-your-own-key" note.
 	OperatorKeyRestricted bool `json:"operator_key_restricted,omitempty"`
+
+	// Search is the RFC BB web-search provider cascade — a single flat list
+	// (search has no tier/model dimension), each with keyability + live
+	// availability. Omitted when no search providers are configured.
+	Search []searchRoutingProvider `json:"search,omitempty"`
+}
+
+// searchRoutingProvider is one entry in the search cascade for the routing view.
+type searchRoutingProvider struct {
+	Provider string `json:"provider"`
+	Primary  bool   `json:"primary"` // first in the (post-filter) cascade
+	// Keyable: this caller has a usable key (operator host key when allowed, an
+	// own CredentialDef, or the provider is keyless). Available: keyable AND not
+	// in a failure cooldown. Selected: the first available provider (what runs
+	// now). Reachable: not in a cooldown, regardless of key.
+	Keyable   *bool  `json:"keyable,omitempty"`
+	Available *bool  `json:"available,omitempty"`
+	Selected  *bool  `json:"selected,omitempty"`
+	Reachable *bool  `json:"reachable,omitempty"`
+	LastError string `json:"last_error,omitempty"` // admin-only
 }
 
 type routingProvider struct {
@@ -197,11 +218,70 @@ func (s *Server) handleRouting(w http.ResponseWriter, r *http.Request) {
 		resp.Providers = append(resp.Providers, rp)
 	}
 
+	// RFC BB: the search-provider cascade — a flat list with keyability + live
+	// availability, same admin/tenant posture as the LLM cascade above (admin
+	// sees last_error; a restricted tenant sees only providers it can key).
+	if s.searchResolver != nil && s.searchRegistry != nil {
+		callerTenant, callerUser := "", ""
+		if !admin {
+			if p, ok := auth.PrincipalFromContext(r.Context()); ok {
+				callerTenant, callerUser = p.TenantID, p.Subject
+			}
+		}
+		allowOperatorKey := !restricted // a restricted tenant can't spend the operator host key
+		snap := s.searchResolver.Snapshot()
+		selectedMarked := false
+		for _, id := range s.searchResolver.Cascade(nil) {
+			p, ok := s.searchRegistry.Get(id)
+			if !ok {
+				continue
+			}
+			keyable := s.searchProviderKeyable(r.Context(), id, p.KeyEnvName(), callerTenant, callerUser, allowOperatorKey)
+			if restricted && !keyable {
+				continue // a restricted tenant sees only providers it can key
+			}
+			av := snap[id]
+			available := keyable && av.Reachable
+			sel := available && !selectedMarked
+			if sel {
+				selectedMarked = true
+			}
+			reachable := av.Reachable
+			sp := searchRoutingProvider{
+				Provider:  id,
+				Primary:   len(resp.Search) == 0,
+				Keyable:   &keyable,
+				Available: &available,
+				Selected:  &sel,
+				Reachable: &reachable,
+			}
+			if admin {
+				sp.LastError = av.LastError
+			}
+			resp.Search = append(resp.Search, sp)
+		}
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	_ = enc.Encode(resp)
+}
+
+// searchProviderKeyable reports whether this caller can supply a key for a
+// search provider: keyless (searxng) is always keyable; an operator host key
+// counts when allowed (a restricted tenant is denied it); otherwise the caller
+// must hold its own CredentialDef of the provider's env-var name (agent="" —
+// the routing view has no agent).
+func (s *Server) searchProviderKeyable(ctx context.Context, id, env, tenantID, userID string, allowOperatorKey bool) bool {
+	if env == "" {
+		return true
+	}
+	if allowOperatorKey && s.searchHostKeys[id] != "" {
+		return true
+	}
+	return s.credKeyable != nil && s.credKeyable(ctx, tenantID, "", userID, env)
 }
 
 // routingTierNames returns the configured tier names (keys of cfg.Tiers) in a

--- a/internal/api/http/search_routing_test.go
+++ b/internal/api/http/search_routing_test.go
@@ -1,0 +1,111 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/search"
+)
+
+func derefB(b *bool) bool { return b != nil && *b }
+
+func byProvider(sps []searchRoutingProvider) map[string]searchRoutingProvider {
+	m := map[string]searchRoutingProvider{}
+	for _, sp := range sps {
+		m[sp.Provider] = sp
+	}
+	return m
+}
+
+// TestRouting_SearchBlock_Admin: an admin sees the flat search cascade with
+// keyability (operator host key / keyless / cred) + the primary flag; the
+// operator-keyed provider is selected.
+func TestRouting_SearchBlock_Admin(t *testing.T) {
+	srv := routingTestServer(t)
+	reg, err := search.BuildRegistry([]search.ProviderSpec{
+		{ID: "serper"}, {ID: "brave"}, {ID: "searxng", BaseURL: "http://sx:8080"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// serper: operator host key → keyable. brave: no host key, no cred → not
+	// keyable. searxng: keyless → keyable.
+	srv.SetSearchRouting(reg, search.NewResolver([]string{"serper", "brave", "searxng"}),
+		map[string]string{"serper": "sk"})
+
+	resp := routingFor(t, srv, []string{auth.ScopeAdmin})
+	if len(resp.Search) != 3 {
+		t.Fatalf("admin should see 3 search providers, got %d: %+v", len(resp.Search), resp.Search)
+	}
+	if resp.Search[0].Provider != "serper" || !resp.Search[0].Primary {
+		t.Errorf("primary should be serper (cascade head): %+v", resp.Search[0])
+	}
+	m := byProvider(resp.Search)
+	if !derefB(m["serper"].Keyable) || !derefB(m["serper"].Available) || !derefB(m["serper"].Selected) {
+		t.Errorf("serper (host key, fresh) should be keyable+available+selected: %+v", m["serper"])
+	}
+	if derefB(m["brave"].Keyable) || derefB(m["brave"].Available) || derefB(m["brave"].Selected) {
+		t.Errorf("brave (no key) should be not-keyable/available/selected: %+v", m["brave"])
+	}
+	if !derefB(m["searxng"].Keyable) {
+		t.Errorf("searxng (keyless) should be keyable: %+v", m["searxng"])
+	}
+}
+
+// TestRouting_SearchBlock_FailoverSelected: a stalled provider is keyable but not
+// available, so "selected" moves to the next available provider; admin sees the
+// stalled provider's last_error.
+func TestRouting_SearchBlock_FailoverSelected(t *testing.T) {
+	srv := routingTestServer(t)
+	reg, _ := search.BuildRegistry([]search.ProviderSpec{{ID: "serper"}, {ID: "searxng", BaseURL: "http://sx"}})
+	res := search.NewResolver([]string{"serper", "searxng"})
+	res.MarkOutcome("serper", errors.New("boom")) // serper stalled
+	srv.SetSearchRouting(reg, res, map[string]string{"serper": "sk"})
+
+	resp := routingFor(t, srv, []string{auth.ScopeAdmin})
+	m := byProvider(resp.Search)
+	if derefB(m["serper"].Available) || derefB(m["serper"].Selected) {
+		t.Errorf("stalled serper should be unavailable + not selected: %+v", m["serper"])
+	}
+	if !derefB(m["searxng"].Selected) {
+		t.Errorf("searxng should be selected when serper is stalled: %+v", m["searxng"])
+	}
+	if m["serper"].LastError != "boom" {
+		t.Errorf("admin should see serper last_error; got %q", m["serper"].LastError)
+	}
+}
+
+// TestRouting_SearchBlock_RestrictedTenant: under LOOMCYCLE_OPERATOR_KEY_RESTRICTION,
+// a non-admin tenant with no own credential sees only providers it can key —
+// here just the keyless SearXNG (the operator's serper key is off-limits) — and
+// no last_error.
+func TestRouting_SearchBlock_RestrictedTenant(t *testing.T) {
+	srv := routingTestServer(t)
+	srv.cfg.Env.OperatorKeyRestriction = true
+	reg, _ := search.BuildRegistry([]search.ProviderSpec{{ID: "serper"}, {ID: "searxng", BaseURL: "http://sx"}})
+	srv.SetSearchRouting(reg, search.NewResolver([]string{"serper", "searxng"}), map[string]string{"serper": "sk"})
+	srv.SetCredKeyable(func(_ context.Context, _, _, _, _ string) bool { return false }) // tenant has no own cred
+
+	resp := routingFor(t, srv, []string{auth.ScopeTenant})
+	if !resp.OperatorKeyRestricted {
+		t.Error("expected operator_key_restricted=true for a restricted tenant")
+	}
+	if len(resp.Search) != 1 || resp.Search[0].Provider != "searxng" {
+		t.Fatalf("restricted tenant should see only keyless searxng; got %+v", resp.Search)
+	}
+	if resp.Search[0].LastError != "" {
+		t.Error("tenant must not see last_error")
+	}
+}
+
+// TestRouting_SearchBlock_OmittedWhenUnconfigured: no search providers → no
+// search block (back-compat: the LLM routing view is unchanged).
+func TestRouting_SearchBlock_OmittedWhenUnconfigured(t *testing.T) {
+	srv := routingTestServer(t) // no SetSearchRouting
+	resp := routingFor(t, srv, []string{auth.ScopeAdmin})
+	if resp.Search != nil {
+		t.Errorf("search block should be omitted when unconfigured; got %+v", resp.Search)
+	}
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -38,6 +38,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/resolve"
 	"github.com/denn-gubsky/loomcycle/internal/runner"
 	"github.com/denn-gubsky/loomcycle/internal/runstate"
+	"github.com/denn-gubsky/loomcycle/internal/search"
 	"github.com/denn-gubsky/loomcycle/internal/skillmatch"
 	"github.com/denn-gubsky/loomcycle/internal/skills"
 	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
@@ -134,6 +135,16 @@ type Server struct {
 	// a keyless provider). Called in the SERVER before Resolve — the lock-free
 	// resolver never does credential-store I/O.
 	credKeyable func(ctx context.Context, tenantID, agentName, userID, name string) bool
+
+	// searchRegistry / searchResolver / searchHostKeys back the RFC BB search
+	// routing view (GET /v1/_routing → "search" block). searchHostKeys maps a
+	// provider id → its operator host key value (non-empty = the operator can
+	// key it); "" for a keyless provider. All nil when no search providers are
+	// configured. Wired via SetSearchRouting (main.go), mirroring the other
+	// optional deps; the WebSearch tool holds its own copies for the run path.
+	searchRegistry *search.Registry
+	searchResolver *search.Resolver
+	searchHostKeys map[string]string
 
 	// limits is the RFC AW per-scope token-budget tracker: month-to-date
 	// counters + cached soft/hard ceilings, checked at admission and
@@ -827,6 +838,16 @@ func (s *Server) SetCredentialResolver(r providers.CredentialResolver) { s.credR
 // before resolution. Nil ⇒ no provider is tenant-keyable.
 func (s *Server) SetCredKeyable(fn func(ctx context.Context, tenantID, agentName, userID, name string) bool) {
 	s.credKeyable = fn
+}
+
+// SetSearchRouting wires the RFC BB search catalog for the routing view (main.go
+// calls it after construction). hostKeys maps a provider id → its operator host
+// key value; a keyless provider (searxng) has no entry. All-nil = no search
+// providers configured (the "search" routing block is then omitted).
+func (s *Server) SetSearchRouting(reg *search.Registry, res *search.Resolver, hostKeys map[string]string) {
+	s.searchRegistry = reg
+	s.searchResolver = res
+	s.searchHostKeys = hostKeys
 }
 
 // markStalledFn returns a closure suitable for loop.RunOptions.MarkStalled.

--- a/internal/search/resolver.go
+++ b/internal/search/resolver.go
@@ -11,6 +11,13 @@ import (
 // provider on one blip.
 const DefaultCooldown = 60 * time.Second
 
+// Availability is one provider's live status for the routing view (RFC BB).
+type Availability struct {
+	Reachable    bool      // outside any failure cooldown right now
+	LastError    string    // last failure text; "" when healthy
+	StalledUntil time.Time // cooldown expiry; zero = never failed
+}
+
 // Resolver is the search analog of resolve.Resolver, minus the tier/model
 // matrix: a single flat priority order + a per-provider last-outcome cooldown
 // (RFC BB — no active probing of paid providers). Safe for concurrent use.
@@ -18,7 +25,12 @@ type Resolver struct {
 	mu       sync.RWMutex
 	priority []string
 	cooldown time.Duration
-	stalled  map[string]time.Time // provider id → cooldown expiry
+	state    map[string]*provState // provider id → last-outcome state
+}
+
+type provState struct {
+	stalledUntil time.Time
+	lastErr      string
 }
 
 // NewResolver builds a resolver over the global default priority order.
@@ -26,7 +38,7 @@ func NewResolver(priority []string) *Resolver {
 	return &Resolver{
 		priority: append([]string(nil), priority...),
 		cooldown: DefaultCooldown,
-		stalled:  map[string]time.Time{},
+		state:    map[string]*provState{},
 	}
 }
 
@@ -46,20 +58,42 @@ func (r *Resolver) Cascade(agentList []string) []string {
 func (r *Resolver) Available(id string) bool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	until, ok := r.stalled[id]
-	return !ok || !time.Now().Before(until)
+	st, ok := r.state[id]
+	return !ok || !time.Now().Before(st.stalledUntil)
 }
 
 // MarkOutcome records the result of a Search call: nil clears any cooldown
 // (success), a non-nil error opens a cooldown window (last-outcome
-// availability). NOT called for ErrNotKeyable or empty-but-ok results — those
-// aren't provider failures.
+// availability). NOT called for an un-keyable skip or an empty-but-ok result —
+// those aren't provider failures.
 func (r *Resolver) MarkOutcome(id string, err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if err == nil {
-		delete(r.stalled, id)
+		delete(r.state, id)
 		return
 	}
-	r.stalled[id] = time.Now().Add(r.cooldown)
+	r.state[id] = &provState{stalledUntil: time.Now().Add(r.cooldown), lastErr: err.Error()}
+}
+
+// Snapshot returns the live availability of every provider in the priority
+// order — the routing view's data source.
+func (r *Resolver) Snapshot() map[string]Availability {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	now := time.Now()
+	out := make(map[string]Availability, len(r.priority))
+	for _, id := range r.priority {
+		st := r.state[id]
+		if st == nil {
+			out[id] = Availability{Reachable: true}
+			continue
+		}
+		out[id] = Availability{
+			Reachable:    !now.Before(st.stalledUntil),
+			LastError:    st.lastErr,
+			StalledUntil: st.stalledUntil,
+		}
+	}
+	return out
 }

--- a/internal/search/resolver_test.go
+++ b/internal/search/resolver_test.go
@@ -46,6 +46,34 @@ func TestResolver_MarkOutcomeAvailability(t *testing.T) {
 	}
 }
 
+func TestResolver_Snapshot(t *testing.T) {
+	r := NewResolver([]string{"brave", "serper"})
+	// Fresh: everything reachable, no error.
+	snap := r.Snapshot()
+	if len(snap) != 2 || !snap["brave"].Reachable || snap["brave"].LastError != "" {
+		t.Fatalf("fresh snapshot = %+v", snap)
+	}
+	// A failure records reachable=false + the last error text.
+	r.MarkOutcome("serper", errors.New("429 rate limited"))
+	snap = r.Snapshot()
+	if snap["serper"].Reachable {
+		t.Error("serper should be unreachable after a failure")
+	}
+	if snap["serper"].LastError != "429 rate limited" {
+		t.Errorf("serper LastError = %q, want the failure text", snap["serper"].LastError)
+	}
+	if snap["serper"].StalledUntil.IsZero() {
+		t.Error("serper StalledUntil should be set")
+	}
+	if !snap["brave"].Reachable {
+		t.Error("brave should stay reachable")
+	}
+	// Snapshot only covers providers in the priority order.
+	if _, ok := r.Snapshot()["exa"]; ok {
+		t.Error("Snapshot should not include a provider outside the priority")
+	}
+}
+
 func equal(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -2320,6 +2320,25 @@ export interface RoutingResponse {
    * key, or has an own CredentialDef). The UI shows a bring-your-own-key note.
    */
   operator_key_restricted?: boolean;
+  /**
+   * RFC BB: the web-search provider cascade — a single flat list (search has no
+   * tier/model dimension), each with keyability + live availability. Omitted
+   * when no search providers are configured.
+   */
+  search?: SearchRoutingProvider[];
+}
+
+// SearchRoutingProvider is one entry in the RFC BB search cascade: the ordered
+// web-search providers, each with whether this caller can key it + its live
+// availability. Rendered by field presence, like the LLM cascade.
+export interface SearchRoutingProvider {
+  provider: string;
+  primary: boolean; // first in the (post-filter) cascade
+  keyable?: boolean; // this caller has a usable key (operator/own-cred/keyless)
+  available?: boolean; // keyable AND not in a failure cooldown
+  selected?: boolean; // the first available provider — what runs now
+  reachable?: boolean; // not in a cooldown, regardless of key
+  last_error?: string; // admin-only
 }
 
 export function getRouting(): Promise<RoutingResponse> {

--- a/web/src/pages/RoutingView.tsx
+++ b/web/src/pages/RoutingView.tsx
@@ -3,6 +3,7 @@ import {
   RoutingCandidate,
   RoutingResponse,
   RoutingTier,
+  SearchRoutingProvider,
   getRouting,
 } from "../api";
 
@@ -157,8 +158,64 @@ export default function RoutingView() {
       {resp && resp.user_tiers.length === 0 && (
         <div className="empty">no tiers configured.</div>
       )}
+
+      {resp && resp.search && resp.search.length > 0 && (
+        <section className="routing-usertier">
+          <h2>search providers</h2>
+          <div className="routing-tier-grid">
+            <div className="routing-tier-card">
+              <div className="routing-tier-title">web search</div>
+              <ol className="routing-cascade">
+                {resp.search.map((sp, i) => (
+                  <SearchRow key={`${sp.provider}/${i}`} sp={sp} />
+                ))}
+              </ol>
+            </div>
+          </div>
+        </section>
+      )}
     </div>
   );
+}
+
+function SearchRow({ sp }: { sp: SearchRoutingProvider }) {
+  const hasAvail = sp.available !== undefined;
+  const selected = sp.selected === true;
+  const rowClass = [
+    "routing-cand",
+    selected ? "selected" : "",
+    hasAvail && !sp.available ? "unavail" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    <li className={rowClass}>
+      <span className="routing-rank">{sp.primary ? "top" : "fallback"}</span>
+      {hasAvail && (
+        <span
+          className={`routing-dot ${sp.available ? "up" : "down"}`}
+          title={searchStatusText(sp)}
+          aria-hidden="true"
+        />
+      )}
+      <span className="routing-provider">{sp.provider}</span>
+      {sp.keyable === false && (
+        <span className="routing-model" title="no usable key for your scope">
+          no key
+        </span>
+      )}
+      {selected && <span className="routing-selected-badge">selected</span>}
+    </li>
+  );
+}
+
+// searchStatusText: a human hover string for a search provider's dot.
+function searchStatusText(sp: SearchRoutingProvider): string {
+  if (sp.keyable === false) return "no usable key for your scope";
+  if (sp.available) return "available";
+  if (sp.last_error) return `in cooldown: ${sp.last_error}`;
+  if (sp.reachable === false) return "in failure cooldown";
+  return "unavailable";
 }
 
 function TierCard({ tier }: { tier: RoutingTier }) {

--- a/web/src/pages/SettingsView.tsx
+++ b/web/src/pages/SettingsView.tsx
@@ -125,7 +125,11 @@ const KNOWN_KEY_NAMES = [
   "DEEPSEEK_API_KEY",
   "GEMINI_API_KEY",
   "OLLAMA_API_KEY",
+  // Web-search providers (RFC BB).
   "BRAVE_API_KEY",
+  "SERPER_API_KEY",
+  "EXA_API_KEY",
+  "TAVILY_API_KEY",
 ];
 
 function CredentialsSection() {


### PR DESCRIPTION
Phase 2 of **RFC BB**: surface web-search providers on the **Settings → Routing** page — the operator's explicit ask ("display search providers availability on the Routing page").

## What

**Backend** — a flat `search` block on `GET /v1/_routing`:
- Re-adds `Resolver.Snapshot` + `Availability` (last-outcome reachability + `last_error`) to `internal/search`.
- Adds `searchRegistry`/`searchResolver`/`searchHostKeys` to the `Server` (wired via a new `SetSearchRouting` setter in `main.go` — same registry/resolver the WebSearch tool uses).
- Each entry: `keyable` / `available` / `selected` / `reachable` (+ admin-only `last_error`), computed with the **same admin/tenant posture as the LLM cascade**: keyable = keyless (searxng) OR an allowed operator host key OR the caller's own CredentialDef (`searchProviderKeyable` mirrors `keyableProvidersFor`); available = keyable AND not in a failure cooldown; selected = the first available (what runs now). A restricted tenant (RFC AX) sees only providers it can key + no `last_error`. The block is **omitted** when no search providers are configured (the LLM view is byte-unchanged).

**Web UI** — a "search providers" section on the Routing page rendering the cascade with availability dots + a "selected" badge + a "no key" marker, data-driven by field presence like the LLM cascade. Plus the Settings→Credentials key-name combobox gains SERPER/EXA/TAVILY_API_KEY.

## What was tested
- `go test ./...` — clean.
- `internal/search`: `Snapshot` (reachable/last_error/stalled).
- Routing: admin (keyable/selected), failover (stalled → selected moves + admin `last_error`), restricted tenant (filtered to keyless + no `last_error`), and omission when unconfigured.
- `tsc --noEmit` clean; `make build-all` embeds the SPA.
- **End-to-end boot smoke**: a config with `serper` (host-keyed) + `searxng` (keyless) → `GET /v1/_routing` returns the search block with serper `selected` and searxng the available fallback.

## Deferred to Phase 3
Per-agent `search_providers` *consumption* (ctx threading), `content_sha256` inclusion, adapter surface, and docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)