### PR TITLE
feat(providers): P2a — config-driven provider resolver + embedded default layer (behavior-identical)

### DIFF
--- a/cmd/loomcycle/embedded/presets.go
+++ b/cmd/loomcycle/embedded/presets.go
@@ -33,6 +33,16 @@ var bundleFS embed.FS
 //go:embed env.insecure.example
 var envInsecureExample []byte
 
+// providers.default.yaml — RFC BF P2a. A `providers:`-ONLY config layer declaring
+// every provider the pre-P2a hardcoded resolver built. cmd/loomcycle prepends it
+// as the unconditional base of the config stack (unless LOOMCYCLE_NO_DEFAULT_PROVIDERS=1)
+// so a config with no `providers:` block resolves providers byte-identically to
+// pre-P2a. It is NOT a selectable preset/bundle (not under presets/ or bundles/)
+// — it is always the base, never chosen by name.
+//
+//go:embed providers.default.yaml
+var providersDefault []byte
+
 // Unit is one embedded, selectable config layer — a preset or a bundle.
 type Unit struct {
 	Name        string // selector name (filename without .yaml)
@@ -134,6 +144,11 @@ func ResolveUnits(names []string) ([]Unit, error) {
 // EnvTemplate returns the embedded env.insecure.example (for `loomcycle
 // env-template` and RFC AR's install dialog).
 func EnvTemplate() []byte { return envInsecureExample }
+
+// DefaultProviders returns the embedded providers.default.yaml bytes — the RFC BF
+// P2a unconditional base layer (see providersDefault). cmd/loomcycle wraps it in a
+// config.Layer and prepends it under any opt-in preset.
+func DefaultProviders() []byte { return providersDefault }
 
 func unitNames() []string {
 	out := make([]string, 0, len(units))

--- a/cmd/loomcycle/embedded/providers.default.yaml
+++ b/cmd/loomcycle/embedded/providers.default.yaml
@@ -1,0 +1,53 @@
+# providers.default.yaml — RFC BF P2a embedded default-providers layer.
+#
+# Declares EVERY provider the pre-P2a hardcoded resolver built, and NOTHING else
+# (no models/tiers/user_tiers — those would clobber an operator's config). This
+# is why it is a separate layer rather than part of base.yaml. cmd/loomcycle
+# prepends it as the UNCONDITIONAL base of the config stack (before any opt-in
+# preset), so a config with no `providers:` block resolves providers exactly as
+# it did before P2a. Operator `providers:` entries deep-merge OVER this layer
+# (last wins), and the whole layer is skipped when LOOMCYCLE_NO_DEFAULT_PROVIDERS=1.
+#
+# base_url is deliberately EMPTY for every entry: cmd/loomcycle's toDriverOptions
+# supplies the per-provider env/driver default (DEEPSEEK_BASE_URL / GEMINI_BASE_URL
+# / OLLAMA_BASE_URL / OLLAMA_CLOUD_BASE_URL — incl. the OLLAMA_BASE_URL=disabled
+# opt-out) so this file hardcodes no endpoint. api_key_env is a NAME, never a value.
+providers:
+  anthropic:
+    driver: anthropic
+    api_key_env: ANTHROPIC_API_KEY
+  openai:
+    driver: openai
+    api_key_env: OPENAI_API_KEY
+  gemini:
+    driver: gemini
+    api_key_env: GEMINI_API_KEY
+  deepseek:
+    driver: deepseek
+    api_key_env: DEEPSEEK_API_KEY
+  ollama:
+    # Hosted ollama.com — Bearer auth via OLLAMA_API_KEY; base URL from
+    # OLLAMA_CLOUD_BASE_URL (default https://ollama.com). num_ctx flows in from
+    # LOOMCYCLE_OLLAMA_NUM_CTX via toDriverOptions.
+    driver: ollama
+    api_key_env: OLLAMA_API_KEY
+    options: {}
+  ollama-local:
+    # Local-network Ollama — keyless; reachability + base URL from OLLAMA_BASE_URL
+    # (default http://localhost:11434; OLLAMA_BASE_URL=disabled opts out). num_ctx
+    # and num_gpu flow in from LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX / _NUM_GPU via
+    # toDriverOptions.
+    driver: ollama
+    options: {}
+  mock:
+    # Synthetic cost-free provider — gated on LOOMCYCLE_MOCK_ENABLED=1.
+    driver: mock
+  mock-stable:
+    # Companion mock with failure injection pinned off (fallback-recovery target).
+    driver: mock
+    options:
+      stable: true
+  code-js:
+    # Synthetic goja provider — gated on LOOMCYCLE_CODE_AGENTS_ENABLED=1;
+    # code_root/deterministic/run_timeout flow from the LOOMCYCLE_CODE_AGENTS_* env.
+    driver: code-js

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -56,14 +56,19 @@ import (
 	lcotel "github.com/denn-gubsky/loomcycle/internal/otel"
 	"github.com/denn-gubsky/loomcycle/internal/pause"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
-	"github.com/denn-gubsky/loomcycle/internal/providers/anthropic"
+	// RFC BF P2a — the resolver now builds providers via providers.NewDriver, not
+	// each driver's New(), so these driver packages are imported ONLY for their
+	// init() self-registration into the RFC BF driver registry. Blank imports keep
+	// their factories registered; codejs + anthropic_oauth_dev stay named below
+	// (still referenced directly: code-agent validation and the residual OAuth path).
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/anthropic"
 	anthropic_oauth_dev "github.com/denn-gubsky/loomcycle/internal/providers/anthropic_oauth_dev"
 	"github.com/denn-gubsky/loomcycle/internal/providers/codejs"
-	"github.com/denn-gubsky/loomcycle/internal/providers/deepseek"
-	"github.com/denn-gubsky/loomcycle/internal/providers/gemini"
-	mockprov "github.com/denn-gubsky/loomcycle/internal/providers/mock"
-	"github.com/denn-gubsky/loomcycle/internal/providers/ollama"
-	"github.com/denn-gubsky/loomcycle/internal/providers/openai"
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/deepseek"
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/gemini"
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/mock"
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/ollama"
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/openai"
 	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
 	"github.com/denn-gubsky/loomcycle/internal/search"
 	// Deterministic stub embedder for runtime tests; its init() registers the
@@ -636,8 +641,19 @@ func main() {
 			log.Printf("auth.env: loaded %d var(s) from %s (a shell export overrides them)", n, authEnvPath)
 		}
 	}
-	// Build the full ordered layer list: embedded presets (base) ++ disk files.
-	layers := make([]config.Layer, 0, len(presetLayers)+len(diskFiles))
+	// Build the full ordered layer list. RFC BF P2a: the embedded default-providers
+	// layer is the UNCONDITIONAL base (before opt-in presets) so a config with no
+	// `providers:` block resolves providers identically to pre-P2a; operator
+	// `providers:` entries deep-merge over it. LOOMCYCLE_NO_DEFAULT_PROVIDERS=1 drops
+	// it (then only explicitly-declared providers exist). It is kept OUT of
+	// presetLayers so the "no config found" error above still fires on a bare run
+	// (a lone default-providers layer is not, on its own, a usable config). Order,
+	// base→top (last wins):
+	//   providers.default → opt-in presets → CONFIG_DIR → CONFIG_FILES/--config
+	layers := make([]config.Layer, 0, 1+len(presetLayers)+len(diskFiles))
+	if os.Getenv("LOOMCYCLE_NO_DEFAULT_PROVIDERS") != "1" {
+		layers = append(layers, config.Layer{Name: "providers.default", Data: embedded.DefaultProviders()})
+	}
 	layers = append(layers, presetLayers...)
 	for _, f := range diskFiles {
 		layers = append(layers, config.Layer{Name: f})
@@ -675,7 +691,10 @@ func main() {
 		log.Printf("otel: disabled (set LOOMCYCLE_OTEL_EXPORTER_OTLP_ENDPOINT to enable)")
 	}
 
-	pr := newProviderResolver(cfg)
+	pr, err := newProviderResolver(cfg)
+	if err != nil {
+		log.Fatalf("provider resolver: %v", err)
+	}
 	validateCodeAgents(cfg, pr)
 	sem := concurrency.New(
 		cfg.Concurrency.MaxConcurrentRuns,
@@ -2916,47 +2935,24 @@ func openStore(cfg *config.Config) (store.Store, func(), error) {
 	}
 }
 
-// providerResolver constructs Provider instances at startup based on which
-// env vars are set. A provider that wasn't configured returns a clear error
-// when an agent tries to use it (rather than failing the whole startup).
+// providerResolver holds the constructed Provider instances keyed by the id
+// agents reference in `provider:` (RFC BF P2a). newProviderResolver builds byID
+// from cfg.Providers via the driver registry (providers.NewDriver) — a
+// config-driven flip of the pre-P2a hardcoded per-provider fields. It is
+// byte-identical when no operator `providers:` block is declared, because the
+// embedded default-providers layer (cmd/loomcycle/embedded/providers.default.yaml)
+// supplies the built-ins. A provider whose enabling env is absent is simply not
+// in byID; Get reproduces the pre-P2a "not configured" error for it.
 type providerResolver struct {
-	anthropic providers.Provider
-	openai    providers.Provider
-	// ollama = hosted ollama.com (Bearer auth via OLLAMA_API_KEY).
-	// ollamaLocal = local-network endpoint (no auth, default
-	// localhost:11434). Both wrap the same internal driver; only the
-	// providerID, auth header, and base URL differ. See v0.8.3 split.
-	ollama      providers.Provider
-	ollamaLocal providers.Provider
-	deepseek    providers.Provider
-	gemini      providers.Provider
-	// v0.11.9 OAuth-dev provider. Registered only when
-	// LOOMCYCLE_ANTHROPIC_OAUTH_DEV_ENABLED=1 AND a token file exists.
-	// nil otherwise — Get("anthropic-oauth-dev") returns a clear error
-	// pointing at `loomcycle anthropic login`.
-	anthropicOAuthDev       providers.Provider
+	byID map[string]providers.Provider
+	// cfg is retained so Get can tell a declared-but-disabled provider (a
+	// bespoke "not configured" error) apart from a truly unknown id.
+	cfg *config.Config
+	// anthropic-oauth-dev remains a residual hardcoded path: its Refresher
+	// lifecycle is main-owned (Start here, Stop at shutdown). The provider goes
+	// into byID like any other; this field only carries the refresher handle for
+	// teardown. See newProviderResolver.
 	anthropicOAuthRefresher *anthropic_oauth_dev.Refresher
-	// v0.12.8 — synthetic mock provider for cost-free stress testing.
-	// Registered only when LOOMCYCLE_MOCK_ENABLED=1. Drives the
-	// canonical 3-agent circuit-stress pipeline with no real-LLM
-	// cost; injection knobs (LOOMCYCLE_MOCK_429_RATE, 500_RATE,
-	// LATENCY_MS, LATENCY_JITTER_MS) exercise the resolver matrix
-	// + runtime-fallback paths under load. See
-	// internal/providers/mock/driver.go.
-	mock providers.Provider
-
-	// v0.12.9 — companion `mock-stable` provider. Same driver
-	// shape, failure rates pinned at zero regardless of env. Lets
-	// operators configure `[mock, mock-stable]` as a tier candidate
-	// list with `fallback_on_error: true`, so a 429 on the primary
-	// escalates to the stable variant under tryProviderFallback —
-	// exercising the recovery path against a known-good target.
-	mockStable providers.Provider
-
-	// RFC J — synthetic code-js provider (operator-authored JS via goja).
-	// Registered only when LOOMCYCLE_CODE_AGENTS_ENABLED=1; nil otherwise,
-	// so Get("code-js") returns a clear "code agents are disabled" error.
-	codeJS providers.Provider
 }
 
 // buildEmbedder turns cfg.Memory.Embedder into a constructed
@@ -3014,79 +3010,62 @@ func buildEmbedder(cfg *config.Config) (providers.Embedder, error) {
 	})
 }
 
-func newProviderResolver(cfg *config.Config) *providerResolver {
-	pr := &providerResolver{}
-	streamOpts := streamhttp.Options{
-		HeaderTimeout: cfg.Env.ProviderHeaderTimeout,
-		IdleTimeout:   cfg.Env.ProviderIdleTimeout,
-	}
-	if cfg.Env.AnthropicAPIKey != "" {
-		pr.anthropic = anthropic.New(cfg.Env.AnthropicAPIKey, "", streamOpts, nil)
-	}
-	if cfg.Env.OpenAIAPIKey != "" {
-		pr.openai = openai.New(cfg.Env.OpenAIAPIKey, "", streamOpts, nil)
-	}
-	// Hosted ollama.com — opts in via OLLAMA_API_KEY. Bearer-auth on the
-	// same /api/chat wire shape as local Ollama; the driver is shared,
-	// only the providerID + auth header + base URL differ.
-	// OLLAMA_CLOUD_BASE_URL overrides the public endpoint for staged
-	// rollouts or vendor mirrors.
-	if cfg.Env.OllamaAPIKey != "" {
-		pr.ollama = ollama.New("ollama", cfg.Env.OllamaAPIKey, cfg.Env.OllamaCloudBaseURL, streamOpts, nil).
-			WithNumCtx(cfg.Env.OllamaNumCtx)
-	}
-	// Local-network Ollama — no API key, local trust model. The loader
-	// defaults OLLAMA_BASE_URL to http://localhost:11434, so this is
-	// effectively always-on. Operators disable it via
-	// OLLAMA_BASE_URL=disabled (or an empty string in shell env).
-	if cfg.Env.OllamaBaseURL != "" && cfg.Env.OllamaBaseURL != "disabled" {
-		// Local Ollama is slow on first-token (cold model load + large-context
-		// eval), so it gets its own, more generous timeout pair rather than the
-		// cloud-shaped global defaults — see Env.OllamaLocalHeaderTimeout.
-		localStreamOpts := streamhttp.Options{
-			HeaderTimeout: cfg.Env.OllamaLocalHeaderTimeout,
-			IdleTimeout:   cfg.Env.OllamaLocalIdleTimeout,
+// expectedBuiltinProviderIDs is the set the embedded default-providers layer
+// declares. Used only by the boot divergence WARN (RFC BF P2a Deliverable 5) —
+// resolution itself is fully config-driven, this just catches a default-layer
+// typo or a surprise LOOMCYCLE_NO_DEFAULT_PROVIDERS run.
+var expectedBuiltinProviderIDs = []string{
+	"anthropic", "code-js", "deepseek", "gemini", "mock", "mock-stable",
+	"ollama", "ollama-local", "openai",
+}
+
+// newProviderResolver builds every enabled provider from cfg.Providers via the
+// RFC BF driver registry (config-driven flip of the pre-P2a hardcoded per-provider
+// construction). It is byte-identical when no operator `providers:` block is
+// declared, because the embedded default-providers layer supplies the built-ins
+// and toDriverOptions/providerEnabled port the exact env behaviour. An
+// unconstructable provider (bad driver/dialect/base_url) is a boot error.
+func newProviderResolver(cfg *config.Config) (*providerResolver, error) {
+	pr := &providerResolver{byID: map[string]providers.Provider{}, cfg: cfg}
+
+	for id, pc := range cfg.Providers {
+		if !providerEnabled(id, pc, cfg) {
+			continue
 		}
-		pr.ollamaLocal = ollama.New("ollama-local", "", cfg.Env.OllamaBaseURL, localStreamOpts, nil).
-			WithNumCtx(cfg.Env.OllamaLocalNumCtx).
-			WithNumGpu(cfg.Env.OllamaLocalNumGpu)
-	}
-	// DeepSeek opts in via DEEPSEEK_API_KEY. Optional DEEPSEEK_BASE_URL
-	// overrides the public endpoint for self-hosted OpenAI-compatible
-	// mirrors. Same on/off semantics as Anthropic + OpenAI.
-	if cfg.Env.DeepSeekAPIKey != "" {
-		pr.deepseek = deepseek.New(cfg.Env.DeepSeekAPIKey, cfg.Env.DeepSeekBaseURL, streamOpts, nil)
-	}
-	// Gemini opts in via GEMINI_API_KEY. Optional GEMINI_BASE_URL
-	// points at a Vertex AI Gemini endpoint instead of the public
-	// generativelanguage.googleapis.com surface.
-	if cfg.Env.GeminiAPIKey != "" {
-		pr.gemini = gemini.New(cfg.Env.GeminiAPIKey, cfg.Env.GeminiBaseURL, streamOpts, nil)
+		p, err := providers.NewDriver(pc.Driver, toDriverOptions(id, pc, cfg))
+		if err != nil {
+			return nil, fmt.Errorf("provider %q: %w", id, err)
+		}
+		pr.byID[id] = p
 	}
 
-	// v0.12.8 — synthetic mock provider. Single gate: LOOMCYCLE_MOCK_ENABLED=1.
-	// Registers as provider id "mock" with four model variants
-	// (mock-researcher / mock-editor / mock-evaluator / mock-generic)
-	// for the canonical circuit-stress 3-agent pipeline. Failure
-	// injection knobs (LOOMCYCLE_MOCK_429_RATE etc.) are read by the
-	// driver itself; logged here so the boot output makes the active
-	// scenario obvious.
-	if os.Getenv("LOOMCYCLE_MOCK_ENABLED") == "1" {
-		pr.mock = mockprov.New()
-		pr.mockStable = mockprov.NewStableProvider()
+	// Residual per-provider boot diagnostics (operator-facing knob echoes, NOT
+	// resolution logic) — kept id-keyed so the boot log is unchanged from pre-P2a
+	// for the mock/code-js paths. anthropic-oauth-dev logs its own below.
+	if _, ok := pr.byID["mock"]; ok {
 		log.Printf("mock provider: enabled (LATENCY_MS=%q LATENCY_JITTER_MS=%q 429_RATE=%q 500_RATE=%q)",
 			os.Getenv("LOOMCYCLE_MOCK_LATENCY_MS"),
 			os.Getenv("LOOMCYCLE_MOCK_LATENCY_JITTER_MS"),
 			os.Getenv("LOOMCYCLE_MOCK_429_RATE"),
 			os.Getenv("LOOMCYCLE_MOCK_500_RATE"))
+	}
+	if _, ok := pr.byID["mock-stable"]; ok {
 		log.Printf("mock-stable provider: enabled (failure injection always off; fallback target for [mock, mock-stable] tier policies)")
 	}
+	if _, ok := pr.byID["code-js"]; ok {
+		log.Printf("code-js provider: enabled (root=%q deterministic=%v run_timeout=%s abi=%s)",
+			cfg.Env.CodeAgentsRoot, cfg.Env.CodeAgentsDeterministic, cfg.Env.CodeAgentsRunTimeout, codejs.ABIVersion)
+	}
 
-	// v0.11.9 — anthropic-oauth-dev. Two gates: env var + tokens on
-	// disk. Without either, the provider is absent from the resolver
-	// matrix and any agent yaml that pins `provider: anthropic-oauth-dev`
-	// fails resolution at request time with a clear error.
+	// v0.11.9 — anthropic-oauth-dev stays a residual hardcoded path (main-owned
+	// Refresher lifecycle; not a registry driver). Two gates: env var + tokens on
+	// disk. The provider (when live) joins byID like any other; the refresher
+	// handle is kept for shutdown teardown.
 	if os.Getenv(anthropic_oauth_dev.EnvEnabled) == "1" {
+		streamOpts := streamhttp.Options{
+			HeaderTimeout: cfg.Env.ProviderHeaderTimeout,
+			IdleTimeout:   cfg.Env.ProviderIdleTimeout,
+		}
 		storePath, pathErr := anthropic_oauth_dev.DefaultTokenStorePath()
 		switch {
 		case pathErr != nil:
@@ -3099,7 +3078,7 @@ func newProviderResolver(cfg *config.Config) *providerResolver {
 				refresher := anthropic_oauth_dev.NewRefresher(store, anthropic_oauth_dev.ExchangeOptions{}, log.Printf)
 				refresher.Start(context.Background())
 				pr.anthropicOAuthRefresher = refresher
-				pr.anthropicOAuthDev = anthropic_oauth_dev.New(
+				pr.byID["anthropic-oauth-dev"] = anthropic_oauth_dev.New(
 					refresher, streamOpts, anthropic_oauth_dev.ResolveClaudeCodeVersion(), nil,
 				)
 				log.Printf("anthropic-oauth-dev: registered (token expires %s; user-agent=claude-cli/%s)",
@@ -3110,22 +3089,156 @@ func newProviderResolver(cfg *config.Config) *providerResolver {
 		}
 	}
 
-	// RFC J — synthetic code-js provider. Single gate:
-	// LOOMCYCLE_CODE_AGENTS_ENABLED=1. Runs operator-authored JS via goja
-	// instead of an LLM. Registered as provider id "code-js"; resolves each
-	// agent's code from agent_code/<name>/index.js under the configured root.
-	if cfg.Env.CodeAgentsEnabled {
-		pr.codeJS = codejs.New(codejs.Config{
-			CodeRoot:      cfg.Env.CodeAgentsRoot,
-			Deterministic: cfg.Env.CodeAgentsDeterministic,
-			RunTimeout:    cfg.Env.CodeAgentsRunTimeout,
-			Logf:          log.Printf,
-		})
-		log.Printf("code-js provider: enabled (root=%q deterministic=%v run_timeout=%s abi=%s)",
-			cfg.Env.CodeAgentsRoot, cfg.Env.CodeAgentsDeterministic, cfg.Env.CodeAgentsRunTimeout, codejs.ABIVersion)
-	}
+	logProviderSummary(pr, cfg)
+	return pr, nil
+}
 
-	return pr
+// providerEnabled reproduces the exact pre-P2a env gates: a keyed provider needs
+// its api_key_env set; ollama-local needs a base URL that isn't the "disabled"
+// opt-out; mock/mock-stable need LOOMCYCLE_MOCK_ENABLED=1; code-js needs
+// CodeAgentsEnabled. anthropic-oauth-dev is intentionally NOT handled here — it is
+// the residual hardcoded path in newProviderResolver.
+func providerEnabled(id string, pc config.ProviderConfig, cfg *config.Config) bool {
+	switch id {
+	case "ollama-local":
+		// The loader defaults OLLAMA_BASE_URL to http://localhost:11434; the opt-out
+		// is the "disabled" sentinel. Read the RESOLVED value (cfg.Env), not
+		// os.Getenv, so the getenvDefault behaviour is preserved exactly.
+		return cfg.Env.OllamaBaseURL != "" && cfg.Env.OllamaBaseURL != "disabled"
+	case "mock", "mock-stable":
+		return os.Getenv("LOOMCYCLE_MOCK_ENABLED") == "1"
+	case "code-js":
+		return cfg.Env.CodeAgentsEnabled
+	default:
+		// Keyed providers (anthropic/openai/deepseek/gemini/ollama + any declared
+		// 3rd-party): enabled iff their api_key_env names a set variable.
+		return pc.APIKeyEnv != "" && os.Getenv(pc.APIKeyEnv) != ""
+	}
+}
+
+// toDriverOptions ports the pre-P2a per-provider construction 1:1 into the driver
+// factory input so an absent `providers:` block is byte-identical. BaseURL:
+// explicit config wins, else the per-id env/driver default (incl. the
+// OLLAMA_*_BASE_URL / DEEPSEEK_BASE_URL / GEMINI_BASE_URL defaults). APIKey +
+// KeyEnvName come from api_key_env (RFC AR per-tenant override). StreamOpts +
+// Options carry the per-provider timeouts and ollama num_ctx/num_gpu.
+func toDriverOptions(id string, pc config.ProviderConfig, cfg *config.Config) providers.DriverOptions {
+	baseURL := pc.BaseURL
+	stream := streamhttp.Options{
+		HeaderTimeout: cfg.Env.ProviderHeaderTimeout,
+		IdleTimeout:   cfg.Env.ProviderIdleTimeout,
+	}
+	opts := map[string]any{}
+	switch id {
+	case "ollama": // hosted ollama.com
+		if baseURL == "" {
+			baseURL = cfg.Env.OllamaCloudBaseURL
+		}
+		if cfg.Env.OllamaNumCtx > 0 {
+			opts["num_ctx"] = cfg.Env.OllamaNumCtx
+		}
+	case "ollama-local":
+		if baseURL == "" {
+			baseURL = cfg.Env.OllamaBaseURL
+		}
+		// Local Ollama is slow on first-token (cold model load + large-context
+		// eval), so it gets its own, more generous timeout pair.
+		stream = streamhttp.Options{
+			HeaderTimeout: cfg.Env.OllamaLocalHeaderTimeout,
+			IdleTimeout:   cfg.Env.OllamaLocalIdleTimeout,
+		}
+		if cfg.Env.OllamaLocalNumCtx > 0 {
+			opts["num_ctx"] = cfg.Env.OllamaLocalNumCtx
+		}
+		if cfg.Env.OllamaLocalNumGpu > 0 {
+			opts["num_gpu"] = cfg.Env.OllamaLocalNumGpu
+		}
+	case "deepseek":
+		if baseURL == "" {
+			baseURL = cfg.Env.DeepSeekBaseURL
+		}
+	case "gemini":
+		if baseURL == "" {
+			baseURL = cfg.Env.GeminiBaseURL
+		}
+	}
+	// Operator-declared options override the env-derived defaults (e.g. mock-stable's
+	// `stable: true`, or a per-provider num_ctx).
+	for k, v := range pc.Options {
+		opts[k] = v
+	}
+	return providers.DriverOptions{
+		ID:           id,
+		Dialect:      pc.Dialect,
+		BaseURL:      baseURL,
+		APIKey:       os.Getenv(pc.APIKeyEnv),
+		KeyEnvName:   pc.APIKeyEnv,
+		StreamOpts:   stream,
+		Options:      opts,
+		Capabilities: toCapabilityPatch(pc.Capabilities),
+		Logf:         log.Printf,
+	}
+}
+
+// notConfiguredError reproduces the pre-P2a "not configured" error for a
+// declared-but-disabled provider so callers (and the probe) see the exact same
+// message they did before the flip. Built-in ids keep their bespoke text; a
+// declared 3rd-party id gets the generic "(set <api_key_env>)" form.
+func notConfiguredError(id string, cfg *config.Config) error {
+	switch id {
+	case "ollama":
+		return fmt.Errorf("ollama provider not configured (set OLLAMA_API_KEY for hosted ollama.com; use provider id \"ollama-local\" for a local-network Ollama)")
+	case "ollama-local":
+		return fmt.Errorf("ollama-local provider not configured (set OLLAMA_BASE_URL, or it's been opted out via OLLAMA_BASE_URL=disabled)")
+	case "mock":
+		return fmt.Errorf("mock provider not configured (set LOOMCYCLE_MOCK_ENABLED=1)")
+	case "mock-stable":
+		return fmt.Errorf("mock-stable provider not configured (set LOOMCYCLE_MOCK_ENABLED=1)")
+	case "code-js":
+		return fmt.Errorf("code-js provider not configured: code agents are disabled (set LOOMCYCLE_CODE_AGENTS_ENABLED=1)")
+	case "anthropic-oauth-dev":
+		return fmt.Errorf("anthropic-oauth-dev not registered (set LOOMCYCLE_ANTHROPIC_OAUTH_DEV_ENABLED=1 + run `loomcycle anthropic login`)")
+	default:
+		env := cfg.Providers[id].APIKeyEnv
+		if env == "" {
+			return fmt.Errorf("%s provider not configured", id)
+		}
+		return fmt.Errorf("%s provider not configured (set %s)", id, env)
+	}
+}
+
+// providerDisabledReason is the probe's short exclusion reason for a
+// declared-but-disabled provider, byte-identical to the pre-P2a jobs slice.
+func providerDisabledReason(id string, pc config.ProviderConfig) string {
+	switch id {
+	case "ollama-local":
+		return "OLLAMA_BASE_URL not configured"
+	case "mock", "mock-stable":
+		return "LOOMCYCLE_MOCK_ENABLED not set"
+	default:
+		return fmt.Sprintf("%s not set", pc.APIKeyEnv)
+	}
+}
+
+// logProviderSummary logs the config-sourced provider inventory (RFC BF P2a
+// Deliverable 5) + a WARN if the merged config is missing a built-in the
+// default-providers layer should have supplied (catches a default-layer typo).
+func logProviderSummary(pr *providerResolver, cfg *config.Config) {
+	enabled := make([]string, 0, len(pr.byID))
+	for id := range pr.byID {
+		enabled = append(enabled, id)
+	}
+	sort.Strings(enabled)
+	log.Printf("providers: %d configured, %d enabled (%s)", len(cfg.Providers), len(pr.byID), strings.Join(enabled, ", "))
+	// Skip the divergence check when the operator deliberately dropped the layer.
+	if os.Getenv("LOOMCYCLE_NO_DEFAULT_PROVIDERS") == "1" {
+		return
+	}
+	for _, id := range expectedBuiltinProviderIDs {
+		if _, ok := cfg.Providers[id]; !ok {
+			log.Printf("providers: WARNING — built-in %q missing from the merged config (default-providers layer dropped or overridden)", id)
+		}
+	}
 }
 
 // toCapabilityPatch translates a config.CapabilityOverride (the `capabilities:`
@@ -3161,7 +3274,9 @@ func toCapabilityPatch(o *config.CapabilityOverride) *providers.CapabilityPatch 
 // Dynamic AgentDefs (created at runtime via the AgentDef tool) are not seen
 // here; their JS validates on first Call and surfaces as an EventError.
 func validateCodeAgents(cfg *config.Config, pr *providerResolver) {
-	cp, _ := pr.codeJS.(*codejs.Provider)
+	// nil interface → (nil,false): cp stays nil when code-js is disabled, matching
+	// the pre-P2a pr.codeJS==nil path.
+	cp, _ := pr.byID["code-js"].(*codejs.Provider)
 	var broken []string
 	for name, def := range cfg.Agents {
 		if def.Provider != "code-js" {
@@ -3206,61 +3321,22 @@ func countCodeAgents(cfg *config.Config) int {
 	return n
 }
 
+// Get returns the constructed provider for id, or the pre-P2a-identical error.
+// A hit is a map lookup. On a miss: a declared-but-disabled provider (present in
+// cfg.Providers, skipped by providerEnabled) — or the residual anthropic-oauth-dev
+// — gets its bespoke "not configured" message; a truly unknown id gets the
+// "unknown provider" error.
 func (p *providerResolver) Get(id string) (providers.Provider, error) {
-	switch id {
-	case "anthropic":
-		if p.anthropic == nil {
-			return nil, fmt.Errorf("anthropic provider not configured (set ANTHROPIC_API_KEY)")
-		}
-		return p.anthropic, nil
-	case "openai":
-		if p.openai == nil {
-			return nil, fmt.Errorf("openai provider not configured (set OPENAI_API_KEY)")
-		}
-		return p.openai, nil
-	case "ollama":
-		if p.ollama == nil {
-			return nil, fmt.Errorf("ollama provider not configured (set OLLAMA_API_KEY for hosted ollama.com; use provider id \"ollama-local\" for a local-network Ollama)")
-		}
-		return p.ollama, nil
-	case "ollama-local":
-		if p.ollamaLocal == nil {
-			return nil, fmt.Errorf("ollama-local provider not configured (set OLLAMA_BASE_URL, or it's been opted out via OLLAMA_BASE_URL=disabled)")
-		}
-		return p.ollamaLocal, nil
-	case "deepseek":
-		if p.deepseek == nil {
-			return nil, fmt.Errorf("deepseek provider not configured (set DEEPSEEK_API_KEY)")
-		}
-		return p.deepseek, nil
-	case "gemini":
-		if p.gemini == nil {
-			return nil, fmt.Errorf("gemini provider not configured (set GEMINI_API_KEY)")
-		}
-		return p.gemini, nil
-	case "anthropic-oauth-dev":
-		if p.anthropicOAuthDev == nil {
-			return nil, fmt.Errorf("anthropic-oauth-dev not registered (set LOOMCYCLE_ANTHROPIC_OAUTH_DEV_ENABLED=1 + run `loomcycle anthropic login`)")
-		}
-		return p.anthropicOAuthDev, nil
-	case "mock":
-		if p.mock == nil {
-			return nil, fmt.Errorf("mock provider not configured (set LOOMCYCLE_MOCK_ENABLED=1)")
-		}
-		return p.mock, nil
-	case "mock-stable":
-		if p.mockStable == nil {
-			return nil, fmt.Errorf("mock-stable provider not configured (set LOOMCYCLE_MOCK_ENABLED=1)")
-		}
-		return p.mockStable, nil
-	case "code-js":
-		if p.codeJS == nil {
-			return nil, fmt.Errorf("code-js provider not configured: code agents are disabled (set LOOMCYCLE_CODE_AGENTS_ENABLED=1)")
-		}
-		return p.codeJS, nil
-	default:
-		return nil, fmt.Errorf("unknown provider %q", id)
+	if prov, ok := p.byID[id]; ok {
+		return prov, nil
 	}
+	if id == "anthropic-oauth-dev" {
+		return nil, notConfiguredError(id, p.cfg)
+	}
+	if _, declared := p.cfg.Providers[id]; declared {
+		return nil, notConfiguredError(id, p.cfg)
+	}
+	return nil, fmt.Errorf("unknown provider %q", id)
 }
 
 // buildResolver constructs the model-resolution matrix
@@ -3303,38 +3379,32 @@ func runResolveProbeOnce(ctx context.Context, r *resolve.Resolver, pr *providerR
 		provider   providers.Provider // nil when excluded
 	}
 
-	jobs := []probeJob{
-		{id: "anthropic", excluded: cfg.Env.AnthropicAPIKey == "",
-			exclReason: "ANTHROPIC_API_KEY not set"},
-		{id: "openai", excluded: cfg.Env.OpenAIAPIKey == "",
-			exclReason: "OPENAI_API_KEY not set"},
-		{id: "deepseek", excluded: cfg.Env.DeepSeekAPIKey == "",
-			exclReason: "DEEPSEEK_API_KEY not set"},
-		{id: "gemini", excluded: cfg.Env.GeminiAPIKey == "",
-			exclReason: "GEMINI_API_KEY not set"},
-		{id: "ollama", excluded: cfg.Env.OllamaAPIKey == "",
-			exclReason: "OLLAMA_API_KEY not set"},
-		{id: "ollama-local", excluded: cfg.Env.OllamaBaseURL == "" || cfg.Env.OllamaBaseURL == "disabled",
-			exclReason: "OLLAMA_BASE_URL not configured"},
-		// v0.11.10 anthropic-oauth-dev. The provider self-registers
-		// only when LOOMCYCLE_ANTHROPIC_OAUTH_DEV_ENABLED=1 AND a
-		// token file is present (cf. lines ~1775-1810). Gate the
-		// probe on the resolver actually having the provider —
-		// pr.Get below catches both the env-var-off case (returns
-		// the canonical "not registered" error) and the
-		// resolver-misconfigured case.
-		{id: "anthropic-oauth-dev"},
-		// v0.12.8 — synthetic mock provider. Excluded unless the
-		// operator opted in via LOOMCYCLE_MOCK_ENABLED=1. The probe
-		// itself is trivial (ListModels returns a fixed slice) so
-		// the matrix populates instantly when enabled.
-		{id: "mock", excluded: os.Getenv("LOOMCYCLE_MOCK_ENABLED") != "1",
-			exclReason: "LOOMCYCLE_MOCK_ENABLED not set"},
-		// v0.12.9 — companion stable variant for fallback testing.
-		// Same gate as `mock` — when one is enabled, both are.
-		{id: "mock-stable", excluded: os.Getenv("LOOMCYCLE_MOCK_ENABLED") != "1",
-			exclReason: "LOOMCYCLE_MOCK_ENABLED not set"},
+	// RFC BF P2a — build the probe set from cfg.Providers (config-driven), deriving
+	// excluded/reason from providerEnabled + providerDisabledReason (byte-identical
+	// to the pre-P2a jobs slice). code-js is skipped: pre-P2a never probed it, so
+	// its resolver-matrix presence is unchanged. Sorted for deterministic log order
+	// (the reachable probes below run concurrently, so line order was never stable).
+	// The residual anthropic-oauth-dev job (not in cfg.Providers) is appended — its
+	// env/token gates are caught by pr.Get in the loop below.
+	ids := make([]string, 0, len(cfg.Providers))
+	for id := range cfg.Providers {
+		if id == "code-js" {
+			continue
+		}
+		ids = append(ids, id)
 	}
+	sort.Strings(ids)
+	jobs := make([]probeJob, 0, len(ids)+1)
+	for _, id := range ids {
+		pc := cfg.Providers[id]
+		excluded := !providerEnabled(id, pc, cfg)
+		reason := ""
+		if excluded {
+			reason = providerDisabledReason(id, pc)
+		}
+		jobs = append(jobs, probeJob{id: id, excluded: excluded, exclReason: reason})
+	}
+	jobs = append(jobs, probeJob{id: "anthropic-oauth-dev"})
 	for i := range jobs {
 		if jobs[i].excluded {
 			continue

--- a/cmd/loomcycle/providers_p2a_test.go
+++ b/cmd/loomcycle/providers_p2a_test.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/cmd/loomcycle/embedded"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// loadDefaultProvidersOnly loads the embedded default-providers layer as the ONLY
+// config layer — i.e. an operator config with NO `providers:` block, which is
+// exactly what main() assembles (the layer is prepended unconditionally). This is
+// the RFC BF P2a behavior-identity substrate: the built-ins come only from the
+// embedded layer, so what newProviderResolver builds here must equal what the
+// pre-P2a hardcoded resolver built.
+func loadDefaultProvidersOnly(t *testing.T) *config.Config {
+	t.Helper()
+	cfg, err := config.LoadLayers(config.Layer{Name: "providers.default", Data: embedded.DefaultProviders()})
+	if err != nil {
+		t.Fatalf("LoadLayers(providers.default): %v", err)
+	}
+	return cfg
+}
+
+// TestNewProviderResolver_NoProvidersBlock_BackCompat is the RFC BF P2a
+// behaviour-identity guarantee: with NO `providers:` block and only
+// ANTHROPIC_API_KEY set, the config-driven resolver builds the anthropic provider
+// (ID()=="anthropic") and returns the SAME "not configured" errors for the
+// unkeyed built-ins that the pre-P2a hardcoded resolver did. The expected error
+// strings are the pre-P2a literals (captured from the old Get() switch), so this
+// asserts against the pre-flip behaviour, not just self-consistency.
+func TestNewProviderResolver_NoProvidersBlock_BackCompat(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test-not-a-real-key")
+	for _, k := range []string{"OPENAI_API_KEY", "DEEPSEEK_API_KEY", "GEMINI_API_KEY", "OLLAMA_API_KEY"} {
+		t.Setenv(k, "")
+	}
+	// Turn off the non-keyed built-ins so only anthropic is enabled — the exact
+	// pre-P2a "only ANTHROPIC_API_KEY set" resolver shape.
+	t.Setenv("OLLAMA_BASE_URL", "disabled")
+	t.Setenv("LOOMCYCLE_MOCK_ENABLED", "")
+	t.Setenv("LOOMCYCLE_CODE_AGENTS_ENABLED", "")
+
+	cfg := loadDefaultProvidersOnly(t)
+	pr, err := newProviderResolver(cfg)
+	if err != nil {
+		t.Fatalf("newProviderResolver: %v", err)
+	}
+
+	ap, err := pr.Get("anthropic")
+	if err != nil {
+		t.Fatalf("Get(anthropic): %v", err)
+	}
+	if ap.ID() != "anthropic" {
+		t.Errorf("anthropic ID() = %q, want %q", ap.ID(), "anthropic")
+	}
+
+	// Byte-identical pre-P2a "not configured" errors for the unkeyed built-ins.
+	wantErr := map[string]string{
+		"openai":   "openai provider not configured (set OPENAI_API_KEY)",
+		"deepseek": "deepseek provider not configured (set DEEPSEEK_API_KEY)",
+		"gemini":   "gemini provider not configured (set GEMINI_API_KEY)",
+		"ollama":   "ollama provider not configured (set OLLAMA_API_KEY for hosted ollama.com; use provider id \"ollama-local\" for a local-network Ollama)",
+	}
+	for id, want := range wantErr {
+		_, err := pr.Get(id)
+		if err == nil || err.Error() != want {
+			t.Errorf("Get(%s) error = %v, want %q", id, err, want)
+		}
+	}
+
+	// An id the config never declares is "unknown provider", not "not configured".
+	if _, err := pr.Get("does-not-exist"); err == nil || err.Error() != `unknown provider "does-not-exist"` {
+		t.Errorf("Get(unknown) error = %v, want unknown-provider", err)
+	}
+}
+
+// TestResolveProbe_NoProvidersBlock_ExclusionReasons locks the probe's exclusion
+// reasons byte-for-byte against the pre-P2a jobs slice, and proves code-js is
+// still NOT probed (it never was pre-P2a). Fully hermetic: every provider is
+// excluded (no keys, ollama-local disabled, mock off), so no ListModels network
+// call runs.
+func TestResolveProbe_NoProvidersBlock_ExclusionReasons(t *testing.T) {
+	for _, k := range []string{"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "DEEPSEEK_API_KEY", "GEMINI_API_KEY", "OLLAMA_API_KEY"} {
+		t.Setenv(k, "")
+	}
+	t.Setenv("OLLAMA_BASE_URL", "disabled")
+	t.Setenv("LOOMCYCLE_MOCK_ENABLED", "")
+	t.Setenv("LOOMCYCLE_CODE_AGENTS_ENABLED", "")
+
+	cfg := loadDefaultProvidersOnly(t)
+	pr, err := newProviderResolver(cfg)
+	if err != nil {
+		t.Fatalf("newProviderResolver: %v", err)
+	}
+	r := buildResolver(cfg, pr) // synchronous probe; all excluded → no network
+	snap := r.Snapshot()
+
+	wantReason := map[string]string{
+		"anthropic":    "ANTHROPIC_API_KEY not set",
+		"openai":       "OPENAI_API_KEY not set",
+		"deepseek":     "DEEPSEEK_API_KEY not set",
+		"gemini":       "GEMINI_API_KEY not set",
+		"ollama":       "OLLAMA_API_KEY not set",
+		"ollama-local": "OLLAMA_BASE_URL not configured",
+		"mock":         "LOOMCYCLE_MOCK_ENABLED not set",
+		"mock-stable":  "LOOMCYCLE_MOCK_ENABLED not set",
+	}
+	for id, want := range wantReason {
+		av, ok := snap[id]
+		if !ok {
+			t.Errorf("probe: no snapshot entry for %q", id)
+			continue
+		}
+		if !av.Excluded || av.LastError != want {
+			t.Errorf("probe %q: excluded=%v reason=%q, want excluded=true reason=%q", id, av.Excluded, av.LastError, want)
+		}
+	}
+	// code-js is never probed (pre-P2a parity): it must not appear in the matrix.
+	if _, ok := snap["code-js"]; ok {
+		t.Error("probe: code-js should not be in the resolver matrix (pre-P2a never probed it)")
+	}
+}
+
+// TestRegisteredDrivers_SevenCompiledIn proves the RFC BF P2a blank imports work:
+// every driver's init() ran, so the registry holds exactly the 7 driver names the
+// resolver depends on. A missing name means a dropped blank import → NewDriver
+// would fail at boot for that provider.
+func TestRegisteredDrivers_SevenCompiledIn(t *testing.T) {
+	got := map[string]bool{}
+	for _, d := range providers.RegisteredDrivers() {
+		got[d] = true
+	}
+	for _, want := range []string{"anthropic", "openai", "gemini", "ollama", "deepseek", "mock", "code-js"} {
+		if !got[want] {
+			t.Errorf("driver %q not registered (blank import missing?); registered=%v", want, providers.RegisteredDrivers())
+		}
+	}
+	// anthropic-oauth-dev is a residual hardcoded path, NOT a registry driver.
+	if got["anthropic-oauth-dev"] {
+		t.Error("anthropic-oauth-dev must not be a registered driver (it is the residual path)")
+	}
+}
+
+// TestToDriverOptions_PortsEnvBaseURLsAndTimeouts locks the behaviour-identity
+// bridge: with no `base_url` in the config (the default-providers layer sets
+// none), toDriverOptions must supply the exact per-id env/driver defaults and
+// per-provider timeouts the pre-P2a resolver used.
+func TestToDriverOptions_PortsEnvBaseURLsAndTimeouts(t *testing.T) {
+	t.Setenv("OLLAMA_BASE_URL", "http://gpu.local:11434")
+	t.Setenv("OLLAMA_CLOUD_BASE_URL", "https://cloud.example")
+	t.Setenv("DEEPSEEK_BASE_URL", "https://ds.mirror")
+	t.Setenv("GEMINI_BASE_URL", "https://vertex.example")
+	t.Setenv("LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX", "131072")
+	t.Setenv("LOOMCYCLE_OLLAMA_LOCAL_NUM_GPU", "99")
+	t.Setenv("LOOMCYCLE_OLLAMA_NUM_CTX", "8192")
+
+	cfg := loadDefaultProvidersOnly(t)
+
+	local := toDriverOptions("ollama-local", cfg.Providers["ollama-local"], cfg)
+	if local.BaseURL != "http://gpu.local:11434" {
+		t.Errorf("ollama-local BaseURL = %q, want the OLLAMA_BASE_URL value", local.BaseURL)
+	}
+	if local.KeyEnvName != "" {
+		t.Errorf("ollama-local KeyEnvName = %q, want empty (keyless)", local.KeyEnvName)
+	}
+	if local.StreamOpts.HeaderTimeout != cfg.Env.OllamaLocalHeaderTimeout {
+		t.Errorf("ollama-local HeaderTimeout = %v, want the local (600s) timeout %v", local.StreamOpts.HeaderTimeout, cfg.Env.OllamaLocalHeaderTimeout)
+	}
+	if n, _ := providers.IntOption(local.Options, "num_ctx"); n != 131072 {
+		t.Errorf("ollama-local num_ctx = %d, want 131072", n)
+	}
+	if n, _ := providers.IntOption(local.Options, "num_gpu"); n != 99 {
+		t.Errorf("ollama-local num_gpu = %d, want 99", n)
+	}
+
+	hosted := toDriverOptions("ollama", cfg.Providers["ollama"], cfg)
+	if hosted.BaseURL != "https://cloud.example" {
+		t.Errorf("ollama BaseURL = %q, want the OLLAMA_CLOUD_BASE_URL value", hosted.BaseURL)
+	}
+	if hosted.KeyEnvName != "OLLAMA_API_KEY" {
+		t.Errorf("ollama KeyEnvName = %q, want OLLAMA_API_KEY", hosted.KeyEnvName)
+	}
+	if n, _ := providers.IntOption(hosted.Options, "num_ctx"); n != 8192 {
+		t.Errorf("ollama num_ctx = %d, want 8192 (LOOMCYCLE_OLLAMA_NUM_CTX)", n)
+	}
+	if _, ok := providers.IntOption(hosted.Options, "num_gpu"); ok {
+		t.Error("hosted ollama must not carry num_gpu (that is ollama-local only)")
+	}
+
+	ds := toDriverOptions("deepseek", cfg.Providers["deepseek"], cfg)
+	if ds.BaseURL != "https://ds.mirror" || ds.KeyEnvName != "DEEPSEEK_API_KEY" {
+		t.Errorf("deepseek opts = {BaseURL:%q KeyEnvName:%q}, want the DEEPSEEK_BASE_URL + DEEPSEEK_API_KEY", ds.BaseURL, ds.KeyEnvName)
+	}
+
+	gm := toDriverOptions("gemini", cfg.Providers["gemini"], cfg)
+	if gm.BaseURL != "https://vertex.example" {
+		t.Errorf("gemini BaseURL = %q, want the GEMINI_BASE_URL value", gm.BaseURL)
+	}
+}
+
+// TestGet_MockStable_IsStableVariant proves mock-stable, built through the driver
+// registry with `options: {stable: true}` (from the default-providers layer),
+// reports the right id — the config-driven replacement for the pre-P2a
+// NewStableProvider() wiring.
+func TestGet_MockStable_IsStableVariant(t *testing.T) {
+	t.Setenv("LOOMCYCLE_MOCK_ENABLED", "1")
+	cfg := loadDefaultProvidersOnly(t)
+	pr, err := newProviderResolver(cfg)
+	if err != nil {
+		t.Fatalf("newProviderResolver: %v", err)
+	}
+	ms, err := pr.Get("mock-stable")
+	if err != nil {
+		t.Fatalf("Get(mock-stable): %v", err)
+	}
+	if ms.ID() != "mock-stable" {
+		t.Errorf("mock-stable ID() = %q, want mock-stable", ms.ID())
+	}
+	m, err := pr.Get("mock")
+	if err != nil {
+		t.Fatalf("Get(mock): %v", err)
+	}
+	if m.ID() != "mock" {
+		t.Errorf("mock ID() = %q, want mock", m.ID())
+	}
+}
+
+// TestNewProviderResolver_NoDefaultProviders_Empty proves LOOMCYCLE_NO_DEFAULT_PROVIDERS
+// semantics at the resolver level: with no declared providers, every Get fails —
+// there is no built-in floor once the default layer is dropped.
+func TestNewProviderResolver_NoDefaultProviders_Empty(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test-not-a-real-key")
+	t.Setenv("LOOMCYCLE_NO_DEFAULT_PROVIDERS", "1") // suppress the divergence WARN
+	// An empty config (no providers:) stands in for the LOOMCYCLE_NO_DEFAULT_PROVIDERS
+	// stack, where main() omits the default-providers layer entirely.
+	cfg, err := config.LoadLayers(config.Layer{Name: "empty", Data: []byte("concurrency:\n  max_concurrent_runs: 1\n")})
+	if err != nil {
+		t.Fatalf("LoadLayers: %v", err)
+	}
+	pr, err := newProviderResolver(cfg)
+	if err != nil {
+		t.Fatalf("newProviderResolver: %v", err)
+	}
+	if _, err := pr.Get("anthropic"); err == nil {
+		t.Error("Get(anthropic) should fail when no providers are declared")
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -96,7 +96,15 @@ func RunDoctor(args []string, stdout, stderr io.Writer) int {
 		r.warn("Providers", "none configured in provider_priority or per-agent providers")
 	}
 	for _, p := range providers {
-		envVar := providerEnvVarName(p)
+		// RFC BF P2a — prefer the config-declared api_key_env for this id (so a
+		// 3rd-party `providers:` entry's key var is checked), falling back to the
+		// hardcoded canonical name for the built-ins. doctor doesn't layer the
+		// embedded default-providers block, so cfg.Providers is empty for a stock
+		// config and the fallback keeps the built-in checks byte-identical.
+		envVar := cfg.ProviderAPIKeyEnv(p)
+		if envVar == "" {
+			envVar = providerEnvVarName(p)
+		}
 		if envVar == "" {
 			r.pass(fmt.Sprintf("Provider %s", p), "no API key required (local provider)")
 			continue
@@ -262,6 +270,10 @@ type configForDoctor interface {
 	// AgentProviderHints — overlays can introduce providers the
 	// top-level list doesn't carry.
 	UserTierProviderHints() []string
+	// ProviderAPIKeyEnv returns the api_key_env declared for a provider id in the
+	// `providers:` block (RFC BF P2a), or "" when the id isn't declared (then the
+	// caller falls back to the hardcoded canonical name for a built-in).
+	ProviderAPIKeyEnv(id string) string
 	StorageBackend() string
 	StoragePgDSN() string
 	StorageDataDir() string

--- a/internal/cli/doctor_adapters.go
+++ b/internal/cli/doctor_adapters.go
@@ -38,6 +38,9 @@ func (r *realConfig) UserTierProviderHints() []string {
 	return out
 }
 
+func (r *realConfig) ProviderAPIKeyEnv(id string) string {
+	return r.cfg.Providers[id].APIKeyEnv
+}
 func (r *realConfig) StorageBackend() string  { return r.cfg.Storage.Backend }
 func (r *realConfig) StoragePgDSN() string    { return r.cfg.Storage.PgDSN }
 func (r *realConfig) StorageDataDir() string  { return r.cfg.Env.DataDir }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -17,6 +17,7 @@ type stubConfig struct {
 	providers      []string
 	agentProviders []string
 	tierProviders  []string
+	providerKeyEnv map[string]string // id → api_key_env (RFC BF P2a)
 	backend        string
 	pgDSN          string
 	dataDir        string
@@ -26,10 +27,13 @@ type stubConfig struct {
 func (s *stubConfig) ProviderPriorityList() []string  { return s.providers }
 func (s *stubConfig) AgentProviderHints() []string    { return s.agentProviders }
 func (s *stubConfig) UserTierProviderHints() []string { return s.tierProviders }
-func (s *stubConfig) StorageBackend() string          { return s.backend }
-func (s *stubConfig) StoragePgDSN() string            { return s.pgDSN }
-func (s *stubConfig) StorageDataDir() string          { return s.dataDir }
-func (s *stubConfig) ListenAddrValue() string         { return s.listen }
+func (s *stubConfig) ProviderAPIKeyEnv(id string) string {
+	return s.providerKeyEnv[id]
+}
+func (s *stubConfig) StorageBackend() string  { return s.backend }
+func (s *stubConfig) StoragePgDSN() string    { return s.pgDSN }
+func (s *stubConfig) StorageDataDir() string  { return s.dataDir }
+func (s *stubConfig) ListenAddrValue() string { return s.listen }
 
 // withStubLoader swaps loadConfigForDoctor for the duration of one
 // test. Restored on cleanup so other tests see the real loader.

--- a/internal/config/alias_test.go
+++ b/internal/config/alias_test.go
@@ -43,19 +43,19 @@ func TestValidateTierCandidate_AliasAware(t *testing.T) {
 	models := map[string]ModelRef{
 		"local-qwen": {Provider: "ollama-local", Model: "qwen3.6:max"},
 	}
-	if err := validateTierCandidate(TierCandidate{Model: "local-qwen"}, models); err != nil {
+	if err := validateTierCandidate(TierCandidate{Model: "local-qwen"}, models, validProviderIDs); err != nil {
 		t.Errorf("bare alias rejected: %v", err)
 	}
-	if err := validateTierCandidate(TierCandidate{Model: "not-an-alias"}, models); err == nil {
+	if err := validateTierCandidate(TierCandidate{Model: "not-an-alias"}, models, validProviderIDs); err == nil {
 		t.Error("empty provider + non-alias model accepted, want error")
 	}
-	if err := validateTierCandidate(TierCandidate{Provider: "deepseek", Model: "deepseek-v4-pro"}, models); err != nil {
+	if err := validateTierCandidate(TierCandidate{Provider: "deepseek", Model: "deepseek-v4-pro"}, models, validProviderIDs); err != nil {
 		t.Errorf("explicit literal candidate rejected: %v", err)
 	}
-	if err := validateTierCandidate(TierCandidate{Provider: "bogus", Model: "x"}, models); err == nil {
+	if err := validateTierCandidate(TierCandidate{Provider: "bogus", Model: "x"}, models, validProviderIDs); err == nil {
 		t.Error("unknown provider accepted, want error")
 	}
-	if err := validateTierCandidate(TierCandidate{Provider: "deepseek"}, models); err == nil {
+	if err := validateTierCandidate(TierCandidate{Provider: "deepseek"}, models, validProviderIDs); err == nil {
 		t.Error("explicit provider + empty model accepted, want error")
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4484,9 +4484,16 @@ func splitCSV(s string) []string {
 	return out
 }
 
-// validProviderIDs is the set of provider names the resolver knows
-// how to dispatch to. Adding a new driver requires extending this set
-// AND wiring the driver into cmd/loomcycle/main.go's resolver.
+// validProviderIDs is the built-in provider FLOOR — the ids the pre-RFC-BF
+// resolver hardcoded. RFC BF P2a: provider references (agent pins, tier
+// candidates, model aliases, provider_priority) validate against
+// knownProviderIDs() = this floor UNION the operator's declared `providers:` keys,
+// so a config-declared 3rd-party provider validates too, while every existing
+// config stays valid whether or not it declares a `providers:` block. Kept as a
+// floor (not replaced by cfg.Providers keys) because validate() also runs on
+// configs assembled WITHOUT the embedded default-providers layer — CLI/unit
+// paths, and LOOMCYCLE_NO_DEFAULT_PROVIDERS — where the built-ins would otherwise
+// vanish from the valid set.
 var validProviderIDs = map[string]bool{
 	"anthropic":    true,
 	"openai":       true,
@@ -4509,6 +4516,22 @@ var validProviderIDs = map[string]bool{
 	// `[{provider: mock, ...}, {provider: mock-stable, ...}]` for
 	// fallback-recovery testing without a real second provider.
 	"mock-stable": true,
+}
+
+// knownProviderIDs is the set a provider reference may name: the built-in floor
+// (validProviderIDs) UNION the operator's declared `providers:` keys (RFC BF P2a).
+// A declared 3rd-party provider validates in tier candidates / agent pins /
+// provider_priority / model aliases; the built-ins always validate so no existing
+// config regresses.
+func (c *Config) knownProviderIDs() map[string]bool {
+	out := make(map[string]bool, len(validProviderIDs)+len(c.Providers))
+	for id := range validProviderIDs {
+		out[id] = true
+	}
+	for id := range c.Providers {
+		out[id] = true
+	}
+	return out
 }
 
 // validTierNames is the closed set of tier names. Operators choose
@@ -4805,14 +4828,14 @@ func validateStaticWebhook(name string, w Webhook) error {
 // provider is valid IFF the model is a defined alias. Otherwise the provider
 // must be a known ID and the model non-empty. Without the alias carve-out an
 // all-aliases tier list fails load with `unknown provider ""`.
-func validateTierCandidate(cand TierCandidate, models map[string]ModelRef) error {
+func validateTierCandidate(cand TierCandidate, models map[string]ModelRef, known map[string]bool) error {
 	if cand.Provider == "" {
 		if _, ok := models[cand.Model]; !ok {
 			return fmt.Errorf("empty provider and %q is not a model alias (define it under models: or set an explicit provider)", cand.Model)
 		}
 		return nil
 	}
-	if !validProviderIDs[cand.Provider] {
+	if !known[cand.Provider] {
 		return fmt.Errorf("unknown provider %q", cand.Provider)
 	}
 	if cand.Model == "" {
@@ -4851,11 +4874,16 @@ func validate(c *Config) error {
 			return fmt.Errorf("skills: inline skill %q: %w", name, err)
 		}
 	}
+	// known = the built-in floor UNION the declared `providers:` keys (RFC BF P2a).
+	// Every provider reference below (priority lists, tier candidates, agent pins,
+	// model aliases) validates against this so a config-declared 3rd-party provider
+	// is accepted while every built-in stays valid.
+	known := c.knownProviderIDs()
 	// Library-level provider priority — validate every entry is a
 	// known provider name. Empty list is fine (resolver falls back
 	// to its hardcoded default order).
 	for i, p := range c.ProviderPriority {
-		if !validProviderIDs[p] {
+		if !known[p] {
 			return fmt.Errorf("provider_priority[%d]: unknown provider %q (want one of anthropic/openai/deepseek/gemini/ollama)", i, p)
 		}
 	}
@@ -4881,20 +4909,44 @@ func validate(c *Config) error {
 			return fmt.Errorf("search_priority[%d]: %q is not an enabled search_providers entry", i, id)
 		}
 	}
-	// RFC BF provider registry (P1): light structural validation only. Each
-	// declared entry needs a driver and a non-negative concurrency cap. The
-	// registry-aware checks — driver name ∈ providers.RegisteredDrivers(),
-	// dialect ∈ the driver's set, models[*].provider ∈ this map — are P2, where
-	// the resolver (which may import internal/providers) becomes authoritative;
-	// config.go stays free of an internal/providers import in P1. An absent
-	// `providers:` block skips the loop entirely, so every existing config
-	// validates identically.
+	// RFC BF provider registry (P2a): structural + registry-aware validation. Each
+	// declared entry needs a driver compiled into the binary (∈ RegisteredDrivers),
+	// a dialect the driver speaks (when set), and a non-negative concurrency cap.
+	// The driver registry is populated by the driver packages' init() — present in
+	// the server binary (blank imports in cmd/loomcycle) and the config test binary
+	// (blank imports in drivers_registry_test.go). An absent `providers:` block
+	// skips the loop, so a config that declares none validates unchanged.
 	for id, pc := range c.Providers {
 		if strings.TrimSpace(pc.Driver) == "" {
 			return fmt.Errorf("providers.%s: driver is required", id)
 		}
 		if pc.MaxConcurrent < 0 {
 			return fmt.Errorf("providers.%s: max_concurrent must be >= 0", id)
+		}
+		dialects, ok := providers.DriverDialects(pc.Driver)
+		if !ok {
+			return fmt.Errorf("providers.%s: unknown driver %q (compiled-in: %v)", id, pc.Driver, providers.RegisteredDrivers())
+		}
+		if pc.Dialect != "" {
+			supported := false
+			for _, d := range dialects {
+				if d == pc.Dialect {
+					supported = true
+					break
+				}
+			}
+			if !supported {
+				return fmt.Errorf("providers.%s: driver %q does not speak dialect %q (supported: %v)", id, pc.Driver, pc.Dialect, dialects)
+			}
+		}
+	}
+	// Model aliases (top-level models:) — a non-empty provider on an alias must be a
+	// known provider (RFC BF P2a; an empty provider defers to the pin/candidate that
+	// names the alias, so it is left unvalidated here). Built-ins always pass via the
+	// floor, so this only newly rejects a typo'd or undeclared 3rd-party provider.
+	for name, ref := range c.Models {
+		if ref.Provider != "" && !known[ref.Provider] {
+			return fmt.Errorf("models.%s: unknown provider %q", name, ref.Provider)
 		}
 	}
 	// Library-level tier definitions.
@@ -4903,7 +4955,7 @@ func validate(c *Config) error {
 			return fmt.Errorf("tiers.%s: unknown tier (want one of low/middle/high)", tierName)
 		}
 		for i, cand := range candidates {
-			if err := validateTierCandidate(cand, c.Models); err != nil {
+			if err := validateTierCandidate(cand, c.Models, known); err != nil {
 				return fmt.Errorf("tiers.%s[%d]: %v", tierName, i, err)
 			}
 		}
@@ -4924,7 +4976,7 @@ func validate(c *Config) error {
 				return fmt.Errorf("user_tiers: empty tier name")
 			}
 			for i, p := range ut.ProviderPriority {
-				if !validProviderIDs[p] {
+				if !known[p] {
 					return fmt.Errorf("user_tiers.%s.provider_priority[%d]: unknown provider %q", tierName, i, p)
 				}
 			}
@@ -4933,7 +4985,7 @@ func validate(c *Config) error {
 					return fmt.Errorf("user_tiers.%s.tiers.%s: unknown tier (want one of low/middle/high)", tierName, taskTier)
 				}
 				for i, cand := range candidates {
-					if err := validateTierCandidate(cand, c.Models); err != nil {
+					if err := validateTierCandidate(cand, c.Models, known); err != nil {
 						return fmt.Errorf("user_tiers.%s.tiers.%s[%d]: %v", tierName, taskTier, i, err)
 					}
 				}
@@ -5028,7 +5080,7 @@ func validate(c *Config) error {
 		}
 		// Per-agent provider override.
 		for i, p := range agent.Providers {
-			if !validProviderIDs[p] {
+			if !known[p] {
 				return fmt.Errorf("agent %q: providers[%d]: unknown provider %q", name, i, p)
 			}
 		}
@@ -5045,7 +5097,7 @@ func validate(c *Config) error {
 				return fmt.Errorf("agent %q: models.%s: unknown tier", name, tierName)
 			}
 			for i, cand := range candidates {
-				if err := validateTierCandidate(cand, c.Models); err != nil {
+				if err := validateTierCandidate(cand, c.Models, known); err != nil {
 					return fmt.Errorf("agent %q: models.%s[%d]: %v", name, tierName, i, err)
 				}
 			}

--- a/internal/config/drivers_registry_test.go
+++ b/internal/config/drivers_registry_test.go
@@ -1,0 +1,19 @@
+package config
+
+// RFC BF P2a — validate() now checks each `providers:` entry's driver against the
+// providers driver registry (providers.RegisteredDrivers / DriverDialects), which
+// is populated by each driver package's init() self-registration. The server
+// binary gets that via blank imports in cmd/loomcycle; the config test binary gets
+// it here so validate()'s driver/dialect checks exercise the real registered
+// factories (e.g. TestValidate_Providers with driver: anthropic/ollama/openai).
+// None of these packages import internal/config, so there is no import cycle
+// (verified: go list -deps of each driver excludes internal/config).
+import (
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/anthropic"
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/codejs"
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/deepseek"
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/gemini"
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/mock"
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/ollama"
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/openai"
+)

--- a/internal/config/providers_test.go
+++ b/internal/config/providers_test.go
@@ -101,6 +101,12 @@ func TestValidate_Providers(t *testing.T) {
 			base(map[string]ProviderConfig{"bad": {Driver: ""}}), "driver is required"},
 		{"negative max_concurrent",
 			base(map[string]ProviderConfig{"bad": {Driver: "openai", MaxConcurrent: -1}}), "max_concurrent must be >= 0"},
+		// RFC BF P2a registry-aware checks (drivers_registry_test.go populates the
+		// registry so these exercise the real registered factories).
+		{"unknown driver",
+			base(map[string]ProviderConfig{"bad": {Driver: "not-a-driver"}}), "unknown driver"},
+		{"unsupported dialect",
+			base(map[string]ProviderConfig{"bad": {Driver: "anthropic", Dialect: "openai-chat"}}), "does not speak dialect"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -109,5 +115,82 @@ func TestValidate_Providers(t *testing.T) {
 				t.Errorf("got %v, want error containing %q", err, tc.wantSub)
 			}
 		})
+	}
+}
+
+// TestValidate_Providers_DialectAccepted proves a driver's canonical dialect is
+// accepted when explicitly set (the counterpart to the "unsupported dialect"
+// rejection above).
+func TestValidate_Providers_DialectAccepted(t *testing.T) {
+	cfg := &Config{
+		Defaults:    Defaults{Provider: "anthropic", Model: "x"},
+		Concurrency: Concurrency{MaxConcurrentRuns: 1},
+		Providers: map[string]ProviderConfig{
+			"anthropic": {Driver: "anthropic", Dialect: "anthropic-messages"},
+		},
+	}
+	if err := validate(cfg); err != nil {
+		t.Errorf("canonical dialect rejected: %v", err)
+	}
+}
+
+// TestValidate_ThirdPartyProvider_AcceptedAsReference proves RFC BF P2a's headline
+// capability: a config-declared 3rd-party provider id (not in the built-in floor)
+// is a valid provider reference in tiers / agent pins / provider_priority, while a
+// truly undeclared id is still rejected.
+func TestValidate_ThirdPartyProvider_AcceptedAsReference(t *testing.T) {
+	base := func() *Config {
+		return &Config{
+			Defaults:    Defaults{Provider: "anthropic", Model: "x"},
+			Concurrency: Concurrency{MaxConcurrentRuns: 1},
+			Providers: map[string]ProviderConfig{
+				// A self-hosted OpenAI-compatible mirror declared by the operator.
+				"my-vllm": {Driver: "openai", BaseURL: "http://vllm.local", APIKeyEnv: "MY_VLLM_KEY"},
+			},
+			ProviderPriority: []string{"my-vllm", "anthropic"},
+			Tiers:            map[string][]TierCandidate{"middle": {{Provider: "my-vllm", Model: "qwen"}}},
+			Agents:           map[string]AgentDef{"a": {Provider: "my-vllm", Model: "qwen"}},
+		}
+	}
+	if err := validate(base()); err != nil {
+		t.Errorf("declared 3rd-party provider rejected as reference: %v", err)
+	}
+
+	// An UNDECLARED id must still fail — the floor + declared set is the ceiling.
+	bad := base()
+	bad.ProviderPriority = []string{"ghost"}
+	if err := validate(bad); err == nil || !strings.Contains(err.Error(), "unknown provider") {
+		t.Errorf("undeclared provider accepted: %v", err)
+	}
+}
+
+// TestValidate_ModelAliasProvider covers the new models[*].provider check: a
+// built-in provider on an alias passes (floor), a declared 3rd-party passes, and
+// a bogus provider is rejected. An empty-provider alias is left to the pin/tier
+// that names it, so it must NOT be rejected here.
+func TestValidate_ModelAliasProvider(t *testing.T) {
+	base := func(models map[string]ModelRef, providers map[string]ProviderConfig) *Config {
+		return &Config{
+			Defaults:    Defaults{Provider: "anthropic", Model: "x"},
+			Concurrency: Concurrency{MaxConcurrentRuns: 1},
+			Models:      models,
+			Providers:   providers,
+		}
+	}
+	if err := validate(base(map[string]ModelRef{"a": {Provider: "anthropic", Model: "claude"}}, nil)); err != nil {
+		t.Errorf("built-in alias provider rejected: %v", err)
+	}
+	if err := validate(base(
+		map[string]ModelRef{"a": {Provider: "my-vllm", Model: "qwen"}},
+		map[string]ProviderConfig{"my-vllm": {Driver: "openai", APIKeyEnv: "MY_VLLM_KEY"}},
+	)); err != nil {
+		t.Errorf("declared 3rd-party alias provider rejected: %v", err)
+	}
+	if err := validate(base(map[string]ModelRef{"a": {Model: "just-a-model"}}, nil)); err != nil {
+		t.Errorf("empty-provider alias must not be validated here: %v", err)
+	}
+	err := validate(base(map[string]ModelRef{"a": {Provider: "bogus", Model: "x"}}, nil))
+	if err == nil || !strings.Contains(err.Error(), "unknown provider") {
+		t.Errorf("bogus alias provider accepted: %v", err)
 	}
 }

--- a/internal/loop/fallback_test.go
+++ b/internal/loop/fallback_test.go
@@ -27,13 +27,16 @@ type tieredProvider struct {
 	errors         []error // returned by Call() at the same index; nil → use responses[idx]
 	calls          int
 	supportsVision bool
+	// nativePromptCache mirrors the real driver capability the loop's cache-loss
+	// event now keys on (RFC BF P2a) — Anthropic sets it, others don't.
+	nativePromptCache bool
 }
 
 func (p *tieredProvider) ID() string                                     { return p.id }
 func (p *tieredProvider) Probe(_ context.Context) error                  { return nil }
 func (p *tieredProvider) ListModels(_ context.Context) ([]string, error) { return []string{"m"}, nil }
 func (p *tieredProvider) Capabilities() providers.Capabilities {
-	return providers.Capabilities{Streaming: true, SupportsVision: p.supportsVision}
+	return providers.Capabilities{Streaming: true, SupportsVision: p.supportsVision, NativePromptCache: p.nativePromptCache}
 }
 func (p *tieredProvider) Call(_ context.Context, _ providers.Request) (<-chan providers.Event, error) {
 	p.mu.Lock()
@@ -306,8 +309,9 @@ func TestFallback_OperatorKeyForbidden_NotCascaded(t *testing.T) {
 // this run are cache-cold.
 func TestFallback_AnthropicToOther_EmitsCacheInvalidated(t *testing.T) {
 	failing := &tieredProvider{
-		id:     "anthropic",
-		errors: []error{fmt.Errorf("anthropic 503: backend unavailable")},
+		id:                "anthropic",
+		nativePromptCache: true, // the loop keys the cache-loss event on this cap
+		errors:            []error{fmt.Errorf("anthropic 503: backend unavailable")},
 	}
 	healthy := &tieredProvider{
 		id:        "deepseek",

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -598,18 +598,19 @@ func tryProviderFallback(
 		},
 	})
 
-	// Cache-loss event when switching AWAY from Anthropic. The
-	// cache_control breakpoints in the system block (and on system_
-	// prompt segments) are Anthropic-specific; no other provider
-	// carries the equivalent state today. A switch FROM anthropic
-	// means downstream iterations on the new provider get cache-
-	// cold rates. Switches INTO anthropic don't emit this event —
-	// the new provider has no cache to begin with, and Anthropic's
-	// implicit cache will warm naturally.
-	if failedProvider == "anthropic" && newProvider.ID() != "anthropic" {
+	// Cache-loss event when switching AWAY from a native-prompt-cache provider
+	// (Anthropic today) to one without it. The cache_control breakpoints in the
+	// system block (and on system_prompt segments) live only on providers that
+	// advertise NativePromptCache; a switch off one drops that state so downstream
+	// iterations run cache-cold. Keyed on Capabilities().NativePromptCache rather
+	// than the literal id "anthropic" (RFC BF P2a) so an operator who names their
+	// Anthropic provider anything still gets the event, and a hypothetical second
+	// native-cache provider is covered without a code change. Switches INTO a
+	// native-cache provider don't emit — the new provider has no cache to lose.
+	if opts.Provider.Capabilities().NativePromptCache && !newProvider.Capabilities().NativePromptCache {
 		emit(providers.Event{
 			Type: providers.EventCacheInvalidated,
-			Text: fmt.Sprintf("Anthropic cache_control breakpoints lost on switch to %s; this run's downstream iterations will be cache-cold", newProvider.ID()),
+			Text: fmt.Sprintf("native prompt-cache breakpoints lost on switch from %s to %s; this run's downstream iterations will be cache-cold", failedProvider, newProvider.ID()),
 		})
 	}
 

--- a/internal/providers/deepseek/driver.go
+++ b/internal/providers/deepseek/driver.go
@@ -186,7 +186,10 @@ func (d *Driver) NonThinkingSibling(model string) (string, bool) {
 // operators filtering by `provider="deepseek"` see DeepSeek calls
 // distinctly with correct streaming-attempt durations.
 func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan providers.Event, error) {
-	return d.inner.Call(lcotel.WithProviderOverride(ctx, "deepseek"), req)
+	// Use the instance ID() (not the literal "deepseek") so a config-declared
+	// provider id (RFC BF P2a) shows up correctly on the inner OpenAI driver's
+	// span; defaults to "deepseek" so the stock case is unchanged.
+	return d.inner.Call(lcotel.WithProviderOverride(ctx, d.ID()), req)
 }
 
 // Probe delegates to the OpenAI driver, which hits GET /v1/models

--- a/internal/providers/mock/driver_test.go
+++ b/internal/providers/mock/driver_test.go
@@ -490,3 +490,37 @@ func TestStableDriverID_OverridesParent(t *testing.T) {
 		t.Errorf("ID() = %q, want mock-stable", got)
 	}
 }
+
+// TestNewFromOptions_StableOption_ZeroesRates — RFC BF P2a: the config-driven
+// mock-stable is built via the registry factory with `options: {stable: true}`
+// and an id override, replacing the pre-P2a NewStableProvider() wiring. It must be
+// behaviour-identical to NewStable(): 429/500 rates zeroed regardless of a hostile
+// env, and the id set from DriverOptions.
+func TestNewFromOptions_StableOption_ZeroesRates(t *testing.T) {
+	t.Setenv("LOOMCYCLE_MOCK_429_RATE", "1.0")
+	t.Setenv("LOOMCYCLE_MOCK_500_RATE", "1.0")
+
+	p, err := newFromOptions(providers.DriverOptions{ID: "mock-stable", Options: map[string]any{"stable": true}})
+	if err != nil {
+		t.Fatalf("newFromOptions: %v", err)
+	}
+	if p.ID() != "mock-stable" {
+		t.Errorf("ID() = %q, want mock-stable", p.ID())
+	}
+	d, ok := p.(*Driver)
+	if !ok {
+		t.Fatalf("newFromOptions returned %T, want *Driver", p)
+	}
+	if d.rate429 != 0 || d.rate500 != 0 {
+		t.Errorf("stable option: rate429=%v rate500=%v, want both 0 even with env=1.0", d.rate429, d.rate500)
+	}
+
+	// Without the option, the driver honours the env rates (non-stable "mock").
+	plain, err := newFromOptions(providers.DriverOptions{ID: "mock"})
+	if err != nil {
+		t.Fatalf("newFromOptions(plain): %v", err)
+	}
+	if pd := plain.(*Driver); pd.rate429 == 0 && pd.rate500 == 0 {
+		t.Error("plain mock should honour the hostile env rates, got both 0")
+	}
+}

--- a/internal/providers/mock/register.go
+++ b/internal/providers/mock/register.go
@@ -22,7 +22,16 @@ func newFromOptions(o providers.DriverOptions) (providers.Provider, error) {
 	if o.ID != "" {
 		d.id = o.ID
 	}
+	// RFC BF P2a — a `stable: true` option builds the failure-injection-off variant
+	// (the pre-P2a "mock-stable"): 429/500 rates pinned to zero regardless of the
+	// LOOMCYCLE_MOCK_* env, latency knobs still apply. Behaviour matches
+	// NewStableProvider() but with the id set from DriverOptions, so the config can
+	// declare `mock-stable: {driver: mock, options: {stable: true}}`.
+	if stable, _ := providers.BoolOption(o.Options, "stable"); stable {
+		d.rate429 = 0
+		d.rate500 = 0
+	}
 	d.capsPatch = o.Capabilities
-	providers.WarnUnknownOptions(o.Logf, "mock", o.Options)
+	providers.WarnUnknownOptions(o.Logf, "mock", o.Options, "stable")
 	return d, nil
 }


### PR DESCRIPTION
## What this is

**P2a of the RFC BF config-driven provider registry.** P1 (#728) landed the `providers:` config schema + the `internal/providers` driver registry (`RegisterDriver`/`NewDriver`/…) with per-driver `init()` self-registration. P2a flips the resolver to build providers **from config via the registry** instead of the hardcoded per-provider fields — **behaviour-identical**. It does **not** add per-provider `max_concurrent` (that is P2b).

## Behaviour-identity guarantee

A config with **no `providers:` block resolves providers identically to pre-P2a** — same instances, base URLs, keys, "not configured" errors, and probe exclusion reasons. This holds because an embedded **default-providers layer** is prepended unconditionally as the stack base and declares exactly the 9 built-ins the old resolver built; `providerEnabled` + `toDriverOptions` port the exact env behaviour 1:1.

## Why (the problem)

The resolver hardcoded each provider's construction, its `Get` error strings, its probe exclusion, and 6 coupling sites keyed on the literal id `"anthropic"`/`"deepseek"`. A config-declared 3rd-party or self-hosted provider (`driver: openai`, custom `base_url`) could be parsed (P1) but never resolved. P2a makes the resolver consume the `providers:` map so a declared provider actually runs, without changing anything for existing configs.

## What changed

- **Embedded default layer** — `cmd/loomcycle/embedded/providers.default.yaml` (`providers:`-only; no models/tiers so it can't clobber operator configs) + `embedded.DefaultProviders()`. main() prepends it unconditionally under any opt-in preset; `LOOMCYCLE_NO_DEFAULT_PROVIDERS=1` drops it. Kept out of `presetLayers` so the "no config found" error still fires on a bare run.
- **Resolver flip** (`cmd/loomcycle/main.go`) — `newProviderResolver` builds `byID` from `cfg.Providers` via `providers.NewDriver`; `providerEnabled` reproduces every env gate; `toDriverOptions` ports base-url/timeout/num_ctx/num_gpu; `Get` is a map lookup returning the byte-identical pre-P2a errors; `anthropic-oauth-dev` stays a residual hardcoded path (main-owned Refresher).
- **Blank imports** — driver packages imported for `init()` self-registration now that `New()` isn't called directly; `RegisteredDrivers()` returns the 7.
- **mock-stable** — declared `driver: mock` + `options: {stable: true}`; the mock factory zeroes the failure rates (matches the old `NewStableProvider`).
- **Probe** — job set built from `cfg.Providers` (deterministic order), skipping `code-js` (pre-P2a never probed it), appending `oauth-dev`; exclusion reasons byte-identical.
- **Validation** (`config.go`) — each `providers:` entry's driver ∈ `RegisteredDrivers` + dialect ∈ the driver's set; model-alias providers validated; provider references validate against the built-in floor **UNION** the declared keys (a declared 3rd-party is accepted; every existing config stays valid — union rather than declared-keys-only keeps CLI/unit paths and `LOOMCYCLE_NO_DEFAULT_PROVIDERS` valid without the default layer).
- **Coupling sites** — loop cache-loss event keyed on `Capabilities().NativePromptCache` (not the literal `"anthropic"`); deepseek otel uses the instance `ID()`; doctor prefers the config-declared `api_key_env` with the hardcoded fallback.

## What was tested

- `go build ./...`, `make build-all`, `go test -race ./...` (exit 0), `go vet ./...`, `gofmt -l` — all clean.
- **Back-compat regression** `TestNewProviderResolver_NoProvidersBlock_BackCompat` — with no `providers:` block and only `ANTHROPIC_API_KEY` set: `Get("anthropic")` returns a working provider (`ID()=="anthropic"`); `Get("openai"/"deepseek"/"gemini"/"ollama")` return the **byte-identical pre-P2a "not configured" strings**. Fail-before verified (breaking one error string makes it fail).
- `TestResolveProbe_NoProvidersBlock_ExclusionReasons` locks the probe reasons + proves `code-js` isn't probed; `TestRegisteredDrivers_SevenCompiledIn`; `TestToDriverOptions_PortsEnvBaseURLsAndTimeouts`; `TestGet_MockStable_IsStableVariant`; config-side unknown-driver/dialect/model-alias/3rd-party tests.
- **Manual (real binary):** stock `loomcycle.example.yaml` (no `providers:`) boots with the same `resolve probe:` lines as pre-P2a (only the additive `providers: N configured` summary is new; excluded lines are now alphabetically ordered — set + content identical); a config adding a 3rd-party `driver: openai` provider registers and appears in the probe; `LOOMCYCLE_NO_DEFAULT_PROVIDERS=1` yields zero providers.

## Notes / decisions

- **Union vs declared-keys-only** for validation: a deliberate deviation from a literal "replace with declared keys" — the floor is kept so configs assembled without the default layer (config unit tests, CLI paths, `NO_DEFAULT_PROVIDERS`) don't regress. Built-ins always valid; a declared 3rd-party is additionally valid.
- **mock-stable** required teaching the mock factory a `stable` option (P1's factory built the failure-injecting variant); this is the behaviour-identity fix for `driver: mock`.
- Excluded-probe **log line order** is now deterministic/alphabetical (was declaration order); content is byte-identical and the reachable probes were already unordered (concurrent).
- `init.go`'s provider wizard is left as-is — it scaffolds a fresh config before any `providers:` block exists, so there is nothing to look up. `mockprov.NewStableProvider` is superseded but left in place (out of scope to remove).
- **P2b** (per-provider `max_concurrent` semaphore) is the next PR.

Does NOT touch REVISIONS/README/adapters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD