### PR TITLE
fix(library): hide retired agents by default in the Agents tab

### DIFF
--- a/packages/library/src/Library.tsx
+++ b/packages/library/src/Library.tsx
@@ -377,6 +377,7 @@ function LibraryBody({
             onRetireRow={canRetire ? handleRetire : undefined}
             onPromoteRow={canPromote ? handlePromote : undefined}
             onError={onError}
+            defaultHideRetired
           />
         )}
         {activeTab === "skills" && (

--- a/packages/library/src/components/LineagePanel.tsx
+++ b/packages/library/src/components/LineagePanel.tsx
@@ -54,6 +54,10 @@ export interface LineagePanelProps {
   // Optional host error sink — called when the version-lineage load
   // fails (in addition to the inline error banner).
   onError?: (e: unknown) => void;
+  // Initial state of the "Hide retired" toggle (default false). Library sets it
+  // true for the agents tab so retired/inactive lineage versions are hidden by
+  // default; still user-toggleable.
+  defaultHideRetired?: boolean;
 }
 
 export default function LineagePanel({
@@ -70,6 +74,7 @@ export default function LineagePanel({
   onRediscover,
   onImport,
   onError,
+  defaultHideRetired,
 }: LineagePanelProps) {
   const data = useLibraryData();
   const [selectedName, setSelectedName] = useState<string>(() =>
@@ -80,7 +85,7 @@ export default function LineagePanel({
   // filter/type/sort/hide-retired state is naturally independent per tab).
   const [filterText, setFilterText] = useState("");
   const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
-  const [hideRetired, setHideRetired] = useState(false);
+  const [hideRetired, setHideRetired] = useState(!!defaultHideRetired);
   const [sortMode, setSortMode] = useState<SortMode>("none");
 
   // The list actually rendered = entries ∘ name-filter ∘ type-filter ∘


### PR DESCRIPTION
The Library **Hide retired** toggle defaulted OFF, so retired/inactive lineage versions cluttered the **Agents** list on every open. Default it **ON** for the Agents tab (still user-toggleable).

- `LineagePanel`: new optional `defaultHideRetired` prop seeds the toggle (default `false` → Skills / MCP tabs unchanged); the per-tab state stays independent (each tab renders its own panel).
- `Library`: pass `defaultHideRetired` on the **Agents** panel only — matching the request's scope (Skills / MCP keep showing retired by default).

## Tested
`packages/library` + `web` typecheck clean; library `vitest` 7/7; web Vite build clean.

Third of the three requested tweaks (with #766 dev/sandbox tier+wildcard). Web dogfoods the package via the source alias, so it's live in the UI; `@loomcycle/library` stays on its 0.2.0 dev line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)