### PR TITLE
feat(sandbox): sandbox bundle + operator guide (RFC BI P1)

### DIFF
--- a/bundles/sandbox/README.md
+++ b/bundles/sandbox/README.md
@@ -1,0 +1,57 @@
+# sandbox bundle
+
+A **code-execution agent** that compiles, tests, and runs code in an **isolated,
+ephemeral sandbox container** — Python / Go / Rust / C++ / Node — *without* giving
+the agent access to loomcycle's own container.
+
+| Agent | Routing | Use it for |
+|---|---|---|
+| **`dev/sandbox`** | `tier: middle` | Writing + building + testing + running code safely in a disposable, network-off container. |
+
+The container work happens in the **builder sidecar** (a separate service);
+loomcycle stays distroless and drives it over HTTP-MCP. The bundle wires the
+`mcp__sandbox__*` tools + the `dev/sandbox` agent + skill. This is a **first-class,
+reusable bundle** — not an `examples/` experiment.
+
+```
+bundles/sandbox/
+├── loomcycle.yaml   # the dev/sandbox agent + skill + mcp_servers.sandbox (identical to the embedded copy)
+└── README.md
+```
+
+The binary ships an **embedded** copy at
+[`cmd/loomcycle/embedded/bundles/sandbox.yaml`](../../cmd/loomcycle/embedded/bundles/sandbox.yaml)
+(`go:embed`). `bundles/sandbox/loomcycle.yaml` is the in-repo source mirror — keep
+the two byte-for-byte identical.
+
+## Enable
+
+```sh
+# the bundle carries no provider matrix — pair it with `base`
+LOOMCYCLE_PRESETS=base,sandbox
+```
+
+### Requirements
+
+- **The builder sidecar** deployed on loomcycle's app network — it serves the
+  `mcp__sandbox__*` tools. Build + run it from
+  [`deploy/builder/`](../../deploy/builder/); full operator guide in
+  [`docs/SANDBOX.md`](../../docs/SANDBOX.md). Without it the sandbox tools are
+  registered-but-unreachable (the MCP pool retries lazily).
+- **`LOOMCYCLE_SANDBOX_TOKEN`** — the shared bearer, set to the SAME value as the
+  sidecar's `SANDBOX_AUTH_TOKEN`. The `mcp_servers.sandbox` header consumes it.
+- **A `middle` tier** — select `base` alongside, or supply your own.
+
+## Overriding
+
+The operator overlay can re-declare any field (last layer wins) — most commonly
+`mcp_servers.sandbox.url` if the sidecar isn't at `http://builder-sidecar:9000`,
+or the agent's tier/sampling. It cannot **widen** `tools` beyond what the bundle
+grants.
+
+## Isolation note
+
+Unlike the `loomcycle-toolbox` image (which runs code in loomcycle's own
+container — single-tenant/trusted only), this bundle runs each session in a
+dedicated, ephemeral, `--network none`, `--read-only`, resource-capped container
+with an in-memory workspace. It is the path for untrusted / multi-tenant code.

