### PR TITLE
feat(explorer): pin Save/Cancel to the top of the edit dialogs (RFC BN P1)

### DIFF
--- a/packages/explorer/src/PathExplorer.tsx
+++ b/packages/explorer/src/PathExplorer.tsx
@@ -481,7 +481,18 @@ function PromptModal({ state, onClose }: { state: ModalState; onClose: () => voi
   return (
     <div className="modal-overlay" onClick={onClose}>
       <form className="modal" onClick={(e) => e.stopPropagation()} onSubmit={submit}>
-        <h3>{state.title}</h3>
+        {/* RFC BN P1: Save/Cancel pinned to the top for consistency with the chunk editor. */}
+        <div className="modal-header sticky-top">
+          <h3>{state.title}</h3>
+          <div className="modal-buttons modal-buttons-top">
+            <button type="button" onClick={onClose} disabled={busy}>
+              cancel
+            </button>
+            <button type="submit" className={state.danger ? "danger" : "primary"} disabled={busy}>
+              {busy ? "working…" : state.submitLabel}
+            </button>
+          </div>
+        </div>
         {state.message && <p className="modal-context">{state.message}</p>}
         {state.fields.map((f, i) => (
           <label key={f.key} className="path-field">
@@ -496,14 +507,6 @@ function PromptModal({ state, onClose }: { state: ModalState; onClose: () => voi
           </label>
         ))}
         {err && <div className="modal-err">{err}</div>}
-        <div className="modal-buttons">
-          <button type="button" onClick={onClose} disabled={busy}>
-            cancel
-          </button>
-          <button type="submit" className={state.danger ? "danger" : "primary"} disabled={busy}>
-            {busy ? "working…" : state.submitLabel}
-          </button>
-        </div>
       </form>
     </div>
   );

--- a/packages/explorer/src/components/ChunkEditorModal.tsx
+++ b/packages/explorer/src/components/ChunkEditorModal.tsx
@@ -67,7 +67,25 @@ export default function ChunkEditorModal({ chunk, scope, browse, onClose, onSave
   return (
     <div className="modal-overlay" onClick={onClose}>
       <form className="modal chunk-editor" onClick={(e) => e.stopPropagation()} onSubmit={submit}>
-        <h3>Edit chunk</h3>
+        {/* RFC BN P1: Save/Cancel pinned to the top so a long chunk body never
+            needs scrolling to reach the save button. */}
+        <div className="modal-header sticky-top">
+          <h3>Edit chunk</h3>
+          <div className="modal-buttons modal-buttons-top">
+            <button type="button" onClick={onClose} disabled={busy}>
+              cancel
+            </button>
+            <button type="submit" className="primary" disabled={busy}>
+              {busy ? "saving…" : "save"}
+            </button>
+          </div>
+        </div>
+        {err && (
+          <div className="modal-err">
+            {err}
+            {conflict && " — reopen the chunk to load the latest, then reapply your edit."}
+          </div>
+        )}
         <label className="path-field">
           <span>Title</span>
           <input className="path-modal-input" value={title} onChange={(e) => setTitle(e.target.value)} />
@@ -111,20 +129,6 @@ export default function ChunkEditorModal({ chunk, scope, browse, onClose, onSave
             onChange={(e) => setFieldsText(e.target.value)}
           />
         </label>
-        {err && (
-          <div className="modal-err">
-            {err}
-            {conflict && " — reopen the chunk to load the latest, then reapply your edit."}
-          </div>
-        )}
-        <div className="modal-buttons">
-          <button type="button" onClick={onClose} disabled={busy}>
-            cancel
-          </button>
-          <button type="submit" className="primary" disabled={busy}>
-            {busy ? "saving…" : "save"}
-          </button>
-        </div>
       </form>
     </div>
   );

--- a/packages/explorer/src/styles.css
+++ b/packages/explorer/src/styles.css
@@ -240,6 +240,31 @@
   font-size: var(--lc-text-sm);
   margin-bottom: 16px;
 }
+/* RFC BN P1: a sticky top action bar (title + Save/Cancel) so a long chunk body
+   never needs scrolling to reach save. The modal itself is the scroll container
+   (max-height:80vh; overflow:auto), so a .sticky-top header pins to its top. */
+.loomcycle-explorer .modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+.loomcycle-explorer .modal-header.sticky-top {
+  position: sticky;
+  top: 0;
+  background: var(--bg);
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border);
+  z-index: 1;
+}
+.loomcycle-explorer .modal-header h3 {
+  margin: 0;
+}
+.loomcycle-explorer .modal-buttons-top {
+  margin: 0;
+  flex-shrink: 0;
+}
 .loomcycle-explorer .modal-textarea {
   width: 100%;
   font-family: inherit;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4015,6 +4015,21 @@ button.primary:disabled {
   align-items: center;
   margin-bottom: 16px;
 }
+/* RFC BN P1: a sticky top action bar for the explorer chunk/path edit dialogs
+   (the modal is the scroll container) — gated on .sticky-top so other modals'
+   headers are unaffected. */
+.modal-header.sticky-top {
+  position: sticky;
+  top: 0;
+  background: var(--bg);
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border);
+  z-index: 1;
+}
+.modal-buttons-top {
+  margin: 0;
+  flex-shrink: 0;
+}
 
 .modal-close {
   background: none;


### PR DESCRIPTION
**RFC BN — Document view UI, Phase 1** (`/loomcycle/rfcs/document-view-ui`).

The chunk/document edit dialog put Save/Cancel at the **bottom**, so a long chunk body forced a scroll just to save. This moves the actions into a **sticky top action bar** (title + Save/Cancel), with error feedback right below it.

- `ChunkEditorModal.tsx` — header row (`.modal-header.sticky-top`) with the buttons; error banner moved up; bottom button block removed.
- `PathExplorer.tsx` `PromptModal` — same top bar, for consistency across the explorer modals.
- CSS in **both** style sheets (`packages/explorer/src/styles.css` + `web/src/styles.css`). The sticky behavior is gated on `.sticky-top` so web's other (non-explorer) modal headers are unaffected; the modal is the scroll container, so the header pins to its top.

**Tested:** web `tsc --noEmit && vite build` clean. Frontend-only; `web/src` + `packages/explorer/src` (dist is gitignored — CI rebuilds). `@loomcycle/explorer` npm version bump deferred to publish (web dogfoods the source via the Vite alias).

First of four phased PRs for RFC BN (P2 markdown, P3 color schemes, P4 cross-refs to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)