### PR TITLE
feat(mcp): forward ${run.root_run_id}/${run.tenant_id} to MCP servers (RFC BI P2b)

### DIFF
--- a/bundles/sandbox/loomcycle.yaml
+++ b/bundles/sandbox/loomcycle.yaml
@@ -159,3 +159,7 @@ mcp_servers:
       # Per-run bearer when present, else the shared LOOMCYCLE_SANDBOX_TOKEN secret
       # (must equal the sidecar's SANDBOX_AUTH_TOKEN).
       Authorization: "Bearer ${run.user_bearer:-${LOOMCYCLE_SANDBOX_TOKEN}}"
+      # Non-secret run identifiers the sidecar tags each session with, for
+      # run-liveness GC + sandbox_close_run (empty when the run carries none).
+      X-Loom-Root-Run: "${run.root_run_id}"
+      X-Loom-Tenant: "${run.tenant_id}"

--- a/bundles/sandbox/loomcycle.yaml
+++ b/bundles/sandbox/loomcycle.yaml
@@ -24,7 +24,7 @@ agents:
   dev/sandbox:
     tier: middle
     effort: medium
-    tools: [mcp__sandbox__sandbox_open, mcp__sandbox__sandbox_exec, mcp__sandbox__sandbox_write, mcp__sandbox__sandbox_read, mcp__sandbox__sandbox_close, mcp__sandbox__sandbox_list, Interruption]
+    tools: [mcp__sandbox__sandbox_open, mcp__sandbox__sandbox_exec, mcp__sandbox__sandbox_write, mcp__sandbox__sandbox_read, mcp__sandbox__sandbox_close, mcp__sandbox__sandbox_touch, mcp__sandbox__sandbox_close_run, mcp__sandbox__sandbox_list, Interruption]
     skills: [dev/sandbox]
     compaction:
       enabled: true
@@ -65,7 +65,7 @@ agents:
 skills:
   dev/sandbox:
     description: Compile, test, and run code safely in an isolated ephemeral sandbox container (Python/Go/Rust/C++/Node) via the builder sidecar.
-    tools: [mcp__sandbox__sandbox_open, mcp__sandbox__sandbox_exec, mcp__sandbox__sandbox_write, mcp__sandbox__sandbox_read, mcp__sandbox__sandbox_close]
+    tools: [mcp__sandbox__sandbox_open, mcp__sandbox__sandbox_exec, mcp__sandbox__sandbox_write, mcp__sandbox__sandbox_read, mcp__sandbox__sandbox_close, mcp__sandbox__sandbox_touch, mcp__sandbox__sandbox_close_run]
     body: |
       # Running code in the sandbox
 
@@ -102,6 +102,12 @@ skills:
         parent agent may drive several commands against the same container.
       - Default to network:"none"; use "egress" only when a step must fetch something
         and the operator enabled egress.
+      - Keepalive: if you'll leave a session idle across a gap with no commands (a
+        parent is thinking between steps), sandbox_touch {session_id} resets its idle
+        timer so it isn't reaped — a normal sandbox_exec already resets it.
+      - Bulk teardown: sandbox_close_run {root_run_id} closes EVERY session you opened
+        for a run at once — use it when a driving parent asks you to clean up a run's
+        sandboxes, not for a single session (use sandbox_close for that).
       - Never assume host access — you only have these sandbox tools.
 
   dev/sandbox-usage:

--- a/cmd/loomcycle/embedded/bundles/sandbox.yaml
+++ b/cmd/loomcycle/embedded/bundles/sandbox.yaml
@@ -159,3 +159,7 @@ mcp_servers:
       # Per-run bearer when present, else the shared LOOMCYCLE_SANDBOX_TOKEN secret
       # (must equal the sidecar's SANDBOX_AUTH_TOKEN).
       Authorization: "Bearer ${run.user_bearer:-${LOOMCYCLE_SANDBOX_TOKEN}}"
+      # Non-secret run identifiers the sidecar tags each session with, for
+      # run-liveness GC + sandbox_close_run (empty when the run carries none).
+      X-Loom-Root-Run: "${run.root_run_id}"
+      X-Loom-Tenant: "${run.tenant_id}"

--- a/cmd/loomcycle/embedded/bundles/sandbox.yaml
+++ b/cmd/loomcycle/embedded/bundles/sandbox.yaml
@@ -24,7 +24,7 @@ agents:
   dev/sandbox:
     tier: middle
     effort: medium
