### PR TITLE
feat(providers): P2b — per-provider max_concurrent concurrency semaphore

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1631,6 +1631,10 @@ func main() {
 	// server's tool set, which isn't in allTools here (F45). New re-points any
 	// Context tool to the COMPLETE post-append catalog, so don't set it here.
 	srv = lchttp.New(cfg, pr, allTools, sem, storeIface)
+	// RFC BF P2b: per-provider concurrency gates (providers.<id>.max_concurrent).
+	// Acquired at run admission before the global slot; empty ⇒ every provider
+	// uncapped, admission unchanged.
+	srv.SetProviderGates(newProviderGates(cfg))
 	// RFC AR: stamp the credential resolver onto each run so a tenant/user's own
 	// provider key (ANTHROPIC_API_KEY, BRAVE_API_KEY, …) overrides the host key.
 	srv.SetCredentialResolver(credResolver)
@@ -3114,6 +3118,41 @@ func providerEnabled(id string, pc config.ProviderConfig, cfg *config.Config) bo
 		// 3rd-party): enabled iff their api_key_env names a set variable.
 		return pc.APIKeyEnv != "" && os.Getenv(pc.APIKeyEnv) != ""
 	}
+}
+
+// newProviderGates builds the RFC BF P2b per-provider concurrency gates from
+// cfg.Providers: one gate per provider whose max_concurrent > 0 (the rest are
+// uncapped → a noop at admission). Shared queue depth + timeout come from the
+// concurrency block (LOOMCYCLE_PROVIDER_QUEUE_DEPTH / _TIMEOUT_MS, defaulting to
+// the global MaxQueueDepth / QueueTimeout). Returns empty gates — hence zero
+// admission overhead — when no provider sets a cap (the default deployment).
+func newProviderGates(cfg *config.Config) *concurrency.ProviderGates {
+	caps := make(map[string]int)
+	for id, pc := range cfg.Providers {
+		if pc.MaxConcurrent > 0 {
+			caps[id] = pc.MaxConcurrent
+		}
+	}
+	depth := cfg.Concurrency.ProviderQueueDepthOrDefault()
+	timeout := cfg.Concurrency.ProviderQueueTimeout()
+	gates := concurrency.NewProviderGates(caps, depth, timeout)
+	if len(caps) > 0 {
+		ids := make([]string, 0, len(caps))
+		for id := range caps {
+			ids = append(ids, id)
+		}
+		sort.Strings(ids) // deterministic log order
+		var b strings.Builder
+		for i, id := range ids {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			fmt.Fprintf(&b, "%s=%d", id, caps[id])
+		}
+		log.Printf("providers: per-provider concurrency caps enabled — %s (queue_depth=%d timeout=%s)",
+			b.String(), depth, timeout)
+	}
+	return gates
 }
 
 // toDriverOptions ports the pre-P2a per-provider construction 1:1 into the driver

--- a/internal/api/grpc/server.go
+++ b/internal/api/grpc/server.go
@@ -1248,9 +1248,11 @@ func mapRunnerErr(err error) error {
 	case errors.Is(err, runner.ErrAgentIDInUse):
 		return status.Error(codes.AlreadyExists, err.Error())
 	case errors.Is(err, runner.ErrBackpressure),
-		errors.Is(err, runner.ErrPerUserQuotaExhausted):
-		// Both backpressure flavors share ResourceExhausted on the
-		// gRPC wire. HTTP distinguishes the two via the JSON body's
+		errors.Is(err, runner.ErrPerUserQuotaExhausted),
+		errors.Is(err, runner.ErrProviderConcurrencyExhausted):
+		// All backpressure flavors share ResourceExhausted on the gRPC
+		// wire — global queue, per-user cap, and the RFC BF P2b per-
+		// provider cap. HTTP distinguishes them via the JSON body's
 		// `code` field + Retry-After header; gRPC consumers branch on
 		// the error message if they need to distinguish.
 		return status.Error(codes.ResourceExhausted, err.Error())

--- a/internal/api/http/concurrency_handlers.go
+++ b/internal/api/http/concurrency_handlers.go
@@ -18,6 +18,16 @@ type concurrencyStatsResponse struct {
 	Active  int            `json:"active"`
 	Queued  int            `json:"queued"`
 	PerUser map[string]int `json:"per_user,omitempty"`
+	// Providers is the RFC BF P2b per-provider gate breakdown, keyed by provider
+	// id. omitempty so the (common) no-max_concurrent deployment returns the
+	// leaner shape without a providers block.
+	Providers map[string]providerGateStat `json:"providers,omitempty"`
+}
+
+// providerGateStat is one gated provider's live counts in the stats response.
+type providerGateStat struct {
+	Active int `json:"active"`
+	Queued int `json:"queued"`
 }
 
 // handleConcurrencyStats serves a point-in-time snapshot of the
@@ -37,10 +47,19 @@ func (s *Server) handleConcurrencyStats(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	st := s.sem.Stats()
-	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(concurrencyStatsResponse{
+	resp := concurrencyStatsResponse{
 		Active:  st.Active,
 		Queued:  st.Queued,
 		PerUser: st.PerUser,
-	})
+	}
+	// RFC BF P2b: fold in the per-provider gate breakdown when any provider is
+	// capped. nil (no gates) leaves the field omitted.
+	if pg := s.providerGates.Stats(); len(pg) > 0 {
+		resp.Providers = make(map[string]providerGateStat, len(pg))
+		for id, gs := range pg {
+			resp.Providers[id] = providerGateStat{Active: gs.Active, Queued: gs.Queued}
+		}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
 }

--- a/internal/api/http/llm_gateway.go
+++ b/internal/api/http/llm_gateway.go
@@ -144,6 +144,16 @@ func (s *Server) prepareGatewayDispatch(w http.ResponseWriter, r *http.Request, 
 		return gatewayDispatch{}, false
 	}
 
+	// Per-provider concurrency gate (RFC BF P2b): acquire BEFORE the global slot
+	// so a request queued on a full per-provider cap doesn't hold a global slot.
+	// The gateway is a one-shot provider.Call (no loop fallback), so there's no
+	// slot to swap — just release both at dispatch end. Uncapped ⇒ noop.
+	provRelease, provErr := s.providerGates.Acquire(r.Context(), providerID)
+	if provErr != nil {
+		writeQuotaError(w, provErr)
+		return gatewayDispatch{}, false
+	}
+
 	// Per-subject quota acquisition. RFC L: when an authenticated
 	// principal is present its Subject is the authoritative fairness key
 	// (a caller can't forge a different user_id to dodge their cap); the
@@ -151,9 +161,15 @@ func (s *Server) prepareGatewayDispatch(w http.ResponseWriter, r *http.Request, 
 	// key bypasses the per-user cap (global semaphore only).
 	release, err := s.sem.AcquireForUser(r.Context(), auth.SubjectForFairness(r.Context(), req.UserID))
 	if err != nil {
+		provRelease()
 		writeQuotaError(w, err)
 		return gatewayDispatch{}, false
 	}
+	// Fold both slot releases into the single handle the caller defers, so the
+	// provider gate slot is freed alongside the global slot (provider acquired
+	// first, released last).
+	globalRelease := release
+	release = func() { globalRelease(); provRelease() }
 
 	provReq, err := llmRequestToProviderRequest(req, modelID, effort)
 	if err != nil {

--- a/internal/api/http/metrics_prom.go
+++ b/internal/api/http/metrics_prom.go
@@ -27,6 +27,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
 )
 
 // handleMetricsProm serves GET /metrics. Bearer-authed (middleware
@@ -86,6 +88,32 @@ func (s *Server) handleMetricsProm(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprintln(w)
 	}
 
+	// RFC BF P2b per-provider concurrency gates — only emitted when at least one
+	// provider sets max_concurrent (otherwise no gates exist and the series would
+	// be empty). Two gauges (slots in use + queue depth), labelled by provider,
+	// sorted for deterministic scrape output.
+	if pg := providerGateSnapshot(s); len(pg) > 0 {
+		provs := make([]string, 0, len(pg))
+		for id := range pg {
+			provs = append(provs, id)
+		}
+		sort.Strings(provs)
+		fmt.Fprintln(w, "# HELP loomcycle_provider_slots_in_use Runs currently holding a per-provider concurrency slot (providers.<id>.max_concurrent).")
+		fmt.Fprintln(w, "# TYPE loomcycle_provider_slots_in_use gauge")
+		for _, id := range provs {
+			labels := mergeLabels(replicaLabels, map[string]string{"provider": id})
+			fmt.Fprintf(w, "loomcycle_provider_slots_in_use%s %d\n", labels, pg[id].Active)
+		}
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "# HELP loomcycle_provider_queue_depth Runs waiting for a per-provider concurrency slot.")
+		fmt.Fprintln(w, "# TYPE loomcycle_provider_queue_depth gauge")
+		for _, id := range provs {
+			labels := mergeLabels(replicaLabels, map[string]string{"provider": id})
+			fmt.Fprintf(w, "loomcycle_provider_queue_depth%s %d\n", labels, pg[id].Queued)
+		}
+		fmt.Fprintln(w)
+	}
+
 	// Build info as a single-series gauge=1 with version metadata as
 	// labels. Standard Prometheus convention — operators alert on
 	// version churn or filter by version in a multi-replica cluster.
@@ -112,6 +140,15 @@ func semaphoreSnapshot(s *Server) (active, queued int, perUser map[string]int) {
 	}
 	stats := s.sem.Stats()
 	return stats.Active, stats.Queued, stats.PerUser
+}
+
+// providerGateSnapshot is a nil-safe view of the RFC BF P2b per-provider gates.
+// Returns nil when none are wired (the common case), so the gauges are omitted.
+func providerGateSnapshot(s *Server) map[string]concurrency.Stats {
+	if s == nil {
+		return nil
+	}
+	return s.providerGates.Stats()
 }
 
 // promReplicaLabels returns `{replica_id="..."}` when running in

--- a/internal/api/http/metrics_prom_test.go
+++ b/internal/api/http/metrics_prom_test.go
@@ -129,6 +129,41 @@ func TestMetricsProm_ReplicaIDLabelWhenSet(t *testing.T) {
 	}
 }
 
