### PR TITLE
feat(sandbox): dev/sandbox to low tier + wildcard sandbox tool grant

### DIFF
--- a/bundles/sandbox/loomcycle.yaml
+++ b/bundles/sandbox/loomcycle.yaml
@@ -8,7 +8,7 @@
 #     docs/SANDBOX.md) — the mcp__sandbox__* tools are served by it.
 #   - LOOMCYCLE_SANDBOX_TOKEN set to the SAME shared secret as the sidecar's
 #     SANDBOX_AUTH_TOKEN (the mcp_servers header below consumes it).
-#   - a `middle` tier — select `base` alongside, or supply your own.
+#   - a `low` tier — select `base` alongside, or supply your own.
 # Without the sidecar the mcp__sandbox__* tools are registered-but-unreachable
 # (the MCP pool retries lazily); nothing else in the bundle is affected.
 #
@@ -22,9 +22,12 @@
 
 agents:
   dev/sandbox:
-    tier: middle
+    tier: low
     effort: medium
-    tools: [mcp__sandbox__sandbox_open, mcp__sandbox__sandbox_exec, mcp__sandbox__sandbox_write, mcp__sandbox__sandbox_read, mcp__sandbox__sandbox_close, mcp__sandbox__sandbox_touch, mcp__sandbox__sandbox_close_run, mcp__sandbox__sandbox_list, Interruption]
+    # mcp__sandbox__* grants the whole sidecar tool family (prefix glob, matched at
+    # exposure AND the fork/create ceiling check) — so future sandbox_* tools are
+    # picked up without editing the bundle.
+    tools: [mcp__sandbox__*, Interruption]
     skills: [dev/sandbox]
     compaction:
       enabled: true
@@ -65,7 +68,7 @@ agents:
 skills:
   dev/sandbox:
     description: Compile, test, and run code safely in an isolated ephemeral sandbox container (Python/Go/Rust/C++/Node) via the builder sidecar.
-    tools: [mcp__sandbox__sandbox_open, mcp__sandbox__sandbox_exec, mcp__sandbox__sandbox_write, mcp__sandbox__sandbox_read, mcp__sandbox__sandbox_close, mcp__sandbox__sandbox_touch, mcp__sandbox__sandbox_close_run]
+    tools: [mcp__sandbox__*]
     body: |
       # Running code in the sandbox
 

--- a/cmd/loomcycle/embedded/bundles/sandbox.yaml
+++ b/cmd/loomcycle/embedded/bundles/sandbox.yaml
@@ -8,7 +8,7 @@
 #     docs/SANDBOX.md) — the mcp__sandbox__* tools are served by it.
 #   - LOOMCYCLE_SANDBOX_TOKEN set to the SAME shared secret as the sidecar's
 #     SANDBOX_AUTH_TOKEN (the mcp_servers header below consumes it).
-#   - a `middle` tier — select `base` alongside, or supply your own.
+#   - a `low` tier — select `base` alongside, or supply your own.
 # Without the sidecar the mcp__sandbox__* tools are registered-but-unreachable
 # (the MCP pool retries lazily); nothing else in the bundle is affected.
 #
@@ -22,9 +22,12 @@
 
 agents:
   dev/sandbox:
-    tier: middle
+    tier: low
     effort: medium
-    tools: [mcp__sandbox__sandbox_open, mcp__sandbox__sandbox_exec, mcp__sandbox__sandbox_write, mcp__sandbox__sandbox_read, mcp__sandbox__sandbox_close, mcp__sandbox__sandbox_touch, mcp__sandbox__sandbox_close_run, mcp__sandbox__sandbox_list, Interruption]
+    # mcp__sandbox__* grants the whole sidecar tool family (prefix glob, matched at
+    # exposure AND the fork/create ceiling check) — so future sandbox_* tools are
+    # picked up without editing the bundle.
+    tools: [mcp__sandbox__*, Interruption]
     skills: [dev/sandbox]
     compaction:
       enabled: true
