### PR TITLE
fix(clienttools): wire-safe client-tool names — client:→client__ (RFC BC)

### DIFF
--- a/internal/api/http/client_tools.go
+++ b/internal/api/http/client_tools.go
@@ -3,6 +3,7 @@ package http
 import (
 	"context"
 	"encoding/json"
+	"log"
 	"net/http"
 	"sync"
 	"time"
@@ -78,17 +79,29 @@ func (s *Server) handleClientTools(w http.ResponseWriter, r *http.Request) {
 		return c.Write(sendCtx, websocket.MessageText, b)
 	}
 
-	conn, deregister, err := s.clientTools.Register(key, hello.Tools, send)
+	// Validate bare names at this untrusted edge (RFC BC): the exposed name is
+	// ToolPrefix+bare, which MUST be a valid LLM function name, so a bare name
+	// with an illegal char (`.`, `:`, …) or one too long is SKIPPED — never
+	// registered, never advertised. Only accepted names go to the registry + are
+	// reflected in hello_ok, so the client sees exactly what it can use. The
+	// registry stays name-agnostic; validation lives here at the boundary.
+	valid := make([]clienttools.ToolSchema, 0, len(hello.Tools))
+	accepted := make([]string, 0, len(hello.Tools))
+	for _, t := range hello.Tools {
+		if !clienttools.ValidBareName(t.Name) {
+			log.Printf("client-tools: skipping tool %q from %s — name must be [a-zA-Z0-9_-] and short enough for the client__ prefix (<=%d total)", t.Name, key.Subject, clienttools.MaxToolNameLen)
+			continue
+		}
+		valid = append(valid, t)
+		accepted = append(accepted, t.Name)
+	}
+
+	conn, deregister, err := s.clientTools.Register(key, valid, send)
 	if err != nil {
 		_ = c.Close(websocket.StatusTryAgainLater, "too many client-tool connections")
 		return
 	}
 	defer deregister() // fails any in-flight invokes so no run hangs
-
-	accepted := make([]string, 0, len(hello.Tools))
-	for _, t := range hello.Tools {
-		accepted = append(accepted, t.Name)
-	}
 	if err := send(ctx, clienttools.HelloOKFrame{
 		Type: clienttools.FrameHelloOK, ConnectionID: conn.ID(), Accepted: accepted,
 	}); err != nil {

--- a/internal/api/http/client_tools_test.go
+++ b/internal/api/http/client_tools_test.go
@@ -62,7 +62,7 @@ func TestHandleClientTools_HelloRoundTrip(t *testing.T) {
 	hello := clienttools.HelloFrame{
 		Type:   clienttools.FrameHello,
 		Client: "test/1",
-		Tools:  []clienttools.ToolSchema{{Name: "browser.read_page", Description: "read the page"}},
+		Tools:  []clienttools.ToolSchema{{Name: "browser_read_page", Description: "read the page"}},
 	}
 	b, _ := json.Marshal(hello)
 	if err := c.Write(ctx, websocket.MessageText, b); err != nil {
@@ -81,8 +81,8 @@ func TestHandleClientTools_HelloRoundTrip(t *testing.T) {
 	if err := json.Unmarshal(data, &ok); err != nil {
 		t.Fatal(err)
 	}
-	if len(ok.Accepted) != 1 || ok.Accepted[0] != "browser.read_page" || ok.ConnectionID == "" {
-		t.Errorf("hello_ok = %+v, want accepted [browser.read_page] + a connection_id", ok)
+	if len(ok.Accepted) != 1 || ok.Accepted[0] != "browser_read_page" || ok.ConnectionID == "" {
+		t.Errorf("hello_ok = %+v, want accepted [browser_read_page] + a connection_id", ok)
 	}
 
 	// The connection is now in the registry under the principal key.
@@ -99,7 +99,7 @@ func TestCandidateTools_AdvertisesAndGatesClientTools(t *testing.T) {
 	key := clienttools.PrincipalKey{Tenant: "t1", Subject: "u1"}
 	silent := func(context.Context, any) error { return nil }
 	_, dereg, _ := reg.Register(key, []clienttools.ToolSchema{
-		{Name: "browser.read_page"}, {Name: "browser.click"},
+		{Name: "browser_read_page"}, {Name: "browser_click"},
 	}, silent)
 	defer dereg()
 
@@ -108,34 +108,79 @@ func TestCandidateTools_AdvertisesAndGatesClientTools(t *testing.T) {
 	srv.clientTools = reg
 	ctx := auth.WithPrincipal(context.Background(), auth.Principal{TenantID: "t1", Subject: "u1"})
 
-	// candidateTools advertises the principal's client-tools (client: prefixed).
-	cands := srv.candidateTools(ctx, "t1", []string{"client:browser.*"})
+	// candidateTools advertises the principal's client-tools (client__ prefixed).
+	cands := srv.candidateTools(ctx, "t1", []string{"client__browser_*"})
 	names := map[string]bool{}
 	for _, tl := range cands {
 		names[tl.Name()] = true
 	}
-	if !names["client:browser.read_page"] || !names["client:browser.click"] {
+	if !names["client__browser_read_page"] || !names["client__browser_click"] {
 		t.Fatalf("candidateTools should advertise both client-tools; got %v", names)
 	}
 
 	// filterTools narrows to exactly what the agent grants.
-	filtered := filterTools(cands, []string{"client:browser.read_page"}, nil)
+	filtered := filterTools(cands, []string{"client__browser_read_page"}, nil)
 	fnames := map[string]bool{}
 	for _, tl := range filtered {
 		fnames[tl.Name()] = true
 	}
-	if !fnames["client:browser.read_page"] {
-		t.Errorf("granted client:browser.read_page should survive filtering; got %v", fnames)
+	if !fnames["client__browser_read_page"] {
+		t.Errorf("granted client__browser_read_page should survive filtering; got %v", fnames)
 	}
-	if fnames["client:browser.click"] {
-		t.Errorf("ungranted client:browser.click should be filtered out; got %v", fnames)
+	if fnames["client__browser_click"] {
+		t.Errorf("ungranted client__browser_click should be filtered out; got %v", fnames)
 	}
 
 	// A different principal sees no client-tools.
 	other := auth.WithPrincipal(context.Background(), auth.Principal{TenantID: "t1", Subject: "someone-else"})
-	for _, tl := range srv.candidateTools(other, "t1", []string{"client:browser.*"}) {
+	for _, tl := range srv.candidateTools(other, "t1", []string{"client__browser_*"}) {
 		if len(tl.Name()) >= len(clienttools.ToolPrefix) && tl.Name()[:len(clienttools.ToolPrefix)] == clienttools.ToolPrefix {
 			t.Errorf("a different principal must not see client-tools; saw %q", tl.Name())
+		}
+	}
+}
+
+func TestHandleClientTools_RejectsWireUnsafeNames(t *testing.T) {
+	reg := clienttools.NewRegistry(0)
+	ts := clientToolsTestServer(t, reg, auth.Principal{TenantID: "t1", Subject: "u1"})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	c, _, err := websocket.Dial(ctx, wsURL(ts.URL), &websocket.DialOptions{
+		Subprotocols: []string{clientToolSubprotocol},
+	})
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.CloseNow()
+
+	// One valid, one dotted (illegal) bare name. The dotted one is skipped at
+	// the hello boundary; only the valid one is accepted + registered.
+	hello := clienttools.HelloFrame{
+		Type: clienttools.FrameHello,
+		Tools: []clienttools.ToolSchema{
+			{Name: "browser_read_page"},
+			{Name: "browser.click"}, // illegal (dot) → skipped
+		},
+	}
+	b, _ := json.Marshal(hello)
+	if err := c.Write(ctx, websocket.MessageText, b); err != nil {
+		t.Fatal(err)
+	}
+	_, data, err := c.Read(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ok clienttools.HelloOKFrame
+	if err := json.Unmarshal(data, &ok); err != nil {
+		t.Fatal(err)
+	}
+	if len(ok.Accepted) != 1 || ok.Accepted[0] != "browser_read_page" {
+		t.Errorf("only the wire-safe name should be accepted; got %v", ok.Accepted)
+	}
+	for _, s := range reg.Provides(clienttools.PrincipalKey{Tenant: "t1", Subject: "u1"}) {
+		if s.Name == "browser.click" {
+			t.Error("a dotted bare name must not be registered")
 		}
 	}
 }

--- a/internal/clienttools/registry_test.go
+++ b/internal/clienttools/registry_test.go
@@ -31,7 +31,7 @@ func TestRegistry_InvokeRoundTrip(t *testing.T) {
 	r := NewRegistry(0)
 	key := PrincipalKey{"t1", "u1"}
 	var c *Conn
-	conn, dereg, err := r.Register(key, []ToolSchema{{Name: "browser.read_page"}}, echoSender(&c, ""))
+	conn, dereg, err := r.Register(key, []ToolSchema{{Name: "browser_read_page"}}, echoSender(&c, ""))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -41,7 +41,7 @@ func TestRegistry_InvokeRoundTrip(t *testing.T) {
 	if r.Count() != 1 {
 		t.Fatalf("Count = %d, want 1", r.Count())
 	}
-	res, err := r.Invoke(context.Background(), key, "browser.read_page", json.RawMessage(`{"q":1}`), InvokeMeta{RunID: "r1"})
+	res, err := r.Invoke(context.Background(), key, "browser_read_page", json.RawMessage(`{"q":1}`), InvokeMeta{RunID: "r1"})
 	if err != nil {
 		t.Fatalf("Invoke: %v", err)
 	}
@@ -55,15 +55,15 @@ func TestRegistry_NoClient(t *testing.T) {
 	key := PrincipalKey{"t1", "u1"}
 	// A connection exists but doesn't provide the tool → still ErrNoClient.
 	var c *Conn
-	conn, dereg, _ := r.Register(key, []ToolSchema{{Name: "browser.click"}}, echoSender(&c, ""))
+	conn, dereg, _ := r.Register(key, []ToolSchema{{Name: "browser_click"}}, echoSender(&c, ""))
 	c = conn
 	defer dereg()
 
-	if _, err := r.Invoke(context.Background(), key, "browser.read_page", nil, InvokeMeta{}); !errors.Is(err, ErrNoClient) {
+	if _, err := r.Invoke(context.Background(), key, "browser_read_page", nil, InvokeMeta{}); !errors.Is(err, ErrNoClient) {
 		t.Errorf("want ErrNoClient for an unprovided tool, got %v", err)
 	}
 	// A different principal → ErrNoClient.
-	if _, err := r.Invoke(context.Background(), PrincipalKey{"t1", "other"}, "browser.click", nil, InvokeMeta{}); !errors.Is(err, ErrNoClient) {
+	if _, err := r.Invoke(context.Background(), PrincipalKey{"t1", "other"}, "browser_click", nil, InvokeMeta{}); !errors.Is(err, ErrNoClient) {
 		t.Errorf("want ErrNoClient for a different principal, got %v", err)
 	}
 }
@@ -73,11 +73,11 @@ func TestRegistry_DisconnectFailsPending(t *testing.T) {
 	key := PrincipalKey{"t1", "u1"}
 	// A sender that never replies — the invoke blocks until dereg.
 	silent := func(context.Context, any) error { return nil }
-	_, dereg, _ := r.Register(key, []ToolSchema{{Name: "fs.read"}}, silent)
+	_, dereg, _ := r.Register(key, []ToolSchema{{Name: "fs_read"}}, silent)
 
 	got := make(chan error, 1)
 	go func() {
-		_, err := r.Invoke(context.Background(), key, "fs.read", nil, InvokeMeta{})
+		_, err := r.Invoke(context.Background(), key, "fs_read", nil, InvokeMeta{})
 		got <- err
 	}()
 	// Give the invoke time to register its pending waiter, then disconnect.
@@ -98,12 +98,12 @@ func TestRegistry_Timeout(t *testing.T) {
 	r := NewRegistry(0)
 	key := PrincipalKey{"t1", "u1"}
 	silent := func(context.Context, any) error { return nil }
-	_, dereg, _ := r.Register(key, []ToolSchema{{Name: "fs.read"}}, silent)
+	_, dereg, _ := r.Register(key, []ToolSchema{{Name: "fs_read"}}, silent)
 	defer dereg()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
 	defer cancel()
-	_, err := r.Invoke(ctx, key, "fs.read", nil, InvokeMeta{})
+	_, err := r.Invoke(ctx, key, "fs_read", nil, InvokeMeta{})
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Errorf("want DeadlineExceeded, got %v", err)
 	}
@@ -113,14 +113,14 @@ func TestRegistry_MostRecentWins(t *testing.T) {
 	r := NewRegistry(0)
 	key := PrincipalKey{"t1", "u1"}
 	var c1, c2 *Conn
-	conn1, d1, _ := r.Register(key, []ToolSchema{{Name: "browser.read_page"}}, echoSender(&c1, "first"))
+	conn1, d1, _ := r.Register(key, []ToolSchema{{Name: "browser_read_page"}}, echoSender(&c1, "first"))
 	c1 = conn1
 	defer d1()
-	conn2, d2, _ := r.Register(key, []ToolSchema{{Name: "browser.read_page"}}, echoSender(&c2, "second"))
+	conn2, d2, _ := r.Register(key, []ToolSchema{{Name: "browser_read_page"}}, echoSender(&c2, "second"))
 	c2 = conn2
 	defer d2()
 
-	res, err := r.Invoke(context.Background(), key, "browser.read_page", nil, InvokeMeta{})
+	res, err := r.Invoke(context.Background(), key, "browser_read_page", nil, InvokeMeta{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -158,16 +158,16 @@ func TestRegistry_ProvidesUnion(t *testing.T) {
 	r := NewRegistry(0)
 	key := PrincipalKey{"t1", "u1"}
 	silent := func(context.Context, any) error { return nil }
-	_, d1, _ := r.Register(key, []ToolSchema{{Name: "browser.read_page"}, {Name: "browser.click"}}, silent)
+	_, d1, _ := r.Register(key, []ToolSchema{{Name: "browser_read_page"}, {Name: "browser_click"}}, silent)
 	defer d1()
-	_, d2, _ := r.Register(key, []ToolSchema{{Name: "browser.navigate"}}, silent)
+	_, d2, _ := r.Register(key, []ToolSchema{{Name: "browser_navigate"}}, silent)
 	defer d2()
 
 	names := map[string]bool{}
 	for _, s := range r.Provides(key) {
 		names[s.Name] = true
 	}
-	for _, want := range []string{"browser.read_page", "browser.click", "browser.navigate"} {
+	for _, want := range []string{"browser_read_page", "browser_click", "browser_navigate"} {
 		if !names[want] {
 			t.Errorf("Provides union missing %q; got %v", want, names)
 		}

--- a/internal/clienttools/tool.go
+++ b/internal/clienttools/tool.go
@@ -4,15 +4,43 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"regexp"
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
 
 // ToolPrefix namespaces client-tools in an agent's `tools` allowlist + the tool
-// names the model sees — mirroring the `mcp__` convention. A client-registered
-// tool "browser.read_page" is granted/called as "client:browser.read_page".
-const ToolPrefix = "client:"
+// names the model sees — mirroring the `mcp__` convention. It MUST stay within
+// the LLM function-name character set (see MaxToolNameLen): a client-registered
+// tool "browser_read_page" is granted/called as "client__browser_read_page".
+//
+// `__` (not `:`) is deliberate: LLM function names must match
+// ^[a-zA-Z0-9_-]{1,64}$ (Anthropic + OpenAI enforce it; ollama's own tool-call
+// recovery rejects anything else). A colon or a dot reaches the wire unescaped
+// and the provider 400s / the model mangles the name — so both the prefix and
+// the client's bare names must be identifier-safe (validated at the WS hello
+// boundary via ValidBareName).
+const ToolPrefix = "client__"
+
+// MaxToolNameLen is the LLM function-name limit. The EXPOSED name
+// (ToolPrefix + bare name) must not exceed it, so ValidBareName bounds the bare
+// name at MaxToolNameLen-len(ToolPrefix).
+const MaxToolNameLen = 64
+
+var bareNameRe = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// ValidBareName reports whether a client-advertised bare tool name yields a
+// wire-safe exposed name: identifier chars only, and short enough that
+// ToolPrefix+name stays within MaxToolNameLen. The runtime validates every
+// hello-advertised name against this at the untrusted edge and skips the rest,
+// so an exposed client-tool name is ALWAYS a valid LLM function name.
+func ValidBareName(name string) bool {
+	if name == "" || len(ToolPrefix)+len(name) > MaxToolNameLen {
+		return false
+	}
+	return bareNameRe.MatchString(name)
+}
 
 // Candidates returns the tools.Tool set to advertise for a principal — one
 // delegating adapter per tool its live connections provide (empty when nothing

--- a/internal/clienttools/tool_test.go
+++ b/internal/clienttools/tool_test.go
@@ -3,12 +3,50 @@ package clienttools
 import (
 	"context"
 	"encoding/json"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
+
+// wireNameRe is the LLM function-name contract every provider enforces
+// (Anthropic/OpenAI reject anything else; ollama's own recovery does too). The
+// v1.16.0 bug exposed `client:browser.read_page` — colon + dot — which no
+// provider accepts, so client-tools were unusable end-to-end.
+var wireNameRe = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,64}$`)
+
+// TestExposedName_IsWireSafe is the regression guard for the wire-safe-name bug:
+// every exposed client-tool name (ToolPrefix + a valid bare name) MUST be a
+// valid LLM function name. This is the check the shipped tests lacked — they
+// never asserted the model-facing name was callable.
+func TestExposedName_IsWireSafe(t *testing.T) {
+	for _, bare := range []string{"browser_read_page", "fs_read", "a", "x-1_2"} {
+		if !ValidBareName(bare) {
+			t.Fatalf("%q should be a valid bare name", bare)
+		}
+		name := (toolAdapter{schema: ToolSchema{Name: bare}}).Name()
+		if !wireNameRe.MatchString(name) {
+			t.Errorf("exposed name %q is not a valid LLM function name", name)
+		}
+	}
+}
+
+func TestValidBareName(t *testing.T) {
+	// Rejected: the exact chars that broke v1.16.0, plus empty + over-long.
+	for _, bad := range []string{"", "browser.read_page", "browser:read", "has space", "a/b", strings.Repeat("x", 64)} {
+		if ValidBareName(bad) {
+			t.Errorf("ValidBareName(%q) = true, want false", bad)
+		}
+	}
+	// Accepted: identifier chars, short enough that client__+name <= 64.
+	for _, ok := range []string{"browser_read_page", "click", "nav-2", strings.Repeat("x", MaxToolNameLen-len(ToolPrefix))} {
+		if !ValidBareName(ok) {
+			t.Errorf("ValidBareName(%q) = false, want true", ok)
+		}
+	}
+}
 
 // ridCtx stamps a RunIdentity so toolAdapter.Execute resolves the routing key.
 func ridCtx(tenant, subject string) context.Context {
@@ -23,7 +61,7 @@ func TestToolAdapter_ExecuteDelegates(t *testing.T) {
 	var c *Conn
 	// The fake client replies ok, echoing the input as the output.
 	conn, dereg, _ := reg.Register(key, []ToolSchema{{
-		Name: "browser.read_page", Description: "read", InputSchema: json.RawMessage(`{"type":"object"}`),
+		Name: "browser_read_page", Description: "read", InputSchema: json.RawMessage(`{"type":"object"}`),
 	}}, echoSender(&c, ""))
 	c = conn
 	defer dereg()
@@ -33,8 +71,8 @@ func TestToolAdapter_ExecuteDelegates(t *testing.T) {
 		t.Fatalf("Candidates = %d, want 1", len(cands))
 	}
 	tool := cands[0]
-	if tool.Name() != "client:browser.read_page" {
-		t.Errorf("Name = %q, want client:browser.read_page", tool.Name())
+	if tool.Name() != "client__browser_read_page" {
+		t.Errorf("Name = %q, want client__browser_read_page", tool.Name())
 	}
 	res, err := tool.Execute(ridCtx("t1", "u1"), json.RawMessage(`{"q":"hi"}`))
 	if err != nil {
@@ -55,7 +93,7 @@ func TestToolAdapter_RendersStringOutput(t *testing.T) {
 		go c.DeliverResult(ResultFrame{Type: FrameResult, CallID: f.CallID, OK: true, Output: json.RawMessage(`"the page title"`)})
 		return nil
 	}
-	conn, dereg, _ := reg.Register(key, []ToolSchema{{Name: "browser.title"}}, send)
+	conn, dereg, _ := reg.Register(key, []ToolSchema{{Name: "browser_title"}}, send)
 	c = conn
 	defer dereg()
 
@@ -68,7 +106,7 @@ func TestToolAdapter_RendersStringOutput(t *testing.T) {
 func TestToolAdapter_NoConnection(t *testing.T) {
 	reg := NewRegistry(0)
 	// No connection for this principal → a clear tool error, not a hang.
-	tool := toolAdapter{reg: reg, schema: ToolSchema{Name: "browser.read_page"}, timeout: time.Second}
+	tool := toolAdapter{reg: reg, schema: ToolSchema{Name: "browser_read_page"}, timeout: time.Second}
 	res, err := tool.Execute(ridCtx("t1", "u1"), nil)
 	if err != nil {
 		t.Fatalf("Execute returned a hard error: %v", err)
@@ -87,7 +125,7 @@ func TestToolAdapter_ClientError(t *testing.T) {
 		go c.DeliverResult(ResultFrame{Type: FrameResult, CallID: f.CallID, OK: false, Error: "element not found"})
 		return nil
 	}
-	conn, dereg, _ := reg.Register(key, []ToolSchema{{Name: "browser.click"}}, send)
+	conn, dereg, _ := reg.Register(key, []ToolSchema{{Name: "browser_click"}}, send)
 	c = conn
 	defer dereg()
 
@@ -101,10 +139,10 @@ func TestToolAdapter_Timeout(t *testing.T) {
 	reg := NewRegistry(0)
 	key := PrincipalKey{"t1", "u1"}
 	silent := func(context.Context, any) error { return nil }
-	_, dereg, _ := reg.Register(key, []ToolSchema{{Name: "fs.read"}}, silent)
+	_, dereg, _ := reg.Register(key, []ToolSchema{{Name: "fs_read"}}, silent)
 	defer dereg()
 
-	tool := toolAdapter{reg: reg, schema: ToolSchema{Name: "fs.read"}, timeout: 30 * time.Millisecond}
+	tool := toolAdapter{reg: reg, schema: ToolSchema{Name: "fs_read"}, timeout: 30 * time.Millisecond}
 	res, _ := tool.Execute(ridCtx("t1", "u1"), nil)
 	if !res.IsError || !strings.Contains(res.Text, "timed out") {
 		t.Errorf("want a timeout tool error, got %+v", res)

--- a/internal/help/builtin/client-tools.md
+++ b/internal/help/builtin/client-tools.md
@@ -18,16 +18,16 @@ protocol — it's a normal tool call; the only new thing is *where* it runs.
   input_schema}` for each tool it provides.
 - loomcycle files the connection under the bearer's **(tenant, subject)** — the
   same identity a run carries — so a run and its user's connection meet on one key.
-- A client-tool appears to the agent under the **`client:` prefix**
-  (`browser.read_page` → `client:browser.read_page`), granted through the agent's
-  normal `tools:` allowlist (globs work: `client:browser.*`).
+- A client-tool appears to the agent under the **`client__` prefix**
+  (`browser_read_page` → `client__browser_read_page`), granted through the agent's
+  normal `tools:` allowlist (globs work: `client__browser_*`).
 
 ## Granting an agent client-tools
 
 ```yaml
 agents:
   page-assistant:
-    tools: [client:browser.*, WebFetch, Context]
+    tools: [client__browser_*, WebFetch, Context]
 ```
 
 An agent sees a client-tool only when **both** hold: its `tools:` grants the name,
@@ -41,15 +41,21 @@ error (`no client connection…` / `…disconnected` / `…timed out`), never a 
 import { LoomcycleClient } from "@loomcycle/client";
 const client = new LoomcycleClient({ baseUrl, authToken });
 const host = client.connectClientTools({
-  tools: [{ name: "browser.read_page", description: "Read the current page" }],
+  tools: [{ name: "browser_read_page", description: "Read the current page" }],
   onInvoke: async ({ tool, input }) => {
-    if (tool === "browser.read_page") return await readPage();
+    if (tool === "browser_read_page") return await readPage();
   },
 });
 // host.close() to stop. Browsers/Node 22+ use the global WebSocket; on older
 // Node pass WebSocketImpl (the `ws` package). The bearer rides the
 // Sec-WebSocket-Protocol subprotocol (browsers can't set an Authorization header).
 ```
+
+Tool names must be **identifier-safe**: a bare name is `[a-zA-Z0-9_-]` (no dots,
+no colons) and short enough that `client__` + name stays ≤ 64 chars — the exposed
+name (`client__browser_read_page`) must be a valid LLM function name. A name that
+isn't is **skipped** at `hello` (not registered, not offered); the `hello_ok`
+frame lists exactly the names that were accepted, so the client sees what stuck.
 
 ## Security
 


### PR DESCRIPTION
Fixes a bug shipped in **v1.16.0**: client-tools were exposed to the model under a name that is **not a valid LLM function name** — `client:browser.read_page`. Both the `client:` prefix (colon) and a dotted bare name fall outside `[a-zA-Z0-9_-]{1,64}`, which Anthropic/OpenAI enforce and ollama's own tool-call recovery (`looksLikeIdentifier`) rejects. loomcycle sent the name to the provider **unescaped**, so a client-tool was uncallable end-to-end: qwen mangled it to `client` (→ `tool not found: client`); Anthropic/OpenAI would 400 the turn. The registry/routing was correct — only the model-facing name broke.

Investigation: `loomcycle-internal/doc-internal/client-tool-wire-safe-names.md`.

## Fix (mirrors the `mcp__` convention, wire-safe by construction)
- `ToolPrefix` `"client:"` → **`"client__"`** — exposed name is now e.g. `client__browser_read_page`.
- **Validate bare names at the WS `hello` boundary** (the untrusted edge): `clienttools.ValidBareName` requires `[a-zA-Z0-9_-]` **and** that `ToolPrefix+name` stays ≤ 64 (`MaxToolNameLen`). An invalid name is **skipped** — not registered, not advertised — and `hello_ok` reflects only the accepted names, so the client sees what stuck. The registry stays name-agnostic.
- **Grant globs unchanged in mechanism** (`policy.Matches`): agents grant `client__browser_*` (was `client:browser.*`). No `looksLikeIdentifier` change — `client__browser_read_page` already passes it.
- Help doc examples + tests → underscore names.

## Why it slipped + the new guard
The shipped tests exercised `candidateTools`/`filterTools` + the `hello_ok` round-trip but **never asserted the model-facing name was callable** — the break only surfaces at the provider boundary. New `TestExposedName_IsWireSafe` asserts every exposed name matches `^[a-zA-Z0-9_-]{1,64}$` (**fails on the old `client:` prefix — verified fail-before**); `TestValidBareName` covers the reject/accept boundary; a hello test asserts a dotted bare name is skipped + not registered.

## Tested
`go test ./...` clean (incl. `-race` on the clienttools + http client-tools tests).

## Consumer follow-up (loomboard, separate repo)
Register underscore bare names (`browser_read_page`, …), grant `client__browser_*`, update the embedded prompt. One-line renames gated on this landing.

## Note
Client-tools shipped in v1.16.0 but have no live consumer yet (loomboard's migration is gated on this fix), so no deployed agent is affected — this makes them actually work before first use. Warrants a **v1.16.1** patch once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)