### PR TITLE
feat(retention): RFC BM P3 — retired-agent memory-scope reclamation

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -2377,8 +2377,13 @@ func main() {
 	// sweeper owns aged-chat pruning — suppress the usage sweeper's legacy
 	// aged-session archiver so a session is never cascade-deleted by both. The
 	// usage-detail rollup is unaffected.
-	retentionOwnsChats := cfg.Env.RetentionEnabled &&
-		cfg.Env.RetentionChatsMode != "" && cfg.Env.RetentionChatsMode != "off"
+	// Only suppress the legacy usage archiver when the retention chats sweep will
+	// ACTUALLY run — mirror retention's chatsPruneEnabled gate (export+prune needs
+	// an ExportDir). Otherwise a misconfigured export+prune-without-dir would
+	// disable BOTH paths, silently leaving aged chats unpruned.
+	retentionChatsActive := cfg.Env.RetentionChatsMode == "prune" ||
+		(cfg.Env.RetentionChatsMode == "export+prune" && cfg.Env.RetentionExportDir != "")
+	retentionOwnsChats := cfg.Env.RetentionEnabled && retentionChatsActive
 	if cfg.Env.UsageSweeperEnabled && storeIface != nil {
 		uCfg := usage.Config{
 			Interval:        cfg.Env.UsageSweepInterval,

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1681,6 +1681,9 @@ func main() {
 	// SEPARATE from the main store — an agent's arbitrary SQL can only ever
 	// reach its own scope file. Wired into the Memory tool (sql_query/sql_exec)
 	// and the server (run-scope drop at top-level run completion).
+	// Declared here (not inside the block) so the RFC BM retention sweeper below
+	// can reclaim a retired agent's SQL-Memory scope; nil when SQL Memory is off.
+	var sqlMemMgr *sqlmem.Manager
 	if cfg.Storage.SqlMemEnabled {
 		sqlMemRoot := cfg.Storage.SqlMemRoot
 		if sqlMemRoot == "" {
@@ -1705,7 +1708,6 @@ func main() {
 		// sqlite deploy gets file-per-scope. The aux DSN is required on
 		// postgres and ignored on sqlite.
 		var (
-			sqlMemMgr  *sqlmem.Manager
 			smErr      error
 			sqlMemTier string
 		)
@@ -2415,7 +2417,16 @@ func main() {
 			// from the legacy LOOMCYCLE_USAGE_RUN_RETENTION_* config in cfg.Load).
 			ChatsMode:   cfg.Env.RetentionChatsMode,
 			ChatsMaxAge: cfg.Env.RetentionChatsMaxAge,
-			ExportDir:   cfg.Env.RetentionExportDir,
+			// RFC BM Phase 3 retired-agent memory reclamation (opt-in; default OFF).
+			MemMode:   cfg.Env.RetentionMemMode,
+			MemMaxAge: cfg.Env.RetentionMemMaxAge,
+			ExportDir: cfg.Env.RetentionExportDir,
+		}
+		// SQL-Memory scope reclamation needs the manager; nil (SQL Memory off) is
+		// fine — the mem sweep then reclaims base memory + dirents only. Typed-nil
+		// guard: only assign the interface field from a non-nil pointer.
+		if sqlMemMgr != nil {
+			rCfg.SQLMem = sqlMemMgr
 		}
 		// Same typed-nil guard as the usage block: only assign the interface field
 		// from a non-nil pointer, or the sweeper's nil-check would see a non-nil

--- a/internal/api/http/retention_report.go
+++ b/internal/api/http/retention_report.go
@@ -31,11 +31,30 @@ type retentionReportResponse struct {
 	// after the legacy LOOMCYCLE_USAGE_RUN_RETENTION_* alias in config.Load.
 	ChatsMode     string `json:"chats_mode"`
 	ChatsMaxAgeMS int64  `json:"chats_max_age_ms"`
-	ExportDir     string `json:"export_dir,omitempty"`
+	// MemMode / MemMaxAgeMS are the RFC BM Phase 3 retired-agent memory-reclamation
+	// knobs (config only — tenant-readable).
+	MemMode     string `json:"mem_mode"`
+	MemMaxAgeMS int64  `json:"mem_max_age_ms"`
+	ExportDir   string `json:"export_dir,omitempty"`
 	// Purgeable is the per-def-type count of versions the CURRENT age + keep-last-N
-	// settings would purge right now, plus an aged-chat-session count under the
-	// "chats" key (both regardless of mode — a preview). Admin-only.
+	// settings would purge right now, plus an aged-chat-session count under "chats"
+	// and a retired-agent memory-reclamation count under "mem" (all regardless of
+	// mode — a preview). Admin-only.
 	Purgeable map[string]int `json:"purgeable,omitempty"`
+	// SQLMemGC surfaces the SEPARATE always-on SQL-Memory garbage collector (RFC AA
+	// Phase 3d/3f — idle-TTL + size-budget eviction of durable scopes), so an
+	// operator sees the full retention picture in one place. Admin-only (an
+	// operator-global infra subsystem, like export_dir).
+	SQLMemGC *sqlMemGCInfo `json:"sqlmem_gc,omitempty"`
+}
+
+// sqlMemGCInfo is the admin-only view of the SQL-Memory GC config. Enabled is
+// true when either eviction trigger is armed (idle-TTL OR size-budget).
+type sqlMemGCInfo struct {
+	Enabled       bool  `json:"enabled"`
+	ScopeTTLMS    int   `json:"scope_ttl_ms"`
+	IntervalMS    int   `json:"interval_ms"`
+	TotalMaxBytes int64 `json:"total_max_bytes"`
 }
 
 // handleRetentionReport serves GET /v1/_retention — the read-only view of the
@@ -62,6 +81,10 @@ func (s *Server) handleRetentionReport(w http.ResponseWriter, r *http.Request) {
 	if chatsMode == "" {
 		chatsMode = "off"
 	}
+	memMode := s.cfg.Env.RetentionMemMode
+	if memMode == "" {
+		memMode = "off"
+	}
 	resp := retentionReportResponse{
 		Admin:         admin,
 		Enabled:       s.cfg.Env.RetentionEnabled,
@@ -71,6 +94,8 @@ func (s *Server) handleRetentionReport(w http.ResponseWriter, r *http.Request) {
 		DefsKeepLastN: s.cfg.Env.RetentionDefsKeepLastN,
 		ChatsMode:     chatsMode,
 		ChatsMaxAgeMS: s.cfg.Env.RetentionChatsMaxAge.Milliseconds(),
+		MemMode:       memMode,
+		MemMaxAgeMS:   s.cfg.Env.RetentionMemMaxAge.Milliseconds(),
 	}
 
 	if s.store == nil {
@@ -85,20 +110,40 @@ func (s *Server) handleRetentionReport(w http.ResponseWriter, r *http.Request) {
 	// purgeable counts.
 	if admin {
 		resp.ExportDir = s.cfg.Env.RetentionExportDir
-		sw := retention.New(s.store, retention.Config{
+		rCfg := retention.Config{
 			DefsMode:      mode,
 			DefsMaxAge:    s.cfg.Env.RetentionDefsMaxAge,
 			DefsKeepLastN: s.cfg.Env.RetentionDefsKeepLastN,
 			ChatsMode:     chatsMode,
 			ChatsMaxAge:   s.cfg.Env.RetentionChatsMaxAge,
+			MemMode:       memMode,
+			MemMaxAge:     s.cfg.Env.RetentionMemMaxAge,
 			ExportDir:     s.cfg.Env.RetentionExportDir,
-		})
+		}
+		// Feed the SQL-Memory manager so the "mem" preview can see which agents
+		// have an SQL-Memory scope. Typed-nil guard (nil pointer → nil interface).
+		if s.sqlMem != nil {
+			rCfg.SQLMem = s.sqlMem
+		}
+		sw := retention.New(s.store, rCfg)
 		counts, err := sw.DryRunCounts(r.Context())
 		if err != nil {
 			writeJSONError(w, http.StatusInternalServerError, "internal", err.Error())
 			return
 		}
 		resp.Purgeable = counts
+
+		// Surface the separate SQL-Memory GC (RFC AA) as infra context.
+		gcInterval := s.cfg.Storage.SqlMemGCIntervalMS
+		if gcInterval == 0 && (s.cfg.Storage.SqlMemScopeTTLMS > 0 || s.cfg.Storage.SqlMemTotalMaxBytes > 0) {
+			gcInterval = int(time.Hour.Milliseconds()) // the sqlmem default
+		}
+		resp.SQLMemGC = &sqlMemGCInfo{
+			Enabled:       s.cfg.Storage.SqlMemScopeTTLMS > 0 || s.cfg.Storage.SqlMemTotalMaxBytes > 0,
+			ScopeTTLMS:    s.cfg.Storage.SqlMemScopeTTLMS,
+			IntervalMS:    gcInterval,
+			TotalMaxBytes: s.cfg.Storage.SqlMemTotalMaxBytes,
+		}
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2366,6 +2366,16 @@ type Env struct {
 	// is exported (per the mode) and cascade-deleted. 0 = no minimum age.
 	// Env: LOOMCYCLE_RETENTION_CHATS_MAX_AGE_MS.
 	RetentionChatsMaxAge time.Duration
+	// RetentionMemMode is the RFC BM Phase 3 retired-agent memory-reclamation
+	// mode: "off" (default / "") | "prune" | "export+prune". Reclaims a
+	// fully-retired agent's SQL-Memory scope + dirents (per tenant) and its
+	// base-memory k/v (only when the name is retired in every tenant). Independent
+	// of RetentionDefsMode/RetentionChatsMode. Env: LOOMCYCLE_RETENTION_MEM_MODE.
+	RetentionMemMode string
+	// RetentionMemMaxAge is the age cutoff for memory reclamation: an agent whose
+	// latest def version was updated before now-this is eligible. 0 = no minimum
+	// age. Env: LOOMCYCLE_RETENTION_MEM_MAX_AGE_MS.
+	RetentionMemMaxAge time.Duration
 	// ReplicasSweepInterval is the dead-replica reaper's tick rate.
 	// Default 60s. Tunable mostly for tests / crash-recovery load
 	// experiments — leave at default in production.
@@ -3335,6 +3345,15 @@ func LoadLayers(layers ...Layer) (*Config, error) {
 		cfg.Env.RetentionChatsMaxAge = cfg.Env.UsageRunRetention
 		if cfg.Env.RetentionExportDir == "" {
 			cfg.Env.RetentionExportDir = cfg.Env.UsageExportDir
+		}
+	}
+	// RFC BM Phase 3 retired-agent memory reclamation (opt-in; default OFF).
+	if v := os.Getenv("LOOMCYCLE_RETENTION_MEM_MODE"); v != "" {
+		cfg.Env.RetentionMemMode = v
+	}
+	if v := os.Getenv("LOOMCYCLE_RETENTION_MEM_MAX_AGE_MS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.Env.RetentionMemMaxAge = time.Duration(n) * time.Millisecond
 		}
 	}
 	if v := os.Getenv("LOOMCYCLE_REPLICAS_SWEEP_INTERVAL_MS"); v != "" {

--- a/internal/retention/sweeper.go
+++ b/internal/retention/sweeper.go
@@ -28,6 +28,7 @@ package retention
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -375,15 +376,25 @@ func (s *Sweeper) Run(ctx context.Context) {
 	}
 }
 
-// sweepOnce runs one pass: the def-version purge (when defsPurgeEnabled) followed
-// by the aged-chat-session purge (when chatsPruneEnabled). Exposed as a method so
-// tests can drive it deterministically without a real Ticker. A no-op when both
-// are disabled. The two sub-sweeps are independent — each carries its own derived
-// deadline and its own failures are logged and skipped so neither can block the
-// other. Returns nil error even on a per-sub-sweep fault (both are logged); the
-// error slot is reserved for a future fatal condition.
+// sweepOnce runs one pass. The MEM reclaim runs FIRST, before the def-version
+// purge: the mem sweep identifies a fully-retired agent via AgentDefListNames, so
+// it must run while the agent's def rows still exist — otherwise a same-tick defs
+// purge with keep_last_n=0 could remove the agent's last version and orphan its
+// SQL-Memory scope + base memory + dirents (nothing left to key the reclaim off).
+// Chats is independent of both. Exposed as a method so tests can drive it without
+// a real Ticker. A no-op when all three are disabled. Each sub-sweep carries its
+// own derived deadline and logs+skips its own failures so none blocks the others.
+// Returns nil error even on a per-sub-sweep fault (all are logged); the error
+// slot is reserved for a future fatal condition.
 func (s *Sweeper) sweepOnce(parent context.Context) (Result, error) {
 	res := Result{PerType: map[string]int{}}
+	if s.memReclaimEnabled() {
+		n, err := s.sweepMemOnce(parent)
+		if err != nil {
+			s.logf("retention: mem sweep failed: %v", err)
+		}
+		res.Mem += n
+	}
 	if s.defsPurgeEnabled() {
 		s.sweepDefsOnce(parent, &res)
 	}
@@ -393,13 +404,6 @@ func (s *Sweeper) sweepOnce(parent context.Context) (Result, error) {
 			s.logf("retention: chats sweep failed: %v", err)
 		}
 		res.Chats += n
-	}
-	if s.memReclaimEnabled() {
-		n, err := s.sweepMemOnce(parent)
-		if err != nil {
-			s.logf("retention: mem sweep failed: %v", err)
-		}
-		res.Mem += n
 	}
 	return res, nil
 }
@@ -587,16 +591,6 @@ func (s *Sweeper) memEligible(ctx context.Context) (pass1 []memTarget, pass2 []s
 		}
 	}
 
-	// Names that actually hold base-memory k/v (so pass 2 skips names with none).
-	baseMemNames := map[string]bool{}
-	if ids, merr := s.store.MemoryListScopeIDs(ctx, store.MemoryScopeAgent); merr != nil {
-		s.logf("retention: mem sweep — list agent memory scopes failed: %v", merr)
-	} else {
-		for _, x := range ids {
-			baseMemNames[x.ScopeID] = true
-		}
-	}
-
 	// Per-name aggregate for the globally-dead base-memory gate: a name is
 	// globally dead iff EVERY (tenant, name) row is fully retired; newest is the
 	// most-recent LastUpdated across all its tenant rows.
@@ -630,12 +624,28 @@ func (s *Sweeper) memEligible(ctx context.Context) (pass1 []memTarget, pass2 []s
 			hasSQL: sqlScopes[[2]string{sm.TenantID, sm.Name}],
 		})
 	}
+	// Pass 2 = every globally-dead + old name. We deliberately do NOT pre-filter
+	// on "has base memory": the only listing available (MemoryListScopeIDs) is
+	// capped at the 200 most-RECENTLY-updated scopes, and a retired agent's memory
+	// is stale by definition — it would sort out of that window and be skipped
+	// forever. reclaimBaseMemory instead calls MemoryDeleteScope directly (a
+	// no-op returning 0 for a name with no memory), and the report probes each
+	// name for existence, so neither depends on the 200-cap.
 	for name, agg := range byName {
-		if agg.allDead && agg.newest.Before(cutoff) && baseMemNames[name] {
+		if agg.allDead && agg.newest.Before(cutoff) {
 			pass2 = append(pass2, name)
 		}
 	}
 	return pass1, pass2, nil
+}
+
+// hasBaseMemory reports whether a name holds ANY base-memory k/v, via a limit-1
+// existence probe (NOT MemoryListScopeIDs, which is capped at the 200
+// most-recently-updated scopes and so would miss a stale retired agent). Used by
+// the dry-run + report count so they match what the real sweep would drop.
+func (s *Sweeper) hasBaseMemory(ctx context.Context, name string) bool {
+	entries, _, err := s.store.MemoryList(ctx, store.MemoryScopeAgent, name, "", 1)
+	return err == nil && len(entries) > 0
 }
 
 // reclaimAgentScope drops one fully-retired agent's TENANT-QUALIFIED per-scope
@@ -696,7 +706,7 @@ func (s *Sweeper) reclaimAgentScope(ctx context.Context, tenant, name string, ha
 // the entries first. Under DryRun it reports would-reclaim without touching rows.
 func (s *Sweeper) reclaimBaseMemory(ctx context.Context, name string) bool {
 	if s.dryRun {
-		return true // caller already confirmed baseMemNames[name]
+		return s.hasBaseMemory(ctx, name) // count only names that actually have memory
 	}
 	if s.memMode == "export+prune" {
 		if err := s.exportBaseMemory(ctx, name); err != nil {
@@ -737,15 +747,17 @@ func (s *Sweeper) exportDirents(ctx context.Context, tenant, name string) error 
 
 // exportBaseMemory dumps one globally-dead agent's base-memory k/v before it is
 // deleted. Bucketed under agent-memory/ with NO tenant segment (base memory is
-// cross-tenant-shared). Warns (but still exports what it read) if the entry set
-// is truncated at the cap.
+// cross-tenant-shared). If the entry set is truncated at the cap, it returns an
+// ERROR so the caller skips the delete — export-then-delete must never delete
+// more than it exported. Such an agent (>memExportKeyCap keys) is retried each
+// tick, staying put with a loud warning rather than losing the un-exported tail.
 func (s *Sweeper) exportBaseMemory(ctx context.Context, name string) error {
 	entries, truncated, err := s.store.MemoryList(ctx, store.MemoryScopeAgent, name, "", memExportKeyCap)
 	if err != nil {
 		return err
 	}
 	if truncated {
-		s.logf("retention: agent memory %q export truncated at %d keys — exported bundle is incomplete", name, memExportKeyCap)
+		return fmt.Errorf("agent memory %q exceeds the %d-key export cap — refusing to delete more than exported", name, memExportKeyCap)
 	}
 	if len(entries) == 0 {
 		return nil
@@ -906,7 +918,17 @@ func (s *Sweeper) countReclaimableMem(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	count := len(pass2) // pass 2 is gated on baseMemNames — each has memory to drop
+	count := 0
+	// Pass 2: count only names that actually hold base memory (probe, not the
+	// 200-capped MemoryListScopeIDs).
+	for _, name := range pass2 {
+		if count >= reportListCap {
+			break
+		}
+		if s.hasBaseMemory(ctx, name) {
+			count++
+		}
+	}
 	for _, t := range pass1 {
 		if count >= reportListCap {
 			break

--- a/internal/retention/sweeper.go
+++ b/internal/retention/sweeper.go
@@ -31,10 +31,28 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 )
+
+// SQLMemory is the minimal internal/sqlmem.Manager surface the RFC BM Phase 3
+// memory-reclamation sweep needs. Defined as an interface so tests can inject a
+// fake and so a nil Manager (SQL Memory disabled) cleanly disables only the
+// SQL-Memory facet of reclamation (base memory + dirents still reclaim).
+// *sqlmem.Manager satisfies it.
+type SQLMemory interface {
+	// ListScopes enumerates every DURABLE (agent/user) scope. Used to gate
+	// export+drop on a scope that actually EXISTS (ExportScope would otherwise
+	// provision an empty scope for an agent that never used SQL Memory).
+	ListScopes(ctx context.Context) ([]sqlmem.ScopeKey, error)
+	// ExportScope returns a logical dump of one scope (export-then-delete).
+	ExportScope(ctx context.Context, key sqlmem.ScopeKey) (*sqlmem.ScopeDump, error)
+	// DropScope drops one durable scope. removed reports whether it existed.
+	DropScope(ctx context.Context, key sqlmem.ScopeKey) (bool, error)
+}
 
 // Config carries the sweeper's tuning knobs. Zero/missing values fall back to
 // the defaults documented per-field.
@@ -75,6 +93,28 @@ type Config struct {
 	// minimum age (every all-terminal, non-pinned session qualifies).
 	ChatsMaxAge time.Duration
 
+	// MemMode is the RFC BM Phase 3 memory-reclamation mode: "off" (default / ""),
+	// "prune" (reclaim a fully-retired agent's per-scope data), or "export+prune"
+	// (dump each facet to ExportDir as JSON, then reclaim). Unknown → off.
+	// Independent of DefsMode/ChatsMode. Reclaims THREE facets of a fully-retired
+	// (LiveVersionCount==0) + old agent: its SQL-Memory scope (SQL tables +
+	// document structure) and its dirents (Path names) — both tenant-qualified, so
+	// dropped per (tenant, name) — plus its base-memory k/v (chunk bodies +
+	// learned facts), which is keyed by the BARE agent name (the memory table has
+	// no tenant column), so it is only dropped when the name is retired in EVERY
+	// tenant (globally dead) to avoid deleting a live same-named agent's memory.
+	MemMode string
+
+	// MemMaxAge is the age cutoff for reclamation: an agent whose latest def
+	// version was updated before Now()-MemMaxAge is eligible. Zero = no minimum age
+	// (every fully-retired agent qualifies). Uses AgentDefNameSummary.LastUpdated.
+	MemMaxAge time.Duration
+
+	// SQLMem is the SQL Memory manager (nil when SQL Memory is disabled). When nil
+	// the mem sweep still reclaims base memory + dirents; only the SQL-Memory scope
+	// drop is skipped. Interface-typed for testability.
+	SQLMem SQLMemory
+
 	// ExportDir is the directory export+prune writes JSON into: def versions under
 	// <ExportDir>/<day>/<def-type>/, chat sessions under <ExportDir>/chats/<day>/.
 	// Required for export+prune (defs OR chats); if empty, the corresponding
@@ -114,9 +154,11 @@ type AdvisoryLocker interface {
 
 const (
 	defaultInterval = 1 * time.Hour
-	purgeBatch      = 500   // versions purged per def-type per tick
-	chatsPruneBatch = 500   // aged chat sessions purged per tick
-	reportListCap   = 10000 // DryRunCounts saturates each count at this cap
+	purgeBatch      = 500     // versions purged per def-type per tick
+	chatsPruneBatch = 500     // aged chat sessions purged per tick
+	memReclaimBatch = 500     // retired-agent reclamations per pass per tick
+	memExportKeyCap = 1000000 // max base-memory keys exported per agent (safety cap)
+	reportListCap   = 10000   // DryRunCounts saturates each count at this cap
 )
 
 // Result is one sweep's per-def-type + total purge count (deleted, or — under
@@ -128,6 +170,13 @@ type Result struct {
 	// would-be-deleted) this sweep. Counted separately from the def totals above:
 	// a session is not a def version.
 	Chats int
+	// Mem is the number of retired-agent reclamation UNITS this sweep (or, under
+	// DryRun, would-be). A unit is one (tenant, name) whose SQL-Memory scope
+	// and/or dirents were dropped, PLUS one per name whose globally-dead base
+	// memory was dropped — so a single agent that has both a tenant scope and
+	// globally-dead base memory counts as two units. It is an activity gauge, not
+	// an agent count.
+	Mem int
 }
 
 // Sweeper periodically exports + purges retired-and-old substrate def versions.
@@ -140,6 +189,9 @@ type Sweeper struct {
 	defsKeepLastN int
 	chatsMode     string
 	chatsMaxAge   time.Duration
+	memMode       string
+	memMaxAge     time.Duration
+	sqlMem        SQLMemory
 	exportDir     string
 	dryRun        bool
 	logf          func(format string, args ...any)
@@ -168,6 +220,10 @@ func New(st store.Store, cfg Config) *Sweeper {
 	if chatsMode == "" {
 		chatsMode = "off"
 	}
+	memMode := cfg.MemMode
+	if memMode == "" {
+		memMode = "off"
+	}
 	keep := cfg.DefsKeepLastN
 	if keep < 0 {
 		// Guard a negative value only. 0 is a valid explicit choice (purge all
@@ -182,6 +238,9 @@ func New(st store.Store, cfg Config) *Sweeper {
 		defsKeepLastN: keep,
 		chatsMode:     chatsMode,
 		chatsMaxAge:   cfg.ChatsMaxAge,
+		memMode:       memMode,
+		memMaxAge:     cfg.MemMaxAge,
+		sqlMem:        cfg.SQLMem,
 		exportDir:     cfg.ExportDir,
 		dryRun:        cfg.DryRun,
 		logf:          cfg.Logger,
@@ -217,6 +276,20 @@ func (s *Sweeper) chatsPruneEnabled() bool {
 	return false
 }
 
+// memReclaimEnabled mirrors defsPurgeEnabled for the RFC BM Phase 3
+// memory-reclamation sweep: "prune" always, "export+prune" only with a
+// configured ExportDir. "off"/unknown → false. Independent of SQLMem being set —
+// base memory + dirents reclaim even with SQL Memory disabled.
+func (s *Sweeper) memReclaimEnabled() bool {
+	switch s.memMode {
+	case "prune":
+		return true
+	case "export+prune":
+		return s.exportDir != ""
+	}
+	return false
+}
+
 // Run drives the sweep loop until ctx is done. The first tick fires after
 // Interval (not immediately) so a fresh process doesn't purge the moment it
 // boots. Blocks — caller starts it on a goroutine.
@@ -224,13 +297,16 @@ func (s *Sweeper) Run(ctx context.Context) {
 	if s.store == nil {
 		return
 	}
-	s.logf("retention: sweeper starting (interval=%s, defs_mode=%s, defs_max_age=%s, keep_last_n=%d, chats_mode=%s, chats_max_age=%s, dry_run=%v)",
-		s.interval, s.defsMode, s.defsMaxAge, s.defsKeepLastN, s.chatsMode, s.chatsMaxAge, s.dryRun)
+	s.logf("retention: sweeper starting (interval=%s, defs_mode=%s, defs_max_age=%s, keep_last_n=%d, chats_mode=%s, chats_max_age=%s, mem_mode=%s, mem_max_age=%s, sqlmem=%v, dry_run=%v)",
+		s.interval, s.defsMode, s.defsMaxAge, s.defsKeepLastN, s.chatsMode, s.chatsMaxAge, s.memMode, s.memMaxAge, s.sqlMem != nil, s.dryRun)
 	if s.defsMode == "export+prune" && s.exportDir == "" {
 		s.logf("retention: defs purge DISABLED — mode=export+prune requires LOOMCYCLE_RETENTION_EXPORT_DIR")
 	}
 	if s.chatsMode == "export+prune" && s.exportDir == "" {
 		s.logf("retention: chats purge DISABLED — mode=export+prune requires LOOMCYCLE_RETENTION_EXPORT_DIR")
+	}
+	if s.memMode == "export+prune" && s.exportDir == "" {
+		s.logf("retention: mem reclaim DISABLED — mode=export+prune requires LOOMCYCLE_RETENTION_EXPORT_DIR")
 	}
 	t := time.NewTicker(s.interval)
 	defer t.Stop()
@@ -274,7 +350,7 @@ func (s *Sweeper) Run(ctx context.Context) {
 			}
 			if err != nil {
 				s.logf("retention: sweep failed: %v", err)
-			} else if res.Total > 0 || res.Chats > 0 {
+			} else if res.Total > 0 || res.Chats > 0 || res.Mem > 0 {
 				verb := "purged"
 				if s.dryRun {
 					verb = "would purge"
@@ -285,10 +361,13 @@ func (s *Sweeper) Run(ctx context.Context) {
 				if res.Chats > 0 {
 					s.logf("retention: %s %d aged chat session(s) (mode=%s)", verb, res.Chats, s.chatsMode)
 				}
+				if res.Mem > 0 {
+					s.logf("retention: %s %d retired-agent memory reclamation unit(s) (mode=%s)", verb, res.Mem, s.memMode)
+				}
 				noOpStreak = 0
 			} else {
 				if noOpStreak == 0 || noOpStreak%noOpHeartbeatEvery == 0 {
-					s.logf("retention: sweep tick — 0 purgeable def versions / chat sessions (streak=%d)", noOpStreak)
+					s.logf("retention: sweep tick — 0 purgeable def versions / chat sessions / agent memory (streak=%d)", noOpStreak)
 				}
 				noOpStreak++
 			}
@@ -314,6 +393,13 @@ func (s *Sweeper) sweepOnce(parent context.Context) (Result, error) {
 			s.logf("retention: chats sweep failed: %v", err)
 		}
 		res.Chats += n
+	}
+	if s.memReclaimEnabled() {
+		n, err := s.sweepMemOnce(parent)
+		if err != nil {
+			s.logf("retention: mem sweep failed: %v", err)
+		}
+		res.Mem += n
 	}
 	return res, nil
 }
@@ -415,6 +501,290 @@ func (s *Sweeper) sweepChatsOnce(parent context.Context) (int, error) {
 	return pruned, nil
 }
 
+// sweepMemOnce reclaims a fully-retired agent's accumulated per-scope data (RFC
+// BM Phase 3). An agent whose every def version is retired (LiveVersionCount==0)
+// and whose latest version is older than MemMaxAge is dead — but its data spans
+// three stores with two different tenant-keying schemes, so reclamation runs in
+// two passes:
+//
+//	Pass 1 (per tenant, name — tenant-safe): drop the agent's SQL-Memory scope
+//	(SQL tables + document structure) and its dirents (Path names). Both are keyed
+//	(tenant, "agent", name), so dropping tenant A's copy never touches tenant B's.
+//
+//	Pass 2 (per name, globally-dead only): drop the agent's base-memory k/v
+//	(document chunk bodies + learned facts). Base memory is keyed by the BARE
+//	agent name (the memory table has no tenant column), so it is SHARED by
+//	same-named agents across tenants — dropping it is safe ONLY when the name is
+//	retired in EVERY tenant. A name live in any tenant keeps its base memory.
+//
+// Own 2-minute deadline; per-agent failures are logged + skipped (retried next
+// tick); a failed SQL-Memory scope drop aborts that agent's dirent drop so names
+// are never orphaned from a still-present scope.
+func (s *Sweeper) sweepMemOnce(parent context.Context) (int, error) {
+	ctx, cancel := context.WithTimeout(parent, 2*time.Minute)
+	defer cancel()
+
+	pass1, pass2, err := s.memEligible(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	reclaimed := 0
+	// Pass 1 — tenant-qualified SQL-Memory scope + dirents.
+	for i, t := range pass1 {
+		if ctx.Err() != nil || i >= memReclaimBatch {
+			break
+		}
+		if s.reclaimAgentScope(ctx, t.tenant, t.name, t.hasSQL) {
+			reclaimed++
+		}
+	}
+	// Pass 2 — globally-dead base memory (cross-tenant-shared).
+	for i, name := range pass2 {
+		if ctx.Err() != nil || i >= memReclaimBatch {
+			break
+		}
+		if s.reclaimBaseMemory(ctx, name) {
+			reclaimed++
+		}
+	}
+	return reclaimed, nil
+}
+
+// memTarget is one pass-1 (tenant-qualified) reclamation candidate.
+type memTarget struct {
+	tenant string
+	name   string
+	hasSQL bool // an existing SQL-Memory scope to export+drop
+}
+
+// memEligible computes the two reclamation candidate sets shared by the sweep
+// and the read-only report, so the eligibility logic can't drift between them.
+// pass1 = every fully-retired (LiveVersionCount==0) + old (tenant, name) with its
+// SQL-Memory-scope-exists flag. pass2 = every name that is retired in EVERY
+// tenant (globally dead) + old AND actually holds base-memory k/v — the only
+// names whose cross-tenant-shared base memory is safe to drop.
+func (s *Sweeper) memEligible(ctx context.Context) (pass1 []memTarget, pass2 []string, err error) {
+	summaries, err := s.store.AgentDefListNames(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Existing SQL-Memory agent scopes, so we export+drop only a scope that
+	// actually exists — ExportScope on an absent scope would provision an empty
+	// one. Nil SQLMem (SQL Memory disabled) leaves the set empty → pass 1 does
+	// dirents only.
+	sqlScopes := map[[2]string]bool{}
+	if s.sqlMem != nil {
+		scopes, lerr := s.sqlMem.ListScopes(ctx)
+		if lerr != nil {
+			s.logf("retention: mem sweep — list sqlmem scopes failed: %v", lerr)
+		}
+		for _, k := range scopes {
+			if k.Scope == string(store.MemoryScopeAgent) {
+				sqlScopes[[2]string{k.Tenant, k.ScopeID}] = true
+			}
+		}
+	}
+
+	// Names that actually hold base-memory k/v (so pass 2 skips names with none).
+	baseMemNames := map[string]bool{}
+	if ids, merr := s.store.MemoryListScopeIDs(ctx, store.MemoryScopeAgent); merr != nil {
+		s.logf("retention: mem sweep — list agent memory scopes failed: %v", merr)
+	} else {
+		for _, x := range ids {
+			baseMemNames[x.ScopeID] = true
+		}
+	}
+
+	// Per-name aggregate for the globally-dead base-memory gate: a name is
+	// globally dead iff EVERY (tenant, name) row is fully retired; newest is the
+	// most-recent LastUpdated across all its tenant rows.
+	type nameAgg struct {
+		allDead bool
+		newest  time.Time
+	}
+	byName := map[string]*nameAgg{}
+	for _, sm := range summaries {
+		agg := byName[sm.Name]
+		if agg == nil {
+			agg = &nameAgg{allDead: true}
+			byName[sm.Name] = agg
+		}
+		if sm.LiveVersionCount > 0 {
+			agg.allDead = false
+		}
+		if sm.LastUpdated.After(agg.newest) {
+			agg.newest = sm.LastUpdated
+		}
+	}
+
+	cutoff := s.now().Add(-s.memMaxAge)
+	for _, sm := range summaries {
+		if sm.LiveVersionCount != 0 || !sm.LastUpdated.Before(cutoff) {
+			continue
+		}
+		pass1 = append(pass1, memTarget{
+			tenant: sm.TenantID,
+			name:   sm.Name,
+			hasSQL: sqlScopes[[2]string{sm.TenantID, sm.Name}],
+		})
+	}
+	for name, agg := range byName {
+		if agg.allDead && agg.newest.Before(cutoff) && baseMemNames[name] {
+			pass2 = append(pass2, name)
+		}
+	}
+	return pass1, pass2, nil
+}
+
+// reclaimAgentScope drops one fully-retired agent's TENANT-QUALIFIED per-scope
+// data: its SQL-Memory scope (when hasSQL) and its dirents. Returns true if
+// anything was reclaimed. export+prune exports each facet before dropping it
+// (export-then-delete); a failed export or a failed SQL-Memory drop skips the
+// rest for this agent so nothing is half-reclaimed. Under DryRun it neither
+// exports nor deletes — it only reports whether there is something to reclaim
+// (the read-only GET /v1/_retention report is the intended preview; SQL-Memory
+// dumps are too heavy to write on a preview tick).
+func (s *Sweeper) reclaimAgentScope(ctx context.Context, tenant, name string, hasSQL bool) bool {
+	if s.dryRun {
+		if hasSQL {
+			return true
+		}
+		rows, err := s.store.DirentListUnder(ctx, tenant, string(store.MemoryScopeAgent), name, "/")
+		return err == nil && len(rows) > 0
+	}
+
+	did := false
+	if hasSQL && s.sqlMem != nil {
+		key := sqlmem.ScopeKey{Tenant: tenant, Scope: string(store.MemoryScopeAgent), ScopeID: name}
+		if s.memMode == "export+prune" {
+			if err := s.exportSQLMemScope(ctx, tenant, name, key); err != nil {
+				s.logf("retention: export sqlmem scope %s/%s failed, skipping agent: %v", tenant, name, err)
+				return false
+			}
+		}
+		removed, err := s.sqlMem.DropScope(ctx, key)
+		if err != nil {
+			// Don't drop the dirents out from under a still-present scope.
+			s.logf("retention: drop sqlmem scope %s/%s failed, skipping agent: %v", tenant, name, err)
+			return false
+		}
+		did = removed
+	}
+
+	// dirents (Path names). "/" is the scope root — its descendants are every
+	// named entry in the scope.
+	if s.memMode == "export+prune" {
+		if err := s.exportDirents(ctx, tenant, name); err != nil {
+			s.logf("retention: export dirents %s/%s failed, skipping dirent delete: %v", tenant, name, err)
+			return did
+		}
+	}
+	n, err := s.store.DirentDeleteUnder(ctx, tenant, string(store.MemoryScopeAgent), name, "/")
+	if err != nil {
+		s.logf("retention: delete dirents %s/%s failed: %v", tenant, name, err)
+	} else if n > 0 {
+		did = true
+	}
+	return did
+}
+
+// reclaimBaseMemory drops a globally-dead agent's base-memory k/v (every key
+// under scope=agent, scope_id=name). The caller MUST have verified the name is
+// retired in every tenant (base memory has no tenant column). export+prune dumps
+// the entries first. Under DryRun it reports would-reclaim without touching rows.
+func (s *Sweeper) reclaimBaseMemory(ctx context.Context, name string) bool {
+	if s.dryRun {
+		return true // caller already confirmed baseMemNames[name]
+	}
+	if s.memMode == "export+prune" {
+		if err := s.exportBaseMemory(ctx, name); err != nil {
+			s.logf("retention: export agent memory %q failed, skipping: %v", name, err)
+			return false
+		}
+	}
+	n, err := s.store.MemoryDeleteScope(ctx, store.MemoryScopeAgent, name)
+	if err != nil {
+		s.logf("retention: delete agent memory %q failed: %v", name, err)
+		return false
+	}
+	return n > 0
+}
+
+// exportSQLMemScope dumps one agent SQL-Memory scope to
+// <ExportDir>/agents/<day>/sqlmem/<tenant>__<name>.json before it is dropped.
+func (s *Sweeper) exportSQLMemScope(ctx context.Context, tenant, name string, key sqlmem.ScopeKey) error {
+	dump, err := s.sqlMem.ExportScope(ctx, key)
+	if err != nil {
+		return err
+	}
+	return s.writeMemExport("sqlmem", tenant, name, dump)
+}
+
+// exportDirents dumps one agent scope's dirents (Path names) before they are
+// deleted. A scope with no dirents writes nothing.
+func (s *Sweeper) exportDirents(ctx context.Context, tenant, name string) error {
+	rows, err := s.store.DirentListUnder(ctx, tenant, string(store.MemoryScopeAgent), name, "/")
+	if err != nil {
+		return err
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	return s.writeMemExport("dirents", tenant, name, rows)
+}
+
+// exportBaseMemory dumps one globally-dead agent's base-memory k/v before it is
+// deleted. Bucketed under agent-memory/ with NO tenant segment (base memory is
+// cross-tenant-shared). Warns (but still exports what it read) if the entry set
+// is truncated at the cap.
+func (s *Sweeper) exportBaseMemory(ctx context.Context, name string) error {
+	entries, truncated, err := s.store.MemoryList(ctx, store.MemoryScopeAgent, name, "", memExportKeyCap)
+	if err != nil {
+		return err
+	}
+	if truncated {
+		s.logf("retention: agent memory %q export truncated at %d keys — exported bundle is incomplete", name, memExportKeyCap)
+	}
+	if len(entries) == 0 {
+		return nil
+	}
+	return s.writeMemExport("agent-memory", "", name, entries)
+}
+
+// writeMemExport marshals one reclamation-export payload to
+// <ExportDir>/agents/<day>/<kind>/<tenant>__<name>.json (0600). Agent names may
+// contain '/' (name grouping) and tenants are operator-controlled, so both are
+// filesystem-sanitized to keep every export a single flat file. The export dir
+// is operator config, never model input.
+func (s *Sweeper) writeMemExport(kind, tenant, name string, payload any) error {
+	day := s.now().UTC().Format("2006-01-02")
+	dir := filepath.Join(s.exportDir, "agents", day, kind)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return err
+	}
+	fname := fsSafe(tenant) + "__" + fsSafe(name) + ".json"
+	blob, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return err
+	}
+	// 0o600: an agent's memory/SQL data may hold sensitive material; operator-only.
+	return os.WriteFile(filepath.Join(dir, fname), blob, 0o600)
+}
+
+// fsSafe replaces path separators + control characters in an export filename
+// component so a '/'-grouped agent name or an odd tenant can't escape the export
+// subtree or create nested directories.
+func fsSafe(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '/' || r == '\\' || r == ':' || r < 0x20 {
+			return '_'
+		}
+		return r
+	}, s)
+}
+
 // exportDef writes one retired def version to ExportDir as JSON, under a
 // per-day/per-def-type subdir (bucketing by the version's created date keeps any
 // single directory bounded). The export dir is operator config, never model
@@ -514,5 +884,44 @@ func (s *Sweeper) DryRunCounts(ctx context.Context) (map[string]int, error) {
 		return nil, err
 	}
 	out["chats"] = len(sessions)
+
+	// Retired-agent memory-reclamation preview — mode-independent, keyed "mem"
+	// (never a def-type name). Counts the same reclamation units the sweep would
+	// take: pass-1 (tenant, name) with an SQL-Memory scope OR dirents, plus every
+	// globally-dead pass-2 name that holds base memory. Saturates at reportListCap.
+	memCount, err := s.countReclaimableMem(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out["mem"] = memCount
 	return out, nil
+}
+
+// countReclaimableMem counts the reclamation units the mem sweep would take
+// right now, WITHOUT touching anything (backs the GET /v1/_retention report). It
+// reuses memEligible so the count can't drift from the sweep; a pass-1 candidate
+// counts only when it has something to reclaim (an SQL-Memory scope OR dirents).
+func (s *Sweeper) countReclaimableMem(ctx context.Context) (int, error) {
+	pass1, pass2, err := s.memEligible(ctx)
+	if err != nil {
+		return 0, err
+	}
+	count := len(pass2) // pass 2 is gated on baseMemNames — each has memory to drop
+	for _, t := range pass1 {
+		if count >= reportListCap {
+			break
+		}
+		if t.hasSQL {
+			count++
+			continue
+		}
+		rows, derr := s.store.DirentListUnder(ctx, t.tenant, string(store.MemoryScopeAgent), t.name, "/")
+		if derr == nil && len(rows) > 0 {
+			count++
+		}
+	}
+	if count > reportListCap {
+		count = reportListCap
+	}
+	return count, nil
 }

--- a/internal/retention/sweeper_test.go
+++ b/internal/retention/sweeper_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
 )
@@ -387,5 +388,342 @@ func TestSweeper_ChatsExportPruneWithoutExportDirDisabled(t *testing.T) {
 	}
 	if _, err := st.GetSession(ctx, sid); err != nil {
 		t.Errorf("disabled sweep deleted the session: %v", err)
+	}
+}
+
+// ---- RFC BM Phase 3: retired-agent memory reclamation ----
+
+func newTestSqlMem(t *testing.T) *sqlmem.Manager {
+	t.Helper()
+	m, err := sqlmem.New(sqlmem.Config{Root: t.TempDir()})
+	if err != nil {
+		t.Fatalf("sqlmem.New: %v", err)
+	}
+	t.Cleanup(func() { _ = m.Close() })
+	return m
+}
+
+// seedRetiredAgent creates n versions of (tenant, name) and retires all of them
+// (LiveVersionCount == 0). seedLiveAgent leaves the version live.
+func seedRetiredAgent(t *testing.T, st *sqlite.Store, tenant, name string, n int) {
+	t.Helper()
+	ctx := context.Background()
+	for i := 0; i < n; i++ {
+		id := tenant + "-" + name + "-v" + string(rune('1'+i))
+		row := store.AgentDefRow{DefID: id, Name: name, TenantID: tenant, Definition: json.RawMessage(`{"model":"x"}`)}
+		if _, err := st.AgentDefCreate(ctx, row); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+		if err := st.AgentDefSetRetired(ctx, id, true); err != nil {
+			t.Fatalf("retire %s: %v", id, err)
+		}
+	}
+}
+
+func seedLiveAgent(t *testing.T, st *sqlite.Store, tenant, name string) {
+	t.Helper()
+	id := tenant + "-" + name + "-live"
+	row := store.AgentDefRow{DefID: id, Name: name, TenantID: tenant, Definition: json.RawMessage(`{"model":"x"}`)}
+	if _, err := st.AgentDefCreate(context.Background(), row); err != nil {
+		t.Fatalf("create live %s: %v", id, err)
+	}
+}
+
+// seedAgentSQLScope provisions the (tenant, agent, name) SQL-Memory scope with a
+// table so ListScopes reports it and DropScope has something to drop.
+func seedAgentSQLScope(t *testing.T, sm *sqlmem.Manager, tenant, name string) {
+	t.Helper()
+	key := sqlmem.ScopeKey{Tenant: tenant, Scope: "agent", ScopeID: name}
+	if _, err := sm.Exec(context.Background(), key, `CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)`, nil, 0); err != nil {
+		t.Fatalf("seed sql scope %s/%s: %v", tenant, name, err)
+	}
+	if _, err := sm.Exec(context.Background(), key, `INSERT INTO t (v) VALUES ('x')`, nil, 0); err != nil {
+		t.Fatalf("seed sql row %s/%s: %v", tenant, name, err)
+	}
+}
+
+func seedAgentDirent(t *testing.T, st *sqlite.Store, tenant, name string) {
+	t.Helper()
+	_, err := st.DirentCreate(context.Background(), store.DirentRow{
+		TenantID: tenant, Scope: "agent", ScopeID: name,
+		ParentPath: "/", Name: "doc1", Kind: "document", ResourceRef: json.RawMessage(`{"document_id":"doc-1"}`),
+	})
+	if err != nil {
+		t.Fatalf("seed dirent %s/%s: %v", tenant, name, err)
+	}
+}
+
+func direntCount(t *testing.T, st *sqlite.Store, tenant, name string) int {
+	t.Helper()
+	rows, err := st.DirentListUnder(context.Background(), tenant, "agent", name, "/")
+	if err != nil {
+		t.Fatalf("dirent list %s/%s: %v", tenant, name, err)
+	}
+	return len(rows)
+}
+
+func sqlScopeExists(t *testing.T, sm *sqlmem.Manager, tenant, name string) bool {
+	t.Helper()
+	scopes, err := sm.ListScopes(context.Background())
+	if err != nil {
+		t.Fatalf("list scopes: %v", err)
+	}
+	for _, k := range scopes {
+		if k.Tenant == tenant && k.Scope == "agent" && k.ScopeID == name {
+			return true
+		}
+	}
+	return false
+}
+
+func memKeyCount(t *testing.T, st *sqlite.Store, name string) int {
+	t.Helper()
+	entries, _, err := st.MemoryList(context.Background(), store.MemoryScopeAgent, name, "", 1000)
+	if err != nil {
+		t.Fatalf("memory list %q: %v", name, err)
+	}
+	return len(entries)
+}
+
+// TestSweeper_MemReclaimsRetiredAgent: a fully-retired + old agent's SQL-Memory
+// scope, dirents, and base-memory k/v are all reclaimed; a live agent's are not.
+func TestSweeper_MemReclaimsRetiredAgent(t *testing.T) {
+	ctx := context.Background()
+	st, err := sqlite.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+	sm := newTestSqlMem(t)
+
+	// Dead agent (all versions retired) in tenant "acme".
+	seedRetiredAgent(t, st, "acme", "dead", 2)
+	seedAgentSQLScope(t, sm, "acme", "dead")
+	seedAgentDirent(t, st, "acme", "dead")
+	if err := st.MemorySet(ctx, store.MemoryScopeAgent, "dead", "k1", json.RawMessage(`1`), 0); err != nil {
+		t.Fatal(err)
+	}
+	// Live agent — must be untouched.
+	seedLiveAgent(t, st, "acme", "alive")
+	seedAgentSQLScope(t, sm, "acme", "alive")
+	seedAgentDirent(t, st, "acme", "alive")
+	if err := st.MemorySet(ctx, store.MemoryScopeAgent, "alive", "k1", json.RawMessage(`1`), 0); err != nil {
+		t.Fatal(err)
+	}
+
+	sw := New(st, Config{MemMode: "prune", SQLMem: sm, Logger: quietLogger, Now: futureHour})
+	res, err := sw.sweepOnce(ctx)
+	if err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+	// One (tenant,name) scope reclamation + one globally-dead base-memory drop = 2.
+	if res.Mem != 2 {
+		t.Errorf("res.Mem = %d, want 2", res.Mem)
+	}
+	if sqlScopeExists(t, sm, "acme", "dead") {
+		t.Error("dead agent's SQL-Memory scope survived")
+	}
+	if n := direntCount(t, st, "acme", "dead"); n != 0 {
+		t.Errorf("dead agent dirents = %d, want 0", n)
+	}
+	if n := memKeyCount(t, st, "dead"); n != 0 {
+		t.Errorf("dead agent base memory keys = %d, want 0", n)
+	}
+	// Live agent fully intact.
+	if !sqlScopeExists(t, sm, "acme", "alive") {
+		t.Error("live agent's SQL-Memory scope was dropped")
+	}
+	if n := direntCount(t, st, "acme", "alive"); n != 1 {
+		t.Errorf("live agent dirents = %d, want 1", n)
+	}
+	if n := memKeyCount(t, st, "alive"); n != 1 {
+		t.Errorf("live agent base memory keys = %d, want 1", n)
+	}
+}
+
+// TestSweeper_MemBaseMemoryOnlyDroppedWhenGloballyDead is the cross-tenant safety
+// test: a name retired in tenant A but LIVE in tenant B keeps its base memory
+// (scope_id is the bare name, shared across tenants), while tenant A's
+// tenant-qualified SQL-Memory scope + dirents are still reclaimed and tenant B's
+// are untouched.
+func TestSweeper_MemBaseMemoryOnlyDroppedWhenGloballyDead(t *testing.T) {
+	ctx := context.Background()
+	st, err := sqlite.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+	sm := newTestSqlMem(t)
+
+	// "shared" is retired in tenant A, LIVE in tenant B → NOT globally dead.
+	seedRetiredAgent(t, st, "A", "shared", 1)
+	seedLiveAgent(t, st, "B", "shared")
+	seedAgentSQLScope(t, sm, "A", "shared")
+	seedAgentSQLScope(t, sm, "B", "shared")
+	seedAgentDirent(t, st, "A", "shared")
+	seedAgentDirent(t, st, "B", "shared")
+	// Base memory is keyed by the bare name — a single partition both share.
+	if err := st.MemorySet(ctx, store.MemoryScopeAgent, "shared", "k1", json.RawMessage(`1`), 0); err != nil {
+		t.Fatal(err)
+	}
+
+	sw := New(st, Config{MemMode: "prune", SQLMem: sm, Logger: quietLogger, Now: futureHour})
+	res, err := sw.sweepOnce(ctx)
+	if err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+	// Only tenant A's scope reclaimed (1 unit); base memory NOT dropped.
+	if res.Mem != 1 {
+		t.Errorf("res.Mem = %d, want 1 (tenant A scope only)", res.Mem)
+	}
+	if n := memKeyCount(t, st, "shared"); n != 1 {
+		t.Errorf("shared base memory keys = %d, want 1 (a live tenant still uses it)", n)
+	}
+	if sqlScopeExists(t, sm, "A", "shared") {
+		t.Error("tenant A's retired SQL-Memory scope survived")
+	}
+	if !sqlScopeExists(t, sm, "B", "shared") {
+		t.Error("tenant B's LIVE SQL-Memory scope was wrongly dropped")
+	}
+	if n := direntCount(t, st, "A", "shared"); n != 0 {
+		t.Errorf("tenant A dirents = %d, want 0", n)
+	}
+	if n := direntCount(t, st, "B", "shared"); n != 1 {
+		t.Errorf("tenant B dirents = %d, want 1 (live, untouched)", n)
+	}
+}
+
+// TestSweeper_MemExportThenDelete: export+prune writes the scope dump, dirents,
+// and base-memory bundles before deleting.
+func TestSweeper_MemExportThenDelete(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	st, err := sqlite.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+	sm := newTestSqlMem(t)
+
+	seedRetiredAgent(t, st, "acme", "dead", 1)
+	seedAgentSQLScope(t, sm, "acme", "dead")
+	seedAgentDirent(t, st, "acme", "dead")
+	if err := st.MemorySet(ctx, store.MemoryScopeAgent, "dead", "k1", json.RawMessage(`1`), 0); err != nil {
+		t.Fatal(err)
+	}
+
+	sw := New(st, Config{MemMode: "export+prune", ExportDir: dir, SQLMem: sm, Logger: quietLogger, Now: futureHour})
+	if _, err := sw.sweepOnce(ctx); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	// Each facet wrote at least one JSON file under agents/<day>/<kind>/.
+	for _, kind := range []string{"sqlmem", "dirents", "agent-memory"} {
+		var found int
+		_ = filepath.WalkDir(dir, func(p string, d os.DirEntry, _ error) error {
+			if d != nil && !d.IsDir() && filepath.Base(filepath.Dir(p)) == kind {
+				found++
+			}
+			return nil
+		})
+		if found == 0 {
+			t.Errorf("export kind %q wrote no file under %s", kind, dir)
+		}
+	}
+	// And the data is actually gone.
+	if sqlScopeExists(t, sm, "acme", "dead") {
+		t.Error("scope survived export+prune")
+	}
+	if memKeyCount(t, st, "dead") != 0 {
+		t.Error("base memory survived export+prune")
+	}
+}
+
+// errSQLMem is a fake SQLMemory whose ExportScope fails, to prove export-then-
+// delete never drops a scope it couldn't export.
+type errSQLMem struct {
+	scopes  []sqlmem.ScopeKey
+	dropped []sqlmem.ScopeKey
+}
+
+func (e *errSQLMem) ListScopes(context.Context) ([]sqlmem.ScopeKey, error) { return e.scopes, nil }
+func (e *errSQLMem) ExportScope(context.Context, sqlmem.ScopeKey) (*sqlmem.ScopeDump, error) {
+	return nil, errExportBoom
+}
+func (e *errSQLMem) DropScope(_ context.Context, k sqlmem.ScopeKey) (bool, error) {
+	e.dropped = append(e.dropped, k)
+	return true, nil
+}
+
+var errExportBoom = &boomErr{}
+
+type boomErr struct{}
+
+func (*boomErr) Error() string { return "boom" }
+
+// TestSweeper_MemExportFailureSkipsDrop: an export failure on the SQL-Memory
+// scope skips BOTH the scope drop and the dirent delete for that agent.
+func TestSweeper_MemExportFailureSkipsDrop(t *testing.T) {
+	ctx := context.Background()
+	st, err := sqlite.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+
+	seedRetiredAgent(t, st, "acme", "dead", 1)
+	seedAgentDirent(t, st, "acme", "dead")
+
+	fake := &errSQLMem{scopes: []sqlmem.ScopeKey{{Tenant: "acme", Scope: "agent", ScopeID: "dead"}}}
+	sw := New(st, Config{MemMode: "export+prune", ExportDir: t.TempDir(), SQLMem: fake, Logger: quietLogger, Now: futureHour})
+	res, err := sw.sweepOnce(ctx)
+	if err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+	if res.Mem != 0 {
+		t.Errorf("res.Mem = %d, want 0 (export failed → nothing reclaimed)", res.Mem)
+	}
+	if len(fake.dropped) != 0 {
+		t.Errorf("DropScope called %d time(s) despite export failure", len(fake.dropped))
+	}
+	if n := direntCount(t, st, "acme", "dead"); n != 1 {
+		t.Errorf("dirents = %d, want 1 (dirent delete must be skipped when the scope export failed)", n)
+	}
+}
+
+// TestSweeper_MemDryRunCounts: the report preview counts reclaimable agents
+// without deleting anything.
+func TestSweeper_MemDryRunCounts(t *testing.T) {
+	ctx := context.Background()
+	st, err := sqlite.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+	sm := newTestSqlMem(t)
+
+	seedRetiredAgent(t, st, "acme", "dead", 1)
+	seedAgentSQLScope(t, sm, "acme", "dead")
+	if err := st.MemorySet(ctx, store.MemoryScopeAgent, "dead", "k1", json.RawMessage(`1`), 0); err != nil {
+		t.Fatal(err)
+	}
+	seedLiveAgent(t, st, "acme", "alive")
+	seedAgentSQLScope(t, sm, "acme", "alive")
+
+	sw := New(st, Config{MemMode: "off", SQLMem: sm, Logger: quietLogger, Now: futureHour})
+	counts, err := sw.DryRunCounts(ctx)
+	if err != nil {
+		t.Fatalf("DryRunCounts: %v", err)
+	}
+	// dead: 1 tenant scope + 1 globally-dead base memory = 2; alive not counted.
+	if counts["mem"] != 2 {
+		t.Errorf("counts[mem] = %d, want 2", counts["mem"])
+	}
+	// Nothing deleted by the preview.
+	if !sqlScopeExists(t, sm, "acme", "dead") {
+		t.Error("DryRunCounts dropped the scope")
+	}
+	if memKeyCount(t, st, "dead") != 1 {
+		t.Error("DryRunCounts deleted base memory")
 	}
 }

--- a/internal/retention/sweeper_test.go
+++ b/internal/retention/sweeper_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -725,5 +726,91 @@ func TestSweeper_MemDryRunCounts(t *testing.T) {
 	}
 	if memKeyCount(t, st, "dead") != 1 {
 		t.Error("DryRunCounts deleted base memory")
+	}
+}
+
+// TestSweeper_MemBaseMemoryReclaimedBeyondScopeIDsCap is a regression for the
+// review's finding #1: pass 2 must NOT gate on MemoryListScopeIDs (capped at the
+// 200 most-recently-updated scopes). A retired agent's base memory is stale, so
+// it sorts out of that window in a busy deployment; if pass 2 gated on the cap it
+// would never reclaim it. Here the retired agent's memory is seeded FIRST (oldest
+// updated_at) and then 200 fresher scopes are added, pushing the retired agent to
+// rank 201 — outside the cap. The reclaim must still happen.
+func TestSweeper_MemBaseMemoryReclaimedBeyondScopeIDsCap(t *testing.T) {
+	ctx := context.Background()
+	st, err := sqlite.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+
+	// The retired agent, with the OLDEST base-memory row.
+	seedRetiredAgent(t, st, "acme", "dead", 1)
+	if err := st.MemorySet(ctx, store.MemoryScopeAgent, "dead", "k1", json.RawMessage(`1`), 0); err != nil {
+		t.Fatal(err)
+	}
+	// 200 fresher agent-memory scopes (no defs — they exist only to fill the
+	// MemoryListScopeIDs top-200 window and evict "dead" from it).
+	for i := 0; i < 200; i++ {
+		id := "live-" + strconv.Itoa(i)
+		if err := st.MemorySet(ctx, store.MemoryScopeAgent, id, "k", json.RawMessage(`1`), 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Sanity: "dead" is NOT in the (capped) MemoryListScopeIDs window.
+	ids, err := st.MemoryListScopeIDs(ctx, store.MemoryScopeAgent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range ids {
+		if s.ScopeID == "dead" {
+			t.Fatalf("test precondition broken: 'dead' is inside the %d-row cap; can't prove the bug", len(ids))
+		}
+	}
+
+	sw := New(st, Config{MemMode: "prune", Logger: quietLogger, Now: futureHour})
+	if _, err := sw.sweepOnce(ctx); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+	if n := memKeyCount(t, st, "dead"); n != 0 {
+		t.Errorf("retired agent base memory NOT reclaimed (keys=%d) — pass 2 skipped it because it fell outside the MemoryListScopeIDs cap", n)
+	}
+}
+
+// TestSweeper_MemRunsBeforeDefsPurge is a regression for the review's finding #2:
+// with keep_last_n=0 the defs purge and the mem reclaim run in the same tick, and
+// the mem sweep keys off AgentDefListNames — so it MUST run before the defs purge,
+// or the purge removes the agent's last def version first and the mem sweep can no
+// longer find it, orphaning its base memory forever.
+func TestSweeper_MemRunsBeforeDefsPurge(t *testing.T) {
+	ctx := context.Background()
+	st, err := sqlite.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+
+	seedRetiredAgent(t, st, "acme", "dead", 1) // 1 retired, non-active, old version
+	if err := st.MemorySet(ctx, store.MemoryScopeAgent, "dead", "k1", json.RawMessage(`1`), 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// Defs purge (keep_last_n=0 → purges the sole retired version) AND mem reclaim
+	// both enabled in the same sweep.
+	sw := New(st, Config{
+		DefsMode: "prune", DefsKeepLastN: 0,
+		MemMode: "prune",
+		Logger:  quietLogger, Now: futureHour,
+	})
+	res, err := sw.sweepOnce(ctx)
+	if err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+	// The def version is purged AND the base memory is reclaimed (mem ran first).
+	if res.Total != 1 {
+		t.Errorf("res.Total = %d, want 1 (the retired def version purged)", res.Total)
+	}
+	if n := memKeyCount(t, st, "dead"); n != 0 {
+		t.Errorf("base memory NOT reclaimed (keys=%d) — the defs purge removed the agent before the mem sweep saw it", n)
 	}
 }

--- a/internal/sqlmem/dump_postgres_test.go
+++ b/internal/sqlmem/dump_postgres_test.go
@@ -88,6 +88,57 @@ func TestListScopes_Postgres(t *testing.T) {
 	}
 }
 
+// TestDropScope_Postgres: DropScope drops one durable scope's schema + role
+// (idempotently), leaves a sibling alone, and refuses the run scope (RFC BM).
+func TestDropScope_Postgres(t *testing.T) {
+	m, _ := pgTestManager(t, Config{})
+	ctx := context.Background()
+
+	target := ScopeKey{Tenant: "t1", Scope: "agent", ScopeID: "gone"}
+	sibling := ScopeKey{Tenant: "t1", Scope: "user", ScopeID: "stays"}
+	for _, k := range []ScopeKey{target, sibling} {
+		if _, err := m.Exec(ctx, k, "CREATE TABLE t (id int)", nil, 0); err != nil {
+			t.Fatalf("create %v: %v", k, err)
+		}
+	}
+
+	removed, err := m.DropScope(ctx, target)
+	if err != nil {
+		t.Fatalf("DropScope: %v", err)
+	}
+	if !removed {
+		t.Error("DropScope removed=false on an existing scope")
+	}
+	scopes, err := m.ListScopes(ctx)
+	if err != nil {
+		t.Fatalf("ListScopes: %v", err)
+	}
+	got := map[ScopeKey]bool{}
+	for _, s := range scopes {
+		if s == target {
+			t.Errorf("dropped scope still listed: %v", s)
+		}
+		got[s] = true
+	}
+	if !got[sibling] {
+		t.Errorf("sibling scope %v was wrongly dropped", sibling)
+	}
+
+	// Idempotent: the schema is already gone.
+	removed, err = m.DropScope(ctx, target)
+	if err != nil {
+		t.Fatalf("second DropScope: %v", err)
+	}
+	if removed {
+		t.Error("second DropScope removed=true, want false (already gone)")
+	}
+
+	// The run scope is rejected.
+	if _, err := m.DropScope(ctx, ScopeKey{Scope: "run", ScopeID: "r1"}); err == nil {
+		t.Error("DropScope accepted the run scope, want error")
+	}
+}
+
 // TestDump_PostgresRoundTrip: bigserial + text + jsonb + timestamptz + a unique
 // constraint + an index + a NULL round-trip through Export → drop → fresh
 // Restore. The serial counter (setval) continues past the restored ids.

--- a/internal/sqlmem/dump_test.go
+++ b/internal/sqlmem/dump_test.go
@@ -17,6 +17,64 @@ func TestTier_SQLite(t *testing.T) {
 	}
 }
 
+// TestDropScope_SQLite: DropScope removes one durable scope (idempotently),
+// leaves siblings alone, and refuses the run scope + an empty key (RFC BM).
+func TestDropScope_SQLite(t *testing.T) {
+	m := newTestManager(t, Config{})
+	ctx := context.Background()
+
+	target := ScopeKey{Tenant: "t1", Scope: "agent", ScopeID: "gone"}
+	sibling := ScopeKey{Tenant: "t1", Scope: "user", ScopeID: "stays"}
+	for _, k := range []ScopeKey{target, sibling} {
+		if _, err := m.Exec(ctx, k, "CREATE TABLE t (id INTEGER)", nil, 0); err != nil {
+			t.Fatalf("create %v: %v", k, err)
+		}
+	}
+
+	removed, err := m.DropScope(ctx, target)
+	if err != nil {
+		t.Fatalf("DropScope: %v", err)
+	}
+	if !removed {
+		t.Error("DropScope removed=false on an existing scope")
+	}
+	// Gone from the listing; the sibling remains.
+	scopes, err := m.ListScopes(ctx)
+	if err != nil {
+		t.Fatalf("ListScopes: %v", err)
+	}
+	for _, s := range scopes {
+		if s == target {
+			t.Errorf("dropped scope still listed: %v", s)
+		}
+	}
+	got := map[ScopeKey]bool{}
+	for _, s := range scopes {
+		got[s] = true
+	}
+	if !got[sibling] {
+		t.Errorf("sibling scope %v was wrongly dropped", sibling)
+	}
+
+	// Idempotent: a second drop reports removed=false, no error.
+	removed, err = m.DropScope(ctx, target)
+	if err != nil {
+		t.Fatalf("second DropScope: %v", err)
+	}
+	if removed {
+		t.Error("second DropScope removed=true, want false (already gone)")
+	}
+
+	// The run scope must be rejected (use DropRunScope).
+	if _, err := m.DropScope(ctx, ScopeKey{Scope: "run", ScopeID: "r1"}); err == nil {
+		t.Error("DropScope accepted the run scope, want error")
+	}
+	// An empty scope_id must be rejected.
+	if _, err := m.DropScope(ctx, ScopeKey{Tenant: "t1", Scope: "agent", ScopeID: ""}); err == nil {
+		t.Error("DropScope accepted an empty scope_id, want error")
+	}
+}
+
 // TestListScopes_SQLiteDurableOnly: agent + user scopes are enumerated; the
 // ephemeral run scope is never listed.
 func TestListScopes_SQLiteDurableOnly(t *testing.T) {

--- a/internal/sqlmem/postgres.go
+++ b/internal/sqlmem/postgres.go
@@ -678,6 +678,22 @@ func (b *postgresBackend) dropRunScope(runID string) (removed bool, err error) {
 	return b.dropScopePG(ctx, schema, role)
 }
 
+// dropScope removes one DURABLE (agent/user) scope: schema names are RE-DERIVED
+// from the key via pgScopeNames, then dropScopePG retires the pool + DROP SCHEMA
+// CASCADE + DROP ROLE + removes both GC meta rows. RFC BM retention reclaim path.
+func (b *postgresBackend) dropScope(key ScopeKey) (removed bool, err error) {
+	if key.Scope == runScope {
+		return false, fmt.Errorf("sqlmem: dropScope is not for the run scope")
+	}
+	schema, role, err := pgScopeNames(key)
+	if err != nil {
+		return false, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	return b.dropScopePG(ctx, schema, role)
+}
+
 // dropScopePG retires the scope's pool, drops its schema (CASCADE) + role, and
 // removes its GC meta row. Shared by run-scope drop and the durable-scope GC
 // sweeper. removed reflects the actual schema drop (3F000 => already gone).

--- a/internal/sqlmem/sqlite.go
+++ b/internal/sqlmem/sqlite.go
@@ -503,6 +503,31 @@ func (b *sqliteBackend) dropRunScope(runID string) (removed bool, err error) {
 	return fencedRemoveDB(runRoot, path)
 }
 
+// dropScope removes one DURABLE (agent/user) scope .db file (and its -wal/-shm
+// sidecars) behind a path fence. The path is RE-DERIVED from (Root, tenant,
+// scope, sanitize(scope_id)) — never a stored path — and fenced under the
+// scope's OWN directory (mirrors sweepStale) so a symlinked .db can't widen the
+// delete to another tenant's subtree. An in-use handle (inUse>0) is REFUSED with
+// an error (not silently skipped) so the RFC BM caller retries next tick rather
+// than assuming the scope is gone and dropping its sibling memory/dirents.
+func (b *sqliteBackend) dropScope(key ScopeKey) (removed bool, err error) {
+	if key.Scope == runScope {
+		return false, fmt.Errorf("sqlmem: dropScope is not for the run scope")
+	}
+	path, err := key.keyPath(b.cfg.Root)
+	if err != nil {
+		return false, err
+	}
+	b.mu.Lock()
+	if h, ok := b.open[path]; ok && h.inUse > 0 {
+		b.mu.Unlock()
+		return false, fmt.Errorf("sqlmem: scope %s/%s in use", key.Scope, key.ScopeID)
+	}
+	b.evictPathLocked(path)
+	b.mu.Unlock()
+	return fencedRemoveDB(filepath.Dir(path), path)
+}
+
 // fencedRemoveDB removes a single scope .db file (and its -wal/-shm
 // sidecars) only after proving the resolved path is strictly inside
 // expectedRoot. It NEVER trusts a stored path — path is re-derived by the

--- a/internal/sqlmem/sqlmem.go
+++ b/internal/sqlmem/sqlmem.go
@@ -27,6 +27,7 @@ package sqlmem
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"strconv"
 	"strings"
 	"sync"
@@ -91,6 +92,13 @@ type backend interface {
 	query(ctx context.Context, key ScopeKey, statement string, args []any) (*QueryResult, error)
 	exec(ctx context.Context, key ScopeKey, statement string, args []any, quotaOverride int) (*ExecResult, error)
 	dropRunScope(runID string) (removed bool, err error)
+	// dropScope drops one DURABLE (agent/user) scope: retire its pool, drop its
+	// schema+role (postgres) / .db file (sqlite), remove its GC meta. Mirrors the
+	// per-scope drop the GC sweeper does, exposed for RFC BM retention (reclaim a
+	// fully-retired agent's SQL-Memory scope). removed reflects an actual drop
+	// (false when the scope was already gone). MUST NOT be called for the run
+	// scope — use dropRunScope.
+	dropScope(key ScopeKey) (removed bool, err error)
 	// beginTx pins the scope connection (so it is not evicted while the txn is
 	// open) and opens a transaction on it. release drops the pin; the caller
 	// MUST call it after Commit/Rollback. The *sql.Tx is backend-agnostic, so
@@ -245,6 +253,22 @@ func (m *Manager) Exec(ctx context.Context, key ScopeKey, statement string, args
 // scope existed.
 func (m *Manager) DropRunScope(runID string) (removed bool, err error) {
 	return m.backend.dropRunScope(runID)
+}
+
+// DropScope removes one DURABLE (agent/user) scope (sqlite: the .db file behind
+// a path fence; postgres: the scope schema + role + GC meta). removed reports
+// whether the scope existed. Rejects the run scope (use DropRunScope) and an
+// empty ScopeID. Used by the RFC BM retention sweeper to reclaim a fully-retired
+// agent's SQL-Memory scope (its SQL tables + document-structure rows). Idempotent
+// — a never-provisioned scope returns removed=false, nil.
+func (m *Manager) DropScope(ctx context.Context, key ScopeKey) (removed bool, err error) {
+	if key.Scope == runScope {
+		return false, fmt.Errorf("sqlmem: DropScope is for durable scopes; use DropRunScope for the run scope")
+	}
+	if key.Scope == "" || strings.TrimSpace(key.ScopeID) == "" {
+		return false, fmt.Errorf("sqlmem: DropScope requires a non-empty scope and scope_id")
+	}
+	return m.backend.dropScope(key)
 }
 
 // VectorsEnabled reports whether this Manager's tier can serve vector columns

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -3363,6 +3363,20 @@ func (s *Store) MemoryDelete(ctx context.Context, scope store.MemoryScope, scope
 	return tag.RowsAffected() > 0, nil
 }
 
+// MemoryDeleteScope removes every entry under (scope, scopeID) in one statement
+// (RFC BM retention). memory_embeddings rows cascade via their ON DELETE CASCADE
+// FK, mirroring single-key MemoryDelete.
+func (s *Store) MemoryDeleteScope(ctx context.Context, scope store.MemoryScope, scopeID string) (int, error) {
+	tag, err := s.pool.Exec(ctx,
+		`DELETE FROM memory WHERE scope = $1 AND scope_id = $2`,
+		string(scope), scopeID,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("memory delete scope: %w", err)
+	}
+	return int(tag.RowsAffected()), nil
+}
+
 // MemoryList enumerates entries for a (scope, scopeID), filtered by
 // prefix and capped at limit. The query fetches limit+1 rows so we
 // can report truncated == true without a separate COUNT(*).

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -3785,6 +3785,24 @@ func (s *Store) MemoryDelete(ctx context.Context, scope store.MemoryScope, scope
 	return n > 0, nil
 }
 
+// MemoryDeleteScope removes every entry under (scope, scopeID) in one statement
+// (RFC BM retention). memory_embeddings rows cascade via their ON DELETE CASCADE
+// FK (foreign_keys=ON in the driver DSN), mirroring single-key MemoryDelete.
+func (s *Store) MemoryDeleteScope(ctx context.Context, scope store.MemoryScope, scopeID string) (int, error) {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM memory WHERE scope = ? AND scope_id = ?`,
+		string(scope), scopeID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return int(n), nil
+}
+
 // MemoryList enumerates entries for a (scope, scopeID), filtered by
 // prefix and capped at limit rows. Expired rows are filtered in the
 // WHERE clause so callers never see them. truncated == true when the

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1419,6 +1419,16 @@ type Store interface {
 	// already expired). Both are non-error paths.
 	MemoryDelete(ctx context.Context, scope MemoryScope, scopeID, key string) (bool, error)
 
+	// MemoryDeleteScope removes EVERY entry under (scope, scopeID) in one
+	// statement and returns the row count deleted (memory_embeddings rows
+	// cascade via their FK). Used by the RFC BM retention sweeper to reclaim a
+	// fully-retired agent's accumulated base-memory k/v. NOTE: the memory table
+	// has no tenant_id column — an agent scope_id is the bare agent name, shared
+	// by same-named agents across tenants — so the caller MUST only invoke this
+	// for a name that is retired in EVERY tenant (globally dead); the store does
+	// not (cannot) enforce tenant isolation here.
+	MemoryDeleteScope(ctx context.Context, scope MemoryScope, scopeID string) (int, error)
+
 	// MemoryList returns entries for the (scope, scopeID) tuple whose
 	// key starts with prefix. An empty prefix returns every key in the
 	// scope. Capped at limit rows; if more rows would match, callers

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -3343,12 +3343,14 @@ func testMemoryListTruncation(t *testing.T, s store.Store) {
 
 func testMemoryTTLExpiry(t *testing.T, s store.Store) {
 	ctx := context.Background()
-	// 50 ms TTL — short enough for a test, long enough to survive the
-	// initial Get on a slow CI runner.
-	if err := s.MemorySet(ctx, store.MemoryScopeAgent, "qa", "warning", json.RawMessage(`"hi"`), 50*time.Millisecond); err != nil {
+	// Part 1 — expires_at is recorded when ttl > 0. Use a LONG ttl so the
+	// confirming Get can never race the expiry: a short-ttl key read on a slow CI
+	// runner could already be gone before the first Get (a MemorySet that itself
+	// takes >ttl under load), which used to flake this test.
+	if err := s.MemorySet(ctx, store.MemoryScopeAgent, "qa", "longlived", json.RawMessage(`"hi"`), time.Hour); err != nil {
 		t.Fatal(err)
 	}
-	got, err := s.MemoryGet(ctx, store.MemoryScopeAgent, "qa", "warning")
+	got, err := s.MemoryGet(ctx, store.MemoryScopeAgent, "qa", "longlived")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3356,7 +3358,13 @@ func testMemoryTTLExpiry(t *testing.T, s store.Store) {
 		t.Error("expires_at should be set when ttl > 0")
 	}
 
-	time.Sleep(100 * time.Millisecond)
+	// Part 2 — a short-ttl key is gone after a sleep well past its ttl. There is
+	// NO Get between the set and the sleep, so runner slowness only makes the key
+	// MORE certainly expired (more wall-clock elapses); this direction can't flake.
+	if err := s.MemorySet(ctx, store.MemoryScopeAgent, "qa", "warning", json.RawMessage(`"hi"`), 50*time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(250 * time.Millisecond)
 
 	_, err = s.MemoryGet(ctx, store.MemoryScopeAgent, "qa", "warning")
 	var nf *store.ErrNotFound
@@ -3364,8 +3372,7 @@ func testMemoryTTLExpiry(t *testing.T, s store.Store) {
 		t.Errorf("expired key should return ErrNotFound, got %v", err)
 	}
 
-	// MemoryList must filter expired entries even before the sweeper
-	// runs.
+	// MemoryList must filter expired entries even before the sweeper runs.
 	listed, _, err := s.MemoryList(ctx, store.MemoryScopeAgent, "qa", "warning", 10)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -136,6 +136,7 @@ func Run(t *testing.T, factory Factory) {
 		{"MemoryGetNotFound", testMemoryGetNotFound},
 		{"MemoryOverwriteUpdatesValue", testMemoryOverwriteUpdatesValue},
 		{"MemoryDelete", testMemoryDelete},
+		{"MemoryDeleteScope", testMemoryDeleteScope},
 		{"MemoryListPrefix", testMemoryListPrefix},
 		{"MemoryListTruncation", testMemoryListTruncation},
 		{"MemoryTTLExpiry", testMemoryTTLExpiry},
@@ -3242,6 +3243,46 @@ func testMemoryDelete(t *testing.T, s store.Store) {
 	}
 	if deleted {
 		t.Error("expected deleted=false on a missing key")
+	}
+}
+
+// testMemoryDeleteScope is the RFC BM Phase 3 bulk-scope delete: it removes every
+// key under one (scope, scopeID) and returns the count, without touching a
+// sibling scope_id or a different scope.
+func testMemoryDeleteScope(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	// Target scope: three keys under (agent, "reaped").
+	_ = s.MemorySet(ctx, store.MemoryScopeAgent, "reaped", "k1", json.RawMessage(`1`), 0)
+	_ = s.MemorySet(ctx, store.MemoryScopeAgent, "reaped", "k2", json.RawMessage(`2`), 0)
+	_ = s.MemorySet(ctx, store.MemoryScopeAgent, "reaped", "k3", json.RawMessage(`3`), 0)
+	// A sibling agent scope_id and a same-id user scope must survive.
+	_ = s.MemorySet(ctx, store.MemoryScopeAgent, "kept", "k1", json.RawMessage(`9`), 0)
+	_ = s.MemorySet(ctx, store.MemoryScopeUser, "reaped", "k1", json.RawMessage(`8`), 0)
+
+	n, err := s.MemoryDeleteScope(ctx, store.MemoryScopeAgent, "reaped")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 3 {
+		t.Errorf("MemoryDeleteScope deleted %d, want 3", n)
+	}
+	if got, _, _ := s.MemoryList(ctx, store.MemoryScopeAgent, "reaped", "", 100); len(got) != 0 {
+		t.Errorf("target scope still has %d keys after delete", len(got))
+	}
+	// Siblings untouched.
+	if got, _, _ := s.MemoryList(ctx, store.MemoryScopeAgent, "kept", "", 100); len(got) != 1 {
+		t.Errorf("sibling agent scope_id lost keys: have %d, want 1", len(got))
+	}
+	if got, _, _ := s.MemoryList(ctx, store.MemoryScopeUser, "reaped", "", 100); len(got) != 1 {
+		t.Errorf("same-id user scope lost keys: have %d, want 1", len(got))
+	}
+	// Idempotent: a second delete removes nothing.
+	n, err = s.MemoryDeleteScope(ctx, store.MemoryScopeAgent, "reaped")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Errorf("second MemoryDeleteScope deleted %d, want 0", n)
 	}
 }
 


### PR DESCRIPTION
## Why
RFC BM P1 (#796) freed retired **def versions**; P2 (#797) freed aged **chats**. But a retired agent's accumulated per-scope **data** was still immortal — its SQL databases + document structure (SQL Memory), document bodies + learned facts (base memory k/v), and Path names (dirents) all outlive the agent forever. P3 reclaims a fully-retired agent's data, opt-in, closing the RFC BM memory family and completing the RFC.

## What
A `mem` sub-sweep in `internal/retention`. An agent whose **every** def version is retired (`AgentDefListNames` `LiveVersionCount==0`) and whose latest version is older than `MemMaxAge` is reclaimed in **two passes with different tenant-keying** — because base memory and the other facets key differently:

- **Pass 1 — per `(tenant, name)`, tenant-qualified (safe):** drop the agent's **SQL-Memory scope** (new `sqlmem.Manager.DropScope`, wrapping the existing `dropScopePG` / sqlite fenced-remove; rejects the run scope + empty key) and its **dirents** (`DirentDeleteUnder` at the scope root).
- **Pass 2 — per `name`, GLOBALLY DEAD only:** drop the agent's **base-memory k/v** (new `store.MemoryDeleteScope`; embeddings cascade via FK). Base memory is keyed by the **bare agent name** (the `memory` table has no tenant column), so it's shared by same-named agents across tenants — dropping it is safe **only when the name is retired in every tenant**. A name live in any tenant keeps its base memory. **This is the load-bearing cross-tenant safety invariant.**

**export-then-delete:** `export+prune` dumps each facet to `<ExportDir>/agents/<day>/{sqlmem,dirents,agent-memory}/<tenant>__<name>.json` before dropping (`fsSafe` filenames for `/`-grouped agent names). SQL-Memory export/drop is gated on `ListScopes` membership so `ExportScope` never provisions an empty scope; a failed export or scope drop **aborts that agent's dirent drop** so names are never orphaned from a still-present scope. `memEligible` is shared by the sweep and the report so the count can't drift.

**Config:** `LOOMCYCLE_RETENTION_MEM_MODE` / `_MEM_MAX_AGE_MS` (opt-in, default off). `main.go` hoists the `sqlMemMgr` declaration so the sweeper can reach it (nil-safe: base memory + dirents still reclaim when SQL Memory is disabled). `GET /v1/_retention` gains `mem_mode`/`mem_max_age` (tenant-readable) + `purgeable["mem"]` + a `sqlmem_gc` block surfacing the separate always-on SQL-Memory GC (admin-only).

**Scope decision:** document age-retention was **dropped** from P3 (operator-confirmed) — the loomcycle document store now holds every RFC and guide, so an age-based purge could delete them, and documents have no cross-scope age-enumeration surface. Explicit `delete_document` remains.

## Tested
- Store contract `MemoryDeleteScope` (sqlite + **real Postgres**) — deletes a whole scope, leaves siblings + same-id other-scope alone, idempotent.
- sqlmem `TestDropScope_SQLite` + `TestDropScope_Postgres` — drops one durable scope idempotently, leaves siblings, rejects run scope + empty key.
- retention `TestSweeper_Mem{ReclaimsRetiredAgent, BaseMemoryOnlyDroppedWhenGloballyDead, ExportThenDelete, ExportFailureSkipsDrop, DryRunCounts}`.
- **Cross-tenant safety is fail-before verified:** dropping the globally-dead gate makes `TestSweeper_MemBaseMemoryOnlyDroppedWhenGloballyDead` fail (base memory deleted while a live tenant still uses it).
- `gofmt` + `go vet` clean; full affected suites green on sqlite + Postgres.

> ⚠️ Pre-existing unrelated failure: `TestStoreContract/ChannelPurge` fails identically on **clean HEAD** (verified via a worktree) — not touched by this change. Flagging separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)