+// TestMetricsProm_ProviderGateSeries pins the RFC BF P2b per-provider gauges:
+// slots-in-use + queue-depth appear (labelled by provider) only when a provider
+// is capped, and stay absent otherwise (empty-series guard).
+func TestMetricsProm_ProviderGateSeries(t *testing.T) {
+	// No gates wired → the provider gauges must be absent.
+	srv := newMetricsPromServer(t, false)
+	rec := httptest.NewRecorder()
+	srv.handleMetricsProm(rec, httptest.NewRequest("GET", "/metrics", nil))
+	if strings.Contains(rec.Body.String(), "loomcycle_provider_slots_in_use") {
+		t.Errorf("provider gauges should be omitted when no provider is capped; body:\n%s", rec.Body.String())
+	}
+
+	// Cap provider "P" at 2 and hold one slot → slots_in_use{P}=1, queue_depth{P}=0.
+	gates := concurrency.NewProviderGates(map[string]int{"P": 2}, 4, time.Second)
+	srv.SetProviderGates(gates)
+	rel, err := gates.Acquire(t.Context(), "P")
+	if err != nil {
+		t.Fatalf("acquire P: %v", err)
+	}
+	defer rel()
+
+	rec = httptest.NewRecorder()
+	srv.handleMetricsProm(rec, httptest.NewRequest("GET", "/metrics", nil))
+	body := rec.Body.String()
+	if !strings.Contains(body, "# TYPE loomcycle_provider_slots_in_use gauge") {
+		t.Errorf("missing slots_in_use TYPE line; body:\n%s", body)
+	}
+	if !strings.Contains(body, `loomcycle_provider_slots_in_use{provider="P"} 1`) {
+		t.Errorf("expected slots_in_use{P}=1; body:\n%s", body)
+	}
+	if !strings.Contains(body, `loomcycle_provider_queue_depth{provider="P"} 0`) {
+		t.Errorf("expected queue_depth{P}=0; body:\n%s", body)
+	}
+}
+
 // TestMetricsProm_TextFormatShape pins the Prometheus exposition
 // format invariants: every metric line that isn't a comment must
 // match `<name>[{labels}] <value>` and every named series must have

--- a/internal/api/http/provider_gate.go
+++ b/internal/api/http/provider_gate.go
@@ -1,0 +1,111 @@
+// provider_gate.go — RFC BF P2b run-admission wiring for the per-provider
+// concurrency gate (internal/concurrency.ProviderGates).
+//
+// Admission ORDER is load-bearing: acquire the per-provider slot BEFORE the
+// global execution slot. A run blocked on a full per-provider cap must NOT
+// already hold a global slot, otherwise a capped provider's overflow would
+// starve runs targeting OTHER (uncapped) providers of global concurrency. An
+// uncapped provider acquires a noop and goes straight to the global slot — zero
+// overhead, no starvation. See the acquire sites in server.go (RunOnce /
+// handleRuns / handleMessages), resume.go, and llm_gateway.go.
+package http
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/runner"
+)
+
+// providerFallbackAcquireTimeout bounds how long a mid-run provider fallback
+// waits to acquire the NEW provider's gate slot. Short on purpose: a mid-run
+// block waiting on a saturated downstream cap is worse than briefly exceeding
+// that cap, so on timeout the run proceeds UNCAPPED for the swapped provider
+// (see providerSlot.swap). Long enough to admit past a brief burst.
+const providerFallbackAcquireTimeout = 2 * time.Second
+
+// providerSlot is the per-provider concurrency slot a single run currently
+// occupies (RFC BF P2b). The initial slot is acquired at admission; the
+// fallbackForRun reResolve closure calls swap() to move the slot when the run
+// fails over to another provider, so the gate counters track the provider
+// actually in use.
+//
+// Single-goroutine per run: acquisition, every swap (driven by loop.Run's
+// synchronous ReResolve callback), and the deferred release all execute in the
+// run's own goroutine, so no mutex is needed. The release is idempotent
+// (Semaphore.Acquire wraps its release in sync.Once, and noop is trivially
+// idempotent), so a defer + a swap that already released the old slot is safe.
+type providerSlot struct {
+	release    func()
+	providerID string
+}
+
+// releaseCurrent releases whatever provider slot the holder currently owns.
+// Deferred at each admission site; safe on a nil holder or before population
+// (resume.go creates the holder empty and fills it inside its goroutine).
+func (ps *providerSlot) releaseCurrent() {
+	if ps == nil || ps.release == nil {
+		return
+	}
+	ps.release()
+}
+
+// swap releases the current provider's gate slot and acquires newProviderID's,
+// under a SHORT bounded timeout. On timeout/backpressure it proceeds UNCAPPED (a
+// noop release) and logs a WARN — never blocks the mid-run fallback nor fails it
+// (RFC BF P2b Deliverable 4). No-op when the holder is nil (sub-agent /
+// interactive-detached runs, which never own a swappable slot) or when the
+// resolver returned the same provider (a same-provider/different-model retry
+// keeps its slot — releasing then re-acquiring could hand our only slot to a
+// competitor).
+func (ps *providerSlot) swap(ctx context.Context, gates *concurrency.ProviderGates, newProviderID string) {
+	if ps == nil || newProviderID == ps.providerID {
+		return
+	}
+	// Free the old provider's slot FIRST so a run queued on it can proceed; this
+	// also means we never hold two provider slots at once (no cross-gate
+	// deadlock).
+	ps.releaseCurrent()
+
+	swapCtx, cancel := context.WithTimeout(ctx, providerFallbackAcquireTimeout)
+	defer cancel()
+	rel, err := gates.Acquire(swapCtx, newProviderID)
+	if err != nil {
+		log.Printf("provider-gate: fallback %s->%s could not acquire the new slot within %s (%v); proceeding UNCAPPED for %s",
+			ps.providerID, newProviderID, providerFallbackAcquireTimeout, err, newProviderID)
+		ps.release = func() {}
+		ps.providerID = newProviderID
+		return
+	}
+	ps.release = rel
+	ps.providerID = newProviderID
+}
+
+// acquireProviderSlot reserves the per-provider concurrency slot for providerID
+// (RFC BF P2b). Returns a populated holder on success; on a saturated cap it
+// returns the raw *concurrency.ErrProviderConcurrencyExhausted so HTTP handlers
+// can hand it to writeQuotaError and RunOnce can reclassify via
+// providerAcquireErrToRunner. Uncapped providers get a noop holder with zero
+// overhead. Keeps the acquire identical across the admission sites.
+func (s *Server) acquireProviderSlot(ctx context.Context, providerID string) (*providerSlot, error) {
+	release, err := s.providerGates.Acquire(ctx, providerID)
+	if err != nil {
+		return nil, err
+	}
+	return &providerSlot{release: release, providerID: providerID}, nil
+}
+
+// providerAcquireErrToRunner maps a provider-gate acquire failure to the runner
+// sentinel vocabulary so RunOnce-driven surfaces (gRPC / MCP / connector /
+// scheduler / webhook) classify it uniformly. A saturated cap → 429/Resource
+// Exhausted; anything else (ctx cancel while queued) → ErrInternal, mirroring
+// how RunOnce already treats a non-backpressure global-slot error.
+func providerAcquireErrToRunner(err error) error {
+	if concurrency.IsProviderConcurrencyExhausted(err) {
+		return fmt.Errorf("%w: %v", runner.ErrProviderConcurrencyExhausted, err)
+	}
+	return fmt.Errorf("%w: %v", runner.ErrInternal, err)
+}

