### PR TITLE
feat(providers): P3 — delete the hardcoded built-in provider floor

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -3014,15 +3014,6 @@ func buildEmbedder(cfg *config.Config) (providers.Embedder, error) {
 	})
 }
 
-// expectedBuiltinProviderIDs is the set the embedded default-providers layer
-// declares. Used only by the boot divergence WARN (RFC BF P2a Deliverable 5) —
-// resolution itself is fully config-driven, this just catches a default-layer
-// typo or a surprise LOOMCYCLE_NO_DEFAULT_PROVIDERS run.
-var expectedBuiltinProviderIDs = []string{
-	"anthropic", "code-js", "deepseek", "gemini", "mock", "mock-stable",
-	"ollama", "ollama-local", "openai",
-}
-
 // newProviderResolver builds every enabled provider from cfg.Providers via the
 // RFC BF driver registry (config-driven flip of the pre-P2a hardcoded per-provider
 // construction). It is byte-identical when no operator `providers:` block is
@@ -3272,9 +3263,10 @@ func providerDisabledReason(id string, pc config.ProviderConfig) string {
 	}
 }
 
-// logProviderSummary logs the config-sourced provider inventory (RFC BF P2a
-// Deliverable 5) + a WARN if the merged config is missing a built-in the
-// default-providers layer should have supplied (catches a default-layer typo).
+// logProviderSummary logs the config-sourced provider inventory. RFC BF P3: the
+// built-ins are now sourced SOLELY from the embedded default-providers layer, so
+// the hardcoded-vs-config divergence WARN (a P2a transition scaffold) is gone —
+// there is no hardcoded expected set left to diverge from.
 func logProviderSummary(pr *providerResolver, cfg *config.Config) {
 	enabled := make([]string, 0, len(pr.byID))
 	for id := range pr.byID {
@@ -3282,15 +3274,6 @@ func logProviderSummary(pr *providerResolver, cfg *config.Config) {
 	}
 	sort.Strings(enabled)
 	log.Printf("providers: %d configured, %d enabled (%s)", len(cfg.Providers), len(pr.byID), strings.Join(enabled, ", "))
-	// Skip the divergence check when the operator deliberately dropped the layer.
-	if os.Getenv("LOOMCYCLE_NO_DEFAULT_PROVIDERS") == "1" {
-		return
-	}
-	for _, id := range expectedBuiltinProviderIDs {
-		if _, ok := cfg.Providers[id]; !ok {
-			log.Printf("providers: WARNING — built-in %q missing from the merged config (default-providers layer dropped or overridden)", id)
-		}
-	}
 }
 
 // toCapabilityPatch translates a config.CapabilityOverride (the `capabilities:`

--- a/cmd/loomcycle/presets_integration_test.go
+++ b/cmd/loomcycle/presets_integration_test.go
@@ -10,15 +10,21 @@ import (
 
 // layersFor resolves embedded unit names to config layers, the same mapping
 // main() does for LOOMCYCLE_PRESETS (kept in lockstep with selectPresetLayers).
+// RFC BF P3: it prepends the embedded default-providers layer as the base — the
+// SOLE source of the built-in providers now that the hardcoded validation floor
+// is gone — exactly as main() assembles the real stack. Without it, a preset
+// stack that references built-ins in provider_priority/tiers would fail to
+// validate.
 func layersFor(t *testing.T, names ...string) []config.Layer {
 	t.Helper()
 	units, err := embedded.ResolveUnits(names)
 	if err != nil {
 		t.Fatalf("ResolveUnits(%v): %v", names, err)
 	}
-	layers := make([]config.Layer, len(units))
-	for i, u := range units {
-		layers[i] = config.Layer{Name: u.Name, Data: u.Data}
+	layers := make([]config.Layer, 0, len(units)+1)
+	layers = append(layers, config.Layer{Name: "providers.default", Data: embedded.DefaultProviders()})
+	for _, u := range units {
+		layers = append(layers, config.Layer{Name: u.Name, Data: u.Data})
 	}
 	return layers
 }

--- a/internal/cli/drivers_test.go
+++ b/internal/cli/drivers_test.go
@@ -1,0 +1,19 @@
+package cli
+
+// RFC BF P3 — loadLayeredConfig now prepends the embedded default-providers layer
+// (the sole source of the built-ins after the hardcoded floor was deleted), so
+// LoadLayers validates each declared entry's driver against the providers driver
+// registry (providers.RegisteredDrivers), populated by each driver package's
+// init() self-registration. The real loomcycle binary gets that via blank imports
+// in cmd/loomcycle; the CLI test binary gets it here so validate()/loadLayeredConfig
+// exercise the same registered factories the server does. None of these packages
+// import internal/cli, so there is no import cycle.
+import (
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/anthropic"
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/codejs"
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/deepseek"
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/gemini"
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/mock"
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/ollama"
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/openai"
+)

--- a/internal/cli/loadcfg.go
+++ b/internal/cli/loadcfg.go
@@ -28,6 +28,23 @@ import (
 func loadLayeredConfig(explicitPath string) (*config.Config, error) {
 	var layers []config.Layer
 
+	// RFC BF P3: the embedded default-providers layer is the base of the stack and
+	// the SOLE source of the built-in providers (P3 deleted the hardcoded
+	// validation floor). Prepend it here — exactly as cmd/loomcycle/main.go does —
+	// so CLI introspection (validate / agents / doctor) resolves and validates the
+	// same provider set the server runs. Without it, a config that references a
+	// built-in (e.g. `provider: anthropic`) with no `providers:` block would fail
+	// CLI validation. LOOMCYCLE_NO_DEFAULT_PROVIDERS=1 opts out (operator declares
+	// its own providers:).
+	if os.Getenv("LOOMCYCLE_NO_DEFAULT_PROVIDERS") != "1" {
+		layers = append(layers, config.Layer{Name: "providers.default", Data: embedded.DefaultProviders()})
+	}
+	// The default-providers layer is infrastructure, not a USER config source, so a
+	// missing --config must still surface its not-found error even when the layer is
+	// present. Track the base count so the explicit-path keep/skip decision below
+	// keys off whether any user layer (presets / CONFIG_DIR / CONFIG_FILES) exists.
+	baseLayerCount := len(layers)
+
 	// Embedded presets — the base of the stack.
 	var presetNames []string
 	for _, n := range strings.Split(os.Getenv("LOOMCYCLE_PRESETS"), ",") {
@@ -65,10 +82,10 @@ func loadLayeredConfig(explicitPath string) (*config.Config, error) {
 
 	// The explicit --config path (highest precedence). When it's absent from
 	// disk but the presets/env layers already provide a config, skip it (a
-	// presets-only stack, RFC AQ); when there are no other layers, keep it so
+	// presets-only stack, RFC AQ); when there are no other USER layers, keep it so
 	// LoadLayers surfaces the same file-not-found error the CLI produced before.
 	if explicitPath = strings.TrimSpace(explicitPath); explicitPath != "" {
-		if _, err := os.Stat(explicitPath); err == nil || len(layers) == 0 {
+		if _, err := os.Stat(explicitPath); err == nil || len(layers) == baseLayerCount {
 			layers = append(layers, config.Layer{Name: explicitPath})
 		}
 	}

--- a/internal/cli/loadcfg_test.go
+++ b/internal/cli/loadcfg_test.go
@@ -55,3 +55,33 @@ func TestLoadLayeredConfig_NoPresetsUnchanged(t *testing.T) {
 		t.Error("deepseek-pro alias present without presets — layering leaked the base preset")
 	}
 }
+
+// TestLoadLayeredConfig_PrependsDefaultProviders is the RFC BF P3 CLI/server-parity
+// guard: a --config that references a built-in provider (anthropic) with NO
+// providers: block validates through the CLI loader because loadLayeredConfig
+// prepends the embedded default-providers layer — exactly as cmd/loomcycle/main.go
+// does. P3 deleted the hardcoded validation floor, so without the prepend the CLI
+// would falsely reject a config the server runs fine.
+//
+// Fail-before: drop the default-providers prepend in loadLayeredConfig → the first
+// load fails "unknown provider anthropic".
+func TestLoadLayeredConfig_PrependsDefaultProviders(t *testing.T) {
+	t.Setenv("LOOMCYCLE_PRESETS", "")
+	t.Setenv("LOOMCYCLE_CONFIG_DIR", "")
+	t.Setenv("LOOMCYCLE_CONFIG_FILES", "")
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "c.yaml")
+	if err := os.WriteFile(cfgPath, []byte("provider_priority: [anthropic]\nagents:\n  a: { provider: anthropic, model: claude }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadLayeredConfig(cfgPath); err != nil {
+		t.Fatalf("a built-in ref without a providers: block was rejected — the default-providers layer isn't prepended: %v", err)
+	}
+
+	// LOOMCYCLE_NO_DEFAULT_PROVIDERS drops the layer → the undeclared built-in ref
+	// must now fail validation (the operator opted into full provider control).
+	t.Setenv("LOOMCYCLE_NO_DEFAULT_PROVIDERS", "1")
+	if _, err := loadLayeredConfig(cfgPath); err == nil {
+		t.Error("with LOOMCYCLE_NO_DEFAULT_PROVIDERS=1 an undeclared built-in ref must fail validation")
+	}
+}

--- a/internal/config/alias_test.go
+++ b/internal/config/alias_test.go
@@ -43,19 +43,23 @@ func TestValidateTierCandidate_AliasAware(t *testing.T) {
 	models := map[string]ModelRef{
 		"local-qwen": {Provider: "ollama-local", Model: "qwen3.6:max"},
 	}
-	if err := validateTierCandidate(TierCandidate{Model: "local-qwen"}, models, validProviderIDs); err != nil {
+	// RFC BF P3: the hardcoded built-in floor (validProviderIDs) is gone — provider
+	// references validate against the declared providers: keys. Pass an explicit
+	// known set standing in for what the default-providers layer would supply.
+	known := map[string]bool{"deepseek": true, "ollama-local": true}
+	if err := validateTierCandidate(TierCandidate{Model: "local-qwen"}, models, known); err != nil {
 		t.Errorf("bare alias rejected: %v", err)
 	}
-	if err := validateTierCandidate(TierCandidate{Model: "not-an-alias"}, models, validProviderIDs); err == nil {
+	if err := validateTierCandidate(TierCandidate{Model: "not-an-alias"}, models, known); err == nil {
 		t.Error("empty provider + non-alias model accepted, want error")
 	}
-	if err := validateTierCandidate(TierCandidate{Provider: "deepseek", Model: "deepseek-v4-pro"}, models, validProviderIDs); err != nil {
+	if err := validateTierCandidate(TierCandidate{Provider: "deepseek", Model: "deepseek-v4-pro"}, models, known); err != nil {
 		t.Errorf("explicit literal candidate rejected: %v", err)
 	}
-	if err := validateTierCandidate(TierCandidate{Provider: "bogus", Model: "x"}, models, validProviderIDs); err == nil {
+	if err := validateTierCandidate(TierCandidate{Provider: "bogus", Model: "x"}, models, known); err == nil {
 		t.Error("unknown provider accepted, want error")
 	}
-	if err := validateTierCandidate(TierCandidate{Provider: "deepseek"}, models, validProviderIDs); err == nil {
+	if err := validateTierCandidate(TierCandidate{Provider: "deepseek"}, models, known); err == nil {
 		t.Error("explicit provider + empty model accepted, want error")
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4528,54 +4528,49 @@ func splitCSV(s string) []string {
 	return out
 }
 
-// validProviderIDs is the built-in provider FLOOR — the ids the pre-RFC-BF
-// resolver hardcoded. RFC BF P2a: provider references (agent pins, tier
-// candidates, model aliases, provider_priority) validate against
-// knownProviderIDs() = this floor UNION the operator's declared `providers:` keys,
-// so a config-declared 3rd-party provider validates too, while every existing
-// config stays valid whether or not it declares a `providers:` block. Kept as a
-// floor (not replaced by cfg.Providers keys) because validate() also runs on
-// configs assembled WITHOUT the embedded default-providers layer — CLI/unit
-// paths, and LOOMCYCLE_NO_DEFAULT_PROVIDERS — where the built-ins would otherwise
-// vanish from the valid set.
-var validProviderIDs = map[string]bool{
-	"anthropic":    true,
-	"openai":       true,
-	"deepseek":     true,
-	"ollama":       true, // hosted ollama.com (Bearer auth)
-	"ollama-local": true, // local-network Ollama (no auth)
-	"gemini":       true,
-	// v0.11.9 — opt-in OAuth-dev provider. config-load accepts the ID;
-	// the resolver returns a clear "not registered" error at request
-	// time if LOOMCYCLE_ANTHROPIC_OAUTH_DEV_ENABLED=1 isn't set or no
-	// token file exists. See docs/PROVIDERS.md.
+// residualProviderIDs are the provider ids valid to REFERENCE but deliberately
+// NOT declared in the `providers:` map — today just anthropic-oauth-dev. RFC BF
+// locked decision #7 keeps it a thin hardcoded registration (its background token
+// Refresher lifecycle is main-owned), so it is neither a registry driver nor a
+// providers.default.yaml entry, yet an operator may still name it in a tier /
+// priority list.
+//
+// RFC BF P3 deleted the old built-in FLOOR: the six real providers +
+// mock/mock-stable/code-js now come SOLELY from the embedded default-providers
+// layer (→ cfg.Providers), which BOTH the server (cmd/loomcycle/main.go) and the
+// CLI (internal/cli.loadLayeredConfig) prepend. Under LOOMCYCLE_NO_DEFAULT_PROVIDERS
+// the operator takes full control and must declare its own `providers:` block;
+// only this residual stays referenceable without one.
+var residualProviderIDs = map[string]bool{
 	"anthropic-oauth-dev": true,
-	// v0.12.8 — synthetic mock provider for cost-free stress testing.
-	// config-load accepts the ID; the resolver returns a clear "not
-	// configured" error at request time if LOOMCYCLE_MOCK_ENABLED=1
-	// isn't set. See internal/providers/mock/driver.go.
-	"mock": true,
-	// v0.12.9 — companion stable variant; same gate as `mock`.
-	// Lets operators configure tier candidate lists like
-	// `[{provider: mock, ...}, {provider: mock-stable, ...}]` for
-	// fallback-recovery testing without a real second provider.
-	"mock-stable": true,
 }
 
-// knownProviderIDs is the set a provider reference may name: the built-in floor
-// (validProviderIDs) UNION the operator's declared `providers:` keys (RFC BF P2a).
-// A declared 3rd-party provider validates in tier candidates / agent pins /
-// provider_priority / model aliases; the built-ins always validate so no existing
-// config regresses.
+// knownProviderIDs is the set a provider reference may name: the operator's
+// declared `providers:` keys (the embedded default-providers layer supplies the
+// built-ins) UNION the anthropic-oauth-dev residual (RFC BF P3). A declared
+// 3rd-party provider validates in tier candidates / agent pins / provider_priority
+// / model aliases.
 func (c *Config) knownProviderIDs() map[string]bool {
-	out := make(map[string]bool, len(validProviderIDs)+len(c.Providers))
-	for id := range validProviderIDs {
+	out := make(map[string]bool, len(residualProviderIDs)+len(c.Providers))
+	for id := range residualProviderIDs {
 		out[id] = true
 	}
 	for id := range c.Providers {
 		out[id] = true
 	}
 	return out
+}
+
+// sortedProviderIDs returns the keys of a known-provider set in deterministic
+// order — for the "unknown provider" validation messages, so the hint reflects
+// the config's ACTUAL declared providers rather than a frozen hardcoded list.
+func sortedProviderIDs(known map[string]bool) []string {
+	ids := make([]string, 0, len(known))
+	for id := range known {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
 }
 
 // validTierNames is the closed set of tier names. Operators choose
@@ -4928,7 +4923,7 @@ func validate(c *Config) error {
 	// to its hardcoded default order).
 	for i, p := range c.ProviderPriority {
 		if !known[p] {
-			return fmt.Errorf("provider_priority[%d]: unknown provider %q (want one of anthropic/openai/deepseek/gemini/ollama)", i, p)
+			return fmt.Errorf("provider_priority[%d]: unknown provider %q (declare it under providers:; known: %v)", i, p, sortedProviderIDs(known))
 		}
 	}
 	// Search providers (RFC BB): validate the enabled set against the known

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -29,7 +29,10 @@ func TestLoadExample(t *testing.T) {
 	}
 
 	t.Setenv("ANTHROPIC_API_KEY", "sk-test")
-	cfg, err := Load(examplePath)
+	// RFC BF P3: the example config references built-in providers but declares no
+	// providers: block (the server supplies them via the embedded default layer),
+	// so load it WITH that layer — as the running server does.
+	cfg, err := loadWithDefaults(examplePath)
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
@@ -1352,7 +1355,9 @@ user_tiers:
 `), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	_, err := Load(yamlPath)
+	// RFC BF P3: default-providers layer supplies the built-ins so validation
+	// reaches the badtier typo rather than tripping on the (valid) default tier.
+	_, err := loadWithDefaults(yamlPath)
 	if err == nil {
 		t.Fatal("expected validation error for unknown provider")
 	}
@@ -1387,7 +1392,7 @@ user_tiers:
 `), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	cfg, err := Load(yamlPath)
+	cfg, err := loadWithDefaults(yamlPath) // RFC BF P3: built-ins via the default-providers layer
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
@@ -1424,7 +1429,9 @@ user_tiers:
 `), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	_, err := Load(yamlPath)
+	// RFC BF P3: built-ins via the default-providers layer so validation reaches
+	// the negative max_fallback_attempts check rather than the provider check.
+	_, err := loadWithDefaults(yamlPath)
 	if err == nil {
 		t.Fatal("expected error for negative max_fallback_attempts")
 	}

--- a/internal/config/layering_test.go
+++ b/internal/config/layering_test.go
@@ -142,7 +142,9 @@ agents:
   code-guru:
     system_prompt: review code
 `)
-	cfg, err := Load(bundle, operator)
+	// RFC BF P3: prepend the default-providers layer (as the server/CLI do) so the
+	// operator's `mock` provider reference validates — the hardcoded floor is gone.
+	cfg, err := LoadLayers(withDefaultProviders(Layer{Name: bundle}, Layer{Name: operator})...)
 	if err != nil {
 		t.Fatalf("Load(bundle, operator): %v", err)
 	}
@@ -194,7 +196,9 @@ func TestLoad_PerLayerEnvExpansion(t *testing.T) {
 	dir := t.TempDir()
 	f1 := writeYAML(t, dir, "f1.yaml", "defaults:\n  model: m\n")
 	f2 := writeYAML(t, dir, "f2.yaml", "provider_priority: [\"${LOOMCYCLE_TEST_PROVIDER}\"]\n")
-	cfg, err := Load(f1, f2)
+	// RFC BF P3: prepend the default-providers layer so the expanded `mock`
+	// provider reference validates (the hardcoded floor is gone).
+	cfg, err := LoadLayers(withDefaultProviders(Layer{Name: f1}, Layer{Name: f2})...)
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}

--- a/internal/config/loadlayers_test.go
+++ b/internal/config/loadlayers_test.go
@@ -17,7 +17,9 @@ provider_priority: [anthropic, openai]
 models:
   base-sonnet: { provider: anthropic, model: claude-sonnet-4-6 }
 `)
-	cfg, err := LoadLayers(Layer{Name: "base", Data: base}, Layer{Name: overlay})
+	// RFC BF P3: the built-ins are only valid when the default-providers layer is
+	// present (the hardcoded floor is gone), so prepend it — as the server/CLI do.
+	cfg, err := LoadLayers(withDefaultProviders(Layer{Name: "base", Data: base}, Layer{Name: overlay})...)
 	if err != nil {
 		t.Fatalf("LoadLayers: %v", err)
 	}
@@ -34,8 +36,13 @@ models:
 // TestLoadLayers_SingleInMemoryLayer: a presets-only stack (one in-memory layer,
 // no disk file) resolves — the bare-start case (RFC AQ §2.2).
 func TestLoadLayers_SingleInMemoryLayer(t *testing.T) {
+	// RFC BF P3: a valid config needs its providers declared (no hardcoded floor).
+	// Declared inline here to keep this the SINGLE-in-memory-layer case the test
+	// exercises (prepending the default-providers layer would make it two).
 	base := []byte(`
 provider_priority: [anthropic]
+providers:
+  anthropic: { driver: anthropic }
 models:
   base-sonnet: { provider: anthropic, model: claude-sonnet-4-6 }
 `)
@@ -56,8 +63,14 @@ models:
 // take the same byte-identical single-file fast path and produce the same result.
 func TestLoadLayers_SingleFileMatchesLoad(t *testing.T) {
 	dir := t.TempDir()
+	// RFC BF P3: providers declared inline so the single-file fast path validates
+	// on BOTH Load and LoadLayers (this test asserts they are byte-identical, so it
+	// can't prepend a default-providers layer to just one side).
 	p := writeYAML(t, dir, "loomcycle.yaml", `
 provider_priority: [anthropic, openai]
+providers:
+  anthropic: { driver: anthropic }
+  openai: { driver: openai }
 `)
 	viaLoad, err := Load(p)
 	if err != nil {

--- a/internal/config/prepend_merge_test.go
+++ b/internal/config/prepend_merge_test.go
@@ -117,7 +117,10 @@ func TestLoad_PrependNotAConflictUnderStrict(t *testing.T) {
 	dir := t.TempDir()
 	base := writeYAML(t, dir, "base.yaml", "provider_priority: [deepseek]\n")
 	over := writeYAML(t, dir, "over.yaml", "provider_priority: !prepend [anthropic]\n")
-	cfg, err := Load(base, over)
+	// RFC BF P3: prepend the default-providers layer so deepseek/anthropic validate
+	// (no hardcoded floor). It sets only providers:, so it neither participates in
+	// the !prepend compose nor trips STRICT (no cross-layer key clobber).
+	cfg, err := LoadLayers(withDefaultProviders(Layer{Name: base}, Layer{Name: over})...)
 	if err != nil {
 		t.Fatalf("strict Load with a !prepend merge should succeed: %v", err)
 	}
@@ -141,7 +144,9 @@ tiers:
 tiers:
   middle: !prepend [oauth-sonnet]
 `)
-	cfg, err := Load(base, over)
+	// RFC BF P3: prepend the default-providers layer so the `deepseek` alias
+	// provider validates (anthropic-oauth-dev stays valid as the residual).
+	cfg, err := LoadLayers(withDefaultProviders(Layer{Name: base}, Layer{Name: over})...)
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}

--- a/internal/config/providers_default_layer_test.go
+++ b/internal/config/providers_default_layer_test.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"github.com/denn-gubsky/loomcycle/cmd/loomcycle/embedded"
+)
+
+// defaultProvidersLayer is the embedded default-providers layer — the SOLE source
+// of the built-in providers after RFC BF P3 (which deleted the hardcoded
+// validation floor). Both the server (cmd/loomcycle/main.go) and the CLI
+// (internal/cli.loadLayeredConfig) prepend it, so a config that references a
+// built-in provider (anthropic/mock/deepseek/…) is only valid in the presence of
+// this layer.
+func defaultProvidersLayer() Layer {
+	return Layer{Name: "providers.default", Data: embedded.DefaultProviders()}
+}
+
+// withDefaultProviders prepends the embedded default-providers layer to layers,
+// mirroring the real server/CLI assembly. Tests that load a built-in-referencing
+// config without their own providers: block use this so provider references
+// validate (RFC BF P3 removed the hardcoded floor that used to make them valid).
+func withDefaultProviders(layers ...Layer) []Layer {
+	return append([]Layer{defaultProvidersLayer()}, layers...)
+}
+
+// loadWithDefaults loads a single config file WITH the embedded default-providers
+// layer prepended — exactly as the server (cmd/loomcycle) and CLI
+// (internal/cli.loadLayeredConfig) assemble it. Replaces bare Load(path) in tests
+// whose fixture references built-in providers, which after RFC BF P3 are only
+// valid when that layer supplies them.
+func loadWithDefaults(path string) (*Config, error) {
+	return LoadLayers(withDefaultProviders(Layer{Name: path})...)
+}

--- a/internal/config/providers_test.go
+++ b/internal/config/providers_test.go
@@ -146,6 +146,10 @@ func TestValidate_ThirdPartyProvider_AcceptedAsReference(t *testing.T) {
 			Providers: map[string]ProviderConfig{
 				// A self-hosted OpenAI-compatible mirror declared by the operator.
 				"my-vllm": {Driver: "openai", BaseURL: "http://vllm.local", APIKeyEnv: "MY_VLLM_KEY"},
+				// RFC BF P3: built-ins have no hardcoded floor — a raw Config passed to
+				// validate() must declare every provider it references (the default
+				// layer does this in the real load path).
+				"anthropic": {Driver: "anthropic"},
 			},
 			ProviderPriority: []string{"my-vllm", "anthropic"},
 			Tiers:            map[string][]TierCandidate{"middle": {{Provider: "my-vllm", Model: "qwen"}}},
@@ -156,7 +160,8 @@ func TestValidate_ThirdPartyProvider_AcceptedAsReference(t *testing.T) {
 		t.Errorf("declared 3rd-party provider rejected as reference: %v", err)
 	}
 
-	// An UNDECLARED id must still fail — the floor + declared set is the ceiling.
+	// An UNDECLARED id must still fail — the declared providers: set (+ the
+	// anthropic-oauth-dev residual) is the ceiling (RFC BF P3 removed the floor).
 	bad := base()
 	bad.ProviderPriority = []string{"ghost"}
 	if err := validate(bad); err == nil || !strings.Contains(err.Error(), "unknown provider") {
@@ -164,10 +169,54 @@ func TestValidate_ThirdPartyProvider_AcceptedAsReference(t *testing.T) {
 	}
 }
 
-// TestValidate_ModelAliasProvider covers the new models[*].provider check: a
-// built-in provider on an alias passes (floor), a declared 3rd-party passes, and
-// a bogus provider is rejected. An empty-provider alias is left to the pin/tier
-// that names it, so it must NOT be rejected here.
+// TestValidate_NoBuiltinFloor_AfterP3 locks the RFC BF P3 removal of the hardcoded
+// built-in provider floor: a config that references a built-in (anthropic) with no
+// providers: block (and no default-providers layer) is REJECTED. Fail-before: on
+// the pre-P3 9-id floor, anthropic was always "known" and this validated.
+func TestValidate_NoBuiltinFloor_AfterP3(t *testing.T) {
+	cfg := &Config{
+		Defaults:         Defaults{Provider: "anthropic", Model: "x"},
+		Concurrency:      Concurrency{MaxConcurrentRuns: 1},
+		ProviderPriority: []string{"anthropic"},
+	}
+	err := validate(cfg)
+	if err == nil || !strings.Contains(err.Error(), "unknown provider") {
+		t.Errorf("validate() = %v; want an unknown-provider error (P3 removed the built-in floor)", err)
+	}
+}
+
+// TestValidate_OAuthDevResidualValidWithoutDeclaration locks RFC BF locked decision
+// #7 through P3: anthropic-oauth-dev is NOT in the providers: map (it is a residual
+// hardcoded registration, never a registry driver nor a default-providers entry)
+// yet stays a valid provider reference with no declaration.
+func TestValidate_OAuthDevResidualValidWithoutDeclaration(t *testing.T) {
+	cfg := &Config{
+		Defaults:         Defaults{Provider: "anthropic-oauth-dev", Model: "x"},
+		Concurrency:      Concurrency{MaxConcurrentRuns: 1},
+		ProviderPriority: []string{"anthropic-oauth-dev"},
+	}
+	if err := validate(cfg); err != nil {
+		t.Errorf("anthropic-oauth-dev residual rejected without a providers: entry: %v", err)
+	}
+}
+
+// TestValidate_BuiltinValidViaDefaultProvidersLayer proves the built-ins ARE valid
+// once the embedded default-providers layer supplies them (the P3 sole source) —
+// the same layer the server and CLI prepend. This is the back-compat guarantee: a
+// providers:-less operator config still validates in the real load path.
+func TestValidate_BuiltinValidViaDefaultProvidersLayer(t *testing.T) {
+	overlay := []byte("defaults: { provider: anthropic, model: x }\nprovider_priority: [anthropic]\nconcurrency: { max_concurrent_runs: 1 }\n")
+	if _, err := LoadLayers(withDefaultProviders(Layer{Name: "overlay", Data: overlay})...); err != nil {
+		t.Errorf("built-in anthropic rejected even WITH the default-providers layer: %v", err)
+	}
+}
+
+// TestValidate_ModelAliasProvider covers the models[*].provider check: a declared
+// provider on an alias passes, a declared 3rd-party passes, and a bogus provider
+// is rejected. An empty-provider alias is left to the pin/tier that names it, so
+// it must NOT be rejected here. RFC BF P3: there is no built-in floor — a
+// referenced built-in must be declared (the default layer does this in the real
+// load path; here it's declared inline).
 func TestValidate_ModelAliasProvider(t *testing.T) {
 	base := func(models map[string]ModelRef, providers map[string]ProviderConfig) *Config {
 		return &Config{
@@ -177,8 +226,11 @@ func TestValidate_ModelAliasProvider(t *testing.T) {
 			Providers:   providers,
 		}
 	}
-	if err := validate(base(map[string]ModelRef{"a": {Provider: "anthropic", Model: "claude"}}, nil)); err != nil {
-		t.Errorf("built-in alias provider rejected: %v", err)
+	if err := validate(base(
+		map[string]ModelRef{"a": {Provider: "anthropic", Model: "claude"}},
+		map[string]ProviderConfig{"anthropic": {Driver: "anthropic"}},
+	)); err != nil {
+		t.Errorf("declared built-in alias provider rejected: %v", err)
 	}
 	if err := validate(base(
 		map[string]ModelRef{"a": {Provider: "my-vllm", Model: "qwen"}},


### PR DESCRIPTION
## Why

RFC BF **Phase 3 — "delete the built-ins."** P2a (#729) already flipped resolution fully config-driven — `newProviderResolver` builds only from `cfg.Providers` via the driver registry, and the boot probe iterates `cfg.Providers` — so the resolver's hardcoded fields, env-gated `New()` block, and `Get()` switch (the RFC's literal P3 targets, written pre-P2a) were **already gone**. What remained were the P2a **scaffolding enumerations** that still hardcoded the built-in set. P3 removes them so the embedded default-providers layer is the *sole* source of the built-ins.

## What

- **`cmd/loomcycle`** — deleted `expectedBuiltinProviderIDs` + the boot **divergence WARN** (a P2a Deliverable-5 transition scaffold comparing the merged config against a hardcoded 9-id list). There's no hardcoded expected set left to diverge from.
- **`internal/config`** — reduced `validProviderIDs` (the hardcoded 9-id validation **floor**) to `residualProviderIDs = {anthropic-oauth-dev}`. That's the one id valid to *reference* but deliberately not in the `providers:` map — RFC BF locked decision **#7** keeps it a thin residual (main-owned token `Refresher`; never a registry driver nor a `providers.default.yaml` entry). Every other built-in now validates only because the default-providers layer supplies it in `cfg.Providers`. Also replaced the stale hardcoded list in the `provider_priority` "unknown provider" message with the config's **actual** known set.
- **`internal/cli`** — `loadLayeredConfig` now **prepends the embedded default-providers layer** (honoring `LOOMCYCLE_NO_DEFAULT_PROVIDERS`), fixing a latent divergence: the CLI claimed to assemble "the SAME layered configuration the server builds" but omitted this base layer. This is what lets `validate`/`doctor`/`agents` accept a built-in-referencing config after the floor is gone. A **missing `--config` still errors** — the default-providers layer is infrastructure, not a user config source, so the explicit-path keep/skip decision keys off *user* layers only (`baseLayerCount`).

**End state:** the embedded default-providers layer is the sole source of the six real providers + `mock`/`mock-stable`/`code-js`, for **both** the server and the CLI. Under `LOOMCYCLE_NO_DEFAULT_PROVIDERS` the operator takes full control and must declare its own `providers:` (only the oauth-dev residual stays referenceable without one).

**Not in scope:** `defaultLibraryPriority` (a resolver default *ordering*, not a registration) and the `anthropic-oauth-dev` residual registration itself (kept per decision #7).

## What was tested

- **Migrated** the config/cli/cmd tests that built a built-in-referencing config *without* the default layer (they relied on the deleted floor): a `withDefaultProviders` helper prepends the embedded layer (mirroring the real load path); `validate()`-direct tests declare their built-ins inline; a CLI `drivers_test.go` registers the driver factories in the CLI test binary (as `cmd/loomcycle` and the config test binary do). One CLI regression found + fixed along the way: a missing `--config` must still error despite the always-present base layer.
- **New guards** (fail-before verified):
  - `TestValidate_NoBuiltinFloor_AfterP3` — a providers-less `provider_priority: [anthropic]` is rejected. Fail-before: restore `anthropic` to the floor → it passes.
  - `TestLoadLayeredConfig_PrependsDefaultProviders` — a providers-less `--config` referencing `anthropic` loads via the CLI; `NO_DEFAULT_PROVIDERS=1` makes it fail. Fail-before: drop the prepend → the first load rejects.
  - `TestValidate_OAuthDevResidualValidWithoutDeclaration`, `TestValidate_BuiltinValidViaDefaultProvidersLayer`.
- `go test -race ./...`, `go vet`, `gofmt -l`, `make build-all` — all clean.
- **Manual (real binary):** `loomcycle validate` on a providers-less config referencing built-ins → **OK** (probe → `provider=anthropic`); with `LOOMCYCLE_NO_DEFAULT_PROVIDERS=1` → fails `provider_priority[0]: unknown provider "anthropic" (declare it under providers:; known: [anthropic-oauth-dev])`; boot logs `providers: 9 configured, 2 enabled (anthropic, ollama-local)` with **no** divergence WARN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD
