### PR TITLE
feat(bundles): chat gains Agent tool + a dev/sandbox-usage delegation skill

### DIFF
--- a/bundles/chat/loomcycle.yaml
+++ b/bundles/chat/loomcycle.yaml
@@ -31,7 +31,7 @@ agents:
     # (Anthropic defaults to 8192; ollama generates until the context fills).
     # Pinning a value would only IMPOSE a per-reply cap, not add headroom.
     unbounded_iterations: true              # interactive chat parks at end_turn
-    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, HTTP, Bashbox, Bash, Document, Memory, Path, Skill, Interruption]
+    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, HTTP, Bashbox, Bash, Document, Memory, Path, Skill, Agent, Interruption]
     memory_scopes: [user]
     sql_scopes: [user]                      # Document is SQL-Memory-backed
     sampling:
@@ -71,7 +71,7 @@ agents:
     # max_tokens OMITTED — ollama-local generates until the context window fills
     # (set the window via LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX, e.g. 131072 for 128K).
     unbounded_iterations: true
-    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, HTTP, Bashbox, Bash, Document, Memory, Path, Skill, Interruption]
+    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, HTTP, Bashbox, Bash, Document, Memory, Path, Skill, Agent, Interruption]
     memory_scopes: [user]
     sql_scopes: [user]
     sampling:
@@ -106,7 +106,7 @@ agents:
     # max_tokens OMITTED — ollama-local generates until the context window fills
     # (set the window via LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX, e.g. 131072 for 128K).
     unbounded_iterations: true
-    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, HTTP, Bashbox, Bash, Document, Memory, Path, Skill, Interruption]
+    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, HTTP, Bashbox, Bash, Document, Memory, Path, Skill, Agent, Interruption]
     memory_scopes: [user]
     sql_scopes: [user]
     sampling:

--- a/bundles/sandbox/README.md
+++ b/bundles/sandbox/README.md
@@ -13,6 +13,12 @@ loomcycle stays distroless and drives it over HTTP-MCP. The bundle wires the
 `mcp__sandbox__*` tools + the `dev/sandbox` agent + skill. This is a **first-class,
 reusable bundle** — not an `examples/` experiment.
 
+It also ships a **`dev/sandbox-usage` skill** so any agent with the `Agent` tool
+(e.g. the `chat/*` agents, which now carry it) can **delegate** to `dev/sandbox` —
+spawn it for a one-shot task, or drive a multi-step session by sharing a `session_id`
+— without holding the powerful `mcp__sandbox__*` tools itself (see `docs/SANDBOX.md`
+→ "Delegating from other agents").
+
 ```
 bundles/sandbox/
 ├── loomcycle.yaml   # the dev/sandbox agent + skill + mcp_servers.sandbox (identical to the embedded copy)

--- a/bundles/sandbox/loomcycle.yaml
+++ b/bundles/sandbox/loomcycle.yaml
@@ -14,6 +14,11 @@
 #
 # The operator overlay can override any field (last layer wins) — e.g. re-declare
 # mcp_servers.sandbox.url if the sidecar isn't at http://builder-sidecar:9000.
+#
+# Besides the dev/sandbox AGENT, this bundle ships a `dev/sandbox-usage` SKILL so any
+# agent with the `Agent` tool (e.g. the chat/* agents) can DELEGATE to dev/sandbox —
+# spawn it for a one-shot task, or drive a multi-step session by sharing a session_id
+# — without holding the powerful mcp__sandbox__* tools itself.
 
 agents:
   dev/sandbox:
@@ -37,7 +42,10 @@ agents:
          test with sandbox_exec. Read a non-zero exit + its output, fix, and re-run —
          that compile→test→fix loop is the core of the job.
       3. Pull results out with sandbox_read when you need to show an artifact.
-      4. Close the session with sandbox_close when the task is done.
+      4. Close the session with sandbox_close when the task is done — UNLESS you were
+         asked to keep it open (a parent driving a multi-step session): then leave it
+         open and report the session_id. Likewise, if you're GIVEN a session_id, reuse
+         it instead of opening a new one.
 
       ## Notes
       - The sandbox has Python, Go, Rust, C/C++, and Node preinstalled. /work is an
@@ -89,9 +97,57 @@ skills:
       ## Rules
       - Reuse ONE session for a task — don't open a new one per command (you'd lose the
         checkout + build cache).
+      - If a caller GIVES you a session_id, reuse it (don't open a new one); if asked to
+        KEEP a session open for follow-up, report the session_id and leave it open — a
+        parent agent may drive several commands against the same container.
       - Default to network:"none"; use "egress" only when a step must fetch something
         and the operator enabled egress.
       - Never assume host access — you only have these sandbox tools.
+
+  dev/sandbox-usage:
+    description: How to run/compile/test code by delegating to the dev/sandbox agent — a one-shot task, or a multi-step session you drive command by command. For agents that have the Agent tool but not the sandbox tools.
+    tools: [Agent]
+    body: |
+      # Using the sandbox (delegate to the dev/sandbox agent)
+
+      You don't hold the sandbox tools directly — by design. To run, compile, or test
+      code, delegate to the `dev/sandbox` sub-agent (it has an isolated, ephemeral
+      container with a full toolchain). You drive it with the `Agent` tool.
+
+      ## One-shot task (simplest)
+      When you can describe the whole job upfront, spawn once and let dev/sandbox run
+      the compile→test→fix loop itself:
+
+        Agent {op:"spawn", name:"dev/sandbox",
+               prompt:"Clone https://github.com/OWNER/REPO, run 'go build ./... && go test ./...', fix any failures, and report the result."}
+
+      It opens a session, iterates, closes it, and returns the result.
+
+      ## Multi-step session (drive it command by command)
+      When you want to inspect each result and decide the next command, keep ONE
+      container alive across spawns by sharing its session_id:
+
+      1. Open + first command — tell it to KEEP the session open and report the id:
+         Agent {op:"spawn", name:"dev/sandbox",
+                prompt:"Open a sandbox session and KEEP IT OPEN (do not close it). Run: <command>. Report the session_id and the output."}
+         → capture the session_id from the returned text.
+      2. Next commands — reuse that session (same container, state preserved):
+         Agent {op:"spawn", name:"dev/sandbox",
+                prompt:"Reuse sandbox session <session_id> — do not open a new one, do not close it. Run: <command>. Report the output."}
+      3. Shut it down when finished:
+         Agent {op:"spawn", name:"dev/sandbox", prompt:"Close sandbox session <session_id>."}
+
+      ## Notes
+      - The container persists between spawns (the sandbox holds it), so the checkout,
+        installed deps, and build cache carry over — as long as you pass the same
+        session_id and don't leave it idle too long.
+      - If a step reports the session is gone (it idled out), reopen it — you'll start
+        fresh unless the operator configured a durable workspace.
+      - Always close the session when the task is done; don't leave sandboxes running.
+      - Compiled binaries run inside the sandbox (it's a real container), so
+        `./your-binary` works there.
+      - If dev/sandbox reports the sandbox tools are unavailable, the builder sidecar
+        isn't deployed — tell the human rather than trying to run code another way.
 
 mcp_servers:
   sandbox:

--- a/cmd/loomcycle/embedded/bundles/chat.yaml
+++ b/cmd/loomcycle/embedded/bundles/chat.yaml
@@ -31,7 +31,7 @@ agents:
     # (Anthropic defaults to 8192; ollama generates until the context fills).
     # Pinning a value would only IMPOSE a per-reply cap, not add headroom.
     unbounded_iterations: true              # interactive chat parks at end_turn
-    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, HTTP, Bashbox, Bash, Document, Memory, Path, Skill, Interruption]
+    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, HTTP, Bashbox, Bash, Document, Memory, Path, Skill, Agent, Interruption]
     memory_scopes: [user]
     sql_scopes: [user]                      # Document is SQL-Memory-backed
     sampling:
@@ -71,7 +71,7 @@ agents:
     # max_tokens OMITTED — ollama-local generates until the context window fills
     # (set the window via LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX, e.g. 131072 for 128K).
     unbounded_iterations: true
-    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, HTTP, Bashbox, Bash, Document, Memory, Path, Skill, Interruption]
+    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, HTTP, Bashbox, Bash, Document, Memory, Path, Skill, Agent, Interruption]
     memory_scopes: [user]
     sql_scopes: [user]
     sampling:
@@ -106,7 +106,7 @@ agents:
     # max_tokens OMITTED — ollama-local generates until the context window fills
     # (set the window via LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX, e.g. 131072 for 128K).
     unbounded_iterations: true
-    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, HTTP, Bashbox, Bash, Document, Memory, Path, Skill, Interruption]
+    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, HTTP, Bashbox, Bash, Document, Memory, Path, Skill, Agent, Interruption]
     memory_scopes: [user]
     sql_scopes: [user]
     sampling:

--- a/cmd/loomcycle/embedded/bundles/sandbox.yaml
+++ b/cmd/loomcycle/embedded/bundles/sandbox.yaml
@@ -14,6 +14,11 @@
 #
 # The operator overlay can override any field (last layer wins) — e.g. re-declare
 # mcp_servers.sandbox.url if the sidecar isn't at http://builder-sidecar:9000.
+#
+# Besides the dev/sandbox AGENT, this bundle ships a `dev/sandbox-usage` SKILL so any
+# agent with the `Agent` tool (e.g. the chat/* agents) can DELEGATE to dev/sandbox —
+# spawn it for a one-shot task, or drive a multi-step session by sharing a session_id
+# — without holding the powerful mcp__sandbox__* tools itself.
 
 agents:
   dev/sandbox:
@@ -37,7 +42,10 @@ agents:
          test with sandbox_exec. Read a non-zero exit + its output, fix, and re-run —
          that compile→test→fix loop is the core of the job.
       3. Pull results out with sandbox_read when you need to show an artifact.
-      4. Close the session with sandbox_close when the task is done.
+      4. Close the session with sandbox_close when the task is done — UNLESS you were
+         asked to keep it open (a parent driving a multi-step session): then leave it
+         open and report the session_id. Likewise, if you're GIVEN a session_id, reuse
+         it instead of opening a new one.
 
       ## Notes
       - The sandbox has Python, Go, Rust, C/C++, and Node preinstalled. /work is an
@@ -89,9 +97,57 @@ skills:
       ## Rules
       - Reuse ONE session for a task — don't open a new one per command (you'd lose the
         checkout + build cache).
+      - If a caller GIVES you a session_id, reuse it (don't open a new one); if asked to
+        KEEP a session open for follow-up, report the session_id and leave it open — a
+        parent agent may drive several commands against the same container.
       - Default to network:"none"; use "egress" only when a step must fetch something
         and the operator enabled egress.
       - Never assume host access — you only have these sandbox tools.
+
+  dev/sandbox-usage:
+    description: How to run/compile/test code by delegating to the dev/sandbox agent — a one-shot task, or a multi-step session you drive command by command. For agents that have the Agent tool but not the sandbox tools.
+    tools: [Agent]
+    body: |
+      # Using the sandbox (delegate to the dev/sandbox agent)
+
+      You don't hold the sandbox tools directly — by design. To run, compile, or test
+      code, delegate to the `dev/sandbox` sub-agent (it has an isolated, ephemeral
+      container with a full toolchain). You drive it with the `Agent` tool.
+
+      ## One-shot task (simplest)
+      When you can describe the whole job upfront, spawn once and let dev/sandbox run
+      the compile→test→fix loop itself:
+
+        Agent {op:"spawn", name:"dev/sandbox",
+               prompt:"Clone https://github.com/OWNER/REPO, run 'go build ./... && go test ./...', fix any failures, and report the result."}
+
+      It opens a session, iterates, closes it, and returns the result.
+
+      ## Multi-step session (drive it command by command)
+      When you want to inspect each result and decide the next command, keep ONE
+      container alive across spawns by sharing its session_id:
+
+      1. Open + first command — tell it to KEEP the session open and report the id:
+         Agent {op:"spawn", name:"dev/sandbox",
+                prompt:"Open a sandbox session and KEEP IT OPEN (do not close it). Run: <command>. Report the session_id and the output."}
+         → capture the session_id from the returned text.
+      2. Next commands — reuse that session (same container, state preserved):
+         Agent {op:"spawn", name:"dev/sandbox",
+                prompt:"Reuse sandbox session <session_id> — do not open a new one, do not close it. Run: <command>. Report the output."}
+      3. Shut it down when finished:
+         Agent {op:"spawn", name:"dev/sandbox", prompt:"Close sandbox session <session_id>."}
+
+      ## Notes
+      - The container persists between spawns (the sandbox holds it), so the checkout,
+        installed deps, and build cache carry over — as long as you pass the same
+        session_id and don't leave it idle too long.
+      - If a step reports the session is gone (it idled out), reopen it — you'll start
+        fresh unless the operator configured a durable workspace.
+      - Always close the session when the task is done; don't leave sandboxes running.
+      - Compiled binaries run inside the sandbox (it's a real container), so
+        `./your-binary` works there.
+      - If dev/sandbox reports the sandbox tools are unavailable, the builder sidecar
+        isn't deployed — tell the human rather than trying to run code another way.
 
 mcp_servers:
   sandbox:

--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -85,6 +85,22 @@ compile→test→fix loop (workspace + build cache persist), close when done.
 Sessions also expire on an idle/absolute TTL, and orphans are reaped at sidecar
 startup.
 
+## Delegating from other agents
+
+An agent doesn't hold the `mcp__sandbox__*` tools directly (by design — tool ceilings
+are per operator-vetted agent, and skills can't widen them). To let a general agent run
+code, it **delegates to `dev/sandbox`** via the `Agent` tool — the sub-agent has the
+sandbox tools; the parent never does. The `sandbox` bundle ships a **`dev/sandbox-usage`
+skill** teaching exactly this, and the bundled **`chat/*` agents get the `Agent` tool**,
+so with `LOOMCYCLE_PRESETS=…,chat,sandbox` a chat agent can:
+
+- **one-shot:** `Agent {op:"spawn", name:"dev/sandbox", prompt:"clone X, build + test, report"}` — dev/sandbox opens a session, iterates, closes, returns; or
+- **multi-step:** open once telling it to keep the session open + report the `session_id`, then reuse that `session_id` on later spawns (same container, state preserved), and close it at the end.
+
+To let your own agent delegate, grant it the `Agent` tool (and, optionally, put
+`dev/sandbox-usage` in its `skills:`). To let an agent run the sandbox *itself* rather
+than delegate, grant it the `mcp__sandbox__*` tools directly.
+
 ## Sidecar configuration
 
 See the environment reference in


### PR DESCRIPTION
Ships the ergonomic enablers from **RFC BI P2 §5** — the secure *delegate, don't widen* path for code execution. (The durable-workspace P2 code is gated on the RFC; this is a bundle-only change usable today.)

## Why

A general agent can't hold the `mcp__sandbox__*` tools directly — tool ceilings are per operator-vetted agent, and skills can't widen them (a runtime-forked skill would otherwise self-escalate). The sanctioned way to compose the capability is **delegation**: the agent spawns the `dev/sandbox` sub-agent (which *does* have the tools) via the `Agent` tool. This wires that path.

## What

- **`chat/medium`, `chat/local`, `chat/local-small`** — add the **`Agent`** tool so they can spawn `dev/sandbox`. (They have no `skills:` field, so all skills are already allowed — no other change needed there.)
- **`sandbox` bundle** — new **`dev/sandbox-usage`** skill (`tools: [Agent]`, instructional, **no sandbox tools**) teaching an agent to:
  - **one-shot:** `Agent {op:"spawn", name:"dev/sandbox", prompt:"clone X, build + test, report"}`; or
  - **multi-step:** open once (keep it open, capture the `session_id`), reuse that id across later spawns (same container, state preserved), close at the end.
- **`dev/sandbox` agent + skill** — honor keep-open/reuse: reuse a given `session_id`; when asked to keep a session open, report the id and leave it running (so a parent can drive several commands against one container).
- **`docs/SANDBOX.md` + the sandbox README** — document the delegation pattern.

## Scope / posture

Bundle-only; **no new primitive or wire change**. The delegation works today over the existing `Agent` tool + tmpfs sessions. RFC BI P2's durable-workspace code (separate, RFC-gated) later makes the multi-step pattern robust across container churn/TTL. The `dev/sandbox-usage` skill lives in the sandbox bundle (chat references it; `skills:` is a pattern allowlist with no matching-declaration requirement, so the default stack without `sandbox` still validates).

## Tested

- `go test ./cmd/loomcycle/... ./internal/config/...` — `TestEmbedded_DefaultStackValidates` (chat + `Agent`), `TestEmbedded_SandboxBundleValidates` (new skill), the chat/team tool-grant + YAML-parse guards — all pass.
- `make build` embeds cleanly; `presets show` confirms chat carries `Agent` (×3) and `dev/sandbox-usage` is present.
- Two-copy source⇄embed mirrors verified identical (chat + sandbox).

Design context: RFC BI P2 (`/loomcycle/rfcs/sandboxed-code-execution-p2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)