### PR TITLE
chore(providers): RFC BF P3 — CLI provider-layer parity + drop P2a scaffolding (keep validation floor)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -3014,15 +3014,6 @@ func buildEmbedder(cfg *config.Config) (providers.Embedder, error) {
 	})
 }
 
-// expectedBuiltinProviderIDs is the set the embedded default-providers layer
-// declares. Used only by the boot divergence WARN (RFC BF P2a Deliverable 5) —
-// resolution itself is fully config-driven, this just catches a default-layer
-// typo or a surprise LOOMCYCLE_NO_DEFAULT_PROVIDERS run.
-var expectedBuiltinProviderIDs = []string{
-	"anthropic", "code-js", "deepseek", "gemini", "mock", "mock-stable",
-	"ollama", "ollama-local", "openai",
-}
-
 // newProviderResolver builds every enabled provider from cfg.Providers via the
 // RFC BF driver registry (config-driven flip of the pre-P2a hardcoded per-provider
 // construction). It is byte-identical when no operator `providers:` block is
@@ -3272,9 +3263,9 @@ func providerDisabledReason(id string, pc config.ProviderConfig) string {
 	}
 }
 
-// logProviderSummary logs the config-sourced provider inventory (RFC BF P2a
-// Deliverable 5) + a WARN if the merged config is missing a built-in the
-// default-providers layer should have supplied (catches a default-layer typo).
+// logProviderSummary logs the config-sourced provider inventory at boot. Under
+// RFC BF providers are fully config-driven; the embedded default-providers layer
+// (cmd/loomcycle/embedded/providers.default.yaml) supplies the built-ins.
 func logProviderSummary(pr *providerResolver, cfg *config.Config) {
 	enabled := make([]string, 0, len(pr.byID))
 	for id := range pr.byID {
@@ -3282,15 +3273,6 @@ func logProviderSummary(pr *providerResolver, cfg *config.Config) {
 	}
 	sort.Strings(enabled)
 	log.Printf("providers: %d configured, %d enabled (%s)", len(cfg.Providers), len(pr.byID), strings.Join(enabled, ", "))
-	// Skip the divergence check when the operator deliberately dropped the layer.
-	if os.Getenv("LOOMCYCLE_NO_DEFAULT_PROVIDERS") == "1" {
-		return
-	}
-	for _, id := range expectedBuiltinProviderIDs {
-		if _, ok := cfg.Providers[id]; !ok {
-			log.Printf("providers: WARNING — built-in %q missing from the merged config (default-providers layer dropped or overridden)", id)
-		}
-	}
 }
 
 // toCapabilityPatch translates a config.CapabilityOverride (the `capabilities:`

--- a/internal/cli/drivers_test.go
+++ b/internal/cli/drivers_test.go
@@ -1,0 +1,18 @@
+package cli
+
+// The production loomcycle binary registers every provider driver via blank
+// imports in cmd/loomcycle/main.go, so `loomcycle validate|agents|doctor` see
+// the full driver set when loadLayeredConfig prepends the embedded
+// default-providers layer (RFC BF). The internal/cli TEST binary does not link
+// cmd/loomcycle, so it must register the same drivers itself — otherwise the
+// default-providers layer fails driver validation with "unknown driver". These
+// blank imports mirror the default-providers.yaml driver set exactly.
+import (
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/anthropic"
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/codejs"
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/deepseek"
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/gemini"
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/mock"
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/ollama"
+	_ "github.com/denn-gubsky/loomcycle/internal/providers/openai"
+)

--- a/internal/cli/loadcfg.go
+++ b/internal/cli/loadcfg.go
@@ -28,7 +28,21 @@ import (
 func loadLayeredConfig(explicitPath string) (*config.Config, error) {
 	var layers []config.Layer
 
-	// Embedded presets — the base of the stack.
+	// Embedded default-providers layer (RFC BF) — the true base of the stack, so
+	// CLI introspection resolves the built-in providers from the SAME source the
+	// server assembles (cmd/loomcycle/main.go prepends it identically). Without
+	// this, validate/doctor/agents fell back on the config package's built-in
+	// floor and could disagree with the running server. LOOMCYCLE_NO_DEFAULT_PROVIDERS=1
+	// drops it (matching the server).
+	if os.Getenv("LOOMCYCLE_NO_DEFAULT_PROVIDERS") != "1" {
+		layers = append(layers, config.Layer{Name: "providers.default", Data: embedded.DefaultProviders()})
+	}
+	// The default-providers layer is always-on infrastructure, NOT operator-supplied
+	// config — the explicit-path check below must not treat it as "a config was
+	// already provided", or a missing --config file would be silently ignored.
+	baseLayers := len(layers)
+
+	// Embedded presets — layered over the default providers.
 	var presetNames []string
 	for _, n := range strings.Split(os.Getenv("LOOMCYCLE_PRESETS"), ",") {
 		if n = strings.TrimSpace(n); n != "" {
@@ -65,10 +79,11 @@ func loadLayeredConfig(explicitPath string) (*config.Config, error) {
 
 	// The explicit --config path (highest precedence). When it's absent from
 	// disk but the presets/env layers already provide a config, skip it (a
-	// presets-only stack, RFC AQ); when there are no other layers, keep it so
-	// LoadLayers surfaces the same file-not-found error the CLI produced before.
+	// presets-only stack, RFC AQ); when there are no other operator layers, keep
+	// it so LoadLayers surfaces the same file-not-found error the CLI produced
+	// before (baseLayers excludes the always-on default-providers layer).
 	if explicitPath = strings.TrimSpace(explicitPath); explicitPath != "" {
-		if _, err := os.Stat(explicitPath); err == nil || len(layers) == 0 {
+		if _, err := os.Stat(explicitPath); err == nil || len(layers) == baseLayers {
 			layers = append(layers, config.Layer{Name: explicitPath})
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4528,16 +4528,26 @@ func splitCSV(s string) []string {
 	return out
 }
 
-// validProviderIDs is the built-in provider FLOOR — the ids the pre-RFC-BF
-// resolver hardcoded. RFC BF P2a: provider references (agent pins, tier
-// candidates, model aliases, provider_priority) validate against
-// knownProviderIDs() = this floor UNION the operator's declared `providers:` keys,
-// so a config-declared 3rd-party provider validates too, while every existing
-// config stays valid whether or not it declares a `providers:` block. Kept as a
-// floor (not replaced by cfg.Providers keys) because validate() also runs on
-// configs assembled WITHOUT the embedded default-providers layer — CLI/unit
-// paths, and LOOMCYCLE_NO_DEFAULT_PROVIDERS — where the built-ins would otherwise
-// vanish from the valid set.
+// validProviderIDs is the built-in provider VALIDATION FLOOR. Provider
+// references (agent pins, tier candidates, model aliases, provider_priority)
+// validate against knownProviderIDs() = this floor UNION the operator's declared
+// `providers:` keys, so a config-declared 3rd-party provider validates too, while
+// every config referencing a built-in stays valid whether or not it declares a
+// `providers:` block.
+//
+// This floor is deliberate and permanent — NOT transitional scaffolding. The
+// hardcoded provider *construction/registration* was removed under RFC BF (the
+// embedded default-providers layer, cmd/loomcycle/embedded/providers.default.yaml,
+// is the sole source of the built-ins at runtime, and both the server and the CLI
+// prepend it). This set exists only so validate() stays a total function that does
+// not depend on that layer having been applied first — it still runs on configs
+// assembled WITHOUT the default layer: unit tests that build a Config directly,
+// and LOOMCYCLE_NO_DEFAULT_PROVIDERS runs. Removing it would make validate() reject
+// a built-in reference in those contexts (see
+// TestValidate_ThirdPartyProvider_AcceptedAsReference, which asserts the
+// floor-plus-declared behavior). anthropic-oauth-dev is the only member the
+// default layer does NOT declare (its Refresher lifecycle is owned by main), so
+// the floor is the sole thing that keeps it a valid reference.
 var validProviderIDs = map[string]bool{
 	"anthropic":    true,
 	"openai":       true,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4923,12 +4923,17 @@ func validate(c *Config) error {
 	// model aliases) validates against this so a config-declared 3rd-party provider
 	// is accepted while every built-in stays valid.
 	known := c.knownProviderIDs()
+	knownList := make([]string, 0, len(known))
+	for id := range known {
+		knownList = append(knownList, id)
+	}
+	sort.Strings(knownList)
 	// Library-level provider priority — validate every entry is a
 	// known provider name. Empty list is fine (resolver falls back
 	// to its hardcoded default order).
 	for i, p := range c.ProviderPriority {
 		if !known[p] {
-			return fmt.Errorf("provider_priority[%d]: unknown provider %q (want one of anthropic/openai/deepseek/gemini/ollama)", i, p)
+			return fmt.Errorf("provider_priority[%d]: unknown provider %q (known: %v)", i, p, knownList)
 		}
 	}
 	// Search providers (RFC BB): validate the enabled set against the known


### PR DESCRIPTION
## Why

RFC BF (config-driven providers) is functionally complete — P2a already deleted the hardcoded provider *construction/registration* (the `providerResolver` env-`New` block + `Get()` switch) and made the embedded default-providers layer the sole runtime source of the built-ins. This PR is the P3 finale: remove the transitional scaffolding P2a left behind, and close a latent CLI/server divergence.

**One deliberate deviation from the plan's literal P3 (signed off in-session):** the plan called for deleting `validProviderIDs` (the built-in validation floor). Investigation showed that floor is **not** vestigial — P2a intentionally kept it *and* shipped a tested capability on top of it (`TestValidate_ThirdPartyProvider_AcceptedAsReference`: built-in references validate via the floor while operator-declared 3rd-party providers validate via `cfg.Providers`). Removing it would make `validate()` depend on the default-providers layer having been applied, change `LOOMCYCLE_NO_DEFAULT_PROVIDERS` semantics, and churn 14 config tests (several asserting the floor as a feature) — real behavior change for cosmetic benefit, since the substantive hardcoded *registration* is already gone. So this PR **keeps the floor** and documents it as the permanent validation-robustness floor it now is.

## What

1. **`fix(cli)`** — the genuine latent bug. CLI introspection (`validate`/`agents`/`doctor`) assembled its config stack **without** the embedded default-providers layer that `cmd/loomcycle` prepends, so it leaned on the config-package floor and could drift from what the server resolves. `loadLayeredConfig` now prepends `embedded.DefaultProviders()` as the base layer (honoring `LOOMCYCLE_NO_DEFAULT_PROVIDERS`, matching the server). Because that layer is always-on infrastructure — not operator config — the explicit-`--config` presence check compares against a `baseLayers` watermark instead of `len(layers)==0`, so a missing `--config` file still surfaces its file-not-found error. The `internal/cli` test binary (which doesn't link `cmd/loomcycle`) registers the same drivers via a test-only blank-import file, or the newly-prepended layer would fail driver-name validation.
2. **`chore(providers)`** — drop `expectedBuiltinProviderIDs` + the boot divergence-WARN in `logProviderSummary` (P2a scaffolding; resolution is fully config-driven now). Keep the one-line inventory log.
3. **`chore(config)`** — the `provider_priority` validation error hardcoded `(want one of anthropic/openai/deepseek/gemini/ollama)`; now reports the actual sorted `knownProviderIDs()` set, matching the `search_providers` error form.
4. **`docs(config)`** — reframe `validProviderIDs`' comment as the deliberate, permanent validation floor (per the decision above). Comment-only.

## What was tested

- `go test ./...` — clean (83 packages, exit 0).
- `make build-all` — deployable binary builds.
- **RFC §8 back-compat E2E** (via `loomcycle validate` on the built binary):
  - Single-file config with **no `providers:` block** referencing `anthropic`/`deepseek`/`ollama-local` → validates (rc=0) — the JobEmber-prod guard.
  - Undeclared provider `ghost` → rejected (rc=2), error now lists the actual known set.
  - Missing `--config` file → rejected (rc=2) — confirms the `baseLayers` guard didn't swallow it.
  - `LOOMCYCLE_NO_DEFAULT_PROVIDERS=1` + no `providers:` block → validates (rc=0) — the floor keeps built-ins valid without the default layer (its raison d'être).
- New regression: `internal/cli/drivers_test.go` (the CLI test binary now mirrors the production driver set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)