### PR TITLE
feat(coord): RFC BH P3a — cross-replica turn-cancel routing

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -2237,6 +2237,26 @@ func main() {
 			go steerCoord.RunSteerAckSubscriber(bgCtx)
 		}
 
+		// Cross-replica turn-cancel (RFC BH P3a; the twin of cancel/steer): a
+		// POST /v1/runs/{run_id}/cancel that lands on a replica not running the
+		// target run routes over the backplane to the owning replica by
+		// runs.replica_id, so a turn-cancel works cluster-wide.
+		if tcReg := srv.TurnCancelRegistry(); tcReg != nil {
+			tcCoord, err := coord.NewTurnCancelCoordinator(coord.TurnCancelCoordinatorConfig{
+				Backplane:    bp,
+				ReplicaID:    cfg.Env.ReplicaID,
+				Store:        pgStore,
+				ReplicaStore: replicaStore,
+				AckTimeout:   ackTimeout,
+			})
+			if err != nil {
+				log.Fatalf("coord: turn-cancel coordinator init: %v", err)
+			}
+			tcReg.SetClusterCanceller(tcCoord)
+			go tcCoord.RunTurnCancelSubscriber(bgCtx, tcReg)
+			go tcCoord.RunTurnCancelAckSubscriber(bgCtx)
+		}
+
 		// v0.12.3 Phase 4: runstate + channel bus backplane fanout.
 		// Both buses were constructed earlier (lines ~1003/1012) and
 		// wired into the server via SetRunStateBus / SetChannelBus.

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -460,6 +460,11 @@ func New(cfg *config.Config, pr ProviderResolver, builtinTools []tools.Tool, sem
 		hookDispatcher: hooks.NewDispatcher(hookReg, nil),
 		startedAt:      time.Now(),
 	}
+	// RFC BH: the turn-cancel registry builds its cancel cause via loop.TurnCancelCause
+	// (the loop recognizes it to PARK the run instead of terminating). Injected here
+	// so the leaf turncancel package stays free of internal/loop; wired at
+	// construction so single-process AND cluster paths both fire the correct cause.
+	s.turnCancelReg.SetCauseFor(loop.TurnCancelCause)
 	// RFC AW: per-scope token-budget tracker. limits.New(nil) is a no-op tracker
 	// (Check always allows, Add no-ops), so a store-less server keeps today's
 	// unlimited behavior. Seeded from the ledger at boot via SeedLimits.
@@ -2502,6 +2507,11 @@ func (s *Server) CancelRegistry() *cancel.Registry { return s.cancelReg }
 // cross-replica SteerCoordinator (SetClusterSteerer + the subscriber
 // goroutines). nil when steering isn't enabled.
 func (s *Server) SteerRegistry() *steer.Registry { return s.steerReg }
+
+// TurnCancelRegistry exposes the per-turn cancel registry so main.go can wire the
+// cross-replica TurnCancelCoordinator (SetClusterCanceller + the subscriber
+// goroutines, RFC BH P3a). Always non-nil (constructed in NewServer).
+func (s *Server) TurnCancelRegistry() *turncancel.Registry { return s.turnCancelReg }
 
 // trySessionLock try-locks the session-scoped mutex for id. Returns
 // (release, true) on success and (nil, false) if another caller already
