### PR TITLE
feat(search): per-agent search_providers + content_sha256 + docs (RFC BB Phase 3)

### DIFF
--- a/adapters/ts/src/types.ts
+++ b/adapters/ts/src/types.ts
@@ -1719,6 +1719,9 @@ export interface LibraryAgentDefinition {
   tools?: string[];
   skills?: string[];
   providers?: string[];
+  /** RFC BB: per-agent web-search fallback list — the ordered providers the
+   *  WebSearch tool tries (empty = the global search_priority default). */
+  search_providers?: string[];
   /** Per-tier candidate list. Server-side opaque shape — kept as
    *  Record<string, unknown> for forward-compat. */
   models?: Record<string, unknown>;

--- a/internal/agents/loader.go
+++ b/internal/agents/loader.go
@@ -85,6 +85,7 @@ type Agent struct {
 	SystemPrompt          string
 	SystemPromptFile      string
 	Providers             []string
+	SearchProviders       []string
 	Models                map[string][]TierCandidate
 	MemoryScopes          []string
 	MemoryQuotaBytes      int
@@ -298,6 +299,7 @@ type frontmatter struct {
 	MaxConcurrentChildren int                        `yaml:"max_concurrent_children"`
 	Skills                []string                   `yaml:"skills"`
 	Providers             []string                   `yaml:"providers"`
+	SearchProviders       []string                   `yaml:"search_providers"`
 	Models                map[string][]TierCandidate `yaml:"models"`
 	MemoryScopes          []string                   `yaml:"memory_scopes"`
 	MemoryQuotaBytes      int                        `yaml:"memory_quota_bytes"`
@@ -366,6 +368,7 @@ func parseAgent(raw []byte) (*Agent, error) {
 	a.MaxConcurrentChildren = fm.MaxConcurrentChildren
 	a.Skills = fm.Skills
 	a.Providers = fm.Providers
+	a.SearchProviders = fm.SearchProviders
 	a.Models = fm.Models
 	a.MemoryScopes = fm.MemoryScopes
 	a.MemoryQuotaBytes = fm.MemoryQuotaBytes

--- a/internal/agents/sign.go
+++ b/internal/agents/sign.go
@@ -130,6 +130,11 @@ type AgentContent struct {
 	Name                  string                     `json:"name,omitempty"`
 	Provider              string                     `json:"provider,omitempty"`
 	Providers             []string                   `json:"providers,omitempty"`
+	// SearchProviders is the per-agent web-search fallback list (RFC BB) —
+	// content-identifying like Providers (a fork that changes it must mint a
+	// distinct content_sha256). omitempty keeps pre-feature rows byte-stable;
+	// normalize() collapses an empty slice to nil.
+	SearchProviders []string `json:"search_providers,omitempty"`
 	// Sampling is the per-agent LLM sampling block (mirrors config.Sampling;
 	// the agents package stays config-free, so it's a local type). Content-
 	// identifying: a fork that only changes temperature must mint a distinct
@@ -192,6 +197,9 @@ func normalize(c *AgentContent) {
 	}
 	if len(c.Providers) == 0 {
 		c.Providers = nil
+	}
+	if len(c.SearchProviders) == 0 {
+		c.SearchProviders = nil
 	}
 	if len(c.Models) == 0 {
 		c.Models = nil
@@ -273,6 +281,7 @@ func FromYAMLAgent(a *Agent) AgentContent {
 		Tools:                 a.Tools,
 		SystemPrompt:          a.SystemPrompt,
 		Providers:             a.Providers,
+		SearchProviders:       a.SearchProviders,
 		Models:                a.Models,
 		MemoryScopes:          a.MemoryScopes,
 		MemoryQuotaBytes:      a.MemoryQuotaBytes,

--- a/internal/agents/sign_test.go
+++ b/internal/agents/sign_test.go
@@ -251,6 +251,57 @@ func TestFromYAMLAgent_EvaluationScopesAndInterruptionAffectHash(t *testing.T) {
 	}
 }
 
+// RFC BB: search_providers is content-identifying (like providers) — a fork
+// that changes ONLY the web-search fallback list must mint a distinct hash,
+// while an empty/unset list stays byte-identical to a pre-feature row.
+func TestFromYAMLAgent_SearchProvidersAffectHash(t *testing.T) {
+	bare := FromYAMLAgent(&Agent{Name: "x"})
+	withSearch := FromYAMLAgent(&Agent{Name: "x", SearchProviders: []string{"brave", "google"}})
+	if Sign(bare) == Sign(withSearch) {
+		t.Error("search_providers did NOT affect the hash — a fork changing only it would be wrongly deduped")
+	}
+	// A different list must produce a different hash again (order-sensitive,
+	// like providers).
+	reordered := FromYAMLAgent(&Agent{Name: "x", SearchProviders: []string{"google", "brave"}})
+	if Sign(withSearch) == Sign(reordered) {
+		t.Error("reordered search_providers hashed identically — order must be significant")
+	}
+	// Backward-compat: an empty search_providers hashes like bare so no
+	// pre-feature row is invalidated.
+	empty := FromYAMLAgent(&Agent{Name: "x", SearchProviders: []string{}})
+	if Sign(bare) != Sign(empty) {
+		t.Error("empty search_providers changed the hash — would invalidate every pre-feature row")
+	}
+}
+
+// TestFromOverlay_RoundTripMatchesYAMLAgent_WithSearchProviders is the path-
+// convergence guarantee for RFC BB: the SAME search_providers reaching the
+// hash via the yaml/.md path (FromYAMLAgent) vs the substrate-read path
+// (FromOverlay, which json-unmarshals the persisted `search_providers`) MUST
+// hash identically. signFromMergedDef (the substrate WRITE producer) also maps
+// def.SearchProviders into the same AgentContent, so all three converge — a
+// static yaml agent and its substrate fork agree on content_sha256.
+func TestFromOverlay_RoundTripMatchesYAMLAgent_WithSearchProviders(t *testing.T) {
+	agent := &Agent{
+		Name:            "researcher",
+		SystemPrompt:    "be thorough",
+		SearchProviders: []string{"brave", "google"},
+	}
+	hashFromYAML := Sign(FromYAMLAgent(agent))
+
+	overlay := json.RawMessage(`{
+		"name": "researcher",
+		"system_prompt": "be thorough",
+		"search_providers": ["brave", "google"]
+	}`)
+	parsed, _ := FromOverlay(overlay)
+	hashFromOverlay := Sign(parsed)
+
+	if hashFromYAML != hashFromOverlay {
+		t.Errorf("search_providers: yaml path vs overlay path diverged:\n %s\n %s", hashFromYAML, hashFromOverlay)
+	}
+}
+
 func TestFromYAMLAgent_ToolCapabilityScopesStillIgnored(t *testing.T) {
 	// The *_def_scopes gates (agent_def_scopes, …) govern which substrate tools
 	// the agent may CALL; they are NOT part of its authored definition and do

--- a/internal/api/http/library_unified.go
+++ b/internal/api/http/library_unified.go
@@ -320,6 +320,7 @@ type staticAgentDefJSON struct {
 	Tools                 []string                          `json:"tools,omitempty"`
 	Skills                []string                          `json:"skills,omitempty"`
 	Providers             []string                          `json:"providers,omitempty"`
+	SearchProviders       []string                          `json:"search_providers,omitempty"`
 	Models                map[string][]config.TierCandidate `json:"models,omitempty"`
 	MemoryScopes          []string                          `json:"memory_scopes,omitempty"`
 	MemoryQuotaBytes      int                               `json:"memory_quota_bytes,omitempty"`
@@ -345,6 +346,7 @@ func marshalStaticAgentDef(def config.AgentDef) json.RawMessage {
 		Tools:                 def.Tools,
 		Skills:                def.Skills,
 		Providers:             def.Providers,
+		SearchProviders:       def.SearchProviders,
 		Models:                def.Models,
 		MemoryScopes:          def.MemoryScopes,
 		MemoryQuotaBytes:      def.MemoryQuotaBytes,

--- a/internal/api/http/resume.go
+++ b/internal/api/http/resume.go
@@ -293,6 +293,8 @@ func (s *Server) resumePausedRun(ctx context.Context, run store.Run) error {
 	adPolicy, evPolicy := s.substratePoliciesForAgent(agentDef, run.Agent)
 	loopCtx = tools.WithAgentDefPolicy(loopCtx, adPolicy)
 	loopCtx = tools.WithSkillPolicy(loopCtx, s.skillPolicyForAgent(agentDef))
+	// RFC BB: per-agent web-search fallback list (empty = global search_priority).
+	loopCtx = tools.WithSearchProviders(loopCtx, agentDef.SearchProviders)
 	loopCtx = tools.WithVolumeDefPolicy(loopCtx, s.volumeDefPolicyForAgent(agentDef))
 	loopCtx = tools.WithEvaluationPolicy(loopCtx, evPolicy)
 	loopCtx = tools.WithHistoryPolicy(loopCtx, s.historyPolicyForAgent(agentDef))

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2182,6 +2182,8 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	adPolicy, evPolicy := s.substratePoliciesForAgent(agentDef, effectiveAgentName)
 	loopCtx = tools.WithAgentDefPolicy(loopCtx, adPolicy)
 	loopCtx = tools.WithSkillPolicy(loopCtx, s.skillPolicyForAgent(agentDef))
+	// RFC BB: per-agent web-search fallback list (empty = global search_priority).
+	loopCtx = tools.WithSearchProviders(loopCtx, agentDef.SearchProviders)
 	loopCtx = tools.WithVolumeDefPolicy(loopCtx, s.volumeDefPolicyForAgent(agentDef))
 	loopCtx = tools.WithEvaluationPolicy(loopCtx, evPolicy)
 	loopCtx = tools.WithHistoryPolicy(loopCtx, s.historyPolicyForAgent(agentDef))
@@ -3619,6 +3621,8 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	adPolicy, evPolicy := s.substratePoliciesForAgent(agentDef, req.Agent)
 	loopCtx = tools.WithAgentDefPolicy(loopCtx, adPolicy)
 	loopCtx = tools.WithSkillPolicy(loopCtx, s.skillPolicyForAgent(agentDef))
+	// RFC BB: per-agent web-search fallback list (empty = global search_priority).
+	loopCtx = tools.WithSearchProviders(loopCtx, agentDef.SearchProviders)
 	loopCtx = tools.WithVolumeDefPolicy(loopCtx, s.volumeDefPolicyForAgent(agentDef))
 	loopCtx = tools.WithEvaluationPolicy(loopCtx, evPolicy)
 	loopCtx = tools.WithHistoryPolicy(loopCtx, s.historyPolicyForAgent(agentDef))
@@ -4156,6 +4160,8 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	adPolicy, evPolicy := s.substratePoliciesForAgent(agentDef, sess.Agent)
 	loopCtx = tools.WithAgentDefPolicy(loopCtx, adPolicy)
 	loopCtx = tools.WithSkillPolicy(loopCtx, s.skillPolicyForAgent(agentDef))
+	// RFC BB: per-agent web-search fallback list (empty = global search_priority).
+	loopCtx = tools.WithSearchProviders(loopCtx, agentDef.SearchProviders)
 	loopCtx = tools.WithVolumeDefPolicy(loopCtx, s.volumeDefPolicyForAgent(agentDef))
 	loopCtx = tools.WithEvaluationPolicy(loopCtx, evPolicy)
 	loopCtx = tools.WithHistoryPolicy(loopCtx, s.historyPolicyForAgent(agentDef))
@@ -5248,6 +5254,7 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 	subADPolicy, subEvPolicy := s.substratePoliciesForAgent(def, name)
 	subCtx = tools.WithAgentDefPolicy(subCtx, subADPolicy)
 	subCtx = tools.WithSkillPolicy(subCtx, s.skillPolicyForAgent(def))
+	subCtx = tools.WithSearchProviders(subCtx, def.SearchProviders)
 	subCtx = tools.WithVolumeDefPolicy(subCtx, s.volumeDefPolicyForAgent(def))
 	subCtx = tools.WithEvaluationPolicy(subCtx, subEvPolicy)
 	subCtx = tools.WithHistoryPolicy(subCtx, s.historyPolicyForAgent(def))

--- a/internal/cli/hash.go
+++ b/internal/cli/hash.go
@@ -222,6 +222,7 @@ func runHashAgentByName(name, cfgPath string, stdout, stderr io.Writer) int {
 		Skills:                def.Skills,
 		SystemPrompt:          def.SystemPrompt,
 		Providers:             def.Providers,
+		SearchProviders:       def.SearchProviders,
 		Models:                convertConfigModels(def.Models),
 		MemoryScopes:          def.MemoryScopes,
 		MemoryQuotaBytes:      def.MemoryQuotaBytes,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4109,6 +4109,7 @@ func agentFromDiscovered(d *agents.Agent) AgentDef {
 		Tier:                  d.Tier,
 		Effort:                d.Effort,
 		Providers:             d.Providers,
+		SearchProviders:       d.SearchProviders,
 		MemoryScopes:          d.MemoryScopes,
 		MemoryQuotaBytes:      d.MemoryQuotaBytes,
 		MemoryBackend:         d.MemoryBackend,

--- a/internal/help/builtin/search-providers.md
+++ b/internal/help/builtin/search-providers.md
@@ -1,0 +1,92 @@
+---
+name: search-providers
+description: "Web search is a first-class, config-declared provider catalog with a fallback circuit (RFC BB) — Brave/Serper/Exa/Tavily/SearXNG behind the WebSearch tool, with per-agent priority + operator/tenant keys + a routing view."
+aliases: [search, websearch, web-search]
+---
+The `WebSearch` tool is a **multi-provider fallback circuit** (RFC BB), not a
+single backend. You call it the same way — `WebSearch("your query")` → a numbered
+list of title / URL / snippet — and the runtime routes the query to the first
+usable provider in a configured cascade, falling over to the next on an error,
+rate-limit, or empty result. The model sees the same shape regardless of which
+provider answered.
+
+You don't pick a provider per call. The operator configures the catalog + a
+default order; an agent may narrow/re-order it with a per-agent list.
+
+## The catalog
+
+Five built-in providers ship today:
+
+```
+brave     Brave Search API (own index).          key: BRAVE_API_KEY
+serper    Serper.dev — cheap Google SERP.        key: SERPER_API_KEY
+exa       Exa — neural/semantic + free tier.     key: EXA_API_KEY
+tavily    Tavily — RAG-tuned search.             key: TAVILY_API_KEY
+searxng   Self-hosted meta-search (70+ engines). KEYLESS (needs base_url)
+```
+
+## Operator config
+
+```yaml
+search_providers:            # which providers are enabled
+  serper: {}
+  exa: {}
+  brave: {}
+  searxng: { base_url: "http://searxng:8080" }   # SearXNG needs its URL
+search_priority: [serper, exa, brave, searxng]   # the global fallback order
+```
+
+With no `search_providers:` block, WebSearch defaults to Brave when
+`BRAVE_API_KEY` is set (the pre-RFC-BB behaviour, unchanged).
+
+## Per-agent fallback list
+
+An agent narrows or re-orders the cascade with its own `search_providers:` — a
+full override of the global order (empty = use the global default):
+
+```yaml
+agents:
+  researcher:
+    tools: [WebSearch]
+    search_providers: [serper, exa]   # try Serper, then Exa; nothing else
+```
+
+Every entry must be an enabled top-level `search_providers` key (validated at
+config load). A runtime-authored agent (AgentDef create/fork) carries the same
+field; it is content-identifying (part of `content_sha256`, like `providers:`).
+
+## Keys — operator and tenant
+
+Each keyed provider resolves its key the same way LLM providers do
+(`help(topic="per-run-credentials")`):
+
+1. A **tenant/user CredentialDef** of the provider's env-var name (e.g.
+   `SERPER_API_KEY`) — a tenant searches on its own quota. Author it via the
+   `CredentialDef` tool or the Web UI Settings → Credentials page.
+2. Else the **operator host key** from that env var (unless the run is
+   operator-key-restricted, RFC AX).
+
+A provider you have no key for is skipped silently (not a failure); SearXNG is
+keyless, so it always runs. A failed provider is put in a short cooldown before
+the circuit tries it again.
+
+## The routing view
+
+**Settings → Routing** shows the search cascade with, per provider: whether you
+can key it, whether it's available right now (last-outcome — paid APIs aren't
+health-probed), and which one is **selected** (the first available = what runs
+now). A restricted tenant sees only the providers it can key itself. Same data
+over `GET /v1/_routing` (the `search` block).
+
+## Provider-specific power features
+
+The fallback circuit is deliberately the lowest-common-denominator "web
+discovery" shape (title/URL/snippet). A provider's richer capabilities (Exa's
+`findSimilar`, Firecrawl's scrape) are **out** of the circuit — reach them by
+mounting that provider's own MCP server and calling its specific tool.
+
+## Cross-references
+
+- `help(topic="per-run-credentials")` — how `$cred:` / tenant keys resolve.
+- `Context op=self` — the resolved provider/model + your scope.
+- `Context op=tools` — confirm you hold the `WebSearch` tool.

--- a/internal/help/loader_test.go
+++ b/internal/help/loader_test.go
@@ -49,6 +49,7 @@ func TestLoadSet_BundledOnly(t *testing.T) {
 		"path",
 		"pause-resume-snapshot",
 		"scopes",
+		"search-providers",
 		"skills",
 		"skills-evolution",
 		"sqlite-vec",

--- a/internal/lookup/agent.go
+++ b/internal/lookup/agent.go
@@ -207,10 +207,15 @@ type SubstrateAgentDef struct {
 	// substrate write path (commit 3 of this PR) persisted it.
 	// Read-side normalizers fall back to SystemPrompt when this is
 	// empty (legacy rows that pre-date the write-side fix).
-	SystemPromptBase string                            `json:"system_prompt_base,omitempty"`
-	Tools            []string                          `json:"tools,omitempty"`
-	Skills           []string                          `json:"skills,omitempty"`
-	Providers        []string                          `json:"providers,omitempty"`
+	SystemPromptBase string   `json:"system_prompt_base,omitempty"`
+	Tools            []string `json:"tools,omitempty"`
+	Skills           []string `json:"skills,omitempty"`
+	Providers        []string `json:"providers,omitempty"`
+	// SearchProviders mirrors config.AgentDef.SearchProviders (RFC BB) so a
+	// runtime-authored agent's web-search fallback list survives the substrate
+	// round-trip instead of being silently dropped before the run. Kept in sync
+	// with builtin.mergedDef (the drift test pins it).
+	SearchProviders  []string                          `json:"search_providers,omitempty"`
 	Models           map[string][]config.TierCandidate `json:"models,omitempty"`
 	MemoryScopes     []string                          `json:"memory_scopes,omitempty"`
 	MemoryQuotaBytes int                               `json:"memory_quota_bytes,omitempty"`
@@ -267,6 +272,7 @@ func (s SubstrateAgentDef) ToConfigDef() config.AgentDef {
 		Tools:                 s.Tools,
 		Skills:                s.Skills,
 		Providers:             s.Providers,
+		SearchProviders:       s.SearchProviders,
 		Models:                s.Models,
 		MemoryScopes:          s.MemoryScopes,
 		MemoryQuotaBytes:      s.MemoryQuotaBytes,

--- a/internal/lookup/agent_test.go
+++ b/internal/lookup/agent_test.go
@@ -294,6 +294,7 @@ func TestAgent_DriftDetection(t *testing.T) {
 		"tools":                   true,
 		"skills":                  true,
 		"providers":               true,
+		"search_providers":        true, // RFC BB — per-agent web-search fallback list
 		"models":                  true,
 		"memory_scopes":           true,
 		"memory_quota_bytes":      true,

--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -863,6 +863,7 @@ type mergedDef struct {
 	Tools            []string                          `json:"tools,omitempty"`
 	Skills           []string                          `json:"skills,omitempty"`
 	Providers        []string                          `json:"providers,omitempty"`
+	SearchProviders  []string                          `json:"search_providers,omitempty"`
 	Models           map[string][]config.TierCandidate `json:"models,omitempty"`
 	MemoryScopes     []string                          `json:"memory_scopes,omitempty"`
 	MemoryQuotaBytes int                               `json:"memory_quota_bytes,omitempty"`
@@ -961,6 +962,9 @@ func (d *mergedDef) applyOverlay(ov mergedDef) {
 	if ov.Providers != nil {
 		d.Providers = ov.Providers
 	}
+	if ov.SearchProviders != nil {
+		d.SearchProviders = ov.SearchProviders
+	}
 	if ov.Models != nil {
 		d.Models = ov.Models
 	}
@@ -1052,6 +1056,7 @@ func staticToMergedDef(s config.AgentDef) mergedDef {
 		Tools:                 s.Tools,
 		Skills:                s.Skills,
 		Providers:             s.Providers,
+		SearchProviders:       s.SearchProviders,
 		Models:                s.Models,
 		MemoryScopes:          s.MemoryScopes,
 		MemoryQuotaBytes:      s.MemoryQuotaBytes,
@@ -1138,6 +1143,7 @@ func signFromMergedDef(name string, def mergedDef) string {
 		// content) — excluded from content_sha256 like the *_def_scopes gates.
 		SystemPrompt:     def.SystemPrompt,
 		Providers:        def.Providers,
+		SearchProviders:  def.SearchProviders,
 		Models:           models,
 		MemoryScopes:     def.MemoryScopes,
 		MemoryQuotaBytes: def.MemoryQuotaBytes,

--- a/internal/tools/builtin/agentdef_test.go
+++ b/internal/tools/builtin/agentdef_test.go
@@ -172,6 +172,59 @@ func TestAgentDefTool_ForkMergesSamplingPerField(t *testing.T) {
 	}
 }
 
+// TestAgentDefTool_SearchProvidersRoundTrips pins the RFC BB read-side
+// projection: a substrate agent authored with search_providers resolves to a
+// config.AgentDef carrying the list, proving it survives
+// mergedDef → SubstrateAgentDef → ToConfigDef (a dropped adapter line silently
+// reverts the agent to the library web-search default at run time).
+func TestAgentDefTool_SearchProvidersRoundTrips(t *testing.T) {
+	tool, ctx, cleanup := agentDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"searcher","overlay":{`+
+		`"system_prompt":"search","search_providers":["brave","google"]}}`))
+	if res.IsError {
+		t.Fatalf("create: %s", res.Text)
+	}
+	def, ok := lookup.Agent(context.Background(), tool.Store, tool.Cfg, "", "searcher")
+	if !ok {
+		t.Fatal("searcher did not resolve via lookup.Agent")
+	}
+	if got := def.SearchProviders; len(got) != 2 || got[0] != "brave" || got[1] != "google" {
+		t.Errorf("SearchProviders = %v, want [brave google] — dropped in mergedDef → SubstrateAgentDef → ToConfigDef", got)
+	}
+}
+
+// TestAgentDefTool_SearchProvidersAffectContentSHA proves search_providers is
+// content-identifying end-to-end: a fork that changes ONLY the web-search
+// fallback list must mint a DIFFERENT content_sha256 than its parent (exercises
+// signFromMergedDef, the substrate WRITE hash producer). If the field were
+// dropped from AgentContent, the fork would dedup as identical content.
+func TestAgentDefTool_SearchProvidersAffectContentSHA(t *testing.T) {
+	tool, ctx, cleanup := agentDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"searcher","overlay":{"system_prompt":"search"}}`))
+	if res.IsError {
+		t.Fatalf("create: %s", res.Text)
+	}
+	parentSHA, _ := decodeResult(t, res.Text)["content_sha256"].(string)
+
+	// Fork inheriting the parent, overlaying only search_providers.
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"fork","name":"searcher","overlay":{"search_providers":["brave"]}}`))
+	if res.IsError {
+		t.Fatalf("fork: %s", res.Text)
+	}
+	forkSHA, _ := decodeResult(t, res.Text)["content_sha256"].(string)
+
+	if parentSHA == "" || forkSHA == "" {
+		t.Fatalf("missing content_sha256: parent=%q fork=%q", parentSHA, forkSHA)
+	}
+	if parentSHA == forkSHA {
+		t.Errorf("fork adding search_providers produced the SAME content_sha256 %q — it is not part of the hash basis", parentSHA)
+	}
+}
+
 func TestAgentDefTool_CreateNewName(t *testing.T) {
 	tool, ctx, cleanup := agentDefFixture(t)
 	defer cleanup()

--- a/internal/tools/builtin/websearch.go
+++ b/internal/tools/builtin/websearch.go
@@ -119,12 +119,13 @@ func (s *WebSearch) Execute(ctx context.Context, input json.RawMessage) (tools.R
 	q := search.Query{Text: args.Query, MaxResults: max}
 
 	// The fallback circuit: walk the cascade, skip un-keyable / cooled-down
-	// providers, and fall over on a failed or empty result. Phase 1 uses the
-	// global cascade; Phase 3 threads the per-agent search_providers list.
+	// providers, and fall over on a failed or empty result. The per-agent
+	// search_providers list (RFC BB Phase 3, stamped on ctx at run-start)
+	// overrides the global order; nil/empty = the global search_priority.
 	var lastErr error
 	sawSuccess := false
 	attempted := 0
-	for _, id := range s.Resolver.Cascade(nil) {
+	for _, id := range s.Resolver.Cascade(tools.SearchProviders(ctx)) {
 		p, ok := s.Registry.Get(id)
 		if !ok {
 			continue // in the priority list but not built (shouldn't happen post-validate)

--- a/internal/tools/builtin/websearch_fallback_test.go
+++ b/internal/tools/builtin/websearch_fallback_test.go
@@ -9,7 +9,48 @@ import (
 	"testing"
 
 	"github.com/denn-gubsky/loomcycle/internal/search"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
+
+// TestWebSearch_PerAgentProvidersOverride: the per-agent search_providers list
+// (RFC BB Phase 3, on ctx) overrides the global cascade — a provider absent from
+// the list is skipped even when it's the global primary.
+func TestWebSearch_PerAgentProvidersOverride(t *testing.T) {
+	braveHit, serperHit := 0, 0
+	brave := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		braveHit++
+		_, _ = w.Write([]byte(`{"web":{"results":[{"title":"B","url":"https://b.example","description":"d"}]}}`))
+	}))
+	defer brave.Close()
+	serper := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		serperHit++
+		_, _ = w.Write([]byte(`{"organic":[{"title":"S","link":"https://s.example","snippet":"d"}]}`))
+	}))
+	defer serper.Close()
+	reg, _ := search.BuildRegistry([]search.ProviderSpec{
+		{ID: "brave", Options: []search.Option{search.WithEndpoint(brave.URL)}},
+		{ID: "serper", Options: []search.Option{search.WithEndpoint(serper.URL)}},
+	})
+	// Global order is [brave, serper] — brave is primary.
+	ws := &WebSearch{Registry: reg, Resolver: search.NewResolver([]string{"brave", "serper"}),
+		HostKeys: map[string]string{"brave": "bk", "serper": "sk"}}
+
+	// Per-agent list = [serper] only → brave is skipped entirely.
+	ctx := tools.WithSearchProviders(context.Background(), []string{"serper"})
+	res, err := ws.Execute(ctx, json.RawMessage(`{"query":"x"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(res.Text, "s.example") {
+		t.Errorf("expected serper's result (per-agent override), got %q", res.Text)
+	}
+	if braveHit != 0 {
+		t.Errorf("brave (global primary, absent from per-agent list) should not be hit; braveHit=%d", braveHit)
+	}
+	if serperHit != 1 {
+		t.Errorf("serper should be hit once; serperHit=%d", serperHit)
+	}
+}
 
 // TestWebSearch_FallbackCircuit is the RFC BB headline: the primary provider
 // errors, so WebSearch falls over to the next provider in the cascade and

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -117,6 +117,23 @@ func AgentTools(ctx context.Context) []string {
 	return v
 }
 
+type ctxKeySearchProviders struct{}
+
+// WithSearchProviders attaches the agent's per-agent web-search fallback list
+// (RFC BB AgentDef.search_providers) to ctx. The HTTP server stamps it once per
+// run at every run-start site; the WebSearch tool reads it via SearchProviders
+// and passes it to the search resolver's Cascade (empty = the global default).
+func WithSearchProviders(ctx context.Context, providers []string) context.Context {
+	return context.WithValue(ctx, ctxKeySearchProviders{}, providers)
+}
+
+// SearchProviders returns the agent's per-agent web-search fallback list from
+// ctx, or nil (= use the global search_priority default) when not attached.
+func SearchProviders(ctx context.Context) []string {
+	v, _ := ctx.Value(ctxKeySearchProviders{}).([]string)
+	return v
+}
+
 // ctxKeyHostPolicy is the context key for the run's effective HTTP
 // host narrowing policy — what the CALLER (top-level: HTTP request
 // body; sub-agent: inherited from the parent's ctx) asked for in


### PR DESCRIPTION
Phase 3 (final) of **RFC BB**: make per-agent `search_providers` actually take effect, put it in the content hash + substrate overlay, and document the feature.

## What

**Consumption** — `AgentDef.search_providers` now drives the WebSearch fallback circuit. Adds `tools.WithSearchProviders`/`SearchProviders` (mirrors `WithAgentTools`), stamped on the loop ctx at every run-start site (handleRuns / handleMessages / RunOnce / runSubAgent + resume, alongside `WithSkillPolicy`); WebSearch walks `Cascade(tools.SearchProviders(ctx))` — the per-agent list overrides the global `search_priority`, empty falls back to global. Sub-agents get their own def's list.

**content_sha256 + overlay** — `search_providers` threads through the hash + the substrate AgentDef overlay + the substrate-def→config.AgentDef run-path adapters, mirroring `providers` exactly (it's content-identifying, not authority-only like `skills:`). Included in **both** hash paths (`FromYAMLAgent` static + `signFromMergedDef` substrate) so a static agent and its substrate fork hash identically (the drift invariant). The substrate adapters (`mergedDef`, `lookup.SubstrateAgentDef` — a locally-decoded struct that needed its own json field, `staticToMergedDef`) carry it to the run path so a **runtime-authored** agent's list actually reaches WebSearch. `resolve.AgentRequest.Providers` (LLM tier resolution) is deliberately untouched.

**Docs + adapter** — a `search-providers` help topic (aliases `search`/`websearch`, so `topic=WebSearch` resolves it) covering the catalog, config, keys, the fallback circuit, the routing view, and the LCD-shape boundary. `search_providers?: string[]` on the TS `LibraryAgentDefinition`. Python (gRPC-only, opaque AgentDef overlay) needs no typed change; neither adapter wraps `/v1/_routing`.

## What was tested
- `go test ./...` — clean.
- Consumption: a per-agent `[serper]` list skips brave (the global primary) entirely (fail-before verified).
- Hash: fork changing only `search_providers` mints a distinct `content_sha256` (both paths); `FromYAMLAgent`↔`signFromMergedDef` convergence; overlay create→resolve round-trips the list; drift tests pin `mergedDef`↔`SubstrateAgentDef` parity + the lookup enumerated list. Fail-before verified per line.
- Help topic parses + resolves via alias; TS `tsc` clean; binary builds.

## RFC BB is now feature-complete across all three phases
- ✅ Phase 1 (#670) — connector + fallback circuit + config
- ✅ Phase 2 (#671) — routing view + Web UI
- ✅ Phase 3 (this PR) — per-agent consumption + hash/overlay + docs

The adapter version bump + publish is a release-time step (the TS field is forward-compatible until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)