### PR TITLE
feat(explorer): cross-reference links + relationship graph (RFC BN P4)

### DIFF
--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -38,7 +38,7 @@ type Document struct {
 func (d *Document) Name() string { return "Document" }
 
 func (d *Document) Description() string {
-	return "A chunked-graph document: each chunk is a first-class unit (UUID, hierarchy, type, fields, graph edges, Markdown body) that agents and humans co-author and query. Ops: create_document/get_document/documents_summary (per-document type/status + display metadata for a set of ids or a Path subtree)/delete_document/set_path, create_chunk/get_chunk/update_chunk/delete_chunk/move_chunk, link_chunks/unlink_chunks, query_chunks (structured filters + a raw sql escape hatch), define_type/list_types, export_md (render the document to Markdown), import_md (build a document from export_md-shaped Markdown). Scope is agent or user; documents are named in the Path tree (path:) — create_document defaults to /documents/<title> if you omit one, and set_path attaches/re-homes a path for an existing document."
+	return "A chunked-graph document: each chunk is a first-class unit (UUID, hierarchy, type, fields, graph edges, Markdown body) that agents and humans co-author and query. Ops: create_document/get_document/documents_summary (per-document type/status + display metadata for a set of ids or a Path subtree)/delete_document/set_path, create_chunk/get_chunk/update_chunk/delete_chunk/move_chunk, link_chunks/unlink_chunks/get_edges (the cross-reference edges touching a document, each enriched with its endpoints' titles/types/statuses), query_chunks (structured filters + a raw sql escape hatch), define_type/list_types, export_md (render the document to Markdown), import_md (build a document from export_md-shaped Markdown). Scope is agent or user; documents are named in the Path tree (path:) — create_document defaults to /documents/<title> if you omit one, and set_path attaches/re-homes a path for an existing document."
 }
 
 // documentInputSchema is a package const so the LoomCycle MCP server can
@@ -48,7 +48,7 @@ func (d *Document) Description() string {
 const documentInputSchema = `{
 	"type": "object",
 	"properties": {
-		"op":          {"type": "string", "enum": ["create_document","get_document","documents_summary","delete_document","set_path","create_chunk","get_chunk","update_chunk","delete_chunk","move_chunk","link_chunks","unlink_chunks","query_chunks","define_type","list_types","export_md","import_md"]},
+		"op":          {"type": "string", "enum": ["create_document","get_document","documents_summary","delete_document","set_path","create_chunk","get_chunk","update_chunk","delete_chunk","move_chunk","link_chunks","unlink_chunks","get_edges","query_chunks","define_type","list_types","export_md","import_md"]},
 		"scope":       {"type": "string", "enum": ["agent","user"], "description": "Which store (default user). agent = this agent; user = this end-user (needs a user_id on the run). tenant scope is not yet supported."},
 		"id":          {"type": "string", "description": "Document id (get/delete_document, set_path) or chunk id (get/update/delete/move_chunk)."},
 		"path":        {"type": "string", "description": "create_document: name the doc in the Path tree (default /documents/<title> if omitted). set_path: the path to attach to an existing document (by id). get/delete_document: address by path instead of id."},
@@ -183,6 +183,8 @@ func (d *Document) Execute(ctx context.Context, raw json.RawMessage) (tools.Resu
 		return d.linkChunks(ctx, key, in)
 	case "unlink_chunks":
 		return d.unlinkChunks(ctx, key, in)
+	case "get_edges":
+		return d.getEdges(ctx, key, in)
 	case "query_chunks":
 		return d.queryChunks(ctx, key, in)
 	case "define_type":
@@ -1152,6 +1154,55 @@ func (d *Document) unlinkChunks(ctx context.Context, key sqlmem.ScopeKey, in doc
 		return errResult("unlink_chunks: " + err.Error()), nil
 	}
 	return jsonResult(map[string]any{"removed": true})
+}
+
+// edgeEndpointFields are the per-endpoint columns get_edges surfaces (present
+// only when non-empty) — the endpoint's title/type/status/document_id, so the UI
+// can render a References list + a relationship graph without a follow-up
+// get_chunk per endpoint.
+var edgeEndpointFields = []string{
+	"from_title", "from_type", "from_status", "from_document_id",
+	"to_title", "to_type", "to_status", "to_document_id",
+}
+
+// getEdges returns every cross-reference edge with an endpoint in the document
+// (outgoing OR incoming), each enriched via a self-join on chunks with both
+// endpoints' title/type/status/document_id. Powers the viewer's References list +
+// the RFC BN relationship graph in ONE call, replacing the raw-SQL escape hatch.
+// LEFT JOINs so a (defensively) dangling endpoint still lists with empty fields.
+func (d *Document) getEdges(ctx context.Context, key sqlmem.ScopeKey, in docInput) (tools.Result, error) {
+	if in.DocumentID == "" {
+		return errResult("get_edges: missing required field: document_id"), nil
+	}
+	res, err := d.query(ctx, key, `SELECT e.from_id AS from_id, e.to_id AS to_id, e.kind AS kind,
+       cf.title AS from_title, cf.type AS from_type, cf.status AS from_status, cf.document_id AS from_document_id,
+       ct.title AS to_title, ct.type AS to_type, ct.status AS to_status, ct.document_id AS to_document_id
+FROM chunk_edges e
+LEFT JOIN chunks cf ON cf.id = e.from_id
+LEFT JOIN chunks ct ON ct.id = e.to_id
+WHERE e.from_id IN (SELECT id FROM chunks WHERE document_id = ?)
+   OR e.to_id IN (SELECT id FROM chunks WHERE document_id = ?)
+ORDER BY e.kind, e.created_at`, in.DocumentID, in.DocumentID)
+	if err != nil {
+		return errResult("get_edges: " + err.Error()), nil
+	}
+	edges := make([]map[string]any, 0, len(res.Rows))
+	for _, r := range res.Rows {
+		m := map[string]any{}
+		for i, c := range res.Columns {
+			if i < len(r) {
+				m[c] = r[i]
+			}
+		}
+		e := map[string]any{"from_id": asStr(m["from_id"]), "to_id": asStr(m["to_id"]), "kind": asStr(m["kind"])}
+		for _, f := range edgeEndpointFields {
+			if v := asStr(m[f]); v != "" {
+				e[f] = v
+			}
+		}
+		edges = append(edges, e)
+	}
+	return jsonResult(map[string]any{"edges": edges})
 }
 
 // --- ops: query ---

--- a/internal/tools/builtin/document_test.go
+++ b/internal/tools/builtin/document_test.go
@@ -791,6 +791,82 @@ func TestDocument_ChunkStatusBoardRoundTrip(t *testing.T) {
 	}
 }
 
+// TestDocument_GetEdges covers RFC BN P4: get_edges returns every edge touching
+// a document (outgoing + incoming, incl. cross-document), enriched with each
+// endpoint's title/type/status/document_id in one call.
+func TestDocument_GetEdges(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+
+	out, res := docExec(t, d, ctx, `{"op":"create_document","scope":"agent","title":"Doc One"}`)
+	if res.IsError {
+		t.Fatalf("create doc1: %q", res.Text)
+	}
+	doc1, root1 := out["document_id"].(string), out["root_chunk_id"].(string)
+	out, res = docExec(t, d, ctx, `{"op":"create_chunk","scope":"agent","document_id":"`+doc1+`","parent_id":"`+root1+`","title":"Bee"}`)
+	if res.IsError {
+		t.Fatalf("create B: %q", res.Text)
+	}
+	bee := out["id"].(string)
+
+	out, res = docExec(t, d, ctx, `{"op":"create_document","scope":"agent","title":"Doc Two"}`)
+	if res.IsError {
+		t.Fatalf("create doc2: %q", res.Text)
+	}
+	doc2, root2 := out["document_id"].(string), out["root_chunk_id"].(string)
+
+	// root1→Bee (same-doc), root1→root2 (cross-doc).
+	for _, l := range []string{
+		`{"op":"link_chunks","scope":"agent","from_id":"` + root1 + `","to_id":"` + bee + `","kind":"has"}`,
+		`{"op":"link_chunks","scope":"agent","from_id":"` + root1 + `","to_id":"` + root2 + `","kind":"xref"}`,
+	} {
+		if _, r := docExec(t, d, ctx, l); r.IsError {
+			t.Fatalf("link: %q", r.Text)
+		}
+	}
+
+	// doc1: both edges touch it (both from root1).
+	out, res = docExec(t, d, ctx, `{"op":"get_edges","scope":"agent","document_id":"`+doc1+`"}`)
+	if res.IsError {
+		t.Fatalf("get_edges doc1: %q", res.Text)
+	}
+	edges, _ := out["edges"].([]any)
+	if len(edges) != 2 {
+		t.Fatalf("doc1 edges = %d, want 2: %s", len(edges), res.Text)
+	}
+	var xref map[string]any
+	for _, e := range edges {
+		m := e.(map[string]any)
+		if m["kind"] == "xref" {
+			xref = m
+		}
+	}
+	if xref == nil {
+		t.Fatalf("no xref edge: %s", res.Text)
+	}
+	// The cross-doc edge is enriched with the FAR endpoint's title + document_id.
+	if xref["to_title"] != "Doc Two" || xref["to_document_id"] != doc2 || xref["from_title"] != "Doc One" {
+		t.Errorf("xref enrichment = %v", xref)
+	}
+
+	// doc2: only the incoming cross-doc edge touches it (to_id = root2).
+	out, res = docExec(t, d, ctx, `{"op":"get_edges","scope":"agent","document_id":"`+doc2+`"}`)
+	if res.IsError {
+		t.Fatalf("get_edges doc2: %q", res.Text)
+	}
+	edges, _ = out["edges"].([]any)
+	if len(edges) != 1 {
+		t.Fatalf("doc2 edges = %d, want 1: %s", len(edges), res.Text)
+	}
+	if m := edges[0].(map[string]any); m["from_document_id"] != doc1 || m["kind"] != "xref" {
+		t.Errorf("doc2 incoming edge = %v", m)
+	}
+
+	// Missing document_id is an error, not a panic.
+	if _, r := docExec(t, d, ctx, `{"op":"get_edges","scope":"agent"}`); !r.IsError {
+		t.Errorf("get_edges without document_id should error")
+	}
+}
+
 // TestDocument_ColorMetadataAndSummary covers RFC BN P3: get_document surfaces
 // the ROOT chunk's type/status + the per-document color settings, and
 // documents_summary returns the same for a set of ids or a Path subtree in one

--- a/packages/explorer/src/components/CrossReferences.tsx
+++ b/packages/explorer/src/components/CrossReferences.tsx
@@ -1,0 +1,144 @@
+import { useState } from "react";
+import type { DocEdge } from "../types";
+import MermaidDiagram from "./Mermaid";
+
+// CrossReferences renders the RFC BN P4 cross-reference surface for a document:
+//   - a References list for the SELECTED chunk (its outgoing + incoming edges),
+//     each same-document target clickable to navigate; a cross-document target is
+//     labeled (↗) but not navigable from this single-document viewer.
+//   - a collapsible whole-document relationship GRAPH (a Mermaid flowchart of the
+//     document's edges), capped to the first N with a "show all" expand so a
+//     heavily cross-linked document doesn't render an unreadable diagram.
+// Fed by one get_edges call (all edges touching the document); renders nothing
+// when the document has no edges.
+export interface CrossReferencesProps {
+  edges: DocEdge[];
+  documentId: string;
+  selectedId?: string;
+  onSelectChunk: (id: string) => void;
+}
+
+// GRAPH_CAP is the default number of edges the relationship graph draws before
+// requiring an explicit "show all" (keeps a big graph readable + cheap).
+const GRAPH_CAP = 24;
+
+export default function CrossReferences({
+  edges,
+  documentId,
+  selectedId,
+  onSelectChunk,
+}: CrossReferencesProps) {
+  const [showGraph, setShowGraph] = useState(false);
+  const [showAll, setShowAll] = useState(false);
+
+  if (edges.length === 0) return null;
+
+  const refs = selectedId
+    ? edges.filter((e) => e.from_id === selectedId || e.to_id === selectedId)
+    : [];
+  const graphEdges = showAll ? edges : edges.slice(0, GRAPH_CAP);
+  const graphDef = buildGraph(graphEdges);
+
+  return (
+    <div className="doc-refs">
+      {selectedId && (
+        <div className="doc-refs-list-wrap">
+          <h4>References</h4>
+          {refs.length === 0 ? (
+            <p className="doc-refs-empty">This chunk has no links.</p>
+          ) : (
+            <ul className="doc-refs-list">
+              {refs.map((e, i) => (
+                <RefRow
+                  key={`${e.from_id}-${e.to_id}-${e.kind}-${i}`}
+                  edge={e}
+                  selectedId={selectedId}
+                  documentId={documentId}
+                  onSelectChunk={onSelectChunk}
+                />
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
+      <div className="doc-graph">
+        <button type="button" className="doc-graph-toggle" onClick={() => setShowGraph((s) => !s)}>
+          {showGraph ? "▼" : "▶"} relationship graph ({edges.length})
+        </button>
+        {showGraph && (
+          <>
+            <MermaidDiagram code={graphDef} />
+            {edges.length > GRAPH_CAP && (
+              <button type="button" className="doc-graph-more" onClick={() => setShowAll((s) => !s)}>
+                {showAll ? `show top ${GRAPH_CAP}` : `show all ${edges.length}`}
+              </button>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function RefRow({
+  edge,
+  selectedId,
+  documentId,
+  onSelectChunk,
+}: {
+  edge: DocEdge;
+  selectedId: string;
+  documentId: string;
+  onSelectChunk: (id: string) => void;
+}) {
+  const outgoing = edge.from_id === selectedId;
+  const otherId = outgoing ? edge.to_id : edge.from_id;
+  const otherTitle = (outgoing ? edge.to_title : edge.from_title) || otherId.slice(0, 8);
+  const otherDoc = outgoing ? edge.to_document_id : edge.from_document_id;
+  // An edge whose far endpoint carries no document_id (defensively) is treated as
+  // same-document; a different document_id is a cross-document link.
+  const sameDoc = !otherDoc || otherDoc === documentId;
+  return (
+    <li className="doc-ref">
+      <span className="doc-ref-kind">{edge.kind}</span>
+      <span className="doc-ref-arrow" aria-hidden>
+        {outgoing ? "→" : "←"}
+      </span>
+      {sameDoc ? (
+        <button type="button" className="doc-ref-target" onClick={() => onSelectChunk(otherId)}>
+          {otherTitle}
+        </button>
+      ) : (
+        <span className="doc-ref-target external" title="In another document">
+          {otherTitle} ↗
+        </span>
+      )}
+    </li>
+  );
+}
+
+// buildGraph renders the document's edges as a Mermaid left-to-right flowchart.
+// Node ids are the chunk ids (prefixed + stripped to mermaid-safe chars); labels
+// are the endpoint titles, sanitized of mermaid metacharacters and truncated.
+// Mermaid dedups nodes by id, so re-declaring a node's label across edges is fine.
+function buildGraph(edges: DocEdge[]): string {
+  const lines = ["graph LR"];
+  for (const e of edges) {
+    const from = `${nodeId(e.from_id)}["${label(e.from_title, e.from_id)}"]`;
+    const to = `${nodeId(e.to_id)}["${label(e.to_title, e.to_id)}"]`;
+    const kind = (e.kind || "link").replace(/[|"]/g, " ");
+    lines.push(`  ${from} -->|${kind}| ${to}`);
+  }
+  return lines.join("\n");
+}
+
+function nodeId(id: string): string {
+  return "n" + id.replace(/[^a-zA-Z0-9]/g, "");
+}
+
+function label(title: string | undefined, id: string): string {
+  const base = (title ?? "").replace(/["[\]{}|<>]/g, " ").replace(/\s+/g, " ").trim();
+  const text = base || id.slice(0, 6);
+  return text.length > 30 ? text.slice(0, 29) + "…" : text;
+}

--- a/packages/explorer/src/components/DocumentChunkTree.tsx
+++ b/packages/explorer/src/components/DocumentChunkTree.tsx
@@ -49,6 +49,9 @@ export interface DocumentChunkTreeProps {
   // (falls back to the default palette). Unset → neutral rows (prior behavior).
   colorEnabled?: boolean;
   scheme?: ColorScheme;
+  // RFC BN P4: chunk ids that have at least one cross-reference edge — those
+  // tiles get a 🔗 badge. Unset → no badges.
+  linkedIds?: Set<string>;
 }
 
 export default function DocumentChunkTree({
@@ -57,6 +60,7 @@ export default function DocumentChunkTree({
   onSelect,
   colorEnabled,
   scheme,
+  linkedIds,
 }: DocumentChunkTreeProps) {
   const [expanded, setExpanded] = useState<Map<string, boolean>>(() => new Map());
   const toggle = useCallback((id: string) => {
@@ -106,6 +110,7 @@ export default function DocumentChunkTree({
           selectedId={selectedId}
           onSelect={onSelect}
           tintScheme={tintScheme}
+          linkedIds={linkedIds}
         />
       ))}
     </ul>
@@ -135,13 +140,15 @@ interface NodeProps {
   selectedId?: string;
   onSelect: (node: ChunkNode) => void;
   tintScheme: ColorScheme | null;
+  linkedIds?: Set<string>;
 }
 
-function ChunkTreeNode({ node, expanded, toggle, selectedId, onSelect, tintScheme }: NodeProps) {
+function ChunkTreeNode({ node, expanded, toggle, selectedId, onSelect, tintScheme, linkedIds }: NodeProps) {
   const hasChildren = node.children.length > 0;
   const isOpen = expanded.get(node.row.id) !== false; // default-expanded
   const isSelected = selectedId === node.row.id;
   const rowStyle = tintScheme ? tintStyle(chunkColor(node.row.status, tintScheme)) : undefined;
+  const hasLink = linkedIds?.has(node.row.id);
   return (
     <li className={`node chunk-node ${isSelected ? "selected" : ""}`}>
       <div className="row chunk-row" style={rowStyle}>
@@ -166,6 +173,11 @@ function ChunkTreeNode({ node, expanded, toggle, selectedId, onSelect, tintSchem
           <span className="chunk-title">{node.row.title || "(untitled)"}</span>
           {node.row.type && <span className="chunk-badge">{node.row.type}</span>}
           {node.row.status && <span className="chunk-badge chunk-status">{node.row.status}</span>}
+          {hasLink && (
+            <span className="chunk-link-badge" title="Has cross-reference links" aria-label="linked">
+              🔗
+            </span>
+          )}
         </button>
       </div>
       {hasChildren && isOpen && (
@@ -179,6 +191,7 @@ function ChunkTreeNode({ node, expanded, toggle, selectedId, onSelect, tintSchem
               selectedId={selectedId}
               onSelect={onSelect}
               tintScheme={tintScheme}
+              linkedIds={linkedIds}
             />
           ))}
         </ul>

--- a/packages/explorer/src/components/DocumentViewerBody.tsx
+++ b/packages/explorer/src/components/DocumentViewerBody.tsx
@@ -4,6 +4,7 @@ import type {
   BrowseScope,
   ChunkDetail,
   ChunkRow,
+  DocEdge,
   DocScope,
   Principal,
 } from "../types";
@@ -21,6 +22,7 @@ import DocumentChunkTree, {
 } from "./DocumentChunkTree";
 import ChunkEditorModal from "./ChunkEditorModal";
 import ColorSchemeEditor from "./ColorSchemeEditor";
+import CrossReferences from "./CrossReferences";
 import Markdown from "./Markdown";
 
 // DocumentViewerBody is the read-mostly surface for one chunked-graph document
@@ -88,6 +90,7 @@ export default function DocumentViewerBody({
   const [assistantOpen, setAssistantOpen] = useState(false);
   const [meta, setMeta] = useState<DocumentMeta | null>(null);
   const [colorsOpen, setColorsOpen] = useState(false);
+  const [edges, setEdges] = useState<DocEdge[]>([]);
 
   const refresh = useCallback(() => setReload((n) => n + 1), []);
 
@@ -113,6 +116,15 @@ export default function DocumentViewerBody({
     [chunks],
   );
   const colorEnabled = !!meta?.color_enabled;
+  // Chunk ids with at least one edge → a 🔗 badge on those tiles.
+  const linkedIds = useMemo(() => {
+    const s = new Set<string>();
+    for (const e of edges) {
+      s.add(e.from_id);
+      s.add(e.to_id);
+    }
+    return s;
+  }, [edges]);
   const toolbarTint = useMemo(
     () =>
       colorEnabled
@@ -156,6 +168,19 @@ export default function DocumentViewerBody({
     };
   }, [data, documentId, scope, reload, browse]);
 
+  // Load the cross-reference edges (RFC BN P4) in one call — powers the 🔗 tile
+  // badge, the References list, and the relationship graph. Best-effort.
+  useEffect(() => {
+    let cancelled = false;
+    data
+      .documentGetEdges(documentId, scope, browse)
+      .then((r) => !cancelled && setEdges(r.edges ?? []))
+      .catch(() => !cancelled && setEdges([]));
+    return () => {
+      cancelled = true;
+    };
+  }, [data, documentId, scope, reload, browse]);
+
   // Reset selection + view when the document changes.
   useEffect(() => {
     setSelectedId(undefined);
@@ -163,6 +188,7 @@ export default function DocumentViewerBody({
     setSubtreeMd(null);
     setMode("chunks");
     setMeta(null);
+    setEdges([]);
   }, [documentId, scope]);
 
   // Fetch the selected chunk's body.
@@ -284,6 +310,7 @@ export default function DocumentViewerBody({
               onSelect={onSelect}
               colorEnabled={colorEnabled}
               scheme={meta?.color_scheme}
+              linkedIds={linkedIds}
             />
           )}
         </div>
@@ -343,6 +370,12 @@ export default function DocumentViewerBody({
                   <p className="doc-empty-body">(empty chunk)</p>
                 )}
               </div>
+              <CrossReferences
+                edges={edges}
+                documentId={documentId}
+                selectedId={selectedId}
+                onSelectChunk={setSelectedId}
+              />
             </>
           ) : (
             <div className="empty">

--- a/packages/explorer/src/components/Markdown.tsx
+++ b/packages/explorer/src/components/Markdown.tsx
@@ -1,17 +1,15 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { Components } from "react-markdown";
+import MermaidDiagram from "./Mermaid";
 
 // Markdown renders a chunk body as GitHub-flavored Markdown (RFC BN): headings,
 // paragraphs, inline styles, links, fenced code, blockquotes, lists, TABLES, and
 // ```mermaid diagrams. It uses react-markdown + remark-gfm; react-markdown is
 // safe by default (it does not emit raw HTML — no rehype-raw — and its default
-// urlTransform strips javascript:/other dangerous hrefs). Mermaid fences render
-// through a lazy `import("mermaid")` with securityLevel:"strict" (bundled
-// DOMPurify), the same posture as the runtime's TeamsView diagram; mermaid is an
-// OPTIONAL peer dep, so a host without it (or a diagram that fails to parse)
-// degrades gracefully to a code block.
+// urlTransform strips javascript:/other dangerous hrefs). ```mermaid fences
+// render through the shared MermaidDiagram (lazy, securityLevel:"strict",
+// graceful fallback to a code block).
 
 export default function Markdown({ source }: { source: string }) {
   return (
@@ -56,54 +54,3 @@ const MD_COMPONENTS: Components = {
     return <code>{children}</code>; // inline
   },
 };
-
-// mermaidSeq gives each render a unique DOM id (mermaid.render requires one).
-// A module counter is fine in the browser (this never runs in the workflow JS
-// sandbox where Math.random / new Date are disallowed).
-let mermaidSeq = 0;
-
-// MermaidDiagram lazily renders a ```mermaid fence to SVG. Theme is read from the
-// nearest [data-theme] ancestor (the explorer root / host <html>), defaulting to
-// the explorer's dark palette. A parse error or a missing mermaid dep falls back
-// to the raw code so a bad diagram never breaks the document view.
-function MermaidDiagram({ code }: { code: string }): ReactNode {
-  const ref = useRef<HTMLDivElement>(null);
-  const [state, setState] = useState<{ svg?: string; err?: boolean }>({});
-
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const mermaid = (await import("mermaid")).default;
-        const attr = ref.current?.closest("[data-theme]")?.getAttribute("data-theme");
-        const dark = attr ? attr === "dark" : true; // explorer default is dark
-        mermaid.initialize({ startOnLoad: false, theme: dark ? "dark" : "default", securityLevel: "strict" });
-        const { svg } = await mermaid.render(`lc-mmd-${mermaidSeq++}`, code);
-        if (!cancelled) setState({ svg });
-      } catch {
-        if (!cancelled) setState({ err: true });
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [code]);
-
-  if (state.err) {
-    // No ref here: the effect already captured the theme on the first (loading)
-    // render, and a <pre> ref would conflict with the <div> ref type below.
-    return (
-      <pre className="md-pre md-mermaid-error" title="diagram failed to render">
-        <code>{code}</code>
-      </pre>
-    );
-  }
-  if (state.svg) {
-    return <div ref={ref} className="md-mermaid" dangerouslySetInnerHTML={{ __html: state.svg }} />;
-  }
-  return (
-    <div ref={ref} className="md-mermaid md-mermaid-loading">
-      rendering diagram…
-    </div>
-  );
-}

--- a/packages/explorer/src/components/Mermaid.tsx
+++ b/packages/explorer/src/components/Mermaid.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useRef, useState, type ReactNode } from "react";
+
+// MermaidDiagram lazily renders a Mermaid definition to SVG. Theme is read from
+// the nearest [data-theme] ancestor (the explorer root / host <html>), defaulting
+// to the explorer's dark palette. It renders with securityLevel:"strict" (bundled
+// DOMPurify) — the same posture as the runtime's TeamsView diagram. mermaid is an
+// OPTIONAL peer dep, so a host without it (or a definition that fails to parse)
+// degrades gracefully to the raw code, and a bad diagram never breaks the view.
+// Shared by the Markdown ```mermaid fence (RFC BN P2) and the cross-reference
+// relationship graph (P4).
+
+// mermaidSeq gives each render a unique DOM id (mermaid.render requires one).
+// A module counter is fine in the browser (this never runs in the workflow JS
+// sandbox where Math.random / new Date are disallowed).
+let mermaidSeq = 0;
+
+export default function MermaidDiagram({ code }: { code: string }): ReactNode {
+  const ref = useRef<HTMLDivElement>(null);
+  const [state, setState] = useState<{ svg?: string; err?: boolean }>({});
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const mermaid = (await import("mermaid")).default;
+        const attr = ref.current?.closest("[data-theme]")?.getAttribute("data-theme");
+        const dark = attr ? attr === "dark" : true; // explorer default is dark
+        mermaid.initialize({ startOnLoad: false, theme: dark ? "dark" : "default", securityLevel: "strict" });
+        const { svg } = await mermaid.render(`lc-mmd-${mermaidSeq++}`, code);
+        if (!cancelled) setState({ svg });
+      } catch {
+        if (!cancelled) setState({ err: true });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [code]);
+
+  if (state.err) {
+    // No ref here: the effect already captured the theme on the first (loading)
+    // render, and a <pre> ref would conflict with the <div> ref type below.
+    return (
+      <pre className="md-pre md-mermaid-error" title="diagram failed to render">
+        <code>{code}</code>
+      </pre>
+    );
+  }
+  if (state.svg) {
+    return <div ref={ref} className="md-mermaid" dangerouslySetInnerHTML={{ __html: state.svg }} />;
+  }
+  return (
+    <div ref={ref} className="md-mermaid md-mermaid-loading">
+      rendering diagram…
+    </div>
+  );
+}

