### PR TITLE
feat(teamdef): TeamDef graph model + authoring tool + validation (RFC AP phase 2)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1612,6 +1612,16 @@ func main() {
 		MaxDefinitionBytes:  cfg.Env.AgentDefMaxDefinitionBytes,
 		MaxDescriptionBytes: cfg.Env.AgentDefMaxDescriptionBytes,
 	})
+	// RFC AP Phase 2 — wire the TeamDef substrate tool (team-workflow graphs).
+	// Tenant-confined at the route (ScopeTenant), but the same dedicated-slot
+	// wiring as ScheduleDef; reached via Connector.TeamDef + POST /v1/_teamdef +
+	// the LoomCycle MCP meta-tool `teamdef`. Reuses the AgentDef byte caps (the
+	// definition is a graph blob, like ScheduleDef/A2A — no dedicated env knob).
+	srv.SetTeamDefTool(&builtin.TeamDef{
+		Store:               storeIface,
+		MaxDefinitionBytes:  cfg.Env.AgentDefMaxDefinitionBytes,
+		MaxDescriptionBytes: cfg.Env.AgentDefMaxDescriptionBytes,
+	})
 	// v1.x RFC G — wire the two A2A substrate tools. Same operator-admin-
 	// only posture as ScheduleDef; reached via Connector + the admin
 	// endpoints + the LoomCycle MCP meta-tools. Identical Store + Cfg +

--- a/internal/api/grpc/server_test.go
+++ b/internal/api/grpc/server_test.go
@@ -769,6 +769,9 @@ func (m *mockConnector) AgentDef(context.Context, json.RawMessage) (connector.To
 func (m *mockConnector) SkillDef(context.Context, json.RawMessage) (connector.ToolResult, error) {
 	return connector.ToolResult{}, nil
 }
+func (m *mockConnector) TeamDef(context.Context, json.RawMessage) (connector.ToolResult, error) {
+	return connector.ToolResult{}, nil
+}
 func (m *mockConnector) Evaluation(context.Context, json.RawMessage) (connector.ToolResult, error) {
 	return connector.ToolResult{}, nil
 }

--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -699,7 +699,7 @@ func requiredScopeFor(method, path string) string {
 // + opaque-404), so opening these gates to ScopeTenant doesn't widen reach.
 func isTenantConfinedDefPath(path string) bool {
 	for _, fam := range []string{
-		"/v1/_agentdef", "/v1/_skilldef", "/v1/_mcpserverdef", "/v1/_scheduledef",
+		"/v1/_agentdef", "/v1/_skilldef", "/v1/_teamdef", "/v1/_mcpserverdef", "/v1/_scheduledef",
 		"/v1/_webhookdef", "/v1/_memorybackenddef", "/v1/_a2aagentdef", "/v1/_a2aservercarddef",
 		// RFC AH Phase 2a — the dynamic-volume substrate is tenant-confined
 		// (write-stamps the caller's tenant + opaque-404s cross-tenant), so

--- a/internal/api/http/auth_principal_test.go
+++ b/internal/api/http/auth_principal_test.go
@@ -230,6 +230,8 @@ func TestRequiredScopeFor(t *testing.T) {
 		{"POST", "/v1/_agentdef", auth.ScopeTenant},
 		{"GET", "/v1/_agentdef/names", auth.ScopeTenant},
 		{"POST", "/v1/_skilldef", auth.ScopeTenant},
+		{"POST", "/v1/_teamdef", auth.ScopeTenant},
+		{"GET", "/v1/_teamdef/names", auth.ScopeTenant},
 		{"POST", "/v1/_mcpserverdef", auth.ScopeTenant},
 		{"GET", "/v1/_mcpserverdef/names", auth.ScopeTenant},
 		{"POST", "/v1/_scheduledef", auth.ScopeTenant},

--- a/internal/api/http/connector_impl.go
+++ b/internal/api/http/connector_impl.go
@@ -486,6 +486,21 @@ func (s *Server) SkillDef(ctx context.Context, input json.RawMessage) (connector
 	return s.dispatchBuiltin(ctx, "SkillDef", input)
 }
 
+// TeamDef dispatches to the RFC AP TeamDef substrate tool (team-workflow
+// graphs). NOT in the per-agent dispatcher (s.tools) — it's authored via the
+// route + MCP meta-tool, not attached to agents — so it uses the dedicated
+// teamDefTool slot like MCPServerDef/ScheduleDef. See SetTeamDefTool for wiring.
+func (s *Server) TeamDef(ctx context.Context, input json.RawMessage) (connector.ToolResult, error) {
+	if s.teamDefTool == nil {
+		return connector.ToolResult{}, fmt.Errorf("TeamDef: not configured (no tool wired via SetTeamDefTool)")
+	}
+	res, err := s.teamDefTool.Execute(ctx, input)
+	if err != nil {
+		return connector.ToolResult{}, err
+	}
+	return connector.ToolResult{Text: res.Text, IsError: res.IsError}, nil
+}
+
 // VolumeDef dispatches to the RFC AH Phase 2a dynamic-volume substrate
 // tool. Unlike MCPServerDef (operator-admin-only) the VolumeDef tool IS in
 // the per-agent dispatcher (s.tools) with a default-deny volume_def_scopes

--- a/internal/api/http/library_admin.go
+++ b/internal/api/http/library_admin.go
@@ -76,6 +76,19 @@ func (s *Server) handleListSkillDefNames(w http.ResponseWriter, r *http.Request)
 	writeJSONOK(w, map[string]any{"names": rows})
 }
 
+// handleListTeamDefNames serves GET /v1/_teamdef/names.
+// RFC AP team-workflow substrate; tenant-scoped like the other name lists.
+func (s *Server) handleListTeamDefNames(w http.ResponseWriter, r *http.Request) {
+	rows, err := s.store.TeamDefListNames(r.Context())
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "store_error", err.Error())
+		return
+	}
+	tenantID, all := s.principalTenantScope(r.Context(), r.URL.Query().Get("tenant"))
+	rows = scopeNames(rows, all, tenantID, func(x store.TeamDefNameSummary) string { return x.TenantID })
+	writeJSONOK(w, map[string]any{"names": rows})
+}
+
 // handleListMCPServerDefNames serves GET /v1/_mcpserverdef/names.
 func (s *Server) handleListMCPServerDefNames(w http.ResponseWriter, r *http.Request) {
 	rows, err := s.store.MCPServerDefListNames(r.Context())

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -309,6 +309,14 @@ type Server struct {
 	// "not configured" errors. Set via SetScheduleDefTool.
 	scheduleDefTool tools.Tool
 
+	// teamDefTool is the RFC AP TeamDef substrate tool (team-workflow
+	// graphs). Tenant-confined (ScopeTenant at the route), but structurally
+	// the same dedicated-slot wiring as scheduleDefTool — NOT in s.tools (not
+	// a per-agent dispatcher tool), reached via Connector.TeamDef + the
+	// POST /v1/_teamdef admin endpoint + the LoomCycle MCP meta-tool `teamdef`.
+	// Nil = the surface returns "not configured" errors. Set via SetTeamDefTool.
+	teamDefTool tools.Tool
+
 	// a2aServerCardDefTool + a2aAgentDefTool are the v1.x RFC G A2A
 	// substrate tools. Same operator-admin-only posture as
 	// scheduleDefTool — NOT in s.tools, reached via Connector +
@@ -777,6 +785,14 @@ func (s *Server) SetMCPServerDefTool(t tools.Tool) {
 // than the MCP-dependent MCPServerDef tool.
 func (s *Server) SetScheduleDefTool(t tools.Tool) {
 	s.scheduleDefTool = t
+}
+
+// SetTeamDefTool wires the RFC AP TeamDef substrate tool. Without this call,
+// Connector.TeamDef + POST /v1/_teamdef + the LoomCycle MCP meta-tool all refuse
+// with "not configured". The tool only needs the store + byte caps, so it can be
+// constructed alongside ScheduleDef in main.go.
+func (s *Server) SetTeamDefTool(t tools.Tool) {
+	s.teamDefTool = t
 }
 
 // SetA2AServerCardDefTool wires the v1.x RFC G A2AServerCardDef substrate
@@ -2513,6 +2529,11 @@ func (s *Server) Mux() http.Handler {
 	// same connector path, different wire surface.
 	mux.Handle("POST /v1/_agentdef", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleSubstrateAgentDef))))
 	mux.Handle("POST /v1/_skilldef", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleSubstrateSkillDef))))
+	// RFC AP Phase 2 TeamDef substrate. Bearer-authed; tenant-confined
+	// (ScopeTenant via isTenantConfinedDefPath) — the tool stamps the caller's
+	// authoritative tenant + opaque-404s cross-tenant reads. Same dispatch shape
+	// as the other substrate admin endpoints.
+	mux.Handle("POST /v1/_teamdef", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleSubstrateTeamDef))))
 	// v0.9.x dynamic MCP server registration. Bearer-authed; operator-
 	// admin-only (no per-agent surface). Same dispatch shape as the
 	// other two substrate admin endpoints.
@@ -2590,6 +2611,7 @@ func (s *Server) Mux() http.Handler {
 	// substrate write endpoints; drives the Web UI's /ui/library tab.
 	mux.Handle("GET /v1/_agentdef/names", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListAgentDefNames))))
 	mux.Handle("GET /v1/_skilldef/names", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListSkillDefNames))))
+	mux.Handle("GET /v1/_teamdef/names", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListTeamDefNames))))
 	mux.Handle("GET /v1/_mcpserverdef/names", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListMCPServerDefNames))))
 	mux.Handle("GET /v1/_scheduledef/names", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListScheduleDefNames))))
 	mux.Handle("GET /v1/_a2aservercarddef/names", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListA2AServerCardDefNames))))

--- a/internal/api/http/substrate_admin.go
+++ b/internal/api/http/substrate_admin.go
@@ -50,6 +50,14 @@ func (s *Server) handleSubstrateSkillDef(w http.ResponseWriter, r *http.Request)
 	s.dispatchSubstrate(w, r, "SkillDef", s.SkillDef)
 }
 
