### PR TITLE
feat(explorer): image upload/paste + Mermaid live-preview editor (RFC BO P3)

### DIFF
--- a/packages/explorer/src/components/ChunkEditorModal.tsx
+++ b/packages/explorer/src/components/ChunkEditorModal.tsx
@@ -1,6 +1,8 @@
-import { useState, type FormEvent } from "react";
+import { useEffect, useState, type FormEvent } from "react";
 import type { BrowseScope, ChunkDetail, DocScope } from "../types";
 import { useExplorerData } from "../lib/dataLayer";
+import MermaidDiagram from "./Mermaid";
+import { readImageAsBase64 } from "../lib/imageUpload";
 
 // ChunkEditorModal edits one chunk's content — title, type, status, Markdown
 // body, and (optional) typed fields as JSON. Save is an optimistic-concurrency
@@ -30,6 +32,37 @@ export default function ChunkEditorModal({ chunk, scope, browse, onClose, onSave
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [conflict, setConflict] = useState(false);
+
+  const isMermaid = type === "mermaid";
+  const isImage = type === "image" || !!chunk.asset;
+
+  // RFC BO — a debounced copy of the body drives the live Mermaid preview so it
+  // re-renders as the author edits the source, but not on every keystroke.
+  const [preview, setPreview] = useState(body);
+  useEffect(() => {
+    if (!isMermaid) return;
+    const t = setTimeout(() => setPreview(body), 400);
+    return () => clearTimeout(t);
+  }, [body, isMermaid]);
+
+  // RFC BO — replace an image chunk's bytes in place (set_asset bumps the
+  // revision, so we hand the updated chunk back and close rather than risk a
+  // stale-revision save afterward).
+  const replaceImage = async (file: File) => {
+    setErr(null);
+    setBusy(true);
+    try {
+      const { mediaType, data: b64 } = await readImageAsBase64(file);
+      const updated = await data.documentSetAsset(chunk.id, mediaType, b64, file.name, scope, browse);
+      onSaved(updated);
+      onClose();
+    } catch (ex) {
+      setErr(ex instanceof Error ? ex.message : String(ex));
+      setBusy(false);
+    }
+  };
+
+  const bodyLabel = isMermaid ? "Mermaid source" : isImage ? "Caption (optional)" : "Body (Markdown)";
 
   const submit = async (e: FormEvent) => {
     e.preventDefault();
@@ -110,15 +143,41 @@ export default function ChunkEditorModal({ chunk, scope, browse, onClose, onSave
             />
           </label>
         </div>
+        {isImage && (
+          <label className="path-field">
+            <span>Replace image</span>
+            <input
+              type="file"
+              accept="image/png,image/jpeg,image/gif,image/webp"
+              disabled={busy}
+              onChange={(e) => {
+                const f = e.target.files?.[0];
+                if (f) void replaceImage(f);
+              }}
+            />
+          </label>
+        )}
         <label className="path-field">
-          <span>Body (Markdown)</span>
+          <span>{bodyLabel}</span>
           <textarea
             className="modal-textarea chunk-body-input"
-            rows={12}
+            rows={isMermaid ? 8 : 12}
             value={body}
             onChange={(e) => setBody(e.target.value)}
           />
         </label>
+        {isMermaid && (
+          <div className="path-field">
+            <span>Preview</span>
+            <div className="chunk-mermaid-preview">
+              {preview.trim() ? (
+                <MermaidDiagram code={preview} />
+              ) : (
+                <p className="doc-empty-body">(enter Mermaid source above)</p>
+              )}
+            </div>
+          </div>
+        )}
         <label className="path-field">
           <span>Fields (JSON, optional)</span>
           <textarea

--- a/packages/explorer/src/components/DocumentViewerBody.tsx
+++ b/packages/explorer/src/components/DocumentViewerBody.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import type {
   AssistantContext,
   BrowseScope,
@@ -8,6 +8,7 @@ import type {
   DocScope,
   Principal,
 } from "../types";
+import { readImageAsBase64, imageFileFromPaste } from "../lib/imageUpload";
 import { useExplorerData } from "../lib/dataLayer";
 import {
   docColor,
@@ -95,6 +96,7 @@ export default function DocumentViewerBody({
   // RFC BO — an image chunk's blob object-URL (fetched with auth) + a load error.
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   const [imageErr, setImageErr] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null); // hidden upload input (RFC BO)
   const [editing, setEditing] = useState<ChunkDetail | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -316,13 +318,110 @@ export default function DocumentViewerBody({
     }
   }, [data, documentId, scope, browse]);
 
+  // RFC BO authoring — create a media chunk under the selected chunk (or the
+  // root). The runtime marks type=image via set_asset; a diagram is a plain
+  // type=mermaid chunk whose body is the source.
+  const canCreate = !!data.documentCreateChunk && !!rootChunkId;
+  const addImageFile = useCallback(
+    async (file: File) => {
+      if (!data.documentCreateChunk || !data.documentSetAsset) return;
+      const parent = selectedId || rootChunkId;
+      if (!parent) return;
+      setErr(null);
+      try {
+        const { mediaType, data: b64 } = await readImageAsBase64(file);
+        const created = await data.documentCreateChunk(
+          documentId,
+          parent,
+          { title: file.name || "image", type: "image" },
+          scope,
+          browse,
+        );
+        await data.documentSetAsset(created.id, mediaType, b64, file.name, scope, browse);
+        refresh();
+        setSelectedId(created.id);
+      } catch (e) {
+        setErr(e instanceof Error ? e.message : String(e));
+      }
+    },
+    [data, documentId, scope, browse, selectedId, rootChunkId, refresh],
+  );
+  const addDiagram = useCallback(async () => {
+    if (!data.documentCreateChunk) return;
+    const parent = selectedId || rootChunkId;
+    if (!parent) return;
+    setErr(null);
+    try {
+      const created = await data.documentCreateChunk(
+        documentId,
+        parent,
+        { title: "Diagram", type: "mermaid", body: "graph TD\n  A[Start] --> B[End]" },
+        scope,
+        browse,
+      );
+      refresh();
+      setSelectedId(created.id);
+      setEditing(created); // open the editor (with live preview) on the new diagram
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    }
+  }, [data, documentId, scope, browse, selectedId, rootChunkId, refresh]);
+
+  // Paste a screenshot anywhere in the viewer → a new image chunk. Ignored while
+  // a modal or a text field is focused (so an editor paste isn't hijacked).
+  useEffect(() => {
+    if (!canCreate) return;
+    const onPaste = (e: ClipboardEvent) => {
+      if (editing || colorsOpen) return;
+      const ae = document.activeElement;
+      const tag = ae?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || (ae as HTMLElement)?.isContentEditable) return;
+      const file = imageFileFromPaste(e.clipboardData?.items);
+      if (file) {
+        e.preventDefault();
+        void addImageFile(file);
+      }
+    };
+    window.addEventListener("paste", onPaste);
+    return () => window.removeEventListener("paste", onPaste);
+  }, [canCreate, editing, colorsOpen, addImageFile]);
+
   return (
     <div className="doc-viewer">
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/png,image/jpeg,image/gif,image/webp"
+        style={{ display: "none" }}
+        onChange={(e) => {
+          const f = e.target.files?.[0];
+          e.target.value = ""; // allow re-selecting the same file
+          if (f) void addImageFile(f);
+        }}
+      />
       <div className="doc-toolbar" style={toolbarTint}>
         <strong className="doc-title" title={rootTitle}>
           {rootTitle}
         </strong>
         <div className="doc-toolbar-actions">
+          {canCreate && (
+            <>
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                title="Add an image chunk (upload — or paste a screenshot into the view)"
+              >
+                + image
+              </button>
+              <button
+                type="button"
+                onClick={() => void addDiagram()}
+                title="Add a Mermaid diagram chunk"
+              >
+                + diagram
+              </button>
+            </>
+          )}
           <button
             type="button"
             className={colorEnabled ? "active" : ""}

--- a/packages/explorer/src/lib/dataLayer.tsx
+++ b/packages/explorer/src/lib/dataLayer.tsx
@@ -92,6 +92,24 @@ export interface ExplorerDataLayer {
     scope: DocScope,
     browse?: BrowseScope,
   ): Promise<ChunkDetail>;
+  // documentCreateChunk creates a new chunk under a parent (RFC BO authoring).
+  documentCreateChunk(
+    documentId: string,
+    parentId: string,
+    patch: ChunkPatch,
+    scope: DocScope,
+    browse?: BrowseScope,
+  ): Promise<ChunkDetail>;
+  // documentSetAsset attaches an image's base64 bytes to a chunk (→ type=image,
+  // served by GET /v1/_document/asset/{id}). RFC BO.
+  documentSetAsset(
+    chunkId: string,
+    mediaType: string,
+    dataBase64: string,
+    filename: string | undefined,
+    scope: DocScope,
+    browse?: BrowseScope,
+  ): Promise<ChunkDetail>;
   // documentGetEdges returns every cross-reference edge touching a document
   // (RFC BN P4) — the References list + relationship graph source.
   documentGetEdges(
@@ -180,6 +198,31 @@ export function dataLayerFromClient(client: LoomcycleClient, assetFetch?: AssetF
       ) as Promise<{ chunks: ChunkRow[] }>,
     documentGetChunk: (id, scope, browse) =>
       client.document({ op: "get_chunk", id, scope }, browse) as Promise<ChunkDetail>,
+    documentCreateChunk: (documentId, parentId, patch, scope, browse) =>
+      client.document(
+        {
+          op: "create_chunk",
+          document_id: documentId,
+          parent_id: parentId,
+          scope,
+          ...patch,
+        } as DocumentToolInput,
+        browse,
+      ) as Promise<ChunkDetail>,
+    documentSetAsset: (chunkId, mediaType, dataBase64, filename, scope, browse) =>
+      client.document(
+        // set_asset is an RFC BO wire op the pinned SDK type doesn't enumerate;
+        // the /v1/_document passthrough accepts it verbatim.
+        {
+          op: "set_asset",
+          id: chunkId,
+          media_type: mediaType,
+          data: dataBase64,
+          ...(filename ? { filename } : {}),
+          scope,
+        } as unknown as DocumentToolInput,
+        browse,
+      ) as Promise<ChunkDetail>,
     documentGetEdges: (documentId, scope, browse) =>
       client.document(
         // get_edges is an RFC BN P4 wire op the pinned SDK type doesn't

--- a/packages/explorer/src/lib/imageUpload.ts
+++ b/packages/explorer/src/lib/imageUpload.ts
@@ -1,0 +1,51 @@
+// RFC BO image-upload helpers for the explorer authoring UI.
+
+// IMAGE_MEDIA_TYPES is the accepted set — mirrors the backend whitelist
+// (validImageMediaTypes / ValidImageMediaType in document.go). SVG is excluded
+// (script-in-SVG XSS surface on the serving endpoint).
+export const IMAGE_MEDIA_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp"];
+
+// isSupportedImage reports whether a File/Blob's type is an accepted image.
+export function isSupportedImage(type: string): boolean {
+  return IMAGE_MEDIA_TYPES.includes(type);
+}
+
+// readImageAsBase64 reads a File/Blob into standard base64 (NO data: prefix — the
+// set_asset op wants the raw base64, matching the backend's decode). Rejects an
+// unsupported media type up front so the server never sees it.
+export function readImageAsBase64(file: File | Blob): Promise<{ mediaType: string; data: string }> {
+  return new Promise((resolve, reject) => {
+    if (!isSupportedImage(file.type)) {
+      reject(new Error(`unsupported image type "${file.type || "unknown"}" (png, jpeg, gif, webp only)`));
+      return;
+    }
+    const reader = new FileReader();
+    reader.onerror = () => reject(reader.error ?? new Error("failed to read file"));
+    reader.onload = () => {
+      // FileReader.readAsDataURL yields "data:<type>;base64,<payload>"; strip the
+      // prefix to hand set_asset the raw base64.
+      const result = String(reader.result ?? "");
+      const comma = result.indexOf(",");
+      if (comma < 0) {
+        reject(new Error("could not decode image data"));
+        return;
+      }
+      resolve({ mediaType: file.type, data: result.slice(comma + 1) });
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
+// imageFileFromPaste extracts the first supported image from a paste event's
+// clipboard items, or null if none (so a normal text paste is ignored).
+export function imageFileFromPaste(items: DataTransferItemList | null | undefined): File | null {
+  if (!items) return null;
+  for (let i = 0; i < items.length; i++) {
+    const it = items[i];
+    if (it.kind === "file" && isSupportedImage(it.type)) {
+      const f = it.getAsFile();
+      if (f) return f;
+    }
+  }
+  return null;
+}

--- a/packages/explorer/src/styles.css
+++ b/packages/explorer/src/styles.css
@@ -1051,3 +1051,11 @@
 .loomcycle-explorer .doc-mermaid-source {
   margin-top: 10px;
 }
+.loomcycle-explorer .chunk-mermaid-preview {
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 10px;
+  background: var(--bg-soft);
+  margin-bottom: 16px;
+  overflow-x: auto;
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6726,3 +6726,11 @@ button.primary:disabled {
 .doc-mermaid-source {
   margin-top: 10px;
 }
+.chunk-mermaid-preview {
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 10px;
+  background: var(--bg-soft);
+  margin-bottom: 16px;
+  overflow-x: auto;
+}


### PR DESCRIPTION
## Why
RFC BO P3 — in-browser authoring. P1 (#788) stored image/mermaid chunks and P2 (#789) rendered them; this lets a human **create and edit** them directly in the explorer (previously chunk creation was agent/assistant-only).

## What

### Authoring entry points (`DocumentViewerBody` toolbar)
- **"+ image"** — file picker → read to base64 → `create_chunk(type=image)` under the selected chunk (or root) → `set_asset` attaches the bytes → new chunk selected.
- **"+ diagram"** — `create_chunk(type=mermaid)` with a starter graph → selected + opened in the editor.
- **Paste a screenshot** anywhere in the viewer → a new image chunk (a `window` paste listener, ignored while a modal or text field is focused so editor pastes aren't hijacked).

### `ChunkEditorModal`
- **`type=mermaid`** → body field labeled "Mermaid source" with a **live `MermaidDiagram` preview** (debounced 400 ms) beneath it.
- **`type=image`** → a **"Replace image"** file input (`set_asset` in place; bumps the revision, so it hands back the updated chunk and closes) + body relabeled "Caption".

### Data layer + helpers
- New **`documentCreateChunk`** + **`documentSetAsset`** ops (both ride the JSON `client.document` passthrough).
- New **`lib/imageUpload.ts`**: `FileReader`→base64, the **png/jpeg/gif/webp** whitelist mirroring the backend, clipboard-image extraction.
- Preview/upload CSS in **both** stylesheets.

## Tested
- `packages/explorer` typecheck + `build:lib` + tests (8/8) green.
- `cd web && npm run build` clean (single `mermaid.core` chunk).
- **Frontend only** — no backend/adapter change. P3 of the 4-phase RFC BO line (P4 = export/import data-URL round-trip + TS asset helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)