### PR TITLE
feat(sandbox): unify the sidecar shared secret on SANDBOX_AUTH_TOKEN

### DIFF
--- a/bundles/sandbox/README.md
+++ b/bundles/sandbox/README.md
@@ -44,7 +44,7 @@ LOOMCYCLE_PRESETS=base,sandbox
   [`deploy/builder/`](../../deploy/builder/); full operator guide in
   [`docs/SANDBOX.md`](../../docs/SANDBOX.md). Without it the sandbox tools are
   registered-but-unreachable (the MCP pool retries lazily).
-- **`LOOMCYCLE_SANDBOX_TOKEN`** — the shared bearer, set to the SAME value as the
+- **`SANDBOX_AUTH_TOKEN`** — the shared bearer, set to the SAME value as the
   sidecar's `SANDBOX_AUTH_TOKEN`. The `mcp_servers.sandbox` header consumes it.
 - **A `middle` tier** — select `base` alongside, or supply your own.
 

--- a/bundles/sandbox/loomcycle.yaml
+++ b/bundles/sandbox/loomcycle.yaml
@@ -6,8 +6,9 @@
 # Selected via `LOOMCYCLE_PRESETS=…,sandbox`. Requires:
 #   - the builder sidecar deployed on the app network (deploy/builder/; see
 #     docs/SANDBOX.md) — the mcp__sandbox__* tools are served by it.
-#   - LOOMCYCLE_SANDBOX_TOKEN set to the SAME shared secret as the sidecar's
-#     SANDBOX_AUTH_TOKEN (the mcp_servers header below consumes it).
+#   - SANDBOX_AUTH_TOKEN set to the SAME value on BOTH loomcycle and the sidecar
+#     — one env var name shared by both services (the sidecar authenticates every
+#     MCP request against it; the mcp_servers header below forwards it).
 #   - a `middle` tier — select `base` alongside, or supply your own.
 # Without the sidecar the mcp__sandbox__* tools are registered-but-unreachable
 # (the MCP pool retries lazily); nothing else in the bundle is affected.
@@ -162,9 +163,10 @@ mcp_servers:
     # overlay if it isn't at this address.
     url: http://builder-sidecar:9000/mcp
     headers:
-      # Per-run bearer when present, else the shared LOOMCYCLE_SANDBOX_TOKEN secret
-      # (must equal the sidecar's SANDBOX_AUTH_TOKEN).
-      Authorization: "Bearer ${run.user_bearer:-${LOOMCYCLE_SANDBOX_TOKEN}}"
+      # The sidecar does SHARED-secret auth: set SANDBOX_AUTH_TOKEN to the same
+      # value on loomcycle + the sidecar. (No ${run.user_bearer} — a per-run
+      # loomcycle bearer isn't the sidecar's secret, so forwarding it would 401.)
+      Authorization: "Bearer ${SANDBOX_AUTH_TOKEN}"
       # Non-secret run identifiers the sidecar tags each session with, for
       # run-liveness GC + sandbox_close_run (empty when the run carries none).
       X-Loom-Root-Run: "${run.root_run_id}"

--- a/cmd/loomcycle/embedded/bundles/sandbox.yaml
+++ b/cmd/loomcycle/embedded/bundles/sandbox.yaml
@@ -6,8 +6,9 @@
 # Selected via `LOOMCYCLE_PRESETS=…,sandbox`. Requires:
 #   - the builder sidecar deployed on the app network (deploy/builder/; see
 #     docs/SANDBOX.md) — the mcp__sandbox__* tools are served by it.
-#   - LOOMCYCLE_SANDBOX_TOKEN set to the SAME shared secret as the sidecar's
-#     SANDBOX_AUTH_TOKEN (the mcp_servers header below consumes it).
+#   - SANDBOX_AUTH_TOKEN set to the SAME value on BOTH loomcycle and the sidecar
+#     — one env var name shared by both services (the sidecar authenticates every
+#     MCP request against it; the mcp_servers header below forwards it).
 #   - a `middle` tier — select `base` alongside, or supply your own.
 # Without the sidecar the mcp__sandbox__* tools are registered-but-unreachable
 # (the MCP pool retries lazily); nothing else in the bundle is affected.
@@ -162,9 +163,10 @@ mcp_servers:
     # overlay if it isn't at this address.
     url: http://builder-sidecar:9000/mcp
     headers:
-      # Per-run bearer when present, else the shared LOOMCYCLE_SANDBOX_TOKEN secret
-      # (must equal the sidecar's SANDBOX_AUTH_TOKEN).
-      Authorization: "Bearer ${run.user_bearer:-${LOOMCYCLE_SANDBOX_TOKEN}}"
+      # The sidecar does SHARED-secret auth: set SANDBOX_AUTH_TOKEN to the same
+      # value on loomcycle + the sidecar. (No ${run.user_bearer} — a per-run
+      # loomcycle bearer isn't the sidecar's secret, so forwarding it would 401.)
+      Authorization: "Bearer ${SANDBOX_AUTH_TOKEN}"
       # Non-secret run identifiers the sidecar tags each session with, for
       # run-liveness GC + sandbox_close_run (empty when the run carries none).
       X-Loom-Root-Run: "${run.root_run_id}"

--- a/cmd/loomcycle/presets_integration_test.go
+++ b/cmd/loomcycle/presets_integration_test.go
@@ -160,6 +160,18 @@ func TestEmbedded_SandboxBundleValidates(t *testing.T) {
 	if sv.Transport != "http" || sv.URL == "" {
 		t.Errorf("sandbox MCP server should be http with a url; got transport=%q url=%q", sv.Transport, sv.URL)
 	}
+	// One shared secret under the sidecar's OWN name: the Authorization header
+	// expands SANDBOX_AUTH_TOKEN from the env (allowlisted) — no LOOMCYCLE_ alias,
+	// and no ${run.user_bearer} prefix (the sidecar does shared-secret auth, so a
+	// per-run bearer would only 401).
+	t.Setenv("SANDBOX_AUTH_TOKEN", "sekret-xyz")
+	cfg2, err := config.LoadLayers(layersFor(t, "base", "sandbox")...)
+	if err != nil {
+		t.Fatalf("reload with SANDBOX_AUTH_TOKEN set: %v", err)
+	}
+	if got := cfg2.MCPServers["sandbox"].Headers["Authorization"]; got != "Bearer sekret-xyz" {
+		t.Errorf("sandbox Authorization = %q, want \"Bearer sekret-xyz\" (SANDBOX_AUTH_TOKEN expanded, no user_bearer)", got)
+	}
 }
 
 // hasToolPreset reports whether tools contains name.

--- a/deploy/builder/INSTALL.md
+++ b/deploy/builder/INSTALL.md
@@ -86,8 +86,8 @@ The sidecar authenticates every MCP call with a bearer. Generate one:
 openssl rand -hex 32     # → the sandbox shared secret
 ```
 
-You'll set it as **both** `SANDBOX_AUTH_TOKEN` (the sidecar) and
-`LOOMCYCLE_SANDBOX_TOKEN` (loomcycle) — same value. Keep it in a root-only env file
+You'll set **`SANDBOX_AUTH_TOKEN`** to the same value in **both** the sidecar and
+loomcycle — one env var name, shared by both services. Keep it in a root-only env file
 on the TrueNAS host, e.g. a tiny sidecar file plus a line in loomcycle's existing
 secrets file:
 
@@ -98,7 +98,7 @@ printf 'SANDBOX_AUTH_TOKEN=%s\n' "$THE_SECRET" \
 chmod 600 /mnt/tank/loomcycle/config/sandbox.secrets.env
 
 # and add the same value to loomcycle's secrets file (Phase 4 of the loomcycle install)
-echo "LOOMCYCLE_SANDBOX_TOKEN=$THE_SECRET" \
+echo "SANDBOX_AUTH_TOKEN=$THE_SECRET" \
   >> /mnt/tank/loomcycle/config/loomcycle.secrets.env
 ```
 
