### PR TITLE
feat(team-examples): runnable starter teams for the orchestrator (RFC BD phase 2)

### DIFF
--- a/bundles/team-examples/README.md
+++ b/bundles/team-examples/README.md
@@ -1,0 +1,38 @@
+# team-examples bundle
+
+Runnable **starter teams** for the RFC BD `team/orchestrator`. The `agent-teams`
+bundle ships the orchestrator + the mechanism; this bundle ships the **content**
+so a team runs end to end out of the box.
+
+```
+LOOMCYCLE_PRESETS=base,agent-teams,team-examples
+```
+
+## What's inside
+
+- **Handler agents** for two domains (agents *can* be static config; TeamDefs cannot):
+  - software: `sdlc/architect`, `sdlc/coder`, `sdlc/reviewer`
+  - marketing: `marketing/writer`, `marketing/editor`
+- A **`team/examples`** skill carrying the ready-to-create TeamDef JSON for:
+  - **`sdlc`** — a software team (architecture → implementation → review ⇄ implementation → PR) that uses the software workspace (ephemeral `work` volume + `git`/`gh` via Bashbox; see the `agent-teams` `team/repo` skill + its operator prerequisites).
+  - **`marketing`** — a Documents-only team (draft → edit ⇄ draft → published) with **no volume/repo/PR** — the Document task board is the deliverable.
+
+Two domains on purpose: SDLC exercises the repo workspace; marketing proves the
+domain-general design (the workspace is optional — RFC BD).
+
+## Why the teams are in a skill, not config
+
+TeamDefs are **runtime-only** (RFC AP has no static team layer — they're created
+via `TeamDef op=create`). So a starter team ships as JSON the orchestrator/assistant
+instantiates on request, not as YAML. Ask the orchestrator to *"set up and run the
+marketing example"* and it creates the TeamDef from `team/examples` and drives it.
+
+## Notes
+
+- The `sdlc/*` handlers are meant to be **spawned by the orchestrator**, which
+  creates the shared ephemeral `work` volume; run standalone they have no volume
+  and their file ops are denied (expected).
+- `loomcycle.yaml` mirrors the embedded copy at
+  `cmd/loomcycle/embedded/bundles/team-examples.yaml`; keep the two in sync.
+- These are starters — fork them (`TeamDef op=fork`) or build your own with the
+  `team/assistant` agent.

