### PR TITLE
feat(http): support `*` allow-all in the host allowlist

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -989,7 +989,13 @@ func main() {
 		log.Printf("note: file tools (Read/Write/Edit/Glob/Grep/Bash) require a `volumes:` binding — none configured; agents with no volume binding have no filesystem access")
 	}
 	if len(staticHosts) == 0 && !cfg.Env.HTTPCallerAuthoritative {
-		log.Printf("note: HTTP + WebFetch tools are registered but disabled — set LOOMCYCLE_HTTP_HOST_ALLOWLIST to enable (or LOOMCYCLE_HTTP_CALLER_AUTHORITATIVE=1 to delegate the allowlist to the caller)")
+		log.Printf("note: HTTP + WebFetch tools are registered but disabled — set LOOMCYCLE_HTTP_HOST_ALLOWLIST to enable (a comma-separated host list, or `*` for all public hosts; or LOOMCYCLE_HTTP_CALLER_AUTHORITATIVE=1 to delegate the allowlist to the caller)")
+	}
+	for _, h := range staticHosts {
+		if h == "*" {
+			log.Printf("note: LOOMCYCLE_HTTP_HOST_ALLOWLIST=* — HTTP + WebFetch may reach ANY public host; the dial-time guard still blocks private/loopback/link-local/metadata IPs (add specific internal hosts via LOOMCYCLE_HTTP_PRIVATE_HOST_ALLOWLIST)")
+			break
+		}
 	}
 	if cfg.Env.HTTPCallerAuthoritative {
 		log.Printf("note: HTTP_CALLER_AUTHORITATIVE=1 — caller's allowed_hosts is the sole policy; operator's static list is fallback only")

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -735,6 +735,7 @@ YAML: every agent's `tools` lists only the network-restricted set (`HTTP` only w
 ```bash
 LOOMCYCLE_BASH_ENABLED=1                   # bash on (still NOT a real sandbox; container required)
 LOOMCYCLE_HTTP_HOST_ALLOWLIST=api.anthropic.com,api.brave.com,github.com,...
+# or LOOMCYCLE_HTTP_HOST_ALLOWLIST=*  # allow ALL public hosts (dial-time private-IP guard still applies)
 LOOMCYCLE_SKILLS_ROOT=/work/.claude/skills
 LOOMCYCLE_HTTP_PRIVATE_HOST_ALLOWLIST=localhost,127.0.0.1
 ```

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -155,7 +155,9 @@ Use cases:
 
 ## Per-request URL allowlist (HTTP / WebFetch / WebSearch)
 
-The operator's `LOOMCYCLE_HTTP_HOST_ALLOWLIST` is a security floor — every host the agent might ever need to reach. For a single run, callers usually want to constrain further: this run is about scraping job listings from `linkedin.com` and `indeed.com`, that one is about reading from `bbc.co.uk`. Per-request narrowing exists for exactly this.
+The operator's `LOOMCYCLE_HTTP_HOST_ALLOWLIST` is a security floor — every host the agent might ever need to reach. It is a comma-separated suffix list (`example.com` matches `example.com` and `api.example.com`). A single `*` entry (`LOOMCYCLE_HTTP_HOST_ALLOWLIST=*`) is the operator's explicit **allow-all**: any hostname passes the name check. This lifts only the name layer — the dial-time IP guard still blocks private/loopback/link-local/metadata addresses, so `*` means "all **public** websites", never "all addresses"; expose specific internal hosts via `LOOMCYCLE_HTTP_PRIVATE_HOST_ALLOWLIST`. A caller cannot use `*` to widen a narrower operator floor — the intersection below still applies.
+
+For a single run, callers usually want to constrain further: this run is about scraping job listings from `linkedin.com` and `indeed.com`, that one is about reading from `bbc.co.uk`. Per-request narrowing exists for exactly this.
 
 ```http
 POST /v1/runs

--- a/internal/tools/builtin/httptool.go
+++ b/internal/tools/builtin/httptool.go
@@ -22,7 +22,10 @@ import (
 //
 //  1. **Hostname allowlist** (HostAllowlist). Suffix-matched: an entry
 //     "example.com" matches "example.com" and "api.example.com" but not
-//     "evil-example.com". Empty allowlist refuses every call.
+//     "evil-example.com". Empty allowlist refuses every call. A single "*"
+//     entry is the operator's explicit allow-all — any hostname passes the
+//     name check (but layer 2 below still applies, so it means all PUBLIC
+//     hosts, never private/loopback IPs).
 //
 //  2. **IP-level block at connect time** via Dialer.Control. Even if the
 //     hostname is allowlisted, the resolved IP is rejected if it falls in
@@ -35,7 +38,9 @@ import (
 // context propagation.
 type HTTP struct {
 	// HostAllowlist is the suffix-matched list of permitted hostnames.
-	// Required: empty allowlist rejects every call.
+	// Required: empty allowlist rejects every call. A single "*" entry means
+	// allow-all (any hostname) — the operator's explicit opt-out of the name
+	// floor; the IP-level dial guard still blocks private addresses.
 	HostAllowlist []string
 	// MaxRequestBytes caps the request body. Default 256 KiB.
 	MaxRequestBytes int64
@@ -264,6 +269,17 @@ func hostAllowed(host string, allowlist []string) bool {
 		entry = strings.ToLower(strings.TrimSuffix(entry, "."))
 		if entry == "" {
 			continue
+		}
+		// "*" is the operator's explicit allow-all sentinel: an operator that
+		// sets LOOMCYCLE_HTTP_HOST_ALLOWLIST=* accepts any hostname. This is
+		// the name-layer ONLY — the IP-level dial guard (layer 2) still
+		// rejects private/loopback/link-local/metadata IPs, so "*" means "all
+		// PUBLIC websites", not "all addresses". A caller cannot use "*" to
+		// widen a narrower operator floor: NarrowHosts intersects the caller's
+		// list against the operator's via this same matcher, so a caller "*"
+		// only survives when the operator floor already contains "*".
+		if entry == "*" {
+			return true
 		}
 		if host == entry {
 			return true

--- a/internal/tools/builtin/httptool_test.go
+++ b/internal/tools/builtin/httptool_test.go
@@ -141,6 +141,78 @@ func TestHTTPRejectsPrivateIPDespiteAllowlist(t *testing.T) {
 	}
 }
 
+// The "*" allow-all sentinel: an operator that sets
+// LOOMCYCLE_HTTP_HOST_ALLOWLIST=* accepts any hostname at the name layer.
+// Pure-matcher unit test.
+func TestHostAllowedWildcard(t *testing.T) {
+	if !hostAllowed("anything.example.com", []string{"*"}) {
+		t.Error(`"*" should allow any host`)
+	}
+	if !hostAllowed("random.tld", []string{"foo.com", "*"}) {
+		t.Error(`"*" anywhere in the list should allow any host`)
+	}
+	if hostAllowed("", []string{"*"}) {
+		t.Error("an empty host is never allowed, even under *")
+	}
+	// A literal "*" is the sentinel, never a suffix — it must NOT be treated
+	// as matching only hosts ending ".*" or exactly "*".
+	if !hostAllowed("deep.sub.domain.io", []string{"*"}) {
+		t.Error(`"*" should match arbitrarily deep subdomains`)
+	}
+}
+
+// The "*" sentinel widens ONLY the name layer (layer 1). The dial-time
+// IP guard (layer 2) still refuses private/loopback IPs, so "*" means
+// "all PUBLIC hosts", never "all addresses". Fail-before is impossible
+// (the guard is independent) but this pins the documented public-only
+// semantics against a future change that might route "*" past the dial
+// guard.
+func TestHTTPWildcardStillBlocksPrivateIP(t *testing.T) {
+	// AllowPrivateIPs stays false so the dial guard is live.
+	h := &HTTP{HostAllowlist: []string{"*"}}
+	body, _ := json.Marshal(map[string]string{
+		"method": "GET",
+		"url":    "http://localhost:1/", // loopback → guard must fire despite *
+	})
+	res, err := h.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Fatalf("wildcard must not lift the private-IP guard; got %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "no public addresses") && !strings.Contains(res.Text, "private") {
+		t.Errorf("rejection should mention private/public; got %q", res.Text)
+	}
+}
+
+// The "*" sentinel does let an otherwise-unlisted PUBLIC-shaped host
+// through the name layer: with the IP guard disabled (as tests do for
+// loopback), a request to a host that is on no explicit allowlist entry
+// succeeds purely because of "*".
+func TestHTTPWildcardAllowsUnlistedHost(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "reached via wildcard")
+	}))
+	defer srv.Close()
+
+	// HostAllowlist is ONLY "*" — the httptest host is on no explicit entry.
+	// AllowPrivateIPs lets the loopback dial complete (the name layer is what
+	// we're exercising here).
+	h := &HTTP{HostAllowlist: []string{"*"}, AllowPrivateIPs: true}
+	body, _ := json.Marshal(map[string]string{"method": "GET", "url": srv.URL})
+	res, err := h.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf(`"*" should admit an unlisted host at the name layer; got %q`, res.Text)
+	}
+	if !strings.Contains(res.Text, "reached via wildcard") {
+		t.Errorf("expected the server body; got %q", res.Text)
+	}
+}
+
 // Direct unit test on dialContext with a public-shaped hostname that
 // resolves entirely to private IPs — proves the guard is what stops
 // the dial, not the layer-1 allowlist exact-match path. Catches the

--- a/internal/tools/builtin/narrowing_test.go
+++ b/internal/tools/builtin/narrowing_test.go
@@ -50,6 +50,34 @@ func TestNarrowHostsCannotWidenOperatorList(t *testing.T) {
 	}
 }
 
+// Security invariant for the "*" allow-all sentinel: a CALLER passing "*"
+// must NOT widen a specific operator floor. intersectHosts keeps a caller
+// entry only if it matches the operator list; "*" matches "acme.com" under
+// neither exact nor suffix nor the sentinel rule (the sentinel fires only
+// when the OPERATOR list contains "*"), so caller "*" is dropped → empty →
+// deny-all. This is the "operator's static list is the floor" invariant.
+func TestNarrowHostsCallerWildcardCannotWidenFloor(t *testing.T) {
+	op := &HTTP{HostAllowlist: []string{"acme.com"}}
+	out := NarrowHosts([]tools.Tool{op}, []string{"*"}, "", false)
+	wrapped := out[0].(*HTTP)
+	if len(wrapped.HostAllowlist) != 0 {
+		t.Errorf("caller %q against operator floor %v must not widen; got %v", "*", op.HostAllowlist, wrapped.HostAllowlist)
+	}
+}
+
+// The complement: when the OPERATOR floor is "*" (allow-all), a caller can
+// still narrow to a specific host — that host survives the intersection
+// because hostAllowed(host, ["*"]) is true.
+func TestNarrowHostsOperatorWildcardFloorLetsCallerNarrow(t *testing.T) {
+	op := &HTTP{HostAllowlist: []string{"*"}}
+	out := NarrowHosts([]tools.Tool{op}, []string{"linkedin.com"}, "", false)
+	wrapped := out[0].(*HTTP)
+	want := []string{"linkedin.com"}
+	if !reflect.DeepEqual(wrapped.HostAllowlist, want) {
+		t.Errorf("operator %q floor should let caller narrow; got %v, want %v", "*", wrapped.HostAllowlist, want)
+	}
+}
+
 // Narrowing flows through WebFetch's HTTP backend. WebFetch wraps an
 // HTTP; the wrapper must narrow the inner HTTP without sharing state
 // with the original.


### PR DESCRIPTION
## Why

Self-host / TrueNAS operators running trusted agents want an explicit "reach every website" posture, but loomcycle had no clean switch for it:

- `LOOMCYCLE_HTTP_HOST_ALLOWLIST` is a **suffix-match** with **empty = deny-all**.
- A literal `*` matched **nothing** (`host == "*"` is false and `HasSuffix(host, ".*")` is false).
- The only workaround was a hand-maintained TLD list (`com,org,net,io,…`) that silently dropped ccTLDs, `.info`, IP-literal hosts, etc. — agents hitting those got `host not in allowlist`.

## What

`hostAllowed` now treats a `*` entry as **allow-all**. Set `LOOMCYCLE_HTTP_HOST_ALLOWLIST=*` and any hostname passes the name check.

Two invariants are deliberately preserved:

1. **Public-web only, not "all addresses".** `*` lifts only the *name* layer (layer 1). The dial-time IP guard (layer 2 — RFC1918 / loopback / link-local / cloud-metadata `169.254.169.254`) still fires, so `*` cannot be used for SSRF into internal infra. Internal hosts stay opt-in via `LOOMCYCLE_HTTP_PRIVATE_HOST_ALLOWLIST`. (Confirmed with the maintainer: public-web only.)
2. **The operator floor still can't be widened by a caller.** `NarrowHosts` intersects the caller's per-run `allowed_hosts` against the operator floor through this *same* matcher, so a caller `*` survives only when the operator floor already contains `*`. Against a specific floor (`["acme.com"]`) a caller `*` → dropped → deny-all. CLAUDE.md rule 8 ("operator's static list is the floor") holds.

One-place change: HTTP, WebFetch (shared backend), and WebSearch result-filtering all route through `hostAllowed`. Boot logs the allow-all posture when `*` is active.

## What was tested

- `TestHostAllowedWildcard` — matcher accepts any host under `*`, at any list position, arbitrarily deep; empty host still rejected.
- `TestHTTPWildcardStillBlocksPrivateIP` — a loopback URL is still refused under `*` (the SSRF guard is independent).
- `TestHTTPWildcardAllowsUnlistedHost` — an otherwise-unlisted host reaches the server purely via `*`.
- `TestNarrowHostsCallerWildcardCannotWidenFloor` — caller `*` against `["acme.com"]` → empty (no widen).
- `TestNarrowHostsOperatorWildcardFloorLetsCallerNarrow` — operator `*` floor still lets a caller narrow to a specific host.
- **Fail-before verified:** removing the `*` branch makes the wildcard tests fail (`"*" should allow any host`, `host "127.0.0.1" not in allowlist`).
- Full `internal/tools/builtin` package + `go build ./...` green; `gofmt`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)