### PR TITLE
docs(truenas): update deploy for the toolbox image + code-execution config

### DIFF
--- a/deploy/truenas/INSTALL.md
+++ b/deploy/truenas/INSTALL.md
@@ -6,14 +6,22 @@ A complete, copy-paste install for **TrueNAS SCALE Electric Eel 24.10+** using
 [`../../docs/TRUENAS.md`](../../docs/TRUENAS.md) for the reference runbook).
 
 Replace `APPS2` with your pool name, `PG_HOST` with your Postgres host,
-`TRUENAS_SCALE_HOST` with your TrueNAS host, and fill the `CHANGE_ME` / `PASTE_…`
-placeholders throughout. **All secrets live in an external env file (Phase 4) —
+`TRUENAS_SCALE_HOST` with your TrueNAS host, `OLLAMA_HOST` with your Ollama host (if
+you use local models), and fill the `CHANGE_ME` / `PASTE_…` placeholders throughout. **All secrets live in an external env file (Phase 4) —
 never in the YAML you paste into the TrueNAS UI.**
 
-> **Image prerequisite.** Pin **`denngubsky/loomcycle:1.6.0` or newer** — v1.6.0 is
-> the first release with the embedded presets (RFC AQ) that this app's
-> `LOOMCYCLE_PRESETS` relies on. Older tags (≤ v1.5.0) have no presets and will fail
-> to boot with `no config found`.
+> **Image choice.** This walkthrough enables in-container code execution, so it uses
+> the **`denngubsky/loomcycle-toolbox:1.23.1`** image — a dev toolchain (python / go /
+> rust / c++ / node + git/gh/curl/jq/rsync/wget/unzip/sqlite3) on a shell-bearing base.
+> Code runs in loomcycle's OWN container, so this is a **single-tenant / trusted**
+> posture ([`../../docs/TOOLBOX_IMAGE.md`](../../docs/TOOLBOX_IMAGE.md)). For a
+> locked-down / multi-tenant deploy, use the secure distroless
+> **`denngubsky/loomcycle:1.23.1`** instead and DELETE the "code execution" env block
+> in Phase 5 (its shell tools have no shell/toolchain in distroless); for ISOLATED
+> untrusted code, keep distroless and add the builder sidecar
+> ([`../../docs/SANDBOX.md`](../../docs/SANDBOX.md)). Either way pin **≥ v1.6.0** — the
+> first release with the embedded presets (RFC AQ) this app's `LOOMCYCLE_PRESETS`
+> relies on; older tags fail to boot with `no config found`.
 
 ---
 
@@ -142,7 +150,7 @@ Notes:
 name: loomcycle
 services:
   loomcycle-migrate:
-    image: denngubsky/loomcycle:1.12.0
+    image: denngubsky/loomcycle-toolbox:1.23.1
     user: "65532:65532"
     restart: "no"
     command: ["migrate", "up"]
@@ -151,7 +159,7 @@ services:
     environment:
       LOOMCYCLE_STORAGE_BACKEND: postgres
   loomcycle:
-    image: denngubsky/loomcycle:1.12.0
+    image: denngubsky/loomcycle-toolbox:1.23.1
     user: "65532:65532"
     restart: unless-stopped
     depends_on:
@@ -165,7 +173,7 @@ services:
       # --- non-secret ("insecure") operational config — safe to keep inline ---
       LOOMCYCLE_LISTEN_ADDR: "0.0.0.0:8787"
       LOOMCYCLE_PUBLIC_URL: "http://TRUENAS_SCALE_HOST:8787"   # externally-reachable base URL (your tunnel/proxy host, or this for direct LAN); agents read it via `Context op=self` (≥ v1.6.7)
-      LOOMCYCLE_PRESETS: "base,document-agent"   # base matrix + the Document Assistant
+      LOOMCYCLE_PRESETS: "base,document-agent,chat,agent-teams,team-examples"   # matrix + built-in agents
       LOOMCYCLE_CONFIG_DIR: /config
       LOOMCYCLE_STORAGE_BACKEND: postgres
       LOOMCYCLE_SQLMEM_ENABLED: "1"              # document-agent needs it
@@ -181,24 +189,33 @@ services:
       LOOMCYCLE_AUDIT_LOG_PATH: /data/audit.log   # a FILE, not the /data dir
       LOOMCYCLE_PG_MAX_OPEN_CONNS: "48"
       LOOMCYCLE_PG_MIN_IDLE_CONNS: "8"
