### PR TITLE
feat(retention): RFC BM P1 — retired def-version retention sweeper

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -76,6 +76,7 @@ import (
 	// to a production binary that never sets the flag.
 	_ "github.com/denn-gubsky/loomcycle/internal/providers/stubembedder"
 	"github.com/denn-gubsky/loomcycle/internal/resolve"
+	"github.com/denn-gubsky/loomcycle/internal/retention"
 	"github.com/denn-gubsky/loomcycle/internal/runner"
 	"github.com/denn-gubsky/loomcycle/internal/runstate"
 	"github.com/denn-gubsky/loomcycle/internal/scheduler"
@@ -2389,6 +2390,32 @@ func main() {
 		go usageSweeper.Run(bgCtx)
 	} else {
 		log.Printf("usage: sweeper disabled (LOOMCYCLE_USAGE_SWEEPER=0 or no Store)")
+	}
+
+	// RFC BM data-retention sweeper — same placement rationale as the usage
+	// sweeper above (runs AFTER the cluster block so it can pick up the
+	// advisoryLock). OPT-IN (default OFF): destructive (it deletes retired def
+	// versions), unlike the lossless usage rollup. When the mode is
+	// export+prune each version is written to the export dir before deletion.
+	if cfg.Env.RetentionEnabled && storeIface != nil {
+		rCfg := retention.Config{
+			Interval:      cfg.Env.RetentionInterval,
+			DefsMode:      cfg.Env.RetentionDefsMode,
+			DefsMaxAge:    cfg.Env.RetentionDefsMaxAge,
+			DefsKeepLastN: cfg.Env.RetentionDefsKeepLastN,
+			ExportDir:     cfg.Env.RetentionExportDir,
+		}
+		// Same typed-nil guard as the usage block: only assign the interface field
+		// from a non-nil pointer, or the sweeper's nil-check would see a non-nil
+		// interface wrapping a nil pointer.
+		if advisoryLock != nil {
+			rCfg.AdvisoryLock = advisoryLock
+			rCfg.AdvisoryLockKey = coord.LockKeyRetentionSweeper
+		}
+		retentionSweeper := retention.New(storeIface, rCfg)
+		go retentionSweeper.Run(bgCtx)
+	} else {
+		log.Printf("retention: sweeper disabled (LOOMCYCLE_RETENTION_ENABLED != 1 or no Store)")
 	}
 
 	// RFC AW: seed the per-scope token-budget tracker from the RFC AV ledger

--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -574,6 +574,12 @@ func requiredScopeFor(method, path string) string {
 	// ScopeAdmin also satisfies. Read-only GET.
 	case path == "/v1/_usage":
 		return auth.ScopeTenant
+	// RFC BM: the data-retention view. Tenant-readable so a tenant operator's UI
+	// can see whether retention is enabled + how it's tuned; the HANDLER strips
+	// the cross-tenant purgeable counts + the export dir for a non-admin caller
+	// (admin gets the full view). ScopeAdmin also satisfies. Read-only GET.
+	case path == "/v1/_retention":
+		return auth.ScopeTenant
 	// RFC AW: the token-budget management surface (GET list + PUT upsert + DELETE).
 	// Tenant-readable/writable so a tenant operator manages its own tenant + user
 	// budgets; the handler enforces the operator-global + cross-tenant admin

--- a/internal/api/http/retention_report.go
+++ b/internal/api/http/retention_report.go
@@ -1,0 +1,93 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/retention"
+)
+
+// retentionReportResponse is the wire shape of GET /v1/_retention (RFC BM). It
+// reports the data-retention sweeper's effective configuration plus — for an
+// admin — a per-def-type count of currently-purgeable retired versions.
+//
+// The purgeable counts + the export_dir are ADMIN-ONLY: the counts span every
+// tenant (the retention purge is an operator-global function, not tenant-scoped),
+// so exposing them to a substrate:tenant operator would be a cross-tenant oracle;
+// export_dir is a host filesystem path (infra detail). A tenant operator still
+// sees the config knobs (so its UI can show that retention exists + how it's
+// tuned), mirroring /v1/_routing's admin-vs-tenant split.
+type retentionReportResponse struct {
+	Admin         bool   `json:"admin"`
+	Enabled       bool   `json:"enabled"`
+	IntervalMS    int64  `json:"interval_ms"`
+	DefsMode      string `json:"defs_mode"`
+	DefsMaxAgeMS  int64  `json:"defs_max_age_ms"`
+	DefsKeepLastN int    `json:"defs_keep_last_n"`
+	ExportDir     string `json:"export_dir,omitempty"`
+	// Purgeable is the per-def-type count of versions the CURRENT age + keep-last-N
+	// settings would purge right now (regardless of mode — a preview). Admin-only.
+	Purgeable map[string]int `json:"purgeable,omitempty"`
+}
+
+// handleRetentionReport serves GET /v1/_retention — the read-only view of the
+// RFC BM data-retention sweeper. Tenant-readable config (see requiredScopeFor);
+// the purgeable counts + export_dir are stripped for a non-admin caller. 503 when
+// the server has no store (an empty/disabled report).
+func (s *Server) handleRetentionReport(w http.ResponseWriter, r *http.Request) {
+	admin := true
+	if p, ok := auth.PrincipalFromContext(r.Context()); ok {
+		admin = auth.HasScope(p.Scopes, auth.ScopeAdmin)
+	}
+
+	// Effective config, applying the same fallbacks retention.New does, so the
+	// report shows what the sweeper actually runs with.
+	interval := s.cfg.Env.RetentionInterval
+	if interval <= 0 {
+		interval = time.Hour
+	}
+	mode := s.cfg.Env.RetentionDefsMode
+	if mode == "" {
+		mode = "off"
+	}
+	resp := retentionReportResponse{
+		Admin:         admin,
+		Enabled:       s.cfg.Env.RetentionEnabled,
+		IntervalMS:    interval.Milliseconds(),
+		DefsMode:      mode,
+		DefsMaxAgeMS:  s.cfg.Env.RetentionDefsMaxAge.Milliseconds(),
+		DefsKeepLastN: s.cfg.Env.RetentionDefsKeepLastN,
+	}
+
+	if s.store == nil {
+		// Read-only, degraded: report config only (no store → nothing to purge).
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+		return
+	}
+
+	// Admin-only global detail: the export dir (infra path) + the cross-tenant
+	// purgeable counts.
+	if admin {
+		resp.ExportDir = s.cfg.Env.RetentionExportDir
+		sw := retention.New(s.store, retention.Config{
+			DefsMode:      mode,
+			DefsMaxAge:    s.cfg.Env.RetentionDefsMaxAge,
+			DefsKeepLastN: s.cfg.Env.RetentionDefsKeepLastN,
+			ExportDir:     s.cfg.Env.RetentionExportDir,
+		})
+		counts, err := sw.DryRunCounts(r.Context())
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, "internal", err.Error())
+			return
+		}
+		resp.Purgeable = counts
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2756,6 +2756,10 @@ func (s *Server) Mux() http.Handler {
 	// /ui/audit page. Bearer-authed admin surface.
 	mux.Handle("GET /v1/_events", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListEvents))))
 	mux.Handle("GET /v1/_usage", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleUsageReport))))
+	// RFC BM — the data-retention view. Tenant-readable config; the cross-tenant
+	// purgeable counts + export dir are admin-only (stripped in the handler).
+	// Scope-gated to substrate:tenant in requiredScopeFor.
+	mux.Handle("GET /v1/_retention", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleRetentionReport))))
 	// RFC AW — per-scope token budgets (list / upsert / delete). Tenant-scoped
 	// (the handlers confine a substrate:tenant caller to its own tenant + reject
 	// the operator-global / cross-tenant writes with 403).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2325,6 +2325,33 @@ type Env struct {
 	// UsageExportDir is where export+prune writes run JSON (per-day subdir,
 	// one file per run). Required for export+prune. Env: LOOMCYCLE_USAGE_EXPORT_DIR.
 	UsageExportDir string
+
+	// --- RFC BM data-retention sweeper (OPT-IN; default OFF). ---
+	// Purges retired-and-old substrate def versions (agent/skill/team/mcp_server/
+	// schedule/a2a/webhook/memory_backend). Unlike the lossless usage rollup this
+	// DELETES data, so it defaults off and its DefsMode defaults to "off".
+
+	// RetentionEnabled turns the sweeper goroutine on. Default false.
+	// Env: LOOMCYCLE_RETENTION_ENABLED=1.
+	RetentionEnabled bool
+	// RetentionInterval is the sweep tick rate. Default 1h.
+	// Env: LOOMCYCLE_RETENTION_INTERVAL_MS.
+	RetentionInterval time.Duration
+	// RetentionExportDir is where export+prune writes def JSON (per-day/per-def-type
+	// subdir, one file per version). Required for the export+prune mode.
+	// Env: LOOMCYCLE_RETENTION_EXPORT_DIR.
+	RetentionExportDir string
+	// RetentionDefsMode is "off" (default) | "prune" | "export+prune".
+	// Env: LOOMCYCLE_RETENTION_DEFS_MODE.
+	RetentionDefsMode string
+	// RetentionDefsMaxAge is the age cutoff: only versions created before
+	// now-RetentionDefsMaxAge are eligible. 0 = no minimum age.
+	// Env: LOOMCYCLE_RETENTION_DEFS_MAX_AGE_MS.
+	RetentionDefsMaxAge time.Duration
+	// RetentionDefsKeepLastN keeps the N most-recent purgeable versions per
+	// (tenant, name) as lineage history. Default 5. 0 = purge all.
+	// Env: LOOMCYCLE_RETENTION_DEFS_KEEP_LAST_N.
+	RetentionDefsKeepLastN int
 	// ReplicasSweepInterval is the dead-replica reaper's tick rate.
 	// Default 60s. Tunable mostly for tests / crash-recovery load
 	// experiments — leave at default in production.
@@ -3049,6 +3076,11 @@ func LoadLayers(layers ...Layer) (*Config, error) {
 		// cmd/loomcycle/main.go where the goroutines are started.
 		HeartbeatSweeperEnabled: true,
 		UsageSweeperEnabled:     true,
+		// RFC BM retention defaults — opt-in (RetentionEnabled zero-false); the
+		// mode defaults off and keep-last-N to 5. The env parse below overrides
+		// these only when the corresponding var is set.
+		RetentionDefsMode:      "off",
+		RetentionDefsKeepLastN: 5,
 	}
 
 	// RFC AH Phase 3 — the legacy filesystem jail is retired. The three env
@@ -3235,6 +3267,30 @@ func LoadLayers(layers ...Layer) (*Config, error) {
 	}
 	cfg.Env.UsageRunRetentionMode = os.Getenv("LOOMCYCLE_USAGE_RUN_RETENTION_MODE")
 	cfg.Env.UsageExportDir = os.Getenv("LOOMCYCLE_USAGE_EXPORT_DIR")