@@ -6282,8 +6292,17 @@ type cancelTurnRequest struct {
 // the run. 409 when the run isn't mid-turn (already parked / terminal) or isn't
 // interactive; a cross-tenant / unknown run folds into an opaque 404 — run_ids
 // are not secrets (returned to callers + shown in the UI), so the gate must not
-// become an existence oracle (mirrors handleRunInput / SteerRun). Idempotent: a
-// second call once the run has parked → 409 not_mid_turn.
+// become an existence oracle. Idempotent: a second call once the run has parked
+// → 409 not_mid_turn.
+//
+// Two paths (RFC BH P3a — cross-replica):
+//   - The run is live on THIS replica (steer registry hit): the P1 local flow —
+//     session-ownership gate + IsArmed + fire the local token.
+//   - The run is NOT live here (steer registry miss): gate ownership via the
+//     SHARED store (works cluster-wide, unlike the per-replica steer registry)
+//     and route the cancel to the owning replica by runs.replica_id via the
+//     turn-cancel registry's cluster fallback. Single-process (no coordinator
+//     wired) folds this back to the P1 "no in-flight run" 404, byte-identical.
 func (s *Server) handleCancelTurn(w http.ResponseWriter, r *http.Request) {
 	if s.turnCancelReg == nil || s.steerReg == nil {
 		http.Error(w, "turn-cancel is not enabled on this server", http.StatusServiceUnavailable)
@@ -6299,48 +6318,71 @@ func (s *Server) handleCancelTurn(w http.ResponseWriter, r *http.Request) {
 	var req cancelTurnRequest
 	_ = json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req)
 	ctx := r.Context()
+	reason := strings.TrimSpace(req.Reason)
 
-	// Tenant-ownership gate (mirrors SteerRun): resolve the live run via the steer
-	// registry, then verify the caller owns its session. A cross-tenant or unknown
-	// run folds into an opaque 404.
-	entry, ok := s.steerReg.Get(runID)
-	if !ok {
+	// Local fast path: the run is live on THIS replica. Gate on its session's
+	// tenant (mirrors SteerRun), then fire the local armed token. Byte-identical
+	// to P1.
+	if entry, ok := s.steerReg.Get(runID); ok {
+		if entry.SessionID != "" && s.store != nil {
+			if sess, err := s.store.GetSession(ctx, entry.SessionID); err == nil {
+				if !sessionOwnershipOK(ctx, sess) {
+					http.Error(w, "no in-flight run for that run_id", http.StatusNotFound)
+					return
+				}
+			}
+		}
+		// Mid-turn? Only an armed run (interactive + in-flight) is turn-cancellable.
+		if !s.turnCancelReg.IsArmed(runID) {
+			code, msg := "not_mid_turn", "run is not mid-turn (already parked or terminal)"
+			// Distinguish a non-interactive run for a clearer error (best-effort;
+			// the caller already passed the ownership gate above).
+			if s.store != nil {
+				if run, err := s.tenantStore(ctx).GetRun(ctx, runID); err == nil && !run.Interactive {
+					code = "not_interactive"
+					msg = "turn-cancel applies only to interactive runs; use POST /v1/agents/{id}/cancel to stop this run"
+				}
+			}
+			writeJSONError(w, http.StatusConflict, code, msg)
+			return
+		}
+		// Fire the local armed token (builds loop.TurnCancelCause via the
+		// registry's causeFor). A false return means the token vanished between
+		// IsArmed and here (the turn just ended / a concurrent cancel won) → 409.
+		if !s.turnCancelReg.CancelLocal(runID, reason) {
+			writeJSONError(w, http.StatusConflict, "not_mid_turn", "run is not mid-turn (already parked or terminal)")
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"run_id": runID, "stopped": true, "parked": true})
+		return
+	}
+
+	// Cross-replica fallback: the run is not live here. Gate ownership via the
+	// shared store (a cross-tenant / unknown run folds into an opaque 404), then
+	// route the cancel to the run's owning replica by runs.replica_id.
+	if s.store == nil {
 		http.Error(w, "no in-flight run for that run_id", http.StatusNotFound)
 		return
 	}
-	if entry.SessionID != "" && s.store != nil {
-		if sess, err := s.store.GetSession(ctx, entry.SessionID); err == nil {
-			if !sessionOwnershipOK(ctx, sess) {
-				http.Error(w, "no in-flight run for that run_id", http.StatusNotFound)
-				return
-			}
-		}
-	}
-
-	// Mid-turn? Only an armed run (interactive + in-flight) is turn-cancellable.
-	if !s.turnCancelReg.IsArmed(runID) {
-		code, msg := "not_mid_turn", "run is not mid-turn (already parked or terminal)"
-		// Distinguish a non-interactive run for a clearer error (best-effort; the
-		// caller already passed the ownership gate above).
-		if s.store != nil {
-			if run, err := s.tenantStore(ctx).GetRun(ctx, runID); err == nil && !run.Interactive {
-				code = "not_interactive"
-				msg = "turn-cancel applies only to interactive runs; use POST /v1/agents/{id}/cancel to stop this run"
-			}
-		}
-		writeJSONError(w, http.StatusConflict, code, msg)
+	if _, err := s.tenantStore(ctx).GetRun(ctx, runID); err != nil {
+		http.Error(w, "no in-flight run for that run_id", http.StatusNotFound)
 		return
 	}
-
-	// Fire the armed token with the operator reason. A false return means the
-	// token vanished between the IsArmed check and here (the turn just ended / a
-	// concurrent cancel won the race) → 409.
-	if !s.turnCancelReg.Cancel(runID, loop.TurnCancelCause(strings.TrimSpace(req.Reason))) {
-		writeJSONError(w, http.StatusConflict, "not_mid_turn", "run is not mid-turn (already parked or terminal)")
+	fired, err := s.turnCancelReg.Cancel(ctx, runID, reason)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	// The loop catches the sentinel cause and parks the run at awaiting_input;
-	// report the intended outcome for an interactive run.
+	if !fired {
+		// Not armed on any reachable replica (already parked / just ended / owner
+		// gone) — and in single-process mode (no coordinator) a steer-registry miss
+		// always lands here. "No in-flight turn to cancel" → 404, byte-identical to
+		// P1's steer-miss response.
+		http.Error(w, "no in-flight run for that run_id", http.StatusNotFound)
+		return
+	}
+	// The owning replica's loop caught the cause and parks the run at
+	// awaiting_input; report the intended outcome for an interactive run.
 	writeJSON(w, http.StatusOK, map[string]any{"run_id": runID, "stopped": true, "parked": true})
 }
 

--- a/internal/api/http/turncancel_handler_test.go
+++ b/internal/api/http/turncancel_handler_test.go
@@ -22,6 +22,9 @@ func turnCancelFixture(t *testing.T) (*Server, func()) {
 	srv, cleanup := channelFanFixture(t)
 	srv.SetSteerRegistry(steer.NewRegistry(4))
 	srv.turnCancelReg = turncancel.NewRegistry()
+	// The fixture replaces the NewServer-built registry, so re-wire the cause
+	// builder it needs to fire (NewServer does this in production).
+	srv.turnCancelReg.SetCauseFor(loop.TurnCancelCause)
 	return srv, cleanup
 }
 
@@ -155,6 +158,101 @@ func TestRequiredScopeFor_TurnCancel(t *testing.T) {
 	// Whole-run cancel (a distinct path) still maps to runs:create — unchanged.
 	if got := requiredScopeFor(http.MethodPost, "/v1/agents/ag-1/cancel"); got != auth.ScopeRunsCreate {
 		t.Errorf("whole-run cancel scope = %q, want %q", got, auth.ScopeRunsCreate)
+	}
+}
+
+// stubClusterCanceller records the cross-replica delegation from the handler's
+// fallback path.
+type stubClusterCanceller struct {
+	calls  int
+	runID  string
+	reason string
+	found  bool
+	err    error
+}
+
+func (s *stubClusterCanceller) CancelRemote(_ context.Context, runID, reason string) (bool, error) {
+	s.calls++
+	s.runID, s.reason = runID, reason
+	return s.found, s.err
+}
+
+// A cross-replica turn-cancel: the run is NOT live on this replica (steer
+// registry miss) but exists in the shared store — the handler gates via the store
+// and routes to the owning replica via the cluster canceller, returning 200.
+func TestHandleCancelTurn_RoutesCrossReplicaAndParks(t *testing.T) {
+	srv, cleanup := turnCancelFixture(t)
+	defer cleanup()
+	ctx := context.Background()
+	sess, err := srv.store.CreateSession(ctx, "", "agent-x", "alice")
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	run, err := srv.store.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "agent-x", UserID: "alice", Interactive: true})
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	// Deliberately NOT registered in the steer registry → the handler takes the
+	// cross-replica fallback and delegates to the cluster canceller.
+	stub := &stubClusterCanceller{found: true}
+	srv.turnCancelReg.SetClusterCanceller(stub)
+
+	rec := doJSON(t, srv, "POST", "/v1/runs/"+run.ID+"/cancel", `{"reason":"remote stop"}`)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if stub.calls != 1 || stub.runID != run.ID || stub.reason != "remote stop" {
+		t.Fatalf("CancelRemote calls=%d runID=%q reason=%q, want 1/%s/remote stop", stub.calls, stub.runID, stub.reason, run.ID)
+	}
+}
+
+// A cross-replica cancel that the owning replica did not fire (parked / gone) →
+// 404 (no in-flight turn to cancel), and a cross-tenant/unknown run never reaches
+// the cluster canceller (opaque 404 at the store gate — no existence oracle).
+func TestHandleCancelTurn_CrossReplicaNotFired_404(t *testing.T) {
+	srv, cleanup := turnCancelFixture(t)
+	defer cleanup()
+	ctx := context.Background()
+	sess, err := srv.store.CreateSession(ctx, "", "agent-x", "alice")
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	run, err := srv.store.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "agent-x", UserID: "alice", Interactive: true})
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	stub := &stubClusterCanceller{found: false}
+	srv.turnCancelReg.SetClusterCanceller(stub)
+
+	if rec := doJSON(t, srv, "POST", "/v1/runs/"+run.ID+"/cancel", `{}`); rec.Code != 404 {
+		t.Fatalf("not-fired remote status = %d, want 404; body=%s", rec.Code, rec.Body.String())
+	}
+	// Unknown run → opaque 404 at the store gate, cluster canceller untouched.
+	if rec := doJSON(t, srv, "POST", "/v1/runs/ghost/cancel", `{}`); rec.Code != 404 {
+		t.Fatalf("unknown run status = %d, want 404", rec.Code)
+	}
+	if stub.calls != 1 {
+		t.Fatalf("cluster canceller calls=%d, want 1 (only the existing run reaches it)", stub.calls)
+	}
+}
+
+// Single-process (no coordinator wired): an existing run that isn't live on this
+// replica → 404, byte-identical to P1's steer-miss response.
+func TestHandleCancelTurn_SingleProcessExistingRunNotLive_404(t *testing.T) {
+	srv, cleanup := turnCancelFixture(t)
+	defer cleanup()
+	ctx := context.Background()
+	sess, err := srv.store.CreateSession(ctx, "", "agent-x", "alice")
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	run, err := srv.store.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "agent-x", UserID: "alice", Interactive: true})
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	// No steer registration, no cluster canceller → fallback finds nothing → 404.
+	if rec := doJSON(t, srv, "POST", "/v1/runs/"+run.ID+"/cancel", `{}`); rec.Code != 404 {
+		t.Fatalf("status = %d, want 404 (no in-flight run); body=%s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/internal/coord/turncancel_coordinator.go
+++ b/internal/coord/turncancel_coordinator.go
@@ -1,0 +1,247 @@
+package coord
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/turncancel"
+)
+
+// TurnCancelCoordinator implements turncancel.ClusterCanceller via the v0.12.0
+// Backplane — the cross-replica twin of SteerCoordinator, for operator
+// turn-cancel (POST /v1/runs/{run_id}/cancel, RFC BH P3a). One instance per
+// replica, wired in main.go's cluster block. When the local turn-cancel registry
+// misses (the run isn't armed on this replica), the registry delegates to
+// CancelRemote which:
+//
+//  1. Looks up the run row by run_id for its owning replica_id.
+//  2. Short-circuits: unknown run / terminal run / unstamped / self-owned /
+//     dead owner all return found=false (the handler serves a not-in-flight 404).
+//  3. Publishes a `loomcycle.turncancel` event {run_id, reason, from_replica}.
+//  4. Waits on a per-run ack channel for up to AckTimeout. An ack means the owner
+//     had the run armed mid-turn and fired it → found=true. A timeout means no
+//     replica fired it (already parked / just ended) → found=false.
+//
+// Two long-lived subscriber goroutines carry the wire side: RunTurnCancelSubscriber
+// (owning side: fires the LOCAL armed token via the registry and acks only when it
+// fired) and RunTurnCancelAckSubscriber (originator side: routes acks to in-flight
+// CancelRemote waiters). Keyed by run_id, like steer.
+type TurnCancelCoordinator struct {
+	bp         Backplane
+	replicaID  string
+	store      turnCancelRunStore
+	replicas   ReplicaLiveness
+	ackTimeout time.Duration
+
+	mu sync.Mutex
+	// ackSubs fans one ack out to every concurrent CancelRemote waiter for the
+	// same run_id (same per-caller-channel pattern as SteerCoordinator).
+	ackSubs map[string][]chan turnCancelAckPayload
+}
+
+// TurnCancelCoordinatorConfig is the constructor input.
+type TurnCancelCoordinatorConfig struct {
+	Backplane    Backplane
+	ReplicaID    string
+	Store        turnCancelRunStore
+	ReplicaStore ReplicaLiveness
+	// AckTimeout caps how long CancelRemote waits for the owning replica's ack.
+	// Default 5s if zero.
+	AckTimeout time.Duration
+}
+
+// turnCancelRunStore is the narrow store surface CancelRemote needs.
+// *storepostgres.Store satisfies it implicitly. Run lookup is by run_id.
+type turnCancelRunStore interface {
+	GetRun(ctx context.Context, runID string) (store.Run, error)
+}
+
+const (
+	topicTurnCancel    = "loomcycle.turncancel"
+	topicTurnCancelAck = "loomcycle.turncancel.ack"
+)
+
+func NewTurnCancelCoordinator(cfg TurnCancelCoordinatorConfig) (*TurnCancelCoordinator, error) {
+	if cfg.Backplane == nil {
+		return nil, errors.New("coord: backplane is required")
+	}
+	if cfg.Store == nil {
+		return nil, errors.New("coord: store is required")
+	}
+	if cfg.ReplicaStore == nil {
+		return nil, errors.New("coord: replica store is required")
+	}
+	if err := ValidateReplicaID(cfg.ReplicaID); err != nil {
+		return nil, err
+	}
+	timeout := cfg.AckTimeout
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+	return &TurnCancelCoordinator{
+		bp:         cfg.Backplane,
+		replicaID:  cfg.ReplicaID,
+		store:      cfg.Store,
+		replicas:   cfg.ReplicaStore,
+		ackTimeout: timeout,
+		ackSubs:    make(map[string][]chan turnCancelAckPayload),
+	}, nil
+}
+
+type turnCancelEventPayload struct {
+	RunID       string `json:"run_id"`
+	Reason      string `json:"reason,omitempty"`
+	FromReplica string `json:"from_replica"`
+}
+
+type turnCancelAckPayload struct {
+	RunID     string `json:"run_id"`
+	ByReplica string `json:"by_replica"`
+	// Fired is always true on the wire (the owner acks only when it fired the
+	// armed token). Carried explicitly for symmetry with the steer ack + so a
+	// future not-fired ack is a non-breaking extension.
+	Fired bool `json:"fired"`
+}
+
+// CancelRemote satisfies turncancel.ClusterCanceller. found=false ⇒ no replica
+// fired a mid-turn cancel for the run (unknown / terminal / self-owned / dead
+// owner / not mid-turn on the owner). found=true ⇒ the owning replica had the
+// run armed and fired it.
+func (c *TurnCancelCoordinator) CancelRemote(ctx context.Context, runID, reason string) (bool, error) {
+	run, err := c.store.GetRun(ctx, runID)
+	if err != nil {
+		var notFound *store.ErrNotFound
+		if errors.As(err, &notFound) {
+			return false, nil
+		}
+		return false, fmt.Errorf("get run: %w", err)
+	}
+	// Only a running run can be mid-turn. Terminal / unstamped / self-owned all
+	// mean "not reachably mid-turn here" (the local registry already missed, so a
+	// self-owned row means the turn isn't armed on this replica).
+	if run.Status != store.RunRunning && run.Status != store.RunStatus("") {
+		return false, nil
+	}
+	if run.ReplicaID == "" || run.ReplicaID == c.replicaID {
+		return false, nil
+	}
+	if alive, err := c.replicas.IsReplicaAlive(ctx, run.ReplicaID, staleReplicaThreshold); err != nil {
+		// Probe failure: proceed with the broadcast — a real cancel may still
+		// land if the owner responds.
+		log.Printf("coord: turncancel IsReplicaAlive probe for %s failed: %v (proceeding)", run.ReplicaID, err)
+	} else if !alive {
+		return false, nil
+	}
+
+	// Live remote owner: broadcast + wait for ack. Each CancelRemote gets its own
+	// buffered channel; RunTurnCancelAckSubscriber fans out to every waiter.
+	ackCh := make(chan turnCancelAckPayload, 1)
+	c.mu.Lock()
+	c.ackSubs[runID] = append(c.ackSubs[runID], ackCh)
+	c.mu.Unlock()
+	defer func() {
+		c.mu.Lock()
+		slice := c.ackSubs[runID]
+		for i, ch := range slice {
+			if ch == ackCh {
+				slice = append(slice[:i], slice[i+1:]...)
+				break
+			}
+		}
+		if len(slice) == 0 {
+			delete(c.ackSubs, runID)
+		} else {
+			c.ackSubs[runID] = slice
+		}
+		c.mu.Unlock()
+	}()
+
+	payload, _ := json.Marshal(turnCancelEventPayload{
+		RunID:       runID,
+		Reason:      reason,
+		FromReplica: c.replicaID,
+	})
+	if err := c.bp.Publish(ctx, topicTurnCancel, payload); err != nil {
+		return false, fmt.Errorf("publish turncancel: %w", err)
+	}
+
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), c.ackTimeout)
+	defer waitCancel()
+	select {
+	case ack := <-ackCh:
+		return ack.Fired, nil
+	case <-waitCtx.Done():
+		// No ack in the window. The owner acks only when it fired a mid-turn
+		// token, so no ack means the run wasn't mid-turn on the owner (already
+		// parked / just ended) — report not-fired so the handler serves 404.
+		return false, nil
+	}
+}
+
+// RunTurnCancelSubscriber is the owning-side listener. Started once per replica.
+// Reads `loomcycle.turncancel`, fires the LOCAL armed token via the registry, and
+// acks only when it actually fired.
+//
+// CRITICAL: uses CancelLocal (never the cluster-delegating Cancel) so a local
+// miss doesn't re-broadcast the event we just received (the CancelLocal lesson —
+// avoids a broadcast storm). A local miss = not our run OR our run but no longer
+// mid-turn; either way we skip silently and do not ack, so only the replica that
+// fired a live token acks.
+func (c *TurnCancelCoordinator) RunTurnCancelSubscriber(ctx context.Context, reg *turncancel.Registry) {
+	ch, err := c.bp.Subscribe(ctx, topicTurnCancel)
+	if err != nil {
+		log.Printf("coord: RunTurnCancelSubscriber subscribe failed: %v", err)
+		return
+	}
+	for evt := range ch {
+		var p turnCancelEventPayload
+		if err := json.Unmarshal(evt.Payload, &p); err != nil {
+			log.Printf("coord: malformed turncancel event: %v", err)
+			continue
+		}
+		if !reg.CancelLocal(p.RunID, p.Reason) {
+			continue // not armed here; the owning replica's subscriber will ack
+		}
+		ack, _ := json.Marshal(turnCancelAckPayload{RunID: p.RunID, ByReplica: c.replicaID, Fired: true})
+		if err := c.bp.Publish(ctx, topicTurnCancelAck, ack); err != nil {
+			log.Printf("coord: publish turncancel ack for %s: %v", p.RunID, err)
+		}
+	}
+}
+
+// RunTurnCancelAckSubscriber is the originator-side ack fan-in. Started once per
+// replica. Routes each ack to the matching in-flight CancelRemote waiter(s).
+func (c *TurnCancelCoordinator) RunTurnCancelAckSubscriber(ctx context.Context) {
+	ch, err := c.bp.Subscribe(ctx, topicTurnCancelAck)
+	if err != nil {
+		log.Printf("coord: RunTurnCancelAckSubscriber subscribe failed: %v", err)
+		return
+	}
+	for evt := range ch {
+		var ack turnCancelAckPayload
+		if err := json.Unmarshal(evt.Payload, &ack); err != nil {
+			log.Printf("coord: malformed turncancel ack: %v", err)
+			continue
+		}
+		c.mu.Lock()
+		waiters := c.ackSubs[ack.RunID]
+		snapshot := make([]chan turnCancelAckPayload, len(waiters))
+		copy(snapshot, waiters)
+		c.mu.Unlock()
+		for _, w := range snapshot {
+			select {
+			case w <- ack:
+			default:
+			}
+		}
+	}
+}
+
+// Compile-time check that we satisfy the turncancel package's interface.
+var _ turncancel.ClusterCanceller = (*TurnCancelCoordinator)(nil)

--- a/internal/coord/turncancel_coordinator_test.go
+++ b/internal/coord/turncancel_coordinator_test.go
@@ -1,0 +1,164 @@
+package coord
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/turncancel"
+)
+
+// causeForTest mirrors loop.TurnCancelCause without importing internal/loop — the
+// coordinator is cause-agnostic (it routes the reason string; the owning
+// replica's registry rebuilds the cause via its own causeFor).
+func causeForTest(reason string) error {
+	if reason == "" {
+		return errors.New("turn cancelled by operator")
+	}
+	return fmt.Errorf("turn cancelled by operator: %s", reason)
+}
+
+func newTurnCancelCoord(t *testing.T, bp Backplane, replicaID string, runs map[string]store.Run, alive bool, timeout time.Duration) *TurnCancelCoordinator {
+	t.Helper()
+	if timeout == 0 {
+		timeout = 2 * time.Second
+	}
+	c, err := NewTurnCancelCoordinator(TurnCancelCoordinatorConfig{
+		Backplane:    bp,
+		ReplicaID:    replicaID,
+		Store:        &stubSteerRunStore{runs: runs}, // reused: same narrow GetRun surface
+		ReplicaStore: stubLiveness{alive: alive},
+		AckTimeout:   timeout,
+	})
+	if err != nil {
+		t.Fatalf("NewTurnCancelCoordinator: %v", err)
+	}
+	return c
+}
+
+func TestTurnCancelCoordinator_NotFound_ReturnsMiss(t *testing.T) {
+	c := newTurnCancelCoord(t, newMemBackplane(), "replica-A", map[string]store.Run{}, true, 0)
+	found, err := c.CancelRemote(context.Background(), "ghost", "x")
+	if err != nil || found {
+		t.Errorf("CancelRemote(unknown) = (%v,%v), want (false,nil)", found, err)
+	}
+}
+
+func TestTurnCancelCoordinator_SelfOwned_ReturnsMiss(t *testing.T) {
+	runs := map[string]store.Run{"run-1": {ID: "run-1", Status: store.RunRunning, ReplicaID: "replica-A"}}
+	c := newTurnCancelCoord(t, newMemBackplane(), "replica-A", runs, true, 0)
+	found, _ := c.CancelRemote(context.Background(), "run-1", "x")
+	if found {
+		t.Errorf("self-owned run = %v, want false — local registry missed ⇒ turn not armed here", found)
+	}
+}
+
+func TestTurnCancelCoordinator_Terminal_ReturnsMiss(t *testing.T) {
+	runs := map[string]store.Run{"run-1": {ID: "run-1", Status: store.RunCompleted, ReplicaID: "replica-B"}}
+	c := newTurnCancelCoord(t, newMemBackplane(), "replica-A", runs, true, 0)
+	found, _ := c.CancelRemote(context.Background(), "run-1", "x")
+	if found {
+		t.Errorf("terminal run = %v, want false", found)
+	}
+}
+
+func TestTurnCancelCoordinator_DeadOwner_ReturnsMiss(t *testing.T) {
+	runs := map[string]store.Run{"run-1": {ID: "run-1", Status: store.RunRunning, ReplicaID: "replica-B"}}
+	c := newTurnCancelCoord(t, newMemBackplane(), "replica-A", runs, false /* dead */, 0)
+	found, _ := c.CancelRemote(context.Background(), "run-1", "x")
+	if found {
+		t.Errorf("dead-owner run = %v, want false", found)
+	}
+}
+
+// The full cross-replica round-trip: originator (A) CancelRemote → owner (B)
+// RunTurnCancelSubscriber fires B's local armed token + acks → A's ack subscriber
+// routes the ack back → CancelRemote returns found=true, and B's turn ctx is
+// cancelled with the operator reason.
+func TestTurnCancelCoordinator_FiresRemoteOwnersArmedToken(t *testing.T) {
+	bp := newMemBackplane()
+	const owner = "replica-B"
+	runs := map[string]store.Run{"run-1": {ID: "run-1", Status: store.RunRunning, ReplicaID: owner}}
+
+	a := newTurnCancelCoord(t, bp, "replica-A", runs, true, 0) // originator
+	b := newTurnCancelCoord(t, bp, owner, runs, true, 0)       // owner
+
+	ownerReg := turncancel.NewRegistry()
+	ownerReg.SetCauseFor(causeForTest)
+	turnCtx, turnCancel := context.WithCancelCause(context.Background())
+	defer turnCancel(nil)
+	ownerReg.Arm("run-1", turnCancel)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go b.RunTurnCancelSubscriber(ctx, ownerReg) // owner side
+	go a.RunTurnCancelAckSubscriber(ctx)        // originator side
+	time.Sleep(30 * time.Millisecond)           // let both Subscribe calls register
+
+	found, err := a.CancelRemote(context.Background(), "run-1", "too slow")
+	if err != nil {
+		t.Fatalf("CancelRemote: %v", err)
+	}
+	if !found {
+		t.Fatalf("CancelRemote = found=%v, want true", found)
+	}
+	// The owner's armed turn ctx was cancelled with the routed reason.
+	if turnCtx.Err() == nil {
+		t.Fatal("owner's armed turn ctx was never cancelled")
+	}
+	if cause := context.Cause(turnCtx); cause == nil || cause.Error() != "turn cancelled by operator: too slow" {
+		t.Fatalf("owner turn cause = %v, want the routed reason", context.Cause(turnCtx))
+	}
+	// The token was consumed on the owner.
+	if ownerReg.IsArmed("run-1") {
+		t.Error("owner token still armed after a remote cancel")
+	}
+}
+
+// A remote owner that is NOT mid-turn (no armed token) never acks, so CancelRemote
+// times out and reports not-fired — the handler serves 404.
+func TestTurnCancelCoordinator_RemoteOwnerNotMidTurn_TimesOut(t *testing.T) {
+	bp := newMemBackplane()
+	const owner = "replica-B"
+	runs := map[string]store.Run{"run-1": {ID: "run-1", Status: store.RunRunning, ReplicaID: owner}}
+
+	a := newTurnCancelCoord(t, bp, "replica-A", runs, true, 150*time.Millisecond)
+	b := newTurnCancelCoord(t, bp, owner, runs, true, 150*time.Millisecond)
+
+	ownerReg := turncancel.NewRegistry() // no armed token (run is parked on the owner)
+	ownerReg.SetCauseFor(causeForTest)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go b.RunTurnCancelSubscriber(ctx, ownerReg)
+	go a.RunTurnCancelAckSubscriber(ctx)
+	time.Sleep(30 * time.Millisecond)
+
+	found, err := a.CancelRemote(context.Background(), "run-1", "")
+	if err != nil {
+		t.Fatalf("CancelRemote: %v", err)
+	}
+	if found {
+		t.Fatal("CancelRemote reported fired for a not-mid-turn remote owner")
+	}
+}
+
+func TestTurnCancelCoordinator_ValidatesConfig(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  TurnCancelCoordinatorConfig
+		want string
+	}{
+		{"nil backplane", TurnCancelCoordinatorConfig{}, "backplane"},
+		{"nil store", TurnCancelCoordinatorConfig{Backplane: newMemBackplane()}, "store"},
+		{"nil replica store", TurnCancelCoordinatorConfig{Backplane: newMemBackplane(), Store: &stubSteerRunStore{}}, "replica store"},
+	}
+	for _, tc := range cases {
+		if _, err := NewTurnCancelCoordinator(tc.cfg); err == nil {
+			t.Errorf("%s: want error mentioning %q, got nil", tc.name, tc.want)
+		}
+	}
+}

