### PR TITLE
feat(webui): Library filter + sort + hide-retired

### DIFF
--- a/internal/api/http/library_unified.go
+++ b/internal/api/http/library_unified.go
@@ -52,9 +52,9 @@ type LibraryEntry struct {
 	LatestVersion    int             `json:"latest_version,omitempty"`
 	LastUpdated      time.Time       `json:"last_updated,omitempty"`
 	StaticDefinition json.RawMessage `json:"static_definition,omitempty"`
-	// LiveVersionCount / ActiveRetired — agents only (the soft-reclaim
-	// status the UI badges on). Zero/false for skills + mcp-servers, whose
-	// summaries don't carry these yet.
+	// LiveVersionCount / ActiveRetired — the soft-reclaim status the UI badges
+	// on and the Library "Hide retired" filter reads. Populated for agents,
+	// skills, AND mcp-servers by their *ListNames summary queries.
 	LiveVersionCount int  `json:"live_version_count,omitempty"`
 	ActiveRetired    bool `json:"active_retired,omitempty"`
 }
@@ -197,6 +197,8 @@ func (s *Server) handleListLibrarySkills(w http.ResponseWriter, r *http.Request)
 			entry.ActiveDefID = sub.ActiveDefID
 			entry.LatestVersion = sub.LatestVersion
 			entry.LastUpdated = sub.LastUpdated
+			entry.LiveVersionCount = sub.LiveVersionCount
+			entry.ActiveRetired = sub.ActiveRetired
 		}
 		entry.Source = deriveSource(entry.InStatic, entry.InSubstrate)
 		entries = append(entries, entry)
@@ -207,13 +209,15 @@ func (s *Server) handleListLibrarySkills(w http.ResponseWriter, r *http.Request)
 			continue
 		}
 		entries = append(entries, LibraryEntry{
-			Name:          name,
-			Source:        deriveSource(false, true),
-			InSubstrate:   true,
-			VersionCount:  sub.VersionCount,
-			ActiveDefID:   sub.ActiveDefID,
-			LatestVersion: sub.LatestVersion,
-			LastUpdated:   sub.LastUpdated,
+			Name:             name,
+			Source:           deriveSource(false, true),
+			InSubstrate:      true,
+			VersionCount:     sub.VersionCount,
+			ActiveDefID:      sub.ActiveDefID,
+			LatestVersion:    sub.LatestVersion,
+			LastUpdated:      sub.LastUpdated,
+			LiveVersionCount: sub.LiveVersionCount,
+			ActiveRetired:    sub.ActiveRetired,
 		})
 	}
 	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
@@ -266,6 +270,8 @@ func (s *Server) handleListLibraryMcpServers(w http.ResponseWriter, r *http.Requ
 			entry.ActiveDefID = sub.ActiveDefID
 			entry.LatestVersion = sub.LatestVersion
 			entry.LastUpdated = sub.LastUpdated
+			entry.LiveVersionCount = sub.LiveVersionCount
+			entry.ActiveRetired = sub.ActiveRetired
 		}
 		entry.Source = deriveSource(entry.InStatic, entry.InSubstrate)
 		entries = append(entries, entry)
@@ -276,13 +282,15 @@ func (s *Server) handleListLibraryMcpServers(w http.ResponseWriter, r *http.Requ
 			continue
 		}
 		entries = append(entries, LibraryEntry{
-			Name:          name,
-			Source:        deriveSource(false, true),
-			InSubstrate:   true,
-			VersionCount:  sub.VersionCount,
-			ActiveDefID:   sub.ActiveDefID,
-			LatestVersion: sub.LatestVersion,
-			LastUpdated:   sub.LastUpdated,
+			Name:             name,
+			Source:           deriveSource(false, true),
+			InSubstrate:      true,
+			VersionCount:     sub.VersionCount,
+			ActiveDefID:      sub.ActiveDefID,
+			LatestVersion:    sub.LatestVersion,
+			LastUpdated:      sub.LastUpdated,
+			LiveVersionCount: sub.LiveVersionCount,
+			ActiveRetired:    sub.ActiveRetired,
 		})
 	}
 	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })

--- a/internal/api/http/library_unified_test.go
+++ b/internal/api/http/library_unified_test.go
@@ -64,6 +64,53 @@ func decodeLibraryEntries(t *testing.T, rec *httptest.ResponseRecorder) []Librar
 	return resp.Entries
 }
 
