### PR TITLE
fix(providers): RFC BF review fixes — keyless providers, api_key_env forwarding, cap-escape visibility + doc cleanup

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -3105,9 +3105,21 @@ func providerEnabled(id string, pc config.ProviderConfig, cfg *config.Config) bo
 	case "code-js":
 		return cfg.Env.CodeAgentsEnabled
 	default:
-		// Keyed providers (anthropic/openai/deepseek/gemini/ollama + any declared
-		// 3rd-party): enabled iff their api_key_env names a set variable.
-		return pc.APIKeyEnv != "" && os.Getenv(pc.APIKeyEnv) != ""
+		// Keyed provider (anthropic/openai/deepseek/gemini/ollama + any declared
+		// 3rd-party naming an api_key_env): enabled iff that env var is set — the
+		// exact pre-RFC-BF gate for the built-ins.
+		if pc.APIKeyEnv != "" {
+			return os.Getenv(pc.APIKeyEnv) != ""
+		}
+		// Keyless declared provider — a self-hosted OpenAI-compatible endpoint
+		// with no auth (vLLM/llama.cpp/a second Ollama behind base_url), the RFC BF
+		// headline case. Declaring it in `providers:` IS the opt-in, so it is
+		// enabled; the driver calls base_url with no key. Without this a keyless
+		// 3rd-party provider was silently treated as "not configured" and could
+		// never be used. No built-in reaches here with an empty api_key_env
+		// (ollama-local/mock/code-js are special-cased above), so this only newly
+		// enables an operator-declared keyless provider.
+		return true
 	}
 }
 
