### PR TITLE
fix(clienttools): accept cross-origin WS handshakes (browsers send Origin)

### DIFF
--- a/internal/api/http/client_tools.go
+++ b/internal/api/http/client_tools.go
@@ -40,6 +40,24 @@ func (s *Server) handleClientTools(w http.ResponseWriter, r *http.Request) {
 
 	c, err := websocket.Accept(w, r, &websocket.AcceptOptions{
 		Subprotocols: []string{clientToolSubprotocol},
+		// NOTE: coder/websocket's AcceptOptions.InsecureSkipVerify is the
+		// WebSocket ORIGIN-CHECK skip on this handshake — it is NOT TLS
+		// verification (unfortunate name collision with tls.Config). No cert
+		// checking is affected. It accepts any Origin. coder/websocket defaults
+		// to same-origin-only (it 403s any handshake whose Origin host != Host) —
+		// a CSRF guard for COOKIE-authenticated sockets. It guards nothing here
+		// and blocks every real browser client, because:
+		//   1. This endpoint authenticates with a BEARER carried in
+		//      Sec-WebSocket-Protocol (or Authorization) — a cross-origin page
+		//      can't read the user's bearer, so it can't forge a connection.
+		//   2. The only cookie auth path (webui.SessionCookie) is SameSite=Strict,
+		//      so a browser never sends it on a cross-site handshake anyway.
+		// A browser CANNOT suppress Origin (the extension sends
+		// Origin: chrome-extension://<id>), and OriginPatterns can't enumerate
+		// ever-changing extension ids + arbitrary web origins — so allow-all +
+		// bearer auth is the correct posture. (This was masked because the
+		// endpoint was only ever tested with curl, which sends no Origin.)
+		InsecureSkipVerify: true,
 	})
 	if err != nil {
 		return // Accept already wrote the handshake error

--- a/internal/api/http/client_tools_test.go
+++ b/internal/api/http/client_tools_test.go
@@ -140,6 +140,44 @@ func TestCandidateTools_AdvertisesAndGatesClientTools(t *testing.T) {
 	}
 }
 
+// TestHandleClientTools_CrossOriginAccepted is the regression guard for the
+// Origin bug: a browser client (extension / web app) ALWAYS sends an Origin
+// header (host != loomcycle's Host), which coder/websocket's default same-origin
+// check would 403 — so every real browser was rejected while curl (no Origin)
+// sailed through. The handshake must SUCCEED with a cross-origin Origin, because
+// auth is a bearer in the subprotocol (unforgeable cross-origin) + a
+// SameSite=Strict cookie (never sent cross-site). Fail-before: drop
+// InsecureSkipVerify and this dial gets a 403.
+func TestHandleClientTools_CrossOriginAccepted(t *testing.T) {
+	reg := clienttools.NewRegistry(0)
+	ts := clientToolsTestServer(t, reg, auth.Principal{TenantID: "t1", Subject: "u1"})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	// Simulate a browser: an Origin whose host is NOT the server's Host.
+	c, _, err := websocket.Dial(ctx, wsURL(ts.URL), &websocket.DialOptions{
+		Subprotocols: []string{clientToolSubprotocol},
+		HTTPHeader:   http.Header{"Origin": []string{"chrome-extension://abcdefghijklmnop"}},
+	})
+	if err != nil {
+		t.Fatalf("cross-origin handshake must be accepted (bearer auth, not cookie CSRF), got: %v", err)
+	}
+	defer c.CloseNow()
+
+	hello := clienttools.HelloFrame{Type: clienttools.FrameHello, Tools: []clienttools.ToolSchema{{Name: "browser_read_page"}}}
+	b, _ := json.Marshal(hello)
+	if err := c.Write(ctx, websocket.MessageText, b); err != nil {
+		t.Fatal(err)
+	}
+	_, data, err := c.Read(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if clienttools.TypeOf(data) != clienttools.FrameHelloOK {
+		t.Errorf("expected hello_ok on a cross-origin connection; got %s", data)
+	}
+}
+
 func TestHandleClientTools_RejectsWireUnsafeNames(t *testing.T) {
 	reg := clienttools.NewRegistry(0)
 	ts := clientToolsTestServer(t, reg, auth.Principal{TenantID: "t1", Subject: "u1"})


### PR DESCRIPTION
## Why

The `/v1/client-tools` WebSocket **rejects every real browser client with 403** — so no browser (the loomboard extension, any web app) can ever connect, no tools register, and the agent gets `tool not found`. Diagnosed by loomboard (the first browser consumer).

`websocket.Accept` was called with **no `OriginPatterns`/`InsecureSkipVerify`**, so coder/websocket applies its default **same-origin check**: 403 any handshake whose `Origin` host ≠ `Host`. A browser **always** sends `Origin` (the extension sends `Origin: chrome-extension://<id>`) → 403. `curl` never sends `Origin` → 101. So every test (curl) passed and every browser failed — the exact same **"verified with curl, never a browser"** gap as the wire-safe-name bug (#680). It also explains the earlier confusion: HTTP/2 was a red herring (disabling it changed nothing); the Origin check was always the cause.

## Fix

Set `AcceptOptions.InsecureSkipVerify` — which in coder/websocket is the **WebSocket Origin-check skip, NOT TLS verification** (unfortunate name collision with `tls.Config`; called out explicitly in a code comment so no one — or no lint hook — misreads it). No cert checking is touched.

**Why it's safe** (the Origin check is a cookie-CSRF guard that protects nothing here):
1. The endpoint authenticates with a **bearer** in `Sec-WebSocket-Protocol` (or `Authorization`) — a cross-origin page **can't read the user's bearer**, so it can't forge a connection.
2. The only cookie auth path (`webui.SessionCookie`) is **`SameSite=Strict`** — a browser never sends it on a cross-site handshake, so there's no ambient-credential CSRF to guard against.

A browser **cannot** suppress `Origin`, and `OriginPatterns` can't enumerate ever-changing extension ids + arbitrary web origins — so **allow-all Origin + bearer auth** is the correct posture.

## Regression (the test that was missing)

`TestHandleClientTools_CrossOriginAccepted` — a handshake with a cross-origin `Origin: chrome-extension://…` must succeed to `hello_ok`. **Verified fail-before:** on the old code it fails with `got 403`; with the fix it passes.

## Tested
`go test ./...` clean (incl. `-race` on the client-tools tests). `gofmt`/`vet` clean.

Warrants a **v1.16.2** patch — this is the last blocker for the loomboard extension end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)