+// TestUnifiedLibrary_Skills_SurfacesRetiredStatus verifies the skills library
+// endpoint carries live_version_count / active_retired (added so the Web UI
+// "Hide retired" filter works on the skills tab, not just agents). Seed two
+// versions with v1 retired + active pointing at the retired v1.
+func TestUnifiedLibrary_Skills_SurfacesRetiredStatus(t *testing.T) {
+	srv, s, cleanup := libraryUnifiedFixture(t, nil, nil)
+	defer cleanup()
+	ctx := t.Context()
+
+	if _, err := s.SkillDefCreate(ctx, store.SkillDefRow{
+		DefID: "sk1", Name: "voice", Version: 1,
+		Definition: []byte(`{"body":"v1"}`), CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.SkillDefCreate(ctx, store.SkillDefRow{
+		DefID: "sk2", Name: "voice", Version: 2, ParentDefID: "sk1",
+		Definition: []byte(`{"body":"v2"}`), CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SkillDefSetRetired(ctx, "sk1", true); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SkillDefSetActive(ctx, "", "voice", "sk1", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	srv.Mux().ServeHTTP(rec, authedRequest("GET", "/v1/_library/skills", nil))
+	entries := decodeLibraryEntries(t, rec)
+
+	if len(entries) != 1 || entries[0].Name != "voice" {
+		t.Fatalf("entries = %+v, want 1 entry 'voice'", entries)
+	}
+	e := entries[0]
+	if e.VersionCount != 2 {
+		t.Errorf("version_count = %d, want 2", e.VersionCount)
+	}
+	if e.LiveVersionCount != 1 {
+		t.Errorf("live_version_count = %d, want 1 (retired excluded)", e.LiveVersionCount)
+	}
+	if !e.ActiveRetired {
+		t.Errorf("active_retired = false, want true (active points at retired sk1)")
+	}
+}
+
 // TestUnifiedLibrary_Agents_StaticOnly — yaml-only entry, empty store.
 // Expect source=static-only, in_static=true, in_substrate=false,
 // version_count=0, static_definition non-nil.

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -4116,13 +4116,16 @@ func (s *Store) SkillDefListNames(ctx context.Context) ([]store.SkillDefNameSumm
 		SELECT
 			d.tenant_id,
 			d.name,
-			COUNT(*)                  AS version_count,
-			MAX(d.version)            AS latest_version,
-			MAX(d.created_at)         AS last_updated,
-			COALESCE(a.def_id, '')    AS active_def_id
+			COUNT(*)                                  AS version_count,
+			COUNT(*) FILTER (WHERE d.retired = FALSE) AS live_version_count,
+			MAX(d.version)                            AS latest_version,
+			MAX(d.created_at)                         AS last_updated,
+			COALESCE(a.def_id, '')                    AS active_def_id,
+			COALESCE(ad.retired, FALSE)               AS active_retired
 		FROM skill_defs d
 		LEFT JOIN skill_def_active a ON a.name = d.name AND a.tenant_id = d.tenant_id
-		GROUP BY d.tenant_id, d.name, a.def_id
+		LEFT JOIN skill_defs ad      ON ad.def_id = a.def_id
+		GROUP BY d.tenant_id, d.name, a.def_id, ad.retired
 		ORDER BY d.tenant_id, d.name`)
 	if err != nil {
 		return nil, fmt.Errorf("skill_def list names: %w", err)
@@ -4132,7 +4135,7 @@ func (s *Store) SkillDefListNames(ctx context.Context) ([]store.SkillDefNameSumm
 	var out []store.SkillDefNameSummary
 	for rows.Next() {
 		var ns store.SkillDefNameSummary
-		if err := rows.Scan(&ns.TenantID, &ns.Name, &ns.VersionCount, &ns.LatestVersion, &ns.LastUpdated, &ns.ActiveDefID); err != nil {
+		if err := rows.Scan(&ns.TenantID, &ns.Name, &ns.VersionCount, &ns.LiveVersionCount, &ns.LatestVersion, &ns.LastUpdated, &ns.ActiveDefID, &ns.ActiveRetired); err != nil {
 			return nil, err
 		}
 		out = append(out, ns)
@@ -4373,13 +4376,16 @@ func (s *Store) MCPServerDefListNames(ctx context.Context) ([]store.MCPServerDef
 		SELECT
 			d.tenant_id,
 			d.name,
-			COUNT(*)                  AS version_count,
-			MAX(d.version)            AS latest_version,
-			MAX(d.created_at)         AS last_updated,
-			COALESCE(a.def_id, '')    AS active_def_id
+			COUNT(*)                                  AS version_count,
+			COUNT(*) FILTER (WHERE d.retired = FALSE) AS live_version_count,
+			MAX(d.version)                            AS latest_version,
+			MAX(d.created_at)                         AS last_updated,
+			COALESCE(a.def_id, '')                    AS active_def_id,
+			COALESCE(ad.retired, FALSE)               AS active_retired
 		FROM mcp_server_defs d
 		LEFT JOIN mcp_server_def_active a ON a.name = d.name AND a.tenant_id = d.tenant_id
-		GROUP BY d.tenant_id, d.name, a.def_id
+		LEFT JOIN mcp_server_defs ad      ON ad.def_id = a.def_id
+		GROUP BY d.tenant_id, d.name, a.def_id, ad.retired
 		ORDER BY d.tenant_id, d.name`)
 	if err != nil {
 		return nil, fmt.Errorf("mcp_server_def list names: %w", err)
@@ -4389,7 +4395,7 @@ func (s *Store) MCPServerDefListNames(ctx context.Context) ([]store.MCPServerDef
 	var out []store.MCPServerDefNameSummary
 	for rows.Next() {
 		var ns store.MCPServerDefNameSummary
-		if err := rows.Scan(&ns.TenantID, &ns.Name, &ns.VersionCount, &ns.LatestVersion, &ns.LastUpdated, &ns.ActiveDefID); err != nil {
+		if err := rows.Scan(&ns.TenantID, &ns.Name, &ns.VersionCount, &ns.LiveVersionCount, &ns.LatestVersion, &ns.LastUpdated, &ns.ActiveDefID, &ns.ActiveRetired); err != nil {
 			return nil, err
 		}
 		out = append(out, ns)

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -4529,13 +4529,16 @@ func (s *Store) SkillDefListNames(ctx context.Context) ([]store.SkillDefNameSumm
 		SELECT
 			d.tenant_id,
 			d.name,
-			COUNT(*)                  AS version_count,
-			MAX(d.version)            AS latest_version,
-			MAX(d.created_at)         AS last_updated,
-			COALESCE(a.def_id, '')    AS active_def_id
+			COUNT(*)                              AS version_count,
+			COUNT(*) FILTER (WHERE d.retired = 0) AS live_version_count,
+			MAX(d.version)                        AS latest_version,
+			MAX(d.created_at)                     AS last_updated,
+			COALESCE(a.def_id, '')                AS active_def_id,
+			COALESCE(ad.retired, 0)               AS active_retired
 		FROM skill_defs d
 		LEFT JOIN skill_def_active a ON a.name = d.name AND a.tenant_id = d.tenant_id
-		GROUP BY d.tenant_id, d.name, a.def_id
+		LEFT JOIN skill_defs ad      ON ad.def_id = a.def_id
+		GROUP BY d.tenant_id, d.name, a.def_id, ad.retired
 		ORDER BY d.tenant_id, d.name`)
 	if err != nil {
 		return nil, err
@@ -4546,10 +4549,12 @@ func (s *Store) SkillDefListNames(ctx context.Context) ([]store.SkillDefNameSumm
 	for rows.Next() {
 		var ns store.SkillDefNameSummary
 		var updatedAt int64
-		if err := rows.Scan(&ns.TenantID, &ns.Name, &ns.VersionCount, &ns.LatestVersion, &updatedAt, &ns.ActiveDefID); err != nil {
+		var activeRetired int
+		if err := rows.Scan(&ns.TenantID, &ns.Name, &ns.VersionCount, &ns.LiveVersionCount, &ns.LatestVersion, &updatedAt, &ns.ActiveDefID, &activeRetired); err != nil {
 			return nil, err
 		}
 		ns.LastUpdated = time.Unix(0, updatedAt)
+		ns.ActiveRetired = activeRetired != 0
 		out = append(out, ns)
 	}
 	return out, rows.Err()
@@ -4803,13 +4808,16 @@ func (s *Store) MCPServerDefListNames(ctx context.Context) ([]store.MCPServerDef
 		SELECT
 			d.tenant_id,
 			d.name,
-			COUNT(*)                  AS version_count,
-			MAX(d.version)            AS latest_version,
-			MAX(d.created_at)         AS last_updated,
-			COALESCE(a.def_id, '')    AS active_def_id
+			COUNT(*)                              AS version_count,
+			COUNT(*) FILTER (WHERE d.retired = 0) AS live_version_count,
+			MAX(d.version)                        AS latest_version,
+			MAX(d.created_at)                     AS last_updated,
+			COALESCE(a.def_id, '')                AS active_def_id,
+			COALESCE(ad.retired, 0)               AS active_retired
 		FROM mcp_server_defs d
 		LEFT JOIN mcp_server_def_active a ON a.name = d.name AND a.tenant_id = d.tenant_id
-		GROUP BY d.tenant_id, d.name, a.def_id
+		LEFT JOIN mcp_server_defs ad      ON ad.def_id = a.def_id
+		GROUP BY d.tenant_id, d.name, a.def_id, ad.retired
 		ORDER BY d.tenant_id, d.name`)
 	if err != nil {
 		return nil, err
@@ -4820,10 +4828,12 @@ func (s *Store) MCPServerDefListNames(ctx context.Context) ([]store.MCPServerDef
 	for rows.Next() {
 		var ns store.MCPServerDefNameSummary
 		var updatedAt int64
-		if err := rows.Scan(&ns.TenantID, &ns.Name, &ns.VersionCount, &ns.LatestVersion, &updatedAt, &ns.ActiveDefID); err != nil {
+		var activeRetired int
+		if err := rows.Scan(&ns.TenantID, &ns.Name, &ns.VersionCount, &ns.LiveVersionCount, &ns.LatestVersion, &updatedAt, &ns.ActiveDefID, &activeRetired); err != nil {
 			return nil, err
 		}
 		ns.LastUpdated = time.Unix(0, updatedAt)
+		ns.ActiveRetired = activeRetired != 0
 		out = append(out, ns)
 	}
 	return out, rows.Err()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2462,6 +2462,12 @@ type SkillDefNameSummary struct {
 	ActiveDefID   string    `json:"active_def_id,omitempty"`
 	LatestVersion int       `json:"latest_version"`
 	LastUpdated   time.Time `json:"last_updated"`
+	// LiveVersionCount / ActiveRetired mirror AgentDefNameSummary — the
+	// soft-reclaim status the Web UI Library's "Hide retired" filter reads.
+	// LiveVersionCount is VersionCount minus retired rows; ActiveRetired is
+	// true when the active pointer references a retired row.
+	LiveVersionCount int  `json:"live_version_count"`
+	ActiveRetired    bool `json:"active_retired,omitempty"`
 }
 
 // SkillDefActiveEntry mirrors AgentDefActiveEntry. Pairs a skill
@@ -2519,6 +2525,10 @@ type MCPServerDefNameSummary struct {
 	// filter key the per-name GetActive call on this so a run only ever
 	// sees its own + shared MCP servers.
 	TenantID string `json:"tenant_id,omitempty"`
+	// LiveVersionCount / ActiveRetired mirror AgentDefNameSummary — the
+	// soft-reclaim status the Web UI Library's "Hide retired" filter reads.
+	LiveVersionCount int  `json:"live_version_count"`
+	ActiveRetired    bool `json:"active_retired,omitempty"`
 }
 
 // MCPServerDefActiveEntry mirrors AgentDefActiveEntry / SkillDefActiveEntry.

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -212,6 +212,7 @@ func Run(t *testing.T, factory Factory) {
 		{"SkillDefAppendOnlyDefinition", testSkillDefAppendOnlyDefinition},
 		{"SkillDefActivePointerIdempotent", testSkillDefActivePointerIdempotent},
 		{"SkillDefRetireReversible", testSkillDefRetireReversible},
+		{"SkillDefListNamesLiveCount", testSkillDefListNamesLiveCount},
 		{"SkillDefStaticFallback", testSkillDefStaticFallback},
 		// RFC N — skill definition plane tenant isolation. Fails on the
 		// pre-migration single-`name`-PK schema (clobber); passes after.
@@ -224,6 +225,7 @@ func Run(t *testing.T, factory Factory) {
 		{"MCPServerDefVersionMonotonic", testMCPServerDefVersionMonotonic},
 		{"MCPServerDefActivePointerIdempotent", testMCPServerDefActivePointerIdempotent},
 		{"MCPServerDefRetireReversible", testMCPServerDefRetireReversible},
+		{"MCPServerDefListNamesLiveCount", testMCPServerDefListNamesLiveCount},
 		// RFC N — MCP server definition plane tenant isolation. Fails on the
 		// pre-migration single-`name`-PK schema (clobber); passes after.
 		{"MCPServerDefTenantIsolation", testMCPServerDefTenantIsolation},
@@ -4551,6 +4553,93 @@ func testAgentDefListNamesLiveCount(t *testing.T, s store.Store) {
 	}
 	if sum.LiveVersionCount != 1 {
 		t.Errorf("LiveVersionCount = %d, want 1 (retired excluded)", sum.LiveVersionCount)
+	}
+}
+
+// testSkillDefListNamesLiveCount mirrors the agent live-count test for skills:
+// VersionCount counts every version, LiveVersionCount excludes retired, and
+// ActiveRetired is true when the active pointer references a retired def. Drives
+// the Web UI Library "Hide retired" filter for the skills tab.
+func testSkillDefListNamesLiveCount(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	v1, err := s.SkillDefCreate(ctx, mkSkillDef("slc-1", "slc-skill", ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.SkillDefCreate(ctx, mkSkillDef("slc-2", "slc-skill", v1.DefID)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SkillDefSetRetired(ctx, v1.DefID, true); err != nil {
+		t.Fatal(err)
+	}
+	find := func() store.SkillDefNameSummary {
+		rows, lerr := s.SkillDefListNames(ctx)
+		if lerr != nil {
+			t.Fatal(lerr)
+		}
+		for _, r := range rows {
+			if r.Name == "slc-skill" && r.TenantID == "" {
+				return r
+			}
+		}
+		t.Fatal("slc-skill not in list")
+		return store.SkillDefNameSummary{}
+	}
+	sum := find()
+	if sum.VersionCount != 2 {
+		t.Errorf("VersionCount = %d, want 2 (retired rows still counted)", sum.VersionCount)
+	}
+	if sum.LiveVersionCount != 1 {
+		t.Errorf("LiveVersionCount = %d, want 1 (retired excluded)", sum.LiveVersionCount)
+	}
+	// Pointing active at the retired v1 surfaces ActiveRetired.
+	if err := s.SkillDefSetActive(ctx, "", "slc-skill", v1.DefID, ""); err != nil {
+		t.Fatal(err)
+	}
+	if !find().ActiveRetired {
+		t.Errorf("ActiveRetired = false, want true (active points at a retired def)")
+	}
+}
+
+// testMCPServerDefListNamesLiveCount mirrors the skill/agent live-count test for
+// the mcp-servers tab.
+func testMCPServerDefListNamesLiveCount(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	v1, err := s.MCPServerDefCreate(ctx, mkMCPServerDef("mlc-1", "mlc-mcp", ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.MCPServerDefCreate(ctx, mkMCPServerDef("mlc-2", "mlc-mcp", v1.DefID)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.MCPServerDefSetRetired(ctx, v1.DefID, true); err != nil {
+		t.Fatal(err)
+	}
+	find := func() store.MCPServerDefNameSummary {
+		rows, lerr := s.MCPServerDefListNames(ctx)
+		if lerr != nil {
+			t.Fatal(lerr)
+		}
+		for _, r := range rows {
+			if r.Name == "mlc-mcp" && r.TenantID == "" {
+				return r
+			}
+		}
+		t.Fatal("mlc-mcp not in list")
+		return store.MCPServerDefNameSummary{}
+	}
+	sum := find()
+	if sum.VersionCount != 2 {
+		t.Errorf("VersionCount = %d, want 2 (retired rows still counted)", sum.VersionCount)
+	}
+	if sum.LiveVersionCount != 1 {
+		t.Errorf("LiveVersionCount = %d, want 1 (retired excluded)", sum.LiveVersionCount)
+	}
+	if err := s.MCPServerDefSetActive(ctx, "", "mlc-mcp", v1.DefID, ""); err != nil {
+		t.Fatal(err)
+	}
+	if !find().ActiveRetired {
+		t.Errorf("ActiveRetired = false, want true (active points at a retired def)")
 	}
 }
 

--- a/packages/library/src/components/LineagePanel.tsx
+++ b/packages/library/src/components/LineagePanel.tsx
@@ -73,6 +73,39 @@ export default function LineagePanel({
   const [selectedName, setSelectedName] = useState<string>(() =>
     entries.length > 0 ? entries[0]!.name : "",
   );
+
+  // List controls (per-tab: each sub-tab renders its own LineagePanel, so the
+  // filter/type/sort/hide-retired state is naturally independent per tab).
+  const [filterText, setFilterText] = useState("");
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
+  const [hideRetired, setHideRetired] = useState(false);
+  const [sortMode, setSortMode] = useState<SortMode>("none");
+
+  // The list actually rendered = entries ∘ name-filter ∘ type-filter ∘
+  // hide-retired ∘ sort. Memoised so selecting a row (which changes
+  // selectedName) doesn't re-run the whole chain. "none" preserves the
+  // server's order (name ASC); the detail pane keeps showing a selected entry
+  // even when a filter hides it from the list (selectedEntry reads full entries).
+  const visibleEntries = useMemo(() => {
+    let out = entries.filter((e) => {
+      if (!nameMatches(e.name, filterText)) return false;
+      if (typeFilter === "dynamic" && !e.in_substrate) return false;
+      if (typeFilter === "static" && !e.in_static) return false;
+      if (hideRetired && entryRetired(e)) return false;
+      return true;
+    });
+    if (sortMode === "asc") {
+      out = [...out].sort((a, b) => a.name.localeCompare(b.name));
+    } else if (sortMode === "desc") {
+      out = [...out].sort((a, b) => b.name.localeCompare(a.name));
+    } else if (sortMode === "type") {
+      // Group by source rank (static-only, both, dynamic-only), then name ASC.
+      out = [...out].sort(
+        (a, b) => sourceRank(a) - sourceRank(b) || a.name.localeCompare(b.name),
+      );
+    }
+    return out;
+  }, [entries, filterText, typeFilter, hideRetired, sortMode]);
   const [versions, setVersions] = useState<DefRow[]>([]);
   const [versionsErr, setVersionsErr] = useState<string | null>(null);
   const [versionsLoading, setVersionsLoading] = useState(false);
@@ -210,11 +243,62 @@ export default function LineagePanel({
       minLeftWidth={220}
       minRightWidth={320}
     >
-      <EntryList
-        entries={entries}
-        selectedName={selectedName}
-        onSelect={setSelectedName}
-      />
+      <div className="lineage-left">
+        <div className="lineage-toolbar">
+          <input
+            type="text"
+            className="lineage-filter-text"
+            placeholder="filter (doc/ = doc/*)…"
+            value={filterText}
+            onChange={(e) => setFilterText(e.target.value)}
+            aria-label="Filter by name"
+          />
+          <div className="lineage-toolbar-row">
+            <select
+              className="lineage-toolbar-select"
+              value={typeFilter}
+              onChange={(e) => setTypeFilter(e.target.value as TypeFilter)}
+              aria-label="Filter by type"
+              title="Show all, only dynamic (substrate), or only static entries"
+            >
+              <option value="all">All</option>
+              <option value="dynamic">Dynamic</option>
+              <option value="static">Static</option>
+            </select>
+            <select
+              className="lineage-toolbar-select"
+              value={sortMode}
+              onChange={(e) => setSortMode(e.target.value as SortMode)}
+              aria-label="Sort"
+              title="Sort order"
+            >
+              <option value="none">Sort: None</option>
+              <option value="type">Sort: Type</option>
+              <option value="asc">Sort: A → Z</option>
+              <option value="desc">Sort: Z → A</option>
+            </select>
+            <label className="lineage-toolbar-check" title="Hide retired / inactive entries">
+              <input
+                type="checkbox"
+                checked={hideRetired}
+                onChange={(e) => setHideRetired(e.target.checked)}
+              />
+              Hide retired
+            </label>
+          </div>
+        </div>
+        {visibleEntries.length === 0 ? (
+          <div className="lineage-list-empty">
+            No {kindLabel.toLowerCase()} match the current filter.
+          </div>
+        ) : (
+          <EntryList
+            entries={visibleEntries}
+            selectedName={selectedName}
+            onSelect={setSelectedName}
+          />
+        )}
+      </div>
       <div className="lineage-right">
         <div className="lineage-header">
           <h3>{selectedName}</h3>
@@ -268,6 +352,45 @@ export default function LineagePanel({
       </div>
     </Splitter>
   );
+}
+
+type TypeFilter = "all" | "dynamic" | "static";
+type SortMode = "none" | "type" | "asc" | "desc";
+
+// nameMatches implements the list filter. A trailing "/" or a "*" makes it a
+// PREFIX match (so "doc/" and "doc/*" both mean "names under the doc/ group");
+// any other text is a case-insensitive substring match.
+function nameMatches(name: string, filter: string): boolean {
+  const f = filter.trim().toLowerCase();
+  if (!f) return true;
+  const n = name.toLowerCase();
+  if (f.includes("*")) return n.startsWith(f.slice(0, f.indexOf("*")));
+  if (f.endsWith("/")) return n.startsWith(f);
+  return n.includes(f);
+}
+
+// entryRetired reports whether an entry should be hidden by "Hide retired": its
+// active def points at a retired row, OR it's a dynamic-only name whose every
+// version is retired (no active pointer, zero live versions) — the reclaimable
+// "inactive" state. A static (bundled/yaml) entry is never retired. The
+// live_version_count / active_retired fields are populated for agents, skills,
+// and mcp-servers by the *ListNames summary queries.
+function entryRetired(e: LibraryEntry): boolean {
+  if (e.active_retired) return true;
+  return (
+    e.in_substrate &&
+    !e.in_static &&
+    !e.active_def_id &&
+    (e.live_version_count ?? 0) === 0
+  );
+}
+
+// sourceRank orders entries for the "Type" sort: static-only, then both, then
+// dynamic-only.
+function sourceRank(e: LibraryEntry): number {
+  if (e.in_static && e.in_substrate) return 1; // both
+  if (e.in_static) return 0; // static-only
+  return 2; // dynamic-only
 }
 
 function newCtaLabel(kind: SubstrateKind): string {

--- a/packages/library/src/styles.css
+++ b/packages/library/src/styles.css
@@ -552,12 +552,77 @@
 }
 
 /* ---- LineagePanel: list-left, lineage-right ---- */
+/* The left pane is a flex column: a fixed toolbar (filter / type / sort /
+   hide-retired) over a scrolling entry list. min-height:0 lets the list — not
+   the pane — own the overflow. */
+.loomcycle-library .lineage-left {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
+.loomcycle-library .lineage-toolbar {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-soft);
+}
+.loomcycle-library .lineage-toolbar-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.loomcycle-library .lineage-filter-text {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 5px 8px;
+  font-size: 12px;
+  font-family: var(--mono);
+  background: var(--bg-input);
+  color: inherit;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+.loomcycle-library .lineage-toolbar-select {
+  padding: 4px 6px;
+  font-size: 12px;
+  background: var(--bg-input);
+  color: inherit;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+.loomcycle-library .lineage-toolbar-check {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--fg-soft);
+  cursor: pointer;
+  white-space: nowrap;
+}
+.loomcycle-library .lineage-list-empty {
+  padding: 16px 14px;
+  font-size: 12px;
+  color: var(--fg-soft);
+}
 .loomcycle-library .lineage-name-list {
   list-style: none;
   margin: 0;
   padding: 0;
   overflow-y: auto;
   height: 100%;
+}
+/* Inside the flex left-pane, the list flexes to fill the space below the
+   toolbar and owns the scroll (overriding the standalone height:100%). */
+.loomcycle-library .lineage-left .lineage-name-list {
+  flex: 1 1 auto;
+  min-height: 0;
+  height: auto;
 }
 .loomcycle-library .lineage-name-row {
   border-bottom: 1px solid var(--border);

--- a/packages/library/src/types.ts
+++ b/packages/library/src/types.ts
@@ -54,8 +54,9 @@ export interface LibraryEntry {
   active_def_id?: string;
   latest_version?: number;
   last_updated?: string;
-  /** Agents only (soft reclaim): live (non-retired) version count, and whether
-   *  the active pointer references a retired row. Absent for skills + mcp. */
+  /** Soft-reclaim status: live (non-retired) version count, and whether the
+   *  active pointer references a retired row. Populated for agents, skills, and
+   *  mcp-servers by the *ListNames summary queries; drives "Hide retired". */
   live_version_count?: number;
   active_retired?: boolean;
   /** Static-side definition payload (same JSON shape as the substrate body).

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2706,12 +2706,75 @@ button.primary:disabled {
 }
 
 /* ---- LineagePanel: list-left, lineage-right ---- */
+/* LineagePanel left pane: fixed filter/type/sort/hide-retired toolbar over a
+   scrolling entry list (mirrors packages/library/src/styles.css; the embedded
+   UI uses this sheet, not the package's scoped one). */
+.lineage-left {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
+.lineage-toolbar {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-soft);
+}
+.lineage-toolbar-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.lineage-filter-text {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 5px 8px;
+  font-size: 12px;
+  font-family: var(--mono);
+  background: var(--bg);
+  color: inherit;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+.lineage-toolbar-select {
+  padding: 4px 6px;
+  font-size: 12px;
+  background: var(--bg);
+  color: inherit;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+.lineage-toolbar-check {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--fg-soft);
+  cursor: pointer;
+  white-space: nowrap;
+}
+.lineage-list-empty {
+  padding: 16px 14px;
+  font-size: 12px;
+  color: var(--fg-soft);
+}
 .lineage-name-list {
   list-style: none;
   margin: 0;
   padding: 0;
   overflow-y: auto;
   height: 100%;
+}
+.lineage-left .lineage-name-list {
+  flex: 1 1 auto;
+  min-height: 0;
+  height: auto;
 }
 .lineage-name-row {
   border-bottom: 1px solid var(--border);


### PR DESCRIPTION
## Why

The Web UI Library lists agents / skills / MCP servers with no way to narrow or order them — only static/dynamic chips per row. As the catalog grows (and with `/`-grouped agent names landing in #687), operators need to filter by name group, hide clutter, and sort. This is the second half of the agent-grouping work you asked for.

## What

A per-tab toolbar above the shared entry list in `packages/library/src/components/LineagePanel.tsx` (each sub-tab renders its own `LineagePanel`, so control state is independent per tab):

- **Name filter** — a trailing `/` or a `*` is a **prefix** match (`doc/` and `doc/*` both mean "names under the `doc/` group"); any other text is a case-insensitive substring. Pairs directly with the new grouped agent names.
- **Type dropdown** — All / Dynamic / Static (derived from `in_substrate` / `in_static`).
- **Sort dropdown** — None (server order, name ASC) / Type (by source) / A→Z / Z→A.
- **Hide retired checkbox** — drops entries whose active def is retired, or whose every version is retired (the reclaimable "inactive" state).

**Backend (commit 1):** "Hide retired" needs per-entry retired status, which the list carried for **agents only**. This adds `live_version_count` + `active_retired` to `SkillDefNameSummary` / `MCPServerDefNameSummary`, computed in the `*ListNames` summary queries (both **sqlite + postgres**) exactly as `AgentDefListNames` already does, and copied into `LibraryEntry` by the two handlers. So Hide-retired now works on **all three tabs**.

**Frontend (commit 2):** pure frontend in `packages/library` — the embedded Web UI picks it up via the Vite **source alias**, so **no npm republish** is needed for loomcycle itself (an `@loomcycle/library` bump is only for external consumers). Styles are scoped under `.loomcycle-library` in the package sheet and mirrored as bare classes in `web/src/styles.css` (the embedded UI uses its own sheet). The detail pane still shows a selected entry even when a filter hides it from the list.

## What was tested

- `storetest` contract gains `SkillDefListNamesLiveCount` + `MCPServerDefListNamesLiveCount` (run against **sqlite AND postgres**): retired-excluded live counts + `active_retired` when the active pointer references a retired def.
- A `/v1/_library/skills` handler test asserts the fields cross the wire.
- `go test ./...` + `gofmt`/`go vet` clean.
- Library package `tsc --noEmit` + the web `tsc && vite build` both clean (the build compiles the package through the source alias).

**Note:** additive JSON fields only (previously omitted for skills/mcp); no wire break, no adapter bump. Independent of #687 — can merge in either order. A manual UI pass (toolbar renders, `doc/` filters, Hide-retired on each tab) is recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)