--- a/internal/turncancel/registry.go
+++ b/internal/turncancel/registry.go
@@ -10,16 +10,41 @@
 // it started — without terminating the run: the loop catches the sentinel cause,
 // synthesizes valid history, and parks the interactive run at awaiting_input.
 //
-// It deliberately does NOT import internal/loop: the caller passes the cancel
-// cause (loop.ErrTurnCancelled, optionally wrapped with an operator reason) as
-// an opaque error, so this leaf package stays dependency-free. Single-process
-// (P1); cross-replica owner-routing by runs.replica_id is P3 (mirror steer).
+// It deliberately does NOT import internal/loop: the caller INJECTS a causeFor
+// (SetCauseFor(loop.TurnCancelCause)) that builds the cancel cause from an
+// operator reason string, so this leaf package stays free of internal/loop AND
+// internal/coord. That same reason-string boundary is what lets P3a route a
+// cancel cross-replica — the wire carries the reason string, and each replica's
+// registry rebuilds the proper loop cause locally via its own causeFor.
+//
+// Cross-replica owner-routing (P3a) mirrors internal/cancel + internal/steer: on
+// a LOCAL MISS, Cancel delegates to a ClusterCanceller (implemented by
+// internal/coord.TurnCancelCoordinator) that routes the cancel to the run's
+// owning replica by runs.replica_id over the backplane. nil ClusterCanceller =
+// single-process mode, byte-identical to P1 (a local miss fires nothing).
 package turncancel
 
 import (
 	"context"
 	"sync"
 )
