### PR TITLE
feat(providers): P2c — deadlock-aware sub-agent per-provider gating

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -3200,6 +3200,19 @@ func toDriverOptions(id string, pc config.ProviderConfig, cfg *config.Config) pr
 		if baseURL == "" {
 			baseURL = cfg.Env.GeminiBaseURL
 		}
+	case "code-js":
+		// RFC BF P2a regression fix (b8d3f42d line): the code-js driver factory
+		// (codejs.newFromOptions) sources code_root/deterministic/run_timeout_seconds
+		// from this options map — but P2a's flip to the registry never ported the
+		// pre-P2a codejs.New(Config{CodeRoot: cfg.Env.CodeAgentsRoot, ...}) mapping,
+		// so with no `providers: code-js: options:` block the compiler root was empty
+		// and EVERY static `provider: code-js` agent failed to load ("no index.js at
+		// <name>/index.js" — a relative path, the empty-root tell). CodeAgentsRoot
+		// defaults to ./agent_code (never empty), so this is byte-identical to
+		// pre-P2a; an explicit options entry still wins via the pc.Options merge below.
+		opts["code_root"] = cfg.Env.CodeAgentsRoot
+		opts["deterministic"] = cfg.Env.CodeAgentsDeterministic
+		opts["run_timeout_seconds"] = int(cfg.Env.CodeAgentsRunTimeout / time.Second)
 	}
 	// Operator-declared options override the env-derived defaults (e.g. mock-stable's
 	// `stable: true`, or a per-provider num_ctx).

--- a/cmd/loomcycle/providers_p2a_test.go
+++ b/cmd/loomcycle/providers_p2a_test.go
@@ -199,6 +199,39 @@ func TestToDriverOptions_PortsEnvBaseURLsAndTimeouts(t *testing.T) {
 	}
 }
 
+// TestToDriverOptions_CodeJSPortsEnvRoot is the regression for the P2a code-js
+// boot break: the switch in toDriverOptions ported the ollama/deepseek/gemini env
+// defaults but NOT code-js, so the driver factory (codejs.newFromOptions) got no
+// code_root and built a compiler with an empty root — every static `provider:
+// code-js` agent then failed to load ("no index.js at <name>/index.js", a
+// relative path = the empty-root tell), crash-looping boot (the "Runtime suites
+// (code-js)" CI job). This asserts the three code-js env knobs are ported into
+// the driver options.
+//
+// Fail-before: drop the `case "code-js"` in toDriverOptions and code_root is
+// absent (StringOption ok=false) → this fails.
+func TestToDriverOptions_CodeJSPortsEnvRoot(t *testing.T) {
+	t.Setenv("LOOMCYCLE_CODE_AGENTS_ROOT", "/srv/agent_code")
+	t.Setenv("LOOMCYCLE_CODE_AGENTS_DETERMINISTIC", "1")
+	t.Setenv("LOOMCYCLE_CODE_AGENTS_RUN_TIMEOUT_SECONDS", "45")
+
+	cfg := loadDefaultProvidersOnly(t)
+	if cfg.Env.CodeAgentsRoot != "/srv/agent_code" {
+		t.Fatalf("cfg.Env.CodeAgentsRoot = %q, want /srv/agent_code (env not parsed?)", cfg.Env.CodeAgentsRoot)
+	}
+
+	opts := toDriverOptions("code-js", cfg.Providers["code-js"], cfg)
+	if root, ok := providers.StringOption(opts.Options, "code_root"); !ok || root != "/srv/agent_code" {
+		t.Errorf("code-js code_root option = %q (ok=%v), want /srv/agent_code — without it the compiler root is empty and every static code agent fails to load", root, ok)
+	}
+	if det, _ := providers.BoolOption(opts.Options, "deterministic"); !det {
+		t.Errorf("code-js deterministic option = false, want true (LOOMCYCLE_CODE_AGENTS_DETERMINISTIC=1)")
+	}
+	if secs, ok := providers.IntOption(opts.Options, "run_timeout_seconds"); !ok || secs != 45 {
+		t.Errorf("code-js run_timeout_seconds = %d (ok=%v), want 45", secs, ok)
+	}
+}
+
 // TestGet_MockStable_IsStableVariant proves mock-stable, built through the driver
 // registry with `options: {stable: true}` (from the default-providers layer),
 // reports the right id — the config-driven replacement for the pre-P2a

--- a/internal/api/http/provider_gate.go
+++ b/internal/api/http/provider_gate.go
@@ -41,6 +41,12 @@ const providerFallbackAcquireTimeout = 2 * time.Second
 type providerSlot struct {
 	release    func()
 	providerID string
+	// noop marks a P2c deadlock carve-out holder: an ANCESTOR in this run tree
+	// already holds providerID's gate slot, so this run runs UNGATED (acquiring
+	// again would make the ancestor await its own descendant behind the same cap).
+	// A noop holder never acquired a gate — swap() and releaseCurrent() are inert
+	// on it, and it deliberately stays ungated even across a mid-run fallback.
+	noop bool
 }
 
 // releaseCurrent releases whatever provider slot the holder currently owns.
