### PR TITLE
docs(search): SearXNG deploy recipe + first-class search-providers guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ Repo-side docs (this directory):
 - [`docs/MCP_SERVER.md`](docs/MCP_SERVER.md). Register loomcycle as an MCP server in Claude Code / Claude Desktop. Copy-paste config snippets for Docker / Homebrew / direct-binary transports, plus the `loomcycle mcp install` helper.
 - [`docs/CLAUDE-CODE.md`](docs/CLAUDE-CODE.md). Driving loomcycle from Claude Code: the recommended `claude-code-plugin-loomcycle` plugin (slash commands + skills + hooks) vs. the manual `loomcycle mcp install` path.
 - [`docs/CONFIGURATION.md`](docs/CONFIGURATION.md). Operator config guide: provider / tier / user_tier resolution rules, four cookbook patterns (single / multi-provider × single / multi-user-tier), `models:` alias map, and the agent `.md` frontmatter field reference.
+- [`docs/SEARCH.md`](docs/SEARCH.md). Web-search providers (RFC BB): the catalog + fallback circuit, `search_providers` / `search_priority` config, per-agent lists, operator/tenant keys, the routing view — and a self-hosted **SearXNG** deploy recipe (the sidecar + the three `settings.yml` knobs + verification).
 - [`docs/POSTGRES.md`](docs/POSTGRES.md). Postgres backend operator guide: configuration, migrations, sqlite → postgres runbook, concurrency benchmark.
 - [`docs/GRPC.md`](docs/GRPC.md). gRPC surface: enablement, wire-shape parity with HTTP + SSE, error mapping, Python adapter quick-start.
 - [`docs/PLAN.md`](docs/PLAN.md). Public roadmap: shipped v0.4 → v0.8.12; planned v0.8.13 → v1.0.

--- a/docker-compose.example.yaml
+++ b/docker-compose.example.yaml
@@ -48,6 +48,13 @@ services:
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY:-}
       GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      # Web-search provider keys (RFC BB) — set whichever you list under
+      # search_providers: in your yaml. SearXNG (below) is keyless. See
+      # docs/SEARCH.md.
+      BRAVE_API_KEY: ${BRAVE_API_KEY:-}
+      # SERPER_API_KEY: ${SERPER_API_KEY:-}
+      # EXA_API_KEY: ${EXA_API_KEY:-}
+      # TAVILY_API_KEY: ${TAVILY_API_KEY:-}
       # Bind to all interfaces inside the container so the port
       # mapping above works; the host port binds to 127.0.0.1 only.
       LOOMCYCLE_LISTEN_ADDR: "0.0.0.0:8787"
@@ -76,3 +83,22 @@ services:
   # and to `depends_on:`:
   #   postgres:
   #     condition: service_healthy
+
+  # --- SearXNG (uncomment for a self-hosted, keyless web-search provider) ---
+  # A metasearch sidecar for the WebSearch tool (RFC BB). loomcycle reaches it
+  # in-network at http://searxng:8080 — no host port needed. Requires a
+  # searxng/settings.yml next to this file with THREE knobs (see docs/SEARCH.md):
+  #   server: { secret_key: "<openssl rand -hex 32>", limiter: false }
+  #   search: { formats: [html, json] }   # json is REQUIRED or /search 403s
+  # Then add to your loomcycle.yaml:
+  #   search_providers: { searxng: { base_url: "http://searxng:8080" } }
+  #   search_priority: [searxng]          # or [searxng, brave] for a fallback
+  # searxng:
+  #   image: searxng/searxng:latest
+  #   container_name: searxng
+  #   restart: unless-stopped
+  #   volumes:
+  #     - ./searxng:/etc/searxng:rw
+  #   environment:
+  #     SEARXNG_BASE_URL: http://searxng:8080/
+  #   # No ports: — only loomcycle needs to reach it, in-network.

--- a/docs/SEARCH.md
+++ b/docs/SEARCH.md
@@ -1,0 +1,182 @@
+# Search providers (RFC BB)
+
+Web search in loomcycle is a **first-class, config-declared provider catalog with
+a fallback circuit** — the search analog of the LLM `provider_priority` / `tiers`
+stack. The `WebSearch` tool walks an ordered list of providers, resolves each
+one's key, and on an error / rate-limit / empty result **falls over to the next**
+— the model sees the same `title / URL / snippet` output regardless of which
+provider answered, and follows no protocol.
+
+This guide covers the catalog, the config, per-agent lists, keys, the routing
+view, and — the reason most people land here — **how to run a self-hosted SearXNG
+provider** (a reproducible deploy recipe).
+
+> **Why this, not a raw Brave key?** Brave killed its free tier in the 2026
+> restructure ($5/1K, no volume discount). Serper/Exa/Tavily are 5–50× cheaper or
+> add capabilities Brave can't, and **SearXNG is free** (you host it). The
+> fallback circuit lets you prefer a cheap/self-hosted primary and keep a paid
+> provider as a safety net — without the agent knowing.
+
+## The catalog
+
+Five built-in providers ship today:
+
+| id        | backend                              | key env var       |
+|-----------|--------------------------------------|-------------------|
+| `brave`   | Brave Search API (own index)         | `BRAVE_API_KEY`   |
+| `serper`  | Serper.dev — cheap Google SERP JSON  | `SERPER_API_KEY`  |
+| `exa`     | Exa — neural/semantic + free tier    | `EXA_API_KEY`     |
+| `tavily`  | Tavily — RAG-tuned search            | `TAVILY_API_KEY`  |
+| `searxng` | Self-hosted metasearch (70+ engines) | **keyless** (needs `base_url`) |
+
+## Config
+
+Declare the enabled providers + the global fallback order in `loomcycle.yaml`:
+
+```yaml
+search_providers:
+  searxng:
+    base_url: "http://searxng:8080"   # required for SearXNG (see the recipe below)
+  brave: {}                            # key from BRAVE_API_KEY
+  # serper: {}                         # key from SERPER_API_KEY
+  # exa: {}
+  # tavily: {}
+search_priority: [searxng, brave]      # try SearXNG first, fall over to Brave
+```
+
+- **`search_priority`** is the global cascade. Every entry must be an enabled
+  `search_providers` key. Empty = the enabled set in map order.
+- **Back-compat:** with **no** `search_providers` block, `WebSearch` defaults to
+  Brave when `BRAVE_API_KEY` is set — existing deployments need no change.
+- **Availability** is tracked by *last outcome* (a short cooldown after a failed
+  call), not active probing — paid APIs aren't health-checked on a timer.
+
+### Per-agent override
+
+An agent can narrow/re-order the cascade with its own list (a full replacement of
+`search_priority`; empty = the global default). It's content-identifying (part of
+`content_sha256`, like `providers:`):
+
+```yaml
+agents:
+  researcher:
+    tools: [WebSearch]
+    search_providers: [serper, exa]   # this agent: Serper then Exa, nothing else
+```
+
+## Keys — operator and tenant
+
+Each keyed provider resolves its key the same way LLM providers do (see
+[`docs/CREDENTIALS.md`](CREDENTIALS.md)):
+
+1. A **tenant/user `CredentialDef`** of the provider's env-var name (e.g.
+   `SERPER_API_KEY`) — a tenant searches on its own quota. Author it via the
+   `CredentialDef` tool or the Web UI **Settings → Credentials** page.
+2. Else the **operator host key** from that env var (unless the run is
+   operator-key-restricted).
+
+SearXNG is keyless — no key needed. A provider with no usable key is skipped in
+the cascade (not a failure).
+
+## The routing view
+
+**Settings → Routing** shows the search cascade with, per provider, whether you
+can key it, whether it's available right now, and which one is **selected** (the
+first available = what runs now). Same data over `GET /v1/_routing` (the `search`
+block). Set `LOOMCYCLE_WEBSEARCH_PROVENANCE=1` to also append a `(via searxng)` /
+`(via brave — searxng fell over)` footer to each result, so a fallover is visible
+per query.
+
+---
+
+## Deploying self-hosted SearXNG (recipe)
+
+This is the exact pattern used on the reference VM. SearXNG runs as a **sidecar
+container on the same network as loomcycle**, reachable in-network at
+`http://searxng:8080` — no host port required.
+
+### 1. Add the SearXNG service
+
+Docker-compose sibling of your `loomcycle` service (same network):
+
+```yaml
+services:
+  searxng:
+    image: searxng/searxng:latest
+    container_name: searxng
+    restart: unless-stopped
+    volumes:
+      - ./searxng:/etc/searxng:rw
+    environment:
+      - SEARXNG_BASE_URL=http://searxng:8080/
+    # No ports: — only loomcycle needs to reach it, in-network.
+```
+
+### 2. `searxng/settings.yml` — the THREE required knobs
+
+Create `./searxng/settings.yml` next to your compose file:
+
+```yaml
+use_default_settings: true
+server:
+  # ① REQUIRED — SearXNG refuses to start on the default key.
+  secret_key: "PASTE THE OUTPUT OF: openssl rand -hex 32"
+  # ② REQUIRED — the bot-detection limiter 429s loomcycle's plain HTTP GET.
+  #    Safe here: this instance is private + in-network only.
+  limiter: false
+search:
+  formats:
+    - html
+    - json   # ③ REQUIRED — loomcycle calls /search?format=json (403 without it).
+```
+
+> **The three failure modes if a knob is missing:** no `secret_key` → SearXNG
+> won't start; `limiter` on → loomcycle's requests are 429'd; no `json` format →
+> `/search?format=json` returns **403** and the WebSearch driver errors (and, if
+> you configured a fallback like Brave, quietly falls over to it — so SearXNG
+> would look "configured" but never actually serve). All three are required.
+
+### 3. Point loomcycle at it
+
+In `loomcycle.yaml`:
+
+```yaml
+search_providers:
+  searxng:
+    base_url: "http://searxng:8080"   # the compose service name
+  brave: {}                            # optional paid fallback
+search_priority: [searxng, brave]
+```
+
+SearXNG needs no key. Keep whatever paid providers you also want as fallbacks.
+
+### 4. Verify (in order)
+
+```sh
+# a) SearXNG returns JSON in-network — the decisive check:
+docker run --rm --network <your-net> curlimages/curl -s \
+  "http://searxng:8080/search?q=test&format=json" | head -c 200
+#    → JSON with "results": [...]   (NOT HTML, NOT 403/429)
+
+# b) loomcycle boot log names the provider:
+docker logs loomcycle | grep 'search:'
+#    → search: N provider(s) configured; priority [searxng ...]
+
+# c) end-to-end — watch SearXNG receive a real WebSearch:
+docker logs -f searxng 2>&1 | grep 'GET /search'
+#    then run an agent that uses WebSearch (or check Settings → Routing:
+#    searxng should show SELECTED). A `GET /search?...&format=json → 200`
+#    line = loomcycle → SearXNG confirmed live.
+```
+
+If `Settings → Routing` shows `searxng` **SELECTED** and the SearXNG access log
+shows the `/search?format=json → 200`, it's working end-to-end. If a fallback
+provider is `selected` instead, SearXNG failed the call — re-check the three
+`settings.yml` knobs (usually the `json` format or the limiter).
+
+## See also
+
+- `loomcycle help search-providers` — the in-agent help topic.
+- [`loomcycle.example.yaml`](../loomcycle.example.yaml) — the full `search_providers` block.
+- [`docker-compose.example.yaml`](../docker-compose.example.yaml) — the commented SearXNG sidecar.
+- [`docs/CREDENTIALS.md`](CREDENTIALS.md) — per-tenant provider keys via `CredentialDef`.

--- a/docs/TRUENAS.md
+++ b/docs/TRUENAS.md
@@ -122,6 +122,16 @@ generate the `trains/` output, and point TrueNAS at the catalog.
 - TrueNAS dataset snapshots back up `data` + your agent datasets; that's orthogonal
   to loomcycle's own `/v1/_snapshots`.
 
+## Web search (SearXNG sidecar)
+
+For a free, self-hosted web-search provider, add a **SearXNG sidecar** on the same
+compose network as loomcycle — reachable in-network at `http://searxng:8080`, no
+host port. It's the same pattern on TrueNAS as anywhere else: a `searxng` service,
+a `searxng/settings.yml` with three required knobs (`secret_key`, `limiter: false`,
+`formats: [html, json]`), and `search_providers: { searxng: { base_url: … } }` +
+`search_priority:` in the overlay. Full recipe + verification: **[`docs/SEARCH.md`](SEARCH.md)**
+(the commented sidecar is in [`docker-compose.example.yaml`](../docker-compose.example.yaml)).
+
 ## Volumes → datasets (RFC AH)
 
 Each agent Volume is **a host dataset mounted into the container** + **a `volumes:`


### PR DESCRIPTION
Follow-up to the VM SearXNG migration — document the deployment pattern in the public repo so it's reproducible (RFC BB deferred the "compose recipe" to Phase 3 docs; this is that).

## What

- **`docs/SEARCH.md`** (new) — the search-provider feature end to end: the catalog + fallback circuit, `search_providers` / `search_priority` config, per-agent lists, operator/tenant keys, the routing view — **plus a step-by-step self-hosted SearXNG recipe**: the sidecar service, the **three required `settings.yml` knobs** (`secret_key` / `limiter: false` / `formats: [html, json]`) with the failure mode each one guards, the loomcycle config, and in-order verification (in-net `format=json` check → boot log → SearXNG access log / Settings→Routing `SELECTED`). This mirrors exactly what was done on the VM.
- **`docker-compose.example.yaml`** — a commented `searxng` sidecar + the search-provider key env hints (`BRAVE`/`SERPER`/`EXA`/`TAVILY`).
- **README** docs index — links `docs/SEARCH.md`.
- **`docs/TRUENAS.md`** — a "Web search (SearXNG sidecar)" section pointing at the recipe (the operator's primary deploy guide).

## Why it's needed
Before this, SearXNG appeared only in the README changelog row + `loomcycle.example.yaml`'s config block — there was no deployment recipe (the sidecar + the settings.yml knobs), which is the part that actually trips people up (a missing `json` format 403s silently and falls over to a paid provider). `docs/SEARCH.md` captures the whole reproducible path.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)