-      OLLAMA_BASE_URL: http://TRUENAS_SCALE_HOST:11434
+      OLLAMA_BASE_URL: http://OLLAMA_HOST:11434
+      LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX: "65535"     # pin the local model's context window
+      LOOMCYCLE_OLLAMA_LOCAL_NUM_GPU: "99"        # force GPU offload where Ollama falls back to CPU
 
-      # --- shell tools (opt-in; grant per agent via tools) ---
-      # Bashbox: in-process gbash sandbox (no OS process, rooted at the agent's
-      # rw volume, no network). The safe default.
+      # --- code execution (TOOLBOX IMAGE ONLY; single-tenant/trusted) ---
+      # Delete this whole block on the distroless image. Grant Bash/Bashbox to an
+      # agent via its tools:.
+      # Bashbox: in-process gbash sandbox (rooted at the agent's rw volume, no
+      # network); host commands you allowlist ESCAPE to the real toolchain.
       LOOMCYCLE_BASHBOX_ENABLED: "1"
-      # Bash: NOT a sandbox — reaches arbitrary files via absolute paths and the
-      # network. Enabled here per request; only grant it to trusted agents.
+      # Bash: NOT a sandbox — reaches arbitrary files + the network; only grant it
+      # to trusted agents (needs the toolbox image's real /bin/sh + toolchain).
       LOOMCYCLE_BASH_ENABLED: "1"
-      # Host-command fallback: these named commands ESCAPE the gbash sandbox and
-      # run on the real host (rw volume required). Keep the list tight.
-      LOOMCYCLE_BASHBOX_FALLBACK_COMMANDS: git,gh,curl,jq,rsync
+      # Fallback = the toolchain drivers. Don't add jq/awk (native to Bashbox) or
+      # bash/sh/env (they'd defeat the sandbox). ./compiled-binary won't run via
+      # Bashbox — use `go run`/`cargo run` or the raw Bash tool.
+      LOOMCYCLE_BASHBOX_FALLBACK_COMMANDS: git,gh,curl,rsync,python3,pip3,go,gofmt,cargo,rustc,node,npm,npx,gcc,g++,cc,c++,clang,clang++,make,cmake,pkg-config
+      # REQUIRED for go/cargo/npm/pip — the fallback scrubs the child env to PATH
+      # only, and those need HOME for their caches (go build errors otherwise).
+      LOOMCYCLE_BASHBOX_FALLBACK_ALLOWED_ENV: HOME
 
       # --- HTTP / WebFetch host policy ---
-      # No wildcard exists; this suffix-list allows whole TLDs (e.g. "com" ⇒ any
-      # *.com). Broadly open to public hosts; private IPs stay hard-blocked.
-      # CALLER_AUTHORITATIVE lets a run further narrow this per-call.
-      LOOMCYCLE_HTTP_HOST_ALLOWLIST: com,org,net,io,ai,dev,gov,edu,co,me,app,xyz,uk,de
+      # "*" allows any host — an SSRF surface, acceptable for a TRUSTED single-tenant
+      # box behind a private network/tunnel (this deploy's posture). For multi-tenant,
+      # NARROW it to a suffix list (e.g. com,org,net,io,ai,dev — allows whole TLDs).
+      # Private IPs stay hard-blocked; a run can further narrow per-call.
+      LOOMCYCLE_HTTP_HOST_ALLOWLIST: "*"
     volumes:
       - /mnt/APPS2/loomcycle/data:/data
       - /mnt/APPS2/loomcycle/config:/config:ro

--- a/deploy/truenas/catalog/app.yaml
+++ b/deploy/truenas/catalog/app.yaml
@@ -1,6 +1,6 @@
 annotations:
   min_scale_version: 24.10.2.2
-app_version: "1.9.0"
+app_version: "1.23.1"
 capabilities: []
 categories:
 - productivity

--- a/deploy/truenas/catalog/ix_values.yaml
+++ b/deploy/truenas/catalog/ix_values.yaml
@@ -1,11 +1,13 @@
 # Static defaults — images + template constants (not user-editable). RFC AR.
 images:
   image:
+    # The wizard defaults to the SECURE distroless image. For in-container code
+    # execution swap to denngubsky/loomcycle-toolbox via Route A (paste compose) —
+    # see ../INSTALL.md / ../../docs/TOOLBOX_IMAGE.md; the catalog wizard stays
+    # distroless (single-tenant code-exec is an explicit Route-A opt-in).
     repository: denngubsky/loomcycle
-    # First release with the embedded presets (RFC AQ) — the dialog's preset
-    # selector renders from the binary. Bump this + app_version in app.yaml in
-    # lockstep on an image bump.
-    tag: "1.9.0"
+    # Bump this + app_version in app.yaml in lockstep on an image bump.
+    tag: "1.23.1"
 consts:
   app_container_name: loomcycle
   # distroless nonroot — the image is fixed at uid/gid 65532 (no arbitrary-uid

--- a/deploy/truenas/docker-compose.yaml
+++ b/deploy/truenas/docker-compose.yaml
@@ -1,98 +1,130 @@
 # loomcycle on TrueNAS SCALE — custom-app (paste-compose) deployment.
 #
-# RFC AR Phase 1. This is the FAST route: TrueNAS SCALE (Electric Eel 24.10+) →
-# Apps → Discover → ⋮ → "Install via YAML" → paste this file. (The formal catalog
-# app with an install wizard lives in ./catalog/ — see ../docs/TRUENAS.md.)
+# Fast route: Apps → Discover → ⋮ → "Install via YAML" → paste this file. The full
+# step-by-step (Postgres, datasets, the secrets env file) is in ./INSTALL.md; the
+# reference runbook is ../docs/TRUENAS.md; the catalog-app (wizard) route is in
+# ./catalog/. Applies to TrueNAS SCALE Electric Eel 24.10+.
 #
-# Before you install — on the TrueNAS host:
-#   1. Create datasets and chown them to the distroless uid (65532):
+# Before you install (copy-paste commands in INSTALL.md) — replace `tank` with your
+# pool name throughout:
+#   1. Datasets, chowned to the container uid 65532:
 #        mkdir -p /mnt/tank/loomcycle/{data,config,work}
 #        chown -R 65532:65532 /mnt/tank/loomcycle
-#   2. Create the loomcycle databases in your existing Postgres ≥ 14 (DB-per-service):
-#        CREATE DATABASE loomcycle;  CREATE DATABASE loomcycle_sqlmem;
-#      and a least-privilege role (see ../docs/TRUENAS.md §Postgres).
-#   3. Drop a thin overlay at /mnt/tank/loomcycle/config/loomcycle.yaml that maps
-#      your agent Volumes to the mounted host paths — copy loomcycle.overlay.example.yaml.
-#   4. Edit the env values + host paths below, then paste.
+#   2. Postgres ≥ 14 with the `loomcycle` + `loomcycle_sqlmem` DBs and a CREATEROLE
+#      login role (see ../docs/TRUENAS.md §Postgres).
+#   3. A thin overlay at /mnt/tank/loomcycle/config/loomcycle.yaml (the agent
+#      `volumes:` block) — copy loomcycle.overlay.example.yaml.
+#   4. A root-only secrets env file at
+#      /mnt/tank/loomcycle/config/loomcycle.secrets.env holding LOOMCYCLE_AUTH_TOKEN,
+#      LOOMCYCLE_OPERATOR_TOKEN_PEPPER, LOOMCYCLE_PG_DSN, LOOMCYCLE_SQLMEM_PG_DSN and
+#      your provider keys. Secrets go in THAT file, never here — TrueNAS's "Install
+#      via YAML" cannot resolve ${VAR}, so `env_file:` (an absolute host path read at
+#      container-create) is the mechanism that works. (INSTALL.md Phase 4.)
+#   5. Fill the placeholders below (TRUENAS_HOST, OLLAMA_HOST, the pool) and paste.
 #
-# loomcycle's provider/tier matrix comes from the EMBEDDED presets (RFC AQ) via
-# LOOMCYCLE_PRESETS — you don't write provider yaml. Secrets are TrueNAS-managed
-# env here, never a yaml layer. Ingress (TLS) is out of scope: the container binds
-# 0.0.0.0:8787 on the app network; front it with your existing tunnel/proxy.
+# ── IMAGE CHOICE (this file uses the toolbox image; read this) ────────────────
+#   • denngubsky/loomcycle-toolbox — SHIPS A DEV TOOLCHAIN (python/go/rust/c++/node
+#     + git/gh/curl/jq/rsync/wget/unzip/sqlite3), so agents can run + compile + test
+#     code via Bash/Bashbox. Code runs in loomcycle's OWN container → WEAK isolation:
+#     use for SINGLE-TENANT / TRUSTED deployments only (docs/TOOLBOX_IMAGE.md).
+#   • denngubsky/loomcycle — the secure DISTROLESS default (no shell/toolchain). For
+#     a locked-down / multi-tenant deploy, switch BOTH images to this and DELETE the
+#     "code execution" env block below. For ISOLATED untrusted code execution, keep
+#     distroless and add the builder sidecar (docs/SANDBOX.md).
 
 name: loomcycle
 
 services:
-  # One-shot schema migration. Runs `loomcycle migrate up` against Postgres, then
-  # exits; the runtime waits for it to complete. Decoupled from the image deploy
-  # (LOOMCYCLE_PG_AUTOMIGRATE=0 on the runtime) so a schema bump is explicit.
+  # One-shot schema migration: runs `loomcycle migrate up`, then exits; the runtime
+  # waits for it (LOOMCYCLE_PG_AUTOMIGRATE=0 below keeps schema bumps explicit).
   loomcycle-migrate:
-    image: denngubsky/loomcycle:1.12.0 # bump to a newer tag as you upgrade (≥1.6.0 required — embedded presets, RFC AQ)
+    image: denngubsky/loomcycle-toolbox:1.23.1   # keep in lockstep with the runtime
     user: "65532:65532"
     restart: "no"
     command: ["migrate", "up"]
+    env_file:
+      # PG DSNs come from here (LOOMCYCLE_PG_DSN / LOOMCYCLE_SQLMEM_PG_DSN).
+      - /mnt/tank/loomcycle/config/loomcycle.secrets.env
     environment:
       LOOMCYCLE_STORAGE_BACKEND: postgres
-      LOOMCYCLE_PG_DSN: ${LOOMCYCLE_PG_DSN:?set LOOMCYCLE_PG_DSN}
-      LOOMCYCLE_SQLMEM_PG_DSN: ${LOOMCYCLE_SQLMEM_PG_DSN:-}
 
   loomcycle:
-    image: denngubsky/loomcycle:1.12.0 # bump to a newer tag as you upgrade (≥1.6.0 required — embedded presets, RFC AQ)
+    image: denngubsky/loomcycle-toolbox:1.23.1
     user: "65532:65532"
     restart: unless-stopped
     depends_on:
       loomcycle-migrate:
         condition: service_completed_successfully
     ports:
-      # The app network port. Front with your tunnel/proxy — no public bind here.
+      # App-network port. Front with your tunnel/proxy — no public bind here.
       - "8787:8787"
+    env_file:
+      # Tokens, PG DSNs, provider keys. NEVER put a secret in `environment:` below
+      # (an inline key would also OVERRIDE the same key from the env file).
+      - /mnt/tank/loomcycle/config/loomcycle.secrets.env
     environment:
-      # Bind all interfaces inside the container (the port mapping above reaches it).
+      # ── core ──────────────────────────────────────────────────────────────
       LOOMCYCLE_LISTEN_ADDR: "0.0.0.0:8787"
-      # The externally-reachable base URL agents see via `Context op=self`
-      # (server.url) so an agent — especially over MCP — can identify the server
-      # it's talking to. Set it to however you front this app (your tunnel/proxy
-      # hostname). Optional (≥ v1.6.7; older tags ignore it).
-      LOOMCYCLE_PUBLIC_URL: ${LOOMCYCLE_PUBLIC_URL:-}
+      # Externally-reachable base URL (your tunnel/proxy host); agents read it via
+      # `Context op=self`. Set to how you actually front the app.
+      LOOMCYCLE_PUBLIC_URL: "http://TRUENAS_HOST:8787"
+      # Provider/tier matrix + built-in agents from the embedded presets (RFC AQ).
+      LOOMCYCLE_PRESETS: "base,document-agent,chat,agent-teams,team-examples"
+      LOOMCYCLE_CONFIG_DIR: /config           # the thin overlay (volumes: block)
+      LOOMCYCLE_DATA_DIR: /data               # loomcycle's own state
 
-      # Provider/tier base from the embedded presets (RFC AQ). Add bundles/overlays:
-      #   base,oauth          → OAuth on top of the base matrix
-      #   base,document-agent → also register the Document Assistant agent
-      LOOMCYCLE_PRESETS: ${LOOMCYCLE_PRESETS:-base}
-      # The thin overlay (your volumes: block etc.) layered over the presets.
-      LOOMCYCLE_CONFIG_DIR: /config
-
-      # Storage — your existing Postgres ≥ 14 (the app does NOT bundle a DB).
+      # ── storage — your external Postgres (DSNs live in the secrets env file) ──
       LOOMCYCLE_STORAGE_BACKEND: postgres
-      LOOMCYCLE_PG_DSN: ${LOOMCYCLE_PG_DSN:?set LOOMCYCLE_PG_DSN}
-      LOOMCYCLE_SQLMEM_PG_DSN: ${LOOMCYCLE_SQLMEM_PG_DSN:-}
-      LOOMCYCLE_SQLMEM_ENABLED: ${LOOMCYCLE_SQLMEM_ENABLED:-0}
-      # Migrations run in the init service above; the runtime must NOT auto-migrate.
-      LOOMCYCLE_PG_AUTOMIGRATE: "0"
-      # Local state (sqlmem cache, snapshots) on the data dataset.
-      LOOMCYCLE_DATA_DIR: /data
+      LOOMCYCLE_PG_AUTOMIGRATE: "0"           # the migrate service handles migrations
+      LOOMCYCLE_SQLMEM_ENABLED: "1"           # Documents / SQL Memory (needs the sqlmem DSN)
+      LOOMCYCLE_PG_MAX_OPEN_CONNS: "48"
+      LOOMCYCLE_PG_MIN_IDLE_CONNS: "8"
 
-      # Secrets — TrueNAS-managed env, never a yaml layer. Generate the token with
-      # `openssl rand -hex 32`; the pepper hardens minted operator-token hashes.
-      LOOMCYCLE_AUTH_TOKEN: ${LOOMCYCLE_AUTH_TOKEN:?set LOOMCYCLE_AUTH_TOKEN}
-      LOOMCYCLE_OPERATOR_TOKEN_PEPPER: ${LOOMCYCLE_OPERATOR_TOKEN_PEPPER:-}
-      # Provider keys — set whichever the selected presets route to.
-      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
-      DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY:-}
-      GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      # ── operability ───────────────────────────────────────────────────────
+      LOOMCYCLE_SCHEDULER_ENABLED: "1"
+      LOOMCYCLE_WEBHOOKS_ENABLED: "1"
+      LOOMCYCLE_METRICS_ENABLED: "1"
+      LOOMCYCLE_METRICS_COLLECT_SYSTEM: "1"
+      LOOMCYCLE_METRICS_RETENTION_DAYS: "7"
+      LOOMCYCLE_AUDIT_LOG_PATH: /data/audit.log   # a FILE, not the /data dir
+      # The code-js synthetic provider (pure-Go JS agents; works on any image).
+      LOOMCYCLE_CODE_AGENTS_ENABLED: "1"
+
+      # ── local models (optional; point at your Ollama) ─────────────────────
+      OLLAMA_BASE_URL: "http://OLLAMA_HOST:11434"
+      LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX: "65535"     # pin the local context window
+      LOOMCYCLE_OLLAMA_LOCAL_NUM_GPU: "99"        # force GPU offload where auto-detect falls back to CPU
+
+      # ── code execution — TOOLBOX IMAGE ONLY, single-tenant/trusted ─────────
+      # DELETE this whole block on the distroless image. Grant Bash/Bashbox to an
+      # agent via its tools:. Bashbox is the in-process sandbox (rooted at the
+      # agent's rw volume, no network); Bash is the unsandboxed escape hatch.
+      LOOMCYCLE_BASHBOX_ENABLED: "1"
+      LOOMCYCLE_BASH_ENABLED: "1"
+      # Host commands that ESCAPE the gbash sandbox to the real toolchain. Only list
+      # what gbash LACKS — do NOT add jq/awk (native to Bashbox) or bash/sh/env
+      # (they'd defeat the sandbox; that's what raw Bash is for).
+      LOOMCYCLE_BASHBOX_FALLBACK_COMMANDS: >-
+        git,gh,curl,rsync,python3,pip3,go,gofmt,cargo,rustc,node,npm,npx,gcc,g++,cc,c++,clang,clang++,make,cmake,pkg-config
+      # REQUIRED for go/cargo/npm/pip: the fallback scrubs the child env down to
+      # PATH only, and those tools need HOME for their caches (go build errors
+      # "neither $XDG_CACHE_HOME nor $HOME are defined" without it).
+      LOOMCYCLE_BASHBOX_FALLBACK_ALLOWED_ENV: HOME
+
+      # ── HTTP / WebFetch host policy ───────────────────────────────────────
+      # "*" allows any host — an SSRF surface, fine for a TRUSTED single-tenant box
+      # behind a private network/tunnel. NARROW it for multi-tenant (a suffix list
+      # like com,org,net,io,ai,dev). Private IPs stay hard-blocked either way.
+      LOOMCYCLE_HTTP_HOST_ALLOWLIST: "*"
     volumes:
-      # loomcycle's own data (sqlmem cache, snapshots). chown 65532:65532.
       - /mnt/tank/loomcycle/data:/data
-      # The thin overlay dir (read-only) — drop loomcycle.yaml here (volumes: block).
       - /mnt/tank/loomcycle/config:/config:ro
-      # Agent filesystem Volume(s) (RFC AH) → ZFS datasets. The overlay's volumes:
-      # block maps a name to the IN-CONTAINER path (e.g. work → /mnt/work). Add a
-      # mount + an overlay entry per agent volume. (The catalog app turns this into
-      # repeating form rows — RFC AR Phase 2.)
+      # Agent filesystem Volume(s) (RFC AH): the overlay's volumes: block maps a
+      # name to the IN-CONTAINER path (e.g. work → /mnt/work). Add a mount + overlay
+      # entry per agent volume.
       - /mnt/tank/loomcycle/work:/mnt/work
     healthcheck:
-      # distroless has no curl — the binary's own probe GETs /healthz.
+      # The binary's own probe GETs /healthz — image-agnostic (no curl needed).
       test: ["CMD", "/usr/local/bin/loomcycle", "health"]
       interval: 30s
       timeout: 5s

--- a/docs/TRUENAS.md
+++ b/docs/TRUENAS.md
@@ -68,10 +68,13 @@ not source `.env.local` in a container — only real env + the mounted overlay.
 ### Route A — custom app (paste compose)
 
 1. Edit [`deploy/truenas/docker-compose.yaml`](../deploy/truenas/docker-compose.yaml):
-   set the env values (`LOOMCYCLE_AUTH_TOKEN`, `LOOMCYCLE_PG_DSN`, provider keys,
-   `LOOMCYCLE_PRESETS`) and the host-path mounts to your datasets. **Pin the image
-   tag** to a release that includes RFC AQ (the preset machinery) — `:latest` is for
-   testing only.
+   put your **secrets** (`LOOMCYCLE_AUTH_TOKEN`, the Postgres DSNs, provider keys) in
+   the root-only `loomcycle.secrets.env` the compose's `env_file:` points at — never
+   inline (TrueNAS's paste-YAML can't resolve `${VAR}`); set the non-secret env
+   (`LOOMCYCLE_PRESETS`, `LOOMCYCLE_PUBLIC_URL`, the pool/host placeholders) inline;
+   and point the host-path mounts at your datasets. **Pin the image tag** (`:latest`
+   is for testing only) — and choose toolbox vs distroless per the image-choice note
+   below and in [`INSTALL.md`](../deploy/truenas/INSTALL.md).
 2. Apps → **Discover Apps** → the **⋮** menu → **Install via YAML**. Name it
    `loomcycle`, paste the file, install.
 3. The `loomcycle-migrate` service runs `migrate up` once; the runtime waits for it,
