### PR TITLE
feat(teamrun): orchestrator walk engine + agent runner (RFC AP phase 4)

### DIFF
--- a/internal/teamgraph/walk.go
+++ b/internal/teamgraph/walk.go
@@ -1,0 +1,37 @@
+package teamgraph
+
+// Pure graph-walk helpers shared by the runtime orchestrator (internal/teamrun).
+// They read the Definition; they never execute a handler — that's the runner's
+// job. Kept here (stdlib-only) so the orchestrator depends only on the model.
+
+// StateByID returns the state with the given id.
+func StateByID(d Definition, id string) (State, bool) {
+	for _, s := range d.States {
+		if s.ID == id {
+			return s, true
+		}
+	}
+	return State{}, false
+}
+
+// NextState resolves the outbound transition from `from` whose `on` label equals
+// `on` (e.g. "success", "pushback:code-fix"), returning the destination state
+// id. Validate guarantees a state's outbound labels are unique, so at most one
+// transition matches.
+func NextState(d Definition, from, on string) (string, bool) {
+	for _, t := range d.Transitions {
+		if t.From == from && t.On == on {
+			return t.To, true
+		}
+	}
+	return "", false
+}
+
+// EffectiveMaxIterations is the per-state cycle cap: the definition's value, or
+// DefaultMaxIterations when unset (0). Validate rejects negatives.
+func EffectiveMaxIterations(d Definition) int {
+	if d.MaxIterations > 0 {
+		return d.MaxIterations
+	}
+	return DefaultMaxIterations
+}

--- a/internal/teamrun/orchestrator.go
+++ b/internal/teamrun/orchestrator.go
@@ -1,0 +1,141 @@
+// Package teamrun is the runtime orchestrator for RFC AP agent teams: it walks a
+// TeamDef's state graph for one unit of work, running each non-terminal state's
+// handler and following the transition the handler selects, until it reaches a
+// terminal state (done) or a state's per-state cycle cap (ErrIterationCap).
+//
+// The engine is a pure graph-walker. It does NOT spawn agents, read the store,
+// or touch a Document chunk — a Runner does the execution and a Task carries the
+// mutable walk position. This keeps the state-machine logic deterministic and
+// unit-testable with a fake runner; the production wiring (spawning agents via
+// the connector, persisting the position onto a Document chunk, firing an
+// Interruption on the cap, and a trigger surface) is layered on top (a
+// follow-up), not baked into the walk.
+//
+// Phase 1 (RFC AP) exercises single-`agent` handlers + `success`/`pushback`
+// transitions + loops. The engine itself is handler-kind-agnostic beyond
+// stopping at `terminal`: which state runs, how, and which edge it picks are all
+// the Runner's concern, so `parallel`/`consolidator` execution (Phase 3) lands
+// entirely in a richer Runner without changing this walk.
+package teamrun
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/denn-gubsky/loomcycle/internal/teamgraph"
+)
+
+// Runner executes one non-terminal state's handler and reports the outcome. The
+// production runner spawns the state's AgentDef(s) via the connector; a test
+// runner returns canned outcomes. A returned error aborts the walk.
+type Runner interface {
+	RunHandler(ctx context.Context, state teamgraph.State, input string) (Outcome, error)
+}
+
+// Outcome is what a handler produced: the text output (which becomes the next
+// state's input) and the transition label it selected. An empty Edge defaults to
+// teamgraph.OnSuccess, so a linear handler needn't name its single edge.
+type Outcome struct {
+	Output string
+	Edge   string
+}
+
+// Task is the mutable walk position for one unit of work (a Document chunk, or an
+// ephemeral run). The caller persists it between steps — State + IterationCounts
+// ride the chunk's status + fields in production; Input threads handler output to
+// the next state. A zero State starts the walk at the definition's entry.
+type Task struct {
+	State           string
+	Input           string
+	IterationCounts map[string]int
+}
+
+// StepRecord is one executed state, for the caller's trace/audit.
+type StepRecord struct {
+	State   string // the state that ran
+	Handler string // its handler kind
+	Agent   string // the handler's agent (for kind=agent/consolidator)
+	Edge    string // the transition label taken
+	Next    string // the destination state
+	Output  string // the handler's output
+}
+
+// ErrIterationCap is returned when a state is entered more than the definition's
+// per-state cap allows — the caller raises an Interruption. It is a distinct type
+// (not a sentinel) so the caller can read which state and the counts.
+type ErrIterationCap struct {
+	State string
+	Count int
+	Max   int
+}
+
+func (e *ErrIterationCap) Error() string {
+	return fmt.Sprintf("teamrun: state %q exceeded max_iterations (%d > %d)", e.State, e.Count, e.Max)
+}
+
+// Walk drives task from its current state (or the definition's entry when
+// task.State is empty) to a terminal state, mutating task in place as it goes:
+// each non-terminal state's handler runs via r, its selected edge picks the next
+// state, and its output becomes the next input. It returns the ordered trace of
+// executed states.
+//
+// Termination is guaranteed: every non-terminal state increments its own entry
+// count, and exceeding the per-state cap returns *ErrIterationCap. So a
+// pushback loop that never converges is bounded, not infinite.
+func Walk(ctx context.Context, d teamgraph.Definition, task *Task, r Runner) ([]StepRecord, error) {
+	if task == nil {
+		return nil, fmt.Errorf("teamrun: nil task")
+	}
+	if task.State == "" {
+		task.State = d.Entry
+	}
+	if task.IterationCounts == nil {
+		task.IterationCounts = map[string]int{}
+	}
+	max := teamgraph.EffectiveMaxIterations(d)
+
+	var trace []StepRecord
+	for {
+		if err := ctx.Err(); err != nil {
+			return trace, err
+		}
+		st, ok := teamgraph.StateByID(d, task.State)
+		if !ok {
+			return trace, fmt.Errorf("teamrun: current state %q is not in the team definition", task.State)
+		}
+		if st.Handler.Kind == teamgraph.HandlerTerminal {
+			return trace, nil // reached an end state — done
+		}
+
+		// Count this entry before running, and refuse to run past the cap so a
+		// non-converging loop can't spend an extra handler run on overflow.
+		task.IterationCounts[st.ID]++
+		if n := task.IterationCounts[st.ID]; n > max {
+			return trace, &ErrIterationCap{State: st.ID, Count: n, Max: max}
+		}
+
+		out, err := r.RunHandler(ctx, st, task.Input)
+		if err != nil {
+			return trace, fmt.Errorf("teamrun: state %q handler: %w", st.ID, err)
+		}
+		edge := out.Edge
+		if edge == "" {
+			edge = teamgraph.OnSuccess
+		}
+		next, ok := teamgraph.NextState(d, st.ID, edge)
+		if !ok {
+			return trace, fmt.Errorf("teamrun: state %q handler selected edge %q with no matching transition", st.ID, edge)
+		}
+
+		trace = append(trace, StepRecord{
+			State:   st.ID,
+			Handler: st.Handler.Kind,
+			Agent:   st.Handler.Agent,
+			Edge:    edge,
+			Next:    next,
+			Output:  out.Output,
+		})
+		task.Input = out.Output
+		task.State = next
+	}
+}

--- a/internal/teamrun/orchestrator_test.go
+++ b/internal/teamrun/orchestrator_test.go
@@ -1,0 +1,174 @@
+package teamrun
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/teamgraph"
+)
+
+// fakeRunner returns a canned Outcome per state id. A state absent from outcomes
+// returns success with an echoed output; a state in errs returns that error.
+type fakeRunner struct {
+	outcomes map[string]Outcome
+	errs     map[string]error
+	calls    []string // state ids run, in order
+}
+
+func (f *fakeRunner) RunHandler(_ context.Context, st teamgraph.State, input string) (Outcome, error) {
+	f.calls = append(f.calls, st.ID)
+	if err := f.errs[st.ID]; err != nil {
+		return Outcome{}, err
+	}
+	if o, ok := f.outcomes[st.ID]; ok {
+		return o, nil
+	}
+	return Outcome{Output: input + ">" + st.ID}, nil
+}
+
+func mustParse(t *testing.T, s string) teamgraph.Definition {
+	t.Helper()
+	d, err := teamgraph.Parse([]byte(s))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if err := teamgraph.Validate(d); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	return d
+}
+
+const linearJSON = `{
+  "entry":"a",
+  "states":[
+    {"state":"a","handler":{"kind":"agent","agent":"agent-a"}},
+    {"state":"b","handler":{"kind":"agent","agent":"agent-b"}},
+    {"state":"c","handler":{"kind":"terminal"}}
+  ],
+  "transitions":[
+    {"from":"a","to":"b","on":"success"},
+    {"from":"b","to":"c","on":"success"}
+  ]}`
+
+func TestWalk_LinearReachesTerminal(t *testing.T) {
+	d := mustParse(t, linearJSON)
+	r := &fakeRunner{}
+	task := &Task{Input: "seed"}
+	trace, err := Walk(context.Background(), d, task, r)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if got := len(trace); got != 2 {
+		t.Fatalf("trace len = %d, want 2 (terminal not executed)", got)
+	}
+	if r.calls[0] != "a" || r.calls[1] != "b" || len(r.calls) != 2 {
+		t.Errorf("ran %v, want [a b]", r.calls)
+	}
+	if task.State != "c" {
+		t.Errorf("final state = %q, want c (terminal)", task.State)
+	}
+	// Output threads: seed → a → b.
+	if task.Input != "seed>a>b" {
+		t.Errorf("final input = %q, want seed>a>b (output threaded)", task.Input)
+	}
+	if trace[0].Agent != "agent-a" || trace[1].Edge != "success" {
+		t.Errorf("trace metadata wrong: %+v", trace)
+	}
+}
+
+func TestWalk_StartsAtEntryAndIsResumable(t *testing.T) {
+	d := mustParse(t, linearJSON)
+
+	// Empty State → starts at entry (a).
+	r1 := &fakeRunner{}
+	Walk(context.Background(), d, &Task{}, r1)
+	if len(r1.calls) == 0 || r1.calls[0] != "a" {
+		t.Errorf("empty task should start at entry a, ran %v", r1.calls)
+	}
+
+	// Preset State → resumes there (b), does NOT restart at entry. Proves the
+	// walk is resumable from a persisted chunk position.
+	r2 := &fakeRunner{}
+	Walk(context.Background(), d, &Task{State: "b"}, r2)
+	if len(r2.calls) != 1 || r2.calls[0] != "b" {
+		t.Errorf("preset state=b should resume at b only, ran %v", r2.calls)
+	}
+}
+
+func TestWalk_PushbackLoopHitsIterationCap(t *testing.T) {
+	// a --success--> b ; b --pushback:redo--> a ; b --success--> done.
+	// The fake b always pushes back, so the loop never converges and the cap
+	// must fire (deterministic: entry state a is entered first each cycle).
+	d := mustParse(t, `{
+	  "entry":"a",
+	  "max_iterations":3,
+	  "states":[
+	    {"state":"a","handler":{"kind":"agent","agent":"a"}},
+	    {"state":"b","handler":{"kind":"agent","agent":"b"}},
+	    {"state":"done","handler":{"kind":"terminal"}}
+	  ],
+	  "transitions":[
+	    {"from":"a","to":"b","on":"success"},
+	    {"from":"b","to":"a","on":"pushback:redo"},
+	    {"from":"b","to":"done","on":"success"}
+	  ]}`)
+	r := &fakeRunner{outcomes: map[string]Outcome{
+		"b": {Output: "needs work", Edge: "pushback:redo"},
+	}}
+	_, err := Walk(context.Background(), d, &Task{}, r)
+	var cap *ErrIterationCap
+	if !errors.As(err, &cap) {
+		t.Fatalf("want *ErrIterationCap, got %v", err)
+	}
+	if cap.State != "a" || cap.Max != 3 || cap.Count != 4 {
+		t.Errorf("cap = %+v, want state=a max=3 count=4", cap)
+	}
+}
+
+func TestWalk_UnknownEdgeErrors(t *testing.T) {
+	d := mustParse(t, linearJSON)
+	r := &fakeRunner{outcomes: map[string]Outcome{
+		"a": {Edge: "pushback:nope"}, // no such transition from a
+	}}
+	_, err := Walk(context.Background(), d, &Task{}, r)
+	if err == nil || !contains(err.Error(), "no matching transition") {
+		t.Fatalf("want no-matching-transition error, got %v", err)
+	}
+}
+
+func TestWalk_HandlerErrorPropagates(t *testing.T) {
+	// The Phase-1 production runner errors on a parallel handler; the engine
+	// must surface that error and stop, not swallow it.
+	d := mustParse(t, `{
+	  "entry":"fan",
+	  "states":[
+	    {"state":"fan","handler":{"kind":"parallel","agents":["x","y"],"consolidator":"c"}},
+	    {"state":"end","handler":{"kind":"terminal"}}
+	  ],
+	  "transitions":[{"from":"fan","to":"end","on":"success"}]}`)
+	r := &fakeRunner{errs: map[string]error{"fan": errors.New("parallel not supported in phase 1")}}
+	_, err := Walk(context.Background(), d, &Task{}, r)
+	if err == nil || !contains(err.Error(), "parallel not supported") {
+		t.Fatalf("want handler error propagated, got %v", err)
+	}
+}
+
+func TestWalk_ContextCancelAborts(t *testing.T) {
+	d := mustParse(t, linearJSON)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := Walk(ctx, d, &Task{}, &fakeRunner{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, got %v", err)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/teamrun/spawn.go
+++ b/internal/teamrun/spawn.go
@@ -1,0 +1,50 @@
+package teamrun
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/denn-gubsky/loomcycle/internal/teamgraph"
+)
+
+// SpawnFunc runs one named agent with an input prompt and returns its final text
+// output. It mirrors builtin.SubAgentRunner exactly, so the orchestrator reuses
+// the existing sub-agent machinery (tenant/identity inheritance, the recursion
+// depth cap, the cancel registry) rather than re-implementing run dispatch.
+type SpawnFunc func(ctx context.Context, agent, input, defID string) (string, error)
+
+// NewAgentRunner returns the Phase-1 production Runner: a single-`agent` state's
+// AgentDef is run via spawn, and its output flows to the next state along the
+// `success` edge.
+//
+// A `parallel`/`consolidator` handler, or an `agent` handler with a consolidator
+// (consolidator-driven edge selection — i.e. pushback), is Phase 3 and returns
+// an error here. The walk surfaces that error and stops, so a team authored with
+// routing it can't yet execute fails loudly instead of silently taking success.
+func NewAgentRunner(spawn SpawnFunc) Runner {
+	return &agentRunner{spawn: spawn}
+}
+
+type agentRunner struct {
+	spawn SpawnFunc
+}
+
+func (r *agentRunner) RunHandler(ctx context.Context, st teamgraph.State, input string) (Outcome, error) {
+	switch st.Handler.Kind {
+	case teamgraph.HandlerAgent:
+		if st.Handler.Consolidator != "" {
+			return Outcome{}, fmt.Errorf("state %q has a consolidator — consolidator-driven edge selection is not supported yet (Phase 3)", st.ID)
+		}
+		out, err := r.spawn(ctx, st.Handler.Agent, input, "")
+		if err != nil {
+			return Outcome{}, err
+		}
+		// No consolidator → a single-agent state advances on success.
+		return Outcome{Output: out}, nil
+	case teamgraph.HandlerParallel, teamgraph.HandlerConsolidator:
+		return Outcome{}, fmt.Errorf("handler kind %q is not supported yet (Phase 3: parallel fan-out + consolidator)", st.Handler.Kind)
+	default:
+		// terminal is handled by the walk; anything else is a validation gap.
+		return Outcome{}, fmt.Errorf("unexpected handler kind %q", st.Handler.Kind)
+	}
+}

--- a/internal/teamrun/spawn_test.go
+++ b/internal/teamrun/spawn_test.go
@@ -1,0 +1,89 @@
+package teamrun
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+func TestAgentRunner_WalksLinearTeamViaSpawn(t *testing.T) {
+	d := mustParse(t, linearJSON)
+
+	// Fake spawn: echoes which agent ran + the input, so we can assert the
+	// output threads state to state.
+	var spawned []string
+	spawn := func(_ context.Context, agent, input, defID string) (string, error) {
+		spawned = append(spawned, agent)
+		return fmt.Sprintf("%s(%s)", agent, input), nil
+	}
+
+	task := &Task{Input: "go"}
+	trace, err := Walk(context.Background(), d, task, NewAgentRunner(spawn))
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if len(spawned) != 2 || spawned[0] != "agent-a" || spawned[1] != "agent-b" {
+		t.Errorf("spawned %v, want [agent-a agent-b]", spawned)
+	}
+	// b's input is a's output: agent-a(go) → agent-b(agent-a(go)).
+	if task.Input != "agent-b(agent-a(go))" {
+		t.Errorf("final input = %q, want agent-b(agent-a(go))", task.Input)
+	}
+	if trace[1].Edge != "success" {
+		t.Errorf("linear agent handler should advance on success, got %q", trace[1].Edge)
+	}
+}
+
+func TestAgentRunner_SpawnErrorStopsWalk(t *testing.T) {
+	d := mustParse(t, linearJSON)
+	spawn := func(_ context.Context, agent, input, defID string) (string, error) {
+		if agent == "agent-b" {
+			return "", fmt.Errorf("boom")
+		}
+		return "ok", nil
+	}
+	_, err := Walk(context.Background(), d, &Task{}, NewAgentRunner(spawn))
+	if err == nil || !contains(err.Error(), "boom") {
+		t.Fatalf("spawn error should abort the walk, got %v", err)
+	}
+}
+
+func TestAgentRunner_ParallelHandlerNotYetSupported(t *testing.T) {
+	d := mustParse(t, `{
+	  "entry":"fan",
+	  "states":[
+	    {"state":"fan","handler":{"kind":"parallel","agents":["x","y"],"consolidator":"c"}},
+	    {"state":"end","handler":{"kind":"terminal"}}
+	  ],
+	  "transitions":[{"from":"fan","to":"end","on":"success"}]}`)
+	called := false
+	spawn := func(_ context.Context, agent, input, defID string) (string, error) { called = true; return "", nil }
+	_, err := Walk(context.Background(), d, &Task{}, NewAgentRunner(spawn))
+	if err == nil || !contains(err.Error(), "Phase 3") {
+		t.Fatalf("parallel handler should be a Phase-3 not-supported error, got %v", err)
+	}
+	if called {
+		t.Errorf("spawn must not be called for an unsupported handler")
+	}
+}
+
+func TestAgentRunner_ConsolidatorOnAgentNotYetSupported(t *testing.T) {
+	// An agent handler with a consolidator = consolidator-driven edge selection
+	// (pushback) — Phase 3. Must fail loudly, not silently take success.
+	d := mustParse(t, `{
+	  "entry":"impl",
+	  "states":[
+	    {"state":"impl","handler":{"kind":"agent","agent":"coder","consolidator":"judge"}},
+	    {"state":"impl2","handler":{"kind":"agent","agent":"coder2"}},
+	    {"state":"done","handler":{"kind":"terminal"}}
+	  ],
+	  "transitions":[
+	    {"from":"impl","to":"impl2","on":"success"},
+	    {"from":"impl2","to":"done","on":"success"}
+	  ]}`)
+	spawn := func(_ context.Context, agent, input, defID string) (string, error) { return "", nil }
+	_, err := Walk(context.Background(), d, &Task{}, NewAgentRunner(spawn))
+	if err == nil || !contains(err.Error(), "consolidator") {
+		t.Fatalf("agent-with-consolidator should be a Phase-3 error, got %v", err)
+	}
+}


### PR DESCRIPTION
Phase 4 of **RFC AP — Agent Teams & Task Workflows** (follows #690 store, #691 tool, #692 render). The runtime that **walks a TeamDef's state graph** for one unit of work: run each non-terminal state's handler → follow the transition it selects → until a terminal state (done) or a per-state cycle cap.

## `internal/teamgraph/walk.go`
Pure graph-walk helpers the orchestrator reads: `StateByID`, `NextState` (resolve the outbound transition for an `on` label), `EffectiveMaxIterations` (def value or the default). No execution.

## `internal/teamrun` (new package)
- **`orchestrator.go` — `Walk(ctx, def, task, runner) []StepRecord`.** A **pure graph-walker**: it does *not* spawn agents, read the store, or touch a chunk. A `Runner` executes each state's handler; a `Task{State, Input, IterationCounts}` carries the mutable walk position — so the walk is **resumable** from a persisted position and unit-testable with a fake runner. **Termination is guaranteed**: every non-terminal state increments its own entry count, and exceeding the cap returns a typed **`*ErrIterationCap`** (the caller raises an Interruption). The engine is handler-kind-agnostic beyond stopping at `terminal`, so **parallel/consolidator execution (Phase 3) lands in a richer Runner without touching the walk**.
- **`spawn.go` — the Phase-1 production Runner (`NewAgentRunner`)**, bridging `builtin.SubAgentRunner`'s exact signature so it reuses the existing sub-agent machinery (tenant/identity inheritance, recursion cap, cancel registry). A single-`agent` state runs its AgentDef and advances on `success`; a `parallel`/`consolidator` handler — or an `agent` handler **with** a consolidator (consolidator-driven edge selection / pushback) — is **Phase 3** and errors loudly rather than silently taking success.

## Deliberately deferred to PR 5 (the wiring)
The transport entry point (a `run` op / trigger), **Document-chunk binding** (walk position ↔ chunk `status`/`fields`), the Interruption-on-cap, and the **agent-teams bundle**. Teams have no static config layer, so no `internal/lookup/team.go` is needed — resolution is `store.TeamDefGetActive` directly (in PR 5).

## Tested
Linear walk reaches terminal + threads output→input; starts at entry / resumes from a preset state; a non-converging pushback loop hits the cap (`*ErrIterationCap`, exact state/count); unknown-edge + handler-error propagation; context-cancel aborts; the agent runner walks a linear team via a fake spawn, propagates spawn errors, and rejects parallel / agent-with-consolidator. `go test ./...` + `gofmt`/`go vet` clean.

Next: **PR 5** — wire the runner to a trigger + Document chunks, raise the Interruption on cap, and ship the `agent-teams` bundle (`agent/assistant` + `team/assistant` + `team/*` skills).

🤖 Generated with [Claude Code](https://claude.com/claude-code)