### PR TITLE
feat(bundles): chat — add HTTP tool + chat/local-small agent

### DIFF
--- a/bundles/chat/loomcycle.yaml
+++ b/bundles/chat/loomcycle.yaml
@@ -31,7 +31,7 @@ agents:
     # (Anthropic defaults to 8192; ollama generates until the context fills).
     # Pinning a value would only IMPOSE a per-reply cap, not add headroom.
     unbounded_iterations: true              # interactive chat parks at end_turn
-    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, Bashbox, Bash, Document, Memory, Path, Skill, Interruption]
+    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, HTTP, Bashbox, Bash, Document, Memory, Path, Skill, Interruption]
     memory_scopes: [user]
     sql_scopes: [user]                      # Document is SQL-Memory-backed
     sampling:
@@ -71,14 +71,14 @@ agents:
     # max_tokens OMITTED — ollama-local generates until the context window fills
     # (set the window via LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX, e.g. 131072 for 128K).
     unbounded_iterations: true
-    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, Bashbox, Bash, Document, Memory, Path, Skill, Interruption]
+    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, HTTP, Bashbox, Bash, Document, Memory, Path, Skill, Interruption]
     memory_scopes: [user]
     sql_scopes: [user]
     sampling:
       temperature: 0.7
     compaction:
       enabled: true
-      autocompact_at_pct: 80
+      autocompact_at_pct: 70
     system_prompt: |
       You are CHAT-LOCAL, the same helpful general-purpose assistant as CHAT, but
       you run entirely on the operator's LOCAL model (ollama-local) — nothing you
@@ -99,3 +99,39 @@ agents:
       - Ask a clarifying question when the request is ambiguous.
       - You run on a local model, so keep tool use deliberate and reasoning
         efficient — prefer one focused search/read over many speculative calls.
+
+  chat/local-small:
+    model: local-small                     # → ollama-local; local-only, no cloud fallback
+    effort: medium
+    # max_tokens OMITTED — ollama-local generates until the context window fills
+    # (set the window via LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX, e.g. 131072 for 128K).
+    unbounded_iterations: true
+    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, HTTP, Bashbox, Bash, Document, Memory, Path, Skill, Interruption]
+    memory_scopes: [user]
+    sql_scopes: [user]
+    sampling:
+      temperature: 0.7
+    compaction:
+      enabled: true
+      autocompact_at_pct: 70
+    system_prompt: |
+      You are CHAT-LOCAL, the same helpful general-purpose assistant as CHAT, but
+      you run entirely on the operator's LOCAL model (ollama-local) — nothing you
+      process leaves the box. Favor this for private or offline work.
+
+      ## Tools
+      - Web: WebSearch for current information, WebFetch to read a specific URL.
+      - Files: Read / Write / Edit / Grep / Glob inside your bound working volume
+        (Grep/Glob to find, Read to inspect, Edit for in-place changes).
+      - Shell: Bashbox is a sandboxed shell (rooted at your volume, no network);
+        git, gh, curl, jq, rsync are available via its fallback. Bash is the
+        unsandboxed escape hatch — prefer Bashbox.
+      - Document / Memory / Path for structured documents, durable user-scope
+        memory, and the virtual filesystem.
+
+      ## Style
+      - Be concise and concrete; lead with the answer, then the reasoning.
+      - Ask a clarifying question when the request is ambiguous.
+      - You run on a local model, so keep tool use deliberate and reasoning
+        efficient — prefer one focused search/read over many speculative calls.
+

--- a/cmd/loomcycle/embedded/bundles/chat.yaml
+++ b/cmd/loomcycle/embedded/bundles/chat.yaml
@@ -31,7 +31,7 @@ agents:
     # (Anthropic defaults to 8192; ollama generates until the context fills).
     # Pinning a value would only IMPOSE a per-reply cap, not add headroom.
     unbounded_iterations: true              # interactive chat parks at end_turn
-    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, Bashbox, Bash, Document, Memory, Path, Skill, Interruption]
+    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, HTTP, Bashbox, Bash, Document, Memory, Path, Skill, Interruption]
     memory_scopes: [user]
     sql_scopes: [user]                      # Document is SQL-Memory-backed
     sampling:
@@ -71,14 +71,14 @@ agents:
     # max_tokens OMITTED — ollama-local generates until the context window fills
     # (set the window via LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX, e.g. 131072 for 128K).
     unbounded_iterations: true
