### PR TITLE
feat(api): RFC BH P2 — decline a pending interruption

### DIFF
--- a/internal/api/http/interruption_decline_test.go
+++ b/internal/api/http/interruption_decline_test.go
@@ -1,0 +1,162 @@
+package http
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/channels"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// These regression tests pin RFC BH P2 — the "declined" disposition on the
+// resolve endpoint. A decline resolves a pending question WITHOUT an answer
+// (skips option validation) and writes the new terminal `declined` status so
+// the waiting Question tool proceeds. They fail on the pre-P2 handler (which
+// had no disposition field: a decline body fell through to the answer path and
+// 422'd on the missing/invalid answer, and InterruptFinish rejected the status).
+
+// seedPendingInterruptWithOptions creates a pending question with declared
+// options in the given tenant and returns run_id + interrupt_id.
+func seedPendingInterruptWithOptions(t *testing.T, st store.Store, tenant, user, agent string) (runID, interruptID string) {
+	t.Helper()
+	runID = seedRunInTenant(t, st, tenant, user, agent)
+	id := store.MintInterruptID(time.Now())
+	if _, err := st.InterruptCreate(context.Background(), store.InterruptRow{
+		InterruptID: id, RunID: runID, UserID: user,
+		Question: "Proceed?", Options: []byte(`["Yes","No"]`), CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("InterruptCreate: %v", err)
+	}
+	return runID, id
+}
+
+// resolveReq drives handleResolveInterrupt with the given JSON body as an
+// own-tenant (acme/alice) caller and returns the recorder.
+func resolveReq(t *testing.T, s *Server, runID, interruptID, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodPost,
+		"/v1/runs/"+runID+"/interrupts/"+interruptID+"/resolve",
+		strings.NewReader(body))
+	r.SetPathValue("run_id", runID)
+	r.SetPathValue("interrupt_id", interruptID)
+	r.Header.Set("Content-Type", "application/json")
+	r = r.WithContext(tenantPrincipalCtx("acme", "alice", auth.ScopeRunsCreate))
+	rr := httptest.NewRecorder()
+	s.handleResolveInterrupt(rr, r)
+	return rr
+}
+
+func TestHandleResolveInterrupt_DeclineSkipsOptionValidationAndWakes(t *testing.T) {
+	s, st := tokenAuthServer(t, "")
+	s.interruptionBus = channels.NewBus()
+	runID, id := seedPendingInterruptWithOptions(t, st, "acme", "alice", "a_acme_dec")
+
+	// A waiter registered before the resolve proves the handler fires the
+	// same wake for a decline as it does for an answer.
+	waker := s.interruptionBus.Register("intr:" + id)
+
+	// Decline with NO answer, against an interrupt that DECLARES options —
+	// option validation is skipped entirely for a decline.
+	rr := resolveReq(t, s, runID, id, `{"disposition":"declined"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("decline status=%d body=%q, want 200", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), `"status":"declined"`) {
+		t.Errorf("response = %q, want status=declined", rr.Body.String())
+	}
+
+	row, _ := st.InterruptGet(context.Background(), id)
+	if row.Status != store.InterruptStatusDeclined {
+		t.Errorf("stored status = %q, want declined", row.Status)
+	}
+	if row.Answer != "" {
+		t.Errorf("stored answer = %q, want empty on decline", row.Answer)
+	}
+	if row.ResolvedBy != store.InterruptResolvedByAPI {
+		t.Errorf("resolved_by = %q, want api (bearer caller)", row.ResolvedBy)
+	}
+
+	select {
+	case <-waker:
+	case <-time.After(time.Second):
+		t.Error("decline did not fire the interruptionBus wake")
+	}
+}
+
+func TestHandleResolveInterrupt_DeclineOnAlreadyTerminalConflicts(t *testing.T) {
+	s, st := tokenAuthServer(t, "")
+	runID, id := seedPendingInterruptWithOptions(t, st, "acme", "alice", "a_acme_dec2")
+	// Already resolved → a subsequent decline must 409, not silently succeed.
+	if err := st.InterruptResolve(context.Background(), id, "Yes", store.InterruptResolvedByWebUI, nil); err != nil {
+		t.Fatalf("InterruptResolve: %v", err)
+	}
+
+	rr := resolveReq(t, s, runID, id, `{"disposition":"declined"}`)
+	if rr.Code != http.StatusConflict {
+		t.Errorf("decline of terminal interrupt status=%d, want 409", rr.Code)
+	}
+}
+
+func TestHandleResolveInterrupt_UnknownDispositionRejected(t *testing.T) {
+	s, st := tokenAuthServer(t, "")
+	// Free-text interrupt (no options) + a valid non-empty answer: the ONLY
+	// thing that can 422 here is the unknown-disposition gate, so this fails
+	// on the pre-P2 handler (which ignored disposition and would resolve).
+	runID := seedRunInTenant(t, st, "acme", "alice", "a_acme_dec3")
+	id := store.MintInterruptID(time.Now())
+	if _, err := st.InterruptCreate(context.Background(), store.InterruptRow{
+		InterruptID: id, RunID: runID, UserID: "alice", Question: "free?", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("InterruptCreate: %v", err)
+	}
+
+	rr := resolveReq(t, s, runID, id, `{"disposition":"skip","answer":"whatever"}`)
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Errorf("unknown disposition status=%d, want 422", rr.Code)
+	}
+	if row, _ := st.InterruptGet(context.Background(), id); row.Status != store.InterruptStatusPending {
+		t.Errorf("interrupt status changed to %q on rejected disposition", row.Status)
+	}
+}
+
+func TestHandleResolveInterrupt_DeclineWithAnswerRejected(t *testing.T) {
+	s, st := tokenAuthServer(t, "")
+	runID, id := seedPendingInterruptWithOptions(t, st, "acme", "alice", "a_acme_dec4")
+
+	// A decline carries no answer; an answer alongside it is contradictory.
+	rr := resolveReq(t, s, runID, id, `{"disposition":"declined","answer":"Yes"}`)
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Errorf("decline+answer status=%d, want 422", rr.Code)
+	}
+	if row, _ := st.InterruptGet(context.Background(), id); row.Status != store.InterruptStatusPending {
+		t.Errorf("interrupt status changed to %q on rejected decline+answer", row.Status)
+	}
+}
+
+// TestHandleResolveInterrupt_AnswerPathUnchanged is the byte-identical
+// regression guard: with no disposition (or "answer"), the existing answer
+// path is unchanged — a valid option answers (200, status=resolved) and an
+// out-of-options answer still 422s (option validation stays active).
+func TestHandleResolveInterrupt_AnswerPathUnchanged(t *testing.T) {
+	s, st := tokenAuthServer(t, "")
+
+	runID, id := seedPendingInterruptWithOptions(t, st, "acme", "alice", "a_acme_ans1")
+	if rr := resolveReq(t, s, runID, id, `{"answer":"Yes"}`); rr.Code != http.StatusOK ||
+		!strings.Contains(rr.Body.String(), `"status":"resolved"`) {
+		t.Errorf("valid answer status=%d body=%q, want 200 status=resolved", rr.Code, rr.Body.String())
+	}
+	if row, _ := st.InterruptGet(context.Background(), id); row.Status != store.InterruptStatusResolved || row.Answer != "Yes" {
+		t.Errorf("answered row = {%q,%q}, want {resolved,Yes}", row.Status, row.Answer)
+	}
+
+	// Out-of-options answer on the answer path still 422s (validation active).
+	runID2, id2 := seedPendingInterruptWithOptions(t, st, "acme", "alice", "a_acme_ans2")
+	if rr := resolveReq(t, s, runID2, id2, `{"answer":"Maybe"}`); rr.Code != http.StatusUnprocessableEntity {
+		t.Errorf("out-of-options answer status=%d, want 422", rr.Code)
+	}
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -5998,11 +5998,24 @@ func (s *Server) handleListUserAgents(w http.ResponseWriter, r *http.Request) {
 // resolveInterruptRequest is the JSON body for the resolve endpoint.
 // kind-discriminated: v0.8.16 supports only kind="question"; future
 // kinds (pause/wait_until/approval) parse different fields.
+//
+// Disposition (RFC BH P2) is optional: "" / "answer" take the existing
+// answer path (Answer validated against declared options); "declined"
+// resolves the interrupt WITHOUT an answer (skips option validation) so
+// the agent PROCEEDS rather than being answered.
 type resolveInterruptRequest struct {
-	Kind       string `json:"kind"`
-	Answer     string `json:"answer"`
-	ResolvedBy string `json:"resolved_by,omitempty"`
+	Kind        string `json:"kind"`
+	Answer      string `json:"answer"`
+	ResolvedBy  string `json:"resolved_by,omitempty"`
+	Disposition string `json:"disposition,omitempty"`
 }
+
+// Resolve dispositions (RFC BH P2). The "declined" disposition maps to
+// the store.InterruptStatusDeclined terminal status.
+const (
+	dispositionAnswer   = "answer"
+	dispositionDeclined = "declined"
+)
 
 // handleResolveInterrupt accepts a human's answer to a pending
 // interruption + wakes the blocked tool. The path captures
@@ -6047,6 +6060,23 @@ func (s *Server) handleResolveInterrupt(w http.ResponseWriter, r *http.Request) 
 		} else {
 			req.ResolvedBy = store.InterruptResolvedByAPI
 		}
+	}
+
+	// Disposition gate (RFC BH P2). Only "" / "answer" / "declined" are
+	// valid; an unknown value is a client error, not a silent answer.
+	switch req.Disposition {
+	case "", dispositionAnswer, dispositionDeclined:
+		// ok
+	default:
+		http.Error(w, fmt.Sprintf("unsupported disposition %q (valid: answer, declined)", req.Disposition), http.StatusUnprocessableEntity)
+		return
+	}
+	declined := req.Disposition == dispositionDeclined
+	if declined && req.Answer != "" {
+		// A decline carries no answer — an answer alongside it is
+		// contradictory. Reject rather than silently dropping it.
+		http.Error(w, "declined disposition must not carry an answer", http.StatusUnprocessableEntity)
+		return
 	}
 
 	// Validate the answer against the stored row's options + expiry.
@@ -6094,35 +6124,53 @@ func (s *Server) handleResolveInterrupt(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Option-list validation: when the original ask declared
-	// options, the answer must be one of them. Free-text answers
-	// (no options) accept any non-empty string.
-	if len(row.Options) > 0 {
-		var opts []string
-		if err := json.Unmarshal(row.Options, &opts); err == nil && len(opts) > 0 {
-			ok := false
-			for _, o := range opts {
-				if o == req.Answer {
-					ok = true
-					break
+	// A decline (RFC BH P2) carries no answer, so it SKIPS option-list
+	// validation entirely — the operator is declining to answer, not
+	// submitting one. The answer path is unchanged.
+	if !declined {
+		// Option-list validation: when the original ask declared
+		// options, the answer must be one of them. Free-text answers
+		// (no options) accept any non-empty string.
+		if len(row.Options) > 0 {
+			var opts []string
+			if err := json.Unmarshal(row.Options, &opts); err == nil && len(opts) > 0 {
+				ok := false
+				for _, o := range opts {
+					if o == req.Answer {
+						ok = true
+						break
+					}
+				}
+				if !ok {
+					http.Error(w, fmt.Sprintf("answer %q is not one of the declared options: %v", req.Answer, opts), http.StatusUnprocessableEntity)
+					return
 				}
 			}
-			if !ok {
-				http.Error(w, fmt.Sprintf("answer %q is not one of the declared options: %v", req.Answer, opts), http.StatusUnprocessableEntity)
-				return
-			}
+		} else if req.Answer == "" {
+			http.Error(w, "answer is required for free-text interrupts", http.StatusUnprocessableEntity)
+			return
 		}
-	} else if req.Answer == "" {
-		http.Error(w, "answer is required for free-text interrupts", http.StatusUnprocessableEntity)
-		return
 	}
 
-	if err := s.store.InterruptResolve(r.Context(), interruptID, req.Answer, req.ResolvedBy, nil); err != nil {
-		if errors.Is(err, store.ErrInterruptAlreadyTerminal) {
+	// Persist the terminal state. A decline uses InterruptFinish (the
+	// answer-less terminal writer) → status=declined; an answer uses
+	// InterruptResolve → status=resolved. Both reject an already-terminal
+	// row with ErrInterruptAlreadyTerminal → 409. finalStatus drives the
+	// wake publish + response so the answer path stays byte-identical.
+	finalStatus := store.InterruptStatusResolved
+	var persistErr error
+	if declined {
+		finalStatus = store.InterruptStatusDeclined
+		persistErr = s.store.InterruptFinish(r.Context(), interruptID, store.InterruptStatusDeclined, req.ResolvedBy)
+	} else {
+		persistErr = s.store.InterruptResolve(r.Context(), interruptID, req.Answer, req.ResolvedBy, nil)
+	}
+	if persistErr != nil {
+		if errors.Is(persistErr, store.ErrInterruptAlreadyTerminal) {
 			http.Error(w, "interrupt already resolved, timed out, or cancelled", http.StatusConflict)
 			return
 		}
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, persistErr.Error(), http.StatusInternalServerError)
 		return
 	}
 
@@ -6142,7 +6190,7 @@ func (s *Server) handleResolveInterrupt(w http.ResponseWriter, r *http.Request) 
 			"interrupt_id": interruptID,
 			"run_id":       runID,
 			"kind":         row.Kind,
-			"status":       store.InterruptStatusResolved,
+			"status":       finalStatus,
 			"answer":       req.Answer,
 			"resolved_by":  req.ResolvedBy,
 		})
@@ -6156,7 +6204,7 @@ func (s *Server) handleResolveInterrupt(w http.ResponseWriter, r *http.Request) 
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"interrupt_id": interruptID,
-		"status":       store.InterruptStatusResolved,
+		"status":       finalStatus,
 		"resolved_at":  time.Now().UTC().Format(time.RFC3339Nano),
 	})
 }

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -3115,7 +3115,7 @@ func (s *Store) InterruptResolve(ctx context.Context, interruptID, answer, resol
 
 func (s *Store) InterruptFinish(ctx context.Context, interruptID, status, resolvedBy string) error {
 	switch status {
-	case store.InterruptStatusTimedOut, store.InterruptStatusCancelled:
+	case store.InterruptStatusTimedOut, store.InterruptStatusCancelled, store.InterruptStatusDeclined:
 		// ok
 	default:
 		return fmt.Errorf("interrupts: finish: invalid terminal status %q", status)

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -8073,7 +8073,7 @@ func (s *Store) InterruptResolve(ctx context.Context, interruptID, answer, resol
 
 func (s *Store) InterruptFinish(ctx context.Context, interruptID, status, resolvedBy string) error {
 	switch status {
-	case store.InterruptStatusTimedOut, store.InterruptStatusCancelled:
+	case store.InterruptStatusTimedOut, store.InterruptStatusCancelled, store.InterruptStatusDeclined:
 		// ok
 	default:
 		return fmt.Errorf("interrupts: finish: invalid terminal status %q", status)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2216,8 +2216,8 @@ type Store interface {
 
 	// InterruptFinish transitions a pending interrupt to a terminal
 	// status WITHOUT an answer (used for timeout sweeper + agent-side
-	// cancel). status must be one of: "timed_out" / "cancelled".
-	// resolvedBy is recorded for audit. Returns
+	// cancel + operator decline). status must be one of: "timed_out" /
+	// "cancelled" / "declined". resolvedBy is recorded for audit. Returns
 	// ErrInterruptAlreadyTerminal on a non-pending row.
 	InterruptFinish(ctx context.Context, interruptID, status, resolvedBy string) error
 
@@ -3481,6 +3481,12 @@ const (
 	InterruptStatusResolved  = "resolved"
 	InterruptStatusTimedOut  = "timed_out"
 	InterruptStatusCancelled = "cancelled"
+	// InterruptStatusDeclined is terminal like cancelled, but semantically
+	// distinct (RFC BH P2): the operator declined to answer a pending
+	// question so the agent should PROCEED without input — not an error.
+	// The waiting Question tool maps it to a NON-error tool_result, whereas
+	// cancelled (run-cancel / timeout) maps to an error result.
+	InterruptStatusDeclined = "declined"
 
 	InterruptPriorityLow    = "low"
 	InterruptPriorityNormal = "normal"

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -340,6 +340,7 @@ func Run(t *testing.T, factory Factory) {
 		{"InterruptResolveRejectsAlreadyTerminal", testInterruptResolveRejectsAlreadyTerminal},
 		{"InterruptResolveRoundTripsAnswerMeta", testInterruptResolveRoundTripsAnswerMeta},
 		{"InterruptFinishSetsTimedOut", testInterruptFinishSetsTimedOut},
+		{"InterruptFinishSetsDeclined", testInterruptFinishSetsDeclined},
 		{"InterruptFinishRejectsAlreadyTerminal", testInterruptFinishRejectsAlreadyTerminal},
 		{"InterruptListByRunFiltersByStatus", testInterruptListByRunFiltersByStatus},
 		{"InterruptListByUserFiltersByStatus", testInterruptListByUserFiltersByStatus},
@@ -8000,6 +8001,33 @@ func testInterruptFinishSetsTimedOut(t *testing.T, s store.Store) {
 	}
 	if r.Answer != "" {
 		t.Errorf("Answer = %q on timeout path; want empty", r.Answer)
+	}
+}
+
+// testInterruptFinishSetsDeclined pins RFC BH P2: InterruptFinish accepts the
+// new "declined" terminal status (it was previously whitelist-rejected as an
+// invalid terminal status) and records it answer-less with the resolver source.
+func testInterruptFinishSetsDeclined(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_, runID := makeRunForInterrupt(t, s, "u_alice", "a_intr_dec", "batch")
+
+	id := store.MintInterruptID(time.Now())
+	_, _ = s.InterruptCreate(ctx, store.InterruptRow{
+		InterruptID: id, RunID: runID, UserID: "u_alice",
+		Question: "Q?", CreatedAt: time.Now(),
+	})
+	if err := s.InterruptFinish(ctx, id, store.InterruptStatusDeclined, store.InterruptResolvedByWebUI); err != nil {
+		t.Fatalf("InterruptFinish(declined): %v", err)
+	}
+	r, _ := s.InterruptGet(ctx, id)
+	if r.Status != store.InterruptStatusDeclined {
+		t.Errorf("Status = %q, want declined", r.Status)
+	}
+	if r.Answer != "" {
+		t.Errorf("Answer = %q on decline path; want empty", r.Answer)
+	}
+	if r.ResolvedBy != store.InterruptResolvedByWebUI {
+		t.Errorf("ResolvedBy = %q, want webui", r.ResolvedBy)
 	}
 }
 

--- a/internal/tools/builtin/interruption.go
+++ b/internal/tools/builtin/interruption.go
@@ -702,6 +702,19 @@ func (it *Interruption) toolResultForStatus(row store.InterruptRow) tools.Result
 			"resolved_by":  row.ResolvedBy,
 		})
 		return tools.Result{Text: string(out)}
+	case store.InterruptStatusDeclined:
+		// RFC BH P2: the operator declined to answer. This is deliberately
+		// a NON-error result (no IsError) — an error could make the agent
+		// retry the question or abort, but the operator's intent is for the
+		// agent to PROCEED without this input. Distinct from the cancelled
+		// branch below, which stays IsError (run-cancel / timeout).
+		out, _ := json.Marshal(map[string]any{
+			"declined":     true,
+			"note":         "The operator declined to answer; proceed without this input.",
+			"interrupt_id": row.InterruptID,
+			"resolved_by":  row.ResolvedBy,
+		})
+		return tools.Result{Text: string(out)}
 	case store.InterruptStatusTimedOut:
 		return tools.Result{
 			IsError: true,

--- a/internal/tools/builtin/interruption_test.go
+++ b/internal/tools/builtin/interruption_test.go
@@ -127,6 +127,68 @@ func TestInterruption_AskBlockUntilResolve(t *testing.T) {
 	}
 }
 
+// TestInterruption_DeclineReturnsNonErrorResult pins RFC BH P2: when the
+// operator declines a pending question (InterruptFinish → declined + wake),
+// the blocked ask returns a NON-error tool_result telling the agent to
+// proceed — distinct from the error-shaped cancelled/timeout results, so the
+// loop continues rather than retrying or aborting. The interrupt declares
+// options to prove a decline needs no valid answer.
+func TestInterruption_DeclineReturnsNonErrorResult(t *testing.T) {
+	tool, ctx, _, cleanup := interruptionFixture(t)
+	defer cleanup()
+
+	resCh := make(chan tools.Result, 1)
+	go func() {
+		res, err := tool.Execute(ctx, json.RawMessage(`{
+			"op":"ask",
+			"question":"Proceed with delete?",
+			"options":["Yes","No"],
+			"timeout_ms":5000
+		}`))
+		if err != nil {
+			t.Errorf("Execute: %v", err)
+		}
+		resCh <- res
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	pending, err := tool.Store.InterruptListByRun(ctx, tools.RunID(ctx), store.InterruptStatusPending)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("expected 1 pending interrupt, got %d", len(pending))
+	}
+	id := pending[0].InterruptID
+
+	// Decline (no answer) — mirrors what the HTTP handler does for the
+	// declined disposition: InterruptFinish(declined) + Notify.
+	if err := tool.Store.InterruptFinish(ctx, id, store.InterruptStatusDeclined, store.InterruptResolvedByWebUI); err != nil {
+		t.Fatalf("InterruptFinish(declined): %v", err)
+	}
+	tool.Bus.Notify("intr:" + id)
+
+	select {
+	case res := <-resCh:
+		if res.IsError {
+			t.Fatalf("declined result must NOT be is_error (agent should proceed); got %+v", res)
+		}
+		var out map[string]any
+		if err := json.Unmarshal([]byte(res.Text), &out); err != nil {
+			t.Fatalf("result not JSON: %v (raw %q)", err, res.Text)
+		}
+		if out["declined"] != true {
+			t.Errorf("declined=%v, want true (raw %q)", out["declined"], res.Text)
+		}
+		if out["resolved_by"] != store.InterruptResolvedByWebUI {
+			t.Errorf("resolved_by=%v, want webui", out["resolved_by"])
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ask did not wake after decline")
+	}
+}
+
 // TestInterruption_AskWakesOnCrossRuntimeResolve guards the F15 durable-wake
 // backstop. In a multi-full-runtime topology the resolve lands on a DIFFERENT
 // runtime: the DB row flips to resolved but THIS process's in-memory Bus is


### PR DESCRIPTION
## Why

RFC BH P2 (`/loomcycle/rfcs/turn-scoped-cancellation` §9): let an operator **decline** a pending interruption (a Question tool call) so the agent PROCEEDS without an answer and without killing the run — the "Skip / decline" action loomboard wants on an interrupt card. Distinct from answering (no option validation) and from the error-shaped run-cancel `cancelled`.

## What

`POST /v1/runs/{run_id}/interrupts/{interrupt_id}/resolve` gains an optional `{ "disposition": "declined" }` (alongside the existing `{ "answer": … }`):
- **`declined`** carries no answer → **skips option-list validation** entirely; persists the new terminal status `declined` via `InterruptFinish` (the answer-less terminal writer); fires the **same** `interruptionBus.Notify("intr:"+id)` wake + `_system/interrupts/resolved` publish.
- The waiting Question tool (`toolResultForStatus`) returns a **NON-error** result `{"declined": true, "note": "…proceed without this input.", …}` — deliberately not `IsError` (an error could make the agent retry/abort; the operator wants it to PROCEED). Distinct from the `cancelled` branch, which stays `IsError` (run-cancel / timeout).
- The **answer path is byte-identical** (`finalStatus` defaults to `resolved`; the option validation, persist, publish, and response are unchanged when no disposition is sent).
- Guards preserved: kind-gate, retarget guard, tenant opaque-404, already-terminal→409, expired→410. `disposition` validation: only `""`/`"answer"`/`"declined"` (unknown → 422); `declined` + a non-empty `answer` → 422 (contradictory).

**Store:** new `store.InterruptStatusDeclined = "declined"` (terminal), whitelisted in `InterruptFinish` on **both** backends (sqlite + postgres); no migration (`status` is a TEXT column); the `WHERE status='pending'` guard keeps a decline idempotent-safe (already-terminal → 409).

## What was tested
- `go test ./...` — clean (85 packages), independently re-run. `go build ./...`, gofmt clean.
- Regression tests, each **fail-before verified**: `InterruptFinishSetsDeclined` (shared store contract → runs against sqlite AND postgres; fails pre-P2 with "invalid terminal status"); `TestInterruption_DeclineReturnsNonErrorResult` (tool end-to-end wake → non-error `declined` payload); handler tests — decline skips option validation + fires the wake, decline+answer → 422, unknown disposition → 422, decline on already-terminal → 409, and the answer path unchanged.

**Deferred (RFC BH P3):** cross-replica owner-routing + TS/gRPC/Python adapters (`cancelInterrupt`) + the gRPC/MCP interruption-resolve connector path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)