+
+// ClusterCanceller is the cross-replica fallback (mirror of
+// cancel.ClusterCanceller / steer.ClusterSteerer). When set, a Cancel that
+// misses the local armed map delegates to CancelRemote, which routes the cancel
+// by runs.replica_id over the backplane to the run's owning replica. nil =
+// single-replica mode; a local miss fires nothing (P1 behaviour, byte-identical).
+//
+// The wire carries the REASON STRING, not a cause error: this leaf can't build a
+// loop cause, and the owning replica rebuilds it locally via its own causeFor.
+// found reports whether the owning replica had the run armed and fired it.
+//
+// The interface lives here (not in internal/coord) so this leaf package stays
+// free of the coord dependency — internal/coord implements it on
+// TurnCancelCoordinator.
+type ClusterCanceller interface {
+	CancelRemote(ctx context.Context, runID, reason string) (found bool, err error)
+}
 
 // Registry maps a live run_id → its currently-armed per-turn CancelCauseFunc.
 // At most one token is armed per run at a time (the loop overwrites it on each
@@ -34,6 +59,13 @@ type Registry struct {
 	// be told apart from the live token and made a no-op — a missed disarm can
 	// therefore never delete a newer turn's token.
 	seq uint64
+	// causeFor builds the cancel cause from an operator reason string. Injected
+	// (SetCauseFor(loop.TurnCancelCause)) so the leaf stays loop-free; a cause
+	// the loop DOESN'T recognize as a turn-cancel would terminate the run, so a
+	// nil causeFor makes the fire methods refuse to fire (fail-safe).
+	causeFor func(reason string) error
+	// cluster is the cross-replica fallback; nil in single-process mode.
+	cluster ClusterCanceller
 }
 
 type entry struct {
@@ -41,9 +73,27 @@ type entry struct {
 	gen    uint64
 }
 
-// NewRegistry returns an empty registry.
+// NewRegistry returns an empty registry. Wire SetCauseFor before use (the fire
+// methods refuse to fire without it); SetClusterCanceller is cluster-mode only.
 func NewRegistry() *Registry {
 	return &Registry{armed: make(map[string]entry)}
+}
+
+// SetCauseFor installs the reason→cause builder (the server passes
+// loop.TurnCancelCause). Called once at server construction; not for mid-flight
+// swaps.
+func (r *Registry) SetCauseFor(fn func(reason string) error) {
+	r.mu.Lock()
+	r.causeFor = fn
+	r.mu.Unlock()
+}
+
+// SetClusterCanceller installs the cross-replica fallback. Called from main.go
+// in cluster mode after the backplane is wired; not for mid-flight swaps.
+func (r *Registry) SetClusterCanceller(c ClusterCanceller) {
+	r.mu.Lock()
+	r.cluster = c
+	r.mu.Unlock()
 }
 
 // Arm registers cancel as run_id's live per-turn token and returns a disarm that
@@ -65,12 +115,45 @@ func (r *Registry) Arm(runID string, cancel context.CancelCauseFunc) func() {
 	}
 }
 
