### PR TITLE
feat(teams): persistent board walk + interruption-on-cap for op=run

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -970,6 +970,35 @@ func main() {
 	}
 	allTools = append(allTools, interruptionTool)
 
+	// RFC AP/BD — wire the TeamDef op=run board + interruption escalation deps
+	// (both opt-in per run; Spawn + Admit are injected separately by
+	// srv.SetTeamDefTool). Board persists a board-bound walk's position onto a
+	// Document chunk (chunk.status = current state) + resumes from it; AskHuman
+	// escalates an iteration cap to a human via the Interruption tool's `ask`
+	// instead of aborting. A run that sets neither board_chunk_id nor
+	// interrupt_on_cap is byte-identical to before. documentTool.SqlMem is
+	// late-bound below (Board holds the *Document pointer, reading SqlMem at call
+	// time), and AskHuman is invoked under the parent run's ctx so the block +
+	// resolve + heartbeat all reuse the standard Interruption machinery.
+	teamDefTool.Board = documentTool
+	teamDefTool.AskHuman = func(ctx context.Context, question string) (string, error) {
+		ask, _ := json.Marshal(map[string]any{"op": "ask", "question": question})
+		res, err := interruptionTool.Execute(ctx, ask)
+		if err != nil {
+			return "", err
+		}
+		if res.IsError {
+			// timeout / cancelled / not-enabled-for-agent / no-run-id — surface as
+			// an error so the cap escalation fails safe to abort.
+			return "", errors.New(res.Text)
+		}
+		var parsed struct {
+			Answer string `json:"answer"`
+		}
+		_ = json.Unmarshal([]byte(res.Text), &parsed)
+		return parsed.Answer, nil
+	}
+
 	// Context tool (v0.8.7). Read-only runtime introspection. The Tools
 	// field is back-filled with the FULL allTools slice after every
 	// other registration (MCP + localapi) so doc/tools ops reflect the

--- a/internal/teamrun/orchestrator.go
+++ b/internal/teamrun/orchestrator.go
@@ -73,6 +73,63 @@ func (e *ErrIterationCap) Error() string {
 	return fmt.Sprintf("teamrun: state %q exceeded max_iterations (%d > %d)", e.State, e.Count, e.Max)
 }
 
+// CapAction is what a cap observer (OnCap) decides when a state trips its
+// per-state iteration cap. The zero value is CapAbort so a nil/incomplete
+// decision fails safe — the termination guarantee holds no matter what the
+// observer returns.
+type CapAction int
+
+const (
+	// CapAbort terminates the walk with *ErrIterationCap (the same outcome as
+	// having no observer). It is the zero value — an unanswered / timed-out /
+	// declined human interruption maps here, so the walk always terminates.
+	CapAbort CapAction = iota
+	// CapContinue grants the capped state one more full max-iteration window
+	// (the tripping entry becomes #1 of the new window) and runs its handler.
+	CapContinue
+	// CapReroute abandons the capped state's handler this cycle and jumps the
+	// walk to Reroute instead, clearing the capped state's counter so a later
+	// revisit gets a fresh window. An empty/unknown Reroute target degrades to
+	// CapAbort at the next state lookup (fail safe).
+	CapReroute
+)
+
+// CapDecision is an OnCap observer's ruling.
+type CapDecision struct {
+	Action  CapAction
+	Reroute string // target state id when Action == CapReroute
+}
+
+// Option customizes a Walk. Zero options → the walk behaves exactly as the
+// bare four-argument form always has (nothing observed; a cap returns
+// *ErrIterationCap), so existing callers and the default op=run path are
+// byte-identical.
+type Option func(*walkConfig)
+
+type walkConfig struct {
+	// onEnterState fires once for each state the walk enters (including the
+	// terminal state), with that state's id. A board-bound run persists the
+	// position here (chunk.status = state). A returned error aborts the walk.
+	onEnterState func(ctx context.Context, state string) error
+	// onCap fires when a state trips its iteration cap. Its CapDecision steers
+	// the walk (abort / continue / reroute). A returned error aborts the walk
+	// with that error. nil = a cap returns *ErrIterationCap as before.
+	onCap func(ctx context.Context, cap *ErrIterationCap) (CapDecision, error)
+}
+
+// OnEnterState registers a hook fired as the walk enters each state (terminal
+// included) — the seam a durable board-bound run uses to persist chunk.status.
+func OnEnterState(f func(ctx context.Context, state string) error) Option {
+	return func(c *walkConfig) { c.onEnterState = f }
+}
+
+// OnCap registers a hook that decides what happens when a state trips its
+// iteration cap — the seam for human-in-the-loop escalation (Interruption).
+// Without it a cap terminates the walk with *ErrIterationCap.
+func OnCap(f func(ctx context.Context, cap *ErrIterationCap) (CapDecision, error)) Option {
+	return func(c *walkConfig) { c.onCap = f }
+}
+
 // Walk drives task from its current state (or the definition's entry when
 // task.State is empty) to a terminal state, mutating task in place as it goes:
 // each non-terminal state's handler runs via r, its selected edge picks the next
