### PR TITLE
fix(teamdef): route op=run through run admission (RFC AP review #1)

### DIFF
--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -799,18 +799,46 @@ func (s *Server) SetTeamDefTool(t tools.Tool) {
 	// tool with only the store + byte caps; the runner lives on the server, so
 	// inject it here (mirrors the AgentTool.Run closure above).
 	//
-	// NOT yet enforced on this path (tracked follow-ups): the agent-depth guard
-	// (it lives in AgentTool.Execute, which op=run bypasses) and RunOnce
-	// admission (RFC AW token budget + deriving the RFC AX operator-key
-	// restriction). A DIRECT op=run over HTTP/MCP therefore doesn't budget-gate
-	// or depth-bound its spawned tree — see the RFC AP review findings.
-	if td, ok := t.(*builtin.TeamDef); ok && td.Spawn == nil {
-		td.Spawn = func(ctx context.Context, name, prompt, defID string) (string, error) {
-			out, _, err := s.runSubAgent(ctx, name, prompt, defID)
-			return out, err
+	if td, ok := t.(*builtin.TeamDef); ok {
+		if td.Spawn == nil {
+			td.Spawn = func(ctx context.Context, name, prompt, defID string) (string, error) {
+				out, _, err := s.runSubAgent(ctx, name, prompt, defID)
+				return out, err
+			}
+		}
+		if td.Admit == nil {
+			td.Admit = s.admitTeamRun
 		}
 	}
 	s.teamDefTool = t
+}
+
+// admitTeamRun gates a `TeamDef op=run` once, before the walk. op=run is a
+// run-trigger reachable over HTTP /v1/_teamdef + the MCP teamdef meta-tool that
+// does NOT pass through RunOnce, so without this a direct call would spawn a
+// team's agents with none of RunOnce's admission. It enforces, and returns a ctx
+// the walk (and thus every spawned sub-run) runs under:
+//   - the agent-depth bound (op=run bypasses AgentTool.Execute's guard, so the
+//     walk counts as one nesting level — its agents + any nested op=run are
+//     bounded like sub-agents);
+//   - the RFC AW token-budget hard ceiling (refuse before spawning anything);
+//   - the RFC AX operator-key restriction (derived from the caller's principal,
+//     stamped on the RunIdentity + provider ctx so restricted callers can't fall
+//     back to the operator's keys through the spawned agents).
+func (s *Server) admitTeamRun(ctx context.Context) (context.Context, error) {
+	if builtin.AgentDepth(ctx) >= builtin.MaxAgentDepth {
+		return nil, fmt.Errorf("team run exceeds max agent depth %d (nested too deep)", builtin.MaxAgentDepth)
+	}
+	id := tools.RunIdentity(ctx)
+	if dec := s.limits.Check(id.TenantID, id.UserID); !dec.Allowed {
+		return nil, fmt.Errorf("%w: %s", runner.ErrTokenLimitExceeded, dec.Refusal.Message)
+	}
+	restricted := s.operatorKeyRestrictedOrCaptured(ctx, id.OperatorKeyRestricted)
+	id.OperatorKeyRestricted = restricted
+	ctx = tools.WithRunIdentity(ctx, id)
+	ctx = providers.WithOperatorKeyAllowed(ctx, !restricted)
+	ctx = builtin.IncrementAgentDepth(ctx)
+	return ctx, nil
 }
 
 // SetA2AServerCardDefTool wires the v1.x RFC G A2AServerCardDef substrate

--- a/internal/api/http/teamdef_admission_test.go
+++ b/internal/api/http/teamdef_admission_test.go
@@ -1,0 +1,46 @@
+package http
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/limits"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
+)
+
+// admitTeamRun is the op=run admission gate (RFC AP review finding #1): op=run
+// does not pass through RunOnce, so this enforces the agent-depth bound, the RFC
+// AW token budget, and the RFC AX operator-key restriction before a team walk.
+
+func TestAdmitTeamRun_RefusesAtMaxDepth(t *testing.T) {
+	s := &Server{cfg: &config.Config{}, limits: limits.New(nil)}
+	ctx := context.Background()
+	for i := 0; i < builtin.MaxAgentDepth; i++ {
+		ctx = builtin.IncrementAgentDepth(ctx)
+	}
+	if _, err := s.admitTeamRun(ctx); err == nil || !strings.Contains(err.Error(), "max agent depth") {
+		t.Fatalf("op=run at max depth should be refused, got %v", err)
+	}
+}
+
+func TestAdmitTeamRun_AllowsAndIncrementsDepth(t *testing.T) {
+	s := &Server{cfg: &config.Config{}, limits: limits.New(nil)} // no-op tracker → always allowed
+	ctx := tools.WithRunIdentity(context.Background(), tools.RunIdentityValue{TenantID: "acme", UserID: "u1"})
+
+	out, err := s.admitTeamRun(ctx)
+	if err != nil {
+		t.Fatalf("admit: %v", err)
+	}
+	// The walk counts as one nesting level so its spawned agents are bounded.
+	if got := builtin.AgentDepth(out); got != 1 {
+		t.Errorf("admitted depth = %d, want 1", got)
+	}
+	// No principal + gate off → not restricted → operator key allowed on the ctx.
+	if !providers.OperatorKeyAllowed(out) {
+		t.Errorf("unrestricted run should allow the operator key")
+	}
+}

--- a/internal/tools/builtin/teamdef.go
+++ b/internal/tools/builtin/teamdef.go
@@ -54,10 +54,19 @@ type TeamDef struct {
 
 	// Spawn runs one of a team's agents and returns its output. It mirrors the
 	// Agent tool's SubAgentRunner exactly, so op=run reuses the existing
-	// sub-agent machinery (tenant/identity inheritance, recursion cap, cancel
-	// registry). Wired by the server via SetTeamDefTool; nil = op=run refuses
-	// with "not configured for execution" (authoring ops still work).
+	// sub-agent machinery (tenant/identity inheritance, cancel registry). Wired
+	// by the server via SetTeamDefTool; nil = op=run refuses with "not configured
+	// for execution" (authoring ops still work).
 	Spawn teamrun.SpawnFunc
+
+	// Admit, if set, gates op=run once before the walk: op=run is a run-trigger
+	// that does NOT pass through RunOnce, so without this a DIRECT HTTP/MCP call
+	// would spawn a team's agents with no RFC AW token-budget check, no RFC AX
+	// operator-key restriction, and no agent-depth bound. Admit enforces those
+	// and returns a ctx enriched with the restriction + an incremented depth for
+	// the walk (used for every spawned agent), or an error that aborts the run.
+	// nil = no admission (unit tests / authoring-only wiring).
+	Admit func(ctx context.Context) (context.Context, error)
 }
 
 const teamDefDescription = `Author, fork, promote, retire, and inspect team workflow definitions at runtime (RFC AP). ` +
@@ -536,8 +545,20 @@ func (t *TeamDef) execRun(ctx context.Context, in teamDefInput) (tools.Result, e
 		return errResult(fmt.Sprintf("run: %s", err)), nil
 	}
 
+	// Run admission (op=run bypasses RunOnce): enforce the token budget +
+	// operator-key restriction + agent-depth bound, and walk under the enriched
+	// ctx so every spawned agent inherits them. A refusal (over budget / too
+	// deep) aborts before any agent is spawned.
+	walkCtx := ctx
+	if t.Admit != nil {
+		walkCtx, err = t.Admit(ctx)
+		if err != nil {
+			return errResult(fmt.Sprintf("run: %s", err)), nil
+		}
+	}
+
 	task := &teamrun.Task{Input: in.Input}
-	trace, walkErr := teamrun.Walk(ctx, def, task, teamrun.NewAgentRunner(t.Spawn))
+	trace, walkErr := teamrun.Walk(walkCtx, def, task, teamrun.NewAgentRunner(t.Spawn))
 
 	steps := make([]map[string]any, 0, len(trace))
 	for _, s := range trace {

--- a/internal/tools/builtin/teamdef_test.go
+++ b/internal/tools/builtin/teamdef_test.go
@@ -3,12 +3,15 @@ package builtin
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
+
+type admitMarkerKey struct{}
 
 // A minimal valid team graph: entry state runs an agent, then a success edge
 // to a terminal state. Validates cleanly (entry resolves, unique states, valid
@@ -92,6 +95,71 @@ func TestTeamDefTool_Run_LinearTeam(t *testing.T) {
 	}
 	if steps, _ := out["steps"].([]any); len(steps) != 2 {
 		t.Errorf("steps len = %d, want 2", len(steps))
+	}
+}
+
+func TestTeamDefTool_Run_AdmitRefusalAbortsBeforeSpawn(t *testing.T) {
+	tool, ctx, done := teamDefFixture(t)
+	defer done()
+
+	spawnCalled := false
+	tool.Spawn = func(_ context.Context, agent, input, defID string) (string, error) {
+		spawnCalled = true
+		return "ok", nil
+	}
+	// Admit refuses (e.g. token budget exceeded / too deep) → the walk must not
+	// start and no agent may be spawned.
+	tool.Admit = func(c context.Context) (context.Context, error) {
+		return nil, errors.New("token budget exceeded: tenant acme over hard ceiling")
+	}
+	createTeam(t, tool, ctx, "admit-refuse", `{
+	  "entry":"a",
+	  "states":[
+	    {"state":"a","handler":{"kind":"agent","agent":"agent-a"}},
+	    {"state":"done","handler":{"kind":"terminal"}}
+	  ],
+	  "transitions":[{"from":"a","to":"done","on":"success"}]}`)
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"run","name":"admit-refuse","input":"x"}`))
+	if !res.IsError || !strings.Contains(res.Text, "token budget exceeded") {
+		t.Fatalf("admission refusal should abort the run; got %q (isErr=%v)", res.Text, res.IsError)
+	}
+	if spawnCalled {
+		t.Errorf("no agent may be spawned when admission refuses")
+	}
+}
+
+func TestTeamDefTool_Run_AdmittedCtxFlowsToSpawn(t *testing.T) {
+	tool, ctx, done := teamDefFixture(t)
+	defer done()
+
+	// Admit enriches the ctx; the Spawn closure must run under THAT ctx (proving
+	// the operator-key restriction / depth increment the real Admit stamps reach
+	// every spawned agent).
+	tool.Admit = func(c context.Context) (context.Context, error) {
+		return context.WithValue(c, admitMarkerKey{}, "admitted"), nil
+	}
+	sawMarker := false
+	tool.Spawn = func(c context.Context, agent, input, defID string) (string, error) {
+		if c.Value(admitMarkerKey{}) == "admitted" {
+			sawMarker = true
+		}
+		return "ok", nil
+	}
+	createTeam(t, tool, ctx, "admit-ctx", `{
+	  "entry":"a",
+	  "states":[
+	    {"state":"a","handler":{"kind":"agent","agent":"agent-a"}},
+	    {"state":"done","handler":{"kind":"terminal"}}
+	  ],
+	  "transitions":[{"from":"a","to":"done","on":"success"}]}`)
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"run","name":"admit-ctx","input":"x"}`))
+	if res.IsError {
+		t.Fatalf("run: %s", res.Text)
+	}
+	if !sawMarker {
+		t.Errorf("spawn did not run under the admitted ctx")
 	}
 }
 


### PR DESCRIPTION
Closes the highest-severity finding from the RFC AP full-feature review (#1).

## Problem
`TeamDef op=run` is a run-trigger reachable over HTTP `/v1/_teamdef` + the MCP `teamdef` meta-tool, but it does **not** pass through `RunOnce`. So a *direct* call spawned a team's agents with none of `RunOnce`'s admission:
- **RFC AX** — the operator-key restriction was never derived, so a restricted/BYOK tenant's team agents fell back to the operator's host API keys.
- **RFC AW** — no token-budget hard-ceiling check; an over-budget tenant (429'd on `POST /v1/runs`) could still burn spend through op=run.
- **Agent-depth** — the guard lives in `AgentTool.Execute`, which op=run bypasses, so the spawned tree was unbounded.

## Fix — one admission gate, run once before the walk
- `TeamDef` gains an `Admit func(ctx) (context.Context, error)` seam; `execRun` calls it before spawning anything and walks under the returned ctx, so **every spawned sub-run inherits the enriched ctx**. A refusal aborts before any agent runs.
- The server wires `admitTeamRun`:
  - refuse at `builtin.MaxAgentDepth` (the walk counts as one nesting level → its agents + any nested op=run are bounded like sub-agents);
  - enforce the RFC AW hard ceiling via `s.limits.Check` (refuse with `runner.ErrTokenLimitExceeded`);
  - derive the RFC AX restriction via `operatorKeyRestrictedOrCaptured` (principal-derived on the direct paths, else the captured bit) and stamp it on the `RunIdentity` + `providers.WithOperatorKeyAllowed`, so `runSubAgent` inherits it into every sub-run + the resolver/driver backstop.

`nil` Admit = no admission (unit tests / authoring-only wiring), matching the `nil` Spawn convention. In-loop op=run is unchanged where it already inherited the bit; this closes the **direct-call** bypass.

## Tested
Admission refusal aborts before any spawn; the admitted ctx flows to the spawn closure; `admitTeamRun` refuses at max depth and, on the happy path, allows + increments depth + leaves the operator key allowed for an unrestricted run. `go test ./...` + gofmt/vet clean.

Next in the review-follow-up sequence: **#2** — carry `TenantID` through snapshot capture/restore for all def families.

🤖 Generated with [Claude Code](https://claude.com/claude-code)