### PR TITLE
feat(providers): P1 — config-driven provider schema + driver registry (additive, no behavior change)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -3128,6 +3128,29 @@ func newProviderResolver(cfg *config.Config) *providerResolver {
 	return pr
 }
 
+// toCapabilityPatch translates a config.CapabilityOverride (the `capabilities:`
+// block on an RFC BF `providers:` entry) into the providers-side
+// providers.CapabilityPatch the driver registry applies inside Capabilities().
+// internal/providers cannot import internal/config (config depends on downstream
+// consumers of providers — the edge would cycle), so this boundary translation
+// lives here at the composition root. Nil in → nil out (no override → advertise
+// driver defaults). Defined for P2's registry wiring; deliberately NOT called by
+// newProviderResolver in P1 (the hardcoded resolver stays authoritative), so P2
+// is a clean flip rather than a rewrite.
+func toCapabilityPatch(o *config.CapabilityOverride) *providers.CapabilityPatch {
+	if o == nil {
+		return nil
+	}
+	return &providers.CapabilityPatch{
+		SupportsThinking:  o.SupportsThinking,
+		SupportsVision:    o.SupportsVision,
+		SupportsEffort:    o.SupportsEffort,
+		NativePromptCache: o.NativePromptCache,
+		ParallelToolCalls: o.ParallelToolCalls,
+		MaxContextTokens:  o.MaxContextTokens,
+	}
+}
+
 // validateCodeAgents fails loud at startup for any statically-configured
 // `provider: code-js` agent whose JS is missing or won't parse (RFC J
 // Deliverable 3) — so a broken code-agent fails the boot, NOT the first

