### PR TITLE
feat(chat): grant SkillDef to all chat/* agents (self-service skill authoring)

### DIFF
--- a/bundles/chat/loomcycle.yaml
+++ b/bundles/chat/loomcycle.yaml
@@ -31,7 +31,7 @@ agents:
     # (Anthropic defaults to 8192; ollama generates until the context fills).
     # Pinning a value would only IMPOSE a per-reply cap, not add headroom.
     unbounded_iterations: true              # interactive chat parks at end_turn
-    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, HTTP, Bashbox, Bash, Document, Memory, Path, Skill, Agent, Interruption]
+    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, HTTP, Bashbox, Bash, Document, Memory, Path, Skill, SkillDef, Agent, Interruption]
     memory_scopes: [user]
     sql_scopes: [user]                      # Document is SQL-Memory-backed
     sampling:
@@ -71,7 +71,7 @@ agents:
     # max_tokens OMITTED — ollama-local generates until the context window fills
     # (set the window via LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX, e.g. 131072 for 128K).
     unbounded_iterations: true
-    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, HTTP, Bashbox, Bash, Document, Memory, Path, Skill, Agent, Interruption]
+    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, HTTP, Bashbox, Bash, Document, Memory, Path, Skill, SkillDef, Agent, Interruption]
     memory_scopes: [user]
     sql_scopes: [user]
     sampling:
@@ -106,7 +106,7 @@ agents:
     # max_tokens OMITTED — ollama-local generates until the context window fills
     # (set the window via LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX, e.g. 131072 for 128K).
     unbounded_iterations: true
-    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, HTTP, Bashbox, Bash, Document, Memory, Path, Skill, Agent, Interruption]
+    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, HTTP, Bashbox, Bash, Document, Memory, Path, Skill, SkillDef, Agent, Interruption]
     memory_scopes: [user]
     sql_scopes: [user]
     sampling:

--- a/cmd/loomcycle/embedded/bundles/chat.yaml
+++ b/cmd/loomcycle/embedded/bundles/chat.yaml
@@ -31,7 +31,7 @@ agents:
     # (Anthropic defaults to 8192; ollama generates until the context fills).
     # Pinning a value would only IMPOSE a per-reply cap, not add headroom.
     unbounded_iterations: true              # interactive chat parks at end_turn
-    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, HTTP, Bashbox, Bash, Document, Memory, Path, Skill, Agent, Interruption]
+    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, HTTP, Bashbox, Bash, Document, Memory, Path, Skill, SkillDef, Agent, Interruption]
     memory_scopes: [user]
     sql_scopes: [user]                      # Document is SQL-Memory-backed
     sampling:
@@ -71,7 +71,7 @@ agents:
     # max_tokens OMITTED — ollama-local generates until the context window fills
     # (set the window via LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX, e.g. 131072 for 128K).
     unbounded_iterations: true
-    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, HTTP, Bashbox, Bash, Document, Memory, Path, Skill, Agent, Interruption]
+    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, HTTP, Bashbox, Bash, Document, Memory, Path, Skill, SkillDef, Agent, Interruption]
     memory_scopes: [user]
     sql_scopes: [user]
     sampling:
@@ -106,7 +106,7 @@ agents:
     # max_tokens OMITTED — ollama-local generates until the context window fills
     # (set the window via LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX, e.g. 131072 for 128K).
     unbounded_iterations: true
-    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, HTTP, Bashbox, Bash, Document, Memory, Path, Skill, Agent, Interruption]
+    tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, HTTP, Bashbox, Bash, Document, Memory, Path, Skill, SkillDef, Agent, Interruption]
     memory_scopes: [user]
     sql_scopes: [user]
     sampling:

--- a/cmd/loomcycle/embedded/presets_test.go
+++ b/cmd/loomcycle/embedded/presets_test.go
@@ -154,9 +154,13 @@ func TestBundle_TeamAndChatToolGrants(t *testing.T) {
 		}
 	}
 	chat := grantsFor(t, "chat")
-	for _, agent := range []string{"chat/medium", "chat/local"} {
-		if !has(chat[agent], "Interruption") {
-			t.Errorf("chat %s must grant Interruption (got %v)", agent, chat[agent])
+	for _, agent := range []string{"chat/medium", "chat/local", "chat/local-small"} {
+		// SkillDef lets a chat agent author a reusable skill mid-conversation
+		// (self-service Case 1); Skill loads them; both must be granted.
+		for _, tool := range []string{"Skill", "SkillDef", "Interruption"} {
+			if !has(chat[agent], tool) {
+				t.Errorf("chat %s must grant %q (got %v)", agent, tool, chat[agent])
+			}
 		}
 	}
 }


### PR DESCRIPTION
The `chat/*` agents already hold `Skill` (load skills on demand) but not `SkillDef` (author them). This grants `SkillDef` so a chat agent can **save a procedure as a reusable skill mid-conversation** — the self-service path for extending an agent *within its existing tool ceiling*.

**Safe by construction:** a skill's declared `tools:` must stay a subset of the agent's (enforced at SkillDef create + Skill invoke), so this can't widen the ceiling or escalate. It only lets the agent author instructions it could already run.

## Changes
- `chat/medium`, `chat/local`, `chat/local-small` — add `SkillDef` to `tools:` (both bundle copies kept byte-identical per the two-copy rule).
- **No prompt change** — the existing Tools sections don't enumerate `Skill` either; agents discover `SkillDef` via `Context op=tools` + the tool's description (and the `adding-capabilities` help topic once #758 lands).
- Extended `TestBundle_TeamAndChatToolGrants` to assert `Skill` + `SkillDef` + `Interruption` on all three chat agents.

## Tested
`TestBundle_TeamAndChatToolGrants` + `TestEmbedded_DefaultStackValidates` pass; `go build ./...` clean.

Part of the RFC BJ self-service line (companion to the Clone UI). Independent of #758.

🤖 Generated with [Claude Code](https://claude.com/claude-code)