### PR TITLE
feat(providers): RFC BG P1 — model_pattern / latest model resolution

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -3398,6 +3398,10 @@ func (p *providerResolver) Get(id string) (providers.Provider, error) {
 func buildResolver(cfg *config.Config, pr *providerResolver) *resolve.Resolver {
 	libraryTiers := convertTiers(cfg.Tiers, cfg.Models)
 	r := resolve.NewResolver(cfg.ProviderPriority, libraryTiers)
+	// RFC BG: surface a silent model-pattern bump (a pattern resolving to a new
+	// concrete model) in the operator log. Set before the first probe so an
+	// initial resolution is recorded (first-seen never warns; only a MOVE does).
+	r.SetLogf(log.Printf)
 
 	// First-round probe — synchronous, so the matrix is hot before
 	// the listener accepts traffic.
@@ -3521,9 +3525,10 @@ func convertTiers(in map[string][]config.TierCandidate, models map[string]config
 		for _, c := range cands {
 			// Expand model aliases (top-level models:) — mirrors the pin
 			// path and the per-agent converter so a library tier candidate
-			// can name an alias too.
-			prov, mdl := config.ExpandModelAlias(models, c.Provider, c.Model)
-			conv = append(conv, resolve.Candidate{Provider: prov, Model: mdl})
+			// can name an alias too. RFC BG: a pattern alias surfaces a glob
+			// (pat) the resolver resolves against the live catalog.
+			prov, mdl, pat := config.ExpandModelAlias(models, c.Provider, c.Model)
+			conv = append(conv, resolve.Candidate{Provider: prov, Model: mdl, ModelPattern: pat})
 		}
 		out[tier] = conv
 	}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1248,9 +1248,32 @@ func (s *Server) resolveAgentDef(ctx context.Context, def config.AgentDef, tenan
 	if !hasPin && s.cfg.Defaults.Model == "" {
 		return "", "", "", fmt.Errorf("%w: agent %q has no pin, no tier, and no defaults", runner.ErrInvalidArgument, agentName)
 	}
-	providerID, model, err = s.cfg.ResolveAgentDefModel(agentName, def)
+	var pattern string
+	providerID, model, pattern, err = s.cfg.ResolveAgentDefModel(agentName, def)
 	if err != nil {
 		return "", "", "", fmt.Errorf("%w: %v", runner.ErrInvalidArgument, err)
+	}
+	// RFC BG: a pinned agent naming a model_pattern alias has no concrete model
+	// yet — config surfaced the glob (config can't see the live catalog). Resolve
+	// it once here, at admission, through the resolver's pin path so Decision.Model
+	// carries the concrete id everything downstream records. A pattern that
+	// matches nothing available fails with ErrPinUnavailable (a pin has no
+	// fallthrough). Concrete pins (pattern == "") take the unchanged path.
+	if pattern != "" {
+		if s.resolver == nil {
+			return "", "", "", fmt.Errorf("%w: agent %q pins model_pattern %q but resolver is not configured",
+				runner.ErrInvalidArgument, agentName, pattern)
+		}
+		dec, rerr := s.resolver.Resolve(resolve.AgentRequest{
+			Name:            agentName,
+			PinProvider:     providerID,
+			PinModelPattern: pattern,
+			Effort:          def.Effort,
+		})
+		if rerr != nil {
+			return "", "", "", rerr
+		}
+		return dec.Provider, dec.Model, dec.Effort, nil
 	}
 	// Effort still flows through on the pin path — an explicit-pin
 	// agent can declare effort and the driver will translate it
@@ -2007,9 +2030,11 @@ func convertConfigCandidates(in map[string][]config.TierCandidate, models map[st
 			// Expand model aliases (top-level models:) the same way the
 			// pin path does — so model: <alias> works in a tier candidate
 			// too, not only as a pin. The resolver matches literal model
-			// strings, so expansion must happen here at the boundary.
-			prov, mdl := config.ExpandModelAlias(models, c.Provider, c.Model)
-			conv = append(conv, resolve.Candidate{Provider: prov, Model: mdl})
+			// strings, so expansion must happen here at the boundary. RFC BG:
+			// a pattern alias surfaces a glob (pat) the resolver turns into a
+			// concrete model against the live catalog.
+			prov, mdl, pat := config.ExpandModelAlias(models, c.Provider, c.Model)
+			conv = append(conv, resolve.Candidate{Provider: prov, Model: mdl, ModelPattern: pat})
 		}
 		out[tier] = conv
 	}

--- a/internal/cli/agents.go
+++ b/internal/cli/agents.go
@@ -64,9 +64,14 @@ func runAgentsList(args []string, stdout, stderr io.Writer) int {
 	// chatty column we truncate to keep things readable.
 	for _, name := range names {
 		def := cfg.Agents[name]
-		provider, model, err := cfg.ResolveAgentModel(name)
+		provider, model, pattern, err := cfg.ResolveAgentModel(name)
 		if err != nil {
 			return fail(stderr, "agent %q: %v", name, err)
+		}
+		// RFC BG: a model_pattern alias has no concrete model until run time;
+		// show the glob so the operator sees what the alias points at.
+		if pattern != "" {
+			model = pattern
 		}
 		tools := strings.Join(def.Tools, ",")
 		if tools == "" {
@@ -105,9 +110,13 @@ func runAgentsListJSON(stdout, stderr io.Writer, cfg *config.Config, names []str
 	fmt.Fprintln(stdout, "[")
 	for i, name := range names {
 		def := cfg.Agents[name]
-		provider, model, err := cfg.ResolveAgentModel(name)
+		provider, model, pattern, err := cfg.ResolveAgentModel(name)
 		if err != nil {
 			return fail(stderr, "agent %q: %v", name, err)
+		}
+		// RFC BG: surface the glob for a model_pattern alias (resolved at run time).
+		if pattern != "" {
+			model = pattern
 		}
 		fmt.Fprintln(stdout, "  {")
 		fmt.Fprintf(stdout, "    \"name\": %s,\n", jsonString(name))

--- a/internal/cli/loadcfg_test.go
+++ b/internal/cli/loadcfg_test.go
@@ -23,7 +23,7 @@ func TestLoadLayeredConfig_PresetAliasResolvesInOverlayAgent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("loadLayeredConfig: %v", err)
 	}
-	prov, model, err := cfg.ResolveAgentModel("probe")
+	prov, model, _, err := cfg.ResolveAgentModel("probe")
 	if err != nil {
 		t.Fatalf("ResolveAgentModel: %v", err)
 	}

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -77,9 +77,14 @@ func RunValidate(args []string, stdout, stderr io.Writer) int {
 	} else {
 		fmt.Fprintf(stdout, "Agents           : %d\n", len(names))
 		for _, name := range names {
-			provider, model, err := cfg.ResolveAgentModel(name)
+			provider, model, pattern, err := cfg.ResolveAgentModel(name)
 			if err != nil {
 				return fail(stderr, "agent %q: %v", name, err)
+			}
+			// RFC BG: a model_pattern alias resolves to a concrete model only at
+			// run time (against the live catalog), so show the glob here.
+			if pattern != "" {
+				model = pattern
 			}
 			fmt.Fprintf(stdout, "  %-24s provider=%-10s model=%s\n", name, provider, model)
 		}

--- a/internal/config/alias_test.go
+++ b/internal/config/alias_test.go
@@ -69,9 +69,9 @@ func TestExpandModelAlias_ExpandsModelAndFillsEmptyProvider(t *testing.T) {
 	models := map[string]ModelRef{
 		"local-gemma": {Provider: "ollama-local", Model: "gemma4:max"},
 	}
-	prov, mdl := ExpandModelAlias(models, "", "local-gemma")
-	if prov != "ollama-local" || mdl != "gemma4:max" {
-		t.Fatalf("got (%q, %q), want (ollama-local, gemma4:max)", prov, mdl)
+	prov, mdl, pat := ExpandModelAlias(models, "", "local-gemma")
+	if prov != "ollama-local" || mdl != "gemma4:max" || pat != "" {
+		t.Fatalf("got (%q, %q, %q), want (ollama-local, gemma4:max, \"\")", prov, mdl, pat)
 	}
 }
 
@@ -82,9 +82,9 @@ func TestExpandModelAlias_ExplicitProviderWins(t *testing.T) {
 	models := map[string]ModelRef{
 		"local-gemma": {Provider: "ollama-local", Model: "gemma4:max"},
 	}
-	prov, mdl := ExpandModelAlias(models, "openai", "local-gemma")
-	if prov != "openai" || mdl != "gemma4:max" {
-		t.Fatalf("got (%q, %q), want (openai, gemma4:max)", prov, mdl)
+	prov, mdl, pat := ExpandModelAlias(models, "openai", "local-gemma")
+	if prov != "openai" || mdl != "gemma4:max" || pat != "" {
+		t.Fatalf("got (%q, %q, %q), want (openai, gemma4:max, \"\")", prov, mdl, pat)
 	}
 }
 
@@ -92,15 +92,15 @@ func TestExpandModelAlias_NonAliasIsLiteralNoop(t *testing.T) {
 	models := map[string]ModelRef{
 		"local-gemma": {Provider: "ollama-local", Model: "gemma4:max"},
 	}
-	prov, mdl := ExpandModelAlias(models, "anthropic", "claude-sonnet-4-6")
-	if prov != "anthropic" || mdl != "claude-sonnet-4-6" {
-		t.Fatalf("got (%q, %q), want (anthropic, claude-sonnet-4-6)", prov, mdl)
+	prov, mdl, pat := ExpandModelAlias(models, "anthropic", "claude-sonnet-4-6")
+	if prov != "anthropic" || mdl != "claude-sonnet-4-6" || pat != "" {
+		t.Fatalf("got (%q, %q, %q), want (anthropic, claude-sonnet-4-6, \"\")", prov, mdl, pat)
 	}
 }
 
 func TestExpandModelAlias_NilMapNoop(t *testing.T) {
-	prov, mdl := ExpandModelAlias(nil, "ollama-local", "local-gemma")
-	if prov != "ollama-local" || mdl != "local-gemma" {
-		t.Fatalf("got (%q, %q), want (ollama-local, local-gemma)", prov, mdl)
+	prov, mdl, pat := ExpandModelAlias(nil, "ollama-local", "local-gemma")
+	if prov != "ollama-local" || mdl != "local-gemma" || pat != "" {
+		t.Fatalf("got (%q, %q, %q), want (ollama-local, local-gemma, \"\")", prov, mdl, pat)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -552,10 +553,20 @@ type Defaults struct {
 	Model    string `yaml:"model"`
 }
 
-// ModelRef points one alias at a (provider, model) pair.
+// ModelRef points one alias at a (provider, model) pair, or — RFC BG — at a
+// (provider, model_pattern) glob that resolves to the newest LISTED model
+// matching the pattern at resolve time. Exactly one of Model / ModelPattern is
+// set (validated at load). ModelRef carries only yaml tags because the alias
+// map is NOT content-hashed (unlike the per-agent TierCandidate map), so
+// ModelPattern needs no json tag to keep any hash byte-stable.
 type ModelRef struct {
 	Provider string `yaml:"provider"`
 	Model    string `yaml:"model"`
+
+	// ModelPattern is a path.Match glob ("claude-haiku-*") matched against the
+	// provider's listed catalog; the resolver picks the newest match (RFC BG).
+	// Mutually exclusive with Model and requires an explicit Provider.
+	ModelPattern string `yaml:"model_pattern"`
 }
 
 // TierCandidate is one entry in a tier's ordered candidate list.
@@ -3922,41 +3933,52 @@ func validateVolumes(c *Config) error {
 	return nil
 }
 
-// ResolveAgentModel returns (provider, model) for the named agent, walking
-// model aliases and provider defaults.
-func (c *Config) ResolveAgentModel(agent string) (provider string, model string, err error) {
+// ResolveAgentModel returns (provider, model, pattern) for the named agent,
+// walking model aliases and provider defaults. pattern is non-empty (and model
+// "") when the agent pins a RFC BG model_pattern alias — the resolver turns the
+// glob into a concrete model at run admission.
+func (c *Config) ResolveAgentModel(agent string) (provider string, model string, pattern string, err error) {
 	def, ok := c.Agents[agent]
 	if !ok {
-		return "", "", fmt.Errorf("unknown agent %q", agent)
+		return "", "", "", fmt.Errorf("unknown agent %q", agent)
 	}
 	return c.ResolveAgentDefModel(agent, def)
 }
 
 // ExpandModelAlias resolves a model-alias (a key in the top-level models:
-// map) to its concrete provider/model. The alias only fills an EMPTY
-// provider — an explicit provider on the pin/candidate always wins — so the
-// tier path and the pin path expand aliases identically. A nil/absent map or
-// a non-alias model is a no-op (the model is treated as a literal). This is
-// the single source of truth for alias expansion, shared by the pin path
+// map) to its concrete provider/model, plus (RFC BG) a model_pattern glob when
+// the alias is a pattern alias. The alias only fills an EMPTY provider — an
+// explicit provider on the pin/candidate always wins — so the tier path and the
+// pin path expand aliases identically. A nil/absent map or a non-alias model is
+// a no-op (the model is treated as a literal, pattern ""). This is the single
+// source of truth for alias expansion, shared by the pin path
 // (ResolveAgentDefModel) and the tier path (the resolver-boundary converters
 // in internal/api/http and cmd/loomcycle); keeping it in one place stops the
 // two paths from drifting.
-func ExpandModelAlias(models map[string]ModelRef, provider, model string) (string, string) {
+//
+// For a pattern alias the returned model is "" and pattern is the glob — the
+// resolver (which owns the live catalog) turns the glob into a concrete model.
+func ExpandModelAlias(models map[string]ModelRef, provider, model string) (rProvider, rModel, rPattern string) {
 	if ref, ok := models[model]; ok {
 		model = ref.Model
+		rPattern = ref.ModelPattern
 		if provider == "" {
 			provider = ref.Provider
 		}
 	}
-	return provider, model
+	return provider, model, rPattern
 }
 
 // ResolveAgentDefModel mirrors ResolveAgentModel but resolves against
 // a caller-supplied AgentDef instead of looking it up in c.Agents.
 // Used by the sub-agent path when an overlay has already produced an
 // effective def whose Provider/Model differ from the static yaml.
-// Same alias-expansion + defaults-fallback rules as ResolveAgentModel.
-func (c *Config) ResolveAgentDefModel(agent string, def AgentDef) (provider string, model string, err error) {
+// Same alias-expansion + defaults-fallback rules as ResolveAgentModel. A
+// non-empty pattern return (with model "") means the def pins a RFC BG
+// model_pattern alias; the caller (the HTTP resolver boundary) resolves the
+// glob against the live catalog. config can't resolve it here — it has no
+// access to the availability matrix.
+func (c *Config) ResolveAgentDefModel(agent string, def AgentDef) (provider string, model string, pattern string, err error) {
 	model = def.Model
 	provider = def.Provider
 
@@ -3967,24 +3989,26 @@ func (c *Config) ResolveAgentDefModel(agent string, def AgentDef) (provider stri
 	// meaningful identifier. Usage/OTEL report loomcycle/code-js regardless
 	// (see internal/providers/codejs). An explicit model still wins.
 	if provider == "code-js" && model == "" {
-		return provider, agent, nil
+		return provider, agent, "", nil
 	}
 
-	// If model is an alias in models:, expand it.
-	provider, model = ExpandModelAlias(c.Models, provider, model)
+	// If model is an alias in models:, expand it (may surface a pattern).
+	provider, model, pattern = ExpandModelAlias(c.Models, provider, model)
 	if provider == "" {
 		provider = c.Defaults.Provider
 	}
-	if model == "" {
+	// A pattern alias supplies no concrete model — the defaults fallback and
+	// the "no model resolved" check below apply only to the non-pattern path.
+	if model == "" && pattern == "" {
 		model = c.Defaults.Model
 	}
 	if provider == "" {
-		return "", "", fmt.Errorf("agent %q: no provider resolved", agent)
+		return "", "", "", fmt.Errorf("agent %q: no provider resolved", agent)
 	}
-	if model == "" {
-		return "", "", fmt.Errorf("agent %q: no model resolved", agent)
+	if model == "" && pattern == "" {
+		return "", "", "", fmt.Errorf("agent %q: no model resolved", agent)
 	}
-	return provider, model, nil
+	return provider, model, pattern, nil
 }
 
 // envVarRe matches ${VAR} interpolation tokens in the YAML source.
@@ -5005,6 +5029,27 @@ func validate(c *Config) error {
 	// names the alias, so it is left unvalidated here). Built-ins always pass via the
 	// floor, so this only newly rejects a typo'd or undeclared 3rd-party provider.
 	for name, ref := range c.Models {
+		// RFC BG: exactly one of model / model_pattern. Both or neither is a
+		// config error — a pattern alias has no concrete model, a concrete alias
+		// has no glob, and an empty alias resolves to nothing.
+		hasModel := ref.Model != ""
+		hasPattern := ref.ModelPattern != ""
+		if hasModel == hasPattern {
+			return fmt.Errorf("models.%s: exactly one of model or model_pattern is required (got model=%q model_pattern=%q)", name, ref.Model, ref.ModelPattern)
+		}
+		if hasPattern {
+			// A pattern is scoped to one provider's catalog, so the provider can't
+			// be deferred to the referencing candidate the way a concrete alias can.
+			if ref.Provider == "" {
+				return fmt.Errorf("models.%s: model_pattern requires an explicit provider", name)
+			}
+			// Reject a malformed glob at load, not at first resolve. path.Match's
+			// only error is ErrBadPattern; the empty name still forces a full scan
+			// of the pattern's syntax (e.g. an unterminated character class).
+			if _, perr := path.Match(ref.ModelPattern, ""); perr != nil {
+				return fmt.Errorf("models.%s: invalid model_pattern %q: %v", name, ref.ModelPattern, perr)
+			}
+		}
 		if ref.Provider != "" && !known[ref.Provider] {
 			return fmt.Errorf("models.%s: unknown provider %q", name, ref.Provider)
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -43,7 +43,7 @@ func TestLoadExample(t *testing.T) {
 		t.Errorf("env not loaded: %q", cfg.Env.AnthropicAPIKey)
 	}
 
-	provider, model, err := cfg.ResolveAgentModel("default")
+	provider, model, _, err := cfg.ResolveAgentModel("default")
 	if err != nil {
 		t.Fatalf("ResolveAgentModel: %v", err)
 	}

--- a/internal/config/model_pattern_test.go
+++ b/internal/config/model_pattern_test.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// RFC BG model_pattern alias validation. A models: entry must set EXACTLY one of
+// model / model_pattern; a pattern alias needs an explicit provider (a pattern
+// is scoped to one catalog) and a legal path.Match glob.
+
+func modelPatternBase(models map[string]ModelRef) *Config {
+	return &Config{
+		Defaults:    Defaults{Provider: "anthropic", Model: "x"},
+		Concurrency: Concurrency{MaxConcurrentRuns: 1},
+		Models:      models,
+	}
+}
+
+func TestValidate_ModelPattern_ValidAliasLoads(t *testing.T) {
+	if err := validate(modelPatternBase(map[string]ModelRef{
+		"haiku": {Provider: "anthropic", ModelPattern: "claude-haiku-*"},
+	})); err != nil {
+		t.Errorf("valid model_pattern alias rejected: %v", err)
+	}
+}
+
+func TestValidate_ModelPattern_RejectsBothModelAndPattern(t *testing.T) {
+	err := validate(modelPatternBase(map[string]ModelRef{
+		"haiku": {Provider: "anthropic", Model: "claude-haiku-4-5", ModelPattern: "claude-haiku-*"},
+	}))
+	if err == nil || !strings.Contains(err.Error(), "exactly one of model or model_pattern") {
+		t.Errorf("both model and model_pattern accepted: %v", err)
+	}
+}
+
+func TestValidate_ModelPattern_RejectsNeitherModelNorPattern(t *testing.T) {
+	err := validate(modelPatternBase(map[string]ModelRef{
+		"empty": {Provider: "anthropic"},
+	}))
+	if err == nil || !strings.Contains(err.Error(), "exactly one of model or model_pattern") {
+		t.Errorf("empty alias (no model, no pattern) accepted: %v", err)
+	}
+}
+
+func TestValidate_ModelPattern_RequiresProvider(t *testing.T) {
+	err := validate(modelPatternBase(map[string]ModelRef{
+		"haiku": {ModelPattern: "claude-haiku-*"},
+	}))
+	if err == nil || !strings.Contains(err.Error(), "model_pattern requires an explicit provider") {
+		t.Errorf("provider-less pattern accepted: %v", err)
+	}
+}
+
+func TestValidate_ModelPattern_RejectsBadGlob(t *testing.T) {
+	// An unterminated character class is path.ErrBadPattern.
+	err := validate(modelPatternBase(map[string]ModelRef{
+		"haiku": {Provider: "anthropic", ModelPattern: "claude-[haiku"},
+	}))
+	if err == nil || !strings.Contains(err.Error(), "invalid model_pattern") {
+		t.Errorf("malformed glob accepted: %v", err)
+	}
+}
+
+// TestValidate_ModelPattern_ConcreteOnlyUnchanged pins the byte-identical
+// guarantee: a config with only concrete aliases validates exactly as before —
+// the RFC BG exactly-one check must not reject a plain model alias.
+func TestValidate_ModelPattern_ConcreteOnlyUnchanged(t *testing.T) {
+	if err := validate(modelPatternBase(map[string]ModelRef{
+		"smart": {Provider: "anthropic", Model: "claude-sonnet-4-6"},
+		"fast":  {Model: "claude-haiku-4-5"}, // empty provider deferred to the referencing candidate
+	})); err != nil {
+		t.Errorf("concrete-only alias config rejected: %v", err)
+	}
+}

--- a/internal/modelver/modelver.go
+++ b/internal/modelver/modelver.go
@@ -1,0 +1,151 @@
+// Package modelver ranks provider model ids by recency using a generic
+// numeric-run scheme (RFC BG — model-pattern / latest resolution). It splits a
+// model id into its runs of digits and compares those runs element-wise as
+// integers, so it orders every id scheme loomcycle sees where naive lexical
+// sorting fails:
+//
+//   - dotted        "qwen3.6"  <  "qwen3.10"          ([3,6]  < [3,10])
+//   - hyphenated    "…-4-5"    <  "…-4-6"             ([4,5]  < [4,6])
+//   - timestamped   "…-4-5-20251001" < "…-4-5-20260101"
+//   - mixed         "gemini-2.5-flash-lite" → [2,5], "gpt-5.4-mini" → [5,4]
+//
+// The comparator is family-agnostic: it ranks only the numeric components, so
+// callers must scope the candidate set to one model family first (the RFC BG
+// glob's literal prefix, e.g. "claude-haiku-*", does this). Comparing ids from
+// different families is meaningless.
+//
+// The one genuine ambiguity — a bare stem vs. a dated snapshot at the same
+// version (e.g. "claude-sonnet-5" vs "claude-sonnet-5-20260401") — is provider
+// convention, not arithmetic, and is resolved by the bareIsNewer flag the caller
+// supplies (Anthropic publishes a bare major as a rolling alias for the newest
+// snapshot of its generation → bareIsNewer=true).
+package modelver
+
+// vector tokenizes a model id into its ordered numeric components. An
+// Ollama-style ":tag" suffix ("qwen3.6:latest") is stripped first; then every
+// maximal run of ASCII digits becomes one int and all non-digit separators
+// (".", "-", "_", letters) are discarded. A model id with no digits ("gpt-oss")
+// yields an empty vector — it is not version-comparable.
+func vector(id string) []int {
+	// Strip an Ollama ":tag" (name:tag) so the tag never enters the version
+	// comparison; the selected id keeps its tag when it is actually called.
+	for i := 0; i < len(id); i++ {
+		if id[i] == ':' {
+			id = id[:i]
+			break
+		}
+	}
+	var out []int
+	for i := 0; i < len(id); {
+		if id[i] < '0' || id[i] > '9' {
+			i++
+			continue
+		}
+		j := i
+		n := 0
+		overflow := false
+		for j < len(id) && id[j] >= '0' && id[j] <= '9' {
+			// Manual accumulation (avoids strconv + bounds a pathological
+			// digit run). Real components are small (versions) or 8-digit
+			// dates, so overflow is unreachable in practice; guard anyway.
+			if n > (maxInt-9)/10 {
+				overflow = true
+			} else {
+				n = n*10 + int(id[j]-'0')
+			}
+			j++
+		}
+		if overflow {
+			n = maxInt // a pathological run sorts last-resort high, never panics
+		}
+		out = append(out, n)
+		i = j
+	}
+	return out
+}
+
+const maxInt = int(^uint(0) >> 1)
+
+// Compare orders model ids a and b by recency. Returns -1 when a is OLDER than
+// b, +1 when NEWER, 0 when equal-rank. Ranking is element-wise numeric over each
+// id's version vector; the first differing component decides (larger = newer).
+//
+// When one vector is a strict prefix of the other (all shared components equal,
+// one has extra trailing components — typically a date), the tie is broken by
+// bareIsNewer:
+//   - bareIsNewer=true  → the SHORTER (bare) vector is newer. Anthropic's rolling
+//     major alias ("claude-sonnet-5") tracks the newest snapshot of its
+//     generation, so it outranks any dated "claude-sonnet-5-<date>".
+//   - bareIsNewer=false → the LONGER (dated snapshot) vector is newer — the
+//     provider-agnostic default: a concrete dated id is newer than a bare stem.
+func Compare(a, b string, bareIsNewer bool) int {
+	va, vb := vector(a), vector(b)
+	n := len(va)
+	if len(vb) < n {
+		n = len(vb)
+	}
+	for i := 0; i < n; i++ {
+		if va[i] != vb[i] {
+			if va[i] < vb[i] {
+				return -1
+			}
+			return 1
+		}
+	}
+	switch {
+	case len(va) == len(vb):
+		return 0
+	case len(va) < len(vb): // a is the shorter one
+		if len(va) == 0 {
+			// a has NO version (a digit-less stem), not a bare major — it always
+			// ranks below a versioned id, regardless of bareIsNewer.
+			return -1
+		}
+		// a is a genuine bare version (a prefix of b, e.g. [5] vs [5,date]).
+		if bareIsNewer {
+			return 1
+		}
+		return -1
+	default: // b is the shorter one
+		if len(vb) == 0 {
+			return 1 // b digit-less → a (versioned) is newer
+		}
+		if bareIsNewer {
+			return -1
+		}
+		return 1
+	}
+}
+
+// Newest returns the id in ids that ranks newest under Compare, and whether a
+// unique newest was found. Returns ("", false) when:
+//   - ids is empty, or
+//   - the match is AMBIGUOUS: more than one id is present and the winner has no
+//     version vector (a set of digit-less ids like "gpt-oss" / "gpt-oss-preview"
+//     the comparator cannot order). The caller should then WARN and fall through
+//     (RFC BG "narrow the glob or pin").
+//
+// A single id — even a digit-less one — is always returned (a unique glob match
+// needs no ranking). Ties among version-comparable ids (identical vectors) break
+// by lexical order (greatest wins) for deterministic selection.
+func Newest(ids []string, bareIsNewer bool) (string, bool) {
+	switch len(ids) {
+	case 0:
+		return "", false
+	case 1:
+		return ids[0], true
+	}
+	best := ids[0]
+	for _, id := range ids[1:] {
+		if c := Compare(id, best, bareIsNewer); c > 0 || (c == 0 && id > best) {
+			best = id
+		}
+	}
+	// A non-empty vector always outranks an empty one (Compare treats the
+	// digit-bearing id as "longer" → newer under the default), so `best` has an
+	// empty vector only when EVERY candidate does — an unrankable digit-less set.
+	if len(vector(best)) == 0 {
+		return "", false
+	}
+	return best, true
+}

--- a/internal/modelver/modelver_test.go
+++ b/internal/modelver/modelver_test.go
@@ -1,0 +1,152 @@
+package modelver
+
+import "testing"
+
+// TestCompare_DottedVersions is the operator's headline case: dotted versions
+// must compare per-segment numerically, so 3.10 is newer than 3.6 (NOT the
+// lexical/decimal answer where "3.6" > "3.10").
+func TestCompare_DottedVersions(t *testing.T) {
+	if Compare("qwen3.6", "qwen3.10", false) >= 0 {
+		t.Error("qwen3.6 should be OLDER than qwen3.10 (3.10 > 3.6 per-segment)")
+	}
+	if Compare("qwen3.10", "qwen3.6", false) <= 0 {
+		t.Error("qwen3.10 should be NEWER than qwen3.6")
+	}
+	if Compare("qwen3.6", "qwen3.6", false) != 0 {
+		t.Error("equal ids should rank equal")
+	}
+}
+
+// TestCompare_TimestampSuffix: an 8-digit YYYYMMDD suffix is a trailing integer,
+// so a later snapshot of the same version is newer, and a minor-version bump
+// beats an older minor's later date.
+func TestCompare_TimestampSuffix(t *testing.T) {
+	if Compare("claude-haiku-4-5-20251001", "claude-haiku-4-5-20260101", false) >= 0 {
+		t.Error("…-20251001 should be OLDER than …-20260101 (later date newer)")
+	}
+	// A minor bump (4-6) beats an older minor's later date (4-5-<date>).
+	if Compare("claude-haiku-4-6", "claude-haiku-4-5-20251001", false) <= 0 {
+		t.Error("claude-haiku-4-6 should be NEWER than claude-haiku-4-5-20251001 (minor beats old minor's date)")
+	}
+}
+
+// TestCompare_HyphenatedNumeric: hyphen-separated components compare numerically
+// (4-10 > 4-5), and a higher major wins.
+func TestCompare_HyphenatedNumeric(t *testing.T) {
+	if Compare("claude-x-4-5", "claude-x-4-10", false) >= 0 {
+		t.Error("…-4-5 should be OLDER than …-4-10 (10 > 5 numerically)")
+	}
+	if Compare("claude-sonnet-4-6", "claude-sonnet-5", false) >= 0 {
+		t.Error("claude-sonnet-4-6 should be OLDER than claude-sonnet-5 (major 5 > 4)")
+	}
+}
+
+// TestCompare_BareVsDated exercises the one genuine ambiguity: a bare major vs a
+// dated snapshot at the same major. bareIsNewer flips which wins.
+func TestCompare_BareVsDated(t *testing.T) {
+	// Anthropic convention (bareIsNewer=true): the rolling bare alias wins.
+	if Compare("claude-sonnet-5", "claude-sonnet-5-20260401", true) <= 0 {
+		t.Error("bareIsNewer=true: bare claude-sonnet-5 should outrank the dated snapshot")
+	}
+	// Default convention (bareIsNewer=false): the concrete dated id wins.
+	if Compare("claude-sonnet-5", "claude-sonnet-5-20260401", false) >= 0 {
+		t.Error("bareIsNewer=false: the dated snapshot should outrank the bare stem")
+	}
+}
+
+// TestCompare_DigitlessNeverOutranksVersioned: a digit-less stem (empty vector)
+// must ALWAYS rank below a versioned id, even under bareIsNewer=true (it is not
+// a bare major — it has no version at all).
+func TestCompare_DigitlessNeverOutranksVersioned(t *testing.T) {
+	for _, bare := range []bool{false, true} {
+		if Compare("gpt-oss", "gpt-5.4", bare) >= 0 {
+			t.Errorf("bareIsNewer=%v: digit-less gpt-oss must rank below versioned gpt-5.4", bare)
+		}
+		if Compare("gpt-5.4", "gpt-oss", bare) <= 0 {
+			t.Errorf("bareIsNewer=%v: versioned gpt-5.4 must rank above digit-less gpt-oss", bare)
+		}
+	}
+}
+
+// TestCompare_OllamaTagStripped: an Ollama ":tag" suffix is stripped before
+// comparison, so the embedded version drives the order.
+func TestCompare_OllamaTagStripped(t *testing.T) {
+	if Compare("qwen3.6:latest", "qwen3.10:latest", false) >= 0 {
+		t.Error("qwen3.6:latest should be OLDER than qwen3.10:latest (tag stripped, 3.10 > 3.6)")
+	}
+	if Compare("qwen3.6:latest", "qwen3.6", false) != 0 {
+		t.Error("a :tag must not change the version rank")
+	}
+}
+
+// TestNewest_AnthropicHaiku: over the live Anthropic haiku family, Newest picks
+// the (only) dated haiku — the exact fix the config needed.
+func TestNewest_AnthropicHaiku(t *testing.T) {
+	got, ok := Newest([]string{"claude-haiku-4-5-20251001"}, true)
+	if !ok || got != "claude-haiku-4-5-20251001" {
+		t.Errorf("Newest = (%q, %v), want claude-haiku-4-5-20251001", got, ok)
+	}
+}
+
+// TestNewest_AnthropicSonnet: with the Anthropic bare-rolling-alias rule, the
+// bare claude-sonnet-5 is newest of its family over 4-6 and a dated 4-5.
+func TestNewest_AnthropicSonnet(t *testing.T) {
+	ids := []string{"claude-sonnet-4-6", "claude-sonnet-4-5-20250929", "claude-sonnet-5"}
+	got, ok := Newest(ids, true)
+	if !ok || got != "claude-sonnet-5" {
+		t.Errorf("Newest = (%q, %v), want claude-sonnet-5", got, ok)
+	}
+}
+
+// TestNewest_MovesWithCatalog: injecting a newer id changes the winner (the
+// change-detection the resolver logs on).
+func TestNewest_MovesWithCatalog(t *testing.T) {
+	before, _ := Newest([]string{"claude-haiku-4-5-20251001"}, true)
+	after, _ := Newest([]string{"claude-haiku-4-5-20251001", "claude-haiku-5"}, true)
+	if before == after {
+		t.Errorf("Newest should move when a newer id appears: before=%q after=%q", before, after)
+	}
+	if after != "claude-haiku-5" {
+		t.Errorf("after = %q, want claude-haiku-5 (major 5 > 4)", after)
+	}
+}
+
+// TestNewest_SingleAndEmpty: a single match (even digit-less) resolves; an empty
+// set does not.
+func TestNewest_SingleAndEmpty(t *testing.T) {
+	if got, ok := Newest([]string{"gpt-oss:latest"}, false); !ok || got != "gpt-oss:latest" {
+		t.Errorf("single digit-less match should resolve: got (%q,%v)", got, ok)
+	}
+	if _, ok := Newest(nil, false); ok {
+		t.Error("empty set must not resolve")
+	}
+}
+
+// TestNewest_DigitlessAmbiguous: several digit-less ids can't be ranked → the
+// caller is told to fall through (RFC BG "narrow the glob or pin").
+func TestNewest_DigitlessAmbiguous(t *testing.T) {
+	if got, ok := Newest([]string{"gpt-oss", "gpt-oss-preview"}, false); ok {
+		t.Errorf("ambiguous digit-less set must not resolve, got %q", got)
+	}
+}
+
+// TestNewest_Mixed confirms the generic scheme across provider families (each
+// scoped by its own glob in practice).
+func TestNewest_Mixed(t *testing.T) {
+	cases := []struct {
+		name string
+		ids  []string
+		want string
+	}{
+		{"gemini", []string{"gemini-2.5-flash-lite", "gemini-2.0-flash"}, "gemini-2.5-flash-lite"},
+		{"gpt", []string{"gpt-5.4-mini", "gpt-5.5-mini", "gpt-4.1-mini"}, "gpt-5.5-mini"},
+		{"deepseek", []string{"deepseek-v4-flash", "deepseek-v3-flash"}, "deepseek-v4-flash"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, ok := Newest(tc.ids, false); !ok || got != tc.want {
+				t.Errorf("Newest = (%q, %v), want %q", got, ok, tc.want)
+			}
+		})
+	}
+}

--- a/internal/resolve/matrix.go
+++ b/internal/resolve/matrix.go
@@ -22,8 +22,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path"
 	"sync"
 	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/modelver"
 )
 
 // Sentinel errors. Wire surfaces (HTTP / gRPC) translate these into
@@ -96,6 +99,14 @@ type AgentRequest struct {
 	// through to a different provider).
 	PinProvider string
 	PinModel    string
+
+	// PinModelPattern (RFC BG) is an alternative to PinModel: a glob the
+	// resolver expands against PinProvider's live catalog to the newest listed
+	// model, once, at admission. Set instead of PinModel when a pinned agent
+	// names a model_pattern alias. PinProvider is still required. A pattern that
+	// matches nothing available fails with ErrPinUnavailable (a pin has no
+	// fallthrough).
+	PinModelPattern string
 
 	// Tier path. When set, the resolver walks the candidate list
 	// (Models[Tier] if non-empty, else library Tiers[Tier]) in the
@@ -192,6 +203,13 @@ type UserTierOverlay struct {
 type Candidate struct {
 	Provider string
 	Model    string
+
+	// ModelPattern (RFC BG) is a path.Match glob that resolves to the newest
+	// listed model on Provider at resolve time. Mutually exclusive with Model
+	// (the config boundary sets exactly one). When set, Resolve/Cascade expand
+	// it against the live catalog; a candidate whose pattern matches nothing
+	// available is skipped like any unavailable candidate (no hard fail).
+	ModelPattern string
 }
 
 // Resolver picks (provider, model) for an agent against the
@@ -225,6 +243,17 @@ type Resolver struct {
 	// SetForceProbeCallback writes under the write lock; ForceProbe
 	// reads under the read lock.
 	forceProbe func(ctx context.Context)
+
+	// logf is the RFC BG change-log sink (nil = no logging, preserving the
+	// resolver's no-log-dependency shape). Written once via SetLogf under the
+	// write lock; read by noteResolved under the read lock Resolve already holds.
+	logf func(string, ...any)
+
+	// lastResolved records the last concrete model a (provider, pattern) resolved
+	// to, so noteResolved can WARN when a pattern silently moves to a new model.
+	// A sync.Map (not the matrix mutex) so the WARN path never upgrades the RLock
+	// Resolve holds. Key: provider + "\x00" + pattern; value: string (model).
+	lastResolved sync.Map
 }
 
 // Availability is the resolver's view of one provider's reachability
@@ -359,20 +388,20 @@ func (r *Resolver) Resolve(req AgentRequest) (Decision, error) {
 		return Decision{}, fmt.Errorf("%w: agent name is required", ErrInvalidArgument)
 	}
 
-	// Pin path. Explicit provider+model bypasses tier resolution
-	// entirely — caller asked for THAT model. Still gated by the
-	// matrix so a stalled pin surfaces as ErrPinUnavailable rather
-	// than the driver's 5xx.
-	if req.PinProvider != "" && req.PinModel != "" {
+	// Pin path. Explicit provider + (model OR RFC BG model_pattern) bypasses
+	// tier resolution entirely — caller asked for THAT model / THAT family.
+	// Still gated by the matrix so a stalled pin surfaces as ErrPinUnavailable
+	// rather than the driver's 5xx.
+	if req.PinProvider != "" && (req.PinModel != "" || req.PinModelPattern != "") {
 		return r.resolvePin(req)
 	}
-	if req.PinProvider != "" || req.PinModel != "" {
+	if req.PinProvider != "" || req.PinModel != "" || req.PinModelPattern != "" {
 		// Half a pin — provider without model or vice versa — is
 		// almost certainly a config typo. The validator should
 		// catch this at load time, but we double-check for cases
 		// where AgentRequest is constructed directly (tests).
-		return Decision{}, fmt.Errorf("%w: pin requires both provider and model (got provider=%q model=%q)",
-			ErrInvalidArgument, req.PinProvider, req.PinModel)
+		return Decision{}, fmt.Errorf("%w: pin requires both provider and model (got provider=%q model=%q model_pattern=%q)",
+			ErrInvalidArgument, req.PinProvider, req.PinModel, req.PinModelPattern)
 	}
 
 	// Tier path.
@@ -452,10 +481,30 @@ func (r *Resolver) Resolve(req AgentRequest) (Decision, error) {
 				continue
 			}
 			sawKeyable = true
-			if r.isAvailableLocked(cand.Provider, cand.Model) {
+			// RFC BG: a pattern candidate resolves to the newest listed model on
+			// its provider. A pattern that matches nothing available is treated as
+			// an unavailable candidate — fall through to the next one (§4.2.5,
+			// never hard-fail on a pattern miss). A concrete candidate takes the
+			// unchanged path (ModelPattern == "" → model := cand.Model), so a
+			// pattern-free config resolves byte-identically.
+			model := cand.Model
+			if cand.ModelPattern != "" {
+				m, ok := r.newestMatchingLocked(cand.Provider, cand.ModelPattern)
+				if !ok {
+					continue
+				}
+				model = m
+			}
+			if r.isAvailableLocked(cand.Provider, model) {
+				// Log a silent model bump only for the candidate we actually
+				// select (not merely one that matched) — so the WARN maps 1:1 to
+				// what runs.
+				if cand.ModelPattern != "" {
+					r.noteResolved(cand.Provider, cand.ModelPattern, model)
+				}
 				return Decision{
 					Provider: cand.Provider,
-					Model:    cand.Model,
+					Model:    model,
 					Effort:   req.Effort,
 				}, nil
 			}
@@ -481,17 +530,33 @@ func keyable(req AgentRequest, provider string) bool {
 
 // resolvePin consults the matrix for the explicit pin and returns
 // either the Decision or ErrPinUnavailable. Caller already checked
-// that both PinProvider and PinModel are set.
+// that PinProvider plus one of PinModel / PinModelPattern is set.
 func (r *Resolver) resolvePin(req AgentRequest) (Decision, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	if !r.isAvailableLocked(req.PinProvider, req.PinModel) {
+	model := req.PinModel
+	if req.PinModelPattern != "" {
+		// RFC BG: expand the pattern once, here at admission, against the live
+		// catalog. A pin has no fallthrough, so a pattern that matches nothing
+		// available surfaces as ErrPinUnavailable — same shape as a stalled
+		// concrete pin.
+		m, ok := r.newestMatchingLocked(req.PinProvider, req.PinModelPattern)
+		if !ok {
+			return Decision{}, fmt.Errorf("%w: agent %q wants %s/%s (pattern matched no available model)",
+				ErrPinUnavailable, req.Name, req.PinProvider, req.PinModelPattern)
+		}
+		model = m
+	}
+	if !r.isAvailableLocked(req.PinProvider, model) {
 		return Decision{}, fmt.Errorf("%w: agent %q wants %s/%s",
-			ErrPinUnavailable, req.Name, req.PinProvider, req.PinModel)
+			ErrPinUnavailable, req.Name, req.PinProvider, model)
+	}
+	if req.PinModelPattern != "" {
+		r.noteResolved(req.PinProvider, req.PinModelPattern, model)
 	}
 	return Decision{
 		Provider: req.PinProvider,
-		Model:    req.PinModel,
+		Model:    model,
 		Effort:   req.Effort,
 	}, nil
 }
@@ -525,9 +590,24 @@ func (r *Resolver) Cascade(req AgentRequest) []Candidate {
 			continue
 		}
 		for _, c := range candidates {
-			if c.Provider == p {
-				out = append(out, c)
+			if c.Provider != p {
+				continue
 			}
+			// RFC BG: expand a pattern candidate to the concrete model it resolves
+			// to now, so the routing view shows what would actually run. If it
+			// resolves to nothing (empty/renamed catalog), fall back to the raw
+			// glob in Model for display — availStatus then shows it unavailable.
+			// Cascade is display-only, so it never notes/warns a move (that would
+			// spam on every routing-view poll). newestMatching takes its own
+			// RLock — Cascade holds none here.
+			if c.ModelPattern != "" {
+				if m, ok := r.newestMatching(c.Provider, c.ModelPattern); ok {
+					c.Model = m
+				} else {
+					c.Model = c.ModelPattern
+				}
+			}
+			out = append(out, c)
 		}
 	}
 	return out
@@ -622,6 +702,81 @@ func (r *Resolver) isAvailableLocked(provider, model string) bool {
 		return false
 	}
 	return true
+}
+
+// newestMatchingLocked returns the newest LISTED, non-stalled, non-rate-limited
+// model on provider that matches the path.Match glob (RFC BG), and whether a
+// ranked match exists. Caller holds r.mu (read or write). Applies the SAME
+// availability predicate as isAvailableLocked, so the returned model is callable
+// by construction — the caller need not re-gate it, though it may.
+//
+// ok=false when the provider is excluded/unreachable, no listed model matches,
+// or the only matches are digit-less ids the comparator can't rank (RFC BG
+// "narrow the glob or pin") — in every case the caller treats the candidate as
+// unavailable and falls through.
+func (r *Resolver) newestMatchingLocked(provider, glob string) (string, bool) {
+	avail, ok := r.matrix[provider]
+	if !ok || avail.Excluded || !avail.Reachable {
+		return "", false
+	}
+	now := time.Now()
+	var matches []string
+	for model, status := range avail.Models {
+		if !status.Listed || status.Stalled {
+			continue
+		}
+		if status.RateLimited && now.Before(status.RateLimitedUntil) {
+			continue
+		}
+		// path.Match's only error is ErrBadPattern; config validation already
+		// rejected a malformed glob at load, and a bad pattern yields matched
+		// false anyway, so a non-match on error is safe.
+		if matched, _ := path.Match(glob, model); matched {
+			matches = append(matches, model)
+		}
+	}
+	// bareIsNewer is a provider convention, not arithmetic: Anthropic publishes a
+	// bare major (claude-sonnet-5) as a rolling alias for the newest snapshot of
+	// its generation, so a bare stem outranks a dated one there. Hardcoded per
+	// the approved RFC BG P1 scope (a per-driver override registry is P2).
+	best, ok := modelver.Newest(matches, provider == "anthropic")
+	if !ok {
+		return "", false
+	}
+	return best, true
+}
+
+// newestMatching is the lock-taking companion to newestMatchingLocked for
+// callers that do NOT already hold r.mu (Cascade). Resolve/resolvePin hold the
+// read lock and call the Locked form directly.
+func (r *Resolver) newestMatching(provider, glob string) (string, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.newestMatchingLocked(provider, glob)
+}
+
+// noteResolved records that (provider, pattern) resolved to model and logs a
+// WARN via logf when the resolution MOVED (a different concrete model than the
+// last time it resolved) — so an operator sees a silent model bump (RFC BG
+// §4.3). Uses lastResolved (a sync.Map), never the matrix mutex, so it is safe
+// to call while Resolve holds the RLock (upgrading to the write lock would
+// deadlock). No-op logging when logf is nil.
+func (r *Resolver) noteResolved(provider, pattern, model string) {
+	key := provider + "\x00" + pattern
+	prev, loaded := r.lastResolved.Swap(key, model)
+	if loaded && prev.(string) != model && r.logf != nil {
+		r.logf("model-pattern: %s %q moved %s → %s", provider, pattern, prev.(string), model)
+	}
+}
+
+// SetLogf wires the RFC BG change-log sink (typically log.Printf). Nil disables
+// logging. Written under the write lock, mirroring SetForceProbeCallback;
+// noteResolved reads it under the RLock Resolve holds, so the field access is
+// race-free without the WARN path ever taking the write lock.
+func (r *Resolver) SetLogf(fn func(string, ...any)) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.logf = fn
 }
 
 // SetReachable updates the matrix for a probe outcome. PR 1 calls

--- a/internal/resolve/pattern_test.go
+++ b/internal/resolve/pattern_test.go
@@ -1,0 +1,240 @@
+package resolve
+
+import (
+	"errors"
+	"testing"
+)
+
+// RFC BG model-pattern resolution. These lock the resolver's expansion of a
+// `model_pattern` glob against the live catalog: it must pick the NEWEST listed
+// model (numeric-run ranking via internal/modelver), honour the Anthropic
+// bare-rolling-alias convention, fall through on a no-match rather than
+// hard-fail, and surface a silent model bump on the log.
+
+// patternReq builds a tier request whose single "low" candidate is a pattern on
+// the given provider — the minimal shape that exercises the tier path without
+// leaning on the library fixture.
+func patternReq(name, provider, glob string) AgentRequest {
+	return AgentRequest{
+		Name:      name,
+		Tier:      "low",
+		Providers: []string{provider},
+		Models:    map[string][]Candidate{"low": {{Provider: provider, ModelPattern: glob}}},
+	}
+}
+
+func TestResolve_PatternCandidateResolvesToNewestListed(t *testing.T) {
+	r := NewResolver([]string{"anthropic"}, nil)
+	// Only a dated snapshot is listed — the operator's config had the bare
+	// `claude-haiku-4-5`, which would 404; the pattern tracks the real catalog.
+	r.SetReachable("anthropic", true, []string{"claude-haiku-4-5-20251001"}, "")
+
+	dec, err := r.Resolve(patternReq("doc-agent", "anthropic", "claude-haiku-*"))
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if dec.Model != "claude-haiku-4-5-20251001" {
+		t.Errorf("resolved model = %q, want claude-haiku-4-5-20251001", dec.Model)
+	}
+}
+
+func TestResolve_PatternPicksHighestVersionAcrossGenerations(t *testing.T) {
+	r := NewResolver([]string{"anthropic"}, nil)
+	// The bare major claude-sonnet-5 ([5]) outranks the older minors regardless
+	// of bareIsNewer — [5] > [4,6] > [4,5,…] at the first differing component.
+	r.SetReachable("anthropic", true, []string{
+		"claude-sonnet-5",
+		"claude-sonnet-4-6",
+		"claude-sonnet-4-5-20250929",
+	}, "")
+
+	dec, err := r.Resolve(patternReq("chat", "anthropic", "claude-sonnet-*"))
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if dec.Model != "claude-sonnet-5" {
+		t.Errorf("resolved model = %q, want claude-sonnet-5", dec.Model)
+	}
+}
+
+func TestResolve_PatternAnthropicBareMajorOutranksDatedSnapshot(t *testing.T) {
+	// The genuine bare-vs-dated tie-break: [5] vs [5,20260101]. Anthropic
+	// publishes the bare major as a rolling alias for the newest snapshot, so
+	// bareIsNewer=true (provider=="anthropic") picks the bare stem.
+	r := NewResolver([]string{"anthropic"}, nil)
+	r.SetReachable("anthropic", true, []string{
+		"claude-sonnet-5",
+		"claude-sonnet-5-20260101",
+	}, "")
+
+	dec, err := r.Resolve(patternReq("chat", "anthropic", "claude-sonnet-*"))
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if dec.Model != "claude-sonnet-5" {
+		t.Errorf("resolved model = %q, want claude-sonnet-5 (bare rolling alias)", dec.Model)
+	}
+}
+
+func TestResolve_PatternNonAnthropicPrefersDatedSnapshot(t *testing.T) {
+	// Same bare-vs-dated shape on a NON-anthropic provider: bareIsNewer=false, so
+	// the concrete dated snapshot ([5,4,20260101]) outranks the bare stem
+	// ([5,4]). Proves the hardcoded provider=="anthropic" discriminator.
+	r := NewResolver([]string{"openai"}, nil)
+	r.SetReachable("openai", true, []string{
+		"gpt-5.4",
+		"gpt-5.4-20260101",
+	}, "")
+
+	dec, err := r.Resolve(patternReq("chat", "openai", "gpt-5.4*"))
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if dec.Model != "gpt-5.4-20260101" {
+		t.Errorf("resolved model = %q, want gpt-5.4-20260101 (dated wins for non-anthropic)", dec.Model)
+	}
+}
+
+func TestResolve_PatternNoMatchFallsThroughToNextCandidate(t *testing.T) {
+	// A pattern that matches nothing available is an unavailable candidate — the
+	// resolver walks on to the next candidate rather than hard-failing (§4.2.5).
+	r := NewResolver([]string{"anthropic", "deepseek"}, nil)
+	r.SetReachable("anthropic", true, []string{"claude-haiku-4-5-20251001"}, "")
+	r.SetReachable("deepseek", true, []string{"deepseek-v4-flash"}, "")
+
+	dec, err := r.Resolve(AgentRequest{
+		Name:      "doc-agent",
+		Tier:      "low",
+		Providers: []string{"anthropic", "deepseek"},
+		Models: map[string][]Candidate{"low": {
+			{Provider: "anthropic", ModelPattern: "claude-nonexistent-*"},
+			{Provider: "deepseek", Model: "deepseek-v4-flash"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if dec.Provider != "deepseek" || dec.Model != "deepseek-v4-flash" {
+		t.Errorf("decision = %+v, want deepseek/deepseek-v4-flash", dec)
+	}
+}
+
+func TestResolve_PatternNoMatchOnlyCandidateIsTierUnavailable(t *testing.T) {
+	// A pattern miss with no fallback candidate is a plain availability outage,
+	// not a policy refusal — ErrTierUnavailable so a client may retry.
+	r := NewResolver([]string{"anthropic"}, nil)
+	r.SetReachable("anthropic", true, []string{"claude-haiku-4-5-20251001"}, "")
+
+	_, err := r.Resolve(patternReq("doc-agent", "anthropic", "claude-nonexistent-*"))
+	if !errors.Is(err, ErrTierUnavailable) {
+		t.Fatalf("err = %v, want ErrTierUnavailable", err)
+	}
+}
+
+func TestResolve_PatternMoveLogsWarn(t *testing.T) {
+	r := NewResolver([]string{"anthropic"}, nil)
+	var logs []string
+	r.SetLogf(func(format string, args ...any) {
+		logs = append(logs, format)
+	})
+	r.SetReachable("anthropic", true, []string{"claude-haiku-4-5-20251001"}, "")
+
+	// First resolution records the concrete model — nothing to compare against,
+	// so it must NOT warn.
+	if _, err := r.Resolve(patternReq("doc-agent", "anthropic", "claude-haiku-*")); err != nil {
+		t.Fatalf("Resolve #1: %v", err)
+	}
+	if len(logs) != 0 {
+		t.Fatalf("first-seen resolution logged %d line(s), want 0", len(logs))
+	}
+
+	// A newer snapshot appears in the catalog — the pattern now resolves to a
+	// DIFFERENT concrete model, which must WARN so the operator sees the bump.
+	r.SetReachable("anthropic", true, []string{
+		"claude-haiku-4-5-20251001",
+		"claude-haiku-5-20260101",
+	}, "")
+	dec, err := r.Resolve(patternReq("doc-agent", "anthropic", "claude-haiku-*"))
+	if err != nil {
+		t.Fatalf("Resolve #2: %v", err)
+	}
+	if dec.Model != "claude-haiku-5-20260101" {
+		t.Errorf("resolved model = %q, want claude-haiku-5-20260101", dec.Model)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("moved resolution logged %d line(s), want 1", len(logs))
+	}
+}
+
+func TestResolvePin_PatternResolvesToNewestListed(t *testing.T) {
+	// A pinned agent naming a model_pattern alias: the resolver expands the glob
+	// on the pinned provider's catalog, once, at admission.
+	r := NewResolver(nil, nil)
+	r.SetReachable("anthropic", true, []string{
+		"claude-haiku-4-5-20251001",
+		"claude-haiku-5-20260101",
+	}, "")
+
+	dec, err := r.Resolve(AgentRequest{
+		Name:            "pinned",
+		PinProvider:     "anthropic",
+		PinModelPattern: "claude-haiku-*",
+		Effort:          "high",
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if dec.Provider != "anthropic" || dec.Model != "claude-haiku-5-20260101" || dec.Effort != "high" {
+		t.Errorf("decision = %+v, want anthropic/claude-haiku-5-20260101/high", dec)
+	}
+}
+
+func TestResolvePin_PatternNoMatchIsPinUnavailable(t *testing.T) {
+	// A pin has no fallthrough, so a pattern that matches nothing available fails
+	// with ErrPinUnavailable — same shape as a stalled concrete pin.
+	r := NewResolver(nil, nil)
+	r.SetReachable("anthropic", true, []string{"claude-haiku-4-5-20251001"}, "")
+
+	_, err := r.Resolve(AgentRequest{
+		Name:            "pinned",
+		PinProvider:     "anthropic",
+		PinModelPattern: "claude-nonexistent-*",
+	})
+	if !errors.Is(err, ErrPinUnavailable) {
+		t.Fatalf("err = %v, want ErrPinUnavailable", err)
+	}
+}
+
+func TestCascade_ExpandsPatternToConcreteModel(t *testing.T) {
+	// The routing view calls Cascade — a pattern candidate must show the concrete
+	// model it would resolve to now, so the availability dot is meaningful.
+	r := NewResolver([]string{"anthropic"}, nil)
+	r.SetReachable("anthropic", true, []string{
+		"claude-sonnet-5",
+		"claude-sonnet-4-6",
+	}, "")
+
+	casc := r.Cascade(patternReq("routing-view", "anthropic", "claude-sonnet-*"))
+	if len(casc) != 1 {
+		t.Fatalf("cascade len = %d, want 1", len(casc))
+	}
+	if casc[0].Model != "claude-sonnet-5" {
+		t.Errorf("cascade model = %q, want claude-sonnet-5", casc[0].Model)
+	}
+}
+
+func TestCascade_UnresolvablePatternKeepsGlobForDisplay(t *testing.T) {
+	// When the pattern resolves to nothing (empty/renamed catalog), Cascade keeps
+	// the raw glob in Model so the routing view shows the pattern with an
+	// unavailable dot rather than an empty cell.
+	r := NewResolver([]string{"anthropic"}, nil)
+	r.SetReachable("anthropic", true, []string{"claude-haiku-4-5-20251001"}, "")
+
+	casc := r.Cascade(patternReq("routing-view", "anthropic", "claude-nonexistent-*"))
+	if len(casc) != 1 {
+		t.Fatalf("cascade len = %d, want 1", len(casc))
+	}
+	if casc[0].Model != "claude-nonexistent-*" {
+		t.Errorf("cascade model = %q, want the raw glob claude-nonexistent-*", casc[0].Model)
+	}
+}


### PR DESCRIPTION
## Why

Provider model IDs churn (Anthropic's `/v1/models` lists only dated ids like `claude-haiku-4-5-20251001` and exposes **zero `-latest` aliases**), so a pinned config goes stale — the alias drops out of `/v1/models`, the routing view goes red, and runs 404 until an operator hand-edits the YAML. RFC BG (`/loomcycle/rfcs/model-pattern-resolution`, approved) adds an opt-in `model_pattern` alias that resolves to the **newest listed model** matching a glob, so the config never needs a manual model-id bump — crossing generation renames, which provider `-latest` can't (and which don't exist for Anthropic anyway).

This is **P1**: the generic version comparator + resolver/config wiring, Anthropic-first. P2 (per-driver comparator overrides, `Context op=self resolved_model`, routing-UI surface) is deferred.

## What

```yaml
models:
  haiku: { provider: anthropic, model_pattern: "claude-haiku-*" }   # → newest listed claude-haiku-*
```

- **`internal/modelver`** (new, pure) — a generic **numeric-run comparator**: split an id into runs of digits, compare element-wise as integers. Orders every scheme loomcycle sees where lexical sort fails — dotted (`qwen3.6` < `qwen3.10`), hyphenated (`…-4-5` < `…-4-6`), timestamped (`…-4-5-20251001` < `…-4-5-20260101`; a minor bump beats an older minor's later date), mixed. `Compare(a,b,bareIsNewer)` resolves the bare-major-vs-dated ambiguity via a per-provider flag (Anthropic's rolling bare alias → `bareIsNewer=true`); a digit-less stem never outranks a versioned id. `Newest` returns ok=false for an empty/unrankable set (caller falls through).
- **config** — `ModelRef.model_pattern` (yaml-only; the alias map isn't content-hashed, so no hash impact); validation: exactly one of `model`/`model_pattern`, a pattern requires an explicit `provider`, and the glob must be a legal `path.Match` pattern (rejected at load). `ExpandModelAlias` extended to surface the pattern (single source of truth preserved).
- **resolver** — `Candidate.ModelPattern` / `AgentRequest.PinModelPattern`; `Resolve`, `resolvePin`, and `Cascade` expand a pattern against the provider's **listed** catalog (`newestMatchingLocked` — same availability predicate as `isAvailableLocked`, so the pick is callable by construction). A pattern that matches nothing available is skipped like any unavailable candidate (never a hard fail). Because everything downstream uses `Decision.Model`, the concrete resolved id is **recorded automatically** (transcript, usage) — no wire/run changes. A silent model bump WARNs via a nil-safe `logf` + a `sync.Map` (the WARN path never upgrades the RLock `Resolve` holds).
- **Byte-identical** when no `model_pattern` is configured — every new branch is gated on `ModelPattern != ""`.

## Design decisions (from the approved RFC)
`bareIsNewer = provider == "anthropic"` hardcoded (no per-driver registry — P2); per-run pin (resolve once at admission); pattern on a `models:` alias only (not raw tier candidates).

## What was tested
- `go test ./...` — clean (84 packages), independently re-run. `go build ./...`, gofmt, `go vet`, `-race` (resolve + config) clean.
- New tests, each **fail-before verified** (fail on the unfixed code): `internal/modelver` (12 cases incl. `3.6` vs `3.10`, timestamps, bare-vs-dated, digit-less, Ollama `:tag`, live Anthropic families); `internal/resolve/pattern_test.go` (pattern → newest listed; Anthropic bare-major outranks dated snapshot; no-match → skip/next; `Cascade` expands; pin path); `internal/config/model_pattern_test.go` (both-set / neither / bad-glob rejected; concrete-only byte-identical).
- Manual (built binary): a `model_pattern` config validates (rc 0); both-set and pattern-without-provider are rejected with clear errors; `agents list` surfaces the glob.

3 commits: modelver comparator → resolve wiring → config wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)