@@ -3278,12 +3290,10 @@ func logProviderSummary(pr *providerResolver, cfg *config.Config) {
 // toCapabilityPatch translates a config.CapabilityOverride (the `capabilities:`
 // block on an RFC BF `providers:` entry) into the providers-side
 // providers.CapabilityPatch the driver registry applies inside Capabilities().
-// internal/providers cannot import internal/config (config depends on downstream
-// consumers of providers — the edge would cycle), so this boundary translation
-// lives here at the composition root. Nil in → nil out (no override → advertise
-// driver defaults). Defined for P2's registry wiring; deliberately NOT called by
-// newProviderResolver in P1 (the hardcoded resolver stays authoritative), so P2
-// is a clean flip rather than a rewrite.
+// The providers package can't import config (it would need config.CapabilityOverride,
+// and providers is a dependency of config), so this boundary translation lives
+// here at the composition root and toDriverOptions feeds the result to every
+// driver factory. Nil in → nil out (no override → advertise driver defaults).
 func toCapabilityPatch(o *config.CapabilityOverride) *providers.CapabilityPatch {
 	if o == nil {
 		return nil

--- a/cmd/loomcycle/providers_review_fixes_test.go
+++ b/cmd/loomcycle/providers_review_fixes_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+)
+
+// TestProviderEnabled_KeylessThirdParty is the RFC BF review-finding regression:
+// a declared 3rd-party provider with NO api_key_env (a keyless self-hosted
+// OpenAI-compatible endpoint — vLLM/llama.cpp behind base_url) must be ENABLED,
+// because declaring it in `providers:` IS the opt-in. Before the fix,
+// providerEnabled's default case required api_key_env, so a keyless provider was
+// silently treated as "not configured" and could never be used.
+func TestProviderEnabled_KeylessThirdParty(t *testing.T) {
+	cfg := &config.Config{}
+	if !providerEnabled("my-vllm", config.ProviderConfig{Driver: "openai", BaseURL: "http://vllm:8000"}, cfg) {
+		t.Error("a keyless declared 3rd-party provider should be enabled")
+	}
+}
+
+// TestProviderEnabled_KeyedUnsetDisabled confirms the other half stays
+// byte-identical: a keyed provider whose api_key_env names an UNSET variable is
+// disabled, exactly as the built-ins were pre-fix.
+func TestProviderEnabled_KeyedUnsetDisabled(t *testing.T) {
+	const env = "LOOMCYCLE_TEST_UNSET_PROVIDER_KEY"
+	os.Unsetenv(env)
+	cfg := &config.Config{}
+	if providerEnabled("my-keyed", config.ProviderConfig{Driver: "openai", APIKeyEnv: env}, cfg) {
+		t.Error("a keyed provider with an unset api_key_env should be disabled")
+	}
+}
+
+// TestNewProviderResolver_KeylessThirdPartyResolvable is the end-to-end #1
+// regression: a keyless declared provider is constructed via the driver registry
+// and resolvable through Get (before the fix it never entered byID, so Get
+// returned "not configured").
+func TestNewProviderResolver_KeylessThirdPartyResolvable(t *testing.T) {
+	cfg := &config.Config{
+		Providers: map[string]config.ProviderConfig{
+			"my-vllm": {Driver: "openai", BaseURL: "http://vllm.local:8000"},
+		},
+	}
+	pr, err := newProviderResolver(cfg)
+	if err != nil {
+		t.Fatalf("newProviderResolver: %v", err)
+	}
+	if _, err := pr.Get("my-vllm"); err != nil {
+		t.Errorf("keyless 3rd-party provider not resolvable: %v", err)
+	}
+}

--- a/internal/api/http/provider_gate.go
+++ b/internal/api/http/provider_gate.go
@@ -66,13 +66,32 @@ func (ps *providerSlot) releaseCurrent() {
 // interactive-detached runs, which never own a swappable slot) or when the
 // resolver returned the same provider (a same-provider/different-model retry
 // keeps its slot — releasing then re-acquiring could hand our only slot to a
-// competitor). No-op too on a P2c carve-out holder (ps.noop): that run is
-// deliberately ungated because an ancestor holds the provider, and it must stay
-// ungated across a fallback — acquiring the fallback target's gate here could
-// reintroduce the parent-awaiting-its-own-descendant deadlock the carve-out
-// exists to prevent.
+// competitor). A P2c carve-out holder (ps.noop) also does NOT acquire the
+// fallback target's gate: that run is deliberately ungated because an ancestor
+// holds its original provider, and it must stay ungated across a fallback —
+// acquiring here could reintroduce the parent-awaiting-its-own-descendant
+// deadlock the carve-out exists to prevent (the run's ctx held-set is fixed at
+// admission, so a slot taken now can't be published to the descendants that
+// would then queue behind it). The cost is a bounded cap-escape: if the fallback
+// target is itself capped and NOT ancestor-held, this run runs ungated on it and
+// may briefly exceed that provider's max_concurrent. That's logged (below) so the
+// over-subscription is visible rather than silent (RFC BF review finding); true
+// enforcement across the carve-out+fallback boundary would need a mutable,
+// subtree-scoped held-set, deferred as a larger change.
 func (ps *providerSlot) swap(ctx context.Context, gates *concurrency.ProviderGates, newProviderID string) {
-	if ps == nil || ps.noop || newProviderID == ps.providerID {
+	if ps == nil || newProviderID == ps.providerID {
+		return
+	}
+	if ps.noop {
+		// Carve-out holder stays ungated across the fallback (deadlock-avoidance,
+		// see the doc comment). Surface the escape when the target is a cap this
+		// run now evades and no ancestor holds it — a same-provider or
+		// ancestor-held target is not an escape (the cap is already respected).
+		if gates.Has(newProviderID) && !holdsProviderSlot(ctx, newProviderID) {
+			log.Printf("provider-gate: carve-out run failed over %s->%s and stays UNGATED on capped %s (deadlock-avoidance); its max_concurrent may be briefly exceeded",
+				ps.providerID, newProviderID, newProviderID)
+		}
+		ps.providerID = newProviderID
 		return
 	}
 	// Free the old provider's slot FIRST so a run queued on it can proceed; this

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -96,11 +96,13 @@ func RunDoctor(args []string, stdout, stderr io.Writer) int {
 		r.warn("Providers", "none configured in provider_priority or per-agent providers")
 	}
 	for _, p := range providers {
-		// RFC BF P2a — prefer the config-declared api_key_env for this id (so a
-		// 3rd-party `providers:` entry's key var is checked), falling back to the
-		// hardcoded canonical name for the built-ins. doctor doesn't layer the
-		// embedded default-providers block, so cfg.Providers is empty for a stock
-		// config and the fallback keeps the built-in checks byte-identical.
+		// RFC BF — prefer the config-declared api_key_env for this id (so a
+		// 3rd-party `providers:` entry's key var is checked). loadLayeredConfig
+		// prepends the embedded default-providers layer (unless
+		// LOOMCYCLE_NO_DEFAULT_PROVIDERS=1), so cfg.Providers carries the built-ins
+		// with their canonical key vars. The providerEnvVarName fallback covers the
+		// opt-out case (no default layer → empty cfg.Providers) and keeps the
+		// built-in checks byte-identical there.
 		envVar := cfg.ProviderAPIKeyEnv(p)
 		if envVar == "" {
 			envVar = providerEnvVarName(p)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,10 +76,11 @@ type Config struct {
 	// Providers is the RFC BF config-driven LLM provider registry: each entry
 	// declares one provider instance (its driver, wire dialect, base URL, key
 	// env, concurrency, driver options, capability overrides) keyed by the
-	// provider id agents reference in `provider:`. Empty = the hardcoded
-	// env-driven resolver in cmd/loomcycle is authoritative (P1 default — this
-	// block is parsed + validated but not yet consumed on the hot path; P2 wires
-	// it into the resolver). See ProviderConfig.
+	// provider id agents reference in `provider:`. The resolver builds every
+	// enabled provider from this map via the driver registry; the embedded
+	// default-providers layer supplies the built-ins, so an operator adds a
+	// 3rd-party provider by declaring another entry here (or drops the built-ins
+	// with LOOMCYCLE_NO_DEFAULT_PROVIDERS). See ProviderConfig.
 	Providers map[string]ProviderConfig `yaml:"providers"`
 
 	// SearchPriority is the global default fallback order the WebSearch tool
@@ -583,9 +584,9 @@ type SearchProviderConfig struct {
 // ProviderConfig is one entry in the RFC BF `providers:` map — a config-declared
 // LLM provider instance. The map key is the provider id agents reference in
 // `provider:` (e.g. "anthropic", "ollama-local"); this struct says which driver
-// serves it and how it is wired. Additive in P1: parsed + lightly validated but
-// not yet consumed by the resolver (cmd/loomcycle's hardcoded construction stays
-// authoritative until P2 flips the seam).
+// serves it and how it is wired. The resolver constructs every enabled provider
+// from these entries via the driver registry (providers.NewDriver); the embedded
+// default-providers layer declares the built-ins.
 //
 // The json: tags mirror SearchProviderConfig's style so an admin JSON surface
 // can serialize the block; the resolver ordering — not this shape — carries the

--- a/internal/providers/anthropic/credkey_test.go
+++ b/internal/providers/anthropic/credkey_test.go
@@ -12,7 +12,7 @@ import (
 // (and the resolved scope is reported for usage attribution); a run without one
 // uses the operator host key with source "operator" (RFC AR / RFC AV).
 func TestResolveKey_OverridesHostKey(t *testing.T) {
-	d := &Driver{apiKey: "host-key"}
+	d := &Driver{apiKey: "host-key", keyEnvName: "ANTHROPIC_API_KEY"}
 
 	if key, source, _, err := d.resolveKey(context.Background()); err != nil || key != "host-key" || source != "operator" {
 		t.Errorf("no resolver: (%q, %q, %v), want (host-key, operator, nil)", key, source, err)
@@ -42,7 +42,7 @@ func TestResolveKey_OverridesHostKey(t *testing.T) {
 // override still wins regardless of the restriction; an allowed run uses the
 // host key as before.
 func TestResolveKey_RestrictedRefusesHostKey(t *testing.T) {
-	d := &Driver{apiKey: "host-key"}
+	d := &Driver{apiKey: "host-key", keyEnvName: "ANTHROPIC_API_KEY"}
 
 	restricted := providers.WithOperatorKeyAllowed(context.Background(), false)
 	if key, _, _, err := d.resolveKey(restricted); !errors.Is(err, providers.ErrOperatorKeyForbidden) || key != "" {

--- a/internal/providers/anthropic/driver.go
+++ b/internal/providers/anthropic/driver.go
@@ -36,6 +36,12 @@ type Driver struct {
 	// id is the provider identity reported by ID(). Defaults to "anthropic" in
 	// New(); the RFC BF driver registry sets it from DriverOptions.ID.
 	id string
+	// keyEnvName is the env-var NAME whose tenant/user credential overrides the
+	// host key (RFC AR/AX). Defaults to "ANTHROPIC_API_KEY" in New(); a
+	// config-declared api_key_env re-points it via SetKeyEnvName so a custom-id
+	// anthropic provider resolves tenant overrides under its OWN var, matching
+	// the var toDriverOptions already sourced the host key from.
+	keyEnvName string
 	// capsPatch is an optional operator override applied inside Capabilities()
 	// (RFC BF). Nil = advertise the driver defaults.
 	capsPatch *providers.CapabilityPatch
@@ -53,10 +59,17 @@ func New(apiKey, baseURL string, streamOpts streamhttp.Options, httpClient *http
 	if httpClient == nil {
 		httpClient = streamhttp.NewClient(streamOpts.HeaderTimeout)
 	}
-	return &Driver{apiKey: apiKey, baseURL: baseURL, http: httpClient, idleTimeout: streamOpts.IdleTimeout, id: "anthropic"}
+	return &Driver{apiKey: apiKey, baseURL: baseURL, http: httpClient, idleTimeout: streamOpts.IdleTimeout, id: "anthropic", keyEnvName: "ANTHROPIC_API_KEY"}
 }
 
 func (d *Driver) ID() string { return d.id }
+
+// SetKeyEnvName overrides the env-var name whose tenant/user credential shadows
+// the host key (RFC AR). New() defaults it to ANTHROPIC_API_KEY; the RFC BF
+// registry factory forwards a config-declared api_key_env through here so a
+// custom-id anthropic provider's tenant overrides resolve under the SAME var the
+// host key was read from.
+func (d *Driver) SetKeyEnvName(name string) { d.keyEnvName = name }
 
 // resolveKey returns the API key to authenticate an inference request AND which
 // credential scope it came from. A tenant/user credential named
@@ -67,12 +80,12 @@ func (d *Driver) ID() string { return d.id }
 // Model-availability probes (fetchModels) stay on the operator key — which
 // models are reachable is an operator concern.
 func (d *Driver) resolveKey(ctx context.Context) (key, source, scopeID string, err error) {
-	return providers.ResolveKeyOrOperator(ctx, "ANTHROPIC_API_KEY", d.apiKey)
+	return providers.ResolveKeyOrOperator(ctx, d.keyEnvName, d.apiKey)
 }
 
 // KeyEnvName reports the env-var name whose tenant/user credential can key this
-// provider (RFC AX Layer-1 routing). Same literal resolveKey resolves.
-func (d *Driver) KeyEnvName() string { return "ANTHROPIC_API_KEY" }
+// provider (RFC AX Layer-1 routing). Same var resolveKey resolves.
+func (d *Driver) KeyEnvName() string { return d.keyEnvName }
 
 func (d *Driver) Capabilities() providers.Capabilities {
 	return d.capsPatch.Apply(providers.Capabilities{

--- a/internal/providers/anthropic/keyenv_forward_test.go
+++ b/internal/providers/anthropic/keyenv_forward_test.go
@@ -1,0 +1,39 @@
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// TestNewDriver_ForwardsKeyEnvName is the RFC BF review-finding regression: a
+// config-declared api_key_env must reach the driver's KeyEnvName() so a custom-id
+// anthropic provider resolves RFC AR/AX tenant credential overrides under its OWN
+// var — matching the var toDriverOptions read the host key from. Before the fix
+// the anthropic driver had no SetKeyEnvName and KeyEnvName() was hardcoded, so
+// the declared api_key_env was dropped for tenant-override resolution.
+func TestNewDriver_ForwardsKeyEnvName(t *testing.T) {
+	p, err := providers.NewDriver("anthropic", providers.DriverOptions{APIKey: "host", KeyEnvName: "MY_CLAUDE_KEY"})
+	if err != nil {
+		t.Fatalf("NewDriver: %v", err)
+	}
+	kp, ok := p.(providers.KeyedProvider)
+	if !ok {
+		t.Fatal("anthropic driver must implement KeyedProvider")
+	}
+	if got := kp.KeyEnvName(); got != "MY_CLAUDE_KEY" {
+		t.Errorf("KeyEnvName() = %q, want MY_CLAUDE_KEY (config api_key_env must be forwarded)", got)
+	}
+}
+
+// TestNewDriver_DefaultKeyEnvName confirms back-compat: with no declared
+// api_key_env the driver keeps the canonical default.
+func TestNewDriver_DefaultKeyEnvName(t *testing.T) {
+	p, err := providers.NewDriver("anthropic", providers.DriverOptions{APIKey: "host"})
+	if err != nil {
+		t.Fatalf("NewDriver: %v", err)
+	}
+	if got := p.(providers.KeyedProvider).KeyEnvName(); got != "ANTHROPIC_API_KEY" {
+		t.Errorf("default KeyEnvName() = %q, want ANTHROPIC_API_KEY", got)
+	}
+}

--- a/internal/providers/anthropic/register.go
+++ b/internal/providers/anthropic/register.go
@@ -10,16 +10,20 @@ func init() {
 	providers.RegisterDriver("anthropic", []string{"anthropic-messages"}, newFromOptions)
 }
 
-// newFromOptions builds an anthropic Driver from the registry DriverOptions.
-// P1 equivalent of cmd/loomcycle/main.go's hardcoded anthropic.New(...); NOT
-// yet on the hot path (P2 wires the registry into the resolver). Anthropic's
-// key env var is fixed (ANTHROPIC_API_KEY) — the driver exposes no SetKeyEnvName
-// — so KeyEnvName is not forwarded. The API version is a compile-time const, so
-// there are no consumable driver options today.
+// newFromOptions builds an anthropic Driver from the registry DriverOptions —
+// the config-driven construction the resolver uses (the RFC BF replacement for
+// the pre-registry hardcoded anthropic.New(...)). A config-declared api_key_env
+// re-points tenant/user credential resolution via SetKeyEnvName, so a custom-id
+// anthropic provider resolves overrides under the SAME var toDriverOptions read
+// the host key from (defaults to ANTHROPIC_API_KEY). The API version is a
+// compile-time const, so there are no consumable driver options today.
 func newFromOptions(o providers.DriverOptions) (providers.Provider, error) {
 	d := New(o.APIKey, o.BaseURL, o.StreamOpts, nil)
 	if o.ID != "" {
 		d.id = o.ID
+	}
+	if o.KeyEnvName != "" {
+		d.SetKeyEnvName(o.KeyEnvName)
 	}
 	d.capsPatch = o.Capabilities
 	providers.WarnUnknownOptions(o.Logf, "anthropic", o.Options)

--- a/internal/providers/codejs/register.go
+++ b/internal/providers/codejs/register.go
@@ -15,12 +15,12 @@ func init() {
 	providers.RegisterDriver("code-js", []string{"code-js"}, newFromOptions)
 }
 
-// newFromOptions builds a code-js Provider from the registry DriverOptions. P1
-// equivalent of cmd/loomcycle/main.go's hardcoded codejs.New(codejs.Config{});
-// NOT yet on the hot path (P2 wires the registry into the resolver). code-js has
-// no HTTP shape — its Config comes from the options map (code_root /
-// deterministic / run_timeout_seconds), a natural mapping for when P2 sources it
-// from a `providers:` entry rather than the env.
+// newFromOptions builds a code-js Provider from the registry DriverOptions — the
+// config-driven construction the resolver uses (the RFC BF replacement for the
+// pre-registry hardcoded codejs.New(codejs.Config{})). code-js has no HTTP shape
+// — its Config comes from the options map (code_root / deterministic /
+// run_timeout_seconds), which cmd/loomcycle's toDriverOptions populates from the
+// LOOMCYCLE_CODE_AGENTS_* env (an explicit `providers:` entry overrides that).
 func newFromOptions(o providers.DriverOptions) (providers.Provider, error) {
 	cfg := Config{Logf: o.Logf}
 	if root, ok := providers.StringOption(o.Options, "code_root"); ok {

--- a/internal/providers/deepseek/register.go
+++ b/internal/providers/deepseek/register.go
@@ -11,11 +11,11 @@ func init() {
 	providers.RegisterDriver("deepseek", []string{"openai-chat"}, newFromOptions)
 }
 
-// newFromOptions builds a deepseek Driver from the registry DriverOptions. P1
-// equivalent of cmd/loomcycle/main.go's hardcoded deepseek.New(...); NOT yet on
-// the hot path (P2 wires the registry into the resolver). New() already points
-// the inner key resolution at DEEPSEEK_API_KEY; a config-declared api_key_env
-// re-points it via SetKeyEnvName.
+// newFromOptions builds a deepseek Driver from the registry DriverOptions — the
+// config-driven construction the resolver uses (the RFC BF replacement for the
+// pre-registry hardcoded deepseek.New(...)). New() already points the inner key
+// resolution at DEEPSEEK_API_KEY; a config-declared api_key_env re-points it via
+// SetKeyEnvName.
 func newFromOptions(o providers.DriverOptions) (providers.Provider, error) {
 	d := New(o.APIKey, o.BaseURL, o.StreamOpts, nil)
 	if o.ID != "" {

--- a/internal/providers/gemini/credkey_test.go
+++ b/internal/providers/gemini/credkey_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestCallKey_OverridesHostKey(t *testing.T) {
-	d := &Driver{apiKey: "host-key"}
+	d := &Driver{apiKey: "host-key", keyEnvName: "GEMINI_API_KEY"}
 	if got, _, _, err := d.resolveKey(context.Background()); err != nil || got != "host-key" {
 		t.Errorf("no resolver: resolveKey = (%q, %v), want (host-key, nil)", got, err)
 	}
@@ -23,7 +23,7 @@ func TestCallKey_OverridesHostKey(t *testing.T) {
 
 // RFC AX: a restricted run with no override refuses with ErrOperatorKeyForbidden.
 func TestResolveKey_RestrictedRefusesHostKey(t *testing.T) {
-	d := &Driver{apiKey: "host-key"}
+	d := &Driver{apiKey: "host-key", keyEnvName: "GEMINI_API_KEY"}
 	restricted := providers.WithOperatorKeyAllowed(context.Background(), false)
 	if got, _, _, err := d.resolveKey(restricted); !errors.Is(err, providers.ErrOperatorKeyForbidden) || got != "" {
 		t.Errorf("restricted, no override: (%q, %v), want (\"\", ErrOperatorKeyForbidden)", got, err)

--- a/internal/providers/gemini/driver.go
+++ b/internal/providers/gemini/driver.go
@@ -59,6 +59,12 @@ type Driver struct {
 	// id is the provider identity reported by ID(). Defaults to "gemini" in
 	// New(); the RFC BF driver registry sets it from DriverOptions.ID.
 	id string
+	// keyEnvName is the env-var NAME whose tenant/user credential overrides the
+	// host key (RFC AR/AX). Defaults to "GEMINI_API_KEY" in New(); a
+	// config-declared api_key_env re-points it via SetKeyEnvName so a custom-id
+	// gemini provider resolves tenant overrides under its OWN var, matching the
+	// var toDriverOptions already sourced the host key from.
+	keyEnvName string
 	// capsPatch is an optional operator override applied inside Capabilities()
 	// (RFC BF). Nil = advertise the driver defaults.
 	capsPatch *providers.CapabilityPatch
@@ -79,10 +85,17 @@ func New(apiKey, baseURL string, streamOpts streamhttp.Options, httpClient *http
 	if httpClient == nil {
 		httpClient = streamhttp.NewClient(streamOpts.HeaderTimeout)
 	}
-	return &Driver{apiKey: apiKey, baseURL: baseURL, http: httpClient, idleTimeout: streamOpts.IdleTimeout, id: "gemini"}
+	return &Driver{apiKey: apiKey, baseURL: baseURL, http: httpClient, idleTimeout: streamOpts.IdleTimeout, id: "gemini", keyEnvName: "GEMINI_API_KEY"}
 }
 
 func (d *Driver) ID() string { return d.id }
+
+// SetKeyEnvName overrides the env-var name whose tenant/user credential shadows
+// the host key (RFC AR). New() defaults it to GEMINI_API_KEY; the RFC BF registry
+// factory forwards a config-declared api_key_env through here so a custom-id
+// gemini provider's tenant overrides resolve under the SAME var the host key was
+// read from.
+func (d *Driver) SetKeyEnvName(name string) { d.keyEnvName = name }
 
 // resolveKey returns the API key to authenticate an inference request AND which
 // credential scope it came from. A tenant/user credential named GEMINI_API_KEY
@@ -93,12 +106,12 @@ func (d *Driver) ID() string { return d.id }
 // Model-availability probes (fetchModels) stay on the host key — which models
 // are reachable is an operator concern.
 func (d *Driver) resolveKey(ctx context.Context) (key, source, scopeID string, err error) {
-	return providers.ResolveKeyOrOperator(ctx, "GEMINI_API_KEY", d.apiKey)
+	return providers.ResolveKeyOrOperator(ctx, d.keyEnvName, d.apiKey)
 }
 
 // KeyEnvName reports the env-var name whose tenant/user credential can key this
-// provider (RFC AX Layer-1 routing). Same literal resolveKey resolves.
-func (d *Driver) KeyEnvName() string { return "GEMINI_API_KEY" }
+// provider (RFC AX Layer-1 routing). Same var resolveKey resolves.
+func (d *Driver) KeyEnvName() string { return d.keyEnvName }
 
 func (d *Driver) Capabilities() providers.Capabilities {
 	return d.capsPatch.Apply(providers.Capabilities{

--- a/internal/providers/gemini/keyenv_forward_test.go
+++ b/internal/providers/gemini/keyenv_forward_test.go
@@ -1,0 +1,38 @@
+package gemini
+
+import (
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// TestNewDriver_ForwardsKeyEnvName is the RFC BF review-finding regression: a
+// config-declared api_key_env must reach KeyEnvName() so a custom-id gemini
+// provider resolves RFC AR/AX tenant credential overrides under its OWN var.
+// Before the fix the gemini driver had no SetKeyEnvName and KeyEnvName() was
+// hardcoded, dropping the declared api_key_env for tenant-override resolution.
+func TestNewDriver_ForwardsKeyEnvName(t *testing.T) {
+	p, err := providers.NewDriver("gemini", providers.DriverOptions{APIKey: "host", KeyEnvName: "MY_GEMINI_KEY"})
+	if err != nil {
+		t.Fatalf("NewDriver: %v", err)
+	}
+	kp, ok := p.(providers.KeyedProvider)
+	if !ok {
+		t.Fatal("gemini driver must implement KeyedProvider")
+	}
+	if got := kp.KeyEnvName(); got != "MY_GEMINI_KEY" {
+		t.Errorf("KeyEnvName() = %q, want MY_GEMINI_KEY (config api_key_env must be forwarded)", got)
+	}
+}
+
+// TestNewDriver_DefaultKeyEnvName confirms back-compat: with no declared
+// api_key_env the driver keeps the canonical default.
+func TestNewDriver_DefaultKeyEnvName(t *testing.T) {
+	p, err := providers.NewDriver("gemini", providers.DriverOptions{APIKey: "host"})
+	if err != nil {
+		t.Fatalf("NewDriver: %v", err)
+	}
+	if got := p.(providers.KeyedProvider).KeyEnvName(); got != "GEMINI_API_KEY" {
+		t.Errorf("default KeyEnvName() = %q, want GEMINI_API_KEY", got)
+	}
+}

--- a/internal/providers/gemini/register.go
+++ b/internal/providers/gemini/register.go
@@ -10,15 +10,20 @@ func init() {
 	providers.RegisterDriver("gemini", []string{"gemini-v1beta"}, newFromOptions)
 }
 
-// newFromOptions builds a gemini Driver from the registry DriverOptions. P1
-// equivalent of cmd/loomcycle/main.go's hardcoded gemini.New(...); NOT yet on
-// the hot path (P2 wires the registry into the resolver). Gemini's key env var
-// is fixed (GEMINI_API_KEY, no SetKeyEnvName) and it has no consumable driver
+// newFromOptions builds a gemini Driver from the registry DriverOptions — the
+// config-driven construction the resolver uses (the RFC BF replacement for the
+// pre-registry hardcoded gemini.New(...)). A config-declared api_key_env
+// re-points tenant/user credential resolution via SetKeyEnvName, so a custom-id
+// gemini provider resolves overrides under the SAME var toDriverOptions read the
+// host key from (defaults to GEMINI_API_KEY). It has no consumable driver
 // options today.
 func newFromOptions(o providers.DriverOptions) (providers.Provider, error) {
 	d := New(o.APIKey, o.BaseURL, o.StreamOpts, nil)
 	if o.ID != "" {
 		d.id = o.ID
+	}
+	if o.KeyEnvName != "" {
+		d.SetKeyEnvName(o.KeyEnvName)
 	}
 	d.capsPatch = o.Capabilities
 	providers.WarnUnknownOptions(o.Logf, "gemini", o.Options)

--- a/internal/providers/mock/register.go
+++ b/internal/providers/mock/register.go
@@ -12,11 +12,11 @@ func init() {
 	providers.RegisterDriver("mock", []string{"mock"}, newFromOptions)
 }
 
-// newFromOptions builds a mock Driver from the registry DriverOptions. P1
-// equivalent of cmd/loomcycle/main.go's hardcoded mockprov.New(); NOT yet on
-// the hot path (P2 wires the registry into the resolver). The mock ignores
-// APIKey/BaseURL (no real HTTP); its behaviour comes from the LOOMCYCLE_MOCK_*
-// env that New() reads.
+// newFromOptions builds a mock Driver from the registry DriverOptions — the
+// config-driven construction the resolver uses (the RFC BF replacement for the
+// pre-registry hardcoded mockprov.New()). The mock ignores APIKey/BaseURL (no
+// real HTTP); its behaviour comes from the LOOMCYCLE_MOCK_* env that New() reads,
+// plus the `stable` option below.
 func newFromOptions(o providers.DriverOptions) (providers.Provider, error) {
 	d := New()
 	if o.ID != "" {

--- a/internal/providers/ollama/credkey_test.go
+++ b/internal/providers/ollama/credkey_test.go
@@ -15,7 +15,7 @@ func TestCallKey_HostedOverride_LocalNever(t *testing.T) {
 		return providers.CredentialResolution{Value: "tenant-ollama"}, name == "OLLAMA_API_KEY"
 	})
 
-	hosted := &Driver{providerID: "ollama", apiKey: "host-key"}
+	hosted := &Driver{providerID: "ollama", apiKey: "host-key", keyEnvName: "OLLAMA_API_KEY"}
 	if got, _, _, err := hosted.resolveKey(ctx); err != nil || got != "tenant-ollama" {
 		t.Errorf("hosted with override: resolveKey = (%q, %v), want (tenant-ollama, nil)", got, err)
 	}
@@ -35,7 +35,7 @@ func TestCallKey_HostedOverride_LocalNever(t *testing.T) {
 func TestResolveKey_RestrictedHostedRefuses_LocalUnaffected(t *testing.T) {
 	restricted := providers.WithOperatorKeyAllowed(context.Background(), false)
 
-	hosted := &Driver{providerID: "ollama", apiKey: "host-key"}
+	hosted := &Driver{providerID: "ollama", apiKey: "host-key", keyEnvName: "OLLAMA_API_KEY"}
 	if got, _, _, err := hosted.resolveKey(restricted); !errors.Is(err, providers.ErrOperatorKeyForbidden) || got != "" {
 		t.Errorf("hosted restricted: (%q, %v), want (\"\", ErrOperatorKeyForbidden)", got, err)
 	}

--- a/internal/providers/ollama/driver.go
+++ b/internal/providers/ollama/driver.go
@@ -55,6 +55,13 @@ type Driver struct {
 	idleTimeout time.Duration
 	numCtx      int // 0 = omit (Ollama server default applies)
 	numGpu      int // 0 = omit (Ollama auto-detects GPU layers); >0 forces offload
+	// keyEnvName is the env-var NAME whose tenant/user credential overrides the
+	// host key (RFC AR/AX), and whether this registration is keyable at all: ""
+	// means keyless (ollama-local) so resolveKey bypasses the RFC AX backstop.
+	// New() derives it from providerID ("ollama"→OLLAMA_API_KEY, else ""); a
+	// config-declared api_key_env re-points it via SetKeyEnvName so a custom-id
+	// ollama-driver provider resolves tenant overrides under its OWN var.
+	keyEnvName string
 	// capsPatch is an optional operator override applied inside Capabilities()
 	// (RFC BF). Nil = advertise the driver defaults. ID() already comes from
 	// providerID, so no separate id field is needed here.
@@ -92,8 +99,22 @@ func New(providerID, apiKey, baseURL string, streamOpts streamhttp.Options, http
 	if httpClient == nil {
 		httpClient = streamhttp.NewClient(streamOpts.HeaderTimeout)
 	}
-	return &Driver{providerID: providerID, apiKey: apiKey, baseURL: baseURL, http: httpClient, idleTimeout: streamOpts.IdleTimeout}
+	// Only the hosted "ollama" registration has an operator key to protect;
+	// "ollama-local" (and any other id) is keyless by default until a
+	// config-declared api_key_env re-points it via SetKeyEnvName.
+	keyEnvName := ""
+	if providerID == "ollama" {
+		keyEnvName = "OLLAMA_API_KEY"
+	}
+	return &Driver{providerID: providerID, apiKey: apiKey, baseURL: baseURL, http: httpClient, idleTimeout: streamOpts.IdleTimeout, keyEnvName: keyEnvName}
 }
+
+// SetKeyEnvName overrides the env-var name whose tenant/user credential shadows
+// the host key (RFC AR). New() derives it from providerID; the RFC BF registry
+// factory forwards a config-declared api_key_env through here so a custom-id
+// ollama-driver provider's tenant overrides resolve under the SAME var the host
+// key was read from. A non-empty name also makes the provider keyable (RFC AX).
+func (d *Driver) SetKeyEnvName(name string) { d.keyEnvName = name }
 
 // WithNumCtx sets the Ollama options.num_ctx that the driver includes
 // on every chat request. Returns the same Driver for chaining at
@@ -238,22 +259,18 @@ func (d *Driver) ID() string { return d.providerID }
 // (RFC AV). Model-availability probes (queryLoadedContext) stay on the operator
 // key.
 func (d *Driver) resolveKey(ctx context.Context) (key, source, scopeID string, err error) {
-	if d.providerID == "ollama" {
-		return providers.ResolveKeyOrOperator(ctx, "OLLAMA_API_KEY", d.apiKey)
+	if d.keyEnvName != "" {
+		return providers.ResolveKeyOrOperator(ctx, d.keyEnvName, d.apiKey)
 	}
 	return d.apiKey, "operator", "", nil
 }
 
 // KeyEnvName reports the env-var name whose tenant/user credential can key this
-// provider (RFC AX Layer-1 routing). Only the hosted "ollama" registration has
-// an operator key to protect; "ollama-local" returns "" so it is always keyable
-// (a restricted run may always route to a keyless local endpoint).
-func (d *Driver) KeyEnvName() string {
-	if d.providerID == "ollama" {
-		return "OLLAMA_API_KEY"
-	}
-	return ""
-}
+// provider (RFC AX Layer-1 routing). Empty for a keyless registration
+// ("ollama-local" by default) so it is always keyable (a restricted run may
+// always route to a keyless local endpoint). A config-declared api_key_env
+// (via SetKeyEnvName) makes a custom-id ollama provider keyable under its own var.
+func (d *Driver) KeyEnvName() string { return d.keyEnvName }
 
 func (d *Driver) Capabilities() providers.Capabilities {
 	return d.capsPatch.Apply(providers.Capabilities{

--- a/internal/providers/ollama/keyenv_forward_test.go
+++ b/internal/providers/ollama/keyenv_forward_test.go
@@ -1,0 +1,46 @@
+package ollama
+
+import (
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// TestNewDriver_ForwardsKeyEnvName is the RFC BF review-finding regression: a
+// config-declared api_key_env must reach KeyEnvName() so a custom-id
+// ollama-driver provider is keyable under its OWN var. Before the fix ollama's
+// KeyEnvName was derived solely from providerID, so a custom id with a declared
+// api_key_env was treated as keyless and its tenant-override resolution was lost.
+func TestNewDriver_ForwardsKeyEnvName(t *testing.T) {
+	p, err := providers.NewDriver("ollama", providers.DriverOptions{ID: "ollama-remote", APIKey: "host", KeyEnvName: "MY_OLLAMA_KEY"})
+	if err != nil {
+		t.Fatalf("NewDriver: %v", err)
+	}
+	kp, ok := p.(providers.KeyedProvider)
+	if !ok {
+		t.Fatal("ollama driver must implement KeyedProvider")
+	}
+	if got := kp.KeyEnvName(); got != "MY_OLLAMA_KEY" {
+		t.Errorf("KeyEnvName() = %q, want MY_OLLAMA_KEY (config api_key_env must be forwarded)", got)
+	}
+}
+
+// TestNewDriver_DefaultKeyEnvName_ByID confirms back-compat: the hosted "ollama"
+// id defaults to OLLAMA_API_KEY and keyless "ollama-local" stays "" (never
+// keyable) when no api_key_env is declared.
+func TestNewDriver_DefaultKeyEnvName_ByID(t *testing.T) {
+	hosted, err := providers.NewDriver("ollama", providers.DriverOptions{ID: "ollama"})
+	if err != nil {
+		t.Fatalf("NewDriver(ollama): %v", err)
+	}
+	if got := hosted.(providers.KeyedProvider).KeyEnvName(); got != "OLLAMA_API_KEY" {
+		t.Errorf("hosted default KeyEnvName() = %q, want OLLAMA_API_KEY", got)
+	}
+	local, err := providers.NewDriver("ollama", providers.DriverOptions{ID: "ollama-local"})
+	if err != nil {
+		t.Fatalf("NewDriver(ollama-local): %v", err)
+	}
+	if got := local.(providers.KeyedProvider).KeyEnvName(); got != "" {
+		t.Errorf("ollama-local KeyEnvName() = %q, want \"\" (keyless)", got)
+	}
+}

--- a/internal/providers/ollama/register.go
+++ b/internal/providers/ollama/register.go
@@ -13,15 +13,20 @@ func init() {
 	providers.RegisterDriver("ollama", []string{"ollama-chat"}, newFromOptions)
 }
 
-// newFromOptions builds an ollama Driver from the registry DriverOptions. P1
-// equivalent of cmd/loomcycle/main.go's hardcoded ollama.New(...).WithNumCtx().
-// WithNumGpu(); NOT yet on the hot path (P2 wires the registry into the
-// resolver). The provider id (DriverOptions.ID → New's providerID) also selects
-// the auth + KeyEnvName behaviour: "ollama-local" is keyless, "ollama" uses
-// OLLAMA_API_KEY. num_ctx / num_gpu come from the options map.
+// newFromOptions builds an ollama Driver from the registry DriverOptions — the
+// config-driven construction the resolver uses (the RFC BF replacement for the
+// pre-registry hardcoded ollama.New(...).WithNumCtx().WithNumGpu()). The
+// provider id (DriverOptions.ID → New's providerID) selects the default auth +
+// KeyEnvName behaviour: "ollama-local" is keyless, "ollama" uses OLLAMA_API_KEY.
+// A config-declared api_key_env re-points that via SetKeyEnvName (so a custom-id
+// ollama provider is keyable under its own var). num_ctx / num_gpu come from the
+// options map.
 func newFromOptions(o providers.DriverOptions) (providers.Provider, error) {
 	// New defaults providerID to "ollama" when o.ID == "".
 	d := New(o.ID, o.APIKey, o.BaseURL, o.StreamOpts, nil)
+	if o.KeyEnvName != "" {
+		d.SetKeyEnvName(o.KeyEnvName)
+	}
 	d.capsPatch = o.Capabilities
 	if n, ok := providers.IntOption(o.Options, "num_ctx"); ok {
 		d.WithNumCtx(n)

--- a/internal/providers/openai/register.go
+++ b/internal/providers/openai/register.go
@@ -11,10 +11,11 @@ func init() {
 	providers.RegisterDriver("openai", []string{"openai-chat"}, newFromOptions)
 }
 
-// newFromOptions builds an openai Driver from the registry DriverOptions. It is
-// the P1 equivalent of cmd/loomcycle/main.go's hardcoded openai.New(...) — NOT
-// yet on the hot path (P2 wires the registry into the resolver). It exists so
-// P2 is a clean flip and the seam is testable now.
+// newFromOptions builds an openai Driver from the registry DriverOptions — the
+// config-driven construction the resolver uses (the RFC BF replacement for the
+// pre-registry hardcoded openai.New(...)). A config-declared api_key_env
+// re-points tenant/user credential resolution via SetKeyEnvName, so a self-hosted
+// OpenAI-compatible mirror can name its own key var.
 func newFromOptions(o providers.DriverOptions) (providers.Provider, error) {
 	d := New(o.APIKey, o.BaseURL, o.StreamOpts, nil)
 	if o.ID != "" {


### PR DESCRIPTION
## Why

Fixes from the RFC BF (config-driven providers) feature-line code review: #1 and #3 (correctness), #2 (observability of a deliberate tradeoff), and the #4–#7 doc cleanup.

## What

**#1 — keyless 3rd-party providers now work** (`fix(providers): enable a declared keyless 3rd-party provider`). `providerEnabled`'s default case required `api_key_env`, so a declared no-auth OpenAI-compatible endpoint (self-hosted vLLM / llama.cpp / a second Ollama behind `base_url` — the RFC's headline case) was silently treated as "not configured". A declared provider with no `api_key_env` is now enabled (declaring it is the opt-in); a keyed provider with its env unset stays disabled, byte-identical. No built-in reaches the default case with an empty key env, so only operator-declared keyless providers change.

**#3 — `api_key_env` forwarded to anthropic/gemini/ollama `KeyEnvName()`** (`fix(providers): forward config api_key_env ...`). A custom-id provider on these drivers read its host key from the declared `api_key_env` but resolved RFC AR/AX per-tenant credential overrides under the driver's *hardcoded* name (openai/deepseek already forwarded it; these three didn't). Each driver now has a settable `keyEnvName` (defaulted in `New()`; ollama derives it from `providerID`) + a `SetKeyEnvName` the registry factory forwards, so the host key and tenant-override var are always the same one. Back-compat preserved for the built-ins.

**#2 — carve-out cap-escape made observable** (`fix(providers): surface the P2c carve-out cap-escape ...`). A P2c carve-out sub-agent that fails over to a different capped provider stayed ungated on it, silently exceeding that provider's `max_concurrent`. `swap()` deliberately does **not** acquire the fallback target's gate — the ctx held-set is fixed at admission, so a slot taken mid-run can't be published to descendants, and acquiring would reintroduce the parent-awaits-descendant deadlock the carve-out prevents (worse than transient over-subscription). Kept deadlock-safe; added a WARN so the escape is visible. True enforcement needs a mutable subtree-scoped held-set — noted as a deferred larger change.

**#4–#7 — doc cleanup** (`docs(providers): drop stale P1/P2 comments ...`). Removed "P1 / not yet on the hot path / until P2 flips the seam" comments (the registry *is* the resolver now) across `config.go` + the driver `register.go` files, and fixed doctor's stale "cfg.Providers is empty" comment (false since P3 prepends the default-providers layer). Comment-only.

## What was tested

- `go test ./...` — clean (83 packages).
- New regression tests, each **verified fail-before** (fails on the unfixed code, passes with the fix):
  - `TestProviderEnabled_KeylessThirdParty` / `_KeyedUnsetDisabled` / `TestNewProviderResolver_KeylessThirdPartyResolvable` (#1)
  - `TestNewDriver_ForwardsKeyEnvName` / `_DefaultKeyEnvName` for anthropic, gemini, ollama (#3)
- Existing anthropic/gemini/ollama credkey struct-literal tests updated to set `keyEnvName` (matching how `New()` populates it — production always constructs via `New()`, fields are unexported).
- `go build` + `loomcycle validate` on a keyless-provider config → accepted (rc 0).

Not fixed here (deliberate): #2 full enforcement (deadlock-risk / larger change) and the interactive-detached-run slot-lifetime finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)