### PR TITLE
feat(sandbox): sandbox_touch + sandbox_close_run + run tagging (RFC BI P2b)

### DIFF
--- a/deploy/builder/README.md
+++ b/deploy/builder/README.md
@@ -33,7 +33,14 @@ loomcycle-builder (this sidecar)  ──►  per-session container
 | `sandbox_exec` | Run a command in a session (`/work`); returns combined output + exit code. |
 | `sandbox_write` / `sandbox_read` | Put files in / pull artifacts out (paths relative to `/work`; `base64` for binary). |
 | `sandbox_close` | Destroy a session (idempotent). |
+| `sandbox_touch` | Reset a session's idle timer — a keepalive to hold a container across a gap between commands. |
+| `sandbox_close_run` | Close ALL your sessions for a given `root_run_id` (bulk teardown of a run tree). |
 | `sandbox_list` | List your own sessions. |
+
+Sessions are tagged with their owning loomcycle **run** via the attested
+`X-Loom-Root-Run` header loomcycle forwards (`${run.root_run_id}`) — that's what
+`sandbox_close_run` matches on. The tag is set from the request header, never a
+tool argument, and it's principal-scoped (a caller only ever closes its own).
 
 Sessions are long-lived — open once, run many commands (the workspace, deps, and
 build cache persist across `sandbox_exec` calls), close when done. They also
@@ -171,9 +178,11 @@ and the build cache (`GOCACHE`/`CARGO_HOME`/`npm` cache all redirect onto `/work
 ## Scope (this release)
 
 Single shared bearer, TTL + explicit close for cleanup, `runc`/`runsc` runtimes,
-and (P2a) **durable workspaces** (above). Deferred: a keepalive + run-liveness-poll
-GC + `sandbox_close_run` (P2b), attested per-tenant identity (multi-tenant isolation
-via loomcycle-filled `X-Loom-Tenant`/`X-Loom-Root-Run` headers), and the Kata
+(P2a) **durable workspaces** (above), and (P2b) the **`sandbox_touch`** keepalive +
+**`sandbox_close_run`** bulk-teardown with attested `X-Loom-Root-Run` session
+tagging. Deferred: **auto-reap on run-end** (a run-liveness poll or a loomcycle
+run-end push — the absolute TTL is the current backstop), attested per-tenant
+identity (multi-tenant isolation via the forwarded `X-Loom-Tenant`), and the Kata
 microVM tier.
 
 ## Tests

--- a/deploy/builder/mcp.go
+++ b/deploy/builder/mcp.go
@@ -94,7 +94,15 @@ func (h *MCPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			writeRPCError(w, id, -32602, "invalid params")
 			return
 		}
-		text, isErr, cerr := h.disp.Call(r.Context(), principal, p.Name, p.Arguments)
+		// The run identifiers are attested — read from the headers loomcycle
+		// filled (X-Loom-Root-Run / X-Loom-Tenant, RFC BI P2b), never from tool
+		// args. Empty when the caller didn't send them.
+		c := caller{
+			Principal: principal,
+			RootRun:   strings.TrimSpace(r.Header.Get("X-Loom-Root-Run")),
+			Tenant:    strings.TrimSpace(r.Header.Get("X-Loom-Tenant")),
+		}
+		text, isErr, cerr := h.disp.Call(r.Context(), c, p.Name, p.Arguments)
 		if cerr != nil {
 			// Protocol-level fault (unknown tool, malformed args).
 			writeRPCError(w, id, -32602, cerr.Error())

--- a/deploy/builder/p2b_test.go
+++ b/deploy/builder/p2b_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// dispatcherWithFake builds a Dispatcher over a fake runner (podman/docker calls
+// are recorded, not executed).
+func dispatcherWithFake() (*Dispatcher, *fakeRunner) {
+	cfg := testCfg()
+	fr := &fakeRunner{}
+	return NewDispatcher(cfg, NewEngine(cfg, fr), NewStore(cfg.SessionIdleTTL, cfg.SessionMaxTTL)), fr
+}
+
+func openSession(t *testing.T, d *Dispatcher, c caller) string {
+	t.Helper()
+	text, isErr, err := d.Call(context.Background(), c, "sandbox_open", json.RawMessage(`{}`))
+	if err != nil || isErr {
+		t.Fatalf("open failed: isErr=%v err=%v text=%s", isErr, err, text)
+	}
+	var o struct {
+		SessionID string `json:"session_id"`
+	}
+	if e := json.Unmarshal([]byte(text), &o); e != nil || o.SessionID == "" {
+		t.Fatalf("open response not parseable: %s", text)
+	}
+	return o.SessionID
+}
+
+func TestDispatch_Touch(t *testing.T) {
+	d, _ := dispatcherWithFake()
+	ctx := context.Background()
+	const p = "op:test"
+	id := openSession(t, d, caller{Principal: p})
+
+	// touch resets the idle clock (Get's side effect) — assert LastUsed advances.
+	before, _ := d.store.Get(id, p, time.Unix(0, 0))
+	oldUsed := before.LastUsed
+	targs, _ := json.Marshal(map[string]any{"session_id": id})
+	res, isErr, _ := d.Call(ctx, caller{Principal: p}, "sandbox_touch", targs)
+	if isErr || !strings.Contains(res, "idle timer reset") {
+		t.Errorf("touch: isErr=%v res=%q", isErr, res)
+	}
+	after, _ := d.store.Get(id, p, time.Now())
+	if !after.LastUsed.After(oldUsed) {
+		t.Errorf("touch should advance LastUsed (%v !> %v)", after.LastUsed, oldUsed)
+	}
+	// unknown session → isError
+	bad, _ := json.Marshal(map[string]any{"session_id": "nope"})
+	if _, isErr, _ := d.Call(ctx, caller{Principal: p}, "sandbox_touch", bad); !isErr {
+		t.Errorf("touch on unknown session should error")
+	}
+	// a foreign principal can't touch it
+	if _, isErr, _ := d.Call(ctx, caller{Principal: "op:other"}, "sandbox_touch", targs); !isErr {
+		t.Errorf("foreign principal must not touch another's session")
+	}
+}
+
+func TestDispatch_CloseRun(t *testing.T) {
+	d, _ := dispatcherWithFake()
+	ctx := context.Background()
+	const p = "op:test"
+
+	a1 := openSession(t, d, caller{Principal: p, RootRun: "run-A"})
+	a2 := openSession(t, d, caller{Principal: p, RootRun: "run-A"})
+	b1 := openSession(t, d, caller{Principal: p, RootRun: "run-B"})
+	openSession(t, d, caller{Principal: p}) // untagged
+	if d.store.Count() != 4 {
+		t.Fatalf("expected 4 sessions, got %d", d.store.Count())
+	}
+
+	// close_run(run-A) closes exactly a1+a2.
+	args, _ := json.Marshal(map[string]any{"root_run_id": "run-A"})
+	res, isErr, _ := d.Call(ctx, caller{Principal: p}, "sandbox_close_run", args)
+	if isErr || !strings.Contains(res, "closed 2 session") {
+		t.Errorf("close_run(run-A): isErr=%v res=%q", isErr, res)
+	}
+	if _, ok := d.store.Get(a1, p, time.Now()); ok {
+		t.Errorf("a1 should be gone")
+	}
+	if _, ok := d.store.Get(a2, p, time.Now()); ok {
+		t.Errorf("a2 should be gone")
+	}
+	if _, ok := d.store.Get(b1, p, time.Now()); !ok {
+		t.Errorf("b1 (run-B) must survive")
+	}
+	if d.store.Count() != 2 {
+		t.Errorf("run-B + untagged should remain; count=%d", d.store.Count())
+	}
+
+	// empty root_run_id is refused (never sweeps untagged sessions).
+	empty, _ := json.Marshal(map[string]any{"root_run_id": ""})
+	if _, isErr, _ := d.Call(ctx, caller{Principal: p}, "sandbox_close_run", empty); !isErr {
+		t.Errorf("close_run with empty root_run_id should error")
+	}
+	// a foreign principal closing run-B closes nothing (principal-scoped).
+	argsB, _ := json.Marshal(map[string]any{"root_run_id": "run-B"})
+	res, _, _ = d.Call(ctx, caller{Principal: "op:other"}, "sandbox_close_run", argsB)
+	if !strings.Contains(res, "closed 0 session") {
+		t.Errorf("foreign close_run should close 0, got %q", res)
+	}
+	if _, ok := d.store.Get(b1, p, time.Now()); !ok {
+		t.Errorf("b1 must survive a foreign close_run")
+	}
+}
+
+// TestMCP_TagsSessionFromAttestedHeader: the X-Loom-Root-Run header (set by the
+// handler from the request, NOT a tool arg) tags the session, so close_run finds
+// it. Drives it through the real HTTP handler.
+func TestMCP_TagsSessionFromAttestedHeader(t *testing.T) {
+	h := newTestHandler(t, &fakeRunner{})
+	call := func(rootRun, body string) string {
+		r, _ := http.NewRequest(http.MethodPost, "/mcp", strings.NewReader(body))
+		r.Header.Set("Authorization", "Bearer secret-token")
+		if rootRun != "" {
+			r.Header.Set("X-Loom-Root-Run", rootRun)
+		}
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, r)
+		return rr.Body.String()
+	}
+	openText := call("run-Z", `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"sandbox_open","arguments":{}}}`)
+	if !strings.Contains(openText, "session_id") {
+		t.Fatalf("open failed: %s", openText)
+	}
+	// The session is tagged run-Z from the header; close_run(run-Z) closes it.
+	closeText := call("run-Z", `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"sandbox_close_run","arguments":{"root_run_id":"run-Z"}}}`)
+	if !strings.Contains(closeText, "closed 1 session") {
+		t.Errorf("close_run should have found the header-tagged session; got %s", closeText)
+	}
+}

--- a/deploy/builder/session.go
+++ b/deploy/builder/session.go
@@ -14,6 +14,9 @@ type Session struct {
 	Image     string
 	Network   string
 	Workspace string // durable workspace name (RFC BI P2a); empty = tmpfs /work
+	RootRun   string // owning loomcycle root_run_id (RFC BI P2b, from the attested
+	//                     X-Loom-Root-Run header); empty = untagged. Enables
+	//                     sandbox_close_run + run-liveness GC.
 	CreatedAt time.Time
 	LastUsed  time.Time // touched on every exec/read/write; drives idle TTL
 }
@@ -57,6 +60,26 @@ func (s *Store) Remove(id string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.m, id)
+}
+
+// RemoveByRun removes + returns every session owned by principal whose RootRun
+// matches rootRun (RFC BI P2b — sandbox_close_run). Principal-scoped, so a caller
+// only ever closes its own sessions; rootRun must be non-empty (guarding against a
+// close_run("") that would sweep every untagged session).
+func (s *Store) RemoveByRun(principal, rootRun string) []*Session {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if rootRun == "" {
+		return nil
+	}
+	var out []*Session
+	for id, sess := range s.m {
+		if sess.Principal == principal && sess.RootRun == rootRun {
+			out = append(out, sess)
+			delete(s.m, id)
+		}
+	}
+	return out
 }
 
 // Count returns the number of live sessions (global; P1 caps globally).

--- a/deploy/builder/tools.go
+++ b/deploy/builder/tools.go
@@ -45,33 +45,51 @@ func (d *Dispatcher) Tools() []toolDescriptor {
 		{Name: "sandbox_write", Description: "Write a file into the sandbox workspace at a path relative to /work (parent dirs are created). Use this to put source files in before compiling.", InputSchema: schemaWrite},
 		{Name: "sandbox_read", Description: "Read a file from the sandbox workspace (path relative to /work). Use this to pull out build output or a generated artifact.", InputSchema: schemaRead},
 		{Name: "sandbox_close", Description: "Destroy a sandbox session and free its resources. Always close a session when finished; sessions also expire on their own after an idle timeout.", InputSchema: schemaClose},
+		{Name: "sandbox_touch", Description: "Reset a session's idle timer (a heartbeat) to keep its container alive across a gap between commands. Use it when you'll return to a session after a pause longer than the idle timeout.", InputSchema: schemaTouch},
+		{Name: "sandbox_close_run", Description: "Close ALL of your sandbox sessions that belong to a given run (bulk teardown by root_run_id). Use it to tear down a whole run's containers at once.", InputSchema: schemaCloseRun},
 		{Name: "sandbox_list", Description: "List your currently open sandbox sessions.", InputSchema: schemaList},
 	}
+}
+
+// caller carries the server-attested identity of an MCP request: the principal
+// derived from the bearer, plus the non-secret run identifiers loomcycle forwards
+// as headers (X-Loom-Root-Run / X-Loom-Tenant, RFC BI P2b). RootRun and Tenant are
+// "" when the caller didn't send them (e.g. a direct client, or loomcycle without
+// the run-id substitution). Unforgeable — they come from the request headers the
+// MCP handler read, not from tool arguments.
+type caller struct {
+	Principal string
+	RootRun   string
+	Tenant    string
 }
 
 // Call dispatches a tools/call. It returns model-facing text and an isError flag
 // (a tool-level failure the model should see + react to), or a non-nil error for
 // a protocol-level fault (malformed arguments) which becomes a JSON-RPC error.
-func (d *Dispatcher) Call(ctx context.Context, principal, name string, args json.RawMessage) (text string, isError bool, err error) {
+func (d *Dispatcher) Call(ctx context.Context, c caller, name string, args json.RawMessage) (text string, isError bool, err error) {
 	switch name {
 	case "sandbox_open":
-		return d.open(ctx, principal, args)
+		return d.open(ctx, c, args)
 	case "sandbox_exec":
-		return d.exec(ctx, principal, args)
+		return d.exec(ctx, c.Principal, args)
 	case "sandbox_write":
-		return d.write(ctx, principal, args)
+		return d.write(ctx, c.Principal, args)
 	case "sandbox_read":
-		return d.read(ctx, principal, args)
+		return d.read(ctx, c.Principal, args)
 	case "sandbox_close":
-		return d.close(ctx, principal, args)
+		return d.close(ctx, c.Principal, args)
+	case "sandbox_close_run":
+		return d.closeRun(ctx, c.Principal, args)
+	case "sandbox_touch":
+		return d.touch(c.Principal, args)
 	case "sandbox_list":
-		return d.list(principal)
+		return d.list(c.Principal)
 	default:
 		return "", false, fmt.Errorf("unknown tool %q", name)
 	}
 }
 
-func (d *Dispatcher) open(ctx context.Context, principal string, raw json.RawMessage) (string, bool, error) {
+func (d *Dispatcher) open(ctx context.Context, c caller, raw json.RawMessage) (string, bool, error) {
 	var in struct {
 		Network   string  `json:"network"`
 		TmpfsMB   int64   `json:"tmpfs_mb"`
@@ -95,7 +113,7 @@ func (d *Dispatcher) open(ctx context.Context, principal string, raw json.RawMes
 	// (never a raw caller path); the request is refused when durable workspaces are
 	// not enabled.
 	if in.Workspace != "" {
-		dir, werr := d.resolveWorkspaceDir(principal, in.Workspace)
+		dir, werr := d.resolveWorkspaceDir(c.Principal, in.Workspace)
 		if werr != nil {
 			return werr.Error(), true, nil
 		}
@@ -111,7 +129,7 @@ func (d *Dispatcher) open(ctx context.Context, principal string, raw json.RawMes
 		return "opening sandbox failed: " + err.Error(), true, nil
 	}
 	now := d.now()
-	sess := &Session{ID: id, Name: name, Principal: principal, Image: o.Image, Network: o.Network, Workspace: in.Workspace, CreatedAt: now, LastUsed: now}
+	sess := &Session{ID: id, Name: name, Principal: c.Principal, Image: o.Image, Network: o.Network, Workspace: in.Workspace, RootRun: c.RootRun, CreatedAt: now, LastUsed: now}
 	d.store.Add(sess)
 
 	respObj := map[string]any{
@@ -349,6 +367,44 @@ func (d *Dispatcher) close(ctx context.Context, principal string, raw json.RawMe
 	return "closed " + sess.ID, false, nil
 }
 
+// touch resets a session's idle timer (RFC BI P2b keepalive) — a driver holding a
+// container across a known gap calls it so the idle TTL doesn't reap the session
+// mid-wait. Get() already refreshes LastUsed as a side effect; this is the explicit
+// keepalive surface.
+func (d *Dispatcher) touch(principal string, raw json.RawMessage) (string, bool, error) {
+	var in struct {
+		SessionID string `json:"session_id"`
+	}
+	if err := unmarshalArgs(raw, &in); err != nil {
+		return "", false, err
+	}
+	sess, ok := d.store.Get(in.SessionID, principal, d.now())
+	if !ok {
+		return "no such session (open one with sandbox_open, or it may have expired)", true, nil
+	}
+	return "touched " + sess.ID + " — idle timer reset", false, nil
+}
+
+// closeRun bulk-closes every session the caller owns for a given loomcycle run
+// tree (RFC BI P2b). Principal-scoped (a caller only closes its own) and requires
+// a non-empty root_run_id. Idempotent — a run with no live sessions returns 0.
+func (d *Dispatcher) closeRun(ctx context.Context, principal string, raw json.RawMessage) (string, bool, error) {
+	var in struct {
+		RootRunID string `json:"root_run_id"`
+	}
+	if err := unmarshalArgs(raw, &in); err != nil {
+		return "", false, err
+	}
+	if in.RootRunID == "" {
+		return "root_run_id is required", true, nil
+	}
+	closed := d.store.RemoveByRun(principal, in.RootRunID)
+	for _, s := range closed {
+		_ = d.eng.Close(ctx, s.Name) // best-effort; store row already removed
+	}
+	return fmt.Sprintf("closed %d session(s) for run %s", len(closed), in.RootRunID), false, nil
+}
+
 func (d *Dispatcher) list(principal string) (string, bool, error) {
 	sessions := d.store.ListByPrincipal(principal)
 	out := make([]map[string]any, 0, len(sessions))
@@ -510,6 +566,16 @@ var (
 		"type": "object",
 		"properties": {"session_id": {"type": "string"}},
 		"required": ["session_id"]
+	}`)
+	schemaTouch = json.RawMessage(`{
+		"type": "object",
+		"properties": {"session_id": {"type": "string", "description": "The session to keep alive (resets its idle timer)."}},
+		"required": ["session_id"]
+	}`)
+	schemaCloseRun = json.RawMessage(`{
+		"type": "object",
+		"properties": {"root_run_id": {"type": "string", "description": "Close every session belonging to this run."}},
+		"required": ["root_run_id"]
 	}`)
 	schemaList = json.RawMessage(`{"type": "object", "properties": {}}`)
 )

--- a/deploy/builder/tools_test.go
+++ b/deploy/builder/tools_test.go
@@ -78,7 +78,7 @@ func TestDispatch_OpenExecCloseLifecycle(t *testing.T) {
 	const principal = "op:test"
 
 	// open
-	text, isErr, err := d.Call(ctx, principal, "sandbox_open", json.RawMessage(`{}`))
+	text, isErr, err := d.Call(ctx, caller{Principal: principal}, "sandbox_open", json.RawMessage(`{}`))
 	if err != nil || isErr {
 		t.Fatalf("open failed: isErr=%v err=%v text=%s", isErr, err, text)
 	}
@@ -95,32 +95,32 @@ func TestDispatch_OpenExecCloseLifecycle(t *testing.T) {
 
 	// exec success → isError false
 	args, _ := json.Marshal(map[string]any{"session_id": opened.SessionID, "command": "echo ok"})
-	text, isErr, _ = d.Call(ctx, principal, "sandbox_exec", args)
+	text, isErr, _ = d.Call(ctx, caller{Principal: principal}, "sandbox_exec", args)
 	if isErr || !strings.Contains(text, "ok") {
 		t.Errorf("exec ok: isErr=%v text=%q", isErr, text)
 	}
 
 	// exec failure → isError true + [exit: 1] marker
 	args, _ = json.Marshal(map[string]any{"session_id": opened.SessionID, "command": "fail"})
-	text, isErr, _ = d.Call(ctx, principal, "sandbox_exec", args)
+	text, isErr, _ = d.Call(ctx, caller{Principal: principal}, "sandbox_exec", args)
 	if !isErr || !strings.Contains(text, "[exit: 1]") {
 		t.Errorf("exec fail should be isError with exit marker: isErr=%v text=%q", isErr, text)
 	}
 
 	// a foreign principal cannot exec in this session
-	_, isErr, _ = d.Call(ctx, "op:other", "sandbox_exec", args)
+	_, isErr, _ = d.Call(ctx, caller{Principal: "op:other"}, "sandbox_exec", args)
 	if !isErr {
 		t.Errorf("foreign principal should get an error (no such session)")
 	}
 
 	// close
 	closeArgs, _ := json.Marshal(map[string]any{"session_id": opened.SessionID})
-	_, isErr, _ = d.Call(ctx, principal, "sandbox_close", closeArgs)
+	_, isErr, _ = d.Call(ctx, caller{Principal: principal}, "sandbox_close", closeArgs)
 	if isErr {
 		t.Errorf("close should succeed")
 	}
 	// second close is idempotent (session gone → not an error)
-	_, isErr, _ = d.Call(ctx, principal, "sandbox_close", closeArgs)
+	_, isErr, _ = d.Call(ctx, caller{Principal: principal}, "sandbox_close", closeArgs)
 	if isErr {
 		t.Errorf("idempotent close should not error")
 	}
@@ -131,10 +131,10 @@ func TestDispatch_CapacityLimit(t *testing.T) {
 	cfg.MaxSessions = 1
 	fr := &fakeRunner{}
 	d := NewDispatcher(cfg, NewEngine(cfg, fr), NewStore(cfg.SessionIdleTTL, cfg.SessionMaxTTL))
-	if _, isErr, _ := d.Call(context.Background(), "p", "sandbox_open", json.RawMessage(`{}`)); isErr {
+	if _, isErr, _ := d.Call(context.Background(), caller{Principal: "p"}, "sandbox_open", json.RawMessage(`{}`)); isErr {
 		t.Fatal("first open should succeed")
 	}
-	text, isErr, _ := d.Call(context.Background(), "p", "sandbox_open", json.RawMessage(`{}`))
+	text, isErr, _ := d.Call(context.Background(), caller{Principal: "p"}, "sandbox_open", json.RawMessage(`{}`))
 	if !isErr || !strings.Contains(text, "capacity") {
 		t.Errorf("second open should hit capacity: isErr=%v text=%q", isErr, text)
 	}

--- a/deploy/builder/workspace_test.go
+++ b/deploy/builder/workspace_test.go
@@ -107,7 +107,7 @@ func TestDispatch_OpenWithWorkspace(t *testing.T) {
 	d := NewDispatcher(cfg, NewEngine(cfg, fr), NewStore(cfg.SessionIdleTTL, cfg.SessionMaxTTL))
 
 	args, _ := json.Marshal(map[string]any{"workspace": "proj"})
-	text, isErr, err := d.Call(context.Background(), "op:test", "sandbox_open", args)
+	text, isErr, err := d.Call(context.Background(), caller{Principal: "op:test"}, "sandbox_open", args)
 	if err != nil || isErr {
 		t.Fatalf("open failed: isErr=%v err=%v text=%s", isErr, err, text)
 	}
@@ -125,7 +125,7 @@ func TestDispatch_OpenWithWorkspace(t *testing.T) {
 	// Gate: with no WorkspaceRoot, a workspace request is refused (tmpfs-only).
 	cfg2 := testCfg()
 	d2 := NewDispatcher(cfg2, NewEngine(cfg2, &fakeRunner{}), NewStore(cfg2.SessionIdleTTL, cfg2.SessionMaxTTL))
-	text2, isErr2, _ := d2.Call(context.Background(), "op:test", "sandbox_open", args)
+	text2, isErr2, _ := d2.Call(context.Background(), caller{Principal: "op:test"}, "sandbox_open", args)
 	if !isErr2 || !strings.Contains(text2, "not enabled") {
 		t.Errorf("workspace without a root should be refused: isErr=%v text=%s", isErr2, text2)
 	}


### PR DESCRIPTION
The **sidecar half of RFC BI P2b** (long-session lifecycle). Companion to **#754** (the loomcycle-core `${run.root_run_id}` substitution + the bundle header). Sidecar-only (`deploy/builder`).

## What

- **Attested run tagging.** The MCP handler reads the `X-Loom-Root-Run` (+ `X-Loom-Tenant`) headers loomcycle forwards and carries them in a `caller` struct alongside the bearer-derived principal; `sandbox_open` tags the session's `RootRun` from the **header, never a tool arg** (unforgeable).
- **`sandbox_touch(session_id)`** — reset the idle timer; a keepalive so a driver can hold a container across a gap between commands without the idle TTL reaping it.
- **`sandbox_close_run(root_run_id)`** — bulk-close every session the caller owns for a run tree (`Store.RemoveByRun`): principal-scoped, non-empty-guarded (never sweeps untagged sessions), idempotent.

## Deferred (documented)

**Auto-reap on run-end** — a run-liveness poll of loomcycle *or* a loomcycle run-end push seam. It needs the `GET /v1/runs/{id}` status contract nailed down + a loomcycle poll token + a live deployment to verify, none of which are testable here. The **absolute TTL is the backstop**, and with durable workspaces (P2a) a reaped container loses no work — so this is an optimization, cleanly scoped as a follow-up.

## Graceful without #754

Until #754 lands (loomcycle sending the header), the header is simply absent → sessions are untagged: `sandbox_touch` still works; `sandbox_close_run` finds nothing; the TTL still reaps. No breakage.

## Tested

`go test -race ./...`:
- `sandbox_touch` advances `LastUsed`; unknown-session + foreign-principal refused.
- `sandbox_close_run` closes exactly the run's sessions, leaves run-B + untagged alone, refuses empty `root_run_id`, and a foreign principal closes 0.
- Header→session tagging verified through the real HTTP handler (open with `X-Loom-Root-Run`, then `close_run` finds it).
- The `Call(principal)` → `Call(caller)` refactor threaded through all tests; gofmt/vet clean; root module unaffected.

Design: RFC BI P2 (`/loomcycle/rfcs/sandboxed-code-execution-p2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)