### PR TITLE
feat(sandbox): builder sidecar for isolated code execution (RFC BI P1)

### DIFF
--- a/deploy/builder/.gitignore
+++ b/deploy/builder/.gitignore
@@ -1,0 +1,3 @@
+# Compiled sidecar binary (produced by `go build` in this dir).
+/builder
+/loomcycle-builder

--- a/deploy/builder/Dockerfile
+++ b/deploy/builder/Dockerfile
@@ -1,0 +1,41 @@
+# loomcycle-builder — the sandbox sidecar image.
+#
+# Runs the sidecar (this module) on a podman-capable base so it can launch
+# per-session sandbox containers. loomcycle itself stays distroless and dials
+# this over HTTP-MCP; ALL container/isolation complexity lives here.
+#
+# ⚠️  Nested containers: running podman INSIDE this container needs a host
+# runtime that supports it. Recommended: the Sysbox runtime (secure, rootless
+# nested containers). Fallback: run this sidecar --privileged (accept the risk;
+# common on TrueNAS which lacks Sysbox). See README.md → "Deploy".
+#
+# Build:
+#   docker build -t denngubsky/loomcycle-builder:dev --build-arg VERSION=dev .
+
+# ---- Stage 1: build the sidecar (stdlib only, static) -----------------------
+FROM golang:1.26-bookworm AS build
+WORKDIR /src
+COPY go.mod ./
+COPY *.go ./
+ARG VERSION=dev
+RUN CGO_ENABLED=0 go build -trimpath \
+    -ldflags "-s -w -X main.version=${VERSION}" \
+    -o /out/loomcycle-builder .
+
+# ---- Stage 2: runtime on podman's purpose-built base ------------------------
+# quay.io/podman/stable ships podman + fuse-overlayfs + slirp4netns + the
+# rootless uid/gid mapping setup — the fiddly parts of running podman in a
+# container are already done here.
+FROM quay.io/podman/stable:latest
+
+# gVisor (runsc) for the strong-isolation runtime tier is OPTIONAL — uncomment
+# to bake it in, then set SANDBOX_RUNTIME=runsc. Left out by default to keep the
+# reference image buildable everywhere (runsc needs a compatible host kernel).
+# RUN dnf -y install runsc || (curl -fsSL https://storage.googleapis.com/gvisor/releases/release/latest/$(uname -m)/runsc -o /usr/local/bin/runsc && chmod +x /usr/local/bin/runsc)
+
+COPY --from=build /out/loomcycle-builder /usr/local/bin/loomcycle-builder
+
+EXPOSE 9000
+# SANDBOX_IMAGE (the toolchain session image) + SANDBOX_AUTH_TOKEN are required
+# at runtime — see README.md. The session image is built from ./session/Dockerfile.
+ENTRYPOINT ["/usr/local/bin/loomcycle-builder"]

--- a/deploy/builder/README.md
+++ b/deploy/builder/README.md
@@ -1,0 +1,143 @@
+# loomcycle-builder — sandbox sidecar
+
+A reference **sidecar** that gives loomcycle agents a safe, isolated, ephemeral
+place to run a real dev toolchain (Python / Go / Rust / C++ / Node) — compile,
+test, run code — **without loomcycle leaving its distroless image or touching a
+container engine**.
+
+## Why a sidecar
+
+loomcycle ships distroless (no shell, no compilers, no podman) and runs non-root
+(uid 65532) — it *cannot* run podman itself (no subuid range, no `newuidmap`),
+and mounting a host podman socket into the process that runs model-authored code
+would be ≈ host root. So the container engine lives here, in a separate service,
+and loomcycle drives it over the one distroless-safe channel it already speaks:
+**MCP over HTTP**. The sidecar owns all podman + isolation + tmpfs complexity; a
+compromised loomcycle can only call the constrained `sandbox_*` API, never craft
+a privileged container.
+
+```
+agent (loomcycle · distroless)
+   │  mcp__sandbox__sandbox_exec        (HTTP-MCP, bearer-authed)
+   ▼
+loomcycle-builder (this sidecar)  ──►  per-session container
+   rootless podman + runsc/tmpfs        --network none --read-only
+                                        --cap-drop=ALL --tmpfs /work
+```
+
+## Tools (MCP `mcp__sandbox__*`)
+
+| Tool | Purpose |
+|---|---|
+| `sandbox_open` | Create a session container; returns a `session_id`. Params: `network` (none/egress), `tmpfs_mb`, `cpu`, `mem_mb`, `pids` (all clamped to operator ceilings). |
+| `sandbox_exec` | Run a command in a session (`/work`); returns combined output + exit code. |
+| `sandbox_write` / `sandbox_read` | Put files in / pull artifacts out (paths relative to `/work`; `base64` for binary). |
+| `sandbox_close` | Destroy a session (idempotent). |
+| `sandbox_list` | List your own sessions. |
+
+Sessions are long-lived — open once, run many commands (the workspace, deps, and
+build cache persist across `sandbox_exec` calls), close when done. They also
+expire on an idle / absolute TTL, and any leftover container is reaped at sidecar
+startup (`loomcycle.managed=1` label).
+
+## Build
+
+```bash
+# The sidecar image (podman-capable):
+docker build -t denngubsky/loomcycle-builder:dev --build-arg VERSION=dev .
+
+# The session image agents run in (pin by digest in prod):
+docker build -t localhost/loomcycle-sandbox-session:latest ./session
+```
+
+## Deploy
+
+Run the sidecar on loomcycle's compose/app network, **no host port** — only
+loomcycle reaches it in-network:
+
+```yaml
+services:
+  builder-sidecar:
+    image: denngubsky/loomcycle-builder:latest
+    container_name: builder-sidecar
+    restart: unless-stopped
+    # Nested podman needs one of:
+    #   runtime: sysbox-runc        # recommended — secure nested containers
+    #   privileged: true            # fallback (accept the risk; e.g. TrueNAS)
+    runtime: sysbox-runc
+    environment:
+      SANDBOX_AUTH_TOKEN: ${LOOMCYCLE_SANDBOX_TOKEN}       # shared secret (see below)
+      SANDBOX_IMAGE: localhost/loomcycle-sandbox-session:latest
+      SANDBOX_RUNTIME: ""            # "" = engine default; set runsc once gVisor is installed
+      SANDBOX_MAX_TMPFS_MB: "2048"
+      SANDBOX_MAX_MEM_MB: "2048"
+      SANDBOX_MAX_CPUS: "2"
+      SANDBOX_SESSION_IDLE_TTL: "15m"
+    # No ports: — in-network only.
+```
+
+Then point loomcycle at it (in the operator config or by selecting the `sandbox`
+bundle — see `docs/SANDBOX.md`):
+
+```yaml
+mcp_servers:
+  sandbox:
+    transport: http
+    url: http://builder-sidecar:9000/mcp
+    headers:
+      Authorization: "Bearer ${run.user_bearer:-${LOOMCYCLE_SANDBOX_TOKEN}}"
+```
+
+The **shared secret** (`LOOMCYCLE_SANDBOX_TOKEN`) goes in loomcycle's env and the
+sidecar's `SANDBOX_AUTH_TOKEN` — set both to the same value. Per-run bearers, when
+present, take precedence (the `${run.user_bearer:-…}` fallback form).
+
+## Configuration (environment)
+
+| Var | Default | Purpose |
+|---|---|---|
+| `SANDBOX_LISTEN_ADDR` | `:9000` | Listen address. |
+| `SANDBOX_AUTH_TOKEN` | — (required) | Shared bearer every MCP request must present. |
+| `SANDBOX_ALLOW_ANON` | `0` | `1` = run unauthenticated (LOCAL DEV ONLY). |
+| `SANDBOX_IMAGE` | — (required) | The session toolchain image. |
+| `SANDBOX_RUNTIME` | `""` | OCI runtime: `""`\|`runc`\|`crun`\|`runsc`\|`kata`. |
+| `SANDBOX_CONTAINER_USER` | `1000:1000` | In-container user (never root). |
+| `SANDBOX_ALLOW_EGRESS` | `0` | `1` permits `network:"egress"` sessions. |
+| `SANDBOX_DEFAULT_TMPFS_MB` / `SANDBOX_MAX_TMPFS_MB` | `512` / `2048` | Workspace tmpfs size + ceiling. |
+| `SANDBOX_MAX_CPUS` / `SANDBOX_MAX_MEM_MB` / `SANDBOX_MAX_PIDS` | `2` / `2048` / `512` | Per-session resource ceilings. |
+| `SANDBOX_SESSION_IDLE_TTL` / `SANDBOX_SESSION_MAX_TTL` | `15m` / `1h` | Idle + absolute session TTL. |
+| `SANDBOX_GC_INTERVAL` | `1m` | GC tick. |
+| `SANDBOX_MAX_SESSIONS` | `32` | Concurrent session cap. |
+| `SANDBOX_MAX_OUTPUT_BYTES` | `1048576` | Per-exec output cap. |
+
+## Security posture
+
+- **Bearer required** on every request (constant-time check); the sidecar
+  refuses to start without a token unless `SANDBOX_ALLOW_ANON=1`.
+- **Every session container** launches `--network none` (unless egress is both
+  operator-enabled and requested), `--read-only`, `--cap-drop=ALL`,
+  `--security-opt no-new-privileges`, non-root user, with `--pids-limit` /
+  `--memory` / `--cpus` caps and an in-memory `--tmpfs /work` (nothing the agent
+  writes touches disk).
+- **No host shell injection**: podman is exec'd directly (no host shell); file
+  paths ride in env vars and content via stdin.
+- **Session ownership**: each session is bound to the caller's principal; a
+  leaked/guessed `session_id` from another principal never resolves. In this
+  release the principal is the shared bearer (single-tenant); the per-tenant
+  attested-identity binding is the next phase.
+
+## Scope (this release)
+
+This is the first phase: single shared bearer, TTL + explicit close for cleanup,
+`runc`/`runsc` runtimes. Deferred: attested per-tenant identity (multi-tenant
+isolation via loomcycle-filled `X-Loom-Tenant`/`X-Loom-Root-Run` headers),
+run-liveness-poll GC, Kata microVM tier, and a bind-mounted shared workspace.
+
+## Tests
+
+```bash
+go test ./...        # arg-construction, MCP wire contract, auth, GC — no podman needed
+```
+
+End-to-end (needs a podman host): build both images, run the sidecar, and drive
+`sandbox_open` → `sandbox_exec` → `sandbox_read` → `sandbox_close` via loomcycle.

--- a/deploy/builder/config.go
+++ b/deploy/builder/config.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+)
+
+// Config is the sidecar's operator-set policy, all from the environment. Every
+// per-call value an agent supplies is clamped to the ceilings here — the model
+// can ask for less isolation headroom but never more than the operator allows.
+type Config struct {
+	ListenAddr string // SANDBOX_LISTEN_ADDR (default :9000)
+
+	// AuthToken is the shared bearer every MCP request must present
+	// (Authorization: Bearer <token>). Required unless AllowAnon — a sandbox
+	// that executes code must never run as an open, unauthenticated service.
+	AuthToken string // SANDBOX_AUTH_TOKEN
+	AllowAnon bool   // SANDBOX_ALLOW_ANON=1 (local dev only; logs a warning)
+
+	// Engine.
+	PodmanBin string // SANDBOX_PODMAN_BIN (default "podman")
+	Image     string // SANDBOX_IMAGE — the toolchain image sessions run
+	Runtime   string // SANDBOX_RUNTIME → --runtime (runc|runsc|kata; "" = engine default)
+	CtrUser   string // SANDBOX_CONTAINER_USER → --user (default "1000:1000"; never root)
+
+	// Network. Sessions are --network none by default; an agent may request
+	// network:"egress" only when the operator opts in.
+	AllowEgress bool // SANDBOX_ALLOW_EGRESS=1
+
+	// Resource ceilings (per session container) + defaults when the caller
+	// omits a value.
+	DefTmpfsMB int64 // SANDBOX_DEFAULT_TMPFS_MB (default 512)
+	MaxTmpfsMB int64 // SANDBOX_MAX_TMPFS_MB (default 2048)
+	DefCPUs    float64
+	MaxCPUs    float64 // SANDBOX_MAX_CPUS (default 2)
+	DefMemMB   int64
+	MaxMemMB   int64 // SANDBOX_MAX_MEM_MB (default 2048)
+	DefPids    int64
+	MaxPids    int64 // SANDBOX_MAX_PIDS (default 512)
+
+	// Exec bounds — mirror the Bash/Bashbox tool guards so behaviour is
+	// consistent across loomcycle's shell surfaces.
+	DefTimeout  time.Duration // 30s
+	MaxTimeout  time.Duration // 5m
+	MaxOutBytes int64         // 1 MiB
+
+	// Session lifecycle.
+	SessionIdleTTL time.Duration // SANDBOX_SESSION_IDLE_TTL (default 15m)
+	SessionMaxTTL  time.Duration // SANDBOX_SESSION_MAX_TTL (default 1h)
+	GCInterval     time.Duration // SANDBOX_GC_INTERVAL (default 1m)
+	MaxSessions    int           // SANDBOX_MAX_SESSIONS (default 32; global in P1)
+}
+
+// LoadConfig reads the environment into a Config, applying defaults and
+// validating the security-critical invariants.
+func LoadConfig() (*Config, error) {
+	c := &Config{
+		ListenAddr:     envStr("SANDBOX_LISTEN_ADDR", ":9000"),
+		AuthToken:      os.Getenv("SANDBOX_AUTH_TOKEN"),
+		AllowAnon:      os.Getenv("SANDBOX_ALLOW_ANON") == "1",
+		PodmanBin:      envStr("SANDBOX_PODMAN_BIN", "podman"),
+		Image:          os.Getenv("SANDBOX_IMAGE"),
+		Runtime:        os.Getenv("SANDBOX_RUNTIME"),
+		CtrUser:        envStr("SANDBOX_CONTAINER_USER", "1000:1000"),
+		AllowEgress:    os.Getenv("SANDBOX_ALLOW_EGRESS") == "1",
+		DefTmpfsMB:     envInt("SANDBOX_DEFAULT_TMPFS_MB", 512),
+		MaxTmpfsMB:     envInt("SANDBOX_MAX_TMPFS_MB", 2048),
+		MaxCPUs:        envFloat("SANDBOX_MAX_CPUS", 2),
+		MaxMemMB:       envInt("SANDBOX_MAX_MEM_MB", 2048),
+		MaxPids:        envInt("SANDBOX_MAX_PIDS", 512),
+		DefTimeout:     30 * time.Second,
+		MaxTimeout:     5 * time.Minute,
+		MaxOutBytes:    envInt("SANDBOX_MAX_OUTPUT_BYTES", 1<<20),
+		SessionIdleTTL: envDur("SANDBOX_SESSION_IDLE_TTL", 15*time.Minute),
+		SessionMaxTTL:  envDur("SANDBOX_SESSION_MAX_TTL", time.Hour),
+		GCInterval:     envDur("SANDBOX_GC_INTERVAL", time.Minute),
+		MaxSessions:    int(envInt("SANDBOX_MAX_SESSIONS", 32)),
+	}
+	// Per-session defaults are the ceilings unless separately narrowed — a
+	// caller asking for less is honoured, more is clamped (see clampOpen).
+	c.DefCPUs = c.MaxCPUs
+	c.DefMemMB = c.MaxMemMB
+	c.DefPids = c.MaxPids
+
+	if c.Image == "" {
+		return nil, fmt.Errorf("SANDBOX_IMAGE is required (the toolchain image sessions run; build the reference one from deploy/builder/session/Dockerfile)")
+	}
+	if c.AuthToken == "" && !c.AllowAnon {
+		return nil, fmt.Errorf("SANDBOX_AUTH_TOKEN is required (a code-execution sandbox must not run unauthenticated); set SANDBOX_ALLOW_ANON=1 ONLY for local dev")
+	}
+	if c.Runtime != "" && c.Runtime != "runc" && c.Runtime != "runsc" && c.Runtime != "crun" && c.Runtime != "kata" && c.Runtime != "kata-runtime" {
+		return nil, fmt.Errorf("SANDBOX_RUNTIME %q not recognised (use runc|crun|runsc|kata)", c.Runtime)
+	}
+	return c, nil
+}
+
+func envStr(name, def string) string {
+	if v := os.Getenv(name); v != "" {
+		return v
+	}
+	return def
+}
+
+func envInt(name string, def int64) int64 {
+	if v := os.Getenv(name); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil {
+			return n
+		}
+	}
+	return def
+}
+
+func envFloat(name string, def float64) float64 {
+	if v := os.Getenv(name); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			return f
+		}
+	}
+	return def
+}
+
+func envDur(name string, def time.Duration) time.Duration {
+	if v := os.Getenv(name); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+	}
+	return def
+}

--- a/deploy/builder/config_test.go
+++ b/deploy/builder/config_test.go
@@ -1,0 +1,53 @@
+package main
+
+import "testing"
+
+func TestLoadConfig_RequiresImage(t *testing.T) {
+	t.Setenv("SANDBOX_IMAGE", "")
+	t.Setenv("SANDBOX_AUTH_TOKEN", "tok")
+	if _, err := LoadConfig(); err == nil {
+		t.Fatal("expected error when SANDBOX_IMAGE unset")
+	}
+}
+
+func TestLoadConfig_RequiresAuthUnlessAnon(t *testing.T) {
+	t.Setenv("SANDBOX_IMAGE", "img")
+	t.Setenv("SANDBOX_AUTH_TOKEN", "")
+	t.Setenv("SANDBOX_ALLOW_ANON", "")
+	if _, err := LoadConfig(); err == nil {
+		t.Fatal("expected error when no token and no anon")
+	}
+	t.Setenv("SANDBOX_ALLOW_ANON", "1")
+	if _, err := LoadConfig(); err != nil {
+		t.Fatalf("anon mode should be allowed: %v", err)
+	}
+}
+
+func TestLoadConfig_RejectsUnknownRuntime(t *testing.T) {
+	t.Setenv("SANDBOX_IMAGE", "img")
+	t.Setenv("SANDBOX_AUTH_TOKEN", "tok")
+	t.Setenv("SANDBOX_RUNTIME", "bogus")
+	if _, err := LoadConfig(); err == nil {
+		t.Fatal("expected error for unknown runtime")
+	}
+}
+
+func TestLoadConfig_Defaults(t *testing.T) {
+	t.Setenv("SANDBOX_IMAGE", "img")
+	t.Setenv("SANDBOX_AUTH_TOKEN", "tok")
+	t.Setenv("SANDBOX_RUNTIME", "")
+	c, err := LoadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.ListenAddr != ":9000" || c.MaxTmpfsMB != 2048 || c.MaxSessions != 32 {
+		t.Errorf("defaults wrong: %+v", c)
+	}
+	// Per-session defaults equal the ceilings unless separately narrowed.
+	if c.DefCPUs != c.MaxCPUs || c.DefMemMB != c.MaxMemMB || c.DefPids != c.MaxPids {
+		t.Errorf("defaults should equal ceilings: %+v", c)
+	}
+	if c.CtrUser != "1000:1000" {
+		t.Errorf("container user default should be non-root: %q", c.CtrUser)
+	}
+}

--- a/deploy/builder/engine.go
+++ b/deploy/builder/engine.go
@@ -1,0 +1,256 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// workDir is the fixed in-container workspace. It is a size-capped tmpfs, so the
+// whole workspace is in RAM and vanishes when the container is removed ("in-memory
+// for safety"). All toolchain caches are redirected here (see sessionEnv) so a
+// read-only rootfs still supports real compiles.
+const workDir = "/work"
+
+// Runner executes a podman argv and returns its combined (stdout+stderr) output,
+// bounded to maxOut bytes, plus the process exit code. Abstracted so the arg
+// construction is unit-testable without a podman host.
+type Runner interface {
+	Run(ctx context.Context, stdin []byte, maxOut int64, argv ...string) (out []byte, exitCode int, err error)
+}
+
+// execRunner is the production Runner backed by os/exec.
+type execRunner struct{}
+
+func (execRunner) Run(ctx context.Context, stdin []byte, maxOut int64, argv ...string) ([]byte, int, error) {
+	if len(argv) == 0 {
+		return nil, -1, errors.New("empty argv")
+	}
+	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+	if stdin != nil {
+		cmd.Stdin = bytes.NewReader(stdin)
+	}
+	bb := &boundedBuf{cap: maxOut}
+	cmd.Stdout = bb
+	cmd.Stderr = bb
+	err := cmd.Run()
+	code := 0
+	if err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			code = ee.ExitCode()
+			err = nil // a non-zero exit is data, not a runner failure
+		} else {
+			code = -1 // failed to start / killed by ctx / not found
+		}
+	}
+	return bb.Bytes(), code, err
+}
+
+// Engine builds + runs podman commands for the session lifecycle.
+type Engine struct {
+	cfg *Config
+	run Runner
+}
+
+func NewEngine(cfg *Config, run Runner) *Engine { return &Engine{cfg: cfg, run: run} }
+
+// openOpts are the clamped, validated parameters for a new session.
+type openOpts struct {
+	Network string // "none" | "egress"
+	TmpfsMB int64
+	CPUs    float64
+	MemMB   int64
+	Pids    int64
+	Image   string
+}
+
+// runArgs builds the `podman run` argv for a session container. Pure + exported
+// to the test via engine_test.go — this is where the hardening posture lives, so
+// it is the thing worth asserting.
+func (e *Engine) runArgs(name string, o openOpts) []string {
+	a := []string{"run", "-d", "--name", name,
+		"--label", "loomcycle.managed=1",
+		"--label", "sandbox.session=" + name,
+	}
+	// Isolation runtime (gVisor/kata) when the operator set one.
+	if e.cfg.Runtime != "" {
+		a = append(a, "--runtime", e.cfg.Runtime)
+	}
+	// Network: off by default; a filtered bridge only when the operator opted
+	// in AND the caller asked for it.
+	if o.Network == "egress" && e.cfg.AllowEgress {
+		a = append(a, "--network", "bridge")
+	} else {
+		a = append(a, "--network", "none")
+	}
+	// Hardening: read-only rootfs; the only writable surfaces are the two
+	// tmpfs mounts; drop every capability; no privilege escalation; non-root
+	// user; resource caps.
+	a = append(a,
+		"--read-only",
+		"--tmpfs", fmt.Sprintf("%s:rw,size=%dm,mode=0700,exec", workDir, o.TmpfsMB),
+		"--tmpfs", "/tmp:rw,size=64m,exec",
+		"--cap-drop", "ALL",
+		"--security-opt", "no-new-privileges",
+		"--user", e.cfg.CtrUser,
+		"--pids-limit", strconv.FormatInt(o.Pids, 10),
+		"--memory", fmt.Sprintf("%dm", o.MemMB),
+		"--cpus", strconv.FormatFloat(o.CPUs, 'f', -1, 64),
+		"--workdir", workDir,
+	)
+	for _, kv := range sessionEnv() {
+		a = append(a, "--env", kv)
+	}
+	a = append(a, o.Image, "sleep", "infinity")
+	return a
+}
+
+// sessionEnv redirects every toolchain's writable state into the tmpfs workspace
+// so a --read-only rootfs still supports go build / cargo / npm / pip.
+func sessionEnv() []string {
+	return []string{
+		"HOME=" + workDir,
+		"TMPDIR=/tmp",
+		"XDG_CACHE_HOME=" + workDir + "/.cache",
+		"GOCACHE=" + workDir + "/.cache/go-build",
+		"GOPATH=" + workDir + "/go",
+		"GOMODCACHE=" + workDir + "/go/pkg/mod",
+		"CARGO_HOME=" + workDir + "/.cargo",
+		"npm_config_cache=" + workDir + "/.npm",
+		"PIP_CACHE_DIR=" + workDir + "/.cache/pip",
+	}
+}
+
+// Open launches a session container and returns its name. The caller wraps it in
+// a Session and stores it.
+func (e *Engine) Open(ctx context.Context, name string, o openOpts) error {
+	out, code, err := e.run.Run(ctx, nil, e.cfg.MaxOutBytes, prepend(e.cfg.PodmanBin, e.runArgs(name, o))...)
+	if err != nil {
+		return fmt.Errorf("podman run: %w", err)
+	}
+	if code != 0 {
+		return fmt.Errorf("podman run exited %d: %s", code, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// execArgs builds `podman exec` for running a command inside a session's shell.
+func (e *Engine) execArgs(name, command string) []string {
+	// The user command runs inside the CONTAINER's login shell — that's the
+	// sandbox boundary. Host-side there is no shell: podman + its args are
+	// exec'd directly (no host shell interpolation), so `command` cannot inject
+	// into the host.
+	return []string{"exec", name, "bash", "-lc", command}
+}
+
+// Exec runs one command in the session, bounded by timeout + maxOut.
+func (e *Engine) Exec(ctx context.Context, name, command string, timeout time.Duration, maxOut int64) (out []byte, code int, timedOut bool, err error) {
+	rctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	out, code, err = e.run.Run(rctx, nil, maxOut, prepend(e.cfg.PodmanBin, e.execArgs(name, command))...)
+	if rctx.Err() == context.DeadlineExceeded {
+		return out, code, true, nil
+	}
+	return out, code, false, err
+}
+
+// Write copies content to <workDir>/<rel> inside the session. The path is passed
+// via an env var (not interpolated into the shell string) and content via stdin,
+// so neither can inject a host or in-container command.
+func (e *Engine) Write(ctx context.Context, name, rel string, content []byte) error {
+	abs := workDir + "/" + rel
+	argv := prepend(e.cfg.PodmanBin, []string{
+		"exec", "-i", "--env", "SBX_DEST=" + abs, name,
+		"bash", "-lc", `mkdir -p "$(dirname "$SBX_DEST")" && cat > "$SBX_DEST"`,
+	})
+	out, code, err := e.run.Run(ctx, content, e.cfg.MaxOutBytes, argv...)
+	if err != nil {
+		return fmt.Errorf("podman exec write: %w", err)
+	}
+	if code != 0 {
+		return fmt.Errorf("write failed (exit %d): %s", code, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// Read returns up to maxBytes of <workDir>/<rel> from the session.
+func (e *Engine) Read(ctx context.Context, name, rel string, maxBytes int64) ([]byte, error) {
+	abs := workDir + "/" + rel
+	argv := prepend(e.cfg.PodmanBin, []string{
+		"exec", "--env", "SBX_SRC=" + abs, name,
+		"bash", "-lc", `cat "$SBX_SRC"`,
+	})
+	out, code, err := e.run.Run(ctx, nil, maxBytes, argv...)
+	if err != nil {
+		return nil, fmt.Errorf("podman exec read: %w", err)
+	}
+	if code != 0 {
+		return nil, fmt.Errorf("read failed (exit %d): %s", code, strings.TrimSpace(string(out)))
+	}
+	return out, nil
+}
+
+// Close force-removes a session container. Idempotent: removing an
+// already-gone container is not an error.
+func (e *Engine) Close(ctx context.Context, name string) error {
+	out, code, err := e.run.Run(ctx, nil, e.cfg.MaxOutBytes, prepend(e.cfg.PodmanBin, []string{"rm", "-f", name})...)
+	if err != nil {
+		return fmt.Errorf("podman rm: %w", err)
+	}
+	if code != 0 && !strings.Contains(string(out), "no such container") {
+		return fmt.Errorf("podman rm exited %d: %s", code, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// ReconcileBoot force-removes every container we previously managed. Run once at
+// startup so a crash that skipped Close doesn't leak orphaned sandboxes.
+func (e *Engine) ReconcileBoot(ctx context.Context) error {
+	argv := prepend(e.cfg.PodmanBin, []string{"ps", "-aq", "--filter", "label=loomcycle.managed=1"})
+	out, code, err := e.run.Run(ctx, nil, e.cfg.MaxOutBytes, argv...)
+	if err != nil || code != 0 {
+		return fmt.Errorf("podman ps: code=%d err=%v", code, err)
+	}
+	for _, id := range strings.Fields(string(out)) {
+		_, _, _ = e.run.Run(ctx, nil, e.cfg.MaxOutBytes, prepend(e.cfg.PodmanBin, []string{"rm", "-f", id})...)
+	}
+	return nil
+}
+
+func prepend(bin string, args []string) []string {
+	return append([]string{bin}, args...)
+}
+
+// boundedBuf is a bytes.Buffer that stops accepting after cap bytes and records
+// that it truncated — mirrors the Bash tool's output bounding.
+type boundedBuf struct {
+	cap       int64
+	n         int64
+	buf       bytes.Buffer
+	truncated bool
+}
+
+func (b *boundedBuf) Write(p []byte) (int, error) {
+	if b.n >= b.cap {
+		b.truncated = true
+		return len(p), nil // discard silently; caller appends a marker
+	}
+	remain := b.cap - b.n
+	if int64(len(p)) > remain {
+		b.buf.Write(p[:remain])
+		b.n = b.cap
+		b.truncated = true
+		return len(p), nil
+	}
+	b.buf.Write(p)
+	b.n += int64(len(p))
+	return len(p), nil
+}
+
+func (b *boundedBuf) Bytes() []byte { return b.buf.Bytes() }

--- a/deploy/builder/engine_test.go
+++ b/deploy/builder/engine_test.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeRunner records the argv it was handed and returns canned output, so tests
+// assert command construction without a podman host.
+type fakeRunner struct {
+	calls [][]string
+	stdin [][]byte
+	fn    func(argv []string, stdin []byte) ([]byte, int, error)
+}
+
+func (f *fakeRunner) Run(_ context.Context, stdin []byte, _ int64, argv ...string) ([]byte, int, error) {
+	cp := append([]string(nil), argv...)
+	f.calls = append(f.calls, cp)
+	f.stdin = append(f.stdin, append([]byte(nil), stdin...))
+	if f.fn != nil {
+		return f.fn(argv, stdin)
+	}
+	return nil, 0, nil
+}
+
+func testCfg() *Config {
+	return &Config{
+		PodmanBin: "podman", Image: "img:latest", CtrUser: "1000:1000",
+		DefTmpfsMB: 512, MaxTmpfsMB: 2048, DefCPUs: 2, MaxCPUs: 2,
+		DefMemMB: 2048, MaxMemMB: 2048, DefPids: 512, MaxPids: 512,
+		DefTimeout: 30 * time.Second, MaxTimeout: 5 * time.Minute, MaxOutBytes: 1 << 20,
+		SessionIdleTTL: 15 * time.Minute, SessionMaxTTL: time.Hour, MaxSessions: 32,
+	}
+}
+
+// hasPair asserts args contains flag immediately followed by value.
+func hasPair(args []string, flag, value string) bool {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag && args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+func has(args []string, v string) bool {
+	for _, a := range args {
+		if a == v {
+			return true
+		}
+	}
+	return false
+}
+
+func TestEngine_RunArgs_HardeningPosture(t *testing.T) {
+	cfg := testCfg()
+	cfg.Runtime = "runsc"
+	e := NewEngine(cfg, &fakeRunner{})
+	args := e.runArgs("loom-sbx-abc", openOpts{Network: "none", TmpfsMB: 512, CPUs: 2, MemMB: 2048, Pids: 512, Image: "img:latest"})
+
+	// The security-critical flags MUST all be present.
+	for _, want := range []struct{ flag, val string }{
+		{"--network", "none"},
+		{"--cap-drop", "ALL"},
+		{"--security-opt", "no-new-privileges"},
+		{"--user", "1000:1000"},
+		{"--runtime", "runsc"},
+		{"--pids-limit", "512"},
+		{"--memory", "2048m"},
+		{"--workdir", workDir},
+	} {
+		if !hasPair(args, want.flag, want.val) {
+			t.Errorf("runArgs missing %s %s in %v", want.flag, want.val, args)
+		}
+	}
+	if !has(args, "--read-only") {
+		t.Errorf("runArgs missing --read-only: %v", args)
+	}
+	if !hasPair(args, "--cpus", "2") {
+		t.Errorf("runArgs missing --cpus 2: %v", args)
+	}
+	// tmpfs workspace is in-memory, size-capped, mode 0700.
+	var tmpfsWork string
+	for i, a := range args {
+		if a == "--tmpfs" && i+1 < len(args) && strings.HasPrefix(args[i+1], workDir+":") {
+			tmpfsWork = args[i+1]
+		}
+	}
+	if tmpfsWork == "" || !strings.Contains(tmpfsWork, "size=512m") || !strings.Contains(tmpfsWork, "mode=0700") {
+		t.Errorf("tmpfs /work mount wrong: %q", tmpfsWork)
+	}
+	// Image + entrypoint come last.
+	if args[len(args)-3] != "img:latest" || args[len(args)-2] != "sleep" || args[len(args)-1] != "infinity" {
+		t.Errorf("expected image + sleep infinity at tail, got %v", args[len(args)-3:])
+	}
+	// Managed label so the crash-sweeper can reap it.
+	if !hasPair(args, "--label", "loomcycle.managed=1") {
+		t.Errorf("runArgs missing managed label: %v", args)
+	}
+}
+
+func TestEngine_RunArgs_NetworkNoneByDefaultAndWhenEgressDisallowed(t *testing.T) {
+	cfg := testCfg()
+	cfg.AllowEgress = false
+	e := NewEngine(cfg, &fakeRunner{})
+	// Even if a session was clamped to egress, runArgs only opens the network
+	// when the operator allows it — belt-and-suspenders with clampOpen.
+	args := e.runArgs("n", openOpts{Network: "egress", TmpfsMB: 512, CPUs: 1, MemMB: 512, Pids: 100})
+	if !hasPair(args, "--network", "none") {
+		t.Errorf("egress must not open the network when AllowEgress=false: %v", args)
+	}
+}
+
+func TestEngine_RunArgs_EgressBridgeWhenAllowed(t *testing.T) {
+	cfg := testCfg()
+	cfg.AllowEgress = true
+	e := NewEngine(cfg, &fakeRunner{})
+	args := e.runArgs("n", openOpts{Network: "egress", TmpfsMB: 512, CPUs: 1, MemMB: 512, Pids: 100})
+	if !hasPair(args, "--network", "bridge") {
+		t.Errorf("egress should open bridge when allowed: %v", args)
+	}
+}
+
+func TestEngine_WriteArgs_PathViaEnvNotShell(t *testing.T) {
+	fr := &fakeRunner{}
+	e := NewEngine(testCfg(), fr)
+	if err := e.Write(context.Background(), "n", "src/main.go", []byte("package main")); err != nil {
+		t.Fatal(err)
+	}
+	argv := fr.calls[0]
+	// The destination path must ride in an env var, never interpolated into the
+	// shell string (injection safety). The shell command references $SBX_DEST.
+	if !has(argv, "SBX_DEST=/work/src/main.go") {
+		t.Errorf("write should pass dest via env: %v", argv)
+	}
+	joined := strings.Join(argv, " ")
+	if strings.Contains(joined, "/work/src/main.go\"") && !has(argv, "SBX_DEST=/work/src/main.go") {
+		t.Errorf("dest path leaked into the command string: %v", argv)
+	}
+	if string(fr.stdin[0]) != "package main" {
+		t.Errorf("content should be piped via stdin, got %q", fr.stdin[0])
+	}
+}
+
+func TestEngine_Exec_TimeoutReported(t *testing.T) {
+	fr := &fakeRunner{fn: func(argv []string, _ []byte) ([]byte, int, error) {
+		return []byte("partial"), -1, nil
+	}}
+	cfg := testCfg()
+	cfg.MaxTimeout = time.Millisecond
+	e := NewEngine(cfg, fr)
+	// A zero timeout uses the default; force a tiny deadline so DeadlineExceeded
+	// is deterministic without depending on the fake sleeping.
+	_, _, timedOut, err := e.Exec(context.Background(), "n", "sleep 1", time.Nanosecond, 1<<20)
+	if err != nil {
+		t.Fatalf("exec err: %v", err)
+	}
+	if !timedOut {
+		t.Errorf("expected timedOut=true for an expired deadline")
+	}
+}
+
+func TestBoundedBuf_TruncatesAtCap(t *testing.T) {
+	b := &boundedBuf{cap: 4}
+	_, _ = b.Write([]byte("ab"))
+	_, _ = b.Write([]byte("cdef"))
+	if got := string(b.Bytes()); got != "abcd" {
+		t.Errorf("bounded buffer = %q, want %q", got, "abcd")
+	}
+	if !b.truncated {
+		t.Errorf("expected truncated=true")
+	}
+}

--- a/deploy/builder/go.mod
+++ b/deploy/builder/go.mod
@@ -1,0 +1,13 @@
+// loomcycle-builder — the reference sandbox sidecar for loomcycle.
+//
+// A STANDALONE module (stdlib only, no dependency on loomcycle's own module or
+// any third party) so it builds + versions independently and never pulls into
+// loomcycle's binary. It runs alongside a distroless loomcycle on the app
+// network and exposes container-backed code-execution as MCP-over-HTTP tools
+// (mcp__sandbox__*), driving rootless podman for per-session sandbox containers.
+//
+// See README.md for the design + deploy story; docs/SANDBOX.md in the loomcycle
+// repo for the operator guide.
+module github.com/denn-gubsky/loomcycle/deploy/builder
+
+go 1.26

--- a/deploy/builder/main.go
+++ b/deploy/builder/main.go
@@ -1,0 +1,95 @@
+// Command loomcycle-builder is the reference sandbox sidecar for loomcycle.
+//
+// It runs alongside a distroless loomcycle on the app network and exposes
+// container-backed code execution as MCP-over-HTTP tools (sandbox_open/exec/
+// write/read/close/list), driving rootless podman for per-session sandbox
+// containers. loomcycle stays distroless and never runs a container engine;
+// all podman + isolation complexity lives here.
+//
+// Security posture: the sidecar is the one privileged component. Run it under a
+// nested-container-capable runtime (Sysbox recommended) or as a dedicated build
+// node. Every MCP request is bearer-authenticated; each session container is
+// launched --network none, --read-only, --cap-drop=ALL, non-root, with cpu/mem/
+// pids caps and an in-memory tmpfs workspace.
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"os"
+	"time"
+)
+
+// version is stamped at build time via -ldflags "-X main.version=...".
+var version = "dev"
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.LUTC)
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		log.Fatalf("config: %v", err)
+	}
+	if cfg.AllowAnon {
+		log.Printf("WARNING: SANDBOX_ALLOW_ANON=1 — running UNAUTHENTICATED; use only for local dev")
+	}
+
+	store := NewStore(cfg.SessionIdleTTL, cfg.SessionMaxTTL)
+	eng := NewEngine(cfg, execRunner{})
+	disp := NewDispatcher(cfg, eng, store)
+
+	// Boot reconciliation: reap any sandbox containers a prior crash left behind
+	// before we start accepting new sessions.
+	{
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		if err := eng.ReconcileBoot(ctx); err != nil {
+			log.Printf("boot reconcile: %v (continuing)", err)
+		}
+		cancel()
+	}
+
+	// TTL garbage collector — reaps idle/aged sessions so a forgotten close (or
+	// a dead loomcycle) can't leak containers indefinitely.
+	go gcLoop(context.Background(), cfg, store, eng)
+
+	mux := http.NewServeMux()
+	mux.Handle("/mcp", NewMCPHandler(cfg, disp, version))
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok\n"))
+	})
+
+	srv := &http.Server{
+		Addr:              cfg.ListenAddr,
+		Handler:           mux,
+		ReadHeaderTimeout: 15 * time.Second,
+	}
+	log.Printf("loomcycle-builder %s listening on %s (image=%s runtime=%q egress=%v)",
+		version, cfg.ListenAddr, cfg.Image, cfg.Runtime, cfg.AllowEgress)
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Printf("server: %v", err)
+		os.Exit(1)
+	}
+}
+
+func gcLoop(ctx context.Context, cfg *Config, store *Store, eng *Engine) {
+	t := time.NewTicker(cfg.GCInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-t.C:
+			for _, sess := range store.Expired(now) {
+				rctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+				if err := eng.Close(rctx, sess.Name); err != nil {
+					log.Printf("gc: close %s: %v", sess.Name, err)
+				} else {
+					log.Printf("gc: reaped expired session %s", sess.ID)
+				}
+				cancel()
+			}
+		}
+	}
+}

--- a/deploy/builder/mcp.go
+++ b/deploy/builder/mcp.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+)
+
+const protocolVersion = "2024-11-05"
+
+// rpcResponse mirrors loomcycle's mcp.Response wire shape.
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int64           `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// MCPHandler serves the Streamable-HTTP MCP surface (single POST → JSON
+// response), matching what loomcycle's internal/tools/mcp/http client expects.
+type MCPHandler struct {
+	cfg  *Config
+	disp *Dispatcher
+	ver  string
+}
+
+func NewMCPHandler(cfg *Config, disp *Dispatcher, version string) *MCPHandler {
+	return &MCPHandler{cfg: cfg, disp: disp, ver: version}
+}
+
+func (h *MCPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	principal, ok := h.authenticate(r)
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, 32<<20))
+	if err != nil {
+		http.Error(w, "read body", http.StatusBadRequest)
+		return
+	}
+
+	var probe struct {
+		ID     *int64          `json:"id"`
+		Method string          `json:"method"`
+		Params json.RawMessage `json:"params"`
+	}
+	if err := json.Unmarshal(body, &probe); err != nil {
+		writeRPCError(w, 0, -32700, "parse error")
+		return
+	}
+
+	// Notifications (no id) get 202 with no body — loomcycle's Notify only
+	// checks the status code.
+	if probe.ID == nil {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+	id := *probe.ID
+
+	switch probe.Method {
+	case "initialize":
+		// Hand out a session correlator; loomcycle stores + echoes it. We do
+		// not require it on later requests (no per-MCP-session server state).
+		w.Header().Set(sessionHeaderName, newSessionCorrelator())
+		writeRPCResult(w, id, mustJSON(map[string]any{
+			"protocolVersion": protocolVersion,
+			"capabilities":    map[string]any{"tools": map[string]any{}},
+			"serverInfo":      map[string]any{"name": "loomcycle-builder", "version": h.ver},
+		}))
+	case "tools/list":
+		writeRPCResult(w, id, mustJSON(map[string]any{"tools": h.disp.Tools()}))
+	case "tools/call":
+		var p struct {
+			Name      string          `json:"name"`
+			Arguments json.RawMessage `json:"arguments"`
+		}
+		if err := json.Unmarshal(probe.Params, &p); err != nil {
+			writeRPCError(w, id, -32602, "invalid params")
+			return
+		}
+		text, isErr, cerr := h.disp.Call(r.Context(), principal, p.Name, p.Arguments)
+		if cerr != nil {
+			// Protocol-level fault (unknown tool, malformed args).
+			writeRPCError(w, id, -32602, cerr.Error())
+			return
+		}
+		writeRPCResult(w, id, mustJSON(map[string]any{
+			"content": []map[string]any{{"type": "text", "text": text}},
+			"isError": isErr,
+		}))
+	default:
+		writeRPCError(w, id, -32601, "method not found: "+probe.Method)
+	}
+}
+
+// authenticate checks the bearer token (constant-time) and returns the derived
+// principal. In AllowAnon mode every caller shares the "anon" principal.
+func (h *MCPHandler) authenticate(r *http.Request) (principal string, ok bool) {
+	if h.cfg.AllowAnon {
+		return "anon", true
+	}
+	tok := strings.TrimSpace(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
+	if tok == "" {
+		return "", false
+	}
+	// Constant-time comparison via fixed-length digests (mirrors loomcycle's
+	// auth-middleware invariant — a length-leaking compare is a side channel).
+	got := sha256.Sum256([]byte(tok))
+	want := sha256.Sum256([]byte(h.cfg.AuthToken))
+	if subtle.ConstantTimeCompare(got[:], want[:]) != 1 {
+		return "", false
+	}
+	return principalFromToken(tok), true
+}
+
+// principalFromToken derives a stable, non-secret owner key from the bearer.
+// P1 has a single shared token → a single principal; the store's principal
+// check is the seam P2 fills with a per-tenant key from an attested header.
+func principalFromToken(tok string) string {
+	sum := sha256.Sum256([]byte(tok))
+	return "op:" + hex.EncodeToString(sum[:8])
+}
+
+const sessionHeaderName = "Mcp-Session-Id"
+
+func newSessionCorrelator() string {
+	id, err := newID()
+	if err != nil {
+		return "sbx-session"
+	}
+	return id
+}
+
+func writeRPCResult(w http.ResponseWriter, id int64, result json.RawMessage) {
+	writeJSON(w, rpcResponse{JSONRPC: "2.0", ID: id, Result: result})
+}
+
+func writeRPCError(w http.ResponseWriter, id int64, code int, msg string) {
+	writeJSON(w, rpcResponse{JSONRPC: "2.0", ID: id, Error: &rpcError{Code: code, Message: msg}})
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		log.Printf("mcp: encode response: %v", err)
+	}
+}
+
+func mustJSON(v any) json.RawMessage {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return json.RawMessage(`null`)
+	}
+	return b
+}

--- a/deploy/builder/mcp_test.go
+++ b/deploy/builder/mcp_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newTestHandler(t *testing.T, fr *fakeRunner) *MCPHandler {
+	t.Helper()
+	cfg := testCfg()
+	cfg.AuthToken = "secret-token"
+	d := NewDispatcher(cfg, NewEngine(cfg, fr), NewStore(cfg.SessionIdleTTL, cfg.SessionMaxTTL))
+	return NewMCPHandler(cfg, d, "test")
+}
+
+func post(h http.Handler, bearer, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(body))
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	return rr
+}
+
+func TestMCP_AuthRequired(t *testing.T) {
+	h := newTestHandler(t, &fakeRunner{})
+	if rr := post(h, "", `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`); rr.Code != http.StatusUnauthorized {
+		t.Errorf("no bearer: got %d want 401", rr.Code)
+	}
+	if rr := post(h, "wrong", `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`); rr.Code != http.StatusUnauthorized {
+		t.Errorf("wrong bearer: got %d want 401", rr.Code)
+	}
+	if rr := post(h, "secret-token", `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`); rr.Code != http.StatusOK {
+		t.Errorf("right bearer: got %d want 200", rr.Code)
+	}
+}
+
+func TestMCP_Initialize(t *testing.T) {
+	h := newTestHandler(t, &fakeRunner{})
+	rr := post(h, "secret-token", `{"jsonrpc":"2.0","id":7,"method":"initialize","params":{}}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("initialize: %d", rr.Code)
+	}
+	if rr.Header().Get("Mcp-Session-Id") == "" {
+		t.Errorf("initialize should set an Mcp-Session-Id header")
+	}
+	var resp rpcResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.ID != 7 {
+		t.Errorf("response id = %d want 7 (must echo request id)", resp.ID)
+	}
+	var res struct {
+		ProtocolVersion string `json:"protocolVersion"`
+		ServerInfo      struct {
+			Name string `json:"name"`
+		} `json:"serverInfo"`
+	}
+	if err := json.Unmarshal(resp.Result, &res); err != nil {
+		t.Fatal(err)
+	}
+	if res.ProtocolVersion != protocolVersion {
+		t.Errorf("protocolVersion = %q want %q", res.ProtocolVersion, protocolVersion)
+	}
+	if res.ServerInfo.Name != "loomcycle-builder" {
+		t.Errorf("serverInfo.name = %q", res.ServerInfo.Name)
+	}
+}
+
+func TestMCP_ToolsList(t *testing.T) {
+	h := newTestHandler(t, &fakeRunner{})
+	rr := post(h, "secret-token", `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`)
+	var resp rpcResponse
+	_ = json.Unmarshal(rr.Body.Bytes(), &resp)
+	var res struct {
+		Tools []struct {
+			Name        string          `json:"name"`
+			InputSchema json.RawMessage `json:"inputSchema"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(resp.Result, &res); err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]bool{"sandbox_open": false, "sandbox_exec": false, "sandbox_write": false, "sandbox_read": false, "sandbox_close": false, "sandbox_list": false}
+	for _, tl := range res.Tools {
+		if _, ok := want[tl.Name]; ok {
+			want[tl.Name] = true
+		}
+		if len(tl.InputSchema) == 0 {
+			t.Errorf("tool %s has empty inputSchema", tl.Name)
+		}
+	}
+	for name, seen := range want {
+		if !seen {
+			t.Errorf("tools/list missing %s", name)
+		}
+	}
+}
+
+func TestMCP_ToolsCall_Open(t *testing.T) {
+	// fake podman run succeeds.
+	h := newTestHandler(t, &fakeRunner{})
+	body := `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"sandbox_open","arguments":{}}}`
+	rr := post(h, "secret-token", body)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("tools/call: %d", rr.Code)
+	}
+	var resp rpcResponse
+	_ = json.Unmarshal(rr.Body.Bytes(), &resp)
+	if resp.ID != 3 {
+		t.Errorf("id echo: %d", resp.ID)
+	}
+	var res struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+		IsError bool `json:"isError"`
+	}
+	if err := json.Unmarshal(resp.Result, &res); err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError || len(res.Content) == 0 || res.Content[0].Type != "text" {
+		t.Fatalf("unexpected call result: %+v", res)
+	}
+	if !strings.Contains(res.Content[0].Text, "session_id") {
+		t.Errorf("open text should carry a session_id: %q", res.Content[0].Text)
+	}
+}
+
+func TestMCP_Notification_202(t *testing.T) {
+	h := newTestHandler(t, &fakeRunner{})
+	rr := post(h, "secret-token", `{"jsonrpc":"2.0","method":"notifications/initialized"}`)
+	if rr.Code != http.StatusAccepted {
+		t.Errorf("notification: got %d want 202", rr.Code)
+	}
+}
+
+func TestMCP_UnknownMethod(t *testing.T) {
+	h := newTestHandler(t, &fakeRunner{})
+	rr := post(h, "secret-token", `{"jsonrpc":"2.0","id":9,"method":"no/such"}`)
+	var resp rpcResponse
+	_ = json.Unmarshal(rr.Body.Bytes(), &resp)
+	if resp.Error == nil || resp.Error.Code != -32601 {
+		t.Errorf("unknown method should return -32601, got %+v", resp.Error)
+	}
+}

--- a/deploy/builder/session.go
+++ b/deploy/builder/session.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"sync"
+	"time"
+)
+
+// Session is one live sandbox container the sidecar manages.
+type Session struct {
+	ID        string // opaque high-entropy id handed to the agent
+	Name      string // podman container name (loom-sbx-<id>)
+	Principal string // owner key derived from the caller's bearer (P1: one
+	//                     shared principal; P2 derives it from the attested tenant)
+	Image     string
+	Network   string
+	CreatedAt time.Time
+	LastUsed  time.Time // touched on every exec/read/write; drives idle TTL
+}
+
+// Store is the in-memory session registry. Sessions are also self-describing on
+// the engine (loomcycle.managed=1 labels), so a crash-sweeper can reap orphans
+// the store lost track of — but the store is the authoritative liveness source
+// while the process is up.
+type Store struct {
+	mu      sync.Mutex
+	m       map[string]*Session
+	idleTTL time.Duration
+	maxTTL  time.Duration
+}
+
+func NewStore(idleTTL, maxTTL time.Duration) *Store {
+	return &Store{m: map[string]*Session{}, idleTTL: idleTTL, maxTTL: maxTTL}
+}
+
+func (s *Store) Add(sess *Session) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m[sess.ID] = sess
+}
+
+// Get returns the session iff it exists AND is owned by principal — a leaked or
+// guessed id from another principal resolves to (nil,false), never another
+// tenant's container. Touches LastUsed on success (a use resets the idle clock).
+func (s *Store) Get(id, principal string, now time.Time) (*Session, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sess, ok := s.m[id]
+	if !ok || sess.Principal != principal {
+		return nil, false
+	}
+	sess.LastUsed = now
+	return sess, true
+}
+
+func (s *Store) Remove(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.m, id)
+}
+
+// Count returns the number of live sessions (global; P1 caps globally).
+func (s *Store) Count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.m)
+}
+
+// ListByPrincipal returns a snapshot of one principal's sessions.
+func (s *Store) ListByPrincipal(principal string) []*Session {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []*Session
+	for _, sess := range s.m {
+		if sess.Principal == principal {
+			cp := *sess
+			out = append(out, &cp)
+		}
+	}
+	return out
+}
+
+// Expired returns and REMOVES every session past its idle or absolute TTL, so
+// the caller can tear down the containers. Removing under the same lock avoids a
+// double-reap race with a concurrent GC tick.
+func (s *Store) Expired(now time.Time) []*Session {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []*Session
+	for id, sess := range s.m {
+		idle := now.Sub(sess.LastUsed) > s.idleTTL
+		aged := now.Sub(sess.CreatedAt) > s.maxTTL
+		if idle || aged {
+			out = append(out, sess)
+			delete(s.m, id)
+		}
+	}
+	return out
+}

--- a/deploy/builder/session/Dockerfile
+++ b/deploy/builder/session/Dockerfile
@@ -1,0 +1,55 @@
+# loomcycle sandbox SESSION image — the toolchain that runs INSIDE each sandbox
+# container the builder sidecar launches. This is NOT loomcycle and NOT the
+# sidecar: it is the disposable environment agent code compiles/runs in.
+#
+# Requirements the sidecar depends on:
+#   - a shell (bash) + coreutils (`sleep`, used as the container's idle command)
+#   - a non-root user at uid:gid 1000:1000 (matches SANDBOX_CONTAINER_USER)
+#   - toolchain caches must work under a --read-only rootfs: the sidecar sets
+#     HOME/GOCACHE/CARGO_HOME/etc. into the writable /work tmpfs, so nothing here
+#     needs to write outside /work or /tmp at runtime.
+#
+# Build + pin (the sidecar's SANDBOX_IMAGE points at this):
+#   docker build -t localhost/loomcycle-sandbox-session:latest ./session
+#
+# Keep it pinned by digest in production.
+
+FROM debian:bookworm-slim
+
+ARG TARGETARCH
+ARG GO_VERSION=1.26.0
+
+RUN set -eux; \
+    apt-get update; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates curl git bash coreutils \
+        python3 python3-pip python3-venv \
+        build-essential clang make cmake pkg-config \
+        nodejs npm; \
+    apt-get clean; rm -rf /var/lib/apt/lists/*
+
+# Go (official tarball). Arch from buildx TARGETARCH, dpkg fallback for plain builds.
+RUN set -eux; \
+    arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
+    curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${arch}.tar.gz" -o /tmp/go.tgz; \
+    tar -C /usr/local -xzf /tmp/go.tgz; rm /tmp/go.tgz
+
+# Rust (rustup), system-wide + world-usable so the uid-1000 session user can use it.
+ENV RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo
+RUN set -eux; \
+    curl -fsSL https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal --default-toolchain stable; \
+    chmod -R go+rwX /usr/local/rustup /usr/local/cargo
+
+# The toolchains live on PATH; per-session writable caches (GOCACHE, CARGO_HOME
+# override, npm cache, HOME) are injected by the sidecar into the /work tmpfs.
+ENV PATH="/usr/local/go/bin:/usr/local/cargo/bin:${PATH}"
+
+# Non-root session user at 1000:1000 (the sidecar launches --user 1000:1000).
+RUN groupadd --gid 1000 sandbox && \
+    useradd --uid 1000 --gid 1000 --create-home --home-dir /home/sandbox --shell /bin/bash sandbox
+
+USER 1000:1000
+WORKDIR /work
+# The sidecar starts the container with `sleep infinity` and exec's commands in;
+# this default is a harmless fallback if run directly.
+CMD ["sleep", "infinity"]

--- a/deploy/builder/session_test.go
+++ b/deploy/builder/session_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStore_GetEnforcesPrincipalOwnership(t *testing.T) {
+	s := NewStore(time.Hour, time.Hour)
+	now := time.Now()
+	s.Add(&Session{ID: "a", Name: "loom-sbx-a", Principal: "op:alice", CreatedAt: now, LastUsed: now})
+
+	if _, ok := s.Get("a", "op:alice", now); !ok {
+		t.Fatalf("owner should resolve its own session")
+	}
+	// A different principal presenting a valid id must NOT reach the session —
+	// the P2 cross-tenant-isolation seam.
+	if _, ok := s.Get("a", "op:mallory", now); ok {
+		t.Fatalf("a foreign principal must not resolve another's session")
+	}
+	if _, ok := s.Get("missing", "op:alice", now); ok {
+		t.Fatalf("unknown id must not resolve")
+	}
+}
+
+func TestStore_GetTouchesLastUsed(t *testing.T) {
+	s := NewStore(time.Hour, time.Hour)
+	t0 := time.Now()
+	s.Add(&Session{ID: "a", Principal: "p", CreatedAt: t0, LastUsed: t0})
+	t1 := t0.Add(time.Minute)
+	if _, ok := s.Get("a", "p", t1); !ok {
+		t.Fatal("get failed")
+	}
+	sess, _ := s.Get("a", "p", t1)
+	if !sess.LastUsed.Equal(t1) {
+		t.Errorf("LastUsed not touched: got %v want %v", sess.LastUsed, t1)
+	}
+}
+
+func TestStore_ExpiredIdleAndAged(t *testing.T) {
+	s := NewStore(10*time.Minute, time.Hour)
+	base := time.Now()
+	// idle: last used 11m ago (> idleTTL)
+	s.Add(&Session{ID: "idle", Principal: "p", CreatedAt: base, LastUsed: base})
+	// aged: created 61m ago but recently used (> maxTTL regardless)
+	s.Add(&Session{ID: "aged", Principal: "p", CreatedAt: base.Add(-61 * time.Minute), LastUsed: base.Add(9 * time.Minute)})
+	// live: fresh
+	s.Add(&Session{ID: "live", Principal: "p", CreatedAt: base.Add(9 * time.Minute), LastUsed: base.Add(9 * time.Minute)})
+
+	now := base.Add(11 * time.Minute)
+	expired := s.Expired(now)
+	got := map[string]bool{}
+	for _, e := range expired {
+		got[e.ID] = true
+	}
+	if !got["idle"] || !got["aged"] {
+		t.Errorf("expected idle+aged expired, got %v", got)
+	}
+	if got["live"] {
+		t.Errorf("live session must not expire")
+	}
+	// Expired removes them.
+	if s.Count() != 1 {
+		t.Errorf("Expired should remove reaped sessions; count=%d want 1", s.Count())
+	}
+}

--- a/deploy/builder/tools.go
+++ b/deploy/builder/tools.go
@@ -1,0 +1,394 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// toolDescriptor is one MCP tool the sidecar advertises via tools/list. Matches
+// loomcycle's mcp.ToolDescriptor shape ({name, description, inputSchema}).
+type toolDescriptor struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"inputSchema"`
+}
+
+// Dispatcher answers tools/list and tools/call.
+type Dispatcher struct {
+	cfg   *Config
+	eng   *Engine
+	store *Store
+	nowFn func() time.Time
+}
+
+func NewDispatcher(cfg *Config, eng *Engine, store *Store) *Dispatcher {
+	return &Dispatcher{cfg: cfg, eng: eng, store: store, nowFn: time.Now}
+}
+
+func (d *Dispatcher) now() time.Time { return d.nowFn() }
+
+// Tools returns the advertised descriptors. Descriptions are model-facing — kept
+// concrete and free of internal jargon.
+func (d *Dispatcher) Tools() []toolDescriptor {
+	return []toolDescriptor{
+		{Name: "sandbox_open", Description: "Open an isolated ephemeral sandbox container with a dev toolchain (Python/Go/Rust/C++/Node) and an in-memory /work directory. Returns a session_id to pass to the other sandbox tools. Reuse one session across a compile/test/fix loop; close it when done.", InputSchema: schemaOpen},
+		{Name: "sandbox_exec", Description: "Run a shell command inside a sandbox session (working directory /work). Returns combined stdout+stderr and the exit code. Non-zero exit is reported so you can read the error and fix it.", InputSchema: schemaExec},
+		{Name: "sandbox_write", Description: "Write a file into the sandbox workspace at a path relative to /work (parent dirs are created). Use this to put source files in before compiling.", InputSchema: schemaWrite},
+		{Name: "sandbox_read", Description: "Read a file from the sandbox workspace (path relative to /work). Use this to pull out build output or a generated artifact.", InputSchema: schemaRead},
+		{Name: "sandbox_close", Description: "Destroy a sandbox session and free its resources. Always close a session when finished; sessions also expire on their own after an idle timeout.", InputSchema: schemaClose},
+		{Name: "sandbox_list", Description: "List your currently open sandbox sessions.", InputSchema: schemaList},
+	}
+}
+
+// Call dispatches a tools/call. It returns model-facing text and an isError flag
+// (a tool-level failure the model should see + react to), or a non-nil error for
+// a protocol-level fault (malformed arguments) which becomes a JSON-RPC error.
+func (d *Dispatcher) Call(ctx context.Context, principal, name string, args json.RawMessage) (text string, isError bool, err error) {
+	switch name {
+	case "sandbox_open":
+		return d.open(ctx, principal, args)
+	case "sandbox_exec":
+		return d.exec(ctx, principal, args)
+	case "sandbox_write":
+		return d.write(ctx, principal, args)
+	case "sandbox_read":
+		return d.read(ctx, principal, args)
+	case "sandbox_close":
+		return d.close(ctx, principal, args)
+	case "sandbox_list":
+		return d.list(principal)
+	default:
+		return "", false, fmt.Errorf("unknown tool %q", name)
+	}
+}
+
+func (d *Dispatcher) open(ctx context.Context, principal string, raw json.RawMessage) (string, bool, error) {
+	var in struct {
+		Network string  `json:"network"`
+		TmpfsMB int64   `json:"tmpfs_mb"`
+		CPUs    float64 `json:"cpu"`
+		MemMB   int64   `json:"mem_mb"`
+		Pids    int64   `json:"pids"`
+	}
+	if err := unmarshalArgs(raw, &in); err != nil {
+		return "", false, err
+	}
+	if d.store.Count() >= d.cfg.MaxSessions {
+		return fmt.Sprintf("sandbox capacity reached (%d open sessions); close one first", d.cfg.MaxSessions), true, nil
+	}
+	o := clampOpen(d.cfg, in.Network, in.TmpfsMB, in.CPUs, in.MemMB, in.Pids)
+	o.Image = d.cfg.Image
+
+	id, err := newID()
+	if err != nil {
+		return "", false, err
+	}
+	name := "loom-sbx-" + id
+	if err := d.eng.Open(ctx, name, o); err != nil {
+		return "opening sandbox failed: " + err.Error(), true, nil
+	}
+	now := d.now()
+	sess := &Session{ID: id, Name: name, Principal: principal, Image: o.Image, Network: o.Network, CreatedAt: now, LastUsed: now}
+	d.store.Add(sess)
+
+	resp, _ := json.Marshal(map[string]any{
+		"session_id":     id,
+		"workspace_path": workDir,
+		"network":        o.Network,
+		"expires_at":     now.Add(d.cfg.SessionMaxTTL).UTC().Format(time.RFC3339),
+	})
+	return string(resp), false, nil
+}
+
+func (d *Dispatcher) exec(ctx context.Context, principal string, raw json.RawMessage) (string, bool, error) {
+	var in struct {
+		SessionID      string `json:"session_id"`
+		Command        string `json:"command"`
+		TimeoutSeconds int    `json:"timeout_seconds"`
+		MaxOutputBytes int64  `json:"max_output_bytes"`
+	}
+	if err := unmarshalArgs(raw, &in); err != nil {
+		return "", false, err
+	}
+	if in.Command == "" {
+		return "command is required", true, nil
+	}
+	sess, ok := d.store.Get(in.SessionID, principal, d.now())
+	if !ok {
+		return "no such session (open one with sandbox_open, or it may have expired)", true, nil
+	}
+
+	timeout := d.cfg.DefTimeout
+	if in.TimeoutSeconds > 0 {
+		timeout = time.Duration(in.TimeoutSeconds) * time.Second
+	}
+	if timeout > d.cfg.MaxTimeout {
+		timeout = d.cfg.MaxTimeout
+	}
+	maxOut := d.cfg.MaxOutBytes
+	if in.MaxOutputBytes > 0 && in.MaxOutputBytes < maxOut {
+		maxOut = in.MaxOutputBytes
+	}
+
+	out, code, timedOut, err := d.eng.Exec(ctx, sess.Name, in.Command, timeout, maxOut)
+	if err != nil {
+		return "exec failed: " + err.Error(), true, nil
+	}
+	text := string(out)
+	if int64(len(out)) >= maxOut {
+		text += fmt.Sprintf("\n[output truncated at %d bytes]", maxOut)
+	}
+	if timedOut {
+		text += fmt.Sprintf("\n[timed out after %s]", timeout)
+		return text, true, nil
+	}
+	if code != 0 {
+		text += fmt.Sprintf("\n[exit: %d]", code)
+		return text, true, nil
+	}
+	return text, false, nil
+}
+
+func (d *Dispatcher) write(ctx context.Context, principal string, raw json.RawMessage) (string, bool, error) {
+	var in struct {
+		SessionID string `json:"session_id"`
+		Path      string `json:"path"`
+		Content   string `json:"content"`
+		Encoding  string `json:"encoding"`
+	}
+	if err := unmarshalArgs(raw, &in); err != nil {
+		return "", false, err
+	}
+	rel, perr := safeRelPath(in.Path)
+	if perr != nil {
+		return perr.Error(), true, nil
+	}
+	sess, ok := d.store.Get(in.SessionID, principal, d.now())
+	if !ok {
+		return "no such session", true, nil
+	}
+	content, derr := decodeContent(in.Content, in.Encoding)
+	if derr != nil {
+		return derr.Error(), true, nil
+	}
+	if err := d.eng.Write(ctx, sess.Name, rel, content); err != nil {
+		return "write failed: " + err.Error(), true, nil
+	}
+	return fmt.Sprintf("wrote %d bytes to %s/%s", len(content), workDir, rel), false, nil
+}
+
+func (d *Dispatcher) read(ctx context.Context, principal string, raw json.RawMessage) (string, bool, error) {
+	var in struct {
+		SessionID string `json:"session_id"`
+		Path      string `json:"path"`
+		MaxBytes  int64  `json:"max_bytes"`
+		Encoding  string `json:"encoding"`
+	}
+	if err := unmarshalArgs(raw, &in); err != nil {
+		return "", false, err
+	}
+	rel, perr := safeRelPath(in.Path)
+	if perr != nil {
+		return perr.Error(), true, nil
+	}
+	sess, ok := d.store.Get(in.SessionID, principal, d.now())
+	if !ok {
+		return "no such session", true, nil
+	}
+	maxBytes := d.cfg.MaxOutBytes
+	if in.MaxBytes > 0 && in.MaxBytes < maxBytes {
+		maxBytes = in.MaxBytes
+	}
+	data, err := d.eng.Read(ctx, sess.Name, rel, maxBytes)
+	if err != nil {
+		return "read failed: " + err.Error(), true, nil
+	}
+	if in.Encoding == "base64" {
+		return base64.StdEncoding.EncodeToString(data), false, nil
+	}
+	return string(data), false, nil
+}
+
+func (d *Dispatcher) close(ctx context.Context, principal string, raw json.RawMessage) (string, bool, error) {
+	var in struct {
+		SessionID string `json:"session_id"`
+	}
+	if err := unmarshalArgs(raw, &in); err != nil {
+		return "", false, err
+	}
+	sess, ok := d.store.Get(in.SessionID, principal, d.now())
+	if !ok {
+		return "no such session (already closed?)", false, nil // idempotent
+	}
+	d.store.Remove(sess.ID)
+	if err := d.eng.Close(ctx, sess.Name); err != nil {
+		return "close reported: " + err.Error(), true, nil
+	}
+	return "closed " + sess.ID, false, nil
+}
+
+func (d *Dispatcher) list(principal string) (string, bool, error) {
+	sessions := d.store.ListByPrincipal(principal)
+	out := make([]map[string]any, 0, len(sessions))
+	for _, s := range sessions {
+		out = append(out, map[string]any{
+			"session_id": s.ID,
+			"network":    s.Network,
+			"created_at": s.CreatedAt.UTC().Format(time.RFC3339),
+			"last_used":  s.LastUsed.UTC().Format(time.RFC3339),
+		})
+	}
+	b, _ := json.Marshal(map[string]any{"sessions": out})
+	return string(b), false, nil
+}
+
+// clampOpen turns caller-requested values into an openOpts within operator
+// ceilings. Zero / negative requests fall back to the defaults; over-ceiling
+// requests are clamped down (never up).
+func clampOpen(cfg *Config, network string, tmpfsMB int64, cpus float64, memMB, pids int64) openOpts {
+	o := openOpts{
+		Network: "none",
+		TmpfsMB: cfg.DefTmpfsMB,
+		CPUs:    cfg.DefCPUs,
+		MemMB:   cfg.DefMemMB,
+		Pids:    cfg.DefPids,
+	}
+	if network == "egress" {
+		o.Network = "egress"
+	}
+	if tmpfsMB > 0 {
+		o.TmpfsMB = tmpfsMB
+	}
+	if o.TmpfsMB > cfg.MaxTmpfsMB {
+		o.TmpfsMB = cfg.MaxTmpfsMB
+	}
+	if cpus > 0 {
+		o.CPUs = cpus
+	}
+	if o.CPUs > cfg.MaxCPUs {
+		o.CPUs = cfg.MaxCPUs
+	}
+	if memMB > 0 {
+		o.MemMB = memMB
+	}
+	if o.MemMB > cfg.MaxMemMB {
+		o.MemMB = cfg.MaxMemMB
+	}
+	if pids > 0 {
+		o.Pids = pids
+	}
+	if o.Pids > cfg.MaxPids {
+		o.Pids = cfg.MaxPids
+	}
+	return o
+}
+
+// safeRelPath validates a caller-supplied workspace path. It must be a relative
+// path that stays under /work — no absolute paths, no "..", no NUL/control
+// bytes. Returns the cleaned relative path.
+func safeRelPath(p string) (string, error) {
+	if p == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	if strings.HasPrefix(p, "/") {
+		return "", fmt.Errorf("path must be relative to %s (no leading /)", workDir)
+	}
+	for _, r := range p {
+		if r == 0 || r < 0x20 {
+			return "", fmt.Errorf("path contains a control character")
+		}
+	}
+	for _, seg := range strings.Split(p, "/") {
+		if seg == ".." {
+			return "", fmt.Errorf("path may not contain '..'")
+		}
+	}
+	return p, nil
+}
+
+func decodeContent(s, encoding string) ([]byte, error) {
+	if encoding == "base64" {
+		b, err := base64.StdEncoding.DecodeString(s)
+		if err != nil {
+			return nil, fmt.Errorf("content is not valid base64: %w", err)
+		}
+		return b, nil
+	}
+	return []byte(s), nil
+}
+
+func unmarshalArgs(raw json.RawMessage, v any) error {
+	if len(raw) == 0 {
+		raw = json.RawMessage("{}")
+	}
+	if err := json.Unmarshal(raw, v); err != nil {
+		return fmt.Errorf("invalid arguments: %w", err)
+	}
+	return nil
+}
+
+// newID returns a 128-bit random hex id for a session — unguessable within a
+// principal (and the store's principal check makes it useless across principals).
+func newID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b[:]), nil
+}
+
+// Input schemas. Kept as raw JSON so they pass through tools/list verbatim.
+var (
+	schemaOpen = json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"network": {"type": "string", "enum": ["none", "egress"], "description": "Network access. 'none' (default) fully isolates the sandbox; 'egress' allows outbound network only if the operator enabled it."},
+			"tmpfs_mb": {"type": "integer", "description": "Size of the in-memory /work workspace in MiB (clamped to the operator maximum)."},
+			"cpu": {"type": "number", "description": "CPU cores (clamped to the operator maximum)."},
+			"mem_mb": {"type": "integer", "description": "Memory limit in MiB (clamped to the operator maximum)."},
+			"pids": {"type": "integer", "description": "Max process count (clamped to the operator maximum)."}
+		}
+	}`)
+	schemaExec = json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"session_id": {"type": "string", "description": "The session from sandbox_open."},
+			"command": {"type": "string", "description": "Shell command to run in /work."},
+			"timeout_seconds": {"type": "integer", "description": "Per-command timeout (clamped to the operator maximum)."},
+			"max_output_bytes": {"type": "integer", "description": "Cap on returned output bytes."}
+		},
+		"required": ["session_id", "command"]
+	}`)
+	schemaWrite = json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"session_id": {"type": "string"},
+			"path": {"type": "string", "description": "Destination path relative to /work."},
+			"content": {"type": "string", "description": "File content (UTF-8, or base64 when encoding=base64)."},
+			"encoding": {"type": "string", "enum": ["utf8", "base64"], "description": "Content encoding (default utf8)."}
+		},
+		"required": ["session_id", "path", "content"]
+	}`)
+	schemaRead = json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"session_id": {"type": "string"},
+			"path": {"type": "string", "description": "Source path relative to /work."},
+			"max_bytes": {"type": "integer"},
+			"encoding": {"type": "string", "enum": ["utf8", "base64"], "description": "Return encoding (base64 for binary files)."}
+		},
+		"required": ["session_id", "path"]
+	}`)
+	schemaClose = json.RawMessage(`{
+		"type": "object",
+		"properties": {"session_id": {"type": "string"}},
+		"required": ["session_id"]
+	}`)
+	schemaList = json.RawMessage(`{"type": "object", "properties": {}}`)
+)

--- a/deploy/builder/tools_test.go
+++ b/deploy/builder/tools_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestClampOpen_ClampsAndDefaults(t *testing.T) {
+	cfg := testCfg() // ceilings: tmpfs 2048, cpu 2, mem 2048, pids 512
+
+	// Over-ceiling requests are clamped DOWN.
+	o := clampOpen(cfg, "none", 999999, 64, 999999, 999999)
+	if o.TmpfsMB != 2048 || o.CPUs != 2 || o.MemMB != 2048 || o.Pids != 512 {
+		t.Errorf("over-ceiling not clamped: %+v", o)
+	}
+	// Zero/omitted → defaults.
+	d := clampOpen(cfg, "", 0, 0, 0, 0)
+	if d.TmpfsMB != 512 || d.CPUs != 2 || d.MemMB != 2048 || d.Pids != 512 || d.Network != "none" {
+		t.Errorf("defaults wrong: %+v", d)
+	}
+	// A smaller request is honoured.
+	sm := clampOpen(cfg, "none", 128, 1, 256, 64)
+	if sm.TmpfsMB != 128 || sm.CPUs != 1 || sm.MemMB != 256 || sm.Pids != 64 {
+		t.Errorf("smaller request not honoured: %+v", sm)
+	}
+	if clampOpen(cfg, "egress", 0, 0, 0, 0).Network != "egress" {
+		t.Errorf("egress request should set Network=egress (engine still gates it)")
+	}
+}
+
+func TestSafeRelPath(t *testing.T) {
+	good := []string{"main.go", "src/main.go", "a/b/c.txt", ".hidden"}
+	for _, p := range good {
+		if _, err := safeRelPath(p); err != nil {
+			t.Errorf("safeRelPath(%q) unexpected error: %v", p, err)
+		}
+	}
+	bad := []string{"", "/etc/passwd", "../escape", "a/../../b", "a/../b", "x\x00y", "line\nbreak"}
+	for _, p := range bad {
+		if _, err := safeRelPath(p); err == nil {
+			t.Errorf("safeRelPath(%q) should have errored", p)
+		}
+	}
+}
+
+func TestDecodeContent(t *testing.T) {
+	if b, err := decodeContent("aGk=", "base64"); err != nil || string(b) != "hi" {
+		t.Errorf("base64 decode: %q %v", b, err)
+	}
+	if _, err := decodeContent("!!!notb64", "base64"); err == nil {
+		t.Errorf("expected base64 error")
+	}
+	if b, _ := decodeContent("plain", "utf8"); string(b) != "plain" {
+		t.Errorf("utf8 passthrough failed")
+	}
+}
+
+// TestDispatch_OpenExecCloseLifecycle drives the tool layer end to end with a
+// fake podman, asserting the session lifecycle + exit-code → isError semantics.
+func TestDispatch_OpenExecCloseLifecycle(t *testing.T) {
+	cfg := testCfg()
+	// exec returns exit 1 for a "fail" command, 0 otherwise; run/rm succeed.
+	fr := &fakeRunner{fn: func(argv []string, _ []byte) ([]byte, int, error) {
+		joined := strings.Join(argv, " ")
+		switch {
+		case strings.Contains(joined, "exec") && strings.Contains(joined, "fail"):
+			return []byte("boom"), 1, nil
+		case strings.Contains(joined, "exec"):
+			return []byte("ok"), 0, nil
+		default:
+			return nil, 0, nil // run / rm
+		}
+	}}
+	d := NewDispatcher(cfg, NewEngine(cfg, fr), NewStore(cfg.SessionIdleTTL, cfg.SessionMaxTTL))
+	ctx := context.Background()
+	const principal = "op:test"
+
+	// open
+	text, isErr, err := d.Call(ctx, principal, "sandbox_open", json.RawMessage(`{}`))
+	if err != nil || isErr {
+		t.Fatalf("open failed: isErr=%v err=%v text=%s", isErr, err, text)
+	}
+	var opened struct {
+		SessionID string `json:"session_id"`
+		Workspace string `json:"workspace_path"`
+	}
+	if e := json.Unmarshal([]byte(text), &opened); e != nil || opened.SessionID == "" {
+		t.Fatalf("open response not parseable: %s (%v)", text, e)
+	}
+	if opened.Workspace != workDir {
+		t.Errorf("workspace_path = %q want %q", opened.Workspace, workDir)
+	}
+
+	// exec success → isError false
+	args, _ := json.Marshal(map[string]any{"session_id": opened.SessionID, "command": "echo ok"})
+	text, isErr, _ = d.Call(ctx, principal, "sandbox_exec", args)
+	if isErr || !strings.Contains(text, "ok") {
+		t.Errorf("exec ok: isErr=%v text=%q", isErr, text)
+	}
+
+	// exec failure → isError true + [exit: 1] marker
+	args, _ = json.Marshal(map[string]any{"session_id": opened.SessionID, "command": "fail"})
+	text, isErr, _ = d.Call(ctx, principal, "sandbox_exec", args)
+	if !isErr || !strings.Contains(text, "[exit: 1]") {
+		t.Errorf("exec fail should be isError with exit marker: isErr=%v text=%q", isErr, text)
+	}
+
+	// a foreign principal cannot exec in this session
+	_, isErr, _ = d.Call(ctx, "op:other", "sandbox_exec", args)
+	if !isErr {
+		t.Errorf("foreign principal should get an error (no such session)")
+	}
+
+	// close
+	closeArgs, _ := json.Marshal(map[string]any{"session_id": opened.SessionID})
+	_, isErr, _ = d.Call(ctx, principal, "sandbox_close", closeArgs)
+	if isErr {
+		t.Errorf("close should succeed")
+	}
+	// second close is idempotent (session gone → not an error)
+	_, isErr, _ = d.Call(ctx, principal, "sandbox_close", closeArgs)
+	if isErr {
+		t.Errorf("idempotent close should not error")
+	}
+}
+
+func TestDispatch_CapacityLimit(t *testing.T) {
+	cfg := testCfg()
+	cfg.MaxSessions = 1
+	fr := &fakeRunner{}
+	d := NewDispatcher(cfg, NewEngine(cfg, fr), NewStore(cfg.SessionIdleTTL, cfg.SessionMaxTTL))
+	if _, isErr, _ := d.Call(context.Background(), "p", "sandbox_open", json.RawMessage(`{}`)); isErr {
+		t.Fatal("first open should succeed")
+	}
+	text, isErr, _ := d.Call(context.Background(), "p", "sandbox_open", json.RawMessage(`{}`))
+	if !isErr || !strings.Contains(text, "capacity") {
+		t.Errorf("second open should hit capacity: isErr=%v text=%q", isErr, text)
+	}
+}


### PR DESCRIPTION
First phase of the isolated code-execution sandbox (RFC BI). This PR adds the **reference sidecar**; a follow-up PR wires the loomcycle-side `sandbox` bundle + config + docs that consume it.

## Why

The distroless loomcycle image can't run podman (no `/etc/subuid`, no `newuidmap`; uid 65532), and mounting a host engine socket into the process that runs model-authored code would be ≈ host root. So container-backed execution lives in a **standalone sidecar** that loomcycle drives over **HTTP-MCP** — loomcycle stays distroless and never touches an engine socket, and a compromised loomcycle can only call the constrained `sandbox_*` API, never craft a privileged container.

## What

New module **`deploy/builder/`** — stdlib only, its own `go.mod`, **excluded from the root module** (zero new deps in loomcycle). It exposes six MCP tools over a minimal Streamable-HTTP MCP server that matches loomcycle's `internal/tools/mcp/http` client wire contract exactly (initialize / `notifications/initialized` / tools/list / tools/call; JSON-RPC 2.0; `content:[{type:"text"}]`; id echo; `Mcp-Session-Id`):

| Tool | Purpose |
|---|---|
| `sandbox_open` | Create a session container → `session_id` (params clamped to operator ceilings). |
| `sandbox_exec` | Run a command in `/work`; combined output + exit code. |
| `sandbox_write` / `sandbox_read` | Files in / artifacts out (relative to `/work`). |
| `sandbox_close` / `sandbox_list` | Destroy / enumerate sessions. |

Long-lived session model: open once, `exec` many across a compile→test→fix loop (workspace + build cache persist), close when done.

**Hardening** on every session container: `--network none` (egress only when operator-enabled AND requested), `--read-only` rootfs with an in-memory `--tmpfs /work` (nothing written touches disk — the "in-memory for safety" requirement), `--cap-drop=ALL`, `no-new-privileges`, non-root user, `--pids-limit`/`--memory`/`--cpus` caps, pluggable `--runtime` (runc/crun/runsc/kata). Bearer-authed (constant-time); refuses to start unauthenticated unless `SANDBOX_ALLOW_ANON`. Sessions are principal-owned (a leaked id from another principal never resolves — the P2 tenant-isolation seam), reaped on idle/absolute TTL, orphans swept at boot via the `loomcycle.managed=1` label. No host shell injection: podman is exec'd directly; file paths ride in env vars, content via stdin.

Also ships `deploy/builder/session/Dockerfile` (the reference toolchain image sessions run) and the sidecar `Dockerfile` (on `quay.io/podman/stable`; Sysbox recommended, `privileged` fallback documented).

## What was tested

- `go test ./...` in the module — **race-clean, gofmt/vet clean**:
  - `TestEngine_RunArgs_HardeningPosture` asserts the full hardening flag set; egress on/off paths.
  - `TestEngine_WriteArgs_PathViaEnvNotShell` — injection safety (path via env, content via stdin).
  - `mcp_test.go` round-trips the handler against the exact shapes loomcycle's client decodes (initialize/tools/list/tools/call, id echo, `Mcp-Session-Id`, 401/200, notification→202, unknown→-32601).
  - path-safety (`../`/abs/control rejected), clamping, principal ownership, TTL GC (idle + aged), capacity cap.
- Root module unaffected: `go list ./...` excludes `deploy/builder`; root `go build ./...` OK.
- ⚠️ **Images not built here** — no local docker daemon. Building both images + an e2e `sandbox_open→exec→read→close` run needs a podman host (Sysbox or privileged); that's the documented next step.

## Scope

RFC BI **P1**: single shared bearer, TTL + explicit close, runc/runsc. Deferred to P2/P3: attested per-tenant identity (loomcycle-filled `X-Loom-Tenant`/`X-Loom-Root-Run` headers), run-liveness-poll GC, Kata microVM tier, shared-workspace bind mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)