--- a/bundles/sandbox/loomcycle.yaml
+++ b/bundles/sandbox/loomcycle.yaml
@@ -1,0 +1,105 @@
+# embedded bundle: sandbox
+# A code-execution agent that runs code in an ISOLATED, ephemeral sandbox
+# container via the builder sidecar — compile, test, and run Python/Go/Rust/C++/
+# Node WITHOUT giving the agent access to loomcycle's own container.
+#
+# Selected via `LOOMCYCLE_PRESETS=…,sandbox`. Requires:
+#   - the builder sidecar deployed on the app network (deploy/builder/; see
+#     docs/SANDBOX.md) — the mcp__sandbox__* tools are served by it.
+#   - LOOMCYCLE_SANDBOX_TOKEN set to the SAME shared secret as the sidecar's
+#     SANDBOX_AUTH_TOKEN (the mcp_servers header below consumes it).
+#   - a `middle` tier — select `base` alongside, or supply your own.
+# Without the sidecar the mcp__sandbox__* tools are registered-but-unreachable
+# (the MCP pool retries lazily); nothing else in the bundle is affected.
+#
+# The operator overlay can override any field (last layer wins) — e.g. re-declare
+# mcp_servers.sandbox.url if the sidecar isn't at http://builder-sidecar:9000.
+
+agents:
+  dev/sandbox:
+    tier: middle
+    effort: medium
+    tools: [mcp__sandbox__sandbox_open, mcp__sandbox__sandbox_exec, mcp__sandbox__sandbox_write, mcp__sandbox__sandbox_read, mcp__sandbox__sandbox_close, mcp__sandbox__sandbox_list, Interruption]
+    skills: [dev/sandbox]
+    compaction:
+      enabled: true
+      autocompact_at_pct: 80
+    system_prompt: |
+      You are SANDBOX, an agent that writes, compiles, tests, and runs code in an
+      isolated ephemeral sandbox. You never run code on the host — every command
+      runs inside a disposable container reached through your sandbox tools.
+
+      ## How you work
+      1. Open ONE sandbox session at the start (sandbox_open) and reuse it for the
+         whole task — the workspace (/work), installed dependencies, and the build
+         cache persist across commands. Only open another for genuinely separate work.
+      2. Put source in with sandbox_write (paths relative to /work), then build and
+         test with sandbox_exec. Read a non-zero exit + its output, fix, and re-run —
+         that compile→test→fix loop is the core of the job.
+      3. Pull results out with sandbox_read when you need to show an artifact.
+      4. Close the session with sandbox_close when the task is done.
+
+      ## Notes
+      - The sandbox has Python, Go, Rust, C/C++, and Node preinstalled. /work is an
+        in-memory workspace that vanishes when the session closes — nothing persists.
+      - By default the sandbox has NO network. If a step must fetch dependencies and
+        the operator enabled it, open the session with network:"egress".
+      - Resource limits (cpu/mem/pids/tmpfs) are capped by the operator; ask for less
+        when a task is small, never more than you need.
+      - If the sandbox tools are unavailable, the builder sidecar isn't deployed —
+        tell the human rather than trying to run code some other way.
+
+      ## Style
+      - Lead with the result (did it build? did tests pass?), then the details.
+      - Show the command you ran and the relevant output, not the whole log.
+      - Ask a clarifying question when the task is ambiguous instead of guessing.
+
+skills:
+  dev/sandbox:
+    description: Compile, test, and run code safely in an isolated ephemeral sandbox container (Python/Go/Rust/C++/Node) via the builder sidecar.
+    tools: [mcp__sandbox__sandbox_open, mcp__sandbox__sandbox_exec, mcp__sandbox__sandbox_write, mcp__sandbox__sandbox_read, mcp__sandbox__sandbox_close]
+    body: |
+      # Running code in the sandbox
+
+      All code runs INSIDE a disposable container, never on the host. One session =
+      one long-lived container you reuse across a compile→test→fix loop.
+
+      ## Lifecycle
+      1. sandbox_open → returns a session_id; pass it to every later call. Options
+         (all optional, all clamped to operator ceilings): network ("none" default |
+         "egress"), tmpfs_mb, cpu, mem_mb, pids.
+      2. sandbox_write {session_id, path, content} — write a file under /work (parent
+         dirs are created). Use encoding:"base64" for binary content.
+      3. sandbox_exec {session_id, command} — run a shell command in /work. You get
+         combined stdout+stderr and the exit code; a non-zero exit is reported so you
+         can read the error and fix it. timeout_seconds is clamped to the operator max.
+      4. sandbox_read {session_id, path} — read a file back out (encoding:"base64" for
+         binary artifacts).
+      5. sandbox_close {session_id} — destroy the session. Always close when done;
+         sessions also expire on an idle timeout.
+
+      ## Example: clone, build, test (Go)
+      - sandbox_open {network:"egress"} → session_id
+      - sandbox_exec {session_id, command:"git clone https://github.com/OWNER/REPO . && go build ./..."}
+      - if the exit code is non-zero, read the error, fix a file with sandbox_write,
+        then re-run "go build ./... && go test ./..."
+      - sandbox_read {session_id, path:"bin/app"} to pull the built binary
+      - sandbox_close {session_id}
+
+      ## Rules
+      - Reuse ONE session for a task — don't open a new one per command (you'd lose the
+        checkout + build cache).
+      - Default to network:"none"; use "egress" only when a step must fetch something
+        and the operator enabled egress.
+      - Never assume host access — you only have these sandbox tools.
+
+mcp_servers:
+  sandbox:
+    transport: http
+    # The builder sidecar on the app network (deploy/builder/). Override in your
+    # overlay if it isn't at this address.
+    url: http://builder-sidecar:9000/mcp
+    headers:
+      # Per-run bearer when present, else the shared LOOMCYCLE_SANDBOX_TOKEN secret
+      # (must equal the sidecar's SANDBOX_AUTH_TOKEN).
+      Authorization: "Bearer ${run.user_bearer:-${LOOMCYCLE_SANDBOX_TOKEN}}"

--- a/cmd/loomcycle/embedded/bundles/sandbox.yaml
+++ b/cmd/loomcycle/embedded/bundles/sandbox.yaml
@@ -1,0 +1,105 @@
+# embedded bundle: sandbox
+# A code-execution agent that runs code in an ISOLATED, ephemeral sandbox
+# container via the builder sidecar — compile, test, and run Python/Go/Rust/C++/
+# Node WITHOUT giving the agent access to loomcycle's own container.
+#
+# Selected via `LOOMCYCLE_PRESETS=…,sandbox`. Requires:
+#   - the builder sidecar deployed on the app network (deploy/builder/; see
+#     docs/SANDBOX.md) — the mcp__sandbox__* tools are served by it.
+#   - LOOMCYCLE_SANDBOX_TOKEN set to the SAME shared secret as the sidecar's
+#     SANDBOX_AUTH_TOKEN (the mcp_servers header below consumes it).
+#   - a `middle` tier — select `base` alongside, or supply your own.
+# Without the sidecar the mcp__sandbox__* tools are registered-but-unreachable
+# (the MCP pool retries lazily); nothing else in the bundle is affected.
+#
+# The operator overlay can override any field (last layer wins) — e.g. re-declare
+# mcp_servers.sandbox.url if the sidecar isn't at http://builder-sidecar:9000.
+
+agents:
+  dev/sandbox:
+    tier: middle
+    effort: medium
+    tools: [mcp__sandbox__sandbox_open, mcp__sandbox__sandbox_exec, mcp__sandbox__sandbox_write, mcp__sandbox__sandbox_read, mcp__sandbox__sandbox_close, mcp__sandbox__sandbox_list, Interruption]
+    skills: [dev/sandbox]
+    compaction:
+      enabled: true
+      autocompact_at_pct: 80
+    system_prompt: |
+      You are SANDBOX, an agent that writes, compiles, tests, and runs code in an
+      isolated ephemeral sandbox. You never run code on the host — every command
+      runs inside a disposable container reached through your sandbox tools.
+
+      ## How you work
+      1. Open ONE sandbox session at the start (sandbox_open) and reuse it for the
+         whole task — the workspace (/work), installed dependencies, and the build
+         cache persist across commands. Only open another for genuinely separate work.
+      2. Put source in with sandbox_write (paths relative to /work), then build and
+         test with sandbox_exec. Read a non-zero exit + its output, fix, and re-run —
+         that compile→test→fix loop is the core of the job.
+      3. Pull results out with sandbox_read when you need to show an artifact.
+      4. Close the session with sandbox_close when the task is done.
+
+      ## Notes
+      - The sandbox has Python, Go, Rust, C/C++, and Node preinstalled. /work is an
+        in-memory workspace that vanishes when the session closes — nothing persists.
+      - By default the sandbox has NO network. If a step must fetch dependencies and
+        the operator enabled it, open the session with network:"egress".
+      - Resource limits (cpu/mem/pids/tmpfs) are capped by the operator; ask for less
+        when a task is small, never more than you need.
+      - If the sandbox tools are unavailable, the builder sidecar isn't deployed —
+        tell the human rather than trying to run code some other way.
+
+      ## Style
+      - Lead with the result (did it build? did tests pass?), then the details.
+      - Show the command you ran and the relevant output, not the whole log.
+      - Ask a clarifying question when the task is ambiguous instead of guessing.
+
+skills:
+  dev/sandbox:
+    description: Compile, test, and run code safely in an isolated ephemeral sandbox container (Python/Go/Rust/C++/Node) via the builder sidecar.
+    tools: [mcp__sandbox__sandbox_open, mcp__sandbox__sandbox_exec, mcp__sandbox__sandbox_write, mcp__sandbox__sandbox_read, mcp__sandbox__sandbox_close]
+    body: |
+      # Running code in the sandbox
+
+      All code runs INSIDE a disposable container, never on the host. One session =
+      one long-lived container you reuse across a compile→test→fix loop.
+
+      ## Lifecycle
+      1. sandbox_open → returns a session_id; pass it to every later call. Options
+         (all optional, all clamped to operator ceilings): network ("none" default |
+         "egress"), tmpfs_mb, cpu, mem_mb, pids.
+      2. sandbox_write {session_id, path, content} — write a file under /work (parent
+         dirs are created). Use encoding:"base64" for binary content.
+      3. sandbox_exec {session_id, command} — run a shell command in /work. You get
+         combined stdout+stderr and the exit code; a non-zero exit is reported so you
+         can read the error and fix it. timeout_seconds is clamped to the operator max.
+      4. sandbox_read {session_id, path} — read a file back out (encoding:"base64" for
+         binary artifacts).
+      5. sandbox_close {session_id} — destroy the session. Always close when done;
+         sessions also expire on an idle timeout.
+
+      ## Example: clone, build, test (Go)
+      - sandbox_open {network:"egress"} → session_id
+      - sandbox_exec {session_id, command:"git clone https://github.com/OWNER/REPO . && go build ./..."}
+      - if the exit code is non-zero, read the error, fix a file with sandbox_write,
+        then re-run "go build ./... && go test ./..."
+      - sandbox_read {session_id, path:"bin/app"} to pull the built binary
+      - sandbox_close {session_id}
+
+      ## Rules
+      - Reuse ONE session for a task — don't open a new one per command (you'd lose the
+        checkout + build cache).
+      - Default to network:"none"; use "egress" only when a step must fetch something
+        and the operator enabled egress.
+      - Never assume host access — you only have these sandbox tools.
+
+mcp_servers:
+  sandbox:
+    transport: http
+    # The builder sidecar on the app network (deploy/builder/). Override in your
+    # overlay if it isn't at this address.
+    url: http://builder-sidecar:9000/mcp
+    headers:
+      # Per-run bearer when present, else the shared LOOMCYCLE_SANDBOX_TOKEN secret
+      # (must equal the sidecar's SANDBOX_AUTH_TOKEN).
+      Authorization: "Bearer ${run.user_bearer:-${LOOMCYCLE_SANDBOX_TOKEN}}"

--- a/cmd/loomcycle/embedded/presets_test.go
+++ b/cmd/loomcycle/embedded/presets_test.go
@@ -22,6 +22,7 @@ func TestUnits_RegistryShape(t *testing.T) {
 		"document-agent": "bundle",
 		"agent-teams":    "bundle",
 		"team-examples":  "bundle",
+		"sandbox":        "bundle",
 	}
 	for name, kind := range want {
 		u, ok := byName[name]

--- a/cmd/loomcycle/presets_integration_test.go
+++ b/cmd/loomcycle/presets_integration_test.go
@@ -124,6 +124,42 @@ func TestEmbedded_DefaultStackValidates(t *testing.T) {
 	}
 }
 
+// TestEmbedded_SandboxBundleValidates: the opt-in sandbox bundle loads +
+// validates on top of base, registering the dev/sandbox agent (with its skill
+// and the mcp__sandbox__* tool grants) and the sandbox MCP server. The bundle is
+// NOT in the default stack (it needs the builder sidecar + a token), so it gets
+// its own guard here — an ACL grant without a matching declaration would fail
+// validate() fatally, exactly as the v1.20.1 default-stack regression did.
+func TestEmbedded_SandboxBundleValidates(t *testing.T) {
+	t.Setenv("LOOMCYCLE_SKILLS_ROOT", "")
+	cfg, err := config.LoadLayers(layersFor(t, "base", "sandbox")...)
+	if err != nil {
+		t.Fatalf("base + sandbox must load + validate cleanly: %v", err)
+	}
+	agent, ok := cfg.Agents["dev/sandbox"]
+	if !ok {
+		t.Fatalf("dev/sandbox agent not registered (agents: %v)", agentNames(cfg))
+	}
+	// The agent must grant the sandbox tools + the auto-added Skill tool.
+	for _, want := range []string{"mcp__sandbox__sandbox_open", "mcp__sandbox__sandbox_exec", "Skill"} {
+		if !hasToolPreset(agent.Tools, want) {
+			t.Errorf("dev/sandbox should grant %q; tools=%v", want, agent.Tools)
+		}
+	}
+	// The inline skill is in the on-demand catalog with its body intact.
+	if sk, ok := cfg.Skills["dev/sandbox"]; !ok || strings.TrimSpace(sk.Body) == "" {
+		t.Errorf("dev/sandbox skill missing or empty in cfg.Skills")
+	}
+	// The MCP server the tools resolve through is declared (http transport + url).
+	sv, ok := cfg.MCPServers["sandbox"]
+	if !ok {
+		t.Fatalf("sandbox MCP server not declared")
+	}
+	if sv.Transport != "http" || sv.URL == "" {
+		t.Errorf("sandbox MCP server should be http with a url; got transport=%q url=%q", sv.Transport, sv.URL)
+	}
+}
+
 // hasToolPreset reports whether tools contains name.
 func hasToolPreset(tools []string, name string) bool {
 	for _, t := range tools {

--- a/docker-compose.example.yaml
+++ b/docker-compose.example.yaml
@@ -102,3 +102,26 @@ services:
   #   environment:
   #     SEARXNG_BASE_URL: http://searxng:8080/
   #   # No ports: — only loomcycle needs to reach it, in-network.
+
+  # --- builder sidecar (uncomment for the isolated code-execution sandbox) ---
+  # Runs a dev toolchain in per-session, network-off, ephemeral containers via
+  # rootless podman; loomcycle drives it over HTTP-MCP and stays distroless.
+  # loomcycle reaches it in-network at http://builder-sidecar:9000/mcp — no host
+  # port. Build it + the session image from deploy/builder/ (see docs/SANDBOX.md),
+  # then select the `sandbox` bundle (LOOMCYCLE_PRESETS=…,sandbox) and set
+  # LOOMCYCLE_SANDBOX_TOKEN on the loomcycle service to the same shared secret.
+  # builder-sidecar:
+  #   image: denngubsky/loomcycle-builder:latest
+  #   container_name: builder-sidecar
+  #   restart: unless-stopped
+  #   # Nested podman needs a capable host runtime — Sysbox (secure) is preferred;
+  #   # privileged: true is the fallback (accept the risk; e.g. on TrueNAS).
+  #   runtime: sysbox-runc
+  #   environment:
+  #     SANDBOX_AUTH_TOKEN: ${LOOMCYCLE_SANDBOX_TOKEN}     # same secret as loomcycle's
+  #     SANDBOX_IMAGE: localhost/loomcycle-sandbox-session:latest
+  #     SANDBOX_MAX_MEM_MB: "2048"
+  #     SANDBOX_MAX_CPUS: "2"
+  #     # SANDBOX_RUNTIME: runsc          # set once gVisor is installed in the image
+  #     # SANDBOX_ALLOW_EGRESS: "1"       # permit network:"egress" sessions
+  #   # No ports: — only loomcycle needs to reach it, in-network.

--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -1,0 +1,113 @@
+# Sandboxed code execution
+
+There are two ways to let a loomcycle agent run code, and they trade off
+convenience against isolation:
+
+- The **`loomcycle-toolbox` image** ([docs/TOOLBOX_IMAGE.md](TOOLBOX_IMAGE.md))
+  bakes a toolchain into loomcycle's own container. Simple, but code runs *as
+  loomcycle* — single-tenant / trusted only.
+- The **builder sidecar** (this doc) runs each code-execution session in a
+  **separate, isolated, ephemeral container** — network-off, read-only rootfs,
+  resource-capped, in-memory workspace. loomcycle stays distroless and never runs
+  a container engine; it drives the sidecar over HTTP-MCP.
+
+**Thesis:** use the toolbox image for a quick trusted setup; use the builder
+sidecar when the code is untrusted or the deployment is multi-tenant.
+
+## Why a sidecar (not loomcycle itself)
+
+loomcycle ships distroless and non-root (uid 65532): it *cannot* run rootless
+podman (no subuid range / `newuidmap`), and mounting a host podman socket into
+the process that runs model-authored code would be ≈ host root. So the engine
+lives in a sidecar, and loomcycle reaches it the one distroless-safe way it
+reaches any external capability — MCP over HTTP. A compromised loomcycle can only
+call the constrained `sandbox_*` API; it can never craft a privileged container.
+
+```
+agent (loomcycle · distroless)
+   │  mcp__sandbox__sandbox_exec        (HTTP-MCP, bearer-authed, in-network)
+   ▼
+builder-sidecar                    ──►  per-session container
+   rootless podman + tmpfs/runsc         --network none --read-only
+                                         --cap-drop=ALL --tmpfs /work
+```
+
+## Quick start
+
+1. **Build the images** (from `deploy/builder/`):
+
+   ```bash
+   docker build -t denngubsky/loomcycle-builder:latest deploy/builder
+   docker build -t localhost/loomcycle-sandbox-session:latest deploy/builder/session
+   ```
+
+2. **Set a shared secret.** Add `LOOMCYCLE_SANDBOX_TOKEN=<openssl rand -hex 32>`
+   to your `.env.local` — it authenticates loomcycle → sidecar. (It's referenced
+   by *name* in the config header below; loomcycle allows `${LOOMCYCLE_*}`
+   interpolation into an MCP header.)
+
+3. **Deploy the sidecar** on loomcycle's compose network (uncomment the
+   `builder-sidecar` block in `docker-compose.example.yaml`), passing the same
+   secret as `SANDBOX_AUTH_TOKEN` and the session image as `SANDBOX_IMAGE`.
+   Nested podman needs a capable host runtime — **Sysbox** (secure) is preferred;
+   `privileged: true` is the fallback (e.g. on TrueNAS, which lacks Sysbox).
+
+4. **Enable the bundle:** `LOOMCYCLE_PRESETS=base,sandbox`. That registers the
+   `dev/sandbox` agent + skill and the `sandbox` MCP server:
+
+   ```yaml
+   mcp_servers:
+     sandbox:
+       transport: http
+       url: http://builder-sidecar:9000/mcp
+       headers:
+         Authorization: "Bearer ${run.user_bearer:-${LOOMCYCLE_SANDBOX_TOKEN}}"
+   ```
+
+   (Selecting the bundle supplies this block; re-declare `url` in your overlay if
+   the sidecar isn't at `builder-sidecar:9000`.)
+
+5. **Run it.** Start the `dev/sandbox` agent (or grant `mcp__sandbox__*` to your
+   own agent) and ask it to compile/test something. It opens a session, writes
+   files, builds, tests, reads the artifact, and closes.
+
+## Tools
+
+| Tool | Purpose |
+|---|---|
+| `sandbox_open` | Create a session → `session_id`. Params (clamped to operator ceilings): `network` (`none`/`egress`), `tmpfs_mb`, `cpu`, `mem_mb`, `pids`. |
+| `sandbox_exec` | Run a command in the session's `/work`; returns combined output + exit code. |
+| `sandbox_write` / `sandbox_read` | Files in / artifacts out (relative to `/work`; `base64` for binary). |
+| `sandbox_close` / `sandbox_list` | Destroy / enumerate your sessions. |
+
+A session is one long-lived container — open once, run many commands across a
+compile→test→fix loop (workspace + build cache persist), close when done.
+Sessions also expire on an idle/absolute TTL, and orphans are reaped at sidecar
+startup.
+
+## Sidecar configuration
+
+See the environment reference in
+[`deploy/builder/README.md`](../deploy/builder/README.md#configuration-environment)
+— `SANDBOX_AUTH_TOKEN` (required), `SANDBOX_IMAGE` (required), `SANDBOX_RUNTIME`
+(`runc`/`crun`/`runsc`/`kata`), the `SANDBOX_MAX_*` ceilings, `SANDBOX_ALLOW_EGRESS`,
+and the session TTLs.
+
+## Isolation posture
+
+Every session container: `--network none` (egress only when operator-enabled AND
+requested), `--read-only` rootfs, in-memory `--tmpfs /work` (nothing written
+touches disk), `--cap-drop=ALL`, `no-new-privileges`, non-root user, and
+`--pids-limit`/`--memory`/`--cpus` caps. For code you truly don't trust, install
+gVisor in the sidecar image and set `SANDBOX_RUNTIME=runsc` for a user-space
+kernel boundary (Kata microVMs are a stronger, heavier option).
+
+The sidecar is the one privileged component — keep it in-network (no host port),
+bearer-authed, and behind Sysbox or an accepted `privileged` grant.
+
+## Scope
+
+This is the first phase: a single shared bearer (single-tenant), TTL + explicit
+`sandbox_close` for cleanup, and the `runc`/`runsc` runtimes. Attested
+per-tenant identity (multi-tenant isolation), run-liveness-poll GC, the Kata
+tier, and a bind-mounted shared workspace are planned follow-ups.


### PR DESCRIPTION
The loomcycle-side wiring for the isolated code-execution sandbox — the consumer of the builder sidecar (#745). Opt-in, **no core change**, no new default behaviour.

> Depends on **#745** (the `deploy/builder/` sidecar) for the `mcp__sandbox__*` tools — land that first or alongside.

## What

Enable with `LOOMCYCLE_PRESETS=base,sandbox`. The `sandbox` bundle registers:

- **`dev/sandbox` agent** (tier `middle`, compaction on) — tools are the `mcp__sandbox__*` set + `Interruption`; plus the auto-added `Skill`.
- **`dev/sandbox` skill** (on-demand) — teaches the `open → write → exec → read → close` loop, session reuse, and the network-off default.
- **`mcp_servers.sandbox`** → `http://builder-sidecar:9000/mcp` with `Authorization: Bearer ${run.user_bearer:-${LOOMCYCLE_SANDBOX_TOKEN}}` — per-run bearer when present, else the shared secret (set to the sidecar's `SANDBOX_AUTH_TOKEN`). The `${LOOMCYCLE_*}`-in-an-MCP-header form is the documented, allowlisted interpolation pattern (`ExpandEnvAllowed`).

Without the sidecar deployed, the sandbox tools are registered-but-unreachable (the MCP pool retries lazily) — nothing else is affected. The agent prompt + skill body reference only the tools (no internal-doc citations).

Also: `bundles/sandbox/` source mirror (byte-identical to the embed) + README; `docs/SANDBOX.md` (toolbox-image-vs-sidecar tradeoff, quick start, tool + config reference, isolation posture); and a commented `builder-sidecar` service in `docker-compose.example.yaml` (mirrors the SearXNG sidecar pattern).

## What was tested

- `go test ./...` — clean.
- New **`TestEmbedded_SandboxBundleValidates`**: loads `base + sandbox` through `config.LoadLayers` (which runs `validate()`) and asserts the agent's `mcp__sandbox__*` + `Skill` grants, the inline `dev/sandbox` skill body, and the `http` MCP server declaration. (A bundle ACL grant without a matching declaration fails `validate()` fatally — this is the guard, mirroring the v1.20.1 default-stack regression.)
- `TestUnits_RegistryShape` now covers the `sandbox` bundle; `TestUnits_ParseAsYAML` validates its YAML.
- `make build` + `loomcycle presets` lists and `presets show sandbox` renders it.
- gofmt / vet clean.

## Scope

RFC BI **P1** (single shared bearer). Attested per-tenant identity, run-liveness-poll GC, and the Kata tier are P2/P3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)