### PR TITLE
feat(teamdef): TeamDef substrate store layer (RFC AP phase 1)

### DIFF
--- a/internal/snapshot/migrations/registry.go
+++ b/internal/snapshot/migrations/registry.go
@@ -35,6 +35,8 @@ const (
 	SectionAgentDefActive     = "agent_def_active"
 	SectionSkillDefs          = "skill_defs"
 	SectionSkillDefActive     = "skill_def_active"
+	SectionTeamDefs           = "team_defs"
+	SectionTeamDefActive      = "team_def_active"
 	SectionMCPServerDefs      = "mcp_server_defs"
 	SectionMCPServerDefActive = "mcp_server_def_active"
 	SectionMemory             = "memory"
@@ -98,6 +100,8 @@ var registry = map[string]map[string]Migrator{
 	SectionAgentDefActive:     {"1.0": identityMigrator},
 	SectionSkillDefs:          {"1.0": identityMigrator},
 	SectionSkillDefActive:     {"1.0": identityMigrator},
+	SectionTeamDefs:           {"1.0": identityMigrator},
+	SectionTeamDefActive:      {"1.0": identityMigrator},
 	SectionMCPServerDefs:      {"1.0": identityMigrator},
 	SectionMCPServerDefActive: {"1.0": identityMigrator},
 	SectionMemory:             {"1.0": identityMigrator},

--- a/internal/snapshot/migrations/registry_test.go
+++ b/internal/snapshot/migrations/registry_test.go
@@ -14,6 +14,7 @@ func TestMigrate_SameVersionIdentity(t *testing.T) {
 	for _, section := range []string{
 		SectionAgentDefs, SectionAgentDefActive,
 		SectionSkillDefs, SectionSkillDefActive,
+		SectionTeamDefs, SectionTeamDefActive,
 		SectionMemory,
 		SectionChannels, SectionEvaluations, SectionPausedRuns,
 		SectionInteractionHistory,

--- a/internal/snapshot/restore.go
+++ b/internal/snapshot/restore.go
@@ -43,6 +43,8 @@ type RestoreResult struct {
 	AgentDefActiveRestored     int      `json:"agent_def_active_restored"`
 	SkillDefsRestored          int      `json:"skill_defs_restored"`
 	SkillDefActiveRestored     int      `json:"skill_def_active_restored"`
+	TeamDefsRestored           int      `json:"team_defs_restored"`
+	TeamDefActiveRestored      int      `json:"team_def_active_restored"`
 	MCPServerDefsRestored      int      `json:"mcp_server_defs_restored"`
 	MCPServerDefActiveRestored int      `json:"mcp_server_def_active_restored"`
 	MemoryRestored             int      `json:"memory_restored"`
@@ -240,6 +242,60 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 			}
 			if inserted {
 				result.SkillDefActiveRestored++
+			}
+		}
+	}
+
+	// team_defs — mirror of skill_defs restore
+	if rawSection, ok := sections[migrations.SectionTeamDefs]; ok {
+		var sec TeamDefsSection
+		if err := decodeWithMigration(migrations.SectionTeamDefs, rawSection, &sec); err != nil {
+			return result, err
+		}
+		for _, e := range sec.Entries {
+			inserted, err := s.SnapshotRestoreTeamDef(ctx, store.TeamDefRow{
+				DefID:                  e.DefID,
+				Name:                   e.Name,
+				Version:                e.Version,
+				ParentDefID:            e.ParentDefID,
+				Definition:             e.Definition,
+				Description:            e.Description,
+				CreatedAt:              e.CreatedAt,
+				CreatedByAgentID:       e.CreatedByAgentID,
+				CreatedByRunID:         e.CreatedByRunID,
+				Retired:                e.Retired,
+				BootstrappedFromStatic: e.BootstrappedFromStatic,
+				ContentSHA256:          e.ContentSHA256,
+			})
+			if err != nil {
+				result.Warnings = append(result.Warnings, fmt.Sprintf("team_def %s: %v", e.DefID, err))
+				continue
+			}
+			if inserted {
+				result.TeamDefsRestored++
+			}
+		}
+	}
+
+	// team_def_active (after team_defs for FK)
+	if rawSection, ok := sections[migrations.SectionTeamDefActive]; ok {
+		var sec TeamDefActiveSection
+		if err := decodeWithMigration(migrations.SectionTeamDefActive, rawSection, &sec); err != nil {
+			return result, err
+		}
+		for _, e := range sec.Entries {
+			inserted, err := s.SnapshotRestoreTeamDefActive(ctx, store.TeamDefActiveEntry{
+				Name:              e.Name,
+				DefID:             e.DefID,
+				PromotedAt:        e.PromotedAt,
+				PromotedByAgentID: e.PromotedByAgentID,
+			})
+			if err != nil {
+				result.Warnings = append(result.Warnings, fmt.Sprintf("team_def_active %s: %v", e.Name, err))
+				continue
+			}
+			if inserted {
+				result.TeamDefActiveRestored++
 			}
 		}
 	}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -123,6 +123,12 @@ func Capture(ctx context.Context, s store.Store, opts CaptureOptions) (*store.Sn
 	if err := captureSkillDefActive(ctx, s, &envelope.Sections.SkillDefActive); err != nil {
 		return nil, nil, err
 	}
+	if err := captureTeamDefs(ctx, s, &envelope.Sections.TeamDefs); err != nil {
+		return nil, nil, err
+	}
+	if err := captureTeamDefActive(ctx, s, &envelope.Sections.TeamDefActive); err != nil {
+		return nil, nil, err
+	}
 	if err := captureMCPServerDefs(ctx, s, &envelope.Sections.MCPServerDefs); err != nil {
 		return nil, nil, err
 	}
@@ -277,6 +283,51 @@ func captureSkillDefActive(ctx context.Context, s store.Store, out *SkillDefActi
 	out.Entries = make([]SkillDefActiveEntry, 0, len(rows))
 	for _, r := range rows {
 		out.Entries = append(out.Entries, SkillDefActiveEntry{
+			Name:              r.Name,
+			DefID:             r.DefID,
+			PromotedAt:        r.PromotedAt,
+			PromotedByAgentID: r.PromotedByAgentID,
+		})
+	}
+	return nil
+}
+
+// captureTeamDefs mirrors captureSkillDefs against teamdefs.
+func captureTeamDefs(ctx context.Context, s store.Store, out *TeamDefsSection) error {
+	out.Version = SectionVersion
+	rows, err := s.SnapshotReadTeamDefs(ctx)
+	if err != nil {
+		return fmt.Errorf("snapshot teamdefs: %w", err)
+	}
+	out.Entries = make([]TeamDefEntry, 0, len(rows))
+	for _, r := range rows {
+		out.Entries = append(out.Entries, TeamDefEntry{
+			DefID:                  r.DefID,
+			Name:                   r.Name,
+			Version:                r.Version,
+			ParentDefID:            r.ParentDefID,
+			Definition:             r.Definition,
+			Description:            r.Description,
+			CreatedAt:              r.CreatedAt,
+			CreatedByAgentID:       r.CreatedByAgentID,
+			CreatedByRunID:         r.CreatedByRunID,
+			Retired:                r.Retired,
+			BootstrappedFromStatic: r.BootstrappedFromStatic,
+			ContentSHA256:          r.ContentSHA256,
+		})
+	}
+	return nil
+}
+
+func captureTeamDefActive(ctx context.Context, s store.Store, out *TeamDefActiveSection) error {
+	out.Version = SectionVersion
+	rows, err := s.SnapshotReadTeamDefActive(ctx)
+	if err != nil {
+		return fmt.Errorf("snapshot teamdef_active: %w", err)
+	}
+	out.Entries = make([]TeamDefActiveEntry, 0, len(rows))
+	for _, r := range rows {
+		out.Entries = append(out.Entries, TeamDefActiveEntry{
 			Name:              r.Name,
 			DefID:             r.DefID,
 			PromotedAt:        r.PromotedAt,

--- a/internal/snapshot/types.go
+++ b/internal/snapshot/types.go
@@ -69,6 +69,8 @@ type Sections struct {
 	AgentDefActive     AgentDefActiveSection      `json:"agent_def_active"`
 	SkillDefs          SkillDefsSection           `json:"skill_defs"`
 	SkillDefActive     SkillDefActiveSection      `json:"skill_def_active"`
+	TeamDefs           TeamDefsSection            `json:"team_defs"`
+	TeamDefActive      TeamDefActiveSection       `json:"team_def_active"`
 	MCPServerDefs      MCPServerDefsSection       `json:"mcp_server_defs"`
 	MCPServerDefActive MCPServerDefActiveSection  `json:"mcp_server_def_active"`
 	Memory             MemorySection              `json:"memory"`
@@ -160,6 +162,44 @@ type SkillDefActiveSection struct {
 }
 
 type SkillDefActiveEntry struct {
+	Name              string    `json:"name"`
+	DefID             string    `json:"def_id"`
+	PromotedAt        time.Time `json:"promoted_at"`
+	PromotedByAgentID string    `json:"promoted_by_agent_id,omitempty"`
+}
+
+// TeamDefsSection mirrors SkillDefsSection.
+type TeamDefsSection struct {
+	Version string         `json:"version"`
+	Entries []TeamDefEntry `json:"entries"`
+}
+
+// TeamDefEntry mirrors SkillDefEntry. Same field set; the
+// definition payload (an opaque workflow graph) is owned by the
+// TeamDef tool.
+type TeamDefEntry struct {
+	DefID                  string          `json:"def_id"`
+	Name                   string          `json:"name"`
+	Version                int             `json:"version"`
+	ParentDefID            string          `json:"parent_def_id,omitempty"`
+	Definition             json.RawMessage `json:"definition"`
+	Description            string          `json:"description,omitempty"`
+	CreatedAt              time.Time       `json:"created_at"`
+	CreatedByAgentID       string          `json:"created_by_agent_id,omitempty"`
+	CreatedByRunID         string          `json:"created_by_run_id,omitempty"`
+	Retired                bool            `json:"retired"`
+	BootstrappedFromStatic bool            `json:"bootstrapped_from_static"`
+	// ContentSHA256 — see AgentDefEntry.ContentSHA256.
+	ContentSHA256 string `json:"content_sha256,omitempty"`
+}
+
+// TeamDefActiveSection mirrors SkillDefActiveSection.
+type TeamDefActiveSection struct {
+	Version string               `json:"version"`
+	Entries []TeamDefActiveEntry `json:"entries"`
+}
+
+type TeamDefActiveEntry struct {
 	Name              string    `json:"name"`
 	DefID             string    `json:"def_id"`
 	PromotedAt        time.Time `json:"promoted_at"`

--- a/internal/store/postgres/migrations/0056_teamdefs.down.sql
+++ b/internal/store/postgres/migrations/0056_teamdefs.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS teamdef_active;
+DROP TABLE IF EXISTS teamdefs;

--- a/internal/store/postgres/migrations/0056_teamdefs.up.sql
+++ b/internal/store/postgres/migrations/0056_teamdefs.up.sql
@@ -1,0 +1,55 @@
+-- 0056_teamdefs.up.sql — TeamDef substrate.
+--
+-- Verbatim clone of the skill_defs substrate (0016 base + 0019
+-- content_sha256 + 0038 tenant_id), collapsed into one migration
+-- since teamdefs is a brand-new table with no upgrade path. The store
+-- stays content-agnostic — the `definition` column carries an opaque
+-- JSON-encoded workflow graph; the tool layer owns that JSON's schema.
+--
+-- Invariants mirrored from skill_defs:
+--   * append-only (only INSERT + UPDATE of `retired`)
+--   * (tenant_id, name, version) is UNIQUE and version is monotonic
+--     per (tenant_id, name)
+--   * parent_def_id chains lineage; empty for v1 / bootstrap rows
+--   * content_sha256 NULL on hashless rows (partial index)
+--   * tenant_id '' = the shared/operator/legacy tenant; two tenants
+--     own the same name independently
+--
+-- Indexes:
+--   teamdefs_by_name           — covers ListByName + GetByNameVersion
+--   teamdefs_by_parent         — partial; covers ListChildren only when
+--                                parent_def_id is set (most rows are v1)
+--   teamdefs_by_run            — partial; covers provenance queries
+--   teamdefs_by_content_sha256 — partial; covers the verify-by-hash path
+CREATE TABLE teamdefs (
+    def_id                    TEXT        PRIMARY KEY,
+    name                      TEXT        NOT NULL,
+    version                   INTEGER     NOT NULL,
+    parent_def_id             TEXT        REFERENCES teamdefs(def_id),
+    definition                JSONB       NOT NULL,
+    description               TEXT,
+    created_at                TIMESTAMPTZ NOT NULL,
+    created_by_agent_id       TEXT,
+    created_by_run_id         TEXT,
+    retired                   BOOLEAN     NOT NULL DEFAULT FALSE,
+    bootstrapped_from_static  BOOLEAN     NOT NULL DEFAULT FALSE,
+    content_sha256            TEXT,
+    tenant_id                 TEXT        NOT NULL DEFAULT '',
+    CONSTRAINT teamdefs_tenant_name_version_key UNIQUE (tenant_id, name, version)
+);
+
+CREATE INDEX teamdefs_by_name           ON teamdefs(name, version DESC);
+CREATE INDEX teamdefs_by_parent         ON teamdefs(parent_def_id) WHERE parent_def_id IS NOT NULL;
+CREATE INDEX teamdefs_by_run            ON teamdefs(created_by_run_id) WHERE created_by_run_id IS NOT NULL;
+CREATE INDEX teamdefs_by_content_sha256 ON teamdefs(content_sha256) WHERE content_sha256 IS NOT NULL;
+
+-- The active pointer: at most one promoted version per (tenant_id, name).
+-- Mirrors skill_def_active 1:1.
+CREATE TABLE teamdef_active (
+    tenant_id             TEXT        NOT NULL DEFAULT '',
+    name                  TEXT        NOT NULL,
+    def_id                TEXT        NOT NULL REFERENCES teamdefs(def_id),
+    promoted_at           TIMESTAMPTZ NOT NULL,
+    promoted_by_agent_id  TEXT,
+    PRIMARY KEY (tenant_id, name)
+);

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -1626,6 +1626,83 @@ func (s *Store) SnapshotReadSkillDefActive(ctx context.Context) ([]store.SkillDe
 	return out, rows.Err()
 }
 
+// SnapshotReadTeamDefs implements store.Store. Mirror of
+// SnapshotReadSkillDefs against teamdefs.
+func (s *Store) SnapshotReadTeamDefs(ctx context.Context) ([]store.TeamDefRow, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT def_id, name, version, parent_def_id, definition::text, description,
+		        created_at, created_by_agent_id, created_by_run_id,
+		        retired, bootstrapped_from_static, tenant_id
+		 FROM teamdefs
+		 ORDER BY tenant_id ASC, name ASC, version ASC`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot read teamdefs: %w", err)
+	}
+	defer rows.Close()
+	var out []store.TeamDefRow
+	for rows.Next() {
+		var (
+			r           store.TeamDefRow
+			parentDefID *string
+			description *string
+			createdBy   *string
+			createdRun  *string
+			definition  string
+		)
+		if err := rows.Scan(
+			&r.DefID, &r.Name, &r.Version, &parentDefID,
+			&definition, &description,
+			&r.CreatedAt, &createdBy, &createdRun,
+			&r.Retired, &r.BootstrappedFromStatic, &r.TenantID,
+		); err != nil {
+			return nil, fmt.Errorf("scan team_def: %w", err)
+		}
+		r.Definition = json.RawMessage(definition)
+		if parentDefID != nil {
+			r.ParentDefID = *parentDefID
+		}
+		if description != nil {
+			r.Description = *description
+		}
+		if createdBy != nil {
+			r.CreatedByAgentID = *createdBy
+		}
+		if createdRun != nil {
+			r.CreatedByRunID = *createdRun
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// SnapshotReadTeamDefActive implements store.Store.
+func (s *Store) SnapshotReadTeamDefActive(ctx context.Context) ([]store.TeamDefActiveEntry, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT name, def_id, promoted_at, promoted_by_agent_id, tenant_id
+		 FROM teamdef_active
+		 ORDER BY tenant_id ASC, name ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot read teamdef_active: %w", err)
+	}
+	defer rows.Close()
+	var out []store.TeamDefActiveEntry
+	for rows.Next() {
+		var (
+			e        store.TeamDefActiveEntry
+			promoter *string
+		)
+		if err := rows.Scan(&e.Name, &e.DefID, &e.PromotedAt, &promoter, &e.TenantID); err != nil {
+			return nil, fmt.Errorf("scan teamdef_active: %w", err)
+		}
+		if promoter != nil {
+			e.PromotedByAgentID = *promoter
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
 // SnapshotReadMCPServerDefs — v0.9.x mirror.
 func (s *Store) SnapshotReadMCPServerDefs(ctx context.Context) ([]store.MCPServerDefRow, error) {
 	rows, err := s.pool.Query(ctx,
@@ -2072,6 +2149,55 @@ func (s *Store) SnapshotRestoreSkillDefActive(ctx context.Context, e store.Skill
 	)
 	if err != nil {
 		return false, fmt.Errorf("snapshot restore skill_def_active: %w", err)
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
+// SnapshotRestoreTeamDef implements store.Store. Mirror of
+// SnapshotRestoreSkillDef against teamdefs.
+func (s *Store) SnapshotRestoreTeamDef(ctx context.Context, r store.TeamDefRow) (bool, error) {
+	if r.DefID == "" || r.Name == "" {
+		return false, fmt.Errorf("snapshot restore team_def: def_id and name required")
+	}
+	createdAt := r.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+	tag, err := s.pool.Exec(ctx,
+		`INSERT INTO teamdefs(
+			def_id, name, version, parent_def_id, definition, description,
+			created_at, created_by_agent_id, created_by_run_id,
+			retired, bootstrapped_from_static, content_sha256, tenant_id
+		) VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10, $11, $12, $13)
+		 ON CONFLICT (def_id) DO NOTHING`,
+		r.DefID, r.Name, r.Version, nullIfEmpty(r.ParentDefID),
+		string(r.Definition), nullIfEmpty(r.Description),
+		createdAt, nullIfEmpty(r.CreatedByAgentID), nullIfEmpty(r.CreatedByRunID),
+		r.Retired, r.BootstrappedFromStatic,
+		nullIfEmpty(r.ContentSHA256), r.TenantID,
+	)
+	if err != nil {
+		return false, fmt.Errorf("snapshot restore team_def: %w", err)
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
+// SnapshotRestoreTeamDefActive implements store.Store.
+func (s *Store) SnapshotRestoreTeamDefActive(ctx context.Context, e store.TeamDefActiveEntry) (bool, error) {
+	if e.Name == "" || e.DefID == "" {
+		return false, fmt.Errorf("snapshot restore teamdef_active: name and def_id required")
+	}
+	promotedAt := e.PromotedAt
+	if promotedAt.IsZero() {
+		promotedAt = time.Now().UTC()
+	}
+	tag, err := s.pool.Exec(ctx,
+		`INSERT INTO teamdef_active(tenant_id, name, def_id, promoted_at, promoted_by_agent_id) VALUES ($1, $2, $3, $4, $5)
+		 ON CONFLICT (tenant_id, name) DO NOTHING`,
+		e.TenantID, e.Name, e.DefID, promotedAt, nullIfEmpty(e.PromotedByAgentID),
+	)
+	if err != nil {
+		return false, fmt.Errorf("snapshot restore teamdef_active: %w", err)
 	}
 	return tag.RowsAffected() > 0, nil
 }
@@ -4248,6 +4374,269 @@ func (s *Store) scanSkillDefRows(rows pgx.Rows) ([]store.SkillDefRow, error) {
 	for rows.Next() {
 		var (
 			r          store.SkillDefRow
+			definition string
+		)
+		if err := rows.Scan(
+			&r.DefID, &r.Name, &r.Version,
+			&r.ParentDefID,
+			&definition,
+			&r.Description,
+			&r.CreatedAt,
+			&r.CreatedByAgentID, &r.CreatedByRunID,
+			&r.Retired, &r.BootstrappedFromStatic,
+			&r.ContentSHA256,
+			&r.TenantID,
+		); err != nil {
+			return nil, err
+		}
+		r.Definition = json.RawMessage(definition)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// ---- TeamDef substrate ----
+//
+// Direct mirror of the SkillDef methods above. Uses the same
+// pg_advisory_xact_lock pattern for per-name version monotonicity
+// (lock key derived from "team_def:"+name so it never collides
+// with the agent_def / skill_def lock namespaces).
+
+func (s *Store) TeamDefCreate(ctx context.Context, row store.TeamDefRow) (store.TeamDefRow, error) {
+	if row.DefID == "" || row.Name == "" {
+		return store.TeamDefRow{}, fmt.Errorf("team_def: def_id + name required")
+	}
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return store.TeamDefRow{}, fmt.Errorf("team_def create begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Per-(tenant, name) advisory lock — RFC N: version allocation is
+	// scoped per-tenant so two tenants' v1 don't collide on the
+	// UNIQUE(tenant_id, name, version). See AgentDefCreate for the
+	// rationale.
+	if _, err := tx.Exec(ctx,
+		`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`,
+		"team_def:"+row.TenantID+":"+row.Name,
+	); err != nil {
+		return store.TeamDefRow{}, fmt.Errorf("team_def create lock: %w", err)
+	}
+
+	if row.ParentDefID != "" {
+		var n int
+		if err := tx.QueryRow(ctx, `SELECT COUNT(*) FROM teamdefs WHERE def_id = $1`, row.ParentDefID).Scan(&n); err != nil {
+			return store.TeamDefRow{}, fmt.Errorf("team_def create parent check: %w", err)
+		}
+		if n == 0 {
+			return store.TeamDefRow{}, store.ErrTeamDefParentNotFound
+		}
+	}
+
+	var maxVer sql.NullInt64
+	if err := tx.QueryRow(ctx, `SELECT MAX(version) FROM teamdefs WHERE tenant_id = $1 AND name = $2`, row.TenantID, row.Name).Scan(&maxVer); err != nil {
+		return store.TeamDefRow{}, fmt.Errorf("team_def create max version: %w", err)
+	}
+	row.Version = 1
+	if maxVer.Valid {
+		row.Version = int(maxVer.Int64) + 1
+	}
+	row.CreatedAt = time.Now().UTC()
+
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO teamdefs (
+			def_id, name, version, parent_def_id, definition, description,
+			created_at, created_by_agent_id, created_by_run_id,
+			retired, bootstrapped_from_static, content_sha256, tenant_id
+		) VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10, $11, $12, $13)`,
+		row.DefID, row.Name, row.Version, nullableString(row.ParentDefID),
+		string(row.Definition), nullableString(row.Description),
+		row.CreatedAt,
+		nullableString(row.CreatedByAgentID), nullableString(row.CreatedByRunID),
+		row.Retired, row.BootstrappedFromStatic,
+		nullableString(row.ContentSHA256), row.TenantID,
+	); err != nil {
+		return store.TeamDefRow{}, fmt.Errorf("team_def insert: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return store.TeamDefRow{}, fmt.Errorf("team_def commit: %w", err)
+	}
+	return row, nil
+}
+
+func (s *Store) TeamDefGet(ctx context.Context, defID string) (store.TeamDefRow, error) {
+	row, err := s.scanTeamDef(s.pool.QueryRow(ctx, teamDefSelect+` WHERE def_id = $1`, defID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return store.TeamDefRow{}, &store.ErrNotFound{Kind: "team_def", ID: defID}
+	}
+	return row, err
+}
+
+func (s *Store) TeamDefGetByNameVersion(ctx context.Context, name string, version int) (store.TeamDefRow, error) {
+	row, err := s.scanTeamDef(s.pool.QueryRow(ctx, teamDefSelect+` WHERE name = $1 AND version = $2`, name, version))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return store.TeamDefRow{}, &store.ErrNotFound{Kind: "team_def", ID: fmt.Sprintf("%s@v%d", name, version)}
+	}
+	return row, err
+}
+
+func (s *Store) TeamDefListByName(ctx context.Context, name string) ([]store.TeamDefRow, error) {
+	rows, err := s.pool.Query(ctx, teamDefSelect+` WHERE name = $1 ORDER BY version DESC`, name)
+	if err != nil {
+		return nil, fmt.Errorf("team_def list by name: %w", err)
+	}
+	defer rows.Close()
+	return s.scanTeamDefRows(rows)
+}
+
+func (s *Store) TeamDefListChildren(ctx context.Context, parentDefID string) ([]store.TeamDefRow, error) {
+	rows, err := s.pool.Query(ctx, teamDefSelect+` WHERE parent_def_id = $1 ORDER BY version DESC`, parentDefID)
+	if err != nil {
+		return nil, fmt.Errorf("team_def list children: %w", err)
+	}
+	defer rows.Close()
+	return s.scanTeamDefRows(rows)
+}
+
+func (s *Store) TeamDefListNames(ctx context.Context) ([]store.TeamDefNameSummary, error) {
+	// RFC N: names are per-tenant; group by tenant_id so a name owned by
+	// N tenants yields N rows (one per tenant) rather than merging them.
+	rows, err := s.pool.Query(ctx, `
+		SELECT
+			d.tenant_id,
+			d.name,
+			COUNT(*)                                  AS version_count,
+			COUNT(*) FILTER (WHERE d.retired = FALSE) AS live_version_count,
+			MAX(d.version)                            AS latest_version,
+			MAX(d.created_at)                         AS last_updated,
+			COALESCE(a.def_id, '')                    AS active_def_id,
+			COALESCE(ad.retired, FALSE)               AS active_retired
+		FROM teamdefs d
+		LEFT JOIN teamdef_active a ON a.name = d.name AND a.tenant_id = d.tenant_id
+		LEFT JOIN teamdefs ad      ON ad.def_id = a.def_id
+		GROUP BY d.tenant_id, d.name, a.def_id, ad.retired
+		ORDER BY d.tenant_id, d.name`)
+	if err != nil {
+		return nil, fmt.Errorf("team_def list names: %w", err)
+	}
+	defer rows.Close()
+
+	var out []store.TeamDefNameSummary
+	for rows.Next() {
+		var ns store.TeamDefNameSummary
+		if err := rows.Scan(&ns.TenantID, &ns.Name, &ns.VersionCount, &ns.LiveVersionCount, &ns.LatestVersion, &ns.LastUpdated, &ns.ActiveDefID, &ns.ActiveRetired); err != nil {
+			return nil, err
+		}
+		out = append(out, ns)
+	}
+	return out, rows.Err()
+}
+
+// TeamDefSetActive UPSERTs the teamdef_active pointer for
+// (tenantID, name). RFC N: validates the def belongs to BOTH the named
+// team AND the supplied tenant — a def can only be promoted within its
+// own tenant, so a caller can't point another tenant's active pointer at
+// a def it owns.
+func (s *Store) TeamDefSetActive(ctx context.Context, tenantID, name, defID, promotedByAgentID string) error {
+	var (
+		rowName   string
+		rowTenant string
+	)
+	err := s.pool.QueryRow(ctx, `SELECT name, tenant_id FROM teamdefs WHERE def_id = $1`, defID).Scan(&rowName, &rowTenant)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return &store.ErrNotFound{Kind: "team_def", ID: defID}
+	}
+	if err != nil {
+		return fmt.Errorf("teamdef_active check: %w", err)
+	}
+	if rowName != name {
+		return fmt.Errorf("teamdef_active: def_id %q has name %q, refusing to promote under name %q", defID, rowName, name)
+	}
+	if rowTenant != tenantID {
+		return fmt.Errorf("teamdef_active: def_id %q belongs to tenant %q, refusing to promote under tenant %q", defID, rowTenant, tenantID)
+	}
+	_, err = s.pool.Exec(ctx, `
+		INSERT INTO teamdef_active (tenant_id, name, def_id, promoted_at, promoted_by_agent_id)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (tenant_id, name) DO UPDATE SET
+		    def_id               = EXCLUDED.def_id,
+		    promoted_at          = EXCLUDED.promoted_at,
+		    promoted_by_agent_id = EXCLUDED.promoted_by_agent_id`,
+		tenantID, name, defID, time.Now().UTC(), nullableString(promotedByAgentID),
+	)
+	if err != nil {
+		return fmt.Errorf("teamdef_active upsert: %w", err)
+	}
+	return nil
+}
+
+// TeamDefGetActive returns the active row for (tenantID, name).
+// *ErrNotFound when no pointer exists.
+func (s *Store) TeamDefGetActive(ctx context.Context, tenantID, name string) (store.TeamDefRow, error) {
+	var defID string
+	err := s.pool.QueryRow(ctx, `SELECT def_id FROM teamdef_active WHERE tenant_id = $1 AND name = $2`, tenantID, name).Scan(&defID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return store.TeamDefRow{}, &store.ErrNotFound{Kind: "teamdef_active", ID: name}
+	}
+	if err != nil {
+		return store.TeamDefRow{}, fmt.Errorf("teamdef_active lookup: %w", err)
+	}
+	return s.TeamDefGet(ctx, defID)
+}
+
+func (s *Store) TeamDefSetRetired(ctx context.Context, defID string, retired bool) error {
+	tag, err := s.pool.Exec(ctx, `UPDATE teamdefs SET retired = $1 WHERE def_id = $2`, retired, defID)
+	if err != nil {
+		return fmt.Errorf("team_def set retired: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return &store.ErrNotFound{Kind: "team_def", ID: defID}
+	}
+	return nil
+}
+
+const teamDefSelect = `SELECT
+	def_id, name, version,
+	COALESCE(parent_def_id, ''),
+	definition::text,
+	COALESCE(description, ''),
+	created_at,
+	COALESCE(created_by_agent_id, ''),
+	COALESCE(created_by_run_id, ''),
+	retired,
+	bootstrapped_from_static,
+	COALESCE(content_sha256, ''),
+	tenant_id
+FROM teamdefs`
+
+func (s *Store) scanTeamDef(row pgx.Row) (store.TeamDefRow, error) {
+	var (
+		out        store.TeamDefRow
+		definition string
+	)
+	err := row.Scan(
+		&out.DefID, &out.Name, &out.Version,
+		&out.ParentDefID,
+		&definition,
+		&out.Description,
+		&out.CreatedAt,
+		&out.CreatedByAgentID, &out.CreatedByRunID,
+		&out.Retired, &out.BootstrappedFromStatic,
+		&out.ContentSHA256,
+		&out.TenantID,
+	)
+	if err != nil {
+		return store.TeamDefRow{}, err
+	}
+	out.Definition = json.RawMessage(definition)
+	return out, nil
+}
+
+func (s *Store) scanTeamDefRows(rows pgx.Rows) ([]store.TeamDefRow, error) {
+	var out []store.TeamDefRow
+	for rows.Next() {
+		var (
+			r          store.TeamDefRow
 			definition string
 		)
 		if err := rows.Scan(

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -362,6 +362,43 @@ func (s *Store) migrate(ctx context.Context) error {
 			tenant_id             TEXT    NOT NULL DEFAULT '',
 			PRIMARY KEY(tenant_id, name)
 		)`,
+		// TeamDef substrate — mirror of skill_defs with the same
+		// identity / lineage / promotion semantics. The `definition`
+		// column carries an opaque JSON workflow-graph blob (the store
+		// stays content-agnostic).
+		`CREATE TABLE IF NOT EXISTS teamdefs (
+			def_id                    TEXT    PRIMARY KEY,
+			name                      TEXT    NOT NULL,
+			version                   INTEGER NOT NULL,
+			parent_def_id             TEXT    REFERENCES teamdefs(def_id),
+			definition                TEXT    NOT NULL,
+			description               TEXT,
+			created_at                INTEGER NOT NULL,
+			created_by_agent_id       TEXT,
+			created_by_run_id         TEXT,
+			retired                   INTEGER NOT NULL DEFAULT 0,
+			bootstrapped_from_static  INTEGER NOT NULL DEFAULT 0,
+			content_sha256            TEXT,
+			tenant_id                 TEXT    NOT NULL DEFAULT '',
+			UNIQUE(tenant_id, name, version)
+		)`,
+		`CREATE INDEX IF NOT EXISTS teamdefs_by_name   ON teamdefs(name, version DESC)`,
+		`CREATE INDEX IF NOT EXISTS teamdefs_by_parent ON teamdefs(parent_def_id) WHERE parent_def_id IS NOT NULL`,
+		`CREATE INDEX IF NOT EXISTS teamdefs_by_run    ON teamdefs(created_by_run_id) WHERE created_by_run_id IS NOT NULL`,
+		// teamdefs_by_content_sha256 — see agent_defs_by_content_sha256 note above.
+		// RFC N: tenant-scoped active pointer. PRIMARY KEY(tenant_id, name)
+		// — two tenants own the same name independently. On a FRESH DB this
+		// CREATE applies the composite PK. See the skill_def_active note for
+		// the full SQLite upgrade caveat (teamdefs is a fresh table, so no
+		// upgrade path applies, but the pattern is identical).
+		`CREATE TABLE IF NOT EXISTS teamdef_active (
+			name                  TEXT    NOT NULL,
+			def_id                TEXT    NOT NULL REFERENCES teamdefs(def_id),
+			promoted_at           INTEGER NOT NULL,
+			promoted_by_agent_id  TEXT,
+			tenant_id             TEXT    NOT NULL DEFAULT '',
+			PRIMARY KEY(tenant_id, name)
+		)`,
 		// v0.9.x MCPServerDef substrate — third member of the
 		// AgentDef / SkillDef / MCPServerDef family. Mirror of the
 		// agent_defs / skill_defs schema; the definition JSONB carries
@@ -977,6 +1014,7 @@ func (s *Store) migrate(ctx context.Context) error {
 		// v0.9.x upgrade path where the table exists without the column.
 		`CREATE INDEX IF NOT EXISTS agent_defs_by_content_sha256      ON agent_defs(content_sha256)      WHERE content_sha256 IS NOT NULL`,
 		`CREATE INDEX IF NOT EXISTS skill_defs_by_content_sha256      ON skill_defs(content_sha256)      WHERE content_sha256 IS NOT NULL`,
+		`CREATE INDEX IF NOT EXISTS teamdefs_by_content_sha256        ON teamdefs(content_sha256)        WHERE content_sha256 IS NOT NULL`,
 		`CREATE INDEX IF NOT EXISTS mcp_server_defs_by_content_sha256 ON mcp_server_defs(content_sha256) WHERE content_sha256 IS NOT NULL`,
 		// v0.8.6 channel_messages_by_visible — runs in addIndexes
 		// (NOT the earlier `stmts` loop) so the visible_at column
@@ -1048,6 +1086,12 @@ func (s *Store) migrate(ctx context.Context) error {
 		// fails even single-tenant. No dynamic_skills table to cover.
 		`CREATE UNIQUE INDEX IF NOT EXISTS uniq_skill_def_active_tenant_name    ON skill_def_active(tenant_id, name)`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS uniq_skill_defs_tenant_name_version  ON skill_defs(tenant_id, name, version)`,
+		// Team plane — same ON CONFLICT(tenant_id, name) / UNIQUE(tenant_id,
+		// name, version) targets as the skill plane. teamdefs is a fresh
+		// table so these are redundant with its CREATE TABLE composite
+		// constraints, but kept for parity with the skill plane's pattern.
+		`CREATE UNIQUE INDEX IF NOT EXISTS uniq_teamdef_active_tenant_name     ON teamdef_active(tenant_id, name)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS uniq_teamdefs_tenant_name_version   ON teamdefs(tenant_id, name, version)`,
 		// MCP plane (RFC N FIX 5-mcp) — same in-place-upgrade gap.
 		// MCPServerDefSetActive does ON CONFLICT(tenant_id, name) on
 		// mcp_server_def_active and MCPServerDefCreate's version-bump inserts
@@ -2558,6 +2602,91 @@ func (s *Store) SnapshotReadSkillDefActive(ctx context.Context) ([]store.SkillDe
 	return out, rows.Err()
 }
 
+// SnapshotReadTeamDefs implements store.Store. Mirror of
+// SnapshotReadSkillDefs against the teamdefs table.
+func (s *Store) SnapshotReadTeamDefs(ctx context.Context) ([]store.TeamDefRow, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT def_id, name, version, parent_def_id, definition, description,
+		        created_at, created_by_agent_id, created_by_run_id,
+		        retired, bootstrapped_from_static, tenant_id
+		 FROM teamdefs
+		 ORDER BY tenant_id ASC, name ASC, version ASC`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot read teamdefs: %w", err)
+	}
+	defer rows.Close()
+	var out []store.TeamDefRow
+	for rows.Next() {
+		var (
+			r           store.TeamDefRow
+			createdNs   int64
+			parentDefID sql.NullString
+			description sql.NullString
+			createdBy   sql.NullString
+			createdRun  sql.NullString
+			definition  string
+			retiredInt  int
+			bootstrap   int
+		)
+		if err := rows.Scan(
+			&r.DefID, &r.Name, &r.Version, &parentDefID,
+			&definition, &description,
+			&createdNs, &createdBy, &createdRun,
+			&retiredInt, &bootstrap, &r.TenantID,
+		); err != nil {
+			return nil, fmt.Errorf("scan team_def: %w", err)
+		}
+		r.Definition = json.RawMessage(definition)
+		r.CreatedAt = time.Unix(0, createdNs)
+		if parentDefID.Valid {
+			r.ParentDefID = parentDefID.String
+		}
+		if description.Valid {
+			r.Description = description.String
+		}
+		if createdBy.Valid {
+			r.CreatedByAgentID = createdBy.String
+		}
+		if createdRun.Valid {
+			r.CreatedByRunID = createdRun.String
+		}
+		r.Retired = retiredInt != 0
+		r.BootstrappedFromStatic = bootstrap != 0
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// SnapshotReadTeamDefActive implements store.Store.
+func (s *Store) SnapshotReadTeamDefActive(ctx context.Context) ([]store.TeamDefActiveEntry, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT name, def_id, promoted_at, promoted_by_agent_id, tenant_id
+		 FROM teamdef_active
+		 ORDER BY tenant_id ASC, name ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot read teamdef_active: %w", err)
+	}
+	defer rows.Close()
+	var out []store.TeamDefActiveEntry
+	for rows.Next() {
+		var (
+			e          store.TeamDefActiveEntry
+			promotedNs int64
+			promoter   sql.NullString
+		)
+		if err := rows.Scan(&e.Name, &e.DefID, &promotedNs, &promoter, &e.TenantID); err != nil {
+			return nil, fmt.Errorf("scan teamdef_active: %w", err)
+		}
+		e.PromotedAt = time.Unix(0, promotedNs)
+		if promoter.Valid {
+			e.PromotedByAgentID = promoter.String
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
 // SnapshotReadMCPServerDefs — v0.9.x mirror.
 func (s *Store) SnapshotReadMCPServerDefs(ctx context.Context) ([]store.MCPServerDefRow, error) {
 	rows, err := s.db.QueryContext(ctx,
@@ -3039,6 +3168,56 @@ func (s *Store) SnapshotRestoreSkillDefActive(ctx context.Context, e store.Skill
 	)
 	if err != nil {
 		return false, fmt.Errorf("snapshot restore skill_def_active: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n > 0, nil
+}
+
+// SnapshotRestoreTeamDef implements store.Store. Mirror of
+// SnapshotRestoreSkillDef against teamdefs.
+func (s *Store) SnapshotRestoreTeamDef(ctx context.Context, r store.TeamDefRow) (bool, error) {
+	if r.DefID == "" || r.Name == "" {
+		return false, fmt.Errorf("snapshot restore team_def: def_id and name required")
+	}
+	createdNs := r.CreatedAt.UnixNano()
+	if r.CreatedAt.IsZero() {
+		createdNs = time.Now().UnixNano()
+	}
+	res, err := s.db.ExecContext(ctx,
+		`INSERT OR IGNORE INTO teamdefs(
+			def_id, name, version, parent_def_id, definition, description,
+			created_at, created_by_agent_id, created_by_run_id,
+			retired, bootstrapped_from_static, content_sha256, tenant_id
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		r.DefID, r.Name, r.Version, nilIfEmpty(r.ParentDefID),
+		string(r.Definition), nilIfEmpty(r.Description),
+		createdNs, nilIfEmpty(r.CreatedByAgentID), nilIfEmpty(r.CreatedByRunID),
+		boolToInt(r.Retired), boolToInt(r.BootstrappedFromStatic),
+		nilIfEmpty(r.ContentSHA256), r.TenantID,
+	)
+	if err != nil {
+		return false, fmt.Errorf("snapshot restore team_def: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n > 0, nil
+}
+
+// SnapshotRestoreTeamDefActive implements store.Store. Mirror of
+// SnapshotRestoreSkillDefActive against teamdef_active.
+func (s *Store) SnapshotRestoreTeamDefActive(ctx context.Context, e store.TeamDefActiveEntry) (bool, error) {
+	if e.Name == "" || e.DefID == "" {
+		return false, fmt.Errorf("snapshot restore teamdef_active: name and def_id required")
+	}
+	promotedNs := e.PromotedAt.UnixNano()
+	if e.PromotedAt.IsZero() {
+		promotedNs = time.Now().UnixNano()
+	}
+	res, err := s.db.ExecContext(ctx,
+		`INSERT OR IGNORE INTO teamdef_active(tenant_id, name, def_id, promoted_at, promoted_by_agent_id) VALUES (?, ?, ?, ?, ?)`,
+		e.TenantID, e.Name, e.DefID, promotedNs, nilIfEmpty(e.PromotedByAgentID),
+	)
+	if err != nil {
+		return false, fmt.Errorf("snapshot restore teamdef_active: %w", err)
 	}
 	n, _ := res.RowsAffected()
 	return n > 0, nil
@@ -4669,6 +4848,287 @@ func (s *Store) scanSkillDefRows(rows *sql.Rows) ([]store.SkillDefRow, error) {
 	for rows.Next() {
 		var (
 			r          store.SkillDefRow
+			definition string
+			createdAt  int64
+			retired    int
+			bootstrap  int
+		)
+		if err := rows.Scan(
+			&r.DefID, &r.Name, &r.Version,
+			&r.ParentDefID,
+			&definition,
+			&r.Description,
+			&createdAt,
+			&r.CreatedByAgentID, &r.CreatedByRunID,
+			&retired, &bootstrap,
+			&r.ContentSHA256,
+			&r.TenantID,
+		); err != nil {
+			return nil, err
+		}
+		r.Definition = json.RawMessage(definition)
+		r.CreatedAt = time.Unix(0, createdAt)
+		r.Retired = retired != 0
+		r.BootstrappedFromStatic = bootstrap != 0
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// ---- TeamDef substrate ----
+//
+// Direct mirror of the SkillDef methods above. Same per-name lock
+// for version monotonicity, same scan/select helpers, same error
+// surfaces. The only divergence is the table name and the typed
+// error (ErrTeamDefParentNotFound instead of ErrSkillDefParentNotFound).
+// If you fix a bug in one of these methods, fix it in the SkillDef
+// twin as well.
+
+func (s *Store) TeamDefCreate(ctx context.Context, row store.TeamDefRow) (store.TeamDefRow, error) {
+	if row.DefID == "" || row.Name == "" {
+		return store.TeamDefRow{}, fmt.Errorf("team_def: def_id + name required")
+	}
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return store.TeamDefRow{}, err
+	}
+	defer conn.Close()
+
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return store.TeamDefRow{}, err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.Background(), "ROLLBACK")
+		}
+	}()
+
+	if row.ParentDefID != "" {
+		var n int
+		if err := conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM teamdefs WHERE def_id = ?`, row.ParentDefID).Scan(&n); err != nil {
+			return store.TeamDefRow{}, err
+		}
+		if n == 0 {
+			return store.TeamDefRow{}, store.ErrTeamDefParentNotFound
+		}
+	}
+
+	var maxVer sql.NullInt64
+	if err := conn.QueryRowContext(ctx,
+		`SELECT MAX(version) FROM teamdefs WHERE tenant_id = ? AND name = ?`, row.TenantID, row.Name,
+	).Scan(&maxVer); err != nil {
+		return store.TeamDefRow{}, err
+	}
+	row.Version = 1
+	if maxVer.Valid {
+		row.Version = int(maxVer.Int64) + 1
+	}
+	row.CreatedAt = time.Now()
+
+	if _, err := conn.ExecContext(ctx,
+		`INSERT INTO teamdefs (
+			def_id, name, version, parent_def_id, definition, description,
+			created_at, created_by_agent_id, created_by_run_id,
+			retired, bootstrapped_from_static, content_sha256, tenant_id
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		row.DefID, row.Name, row.Version, nilIfEmpty(row.ParentDefID),
+		string(row.Definition), nilIfEmpty(row.Description),
+		row.CreatedAt.UnixNano(),
+		nilIfEmpty(row.CreatedByAgentID), nilIfEmpty(row.CreatedByRunID),
+		boolToInt(row.Retired), boolToInt(row.BootstrappedFromStatic),
+		nilIfEmpty(row.ContentSHA256), row.TenantID,
+	); err != nil {
+		return store.TeamDefRow{}, err
+	}
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return store.TeamDefRow{}, err
+	}
+	committed = true
+	return row, nil
+}
+
+func (s *Store) TeamDefGet(ctx context.Context, defID string) (store.TeamDefRow, error) {
+	row, err := s.scanTeamDef(s.db.QueryRowContext(ctx, teamDefSelect+` WHERE def_id = ?`, defID))
+	if err == sql.ErrNoRows {
+		return store.TeamDefRow{}, &store.ErrNotFound{Kind: "team_def", ID: defID}
+	}
+	return row, err
+}
+
+func (s *Store) TeamDefGetByNameVersion(ctx context.Context, name string, version int) (store.TeamDefRow, error) {
+	row, err := s.scanTeamDef(s.db.QueryRowContext(ctx, teamDefSelect+` WHERE name = ? AND version = ?`, name, version))
+	if err == sql.ErrNoRows {
+		return store.TeamDefRow{}, &store.ErrNotFound{Kind: "team_def", ID: fmt.Sprintf("%s@v%d", name, version)}
+	}
+	return row, err
+}
+
+func (s *Store) TeamDefListByName(ctx context.Context, name string) ([]store.TeamDefRow, error) {
+	rows, err := s.db.QueryContext(ctx, teamDefSelect+` WHERE name = ? ORDER BY version DESC`, name)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return s.scanTeamDefRows(rows)
+}
+
+func (s *Store) TeamDefListChildren(ctx context.Context, parentDefID string) ([]store.TeamDefRow, error) {
+	rows, err := s.db.QueryContext(ctx, teamDefSelect+` WHERE parent_def_id = ? ORDER BY version DESC`, parentDefID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return s.scanTeamDefRows(rows)
+}
+
+func (s *Store) TeamDefListNames(ctx context.Context) ([]store.TeamDefNameSummary, error) {
+	// RFC N: names are per-tenant; group by tenant_id so a name owned by
+	// N tenants yields N rows (one per tenant) rather than merging them.
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT
+			d.tenant_id,
+			d.name,
+			COUNT(*)                              AS version_count,
+			COUNT(*) FILTER (WHERE d.retired = 0) AS live_version_count,
+			MAX(d.version)                        AS latest_version,
+			MAX(d.created_at)                     AS last_updated,
+			COALESCE(a.def_id, '')                AS active_def_id,
+			COALESCE(ad.retired, 0)               AS active_retired
+		FROM teamdefs d
+		LEFT JOIN teamdef_active a ON a.name = d.name AND a.tenant_id = d.tenant_id
+		LEFT JOIN teamdefs ad      ON ad.def_id = a.def_id
+		GROUP BY d.tenant_id, d.name, a.def_id, ad.retired
+		ORDER BY d.tenant_id, d.name`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []store.TeamDefNameSummary
+	for rows.Next() {
+		var ns store.TeamDefNameSummary
+		var updatedAt int64
+		var activeRetired int
+		if err := rows.Scan(&ns.TenantID, &ns.Name, &ns.VersionCount, &ns.LiveVersionCount, &ns.LatestVersion, &updatedAt, &ns.ActiveDefID, &activeRetired); err != nil {
+			return nil, err
+		}
+		ns.LastUpdated = time.Unix(0, updatedAt)
+		ns.ActiveRetired = activeRetired != 0
+		out = append(out, ns)
+	}
+	return out, rows.Err()
+}
+
+// TeamDefSetActive UPSERTs the teamdef_active pointer for
+// (tenantID, name). RFC N: validates the def belongs to BOTH the named
+// team AND the supplied tenant — a def can only be promoted within its
+// own tenant.
+func (s *Store) TeamDefSetActive(ctx context.Context, tenantID, name, defID, promotedByAgentID string) error {
+	var (
+		rowName   string
+		rowTenant string
+	)
+	err := s.db.QueryRowContext(ctx, `SELECT name, tenant_id FROM teamdefs WHERE def_id = ?`, defID).Scan(&rowName, &rowTenant)
+	if err == sql.ErrNoRows {
+		return &store.ErrNotFound{Kind: "team_def", ID: defID}
+	}
+	if err != nil {
+		return err
+	}
+	if rowName != name {
+		return fmt.Errorf("teamdef_active: def_id %q has name %q, refusing to promote under name %q", defID, rowName, name)
+	}
+	if rowTenant != tenantID {
+		return fmt.Errorf("teamdef_active: def_id %q belongs to tenant %q, refusing to promote under tenant %q", defID, rowTenant, tenantID)
+	}
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO teamdef_active (tenant_id, name, def_id, promoted_at, promoted_by_agent_id)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(tenant_id, name) DO UPDATE SET
+		    def_id               = excluded.def_id,
+		    promoted_at          = excluded.promoted_at,
+		    promoted_by_agent_id = excluded.promoted_by_agent_id`,
+		tenantID, name, defID, time.Now().UnixNano(), nilIfEmpty(promotedByAgentID),
+	)
+	return err
+}
+
+func (s *Store) TeamDefGetActive(ctx context.Context, tenantID, name string) (store.TeamDefRow, error) {
+	var defID string
+	err := s.db.QueryRowContext(ctx, `SELECT def_id FROM teamdef_active WHERE tenant_id = ? AND name = ?`, tenantID, name).Scan(&defID)
+	if err == sql.ErrNoRows {
+		return store.TeamDefRow{}, &store.ErrNotFound{Kind: "teamdef_active", ID: name}
+	}
+	if err != nil {
+		return store.TeamDefRow{}, err
+	}
+	return s.TeamDefGet(ctx, defID)
+}
+
+func (s *Store) TeamDefSetRetired(ctx context.Context, defID string, retired bool) error {
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE teamdefs SET retired = ? WHERE def_id = ?`,
+		boolToInt(retired), defID,
+	)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return &store.ErrNotFound{Kind: "team_def", ID: defID}
+	}
+	return nil
+}
+
+const teamDefSelect = `SELECT
+	def_id, name, version,
+	COALESCE(parent_def_id, ''),
+	definition,
+	COALESCE(description, ''),
+	created_at,
+	COALESCE(created_by_agent_id, ''),
+	COALESCE(created_by_run_id, ''),
+	retired,
+	bootstrapped_from_static,
+	COALESCE(content_sha256, ''),
+	tenant_id
+FROM teamdefs`
+
+func (s *Store) scanTeamDef(row *sql.Row) (store.TeamDefRow, error) {
+	var (
+		out        store.TeamDefRow
+		definition string
+		createdAt  int64
+		retired    int
+		bootstrap  int
+	)
+	err := row.Scan(
+		&out.DefID, &out.Name, &out.Version,
+		&out.ParentDefID,
+		&definition,
+		&out.Description,
+		&createdAt,
+		&out.CreatedByAgentID, &out.CreatedByRunID,
+		&retired, &bootstrap,
+		&out.ContentSHA256,
+		&out.TenantID,
+	)
+	if err != nil {
+		return store.TeamDefRow{}, err
+	}
+	out.Definition = json.RawMessage(definition)
+	out.CreatedAt = time.Unix(0, createdAt)
+	out.Retired = retired != 0
+	out.BootstrappedFromStatic = bootstrap != 0
+	return out, nil
+}
+
+func (s *Store) scanTeamDefRows(rows *sql.Rows) ([]store.TeamDefRow, error) {
+	var out []store.TeamDefRow
+	for rows.Next() {
+		var (
+			r          store.TeamDefRow
 			definition string
 			createdAt  int64
 			retired    int

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -964,6 +964,15 @@ type Store interface {
 	// skill_def_active. Ordered by name ASC for determinism.
 	SnapshotReadSkillDefActive(ctx context.Context) ([]SkillDefActiveEntry, error)
 
+	// SnapshotReadTeamDefs returns every row in teamdefs across
+	// all names + versions. Ordered by (name ASC, version ASC) for
+	// snapshot determinism. Mirrors SnapshotReadSkillDefs.
+	SnapshotReadTeamDefs(ctx context.Context) ([]TeamDefRow, error)
+
+	// SnapshotReadTeamDefActive returns every row in
+	// teamdef_active. Ordered by name ASC for determinism.
+	SnapshotReadTeamDefActive(ctx context.Context) ([]TeamDefActiveEntry, error)
+
 	// SnapshotReadMCPServerDefs — v0.9.x mirror of SnapshotReadSkillDefs.
 	SnapshotReadMCPServerDefs(ctx context.Context) ([]MCPServerDefRow, error)
 
@@ -1051,6 +1060,14 @@ type Store interface {
 	// SnapshotRestoreSkillDefActive mirrors SnapshotRestoreAgentDefActive
 	// for skill_def_active. ON CONFLICT (tenant_id, name) DO NOTHING.
 	SnapshotRestoreSkillDefActive(ctx context.Context, entry SkillDefActiveEntry) (bool, error)
+
+	// SnapshotRestoreTeamDef mirrors SnapshotRestoreSkillDef for
+	// teamdefs. Idempotent on def_id.
+	SnapshotRestoreTeamDef(ctx context.Context, r TeamDefRow) (bool, error)
+
+	// SnapshotRestoreTeamDefActive mirrors SnapshotRestoreSkillDefActive
+	// for teamdef_active. ON CONFLICT (tenant_id, name) DO NOTHING.
+	SnapshotRestoreTeamDefActive(ctx context.Context, entry TeamDefActiveEntry) (bool, error)
 
 	// SnapshotRestoreMCPServerDef — v0.9.x mirror.
 	SnapshotRestoreMCPServerDef(ctx context.Context, r MCPServerDefRow) (bool, error)
@@ -1432,6 +1449,33 @@ type Store interface {
 	// tenantID "" = the shared/operator/legacy tenant.
 	SkillDefGetActive(ctx context.Context, tenantID, name string) (SkillDefRow, error)
 	SkillDefSetRetired(ctx context.Context, defID string, retired bool) error
+
+	// ---- TeamDef substrate ----
+	//
+	// Mirror of SkillDef* with the same invariants. Concurrency
+	// posture is identical: a per-name lock makes version monotonic
+	// across concurrent forks. The Definition payload is an opaque
+	// workflow-graph blob instead of a skill body — the store stays
+	// content-agnostic.
+
+	TeamDefCreate(ctx context.Context, row TeamDefRow) (TeamDefRow, error)
+	TeamDefGet(ctx context.Context, defID string) (TeamDefRow, error)
+	TeamDefGetByNameVersion(ctx context.Context, name string, version int) (TeamDefRow, error)
+	TeamDefListByName(ctx context.Context, name string) ([]TeamDefRow, error)
+	TeamDefListChildren(ctx context.Context, parentDefID string) ([]TeamDefRow, error)
+	TeamDefListNames(ctx context.Context) ([]TeamDefNameSummary, error)
+	// TeamDefSetActive UPSERTs the teamdef_active pointer for
+	// `(tenantID, name)`. RFC N: the active pointer is per-tenant, and a
+	// def can only be promoted within its own tenant — implementations
+	// refuse if the def's tenant_id ≠ tenantID. tenantID "" = the shared/
+	// operator/legacy tenant.
+	TeamDefSetActive(ctx context.Context, tenantID, name, defID, promotedByAgentID string) error
+	// TeamDefGetActive returns the currently-active row for
+	// `(tenantID, name)`. Returns *ErrNotFound when no active pointer
+	// exists (the caller falls through to the static fallback). RFC N:
+	// tenantID "" = the shared/operator/legacy tenant.
+	TeamDefGetActive(ctx context.Context, tenantID, name string) (TeamDefRow, error)
+	TeamDefSetRetired(ctx context.Context, defID string, retired bool) error
 
 	// ---- v0.9.x MCPServerDef substrate ----
 	//
@@ -2482,6 +2526,71 @@ type SkillDefActiveEntry struct {
 	TenantID string `json:"tenant_id,omitempty"`
 }
 
+// ---- TeamDef substrate types ----
+//
+// Mirror of SkillDef* — same identity / lineage / provenance
+// semantics, but the Definition payload is an opaque workflow-graph
+// blob instead of a skill body. The store layer does NOT interpret
+// it.
+//
+// Identity, lineage, and provenance fields carry identical
+// invariants to SkillDefRow. See the AgentDefRow doc for full
+// detail — the comments below only call out team-specific quirks.
+type TeamDefRow struct {
+	DefID                  string          `json:"def_id"`
+	Name                   string          `json:"name"`
+	Version                int             `json:"version"`
+	ParentDefID            string          `json:"parent_def_id,omitempty"`
+	Definition             json.RawMessage `json:"definition"`
+	Description            string          `json:"description,omitempty"`
+	CreatedAt              time.Time       `json:"created_at"`
+	CreatedByAgentID       string          `json:"created_by_agent_id,omitempty"`
+	CreatedByRunID         string          `json:"created_by_run_id,omitempty"`
+	Retired                bool            `json:"retired"`
+	BootstrappedFromStatic bool            `json:"bootstrapped_from_static"`
+	// ContentSHA256 — see AgentDefRow.ContentSHA256. Same semantics.
+	ContentSHA256 string `json:"content_sha256,omitempty"`
+	// TenantID is the RFC N tenant-isolation axis. "" = the shared/
+	// operator/legacy tenant. The UNIQUE constraint is (tenant_id, name,
+	// version), so two tenants own the same name+version independently.
+	// Deliberately NOT part of the content hash — tenant is operational
+	// identity, not content (same rule AgentDefRow follows), so two
+	// tenants forking the same body get the same content_sha256. Set from
+	// the authoritative principal at the write site; never from the wire.
+	TenantID string `json:"tenant_id,omitempty"`
+}
+
+// TeamDefNameSummary mirrors SkillDefNameSummary.
+type TeamDefNameSummary struct {
+	Name string `json:"name"`
+	// TenantID is the RFC N owning tenant. A name owned by N tenants
+	// yields N summary rows (one per tenant) — without grouping by tenant
+	// the listing would merge distinct tenants' versions under one name.
+	TenantID      string    `json:"tenant_id,omitempty"`
+	VersionCount  int       `json:"version_count"`
+	ActiveDefID   string    `json:"active_def_id,omitempty"`
+	LatestVersion int       `json:"latest_version"`
+	LastUpdated   time.Time `json:"last_updated"`
+	// LiveVersionCount / ActiveRetired mirror AgentDefNameSummary — the
+	// soft-reclaim status the Web UI Library's "Hide retired" filter reads.
+	// LiveVersionCount is VersionCount minus retired rows; ActiveRetired is
+	// true when the active pointer references a retired row.
+	LiveVersionCount int  `json:"live_version_count"`
+	ActiveRetired    bool `json:"active_retired,omitempty"`
+}
+
+// TeamDefActiveEntry mirrors SkillDefActiveEntry. Pairs a team
+// name with the def_id currently promoted to active.
+type TeamDefActiveEntry struct {
+	Name              string    `json:"name"`
+	DefID             string    `json:"def_id"`
+	PromotedAt        time.Time `json:"promoted_at"`
+	PromotedByAgentID string    `json:"promoted_by_agent_id,omitempty"`
+	// TenantID is the RFC N tenant-isolation axis (part of the
+	// teamdef_active PK). "" = the shared/operator/legacy tenant.
+	TenantID string `json:"tenant_id,omitempty"`
+}
+
 // ---- v0.9.x MCPServerDef substrate types ----
 //
 // Mirror of AgentDef* / SkillDef* with the same identity / lineage /
@@ -3044,6 +3153,10 @@ var ErrAgentDefParentNotFound = &SubstrateError{Code: "parent_not_found", Msg: "
 // ErrSkillDefParentNotFound mirrors ErrAgentDefParentNotFound for
 // the SkillDef substrate.
 var ErrSkillDefParentNotFound = &SubstrateError{Code: "parent_not_found", Msg: "skill_def: parent_def_id does not exist"}
+
+// ErrTeamDefParentNotFound mirrors ErrSkillDefParentNotFound for
+// the TeamDef substrate.
+var ErrTeamDefParentNotFound = &SubstrateError{Code: "parent_not_found", Msg: "team_def: parent_def_id does not exist"}
 
 // ErrMCPServerDefParentNotFound mirrors the AgentDef + SkillDef
 // pattern for the v0.9.x MCPServerDef substrate.

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -220,6 +220,17 @@ func Run(t *testing.T, factory Factory) {
 		{"SkillDefContentSHA256RoundTrip", testSkillDefContentSHA256RoundTrip},
 		{"BackfillSkillDefContentSHA256", testBackfillSkillDefContentSHA256},
 		{"SkillDefSnapshotReadEmpty", testSkillDefSnapshotReadEmpty},
+		// TeamDef substrate — mirror of the SkillDef tests.
+		{"TeamDefCreateAndGet", testTeamDefCreateAndGet},
+		{"TeamDefVersionMonotonicUnderContention", testTeamDefVersionMonotonicUnderContention},
+		{"TeamDefActivePointerIdempotent", testTeamDefActivePointerIdempotent},
+		{"TeamDefRetireReversible", testTeamDefRetireReversible},
+		{"TeamDefListNamesLiveCount", testTeamDefListNamesLiveCount},
+		{"TeamDefStaticFallback", testTeamDefStaticFallback},
+		// RFC N — team definition plane tenant isolation. Fails on the
+		// pre-migration single-`name`-PK schema (clobber); passes after.
+		{"TeamDefTenantIsolation", testTeamDefTenantIsolation},
+		{"TeamDefContentSHA256RoundTrip", testTeamDefContentSHA256RoundTrip},
 		// v0.9.x MCPServerDef substrate — mirror of the AgentDef + SkillDef tests.
 		{"MCPServerDefCreateAndGet", testMCPServerDefCreateAndGet},
 		{"MCPServerDefVersionMonotonic", testMCPServerDefVersionMonotonic},
@@ -5317,6 +5328,288 @@ func testSkillDefSnapshotReadEmpty(t *testing.T, s store.Store) {
 	ptrs, _ = s.SnapshotReadSkillDefActive(ctx)
 	if len(ptrs) != 1 {
 		t.Errorf("after restore: %d pointers", len(ptrs))
+	}
+}
+
+// ---- TeamDef contract tests ----
+//
+// Direct mirror of the SkillDef tests above. Same invariants:
+// monotonic versioning under contention, idempotent active pointer,
+// reversible retire flag, per-tenant isolation, content-hash
+// round-trip. The Definition payload is an opaque workflow-graph blob.
+
+func mkTeamDef(id, name string, parent string) store.TeamDefRow {
+	return store.TeamDefRow{
+		DefID:       id,
+		Name:        name,
+		ParentDefID: parent,
+		Definition:  json.RawMessage(`{"graph":{"nodes":["a"]},"description":"test row"}`),
+		Description: "test row",
+	}
+}
+
+// testTeamDefListNamesLiveCount mirrors the skill live-count test for teams:
+// VersionCount counts every version, LiveVersionCount excludes retired, and
+// ActiveRetired is true when the active pointer references a retired def. Drives
+// the Web UI Library "Hide retired" filter for the teams tab.
+func testTeamDefListNamesLiveCount(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	v1, err := s.TeamDefCreate(ctx, mkTeamDef("tlc-1", "tlc-team", ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.TeamDefCreate(ctx, mkTeamDef("tlc-2", "tlc-team", v1.DefID)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.TeamDefSetRetired(ctx, v1.DefID, true); err != nil {
+		t.Fatal(err)
+	}
+	find := func() store.TeamDefNameSummary {
+		rows, lerr := s.TeamDefListNames(ctx)
+		if lerr != nil {
+			t.Fatal(lerr)
+		}
+		for _, r := range rows {
+			if r.Name == "tlc-team" && r.TenantID == "" {
+				return r
+			}
+		}
+		t.Fatal("tlc-team not in list")
+		return store.TeamDefNameSummary{}
+	}
+	sum := find()
+	if sum.VersionCount != 2 {
+		t.Errorf("VersionCount = %d, want 2 (retired rows still counted)", sum.VersionCount)
+	}
+	if sum.LiveVersionCount != 1 {
+		t.Errorf("LiveVersionCount = %d, want 1 (retired excluded)", sum.LiveVersionCount)
+	}
+	// Pointing active at the retired v1 surfaces ActiveRetired.
+	if err := s.TeamDefSetActive(ctx, "", "tlc-team", v1.DefID, ""); err != nil {
+		t.Fatal(err)
+	}
+	if !find().ActiveRetired {
+		t.Errorf("ActiveRetired = false, want true (active points at a retired def)")
+	}
+}
+
+func testTeamDefCreateAndGet(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	row, err := s.TeamDefCreate(ctx, mkTeamDef("td-1", "team-alpha", ""))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if row.Version != 1 {
+		t.Errorf("first version = %d, want 1", row.Version)
+	}
+	got, err := s.TeamDefGet(ctx, "td-1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Name != "team-alpha" || got.Version != 1 {
+		t.Errorf("got %+v", got)
+	}
+	if got.CreatedAt.IsZero() {
+		t.Error("created_at not populated")
+	}
+}
+
+func testTeamDefVersionMonotonicUnderContention(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	const G = 50
+	const Per = 5
+	var wg sync.WaitGroup
+	errs := make(chan error, G*Per)
+	for g := 0; g < G; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < Per; i++ {
+				id := fmt.Sprintf("td-%d-%d", g, i)
+				_, err := s.TeamDefCreate(ctx, mkTeamDef(id, "team-race", ""))
+				if err != nil {
+					errs <- err
+					return
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("create error: %v", err)
+	}
+	rows, err := s.TeamDefListByName(ctx, "team-race")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != G*Per {
+		t.Fatalf("got %d versions, want %d", len(rows), G*Per)
+	}
+	versions := make(map[int]bool, len(rows))
+	for _, r := range rows {
+		if versions[r.Version] {
+			t.Errorf("duplicate version %d", r.Version)
+		}
+		versions[r.Version] = true
+	}
+	for v := 1; v <= G*Per; v++ {
+		if !versions[v] {
+			t.Errorf("missing version %d", v)
+		}
+	}
+}
+
+func testTeamDefActivePointerIdempotent(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	a, err := s.TeamDefCreate(ctx, mkTeamDef("td-a", "team-promo", ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := s.TeamDefCreate(ctx, mkTeamDef("td-b", "team-promo", ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.TeamDefSetActive(ctx, "", "team-promo", a.DefID, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.TeamDefSetActive(ctx, "", "team-promo", b.DefID, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.TeamDefSetActive(ctx, "", "team-promo", a.DefID, ""); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.TeamDefGetActive(ctx, "", "team-promo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.DefID != a.DefID {
+		t.Errorf("active = %s, want %s", got.DefID, a.DefID)
+	}
+}
+
+func testTeamDefRetireReversible(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	row, err := s.TeamDefCreate(ctx, mkTeamDef("td-r-1", "team-retireagent", ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.TeamDefSetRetired(ctx, row.DefID, true); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := s.TeamDefGet(ctx, row.DefID)
+	if !got.Retired {
+		t.Error("retire(true) didn't stick")
+	}
+	if err := s.TeamDefSetRetired(ctx, row.DefID, false); err != nil {
+		t.Fatal(err)
+	}
+	got, _ = s.TeamDefGet(ctx, row.DefID)
+	if got.Retired {
+		t.Error("retire(false) didn't reverse")
+	}
+	rows, _ := s.TeamDefListByName(ctx, "team-retireagent")
+	if len(rows) != 1 {
+		t.Errorf("list after retire toggle: got %d, want 1", len(rows))
+	}
+}
+
+func testTeamDefStaticFallback(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_, err := s.TeamDefGetActive(ctx, "", "no-such-team-name")
+	var nf *store.ErrNotFound
+	if !errors.As(err, &nf) {
+		t.Errorf("got %v, want *ErrNotFound", err)
+	}
+}
+
+// testTeamDefTenantIsolation pins the RFC N boundary: the SAME team
+// name registered under two tenants must resolve to each tenant's OWN
+// definition + active pointer — no cross-tenant clobber, no cross-tenant
+// read. Covers teamdefs + teamdef_active + the cross-tenant promote refusal.
+//
+// FAIL-BEFORE: on a single-`name`-PK schema (teamdef_active PK = (name),
+// teamdefs UNIQUE = (name, version)), tenant B's writes overwrite tenant
+// A's (last-writer-wins on the single global pointer), so the GetActive(A)
+// assertion reads back B's def_id and the test fails. The composite
+// (tenant_id, name) PK is what makes the two rows coexist.
+func testTeamDefTenantIsolation(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	const name = "summarize-team"
+
+	aDef := mkTeamDef("tti-a", name, "")
+	aDef.TenantID = "tenant-a"
+	aDef.Definition = json.RawMessage(`{"body":"A"}`)
+	aRow, err := s.TeamDefCreate(ctx, aDef)
+	if err != nil {
+		t.Fatalf("create A: %v", err)
+	}
+
+	bDef := mkTeamDef("tti-b", name, "")
+	bDef.TenantID = "tenant-b"
+	bDef.Definition = json.RawMessage(`{"body":"B"}`)
+	bRow, err := s.TeamDefCreate(ctx, bDef)
+	if err != nil {
+		t.Fatalf("create B: %v", err)
+	}
+
+	if err := s.TeamDefSetActive(ctx, "tenant-a", name, aRow.DefID, ""); err != nil {
+		t.Fatalf("promote A: %v", err)
+	}
+	if err := s.TeamDefSetActive(ctx, "tenant-b", name, bRow.DefID, ""); err != nil {
+		t.Fatalf("promote B: %v", err)
+	}
+
+	gotA, err := s.TeamDefGetActive(ctx, "tenant-a", name)
+	if err != nil {
+		t.Fatalf("get active A: %v", err)
+	}
+	if gotA.DefID != aRow.DefID || gotA.TenantID != "tenant-a" || !jsonEqual(gotA.Definition, `{"body":"A"}`) {
+		t.Errorf("tenant-a clobbered: got def_id=%q tenant=%q def=%s, want A's own def",
+			gotA.DefID, gotA.TenantID, gotA.Definition)
+	}
+
+	gotB, err := s.TeamDefGetActive(ctx, "tenant-b", name)
+	if err != nil {
+		t.Fatalf("get active B: %v", err)
+	}
+	if gotB.DefID != bRow.DefID || gotB.TenantID != "tenant-b" || !jsonEqual(gotB.Definition, `{"body":"B"}`) {
+		t.Errorf("tenant-b clobbered: got def_id=%q tenant=%q def=%s, want B's own def",
+			gotB.DefID, gotB.TenantID, gotB.Definition)
+	}
+
+	// A def can only be promoted within its own tenant — promoting A's
+	// def under tenant-b must be refused.
+	if err := s.TeamDefSetActive(ctx, "tenant-b", name, aRow.DefID, ""); err == nil {
+		t.Error("cross-tenant promote (A's def under tenant-b) unexpectedly succeeded")
+	}
+}
+
+func testTeamDefContentSHA256RoundTrip(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	row := mkTeamDef("td-hash", "team-alpha-hash", "")
+	row.ContentSHA256 = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	written, err := s.TeamDefCreate(ctx, row)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if written.ContentSHA256 != row.ContentSHA256 {
+		t.Errorf("write echo: got %q, want %q", written.ContentSHA256, row.ContentSHA256)
+	}
+	got, err := s.TeamDefGet(ctx, "td-hash")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.ContentSHA256 != row.ContentSHA256 {
+		t.Errorf("get: ContentSHA256 = %q, want %q", got.ContentSHA256, row.ContentSHA256)
+	}
+
+	plain, err := s.TeamDefCreate(ctx, mkTeamDef("td-no-hash", "team-alpha-no-hash", ""))
+	if err != nil {
+		t.Fatalf("create no-hash: %v", err)
+	}
+	if plain.ContentSHA256 != "" {
+		t.Errorf("hashless row: got %q, want empty", plain.ContentSHA256)
 	}
 }
 


### PR DESCRIPTION
First phase of **RFC AP — Agent Teams & Task Workflows** (design-locked in the loomcycle Document `/loomcycle/rfcs/agent-teams`). This PR adds only the **persistence substrate** for the new `TeamDef` family; the authoring tool, graph validation, diagram renderer, and `team/orchestrator` runtime follow in subsequent PRs.

## Why
A `TeamDef` is a workflow graph (states + transitions + per-state handlers) stored as a content-addressed, forkable, tenant-scoped substrate def. Its row is structurally **identical to `SkillDefRow`** — an opaque JSON `definition` blob plus the standard lineage / tenant / content-hash / provenance fields — so the store layer is a verbatim clone of the SkillDef substrate and stays completely content-agnostic (the tool layer owns the `definition` JSON schema).

## What
- **`store.go`** — `TeamDefRow` / `TeamDefNameSummary` / `TeamDefActiveEntry` (mirror SkillDef, including the `live_version_count` / `active_retired` summary fields from v1.16.3); the 9 `Store`-interface methods (`Create`/`Get`/`GetByNameVersion`/`ListByName`/`ListChildren`/`ListNames`/`SetActive`/`GetActive`/`SetRetired`); the 4 snapshot hooks; `ErrTeamDefParentNotFound`.
- **sqlite** — `teamdefs` + `teamdef_active` in the inline schema + indexes; all methods + snapshot hooks.
- **postgres** — migration **`0056_teamdefs`** (skill_defs' `0016`+`0019`+`0038` collapsed, since `teamdefs` is a fresh table); all methods + snapshot hooks.
- **snapshot** — `TeamDefs` / `TeamDefActive` sections wired into capture + restore (FK-ordered) + the identity-migrator registry.
- **storetest** — `mkTeamDef` + 8 contract tests (create/get, version-monotonic, active-pointer idempotent, retire-reversible, `ListNamesLiveCount`, static fallback, tenant isolation, `content_sha256` round-trip), registered in the suite (run against **sqlite + postgres**).

## Tested
`go test ./...` clean; the `TeamDef` contract subtests pass on sqlite; snapshot round-trip tests pass; `gofmt`/`go vet` clean.

Part of the RFC AP phased rollout: **store (this PR)** → content-hash + authoring tool + graph validation → `render_diagram` → `team/orchestrator` → `agent-teams` bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)