### PR TITLE
fix(webui): Library detail panel scrolls independently of the list

### DIFF
--- a/packages/library/src/styles.css
+++ b/packages/library/src/styles.css
@@ -436,6 +436,11 @@
   gap: 0;
   height: 100%;
   min-height: 0;
+  /* Bound the single grid row to the splitter's height (not content) so each
+   * pane's own overflow-y:auto engages and the list + detail scroll
+   * INDEPENDENTLY. Without this the implicit `auto` row grows to content and the
+   * whole view scrolls as one, pushing a selected agent's detail off-screen. */
+  grid-template-rows: minmax(0, 1fr);
 }
 .loomcycle-library .splitter.dragging {
   /* Suppress text-select highlighting during a drag. */

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2129,6 +2129,13 @@ button.primary:disabled {
   gap: 0;
   height: 100%;
   min-height: 0;
+  /* Bound the single grid row to the splitter's height (not content). Without
+   * this the implicit row is `auto` (content-sized), so each pane grows to its
+   * content and the WHOLE view scrolls as one — the list + detail move together
+   * and a selected agent's detail scrolls off-screen. minmax(0, 1fr) pins the
+   * row to the available height with a 0 floor, so each pane's own
+   * overflow-y:auto engages and the list + detail scroll INDEPENDENTLY. */
+  grid-template-rows: minmax(0, 1fr);
 }
 .splitter.dragging {
   /* Suppress text-select highlighting during a drag — without this


### PR DESCRIPTION
## Why

On the Web UI **Library** tab, selecting an agent low in the list left its detail panel scrolled off-screen — appearing as a blank/empty detail pane. It was most visible on a dynamically-created substrate agent with a large `system_prompt` (e.g. loomboard's `chrome-assistant`), which is what surfaced it. Reported as "the agents list is scrolled together with the right panel; content for agents at the bottom is scrolled out of the screen."

**Not a scope/tenant bug** — the `/v1/_agentdef` fetch returns the full definition (HTTP 200) for the tenant session; this is purely a layout issue.

## Root cause

The Library view is a `Splitter` (CSS grid). Its left name-list (`.lineage-name-list`) and right detail panel (`.lineage-right`) each already have their own `overflow-y: auto` — but `.splitter` set **no `grid-template-rows`**, so the single row was implicitly `auto` (content-sized). Each pane grew to its content height instead of being bounded to the splitter, so neither pane's internal scroll engaged and the whole view scrolled as one unit.

## Fix

`grid-template-rows: minmax(0, 1fr)` on `.splitter` pins the row to the available height (0 floor allows the panes to shrink so their scroll engages). The list and the detail now scroll **independently**. Applied to both `web/src/styles.css` (the loomcycle Web UI) and `packages/library/src/styles.css` (the `@loomcycle/library` external-host sheet).

## Tested
- CSS-only; `npm run build` (tsc + vite) clean; SPA embeds.
- Visual verification recommended on the running Web UI (select an agent low in the list → its detail is reachable; the two panes scroll independently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)