@@ -60,9 +66,13 @@ func (ps *providerSlot) releaseCurrent() {
 // interactive-detached runs, which never own a swappable slot) or when the
 // resolver returned the same provider (a same-provider/different-model retry
 // keeps its slot — releasing then re-acquiring could hand our only slot to a
-// competitor).
+// competitor). No-op too on a P2c carve-out holder (ps.noop): that run is
+// deliberately ungated because an ancestor holds the provider, and it must stay
+// ungated across a fallback — acquiring the fallback target's gate here could
+// reintroduce the parent-awaiting-its-own-descendant deadlock the carve-out
+// exists to prevent.
 func (ps *providerSlot) swap(ctx context.Context, gates *concurrency.ProviderGates, newProviderID string) {
-	if ps == nil || newProviderID == ps.providerID {
+	if ps == nil || ps.noop || newProviderID == ps.providerID {
 		return
 	}
 	// Free the old provider's slot FIRST so a run queued on it can proceed; this
@@ -85,17 +95,54 @@ func (ps *providerSlot) swap(ctx context.Context, gates *concurrency.ProviderGat
 }
 
 // acquireProviderSlot reserves the per-provider concurrency slot for providerID
-// (RFC BF P2b). Returns a populated holder on success; on a saturated cap it
+// (RFC BF P2b/P2c). Returns a populated holder on success; on a saturated cap it
 // returns the raw *concurrency.ErrProviderConcurrencyExhausted so HTTP handlers
 // can hand it to writeQuotaError and RunOnce can reclassify via
 // providerAcquireErrToRunner. Uncapped providers get a noop holder with zero
 // overhead. Keeps the acquire identical across the admission sites.
+//
+// P2c deadlock carve-out: when an ANCESTOR in this run tree already holds
+// providerID's gate slot (holdsProviderSlot), this run runs UNGATED — a noop
+// holder, no gate touched. Gating it would let a fan-out parent await its own
+// descendant queued behind the same cap (a self-deadlock). At the top-level
+// admission sites the held-set is always empty, so the carve-out never fires and
+// behavior is byte-identical to P2b; it fires only for sub-agents whose provider
+// their parent already holds.
+//
+// A run that DOES take a real slot must run its protected work under
+// heldSlotCtx(ctx, slot) so descendants see providerID as held (that stamp is a
+// separate call, not folded in here, so the interactive-detach path — which
+// releases its slot at hand-off — can opt out).
 func (s *Server) acquireProviderSlot(ctx context.Context, providerID string) (*providerSlot, error) {
+	if holdsProviderSlot(ctx, providerID) {
+		return &providerSlot{noop: true}, nil
+	}
 	release, err := s.providerGates.Acquire(ctx, providerID)
 	if err != nil {
 		return nil, err
 	}
 	return &providerSlot{release: release, providerID: providerID}, nil
+}
+
+// heldSlotCtx augments ctx with slot's provider in the ancestor-held set (P2c)
+// so descendants spawned under the returned ctx take the deadlock carve-out for
+// that provider. It stamps ONLY when the slot is a real CAPPED holder that
+// persists for the loop it guards:
+//   - a nil / carve-out (noop) / empty holder holds no fresh gate → ctx unchanged;
+//   - an UNCAPPED provider has no gate at all → nothing for a descendant to skip,
+//     so ctx is returned unchanged, preserving P2b's zero-overhead-when-uncapped.
+//
+// Callers wrap the ctx passed to loop.Run with this. A run whose slot is released
+// before its loop runs (the interactive-detached top-level run) deliberately does
+// NOT call this — its descendants gate normally because nothing is held.
+func (s *Server) heldSlotCtx(ctx context.Context, slot *providerSlot) context.Context {
+	if slot == nil || slot.noop || slot.providerID == "" {
+		return ctx
+	}
+	if !s.providerGates.Has(slot.providerID) {
+		return ctx
+	}
+	return withHeldProviderSlot(ctx, slot.providerID)
 }
 
 // providerAcquireErrToRunner maps a provider-gate acquire failure to the runner

--- a/internal/api/http/provider_gate_subagent_test.go
+++ b/internal/api/http/provider_gate_subagent_test.go
@@ -1,0 +1,427 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// multiResolver maps a resolved provider id to a DISTINCT provider instance, so
+// a test can give a parent and its sub-agents different scripted providers while
+// each still resolves to its own gate key. (stubResolver returns one instance for
+// every id — fine when the gate key is all that matters, but the sub-agent tests
+// need the parent + children to behave differently per call.)
+type multiResolver struct{ byID map[string]providers.Provider }
+
+func (r *multiResolver) Get(id string) (providers.Provider, error) {
+	if p, ok := r.byID[id]; ok {
+		return p, nil
+	}
+	return nil, fmt.Errorf("no provider %q", id)
+}
+
+// --- P2c ctx held-set primitives (pure unit tests) ---
+
+// TestWithHeldProviderSlot_CopyOnAddIndependentSupersets locks the copy-on-add
+// invariant that makes parallel_spawn safe: two siblings augmenting the SAME
+// parent ctx each get an independent superset (a sibling never sees the other's
+// provider), the parent's set is never mutated, and a grandchild sees its whole
+// ancestry (nested depth). A shared-map implementation would fail every one of
+// these.
+func TestWithHeldProviderSlot_CopyOnAddIndependentSupersets(t *testing.T) {
+	base := context.Background()
+	if holdsProviderSlot(base, "P") {
+		t.Fatal("empty ctx must hold no provider")
+	}
+
+	parent := withHeldProviderSlot(base, "P")
+	if !holdsProviderSlot(parent, "P") {
+		t.Fatal("parent ctx should hold P")
+	}
+
+	// Two siblings each add their OWN provider off the same parent ctx.
+	childA := withHeldProviderSlot(parent, "A")
+	childB := withHeldProviderSlot(parent, "B")
+
+	if !holdsProviderSlot(childA, "P") || !holdsProviderSlot(childA, "A") {
+		t.Error("childA should hold P and A")
+	}
+	if holdsProviderSlot(childA, "B") {
+		t.Error("childA must NOT see sibling B's provider — copy-on-add leaked a shared map")
+	}
+	if !holdsProviderSlot(childB, "P") || !holdsProviderSlot(childB, "B") {
+		t.Error("childB should hold P and B")
+	}
+	if holdsProviderSlot(childB, "A") {
+		t.Error("childB must NOT see sibling A's provider — copy-on-add leaked a shared map")
+	}
+
+	// The parent's set must be untouched by either child's add.
+	if holdsProviderSlot(parent, "A") || holdsProviderSlot(parent, "B") {
+		t.Error("a child's add mutated the parent's held-set (copy-on-add violated)")
+	}
+
+	// Grandchild sees the full ancestry of its branch, not the sibling branch.
+	grand := withHeldProviderSlot(childA, "G")
+	for _, id := range []string{"P", "A", "G"} {
+		if !holdsProviderSlot(grand, id) {
+			t.Errorf("grandchild should hold ancestor %q", id)
+		}
+	}
+	if holdsProviderSlot(grand, "B") {
+		t.Error("grandchild must not see the sibling branch's provider B")
+	}
+}
+
+// TestHeldSlotCtx_StampsOnlyRealCappedSlot proves the zero-overhead guarantee:
+// heldSlotCtx enters a provider into the held-set ONLY for a real capped holder.
+// An uncapped provider, a carve-out (noop) holder, and a nil holder all leave the
+// ctx (and thus the held-set) untouched.
+func TestHeldSlotCtx_StampsOnlyRealCappedSlot(t *testing.T) {
+	gates := concurrency.NewProviderGates(map[string]int{"capped": 2}, 4, time.Second)
+	s := &Server{providerGates: gates}
+	base := context.Background()
+
+	// Uncapped provider → not gated → nothing to skip → ctx unchanged.
+	if got := s.heldSlotCtx(base, &providerSlot{release: func() {}, providerID: "uncapped"}); holdsProviderSlot(got, "uncapped") {
+		t.Error("uncapped provider must NOT enter the held-set (zero-overhead)")
+	}
+	// Carve-out (noop) holder → holds no fresh gate → ctx unchanged.
+	if got := s.heldSlotCtx(base, &providerSlot{noop: true, providerID: "capped"}); got != base {
+		t.Error("carve-out holder must return ctx unchanged")
+	}
+	// nil holder → ctx unchanged.
+	if got := s.heldSlotCtx(base, nil); got != base {
+		t.Error("nil slot must return ctx unchanged")
+	}
+	// Real capped slot → provider held so descendants take the carve-out.
+	if got := s.heldSlotCtx(base, &providerSlot{release: func() {}, providerID: "capped"}); !holdsProviderSlot(got, "capped") {
+		t.Error("a real capped slot must enter the held-set")
+	}
+}
+
+// TestAcquireProviderSlot_CarveOutWhenAncestorHolds proves the deadlock carve-out
+// at the acquire seam: when the ctx already marks provider P as ancestor-held,
+// acquireProviderSlot returns a noop holder WITHOUT touching P's gate (so a
+// parent never awaits a child queued behind its own slot), and that holder is
+// inert on both swap (must not acquire a fallback target) and release. Also
+// covers the sub-agent fallback path: a REAL sub-agent slot swaps P->Q with no
+// leak.
+//
+// Fail-before: drop the holdsProviderSlot check in acquireProviderSlot and the
+// carve-out branch instead occupies P's gate (Active=1) — this test's Active==0
+// assertion fails.
+func TestAcquireProviderSlot_CarveOutWhenAncestorHolds(t *testing.T) {
+	gates := concurrency.NewProviderGates(map[string]int{"P": 1, "Q": 1}, 2, time.Second)
+	s := &Server{providerGates: gates}
+
+	// Ancestor holds P → the child's acquire takes the carve-out.
+	ctx := withHeldProviderSlot(context.Background(), "P")
+	slot, err := s.acquireProviderSlot(ctx, "P")
+	if err != nil {
+		t.Fatalf("acquire under ancestor-held P: %v", err)
+	}
+	if !slot.noop {
+		t.Fatal("expected a carve-out noop holder when an ancestor holds P")
+	}
+	if g := gates.Stats()["P"]; g.Active != 0 {
+		t.Errorf("carve-out must not occupy P's gate; active=%d want 0", g.Active)
+	}
+	// A carve-out holder must stay ungated across a fallback — swap is inert.
+	slot.swap(context.Background(), gates, "Q")
+	if g := gates.Stats()["Q"]; g.Active != 0 {
+		t.Errorf("carve-out swap acquired Q's gate; active=%d want 0 (must stay ungated)", g.Active)
+	}
+	slot.releaseCurrent() // inert; must not panic
+	if g := gates.Stats()["P"]; g.Active != 0 {
+		t.Errorf("P active=%d after carve-out release, want 0", g.Active)
+	}
+
+	// Sub-agent fallback: a REAL (non-carve-out) slot swaps P->Q with no leak.
+	real, err := s.acquireProviderSlot(context.Background(), "P")
+	if err != nil {
+		t.Fatalf("acquire real P: %v", err)
+	}
+	real.swap(context.Background(), gates, "Q")
+	if gP, gQ := gates.Stats()["P"], gates.Stats()["Q"]; gP.Active != 0 || gQ.Active != 1 {
+		t.Fatalf("after sub-agent fallback P->Q: P active=%d (want 0) Q active=%d (want 1)", gP.Active, gQ.Active)
+	}
+	real.releaseCurrent()
+	if gP, gQ := gates.Stats()["P"], gates.Stats()["Q"]; gP.Active != 0 || gQ.Active != 0 {
+		t.Errorf("after release: P active=%d Q active=%d, want 0/0 (no leak)", gP.Active, gQ.Active)
+	}
+}
+
+// --- End-to-end sub-agent gating through the full admission + spawn path ---
+
+// TestProviderGate_SubAgentFanoutBatchesToCap is THE ats-filter goal (RFC BF §4):
+// a code-js-style PARENT on an UNCAPPED provider fans out N same-provider workers
+// resolving to a CAPPED provider; P2c gates the SUB-AGENTS so exactly `cap` of
+// them call the provider at once, the rest queue and drain, the parent holds NO
+// worker-provider slot, and every child completes with no deadlock.
+//
+// Fail-before: revert runSubAgent to P2b (sub-agents ungated) and the workers all
+// run at once → peakInFlight == workers, not cap.
+func TestProviderGate_SubAgentFanoutBatchesToCap(t *testing.T) {
+	const cap = 2
+	const workers = 5
+
+	// Parent (uncapped provider): iter1 fans out N workers; iter2 wraps up.
+	spawnEntries := make([]string, workers)
+	for i := range spawnEntries {
+		spawnEntries[i] = fmt.Sprintf(`{"name":"worker","prompt":"task-%d"}`, i)
+	}
+	parallelSpawnInput := `{"op":"parallel_spawn","spawns":[` + strings.Join(spawnEntries, ",") + `]}`
+	parentProv := &scriptedProvider{
+		scripts: [][]providers.Event{
+			{
+				{Type: providers.EventToolCall, ToolUse: &providers.ToolUse{ID: "tu_fanout", Name: "Agent", Input: json.RawMessage(parallelSpawnInput)}},
+				{Type: providers.EventDone, StopReason: "tool_use", Usage: &providers.Usage{InputTokens: 1, OutputTokens: 1}},
+			},
+			{
+				{Type: providers.EventText, Text: "ats-filter done"},
+				{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 1, OutputTokens: 1}},
+			},
+		},
+	}
+	// Workers (capped provider): each a single-iteration run; countingProvider
+	// records the peak concurrent Call so we can assert it equals the cap exactly.
+	workerProv := &countingProvider{delay: 40 * time.Millisecond}
+
+	cfg := makeBaseConfig()
+	cfg.Agents = map[string]config.AgentDef{
+		// max_concurrent_children high so the Agent tool's own fan-out semaphore
+		// (default 4) is NOT the limiter — the PROVIDER gate must be the only cap.
+		"ats-filter": {Provider: "codejs-prov", Model: "m", Tools: []string{"Agent"}, MaxConcurrentChildren: workers + 5},
+		"worker":     {Provider: "ollama-prov", Model: "m", Tools: []string{}},
+	}
+
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "fanout_gate.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	sem := concurrency.New(16, 16, 5*time.Second) // global never gates first
+	gates := concurrency.NewProviderGates(map[string]int{"ollama-prov": cap}, workers, 5*time.Second)
+	resolver := &multiResolver{byID: map[string]providers.Provider{"codejs-prov": parentProv, "ollama-prov": workerProv}}
+	srv := New(cfg, resolver, []tools.Tool{}, sem, st)
+	srv.SetProviderGates(gates)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"ats-filter","agent_id":"ats-parent","segments":[{"role":"user","content":[{"type":"trusted-text","text":"go"}]}]}`,
+	))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d body=%s", resp.StatusCode, body)
+	}
+
+	// THE ASSERTION: at most `cap` workers ever called the provider at once.
+	if peak := workerProv.peakInFlight(); peak != cap {
+		t.Errorf("peak concurrent worker provider.Call = %d, want exactly cap=%d (P2c must gate sub-agents; P2b left them ungated → peak would be %d)", peak, cap, workers)
+	}
+	// The parent holds NO worker-provider slot, and the gate drains to zero.
+	if g := gates.Stats()["ollama-prov"]; g.Active != 0 || g.Queued != 0 {
+		t.Errorf("final ollama-prov gate state active=%d queued=%d, want 0/0", g.Active, g.Queued)
+	}
+	// All N workers actually ran (the rest queued behind the cap, then drained) —
+	// each is a persisted sub-run under the parent.
+	childRuns, err := st.ListRunsByParentAgentID(context.Background(), "ats-parent")
+	if err != nil {
+		t.Fatalf("ListRunsByParentAgentID: %v", err)
+	}
+	if len(childRuns) != workers {
+		t.Errorf("expected %d worker sub-runs (all queued then drained), got %d", workers, len(childRuns))
+	}
+}
+
+// TestProviderGate_SameProviderParentChildTakesCarveOut is the deadlock carve-out
+// end-to-end (RFC BF §4): a PARENT resolving to provider P (cap 1) holds P's only
+// slot, then spawns a child ALSO resolving to P. Without the carve-out the child
+// would queue behind the parent's own slot and time out — the parent awaiting its
+// own child is a self-deadlock. With the carve-out the child runs UNGATED and the
+// parent completes.
+//
+// Fail-before (revert the carve-out): the child's acquire blocks then times out
+// on P's cap BEFORE its sub-run row is created, so ListRunsByParentAgentID
+// returns 0 children and the parent's tool_result carries the exhaustion error.
+func TestProviderGate_SameProviderParentChildTakesCarveOut(t *testing.T) {
+	// One provider instance serves parent + child (they share provider id "P", the
+	// gate key). op=spawn is synchronous, so the three Calls arrive in a fixed
+	// order: parent-iter1 (spawn) -> child-iter1 (text) -> parent-iter2 (final).
+	prov := &scriptedProvider{
+		scripts: [][]providers.Event{
+			{
+				{Type: providers.EventToolCall, ToolUse: &providers.ToolUse{ID: "tu_spawn", Name: "Agent", Input: json.RawMessage(`{"name":"child","prompt":"go"}`)}},
+				{Type: providers.EventDone, StopReason: "tool_use", Usage: &providers.Usage{InputTokens: 1, OutputTokens: 1}},
+			},
+			{
+				{Type: providers.EventText, Text: "child ran despite the cap"},
+				{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 1, OutputTokens: 1}},
+			},
+			{
+				{Type: providers.EventText, Text: "parent done"},
+				{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 1, OutputTokens: 1}},
+			},
+		},
+	}
+
+	cfg := makeBaseConfig()
+	cfg.Agents = map[string]config.AgentDef{
+		"parent": {Provider: "P", Model: "m", Tools: []string{"Agent"}, SystemPrompt: "parent"},
+		"child":  {Provider: "P", Model: "m", Tools: []string{}, SystemPrompt: "child"},
+	}
+
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "carveout.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	sem := concurrency.New(8, 8, 5*time.Second)
+	// cap 1: the parent takes the only slot. Short timeout so the FAIL-BEFORE path
+	// (child gated) times out fast instead of hanging the test.
+	gates := concurrency.NewProviderGates(map[string]int{"P": 1}, 1, 500*time.Millisecond)
+	srv := New(cfg, &stubResolver{p: prov}, []tools.Tool{}, sem, st)
+	srv.SetProviderGates(gates)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"parent","agent_id":"parent-carveout","segments":[{"role":"user","content":[{"type":"trusted-text","text":"go"}]}]}`,
+	))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d body=%s", resp.StatusCode, body)
+	}
+	bodyStr := string(body)
+
+	// No deadlock: the parent completed its final turn.
+	if !strings.Contains(bodyStr, "parent done") {
+		t.Errorf("parent did not complete (deadlock?); body=\n%s", bodyStr)
+	}
+	// The child must NOT have been gated-and-timed-out.
+	if strings.Contains(bodyStr, "provider concurrency exhausted") || strings.Contains(bodyStr, "provider gate") {
+		t.Errorf("child was gated on the parent-held provider (carve-out missing); body=\n%s", bodyStr)
+	}
+
+	// The child actually ran: its sub-run row exists and its transcript carries
+	// its output. In the fail-before path the acquire fails BEFORE the sub-run is
+	// created, so this returns zero children.
+	childRuns, err := st.ListRunsByParentAgentID(context.Background(), "parent-carveout")
+	if err != nil {
+		t.Fatalf("ListRunsByParentAgentID: %v", err)
+	}
+	if len(childRuns) != 1 {
+		t.Fatalf("expected exactly 1 child run (carve-out let it run); got %d — the child was gated behind the parent's own slot", len(childRuns))
+	}
+	childTranscript, err := st.GetTranscript(context.Background(), childRuns[0].SessionID)
+	if err != nil {
+		t.Fatalf("GetTranscript(child): %v", err)
+	}
+	var sawChildText bool
+	for _, ev := range childTranscript {
+		if ev.Type == "text" && strings.Contains(string(ev.Payload), "child ran despite the cap") {
+			sawChildText = true
+		}
+	}
+	if !sawChildText {
+		t.Errorf("child transcript missing its output — it did not run to completion")
+	}
+
+	// The parent's slot is released at run end; nothing leaked on the gate.
+	if g := gates.Stats()["P"]; g.Active != 0 || g.Queued != 0 {
+		t.Errorf("final P gate state active=%d queued=%d, want 0/0", g.Active, g.Queued)
+	}
+}
+
+// TestProviderGate_SubAgentZeroOverheadWhenUnconfigured proves the whole P2c path
+// is inert when no provider is capped: a parent fans out N workers, all run
+// concurrently (peak > 1, bounded only by the Agent tool's fan-out cap), and no
+// gates exist at any level.
+func TestProviderGate_SubAgentZeroOverheadWhenUnconfigured(t *testing.T) {
+	const workers = 4
+
+	spawnEntries := make([]string, workers)
+	for i := range spawnEntries {
+		spawnEntries[i] = fmt.Sprintf(`{"name":"worker","prompt":"task-%d"}`, i)
+	}
+	parentProv := &scriptedProvider{
+		scripts: [][]providers.Event{
+			{
+				{Type: providers.EventToolCall, ToolUse: &providers.ToolUse{ID: "tu_fanout", Name: "Agent", Input: json.RawMessage(`{"op":"parallel_spawn","spawns":[` + strings.Join(spawnEntries, ",") + `]}`)}},
+				{Type: providers.EventDone, StopReason: "tool_use", Usage: &providers.Usage{InputTokens: 1, OutputTokens: 1}},
+			},
+			{
+				{Type: providers.EventText, Text: "done"},
+				{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 1, OutputTokens: 1}},
+			},
+		},
+	}
+	workerProv := &countingProvider{delay: 30 * time.Millisecond}
+
+	cfg := makeBaseConfig()
+	cfg.Agents = map[string]config.AgentDef{
+		"parent": {Provider: "codejs-prov", Model: "m", Tools: []string{"Agent"}, MaxConcurrentChildren: workers},
+		"worker": {Provider: "ollama-prov", Model: "m", Tools: []string{}},
+	}
+
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "sub_zero.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	sem := concurrency.New(16, 16, 5*time.Second)
+	// The default deployment: no caps → zero gates built.
+	gates := concurrency.NewProviderGates(map[string]int{}, 16, time.Second)
+	if gates.Len() != 0 {
+		t.Fatalf("expected 0 gates, got %d", gates.Len())
+	}
+	resolver := &multiResolver{byID: map[string]providers.Provider{"codejs-prov": parentProv, "ollama-prov": workerProv}}
+	srv := New(cfg, resolver, []tools.Tool{}, sem, st)
+	srv.SetProviderGates(gates)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"parent","segments":[{"role":"user","content":[{"type":"trusted-text","text":"go"}]}]}`,
+	))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	_, _ = io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	// No gate anywhere: the workers overlap (peak > 1 proves they weren't
+	// serialised) and no gate stats exist.
+	if peak := workerProv.peakInFlight(); peak <= 1 {
+		t.Errorf("peak = %d; with no gate all %d workers should overlap (peak > 1)", peak, workers)
+	}
+	if gates.Stats() != nil {
+		t.Errorf("gates.Stats() = %v, want nil (no gates configured)", gates.Stats())
+	}
+}

--- a/internal/api/http/provider_held.go
+++ b/internal/api/http/provider_held.go
@@ -1,0 +1,50 @@
+// provider_held.go — RFC BF P2c ancestor-held-provider set.
+//
+// P2b gates a TOP-LEVEL run on its resolved provider but deliberately leaves
+// sub-agents ungated, to avoid a self-deadlock: a fan-out parent holding
+// provider P's slot could otherwise queue behind its own children that also want
+// P. P2c gates EVERY run — top-level and sub-agent — on its resolved provider,
+// EXCEPT it skips the gate for a provider an ANCESTOR in the same run tree
+// already holds (the deadlock carve-out).
+//
+// The mechanism is a ctx-carried set of provider ids whose gate slots are held
+// by ancestors. A run stamps its own provider onto the set (via
+// Server.heldSlotCtx) exactly when it takes a REAL capped slot that persists for
+// the loop it guards; its descendants read the set (via holdsProviderSlot) and
+// take the carve-out when their provider is already held above them.
+package http
+
+import "context"
+
+// heldProviderSlotsKey is the unexported ctx key for the ancestor-held provider
+// set. A dedicated unexported type keeps the key private to this package per the
+// Go context convention (no cross-package collision or read).
+type heldProviderSlotsKey struct{}
+
+// withHeldProviderSlot returns a ctx whose ancestor-held set is the parent's set
+// PLUS providerID.
+//
+// COPY-ON-ADD is load-bearing: parallel_spawn runs its children concurrently off
+// the SAME parent ctx, and each child augments that ctx with its OWN resolved
+// provider. Mutating a shared map here would race the sibling goroutines and
+// cross-contaminate their carve-out decisions, so every add allocates a fresh
+// superset the caller owns exclusively.
+func withHeldProviderSlot(ctx context.Context, providerID string) context.Context {
+	prev, _ := ctx.Value(heldProviderSlotsKey{}).(map[string]struct{})
+	next := make(map[string]struct{}, len(prev)+1)
+	for id := range prev {
+		next[id] = struct{}{}
+	}
+	next[providerID] = struct{}{}
+	return context.WithValue(ctx, heldProviderSlotsKey{}, next)
+}
+
+// holdsProviderSlot reports whether an ancestor in this run tree already holds
+// providerID's gate slot. When true the current run must NOT acquire that gate
+// again — the ancestor would await its own descendant queued behind the same cap
+// (a self-deadlock), so the descendant runs UNGATED (the P2c carve-out).
+func holdsProviderSlot(ctx context.Context, providerID string) bool {
+	held, _ := ctx.Value(heldProviderSlotsKey{}).(map[string]struct{})
+	_, ok := held[providerID]
+	return ok
+}

--- a/internal/api/http/resume.go
+++ b/internal/api/http/resume.go
@@ -392,6 +392,12 @@ func (s *Server) resumePausedRun(ctx context.Context, run store.Run) error {
 		provSlot.release = provRelease
 		provSlot.providerID = providerID
 		defer provSlot.releaseCurrent()
+		// RFC BF P2c: a resumed run holds provSlot for its whole re-entered loop,
+		// so publish its provider into the ancestor-held set — sub-agents it spawns
+		// (a resumed fan-out parent) skip the gate for the SAME provider (deadlock
+		// carve-out). Without this a same-provider parent→child spawn after resume
+		// would self-deadlock. No-op for uncapped/noop slots.
+		loopCtx = s.heldSlotCtx(loopCtx, provSlot)
 
 		// Respect the per-tenant fairness semaphore so a boot that resumes many
 		// runs doesn't blow past MAX_CONCURRENT_RUNS. Acquired inside the

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2406,6 +2406,11 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	// fan-out parent can park mid-tool-call (no-op unless LOOMCYCLE_RESUME_FANOUT).
 	loopCtx = tools.WithPauseGate(loopCtx, gate)
 
+	// RFC BF P2c: publish this run's provider into the ancestor-held set so any
+	// sub-agents it spawns skip the gate for the SAME provider (the deadlock
+	// carve-out) while still gating on any OTHER provider. No-op for an
+	// uncapped/noop slot, so uncapped runs stay zero-overhead.
+	loopCtx = s.heldSlotCtx(loopCtx, provSlot)
 	fbPolicy, fbReResolve := s.fallbackForRun(effectiveTenantID, effectiveUserID, effectiveAgentName, in.UserTier, operatorKeyRestricted, provSlot)
 	res, runErr := loop.Run(loopCtx, loop.RunOptions{
 		Provider:               provider,
@@ -3965,7 +3970,12 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	loopRes, runErr := loop.Run(loopCtx, runOpts)
+	// RFC BF P2c: the synchronous run holds provSlot for the whole loop, so
+	// publish its provider into the ancestor-held set — sub-agents it spawns skip
+	// the gate for the SAME provider (carve-out). The interactive-detached branch
+	// above does NOT do this: it releases provSlot at hand-off (fbSlot=nil), so its
+	// sub-agents must gate normally. No-op for uncapped/noop slots.
+	loopRes, runErr := loop.Run(s.heldSlotCtx(loopCtx, provSlot), runOpts)
 	if runErr != nil {
 		stream.send(providers.Event{Type: providers.EventError, Error: runErr.Error()})
 	}
@@ -4422,6 +4432,10 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	defer deregGate()
 	// RFC X Phase 3: expose the gate to the Agent tool (parallel_spawn parent park).
 	loopCtx = tools.WithPauseGate(loopCtx, gate)
+	// RFC BF P2c: publish this run's provider into the ancestor-held set so its
+	// sub-agents skip the gate for the SAME provider (deadlock carve-out). No-op
+	// for uncapped/noop slots.
+	loopCtx = s.heldSlotCtx(loopCtx, provSlot)
 	fbPolicy, fbReResolve := s.fallbackForRun(sess.TenantID, sess.UserID, sess.Agent, body.UserTier, operatorKeyRestricted, provSlot)
 	loopRes, runErr := loop.Run(loopCtx, loop.RunOptions{
 		Provider:               provider,
@@ -5228,6 +5242,21 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 		return "", "", fmt.Errorf("provider for sub-agent %q: %w", name, err)
 	}
 
+	// RFC BF P2c: gate the sub-agent on ITS resolved provider so a fan-out parent's
+	// same-provider children run at most `max_concurrent` at a time (the rest queue
+	// inside acquireProviderSlot), EXCEPT when an ANCESTOR already holds that
+	// provider — acquireProviderSlot then returns a noop carve-out holder so the
+	// parent never awaits a child queued behind the parent's own slot (self-
+	// deadlock). Acquired BEFORE the sub-session row so a saturated cap fails fast
+	// without leaving an orphan run. The whole run tree still takes ONE global slot
+	// (the parent's) — sub-runs never touch s.sem, so there is no global-semaphore
+	// deadlock. Uncapped ⇒ noop, zero overhead.
+	subSlot, provErr := s.acquireProviderSlot(ctx, providerID)
+	if provErr != nil {
+		return "", "", fmt.Errorf("sub-agent %q provider gate: %w", name, provErr)
+	}
+	defer subSlot.releaseCurrent()
+
 	// Generate a fresh agent_id for the sub-run. Always generated;
 	// callers can't override (the sub is loomcycle-controlled).
 	subAgentID := newAgentID()
@@ -5522,12 +5551,15 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 	// that itself parallel_spawns) can park mid-tool-call too.
 	subCtx = tools.WithPauseGate(subCtx, subGate)
 
-	// RFC BF P2b: sub-agents take NO per-provider gate slot (they run under the
-	// parent's admission, never acquiring a global slot either). Gating them would
-	// risk a parent holding provider P's slot while awaiting children that queue
-	// on the same gate — a self-deadlock. nil slot ⇒ fallback doesn't swap.
-	fbPolicy, fbReResolve := s.fallbackForRun(tenantFromCtx(ctx), parentIdentity.UserID, name, parentTier, parentIdentity.OperatorKeyRestricted, nil)
-	res, runErr := loop.Run(subCtx, loop.RunOptions{
+	// RFC BF P2c: the sub-agent's fallback moves ITS OWN provider slot (subSlot,
+	// acquired above), mirroring a top-level run — so a mid-run failover to another
+	// capped provider re-gates on the new one. A carve-out (noop) subSlot never
+	// swaps (it's deliberately ungated). Sub-runs still take no GLOBAL slot.
+	fbPolicy, fbReResolve := s.fallbackForRun(tenantFromCtx(ctx), parentIdentity.UserID, name, parentTier, parentIdentity.OperatorKeyRestricted, subSlot)
+	// RFC BF P2c: publish the sub-agent's provider into the ancestor-held set on
+	// its OWN loop ctx (copy-on-add) so grandchildren it spawns take the carve-out
+	// for the same provider. No-op for a carve-out/uncapped subSlot.
+	res, runErr := loop.Run(s.heldSlotCtx(subCtx, subSlot), loop.RunOptions{
 		Provider:            provider,
 		Model:               model,
 		Tools:               subTools,


### PR DESCRIPTION
## Why

This completes **RFC BF §4 — the ats-filter goal** from the original per-provider-concurrency ask.

P2b added the per-provider `max_concurrent` gate but wired it to **top-level runs only**. It deliberately left **sub-agents ungated** to dodge a self-deadlock: a fan-out parent holding provider P's slot would otherwise queue behind its own children that also want P. The cost of that shortcut: a `code-js` parent (`ats-filter`) that fans out `ollama-local` sub-agents could **not** cap them — all N hit the GPU at once, defeating the cap the operator configured on the shared local model.

## What

P2c gates **every** run — top-level **and** sub-agent — on **its** resolved provider, **except** it skips the gate for a provider an **ancestor in the same run tree already holds** (the deadlock carve-out).

- **`ats-filter`** (code-js, top-level) holds the `code-js` slot (or none if uncapped) — **no `ollama-local` slot**.
- Its sub-agents resolve to `ollama-local`; no ancestor holds it → each acquires an `ollama-local` slot → with `max_concurrent: 2`, exactly **2 run at once, the rest queue and drain**, and the parent (holding no `ollama-local` slot) awaits them with **no deadlock**.
- **Carve-out (rare):** a parent that itself resolves to P and spawns children **also** on P → the children see an ancestor holding P → they **skip the gate** (run ungated) so the parent never awaits a child queued behind the parent's own slot.

### The ancestor-held-set carve-out
`internal/api/http/provider_held.go` adds a ctx-carried set of provider ids whose gate slots ancestors hold. `withHeldProviderSlot` is **copy-on-add** — `parallel_spawn` runs children concurrently off the *same* parent ctx, so each child must get an independent superset; a shared mutated map would race and cross-contaminate siblings' carve-out decisions.

- `acquireProviderSlot` returns a **noop carve-out holder** (no gate touched) when `holdsProviderSlot(ctx, providerID)`. At the top-level sites the held-set is always empty, so the carve-out never fires there and behavior is **byte-identical to P2b**.
- `heldSlotCtx(ctx, slot)` stamps the provider into the held-set **only** for a real *capped* slot (uncapped/noop/nil → ctx unchanged → **uncapped stays zero-overhead**).
- A carve-out holder is **inert on swap and release** and stays ungated across a fallback (re-acquiring a fallback target's gate could reintroduce the deadlock the carve-out prevents).

### Sub-agent gate in `runSubAgent`
Reverses P2b's `nil`: the sub-agent acquires **its own** provider slot (ancestor-aware) before its sub-session row (fail-fast, no orphan run), holds it for the loop, passes it to `fallbackForRun` so a mid-run failover **re-gates** on the new provider, and runs the sub-loop under `heldSlotCtx` so grandchildren inherit the held set. **Sub-runs still take no global `s.sem` slot** (unchanged) — no global-semaphore deadlock.

### The ctx-plumbing path I confirmed (parent → Agent tool → runSubAgent)
The top-level run stamps `heldSlotCtx(loopCtx, provSlot)` on the ctx into `loop.Run` → the loop threads it as `iterCtx` to tool dispatch → `AgentTool.Execute` (`op=spawn` / `op=parallel_spawn`) derives the child ctx via `IncrementAgentDepth`/`WithSpawnIndex` (both `WithValue`, so the held-set survives) → `a.Run`/`a.RunDetailed` = `s.runSubAgent` receives the parent's held-set. `parallel_spawn` augments each child ctx with its own provider once acquired (copy-on-add).

Wrapped `loop.Run` ctx at every persistent-slot site: `RunOnce`, `handleMessages`, the **synchronous** `handleRuns`, and `resume.go`. The **interactive-detached** `handleRuns` branch deliberately does **not** stamp — it releases its slot at hand-off (`fbSlot=nil`), so its sub-agents gate normally.

**Top-level P2b behavior is unchanged; uncapped providers stay zero-overhead at every level.**

### Known limitation (surfaced)
The held-set reflects the *initially* resolved provider; a mid-run fallback swaps the slot but not descendants' carve-out set, so the rare compound case (a run fails over to Q, then spawns same-Q children while Q's cap is fully held) is not covered. The direct same-provider parent→child case (the ats-filter goal) is fully covered.

## What was tested

`go build ./...`, `make build-all`, `go test -race ./...`, `go vet ./...`, `gofmt -l` — all clean.

**Headline test:** `TestProviderGate_SubAgentFanoutBatchesToCap` — an uncapped parent fans out 5 same-provider workers on a provider capped at 2, through the real server Mux; asserts **peak concurrent worker `provider.Call` == 2**, all 5 sub-runs complete (queue then drain), gate drains to 0. **Fail-before verified**: reverting `runSubAgent` to P2b → peak == 5.

**Carve-out test:** `TestProviderGate_SameProviderParentChildTakesCarveOut` — parent on P (cap 1) spawns a child also on P; the carve-out lets the child run ungated and the parent completes (no deadlock). Asserts on the **store** (the child sub-run exists) — the fail-before path errors at acquire *before* the sub-run row is created, so `ListRunsByParentAgentID` returns 0. **Fail-before verified**.

Plus `TestProviderGate_SubAgentZeroOverheadWhenUnconfigured`, `TestWithHeldProviderSlot_CopyOnAddIndependentSupersets` (copy-on-add + nested depth), `TestHeldSlotCtx_StampsOnlyRealCappedSlot`, `TestAcquireProviderSlot_CarveOutWhenAncestorHolds` (carve-out inert + sub-agent fallback swap no-leak).

**Manual:** built `make build-all` and booted with a `mock` provider `max_concurrent: 2`; boot log confirms `per-provider concurrency caps enabled — mock=2` and `GET /v1/_concurrency/stats` reports `providers.mock` — the YAML→gate wiring the Go tests set directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD
