### PR TITLE
feat(explorer): per-chunk +text / reorder / delete controls (RFC BP P2)

### DIFF
--- a/packages/explorer/src/components/DocumentViewerBody.tsx
+++ b/packages/explorer/src/components/DocumentViewerBody.tsx
@@ -98,6 +98,7 @@ export default function DocumentViewerBody({
   const [imageErr, setImageErr] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null); // hidden upload input (RFC BO)
   const [editing, setEditing] = useState<ChunkDetail | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState(false); // RFC BP delete confirm
   const [err, setErr] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [reload, setReload] = useState(0);
@@ -367,6 +368,73 @@ export default function DocumentViewerBody({
     }
   }, [data, documentId, scope, browse, selectedId, rootChunkId, refresh]);
 
+  // RFC BP — "+ text": a plain text chunk immediately AFTER the selected chunk
+  // (via after_id) when a non-root chunk is selected; otherwise appended under
+  // the root. Opens the editor on the new chunk.
+  const addText = useCallback(async () => {
+    if (!data.documentCreateChunk) return;
+    const insertAfter = selectedId && !selectedIsRoot ? selectedId : undefined;
+    const parent = selectedId || rootChunkId;
+    if (!parent) return;
+    setErr(null);
+    try {
+      const created = await data.documentCreateChunk(
+        documentId,
+        insertAfter ? "" : parent, // after_id resolves the parent server-side
+        { title: "Text", body: "" },
+        scope,
+        browse,
+        insertAfter,
+      );
+      refresh();
+      setSelectedId(created.id);
+      setEditing(created);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    }
+  }, [data, documentId, scope, browse, selectedId, selectedIsRoot, rootChunkId, refresh]);
+
+  // RFC BP — the selected chunk's siblings (same parent) in position order, to
+  // gate the up/down buttons at the level boundaries.
+  const siblingBounds = useMemo(() => {
+    if (!selectedDetail || selectedIsRoot) return { canUp: false, canDown: false };
+    const parent = selectedDetail.parent_id ?? "";
+    const sibs = chunks
+      .filter((c) => (c.parent_id ?? "") === parent)
+      .sort((a, b) => a.position - b.position || a.id.localeCompare(b.id));
+    const i = sibs.findIndex((c) => c.id === selectedDetail.id);
+    return { canUp: i > 0, canDown: i >= 0 && i < sibs.length - 1 };
+  }, [chunks, selectedDetail, selectedIsRoot]);
+
+  const reorderSelected = useCallback(
+    async (direction: "up" | "down") => {
+      if (!data.documentReorderChunk || !selectedId) return;
+      setErr(null);
+      try {
+        await data.documentReorderChunk(selectedId, direction, scope, browse);
+        refresh();
+      } catch (e) {
+        setErr(e instanceof Error ? e.message : String(e));
+      }
+    },
+    [data, selectedId, scope, browse, refresh],
+  );
+
+  const deleteSelected = useCallback(async () => {
+    if (!data.documentDeleteChunk || !selectedDetail) return;
+    setErr(null);
+    const parentId = selectedDetail.parent_id;
+    try {
+      await data.documentDeleteChunk(selectedDetail.id, scope, browse);
+      setConfirmDelete(false);
+      setSelectedId(parentId || rootChunkId);
+      refresh();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+      setConfirmDelete(false);
+    }
+  }, [data, selectedDetail, scope, browse, rootChunkId, refresh]);
+
   // Paste a screenshot anywhere in the viewer → a new image chunk. Ignored while
   // a modal or a text field is focused (so an editor paste isn't hijacked).
   useEffect(() => {
@@ -406,6 +474,13 @@ export default function DocumentViewerBody({
         <div className="doc-toolbar-actions">
           {canCreate && (
             <>
+              <button
+                type="button"
+                onClick={() => void addText()}
+                title="Add a text chunk after the selected chunk"
+              >
+                + text
+              </button>
               <button
                 type="button"
                 onClick={() => fileInputRef.current?.click()}
@@ -508,6 +583,37 @@ export default function DocumentViewerBody({
                   <button type="button" onClick={() => setEditing(selectedDetail)}>
                     edit
                   </button>
+                  {/* RFC BP — reorder within the level + delete (not for the root). */}
+                  {!selectedIsRoot && (
+                    <>
+                      <button
+                        type="button"
+                        onClick={() => void reorderSelected("up")}
+                        disabled={!siblingBounds.canUp}
+                        title="Move this chunk up within its level"
+                      >
+                        ↑
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void reorderSelected("down")}
+                        disabled={!siblingBounds.canDown}
+                        title="Move this chunk down within its level"
+                      >
+                        ↓
+                      </button>
+                    </>
+                  )}
+                  {!selectedIsRoot && (
+                    <button
+                      type="button"
+                      className="danger"
+                      onClick={() => setConfirmDelete(true)}
+                      title="Delete this chunk and its sub-chunks"
+                    >
+                      delete
+                    </button>
+                  )}
                 </div>
               </div>
               <div className="doc-content-body">
@@ -596,6 +702,25 @@ export default function DocumentViewerBody({
           onClose={() => setColorsOpen(false)}
           onSaved={refresh}
         />
+      )}
+      {confirmDelete && selectedDetail && (
+        <div className="modal-overlay" onClick={() => setConfirmDelete(false)}>
+          <div className="modal chunk-delete-confirm" onClick={(e) => e.stopPropagation()}>
+            <h3>Delete chunk</h3>
+            <p className="modal-context">
+              Delete “{selectedDetail.title || "(untitled)"}” and all of its sub-chunks? This
+              cannot be undone.
+            </p>
+            <div className="modal-buttons">
+              <button type="button" onClick={() => setConfirmDelete(false)}>
+                cancel
+              </button>
+              <button type="button" className="danger" onClick={() => void deleteSelected()}>
+                delete
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/packages/explorer/src/lib/dataLayer.tsx
+++ b/packages/explorer/src/lib/dataLayer.tsx
@@ -93,13 +93,30 @@ export interface ExplorerDataLayer {
     browse?: BrowseScope,
   ): Promise<ChunkDetail>;
   // documentCreateChunk creates a new chunk under a parent (RFC BO authoring).
+  // afterId (RFC BP) inserts the new chunk immediately after that sibling
+  // (server insert-and-shift); when set it overrides parentId.
   documentCreateChunk(
     documentId: string,
     parentId: string,
     patch: ChunkPatch,
     scope: DocScope,
     browse?: BrowseScope,
+    afterId?: string,
   ): Promise<ChunkDetail>;
+  // documentReorderChunk moves a chunk up/down within its level (RFC BP).
+  documentReorderChunk(
+    id: string,
+    direction: "up" | "down",
+    scope: DocScope,
+    browse?: BrowseScope,
+  ): Promise<unknown>;
+  // documentDeleteChunk deletes a chunk + its subtree (RFC BP; existing
+  // delete_chunk op — cascades, refuses the document root).
+  documentDeleteChunk(
+    id: string,
+    scope: DocScope,
+    browse?: BrowseScope,
+  ): Promise<unknown>;
   // documentSetAsset attaches an image's base64 bytes to a chunk (→ type=image,
   // served by GET /v1/_document/asset/{id}). RFC BO.
   documentSetAsset(
@@ -198,17 +215,27 @@ export function dataLayerFromClient(client: LoomcycleClient, assetFetch?: AssetF
       ) as Promise<{ chunks: ChunkRow[] }>,
     documentGetChunk: (id, scope, browse) =>
       client.document({ op: "get_chunk", id, scope }, browse) as Promise<ChunkDetail>,
-    documentCreateChunk: (documentId, parentId, patch, scope, browse) =>
+    documentCreateChunk: (documentId, parentId, patch, scope, browse, afterId) =>
       client.document(
         {
           op: "create_chunk",
           document_id: documentId,
           parent_id: parentId,
           scope,
+          ...(afterId ? { after_id: afterId } : {}),
           ...patch,
-        } as DocumentToolInput,
+        } as unknown as DocumentToolInput,
         browse,
       ) as Promise<ChunkDetail>,
+    documentReorderChunk: (id, direction, scope, browse) =>
+      client.document(
+        // reorder_chunk is an RFC BP wire op the pinned SDK type doesn't
+        // enumerate; the /v1/_document passthrough accepts it verbatim.
+        { op: "reorder_chunk", id, direction, scope } as unknown as DocumentToolInput,
+        browse,
+      ),
+    documentDeleteChunk: (id, scope, browse) =>
+      client.document({ op: "delete_chunk", id, scope } as unknown as DocumentToolInput, browse),
     documentSetAsset: (chunkId, mediaType, dataBase64, filename, scope, browse) =>
       client.document(
         // set_asset is an RFC BO wire op the pinned SDK type doesn't enumerate;

--- a/packages/explorer/src/styles.css
+++ b/packages/explorer/src/styles.css
@@ -655,6 +655,15 @@
   border-radius: 4px;
   cursor: pointer;
 }
+/* RFC BP — up/down reorder + delete controls. */
+.loomcycle-explorer .doc-content-controls > button:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.loomcycle-explorer .doc-content-controls > button.danger {
+  color: var(--danger);
+  border-color: var(--danger);
+}
 /* The selected-chunk view (chunk body OR assembled markdown) scrolls
    independently of the fixed head — both modes can be long. */
 .loomcycle-explorer .doc-content-body {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5336,6 +5336,15 @@ button.primary:disabled {
   border-radius: 4px;
   cursor: pointer;
 }
+/* RFC BP — up/down reorder + delete controls. */
+.doc-content-controls > button:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.doc-content-controls > button.danger {
+  color: var(--danger);
+  border-color: var(--danger);
+}
 /* The selected-chunk view (chunk body OR assembled markdown) scrolls
    independently of the fixed head — both modes can be long. */
 .doc-content-body {


### PR DESCRIPTION
## Why
RFC BP P2 — the viewer half. [P1 (#793)](https://github.com/denn-gubsky/loomcycle/pull/793) added the backend ops (`create_chunk after_id`, `reorder_chunk`); this wires them + the existing `delete_chunk` into `DocumentViewerBody` as first-class per-chunk buttons.

## What
- **+ text** (in `doc-toolbar-actions`, beside + image / + diagram): creates a plain text chunk **immediately after the selected chunk** via `after_id` (when a non-root chunk is selected), else appends under the root; opens the editor on the new chunk.
- **↑ / ↓** (in `doc-content-controls`, beside "edit"): reorder the selected chunk within its level via `reorder_chunk`. Enablement is computed from the loaded flat `chunks` (same-parent siblings, position-sorted): **↑ disabled at first, ↓ at last; both hidden for the root**.
- **delete** (danger; **hidden for the root**): a small confirm modal (reusing the shared `.modal-*` classes — PathExplorer's `PromptModal` is module-private) → `delete_chunk`, then select the parent + refresh.

## Data layer
New **`documentReorderChunk`** + **`documentDeleteChunk`** (ride the generic `document()` passthrough — no adapter method needed); **`documentCreateChunk` gains an optional `afterId`**. The chunk/markdown toggle is **unchanged** (the "remove it" ask was withdrawn). CSS (disabled + danger control states) mirrored into **both** stylesheets.

## Tested
- `packages/explorer` typecheck + `build:lib` + tests (8/8) green.
- `cd web && npm run build` clean.
- **Frontend only.** Pairs with **#793** (backend) for end-to-end — the wire ops match by construction. Merge #793 first (or together) so the buttons work against a deployed runtime.

## RFC BP arc
P0 RFC ✅ · **P1 backend #793** · **P2 viewer this PR** — completes RFC BP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)