--- a/cmd/loomcycle/providers_p1_test.go
+++ b/cmd/loomcycle/providers_p1_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// TestToCapabilityPatch covers the RFC BF config→providers boundary translation:
+// nil in → nil out, and each set/unset field maps across faithfully (a pointer
+// override survives, an unset field stays nil so it doesn't clobber a driver
+// default when Apply runs).
+func TestToCapabilityPatch(t *testing.T) {
+	if got := toCapabilityPatch(nil); got != nil {
+		t.Errorf("nil override must translate to nil patch, got %+v", got)
+	}
+
+	tru := true
+	fls := false
+	n := 262144
+	in := &config.CapabilityOverride{
+		SupportsThinking: &tru,
+		SupportsVision:   &fls,
+		MaxContextTokens: &n,
+		// SupportsEffort / NativePromptCache / ParallelToolCalls intentionally
+		// left nil to prove unset fields stay nil across the boundary.
+	}
+	got := toCapabilityPatch(in)
+	if got == nil {
+		t.Fatal("non-nil override translated to nil patch")
+	}
+	if got.SupportsThinking == nil || *got.SupportsThinking != true {
+		t.Errorf("SupportsThinking = %v, want *true", got.SupportsThinking)
+	}
+	if got.SupportsVision == nil || *got.SupportsVision != false {
+		t.Errorf("SupportsVision = %v, want *false", got.SupportsVision)
+	}
+	if got.MaxContextTokens == nil || *got.MaxContextTokens != n {
+		t.Errorf("MaxContextTokens = %v, want *%d", got.MaxContextTokens, n)
+	}
+	if got.SupportsEffort != nil || got.NativePromptCache != nil || got.ParallelToolCalls != nil {
+		t.Errorf("unset override fields must stay nil, got effort=%v cache=%v parallel=%v",
+			got.SupportsEffort, got.NativePromptCache, got.ParallelToolCalls)
+	}
+
+	// The translated patch must overlay correctly onto a base Capabilities —
+	// end-to-end proof the boundary + the providers-side Apply agree.
+	base := providers.Capabilities{SupportsEffort: true, SupportsVision: true}
+	out := got.Apply(base)
+	if !out.SupportsThinking || out.SupportsVision || out.MaxContextTokens != n {
+		t.Errorf("Apply(base) = %+v, want thinking=true vision=false max=%d", out, n)
+	}
+	if !out.SupportsEffort {
+		t.Error("SupportsEffort should be untouched by the patch (still true)")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,6 +73,15 @@ type Config struct {
 	// TAVILY_API_KEY), overridable per-tenant via CredentialDef.
 	SearchProviders map[string]SearchProviderConfig `yaml:"search_providers"`
 
+	// Providers is the RFC BF config-driven LLM provider registry: each entry
+	// declares one provider instance (its driver, wire dialect, base URL, key
+	// env, concurrency, driver options, capability overrides) keyed by the
+	// provider id agents reference in `provider:`. Empty = the hardcoded
+	// env-driven resolver in cmd/loomcycle is authoritative (P1 default — this
+	// block is parsed + validated but not yet consumed on the hot path; P2 wires
+	// it into the resolver). See ProviderConfig.
+	Providers map[string]ProviderConfig `yaml:"providers"`
+
 	// SearchPriority is the global default fallback order the WebSearch tool
 	// walks when an agent declares no per-agent `search_providers:` list.
 	// Every entry must be an enabled SearchProviders key. Empty = the enabled
@@ -569,6 +578,61 @@ type TierCandidate struct {
 // from the env var the driver names); SearXNG needs its self-hosted base_url.
 type SearchProviderConfig struct {
 	BaseURL string `json:"base_url,omitempty" yaml:"base_url"` // SearXNG only, e.g. http://searxng:8080
+}
+
+// ProviderConfig is one entry in the RFC BF `providers:` map — a config-declared
+// LLM provider instance. The map key is the provider id agents reference in
+// `provider:` (e.g. "anthropic", "ollama-local"); this struct says which driver
+// serves it and how it is wired. Additive in P1: parsed + lightly validated but
+// not yet consumed by the resolver (cmd/loomcycle's hardcoded construction stays
+// authoritative until P2 flips the seam).
+//
+// The json: tags mirror SearchProviderConfig's style so an admin JSON surface
+// can serialize the block; the resolver ordering — not this shape — carries the
+// substrate content_sha256 concerns.
+type ProviderConfig struct {
+	// Driver names the compiled-in driver that serves this provider (one of
+	// providers.RegisteredDrivers() — anthropic/openai/gemini/ollama/deepseek/
+	// mock/code-js). Required. The driver-name-against-registry cross-check is
+	// deferred to P2 (config.go must not import internal/providers in P1).
+	Driver string `json:"driver" yaml:"driver"`
+	// Dialect selects the wire dialect when a driver speaks more than one; empty
+	// = the driver's canonical default. Validated against the driver's dialect
+	// set in P2 (registry-aware).
+	Dialect string `json:"dialect,omitempty" yaml:"dialect,omitempty"`
+	// BaseURL overrides the driver's default endpoint (self-hosted mirror, Vertex
+	// Gemini, local Ollama, …). Empty = driver default.
+	BaseURL string `json:"base_url,omitempty" yaml:"base_url,omitempty"`
+	// APIKeyEnv is the env-var NAME (never the value) whose credential keys this
+	// provider and can be overridden per-tenant (RFC AR). Empty = the driver's
+	// built-in default (e.g. OPENAI_API_KEY).
+	APIKeyEnv string `json:"api_key_env,omitempty" yaml:"api_key_env,omitempty"`
+	// MaxConcurrent caps in-flight calls to this provider. 0 = unbounded (the
+	// current behaviour). Must be >= 0.
+	MaxConcurrent int `json:"max_concurrent,omitempty" yaml:"max_concurrent,omitempty"`
+	// Options carries driver-specific tuning (ollama num_ctx/num_gpu, code-js
+	// code_root, …), passed opaquely to the driver factory. Unknown keys are
+	// logged and ignored by the driver, never fatal.
+	Options map[string]any `json:"options,omitempty" yaml:"options,omitempty"`
+	// Capabilities is an optional operator override of the driver's advertised
+	// Capabilities (a model behind an OpenAI-compatible base URL that DOES
+	// support vision, say). Nil = advertise the driver defaults.
+	Capabilities *CapabilityOverride `json:"capabilities,omitempty" yaml:"capabilities,omitempty"`
+}
+
+// CapabilityOverride is the operator-facing override of a driver's advertised
+// providers.Capabilities (RFC BF), under a `providers:` entry's `capabilities:`
+// block. Every field is a pointer so "unset" (nil) is distinct from "false"/"0":
+// an override that only flips one capability must not silently zero the rest.
+// The nil-safe overlay lives on the providers side (providers.CapabilityPatch);
+// cmd/loomcycle translates this → that at the composition root.
+type CapabilityOverride struct {
+	SupportsThinking  *bool `json:"supports_thinking,omitempty" yaml:"supports_thinking,omitempty"`
+	SupportsVision    *bool `json:"supports_vision,omitempty" yaml:"supports_vision,omitempty"`
+	SupportsEffort    *bool `json:"supports_effort,omitempty" yaml:"supports_effort,omitempty"`
+	NativePromptCache *bool `json:"native_prompt_cache,omitempty" yaml:"native_prompt_cache,omitempty"`
+	ParallelToolCalls *bool `json:"parallel_tool_calls,omitempty" yaml:"parallel_tool_calls,omitempty"`
+	MaxContextTokens  *int  `json:"max_context_tokens,omitempty" yaml:"max_context_tokens,omitempty"`
 }
 
 // SearchHostKey returns the operator host API key for a search-provider id
@@ -4815,6 +4879,22 @@ func validate(c *Config) error {
 	for i, id := range c.SearchPriority {
 		if !enabledSearch[id] {
 			return fmt.Errorf("search_priority[%d]: %q is not an enabled search_providers entry", i, id)
+		}
+	}
+	// RFC BF provider registry (P1): light structural validation only. Each
+	// declared entry needs a driver and a non-negative concurrency cap. The
+	// registry-aware checks — driver name ∈ providers.RegisteredDrivers(),
+	// dialect ∈ the driver's set, models[*].provider ∈ this map — are P2, where
+	// the resolver (which may import internal/providers) becomes authoritative;
+	// config.go stays free of an internal/providers import in P1. An absent
+	// `providers:` block skips the loop entirely, so every existing config
+	// validates identically.
+	for id, pc := range c.Providers {
+		if strings.TrimSpace(pc.Driver) == "" {
+			return fmt.Errorf("providers.%s: driver is required", id)
+		}
+		if pc.MaxConcurrent < 0 {
+			return fmt.Errorf("providers.%s: max_concurrent must be >= 0", id)
 		}
 	}
 	// Library-level tier definitions.

--- a/internal/config/providers_test.go
+++ b/internal/config/providers_test.go
@@ -1,0 +1,113 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestProviders_UnmarshalYAML locks the RFC BF `providers:` block round-trip:
+// every field (driver/dialect/base_url/api_key_env/max_concurrent/options/
+// capabilities) parses into ProviderConfig, and the pointer capability fields
+// distinguish an explicit false from an unset field.
+func TestProviders_UnmarshalYAML(t *testing.T) {
+	var doc struct {
+		Providers map[string]ProviderConfig `yaml:"providers"`
+	}
+	src := "providers:\n" +
+		"  ollama-local:\n" +
+		"    driver: ollama\n" +
+		"    dialect: ollama-chat\n" +
+		"    base_url: http://localhost:11434\n" +
+		"    max_concurrent: 4\n" +
+		"    options:\n" +
+		"      num_ctx: 131072\n" +
+		"      num_gpu: 99\n" +
+		"    capabilities:\n" +
+		"      supports_vision: false\n" +
+		"      max_context_tokens: 131072\n" +
+		"  anthropic:\n" +
+		"    driver: anthropic\n" +
+		"    api_key_env: ANTHROPIC_API_KEY\n"
+	if err := yaml.Unmarshal([]byte(src), &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	ol, ok := doc.Providers["ollama-local"]
+	if !ok {
+		t.Fatalf("ollama-local entry missing (%+v)", doc.Providers)
+	}
+	if ol.Driver != "ollama" || ol.Dialect != "ollama-chat" || ol.BaseURL != "http://localhost:11434" {
+		t.Errorf("ollama-local core fields = %+v", ol)
+	}
+	if ol.MaxConcurrent != 4 {
+		t.Errorf("max_concurrent = %d, want 4", ol.MaxConcurrent)
+	}
+	if n, ok := ol.Options["num_ctx"]; !ok || n != 131072 {
+		t.Errorf("options.num_ctx = %v (%T), want 131072", n, n)
+	}
+	if ol.Capabilities == nil {
+		t.Fatal("capabilities block did not parse")
+	}
+	// Explicit false must be a non-nil *bool pointing at false (distinct from
+	// unset) — this is the load-bearing reason the override fields are pointers.
+	if ol.Capabilities.SupportsVision == nil || *ol.Capabilities.SupportsVision != false {
+		t.Errorf("supports_vision = %v, want a non-nil *false", ol.Capabilities.SupportsVision)
+	}
+	if ol.Capabilities.SupportsThinking != nil {
+		t.Errorf("supports_thinking should be nil (unset), got %v", *ol.Capabilities.SupportsThinking)
+	}
+	if ol.Capabilities.MaxContextTokens == nil || *ol.Capabilities.MaxContextTokens != 131072 {
+		t.Errorf("max_context_tokens = %v, want *131072", ol.Capabilities.MaxContextTokens)
+	}
+
+	an := doc.Providers["anthropic"]
+	if an.Driver != "anthropic" || an.APIKeyEnv != "ANTHROPIC_API_KEY" {
+		t.Errorf("anthropic entry = %+v", an)
+	}
+}
+
+// TestValidate_Providers covers the P1 light validation: a good block passes,
+// an empty driver or negative max_concurrent fails, and an absent block never
+// changes the outcome (every existing config validates identically).
+func TestValidate_Providers(t *testing.T) {
+	base := func(p map[string]ProviderConfig) *Config {
+		return &Config{
+			Defaults:    Defaults{Provider: "anthropic", Model: "x"},
+			Concurrency: Concurrency{MaxConcurrentRuns: 1},
+			Providers:   p,
+		}
+	}
+
+	if err := validate(base(map[string]ProviderConfig{
+		"anthropic": {Driver: "anthropic"},
+		"ol":        {Driver: "ollama", MaxConcurrent: 8, Options: map[string]any{"num_ctx": 131072}},
+	})); err != nil {
+		t.Errorf("valid providers block rejected: %v", err)
+	}
+
+	// Absence is a no-op: nil map validates exactly like a config without the key.
+	if err := validate(base(nil)); err != nil {
+		t.Errorf("absent providers block should validate: %v", err)
+	}
+
+	cases := []struct {
+		name    string
+		cfg     *Config
+		wantSub string
+	}{
+		{"empty driver",
+			base(map[string]ProviderConfig{"bad": {Driver: ""}}), "driver is required"},
+		{"negative max_concurrent",
+			base(map[string]ProviderConfig{"bad": {Driver: "openai", MaxConcurrent: -1}}), "max_concurrent must be >= 0"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validate(tc.cfg)
+			if err == nil || !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("got %v, want error containing %q", err, tc.wantSub)
+			}
+		})
+	}
+}

--- a/internal/providers/anthropic/driver.go
+++ b/internal/providers/anthropic/driver.go
@@ -33,6 +33,12 @@ type Driver struct {
 	baseURL     string
 	http        *http.Client
 	idleTimeout time.Duration
+	// id is the provider identity reported by ID(). Defaults to "anthropic" in
+	// New(); the RFC BF driver registry sets it from DriverOptions.ID.
+	id string
+	// capsPatch is an optional operator override applied inside Capabilities()
+	// (RFC BF). Nil = advertise the driver defaults.
+	capsPatch *providers.CapabilityPatch
 }
 
 // New constructs a Driver. baseURL may be empty for the default endpoint.
@@ -47,10 +53,10 @@ func New(apiKey, baseURL string, streamOpts streamhttp.Options, httpClient *http
 	if httpClient == nil {
 		httpClient = streamhttp.NewClient(streamOpts.HeaderTimeout)
 	}
-	return &Driver{apiKey: apiKey, baseURL: baseURL, http: httpClient, idleTimeout: streamOpts.IdleTimeout}
+	return &Driver{apiKey: apiKey, baseURL: baseURL, http: httpClient, idleTimeout: streamOpts.IdleTimeout, id: "anthropic"}
 }
 
-func (d *Driver) ID() string { return "anthropic" }
+func (d *Driver) ID() string { return d.id }
 
 // resolveKey returns the API key to authenticate an inference request AND which
 // credential scope it came from. A tenant/user credential named
@@ -69,7 +75,7 @@ func (d *Driver) resolveKey(ctx context.Context) (key, source, scopeID string, e
 func (d *Driver) KeyEnvName() string { return "ANTHROPIC_API_KEY" }
 
 func (d *Driver) Capabilities() providers.Capabilities {
-	return providers.Capabilities{
+	return d.capsPatch.Apply(providers.Capabilities{
 		NativePromptCache: true,
 		ParallelToolCalls: true,
 		Streaming:         true,
@@ -77,7 +83,7 @@ func (d *Driver) Capabilities() providers.Capabilities {
 		SupportsThinking:  true,
 		SupportsEffort:    true,
 		SupportsVision:    true, // per-model refined by anthropicSupportsVision
-	}
+	})
 }
 
 // Call sends the request and returns a channel of Events. The channel is

--- a/internal/providers/anthropic/register.go
+++ b/internal/providers/anthropic/register.go
@@ -1,0 +1,27 @@
+package anthropic
+
+import "github.com/denn-gubsky/loomcycle/internal/providers"
+
+// init registers the anthropic driver with the RFC BF driver registry.
+// Registration records only the factory (no construction, no activation). The
+// single canonical dialect is "anthropic-messages" (the Messages API wire
+// shape).
+func init() {
+	providers.RegisterDriver("anthropic", []string{"anthropic-messages"}, newFromOptions)
+}
+
+// newFromOptions builds an anthropic Driver from the registry DriverOptions.
+// P1 equivalent of cmd/loomcycle/main.go's hardcoded anthropic.New(...); NOT
+// yet on the hot path (P2 wires the registry into the resolver). Anthropic's
+// key env var is fixed (ANTHROPIC_API_KEY) — the driver exposes no SetKeyEnvName
+// — so KeyEnvName is not forwarded. The API version is a compile-time const, so
+// there are no consumable driver options today.
+func newFromOptions(o providers.DriverOptions) (providers.Provider, error) {
+	d := New(o.APIKey, o.BaseURL, o.StreamOpts, nil)
+	if o.ID != "" {
+		d.id = o.ID
+	}
+	d.capsPatch = o.Capabilities
+	providers.WarnUnknownOptions(o.Logf, "anthropic", o.Options)
+	return d, nil
+}

--- a/internal/providers/codejs/provider.go
+++ b/internal/providers/codejs/provider.go
@@ -57,6 +57,13 @@ type Provider struct {
 	deterministic bool
 	runTimeout    time.Duration
 	logf          func(string, ...any)
+	// id is the provider identity reported by ID(). Defaults to providerID
+	// ("code-js") in New(); the RFC BF driver registry sets it from
+	// DriverOptions.ID.
+	id string
+	// capsPatch is an optional operator override applied inside Capabilities()
+	// (RFC BF). Nil = advertise the driver defaults.
+	capsPatch *providers.CapabilityPatch
 
 	counter atomic.Uint64 // mints unique tool_use IDs for the transcript
 }
@@ -75,10 +82,11 @@ func New(cfg Config) *Provider {
 		deterministic: cfg.Deterministic,
 		runTimeout:    cfg.RunTimeout,
 		logf:          logf,
+		id:            providerID,
 	}
 }
 
-func (p *Provider) ID() string { return providerID }
+func (p *Provider) ID() string { return p.id }
 
 // Capabilities: code-js streams events but has no LLM-shaped knobs — no native
 // cache, no parallel tool calls (one frontier at a time), no thinking/effort.
@@ -90,7 +98,7 @@ func (p *Provider) Capabilities() providers.Capabilities {
 	// MetadataViaInput: code-js receives run metadata structurally as
 	// input.metadata / input.payload_metadata (see buildInput), so the
 	// run-build path must not also serialize it into prompt segments.
-	return providers.Capabilities{Streaming: true, UnboundedIterations: true, MetadataViaInput: true}
+	return p.capsPatch.Apply(providers.Capabilities{Streaming: true, UnboundedIterations: true, MetadataViaInput: true})
 }
 
 // Probe always succeeds — code-js is in-process, always reachable.

--- a/internal/providers/codejs/register.go
+++ b/internal/providers/codejs/register.go
@@ -1,0 +1,42 @@
+package codejs
+
+import (
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// init registers the code-js driver with the RFC BF driver registry.
+// Registration records only the factory — it neither reads the
+// LOOMCYCLE_CODE_AGENTS_* env nor enables the provider (that stays behind the
+// resolver's LOOMCYCLE_CODE_AGENTS_ENABLED gate in cmd/loomcycle). The canonical
+// dialect is "code-js" (the synthetic goja-replay "wire").
+func init() {
+	providers.RegisterDriver("code-js", []string{"code-js"}, newFromOptions)
+}
+
+// newFromOptions builds a code-js Provider from the registry DriverOptions. P1
+// equivalent of cmd/loomcycle/main.go's hardcoded codejs.New(codejs.Config{});
+// NOT yet on the hot path (P2 wires the registry into the resolver). code-js has
+// no HTTP shape — its Config comes from the options map (code_root /
+// deterministic / run_timeout_seconds), a natural mapping for when P2 sources it
+// from a `providers:` entry rather than the env.
+func newFromOptions(o providers.DriverOptions) (providers.Provider, error) {
+	cfg := Config{Logf: o.Logf}
+	if root, ok := providers.StringOption(o.Options, "code_root"); ok {
+		cfg.CodeRoot = root
+	}
+	if det, ok := providers.BoolOption(o.Options, "deterministic"); ok {
+		cfg.Deterministic = det
+	}
+	if secs, ok := providers.IntOption(o.Options, "run_timeout_seconds"); ok {
+		cfg.RunTimeout = time.Duration(secs) * time.Second
+	}
+	p := New(cfg)
+	if o.ID != "" {
+		p.id = o.ID
+	}
+	p.capsPatch = o.Capabilities
+	providers.WarnUnknownOptions(o.Logf, "code-js", o.Options, "code_root", "deterministic", "run_timeout_seconds")
+	return p, nil
+}

--- a/internal/providers/deepseek/driver.go
+++ b/internal/providers/deepseek/driver.go
@@ -45,6 +45,12 @@ const defaultBaseURL = "https://api.deepseek.com/v1"
 // tool-call shape) comes from the embedded driver.
 type Driver struct {
 	inner *openai.Driver
+	// id is the provider identity reported by ID(). Defaults to "deepseek" in
+	// New(); the RFC BF driver registry sets it from DriverOptions.ID.
+	id string
+	// capsPatch is an optional operator override applied inside Capabilities()
+	// (RFC BF), AFTER the DeepSeek-specific patches. Nil = advertise defaults.
+	capsPatch *providers.CapabilityPatch
 }
 
 // New constructs a Driver. baseURL may be empty for the public
@@ -61,20 +67,27 @@ func New(apiKey, baseURL string, streamOpts streamhttp.Options, httpClient *http
 	// DEEPSEEK_API_KEY, not OPENAI_API_KEY — the wrapped driver would otherwise
 	// resolve the OpenAI name.
 	inner.SetKeyEnvName("DEEPSEEK_API_KEY")
-	return &Driver{inner: inner}
+	return &Driver{inner: inner, id: "deepseek"}
 }
 
-// ID returns "deepseek" so the provider resolver in cmd/loomcycle
-// dispatches per-agent `provider: deepseek` config to this driver
-// rather than the OpenAI one. Distinct from the inner driver's ID()
-// — that's what makes the wrapper worth its weight.
-func (d *Driver) ID() string { return "deepseek" }
+// ID returns "deepseek" (by default) so the provider resolver in cmd/loomcycle
+// dispatches per-agent `provider: deepseek` config to this driver rather than
+// the OpenAI one. Distinct from the inner driver's ID() — that's what makes the
+// wrapper worth its weight. The RFC BF registry may override it via the factory.
+func (d *Driver) ID() string { return d.id }
 
 // KeyEnvName reports the env-var name whose tenant/user credential can key this
 // provider (RFC AX Layer-1 routing). Delegates to the inner OpenAI driver, whose
 // SetKeyEnvName was pointed at "DEEPSEEK_API_KEY" in New — the same literal the
 // inner driver's resolveKey resolves.
 func (d *Driver) KeyEnvName() string { return d.inner.KeyEnvName() }
+
+// SetKeyEnvName overrides the env-var name whose tenant/user credential shadows
+// the host key (RFC AR), delegating to the inner OpenAI driver. New() already
+// points it at DEEPSEEK_API_KEY; the RFC BF registry factory forwards a
+// config-declared api_key_env through here (e.g. a self-hosted OpenAI-compatible
+// DeepSeek mirror naming its own key var).
+func (d *Driver) SetKeyEnvName(name string) { d.inner.SetKeyEnvName(name) }
 
 // Capabilities reports the provider's MAXIMUM surface — what at
 // least one model on DeepSeek can do — not the per-model details.
@@ -98,7 +111,9 @@ func (d *Driver) Capabilities() providers.Capabilities {
 	// loop then gates an image to DeepSeek upstream with a clear error rather
 	// than the inner OpenAI wire builder producing an image_url DeepSeek 400s on.
 	caps.SupportsVision = false
-	return caps
+	// RFC BF operator override applies last, so an operator can, e.g., re-enable
+	// vision for a self-hosted multimodal DeepSeek mirror behind base_url.
+	return d.capsPatch.Apply(caps)
 }
 
 // IsThinkingModel reports whether the named DeepSeek model is a

--- a/internal/providers/deepseek/register.go
+++ b/internal/providers/deepseek/register.go
@@ -1,0 +1,30 @@
+package deepseek
+
+import "github.com/denn-gubsky/loomcycle/internal/providers"
+
+// init registers the deepseek driver with the RFC BF driver registry.
+// Registration records only the factory. DeepSeek speaks the OpenAI Chat
+// Completions wire shape, so its canonical dialect is "openai-chat" (same
+// dialect string the openai driver registers — they are distinct DRIVER names,
+// so there is no collision).
+func init() {
+	providers.RegisterDriver("deepseek", []string{"openai-chat"}, newFromOptions)
+}
+
+// newFromOptions builds a deepseek Driver from the registry DriverOptions. P1
+// equivalent of cmd/loomcycle/main.go's hardcoded deepseek.New(...); NOT yet on
+// the hot path (P2 wires the registry into the resolver). New() already points
+// the inner key resolution at DEEPSEEK_API_KEY; a config-declared api_key_env
+// re-points it via SetKeyEnvName.
+func newFromOptions(o providers.DriverOptions) (providers.Provider, error) {
+	d := New(o.APIKey, o.BaseURL, o.StreamOpts, nil)
+	if o.ID != "" {
+		d.id = o.ID
+	}
+	if o.KeyEnvName != "" {
+		d.SetKeyEnvName(o.KeyEnvName)
+	}
+	d.capsPatch = o.Capabilities
+	providers.WarnUnknownOptions(o.Logf, "deepseek", o.Options)
+	return d, nil
+}

--- a/internal/providers/driver.go
+++ b/internal/providers/driver.go
@@ -1,0 +1,269 @@
+package providers
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
+)
+
+// CapabilityPatch is the providers-side mirror of config.CapabilityOverride
+// (RFC BF): an operator override of a driver's advertised Capabilities. Every
+// field is a pointer so "unset" (nil) is distinct from "set to false/0" — an
+// override that only flips SupportsVision must not silently zero the rest.
+//
+// The config package cannot be imported here (internal/providers is a
+// dependency of config's downstream consumers and a config→providers edge would
+// cycle), so the config.CapabilityOverride → CapabilityPatch translation lives
+// at the composition root in cmd/loomcycle (toCapabilityPatch). This type is the
+// providers-side half of that boundary.
+type CapabilityPatch struct {
+	SupportsThinking  *bool
+	SupportsVision    *bool
+	SupportsEffort    *bool
+	NativePromptCache *bool
+	ParallelToolCalls *bool
+	MaxContextTokens  *int
+}
+
+// Apply overlays the non-nil fields of p onto c and returns the result. A nil
+// receiver returns c unchanged, so a driver can call
+// `return d.capsPatch.Apply(base)` unconditionally whether or not an override
+// was configured. Mirrors how the DeepSeek driver hand-patches its inner caps —
+// the patch is a config-driven generalisation of that pattern.
+func (p *CapabilityPatch) Apply(c Capabilities) Capabilities {
+	if p == nil {
+		return c
+	}
+	if p.SupportsThinking != nil {
+		c.SupportsThinking = *p.SupportsThinking
+	}
+	if p.SupportsVision != nil {
+		c.SupportsVision = *p.SupportsVision
+	}
+	if p.SupportsEffort != nil {
+		c.SupportsEffort = *p.SupportsEffort
+	}
+	if p.NativePromptCache != nil {
+		c.NativePromptCache = *p.NativePromptCache
+	}
+	if p.ParallelToolCalls != nil {
+		c.ParallelToolCalls = *p.ParallelToolCalls
+	}
+	if p.MaxContextTokens != nil {
+		c.MaxContextTokens = *p.MaxContextTokens
+	}
+	return c
+}
+
+// DriverOptions is the construction input a DriverFactory receives (RFC BF): the
+// operator's `providers:` entry translated into the shape a driver needs to
+// build one instance. It is the LLM sibling of EmbedderOptions — everything a
+// driver's New(...) needs, sourced from config + env at the composition root.
+type DriverOptions struct {
+	// ID is the provider identity this instance reports from Provider.ID()
+	// (the key under `providers:` — e.g. "ollama-local" for the "ollama"
+	// driver). Empty defaults to the driver's canonical name in the factory.
+	ID string
+	// Dialect is the wire dialect the driver should speak; empty resolves to
+	// the driver's canonical default (see NewDriver). Validated against the
+	// driver's registered dialect set before the factory runs.
+	Dialect string
+	// BaseURL overrides the driver's default endpoint. Empty = driver default.
+	BaseURL string
+	// APIKey is the operator host key for this provider. Tenant/user overrides
+	// (RFC AR) still resolve per-call via the credential store; this is the
+	// fallback host key the driver was constructed with.
+	APIKey string
+	// KeyEnvName is the well-known env-var NAME whose tenant/user credential
+	// overrides the host key (RFC AR/AX). Empty leaves the driver's built-in
+	// default (e.g. "OPENAI_API_KEY"); the DeepSeek/OpenAI factories forward it
+	// via SetKeyEnvName so a self-hosted OpenAI-compatible mirror can name its
+	// own key var.
+	KeyEnvName string
+	// StreamOpts carries the per-stream HTTP timeouts (header + idle). Zero
+	// fields resolve to streamhttp defaults inside each driver's New(...).
+	StreamOpts streamhttp.Options
+	// Options carries driver-specific tuning from the `providers:` entry's
+	// `options:` map (e.g. ollama num_ctx/num_gpu, code-js code_root). Unknown
+	// keys are logged via Logf and ignored, never fatal (see WarnUnknownOptions).
+	Options map[string]any
+	// Capabilities is the optional operator override applied inside the driver's
+	// Capabilities(). Nil = advertise the driver's built-in defaults.
+	Capabilities *CapabilityPatch
+	// Logf is the boot-time logger for advisory warnings (unknown option keys).
+	// Nil is tolerated (warnings are dropped).
+	Logf func(string, ...any)
+}
+
+// DriverFactory builds one Provider instance from DriverOptions. Errors are
+// surfaced to the operator at boot — typical failure modes mirror the embedder
+// side ("missing API key", "bad base URL").
+type DriverFactory func(DriverOptions) (Provider, error)
+
+// driverEntry is one registered driver: the ordered set of wire dialects it can
+// speak (first = canonical default) plus its factory.
+type driverEntry struct {
+	dialects []string
+	factory  DriverFactory
+}
+
+var (
+	driverRegistryMu sync.RWMutex
+	driverRegistry   = map[string]driverEntry{}
+)
+
+// RegisterDriver records a driver name → (dialects, factory) mapping. Drivers
+// call this from their init() so the consumer side (cmd/loomcycle) never needs
+// to know which drivers are compiled in. dialects must be non-empty; the first
+// entry is the canonical default NewDriver picks when DriverOptions.Dialect is
+// blank.
+//
+// Panics on a duplicate driver name (unlike RegisterEmbedder, which allows
+// re-registration): two packages claiming the same driver name is a build-time
+// programming error, not a runtime fake-injection seam — tests exercise
+// NewDriver against the real registered factories rather than re-registering.
+func RegisterDriver(driver string, dialects []string, f DriverFactory) {
+	if len(dialects) == 0 {
+		panic(fmt.Sprintf("providers: driver %q registered with no dialects", driver))
+	}
+	driverRegistryMu.Lock()
+	defer driverRegistryMu.Unlock()
+	if _, dup := driverRegistry[driver]; dup {
+		panic(fmt.Sprintf("providers: driver %q already registered", driver))
+	}
+	// Copy so a caller mutating its slice after registration can't corrupt the
+	// registry's dialect set.
+	dcopy := append([]string(nil), dialects...)
+	driverRegistry[driver] = driverEntry{dialects: dcopy, factory: f}
+}
+
+// NewDriver looks up the registered factory for `driver` and returns a
+// configured Provider. Unknown driver → error listing RegisteredDrivers() (an
+// operator with a typo sees what's available). When o.Dialect is empty it is
+// defaulted to the driver's canonical dialect; when set, it must be one of the
+// driver's registered dialects (error otherwise).
+func NewDriver(driver string, o DriverOptions) (Provider, error) {
+	driverRegistryMu.RLock()
+	entry, ok := driverRegistry[driver]
+	driverRegistryMu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("unknown provider driver %q (known: %v)", driver, RegisteredDrivers())
+	}
+	if o.Dialect == "" {
+		o.Dialect = entry.dialects[0]
+	} else if !containsString(entry.dialects, o.Dialect) {
+		return nil, fmt.Errorf("driver %q does not support dialect %q (supported: %v)", driver, o.Dialect, entry.dialects)
+	}
+	return entry.factory(o)
+}
+
+// RegisteredDrivers returns the sorted list of registered driver names. Used in
+// error messages + operator introspection so "which drivers are wired in" is
+// answerable without grepping the binary.
+func RegisteredDrivers() []string {
+	driverRegistryMu.RLock()
+	defer driverRegistryMu.RUnlock()
+	out := make([]string, 0, len(driverRegistry))
+	for name := range driverRegistry {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// DriverDialects returns the ordered dialect set a driver supports (first =
+// canonical default), and whether the driver is registered.
+func DriverDialects(driver string) ([]string, bool) {
+	driverRegistryMu.RLock()
+	entry, ok := driverRegistry[driver]
+	driverRegistryMu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	return append([]string(nil), entry.dialects...), true
+}
+
+// DefaultDialect returns a driver's canonical dialect (the first registered),
+// and whether the driver is registered.
+func DefaultDialect(driver string) (string, bool) {
+	driverRegistryMu.RLock()
+	entry, ok := driverRegistry[driver]
+	driverRegistryMu.RUnlock()
+	if !ok || len(entry.dialects) == 0 {
+		return "", false
+	}
+	return entry.dialects[0], true
+}
+
+// WarnUnknownOptions logs (via logf, when non-nil) each key in opts that is not
+// in known. Drivers call this from their factory so an operator's typo'd
+// provider option surfaces as a boot warning instead of being silently dropped.
+// Advisory only — an unknown option never fails construction.
+func WarnUnknownOptions(logf func(string, ...any), driver string, opts map[string]any, known ...string) {
+	if logf == nil || len(opts) == 0 {
+		return
+	}
+	knownSet := make(map[string]bool, len(known))
+	for _, k := range known {
+		knownSet[k] = true
+	}
+	for k := range opts {
+		if !knownSet[k] {
+			logf("provider driver %q: ignoring unknown option %q", driver, k)
+		}
+	}
+}
+
+// IntOption reads an integer driver option, tolerating the int/int64/float64
+// shapes the YAML and JSON decoders produce for a numeric `options:` value.
+// Returns (0,false) when the key is absent or not a number.
+func IntOption(opts map[string]any, key string) (int, bool) {
+	v, ok := opts[key]
+	if !ok {
+		return 0, false
+	}
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case int64:
+		return int(n), true
+	case float64:
+		return int(n), true
+	}
+	return 0, false
+}
+
+// StringOption reads a string driver option. Returns ("",false) when absent or
+// not a string.
+func StringOption(opts map[string]any, key string) (string, bool) {
+	v, ok := opts[key]
+	if !ok {
+		return "", false
+	}
+	s, ok := v.(string)
+	return s, ok
+}
+
+// BoolOption reads a bool driver option. Returns (false,false) when absent or
+// not a bool.
+func BoolOption(opts map[string]any, key string) (bool, bool) {
+	v, ok := opts[key]
+	if !ok {
+		return false, false
+	}
+	b, ok := v.(bool)
+	return b, ok
+}
+
+// containsString reports whether s is in xs. Local helper to keep NewDriver's
+// dialect check dependency-free.
+func containsString(xs []string, s string) bool {
+	for _, x := range xs {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/providers/driver_registration_test.go
+++ b/internal/providers/driver_registration_test.go
@@ -1,0 +1,148 @@
+package providers_test
+
+import (
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+
+	// Blank imports trigger each driver package's init(), which registers it
+	// with the RFC BF driver registry. main.go imports all of these on the
+	// hardcoded resolver path too — the registration is a pure side effect, so
+	// importing them here exercises the real init()s without any wiring.
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/anthropic"
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/codejs"
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/deepseek"
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/gemini"
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/mock"
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/ollama"
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/openai"
+)
+
+// TestRegisteredDrivers_TheSeven locks that exactly the seven LLM drivers
+// self-register — anthropic-oauth-dev (residual, keeps its own path per RFC BF)
+// and mock-stable (a resolver-side wrapper, not a config-declared driver) do
+// NOT.
+func TestRegisteredDrivers_TheSeven(t *testing.T) {
+	want := []string{"anthropic", "code-js", "deepseek", "gemini", "mock", "ollama", "openai"}
+	got := providers.RegisteredDrivers()
+	set := map[string]bool{}
+	for _, d := range got {
+		set[d] = true
+	}
+	for _, w := range want {
+		if !set[w] {
+			t.Errorf("driver %q not registered (got %v)", w, got)
+		}
+	}
+	for _, absent := range []string{"anthropic-oauth-dev", "mock-stable"} {
+		if set[absent] {
+			t.Errorf("driver %q should NOT be registered (residual/wrapper), got %v", absent, got)
+		}
+	}
+}
+
+// TestNewDriver_OpenAI_IDAndCapsPatchAndInterfaces proves the seam end to end
+// for the openai driver: the factory-built instance reports the configured
+// DriverOptions.ID, reflects a capability override inside Capabilities(), and —
+// critically — still satisfies the optional KeyedProvider interface (the
+// in-driver capsPatch approach preserves it; an external wrapper would not).
+func TestNewDriver_OpenAI_IDAndCapsPatchAndInterfaces(t *testing.T) {
+	tru := true
+	p, err := providers.NewDriver("openai", providers.DriverOptions{
+		ID:           "openai-eu",
+		APIKey:       "unused-in-this-test",
+		KeyEnvName:   "OPENAI_EU_API_KEY",
+		Capabilities: &providers.CapabilityPatch{SupportsThinking: &tru},
+	})
+	if err != nil {
+		t.Fatalf("NewDriver(openai): %v", err)
+	}
+	if p.ID() != "openai-eu" {
+		t.Errorf("ID() = %q, want the configured %q", p.ID(), "openai-eu")
+	}
+	// Base openai SupportsThinking is false; the override must flip it.
+	if !p.Capabilities().SupportsThinking {
+		t.Error("capsPatch override not reflected in Capabilities().SupportsThinking")
+	}
+	kp, ok := p.(providers.KeyedProvider)
+	if !ok {
+		t.Fatal("factory-built openai driver must still satisfy providers.KeyedProvider")
+	}
+	if kp.KeyEnvName() != "OPENAI_EU_API_KEY" {
+		t.Errorf("KeyEnvName() = %q, want the forwarded %q", kp.KeyEnvName(), "OPENAI_EU_API_KEY")
+	}
+}
+
+// TestNewDriver_DeepSeek_PreservesThinkingDowngrader proves the deepseek factory
+// preserves the optional ThinkingDowngrader interface (an external wrapper type
+// would break the loop's x.(ThinkingDowngrader) assertion).
+func TestNewDriver_DeepSeek_PreservesThinkingDowngrader(t *testing.T) {
+	p, err := providers.NewDriver("deepseek", providers.DriverOptions{ID: "deepseek"})
+	if err != nil {
+		t.Fatalf("NewDriver(deepseek): %v", err)
+	}
+	td, ok := p.(providers.ThinkingDowngrader)
+	if !ok {
+		t.Fatal("factory-built deepseek driver must still satisfy providers.ThinkingDowngrader")
+	}
+	if sib, down := td.NonThinkingSibling("deepseek-reasoner"); !down || sib != "deepseek-chat" {
+		t.Errorf("NonThinkingSibling(deepseek-reasoner) = (%q,%v), want (deepseek-chat,true)", sib, down)
+	}
+	// deepseek must also stay a KeyedProvider (its key env is DEEPSEEK_API_KEY).
+	if kp, ok := p.(providers.KeyedProvider); !ok || kp.KeyEnvName() != "DEEPSEEK_API_KEY" {
+		t.Errorf("deepseek KeyedProvider = %v / %q, want true / DEEPSEEK_API_KEY", ok, keyEnv(p))
+	}
+}
+
+// TestNewDriver_Ollama_IDDrivesKeyEnv proves the ONE ollama driver serves BOTH
+// provider ids: built as "ollama-local" it is keyless (a restricted run may
+// always route to it); the canonical "ollama" registration keys off
+// OLLAMA_API_KEY.
+func TestNewDriver_Ollama_IDDrivesKeyEnv(t *testing.T) {
+	local, err := providers.NewDriver("ollama", providers.DriverOptions{ID: "ollama-local"})
+	if err != nil {
+		t.Fatalf("NewDriver(ollama, ollama-local): %v", err)
+	}
+	if local.ID() != "ollama-local" {
+		t.Errorf("ID() = %q, want ollama-local", local.ID())
+	}
+	if kp, ok := local.(providers.KeyedProvider); ok && kp.KeyEnvName() != "" {
+		t.Errorf("ollama-local KeyEnvName() = %q, want \"\" (keyless)", kp.KeyEnvName())
+	}
+
+	hosted, err := providers.NewDriver("ollama", providers.DriverOptions{ID: "ollama"})
+	if err != nil {
+		t.Fatalf("NewDriver(ollama, ollama): %v", err)
+	}
+	if kp, ok := hosted.(providers.KeyedProvider); !ok || kp.KeyEnvName() != "OLLAMA_API_KEY" {
+		t.Errorf("hosted ollama KeyEnvName mismatch: ok=%v key=%q", ok, keyEnv(hosted))
+	}
+}
+
+// TestNewDriver_Mock_IDAndCaps proves the mock factory honours DriverOptions.ID
+// and a capability override (the mock is the cheapest full driver to build).
+func TestNewDriver_Mock_IDAndCaps(t *testing.T) {
+	no := false
+	p, err := providers.NewDriver("mock", providers.DriverOptions{
+		ID:           "mock",
+		Capabilities: &providers.CapabilityPatch{SupportsVision: &no},
+	})
+	if err != nil {
+		t.Fatalf("NewDriver(mock): %v", err)
+	}
+	if p.ID() != "mock" {
+		t.Errorf("ID() = %q, want mock", p.ID())
+	}
+	// Base mock SupportsVision is true; the override must flip it to false.
+	if p.Capabilities().SupportsVision {
+		t.Error("capsPatch override not reflected: SupportsVision should be false")
+	}
+}
+
+// keyEnv is a test helper: the KeyEnvName if p is a KeyedProvider, else "".
+func keyEnv(p providers.Provider) string {
+	if kp, ok := p.(providers.KeyedProvider); ok {
+		return kp.KeyEnvName()
+	}
+	return ""
+}

--- a/internal/providers/driver_test.go
+++ b/internal/providers/driver_test.go
@@ -1,0 +1,213 @@
+package providers_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// fakeProvider is a minimal Provider so a synthetic DriverFactory can return
+// something without pulling a real driver package into this test (which would
+// couple the registry-mechanics tests to driver construction). Its ID echoes the
+// DriverOptions.ID so tests can assert the factory received the option.
+type fakeProvider struct {
+	id      string
+	dialect string
+	caps    providers.Capabilities
+}
+
+func (f *fakeProvider) ID() string                           { return f.id }
+func (f *fakeProvider) Capabilities() providers.Capabilities { return f.caps }
+func (f *fakeProvider) Call(context.Context, providers.Request) (<-chan providers.Event, error) {
+	return nil, nil
+}
+func (f *fakeProvider) Probe(context.Context) error                  { return nil }
+func (f *fakeProvider) ListModels(context.Context) ([]string, error) { return []string{}, nil }
+
+func fakeFactory(o providers.DriverOptions) (providers.Provider, error) {
+	return &fakeProvider{id: o.ID, dialect: o.Dialect}, nil
+}
+
+// TestRegisterDriver_LookupAndUnknown covers the happy path (register → NewDriver
+// returns an instance the factory built) and the unknown-driver error, which
+// must name the registered set so an operator with a typo can self-correct.
+func TestRegisterDriver_LookupAndUnknown(t *testing.T) {
+	providers.RegisterDriver("test-basic", []string{"d1", "d2"}, fakeFactory)
+
+	got, err := providers.NewDriver("test-basic", providers.DriverOptions{ID: "inst-a"})
+	if err != nil {
+		t.Fatalf("NewDriver: %v", err)
+	}
+	if got.ID() != "inst-a" {
+		t.Errorf("factory did not receive DriverOptions.ID: got %q, want %q", got.ID(), "inst-a")
+	}
+
+	_, err = providers.NewDriver("test-nope", providers.DriverOptions{})
+	if err == nil || !strings.Contains(err.Error(), "unknown provider driver") {
+		t.Errorf("unknown driver: got %v, want error naming the unknown driver", err)
+	}
+	if err != nil && !strings.Contains(err.Error(), "test-basic") {
+		t.Errorf("unknown-driver error should list registered drivers, got %v", err)
+	}
+}
+
+// TestRegisterDriver_DuplicatePanics locks the build-time invariant: two
+// packages claiming one driver name is a programming error, not a fake seam.
+func TestRegisterDriver_DuplicatePanics(t *testing.T) {
+	providers.RegisterDriver("test-dup", []string{"d1"}, fakeFactory)
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("re-registering a driver name must panic")
+		}
+		if !strings.Contains(strings.ToLower(err2str(r)), "already registered") {
+			t.Errorf("panic message = %v, want 'already registered'", r)
+		}
+	}()
+	providers.RegisterDriver("test-dup", []string{"d1"}, fakeFactory)
+}
+
+// TestRegisterDriver_NoDialectsPanics locks that a driver must declare at least
+// one dialect (the canonical default has to exist).
+func TestRegisterDriver_NoDialectsPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("registering a driver with no dialects must panic")
+		}
+	}()
+	providers.RegisterDriver("test-nodialect", nil, fakeFactory)
+}
+
+// TestNewDriver_DialectDefaultAndValidation covers dialect resolution: empty
+// defaults to the canonical (first) dialect; an explicit-but-unsupported dialect
+// errors; an explicit-and-supported dialect passes through.
+func TestNewDriver_DialectDefaultAndValidation(t *testing.T) {
+	providers.RegisterDriver("test-dialect", []string{"canon", "alt"}, fakeFactory)
+
+	// Empty dialect → canonical default reaches the factory.
+	got, err := providers.NewDriver("test-dialect", providers.DriverOptions{ID: "x"})
+	if err != nil {
+		t.Fatalf("NewDriver (default dialect): %v", err)
+	}
+	if fp := got.(*fakeProvider); fp.dialect != "canon" {
+		t.Errorf("default dialect = %q, want canonical %q", fp.dialect, "canon")
+	}
+
+	// Explicit supported dialect passes through untouched.
+	got, err = providers.NewDriver("test-dialect", providers.DriverOptions{ID: "x", Dialect: "alt"})
+	if err != nil {
+		t.Fatalf("NewDriver (explicit dialect): %v", err)
+	}
+	if fp := got.(*fakeProvider); fp.dialect != "alt" {
+		t.Errorf("explicit dialect = %q, want %q", fp.dialect, "alt")
+	}
+
+	// Unsupported dialect errors, naming the supported set.
+	_, err = providers.NewDriver("test-dialect", providers.DriverOptions{Dialect: "bogus"})
+	if err == nil || !strings.Contains(err.Error(), "does not support dialect") {
+		t.Errorf("unsupported dialect: got %v, want a 'does not support dialect' error", err)
+	}
+}
+
+// TestDriverIntrospection covers the registry read helpers.
+func TestDriverIntrospection(t *testing.T) {
+	providers.RegisterDriver("test-introspect", []string{"first", "second"}, fakeFactory)
+
+	if d, ok := providers.DefaultDialect("test-introspect"); !ok || d != "first" {
+		t.Errorf("DefaultDialect = (%q,%v), want (first,true)", d, ok)
+	}
+	if _, ok := providers.DefaultDialect("test-absent"); ok {
+		t.Error("DefaultDialect for an unregistered driver should return ok=false")
+	}
+	ds, ok := providers.DriverDialects("test-introspect")
+	if !ok || len(ds) != 2 || ds[0] != "first" || ds[1] != "second" {
+		t.Errorf("DriverDialects = (%v,%v), want ([first second],true)", ds, ok)
+	}
+	// RegisteredDrivers is sorted and includes what we registered here.
+	if !containsStr(providers.RegisteredDrivers(), "test-introspect") {
+		t.Error("RegisteredDrivers should include test-introspect")
+	}
+}
+
+// TestCapabilityPatch_Apply covers the overlay: nil receiver is a no-op; a patch
+// only touches the fields it sets (unset stays at the base value).
+func TestCapabilityPatch_Apply(t *testing.T) {
+	base := providers.Capabilities{
+		SupportsThinking: false,
+		SupportsVision:   true,
+		MaxContextTokens: 100,
+	}
+
+	// Nil patch → unchanged.
+	if got := (*providers.CapabilityPatch)(nil).Apply(base); got != base {
+		t.Errorf("nil patch changed caps: %+v", got)
+	}
+
+	// Only SupportsThinking + MaxContextTokens overridden; SupportsVision stays.
+	yes := true
+	n := 4096
+	got := (&providers.CapabilityPatch{SupportsThinking: &yes, MaxContextTokens: &n}).Apply(base)
+	if !got.SupportsThinking {
+		t.Error("SupportsThinking not overridden to true")
+	}
+	if got.MaxContextTokens != 4096 {
+		t.Errorf("MaxContextTokens = %d, want 4096", got.MaxContextTokens)
+	}
+	if !got.SupportsVision {
+		t.Error("SupportsVision should be untouched (still true)")
+	}
+}
+
+// TestOptionHelpers covers the numeric/string/bool option readers, including the
+// float64 shape a JSON decoder produces for an integer literal.
+func TestOptionHelpers(t *testing.T) {
+	opts := map[string]any{
+		"i":     42,
+		"i64":   int64(7),
+		"jsonN": float64(2048), // JSON decodes integers to float64
+		"s":     "hello",
+		"b":     true,
+	}
+	if n, ok := providers.IntOption(opts, "i"); !ok || n != 42 {
+		t.Errorf("IntOption(i) = (%d,%v)", n, ok)
+	}
+	if n, ok := providers.IntOption(opts, "i64"); !ok || n != 7 {
+		t.Errorf("IntOption(i64) = (%d,%v)", n, ok)
+	}
+	if n, ok := providers.IntOption(opts, "jsonN"); !ok || n != 2048 {
+		t.Errorf("IntOption(jsonN) = (%d,%v)", n, ok)
+	}
+	if _, ok := providers.IntOption(opts, "s"); ok {
+		t.Error("IntOption on a string should return ok=false")
+	}
+	if s, ok := providers.StringOption(opts, "s"); !ok || s != "hello" {
+		t.Errorf("StringOption(s) = (%q,%v)", s, ok)
+	}
+	if b, ok := providers.BoolOption(opts, "b"); !ok || !b {
+		t.Errorf("BoolOption(b) = (%v,%v)", b, ok)
+	}
+	if _, ok := providers.StringOption(opts, "absent"); ok {
+		t.Error("StringOption on an absent key should return ok=false")
+	}
+}
+
+func err2str(r any) string {
+	if e, ok := r.(error); ok {
+		return e.Error()
+	}
+	if s, ok := r.(string); ok {
+		return s
+	}
+	return ""
+}
+
+func containsStr(xs []string, s string) bool {
+	for _, x := range xs {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/providers/gemini/driver.go
+++ b/internal/providers/gemini/driver.go
@@ -56,6 +56,12 @@ type Driver struct {
 	baseURL     string
 	http        *http.Client
 	idleTimeout time.Duration
+	// id is the provider identity reported by ID(). Defaults to "gemini" in
+	// New(); the RFC BF driver registry sets it from DriverOptions.ID.
+	id string
+	// capsPatch is an optional operator override applied inside Capabilities()
+	// (RFC BF). Nil = advertise the driver defaults.
+	capsPatch *providers.CapabilityPatch
 }
 
 // New constructs a Driver. baseURL may be empty for the default
@@ -73,10 +79,10 @@ func New(apiKey, baseURL string, streamOpts streamhttp.Options, httpClient *http
 	if httpClient == nil {
 		httpClient = streamhttp.NewClient(streamOpts.HeaderTimeout)
 	}
-	return &Driver{apiKey: apiKey, baseURL: baseURL, http: httpClient, idleTimeout: streamOpts.IdleTimeout}
+	return &Driver{apiKey: apiKey, baseURL: baseURL, http: httpClient, idleTimeout: streamOpts.IdleTimeout, id: "gemini"}
 }
 
-func (d *Driver) ID() string { return "gemini" }
+func (d *Driver) ID() string { return d.id }
 
 // resolveKey returns the API key to authenticate an inference request AND which
 // credential scope it came from. A tenant/user credential named GEMINI_API_KEY
@@ -95,7 +101,7 @@ func (d *Driver) resolveKey(ctx context.Context) (key, source, scopeID string, e
 func (d *Driver) KeyEnvName() string { return "GEMINI_API_KEY" }
 
 func (d *Driver) Capabilities() providers.Capabilities {
-	return providers.Capabilities{
+	return d.capsPatch.Apply(providers.Capabilities{
 		// Gemini has implicit prompt caching on long contexts but no
 		// operator-controlled cache_control like Anthropic. Mark
 		// false until we add the explicit-cache surface.
@@ -117,7 +123,7 @@ func (d *Driver) Capabilities() providers.Capabilities {
 		// No per-model gate — operator-trust per RFC AT §5.3; a non-vision
 		// model surfaces via the existing provider-fallback error.
 		SupportsVision: true,
-	}
+	})
 }
 
 // Call sends the request and returns a channel of Events.

--- a/internal/providers/gemini/register.go
+++ b/internal/providers/gemini/register.go
@@ -1,0 +1,26 @@
+package gemini
+
+import "github.com/denn-gubsky/loomcycle/internal/providers"
+
+// init registers the gemini driver with the RFC BF driver registry.
+// Registration records only the factory. The single canonical dialect is
+// "gemini-v1beta" (the generateContent /v1beta wire shape); a Vertex AI gateway
+// reuses it via a base_url override.
+func init() {
+	providers.RegisterDriver("gemini", []string{"gemini-v1beta"}, newFromOptions)
+}
+
+// newFromOptions builds a gemini Driver from the registry DriverOptions. P1
+// equivalent of cmd/loomcycle/main.go's hardcoded gemini.New(...); NOT yet on
+// the hot path (P2 wires the registry into the resolver). Gemini's key env var
+// is fixed (GEMINI_API_KEY, no SetKeyEnvName) and it has no consumable driver
+// options today.
+func newFromOptions(o providers.DriverOptions) (providers.Provider, error) {
+	d := New(o.APIKey, o.BaseURL, o.StreamOpts, nil)
+	if o.ID != "" {
+		d.id = o.ID
+	}
+	d.capsPatch = o.Capabilities
+	providers.WarnUnknownOptions(o.Logf, "gemini", o.Options)
+	return d, nil
+}

--- a/internal/providers/mock/driver.go
+++ b/internal/providers/mock/driver.go
@@ -64,6 +64,14 @@ type Driver struct {
 	rate429       float64
 	rate500       float64
 
+	// id is the provider identity reported by ID(). Defaults to "mock" in New();
+	// the RFC BF driver registry sets it from DriverOptions.ID. (The mock-stable
+	// variant overrides ID() via the stableDriver wrapper, unaffected by this.)
+	id string
+	// capsPatch is an optional operator override applied inside Capabilities()
+	// (RFC BF). Nil = advertise the driver defaults.
+	capsPatch *providers.CapabilityPatch
+
 	mu  sync.Mutex
 	rng *rand.Rand
 }
@@ -82,6 +90,7 @@ func New() *Driver {
 		// produce different failure-injection patterns; tests that
 		// need determinism use the WithRNG variant below.
 		rng: rand.New(rand.NewSource(time.Now().UnixNano())),
+		id:  "mock",
 	}
 	return d
 }
@@ -126,10 +135,10 @@ func NewStableProvider() providers.Provider {
 	return &stableDriver{Driver: NewStable()}
 }
 
-func (d *Driver) ID() string { return "mock" }
+func (d *Driver) ID() string { return d.id }
 
 func (d *Driver) Capabilities() providers.Capabilities {
-	return providers.Capabilities{
+	return d.capsPatch.Apply(providers.Capabilities{
 		Streaming:         false,
 		ParallelToolCalls: false,
 		// MaxContextTokens left at 0 — the loop treats 0 as "no cap"
@@ -142,7 +151,7 @@ func (d *Driver) Capabilities() providers.Capabilities {
 		// The mock is a test double — accept image content so loop-level
 		// vision tests (RFC AT) can route an image through to a provider.
 		SupportsVision: true,
-	}
+	})
 }
 
 func (d *Driver) Probe(_ context.Context) error { return nil }

--- a/internal/providers/mock/register.go
+++ b/internal/providers/mock/register.go
@@ -1,0 +1,28 @@
+package mock
+
+import "github.com/denn-gubsky/loomcycle/internal/providers"
+
+// init registers the mock driver with the RFC BF driver registry. Registration
+// records only the factory — it neither reads the LOOMCYCLE_MOCK_* env vars nor
+// enables the provider (that stays behind the resolver's LOOMCYCLE_MOCK_ENABLED
+// gate in cmd/loomcycle). The canonical dialect is "mock" (no real wire). Only
+// the base "mock" driver is registered; the mock-stable variant remains a
+// resolver-side wrapper, not a config-declared driver.
+func init() {
+	providers.RegisterDriver("mock", []string{"mock"}, newFromOptions)
+}
+
+// newFromOptions builds a mock Driver from the registry DriverOptions. P1
+// equivalent of cmd/loomcycle/main.go's hardcoded mockprov.New(); NOT yet on
+// the hot path (P2 wires the registry into the resolver). The mock ignores
+// APIKey/BaseURL (no real HTTP); its behaviour comes from the LOOMCYCLE_MOCK_*
+// env that New() reads.
+func newFromOptions(o providers.DriverOptions) (providers.Provider, error) {
+	d := New()
+	if o.ID != "" {
+		d.id = o.ID
+	}
+	d.capsPatch = o.Capabilities
+	providers.WarnUnknownOptions(o.Logf, "mock", o.Options)
+	return d, nil
+}

--- a/internal/providers/ollama/driver.go
+++ b/internal/providers/ollama/driver.go
@@ -55,6 +55,10 @@ type Driver struct {
 	idleTimeout time.Duration
 	numCtx      int // 0 = omit (Ollama server default applies)
 	numGpu      int // 0 = omit (Ollama auto-detects GPU layers); >0 forces offload
+	// capsPatch is an optional operator override applied inside Capabilities()
+	// (RFC BF). Nil = advertise the driver defaults. ID() already comes from
+	// providerID, so no separate id field is needed here.
+	capsPatch *providers.CapabilityPatch
 	// ctxCache memoises each model's loaded context window read from
 	// /api/ps (model name → ctxCacheEntry), so the gauge lookup costs one
 	// cheap request per model, not per turn. Concurrent-safe (the Driver is
@@ -252,7 +256,7 @@ func (d *Driver) KeyEnvName() string {
 }
 
 func (d *Driver) Capabilities() providers.Capabilities {
-	return providers.Capabilities{
+	return d.capsPatch.Apply(providers.Capabilities{
 		NativePromptCache: false,
 		ParallelToolCalls: true, // model-dependent; we report the optimistic case
 		Streaming:         true,
@@ -277,7 +281,7 @@ func (d *Driver) Capabilities() providers.Capabilities {
 		// (RFC AT §5.4); a non-vision model's failure surfaces via the existing
 		// provider-fallback error rather than a silent drop.
 		SupportsVision: true,
-	}
+	})
 }
 
 // Call sends the chat request and streams Events. The goroutine that reads

--- a/internal/providers/ollama/register.go
+++ b/internal/providers/ollama/register.go
@@ -1,0 +1,34 @@
+package ollama
+
+import "github.com/denn-gubsky/loomcycle/internal/providers"
+
+// init registers the ollama driver with the RFC BF driver registry.
+// Registration records only the factory. The single canonical dialect is
+// "ollama-chat" (the /api/chat NDJSON wire shape). ONE driver serves BOTH the
+// hosted "ollama" and local-network "ollama-local" provider ids — they share
+// the wire shape and differ only by base_url + auth (derived from the id), so
+// the config declares two `providers:` entries (different ids) that both name
+// driver "ollama".
+func init() {
+	providers.RegisterDriver("ollama", []string{"ollama-chat"}, newFromOptions)
+}
+
+// newFromOptions builds an ollama Driver from the registry DriverOptions. P1
+// equivalent of cmd/loomcycle/main.go's hardcoded ollama.New(...).WithNumCtx().
+// WithNumGpu(); NOT yet on the hot path (P2 wires the registry into the
+// resolver). The provider id (DriverOptions.ID → New's providerID) also selects
+// the auth + KeyEnvName behaviour: "ollama-local" is keyless, "ollama" uses
+// OLLAMA_API_KEY. num_ctx / num_gpu come from the options map.
+func newFromOptions(o providers.DriverOptions) (providers.Provider, error) {
+	// New defaults providerID to "ollama" when o.ID == "".
+	d := New(o.ID, o.APIKey, o.BaseURL, o.StreamOpts, nil)
+	d.capsPatch = o.Capabilities
+	if n, ok := providers.IntOption(o.Options, "num_ctx"); ok {
+		d.WithNumCtx(n)
+	}
+	if n, ok := providers.IntOption(o.Options, "num_gpu"); ok {
+		d.WithNumGpu(n)
+	}
+	providers.WarnUnknownOptions(o.Logf, "ollama", o.Options, "num_ctx", "num_gpu")
+	return d, nil
+}

--- a/internal/providers/openai/driver.go
+++ b/internal/providers/openai/driver.go
@@ -40,6 +40,13 @@ type Driver struct {
 	// Defaults to "OPENAI_API_KEY"; the DeepSeek wrapper points it at
 	// "DEEPSEEK_API_KEY" via SetKeyEnvName since it reuses this driver.
 	keyEnvName string
+	// id is the provider identity reported by ID(). Defaults to "openai" in
+	// New(); the RFC BF driver registry sets it from DriverOptions.ID so one
+	// driver can serve a config-declared provider under any id.
+	id string
+	// capsPatch is an optional operator override applied inside Capabilities()
+	// (RFC BF). Nil = advertise the driver defaults.
+	capsPatch *providers.CapabilityPatch
 }
 
 // New constructs a Driver. baseURL may be empty for the default endpoint, or
@@ -56,7 +63,7 @@ func New(apiKey, baseURL string, streamOpts streamhttp.Options, httpClient *http
 	if httpClient == nil {
 		httpClient = streamhttp.NewClient(streamOpts.HeaderTimeout)
 	}
-	return &Driver{apiKey: apiKey, baseURL: baseURL, http: httpClient, idleTimeout: streamOpts.IdleTimeout, keyEnvName: "OPENAI_API_KEY"}
+	return &Driver{apiKey: apiKey, baseURL: baseURL, http: httpClient, idleTimeout: streamOpts.IdleTimeout, keyEnvName: "OPENAI_API_KEY", id: "openai"}
 }
 
 // SetKeyEnvName overrides the env-var name whose tenant/user credential shadows
@@ -82,10 +89,10 @@ func (d *Driver) resolveKey(ctx context.Context) (key, source, scopeID string, e
 // DeepSeek wrapper's SetKeyEnvName reflows this to "DEEPSEEK_API_KEY".
 func (d *Driver) KeyEnvName() string { return d.keyEnvName }
 
-func (d *Driver) ID() string { return "openai" }
+func (d *Driver) ID() string { return d.id }
 
 func (d *Driver) Capabilities() providers.Capabilities {
-	return providers.Capabilities{
+	return d.capsPatch.Apply(providers.Capabilities{
 		NativePromptCache: false, // OpenAI auto-caches; no explicit knob like Anthropic
 		ParallelToolCalls: true,
 		Streaming:         true,
@@ -99,7 +106,7 @@ func (d *Driver) Capabilities() providers.Capabilities {
 		// models will see the API's 400 surface clearly.
 		SupportsEffort: true,
 		SupportsVision: true, // per-model refined by openaiSupportsVision
-	}
+	})
 }
 
 // Call sends the request and returns a channel of Events. The goroutine that

--- a/internal/providers/openai/register.go
+++ b/internal/providers/openai/register.go
@@ -1,0 +1,31 @@
+package openai
+
+import "github.com/denn-gubsky/loomcycle/internal/providers"
+
+// init registers the openai driver with the RFC BF driver registry. Registration
+// only records the factory — it constructs nothing and enables nothing (the
+// operator's `providers:` config + resolver decide activation). The single
+// canonical dialect is "openai-chat" (Chat Completions wire shape); any
+// OpenAI-compatible endpoint reuses it via a base_url override.
+func init() {
+	providers.RegisterDriver("openai", []string{"openai-chat"}, newFromOptions)
+}
+
+// newFromOptions builds an openai Driver from the registry DriverOptions. It is
+// the P1 equivalent of cmd/loomcycle/main.go's hardcoded openai.New(...) — NOT
+// yet on the hot path (P2 wires the registry into the resolver). It exists so
+// P2 is a clean flip and the seam is testable now.
+func newFromOptions(o providers.DriverOptions) (providers.Provider, error) {
+	d := New(o.APIKey, o.BaseURL, o.StreamOpts, nil)
+	if o.ID != "" {
+		d.id = o.ID
+	}
+	if o.KeyEnvName != "" {
+		d.SetKeyEnvName(o.KeyEnvName)
+	}
+	d.capsPatch = o.Capabilities
+	// The openai driver has no driver-specific options today; surface any that
+	// were configured as an advisory warning rather than silently dropping them.
+	providers.WarnUnknownOptions(o.Logf, "openai", o.Options)
+	return d, nil
+}


### PR DESCRIPTION
## What this is

**P1 of RFC BF (Config-Driven LLM Provider Registry)** — a 3-phase migration from the hardcoded env-driven provider construction in `cmd/loomcycle` to a config-declared `providers:` registry.

**P1 is strictly additive with ZERO runtime behavior change.** The hardcoded resolver (`newProviderResolver` / `Get` / `runResolveProbeOnce`) is untouched and stays authoritative. Everything here is *present but not yet on the hot path* — P2 flips the seam.

## Why

The provider set is currently baked into `cmd/loomcycle/main.go` (one `if key != "" { pr.x = xdriver.New(...) }` per provider) and the closed `validProviderIDs` map in config. RFC BF makes providers config-declared so an operator can add/point/tune a provider (self-hosted OpenAI-compatible mirror, a second Ollama, a capability override) without a code change. P1 lays the schema + registry so P2 is a clean flip rather than a rewrite.

## What's added

**1. Config schema (`internal/config/config.go`)**
- `Providers map[string]ProviderConfig` top-level field.
- `ProviderConfig` (driver/dialect/base_url/api_key_env/max_concurrent/options/capabilities) + pointer-field `CapabilityOverride` (unset ≠ false).
- `validate()` gains a P1-light loop: WHEN the block is present, each entry needs a non-empty `driver` and `max_concurrent >= 0`. Registry-aware checks (driver ∈ registry, dialect, `models[*].provider`) are deferred to P2 so `config.go` stays free of an `internal/providers` import. **An absent block validates every existing config identically.**

**2. Driver registry (`internal/providers/driver.go`, new)**
- Mirrors the embedder registry: `RegisterDriver` / `NewDriver` / `RegisteredDrivers` + `DriverDialects` / `DefaultDialect`, `sync.RWMutex` map.
- `DriverOptions` construction input, `DriverFactory` type, and `CapabilityPatch` (providers-side mirror of `config.CapabilityOverride`) with a nil-safe `Apply` overlay.
- Registration carries a driver's dialects (first = canonical default); `NewDriver` defaults a blank dialect and rejects an unsupported one. **Duplicate driver names panic** (a build-time programming error). Plus option-reader helpers (Int/String/Bool + an unknown-key warner).

**3. Driver self-registration (per driver package)**
Each of **anthropic / openai / gemini / ollama / deepseek / mock / code-js** gains:
- an `id` field (defaulted in `New()` to today's literal → `ID()` unchanged; ollama reuses its `providerID`; deepseek gains `SetKeyEnvName` delegating to its inner driver),
- a `capsPatch` applied **inside** `Capabilities()` (an in-driver patch, NOT an external wrapper — so `x.(KeyedProvider)` / `x.(ThinkingDowngrader)` assertions survive),
- a `register.go` with `init()` → `RegisterDriver(name, dialects, factory)`; the factory builds via the existing `New(...)` and forwards id/keyEnvName/capsPatch + driver options (ollama num_ctx/num_gpu; code-js code_root/deterministic/run_timeout_seconds; unknown keys warned).

`anthropic-oauth-dev` (residual path per the RFC) and `mock-stable` (a resolver-side wrapper) are deliberately **not** registered.

**4. Boundary translation (`cmd/loomcycle/main.go`)**
- `toCapabilityPatch(*config.CapabilityOverride) *providers.CapabilityPatch` (nil→nil). Defined + tested but **not** wired into `newProviderResolver` — so P2 is a clean flip.

## Zero-behavior-change invariant — how it's verified

- `newProviderResolver` / `Get` / `runResolveProbeOnce` are untouched (see the `main.go` diff: the only change is the added `toCapabilityPatch`).
- Every existing `New(...)` signature is unchanged — the ~58 direct callers keep compiling.
- Registration is a pure side effect (records a factory; constructs + enables nothing — the `LOOMCYCLE_MOCK_ENABLED` / `LOOMCYCLE_CODE_AGENTS_ENABLED` gates stay in the resolver).
- Each `ID()` returns a field defaulted to today's literal in `New()`, so behavior is identical.
- `./bin/loomcycle validate loomcycle.example.yaml` (no `providers:` block) → `OK`, byte-identical to before.

## Tested

- `internal/providers/driver_test.go` — `TestRegisterDriver_LookupAndUnknown`, `TestRegisterDriver_DuplicatePanics`, `TestRegisterDriver_NoDialectsPanics`, `TestNewDriver_DialectDefaultAndValidation`, `TestDriverIntrospection`, `TestCapabilityPatch_Apply`, `TestOptionHelpers`.
- `internal/providers/driver_registration_test.go` — `TestRegisteredDrivers_TheSeven` (exactly the 7; excludes oauth-dev/mock-stable), `TestNewDriver_OpenAI_IDAndCapsPatchAndInterfaces` (ID + capsPatch + still a KeyedProvider), `TestNewDriver_DeepSeek_PreservesThinkingDowngrader`, `TestNewDriver_Ollama_IDDrivesKeyEnv` (one driver, two ids), `TestNewDriver_Mock_IDAndCaps`.
- `internal/config/providers_test.go` — `TestProviders_UnmarshalYAML` (full round-trip incl. explicit-false capability pointer distinct from unset), `TestValidate_Providers` (good/empty-driver/negative-cap + absent-is-a-no-op).
- `cmd/loomcycle/providers_p1_test.go` — `TestToCapabilityPatch`.
- **Full suite:** `go test -race -timeout 900s ./...` → all 83 packages `ok`, no races.
- `go build ./...`, `make build-all` (UI + Go binary), `go vet ./...`, `gofmt -l`, `go mod tidy` diff — all clean.
- **Manual:** built `./bin/loomcycle`; `validate` on the stock example (no `providers:`) → `OK`; on a config WITH a `providers:` block → `OK`; on a bad entry (empty driver) → exit 2, `config: providers.broken: driver is required`.

## Decision noted for review

`RegisterDriver` **panics** on a duplicate driver name (the RFC/task's explicit "dup-panic" requirement), which differs from `RegisterEmbedder` (later-wins). Rationale documented in-code: two packages claiming one driver name is a build-time programming error, and tests exercise `NewDriver` against the real registered factories rather than re-registering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD