### PR TITLE
feat(deploy): loomcycle-toolbox image with a dev toolchain

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -176,6 +176,55 @@ dockers:
       - "--label=org.opencontainers.image.licenses=Apache-2.0"
     goarch: arm64
 
+  # loomcycle-toolbox — the SAME binary on a non-distroless Debian base with a
+  # dev toolchain (Python/Go/Rust/C++/Node + git/gh/curl) so agents can run
+  # scripts + compile/test code via Bash / Bashbox fallback. Weak isolation
+  # (code runs in loomcycle's own container) — single-tenant/trusted only; see
+  # Dockerfile.toolbox + docs/TOOLBOX_IMAGE.md. Reuses the same pre-built
+  # `loomcycle` binary (ids: [loomcycle]) — only the runtime base differs.
+  #
+  # NOTE: the toolbox layers run apt-get + toolchain downloads, so the arm64
+  # build executes under QEMU emulation on the amd64 release runner and is
+  # SLOW (tens of minutes) vs the trivial distroless COPY. Watch the release
+  # job's duration; if it times out, drop the -arm64 block + its manifest arm64
+  # entry to ship amd64-only until a native arm64 runner is available.
+  - id: loomcycle-toolbox-amd64
+    ids:
+      - loomcycle
+    image_templates:
+      - "denngubsky/loomcycle-toolbox:{{ .Version }}-amd64"
+      - "denngubsky/loomcycle-toolbox:latest-amd64"
+    dockerfile: Dockerfile.toolbox
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.title=loomcycle-toolbox"
+      - "--label=org.opencontainers.image.description=loomcycle + a developer toolchain (Python/Go/Rust/C++/Node) for single-tenant code execution"
+      - "--label=org.opencontainers.image.url=https://github.com/denn-gubsky/loomcycle"
+      - "--label=org.opencontainers.image.source=https://github.com/denn-gubsky/loomcycle"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.licenses=Apache-2.0"
+    goarch: amd64
+  - id: loomcycle-toolbox-arm64
+    ids:
+      - loomcycle
+    image_templates:
+      - "denngubsky/loomcycle-toolbox:{{ .Version }}-arm64"
+      - "denngubsky/loomcycle-toolbox:latest-arm64"
+    dockerfile: Dockerfile.toolbox
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.title=loomcycle-toolbox"
+      - "--label=org.opencontainers.image.description=loomcycle + a developer toolchain (Python/Go/Rust/C++/Node) for single-tenant code execution"
+      - "--label=org.opencontainers.image.url=https://github.com/denn-gubsky/loomcycle"
+      - "--label=org.opencontainers.image.source=https://github.com/denn-gubsky/loomcycle"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.licenses=Apache-2.0"
+    goarch: arm64
+
 # docker_manifests joins per-arch images into one multi-arch manifest
 # the operator pulls with `docker pull denngubsky/loomcycle:vX.Y.Z`
 # regardless of their host arch.
@@ -188,3 +237,11 @@ docker_manifests:
     image_templates:
       - "denngubsky/loomcycle:latest-amd64"
       - "denngubsky/loomcycle:latest-arm64"
+  - name_template: "denngubsky/loomcycle-toolbox:{{ .Version }}"
+    image_templates:
+      - "denngubsky/loomcycle-toolbox:{{ .Version }}-amd64"
+      - "denngubsky/loomcycle-toolbox:{{ .Version }}-arm64"
+  - name_template: "denngubsky/loomcycle-toolbox:latest"
+    image_templates:
+      - "denngubsky/loomcycle-toolbox:latest-amd64"
+      - "denngubsky/loomcycle-toolbox:latest-arm64"