--- a/packages/explorer/src/index.ts
+++ b/packages/explorer/src/index.ts
@@ -19,6 +19,7 @@ export type {
   PathEntry,
   ChunkRow,
   ChunkDetail,
+  DocEdge,
   Principal,
   AssistantContext,
 } from "./types";

--- a/packages/explorer/src/lib/dataLayer.tsx
+++ b/packages/explorer/src/lib/dataLayer.tsx
@@ -4,6 +4,7 @@ import type {
   BrowseScope,
   ChunkDetail,
   ChunkRow,
+  DocEdge,
   DocScope,
   PathEntry,
   PathScope,
@@ -90,6 +91,13 @@ export interface ExplorerDataLayer {
     scope: DocScope,
     browse?: BrowseScope,
   ): Promise<ChunkDetail>;
+  // documentGetEdges returns every cross-reference edge touching a document
+  // (RFC BN P4) — the References list + relationship graph source.
+  documentGetEdges(
+    documentId: string,
+    scope: DocScope,
+    browse?: BrowseScope,
+  ): Promise<{ edges: DocEdge[] }>;
   documentUpdateChunk(
     id: string,
     revision: number,
@@ -161,6 +169,13 @@ export function dataLayerFromClient(client: LoomcycleClient): ExplorerDataLayer 
       ) as Promise<{ chunks: ChunkRow[] }>,
     documentGetChunk: (id, scope, browse) =>
       client.document({ op: "get_chunk", id, scope }, browse) as Promise<ChunkDetail>,
+    documentGetEdges: (documentId, scope, browse) =>
+      client.document(
+        // get_edges is an RFC BN P4 wire op the pinned SDK type doesn't
+        // enumerate; the /v1/_document passthrough accepts it verbatim.
+        { op: "get_edges", document_id: documentId, scope } as unknown as DocumentToolInput,
+        browse,
+      ) as Promise<{ edges: DocEdge[] }>,
     documentUpdateChunk: (id, revision, patch, scope, browse) =>
       client.document(
         // `patch.fields` is unknown but DocumentToolInput.fields is a typed

--- a/packages/explorer/src/styles.css
+++ b/packages/explorer/src/styles.css
@@ -933,3 +933,92 @@
   color: var(--fg-soft);
   font-size: var(--lc-text-xs);
 }
+
+/* ============================================================
+   RFC BN P4 — cross-reference links + relationship graph
+   ============================================================ */
+.loomcycle-explorer .chunk-link-badge {
+  font-size: 0.85em;
+  line-height: 1;
+  opacity: 0.85;
+}
+.loomcycle-explorer .doc-refs {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+.loomcycle-explorer .doc-refs h4 {
+  margin: 0 0 6px 0;
+  font-size: var(--lc-text-sm);
+  color: var(--fg-soft);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.loomcycle-explorer .doc-refs-empty {
+  color: var(--fg-soft);
+  font-size: var(--lc-text-sm);
+  margin: 0;
+}
+.loomcycle-explorer .doc-refs-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.loomcycle-explorer .doc-ref {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--lc-text-sm);
+}
+.loomcycle-explorer .doc-ref-kind {
+  font-family: var(--mono);
+  font-size: var(--lc-text-xs);
+  color: var(--fg-soft);
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 1px 5px;
+}
+.loomcycle-explorer .doc-ref-arrow {
+  color: var(--fg-muted);
+}
+.loomcycle-explorer .doc-ref-target {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  padding: 0;
+  font: inherit;
+  text-align: left;
+}
+.loomcycle-explorer .doc-ref-target:hover {
+  text-decoration: underline;
+}
+.loomcycle-explorer .doc-ref-target.external {
+  color: var(--fg-soft);
+  cursor: default;
+}
+.loomcycle-explorer .doc-graph {
+  margin-top: 12px;
+}
+.loomcycle-explorer .doc-graph-toggle,
+.loomcycle-explorer .doc-graph-more {
+  background: none;
+  border: none;
+  color: var(--fg-soft);
+  cursor: pointer;
+  padding: 2px 0;
+  font: inherit;
+  font-size: var(--lc-text-sm);
+}
+.loomcycle-explorer .doc-graph-toggle:hover,
+.loomcycle-explorer .doc-graph-more:hover {
+  color: var(--accent);
+}
+.loomcycle-explorer .doc-graph-more {
+  margin-top: 6px;
+  font-size: var(--lc-text-xs);
+}

--- a/packages/explorer/src/types.ts
+++ b/packages/explorer/src/types.ts
@@ -50,6 +50,26 @@ export interface ChunkDetail extends ChunkRow {
   fields?: unknown;
 }
 
+// DocEdge is one cross-reference edge from get_edges (RFC BN P4): a typed link
+// between two chunks (possibly in different documents), enriched with each
+// endpoint's title/type/status/document_id so the viewer can render a References
+// list + a relationship graph without a per-endpoint get_chunk. The endpoint
+// fields are omitted when empty (a dangling endpoint, or a chunk with no
+// type/status).
+export interface DocEdge {
+  from_id: string;
+  to_id: string;
+  kind: string;
+  from_title?: string;
+  from_type?: string;
+  from_status?: string;
+  from_document_id?: string;
+  to_title?: string;
+  to_type?: string;
+  to_status?: string;
+  to_document_id?: string;
+}
+
 // Principal is the authenticated identity behind the session (resolved by the
 // host, e.g. via GET /v1/_me). The explorer only reads `subject` — it is passed
 // into the renderAssistant slot's context so a host-provided Document Assistant

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6608,3 +6608,92 @@ button.primary:disabled {
   color: var(--fg-soft);
   font-size: var(--lc-text-xs);
 }
+
+/* ============================================================
+   RFC BN P4 — cross-reference links + relationship graph (explorer)
+   ============================================================ */
+.chunk-link-badge {
+  font-size: 0.85em;
+  line-height: 1;
+  opacity: 0.85;
+}
+.doc-refs {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+.doc-refs h4 {
+  margin: 0 0 6px 0;
+  font-size: var(--lc-text-sm);
+  color: var(--fg-soft);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.doc-refs-empty {
+  color: var(--fg-soft);
+  font-size: var(--lc-text-sm);
+  margin: 0;
+}
+.doc-refs-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.doc-ref {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--lc-text-sm);
+}
+.doc-ref-kind {
+  font-family: var(--lc-font-mono, monospace);
+  font-size: var(--lc-text-xs);
+  color: var(--fg-soft);
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 1px 5px;
+}
+.doc-ref-arrow {
+  color: var(--fg-muted);
+}
+.doc-ref-target {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  padding: 0;
+  font: inherit;
+  text-align: left;
+}
+.doc-ref-target:hover {
+  text-decoration: underline;
+}
+.doc-ref-target.external {
+  color: var(--fg-soft);
+  cursor: default;
+}
+.doc-graph {
+  margin-top: 12px;
+}
+.doc-graph-toggle,
+.doc-graph-more {
+  background: none;
+  border: none;
+  color: var(--fg-soft);
+  cursor: pointer;
+  padding: 2px 0;
+  font: inherit;
+  font-size: var(--lc-text-sm);
+}
+.doc-graph-toggle:hover,
+.doc-graph-more:hover {
+  color: var(--accent);
+}
+.doc-graph-more {
+  margin-top: 6px;
+  font-size: var(--lc-text-xs);
+}


### PR DESCRIPTION
## Why
RFC BN P4 — the final phase. Chunks can link to each other (`link_chunks`, incl. **cross-document** edges), and the migrated doc store now has 26 such relations — but they were **invisible in the viewer** (only in the `export_md` trailer or a raw `query_chunks` SQL). This surfaces them.

## What

### Backend (`internal/tools/builtin/document.go`)
- **New `get_edges` op** (`{document_id}`) returns every edge with an endpoint in the document — **outgoing OR incoming, including cross-document** — enriched via a self-join on `chunks` with both endpoints' `title`/`type`/`status`/`document_id`. That gives the References list + the graph **in one call**, replacing the raw-SQL escape hatch. `LEFT JOIN`s so a (defensively) dangling endpoint still lists.
- Regression test `TestDocument_GetEdges` (same-doc + cross-doc edges, both directions, enrichment, missing-arg error).
- HTTP/MCP/gRPC need **no route change** — `/v1/_document` forwards the op verbatim.

### Frontend (`packages/explorer/` + mirrored `web/src/styles.css`)
- **Extracted** the P2 `MermaidDiagram` into a shared `components/Mermaid.tsx` (now reused by the Markdown fence **and** the new graph; lazy `import("mermaid")`, `securityLevel:"strict"`, graceful fallback).
- **Data layer**: `documentGetEdges` + a `DocEdge` type.
- **`DocumentChunkTree`** shows a **🔗 badge** on tiles that have edges.
- **`CrossReferences`**: a **References** list for the selected chunk (same-document targets **clickable to navigate**; cross-document targets labeled `↗`, non-navigable from a single-document viewer) + a **collapsible whole-document Mermaid relationship graph**, capped to the first 24 edges with a **"show all"** expand so a heavily cross-linked document stays readable.
- **`DocumentViewerBody`** fetches the edges once (best-effort) and wires all three.
- Exported `DocEdge` from the package index.

## Notes
- Cross-document navigation from the References list is deliberately out of scope (the single-document viewer has no handle to open a sibling document); such targets are labeled `↗`.
- **Frontend adds no dependencies** (mermaid arrived in P2). Single `mermaid.core` chunk confirmed (shared renderer + TeamsView dedupe).

## Tested
- `go test ./internal/tools/...` clean (incl. the new test); `go build ./internal/...` clean.
- `packages/explorer` standalone `npm run typecheck` clean.
- `cd web && npm run build` clean (tsc + vite).

## RFC BN arc
This completes RFC BN: **P1** #781 (Save/Cancel to top), **P2** #782 (tables + Mermaid), **P3** #783 (color schemes + tree coloring), **P4** this PR (cross-reference links + graph).

🤖 Generated with [Claude Code](https://claude.com/claude-code)