### PR TITLE
docs(agents): add CUSTOMIZING_AGENTS.md — adding skills, tools, MCP servers (RFC BJ Phase 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,7 @@ Repo-side docs (this directory):
 
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md). Request flow, provider abstraction, agent loop, sub-agents, skills, storage, concurrency, cancellation.
 - [`docs/TOOLS.md`](docs/TOOLS.md). Two-layer default-deny model, every built-in tool, MCP / LocalAPI integrations, per-request narrowing.
+- [`docs/CUSTOMIZING_AGENTS.md`](docs/CUSTOMIZING_AGENTS.md). Adding a skill, tool, or whole MCP server to a chat agent: the capability model (who may widen a tool ceiling and why), when a skill is free vs when you must derive a new agent, `mcp__<server>__*` grants, in-place widening of dynamic agents, and delegation.
 - [`docs/PATH.md`](docs/PATH.md). The Path primitive (RFC AL): a Unix-like VFS over Memory / Volumes / Documents — the dirent model, the six ops, and the off-run cross-transport surface (HTTP / gRPC / MCP / TS / Python).
 - [`docs/DOCUMENTS.md`](docs/DOCUMENTS.md). The Document primitive (RFC AK): chunked-graph documents — content/structure split, the 13 ops, optimistic concurrency, atomic deletes, and the off-run cross-transport surface.
 - [`docs/MCP_INTEGRATION.md`](docs/MCP_INTEGRATION.md). End-to-end MCP HTTP pipeline: request lifecycle, `${run.user_bearer}` substitution, model-visibility boundary, recipe for wrapping a REST API as an MCP server consumable by loomcycle.

--- a/docs/CUSTOMIZING_AGENTS.md
+++ b/docs/CUSTOMIZING_AGENTS.md
@@ -1,0 +1,93 @@
+# Customizing agents — adding skills, tools, and MCP servers
+
+You start from a bundled agent (say `chat/medium`) and want to teach it something new: a skill, a tool, a whole MCP server. loomcycle is deliberately strict about *who* may widen an agent's tools — so a compromised or prompt-injected agent can't escalate its own privileges — which makes the *how* non-obvious. This guide is the correct algorithm.
+
+The short version: **adding a skill that uses tools the agent already has is free; adding a new tool is an operator action (create a new agent with the wider tool list); and you never let an in-run agent widen its own tools.**
+
+## The capability model in one minute
+
+- **An agent's tool ceiling is its `tools:` list.** That is the hard boundary — an agent can only ever call tools in its own `tools:`, enforced by the dispatcher (see [`docs/TOOLS.md`](TOOLS.md), the two-layer default-deny model).
+- **Skills can't widen tools.** A skill is *instructions*; when it loads, its declared `tools:` must be a subset of the agent's `tools:`. A skill can never grant a tool the agent doesn't already hold.
+- **Sub-agents can have different tools.** The sanctioned way to *compose* a bigger capability without widening a chat agent is to delegate to a purpose-built sub-agent (each is operator-vetted). This is exactly how the `chat/*` agents reach the code sandbox — they hold the `Agent` tool and delegate to `dev/sandbox`, which holds the sandbox tools.
+- **Only an operator may widen a ceiling.** Widening `tools:` is a human/operator action — the Web UI console or the API, over an admin/operator bearer. An **in-run LLM can never widen its own (or a child's) tools**: `fork`/`create` invoked from inside a run are subset-checked against the caller's own tools, so a prompt injection can't escalate. The operator bearer is the exemption (the bearer *is* the boundary).
+
+## Which case are you in?
+
+1. **A skill that uses only tools the agent already has** → create a SkillDef. No fork, same conversation. See [Case 1](#case-1--add-a-skill).
+2. **A new tool, or a skill/MCP tool the agent doesn't have** → the tool ceiling must widen → create a new agent with the extended `tools:`. See [Case 2](#case-2--add-a-new-tool-or-mcp-server).
+
+## Case 1 — Add a skill
+
+A chat agent that ships with the `Skill` tool and no `skills:` restriction (like `chat/medium`) has an **allow-all** skill policy: it can discover and load *any* skill on demand, as long as that skill's `tools:` are a subset of the agent's tools.
+
+So adding a skill is just authoring one:
+
+- **Web UI:** Library → Skills → Create. Give it a `/`-grouped name (e.g. `research/summarize`), a body (the instructions), and the `tools:` it needs (must be ⊆ the agent's tools).
+- **Or the `SkillDef` tool** (`op=create`) from an agent whose `skills:` allowlist permits the name.
+
+The agent picks it up on its **next turn** — same conversation, no fork, no restart. If the skill declares a tool the agent lacks, loading it is refused (an `is_error` result) — that means you're actually in Case 2.
+
+> Skills are on-demand: the body is loaded via the `Skill` tool at run time, not baked into the prompt. See the `skills:` pattern-allowlist model in [`docs/TOOLS.md`](TOOLS.md) and [`docs/CONFIGURATION.md`](CONFIGURATION.md).
+
+## Case 2 — Add a new tool (or MCP server)
+
+The tool ceiling can only be widened by an operator, and a **static (bundled) agent cannot be widened in place**. So the pattern is **create a new agent with the wider ceiling**:
+
+1. **Create a new agent** with a new name (e.g. `chat/mine`), seeded from the bundled one's configuration, and add the tool(s) you want to its `tools:`.
+   - **Web UI:** Library → Agents → Create. Set the name, system prompt, tier, and the `tools:` list including the new tool. Over an admin/operator bearer this is unbounded — the bearer is the authority.
+   - **Or the `AgentDef` tool** `op=create` under a new name with the extended `tools:` list, over an operator bearer.
+2. **Talk to the new agent.**
+
+**Why not `fork`?** `fork` may only *narrow* tools — its ceiling is the lineage root — by design, so a fork can't escalate. And `create` refuses a name that matches a bundled/static agent, so a clone must take a new name.
+
+**Why not edit `chat/medium` directly?** It's a static bundled agent (ground truth in the config); it's immutable at runtime. Derive your own agent from it instead.
+
+> ⚠️ **Conversation history does not carry over.** A conversation is bound to its agent (the agent is a column on the session). The chat you had with `chat/medium` does **not** continue under `chat/mine` — the new agent starts fresh. (Carrying a conversation into a derived agent is a planned convenience — see [Planned improvements](#planned-improvements).)
+
+### Adding a whole MCP server
+
+To give an agent every tool of an MCP server:
+
+1. **Declare the server** (once):
+   - **Static:** add it to `mcp_servers:` in your config — see [`docs/MCP_INTEGRATION.md`](MCP_INTEGRATION.md).
+   - **Runtime:** the `MCPServerDef` tool (`op=create`) or Web UI → Library → MCP.
+2. **Grant its tools** in the (new) agent's `tools:`. You can name individual tools by their full name `mcp__<server>__<tool>`, or grant the **whole server with one prefix-glob entry**:
+
+   ```yaml
+   tools: [Read, Write, WebSearch, "mcp__slack__*"]   # all tools of the "slack" server
+   ```
+
+   Prefix globs (`mcp__<server>__*`) are matched at the agent-exposure layer (see [`docs/TOOLS.md`](TOOLS.md) → *Glob support*), so tools later added to that server are covered without editing the agent again.
+
+Because that adds a new tool to the ceiling, use the Case 2 flow (create a new agent) to introduce it.
+
+## Widening a *dynamic* agent in place
+
+If the agent you want to widen is already a **dynamic** agent — one you created, not a bundled static one — an operator can widen it **in place** instead of making yet another name: re-run `create` under the **same name** with the extended `tools:` (over the operator bearer). It becomes a new active version of that name, and any ongoing conversation picks up the wider tools on its **next turn** — same identity, no lost history.
+
+This is why the recommended pattern is: **derive your own dynamic agent from the bundled one once** (Case 2), then widen *that* in place whenever you need more — you only pay the "new identity / fresh conversation" cost a single time.
+
+## Prefer delegation when you can
+
+Widening a chat agent's own ceiling gives it — and anything that can prompt it — direct access to the new tool. When the new capability is a self-contained task (run code, hit a specific API, drive a browser), the safer composition is a **dedicated sub-agent**: give the sub-agent the powerful tools, keep your chat agent's ceiling narrow, and let it **delegate** via the `Agent` tool. The chat agent orchestrates; the sub-agent is the only thing holding the sharp tools, and it was vetted by you. (This is the model the `dev/sandbox` agent uses for code execution.)
+
+## Security — why it works this way
+
+- **The tool ceiling is a trust boundary.** An in-run LLM can never grant itself or a child a tool beyond its own set, so a prompt injection can't escalate. `fork`/`create` from inside a run are subset-checked; only the operator bearer is unbounded.
+- **Skills are authority-limited** to the agent's tools — they add instructions, not capabilities.
+- **Delegation** to an operator-vetted sub-agent is the safe way to compose a larger capability.
+
+## Planned improvements
+
+These manual steps are being made smoother:
+
+- A one-click **Clone** action in the Library (derive a new agent from an existing one with tools pre-filled and editable).
+- Wildcard MCP grants understood by the **fork/create ceiling check**, not just the exposure layer (so derived agents and meta-agents can carry a `mcp__<server>__*` grant).
+- **Carrying a conversation** into a derived agent (optionally compacted), so widening a capability no longer means starting the chat over.
+
+## See also
+
+- [`docs/TOOLS.md`](TOOLS.md) — the two-layer default-deny model, every built-in tool, glob support, per-request narrowing.
+- [`docs/CONFIGURATION.md`](CONFIGURATION.md) — agent frontmatter fields, tiers, the `skills:` allowlist.
+- [`docs/MCP_INTEGRATION.md`](MCP_INTEGRATION.md) — declaring and consuming MCP servers.
+- [`docs/HISTORY.md`](HISTORY.md) — browsing and resuming past chats (a chat = a session).

--- a/docs/CUSTOMIZING_AGENTS.md
+++ b/docs/CUSTOMIZING_AGENTS.md
@@ -87,6 +87,7 @@ These manual steps are being made smoother:
 
 ## See also
 
+- **Agents themselves** can read the model-facing version of this algorithm at run time via `Context op=help topic=adding-capabilities` (why you can't widen your own tools; load a skill within your ceiling, delegate to a sub-agent, or ask the operator).
 - [`docs/TOOLS.md`](TOOLS.md) — the two-layer default-deny model, every built-in tool, glob support, per-request narrowing.
 - [`docs/CONFIGURATION.md`](CONFIGURATION.md) — agent frontmatter fields, tiers, the `skills:` allowlist.
 - [`docs/MCP_INTEGRATION.md`](MCP_INTEGRATION.md) — declaring and consuming MCP servers.

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -137,6 +137,8 @@ This is a feature, not a bug. New agents start with no privileges; you grant the
 
 Entries ending in `*` match by prefix. The canonical use is exposing all tools from one MCP server: `"mcp__brave-search__*"`. Built-in names are short and unambiguous so globs aren't usually needed for them, but the same machinery applies.
 
+> Adding a new skill, tool, or MCP server to an existing agent (and the rules on *who* may widen a tool ceiling) is covered end-to-end in [`docs/CUSTOMIZING_AGENTS.md`](CUSTOMIZING_AGENTS.md).
+
 ### Caller-side narrowing
 
 The HTTP request can carry `tools` in the body to further narrow the agent's set on a single run:

--- a/internal/help/builtin/adding-capabilities.md
+++ b/internal/help/builtin/adding-capabilities.md
@@ -1,0 +1,76 @@
+---
+name: adding-capabilities
+description: "How to gain a capability you don't have — you can't widen your own tools; load a skill within your ceiling, delegate to a sub-agent that holds the tool, or ask the operator to widen you."
+aliases: [tool-ceiling, widening-tools]
+---
+Your tools are **fixed for this run**. You can only call the tools in
+your own tool set, and you **cannot widen it yourself** — not with a
+skill, not by authoring or forking an agent. This is a security
+boundary: if an agent could grant itself new tools, a single injected
+instruction would become privilege escalation. So when you need a
+capability you don't have, use one of the paths below — do not try to
+work around a missing tool.
+
+## Decision tree
+
+**1. You need a skill (instructions), and it only uses tools you
+already have.** This is free. Use the `Skill` tool: `op=list` to
+discover what's available, `op=invoke` to load a skill's body as a
+`tool_result` at the moment it's relevant. If you also hold `SkillDef`
+and your `skills:` allowlist permits the name, you can author one —
+but the skill's declared `tools:` must be a **subset of yours**.
+Loading a skill that needs a tool you lack is refused. See
+`Context op=help topic=skills`.
+
+**2. You need a TOOL you don't have.** You can't give it to yourself.
+Two real paths:
+
+- **Delegate to a sub-agent that has it.** If you hold the `Agent`
+  tool, spawn a purpose-built sub-agent that holds the tool and let it
+  do the work — a sub-agent may hold tools you don't (it was vetted by
+  the operator, not minted by you). This is the sanctioned way to
+  compose a capability beyond your ceiling: e.g. spawn a code/sandbox
+  agent to compile and run code, or an agent that holds a specific MCP
+  tool to make that call. Prefer this whenever the missing capability
+  is a self-contained task. See `Context op=help topic=subagents`.
+- **Ask the human operator to widen you.** Adding a tool to your own
+  set is an operator action (they derive an agent that carries the
+  extra tool). You can't do it; if the task genuinely needs it and
+  delegation doesn't fit, surface the need — use the `Interruption`
+  tool to ask — rather than silently failing or faking the result.
+
+**3. Report honestly when you're blocked.** If you lack a tool, can't
+delegate (no `Agent` tool or no suitable sub-agent), and can't ask,
+say so plainly. Never pretend a tool ran or fabricate its output.
+
+## If you author agents (meta-agents)
+
+If you hold `AgentDef` (and a non-empty `agent_def_scopes`), you can
+create and fork agents — but **you still can't escalate**:
+
+- `create` — a new agent's `tools:` can never exceed **your own**
+  tools. You cannot mint a child more capable than yourself.
+- `fork` — may only **narrow** an existing agent's tools; the lineage
+  root is a permanent ceiling. A fork can never add a tool the root
+  lacks.
+
+So to give any agent a tool that no existing agent (in your reach)
+already holds, a **human operator** must introduce it. What you *can*
+do is compose and specialise within the tools already available to
+you.
+
+## Granting a whole MCP server
+
+When a `tools:` list should include every tool of one MCP server, a
+single prefix-glob entry covers it: `mcp__<server>__*` (e.g.
+`mcp__slack__*`). It matches all of that server's advertised tools, so
+tools later added to the server are covered automatically. (This is
+still subject to the ceiling rules above — it's a convenience for
+listing, not a way to widen past what you may already grant.)
+
+## See also
+
+- `Context op=help topic=skills` — the on-demand skill model.
+- `Context op=help topic=subagents` — spawning vs channel handoff.
+- `Context op=help topic=scopes` — what your grants are scoped to.
+- `Context op=self` — inspect your own tools, model, and sandbox right now.

--- a/internal/help/builtin/skills.md
+++ b/internal/help/builtin/skills.md
@@ -69,7 +69,9 @@ A skill declares its own `tools:` — the tool ceiling for work done
 under it. That set must be a **subset** of your effective `tools`.
 A skill can narrow, never widen. If a skill needs a tool you don't
 hold, the invoke is refused (surfaced as `is_error`) — request the
-tool from the operator, or use a different skill.
+tool from the operator, or use a different skill. When you need a
+capability beyond your tools, see `Context op=help topic=adding-capabilities`
+(delegate to a sub-agent, or ask the operator to widen you).
 
 ## The run-start note
 

--- a/internal/help/loader_test.go
+++ b/internal/help/loader_test.go
@@ -23,6 +23,7 @@ func TestLoadSet_BundledOnly(t *testing.T) {
 	// in alphabetical order for diff readability.
 	want := []string{
 		"a2a-integration",
+		"adding-capabilities",
 		"agent-teams",
 		"bashbox",
 		"channel-admin",


### PR DESCRIPTION
**RFC BJ Phase 1** ([`/loomcycle/rfcs/personalize-chat-agents`](https://github.com/denn-gubsky/loomcycle)) — document the correct, already-working algorithm for extending a chat agent, so users stop hitting the "fork won't widen / where do I click?" wall. **Docs only.**

## What it documents

`docs/CUSTOMIZING_AGENTS.md`:

- **The capability model** — the tool ceiling is the agent's `tools:`; skills can't widen it; sub-agents can differ; **only an operator (bearer) may widen — an in-run LLM never can** (the anti-escalation invariant).
- **Case 1 — a skill within the existing ceiling is free:** create a SkillDef; a chat agent with the allow-all skills policy picks it up on the next turn — no fork, same conversation.
- **Case 2 — a new tool / MCP server** needs an operator to create a **new** agent with the wider `tools:` (fork only narrows; `create` refuses static bundled names).
- **Granting a whole MCP server today** via the `mcp__<server>__*` prefix glob — already matched at the agent-exposure layer (`internal/tools/policy/policy.go:48`).
- **Widening a *dynamic* agent in place** (re-create under the same name) — same identity, no lost history — and the "derive once, then widen in place" recommendation.
- The **delegation** pattern (keep the chat ceiling narrow; a vetted sub-agent holds the sharp tools), the **conversation-history caveat**, and a short *planned improvements* note (Clone action, wildcard ceiling checks, conversation carry-over — Phases 2–4).

Linked from the README docs list and cross-referenced from `docs/TOOLS.md`.

## Note discovered while writing

`mcp__<server>__*` globs **already work at the exposure layer** (`policy.Apply`), so an operator can grant a whole MCP server today. That shrinks Phase 3's real scope to just the fork/create **ceiling** subset check (`assertToolsSubset`) — I'll update the RFC's Phase 3 accordingly.

## Tested

Docs only — no code/wire/schema change. Verified all cross-linked docs exist (`TOOLS.md`, `CONFIGURATION.md`, `MCP_INTEGRATION.md`, `HISTORY.md`) and the claims against the code (`agentdef.go` ceiling checks, `policy.go` globs, `addSkillToolDefaults` allow-all default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)