### PR TITLE
feat(document): image & mermaid chunks — P1 backend (RFC BO)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -962,8 +962,9 @@ func main() {
 
 	// RFC AK — the Document tool (chunked-graph documents). Store late-bound
 	// below; SqlMem bound in the SQL Memory block (Document requires it); Bus
-	// for change events.
-	documentTool := &builtin.Document{Bus: channelBus}
+	// for change events. MaxAssetBytes (RFC BO) caps a stored image's decoded
+	// size (0 → the tool's built-in default).
+	documentTool := &builtin.Document{Bus: channelBus, MaxAssetBytes: int(cfg.Env.MaxDocumentAssetBytes)}
 	allTools = append(allTools, documentTool)
 
 	// RFC BE — the History tool (browse/search/annotate past chats). Store

--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -714,6 +714,12 @@ func requiredScopeFor(method, path string) string {
 // The def handlers confine a non-admin principal to its own tenant (write-stamp
 // + opaque-404), so opening these gates to ScopeTenant doesn't widen reach.
 func isTenantConfinedDefPath(path string) bool {
+	// RFC BO — the image-asset serving GET lives UNDER /v1/_document with a
+	// variable {chunk_id} suffix, so it needs a prefix match (the family list
+	// below is exact-match). Same ScopeTenant posture as /v1/_document itself.
+	if strings.HasPrefix(path, "/v1/_document/asset/") {
+		return true
+	}
 	for _, fam := range []string{
 		"/v1/_agentdef", "/v1/_skilldef", "/v1/_teamdef", "/v1/_mcpserverdef", "/v1/_scheduledef",
 		"/v1/_webhookdef", "/v1/_memorybackenddef", "/v1/_a2aagentdef", "/v1/_a2aservercarddef",

--- a/internal/api/http/provider_gate_admission_test.go
+++ b/internal/api/http/provider_gate_admission_test.go
@@ -127,7 +127,12 @@ func TestProviderGate_CappedOverflowDoesNotHoldGlobalSlot(t *testing.T) {
 func TestProviderGate_BatchesToCap(t *testing.T) {
 	const cap = 2
 	const total = 5
-	prov := &countingProvider{delay: 40 * time.Millisecond}
+	// holdUntil=cap makes the two admitted calls rendezvous before releasing, so
+	// the peak deterministically reaches cap — the gate admits cap concurrently,
+	// but a loaded CI race-runner could otherwise stagger them so only one is
+	// ever in-flight (a false peak=1). The gate still bounds true concurrency at
+	// cap regardless.
+	prov := &countingProvider{delay: 40 * time.Millisecond, holdUntil: cap}
 	cfg := gateTestConfig()
 	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "batch.db"))
 	if err != nil {
@@ -158,6 +163,8 @@ func TestProviderGate_BatchesToCap(t *testing.T) {
 	}
 	wg.Wait()
 
+	// The gate must admit EXACTLY cap concurrently: never more (the ceiling),
+	// and — thanks to the rendezvous barrier — the peak reliably reaches it.
 	if peak := prov.peakInFlight(); peak != cap {
 		t.Errorf("peak concurrent provider.Call = %d, want exactly cap=%d", peak, cap)
 	}
@@ -329,10 +336,20 @@ func TestProviderSlot_SwapMovesSlotNoLeak(t *testing.T) {
 // cap through the full admission + loop path.
 type countingProvider struct {
 	delay time.Duration
+	// holdUntil (0 = off) makes Call RENDEZVOUS: an admitted call blocks until
+	// `holdUntil` calls are simultaneously in-flight (or a generous deadline)
+	// before running its delay. This makes the observed peak deterministically
+	// reach the gate cap regardless of CI scheduling jitter — without it, a
+	// loaded race-runner can stagger the admitted requests so only one is ever
+	// in provider.Call at a time (a false peak=1). A genuine under-admit bug
+	// still leaves peak < holdUntil (the deadline fires) and fails the test.
+	holdUntil int
 
 	mu       sync.Mutex
 	inFlight int
 	peak     int
+	arrived  int
+	barrier  chan struct{}
 }
 
 func (c *countingProvider) ID() string                    { return "counting" }
@@ -349,7 +366,25 @@ func (c *countingProvider) Call(ctx context.Context, _ providers.Request) (<-cha
 	if c.inFlight > c.peak {
 		c.peak = c.inFlight
 	}
+	var barrier chan struct{}
+	if c.holdUntil > 0 {
+		if c.barrier == nil {
+			c.barrier = make(chan struct{})
+		}
+		barrier = c.barrier
+		c.arrived++
+		if c.arrived == c.holdUntil { // fires exactly once → release the batch together
+			close(c.barrier)
+		}
+	}
 	c.mu.Unlock()
+	if barrier != nil {
+		select {
+		case <-barrier:
+		case <-time.After(2 * time.Second): // safety valve: a real under-admit bug won't hang the test
+		case <-ctx.Done():
+		}
+	}
 	ch := make(chan providers.Event, 4)
 	go func() {
 		defer close(ch)

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -445,6 +445,19 @@ func (s *Server) maxRequestBytes() int64 {
 	return defaultMaxRequestBytes
 }
 
+// defaultMaxDocumentBytes bounds a POST /v1/_document body (set_asset base64
+// image payloads + large import_md docs). RFC BO.
+const defaultMaxDocumentBytes = 8 << 20
+
+// maxDocumentBytes returns the configured Document-route body cap, falling back
+// to defaultMaxDocumentBytes when unset (<=0).
+func (s *Server) maxDocumentBytes() int64 {
+	if n := s.cfg.Env.MaxDocumentAssetBytes; n > 0 {
+		return n
+	}
+	return defaultMaxDocumentBytes
+}
+
 func New(cfg *config.Config, pr ProviderResolver, builtinTools []tools.Tool, sem *concurrency.Semaphore, st store.Store) *Server {
 	// Hook registry is constructed with the operator-yaml host-widen
 	// permit list (cfg.Hooks.PermitHostWiden.Owners). Without an entry
@@ -2776,6 +2789,10 @@ func (s *Server) Mux() http.Handler {
 	// the wire. Same dispatch shape as the other substrate admin endpoints.
 	mux.Handle("POST /v1/_path", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleSubstratePath))))
 	mux.Handle("POST /v1/_document", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleSubstrateDocument))))
+	// RFC BO — serve an image chunk's raw bytes. Same auth posture as
+	// /v1/_document (bearer + ScopeTenant, scope resolved from the principal,
+	// opaque-404 cross-scope). GET because the payload is binary, not JSON.
+	mux.Handle("GET /v1/_document/asset/{chunk_id}", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleSubstrateDocumentAsset))))
 	// RFC BE History tool — browse/search/annotate past chats. Tenant-confined
 	// (ScopeTenant via isTenantConfinedDefPath); the tool's own scope fold +
 	// admin-gated `global` keep a tenant operator inside its own tenant.

--- a/internal/api/http/substrate_admin.go
+++ b/internal/api/http/substrate_admin.go
@@ -5,11 +5,13 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/connector"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
+	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
 )
 
 // v0.8.22 substrate admin endpoints. Two handlers (AgentDef +
@@ -127,6 +129,42 @@ func (s *Server) handleSubstrateDocument(w http.ResponseWriter, r *http.Request)
 	s.dispatchSubstrateCtx(w, r, "Document", s.Document, s.substrateBrowseCtxFn(r))
 }
 
+// handleSubstrateDocumentAsset serves GET /v1/_document/asset/{chunk_id} — the
+// raw bytes of an image chunk's stored asset (RFC BO). The existing /v1/_document
+// is a POST JSON passthrough, unsuitable for binary, so this is a dedicated GET.
+// SECURITY: bearer-authed (same middleware + scope gate as /v1/_document); the
+// scope/tenant/subject are resolved from the principal (substrateBrowseCtxFn),
+// NEVER the wire — a caller can only read an asset in a scope it may see, and any
+// miss (no asset / wrong scope / read fault) returns an OPAQUE 404 so chunk ids
+// can't be probed across scopes. Content-Type is the STORED whitelisted media
+// type (never sniffed) + nosniff, so a stored value can't be coerced into HTML.
+func (s *Server) handleSubstrateDocumentAsset(w http.ResponseWriter, r *http.Request) {
+	chunkID := strings.TrimSpace(r.PathValue("chunk_id"))
+	if chunkID == "" {
+		writeJSONError(w, http.StatusBadRequest, "bad_request", "missing chunk id")
+		return
+	}
+	if s.store == nil || s.sqlMem == nil {
+		http.NotFound(w, r) // no doc store configured → nothing to serve (opaque)
+		return
+	}
+	scope := strings.TrimSpace(r.URL.Query().Get("scope"))
+	ctx := s.substrateBrowseCtxFn(r)(r.Context())
+	doc := &builtin.Document{Store: s.store, SqlMem: s.sqlMem}
+	mediaType, data, ok, err := doc.ReadAsset(ctx, scope, chunkID)
+	if err != nil || !ok || !builtin.ValidImageMediaType(mediaType) {
+		http.NotFound(w, r) // opaque — never distinguish missing/forbidden/error
+		return
+	}
+	w.Header().Set("Content-Type", mediaType)
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Content-Disposition", "inline")
+	w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+	w.Header().Set("Cache-Control", "private, max-age=300")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
+}
+
 // handleSubstrateHistory serves POST /v1/_history.
 // RFC BE History tool (browse/search/annotate past chats). Bearer-authed;
 // tenant-confined (ScopeTenant via isTenantConfinedDefPath; admin satisfies).
@@ -176,7 +214,10 @@ func (s *Server) dispatchSubstrateCtx(
 	connectorFn func(ctx context.Context, input json.RawMessage) (connector.ToolResult, error),
 	ctxFn func(context.Context) context.Context,
 ) {
-	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 1<<20)) // 1 MB cap
+	// Operator-authed substrate ops; the cap (default 8 MiB, RFC BO) admits a
+	// set_asset base64 image payload + a large import_md document — the historical
+	// 1 MiB forced large docs to be split.
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, s.maxDocumentBytes()))
 	if err != nil {
 		writeJSONError(w, http.StatusBadRequest, "bad_request", "read body: "+err.Error())
 		return

--- a/internal/api/http/substrate_admin_test.go
+++ b/internal/api/http/substrate_admin_test.go
@@ -3,6 +3,7 @@ package http
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -560,6 +561,7 @@ func substratePathDocFixture(t *testing.T) *httptest.Server {
 	pathTool := &builtin.Path{Store: st}
 	docTool := &builtin.Document{Store: st, SqlMem: mgr, Bus: channels.NewBus()}
 	srv := New(cfg, &stubResolver{}, []tools.Tool{pathTool, docTool}, concurrency.New(1, 1, time.Second), st)
+	srv.SetSqlMem(mgr) // RFC BO — the asset-serving GET reads via s.sqlMem (main.go wires this in prod)
 	return httptest.NewServer(srv.Mux())
 }
 
@@ -604,6 +606,91 @@ func TestSubstrateAdmin_Document_HappyPath(t *testing.T) {
 	if out["document_id"] == nil || out["root_chunk_id"] == nil {
 		t.Errorf("create_document response missing ids: %v", out)
 	}
+}
+
+// TestSubstrateAdmin_DocumentAsset_ServesAndIsolates (RFC BO P1): GET
+// /v1/_document/asset/{id} serves an image chunk's bytes with the stored
+// whitelisted Content-Type + nosniff, and returns an OPAQUE 404 for a missing
+// chunk, a cross-scope read, or a missing bearer (401 at the auth layer).
+func TestSubstrateAdmin_DocumentAsset_ServesAndIsolates(t *testing.T) {
+	ts := substratePathDocFixture(t)
+	defer ts.Close()
+
+	// document + a chunk under its root.
+	var doc map[string]any
+	r := postAdmin(t, ts, "/v1/_document", `{"op":"create_document","scope":"user","title":"Figures"}`)
+	_ = json.NewDecoder(r.Body).Decode(&doc)
+	r.Body.Close()
+	docID, root := doc["document_id"].(string), doc["root_chunk_id"].(string)
+	var ch map[string]any
+	r = postAdmin(t, ts, "/v1/_document", `{"op":"create_chunk","scope":"user","document_id":"`+docID+`","parent_id":"`+root+`","title":"img"}`)
+	_ = json.NewDecoder(r.Body).Decode(&ch)
+	r.Body.Close()
+	chunkID := ch["id"].(string)
+
+	// attach an image asset (non-UTF-8 bytes → exercises the BLOB path).
+	raw := []byte{0x89, 0x50, 0x4e, 0x47, 0xff, 0xfe, 0x01, 0x02}
+	b64 := base64.StdEncoding.EncodeToString(raw)
+	r = postAdmin(t, ts, "/v1/_document", `{"op":"set_asset","scope":"user","id":"`+chunkID+`","media_type":"image/png","data":"`+b64+`"}`)
+	if r.StatusCode != 200 {
+		body, _ := io.ReadAll(r.Body)
+		t.Fatalf("set_asset: %d %s", r.StatusCode, body)
+	}
+	r.Body.Close()
+
+	// GET the asset → 200 + right headers + exact bytes.
+	g := getAsset(t, ts, "/v1/_document/asset/"+chunkID+"?scope=user", true)
+	if g.StatusCode != 200 {
+		t.Fatalf("serve status = %d, want 200", g.StatusCode)
+	}
+	if ct := g.Header.Get("Content-Type"); ct != "image/png" {
+		t.Errorf("Content-Type = %q, want image/png", ct)
+	}
+	if g.Header.Get("X-Content-Type-Options") != "nosniff" {
+		t.Errorf("missing X-Content-Type-Options: nosniff")
+	}
+	body, _ := io.ReadAll(g.Body)
+	g.Body.Close()
+	if !bytes.Equal(body, raw) {
+		t.Errorf("served bytes mismatch: got %v want %v", body, raw)
+	}
+
+	// A nonexistent chunk id → opaque 404.
+	g = getAsset(t, ts, "/v1/_document/asset/deadbeefdeadbeef?scope=user", true)
+	if g.StatusCode != 404 {
+		t.Errorf("nonexistent asset = %d, want 404", g.StatusCode)
+	}
+	g.Body.Close()
+
+	// A DIFFERENT scope (agent) has no such asset → 404 (scope isolation).
+	g = getAsset(t, ts, "/v1/_document/asset/"+chunkID+"?scope=agent", true)
+	if g.StatusCode != 404 {
+		t.Errorf("cross-scope asset = %d, want 404", g.StatusCode)
+	}
+	g.Body.Close()
+
+	// No bearer → 401 at the auth middleware (never reaches the handler).
+	g = getAsset(t, ts, "/v1/_document/asset/"+chunkID+"?scope=user", false)
+	if g.StatusCode != 401 {
+		t.Errorf("no-auth = %d, want 401", g.StatusCode)
+	}
+	g.Body.Close()
+}
+
+func getAsset(t *testing.T, ts *httptest.Server, path string, withAuth bool) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest("GET", ts.URL+path, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if withAuth {
+		req.Header.Set("Authorization", "Bearer test-token")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
 }
 
 // TestSubstrateAdminUserCtx_ResolvesPrincipalSubject: the user-aware ctx used

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2099,7 +2099,13 @@ type Env struct {
 	// operators tune it down to shrink the per-request memory ceiling.
 	// LOOMCYCLE_MAX_REQUEST_BYTES (bytes; <=0 ignored, default kept).
 	MaxRequestBytes int64
-	AuthToken       string
+	// MaxDocumentAssetBytes caps BOTH the POST /v1/_document request body (so a
+	// set_asset base64 image payload fits) and the decoded image size the
+	// Document tool stores (RFC BO). Default 8 MiB. A base64 payload is ~1.33× the
+	// decoded bytes, so the request cap is the binding one on upload.
+	// LOOMCYCLE_MAX_DOCUMENT_ASSET_BYTES (bytes; <=0 ignored, default kept).
+	MaxDocumentAssetBytes int64
+	AuthToken             string
 	// OperatorTokenPepper is prepended to a bearer before SHA-256 when
 	// hashing OperatorTokenDef tokens (RFC L). A stolen DB dump without
 	// the pepper yields no usable token lookup. Secret — never logged.
@@ -3472,6 +3478,12 @@ func LoadLayers(layers ...Layer) (*Config, error) {
 	if v := os.Getenv("LOOMCYCLE_MAX_REQUEST_BYTES"); v != "" {
 		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
 			cfg.Env.MaxRequestBytes = n
+		}
+	}
+	cfg.Env.MaxDocumentAssetBytes = 8 << 20 // RFC BO
+	if v := os.Getenv("LOOMCYCLE_MAX_DOCUMENT_ASSET_BYTES"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
+			cfg.Env.MaxDocumentAssetBytes = n
 		}
 	}
 	cfg.Env.ChannelsSweepInterval = 15 * time.Minute

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -3,6 +3,7 @@ package builtin
 import (
 	"context"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -33,12 +34,16 @@ type Document struct {
 	Store  store.Store
 	SqlMem *sqlmem.Manager
 	Bus    *channels.Bus
+	// MaxAssetBytes caps the DECODED size of an image asset (set_asset); 0 = a
+	// conservative built-in default. The wire (base64) payload is bounded
+	// separately by the /v1/_document request-body cap. RFC BO.
+	MaxAssetBytes int
 }
 
 func (d *Document) Name() string { return "Document" }
 
 func (d *Document) Description() string {
-	return "A chunked-graph document: each chunk is a first-class unit (UUID, hierarchy, type, fields, graph edges, Markdown body) that agents and humans co-author and query. Ops: create_document/get_document/documents_summary (per-document type/status + display metadata for a set of ids or a Path subtree)/delete_document/set_path, create_chunk/get_chunk/update_chunk/delete_chunk/move_chunk, link_chunks/unlink_chunks/get_edges (the cross-reference edges touching a document, each enriched with its endpoints' titles/types/statuses), query_chunks (structured filters + a raw sql escape hatch), define_type/list_types, export_md (render the document to Markdown), import_md (build a document from export_md-shaped Markdown). Scope is agent or user; documents are named in the Path tree (path:) — create_document defaults to /documents/<title> if you omit one, and set_path attaches/re-homes a path for an existing document."
+	return "A chunked-graph document: each chunk is a first-class unit (UUID, hierarchy, type, fields, graph edges, Markdown body) that agents and humans co-author and query. Ops: create_document/get_document/documents_summary (per-document type/status + display metadata for a set of ids or a Path subtree)/delete_document/set_path, create_chunk/get_chunk/update_chunk/delete_chunk/move_chunk, link_chunks/unlink_chunks/get_edges (the cross-reference edges touching a document, each enriched with its endpoints' titles/types/statuses), query_chunks (structured filters + a raw sql escape hatch), define_type/list_types, set_asset (attach an image's bytes to a chunk → type=image, served by GET /v1/_document/asset/{id})/get_asset (asset metadata), export_md (render the document to Markdown), import_md (build a document from export_md-shaped Markdown). Scope is agent or user; documents are named in the Path tree (path:) — create_document defaults to /documents/<title> if you omit one, and set_path attaches/re-homes a path for an existing document."
 }
 
 // documentInputSchema is a package const so the LoomCycle MCP server can
@@ -48,7 +53,7 @@ func (d *Document) Description() string {
 const documentInputSchema = `{
 	"type": "object",
 	"properties": {
-		"op":          {"type": "string", "enum": ["create_document","get_document","documents_summary","delete_document","set_path","create_chunk","get_chunk","update_chunk","delete_chunk","move_chunk","link_chunks","unlink_chunks","get_edges","query_chunks","define_type","list_types","export_md","import_md"]},
+		"op":          {"type": "string", "enum": ["create_document","get_document","documents_summary","delete_document","set_path","create_chunk","get_chunk","update_chunk","delete_chunk","move_chunk","link_chunks","unlink_chunks","get_edges","query_chunks","define_type","list_types","set_asset","get_asset","export_md","import_md"]},
 		"scope":       {"type": "string", "enum": ["agent","user"], "description": "Which store (default user). agent = this agent; user = this end-user (needs a user_id on the run). tenant scope is not yet supported."},
 		"id":          {"type": "string", "description": "Document id (get/delete_document, set_path) or chunk id (get/update/delete/move_chunk)."},
 		"path":        {"type": "string", "description": "create_document: name the doc in the Path tree (default /documents/<title> if omitted). set_path: the path to attach to an existing document (by id). get/delete_document: address by path instead of id."},
@@ -66,6 +71,9 @@ const documentInputSchema = `{
 		"from_id":     {"type": "string"},
 		"to_id":       {"type": "string"},
 		"kind":        {"type": "string", "description": "link/unlink_chunks: edge kind (promotes/targets/...)."},
+		"media_type":  {"type": "string", "description": "set_asset: the image MIME type (image/png, image/jpeg, image/gif, image/webp)."},
+		"data":        {"type": "string", "description": "set_asset: the image bytes as standard base64 (no data: prefix)."},
+		"filename":    {"type": "string", "description": "set_asset: an optional original filename (metadata only)."},
 		"under_path":  {"type": "string", "description": "query_chunks / documents_summary: restrict to documents at/under this Path-tree path."},
 		"sql":         {"type": "string", "description": "query_chunks: raw read-only SELECT against the chunk tables (escape hatch; validator-gated)."},
 		"limit":       {"type": "integer"},
@@ -97,7 +105,13 @@ type docInput struct {
 	FromID      string          `json:"from_id"`
 	ToID        string          `json:"to_id"`
 	Kind        string          `json:"kind"`
-	UnderPath   string          `json:"under_path"`
+	// MediaType/Data/Filename carry an image asset for set_asset (RFC BO). Data
+	// is standard base64 (no data: prefix); it is decoded to raw bytes and stored
+	// in the chunk_assets BYTEA/BLOB table.
+	MediaType string `json:"media_type"`
+	Data      string `json:"data"`
+	Filename  string `json:"filename"`
+	UnderPath string `json:"under_path"`
 	SQL         string          `json:"sql"`
 	Limit       int             `json:"limit"`
 	Name        string          `json:"name"`
@@ -191,6 +205,10 @@ func (d *Document) Execute(ctx context.Context, raw json.RawMessage) (tools.Resu
 		return d.defineType(ctx, key, in)
 	case "list_types":
 		return d.listTypes(ctx, key, in)
+	case "set_asset":
+		return d.setAsset(ctx, key, mscope, in)
+	case "get_asset":
+		return d.getAsset(ctx, key, in)
 	case "export_md":
 		return d.exportMD(ctx, key, mscope, in)
 	case "import_md":
@@ -244,6 +262,21 @@ func (d *Document) ensureSchema(ctx context.Context, key sqlmem.ScopeKey) error 
 		if _, err := d.SqlMem.Exec(ctx, key, ddl, nil, 0); err != nil {
 			return err
 		}
+	}
+	// chunk_assets (RFC BO) holds image chunk bytes as TRUE binary. The binary
+	// column type is the ONE non-portable part of the doc schema — sqlite BLOB vs
+	// postgres BYTEA — so it is built per-tier here rather than in the static
+	// docSchemaDDL. Bytes are bound/scanned as []byte; base64 exists only on the
+	// wire (set_asset payload / export_md data-URL), decoded before storage.
+	binType := "BLOB"
+	if d.SqlMem.Tier() == "postgres" {
+		binType = "BYTEA"
+	}
+	assetDDL := `CREATE TABLE IF NOT EXISTS chunk_assets (
+		chunk_id TEXT PRIMARY KEY, media_type TEXT NOT NULL, bytes ` + binType + ` NOT NULL,
+		size BIGINT NOT NULL, created_at BIGINT NOT NULL)`
+	if _, err := d.SqlMem.Exec(ctx, key, assetDDL, nil, 0); err != nil {
+		return err
 	}
 	return nil
 }
@@ -377,6 +410,21 @@ func asInt(v any) int {
 		return int(t)
 	default:
 		return 0
+	}
+}
+
+// asBytes extracts raw bytes from a SQL cell — a BYTEA/BLOB column comes back as
+// []byte via database/sql; a string form (defensive) preserves the bytes. Used
+// only for the chunk_assets.bytes column (RFC BO); asStr would work too since a
+// Go string holds arbitrary bytes, but []byte is the honest type.
+func asBytes(v any) []byte {
+	switch t := v.(type) {
+	case []byte:
+		return t
+	case string:
+		return []byte(t)
+	default:
+		return nil
 	}
 }
 
@@ -809,6 +857,11 @@ func (d *Document) deleteDocument(ctx context.Context, key sqlmem.ScopeKey, msco
 		if err := d.execTxn(ctx, txnID, `DELETE FROM chunk_edges WHERE from_id IN (SELECT id FROM chunks WHERE document_id = ?) OR to_id IN (SELECT id FROM chunks WHERE document_id = ?)`, docID, docID); err != nil {
 			return err
 		}
+		// Drop image assets BEFORE the chunk rows (the subquery resolves against
+		// chunks). RFC BO.
+		if err := d.execTxn(ctx, txnID, `DELETE FROM chunk_assets WHERE chunk_id IN (SELECT id FROM chunks WHERE document_id = ?)`, docID); err != nil {
+			return err
+		}
 		if err := d.execTxn(ctx, txnID, `DELETE FROM chunks WHERE document_id = ?`, docID); err != nil {
 			return err
 		}
@@ -897,7 +950,13 @@ func (d *Document) getChunk(ctx context.Context, key sqlmem.ScopeKey, mscope sto
 		return errResult("get_chunk: no such chunk: " + in.ID), nil
 	}
 	cb := d.readBody(ctx, mscope, key.ScopeID, in.ID)
-	return jsonResult(chunkResponse(row, cb))
+	resp := chunkResponse(row, cb)
+	// RFC BO: surface an image chunk's stored asset (metadata only — the bytes
+	// come from GET /v1/_document/asset/{id}) so a viewer knows to render an img.
+	if mt, sz, ok := d.assetMeta(ctx, key, in.ID); ok {
+		resp["asset"] = map[string]any{"media_type": mt, "size": sz}
+	}
+	return jsonResult(resp)
 }
 
 func chunkResponse(row chunkRow, cb chunkBody) map[string]any {
@@ -918,6 +977,154 @@ func chunkResponse(row chunkRow, cb chunkBody) map[string]any {
 		out["fields"] = cb.Fields
 	}
 	return out
+}
+
+// --- asset ops (RFC BO — image chunks) ---
+
+// validImageMediaTypes is the RFC AT vision whitelist (the common denominator
+// across the four vision providers), reused here as the set an image chunk may
+// store — defined locally to avoid importing internal/loop. SVG is deliberately
+// excluded (script-in-SVG is an XSS surface on the serving endpoint).
+var validImageMediaTypes = map[string]bool{
+	"image/png":  true,
+	"image/jpeg": true,
+	"image/gif":  true,
+	"image/webp": true,
+}
+
+// ValidImageMediaType reports whether mt is an allowed image chunk media type
+// (RFC BO) — exported for the serving handler's defense-in-depth Content-Type
+// check (never serve a non-whitelisted type even if one somehow got stored).
+func ValidImageMediaType(mt string) bool { return validImageMediaTypes[mt] }
+
+// defaultMaxAssetBytes bounds a decoded image when the tool has no configured cap.
+const defaultMaxAssetBytes = 8 << 20 // 8 MiB
+
+func (d *Document) maxAssetBytes() int {
+	if d.MaxAssetBytes > 0 {
+		return d.MaxAssetBytes
+	}
+	return defaultMaxAssetBytes
+}
+
+// setAsset attaches (or replaces) an image chunk's binary asset: decode the
+// base64 payload to raw bytes, upsert the chunk_assets row, and mark the chunk
+// type=image with its media_type/size in fields. The chunk must already exist
+// (create_chunk first) — mirrors document create + set_path.
+func (d *Document) setAsset(ctx context.Context, key sqlmem.ScopeKey, mscope store.MemoryScope, in docInput) (tools.Result, error) {
+	if in.ID == "" {
+		return errResult("set_asset: missing required field: id (the chunk id)"), nil
+	}
+	if in.MediaType == "" {
+		return errResult("set_asset: missing required field: media_type"), nil
+	}
+	if !validImageMediaTypes[in.MediaType] {
+		return errResult(fmt.Sprintf("set_asset: unsupported media_type %q (allowed: image/png, image/jpeg, image/gif, image/webp)", in.MediaType)), nil
+	}
+	if in.Data == "" {
+		return errResult("set_asset: missing required field: data (base64 image bytes)"), nil
+	}
+	raw, err := base64.StdEncoding.DecodeString(in.Data)
+	if err != nil {
+		return errResult("set_asset: data must be valid standard base64 (no data: prefix): " + err.Error()), nil
+	}
+	if len(raw) == 0 {
+		return errResult("set_asset: empty image data"), nil
+	}
+	if len(raw) > d.maxAssetBytes() {
+		return errResult(fmt.Sprintf("set_asset: image is %d bytes, exceeds the %d-byte cap", len(raw), d.maxAssetBytes())), nil
+	}
+	row, ok, err := d.getChunkRow(ctx, key, in.ID)
+	if err != nil {
+		return errResult("set_asset: " + err.Error()), nil
+	}
+	if !ok {
+		return errResult("set_asset: no such chunk: " + in.ID), nil
+	}
+	now := time.Now().UnixNano()
+	// Upsert the asset row + mark the chunk type=image in ONE transaction
+	// (portable upsert = delete-then-insert — no ON CONFLICT dialect split).
+	txErr := d.withSqlTxn(ctx, key, func(txnID string) error {
+		if err := d.execTxn(ctx, txnID, `DELETE FROM chunk_assets WHERE chunk_id = ?`, in.ID); err != nil {
+			return err
+		}
+		if err := d.execTxn(ctx, txnID, `INSERT INTO chunk_assets (chunk_id, media_type, bytes, size, created_at) VALUES (?, ?, ?, ?, ?)`,
+			in.ID, in.MediaType, raw, int64(len(raw)), now); err != nil {
+			return err
+		}
+		return d.execTxn(ctx, txnID, `UPDATE chunks SET type = 'image', updated_at = ?, revision = revision + 1 WHERE id = ?`, now, in.ID)
+	})
+	if txErr != nil {
+		return errResult("set_asset: " + txErr.Error()), nil
+	}
+	// Record the asset facts in the chunk's fields (merged — keep any existing
+	// keys + the caption body). Fields live in Memory alongside the body.
+	cb := d.readBody(ctx, mscope, key.ScopeID, in.ID)
+	fields := map[string]any{}
+	if len(cb.Fields) > 0 {
+		_ = json.Unmarshal(cb.Fields, &fields)
+	}
+	fields["kind"] = "image"
+	fields["media_type"] = in.MediaType
+	fields["size"] = len(raw)
+	if in.Filename != "" {
+		fields["filename"] = in.Filename
+	}
+	nf, _ := json.Marshal(fields)
+	if err := d.writeBody(ctx, mscope, key.ScopeID, in.ID, cb.Body, nf); err != nil {
+		return errResult("set_asset: fields: " + err.Error()), nil
+	}
+	d.publishChange(ctx, mscope, key.ScopeID, row.DocumentID, "set_asset", in.ID)
+	return d.getChunk(ctx, key, mscope, docInput{ID: in.ID})
+}
+
+// getAsset returns an image chunk's asset METADATA (media_type, size) — never
+// the bytes (those come from GET /v1/_document/asset/{id}).
+func (d *Document) getAsset(ctx context.Context, key sqlmem.ScopeKey, in docInput) (tools.Result, error) {
+	if in.ID == "" {
+		return errResult("get_asset: missing required field: id (the chunk id)"), nil
+	}
+	mt, sz, ok := d.assetMeta(ctx, key, in.ID)
+	if !ok {
+		return errResult("get_asset: no asset on chunk: " + in.ID), nil
+	}
+	return jsonResult(map[string]any{"chunk_id": in.ID, "media_type": mt, "size": sz})
+}
+
+// assetMeta reads an asset's media_type + size (no bytes). ok=false when the
+// chunk has no asset in this scope.
+func (d *Document) assetMeta(ctx context.Context, key sqlmem.ScopeKey, chunkID string) (mediaType string, size int, ok bool) {
+	res, err := d.query(ctx, key, `SELECT media_type, size FROM chunk_assets WHERE chunk_id = ? LIMIT 1`, chunkID)
+	if err != nil || len(res.Rows) == 0 || len(res.Rows[0]) < 2 {
+		return "", 0, false
+	}
+	return asStr(res.Rows[0][0]), asInt(res.Rows[0][1]), true
+}
+
+// ReadAsset reads an image chunk's raw bytes for the HTTP serving endpoint. scope
+// is "agent"|"user" (default user); the ScopeKey + tenant come from ctx exactly
+// as the tool's own ops resolve them, so a caller can only read an asset in its
+// OWN scope (cross-scope simply misses → opaque 404 at the handler). ok=false
+// when the chunk has no asset in this scope.
+func (d *Document) ReadAsset(ctx context.Context, scope, chunkID string) (mediaType string, data []byte, ok bool, err error) {
+	if d.Store == nil || d.SqlMem == nil {
+		return "", nil, false, fmt.Errorf("Document asset: requires SQL Memory (set LOOMCYCLE_SQLMEM_ENABLED=1)")
+	}
+	key, _, err := d.resolveScope(ctx, scope)
+	if err != nil {
+		return "", nil, false, err
+	}
+	if err := d.ensureSchema(ctx, key); err != nil {
+		return "", nil, false, err
+	}
+	res, err := d.query(ctx, key, `SELECT media_type, bytes FROM chunk_assets WHERE chunk_id = ? LIMIT 1`, chunkID)
+	if err != nil {
+		return "", nil, false, err
+	}
+	if len(res.Rows) == 0 || len(res.Rows[0]) < 2 {
+		return "", nil, false, nil
+	}
+	return asStr(res.Rows[0][0]), asBytes(res.Rows[0][1]), true, nil
 }
 
 func (d *Document) updateChunk(ctx context.Context, key sqlmem.ScopeKey, mscope store.MemoryScope, in docInput, raw json.RawMessage) (tools.Result, error) {
@@ -1046,6 +1253,9 @@ func (d *Document) deleteChunk(ctx context.Context, key sqlmem.ScopeKey, mscope 
 		}
 		for _, cid := range ids {
 			if err := d.execTxn(ctx, txnID, `DELETE FROM chunk_edges WHERE from_id = ? OR to_id = ?`, cid, cid); err != nil {
+				return err
+			}
+			if err := d.execTxn(ctx, txnID, `DELETE FROM chunk_assets WHERE chunk_id = ?`, cid); err != nil {
 				return err
 			}
 			if err := d.execTxn(ctx, txnID, `DELETE FROM chunks WHERE id = ?`, cid); err != nil {

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -112,9 +112,9 @@ type docInput struct {
 	Data      string `json:"data"`
 	Filename  string `json:"filename"`
 	UnderPath string `json:"under_path"`
-	SQL         string          `json:"sql"`
-	Limit       int             `json:"limit"`
-	Name        string          `json:"name"`
+	SQL       string `json:"sql"`
+	Limit     int    `json:"limit"`
+	Name      string `json:"name"`
 	// IncludeMetadata gates export_md's round-trip comments (default true when
 	// omitted; a pointer so an explicit `false` is distinguishable from unset).
 	IncludeMetadata *bool `json:"include_metadata"`

--- a/internal/tools/builtin/document_test.go
+++ b/internal/tools/builtin/document_test.go
@@ -1,8 +1,10 @@
 package builtin
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"os"
 	"strings"
@@ -788,6 +790,96 @@ func TestDocument_ChunkStatusBoardRoundTrip(t *testing.T) {
 	}
 	if err := d.SetChunkStatus(ctx, "agent", "nope", "x"); err == nil || !strings.Contains(err.Error(), "no such chunk") {
 		t.Errorf("SetChunkStatus(nope) err = %v, want 'no such chunk'", err)
+	}
+}
+
+// TestDocument_ImageAssetRoundTrip covers RFC BO P1: set_asset stores an image
+// chunk's bytes in the chunk_assets BYTEA/BLOB table, marks the chunk type=image,
+// surfaces an asset indicator on get_chunk, ReadAsset returns the exact bytes,
+// scope isolation holds, and delete_chunk drops the asset.
+func TestDocument_ImageAssetRoundTrip(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+
+	out, res := docExec(t, d, ctx, `{"op":"create_document","scope":"agent","title":"Figures"}`)
+	if res.IsError {
+		t.Fatalf("create_document: %s", res.Text)
+	}
+	docID := out["document_id"].(string)
+	out, res = docExec(t, d, ctx, `{"op":"create_chunk","scope":"agent","document_id":"`+docID+`","title":"diagram.png"}`)
+	if res.IsError {
+		t.Fatalf("create_chunk: %s", res.Text)
+	}
+	chunkID := out["id"].(string)
+
+	// Arbitrary bytes (incl. a PNG magic prefix + non-UTF-8) — the tool validates
+	// media_type + base64 + size, not the pixel format; non-UTF-8 exercises the
+	// BLOB path (a JSON store would mangle these bytes).
+	rawImg := []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xff, 0xfe, 0x00, 0x01, 0x02}
+	b64 := base64.StdEncoding.EncodeToString(rawImg)
+	out, res = docExec(t, d, ctx, `{"op":"set_asset","scope":"agent","id":"`+chunkID+`","media_type":"image/png","data":"`+b64+`","filename":"diagram.png"}`)
+	if res.IsError {
+		t.Fatalf("set_asset: %s", res.Text)
+	}
+	if out["type"] != "image" {
+		t.Errorf("set_asset did not mark type=image: %s", res.Text)
+	}
+	asset, _ := out["asset"].(map[string]any)
+	if asset["media_type"] != "image/png" || int(asset["size"].(float64)) != len(rawImg) {
+		t.Errorf("asset indicator = %v (want media_type=image/png size=%d)", out["asset"], len(rawImg))
+	}
+
+	// get_asset returns metadata only.
+	out, res = docExec(t, d, ctx, `{"op":"get_asset","scope":"agent","id":"`+chunkID+`"}`)
+	if res.IsError || out["media_type"] != "image/png" || int(out["size"].(float64)) != len(rawImg) {
+		t.Errorf("get_asset = %s", res.Text)
+	}
+
+	// ReadAsset (the serving path) returns the EXACT bytes.
+	mt, data, ok, err := d.ReadAsset(ctx, "agent", chunkID)
+	if err != nil || !ok {
+		t.Fatalf("ReadAsset: ok=%v err=%v", ok, err)
+	}
+	if mt != "image/png" || !bytes.Equal(data, rawImg) {
+		t.Errorf("ReadAsset bytes mismatch: mt=%q got %v want %v", mt, data, rawImg)
+	}
+
+	// Scope isolation: the SAME chunk id under the USER scope has no asset.
+	if _, _, ok, _ := d.ReadAsset(ctx, "user", chunkID); ok {
+		t.Errorf("ReadAsset(user) unexpectedly found an agent-scope asset (scope isolation broken)")
+	}
+
+	// delete_chunk drops the asset row too.
+	if _, dres := docExec(t, d, ctx, `{"op":"delete_chunk","scope":"agent","id":"`+chunkID+`"}`); dres.IsError {
+		t.Fatalf("delete_chunk: %s", dres.Text)
+	}
+	if _, _, ok, _ := d.ReadAsset(ctx, "agent", chunkID); ok {
+		t.Errorf("asset survived delete_chunk")
+	}
+}
+
+// TestDocument_SetAssetValidation covers set_asset's guards (RFC BO): media_type
+// whitelist, base64 validity, the size cap, and a missing chunk.
+func TestDocument_SetAssetValidation(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	d.MaxAssetBytes = 16 // tiny cap for the over-cap case
+	out, _ := docExec(t, d, ctx, `{"op":"create_document","scope":"agent","title":"V"}`)
+	docID := out["document_id"].(string)
+	out, _ = docExec(t, d, ctx, `{"op":"create_chunk","scope":"agent","document_id":"`+docID+`","title":"x"}`)
+	chunkID := out["id"].(string)
+	okData := base64.StdEncoding.EncodeToString([]byte("tiny"))
+
+	if _, res := docExec(t, d, ctx, `{"op":"set_asset","scope":"agent","id":"`+chunkID+`","media_type":"text/html","data":"`+okData+`"}`); !res.IsError || !strings.Contains(res.Text, "unsupported media_type") {
+		t.Errorf("text/html should be rejected: %s", res.Text)
+	}
+	if _, res := docExec(t, d, ctx, `{"op":"set_asset","scope":"agent","id":"`+chunkID+`","media_type":"image/png","data":"!!!not base64!!!"}`); !res.IsError {
+		t.Errorf("invalid base64 should be rejected")
+	}
+	big := base64.StdEncoding.EncodeToString(make([]byte, 17)) // 17 > 16-byte cap
+	if _, res := docExec(t, d, ctx, `{"op":"set_asset","scope":"agent","id":"`+chunkID+`","media_type":"image/png","data":"`+big+`"}`); !res.IsError || !strings.Contains(res.Text, "exceeds") {
+		t.Errorf("over-cap should be rejected: %s", res.Text)
+	}
+	if _, res := docExec(t, d, ctx, `{"op":"set_asset","scope":"agent","id":"nope","media_type":"image/png","data":"`+okData+`"}`); !res.IsError || !strings.Contains(res.Text, "no such chunk") {
+		t.Errorf("missing chunk should be rejected: %s", res.Text)
 	}
 }
 


### PR DESCRIPTION
## Why
RFC BO (`/loomcycle/rfcs/document-image-diagram-chunks`) makes **images and Mermaid diagrams first-class typed chunks** in the Document store. Today a chunk is text-only; there's no binary slot, and images can't be stored or served. **P1** builds the backend storage + serving substrate for image chunks. (A `mermaid` chunk needs no backend — its body is plain source; type-aware rendering is P2.)

## What

### Storage — `chunk_assets` (BYTEA/BLOB)
A new `chunk_assets(chunk_id PK, media_type, bytes, size, created_at)` table in SQL Memory holds image bytes as **true binary** — sqlite `BLOB` / postgres `BYTEA`, chosen per-tier via `SqlMem.Tier()` (the one non-portable column, so it's built in `ensureSchema`, not the static `docSchemaDDL`). Bytes bind/scan as `[]byte`; base64 exists **only on the wire**.

### Ops (mirror `set_path`)
- **`set_asset {id, media_type, data(base64), filename?}`** — validate media_type against the **png/jpeg/gif/webp** whitelist (**SVG excluded** — script-in-SVG XSS), validate base64, enforce the size cap, upsert the asset row (delete+insert in one txn), and mark the chunk `type=image` with `kind`/`media_type`/`size` in its `fields`.
- **`get_asset {id}`** — metadata only (never the bytes).
- `get_chunk` gains an **`asset`** indicator; `delete_chunk`/`delete_document` drop the asset row in the same cascade transaction.

### Serving — `GET /v1/_document/asset/{chunk_id}`
A dedicated route (POST `/v1/_document` is JSON-only). **Security (trust boundary):** bearer-authed; scope/tenant resolved from the **principal** (`substrateBrowseCtxFn`), never the wire; **opaque 404** for missing / cross-scope / error so chunk ids can't be probed; `Content-Type` is the **stored whitelisted** media_type + `X-Content-Type-Options: nosniff` (no HTML-as-image); joins the `ScopeTenant` gate via a prefix match in `isTenantConfinedDefPath`.

### Caps
`LOOMCYCLE_MAX_DOCUMENT_ASSET_BYTES` (default 8 MiB) bounds both the decoded image (in the tool) **and** the POST `/v1/_document` body — which also **lifts the old 1 MiB substrate cap** that forced large `import_md` docs to be split.

## Tested
- `TestDocument_ImageAssetRoundTrip` — BYTEA round-trip incl. **non-UTF-8 bytes** (a JSON store would mangle these), asset indicator, `ReadAsset` bytes, **scope isolation**, delete cleanup.
- `TestDocument_SetAssetValidation` — media_type / base64 / size-cap / missing-chunk.
- `TestSubstrateAdmin_DocumentAsset_ServesAndIsolates` — 200 + Content-Type + nosniff + exact bytes; opaque 404 for missing/cross-scope; 401 no-auth.
- `go build ./...`, `go vet`, affected suites (`builtin`, `api/http`, `config`) all green.

**Backend only** — no adapter/frontend change (viewer rendering is P2). This is P1 of a 4-phase RFC-gated line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)