### PR TITLE
feat: interactive (resident) sub-agents — Agent open/send/close (RFC BK P1)

### DIFF
--- a/bundles/sandbox/loomcycle.yaml
+++ b/bundles/sandbox/loomcycle.yaml
@@ -146,9 +146,26 @@ skills:
 
       It opens a session, iterates, closes it, and returns the result.
 
-      ## Multi-step session (drive it command by command)
-      When you want to inspect each result and decide the next command, keep ONE
-      container alive across spawns by sharing its session_id:
+      ## Resident session (preferred for interactive, multi-step work)
+      When you'll drive several commands and inspect each result, keep dev/sandbox
+      RESIDENT with the Agent open/send/close ops. The child stays alive between your
+      instructions — its container stays warm and it remembers the conversation, so you
+      never re-thread a session_id:
+
+      1. Open — it runs the first command and parks, holding its container:
+         Agent {op:"open", name:"dev/sandbox",
+                prompt:"Open a sandbox session, keep it open, run: <command>, and report the output."}
+         → capture child_run_id from the returned envelope.
+      2. Each next step — no session_id to pass; it sees its whole prior conversation:
+         Agent {op:"send", child_run_id:"<child_run_id>", prompt:"Now run: <command>."}
+      3. When finished — close it (frees the container):
+         Agent {op:"close", child_run_id:"<child_run_id>"}
+
+      Full lifecycle: Context op=help topic=resident-sub-agents.
+
+      ## Multi-step session without resident ops (fallback)
+      If you can't use open/send/close, you can still keep ONE container alive across
+      plain spawns by sharing its session_id (fragile — you must carry the id yourself):
 
       1. Open + first command — tell it to KEEP the session open and report the id:
          Agent {op:"spawn", name:"dev/sandbox",

--- a/cmd/loomcycle/embedded/bundles/sandbox.yaml
+++ b/cmd/loomcycle/embedded/bundles/sandbox.yaml
@@ -146,9 +146,26 @@ skills:
 
       It opens a session, iterates, closes it, and returns the result.
 
-      ## Multi-step session (drive it command by command)
-      When you want to inspect each result and decide the next command, keep ONE
-      container alive across spawns by sharing its session_id:
+      ## Resident session (preferred for interactive, multi-step work)
+      When you'll drive several commands and inspect each result, keep dev/sandbox
+      RESIDENT with the Agent open/send/close ops. The child stays alive between your
+      instructions — its container stays warm and it remembers the conversation, so you
+      never re-thread a session_id:
+
+      1. Open — it runs the first command and parks, holding its container:
+         Agent {op:"open", name:"dev/sandbox",
+                prompt:"Open a sandbox session, keep it open, run: <command>, and report the output."}
+         → capture child_run_id from the returned envelope.
+      2. Each next step — no session_id to pass; it sees its whole prior conversation:
+         Agent {op:"send", child_run_id:"<child_run_id>", prompt:"Now run: <command>."}
+      3. When finished — close it (frees the container):
+         Agent {op:"close", child_run_id:"<child_run_id>"}
+
+      Full lifecycle: Context op=help topic=resident-sub-agents.
+
+      ## Multi-step session without resident ops (fallback)
+      If you can't use open/send/close, you can still keep ONE container alive across
+      plain spawns by sharing its session_id (fragile — you must carry the id yourself):
 
       1. Open + first command — tell it to KEEP the session open and report the id:
          Agent {op:"spawn", name:"dev/sandbox",

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -2648,6 +2648,9 @@ func main() {
 		sessionGCMaxIdle = 10 * time.Minute
 	}
 	go srv.RunSessionLockGC(bgCtx, sessionGCInterval, sessionGCMaxIdle)
+	// RFC BK: idle-reap resident interactive sub-agents (per-replica; in-process
+	// registry, no cluster coordination needed).
+	go srv.RunResidentSweeper(bgCtx)
 
 	// v0.8.15: LoomCycle MCP — when launched via `loomcycle mcp --config Y`,
 	// expose the runtime as an MCP server over stdio alongside the HTTP

--- a/internal/api/http/resident.go
+++ b/internal/api/http/resident.go
@@ -1,0 +1,343 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/loop"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/steer"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// --- RFC BK: resident (interactive) sub-agents ---
+//
+// A resident child is a PERSISTENT interactive sub-run a parent drives via the
+// Agent tool's open/send/close ops. Unlike a spawn (fire-and-return), the child
+// stays resident between sends — its loop goroutine parks at awaiting_input, so
+// anything it holds (a warm sandbox container, a REPL, working memory) survives
+// from one send to the next. Each send blocks until the child re-parks.
+//
+// P1 is single-replica: the registry is in-process. A child is addressable only
+// within its opener's tenant. The provider slot is held for the child's life
+// (bounded by the per-run cap; a same-provider child gets the RFC BF ancestor
+// carve-out so it pins nothing). Prompt sandbox-container teardown on close is a
+// follow-up — on close/idle the container idle-reaps on the sidecar's own TTL.
+
+const (
+	defaultMaxResidentChildren    = 8
+	defaultResidentChildIdleTTLMs = 30 * 60 * 1000 // 30 min
+	residentSweepInterval         = 60 * time.Second
+)
+
+// residentChild is a live handle to one resident interactive sub-agent.
+type residentChild struct {
+	runID         string
+	agentID       string // cancel-registry key (close/idle cancel by agent_id)
+	parentAgentID string // the opener's agent id (parent-teardown backstop)
+	tenantID      string // ownership: send/close must come from this tenant
+	userID        string
+	cancel        context.CancelCauseFunc // direct fallback if the registry entry is gone
+	idleTTL       time.Duration
+
+	mu         sync.Mutex
+	buf        strings.Builder // assistant text accumulated for the CURRENT turn
+	state      string          // "awaiting_input" | "completed" | "failed"
+	turnDone   chan struct{}   // closed once when the current turn parks or the run ends
+	turnClosed bool
+	lastUsed   time.Time
+	done       bool // loop goroutine exited
+}
+
+// beginTurn resets the per-turn buffer + wake channel. Called before open's
+// first turn and before every send. Returns the channel the caller waits on.
+func (rc *residentChild) beginTurn(now time.Time) <-chan struct{} {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	rc.buf.Reset()
+	rc.turnDone = make(chan struct{})
+	rc.turnClosed = false
+	rc.lastUsed = now
+	return rc.turnDone
+}
+
+func (rc *residentChild) appendText(t string) {
+	rc.mu.Lock()
+	rc.buf.WriteString(t)
+	rc.mu.Unlock()
+}
+
+// endTurn records the turn's terminal state and wakes the waiter exactly once.
+// Idempotent per turn: the park boundary (fwd) and the loop-exit both call it;
+// whichever comes first wins, the second is a no-op.
+func (rc *residentChild) endTurn(state string) {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	rc.state = state
+	if !rc.turnClosed && rc.turnDone != nil {
+		rc.turnClosed = true
+		close(rc.turnDone)
+	}
+}
+
+func (rc *residentChild) markDone(state string) {
+	rc.mu.Lock()
+	rc.done = true
+	rc.mu.Unlock()
+	rc.endTurn(state) // wake a waiter blocked on the final (non-parking) turn
+}
+
+func (rc *residentChild) readTurn() (string, string) {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	return rc.buf.String(), rc.state
+}
+
+// residentRegistry maps child run_id → residentChild (P1 in-process).
+type residentRegistry struct {
+	mu sync.Mutex
+	m  map[string]*residentChild
+}
+
+func newResidentRegistry() *residentRegistry {
+	return &residentRegistry{m: map[string]*residentChild{}}
+}
+
+func (r *residentRegistry) add(rc *residentChild) {
+	r.mu.Lock()
+	r.m[rc.runID] = rc
+	r.mu.Unlock()
+}
+
+func (r *residentRegistry) get(runID string) (*residentChild, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	rc, ok := r.m[runID]
+	return rc, ok
+}
+
+func (r *residentRegistry) remove(runID string) {
+	r.mu.Lock()
+	delete(r.m, runID)
+	r.mu.Unlock()
+}
+
+func (r *residentRegistry) countByParent(parentAgentID string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	n := 0
+	for _, rc := range r.m {
+		if rc.parentAgentID == parentAgentID {
+			n++
+		}
+	}
+	return n
+}
+
+func (r *residentRegistry) snapshot() []*residentChild {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]*residentChild, 0, len(r.m))
+	for _, rc := range r.m {
+		out = append(out, rc)
+	}
+	return out
+}
+
+// maxResidentChildren / residentChildIdleTTL read the operator knobs with
+// defaults. (Env is parsed into cfg.Env at config load — see config additions.)
+func (s *Server) maxResidentChildren() int {
+	if s.cfg != nil && s.cfg.Env.MaxInteractiveChildren > 0 {
+		return s.cfg.Env.MaxInteractiveChildren
+	}
+	return defaultMaxResidentChildren
+}
+
+func (s *Server) residentChildIdleTTL() time.Duration {
+	if s.cfg != nil && s.cfg.Env.InteractiveChildIdleTTLMs > 0 {
+		return time.Duration(s.cfg.Env.InteractiveChildIdleTTLMs) * time.Millisecond
+	}
+	return time.Duration(defaultResidentChildIdleTTLMs) * time.Millisecond
+}
+
+// openResidentChild starts a resident interactive sub-run, runs its first turn,
+// parks it at awaiting_input, and returns (childRunID, firstOutput, state).
+func (s *Server) openResidentChild(ctx context.Context, name, prompt, defID string, idleTTLSeconds int) (string, string, string, error) {
+	if s.residentReg == nil {
+		return "", "", "", fmt.Errorf("resident sub-agents are not enabled on this runtime")
+	}
+	parent := tools.RunIdentity(ctx)
+	if cap := s.maxResidentChildren(); s.residentReg.countByParent(parent.AgentID) >= cap {
+		return "", "", "", fmt.Errorf("resident sub-agent cap reached (%d open for this run); close one before opening another", cap)
+	}
+
+	rc := &residentChild{parentAgentID: parent.AgentID, idleTTL: s.residentChildIdleTTL()}
+	if idleTTLSeconds > 0 {
+		rc.idleTTL = time.Duration(idleTTLSeconds) * time.Second
+	}
+	// Capturing emit: accumulate the child's assistant text for the current turn;
+	// the awaiting_input boundary ends the turn and wakes the waiter.
+	fwd := func(ev providers.Event) {
+		switch ev.Type {
+		case providers.EventText:
+			rc.appendText(ev.Text)
+		case providers.EventAwaitingInput:
+			rc.endTurn("awaiting_input")
+		}
+	}
+	// The child must SURVIVE this tool call returning → detach its ctx from the
+	// parent request's cancellation (keep values) before prepareSubRun wraps it
+	// in its own cancel scope (fired by close / idle-reap / parent teardown).
+	prep, err := s.prepareSubRun(context.WithoutCancel(ctx), name, prompt, defID, true, fwd)
+	if err != nil {
+		return "", "", "", err
+	}
+	rc.runID = prep.RunID
+	rc.agentID = prep.AgentID
+	rc.tenantID = prep.TenantID
+	rc.userID = prep.UserID
+	rc.cancel = prep.CancelFn
+
+	steerQ, onSteer, deregSteer := s.makeSteer(prep.SteerCtx, prep.RunID, prep.AgentID, prep.SessionID, prep.UserID, prep.Emit)
+	prep.Opts.Interactive = true
+	prep.Opts.SteerQueue = steerQ
+	prep.Opts.OnSteer = onSteer
+	prep.Opts.ArmTurnCancel = s.armTurnCancel(prep.RunID)
+
+	turnDone := rc.beginTurn(time.Now())
+	s.residentReg.add(rc)
+
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Printf("resident child %s panicked: %v", prep.RunID, r)
+				rc.markDone("failed")
+			}
+			deregSteer()
+			prep.cleanup()
+			prep.Slot.releaseCurrent()
+			s.residentReg.remove(prep.RunID)
+		}()
+		res, runErr := loop.Run(prep.LoopCtx, prep.Opts)
+		st := "completed"
+		if runErr != nil {
+			st = "failed"
+			prep.Emit(providers.Event{Type: providers.EventError, Error: runErr.Error()})
+		}
+		s.finishRunWithCancel(context.WithoutCancel(prep.SteerCtx), prep.SteerCtx, prep.RunID, res, runErr, prep.Meta)
+		rc.markDone(st)
+	}()
+
+	out, state, aerr := waitResidentTurn(ctx, rc, turnDone)
+	return prep.RunID, out, state, aerr
+}
+
+// sendResidentChild injects the next instruction into a resident child and
+// blocks until it re-parks (or terminates), returning that turn's output.
+func (s *Server) sendResidentChild(ctx context.Context, childRunID, prompt string) (string, string, error) {
+	rc, ok := s.lookupOwnedResident(ctx, childRunID)
+	if !ok {
+		return "", "", fmt.Errorf("resident sub-agent %q not found (it may have been closed or timed out)", childRunID)
+	}
+	turnDone := rc.beginTurn(time.Now())
+	if _, err := s.steerReg.Push(ctx, childRunID, steer.Message{Text: prompt, Source: "agent", EnqueuedAt: time.Now()}); err != nil {
+		return "", "", fmt.Errorf("steer resident sub-agent %q: %w", childRunID, err)
+	}
+	out, state, aerr := waitResidentTurn(ctx, rc, turnDone)
+	return out, state, aerr
+}
+
+// closeResidentChild finalizes a resident child (idempotent). Cancelling the
+// child's loop ctx terminates it and fires its goroutine teardown.
+func (s *Server) closeResidentChild(ctx context.Context, childRunID string) error {
+	rc, ok := s.lookupOwnedResident(ctx, childRunID)
+	if !ok {
+		return nil // idempotent: already gone (or not ours → opaque)
+	}
+	if _, found := s.cancelReg.Cancel(rc.agentID, "closed by parent (resident sub-agent)"); !found && rc.cancel != nil {
+		rc.cancel(fmt.Errorf("closed by parent"))
+	}
+	return nil
+}
+
+// lookupOwnedResident resolves a child by run_id and enforces tenant ownership
+// (a cross-tenant caller gets a not-found, never another tenant's child).
+func (s *Server) lookupOwnedResident(ctx context.Context, childRunID string) (*residentChild, bool) {
+	if s.residentReg == nil {
+		return nil, false
+	}
+	rc, ok := s.residentReg.get(childRunID)
+	if !ok {
+		return nil, false
+	}
+	if rc.tenantID != tools.RunIdentity(ctx).TenantID {
+		return nil, false
+	}
+	return rc, true
+}
+
+// waitResidentTurn blocks until the child finishes its current turn (parks or
+// terminates) or the caller's ctx is cancelled.
+func waitResidentTurn(ctx context.Context, rc *residentChild, turnDone <-chan struct{}) (string, string, error) {
+	select {
+	case <-turnDone:
+		out, st := rc.readTurn()
+		return out, st, nil
+	case <-ctx.Done():
+		// The caller went away; the child keeps running (re-addressable by a
+		// later send, or reaped on parent teardown / idle).
+		return "", "interrupted", ctx.Err()
+	}
+}
+
+// closeResidentChildrenOf cancels every resident child opened by parentAgentID —
+// the parent-teardown backstop (a parent that completes/errors without closing
+// its children). Called from finishRunWithCancel. Cheap when there are none.
+func (s *Server) closeResidentChildrenOf(parentAgentID string) {
+	if s.residentReg == nil || parentAgentID == "" {
+		return
+	}
+	for _, rc := range s.residentReg.snapshot() {
+		if rc.parentAgentID != parentAgentID {
+			continue
+		}
+		if _, found := s.cancelReg.Cancel(rc.agentID, "parent run ended (resident sub-agent)"); !found && rc.cancel != nil {
+			rc.cancel(fmt.Errorf("parent run ended"))
+		}
+	}
+}
+
+// RunResidentSweeper idle-reaps resident children (per-replica; the registry is
+// in-process, so no cluster coordination). Started once at boot (main.go, with
+// the shutdown ctx). Exported so package main can launch it.
+func (s *Server) RunResidentSweeper(ctx context.Context) {
+	if s.residentReg == nil {
+		return
+	}
+	t := time.NewTicker(residentSweepInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-t.C:
+			for _, rc := range s.residentReg.snapshot() {
+				rc.mu.Lock()
+				idle := now.Sub(rc.lastUsed) > rc.idleTTL
+				done := rc.done
+				rc.mu.Unlock()
+				if done || !idle {
+					continue
+				}
+				log.Printf("resident child %s idle-reaped after %s", rc.runID, rc.idleTTL)
+				if _, found := s.cancelReg.Cancel(rc.agentID, "idle timeout (resident sub-agent)"); !found && rc.cancel != nil {
+					rc.cancel(fmt.Errorf("idle timeout"))
+				}
+			}
+		}
+	}
+}

