### PR TITLE
feat(api): RFC BH P1 — turn-scoped cancellation (stop a turn, park not terminate)

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -643,6 +643,12 @@ func requiredScopeFor(method, path string) string {
 		return auth.ScopeRunsCreate
 	case method == http.MethodPost && strings.HasPrefix(path, "/v1/runs/") && strings.HasSuffix(path, "/compact"):
 		return auth.ScopeRunsCreate
+	// RFC BH turn-cancel: stop the current turn of an interactive run + park it —
+	// a run-state mutation, same scope as steer/resolve/compact. Distinct path
+	// from whole-run cancel (POST /v1/agents/{id}/cancel). Without this case the
+	// POST /v1/runs/.../cancel would default-deny as ScopeAdmin below.
+	case method == http.MethodPost && strings.HasPrefix(path, "/v1/runs/") && strings.HasSuffix(path, "/cancel"):
+		return auth.ScopeRunsCreate
 	// Operator steering / continuation input is a run-state MUTATION (it injects
 	// text into a live run), so it requires runs:create like cancel/resolve/
 	// compact — NOT the read scope. (exp7 I1: it previously fell through to the

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -49,6 +49,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
 	"github.com/denn-gubsky/loomcycle/internal/tools/policy"
+	"github.com/denn-gubsky/loomcycle/internal/turncancel"
 	"github.com/denn-gubsky/loomcycle/internal/webui"
 
 	"go.opentelemetry.io/otel/trace"
@@ -106,6 +107,12 @@ type Server struct {
 	// interactive terminal). nil disables steering (POST /v1/runs/{id}/input
 	// → 404). Set at boot via SetSteerRegistry.
 	steerReg *steer.Registry
+
+	// turnCancelReg maps a live run_id → its currently-armed per-turn cancel
+	// token (RFC BH). Firing it stops the CURRENT turn of an interactive run and
+	// parks it at awaiting_input (vs the whole-run cancel registry, which
+	// terminates). Always non-nil after New(); armed only for interactive runs.
+	turnCancelReg *turncancel.Registry
 
 	// sessionLocks tracks per-session mutexes used by continuation
 	// requests (handleMessages, or handleRuns with a non-empty
@@ -447,6 +454,7 @@ func New(cfg *config.Config, pr ProviderResolver, builtinTools []tools.Tool, sem
 		sem:            sem,
 		store:          st,
 		cancelReg:      cancel.NewRegistry(),
+		turnCancelReg:  turncancel.NewRegistry(),
 		sessionLocks:   runner.NewSessionLockMap(),
 		hookRegistry:   hookReg,
 		hookDispatcher: hooks.NewDispatcher(hookReg, nil),
@@ -2893,6 +2901,7 @@ func (s *Server) Mux() http.Handler {
 	// PR 2 / interactive terminal: inject an operator "steering" instruction
 	// into an in-flight run (appended to the live conversation mid-turn).
 	mux.Handle("POST /v1/runs/{run_id}/input", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleRunInput))))
+	mux.Handle("POST /v1/runs/{run_id}/cancel", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleCancelTurn))))
 	mux.Handle("POST /v1/runs/{run_id}/compact", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleCompactRun))))
 	// Re-attach to a running (or finished) run's event stream — the operator
 	// leaves the interactive /run terminal and returns to the same live run.
@@ -3947,6 +3956,12 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	// RFC X Phase 3: expose the gate to the Agent tool so a parallel_spawn
 	// fan-out parent can park mid-tool-call (no-op unless LOOMCYCLE_RESUME_FANOUT).
 	loopCtx = tools.WithPauseGate(loopCtx, gate)
+	// RFC BH: make an INTERACTIVE run turn-cancellable — POST /v1/runs/{id}/cancel
+	// stops the current turn and parks it (vs whole-run cancel, which terminates).
+	// Non-interactive runs stay unarmable so a turn-cancel on them 409s.
+	if req.Interactive {
+		runOpts.ArmTurnCancel = s.armTurnCancel(runID)
+	}
 
 	if req.Interactive && s.store != nil {
 		// Detached run: execute the loop in a background goroutine that
@@ -4487,6 +4502,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		Metadata:               body.Metadata,
 		RunTimeoutSeconds:      pickRunTimeout(body.RunTimeoutSeconds, agentDef.RunTimeoutSeconds),
 		Interactive:            body.Interactive,
+		ArmTurnCancel:          s.armTurnCancelIf(body.Interactive, run.ID),                  // RFC BH: turn-cancellable when interactive
 		Sampling:               config.MergeSampling(agentDef.Sampling, body.Sampling),       // per-run wins per field
 		Compaction:             config.MergeCompaction(agentDef.Compaction, body.Compaction), // per-run wins per field
 		ContextPlugins:         s.contextPlugins,                                             // RFC Z runtime-wide chain (code-js exempt in the loop)
@@ -4834,6 +4850,27 @@ func (s *Server) openOrCreateSessionAndRun(ctx context.Context, requestedSession
 // (EventChannelPublish / EventChannelDelivery) emit directly from inside
 // tool.Execute() — which runs in a tool goroutine, not the loop. The
 // mutex makes that safe for any concurrent caller.
+// armTurnCancel returns a loop.RunOptions.ArmTurnCancel closure that registers
+// the run's per-turn cancel token in turnCancelReg (RFC BH). The loop invokes it
+// at each turn start with that turn's CancelCauseFunc; the returned disarm clears
+// the token at the turn boundary. POST /v1/runs/{id}/cancel fires the armed token
+// to stop the current turn and park the run.
+func (s *Server) armTurnCancel(runID string) func(context.CancelCauseFunc) func() {
+	return func(tc context.CancelCauseFunc) func() {
+		return s.turnCancelReg.Arm(runID, tc)
+	}
+}
+
+// armTurnCancelIf returns armTurnCancel(runID) for an interactive run, nil
+// otherwise — a non-interactive run stays unarmable so a turn-cancel on it 409s
+// (stopping its only turn would terminate it; use whole-run cancel instead).
+func (s *Server) armTurnCancelIf(interactive bool, runID string) func(context.CancelCauseFunc) func() {
+	if !interactive {
+		return nil
+	}
+	return s.armTurnCancel(runID)
+}
+
 // makeSteer wires a run's operator steering queue (PR 2 / interactive
 // terminal). It registers the run in the steer registry and returns the
 // loop's SteerQueue, the OnSteer callback, and a deregister func (defer it so
@@ -6183,6 +6220,80 @@ func (s *Server) handleRunInput(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"run_id": runID, "delivered": delivered})
+}
+
+// cancelTurnRequest is the (optional) JSON body for POST /v1/runs/{run_id}/cancel.
+type cancelTurnRequest struct {
+	Reason string `json:"reason"`
+}
+
+// handleCancelTurn serves POST /v1/runs/{run_id}/cancel (RFC BH) — stop the
+// CURRENT turn of an interactive run (its in-flight model generation + the tool
+// calls it started) and park it at awaiting_input, session + transcript intact.
+// This is NOT whole-run cancel (POST /v1/agents/{id}/cancel), which terminates
+// the run. 409 when the run isn't mid-turn (already parked / terminal) or isn't
+// interactive; a cross-tenant / unknown run folds into an opaque 404 — run_ids
+// are not secrets (returned to callers + shown in the UI), so the gate must not
+// become an existence oracle (mirrors handleRunInput / SteerRun). Idempotent: a
+// second call once the run has parked → 409 not_mid_turn.
+func (s *Server) handleCancelTurn(w http.ResponseWriter, r *http.Request) {
+	if s.turnCancelReg == nil || s.steerReg == nil {
+		http.Error(w, "turn-cancel is not enabled on this server", http.StatusServiceUnavailable)
+		return
+	}
+	runID := r.PathValue("run_id")
+	if !validIdent(runID) {
+		http.Error(w, "run_id must match [A-Za-z0-9_-]{1,128}", http.StatusBadRequest)
+		return
+	}
+	// The body is optional — an absent/empty body is a reason-less cancel — so a
+	// decode error (incl. EOF) is not fatal; the reason is a non-secret annotation.
+	var req cancelTurnRequest
+	_ = json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req)
+	ctx := r.Context()
+
+	// Tenant-ownership gate (mirrors SteerRun): resolve the live run via the steer
+	// registry, then verify the caller owns its session. A cross-tenant or unknown
+	// run folds into an opaque 404.
+	entry, ok := s.steerReg.Get(runID)
+	if !ok {
+		http.Error(w, "no in-flight run for that run_id", http.StatusNotFound)
+		return
+	}
+	if entry.SessionID != "" && s.store != nil {
+		if sess, err := s.store.GetSession(ctx, entry.SessionID); err == nil {
+			if !sessionOwnershipOK(ctx, sess) {
+				http.Error(w, "no in-flight run for that run_id", http.StatusNotFound)
+				return
+			}
+		}
+	}
+
+	// Mid-turn? Only an armed run (interactive + in-flight) is turn-cancellable.
+	if !s.turnCancelReg.IsArmed(runID) {
+		code, msg := "not_mid_turn", "run is not mid-turn (already parked or terminal)"
+		// Distinguish a non-interactive run for a clearer error (best-effort; the
+		// caller already passed the ownership gate above).
+		if s.store != nil {
+			if run, err := s.tenantStore(ctx).GetRun(ctx, runID); err == nil && !run.Interactive {
+				code = "not_interactive"
+				msg = "turn-cancel applies only to interactive runs; use POST /v1/agents/{id}/cancel to stop this run"
+			}
+		}
+		writeJSONError(w, http.StatusConflict, code, msg)
+		return
+	}
+
+	// Fire the armed token with the operator reason. A false return means the
+	// token vanished between the IsArmed check and here (the turn just ended / a
+	// concurrent cancel won the race) → 409.
+	if !s.turnCancelReg.Cancel(runID, loop.TurnCancelCause(strings.TrimSpace(req.Reason))) {
+		writeJSONError(w, http.StatusConflict, "not_mid_turn", "run is not mid-turn (already parked or terminal)")
+		return
+	}
+	// The loop catches the sentinel cause and parks the run at awaiting_input;
+	// report the intended outcome for an interactive run.
+	writeJSON(w, http.StatusOK, map[string]any{"run_id": runID, "stopped": true, "parked": true})
 }
 
 // minCompactMessages: a conversation shorter than this isn't worth a model call.

