### PR TITLE
fix(webui): Library list + detail scroll independently (complete the height chain)

### DIFF
--- a/packages/library/src/styles.css
+++ b/packages/library/src/styles.css
@@ -10,6 +10,14 @@
    light override) so the package is self-contained — no external tokens.css. */
 
 .loomcycle-library {
+  /* Fill the host container + propagate a definite height so the Splitter's
+   * grid row (grid-template-rows: minmax(0,1fr)) is bounded and the list +
+   * detail panes scroll independently. A host must give this element a bounded
+   * parent (the standard fill-the-container contract). */
+  height: 100%;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
   /* dark palette (default) — resolved from the loomcycle --lc-* design tokens */
   --bg: #0f1115;
   --bg-soft: #161922;
@@ -505,7 +513,8 @@
 .loomcycle-library .library-view {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  flex: 1;
+  min-height: 0;
 }
 .loomcycle-library .library-subtabs {
   display: flex;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2647,10 +2647,23 @@ button.primary:disabled {
 }
 
 /* ---- Library page (top-level) ---- */
+/* The @loomcycle/library root. It MUST propagate a definite height down to
+ * .library-view → .library-content → .splitter, or the Splitter's grid row
+ * (grid-template-rows: minmax(0,1fr)) has no bounded height to resolve against,
+ * the panes grow to content, and the whole Library scrolls as ONE instead of
+ * the list + detail scrolling independently. The package's own styles.css sets
+ * only color vars here; the web app relies on this global sheet, so bound it. */
+.loomcycle-library {
+  height: 100%;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
 .library-view {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  flex: 1;
+  min-height: 0;
 }
 .library-subtabs {
   display: flex;


### PR DESCRIPTION
## Why

Reported: the Library **Agents list scrolling doesn't work** — the v1.15.1 "independent scroll" fix (#674) didn't actually take effect in the web app.

## Root cause

#674 added `grid-template-rows: minmax(0, 1fr)` to `.splitter` — correct, but it only bounds the grid row if `.splitter` *itself* has a definite height. It doesn't: the `@loomcycle/library` root element `.loomcycle-library` had **no height rule** (the package's own sheet sets only color vars there; web's global sheet had no rule for it at all). So `.library-view { height: 100% }` had no definite parent to resolve against → the whole chain grew to content → the entire Library scrolled as one unit (the list couldn't scroll on its own; a selection low in the list left its detail scrolled off-screen). The `.splitter` fix sat *below* the broken link.

## Fix

Complete the height chain by bounding the package root:
- `.loomcycle-library` → `height: 100%; min-height: 0; display: flex; flex-direction: column`
- `.library-view` → `flex: 1; min-height: 0` (was `height: 100%`)

Now every link is bounded: `.content`(flex:1) → **`.loomcycle-library`** → `.library-view` → `.library-content` → `.splitter`(grid row bounded, #674) → `.splitter-pane` → the list / detail each engages its own `overflow-y: auto`.

Applied to **both** `web/src/styles.css` (the web app relies on this global sheet — it deliberately doesn't import the package sheet) **and** `packages/library/src/styles.css` (so external `@loomcycle/library` hosts get the fill-the-container contract too — e.g. loomboard).

## Tested
CSS-only; `npm run build` clean; the emitted bundle carries `.loomcycle-library{height:100%…}`. Full height chain traced link-by-link (all bounded). Visual confirmation on a long agents list is the final check post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)