### PR TITLE
fix(sandbox): run session commands in a non-login shell (toolchain on PATH)

### DIFF
--- a/deploy/builder/engine.go
+++ b/deploy/builder/engine.go
@@ -160,11 +160,15 @@ func (e *Engine) Open(ctx context.Context, name string, o openOpts) error {
 
 // execArgs builds `podman exec` for running a command inside a session's shell.
 func (e *Engine) execArgs(name, command string) []string {
-	// The user command runs inside the CONTAINER's login shell — that's the
-	// sandbox boundary. Host-side there is no shell: podman + its args are
-	// exec'd directly (no host shell interpolation), so `command` cannot inject
-	// into the host.
-	return []string{"exec", name, "bash", "-lc", command}
+	// NON-login shell (`bash -c`, not `-lc`): the toolchain lives on the image's
+	// ENV PATH (/usr/local/go/bin, /usr/local/cargo/bin), which `docker exec`
+	// inherits. A LOGIN shell would source /etc/profile and RESET PATH to the
+	// Debian default — dropping go/cargo/rustc ("go: command not found") while
+	// leaving /usr/bin tools (python3, gcc, node) working. Non-login keeps the
+	// image PATH + the sidecar's --env cache overrides, and also avoids the
+	// login shell reading $HOME/.bash_profile. Host-side there is no shell:
+	// podman + args are exec'd directly, so `command` can't inject into the host.
+	return []string{"exec", name, "bash", "-c", command}
 }
 
 // Exec runs one command in the session, bounded by timeout + maxOut.
@@ -185,7 +189,7 @@ func (e *Engine) Write(ctx context.Context, name, rel string, content []byte) er
 	abs := workDir + "/" + rel
 	argv := prepend(e.cfg.PodmanBin, []string{
 		"exec", "-i", "--env", "SBX_DEST=" + abs, name,
-		"bash", "-lc", `mkdir -p "$(dirname "$SBX_DEST")" && cat > "$SBX_DEST"`,
+		"bash", "-c", `mkdir -p "$(dirname "$SBX_DEST")" && cat > "$SBX_DEST"`,
 	})
 	out, code, err := e.run.Run(ctx, content, e.cfg.MaxOutBytes, argv...)
 	if err != nil {
@@ -202,7 +206,7 @@ func (e *Engine) Read(ctx context.Context, name, rel string, maxBytes int64) ([]
 	abs := workDir + "/" + rel
 	argv := prepend(e.cfg.PodmanBin, []string{
 		"exec", "--env", "SBX_SRC=" + abs, name,
-		"bash", "-lc", `cat "$SBX_SRC"`,
+		"bash", "-c", `cat "$SBX_SRC"`,
 	})
 	out, code, err := e.run.Run(ctx, nil, maxBytes, argv...)
 	if err != nil {

--- a/deploy/builder/engine_test.go
+++ b/deploy/builder/engine_test.go
@@ -144,6 +144,31 @@ func TestEngine_WriteArgs_PathViaEnvNotShell(t *testing.T) {
 	}
 }
 
+// TestEngine_ExecArgs_NonLoginShell is the regression for "go: command not
+// found": the toolchain (go/cargo/rustc) lives on the image's ENV PATH, which a
+// NON-login shell inherits but a login shell (`bash -lc`) resets via /etc/profile.
+// exec must use `bash -c`, not `bash -lc`.
+func TestEngine_ExecArgs_NonLoginShell(t *testing.T) {
+	e := NewEngine(testCfg(), &fakeRunner{})
+	argv := e.execArgs("sess", "go build ./...")
+	// Must run bash -c "<command>" (non-login), NOT bash -lc.
+	var shellFlag string
+	for i, a := range argv {
+		if a == "bash" && i+1 < len(argv) {
+			shellFlag = argv[i+1]
+		}
+	}
+	if shellFlag != "-c" {
+		t.Errorf("exec should use a non-login shell (bash -c); got flag %q in %v", shellFlag, argv)
+	}
+	if shellFlag == "-lc" {
+		t.Errorf("bash -lc resets PATH via /etc/profile — drops /usr/local/go/bin: %v", argv)
+	}
+	if argv[len(argv)-1] != "go build ./..." {
+		t.Errorf("command not passed as the final arg: %v", argv)
+	}
+}
+
 func TestEngine_Exec_TimeoutReported(t *testing.T) {
 	fr := &fakeRunner{fn: func(argv []string, _ []byte) ([]byte, int, error) {
 		return []byte("partial"), -1, nil


### PR DESCRIPTION
## Bug (from a live transcript)

`go build` in the sandbox → `bash: line 1: go: command not found` (exit 127); `which go` → nothing — even though the session image installs Go at `/usr/local/go/bin` and sets it on `ENV PATH`, and the agent prompt correctly says Go is preinstalled.

## Root cause

The sidecar exec'd commands via **`bash -lc`** (a **login** shell). A login bash sources `/etc/profile`, which **resets `PATH`** to the Debian default (`/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`) — **discarding the image's `ENV PATH=/usr/local/go/bin:/usr/local/cargo/bin:…`**. So the toolchains in `/usr/local/*` (go, cargo, rustc) fell off PATH, while `/usr/bin` tools (python3, gcc, node, git) kept working — exactly the symptom.

## Fix

Exec via **`bash -c`** (non-login) in `execArgs` + `Write` + `Read`. `docker exec` inherits the container's environment (the image `ENV PATH` + the sidecar's `--env` cache overrides like `GOCACHE`/`CARGO_HOME`), so a non-login shell sees the full toolchain PATH. Bonus: it also stops the login shell reading `$HOME/.bash_profile` (the permission noise seen earlier).

Sidecar-only (`deploy/builder`) — **needs a rebuilt `loomcycle-builder(-docker)` image**.

## Tested
`TestEngine_ExecArgs_NonLoginShell` asserts `bash -c` (not `-lc`); sidecar module `go test ./...` clean; gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)