@@ -80,11 +137,18 @@ func (e *ErrIterationCap) Error() string {
 // executed states.
 //
 // Termination is guaranteed: every non-terminal state increments its own entry
-// count, and exceeding the per-state cap returns *ErrIterationCap. So a
-// pushback loop that never converges is bounded, not infinite.
-func Walk(ctx context.Context, d teamgraph.Definition, task *Task, r Runner) ([]StepRecord, error) {
+// count, and exceeding the per-state cap returns *ErrIterationCap — unless an
+// OnCap observer rules CapContinue/CapReroute, in which case the loop is bounded
+// instead by how long a human keeps answering (an unanswered/aborted decision
+// still returns *ErrIterationCap). So a pushback loop that never converges is
+// always bounded, never infinite.
+func Walk(ctx context.Context, d teamgraph.Definition, task *Task, r Runner, opts ...Option) ([]StepRecord, error) {
 	if task == nil {
 		return nil, fmt.Errorf("teamrun: nil task")
+	}
+	var cfg walkConfig
+	for _, o := range opts {
+		o(&cfg)
 	}
 	if task.State == "" {
 		task.State = d.Entry
@@ -103,6 +167,15 @@ func Walk(ctx context.Context, d teamgraph.Definition, task *Task, r Runner) ([]
 		if !ok {
 			return trace, fmt.Errorf("teamrun: current state %q is not in the team definition", task.State)
 		}
+		// Observe the entered (validated) state before dispatch, so a board-bound
+		// run persists the position it is ABOUT to work — a crash resumes at this
+		// state (at-least-once for its handler). Fires for the terminal state too,
+		// so a completed board lands on the end state.
+		if cfg.onEnterState != nil {
+			if err := cfg.onEnterState(ctx, st.ID); err != nil {
+				return trace, err
+			}
+		}
 		if st.Handler.Kind == teamgraph.HandlerTerminal {
 			return trace, nil // reached an end state — done
 		}
@@ -111,7 +184,27 @@ func Walk(ctx context.Context, d teamgraph.Definition, task *Task, r Runner) ([]
 		// non-converging loop can't spend an extra handler run on overflow.
 		task.IterationCounts[st.ID]++
 		if n := task.IterationCounts[st.ID]; n > max {
-			return trace, &ErrIterationCap{State: st.ID, Count: n, Max: max}
+			capErr := &ErrIterationCap{State: st.ID, Count: n, Max: max}
+			if cfg.onCap == nil {
+				return trace, capErr
+			}
+			dec, err := cfg.onCap(ctx, capErr)
+			if err != nil {
+				return trace, err
+			}
+			switch dec.Action {
+			case CapContinue:
+				// Fresh window; this tripping entry becomes iteration #1.
+				task.IterationCounts[st.ID] = 1
+			case CapReroute:
+				// Unstick the capped state (fresh window on a future revisit) and
+				// jump. An unknown target is caught by StateByID next iteration.
+				task.IterationCounts[st.ID] = 0
+				task.State = dec.Reroute
+				continue
+			default: // CapAbort (and the zero value) — terminate, fail safe.
+				return trace, capErr
+			}
 		}
 
 		out, err := r.RunHandler(ctx, st, task.Input)

--- a/internal/teamrun/orchestrator_test.go
+++ b/internal/teamrun/orchestrator_test.go
@@ -168,6 +168,178 @@ func TestWalk_ContextCancelAborts(t *testing.T) {
 	}
 }
 
+// pingPongJSON is an a↔b success loop with no terminal + cap 2 — it never
+// converges, so the per-state cap always fires (the OnCap escalation seam).
+const pingPongJSON = `{
+  "entry":"a",
+  "max_iterations":2,
+  "states":[
+    {"state":"a","handler":{"kind":"agent","agent":"a"}},
+    {"state":"b","handler":{"kind":"agent","agent":"b"}}
+  ],
+  "transitions":[
+    {"from":"a","to":"b","on":"success"},
+    {"from":"b","to":"a","on":"success"}
+  ]}`
+
+// rerouteJSON is the a↔b loop plus a terminal `done` reachable via a
+// never-taken pushback edge — the fake always takes success, so `done` is only
+// reached when an OnCap reroute jumps to it.
+const rerouteJSON = `{
+  "entry":"a",
+  "max_iterations":2,
+  "states":[
+    {"state":"a","handler":{"kind":"agent","agent":"a"}},
+    {"state":"b","handler":{"kind":"agent","agent":"b"}},
+    {"state":"done","handler":{"kind":"terminal"}}
+  ],
+  "transitions":[
+    {"from":"a","to":"b","on":"success"},
+    {"from":"b","to":"a","on":"success"},
+    {"from":"b","to":"done","on":"pushback:stop"}
+  ]}`
+
+// TestWalk_OnEnterStateObservesEveryEnteredState pins the board-persistence seam:
+// OnEnterState fires once per entered state, in order, INCLUDING the terminal —
+// so a board-bound run's chunk.status lands on the end state when the walk
+// completes.
+func TestWalk_OnEnterStateObservesEveryEnteredState(t *testing.T) {
+	d := mustParse(t, linearJSON) // a → b → c(terminal)
+	var entered []string
+	if _, err := Walk(context.Background(), d, &Task{Input: "seed"}, &fakeRunner{},
+		OnEnterState(func(_ context.Context, s string) error {
+			entered = append(entered, s)
+			return nil
+		})); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if want := []string{"a", "b", "c"}; !equalStrs(entered, want) {
+		t.Errorf("entered %v, want %v (terminal observed too)", entered, want)
+	}
+}
+
+// TestWalk_OnEnterStateFiresOnResume proves a resumed walk (preset State) re-
+// observes from the persisted position, not the entry — so a board-bound run
+// continues where it left off.
+func TestWalk_OnEnterStateFiresOnResume(t *testing.T) {
+	d := mustParse(t, linearJSON)
+	var entered []string
+	if _, err := Walk(context.Background(), d, &Task{State: "b"}, &fakeRunner{},
+		OnEnterState(func(_ context.Context, s string) error {
+			entered = append(entered, s)
+			return nil
+		})); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if want := []string{"b", "c"}; !equalStrs(entered, want) {
+		t.Errorf("entered %v, want %v (resumed at b, no a)", entered, want)
+	}
+}
+
+// TestWalk_OnEnterStateErrorAborts: a persistence failure aborts the walk before
+// the failing state's handler runs (durability is load-bearing — a walk that
+// can't record its position must not advance).
+func TestWalk_OnEnterStateErrorAborts(t *testing.T) {
+	d := mustParse(t, linearJSON)
+	r := &fakeRunner{}
+	sentinel := errors.New("persist failed")
+	_, err := Walk(context.Background(), d, &Task{}, r,
+		OnEnterState(func(_ context.Context, s string) error {
+			if s == "b" {
+				return sentinel
+			}
+			return nil
+		}))
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("want sentinel error, got %v", err)
+	}
+	if len(r.calls) != 1 || r.calls[0] != "a" {
+		t.Errorf("ran %v, want [a] (b handler must not run after its persist fails)", r.calls)
+	}
+}
+
+// TestWalk_OnCapContinueGrantsAnotherWindow: a CapContinue ruling resets the
+// capped state's window and keeps walking; a later CapAbort still terminates with
+// *ErrIterationCap. Proves the human-in-the-loop escalation is bounded by the
+// human's answers, never infinite.
+func TestWalk_OnCapContinueGrantsAnotherWindow(t *testing.T) {
+	d := mustParse(t, pingPongJSON)
+	calls := 0
+	_, err := Walk(context.Background(), d, &Task{}, &fakeRunner{},
+		OnCap(func(_ context.Context, _ *ErrIterationCap) (CapDecision, error) {
+			calls++
+			if calls == 1 {
+				return CapDecision{Action: CapContinue}, nil
+			}
+			return CapDecision{Action: CapAbort}, nil
+		}))
+	var cap *ErrIterationCap
+	if !errors.As(err, &cap) {
+		t.Fatalf("want *ErrIterationCap after abort, got %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("onCap called %d times, want 2 (continue once, then abort)", calls)
+	}
+}
+
+// TestWalk_OnCapRerouteJumpsToTarget: a CapReroute ruling jumps the walk to the
+// named state without running the capped state's handler; rerouting to a terminal
+// completes the walk cleanly.
+func TestWalk_OnCapRerouteJumpsToTarget(t *testing.T) {
+	d := mustParse(t, rerouteJSON)
+	task := &Task{}
+	_, err := Walk(context.Background(), d, task, &fakeRunner{},
+		OnCap(func(_ context.Context, _ *ErrIterationCap) (CapDecision, error) {
+			return CapDecision{Action: CapReroute, Reroute: "done"}, nil
+		}))
+	if err != nil {
+		t.Fatalf("reroute to a terminal should complete, got %v", err)
+	}
+	if task.State != "done" {
+		t.Errorf("final state = %q, want done (rerouted)", task.State)
+	}
+}
+
+// TestWalk_OnCapAbortReturnsCapErr: an explicit CapAbort (and the zero-value
+// decision) terminates with *ErrIterationCap — the same outcome as no observer.
+func TestWalk_OnCapAbortReturnsCapErr(t *testing.T) {
+	d := mustParse(t, pingPongJSON)
+	_, err := Walk(context.Background(), d, &Task{}, &fakeRunner{},
+		OnCap(func(_ context.Context, _ *ErrIterationCap) (CapDecision, error) {
+			return CapDecision{Action: CapAbort}, nil
+		}))
+	var cap *ErrIterationCap
+	if !errors.As(err, &cap) {
+		t.Fatalf("abort should return *ErrIterationCap, got %v", err)
+	}
+}
+
+// TestWalk_OnCapErrorPropagates: an error from the OnCap observer aborts the walk
+// with that error (e.g. the interruption machinery is unreachable).
+func TestWalk_OnCapErrorPropagates(t *testing.T) {
+	d := mustParse(t, pingPongJSON)
+	sentinel := errors.New("interruption bus down")
+	_, err := Walk(context.Background(), d, &Task{}, &fakeRunner{},
+		OnCap(func(_ context.Context, _ *ErrIterationCap) (CapDecision, error) {
+			return CapDecision{}, sentinel
+		}))
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("want sentinel, got %v", err)
+	}
+}
+
+func equalStrs(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func contains(s, sub string) bool {
 	for i := 0; i+len(sub) <= len(s); i++ {
 		if s[i:i+len(sub)] == sub {

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -385,6 +385,73 @@ func (d *Document) getChunkRow(ctx context.Context, key sqlmem.ScopeKey, id stri
 	return scanChunkRow(res.Columns, res.Rows[0]), true, nil
 }
 
+// --- board surface (chunk.status as a durable walk position) ---
+
+// GetChunkStatus reads a chunk's status field. It is the narrow read half of the
+// Document-board surface a TeamDef `op=run` uses to RESUME from a persisted walk
+// position (chunk.status = the team state to continue from). scope is "agent" or
+// "user" (default user); the ScopeKey + tenant come from ctx exactly as the
+// tool's own ops resolve them. ok=false when the chunk doesn't exist in this
+// scope (so a caller can distinguish "no such chunk" from "status is empty").
+func (d *Document) GetChunkStatus(ctx context.Context, scope, chunkID string) (status string, ok bool, err error) {
+	if d.Store == nil || d.SqlMem == nil {
+		return "", false, fmt.Errorf("Document board: requires SQL Memory (set LOOMCYCLE_SQLMEM_ENABLED=1)")
+	}
+	key, _, err := d.resolveScope(ctx, scope)
+	if err != nil {
+		return "", false, err
+	}
+	if err := d.ensureSchema(ctx, key); err != nil {
+		return "", false, err
+	}
+	row, found, err := d.getChunkRow(ctx, key, chunkID)
+	if err != nil {
+		return "", false, err
+	}
+	if !found {
+		return "", false, nil
+	}
+	return row.Status, true, nil
+}
+
+// SetChunkStatus sets a chunk's status field — the write half of the board
+// surface, called on each state transition so chunk.status durably reflects the
+// walk's current position. It reuses the same atomic, revision-guarded bump as
+// update_chunk (read the current revision, then UPDATE ... WHERE revision = ?)
+// so a concurrent human/agent edit of the same chunk is a clean conflict rather
+// than a silent lost write. Reusing the tool's SQL path keeps the chunk-schema
+// logic in one place (no hand-rolled board SQL to drift). A best-effort change
+// event lets the Web UI board follow along live.
+func (d *Document) SetChunkStatus(ctx context.Context, scope, chunkID, status string) error {
+	if d.Store == nil || d.SqlMem == nil {
+		return fmt.Errorf("Document board: requires SQL Memory (set LOOMCYCLE_SQLMEM_ENABLED=1)")
+	}
+	key, mscope, err := d.resolveScope(ctx, scope)
+	if err != nil {
+		return err
+	}
+	if err := d.ensureSchema(ctx, key); err != nil {
+		return err
+	}
+	row, found, err := d.getChunkRow(ctx, key, chunkID)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("no such chunk: %s", chunkID)
+	}
+	now := time.Now().UnixNano()
+	res, err := d.SqlMem.Exec(ctx, key, d.SqlMem.Rebind(`UPDATE chunks SET status = ?, revision = revision + 1, updated_at = ? WHERE id = ? AND revision = ?`), []any{nullIfEmpty(status), now, chunkID, row.Revision}, 0)
+	if err != nil {
+		return err
+	}
+	if res.RowsAffected == 0 {
+		return fmt.Errorf("chunk %s: revision conflict setting status (changed by a concurrent write)", chunkID)
+	}
+	d.publishChange(ctx, mscope, key.ScopeID, row.DocumentID, "update_chunk", chunkID)
+	return nil
+}
+
 // --- ops: document lifecycle ---
 
 func (d *Document) createDocument(ctx context.Context, key sqlmem.ScopeKey, mscope store.MemoryScope, in docInput) (tools.Result, error) {

--- a/internal/tools/builtin/document_test.go
+++ b/internal/tools/builtin/document_test.go
@@ -729,3 +729,64 @@ func TestDocument_SetPath(t *testing.T) {
 		t.Errorf("set_path on unknown id should fail")
 	}
 }
+
+// TestDocument_ChunkStatusBoardRoundTrip exercises the board surface the TeamDef
+// op=run walk drives: SetChunkStatus persists a chunk's status (revision-guarded,
+// reusing update_chunk's atomic bump) and GetChunkStatus reads it back — the
+// durable, resumable walk position. A missing chunk is ok=false on read and an
+// error on write (never a phantom).
+func TestDocument_ChunkStatusBoardRoundTrip(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+
+	out, res := docExec(t, d, ctx, `{"op":"create_document","scope":"agent","title":"Board"}`)
+	if res.IsError {
+		t.Fatalf("create_document: %s", res.Text)
+	}
+	docID, _ := out["document_id"].(string)
+	out, res = docExec(t, d, ctx, `{"op":"create_chunk","scope":"agent","document_id":"`+docID+`","title":"task"}`)
+	if res.IsError {
+		t.Fatalf("create_chunk: %s", res.Text)
+	}
+	chunkID, _ := out["id"].(string)
+
+	// Fresh chunk: exists, no status yet.
+	status, ok, err := d.GetChunkStatus(ctx, "agent", chunkID)
+	if err != nil {
+		t.Fatalf("GetChunkStatus: %v", err)
+	}
+	if !ok || status != "" {
+		t.Errorf("fresh chunk status = (%q,%v), want (\"\",true)", status, ok)
+	}
+
+	// Persist a status, read it back — and confirm the tool's own get_chunk agrees.
+	if err := d.SetChunkStatus(ctx, "agent", chunkID, "review"); err != nil {
+		t.Fatalf("SetChunkStatus: %v", err)
+	}
+	status, ok, err = d.GetChunkStatus(ctx, "agent", chunkID)
+	if err != nil {
+		t.Fatalf("GetChunkStatus: %v", err)
+	}
+	if !ok || status != "review" {
+		t.Errorf("status = (%q,%v), want (review,true)", status, ok)
+	}
+	got, _ := docExec(t, d, ctx, `{"op":"get_chunk","scope":"agent","id":"`+chunkID+`"}`)
+	if got["status"] != "review" {
+		t.Errorf("get_chunk status = %v, want review (board write visible to the tool)", got["status"])
+	}
+
+	// Advance the status (the transition case).
+	if err := d.SetChunkStatus(ctx, "agent", chunkID, "done"); err != nil {
+		t.Fatalf("SetChunkStatus: %v", err)
+	}
+	if status, _, _ = d.GetChunkStatus(ctx, "agent", chunkID); status != "done" {
+		t.Errorf("status = %q, want done", status)
+	}
+
+	// Unknown chunk: ok=false on read, error on write (no phantom).
+	if _, ok, err := d.GetChunkStatus(ctx, "agent", "nope"); err != nil || ok {
+		t.Errorf("GetChunkStatus(nope) = (ok=%v,err=%v), want (false,nil)", ok, err)
+	}
+	if err := d.SetChunkStatus(ctx, "agent", "nope", "x"); err == nil || !strings.Contains(err.Error(), "no such chunk") {
+		t.Errorf("SetChunkStatus(nope) err = %v, want 'no such chunk'", err)
+	}
+}

--- a/internal/tools/builtin/teamdef.go
+++ b/internal/tools/builtin/teamdef.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	"github.com/denn-gubsky/loomcycle/internal/teamgraph"
@@ -67,6 +68,31 @@ type TeamDef struct {
 	// the walk (used for every spawned agent), or an error that aborts the run.
 	// nil = no admission (unit tests / authoring-only wiring).
 	Admit func(ctx context.Context) (context.Context, error)
+
+	// Board, if set, lets an op=run OPTIONALLY bind to a Document task board: when
+	// the caller passes board_chunk_id, the walk persists its position onto that
+	// chunk's status (chunk.status = the current team state) on every transition
+	// and RESUMES from the persisted status on the next run — durable, resumable
+	// progress. Satisfied by *Document (same package). nil = board binding is
+	// unavailable (board_chunk_id is then refused). Wired by SetTeamDefTool.
+	Board teamBoard
+
+	// AskHuman, if set, escalates an iteration-cap overflow to a human instead of
+	// aborting: when the caller passes interrupt_on_cap, a capped state raises an
+	// Interruption `ask` (this closure blocks until answered/timed-out/cancelled)
+	// and the answer decides continue / reroute:<state> / abort. It mirrors the
+	// Spawn/Admit injection — wired by the server to the Interruption tool. nil (or
+	// a run that omits interrupt_on_cap) = a cap returns the iteration_cap outcome.
+	AskHuman func(ctx context.Context, question string) (answer string, err error)
+}
+
+// teamBoard is the minimal Document-board surface a board-bound op=run needs: read
+// a chunk's status to resume, and set it to persist each transition. An interface
+// (satisfied by *Document, same package) keeps op=run testable with a fake and
+// documents exactly the two operations the walk performs against a board.
+type teamBoard interface {
+	GetChunkStatus(ctx context.Context, scope, chunkID string) (status string, ok bool, err error)
+	SetChunkStatus(ctx context.Context, scope, chunkID, status string) error
 }
 
 const teamDefDescription = `Author, fork, promote, retire, and inspect team workflow definitions at runtime (see Context op=help topic=agent-teams). ` +
@@ -78,7 +104,9 @@ const teamDefDescription = `Author, fork, promote, retire, and inspect team work
 	`scheme applied) for a stored team, or — when given an inline overlay — a dry-run preview of an unsaved ` +
 	`graph (syntax-checked, not persisted). run walks a team's graph for a given input — each state's agent runs via the ` +
 	`sub-agent machinery, output threads to the next state, until a terminal state (Phase 1: single-agent linear ` +
-	`teams; parallel/consolidator + pushback routing are deferred). retire soft-retires one version; delete ` +
+	`teams; parallel/consolidator + pushback routing are deferred). run may OPTIONALLY bind to a Document chunk board ` +
+	`(board_chunk_id) so progress persists as chunk.status and resumes across runs, and may escalate an iteration cap ` +
+	`to a human (interrupt_on_cap) instead of aborting. retire soft-retires one version; delete ` +
 	`hard-removes a whole team by name (all versions + active pointer), scoped to your tenant. Operations: ` +
 	`create, fork, get, list, retire, delete, promote, verify, render_diagram, run.`
 
@@ -107,7 +135,10 @@ const teamDefInputSchema = `{
     "content_sha256": {"type": "string", "description": "Input for op=verify — the local content hash to compare against the active row."},
     "format":         {"type": "string", "enum": ["mermaid","d2"], "description": "render_diagram output format (default mermaid; d2 is deferred)."},
     "highlight_state": {"type": "string", "description": "render_diagram: optionally mark this state (e.g. a chunk's current state) with a bold outline."},
-    "input":          {"type": "string", "description": "run: the initial input handed to the entry state's agent (the task/prompt the team works on)."}
+    "input":          {"type": "string", "description": "run: the initial input handed to the entry state's agent (the task/prompt the team works on)."},
+    "board_chunk_id": {"type": "string", "description": "run (optional): bind the walk to a Document chunk task board. Each state transition persists chunk.status = the current team state (durable progress), and a later run RESUMES from the persisted status. Omit for an ephemeral run (default)."},
+    "board_scope":    {"type": "string", "enum": ["agent","user"], "description": "run (optional): the Document scope of board_chunk_id (default user)."},
+    "interrupt_on_cap": {"type": "boolean", "description": "run (optional): when a state hits its iteration cap, ask a human (Interruption) whether to continue / reroute:<state> / abort instead of returning the iteration_cap outcome. An unanswered/timed-out/declined ask aborts (still terminates). Default false."}
   },
   "required": ["op"]
 }`
@@ -121,10 +152,13 @@ type teamDefInput struct {
 	Description    string          `json:"description,omitempty"`
 	Promote        *bool           `json:"promote,omitempty"`
 	Retired        *bool           `json:"retired,omitempty"`
-	ContentSHA256  string          `json:"content_sha256,omitempty"`  // input for op: verify
-	Format         string          `json:"format,omitempty"`          // render_diagram: mermaid (default) | d2
-	HighlightState string          `json:"highlight_state,omitempty"` // render_diagram: mark a state
-	Input          string          `json:"input,omitempty"`           // run: initial input to the entry state
+	ContentSHA256  string          `json:"content_sha256,omitempty"`   // input for op: verify
+	Format         string          `json:"format,omitempty"`           // render_diagram: mermaid (default) | d2
+	HighlightState string          `json:"highlight_state,omitempty"`  // render_diagram: mark a state
+	Input          string          `json:"input,omitempty"`            // run: initial input to the entry state
+	BoardChunkID   string          `json:"board_chunk_id,omitempty"`   // run: bind the walk to a Document chunk board
+	BoardScope     string          `json:"board_scope,omitempty"`      // run: board_chunk_id's Document scope (agent|user, default user)
+	InterruptOnCap bool            `json:"interrupt_on_cap,omitempty"` // run: escalate an iteration cap to a human instead of aborting
 }
 
 // Name implements tools.Tool.
@@ -563,12 +597,32 @@ func (t *TeamDef) execRenderDiagram(ctx context.Context, in teamDefInput) (tools
 // parallel/consolidator handler, or a pushback route (agent+consolidator), is a
 // loud not-yet-supported error rather than a silent success.
 //
-// The walk is ephemeral: the position isn't persisted to a Document chunk and a
-// cycle-cap overflow returns a clear error rather than raising an Interruption —
-// the chunk-backed persistent walk (with Interruption-on-cap) is a follow-up.
+// Two opt-in additions (RFC AP/BD), both additive — a run that sets neither is
+// byte-identical to the ephemeral Phase-1 path (no board, cap → iteration_cap):
+//   - board_chunk_id binds the walk to a Document chunk task board. Each state
+//     transition upserts the chunk's status to the current state (durable
+//     progress), and a later run RESUMES from the persisted status. The board
+//     tracks POSITION only — the threaded intermediate output is NOT persisted, so
+//     a resumed walk re-seeds the entry input from the caller's `input` (each
+//     state re-reads its working material from the chunk the agents co-author).
+//   - interrupt_on_cap escalates an iteration-cap overflow to a human via the
+//     Interruption machinery (continue / reroute:<state> / abort) instead of
+//     returning the iteration_cap outcome. An unanswered/declined ask aborts, so
+//     the termination guarantee holds.
 func (t *TeamDef) execRun(ctx context.Context, in teamDefInput) (tools.Result, error) {
 	if t.Spawn == nil {
 		return errResult("run: this TeamDef tool is not configured for execution (no runner wired)"), nil
+	}
+
+	// Board binding is opt-in; if requested it MUST be wired (a SQL-Memory-backed
+	// Document tool), else fail loud rather than silently dropping durability.
+	boardBound := in.BoardChunkID != ""
+	if boardBound && t.Board == nil {
+		return errResult("run: board_chunk_id set but this TeamDef tool has no Document board wired (requires SQL Memory)"), nil
+	}
+	boardScope := in.BoardScope
+	if boardScope == "" {
+		boardScope = "user"
 	}
 
 	var row store.TeamDefRow
@@ -613,7 +667,65 @@ func (t *TeamDef) execRun(ctx context.Context, in teamDefInput) (tools.Result, e
 	}
 
 	task := &teamrun.Task{Input: in.Input}
-	trace, walkErr := teamrun.Walk(walkCtx, def, task, teamrun.NewAgentRunner(t.Spawn))
+
+	// Assemble walk options. When neither feature is used, opts is empty and Walk
+	// runs with no options → the ephemeral Phase-1 behaviour is byte-identical.
+	var opts []teamrun.Option
+	resumedFrom := ""
+	if boardBound {
+		// Resume: continue from the chunk's persisted status when it names a state
+		// still in the current graph (a graph edit that dropped that state falls
+		// back to the entry — start over rather than resume into a hole).
+		status, ok, gerr := t.Board.GetChunkStatus(walkCtx, boardScope, in.BoardChunkID)
+		if gerr != nil {
+			return errResult(fmt.Sprintf("run: board: %s", gerr)), nil
+		}
+		if ok && status != "" {
+			if _, known := teamgraph.StateByID(def, status); known {
+				task.State = status
+				resumedFrom = status
+			}
+		}
+		opts = append(opts, teamrun.OnEnterState(func(c context.Context, state string) error {
+			if serr := t.Board.SetChunkStatus(c, boardScope, in.BoardChunkID, state); serr != nil {
+				return fmt.Errorf("board: %w", serr)
+			}
+			return nil
+		}))
+	}
+
+	interruptions := 0
+	lastDecision := ""
+	if in.InterruptOnCap && t.AskHuman != nil {
+		opts = append(opts, teamrun.OnCap(func(c context.Context, capErr *teamrun.ErrIterationCap) (teamrun.CapDecision, error) {
+			interruptions++
+			q := fmt.Sprintf(
+				"Team %q: state %q hit its iteration cap (%d entries > max %d). "+
+					"Reply `continue` to grant another %d-iteration window, `reroute:<state>` to jump to another state, or `abort` to stop.",
+				row.Name, capErr.State, capErr.Count, capErr.Max, capErr.Max)
+			answer, aerr := t.AskHuman(c, q)
+			if aerr != nil {
+				// Interruption unavailable / timed out / cancelled / declined →
+				// abort. Preserves the termination guarantee (a failed escalation
+				// never loops).
+				lastDecision = "abort"
+				return teamrun.CapDecision{Action: teamrun.CapAbort}, nil
+			}
+			dec := parseCapAnswer(answer)
+			// A reroute to an unknown state degrades to abort (fail safe) so a
+			// human typo can't send the walk into a non-existent state.
+			if dec.Action == teamrun.CapReroute {
+				if _, known := teamgraph.StateByID(def, dec.Reroute); !known {
+					lastDecision = "abort"
+					return teamrun.CapDecision{Action: teamrun.CapAbort}, nil
+				}
+			}
+			lastDecision = capActionLabel(dec)
+			return dec, nil
+		}))
+	}
+
+	trace, walkErr := teamrun.Walk(walkCtx, def, task, teamrun.NewAgentRunner(t.Spawn), opts...)
 
 	steps := make([]map[string]any, 0, len(trace))
 	for _, s := range trace {
@@ -626,12 +738,34 @@ func (t *TeamDef) execRun(ctx context.Context, in teamDefInput) (tools.Result, e
 		})
 	}
 
+	// annotate adds the opt-in board/interruption fields to a response ONLY when
+	// the relevant feature was used, keeping the default ephemeral response shape
+	// byte-identical for existing callers.
+	annotate := func(m map[string]any) map[string]any {
+		if boardBound {
+			m["board_chunk_id"] = in.BoardChunkID
+			m["board_scope"] = boardScope
+			if resumedFrom != "" {
+				m["resumed_from"] = resumedFrom
+			}
+		}
+		if in.InterruptOnCap {
+			m["interruptions"] = interruptions
+			if lastDecision != "" {
+				m["cap_decision"] = lastDecision
+			}
+		}
+		return m
+	}
+
 	if walkErr != nil {
 		var capErr *teamrun.ErrIterationCap
 		if errors.As(walkErr, &capErr) {
 			// Cap overflow is a first-class outcome, not a tool fault — report it
-			// with the trace so the caller sees how far the walk got.
-			return okJSON(map[string]any{
+			// with the trace so the caller sees how far the walk got. (When
+			// interrupt_on_cap escalated, this is the human's abort / a failed
+			// escalation; continue/reroute keep the walk going and don't land here.)
+			return okJSON(annotate(map[string]any{
 				"name":            row.Name,
 				"def_id":          row.DefID,
 				"status":          "iteration_cap",
@@ -639,19 +773,53 @@ func (t *TeamDef) execRun(ctx context.Context, in teamDefInput) (tools.Result, e
 				"max_iterations":  capErr.Max,
 				"iteration_count": capErr.Count,
 				"steps":           steps,
-			})
+			}))
 		}
 		return errResult(fmt.Sprintf("run: %s", walkErr)), nil
 	}
 
-	return okJSON(map[string]any{
+	return okJSON(annotate(map[string]any{
 		"name":         row.Name,
 		"def_id":       row.DefID,
 		"status":       "completed",
 		"final_state":  task.State,
 		"final_output": task.Input, // Walk threads the last handler's output here
 		"steps":        steps,
-	})
+	}))
+}
+
+// parseCapAnswer maps a human's free-text cap answer to a walk decision. Only an
+// explicit "continue" or "reroute:<state>" proceeds; everything else — "abort",
+// empty, or an unrecognised reply — is abort, so the default is always to stop
+// (the termination guarantee). The reroute target keeps its original case (it's a
+// state id); only the keyword match is case-insensitive.
+func parseCapAnswer(answer string) teamrun.CapDecision {
+	trimmed := strings.TrimSpace(answer)
+	switch {
+	case strings.EqualFold(trimmed, "continue"):
+		return teamrun.CapDecision{Action: teamrun.CapContinue}
+	case strings.HasPrefix(strings.ToLower(trimmed), "reroute"):
+		target := strings.TrimSpace(trimmed[len("reroute"):])
+		target = strings.TrimSpace(strings.TrimPrefix(target, ":"))
+		if target == "" {
+			return teamrun.CapDecision{Action: teamrun.CapAbort}
+		}
+		return teamrun.CapDecision{Action: teamrun.CapReroute, Reroute: target}
+	default:
+		return teamrun.CapDecision{Action: teamrun.CapAbort}
+	}
+}
+
+// capActionLabel is the human-readable decision recorded on the run response.
+func capActionLabel(d teamrun.CapDecision) string {
+	switch d.Action {
+	case teamrun.CapContinue:
+		return "continue"
+	case teamrun.CapReroute:
+		return "reroute:" + d.Reroute
+	default:
+		return "abort"
+	}
 }
 
 // ---- helpers ----

--- a/internal/tools/builtin/teamdef_test.go
+++ b/internal/tools/builtin/teamdef_test.go
@@ -548,3 +548,229 @@ func TestTeamDefTool_RoundTrip(t *testing.T) {
 		t.Fatalf("promote: %s", res.Text)
 	}
 }
+
+// --- op=run: Document board binding + Interruption-on-cap (RFC AP/BD) ---
+
+// fakeBoard is an in-memory teamBoard for op=run board tests: it records every
+// SetChunkStatus in order and can pre-seed a status so a run RESUMES from it.
+type fakeBoard struct {
+	status   string   // current persisted status (seeds resume; updated by Set)
+	exists   bool     // whether GetChunkStatus reports the chunk as present
+	setCalls []string // states persisted, in order
+}
+
+func (f *fakeBoard) GetChunkStatus(_ context.Context, _, _ string) (string, bool, error) {
+	return f.status, f.exists, nil
+}
+
+func (f *fakeBoard) SetChunkStatus(_ context.Context, _, _, status string) error {
+	f.setCalls = append(f.setCalls, status)
+	f.status = status
+	return nil
+}
+
+const linearBoardTeam = `{
+  "entry":"a",
+  "states":[
+    {"state":"a","handler":{"kind":"agent","agent":"agent-a"}},
+    {"state":"b","handler":{"kind":"agent","agent":"agent-b"}},
+    {"state":"done","handler":{"kind":"terminal"}}
+  ],
+  "transitions":[
+    {"from":"a","to":"b","on":"success"},
+    {"from":"b","to":"done","on":"success"}
+  ]}`
+
+// pingPongTeam is an a↔b success loop with no terminal + cap 2 — it never
+// converges, so the per-state cap always fires (drives the interrupt-on-cap path).
+const pingPongTeam = `{
+  "entry":"a","max_iterations":2,
+  "states":[{"state":"a","handler":{"kind":"agent","agent":"a"}},{"state":"b","handler":{"kind":"agent","agent":"b"}}],
+  "transitions":[{"from":"a","to":"b","on":"success"},{"from":"b","to":"a","on":"success"}]}`
+
+// TestTeamDefTool_Run_BoardPersistsStatusAcrossTransitions: a board-bound run
+// upserts chunk.status on entering each state — including the terminal, so a
+// completed board lands on the end state.
+func TestTeamDefTool_Run_BoardPersistsStatusAcrossTransitions(t *testing.T) {
+	tool, ctx, done := teamDefFixture(t)
+	defer done()
+	tool.Spawn = func(_ context.Context, agent, input, defID string) (string, error) { return agent + "!", nil }
+	board := &fakeBoard{exists: true}
+	tool.Board = board
+	createTeam(t, tool, ctx, "board-linear", linearBoardTeam)
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"run","name":"board-linear","input":"seed","board_chunk_id":"chunk-1"}`))
+	if res.IsError {
+		t.Fatalf("run: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	if out["status"] != "completed" {
+		t.Errorf("status = %v, want completed", out["status"])
+	}
+	if out["board_chunk_id"] != "chunk-1" {
+		t.Errorf("board_chunk_id = %v, want chunk-1", out["board_chunk_id"])
+	}
+	if got := strings.Join(board.setCalls, ","); got != "a,b,done" {
+		t.Errorf("persisted status sequence %q, want a,b,done (terminal included)", got)
+	}
+}
+
+// TestTeamDefTool_Run_BoardResumesFromPersistedState: a run whose board chunk
+// already holds a mid-graph status resumes THERE — the earlier state's agent is
+// not re-spawned. This is the durable-resume guarantee.
+func TestTeamDefTool_Run_BoardResumesFromPersistedState(t *testing.T) {
+	tool, ctx, done := teamDefFixture(t)
+	defer done()
+	var spawned []string
+	tool.Spawn = func(_ context.Context, agent, input, defID string) (string, error) {
+		spawned = append(spawned, agent)
+		return agent + "!", nil
+	}
+	board := &fakeBoard{exists: true, status: "b"} // a prior run left off at b
+	tool.Board = board
+	createTeam(t, tool, ctx, "board-resume", linearBoardTeam)
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"run","name":"board-resume","input":"seed","board_chunk_id":"chunk-1"}`))
+	if res.IsError {
+		t.Fatalf("run: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	if out["resumed_from"] != "b" {
+		t.Errorf("resumed_from = %v, want b", out["resumed_from"])
+	}
+	if len(spawned) != 1 || spawned[0] != "agent-b" {
+		t.Errorf("spawned %v, want [agent-b] (resumed at b, agent-a skipped)", spawned)
+	}
+	if out["final_state"] != "done" {
+		t.Errorf("final_state = %v, want done", out["final_state"])
+	}
+	if got := strings.Join(board.setCalls, ","); got != "b,done" {
+		t.Errorf("persisted status sequence %q, want b,done", got)
+	}
+}
+
+// TestTeamDefTool_Run_InterruptOnCapContinuesThenAborts: the cap escalates to a
+// human; `continue` grants another window, a later `abort` terminates. The run
+// still reports the iteration_cap outcome (termination preserved).
+func TestTeamDefTool_Run_InterruptOnCapContinuesThenAborts(t *testing.T) {
+	tool, ctx, done := teamDefFixture(t)
+	defer done()
+	tool.Spawn = func(_ context.Context, agent, input, defID string) (string, error) { return "ok", nil }
+	asked := 0
+	tool.AskHuman = func(_ context.Context, _ string) (string, error) {
+		asked++
+		if asked == 1 {
+			return "continue", nil
+		}
+		return "abort", nil
+	}
+	createTeam(t, tool, ctx, "intr-loop", pingPongTeam)
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"run","name":"intr-loop","input":"x","interrupt_on_cap":true}`))
+	if res.IsError {
+		t.Fatalf("iteration cap should be a reported outcome, not a tool error: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	if out["status"] != "iteration_cap" {
+		t.Errorf("status = %v, want iteration_cap (human aborted)", out["status"])
+	}
+	if asked != 2 {
+		t.Errorf("AskHuman called %d times, want 2 (continue then abort)", asked)
+	}
+	if out["interruptions"].(float64) != 2 {
+		t.Errorf("interruptions = %v, want 2", out["interruptions"])
+	}
+	if out["cap_decision"] != "abort" {
+		t.Errorf("cap_decision = %v, want abort", out["cap_decision"])
+	}
+}
+
+// TestTeamDefTool_Run_InterruptOnCapReroutesToTerminal: a human `reroute:<state>`
+// answer jumps the walk to a terminal, completing the run instead of aborting.
+func TestTeamDefTool_Run_InterruptOnCapReroutesToTerminal(t *testing.T) {
+	tool, ctx, done := teamDefFixture(t)
+	defer done()
+	tool.Spawn = func(_ context.Context, agent, input, defID string) (string, error) { return "ok", nil }
+	tool.AskHuman = func(_ context.Context, _ string) (string, error) { return "reroute:done", nil }
+	createTeam(t, tool, ctx, "intr-reroute", `{
+	  "entry":"a","max_iterations":2,
+	  "states":[
+	    {"state":"a","handler":{"kind":"agent","agent":"a"}},
+	    {"state":"b","handler":{"kind":"agent","agent":"b"}},
+	    {"state":"done","handler":{"kind":"terminal"}}
+	  ],
+	  "transitions":[
+	    {"from":"a","to":"b","on":"success"},
+	    {"from":"b","to":"a","on":"success"},
+	    {"from":"b","to":"done","on":"pushback:stop"}
+	  ]}`)
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"run","name":"intr-reroute","input":"x","interrupt_on_cap":true}`))
+	if res.IsError {
+		t.Fatalf("run: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	if out["status"] != "completed" {
+		t.Errorf("status = %v, want completed (rerouted to terminal)", out["status"])
+	}
+	if out["final_state"] != "done" {
+		t.Errorf("final_state = %v, want done", out["final_state"])
+	}
+	if out["cap_decision"] != "reroute:done" {
+		t.Errorf("cap_decision = %v, want reroute:done", out["cap_decision"])
+	}
+}
+
+// TestTeamDefTool_Run_DefaultPathIgnoresBoardAndInterrupt pins the additive
+// contract: with a board + AskHuman WIRED but neither board_chunk_id nor
+// interrupt_on_cap set, the run is byte-identical to the ephemeral path — the
+// board is never touched, the human never asked, and the opt-in response fields
+// are absent. (Fail-before: pass opts unconditionally and this test breaks.)
+func TestTeamDefTool_Run_DefaultPathIgnoresBoardAndInterrupt(t *testing.T) {
+	tool, ctx, done := teamDefFixture(t)
+	defer done()
+	tool.Spawn = func(_ context.Context, agent, input, defID string) (string, error) { return "ok", nil }
+	board := &fakeBoard{exists: true}
+	tool.Board = board
+	asked := 0
+	tool.AskHuman = func(_ context.Context, _ string) (string, error) { asked++; return "continue", nil }
+	createTeam(t, tool, ctx, "plain-loop", pingPongTeam)
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"run","name":"plain-loop","input":"x"}`))
+	if res.IsError {
+		t.Fatalf("run: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	if out["status"] != "iteration_cap" {
+		t.Errorf("status = %v, want iteration_cap (unchanged default)", out["status"])
+	}
+	if out["capped_state"] != "a" {
+		t.Errorf("capped_state = %v, want a", out["capped_state"])
+	}
+	if asked != 0 {
+		t.Errorf("AskHuman called %d times, want 0 (interrupt_on_cap not set)", asked)
+	}
+	if len(board.setCalls) != 0 {
+		t.Errorf("board written %d times, want 0 (board_chunk_id not set)", len(board.setCalls))
+	}
+	if _, ok := out["board_chunk_id"]; ok {
+		t.Errorf("board_chunk_id must be absent from the default response: %v", out)
+	}
+	if _, ok := out["interruptions"]; ok {
+		t.Errorf("interruptions must be absent from the default response: %v", out)
+	}
+}
+
+// TestTeamDefTool_Run_BoardChunkIDWithoutBoardWiredErrors: requesting a board
+// without one wired fails loud rather than silently dropping durability.
+func TestTeamDefTool_Run_BoardChunkIDWithoutBoardWiredErrors(t *testing.T) {
+	tool, ctx, done := teamDefFixture(t)
+	defer done()
+	tool.Spawn = func(_ context.Context, agent, input, defID string) (string, error) { return "ok", nil }
+	// tool.Board left nil.
+	createTeam(t, tool, ctx, "board-missing", linearBoardTeam)
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"run","name":"board-missing","input":"x","board_chunk_id":"c1"}`))
+	if !res.IsError || !strings.Contains(res.Text, "no Document board wired") {
+		t.Fatalf("board_chunk_id without a wired board should error; got %q (isErr=%v)", res.Text, res.IsError)
+	}
+}


### PR DESCRIPTION
## Why

`TeamDef op=run` was ephemeral: the walk position lived only in memory, so a team's progress vanished when the run ended, and a per-state iteration-cap overflow aborted with a plain `iteration_cap` outcome. This lands the RFC AP/BD deferral — a **durable, resumable Document task board** (the team's progress persists as `chunk.status` = the current state) and a **human-in-the-loop escalation on the cap** (ask the human instead of aborting). Both are **strictly opt-in**, so existing callers and tests are byte-identical.

## What

- **`teamrun.Walk` gains two backward-compatible variadic options** (`OnEnterState`, `OnCap`). Called with no options it behaves exactly as the four-arg form always has (nothing observed; a cap returns `*ErrIterationCap`), so the default `op=run` path and every existing caller/test are unchanged.
  - **`OnEnterState`** fires as the walk enters each state (terminal included) — the seam a board-bound run uses to persist `chunk.status` = the current team state (at-least-once for that state on a crash/resume).
  - **`OnCap`** decides the cap outcome via a `CapDecision`: `CapContinue` grants a fresh max-iteration window, `CapReroute` jumps to another state, `CapAbort` (the zero value) terminates with `*ErrIterationCap`. **Termination is preserved** — an unanswered/aborted human decision still stops the walk; a continue/reroute loop is bounded by how long a human keeps answering.
- **`Document` gains `GetChunkStatus`/`SetChunkStatus`** — the narrow board surface, reusing `update_chunk`'s atomic revision-guarded bump. No new `store.Store` method (so no storetest contract change needed); the SQL is portable (`Rebind` + `nullIfEmpty`, same path as `update_chunk`, which is already sqlite+postgres tested).
- **`TeamDef op=run` adds three additive fields**: `board_chunk_id` + `board_scope` bind the walk to a Document chunk (persist each transition, resume from the persisted status); `interrupt_on_cap` escalates a cap to a human via the Interruption tool (`continue` / `reroute:<state>` / `abort`). `Board` + `AskHuman` are injected in `main.go`, mirroring the existing `Spawn`/`Admit` wiring. Opt-in response fields (`board_chunk_id`, `board_scope`, `resumed_from`, `interruptions`, `cap_decision`) are added **only when the feature is used**, so the default response shape is byte-identical.

## Design decisions & forks resolved

- **Board addressed by explicit `board_chunk_id`**, not RFC BD's `team:<name>` root-chunk discovery convention — minimal and precise; discovery can layer on later without changing this surface.
- **Board tracks POSITION only** (`chunk.status`), not the threaded intermediate output. A resumed walk re-seeds the entry input from the caller's `input` (each state re-reads its working material from the chunk the agents co-author). Documented as a deliberate limitation.
- **Board-binding and interrupt-on-cap are independent opt-in flags**, not coupled — conceptually distinct, independently useful, and both default-off keeps the default path byte-identical.
- **Fail-safe cap parsing**: only an explicit `continue` / `reroute:<state>` proceeds; `abort`, empty, timeout, cancel, not-enabled, or an unknown reroute target all → abort. A reroute target is validated against the graph before the jump.
- **Board requested but not wired** (no SQL Memory) → loud error, never a silent durability drop.

## Tested

`go test ./...` clean from the repo root; `gofmt`/`go vet` clean.

New tests:
- **teamrun** (`internal/teamrun/orchestrator_test.go`): `TestWalk_OnEnterStateObservesEveryEnteredState`, `TestWalk_OnEnterStateFiresOnResume`, `TestWalk_OnEnterStateErrorAborts`, `TestWalk_OnCapContinueGrantsAnotherWindow`, `TestWalk_OnCapRerouteJumpsToTarget`, `TestWalk_OnCapAbortReturnsCapErr`, `TestWalk_OnCapErrorPropagates`.
- **teamdef op=run** (`internal/tools/builtin/teamdef_test.go`): `TestTeamDefTool_Run_BoardPersistsStatusAcrossTransitions`, `TestTeamDefTool_Run_BoardResumesFromPersistedState`, `TestTeamDefTool_Run_InterruptOnCapContinuesThenAborts`, `TestTeamDefTool_Run_InterruptOnCapReroutesToTerminal`, `TestTeamDefTool_Run_DefaultPathIgnoresBoardAndInterrupt` (the byte-identical/opt-in guard), `TestTeamDefTool_Run_BoardChunkIDWithoutBoardWiredErrors`.
- **document** (`internal/tools/builtin/document_test.go`): `TestDocument_ChunkStatusBoardRoundTrip`.

Fail-before verified the opt-in guard: temporarily making the `OnCap` option unconditional made `TestTeamDefTool_Run_DefaultPathIgnoresBoardAndInterrupt` fail (human asked when it shouldn't be); reverted, green again.

The default (unbound, no `interrupt_on_cap`) `op=run` path is confirmed byte-identical — `Walk` is invoked with zero options, and the response map is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
