### PR TITLE
test(provider-gate): de-flake the two sub-agent gate tests (CI race runner)

### DIFF
--- a/internal/api/http/provider_gate_subagent_test.go
+++ b/internal/api/http/provider_gate_subagent_test.go
@@ -199,7 +199,12 @@ func TestProviderGate_SubAgentFanoutBatchesToCap(t *testing.T) {
 	}
 	// Workers (capped provider): each a single-iteration run; countingProvider
 	// records the peak concurrent Call so we can assert it equals the cap exactly.
-	workerProv := &countingProvider{delay: 40 * time.Millisecond}
+	// holdUntil=cap makes the admitted workers RENDEZVOUS before releasing, so the
+	// observed peak deterministically reaches the gate cap regardless of race-runner
+	// scheduling jitter (a delay-only window flaked on loaded CI). A real
+	// under/over-gate bug still fails: too few admitted → the barrier deadline fires
+	// (peak < cap); too many admitted → peak > cap.
+	workerProv := &countingProvider{delay: 40 * time.Millisecond, holdUntil: cap}
 
 	cfg := makeBaseConfig()
 	cfg.Agents = map[string]config.AgentDef{
@@ -381,7 +386,13 @@ func TestProviderGate_SubAgentZeroOverheadWhenUnconfigured(t *testing.T) {
 			},
 		},
 	}
-	workerProv := &countingProvider{delay: 30 * time.Millisecond}
+	// holdUntil=workers: with NO gate all workers should overlap, so make them
+	// RENDEZVOUS — peak deterministically reaches `workers` (>1) regardless of
+	// race-runner jitter (a delay-only window flaked on loaded CI, staggering the
+	// workers to a false peak=1). A real serialization bug leaves them unable to
+	// rendezvous → the barrier deadline fires per call → peak stays 1 → the
+	// `peak <= 1` assertion still catches it.
+	workerProv := &countingProvider{delay: 30 * time.Millisecond, holdUntil: workers}
 
 	cfg := makeBaseConfig()
 	cfg.Agents = map[string]config.AgentDef{


### PR DESCRIPTION
## Problem
`TestProviderGate_SubAgentZeroOverheadWhenUnconfigured` flaked on the **race-detector** CI job (surfaced on the v1.32.0 release PR): `peak = 1; with no gate all 4 workers should overlap (peak > 1)`. The worker `countingProvider` relied on a **delay-only** overlap window (30 ms), and a loaded race runner staggered the 4 spawned workers so only one was ever in `provider.Call` at a time — a false `peak=1`. Its sibling `TestProviderGate_SubAgentFanoutBatchesToCap` (asserts `peak == cap`) has the same fragility.

Not related to RFC BM — the release PR was docs-only; this is a pre-existing race-runner flake.

## Fix
The deterministic mechanism already exists — the **`holdUntil` rendezvous barrier** on `countingProvider`, added for `TestProviderGate_BatchesToCap` in `provider_gate_admission_test.go` — but was never applied to these two sub-agent tests. This wires it in:
- **ZeroOverheadWhenUnconfigured**: `holdUntil=workers` → the ungated workers rendezvous → `peak` reaches `workers` (>1) regardless of jitter.
- **FanoutBatchesToCap**: `holdUntil=cap` → the gate-admitted workers rendezvous → `peak` reaches exactly `cap`.

Both still catch a real gate bug: too few admitted → the 2 s barrier deadline fires → `peak < expected`; too many admitted → `peak > expected`.

## Tested
`go test ./internal/api/http/ -run 'TestProviderGate_SubAgent...' -race -count=5` + the full `TestProviderGate` suite under `-race`, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)