### PR TITLE
fix(sandbox): make the tmpfs /work writable by the non-root container user

### DIFF
--- a/deploy/builder/engine.go
+++ b/deploy/builder/engine.go
@@ -104,7 +104,13 @@ func (e *Engine) runArgs(name string, o openOpts) []string {
 	if o.WorkspaceHostDir != "" {
 		a = append(a, "-v", o.WorkspaceHostDir+":"+workDir+":rw")
 	} else {
-		a = append(a, "--tmpfs", fmt.Sprintf("%s:rw,size=%dm,mode=0700,exec", workDir, o.TmpfsMB))
+		// A tmpfs mounts ROOT-owned; the container runs as the non-root CtrUser
+		// (--user below). At mode=0700 that user can't write OR read/search /work
+		// (file writes AND `bash -l` reading $HOME/.bash_profile both fail with
+		// "permission denied"), so /work must be writable by other — mode=0777.
+		// (Docker's --tmpfs doesn't reliably honor uid=/gid=, so mode is the
+		// portable knob; the mount is container-private + ephemeral, single-user.)
+		a = append(a, "--tmpfs", fmt.Sprintf("%s:rw,size=%dm,mode=0777,exec", workDir, o.TmpfsMB))
 	}
 	a = append(a,
 		"--tmpfs", "/tmp:rw,size=64m,exec",

--- a/deploy/builder/engine_test.go
+++ b/deploy/builder/engine_test.go
@@ -88,7 +88,7 @@ func TestEngine_RunArgs_HardeningPosture(t *testing.T) {
 			tmpfsWork = args[i+1]
 		}
 	}
-	if tmpfsWork == "" || !strings.Contains(tmpfsWork, "size=512m") || !strings.Contains(tmpfsWork, "mode=0700") {
+	if tmpfsWork == "" || !strings.Contains(tmpfsWork, "size=512m") || !strings.Contains(tmpfsWork, "mode=0777") {
 		t.Errorf("tmpfs /work mount wrong: %q", tmpfsWork)
 	}
 	// Image + entrypoint come last.

--- a/deploy/builder/workspace_test.go
+++ b/deploy/builder/workspace_test.go
@@ -38,6 +38,34 @@ func TestEngine_RunArgs_DurableWorkspaceBindMount(t *testing.T) {
 	}
 }
 
+// TestEngine_RunArgs_TmpfsWorkWritableByNonRoot is the regression for the /work
+// permission bug: the container runs as a NON-ROOT user (--user CtrUser), but a
+// tmpfs mounts root-owned — so mode=0700 left /work neither writable nor readable
+// by that user (file writes AND `bash -l` reading $HOME/.bash_profile both failed
+// with "permission denied"). /work must be mode=0777.
+func TestEngine_RunArgs_TmpfsWorkWritableByNonRoot(t *testing.T) {
+	e := NewEngine(testCfg(), &fakeRunner{})
+	args := e.runArgs("n", openOpts{Network: "none", TmpfsMB: 512, CPUs: 1, MemMB: 512, Pids: 100, Image: "img"})
+	var workTmpfs string
+	for i, a := range args {
+		if a == "--tmpfs" && i+1 < len(args) && strings.HasPrefix(args[i+1], workDir+":") {
+			workTmpfs = args[i+1]
+		}
+	}
+	if workTmpfs == "" {
+		t.Fatalf("no tmpfs /work mount found: %v", args)
+	}
+	if !strings.Contains(workTmpfs, "mode=0777") {
+		t.Errorf("/work tmpfs must be mode=0777 (writable by the non-root user); got %q", workTmpfs)
+	}
+	if strings.Contains(workTmpfs, "mode=0700") {
+		t.Errorf("/work tmpfs is mode=0700 (root-only) — the non-root user can't write: %q", workTmpfs)
+	}
+	if !strings.Contains(workTmpfs, "exec") {
+		t.Errorf("/work tmpfs lost exec (compiled binaries must run in /work): %q", workTmpfs)
+	}
+}
+
 func TestValidateWorkspaceName(t *testing.T) {
 	for _, n := range []string{"proj", "my-repo", "a1", "build_2", "x"} {
 		if err := validateWorkspaceName(n); err != nil {


### PR DESCRIPTION
## Bug

The default (ephemeral) sandbox session mounted `/work` as `--tmpfs …,mode=0700`, but the container runs as a **non-root** user (`--user CtrUser`, default `1000:1000`). A tmpfs mounts **root-owned**, so at `mode=0700` the container user could neither write **nor read/search** `/work`:

```
write failed: … bash: /work/.bash_profile: Permission denied
bash: line 1: /work/circle_area.py: Permission denied
```

Every `sandbox_write` / `sandbox_exec` file op failed, and `bash -lc` failed to read `$HOME/.bash_profile` (HOME=`/work`). Only inline `python3 -c` (which writes nothing) worked. `/tmp` was fine because it has no `mode` override (defaults to writable). Net: the sandbox was unusable for anything touching a file.

## Fix

Mount the `/work` tmpfs `mode=0777`. Docker's `--tmpfs` doesn't reliably honor `uid=`/`gid=`, so `mode` is the portable knob; the mount is container-private, ephemeral, and single-user, so world-writable is not a meaningful exposure. The **durable-workspace** bind-mount path is unaffected (it's already `chown`ed to `CtrUser` by the sidecar — which is also why enabling `SANDBOX_WORKSPACE_ROOT` sidesteps this bug).

## Tested
- New `TestEngine_RunArgs_TmpfsWorkWritableByNonRoot` (mode=0777, not 0700; `exec` preserved).
- Updated the existing `engine_test.go` expectation.
- Sidecar module `go test ./...` clean; gofmt clean.

**Deploy:** sidecar-only — needs a rebuilt `loomcycle-builder(-docker)` image. I'll push a patched image so it's pullable immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)