### PR TITLE
fix(mcp): re-probe static MCP servers at run start when skipped at boot

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1263,14 +1263,28 @@ func main() {
 	// mcp__<server>__<tool> tool triggers the handshake there. Server
 	// mode keeps eager init — fail-fast is correct when the operator
 	// is starting a long-lived daemon.
+	// Static MCP servers that failed (or, in `loomcycle mcp` mode, never attempted)
+	// their boot handshake. Threaded into the run-start re-probe
+	// (mcp.StaticToolsForRun) so a peer that comes up AFTER loomcycle self-heals on
+	// the next run that references it — no restart. A static server's tools reach
+	// the catalog ONLY via this boot loop, and the lazy resolver advertises nothing
+	// to a fresh model, so without the re-probe a boot-skipped server (e.g. a
+	// sidecar that started second) stays invisible until a loomcycle restart.
+	// Populated here (single-threaded boot), then read-only once the enumerator is
+	// set below.
+	skippedStaticMCP := map[string]bool{}
 	if mcpMode {
-		log.Printf("mcp mode: skipping eager upstream MCP init for %d server(s); lazy resolver will handshake on first agent call", len(cfg.MCPServers))
+		log.Printf("mcp mode: skipping eager upstream MCP init for %d server(s); run-start re-probe + lazy resolver handshake on first agent use", len(cfg.MCPServers))
+		for name := range cfg.MCPServers {
+			skippedStaticMCP[name] = true
+		}
 	} else {
 		mcpInitCtx, mcpInitCancel := context.WithTimeout(context.Background(), 30*time.Second)
 		for name, srv := range cfg.MCPServers {
 			_, descs, err := mcpPool.GetWithRetry(mcpInitCtx, name, log.Printf)
 			if err != nil {
-				log.Printf("mcp[%s]: skipped — %v", name, err)
+				log.Printf("mcp[%s]: skipped — %v — run-start re-probe will retry when a run references it", name, err)
+				skippedStaticMCP[name] = true
 				continue
 			}
 			filtered := applyToolsFilter(descs, srv.Tools)
@@ -1896,6 +1910,11 @@ func main() {
 		// bounded run-start handshake for a REFERENCED server whose cache is
 		// empty) lives in the testable mcp.DynamicToolsForRun helper.
 		out := mcp.DynamicToolsForRun(ctx, mcpPool, dynamicMCPRegistry, mcpActiveDefReader{storeIface}, tenant, wantServers, runStartMCPDiscoveryTimeout, log.Printf)
+		// Recover STATIC (yaml) MCP servers skipped at boot without a restart —
+		// the static sibling of the F33 dynamic re-probe above. Scoped to the
+		// servers this run references (wantServers) and to those that actually
+		// failed boot (skippedStaticMCP), so a healthy server is never re-dialed.
+		out = append(out, mcp.StaticToolsForRun(ctx, mcpPool, cfg.MCPServers, skippedStaticMCP, tenant, wantServers, runStartMCPDiscoveryTimeout, log.Printf)...)
 		if cfg.Env.A2AServerEnabled {
 			resolve := func(ctx context.Context, name string) (config.A2AAgent, bool) {
 				// RFC N: the enumerator's `tenant` is authoritative (server

--- a/internal/tools/mcp/enumerate.go
+++ b/internal/tools/mcp/enumerate.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/lookup"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
@@ -117,6 +118,89 @@ func DynamicToolsForRun(
 		}
 		if logf != nil {
 			logf("mcp[%s]: run-start discovery advertised %d tool(s) (F33: referenced server had no cached tools)", name, len(descs))
+		}
+	}
+	return out
+}
+
+// StaticToolsForRun recovers the tools of STATIC (yaml `mcp_servers:`) servers that
+// were SKIPPED at boot — the run-start counterpart to the boot handshake loop, and
+// the static-server sibling of DynamicToolsForRun.
+//
+// Why it exists. A static server's tools enter the tool catalog ONLY via the boot
+// handshake loop (cmd/loomcycle/main.go). If the peer is unreachable during
+// loomcycle's boot window it is skipped and its tools never register — invisible to
+// every run until a loomcycle restart. The lazy resolver (lazy.go) does NOT close
+// this: it recovers an actual tool CALL but never ADVERTISES a tool to a fresh
+// model, so an agent whose only access is that server never enters tool-calling
+// mode and can't trigger the lazy path. This advertises + wires the tools at run
+// start instead, so a sidecar that comes up AFTER loomcycle self-heals on the next
+// run that references it.
+//
+// skipped is the set of static server names that failed the boot handshake (in
+// `loomcycle mcp` mode, where eager init is skipped entirely, it is EVERY static
+// server). Only those are considered — a boot-registered server is already in the
+// candidateTools floor, so re-advertising it here would be wasted work + a needless
+// per-tenant handshake.
+//
+// Per skipped server THIS run references (wantServers, from the agent's declared
+// tools):
+//   - cached tools/list in the pool (a prior run already re-probed) → advertise
+//     from cache, no handshake — the fast path once the peer is up.
+//   - else → one bounded handshake under the run's tenant; on success advertise +
+//     leave the entry warm; on failure drop it and continue (the lazy resolver
+//     still backstops the actual call).
+//
+// A server the run does NOT reference is never handshaked, so a single down peer
+// can't slow every run. The operator's per-server tools filter (srv.Tools) is
+// applied exactly as the boot loop does. Best-effort throughout; logf may be nil.
+func StaticToolsForRun(
+	ctx context.Context,
+	pool *Pool,
+	servers map[string]config.MCPServer,
+	skipped map[string]bool,
+	tenant string,
+	wantServers map[string]bool,
+	handshakeTimeout time.Duration,
+	logf func(string, ...any),
+) []tools.Tool {
+	if pool == nil || len(skipped) == 0 {
+		return nil
+	}
+	var out []tools.Tool
+	for name := range skipped {
+		// Only pay for a server this run actually uses (mirror the F33 gate).
+		if !wantServers[sanitiseServerName(name)] {
+			continue
+		}
+		srv, ok := servers[name]
+		if !ok {
+			continue // config no longer declares it (defensive)
+		}
+		// Fast path: a prior run already re-probed this peer → advertise from the
+		// pool's cache without a wire round-trip.
+		if cached := pool.PeekTools(tenant, name); len(cached) > 0 {
+			for _, d := range ApplyToolsFilter(cached, srv.Tools) {
+				out = append(out, NewTool(pool, name, d))
+			}
+			continue
+		}
+		// Empty cache → one bounded handshake under the run's tenant (so pool.Get
+		// dials the tenant's spec, mirroring DynamicToolsForRun).
+		hsCtx, cancel := context.WithTimeout(withTenant(ctx, tenant), handshakeTimeout)
+		_, descs, err := pool.Get(hsCtx, name)
+		cancel()
+		if err != nil {
+			if logf != nil {
+				logf("mcp[%s]: run-start re-probe failed (skipped at boot): %v — lazy first-call fallback still applies", name, err)
+			}
+			continue
+		}
+		for _, d := range ApplyToolsFilter(descs, srv.Tools) {
+			out = append(out, NewTool(pool, name, d))
+		}
+		if logf != nil {
+			logf("mcp[%s]: run-start re-probe advertised %d tool(s) (recovered a server skipped at boot)", name, len(descs))
 		}
 	}
 	return out

--- a/internal/tools/mcp/static_test.go
+++ b/internal/tools/mcp/static_test.go
@@ -1,0 +1,183 @@
+package mcp_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+	"github.com/denn-gubsky/loomcycle/internal/tools/mcp"
+	"github.com/denn-gubsky/loomcycle/internal/tools/mcp/stdio"
+)
+
+// staticServers builds a cfg.MCPServers-shaped map of stdio servers (Tools nil =
+// allow all), the shape StaticToolsForRun reads for the operator tools filter.
+func staticServers(names ...string) map[string]config.MCPServer {
+	m := map[string]config.MCPServer{}
+	for _, n := range names {
+		m[n] = config.MCPServer{Transport: "stdio"}
+	}
+	return m
+}
+
+// TestStaticToolsForRun_RecoversSkippedReferenced is the core regression: a static
+// server SKIPPED at boot but referenced by the run is handshaked at run start and
+// its tools advertised — the exact gap that left an agent's mcp__<server>__* tools
+// invisible until a loomcycle restart. On the pre-fix code (no run-start static
+// re-probe) this server contributes zero tools.
+func TestStaticToolsForRun_RecoversSkippedReferenced(t *testing.T) {
+	pool := newPoolWithFake(t, "ok") // exposes one tool: web_search
+
+	out := mcp.StaticToolsForRun(context.Background(), pool,
+		staticServers("search"), map[string]bool{"search": true}, // skipped at boot
+		"", map[string]bool{"search": true}, // referenced by the run
+		5*time.Second, nil)
+	if len(out) != 1 {
+		t.Fatalf("want 1 recovered tool, got %d", len(out))
+	}
+	if got, want := out[0].Name(), "mcp__search__web_search"; got != want {
+		t.Errorf("tool name = %q, want %q", got, want)
+	}
+}
+
+// TestStaticToolsForRun_IgnoresBootRegistered — a server NOT in the skipped set is
+// already in the boot catalog (candidateTools' floor); StaticToolsForRun must not
+// re-advertise or re-dial it. This is the discriminator vs a blanket re-probe.
+func TestStaticToolsForRun_IgnoresBootRegistered(t *testing.T) {
+	dialed := false
+	pool := mcp.NewPool(func(_, _ string) (mcp.Caller, error) {
+		dialed = true
+		return nil, errors.New("must not dial a boot-registered server")
+	}, nil, nil)
+	t.Cleanup(pool.Close)
+
+	out := mcp.StaticToolsForRun(context.Background(), pool,
+		staticServers("search"), map[string]bool{}, // empty skipped set
+		"", map[string]bool{"search": true}, time.Second, nil)
+	if len(out) != 0 || dialed {
+		t.Errorf("boot-registered server must be ignored (tools=%d dialed=%v)", len(out), dialed)
+	}
+}
+
+// TestStaticToolsForRun_SkipsUnreferenced — a skipped server the run does NOT
+// reference is never handshaked, so one down peer can't slow every run.
+func TestStaticToolsForRun_SkipsUnreferenced(t *testing.T) {
+	dialed := false
+	pool := mcp.NewPool(func(_, _ string) (mcp.Caller, error) {
+		dialed = true
+		return nil, errors.New("must not dial an unreferenced server")
+	}, nil, nil)
+	t.Cleanup(pool.Close)
+
+	out := mcp.StaticToolsForRun(context.Background(), pool,
+		staticServers("search"), map[string]bool{"search": true},
+		"", map[string]bool{}, time.Second, nil) // not referenced by the run
+	if len(out) != 0 || dialed {
+		t.Errorf("unreferenced skipped server must not be dialed (tools=%d dialed=%v)", len(out), dialed)
+	}
+}
+
+// TestStaticToolsForRun_CacheFastPath — once the first run re-probes + warms the
+// pool cache, a second run advertises from cache with NO fresh handshake.
+func TestStaticToolsForRun_CacheFastPath(t *testing.T) {
+	var builds int32
+	build := func(_, _ string) (mcp.Caller, error) {
+		atomic.AddInt32(&builds, 1)
+		c, err := stdio.Spawn(stdio.Config{Command: os.Args[0], Env: []string{"BE_MCP_SERVER=ok"}})
+		if err != nil {
+			return nil, err
+		}
+		return c, nil
+	}
+	teardown := func(c mcp.Caller) {
+		if cl, ok := c.(*stdio.Client); ok {
+			_ = cl.Close()
+		}
+	}
+	pool := mcp.NewPool(build, teardown, nil)
+	t.Cleanup(pool.Close)
+
+	probe := func() []tools.Tool {
+		return mcp.StaticToolsForRun(context.Background(), pool,
+			staticServers("search"), map[string]bool{"search": true},
+			"", map[string]bool{"search": true}, 5*time.Second, nil)
+	}
+	if out := probe(); len(out) != 1 {
+		t.Fatalf("first run: want 1 tool, got %d", len(out))
+	}
+	if out := probe(); len(out) != 1 {
+		t.Fatalf("second run: want 1 tool from cache, got %d", len(out))
+	}
+	if n := atomic.LoadInt32(&builds); n != 1 {
+		t.Errorf("want exactly 1 handshake across two runs (cache fast path), got %d", n)
+	}
+}
+
+// TestStaticToolsForRun_DialsRunTenant — the enumerator runs before RunIdentity is
+// on ctx, so the handshake must stamp the EXPLICIT run tenant onto the pool ctx
+// (else pool.Get dials the shared "" slot). Mirrors the dynamic-path guard.
+func TestStaticToolsForRun_DialsRunTenant(t *testing.T) {
+	var gotTenant string
+	pool := mcp.NewPool(
+		func(tenant, _ string) (mcp.Caller, error) {
+			gotTenant = tenant
+			return nil, errors.New("stop after recording tenant")
+		},
+		nil,
+		func(ctx context.Context) string { return tools.RunIdentity(ctx).TenantID },
+	)
+	t.Cleanup(pool.Close)
+
+	// ctx has NO RunIdentity (run-creation time); the explicit tenant must win.
+	mcp.StaticToolsForRun(context.Background(), pool,
+		staticServers("search"), map[string]bool{"search": true},
+		"acme", map[string]bool{"search": true}, time.Second, nil)
+	if gotTenant != "acme" {
+		t.Errorf("handshake dialed tenant %q, want %q (tenant stamp missing)", gotTenant, "acme")
+	}
+}
+
+// TestStaticToolsForRun_HandshakeFailsGracefully — a referenced skipped peer that's
+// still down advertises nothing and never panics (the lazy resolver backstops the
+// actual call).
+func TestStaticToolsForRun_HandshakeFailsGracefully(t *testing.T) {
+	pool := mcp.NewPool(func(_, _ string) (mcp.Caller, error) {
+		return nil, errors.New("peer still down")
+	}, nil, nil)
+	t.Cleanup(pool.Close)
+
+	out := mcp.StaticToolsForRun(context.Background(), pool,
+		staticServers("down"), map[string]bool{"down": true},
+		"", map[string]bool{"down": true}, time.Second, nil)
+	if len(out) != 0 {
+		t.Fatalf("want 0 tools when the peer is down, got %d", len(out))
+	}
+}
+
+// TestStaticToolsForRun_AppliesOperatorFilter — the per-server tools allowlist is
+// honored exactly as the boot loop does, so a re-probe can't widen past the
+// operator's narrowing.
+func TestStaticToolsForRun_AppliesOperatorFilter(t *testing.T) {
+	pool := newPoolWithFake(t, "ok") // exposes web_search
+	servers := map[string]config.MCPServer{
+		"search": {Transport: "stdio", Tools: []string{"not_web_search"}}, // excludes web_search
+	}
+	out := mcp.StaticToolsForRun(context.Background(), pool,
+		servers, map[string]bool{"search": true},
+		"", map[string]bool{"search": true}, 5*time.Second, nil)
+	if len(out) != 0 {
+		t.Errorf("operator tools filter must drop web_search on re-probe; got %d tools", len(out))
+	}
+}
+
+// TestStaticToolsForRun_NoSkipsIsNoop — the common case (nothing skipped at boot)
+// short-circuits: no work, no allocation, nil result.
+func TestStaticToolsForRun_NoSkipsIsNoop(t *testing.T) {
+	if out := mcp.StaticToolsForRun(context.Background(), nil, nil, nil, "", nil, time.Second, nil); out != nil {
+		t.Errorf("empty skipped set + nil pool must be a no-op; got %v", out)
+	}
+}


### PR DESCRIPTION
## The bug

A static (`mcp_servers:` yaml) server's tools reach the tool catalog **only** via the boot handshake loop (`cmd/loomcycle/main.go`). If the peer is unreachable during loomcycle's 30-second boot window, it's logged `mcp[<name>]: skipped` and its tools **never register** — invisible to every run until a loomcycle **restart**.

The lazy resolver (`internal/tools/mcp/lazy.go`) does **not** close this. Its own docstring is explicit: it *"does not mutate s.tools… Tools that need to be ADVERTISED in the spec list to a fresh model would still need boot-time registration."* It recovers an actual tool **call**, but a fresh model can't emit a `tool_use` for a tool that isn't in its advertised spec — so an agent whose only access is that server never enters tool-calling mode and the lazy path never fires. **Deadlock.**

**Reported symptom:** the builder sidecar started *after* loomcycle, so the `dev/sandbox` agent's `mcp__sandbox__*` tools were absent from `Context op=tools` (only `Context` / `Interruption` / `Skill` showed) and uncallable.

## The asymmetry it fixes

**Dynamic** (substrate) MCP servers *and* A2A peers already get a bounded **run-start re-probe** (F33: `SetDynamicToolEnumerator` → `DynamicToolsForRun`). **Static yaml servers had none** — one boot shot, then invisible until restart. This adds the missing static sibling.

## The change

- The boot loop records the set of static servers that failed the handshake (`skippedStaticMCP`; in `loomcycle mcp` mode, where eager init is skipped, it's *every* static server). Read-only after boot.
- New **`mcp.StaticToolsForRun`** (`enumerate.go`): for each skipped server **this run references** (`wantServers`, from the agent's declared tools) — advertise from the pool cache when warm, else **one bounded handshake** under the run's tenant; on success advertise + leave the entry warm, on failure drop it (the lazy resolver still backstops). A server the run doesn't reference is never dialed, so one down peer can't slow every run. The operator's per-server `tools:` filter is applied exactly as boot does.
- Wired into the enumerator alongside the dynamic + A2A enumeration.

**Net:** a sidecar / MCP peer that comes up *after* loomcycle **self-heals on the next run that references it — no restart.** Healthy boot-registered servers are never re-dialed (gated to the skipped set); no duplication with the boot catalog (collapsed by `filterTools` anyway).

**Scope note:** re-probe eligibility uses the same `wantServers` derivation as F33 — it keys off explicit `mcp__<server>__*` patterns, so a wildcard-`*`-tools agent doesn't trigger it (parity with the existing dynamic path, not a regression).

## Tested

8 new unit tests (`internal/tools/mcp/static_test.go`):
- recovers a skipped + referenced server (the core regression)
- ignores boot-registered servers (no re-dial)
- skips unreferenced servers (no dial)
- cache fast-path — exactly one handshake across two runs
- dials the explicit run tenant (pre-RunIdentity)
- fails gracefully when the peer is still down
- applies the operator tools filter (can't widen past the narrowing)
- no-op on an empty skipped set

`go test ./...` clean; gofmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)