### PR TITLE
feat(webui): teams board — TeamDef list + state diagram (RFC BD #3)

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1441,6 +1441,50 @@ export function listMemoryBackendDefNames(): Promise<DefNamesResponse> {
   return jsonFetch<DefNamesResponse>("/v1/_memorybackenddef/names");
 }
 
+// ---- Teams (RFC AP / BD) ----
+//
+// TeamDefs are the agent-team workflow graphs. The Teams view lists them
+// (/v1/_teamdef/names) and renders a selected team's Mermaid stateDiagram
+// via the render_diagram op (POST /v1/_teamdef). Read-only.
+export interface TeamNameSummary {
+  name: string;
+  tenant_id?: string;
+  version_count: number;
+  active_def_id?: string;
+  latest_version: number;
+  last_updated?: string;
+  live_version_count?: number;
+  active_retired?: boolean;
+}
+
+export interface ListTeamsResponse {
+  names: TeamNameSummary[] | null;
+}
+
+export function listTeams(): Promise<ListTeamsResponse> {
+  return jsonFetch<ListTeamsResponse>("/v1/_teamdef/names");
+}
+
+export interface TeamDiagram {
+  name: string;
+  def_id: string;
+  format: string;
+  diagram: string;
+}
+
+// renderTeamDiagram resolves a team's active version and returns its Mermaid
+// stateDiagram-v2 source (with the colour scheme baked in). highlightState
+// (optional) marks one state with a bold outline — e.g. a chunk's current state.
+export function renderTeamDiagram(name: string, highlightState?: string): Promise<TeamDiagram> {
+  const body: Record<string, unknown> = { op: "render_diagram", name };
+  if (highlightState) body.highlight_state = highlightState;
+  return jsonFetch<TeamDiagram>("/v1/_teamdef", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
 // listDefVersionsByName uses the existing op-discriminated POST
 // endpoint with `{op:"list", name}` to retrieve every version of one
 // declared name. Used by the Library UI when an operator clicks into

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -22,6 +22,7 @@ import {
   ScrollText,
   Settings,
   Sun,
+  Workflow,
 } from "lucide-react";
 import { Principal, UserSummary, getHealth, getWhoami, listUsers } from "../api";
 import { useTheme } from "../hooks/useTheme";
@@ -65,6 +66,7 @@ const NAV_ITEMS: NavItem[] = [
   { to: "/paths", label: "paths", Icon: FolderTree, vis: "tenant" },
   { to: "/channels", label: "channels", Icon: Radio, vis: "admin" },
   { to: "/schedules", label: "schedules", Icon: CalendarClock, vis: "tenant" },
+  { to: "/teams", label: "teams", Icon: Workflow, vis: "tenant" },
   { to: "/interrupts", label: "interrupts", Icon: Bell, vis: "tenant" },
   { to: "/memory", label: "memory", Icon: Brain, vis: "admin" },
   { to: "/snapshots", label: "snapshots", Icon: Camera, vis: "admin" },

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -26,6 +26,7 @@ import PathTreeView from "./pages/PathTreeView";
 import DocumentsView from "./pages/DocumentsView";
 import ChannelsView from "./pages/ChannelsView";
 import SchedulesView from "./pages/SchedulesView";
+import TeamsView from "./pages/TeamsView";
 import SettingsView from "./pages/SettingsView";
 import Layout from "./components/Layout";
 import AgentIdRedirect from "./components/AgentIdRedirect";
@@ -48,6 +49,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
         <Route path="/" element={<Layout />}>
           <Route index element={<Navigate to="/agents" replace />} />
           <Route path="run" element={<RunView />} />
+          <Route path="teams" element={<TeamsView />} />
           <Route path="agents" element={<AgentsView />} />
           <Route path="agents/:agentId" element={<AgentIdRedirect />} />
           <Route path="library" element={<LibraryView />}>

--- a/web/src/pages/TeamsView.tsx
+++ b/web/src/pages/TeamsView.tsx
@@ -1,0 +1,172 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  TeamDiagram,
+  TeamNameSummary,
+  listTeams,
+  renderTeamDiagram,
+} from "../api";
+
+// TeamsView — the agent-team board (RFC AP / BD).
+//
+// Lists TeamDefs (/v1/_teamdef/names) and, for a selected team, renders its
+// Mermaid stateDiagram-v2 source via the render_diagram op — the workflow's
+// states, transitions, and colour scheme. An optional "highlight state" marks
+// one state (e.g. a running chunk's current state) with a bold outline.
+//
+// v1 shows the diagram SOURCE (dep-free): it renders in any Markdown/Mermaid
+// viewer and is copy-pasteable. A live in-page graph render (the `mermaid` lib)
+// + binding to a running Document board's current state are follow-ups.
+
+export default function TeamsView() {
+  const [teams, setTeams] = useState<TeamNameSummary[]>([]);
+  const [selected, setSelected] = useState<string>("");
+  const [highlight, setHighlight] = useState<string>("");
+  const [diagram, setDiagram] = useState<TeamDiagram | null>(null);
+  const [err, setErr] = useState<string>("");
+  const [diagErr, setDiagErr] = useState<string>("");
+  const [loading, setLoading] = useState(false);
+
+  const fetchTeams = useCallback(async () => {
+    setLoading(true);
+    setErr("");
+    try {
+      const resp = await listTeams();
+      setTeams(resp.names ?? []);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchTeams();
+  }, [fetchTeams]);
+
+  const fetchDiagram = useCallback(async (name: string, hl: string) => {
+    if (!name) return;
+    setDiagErr("");
+    try {
+      setDiagram(await renderTeamDiagram(name, hl || undefined));
+    } catch (e) {
+      setDiagram(null);
+      setDiagErr(e instanceof Error ? e.message : String(e));
+    }
+  }, []);
+
+  useEffect(() => {
+    if (selected) void fetchDiagram(selected, highlight);
+  }, [selected, highlight, fetchDiagram]);
+
+  return (
+    <div style={{ padding: "1rem", display: "flex", flexDirection: "column", gap: "1rem" }}>
+      <div>
+        <h1>teams</h1>
+        <p style={{ opacity: 0.7, margin: "0.25rem 0" }}>
+          Agent-team workflows (RFC AP). Select a team to see its state-machine
+          diagram — states, transitions, and the colour scheme.
+        </p>
+      </div>
+
+      {err && <div style={{ color: "var(--error, #e03131)" }}>Failed to load teams: {err}</div>}
+
+      <div style={{ display: "flex", gap: "1.5rem", alignItems: "flex-start", flexWrap: "wrap" }}>
+        {/* Team list */}
+        <div style={{ minWidth: 220, flex: "0 0 auto" }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+            <strong>teams ({teams.length})</strong>
+            <button onClick={() => void fetchTeams()} disabled={loading}>
+              {loading ? "…" : "refresh"}
+            </button>
+          </div>
+          {teams.length === 0 && !loading && (
+            <p style={{ opacity: 0.6 }}>
+              No teams yet. Create one with the <code>TeamDef</code> tool or the{" "}
+              <code>team/assistant</code> agent.
+            </p>
+          )}
+          <ul style={{ listStyle: "none", padding: 0, margin: "0.5rem 0" }}>
+            {teams.map((t) => {
+              const key = t.tenant_id ? `${t.tenant_id}/${t.name}` : t.name;
+              const isSel = selected === t.name;
+              return (
+                <li key={key}>
+                  <button
+                    onClick={() => setSelected(t.name)}
+                    style={{
+                      display: "block",
+                      width: "100%",
+                      textAlign: "left",
+                      padding: "0.4rem 0.6rem",
+                      margin: "0.15rem 0",
+                      border: "1px solid var(--border, #ccc)",
+                      borderRadius: 6,
+                      background: isSel ? "var(--accent-bg, #eef)" : "transparent",
+                      cursor: "pointer",
+                    }}
+                  >
+                    <div style={{ fontWeight: 600 }}>{t.name}</div>
+                    <div style={{ fontSize: "0.8em", opacity: 0.65 }}>
+                      v{t.latest_version} · {t.version_count} version
+                      {t.version_count === 1 ? "" : "s"}
+                      {t.active_retired ? " · retired" : ""}
+                      {t.tenant_id ? ` · ${t.tenant_id}` : ""}
+                    </div>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+
+        {/* Selected team diagram */}
+        <div style={{ flex: "1 1 420px", minWidth: 320 }}>
+          {!selected && <p style={{ opacity: 0.6 }}>Select a team to view its diagram.</p>}
+          {selected && (
+            <div>
+              <div style={{ display: "flex", gap: "0.75rem", alignItems: "center", flexWrap: "wrap" }}>
+                <strong>{selected}</strong>
+                <label style={{ fontSize: "0.85em", opacity: 0.8 }}>
+                  highlight state:{" "}
+                  <input
+                    value={highlight}
+                    onChange={(e) => setHighlight(e.target.value)}
+                    placeholder="(state id)"
+                    style={{ padding: "0.2rem 0.4rem" }}
+                  />
+                </label>
+              </div>
+              {diagErr && (
+                <div style={{ color: "var(--error, #e03131)", marginTop: "0.5rem" }}>
+                  {diagErr}
+                </div>
+              )}
+              {diagram && (
+                <>
+                  <p style={{ fontSize: "0.8em", opacity: 0.6, margin: "0.5rem 0 0.25rem" }}>
+                    Mermaid <code>stateDiagram-v2</code> — paste into any Mermaid viewer, or
+                    view where Mermaid renders (GitHub, the docs viewer).
+                  </p>
+                  <pre
+                    style={{
+                      background: "var(--code-bg, #f6f8fa)",
+                      border: "1px solid var(--border, #ddd)",
+                      borderRadius: 6,
+                      padding: "0.75rem",
+                      overflowX: "auto",
+                      fontFamily: "var(--mono, monospace)",
+                      fontSize: "0.85em",
+                      whiteSpace: "pre",
+                    }}
+                  >
+                    {diagram.diagram}
+                  </pre>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
RFC BD follow-up **#3 — Web UI team board**. A "teams" page so an operator can see the agent-team workflows from the Web UI, not just the CLI/MCP.

## What it adds
- **`web/src/api.ts`** — `listTeams()` (GET `/v1/_teamdef/names`) + `renderTeamDiagram(name, highlightState?)` (POST `/v1/_teamdef` `op=render_diagram`) + types.
- **`web/src/pages/TeamsView.tsx`** — a read-only board: lists TeamDefs (version + retired badges), and on select renders the team's Mermaid `stateDiagram-v2` (states, transitions, colour scheme) with an optional **highlight-state** input (marks one state — e.g. a running chunk's current state — with a bold outline).
- **`main.tsx`** `/teams` route + **`Layout.tsx`** a tenant-visible **teams** nav entry.

## Scope note (needs your visual review)
v1 shows the diagram **source** (dep-free — it renders in any Mermaid/Markdown viewer and copy-pastes). A **live in-page graph render** (adding the `mermaid` lib) and **binding to a running Document board's current state** are deliberate follow-ups — I avoided a heavy blind dependency I couldn't visually verify. The page is build-verified but hasn't had a visual pass, so give it a look.

## Tested
`npm run typecheck` (tsc --noEmit) + `npm run build` (vite) clean; `vitest` 38/38 pass. Web UI ships as source — `dist` is gitignored + CI rebuilds; this commits `web/src` only.

Third of three RFC BD follow-up PRs (with #1 per-tenant repo token + #2 domain workspace skills).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