@@ -131,6 +134,31 @@ a `searxng/settings.yml` with three required knobs (`secret_key`, `limiter: fals
 `formats: [html, json]`), and `search_providers: { searxng: { base_url: … } }` +
 `search_priority:` in the overlay. Full recipe + verification: **[`docs/SEARCH.md`](SEARCH.md)**
 (the commented sidecar is in [`docker-compose.example.yaml`](../docker-compose.example.yaml)).
+
+## Code execution (the toolbox image)
+
+By default the app runs the **distroless** image — no shell, no compilers, so agents
+can't run scripts or compile code. To let them, switch both services to the
+**`denngubsky/loomcycle-toolbox`** image (same uid + mount paths — a drop-in swap; it
+bakes in python / go / rust / c++ / node + git/gh/curl/jq/rsync/wget/unzip/sqlite3)
+and enable a shell tool, then grant it to an agent via its `tools:`:
+
+- **`LOOMCYCLE_BASH_ENABLED=1`** — the raw `Bash` tool (unsandboxed: the whole
+  toolchain, and it can run a compiled `./binary`). Simplest for a trusted box.
+- **`LOOMCYCLE_BASHBOX_ENABLED=1`** + `LOOMCYCLE_BASHBOX_FALLBACK_COMMANDS=<drivers>`
+  + **`LOOMCYCLE_BASHBOX_FALLBACK_ALLOWED_ENV=HOME`** — the mostly-sandboxed Bashbox,
+  where only allowlisted host commands escape. `HOME` is **required** or `go`/`cargo`/
+  `npm`/`pip` fail (they need it for their caches); don't allowlist `jq`/`awk` (native
+  to Bashbox) or `bash`/`sh`/`env`; a bare `./binary` can't run via Bashbox (use
+  `go run` / `cargo run`, or the raw `Bash` tool).
+
+⚠️ Code runs in loomcycle's OWN container — **single-tenant / trusted only**. For
+untrusted or multi-tenant code, keep the distroless image and run each session in an
+isolated, ephemeral container via the **builder sidecar** ([`SANDBOX.md`](SANDBOX.md)).
+Full tradeoff + tool reference: [`TOOLBOX_IMAGE.md`](TOOLBOX_IMAGE.md). The paste
+compose in [`deploy/truenas/docker-compose.yaml`](../deploy/truenas/docker-compose.yaml)
+ships this block ready to use (toolbox image); walkthrough in
+[`INSTALL.md`](../deploy/truenas/INSTALL.md).
 
 ## Volumes → datasets (RFC AH)
 


### PR DESCRIPTION
Brings the TrueNAS deploy docs in line with the proven working deployment (the toolbox image, code execution enabled) and fixes real inconsistencies in the old files. **Docs/deploy only** — no binary/adapter/wire change; references the already-released `1.23.1` images, so no new tag needed.

## Why

The current TrueNAS files had two concrete bugs the on-box test surfaced:
1. **`deploy/truenas/docker-compose.yaml` used `${VAR}` interpolation** — which TrueNAS's *Install via YAML* can't resolve (INSTALL.md itself documents this). It was also stale at `1.12.0`.
2. Both compose + INSTALL enabled **shell tools + a `git,gh,curl,jq,rsync` fallback on the DISTROLESS image** — which has no shell and none of those binaries, so they'd all fail. And they omitted **`HOME`**, without which `go`/`cargo`/`npm`/`pip` error on their caches.

## What

- **`docker-compose.yaml`** — rewritten to the `env_file` secrets pattern, bumped to **`denngubsky/loomcycle-toolbox:1.23.1`**, and expanded to the full working env (presets `base,document-agent,chat,agent-teams,team-examples`, SQL Memory, scheduler, webhooks, metrics, audit log, PG pool tuning, ollama-local knobs). The **code-execution block** is clearly fenced (Bash/Bashbox + the full toolchain fallback + the **required** `LOOMCYCLE_BASHBOX_FALLBACK_ALLOWED_ENV=HOME`), with a header note on toolbox-vs-distroless and the single-tenant/trusted posture.
- **`INSTALL.md`** — image banner + Phase-5 paste block → toolbox `1.23.1`, full toolchain fallback + `HOME`, ollama knobs, expanded presets; removed a duplicate `LOOMCYCLE_CODE_AGENTS_ENABLED`; added the `OLLAMA_HOST` placeholder.
- **`docs/TRUENAS.md`** — new **"Code execution (the toolbox image)"** section (the `HOME` requirement, the jq/awk-are-native + compiled-binary caveats, the distroless/sidecar alternatives); the Route-A step now points secrets at the `env_file`.
- **`catalog/{app.yaml,ix_values.yaml}`** — image tag + `app_version` `1.9.0` → `1.23.1`; the wizard **stays on the secure distroless image** (toolbox is a deliberate Route-A opt-in), documented inline.

## What was tested

- Both YAML blocks (the standalone compose + the INSTALL Phase-5 fence) parse cleanly (`yaml.safe_load`): correct toolbox image, presets, `HOME`, `HOST_ALLOWLIST`, ollama knobs; **no duplicate keys**; the folded `FALLBACK_COMMANDS` scalar has **no stray newline** and excludes `jq`.
- No Go/adapter change → no `go test` impact.

Based on the operator's validated TrueNAS `1.23.1` deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)