@@ -65,7 +68,7 @@ agents:
 skills:
   dev/sandbox:
     description: Compile, test, and run code safely in an isolated ephemeral sandbox container (Python/Go/Rust/C++/Node) via the builder sidecar.
-    tools: [mcp__sandbox__sandbox_open, mcp__sandbox__sandbox_exec, mcp__sandbox__sandbox_write, mcp__sandbox__sandbox_read, mcp__sandbox__sandbox_close, mcp__sandbox__sandbox_touch, mcp__sandbox__sandbox_close_run]
+    tools: [mcp__sandbox__*]
     body: |
       # Running code in the sandbox
 

--- a/cmd/loomcycle/presets_integration_test.go
+++ b/cmd/loomcycle/presets_integration_test.go
@@ -140,13 +140,17 @@ func TestEmbedded_SandboxBundleValidates(t *testing.T) {
 	if !ok {
 		t.Fatalf("dev/sandbox agent not registered (agents: %v)", agentNames(cfg))
 	}
-	// The agent must grant the sandbox tools + the auto-added Skill tool — incl. the
-	// P2b lifecycle tools (touch keepalive + close_run bulk teardown), else the agent
-	// can't reach them even though the sidecar advertises them.
-	for _, want := range []string{"mcp__sandbox__sandbox_open", "mcp__sandbox__sandbox_exec", "mcp__sandbox__sandbox_touch", "mcp__sandbox__sandbox_close_run", "Skill"} {
+	// The agent grants the whole sandbox tool family via the `mcp__sandbox__*`
+	// prefix glob (auto-includes future sandbox_* tools) + the auto-added Skill tool.
+	for _, want := range []string{"mcp__sandbox__*", "Skill"} {
 		if !hasToolPreset(agent.Tools, want) {
 			t.Errorf("dev/sandbox should grant %q; tools=%v", want, agent.Tools)
 		}
+	}
+	// dev/sandbox runs on the low tier (cheap model — it drives a toolchain, not deep
+	// reasoning; the base preset supplies `low`).
+	if agent.Tier != "low" {
+		t.Errorf("dev/sandbox tier = %q, want low", agent.Tier)
 	}
 	// The inline skill is in the on-demand catalog with its body intact.
 	if sk, ok := cfg.Skills["dev/sandbox"]; !ok || strings.TrimSpace(sk.Body) == "" {


### PR DESCRIPTION
Two tweaks to the bundled `dev/sandbox` agent.

**1. tier `middle` → `low`.** It drives a toolchain (write/exec/read), not deep reasoning, so the cheap tier fits. The `base` preset supplies `low`; the bundle's tier requirement comment is updated accordingly.

**2. `tools:` → `mcp__sandbox__*`** (agent: `[mcp__sandbox__*, Interruption]`, skill: `[mcp__sandbox__*]`), replacing the explicit `sandbox_open/exec/write/read/close/touch/close_run/list` enumeration. The `mcp__sandbox__*` prefix glob is matched both at the exposure layer (`policy.Apply`) **and** — since RFC BJ Phase 3 (#761) — at the fork/create **ceiling** check (`assertToolsSubset`). So:
- the agent auto-picks-up any **future** `sandbox_*` tool with no bundle edit, and
- a **fork** of `dev/sandbox` can still narrow to specific tools (the wildcard root covers them).

Both bundle copies stay byte-identical. `TestEmbedded_SandboxBundleValidates` now asserts the wildcard grant + `Skill` + the `low` tier (replacing the per-tool checks).

## Tested
`TestEmbedded_SandboxBundleValidates` + `TestEmbedded_DefaultStackValidates` pass (the glob validates, the `low` tier resolves against base); `go build ./...` + gofmt clean.

Companion to #765 (tmpfs perms). Independent of #764 (touches different lines of the bundle — the agent block, not the mcp_servers header).

🤖 Generated with [Claude Code](https://claude.com/claude-code)