### PR TITLE
fix(history): resolve 5 code-review findings on the History tool

### DIFF
--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -855,11 +855,17 @@ func (s *Store) ListSessions(ctx context.Context, f store.SessionFilter, limit, 
 		conds = append(conds, "s.pinned")
 	}
 	if f.Tag != "" {
-		// Literal substring match against the JSON-array text, tag matched WITH
-		// its quotes so `"q3"` can't match inside `"q3-plan"`; strpos (not LIKE)
-		// avoids interpreting `%`/`_` in the tag.
+		// Substring match against the JSON-array text. The needle is the tag
+		// JSON-encoded (store.EncodeTagMatch) so it matches the stored element
+		// byte-for-byte even when the tag contains a quote/backslash (which
+		// EncodeTags escapes); its surrounding quotes keep `"q3"` from matching
+		// inside `"q3-plan"`; strpos (not LIKE) avoids interpreting `%`/`_`.
+		needle, err := store.EncodeTagMatch(f.Tag)
+		if err != nil {
+			return nil, 0, fmt.Errorf("encode tag filter: %w", err)
+		}
 		conds = append(conds, fmt.Sprintf("strpos(s.tags, $%d) > 0", i))
-		args = append(args, `"`+f.Tag+`"`)
+		args = append(args, needle)
 		i++
 	}
 	if f.TitleContains != "" {

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -1766,11 +1766,17 @@ func (s *Store) ListSessions(ctx context.Context, f store.SessionFilter, limit, 
 		innerConds = append(innerConds, "s.pinned = 1")
 	}
 	if f.Tag != "" {
-		// Literal substring match against the JSON-array text. The tag is
-		// matched WITH its surrounding quotes so `"q3"` cannot match inside
-		// `"q3-plan"`; INSTR (not LIKE) avoids interpreting `%`/`_` in the tag.
+		// Substring match against the JSON-array text. The needle is the tag
+		// JSON-encoded (store.EncodeTagMatch) so it matches the stored element
+		// byte-for-byte even when the tag contains a quote/backslash (which
+		// EncodeTags escapes); its surrounding quotes keep `"q3"` from matching
+		// inside `"q3-plan"`; INSTR (not LIKE) avoids interpreting `%`/`_`.
+		needle, err := store.EncodeTagMatch(f.Tag)
+		if err != nil {
+			return nil, 0, fmt.Errorf("encode tag filter: %w", err)
+		}
 		innerConds = append(innerConds, "INSTR(s.tags, ?) > 0")
-		innerArgs = append(innerArgs, `"`+f.Tag+`"`)
+		innerArgs = append(innerArgs, needle)
 	}
 	if f.TitleContains != "" {
 		innerConds = append(innerConds, "INSTR(LOWER(s.title), LOWER(?)) > 0")

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -776,6 +776,22 @@ func EncodeTags(tags []string) (string, error) {
 	return string(b), nil
 }
 
+// EncodeTagMatch returns the JSON-encoded form of a SINGLE tag — i.e. exactly
+// how that tag appears as an element inside an EncodeTags array, including its
+// surrounding quotes and any escaping (a `"`/`\`/`<` etc. is escaped identically
+// to how it was stored). The tag filter uses this as a substring needle so a tag
+// containing an escaped character still matches its stored form; the surrounding
+// quotes also keep `"q3"` from matching inside `"q3-plan"`. It shares
+// json.Marshal with EncodeTags so the needle can never drift from the storage
+// encoding.
+func EncodeTagMatch(tag string) (string, error) {
+	b, err := json.Marshal(tag)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
 // DecodeTags parses a stored sessions.tags value. An empty string (NULL column
 // / legacy row) and an empty JSON array both decode to nil, so the round-tripped
 // SessionSummary.Tags stays clean for JSON omitempty.

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -88,6 +88,7 @@ func Run(t *testing.T, factory Factory) {
 		{"GetRunByAgentIDReturnsMostRecent", testGetRunByAgentIDReturnsMostRecent},
 		{"ListActiveRunsByUser", testListActiveRunsByUser},
 		{"ListSessions", testListSessions},
+		{"ListSessionsTagEscaping", testListSessionsTagEscaping},
 		{"ListSessionsTenantIsolation", testListSessionsTenantIsolation},
 		{"SetSessionMeta", testSetSessionMeta},
 		// RFC BE op=related — the per-session embedding index. Unlike
@@ -1629,6 +1630,38 @@ func summaryIDs(list []store.SessionSummary) []string {
 // independently, archived exclude-by-default, pinned-first ordering, the
 // token/cost/run_count aggregation, and offset pagination — across two tenants,
 // two users, and two agents.
+// testListSessionsTagEscaping is the RFC BE review regression: a tag containing
+// a JSON-special character (a double-quote) must still be matched by the tag
+// filter. Before the fix the filter searched for the raw `"tag"` needle while
+// EncodeTags stored the tag JSON-escaped, so such a tag could never match its
+// own chat. Runs on both backends (the fix is shared store.EncodeTagMatch).
+func testListSessionsTagEscaping(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	sess, err := s.CreateSession(ctx, "t1", "agentA", "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	const quoted = `he said "hi"`
+	if err := s.SetSessionMeta(ctx, sess.ID, store.SessionMetaPatch{
+		Tags: tagsPtr([]string{quoted, "plain"}),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// The quote-bearing tag matches its chat.
+	list, _, err := s.ListSessions(ctx, store.SessionFilter{TenantID: "t1", Tag: quoted}, 50, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 1 || list[0].SessionID != sess.ID {
+		t.Fatalf("tag=%q = %v, want [%s]", quoted, summaryIDs(list), sess.ID)
+	}
+	// A different quoted tag does NOT match (no accidental widening).
+	list, _, _ = s.ListSessions(ctx, store.SessionFilter{TenantID: "t1", Tag: `she said "bye"`}, 50, 0)
+	if len(list) != 0 {
+		t.Fatalf("tag=%q = %v, want []", `she said "bye"`, summaryIDs(list))
+	}
+}
+
 func testListSessions(t *testing.T, s store.Store) {
 	ctx := context.Background()
 

--- a/internal/tools/builtin/context.go
+++ b/internal/tools/builtin/context.go
@@ -27,7 +27,7 @@ import (
 // agents narrow the output instead of paying for a kitchen-sink dump
 // on every call.
 //
-// Nine ops total — PR 1 ships four of them:
+// Ten ops:
 //
 //	self        — identity bundle (agent name, run/agent ids, user, tenant,
 //	              tier, resolved provider + model + sampling; the `principal`
@@ -36,9 +36,10 @@ import (
 //	tools       — post-filter tool catalog
 //	doc         — detailed schema/docstring for one tool by name
 //	permissions — gates that apply to the caller (tool ACL, host policy, scopes)
+//	agents / lineage / evaluations / channels / help / time
 //
-// PR 2 adds:  agents / lineage / evaluations
-// PR 3 adds:  channels / history + default-add + opt-out
+// (A former `history` op was removed — superseded by the standalone History
+// tool, which adds owner scopes + listing/search/annotation; see its docs.)
 //
 // All op results are deterministic and side-effect-free. Calling
 // Context never modifies anything in storage or in-process state.

--- a/internal/tools/builtin/history.go
+++ b/internal/tools/builtin/history.go
@@ -210,6 +210,9 @@ func (h *History) filterForScope(ctx context.Context, scope string, in historyIn
 		IncludeArchived: in.IncludeArchived,
 	}
 	if in.Status != "" {
+		if !validChatStatus(in.Status) {
+			return store.SessionFilter{}, fmt.Errorf("history: unknown status %q (want one of: running, completed, failed, cancelled)", in.Status)
+		}
 		f.Status = store.RunStatus(in.Status)
 	}
 	if in.From != "" {
@@ -226,11 +229,25 @@ func (h *History) filterForScope(ctx context.Context, scope string, in historyIn
 		}
 		f.To = t
 	}
+	// self/user resolve the owner id from ctx identity. An EMPTY resolved id
+	// must NOT silently drop the constraint — SessionFilter treats "" as "no
+	// filter on that axis", which would widen the listing to the whole tenant
+	// (e.g. a no-user Schedule/Webhook run with history_scope:[user] seeing every
+	// user's chats). The by-id fold (loadSessionInScope) stays strict, so we
+	// refuse here to keep list/search/related symmetric with it: no identity ⇒
+	// no identity-scoped listing.
 	switch scope {
 	case "self":
-		f.AgentName = tools.AgentName(ctx)
+		agent := tools.AgentName(ctx)
+		if agent == "" {
+			return store.SessionFilter{}, fmt.Errorf("history: self scope needs an agent identity in the run context (none present — use tenant or user scope)")
+		}
+		f.AgentName = agent
 		f.TenantID = ident.TenantID
 	case "user":
+		if ident.UserID == "" {
+			return store.SessionFilter{}, fmt.Errorf("history: user scope needs a user identity in the run context (none present — use tenant scope)")
+		}
 		f.UserID = ident.UserID
 		f.TenantID = ident.TenantID
 	case "tenant":
@@ -240,6 +257,35 @@ func (h *History) filterForScope(ctx context.Context, scope string, in historyIn
 		// principal (policy resolution dropped `global` otherwise).
 	}
 	return f, nil
+}
+
+// validChatStatus reports whether s is one of the derived chat statuses
+// ListSessions can filter on. Rejecting an unknown value up front turns a silent
+// empty page (a typo like "complete") into a clear error.
+func validChatStatus(s string) bool {
+	switch store.RunStatus(s) {
+	case store.RunRunning, store.RunCompleted, store.RunFailed, store.RunCancelled:
+		return true
+	}
+	return false
+}
+
+// list-page clamp — mirrors the store's ListSessions clamp so the tool passes,
+// and echoes, the SAME limit the store will use (truthful pagination metadata
+// when the caller omits or overshoots it).
+const (
+	listLimitDefault = 50
+	listLimitMax     = 500
+)
+
+func effectiveListLimit(limit int) int {
+	if limit <= 0 {
+		return listLimitDefault
+	}
+	if limit > listLimitMax {
+		return listLimitMax
+	}
+	return limit
 }
 
 func (h *History) list(ctx context.Context, scope string, in historyInput, isSearch bool) (tools.Result, error) {
@@ -255,7 +301,8 @@ func (h *History) list(ctx context.Context, scope string, in historyInput, isSea
 		// full-text search is deferred (an FTS index, additive later).
 		f.TitleContains = in.Query
 	}
-	rows, total, err := h.Store.ListSessions(ctx, f, in.Limit, in.Offset)
+	limit := effectiveListLimit(in.Limit)
+	rows, total, err := h.Store.ListSessions(ctx, f, limit, in.Offset)
 	if err != nil {
 		return errResult("history: list: " + err.Error()), nil
 	}
@@ -263,7 +310,7 @@ func (h *History) list(ctx context.Context, scope string, in historyInput, isSea
 		"scope":  scope,
 		"chats":  rows,
 		"total":  total,
-		"limit":  in.Limit,
+		"limit":  limit, // the effective limit the store applied, not the raw request
 		"offset": in.Offset,
 	})
 }

--- a/internal/tools/builtin/history_test.go
+++ b/internal/tools/builtin/history_test.go
@@ -171,6 +171,69 @@ func TestHistory_GlobalRefusedForNonAdmin(t *testing.T) {
 	}
 }
 
+// TestHistory_UserScopeRefusesWithoutUserIdentity is the RFC BE review
+// regression: scope=user must NOT widen to the whole tenant when the run carries
+// no user identity. Before the fix an empty UserID dropped the owner filter, so
+// list/search/related returned EVERY user's chats in the tenant (a within-tenant
+// leak); the by-id fold stayed strict, so the two paths disagreed.
+func TestHistory_UserScopeRefusesWithoutUserIdentity(t *testing.T) {
+	h, s := historyFixture(t)
+	seedChat(t, s, "t1", "agentA", "bob") // another user's chat in the tenant
+	// Caller granted user scope but carrying NO user identity (empty UserID).
+	res, _ := h.Execute(histCtx([]string{"user"}, "agentA", "", "t1"),
+		json.RawMessage(`{"op":"list","scope":"user"}`))
+	if !res.IsError {
+		t.Fatalf("user scope with no user identity must refuse, not widen to the tenant; got %s", res.Text)
+	}
+}
+
+// TestHistory_SelfScopeRefusesWithoutAgentIdentity: scope=self must refuse when
+// no agent identity is present (an off-run operator call) rather than silently
+// listing every agent's chats in the tenant.
+func TestHistory_SelfScopeRefusesWithoutAgentIdentity(t *testing.T) {
+	h, s := historyFixture(t)
+	seedChat(t, s, "t1", "agentB", "alice")
+	res, _ := h.Execute(histCtx([]string{"self"}, "", "alice", "t1"),
+		json.RawMessage(`{"op":"list","scope":"self"}`))
+	if !res.IsError {
+		t.Fatalf("self scope with no agent identity must refuse; got %s", res.Text)
+	}
+}
+
+// TestHistory_ListEchoesEffectiveLimit: with no limit supplied, the response
+// reports the effective limit the store applied (50), not the raw request (0),
+// so a client that paginates by the echoed limit advances correctly.
+func TestHistory_ListEchoesEffectiveLimit(t *testing.T) {
+	h, s := historyFixture(t)
+	seedChat(t, s, "t1", "agentA", "alice")
+	res, _ := h.Execute(histCtx([]string{"self"}, "agentA", "alice", "t1"),
+		json.RawMessage(`{"op":"list","scope":"self"}`))
+	if res.IsError {
+		t.Fatalf("list: %s", res.Text)
+	}
+	var out struct {
+		Limit int `json:"limit"`
+	}
+	if err := json.Unmarshal([]byte(res.Text), &out); err != nil {
+		t.Fatalf("decode list: %v (%s)", err, res.Text)
+	}
+	if out.Limit != 50 {
+		t.Errorf("echoed limit = %d, want 50 (the effective default)", out.Limit)
+	}
+}
+
+// TestHistory_ListRejectsInvalidStatus: an unknown status value is rejected up
+// front rather than silently returning an empty page (a typo like "complete").
+func TestHistory_ListRejectsInvalidStatus(t *testing.T) {
+	h, s := historyFixture(t)
+	seedChat(t, s, "t1", "agentA", "alice")
+	res, _ := h.Execute(histCtx([]string{"self"}, "agentA", "alice", "t1"),
+		json.RawMessage(`{"op":"list","scope":"self","status":"complete"}`))
+	if !res.IsError {
+		t.Fatalf("invalid status should be rejected; got %s", res.Text)
+	}
+}
+
 // TestHistory_GlobalSpansTenantsWhenGranted: an admin (policy includes global)
 // sees chats across tenants.
 func TestHistory_GlobalSpansTenantsWhenGranted(t *testing.T) {


### PR DESCRIPTION
## Why

A full feature code review of the RFC BE History tool (PRs #718–#722) surfaced one substantive isolation gap plus four minor correctness/cleanup items. This PR fixes all five, each with a fail-before-verified regression test.

## What

**1. Isolation — identity-scoped listing must not widen (main fix).**
`filterForScope` resolved the owner id from ctx identity, but `SessionFilter` treats an empty axis as "no filter on that axis". So a `scope=self`/`scope=user` `list`/`search`/`related` whose resolved `AgentName`/`UserID` was empty silently **widened to the whole tenant** — e.g. a no-user Schedule/Webhook run granted `history_scope:[user]` would list *every* user's chats. The by-id fold (`loadSessionInScope`) stayed strict, so the two paths disagreed. Now `self`/`user` **refuse** when the resolved identity is empty (no identity ⇒ no identity-scoped listing). Tenant-bounded before the fix, but a within-tenant privilege escalation.

**2. Truthful pagination.** `list`/`search` echoed the raw request `limit` (0 when unset) instead of the effective limit the store applied (default 50, cap 500); a client paginating by the echoed value never advanced. Now echoes the effective limit.

**3. Tag filter vs. JSON escaping.** The tag filter searched for the raw needle `"`+tag+`"`, but `EncodeTags` stores each tag JSON-escaped, so a tag containing a `"`/`\` (e.g. `he said "hi"`) never matched its own chat. Both backends now build the needle via a new shared `store.EncodeTagMatch` (JSON-encodes the single tag exactly as it's stored — the needle can't drift from the encoding, and the surrounding quotes still prevent `"q3"` matching inside `"q3-plan"`).

**4. Status validation.** An unknown `status` filter was passed straight to the query and silently returned an empty page (a typo like `complete`); now rejected up front with a clear error.

**5. Stale comment.** The `Context` tool's doc comment still said "Nine ops total" and listed a `history` op (removed in #719, superseded by this tool); corrected to the current ten ops.

## What was tested

- **New regression tests, all fail on the pre-fix code (verified by reverting):**
  - `TestHistory_UserScopeRefusesWithoutUserIdentity`, `TestHistory_SelfScopeRefusesWithoutAgentIdentity` (finding 1)
  - `TestHistory_ListEchoesEffectiveLimit` (finding 2)
  - `TestHistory_ListRejectsInvalidStatus` (finding 4)
  - `storetest` contract `ListSessionsTagEscaping` — runs on **both** sqlite + postgres (finding 3)
- `go test ./...` clean; `gofmt`/`go vet` clean.
- Existing happy-path scope tests (`ListSelfScopeFiltersByAgent`, `ListUserScopeFiltersByUser`, `ListTenantScopeSpansTenantOnly`, global admin/non-admin) still pass — the refuse-on-empty guard does not affect calls that carry an identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)