+	// RFC BM data-retention sweeper (opt-in; default OFF). The New() constructor
+	// applies the 1h interval fallback when RetentionInterval stays 0.
+	cfg.Env.RetentionEnabled = os.Getenv("LOOMCYCLE_RETENTION_ENABLED") == "1"
+	if v := os.Getenv("LOOMCYCLE_RETENTION_INTERVAL_MS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.Env.RetentionInterval = time.Duration(n) * time.Millisecond
+		}
+	}
+	cfg.Env.RetentionExportDir = os.Getenv("LOOMCYCLE_RETENTION_EXPORT_DIR")
+	if v := os.Getenv("LOOMCYCLE_RETENTION_DEFS_MODE"); v != "" {
+		cfg.Env.RetentionDefsMode = v
+	}
+	if v := os.Getenv("LOOMCYCLE_RETENTION_DEFS_MAX_AGE_MS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.Env.RetentionDefsMaxAge = time.Duration(n) * time.Millisecond
+		}
+	}
+	// keep-last-N accepts 0 (purge all); only a non-empty, non-negative value
+	// overrides the default-5 set above.
+	if v := os.Getenv("LOOMCYCLE_RETENTION_DEFS_KEEP_LAST_N"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			cfg.Env.RetentionDefsKeepLastN = n
+		}
+	}
 	if v := os.Getenv("LOOMCYCLE_REPLICAS_SWEEP_INTERVAL_MS"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			cfg.Env.ReplicasSweepInterval = time.Duration(n) * time.Millisecond

--- a/internal/coord/advisory_lock.go
+++ b/internal/coord/advisory_lock.go
@@ -129,6 +129,10 @@ var (
 	// rollup-and-prune, so only one replica per tick folds old
 	// token_usage rows into usage_archive and deletes them.
 	LockKeyUsageSweeper int64
+	// LockKeyRetentionSweeper gates the RFC BM data-retention sweep, so only
+	// one replica per tick exports + purges retired-and-old substrate def
+	// versions (agent/skill/team/mcp_server/schedule/a2a/webhook/memory_backend).
+	LockKeyRetentionSweeper int64
 )
 
 func init() {
@@ -142,6 +146,7 @@ func init() {
 	LockKeyResumePausedRuns = fnvKey("resume_paused_runs")
 	LockKeyEphemeralVolumeSweeper = fnvKey("ephemeral_volume_sweeper")
 	LockKeyUsageSweeper = fnvKey("usage_sweeper")
+	LockKeyRetentionSweeper = fnvKey("retention_sweeper")
 }
 
 // fnvKey hashes a sweeper-name string to a stable int64 lock key.

--- a/internal/retention/sweeper.go
+++ b/internal/retention/sweeper.go
@@ -1,0 +1,337 @@
+// Package retention runs the periodic RFC BM data-retention sweeper alongside
+// the HTTP server. Without it, retired substrate def versions
+// (agent/skill/team/mcp_server/schedule/a2a_server_card/a2a_agent/webhook/
+// memory_backend) accumulate forever — a self-evolving fleet forks and retires
+// versions continuously, so the *_defs tables grow unbounded even though a
+// retired-and-old version is only ever read for lineage history.
+//
+// The sweeper is store-agnostic: it lists purgeable versions per def-type via
+// store.ListPurgeableRetiredDefVersions and deletes them via
+// store.DeleteDefVersions. The store owns the SQL (the retired / non-active /
+// keep-last-N exclusions + the hardcoded table allowlist).
+//
+// Unlike the RFC AV usage rollup (a lossless compaction), this DELETES data, so
+// it is OPT-IN and defaults OFF: an "off" DefsMode is a no-op. When
+// DefsMode=export+prune each version is written to ExportDir as JSON BEFORE it
+// is deleted (export-then-delete: a failed export never deletes the row), so the
+// retired history survives outside the database.
+package retention
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// Config carries the sweeper's tuning knobs. Zero/missing values fall back to
+// the defaults documented per-field.
+type Config struct {
+	// Interval is how often the sweeper wakes up. Default 1h. The work is cheap
+	// and idempotent, so the exact cadence isn't load-bearing.
+	Interval time.Duration
+
+	// DefsMode is one of "off" (default / ""), "prune" (delete purgeable retired
+	// versions), or "export+prune" (write each to ExportDir as JSON, then
+	// delete). Unknown → treated as off. Destructive modes are opt-in.
+	DefsMode string
+
+	// DefsMaxAge is the age cutoff: only versions created before Now()-DefsMaxAge
+	// are eligible. Zero = no minimum age (every retired non-active version past
+	// keep-last-N qualifies).
+	DefsMaxAge time.Duration
+
+	// DefsKeepLastN keeps the N most-recent qualifying (retired, old, non-active)
+	// versions per (tenant, name) as lineage history; the rest are purged. 0
+	// keeps none (purge every qualifying version). The operator-facing default
+	// (5) is applied by the config layer — New only guards a negative value to 0,
+	// so an explicit 0 stays meaningful.
+	DefsKeepLastN int
+
+	// ExportDir is the directory export+prune writes def JSON into (one file per
+	// version, under a per-day/per-def-type subdir). Required for export+prune;
+	// if empty, the purge is DISABLED (never delete a version we were asked to
+	// export but can't).
+	ExportDir string
+
+	// DryRun, when true, lists + (in export+prune) exports but NEVER deletes —
+	// it only counts what WOULD be purged. Lets an operator preview impact.
+	DryRun bool
+
+	// Logger is the structured logger for sweep results. Defaults to log.Printf.
+	Logger func(format string, args ...any)
+
+	// AdvisoryLock is the singleton-sweeper gate. When set, each tick acquires
+	// the lock before sweeping — only one replica per cluster runs the purge per
+	// tick. Nil = single-replica mode. Interface-typed so this package stays free
+	// of an internal/coord import.
+	AdvisoryLock AdvisoryLocker
+
+	// AdvisoryLockKey is the lock-key int64 (typically
+	// coord.LockKeyRetentionSweeper). Only consulted when AdvisoryLock is non-nil.
+	AdvisoryLockKey int64
+
+	// Now is the clock sweepOnce reads to compute the age cutoff
+	// (cutoff = Now() - DefsMaxAge). Nil defaults to time.Now. Injectable so
+	// tests can pin the cutoff deterministically.
+	Now func() time.Time
+}
+
+// AdvisoryLocker is the minimum surface the sweeper needs from
+// internal/coord.AdvisoryLock. Defined here so internal/retention stays free of
+// the internal/coord import. *coord.AdvisoryLock satisfies it implicitly.
+type AdvisoryLocker interface {
+	TryRun(ctx context.Context, lockKey int64, fn func(ctx context.Context) error) (bool, error)
+}
+
+const (
+	defaultInterval = 1 * time.Hour
+	purgeBatch      = 500   // versions purged per def-type per tick
+	reportListCap   = 10000 // DryRunCounts saturates the per-type count at this cap
+)
+
+// Result is one sweep's per-def-type + total purge count (deleted, or — under
+// DryRun — would-be-deleted).
+type Result struct {
+	PerType map[string]int
+	Total   int
+}
+
+// Sweeper periodically exports + purges retired-and-old substrate def versions.
+// Construct via New, then call Run(ctx) on a goroutine that owns the lifecycle.
+type Sweeper struct {
+	store         store.Store
+	interval      time.Duration
+	defsMode      string
+	defsMaxAge    time.Duration
+	defsKeepLastN int
+	exportDir     string
+	dryRun        bool
+	logf          func(format string, args ...any)
+	lock          AdvisoryLocker
+	lockKey       int64
+	now           func() time.Time
+}
+
+// New constructs a Sweeper. A nil store means "no persistence" — Run is then a
+// no-op.
+func New(st store.Store, cfg Config) *Sweeper {
+	if cfg.Interval <= 0 {
+		cfg.Interval = defaultInterval
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = log.Printf
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	mode := cfg.DefsMode
+	if mode == "" {
+		mode = "off"
+	}
+	keep := cfg.DefsKeepLastN
+	if keep < 0 {
+		// Guard a negative value only. 0 is a valid explicit choice (purge all
+		// retired non-active versions); the default of 5 lives in the config layer.
+		keep = 0
+	}
+	return &Sweeper{
+		store:         st,
+		interval:      cfg.Interval,
+		defsMode:      mode,
+		defsMaxAge:    cfg.DefsMaxAge,
+		defsKeepLastN: keep,
+		exportDir:     cfg.ExportDir,
+		dryRun:        cfg.DryRun,
+		logf:          cfg.Logger,
+		lock:          cfg.AdvisoryLock,
+		lockKey:       cfg.AdvisoryLockKey,
+		now:           cfg.Now,
+	}
+}
+
+// defsPurgeEnabled reports whether the destructive def purge should run:
+// "prune" always, "export+prune" only with a configured ExportDir (never delete
+// a version we were asked to export but can't). "off"/unknown → false.
+func (s *Sweeper) defsPurgeEnabled() bool {
+	switch s.defsMode {
+	case "prune":
+		return true
+	case "export+prune":
+		return s.exportDir != ""
+	}
+	return false
+}
+
+// Run drives the sweep loop until ctx is done. The first tick fires after
+// Interval (not immediately) so a fresh process doesn't purge the moment it
+// boots. Blocks — caller starts it on a goroutine.
+func (s *Sweeper) Run(ctx context.Context) {
+	if s.store == nil {
+		return
+	}
+	s.logf("retention: sweeper starting (interval=%s, defs_mode=%s, defs_max_age=%s, keep_last_n=%d, dry_run=%v)",
+		s.interval, s.defsMode, s.defsMaxAge, s.defsKeepLastN, s.dryRun)
+	if s.defsMode == "export+prune" && s.exportDir == "" {
+		s.logf("retention: defs purge DISABLED — mode=export+prune requires LOOMCYCLE_RETENTION_EXPORT_DIR")
+	}
+	t := time.NewTicker(s.interval)
+	defer t.Stop()
+
+	// Suppress the no-op log after the first tick until a non-zero sweep or every
+	// Nth tick (roughly daily at the default 1h interval) — enough to confirm the
+	// goroutine is alive without flooding the log.
+	const noOpHeartbeatEvery = 24
+	noOpStreak := 0
+
+	for {
+		select {
+		case <-ctx.Done():
+			s.logf("retention: sweeper stopping (ctx done)")
+			return
+		case <-t.C:
+			var (
+				res Result
+				err error
+			)
+			doWork := func(ctx context.Context) {
+				res, err = s.sweepOnce(ctx)
+			}
+			if s.lock != nil {
+				acquired, lockErr := s.lock.TryRun(ctx, s.lockKey, func(ctx context.Context) error {
+					// Return nil so TryRun's err signals ONLY infra failures, kept
+					// distinct from the per-sweep failure log below.
+					doWork(ctx)
+					return nil
+				})
+				if lockErr != nil {
+					s.logf("retention: advisory lock infra error: %v", lockErr)
+					continue
+				}
+				if !acquired {
+					// Another replica is running this tick — silent.
+					continue
+				}
+			} else {
+				doWork(ctx)
+			}
+			if err != nil {
+				s.logf("retention: sweep failed: %v", err)
+			} else if res.Total > 0 {
+				verb := "purged"
+				if s.dryRun {
+					verb = "would purge"
+				}
+				s.logf("retention: %s %d retired def version(s) across %d type(s) (mode=%s)", verb, res.Total, len(res.PerType), s.defsMode)
+				noOpStreak = 0
+			} else {
+				if noOpStreak == 0 || noOpStreak%noOpHeartbeatEvery == 0 {
+					s.logf("retention: sweep tick — 0 purgeable def versions (streak=%d)", noOpStreak)
+				}
+				noOpStreak++
+			}
+		}
+	}
+}
+
+// sweepOnce runs one pass over every def-type. Exposed as a method so tests can
+// drive it deterministically without a real Ticker. A no-op when the purge is
+// disabled (mode=off, or export+prune with no ExportDir). The batch shares one
+// 2-minute deadline; per-type failures are logged and skipped so one bad type
+// never blocks the others.
+func (s *Sweeper) sweepOnce(parent context.Context) (Result, error) {
+	res := Result{PerType: map[string]int{}}
+	if !s.defsPurgeEnabled() {
+		return res, nil
+	}
+	ctx, cancel := context.WithTimeout(parent, 2*time.Minute)
+	defer cancel()
+	cutoff := s.now().Add(-s.defsMaxAge)
+	for _, defType := range store.RetentionDefTypes {
+		if ctx.Err() != nil {
+			break
+		}
+		refs, err := s.store.ListPurgeableRetiredDefVersions(ctx, defType, cutoff, s.defsKeepLastN, purgeBatch)
+		if err != nil {
+			s.logf("retention: list %s failed: %v", defType, err)
+			continue
+		}
+		if len(refs) == 0 {
+			continue
+		}
+		ids := make([]string, 0, len(refs))
+		for _, ref := range refs {
+			if s.defsMode == "export+prune" {
+				if err := s.exportDef(ref); err != nil {
+					// Never delete a version we failed to export — retry next tick.
+					s.logf("retention: export %s/%s failed, skipping delete: %v", defType, ref.DefID, err)
+					continue
+				}
+			}
+			ids = append(ids, ref.DefID)
+		}
+		if len(ids) == 0 {
+			continue
+		}
+		if s.dryRun {
+			// Preview only: count what WOULD be deleted, touch nothing.
+			res.PerType[defType] += len(ids)
+			res.Total += len(ids)
+			continue
+		}
+		n, err := s.store.DeleteDefVersions(ctx, defType, ids)
+		if err != nil {
+			s.logf("retention: delete %s failed: %v", defType, err)
+			continue
+		}
+		res.PerType[defType] += n
+		res.Total += n
+	}
+	return res, nil
+}
+
+// exportDef writes one retired def version to ExportDir as JSON, under a
+// per-day/per-def-type subdir (bucketing by the version's created date keeps any
+// single directory bounded). The export dir is operator config, never model
+// input.
+func (s *Sweeper) exportDef(ref store.RetiredDefRef) error {
+	day := ref.CreatedAt
+	if day.IsZero() {
+		day = s.now()
+	}
+	dir := filepath.Join(s.exportDir, day.UTC().Format("2006-01-02"), ref.DefType)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return err
+	}
+	blob, err := json.MarshalIndent(ref, "", "  ")
+	if err != nil {
+		return err
+	}
+	// 0o600: a def body may hold sensitive prompt / config material; operator-only.
+	return os.WriteFile(filepath.Join(dir, ref.DefID+".json"), blob, 0o600)
+}
+
+// DryRunCounts returns the per-def-type count of currently-purgeable versions
+// WITHOUT deleting anything — backing the read-only GET /v1/_retention report.
+// It reports the counts the CONFIGURED age + keep-last-N would purge regardless
+// of DefsMode (so an operator can preview impact before enabling a destructive
+// mode). Each count saturates at reportListCap.
+func (s *Sweeper) DryRunCounts(ctx context.Context) (map[string]int, error) {
+	out := map[string]int{}
+	if s.store == nil {
+		return out, nil
+	}
+	cutoff := s.now().Add(-s.defsMaxAge)
+	for _, defType := range store.RetentionDefTypes {
+		refs, err := s.store.ListPurgeableRetiredDefVersions(ctx, defType, cutoff, s.defsKeepLastN, reportListCap)
+		if err != nil {
+			return nil, err
+		}
+		out[defType] = len(refs)
+	}
+	return out, nil
+}

--- a/internal/retention/sweeper_test.go
+++ b/internal/retention/sweeper_test.go
@@ -1,0 +1,234 @@
+package retention
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+)
+
+// fakeStore embeds store.Store (nil) and overrides only the two methods the
+// sweeper calls, so the sweeper's own logic (export-then-delete, dry-run,
+// mode/export-dir gating) can be tested without a real backend. Any other
+// interface method would panic on the nil embed — the sweeper never calls them.
+type fakeStore struct {
+	store.Store
+	purgeable   map[string][]store.RetiredDefRef
+	deleteCalls []deleteCall
+}
+
+type deleteCall struct {
+	defType string
+	ids     []string
+}
+
+func (f *fakeStore) ListPurgeableRetiredDefVersions(_ context.Context, defType string, _ time.Time, _, _ int) ([]store.RetiredDefRef, error) {
+	return f.purgeable[defType], nil
+}
+
+func (f *fakeStore) DeleteDefVersions(_ context.Context, defType string, defIDs []string) (int, error) {
+	f.deleteCalls = append(f.deleteCalls, deleteCall{defType: defType, ids: append([]string(nil), defIDs...)})
+	return len(defIDs), nil
+}
+
+func agentRefs(ids ...string) []store.RetiredDefRef {
+	out := make([]store.RetiredDefRef, len(ids))
+	for i, id := range ids {
+		out[i] = store.RetiredDefRef{
+			DefType:    "agent",
+			DefID:      id,
+			Name:       "a",
+			Version:    i + 1,
+			Definition: json.RawMessage(`{"model":"x"}`),
+			CreatedAt:  time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC),
+		}
+	}
+	return out
+}
+
+func quietLogger(string, ...any) {}
+
+// TestSweeper_DryRunDeletesNothing: DryRun counts purgeable versions but never
+// calls DeleteDefVersions.
+func TestSweeper_DryRunDeletesNothing(t *testing.T) {
+	fs := &fakeStore{purgeable: map[string][]store.RetiredDefRef{"agent": agentRefs("d1", "d2")}}
+	sw := New(fs, Config{DefsMode: "prune", DryRun: true, Logger: quietLogger})
+	res, err := sw.sweepOnce(context.Background())
+	if err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+	if res.Total != 2 || res.PerType["agent"] != 2 {
+		t.Errorf("res = %+v, want total 2 / agent 2", res)
+	}
+	if len(fs.deleteCalls) != 0 {
+		t.Errorf("dry-run issued %d delete call(s), want 0", len(fs.deleteCalls))
+	}
+}
+
+// TestSweeper_ExportPruneWritesFilesThenDeletes: each version is written to
+// ExportDir as JSON before it is deleted.
+func TestSweeper_ExportPruneWritesFilesThenDeletes(t *testing.T) {
+	dir := t.TempDir()
+	fs := &fakeStore{purgeable: map[string][]store.RetiredDefRef{"agent": agentRefs("d1", "d2")}}
+	sw := New(fs, Config{DefsMode: "export+prune", ExportDir: dir, Logger: quietLogger})
+	res, err := sw.sweepOnce(context.Background())
+	if err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+	if res.Total != 2 {
+		t.Errorf("res.Total = %d, want 2", res.Total)
+	}
+	// Files written under <dir>/2026-07-01/agent/<id>.json.
+	for _, id := range []string{"d1", "d2"} {
+		p := filepath.Join(dir, "2026-07-01", "agent", id+".json")
+		blob, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("read export %s: %v", p, err)
+		}
+		var ref store.RetiredDefRef
+		if err := json.Unmarshal(blob, &ref); err != nil {
+			t.Fatalf("export %s not valid RetiredDefRef JSON: %v", p, err)
+		}
+		if ref.DefID != id {
+			t.Errorf("export %s has def_id %q", p, ref.DefID)
+		}
+	}
+	// And the delete followed the export.
+	if len(fs.deleteCalls) != 1 || len(fs.deleteCalls[0].ids) != 2 {
+		t.Fatalf("delete calls = %+v, want one call of 2 ids", fs.deleteCalls)
+	}
+}
+
+// TestSweeper_ExportPruneWithoutExportDirDisabled: export+prune with no
+// ExportDir is a no-op (never delete a version we can't export).
+func TestSweeper_ExportPruneWithoutExportDirDisabled(t *testing.T) {
+	fs := &fakeStore{purgeable: map[string][]store.RetiredDefRef{"agent": agentRefs("d1")}}
+	sw := New(fs, Config{DefsMode: "export+prune", ExportDir: "", Logger: quietLogger})
+	if sw.defsPurgeEnabled() {
+		t.Error("defsPurgeEnabled() = true for export+prune with empty ExportDir, want false")
+	}
+	res, err := sw.sweepOnce(context.Background())
+	if err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+	if res.Total != 0 || len(fs.deleteCalls) != 0 {
+		t.Errorf("disabled sweep purged %d / %d delete calls, want 0/0", res.Total, len(fs.deleteCalls))
+	}
+}
+
+// TestSweeper_ModeOffIsNoOp: the default off mode never touches the store.
+func TestSweeper_ModeOffIsNoOp(t *testing.T) {
+	fs := &fakeStore{purgeable: map[string][]store.RetiredDefRef{"agent": agentRefs("d1", "d2")}}
+	sw := New(fs, Config{DefsMode: "", Logger: quietLogger}) // "" → off
+	res, err := sw.sweepOnce(context.Background())
+	if err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+	if res.Total != 0 || len(fs.deleteCalls) != 0 {
+		t.Errorf("off-mode sweep purged %d / %d delete calls, want 0/0", res.Total, len(fs.deleteCalls))
+	}
+}
+
+// TestSweeper_KeepLastNAndActiveExclusionHonored drives the whole stack against
+// a REAL sqlite store: seed 5 versions, retire the 4 oldest, promote a retired
+// one as active, then run the sweeper with keep_last_n=1. Only the retired,
+// non-active, beyond-keep-N versions must be deleted.
+func TestSweeper_KeepLastNAndActiveExclusionHonored(t *testing.T) {
+	ctx := context.Background()
+	st, err := sqlite.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+
+	ids := []string{"v1", "v2", "v3", "v4", "v5"}
+	for _, id := range ids {
+		row := store.AgentDefRow{DefID: id, Name: "agent-x", Definition: json.RawMessage(`{"model":"x"}`)}
+		if _, err := st.AgentDefCreate(ctx, row); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+	for _, id := range ids[:4] { // retire v1..v4; v5 stays live
+		if err := st.AgentDefSetRetired(ctx, id, true); err != nil {
+			t.Fatalf("retire %s: %v", id, err)
+		}
+	}
+	// Promote a retired version (v3) as active AFTER retiring, so the pointer
+	// isn't cleared — the active guard must still exclude it.
+	if err := st.AgentDefSetActive(ctx, "", "agent-x", "v3", ""); err != nil {
+		t.Fatalf("promote v3: %v", err)
+	}
+
+	// Now() in the future so the zero DefsMaxAge cutoff clears every row's age.
+	sw := New(st, Config{
+		DefsMode:      "prune",
+		DefsKeepLastN: 1,
+		Logger:        quietLogger,
+		Now:           func() time.Time { return time.Now().Add(time.Hour) },
+	})
+	res, err := sw.sweepOnce(ctx)
+	if err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+	// Purgeable: v1, v2 (v4 kept by keep-last-N=1, v3 active, v5 live).
+	if res.Total != 2 || res.PerType["agent"] != 2 {
+		t.Errorf("res = %+v, want total 2 / agent 2", res)
+	}
+	for _, id := range []string{"v1", "v2"} {
+		if _, err := st.AgentDefGet(ctx, id); err == nil {
+			t.Errorf("%s still present after sweep", id)
+		}
+	}
+	for _, id := range []string{"v3", "v4", "v5"} {
+		if _, err := st.AgentDefGet(ctx, id); err != nil {
+			t.Errorf("%s wrongly deleted: %v", id, err)
+		}
+	}
+}
+
+// TestSweeper_DryRunCountsReportsPerType: the endpoint-backing preview counts
+// purgeable versions per def-type without deleting.
+func TestSweeper_DryRunCountsReportsPerType(t *testing.T) {
+	ctx := context.Background()
+	st, err := sqlite.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+
+	ids := []string{"v1", "v2", "v3"}
+	for _, id := range ids {
+		if _, err := st.AgentDefCreate(ctx, store.AgentDefRow{DefID: id, Name: "agent-y", Definition: json.RawMessage(`{"model":"x"}`)}); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+	for _, id := range ids { // retire all three
+		if err := st.AgentDefSetRetired(ctx, id, true); err != nil {
+			t.Fatalf("retire %s: %v", id, err)
+		}
+	}
+	sw := New(st, Config{
+		DefsMode:      "off", // counts are mode-independent
+		DefsKeepLastN: 1,
+		Logger:        quietLogger,
+		Now:           func() time.Time { return time.Now().Add(time.Hour) },
+	})
+	counts, err := sw.DryRunCounts(ctx)
+	if err != nil {
+		t.Fatalf("DryRunCounts: %v", err)
+	}
+	// keep-last-N=1 keeps v3; v1, v2 purgeable.
+	if counts["agent"] != 2 {
+		t.Errorf("counts[agent] = %d, want 2", counts["agent"])
+	}
+	for _, dt := range []string{"skill", "webhook", "memory_backend"} {
+		if counts[dt] != 0 {
+			t.Errorf("counts[%s] = %d, want 0", dt, counts[dt])
+		}
+	}
+}

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -4262,6 +4262,86 @@ func (s *Store) AgentDefListNames(ctx context.Context) ([]store.AgentDefNameSumm
 	return out, rows.Err()
 }
 
+// ListPurgeableRetiredDefVersions — RFC BM retention. created_at is TIMESTAMPTZ
+// here, so olderThan binds directly. The row_number() window can't live in a
+// WHERE (SQL disallows window functions there), so it's computed in a subselect
+// (over the retired+old+non-active set) and the outer query filters rn >
+// keepLastN, which also lets LIMIT apply to the final result.
+func (s *Store) ListPurgeableRetiredDefVersions(ctx context.Context, defType string, olderThan time.Time, keepLastN, limit int) ([]store.RetiredDefRef, error) {
+	defsTable, activeTable, ok := store.RetentionDefTables(defType)
+	if !ok {
+		return nil, fmt.Errorf("retention: unknown def type %q", defType)
+	}
+	if keepLastN < 0 {
+		keepLastN = 0
+	}
+	if limit <= 0 {
+		limit = 500
+	}
+	// defsTable/activeTable are allowlisted names (never caller input) — safe to
+	// interpolate. Values (cutoff/keepLastN/limit) stay parameterized. The two
+	// NOT EXISTS clauses exclude (a) the active version and (b) any version still
+	// referenced as a parent_def_id — so we never purge a version whose descendant
+	// survives. This keeps lineage intact AND avoids the parent_def_id FK violation
+	// a single batched DELETE of a still-referenced parent would trigger; a retired
+	// chain drains leaf-first over successive ticks.
+	q := fmt.Sprintf(`
+		SELECT def_id, tenant_id, name, version, definition::text, created_at
+		FROM (
+			SELECT d.def_id, d.tenant_id, d.name, d.version, d.definition, d.created_at,
+			       ROW_NUMBER() OVER (PARTITION BY d.tenant_id, d.name ORDER BY d.version DESC) AS rn
+			FROM %s d
+			WHERE d.retired = TRUE
+			  AND d.created_at < $1
+			  AND NOT EXISTS (SELECT 1 FROM %s a WHERE a.def_id = d.def_id)
+			  AND NOT EXISTS (SELECT 1 FROM %s c WHERE c.parent_def_id = d.def_id)
+		) sub
+		WHERE sub.rn > $2
+		ORDER BY sub.tenant_id, sub.name, sub.version DESC
+		LIMIT $3`, defsTable, activeTable, defsTable)
+	rows, err := s.pool.Query(ctx, q, olderThan, keepLastN, limit)
+	if err != nil {
+		return nil, fmt.Errorf("retention list %s: %w", defType, err)
+	}
+	defer rows.Close()
+
+	var out []store.RetiredDefRef
+	for rows.Next() {
+		ref := store.RetiredDefRef{DefType: defType}
+		var definition string
+		if err := rows.Scan(&ref.DefID, &ref.TenantID, &ref.Name, &ref.Version, &definition, &ref.CreatedAt); err != nil {
+			return nil, err
+		}
+		ref.Definition = json.RawMessage(definition)
+		out = append(out, ref)
+	}
+	return out, rows.Err()
+}
+
+// DeleteDefVersions — RFC BM retention hard-delete. See the store interface.
+func (s *Store) DeleteDefVersions(ctx context.Context, defType string, defIDs []string) (int, error) {
+	defsTable, _, ok := store.RetentionDefTables(defType)
+	if !ok {
+		return 0, fmt.Errorf("retention: unknown def type %q", defType)
+	}
+	if len(defIDs) == 0 {
+		return 0, nil
+	}
+	placeholders := make([]string, len(defIDs))
+	args := make([]any, len(defIDs))
+	for i, id := range defIDs {
+		placeholders[i] = fmt.Sprintf("$%d", i+1)
+		args[i] = id
+	}
+	// defsTable is allowlisted; the ids are parameterized.
+	q := fmt.Sprintf(`DELETE FROM %s WHERE def_id IN (%s)`, defsTable, strings.Join(placeholders, ", "))
+	res, err := s.pool.Exec(ctx, q, args...)
+	if err != nil {
+		return 0, fmt.Errorf("retention delete %s: %w", defType, err)
+	}
+	return int(res.RowsAffected()), nil
+}
+
 // AgentDefSetActive UPSERTs the agent_def_active pointer for
 // (tenantID, name). RFC N: validates the def belongs to BOTH the named
 // agent AND the supplied tenant — a def can only be promoted within its

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -4735,6 +4735,89 @@ func (s *Store) AgentDefListNames(ctx context.Context) ([]store.AgentDefNameSumm
 	return out, rows.Err()
 }
 
+// ListPurgeableRetiredDefVersions — RFC BM retention. created_at is an INTEGER
+// unix-nano column here, so olderThan binds as .UnixNano(). SQLite (>=3.25)
+// supports the row_number() window; as in Postgres it's computed in a subselect
+// (SQL disallows window functions in WHERE) so the outer query can filter
+// rn > keepLastN and apply LIMIT.
+func (s *Store) ListPurgeableRetiredDefVersions(ctx context.Context, defType string, olderThan time.Time, keepLastN, limit int) ([]store.RetiredDefRef, error) {
+	defsTable, activeTable, ok := store.RetentionDefTables(defType)
+	if !ok {
+		return nil, fmt.Errorf("retention: unknown def type %q", defType)
+	}
+	if keepLastN < 0 {
+		keepLastN = 0
+	}
+	if limit <= 0 {
+		limit = 500
+	}
+	// defsTable/activeTable are allowlisted names (never caller input) — safe to
+	// interpolate. Values stay parameterized. The two NOT EXISTS clauses exclude
+	// (a) the active version and (b) any version still referenced as a
+	// parent_def_id — so we never purge a version whose descendant survives. This
+	// keeps lineage intact AND avoids the postgres parent_def_id FK violation that
+	// a single batched DELETE of a still-referenced parent would trigger; a
+	// retired chain drains leaf-first over successive ticks.
+	q := fmt.Sprintf(`
+		SELECT def_id, tenant_id, name, version, definition, created_at
+		FROM (
+			SELECT d.def_id, d.tenant_id, d.name, d.version, d.definition, d.created_at,
+			       ROW_NUMBER() OVER (PARTITION BY d.tenant_id, d.name ORDER BY d.version DESC) AS rn
+			FROM %s d
+			WHERE d.retired = 1
+			  AND d.created_at < ?
+			  AND NOT EXISTS (SELECT 1 FROM %s a WHERE a.def_id = d.def_id)
+			  AND NOT EXISTS (SELECT 1 FROM %s c WHERE c.parent_def_id = d.def_id)
+		) sub
+		WHERE sub.rn > ?
+		ORDER BY sub.tenant_id, sub.name, sub.version DESC
+		LIMIT ?`, defsTable, activeTable, defsTable)
+	rows, err := s.db.QueryContext(ctx, q, olderThan.UnixNano(), keepLastN, limit)
+	if err != nil {
+		return nil, fmt.Errorf("retention list %s: %w", defType, err)
+	}
+	defer rows.Close()
+
+	var out []store.RetiredDefRef
+	for rows.Next() {
+		ref := store.RetiredDefRef{DefType: defType}
+		var definition string
+		var createdAt int64
+		if err := rows.Scan(&ref.DefID, &ref.TenantID, &ref.Name, &ref.Version, &definition, &createdAt); err != nil {
+			return nil, err
+		}
+		ref.Definition = json.RawMessage(definition)
+		ref.CreatedAt = time.Unix(0, createdAt)
+		out = append(out, ref)
+	}
+	return out, rows.Err()
+}
+
+// DeleteDefVersions — RFC BM retention hard-delete. See the store interface.
+func (s *Store) DeleteDefVersions(ctx context.Context, defType string, defIDs []string) (int, error) {
+	defsTable, _, ok := store.RetentionDefTables(defType)
+	if !ok {
+		return 0, fmt.Errorf("retention: unknown def type %q", defType)
+	}
+	if len(defIDs) == 0 {
+		return 0, nil
+	}
+	placeholders := make([]string, len(defIDs))
+	args := make([]any, len(defIDs))
+	for i, id := range defIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	// defsTable is allowlisted; the ids are parameterized.
+	q := fmt.Sprintf(`DELETE FROM %s WHERE def_id IN (%s)`, defsTable, strings.Join(placeholders, ", "))
+	res, err := s.db.ExecContext(ctx, q, args...)
+	if err != nil {
+		return 0, fmt.Errorf("retention delete %s: %w", defType, err)
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}
+
 // AgentDefSetActive UPSERTs the agent_def_active pointer for
 // (tenantID, name). RFC N: validates the def belongs to BOTH the named
 // agent AND the supplied tenant — a def can only be promoted within its

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1012,6 +1012,30 @@ type Store interface {
 	// RFC AV Phase 2b2.
 	DeleteSessionCascade(ctx context.Context, sessionID string) error
 
+	// ListPurgeableRetiredDefVersions returns retired-and-old substrate def
+	// versions eligible for the RFC BM data-retention purge, for one def-type
+	// (agent / skill / team / mcp_server / schedule / a2a_server_card /
+	// a2a_agent / webhook / memory_backend — see RetentionDefTables). A row
+	// qualifies when ALL of:
+	//   - retired = true,
+	//   - created_at < olderThan (the age cutoff),
+	//   - it is NOT the current active pointer (defence-in-depth: even a
+	//     retired-but-active "ActiveRetired" corrupt-legacy row is protected),
+	//   - and it is beyond the keepLastN most-recent qualifying versions per
+	//     (tenant_id, name) — so the N newest retired versions survive as
+	//     lineage history. keepLastN=0 keeps none (purge every qualifying row).
+	// Ordered (tenant, name, version DESC), capped at limit (<=0 → a sane
+	// default). An unknown defType is an error (the def-type is looked up in a
+	// hardcoded table allowlist and NEVER interpolated raw). Read-only.
+	ListPurgeableRetiredDefVersions(ctx context.Context, defType string, olderThan time.Time, keepLastN, limit int) ([]RetiredDefRef, error)
+
+	// DeleteDefVersions hard-deletes the given def_ids from one def-type's defs
+	// table (RFC BM purge). Empty defIDs → (0, nil). Returns the rows-affected
+	// count. An unknown defType is an error (allowlist-checked, never
+	// interpolated raw). The caller (the retention sweeper) supplies only ids
+	// that ListPurgeableRetiredDefVersions returned.
+	DeleteDefVersions(ctx context.Context, defType string, defIDs []string) (int, error)
+
 	// GetTranscript returns all events for a session, ordered by Seq.
 	// Returns an empty slice (not error) for a session with no runs yet.
 	GetTranscript(ctx context.Context, sessionID string) ([]Event, error)
@@ -2741,6 +2765,62 @@ type AgentDefNameSummary struct {
 	// until the next retire/promote heals it. Normally false: the
 	// retire-of-active path now clears the pointer.
 	ActiveRetired bool `json:"active_retired,omitempty"`
+}
+
+// RetiredDefRef identifies one purgeable retired substrate def version (RFC BM
+// data retention). Definition carries the full JSON body so the sweeper can
+// export it before deleting (export-then-delete). DefType is the retention
+// def-type key (see RetentionDefTables), not a table name.
+type RetiredDefRef struct {
+	DefType    string          `json:"def_type"`
+	DefID      string          `json:"def_id"`
+	TenantID   string          `json:"tenant_id,omitempty"`
+	Name       string          `json:"name"`
+	Version    int             `json:"version"`
+	Definition json.RawMessage `json:"definition"`
+	CreatedAt  time.Time       `json:"created_at"`
+}
+
+// retentionDefTables is the hardcoded allowlist mapping an RFC BM retention
+// def-type to its (defs, active) physical table pair. Both store backends
+// (SQLite + Postgres) use the SAME physical table names for these 9 uniform
+// versioned def families, so the allowlist is shared here — a single source of
+// truth that can't drift between backends.
+//
+// SECURITY: the retention store methods parameterize the table name INTO SQL via
+// fmt.Sprintf. The table name MUST come from this allowlist and NEVER from a
+// caller-supplied string, or an attacker-influenced def-type would be a SQL
+// injection sink. RetentionDefTables returns ok=false for anything not listed;
+// the store methods turn that into an error before building any query.
+var retentionDefTables = map[string][2]string{
+	"agent":           {"agent_defs", "agent_def_active"},
+	"skill":           {"skill_defs", "skill_def_active"},
+	"team":            {"teamdefs", "teamdef_active"},
+	"mcp_server":      {"mcp_server_defs", "mcp_server_def_active"},
+	"schedule":        {"schedule_defs", "schedule_def_active"},
+	"a2a_server_card": {"a2a_server_card_defs", "a2a_server_card_def_active"},
+	"a2a_agent":       {"a2a_agent_defs", "a2a_agent_def_active"},
+	"webhook":         {"webhook_defs", "webhook_def_active"},
+	"memory_backend":  {"memory_backend_defs", "memory_backend_def_active"},
+}
+
+// RetentionDefTypes is the stable, ordered list of versioned substrate def-types
+// the RFC BM retention sweeper purges. Ordered for deterministic sweeps + reports.
+var RetentionDefTypes = []string{
+	"agent", "skill", "team", "mcp_server", "schedule",
+	"a2a_server_card", "a2a_agent", "webhook", "memory_backend",
+}
+
+// RetentionDefTables returns the (defsTable, activeTable) physical table pair for
+// a retention def-type, or ok=false for an unknown type. Callers MUST reject
+// ok=false before building SQL — the returned strings are the ONLY def-table
+// names that may be interpolated into a retention query.
+func RetentionDefTables(defType string) (defsTable, activeTable string, ok bool) {
+	p, ok := retentionDefTables[defType]
+	if !ok {
+		return "", "", false
+	}
+	return p[0], p[1], true
 }
 
 // ---- v0.8.22 SkillDef substrate types ----

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -214,6 +214,10 @@ func Run(t *testing.T, factory Factory) {
 		{"AgentDefContentSHA256RoundTrip", testAgentDefContentSHA256RoundTrip},
 		{"BackfillAgentDefContentSHA256", testBackfillAgentDefContentSHA256},
 		{"BackfillAgentDefSystemPromptBaseFillsLegacyRows", testBackfillAgentDefSystemPromptBase},
+		// RFC BM data retention: list + delete purgeable retired def versions.
+		// Asserts the retired / non-active / keep-last-N exclusions are each
+		// load-bearing, and DeleteDefVersions removes exactly the listed rows.
+		{"RetentionPurgeDefVersions", testRetentionPurgeDefVersions},
 		// v0.8.22 SkillDef substrate — mirror of the AgentDef tests.
 		{"SkillDefCreateAndGet", testSkillDefCreateAndGet},
 		{"SkillDefVersionMonotonicUnderContention", testSkillDefVersionMonotonicUnderContention},
@@ -5443,6 +5447,138 @@ func testBackfillAgentDefSystemPromptBase(t *testing.T, s store.Store) {
 	}
 	if n2 != 0 {
 		t.Errorf("idempotent? second pass backfilled %d rows, want 0", n2)
+	}
+}
+
+// testRetentionPurgeDefVersions exercises the RFC BM retention store surface on
+// the agent def-type (all 9 families share one uniform schema, so agent is
+// representative). Setup: 5 versions under one (tenant, name); retire the 4
+// oldest, then promote a RETIRED version as active. Each exclusion is made
+// load-bearing:
+//   - the ACTIVE version (rt-3, retired + active) must be excluded even though
+//     it is retired + old — proving the NOT EXISTS active guard, not just the
+//     retired filter, is what protects it;
+//   - the keepLastN=1 newest qualifying version (rt-4) must survive;
+//   - the LIVE version (rt-5) must never appear.
+//
+// Then DeleteDefVersions must remove exactly the listed rows and nothing else.
+func testRetentionPurgeDefVersions(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	const name = "retain-agent"
+	ids := []string{"rt-1", "rt-2", "rt-3", "rt-4", "rt-5"}
+
+	// 5 monotonic versions v1..v5 under one (tenant="", name).
+	for _, id := range ids {
+		if _, err := s.AgentDefCreate(ctx, mkDef(id, name, "")); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+	// Retire the 4 oldest (rt-1..rt-4); rt-5 stays live.
+	for _, id := range ids[:4] {
+		if err := s.AgentDefSetRetired(ctx, id, true); err != nil {
+			t.Fatalf("retire %s: %v", id, err)
+		}
+	}
+	// Promote a RETIRED version (rt-3) as active — AFTER retiring, so the
+	// retire-of-active clear-pointer path doesn't fire. This yields the
+	// "ActiveRetired" corrupt-legacy state the active guard must survive.
+	if err := s.AgentDefSetActive(ctx, "", name, "rt-3", ""); err != nil {
+		t.Fatalf("promote rt-3: %v", err)
+	}
+
+	future := time.Now().Add(time.Hour) // age cutoff in the future → all rows qualify by age
+	got, err := s.ListPurgeableRetiredDefVersions(ctx, "agent", future, 1, 100)
+	if err != nil {
+		t.Fatalf("list purgeable: %v", err)
+	}
+	gotIDs := map[string]bool{}
+	for _, r := range got {
+		gotIDs[r.DefID] = true
+		if r.DefType != "agent" {
+			t.Errorf("ref.DefType = %q, want agent", r.DefType)
+		}
+		if r.Name != name {
+			t.Errorf("ref.Name = %q, want %q", r.Name, name)
+		}
+		if len(r.Definition) == 0 {
+			t.Errorf("ref %s: empty Definition (export would lose the body)", r.DefID)
+		}
+	}
+	// Expected purgeable: rt-1, rt-2 only.
+	want := map[string]bool{"rt-1": true, "rt-2": true}
+	if !reflect.DeepEqual(gotIDs, want) {
+		t.Fatalf("purgeable ids = %v, want %v (rt-3 active, rt-4 kept-by-N, rt-5 live)", gotIDs, want)
+	}
+
+	// DeleteDefVersions removes exactly those two.
+	deleted, err := s.DeleteDefVersions(ctx, "agent", []string{"rt-1", "rt-2"})
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if deleted != 2 {
+		t.Errorf("deleted = %d, want 2", deleted)
+	}
+	// rt-1, rt-2 gone; rt-3, rt-4, rt-5 survive.
+	for _, id := range []string{"rt-1", "rt-2"} {
+		if _, err := s.AgentDefGet(ctx, id); err == nil {
+			t.Errorf("%s still present after delete", id)
+		}
+	}
+	for _, id := range []string{"rt-3", "rt-4", "rt-5"} {
+		if _, err := s.AgentDefGet(ctx, id); err != nil {
+			t.Errorf("%s wrongly deleted: %v", id, err)
+		}
+	}
+	// A second list finds nothing new purgeable (rt-4 kept, rest gone/excluded).
+	again, err := s.ListPurgeableRetiredDefVersions(ctx, "agent", future, 1, 100)
+	if err != nil {
+		t.Fatalf("list after delete: %v", err)
+	}
+	if len(again) != 0 {
+		t.Errorf("after delete, still purgeable: %+v, want none", again)
+	}
+
+	// Empty id list is a no-op.
+	if n, err := s.DeleteDefVersions(ctx, "agent", nil); err != nil || n != 0 {
+		t.Errorf("delete empty = (%d, %v), want (0, nil)", n, err)
+	}
+	// Unknown def-type is rejected on BOTH methods (allowlist guard) — never a
+	// silent no-op that would let a caller string reach SQL.
+	if _, err := s.ListPurgeableRetiredDefVersions(ctx, "not_a_def_type", future, 1, 100); err == nil {
+		t.Error("list with unknown def-type: want error, got nil")
+	}
+	if _, err := s.DeleteDefVersions(ctx, "not_a_def_type", []string{"x"}); err == nil {
+		t.Error("delete with unknown def-type: want error, got nil")
+	}
+
+	// Parent-of-survivor exclusion (RFC BM leaf-only rule): a retired+old version
+	// that is still the parent_def_id of a SURVIVING version must NOT be purgeable
+	// — purging it would orphan the child's lineage and FK-violate on postgres
+	// (parent_def_id REFERENCES <defs>(def_id)). Use a fresh name to isolate.
+	const pname = "retain-lineage"
+	if _, err := s.AgentDefCreate(ctx, mkDef("pa-1", pname, "")); err != nil {
+		t.Fatalf("create pa-1: %v", err)
+	}
+	if _, err := s.AgentDefCreate(ctx, mkDef("pa-2", pname, "pa-1")); err != nil { // child of pa-1
+		t.Fatalf("create pa-2: %v", err)
+	}
+	// Retire the PARENT (pa-1) only; pa-2 (child) stays live + becomes active.
+	if err := s.AgentDefSetRetired(ctx, "pa-1", true); err != nil {
+		t.Fatalf("retire pa-1: %v", err)
+	}
+	if err := s.AgentDefSetActive(ctx, "", pname, "pa-2", ""); err != nil {
+		t.Fatalf("promote pa-2: %v", err)
+	}
+	// keepLastN=0 so keep-N doesn't mask the parent-exclusion: pa-1 is retired,
+	// old, non-active, beyond-N — purgeable ONLY the leaf rule protects it.
+	pg, err := s.ListPurgeableRetiredDefVersions(ctx, "agent", future, 0, 100)
+	if err != nil {
+		t.Fatalf("list (lineage): %v", err)
+	}
+	for _, r := range pg {
+		if r.DefID == "pa-1" {
+			t.Errorf("pa-1 (retired parent of surviving pa-2) must NOT be purgeable — would orphan lineage / FK-violate")
+		}
 	}
 }
 


### PR DESCRIPTION
## Why
RFC BM (`/loomcycle/rfcs/data-retention`) adds a data-retention subsystem to age out retired/old data. **P1** fills the sharpest gap: **9 versioned def stores** (agent, skill, team, mcp_server, schedule, a2a×2, webhook, memory_backend) had a soft `SetRetired` but **no hard-delete** — retired versions accumulated forever. Opt-in, cluster-gated, export-then-delete. **No migration.**

## What

### Store (both backends; table-parameterized via a hardcoded allowlist — never caller input)
- **`ListPurgeableRetiredDefVersions(defType, olderThan, keepLastN, limit)`** — `retired AND created_at<cutoff AND NOT active AND row_number() OVER (PARTITION BY tenant,name ORDER BY version DESC) > keepLastN`. `created_at` bound as `time.Time` (pg TIMESTAMPTZ) / `UnixNano` (sqlite INTEGER). Returns each version's `definition` for export.
- **`DeleteDefVersions(defType, defIDs)`**.
- **Leaf-only rule (FK + lineage safety):** the list also **excludes any version still referenced as a `parent_def_id`** — so a retired parent whose descendant survives is never purged. This prevents both an orphaned lineage **and** the postgres `parent_def_id` FK violation that a batched DELETE of a still-referenced parent would trigger (rolling back the whole batch and spinning). Retired chains drain leaf-first over ticks. **Verified on real Postgres.**

### Sweeper (`internal/retention`, mirrors `internal/usage`)
Ticker `Run` gated by `coord.LockKeyRetentionSweeper`; per-type list → export (export+prune writes JSON to `ExportDir/YYYY-MM-DD/<defType>/<id>.json`, **skip-delete-on-export-failure**) → delete; batched (500/type/tick); `DryRun` counts without deleting.

### Config (opt-in, default off)
`LOOMCYCLE_RETENTION_ENABLED` / `_INTERVAL_MS` / `_EXPORT_DIR` / `_DEFS_MODE` (off|prune|export+prune) / `_DEFS_MAX_AGE_MS` / `_DEFS_KEEP_LAST_N` (default 5). Started in main.go after the cluster block with the typed-nil advisoryLock guard.

### `GET /v1/_retention` (read-only)
Config for any tenant operator; the cross-tenant purgeable counts + `export_dir` are **admin-only** (no cross-tenant oracle; mirrors `/v1/_routing`).

## Review note
I delegated the mechanical build, then **reviewed the data-deletion SQL closely and fixed the FK-parent bug** (the leaf-only rule above) that a plain batched delete would have hit on Postgres — verified with a load-bearing parent-of-survivor contract assertion on both backends.

## Tested
- Contract `testRetentionPurgeDefVersions` (retired / active / keep-N / **parent-of-survivor** exclusions all load-bearing) — **PASS on sqlite AND real Postgres** (`make pg-up`).
- `internal/retention` unit tests; `config`/`coord`/`api/http` green; `go build ./...` + gofmt clean.

Backend only. P1 of the RFC BM line (P2 = chats/runs/events; P3 = memory/SQL-Memory/documents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)