--- a/internal/api/http/provider_gate_admission_test.go
+++ b/internal/api/http/provider_gate_admission_test.go
@@ -1,0 +1,372 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// gateTestConfig returns a base config with two pinned agents: "capped" →
+// provider "capped-prov" and "uncapped" → provider "uncapped-prov". The gate
+// keys off the resolved provider id (= the agent's Provider pin), so this lets a
+// test cap one provider and leave another uncapped.
+func gateTestConfig() *config.Config {
+	cfg := makeBaseConfig()
+	cfg.Agents["capped"] = config.AgentDef{Provider: "capped-prov", Model: "m", Tools: []string{}}
+	cfg.Agents["uncapped"] = config.AgentDef{Provider: "uncapped-prov", Model: "m", Tools: []string{}}
+	return cfg
+}
+
+func gateRunBody(agent, userID string) string {
+	return `{"agent":"` + agent + `","user_id":"` + userID +
+		`","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`
+}
+
+// waitForGate polls a provider gate's Stats until (active,queued) match or the
+// deadline elapses — poll-until instead of a fixed sleep so -race doesn't flake.
+func waitForGate(t *testing.T, gates *concurrency.ProviderGates, id string, wantActive, wantQueued int, deadline time.Duration) {
+	t.Helper()
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		st := gates.Stats()[id]
+		if st.Active == wantActive && st.Queued == wantQueued {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	st := gates.Stats()[id]
+	t.Fatalf("waitForGate(%s): timed out; want active=%d queued=%d, got active=%d queued=%d",
+		id, wantActive, wantQueued, st.Active, st.Queued)
+}
+
+// TestProviderGate_CappedOverflowDoesNotHoldGlobalSlot is THE ordering guard:
+// with provider "capped-prov" capped at 1 and the global cap high, a first
+// capped run + an uncapped run both admit (2 global slots held); a SECOND capped
+// run queues on the PROVIDER gate and — critically — does NOT hold a global slot
+// (global active stays 2, gate queued 1). This proves the provider gate is
+// acquired BEFORE the global slot, so a saturated provider's overflow can't
+// starve runs targeting other providers.
+func TestProviderGate_CappedOverflowDoesNotHoldGlobalSlot(t *testing.T) {
+	prov := &pausableProvider{release: make(chan struct{}), finalText: "ok"}
+	cfg := gateTestConfig()
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "gate.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	sem := concurrency.New(8, 8, time.Second) // global cap high — never gates first
+	// Long queue timeout so the 2nd capped run STAYS queued while we observe it.
+	gates := concurrency.NewProviderGates(map[string]int{"capped-prov": 1}, 4, 5*time.Second)
+	srv := New(cfg, &stubResolver{p: prov}, []tools.Tool{}, sem, st)
+	srv.SetProviderGates(gates)
+	ts := httptest.NewServer(srv.Mux())
+
+	// Robust teardown: even if an assertion below fails (t.Fatalf), the held
+	// runs must be released so ts.Close() doesn't block on in-flight requests.
+	// Cleanups run LIFO — register ts.Close FIRST so the drain runs before it.
+	var wg sync.WaitGroup
+	var releaseOnce sync.Once
+	drain := func() { releaseOnce.Do(func() { close(prov.release) }) }
+	t.Cleanup(ts.Close)
+	t.Cleanup(func() { drain(); wg.Wait() })
+
+	post := func(agent, user string) {
+		resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(gateRunBody(agent, user)))
+		if err == nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+		}
+	}
+	// Run A: capped-prov, takes the single gate slot + a global slot.
+	wg.Add(1)
+	go func() { defer wg.Done(); post("capped", "a") }()
+	waitForGate(t, gates, "capped-prov", 1, 0, 2*time.Second)
+
+	// Run B: uncapped-prov, admits immediately (NOT starved) → global active 2.
+	wg.Add(1)
+	go func() { defer wg.Done(); post("uncapped", "b") }()
+	waitForActive(t, sem, 2, 2*time.Second)
+
+	// Run C: a SECOND capped-prov run — must queue on the provider gate.
+	wg.Add(1)
+	go func() { defer wg.Done(); post("capped", "c") }()
+	waitForGate(t, gates, "capped-prov", 1, 1, 2*time.Second)
+
+	// THE ASSERTION: C is queued on the gate but holds NO global slot — global
+	// active is still 2 (A + B), not 3. If the global slot were acquired before
+	// the gate, C would be occupying a 3rd global slot here.
+	if got := sem.Stats().Active; got != 2 {
+		t.Fatalf("global active = %d while a capped run is gate-queued; want 2 (queued run must NOT hold a global slot)", got)
+	}
+
+	drain()
+	wg.Wait()
+	if g := gates.Stats()["capped-prov"]; g.Active != 0 || g.Queued != 0 {
+		t.Errorf("final gate state active=%d queued=%d, want 0/0", g.Active, g.Queued)
+	}
+}
+
+// TestProviderGate_BatchesToCap — N > cap runs to a capped provider run at most
+// `cap` at a time through the FULL admission path; the observed peak concurrency
+// (measured inside provider.Call) equals the cap exactly (the operator's VRAM
+// goal). The rest queue and drain.
+func TestProviderGate_BatchesToCap(t *testing.T) {
+	const cap = 2
+	const total = 5
+	prov := &countingProvider{delay: 40 * time.Millisecond}
+	cfg := gateTestConfig()
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "batch.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	sem := concurrency.New(16, 16, 5*time.Second) // global never gates first
+	gates := concurrency.NewProviderGates(map[string]int{"capped-prov": cap}, total, 5*time.Second)
+	srv := New(cfg, &stubResolver{p: prov}, []tools.Tool{}, sem, st)
+	srv.SetProviderGates(gates)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	var wg sync.WaitGroup
+	for i := 0; i < total; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(gateRunBody("capped", "u")))
+			if err != nil {
+				t.Errorf("post: %v", err)
+				return
+			}
+			_, _ = io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+		}()
+	}
+	wg.Wait()
+
+	if peak := prov.peakInFlight(); peak != cap {
+		t.Errorf("peak concurrent provider.Call = %d, want exactly cap=%d", peak, cap)
+	}
+	if g := gates.Stats()["capped-prov"]; g.Active != 0 || g.Queued != 0 {
+		t.Errorf("final gate state active=%d queued=%d, want 0/0", g.Active, g.Queued)
+	}
+}
+
+// TestProviderGate_OverCapReturns429 — an over-cap admission past a full queue
+// returns HTTP 429 with code "provider_concurrency_exhausted" + Retry-After and
+// the provider/cap fields.
+func TestProviderGate_OverCapReturns429(t *testing.T) {
+	prov := &pausableProvider{release: make(chan struct{}), finalText: "ok"}
+	cfg := gateTestConfig()
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "429.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	sem := concurrency.New(8, 8, time.Second)
+	// cap 1, queue depth 0 → the 2nd run is refused immediately (deterministic).
+	gates := concurrency.NewProviderGates(map[string]int{"capped-prov": 1}, 0, time.Second)
+	srv := New(cfg, &stubResolver{p: prov}, []tools.Tool{}, sem, st)
+	srv.SetProviderGates(gates)
+	ts := httptest.NewServer(srv.Mux())
+
+	var wg sync.WaitGroup
+	var releaseOnce sync.Once
+	drain := func() { releaseOnce.Do(func() { close(prov.release) }) }
+	t.Cleanup(ts.Close)
+	t.Cleanup(func() { drain(); wg.Wait() })
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(gateRunBody("capped", "a")))
+		if err == nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+		}
+	}()
+	waitForGate(t, gates, "capped-prov", 1, 0, 2*time.Second)
+
+	// 2nd capped run: gate full (depth 0) → 429.
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(gateRunBody("capped", "b")))
+	if err != nil {
+		t.Fatalf("2nd post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("status = %d, want 429", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Retry-After"); got != "5" {
+		t.Errorf("Retry-After = %q, want 5", got)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	var parsed struct {
+		Code     string `json:"code"`
+		Provider string `json:"provider"`
+		Cap      int    `json:"cap"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, body)
+	}
+	if parsed.Code != "provider_concurrency_exhausted" || parsed.Provider != "capped-prov" || parsed.Cap != 1 {
+		t.Errorf("body = %+v, want code=provider_concurrency_exhausted provider=capped-prov cap=1", parsed)
+	}
+
+	drain()
+	wg.Wait()
+}
+
+// TestProviderGate_ZeroOverheadWhenUnconfigured — with no max_concurrent
+// anywhere, no gates are built and admission is the unchanged path: many
+// concurrent runs to the same provider all admit (only the global cap applies),
+// and the gate holder is a noop.
+func TestProviderGate_ZeroOverheadWhenUnconfigured(t *testing.T) {
+	prov := &countingProvider{delay: 20 * time.Millisecond}
+	cfg := gateTestConfig()
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "zero.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	sem := concurrency.New(8, 8, 5*time.Second)
+	// The default deployment: NewProviderGates with an empty caps map → zero gates.
+	gates := concurrency.NewProviderGates(map[string]int{}, 16, time.Second)
+	if gates.Len() != 0 {
+		t.Fatalf("expected 0 gates built, got %d", gates.Len())
+	}
+	srv := New(cfg, &stubResolver{p: prov}, []tools.Tool{}, sem, st)
+	srv.SetProviderGates(gates)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	const n = 5
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(gateRunBody("capped", "u")))
+			if err != nil {
+				t.Errorf("post: %v", err)
+				return
+			}
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("status = %d, want 200 (no gate should apply)", resp.StatusCode)
+			}
+			_, _ = io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+		}()
+	}
+	wg.Wait()
+
+	// No gate means no per-provider ceiling; peak is bounded only by the global
+	// cap, so all n overlapped (peak > 1 proves the path wasn't accidentally
+	// serialised). Gate stats stay empty.
+	if peak := prov.peakInFlight(); peak <= 1 {
+		t.Errorf("peak = %d; with no gate all %d runs should overlap (peak > 1)", peak, n)
+	}
+	if gates.Stats() != nil {
+		t.Errorf("gates.Stats() = %v, want nil (no gates configured)", gates.Stats())
+	}
+}
+
+// TestProviderSlot_SwapMovesSlotNoLeak covers the fallback slot handling
+// (Deliverable 4): swapping a run's provider slot from P to Q releases P's slot
+// and holds Q's, and after the final release BOTH gate counts return to 0 — no
+// leak. Also covers the same-provider no-op and the uncapped-target case.
+func TestProviderSlot_SwapMovesSlotNoLeak(t *testing.T) {
+	gates := concurrency.NewProviderGates(map[string]int{"P": 1, "Q": 1}, 2, time.Second)
+
+	slot, err := (&Server{providerGates: gates}).acquireProviderSlot(context.Background(), "P")
+	if err != nil {
+		t.Fatalf("acquire P: %v", err)
+	}
+	if g := gates.Stats()["P"]; g.Active != 1 {
+		t.Fatalf("P active = %d, want 1", g.Active)
+	}
+
+	// Same-provider swap is a no-op — keeps P's slot (a same-provider retry must
+	// not surrender its slot to a competitor).
+	slot.swap(context.Background(), gates, "P")
+	if g := gates.Stats()["P"]; g.Active != 1 {
+		t.Fatalf("after same-provider swap P active = %d, want 1 (kept)", g.Active)
+	}
+
+	// Swap P → Q: P released, Q acquired.
+	slot.swap(context.Background(), gates, "Q")
+	if gP, gQ := gates.Stats()["P"], gates.Stats()["Q"]; gP.Active != 0 || gQ.Active != 1 {
+		t.Fatalf("after P->Q swap: P active=%d (want 0) Q active=%d (want 1)", gP.Active, gQ.Active)
+	}
+	if slot.providerID != "Q" {
+		t.Errorf("holder providerID = %q, want Q", slot.providerID)
+	}
+
+	// Final release frees Q — no slot leaked on either gate.
+	slot.releaseCurrent()
+	if gP, gQ := gates.Stats()["P"], gates.Stats()["Q"]; gP.Active != 0 || gQ.Active != 0 {
+		t.Errorf("after release: P active=%d Q active=%d, want 0/0 (no leak)", gP.Active, gQ.Active)
+	}
+}
+
+// countingProvider records the peak number of concurrent provider.Call
+// executions — used to assert the gate limits real in-flight LLM calls to the
+// cap through the full admission + loop path.
+type countingProvider struct {
+	delay time.Duration
+
+	mu       sync.Mutex
+	inFlight int
+	peak     int
+}
+
+func (c *countingProvider) ID() string                    { return "counting" }
+func (c *countingProvider) Probe(_ context.Context) error { return nil }
+func (c *countingProvider) ListModels(_ context.Context) ([]string, error) {
+	return []string{"m"}, nil
+}
+func (c *countingProvider) Capabilities() providers.Capabilities {
+	return providers.Capabilities{Streaming: true}
+}
+func (c *countingProvider) Call(ctx context.Context, _ providers.Request) (<-chan providers.Event, error) {
+	c.mu.Lock()
+	c.inFlight++
+	if c.inFlight > c.peak {
+		c.peak = c.inFlight
+	}
+	c.mu.Unlock()
+	ch := make(chan providers.Event, 4)
+	go func() {
+		defer close(ch)
+		select {
+		case <-time.After(c.delay):
+		case <-ctx.Done():
+		}
+		c.mu.Lock()
+		c.inFlight--
+		c.mu.Unlock()
+		ch <- providers.Event{Type: providers.EventText, Text: "ok"}
+		ch <- providers.Event{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 1, OutputTokens: 1}}
+	}()
+	return ch, nil
+}
+func (c *countingProvider) peakInFlight() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.peak
+}

--- a/internal/api/http/resume.go
+++ b/internal/api/http/resume.go
@@ -303,7 +303,12 @@ func (s *Server) resumePausedRun(ctx context.Context, run store.Run) error {
 	loopCtx = tools.WithDispatcher(loopCtx, dispatcher)
 
 	heartbeat := s.makeHeartbeat(run.ID)
-	fbPolicy, fbReResolve := s.fallbackForRun(run.TenantID, run.UserID, run.Agent, run.UserTier, run.OperatorKeyRestricted)
+	// RFC BF P2b: the per-provider slot is acquired INSIDE the resume goroutine
+	// (below), after the fan-out reconcile, so the caller's resume loop never
+	// blocks on a full gate. Create the holder empty here so fallbackForRun's
+	// reResolve closure can capture it; it's populated before loop.Run runs.
+	provSlot := &providerSlot{}
+	fbPolicy, fbReResolve := s.fallbackForRun(run.TenantID, run.UserID, run.Agent, run.UserTier, run.OperatorKeyRestricted, provSlot)
 	gate, deregGate := s.newPauseGate(run.ID)
 	// RFC X Phase 3: a re-dispatched run that itself fans out can park too.
 	loopCtx = tools.WithPauseGate(loopCtx, gate)
@@ -372,6 +377,21 @@ func (s *Server) resumePausedRun(ctx context.Context, run store.Run) error {
 			}
 			runOpts.PriorMessages = append(runOpts.PriorMessages, toolResult)
 		}
+
+		// RFC BF P2b per-provider gate: acquire BEFORE the global slot (same
+		// ordering rationale as a fresh run) and AFTER the fan-out reconcile
+		// above (holding a provider slot while awaiting children could deadlock).
+		// Populate the holder so a mid-run fallback swaps the slot; released via
+		// the holder at run end. A saturated cap fails the resume loudly rather
+		// than silently un-resuming.
+		provRelease, provErr := s.providerGates.Acquire(runCtx, providerID)
+		if provErr != nil {
+			s.finishRunFailedReason(run.ID, "resume: acquire provider slot: "+provErr.Error(), meta)
+			return
+		}
+		provSlot.release = provRelease
+		provSlot.providerID = providerID
+		defer provSlot.releaseCurrent()
 
 		// Respect the per-tenant fairness semaphore so a boot that resumes many
 		// runs doesn't blow past MAX_CONCURRENT_RUNS. Acquired inside the

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -67,7 +67,14 @@ type Server struct {
 	providers ProviderResolver
 	tools     []tools.Tool
 	sem       *concurrency.Semaphore
-	store     store.Store // optional; nil means "don't persist"
+	// providerGates caps in-flight runs PER provider id (RFC BF P2b,
+	// providers.<id>.max_concurrent). Acquired at admission BEFORE the global
+	// sem so a run blocked on a full per-provider cap doesn't hold a global slot
+	// (see internal/api/http/provider_gate.go for the ordering rationale). nil /
+	// empty ⇒ every provider is uncapped and every Acquire is a noop (its methods
+	// are nil-safe). Wired at boot via SetProviderGates.
+	providerGates *concurrency.ProviderGates
+	store         store.Store // optional; nil means "don't persist"
 
 	// sqlMem is the RFC AA SQL Memory manager (per-scope sqlite databases
 	// backing the Memory tool's sql_query/sql_exec). Nil when the subsystem
@@ -919,6 +926,12 @@ func (s *Server) SessionLocks() *runner.SessionLockMap { return s.sessionLocks }
 // (cfg.ResolveAgentModel) — back-compat with v0.6.x.
 func (s *Server) SetResolver(r *resolve.Resolver) { s.resolver = r }
 
+// SetProviderGates wires the RFC BF P2b per-provider concurrency gates. Call
+// from cmd/loomcycle/main.go after building them from cfg.Providers. Optional:
+// when unset (nil), every provider is uncapped and admission is unchanged —
+// ProviderGates' methods are nil-safe.
+func (s *Server) SetProviderGates(g *concurrency.ProviderGates) { s.providerGates = g }
+
 // SetCredentialResolver wires the RFC AR credential resolver (env-var-name →
 // tenant/user credential value, scope agent>user>tenant). The Server stamps it
 // onto each run's ctx so provider drivers + WebSearch prefer a tenant-supplied
@@ -1075,6 +1088,9 @@ func writeResolveError(w http.ResponseWriter, err error) {
 //     The user has hit their personal cap; they specifically need to
 //     wait. Body carries `user_id` + `cap` so the adapter can surface
 //     it in error messages or rate-limit telemetry.
+//   - `code: "provider_concurrency_exhausted"` + `Retry-After: 5`. A
+//     specific provider's `max_concurrent` cap is saturated (RFC BF P2b).
+//     Body carries `provider` + `cap`; retry a different tier immediately.
 //   - `code: "backpressure"`. The global queue is full (or timed out).
 //     Operator-wide load signal; back off with longer jitter.
 //
@@ -1082,6 +1098,19 @@ func writeResolveError(w http.ResponseWriter, err error) {
 // shouldn't happen with the current AcquireForUser implementation but
 // the safe-default keeps a panic from surfacing as an opaque 200.
 func writeQuotaError(w http.ResponseWriter, err error) {
+	var pce *concurrency.ErrProviderConcurrencyExhausted
+	if errors.As(err, &pce) {
+		// RFC BF P2b: a specific provider's max_concurrent cap is saturated.
+		// 429 + Retry-After like per-user quota, but a distinct `code` +
+		// `provider`/`cap` fields so an adapter can retry a different tier
+		// immediately rather than backing off operator-wide.
+		w.Header().Set("Retry-After", "5")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		fmt.Fprintf(w, `{"code":"provider_concurrency_exhausted","error":%q,"provider":%q,"cap":%d}`,
+			pce.Error(), pce.Provider, pce.Cap)
+		return
+	}
 	var pue *concurrency.ErrPerUserQuotaExhausted
 	if errors.As(err, &pue) {
 		w.Header().Set("Retry-After", "5")
@@ -1909,7 +1938,12 @@ func (s *Server) ResolveChannelScope(ctx context.Context, channel string) (strin
 // On no-more-candidates the closure returns an error — the loop
 // then surfaces the ORIGINAL provider error to the caller (the
 // fallback path is terminal for this run).
-func (s *Server) fallbackForRun(tenantID, userID, agentName, userTier string, restricted bool) (loop.FallbackPolicy, func(ctx context.Context, failedProvider, failedModel string, cause error) (providers.Provider, string, string, error)) {
+// slot (RFC BF P2b) is the run's per-provider concurrency slot; on a committed
+// fallback the closure moves it from the failed provider to the new one so the
+// gate counters track the provider actually in use. nil for runs that hold no
+// swappable slot (sub-agents — they never take a provider slot — and
+// interactive-detached runs, which release their slots at hand-off).
+func (s *Server) fallbackForRun(tenantID, userID, agentName, userTier string, restricted bool, slot *providerSlot) (loop.FallbackPolicy, func(ctx context.Context, failedProvider, failedModel string, cause error) (providers.Provider, string, string, error)) {
 	overlay := s.userTierOverlay(userTier)
 	if overlay == nil || !overlay.FallbackOnError {
 		return loop.FallbackPolicy{}, nil
@@ -1942,6 +1976,16 @@ func (s *Server) fallbackForRun(tenantID, userID, agentName, userTier string, re
 		if err != nil {
 			return nil, "", "", err
 		}
+		// RFC BF P2b: move the per-provider concurrency slot to the fallback
+		// target so a capped provider's counter tracks the provider actually in
+		// use — releasing the failed provider's slot for a queued run there and
+		// (short-timeout) acquiring the new one. Done here rather than at the
+		// loop's commit point to keep the loop package free of admission
+		// concerns; in the rare case tryProviderFallback then refuses the switch
+		// (e.g. the RFC AT vision re-check), the run terminates and the deferred
+		// releaseCurrent frees the newly-acquired slot — a negligible transient
+		// on a failing run. No-op when slot is nil.
+		slot.swap(ctx, s.providerGates, newProviderID)
 		return newProvider, newModel, newEffort, nil
 	}
 	return policy, reResolve
@@ -2087,6 +2131,18 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	if err := s.pausedRunErr(); err != nil {
 		return err
 	}
+
+	// ---- Per-provider concurrency gate (RFC BF P2b) ----
+	// Acquire the provider slot BEFORE the global slot so a run blocked on a full
+	// per-provider cap doesn't already hold a global slot (which would starve
+	// runs targeting other, uncapped providers). Uncapped providers get a noop
+	// holder — zero overhead. The holder is threaded into fallbackForRun so a
+	// mid-run provider switch moves the slot with it.
+	provSlot, provErr := s.acquireProviderSlot(ctx, providerID)
+	if provErr != nil {
+		return providerAcquireErrToRunner(provErr)
+	}
+	defer provSlot.releaseCurrent()
 
 	// ---- Concurrency slot ----
 	acquireStart := time.Now()
@@ -2350,7 +2406,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	// fan-out parent can park mid-tool-call (no-op unless LOOMCYCLE_RESUME_FANOUT).
 	loopCtx = tools.WithPauseGate(loopCtx, gate)
 
-	fbPolicy, fbReResolve := s.fallbackForRun(effectiveTenantID, effectiveUserID, effectiveAgentName, in.UserTier, operatorKeyRestricted)
+	fbPolicy, fbReResolve := s.fallbackForRun(effectiveTenantID, effectiveUserID, effectiveAgentName, in.UserTier, operatorKeyRestricted, provSlot)
 	res, runErr := loop.Run(loopCtx, loop.RunOptions{
 		Provider:               provider,
 		Model:                  model,
@@ -3466,6 +3522,17 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Per-provider concurrency gate (RFC BF P2b): acquire BEFORE the global slot
+	// so a run queued on a full per-provider cap doesn't hold a global slot and
+	// starve uncapped-provider runs. Reported as 429 (provider_concurrency_
+	// exhausted) before the SSE stream opens. Uncapped ⇒ noop.
+	provSlot, provErr := s.acquireProviderSlot(r.Context(), providerID)
+	if provErr != nil {
+		writeQuotaError(w, provErr)
+		return
+	}
+	defer provSlot.releaseCurrent()
+
 	// Acquire concurrency slot first so backpressure is reported as 429
 	// before we open the SSE stream.
 	acquireStart := time.Now()
@@ -3798,7 +3865,16 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	// minutes → presumed dead). Cheap (~10–100 calls per run).
 	heartbeat := s.makeHeartbeat(runID)
 
-	fbPolicy, fbReResolve := s.fallbackForRun(req.TenantID, req.UserID, req.Agent, req.UserTier, operatorKeyRestricted)
+	// RFC BF P2b: an interactive run detaches into a goroutine that OUTLIVES this
+	// handler, and the deferred releaseCurrent frees the provider slot at
+	// hand-off (mirroring the global slot). Pass nil so the detached loop doesn't
+	// swap an already-released holder (which would acquire + leak a slot with no
+	// releaser). Synchronous runs get the real holder and swap on fallback.
+	fbSlot := provSlot
+	if req.Interactive && s.store != nil {
+		fbSlot = nil
+	}
+	fbPolicy, fbReResolve := s.fallbackForRun(req.TenantID, req.UserID, req.Agent, req.UserTier, operatorKeyRestricted, fbSlot)
 	runOpts := loop.RunOptions{
 		Provider:               provider,
 		Model:                  model,
@@ -4084,6 +4160,16 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Per-provider concurrency gate (RFC BF P2b): a continuation starts a new
+	// turn, so gate it too — before the global slot, same ordering rationale as a
+	// fresh run. Uncapped ⇒ noop.
+	provSlot, provErr := s.acquireProviderSlot(r.Context(), providerID)
+	if provErr != nil {
+		writeQuotaError(w, provErr)
+		return
+	}
+	defer provSlot.releaseCurrent()
+
 	// Acquire concurrency slot before opening the SSE stream so backpressure
 	// is reported as 429. user_id comes from the session (set at original
 	// creation); continuations don't accept a new user_id.
@@ -4336,7 +4422,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	defer deregGate()
 	// RFC X Phase 3: expose the gate to the Agent tool (parallel_spawn parent park).
 	loopCtx = tools.WithPauseGate(loopCtx, gate)
-	fbPolicy, fbReResolve := s.fallbackForRun(sess.TenantID, sess.UserID, sess.Agent, body.UserTier, operatorKeyRestricted)
+	fbPolicy, fbReResolve := s.fallbackForRun(sess.TenantID, sess.UserID, sess.Agent, body.UserTier, operatorKeyRestricted, provSlot)
 	loopRes, runErr := loop.Run(loopCtx, loop.RunOptions{
 		Provider:               provider,
 		Model:                  model,
@@ -5436,7 +5522,11 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 	// that itself parallel_spawns) can park mid-tool-call too.
 	subCtx = tools.WithPauseGate(subCtx, subGate)
 
-	fbPolicy, fbReResolve := s.fallbackForRun(tenantFromCtx(ctx), parentIdentity.UserID, name, parentTier, parentIdentity.OperatorKeyRestricted)
+	// RFC BF P2b: sub-agents take NO per-provider gate slot (they run under the
+	// parent's admission, never acquiring a global slot either). Gating them would
+	// risk a parent holding provider P's slot while awaiting children that queue
+	// on the same gate — a self-deadlock. nil slot ⇒ fallback doesn't swap.
+	fbPolicy, fbReResolve := s.fallbackForRun(tenantFromCtx(ctx), parentIdentity.UserID, name, parentTier, parentIdentity.OperatorKeyRestricted, nil)
 	res, runErr := loop.Run(subCtx, loop.RunOptions{
 		Provider:            provider,
 		Model:               model,

--- a/internal/api/webhook/server.go
+++ b/internal/api/webhook/server.go
@@ -500,7 +500,11 @@ func (rec *Receiver) spawnSetupErrorResponse(w http.ResponseWriter, err error) {
 		// same way (retry-next-window / raise-limit) rather than treating it as
 		// a transient 503 and retry-storming a budget-exhausted scope.
 		writeError(w, http.StatusTooManyRequests, "token_limit_exceeded", "")
-	case errors.Is(err, runner.ErrBackpressure), errors.Is(err, runner.ErrPerUserQuotaExhausted):
+	case errors.Is(err, runner.ErrBackpressure), errors.Is(err, runner.ErrPerUserQuotaExhausted),
+		errors.Is(err, runner.ErrProviderConcurrencyExhausted):
+		// Transient load (global queue / per-user cap / RFC BF P2b per-provider
+		// cap) → 503 so a webhook client retries with backoff rather than
+		// treating it as a permanent failure.
 		writeError(w, http.StatusServiceUnavailable, "runtime_unavailable", "")
 	default:
 		writeError(w, http.StatusServiceUnavailable, "runtime_unavailable", "")

--- a/internal/concurrency/provider_gates.go
+++ b/internal/concurrency/provider_gates.go
@@ -1,0 +1,152 @@
+// provider_gates.go — RFC BF P2b per-provider concurrency gate.
+//
+// A ProviderGates holds one counting Semaphore PER provider id. A provider whose
+// config sets `max_concurrent > 0` gets a gate that caps in-flight runs to that
+// provider (the rest queue in loomcycle, then 429); a provider with
+// max_concurrent 0/unset gets NO gate and Acquire is a zero-alloc noop — the
+// common, uncapped case. This is the per-provider analogue of the per-user cap
+// (WithPerUserCap): it deliberately reuses the same queue/timeout/backpressure
+// machinery rather than reinventing it.
+//
+// Admission acquires the provider gate BEFORE the global execution slot (see the
+// ordering rationale in internal/api/http RunOnce): a run blocked on a full
+// per-provider cap must not already hold a global slot, or a saturated provider's
+// overflow would starve runs targeting OTHER (uncapped) providers.
+package concurrency
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// noopRelease is the shared release func returned for uncapped providers. A
+// single package-level value avoids an allocation on the hot (uncapped) path.
+var noopRelease = func() {}
+
+// ErrProviderConcurrencyExhausted signals a provider's per-provider concurrency
+// cap (max_concurrent) rejected the run — that provider's queue was full or the
+// wait timed out. Distinct from BackpressureError (global queue) and
+// ErrPerUserQuotaExhausted (per-user cap) because the retry strategy differs: the
+// run targets a specific saturated provider, so a caller could retry a different
+// tier/provider immediately rather than backing off operator-wide.
+//
+// Callers should surface HTTP 429 + `Retry-After: 5` with
+// `code: "provider_concurrency_exhausted"` / gRPC ResourceExhausted.
+type ErrProviderConcurrencyExhausted struct {
+	Provider string
+	Cap      int
+}
+
+func (e *ErrProviderConcurrencyExhausted) Error() string {
+	return fmt.Sprintf("provider concurrency exhausted: provider=%s cap=%d", e.Provider, e.Cap)
+}
+
+// Code is the typed identifier used in the HTTP error envelope so adapter
+// consumers can branch retry strategies on the wire shape.
+func (e *ErrProviderConcurrencyExhausted) Code() string { return "provider_concurrency_exhausted" }
+
+// IsProviderConcurrencyExhausted reports whether err is an
+// *ErrProviderConcurrencyExhausted. Mirrors IsBackpressure /
+// IsPerUserQuotaExhausted.
+func IsProviderConcurrencyExhausted(err error) bool {
+	var e *ErrProviderConcurrencyExhausted
+	return errors.As(err, &e)
+}
+
+// ProviderGates maps a provider id → its concurrency gate. Only providers with a
+// positive cap have an entry; everything else is uncapped and Acquire short-
+// circuits to a noop. Immutable after NewProviderGates — safe for concurrent use
+// (the underlying Semaphores carry their own locking).
+type ProviderGates struct {
+	byID    map[string]*Semaphore
+	timeout time.Duration
+}
+
+// NewProviderGates builds one gate per provider id whose cap is > 0. queueDepth
+// and timeout are shared across all gates (the RFC BF P2b
+// LOOMCYCLE_PROVIDER_QUEUE_DEPTH / _TIMEOUT_MS knobs). A caps map with no
+// positive entry (the common case — no operator set max_concurrent) yields an
+// empty ProviderGates whose Acquire is always a noop: zero gates built, zero
+// overhead on the admission path.
+func NewProviderGates(caps map[string]int, queueDepth int, timeout time.Duration) *ProviderGates {
+	g := &ProviderGates{byID: make(map[string]*Semaphore, len(caps)), timeout: timeout}
+	for id, c := range caps {
+		if c > 0 {
+			// Per-user cap intentionally left off: this gate counts the GLOBAL
+			// in-flight runs to the provider, not per-user — the whole point is
+			// bounding total load against a shared resource (e.g. one GPU).
+			g.byID[id] = New(c, queueDepth, timeout)
+		}
+	}
+	return g
+}
+
+// Acquire reserves a slot for provider id. If no gate exists for id (uncapped —
+// the common case), returns the shared noop release + nil with zero contention.
+// If gated, blocks up to the queue timeout; a full queue / timeout maps to
+// *ErrProviderConcurrencyExhausted and a ctx cancel returns ctx.Err(). Nil-safe:
+// a nil *ProviderGates is always a noop, so a Server with no gates wired keeps
+// today's behaviour.
+//
+// Call the returned release exactly once when the run's use of the provider
+// ends. The Semaphore's release is idempotent (sync.Once), so a double call —
+// e.g. defer + a fallback slot-swap — is safe.
+func (g *ProviderGates) Acquire(ctx context.Context, id string) (release func(), err error) {
+	if g == nil {
+		return noopRelease, nil
+	}
+	sem, ok := g.byID[id]
+	if !ok {
+		return noopRelease, nil
+	}
+	// Empty userID → the per-user path is skipped; this counts the provider's
+	// GLOBAL in-flight total, which is exactly the semantics we want.
+	rel, aerr := sem.Acquire(ctx)
+	if aerr != nil {
+		// Queue full or per-acquire timeout → the provider's cap is saturated.
+		// Reclassify to the provider-typed error so wire surfaces emit the right
+		// 429 code; ctx cancel and any other error pass through unchanged.
+		if IsBackpressure(aerr) {
+			return nil, &ErrProviderConcurrencyExhausted{Provider: id, Cap: sem.maxConcurrent}
+		}
+		return nil, aerr
+	}
+	return rel, nil
+}
+
+// Has reports whether provider id is gated (has a positive cap). Used by the
+// admission fast-path and tests asserting the zero-overhead-when-unconfigured
+// guarantee.
+func (g *ProviderGates) Has(id string) bool {
+	if g == nil {
+		return false
+	}
+	_, ok := g.byID[id]
+	return ok
+}
+
+// Len returns the number of gated providers. Zero means fully uncapped.
+func (g *ProviderGates) Len() int {
+	if g == nil {
+		return 0
+	}
+	return len(g.byID)
+}
+
+// Stats returns a per-provider snapshot (active + queued) for every gated
+// provider, keyed by provider id. Nil when no gates are configured. Feeds the
+// loomcycle_provider_slots_in_use / _queue_depth Prometheus gauges + the
+// /v1/_concurrency/stats endpoint. The per-gate PerUser field is always nil
+// (this gate never does per-user accounting), so callers ignore it.
+func (g *ProviderGates) Stats() map[string]Stats {
+	if g == nil || len(g.byID) == 0 {
+		return nil
+	}
+	out := make(map[string]Stats, len(g.byID))
+	for id, sem := range g.byID {
+		out[id] = sem.Stats()
+	}
+	return out
+}

--- a/internal/concurrency/provider_gates_test.go
+++ b/internal/concurrency/provider_gates_test.go
@@ -1,0 +1,189 @@
+package concurrency
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestProviderGates_CapsConcurrentToN — a provider capped at N admits exactly N
+// concurrent acquisitions; the N+1th (with no queue room) is refused with the
+// typed *ErrProviderConcurrencyExhausted carrying the provider id + cap.
+func TestProviderGates_CapsConcurrentToN(t *testing.T) {
+	// cap=2, queueDepth=0 so the 3rd acquire is refused immediately rather than
+	// queuing — keeps the "peak == cap" assertion deterministic.
+	g := NewProviderGates(map[string]int{"p": 2}, 0, 50*time.Millisecond)
+
+	rel1, err := g.Acquire(context.Background(), "p")
+	if err != nil {
+		t.Fatalf("acquire 1: %v", err)
+	}
+	rel2, err := g.Acquire(context.Background(), "p")
+	if err != nil {
+		t.Fatalf("acquire 2: %v", err)
+	}
+	if st := g.Stats()["p"]; st.Active != 2 {
+		t.Fatalf("active = %d, want 2", st.Active)
+	}
+
+	// 3rd exceeds the cap and the queue has no room → typed refusal.
+	_, err = g.Acquire(context.Background(), "p")
+	if !IsProviderConcurrencyExhausted(err) {
+		t.Fatalf("3rd acquire err = %v, want ErrProviderConcurrencyExhausted", err)
+	}
+	var pce *ErrProviderConcurrencyExhausted
+	if !asProviderErr(err, &pce) {
+		t.Fatalf("err is not *ErrProviderConcurrencyExhausted: %v", err)
+	}
+	if pce.Provider != "p" || pce.Cap != 2 {
+		t.Errorf("typed err provider=%q cap=%d, want p / 2", pce.Provider, pce.Cap)
+	}
+	if pce.Code() != "provider_concurrency_exhausted" {
+		t.Errorf("Code() = %q", pce.Code())
+	}
+
+	// Releasing one frees a slot for a fresh acquire.
+	rel1()
+	rel3, err := g.Acquire(context.Background(), "p")
+	if err != nil {
+		t.Fatalf("acquire after release: %v", err)
+	}
+	rel2()
+	rel3()
+	if st := g.Stats()["p"]; st.Active != 0 {
+		t.Errorf("final active = %d, want 0", st.Active)
+	}
+}
+
+// TestProviderGates_QueueThenTimeoutReturnsTypedError — with queue room, an
+// over-cap acquire waits then times out (no releaser arrives) and returns the
+// typed error rather than blocking forever.
+func TestProviderGates_QueueThenTimeoutReturnsTypedError(t *testing.T) {
+	g := NewProviderGates(map[string]int{"p": 1}, 4, 30*time.Millisecond)
+	rel, err := g.Acquire(context.Background(), "p")
+	if err != nil {
+		t.Fatalf("acquire 1: %v", err)
+	}
+	defer rel()
+
+	start := time.Now()
+	_, err = g.Acquire(context.Background(), "p")
+	if !IsProviderConcurrencyExhausted(err) {
+		t.Fatalf("queued acquire err = %v, want ErrProviderConcurrencyExhausted", err)
+	}
+	if elapsed := time.Since(start); elapsed < 20*time.Millisecond {
+		t.Errorf("returned after %s, expected to wait ~the queue timeout (30ms)", elapsed)
+	}
+}
+
+// TestProviderGates_BatchesToCap — N runs (> cap) resolving to a capped provider
+// run at most `cap` at a time; the rest queue and drain in batches. The observed
+// peak concurrency equals the cap exactly (the operator's VRAM goal).
+func TestProviderGates_BatchesToCap(t *testing.T) {
+	const cap = 2
+	const total = 6
+	// Generous queue + timeout so every run eventually admits (none refused).
+	g := NewProviderGates(map[string]int{"p": cap}, total, 2*time.Second)
+
+	var mu sync.Mutex
+	inFlight, peak := 0, 0
+	var wg sync.WaitGroup
+	for i := 0; i < total; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rel, err := g.Acquire(context.Background(), "p")
+			if err != nil {
+				t.Errorf("acquire: %v", err)
+				return
+			}
+			mu.Lock()
+			inFlight++
+			if inFlight > peak {
+				peak = inFlight
+			}
+			mu.Unlock()
+			time.Sleep(20 * time.Millisecond) // simulate the provider call
+			mu.Lock()
+			inFlight--
+			mu.Unlock()
+			rel()
+		}()
+	}
+	wg.Wait()
+
+	if peak != cap {
+		t.Errorf("peak concurrency = %d, want exactly cap=%d", peak, cap)
+	}
+	if st := g.Stats()["p"]; st.Active != 0 || st.Queued != 0 {
+		t.Errorf("final gate state active=%d queued=%d, want 0/0", st.Active, st.Queued)
+	}
+}
+
+// TestProviderGates_UncappedProviderIsNoop — a provider with no gate (cap
+// unset/0) never queues: Acquire returns a usable noop release immediately, no
+// matter how many are outstanding.
+func TestProviderGates_UncappedProviderIsNoop(t *testing.T) {
+	// Only "capped" is gated; "free" has no entry.
+	g := NewProviderGates(map[string]int{"capped": 1, "free": 0}, 0, time.Second)
+	if g.Has("free") {
+		t.Fatal("free should not be gated (cap 0)")
+	}
+	for i := 0; i < 100; i++ {
+		rel, err := g.Acquire(context.Background(), "free")
+		if err != nil {
+			t.Fatalf("uncapped acquire %d: %v", i, err)
+		}
+		if rel == nil {
+			t.Fatalf("uncapped acquire %d returned nil release", i)
+		}
+		// Deliberately do NOT release between iterations — an uncapped provider
+		// must never queue or refuse on outstanding count.
+	}
+	if st := g.Stats()["free"]; st.Active != 0 {
+		t.Errorf("uncapped provider recorded active=%d, want 0 (no accounting)", st.Active)
+	}
+}
+
+// TestProviderGates_NoCapsBuildsNoGates — the zero-overhead-when-unconfigured
+// guarantee: a caps map with no positive entry builds ZERO gates, and Acquire is
+// a noop for every id. This is the default deployment (no operator set
+// max_concurrent).
+func TestProviderGates_NoCapsBuildsNoGates(t *testing.T) {
+	g := NewProviderGates(map[string]int{"a": 0, "b": 0}, 16, time.Second)
+	if g.Len() != 0 {
+		t.Fatalf("Len = %d, want 0 gates built", g.Len())
+	}
+	if g.Stats() != nil {
+		t.Errorf("Stats = %v, want nil when no gates", g.Stats())
+	}
+	rel, err := g.Acquire(context.Background(), "a")
+	if err != nil || rel == nil {
+		t.Fatalf("Acquire on ungated id: rel==nil=%v err=%v, want noop+nil", rel == nil, err)
+	}
+}
+
+// TestProviderGates_NilIsNoop — a nil *ProviderGates (a Server with none wired)
+// is fully inert: every method is safe and Acquire is a noop.
+func TestProviderGates_NilIsNoop(t *testing.T) {
+	var g *ProviderGates
+	if g.Has("x") || g.Len() != 0 || g.Stats() != nil {
+		t.Errorf("nil gates not inert: has=%v len=%d stats=%v", g.Has("x"), g.Len(), g.Stats())
+	}
+	rel, err := g.Acquire(context.Background(), "x")
+	if err != nil || rel == nil {
+		t.Fatalf("nil Acquire: rel==nil=%v err=%v, want noop+nil", rel == nil, err)
+	}
+	rel() // must not panic
+}
+
+// asProviderErr is a tiny errors.As wrapper kept local to the test so the assert
+// above reads cleanly.
+func asProviderErr(err error, target **ErrProviderConcurrencyExhausted) bool {
+	e, ok := err.(*ErrProviderConcurrencyExhausted)
+	if ok {
+		*target = e
+	}
+	return ok
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1943,11 +1943,40 @@ type Concurrency struct {
 	// `code: "per_user_quota_exhausted"` + `Retry-After: 5`.
 	// Env: LOOMCYCLE_MAX_CONCURRENT_RUNS_PER_USER.
 	MaxConcurrentRunsPerUser int `yaml:"max_concurrent_runs_per_user"`
+	// ProviderQueueDepth is the queue depth of each RFC BF P2b per-provider
+	// concurrency gate (max_concurrent). 0 (default) = inherit MaxQueueDepth, so
+	// a provider cap queues the same way the global semaphore does. Only used by
+	// providers whose `max_concurrent` > 0.
+	// Env: LOOMCYCLE_PROVIDER_QUEUE_DEPTH.
+	ProviderQueueDepth int `yaml:"provider_queue_depth"`
+	// ProviderQueueTimeoutMS is the per-acquire wait cap of each per-provider
+	// gate before it returns provider_concurrency_exhausted (429). 0 (default) =
+	// inherit QueueTimeoutMS.
+	// Env: LOOMCYCLE_PROVIDER_QUEUE_TIMEOUT_MS.
+	ProviderQueueTimeoutMS int `yaml:"provider_queue_timeout_ms"`
 }
 
 // QueueTimeout returns QueueTimeoutMS as a duration.
 func (c Concurrency) QueueTimeout() time.Duration {
 	return time.Duration(c.QueueTimeoutMS) * time.Millisecond
+}
+
+// ProviderQueueDepthOrDefault returns the per-provider gate queue depth,
+// inheriting the global MaxQueueDepth when unset (RFC BF P2b).
+func (c Concurrency) ProviderQueueDepthOrDefault() int {
+	if c.ProviderQueueDepth > 0 {
+		return c.ProviderQueueDepth
+	}
+	return c.MaxQueueDepth
+}
+
+// ProviderQueueTimeout returns the per-provider gate per-acquire timeout,
+// inheriting the global QueueTimeout() when unset (RFC BF P2b).
+func (c Concurrency) ProviderQueueTimeout() time.Duration {
+	if c.ProviderQueueTimeoutMS > 0 {
+		return time.Duration(c.ProviderQueueTimeoutMS) * time.Millisecond
+	}
+	return c.QueueTimeout()
 }
 
 // CacheConfig is the cache layer config; v0.1 only honours .Native.Enabled.
@@ -3383,6 +3412,21 @@ func LoadLayers(layers ...Layer) (*Config, error) {
 			} else {
 				cfg.Concurrency.MaxConcurrentRunsPerUser = n
 			}
+		}
+	}
+
+	// RFC BF P2b — per-provider gate tuning. Both default to the global
+	// concurrency knobs (see ProviderQueueDepthOrDefault / ProviderQueueTimeout);
+	// these env overrides let a containerized operator tune the gate without
+	// editing mounted yaml. Negative values are ignored (keep the inherit-0).
+	if v := strings.TrimSpace(os.Getenv("LOOMCYCLE_PROVIDER_QUEUE_DEPTH")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			cfg.Concurrency.ProviderQueueDepth = n
+		}
+	}
+	if v := strings.TrimSpace(os.Getenv("LOOMCYCLE_PROVIDER_QUEUE_TIMEOUT_MS")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			cfg.Concurrency.ProviderQueueTimeoutMS = n
 		}
 	}
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -88,6 +88,14 @@ var (
 	// Wire: HTTP 429 + Retry-After: 5 / gRPC ResourceExhausted.
 	// (v0.10.1)
 	ErrPerUserQuotaExhausted = errors.New("per_user_quota_exhausted")
+	// ErrProviderConcurrencyExhausted — a per-provider concurrency cap
+	// (providers.<id>.max_concurrent, RFC BF P2b) rejected the run: that
+	// provider's in-flight count is at cap and its queue is full/timed out.
+	// Distinct from ErrBackpressure (global queue) because the run targets a
+	// specific saturated provider — a caller could retry a different tier
+	// immediately rather than backing off operator-wide.
+	// Wire: HTTP 429 + Retry-After: 5 / gRPC ResourceExhausted.
+	ErrProviderConcurrencyExhausted = errors.New("provider_concurrency_exhausted")
 	// ErrRuntimePaused — a runtime-wide pause (POST /v1/_pause) is in
 	// effect, so new runs are not admitted (RFC X / F41). The runtime is
 	// quiescing for a snapshot; retry after resume. Wire: HTTP 503 / gRPC

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -321,6 +321,12 @@ func (s *Scheduler) fireOne(ctx context.Context, row store.ScheduleDueRow, now t
 		if errors.Is(runErr, runner.ErrPerUserQuotaExhausted) {
 			status = "skipped"
 		}
+		// RFC BF P2b: a per-provider cap refusal is transient load, not a run
+		// failure — label it "skipped" like the other backpressure flavors so a
+		// saturated provider doesn't burn the schedule's max_fires budget.
+		if errors.Is(runErr, runner.ErrProviderConcurrencyExhausted) {
+			status = "skipped"
+		}
 		if errors.Is(runErr, runner.ErrUnknownAgent) {
 			countAsFire = false
 			s.logf("scheduler: schedule %q could not resolve agent %q in tenant %q — not counting toward max_fires; check the agent exists in this tenant (F38)",


### PR DESCRIPTION
## Why

This is **P2b** of the config-driven LLM provider registry (RFC BF). P1 (schema + driver registry) and P2a (config-driven resolver + embedded default layer) are merged; the `max_concurrent` field already exists on `ProviderConfig`. P2b makes it real: **≤N runs to a given provider execute at once; the rest queue in loomcycle** (folding in the original per-provider-concurrency ask). The motivating case is a VRAM-bound local model — `ollama-local: 2` → at most 2 local runs in flight, no context-swapping thrash.

## What

- **`concurrency.ProviderGates`** — one counting `Semaphore` per provider id (built from `providers.<id>.max_concurrent`), reusing the existing per-user queue/timeout/backpressure machinery. A provider with `max_concurrent` 0/unset gets **no gate** — `Acquire` returns a shared noop with zero contention (the common, uncapped path). Nil-safe. Queue depth + timeout come from new `LOOMCYCLE_PROVIDER_QUEUE_DEPTH` / `LOOMCYCLE_PROVIDER_QUEUE_TIMEOUT_MS` knobs, defaulting to the global `max_queue_depth` / `queue_timeout_ms`.
- **Typed error → 429** — `runner.ErrProviderConcurrencyExhausted` / `concurrency.ErrProviderConcurrencyExhausted`. HTTP 429 `code: "provider_concurrency_exhausted"` + `Retry-After: 5` + `provider`/`cap` fields; gRPC `ResourceExhausted`; webhook 503 (transient); scheduler `skipped` (doesn't burn `max_fires`).
- **Admission ordering (the load-bearing part)** — the per-provider slot is acquired **BEFORE** the global execution slot at every real-slot site (`RunOnce`, `handleRuns`, `handleMessages`, `resume`, `llm_gateway`), after the pause gate. **Rationale:** a run blocked on a full per-provider cap must not already hold a global slot, or a saturated provider's overflow would starve runs targeting other, uncapped providers. Uncapped providers acquire a noop and go straight to the global slot — no starvation, no overhead. Factored into `acquireProviderSlot` for consistency. *Embeddings are not gated — they call the embedder directly with no chat provider id.*
- **Fallback slot swap (target design)** — a mutable `providerSlot` holder is threaded into `fallbackForRun`; on a committed provider switch the reResolve closure releases the failed provider's slot and (short bounded timeout) acquires the new one, so gate counters track the provider actually in use. On new-slot timeout it proceeds **UNCAPPED + WARN** rather than blocking a mid-run fallback. Sub-agents pass a `nil` holder (they never take a global slot — gating them could deadlock a parent against its own children on the same gate); interactive-*detached* runs also pass `nil` (they release their slots at hand-off, mirroring the global slot). No leak, no deadlock, uncapped runs untouched.
- **Metrics (runtime-only)** — `loomcycle_provider_slots_in_use{provider}` + `loomcycle_provider_queue_depth{provider}` gauges on `/metrics`, and an additive `providers` block on `/v1/_concurrency/stats`, both emitted only when a provider is capped.

### Zero-overhead guarantee
No `max_concurrent` anywhere ⇒ zero gates built ⇒ every `Acquire` is a noop and admission is byte-identical to pre-P2b.

### Deferred
The RFC §4.6 `provider_wait` SSE/gRPC event is **deferred** to a later PR — it's cross-transport and would force an adapter version bump. P2b stays wire-stable (no adapter lockstep; adapters/README/REVISIONS untouched).

## What was tested

- `go build ./...`, `make build-all`, `go vet ./...`, `gofmt -l` — all clean.
- `go test -race ./...` — full suite green.
- **Unit** (`internal/concurrency`): `TestProviderGates_CapsConcurrentToN`, `TestProviderGates_QueueThenTimeoutReturnsTypedError`, `TestProviderGates_BatchesToCap`, `TestProviderGates_UncappedProviderIsNoop`, `TestProviderGates_NoCapsBuildsNoGates`, `TestProviderGates_NilIsNoop`.
- **Admission ordering (the critical guard)**: `TestProviderGate_CappedOverflowDoesNotHoldGlobalSlot` — a gate-queued capped run holds **no** global slot while an uncapped run admits immediately. Verified fail-before: reversing the acquire order makes it fail (`global active = 3 ... want 2`).
- **Batching**: `TestProviderGate_BatchesToCap` — peak concurrent `provider.Call` through the full admission path == cap.
- **429 shape**: `TestProviderGate_OverCapReturns429`.
- **Zero-overhead**: `TestProviderGate_ZeroOverheadWhenUnconfigured`.
- **Fallback no-leak**: `TestProviderSlot_SwapMovesSlotNoLeak` — gate counts return to 0 after a P→Q swap.
- **Metrics**: `TestMetricsProm_ProviderGateSeries`.
- **Manual**: booted `./bin/loomcycle` with `providers: { mock: { driver: mock, max_concurrent: 2 } }` + a mock-pinned agent (1.5s mock latency), fired 4 concurrent runs → `/v1/_concurrency/stats` showed `providers.mock {active:2, queued:2}` with **global `active:2` (not 4)** — the 2 queued runs did **not** hold global slots — draining to 0. Boot log: `providers: per-provider concurrency caps enabled — mock=2 (queue_depth=16 timeout=30s)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD