### PR TITLE
feat(library): Clone action for agents — create-from-template that may widen tools (RFC BJ Phase 2)

### DIFF
--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loomcycle/library",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "description": "Embeddable React Library component for the loomcycle agentic runtime — the Agents / Skills / MCP-Servers substrate browser (lineage, create/fork/promote/retire, Claude Code import) as a standalone, themeable package.",
   "license": "Apache-2.0",

--- a/packages/library/src/Library.tsx
+++ b/packages/library/src/Library.tsx
@@ -43,6 +43,7 @@ const DEFAULT_TABS: LibraryTab[] = ["agents", "skills", "mcp"];
 export interface LibraryActionCapabilities {
   create?: boolean;
   fork?: boolean;
+  clone?: boolean;
   promote?: boolean;
   retire?: boolean;
   import?: boolean;
@@ -216,6 +217,9 @@ function LibraryBody({
   // version, so it's gated behind the fork capability.
   const canCreate = actions?.create !== false;
   const canFork = actions?.fork !== false;
+  // Clone is a create-from-template (may widen tools); gate it on create, since
+  // that's the substrate op it uses.
+  const canClone = actions?.clone !== false && canCreate;
   const canPromote = actions?.promote !== false;
   const canRetire = actions?.retire !== false;
   const canImport = actions?.import !== false;
@@ -263,6 +267,10 @@ function LibraryBody({
   const handleCreate = () => setModal({ kind: tabKind, mode: "create" });
   const handleEdit = (row: DefRow) =>
     setModal({ kind: tabKind, mode: "fork", forkSource: row });
+  // Clone seeds a create modal from the row's full definition (name suggested +
+  // editable, tools editable/widenable). Distinct from fork, which can't widen.
+  const handleClone = (row: DefRow) =>
+    setModal({ kind: tabKind, mode: "clone", forkSource: row });
 
   // After an import, "Use with a local LLM" opens the agent-create modal
   // prefilled with the imported skills + mcp tools on a local model. A synthetic
@@ -365,6 +373,7 @@ function LibraryBody({
             renderDefinition={renderAgentDefinition}
             onCreateNew={canCreate ? handleCreate : undefined}
             onEditRow={canFork ? handleEdit : undefined}
+            onCloneRow={canClone ? handleClone : undefined}
             onRetireRow={canRetire ? handleRetire : undefined}
             onPromoteRow={canPromote ? handlePromote : undefined}
             onError={onError}

--- a/packages/library/src/components/LibraryEditModal.tsx
+++ b/packages/library/src/components/LibraryEditModal.tsx
@@ -39,7 +39,10 @@ import { useLibraryData } from "../lib/dataLayer";
 // .library-modal-* extensions for the wider layout.
 
 export type ModalKind = "agent" | "skill" | "mcp-server";
-export type ModalMode = "create" | "fork";
+// "clone" seeds a CREATE from an existing def (all fields pre-filled, name
+// suggested + editable). Unlike "fork" it may WIDEN tools — it's a brand-new
+// agent over the operator bearer, not a lineage version. Submit path = create.
+export type ModalMode = "create" | "fork" | "clone";
 
 export interface LibraryEditModalProps {
   kind: ModalKind;
@@ -94,14 +97,19 @@ export default function LibraryEditModal({
   const [submitErr, setSubmitErr] = useState<string | null>(null);
 
   // --- Common fields across all flavors
-  const [name, setName] = useState(forkSource?.name ?? "");
+  // Clone suggests a distinct new name (the source can't be recreated under its
+  // own name — a static name is refused and a dynamic one would re-version in
+  // place) but leaves it editable; create/fork keep the source name as-is.
+  const [name, setName] = useState(
+    mode === "clone" ? suggestCloneName(forkSource?.name) : (forkSource?.name ?? ""),
+  );
   const [description, setDescription] = useState<string>(
     pickString(forkSource?.definition, "description"),
   );
   // Promote default: ON for create (operator created it, they want it
   // active), OFF for fork (review the new version before activating).
   // Matches substrate tool defaults.
-  const [promote, setPromote] = useState(mode === "create");
+  const [promote, setPromote] = useState(mode === "create" || mode === "clone");
 
   // --- Agent-flavor structured fields (v0.11.6 — every editable
   // overlay field has its own input; no JSON catch-all).
@@ -257,7 +265,8 @@ export default function LibraryEditModal({
       : entries.map(([key, value]) => ({ key, value }));
   });
 
-  const titlePrefix = mode === "create" ? "Create" : "Edit (fork)";
+  const titlePrefix =
+    mode === "create" ? "Create" : mode === "clone" ? "Clone" : "Edit (fork)";
   const titleLabel =
     kind === "agent"
       ? "agent"
@@ -285,7 +294,7 @@ export default function LibraryEditModal({
 
   const validateLocal = (): string | null => {
     if (!name.trim()) return "Name is required.";
-    if (mode === "create" && existingNames) {
+    if ((mode === "create" || mode === "clone") && existingNames) {
       const hit = existingNames.find((e) => e.name === name.trim());
       // A name is reclaimable when it has NO live active version and isn't
       // static — every version retired (the active pointer was cleared on
@@ -530,7 +539,10 @@ export default function LibraryEditModal({
       const substrateKind = kindToSubstrate(kind);
       const overlay = { ...buildOverlay(), ...advancedOv };
       let row: DefRow;
-      if (mode === "create") {
+      if (mode === "create" || mode === "clone") {
+        // Clone is a create under a new name — the operator bearer path, so it
+        // may carry a wider `tools:` than the source (fork can't). The substrate
+        // still bounds it by the caller's own tools.
         row = await data.createDef(substrateKind, name.trim(), overlay, promote);
       } else {
         // Pass the active def_id as parent_def_id so the fork hangs
@@ -585,7 +597,7 @@ export default function LibraryEditModal({
             onChange={(e) => setName(e.target.value)}
             disabled={mode === "fork" || submitting}
             placeholder="my-agent"
-            autoFocus={mode === "create"}
+            autoFocus={mode === "create" || mode === "clone"}
           />
         </div>
 
@@ -726,7 +738,9 @@ export default function LibraryEditModal({
               ? "Saving…"
               : mode === "create"
                 ? "Create"
-                : "Save fork"}
+                : mode === "clone"
+                  ? "Clone"
+                  : "Save fork"}
           </button>
         </div>
       </div>
@@ -1565,6 +1579,14 @@ function pickString(def: unknown, key: string): string {
   if (!def || typeof def !== "object") return "";
   const v = (def as Record<string, unknown>)[key];
   return typeof v === "string" ? v : "";
+}
+
+// suggestCloneName derives an editable starting name for a clone: "<src>-copy"
+// (keeping any "/"-group prefix, e.g. chat/medium -> chat/medium-copy). Empty
+// source -> empty (the user must name it).
+function suggestCloneName(src: string | undefined): string {
+  const s = (src ?? "").trim();
+  return s ? `${s}-copy` : "";
 }
 
 function pickStringArray(def: unknown, key: string): string[] {

--- a/packages/library/src/components/LineagePanel.tsx
+++ b/packages/library/src/components/LineagePanel.tsx
@@ -40,6 +40,7 @@ export interface LineagePanelProps {
   // that wants the panel read-only.
   onCreateNew?: () => void;
   onEditRow?: (row: DefRow) => void;
+  onCloneRow?: (row: DefRow) => void;
   onRetireRow?: (row: DefRow) => void;
   onPromoteRow?: (row: DefRow) => void;
   // v0.10.4 — MCP-only "Rediscover tools" button in the header.
@@ -63,6 +64,7 @@ export default function LineagePanel({
   renderDefinition,
   onCreateNew,
   onEditRow,
+  onCloneRow,
   onRetireRow,
   onPromoteRow,
   onRediscover,
@@ -346,6 +348,7 @@ export default function LineagePanel({
           onSelect={setSelectedDefID}
           renderDefinition={renderDefinition}
           onEditRow={onEditRow}
+          onCloneRow={onCloneRow}
           onRetireRow={onRetireRow}
           onPromoteRow={onPromoteRow}
         />

--- a/packages/library/src/components/LineageTree.tsx
+++ b/packages/library/src/components/LineageTree.tsx
@@ -63,6 +63,7 @@ export interface LineageTreeProps {
   // pointer for the name to this row. Buttons stopPropagation so
   // they don't toggle content / selection on click.
   onEditRow?: (row: DefRow) => void;
+  onCloneRow?: (row: DefRow) => void;
   onRetireRow?: (row: DefRow) => void;
   onPromoteRow?: (row: DefRow) => void;
 }
@@ -75,6 +76,7 @@ export default function LineageTree({
   onSelect,
   renderDefinition,
   onEditRow,
+  onCloneRow,
   onRetireRow,
   onPromoteRow,
 }: LineageTreeProps) {
@@ -143,6 +145,7 @@ export default function LineageTree({
           onSelect={onSelect}
           renderDefinition={renderDefinition}
           onEditRow={onEditRow}
+          onCloneRow={onCloneRow}
           onRetireRow={onRetireRow}
           onPromoteRow={onPromoteRow}
         />
@@ -164,6 +167,7 @@ function LineageNodeRow({
   onSelect,
   renderDefinition,
   onEditRow,
+  onCloneRow,
   onRetireRow,
   onPromoteRow,
 }: {
@@ -179,6 +183,7 @@ function LineageNodeRow({
   onSelect?: (defID: string) => void;
   renderDefinition?: (row: DefRow) => React.ReactNode;
   onEditRow?: (row: DefRow) => void;
+  onCloneRow?: (row: DefRow) => void;
   onRetireRow?: (row: DefRow) => void;
   onPromoteRow?: (row: DefRow) => void;
 }) {
@@ -265,7 +270,7 @@ function LineageNodeRow({
             {isDetailOpen ? "▾" : "▸"} content
           </span>
         )}
-        {(onEditRow || onRetireRow || onPromoteRow) && (
+        {(onEditRow || onCloneRow || onRetireRow || onPromoteRow) && (
           <span className="lineage-row-actions">
             {onEditRow && (
               <button
@@ -282,6 +287,19 @@ function LineageNodeRow({
                 }
               >
                 {row.def_id.startsWith("static:") ? "Edit (forks from yaml)" : "Edit ✎"}
+              </button>
+            )}
+            {onCloneRow && (
+              <button
+                type="button"
+                className="lineage-row-action"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onCloneRow(row);
+                }}
+                title="Clone into a NEW agent — seeds a create you can edit, including adding tools (unlike Edit/fork, which can only narrow)"
+              >
+                Clone ⧉
               </button>
             )}
             {onPromoteRow && !isActive && !row.def_id.startsWith("static:") && !row.retired && (
@@ -361,6 +379,7 @@ function LineageNodeRow({
               onSelect={onSelect}
               renderDefinition={renderDefinition}
               onEditRow={onEditRow}
+              onCloneRow={onCloneRow}
               onRetireRow={onRetireRow}
               onPromoteRow={onPromoteRow}
             />


### PR DESCRIPTION
**RFC BJ Phase 2.** Adds a per-row **Clone ⧉** action on the Library → Agents list that derives a **new** agent from an existing one — pre-filling every field (system prompt, tools, skills, sampling, tier, …) with the name suggested + editable and the **tools list editable, including adding tools**, which fork cannot do.

## Clone vs fork

| | fork (existing "Edit ✎") | clone (new) |
|---|---|---|
| Result | new version in a lineage | brand-new independent agent (new name) |
| Tools | may only **narrow** (lineage-root ceiling) | may **widen** (operator bearer path) |
| Submit op | `forkDef` | `createDef` |

This is the missing UI answer to "I want `chat/medium` plus one more tool" — clone it, add the tool, done. (The substrate still bounds a clone by the caller's own tools; over the operator/admin bearer that's unbounded, so the console can grant what it's authorized for.)

## Implementation
- **`LibraryEditModal`** — new `mode: "clone"`: submits via `createDef()`, suggests `<src>-copy` as an editable name, keeps the name field editable + focused, promote-on by default, runs the create collision check; title + button read "Clone".
- Threaded **`onCloneRow`** through `LineageTree` (the row button, after Edit) and `LineagePanel`.
- **`Library`** — a `clone?` capability (gated on `create`), `handleClone`, wired to the **Agents** panel only (matches the ask; fork stays on all tabs).
- Bumped **`@loomcycle/library` 0.1.0 → 0.2.0** (new feature; publishes on a `library-v0.2.0` tag — the web dogfoods via the source alias, so it's live in the UI regardless).

## Tested
`packages/library` typecheck + `web` typecheck clean; `web` Vite build succeeds; library `vitest` 7/7 pass.

Companion to #759 (SkillDef self-service). Independent of #758.

🤖 Generated with [Claude Code](https://claude.com/claude-code)