### PR TITLE
fix(skill): resolve a glob-scoped skill against the agent's raw tool patterns

### DIFF
--- a/internal/api/http/resume.go
+++ b/internal/api/http/resume.go
@@ -251,6 +251,7 @@ func (s *Server) resumePausedRun(ctx context.Context, run store.Run) error {
 	steerQ, onSteer, deregSteer := s.makeSteer(runCtx, run.ID, run.AgentID, run.SessionID, run.UserID, emit)
 
 	loopCtx := tools.WithAgentTools(runCtx, toolNames(allowedTools))
+	loopCtx = tools.WithAgentToolPatterns(loopCtx, agentDef.Tools) // raw globs for the Skill subset check
 	// RFC AR: honor a tenant/user provider-key override on the resumed run too.
 	loopCtx = providers.WithCredentialResolver(loopCtx, s.credResolver)
 	// RFC AX: mirror the restored negative permission bit onto ctx for the

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2383,6 +2383,9 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	defer deregSteer()
 
 	loopCtx := tools.WithAgentTools(runCtx, toolNames(allowedTools))
+	// Raw (glob-preserving) patterns for the Skill tool's subset check — the
+	// resolved names above have the agent's globs already expanded.
+	loopCtx = tools.WithAgentToolPatterns(loopCtx, agentDef.Tools)
 	// RFC AR: honor a tenant/user provider-key override (ANTHROPIC_API_KEY,
 	// BRAVE_API_KEY, …) for this run. Sub-agents inherit it via subRunCtx←ctx.
 	loopCtx = providers.WithCredentialResolver(loopCtx, s.credResolver)
@@ -3868,6 +3871,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	// Skill tool's subset check on each call) read it via ctx instead
 	// of being constructed per-run.
 	loopCtx := tools.WithAgentTools(runCtx, toolNames(allowedTools))
+	loopCtx = tools.WithAgentToolPatterns(loopCtx, agentDef.Tools) // raw globs for the Skill subset check
 	// RFC AR: honor a tenant/user provider-key override (ANTHROPIC_API_KEY,
 	// BRAVE_API_KEY, …) for this run. Sub-agents inherit it via subRunCtx←ctx.
 	loopCtx = providers.WithCredentialResolver(loopCtx, s.credResolver)
@@ -4434,6 +4438,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	heartbeat := s.makeHeartbeat(run.ID)
 
 	loopCtx := tools.WithAgentTools(runCtx, toolNames(allowedTools))
+	loopCtx = tools.WithAgentToolPatterns(loopCtx, agentDef.Tools) // raw globs for the Skill subset check
 	// RFC AR: honor a tenant/user provider-key override (ANTHROPIC_API_KEY,
 	// BRAVE_API_KEY, …) for this run. Sub-agents inherit it via subRunCtx←ctx.
 	loopCtx = providers.WithCredentialResolver(loopCtx, s.credResolver)
@@ -5546,6 +5551,7 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 	// recursive Agent tool call from this sub picks up the right
 	// parent_agent_id (= subAgentID).
 	subCtx := tools.WithAgentTools(subRunCtx, toolNames(subTools))
+	subCtx = tools.WithAgentToolPatterns(subCtx, def.Tools) // raw globs for the Skill subset check
 	subCtx = tools.WithRunIdentity(subCtx, subRID)
 	subCtx = tools.WithAgentName(subCtx, name)
 	// Sub-agents get THEIR OWN Memory policy from yaml — the parent's

--- a/internal/tools/builtin/skill.go
+++ b/internal/tools/builtin/skill.go
@@ -146,9 +146,12 @@ func (s *SkillTool) execInvoke(ctx context.Context, policy tools.SkillPolicyValu
 		return tools.Result{IsError: true, Text: err.Error()}, nil
 	}
 	// SECURITY: enforce skill.tools ⊆ agent.tools at tool-call time. Agent
-	// tools are read from ctx so the SkillTool struct stays per-server.
+	// tools are read from ctx so the SkillTool struct stays per-server. Prefer
+	// the raw patterns (globs intact) over the resolved effective list so a
+	// glob-scoped skill matches a glob-scoped agent (see skillToolsExceedingAgent).
 	agentTools := tools.AgentTools(ctx)
-	if widening := skillToolsExceedingAgent(allowedTools, agentTools); len(widening) > 0 {
+	agentPatterns := tools.AgentToolPatterns(ctx)
+	if widening := skillToolsExceedingAgent(allowedTools, agentTools, agentPatterns); len(widening) > 0 {
 		return tools.Result{
 			IsError: true,
 			Text: fmt.Sprintf(
@@ -285,20 +288,43 @@ func (s *SkillTool) resolveSkill(ctx context.Context, name string) (string, []st
 	return sk.Body, sk.Tools, "static", nil
 }
 
-// skillToolsExceedingAgent returns the subset of skill tools that the
-// agent does NOT grant (literal + glob composition via policy.Matches).
-// Mirrors resolveSkills' check in internal/config so the static and
-// dynamic skill paths apply the same security rule.
-func skillToolsExceedingAgent(skillTools, agentTools []string) []string {
+// skillToolsExceedingAgent returns the subset of skill tools the agent does
+// NOT grant. skill.tools ⊆ agent.tools — a skill may never widen the agent.
+//
+// agentPatterns is the agent's RAW tool declaration (globs preserved, e.g.
+// "mcp__sandbox__*"); agentTools is the run's EFFECTIVE list (that glob already
+// RESOLVED to concrete pool tools like mcp__sandbox__open). When the raw
+// patterns are attached we check against them with toolCoveredByRoot — the same
+// root-covers logic SkillDef authorship uses — so a skill GLOB requirement
+// matches the agent's declared glob (invoke-time and create-time agree). A
+// concrete agent list can never cover a broader skill glob, which is why the
+// resolved list alone gave a false "not granted" for a glob-scoped skill.
+//
+// Fallback (no raw patterns attached — legacy callers/tests): match the skill
+// tool against the effective set via policy.Matches, preserving prior behavior.
+//
+// (RFC BA moved subset enforcement to Skill-invoke + SkillDef authorship;
+// config-load no longer performs it — a pattern allowlist can't be resolved to
+// a concrete skill set there.)
+func skillToolsExceedingAgent(skillTools, agentTools, agentPatterns []string) []string {
 	if len(skillTools) == 0 {
 		return nil
 	}
-	agentSet := make(map[string]bool, len(agentTools))
-	for _, t := range agentTools {
-		agentSet[t] = true
+	var agentSet map[string]bool
+	if len(agentPatterns) == 0 {
+		agentSet = make(map[string]bool, len(agentTools))
+		for _, t := range agentTools {
+			agentSet[t] = true
+		}
 	}
 	var widening []string
 	for _, t := range skillTools {
+		if len(agentPatterns) > 0 {
+			if !toolCoveredByRoot(t, agentPatterns) {
+				widening = append(widening, t)
+			}
+			continue
+		}
 		if !policy.Matches(t, agentSet) {
 			widening = append(widening, t)
 		}

--- a/internal/tools/builtin/skill_test.go
+++ b/internal/tools/builtin/skill_test.go
@@ -136,6 +136,52 @@ func TestSkillTool_RefusesBroaderGlob(t *testing.T) {
 	}
 }
 
+// Regression (v1.25.2): a GLOB-scoped skill loads for a GLOB-scoped agent.
+// At invoke time AgentTools carries the agent's "mcp__sandbox__*" already
+// RESOLVED to concrete pool tools, so the subset check must consult the RAW
+// patterns (WithAgentToolPatterns) — else the skill glob can't match the
+// concrete list and the agent falsely reports "requires [mcp__sandbox__*] not
+// granted". Reproduces the bundled dev/sandbox agent+skill config.
+func TestSkillTool_GlobSkillCoveredByAgentGlobPattern(t *testing.T) {
+	set := loadSetWithSkills(t, []struct {
+		Name  string
+		Tools []string
+		Body  string
+	}{
+		{Name: "sbx", Tools: []string{"mcp__sandbox__*"}, Body: "OK"},
+	})
+	tool := &SkillTool{Set: set}
+	// AgentTools = the resolved concrete expansion; patterns = the raw glob.
+	ctx := tools.WithAgentTools(context.Background(),
+		[]string{"mcp__sandbox__open", "mcp__sandbox__exec", "mcp__sandbox__close", "Interruption"})
+	ctx = tools.WithAgentToolPatterns(ctx, []string{"mcp__sandbox__*", "Interruption"})
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"name":"sbx"}`))
+	if res.IsError {
+		t.Errorf("glob-scoped skill should load for a glob-scoped agent: %s", res.Text)
+	}
+}
+
+// The strict rule still holds via the raw-patterns path: a skill glob is
+// refused when the agent's raw patterns are narrower than the skill demands.
+func TestSkillTool_GlobSkillRefusedByNarrowerAgentPattern(t *testing.T) {
+	set := loadSetWithSkills(t, []struct {
+		Name  string
+		Tools []string
+		Body  string
+	}{
+		{Name: "sbx", Tools: []string{"mcp__sandbox__*"}, Body: "OK"},
+	})
+	tool := &SkillTool{Set: set}
+	ctx := tools.WithAgentTools(context.Background(), []string{"mcp__sandbox__exec"})
+	ctx = tools.WithAgentToolPatterns(ctx, []string{"mcp__sandbox__exec"}) // literal, not the glob
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"name":"sbx"}`))
+	if !res.IsError {
+		t.Error("skill glob must NOT be covered by a narrower agent literal pattern")
+	}
+}
+
 // A skill with empty allowed-tools (pure prose-guidance) attaches
 // regardless of agent's tool set.
 func TestSkillTool_EmptyToolsAlwaysAllowed(t *testing.T) {

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -117,6 +117,27 @@ func AgentTools(ctx context.Context) []string {
 	return v
 }
 
+// ctxKeyAgentToolPatterns holds the agent's RAW tool declaration — globs
+// preserved (e.g. "mcp__sandbox__*"), unlike ctxKeyAgentTools which carries the
+// glob RESOLVED to concrete pool tool names. The Skill tool's subset check needs
+// the raw form so a glob-scoped skill can be matched against a glob-scoped agent
+// (a resolved concrete list can never cover a broader skill glob).
+type ctxKeyAgentToolPatterns struct{}
+
+// WithAgentToolPatterns attaches the agent's raw tool patterns. Set at run start
+// alongside WithAgentTools; both describe "what the agent can use" — this one
+// before glob resolution, that one after.
+func WithAgentToolPatterns(ctx context.Context, patterns []string) context.Context {
+	return context.WithValue(ctx, ctxKeyAgentToolPatterns{}, patterns)
+}
+
+// AgentToolPatterns returns the agent's raw tool patterns from ctx, or nil if
+// not attached (callers then fall back to the resolved AgentTools list).
+func AgentToolPatterns(ctx context.Context) []string {
+	v, _ := ctx.Value(ctxKeyAgentToolPatterns{}).([]string)
+	return v
+}
+
 type ctxKeySearchProviders struct{}
 
 // WithSearchProviders attaches the agent's per-agent web-search fallback list


### PR DESCRIPTION
## Bug

The bundled **dev/sandbox** agent can't load its own skill:

```
skill "dev/sandbox" (static) requires tools [mcp__sandbox__*] not granted by
this agent's tools — skills cannot widen the agent's tool set
```

…even though the agent is declared `tools: [mcp__sandbox__*, Interruption]` and the skill `tools: [mcp__sandbox__*]`. Regression from the v1.25.1 change that switched the bundled agent+skill to the wildcard/template form.

## Root cause

The invoke-time `skill.tools ⊆ agent.tools` check (`SkillTool.execInvoke`) ran against the agent's **effective** tools (`AgentTools` ctx) — where the agent's own `mcp__sandbox__*` glob has already **resolved** to concrete pool tools (`mcp__sandbox__open`, `mcp__sandbox__exec`, …). A concrete list can never cover a *broader* skill **glob**: `policy.Matches("mcp__sandbox__*", {concrete names})` treats the skill's `"mcp__sandbox__*"` as a literal tool name and misses. So the check falsely reported widening.

Create-time (`SkillDef` authorship / bundle validation) checks the **raw** patterns via `toolCoveredByRoot` and passed — which is why the config validated but wouldn't load. That invoke-vs-create asymmetry is the bug.

## Fix

Thread the agent's **raw** tool patterns into ctx (`tools.WithAgentToolPatterns`, attached at every run-start site next to `WithAgentTools`: the three `server.go` run paths, the sub-agent path, and `resume.go`). When present, the subset check runs against them with **`toolCoveredByRoot`** — the same root-covers logic create-time uses — so invoke-time and create-time now agree on glob-vs-glob. Falls back to the prior `policy.Matches` path when patterns aren't attached (legacy callers / the `{"*"}` admin+substrate contexts / existing tests unchanged).

This also fixes the general personalization flow: cloning an agent scoped to `mcp__x__*` and authoring a skill scoped to `mcp__x__*`.

## Tested
- `TestSkillTool_GlobSkillCoveredByAgentGlobPattern` — glob skill loads for a glob agent (raw pattern attached, `AgentTools` = resolved concretes). Fails on the unfixed code.
- `TestSkillTool_GlobSkillRefusedByNarrowerAgentPattern` — strict rule still holds (narrower agent pattern refuses a broader skill glob).
- Existing `GlobCoversSkillLiteral` / `RefusesBroaderGlob` / `EmptyToolsAlwaysAllowed` preserved via the fallback path.
- `internal/tools/...` + `internal/api/http` green; full `go test ./...` clean; gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)