--- a/internal/api/http/resident.go
+++ b/internal/api/http/resident.go
@@ -167,7 +167,9 @@ func (s *Server) residentChildIdleTTL() time.Duration {
 // openResidentChild starts a resident interactive sub-run, runs its first turn,
 // parks it at awaiting_input, and returns (childRunID, firstOutput, state).
 func (s *Server) openResidentChild(ctx context.Context, name, prompt, defID string, idleTTLSeconds int) (string, string, string, error) {
-	if s.residentReg == nil {
+	if s.residentReg == nil || s.steerReg == nil {
+		// A resident child parks on its steer queue between turns; without the
+		// steer registry it could not park (nor could send reach it).
 		return "", "", "", fmt.Errorf("resident sub-agents are not enabled on this runtime")
 	}
 	parent := tools.RunIdentity(ctx)
@@ -325,19 +327,29 @@ func (s *Server) RunResidentSweeper(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case now := <-t.C:
-			for _, rc := range s.residentReg.snapshot() {
-				rc.mu.Lock()
-				idle := now.Sub(rc.lastUsed) > rc.idleTTL
-				done := rc.done
-				rc.mu.Unlock()
-				if done || !idle {
-					continue
-				}
-				log.Printf("resident child %s idle-reaped after %s", rc.runID, rc.idleTTL)
-				if _, found := s.cancelReg.Cancel(rc.agentID, "idle timeout (resident sub-agent)"); !found && rc.cancel != nil {
-					rc.cancel(fmt.Errorf("idle timeout"))
-				}
-			}
+			s.sweepResidentChildren(now)
+		}
+	}
+}
+
+// sweepResidentChildren cancels every resident child idle past its TTL (the
+// per-tick body of RunResidentSweeper; separated so tests can drive one sweep
+// without wall-clock waiting).
+func (s *Server) sweepResidentChildren(now time.Time) {
+	if s.residentReg == nil {
+		return
+	}
+	for _, rc := range s.residentReg.snapshot() {
+		rc.mu.Lock()
+		idle := now.Sub(rc.lastUsed) > rc.idleTTL
+		done := rc.done
+		rc.mu.Unlock()
+		if done || !idle {
+			continue
+		}
+		log.Printf("resident child %s idle-reaped after %s", rc.runID, rc.idleTTL)
+		if _, found := s.cancelReg.Cancel(rc.agentID, "idle timeout (resident sub-agent)"); !found && rc.cancel != nil {
+			rc.cancel(fmt.Errorf("idle timeout"))
 		}
 	}
 }

--- a/internal/api/http/resident_test.go
+++ b/internal/api/http/resident_test.go
@@ -1,0 +1,184 @@
+package http
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/steer"
+	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// newResidentTestServer builds a server whose stub provider parks an interactive
+// run after every turn (text "ok" → end_turn), with the steer registry wired so
+// a resident child can park + be steered. The provider replays its events on
+// each Call, so open + N sends all park cleanly.
+func newResidentTestServer(t *testing.T) *Server {
+	t.Helper()
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "stub", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			"child": {Model: "stub-model", SystemPrompt: "be brief"},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 8, MaxQueueDepth: 8, QueueTimeoutMS: 1000},
+	}
+	cfg.Env.AuthToken = ""
+	provider := &stubProvider{events: []providers.Event{
+		{Type: providers.EventText, Text: "ok"},
+		{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 1, OutputTokens: 1}},
+	}}
+	sem := concurrency.New(8, 8, 100*time.Millisecond)
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "resident.db"))
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	srv := New(cfg, &stubResolver{p: provider}, []tools.Tool{}, sem, st)
+	srv.SetSteerRegistry(steer.NewRegistry(0))
+	return srv
+}
+
+func residentParentCtx(agentID, tenant string) context.Context {
+	return tools.WithRunIdentity(context.Background(), tools.RunIdentityValue{
+		AgentID: agentID, TenantID: tenant,
+	})
+}
+
+// waitResidentGone polls until the child is removed from the resident registry
+// (its loop goroutine ran its teardown after a cancel).
+func waitResidentGone(t *testing.T, srv *Server, runID string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, ok := srv.residentReg.get(runID); !ok {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("resident child %s was not reaped within the deadline", runID)
+}
+
+// TestResidentChild_OpenSendClose is the core RFC BK loop: open parks the child
+// (state awaiting_input, first output captured), send resumes it for another
+// turn, close reaps it — and a closed child is gone (send errors, re-close is a
+// no-op). Everything below is real (prepareSubRun → loop → steer → park); only
+// the provider is stubbed.
+func TestResidentChild_OpenSendClose(t *testing.T) {
+	srv := newResidentTestServer(t)
+	ctx := residentParentCtx("parent-agent", "")
+
+	runID, out, state, err := srv.openResidentChild(ctx, "child", "start", "", 0)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if runID == "" || state != "awaiting_input" || !strings.Contains(out, "ok") {
+		t.Fatalf("open result: runID=%q state=%q out=%q", runID, state, out)
+	}
+	if n := srv.residentReg.countByParent("parent-agent"); n != 1 {
+		t.Fatalf("expected 1 resident child, got %d", n)
+	}
+
+	out2, state2, err := srv.sendResidentChild(ctx, runID, "again")
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if state2 != "awaiting_input" || !strings.Contains(out2, "ok") {
+		t.Fatalf("send result: state=%q out=%q", state2, out2)
+	}
+
+	if err := srv.closeResidentChild(ctx, runID); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	waitResidentGone(t, srv, runID)
+
+	// Idempotent: closing an already-gone child is not an error.
+	if err := srv.closeResidentChild(ctx, runID); err != nil {
+		t.Errorf("second close should be a no-op, got %v", err)
+	}
+	// Sending to a gone child errors (not found).
+	if _, _, err := srv.sendResidentChild(ctx, runID, "x"); err == nil {
+		t.Error("send to a closed child should error")
+	}
+}
+
+// TestResidentChild_PerRunCapErrors asserts op=open errors (not queues) once the
+// opener holds the configured maximum resident children.
+func TestResidentChild_PerRunCapErrors(t *testing.T) {
+	srv := newResidentTestServer(t)
+	srv.cfg.Env.MaxInteractiveChildren = 1
+	ctx := residentParentCtx("parent-agent", "")
+
+	runID, _, _, err := srv.openResidentChild(ctx, "child", "one", "", 0)
+	if err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+	defer func() { _ = srv.closeResidentChild(ctx, runID) }()
+
+	_, _, _, err = srv.openResidentChild(ctx, "child", "two", "", 0)
+	if err == nil {
+		t.Fatal("second open should hit the per-run cap")
+	}
+	if !strings.Contains(err.Error(), "cap reached") {
+		t.Errorf("unexpected cap error: %v", err)
+	}
+}
+
+// TestResidentChild_TenantIsolation asserts a child is addressable only within
+// its opener's tenant — a different tenant gets an opaque not-found on send and
+// an opaque no-op on close (which must NOT reap the owner's child).
+func TestResidentChild_TenantIsolation(t *testing.T) {
+	srv := newResidentTestServer(t)
+	owner := residentParentCtx("parent-a", "tenant-a")
+	intruder := residentParentCtx("parent-b", "tenant-b")
+
+	runID, _, _, err := srv.openResidentChild(owner, "child", "start", "", 0)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = srv.closeResidentChild(owner, runID) }()
+
+	if _, _, err := srv.sendResidentChild(intruder, runID, "x"); err == nil {
+		t.Error("cross-tenant send should be refused")
+	}
+	if err := srv.closeResidentChild(intruder, runID); err != nil {
+		t.Errorf("cross-tenant close should be an opaque no-op, got %v", err)
+	}
+	if _, ok := srv.residentReg.get(runID); !ok {
+		t.Error("cross-tenant close must NOT reap the owner's child")
+	}
+}
+
+// TestResidentChild_ParentTeardownReaps asserts the finishRunWithCancel backstop
+// closes resident children a parent opened but never closed itself.
+func TestResidentChild_ParentTeardownReaps(t *testing.T) {
+	srv := newResidentTestServer(t)
+	ctx := residentParentCtx("parent-agent", "")
+
+	runID, _, _, err := srv.openResidentChild(ctx, "child", "start", "", 0)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	srv.closeResidentChildrenOf("parent-agent") // simulate the parent run ending
+	waitResidentGone(t, srv, runID)
+}
+
+// TestResidentChild_IdleSweepReaps asserts an idle child (no send past its TTL)
+// is reaped by the sweeper.
+func TestResidentChild_IdleSweepReaps(t *testing.T) {
+	srv := newResidentTestServer(t)
+	ctx := residentParentCtx("parent-agent", "")
+
+	runID, _, _, err := srv.openResidentChild(ctx, "child", "start", "", 0)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	// One sweep far in the future → past any idle TTL → the child is reaped.
+	srv.sweepResidentChildren(time.Now().Add(24 * time.Hour))
+	waitResidentGone(t, srv, runID)
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -114,6 +114,11 @@ type Server struct {
 	// terminates). Always non-nil after New(); armed only for interactive runs.
 	turnCancelReg *turncancel.Registry
 
+	// residentReg maps a resident interactive sub-agent's run_id → its live
+	// handle (RFC BK). In-process (P1 single-replica). Non-nil after New();
+	// drives Agent op=open/send/close + the idle sweeper + parent-teardown reap.
+	residentReg *residentRegistry
+
 	// sessionLocks tracks per-session mutexes used by continuation
 	// requests (handleMessages, or handleRuns with a non-empty
 	// SessionID). A concurrent request to the same session fast-fails
@@ -485,6 +490,7 @@ func New(cfg *config.Config, pr ProviderResolver, builtinTools []tools.Tool, sem
 	} else {
 		s.contextPlugins = cp
 	}
+	s.residentReg = newResidentRegistry() // RFC BK: resident interactive sub-agents
 	s.tools = append(s.tools, &builtin.AgentTool{
 		// Run drops the run_id (the common sequential/spawn path); RunDetailed
 		// keeps it for the parallel_spawn ledger (RFC X Phase 3). Both drive
@@ -494,6 +500,11 @@ func New(cfg *config.Config, pr ProviderResolver, builtinTools []tools.Tool, sem
 			return out, err
 		},
 		RunDetailed: s.runSubAgent,
+		// RFC BK resident sub-agents: open/send/close drive a persistent
+		// interactive child (the interactive fork of runSubAgent).
+		OpenChild:   s.openResidentChild,
+		SendChild:   s.sendResidentChild,
+		CloseChild:  s.closeResidentChild,
 		SpawnLedger: cfg.Env.ResumeFanout, // RFC X Phase 3: record the spawn ledger (default off)
 		// v0.11.8 — per-agent max_concurrent_children cap for
 		// Agent.parallel_spawn. Walks the same resolver chain as
@@ -6886,6 +6897,12 @@ func (s *Server) finishRunWithCancel(ctx context.Context, runCtx context.Context
 	if meta.IsTopLevel {
 		defer s.purgeEphemeralVolumesForRun(meta.RootRunID)
 	}
+	// RFC BK: close any resident interactive sub-agents this run opened — the
+	// backstop for a parent that completes/errors without closing them itself. A
+	// parent CANCEL already cascades to them (they register with ParentAgentID);
+	// this defer covers the NORMAL-completion path the cascade misses. Fires on
+	// every terminal branch below; a no-op when the run opened none.
+	defer s.closeResidentChildrenOf(meta.AgentID)
 	if cause := context.Cause(runCtx); errors.Is(cause, cancel.ErrCancelledByAPI) {
 		// API-cancel terminal write. Reason text comes from the
 		// optional wrapper; falls back to the sentinel string.

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -5266,6 +5266,61 @@ func secretEnvValues(environ []string) map[string]string {
 // early resolution/provider error), otherwise the sub-run's id even on failure
 // so the parent's spawn ledger can re-find it. (Wired to AgentTool.Run.)
 func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, defID string) (string, string, error) {
+	prep, err := s.prepareSubRun(ctx, name, prompt, defID, false, func(providers.Event) {})
+	if err != nil {
+		return "", "", err
+	}
+	defer prep.Slot.releaseCurrent() // registered first → runs LAST (matches original)
+	defer prep.cleanup()             // registered second → runs first
+	res, runErr := loop.Run(prep.LoopCtx, prep.Opts)
+	s.finishRunWithCancel(ctx, prep.SteerCtx, prep.RunID, res, runErr, prep.Meta)
+	if runErr != nil {
+		// Wrap with session/run IDs so a developer reading parent logs
+		// can locate the sub's transcript directly. The parent agent's
+		// model sees the unwrapped error message. agent_id is the v0.4
+		// addressable handle, so include it too — the easiest hint for
+		// "GET /v1/agents/<this>" debugging.
+		return "", prep.RunID, fmt.Errorf("sub-agent %q failed (agent=%s session=%s run=%s): %w",
+			name, prep.AgentID, prep.SessionID, prep.RunID, runErr)
+	}
+	// Surface the sub agent_id to the parent agent's transcript by
+	// prefixing the tool_result text. Parent caller's model sees this
+	// and can echo it to the UI. Cheap; unblocks future "cancel only
+	// the sub" UX.
+	return formatSubAgentOutput(prep.AgentID, res.FinalText), prep.RunID, nil
+}
+
+// subRunPrep bundles a fully-prepared sub-run ready to enter loop.Run. The
+// synchronous path (runSubAgent) and the resident interactive path (RFC BK)
+// share this setup so tenant/tool-ceiling/credential/policy wiring has ONE
+// source of truth. cleanup() releases the span / pause gate / cancel-registry
+// entry / run-cancel func in the SAME order runSubAgent's defers did (LIFO of
+// their original registration), EXCLUDING the provider Slot — the caller
+// releases Slot itself (sync: defer at return; interactive: after hand-off, so
+// a parked child does not pin the provider gate).
+type subRunPrep struct {
+	AgentID   string
+	SessionID string
+	RunID     string
+	UserID    string
+	TenantID  string
+	LoopCtx   context.Context         // == s.heldSlotCtx(subCtx, Slot); pass to loop.Run
+	SteerCtx  context.Context         // subRunCtx (the WithCancelCause base); for finishRunWithCancel + makeSteer + cancel wiring
+	CancelFn  context.CancelCauseFunc // cancels the sub-run (used by RFC BK close)
+	Meta      runStateMeta
+	Emit      func(providers.Event) // the recording emit (also set as Opts.OnEvent)
+	Opts      loop.RunOptions       // fully built; interactive fields (SteerQueue/OnSteer/Interactive/ArmTurnCancel) left ZERO for the caller to set
+	Slot      *providerSlot         // acquired provider slot; caller releases
+	cleanup   func()
+}
+
+// prepareSubRun does all sub-run setup shared by the synchronous spawn path and
+// the resident interactive path. fwd is the recording emit's forward sink (the
+// sync path passes a no-op; the interactive path passes a turn-capturer).
+// interactive=true means: pass a nil provider slot to fallbackForRun (a parked
+// resident child, like a top-level interactive run, must not swap/hold the
+// provider gate across turns) — everything else is identical.
+func (s *Server) prepareSubRun(ctx context.Context, name, prompt, defID string, interactive bool, fwd func(providers.Event)) (*subRunPrep, error) {
 	// RFC N: a parent in tenant T resolves the sub-agent name within T's
 	// view (parent tenant flows via ctx RunIdentity, inherited by every
 	// sub-agent). Confirms RFC N's open-question on cross-boundary spawn:
@@ -5273,7 +5328,7 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 	// tenant's private agent by name.
 	def, ok := lookup.Agent(ctx, s.store, s.cfg, tenantFromCtx(ctx), name)
 	if !ok {
-		return "", "", fmt.Errorf("unknown sub-agent %q (not in cfg.Agents, dynamic_agents, or agent_def_active)", name)
+		return nil, fmt.Errorf("unknown sub-agent %q (not in cfg.Agents, dynamic_agents, or agent_def_active)", name)
 	}
 
 	// v0.8.5 substrate: when defID is set, overlay the named def's
@@ -5284,17 +5339,17 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 	// the operator's static agent boundary.
 	if defID != "" {
 		if s.store == nil {
-			return "", "", fmt.Errorf("Agent tool: def_id pinning requires a configured store backend")
+			return nil, fmt.Errorf("Agent tool: def_id pinning requires a configured store backend")
 		}
 		row, err := s.store.AgentDefGet(ctx, defID)
 		if err != nil {
-			return "", "", fmt.Errorf("Agent tool: def_id %q lookup failed: %w", defID, err)
+			return nil, fmt.Errorf("Agent tool: def_id %q lookup failed: %w", defID, err)
 		}
 		if row.Name != name {
-			return "", "", fmt.Errorf("Agent tool: def_id %q is for agent %q, not %q (cross-name pinning refused)", defID, row.Name, name)
+			return nil, fmt.Errorf("Agent tool: def_id %q is for agent %q, not %q (cross-name pinning refused)", defID, row.Name, name)
 		}
 		if row.Retired {
-			return "", "", fmt.Errorf("Agent tool: def_id %q is retired", defID)
+			return nil, fmt.Errorf("Agent tool: def_id %q is retired", defID)
 		}
 		def = applyAgentDefOverlay(def, row.Definition)
 	}
@@ -5315,11 +5370,11 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 	// credential-aware routing applies to the sub-run too.
 	providerID, model, effort, err := s.resolveAgentDef(ctx, def, parentIdentity.TenantID, parentIdentity.UserID, name, parentTier, parentIdentity.OperatorKeyRestricted)
 	if err != nil {
-		return "", "", fmt.Errorf("resolve sub-agent %q model: %w", name, err)
+		return nil, fmt.Errorf("resolve sub-agent %q model: %w", name, err)
 	}
 	provider, err := s.providers.Get(providerID)
 	if err != nil {
-		return "", "", fmt.Errorf("provider for sub-agent %q: %w", name, err)
+		return nil, fmt.Errorf("provider for sub-agent %q: %w", name, err)
 	}
 
 	// RFC BF P2c: gate the sub-agent on ITS resolved provider so a fan-out parent's
@@ -5333,9 +5388,22 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 	// deadlock. Uncapped ⇒ noop, zero overhead.
 	subSlot, provErr := s.acquireProviderSlot(ctx, providerID)
 	if provErr != nil {
-		return "", "", fmt.Errorf("sub-agent %q provider gate: %w", name, provErr)
+		return nil, fmt.Errorf("sub-agent %q provider gate: %w", name, provErr)
 	}
-	defer subSlot.releaseCurrent()
+	// prepOK guards the acquired-resource cleanups below. On any early-error
+	// return prepOK is still false, so each guarded defer fires — reproducing
+	// the net effect of runSubAgent's original five defers (no leaked slot /
+	// span / registry entry / cancel func). On success prepOK flips true right
+	// before the return, so NONE of the guarded defers fire: the caller owns
+	// teardown via prep.cleanup() + prep.Slot.releaseCurrent(). The provider
+	// Slot is released here ONLY on the error path — on success it is handed
+	// back in prep.Slot for the caller to release.
+	prepOK := false
+	defer func() {
+		if !prepOK {
+			subSlot.releaseCurrent()
+		}
+	}()
 
 	// Generate a fresh agent_id for the sub-run. Always generated;
 	// callers can't override (the sub is loomcycle-controlled).
@@ -5371,7 +5439,7 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 	}
 	subSessionID, subRunID, err := s.openOrCreateSessionAndRun(ctx, "", name, parentIdentity.TenantID, parentIdentity.UserID, subIdentity)
 	if err != nil {
-		return "", "", fmt.Errorf("create sub-session for %q: %w", name, err)
+		return nil, fmt.Errorf("create sub-session for %q: %w", name, err)
 	}
 
 	// RFC X Phase 3 spawn ledger: when this sub-run is a parallel_spawn child
@@ -5405,7 +5473,11 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 	// the registry entry lets the cascade walk in Cancel() find this
 	// sub explicitly (belt-and-braces against grandchild races).
 	subRunCtx, subCancelFn := context.WithCancelCause(ctx)
-	defer subCancelFn(nil)
+	defer func() {
+		if !prepOK {
+			subCancelFn(nil)
+		}
+	}()
 	regErr := s.cancelReg.Register(cancel.Entry{
 		AgentID:       subAgentID,
 		RunID:         subRunID,
@@ -5414,14 +5486,20 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 		ParentAgentID: parentIdentity.AgentID,
 		StartedAt:     time.Now(),
 	}, subCancelFn)
+	registered := false
 	if regErr != nil {
 		// A duplicate-active collision is essentially impossible here
 		// (subAgentID is freshly generated); log and continue without
 		// registering rather than fail the run for a registry hiccup.
 		log.Printf("cancel registry: sub-agent register failed (%s): %v", subAgentID, regErr)
 	} else {
-		defer s.cancelReg.Deregister(subAgentID)
+		registered = true
 	}
+	defer func() {
+		if !prepOK && registered {
+			s.cancelReg.Deregister(subAgentID)
+		}
+	}()
 	// v0.10.0 OTEL: sub-runs open their own loomcycle.run span. The
 	// span is automatically a child of the parent's
 	// loomcycle.iteration span via ctx propagation (the Agent built-in
@@ -5435,7 +5513,11 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 		UserID:        parentIdentity.UserID,
 		ParentAgentID: parentIdentity.AgentID,
 	})
-	defer subRunSpan.End()
+	defer func() {
+		if !prepOK {
+			subRunSpan.End()
+		}
+	}()
 
 	// v0.9.x: sub-agent meta for runstate.Bus. ParentAgentID lets
 	// SSE subscribers see the lineage edge.
@@ -5540,7 +5622,7 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 	// stream is fwd=no-op so sub events don't bleed into the parent's
 	// event stream. The parent observes only the wrapping
 	// tool_call/tool_result on its own stream.
-	subEmit := s.makeRecordingEmit(ctx, subRunID, subRID, subSessionID, func(providers.Event) {})
+	subEmit := s.makeRecordingEmit(ctx, subRunID, subRID, subSessionID, fwd)
 
 	// Sub-run gets ITS OWN agent tools attached to ctx — the parent's
 	// tool list does not leak to the child (and vice versa). This
@@ -5627,7 +5709,11 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 	// boundary while paused (so a fan-out tree quiesces). NOT admission-gated —
 	// it's a child of an already-admitted run, not new top-level work.
 	subGate, deregSubGate := s.newPauseGate(subRunID)
-	defer deregSubGate()
+	defer func() {
+		if !prepOK {
+			deregSubGate()
+		}
+	}()
 	// RFC X Phase 3: expose the gate so a NESTED fan-out parent (a sub-agent
 	// that itself parallel_spawns) can park mid-tool-call too.
 	subCtx = tools.WithPauseGate(subCtx, subGate)
@@ -5636,11 +5722,18 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 	// acquired above), mirroring a top-level run — so a mid-run failover to another
 	// capped provider re-gates on the new one. A carve-out (noop) subSlot never
 	// swaps (it's deliberately ungated). Sub-runs still take no GLOBAL slot.
-	fbPolicy, fbReResolve := s.fallbackForRun(tenantFromCtx(ctx), parentIdentity.UserID, name, parentTier, parentIdentity.OperatorKeyRestricted, subSlot)
+	// A resident interactive child (like a top-level interactive run) must NOT
+	// swap/hold the provider gate across parked turns, so it passes a nil slot.
+	fbSlot := subSlot
+	if interactive {
+		fbSlot = nil
+	}
+	fbPolicy, fbReResolve := s.fallbackForRun(tenantFromCtx(ctx), parentIdentity.UserID, name, parentTier, parentIdentity.OperatorKeyRestricted, fbSlot)
 	// RFC BF P2c: publish the sub-agent's provider into the ancestor-held set on
 	// its OWN loop ctx (copy-on-add) so grandchildren it spawns take the carve-out
 	// for the same provider. No-op for a carve-out/uncapped subSlot.
-	res, runErr := loop.Run(s.heldSlotCtx(subCtx, subSlot), loop.RunOptions{
+	loopCtx := s.heldSlotCtx(subCtx, subSlot)
+	opts := loop.RunOptions{
 		Provider:            provider,
 		Model:               model,
 		Tools:               subTools,
@@ -5676,23 +5769,37 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 		ReResolve:              fbReResolve,
 		Hooks:                  s.hookDispatcher,
 		MaxSameProviderRetries: s.retryAttemptsForAgent(def, parentTier),
-	})
-	s.finishRunWithCancel(ctx, subRunCtx, subRunID, res, runErr, subMeta)
-
-	if runErr != nil {
-		// Wrap with session/run IDs so a developer reading parent logs
-		// can locate the sub's transcript directly. The parent agent's
-		// model sees the unwrapped error message. agent_id is the v0.4
-		// addressable handle, so include it too — the easiest hint for
-		// "GET /v1/agents/<this>" debugging.
-		return "", subRunID, fmt.Errorf("sub-agent %q failed (agent=%s session=%s run=%s): %w",
-			name, subAgentID, subSessionID, subRunID, runErr)
 	}
-	// Surface the sub agent_id to the parent agent's transcript by
-	// prefixing the tool_result text. Parent caller's model sees this
-	// and can echo it to the UI. Cheap; unblocks future "cancel only
-	// the sub" UX.
-	return formatSubAgentOutput(subAgentID, res.FinalText), subRunID, nil
+
+	// cleanup fires the SAME releases as the guarded error-defers above, in the
+	// SAME order runSubAgent's original defers ran LIFO (deregSubGate →
+	// subRunSpan.End → cancelReg.Deregister when registered → subCancelFn). The
+	// provider Slot is EXCLUDED — the caller releases prep.Slot itself.
+	cleanup := func() {
+		deregSubGate()
+		subRunSpan.End()
+		if registered {
+			s.cancelReg.Deregister(subAgentID)
+		}
+		subCancelFn(nil)
+	}
+
+	prepOK = true
+	return &subRunPrep{
+		AgentID:   subAgentID,
+		SessionID: subSessionID,
+		RunID:     subRunID,
+		UserID:    parentIdentity.UserID,
+		TenantID:  parentIdentity.TenantID,
+		LoopCtx:   loopCtx,
+		SteerCtx:  subRunCtx,
+		CancelFn:  subCancelFn,
+		Meta:      subMeta,
+		Emit:      subEmit,
+		Opts:      opts,
+		Slot:      subSlot,
+		cleanup:   cleanup,
+	}, nil
 }
 
 // agentResponse is the JSON shape returned by GET /v1/agents/{id} and

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2167,6 +2167,14 @@ type Env struct {
 	// LOOMCYCLE_RESUME_FANOUT=1; should be on at BOTH the capturing and
 	// restoring instances for a cross-instance hand-off.
 	ResumeFanout bool
+	// MaxInteractiveChildren caps how many resident interactive sub-agents (RFC
+	// BK Agent op=open) one run may hold open at once. 0 = the code default (8).
+	// Exceeding it fails op=open (the parent must close one first).
+	MaxInteractiveChildren int
+	// InteractiveChildIdleTTLMs is the default idle-reap window for a resident
+	// interactive sub-agent — reaped after this long with no send. 0 = the code
+	// default (30 min). Per-open overridable via op=open's idle_ttl_seconds.
+	InteractiveChildIdleTTLMs int
 	// BraveAPIKey enables the WebSearch tool. Empty = WebSearch refuses
 	// every call. Lives at https://api.search.brave.com/.
 	BraveAPIKey string
@@ -3011,6 +3019,8 @@ func LoadLayers(layers ...Layer) (*Config, error) {
 		MCPAllowPrivateIPs:          getenvBool("LOOMCYCLE_MCP_ALLOW_PRIVATE_IPS", true),
 		HTTPCallerAuthoritative:     os.Getenv("LOOMCYCLE_HTTP_CALLER_AUTHORITATIVE") == "1",
 		ResumeFanout:                os.Getenv("LOOMCYCLE_RESUME_FANOUT") == "1",
+		MaxInteractiveChildren:      getenvInt("LOOMCYCLE_MAX_INTERACTIVE_CHILDREN", 0),
+		InteractiveChildIdleTTLMs:   getenvInt("LOOMCYCLE_INTERACTIVE_CHILD_IDLE_TTL_MS", 0),
 		BraveAPIKey:                 os.Getenv("BRAVE_API_KEY"),
 		SerperAPIKey:                os.Getenv("SERPER_API_KEY"),
 		ExaAPIKey:                   os.Getenv("EXA_API_KEY"),

--- a/internal/help/builtin/resident-sub-agents.md
+++ b/internal/help/builtin/resident-sub-agents.md
@@ -1,0 +1,41 @@
+---
+name: resident-sub-agents
+description: when (and how) to drive a persistent, steerable sub-agent with Agent open/send/close instead of re-spawning.
+---
+# Resident sub-agents — open / send / close
+
+Most sub-agent work is one-shot: `Agent {op:"spawn", …}` runs a child to completion and returns its text. But some helpers need to **keep state across many steps** — a warm sandbox container through a compile→test→fix loop, a REPL or debugger, a long multi-turn analysis. Re-spawning throws that state away every call and forces you to re-thread it by hand. The resident ops solve that.
+
+## The three ops
+
+- **`open`** — start a PERSISTENT child and run its first turn:
+  ```
+  Agent {op:"open", name:"dev/sandbox", prompt:"<first instruction>"}
+  → {"child_run_id":"run_…", "state":"awaiting_input", "output":"…"}
+  ```
+  Capture the `child_run_id` — it's the handle for everything after. The child then **parks**, resident, waiting for your next instruction. Its conversation and anything it holds (a sandbox container, installed deps, a build cache) stay live.
+
+- **`send`** — give the resident child its next instruction and get that turn's output:
+  ```
+  Agent {op:"send", child_run_id:"run_…", prompt:"<next instruction>"}
+  → {"child_run_id":"run_…", "state":"awaiting_input", "output":"…"}
+  ```
+  It blocks until the child finishes the turn and re-parks. The child sees its full prior conversation — you don't restate context.
+
+- **`close`** — shut the child down and free its resources:
+  ```
+  Agent {op:"close", child_run_id:"run_…"}
+  ```
+  Idempotent. **Always close a child you opened** once you're done with it.
+
+## When to use resident vs spawn
+
+- **Use `spawn` / `parallel_spawn`** when you can describe the whole job up front, or when N independent specialists run at once. The child is stateless and returns once.
+- **Use `open` / `send` / `close`** when you'll inspect each result and decide the next step, and the child must stay stateful between steps. A compile→test→fix loop against one warm sandbox container is the canonical case: `open` (write + build), `send` ("now run the tests"), `send` ("fix line 42 and re-run") — the container stays hot the whole time; no re-spawn, no session_id to carry.
+
+## Rules & limits
+
+- **You own the lifecycle.** The child stays alive until you `close` it, or it is idle-reaped after a period with no `send` (operator-configured; override per child with `open`'s `idle_ttl_seconds`), or the run that opened it ends.
+- **Bounded.** A run may hold only so many resident children at once (operator cap); exceeding it fails `open` — close one first.
+- **`state`** tells you where the child is: `awaiting_input` (parked, ready for the next `send`), `completed`/`failed` (the child ended — a further `send` will fail), `closed`.
+- **Container caveat:** a resident child keeps its sandbox container warm between closely-spaced sends, but the container has its own idle timeout on the sandbox side — a very long pause (e.g. waiting on a human across many minutes) can still reap it. For a genuinely long-lived workspace, ask the child to use a durable workspace.

--- a/internal/tools/builtin/agent.go
+++ b/internal/tools/builtin/agent.go
@@ -334,7 +334,7 @@ const agentInputSchema = `{
 const agentDescription = `Spawn or drive named sub-agents, each with its own tool allowlist (your tool set does not transfer). ` +
 	`Stateless ops: 'spawn' (default; one child, return its final text) and 'parallel_spawn' (N children concurrently, JSON envelope with per-child ok/output/error) — best when you describe the whole task up front. ` +
 	`Resident ops (stateful): 'open' starts a persistent sub-agent and returns a child_run_id, 'send' gives it the next instruction and returns that turn's output, 'close' shuts it down. Use these when the child must keep state between steps — a warm sandbox container, a REPL, a multi-turn analysis — instead of re-spawning and re-threading state by hand. Close what you open. ` +
-	`See Context.help(topic="fan-out-patterns") for spawn vs parallel_spawn vs Channel.publish.`
+	`See Context.help(topic="fan-out-patterns") for spawn vs parallel_spawn vs Channel.publish, and Context.help(topic="resident-sub-agents") for the open/send/close lifecycle.`
 
 // Name implements tools.Tool.
 func (a *AgentTool) Name() string { return "Agent" }

--- a/internal/tools/builtin/agent.go
+++ b/internal/tools/builtin/agent.go
@@ -44,6 +44,31 @@ type SubAgentRunner func(ctx context.Context, name string, prompt string, defID 
 // callers + tests are unaffected.
 type SubAgentRunnerDetailed func(ctx context.Context, name string, prompt string, defID string) (output string, runID string, err error)
 
+// OpenChildRunner starts a PERSISTENT interactive sub-run (RFC BK), runs its
+// first turn, parks it at awaiting_input, and returns the child's run id, the
+// first turn's assistant output, and the child's state ("awaiting_input" when
+// parked, "completed"/"failed" if the first turn already ended the run). The
+// child stays RESIDENT — reachable via SendChildRunner / CloseChildRunner —
+// until it is closed, idle-reaped, or its parent run's tree tears down. Unlike
+// SubAgentRunner (fire-and-return), the child keeps its conversation + any
+// resources it holds (e.g. a warm sandbox container) between sends.
+//
+// idleTTLSeconds overrides the operator-default idle reap window for THIS child
+// (0 = use the default). The parent owns the child's lifecycle.
+type OpenChildRunner func(ctx context.Context, name, prompt, defID string, idleTTLSeconds int) (childRunID, output, state string, err error)
+
+// SendChildRunner injects the next instruction into a resident child (RFC BK)
+// and BLOCKS until the child re-parks at awaiting_input (or terminates),
+// returning that turn's assistant output + the child's resulting state. The
+// caller must own the child (same run tree / tenant); an unknown or unowned
+// child_run_id is an error.
+type SendChildRunner func(ctx context.Context, childRunID, prompt string) (output, state string, err error)
+
+// CloseChildRunner finalizes a resident child (RFC BK), firing its teardown
+// (e.g. sandbox_close_run). Idempotent — closing an already-gone child is not an
+// error. The caller must own the child.
+type CloseChildRunner func(ctx context.Context, childRunID string) (err error)
+
 // MaxConcurrentChildrenLookup resolves the per-agent
 // `max_concurrent_children` cap for the named CALLING agent (the
 // parent that is invoking Agent.parallel_spawn). Returns 0 when the
@@ -162,6 +187,14 @@ type AgentTool struct {
 	// `max_concurrent_children` override. nil = always use
 	// DefaultMaxConcurrentChildren. Wired by the HTTP server at boot.
 	CapLookup MaxConcurrentChildrenLookup
+
+	// OpenChild / SendChild / CloseChild wire the RFC BK resident-child ops
+	// (open/send/close). nil = the op is unavailable (the tool refuses with a
+	// clear "not wired" message), so a runtime without interactive sub-agents
+	// stays byte-identical for spawn/parallel_spawn. Set by the HTTP server.
+	OpenChild  OpenChildRunner
+	SendChild  SendChildRunner
+	CloseChild CloseChildRunner
 }
 
 // runChild drives one sub-agent, preferring RunDetailed (surfaces the child
@@ -192,6 +225,12 @@ type agentInput struct {
 
 	// Parallel-spawn fields (op="parallel_spawn").
 	Spawns []parallelSpawnEntry `json:"spawns,omitempty"`
+
+	// Resident-child fields (RFC BK). op="open" reuses Name/Prompt/DefID and
+	// optionally IdleTTLSeconds; op="send" uses ChildRunID + Prompt; op="close"
+	// uses ChildRunID.
+	ChildRunID     string `json:"child_run_id,omitempty"`
+	IdleTTLSeconds int    `json:"idle_ttl_seconds,omitempty"`
 }
 
 // parallelSpawnEntry is one row in a parallel_spawn `spawns` array.
@@ -260,15 +299,42 @@ const agentInputSchema = `{
         }
       },
       "required": ["op", "spawns"]
+    },
+    {
+      "title": "open — start a resident, steerable sub-agent",
+      "properties": {
+        "op":     {"type": "string", "enum": ["open"], "description": "Start a PERSISTENT sub-agent you can steer over multiple turns. Returns {child_run_id, state, output}. The child keeps its conversation AND any resources it holds (e.g. a warm sandbox container) between sends — use this instead of re-spawning when the child must stay stateful."},
+        "name":   {"type": "string", "description": "Sub-agent name. Must match a key in the loomcycle.yaml agents map."},
+        "prompt": {"type": "string", "description": "The first instruction for the child. It runs one turn, then parks awaiting your next send."},
+        "def_id": {"type": "string", "description": "Optional. Pin this child to a specific agent_defs row id."},
+        "idle_ttl_seconds": {"type": "integer", "description": "Optional. Reap the child after this many seconds with no send (0 = operator default). You own the child's lifecycle — close it when done."}
+      },
+      "required": ["op", "name", "prompt"]
+    },
+    {
+      "title": "send — give a resident sub-agent its next instruction",
+      "properties": {
+        "op":           {"type": "string", "enum": ["send"], "description": "Steer a resident child's next turn. Blocks until the child finishes the turn and returns its output."},
+        "child_run_id": {"type": "string", "description": "The child_run_id returned by op=open."},
+        "prompt":       {"type": "string", "description": "The next instruction for the child. It sees its full prior conversation."}
+      },
+      "required": ["op", "child_run_id", "prompt"]
+    },
+    {
+      "title": "close — shut down a resident sub-agent",
+      "properties": {
+        "op":           {"type": "string", "enum": ["close"], "description": "Finalize a resident child and free its resources (idempotent). Always close a child you opened once you're done with it."},
+        "child_run_id": {"type": "string", "description": "The child_run_id to close."}
+      },
+      "required": ["op", "child_run_id"]
     }
   ]
 }`
 
-const agentDescription = `Spawn named sub-agents in fresh sessions and return their final outputs. ` +
-	`Two ops: 'spawn' (default; one child, return its text) and 'parallel_spawn' (N children concurrently, return JSON envelope with per-child ok/output/error). ` +
-	`Each sub-agent has its own tool allowlist (from loomcycle.yaml); your tool set does not transfer. ` +
-	`Use 'spawn' when you need the child's output before deciding the next step; use 'parallel_spawn' when N independent specialists can run at once and you'll consolidate after all return. ` +
-	`See Context.help(topic="fan-out-patterns") for guidance on parallel_spawn vs sequential spawn vs Channel.publish.`
+const agentDescription = `Spawn or drive named sub-agents, each with its own tool allowlist (your tool set does not transfer). ` +
+	`Stateless ops: 'spawn' (default; one child, return its final text) and 'parallel_spawn' (N children concurrently, JSON envelope with per-child ok/output/error) — best when you describe the whole task up front. ` +
+	`Resident ops (stateful): 'open' starts a persistent sub-agent and returns a child_run_id, 'send' gives it the next instruction and returns that turn's output, 'close' shuts it down. Use these when the child must keep state between steps — a warm sandbox container, a REPL, a multi-turn analysis — instead of re-spawning and re-threading state by hand. Close what you open. ` +
+	`See Context.help(topic="fan-out-patterns") for spawn vs parallel_spawn vs Channel.publish.`
 
 // Name implements tools.Tool.
 func (a *AgentTool) Name() string { return "Agent" }
@@ -300,8 +366,14 @@ func (a *AgentTool) Execute(ctx context.Context, input json.RawMessage) (tools.R
 		return a.executeSpawn(ctx, in)
 	case "parallel_spawn":
 		return a.executeParallelSpawn(ctx, in)
+	case "open":
+		return a.executeOpen(ctx, in)
+	case "send":
+		return a.executeSend(ctx, in)
+	case "close":
+		return a.executeClose(ctx, in)
 	default:
-		return tools.Result{IsError: true, Text: fmt.Sprintf("unknown op %q (expected 'spawn' or 'parallel_spawn')", in.Op)}, nil
+		return tools.Result{IsError: true, Text: fmt.Sprintf("unknown op %q (expected 'spawn', 'parallel_spawn', 'open', 'send', or 'close')", in.Op)}, nil
 	}
 }
 
@@ -550,6 +622,98 @@ func (a *AgentTool) executeParallelSpawn(ctx context.Context, in agentInput) (to
 		return tools.Result{IsError: true, Text: fmt.Sprintf("internal: marshal parallel_spawn envelope: %s", err)}, nil
 	}
 	return tools.Result{Text: string(body)}, nil
+}
+
+// residentChildResult is the JSON envelope the resident-child ops (open/send/
+// close) return. child_run_id is the handle the model reuses for send/close;
+// state tells it whether the child is still awaiting_input; output is the turn's
+// assistant text.
+type residentChildResult struct {
+	ChildRunID string `json:"child_run_id,omitempty"`
+	State      string `json:"state"`
+	Output     string `json:"output"`
+}
+
+// residentResult marshals the resident-child envelope.
+func residentResult(childRunID, state, output string) (tools.Result, error) {
+	body, err := json.Marshal(residentChildResult{ChildRunID: childRunID, State: state, Output: output})
+	if err != nil {
+		return tools.Result{IsError: true, Text: fmt.Sprintf("internal: marshal resident-child envelope: %s", err)}, nil
+	}
+	return tools.Result{Text: string(body)}, nil
+}
+
+// executeOpen (RFC BK) starts a resident interactive sub-agent, runs its first
+// turn, parks it at awaiting_input, and returns {child_run_id, state, output}.
+// The child stays alive for follow-up sends until closed / idle-reaped / the
+// parent tree tears down. A resident child counts against the recursion depth
+// exactly like a spawn — it is a sub-run one level deeper.
+func (a *AgentTool) executeOpen(ctx context.Context, in agentInput) (tools.Result, error) {
+	if a.OpenChild == nil {
+		return tools.Result{IsError: true, Text: "Agent op=open (resident sub-agent) is not available on this runtime"}, nil
+	}
+	in.Name = strings.TrimSpace(in.Name)
+	if in.Name == "" {
+		return tools.Result{IsError: true, Text: "missing required field: name"}, nil
+	}
+	if in.Prompt == "" {
+		return tools.Result{IsError: true, Text: "missing required field: prompt"}, nil
+	}
+	if in.ChildRunID != "" {
+		return tools.Result{IsError: true, Text: "op=open mints a NEW child; do not pass child_run_id (use op=send with the id op=open returns)"}, nil
+	}
+	if in.IdleTTLSeconds < 0 {
+		return tools.Result{IsError: true, Text: "idle_ttl_seconds must be >= 0 (0 = operator default)"}, nil
+	}
+	if AgentDepth(ctx) >= MaxAgentDepth {
+		return tools.Result{IsError: true, Text: fmt.Sprintf(
+			"max sub-agent recursion depth (%d) reached at agent %q; refusing to open deeper", MaxAgentDepth, in.Name)}, nil
+	}
+	subCtx := IncrementAgentDepth(ctx)
+	if !in.Compaction.IsZero() {
+		subCtx = tools.WithCompactionOverride(subCtx, in.Compaction)
+	}
+	childRunID, output, state, err := a.OpenChild(subCtx, in.Name, in.Prompt, in.DefID, in.IdleTTLSeconds)
+	if err != nil {
+		return tools.Result{IsError: true, Text: err.Error()}, nil
+	}
+	return residentResult(childRunID, state, output)
+}
+
+// executeSend (RFC BK) steers a resident child with the next instruction and
+// blocks until it re-parks (or terminates), returning that turn's output.
+func (a *AgentTool) executeSend(ctx context.Context, in agentInput) (tools.Result, error) {
+	if a.SendChild == nil {
+		return tools.Result{IsError: true, Text: "Agent op=send (resident sub-agent) is not available on this runtime"}, nil
+	}
+	in.ChildRunID = strings.TrimSpace(in.ChildRunID)
+	if in.ChildRunID == "" {
+		return tools.Result{IsError: true, Text: "missing required field: child_run_id (the id op=open returned)"}, nil
+	}
+	if in.Prompt == "" {
+		return tools.Result{IsError: true, Text: "missing required field: prompt"}, nil
+	}
+	output, state, err := a.SendChild(ctx, in.ChildRunID, in.Prompt)
+	if err != nil {
+		return tools.Result{IsError: true, Text: err.Error()}, nil
+	}
+	return residentResult(in.ChildRunID, state, output)
+}
+
+// executeClose (RFC BK) finalizes a resident child (idempotent), firing its
+// teardown so any resources it held (e.g. a sandbox container) are released.
+func (a *AgentTool) executeClose(ctx context.Context, in agentInput) (tools.Result, error) {
+	if a.CloseChild == nil {
+		return tools.Result{IsError: true, Text: "Agent op=close (resident sub-agent) is not available on this runtime"}, nil
+	}
+	in.ChildRunID = strings.TrimSpace(in.ChildRunID)
+	if in.ChildRunID == "" {
+		return tools.Result{IsError: true, Text: "missing required field: child_run_id"}, nil
+	}
+	if err := a.CloseChild(ctx, in.ChildRunID); err != nil {
+		return tools.Result{IsError: true, Text: err.Error()}, nil
+	}
+	return residentResult(in.ChildRunID, "closed", "")
 }
 
 // errAgentBadInput is reserved for future structured errors. Currently

--- a/internal/tools/builtin/agent_test.go
+++ b/internal/tools/builtin/agent_test.go
@@ -759,3 +759,177 @@ func TestAgentTool_ParallelSpawn_NoWatcherNoLedgerWhenFlagOff(t *testing.T) {
 		t.Errorf("expected no ledger events with SpawnLedger off, got %d", len(events))
 	}
 }
+
+// --- RFC BK resident sub-agent ops (open / send / close) ---
+
+// parseResident decodes the JSON envelope open/send/close return.
+func parseResident(t *testing.T, res tools.Result) residentChildResult {
+	t.Helper()
+	if res.IsError {
+		t.Fatalf("unexpected error result: %s", res.Text)
+	}
+	var out residentChildResult
+	if err := json.Unmarshal([]byte(res.Text), &out); err != nil {
+		t.Fatalf("envelope not JSON: %q (%v)", res.Text, err)
+	}
+	return out
+}
+
+func TestAgentTool_Open_HappyPath(t *testing.T) {
+	var gotName, gotPrompt, gotDef string
+	var gotTTL int
+	a := &AgentTool{
+		Run: func(context.Context, string, string, string) (string, error) { return "", nil },
+		OpenChild: func(_ context.Context, name, prompt, defID string, ttl int) (string, string, string, error) {
+			gotName, gotPrompt, gotDef, gotTTL = name, prompt, defID, ttl
+			return "run_child_1", "first turn output", "awaiting_input", nil
+		},
+	}
+	res, err := a.Execute(context.Background(),
+		json.RawMessage(`{"op":"open","name":"dev/sandbox","prompt":"build it","def_id":"def_x","idle_ttl_seconds":120}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := parseResident(t, res)
+	if env.ChildRunID != "run_child_1" || env.State != "awaiting_input" || env.Output != "first turn output" {
+		t.Errorf("envelope = %+v", env)
+	}
+	if gotName != "dev/sandbox" || gotPrompt != "build it" || gotDef != "def_x" || gotTTL != 120 {
+		t.Errorf("runner args: name=%q prompt=%q def=%q ttl=%d", gotName, gotPrompt, gotDef, gotTTL)
+	}
+}
+
+func TestAgentTool_Open_NotWired(t *testing.T) {
+	a := &AgentTool{Run: func(context.Context, string, string, string) (string, error) { return "", nil }}
+	res, _ := a.Execute(context.Background(), json.RawMessage(`{"op":"open","name":"x","prompt":"y"}`))
+	if !res.IsError || !strings.Contains(res.Text, "not available") {
+		t.Errorf("open with nil OpenChild should refuse: %+v", res)
+	}
+}
+
+func TestAgentTool_Open_MissingFields(t *testing.T) {
+	a := &AgentTool{
+		Run: func(context.Context, string, string, string) (string, error) { return "", nil },
+		OpenChild: func(context.Context, string, string, string, int) (string, string, string, error) {
+			return "", "", "", nil
+		},
+	}
+	for _, in := range []string{`{"op":"open","prompt":"y"}`, `{"op":"open","name":"x"}`} {
+		res, _ := a.Execute(context.Background(), json.RawMessage(in))
+		if !res.IsError {
+			t.Errorf("expected error for %s", in)
+		}
+	}
+}
+
+func TestAgentTool_Open_RejectsChildRunID(t *testing.T) {
+	a := &AgentTool{
+		Run: func(context.Context, string, string, string) (string, error) { return "", nil },
+		OpenChild: func(context.Context, string, string, string, int) (string, string, string, error) {
+			return "", "", "", nil
+		},
+	}
+	res, _ := a.Execute(context.Background(),
+		json.RawMessage(`{"op":"open","name":"x","prompt":"y","child_run_id":"run_1"}`))
+	if !res.IsError || !strings.Contains(res.Text, "mints a NEW child") {
+		t.Errorf("open must reject a passed child_run_id: %+v", res)
+	}
+}
+
+func TestAgentTool_Open_DepthGuard(t *testing.T) {
+	called := false
+	a := &AgentTool{
+		Run: func(context.Context, string, string, string) (string, error) { return "", nil },
+		OpenChild: func(context.Context, string, string, string, int) (string, string, string, error) {
+			called = true
+			return "", "", "", nil
+		},
+	}
+	ctx := context.Background()
+	for i := 0; i < MaxAgentDepth; i++ {
+		ctx = IncrementAgentDepth(ctx)
+	}
+	res, _ := a.Execute(ctx, json.RawMessage(`{"op":"open","name":"x","prompt":"y"}`))
+	if !res.IsError || !strings.Contains(res.Text, "recursion depth") {
+		t.Errorf("open should hit the depth guard: %+v", res)
+	}
+	if called {
+		t.Error("OpenChild must not be called past the depth cap")
+	}
+}
+
+func TestAgentTool_Send_HappyPath(t *testing.T) {
+	var gotID, gotPrompt string
+	a := &AgentTool{
+		Run: func(context.Context, string, string, string) (string, error) { return "", nil },
+		SendChild: func(_ context.Context, childRunID, prompt string) (string, string, error) {
+			gotID, gotPrompt = childRunID, prompt
+			return "turn 2 output", "awaiting_input", nil
+		},
+	}
+	res, _ := a.Execute(context.Background(),
+		json.RawMessage(`{"op":"send","child_run_id":"run_child_1","prompt":"now test it"}`))
+	env := parseResident(t, res)
+	if env.Output != "turn 2 output" || env.State != "awaiting_input" || env.ChildRunID != "run_child_1" {
+		t.Errorf("envelope = %+v", env)
+	}
+	if gotID != "run_child_1" || gotPrompt != "now test it" {
+		t.Errorf("runner args: id=%q prompt=%q", gotID, gotPrompt)
+	}
+}
+
+func TestAgentTool_Send_MissingFields(t *testing.T) {
+	a := &AgentTool{
+		Run:       func(context.Context, string, string, string) (string, error) { return "", nil },
+		SendChild: func(context.Context, string, string) (string, string, error) { return "", "", nil },
+	}
+	for _, in := range []string{`{"op":"send","prompt":"y"}`, `{"op":"send","child_run_id":"r"}`} {
+		res, _ := a.Execute(context.Background(), json.RawMessage(in))
+		if !res.IsError {
+			t.Errorf("expected error for %s", in)
+		}
+	}
+}
+
+func TestAgentTool_Send_NotWired(t *testing.T) {
+	a := &AgentTool{Run: func(context.Context, string, string, string) (string, error) { return "", nil }}
+	res, _ := a.Execute(context.Background(), json.RawMessage(`{"op":"send","child_run_id":"r","prompt":"y"}`))
+	if !res.IsError || !strings.Contains(res.Text, "not available") {
+		t.Errorf("send with nil SendChild should refuse: %+v", res)
+	}
+}
+
+func TestAgentTool_Close_HappyPath(t *testing.T) {
+	var gotID string
+	a := &AgentTool{
+		Run:        func(context.Context, string, string, string) (string, error) { return "", nil },
+		CloseChild: func(_ context.Context, childRunID string) error { gotID = childRunID; return nil },
+	}
+	res, _ := a.Execute(context.Background(), json.RawMessage(`{"op":"close","child_run_id":"run_child_1"}`))
+	env := parseResident(t, res)
+	if env.State != "closed" || env.ChildRunID != "run_child_1" {
+		t.Errorf("envelope = %+v", env)
+	}
+	if gotID != "run_child_1" {
+		t.Errorf("close arg = %q", gotID)
+	}
+}
+
+func TestAgentTool_Close_MissingChildRunID(t *testing.T) {
+	a := &AgentTool{
+		Run:        func(context.Context, string, string, string) (string, error) { return "", nil },
+		CloseChild: func(context.Context, string) error { return nil },
+	}
+	res, _ := a.Execute(context.Background(), json.RawMessage(`{"op":"close"}`))
+	if !res.IsError {
+		t.Errorf("close without child_run_id should error: %+v", res)
+	}
+}
+
+func TestAgentTool_Close_NotWired(t *testing.T) {
+	a := &AgentTool{Run: func(context.Context, string, string, string) (string, error) { return "", nil }}
+	res, _ := a.Execute(context.Background(), json.RawMessage(`{"op":"close","child_run_id":"r"}`))
+	if !res.IsError || !strings.Contains(res.Text, "not available") {
+		t.Errorf("close with nil CloseChild should refuse: %+v", res)
+	}
+}


### PR DESCRIPTION
Implements **RFC BK P1** (`/loomcycle/rfcs/interactive-sub-agents`, approved): a parent agent can drive a **persistent, steerable** sub-agent via three new `Agent` ops instead of re-spawning and re-threading state by hand. The motivating case is the `dev/sandbox` agent — a compile→test→fix loop where the container stays warm across steps.

## The ops
- **`open`** `{name, prompt, def_id?, idle_ttl_seconds?}` → starts a persistent interactive sub-run, runs its first turn, parks it at `awaiting_input`, returns `{child_run_id, state, output}`. The child stays resident.
- **`send`** `{child_run_id, prompt}` → steers the child's next turn; **blocks** until it re-parks (or terminates); returns that turn's output. The child keeps its full conversation.
- **`close`** `{child_run_id}` → finalizes the child (idempotent; cascades to grandchildren).

## Design (reuses the interactive-run engine, no new external wire)
- `open` forks `runSubAgent`'s setup via a new **`prepareSubRun`** (extracted in a separate behavior-preserving commit — one source of truth for tenant/tool-ceiling/credential/policy wiring), then runs the loop with `Interactive:true` + a steer queue in a **detached goroutine under `context.WithoutCancel`** so the child survives the parent's tool call returning.
- **Synchronous `send`** blocks on the child's own capturing emit: the resident child's `fwd` sees `EventAwaitingInput` and signals the turn boundary — **no change to the shared steer registry** (`send` only uses `steerReg.Push` to inject).
- `close` / idle-reap / parent-teardown all go through `cancelReg.Cancel(childAgentID)` → the child's park→cancel→teardown chain.

## Lifecycle / GC
Explicit `close` + an **idle TTL** (per-replica sweeper) + a **parent-teardown backstop** in `finishRunWithCancel` (a parent that ends without closing its children — the cancel cascade already covers parent *cancel*; this covers normal *completion*).

## Decisions (from the approved RFC)
- Ops `open`/`send`/`close`; **synchronous** `send`; **operator default + per-open** idle-TTL; per-run cap **errors** (not queues); **single-replica** (P1).
- Knobs: `LOOMCYCLE_MAX_INTERACTIVE_CHILDREN` (default 8), `LOOMCYCLE_INTERACTIVE_CHILD_IDLE_TTL_MS` (default 30m).
- Provider slot held for the child's life (bounded by the cap; a same-provider child takes the existing RFC BF ancestor carve-out, so it pins nothing).

## Commits
1. `feat(agent)` — parent-side ops + schema + 11 unit tests (unwired → clean refusal, so spawn/parallel_spawn stay byte-identical).
2. `refactor(api)` — extract `prepareSubRun` (behavior-preserving; existing sub-agent/provider-gate/fanout tests green).
3. `feat(api)` — `resident.go` engine + config knobs + wiring + teardown backstop + sweeper.
4. `test(api)` — 5 integration tests through the real engine.
5. `docs(agent)` — `resident-sub-agents` help topic + `dev/sandbox-usage` "prefer open/send" section (model-facing text carries no RFC references).

## Tested
- `TestAgentTool_{Open,Send,Close}_*` (parent-side); `TestResidentChild_{OpenSendClose,PerRunCapErrors,TenantIsolation,ParentTeardownReaps,IdleSweepReaps}` (engine, through the real loop/steer/park with a stubbed provider).
- **Full `go test ./...` clean; `go build ./...` OK; gofmt clean.**

## Not in P1 (deferred to P2/P3 per the RFC)
Cross-replica `send`/`close`; incremental/streamed child output; turn-cancel of a child send; prompt sandbox-container teardown on close (P1: the container idle-reaps on the sidecar's own TTL); Team Orchestrator resident helpers + Web-UI visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)