-// Cancel fires run_id's armed token with cause and removes it, returning whether
-// a token was armed. Removing on fire makes a double-cancel idempotent: the
-// second call finds nothing armed and returns false (the handler 409s it), so a
-// cancel that races the turn ending / a repeat click can never double-fire.
-func (r *Registry) Cancel(runID string, cause error) bool {
+// Cancel is the handler-facing entry: it fires run_id's armed per-turn token with
+// the operator reason and reports whether a cancel fired. On a LOCAL hit it fires
+// here (building the proper loop cause via causeFor). On a local miss in cluster
+// mode it delegates to the ClusterCanceller, which routes to the owning replica
+// by runs.replica_id. Single-process (cluster == nil) → a local miss is
+// (false, nil), byte-identical to P1.
+func (r *Registry) Cancel(ctx context.Context, runID, reason string) (bool, error) {
+	if r.CancelLocal(runID, reason) {
+		return true, nil
+	}
 	r.mu.Lock()
+	cluster := r.cluster
+	r.mu.Unlock()
+	if cluster == nil {
+		return false, nil
+	}
+	return cluster.CancelRemote(ctx, runID, reason)
+}
+
+// CancelLocal fires run_id's LOCALLY-armed token with the operator reason and
+// removes it, returning whether a token was armed here. It NEVER delegates to the
+// cluster (the CancelLocal lesson — a cluster subscriber dispatching an inbound
+// backplane event must not re-broadcast on a local miss), so it is what both the
+// handler's local fast path and the coordinator's owning-side subscriber call.
+//
+// Removing on fire makes a double-cancel idempotent: the second call finds
+// nothing armed and returns false (the handler 409s it), so a cancel that races
+// the turn ending / a repeat click can never double-fire.
+func (r *Registry) CancelLocal(runID, reason string) bool {
+	r.mu.Lock()
+	causeFor := r.causeFor
+	if causeFor == nil {
+		// Defensive floor — never hit in production (the server wires SetCauseFor
+		// at construction). Without a cause builder we can't produce a cause the
+		// loop recognizes as a turn-cancel, and firing a wrong cause would
+		// TERMINATE the run instead of parking it. Refuse, leaving the token armed.
+		r.mu.Unlock()
+		return false
+	}
 	e, ok := r.armed[runID]
 	if ok {
 		delete(r.armed, runID)
@@ -79,7 +162,7 @@ func (r *Registry) Cancel(runID string, cause error) bool {
 	if !ok {
 		return false
 	}
-	e.cancel(cause)
+	e.cancel(causeFor(reason))
 	return true
 }
 

--- a/internal/turncancel/registry_test.go
+++ b/internal/turncancel/registry_test.go
@@ -3,15 +3,48 @@ package turncancel
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 )
 
 var errTest = errors.New("turn cancelled by operator")
 
-// TestRegistry_CancelFiresArmedTokenWithCause verifies Arm→Cancel delivers the
-// cause to the armed context and reports that a token was armed.
-func TestRegistry_CancelFiresArmedTokenWithCause(t *testing.T) {
+// causeForTest mirrors loop.TurnCancelCause: it wraps errTest so errors.Is holds
+// and the reason string is recoverable, without importing internal/loop.
+func causeForTest(reason string) error {
+	if reason == "" {
+		return errTest
+	}
+	return fmt.Errorf("%w: %s", errTest, reason)
+}
+
+func newReg() *Registry {
 	r := NewRegistry()
+	r.SetCauseFor(causeForTest)
+	return r
+}
+
+// fakeCluster is a stub ClusterCanceller recording the delegated CancelRemote.
+type fakeCluster struct {
+	calls  int
+	runID  string
+	reason string
+	found  bool
+	err    error
+}
+
+func (f *fakeCluster) CancelRemote(_ context.Context, runID, reason string) (bool, error) {
+	f.calls++
+	f.runID, f.reason = runID, reason
+	return f.found, f.err
+}
+
+// TestRegistry_CancelLocalFiresArmedTokenWithCause verifies Arm→CancelLocal
+// delivers the causeFor-built cause (carrying the reason) to the armed context
+// and reports that a token was armed.
+func TestRegistry_CancelLocalFiresArmedTokenWithCause(t *testing.T) {
+	r := newReg()
 	ctx, cancel := context.WithCancelCause(context.Background())
 	defer cancel(nil)
 	r.Arm("run-1", cancel)
@@ -19,51 +52,55 @@ func TestRegistry_CancelFiresArmedTokenWithCause(t *testing.T) {
 	if !r.IsArmed("run-1") {
 		t.Fatal("IsArmed false right after Arm")
 	}
-	if got := r.Cancel("run-1", errTest); !got {
-		t.Fatal("Cancel returned false for an armed run")
+	if got := r.CancelLocal("run-1", "too slow"); !got {
+		t.Fatal("CancelLocal returned false for an armed run")
 	}
 	if err := ctx.Err(); err == nil {
-		t.Fatal("armed context not cancelled after Cancel")
+		t.Fatal("armed context not cancelled after CancelLocal")
 	}
-	if cause := context.Cause(ctx); !errors.Is(cause, errTest) {
-		t.Fatalf("cause = %v, want %v", cause, errTest)
+	cause := context.Cause(ctx)
+	if !errors.Is(cause, errTest) {
+		t.Fatalf("cause = %v, want wrap of errTest", cause)
 	}
-}
-
-// TestRegistry_CancelUnarmedReturnsFalse verifies a Cancel with no armed token
-// (never armed / already fired / already disarmed) reports false so the handler
-// can 409 it.
-func TestRegistry_CancelUnarmedReturnsFalse(t *testing.T) {
-	r := NewRegistry()
-	if r.Cancel("missing", errTest) {
-		t.Fatal("Cancel returned true for an unarmed run")
+	if !strings.Contains(cause.Error(), "too slow") {
+		t.Fatalf("cause %q did not carry the operator reason", cause.Error())
 	}
 }
 
-// TestRegistry_CancelIsIdempotent verifies a second Cancel after the token fired
-// finds nothing armed — a repeated stop click / a cancel racing the turn end is
-// a no-op, not a double-fire.
-func TestRegistry_CancelIsIdempotent(t *testing.T) {
-	r := NewRegistry()
+// TestRegistry_CancelLocalUnarmedReturnsFalse verifies a CancelLocal with no
+// armed token (never armed / already fired / already disarmed) reports false so
+// the handler can 409 it.
+func TestRegistry_CancelLocalUnarmedReturnsFalse(t *testing.T) {
+	r := newReg()
+	if r.CancelLocal("missing", "x") {
+		t.Fatal("CancelLocal returned true for an unarmed run")
+	}
+}
+
+// TestRegistry_CancelLocalIsIdempotent verifies a second CancelLocal after the
+// token fired finds nothing armed — a repeated stop click / a cancel racing the
+// turn end is a no-op, not a double-fire.
+func TestRegistry_CancelLocalIsIdempotent(t *testing.T) {
+	r := newReg()
 	_, cancel := context.WithCancelCause(context.Background())
 	defer cancel(nil)
 	r.Arm("run-1", cancel)
 
-	if !r.Cancel("run-1", errTest) {
-		t.Fatal("first Cancel returned false")
+	if !r.CancelLocal("run-1", "") {
+		t.Fatal("first CancelLocal returned false")
 	}
 	if r.IsArmed("run-1") {
-		t.Fatal("token still armed after Cancel")
+		t.Fatal("token still armed after CancelLocal")
 	}
-	if r.Cancel("run-1", errTest) {
-		t.Fatal("second Cancel returned true (not idempotent)")
+	if r.CancelLocal("run-1", "") {
+		t.Fatal("second CancelLocal returned true (not idempotent)")
 	}
 }
 
 // TestRegistry_DisarmClearsArmedState verifies the disarm returned by Arm removes
-// the token so a subsequent Cancel is a no-op (the loop disarms before parking).
+// the token so a subsequent CancelLocal is a no-op (the loop disarms before parking).
 func TestRegistry_DisarmClearsArmedState(t *testing.T) {
-	r := NewRegistry()
+	r := newReg()
 	ctx, cancel := context.WithCancelCause(context.Background())
 	defer cancel(nil)
 	disarm := r.Arm("run-1", cancel)
@@ -72,11 +109,11 @@ func TestRegistry_DisarmClearsArmedState(t *testing.T) {
 	if r.IsArmed("run-1") {
 		t.Fatal("IsArmed true after disarm")
 	}
-	if r.Cancel("run-1", errTest) {
-		t.Fatal("Cancel fired after disarm")
+	if r.CancelLocal("run-1", "") {
+		t.Fatal("CancelLocal fired after disarm")
 	}
 	if ctx.Err() != nil {
-		t.Fatal("context cancelled despite disarm (no Cancel)")
+		t.Fatal("context cancelled despite disarm (no CancelLocal)")
 	}
 }
 
@@ -84,8 +121,8 @@ func TestRegistry_DisarmClearsArmedState(t *testing.T) {
 // generation invariant: after a turn re-arms, the PREVIOUS turn's disarm must not
 // delete the new turn's live token (a missed disarm can't disable the run).
 func TestRegistry_StaleDisarmDoesNotClobberReArmedToken(t *testing.T) {
-	r := NewRegistry()
-	_, cancel1 := context.WithCancelCause(context.Background())
+	r := newReg()
+	ctx1, cancel1 := context.WithCancelCause(context.Background())
 	defer cancel1(nil)
 	disarm1 := r.Arm("run-1", cancel1)
 
@@ -99,18 +136,22 @@ func TestRegistry_StaleDisarmDoesNotClobberReArmedToken(t *testing.T) {
 	if !r.IsArmed("run-1") {
 		t.Fatal("stale disarm cleared the re-armed token")
 	}
-	if !r.Cancel("run-1", errTest) {
-		t.Fatal("Cancel found no armed token after re-arm")
+	if !r.CancelLocal("run-1", "") {
+		t.Fatal("CancelLocal found no armed token after re-arm")
 	}
-	if context.Cause(ctx2) == nil || !errors.Is(context.Cause(ctx2), errTest) {
+	// Turn 2's ctx is the one fired; turn 1's is left untouched.
+	if ctx2.Err() == nil || !errors.Is(context.Cause(ctx2), errTest) {
 		t.Fatalf("re-armed token (turn 2) not the one fired: cause=%v", context.Cause(ctx2))
+	}
+	if ctx1.Err() != nil {
+		t.Fatal("turn 1 ctx fired despite being overwritten")
 	}
 }
 
 // TestRegistry_RunsAreIndependent verifies tokens are keyed by run_id — cancelling
 // one run does not disturb another.
 func TestRegistry_RunsAreIndependent(t *testing.T) {
-	r := NewRegistry()
+	r := newReg()
 	ctxA, cancelA := context.WithCancelCause(context.Background())
 	defer cancelA(nil)
 	ctxB, cancelB := context.WithCancelCause(context.Background())
@@ -118,7 +159,7 @@ func TestRegistry_RunsAreIndependent(t *testing.T) {
 	r.Arm("run-a", cancelA)
 	r.Arm("run-b", cancelB)
 
-	r.Cancel("run-a", errTest)
+	r.CancelLocal("run-a", "")
 	if ctxA.Err() == nil {
 		t.Fatal("run-a not cancelled")
 	}
@@ -127,5 +168,93 @@ func TestRegistry_RunsAreIndependent(t *testing.T) {
 	}
 	if !r.IsArmed("run-b") {
 		t.Fatal("run-b disarmed by a run-a cancel")
+	}
+}
+
+// TestRegistry_CancelLocalRefusesWithoutCauseFor verifies the fail-safe: a
+// registry with no causeFor wired refuses to fire (a wrong/nil cause would
+// terminate the run) and LEAVES the token armed for a later, correctly-wired fire.
+func TestRegistry_CancelLocalRefusesWithoutCauseFor(t *testing.T) {
+	r := NewRegistry() // no SetCauseFor
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	r.Arm("run-1", cancel)
+
+	if r.CancelLocal("run-1", "x") {
+		t.Fatal("CancelLocal fired without a causeFor")
+	}
+	if ctx.Err() != nil {
+		t.Fatal("context cancelled despite no causeFor")
+	}
+	if !r.IsArmed("run-1") {
+		t.Fatal("token dropped without firing (must stay armed for a later fire)")
+	}
+}
+
+// TestRegistry_CancelDelegatesToClusterOnLocalMiss verifies the P3a delegation:
+// a Cancel that misses the local armed map routes to the ClusterCanceller (the
+// owning-replica route) and returns its found result.
+func TestRegistry_CancelDelegatesToClusterOnLocalMiss(t *testing.T) {
+	r := newReg()
+	fc := &fakeCluster{found: true}
+	r.SetClusterCanceller(fc)
+
+	fired, err := r.Cancel(context.Background(), "remote-run", "operator stop")
+	if err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if !fired {
+		t.Fatal("Cancel did not report the remote fire")
+	}
+	if fc.calls != 1 || fc.runID != "remote-run" || fc.reason != "operator stop" {
+		t.Fatalf("CancelRemote calls=%d runID=%q reason=%q, want 1/remote-run/operator stop", fc.calls, fc.runID, fc.reason)
+	}
+}
+
+// TestRegistry_CancelSingleProcessLocalMissIsFalse verifies byte-identical P1
+// behaviour: with no ClusterCanceller wired, a local miss returns (false, nil)
+// and never touches the cluster path.
+func TestRegistry_CancelSingleProcessLocalMissIsFalse(t *testing.T) {
+	r := newReg()
+	fired, err := r.Cancel(context.Background(), "ghost", "x")
+	if fired || err != nil {
+		t.Fatalf("Cancel(ghost) = (%v,%v), want (false,nil)", fired, err)
+	}
+}
+
+// TestRegistry_CancelLocalHitDoesNotDelegate verifies a locally-armed run fires
+// LOCALLY and never reaches the cluster (no needless remote round-trip).
+func TestRegistry_CancelLocalHitDoesNotDelegate(t *testing.T) {
+	r := newReg()
+	fc := &fakeCluster{found: true}
+	r.SetClusterCanceller(fc)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	r.Arm("run-1", cancel)
+
+	fired, err := r.Cancel(context.Background(), "run-1", "stop")
+	if err != nil || !fired {
+		t.Fatalf("Cancel(local) = (%v,%v), want (true,nil)", fired, err)
+	}
+	if fc.calls != 0 {
+		t.Fatalf("cluster CancelRemote called %d times for a local hit, want 0", fc.calls)
+	}
+	if ctx.Err() == nil {
+		t.Fatal("local armed token not fired")
+	}
+}
+
+// TestRegistry_CancelPropagatesClusterError verifies a cluster error surfaces to
+// the caller (the handler maps it to 500) rather than being swallowed as a miss.
+func TestRegistry_CancelPropagatesClusterError(t *testing.T) {
+	r := newReg()
+	boom := errors.New("backplane down")
+	r.SetClusterCanceller(&fakeCluster{err: boom})
+	fired, err := r.Cancel(context.Background(), "remote-run", "")
+	if fired {
+		t.Fatal("Cancel reported fired on a cluster error")
+	}
+	if !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want %v", err, boom)
 	}
 }


### PR DESCRIPTION
## Why

RFC BH P3a (`/loomcycle/rfcs/turn-scoped-cancellation` §9): make `POST /v1/runs/{id}/cancel` work cluster-wide. P1's turn-cancel registry is single-process, so a cancel that lands on a replica not running the target run 409s `not_mid_turn` even though the run is mid-turn on another replica. This routes the cancel to the run's owning replica by `runs.replica_id` — the exact owner-routing steer already does.

**Decline needs no cross-replica work** (verified): P2's decline writes the terminal status to the shared store, and a blocked Question tool on any replica wakes via the 15s store-poll backstop + the backplane-backed interruption bus. So this PR is turn-cancel only.

## What (mirrors the steer coordinator + the cancel registry's ClusterCanceller)

- **`internal/turncancel`** — added a leaf-local `ClusterCanceller interface { CancelRemote(ctx, runID, reason string) (found, err) }` + `SetClusterCanceller` + an injected `causeFor` (`SetCauseFor(loop.TurnCancelCause)`) so the leaf stays free of `internal/loop` **and** `internal/coord`. The **wire carries the reason string**; each replica rebuilds the proper loop cause locally. `Cancel(ctx, runID, reason)` fires locally on a hit, else delegates to the cluster (nil ⇒ single-process, **byte-identical to P1**). `CancelLocal(runID, reason)` never delegates — the subscriber uses it (the "CancelLocal lesson", no re-broadcast). Nil-`causeFor` fail-safe: refuse to fire and leave the token armed (firing an unrecognized cause would *terminate* the run, not park it).
- **`internal/coord/turncancel_coordinator.go`** (new) — a clone of `steer_coordinator.go`: topics `loomcycle.turncancel`/`.ack`; `CancelRemote` does `GetRun` → owner-routing short-circuits (unknown / terminal / self-owned / dead-owner → `found=false`) → publish → wait ack; `RunTurnCancelSubscriber` fires the local armed token via `CancelLocal` and **acks only when it actually fired**; `RunTurnCancelAckSubscriber` fans acks. Compile-checked against `turncancel.ClusterCanceller`.
- **handler** `handleCancelTurn` — two paths: **local fast path** (steer-registry hit → P1 flow, byte-identical); **cross-replica fallback** (steer-registry miss → gate ownership via the **shared store** `tenantStore.GetRun` (opaque 404, works cluster-wide unlike the per-replica steer registry) → route via `Cancel`). Single-process folds the miss back to P1's `no in-flight run` 404.
- **`cmd/loomcycle/main.go`** — wires the coordinator in the existing cluster block beside cancel/steer (guarded; reuses the backplane/`pgStore`/`replicaStore`/ackTimeout).

## What was tested
- `go test ./...` — clean (85 packages), independently re-run; `go build ./...`, gofmt clean; **`go test -race ./internal/coord ./internal/turncancel`** clean.
- Regression tests, each **fail-before verified**: registry local-miss delegates to the cluster hook (+ propagates its error); the subscriber fires a remote owner's armed token (ack round-trip; a not-mid-turn owner never acks → originator times out to `found=false`); the handler routes cross-replica + parks; short-circuits (non-running / self-owned / dead-owner); single-process byte-identical to P1 (incl. the P1 handler tests).

**Note (out of scope):** the existing **steer** HTTP path (`SteerRun`) appears to have the same latent cross-replica gap — it early-returns 404 on a local `steerReg.Get` miss before `Push`'s cross-replica delegation can run — so steer's own cross-replica delegation may be effectively dead on the HTTP path. Not touched here; worth a separate look.

**Next (RFC BH P3b):** gRPC `CancelTurn` + `ResolveInterrupt`(disposition) RPCs + TS (`cancelTurn`/`cancelInterrupt`) + Python adapters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)