+// handleSubstrateTeamDef serves POST /v1/_teamdef.
+// RFC AP Phase 2 team-workflow substrate. Bearer-authed; tenant-confined
+// (ScopeTenant via isTenantConfinedDefPath) — same dispatch shape as the
+// AgentDef + SkillDef admin endpoints.
+func (s *Server) handleSubstrateTeamDef(w http.ResponseWriter, r *http.Request) {
+	s.dispatchSubstrate(w, r, "TeamDef", s.TeamDef)
+}
+
 // handleSubstrateMCPServerDef serves POST /v1/_mcpserverdef.
 // v0.9.x dynamic MCP server registration. Bearer-authed; same
 // dispatch shape as the AgentDef + SkillDef admin endpoints.

--- a/internal/api/http/substrate_admin_test.go
+++ b/internal/api/http/substrate_admin_test.go
@@ -54,6 +54,9 @@ func substrateAdminFixture(t *testing.T) *httptest.Server {
 	// HTTP handler + Connector method look up. Without this call,
 	// POST /v1/_scheduledef returns "ScheduleDef: not configured".
 	srv.SetScheduleDefTool(&builtin.ScheduleDef{Store: st, Cfg: cfg})
+	// RFC AP TeamDef — same dedicated-slot wiring; without it POST /v1/_teamdef
+	// returns "TeamDef: not configured".
+	srv.SetTeamDefTool(&builtin.TeamDef{Store: st})
 	return httptest.NewServer(srv.Mux())
 }
 
