### PR TITLE
feat(websearch): opt-in provenance footer — which search provider answered

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -785,7 +785,7 @@ func main() {
 		&builtin.NotebookEdit{},
 		httpTool,
 		&builtin.WebFetch{HTTP: httpTool},
-		&builtin.WebSearch{Registry: searchRegistry, Resolver: searchResolver, HostKeys: searchHostKeys},
+		&builtin.WebSearch{Registry: searchRegistry, Resolver: searchResolver, HostKeys: searchHostKeys, ShowProvenance: cfg.Env.WebSearchProvenance},
 		&builtin.Bash{Enabled: cfg.Env.BashEnabled},
 		// Bashbox — a TRUE in-process sandbox (gbash): no OS process, paths
 		// rooted at the volume, no network, and read-only volumes are honored

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2069,6 +2069,10 @@ type Env struct {
 	SerperAPIKey string
 	ExaAPIKey    string
 	TavilyAPIKey string
+	// WebSearchProvenance appends a "(via <provider>)" footer to a successful
+	// WebSearch result naming which search provider answered + any fallover
+	// (RFC BB). Off by default (byte-identical output); LOOMCYCLE_WEBSEARCH_PROVENANCE=1.
+	WebSearchProvenance bool
 	// BashEnabled gates the Bash tool. Defaults to false. Even when
 	// true the tool is NOT a true sandbox — it restricts cwd, scrubs
 	// env, bounds output, and times out, but cannot prevent the spawned
@@ -2877,6 +2881,7 @@ func LoadLayers(layers ...Layer) (*Config, error) {
 		SerperAPIKey:              os.Getenv("SERPER_API_KEY"),
 		ExaAPIKey:                 os.Getenv("EXA_API_KEY"),
 		TavilyAPIKey:              os.Getenv("TAVILY_API_KEY"),
+		WebSearchProvenance:       os.Getenv("LOOMCYCLE_WEBSEARCH_PROVENANCE") == "1",
 		BashEnabled:               os.Getenv("LOOMCYCLE_BASH_ENABLED") == "1",
 		BashboxEnabled:            os.Getenv("LOOMCYCLE_BASHBOX_ENABLED") == "1",
 		BashboxFallbackCommands:   splitCSV(os.Getenv("LOOMCYCLE_BASHBOX_FALLBACK_COMMANDS")),

--- a/internal/help/builtin/search-providers.md
+++ b/internal/help/builtin/search-providers.md
@@ -78,6 +78,14 @@ health-probed), and which one is **selected** (the first available = what runs
 now). A restricted tenant sees only the providers it can key itself. Same data
 over `GET /v1/_routing` (the `search` block).
 
+## Which provider answered a query?
+
+The routing view's `selected` is the *current* pick — not necessarily what served
+a specific call (a fallover is otherwise invisible in the uniform output). Set
+`LOOMCYCLE_WEBSEARCH_PROVENANCE=1` to append a compact footer to each successful
+result: `(via searxng)`, or `(via brave — searxng fell over)` when earlier
+providers were tried and passed over. Off by default (byte-identical output).
+
 ## Provider-specific power features
 
 The fallback circuit is deliberately the lowest-common-denominator "web

--- a/internal/tools/builtin/websearch.go
+++ b/internal/tools/builtin/websearch.go
@@ -48,6 +48,13 @@ type WebSearch struct {
 	// non-matching results; WebSearchFilterKeep returns everything. Ignored
 	// when AllowedHosts is nil.
 	FilterMode string
+	// ShowProvenance appends a compact "(via <provider>)" footer to a successful
+	// result naming which provider answered (and any that fell over first), so
+	// operators/agents can see the effective engine per query — a fallover is
+	// otherwise invisible in the uniform output. Off by default (byte-identical
+	// output for parsers that don't want it); enabled by
+	// LOOMCYCLE_WEBSEARCH_PROVENANCE=1. RFC BB.
+	ShowProvenance bool
 }
 
 // FilterMode constants for WebSearch.FilterMode.
@@ -125,6 +132,7 @@ func (s *WebSearch) Execute(ctx context.Context, input json.RawMessage) (tools.R
 	var lastErr error
 	sawSuccess := false
 	attempted := 0
+	var passedOver []string // providers tried that didn't serve (errored or empty), for the provenance footer
 	for _, id := range s.Resolver.Cascade(tools.SearchProviders(ctx)) {
 		p, ok := s.Registry.Get(id)
 		if !ok {
@@ -150,6 +158,7 @@ func (s *WebSearch) Execute(ctx context.Context, input json.RawMessage) (tools.R
 		if err != nil {
 			s.Resolver.MarkOutcome(id, err)
 			lastErr = err
+			passedOver = append(passedOver, id)
 			log.Printf("websearch: provider %q failed: %v (falling over)", id, err)
 			continue
 		}
@@ -157,9 +166,14 @@ func (s *WebSearch) Execute(ctx context.Context, input json.RawMessage) (tools.R
 		sawSuccess = true
 		results := filterSearchHosts(res.Results, s.AllowedHosts, s.FilterMode)
 		if len(results) == 0 {
-			continue // empty (or filtered to empty) → try the next provider
+			passedOver = append(passedOver, id) // succeeded-but-empty → fell over
+			continue                            // empty (or filtered to empty) → try the next provider
 		}
-		return tools.Result{Text: renderSearchResults(results, max)}, nil
+		text := renderSearchResults(results, max)
+		if s.ShowProvenance {
+			text += "\n" + searchProvenance(id, passedOver)
+		}
+		return tools.Result{Text: text}, nil
 	}
 
 	switch {
@@ -206,4 +220,14 @@ func renderSearchResults(results []search.Result, max int) string {
 		fmt.Fprintf(&b, "[%d] %s — %s\n   %s\n", rendered, title, r.URL, desc)
 	}
 	return strings.TrimRight(b.String(), "\n")
+}
+
+// searchProvenance is the compact footer appended to a successful result when
+// ShowProvenance is on: "(via <provider>)", or "(via <provider> — <a>, <b> fell
+// over)" when earlier providers were tried and passed over (errored or empty).
+func searchProvenance(used string, passedOver []string) string {
+	if len(passedOver) == 0 {
+		return "(via " + used + ")"
+	}
+	return "(via " + used + " — " + strings.Join(passedOver, ", ") + " fell over)"
 }

--- a/internal/tools/builtin/websearch_fallback_test.go
+++ b/internal/tools/builtin/websearch_fallback_test.go
@@ -102,6 +102,49 @@ func TestWebSearch_FallbackCircuit(t *testing.T) {
 	}
 }
 
+// TestWebSearch_Provenance: with ShowProvenance on, a successful result carries a
+// "(via <provider>)" footer — and names the providers that fell over first. Off
+// (default), the output is byte-identical (no footer).
+func TestWebSearch_Provenance(t *testing.T) {
+	braveErr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+	}))
+	defer braveErr.Close()
+	serperOK := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"organic":[{"title":"S","link":"https://s.example","snippet":"d"}]}`))
+	}))
+	defer serperOK.Close()
+
+	newWS := func(prov bool) *WebSearch {
+		reg, _ := search.BuildRegistry([]search.ProviderSpec{
+			{ID: "brave", Options: []search.Option{search.WithEndpoint(braveErr.URL)}},
+			{ID: "serper", Options: []search.Option{search.WithEndpoint(serperOK.URL)}},
+		})
+		return &WebSearch{Registry: reg, Resolver: search.NewResolver([]string{"brave", "serper"}),
+			HostKeys: map[string]string{"brave": "bk", "serper": "sk"}, ShowProvenance: prov}
+	}
+
+	// Off → no footer (byte-identical to the plain render).
+	res, _ := newWS(false).Execute(context.Background(), json.RawMessage(`{"query":"x"}`))
+	if strings.Contains(res.Text, "(via") {
+		t.Errorf("provenance OFF should add no footer; got %q", res.Text)
+	}
+
+	// On → footer names the winner + the fallover.
+	res, _ = newWS(true).Execute(context.Background(), json.RawMessage(`{"query":"x"}`))
+	if !strings.HasSuffix(res.Text, "(via serper — brave fell over)") {
+		t.Errorf("expected fallover provenance footer; got %q", res.Text)
+	}
+
+	// On, single-provider success (no fallover) → bare "(via serper)".
+	regSolo, _ := search.BuildRegistry([]search.ProviderSpec{{ID: "serper", Options: []search.Option{search.WithEndpoint(serperOK.URL)}}})
+	solo := &WebSearch{Registry: regSolo, Resolver: search.NewResolver([]string{"serper"}), HostKeys: map[string]string{"serper": "sk"}, ShowProvenance: true}
+	res, _ = solo.Execute(context.Background(), json.RawMessage(`{"query":"x"}`))
+	if !strings.HasSuffix(res.Text, "(via serper)") || strings.Contains(res.Text, "fell over") {
+		t.Errorf("expected bare '(via serper)' footer; got %q", res.Text)
+	}
+}
+
 // TestWebSearch_AllProvidersFail: when every provider errors, the tool surfaces
 // the last error (IsError) rather than a silent "no results".
 func TestWebSearch_AllProvidersFail(t *testing.T) {


### PR DESCRIPTION
## Why

A `WebSearch` result renders identically no matter which provider served it, so a **fallover** (e.g. `searxng → brave`) is invisible, and the routing view's `selected` is only the *current* pick — not necessarily what served a specific call. Requested after confirming a self-hosted SearXNG deployment: "add metadata to identify the really-used search engine."

## What

Opt-in **provenance footer**. With `LOOMCYCLE_WEBSEARCH_PROVENANCE=1`, a successful result gets a compact footer:
- `(via searxng)` — the provider that answered
- `(via brave — searxng, serper fell over)` — when earlier providers were tried and passed over (errored or empty)

**Off by default** → byte-identical output, so existing output-parsers (e.g. jobs-search-agent) are unaffected until an operator enables it. The fallback loop already knows the winning provider id and now tracks the passed-over ones, so this is a render-time addition — no new event/wire plumbing.

`cfg.Env.WebSearchProvenance` (env `LOOMCYCLE_WEBSEARCH_PROVENANCE=1`) → `WebSearch.ShowProvenance`. Documented in the `search-providers` help topic.

## Tested
- `go test ./...` clean.
- New `TestWebSearch_Provenance`: off → no footer; on → `(via serper — brave fell over)` on a fallover, and bare `(via serper)` on a clean single-provider hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)