@@ -180,10 +180,11 @@ On the **loomcycle** service, two changes:
    ```yaml
    LOOMCYCLE_PRESETS: "base,document-agent,chat,agent-teams,team-examples,sandbox"
    ```
-2. Ensure `LOOMCYCLE_SANDBOX_TOKEN` is set (Phase 2 added it to
+2. Ensure `SANDBOX_AUTH_TOKEN` is set (Phase 2 added it to
    `loomcycle.secrets.env`, which the loomcycle service already reads via `env_file`).
-   The bundle's MCP header is `Authorization: Bearer ${run.user_bearer:-${LOOMCYCLE_SANDBOX_TOKEN}}`,
-   so it uses that shared secret when there's no per-run bearer.
+   The bundle's MCP header is `Authorization: Bearer ${SANDBOX_AUTH_TOKEN}` — the
+   same env var name the sidecar authenticates against, so both services share one
+   secret under one name.
 
 That's it — the bundle carries the `mcp_servers.sandbox` URL (`http://builder-sidecar:9000/mcp`).
 If your sidecar service has a different name/port, override it in your config overlay:
@@ -194,7 +195,7 @@ mcp_servers:
     transport: http
     url: http://builder-sidecar:9000/mcp
     headers:
-      Authorization: "Bearer ${run.user_bearer:-${LOOMCYCLE_SANDBOX_TOKEN}}"
+      Authorization: "Bearer ${SANDBOX_AUTH_TOKEN}"
 ```
 
 Redeploy the app (Save). loomcycle waits on migrate, boots, and the MCP pool connects
@@ -277,7 +278,7 @@ secure nested runtime — `runtime: sysbox-runc` — but TrueNAS SCALE doesn't s
 | Symptom | Cause / fix |
 |---|---|
 | Sidecar exits at start: `SANDBOX_IMAGE is required` / `SANDBOX_AUTH_TOKEN is required` | Set both — `SANDBOX_IMAGE` (env) and `SANDBOX_AUTH_TOKEN` (the `env_file`). For local dev only, `SANDBOX_ALLOW_ANON=1` skips auth (logs a warning). |
-| `mcp__sandbox__*` tools never appear in loomcycle | (a) the sidecar isn't in the SAME compose/network → loomcycle can't resolve `builder-sidecar`; (b) token mismatch → the sidecar 401s (check `SANDBOX_AUTH_TOKEN` == `LOOMCYCLE_SANDBOX_TOKEN`); (c) the `sandbox` preset isn't in `LOOMCYCLE_PRESETS`. |
+| `mcp__sandbox__*` tools never appear in loomcycle | (a) the sidecar isn't in the SAME compose/network → loomcycle can't resolve `builder-sidecar`; (b) token mismatch → the sidecar 401s (check `SANDBOX_AUTH_TOKEN` == `SANDBOX_AUTH_TOKEN`); (c) the `sandbox` preset isn't in `LOOMCYCLE_PRESETS`. |
 | `sandbox_open` fails: `permission denied` on `/var/run/docker.sock` | The socket path is wrong or not mounted, or the container user can't read it — verify `ls -l /var/run/docker.sock` on the host and the `volumes:` mount; run the sidecar as root (no `user:` line). |
 | `sandbox_open` fails: image pull / `no such image` | The HOST Docker can't pull `SANDBOX_IMAGE` — confirm you pushed the session image and, if the registry is private, `docker login` on the TrueNAS host. |
 | Nested-podman sessions fail to start (podman model) | Nested rootless podman storage/kernel quirk — switch to the host-Docker-socket model, or run the sidecar in a VM. |

--- a/deploy/builder/README.md
+++ b/deploy/builder/README.md
@@ -83,7 +83,7 @@ services:
     restart: unless-stopped
     environment:
       SANDBOX_PODMAN_BIN: docker                         # drive the host Docker (socket model)
-      SANDBOX_AUTH_TOKEN: ${LOOMCYCLE_SANDBOX_TOKEN}     # shared secret (see below)
+      SANDBOX_AUTH_TOKEN: ${SANDBOX_AUTH_TOKEN}     # shared secret (see below)
       SANDBOX_IMAGE: denngubsky/loomcycle-sandbox-session:latest
       SANDBOX_MAX_MEM_MB: "2048"
       SANDBOX_MAX_CPUS: "2"
@@ -102,12 +102,14 @@ mcp_servers:
     transport: http
     url: http://builder-sidecar:9000/mcp
     headers:
-      Authorization: "Bearer ${run.user_bearer:-${LOOMCYCLE_SANDBOX_TOKEN}}"
+      Authorization: "Bearer ${SANDBOX_AUTH_TOKEN}"
 ```
 
-The **shared secret** (`LOOMCYCLE_SANDBOX_TOKEN`) goes in loomcycle's env and the
-sidecar's `SANDBOX_AUTH_TOKEN` — set both to the same value. Per-run bearers, when
-present, take precedence (the `${run.user_bearer:-…}` fallback form).
+Set **`SANDBOX_AUTH_TOKEN`** to the same value in **both** services' env — one env
+var name shared by loomcycle and the sidecar. The sidecar does shared-secret auth
+(a single constant-time bearer check), so the header is the plain token, not a
+per-run `${run.user_bearer}` (a per-run loomcycle bearer isn't the sidecar's
+secret — forwarding it would 401).
 
 ## Configuration (environment)
 

--- a/docker-compose.example.yaml
+++ b/docker-compose.example.yaml
@@ -109,7 +109,7 @@ services:
   # loomcycle reaches it in-network at http://builder-sidecar:9000/mcp — no host
   # port. Build it + the session image from deploy/builder/ (see docs/SANDBOX.md),
   # then select the `sandbox` bundle (LOOMCYCLE_PRESETS=…,sandbox) and set
-  # LOOMCYCLE_SANDBOX_TOKEN on the loomcycle service to the same shared secret.
+  # SANDBOX_AUTH_TOKEN on the loomcycle service to the same shared secret.
   # builder-sidecar:
   #   image: denngubsky/loomcycle-builder:latest
   #   container_name: builder-sidecar
@@ -118,7 +118,7 @@ services:
   #   # privileged: true is the fallback (accept the risk; e.g. on TrueNAS).
   #   runtime: sysbox-runc
   #   environment:
-  #     SANDBOX_AUTH_TOKEN: ${LOOMCYCLE_SANDBOX_TOKEN}     # same secret as loomcycle's
+  #     SANDBOX_AUTH_TOKEN: ${SANDBOX_AUTH_TOKEN}     # same secret as loomcycle's
   #     SANDBOX_IMAGE: localhost/loomcycle-sandbox-session:latest
   #     SANDBOX_MAX_MEM_MB: "2048"
   #     SANDBOX_MAX_CPUS: "2"

--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -41,7 +41,7 @@ builder-sidecar                    ──►  per-session container
    docker build -t localhost/loomcycle-sandbox-session:latest deploy/builder/session
    ```
 
-2. **Set a shared secret.** Add `LOOMCYCLE_SANDBOX_TOKEN=<openssl rand -hex 32>`
+2. **Set a shared secret.** Add `SANDBOX_AUTH_TOKEN=<openssl rand -hex 32>`
    to your `.env.local` — it authenticates loomcycle → sidecar. (It's referenced
    by *name* in the config header below; loomcycle allows `${LOOMCYCLE_*}`
    interpolation into an MCP header.)
@@ -61,7 +61,7 @@ builder-sidecar                    ──►  per-session container
        transport: http
        url: http://builder-sidecar:9000/mcp
        headers:
-         Authorization: "Bearer ${run.user_bearer:-${LOOMCYCLE_SANDBOX_TOKEN}}"
+         Authorization: "Bearer ${SANDBOX_AUTH_TOKEN}"
    ```
 
    (Selecting the bundle supplies this block; re-declare `url` in your overlay if

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4128,7 +4128,13 @@ func ExpandEnvAllowed(name string) bool {
 		"TAVILY_API_KEY",
 		"GITHUB_TOKEN",
 		"SLACK_BOT_TOKEN",
-		"REDIS_URL":
+		"REDIS_URL",
+		// SANDBOX_AUTH_TOKEN is the builder-sidecar's shared secret (deploy/builder).
+		// The `sandbox` bundle forwards it in the sidecar's MCP Authorization header,
+		// and the sidecar authenticates against the same name — so both services use
+		// ONE env var instead of a LOOMCYCLE_-prefixed alias. Not a loomcycle infra
+		// secret (those are in expandDenyNames), so allowlisting it here is safe.
+		"SANDBOX_AUTH_TOKEN":
 		return true
 	}
 	return false

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2324,7 +2324,9 @@ scheduled_runs:
 // and the known third-party names are allowed; provider keys + arbitrary names
 // are NOT (they must never be expandable into outbound fields).
 func TestExpandEnvAllowed_Predicate(t *testing.T) {
-	allowed := []string{"LOOMCYCLE_FOO", "LOOMCYCLE_GITEA_WEBHOOK_SECRET", "GITHUB_TOKEN", "BRAVE_API_KEY"}
+	// SANDBOX_AUTH_TOKEN is the builder-sidecar shared secret — allowlisted so the
+	// sandbox bundle's MCP header can use the SAME name as the sidecar's own env.
+	allowed := []string{"LOOMCYCLE_FOO", "LOOMCYCLE_GITEA_WEBHOOK_SECRET", "GITHUB_TOKEN", "BRAVE_API_KEY", "SANDBOX_AUTH_TOKEN"}
 	for _, n := range allowed {
 		if !ExpandEnvAllowed(n) {
 			t.Errorf("ExpandEnvAllowed(%q) = false, want true", n)


### PR DESCRIPTION
## Problem

The `sandbox` bundle required the shared secret under **two different names** — `LOOMCYCLE_SANDBOX_TOKEN` on loomcycle vs `SANDBOX_AUTH_TOKEN` on the builder-sidecar — only because loomcycle's env-expand allowlist admits `LOOMCYCLE_*`-prefixed names. Setting one secret under two names is confusing, and a mismatch surfaces only as `mcp[sandbox]: handshake failed … 401: unauthorized` (exactly the diagnosis from the field).

## Change — one env var for both services

- **Allowlist `SANDBOX_AUTH_TOKEN`** in `config.ExpandEnvAllowed` (next to the third-party service keys). It's the sandbox *integration* secret, **not** a loomcycle infra secret — those (DSN, operator bearer, pepper, KEK…) stay denied in `expandDenyNames`.
- **Bundle header → `Bearer ${SANDBOX_AUTH_TOKEN}`** (both copies), dropping the `${run.user_bearer:-…}` prefix. The sidecar does **shared-secret** auth (a single constant-time bearer check), so forwarding a per-run loomcycle bearer could only 401 an authenticated run — it never helped. This also fixes a latent footgun where authenticated runs would 401 at the sandbox even with the token set correctly.
- **Docs** updated: `deploy/builder/INSTALL.md`, `deploy/builder/README.md`, `docs/SANDBOX.md`, `docker-compose.example.yaml`, `bundles/sandbox/README.md`. (`REVISIONS.md` left as historical v1.23.0 notes.)

Now: set **`SANDBOX_AUTH_TOKEN`** to the same value in both services' env. Done.

## ⚠️ Breaking (opt-in sandbox bundle only)

A deployment currently using `LOOMCYCLE_SANDBOX_TOKEN` must **rename it to `SANDBOX_AUTH_TOKEN`** on the loomcycle service (same value the sidecar already uses). No effect on deployments that don't use the sandbox bundle.

## Tested

- `TestExpandEnvAllowed_Predicate` — `SANDBOX_AUTH_TOKEN` allowed.
- `TestEmbedded_SandboxBundleValidates` — now asserts the header expands to `Bearer <token>` (env-set) with **no** `user_bearer` and no `LOOMCYCLE_` alias; both bundle copies byte-identical.
- `go test ./...` clean; gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)