### PR TITLE
fix(bundles): declare the team/* channel so v1.20.0 boots (fixes crash-loop)

### DIFF
--- a/bundles/agent-teams/loomcycle.yaml
+++ b/bundles/agent-teams/loomcycle.yaml
@@ -40,6 +40,23 @@
 # Run team/orchestrator INTERACTIVELY (start it with interactive:true from the /run
 # terminal) so it is the human's steerable contact point.
 
+# Coordination bus for team/orchestrator (RFC BD). Channels are STATIC-declared
+# (the Channel tool refuses any channel not in a channels: block), so
+# team/orchestrator's `channels: publish/subscribe: [team/*]` grant needs a
+# declared channel under the team/* prefix — without this the whole config fails
+# to load ("no declared channel matches the prefix"). This gives the orchestrator
+# a durable side-channel for cross-branch status (agents publish progress, the
+# orchestrator subscribes to fan them in); parallel fan-out itself still uses the
+# Agent parallel_spawn envelope. scope=user so the orchestrator and the
+# sub-agents it spawns (which inherit the user) share one bus.
+channels:
+  team/coordination:
+    description: "Team coordination bus — agents publish branch status/results; team/orchestrator subscribes to fan them in."
+    scope: user
+    default_ttl: 86400
+    max_messages: 10000
+    semantic: broadcast
+
 agents:
   agent/assistant:
     tier: middle

--- a/cmd/loomcycle/embedded/bundles/agent-teams.yaml
+++ b/cmd/loomcycle/embedded/bundles/agent-teams.yaml
@@ -40,6 +40,23 @@
 # Run team/orchestrator INTERACTIVELY (start it with interactive:true from the /run
 # terminal) so it is the human's steerable contact point.
 
+# Coordination bus for team/orchestrator (RFC BD). Channels are STATIC-declared
+# (the Channel tool refuses any channel not in a channels: block), so
+# team/orchestrator's `channels: publish/subscribe: [team/*]` grant needs a
+# declared channel under the team/* prefix — without this the whole config fails
+# to load ("no declared channel matches the prefix"). This gives the orchestrator
+# a durable side-channel for cross-branch status (agents publish progress, the
+# orchestrator subscribes to fan them in); parallel fan-out itself still uses the
+# Agent parallel_spawn envelope. scope=user so the orchestrator and the
+# sub-agents it spawns (which inherit the user) share one bus.
+channels:
+  team/coordination:
+    description: "Team coordination bus — agents publish branch status/results; team/orchestrator subscribes to fan them in."
+    scope: user
+    default_ttl: 86400
+    max_messages: 10000
+    semantic: broadcast
+
 agents:
   agent/assistant:
     tier: middle

--- a/cmd/loomcycle/presets_integration_test.go
+++ b/cmd/loomcycle/presets_integration_test.go
@@ -98,6 +98,32 @@ skills:
 	}
 }
 
+// TestEmbedded_DefaultStackValidates is the v1.20.1 regression: the full default
+// preset stack the TrueNAS/Docker deploy ships (base + the four bundles) must
+// LOAD AND VALIDATE cleanly. v1.20.0 shipped a fatal boot error here —
+// team/orchestrator granted `channels: [team/*]` but no team/* channel was
+// declared, so validate() rejected the whole config ("no declared channel
+// matches the prefix") and the server crash-looped on boot. LoadLayers runs
+// validate(), so this fails on the unfixed bundles.
+func TestEmbedded_DefaultStackValidates(t *testing.T) {
+	t.Setenv("LOOMCYCLE_SKILLS_ROOT", "")
+	cfg, err := config.LoadLayers(layersFor(t, "base", "document-agent", "chat", "agent-teams", "team-examples")...)
+	if err != nil {
+		t.Fatalf("the default preset stack must load + validate cleanly: %v", err)
+	}
+	// The orchestrator's team/* channel ACL now resolves to a declared channel.
+	if _, ok := cfg.Channels["team/coordination"]; !ok {
+		names := make([]string, 0, len(cfg.Channels))
+		for n := range cfg.Channels {
+			names = append(names, n)
+		}
+		t.Errorf("agent-teams bundle should declare the team/coordination channel; channels=%v", names)
+	}
+	if _, ok := cfg.Agents["team/orchestrator"]; !ok {
+		t.Errorf("team/orchestrator should be registered")
+	}
+}
+
 // hasToolPreset reports whether tools contains name.
 func hasToolPreset(tools []string, name string) bool {
 	for _, t := range tools {


### PR DESCRIPTION
## Why (production down)

v1.20.0 **crash-loops on boot** with the standard deploy preset stack (`LOOMCYCLE_PRESETS=base,document-agent,chat,agent-teams,team-examples`). Config validation fails fatally:

```
config: agent "team/orchestrator": channels.publish[0]: channel "team/*": no declared channel matches the prefix
```

The server never starts — it restarts every second.

## Root cause

v1.19.2 (#717, folded into v1.20.0) added `channels: {publish: [team/*], subscribe: [team/*]}` to `team/orchestrator` to clear the "Channel tool listed but its ACL is empty" boot warning. But **channels are static-declared** — the Channel tool refuses any channel not in a `channels:` block (`internal/tools/builtin/channel.go`) — and the `agent-teams` bundle declared **none**. `validateAgentChannelEntry` then rejects a `team/*` wildcard ACL that matches no declared channel, **fatally, at config load**.

The gap that let it ship: no test exercised the full embedded preset stack through `validate()`.

## What

Declare a `team/coordination` channel (`scope: user`, `semantic: broadcast`) under the `team/*` prefix in **both** the embedded bundle (`cmd/loomcycle/embedded/bundles/agent-teams.yaml`) and its mirror (`bundles/agent-teams/loomcycle.yaml`). This **completes** the #717 grant rather than reverting the operator's intent: `team/orchestrator`'s Channel tool is now functional (a durable side-channel for cross-branch status) instead of default-denied. Additive — no other agent is affected, and no runtime cost until an agent publishes.

## What was tested

- **New regression `TestEmbedded_DefaultStackValidates`** — loads the full default preset stack through `LoadLayers` (which runs `validate()`) and asserts it validates + that `team/coordination` is declared. **Fails on the unfixed bundles with the exact boot error** (verified by `git stash` of the two YAMLs → red → restore).
- Reproduced the crash pre-fix and confirmed the fix post-fix via `loomcycle doctor` with the 5-preset stack: `[FAIL] Config parses` → **`[PASS] Config parses`**.
- `go test ./cmd/loomcycle/ ./internal/config/` clean; gofmt clean.

## Follow-up (not in this hotfix)

Full cross-agent team-channel coordination isn't wired end-to-end (handler agents don't yet carry the `team/*` grant, and no skill drives channel ops — parallel fan-out uses the `Agent` parallel_spawn envelope). This PR only restores a valid, bootable config; wiring handlers into the coordination bus is a separate feature if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)