--- a/bundles/team-examples/loomcycle.yaml
+++ b/bundles/team-examples/loomcycle.yaml
@@ -1,0 +1,159 @@
+# RFC BD embedded bundle: team-examples
+#
+# Runnable STARTER TEAMS for the team/orchestrator (RFC BD). The `agent-teams`
+# bundle ships the orchestrator + the mechanism; this bundle ships the CONTENT so
+# a team actually runs end to end out of the box. Select all three:
+#   LOOMCYCLE_PRESETS=base,agent-teams,team-examples
+#
+# It provides:
+#   - handler agents for two domains (they CAN be static config; TeamDefs cannot):
+#       software: sdlc/architect, sdlc/coder, sdlc/reviewer
+#       marketing: marketing/writer, marketing/editor
+#   - a `team/examples` skill carrying the ready-to-create TeamDef JSON for an
+#     `sdlc` team (software workspace: repo volume + PR) and a `marketing` team
+#     (Documents-only), so the orchestrator/assistant can `TeamDef op=create` them
+#     and drive them. (TeamDefs are runtime-only — RFC AP has no static team layer
+#     — so a starter team ships as JSON a skill instantiates, not as config.)
+#
+# Two domains on purpose: the SDLC team exercises the software workspace (ephemeral
+# volume + git/gh via Bashbox — see the agent-teams `team/repo` skill + its
+# operator prereqs); the marketing team proves the domain-general design with NO
+# volume/repo/PR — its deliverable is the Document task board itself.
+#
+# The handler agents are meant to be SPAWNED BY the orchestrator (which creates the
+# shared ephemeral `work` volume for software teams); the sdlc/* agents' file/exec
+# tools resolve that shared volume. Run standalone (no orchestrator), an sdlc/*
+# agent has no `work` volume and its file ops are denied — expected.
+#
+# No provider matrix here (agents declare `tier: middle`); bring `base`. Overlay to
+# retarget tiers / swap prompts. Cannot widen tools (the ceiling is unchanged).
+
+agents:
+  # ---- software (SDLC) handlers — operate the shared ephemeral `work` volume ----
+  sdlc/architect:
+    tier: middle
+    max_tokens: 8192
+    effort: high
+    tools: [Read, Grep, Glob, Context]
+    system_prompt: |
+      You are the ARCHITECT on a software team. Given a task (and read access to the
+      checked-out repo in the `work` volume), produce a SHORT technical design: the
+      approach, the files/modules to touch, and the risks. Do not write code. Be
+      terse and structured — a planner and a coder read your output next. End with a
+      one-line "ready to implement?" so the orchestrator can gate on approval.
+
+  sdlc/coder:
+    tier: middle
+    max_tokens: 16384
+    effort: medium
+    tools: [Read, Write, Edit, Grep, Glob, Bashbox, Context]
+    system_prompt: |
+      You are the CODER on a software team. Implement the approved design in the
+      repo checked out in the `work` volume: edit files with Write/Edit, and use
+      Bashbox (volume="work") to build/test/format. Make the SMALLEST change that
+      satisfies the task; match the surrounding code's style. When done, summarize
+      what you changed (files + one line each) — the reviewer reads it next. Do not
+      commit or push; the orchestrator opens the PR.
+
+  sdlc/reviewer:
+    tier: middle
+    max_tokens: 8192
+    effort: high
+    tools: [Read, Grep, Glob, Bashbox, Context]
+    system_prompt: |
+      You are the REVIEWER on a software team. Review the coder's change in the
+      `work` volume: read the diff (Bashbox volume="work": `git diff`), check
+      correctness, tests, and style. Return a verdict the orchestrator routes on:
+      "approve" (advance to PR) or "pushback: <specific, actionable reasons>" (back
+      to the coder). Be concrete — name files + lines. Do not edit code yourself.
+
+  # ---- marketing handlers — Documents only, no volume/repo ----
+  marketing/writer:
+    tier: middle
+    max_tokens: 8192
+    effort: medium
+    tools: [Document, WebSearch, Context]
+    memory_scopes: [user]
+    system_prompt: |
+      You are the WRITER on a marketing team. Draft the requested copy (a post, an
+      email, a landing section) directly into the team's Document task board: put the
+      draft in the relevant chunk's body (Document op=update_chunk). Use WebSearch
+      only to check facts. Keep the brand voice the operator specified. When done,
+      say what you drafted and where — the editor reviews it next. There is no repo
+      and no PR; the Document is the deliverable.
+
+  marketing/editor:
+    tier: middle
+    max_tokens: 8192
+    effort: high
+    tools: [Document, Context]
+    system_prompt: |
+      You are the EDITOR on a marketing team. Review the writer's draft in the
+      Document task board (Document op=get_chunk): tighten the copy, fix voice/tone,
+      and check the brief is met. Either polish it in place (op=update_chunk) and
+      return "approve", or return "pushback: <specific edits>" for the writer. Be
+      concrete. The Document is the deliverable — no repo, no PR.
+
+skills:
+  team/examples:
+    description: Ready-to-create starter TeamDefs (an SDLC software team + a marketing Documents-only team) the orchestrator can instantiate and drive.
+    tools: [TeamDef, Document]
+    body: |
+      # Starter teams
+
+      Two ready-to-run example teams. To use one: `TeamDef op=create name="<name>"
+      overlay=<the JSON below>` (it validates on write), then drive it per the
+      team/orchestrate skill. Both reference handler agents shipped by the
+      team-examples bundle — confirm they exist with `AgentDef op=list` first.
+
+      ## `sdlc` — a software team (repo workspace + PR)
+      Needs the software prerequisites from the `team/repo` skill (Bashbox + git/gh +
+      a dynamic_root volume + GITHUB_TOKEN). Set up the `work` volume + clone per
+      team/repo BEFORE driving, and open the PR at the terminal state.
+      ```json
+      {
+        "entry": "architecture",
+        "max_iterations": 5,
+        "states": [
+          {"state": "architecture",   "handler": {"kind": "agent", "agent": "sdlc/architect"}},
+          {"state": "implementation", "handler": {"kind": "agent", "agent": "sdlc/coder"}},
+          {"state": "review",         "handler": {"kind": "agent", "agent": "sdlc/reviewer"}},
+          {"state": "pr",             "handler": {"kind": "terminal"}}
+        ],
+        "transitions": [
+          {"from": "architecture",   "to": "implementation", "on": "success"},
+          {"from": "implementation", "to": "review",         "on": "success"},
+          {"from": "review",         "to": "pr",             "on": "success"},
+          {"from": "review",         "to": "implementation", "on": "pushback:code-fix"}
+        ]
+      }
+      ```
+      Flow: architect designs → coder implements in `work` → reviewer approves
+      (→ PR) or pushes back to the coder → at `pr` you `gh pr create` (team/repo).
+
+      ## `marketing` — a Documents-only team (no repo, no PR)
+      No volume, no git — the Document task board is the deliverable. Create a board
+      (Document op=create_document), seed a chunk at `draft`, and drive.
+      ```json
+      {
+        "entry": "draft",
+        "max_iterations": 4,
+        "states": [
+          {"state": "draft",     "handler": {"kind": "agent", "agent": "marketing/writer"}},
+          {"state": "edit",      "handler": {"kind": "agent", "agent": "marketing/editor"}},
+          {"state": "published", "handler": {"kind": "terminal"}}
+        ],
+        "transitions": [
+          {"from": "draft", "to": "edit",      "on": "success"},
+          {"from": "edit",  "to": "published", "on": "success"},
+          {"from": "edit",  "to": "draft",     "on": "pushback:revise"}
+        ]
+      }
+      ```
+      Flow: writer drafts into the Document → editor polishes (→ published) or pushes
+      back to the writer. The finished copy lives in the Document chunk.
+
+      ## Note
+      These are STARTERS — fork + edit them (`TeamDef op=fork`) or build your own with
+      team/assistant. The handler agents are likewise examples: retarget their tiers
+      or swap prompts via an overlay.