--- a/internal/api/http/turncancel_handler_test.go
+++ b/internal/api/http/turncancel_handler_test.go
@@ -1,0 +1,170 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/loop"
+	"github.com/denn-gubsky/loomcycle/internal/steer"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/turncancel"
+)
+
+// turnCancelFixture reuses the channel fan fixture's store + auth token and wires
+// the steer + turn-cancel registries the handler needs.
+func turnCancelFixture(t *testing.T) (*Server, func()) {
+	t.Helper()
+	srv, cleanup := channelFanFixture(t)
+	srv.SetSteerRegistry(steer.NewRegistry(4))
+	srv.turnCancelReg = turncancel.NewRegistry()
+	return srv, cleanup
+}
+
+// POST /v1/runs/{id}/cancel fires the run's armed per-turn token (delivering the
+// operator reason via the cancel cause) and reports stopped/parked.
+func TestHandleCancelTurn_FiresArmedTokenAndParks(t *testing.T) {
+	srv, cleanup := turnCancelFixture(t)
+	defer cleanup()
+	_, dereg := srv.steerReg.Register(steer.Entry{RunID: "run-1"}) // no SessionID → ownership gate skipped
+	defer dereg()
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	srv.turnCancelReg.Arm("run-1", cancel)
+
+	rec := doJSON(t, srv, "POST", "/v1/runs/run-1/cancel", `{"reason":"too slow"}`)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var out struct {
+		RunID   string `json:"run_id"`
+		Stopped bool   `json:"stopped"`
+		Parked  bool   `json:"parked"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !out.Stopped || !out.Parked || out.RunID != "run-1" {
+		t.Errorf("response = %+v, want {run-1, stopped, parked}", out)
+	}
+
+	// The armed turn ctx was cancelled with the turn-cancel cause + the reason.
+	if ctx.Err() == nil {
+		t.Fatal("armed turn ctx was not cancelled")
+	}
+	cause := context.Cause(ctx)
+	if !errors.Is(cause, loop.ErrTurnCancelled) {
+		t.Errorf("cause = %v, want ErrTurnCancelled", cause)
+	}
+	if !strings.Contains(cause.Error(), "too slow") {
+		t.Errorf("cause %q did not carry the operator reason", cause.Error())
+	}
+	// Token consumed → no longer armed.
+	if srv.turnCancelReg.IsArmed("run-1") {
+		t.Error("token still armed after a successful cancel")
+	}
+}
+
+// A second cancel once the turn has been stopped is a no-op 409 (idempotent).
+func TestHandleCancelTurn_SecondCallIs409(t *testing.T) {
+	srv, cleanup := turnCancelFixture(t)
+	defer cleanup()
+	_, dereg := srv.steerReg.Register(steer.Entry{RunID: "run-1"})
+	defer dereg()
+	_, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	srv.turnCancelReg.Arm("run-1", cancel)
+
+	if rec := doJSON(t, srv, "POST", "/v1/runs/run-1/cancel", `{}`); rec.Code != 200 {
+		t.Fatalf("first cancel status = %d, want 200", rec.Code)
+	}
+	rec := doJSON(t, srv, "POST", "/v1/runs/run-1/cancel", `{}`)
+	if rec.Code != 409 {
+		t.Fatalf("second cancel status = %d, want 409; body=%s", rec.Code, rec.Body.String())
+	}
+	if code := errorCode(t, rec.Body.Bytes()); code != "not_mid_turn" {
+		t.Errorf("code = %q, want not_mid_turn", code)
+	}
+}
+
+// A live but NOT-mid-turn run (registered, unarmed, no run row) → 409 not_mid_turn.
+func TestHandleCancelTurn_409WhenNotMidTurn(t *testing.T) {
+	srv, cleanup := turnCancelFixture(t)
+	defer cleanup()
+	_, dereg := srv.steerReg.Register(steer.Entry{RunID: "run-1"})
+	defer dereg()
+
+	rec := doJSON(t, srv, "POST", "/v1/runs/run-1/cancel", `{}`)
+	if rec.Code != 409 {
+		t.Fatalf("status = %d, want 409; body=%s", rec.Code, rec.Body.String())
+	}
+	if code := errorCode(t, rec.Body.Bytes()); code != "not_mid_turn" {
+		t.Errorf("code = %q, want not_mid_turn", code)
+	}
+}
+
+// A cancel on a non-existent live run → opaque 404 (no existence oracle).
+func TestHandleCancelTurn_404WhenNoLiveRun(t *testing.T) {
+	srv, cleanup := turnCancelFixture(t)
+	defer cleanup()
+
+	rec := doJSON(t, srv, "POST", "/v1/runs/ghost/cancel", `{}`)
+	if rec.Code != 404 {
+		t.Errorf("status = %d, want 404 (no in-flight run); body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// A turn-cancel on a NON-interactive run → 409 not_interactive (stopping its only
+// turn would terminate it — use whole-run cancel instead).
+func TestHandleCancelTurn_409NonInteractive(t *testing.T) {
+	srv, cleanup := turnCancelFixture(t)
+	defer cleanup()
+	ctx := context.Background()
+	sess, err := srv.store.CreateSession(ctx, "", "agent-x", "alice")
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	// Default RunIdentity → Interactive:false.
+	run, err := srv.store.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "agent-x", UserID: "alice"})
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	_, dereg := srv.steerReg.Register(steer.Entry{RunID: run.ID}) // registered but never armed
+	defer dereg()
+
+	rec := doJSON(t, srv, "POST", "/v1/runs/"+run.ID+"/cancel", `{}`)
+	if rec.Code != 409 {
+		t.Fatalf("status = %d, want 409; body=%s", rec.Code, rec.Body.String())
+	}
+	if code := errorCode(t, rec.Body.Bytes()); code != "not_interactive" {
+		t.Errorf("code = %q, want not_interactive", code)
+	}
+}
+
+// The turn-cancel route requires runs:create (same as steer/resolve/compact), and
+// the whole-run cancel route is unchanged.
+func TestRequiredScopeFor_TurnCancel(t *testing.T) {
+	if got := requiredScopeFor(http.MethodPost, "/v1/runs/run-1/cancel"); got != auth.ScopeRunsCreate {
+		t.Errorf("turn-cancel scope = %q, want %q", got, auth.ScopeRunsCreate)
+	}
+	// Whole-run cancel (a distinct path) still maps to runs:create — unchanged.
+	if got := requiredScopeFor(http.MethodPost, "/v1/agents/ag-1/cancel"); got != auth.ScopeRunsCreate {
+		t.Errorf("whole-run cancel scope = %q, want %q", got, auth.ScopeRunsCreate)
+	}
+}
+
+func errorCode(t *testing.T, body []byte) string {
+	t.Helper()
+	var e struct {
+		Code string `json:"code"`
+	}
+	if err := json.Unmarshal(body, &e); err != nil {
+		t.Fatalf("decode error body %q: %v", body, err)
+	}
+	return e.Code
+}

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -101,6 +101,17 @@ type RunOptions struct {
 	// bound it. Set an explicit MaxIterations to cap an interactive session.
 	Interactive bool
 
+	// ArmTurnCancel, when non-nil, makes THIS run turn-cancellable (RFC BH). At
+	// the start of each turn the loop calls it with the turn's CancelCauseFunc to
+	// register the run's currently-armed per-turn cancel token; the returned
+	// disarm is called at the turn boundary. Firing the token (cause
+	// ErrTurnCancelled, with the RUN ctx still alive) stops the current turn's
+	// model call + tool dispatch and parks the run at awaiting_input instead of
+	// terminating it. nil = not turn-cancellable — the loop behaves EXACTLY as it
+	// did before (the wrapping turn ctx is never fired). Wired for interactive
+	// runs only; the server passes a closure that arms its turncancel.Registry.
+	ArmTurnCancel func(turnCancel context.CancelCauseFunc) (disarm func())
+
 	// PauseGate, when non-nil, cooperatively quiesces this run for the
 	// runtime-wide pause/snapshot protocol (RFC X / F41). At the TOP of each
 	// iteration the loop asks PauseRequested(); if true it calls Park, which
@@ -729,6 +740,80 @@ type RunResult struct {
 	Usage      providers.Usage // sum across iterations
 }
 
+// ErrTurnCancelled is the cancel cause the server fires on a run's armed per-turn
+// token (RFC BH). The loop catches it — the RUN ctx is still alive — and parks
+// the interactive run instead of terminating (a whole-run cancel cause, e.g.
+// cancel.ErrCancelledByAPI, is NOT this and still terminates). Callers wrap it
+// with an operator reason via TurnCancelCause; errors.Is still matches.
+var ErrTurnCancelled = errors.New("turn cancelled by operator")
+
+// turnCancel wraps ErrTurnCancelled with an operator reason. It Unwraps to the
+// sentinel so errors.Is(cause, ErrTurnCancelled) holds; reasonFromCause pulls the
+// reason back out for the EventTurnCancelled payload.
+type turnCancel struct{ reason string }
+
+func (t *turnCancel) Error() string { return ErrTurnCancelled.Error() + ": " + t.reason }
+func (t *turnCancel) Unwrap() error { return ErrTurnCancelled }
+
+// TurnCancelCause builds the cancel cause the server fires on the per-turn token.
+// reason == "" returns the bare sentinel; a non-empty reason is carried through
+// to EventTurnCancelled. It lives here (not in internal/turncancel) so the leaf
+// registry stays free of the loop package — the server imports loop already.
+func TurnCancelCause(reason string) error {
+	if reason == "" {
+		return ErrTurnCancelled
+	}
+	return &turnCancel{reason: reason}
+}
+
+// reasonFromCause returns the operator reason carried by a TurnCancelCause, or ""
+// for the bare sentinel / any other error.
+func reasonFromCause(cause error) string {
+	var t *turnCancel
+	if errors.As(cause, &t) {
+		return t.reason
+	}
+	return ""
+}
+
+// cancelledToolResults synthesizes an error-shaped tool_result for every pending
+// tool_use a turn-cancelled turn started but never dispatched, so the next model
+// call sees a well-formed assistant(tool_use)/user(tool_result) pairing — a
+// dangling tool_use 400s Anthropic (RFC BH §9.1). Shape + IsError match how
+// executePendingTools reports a ctx-cancelled tool, so a cancel mid-generation
+// and a cancel mid-dispatch leave byte-comparable history.
+func cancelledToolResults(pending []providers.ToolUse) []providers.ContentBlock {
+	out := make([]providers.ContentBlock, len(pending))
+	for i, tu := range pending {
+		out[i] = providers.ContentBlock{
+			Type:      "tool_result",
+			ToolUseID: tu.ID,
+			ToolName:  tu.Name,
+			Text:      "cancelled by operator",
+			IsError:   true,
+		}
+	}
+	return out
+}
+
+// finishTurnCancel completes an operator-cancelled turn: it emits the
+// turn_cancelled marker, disarms the turn-cancel token (the run is no longer
+// mid-turn, so a racing cancel 409s), and parks an interactive run at
+// awaiting_input. It returns the updated messages, the refreshed footprint, and
+// resumed=true when the operator's next message arrives (the caller continues the
+// loop) or false to terminate — ctx cancelled during the park, or a
+// non-interactive run (the handler 409s that case, so it is only a safety net:
+// stopping a non-interactive run's only turn would terminate it).
+func finishTurnCancel(ctx context.Context, opts RunOptions, messages []providers.Message, sinceTurn, lastCtxTokens int, reason string, emit func(providers.Event), disarm func()) ([]providers.Message, int, bool) {
+	emit(providers.Event{Type: providers.EventTurnCancelled,
+		TurnCancelled: &providers.TurnCancelledEventInfo{Reason: reason, SinceTurn: sinceTurn}})
+	disarm()
+	if opts.Interactive && opts.SteerQueue != nil {
+		return parkForOperatorTurn(ctx, opts, messages, sinceTurn, lastCtxTokens, emit)
+	}
+	return messages, lastCtxTokens, false
+}
+
 // Run drives the agent loop to completion.
 // parkHeartbeatInterval is how often a parked interactive run pulses
 // OnHeartbeat while idle, so the staleness sweeper doesn't reap it (the
@@ -1311,6 +1396,20 @@ func Run(ctx context.Context, opts RunOptions) (RunResult, error) {
 		}()
 	}
 
+	// RFC BH turn-scoped cancel: turnCancelFn cancels the CURRENT turn's ctx and
+	// disarmTurn removes its armed registry token. Both are re-created per turn
+	// (below, right before the model call) and released here on Run exit — any
+	// path, including a panic unwinding through a caller's recover — so a
+	// turn-cancel can never fire against a finished run. Initialised to no-ops so
+	// the first turn's setup + a non-turn-cancellable run (ArmTurnCancel nil) are
+	// clean.
+	turnCancelFn := context.CancelCauseFunc(func(error) {})
+	disarmTurn := func() {}
+	defer func() {
+		disarmTurn()
+		turnCancelFn(nil)
+	}()
+
 outerLoop:
 	for iter := 0; iter < iterCap; iter++ {
 		// v0.10.0 OTEL: one loomcycle.iteration span per turn. Nested
@@ -1321,6 +1420,15 @@ outerLoop:
 		// so End() is called explicitly at each — Go's `defer` runs
 		// at function-scope only, not loop-iteration-scope.
 		iterCtx, iterSpan := lcotel.RecordIteration(ctx, iter)
+
+		// RFC BH: release the PREVIOUS turn's cancel ctx + registry token at the top
+		// of each iteration — before any early-return path below (pause-gate,
+		// context-transform) — so nothing leaks and a cancel racing the inter-turn
+		// boundary finds no armed token (409). This turn re-arms lower, right before
+		// the model call. No-ops on the first iteration and after a park (already
+		// disarmed there).
+		disarmTurn()
+		turnCancelFn(nil)
 
 		// Stamp the CURRENTLY-resolved provider/model onto the per-iteration
 		// ctx so the Context tool's op=self can report them to the agent
@@ -1421,6 +1529,20 @@ outerLoop:
 			reqSystem, reqMessages = cs, cm
 		}
 
+		// RFC BH: arm the per-turn cancel token covering THIS turn's model call +
+		// tool dispatch (the previous turn was released at the top of the loop).
+		// turnCtx is a child of the RUN ctx, so a whole-run cancel STILL cascades to
+		// the turn; a turn-cancel fires only turnCtx (cause ErrTurnCancelled, run ctx
+		// alive) and is caught below. When ArmTurnCancel is nil the token is never
+		// fired, so turnCtx behaves exactly like iterCtx — the loop stays
+		// byte-identical.
+		var turnCtx context.Context
+		turnCtx, turnCancelFn = context.WithCancelCause(iterCtx)
+		disarmTurn = func() {}
+		if opts.ArmTurnCancel != nil {
+			disarmTurn = opts.ArmTurnCancel(turnCancelFn)
+		}
+
 		req := providers.Request{
 			Model:     opts.Model,
 			System:    reqSystem,
@@ -1445,7 +1567,7 @@ outerLoop:
 			req.Seed = s.Seed
 			req.Stop = s.Stop
 		}
-		ch, err := opts.Provider.Call(iterCtx, req)
+		ch, err := opts.Provider.Call(turnCtx, req)
 		if err != nil {
 			// v0.12.9 same-provider retry: when the operator opted
 			// into MaxSameProviderRetries > 0, retryable errors
@@ -1474,6 +1596,7 @@ outerLoop:
 				case <-ctx.Done():
 					lcotel.SetSpanError(iterSpan, ctx.Err())
 					iterSpan.End()
+					turnCancelFn(nil) // RFC BH: release this turn's cancel ctx before terminating (no leak)
 					return RunResult{Iterations: iter}, ctx.Err()
 				case <-time.After(backoff):
 				}
@@ -1534,6 +1657,7 @@ outerLoop:
 			emit(providers.Event{Type: providers.EventError, Error: err.Error()})
 			lcotel.SetSpanError(iterSpan, err)
 			iterSpan.End()
+			turnCancelFn(nil) // RFC BH: release this turn's cancel ctx before terminating (no leak)
 			return RunResult{Iterations: iter}, err
 		}
 		// Call() succeeded — the connection / driver was healthy
@@ -1604,6 +1728,17 @@ outerLoop:
 				iterReasoning = ev.Reasoning
 				iterReasoningSignature = ev.ReasoningSignature
 			case providers.EventError:
+				// RFC BH: an operator turn-cancel aborted this turn's stream (turnCtx
+				// cancelled, RUN ctx still alive) — not a provider fault. Skip the
+				// retry / fallback / matrix-feedback machinery below (which would
+				// MarkStalled the model + could swap providers), drain the channel so
+				// the sender goroutine doesn't leak, and let the post-stream
+				// turn-cancel handler park the run.
+				if ctx.Err() == nil && errors.Is(context.Cause(turnCtx), ErrTurnCancelled) {
+					for range ch {
+					}
+					break
+				}
 				// v0.8.2 classification: build the RAW error string so
 				// the status-prefix regex sees the bare "<name>
 				// <code>:" shape. The streamErr wrap below would
@@ -1636,6 +1771,7 @@ outerLoop:
 					case <-ctx.Done():
 						lcotel.SetSpanError(iterSpan, ctx.Err())
 						iterSpan.End()
+						turnCancelFn(nil) // RFC BH: release this turn's cancel ctx before terminating (no leak)
 						return RunResult{Iterations: iter}, ctx.Err()
 					case <-time.After(backoff):
 					}
@@ -1678,9 +1814,18 @@ outerLoop:
 				}
 				lcotel.SetSpanErrorMessage(iterSpan, ev.Error)
 				iterSpan.End()
+				turnCancelFn(nil) // RFC BH: release this turn's cancel ctx before terminating (no leak)
 				return RunResult{Iterations: iter}, fmt.Errorf("provider error: %s", ev.Error)
 			}
 		}
+
+		// RFC BH: did the operator cancel THIS turn while the model was generating
+		// (run ctx still alive)? Covers both a driver that surfaced EventError on
+		// the turnCtx-cancel (short-circuited above) and one that just closed the
+		// stream. The run-level cancel is checked FIRST (ctx.Err()==nil): a
+		// whole-run cancel terminates as before, never mistaken for a turn-cancel.
+		turnCancelledMidGen := opts.ArmTurnCancel != nil && ctx.Err() == nil &&
+			errors.Is(context.Cause(turnCtx), ErrTurnCancelled)
 
 		// Prepend any text before tool_use blocks so the assistant turn is well-formed.
 		if iterText != "" {
@@ -1759,6 +1904,31 @@ outerLoop:
 		stopReason = iterStop
 		finalText = iterText
 
+		// RFC BH turn-cancel (mid-generation): the operator stopped this turn while
+		// the model was streaming. Keep the partial assistant output (appended
+		// above; a completed call's usage was billed above too), but leave the
+		// history VALID before parking:
+		//   - drop a content-less assistant turn (cancel before anything streamed) —
+		//     an empty assistant message 400s the next call;
+		//   - synthesize a "cancelled by operator" tool_result for every tool_use the
+		//     model started but we never dispatched — a dangling tool_use 400s too.
+		// Then route into the interactive park (not the terminate/break path).
+		if turnCancelledMidGen {
+			if n := len(messages); n > 0 && messages[n-1].Role == "assistant" && len(messages[n-1].Content) == 0 {
+				messages = messages[:n-1]
+			}
+			if len(pendingTools) > 0 {
+				messages = append(messages, providers.Message{Role: "user", Content: cancelledToolResults(pendingTools)})
+			}
+			var resumed bool
+			messages, lastCtxTokens, resumed = finishTurnCancel(ctx, opts, messages, iter, lastCtxTokens, reasonFromCause(context.Cause(turnCtx)), emit, disarmTurn)
+			iterSpan.End()
+			if !resumed {
+				break
+			}
+			continue outerLoop
+		}
+
 		// Terminal: model is done.
 		if iterStop != "tool_use" || len(pendingTools) == 0 {
 			// Persistent interactive run: park instead of terminating. Wait
@@ -1767,6 +1937,10 @@ outerLoop:
 			// trade-off of an always-on terminal agent (bounded by the
 			// existing per-user / global run caps).
 			if opts.Interactive && opts.SteerQueue != nil {
+				// RFC BH: the turn ended and the run is about to park — no longer
+				// mid-turn, so disarm the turn-cancel token (a cancel while parked
+				// finds nothing armed → the handler 409s it).
+				disarmTurn()
 				var resumedWithInput bool
 				messages, lastCtxTokens, resumedWithInput = parkForOperatorTurn(ctx, opts, messages, iter, lastCtxTokens, emit)
 				iterSpan.End()
@@ -1802,12 +1976,38 @@ outerLoop:
 			// Tenant=="", still fire on all).
 			Tenant: ident.TenantID,
 		}
-		toolResults := executePendingTools(iterCtx, opts.Dispatcher, pendingTools, opts.ToolParallelism, opts.Hooks, hookIdent, emit)
+		toolResults := executePendingTools(turnCtx, opts.Dispatcher, pendingTools, opts.ToolParallelism, opts.Hooks, hookIdent, emit)
 		messages = append(messages, providers.Message{Role: "user", Content: toolResults})
-		// Normal fall-through to next iteration. End the iteration span
-		// here — the for loop's continue will open a fresh one.
+
+		// RFC BH turn-cancel (mid-tool-dispatch): the operator stopped this turn
+		// while its tools ran. executePendingTools returns one result per pending
+		// tool (a ctx-cancelled tool is reported error-shaped), so the
+		// assistant(tool_use)/user(tool_result) pairing above is already VALID — no
+		// synthesis needed. The completed model call was billed above; the
+		// interrupted tools just carry an error result. Park instead of looping into
+		// another model turn. Run-cancel is checked first (ctx.Err()==nil).
+		if opts.ArmTurnCancel != nil && ctx.Err() == nil && errors.Is(context.Cause(turnCtx), ErrTurnCancelled) {
+			var resumed bool
+			messages, lastCtxTokens, resumed = finishTurnCancel(ctx, opts, messages, iter, lastCtxTokens, reasonFromCause(context.Cause(turnCtx)), emit, disarmTurn)
+			iterSpan.End()
+			if !resumed {
+				break
+			}
+			continue outerLoop
+		}
+
+		// Normal fall-through to next iteration. Disarm the turn-cancel token at
+		// this turn boundary so a cancel racing the inter-turn gap finds nothing
+		// armed (409) rather than firing a spent token (RFC BH §9.4); the next turn
+		// re-arms. End the iteration span here — the for loop's continue opens a
+		// fresh one.
+		disarmTurn()
 		iterSpan.End()
 	}
+	// RFC BH: release the last turn's cancel ctx once the loop has exited (break or
+	// MaxIterations exhaustion). The run-exit defer would catch it too, but calling
+	// it here keeps the context lifecycle explicit + go-vet clean.
+	turnCancelFn(nil)
 
 	// If the for loop exited by exhausting MaxIterations while the model was
 	// still mid-tool-use, the stop_reason will be stuck at "tool_use" but no

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -758,6 +758,42 @@ func parkForInput(ctx context.Context, q <-chan steer.Message, heartbeat func())
 	}
 }
 
+// parkForOperatorTurn parks a persistent interactive run at awaiting_input until
+// the operator's next real message. It emits EventAwaitingInput, then blocks on
+// the steer queue, handling a steer.KindCompact control inline (replace history
+// with the summary pair + re-park; compaction is not itself new input) exactly
+// like the terminal park it was extracted from. Returns the updated messages,
+// the refreshed context footprint (changed only when a compaction ran), and
+// whether a real operator turn arrived — false ⇒ ctx cancelled / queue closed ⇒
+// the caller terminates the run.
+func parkForOperatorTurn(ctx context.Context, opts RunOptions, messages []providers.Message, sinceTurn, lastCtxTokens int, emit func(providers.Event)) ([]providers.Message, int, bool) {
+	emit(providers.Event{Type: providers.EventAwaitingInput,
+		AwaitingInput: &providers.AwaitingInputEventInfo{SinceTurn: sinceTurn}})
+	for {
+		m, resumed := parkForInput(ctx, opts.SteerQueue, opts.OnHeartbeat)
+		if !resumed {
+			return messages, lastCtxTokens, false // ctx cancelled (or queue closed) → terminate
+		}
+		if m.Kind == steer.KindCompact {
+			messages = applyCompactSummary(messages, m.Text, m.KeepN, m.KeepFirst, emit)
+			// Refresh the footprint so the next operator turn's op=self reports the
+			// compacted size, not the stale pre-compaction value. Without this a
+			// parked run that compacted kept reporting its old ~full context
+			// (used_tokens / used_pct) until the next real turn's usage landed.
+			lastCtxTokens = estimateMessageTokens(messages)
+			continue // re-park: wait for the operator's actual next turn
+		}
+		messages = append(messages, providers.Message{
+			Role:    "user",
+			Content: []providers.ContentBlock{{Type: "text", Text: m.Text}},
+		})
+		if opts.OnSteer != nil {
+			opts.OnSteer(m)
+		}
+		return messages, lastCtxTokens, true
+	}
+}
+
 // CompactionMessages builds the replacement conversation for a compaction: an
 // optional pinned task (kept verbatim), the summary of the middle span, and the
 // kept recent tail. Shape: [user(<pinned?> + <summary>), assistant(ack)] ++ keptTail.
@@ -1731,39 +1767,8 @@ outerLoop:
 			// trade-off of an always-on terminal agent (bounded by the
 			// existing per-user / global run caps).
 			if opts.Interactive && opts.SteerQueue != nil {
-				emit(providers.Event{Type: providers.EventAwaitingInput,
-					AwaitingInput: &providers.AwaitingInputEventInfo{SinceTurn: iter}})
-				// Park until a real operator turn arrives. A steer.KindCompact
-				// control replaces the in-memory history with the summary pair
-				// and RE-parks (compaction is not itself new input — the
-				// operator's next message is), so the loop never calls the
-				// provider on the bare summary.
-				resumedWithInput := false
-				for {
-					m, resumed := parkForInput(ctx, opts.SteerQueue, opts.OnHeartbeat)
-					if !resumed {
-						break // ctx cancelled (or queue closed) → terminate
-					}
-					if m.Kind == steer.KindCompact {
-						messages = applyCompactSummary(messages, m.Text, m.KeepN, m.KeepFirst, emit)
-						// Refresh the footprint so the next operator turn's op=self
-						// reports the compacted size, not the stale pre-compaction
-						// value. Without this a parked run that compacted kept
-						// reporting its old ~full context (used_tokens / used_pct)
-						// until the next real turn's usage landed.
-						lastCtxTokens = estimateMessageTokens(messages)
-						continue // re-park: wait for the operator's actual next turn
-					}
-					messages = append(messages, providers.Message{
-						Role:    "user",
-						Content: []providers.ContentBlock{{Type: "text", Text: m.Text}},
-					})
-					if opts.OnSteer != nil {
-						opts.OnSteer(m)
-					}
-					resumedWithInput = true
-					break
-				}
+				var resumedWithInput bool
+				messages, lastCtxTokens, resumedWithInput = parkForOperatorTurn(ctx, opts, messages, iter, lastCtxTokens, emit)
 				iterSpan.End()
 				if !resumedWithInput {
 					break

--- a/internal/loop/turncancel_test.go
+++ b/internal/loop/turncancel_test.go
@@ -1,0 +1,443 @@
+package loop
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/steer"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// heldProvider runs a caller-supplied turn0 function on the first Call (so a
+// test can hold the model mid-generation), then emits resumeText + end_turn on
+// every later turn. It records each call's Messages so a test can assert the
+// history the NEXT turn was handed.
+type heldProvider struct {
+	mu         sync.Mutex
+	requests   [][]providers.Message
+	turn       int
+	turn0      func(ctx context.Context, ch chan<- providers.Event)
+	resumeText string
+}
+
+func (p *heldProvider) ID() string                                   { return "scripted" }
+func (p *heldProvider) Probe(context.Context) error                  { return nil }
+func (p *heldProvider) ListModels(context.Context) ([]string, error) { return nil, nil }
+func (p *heldProvider) Capabilities() providers.Capabilities {
+	return providers.Capabilities{Streaming: true}
+}
+
+func (p *heldProvider) Call(ctx context.Context, req providers.Request) (<-chan providers.Event, error) {
+	p.mu.Lock()
+	p.requests = append(p.requests, append([]providers.Message(nil), req.Messages...))
+	turn := p.turn
+	p.turn++
+	p.mu.Unlock()
+
+	ch := make(chan providers.Event)
+	go func() {
+		defer close(ch)
+		if turn == 0 && p.turn0 != nil {
+			p.turn0(ctx, ch)
+			return
+		}
+		ch <- providers.Event{Type: providers.EventText, Text: p.resumeText}
+		ch <- providers.Event{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{}}
+	}()
+	return ch, nil
+}
+
+func (p *heldProvider) reqAt(i int) []providers.Message {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if i >= len(p.requests) {
+		return nil
+	}
+	return p.requests[i]
+}
+
+func (p *heldProvider) callCount() int { p.mu.Lock(); defer p.mu.Unlock(); return len(p.requests) }
+
+// blockingTool blocks in Execute until its ctx is cancelled, then returns an
+// error-shaped result — the shape a ctx-cancelled tool produces under a
+// turn-cancel mid-dispatch. It signals `started` once so the test can fire the
+// cancel only after dispatch is genuinely in-flight.
+type blockingTool struct{ started chan struct{} }
+
+func (blockingTool) Name() string                 { return "Block" }
+func (blockingTool) Description() string          { return "blocks until ctx is cancelled" }
+func (blockingTool) InputSchema() json.RawMessage { return json.RawMessage(`{"type":"object"}`) }
+func (b blockingTool) Execute(ctx context.Context, _ json.RawMessage) (tools.Result, error) {
+	select {
+	case b.started <- struct{}{}:
+	default:
+	}
+	<-ctx.Done()
+	return tools.Result{Text: "tool cancelled: " + ctx.Err().Error(), IsError: true}, nil
+}
+
+// eventSink buffers events off the loop goroutine and lets a test wait for a
+// specific type without blocking the loop.
+type eventSink struct{ ch chan providers.Event }
+
+func newEventSink() *eventSink { return &eventSink{ch: make(chan providers.Event, 512)} }
+func (s *eventSink) emit(ev providers.Event) {
+	select {
+	case s.ch <- ev:
+	default: // never wedge the loop if a test stops draining
+	}
+}
+
+// waitFor drains events until one of type want arrives, returning it. Fails the
+// test on timeout.
+func (s *eventSink) waitFor(t *testing.T, want providers.EventType, timeout time.Duration) providers.Event {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		select {
+		case ev := <-s.ch:
+			if ev.Type == want {
+				return ev
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for event %q", want)
+		}
+	}
+}
+
+// assertNoDanglingToolUse asserts every assistant tool_use block has a matching
+// tool_result in the immediately-following user turn — the invariant a
+// turn-cancel must preserve so the next model call doesn't 400 (RFC BH §9.1).
+func assertNoDanglingToolUse(t *testing.T, msgs []providers.Message) {
+	t.Helper()
+	for i, m := range msgs {
+		if m.Role != "assistant" {
+			continue
+		}
+		var ids []string
+		for _, c := range m.Content {
+			if c.Type == "tool_use" {
+				ids = append(ids, c.ToolUseID)
+			}
+		}
+		if len(ids) == 0 {
+			continue
+		}
+		if i+1 >= len(msgs) || msgs[i+1].Role != "user" {
+			t.Fatalf("assistant tool_use at %d not followed by a user tool_result turn; msgs=%+v", i, msgs)
+		}
+		got := map[string]bool{}
+		for _, c := range msgs[i+1].Content {
+			if c.Type == "tool_result" {
+				got[c.ToolUseID] = true
+			}
+		}
+		for _, id := range ids {
+			if !got[id] {
+				t.Fatalf("tool_use %q has no tool_result in the next turn; msgs=%+v", id, msgs)
+			}
+		}
+	}
+}
+
+func turnCancelOpts(prov providers.Provider, tools []tools.Tool, q chan steer.Message, armCh chan context.CancelCauseFunc, sink *eventSink) RunOptions {
+	return RunOptions{
+		Provider:    prov,
+		Model:       "x",
+		Tools:       tools,
+		Dispatcher:  dispatcherFor(tools),
+		Segments:    steerSegs(),
+		SteerQueue:  q,
+		Interactive: true,
+		OnEvent:     sink.emit,
+		ArmTurnCancel: func(tc context.CancelCauseFunc) func() {
+			armCh <- tc
+			return func() {}
+		},
+	}
+}
+
+func dispatcherFor(ts []tools.Tool) *tools.Dispatcher { return tools.NewDispatcher(ts) }
+
+// A turn-cancel mid-generation parks the run at awaiting_input (it does NOT
+// terminate), keeps the partial assistant output, emits turn_cancelled, and the
+// next operator message continues the run.
+func TestRun_TurnCancel_MidGeneration_ParksAndResumes(t *testing.T) {
+	q := make(chan steer.Message, 4)
+	armCh := make(chan context.CancelCauseFunc, 8)
+	sink := newEventSink()
+	started := make(chan struct{})
+	prov := &heldProvider{
+		resumeText: "resumed",
+		turn0: func(ctx context.Context, ch chan<- providers.Event) {
+			ch <- providers.Event{Type: providers.EventText, Text: "partial answer"}
+			close(started)
+			<-ctx.Done() // hold until the operator turn-cancels this turn
+			ch <- providers.Event{Type: providers.EventError, Error: "context canceled"}
+		},
+	}
+	ts := []tools.Tool{noopTool{}}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() { _, _ = Run(ctx, turnCancelOpts(prov, ts, q, armCh, sink)); close(done) }()
+
+	tc0 := <-armCh // turn 0's armed token
+	<-started      // generation is in-flight
+	tc0(ErrTurnCancelled)
+
+	ev := sink.waitFor(t, providers.EventTurnCancelled, 2*time.Second)
+	if ev.TurnCancelled == nil {
+		t.Fatal("turn_cancelled event carried no payload")
+	}
+	sink.waitFor(t, providers.EventAwaitingInput, 2*time.Second) // parked, not terminated
+
+	select {
+	case <-done:
+		t.Fatal("run terminated on a turn-cancel; it must park")
+	default:
+	}
+
+	// The operator's next message continues the run.
+	q <- steer.Message{Text: "continue"}
+	sink.waitFor(t, providers.EventAwaitingInput, 2*time.Second) // turn 1 ran, parked again
+
+	if prov.callCount() < 2 {
+		t.Fatalf("provider called %d times, want >=2 (resume ran)", prov.callCount())
+	}
+	req1 := prov.reqAt(1)
+	if !hasUserText(req1, "continue") {
+		t.Errorf("resume request missing the operator's continue turn; msgs=%+v", req1)
+	}
+	// Partial assistant output is preserved across the cancel.
+	foundPartial := false
+	for _, m := range req1 {
+		if m.Role == "assistant" {
+			for _, c := range m.Content {
+				if c.Type == "text" && c.Text == "partial answer" {
+					foundPartial = true
+				}
+			}
+		}
+	}
+	if !foundPartial {
+		t.Errorf("partial assistant output not preserved after turn-cancel; msgs=%+v", req1)
+	}
+	assertNoDanglingToolUse(t, req1)
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("run did not terminate after whole-run cancel")
+	}
+}
+
+// A turn-cancel mid-generation with a tool_use already streamed synthesizes a
+// cancelled tool_result so the resumed conversation has no dangling tool_use.
+func TestRun_TurnCancel_MidGeneration_SynthesizesToolResult(t *testing.T) {
+	q := make(chan steer.Message, 4)
+	armCh := make(chan context.CancelCauseFunc, 8)
+	sink := newEventSink()
+	started := make(chan struct{})
+	prov := &heldProvider{
+		resumeText: "resumed",
+		turn0: func(ctx context.Context, ch chan<- providers.Event) {
+			// A tool_use streamed but no EventDone / dispatch before the cancel.
+			ch <- providers.Event{Type: providers.EventToolCall,
+				ToolUse: &providers.ToolUse{ID: "t1", Name: "Noop", Input: json.RawMessage(`{}`)}}
+			close(started)
+			<-ctx.Done()
+			ch <- providers.Event{Type: providers.EventError, Error: "context canceled"}
+		},
+	}
+	ts := []tools.Tool{noopTool{}}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() { _, _ = Run(ctx, turnCancelOpts(prov, ts, q, armCh, sink)); close(done) }()
+
+	tc0 := <-armCh
+	<-started
+	tc0(ErrTurnCancelled)
+	sink.waitFor(t, providers.EventTurnCancelled, 2*time.Second)
+	sink.waitFor(t, providers.EventAwaitingInput, 2*time.Second)
+
+	q <- steer.Message{Text: "continue"}
+	sink.waitFor(t, providers.EventAwaitingInput, 2*time.Second)
+
+	req1 := prov.reqAt(1)
+	assertNoDanglingToolUse(t, req1) // the synthesized tool_result pairs the tool_use
+	// The synthesized result is error-shaped ("cancelled by operator").
+	foundCancelled := false
+	for _, m := range req1 {
+		for _, c := range m.Content {
+			if c.Type == "tool_result" && c.ToolUseID == "t1" && c.IsError {
+				foundCancelled = true
+			}
+		}
+	}
+	if !foundCancelled {
+		t.Errorf("no error-shaped cancelled tool_result for the started tool_use; msgs=%+v", req1)
+	}
+
+	cancel()
+	<-done
+}
+
+// A turn-cancel mid-tool-dispatch parks with a VALID history: executePendingTools
+// returns one result per pending tool (the cancelled one error-shaped), so the
+// next model call has no dangling tool_use.
+func TestRun_TurnCancel_MidToolDispatch_ParksWithValidHistory(t *testing.T) {
+	q := make(chan steer.Message, 4)
+	armCh := make(chan context.CancelCauseFunc, 8)
+	sink := newEventSink()
+	toolStarted := make(chan struct{}, 1)
+	prov := &heldProvider{
+		resumeText: "resumed",
+		turn0: func(_ context.Context, ch chan<- providers.Event) {
+			ch <- providers.Event{Type: providers.EventToolCall,
+				ToolUse: &providers.ToolUse{ID: "t1", Name: "Block", Input: json.RawMessage(`{}`)}}
+			ch <- providers.Event{Type: providers.EventDone, StopReason: "tool_use", Usage: &providers.Usage{InputTokens: 5}}
+		},
+	}
+	ts := []tools.Tool{blockingTool{started: toolStarted}}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() { _, _ = Run(ctx, turnCancelOpts(prov, ts, q, armCh, sink)); close(done) }()
+
+	tc0 := <-armCh
+	<-toolStarted // tool dispatch is in-flight
+	tc0(ErrTurnCancelled)
+	sink.waitFor(t, providers.EventTurnCancelled, 2*time.Second)
+	sink.waitFor(t, providers.EventAwaitingInput, 2*time.Second)
+
+	select {
+	case <-done:
+		t.Fatal("run terminated on a mid-dispatch turn-cancel; it must park")
+	default:
+	}
+
+	q <- steer.Message{Text: "continue"}
+	sink.waitFor(t, providers.EventAwaitingInput, 2*time.Second)
+
+	req1 := prov.reqAt(1)
+	assertNoDanglingToolUse(t, req1)
+	if !hasUserText(req1, "continue") {
+		t.Errorf("resume request missing the operator's continue turn; msgs=%+v", req1)
+	}
+
+	cancel()
+	<-done
+}
+
+// Arming a run but never firing the token leaves behavior byte-identical: the
+// interactive run parks at end_turn and resumes on input exactly as an
+// un-armed run does (the wrapping turn ctx is inert).
+func TestRun_TurnCancel_ArmedButNeverFired_BehavesNormally(t *testing.T) {
+	q := make(chan steer.Message, 4)
+	armCh := make(chan context.CancelCauseFunc, 8)
+	sink := newEventSink()
+	prov := &heldProvider{resumeText: "ok"} // turn0 nil → end_turn immediately
+	ts := []tools.Tool{noopTool{}}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() { _, _ = Run(ctx, turnCancelOpts(prov, ts, q, armCh, sink)); close(done) }()
+
+	sink.waitFor(t, providers.EventAwaitingInput, 2*time.Second) // parked at first end_turn
+	q <- steer.Message{Text: "again"}
+	sink.waitFor(t, providers.EventAwaitingInput, 2*time.Second) // resumed + parked again
+	if prov.callCount() < 2 {
+		t.Fatalf("armed-but-unfired run did not resume normally: calls=%d", prov.callCount())
+	}
+	cancel()
+	<-done
+}
+
+// A WHOLE-RUN cancel during generation still TERMINATES the run — it is not a
+// turn-cancel (its cause is not ErrTurnCancelled) and must never be mistaken for
+// one even when the run is turn-cancellable.
+func TestRun_WholeRunCancel_DuringGeneration_Terminates(t *testing.T) {
+	q := make(chan steer.Message, 4)
+	armCh := make(chan context.CancelCauseFunc, 8)
+	sink := newEventSink()
+	started := make(chan struct{})
+	prov := &heldProvider{
+		turn0: func(ctx context.Context, ch chan<- providers.Event) {
+			ch <- providers.Event{Type: providers.EventText, Text: "partial"}
+			close(started)
+			<-ctx.Done()
+			ch <- providers.Event{Type: providers.EventError, Error: "context canceled"}
+		},
+	}
+	ts := []tools.Tool{noopTool{}}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() { _, _ = Run(ctx, turnCancelOpts(prov, ts, q, armCh, sink)); close(done) }()
+
+	<-armCh
+	<-started
+	cancel() // whole-run cancel, NOT the turn token
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("whole-run cancel did not terminate a turn-cancellable run")
+	}
+	// It must not have parked / emitted a turn_cancelled marker.
+	for {
+		select {
+		case ev := <-sink.ch:
+			if ev.Type == providers.EventTurnCancelled {
+				t.Fatal("whole-run cancel emitted turn_cancelled (mistaken for a turn-cancel)")
+			}
+			if ev.Type == providers.EventAwaitingInput {
+				t.Fatal("whole-run cancel parked the run instead of terminating it")
+			}
+		default:
+			return
+		}
+	}
+}
+
+// A turn-cancel on a NON-interactive run cannot park (stopping its only turn
+// would end it), so the loop's safety net terminates it. The server 409s this
+// case before firing, so this only exercises the loop guard.
+func TestRun_TurnCancel_NonInteractive_Terminates(t *testing.T) {
+	q := make(chan steer.Message, 4)
+	armCh := make(chan context.CancelCauseFunc, 8)
+	sink := newEventSink()
+	started := make(chan struct{})
+	prov := &heldProvider{
+		turn0: func(ctx context.Context, ch chan<- providers.Event) {
+			ch <- providers.Event{Type: providers.EventText, Text: "partial"}
+			close(started)
+			<-ctx.Done()
+			ch <- providers.Event{Type: providers.EventError, Error: "context canceled"}
+		},
+	}
+	ts := []tools.Tool{noopTool{}}
+	opts := turnCancelOpts(prov, ts, q, armCh, sink)
+	opts.Interactive = false // non-interactive, but still armable
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() { _, _ = Run(ctx, opts); close(done) }()
+
+	tc0 := <-armCh
+	<-started
+	tc0(ErrTurnCancelled)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("turn-cancel on a non-interactive run did not terminate (safety net)")
+	}
+}

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -529,6 +529,18 @@ const (
 	// through the server's makeRecordingEmit path (soft-at-admission + in-flight
 	// crossing), so the /run terminal + chat render a budget banner.
 	EventLimit EventType = "limit"
+
+	// EventTurnCancelled is emitted by the loop when an operator cancels the
+	// CURRENT TURN of an interactive run (RFC BH) — the in-flight generation +
+	// the tool calls it started are stopped, but the run is NOT terminated: it
+	// parks at awaiting_input (an EventAwaitingInput follows) with its session +
+	// transcript intact, and the operator's next message continues it. Distinct
+	// from the run-level "cancelled" stop_reason (whole-run cancel, terminal) so a
+	// UI can render "turn stopped, input re-enabled" vs "run ended". The
+	// TurnCancelled field carries the optional operator reason + the turn index.
+	// Server-persisted + forwarded via makeRecordingEmit, and auto-replayed on
+	// re-attach (runEventToFrame's default round-trips it).
+	EventTurnCancelled EventType = "turn_cancelled"
 )
 
 // Event is one streamed datum from a provider call (or, after the loop layer
@@ -582,6 +594,10 @@ type Event struct {
 	// AwaitingInput carries the structured payload on EventAwaitingInput (a
 	// persistent interactive run parked at end_turn). Nil otherwise.
 	AwaitingInput *AwaitingInputEventInfo `json:"awaiting_input,omitempty"`
+
+	// TurnCancelled carries the structured payload on EventTurnCancelled (an
+	// operator turn-cancel, RFC BH). Nil on all other event types.
+	TurnCancelled *TurnCancelledEventInfo `json:"turn_cancelled,omitempty"`
 
 	// SpawnChild carries the structured payload on EventSpawnChildStarted /
 	// EventSpawnChildResult (RFC X Phase 3 spawn ledger). Nil otherwise.
@@ -768,6 +784,17 @@ type UserInputEventInfo struct {
 type AwaitingInputEventInfo struct {
 	// SinceTurn is the iteration index the run parked at. Informational —
 	// lets the UI show "idle after N turns".
+	SinceTurn int `json:"since_turn"`
+}
+
+// TurnCancelledEventInfo is the structured payload on EventTurnCancelled — the
+// operator stopped the current turn of an interactive run (RFC BH). The run then
+// parks at awaiting_input (an EventAwaitingInput follows).
+type TurnCancelledEventInfo struct {
+	// Reason is the operator's optional free-text reason (empty when none was
+	// given). Non-secret; surfaced for the UI's "turn stopped" notice.
+	Reason string `json:"reason,omitempty"`
+	// SinceTurn is the iteration index the turn was cancelled at. Informational.
 	SinceTurn int `json:"since_turn"`
 }
 

--- a/internal/turncancel/registry.go
+++ b/internal/turncancel/registry.go
@@ -1,0 +1,94 @@
+// Package turncancel implements the in-memory per-run "turn-scoped cancel"
+// registry (RFC BH). It mirrors internal/steer's run-keyed shape: an in-memory
+// map (run_id → the currently-armed per-turn cancel func) that vanishes when the
+// process exits; the run's transcript is the durable record.
+//
+// Unlike the whole-run cancel registry (internal/cancel, one func per run for
+// the run's lifetime), a turn-cancel token is armed at the START of each loop
+// iteration (the model call + tool dispatch) and disarmed at the turn boundary.
+// Firing it stops the CURRENT turn — the in-flight generation and the tool calls
+// it started — without terminating the run: the loop catches the sentinel cause,
+// synthesizes valid history, and parks the interactive run at awaiting_input.
+//
+// It deliberately does NOT import internal/loop: the caller passes the cancel
+// cause (loop.ErrTurnCancelled, optionally wrapped with an operator reason) as
+// an opaque error, so this leaf package stays dependency-free. Single-process
+// (P1); cross-replica owner-routing by runs.replica_id is P3 (mirror steer).
+package turncancel
+
+import (
+	"context"
+	"sync"
+)
+
+// Registry maps a live run_id → its currently-armed per-turn CancelCauseFunc.
+// At most one token is armed per run at a time (the loop overwrites it on each
+// turn via Arm and clears it via the returned disarm). Safe for concurrent use
+// by the run goroutines (Arm/disarm) and the HTTP handler goroutines (Cancel/
+// IsArmed).
+type Registry struct {
+	mu    sync.Mutex
+	armed map[string]entry
+	// seq is a monotonic generation counter. Each Arm stamps the entry with a
+	// fresh gen so a stale disarm (from a turn that has since been re-armed) can
+	// be told apart from the live token and made a no-op — a missed disarm can
+	// therefore never delete a newer turn's token.
+	seq uint64
+}
+
+type entry struct {
+	cancel context.CancelCauseFunc
+	gen    uint64
+}
+
+// NewRegistry returns an empty registry.
+func NewRegistry() *Registry {
+	return &Registry{armed: make(map[string]entry)}
+}
+
+// Arm registers cancel as run_id's live per-turn token and returns a disarm that
+// removes it. Re-arming (the next turn) overwrites the prior token; the prior
+// turn's disarm then finds a generation mismatch and no-ops, so a caller that
+// forgets to disarm an old turn can never clobber the newer turn's token.
+func (r *Registry) Arm(runID string, cancel context.CancelCauseFunc) func() {
+	r.mu.Lock()
+	r.seq++
+	gen := r.seq
+	r.armed[runID] = entry{cancel: cancel, gen: gen}
+	r.mu.Unlock()
+	return func() {
+		r.mu.Lock()
+		if e, ok := r.armed[runID]; ok && e.gen == gen {
+			delete(r.armed, runID)
+		}
+		r.mu.Unlock()
+	}
+}
+
+// Cancel fires run_id's armed token with cause and removes it, returning whether
+// a token was armed. Removing on fire makes a double-cancel idempotent: the
+// second call finds nothing armed and returns false (the handler 409s it), so a
+// cancel that races the turn ending / a repeat click can never double-fire.
+func (r *Registry) Cancel(runID string, cause error) bool {
+	r.mu.Lock()
+	e, ok := r.armed[runID]
+	if ok {
+		delete(r.armed, runID)
+	}
+	r.mu.Unlock()
+	if !ok {
+		return false
+	}
+	e.cancel(cause)
+	return true
+}
+
+// IsArmed reports whether run_id currently has an armed per-turn token — i.e. the
+// run is mid-turn and turn-cancellable. False once the turn ends (disarmed), the
+// token has been fired (Cancel removes it), or the run terminates.
+func (r *Registry) IsArmed(runID string) bool {
+	r.mu.Lock()
+	_, ok := r.armed[runID]
+	r.mu.Unlock()
+	return ok
+}

--- a/internal/turncancel/registry_test.go
+++ b/internal/turncancel/registry_test.go
@@ -1,0 +1,131 @@
+package turncancel
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+var errTest = errors.New("turn cancelled by operator")
+
+// TestRegistry_CancelFiresArmedTokenWithCause verifies Arm→Cancel delivers the
+// cause to the armed context and reports that a token was armed.
+func TestRegistry_CancelFiresArmedTokenWithCause(t *testing.T) {
+	r := NewRegistry()
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	r.Arm("run-1", cancel)
+
+	if !r.IsArmed("run-1") {
+		t.Fatal("IsArmed false right after Arm")
+	}
+	if got := r.Cancel("run-1", errTest); !got {
+		t.Fatal("Cancel returned false for an armed run")
+	}
+	if err := ctx.Err(); err == nil {
+		t.Fatal("armed context not cancelled after Cancel")
+	}
+	if cause := context.Cause(ctx); !errors.Is(cause, errTest) {
+		t.Fatalf("cause = %v, want %v", cause, errTest)
+	}
+}
+
+// TestRegistry_CancelUnarmedReturnsFalse verifies a Cancel with no armed token
+// (never armed / already fired / already disarmed) reports false so the handler
+// can 409 it.
+func TestRegistry_CancelUnarmedReturnsFalse(t *testing.T) {
+	r := NewRegistry()
+	if r.Cancel("missing", errTest) {
+		t.Fatal("Cancel returned true for an unarmed run")
+	}
+}
+
+// TestRegistry_CancelIsIdempotent verifies a second Cancel after the token fired
+// finds nothing armed — a repeated stop click / a cancel racing the turn end is
+// a no-op, not a double-fire.
+func TestRegistry_CancelIsIdempotent(t *testing.T) {
+	r := NewRegistry()
+	_, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	r.Arm("run-1", cancel)
+
+	if !r.Cancel("run-1", errTest) {
+		t.Fatal("first Cancel returned false")
+	}
+	if r.IsArmed("run-1") {
+		t.Fatal("token still armed after Cancel")
+	}
+	if r.Cancel("run-1", errTest) {
+		t.Fatal("second Cancel returned true (not idempotent)")
+	}
+}
+
+// TestRegistry_DisarmClearsArmedState verifies the disarm returned by Arm removes
+// the token so a subsequent Cancel is a no-op (the loop disarms before parking).
+func TestRegistry_DisarmClearsArmedState(t *testing.T) {
+	r := NewRegistry()
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	disarm := r.Arm("run-1", cancel)
+
+	disarm()
+	if r.IsArmed("run-1") {
+		t.Fatal("IsArmed true after disarm")
+	}
+	if r.Cancel("run-1", errTest) {
+		t.Fatal("Cancel fired after disarm")
+	}
+	if ctx.Err() != nil {
+		t.Fatal("context cancelled despite disarm (no Cancel)")
+	}
+}
+
+// TestRegistry_StaleDisarmDoesNotClobberReArmedToken verifies the core
+// generation invariant: after a turn re-arms, the PREVIOUS turn's disarm must not
+// delete the new turn's live token (a missed disarm can't disable the run).
+func TestRegistry_StaleDisarmDoesNotClobberReArmedToken(t *testing.T) {
+	r := NewRegistry()
+	_, cancel1 := context.WithCancelCause(context.Background())
+	defer cancel1(nil)
+	disarm1 := r.Arm("run-1", cancel1)
+
+	// Next turn re-arms without the caller having disarmed turn 1 (overwrite).
+	ctx2, cancel2 := context.WithCancelCause(context.Background())
+	defer cancel2(nil)
+	r.Arm("run-1", cancel2)
+
+	// The stale disarm from turn 1 must be a no-op.
+	disarm1()
+	if !r.IsArmed("run-1") {
+		t.Fatal("stale disarm cleared the re-armed token")
+	}
+	if !r.Cancel("run-1", errTest) {
+		t.Fatal("Cancel found no armed token after re-arm")
+	}
+	if context.Cause(ctx2) == nil || !errors.Is(context.Cause(ctx2), errTest) {
+		t.Fatalf("re-armed token (turn 2) not the one fired: cause=%v", context.Cause(ctx2))
+	}
+}
+
+// TestRegistry_RunsAreIndependent verifies tokens are keyed by run_id — cancelling
+// one run does not disturb another.
+func TestRegistry_RunsAreIndependent(t *testing.T) {
+	r := NewRegistry()
+	ctxA, cancelA := context.WithCancelCause(context.Background())
+	defer cancelA(nil)
+	ctxB, cancelB := context.WithCancelCause(context.Background())
+	defer cancelB(nil)
+	r.Arm("run-a", cancelA)
+	r.Arm("run-b", cancelB)
+
+	r.Cancel("run-a", errTest)
+	if ctxA.Err() == nil {
+		t.Fatal("run-a not cancelled")
+	}
+	if ctxB.Err() != nil {
+		t.Fatal("run-b cancelled by a run-a cancel")
+	}
+	if !r.IsArmed("run-b") {
+		t.Fatal("run-b disarmed by a run-a cancel")
+	}
+}


### PR DESCRIPTION
## Why

loomboard (RFC BH) needs a non-destructive "stop" for interactive sessions — the Claude-Code **Esc**: interrupt what the agent is doing *right now* (in-flight generation + its tool calls) and keep the conversation, rather than the only stop today (whole-run cancel) which throws away the session. This is **P1** of RFC BH (`/loomcycle/rfcs/turn-scoped-cancellation`, §9 decisions): the turn-cancel core, single-replica, HTTP. P2 (interruption decline) and P3 (cross-replica + adapters) are deferred.

## What

`POST /v1/runs/{run_id}/cancel {reason?}` → `{run_id, stopped, parked}` stops the **current turn** of an **interactive** run and parks it at `awaiting_input`; the session, transcript, and context survive, and the next operator message continues normally.

- **`internal/loop`** — each turn's model call + tool dispatch now run under a per-turn child ctx (`turnCtx = WithCancelCause(iterCtx)`, a child of the run ctx so a whole-run cancel still cascades). `RunOptions.ArmTurnCancel` (nil ⇒ un-armable ⇒ **byte-identical** to today) hands the loop each turn's cancel func to register. On a turn-cancel the loop keeps the partial assistant output, synthesizes `cancelled by operator` tool_results for any dangling `tool_use` (so the next model call is well-formed), emits `turn_cancelled`, and routes into the **existing** interactive `awaiting_input` park (extracted as `parkForOperatorTurn`).
- **Run-cancel vs turn-cancel is double-guarded and airtight:** a turn-cancel is caught only when `ctx.Err() == nil` (run ctx alive) **and** `errors.Is(context.Cause(turnCtx), ErrTurnCancelled)`. A whole-run cancel sets `ctx.Err() != nil` and propagates its own `cancel.ErrCancelledByAPI` cause down to the child — *both* guards fail — so it can never be mistaken and still **terminates** exactly as before.
- **`internal/turncancel`** (new leaf pkg) — a run-scoped registry of the armed per-turn cancel token (mirrors `internal/steer`), armed at each turn start / disarmed at the boundary, with a generation counter so a stale disarm can't clobber a re-armed token, and remove-on-fire for idempotency.
- **`internal/providers`** — `EventTurnCancelled` SSE frame (distinct from run-level `cancelled`; auto-persisted + auto-replayed on re-attach).
- **handler** — `handleCancelTurn` mirrors `SteerRun`'s tenant/ownership gate (cross-tenant/unknown → opaque 404); 409 `not_mid_turn` / `not_interactive` when not turn-cancellable; idempotent. New `/cancel` suffix → `runs:create` scope (else it default-denied as `ScopeAdmin`). Wired for interactive runs at both `/v1/runs` and `/v1/sessions/{id}/messages`. Whole-run cancel untouched.

## Semantics (RFC §9)
Partial output kept + valid history (synthesized cancelled tool_results); a cancelled mid-generation call emits no usage → not billed (matches cancelled-run behavior); idempotent no-op → 409 when not mid-turn; interactive runs only.

## What was tested
- `go test ./...` — clean (85 packages), independently re-run. `go build ./...`, gofmt, and **`go vet`** (lostcancel is vet-only — the per-turn ctx lifecycle is release-at-top + explicit release before every return + defer backstop) all clean.
- Regression tests, each **fail-before verified**: turn-cancel mid-generation parks (run stays `running`, session/transcript intact) + next steer continues; mid-tool-dispatch synthesizes valid tool_results (no dangling tool_use); non-interactive → 409; not-mid-turn → 409; `turn_cancelled` emitted; whole-run cancel still terminates; byte-identical when the endpoint is never called; `internal/turncancel` registry unit tests.
- Manual smoke (built binary, mock provider): interactive run parks → turn-cancel on the parked run 409s `not_mid_turn` (proves arm→disarm-before-park end-to-end) → steer resumes it (session survives); ghost run → opaque 404; whole-run cancel intact.

5 commits: turncancel registry → `EventTurnCancelled` → extract `parkForOperatorTurn` → loop turn-cancel core → handler.

**Deferred (RFC BH):** P2 interruption-decline; P3 cross-replica owner-routing + TS/gRPC/Python adapters (`cancelTurn`/`cancelInterrupt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)