### PR TITLE
feat(agentdef): make the tool-ceiling check glob-aware (RFC BJ Phase 3)

### DIFF
--- a/docs/CUSTOMIZING_AGENTS.md
+++ b/docs/CUSTOMIZING_AGENTS.md
@@ -57,7 +57,7 @@ To give an agent every tool of an MCP server:
    tools: [Read, Write, WebSearch, "mcp__slack__*"]   # all tools of the "slack" server
    ```
 
-   Prefix globs (`mcp__<server>__*`) are matched at the agent-exposure layer (see [`docs/TOOLS.md`](TOOLS.md) → *Glob support*), so tools later added to that server are covered without editing the agent again.
+   Prefix globs (`mcp__<server>__*`) are matched both at the agent-exposure layer (see [`docs/TOOLS.md`](TOOLS.md) → *Glob support*) — so tools later added to that server are covered without editing the agent again — and by the fork/create **ceiling** check, so a fork or clone can carry a `mcp__<server>__*` grant (or narrow it to specific `mcp__<server>__<tool>` entries) without it reading as widening.
 
 Because that adds a new tool to the ceiling, use the Case 2 flow (create a new agent) to introduce it.
 
@@ -81,8 +81,6 @@ Widening a chat agent's own ceiling gives it — and anything that can prompt it
 
 These manual steps are being made smoother:
 
-- A one-click **Clone** action in the Library (derive a new agent from an existing one with tools pre-filled and editable).
-- Wildcard MCP grants understood by the **fork/create ceiling check**, not just the exposure layer (so derived agents and meta-agents can carry a `mcp__<server>__*` grant).
 - **Carrying a conversation** into a derived agent (optionally compacted), so widening a capability no longer means starting the chat over.
 
 ## See also

--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -752,16 +752,40 @@ func assertToolsSubset(proposed, root []string) error {
 			return nil
 		}
 	}
-	rootSet := make(map[string]bool, len(root))
-	for _, t := range root {
-		rootSet[t] = true
-	}
 	for _, t := range proposed {
-		if !rootSet[t] {
+		if !toolCoveredByRoot(t, root) {
 			return fmt.Errorf("Tools cannot widen — %q is not in the operator-blessed root %v", t, root)
 		}
 	}
 	return nil
+}
+
+// toolCoveredByRoot reports whether a single proposed tool entry is within the
+// ceiling `root`. It understands the trailing-`*` prefix glob the exposure layer
+// (internal/tools/policy) already honors, so a ceiling that grants a whole MCP
+// server via `mcp__<server>__*` covers that server's concrete tools AND the same
+// (or a narrower) wildcard:
+//
+//	root entry      covers proposed
+//	------------    ---------------------------------------------------
+//	*               anything (handled by assertToolsSubset's short-circuit)
+//	mcp__slack__*   mcp__slack__send · mcp__slack__* · mcp__slack__x* (prefix)
+//	mcp__slack__x   mcp__slack__x only (exact)
+//
+// A proposed wildcard is covered ONLY when a root entry's prefix is itself a
+// prefix of the proposed string — so a broader proposed wildcard (`mcp__*`) is
+// NOT covered by a narrower root wildcard (`mcp__slack__*`), and an exact root
+// entry never covers a broader proposed wildcard. Both would be widening.
+func toolCoveredByRoot(proposed string, root []string) bool {
+	for _, r := range root {
+		if r == proposed {
+			return true // exact match (also covers wildcard == identical wildcard)
+		}
+		if strings.HasSuffix(r, "*") && strings.HasPrefix(proposed, r[:len(r)-1]) {
+			return true // root prefix-glob covers a concrete tool or a narrower wildcard
+		}
+	}
+	return false
 }
 
 // bootstrapStatic snapshots the cfg.Agents[name] static MD into a v1

--- a/internal/tools/builtin/agentdef_test.go
+++ b/internal/tools/builtin/agentdef_test.go
@@ -472,6 +472,44 @@ func TestAgentDefTool_CreateIdempotentOnSameContent(t *testing.T) {
 	}
 }
 
+// TestAssertToolsSubset_WildcardCoverage exercises the glob-aware ceiling check:
+// an operator-blessed `mcp__<server>__*` grant covers that server's concrete
+// tools (and the same/narrower wildcard) on a fork, mirroring the exposure
+// layer's prefix-glob — but never widens (a broader proposed wildcard, or a
+// different family, is still rejected).
+func TestAssertToolsSubset_WildcardCoverage(t *testing.T) {
+	cases := []struct {
+		name     string
+		proposed []string
+		root     []string
+		wantErr  bool
+	}{
+		{"glob root covers concrete", []string{"mcp__slack__send"}, []string{"mcp__slack__*"}, false},
+		{"glob root covers identical glob", []string{"mcp__slack__*"}, []string{"mcp__slack__*"}, false},
+		{"glob root covers many concretes", []string{"mcp__slack__send", "mcp__slack__list"}, []string{"mcp__slack__*"}, false},
+		{"glob root rejects other family", []string{"mcp__other__x"}, []string{"mcp__slack__*"}, true},
+		{"exact root cannot widen to family", []string{"mcp__slack__*"}, []string{"mcp__slack__send"}, true},
+		{"broad root covers narrow glob", []string{"mcp__slack__*"}, []string{"mcp__*"}, false},
+		{"narrow root cannot cover broad glob", []string{"mcp__*"}, []string{"mcp__slack__*"}, true},
+		{"prefix boundary is precise", []string{"mcp__slack__send"}, []string{"mcp__slacker__*"}, true},
+		{"exact still works", []string{"Read"}, []string{"Read", "Write"}, false},
+		{"exact miss still rejected", []string{"Write"}, []string{"Read"}, true},
+		{"star root allows anything", []string{"mcp__x__y", "mcp__z__*"}, []string{"*"}, false},
+		{"empty proposed is ok", nil, []string{"mcp__slack__*"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := assertToolsSubset(tc.proposed, tc.root)
+			if tc.wantErr && err == nil {
+				t.Errorf("assertToolsSubset(%v, %v) = nil, want error", tc.proposed, tc.root)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("assertToolsSubset(%v, %v) = %v, want nil", tc.proposed, tc.root, err)
+			}
+		})
+	}
+}
+
 func TestAgentDefTool_ForkToolsCannotWiden(t *testing.T) {
 	tool, ctx, cleanup := agentDefFixture(t)
 	defer cleanup()


### PR DESCRIPTION
**RFC BJ Phase 3.** The agent-**exposure** layer (`internal/tools/policy`) already honors a trailing-`*` prefix glob, so an operator can grant a whole MCP server with `mcp__<server>__*` in an agent's `tools:`. But the fork/create **ceiling** check (`assertToolsSubset`, shared by AgentDef create/fork + SkillDef) did exact-match only — so a fork of an agent whose root granted `mcp__slack__*` could **not** propose `mcp__slack__send` (or even keep `mcp__slack__*`), reading a within-family *narrowing* as "widening."

## The change

`assertToolsSubset` now considers a proposed entry **covered** when a root entry:
- is `*` (unchanged short-circuit), or
- is a prefix-glob `X*` and the proposed string starts with `X` — covers a concrete tool **and** the same/narrower wildcard, or
- exactly equals the proposed entry (unchanged).

**It never widens:**
- a broader proposed wildcard (`mcp__*`) is NOT covered by a narrower root (`mcp__slack__*`);
- an exact root entry never covers a broader proposed wildcard;
- a different family is rejected, and the prefix boundary is precise (`mcp__slacker__*` does **not** cover `mcp__slack__send`).

Primary beneficiary is **fork** (its ceiling is the declared patterns, e.g. `mcp__slack__*`). `create`'s ceiling is the *expanded concrete* run tools, so exact matches there are unchanged (correct — an in-run agent grants what it literally resolved to).

## Files
- `agentdef.go`: new `toolCoveredByRoot` helper; `assertToolsSubset` delegates per-entry.
- `agentdef_test.go`: table-driven `TestAssertToolsSubset_WildcardCoverage` (12 cases incl. precise-prefix-boundary + no-widen guards).
- `docs/CUSTOMIZING_AGENTS.md`: the `mcp__<server>__*` grant now carries through fork/clone; moved Clone (#760) + this ceiling item out of "planned" (Phase 4 conversation-carry-over remains).

## Tested
New test + the existing `Fork`/`CreateRefused`/`SkillDefTool` widening tests pass; `go test ./...` clean; gofmt/vet clean.

Next: **Phase 4** (context replay). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)