### PR TITLE
feat(document): image/mermaid export-import round-trip + TS asset helper (RFC BO P4)

### DIFF
--- a/adapters/ts/src/client.ts
+++ b/adapters/ts/src/client.ts
@@ -1440,6 +1440,44 @@ export class LoomcycleClient {
     });
   }
 
+  /** Build the URL of an image chunk's asset (RFC BO) — `GET
+   *  /v1/_document/asset/{chunkId}`. Attach the bytes to a chunk with the
+   *  `set_asset` op via {@link LoomcycleClient.document}, then read them here.
+   *  `scope` is "agent" | "user" (default "user"); `scopeId`/`tenant` are the
+   *  RFC AS browse overrides. NOTE: the URL needs the bearer to fetch — use
+   *  {@link LoomcycleClient.fetchDocumentAsset} for an authenticated GET (a bare
+   *  <img src> can't carry the Authorization header). */
+  documentAssetUrl(
+    chunkId: string,
+    opts?: { scope?: string; scopeId?: string; tenant?: string },
+  ): string {
+    const q = new URLSearchParams({ scope: opts?.scope ?? "user" });
+    if (opts?.scopeId) q.set("scope_id", opts.scopeId);
+    if (opts?.tenant) q.set("tenant", opts.tenant);
+    return `${this.ctx.baseUrl}/v1/_document/asset/${encodeURIComponent(chunkId)}?${q.toString()}`;
+  }
+
+  /** Fetch an image chunk's asset bytes (RFC BO) with authentication — returns
+   *  the raw {@link Response} so a caller can `.blob()` / `.arrayBuffer()` it.
+   *  Adds the bearer header (a bare <img src> can't). Throws on a non-2xx
+   *  (a cross-scope / missing asset is an opaque 404). */
+  async fetchDocumentAsset(
+    chunkId: string,
+    opts?: { scope?: string; scopeId?: string; tenant?: string; signal?: AbortSignal },
+  ): Promise<Response> {
+    const headers: Record<string, string> = {};
+    if (this.ctx.authToken) headers.Authorization = `Bearer ${this.ctx.authToken}`;
+    const resp = await this.ctx.fetchImpl(this.documentAssetUrl(chunkId, opts), {
+      method: "GET",
+      headers,
+      signal: opts?.signal,
+    });
+    if (!resp.ok) {
+      throw new Error(`fetchDocumentAsset: ${resp.status} ${resp.statusText}`);
+    }
+    return resp;
+  }
+
   /** Invoke the RFC BE History tool over HTTP (`POST /v1/_history`). Browse,
    *  search, and annotate PAST CHATS — a chat is a session (it may span
    *  several runs). Op-discriminated (`list`/`get`/`search`/`rename`/

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -1101,6 +1101,16 @@ func (d *Document) assetMeta(ctx context.Context, key sqlmem.ScopeKey, chunkID s
 	return asStr(res.Rows[0][0]), asInt(res.Rows[0][1]), true
 }
 
+// readAssetRow reads an asset's media_type + raw bytes using the CURRENT resolved
+// key (no scope re-resolution — for export_md, which already holds the key).
+func (d *Document) readAssetRow(ctx context.Context, key sqlmem.ScopeKey, chunkID string) (mediaType string, data []byte, ok bool) {
+	res, err := d.query(ctx, key, `SELECT media_type, bytes FROM chunk_assets WHERE chunk_id = ? LIMIT 1`, chunkID)
+	if err != nil || len(res.Rows) == 0 || len(res.Rows[0]) < 2 {
+		return "", nil, false
+	}
+	return asStr(res.Rows[0][0]), asBytes(res.Rows[0][1]), true
+}
+
 // ReadAsset reads an image chunk's raw bytes for the HTTP serving endpoint. scope
 // is "agent"|"user" (default user); the ScopeKey + tenant come from ctx exactly
 // as the tool's own ops resolve them, so a caller can only read an asset in its
@@ -1601,8 +1611,23 @@ func (d *Document) exportMD(ctx context.Context, key sqlmem.ScopeKey, mscope sto
 			mj, _ := json.Marshal(meta)
 			b.WriteString("<!-- loom: " + string(mj) + " -->\n")
 		}
-		if cb.Body != "" {
-			b.WriteString("\n" + cb.Body + "\n")
+		// RFC BO — render media chunks self-contained + human-readable (and
+		// re-importable): a mermaid chunk's source as a ```mermaid fence, an image
+		// chunk's bytes as a data-URL. import_md re-detects both (see
+		// classifyMediaBody). A plain chunk emits its body verbatim.
+		switch {
+		case row.Type == "mermaid" && cb.Body != "":
+			b.WriteString("\n```mermaid\n" + cb.Body + "\n```\n")
+		case row.Type == "image":
+			if mt, raw, ok := d.readAssetRow(ctx, key, row.ID); ok {
+				b.WriteString("\n![" + imgAltForExport(cb.Body) + "](data:" + mt + ";base64," + base64.StdEncoding.EncodeToString(raw) + ")\n")
+			} else if cb.Body != "" {
+				b.WriteString("\n" + cb.Body + "\n")
+			}
+		default:
+			if cb.Body != "" {
+				b.WriteString("\n" + cb.Body + "\n")
+			}
 		}
 		b.WriteString("\n")
 		for _, c := range byParent[row.ID] {
@@ -1635,6 +1660,12 @@ func (d *Document) exportMD(ctx context.Context, key sqlmem.ScopeKey, mscope sto
 
 // --- ops: Markdown import ---
 
+// imgAltForExport makes a chunk caption safe as Markdown image alt text: no
+// newlines (one line) and no ']' (which would close the alt early). RFC BO.
+var imgAltReplacer = strings.NewReplacer("\r\n", " ", "\n", " ", "\r", " ", "]", "")
+
+func imgAltForExport(caption string) string { return imgAltReplacer.Replace(caption) }
+
 // mdChunk is one parsed chunk from an export_md-shaped document.
 type mdChunk struct {
 	level  int
@@ -1644,6 +1675,12 @@ type mdChunk struct {
 	status string
 	fields json.RawMessage
 	body   string
+	// RFC BO — set when the body was a self-contained media form: an image
+	// chunk's decoded bytes to re-attach via set_asset (assetData base64 +
+	// assetMediaType), unwrapped from a data-URL. A mermaid chunk carries its
+	// source in body (fence stripped) with typ="mermaid".
+	assetMediaType string
+	assetData      string
 }
 
 type mdEdge struct{ from, to, kind string }
@@ -1651,7 +1688,30 @@ type mdEdge struct{ from, to, kind string }
 var (
 	mdHeadingRe = regexp.MustCompile(`^(#{1,6})\s+(.*)$`)
 	mdEdgeRe    = regexp.MustCompile(`^\s*(\S+)\s*->\s*(\S+)\s*\[(.*)\]\s*$`)
+	// RFC BO — detect a WHOLE-body media form (anchored, so a text chunk that
+	// merely contains a fence/image among prose is NOT reclassified). A mermaid
+	// fence: ```mermaid\n<source>\n```. A data-URL image: ![alt](data:<mt>;base64,<b64>).
+	mdMermaidFenceRe = regexp.MustCompile("(?s)^```mermaid\\s*\\n(.*?)\\n?```$")
+	mdDataImageRe    = regexp.MustCompile(`^!\[([^\]]*)\]\(data:([a-zA-Z0-9.+/-]+);base64,([A-Za-z0-9+/=\s]+)\)$`)
 )
+
+// classifyMediaBody detects a chunk body that is ENTIRELY a media form (RFC BO)
+// and returns the reconstructed chunk type + unwrapped content. typ="" means the
+// body is ordinary Markdown (left untouched). For an image, mediaType+assetData
+// (base64) are the bytes to re-attach via set_asset and newBody is the alt/caption;
+// for mermaid, newBody is the raw source (fence stripped).
+func classifyMediaBody(body string) (typ, mediaType, assetData, newBody string) {
+	trimmed := strings.TrimSpace(body)
+	if m := mdMermaidFenceRe.FindStringSubmatch(trimmed); m != nil {
+		return "mermaid", "", "", m[1]
+	}
+	if m := mdDataImageRe.FindStringSubmatch(trimmed); m != nil {
+		// Strip any whitespace the base64 payload may carry across lines.
+		data := strings.Join(strings.Fields(m[3]), "")
+		return "image", m[2], data, m[1]
+	}
+	return "", "", "", body
+}
 
 // parseLoomMarkdown parses an export_md output: heading lines define the chunk
 // hierarchy (level = heading depth), an optional `<!-- loom: {…} -->` line
@@ -1667,6 +1727,15 @@ func parseLoomMarkdown(md string) ([]mdChunk, []mdEdge) {
 	flush := func() {
 		if cur != nil {
 			cur.body = strings.Trim(strings.Join(bodyLines, "\n"), "\n")
+			// RFC BO — reconstruct a media chunk from a whole-body media form. The
+			// meta comment's type (if any) and the rendered form agree on a loom
+			// round-trip; a clean export (no meta) is inferred purely from the form.
+			if typ, mt, ad, nb := classifyMediaBody(cur.body); typ != "" {
+				if cur.typ == "" {
+					cur.typ = typ
+				}
+				cur.body, cur.assetMediaType, cur.assetData = nb, mt, ad
+			}
 			chunks = append(chunks, *cur)
 		}
 		cur = nil
@@ -1719,6 +1788,16 @@ func resultField(r tools.Result, field string) string {
 	return asStr(m[field])
 }
 
+// importAsset re-attaches an image chunk's bytes during import_md (RFC BO) by
+// reusing setAsset — which validates the media_type + size and marks the chunk
+// type=image. Best-effort: a bad/oversized data-URL is skipped (the chunk stays,
+// just without its image) rather than aborting the whole import.
+func (d *Document) importAsset(ctx context.Context, key sqlmem.ScopeKey, mscope store.MemoryScope, chunkID string, c mdChunk) {
+	_, _ = d.setAsset(ctx, key, mscope, docInput{
+		ID: chunkID, MediaType: c.assetMediaType, Data: c.assetData,
+	})
+}
+
 // importMD builds a document from export_md-shaped Markdown (RFC AK §4.5 / RFC
 // AM Phase 3). With no document_id it creates a NEW document (the first heading
 // becomes the root); with a document_id (+ optional parent_id) it imports the
@@ -1762,6 +1841,9 @@ func (d *Document) importMD(ctx context.Context, key sqlmem.ScopeKey, mscope sto
 				return errResult("import_md: " + err.Error()), nil
 			}
 		}
+		if first.assetData != "" {
+			d.importAsset(ctx, key, mscope, rootID, first)
+		}
 		if first.oldID != "" {
 			oldToNew[first.oldID] = rootID
 		}
@@ -1802,6 +1884,9 @@ func (d *Document) importMD(ctx context.Context, key sqlmem.ScopeKey, mscope sto
 			return cc, nil
 		}
 		newID := resultField(cc, "id")
+		if c.assetData != "" {
+			d.importAsset(ctx, key, mscope, newID, c)
+		}
 		if c.oldID != "" {
 			oldToNew[c.oldID] = newID
 		}

--- a/internal/tools/builtin/document_test.go
+++ b/internal/tools/builtin/document_test.go
@@ -546,6 +546,82 @@ func TestDocument_ImportMD_RoundTrip(t *testing.T) {
 	}
 }
 
+// TestDocument_ExportImport_MediaChunks covers RFC BO P4: export renders a
+// mermaid chunk as a ```mermaid fence and an image chunk as a self-contained
+// data-URL, and import reconstructs both (mermaid source unwrapped; image bytes
+// re-attached to a type=image chunk) — including on a CLEAN (no-metadata) export
+// where the type must be inferred purely from the rendered form.
+func TestDocument_ExportImport_MediaChunks(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	out, _ := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Media"}`)
+	docID := out["document_id"].(string)
+	root := out["root_chunk_id"].(string)
+
+	// A mermaid chunk (body = source).
+	docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+docID+`","parent_id":"`+root+`","title":"Flow","type":"mermaid","body":"graph TD\n  A --> B"}`)
+	// An image chunk (create + set_asset).
+	out, _ = docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+docID+`","parent_id":"`+root+`","title":"Shot","body":"a caption"}`)
+	img := out["id"].(string)
+	rawImg := []byte{0x89, 0x50, 0x4e, 0x47, 0xff, 0xfe, 0x10, 0x20}
+	b64 := base64.StdEncoding.EncodeToString(rawImg)
+	if _, r := docExec(t, d, ctx, `{"op":"set_asset","scope":"user","id":"`+img+`","media_type":"image/png","data":"`+b64+`"}`); r.IsError {
+		t.Fatalf("set_asset: %s", r.Text)
+	}
+
+	// Export (clean — no loom metadata; type must be inferred from the form).
+	out, res := docExec(t, d, ctx, `{"op":"export_md","scope":"user","document_id":"`+docID+`","include_metadata":false}`)
+	if res.IsError {
+		t.Fatalf("export_md: %s", res.Text)
+	}
+	md := out["markdown"].(string)
+	if !strings.Contains(md, "```mermaid\ngraph TD\n  A --> B\n```") {
+		t.Errorf("mermaid chunk not exported as a fence:\n%s", md)
+	}
+	if !strings.Contains(md, "![a caption](data:image/png;base64,"+b64+")") {
+		t.Errorf("image chunk not exported as a data-URL:\n%s", md)
+	}
+
+	// Import the clean export into a NEW document → types + bytes reconstructed.
+	reqB, _ := json.Marshal(map[string]any{"op": "import_md", "scope": "user", "markdown": md})
+	out, res = docExec(t, d, ctx, string(reqB))
+	if res.IsError {
+		t.Fatalf("import_md: %s", res.Text)
+	}
+	newDoc := out["document_id"].(string)
+
+	// Find the reconstructed chunks by title + assert their type + the image bytes.
+	q, _ := docExec(t, d, ctx, `{"op":"query_chunks","scope":"user","document_id":"`+newDoc+`"}`)
+	rows, _ := q["chunks"].([]any)
+	var mermaidOK, imageID string
+	for _, rr := range rows {
+		m := rr.(map[string]any)
+		if m["title"] == "Flow" && m["type"] == "mermaid" {
+			mermaidOK = m["id"].(string)
+		}
+		if m["title"] == "Shot" && m["type"] == "image" {
+			imageID = m["id"].(string)
+		}
+	}
+	if mermaidOK == "" {
+		t.Errorf("mermaid chunk not reconstructed as type=mermaid: %v", rows)
+	} else {
+		gc, _ := docExec(t, d, ctx, `{"op":"get_chunk","scope":"user","id":"`+mermaidOK+`"}`)
+		if gc["body"] != "graph TD\n  A --> B" {
+			t.Errorf("mermaid source not unwrapped: %q", gc["body"])
+		}
+	}
+	if imageID == "" {
+		t.Fatalf("image chunk not reconstructed as type=image: %v", rows)
+	}
+	mt, data, ok, err := d.ReadAsset(ctx, "user", imageID)
+	if err != nil || !ok {
+		t.Fatalf("reimported ReadAsset: ok=%v err=%v", ok, err)
+	}
+	if mt != "image/png" || !bytes.Equal(data, rawImg) {
+		t.Errorf("reimported image bytes mismatch: mt=%q got %v want %v", mt, data, rawImg)
+	}
+}
+
 // Hardening: link_chunks must refuse an edge to a non-existent chunk (no
 // born-dangling edges).
 func TestDocument_LinkChunksValidatesEndpoints(t *testing.T) {


### PR DESCRIPTION
## Why
RFC BO P4 — the final phase. P1–P3 gave the store typed image/mermaid chunks, a viewer, and authoring. This makes media chunks **portable through `export_md`/`import_md`** and gives the TS adapter a first-class asset accessor. **Completes RFC BO.**

## What

### `export_md` — self-contained + human-readable
- **mermaid chunk** → a ```mermaid fenced block (its source).
- **image chunk** → a data-URL `![caption](data:<media_type>;base64,<bytes>)` read from `chunk_assets` (the one place bytes are base64'd — export is for portability).
- A plain chunk is unchanged; the `<!-- loom -->` metadata comment still records `type` when `include_metadata` is on.

### `import_md` — reconstructs both
`classifyMediaBody` detects a **whole-body** media form: a ```mermaid fence → `type=mermaid` (source unwrapped); a data-URL image → `type=image` with the bytes re-attached via `set_asset`. **Anchored** matching, so a text chunk that merely contains a fence/image among prose is NOT reclassified. Works from a **clean export too** (no loom metadata — type inferred purely from the rendered form). A bad/oversized data-URL is skipped, not fatal.

### TS adapter (`@loomcycle/client`)
- **`documentAssetUrl(chunkId, {scope,scopeId,tenant})`** — builds the `GET /v1/_document/asset/{id}` URL.
- **`fetchDocumentAsset(...)`** — the authenticated GET (adds the bearer a bare `<img src>` can't) → `Response` for `.blob()`/`.arrayBuffer()`. Additive.

## Tested
- `TestDocument_ExportImport_MediaChunks` — clean export → fence + data-URL; import → `type=mermaid` source unwrapped + `type=image` bytes **byte-identical** via `ReadAsset`. Existing export/import round-trip unaffected.
- `go build ./...` + `gofmt` clean; TS adapter builds clean.

## Note
The `@loomcycle/client` version bump (to publish the new methods on npm) is a **release-time** step — the RFC BO release-notes PR will bump it to match the tag, as v1.29.0 did for `@loomcycle/explorer`.

## RFC BO — complete
P1 #788 · P2 #789 · P3 #790 · **P4 this PR**. After merge, the line is ready to tag a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)