--- a/cmd/loomcycle/embedded/bundles/team-examples.yaml
+++ b/cmd/loomcycle/embedded/bundles/team-examples.yaml
@@ -1,0 +1,159 @@
+# RFC BD embedded bundle: team-examples
+#
+# Runnable STARTER TEAMS for the team/orchestrator (RFC BD). The `agent-teams`
+# bundle ships the orchestrator + the mechanism; this bundle ships the CONTENT so
+# a team actually runs end to end out of the box. Select all three:
+#   LOOMCYCLE_PRESETS=base,agent-teams,team-examples
+#
+# It provides:
+#   - handler agents for two domains (they CAN be static config; TeamDefs cannot):
+#       software: sdlc/architect, sdlc/coder, sdlc/reviewer
+#       marketing: marketing/writer, marketing/editor
+#   - a `team/examples` skill carrying the ready-to-create TeamDef JSON for an
+#     `sdlc` team (software workspace: repo volume + PR) and a `marketing` team
+#     (Documents-only), so the orchestrator/assistant can `TeamDef op=create` them
+#     and drive them. (TeamDefs are runtime-only — RFC AP has no static team layer
+#     — so a starter team ships as JSON a skill instantiates, not as config.)
+#
+# Two domains on purpose: the SDLC team exercises the software workspace (ephemeral
+# volume + git/gh via Bashbox — see the agent-teams `team/repo` skill + its
+# operator prereqs); the marketing team proves the domain-general design with NO
+# volume/repo/PR — its deliverable is the Document task board itself.
+#
+# The handler agents are meant to be SPAWNED BY the orchestrator (which creates the
+# shared ephemeral `work` volume for software teams); the sdlc/* agents' file/exec
+# tools resolve that shared volume. Run standalone (no orchestrator), an sdlc/*
+# agent has no `work` volume and its file ops are denied — expected.
+#
+# No provider matrix here (agents declare `tier: middle`); bring `base`. Overlay to
+# retarget tiers / swap prompts. Cannot widen tools (the ceiling is unchanged).
+
+agents:
+  # ---- software (SDLC) handlers — operate the shared ephemeral `work` volume ----
+  sdlc/architect:
+    tier: middle
+    max_tokens: 8192
+    effort: high
+    tools: [Read, Grep, Glob, Context]
+    system_prompt: |
+      You are the ARCHITECT on a software team. Given a task (and read access to the
+      checked-out repo in the `work` volume), produce a SHORT technical design: the
+      approach, the files/modules to touch, and the risks. Do not write code. Be
+      terse and structured — a planner and a coder read your output next. End with a
+      one-line "ready to implement?" so the orchestrator can gate on approval.
+
+  sdlc/coder:
+    tier: middle
+    max_tokens: 16384
+    effort: medium
+    tools: [Read, Write, Edit, Grep, Glob, Bashbox, Context]
+    system_prompt: |
+      You are the CODER on a software team. Implement the approved design in the
+      repo checked out in the `work` volume: edit files with Write/Edit, and use
+      Bashbox (volume="work") to build/test/format. Make the SMALLEST change that
+      satisfies the task; match the surrounding code's style. When done, summarize
+      what you changed (files + one line each) — the reviewer reads it next. Do not
+      commit or push; the orchestrator opens the PR.
+
+  sdlc/reviewer:
+    tier: middle
+    max_tokens: 8192
+    effort: high
+    tools: [Read, Grep, Glob, Bashbox, Context]
+    system_prompt: |
+      You are the REVIEWER on a software team. Review the coder's change in the
+      `work` volume: read the diff (Bashbox volume="work": `git diff`), check
+      correctness, tests, and style. Return a verdict the orchestrator routes on:
+      "approve" (advance to PR) or "pushback: <specific, actionable reasons>" (back
+      to the coder). Be concrete — name files + lines. Do not edit code yourself.
+
+  # ---- marketing handlers — Documents only, no volume/repo ----
+  marketing/writer:
+    tier: middle
+    max_tokens: 8192
+    effort: medium
+    tools: [Document, WebSearch, Context]
+    memory_scopes: [user]
+    system_prompt: |
+      You are the WRITER on a marketing team. Draft the requested copy (a post, an
+      email, a landing section) directly into the team's Document task board: put the
+      draft in the relevant chunk's body (Document op=update_chunk). Use WebSearch
+      only to check facts. Keep the brand voice the operator specified. When done,
+      say what you drafted and where — the editor reviews it next. There is no repo
+      and no PR; the Document is the deliverable.
+
+  marketing/editor:
+    tier: middle
+    max_tokens: 8192
+    effort: high
+    tools: [Document, Context]
+    system_prompt: |
+      You are the EDITOR on a marketing team. Review the writer's draft in the
+      Document task board (Document op=get_chunk): tighten the copy, fix voice/tone,
+      and check the brief is met. Either polish it in place (op=update_chunk) and
+      return "approve", or return "pushback: <specific edits>" for the writer. Be
+      concrete. The Document is the deliverable — no repo, no PR.
+
+skills:
+  team/examples:
+    description: Ready-to-create starter TeamDefs (an SDLC software team + a marketing Documents-only team) the orchestrator can instantiate and drive.
+    tools: [TeamDef, Document]
+    body: |
+      # Starter teams
+
+      Two ready-to-run example teams. To use one: `TeamDef op=create name="<name>"
+      overlay=<the JSON below>` (it validates on write), then drive it per the
+      team/orchestrate skill. Both reference handler agents shipped by the
+      team-examples bundle — confirm they exist with `AgentDef op=list` first.
+
+      ## `sdlc` — a software team (repo workspace + PR)
+      Needs the software prerequisites from the `team/repo` skill (Bashbox + git/gh +
+      a dynamic_root volume + GITHUB_TOKEN). Set up the `work` volume + clone per
+      team/repo BEFORE driving, and open the PR at the terminal state.
+      ```json
+      {
+        "entry": "architecture",
+        "max_iterations": 5,
+        "states": [
+          {"state": "architecture",   "handler": {"kind": "agent", "agent": "sdlc/architect"}},
+          {"state": "implementation", "handler": {"kind": "agent", "agent": "sdlc/coder"}},
+          {"state": "review",         "handler": {"kind": "agent", "agent": "sdlc/reviewer"}},
+          {"state": "pr",             "handler": {"kind": "terminal"}}
+        ],
+        "transitions": [
+          {"from": "architecture",   "to": "implementation", "on": "success"},
+          {"from": "implementation", "to": "review",         "on": "success"},
+          {"from": "review",         "to": "pr",             "on": "success"},
+          {"from": "review",         "to": "implementation", "on": "pushback:code-fix"}
+        ]
+      }
+      ```
+      Flow: architect designs → coder implements in `work` → reviewer approves
+      (→ PR) or pushes back to the coder → at `pr` you `gh pr create` (team/repo).
+
+      ## `marketing` — a Documents-only team (no repo, no PR)
+      No volume, no git — the Document task board is the deliverable. Create a board
+      (Document op=create_document), seed a chunk at `draft`, and drive.
+      ```json
+      {
+        "entry": "draft",
+        "max_iterations": 4,
+        "states": [
+          {"state": "draft",     "handler": {"kind": "agent", "agent": "marketing/writer"}},
+          {"state": "edit",      "handler": {"kind": "agent", "agent": "marketing/editor"}},
+          {"state": "published", "handler": {"kind": "terminal"}}
+        ],
+        "transitions": [
+          {"from": "draft", "to": "edit",      "on": "success"},
+          {"from": "edit",  "to": "published", "on": "success"},
+          {"from": "edit",  "to": "draft",     "on": "pushback:revise"}
+        ]
+      }
+      ```
+      Flow: writer drafts into the Document → editor polishes (→ published) or pushes
+      back to the writer. The finished copy lives in the Document chunk.
+
+      ## Note
+      These are STARTERS — fork + edit them (`TeamDef op=fork`) or build your own with
+      team/assistant. The handler agents are likewise examples: retarget their tiers
+      or swap prompts via an overlay.