-    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, Bashbox, Bash, Document, Memory, Path, Skill, Interruption]
+    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, HTTP, Bashbox, Bash, Document, Memory, Path, Skill, Interruption]
     memory_scopes: [user]
     sql_scopes: [user]
     sampling:
       temperature: 0.7
     compaction:
       enabled: true
-      autocompact_at_pct: 80
+      autocompact_at_pct: 70
     system_prompt: |
       You are CHAT-LOCAL, the same helpful general-purpose assistant as CHAT, but
       you run entirely on the operator's LOCAL model (ollama-local) — nothing you
@@ -99,3 +99,39 @@ agents:
       - Ask a clarifying question when the request is ambiguous.
       - You run on a local model, so keep tool use deliberate and reasoning
         efficient — prefer one focused search/read over many speculative calls.
+
+  chat/local-small:
+    model: local-small                     # → ollama-local; local-only, no cloud fallback
+    effort: medium
+    # max_tokens OMITTED — ollama-local generates until the context window fills
+    # (set the window via LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX, e.g. 131072 for 128K).
+    unbounded_iterations: true
+    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, HTTP, Bashbox, Bash, Document, Memory, Path, Skill, Interruption]
+    memory_scopes: [user]
+    sql_scopes: [user]
+    sampling:
+      temperature: 0.7
+    compaction:
+      enabled: true
+      autocompact_at_pct: 70
+    system_prompt: |
+      You are CHAT-LOCAL, the same helpful general-purpose assistant as CHAT, but
+      you run entirely on the operator's LOCAL model (ollama-local) — nothing you
+      process leaves the box. Favor this for private or offline work.
+
+      ## Tools
+      - Web: WebSearch for current information, WebFetch to read a specific URL.
+      - Files: Read / Write / Edit / Grep / Glob inside your bound working volume
+        (Grep/Glob to find, Read to inspect, Edit for in-place changes).
+      - Shell: Bashbox is a sandboxed shell (rooted at your volume, no network);
+        git, gh, curl, jq, rsync are available via its fallback. Bash is the
+        unsandboxed escape hatch — prefer Bashbox.
+      - Document / Memory / Path for structured documents, durable user-scope
+        memory, and the virtual filesystem.
+
+      ## Style
+      - Be concise and concrete; lead with the answer, then the reasoning.
+      - Ask a clarifying question when the request is ambiguous.
+      - You run on a local model, so keep tool use deliberate and reasoning
+        efficient — prefer one focused search/read over many speculative calls.
+


### PR DESCRIPTION
## Why

Operator update to the bundled `chat` agents (requested for the v1.22.0 release).

## What
- **HTTP tool** granted to `chat/medium` + `chat/local` (alongside `WebFetch`) — a chat agent can now call a JSON/API endpoint directly, not only fetch a page.
- `chat/local` **`autocompact_at_pct` 80 → 70** — compact earlier on the slower local model (per the local-model prefill-cost guidance in `docs/CONFIGURATION.md`).
- New **`chat/local-small`** agent — the same local assistant pinned to the `local-small` alias (ollama-local / `gemma4:9b`, from the base preset) for a lighter local model.

## The two-copy sync (v1.20.1 lesson)
The chat bundle has **two byte-identical copies** — the source `bundles/chat/loomcycle.yaml` and the `//go:embed` mirror `cmd/loomcycle/embedded/bundles/chat.yaml` that the **deployed binary actually reads**. The incoming edit touched only the source; this PR applies the identical change to the mirror too (the v1.20.1 boot-crash was exactly a bundle edited in one copy but not the other). Both are in sync here.

## What was tested
- **`TestEmbedded_DefaultStackValidates`** — loads the full default preset stack (`base,document-agent,chat,agent-teams,team-examples`) through `validate()`; **passes** with the new agent (the boot-safety guard).
- `go test ./cmd/loomcycle/...` (incl. the embedded presets_test grant checks) + `go build` clean.
- `agents list` over `base,chat`: `chat/local` + `chat/local-small` resolve (ollama-local); `local-small` maps to the defined base-preset alias. (`chat/medium` shows "no provider resolved" only because this is a keyless shell — pre-existing, `validate()` is static and unaffected.)

Note: `chat/local-small`'s `system_prompt` is copied verbatim from `chat/local` (still says "You are CHAT-LOCAL") — cosmetic, left as authored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)