### PR TITLE
fix(providers): port code-js env into the driver options (P2a regress)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -3200,6 +3200,19 @@ func toDriverOptions(id string, pc config.ProviderConfig, cfg *config.Config) pr
 		if baseURL == "" {
 			baseURL = cfg.Env.GeminiBaseURL
 		}
+	case "code-js":
+		// RFC BF P2a regression fix (b8d3f42d line): the code-js driver factory
+		// (codejs.newFromOptions) sources code_root/deterministic/run_timeout_seconds
+		// from this options map — but P2a's flip to the registry never ported the
+		// pre-P2a codejs.New(Config{CodeRoot: cfg.Env.CodeAgentsRoot, ...}) mapping,
+		// so with no `providers: code-js: options:` block the compiler root was empty
+		// and EVERY static `provider: code-js` agent failed to load ("no index.js at
+		// <name>/index.js" — a relative path, the empty-root tell). CodeAgentsRoot
+		// defaults to ./agent_code (never empty), so this is byte-identical to
+		// pre-P2a; an explicit options entry still wins via the pc.Options merge below.
+		opts["code_root"] = cfg.Env.CodeAgentsRoot
+		opts["deterministic"] = cfg.Env.CodeAgentsDeterministic
+		opts["run_timeout_seconds"] = int(cfg.Env.CodeAgentsRunTimeout / time.Second)
 	}
 	// Operator-declared options override the env-derived defaults (e.g. mock-stable's
 	// `stable: true`, or a per-provider num_ctx).

--- a/cmd/loomcycle/providers_p2a_test.go
+++ b/cmd/loomcycle/providers_p2a_test.go
@@ -199,6 +199,39 @@ func TestToDriverOptions_PortsEnvBaseURLsAndTimeouts(t *testing.T) {
 	}
 }
 
+// TestToDriverOptions_CodeJSPortsEnvRoot is the regression for the P2a code-js
+// boot break: the switch in toDriverOptions ported the ollama/deepseek/gemini env
+// defaults but NOT code-js, so the driver factory (codejs.newFromOptions) got no
+// code_root and built a compiler with an empty root — every static `provider:
+// code-js` agent then failed to load ("no index.js at <name>/index.js", a
+// relative path = the empty-root tell), crash-looping boot (the "Runtime suites
+// (code-js)" CI job). This asserts the three code-js env knobs are ported into
+// the driver options.
+//
+// Fail-before: drop the `case "code-js"` in toDriverOptions and code_root is
+// absent (StringOption ok=false) → this fails.
+func TestToDriverOptions_CodeJSPortsEnvRoot(t *testing.T) {
+	t.Setenv("LOOMCYCLE_CODE_AGENTS_ROOT", "/srv/agent_code")
+	t.Setenv("LOOMCYCLE_CODE_AGENTS_DETERMINISTIC", "1")
+	t.Setenv("LOOMCYCLE_CODE_AGENTS_RUN_TIMEOUT_SECONDS", "45")
+
+	cfg := loadDefaultProvidersOnly(t)
+	if cfg.Env.CodeAgentsRoot != "/srv/agent_code" {
+		t.Fatalf("cfg.Env.CodeAgentsRoot = %q, want /srv/agent_code (env not parsed?)", cfg.Env.CodeAgentsRoot)
+	}
+
+	opts := toDriverOptions("code-js", cfg.Providers["code-js"], cfg)
+	if root, ok := providers.StringOption(opts.Options, "code_root"); !ok || root != "/srv/agent_code" {
+		t.Errorf("code-js code_root option = %q (ok=%v), want /srv/agent_code — without it the compiler root is empty and every static code agent fails to load", root, ok)
+	}
+	if det, _ := providers.BoolOption(opts.Options, "deterministic"); !det {
+		t.Errorf("code-js deterministic option = false, want true (LOOMCYCLE_CODE_AGENTS_DETERMINISTIC=1)")
+	}
+	if secs, ok := providers.IntOption(opts.Options, "run_timeout_seconds"); !ok || secs != 45 {
+		t.Errorf("code-js run_timeout_seconds = %d (ok=%v), want 45", secs, ok)
+	}
+}
+
 // TestGet_MockStable_IsStableVariant proves mock-stable, built through the driver
 // registry with `options: {stable: true}` (from the default-providers layer),
 // reports the right id — the config-driven replacement for the pre-P2a


### PR DESCRIPTION
## Why

`main` is red: the **Runtime suites (code-js)** CI job has crash-looped on boot since **P2a (#729)** with:

```
code-js agents failed to load:
  - code-agent "kvflow": no index.js at kvflow/index.js
    (a substrate-authored or forked code agent must supply an inline code_body)
```

That path is **relative** (`kvflow/index.js`, not the absolute `.../agent_code/kvflow/index.js` the boot log prints) — the tell that the code-js compiler was built with an **empty root**.

### Root cause
P2a (#729) flipped provider construction to the RFC BF driver registry. `toDriverOptions` ports the env-derived options for `ollama` / `ollama-local` / `deepseek` / `gemini` — but there was **no `case "code-js"`**. The code-js factory (`codejs.newFromOptions`) sources `code_root` / `deterministic` / `run_timeout_seconds` from the options map, so with no explicit `providers: code-js: options:` block it got an empty `code_root` → `codejs.New(Config{CodeRoot: ""})` → compiler root `""` → every statically-configured `provider: code-js` agent fails to load at boot. The boot log still printed the correct `cfg.Env.CodeAgentsRoot`, masking the mismatch.

This is independent of the P2c PR (#731); P2c just inherits the red because it branches off P2b.

## What

Add the missing `case "code-js"` to `toDriverOptions`, porting the pre-P2a construction 1:1:

```go
case "code-js":
    opts["code_root"] = cfg.Env.CodeAgentsRoot
    opts["deterministic"] = cfg.Env.CodeAgentsDeterministic
    opts["run_timeout_seconds"] = int(cfg.Env.CodeAgentsRunTimeout / time.Second)
```

`cfg.Env.CodeAgentsRoot` defaults to `./agent_code` (never empty), so an absent `providers:` block is **byte-identical to pre-P2a**. An explicit `providers: code-js: options:` entry still overrides via the existing `pc.Options` merge that runs after the switch.

## What was tested

- **Regression:** `TestToDriverOptions_CodeJSPortsEnvRoot` asserts the three env knobs land in the driver options. **Fail-before verified** (drop the `case` → `code_root` ok=false, deterministic=false, run_timeout=0).
- **End-to-end:** `make runtime-codejs` (the failing CI job) — **failed before** the fix (`no index.js at kvflow/index.js`), **passes after** (`all runtime-codejs suites PASSED`).
- `go build ./...`, `go vet ./cmd/loomcycle/`, `gofmt -l`, `go test ./cmd/loomcycle/` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD
