### PR TITLE
fix(snapshot): carry tenant_id through def snapshots (RFC AP review #2)

### DIFF
--- a/internal/snapshot/restore.go
+++ b/internal/snapshot/restore.go
@@ -147,6 +147,7 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 		for _, e := range sec.Entries {
 			inserted, err := s.SnapshotRestoreAgentDef(ctx, store.AgentDefRow{
 				DefID:                  e.DefID,
+				TenantID:               e.TenantID,
 				Name:                   e.Name,
 				Version:                e.Version,
 				ParentDefID:            e.ParentDefID,
@@ -178,6 +179,7 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 		for _, e := range sec.Entries {
 			inserted, err := s.SnapshotRestoreAgentDefActive(ctx, store.AgentDefActiveEntry{
 				Name:              e.Name,
+				TenantID:          e.TenantID,
 				DefID:             e.DefID,
 				PromotedAt:        e.PromotedAt,
 				PromotedByAgentID: e.PromotedByAgentID,
@@ -201,6 +203,7 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 		for _, e := range sec.Entries {
 			inserted, err := s.SnapshotRestoreSkillDef(ctx, store.SkillDefRow{
 				DefID:                  e.DefID,
+				TenantID:               e.TenantID,
 				Name:                   e.Name,
 				Version:                e.Version,
 				ParentDefID:            e.ParentDefID,
@@ -232,6 +235,7 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 		for _, e := range sec.Entries {
 			inserted, err := s.SnapshotRestoreSkillDefActive(ctx, store.SkillDefActiveEntry{
 				Name:              e.Name,
+				TenantID:          e.TenantID,
 				DefID:             e.DefID,
 				PromotedAt:        e.PromotedAt,
 				PromotedByAgentID: e.PromotedByAgentID,
@@ -255,6 +259,7 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 		for _, e := range sec.Entries {
 			inserted, err := s.SnapshotRestoreTeamDef(ctx, store.TeamDefRow{
 				DefID:                  e.DefID,
+				TenantID:               e.TenantID,
 				Name:                   e.Name,
 				Version:                e.Version,
 				ParentDefID:            e.ParentDefID,
@@ -286,6 +291,7 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 		for _, e := range sec.Entries {
 			inserted, err := s.SnapshotRestoreTeamDefActive(ctx, store.TeamDefActiveEntry{
 				Name:              e.Name,
+				TenantID:          e.TenantID,
 				DefID:             e.DefID,
 				PromotedAt:        e.PromotedAt,
 				PromotedByAgentID: e.PromotedByAgentID,
@@ -309,6 +315,7 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 		for _, e := range sec.Entries {
 			inserted, err := s.SnapshotRestoreMCPServerDef(ctx, store.MCPServerDefRow{
 				DefID:                  e.DefID,
+				TenantID:               e.TenantID,
 				Name:                   e.Name,
 				Version:                e.Version,
 				ParentDefID:            e.ParentDefID,
@@ -340,6 +347,7 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 		for _, e := range sec.Entries {
 			inserted, err := s.SnapshotRestoreMCPServerDefActive(ctx, store.MCPServerDefActiveEntry{
 				Name:              e.Name,
+				TenantID:          e.TenantID,
 				DefID:             e.DefID,
 				PromotedAt:        e.PromotedAt,
 				PromotedByAgentID: e.PromotedByAgentID,

--- a/internal/snapshot/restore_test.go
+++ b/internal/snapshot/restore_test.go
@@ -116,6 +116,79 @@ func TestRoundTrip_WithMemoryAndAgentDefs(t *testing.T) {
 	}
 }
 
+// TestRoundTrip_PreservesDefTenantID pins the RFC AP review #2 fix: a snapshot
+// capture→restore must PRESERVE each def's owning tenant. Before the fix the
+// snapshot DTO types dropped tenant_id, so every def (Agent/Skill/Team/MCPServer)
+// collapsed to the shared "" tenant on restore — a cross-tenant disclosure +
+// same-name active-pointer collisions. This seeds each family under a DISTINCT
+// tenant and asserts the tenant round-trips, including the active pointer.
+func TestRoundTrip_PreservesDefTenantID(t *testing.T) {
+	src, srcClose := newTestStore(t)
+	defer srcClose()
+	dst, dstClose := newTestStore(t)
+	defer dstClose()
+	ctx := context.Background()
+
+	def := json.RawMessage(`{"x":1}`)
+	if _, err := src.AgentDefCreate(ctx, store.AgentDefRow{DefID: "ad1", Name: "a", Version: 1, TenantID: "acme", Definition: def}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := src.SkillDefCreate(ctx, store.SkillDefRow{DefID: "sd1", Name: "s", Version: 1, TenantID: "beta", Definition: def}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := src.TeamDefCreate(ctx, store.TeamDefRow{DefID: "td1", Name: "t", Version: 1, TenantID: "gamma", Definition: def}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := src.MCPServerDefCreate(ctx, store.MCPServerDefRow{DefID: "md1", Name: "m", Version: 1, TenantID: "delta", Definition: def}); err != nil {
+		t.Fatal(err)
+	}
+	// An active pointer in a non-empty tenant — the active section must carry it too.
+	if err := src.AgentDefSetActive(ctx, "acme", "a", "ad1", "agentX"); err != nil {
+		t.Fatal(err)
+	}
+
+	_, raw, err := Capture(ctx, src, CaptureOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Restore(ctx, dst, raw, RestoreOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	tenantOf := func(kind string) string {
+		switch kind {
+		case "agent":
+			d, _ := dst.SnapshotReadAgentDefs(ctx)
+			return d[0].TenantID
+		case "skill":
+			d, _ := dst.SnapshotReadSkillDefs(ctx)
+			return d[0].TenantID
+		case "team":
+			d, _ := dst.SnapshotReadTeamDefs(ctx)
+			return d[0].TenantID
+		case "mcp":
+			d, _ := dst.SnapshotReadMCPServerDefs(ctx)
+			return d[0].TenantID
+		}
+		return ""
+	}
+	for _, tc := range []struct{ kind, want string }{
+		{"agent", "acme"}, {"skill", "beta"}, {"team", "gamma"}, {"mcp", "delta"},
+	} {
+		if got := tenantOf(tc.kind); got != tc.want {
+			t.Errorf("%s def restored under tenant %q, want %q (tenant dropped)", tc.kind, got, tc.want)
+		}
+	}
+	// The active pointer's tenant must survive too.
+	act, err := dst.SnapshotReadAgentDefActive(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(act) != 1 || act[0].TenantID != "acme" {
+		t.Errorf("agent_def_active restored = %+v, want tenant acme", act)
+	}
+}
+
 // TestRoundTrip_PreservesAgentDefSampling pins the v0.28.0 contract that a
 // substrate-authored agent's per-agent LLM sampling block (temperature, top_p,
 // seed, stop — the breeder/exp6 path) survives capture → Export (the external

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -213,6 +213,7 @@ func captureAgentDefs(ctx context.Context, s store.Store, out *AgentDefsSection)
 	for _, r := range rows {
 		out.Entries = append(out.Entries, AgentDefEntry{
 			DefID:                  r.DefID,
+			TenantID:               r.TenantID,
 			Name:                   r.Name,
 			Version:                r.Version,
 			ParentDefID:            r.ParentDefID,
@@ -239,6 +240,7 @@ func captureAgentDefActive(ctx context.Context, s store.Store, out *AgentDefActi
 	for _, r := range rows {
 		out.Entries = append(out.Entries, AgentDefActiveEntry{
 			Name:              r.Name,
+			TenantID:          r.TenantID,
 			DefID:             r.DefID,
 			PromotedAt:        r.PromotedAt,
 			PromotedByAgentID: r.PromotedByAgentID,
@@ -258,6 +260,7 @@ func captureSkillDefs(ctx context.Context, s store.Store, out *SkillDefsSection)
 	for _, r := range rows {
 		out.Entries = append(out.Entries, SkillDefEntry{
 			DefID:                  r.DefID,
+			TenantID:               r.TenantID,
 			Name:                   r.Name,
 			Version:                r.Version,
 			ParentDefID:            r.ParentDefID,
@@ -284,6 +287,7 @@ func captureSkillDefActive(ctx context.Context, s store.Store, out *SkillDefActi
 	for _, r := range rows {
 		out.Entries = append(out.Entries, SkillDefActiveEntry{
 			Name:              r.Name,
+			TenantID:          r.TenantID,
 			DefID:             r.DefID,
 			PromotedAt:        r.PromotedAt,
 			PromotedByAgentID: r.PromotedByAgentID,
@@ -303,6 +307,7 @@ func captureTeamDefs(ctx context.Context, s store.Store, out *TeamDefsSection) e
 	for _, r := range rows {
 		out.Entries = append(out.Entries, TeamDefEntry{
 			DefID:                  r.DefID,
+			TenantID:               r.TenantID,
 			Name:                   r.Name,
 			Version:                r.Version,
 			ParentDefID:            r.ParentDefID,
@@ -329,6 +334,7 @@ func captureTeamDefActive(ctx context.Context, s store.Store, out *TeamDefActive
 	for _, r := range rows {
 		out.Entries = append(out.Entries, TeamDefActiveEntry{
 			Name:              r.Name,
+			TenantID:          r.TenantID,
 			DefID:             r.DefID,
 			PromotedAt:        r.PromotedAt,
 			PromotedByAgentID: r.PromotedByAgentID,
@@ -350,6 +356,7 @@ func captureMCPServerDefs(ctx context.Context, s store.Store, out *MCPServerDefs
 	for _, r := range rows {
 		out.Entries = append(out.Entries, MCPServerDefEntry{
 			DefID:                  r.DefID,
+			TenantID:               r.TenantID,
 			Name:                   r.Name,
 			Version:                r.Version,
 			ParentDefID:            r.ParentDefID,
@@ -376,6 +383,7 @@ func captureMCPServerDefActive(ctx context.Context, s store.Store, out *MCPServe
 	for _, r := range rows {
 		out.Entries = append(out.Entries, MCPServerDefActiveEntry{
 			Name:              r.Name,
+			TenantID:          r.TenantID,
 			DefID:             r.DefID,
 			PromotedAt:        r.PromotedAt,
 			PromotedByAgentID: r.PromotedByAgentID,

--- a/internal/snapshot/types.go
+++ b/internal/snapshot/types.go
@@ -97,7 +97,13 @@ type AgentDefsSection struct {
 // can evolve independently — adding a field here doesn't require
 // adding it to the store struct, and vice versa.
 type AgentDefEntry struct {
-	DefID                  string          `json:"def_id"`
+	DefID string `json:"def_id"`
+	// TenantID is the RFC N tenant-isolation axis. Carried through the snapshot
+	// so a multi-tenant capture→restore preserves each def's owning tenant;
+	// without it every def collapsed to the shared "" tenant on restore
+	// (cross-tenant disclosure + same-name active-pointer collisions). Additive
+	// (omitempty) — older snapshots restore with an empty tenant as before.
+	TenantID               string          `json:"tenant_id,omitempty"`
 	Name                   string          `json:"name"`
 	Version                int             `json:"version"`
 	ParentDefID            string          `json:"parent_def_id,omitempty"`
@@ -125,6 +131,7 @@ type AgentDefActiveSection struct {
 
 type AgentDefActiveEntry struct {
 	Name              string    `json:"name"`
+	TenantID          string    `json:"tenant_id,omitempty"` // RFC N — see AgentDefEntry.TenantID
 	DefID             string    `json:"def_id"`
 	PromotedAt        time.Time `json:"promoted_at"`
 	PromotedByAgentID string    `json:"promoted_by_agent_id,omitempty"`
@@ -141,6 +148,7 @@ type SkillDefsSection struct {
 // tools) is owned by the SkillDef tool.
 type SkillDefEntry struct {
 	DefID                  string          `json:"def_id"`
+	TenantID               string          `json:"tenant_id,omitempty"` // RFC N — see AgentDefEntry.TenantID
 	Name                   string          `json:"name"`
 	Version                int             `json:"version"`
 	ParentDefID            string          `json:"parent_def_id,omitempty"`
@@ -163,6 +171,7 @@ type SkillDefActiveSection struct {
 
 type SkillDefActiveEntry struct {
 	Name              string    `json:"name"`
+	TenantID          string    `json:"tenant_id,omitempty"` // RFC N — see AgentDefEntry.TenantID
 	DefID             string    `json:"def_id"`
 	PromotedAt        time.Time `json:"promoted_at"`
 	PromotedByAgentID string    `json:"promoted_by_agent_id,omitempty"`
@@ -179,6 +188,7 @@ type TeamDefsSection struct {
 // TeamDef tool.
 type TeamDefEntry struct {
 	DefID                  string          `json:"def_id"`
+	TenantID               string          `json:"tenant_id,omitempty"` // RFC N — see AgentDefEntry.TenantID
 	Name                   string          `json:"name"`
 	Version                int             `json:"version"`
 	ParentDefID            string          `json:"parent_def_id,omitempty"`
@@ -201,6 +211,7 @@ type TeamDefActiveSection struct {
 
 type TeamDefActiveEntry struct {
 	Name              string    `json:"name"`
+	TenantID          string    `json:"tenant_id,omitempty"` // RFC N — see AgentDefEntry.TenantID
 	DefID             string    `json:"def_id"`
 	PromotedAt        time.Time `json:"promoted_at"`
 	PromotedByAgentID string    `json:"promoted_by_agent_id,omitempty"`
@@ -220,6 +231,7 @@ type MCPServerDefsSection struct {
 // / discovered_tools) is owned by the MCPServerDef tool.
 type MCPServerDefEntry struct {
 	DefID                  string          `json:"def_id"`
+	TenantID               string          `json:"tenant_id,omitempty"` // RFC N — see AgentDefEntry.TenantID
 	Name                   string          `json:"name"`
 	Version                int             `json:"version"`
 	ParentDefID            string          `json:"parent_def_id,omitempty"`
@@ -242,6 +254,7 @@ type MCPServerDefActiveSection struct {
 
 type MCPServerDefActiveEntry struct {
 	Name              string    `json:"name"`
+	TenantID          string    `json:"tenant_id,omitempty"` // RFC N — see AgentDefEntry.TenantID
 	DefID             string    `json:"def_id"`
 	PromotedAt        time.Time `json:"promoted_at"`
 	PromotedByAgentID string    `json:"promoted_by_agent_id,omitempty"`


### PR DESCRIPTION
Fixes review finding #2 (systemic). Independent of #695 (no file overlap) — branched off main.

## Problem
The snapshot DTO types — `AgentDefEntry` / `SkillDefEntry` / `TeamDefEntry` / `MCPServerDefEntry` and their `*ActiveEntry` siblings — had **no `TenantID` field**. So capture read the tenant-bearing store rows but dropped `tenant_id`, and restore reconstructed every def + active pointer under the shared `""` tenant.

A **multi-tenant snapshot restore** (a documented HA/DR + boot crash-recovery op) therefore **collapsed every tenant's private defs into `""`**:
- cross-tenant disclosure — tenant A's def becomes the shared fork-fallback base any tenant can read/fork;
- same-name active-pointer collisions — sqlite `INSERT OR IGNORE` silently drops the loser; postgres warns.

## Fix
The store layer was already tenant-aware end to end (`SnapshotRead*` SELECT + Scan `tenant_id`; `SnapshotRestore*` INSERT `r.TenantID`) — the gap was purely the DTO in between. So: add `TenantID` (`json:",omitempty"`) to all **8** def/active snapshot entry types, populate it in capture from `r.TenantID`, and thread it back into the store row in restore. **Systemic across all four snapshotted def families**, not TeamDef-specific.

**Additive + backward-compatible**: an older snapshot without `tenant_id` restores with an empty tenant exactly as before — no section-version bump.

## Tested
`TestRoundTrip_PreservesDefTenantID` seeds one def per family under a **distinct** tenant (+ an active pointer) and asserts each tenant survives capture→restore. Fails on the pre-fix code (every def came back under `""`). `go test ./...` + gofmt/vet clean.

Review follow-up sequence: #1 op=run admission (#695) ✅ · **#2 snapshot tenant (this)** · #3 accepted as-is. Next up (collaborative): the runtime orchestrator agent + ephemeral volumes for teams that work with repositories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)