-    tools: [mcp__sandbox__sandbox_open, mcp__sandbox__sandbox_exec, mcp__sandbox__sandbox_write, mcp__sandbox__sandbox_read, mcp__sandbox__sandbox_close, mcp__sandbox__sandbox_list, Interruption]
+    tools: [mcp__sandbox__sandbox_open, mcp__sandbox__sandbox_exec, mcp__sandbox__sandbox_write, mcp__sandbox__sandbox_read, mcp__sandbox__sandbox_close, mcp__sandbox__sandbox_touch, mcp__sandbox__sandbox_close_run, mcp__sandbox__sandbox_list, Interruption]
     skills: [dev/sandbox]
     compaction:
       enabled: true
@@ -65,7 +65,7 @@ agents:
 skills:
   dev/sandbox:
     description: Compile, test, and run code safely in an isolated ephemeral sandbox container (Python/Go/Rust/C++/Node) via the builder sidecar.
-    tools: [mcp__sandbox__sandbox_open, mcp__sandbox__sandbox_exec, mcp__sandbox__sandbox_write, mcp__sandbox__sandbox_read, mcp__sandbox__sandbox_close]
+    tools: [mcp__sandbox__sandbox_open, mcp__sandbox__sandbox_exec, mcp__sandbox__sandbox_write, mcp__sandbox__sandbox_read, mcp__sandbox__sandbox_close, mcp__sandbox__sandbox_touch, mcp__sandbox__sandbox_close_run]
     body: |
       # Running code in the sandbox
 
@@ -102,6 +102,12 @@ skills:
         parent agent may drive several commands against the same container.
       - Default to network:"none"; use "egress" only when a step must fetch something
         and the operator enabled egress.
+      - Keepalive: if you'll leave a session idle across a gap with no commands (a
+        parent is thinking between steps), sandbox_touch {session_id} resets its idle
+        timer so it isn't reaped — a normal sandbox_exec already resets it.
+      - Bulk teardown: sandbox_close_run {root_run_id} closes EVERY session you opened
+        for a run at once — use it when a driving parent asks you to clean up a run's
+        sandboxes, not for a single session (use sandbox_close for that).
       - Never assume host access — you only have these sandbox tools.
 
   dev/sandbox-usage:

--- a/cmd/loomcycle/presets_integration_test.go
+++ b/cmd/loomcycle/presets_integration_test.go
@@ -140,8 +140,10 @@ func TestEmbedded_SandboxBundleValidates(t *testing.T) {
 	if !ok {
 		t.Fatalf("dev/sandbox agent not registered (agents: %v)", agentNames(cfg))
 	}
-	// The agent must grant the sandbox tools + the auto-added Skill tool.
-	for _, want := range []string{"mcp__sandbox__sandbox_open", "mcp__sandbox__sandbox_exec", "Skill"} {
+	// The agent must grant the sandbox tools + the auto-added Skill tool — incl. the
+	// P2b lifecycle tools (touch keepalive + close_run bulk teardown), else the agent
+	// can't reach them even though the sidecar advertises them.
+	for _, want := range []string{"mcp__sandbox__sandbox_open", "mcp__sandbox__sandbox_exec", "mcp__sandbox__sandbox_touch", "mcp__sandbox__sandbox_close_run", "Skill"} {
 		if !hasToolPreset(agent.Tools, want) {
 			t.Errorf("dev/sandbox should grant %q; tools=%v", want, agent.Tools)
 		}

--- a/internal/tools/mcp/http/client.go
+++ b/internal/tools/mcp/http/client.go
@@ -290,6 +290,11 @@ func (c *Client) do(ctx context.Context, body []byte) (*http.Response, error) {
 			}
 			subV = resolvedV
 		}
+		// RFC BI P2b — non-secret run identifiers (${run.root_run_id} /
+		// ${run.tenant_id}) an operator forwards to a downstream MCP server for
+		// attribution (e.g. the sandbox sidecar tagging a session for
+		// run-liveness GC). Never drops (empty when the run carries none).
+		subV = substituteRunIDs(subV, runIdent.RootRunID, runIdent.TenantID)
 		req.Header.Set(k, subV)
 	}
 	c.sessMu.Lock()

--- a/internal/tools/mcp/http/substitute.go
+++ b/internal/tools/mcp/http/substitute.go
@@ -121,6 +121,38 @@ func substituteCredentialRefs(s string, creds map[string]string) (out string, dr
 	return out, drop, missing
 }
 
+// runIDRe matches the NON-secret per-run identifier tokens (RFC BI P2b):
+//
+//	${run.root_run_id}   — the top-level run id of this spawn tree
+//	${run.tenant_id}     — the run's tenant
+//
+// Unlike the bearer/credential tokens, these are non-secret identifiers an
+// operator forwards to a downstream MCP server so it can attribute a request to
+// a run/tenant (e.g. the sandbox sidecar tagging a session for run-liveness GC).
+// An unresolved token therefore substitutes to EMPTY rather than dropping the
+// whole header — an empty identifier is harmless (the server treats it as
+// "unknown"), whereas dropping would silently strip a header the operator wired.
+var runIDRe = regexp.MustCompile(`\$\{run\.(root_run_id|tenant_id)\}`)
+
+// substituteRunIDs replaces ${run.root_run_id} / ${run.tenant_id} in s with the
+// run's (non-secret) identifiers, or empty when the run carries none. Pure
+// function; never drops. Runs after the bearer/credential passes (the regexes
+// are disjoint, so order is irrelevant).
+func substituteRunIDs(s, rootRunID, tenantID string) string {
+	if !strings.Contains(s, "${run.") {
+		return s
+	}
+	return runIDRe.ReplaceAllStringFunc(s, func(m string) string {
+		switch m {
+		case "${run.root_run_id}":
+			return rootRunID
+		case "${run.tenant_id}":
+			return tenantID
+		}
+		return ""
+	})
+}
+
 // tokenPrefix returns a triage-safe 4-char prefix + ellipsis for a
 // bearer-shaped string, or "(empty)" for the empty string. Used only
 // on WARN paths; never invoked on the happy path. Satisfies CLAUDE.md

--- a/internal/tools/mcp/http/substitute_test.go
+++ b/internal/tools/mcp/http/substitute_test.go
@@ -256,3 +256,24 @@ func TestSubstituteCredentialRefs_InvalidKeyCharIgnored(t *testing.T) {
 		t.Errorf("drop = true, want false for non-matching expression")
 	}
 }
+
+func TestSubstituteRunIDs(t *testing.T) {
+	// Both identifiers resolve.
+	got := substituteRunIDs("run=${run.root_run_id} tenant=${run.tenant_id}", "r-123", "acme")
+	if got != "run=r-123 tenant=acme" {
+		t.Errorf("got = %q", got)
+	}
+	// Unresolved (empty run) → empty substitution, NOT a dropped/literal token.
+	got = substituteRunIDs("X-Loom-Root-Run=[${run.root_run_id}]", "", "")
+	if got != "X-Loom-Root-Run=[]" {
+		t.Errorf("empty root_run_id should substitute to empty, got %q", got)
+	}
+	// No token → unchanged (and the fast-path returns it verbatim).
+	if got := substituteRunIDs("Bearer abc", "r-1", "t-1"); got != "Bearer abc" {
+		t.Errorf("no-token passthrough failed: %q", got)
+	}
+	// Disjoint from the bearer/credential tokens — leaves them alone.
+	if got := substituteRunIDs("${run.user_bearer}", "r", "t"); got != "${run.user_bearer}" {
+		t.Errorf("must not touch ${run.user_bearer}: %q", got)
+	}
+}


### PR DESCRIPTION
The **loomcycle-core half of RFC BI P2b** — forwarding the run's non-secret identifiers to a downstream MCP server so the sandbox sidecar can attribute sessions to a run tree. (The sidecar half — `sandbox_touch`, `sandbox_close_run`, header-tagging, the run-liveness poll — is a follow-up PR on `deploy/builder`.)

## What

- `internal/tools/mcp/http` — new **`substituteRunIDs`** adds `${run.root_run_id}` and `${run.tenant_id}` substitution to outbound MCP header values, alongside the existing `${run.user_bearer}` / `${run.credentials.<n>}` / `$cred:`. These are **non-secret identifiers**, so an unresolved token substitutes to **empty** (not a dropped header). Disjoint from the bearer/credential regexes; runs after them; never drops.
- The **`sandbox` bundle** forwards `X-Loom-Root-Run: ${run.root_run_id}` + `X-Loom-Tenant: ${run.tenant_id}` on `mcp_servers.sandbox` (source ⇄ embed mirror identical).

## Why

P2b's `sandbox_close_run` + run-liveness GC need each session tagged with its owning run tree, and it must be **attested** (loomcycle-filled, not agent-supplied) — this is the substitution that delivers it. `X-Loom-Tenant` is forwarded now too, setting up the later attested per-tenant binding.

## Tested

- `TestSubstituteRunIDs` — resolves both, empty-on-missing (no dropped header), no-token passthrough, and leaves `${run.user_bearer}` untouched.
- Full `go test ./...` clean; the sandbox bundle still loads + validates (`TestEmbedded_SandboxBundleValidates`); gofmt clean.

Additive; no wire/schema change; adapters unchanged. Design: RFC BI P2 (`/loomcycle/rfcs/sandboxed-code-execution-p2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)