### PR TITLE
ci: bump actions/checkout + actions/setup-node to v5 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         go-version: ["1.26.x"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-go@v5
         with:
@@ -92,7 +92,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-go@v5
         with:
@@ -137,7 +137,7 @@ jobs:
     name: Runtime suites (code-js)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-go@v5
         with:
@@ -166,8 +166,8 @@ jobs:
       run:
         working-directory: adapters/ts
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: npm
@@ -183,8 +183,8 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: npm
@@ -214,7 +214,7 @@ jobs:
       run:
         working-directory: adapters/python
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"

--- a/.github/workflows/publish-explorer.yml
+++ b/.github/workflows/publish-explorer.yml
@@ -39,9 +39,9 @@ jobs:
     name: Publish @loomcycle/explorer
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/publish-library.yml
+++ b/.github/workflows/publish-library.yml
@@ -37,9 +37,9 @@ jobs:
     name: Publish @loomcycle/library
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/publish-python-adapter.yml
+++ b/.github/workflows/publish-python-adapter.yml
@@ -42,7 +42,7 @@ jobs:
     name: Publish loomcycle (Python adapter)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/publish-ts-adapter.yml
+++ b/.github/workflows/publish-ts-adapter.yml
@@ -47,9 +47,9 @@ jobs:
     name: Publish @loomcycle/client
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           # Node 24: npm@latest (below) requires Node >=22 — on Node 20 the
           # `npm install -g npm@latest` step failed EBADENGINE before ever

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
     name: goreleaser
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # goreleaser needs full git history for the version
           # template + commit-date stamp.
@@ -66,7 +66,7 @@ jobs:
           go-version: "1.26"
           cache: true
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: npm


### PR DESCRIPTION
Resolves the **Node.js 20 deprecation** warnings on the CI/publish workflows.

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/checkout@v4`, `actions/setup-node@v4`.

`checkout@v4` / `setup-node@v4` declare the Node 20 runtime; the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env was *forcing* them onto Node 24 (hence the "being forced to run on Node.js 24" phrasing), but the warning fires at the source — the action's declared runtime. Bumping both to **@v5** (native Node 24) across all six workflows clears it.

## Scope
- `actions/checkout@v4 → @v5` and `actions/setup-node@v4 → @v5` (ci, release, publish-ts/library/explorer/python).
- `setup-go@v5` / `setup-python@v5` already Node-24 — untouched.
- `docker/*@v3` + `goreleaser@v6` are at their latest major and remain Node-20; the `FORCE_…NODE24` env (kept) covers them until they ship a Node-24 major.

## The other two annotations
- **`git failed exit 128`** — a benign `actions/checkout` post-step cleanup message (the job succeeds); the v5 runtime may also clear it.
- **`Skipping publish — version mismatch (1.25.0 vs 1.25.1)`** — **intended**, not an error: a no-wire-change release leaves the adapter version unchanged, so the publish correctly skips-but-green. No change.

## Tested
CI-only. YAML validated for all six workflows; the PR's own CI run exercises the bumped actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)