### PR TITLE
feat(explorer): render image & mermaid chunks in the viewer (RFC BO P2)

### DIFF
--- a/packages/explorer/src/components/DocumentChunkTree.tsx
+++ b/packages/explorer/src/components/DocumentChunkTree.tsx
@@ -31,6 +31,14 @@ export function buildChunkTree(chunks: ChunkRow[]): ChunkNode[] {
   return roots;
 }
 
+// typeIcon returns a small glyph for a media chunk type (RFC BO) so the tree
+// distinguishes image / diagram chunks at a glance; "" for a plain text chunk.
+function typeIcon(type: string | undefined): string {
+  if (type === "image") return "🖼";
+  if (type === "mermaid") return "📊";
+  return "";
+}
+
 // findChunkNode locates a node by id within a chunk forest.
 export function findChunkNode(nodes: ChunkNode[], id: string): ChunkNode | undefined {
   for (const n of nodes) {
@@ -170,6 +178,11 @@ function ChunkTreeNode({ node, expanded, toggle, selectedId, onSelect, tintSchem
           onClick={() => onSelect(node)}
           title={node.row.title}
         >
+          {typeIcon(node.row.type) && (
+            <span className="chunk-type-icon" aria-hidden>
+              {typeIcon(node.row.type)}
+            </span>
+          )}
           <span className="chunk-title">{node.row.title || "(untitled)"}</span>
           {node.row.type && <span className="chunk-badge">{node.row.type}</span>}
           {node.row.status && <span className="chunk-badge chunk-status">{node.row.status}</span>}

--- a/packages/explorer/src/components/DocumentViewerBody.tsx
+++ b/packages/explorer/src/components/DocumentViewerBody.tsx
@@ -24,6 +24,15 @@ import ChunkEditorModal from "./ChunkEditorModal";
 import ColorSchemeEditor from "./ColorSchemeEditor";
 import CrossReferences from "./CrossReferences";
 import Markdown from "./Markdown";
+import MermaidDiagram from "./Mermaid";
+
+// imageAlt derives an image chunk's alt text: the fields.alt override, else the
+// chunk title, else a generic label (RFC BO).
+function imageAlt(chunk: ChunkDetail): string {
+  const f = (chunk.fields ?? {}) as { alt?: unknown };
+  if (typeof f.alt === "string" && f.alt.trim() !== "") return f.alt;
+  return chunk.title || "image";
+}
 
 // DocumentViewerBody is the read-mostly surface for one chunked-graph document
 // (RFC AK). The chunk tree stays on the left for navigation; the right pane
@@ -83,6 +92,9 @@ export default function DocumentViewerBody({
   const [selectedDetail, setSelectedDetail] = useState<ChunkDetail | null>(null);
   const [mode, setMode] = useState<Mode>("chunks");
   const [subtreeMd, setSubtreeMd] = useState<string | null>(null);
+  // RFC BO — an image chunk's blob object-URL (fetched with auth) + a load error.
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [imageErr, setImageErr] = useState<string | null>(null);
   const [editing, setEditing] = useState<ChunkDetail | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -207,6 +219,36 @@ export default function DocumentViewerBody({
     };
   }, [data, selectedId, scope, reload, browse]);
 
+  // RFC BO — for an image chunk, fetch its bytes WITH auth into a blob object-URL
+  // for <img src> (a bare <img src=/v1/...> can't carry a bearer). Revoke the URL
+  // on change/unmount so blobs don't leak.
+  useEffect(() => {
+    const isImage = selectedDetail?.type === "image" || !!selectedDetail?.asset;
+    if (!selectedDetail || !isImage || !data.documentAssetObjectUrl) {
+      setImageUrl(null);
+      setImageErr(null);
+      return;
+    }
+    let cancelled = false;
+    let url: string | null = null;
+    setImageErr(null);
+    data
+      .documentAssetObjectUrl(selectedDetail.id, scope, browse)
+      .then((u) => {
+        if (cancelled) {
+          URL.revokeObjectURL(u);
+          return;
+        }
+        url = u;
+        setImageUrl(u);
+      })
+      .catch((e) => !cancelled && setImageErr(e instanceof Error ? e.message : String(e)));
+    return () => {
+      cancelled = true;
+      if (url) URL.revokeObjectURL(url);
+    };
+  }, [data, selectedDetail, scope, browse]);
+
   // Assemble the selected chunk + its sub-chunks into one Markdown string for the
   // markdown view (fetches each descendant's body; heading depth is relative to
   // the selected chunk, so it reads as a standalone part — or the whole document
@@ -232,7 +274,19 @@ export default function DocumentViewerBody({
           .map((it, idx) => {
             const lvl = Math.min(it.depth + 1, 6);
             const d = details[idx];
-            return "#".repeat(lvl) + " " + it.node.row.title + (d.body ? "\n\n" + d.body : "") + "\n";
+            const heading = "#".repeat(lvl) + " " + it.node.row.title;
+            // RFC BO — render media child chunks correctly in the assembled view:
+            // a mermaid chunk's body becomes a ```mermaid fence (so it draws);
+            // an image chunk shows a placeholder (its bytes need the auth'd asset
+            // GET, which the plain-string assembler can't inline).
+            if (d.type === "mermaid" && d.body) {
+              return heading + "\n\n```mermaid\n" + d.body + "\n```\n";
+            }
+            if (d.type === "image" || d.asset) {
+              const cap = d.body ? " — " + d.body : "";
+              return heading + "\n\n_🖼 image chunk_" + cap + "\n";
+            }
+            return heading + (d.body ? "\n\n" + d.body : "") + "\n";
           })
           .join("\n");
         setSubtreeMd(md);
@@ -358,7 +412,33 @@ export default function DocumentViewerBody({
                 </div>
               </div>
               <div className="doc-content-body">
-                {mode === "markdown" ? (
+                {selectedDetail.type === "mermaid" ? (
+                  // RFC BO — a diagram chunk: body IS the Mermaid source.
+                  selectedDetail.body ? (
+                    <>
+                      <MermaidDiagram code={selectedDetail.body} />
+                      {mode === "markdown" && (
+                        <pre className="md-pre doc-mermaid-source">
+                          <code>{selectedDetail.body}</code>
+                        </pre>
+                      )}
+                    </>
+                  ) : (
+                    <p className="doc-empty-body">(empty diagram)</p>
+                  )
+                ) : selectedDetail.type === "image" || selectedDetail.asset ? (
+                  // RFC BO — an image chunk: bytes come from the auth'd asset GET.
+                  imageErr ? (
+                    <p className="doc-empty-body">Image failed to load: {imageErr}</p>
+                  ) : imageUrl ? (
+                    <figure className="doc-image">
+                      <img src={imageUrl} alt={imageAlt(selectedDetail)} />
+                      {selectedDetail.body && <figcaption>{selectedDetail.body}</figcaption>}
+                    </figure>
+                  ) : (
+                    <p className="doc-empty-body">Loading image…</p>
+                  )
+                ) : mode === "markdown" ? (
                   subtreeMd !== null ? (
                     <Markdown source={subtreeMd} />
                   ) : (

--- a/packages/explorer/src/components/ExplorerRoot.tsx
+++ b/packages/explorer/src/components/ExplorerRoot.tsx
@@ -1,6 +1,6 @@
 import { useMemo, type ReactNode } from "react";
 import type { LoomcycleClient } from "@loomcycle/client";
-import { createLoomcycleClient, type Connection } from "../lib/createClient";
+import { createLoomcycleClient, assetFetchFromConnection, type Connection } from "../lib/createClient";
 import {
   ExplorerDataProvider,
   dataLayerFromClient,
@@ -29,7 +29,11 @@ export function useResolvedDataLayer(src: ExplorerDataSource): ExplorerDataLayer
   return useMemo<ExplorerDataLayer | null>(() => {
     if (dataLayer) return dataLayer;
     if (client) return dataLayerFromClient(client);
-    if (connection) return dataLayerFromClient(createLoomcycleClient(connection));
+    if (connection)
+      return dataLayerFromClient(
+        createLoomcycleClient(connection),
+        assetFetchFromConnection(connection), // RFC BO — binary image-asset GET
+      );
     return null;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dataLayer, client, connection?.baseUrl, connection?.token, connection?.fetch]);

--- a/packages/explorer/src/index.ts
+++ b/packages/explorer/src/index.ts
@@ -25,8 +25,8 @@ export type {
 } from "./types";
 
 // Connection → client factory (the default data-source path).
-export { createLoomcycleClient } from "./lib/createClient";
-export type { Connection } from "./lib/createClient";
+export { createLoomcycleClient, assetFetchFromConnection } from "./lib/createClient";
+export type { Connection, AssetFetch } from "./lib/createClient";
 
 // The data-layer seam: inject a custom implementation, or build one from a
 // @loomcycle/client instance.

--- a/packages/explorer/src/lib/createClient.ts
+++ b/packages/explorer/src/lib/createClient.ts
@@ -26,3 +26,23 @@ export function createLoomcycleClient(c: Connection): LoomcycleClient {
     fetch: (input, init) => (impl ? impl(input, init) : fetch(input, init)),
   });
 }
+
+/** AssetFetch does a raw authenticated GET against a relative loomcycle path and
+ *  returns the Response — for BINARY endpoints (RFC BO image assets) the JSON
+ *  client can't model. It mirrors the Connection's transport: the custom `fetch`
+ *  (e.g. the Web UI's same-origin cookie fetch) carries cookie auth, and a bearer
+ *  token is added as an Authorization header when set. */
+export type AssetFetch = (path: string) => Promise<Response>;
+
+/** Build the AssetFetch from a Connection — the SAME auth transport the JSON
+ *  client uses, so an image asset loads under both cookie (web) and bearer
+ *  (standalone package) auth. */
+export function assetFetchFromConnection(c: Connection): AssetFetch {
+  const impl = c.fetch;
+  const doFetch: typeof fetch = (input, init) => (impl ? impl(input, init) : fetch(input, init));
+  return (path) => {
+    const headers: Record<string, string> = {};
+    if (c.token) headers.Authorization = `Bearer ${c.token}`;
+    return doFetch(c.baseUrl + path, { headers });
+  };
+}

--- a/packages/explorer/src/lib/dataLayer.tsx
+++ b/packages/explorer/src/lib/dataLayer.tsx
@@ -10,6 +10,7 @@ import type {
   PathScope,
 } from "../types";
 import type { DocSummary, DocumentMeta } from "./colorScheme";
+import type { AssetFetch } from "./createClient";
 
 // ChunkPatch is the subset of chunk fields update_chunk accepts. `fields` is
 // unknown (arbitrary typed JSON the chunk carries); a blank/absent value leaves
@@ -98,6 +99,16 @@ export interface ExplorerDataLayer {
     scope: DocScope,
     browse?: BrowseScope,
   ): Promise<{ edges: DocEdge[] }>;
+  // documentAssetObjectUrl fetches an image chunk's bytes (RFC BO) WITH auth and
+  // returns a blob object-URL for an <img src> — a bare <img src=/v1/...> can't
+  // carry a bearer header. The CALLER must URL.revokeObjectURL when done. Absent
+  // when the data source can't do a raw binary GET (a bare client with no
+  // connection) → the viewer falls back to a placeholder.
+  documentAssetObjectUrl?(
+    chunkId: string,
+    scope: DocScope,
+    browse?: BrowseScope,
+  ): Promise<string>;
   documentUpdateChunk(
     id: string,
     revision: number,
@@ -122,7 +133,7 @@ export interface ExplorerDataLayer {
 // the SDK serializes it to ?scope_id= / ?tenant= (empty/undefined → the caller's
 // own subject, byte-identical to the pre-RFC-AS behaviour). Responses are
 // op-varying `unknown`, cast to the kept shapes the components consume.
-export function dataLayerFromClient(client: LoomcycleClient): ExplorerDataLayer {
+export function dataLayerFromClient(client: LoomcycleClient, assetFetch?: AssetFetch): ExplorerDataLayer {
   return {
     pathLs: (path, scope, recursive, browse) =>
       client.path(
@@ -200,6 +211,24 @@ export function dataLayerFromClient(client: LoomcycleClient): ExplorerDataLayer 
         },
         browse,
       ) as Promise<{ markdown: string; title: string; document_id: string }>,
+    // Present only when an AssetFetch was supplied (the connection path); a bare
+    // client can't do the raw binary GET, so the op is omitted and the viewer
+    // shows a placeholder.
+    ...(assetFetch
+      ? {
+          documentAssetObjectUrl: async (chunkId, scope, browse) => {
+            const q = new URLSearchParams({ scope });
+            if (browse?.scopeId) q.set("scope_id", browse.scopeId);
+            if (browse?.tenant) q.set("tenant", browse.tenant);
+            const resp = await assetFetch(
+              `/v1/_document/asset/${encodeURIComponent(chunkId)}?${q.toString()}`,
+            );
+            if (!resp.ok) throw new Error(`asset fetch failed: ${resp.status}`);
+            const blob = await resp.blob();
+            return URL.createObjectURL(blob);
+          },
+        }
+      : {}),
   };
 }
 

--- a/packages/explorer/src/styles.css
+++ b/packages/explorer/src/styles.css
@@ -1022,3 +1022,32 @@
   margin-top: 6px;
   font-size: var(--lc-text-xs);
 }
+
+/* ============================================================
+   RFC BO — image & diagram chunks
+   ============================================================ */
+.loomcycle-explorer .chunk-type-icon {
+  font-size: 0.9em;
+  line-height: 1;
+  margin-right: 2px;
+}
+.loomcycle-explorer .doc-image {
+  margin: 0;
+  text-align: center;
+}
+.loomcycle-explorer .doc-image img {
+  max-width: 100%;
+  height: auto;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg-soft);
+}
+.loomcycle-explorer .doc-image figcaption {
+  margin-top: 6px;
+  color: var(--fg-soft);
+  font-size: var(--lc-text-sm);
+  font-style: italic;
+}
+.loomcycle-explorer .doc-mermaid-source {
+  margin-top: 10px;
+}

--- a/packages/explorer/src/types.ts
+++ b/packages/explorer/src/types.ts
@@ -48,6 +48,9 @@ export interface ChunkRow {
 export interface ChunkDetail extends ChunkRow {
   body: string;
   fields?: unknown;
+  // asset (RFC BO) is present on an image chunk — metadata only; the bytes are
+  // fetched from GET /v1/_document/asset/{id} via documentAssetObjectUrl.
+  asset?: { media_type: string; size: number };
 }
 
 // DocEdge is one cross-reference edge from get_edges (RFC BN P4): a typed link

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6697,3 +6697,32 @@ button.primary:disabled {
   margin-top: 6px;
   font-size: var(--lc-text-xs);
 }
+
+/* ============================================================
+   RFC BO — image & diagram chunks (explorer, dogfooded)
+   ============================================================ */
+.chunk-type-icon {
+  font-size: 0.9em;
+  line-height: 1;
+  margin-right: 2px;
+}
+.doc-image {
+  margin: 0;
+  text-align: center;
+}
+.doc-image img {
+  max-width: 100%;
+  height: auto;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg-soft);
+}
+.doc-image figcaption {
+  margin-top: 6px;
+  color: var(--fg-soft);
+  font-size: var(--lc-text-sm);
+  font-style: italic;
+}
+.doc-mermaid-source {
+  margin-top: 10px;
+}


### PR DESCRIPTION
## Why
RFC BO P2 — the viewer half. [P1 (#788)](https://github.com/denn-gubsky/loomcycle/pull/788) gave the store typed **image** chunks (bytes in `chunk_assets`, served by `GET /v1/_document/asset/{id}`) and the **`type=mermaid`** convention. This makes the `@loomcycle/explorer` viewer (dogfooded by the Web UI) actually **render** both.

## What

### Type-aware chunk view (`DocumentViewerBody`)
- **`type=mermaid`** → the shared `MermaidDiagram` on the chunk body (raw source); markdown mode additionally shows the source in a code block.
- **`type=image`** (or an `asset` indicator) → an `<img>` in a `<figure>` with the body as an optional caption; `alt = fields.alt || title`.
- everything else → `Markdown` (unchanged).

### Authenticated image fetch
A bare `<img src=/v1/_document/asset/...>` **can't carry a bearer header**, so the data layer gains an optional **`documentAssetObjectUrl`** that fetches the asset **with auth → blob → `URL.createObjectURL`** (revoked on change/unmount). The fetcher is built from the **Connection** (`assetFetchFromConnection`), so it reuses the **same transport as every other call** — cookie auth for the Web UI, bearer for the standalone package. Absent when the source is a bare client (no connection) → the viewer shows a placeholder.

### Also
- 🖼 / 📊 **type icons** on image/mermaid tiles in the chunk tree.
- The **markdown-assembly view** wraps a mermaid child's body in a ```mermaid fence (so it draws in the whole-document view) and shows an image placeholder (bytes need the auth'd GET the plain-string assembler can't inline).
- `ChunkDetail` gains the `asset` field; image/diagram CSS in **both** stylesheets; exported `AssetFetch` + `assetFetchFromConnection`.

## Tested
- `packages/explorer` typecheck + `build:lib` + tests green.
- `cd web && npm run build` clean (single `mermaid.core` chunk — dedupe holds).
- **No backend/adapter change** — pure viewer. P2 of the 4-phase RFC BO line (P3 = Web-UI upload/paste + Mermaid editor; P4 = export/import round-trip + TS asset helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)