--- a/cmd/loomcycle/embedded/presets_test.go
+++ b/cmd/loomcycle/embedded/presets_test.go
@@ -21,6 +21,7 @@ func TestUnits_RegistryShape(t *testing.T) {
 		"oauth":          "preset",
 		"document-agent": "bundle",
 		"agent-teams":    "bundle",
+		"team-examples":  "bundle",
 	}
 	for name, kind := range want {
 		u, ok := byName[name]
@@ -102,6 +103,39 @@ func TestBundle_AgentTeamsHasOrchestrator(t *testing.T) {
 	for _, s := range []string{"team/orchestrate", "team/repo"} {
 		if _, ok := tree.Skills[s]; !ok {
 			t.Errorf("agent-teams bundle missing skill %q", s)
+		}
+	}
+}
+
+// TestBundle_TeamExamplesHasStarters guards the RFC BD Phase 2 starter content:
+// the team-examples bundle must ship the SDLC + marketing handler agents and the
+// team/examples skill (the ready-to-create TeamDefs). Without these the
+// orchestrator has nothing to drive out of the box.
+func TestBundle_TeamExamplesHasStarters(t *testing.T) {
+	data, err := Show("team-examples")
+	if err != nil {
+		t.Fatalf("Show(team-examples): %v", err)
+	}
+	var tree struct {
+		Agents map[string]any `yaml:"agents"`
+		Skills map[string]any `yaml:"skills"`
+	}
+	if err := yaml.Unmarshal(data, &tree); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, a := range []string{"sdlc/architect", "sdlc/coder", "sdlc/reviewer", "marketing/writer", "marketing/editor"} {
+		if _, ok := tree.Agents[a]; !ok {
+			t.Errorf("team-examples missing handler agent %q", a)
+		}
+	}
+	if _, ok := tree.Skills["team/examples"]; !ok {
+		t.Errorf("team-examples missing the team/examples skill")
+	}
+	// The skill must carry both starter TeamDefs so they're actually creatable.
+	body, _ := Show("team-examples")
+	for _, marker := range []string{"sdlc/architect", "marketing/writer", `"entry": "architecture"`, `"entry": "draft"`} {
+		if !strings.Contains(string(body), marker) {
+			t.Errorf("team/examples skill missing starter marker %q", marker)
 		}
 	}
 }


### PR DESCRIPTION
**RFC BD Phase 2** (you picked "starter teams + handler agents"). The `agent-teams` bundle shipped the orchestrator + mechanism but **nothing to drive** — an operator had to build a whole team first. This adds an opt-in **`team-examples`** bundle so `LOOMCYCLE_PRESETS=base,agent-teams,team-examples` gives a working team end to end.

## Two domains, on purpose (proves the workspace is domain-pluggable)
- **Software (`sdlc`)** — handler agents `sdlc/architect`, `sdlc/coder`, `sdlc/reviewer` + an `sdlc` TeamDef (architecture → implementation → review ⇄ implementation → PR). Exercises the **software workspace** (ephemeral `work` volume + `git`/`gh` via Bashbox; see the `agent-teams` `team/repo` skill + its operator prereqs). Handlers operate the shared ephemeral volume the orchestrator creates.
- **Marketing (docs-only)** — handler agents `marketing/writer`, `marketing/editor` + a `marketing` TeamDef (draft → edit ⇄ draft → published). **No volume/repo/PR** — the Document task board *is* the deliverable.

## Why teams ship in a skill, not config
TeamDefs are **runtime-only** (RFC AP has no static team layer). So the starter teams ship as ready-to-create JSON in a **`team/examples`** skill the orchestrator/assistant instantiates via `TeamDef op=create` on request (*"set up and run the marketing example"*). The **handler agents** ship as static config (agents can). Kept in its own opt-in bundle so `agent-teams` stays the clean mechanism.

## Tested
`TestBundle_TeamExamplesHasStarters` (5 handler agents + the `team/examples` skill + both starter TeamDefs present) + the registry-shape guard; the 3-bundle stack parses + validates. `go test ./...` + gofmt clean.

Now selecting the three bundles gives: the orchestrator (drive + human face), the two authoring assistants, and two ready-to-run teams (one software, one docs) — a full, demoable RFC BD line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)