### PR TITLE
feat(bash): inject per-tenant credentials into raw Bash env

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -782,6 +782,13 @@ func main() {
 		FallbackAllowedCreds: cfg.Env.BashboxFallbackAllowedCreds,
 	}
 
+	// Bash is likewise a named var so its CredResolve can be late-bound after
+	// the credential engine — it injects per-tenant creds into the raw child env.
+	bashTool := &builtin.Bash{
+		Enabled:      cfg.Env.BashEnabled,
+		AllowedCreds: cfg.Env.BashAllowedCreds,
+	}
+
 	allTools := []tools.Tool{
 		// The file/exec tools resolve their sandbox root per-call from the
 		// run's VolumePolicy (RFC AH); an agent bound to no volume is refused
@@ -796,7 +803,9 @@ func main() {
 		httpTool,
 		&builtin.WebFetch{HTTP: httpTool},
 		&builtin.WebSearch{Registry: searchRegistry, Resolver: searchResolver, HostKeys: searchHostKeys, ShowProvenance: cfg.Env.WebSearchProvenance},
-		&builtin.Bash{Enabled: cfg.Env.BashEnabled},
+		// Bash — constructed above so CredResolve can be late-bound after the
+		// credential engine exists (per-tenant cred injection into the child env).
+		bashTool,
 		// Bashbox — a TRUE in-process sandbox (gbash): no OS process, paths
 		// rooted at the volume, no network, and read-only volumes are honored
 		// (writes hit an in-RAM overlay). Opt-in like Bash. Constructed above so
@@ -1414,6 +1423,29 @@ func main() {
 		res, found, err := credEngine.Resolve(ctx, ri.TenantID, tools.AgentName(ctx), ri.UserID, name)
 		if err != nil {
 			log.Printf("bashbox: credential resolve %q failed for tenant=%s: %v", name, ri.TenantID, err)
+			return "", false
+		}
+		if !found {
+			return "", false
+		}
+		registerSecret(res.Value)
+		return res.Value, true
+	}
+	// Raw Bash mirrors the Bashbox fallback: inject PER-TENANT credentials named
+	// in LOOMCYCLE_BASH_ALLOWED_CREDS into the child's env, resolved for the run's
+	// own identity (agent>user>tenant) — so a tenant's own GITHUB_TOKEN reaches
+	// the command instead of one shared operator host var. Only the
+	// operator-allowlisted names are injected; the value goes solely into the
+	// child's env (registerSecret masks any transcript echo). Fails soft (no KEK /
+	// miss → the host-env allowlist still applies).
+	bashTool.CredResolve = func(ctx context.Context, name string) (string, bool) {
+		if !credEngine.CanResolve() {
+			return "", false
+		}
+		ri := tools.RunIdentity(ctx)
+		res, found, err := credEngine.Resolve(ctx, ri.TenantID, tools.AgentName(ctx), ri.UserID, name)
+		if err != nil {
+			log.Printf("bash: credential resolve %q failed for tenant=%s: %v", name, ri.TenantID, err)
 			return "", false
 		}
 		if !found {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2089,6 +2089,15 @@ type Env struct {
 	// network calls. Operators wanting real isolation should run
 	// loomcycle inside a container or VM.
 	BashEnabled bool
+	// BashAllowedCreds names RFC AR credentials (by CredentialDef name, e.g.
+	// GITHUB_TOKEN) injected into the raw Bash tool's child env — a PER-TENANT
+	// counterpart to the operator-shared env allowlist: each is resolved for the
+	// run's own (tenant, user, agent) identity via the credential engine, so a
+	// tenant's own GITHUB_TOKEN reaches the command instead of one shared
+	// operator host var. A resolved cred overrides a same-named host env var.
+	// Sourced from LOOMCYCLE_BASH_ALLOWED_CREDS (comma-separated). Requires a KEK
+	// (LOOMCYCLE_SECRET_KEY) for the engine to resolve; empty (default) = none.
+	BashAllowedCreds []string
 	// BashboxEnabled gates the Bashbox tool — a TRUE in-process sandbox
 	// (gbash) that spawns no OS process, roots all paths at the mounted
 	// volume, and has no network. Unlike Bash it HONORS read-only volumes
@@ -2904,6 +2913,7 @@ func LoadLayers(layers ...Layer) (*Config, error) {
 		ClientToolMaxBytes:          int64(getenvInt("LOOMCYCLE_CLIENT_TOOL_MAX_BYTES", 1<<20)),
 		ClientToolMaxConns:          getenvInt("LOOMCYCLE_CLIENT_TOOL_MAX_CONNS", 8),
 		BashEnabled:                 os.Getenv("LOOMCYCLE_BASH_ENABLED") == "1",
+		BashAllowedCreds:            splitCSV(os.Getenv("LOOMCYCLE_BASH_ALLOWED_CREDS")),
 		BashboxEnabled:              os.Getenv("LOOMCYCLE_BASHBOX_ENABLED") == "1",
 		BashboxFallbackCommands:     splitCSV(os.Getenv("LOOMCYCLE_BASHBOX_FALLBACK_COMMANDS")),
 		BashboxFallbackAllowedEnv:   splitCSV(os.Getenv("LOOMCYCLE_BASHBOX_FALLBACK_ALLOWED_ENV")),

--- a/internal/tools/builtin/bash.go
+++ b/internal/tools/builtin/bash.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/tools"
@@ -179,6 +180,45 @@ func scrubbedHostEnv(allowedExtra []string) []string {
 	}
 	for _, name := range allowedExtra {
 		if v := os.Getenv(name); v != "" {
+			out = append(out, name+"="+v)
+		}
+	}
+	return out
+}
+
+// mergeCredEnv overlays per-tenant RFC AR credentials onto a host env slice.
+// host is the operator-allowlisted host vars (from scrubbedHostEnv); for each
+// name in allowedCreds it resolves the run's own (tenant/user/agent) credential
+// via resolve and either OVERRIDES a same-named host var or appends it — so a
+// tenant-specific secret wins over a shared operator host var. resolve==nil or
+// no cred names → host is returned unchanged (byte-identical to the pre-cred
+// behavior). Shared by the Bash tool and the Bashbox host-command fallback so
+// the two security-sensitive credential-injection paths can't drift apart
+// (mirrors the scrubbedHostEnv sharing rationale). Deterministic order: host
+// names first (declared order), then creds not already contributed by a host
+// var. The resolved value is a secret — the caller must registerSecret it and
+// it goes only into the child's env, never a log.
+func mergeCredEnv(ctx context.Context, host, allowedCreds []string, resolve func(ctx context.Context, name string) (string, bool)) []string {
+	if resolve == nil || len(allowedCreds) == 0 {
+		return host
+	}
+	idx := make(map[string]int, len(host)) // name -> position in out
+	out := make([]string, 0, len(host)+len(allowedCreds))
+	for _, kv := range host {
+		if i := strings.IndexByte(kv, '='); i > 0 {
+			idx[kv[:i]] = len(out)
+		}
+		out = append(out, kv)
+	}
+	for _, name := range allowedCreds {
+		v, ok := resolve(ctx, name)
+		if !ok || v == "" {
+			continue
+		}
+		if pos, seen := idx[name]; seen {
+			out[pos] = name + "=" + v // cred overrides the host var
+		} else {
+			idx[name] = len(out)
 			out = append(out, name+"="+v)
 		}
 	}

--- a/internal/tools/builtin/bash.go
+++ b/internal/tools/builtin/bash.go
@@ -45,6 +45,22 @@ type Bash struct {
 	// because most binaries break without it). Empty by default —
 	// only PATH leaks.
 	AllowedExtraEnv []string
+
+	// AllowedCreds names RFC AR credentials (by CredentialDef name, e.g.
+	// GITHUB_TOKEN) injected into the child's env — a PER-TENANT counterpart to
+	// AllowedExtraEnv (which reads one shared operator host var). Each is
+	// resolved for the run's own (tenant, user, agent) identity via CredResolve,
+	// so a tenant's own GITHUB_TOKEN reaches the command instead of one shared
+	// operator host var. A resolved cred OVERRIDES a same-named host env var.
+	// Empty (default) = none, so behavior is unchanged unless the operator opts
+	// in with LOOMCYCLE_BASH_ALLOWED_CREDS.
+	AllowedCreds []string
+	// CredResolve resolves an RFC AR credential by NAME for the run on ctx (the
+	// tenant/user/agent come from the run identity on ctx, so resolution is
+	// tenant-isolated), returning (value, ok). Wired to credential.Engine.Resolve.
+	// nil = credential injection disabled. The value is a secret — it goes only
+	// into the child's env and must never be logged.
+	CredResolve func(ctx context.Context, name string) (string, bool)
 }
 
 func (b *Bash) Name() string { return "Bash" }
@@ -121,7 +137,9 @@ func (b *Bash) Execute(ctx context.Context, input json.RawMessage) (tools.Result
 
 	cmd := exec.CommandContext(runCtx, "/bin/sh", "-c", args.Command)
 	cmd.Dir = cwd
-	cmd.Env = b.buildEnv()
+	// Pass the original Execute ctx (carries the run identity) rather than the
+	// timeout-bound runCtx — see buildEnv.
+	cmd.Env = b.buildEnv(ctx)
 	// Capture combined output through a bounded buffer. We write to a
 	// LimitedWriter rather than reading all-at-once so a malicious command
 	// can't OOM us by producing 100 GiB of output before we read it.
@@ -163,9 +181,14 @@ func (b *Bash) Execute(ctx context.Context, input json.RawMessage) (tools.Result
 // buildEnv constructs the env passed to the child. Only PATH leaks by
 // default (most binaries are unusable without it), plus any explicitly
 // allow-listed names. Sensitive secrets like API keys never leak — the
-// model could otherwise extract them via `env`.
-func (b *Bash) buildEnv() []string {
-	return scrubbedHostEnv(b.AllowedExtraEnv)
+// model could otherwise extract them via `env`. On top of that, any RFC AR
+// credential in AllowedCreds is resolved for THIS run's identity (from ctx)
+// and injected per-tenant, overriding a same-named host var. ctx is the
+// caller's Execute ctx (carries the run identity), NOT the command's
+// timeout-bound context — a credential store read is setup, not part of the
+// bounded command execution, so it must not race the command's wall-clock.
+func (b *Bash) buildEnv(ctx context.Context) []string {
+	return mergeCredEnv(ctx, scrubbedHostEnv(b.AllowedExtraEnv), b.AllowedCreds, b.CredResolve)
 }
 
 // scrubbedHostEnv builds the environment for a host child process: PATH always

--- a/internal/tools/builtin/bash_test.go
+++ b/internal/tools/builtin/bash_test.go
@@ -183,3 +183,104 @@ func TestBashCallerTimeoutCappedAtHardCeiling(t *testing.T) {
 		t.Errorf("missing output: %q", res.Text)
 	}
 }
+
+// TestBash_BuildEnv_InjectsTenantCreds: the child env carries PATH + the host
+// allowlist + per-tenant credentials (resolved from the run's ctx identity), and
+// a cred OVERRIDES a same-named host var. Tenant B resolves a different token —
+// proving resolution is ctx/tenant-scoped. Mirrors the Bashbox fallback test.
+func TestBash_BuildEnv_InjectsTenantCreds(t *testing.T) {
+	t.Setenv("LOOMCYCLE_TEST_HOSTVAR", "hostval")
+	t.Setenv("LOOMCYCLE_TEST_SHARED", "from-host")
+
+	b := &Bash{
+		AllowedExtraEnv: []string{"LOOMCYCLE_TEST_HOSTVAR", "LOOMCYCLE_TEST_SHARED"},
+		AllowedCreds:    []string{"GITHUB_TOKEN", "LOOMCYCLE_TEST_SHARED"},
+		CredResolve: func(ctx context.Context, name string) (string, bool) {
+			ten := tools.RunIdentity(ctx).TenantID
+			switch name {
+			case "GITHUB_TOKEN":
+				return "tok-" + ten, true
+			case "LOOMCYCLE_TEST_SHARED":
+				return "from-cred", true
+			}
+			return "", false
+		},
+	}
+	envMap := func(ctx context.Context) map[string]string {
+		m := map[string]string{}
+		for _, kv := range b.buildEnv(ctx) {
+			if i := strings.IndexByte(kv, '='); i > 0 {
+				m[kv[:i]] = kv[i+1:]
+			}
+		}
+		return m
+	}
+
+	m := envMap(tools.WithRunIdentity(context.Background(), tools.RunIdentityValue{TenantID: "acme"}))
+	if _, ok := m["PATH"]; !ok {
+		t.Errorf("PATH should always pass")
+	}
+	if m["LOOMCYCLE_TEST_HOSTVAR"] != "hostval" {
+		t.Errorf("host allowlist var missing: %v", m)
+	}
+	if m["GITHUB_TOKEN"] != "tok-acme" {
+		t.Errorf("per-tenant cred = %q, want tok-acme", m["GITHUB_TOKEN"])
+	}
+	if m["LOOMCYCLE_TEST_SHARED"] != "from-cred" {
+		t.Errorf("cred must override same-named host var, got %q", m["LOOMCYCLE_TEST_SHARED"])
+	}
+
+	mb := envMap(tools.WithRunIdentity(context.Background(), tools.RunIdentityValue{TenantID: "beta"}))
+	if mb["GITHUB_TOKEN"] != "tok-beta" {
+		t.Errorf("tenant B cred = %q, want tok-beta (tenant isolation)", mb["GITHUB_TOKEN"])
+	}
+}
+
+// TestBash_BuildEnv_NoResolverIsHostOnly: without CredResolve wired, the declared
+// cred names resolve to nothing (host env only) — byte-identical to the
+// pre-feature behavior (operator must opt in).
+func TestBash_BuildEnv_NoResolverIsHostOnly(t *testing.T) {
+	b := &Bash{AllowedCreds: []string{"GITHUB_TOKEN"}} // CredResolve nil
+	for _, kv := range b.buildEnv(context.Background()) {
+		if strings.HasPrefix(kv, "GITHUB_TOKEN=") {
+			t.Errorf("no CredResolve → creds must not resolve, got %q", kv)
+		}
+	}
+}
+
+// TestBash_InjectsCredIntoChildEnv: a resolved per-tenant credential actually
+// lands in the REAL subprocess env (`env` output) and overrides a same-named
+// host var — exercises the full run-time path, not just buildEnv.
+func TestBash_InjectsCredIntoChildEnv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
+	t.Setenv("LOOMCYCLE_TEST_CRED", "from-host") // host var the cred must override
+	cwd, _ := filepath.EvalSymlinks(t.TempDir())
+	b := &Bash{
+		Enabled:         true,
+		AllowedExtraEnv: []string{"LOOMCYCLE_TEST_CRED"},
+		AllowedCreds:    []string{"LOOMCYCLE_TEST_CRED"},
+		CredResolve: func(ctx context.Context, name string) (string, bool) {
+			if name == "LOOMCYCLE_TEST_CRED" {
+				return "tenant-cred-" + tools.RunIdentity(ctx).TenantID, true
+			}
+			return "", false
+		},
+	}
+	ctx := tools.WithRunIdentity(bashCtx(cwd), tools.RunIdentityValue{TenantID: "acme"})
+	body, _ := json.Marshal(map[string]string{"command": "env"})
+	res, err := b.Execute(ctx, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error: %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "LOOMCYCLE_TEST_CRED=tenant-cred-acme") {
+		t.Errorf("per-tenant cred not injected into child env: %q", res.Text)
+	}
+	if strings.Contains(res.Text, "LOOMCYCLE_TEST_CRED=from-host") {
+		t.Errorf("cred must override the same-named host var, but host value leaked: %q", res.Text)
+	}
+}

--- a/internal/tools/builtin/bashbox.go
+++ b/internal/tools/builtin/bashbox.go
@@ -223,31 +223,7 @@ func (b *Bashbox) fallbackProxy(name, hostRoot string, readOnly bool) commands.C
 // Deterministic order: host names first (in declared order), then creds that were
 // not already contributed by a host var.
 func (b *Bashbox) fallbackEnv(ctx context.Context) []string {
-	host := scrubbedHostEnv(b.FallbackAllowedEnv)
-	if b.CredResolve == nil || len(b.FallbackAllowedCreds) == 0 {
-		return host
-	}
-	idx := make(map[string]int, len(host)) // name -> position in out
-	out := make([]string, 0, len(host)+len(b.FallbackAllowedCreds))
-	for _, kv := range host {
-		if i := strings.IndexByte(kv, '='); i > 0 {
-			idx[kv[:i]] = len(out)
-		}
-		out = append(out, kv)
-	}
-	for _, name := range b.FallbackAllowedCreds {
-		v, ok := b.CredResolve(ctx, name)
-		if !ok || v == "" {
-			continue
-		}
-		if pos, seen := idx[name]; seen {
-			out[pos] = name + "=" + v // cred overrides the host var
-		} else {
-			idx[name] = len(out)
-			out = append(out, name+"="+v)
-		}
-	}
-	return out
+	return mergeCredEnv(ctx, scrubbedHostEnv(b.FallbackAllowedEnv), b.FallbackAllowedCreds, b.CredResolve)
 }
 
 // fallbackHostCwd maps the sandbox working directory to a real host path. In rw


### PR DESCRIPTION
## Why

Bashbox's host-command fallback already resolves per-tenant RFC AR credentials into a child's env (`FallbackAllowedCreds` + `CredResolve`), but **raw Bash's env allowlist was config-wired for host vars only**. A raw-Bash agent could therefore only receive one shared operator host var — never a per-tenant secret (e.g. a per-tenant `GITHUB_TOKEN`). This mirrors the Bashbox pattern for raw Bash so a tenant's own credential reaches the command.

## What

- **`internal/tools/builtin/bash.go`** — add `AllowedCreds []string` + `CredResolve func(ctx, name) (string, bool)` to the `Bash` tool (mirroring Bashbox). `buildEnv` now takes `ctx` and injects the resolved per-tenant creds via a shared helper; a resolved cred **overrides** a same-named host var, exactly like Bashbox.
- **`mergeCredEnv` (shared helper)** — extracted from `Bashbox.fallbackEnv` in a preceding pure-refactor commit so the two security-sensitive credential-injection paths can't drift apart (the same rationale the existing `scrubbedHostEnv` comment documents). Bashbox now delegates to it; no behavior change, guarded by the existing `TestBashbox_FallbackEnv_*` tests.
- **`internal/config/config.go`** — new knob `LOOMCYCLE_BASH_ALLOWED_CREDS` (comma-separated cred names), parsed into `Env.BashAllowedCreds`.
- **`cmd/loomcycle/main.go`** — `Bash` is now a named var (like `bashboxTool`) so its `CredResolve` is late-bound after the credential engine exists; the closure resolves for the run's `(tenant, agent, user)` identity and `registerSecret`s the value.

### Security posture (no raw-Bash protection weakened)
- **Tenant-isolated:** resolution keys off the run's own `(tenant, user, agent)` identity from `ctx` — never model-supplied.
- **Secrets never leak:** the resolved value goes solely into the child's env and is `registerSecret`'d; only the cred NAME + tenant are ever logged (never the value).
- **Opt-in / fail-soft:** unset `LOOMCYCLE_BASH_ALLOWED_CREDS` → `mergeCredEnv` returns the host env **unchanged** (byte-identical to before). No KEK / a miss → the host-env allowlist still applies.
- **Untouched:** cwd-binding, env-scrubbing (only PATH + allowlisted names + opt-in creds leak), output bounds, and the command timeout. `buildEnv` takes the un-timeout'd `Execute` ctx so a credential store read is not part of the bounded command execution.

## Changelog (not in REVISIONS.md/README.md per convention)
Runtime-only. New env knob `LOOMCYCLE_BASH_ALLOWED_CREDS`. No wire/schema change.

## What was tested
- `go test ./...` — full suite passes clean (exit 0).
- `go vet ./...` on affected packages — clean. `gofmt` clean (config.go env-parse block verified with `git diff --ignore-all-space`: only intended lines changed, alignment column unmoved).
- New tests in `internal/tools/builtin/bash_test.go`:
  - `TestBash_BuildEnv_InjectsTenantCreds` — per-tenant cred injected; tenant A vs B isolation; cred overrides same-named host var.
  - `TestBash_BuildEnv_NoResolverIsHostOnly` — not configured → host env only (opt-in posture).
  - `TestBash_InjectsCredIntoChildEnv` — cred lands in the REAL subprocess `env` output and overrides the host var (full run-time path).
- Existing `TestBashbox_FallbackEnv_*` still pass → the `mergeCredEnv` extraction is behavior-preserving.
- Manual: `go build -o bin/loomcycle ./cmd/loomcycle` succeeds; binary boots the config-load path (`env-template`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)