### PR TITLE
feat: bounded/interruptible resident sub-agents — send timeout, poll, cancel (RFC BK P2)

### DIFF
--- a/internal/api/http/resident.go
+++ b/internal/api/http/resident.go
@@ -32,6 +32,10 @@ const (
 	defaultMaxResidentChildren    = 8
 	defaultResidentChildIdleTTLMs = 30 * 60 * 1000 // 30 min
 	residentSweepInterval         = 60 * time.Second
+	// residentCancelReparkTimeout bounds how long op=cancel waits for the child's
+	// loop to re-park after its turn is stopped (RFC BK P2). The re-park is near-
+	// instant once the turn ctx cancels; this is only a backstop.
+	residentCancelReparkTimeout = 15 * time.Second
 )
 
 // residentChild is a live handle to one resident interactive sub-agent.
@@ -49,6 +53,7 @@ type residentChild struct {
 	state      string          // "awaiting_input" | "completed" | "failed"
 	turnDone   chan struct{}   // closed once when the current turn parks or the run ends
 	turnClosed bool
+	running    bool // a turn is in flight (between beginTurn and park/terminal) — RFC BK P2
 	lastUsed   time.Time
 	done       bool // loop goroutine exited
 }
@@ -61,6 +66,7 @@ func (rc *residentChild) beginTurn(now time.Time) <-chan struct{} {
 	rc.buf.Reset()
 	rc.turnDone = make(chan struct{})
 	rc.turnClosed = false
+	rc.running = true
 	rc.lastUsed = now
 	return rc.turnDone
 }
@@ -78,10 +84,20 @@ func (rc *residentChild) endTurn(state string) {
 	rc.mu.Lock()
 	defer rc.mu.Unlock()
 	rc.state = state
+	rc.running = false
 	if !rc.turnClosed && rc.turnDone != nil {
 		rc.turnClosed = true
 		close(rc.turnDone)
 	}
+}
+
+// currentTurnDone returns the channel the in-flight (or just-ended) turn signals
+// on, and whether a turn is currently running. Used by poll/cancel, which don't
+// start a new turn.
+func (rc *residentChild) currentTurnDone() (<-chan struct{}, bool) {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	return rc.turnDone, rc.running
 }
 
 func (rc *residentChild) markDone(state string) {
@@ -234,23 +250,71 @@ func (s *Server) openResidentChild(ctx context.Context, name, prompt, defID stri
 		rc.markDone(st)
 	}()
 
-	out, state, aerr := waitResidentTurn(ctx, rc, turnDone)
+	// open always blocks for the FIRST park (no timeout) — by the time it returns
+	// the child is parked and ready for the first send.
+	out, state, aerr := rc.awaitTurn(ctx, turnDone, 0, true)
 	return prep.RunID, out, state, aerr
 }
 
-// sendResidentChild injects the next instruction into a resident child and
-// blocks until it re-parks (or terminates), returning that turn's output.
-func (s *Server) sendResidentChild(ctx context.Context, childRunID, prompt string) (string, string, error) {
+// sendResidentChild injects the next instruction into a resident child and waits
+// for that turn (RFC BK P2: timeoutMs bounds the wait — 0 blocks until re-park,
+// >0 returns state "running" + the partial output if the turn is still going).
+func (s *Server) sendResidentChild(ctx context.Context, childRunID, prompt string, timeoutMs int) (string, string, error) {
 	rc, ok := s.lookupOwnedResident(ctx, childRunID)
 	if !ok {
 		return "", "", fmt.Errorf("resident sub-agent %q not found (it may have been closed or timed out)", childRunID)
+	}
+	// A send while the previous turn is still in flight would interleave two
+	// turns. Refuse — the parent should poll to await it, or cancel to interrupt.
+	if _, running := rc.currentTurnDone(); running {
+		return "", "", fmt.Errorf("resident sub-agent %q is still running its previous turn; poll to await it or cancel to interrupt", childRunID)
 	}
 	turnDone := rc.beginTurn(time.Now())
 	if _, err := s.steerReg.Push(ctx, childRunID, steer.Message{Text: prompt, Source: "agent", EnqueuedAt: time.Now()}); err != nil {
 		return "", "", fmt.Errorf("steer resident sub-agent %q: %w", childRunID, err)
 	}
-	out, state, aerr := waitResidentTurn(ctx, rc, turnDone)
-	return out, state, aerr
+	return rc.awaitTurn(ctx, turnDone, time.Duration(timeoutMs)*time.Millisecond, true)
+}
+
+// pollResidentChild checks a resident child without sending new input (RFC BK P2)
+// — returns its current output-so-far + state. timeoutMs=0 is a non-blocking
+// snapshot; >0 waits up to that long for the child to park.
+func (s *Server) pollResidentChild(ctx context.Context, childRunID string, timeoutMs int) (string, string, error) {
+	rc, ok := s.lookupOwnedResident(ctx, childRunID)
+	if !ok {
+		return "", "", fmt.Errorf("resident sub-agent %q not found (it may have been closed or timed out)", childRunID)
+	}
+	td, _ := rc.currentTurnDone()
+	if td == nil {
+		// No turn has ever started (shouldn't happen post-open) — report state.
+		out, st := rc.readTurn()
+		return out, st, nil
+	}
+	return rc.awaitTurn(ctx, td, time.Duration(timeoutMs)*time.Millisecond, false)
+}
+
+// cancelResidentChildTurn turn-cancels a resident child's CURRENT turn (RFC BK
+// P2): it fires the child's armed turn-cancel token so the loop stops the
+// in-flight turn and re-parks at awaiting_input — the child stays alive. The
+// child is co-located (fire the local token directly; ownership already gated by
+// lookupOwnedResident). A child that isn't mid-turn is a no-op.
+func (s *Server) cancelResidentChildTurn(ctx context.Context, childRunID string) (string, string, error) {
+	rc, ok := s.lookupOwnedResident(ctx, childRunID)
+	if !ok {
+		return "", "", fmt.Errorf("resident sub-agent %q not found (it may have been closed or timed out)", childRunID)
+	}
+	td, running := rc.currentTurnDone()
+	if !running {
+		out, st := rc.readTurn() // already parked/idle — nothing to cancel
+		return out, st, nil
+	}
+	if s.turnCancelReg == nil || !s.turnCancelReg.CancelLocal(childRunID, "cancelled by parent (resident sub-agent)") {
+		// Not armed / token vanished (the turn just ended) — treat as parked.
+		out, st := rc.readTurn()
+		return out, st, nil
+	}
+	// Wait (bounded) for the loop to re-park after the turn is stopped.
+	return rc.awaitTurn(ctx, td, residentCancelReparkTimeout, false)
 }
 
 // closeResidentChild finalizes a resident child (idempotent). Cancelling the
@@ -282,17 +346,48 @@ func (s *Server) lookupOwnedResident(ctx context.Context, childRunID string) (*r
 	return rc, true
 }
 
-// waitResidentTurn blocks until the child finishes its current turn (parks or
-// terminates) or the caller's ctx is cancelled.
-func waitResidentTurn(ctx context.Context, rc *residentChild, turnDone <-chan struct{}) (string, string, error) {
+// awaitTurn waits for the child's current turn to finish (park or terminate),
+// returning its output-so-far + state. The zero-timeout behavior differs by
+// caller (blockWhenZero): open/send block until the turn ends (P1 semantics);
+// poll takes a non-blocking snapshot. A positive timeout bounds the wait — on
+// expiry the turn is still in flight, so it returns the partial output with
+// state "running". A cancelled caller ctx returns state "interrupted" (the child
+// keeps running — re-addressable by a later send/poll, or reaped on teardown).
+func (rc *residentChild) awaitTurn(ctx context.Context, turnDone <-chan struct{}, timeout time.Duration, blockWhenZero bool) (string, string, error) {
+	if timeout <= 0 {
+		if blockWhenZero {
+			select {
+			case <-turnDone:
+				out, st := rc.readTurn()
+				return out, st, nil
+			case <-ctx.Done():
+				out, _ := rc.readTurn()
+				return out, "interrupted", ctx.Err()
+			}
+		}
+		// Non-blocking snapshot (poll): a closed turnDone (parked/ended) reports
+		// its terminal state; an open one means a turn is still in flight.
+		select {
+		case <-turnDone:
+			out, st := rc.readTurn()
+			return out, st, nil
+		default:
+			out, _ := rc.readTurn()
+			return out, "running", nil
+		}
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
 	select {
 	case <-turnDone:
 		out, st := rc.readTurn()
 		return out, st, nil
+	case <-timer.C:
+		out, _ := rc.readTurn()
+		return out, "running", nil
 	case <-ctx.Done():
-		// The caller went away; the child keeps running (re-addressable by a
-		// later send, or reaped on parent teardown / idle).
-		return "", "interrupted", ctx.Err()
+		out, _ := rc.readTurn()
+		return out, "interrupted", ctx.Err()
 	}
 }
 

--- a/internal/api/http/resident_test.go
+++ b/internal/api/http/resident_test.go
@@ -84,7 +84,7 @@ func TestResidentChild_OpenSendClose(t *testing.T) {
 		t.Fatalf("expected 1 resident child, got %d", n)
 	}
 
-	out2, state2, err := srv.sendResidentChild(ctx, runID, "again")
+	out2, state2, err := srv.sendResidentChild(ctx, runID, "again", 0)
 	if err != nil {
 		t.Fatalf("send: %v", err)
 	}
@@ -102,7 +102,7 @@ func TestResidentChild_OpenSendClose(t *testing.T) {
 		t.Errorf("second close should be a no-op, got %v", err)
 	}
 	// Sending to a gone child errors (not found).
-	if _, _, err := srv.sendResidentChild(ctx, runID, "x"); err == nil {
+	if _, _, err := srv.sendResidentChild(ctx, runID, "x", 0); err == nil {
 		t.Error("send to a closed child should error")
 	}
 }
@@ -143,7 +143,7 @@ func TestResidentChild_TenantIsolation(t *testing.T) {
 	}
 	defer func() { _ = srv.closeResidentChild(owner, runID) }()
 
-	if _, _, err := srv.sendResidentChild(intruder, runID, "x"); err == nil {
+	if _, _, err := srv.sendResidentChild(intruder, runID, "x", 0); err == nil {
 		t.Error("cross-tenant send should be refused")
 	}
 	if err := srv.closeResidentChild(intruder, runID); err != nil {
@@ -181,4 +181,130 @@ func TestResidentChild_IdleSweepReaps(t *testing.T) {
 	// One sweep far in the future → past any idle TTL → the child is reaped.
 	srv.sweepResidentChildren(time.Now().Add(24 * time.Hour))
 	waitResidentGone(t, srv, runID)
+}
+
+// gatedProvider emits a line of text, then blocks before end_turn until the test
+// releases its gate (or the turn's ctx is cancelled — RFC BH turn-cancel). Lets
+// a test hold a turn "running" to exercise send timeout_ms / poll / cancel.
+type gatedProvider struct {
+	text string
+	gate chan struct{} // one token per turn that should complete
+}
+
+func (g *gatedProvider) ID() string                    { return "stub" }
+func (g *gatedProvider) Probe(_ context.Context) error { return nil }
+func (g *gatedProvider) ListModels(_ context.Context) ([]string, error) {
+	return []string{"stub-model"}, nil
+}
+func (g *gatedProvider) Capabilities() providers.Capabilities {
+	return providers.Capabilities{Streaming: true}
+}
+func (g *gatedProvider) Call(ctx context.Context, _ providers.Request) (<-chan providers.Event, error) {
+	ch := make(chan providers.Event, 4)
+	go func() {
+		defer close(ch)
+		ch <- providers.Event{Type: providers.EventText, Text: g.text}
+		select {
+		case <-g.gate:
+			ch <- providers.Event{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 1, OutputTokens: 1}}
+		case <-ctx.Done():
+			// turn cancelled → emit nothing more; the loop re-parks the run.
+		}
+	}()
+	return ch, nil
+}
+
+// newGatedResidentServer builds a resident-capable server driven by a gated
+// provider. gate is buffered so the caller pre-fills a token for the open turn.
+func newGatedResidentServer(t *testing.T) (*Server, chan struct{}) {
+	t.Helper()
+	cfg := &config.Config{
+		Defaults:    config.Defaults{Provider: "stub", Model: "stub-model"},
+		Agents:      map[string]config.AgentDef{"child": {Model: "stub-model", SystemPrompt: "be brief"}},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 8, MaxQueueDepth: 8, QueueTimeoutMS: 1000},
+	}
+	cfg.Env.AuthToken = ""
+	gate := make(chan struct{}, 4)
+	sem := concurrency.New(8, 8, 100*time.Millisecond)
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "gated.db"))
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	srv := New(cfg, &stubResolver{p: &gatedProvider{text: "working", gate: gate}}, []tools.Tool{}, sem, st)
+	srv.SetSteerRegistry(steer.NewRegistry(0))
+	return srv, gate
+}
+
+// TestResidentChild_SendTimeoutThenPoll: a slow turn makes send return
+// state "running" + partial output; poll then awaits its completion.
+func TestResidentChild_SendTimeoutThenPoll(t *testing.T) {
+	srv, gate := newGatedResidentServer(t)
+	ctx := residentParentCtx("parent-agent", "")
+
+	gate <- struct{}{} // let the open turn complete + park
+	runID, _, state, err := srv.openResidentChild(ctx, "child", "start", "", 0)
+	if err != nil || state != "awaiting_input" {
+		t.Fatalf("open: state=%q err=%v", state, err)
+	}
+	defer func() { _ = srv.closeResidentChild(ctx, runID) }()
+
+	// send with a short timeout while the turn is gated → returns "running".
+	out, state, err := srv.sendResidentChild(ctx, runID, "do slow work", 100)
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if state != "running" {
+		t.Fatalf("expected state=running on a gated turn, got %q (out=%q)", state, out)
+	}
+	if !strings.Contains(out, "working") {
+		t.Errorf("expected partial output while running, got %q", out)
+	}
+
+	// a second send is refused while the turn is still in flight.
+	if _, _, err := srv.sendResidentChild(ctx, runID, "again", 100); err == nil {
+		t.Error("send during a running turn should be refused")
+	}
+
+	gate <- struct{}{} // release the turn
+	out, state, err = srv.pollResidentChild(ctx, runID, 2000)
+	if err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	if state != "awaiting_input" {
+		t.Fatalf("poll after release: state=%q out=%q", state, out)
+	}
+}
+
+// TestResidentChild_CancelStopsTurn: cancel turn-cancels a running turn and the
+// child re-parks (stays alive).
+func TestResidentChild_CancelStopsTurn(t *testing.T) {
+	srv, gate := newGatedResidentServer(t)
+	ctx := residentParentCtx("parent-agent", "")
+
+	gate <- struct{}{} // open turn completes + parks
+	runID, _, state, err := srv.openResidentChild(ctx, "child", "start", "", 0)
+	if err != nil || state != "awaiting_input" {
+		t.Fatalf("open: state=%q err=%v", state, err)
+	}
+	defer func() { _ = srv.closeResidentChild(ctx, runID) }()
+
+	// start a gated (never-released) turn → send times out "running".
+	_, state, err = srv.sendResidentChild(ctx, runID, "loop forever", 100)
+	if err != nil || state != "running" {
+		t.Fatalf("send: state=%q err=%v", state, err)
+	}
+
+	// cancel stops the turn and re-parks the child (alive).
+	_, state, err = srv.cancelResidentChildTurn(ctx, runID)
+	if err != nil {
+		t.Fatalf("cancel: %v", err)
+	}
+	if state != "awaiting_input" {
+		t.Fatalf("cancel should re-park the child, got state=%q", state)
+	}
+	// the child is still resident (cancel != close).
+	if _, ok := srv.residentReg.get(runID); !ok {
+		t.Error("cancel must keep the child resident")
+	}
 }

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -500,10 +500,12 @@ func New(cfg *config.Config, pr ProviderResolver, builtinTools []tools.Tool, sem
 			return out, err
 		},
 		RunDetailed: s.runSubAgent,
-		// RFC BK resident sub-agents: open/send/close drive a persistent
-		// interactive child (the interactive fork of runSubAgent).
+		// RFC BK resident sub-agents: open/send/poll/cancel/close drive a
+		// persistent interactive child (the interactive fork of runSubAgent).
 		OpenChild:   s.openResidentChild,
 		SendChild:   s.sendResidentChild,
+		PollChild:   s.pollResidentChild,
+		CancelChild: s.cancelResidentChildTurn,
 		CloseChild:  s.closeResidentChild,
 		SpawnLedger: cfg.Env.ResumeFanout, // RFC X Phase 3: record the spawn ledger (default off)
 		// v0.11.8 — per-agent max_concurrent_children cap for

--- a/internal/help/builtin/resident-sub-agents.md
+++ b/internal/help/builtin/resident-sub-agents.md
@@ -20,7 +20,21 @@ Most sub-agent work is one-shot: `Agent {op:"spawn", …}` runs a child to compl
   Agent {op:"send", child_run_id:"run_…", prompt:"<next instruction>"}
   → {"child_run_id":"run_…", "state":"awaiting_input", "output":"…"}
   ```
-  It blocks until the child finishes the turn and re-parks. The child sees its full prior conversation — you don't restate context.
+  By default it blocks until the child finishes the turn and re-parks. The child sees its full prior conversation — you don't restate context. Pass **`timeout_ms`** to bound the wait: if the turn is still going after that long, `send` returns early with `"state":"running"` and the partial output-so-far, so a long turn doesn't block you indefinitely — then `poll` to await it, or `cancel` to stop it.
+
+- **`poll`** — check on a running child without giving it new input:
+  ```
+  Agent {op:"poll", child_run_id:"run_…", timeout_ms:30000}
+  → {"state":"running"|"awaiting_input", "output":"<output so far>"}
+  ```
+  `timeout_ms:0` (or omitted) is an instant snapshot; a positive value waits up to that long for the child to park. Use it after a `send` returned `"running"`.
+
+- **`cancel`** — stop the child's current turn (it stays alive):
+  ```
+  Agent {op:"cancel", child_run_id:"run_…"}
+  → {"state":"awaiting_input", "output":"<partial>"}
+  ```
+  Turn-cancels the in-flight turn and re-parks the child — for a turn that's stuck or no longer worth finishing. Different from `close` (which terminates the child). A no-op if the child is already parked.
 
 - **`close`** — shut the child down and free its resources:
   ```

--- a/internal/tools/builtin/agent.go
+++ b/internal/tools/builtin/agent.go
@@ -58,11 +58,24 @@ type SubAgentRunnerDetailed func(ctx context.Context, name string, prompt string
 type OpenChildRunner func(ctx context.Context, name, prompt, defID string, idleTTLSeconds int) (childRunID, output, state string, err error)
 
 // SendChildRunner injects the next instruction into a resident child (RFC BK)
-// and BLOCKS until the child re-parks at awaiting_input (or terminates),
-// returning that turn's assistant output + the child's resulting state. The
-// caller must own the child (same run tree / tenant); an unknown or unowned
-// child_run_id is an error.
-type SendChildRunner func(ctx context.Context, childRunID, prompt string) (output, state string, err error)
+// and waits for that turn's result. timeoutMs bounds the wait: 0 blocks until the
+// child re-parks at awaiting_input (or terminates), matching P1; >0 returns
+// early with state "running" + the partial output-so-far if the turn is still in
+// flight after timeoutMs. The caller must own the child (same tenant); an unknown
+// or unowned child_run_id is an error.
+type SendChildRunner func(ctx context.Context, childRunID, prompt string, timeoutMs int) (output, state string, err error)
+
+// PollChildRunner checks on a resident child WITHOUT sending new input (RFC BK
+// P2): it returns the current turn's output-so-far + state. timeoutMs=0 is a
+// non-blocking snapshot; >0 waits up to that long for the child to park. Used to
+// await a child after a send returned state "running".
+type PollChildRunner func(ctx context.Context, childRunID string, timeoutMs int) (output, state string, err error)
+
+// CancelChildRunner turn-cancels a resident child's CURRENT turn (RFC BK P2):
+// it stops the in-flight model call + tool dispatch and re-parks the child at
+// awaiting_input (the child stays alive — unlike close, which terminates it).
+// A child that is already parked is a no-op.
+type CancelChildRunner func(ctx context.Context, childRunID string) (output, state string, err error)
 
 // CloseChildRunner finalizes a resident child (RFC BK), firing its teardown
 // (e.g. sandbox_close_run). Idempotent — closing an already-gone child is not an
@@ -188,13 +201,16 @@ type AgentTool struct {
 	// DefaultMaxConcurrentChildren. Wired by the HTTP server at boot.
 	CapLookup MaxConcurrentChildrenLookup
 
-	// OpenChild / SendChild / CloseChild wire the RFC BK resident-child ops
-	// (open/send/close). nil = the op is unavailable (the tool refuses with a
-	// clear "not wired" message), so a runtime without interactive sub-agents
-	// stays byte-identical for spawn/parallel_spawn. Set by the HTTP server.
-	OpenChild  OpenChildRunner
-	SendChild  SendChildRunner
-	CloseChild CloseChildRunner
+	// OpenChild / SendChild / PollChild / CancelChild / CloseChild wire the RFC
+	// BK resident-child ops (open/send/poll/cancel/close). nil = the op is
+	// unavailable (the tool refuses with a clear "not wired" message), so a
+	// runtime without interactive sub-agents stays byte-identical for
+	// spawn/parallel_spawn. Set by the HTTP server.
+	OpenChild   OpenChildRunner
+	SendChild   SendChildRunner
+	PollChild   PollChildRunner
+	CancelChild CancelChildRunner
+	CloseChild  CloseChildRunner
 }
 
 // runChild drives one sub-agent, preferring RunDetailed (surfaces the child
@@ -227,10 +243,16 @@ type agentInput struct {
 	Spawns []parallelSpawnEntry `json:"spawns,omitempty"`
 
 	// Resident-child fields (RFC BK). op="open" reuses Name/Prompt/DefID and
-	// optionally IdleTTLSeconds; op="send" uses ChildRunID + Prompt; op="close"
-	// uses ChildRunID.
+	// optionally IdleTTLSeconds; op="send" uses ChildRunID + Prompt (+ optional
+	// TimeoutMs); op="poll" uses ChildRunID (+ optional TimeoutMs); op="close"
+	// and op="cancel" use ChildRunID.
 	ChildRunID     string `json:"child_run_id,omitempty"`
 	IdleTTLSeconds int    `json:"idle_ttl_seconds,omitempty"`
+	// TimeoutMs bounds a send/poll (RFC BK P2). send: 0 = block until the child
+	// parks (P1 behavior); >0 = return {state:"running", partial output} if the
+	// turn is still going after this long. poll: 0 = a non-blocking snapshot; >0 =
+	// wait up to this long for the child to park.
+	TimeoutMs int `json:"timeout_ms,omitempty"`
 }
 
 // parallelSpawnEntry is one row in a parallel_spawn `spawns` array.
@@ -314,11 +336,29 @@ const agentInputSchema = `{
     {
       "title": "send — give a resident sub-agent its next instruction",
       "properties": {
-        "op":           {"type": "string", "enum": ["send"], "description": "Steer a resident child's next turn. Blocks until the child finishes the turn and returns its output."},
+        "op":           {"type": "string", "enum": ["send"], "description": "Steer a resident child's next turn. Waits for the turn and returns its output."},
         "child_run_id": {"type": "string", "description": "The child_run_id returned by op=open."},
-        "prompt":       {"type": "string", "description": "The next instruction for the child. It sees its full prior conversation."}
+        "prompt":       {"type": "string", "description": "The next instruction for the child. It sees its full prior conversation."},
+        "timeout_ms":   {"type": "integer", "description": "Optional. 0 (default) blocks until the child parks. >0 returns early with state \"running\" + the partial output if the turn is still going after this long — then use op=poll to await it, or op=cancel to interrupt."}
       },
       "required": ["op", "child_run_id", "prompt"]
+    },
+    {
+      "title": "poll — check on a resident sub-agent without sending input",
+      "properties": {
+        "op":           {"type": "string", "enum": ["poll"], "description": "Return a resident child's current output-so-far + state, without giving it new input. Use it to await a child after send returned state \"running\"."},
+        "child_run_id": {"type": "string", "description": "The child_run_id to check."},
+        "timeout_ms":   {"type": "integer", "description": "Optional. 0 (default) is a non-blocking snapshot; >0 waits up to this long for the child to park."}
+      },
+      "required": ["op", "child_run_id"]
+    },
+    {
+      "title": "cancel — stop a resident sub-agent's current turn",
+      "properties": {
+        "op":           {"type": "string", "enum": ["cancel"], "description": "Turn-cancel a resident child: stop its in-flight turn and re-park it (the child stays alive — use op=close to shut it down). A no-op if it's already parked."},
+        "child_run_id": {"type": "string", "description": "The child_run_id whose current turn to stop."}
+      },
+      "required": ["op", "child_run_id"]
     },
     {
       "title": "close — shut down a resident sub-agent",
@@ -333,7 +373,7 @@ const agentInputSchema = `{
 
 const agentDescription = `Spawn or drive named sub-agents, each with its own tool allowlist (your tool set does not transfer). ` +
 	`Stateless ops: 'spawn' (default; one child, return its final text) and 'parallel_spawn' (N children concurrently, JSON envelope with per-child ok/output/error) — best when you describe the whole task up front. ` +
-	`Resident ops (stateful): 'open' starts a persistent sub-agent and returns a child_run_id, 'send' gives it the next instruction and returns that turn's output, 'close' shuts it down. Use these when the child must keep state between steps — a warm sandbox container, a REPL, a multi-turn analysis — instead of re-spawning and re-threading state by hand. Close what you open. ` +
+	`Resident ops (stateful): 'open' starts a persistent sub-agent and returns a child_run_id; 'send' gives it the next instruction and returns that turn's output (optional timeout_ms bounds the wait — a long turn returns state "running" + partial output); 'poll' checks a running child without new input; 'cancel' stops a child's current turn (it stays alive); 'close' shuts it down. Use these when the child must keep state between steps — a warm sandbox container, a REPL, a multi-turn analysis — instead of re-spawning and re-threading state by hand. Close what you open. ` +
 	`See Context.help(topic="fan-out-patterns") for spawn vs parallel_spawn vs Channel.publish, and Context.help(topic="resident-sub-agents") for the open/send/close lifecycle.`
 
 // Name implements tools.Tool.
@@ -370,10 +410,14 @@ func (a *AgentTool) Execute(ctx context.Context, input json.RawMessage) (tools.R
 		return a.executeOpen(ctx, in)
 	case "send":
 		return a.executeSend(ctx, in)
+	case "poll":
+		return a.executePoll(ctx, in)
+	case "cancel":
+		return a.executeCancel(ctx, in)
 	case "close":
 		return a.executeClose(ctx, in)
 	default:
-		return tools.Result{IsError: true, Text: fmt.Sprintf("unknown op %q (expected 'spawn', 'parallel_spawn', 'open', 'send', or 'close')", in.Op)}, nil
+		return tools.Result{IsError: true, Text: fmt.Sprintf("unknown op %q (expected 'spawn', 'parallel_spawn', 'open', 'send', 'poll', 'cancel', or 'close')", in.Op)}, nil
 	}
 }
 
@@ -693,7 +737,48 @@ func (a *AgentTool) executeSend(ctx context.Context, in agentInput) (tools.Resul
 	if in.Prompt == "" {
 		return tools.Result{IsError: true, Text: "missing required field: prompt"}, nil
 	}
-	output, state, err := a.SendChild(ctx, in.ChildRunID, in.Prompt)
+	if in.TimeoutMs < 0 {
+		return tools.Result{IsError: true, Text: "timeout_ms must be >= 0 (0 = block until the child parks)"}, nil
+	}
+	output, state, err := a.SendChild(ctx, in.ChildRunID, in.Prompt, in.TimeoutMs)
+	if err != nil {
+		return tools.Result{IsError: true, Text: err.Error()}, nil
+	}
+	return residentResult(in.ChildRunID, state, output)
+}
+
+// executePoll (RFC BK P2) checks on a resident child without sending new input —
+// returns its current output-so-far + state. Used to await a child after a send
+// returned state "running" (timeout_ms=0 is a non-blocking snapshot).
+func (a *AgentTool) executePoll(ctx context.Context, in agentInput) (tools.Result, error) {
+	if a.PollChild == nil {
+		return tools.Result{IsError: true, Text: "Agent op=poll (resident sub-agent) is not available on this runtime"}, nil
+	}
+	in.ChildRunID = strings.TrimSpace(in.ChildRunID)
+	if in.ChildRunID == "" {
+		return tools.Result{IsError: true, Text: "missing required field: child_run_id"}, nil
+	}
+	if in.TimeoutMs < 0 {
+		return tools.Result{IsError: true, Text: "timeout_ms must be >= 0 (0 = non-blocking snapshot)"}, nil
+	}
+	output, state, err := a.PollChild(ctx, in.ChildRunID, in.TimeoutMs)
+	if err != nil {
+		return tools.Result{IsError: true, Text: err.Error()}, nil
+	}
+	return residentResult(in.ChildRunID, state, output)
+}
+
+// executeCancel (RFC BK P2) turn-cancels a resident child's current turn (stops
+// it and re-parks the child — the child stays alive, unlike close).
+func (a *AgentTool) executeCancel(ctx context.Context, in agentInput) (tools.Result, error) {
+	if a.CancelChild == nil {
+		return tools.Result{IsError: true, Text: "Agent op=cancel (resident sub-agent) is not available on this runtime"}, nil
+	}
+	in.ChildRunID = strings.TrimSpace(in.ChildRunID)
+	if in.ChildRunID == "" {
+		return tools.Result{IsError: true, Text: "missing required field: child_run_id"}, nil
+	}
+	output, state, err := a.CancelChild(ctx, in.ChildRunID)
 	if err != nil {
 		return tools.Result{IsError: true, Text: err.Error()}, nil
 	}

--- a/internal/tools/builtin/agent_test.go
+++ b/internal/tools/builtin/agent_test.go
@@ -860,30 +860,31 @@ func TestAgentTool_Open_DepthGuard(t *testing.T) {
 
 func TestAgentTool_Send_HappyPath(t *testing.T) {
 	var gotID, gotPrompt string
+	var gotTimeout int
 	a := &AgentTool{
 		Run: func(context.Context, string, string, string) (string, error) { return "", nil },
-		SendChild: func(_ context.Context, childRunID, prompt string) (string, string, error) {
-			gotID, gotPrompt = childRunID, prompt
+		SendChild: func(_ context.Context, childRunID, prompt string, timeoutMs int) (string, string, error) {
+			gotID, gotPrompt, gotTimeout = childRunID, prompt, timeoutMs
 			return "turn 2 output", "awaiting_input", nil
 		},
 	}
 	res, _ := a.Execute(context.Background(),
-		json.RawMessage(`{"op":"send","child_run_id":"run_child_1","prompt":"now test it"}`))
+		json.RawMessage(`{"op":"send","child_run_id":"run_child_1","prompt":"now test it","timeout_ms":5000}`))
 	env := parseResident(t, res)
 	if env.Output != "turn 2 output" || env.State != "awaiting_input" || env.ChildRunID != "run_child_1" {
 		t.Errorf("envelope = %+v", env)
 	}
-	if gotID != "run_child_1" || gotPrompt != "now test it" {
-		t.Errorf("runner args: id=%q prompt=%q", gotID, gotPrompt)
+	if gotID != "run_child_1" || gotPrompt != "now test it" || gotTimeout != 5000 {
+		t.Errorf("runner args: id=%q prompt=%q timeout=%d", gotID, gotPrompt, gotTimeout)
 	}
 }
 
 func TestAgentTool_Send_MissingFields(t *testing.T) {
 	a := &AgentTool{
 		Run:       func(context.Context, string, string, string) (string, error) { return "", nil },
-		SendChild: func(context.Context, string, string) (string, string, error) { return "", "", nil },
+		SendChild: func(context.Context, string, string, int) (string, string, error) { return "", "", nil },
 	}
-	for _, in := range []string{`{"op":"send","prompt":"y"}`, `{"op":"send","child_run_id":"r"}`} {
+	for _, in := range []string{`{"op":"send","prompt":"y"}`, `{"op":"send","child_run_id":"r"}`, `{"op":"send","child_run_id":"r","prompt":"y","timeout_ms":-1}`} {
 		res, _ := a.Execute(context.Background(), json.RawMessage(in))
 		if !res.IsError {
 			t.Errorf("expected error for %s", in)
@@ -931,5 +932,85 @@ func TestAgentTool_Close_NotWired(t *testing.T) {
 	res, _ := a.Execute(context.Background(), json.RawMessage(`{"op":"close","child_run_id":"r"}`))
 	if !res.IsError || !strings.Contains(res.Text, "not available") {
 		t.Errorf("close with nil CloseChild should refuse: %+v", res)
+	}
+}
+
+func TestAgentTool_Poll_HappyPath(t *testing.T) {
+	var gotID string
+	var gotTimeout int
+	a := &AgentTool{
+		Run: func(context.Context, string, string, string) (string, error) { return "", nil },
+		PollChild: func(_ context.Context, childRunID string, timeoutMs int) (string, string, error) {
+			gotID, gotTimeout = childRunID, timeoutMs
+			return "partial so far", "running", nil
+		},
+	}
+	res, _ := a.Execute(context.Background(),
+		json.RawMessage(`{"op":"poll","child_run_id":"run_child_1","timeout_ms":2000}`))
+	env := parseResident(t, res)
+	if env.State != "running" || env.Output != "partial so far" || env.ChildRunID != "run_child_1" {
+		t.Errorf("envelope = %+v", env)
+	}
+	if gotID != "run_child_1" || gotTimeout != 2000 {
+		t.Errorf("runner args: id=%q timeout=%d", gotID, gotTimeout)
+	}
+}
+
+func TestAgentTool_Poll_MissingChildRunID(t *testing.T) {
+	a := &AgentTool{
+		Run:       func(context.Context, string, string, string) (string, error) { return "", nil },
+		PollChild: func(context.Context, string, int) (string, string, error) { return "", "", nil },
+	}
+	for _, in := range []string{`{"op":"poll"}`, `{"op":"poll","child_run_id":"r","timeout_ms":-5}`} {
+		res, _ := a.Execute(context.Background(), json.RawMessage(in))
+		if !res.IsError {
+			t.Errorf("expected error for %s", in)
+		}
+	}
+}
+
+func TestAgentTool_Poll_NotWired(t *testing.T) {
+	a := &AgentTool{Run: func(context.Context, string, string, string) (string, error) { return "", nil }}
+	res, _ := a.Execute(context.Background(), json.RawMessage(`{"op":"poll","child_run_id":"r"}`))
+	if !res.IsError || !strings.Contains(res.Text, "not available") {
+		t.Errorf("poll with nil PollChild should refuse: %+v", res)
+	}
+}
+
+func TestAgentTool_Cancel_HappyPath(t *testing.T) {
+	var gotID string
+	a := &AgentTool{
+		Run: func(context.Context, string, string, string) (string, error) { return "", nil },
+		CancelChild: func(_ context.Context, childRunID string) (string, string, error) {
+			gotID = childRunID
+			return "stopped mid-turn", "awaiting_input", nil
+		},
+	}
+	res, _ := a.Execute(context.Background(), json.RawMessage(`{"op":"cancel","child_run_id":"run_child_1"}`))
+	env := parseResident(t, res)
+	if env.State != "awaiting_input" || env.ChildRunID != "run_child_1" {
+		t.Errorf("envelope = %+v", env)
+	}
+	if gotID != "run_child_1" {
+		t.Errorf("cancel arg = %q", gotID)
+	}
+}
+
+func TestAgentTool_Cancel_MissingChildRunID(t *testing.T) {
+	a := &AgentTool{
+		Run:         func(context.Context, string, string, string) (string, error) { return "", nil },
+		CancelChild: func(context.Context, string) (string, string, error) { return "", "", nil },
+	}
+	res, _ := a.Execute(context.Background(), json.RawMessage(`{"op":"cancel"}`))
+	if !res.IsError {
+		t.Errorf("cancel without child_run_id should error: %+v", res)
+	}
+}
+
+func TestAgentTool_Cancel_NotWired(t *testing.T) {
+	a := &AgentTool{Run: func(context.Context, string, string, string) (string, error) { return "", nil }}
+	res, _ := a.Execute(context.Background(), json.RawMessage(`{"op":"cancel","child_run_id":"r"}`))
+	if !res.IsError || !strings.Contains(res.Text, "not available") {
+		t.Errorf("cancel with nil CancelChild should refuse: %+v", res)
 	}
 }


### PR DESCRIPTION
Implements **RFC BK P2** on top of the shipped P1 (v1.26.0). Decisions were confirmed against the RFC before build (recorded in the RFC Document's new "P2 — Design" section): **bounded + interruptible sends**, and **document co-location** (no new cross-replica plumbing).

## New in-band surface

- **`send` gains `timeout_ms`** — `0` blocks until the child re-parks (P1 semantics, unchanged); `>0` returns early with `{state:"running", output:"<partial>"}` if the turn is still in flight, so a long child turn no longer blocks the parent indefinitely.
- **`poll`** (new op) — check a resident child WITHOUT sending new input; `timeout_ms:0` is a non-blocking snapshot, `>0` waits up to that long for it to park. Used to await a child after a `send` returned `"running"`.
- **`cancel`** (new op) — turn-cancel the child's CURRENT turn and re-park it; the child stays alive (distinct from `close`, which terminates it). A no-op if already parked.

## Why the scope is what it is

A resident child *is* an ordinary interactive run, so much of P2's original wishlist was already delivered by P1's reuse of the interactive-run engine:
- **Streamed output for observers** → `GET /v1/runs/{child}/stream` already re-attaches/tails.
- **External turn-cancel** → `POST /v1/runs/{child}/cancel` (RFC BH) already works on the child.
- **Cross-replica** → the child's external steer/cancel/stream already route to the owning replica, and **parent+child are always co-located** (the child's goroutine runs on the parent's replica), so *in-band* send/poll/cancel/close are inherently local.

So the genuinely-new work is the in-band `timeout_ms`/`poll`/`cancel` surface — not speculative cross-replica plumbing.

## Implementation

- `send` refuses while a turn is in flight (a `running` flag on `residentChild` — poll or cancel instead).
- `poll`/`cancel` reuse the child's own turn-boundary signal (the capturing `fwd` seeing `EventAwaitingInput`); a timeout-aware `awaitTurn` returns `"running"` + partial on expiry.
- `cancel` fires the child's armed turn-cancel token directly (`turnCancelReg.CancelLocal` — co-located, ownership already gated by the resident lookup), then awaits the re-park.

## Tested

- `TestResidentChild_SendTimeoutThenPoll`, `TestResidentChild_CancelStopsTurn` (via a gated provider that holds a turn "running"); `TestAgentTool_{Poll,Cancel}_*` + send-timeout on the parent side. P1 resident tests updated for the new signature and still green.
- **Full `go test ./...` clean; `go build ./...` OK; gofmt clean.**

## Deferred to P3
A true in-band stream (beyond timeout+poll); resident children surviving snapshot/resume (the one case that would create a real in-band cross-replica need); Team Orchestrator resident helpers + Web-UI visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)