### PR TITLE
feat(retention): RFC BM P2 — chats/runs/events retention + pinned exemption

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -2370,14 +2370,22 @@ func main() {
 	// advisoryLock stays nil and the sweeper's lock-gating branch is
 	// bypassed. Pruning is a compaction to daily usage_archive buckets,
 	// not data loss — billing totals are preserved.
+	// RFC BM Phase 2 reconciliation: when the retention sweeper is enabled AND its
+	// effective (post-alias) chats mode is a delete-bearing one, the retention
+	// sweeper owns aged-chat pruning — suppress the usage sweeper's legacy
+	// aged-session archiver so a session is never cascade-deleted by both. The
+	// usage-detail rollup is unaffected.
+	retentionOwnsChats := cfg.Env.RetentionEnabled &&
+		cfg.Env.RetentionChatsMode != "" && cfg.Env.RetentionChatsMode != "off"
 	if cfg.Env.UsageSweeperEnabled && storeIface != nil {
 		uCfg := usage.Config{
 			Interval:        cfg.Env.UsageSweepInterval,
 			DetailRetention: cfg.Env.UsageDetailRetention,
 			// RFC AV Phase 2b2 old-run archiver (opt-in; default OFF).
-			RunRetention:     cfg.Env.UsageRunRetention,
-			RunRetentionMode: cfg.Env.UsageRunRetentionMode,
-			ExportDir:        cfg.Env.UsageExportDir,
+			RunRetention:       cfg.Env.UsageRunRetention,
+			RunRetentionMode:   cfg.Env.UsageRunRetentionMode,
+			ExportDir:          cfg.Env.UsageExportDir,
+			DisableRunArchiver: retentionOwnsChats,
 		}
 		// Same typed-nil guard as the heartbeat block: only assign the
 		// interface field from a non-nil pointer, or the sweeper's
@@ -2403,7 +2411,11 @@ func main() {
 			DefsMode:      cfg.Env.RetentionDefsMode,
 			DefsMaxAge:    cfg.Env.RetentionDefsMaxAge,
 			DefsKeepLastN: cfg.Env.RetentionDefsKeepLastN,
-			ExportDir:     cfg.Env.RetentionExportDir,
+			// RFC BM Phase 2 aged-chat archiver (opt-in; default OFF, or inherited
+			// from the legacy LOOMCYCLE_USAGE_RUN_RETENTION_* config in cfg.Load).
+			ChatsMode:   cfg.Env.RetentionChatsMode,
+			ChatsMaxAge: cfg.Env.RetentionChatsMaxAge,
+			ExportDir:   cfg.Env.RetentionExportDir,
 		}
 		// Same typed-nil guard as the usage block: only assign the interface field
 		// from a non-nil pointer, or the sweeper's nil-check would see a non-nil

--- a/internal/api/http/retention_report.go
+++ b/internal/api/http/retention_report.go
@@ -26,9 +26,15 @@ type retentionReportResponse struct {
 	DefsMode      string `json:"defs_mode"`
 	DefsMaxAgeMS  int64  `json:"defs_max_age_ms"`
 	DefsKeepLastN int    `json:"defs_keep_last_n"`
+	// ChatsMode / ChatsMaxAgeMS are the RFC BM Phase 2 aged-chat archiver knobs
+	// (config only — tenant-readable). ChatsMode reflects the effective value
+	// after the legacy LOOMCYCLE_USAGE_RUN_RETENTION_* alias in config.Load.
+	ChatsMode     string `json:"chats_mode"`
+	ChatsMaxAgeMS int64  `json:"chats_max_age_ms"`
 	ExportDir     string `json:"export_dir,omitempty"`
 	// Purgeable is the per-def-type count of versions the CURRENT age + keep-last-N
-	// settings would purge right now (regardless of mode — a preview). Admin-only.
+	// settings would purge right now, plus an aged-chat-session count under the
+	// "chats" key (both regardless of mode — a preview). Admin-only.
 	Purgeable map[string]int `json:"purgeable,omitempty"`
 }
 
@@ -52,6 +58,10 @@ func (s *Server) handleRetentionReport(w http.ResponseWriter, r *http.Request) {
 	if mode == "" {
 		mode = "off"
 	}
+	chatsMode := s.cfg.Env.RetentionChatsMode
+	if chatsMode == "" {
+		chatsMode = "off"
+	}
 	resp := retentionReportResponse{
 		Admin:         admin,
 		Enabled:       s.cfg.Env.RetentionEnabled,
@@ -59,6 +69,8 @@ func (s *Server) handleRetentionReport(w http.ResponseWriter, r *http.Request) {
 		DefsMode:      mode,
 		DefsMaxAgeMS:  s.cfg.Env.RetentionDefsMaxAge.Milliseconds(),
 		DefsKeepLastN: s.cfg.Env.RetentionDefsKeepLastN,
+		ChatsMode:     chatsMode,
+		ChatsMaxAgeMS: s.cfg.Env.RetentionChatsMaxAge.Milliseconds(),
 	}
 
 	if s.store == nil {
@@ -77,6 +89,8 @@ func (s *Server) handleRetentionReport(w http.ResponseWriter, r *http.Request) {
 			DefsMode:      mode,
 			DefsMaxAge:    s.cfg.Env.RetentionDefsMaxAge,
 			DefsKeepLastN: s.cfg.Env.RetentionDefsKeepLastN,
+			ChatsMode:     chatsMode,
+			ChatsMaxAge:   s.cfg.Env.RetentionChatsMaxAge,
 			ExportDir:     s.cfg.Env.RetentionExportDir,
 		})
 		counts, err := sw.DryRunCounts(r.Context())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2352,6 +2352,20 @@ type Env struct {
 	// (tenant, name) as lineage history. Default 5. 0 = purge all.
 	// Env: LOOMCYCLE_RETENTION_DEFS_KEEP_LAST_N.
 	RetentionDefsKeepLastN int
+	// RetentionChatsMode is the RFC BM Phase 2 aged-chat archiver mode:
+	// "off" (default / "") | "prune" | "export+prune" — deletes aged sessions +
+	// their runs + events (pinned sessions always exempt). Independent of
+	// RetentionDefsMode. Env: LOOMCYCLE_RETENTION_CHATS_MODE.
+	// Back-compat: when unset AND the legacy LOOMCYCLE_USAGE_RUN_RETENTION_*
+	// archiver is configured, it is inherited (see Load) so an existing operator's
+	// config keeps pruning aged chats — now via the retention sweeper, which then
+	// makes the usage archiver exclusive so the two never double-run.
+	RetentionChatsMode string
+	// RetentionChatsMaxAge is the age cutoff for the chats archiver: a session
+	// whose runs are ALL terminal and whose latest completed_at is older than this
+	// is exported (per the mode) and cascade-deleted. 0 = no minimum age.
+	// Env: LOOMCYCLE_RETENTION_CHATS_MAX_AGE_MS.
+	RetentionChatsMaxAge time.Duration
 	// ReplicasSweepInterval is the dead-replica reaper's tick rate.
 	// Default 60s. Tunable mostly for tests / crash-recovery load
 	// experiments — leave at default in production.
@@ -3289,6 +3303,38 @@ func LoadLayers(layers ...Layer) (*Config, error) {
 	if v := os.Getenv("LOOMCYCLE_RETENTION_DEFS_KEEP_LAST_N"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
 			cfg.Env.RetentionDefsKeepLastN = n
+		}
+	}
+	// RFC BM Phase 2 aged-chat archiver (opt-in; default OFF).
+	if v := os.Getenv("LOOMCYCLE_RETENTION_CHATS_MODE"); v != "" {
+		cfg.Env.RetentionChatsMode = v
+	}
+	if v := os.Getenv("LOOMCYCLE_RETENTION_CHATS_MAX_AGE_MS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.Env.RetentionChatsMaxAge = time.Duration(n) * time.Millisecond
+		}
+	}
+	// Back-compat: the RFC AV Phase 2b2 aged-session archiver
+	// (LOOMCYCLE_USAGE_RUN_RETENTION_*) is subsumed by the RFC BM chats sweeper.
+	// When the operator hasn't set an explicit chats mode but HAS configured the
+	// legacy archiver, inherit its knobs so their config keeps pruning aged chats
+	// — now via the retention sweeper (which main.go then makes exclusive so the
+	// two never double-run). A positive RunRetention is the intent-to-prune
+	// signal; an empty legacy mode maps to "prune" (the archiver's only enabled
+	// non-export mode) so the inherited config actually takes effect.
+	// Back-compat alias: an operator's legacy usage aged-session archiver config
+	// (LOOMCYCLE_USAGE_RUN_RETENTION_*) drives the new retention chats family when
+	// its own knobs are unset. Inherit ONLY when the legacy archiver was GENUINELY
+	// enabled — RunRetention>0 AND a delete-bearing mode (prune|export+prune) —
+	// exactly matching the legacy runArchivalEnabled() gate. A legacy config with
+	// no/off mode was dormant (never deleted), so it must stay dormant here: never
+	// activate deletion the legacy config didn't do.
+	if cfg.Env.RetentionChatsMode == "" && cfg.Env.UsageRunRetention > 0 &&
+		(cfg.Env.UsageRunRetentionMode == "prune" || cfg.Env.UsageRunRetentionMode == "export+prune") {
+		cfg.Env.RetentionChatsMode = cfg.Env.UsageRunRetentionMode
+		cfg.Env.RetentionChatsMaxAge = cfg.Env.UsageRunRetention
+		if cfg.Env.RetentionExportDir == "" {
+			cfg.Env.RetentionExportDir = cfg.Env.UsageExportDir
 		}
 	}
 	if v := os.Getenv("LOOMCYCLE_REPLICAS_SWEEP_INTERVAL_MS"); v != "" {

--- a/internal/retention/sweeper.go
+++ b/internal/retention/sweeper.go
@@ -15,6 +15,14 @@
 // DefsMode=export+prune each version is written to ExportDir as JSON BEFORE it
 // is deleted (export-then-delete: a failed export never deletes the row), so the
 // retired history survives outside the database.
+//
+// RFC BM Phase 2 adds a second, independent family: aged CHAT sessions (a
+// session whose runs are all terminal + old, plus its runs + events), gated by
+// ChatsMode with the same off / prune / export+prune semantics and the same
+// export-then-delete guarantee. Pinned sessions are always exempt. This subsumes
+// the RFC AV Phase 2b2 aged-session archiver in internal/usage — cmd/loomcycle
+// disables that one whenever this chats sub-sweep is active so a session is never
+// deleted by two sweepers at once.
 package retention
 
 import (
@@ -52,9 +60,25 @@ type Config struct {
 	// so an explicit 0 stays meaningful.
 	DefsKeepLastN int
 
-	// ExportDir is the directory export+prune writes def JSON into (one file per
-	// version, under a per-day/per-def-type subdir). Required for export+prune;
-	// if empty, the purge is DISABLED (never delete a version we were asked to
+	// ChatsMode is the RFC BM Phase 2 aged-chat archiver mode: "off"
+	// (default / ""), "prune" (cascade-delete aged sessions + their runs +
+	// events), or "export+prune" (write each session bundle to ExportDir as JSON,
+	// then delete). Unknown → off. Independent of DefsMode — a deployment can
+	// purge defs, chats, both, or neither. This subsumes the RFC AV Phase 2b2
+	// usage-sweeper aged-session archiver (main.go disables that one when this is
+	// on so the two never double-run). A PINNED session is always exempt (the
+	// store's PrunableAgedSessions excludes it).
+	ChatsMode string
+
+	// ChatsMaxAge is the age cutoff for the chats archiver: only sessions whose
+	// most-recent completed_at is before Now()-ChatsMaxAge are eligible. Zero = no
+	// minimum age (every all-terminal, non-pinned session qualifies).
+	ChatsMaxAge time.Duration
+
+	// ExportDir is the directory export+prune writes JSON into: def versions under
+	// <ExportDir>/<day>/<def-type>/, chat sessions under <ExportDir>/chats/<day>/.
+	// Required for export+prune (defs OR chats); if empty, the corresponding
+	// export+prune purge is DISABLED (never delete something we were asked to
 	// export but can't).
 	ExportDir string
 
@@ -91,14 +115,19 @@ type AdvisoryLocker interface {
 const (
 	defaultInterval = 1 * time.Hour
 	purgeBatch      = 500   // versions purged per def-type per tick
-	reportListCap   = 10000 // DryRunCounts saturates the per-type count at this cap
+	chatsPruneBatch = 500   // aged chat sessions purged per tick
+	reportListCap   = 10000 // DryRunCounts saturates each count at this cap
 )
 
 // Result is one sweep's per-def-type + total purge count (deleted, or — under
-// DryRun — would-be-deleted).
+// DryRun — would-be-deleted), plus the aged-chat-session count.
 type Result struct {
 	PerType map[string]int
 	Total   int
+	// Chats is the number of aged chat sessions deleted (or, under DryRun,
+	// would-be-deleted) this sweep. Counted separately from the def totals above:
+	// a session is not a def version.
+	Chats int
 }
 
 // Sweeper periodically exports + purges retired-and-old substrate def versions.
@@ -109,6 +138,8 @@ type Sweeper struct {
 	defsMode      string
 	defsMaxAge    time.Duration
 	defsKeepLastN int
+	chatsMode     string
+	chatsMaxAge   time.Duration
 	exportDir     string
 	dryRun        bool
 	logf          func(format string, args ...any)
@@ -133,6 +164,10 @@ func New(st store.Store, cfg Config) *Sweeper {
 	if mode == "" {
 		mode = "off"
 	}
+	chatsMode := cfg.ChatsMode
+	if chatsMode == "" {
+		chatsMode = "off"
+	}
 	keep := cfg.DefsKeepLastN
 	if keep < 0 {
 		// Guard a negative value only. 0 is a valid explicit choice (purge all
@@ -145,6 +180,8 @@ func New(st store.Store, cfg Config) *Sweeper {
 		defsMode:      mode,
 		defsMaxAge:    cfg.DefsMaxAge,
 		defsKeepLastN: keep,
+		chatsMode:     chatsMode,
+		chatsMaxAge:   cfg.ChatsMaxAge,
 		exportDir:     cfg.ExportDir,
 		dryRun:        cfg.DryRun,
 		logf:          cfg.Logger,
@@ -167,6 +204,19 @@ func (s *Sweeper) defsPurgeEnabled() bool {
 	return false
 }
 
+// chatsPruneEnabled mirrors defsPurgeEnabled for the aged-chat archiver:
+// "prune" always, "export+prune" only with a configured ExportDir (never delete
+// a session we were asked to export but can't). "off"/unknown → false.
+func (s *Sweeper) chatsPruneEnabled() bool {
+	switch s.chatsMode {
+	case "prune":
+		return true
+	case "export+prune":
+		return s.exportDir != ""
+	}
+	return false
+}
+
 // Run drives the sweep loop until ctx is done. The first tick fires after
 // Interval (not immediately) so a fresh process doesn't purge the moment it
 // boots. Blocks — caller starts it on a goroutine.
@@ -174,10 +224,13 @@ func (s *Sweeper) Run(ctx context.Context) {
 	if s.store == nil {
 		return
 	}
-	s.logf("retention: sweeper starting (interval=%s, defs_mode=%s, defs_max_age=%s, keep_last_n=%d, dry_run=%v)",
-		s.interval, s.defsMode, s.defsMaxAge, s.defsKeepLastN, s.dryRun)
+	s.logf("retention: sweeper starting (interval=%s, defs_mode=%s, defs_max_age=%s, keep_last_n=%d, chats_mode=%s, chats_max_age=%s, dry_run=%v)",
+		s.interval, s.defsMode, s.defsMaxAge, s.defsKeepLastN, s.chatsMode, s.chatsMaxAge, s.dryRun)
 	if s.defsMode == "export+prune" && s.exportDir == "" {
 		s.logf("retention: defs purge DISABLED — mode=export+prune requires LOOMCYCLE_RETENTION_EXPORT_DIR")
+	}
+	if s.chatsMode == "export+prune" && s.exportDir == "" {
+		s.logf("retention: chats purge DISABLED — mode=export+prune requires LOOMCYCLE_RETENTION_EXPORT_DIR")
 	}
 	t := time.NewTicker(s.interval)
 	defer t.Stop()
@@ -221,16 +274,21 @@ func (s *Sweeper) Run(ctx context.Context) {
 			}
 			if err != nil {
 				s.logf("retention: sweep failed: %v", err)
-			} else if res.Total > 0 {
+			} else if res.Total > 0 || res.Chats > 0 {
 				verb := "purged"
 				if s.dryRun {
 					verb = "would purge"
 				}
-				s.logf("retention: %s %d retired def version(s) across %d type(s) (mode=%s)", verb, res.Total, len(res.PerType), s.defsMode)
+				if res.Total > 0 {
+					s.logf("retention: %s %d retired def version(s) across %d type(s) (mode=%s)", verb, res.Total, len(res.PerType), s.defsMode)
+				}
+				if res.Chats > 0 {
+					s.logf("retention: %s %d aged chat session(s) (mode=%s)", verb, res.Chats, s.chatsMode)
+				}
 				noOpStreak = 0
 			} else {
 				if noOpStreak == 0 || noOpStreak%noOpHeartbeatEvery == 0 {
-					s.logf("retention: sweep tick — 0 purgeable def versions (streak=%d)", noOpStreak)
+					s.logf("retention: sweep tick — 0 purgeable def versions / chat sessions (streak=%d)", noOpStreak)
 				}
 				noOpStreak++
 			}
@@ -238,16 +296,32 @@ func (s *Sweeper) Run(ctx context.Context) {
 	}
 }
 
-// sweepOnce runs one pass over every def-type. Exposed as a method so tests can
-// drive it deterministically without a real Ticker. A no-op when the purge is
-// disabled (mode=off, or export+prune with no ExportDir). The batch shares one
-// 2-minute deadline; per-type failures are logged and skipped so one bad type
-// never blocks the others.
+// sweepOnce runs one pass: the def-version purge (when defsPurgeEnabled) followed
+// by the aged-chat-session purge (when chatsPruneEnabled). Exposed as a method so
+// tests can drive it deterministically without a real Ticker. A no-op when both
+// are disabled. The two sub-sweeps are independent — each carries its own derived
+// deadline and its own failures are logged and skipped so neither can block the
+// other. Returns nil error even on a per-sub-sweep fault (both are logged); the
+// error slot is reserved for a future fatal condition.
 func (s *Sweeper) sweepOnce(parent context.Context) (Result, error) {
 	res := Result{PerType: map[string]int{}}
-	if !s.defsPurgeEnabled() {
-		return res, nil
+	if s.defsPurgeEnabled() {
+		s.sweepDefsOnce(parent, &res)
 	}
+	if s.chatsPruneEnabled() {
+		n, err := s.sweepChatsOnce(parent)
+		if err != nil {
+			s.logf("retention: chats sweep failed: %v", err)
+		}
+		res.Chats += n
+	}
+	return res, nil
+}
+
+// sweepDefsOnce purges one batch of retired-and-old def versions per def-type,
+// accumulating into res. The batch shares one 2-minute deadline; per-type
+// failures are logged and skipped so one bad type never blocks the others.
+func (s *Sweeper) sweepDefsOnce(parent context.Context, res *Result) {
 	ctx, cancel := context.WithTimeout(parent, 2*time.Minute)
 	defer cancel()
 	cutoff := s.now().Add(-s.defsMaxAge)
@@ -291,7 +365,54 @@ func (s *Sweeper) sweepOnce(parent context.Context) (Result, error) {
 		res.PerType[defType] += n
 		res.Total += n
 	}
-	return res, nil
+}
+
+// sweepChatsOnce archives one batch of aged chat sessions (RFC BM Phase 2): list
+// sessions whose runs are ALL terminal + old (pinned sessions are excluded by the
+// store), export each (export+prune mode) then cascade-delete it (session + runs
+// + events). Prunes by SESSION, not by run — the continuation path replays the
+// whole-session transcript, so pruning one aged run inside a still-continued
+// session would corrupt it. This subsumes usage.archiveSessionsOnce (main.go
+// disables that archiver when this sub-sweep is on so the two never double-run).
+// Own 2-minute deadline (export writes files); per-session failures are logged +
+// skipped, and the batch breaks cleanly once the shared deadline expires.
+func (s *Sweeper) sweepChatsOnce(parent context.Context) (int, error) {
+	ctx, cancel := context.WithTimeout(parent, 2*time.Minute)
+	defer cancel()
+	cutoff := s.now().Add(-s.chatsMaxAge)
+	sessions, err := s.store.PrunableAgedSessions(ctx, cutoff, chatsPruneBatch)
+	if err != nil {
+		return 0, err
+	}
+	pruned := 0
+	for _, sid := range sessions {
+		// The whole batch shares one deadline; once it expires every remaining
+		// export/DeleteSessionCascade would fail with the same ctx error — stop
+		// cleanly and return what we finished. The next tick resumes from where
+		// this one stopped (PrunableAgedSessions is re-queried).
+		if ctx.Err() != nil {
+			break
+		}
+		if s.chatsMode == "export+prune" {
+			if err := s.exportSession(ctx, sid); err != nil {
+				// Never delete a session we failed to export — retry next tick.
+				s.logf("retention: export chat session %s failed, skipping delete: %v", sid, err)
+				continue
+			}
+		}
+		if s.dryRun {
+			// Preview only: count what WOULD be deleted (export, if any, has run —
+			// mirroring the defs dry-run), touch no rows.
+			pruned++
+			continue
+		}
+		if err := s.store.DeleteSessionCascade(ctx, sid); err != nil {
+			s.logf("retention: delete chat session %s failed: %v", sid, err)
+			continue
+		}
+		pruned++
+	}
+	return pruned, nil
 }
 
 // exportDef writes one retired def version to ExportDir as JSON, under a
@@ -315,11 +436,62 @@ func (s *Sweeper) exportDef(ref store.RetiredDefRef) error {
 	return os.WriteFile(filepath.Join(dir, ref.DefID+".json"), blob, 0o600)
 }
 
-// DryRunCounts returns the per-def-type count of currently-purgeable versions
-// WITHOUT deleting anything — backing the read-only GET /v1/_retention report.
-// It reports the counts the CONFIGURED age + keep-last-N would purge regardless
-// of DefsMode (so an operator can preview impact before enabling a destructive
-// mode). Each count saturates at reportListCap.
+// exportSession writes one aged chat session (its runs + all events) to
+// <ExportDir>/chats/<day>/<sid>.json, bucketed by the session's latest completed
+// date so any single directory stays bounded. Lifted from usage.exportSession —
+// the RFC BM chats sweeper subsumes the RFC AV aged-session archiver; the
+// "chats/" segment keeps these bundles separate from the def-version exports
+// under the same ExportDir. The export dir is operator config, never model input.
+func (s *Sweeper) exportSession(ctx context.Context, sessionID string) error {
+	runs, err := s.store.RunsForSession(ctx, sessionID)
+	if err != nil {
+		return err
+	}
+	events, err := s.store.GetTranscript(ctx, sessionID)
+	if err != nil {
+		return err
+	}
+	// Bucket by the session's latest completed_at (fall back to latest start,
+	// then to now if a session somehow has no timestamps).
+	var day time.Time
+	for _, r := range runs {
+		if !r.CompletedAt.IsZero() && r.CompletedAt.After(day) {
+			day = r.CompletedAt
+		}
+	}
+	if day.IsZero() {
+		for _, r := range runs {
+			if r.StartedAt.After(day) {
+				day = r.StartedAt
+			}
+		}
+	}
+	if day.IsZero() {
+		day = s.now()
+	}
+	dir := filepath.Join(s.exportDir, "chats", day.UTC().Format("2006-01-02"))
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return err
+	}
+	payload := struct {
+		SessionID string        `json:"session_id"`
+		Runs      []store.Run   `json:"runs"`
+		Events    []store.Event `json:"events"`
+	}{SessionID: sessionID, Runs: runs, Events: events}
+	blob, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return err
+	}
+	// 0o600: run transcripts may hold sensitive tool I/O; operator-only.
+	return os.WriteFile(filepath.Join(dir, sessionID+".json"), blob, 0o600)
+}
+
+// DryRunCounts returns the count of currently-purgeable items per def-type PLUS
+// an aged-chat-session count under the "chats" key, WITHOUT deleting anything —
+// backing the read-only GET /v1/_retention report. It reports what the CONFIGURED
+// age + keep-last-N (defs) / age (chats) would purge regardless of mode (so an
+// operator can preview impact before enabling a destructive mode). Each count
+// saturates at reportListCap.
 func (s *Sweeper) DryRunCounts(ctx context.Context) (map[string]int, error) {
 	out := map[string]int{}
 	if s.store == nil {
@@ -333,5 +505,14 @@ func (s *Sweeper) DryRunCounts(ctx context.Context) (map[string]int, error) {
 		}
 		out[defType] = len(refs)
 	}
+	// Aged-chat sessions preview — mode-independent, like the def counts. Keyed
+	// "chats" (never a def-type name, so no collision). Pinned sessions are
+	// excluded by the store.
+	chatsCutoff := s.now().Add(-s.chatsMaxAge)
+	sessions, err := s.store.PrunableAgedSessions(ctx, chatsCutoff, reportListCap)
+	if err != nil {
+		return nil, err
+	}
+	out["chats"] = len(sessions)
 	return out, nil
 }

--- a/internal/retention/sweeper_test.go
+++ b/internal/retention/sweeper_test.go
@@ -1,6 +1,7 @@
 package retention
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"os"
@@ -230,5 +231,161 @@ func TestSweeper_DryRunCountsReportsPerType(t *testing.T) {
 		if counts[dt] != 0 {
 			t.Errorf("counts[%s] = %d, want 0", dt, counts[dt])
 		}
+	}
+	// No sessions seeded → the "chats" preview count is 0 (present regardless of
+	// ChatsMode, mirroring the def-type counts).
+	if counts["chats"] != 0 {
+		t.Errorf("counts[chats] = %d, want 0", counts["chats"])
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+// seedCompletedChatSession creates a session with one completed run (with an
+// event) — the aged-chat unit the chats sub-sweep prunes. Returns the session id.
+func seedCompletedChatSession(t *testing.T, st *sqlite.Store, agentID string) string {
+	t.Helper()
+	ctx := context.Background()
+	sess, err := st.CreateSession(ctx, "t", "default", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := st.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: agentID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AppendEvent(ctx, run.ID, "text", []byte(`{"t":"hi"}`)); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.FinishRun(ctx, run.ID, store.RunCompleted, "end_turn", store.Usage{Model: "m", Provider: "p"}, ""); err != nil {
+		t.Fatal(err)
+	}
+	return sess.ID
+}
+
+// futureHour pins Now() an hour ahead so a just-completed session lands before
+// the cutoff (Now()-ChatsMaxAge with the zero max-age used by these tests).
+func futureHour() time.Time { return time.Now().Add(time.Hour) }
+
+// TestSweeper_ChatsPinnedSessionNotPruned: the chats sub-sweep never deletes a
+// PINNED session (the store excludes it), while an identical unpinned aged
+// session IS pruned. Drives the whole stack against a real sqlite store.
+func TestSweeper_ChatsPinnedSessionNotPruned(t *testing.T) {
+	ctx := context.Background()
+	st, err := sqlite.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+
+	pinnedID := seedCompletedChatSession(t, st, "pinned-a")
+	unpinnedID := seedCompletedChatSession(t, st, "unpinned-a")
+	if err := st.SetSessionMeta(ctx, pinnedID, store.SessionMetaPatch{Pinned: boolPtr(true)}); err != nil {
+		t.Fatalf("pin: %v", err)
+	}
+
+	sw := New(st, Config{ChatsMode: "prune", Logger: quietLogger, Now: futureHour})
+	res, err := sw.sweepOnce(ctx)
+	if err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+	if res.Chats != 1 {
+		t.Errorf("res.Chats = %d, want 1 (only the unpinned session)", res.Chats)
+	}
+	if _, err := st.GetSession(ctx, pinnedID); err != nil {
+		t.Errorf("pinned session was pruned: %v", err)
+	}
+	if _, err := st.GetSession(ctx, unpinnedID); err == nil {
+		t.Errorf("unpinned aged session survived the prune")
+	}
+}
+
+// TestSweeper_ChatsDryRunDeletesNothing: DryRun counts the aged session but never
+// cascade-deletes it.
+func TestSweeper_ChatsDryRunDeletesNothing(t *testing.T) {
+	ctx := context.Background()
+	st, err := sqlite.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+
+	sid := seedCompletedChatSession(t, st, "dry-a")
+	sw := New(st, Config{ChatsMode: "prune", DryRun: true, Logger: quietLogger, Now: futureHour})
+	res, err := sw.sweepOnce(ctx)
+	if err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+	if res.Chats != 1 {
+		t.Errorf("res.Chats = %d, want 1 (counts what WOULD be pruned)", res.Chats)
+	}
+	if _, err := st.GetSession(ctx, sid); err != nil {
+		t.Errorf("dry-run deleted the session: %v", err)
+	}
+}
+
+// TestSweeper_ChatsExportPruneWritesBundleThenDeletes: each aged session is
+// written to <ExportDir>/chats/<day>/<sid>.json (with runs + events) before it is
+// cascade-deleted.
+func TestSweeper_ChatsExportPruneWritesBundleThenDeletes(t *testing.T) {
+	ctx := context.Background()
+	st, err := sqlite.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+
+	dir := t.TempDir()
+	sid := seedCompletedChatSession(t, st, "exp-a")
+	sw := New(st, Config{ChatsMode: "export+prune", ExportDir: dir, Logger: quietLogger, Now: futureHour})
+	res, err := sw.sweepOnce(ctx)
+	if err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+	if res.Chats != 1 {
+		t.Errorf("res.Chats = %d, want 1", res.Chats)
+	}
+	// Bundle written under <dir>/chats/<day>/<sid>.json.
+	matches, _ := filepath.Glob(filepath.Join(dir, "chats", "*", sid+".json"))
+	if len(matches) != 1 {
+		t.Fatalf("export glob = %v, want one chats/<day>/%s.json", matches, sid)
+	}
+	blob, err := os.ReadFile(matches[0])
+	if err != nil ||
+		!bytes.Contains(blob, []byte(sid)) ||
+		!bytes.Contains(blob, []byte(`"runs"`)) ||
+		!bytes.Contains(blob, []byte(`"events"`)) {
+		t.Errorf("bundle missing session_id / runs / events: err=%v", err)
+	}
+	// Deletion followed the export.
+	if _, err := st.GetSession(ctx, sid); err == nil {
+		t.Errorf("session survived export+prune")
+	}
+}
+
+// TestSweeper_ChatsExportPruneWithoutExportDirDisabled: export+prune with no
+// ExportDir is a no-op (never delete a session we can't export).
+func TestSweeper_ChatsExportPruneWithoutExportDirDisabled(t *testing.T) {
+	ctx := context.Background()
+	st, err := sqlite.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+
+	sid := seedCompletedChatSession(t, st, "noexp-a")
+	sw := New(st, Config{ChatsMode: "export+prune", Logger: quietLogger, Now: futureHour}) // no ExportDir
+	if sw.chatsPruneEnabled() {
+		t.Error("chatsPruneEnabled() = true for export+prune with empty ExportDir, want false")
+	}
+	res, err := sw.sweepOnce(ctx)
+	if err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+	if res.Chats != 0 {
+		t.Errorf("disabled chats sweep pruned %d, want 0", res.Chats)
+	}
+	if _, err := st.GetSession(ctx, sid); err != nil {
+		t.Errorf("disabled sweep deleted the session: %v", err)
 	}
 }

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -752,6 +752,11 @@ func (s *Store) RollupAndPruneUsage(ctx context.Context, olderThan time.Time) (i
 // pause_state) and its most-recent completed_at is before olderThan — so an aged
 // run inside a still-active session is never pruned out from under a
 // continuation's whole-session transcript replay.
+//
+// A PINNED session (sessions.pinned) is never returned — pinning is the
+// operator's explicit "keep this" and must exempt the chat from ALL automated
+// retention paths (RFC BM Phase 2 chats sweeper + the legacy RFC AV archiver,
+// both of which consume this list).
 func (s *Store) PrunableAgedSessions(ctx context.Context, olderThan time.Time, limit int) ([]string, error) {
 	if limit <= 0 {
 		limit = 500
@@ -764,6 +769,7 @@ func (s *Store) PrunableAgedSessions(ctx context.Context, olderThan time.Time, l
 		                 THEN 1 ELSE 0 END) = 0
 		    AND MAX(completed_at) IS NOT NULL
 		    AND MAX(completed_at) < $4
+		    AND session_id NOT IN (SELECT id FROM sessions WHERE pinned = TRUE)
 		 ORDER BY MAX(completed_at) ASC
 		 LIMIT $5`,
 		string(store.RunCompleted), string(store.RunFailed), string(store.RunCancelled),

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -1674,6 +1674,11 @@ func (s *Store) RollupAndPruneUsage(ctx context.Context, olderThan time.Time) (i
 // pause_state) and its most-recent completed_at is before olderThan — so an
 // aged run inside a still-active session is never pruned out from under a
 // continuation's whole-session transcript replay.
+//
+// A PINNED session (sessions.pinned = 1) is never returned — pinning is the
+// operator's explicit "keep this" and must exempt the chat from ALL automated
+// retention paths (RFC BM Phase 2 chats sweeper + the legacy RFC AV archiver,
+// both of which consume this list).
 func (s *Store) PrunableAgedSessions(ctx context.Context, olderThan time.Time, limit int) ([]string, error) {
 	if limit <= 0 {
 		limit = 500
@@ -1686,6 +1691,7 @@ func (s *Store) PrunableAgedSessions(ctx context.Context, olderThan time.Time, l
 		                 THEN 1 ELSE 0 END) = 0
 		    AND MAX(completed_at) IS NOT NULL
 		    AND MAX(completed_at) < ?
+		    AND session_id NOT IN (SELECT id FROM sessions WHERE pinned = 1)
 		 ORDER BY MAX(completed_at) ASC
 		 LIMIT ?`,
 		string(store.RunCompleted), string(store.RunFailed), string(store.RunCancelled),

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -998,7 +998,10 @@ type Store interface {
 	// capped at limit. The archiver (RFC AV Phase 2b2) prunes by SESSION, not by
 	// run — the continuation path replays GetTranscript(session_id) (all runs),
 	// so pruning one aged run inside a still-continued session would corrupt the
-	// transcript. A session with any non-terminal run is never returned.
+	// transcript. A session with any non-terminal run is never returned. A PINNED
+	// session (sessions.pinned) is likewise never returned — pinning exempts a
+	// chat from ALL automated retention (the RFC BM chats sweeper + this legacy
+	// RFC AV archiver both consume this list).
 	PrunableAgedSessions(ctx context.Context, olderThan time.Time, limit int) ([]string, error)
 
 	// RunsForSession returns every run in the session (any status), oldest first.

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -376,6 +376,9 @@ func Run(t *testing.T, factory Factory) {
 		// incl. nullable tiers.
 		{"TokenLimits", testTokenLimits},
 		{"SessionArchiver", testSessionArchiver},
+		// RFC BM Phase 2: a PINNED session is exempt from PrunableAgedSessions
+		// (all automated retention). Fails on the pre-fix query (no exclusion).
+		{"PrunableAgedSessionsExcludesPinned", testPrunableAgedSessionsExcludesPinned},
 		// RFC AF (v1.0.1): the cluster hook registry persists the
 		// authoritative tenant_id. Exercises the new column's INSERT/SELECT
 		// ordinals on a REAL backend (the go-postgres CI job) — SQLite skips
@@ -1164,6 +1167,55 @@ func testSessionArchiver(t *testing.T, s store.Store) {
 	// Session B untouched.
 	if _, err := s.GetRun(ctx, runB2.ID); err != nil {
 		t.Errorf("session B run was affected: %v", err)
+	}
+}
+
+// testPrunableAgedSessionsExcludesPinned is the RFC BM Phase 2 pinned-exemption
+// regression: a PINNED session, even when all its runs are terminal + old, must
+// NEVER be returned by PrunableAgedSessions — pinning is the operator's explicit
+// "keep this" and exempts the chat from ALL automated retention (the chats
+// sweeper AND the legacy usage archiver both consume this list). An identical
+// UNpinned session in the same state IS returned. Fails on the pre-fix query
+// (no pinned exclusion) — the pinned session would appear in the prunable set.
+func testPrunableAgedSessionsExcludesPinned(t *testing.T, s store.Store) {
+	ctx := context.Background()
+
+	// Two sessions, each with one completed run — identical except one is pinned.
+	mkAged := func(agentID string) string {
+		sess, err := s.CreateSession(ctx, "t", "default", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		run, err := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: agentID})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := s.FinishRun(ctx, run.ID, store.RunCompleted, "end_turn", store.Usage{Model: "m", Provider: "p"}, ""); err != nil {
+			t.Fatal(err)
+		}
+		return sess.ID
+	}
+	pinnedID := mkAged("pinned-a")
+	unpinnedID := mkAged("unpinned-a")
+	if err := s.SetSessionMeta(ctx, pinnedID, store.SessionMetaPatch{Pinned: boolPtr(true)}); err != nil {
+		t.Fatalf("SetSessionMeta pin: %v", err)
+	}
+
+	// A future cutoff → both sessions are all-terminal and old enough to qualify;
+	// only the pinned exemption should keep the pinned one out.
+	got, err := s.PrunableAgedSessions(ctx, time.Now().Add(time.Hour), 100)
+	if err != nil {
+		t.Fatalf("PrunableAgedSessions: %v", err)
+	}
+	ids := map[string]bool{}
+	for _, id := range got {
+		ids[id] = true
+	}
+	if ids[pinnedID] {
+		t.Errorf("pinned session %s returned as prunable; pinning must exempt it from all retention: %v", pinnedID, got)
+	}
+	if !ids[unpinnedID] {
+		t.Errorf("unpinned aged session %s missing from prunable set: %v", unpinnedID, got)
 	}
 }
 

--- a/internal/usage/sweeper.go
+++ b/internal/usage/sweeper.go
@@ -65,6 +65,14 @@ type Config struct {
 	// archival is disabled (never delete a session we were asked to export).
 	ExportDir string
 
+	// DisableRunArchiver, when true, suppresses the opt-in aged-SESSION archiver
+	// (archiveSessionsOnce) even if RunRetention/RunRetentionMode/ExportDir would
+	// otherwise enable it. The usage-detail RollupAndPruneUsage still runs — only
+	// session archival is disabled. Set by cmd/loomcycle when the RFC BM retention
+	// sweeper owns aged-chat pruning, so a session is never cascade-deleted by
+	// both sweepers at once (RFC BM Phase 2 reconciliation).
+	DisableRunArchiver bool
+
 	// Logger is the structured logger used for sweep results. Defaults
 	// to log.Printf when nil. Errors are logged at every tick;
 	// successful sweeps with zero rows are logged only periodically
@@ -111,16 +119,17 @@ const (
 // deletes them, and (opt-in) archives aged sessions. Construct via New,
 // then call Run(ctx) on a goroutine that owns the lifecycle.
 type Sweeper struct {
-	store           store.Store
-	interval        time.Duration
-	detailRetention time.Duration
-	runRetention    time.Duration
-	runMode         string
-	exportDir       string
-	logf            func(format string, args ...any)
-	lock            AdvisoryLocker
-	lockKey         int64
-	now             func() time.Time
+	store              store.Store
+	interval           time.Duration
+	detailRetention    time.Duration
+	runRetention       time.Duration
+	runMode            string
+	exportDir          string
+	disableRunArchiver bool
+	logf               func(format string, args ...any)
+	lock               AdvisoryLocker
+	lockKey            int64
+	now                func() time.Time
 }
 
 // New constructs a Sweeper with the supplied tuning. A nil store means
@@ -144,23 +153,28 @@ func New(st store.Store, cfg Config) *Sweeper {
 		mode = "off"
 	}
 	return &Sweeper{
-		store:           st,
-		interval:        cfg.Interval,
-		detailRetention: cfg.DetailRetention,
-		runRetention:    cfg.RunRetention,
-		runMode:         mode,
-		exportDir:       cfg.ExportDir,
-		logf:            cfg.Logger,
-		lock:            cfg.AdvisoryLock,
-		lockKey:         cfg.AdvisoryLockKey,
-		now:             cfg.Now,
+		store:              st,
+		interval:           cfg.Interval,
+		detailRetention:    cfg.DetailRetention,
+		runRetention:       cfg.RunRetention,
+		runMode:            mode,
+		exportDir:          cfg.ExportDir,
+		disableRunArchiver: cfg.DisableRunArchiver,
+		logf:               cfg.Logger,
+		lock:               cfg.AdvisoryLock,
+		lockKey:            cfg.AdvisoryLockKey,
+		now:                cfg.Now,
 	}
 }
 
 // runArchivalEnabled reports whether the opt-in old-run archiver should run:
-// a positive RunRetention, a delete-bearing mode, and — for export+prune — a
-// configured ExportDir (never delete a run we were asked to export but can't).
+// not explicitly disabled (the RFC BM retention sweeper owns chats), a positive
+// RunRetention, a delete-bearing mode, and — for export+prune — a configured
+// ExportDir (never delete a run we were asked to export but can't).
 func (s *Sweeper) runArchivalEnabled() bool {
+	if s.disableRunArchiver {
+		return false
+	}
 	if s.runRetention <= 0 {
 		return false
 	}


### PR DESCRIPTION
## Why
RFC BM P2 extends the [P1 (#796)](https://github.com/denn-gubsky/loomcycle/pull/796) retention sweeper with a **chats family** — aged sessions + their runs + events — reusing the existing prune path and reconciling with the pre-existing usage aged-session archiver so they never double-run.

## What
- **Chats sub-sweep** (`internal/retention`): `sweepOnce` orchestrates `sweepDefsOnce` (byte-identical) + `sweepChatsOnce` — `PrunableAgedSessions(cutoff, 500)` → export (export+prune writes the session+runs+events bundle to `ExportDir/chats/YYYY-MM-DD/<sid>.json`, 0600, skip-delete-on-export-failure) → `DeleteSessionCascade`; own 2-min deadline; DryRun suppresses only the delete. Config gains `ChatsMode` (off|prune|export+prune) + `ChatsMaxAge`; `Result` gains `Chats`; `DryRunCounts` reports a mode-independent `chats` count.
- **Pinned exemption** (store, both backends): `PrunableAgedSessions` now excludes `session_id NOT IN (SELECT id FROM sessions WHERE pinned)` — a pinned chat is **never** auto-pruned by any retention path (also protects the legacy usage archiver). Literal predicate → placeholder numbering unchanged. Contract case `testPrunableAgedSessionsExcludesPinned`.
- **Back-compat alias** (config): legacy `LOOMCYCLE_USAGE_RUN_RETENTION_*` drives `retention.chats` when its own knobs are unset — **but only when the legacy archiver was genuinely enabled** (RunRetention>0 AND a delete-bearing mode, matching the old gate). A dormant legacy config stays dormant — never activates deletion it didn't do before. *(Reviewer fix: the initial draft mapped an empty mode → prune, which would have activated deletion; corrected.)*
- **Double-run reconciliation**: `usage.Config.DisableRunArchiver` — when retention owns chats, main.go sets it so the usage sweeper skips session archival (its usage-detail rollup still runs); only the retention sweeper prunes. Retention off ⇒ usage archiver unchanged.
- **Report**: `GET /v1/_retention` gains chats mode/max_age (tenant-readable) + `purgeable["chats"]` (admin-only).

## Review notes
I delegated the mechanical build (airtight no-git spec) then reviewed: **fixed the alias back-compat semantic** (above) and **ran the Postgres contract myself** — `PrunableAgedSessionsExcludesPinned` + `RetentionPurgeDefVersions` + `SessionArchiver` all PASS on real PG (confirming the pinned change doesn't regress the existing archiver). Both new regressions proven fail-before.

## Tested
sqlite + Postgres contract green; `retention`/`usage`/`config`/`api/http` suites green; `go build ./...` + gofmt clean.

RFC BM arc: P1 defs #796 ✅ · **P2 chats this PR** · P3 = memory-scope reclamation + SQL-Memory GC surfacing + documents age/MD-export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)