--- a/Dockerfile.toolbox
+++ b/Dockerfile.toolbox
@@ -1,0 +1,98 @@
+# Dockerfile.toolbox — goreleaser variant, NON-distroless developer-toolbox image.
+#
+# Ships the SAME statically-built loomcycle binary as the distroless image, but
+# on a shell-bearing Debian base preloaded with a development toolchain
+# (Python, Go, Rust, C/C++, Node + npm, git, gh, curl). Agents can then run
+# scripts and compile/test code via the Bash tool (LOOMCYCLE_BASH_ENABLED=1)
+# or Bashbox's operator-allowlisted host-command fallback — neither of which
+# works in the distroless image, which has no shell and no compilers.
+#
+# ⚠️  WEAK ISOLATION — READ BEFORE USE.
+# Code runs in loomcycle's OWN container, NOT a per-session sandbox: a command
+# can reach anything the loomcycle process can (mounted volumes, env, network).
+# Use this image ONLY for single-tenant, trusted deployments — the same trust
+# boundary an operator already accepts by enabling the Bash tool / Bashbox
+# host-command fallback. For untrusted or multi-tenant code execution use the
+# builder-sidecar sandbox (docs/TOOLBOX_IMAGE.md → "When NOT to use this"),
+# which runs each session in an isolated, ephemeral, network-off container.
+#
+# Like Dockerfile.release, this variant COPIES the pre-built binary rather than
+# compiling — goreleaser builds every arch in its `builds:` stage. Referenced
+# by .goreleaser.yaml's dockers[] (loomcycle-toolbox-*). For a local build,
+# `make build` the binary first, then `docker build -f Dockerfile.toolbox .`
+# from a context that has ./loomcycle at its root.
+#
+# Published to docker.io/denngubsky/loomcycle-toolbox.
+
+FROM debian:bookworm-slim
+
+# buildx supplies TARGETARCH (amd64 / arm64) automatically when --platform is
+# set (goreleaser passes it per image). GO_VERSION tracks the go-builder stage
+# in the main Dockerfile.
+ARG TARGETARCH
+ARG GO_VERSION=1.26.0
+
+# ---- OS packages + language toolchains --------------------------------------
+# One apt layer; lists cleaned at the end to keep the (already large) image
+# from carrying the package cache.
+RUN set -eux; \
+    apt-get update; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates curl git bash gnupg \
+        python3 python3-pip python3-venv \
+        build-essential clang make cmake pkg-config \
+        nodejs npm; \
+    # GitHub CLI (gh) from its official apt repo — the loop's git/gh workflows
+    # (ephemeral repo volumes, PR creation) rely on it.
+    mkdir -p -m 755 /etc/apt/keyrings; \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        -o /etc/apt/keyrings/githubcli-archive-keyring.gpg; \
+    chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg; \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list; \
+    apt-get update; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gh; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
+
+# ---- Go (official tarball; Debian's package lags too far behind) -------------
+# buildx sets TARGETARCH under --platform (goreleaser's path); fall back to
+# dpkg so a plain `docker build` (no buildx) also resolves the right tarball —
+# dpkg's amd64/arm64 match Go's linux-<arch> naming exactly.
+RUN set -eux; \
+    arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
+    curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${arch}.tar.gz" \
+        -o /tmp/go.tar.gz; \
+    tar -C /usr/local -xzf /tmp/go.tar.gz; \
+    rm /tmp/go.tar.gz
+
+# ---- Rust (rustup, minimal profile, shared under /usr/local) ----------------
+# Installed system-wide so the non-root runtime user can invoke + update it.
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo
+RUN set -eux; \
+    curl -fsSL https://sh.rustup.rs \
+        | sh -s -- -y --no-modify-path --profile minimal --default-toolchain stable; \
+    chmod -R go+rwX /usr/local/rustup /usr/local/cargo
+
+# ---- non-root runtime user (mirror the distroless "nonroot" posture) --------
+# uid/gid 65532 + home /home/nonroot match gcr.io/distroless/static:nonroot, so
+# config (/home/nonroot/.config/loomcycle) and data mounts carry over unchanged
+# between the distroless and toolbox images — a drop-in image swap.
+RUN set -eux; \
+    groupadd --gid 65532 nonroot; \
+    useradd --uid 65532 --gid 65532 --create-home --home-dir /home/nonroot \
+        --shell /bin/bash nonroot; \
+    install -d -o 65532 -g 65532 /home/nonroot/go
+
+# PATH must expose the toolchains to the runtime user's shell. GOPATH lands in
+# the writable home so `go install` / module cache work as uid 65532.
+ENV PATH="/usr/local/go/bin:/usr/local/cargo/bin:/home/nonroot/go/bin:${PATH}" \
+    GOPATH="/home/nonroot/go"
+
+COPY loomcycle /usr/local/bin/loomcycle
+
+USER 65532:65532
+WORKDIR /home/nonroot
+EXPOSE 8787
+ENTRYPOINT ["/usr/local/bin/loomcycle"]

--- a/docs/DOCKER_HUB_OVERVIEW.md
+++ b/docs/DOCKER_HUB_OVERVIEW.md
@@ -107,6 +107,10 @@ The compose file documents the Postgres backend upgrade path (commented out by d
 - **No `docker exec ... sh`** — distroless has no shell. Use `docker logs` to debug.
 - **OCI labels** identify source, version, commit SHA, and Apache-2.0 license for supply-chain inspectors.
 
+### Variant: `denngubsky/loomcycle-toolbox`
+
+Need agents to run scripts or compile/test code? The distroless image has no shell, Python, or compilers. `denngubsky/loomcycle-toolbox` is the **same binary on a Debian base with a dev toolchain** (Python / Go / Rust / C++ / Node + `git`/`gh`/`curl`), a drop-in image swap (same uid 65532, same mount paths). ⚠️ Weak isolation — code runs in loomcycle's own container, so **single-tenant / trusted deployments only**. See [`docs/TOOLBOX_IMAGE.md`](https://github.com/denn-gubsky/loomcycle/blob/main/docs/TOOLBOX_IMAGE.md).
+
 ## What you get inside
 
 - **`POST /v1/runs`** — run an agent with SSE event stream (tool-use loop, native cache_control on Anthropic, retries with backoff).

--- a/docs/TOOLBOX_IMAGE.md
+++ b/docs/TOOLBOX_IMAGE.md
@@ -1,0 +1,112 @@
+# The `loomcycle-toolbox` image
+
+**The default `denngubsky/loomcycle` image is distroless** — no shell, no
+package manager, no Python, no compilers ([`Dockerfile`](../Dockerfile) →
+`gcr.io/distroless/static:nonroot`). That is the right default: a ~40 MB image
+with almost no attack surface. But it means an agent **cannot run a script or
+compile code** — the `Bash` tool execs `/bin/sh`, which doesn't exist there, and
+`Bashbox` (the pure-Go shell) has no real toolchain to reach.
+
+`denngubsky/loomcycle-toolbox` is the **same loomcycle binary on a non-distroless
+Debian base with a development toolchain baked in** (Python, Go, Rust, C/C++,
+Node + npm, plus `git`, `gh`, `curl`). Swap the image and your agents can run
+`python3`, `go build`, `cargo test`, `npm ci`, `gcc`, etc. — no loomcycle code
+change, no sidecar.
+
+**Thesis:** use the toolbox image when you want a trusted single-tenant deploy
+to run code the easy way; use the distroless image (plus the builder-sidecar
+sandbox) when isolation matters.
+
+---
+
+## ⚠️ When NOT to use this — isolation
+
+The toolbox image runs agent code **inside loomcycle's own container**. There is
+**no per-command sandbox**: a command reaches everything the loomcycle process
+can — every mounted volume, the process environment, and the network. This is
+the *same* trust boundary you already accept by enabling the `Bash` tool or the
+Bashbox host-command fallback (see `CLAUDE.md` rule #7 / `docs/TOOLS.md`), just
+with a real toolchain behind it.
+
+That is acceptable for a **single-tenant, trusted** deployment (e.g. your own
+local-agent fan-out). It is **not** safe for:
+
+- untrusted prompts / code you would not run on your own machine,
+- multi-tenant deployments where one tenant's code must not see another's data.
+
+For those, keep the distroless image and run each code-execution session in an
+isolated, ephemeral, network-off container via the **builder-sidecar sandbox**
+(a separate, upcoming component — a sidecar owns podman + tmpfs + gVisor and
+exposes `sandbox_*` tools; loomcycle stays distroless and drives it over MCP).
+
+---
+
+## What's inside
+
+| Toolchain | Provided by |
+|---|---|
+| Python 3 + `pip` + `venv` | Debian packages |
+| Go | official tarball at `/usr/local/go` (`GOPATH=/home/nonroot/go`) |
+| Rust + Cargo | `rustup` (stable, minimal), system-wide under `/usr/local` |
+| C / C++ | `build-essential` (gcc/g++/make), `clang`, `cmake`, `pkg-config` |
+| Node + npm | Debian packages |
+| `git`, `gh`, `curl` | for cloning, PRs, and agent HTTP/API calls |
+
+- **User:** `nonroot`, uid/gid **65532**, home `/home/nonroot` — identical to the
+  distroless image, so config (`/home/nonroot/.config/loomcycle`) and data mounts
+  carry over unchanged. The image swap is drop-in.
+- **Architectures:** `linux/amd64` + `linux/arm64`.
+- **Size:** large (a full toolchain — expect several hundred MB), the deliberate
+  cost of a real dev environment vs the ~40 MB distroless image.
+
+---
+
+## Using it
+
+Two ways to give an agent the toolchain, both already in loomcycle — the toolbox
+image just makes the underlying binaries exist:
+
+1. **The `Bash` tool** — set `LOOMCYCLE_BASH_ENABLED=1` and bind the agent a
+   `volumes:` working directory. `Bash` now has a real `/bin/sh` + the toolchain.
+2. **Bashbox host-command fallback** — allowlist the binaries you want
+   (`LOOMCYCLE_BASHBOX_ENABLED=1`,
+   `LOOMCYCLE_BASHBOX_FALLBACK_COMMANDS=python3,go,cargo,npm,gcc,git,gh`,
+   plus `..._FALLBACK_ALLOWED_ENV` / `..._FALLBACK_ALLOWED_CREDS` as needed).
+
+Both require the agent to have a `volumes:` binding — that bound directory is the
+compile/test workspace (see `docs/TOOLS.md` on volumes).
+
+### Docker Compose (image swap)
+
+Take your existing compose and change only the image tag on the loomcycle
+service (everything else — env, volumes, ports — is unchanged):
+
+```yaml
+services:
+  loomcycle:
+    image: denngubsky/loomcycle-toolbox:latest   # was denngubsky/loomcycle:latest
+    environment:
+      LOOMCYCLE_LISTEN_ADDR: 0.0.0.0:8787
+      LOOMCYCLE_BASH_ENABLED: "1"                 # or the Bashbox fallback vars
+      # ... your existing provider keys / auth token
+    volumes:
+      - ./config:/home/nonroot/.config/loomcycle:ro
+      - ./data:/home/nonroot/.local/share/loomcycle
+      - ./work:/mnt/work                          # agent compile/test workspace
+```
+
+Then declare `/mnt/work` as a `volumes:` binding in your loomcycle config and
+add it to the agents that should run code.
+
+---
+
+## Tags & registry
+
+| Tag | Points at |
+|---|---|
+| `denngubsky/loomcycle-toolbox:latest` | most recent stable |
+| `denngubsky/loomcycle-toolbox:vX.Y.Z` | exact pin (recommended for prod) |
+
+The toolbox image is versioned in lockstep with the main image — the same `vX.Y.Z`
+tag builds both. (Docker Hub strips the hyphen from `denn-gubsky` → `denngubsky`;
+GHCR keeps it.)


### PR DESCRIPTION
## Why

The default `denngubsky/loomcycle` image is **distroless** (`gcr.io/distroless/static:nonroot`) — no shell, no Python, no compilers. That's the right default (~40 MB, tiny attack surface), but it means an agent **cannot run a script or compile code**: the `Bash` tool execs `/bin/sh` (absent in distroless) and `Bashbox` (pure-Go gbash) has no real toolchain to reach. The concrete pain: on the TrueNAS / JobEmber deploy, models can't run `python3`.

## What

A second, **non-distroless** build target — `denngubsky/loomcycle-toolbox` — carrying the **same** loomcycle binary on a Debian base preloaded with a dev toolchain, so the *existing* `Bash` tool / Bashbox host-command fallback just work. **No loomcycle code change.**

- **`Dockerfile.toolbox`** — `debian:bookworm-slim` + Python 3, Go, Rust (rustup), C/C++ (`build-essential`/clang/cmake), Node + npm, `git`, `gh`, `curl`. Runs as `nonroot` / **uid 65532** with home `/home/nonroot` — identical to the distroless image, so config + data mounts carry over unchanged (**drop-in image swap**). Arch resolved from buildx `TARGETARCH` with a `dpkg` fallback so a plain `docker build` also works.
- **`.goreleaser.yaml`** — `loomcycle-toolbox` amd64 + arm64 `dockers` entries + multi-arch manifests, reusing the same pre-built binary (`ids: [loomcycle]`); only the runtime base differs.
- **`docs/TOOLBOX_IMAGE.md`** + a pointer in the Docker Hub overview.

### Isolation posture (important)
Code runs in **loomcycle's own container** — there is no per-command sandbox. This is the **same trust boundary** an operator already accepts by enabling the Bash tool / Bashbox fallback, just with a real toolchain behind it. Documented loudly as **single-tenant / trusted only**. Untrusted or multi-tenant code execution is the job of the upcoming **builder-sidecar sandbox** (keeps the distroless image; isolates each session in an ephemeral, network-off container) — that's the RFC-gated follow-up, not this PR.

## What was tested

- `goreleaser check` → **config schema valid**. The command's non-zero exit is the **pre-existing** `dockers`/`docker_manifests`/`brews` *deprecation* gate (present before this change), not a problem with the added entries.
- Re-read the Dockerfile against `Dockerfile.release`'s binary-copy pattern; hardened arch resolution for both buildx and plain builds.
- ⚠️ **Not built here** — the local Docker daemon isn't running, so the image itself was not built/run. **Please watch the first release job**: the toolbox **arm64** layer runs `apt-get` + toolchain downloads under **QEMU emulation** on the amd64 runner and will be slow (tens of minutes) vs the trivial distroless COPY. If it times out, drop the `loomcycle-toolbox-arm64` `dockers` block + its manifest arm64 entry to ship amd64-only until a native arm64 runner is available (noted inline in `.goreleaser.yaml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)