### PR TITLE
feat(store): add session metadata + scope-filterable ListSessions

### DIFF
--- a/internal/store/postgres/migrations/0057_sessions_metadata.down.sql
+++ b/internal/store/postgres/migrations/0057_sessions_metadata.down.sql
@@ -1,0 +1,9 @@
+DROP INDEX IF EXISTS sessions_by_archived_at;
+DROP INDEX IF EXISTS sessions_by_pinned;
+ALTER TABLE sessions DROP COLUMN IF EXISTS summary_updated_at;
+ALTER TABLE sessions DROP COLUMN IF EXISTS summary;
+ALTER TABLE sessions DROP COLUMN IF EXISTS archived_at;
+ALTER TABLE sessions DROP COLUMN IF EXISTS pinned;
+ALTER TABLE sessions DROP COLUMN IF EXISTS tags;
+ALTER TABLE sessions DROP COLUMN IF EXISTS description;
+ALTER TABLE sessions DROP COLUMN IF EXISTS title;

--- a/internal/store/postgres/migrations/0057_sessions_metadata.up.sql
+++ b/internal/store/postgres/migrations/0057_sessions_metadata.up.sql
@@ -1,0 +1,23 @@
+-- 0057_sessions_metadata.up.sql — RFC BE: human/organizational chat metadata on
+-- the session row (the History tool's browse/search/annotate surface).
+--
+-- A "chat" is a session; these columns give it a human handle. All additive +
+-- nullable so existing rows read the zero value.
+--
+-- archived_at / summary_updated_at are BIGINT unix-NANOSECONDS (NULL = unset),
+-- deliberately NOT TIMESTAMPTZ like sessions.created_at: the store layer
+-- round-trips these two through the same int64 path as the SQLite adapter
+-- (sessions.archived_at INTEGER), so the cross-backend scan stays uniform.
+-- tags is a JSON array stored as TEXT (shared store.EncodeTags/DecodeTags);
+-- pinned is a BOOLEAN.
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS title              TEXT;
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS description        TEXT;
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS tags               TEXT;
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS pinned             BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS archived_at        BIGINT;
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS summary            TEXT;
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS summary_updated_at BIGINT;
+
+-- Partial indexes stay small: only pinned / archived rows carry the flag.
+CREATE INDEX IF NOT EXISTS sessions_by_pinned      ON sessions(pinned)      WHERE pinned;
+CREATE INDEX IF NOT EXISTS sessions_by_archived_at ON sessions(archived_at) WHERE archived_at IS NOT NULL;

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -242,15 +242,21 @@ func (s *Store) CreateSession(ctx context.Context, tenantID, agent, userID strin
 // GetSession returns the row by ID or *store.ErrNotFound.
 func (s *Store) GetSession(ctx context.Context, sessionID string) (store.Session, error) {
 	var (
-		out       store.Session
-		userID    *string
-		createdAt time.Time
+		out                        store.Session
+		userID                     *string
+		createdAt                  time.Time
+		title, description, tags   *string
+		summary                    *string
+		pinned                     bool
+		archivedNs, summaryUpdedNs *int64
 	)
 	row := s.pool.QueryRow(ctx,
-		`SELECT id, tenant_id, agent, user_id, created_at
+		`SELECT id, tenant_id, agent, user_id, created_at,
+		        title, description, tags, pinned, archived_at, summary, summary_updated_at
 		 FROM sessions WHERE id = $1`, sessionID,
 	)
-	if err := row.Scan(&out.ID, &out.TenantID, &out.Agent, &userID, &createdAt); err != nil {
+	if err := row.Scan(&out.ID, &out.TenantID, &out.Agent, &userID, &createdAt,
+		&title, &description, &tags, &pinned, &archivedNs, &summary, &summaryUpdedNs); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return store.Session{}, &store.ErrNotFound{Kind: "session", ID: sessionID}
 		}
@@ -260,6 +266,29 @@ func (s *Store) GetSession(ctx context.Context, sessionID string) (store.Session
 		out.UserID = *userID
 	}
 	out.CreatedAt = createdAt
+	if title != nil {
+		out.Title = *title
+	}
+	if description != nil {
+		out.Description = *description
+	}
+	if tags != nil {
+		decoded, derr := store.DecodeTags(*tags)
+		if derr != nil {
+			return store.Session{}, fmt.Errorf("decode session tags: %w", derr)
+		}
+		out.Tags = decoded
+	}
+	out.Pinned = pinned
+	if archivedNs != nil {
+		out.ArchivedAt = time.Unix(0, *archivedNs)
+	}
+	if summary != nil {
+		out.Summary = *summary
+	}
+	if summaryUpdedNs != nil {
+		out.SummaryUpdatedAt = time.Unix(0, *summaryUpdedNs)
+	}
 	return out, nil
 }
 
@@ -775,6 +804,250 @@ func (s *Store) RunsForSession(ctx context.Context, sessionID string) ([]store.R
 	}
 	defer rows.Close()
 	return scanRunRows(rows)
+}
+
+// ListSessions returns sessions matching the filter, rolled up with their runs'
+// aggregates (RFC BE). Mirrors the SQLite adapter: the aggregation runs in a
+// derived subquery so session-level filters narrow the GROUP BY and derived
+// filters (status + last-activity window) apply to the aggregate; the count and
+// page queries share the exact filtered set. See store.SessionSummary for the
+// derived Status + LastActivity semantics.
+//
+// SUM(bigint) yields NUMERIC in Postgres, so the token/count aggregates are cast
+// back to BIGINT (and cost to DOUBLE PRECISION) — otherwise pgx would surface a
+// pgtype.Numeric that won't scan into int64/float64.
+func (s *Store) ListSessions(ctx context.Context, f store.SessionFilter, limit, offset int) ([]store.SessionSummary, int64, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 500 {
+		limit = 500
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	var (
+		conds []string // session-level (inside the GROUP BY subquery)
+		outer []string // derived (over the aggregate)
+		args  []any
+		i     = 1
+	)
+	if f.TenantID != "" {
+		conds = append(conds, fmt.Sprintf("s.tenant_id = $%d", i))
+		args = append(args, f.TenantID)
+		i++
+	}
+	if f.UserID != "" {
+		conds = append(conds, fmt.Sprintf("s.user_id = $%d", i))
+		args = append(args, f.UserID)
+		i++
+	}
+	if f.AgentName != "" {
+		conds = append(conds, fmt.Sprintf("s.agent = $%d", i))
+		args = append(args, f.AgentName)
+		i++
+	}
+	if !f.IncludeArchived {
+		conds = append(conds, "s.archived_at IS NULL")
+	}
+	if f.IncludePinned {
+		conds = append(conds, "s.pinned")
+	}
+	if f.Tag != "" {
+		// Literal substring match against the JSON-array text, tag matched WITH
+		// its quotes so `"q3"` can't match inside `"q3-plan"`; strpos (not LIKE)
+		// avoids interpreting `%`/`_` in the tag.
+		conds = append(conds, fmt.Sprintf("strpos(s.tags, $%d) > 0", i))
+		args = append(args, `"`+f.Tag+`"`)
+		i++
+	}
+	if f.TitleContains != "" {
+		conds = append(conds, fmt.Sprintf("strpos(lower(s.title), lower($%d)) > 0", i))
+		args = append(args, f.TitleContains)
+		i++
+	}
+	innerWhere := ""
+	if len(conds) > 0 {
+		innerWhere = "WHERE " + strings.Join(conds, " AND ")
+	}
+	if f.Status != "" {
+		outer = append(outer, fmt.Sprintf("agg.status = $%d", i))
+		args = append(args, string(f.Status))
+		i++
+	}
+	if !f.From.IsZero() {
+		outer = append(outer, fmt.Sprintf("agg.last_activity >= $%d", i))
+		args = append(args, f.From)
+		i++
+	}
+	if !f.To.IsZero() {
+		outer = append(outer, fmt.Sprintf("agg.last_activity <= $%d", i))
+		args = append(args, f.To)
+		i++
+	}
+	outerWhere := ""
+	if len(outer) > 0 {
+		outerWhere = "WHERE " + strings.Join(outer, " AND ")
+	}
+
+	inner := `SELECT
+			s.id, s.tenant_id, s.agent, s.user_id, s.created_at,
+			s.title, s.description, s.tags, s.pinned, s.archived_at, s.summary,
+			COUNT(r.id)::BIGINT AS run_count,
+			COALESCE(SUM(r.input_tokens), 0)::BIGINT AS in_tok,
+			COALESCE(SUM(r.output_tokens), 0)::BIGINT AS out_tok,
+			COALESCE(SUM(r.cost), 0)::DOUBLE PRECISION AS cost,
+			COALESCE(MAX(CASE WHEN r.completed_at IS NOT NULL AND r.completed_at > r.started_at
+			                  THEN r.completed_at ELSE r.started_at END), s.created_at) AS last_activity,
+			CASE WHEN MAX(CASE WHEN r.status = 'running' THEN 1 ELSE 0 END) = 1 THEN 'running'
+			     ELSE COALESCE((SELECT r2.status FROM runs r2 WHERE r2.session_id = s.id
+			                    ORDER BY r2.started_at DESC LIMIT 1), '') END AS status
+		FROM sessions s
+		LEFT JOIN runs r ON r.session_id = s.id
+		` + innerWhere + `
+		GROUP BY s.id`
+
+	var total int64
+	if err := s.pool.QueryRow(ctx,
+		"SELECT COUNT(*) FROM ("+inner+") agg "+outerWhere, args...,
+	).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("count sessions: %w", err)
+	}
+
+	pageArgs := append(append([]any{}, args...), limit, offset)
+	rows, err := s.pool.Query(ctx,
+		"SELECT agg.id, agg.tenant_id, agg.agent, agg.user_id, agg.created_at, "+
+			"agg.title, agg.description, agg.tags, agg.pinned, agg.archived_at, agg.summary, "+
+			"agg.run_count, agg.in_tok, agg.out_tok, agg.cost, agg.last_activity, agg.status "+
+			"FROM ("+inner+") agg "+outerWhere+
+			fmt.Sprintf(" ORDER BY agg.pinned DESC, agg.last_activity DESC LIMIT $%d OFFSET $%d", i, i+1),
+		pageArgs...,
+	)
+	if err != nil {
+		return nil, 0, fmt.Errorf("query sessions: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]store.SessionSummary, 0, limit)
+	for rows.Next() {
+		var (
+			ss                       store.SessionSummary
+			userID                   *string
+			title, description, tags *string
+			summary                  *string
+			pinned                   bool
+			archivedNs               *int64
+			runCount                 int64
+			createdAt, lastActivity  time.Time
+			statusStr                string
+		)
+		if err := rows.Scan(
+			&ss.SessionID, &ss.TenantID, &ss.Agent, &userID, &createdAt,
+			&title, &description, &tags, &pinned, &archivedNs, &summary,
+			&runCount, &ss.InputTokens, &ss.OutputTokens, &ss.Cost, &lastActivity, &statusStr,
+		); err != nil {
+			return nil, 0, fmt.Errorf("scan session: %w", err)
+		}
+		ss.CreatedAt = createdAt
+		ss.LastActivity = lastActivity
+		ss.RunCount = int(runCount)
+		if userID != nil {
+			ss.UserID = *userID
+		}
+		if title != nil {
+			ss.Title = *title
+		}
+		if description != nil {
+			ss.Description = *description
+		}
+		if summary != nil {
+			ss.Summary = *summary
+		}
+		if tags != nil {
+			decoded, derr := store.DecodeTags(*tags)
+			if derr != nil {
+				return nil, 0, fmt.Errorf("decode session tags: %w", derr)
+			}
+			ss.Tags = decoded
+		}
+		ss.Pinned = pinned
+		ss.Archived = archivedNs != nil
+		if statusStr != "" {
+			ss.Status = store.RunStatus(statusStr)
+		}
+		out = append(out, ss)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("iter sessions: %w", err)
+	}
+	return out, total, nil
+}
+
+// SetSessionMeta writes only the non-nil fields of the patch onto the session
+// row (RFC BE). Returns *store.ErrNotFound when the session does not exist.
+func (s *Store) SetSessionMeta(ctx context.Context, sessionID string, p store.SessionMetaPatch) error {
+	now := time.Now().UnixNano()
+	var sets []string
+	var args []any
+	i := 1
+	if p.Title != nil {
+		sets = append(sets, fmt.Sprintf("title = $%d", i))
+		args = append(args, nullableText(*p.Title))
+		i++
+	}
+	if p.Description != nil {
+		sets = append(sets, fmt.Sprintf("description = $%d", i))
+		args = append(args, nullableText(*p.Description))
+		i++
+	}
+	if p.Summary != nil {
+		// A summary write always stamps summary_updated_at (idempotent recap).
+		sets = append(sets, fmt.Sprintf("summary = $%d", i))
+		args = append(args, nullableText(*p.Summary))
+		i++
+		sets = append(sets, fmt.Sprintf("summary_updated_at = $%d", i))
+		args = append(args, now)
+		i++
+	}
+	if p.Tags != nil {
+		encoded, err := store.EncodeTags(*p.Tags)
+		if err != nil {
+			return fmt.Errorf("encode session tags: %w", err)
+		}
+		sets = append(sets, fmt.Sprintf("tags = $%d", i))
+		args = append(args, encoded)
+		i++
+	}
+	if p.Pinned != nil {
+		sets = append(sets, fmt.Sprintf("pinned = $%d", i))
+		args = append(args, *p.Pinned)
+		i++
+	}
+	if p.Archived != nil {
+		if *p.Archived {
+			sets = append(sets, fmt.Sprintf("archived_at = $%d", i))
+			args = append(args, now)
+			i++
+		} else {
+			sets = append(sets, "archived_at = NULL")
+		}
+	}
+	if len(sets) == 0 {
+		// Empty patch: still surface ErrNotFound for a missing session.
+		_, err := s.GetSession(ctx, sessionID)
+		return err
+	}
+	args = append(args, sessionID)
+	tag, err := s.pool.Exec(ctx,
+		fmt.Sprintf("UPDATE sessions SET %s WHERE id = $%d", strings.Join(sets, ", "), i), args...)
+	if err != nil {
+		return fmt.Errorf("set session meta: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return &store.ErrNotFound{Kind: "session", ID: sessionID}
+	}
+	return nil
 }
 
 // DeleteSessionCascade deletes a session + all its runs + events in one tx (RFC

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -967,6 +967,18 @@ func (s *Store) migrate(ctx context.Context) error {
 		// at CreateRun from the principal + gate; read back on resume/restore so a
 		// re-dispatched run keeps its restriction. 0 on legacy rows (fail-open).
 		`ALTER TABLE runs ADD COLUMN operator_key_restricted INTEGER NOT NULL DEFAULT 0`,
+		// RFC BE — human/organizational chat metadata on the session row (the
+		// History tool's browse/search/annotate surface). All additive + nullable
+		// so legacy rows read the zero value. tags is a JSON array (NULL = never
+		// set); archived_at / summary_updated_at are unix nanos (NULL = unset);
+		// pinned is 0/1.
+		`ALTER TABLE sessions ADD COLUMN title TEXT`,
+		`ALTER TABLE sessions ADD COLUMN description TEXT`,
+		`ALTER TABLE sessions ADD COLUMN tags TEXT`,
+		`ALTER TABLE sessions ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE sessions ADD COLUMN archived_at INTEGER`,
+		`ALTER TABLE sessions ADD COLUMN summary TEXT`,
+		`ALTER TABLE sessions ADD COLUMN summary_updated_at INTEGER`,
 	}
 	for _, q := range addColumns {
 		if _, err := s.db.ExecContext(ctx, q); err != nil {
@@ -1031,6 +1043,11 @@ func (s *Store) migrate(ctx context.Context) error {
 		// (DELETE WHERE expires_at < now() AND expires_at > 0) and the
 		// per-Get expiry filter. Partial: only TTL-bearing rows.
 		`CREATE INDEX IF NOT EXISTS dynamic_agents_by_expires_at ON dynamic_agents(expires_at) WHERE expires_at > 0`,
+		// RFC BE — session-metadata listing. Partial indexes stay small: only
+		// pinned rows / archived rows carry the flag. Live in addIndexes (not the
+		// CREATE TABLE block) so the columns added above are guaranteed present.
+		`CREATE INDEX IF NOT EXISTS sessions_by_pinned ON sessions(pinned) WHERE pinned = 1`,
+		`CREATE INDEX IF NOT EXISTS sessions_by_archived_at ON sessions(archived_at) WHERE archived_at IS NOT NULL`,
 		// v0.8.16 Interruption tool indexes.
 		//   * by_run_status drives "is this run blocked?" + listing.
 		//   * by_user_status drives the Web UI inbox view (the
@@ -1174,10 +1191,14 @@ func (s *Store) CreateSession(ctx context.Context, tenantID, agent, userID strin
 func (s *Store) GetSession(ctx context.Context, sessionID string) (store.Session, error) {
 	var sess store.Session
 	var createdNs int64
-	var userID sql.NullString
+	var userID, title, description, tags, summary sql.NullString
+	var pinned, archivedNs, summaryUpdNs sql.NullInt64
 	err := s.db.QueryRowContext(ctx,
-		`SELECT id, tenant_id, agent, created_at, user_id FROM sessions WHERE id = ?`, sessionID,
-	).Scan(&sess.ID, &sess.TenantID, &sess.Agent, &createdNs, &userID)
+		`SELECT id, tenant_id, agent, created_at, user_id,
+		        title, description, tags, pinned, archived_at, summary, summary_updated_at
+		 FROM sessions WHERE id = ?`, sessionID,
+	).Scan(&sess.ID, &sess.TenantID, &sess.Agent, &createdNs, &userID,
+		&title, &description, &tags, &pinned, &archivedNs, &summary, &summaryUpdNs)
 	if errors.Is(err, sql.ErrNoRows) {
 		return store.Session{}, &store.ErrNotFound{Kind: "session", ID: sessionID}
 	}
@@ -1187,6 +1208,29 @@ func (s *Store) GetSession(ctx context.Context, sessionID string) (store.Session
 	sess.CreatedAt = time.Unix(0, createdNs)
 	if userID.Valid {
 		sess.UserID = userID.String
+	}
+	if title.Valid {
+		sess.Title = title.String
+	}
+	if description.Valid {
+		sess.Description = description.String
+	}
+	if tags.Valid {
+		decoded, derr := store.DecodeTags(tags.String)
+		if derr != nil {
+			return store.Session{}, fmt.Errorf("decode session tags: %w", derr)
+		}
+		sess.Tags = decoded
+	}
+	sess.Pinned = pinned.Valid && pinned.Int64 != 0
+	if archivedNs.Valid {
+		sess.ArchivedAt = time.Unix(0, archivedNs.Int64)
+	}
+	if summary.Valid {
+		sess.Summary = summary.String
+	}
+	if summaryUpdNs.Valid {
+		sess.SummaryUpdatedAt = time.Unix(0, summaryUpdNs.Int64)
 	}
 	return sess, nil
 }
@@ -1658,6 +1702,235 @@ func (s *Store) RunsForSession(ctx context.Context, sessionID string) ([]store.R
 		out = append(out, r)
 	}
 	return out, rows.Err()
+}
+
+// ListSessions returns sessions matching the filter, rolled up with their runs'
+// aggregates (RFC BE). The aggregation runs in a derived subquery so the
+// session-level filters (tenant/user/agent/tag/title/pinned/archived) narrow the
+// GROUP BY, and the derived filters (status + the last-activity time window)
+// apply to the aggregate — the count and page queries share the exact filtered
+// set. See store.SessionSummary for the derived Status + LastActivity semantics.
+func (s *Store) ListSessions(ctx context.Context, f store.SessionFilter, limit, offset int) ([]store.SessionSummary, int64, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 500 {
+		limit = 500 // cap to keep memory bounded (mirrors ListEvents)
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	// Session-level filters (applied inside the GROUP BY subquery).
+	var innerConds []string
+	var innerArgs []any
+	if f.TenantID != "" {
+		innerConds = append(innerConds, "s.tenant_id = ?")
+		innerArgs = append(innerArgs, f.TenantID)
+	}
+	if f.UserID != "" {
+		innerConds = append(innerConds, "s.user_id = ?")
+		innerArgs = append(innerArgs, f.UserID)
+	}
+	if f.AgentName != "" {
+		innerConds = append(innerConds, "s.agent = ?")
+		innerArgs = append(innerArgs, f.AgentName)
+	}
+	if !f.IncludeArchived {
+		innerConds = append(innerConds, "s.archived_at IS NULL")
+	}
+	if f.IncludePinned {
+		innerConds = append(innerConds, "s.pinned = 1")
+	}
+	if f.Tag != "" {
+		// Literal substring match against the JSON-array text. The tag is
+		// matched WITH its surrounding quotes so `"q3"` cannot match inside
+		// `"q3-plan"`; INSTR (not LIKE) avoids interpreting `%`/`_` in the tag.
+		innerConds = append(innerConds, "INSTR(s.tags, ?) > 0")
+		innerArgs = append(innerArgs, `"`+f.Tag+`"`)
+	}
+	if f.TitleContains != "" {
+		innerConds = append(innerConds, "INSTR(LOWER(s.title), LOWER(?)) > 0")
+		innerArgs = append(innerArgs, f.TitleContains)
+	}
+	innerWhere := ""
+	if len(innerConds) > 0 {
+		innerWhere = "WHERE " + strings.Join(innerConds, " AND ")
+	}
+
+	// Derived filters (applied to the aggregate).
+	var outerConds []string
+	var outerArgs []any
+	if f.Status != "" {
+		outerConds = append(outerConds, "agg.status = ?")
+		outerArgs = append(outerArgs, string(f.Status))
+	}
+	if !f.From.IsZero() {
+		outerConds = append(outerConds, "agg.last_activity >= ?")
+		outerArgs = append(outerArgs, f.From.UnixNano())
+	}
+	if !f.To.IsZero() {
+		outerConds = append(outerConds, "agg.last_activity <= ?")
+		outerArgs = append(outerArgs, f.To.UnixNano())
+	}
+	outerWhere := ""
+	if len(outerConds) > 0 {
+		outerWhere = "WHERE " + strings.Join(outerConds, " AND ")
+	}
+
+	// last_activity = MAX of each run's completed-or-started time, falling back
+	// to the session's created_at when it has no runs. status = "running" if any
+	// run is active, else the most recent run's status ("" for a runless
+	// session). Both are computed as columns so the outer query can filter them.
+	inner := `SELECT
+			s.id, s.tenant_id, s.agent, s.user_id, s.created_at,
+			s.title, s.description, s.tags, s.pinned, s.archived_at, s.summary,
+			COUNT(r.id) AS run_count,
+			COALESCE(SUM(r.input_tokens), 0) AS in_tok,
+			COALESCE(SUM(r.output_tokens), 0) AS out_tok,
+			COALESCE(SUM(r.cost), 0) AS cost,
+			COALESCE(MAX(CASE WHEN r.completed_at IS NOT NULL AND r.completed_at > r.started_at
+			                  THEN r.completed_at ELSE r.started_at END), s.created_at) AS last_activity,
+			CASE WHEN MAX(CASE WHEN r.status = 'running' THEN 1 ELSE 0 END) = 1 THEN 'running'
+			     ELSE COALESCE((SELECT r2.status FROM runs r2 WHERE r2.session_id = s.id
+			                    ORDER BY r2.started_at DESC LIMIT 1), '') END AS status
+		FROM sessions s
+		LEFT JOIN runs r ON r.session_id = s.id
+		` + innerWhere + `
+		GROUP BY s.id`
+
+	countArgs := append(append([]any{}, innerArgs...), outerArgs...)
+	var total int64
+	if err := s.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM ("+inner+") agg "+outerWhere, countArgs...,
+	).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+
+	pageArgs := append(append([]any{}, innerArgs...), outerArgs...)
+	pageArgs = append(pageArgs, limit, offset)
+	rows, err := s.db.QueryContext(ctx,
+		"SELECT agg.id, agg.tenant_id, agg.agent, agg.user_id, agg.created_at, "+
+			"agg.title, agg.description, agg.tags, agg.pinned, agg.archived_at, agg.summary, "+
+			"agg.run_count, agg.in_tok, agg.out_tok, agg.cost, agg.last_activity, agg.status "+
+			"FROM ("+inner+") agg "+outerWhere+
+			" ORDER BY agg.pinned DESC, agg.last_activity DESC LIMIT ? OFFSET ?",
+		pageArgs...,
+	)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	out := make([]store.SessionSummary, 0, limit)
+	for rows.Next() {
+		var ss store.SessionSummary
+		var userID, title, description, tags, summary sql.NullString
+		var createdNs, lastActNs int64
+		var archivedNs sql.NullInt64
+		var pinnedInt int64
+		var statusStr string
+		if err := rows.Scan(
+			&ss.SessionID, &ss.TenantID, &ss.Agent, &userID, &createdNs,
+			&title, &description, &tags, &pinnedInt, &archivedNs, &summary,
+			&ss.RunCount, &ss.InputTokens, &ss.OutputTokens, &ss.Cost, &lastActNs, &statusStr,
+		); err != nil {
+			return nil, 0, err
+		}
+		ss.CreatedAt = time.Unix(0, createdNs)
+		ss.LastActivity = time.Unix(0, lastActNs)
+		if userID.Valid {
+			ss.UserID = userID.String
+		}
+		if title.Valid {
+			ss.Title = title.String
+		}
+		if description.Valid {
+			ss.Description = description.String
+		}
+		if summary.Valid {
+			ss.Summary = summary.String
+		}
+		if tags.Valid {
+			decoded, derr := store.DecodeTags(tags.String)
+			if derr != nil {
+				return nil, 0, fmt.Errorf("decode session tags: %w", derr)
+			}
+			ss.Tags = decoded
+		}
+		ss.Pinned = pinnedInt != 0
+		ss.Archived = archivedNs.Valid
+		if statusStr != "" {
+			ss.Status = store.RunStatus(statusStr)
+		}
+		out = append(out, ss)
+	}
+	return out, total, rows.Err()
+}
+
+// SetSessionMeta writes only the non-nil fields of the patch onto the session
+// row (RFC BE). Returns *store.ErrNotFound when the session does not exist.
+func (s *Store) SetSessionMeta(ctx context.Context, sessionID string, p store.SessionMetaPatch) error {
+	now := time.Now().UnixNano()
+	var sets []string
+	var args []any
+	if p.Title != nil {
+		sets = append(sets, "title = ?")
+		args = append(args, nilIfEmpty(*p.Title))
+	}
+	if p.Description != nil {
+		sets = append(sets, "description = ?")
+		args = append(args, nilIfEmpty(*p.Description))
+	}
+	if p.Summary != nil {
+		// A summary write always stamps summary_updated_at (idempotent recap).
+		sets = append(sets, "summary = ?", "summary_updated_at = ?")
+		args = append(args, nilIfEmpty(*p.Summary), now)
+	}
+	if p.Tags != nil {
+		encoded, err := store.EncodeTags(*p.Tags)
+		if err != nil {
+			return fmt.Errorf("encode session tags: %w", err)
+		}
+		sets = append(sets, "tags = ?")
+		args = append(args, encoded)
+	}
+	if p.Pinned != nil {
+		pv := int64(0)
+		if *p.Pinned {
+			pv = 1
+		}
+		sets = append(sets, "pinned = ?")
+		args = append(args, pv)
+	}
+	if p.Archived != nil {
+		if *p.Archived {
+			sets = append(sets, "archived_at = ?")
+			args = append(args, now)
+		} else {
+			sets = append(sets, "archived_at = NULL")
+		}
+	}
+	if len(sets) == 0 {
+		// Empty patch: still surface ErrNotFound for a missing session so the
+		// caller sees consistent semantics.
+		_, err := s.GetSession(ctx, sessionID)
+		return err
+	}
+	args = append(args, sessionID)
+	res, err := s.db.ExecContext(ctx,
+		"UPDATE sessions SET "+strings.Join(sets, ", ")+" WHERE id = ?", args...)
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return &store.ErrNotFound{Kind: "session", ID: sessionID}
+	}
+	return nil
 }
 
 // DeleteSessionCascade deletes a session + all its runs + events in one tx (RFC

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -130,6 +130,31 @@ type Session struct {
 	// rows that pre-date the column. Caller-supplied at session
 	// creation; sub-agent sessions inherit the parent's value.
 	UserID string `json:"user_id,omitempty"`
+
+	// --- RFC BE: human/organizational chat metadata. ---
+	// A "chat" is a session; these give it a human handle for the History
+	// tool's browse/search/annotate surface. All additive + nullable — legacy
+	// rows read the zero value. Never a secret.
+
+	// Title / Description are the human-authored labels (History op=rename /
+	// annotate). Empty = never set.
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	// Tags is a free-form label set, stored as a JSON array in sessions.tags.
+	// nil = the column is NULL (never set); a non-nil empty slice round-trips
+	// as an explicit empty set. Encoded via EncodeTags / DecodeTags.
+	Tags []string `json:"tags,omitempty"`
+	// Pinned floats the chat to the top of a listing (pinned-first ordering).
+	Pinned bool `json:"pinned,omitempty"`
+	// ArchivedAt marks a reversible soft-hide (History op=archive) — excluded
+	// from listings by default. Zero time = not archived. Distinct from the
+	// RFC AV retention pruner, which hard-deletes.
+	ArchivedAt time.Time `json:"archived_at,omitempty"`
+	// Summary is the cached recap of the chat (History op=recap), refreshed
+	// idempotently; SummaryUpdatedAt stamps when it was last written. Zero
+	// time = no recap yet.
+	Summary          string    `json:"summary,omitempty"`
+	SummaryUpdatedAt time.Time `json:"summary_updated_at,omitempty"`
 }
 
 // RunStatus is the terminal state of a run, or "running" while it's still in
@@ -142,6 +167,78 @@ const (
 	RunFailed    RunStatus = "failed"
 	RunCancelled RunStatus = "cancelled"
 )
+
+// SessionFilter narrows a ListSessions query (RFC BE — the History tool's
+// browse/search surface). Zero values mean "no filter on that axis":
+//   - TenantID == "" → all tenants (mirrors EventFilter.TenantID; the HTTP
+//     layer enforces admin-only for the cross-tenant view). Non-empty →
+//     restrict to that tenant.
+//   - UserID / AgentName == "" → no filter on that axis.
+//   - Status == "" → any status; non-empty → only sessions whose derived
+//     status (see SessionSummary.Status) matches.
+//   - From / To zero-value → unbounded on that side. Both bound the session's
+//     LastActivity (not created_at) so the window means "chats active in it".
+//   - Tag == "" → no tag filter; non-empty → sessions carrying that exact tag.
+//   - TitleContains == "" → no title filter; non-empty → case-insensitive
+//     substring match on the title.
+type SessionFilter struct {
+	TenantID      string
+	UserID        string
+	AgentName     string
+	Status        RunStatus
+	From, To      time.Time
+	Tag           string
+	TitleContains string
+	// IncludePinned, when true, RESTRICTS the result to pinned sessions only
+	// (the "pinned chats" view). false = no pinned filter — every session,
+	// still ordered pinned-first. (Named for the view it powers; it is a
+	// narrowing filter, not an additive one.)
+	IncludePinned bool
+	// IncludeArchived, when false (the default), EXCLUDES archived sessions;
+	// true includes them alongside the rest.
+	IncludeArchived bool
+}
+
+// SessionSummary is one row of ListSessions: a chat's metadata plus aggregates
+// rolled up from its runs (RFC BE). Token/cost/run-count come from the runs
+// table (RFC AV columns); Status is the session's derived status — "running" if
+// any run is active, else the most recent run's terminal status ("" for a
+// session with no runs yet).
+type SessionSummary struct {
+	SessionID    string    `json:"session_id"`
+	TenantID     string    `json:"tenant_id"`
+	Agent        string    `json:"agent"`
+	UserID       string    `json:"user_id,omitempty"`
+	CreatedAt    time.Time `json:"created_at"`
+	LastActivity time.Time `json:"last_activity"`
+	RunCount     int       `json:"run_count"`
+
+	Title       string   `json:"title,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+	Pinned      bool     `json:"pinned,omitempty"`
+	Archived    bool     `json:"archived,omitempty"`
+	Summary     string   `json:"summary,omitempty"`
+
+	InputTokens  int64     `json:"input_tokens"`
+	OutputTokens int64     `json:"output_tokens"`
+	Cost         float64   `json:"cost"`
+	Status       RunStatus `json:"status,omitempty"`
+}
+
+// SessionMetaPatch is a partial update to a session's RFC BE metadata. A nil
+// pointer leaves that field unchanged; a non-nil pointer writes it (an empty
+// string / empty slice is a legitimate "clear it" value). Archived==true stamps
+// archived_at=now; false clears it. A non-nil Summary also stamps
+// summary_updated_at=now.
+type SessionMetaPatch struct {
+	Title       *string
+	Description *string
+	Summary     *string
+	Tags        *[]string
+	Pinned      *bool
+	Archived    *bool
+}
 
 // Run is one execution within a session.
 type Run struct {
@@ -660,6 +757,39 @@ func DecodeParentContext(s string) (*ParentContext, error) {
 	return &p, nil
 }
 
+// EncodeTags marshals a session-tag slice into the JSON stored in
+// sessions.tags (RFC BE). A nil slice encodes to "[]" (an explicit empty set),
+// so callers that mean "leave the column unchanged" must skip the column
+// entirely rather than passing nil here. Shared by both backends so the SQLite
+// and Postgres column formats can't drift.
+func EncodeTags(tags []string) (string, error) {
+	if tags == nil {
+		tags = []string{}
+	}
+	b, err := json.Marshal(tags)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// DecodeTags parses a stored sessions.tags value. An empty string (NULL column
+// / legacy row) and an empty JSON array both decode to nil, so the round-tripped
+// SessionSummary.Tags stays clean for JSON omitempty.
+func DecodeTags(s string) ([]string, error) {
+	if s == "" {
+		return nil, nil
+	}
+	var out []string
+	if err := json.Unmarshal([]byte(s), &out); err != nil {
+		return nil, err
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}
+
 // UserSummary is one row of ListUsers' output: distinct user_id with
 // summary stats. Drives the Web UI's user picker so operators can see
 // who has active runs and pick from a list rather than typing a UUID.
@@ -793,6 +923,23 @@ type Store interface {
 	// offset-based for simplicity; cursor-based pagination is a
 	// follow-up if scale demands.
 	ListEvents(ctx context.Context, filter EventFilter, limit, offset int) ([]Event, int64, error)
+
+	// ListSessions returns sessions matching the filter, each rolled up with
+	// its runs' aggregates (RFC BE — the History tool's browse/search surface).
+	// RunCount / InputTokens / OutputTokens / Cost sum the session's runs;
+	// LastActivity is the max of the runs' started/completed times (falling
+	// back to the session's created_at when it has no runs); Status is derived
+	// (running if any run is active, else the latest run's status). Ordered
+	// pinned-first then LastActivity DESC. Returns the page rows AND the total
+	// match count for offset pagination, mirroring ListEvents. Empty TenantID =
+	// all tenants (the HTTP layer gates the cross-tenant view to admins).
+	ListSessions(ctx context.Context, filter SessionFilter, limit, offset int) ([]SessionSummary, int64, error)
+
+	// SetSessionMeta applies a partial metadata update to a session (RFC BE).
+	// Only the non-nil fields of the patch are written; the rest are left
+	// unchanged. Returns *ErrNotFound when sessionID does not exist. See
+	// SessionMetaPatch for the archived_at / summary_updated_at side effects.
+	SetSessionMeta(ctx context.Context, sessionID string, patch SessionMetaPatch) error
 
 	// GetLastEventForRun returns the highest-seq event recorded for
 	// the given run. v0.8.21 introduces this so the list-agents

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -87,6 +87,9 @@ func Run(t *testing.T, factory Factory) {
 		{"GetRunByAgentIDNotFound", testGetRunByAgentIDNotFound},
 		{"GetRunByAgentIDReturnsMostRecent", testGetRunByAgentIDReturnsMostRecent},
 		{"ListActiveRunsByUser", testListActiveRunsByUser},
+		{"ListSessions", testListSessions},
+		{"ListSessionsTenantIsolation", testListSessionsTenantIsolation},
+		{"SetSessionMeta", testSetSessionMeta},
 		{"ListUsers", testListUsers},
 		{"ListRunsByParentAgentID", testListRunsByParentAgentID},
 		{"UpdateHeartbeat", testUpdateHeartbeat},
@@ -1600,6 +1603,309 @@ func testListActiveRunsByUser(t *testing.T, s store.Store) {
 
 	if got, _ := s.ListActiveRunsByUser(ctx, "", store.RunRunning); len(got) != 0 {
 		t.Errorf("empty userID should return no rows, got %d", len(got))
+	}
+}
+
+// --- RFC BE: ListSessions + SetSessionMeta ---
+
+func strPtr(s string) *string      { return &s }
+func boolPtr(b bool) *bool         { return &b }
+func tagsPtr(t []string) *[]string { return &t }
+
+func summaryIDs(list []store.SessionSummary) []string {
+	out := make([]string, len(list))
+	for i, x := range list {
+		out[i] = x.SessionID
+	}
+	return out
+}
+
+// testListSessions exercises the RFC BE browse/search surface: every filter axis
+// independently, archived exclude-by-default, pinned-first ordering, the
+// token/cost/run_count aggregation, and offset pagination — across two tenants,
+// two users, and two agents.
+func testListSessions(t *testing.T, s store.Store) {
+	ctx := context.Background()
+
+	// t1 / alice / agentA — 2 completed runs (tokens + cost aggregate).
+	s1, _ := s.CreateSession(ctx, "t1", "agentA", "alice")
+	r11, _ := s.CreateRun(ctx, s1.ID, store.RunIdentity{UserID: "alice", TenantID: "t1"})
+	r12, _ := s.CreateRun(ctx, s1.ID, store.RunIdentity{UserID: "alice", TenantID: "t1"})
+	if err := s.FinishRun(ctx, r11.ID, store.RunCompleted, "end_turn", store.Usage{InputTokens: 100, OutputTokens: 50, Cost: 0.5, CostCurrency: "USD", Model: "m", Provider: "p"}, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.FinishRun(ctx, r12.ID, store.RunCompleted, "end_turn", store.Usage{InputTokens: 10, OutputTokens: 5, Cost: 0.25, CostCurrency: "USD", Model: "m", Provider: "p"}, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetSessionMeta(ctx, s1.ID, store.SessionMetaPatch{
+		Title: strPtr("Quarterly Review"),
+		Tags:  tagsPtr([]string{"urgent", "q3"}),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// t1 / bob / agentB — 1 still-running run.
+	s2, _ := s.CreateSession(ctx, "t1", "agentB", "bob")
+	if _, err := s.CreateRun(ctx, s2.ID, store.RunIdentity{UserID: "bob", TenantID: "t1"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// t2 / carol / agentA — 1 completed run (different tenant).
+	s3, _ := s.CreateSession(ctx, "t2", "agentA", "carol")
+	r31, _ := s.CreateRun(ctx, s3.ID, store.RunIdentity{UserID: "carol", TenantID: "t2"})
+	_ = s.FinishRun(ctx, r31.ID, store.RunCompleted, "end_turn", store.Usage{InputTokens: 20, OutputTokens: 10, Cost: 0.2, CostCurrency: "USD", Model: "m", Provider: "p"}, "")
+
+	// t1 / alice / agentA — pinned; tag "q3-plan" (quote-boundary check vs "q3").
+	s4, _ := s.CreateSession(ctx, "t1", "agentA", "alice")
+	r41, _ := s.CreateRun(ctx, s4.ID, store.RunIdentity{UserID: "alice", TenantID: "t1"})
+	_ = s.FinishRun(ctx, r41.ID, store.RunCompleted, "end_turn", store.Usage{Model: "m", Provider: "p"}, "")
+	if err := s.SetSessionMeta(ctx, s4.ID, store.SessionMetaPatch{Pinned: boolPtr(true), Tags: tagsPtr([]string{"q3-plan"})}); err != nil {
+		t.Fatal(err)
+	}
+
+	// t1 / alice — archived (excluded by default).
+	s5, _ := s.CreateSession(ctx, "t1", "agentA", "alice")
+	if err := s.SetSessionMeta(ctx, s5.ID, store.SessionMetaPatch{Archived: boolPtr(true)}); err != nil {
+		t.Fatal(err)
+	}
+
+	byID := func(list []store.SessionSummary) map[string]store.SessionSummary {
+		m := map[string]store.SessionSummary{}
+		for _, x := range list {
+			m[x.SessionID] = x
+		}
+		return m
+	}
+
+	// 1. Tenant t1, default (archived excluded): S1, S2, S4.
+	list, total, err := s.ListSessions(ctx, store.SessionFilter{TenantID: "t1"}, 50, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 3 {
+		t.Errorf("t1 total = %d, want 3 (%v)", total, summaryIDs(list))
+	}
+	m := byID(list)
+	if _, ok := m[s1.ID]; !ok {
+		t.Errorf("t1 list missing s1")
+	}
+	if _, ok := m[s3.ID]; ok {
+		t.Errorf("t1 list leaked t2's s3 (tenant isolation)")
+	}
+	if _, ok := m[s5.ID]; ok {
+		t.Errorf("t1 list included archived s5 by default")
+	}
+	// Pinned-first ordering.
+	if len(list) == 0 || list[0].SessionID != s4.ID {
+		t.Errorf("pinned session should sort first; got %v", summaryIDs(list))
+	}
+	// Aggregation on S1.
+	agg := m[s1.ID]
+	if agg.RunCount != 2 || agg.InputTokens != 110 || agg.OutputTokens != 55 {
+		t.Errorf("s1 aggregate = run_count %d in %d out %d, want 2/110/55", agg.RunCount, agg.InputTokens, agg.OutputTokens)
+	}
+	if agg.Cost < 0.75-1e-9 || agg.Cost > 0.75+1e-9 {
+		t.Errorf("s1 cost = %v, want 0.75", agg.Cost)
+	}
+	if agg.Status != store.RunCompleted {
+		t.Errorf("s1 status = %q, want completed", agg.Status)
+	}
+	if agg.Title != "Quarterly Review" {
+		t.Errorf("s1 title = %q, want Quarterly Review", agg.Title)
+	}
+	if len(agg.Tags) != 2 {
+		t.Errorf("s1 tags = %v, want [urgent q3]", agg.Tags)
+	}
+	// S2 (running) reports a "running" derived status.
+	if m[s2.ID].Status != store.RunRunning {
+		t.Errorf("s2 status = %q, want running", m[s2.ID].Status)
+	}
+
+	// 2. Tenant + user filter → S1, S4 (both alice); not S2 (bob).
+	list, _, _ = s.ListSessions(ctx, store.SessionFilter{TenantID: "t1", UserID: "alice"}, 50, 0)
+	m = byID(list)
+	if len(list) != 2 || m[s1.ID].SessionID == "" || m[s4.ID].SessionID == "" {
+		t.Errorf("t1/alice = %v, want [s1 s4]", summaryIDs(list))
+	}
+
+	// 3. Agent filter.
+	list, _, _ = s.ListSessions(ctx, store.SessionFilter{TenantID: "t1", AgentName: "agentB"}, 50, 0)
+	if len(list) != 1 || list[0].SessionID != s2.ID {
+		t.Errorf("t1/agentB = %v, want [s2]", summaryIDs(list))
+	}
+
+	// 4. Status filter.
+	list, _, _ = s.ListSessions(ctx, store.SessionFilter{TenantID: "t1", Status: store.RunRunning}, 50, 0)
+	if len(list) != 1 || list[0].SessionID != s2.ID {
+		t.Errorf("t1/running = %v, want [s2]", summaryIDs(list))
+	}
+	list, _, _ = s.ListSessions(ctx, store.SessionFilter{TenantID: "t1", Status: store.RunCompleted}, 50, 0)
+	if m = byID(list); len(list) != 2 || m[s1.ID].SessionID == "" || m[s4.ID].SessionID == "" {
+		t.Errorf("t1/completed = %v, want [s1 s4]", summaryIDs(list))
+	}
+
+	// 5. Archived inclusion → 4 (adds S5).
+	_, total, _ = s.ListSessions(ctx, store.SessionFilter{TenantID: "t1", IncludeArchived: true}, 50, 0)
+	if total != 4 {
+		t.Errorf("t1 include-archived total = %d, want 4", total)
+	}
+
+	// 6. Pinned-only filter.
+	list, _, _ = s.ListSessions(ctx, store.SessionFilter{TenantID: "t1", IncludePinned: true}, 50, 0)
+	if len(list) != 1 || list[0].SessionID != s4.ID {
+		t.Errorf("t1/pinned-only = %v, want [s4]", summaryIDs(list))
+	}
+
+	// 7. Tag filter — exact-token, quote-boundary safe ("q3" must NOT match "q3-plan").
+	list, _, _ = s.ListSessions(ctx, store.SessionFilter{TenantID: "t1", Tag: "q3"}, 50, 0)
+	if len(list) != 1 || list[0].SessionID != s1.ID {
+		t.Errorf("t1/tag=q3 = %v, want [s1] (must not match s4's \"q3-plan\")", summaryIDs(list))
+	}
+
+	// 8. Title-contains (case-insensitive).
+	list, _, _ = s.ListSessions(ctx, store.SessionFilter{TenantID: "t1", TitleContains: "quarterly"}, 50, 0)
+	if len(list) != 1 || list[0].SessionID != s1.ID {
+		t.Errorf("t1/title~quarterly = %v, want [s1]", summaryIDs(list))
+	}
+
+	// 9. Pagination (limit/offset + stable total).
+	page1, total, _ := s.ListSessions(ctx, store.SessionFilter{TenantID: "t1"}, 2, 0)
+	if len(page1) != 2 || total != 3 {
+		t.Errorf("page1 = %d rows total %d, want 2/3", len(page1), total)
+	}
+	page2, total2, _ := s.ListSessions(ctx, store.SessionFilter{TenantID: "t1"}, 2, 2)
+	if len(page2) != 1 || total2 != 3 {
+		t.Errorf("page2 = %d rows total %d, want 1/3", len(page2), total2)
+	}
+
+	// 10. All-tenants (empty TenantID) spans t1 + t2 non-archived: S1,S2,S4,S3 = 4.
+	_, total, _ = s.ListSessions(ctx, store.SessionFilter{}, 50, 0)
+	if total != 4 {
+		t.Errorf("all-tenants total = %d, want 4", total)
+	}
+}
+
+// testListSessionsTenantIsolation asserts a tenant-scoped ListSessions never
+// returns another tenant's chats (RFC BE — the load-bearing isolation contract).
+func testListSessionsTenantIsolation(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	a, _ := s.CreateSession(ctx, "A", "agentA", "u1")
+	if _, err := s.CreateRun(ctx, a.ID, store.RunIdentity{UserID: "u1", TenantID: "A"}); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := s.CreateSession(ctx, "B", "agentB", "u2")
+	if _, err := s.CreateRun(ctx, b.ID, store.RunIdentity{UserID: "u2", TenantID: "B"}); err != nil {
+		t.Fatal(err)
+	}
+
+	list, total, err := s.ListSessions(ctx, store.SessionFilter{TenantID: "A"}, 50, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 1 || len(list) != 1 || list[0].SessionID != a.ID {
+		t.Fatalf("tenant A list = %v (total %d), want only [%s]", summaryIDs(list), total, a.ID)
+	}
+	for _, x := range list {
+		if x.SessionID == b.ID || x.TenantID == "B" {
+			t.Errorf("tenant B's session %s leaked into tenant A's list", b.ID)
+		}
+	}
+}
+
+// testSetSessionMeta round-trips every metadata field, asserts a partial patch
+// leaves the rest unchanged, archive sets/clears archived_at, a summary write
+// stamps summary_updated_at, and a missing id returns ErrNotFound (RFC BE).
+func testSetSessionMeta(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	sess, _ := s.CreateSession(ctx, "t", "agentA", "alice")
+
+	// Round-trip each field.
+	if err := s.SetSessionMeta(ctx, sess.ID, store.SessionMetaPatch{
+		Title:       strPtr("My Chat"),
+		Description: strPtr("a description"),
+		Summary:     strPtr("a recap"),
+		Tags:        tagsPtr([]string{"a", "b"}),
+		Pinned:      boolPtr(true),
+		Archived:    boolPtr(true),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.GetSession(ctx, sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Title != "My Chat" || got.Description != "a description" || got.Summary != "a recap" {
+		t.Errorf("meta round-trip: title=%q desc=%q summary=%q", got.Title, got.Description, got.Summary)
+	}
+	if len(got.Tags) != 2 || got.Tags[0] != "a" || got.Tags[1] != "b" {
+		t.Errorf("tags round-trip = %v, want [a b]", got.Tags)
+	}
+	if !got.Pinned {
+		t.Errorf("pinned not set")
+	}
+	if got.ArchivedAt.IsZero() {
+		t.Errorf("archived_at not stamped on archive")
+	}
+	if got.SummaryUpdatedAt.IsZero() {
+		t.Errorf("summary_updated_at not stamped on summary write")
+	}
+	firstSummaryStamp := got.SummaryUpdatedAt
+
+	// Partial patch: only description changes; the rest survive untouched.
+	if err := s.SetSessionMeta(ctx, sess.ID, store.SessionMetaPatch{Description: strPtr("changed")}); err != nil {
+		t.Fatal(err)
+	}
+	got, _ = s.GetSession(ctx, sess.ID)
+	if got.Description != "changed" {
+		t.Errorf("partial patch description = %q, want changed", got.Description)
+	}
+	if got.Title != "My Chat" || !got.Pinned || len(got.Tags) != 2 || got.Summary != "a recap" {
+		t.Errorf("partial patch clobbered other fields: title=%q pinned=%v tags=%v summary=%q",
+			got.Title, got.Pinned, got.Tags, got.Summary)
+	}
+
+	// Un-archive clears archived_at.
+	if err := s.SetSessionMeta(ctx, sess.ID, store.SessionMetaPatch{Archived: boolPtr(false)}); err != nil {
+		t.Fatal(err)
+	}
+	got, _ = s.GetSession(ctx, sess.ID)
+	if !got.ArchivedAt.IsZero() {
+		t.Errorf("archived_at not cleared on un-archive: %v", got.ArchivedAt)
+	}
+
+	// A fresh summary write refreshes summary_updated_at (idempotent recap).
+	if err := s.SetSessionMeta(ctx, sess.ID, store.SessionMetaPatch{Summary: strPtr("newer recap")}); err != nil {
+		t.Fatal(err)
+	}
+	got, _ = s.GetSession(ctx, sess.ID)
+	if got.Summary != "newer recap" {
+		t.Errorf("summary re-write = %q, want 'newer recap'", got.Summary)
+	}
+	if got.SummaryUpdatedAt.Before(firstSummaryStamp) {
+		t.Errorf("summary_updated_at went backwards on re-write: %v < %v", got.SummaryUpdatedAt, firstSummaryStamp)
+	}
+
+	// Tags can be cleared to an explicit empty set (reads back as no tags).
+	if err := s.SetSessionMeta(ctx, sess.ID, store.SessionMetaPatch{Tags: tagsPtr([]string{})}); err != nil {
+		t.Fatal(err)
+	}
+	got, _ = s.GetSession(ctx, sess.ID)
+	if len(got.Tags) != 0 {
+		t.Errorf("cleared tags = %v, want empty", got.Tags)
+	}
+
+	// ErrNotFound on a missing id (patch present).
+	var nf *store.ErrNotFound
+	if err := s.SetSessionMeta(ctx, "s_does_not_exist", store.SessionMetaPatch{Title: strPtr("x")}); !errors.As(err, &nf) {
+		t.Errorf("SetSessionMeta on missing id: got %v (%T), want *store.ErrNotFound", err, err)
+	}
+	// ErrNotFound on a missing id (empty patch).
+	if err := s.SetSessionMeta(ctx, "s_missing2", store.SessionMetaPatch{}); !errors.As(err, &nf) {
+		t.Errorf("empty patch on missing id: got %v, want *store.ErrNotFound", err)
+	}
+	// Empty patch on an existing id is a no-op (nil error).
+	if err := s.SetSessionMeta(ctx, sess.ID, store.SessionMetaPatch{}); err != nil {
+		t.Errorf("empty patch on existing id: got %v, want nil", err)
 	}
 }
 


### PR DESCRIPTION
## Why

RFC BE introduces a `History` built-in tool (browse / search / rename / annotate past chats). This is **PR 1 — the storage foundation only** (no tool, no HTTP/MCP; those are PR 2). A "chat" is a `session` (session → runs → events), and today sessions carry no human-facing metadata (title/description/tags/flags) and there is no scope-filterable way to list them. This PR adds that metadata to the `sessions` row and a tenant-safe, aggregate-rolled-up session listing that PR 2's tool will sit on top of.

## What

- **Migration — additive, nullable, both backends.** `sessions` gains `title`, `description`, `tags` (JSON array), `pinned`, `archived_at` (unix nano), `summary`, `summary_updated_at`, plus partial indexes on `pinned` and `archived_at`.
  - sqlite: appended to `migrate()`'s `addColumns` / `addIndexes` lists (same pattern as the existing `user_id` ALTER; duplicate-column and `IF NOT EXISTS` guards keep it idempotent).
  - postgres: new migration **0057_sessions_metadata** (`ADD COLUMN IF NOT EXISTS`). `archived_at` / `summary_updated_at` are `BIGINT` unix-nanoseconds — deliberately not `TIMESTAMPTZ` like `created_at` — so both adapters round-trip these two through the same `int64` path and the scan stays uniform. Documented in the migration header.
- **`store.Session`** gains the metadata fields; `GetSession` selects + scans them (nullable-safe).
- **New `Store` methods on both backends:**
  - `ListSessions(ctx, SessionFilter, limit, offset) ([]SessionSummary, total, error)` — a GROUP BY over `runs` per session for `run_count`, `SUM(input_tokens)`/`SUM(output_tokens)`, `SUM(cost)`, `last_activity = MAX(started/completed)`, and a derived `status` (running if any run is active, else the latest run's status). Session-level filters (tenant/user/agent/tag/title/pinned/archived) narrow the aggregate subquery; derived filters (status + last-activity window) apply to the aggregate — so the count and page queries share one filtered set. Ordered `pinned DESC, last_activity DESC`; returns rows + total for offset pagination (mirrors `ListEvents`). (postgres: `SUM(bigint)` yields `NUMERIC`, cast back to `BIGINT`/`DOUBLE PRECISION` so pgx scans into `int64`/`float64`.)
  - `SetSessionMeta(ctx, sessionID, SessionMetaPatch)` — writes only the non-nil patch fields; `Archived` true stamps / false clears `archived_at`; a `Summary` write also stamps `summary_updated_at`; `ErrNotFound` on a missing id.
  - New `SessionFilter` / `SessionSummary` / `SessionMetaPatch` types + shared `EncodeTags` / `DecodeTags` helpers (JSON, one place so the two column formats can't drift).
- **Tag / title matching** uses `INSTR`/`strpos` (literal substring, not `LIKE`) so a tag or title fragment containing `%`/`_` can't over-match; the tag is matched *with* its surrounding JSON quotes so `q3` can't match inside `q3-plan`.

### Assumption flagged for review

`SessionFilter.IncludePinned` — the task named the field but only defined `IncludeArchived`'s semantics. I implemented `IncludePinned=true` as **restrict-to-pinned-only** (the "pinned chats" view), documented on the type. Easy to change in PR 2 if a different meaning is wanted.

## What was tested

- `go test ./...` — green (83 packages), `gofmt` + `go vet` clean.
- Store **contract tests run on both backends** (the 3-way drift discipline):
  - `TestStoreContract/ListSessions` — every filter axis independently (tenant, user, agent, status, tag, title-contains), archived excluded by default + included when asked, pinned-first ordering, token/cost/run_count aggregation, and limit/offset + total pagination.
  - `TestStoreContract/ListSessionsTenantIsolation` — a `SessionFilter{TenantID:"A"}` never returns tenant B's sessions.
  - `TestStoreContract/SetSessionMeta` — per-field round-trip, partial patch leaves others unchanged, archive set/clear, summary re-write refreshes the stamp, `ErrNotFound` on a missing id.
- **Postgres path exercised for real:** ran the contract against a live Postgres 16 fixture (`AutoMigrate` applied migration 0057) — all three new subtests PASS, plus the full existing contract stayed green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
