### PR TITLE
feat: resident sub-agent Web-UI visibility + operator control (RFC BK P3)

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -595,6 +595,13 @@ func requiredScopeFor(method, path string) string {
 	// satisfies. Read-only GET.
 	case path == "/v1/_models":
 		return auth.ScopeTenant
+	// RFC BK P3 — resident interactive sub-agent visibility + operator control.
+	// GET /v1/_resident lists (tenant-scoped in the handler); POST
+	// /v1/_resident/{run_id}/close|cancel act on one (tenant-gated in the handler,
+	// opaque-404 cross-tenant). Tenant-readable/actionable so a tenant operator
+	// can see + reap its own runs' resident children; ScopeAdmin also satisfies.
+	case path == "/v1/_resident" || strings.HasPrefix(path, "/v1/_resident/"):
+		return auth.ScopeTenant
 	// Everything else under /v1/_* is OPERATOR-admin: token minting
 	// (_operatortokendef), runtime admin (pause/resume/state/snapshots/metrics),
 	// resolver, cross-tenant user focus.

--- a/internal/api/http/resident.go
+++ b/internal/api/http/resident.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -42,6 +43,7 @@ const (
 type residentChild struct {
 	runID         string
 	agentID       string // cancel-registry key (close/idle cancel by agent_id)
+	agentName     string // the resident child's agent name (for Web-UI visibility)
 	parentAgentID string // the opener's agent id (parent-teardown backstop)
 	tenantID      string // ownership: send/close must come from this tenant
 	userID        string
@@ -113,6 +115,39 @@ func (rc *residentChild) readTurn() (string, string) {
 	return rc.buf.String(), rc.state
 }
 
+// residentInfo is the non-secret read model for Web-UI visibility (RFC BK P3).
+// State: "running" (mid-turn) | "awaiting_input" (parked) | "completed" | "failed".
+type residentInfo struct {
+	ChildRunID     string    `json:"child_run_id"`
+	AgentID        string    `json:"agent_id"`
+	Agent          string    `json:"agent,omitempty"`
+	ParentAgentID  string    `json:"parent_agent_id,omitempty"`
+	TenantID       string    `json:"tenant_id,omitempty"`
+	State          string    `json:"state"`
+	IdleTTLSeconds int       `json:"idle_ttl_seconds"`
+	LastUsedAt     time.Time `json:"last_used_at"`
+}
+
+// snapshotInfo returns the child's current read model.
+func (rc *residentChild) snapshotInfo() residentInfo {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	state := rc.state
+	if rc.running {
+		state = "running"
+	}
+	return residentInfo{
+		ChildRunID:     rc.runID,
+		AgentID:        rc.agentID,
+		Agent:          rc.agentName,
+		ParentAgentID:  rc.parentAgentID,
+		TenantID:       rc.tenantID,
+		State:          state,
+		IdleTTLSeconds: int(rc.idleTTL / time.Second),
+		LastUsedAt:     rc.lastUsed,
+	}
+}
+
 // residentRegistry maps child run_id → residentChild (P1 in-process).
 type residentRegistry struct {
 	mu sync.Mutex
@@ -160,6 +195,18 @@ func (r *residentRegistry) snapshot() []*residentChild {
 	out := make([]*residentChild, 0, len(r.m))
 	for _, rc := range r.m {
 		out = append(out, rc)
+	}
+	return out
+}
+
+// listInfo returns a read-model snapshot of every resident child (RFC BK P3).
+// Snapshots the pointers under the registry lock, then reads each child under
+// its OWN lock — no lock-ordering between the registry and a child.
+func (r *residentRegistry) listInfo() []residentInfo {
+	children := r.snapshot()
+	out := make([]residentInfo, 0, len(children))
+	for _, rc := range children {
+		out = append(out, rc.snapshotInfo())
 	}
 	return out
 }
@@ -216,6 +263,7 @@ func (s *Server) openResidentChild(ctx context.Context, name, prompt, defID stri
 	}
 	rc.runID = prep.RunID
 	rc.agentID = prep.AgentID
+	rc.agentName = name
 	rc.tenantID = prep.TenantID
 	rc.userID = prep.UserID
 	rc.cancel = prep.CancelFn
@@ -447,4 +495,80 @@ func (s *Server) sweepResidentChildren(now time.Time) {
 			rc.cancel(fmt.Errorf("idle timeout"))
 		}
 	}
+}
+
+// --- RFC BK P3: Web-UI visibility + operator control ---
+
+// residentForOperator resolves a resident child by run_id for an operator HTTP
+// request, gated by the caller's tenant scope (all = admin/legacy/open). A child
+// in another tenant folds into not-found (opaque — run_ids aren't secrets, but
+// the gate must not become a cross-tenant existence oracle).
+func (s *Server) residentForOperator(runID, scopeTenant string, all bool) (*residentChild, bool) {
+	if s.residentReg == nil {
+		return nil, false
+	}
+	rc, ok := s.residentReg.get(runID)
+	if !ok {
+		return nil, false
+	}
+	if !all && rc.tenantID != scopeTenant {
+		return nil, false
+	}
+	return rc, true
+}
+
+// handleListResident serves GET /v1/_resident — the resident interactive
+// sub-agents visible to the caller (RFC BK P3). Tenant-scoped: an operator sees
+// its own tenant's; admin/legacy/open see all (or focus one via ?tenant=).
+// Per-replica (the registry is in-process; a child is co-located with its run).
+func (s *Server) handleListResident(w http.ResponseWriter, r *http.Request) {
+	out := make([]residentInfo, 0)
+	if s.residentReg != nil {
+		scopeTenant, all := s.principalTenantScope(r.Context(), r.URL.Query().Get("tenant"))
+		for _, info := range s.residentReg.listInfo() {
+			if !all && info.TenantID != scopeTenant {
+				continue
+			}
+			out = append(out, info)
+		}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"resident": out})
+}
+
+// handleResidentClose serves POST /v1/_resident/{run_id}/close — terminate a
+// resident child (RFC BK P3), tenant-gated. Idempotent (unknown/other-tenant → 404).
+func (s *Server) handleResidentClose(w http.ResponseWriter, r *http.Request) {
+	runID := r.PathValue("run_id")
+	if !validIdent(runID) {
+		http.Error(w, "run_id must match [A-Za-z0-9_-]{1,128}", http.StatusBadRequest)
+		return
+	}
+	scopeTenant, all := s.principalTenantScope(r.Context(), "")
+	rc, ok := s.residentForOperator(runID, scopeTenant, all)
+	if !ok {
+		http.Error(w, "no resident sub-agent for that run_id", http.StatusNotFound)
+		return
+	}
+	if _, found := s.cancelReg.Cancel(rc.agentID, "closed by operator (resident sub-agent)"); !found && rc.cancel != nil {
+		rc.cancel(fmt.Errorf("closed by operator"))
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"run_id": runID, "closed": true})
+}
+
+// handleResidentCancel serves POST /v1/_resident/{run_id}/cancel — turn-cancel a
+// resident child's CURRENT turn (RFC BK P3), tenant-gated. The child stays alive.
+func (s *Server) handleResidentCancel(w http.ResponseWriter, r *http.Request) {
+	runID := r.PathValue("run_id")
+	if !validIdent(runID) {
+		http.Error(w, "run_id must match [A-Za-z0-9_-]{1,128}", http.StatusBadRequest)
+		return
+	}
+	scopeTenant, all := s.principalTenantScope(r.Context(), "")
+	rc, ok := s.residentForOperator(runID, scopeTenant, all)
+	if !ok {
+		http.Error(w, "no resident sub-agent for that run_id", http.StatusNotFound)
+		return
+	}
+	stopped := s.turnCancelReg != nil && s.turnCancelReg.CancelLocal(rc.runID, "cancelled by operator (resident sub-agent)")
+	writeJSON(w, http.StatusOK, map[string]any{"run_id": runID, "stopped": stopped})
 }

--- a/internal/api/http/resident_test.go
+++ b/internal/api/http/resident_test.go
@@ -2,6 +2,9 @@ package http
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -306,5 +309,103 @@ func TestResidentChild_CancelStopsTurn(t *testing.T) {
 	// the child is still resident (cancel != close).
 	if _, ok := srv.residentReg.get(runID); !ok {
 		t.Error("cancel must keep the child resident")
+	}
+}
+
+// --- RFC BK P3: Web-UI visibility + operator control ---
+
+// TestResidentP3_ListAndClose drives GET /v1/_resident + POST close through the
+// real HTTP mux (open mode → the caller sees all tenants).
+func TestResidentP3_ListAndClose(t *testing.T) {
+	srv := newResidentTestServer(t)
+	ctx := residentParentCtx("parent-agent", "")
+	runID, _, _, err := srv.openResidentChild(ctx, "child", "start", "", 0)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	// GET /v1/_resident lists the child with its state.
+	resp, err := http.Get(ts.URL + "/v1/_resident")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	var listBody struct {
+		Resident []residentInfo `json:"resident"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&listBody)
+	resp.Body.Close()
+	if len(listBody.Resident) != 1 {
+		t.Fatalf("expected 1 resident child, got %d (%+v)", len(listBody.Resident), listBody.Resident)
+	}
+	got := listBody.Resident[0]
+	if got.ChildRunID != runID || got.Agent != "child" || got.State != "awaiting_input" {
+		t.Errorf("resident info = %+v", got)
+	}
+
+	// POST close reaps it.
+	cresp, err := http.Post(ts.URL+"/v1/_resident/"+runID+"/close", "application/json", nil)
+	if err != nil {
+		t.Fatalf("POST close: %v", err)
+	}
+	if cresp.StatusCode != 200 {
+		t.Fatalf("close status = %d", cresp.StatusCode)
+	}
+	cresp.Body.Close()
+	waitResidentGone(t, srv, runID)
+
+	// GET again → empty.
+	resp2, _ := http.Get(ts.URL + "/v1/_resident")
+	var after struct {
+		Resident []residentInfo `json:"resident"`
+	}
+	_ = json.NewDecoder(resp2.Body).Decode(&after)
+	resp2.Body.Close()
+	if len(after.Resident) != 0 {
+		t.Errorf("expected empty list after close, got %+v", after.Resident)
+	}
+}
+
+// TestResidentP3_FillResidentState checks the Activity-view enrichment: a run
+// that's a live resident child gets resident=true + its state; others don't.
+func TestResidentP3_FillResidentState(t *testing.T) {
+	srv := newResidentTestServer(t)
+	ctx := residentParentCtx("parent-agent", "")
+	runID, _, _, err := srv.openResidentChild(ctx, "child", "start", "", 0)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = srv.closeResidentChild(ctx, runID) }()
+
+	rows := []agentResponse{{RunID: runID}, {RunID: "not-a-resident-run"}}
+	srv.fillResidentState(rows)
+	if !rows[0].Resident || rows[0].ResidentState != "awaiting_input" {
+		t.Errorf("resident row = %+v", rows[0])
+	}
+	if rows[1].Resident {
+		t.Errorf("non-resident row should not be flagged: %+v", rows[1])
+	}
+}
+
+// TestResidentP3_OperatorTenantGate: an operator sees/acts on a child only in
+// its own tenant; admin (all) sees any.
+func TestResidentP3_OperatorTenantGate(t *testing.T) {
+	srv := newResidentTestServer(t)
+	ctx := residentParentCtx("parent-a", "tenant-a")
+	runID, _, _, err := srv.openResidentChild(ctx, "child", "start", "", 0)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = srv.closeResidentChild(ctx, runID) }()
+
+	if _, ok := srv.residentForOperator(runID, "tenant-b", false); ok {
+		t.Error("cross-tenant operator must NOT resolve the child")
+	}
+	if _, ok := srv.residentForOperator(runID, "tenant-a", false); !ok {
+		t.Error("owning-tenant operator should resolve the child")
+	}
+	if _, ok := srv.residentForOperator(runID, "", true); !ok {
+		t.Error("admin (all) should resolve the child")
 	}
 }

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2652,6 +2652,13 @@ func (s *Server) Mux() http.Handler {
 	// live availability + the active-providers header. Scope-gated in
 	// requiredScopeFor.
 	mux.Handle("GET /v1/_routing", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleRouting))))
+	// RFC BK P3: resident interactive sub-agent visibility + operator control.
+	// GET lists (tenant-scoped); POST close/cancel act on one (tenant-gated).
+	// Per-replica (the resident registry is in-process). Scope-gated in
+	// requiredScopeFor (ScopeTenant).
+	mux.Handle("GET /v1/_resident", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListResident))))
+	mux.Handle("POST /v1/_resident/{run_id}/close", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleResidentClose))))
+	mux.Handle("POST /v1/_resident/{run_id}/cancel", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleResidentCancel))))
 	// Operator-triggered immediate re-probe (issue #88) — unsticks the
 	// availability matrix after a transient outage without a restart,
 	// instead of waiting up to a full probe interval for the next tick.
@@ -5870,6 +5877,13 @@ type agentResponse struct {
 	// cost to the user-initiated request in a single fetch. Omitted when
 	// the run carried no context.
 	ParentContext *store.ParentContext `json:"parent_context,omitempty"`
+	// RFC BK P3 — resident interactive sub-agent visibility. Resident is true
+	// when this run is a LIVE resident child (open via Agent op=open, in this
+	// replica's registry); ResidentState is its current state ("running" |
+	// "awaiting_input" | "completed" | "failed"). Both omitted for ordinary runs
+	// so the Activity view can badge resident children + show their live state.
+	Resident      bool   `json:"resident,omitempty"`
+	ResidentState string `json:"resident_state,omitempty"`
 }
 
 type agentResponseUsage struct {
@@ -6129,7 +6143,24 @@ func (s *Server) handleListUserAgents(w http.ResponseWriter, r *http.Request) {
 		out = append(out, runToAgentResponse(run, live))
 	}
 	fillAwaitedStateForRunning(r.Context(), s.store, out)
+	s.fillResidentState(out) // RFC BK P3: badge resident children + their live state
 	writeJSON(w, http.StatusOK, map[string]any{"agents": out})
+}
+
+// fillResidentState enriches agent rows that are LIVE resident children (RFC BK
+// P3) with resident=true + their current state, so the Activity view can badge
+// them. Per-replica (the registry is in-process); a row whose run isn't resident
+// here is left unchanged.
+func (s *Server) fillResidentState(rows []agentResponse) {
+	if s.residentReg == nil {
+		return
+	}
+	for i := range rows {
+		if info, ok := s.residentReg.get(rows[i].RunID); ok {
+			rows[i].Resident = true
+			rows[i].ResidentState = info.snapshotInfo().State
+		}
+	}
 }
 
 // ---- Interruption (v0.8.16) ---------------------------------------

--- a/internal/help/builtin/resident-sub-agents.md
+++ b/internal/help/builtin/resident-sub-agents.md
@@ -47,6 +47,10 @@ Most sub-agent work is one-shot: `Agent {op:"spawn", …}` runs a child to compl
 - **Use `spawn` / `parallel_spawn`** when you can describe the whole job up front, or when N independent specialists run at once. The child is stateless and returns once.
 - **Use `open` / `send` / `close`** when you'll inspect each result and decide the next step, and the child must stay stateful between steps. A compile→test→fix loop against one warm sandbox container is the canonical case: `open` (write + build), `send` ("now run the tests"), `send` ("fix line 42 and re-run") — the container stays hot the whole time; no re-spawn, no session_id to carry.
 
+## Keeping a helper resident across a long task
+
+A long-lived agent — an interactive session, or an orchestrator driving many steps or states — can keep ONE helper resident for the whole task: `open` it once, `send` it work as each step arrives (across state transitions, tool loops, whatever), and `close` it at the end. The child is parented to your run, so it stays alive as long as you do (and is reaped automatically if you finish without closing it). This is how you give a multi-step workflow a single warm sandbox / REPL / analysis context instead of standing one up per step.
+
 ## Rules & limits
 
 - **You own the lifecycle.** The child stays alive until you `close` it, or it is idle-reaped after a period with no `send` (operator-configured; override per child with `open`'s `idle_ttl_seconds`), or the run that opened it ends.

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -87,10 +87,28 @@ export interface Agent {
   // handle. Absent in single-replica deployments (the server omits
   // the field when its replica_id is unset).
   replica_id?: string;
+  // RFC BK P3: this run is a LIVE resident interactive sub-agent (opened via
+  // Agent op=open). `resident_state` is its current state — "running" (mid-turn)
+  // or "awaiting_input" (parked). Absent for ordinary runs.
+  resident?: boolean;
+  resident_state?: "running" | "awaiting_input" | "completed" | "failed" | "";
 }
 
 export interface ListAgentsResponse {
   agents: Agent[];
+}
+
+// ResidentChild mirrors the server's residentInfo (RFC BK P3) — a live resident
+// interactive sub-agent, from GET /v1/_resident.
+export interface ResidentChild {
+  child_run_id: string;
+  agent_id: string;
+  agent?: string;
+  parent_agent_id?: string;
+  tenant_id?: string;
+  state: "running" | "awaiting_input" | "completed" | "failed";
+  idle_ttl_seconds: number;
+  last_used_at: string;
 }
 
 // LimitEventInfo mirrors providers.LimitInfo — the sidecar on a `limit`
@@ -524,6 +542,33 @@ export async function cancelAgent(agentId: string, reason?: string): Promise<unk
     credentials: "same-origin",
     headers: { "Content-Type": "application/json", Accept: "application/json" },
     body: JSON.stringify({ reason: reason ?? "" }),
+  });
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`${resp.status} ${resp.statusText}: ${body.slice(0, 200)}`);
+  }
+  return resp.json();
+}
+
+// ---- Resident interactive sub-agents (RFC BK P3) -------------------
+
+export async function listResidentChildren(): Promise<{ resident: ResidentChild[] }> {
+  return jsonFetch<{ resident: ResidentChild[] }>(`/v1/_resident`);
+}
+
+// closeResidentChild terminates a resident child; cancelResidentChildTurn
+// turn-cancels its current turn (the child stays alive). run_id = the child's.
+export async function closeResidentChild(runId: string): Promise<unknown> {
+  return residentAction(runId, "close");
+}
+export async function cancelResidentChildTurn(runId: string): Promise<unknown> {
+  return residentAction(runId, "cancel");
+}
+async function residentAction(runId: string, op: "close" | "cancel"): Promise<unknown> {
+  const resp = await fetch(`/v1/_resident/${encodeURIComponent(runId)}/${op}`, {
+    method: "POST",
+    credentials: "same-origin",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
   });
   if (!resp.ok) {
     const body = await resp.text();

--- a/web/src/components/AgentDetailPane.tsx
+++ b/web/src/components/AgentDetailPane.tsx
@@ -7,6 +7,8 @@ import {
   TranscriptEvent,
   UserInputPayload,
   cancelAgent,
+  cancelResidentChildTurn,
+  closeResidentChild,
   getAgent,
   getTranscript,
 } from "../api";
@@ -54,6 +56,7 @@ export default function AgentDetailPane({ agentId, ancestors, onSelect }: AgentD
   const [events, setEvents] = useState<TranscriptEvent[]>([]);
   const [err, setErr] = useState<string | null>(null);
   const [cancelInFlight, setCancelInFlight] = useState(false);
+  const [residentInFlight, setResidentInFlight] = useState(false); // RFC BK P3
   const [parentAgent, setParentAgent] = useState<Agent | null>(null);
   const tailRef = useRef<HTMLDivElement | null>(null);
 
@@ -154,6 +157,14 @@ export default function AgentDetailPane({ agentId, ancestors, onSelect }: AgentD
                 interactive
               </span>
             )}
+            {agent.resident && (
+              <span
+                className="pill-resident"
+                title="Resident sub-agent — a persistent interactive child a parent drives via Agent open/send/close; stays warm between turns"
+              >
+                resident{agent.resident_state ? ` · ${agent.resident_state}` : ""}
+              </span>
+            )}
             <strong>{agent.agent || "(unknown agent)"}</strong>
             <code className="agent-id">{agent.agent_id}</code>
             {agent.status === "running" && (
@@ -173,6 +184,48 @@ export default function AgentDetailPane({ agentId, ancestors, onSelect }: AgentD
               >
                 {cancelInFlight ? "cancelling…" : "cancel"}
               </button>
+            )}
+            {agent.resident && agent.run_id && (
+              // RFC BK P3 — operator control of a resident child. cancel-turn
+              // stops the current turn (child stays alive); close terminates it.
+              <>
+                {agent.resident_state === "running" && (
+                  <button
+                    className="cancel-btn"
+                    disabled={residentInFlight}
+                    title="Turn-cancel the child's current turn (it stays alive, awaiting the next instruction)"
+                    onClick={async () => {
+                      setResidentInFlight(true);
+                      try {
+                        await cancelResidentChildTurn(agent.run_id);
+                      } catch (e) {
+                        setErr(e instanceof Error ? e.message : String(e));
+                      } finally {
+                        setResidentInFlight(false);
+                      }
+                    }}
+                  >
+                    {residentInFlight ? "…" : "cancel turn"}
+                  </button>
+                )}
+                <button
+                  className="cancel-btn"
+                  disabled={residentInFlight}
+                  title="Close this resident sub-agent (terminate it and free its resources)"
+                  onClick={async () => {
+                    setResidentInFlight(true);
+                    try {
+                      await closeResidentChild(agent.run_id);
+                    } catch (e) {
+                      setErr(e instanceof Error ? e.message : String(e));
+                    } finally {
+                      setResidentInFlight(false);
+                    }
+                  }}
+                >
+                  {residentInFlight ? "…" : "close resident"}
+                </button>
+              </>
             )}
             {agent.status === "running" && agent.run_id && (
               // Re-attach to a live (notably interactive/parked) run in the

--- a/web/src/components/AgentsTree.tsx
+++ b/web/src/components/AgentsTree.tsx
@@ -176,6 +176,11 @@ function AgentsTreeNode({ node, depth, expandedMap, setExpanded, selectedId, onS
               interactive
             </span>
           )}
+          {a.resident && (
+            <span className="pill-resident" title="Resident sub-agent — a persistent interactive child driven via Agent open/send/close">
+              resident{a.resident_state ? ` · ${a.resident_state}` : ""}
+            </span>
+          )}
         </span>
         {onSelect ? (
           <button

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4444,6 +4444,19 @@ button.primary:disabled {
      cell. justify-self is a no-op in the (non-grid) detail-pane + switcher uses. */
   justify-self: start;
 }
+/* RFC BK P3 — resident interactive sub-agent chip. Distinct hue (amber) from the
+   interactive (green) chip so a resident child is scannable in the runs tree. */
+.pill-resident {
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 10px;
+  text-transform: lowercase;
+  letter-spacing: 0.03em;
+  background: rgba(230, 168, 84, 0.15);
+  color: var(--warn, #e6a854);
+  border: 1px solid var(--warn, #e6a854);
+  justify-self: start;
+}
 .run-form-advanced {
   margin: 8px 0;
 }


### PR DESCRIPTION
Implements **RFC BK P3** on top of P1 (v1.26.0) + P2 (v1.27.0). Decisions confirmed against the RFC before build (recorded in the RFC Document's new "P3 — Design" chunk): **enrich the existing Activity view** (not a new nav), **read + close/cancel** control, and **team-orchestrator = docs note** (it already works).

## The two P3 items

**1. Web-UI visibility of a run's resident children** (the build):
- **`GET /v1/_resident`** — tenant-scoped list of live resident children (`child_run_id`, `agent`, `state` [running/awaiting_input/completed/failed], `parent`, `idle_ttl_s`, `last_used_at`). Per-replica (the registry is in-process; a child is co-located with its run). Operator sees its own tenant; admin/legacy/open see all (or focus via `?tenant=`).
- **`POST /v1/_resident/{run_id}/close`** (terminate) + **`/cancel`** (turn-cancel the current turn, child stays alive) — tenant-gated, opaque-404 cross-tenant.
- **Activity enrichment:** `agentResponse` gains `resident`/`resident_state`; the runs tree + detail pane show a `resident · <state>` badge, and the detail pane adds "cancel turn" / "close resident" actions.
- `requiredScopeFor`: `/v1/_resident*` → `ScopeTenant`.

**2. Team-orchestrator resident helpers — already works (docs note only):** `team/orchestrator` has the `Agent` tool and is a long-lived interactive run (`unbounded_iterations`), so it can already `open` a helper, drive it across states with `send`/`poll`/`cancel`, and `close` at the end. A resident child it opens is parented to the orchestrator run and survives state transitions — no new plumbing. Added a help-topic section ("Keeping a helper resident across a long task") so it's discoverable.

## Notes
- **Per-replica:** `GET /v1/_resident` lists this replica's registry (resident children are co-located with their runs). A cluster-wide aggregate is deferred (not needed under the co-location model).
- Additive JSON (`resident`/`resident_state`) — no adapter break; adapters stay 1.25.0.
- Web UI: `web/src` only (dist is gitignored, CI rebuilds); tsc + vite build clean.

## Tested
- `TestResidentP3_{ListAndClose (httptest), FillResidentState, OperatorTenantGate}`; existing resident tests green.
- Full `go test ./...` clean; `go build ./...` OK; gofmt clean; Web UI `tsc --noEmit && vite build` clean.

## Beyond P3 (future)
A true in-band stream (beyond timeout+poll); resident children surviving snapshot/resume (the one genuine cross-replica in-band case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)