### PR TITLE
feat(explorer): per-document color schemes + Path-tree coloring (RFC BN P3)

### DIFF
--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -38,7 +38,7 @@ type Document struct {
 func (d *Document) Name() string { return "Document" }
 
 func (d *Document) Description() string {
-	return "A chunked-graph document: each chunk is a first-class unit (UUID, hierarchy, type, fields, graph edges, Markdown body) that agents and humans co-author and query. Ops: create_document/get_document/delete_document/set_path, create_chunk/get_chunk/update_chunk/delete_chunk/move_chunk, link_chunks/unlink_chunks, query_chunks (structured filters + a raw sql escape hatch), define_type/list_types, export_md (render the document to Markdown), import_md (build a document from export_md-shaped Markdown). Scope is agent or user; documents are named in the Path tree (path:) — create_document defaults to /documents/<title> if you omit one, and set_path attaches/re-homes a path for an existing document."
+	return "A chunked-graph document: each chunk is a first-class unit (UUID, hierarchy, type, fields, graph edges, Markdown body) that agents and humans co-author and query. Ops: create_document/get_document/documents_summary (per-document type/status + display metadata for a set of ids or a Path subtree)/delete_document/set_path, create_chunk/get_chunk/update_chunk/delete_chunk/move_chunk, link_chunks/unlink_chunks, query_chunks (structured filters + a raw sql escape hatch), define_type/list_types, export_md (render the document to Markdown), import_md (build a document from export_md-shaped Markdown). Scope is agent or user; documents are named in the Path tree (path:) — create_document defaults to /documents/<title> if you omit one, and set_path attaches/re-homes a path for an existing document."
 }
 
 // documentInputSchema is a package const so the LoomCycle MCP server can
@@ -48,12 +48,13 @@ func (d *Document) Description() string {
 const documentInputSchema = `{
 	"type": "object",
 	"properties": {
-		"op":          {"type": "string", "enum": ["create_document","get_document","delete_document","set_path","create_chunk","get_chunk","update_chunk","delete_chunk","move_chunk","link_chunks","unlink_chunks","query_chunks","define_type","list_types","export_md","import_md"]},
+		"op":          {"type": "string", "enum": ["create_document","get_document","documents_summary","delete_document","set_path","create_chunk","get_chunk","update_chunk","delete_chunk","move_chunk","link_chunks","unlink_chunks","query_chunks","define_type","list_types","export_md","import_md"]},
 		"scope":       {"type": "string", "enum": ["agent","user"], "description": "Which store (default user). agent = this agent; user = this end-user (needs a user_id on the run). tenant scope is not yet supported."},
 		"id":          {"type": "string", "description": "Document id (get/delete_document, set_path) or chunk id (get/update/delete/move_chunk)."},
 		"path":        {"type": "string", "description": "create_document: name the doc in the Path tree (default /documents/<title> if omitted). set_path: the path to attach to an existing document (by id). get/delete_document: address by path instead of id."},
 		"title":       {"type": "string"},
 		"document_id": {"type": "string"},
+		"document_ids": {"type": "array", "items": {"type": "string"}, "description": "documents_summary: the document ids to summarize (combine with or instead of under_path)."},
 		"parent_id":   {"type": "string", "description": "create_chunk: parent chunk (omit for a child of the root)."},
 		"new_parent_id": {"type": "string", "description": "move_chunk: the new parent."},
 		"type":        {"type": "string", "description": "Optional supertag-like chunk type."},
@@ -65,7 +66,7 @@ const documentInputSchema = `{
 		"from_id":     {"type": "string"},
 		"to_id":       {"type": "string"},
 		"kind":        {"type": "string", "description": "link/unlink_chunks: edge kind (promotes/targets/...)."},
-		"under_path":  {"type": "string", "description": "query_chunks: restrict to documents at/under this Path-tree path."},
+		"under_path":  {"type": "string", "description": "query_chunks / documents_summary: restrict to documents at/under this Path-tree path."},
 		"sql":         {"type": "string", "description": "query_chunks: raw read-only SELECT against the chunk tables (escape hatch; validator-gated)."},
 		"limit":       {"type": "integer"},
 		"name":        {"type": "string", "description": "define/list_types: the type name."},
@@ -84,6 +85,7 @@ type docInput struct {
 	Path        string          `json:"path"`
 	Title       string          `json:"title"`
 	DocumentID  string          `json:"document_id"`
+	DocumentIDs []string        `json:"document_ids"`
 	ParentID    string          `json:"parent_id"`
 	NewParentID string          `json:"new_parent_id"`
 	Type        string          `json:"type"`
@@ -160,7 +162,9 @@ func (d *Document) Execute(ctx context.Context, raw json.RawMessage) (tools.Resu
 	case "create_document":
 		return d.createDocument(ctx, key, mscope, in)
 	case "get_document":
-		return d.getDocument(ctx, key, in)
+		return d.getDocument(ctx, key, mscope, in)
+	case "documents_summary":
+		return d.documentsSummary(ctx, key, mscope, in)
 	case "delete_document":
 		return d.deleteDocument(ctx, key, mscope, in)
 	case "set_path":
@@ -616,7 +620,7 @@ func (d *Document) docIDFromInput(ctx context.Context, key sqlmem.ScopeKey, in d
 	return ref.DocumentID, nil
 }
 
-func (d *Document) getDocument(ctx context.Context, key sqlmem.ScopeKey, in docInput) (tools.Result, error) {
+func (d *Document) getDocument(ctx context.Context, key sqlmem.ScopeKey, mscope store.MemoryScope, in docInput) (tools.Result, error) {
 	docID, err := d.docIDFromInput(ctx, key, in)
 	if err != nil {
 		return errResult("get_document: " + err.Error()), nil
@@ -632,10 +636,153 @@ func (d *Document) getDocument(ctx context.Context, key sqlmem.ScopeKey, in docI
 	for i, c := range res.Columns {
 		m[c] = res.Rows[0][i]
 	}
-	return jsonResult(map[string]any{
+	rootID := asStr(m["root_chunk_id"])
+	resp := map[string]any{
 		"document_id": asStr(m["id"]), "title": asStr(m["title"]),
-		"root_chunk_id": asStr(m["root_chunk_id"]),
-	})
+		"root_chunk_id": rootID,
+	}
+	// Enrich with the ROOT chunk's type/status (the document's own kind/state)
+	// and its RFC BN color settings (persisted in the root chunk's fields) so the
+	// UI can render a document tile/tree row without a second get_chunk.
+	if rootID != "" {
+		if row, ok, rerr := d.getChunkRow(ctx, key, rootID); rerr == nil && ok {
+			if row.Type != "" {
+				resp["type"] = row.Type
+			}
+			if row.Status != "" {
+				resp["status"] = row.Status
+			}
+		}
+		enabled, scheme := docColorMeta(d.readBody(ctx, mscope, key.ScopeID, rootID))
+		resp["color_enabled"] = enabled
+		if len(scheme) > 0 {
+			resp["color_scheme"] = scheme
+		}
+	}
+	return jsonResult(resp)
+}
+
+// docColorMeta extracts the RFC BN per-document color settings from a root
+// chunk's Memory-stored fields. color_enabled toggles tinting for the whole
+// document; color_scheme is an opaque frontend map (doc.<type>.<status> and
+// chunk.<status> → CSS color) the backend stores and returns verbatim — it does
+// not interpret the palette. Both are optional; absent → (false, nil).
+func docColorMeta(cb chunkBody) (enabled bool, scheme json.RawMessage) {
+	if len(cb.Fields) == 0 {
+		return false, nil
+	}
+	var f struct {
+		ColorEnabled *bool           `json:"color_enabled"`
+		ColorScheme  json.RawMessage `json:"color_scheme"`
+	}
+	if err := json.Unmarshal(cb.Fields, &f); err != nil {
+		return false, nil
+	}
+	if f.ColorEnabled != nil {
+		enabled = *f.ColorEnabled
+	}
+	return enabled, f.ColorScheme
+}
+
+// inPlaceholders builds a `?,?,…` list and the matching args for a SQL IN clause
+// (Rebind converts `?`→`$N` on the postgres tier). Caller guarantees len>0.
+func inPlaceholders(ids []string) (string, []any) {
+	var sb strings.Builder
+	args := make([]any, 0, len(ids))
+	for i, id := range ids {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		sb.WriteByte('?')
+		args = append(args, id)
+	}
+	return sb.String(), args
+}
+
+// documentsSummary returns per-document display metadata — title, the ROOT
+// chunk's type/status, and the RFC BN color settings — for a set of document ids
+// and/or every document under a Path-tree path. It powers the Path-tree coloring
+// in ONE call (dirents carry only a document_id, not type/status), avoiding an
+// N+1 of get_document per row. Unknown/out-of-scope ids are silently skipped
+// (opaque — a caller can't probe another scope's documents).
+func (d *Document) documentsSummary(ctx context.Context, key sqlmem.ScopeKey, mscope store.MemoryScope, in docInput) (tools.Result, error) {
+	ids := in.DocumentIDs
+	if in.UnderPath != "" {
+		under, err := d.documentsUnderPath(ctx, key, in.UnderPath)
+		if err != nil {
+			return errResult("documents_summary: " + err.Error()), nil
+		}
+		ids = append(ids, under...)
+	}
+	// Dedup + drop empties (a caller may mix document_ids with under_path, and
+	// the two sets can overlap).
+	seen := map[string]bool{}
+	var uniq []string
+	for _, id := range ids {
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		uniq = append(uniq, id)
+	}
+	if len(uniq) == 0 {
+		return jsonResult(map[string]any{"documents": []any{}})
+	}
+	// Batch: the documents rows.
+	ph, args := inPlaceholders(uniq)
+	dres, err := d.query(ctx, key, `SELECT id, title, root_chunk_id FROM documents WHERE id IN (`+ph+`)`, args...)
+	if err != nil {
+		return errResult("documents_summary: " + err.Error()), nil
+	}
+	type docMeta struct{ title, root string }
+	docs := map[string]docMeta{}
+	var rootIDs []string
+	for _, r := range dres.Rows {
+		id, title, root := asStr(r[0]), asStr(r[1]), asStr(r[2])
+		docs[id] = docMeta{title: title, root: root}
+		if root != "" {
+			rootIDs = append(rootIDs, root)
+		}
+	}
+	// Batch: the root chunk rows (type/status).
+	rootRows := map[string]chunkRow{}
+	if len(rootIDs) > 0 {
+		rph, rargs := inPlaceholders(rootIDs)
+		rres, err := d.query(ctx, key, `SELECT `+chunkSelectCols+` FROM chunks WHERE id IN (`+rph+`)`, rargs...)
+		if err != nil {
+			return errResult("documents_summary: " + err.Error()), nil
+		}
+		for _, r := range rres.Rows {
+			row := scanChunkRow(rres.Columns, r)
+			rootRows[row.ID] = row
+		}
+	}
+	out := make([]map[string]any, 0, len(uniq))
+	for _, id := range uniq {
+		dm, ok := docs[id]
+		if !ok {
+			continue // no such document in this scope → skip (opaque)
+		}
+		entry := map[string]any{"document_id": id, "title": dm.title, "color_enabled": false}
+		if dm.root != "" {
+			entry["root_chunk_id"] = dm.root
+			if row, ok := rootRows[dm.root]; ok {
+				if row.Type != "" {
+					entry["type"] = row.Type
+				}
+				if row.Status != "" {
+					entry["status"] = row.Status
+				}
+			}
+			enabled, scheme := docColorMeta(d.readBody(ctx, mscope, key.ScopeID, dm.root))
+			entry["color_enabled"] = enabled
+			if len(scheme) > 0 {
+				entry["color_scheme"] = scheme
+			}
+		}
+		out = append(out, entry)
+	}
+	return jsonResult(map[string]any{"documents": out})
 }
 
 func (d *Document) deleteDocument(ctx context.Context, key sqlmem.ScopeKey, mscope store.MemoryScope, in docInput) (tools.Result, error) {

--- a/internal/tools/builtin/document_test.go
+++ b/internal/tools/builtin/document_test.go
@@ -790,3 +790,101 @@ func TestDocument_ChunkStatusBoardRoundTrip(t *testing.T) {
 		t.Errorf("SetChunkStatus(nope) err = %v, want 'no such chunk'", err)
 	}
 }
+
+// TestDocument_ColorMetadataAndSummary covers RFC BN P3: get_document surfaces
+// the ROOT chunk's type/status + the per-document color settings, and
+// documents_summary returns the same for a set of ids or a Path subtree in one
+// call (so the Path tree can color rows without an N+1 of get_document).
+func TestDocument_ColorMetadataAndSummary(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+
+	out, res := docExec(t, d, ctx, `{"op":"create_document","scope":"agent","title":"RFC One","path":"/docs/rfc-one"}`)
+	if res.IsError {
+		t.Fatalf("create doc1: %q", res.Text)
+	}
+	doc1, root1 := out["document_id"].(string), out["root_chunk_id"].(string)
+
+	out, res = docExec(t, d, ctx, `{"op":"create_document","scope":"agent","title":"RFC Two","path":"/docs/rfc-two"}`)
+	if res.IsError {
+		t.Fatalf("create doc2: %q", res.Text)
+	}
+	doc2, root2 := out["document_id"].(string), out["root_chunk_id"].(string)
+
+	// doc1: kind/state + color settings on its ROOT chunk (revision 1).
+	scheme := `{"doc.rfc.done":"#123456","chunk.done":"#654321"}`
+	_, res = docExec(t, d, ctx, `{"op":"update_chunk","scope":"agent","id":"`+root1+`","revision":1,"type":"rfc","status":"done","fields":{"color_enabled":true,"color_scheme":`+scheme+`}}`)
+	if res.IsError {
+		t.Fatalf("update root1: %q", res.Text)
+	}
+	// doc2: a kind/state but NO color settings (disabled by default).
+	_, res = docExec(t, d, ctx, `{"op":"update_chunk","scope":"agent","id":"`+root2+`","revision":1,"type":"rfc","status":"draft"}`)
+	if res.IsError {
+		t.Fatalf("update root2: %q", res.Text)
+	}
+
+	// get_document surfaces the root's type/status + color settings.
+	out, res = docExec(t, d, ctx, `{"op":"get_document","scope":"agent","id":"`+doc1+`"}`)
+	if res.IsError {
+		t.Fatalf("get_document: %q", res.Text)
+	}
+	if out["type"] != "rfc" || out["status"] != "done" {
+		t.Errorf("get_document type/status = %s", res.Text)
+	}
+	if out["color_enabled"] != true {
+		t.Errorf("get_document color_enabled = %v, want true", out["color_enabled"])
+	}
+	if cs, _ := out["color_scheme"].(map[string]any); cs["doc.rfc.done"] != "#123456" {
+		t.Errorf("get_document color_scheme = %v", out["color_scheme"])
+	}
+
+	// A color-less document: color_enabled=false and no color_scheme key.
+	out, res = docExec(t, d, ctx, `{"op":"get_document","scope":"agent","id":"`+doc2+`"}`)
+	if res.IsError {
+		t.Fatalf("get_document doc2: %q", res.Text)
+	}
+	if out["color_enabled"] != false {
+		t.Errorf("doc2 color_enabled = %v, want false", out["color_enabled"])
+	}
+	if _, has := out["color_scheme"]; has {
+		t.Errorf("doc2 should have no color_scheme: %s", res.Text)
+	}
+
+	// documents_summary by explicit ids: both docs, type/status + color flags.
+	out, res = docExec(t, d, ctx, `{"op":"documents_summary","scope":"agent","document_ids":["`+doc1+`","`+doc2+`"]}`)
+	if res.IsError {
+		t.Fatalf("documents_summary ids: %q", res.Text)
+	}
+	docs, _ := out["documents"].([]any)
+	if len(docs) != 2 {
+		t.Fatalf("documents_summary = %d docs, want 2: %s", len(docs), res.Text)
+	}
+	byID := map[string]map[string]any{}
+	for _, dd := range docs {
+		m := dd.(map[string]any)
+		byID[m["document_id"].(string)] = m
+	}
+	if byID[doc1]["type"] != "rfc" || byID[doc1]["status"] != "done" || byID[doc1]["color_enabled"] != true {
+		t.Errorf("summary doc1 = %v", byID[doc1])
+	}
+	if byID[doc2]["color_enabled"] != false {
+		t.Errorf("summary doc2 color_enabled = %v, want false", byID[doc2]["color_enabled"])
+	}
+
+	// documents_summary by under_path resolves the same set via the Path tree.
+	out, res = docExec(t, d, ctx, `{"op":"documents_summary","scope":"agent","under_path":"/docs"}`)
+	if res.IsError {
+		t.Fatalf("documents_summary under_path: %q", res.Text)
+	}
+	if docs, _ := out["documents"].([]any); len(docs) != 2 {
+		t.Errorf("under_path summary = %d docs, want 2: %s", len(docs), res.Text)
+	}
+
+	// An unknown id is silently skipped (opaque), not an error.
+	out, res = docExec(t, d, ctx, `{"op":"documents_summary","scope":"agent","document_ids":["`+doc1+`","nope"]}`)
+	if res.IsError {
+		t.Fatalf("documents_summary unknown: %q", res.Text)
+	}
+	if docs, _ := out["documents"].([]any); len(docs) != 1 {
+		t.Errorf("unknown id should be skipped: %s", res.Text)
+	}
+}

--- a/packages/explorer/src/PathExplorer.tsx
+++ b/packages/explorer/src/PathExplorer.tsx
@@ -16,6 +16,7 @@ import type {
   Principal,
 } from "./types";
 import { useExplorerData, type ExplorerDataLayer } from "./lib/dataLayer";
+import type { DocSummary } from "./lib/colorScheme";
 import {
   ExplorerRoot,
   useResolvedDataLayer,
@@ -206,6 +207,41 @@ function PathExplorerBody({
   }, [refresh, setSelected]);
 
   const tree = useMemo(() => buildPathTree(entries), [entries]);
+
+  // RFC BN: fetch per-document type/status + color settings for every document
+  // dirent in the tree, in ONE documents_summary call, so PathTree can color +
+  // badge document rows. Best-effort — a failure just leaves rows neutral.
+  const [summaries, setSummaries] = useState<Map<string, DocSummary>>(() => new Map());
+  useEffect(() => {
+    if (scope === "tenant") {
+      setSummaries(new Map()); // documents are agent|user only
+      return;
+    }
+    const ids = entries
+      .filter((e) => e.kind === "document")
+      .map((e) => (e.resource_ref as { document_id?: string } | undefined)?.document_id)
+      .filter((id): id is string => !!id);
+    if (ids.length === 0) {
+      setSummaries(new Map());
+      return;
+    }
+    let cancelled = false;
+    data
+      .documentsSummary({ documentIds: ids }, scope as DocScope, browse)
+      .then((resp) => {
+        if (cancelled) return;
+        const m = new Map<string, DocSummary>();
+        for (const d of resp.documents ?? []) m.set(d.document_id, d);
+        setSummaries(m);
+      })
+      .catch(() => {
+        if (!cancelled) setSummaries(new Map());
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [data, entries, scope, browse]);
+
   const selected = useMemo(
     () => (selectedPath ? findNode(tree, selectedPath) : undefined),
     [tree, selectedPath],
@@ -386,6 +422,7 @@ function PathExplorerBody({
               tree={tree}
               selectedPath={selectedPath}
               onSelect={(n) => setSelected(n.fullPath)}
+              summaries={summaries}
             />
           )}
         </div>

--- a/packages/explorer/src/components/ColorSchemeEditor.tsx
+++ b/packages/explorer/src/components/ColorSchemeEditor.tsx
@@ -1,0 +1,232 @@
+import { useEffect, useMemo, useState } from "react";
+import type { BrowseScope, ChunkDetail, DocScope } from "../types";
+import { useExplorerData } from "../lib/dataLayer";
+import { DEFAULT_SCHEME, type ColorScheme } from "../lib/colorScheme";
+
+// ColorSchemeEditor edits a document's RFC BN color settings — the color_enabled
+// flag + the per-(doc-type/status) and per-(chunk-status) palette — persisted in
+// the document's ROOT chunk fields. It fetches the root chunk on open (for the
+// revision + any sibling fields it must preserve) and writes back with
+// update_chunk. A "copy to all documents of this type" action stamps the same
+// palette onto every same-type document in scope, so a tree of like documents
+// stays visually consistent without per-doc editing.
+export interface ColorSchemeEditorProps {
+  documentId: string;
+  rootChunkId: string;
+  docType?: string;
+  docStatus?: string;
+  // chunkStatuses — the distinct statuses present in this document's chunks, so
+  // the editor offers a color for each one actually in use (plus the defaults).
+  chunkStatuses: string[];
+  scope: DocScope;
+  browse?: BrowseScope;
+  onClose: () => void;
+  // onSaved fires after a successful save so the viewer reloads its color meta +
+  // re-tints the tree.
+  onSaved: () => void;
+}
+
+// normalizeHex coerces a scheme color to the #rrggbb an <input type="color">
+// requires (it rejects #rgb and names); a bad value falls back to neutral grey.
+function normalizeHex(v: string | undefined): string {
+  const m = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i.exec((v ?? "").trim());
+  if (!m) return "#888888";
+  let h = m[1];
+  if (h.length === 3) h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
+  return "#" + h.toLowerCase();
+}
+
+export default function ColorSchemeEditor({
+  documentId,
+  rootChunkId,
+  docType,
+  docStatus,
+  chunkStatuses,
+  scope,
+  browse,
+  onClose,
+  onSaved,
+}: ColorSchemeEditorProps) {
+  const data = useExplorerData();
+  const [root, setRoot] = useState<ChunkDetail | null>(null);
+  const [enabled, setEnabled] = useState(false);
+  const [scheme, setScheme] = useState<ColorScheme>({});
+  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState<string | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  // The keys the editor exposes: the defaults, plus this document's own doc key
+  // and every chunk-status key actually in use — so a document with a bespoke
+  // type/status still gets a picker. Stable + grouped (doc.* then chunk.*).
+  const keys = useMemo(() => {
+    const set = new Set<string>(Object.keys(DEFAULT_SCHEME));
+    if (docType) set.add(`doc.${docType}.${docStatus || "draft"}`);
+    for (const s of chunkStatuses) if (s) set.add(`chunk.${s}`);
+    return [...set].sort();
+  }, [docType, docStatus, chunkStatuses]);
+
+  // Load the root chunk once for its revision + existing fields + stored scheme.
+  useEffect(() => {
+    let cancelled = false;
+    data
+      .documentGetChunk(rootChunkId, scope, browse)
+      .then((d) => {
+        if (cancelled) return;
+        setRoot(d);
+        const f = (d.fields ?? {}) as Record<string, unknown>;
+        setEnabled(f.color_enabled === true);
+        const stored = (f.color_scheme as ColorScheme) ?? {};
+        // Seed from defaults so every picker shows a sensible starting color,
+        // with the document's stored overrides on top.
+        setScheme({ ...DEFAULT_SCHEME, ...stored });
+      })
+      .catch((e) => !cancelled && setErr(e instanceof Error ? e.message : String(e)));
+    return () => {
+      cancelled = true;
+    };
+  }, [data, rootChunkId, scope, browse]);
+
+  const setColor = (key: string, hex: string) =>
+    setScheme((prev) => ({ ...prev, [key]: hex }));
+
+  // fieldsWith merges the color settings into an existing chunk's fields, so a
+  // save never clobbers other typed fields the root chunk carries.
+  const fieldsWith = (existing: unknown): Record<string, unknown> => ({
+    ...((existing ?? {}) as Record<string, unknown>),
+    color_enabled: enabled,
+    color_scheme: scheme,
+  });
+
+  const save = async () => {
+    if (!root) return;
+    setBusy(true);
+    setErr(null);
+    setStatus(null);
+    try {
+      await data.documentUpdateChunk(
+        rootChunkId,
+        root.revision,
+        { fields: fieldsWith(root.fields) },
+        scope,
+        browse,
+      );
+      onSaved();
+      onClose();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+      setBusy(false);
+    }
+  };
+
+  // copyToType stamps THIS palette onto every OTHER document of the same type in
+  // scope (best-effort; reports how many were updated). Each target is read for
+  // its own root revision + fields so the write is a safe merge.
+  const copyToType = async () => {
+    if (!docType) {
+      setErr("this document has no type to match");
+      return;
+    }
+    setBusy(true);
+    setErr(null);
+    setStatus(null);
+    try {
+      const { documents } = await data.documentsSummary({ underPath: "/" }, scope, browse);
+      const targets = (documents ?? []).filter(
+        (d) => d.type === docType && d.document_id !== documentId && d.root_chunk_id,
+      );
+      let applied = 0;
+      for (const t of targets) {
+        try {
+          const tr = await data.documentGetChunk(t.root_chunk_id as string, scope, browse);
+          await data.documentUpdateChunk(
+            t.root_chunk_id as string,
+            tr.revision,
+            { fields: fieldsWith(tr.fields) },
+            scope,
+            browse,
+          );
+          applied++;
+        } catch {
+          // Skip a target that failed (revision race / gone); keep going.
+        }
+      }
+      setStatus(`Applied to ${applied} other ${docType} document(s).`);
+      onSaved();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const docKeys = keys.filter((k) => k.startsWith("doc."));
+  const chunkKeys = keys.filter((k) => k.startsWith("chunk."));
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal scheme-editor" onClick={(e) => e.stopPropagation()}>
+        <div className="scheme-editor-head">
+          <h3>Document colors</h3>
+          <div className="scheme-editor-actions">
+            <button type="button" onClick={onClose} disabled={busy}>
+              cancel
+            </button>
+            <button type="button" className="primary" onClick={() => void save()} disabled={busy || !root}>
+              {busy ? "saving…" : "save"}
+            </button>
+          </div>
+        </div>
+        {err && <div className="modal-err">{err}</div>}
+        {!root ? (
+          <p className="modal-context">Loading…</p>
+        ) : (
+          <>
+            <label className="scheme-toggle">
+              <input
+                type="checkbox"
+                checked={enabled}
+                onChange={(e) => setEnabled(e.target.checked)}
+              />
+              <span>Enable coloring for this document</span>
+            </label>
+            <p className="modal-context">
+              Document rows are tinted by type + status; chunk tiles by status. Colors apply as a
+              semi-transparent wash so text stays readable.
+            </p>
+
+            <div className="scheme-group">
+              <h4>Document (type · status)</h4>
+              {docKeys.map((k) => (
+                <ColorRow key={k} label={k.slice("doc.".length)} value={scheme[k]} onChange={(hex) => setColor(k, hex)} />
+              ))}
+            </div>
+            <div className="scheme-group">
+              <h4>Chunks (status)</h4>
+              {chunkKeys.map((k) => (
+                <ColorRow key={k} label={k.slice("chunk.".length)} value={scheme[k]} onChange={(hex) => setColor(k, hex)} />
+              ))}
+            </div>
+
+            <div className="scheme-editor-foot">
+              <button type="button" onClick={() => void copyToType()} disabled={busy || !docType} title={docType ? `Apply this palette to every other ${docType} document` : "This document has no type"}>
+                copy to all {docType || "same-type"} documents
+              </button>
+              {status && <span className="scheme-status">{status}</span>}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ColorRow({ label, value, onChange }: { label: string; value: string | undefined; onChange: (hex: string) => void }) {
+  const hex = normalizeHex(value);
+  return (
+    <label className="scheme-row">
+      <input type="color" value={hex} onChange={(e) => onChange(e.target.value)} />
+      <span className="scheme-key">{label}</span>
+      <code className="scheme-hex">{hex}</code>
+    </label>
+  );
+}

--- a/packages/explorer/src/components/DocumentChunkTree.tsx
+++ b/packages/explorer/src/components/DocumentChunkTree.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import type { ChunkRow } from "../types";
+import { chunkColor, effectiveScheme, tintStyle, type ColorScheme } from "../lib/colorScheme";
 
 // DocumentChunkTree renders a document's chunk hierarchy (RFC AK), built from
 // the flat query_chunks list by parent_id + position. Mirrors PathTree: a single
@@ -44,9 +45,19 @@ export interface DocumentChunkTreeProps {
   tree: ChunkNode[];
   selectedId?: string;
   onSelect: (node: ChunkNode) => void;
+  // RFC BN: when colorEnabled, chunk rows are tinted by status via `scheme`
+  // (falls back to the default palette). Unset → neutral rows (prior behavior).
+  colorEnabled?: boolean;
+  scheme?: ColorScheme;
 }
 
-export default function DocumentChunkTree({ tree, selectedId, onSelect }: DocumentChunkTreeProps) {
+export default function DocumentChunkTree({
+  tree,
+  selectedId,
+  onSelect,
+  colorEnabled,
+  scheme,
+}: DocumentChunkTreeProps) {
   const [expanded, setExpanded] = useState<Map<string, boolean>>(() => new Map());
   const toggle = useCallback((id: string) => {
     setExpanded((prev) => {
@@ -74,6 +85,9 @@ export default function DocumentChunkTree({ tree, selectedId, onSelect }: Docume
     });
   }, [tree, selectedId]);
 
+  // Resolve the palette once (null → no tinting) and thread it down.
+  const tintScheme = colorEnabled ? effectiveScheme(scheme) : null;
+
   if (tree.length === 0) {
     return (
       <div className="empty">
@@ -91,6 +105,7 @@ export default function DocumentChunkTree({ tree, selectedId, onSelect }: Docume
           toggle={toggle}
           selectedId={selectedId}
           onSelect={onSelect}
+          tintScheme={tintScheme}
         />
       ))}
     </ul>
@@ -119,15 +134,17 @@ interface NodeProps {
   toggle: (id: string) => void;
   selectedId?: string;
   onSelect: (node: ChunkNode) => void;
+  tintScheme: ColorScheme | null;
 }
 
-function ChunkTreeNode({ node, expanded, toggle, selectedId, onSelect }: NodeProps) {
+function ChunkTreeNode({ node, expanded, toggle, selectedId, onSelect, tintScheme }: NodeProps) {
   const hasChildren = node.children.length > 0;
   const isOpen = expanded.get(node.row.id) !== false; // default-expanded
   const isSelected = selectedId === node.row.id;
+  const rowStyle = tintScheme ? tintStyle(chunkColor(node.row.status, tintScheme)) : undefined;
   return (
     <li className={`node chunk-node ${isSelected ? "selected" : ""}`}>
-      <div className="row chunk-row">
+      <div className="row chunk-row" style={rowStyle}>
         <button
           type="button"
           className="tree-caret"
@@ -161,6 +178,7 @@ function ChunkTreeNode({ node, expanded, toggle, selectedId, onSelect }: NodePro
               toggle={toggle}
               selectedId={selectedId}
               onSelect={onSelect}
+              tintScheme={tintScheme}
             />
           ))}
         </ul>

--- a/packages/explorer/src/components/DocumentViewerBody.tsx
+++ b/packages/explorer/src/components/DocumentViewerBody.tsx
@@ -8,12 +8,19 @@ import type {
   Principal,
 } from "../types";
 import { useExplorerData } from "../lib/dataLayer";
+import {
+  docColor,
+  effectiveScheme,
+  tintStyle,
+  type DocumentMeta,
+} from "../lib/colorScheme";
 import DocumentChunkTree, {
   buildChunkTree,
   findChunkNode,
   type ChunkNode,
 } from "./DocumentChunkTree";
 import ChunkEditorModal from "./ChunkEditorModal";
+import ColorSchemeEditor from "./ColorSchemeEditor";
 import Markdown from "./Markdown";
 
 // DocumentViewerBody is the read-mostly surface for one chunked-graph document
@@ -79,6 +86,8 @@ export default function DocumentViewerBody({
   const [loading, setLoading] = useState(false);
   const [reload, setReload] = useState(0);
   const [assistantOpen, setAssistantOpen] = useState(false);
+  const [meta, setMeta] = useState<DocumentMeta | null>(null);
+  const [colorsOpen, setColorsOpen] = useState(false);
 
   const refresh = useCallback(() => setReload((n) => n + 1), []);
 
@@ -90,6 +99,26 @@ export default function DocumentViewerBody({
   const selectedIsRoot = useMemo(
     () => !!selectedDetail && !selectedDetail.parent_id,
     [selectedDetail],
+  );
+
+  // Color (RFC BN). rootChunkId comes from the meta (or the loaded root chunk);
+  // chunkStatuses seeds the editor's per-status pickers; the toolbar tints to the
+  // document's own doc.<type>.<status> color when coloring is enabled.
+  const rootChunkId = useMemo(
+    () => meta?.root_chunk_id ?? chunks.find((c) => !c.parent_id)?.id,
+    [meta, chunks],
+  );
+  const chunkStatuses = useMemo(
+    () => [...new Set(chunks.map((c) => c.status).filter((s): s is string => !!s))],
+    [chunks],
+  );
+  const colorEnabled = !!meta?.color_enabled;
+  const toolbarTint = useMemo(
+    () =>
+      colorEnabled
+        ? tintStyle(docColor(meta?.type, meta?.status, effectiveScheme(meta?.color_scheme)))
+        : undefined,
+    [colorEnabled, meta?.type, meta?.status, meta?.color_scheme],
   );
 
   // Load the chunk list when the document / scope / reload changes. Default the
@@ -113,12 +142,27 @@ export default function DocumentViewerBody({
     };
   }, [data, documentId, scope, reload, browse]);
 
+  // Load the document's color metadata (RFC BN) alongside the chunk list. It
+  // drives the chunk-tree tint, the toolbar tint, and seeds the color editor.
+  // Best-effort — a failure just leaves the document uncolored.
+  useEffect(() => {
+    let cancelled = false;
+    data
+      .documentGet(documentId, scope, browse)
+      .then((m) => !cancelled && setMeta(m))
+      .catch(() => !cancelled && setMeta(null));
+    return () => {
+      cancelled = true;
+    };
+  }, [data, documentId, scope, reload, browse]);
+
   // Reset selection + view when the document changes.
   useEffect(() => {
     setSelectedId(undefined);
     setSelectedDetail(null);
     setSubtreeMd(null);
     setMode("chunks");
+    setMeta(null);
   }, [documentId, scope]);
 
   // Fetch the selected chunk's body.
@@ -194,11 +238,20 @@ export default function DocumentViewerBody({
 
   return (
     <div className="doc-viewer">
-      <div className="doc-toolbar">
+      <div className="doc-toolbar" style={toolbarTint}>
         <strong className="doc-title" title={rootTitle}>
           {rootTitle}
         </strong>
         <div className="doc-toolbar-actions">
+          <button
+            type="button"
+            className={colorEnabled ? "active" : ""}
+            onClick={() => setColorsOpen(true)}
+            disabled={!rootChunkId}
+            title="Colors — tint chunk tiles + the Path tree by type/status"
+          >
+            colors
+          </button>
           <button type="button" onClick={() => void download()} title="Download the whole document as Markdown (.md)">
             ↓ .md
           </button>
@@ -225,7 +278,13 @@ export default function DocumentViewerBody({
               <p>Loading…</p>
             </div>
           ) : (
-            <DocumentChunkTree tree={tree} selectedId={selectedId} onSelect={onSelect} />
+            <DocumentChunkTree
+              tree={tree}
+              selectedId={selectedId}
+              onSelect={onSelect}
+              colorEnabled={colorEnabled}
+              scheme={meta?.color_scheme}
+            />
           )}
         </div>
         <div className="doc-content">
@@ -310,6 +369,19 @@ export default function DocumentViewerBody({
           scope={scope}
           browse={browse}
           onClose={() => setEditing(null)}
+          onSaved={refresh}
+        />
+      )}
+      {colorsOpen && rootChunkId && (
+        <ColorSchemeEditor
+          documentId={documentId}
+          rootChunkId={rootChunkId}
+          docType={meta?.type}
+          docStatus={meta?.status}
+          chunkStatuses={chunkStatuses}
+          scope={scope}
+          browse={browse}
+          onClose={() => setColorsOpen(false)}
           onSaved={refresh}
         />
       )}

--- a/packages/explorer/src/components/PathTree.tsx
+++ b/packages/explorer/src/components/PathTree.tsx
@@ -1,5 +1,11 @@
 import { useCallback, useEffect, useState } from "react";
 import type { PathEntry } from "../types";
+import {
+  docColor,
+  effectiveScheme,
+  tintStyle,
+  type DocSummary,
+} from "../lib/colorScheme";
 
 // PathTree renders the RFC AL dirent tree. The Path tool's `ls recursive`
 // returns a FLAT list of dirents; buildPathTree reconstructs the hierarchy,
@@ -98,9 +104,12 @@ export interface PathTreeProps {
   tree: PathNode[];
   selectedPath?: string;
   onSelect: (node: PathNode) => void;
+  // RFC BN: per-document display metadata keyed by document_id, used to color a
+  // document row + badge its type/status. Unset → neutral rows (prior behavior).
+  summaries?: Map<string, DocSummary>;
 }
 
-export default function PathTree({ tree, selectedPath, onSelect }: PathTreeProps) {
+export default function PathTree({ tree, selectedPath, onSelect, summaries }: PathTreeProps) {
   const [expanded, setExpanded] = useState<Map<string, boolean>>(() => new Map());
   const toggle = useCallback((p: string) => {
     setExpanded((prev) => {
@@ -146,6 +155,7 @@ export default function PathTree({ tree, selectedPath, onSelect }: PathTreeProps
           toggle={toggle}
           selectedPath={selectedPath}
           onSelect={onSelect}
+          summaries={summaries}
         />
       ))}
     </ul>
@@ -158,15 +168,29 @@ interface NodeProps {
   toggle: (p: string) => void;
   selectedPath?: string;
   onSelect: (node: PathNode) => void;
+  summaries?: Map<string, DocSummary>;
 }
 
-function PathTreeNode({ node, expanded, toggle, selectedPath, onSelect }: NodeProps) {
+// documentSummaryOf returns the summary for a `document` node (by its dirent's
+// document_id), or undefined for a non-document node / missing summary.
+function documentSummaryOf(node: PathNode, summaries?: Map<string, DocSummary>): DocSummary | undefined {
+  if (node.kind !== "document" || !summaries) return undefined;
+  const ref = node.resourceRef as { document_id?: string } | undefined;
+  return ref?.document_id ? summaries.get(ref.document_id) : undefined;
+}
+
+function PathTreeNode({ node, expanded, toggle, selectedPath, onSelect, summaries }: NodeProps) {
   const hasChildren = node.children.length > 0;
   const isOpen = expanded.get(node.fullPath) !== false; // default-expanded
   const isSelected = selectedPath === node.fullPath;
+  const summary = documentSummaryOf(node, summaries);
+  const rowStyle =
+    summary && summary.color_enabled
+      ? tintStyle(docColor(summary.type, summary.status, effectiveScheme(summary.color_scheme)))
+      : undefined;
   return (
     <li className={`node path-node kind-${node.kind} ${isSelected ? "selected" : ""}`}>
-      <div className="row path-row">
+      <div className="row path-row" style={rowStyle}>
         <button
           type="button"
           className="tree-caret"
@@ -189,6 +213,8 @@ function PathTreeNode({ node, expanded, toggle, selectedPath, onSelect }: NodePr
             {KIND_ICON[node.kind] ?? "•"}
           </span>
           <span className="path-name">{node.name}</span>
+          {summary?.type && <span className="chunk-badge">{summary.type}</span>}
+          {summary?.status && <span className="chunk-badge chunk-status">{summary.status}</span>}
           {!node.explicit && (
             <span className="path-implicit" title="Implicit directory (no stored entry)">
               implicit
@@ -206,6 +232,7 @@ function PathTreeNode({ node, expanded, toggle, selectedPath, onSelect }: NodePr
               toggle={toggle}
               selectedPath={selectedPath}
               onSelect={onSelect}
+              summaries={summaries}
             />
           ))}
         </ul>

--- a/packages/explorer/src/index.ts
+++ b/packages/explorer/src/index.ts
@@ -32,6 +32,19 @@ export type { Connection } from "./lib/createClient";
 export { dataLayerFromClient } from "./lib/dataLayer";
 export type { ExplorerDataLayer, ChunkPatch } from "./lib/dataLayer";
 
+// RFC BN per-document color schemes: the metadata shapes the data layer produces
+// (documents_summary / get_document) + the palette resolvers, for a host that
+// renders its own colored view.
+export type { ColorScheme, DocSummary, DocumentMeta } from "./lib/colorScheme";
+export {
+  DEFAULT_SCHEME,
+  effectiveScheme,
+  docColor,
+  chunkColor,
+  hexToTint,
+  tintStyle,
+} from "./lib/colorScheme";
+
 // The shared data-source contract (connection | client | dataLayer), for hosts
 // typing their own wrappers.
 export type { ExplorerDataSource } from "./components/ExplorerRoot";

--- a/packages/explorer/src/lib/colorScheme.ts
+++ b/packages/explorer/src/lib/colorScheme.ts
@@ -1,0 +1,108 @@
+import type { CSSProperties } from "react";
+
+// RFC BN per-document color schemes. A document can tint its chunk tiles and its
+// Path-tree row by (document type, state) and (chunk state), so a reader scanning
+// the tree sees kind + progress at a glance. A scheme is a flat map of semantic
+// keys → CSS hex colors, stored in the document's ROOT chunk fields (color_scheme)
+// alongside a color_enabled flag; the backend stores/returns it verbatim and this
+// module is the only place that interprets it.
+
+// ColorScheme maps a semantic key to a CSS hex color. Keys:
+//   doc.<type>.<status>  — a document tile/row by its ROOT chunk's type + status
+//   doc.<type>           — fallback for any status of that document type
+//   chunk.<status>       — a chunk tile by its own status
+// Unknown keys are ignored; a missing key → no tint (neutral).
+export type ColorScheme = Record<string, string>;
+
+// DocSummary is one row of the document `documents_summary` op (Path-tree color).
+export interface DocSummary {
+  document_id: string;
+  title: string;
+  root_chunk_id?: string;
+  type?: string;
+  status?: string;
+  color_enabled: boolean;
+  color_scheme?: ColorScheme;
+}
+
+// DocumentMeta is the enriched get_document result (the viewer's own document).
+export interface DocumentMeta {
+  document_id: string;
+  title: string;
+  root_chunk_id?: string;
+  type?: string;
+  status?: string;
+  color_enabled: boolean;
+  color_scheme?: ColorScheme;
+}
+
+// DEFAULT_SCHEME seeds a new document's palette. The hexes are mid-tone so the
+// low-alpha wash reads on BOTH the dark and light explorer themes; the scheme
+// editor starts from this, and the resolver falls back to it when a document has
+// color_enabled but no stored scheme yet.
+export const DEFAULT_SCHEME: ColorScheme = {
+  "doc.rfc.draft": "#c99a3a",
+  "doc.rfc.review": "#6a7bd6",
+  "doc.rfc.confirmed": "#3a9ad6",
+  "doc.rfc.done": "#3aa06a",
+  "doc.document.done": "#3aa06a",
+  "doc.research.done": "#8a6ad6",
+  "doc.publication.draft": "#c99a3a",
+  "chunk.draft": "#c99a3a",
+  "chunk.review": "#6a7bd6",
+  "chunk.confirmed": "#3a9ad6",
+  "chunk.done": "#3aa06a",
+};
+
+// TINT_ALPHA washes every scheme color into a tile background — a tint, not a
+// fill — so the row text stays readable (the loomcycle tinted-tile pattern).
+const TINT_ALPHA = 0.16;
+
+// effectiveScheme is what the resolvers read: the stored scheme if present, else
+// the defaults (so color_enabled alone gives a sensible palette before any edit).
+export function effectiveScheme(scheme: ColorScheme | undefined): ColorScheme {
+  return scheme && Object.keys(scheme).length > 0 ? scheme : DEFAULT_SCHEME;
+}
+
+// docColor resolves a document's raw tile color from its (type,status): tries
+// doc.<type>.<status>, then doc.<type>. Returns undefined for no match.
+export function docColor(
+  type: string | undefined,
+  status: string | undefined,
+  scheme: ColorScheme,
+): string | undefined {
+  const t = type ?? "";
+  const s = status ?? "";
+  if (t && s && scheme[`doc.${t}.${s}`]) return scheme[`doc.${t}.${s}`];
+  if (t && scheme[`doc.${t}`]) return scheme[`doc.${t}`];
+  return undefined;
+}
+
+// chunkColor resolves a chunk tile's raw color from its status (chunk.<status>).
+export function chunkColor(status: string | undefined, scheme: ColorScheme): string | undefined {
+  const s = status ?? "";
+  return s ? scheme[`chunk.${s}`] : undefined;
+}
+
+// hexToTint converts a #rgb / #rrggbb color to an rgba() wash at TINT_ALPHA;
+// undefined for a value it can't parse (→ no tint applied).
+export function hexToTint(hex: string): string | undefined {
+  const m = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(hex.trim());
+  if (!m) return undefined;
+  let h = m[1];
+  if (h.length === 3) h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${TINT_ALPHA})`;
+}
+
+// tintStyle is the inline style for a tinted row/tile: a low-alpha wash
+// background + a full-color left accent. undefined (→ no style) when the color is
+// absent or unparseable, so a caller spreads it unconditionally.
+export function tintStyle(color: string | undefined): CSSProperties | undefined {
+  if (!color) return undefined;
+  const bg = hexToTint(color);
+  if (!bg) return undefined;
+  return { background: bg, borderLeft: `3px solid ${color}` };
+}

--- a/packages/explorer/src/lib/dataLayer.tsx
+++ b/packages/explorer/src/lib/dataLayer.tsx
@@ -8,6 +8,7 @@ import type {
   PathEntry,
   PathScope,
 } from "../types";
+import type { DocSummary, DocumentMeta } from "./colorScheme";
 
 // ChunkPatch is the subset of chunk fields update_chunk accepts. `fields` is
 // unknown (arbitrary typed JSON the chunk carries); a blank/absent value leaves
@@ -66,6 +67,19 @@ export interface ExplorerDataLayer {
     scope: DocScope,
     browse?: BrowseScope,
   ): Promise<unknown>;
+  documentGet(
+    id: string,
+    scope: DocScope,
+    browse?: BrowseScope,
+  ): Promise<DocumentMeta>;
+  // documentsSummary returns per-document display metadata (type/status + RFC BN
+  // color settings) for a set of ids and/or a Path subtree — the Path tree's
+  // one-call coloring source (dirents carry only a document_id).
+  documentsSummary(
+    opts: { documentIds?: string[]; underPath?: string },
+    scope: DocScope,
+    browse?: BrowseScope,
+  ): Promise<{ documents: DocSummary[] }>;
   documentQueryChunks(
     documentId: string,
     scope: DocScope,
@@ -125,6 +139,21 @@ export function dataLayerFromClient(client: LoomcycleClient): ExplorerDataLayer 
       }>,
     documentDelete: (id, scope, browse) =>
       client.document({ op: "delete_document", id, scope }, browse),
+    documentGet: (id, scope, browse) =>
+      client.document({ op: "get_document", id, scope }, browse) as Promise<DocumentMeta>,
+    documentsSummary: (opts, scope, browse) =>
+      client.document(
+        // documents_summary + document_ids are RFC BN wire additions the pinned
+        // SDK type doesn't enumerate; the /v1/_document passthrough accepts them
+        // verbatim, so cast past DocumentToolInput (same pattern as update_chunk).
+        {
+          op: "documents_summary",
+          scope,
+          ...(opts.documentIds ? { document_ids: opts.documentIds } : {}),
+          ...(opts.underPath ? { under_path: opts.underPath } : {}),
+        } as unknown as DocumentToolInput,
+        browse,
+      ) as Promise<{ documents: DocSummary[] }>,
     documentQueryChunks: (documentId, scope, browse) =>
       client.document(
         { op: "query_chunks", document_id: documentId, scope, limit: 1000 },

--- a/packages/explorer/src/styles.css
+++ b/packages/explorer/src/styles.css
@@ -765,3 +765,102 @@
   border-top: 1px solid var(--border);
   background: var(--bg-soft);
 }
+
+/* ============================================================
+   RFC BN — per-document color-scheme editor
+   ============================================================ */
+.loomcycle-explorer .scheme-editor {
+  max-width: 520px;
+}
+.loomcycle-explorer .scheme-editor-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  position: sticky;
+  top: 0;
+  background: var(--bg);
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 12px;
+}
+.loomcycle-explorer .scheme-editor-head h3 {
+  margin: 0;
+}
+.loomcycle-explorer .scheme-editor-actions {
+  display: flex;
+  gap: 8px;
+}
+.loomcycle-explorer .scheme-editor-actions button {
+  padding: 8px 16px;
+  border: 1px solid var(--border);
+  background: var(--bg-soft);
+  color: var(--fg);
+  border-radius: 4px;
+  cursor: pointer;
+}
+.loomcycle-explorer .scheme-editor-actions button.primary {
+  background: var(--running);
+  color: white;
+  border-color: var(--running);
+}
+.loomcycle-explorer .scheme-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+  font-size: var(--lc-text-sm);
+}
+.loomcycle-explorer .scheme-group {
+  margin-top: 14px;
+}
+.loomcycle-explorer .scheme-group h4 {
+  margin: 0 0 6px 0;
+  font-size: var(--lc-text-sm);
+  color: var(--fg-soft);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.loomcycle-explorer .scheme-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 3px 0;
+}
+.loomcycle-explorer .scheme-row input[type="color"] {
+  width: 28px;
+  height: 22px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: none;
+  cursor: pointer;
+}
+.loomcycle-explorer .scheme-key {
+  flex: 1;
+  font-size: var(--lc-text-sm);
+}
+.loomcycle-explorer .scheme-hex {
+  color: var(--fg-soft);
+  font-size: var(--lc-text-xs);
+}
+.loomcycle-explorer .scheme-editor-foot {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+.loomcycle-explorer .scheme-editor-foot button {
+  padding: 6px 12px;
+  border: 1px solid var(--border);
+  background: var(--bg-soft);
+  color: var(--fg);
+  border-radius: 4px;
+  cursor: pointer;
+}
+.loomcycle-explorer .scheme-status {
+  color: var(--fg-soft);
+  font-size: var(--lc-text-xs);
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6450,3 +6450,102 @@ button.primary:disabled {
 .limit-banner.hard .tl-payload {
   color: var(--failed);
 }
+
+/* ============================================================
+   RFC BN — per-document color-scheme editor (explorer, dogfooded)
+   ============================================================ */
+.scheme-editor {
+  max-width: 520px;
+}
+.scheme-editor-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  position: sticky;
+  top: 0;
+  background: var(--bg);
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 12px;
+}
+.scheme-editor-head h3 {
+  margin: 0;
+}
+.scheme-editor-actions {
+  display: flex;
+  gap: 8px;
+}
+.scheme-editor-actions button {
+  padding: 8px 16px;
+  border: 1px solid var(--border);
+  background: var(--bg-soft);
+  color: var(--fg);
+  border-radius: 4px;
+  cursor: pointer;
+}
+.scheme-editor-actions button.primary {
+  background: var(--running);
+  color: white;
+  border-color: var(--running);
+}
+.scheme-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+  font-size: var(--lc-text-sm);
+}
+.scheme-group {
+  margin-top: 14px;
+}
+.scheme-group h4 {
+  margin: 0 0 6px 0;
+  font-size: var(--lc-text-sm);
+  color: var(--fg-soft);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.scheme-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 3px 0;
+}
+.scheme-row input[type="color"] {
+  width: 28px;
+  height: 22px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: none;
+  cursor: pointer;
+}
+.scheme-key {
+  flex: 1;
+  font-size: var(--lc-text-sm);
+}
+.scheme-hex {
+  color: var(--fg-soft);
+  font-size: var(--lc-text-xs);
+}
+.scheme-editor-foot {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+.scheme-editor-foot button {
+  padding: 6px 12px;
+  border: 1px solid var(--border);
+  background: var(--bg-soft);
+  color: var(--fg);
+  border-radius: 4px;
+  cursor: pointer;
+}
+.scheme-status {
+  color: var(--fg-soft);
+  font-size: var(--lc-text-xs);
+}


### PR DESCRIPTION
## Why
RFC BN P3. Now that the loomcycle document store is the primary home for all project docs (RFCs, guides, research — each with a `type` and `status`), the viewer should surface that structure. Before this, chunk/document type+state were neutral monochrome badges and the **Path tree couldn't distinguish documents by type/state at all**. This colors both trees, driven by per-document settings the operator controls.

## What

### Backend (`internal/tools/builtin/document.go`)
- **`get_document`** now also returns the **root chunk's `type`/`status`** (the document's own kind/state) + the color settings **`color_enabled` + `color_scheme`**, stored in the root chunk's `fields` — **zero migration** (the `documents` table gains no column).
- **New `documents_summary` op** (`{document_ids}` and/or `{under_path}`) returns per-document type/status + color settings **in ONE call**, so the Path tree colors rows without an N+1 of `get_document` (dirents carry only a `document_id`). Unknown/out-of-scope ids are silently skipped (opaque); the document + root-chunk-row lookups are batched into two `IN (…)` queries.
- HTTP/MCP/gRPC need **no route change** — `/v1/_document` forwards the op + `document_ids` verbatim.
- Regression test `TestDocument_ColorMetadataAndSummary` (get_document enrichment, summary by ids + by under_path, color-less default, unknown-id skip).

### Frontend (`packages/explorer/` + mirrored `web/src/styles.css`)
- **`lib/colorScheme.ts`** — `ColorScheme`/`DocSummary`/`DocumentMeta` types, a **default palette**, and `docColor`/`chunkColor`/`hexToTint`/`tintStyle` resolvers. Tint = a **low-alpha wash background + a full-color left accent** (the loomcycle tinted-tile pattern), readable on both themes.
- **Data layer** — `documentGet` (enriched) + `documentsSummary`.
- **`DocumentChunkTree`** tints chunk rows by status; **`PathTree`** tints + badges document rows from a `documentsSummary` map (fetched once per tree in `PathExplorer`); **`DocumentViewerBody`** tints its toolbar + adds a **"colors"** button.
- **`ColorSchemeEditor`** — a per-document **enabled** toggle + color pickers (`doc.<type>.<status>` and `chunk.<status>`) writing back to the root chunk `fields`, plus the confirmed **"copy this palette to all documents of this type"** batch action.
- Exported the color types + resolvers from the package index (the `ExplorerDataLayer` contract now references them).

## Notes / scope
- Color metadata lives in the **root chunk's `fields`** (the confirmed decision) — no schema migration.
- The left Path tree re-tints on its next reload; changing a scheme in the right-pane editor persists immediately and shows on the next tree refresh (a cross-pane live-refresh is deliberately out of scope for P3).
- **Frontend adds no dependencies.** Independent of P2 (#782) — both branch off `main`; the only shared file is `styles.css` (different, non-overlapping blocks).

## Tested
- `go test ./internal/tools/...` clean (incl. the new test); `go build ./internal/...` clean.
- `packages/explorer` standalone `npm run typecheck` clean.
- `cd web && npm run build` clean (tsc + vite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)