@@ -80,6 +83,92 @@ func TestSubstrateAdmin_SkillDef_HappyPath(t *testing.T) {
 	}
 	if out["promoted"].(bool) != true {
 		t.Errorf("create default promote = false; want true")
+	}
+}
+
+// TestSubstrateAdmin_TeamDef_HappyPath drives a valid team-graph create through
+// POST /v1/_teamdef and asserts the row persists (RFC AP Phase 2).
+func TestSubstrateAdmin_TeamDef_HappyPath(t *testing.T) {
+	ts := substrateAdminFixture(t)
+	defer ts.Close()
+
+	body := `{"op":"create","name":"review-team","overlay":{` +
+		`"entry":"review",` +
+		`"states":[{"state":"review","handler":{"kind":"agent","agent":"reviewer"}},{"state":"done","handler":{"kind":"terminal"}}],` +
+		`"transitions":[{"from":"review","to":"done","on":"success"}]}}`
+	resp := postAdmin(t, ts, "/v1/_teamdef", body)
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, raw)
+	}
+	var out map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out["name"] != "review-team" {
+		t.Errorf("name = %v, want review-team", out["name"])
+	}
+	if out["version"].(float64) != 1 {
+		t.Errorf("version = %v, want 1", out["version"])
+	}
+	if sha, _ := out["content_sha256"].(string); !strings.HasPrefix(sha, "sha256:") {
+		t.Errorf("content_sha256 = %q, want sha256:-prefixed", sha)
+	}
+}
+
+// TestSubstrateAdmin_TeamDef_InvalidGraph422 confirms an invalid graph surfaces
+// as a 422 tool_refused (dispatchSubstrate maps the tool's IsError to 422).
+func TestSubstrateAdmin_TeamDef_InvalidGraph422(t *testing.T) {
+	ts := substrateAdminFixture(t)
+	defer ts.Close()
+
+	body := `{"op":"create","name":"bad-team","overlay":{` +
+		`"entry":"review",` +
+		`"states":[{"state":"review","handler":{"kind":"agent","agent":"reviewer"}}],` +
+		`"transitions":[{"from":"review","to":"ghost","on":"success"}]}}`
+	resp := postAdmin(t, ts, "/v1/_teamdef", body)
+	defer resp.Body.Close()
+	if resp.StatusCode != 422 {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 422; body=%s", resp.StatusCode, raw)
+	}
+}
+
+// TestSubstrateAdmin_TeamDef_ListNames covers GET /v1/_teamdef/names.
+func TestSubstrateAdmin_TeamDef_ListNames(t *testing.T) {
+	ts := substrateAdminFixture(t)
+	defer ts.Close()
+
+	_ = postAdmin(t, ts, "/v1/_teamdef", `{"op":"create","name":"digest-team","overlay":{`+
+		`"entry":"a","states":[{"state":"a","handler":{"kind":"terminal"}}],"transitions":[]}}`)
+
+	req, _ := http.NewRequest("GET", ts.URL+"/v1/_teamdef/names", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, raw)
+	}
+	var env struct {
+		Names []map[string]any `json:"names"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	found := false
+	for _, n := range env.Names {
+		if n["name"] == "digest-team" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("digest-team not in names list: %v", env.Names)
 	}
 }
 

--- a/internal/api/mcp/handlers.go
+++ b/internal/api/mcp/handlers.go
@@ -67,6 +67,12 @@ var handlersByName = map[string]toolHandler{
 	"skilldef": wrapBuiltin("skilldef", func(c connector.Connector, ctx context.Context, in json.RawMessage) (connector.ToolResult, error) {
 		return c.SkillDef(ctx, in)
 	}),
+	// RFC AP Phase 2 team-workflow substrate. Tenant-confined (the tool stamps
+	// the row's tenant from ctx + opaque-404s cross-tenant reads); mirror of
+	// skilldef.
+	"teamdef": wrapBuiltin("teamdef", func(c connector.Connector, ctx context.Context, in json.RawMessage) (connector.ToolResult, error) {
+		return c.TeamDef(ctx, in)
+	}),
 	// v0.9.x dynamic MCP server registration. Operator-admin-only;
 	// the LoomCycle MCP server is bearer-authed so external
 	// orchestrators (Claude Code, n8n via the MCP Client Tool) can

--- a/internal/api/mcp/http_transport_test.go
+++ b/internal/api/mcp/http_transport_test.go
@@ -83,6 +83,9 @@ func (m *httpMockConnector) AgentDef(context.Context, json.RawMessage) (connecto
 func (m *httpMockConnector) SkillDef(context.Context, json.RawMessage) (connector.ToolResult, error) {
 	return connector.ToolResult{}, nil
 }
+func (m *httpMockConnector) TeamDef(context.Context, json.RawMessage) (connector.ToolResult, error) {
+	return connector.ToolResult{}, nil
+}
 func (m *httpMockConnector) Evaluation(context.Context, json.RawMessage) (connector.ToolResult, error) {
 	return connector.ToolResult{}, nil
 }

--- a/internal/api/mcp/server_test.go
+++ b/internal/api/mcp/server_test.go
@@ -128,6 +128,9 @@ func (m *mockConnector) AgentDef(_ context.Context, _ json.RawMessage) (connecto
 func (m *mockConnector) SkillDef(_ context.Context, _ json.RawMessage) (connector.ToolResult, error) {
 	return connector.ToolResult{}, nil
 }
+func (m *mockConnector) TeamDef(_ context.Context, _ json.RawMessage) (connector.ToolResult, error) {
+	return connector.ToolResult{}, nil
+}
 func (m *mockConnector) Evaluation(_ context.Context, _ json.RawMessage) (connector.ToolResult, error) {
 	return connector.ToolResult{}, nil
 }
@@ -392,8 +395,8 @@ func TestServer_ToolsList_ReturnsFullCatalogue(t *testing.T) {
 	if err := json.Unmarshal(resps[0].Result, &result); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if len(result.Tools) != 47 {
-		t.Errorf("got %d tools, want 47 (+credentialdef on top of the path/document/volumedef/spawn_runs/compact_run list)", len(result.Tools))
+	if len(result.Tools) != 48 {
+		t.Errorf("got %d tools, want 48 (+teamdef on top of the credentialdef/path/document/volumedef/spawn_runs/compact_run list)", len(result.Tools))
 	}
 	names := map[string]bool{}
 	for _, td := range result.Tools {
@@ -403,7 +406,7 @@ func TestServer_ToolsList_ReturnsFullCatalogue(t *testing.T) {
 		t.Error("catalogue missing the credentialdef meta-tool")
 	}
 	// Spot-check across categories — through the v1.x additions.
-	for _, want := range []string{"spawn_run", "spawn_runs", "compact_run", "register_agent", "memory", "agentdef", "skilldef", "mcpserverdef", "scheduledef", "a2aservercarddef", "a2aagentdef", "webhookdef", "memorybackenddef", "operatortokendef", "volumedef", "path", "document", "pause_runtime", "create_snapshot", "get_snapshot", "resolve_probe", "interruption_resolve", "register_hook", "list_hooks", "delete_hook", "list_channels", "stream_user_run_states", "publish_channel", "subscribe_channel", "peek_channel", "ack_channel"} {
+	for _, want := range []string{"spawn_run", "spawn_runs", "compact_run", "register_agent", "memory", "agentdef", "skilldef", "teamdef", "mcpserverdef", "scheduledef", "a2aservercarddef", "a2aagentdef", "webhookdef", "memorybackenddef", "operatortokendef", "volumedef", "path", "document", "pause_runtime", "create_snapshot", "get_snapshot", "resolve_probe", "interruption_resolve", "register_hook", "list_hooks", "delete_hook", "list_channels", "stream_user_run_states", "publish_channel", "subscribe_channel", "peek_channel", "ack_channel"} {
 		if !names[want] {
 			t.Errorf("missing tool %q in tools/list", want)
 		}

--- a/internal/api/mcp/toolauthz.go
+++ b/internal/api/mcp/toolauthz.go
@@ -47,6 +47,7 @@ var tenantConfinableTools = map[string]bool{
 	// cross-tenant reads.
 	"agentdef":         true,
 	"skilldef":         true,
+	"teamdef":          true, // RFC AP — tenant-confined team-workflow substrate
 	"mcpserverdef":     true,
 	"scheduledef":      true,
 	"a2aservercarddef": true,

--- a/internal/api/mcp/tools.go
+++ b/internal/api/mcp/tools.go
@@ -225,6 +225,11 @@ func toolDescriptors() []loommcp.ToolDescriptor {
 			InputSchema: builtinSchema("skilldef"),
 		},
 		{
+			Name:        "teamdef",
+			Description: "TeamDef tool ops (create/fork/get/list/promote/retire/verify). RFC AP team-workflow substrate — a state-machine graph (states + transitions) validated before any write; invalid graphs are refused. Colours are excluded from the content hash. Tenant-confined. Pass-through.",
+			InputSchema: builtinSchema("teamdef"),
+		},
+		{
 			Name:        "mcpserverdef",
 			Description: "MCPServerDef tool ops (create/fork/get/list/promote/retire/rediscover/verify). v0.9.x dynamic MCP server registration. Operator-admin-only — register HTTP / Streamable-HTTP MCP servers at runtime; stdio stays yaml. URL hostname must be in LOOMCYCLE_HTTP_HOST_ALLOWLIST. Pass-through.",
 			InputSchema: builtinSchema("mcpserverdef"),

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -125,6 +125,17 @@ type Connector interface {
 	Channel(ctx context.Context, input json.RawMessage) (ToolResult, error)
 	AgentDef(ctx context.Context, input json.RawMessage) (ToolResult, error)
 	SkillDef(ctx context.Context, input json.RawMessage) (ToolResult, error)
+
+	// TeamDef — RFC AP team-workflow substrate. Op-discriminated (create /
+	// fork / get / list / promote / retire / verify). The definition is a
+	// teamgraph state-machine (states + transitions), validated before any
+	// write; an invalid graph is refused and persists nothing. TENANT-CONFINED
+	// (ScopeTenant, like SkillDef): the tool stamps the caller's authoritative
+	// tenant + opaque-404s cross-tenant. Reachable via POST /v1/_teamdef admin
+	// endpoint + the LoomCycle MCP meta-tool `teamdef` (gRPC + adapter twins
+	// deferred to a follow-up). All dispatch through this single method.
+	TeamDef(ctx context.Context, input json.RawMessage) (ToolResult, error)
+
 	Evaluation(ctx context.Context, input json.RawMessage) (ToolResult, error)
 	Context(ctx context.Context, input json.RawMessage) (ToolResult, error)
 

--- a/internal/teamgraph/graph.go
+++ b/internal/teamgraph/graph.go
@@ -1,0 +1,106 @@
+// Package teamgraph is the domain model for a TeamDef's `definition` JSON —
+// the workflow graph of RFC AP (Agent Teams & Task Workflows): states (nodes),
+// transitions (edges), and the per-state handler that decides who acts.
+//
+// The graph IS the state machine: nodes are author-defined states, edges are the
+// allowed transitions (with loops), and each state binds a handler. This package
+// is deliberately loomcycle-dependency-free (stdlib only) so the store's
+// content-hash (internal/agents/teamsign), the TeamDef tool, the diagram
+// renderer, and the runtime orchestrator can all share one model without an
+// import cycle.
+package teamgraph
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// DefaultMaxIterations is the per-state cycle cap applied when a Definition
+// omits max_iterations. Exceeding it fires an Interruption at run time.
+const DefaultMaxIterations = 10
+
+// Handler kinds — the "who acts" bound to a state.
+const (
+	HandlerAgent        = "agent"        // a single AgentDef run
+	HandlerParallel     = "parallel"     // fan out N agents + a consolidator
+	HandlerConsolidator = "consolidator" // a standalone consolidator-agent state
+	HandlerTerminal     = "terminal"     // an end state; no agent, no outbound edges required
+)
+
+// Transition kinds — the `on` label prefix. success is bare; pushback and
+// conditional carry a `:<suffix>`.
+const (
+	OnSuccess     = "success"
+	OnPushback    = "pushback"    // pushback:<reason>
+	OnConditional = "conditional" // conditional:<expr>
+)
+
+// Wait modes for a parallel handler (mirrors Channel.await).
+const (
+	WaitAll     = "all"
+	WaitAny     = "any"
+	WaitAtLeast = "at_least" // at_least:<N>
+)
+
+// Definition is the full `definition` JSON of a TeamDef.
+type Definition struct {
+	Entry         string       `json:"entry"`
+	MaxIterations int          `json:"max_iterations,omitempty"`
+	States        []State      `json:"states"`
+	Transitions   []Transition `json:"transitions"`
+	// Colors is presentation only (unsaturated state fills, saturated transition
+	// edges). It is EXCLUDED from the content hash (see internal/agents/teamsign)
+	// so recolouring a workflow doesn't fork its identity.
+	Colors *Colors `json:"colors,omitempty"`
+}
+
+// State is one node: an id + the handler that runs when a task is in it.
+type State struct {
+	ID      string  `json:"state"`
+	Handler Handler `json:"handler"`
+}
+
+// Handler is the "who acts" for a state.
+type Handler struct {
+	Kind string `json:"kind"` // agent | parallel | consolidator | terminal
+	// Agent — for kind=agent and kind=consolidator: the AgentDef name to run.
+	Agent string `json:"agent,omitempty"`
+	// Agents — for kind=parallel: the AgentDef names fanned out concurrently.
+	Agents []string `json:"agents,omitempty"`
+	// Wait — for kind=parallel: all | any | at_least:<N> (default all).
+	Wait string `json:"wait,omitempty"`
+	// Consolidator — the AgentDef name that reads the handler's output(s) and
+	// picks the outgoing transition. REQUIRED for kind=parallel; OPTIONAL for
+	// kind=agent ("re-evaluate after one agent").
+	Consolidator string `json:"consolidator,omitempty"`
+	// InputTemplate / TimeoutMS — optional per-handler run config.
+	InputTemplate string `json:"input_template,omitempty"`
+	TimeoutMS     int    `json:"timeout_ms,omitempty"`
+}
+
+// Transition is one edge: from-state → to-state, gated by an `on` label.
+type Transition struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+	On   string `json:"on"` // success | pushback:<reason> | conditional:<expr>
+}
+
+// Colors is the optional presentation scheme.
+type Colors struct {
+	// Transitions maps a transition kind/label (success, pushback,
+	// pushback:<reason>, conditional) to a saturated edge colour.
+	Transitions map[string]string `json:"transitions,omitempty"`
+	// States maps a state id to an unsaturated fill colour (hex or a named key).
+	States map[string]string `json:"states,omitempty"`
+}
+
+// Parse unmarshals a TeamDef definition JSON. It does NOT validate the graph —
+// call Validate for that. Unknown keys are tolerated (forward-compat + operator
+// extension), matching the AgentDef overlay's additionalProperties:true stance.
+func Parse(defJSON []byte) (Definition, error) {
+	var d Definition
+	if err := json.Unmarshal(defJSON, &d); err != nil {
+		return Definition{}, fmt.Errorf("team definition: invalid JSON: %w", err)
+	}
+	return d, nil
+}

--- a/internal/teamgraph/sign.go
+++ b/internal/teamgraph/sign.go
@@ -1,0 +1,42 @@
+package teamgraph
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+)
+
+// teamContent is the closed set of content-identifying fields hashed into a
+// TeamDef's content_sha256. The COLOR scheme (presentation) and identity/tenant
+// (operational) are deliberately EXCLUDED — mirroring how `skills:` and
+// tenant_id are excluded from AgentDef's hash — so two tenants forking the same
+// workflow share a hash and recolouring never changes a def's identity.
+//
+// DO NOT reorder these fields: json.Marshal emits them in declaration order and
+// the resulting bytes are the hash input, so reordering would break every
+// existing content_sha256.
+type teamContent struct {
+	Name          string       `json:"name"`
+	Entry         string       `json:"entry"`
+	MaxIterations int          `json:"max_iterations,omitempty"`
+	States        []State      `json:"states"`
+	Transitions   []Transition `json:"transitions"`
+}
+
+// Sign returns "sha256:" + the lowercase-hex SHA-256 of a TeamDef's canonical
+// content (name + graph, minus colours). Deterministic: equal content → equal
+// hash. Mirrors skills.Sign / agents.Sign.
+func Sign(name string, d Definition) string {
+	buf, err := json.Marshal(teamContent{
+		Name:          name,
+		Entry:         d.Entry,
+		MaxIterations: d.MaxIterations,
+		States:        d.States,
+		Transitions:   d.Transitions,
+	})
+	if err != nil {
+		buf = []byte("{}")
+	}
+	sum := sha256.Sum256(buf)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}

--- a/internal/teamgraph/sign_test.go
+++ b/internal/teamgraph/sign_test.go
@@ -1,0 +1,36 @@
+package teamgraph
+
+import "testing"
+
+func TestSign_DeterministicAndColorExcluded(t *testing.T) {
+	base, _ := Parse([]byte(sdlcJSON))
+	h1 := Sign("sdlc", base)
+	h2 := Sign("sdlc", base)
+	if h1 != h2 {
+		t.Fatalf("Sign not deterministic: %q vs %q", h1, h2)
+	}
+	if len(h1) != len("sha256:")+64 {
+		t.Errorf("hash shape wrong: %q", h1)
+	}
+
+	// Adding a color scheme must NOT change the hash (presentation, not content).
+	colored := base
+	colored.Colors = &Colors{
+		States:      map[string]string{"review": "pink"},
+		Transitions: map[string]string{"success": "#2f9e44"},
+	}
+	if Sign("sdlc", colored) != h1 {
+		t.Errorf("colours must be excluded from the content hash")
+	}
+
+	// A different name → different hash.
+	if Sign("other", base) == h1 {
+		t.Errorf("name is content-identifying; hash should differ")
+	}
+	// A graph change → different hash.
+	changed := base
+	changed.MaxIterations = 99
+	if Sign("sdlc", changed) == h1 {
+		t.Errorf("a graph change should change the hash")
+	}
+}

--- a/internal/teamgraph/validate.go
+++ b/internal/teamgraph/validate.go
@@ -1,0 +1,173 @@
+package teamgraph
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Validate checks a TeamDef definition graph for the invariants RFC AP requires
+// at create/fork time. It is imperative (mirroring how AgentDef validates code
+// and MCPServerDef validates transport) rather than JSON-Schema-enforced.
+//
+// Rules:
+//   - exactly one non-empty `entry`, resolving to a state;
+//   - ≥1 state; state ids unique + non-empty;
+//   - each state's handler is a valid kind with its required fields;
+//   - every transition's from/to resolves to a state; `on` is well-formed
+//     (success | pushback:<reason> | conditional:<expr>);
+//   - a state's outbound transition labels are unique (so a consolidator's
+//     next_edge is unambiguous);
+//   - a terminal state has no outbound transitions;
+//   - every state is reachable from `entry`;
+//   - max_iterations ≥ 0 (0 = use the default). Cycle termination is guaranteed
+//     because the per-state cap applies to every state.
+func Validate(d Definition) error {
+	if strings.TrimSpace(d.Entry) == "" {
+		return fmt.Errorf("team definition: `entry` is required")
+	}
+	if len(d.States) == 0 {
+		return fmt.Errorf("team definition: at least one state is required")
+	}
+	if d.MaxIterations < 0 {
+		return fmt.Errorf("team definition: max_iterations must be >= 0 (0 = default %d)", DefaultMaxIterations)
+	}
+
+	// State ids: unique + non-empty; validate each handler.
+	states := make(map[string]State, len(d.States))
+	for i, s := range d.States {
+		if strings.TrimSpace(s.ID) == "" {
+			return fmt.Errorf("team definition: state[%d] has an empty `state` id", i)
+		}
+		if _, dup := states[s.ID]; dup {
+			return fmt.Errorf("team definition: duplicate state id %q", s.ID)
+		}
+		if err := validateHandler(s.ID, s.Handler); err != nil {
+			return err
+		}
+		states[s.ID] = s
+	}
+
+	if _, ok := states[d.Entry]; !ok {
+		return fmt.Errorf("team definition: entry %q does not resolve to a state", d.Entry)
+	}
+
+	// Transitions: endpoints resolve; `on` well-formed; per-state label uniqueness.
+	outbound := make(map[string]map[string]bool) // state -> set of `on` labels
+	adj := make(map[string][]string)             // state -> reachable states
+	for i, t := range d.Transitions {
+		if _, ok := states[t.From]; !ok {
+			return fmt.Errorf("team definition: transition[%d] from %q does not resolve to a state", i, t.From)
+		}
+		if _, ok := states[t.To]; !ok {
+			return fmt.Errorf("team definition: transition[%d] to %q does not resolve to a state", i, t.To)
+		}
+		if err := validateOn(i, t.On); err != nil {
+			return err
+		}
+		if states[t.From].Handler.Kind == HandlerTerminal {
+			return fmt.Errorf("team definition: terminal state %q must have no outbound transitions", t.From)
+		}
+		if outbound[t.From] == nil {
+			outbound[t.From] = map[string]bool{}
+		}
+		if outbound[t.From][t.On] {
+			return fmt.Errorf("team definition: state %q has duplicate outbound transition label %q (ambiguous route)", t.From, t.On)
+		}
+		outbound[t.From][t.On] = true
+		adj[t.From] = append(adj[t.From], t.To)
+	}
+
+	// Reachability: BFS from entry; every state must be reachable.
+	seen := map[string]bool{d.Entry: true}
+	queue := []string{d.Entry}
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		for _, nxt := range adj[cur] {
+			if !seen[nxt] {
+				seen[nxt] = true
+				queue = append(queue, nxt)
+			}
+		}
+	}
+	for _, s := range d.States {
+		if !seen[s.ID] {
+			return fmt.Errorf("team definition: state %q is unreachable from entry %q", s.ID, d.Entry)
+		}
+	}
+
+	return nil
+}
+
+func validateHandler(stateID string, h Handler) error {
+	switch h.Kind {
+	case HandlerAgent, HandlerConsolidator:
+		if strings.TrimSpace(h.Agent) == "" {
+			return fmt.Errorf("team definition: state %q handler kind %q requires `agent`", stateID, h.Kind)
+		}
+		if len(h.Agents) > 0 {
+			return fmt.Errorf("team definition: state %q handler kind %q must not set `agents` (use `agent`)", stateID, h.Kind)
+		}
+	case HandlerParallel:
+		if len(h.Agents) == 0 {
+			return fmt.Errorf("team definition: state %q parallel handler requires a non-empty `agents`", stateID)
+		}
+		for _, a := range h.Agents {
+			if strings.TrimSpace(a) == "" {
+				return fmt.Errorf("team definition: state %q parallel handler has an empty agent name", stateID)
+			}
+		}
+		if strings.TrimSpace(h.Consolidator) == "" {
+			return fmt.Errorf("team definition: state %q parallel handler requires a `consolidator` agent", stateID)
+		}
+		if err := validateWait(stateID, h.Wait); err != nil {
+			return err
+		}
+	case HandlerTerminal:
+		if h.Agent != "" || len(h.Agents) != 0 || h.Consolidator != "" {
+			return fmt.Errorf("team definition: state %q terminal handler must not set agent/agents/consolidator", stateID)
+		}
+	case "":
+		return fmt.Errorf("team definition: state %q handler is missing a `kind`", stateID)
+	default:
+		return fmt.Errorf("team definition: state %q has unknown handler kind %q (want agent|parallel|consolidator|terminal)", stateID, h.Kind)
+	}
+	if h.TimeoutMS < 0 {
+		return fmt.Errorf("team definition: state %q handler timeout_ms must be >= 0", stateID)
+	}
+	return nil
+}
+
+func validateWait(stateID, wait string) error {
+	if wait == "" || wait == WaitAll || wait == WaitAny {
+		return nil
+	}
+	if n, ok := strings.CutPrefix(wait, WaitAtLeast+":"); ok {
+		k, err := strconv.Atoi(n)
+		if err != nil || k < 1 {
+			return fmt.Errorf("team definition: state %q wait %q: at_least:<N> needs a positive integer", stateID, wait)
+		}
+		return nil
+	}
+	return fmt.Errorf("team definition: state %q has invalid wait %q (want all|any|at_least:<N>)", stateID, wait)
+}
+
+func validateOn(i int, on string) error {
+	if on == OnSuccess {
+		return nil
+	}
+	if reason, ok := strings.CutPrefix(on, OnPushback+":"); ok {
+		if strings.TrimSpace(reason) == "" {
+			return fmt.Errorf("team definition: transition[%d] pushback: needs a non-empty reason", i)
+		}
+		return nil
+	}
+	if expr, ok := strings.CutPrefix(on, OnConditional+":"); ok {
+		if strings.TrimSpace(expr) == "" {
+			return fmt.Errorf("team definition: transition[%d] conditional: needs a non-empty expression", i)
+		}
+		return nil
+	}
+	return fmt.Errorf("team definition: transition[%d] has invalid `on` %q (want success | pushback:<reason> | conditional:<expr>)", i, on)
+}

--- a/internal/teamgraph/validate_test.go
+++ b/internal/teamgraph/validate_test.go
@@ -1,0 +1,107 @@
+package teamgraph
+
+import (
+	"strings"
+	"testing"
+)
+
+// A valid full workflow: parallel review + consolidator + pushback loops (the
+// RFC's SDLC pilot, abbreviated). Must pass.
+const sdlcJSON = `{
+  "entry": "implementation",
+  "max_iterations": 10,
+  "states": [
+    { "state": "implementation", "handler": { "kind": "agent", "agent": "code-guru" } },
+    { "state": "review", "handler": {
+        "kind": "parallel", "agents": ["sec-rev", "code-rev"], "wait": "all",
+        "consolidator": "sdlc-consolidator" } },
+    { "state": "pr", "handler": { "kind": "terminal" } }
+  ],
+  "transitions": [
+    { "from": "implementation", "to": "review", "on": "success" },
+    { "from": "review", "to": "pr", "on": "success" },
+    { "from": "review", "to": "implementation", "on": "pushback:code-fix" }
+  ]
+}`
+
+func TestValidate_ValidSDLC(t *testing.T) {
+	d, err := Parse([]byte(sdlcJSON))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if err := Validate(d); err != nil {
+		t.Fatalf("valid SDLC graph should pass, got: %v", err)
+	}
+}
+
+func TestValidate_ValidLinear(t *testing.T) {
+	d, _ := Parse([]byte(`{
+	  "entry": "draft",
+	  "states": [
+	    {"state":"draft","handler":{"kind":"agent","agent":"writer"}},
+	    {"state":"done","handler":{"kind":"terminal"}}
+	  ],
+	  "transitions": [{"from":"draft","to":"done","on":"success"}]
+	}`))
+	if err := Validate(d); err != nil {
+		t.Fatalf("valid linear graph should pass, got: %v", err)
+	}
+}
+
+func TestValidate_Rejections(t *testing.T) {
+	cases := []struct {
+		name string
+		json string
+		want string // substring of the error
+	}{
+		{"empty entry",
+			`{"entry":"","states":[{"state":"a","handler":{"kind":"terminal"}}]}`, "`entry` is required"},
+		{"no states",
+			`{"entry":"a","states":[]}`, "at least one state"},
+		{"entry not a state",
+			`{"entry":"x","states":[{"state":"a","handler":{"kind":"terminal"}}]}`, "does not resolve"},
+		{"duplicate state",
+			`{"entry":"a","states":[{"state":"a","handler":{"kind":"terminal"}},{"state":"a","handler":{"kind":"terminal"}}]}`, "duplicate state"},
+		{"dangling transition to",
+			`{"entry":"a","states":[{"state":"a","handler":{"kind":"agent","agent":"w"}}],"transitions":[{"from":"a","to":"ghost","on":"success"}]}`, "does not resolve"},
+		{"bad on label",
+			`{"entry":"a","states":[{"state":"a","handler":{"kind":"agent","agent":"w"}},{"state":"b","handler":{"kind":"terminal"}}],"transitions":[{"from":"a","to":"b","on":"maybe"}]}`, "invalid `on`"},
+		{"unreachable state",
+			`{"entry":"a","states":[{"state":"a","handler":{"kind":"terminal"}},{"state":"island","handler":{"kind":"terminal"}}]}`, "unreachable"},
+		{"parallel without consolidator",
+			`{"entry":"a","states":[{"state":"a","handler":{"kind":"parallel","agents":["x"]}}]}`, "requires a `consolidator`"},
+		{"parallel without agents",
+			`{"entry":"a","states":[{"state":"a","handler":{"kind":"parallel","consolidator":"c"}}]}`, "non-empty `agents`"},
+		{"agent without agent name",
+			`{"entry":"a","states":[{"state":"a","handler":{"kind":"agent"}}]}`, "requires `agent`"},
+		{"unknown handler kind",
+			`{"entry":"a","states":[{"state":"a","handler":{"kind":"delay"}}]}`, "unknown handler kind"},
+		{"missing handler kind",
+			`{"entry":"a","states":[{"state":"a","handler":{}}]}`, "missing a `kind`"},
+		{"duplicate outbound label",
+			`{"entry":"a","states":[{"state":"a","handler":{"kind":"agent","agent":"w"}},{"state":"b","handler":{"kind":"terminal"}},{"state":"c","handler":{"kind":"terminal"}}],"transitions":[{"from":"a","to":"b","on":"success"},{"from":"a","to":"c","on":"success"}]}`, "duplicate outbound transition label"},
+		{"terminal with outbound",
+			`{"entry":"a","states":[{"state":"a","handler":{"kind":"terminal"}},{"state":"b","handler":{"kind":"terminal"}}],"transitions":[{"from":"a","to":"b","on":"success"}]}`, "terminal state"},
+		{"bad wait",
+			`{"entry":"a","states":[{"state":"a","handler":{"kind":"parallel","agents":["x"],"consolidator":"c","wait":"most"}}]}`, "invalid wait"},
+		{"empty pushback reason",
+			`{"entry":"a","states":[{"state":"a","handler":{"kind":"agent","agent":"w"}},{"state":"b","handler":{"kind":"terminal"}}],"transitions":[{"from":"a","to":"b","on":"pushback:"}]}`, "non-empty reason"},
+		{"negative max_iterations",
+			`{"entry":"a","max_iterations":-1,"states":[{"state":"a","handler":{"kind":"terminal"}}]}`, "max_iterations"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d, err := Parse([]byte(tc.json))
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			err = Validate(d)
+			if err == nil {
+				t.Fatalf("expected rejection, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %q, want substring %q", err.Error(), tc.want)
+			}
+		})
+	}
+}

--- a/internal/tools/builtin/teamdef.go
+++ b/internal/tools/builtin/teamdef.go
@@ -1,0 +1,524 @@
+package builtin
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/teamgraph"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// TeamDef is the RFC AP Phase 2 built-in tool that lets operators + tenant
+// agents author, fork, promote, retire, and inspect TEAM workflow definitions
+// at runtime. Structural mirror of the SkillDef tool — same six+verify
+// operations, same content-addressed lineage model, same append-only storage —
+// but the `definition` payload is a teamgraph workflow graph (states +
+// transitions), not a skill body.
+//
+// Differences from SkillDef (all deliberate):
+//   - No static-config layer. There is no cfg.Teams, so create never refuses a
+//     "static" name and fork resolves parents ONLY from the store (pin def_id →
+//     own-tenant active → shared "" active). There is no static bootstrap path.
+//   - No per-agent scope gate. TeamDef authoring is gated at the HTTP route
+//     (ScopeTenant) + the MCP meta-tool authz list; the tool itself does NOT
+//     sub-gate by name. MVP simplification — a per-agent `team_def` capability
+//     (mirroring *_def_scopes) could be layered on later without changing this
+//     tool's storage or wire shape.
+//   - No tools ceiling. A team has no `tools` field to narrow/widen.
+//
+// The graph is validated (teamgraph.Validate) at create/fork BEFORE any write —
+// an invalid graph is refused with an errResult and persists nothing. The
+// content_sha256 is teamgraph.Sign (name + graph, colours excluded), so two
+// tenants forking the same workflow share a hash and recolouring never forks a
+// def's identity.
+//
+// Server-stamped fields: created_at, created_by_agent_id (from
+// tools.RunIdentity), tenant_id (from the authoritative principal on ctx). The
+// model NEVER supplies these.
+type TeamDef struct {
+	// Store is the persistence backend. Required.
+	Store store.Store
+
+	// MaxDefinitionBytes caps the serialised definition JSON
+	// (mirrors AgentDef/ScheduleDef). 0 = no cap.
+	MaxDefinitionBytes int
+
+	// MaxDescriptionBytes caps the free-text description field. 0 = no cap.
+	MaxDescriptionBytes int
+}
+
+const teamDefDescription = `Author, fork, promote, retire, and inspect team workflow definitions at runtime (RFC AP). ` +
+	`The definition is a state-machine graph (states with agent/parallel/consolidator/terminal handlers + ` +
+	`transitions gated by success/pushback/conditional). The graph is validated before any write — an invalid ` +
+	`graph (dangling transition, parallel without a consolidator, unreachable state, …) is refused and persists ` +
+	`nothing. Colours are presentation-only and excluded from the content hash. Promotion is explicit — selection ` +
+	`is policy, not runtime. Operations: create, fork, get, list, retire, promote, verify.`
+
+const teamDefInputSchema = `{
+  "type": "object",
+  "properties": {
+    "op":            {"type": "string", "enum": ["create","fork","get","list","retire","promote","verify"], "description": "Operation to perform."},
+    "name":          {"type": "string", "description": "Team name (required for create/fork/list/verify)."},
+    "def_id":        {"type": "string", "description": "Existing def_id (required for get/retire/promote)."},
+    "parent_def_id": {"type": "string", "description": "Fork parent (optional for fork — when absent, forks the active def of the name in your tenant, falling back to the shared \"\" base)."},
+    "overlay": {
+      "type": "object",
+      "description": "Team workflow graph. Top-level fields are merged per-field over the parent (slices replace wholesale). Server-set fields (def_id, version, parent_def_id, created_*) are ignored if supplied.",
+      "properties": {
+        "entry":          {"type": "string", "description": "The entry state id."},
+        "max_iterations": {"type": "integer", "description": "Per-state cycle cap (0 = default)."},
+        "states":         {"type": "array", "items": {"type": "object"}, "description": "State nodes: each is {state, handler:{kind, agent|agents, wait?, consolidator?, ...}}. Replaces the parent's states wholesale."},
+        "transitions":    {"type": "array", "items": {"type": "object"}, "description": "Edges: each is {from, to, on}. Replaces the parent's transitions wholesale."},
+        "colors":         {"type": "object", "description": "Presentation-only fills/edge colours. Excluded from the content hash."}
+      },
+      "additionalProperties": true
+    },
+    "description":    {"type": "string", "description": "Free-text rationale for create/fork."},
+    "promote":        {"type": "boolean", "description": "create defaults true, fork defaults false."},
+    "retired":        {"type": "boolean", "description": "Required for retire — set true to retire, false to un-retire."},
+    "content_sha256": {"type": "string", "description": "Input for op=verify — the local content hash to compare against the active row."}
+  },
+  "required": ["op"]
+}`
+
+type teamDefInput struct {
+	Op            string          `json:"op"`
+	Name          string          `json:"name,omitempty"`
+	DefID         string          `json:"def_id,omitempty"`
+	ParentDefID   string          `json:"parent_def_id,omitempty"`
+	Overlay       json.RawMessage `json:"overlay,omitempty"`
+	Description   string          `json:"description,omitempty"`
+	Promote       *bool           `json:"promote,omitempty"`
+	Retired       *bool           `json:"retired,omitempty"`
+	ContentSHA256 string          `json:"content_sha256,omitempty"` // input for op: verify
+}
+
+// Name implements tools.Tool.
+func (t *TeamDef) Name() string { return "TeamDef" }
+
+// Description implements tools.Tool.
+func (t *TeamDef) Description() string { return teamDefDescription }
+
+// InputSchema implements tools.Tool.
+func (t *TeamDef) InputSchema() json.RawMessage { return json.RawMessage(teamDefInputSchema) }
+
+// Execute implements tools.Tool.
+func (t *TeamDef) Execute(ctx context.Context, raw json.RawMessage) (tools.Result, error) {
+	if t.Store == nil {
+		return errResult("TeamDef tool: not configured (no Store backend)"), nil
+	}
+	var in teamDefInput
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return errResult(fmt.Sprintf("invalid input JSON: %s", err)), nil
+	}
+	switch in.Op {
+	case "create":
+		return t.execCreate(ctx, in)
+	case "fork":
+		return t.execFork(ctx, in)
+	case "get":
+		return t.execGet(ctx, in)
+	case "list":
+		return t.execList(ctx, in)
+	case "retire":
+		return t.execRetire(ctx, in)
+	case "promote":
+		return t.execPromote(ctx, in)
+	case "verify":
+		return t.execVerify(ctx, in)
+	case "":
+		return errResult("missing required field: op"), nil
+	default:
+		return errResult(fmt.Sprintf("unknown op %q (must be one of: create, fork, get, list, retire, promote, verify)", in.Op)), nil
+	}
+}
+
+// ---- create ----
+
+func (t *TeamDef) execCreate(ctx context.Context, in teamDefInput) (tools.Result, error) {
+	if in.Name == "" {
+		return errResult("create: missing required field: name"), nil
+	}
+	defJSON, err := t.buildDefinition("", in.Overlay)
+	if err != nil {
+		return errResult(fmt.Sprintf("create: %s", err)), nil
+	}
+	def, err := teamgraph.Parse(defJSON)
+	if err != nil {
+		return errResult(fmt.Sprintf("create: %s", err)), nil
+	}
+	// Validate the merged graph BEFORE any write — an invalid graph must
+	// never reach storage (a broken team is silent orchestration corruption).
+	if err := teamgraph.Validate(def); err != nil {
+		return errResult(fmt.Sprintf("create: %s", err)), nil
+	}
+	if err := t.checkSizeCaps(defJSON, in.Description); err != nil {
+		return errResult(fmt.Sprintf("create: %s", err)), nil
+	}
+
+	ident := tools.RunIdentity(ctx)
+	// RFC N: the tenant comes from the authoritative run identity in ctx, never
+	// from tool input. "" = shared/legacy tenant. Used for the row stamp + the
+	// promote — both scoped to the team's own tenant.
+	tenantID := ident.TenantID
+	row := store.TeamDefRow{
+		DefID:            mintTeamDefID(),
+		Name:             in.Name,
+		Definition:       defJSON,
+		Description:      in.Description,
+		CreatedByAgentID: ident.AgentID,
+		ContentSHA256:    teamgraph.Sign(in.Name, def),
+		TenantID:         tenantID,
+	}
+	created, err := t.Store.TeamDefCreate(ctx, row)
+	if err != nil {
+		return errResult(fmt.Sprintf("create: %s", err)), nil
+	}
+	promote := true
+	if in.Promote != nil {
+		promote = *in.Promote
+	}
+	if promote {
+		if err := t.Store.TeamDefSetActive(ctx, tenantID, in.Name, created.DefID, ident.AgentID); err != nil {
+			return errResult(fmt.Sprintf("create: promote: %s", err)), nil
+		}
+	}
+	return okJSON(teamDefRowResponse(created, promote))
+}
+
+// ---- fork ----
+
+func (t *TeamDef) execFork(ctx context.Context, in teamDefInput) (tools.Result, error) {
+	if in.Name == "" {
+		return errResult("fork: missing required field: name"), nil
+	}
+
+	// Resolve the parent from the STORE only (no static bootstrap — there is no
+	// cfg.Teams). Three paths, mirroring SkillDef minus the static branch:
+	//   1. parent_def_id supplied → pin
+	//   2. parent_def_id empty + own-tenant active pointer → use it
+	//   3. neither → fall back to the shared ("") active base, else refuse.
+	// RFC N: fork resolves + stamps within the team's own tenant (from the
+	// authoritative run identity, never tool input).
+	ident := tools.RunIdentity(ctx)
+	tenantID := ident.TenantID
+
+	parentDefID := in.ParentDefID
+	var parent store.TeamDefRow
+	if parentDefID != "" {
+		row, err := t.Store.TeamDefGet(ctx, parentDefID)
+		if err != nil {
+			var nf *store.ErrNotFound
+			if errors.As(err, &nf) {
+				return errResult(fmt.Sprintf("fork: parent_def_id %q not found", parentDefID)), nil
+			}
+			return errResult(fmt.Sprintf("fork: %s", err)), nil
+		}
+		if row.Name != in.Name {
+			return errResult(fmt.Sprintf("fork: parent_def_id %q has name %q, refusing to fork under name %q", parentDefID, row.Name, in.Name)), nil
+		}
+		// Allow forking the SHARED ("") base or the caller's own tenant (the fork
+		// lands under the caller's tenant); refuse another specific tenant's
+		// private def unless the caller is substrate:admin (crosses tenants, RFC L).
+		if row.TenantID != "" && row.TenantID != tenantID && !defCallerIsAdmin(ctx) {
+			return errResult(fmt.Sprintf("fork: parent_def_id %q belongs to another tenant, refusing", parentDefID)), nil
+		}
+		parent = row
+	} else {
+		row, err := t.Store.TeamDefGetActive(ctx, tenantID, in.Name)
+		if err == nil {
+			parent = row
+			parentDefID = row.DefID
+		} else {
+			var nf *store.ErrNotFound
+			if !errors.As(err, &nf) {
+				return errResult(fmt.Sprintf("fork: %s", err)), nil
+			}
+			// No own-tenant active pointer. Fall back to the SHARED ("") base so a
+			// per-tenant principal can fork a name seeded under the legacy "" tenant.
+			// Skip when tenantID is already "" (identical lookup).
+			if tenantID != "" {
+				if shared, serr := t.Store.TeamDefGetActive(ctx, "", in.Name); serr == nil {
+					parent = shared
+					parentDefID = shared.DefID
+				} else if !errors.As(serr, &nf) {
+					return errResult(fmt.Sprintf("fork: %s", serr)), nil
+				}
+			}
+			if parentDefID == "" {
+				return errResult(fmt.Sprintf("fork: no parent — name %q has no DB version to fork (own tenant or shared \"\")", in.Name)), nil
+			}
+		}
+	}
+
+	defJSON, err := t.buildDefinition(string(parent.Definition), in.Overlay)
+	if err != nil {
+		return errResult(fmt.Sprintf("fork: %s", err)), nil
+	}
+	def, err := teamgraph.Parse(defJSON)
+	if err != nil {
+		return errResult(fmt.Sprintf("fork: %s", err)), nil
+	}
+	if err := teamgraph.Validate(def); err != nil {
+		return errResult(fmt.Sprintf("fork: %s", err)), nil
+	}
+	if err := t.checkSizeCaps(defJSON, in.Description); err != nil {
+		return errResult(fmt.Sprintf("fork: %s", err)), nil
+	}
+
+	row := store.TeamDefRow{
+		DefID:            mintTeamDefID(),
+		Name:             in.Name,
+		ParentDefID:      parentDefID,
+		Definition:       defJSON,
+		Description:      in.Description,
+		CreatedByAgentID: ident.AgentID,
+		ContentSHA256:    teamgraph.Sign(in.Name, def),
+		TenantID:         tenantID,
+	}
+	created, err := t.Store.TeamDefCreate(ctx, row)
+	if err != nil {
+		return errResult(fmt.Sprintf("fork: %s", err)), nil
+	}
+	promote := false
+	if in.Promote != nil {
+		promote = *in.Promote
+	}
+	if promote {
+		if err := t.Store.TeamDefSetActive(ctx, tenantID, in.Name, created.DefID, ident.AgentID); err != nil {
+			return errResult(fmt.Sprintf("fork: promote: %s", err)), nil
+		}
+	}
+	return okJSON(teamDefRowResponse(created, promote))
+}
+
+// ---- get / list ----
+
+func (t *TeamDef) execGet(ctx context.Context, in teamDefInput) (tools.Result, error) {
+	if in.DefID == "" {
+		return errResult("get: missing required field: def_id"), nil
+	}
+	row, err := t.Store.TeamDefGet(ctx, in.DefID)
+	if err != nil {
+		var nf *store.ErrNotFound
+		if errors.As(err, &nf) {
+			return errResult(fmt.Sprintf("get: def_id %q not found", in.DefID)), nil
+		}
+		return errResult(fmt.Sprintf("get: %s", err)), nil
+	}
+	// RFC N: def_id is a global handle but a def is owned by exactly one tenant.
+	// A caller in tenant T cannot read another tenant's def — return the SAME
+	// opaque not-found a missing def returns (never leak existence/body).
+	if !defCallerIsAdmin(ctx) && row.TenantID != tools.RunIdentity(ctx).TenantID {
+		return errResult(fmt.Sprintf("get: def_id %q not found", in.DefID)), nil
+	}
+	return okJSON(teamDefRowResponse(row, false))
+}
+
+func (t *TeamDef) execList(ctx context.Context, in teamDefInput) (tools.Result, error) {
+	if in.Name == "" {
+		return errResult("list: missing required field: name"), nil
+	}
+	rows, err := t.Store.TeamDefListByName(ctx, in.Name)
+	if err != nil {
+		return errResult(fmt.Sprintf("list: %s", err)), nil
+	}
+	// RFC N: TeamDefListByName returns rows across ALL tenants for a name.
+	// Filter to the caller's own tenant so a tenant lists only its own versions.
+	tenantID := tools.RunIdentity(ctx).TenantID
+	out := make([]map[string]any, 0, len(rows))
+	for _, r := range rows {
+		if !defCallerIsAdmin(ctx) && r.TenantID != tenantID {
+			continue
+		}
+		out = append(out, teamDefRowResponseMap(r))
+	}
+	return okJSON(map[string]any{"name": in.Name, "versions": out})
+}
+
+// ---- retire / promote ----
+
+func (t *TeamDef) execRetire(ctx context.Context, in teamDefInput) (tools.Result, error) {
+	if in.DefID == "" {
+		return errResult("retire: missing required field: def_id"), nil
+	}
+	if in.Retired == nil {
+		return errResult("retire: missing required field: retired (true|false)"), nil
+	}
+	row, err := t.Store.TeamDefGet(ctx, in.DefID)
+	if err != nil {
+		var nf *store.ErrNotFound
+		if errors.As(err, &nf) {
+			return errResult(fmt.Sprintf("retire: def_id %q not found", in.DefID)), nil
+		}
+		return errResult(fmt.Sprintf("retire: %s", err)), nil
+	}
+	// RFC N: refuse cross-tenant retire. TeamDefSetRetired is a global
+	// by-def_id mutation; opaque not-found — don't leak existence.
+	if !defCallerIsAdmin(ctx) && row.TenantID != tools.RunIdentity(ctx).TenantID {
+		return errResult(fmt.Sprintf("retire: def_id %q not found", in.DefID)), nil
+	}
+	if err := t.Store.TeamDefSetRetired(ctx, in.DefID, *in.Retired); err != nil {
+		return errResult(fmt.Sprintf("retire: %s", err)), nil
+	}
+	return okJSON(map[string]any{"def_id": in.DefID, "retired": *in.Retired})
+}
+
+func (t *TeamDef) execPromote(ctx context.Context, in teamDefInput) (tools.Result, error) {
+	if in.DefID == "" {
+		return errResult("promote: missing required field: def_id"), nil
+	}
+	row, err := t.Store.TeamDefGet(ctx, in.DefID)
+	if err != nil {
+		var nf *store.ErrNotFound
+		if errors.As(err, &nf) {
+			return errResult(fmt.Sprintf("promote: def_id %q not found", in.DefID)), nil
+		}
+		return errResult(fmt.Sprintf("promote: %s", err)), nil
+	}
+	// RFC N: refuse cross-tenant promote (opaque not-found). Belt-and-suspenders
+	// with TeamDefSetActive, which also refuses when ident.TenantID ≠ row.TenantID.
+	if !defCallerIsAdmin(ctx) && row.TenantID != tools.RunIdentity(ctx).TenantID {
+		return errResult(fmt.Sprintf("promote: def_id %q not found", in.DefID)), nil
+	}
+	ident := tools.RunIdentity(ctx)
+	if err := t.Store.TeamDefSetActive(ctx, ident.TenantID, row.Name, row.DefID, ident.AgentID); err != nil {
+		return errResult(fmt.Sprintf("promote: %s", err)), nil
+	}
+	return okJSON(map[string]any{"def_id": row.DefID, "name": row.Name, "promoted": true})
+}
+
+// execVerify compares a caller-supplied content_sha256 against the active row's
+// (same shape as SkillDef verify): the caller passes name + a locally-computed
+// hash, and the tool reports whether it matches the deployed active def.
+func (t *TeamDef) execVerify(ctx context.Context, in teamDefInput) (tools.Result, error) {
+	if in.Name == "" {
+		return errResult("verify: missing required field: name"), nil
+	}
+	// RFC N: verify against the team's own tenant active pointer.
+	row, err := t.Store.TeamDefGetActive(ctx, tools.RunIdentity(ctx).TenantID, in.Name)
+	if err != nil {
+		var nf *store.ErrNotFound
+		if errors.As(err, &nf) {
+			return okJSON(map[string]any{
+				"matches":        false,
+				"current_sha256": "",
+				"current_def_id": "",
+				"version":        0,
+				"name":           in.Name,
+				"deployed":       false,
+			})
+		}
+		return errResult(fmt.Sprintf("verify: %s", err)), nil
+	}
+	return okJSON(map[string]any{
+		"matches":        in.ContentSHA256 != "" && in.ContentSHA256 == row.ContentSHA256,
+		"current_sha256": row.ContentSHA256,
+		"current_def_id": row.DefID,
+		"version":        row.Version,
+		"name":           row.Name,
+		"deployed":       true,
+	})
+}
+
+// ---- helpers ----
+
+// buildDefinition parses the base definition (parent's JSON for fork; empty for
+// create) into a teamgraph.Definition, applies the overlay per top-level field,
+// and returns the merged definition marshalled back to JSON. Slices replace
+// wholesale — a team graph is cohesive; states/transitions are NOT
+// element-merged. The returned bytes are exactly what create/fork parse +
+// validate + persist (validate-what-you-store).
+func (t *TeamDef) buildDefinition(parentJSON string, overlay json.RawMessage) (json.RawMessage, error) {
+	base := teamgraph.Definition{}
+	if parentJSON != "" {
+		parsed, err := teamgraph.Parse([]byte(parentJSON))
+		if err != nil {
+			return nil, fmt.Errorf("parse parent definition: %w", err)
+		}
+		base = parsed
+	}
+	if len(overlay) > 0 {
+		ov, err := teamgraph.Parse(overlay)
+		if err != nil {
+			return nil, fmt.Errorf("parse overlay: %w", err)
+		}
+		applyTeamOverlay(&base, ov)
+	}
+	merged, err := json.Marshal(base)
+	if err != nil {
+		return nil, fmt.Errorf("marshal merged definition: %w", err)
+	}
+	return merged, nil
+}
+
+// applyTeamOverlay merges ov over base per top-level field. Scalars set-if-set;
+// slices/maps replace wholesale (never element-merged) since the graph is a
+// cohesive unit.
+func applyTeamOverlay(base *teamgraph.Definition, ov teamgraph.Definition) {
+	if ov.Entry != "" {
+		base.Entry = ov.Entry
+	}
+	if ov.MaxIterations != 0 {
+		base.MaxIterations = ov.MaxIterations
+	}
+	if ov.States != nil {
+		base.States = ov.States
+	}
+	if ov.Transitions != nil {
+		base.Transitions = ov.Transitions
+	}
+	if ov.Colors != nil {
+		base.Colors = ov.Colors
+	}
+}
+
+func (t *TeamDef) checkSizeCaps(defJSON []byte, description string) error {
+	if t.MaxDefinitionBytes > 0 && len(defJSON) > t.MaxDefinitionBytes {
+		return fmt.Errorf("definition (%d bytes) exceeds max %d", len(defJSON), t.MaxDefinitionBytes)
+	}
+	if t.MaxDescriptionBytes > 0 && len(description) > t.MaxDescriptionBytes {
+		return fmt.Errorf("description (%d bytes) exceeds max %d", len(description), t.MaxDescriptionBytes)
+	}
+	return nil
+}
+
+// teamDefRowResponse + Map shape the tool's reply envelope (mirror of
+// skillDefRowResponse). bootstrapped_from_static is always false for teams
+// (no static layer) but included so the response shape matches the sibling
+// def-family tools + the Library UI.
+func teamDefRowResponse(row store.TeamDefRow, promoted bool) map[string]any {
+	m := teamDefRowResponseMap(row)
+	m["promoted"] = promoted
+	return m
+}
+
+func teamDefRowResponseMap(row store.TeamDefRow) map[string]any {
+	return map[string]any{
+		"def_id":                   row.DefID,
+		"name":                     row.Name,
+		"version":                  row.Version,
+		"parent_def_id":            row.ParentDefID,
+		"description":              row.Description,
+		"created_at":               row.CreatedAt.UTC().Format("2006-01-02T15:04:05.000000000Z"),
+		"created_by_agent_id":      row.CreatedByAgentID,
+		"retired":                  row.Retired,
+		"bootstrapped_from_static": row.BootstrappedFromStatic,
+		"content_sha256":           row.ContentSHA256,
+		"definition":               row.Definition,
+	}
+}
+
+// mintTeamDefID returns a fresh opaque ID for a new row. Same 64-bit-entropy
+// shape as mintSkillDefID but with the "tdf_" prefix so team defs never collide
+// with agent/skill defs in logs / grep output.
+func mintTeamDefID() string {
+	var b [8]byte
+	_, _ = rand.Read(b[:])
+	return "tdf_" + hex.EncodeToString(b[:])
+}

--- a/internal/tools/builtin/teamdef_test.go
+++ b/internal/tools/builtin/teamdef_test.go
@@ -1,0 +1,243 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// A minimal valid team graph: entry state runs an agent, then a success edge
+// to a terminal state. Validates cleanly (entry resolves, unique states, valid
+// handlers, well-formed transition, terminal has no outbound, all reachable).
+const validTeamGraph = `{
+  "entry": "review",
+  "states": [
+    {"state": "review", "handler": {"kind": "agent", "agent": "reviewer"}},
+    {"state": "done", "handler": {"kind": "terminal"}}
+  ],
+  "transitions": [
+    {"from": "review", "to": "done", "on": "success"}
+  ]
+}`
+
+// teamDefFixture builds a TeamDef tool over in-memory SQLite. The ctx carries a
+// RunIdentity (shared "" tenant) so create/get/list/promote/retire resolve
+// against the same tenant.
+func teamDefFixture(t *testing.T) (*TeamDef, context.Context, func()) {
+	t.Helper()
+	s, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	tool := &TeamDef{
+		Store:               s,
+		MaxDefinitionBytes:  131072,
+		MaxDescriptionBytes: 8192,
+	}
+	ctx := tools.WithRunIdentity(context.Background(), tools.RunIdentityValue{AgentID: "a_test"})
+	return tool, ctx, func() { _ = s.Close() }
+}
+
+func createTeam(t *testing.T, tool *TeamDef, ctx context.Context, name, overlay string) map[string]any {
+	t.Helper()
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"`+name+`","overlay":`+overlay+`}`))
+	if res.IsError {
+		t.Fatalf("create %q: %s", name, res.Text)
+	}
+	return decodeResult(t, res.Text)
+}
+
+func TestTeamDefTool_CreateValidGraphPersists(t *testing.T) {
+	tool, ctx, cleanup := teamDefFixture(t)
+	defer cleanup()
+
+	out := createTeam(t, tool, ctx, "review-team", validTeamGraph)
+	if out["name"] != "review-team" {
+		t.Errorf("name = %v, want review-team", out["name"])
+	}
+	if out["version"].(float64) != 1 {
+		t.Errorf("version = %v, want 1", out["version"])
+	}
+	if out["promoted"].(bool) != true {
+		t.Errorf("create default promote = false; want true")
+	}
+	sha, _ := out["content_sha256"].(string)
+	if !strings.HasPrefix(sha, "sha256:") {
+		t.Errorf("content_sha256 = %q, want sha256:-prefixed", sha)
+	}
+}
+
+// TestTeamDefTool_CreateInvalidGraphRefusedPersistsNothing pins the RFC AP
+// validate-before-write invariant: an invalid graph is refused AND nothing is
+// stored (fail-before: drop the teamgraph.Validate call in execCreate and the
+// dangling-transition graph persists, so list would return 1 version).
+func TestTeamDefTool_CreateInvalidGraphRefusedPersistsNothing(t *testing.T) {
+	tool, ctx, cleanup := teamDefFixture(t)
+	defer cleanup()
+
+	// A dangling transition (to a non-existent state).
+	dangling := `{
+      "entry": "review",
+      "states": [{"state": "review", "handler": {"kind": "agent", "agent": "reviewer"}}],
+      "transitions": [{"from": "review", "to": "ghost", "on": "success"}]
+    }`
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"bad-team","overlay":`+dangling+`}`))
+	if !res.IsError {
+		t.Fatalf("dangling-transition graph should refuse; got %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "does not resolve to a state") {
+		t.Errorf("refusal should name the validation failure; got %s", res.Text)
+	}
+
+	// A parallel handler missing its consolidator.
+	noConsolidator := `{
+      "entry": "fan",
+      "states": [
+        {"state": "fan", "handler": {"kind": "parallel", "agents": ["a","b"]}},
+        {"state": "done", "handler": {"kind": "terminal"}}
+      ],
+      "transitions": [{"from": "fan", "to": "done", "on": "success"}]
+    }`
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"bad-team","overlay":`+noConsolidator+`}`))
+	if !res.IsError {
+		t.Fatalf("parallel-without-consolidator should refuse; got %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "consolidator") {
+		t.Errorf("refusal should mention the missing consolidator; got %s", res.Text)
+	}
+
+	// Nothing persisted for the refused name.
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"list","name":"bad-team"}`))
+	if res.IsError {
+		t.Fatalf("list: %s", res.Text)
+	}
+	versions := decodeResult(t, res.Text)["versions"].([]any)
+	if len(versions) != 0 {
+		t.Errorf("refused creates persisted %d versions; want 0", len(versions))
+	}
+}
+
+// TestTeamDefTool_ForkColoursOnlyKeepsHash: a fork applying only a `colors`
+// overlay produces a new version whose content_sha256 EQUALS the parent's,
+// because colours are excluded from the content hash (teamgraph.Sign).
+func TestTeamDefTool_ForkColoursOnlyKeepsHash(t *testing.T) {
+	tool, ctx, cleanup := teamDefFixture(t)
+	defer cleanup()
+
+	parent := createTeam(t, tool, ctx, "colour-team", validTeamGraph)
+	parentSHA := parent["content_sha256"].(string)
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"fork","name":"colour-team","overlay":{"colors":{"states":{"review":"#eeeeee"}}}}`))
+	if res.IsError {
+		t.Fatalf("colours-only fork: %s", res.Text)
+	}
+	fork := decodeResult(t, res.Text)
+	if fork["version"].(float64) != 2 {
+		t.Errorf("fork version = %v, want 2", fork["version"])
+	}
+	if fork["content_sha256"].(string) != parentSHA {
+		t.Errorf("colours-only fork changed the hash: got %s, want %s (parent)", fork["content_sha256"], parentSHA)
+	}
+	// The colours DID land in the persisted definition.
+	defBytes, err := json.Marshal(fork["definition"])
+	if err != nil {
+		t.Fatalf("marshal fork definition: %v", err)
+	}
+	if !strings.Contains(string(defBytes), "#eeeeee") {
+		t.Errorf("fork definition missing the overlay colours: %v", fork["definition"])
+	}
+}
+
+// TestTeamDefTool_ForkGraphReplacingChangesHash: a fork whose overlay replaces
+// the graph (new entry + states + transitions) changes the content_sha256.
+func TestTeamDefTool_ForkGraphReplacingChangesHash(t *testing.T) {
+	tool, ctx, cleanup := teamDefFixture(t)
+	defer cleanup()
+
+	parent := createTeam(t, tool, ctx, "graph-team", validTeamGraph)
+	parentSHA := parent["content_sha256"].(string)
+
+	replacement := `{
+      "entry": "plan",
+      "states": [
+        {"state": "plan", "handler": {"kind": "agent", "agent": "planner"}},
+        {"state": "end", "handler": {"kind": "terminal"}}
+      ],
+      "transitions": [{"from": "plan", "to": "end", "on": "success"}]
+    }`
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"fork","name":"graph-team","overlay":`+replacement+`}`))
+	if res.IsError {
+		t.Fatalf("graph-replacing fork: %s", res.Text)
+	}
+	fork := decodeResult(t, res.Text)
+	if fork["content_sha256"].(string) == parentSHA {
+		t.Errorf("graph-replacing fork should change the hash; both = %s", parentSHA)
+	}
+}
+
+// TestTeamDefTool_RoundTrip exercises get / list / retire / promote / verify.
+func TestTeamDefTool_RoundTrip(t *testing.T) {
+	tool, ctx, cleanup := teamDefFixture(t)
+	defer cleanup()
+
+	created := createTeam(t, tool, ctx, "rt-team", validTeamGraph)
+	defID := created["def_id"].(string)
+	sha := created["content_sha256"].(string)
+
+	// get by def_id.
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"get","def_id":"`+defID+`"}`))
+	if res.IsError {
+		t.Fatalf("get: %s", res.Text)
+	}
+	if decodeResult(t, res.Text)["def_id"].(string) != defID {
+		t.Errorf("get returned wrong def_id")
+	}
+
+	// list has exactly the one version.
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"list","name":"rt-team"}`))
+	if res.IsError {
+		t.Fatalf("list: %s", res.Text)
+	}
+	if n := len(decodeResult(t, res.Text)["versions"].([]any)); n != 1 {
+		t.Errorf("list returned %d versions, want 1", n)
+	}
+
+	// verify: correct hash matches; a bogus one does not (deployed stays true).
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"verify","name":"rt-team","content_sha256":"`+sha+`"}`))
+	if res.IsError {
+		t.Fatalf("verify(match): %s", res.Text)
+	}
+	v := decodeResult(t, res.Text)
+	if v["matches"].(bool) != true || v["deployed"].(bool) != true {
+		t.Errorf("verify(match) = %v, want matches+deployed true", v)
+	}
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"verify","name":"rt-team","content_sha256":"sha256:deadbeef"}`))
+	if decodeResult(t, res.Text)["matches"].(bool) != false {
+		t.Error("verify(mismatch) should report matches=false")
+	}
+
+	// retire true → false round-trip.
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"retire","def_id":"`+defID+`","retired":true}`))
+	if res.IsError || decodeResult(t, res.Text)["retired"].(bool) != true {
+		t.Fatalf("retire(true): %s", res.Text)
+	}
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"retire","def_id":"`+defID+`","retired":false}`))
+	if res.IsError || decodeResult(t, res.Text)["retired"].(bool) != false {
+		t.Fatalf("retire(false): %s", res.Text)
+	}
+
+	// A fork (not auto-promoted) then explicit promote flips the active pointer.
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"fork","name":"rt-team","overlay":{"colors":{"states":{"review":"#abcabc"}}}}`))
+	if res.IsError {
+		t.Fatalf("fork: %s", res.Text)
+	}
+	forkID := decodeResult(t, res.Text)["def_id"].(string)
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"promote","def_id":"`+forkID+`"}`))
+	if res.IsError || decodeResult(t, res.Text)["promoted"].(bool) != true {
+		t.Fatalf("promote: %s", res.Text)
+	}
+}

--- a/internal/tools/builtin/wrapper_schemas.go
+++ b/internal/tools/builtin/wrapper_schemas.go
@@ -26,6 +26,7 @@ var mcpWrapperSchemas = map[string]string{
 	"channel":          channelInputSchema,
 	"agentdef":         agentDefInputSchema,
 	"skilldef":         skillDefInputSchema,
+	"teamdef":          teamDefInputSchema,
 	"mcpserverdef":     mcpServerDefInputSchema,
 	"scheduledef":      scheduleDefInputSchema,
 	"a2aservercarddef": a2aServerCardDefInputSchema,


### PR DESCRIPTION
Phase 2 of **RFC AP — Agent Teams & Task Workflows** (follows the phase-1 store substrate, #690). A `TeamDef` is now **authorable, forkable, and manageable end-to-end over HTTP + MCP**.

## New `internal/teamgraph` package — the definition's domain model
Stdlib-only (no import cycle) so the tool, content-hash, and the future renderer/orchestrator all share one model:
- **graph.go** — `Definition` / `State` / `Handler` / `Transition` / `Colors` (states = nodes, transitions = edges, per-state handler `agent | parallel | consolidator | terminal`) + `Parse`.
- **validate.go** — imperative graph validation: one resolving `entry`; unique non-empty state ids; a valid handler per kind (parallel ⇒ `agents` + `consolidator`; agent/consolidator ⇒ `agent`; terminal is bare); every transition endpoint resolves; well-formed `on` (`success` | `pushback:<reason>` | `conditional:<expr>`); **unique outbound labels per state** (so a consolidator's `next_edge` is unambiguous); terminal states have no outbound; **full reachability from `entry`**; `wait` = `all|any|at_least:<N>`.
- **sign.go** — `content_sha256` over `{name, entry, max_iterations, states, transitions}`; **colours + identity/tenant excluded** (recolour/fork ≠ new identity), mirroring `skills.Sign`.

## New `TeamDef` builtin tool
Cloned from `skilldef.go`: `create/fork/get/list/retire/promote/verify`. create/fork **parse → `Validate` (refuse + persist nothing on an invalid graph) → `Sign`**. Overlay is a per-top-level-field merge of the graph (slices replace wholesale — a graph is cohesive). No static-config collision, no per-agent scope gate (the route's `ScopeTenant` guards it — a noted MVP simplification), no tools-ceiling.

## Wiring (mirrors SkillDef)
`Connector.TeamDef`; HTTP **`POST /v1/_teamdef`** + **`GET /v1/_teamdef/names`** (`ScopeTenant`, tenant-scoped names); MCP **`teamdef`** meta-tool; tool constructed + registered in `main.go` (reuses the AgentDef byte caps). RFC N tenant isolation preserved.

## Deferred to a follow-up (noted)
The gRPC `TeamDef` RPC (substrate defs use per-family proto RPCs → needs a new proto message + codegen) and the TS/Python adapter twins. **HTTP + MCP fully cover authoring today.**

## Tested
`teamgraph` validator (valid SDLC + 17 rejection cases) + `Sign` (determinism, colours-excluded); the `TeamDef` tool (create / validate-refusal / colours-only-fork-keeps-hash / graph-fork-changes-hash / get / list / retire / promote / verify) on in-memory sqlite; MCP tools-list count + HTTP route-scope + a create/invalid-422/names handler test updated. `go test ./...` + `gofmt`/`go vet` clean.

Next in the RFC AP rollout: **`render_diagram`** (Mermaid + colour scheme) → **`team/orchestrator`** runtime → **`agent-teams` bundle**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)