### PR TITLE
feat(memory): tenant-isolate the base Memory store + provenance columns (RFC BL P1)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -3807,7 +3807,7 @@ func bootstrapMemoryEntries(ctx context.Context, cfg *config.Config, st store.St
 			failed++
 			continue
 		}
-		if _, err := st.MemoryGet(ctx, scope, e.ScopeID, key); err == nil {
+		if _, err := st.MemoryGet(ctx, "", scope, e.ScopeID, key); err == nil {
 			// Row already present — yaml seeding is a one-time
 			// bootstrap, never an overwrite. This is the line that
 			// makes the loader safe to re-run on every boot.
@@ -3832,7 +3832,7 @@ func bootstrapMemoryEntries(ctx context.Context, cfg *config.Config, st store.St
 			failed++
 			continue
 		}
-		if err := st.MemorySet(ctx, scope, e.ScopeID, key, valBytes, 0); err != nil {
+		if err := st.MemorySet(ctx, "", scope, e.ScopeID, key, valBytes, 0); err != nil {
 			log.Printf("memory.entries[%d] (%s/%s/%s): set failed: %v",
 				i, scope, e.ScopeID, key, err)
 			failed++
@@ -3861,7 +3861,7 @@ func bootstrapMemoryEntries(ctx context.Context, cfg *config.Config, st store.St
 				i, scope, e.ScopeID, key, embedErr)
 			continue
 		}
-		if err := st.MemoryEmbedSet(ctx, scope, e.ScopeID, key, store.MemoryEmbedding{
+		if err := st.MemoryEmbedSet(ctx, "", scope, e.ScopeID, key, store.MemoryEmbedding{
 			Provider:  embedder.Provider(),
 			Model:     embedder.Model(),
 			Dimension: embedder.Dimension(),

--- a/internal/api/http/memory.go
+++ b/internal/api/http/memory.go
@@ -104,7 +104,7 @@ func (s *Server) handleListMemoryScopeIDs(w http.ResponseWriter, r *http.Request
 			"scope must be one of: agent, user")
 		return
 	}
-	rows, err := s.store.MemoryListScopeIDs(r.Context(), store.MemoryScope(scope))
+	rows, err := s.store.MemoryListScopeIDs(r.Context(), "", store.MemoryScope(scope))
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "internal", err.Error())
 		return
@@ -147,7 +147,7 @@ func (s *Server) handleListMemoryEntries(w http.ResponseWriter, r *http.Request)
 	if limit > 1000 {
 		limit = 1000
 	}
-	entries, truncated, err := s.store.MemoryList(r.Context(), store.MemoryScope(scope), scopeID, prefix, limit)
+	entries, truncated, err := s.store.MemoryList(r.Context(), "", store.MemoryScope(scope), scopeID, prefix, limit)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "internal", err.Error())
 		return
@@ -169,7 +169,7 @@ func (s *Server) handleListMemoryEntries(w http.ResponseWriter, r *http.Request)
 	if r.URL.Query().Get("include_embedding_metadata") == "true" && s.store.SupportsVectors() {
 		meta := make(map[string]memoryEmbedMeta)
 		for _, e := range entries {
-			emb, err := s.store.MemoryEmbedGet(r.Context(), store.MemoryScope(scope), scopeID, e.Key)
+			emb, err := s.store.MemoryEmbedGet(r.Context(), "", store.MemoryScope(scope), scopeID, e.Key)
 			if err != nil || emb.Dimension == 0 {
 				continue // no embedding for this key (or a transient error) → omit
 			}
@@ -206,7 +206,7 @@ func (s *Server) handleGetMemoryEntry(w http.ResponseWriter, r *http.Request) {
 			"scope_id and key are required")
 		return
 	}
-	entry, err := s.store.MemoryGet(r.Context(), store.MemoryScope(scope), scopeID, key)
+	entry, err := s.store.MemoryGet(r.Context(), "", store.MemoryScope(scope), scopeID, key)
 	if err != nil {
 		var nf *store.ErrNotFound
 		if errors.As(err, &nf) {
@@ -316,7 +316,7 @@ func (s *Server) handlePutMemoryEntry(w http.ResponseWriter, r *http.Request) {
 	if body.TTLSeconds > 0 {
 		ttl = time.Duration(body.TTLSeconds) * time.Second
 	}
-	if err := s.store.MemorySet(r.Context(), store.MemoryScope(scope), scopeID, key, body.Value, ttl); err != nil {
+	if err := s.store.MemorySet(r.Context(), "", store.MemoryScope(scope), scopeID, key, body.Value, ttl); err != nil {
 		if errors.Is(err, store.ErrMemoryQuotaExceeded) {
 			writeJSONError(w, http.StatusRequestEntityTooLarge, "memory_quota_exceeded", err.Error())
 			return
@@ -366,7 +366,7 @@ func (s *Server) handleDeleteMemoryEntry(w http.ResponseWriter, r *http.Request)
 			"scope_id and key are required")
 		return
 	}
-	if _, err := s.store.MemoryDelete(r.Context(), store.MemoryScope(scope), scopeID, key); err != nil {
+	if _, err := s.store.MemoryDelete(r.Context(), "", store.MemoryScope(scope), scopeID, key); err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "internal", err.Error())
 		return
 	}
@@ -394,7 +394,7 @@ func (s *Server) embedMemoryEntry(ctx context.Context, scope store.MemoryScope, 
 	if len(vecs) != 1 {
 		return errors.New("embedder returned unexpected vector count")
 	}
-	return s.store.MemoryEmbedSet(ctx, scope, scopeID, key, store.MemoryEmbedding{
+	return s.store.MemoryEmbedSet(ctx, "", scope, scopeID, key, store.MemoryEmbedding{
 		Provider:  s.embedder.Provider(),
 		Model:     s.embedder.Model(),
 		Dimension: s.embedder.Dimension(),

--- a/internal/api/http/memory.go
+++ b/internal/api/http/memory.go
@@ -104,7 +104,10 @@ func (s *Server) handleListMemoryScopeIDs(w http.ResponseWriter, r *http.Request
 			"scope must be one of: agent, user")
 		return
 	}
-	rows, err := s.store.MemoryListScopeIDs(r.Context(), "", store.MemoryScope(scope))
+	// RFC BL: scope the admin browse to the authenticated principal's tenant
+	// (server-sourced via tenantFromCtx — never from the URL/body). Open mode /
+	// legacy resolve to "" so single-tenant deployments are unchanged.
+	rows, err := s.store.MemoryListScopeIDs(r.Context(), tenantFromCtx(r.Context()), store.MemoryScope(scope))
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "internal", err.Error())
 		return
@@ -147,7 +150,10 @@ func (s *Server) handleListMemoryEntries(w http.ResponseWriter, r *http.Request)
 	if limit > 1000 {
 		limit = 1000
 	}
-	entries, truncated, err := s.store.MemoryList(r.Context(), "", store.MemoryScope(scope), scopeID, prefix, limit)
+	// RFC BL: tenant from the authenticated principal (server-sourced), one
+	// lookup reused by the entries list + the per-key embedding-metadata probe.
+	tenantID := tenantFromCtx(r.Context())
+	entries, truncated, err := s.store.MemoryList(r.Context(), tenantID, store.MemoryScope(scope), scopeID, prefix, limit)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "internal", err.Error())
 		return
@@ -169,7 +175,7 @@ func (s *Server) handleListMemoryEntries(w http.ResponseWriter, r *http.Request)
 	if r.URL.Query().Get("include_embedding_metadata") == "true" && s.store.SupportsVectors() {
 		meta := make(map[string]memoryEmbedMeta)
 		for _, e := range entries {
-			emb, err := s.store.MemoryEmbedGet(r.Context(), "", store.MemoryScope(scope), scopeID, e.Key)
+			emb, err := s.store.MemoryEmbedGet(r.Context(), tenantID, store.MemoryScope(scope), scopeID, e.Key)
 			if err != nil || emb.Dimension == 0 {
 				continue // no embedding for this key (or a transient error) → omit
 			}
@@ -206,7 +212,7 @@ func (s *Server) handleGetMemoryEntry(w http.ResponseWriter, r *http.Request) {
 			"scope_id and key are required")
 		return
 	}
-	entry, err := s.store.MemoryGet(r.Context(), "", store.MemoryScope(scope), scopeID, key)
+	entry, err := s.store.MemoryGet(r.Context(), tenantFromCtx(r.Context()), store.MemoryScope(scope), scopeID, key)
 	if err != nil {
 		var nf *store.ErrNotFound
 		if errors.As(err, &nf) {
@@ -316,7 +322,7 @@ func (s *Server) handlePutMemoryEntry(w http.ResponseWriter, r *http.Request) {
 	if body.TTLSeconds > 0 {
 		ttl = time.Duration(body.TTLSeconds) * time.Second
 	}
-	if err := s.store.MemorySet(r.Context(), "", store.MemoryScope(scope), scopeID, key, body.Value, ttl); err != nil {
+	if err := s.store.MemorySet(r.Context(), tenantFromCtx(r.Context()), store.MemoryScope(scope), scopeID, key, body.Value, ttl); err != nil {
 		if errors.Is(err, store.ErrMemoryQuotaExceeded) {
 			writeJSONError(w, http.StatusRequestEntityTooLarge, "memory_quota_exceeded", err.Error())
 			return
@@ -366,7 +372,7 @@ func (s *Server) handleDeleteMemoryEntry(w http.ResponseWriter, r *http.Request)
 			"scope_id and key are required")
 		return
 	}
-	if _, err := s.store.MemoryDelete(r.Context(), "", store.MemoryScope(scope), scopeID, key); err != nil {
+	if _, err := s.store.MemoryDelete(r.Context(), tenantFromCtx(r.Context()), store.MemoryScope(scope), scopeID, key); err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "internal", err.Error())
 		return
 	}
@@ -394,7 +400,9 @@ func (s *Server) embedMemoryEntry(ctx context.Context, scope store.MemoryScope, 
 	if len(vecs) != 1 {
 		return errors.New("embedder returned unexpected vector count")
 	}
-	return s.store.MemoryEmbedSet(ctx, "", scope, scopeID, key, store.MemoryEmbedding{
+	// RFC BL: same tenant partition the PUT wrote the k/v row under
+	// (tenantFromCtx reads the principal on the request ctx).
+	return s.store.MemoryEmbedSet(ctx, tenantFromCtx(ctx), scope, scopeID, key, store.MemoryEmbedding{
 		Provider:  s.embedder.Provider(),
 		Model:     s.embedder.Model(),
 		Dimension: s.embedder.Dimension(),

--- a/internal/api/http/memory_admin.go
+++ b/internal/api/http/memory_admin.go
@@ -81,7 +81,8 @@ func (s *Server) handleMemoryEmbedStats(w http.ResponseWriter, r *http.Request) 
 			"scope must be one of: agent, user")
 		return
 	}
-	stats, err := s.store.MemoryEmbedStats(r.Context(), "", store.MemoryScope(scope))
+	// RFC BL: tenant from the authenticated principal (server-sourced).
+	stats, err := s.store.MemoryEmbedStats(r.Context(), tenantFromCtx(r.Context()), store.MemoryScope(scope))
 	if err != nil {
 		// Vector-unsupported can also surface here from refusal-stub
 		// backends — treat as 503 for consistency with the upfront
@@ -170,7 +171,10 @@ func (s *Server) handleMemoryReembed(w http.ResponseWriter, r *http.Request) {
 			limit = n
 		}
 	}
-	rows, err := s.store.MemoryEmbedListByModel(r.Context(), "",
+	// RFC BL: tenant from the authenticated principal, reused for the read +
+	// the write-back below so the reembed stays within one tenant partition.
+	tenantID := tenantFromCtx(r.Context())
+	rows, err := s.store.MemoryEmbedListByModel(r.Context(), tenantID,
 		store.MemoryScope(scope), scopeID,
 		currentEmbedder.Provider, currentEmbedder.Model, limit)
 	if err != nil {
@@ -235,7 +239,7 @@ func (s *Server) handleMemoryReembed(w http.ResponseWriter, r *http.Request) {
 			EmbedText: string(row.Value),
 			CreatedAt: time.Now().UTC(),
 		}
-		if err := s.store.MemoryEmbedSet(r.Context(), "",
+		if err := s.store.MemoryEmbedSet(r.Context(), tenantID,
 			store.MemoryScope(scope), scopeID, row.Key, emb); err != nil {
 			failed++
 			failedKeys = append(failedKeys, row.Key)

--- a/internal/api/http/memory_admin.go
+++ b/internal/api/http/memory_admin.go
@@ -81,7 +81,7 @@ func (s *Server) handleMemoryEmbedStats(w http.ResponseWriter, r *http.Request) 
 			"scope must be one of: agent, user")
 		return
 	}
-	stats, err := s.store.MemoryEmbedStats(r.Context(), store.MemoryScope(scope))
+	stats, err := s.store.MemoryEmbedStats(r.Context(), "", store.MemoryScope(scope))
 	if err != nil {
 		// Vector-unsupported can also surface here from refusal-stub
 		// backends — treat as 503 for consistency with the upfront
@@ -170,10 +170,9 @@ func (s *Server) handleMemoryReembed(w http.ResponseWriter, r *http.Request) {
 			limit = n
 		}
 	}
-	rows, err := s.store.MemoryEmbedListByModel(r.Context(),
+	rows, err := s.store.MemoryEmbedListByModel(r.Context(), "",
 		store.MemoryScope(scope), scopeID,
-		currentEmbedder.Provider, currentEmbedder.Model, limit,
-	)
+		currentEmbedder.Provider, currentEmbedder.Model, limit)
 	if err != nil {
 		if errors.Is(err, store.ErrVectorUnsupported) {
 			writeJSONError(w, http.StatusServiceUnavailable, "vector_unsupported", err.Error())
@@ -236,7 +235,7 @@ func (s *Server) handleMemoryReembed(w http.ResponseWriter, r *http.Request) {
 			EmbedText: string(row.Value),
 			CreatedAt: time.Now().UTC(),
 		}
-		if err := s.store.MemoryEmbedSet(r.Context(),
+		if err := s.store.MemoryEmbedSet(r.Context(), "",
 			store.MemoryScope(scope), scopeID, row.Key, emb); err != nil {
 			failed++
 			failedKeys = append(failedKeys, row.Key)

--- a/internal/api/http/memory_admin_test.go
+++ b/internal/api/http/memory_admin_test.go
@@ -43,7 +43,7 @@ func newVectorAdminStore(s store.Store, supports bool) *vectorAdminStore {
 
 func (v *vectorAdminStore) SupportsVectors() bool { return v.supports }
 
-func (v *vectorAdminStore) MemoryEmbedSet(ctx context.Context, scope store.MemoryScope, scopeID, key string, e store.MemoryEmbedding) error {
+func (v *vectorAdminStore) MemoryEmbedSet(ctx context.Context, _ string, scope store.MemoryScope, scopeID, key string, e store.MemoryEmbedding) error {
 	if !v.supports {
 		return store.ErrVectorUnsupported
 	}
@@ -53,7 +53,7 @@ func (v *vectorAdminStore) MemoryEmbedSet(ctx context.Context, scope store.Memor
 	return nil
 }
 
-func (v *vectorAdminStore) MemoryEmbedGet(ctx context.Context, scope store.MemoryScope, scopeID, key string) (store.MemoryEmbedding, error) {
+func (v *vectorAdminStore) MemoryEmbedGet(ctx context.Context, _ string, scope store.MemoryScope, scopeID, key string) (store.MemoryEmbedding, error) {
 	v.mu.Lock()
 	defer v.mu.Unlock()
 	e, ok := v.embeds[string(scope)+"|"+scopeID+"|"+key]
@@ -63,7 +63,7 @@ func (v *vectorAdminStore) MemoryEmbedGet(ctx context.Context, scope store.Memor
 	return e, nil
 }
 
-func (v *vectorAdminStore) MemoryEmbedListByModel(ctx context.Context, scope store.MemoryScope, scopeID, currentProvider, currentModel string, limit int) ([]store.MemoryEntry, error) {
+func (v *vectorAdminStore) MemoryEmbedListByModel(ctx context.Context, _ string, scope store.MemoryScope, scopeID, currentProvider, currentModel string, limit int) ([]store.MemoryEntry, error) {
 	if !v.supports {
 		return nil, store.ErrVectorUnsupported
 	}
@@ -79,7 +79,7 @@ func (v *vectorAdminStore) MemoryEmbedListByModel(ctx context.Context, scope sto
 			continue
 		}
 		key := strings.TrimPrefix(k, prefix)
-		entry, err := v.Store.MemoryGet(ctx, scope, scopeID, key)
+		entry, err := v.Store.MemoryGet(ctx, "", scope, scopeID, key)
 		if err != nil {
 			continue
 		}
@@ -91,11 +91,11 @@ func (v *vectorAdminStore) MemoryEmbedListByModel(ctx context.Context, scope sto
 	return out, nil
 }
 
-func (v *vectorAdminStore) MemoryEmbedSearch(ctx context.Context, scope store.MemoryScope, scopeID, keyPrefix string, query []float32, topK int) ([]store.MemorySearchEntry, error) {
+func (v *vectorAdminStore) MemoryEmbedSearch(ctx context.Context, _ string, scope store.MemoryScope, scopeID, keyPrefix string, query []float32, topK int) ([]store.MemorySearchEntry, error) {
 	return nil, errors.New("MemoryEmbedSearch not implemented in admin fake")
 }
 
-func (v *vectorAdminStore) MemoryEmbedStats(ctx context.Context, scope store.MemoryScope) (store.MemoryEmbedStats, error) {
+func (v *vectorAdminStore) MemoryEmbedStats(ctx context.Context, _ string, scope store.MemoryScope) (store.MemoryEmbedStats, error) {
 	if !v.supports {
 		return store.MemoryEmbedStats{}, store.ErrVectorUnsupported
 	}
@@ -194,7 +194,7 @@ func preloadReembedFixture(t *testing.T, srv *Server, vs *vectorAdminStore) {
 	ctx := context.Background()
 	// k/v rows.
 	for _, k := range []string{"old1", "old2", "current"} {
-		if err := srv.store.MemorySet(ctx, store.MemoryScopeUser, "alice", k, []byte(`"x"`), 0); err != nil {
+		if err := srv.store.MemorySet(ctx, "", store.MemoryScopeUser, "alice", k, []byte(`"x"`), 0); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -340,7 +340,7 @@ func TestReembed_DryRunDefaultEvenWithoutFlag(t *testing.T) {
 	// Confirm no writes happened by re-checking the embedder
 	// versions on the two old rows.
 	for _, k := range []string{"old1", "old2"} {
-		emb, err := vs.MemoryEmbedGet(context.Background(), store.MemoryScopeUser, "alice", k)
+		emb, err := vs.MemoryEmbedGet(context.Background(), "", store.MemoryScopeUser, "alice", k)
 		if err != nil {
 			t.Fatalf("%s: %v", k, err)
 		}
@@ -375,7 +375,7 @@ func TestReembed_RealRunReembedsRowsAndUpdatesModel(t *testing.T) {
 	}
 	// Both old rows must now report the new model.
 	for _, k := range []string{"old1", "old2"} {
-		emb, err := vs.MemoryEmbedGet(context.Background(), store.MemoryScopeUser, "alice", k)
+		emb, err := vs.MemoryEmbedGet(context.Background(), "", store.MemoryScopeUser, "alice", k)
 		if err != nil {
 			t.Fatalf("%s: %v", k, err)
 		}
@@ -385,7 +385,7 @@ func TestReembed_RealRunReembedsRowsAndUpdatesModel(t *testing.T) {
 	}
 	// The already-current row must NOT have been re-embedded —
 	// MemoryEmbedListByModel excludes it.
-	emb, _ := vs.MemoryEmbedGet(context.Background(), store.MemoryScopeUser, "alice", "current")
+	emb, _ := vs.MemoryEmbedGet(context.Background(), "", store.MemoryScopeUser, "alice", "current")
 	if emb.Model != "text-embedding-3-large" {
 		t.Errorf("current row unexpectedly changed: %+v", emb)
 	}

--- a/internal/api/http/memory_test.go
+++ b/internal/api/http/memory_test.go
@@ -29,14 +29,14 @@ func memoryAdminFixture(t *testing.T) *Server {
 
 	ctx := t.Context()
 	for _, k := range []string{"voice", "tone"} {
-		if err := st.MemorySet(ctx, store.MemoryScopeUser, "alice", k, []byte(`"`+k+`-value"`), 0); err != nil {
+		if err := st.MemorySet(ctx, "", store.MemoryScopeUser, "alice", k, []byte(`"`+k+`-value"`), 0); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if err := st.MemorySet(ctx, store.MemoryScopeUser, "bob", "voice", []byte(`"bob-voice"`), 0); err != nil {
+	if err := st.MemorySet(ctx, "", store.MemoryScopeUser, "bob", "voice", []byte(`"bob-voice"`), 0); err != nil {
 		t.Fatal(err)
 	}
-	if err := st.MemorySet(ctx, store.MemoryScopeAgent, "qa-agent", "warnings", []byte(`5`), 0); err != nil {
+	if err := st.MemorySet(ctx, "", store.MemoryScopeAgent, "qa-agent", "warnings", []byte(`5`), 0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -237,7 +237,7 @@ func TestHandleGetMemoryEntry_RoundTrip(t *testing.T) {
 // the full Mux() so the pattern matching is part of the test.
 func TestHandleGetMemoryEntry_MultiSegmentKey(t *testing.T) {
 	s := memoryAdminFixture(t)
-	if err := s.store.MemorySet(t.Context(), store.MemoryScopeAgent, "qa-agent",
+	if err := s.store.MemorySet(t.Context(), "", store.MemoryScopeAgent, "qa-agent",
 		"events/2026-05-09T10:00", []byte(`"first event"`), 0); err != nil {
 		t.Fatal(err)
 	}
@@ -290,7 +290,7 @@ func TestHandlePutMemoryEntry_CreatesAndOverwrites(t *testing.T) {
 
 	// Read back via the store directly (the admin GET is exercised
 	// in TestHandleGetMemoryEntry_*).
-	got, err := s.store.MemoryGet(t.Context(), store.MemoryScopeUser, "charlie", "profile")
+	got, err := s.store.MemoryGet(t.Context(), "", store.MemoryScopeUser, "charlie", "profile")
 	if err != nil {
 		t.Fatalf("MemoryGet after PUT: %v", err)
 	}
@@ -308,7 +308,7 @@ func TestHandlePutMemoryEntry_CreatesAndOverwrites(t *testing.T) {
 	if rec2.Code != http.StatusOK {
 		t.Fatalf("overwrite status = %d, want 200", rec2.Code)
 	}
-	got2, _ := s.store.MemoryGet(t.Context(), store.MemoryScopeUser, "charlie", "profile")
+	got2, _ := s.store.MemoryGet(t.Context(), "", store.MemoryScopeUser, "charlie", "profile")
 	if string(got2.Value) != `{"role": "director"}` {
 		t.Errorf("overwrite value = %s", got2.Value)
 	}
@@ -352,7 +352,7 @@ func TestHandleDeleteMemoryEntry_RemovesRow(t *testing.T) {
 	if rec.Code != http.StatusNoContent {
 		t.Fatalf("status = %d, want 204; body=%s", rec.Code, rec.Body.String())
 	}
-	if _, err := s.store.MemoryGet(t.Context(), store.MemoryScopeUser, "alice", "voice"); err == nil {
+	if _, err := s.store.MemoryGet(t.Context(), "", store.MemoryScopeUser, "alice", "voice"); err == nil {
 		t.Errorf("expected NotFound after DELETE, got nil error")
 	}
 }
@@ -383,7 +383,7 @@ func memoryAdminAuthedFixture(t *testing.T) *Server {
 	}
 	t.Cleanup(func() { _ = st.Close() })
 
-	if err := st.MemorySet(t.Context(), store.MemoryScopeUser, "alice", "voice",
+	if err := st.MemorySet(t.Context(), "", store.MemoryScopeUser, "alice", "voice",
 		[]byte(`"alice-voice"`), 0); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/api/http/memory_test.go
+++ b/internal/api/http/memory_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/cancel"
 	"github.com/denn-gubsky/loomcycle/internal/concurrency"
 	"github.com/denn-gubsky/loomcycle/internal/config"
@@ -50,6 +51,53 @@ func memoryAdminFixture(t *testing.T) *Server {
 		hookRegistry:   hookReg,
 		hookDispatcher: hooks.NewDispatcher(hookReg, nil),
 		sem:            concurrency.New(8, 16, 30000),
+	}
+}
+
+// TestHandleMemory_TenantIsolation: an admin PUT under principal-tenant A is
+// invisible to a GET under principal-tenant B (opaque 404) and visible to A.
+// RFC BL turn-on — the admin endpoints source the tenant from the authenticated
+// principal (tenantFromCtx), never the URL/body. Fails on the pre-stamp code
+// where both principals keyed tenant "" so B read A's row.
+func TestHandleMemory_TenantIsolation(t *testing.T) {
+	s := memoryAdminFixture(t)
+
+	withTenant := func(r *http.Request, tenant string) *http.Request {
+		return r.WithContext(auth.WithPrincipal(r.Context(), auth.Principal{
+			TenantID: tenant, Subject: "op", Scopes: []string{auth.ScopeAdmin},
+		}))
+	}
+	setKeyPath := func(r *http.Request) {
+		r.SetPathValue("scope", "user")
+		r.SetPathValue("scope_id", "alice")
+		r.SetPathValue("key", "secret")
+	}
+
+	// PUT key "secret" under principal tenant A.
+	put := httptest.NewRequest("PUT", "/v1/_memory/scopes/user/alice/keys/secret", strings.NewReader(`{"value":"a-only"}`))
+	setKeyPath(put)
+	putRec := httptest.NewRecorder()
+	s.handlePutMemoryEntry(putRec, withTenant(put, "tenant-a"))
+	if putRec.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d, body = %s", putRec.Code, putRec.Body.String())
+	}
+
+	// GET under principal tenant B → 404 (cross-tenant read is opaque).
+	getB := httptest.NewRequest("GET", "/v1/_memory/scopes/user/alice/keys/secret", nil)
+	setKeyPath(getB)
+	recB := httptest.NewRecorder()
+	s.handleGetMemoryEntry(recB, withTenant(getB, "tenant-b"))
+	if recB.Code != http.StatusNotFound {
+		t.Errorf("GET under tenant B = %d, want 404 (must not see tenant A's row); body=%s", recB.Code, recB.Body.String())
+	}
+
+	// GET under principal tenant A → the row.
+	getA := httptest.NewRequest("GET", "/v1/_memory/scopes/user/alice/keys/secret", nil)
+	setKeyPath(getA)
+	recA := httptest.NewRecorder()
+	s.handleGetMemoryEntry(recA, withTenant(getA, "tenant-a"))
+	if recA.Code != http.StatusOK || !strings.Contains(recA.Body.String(), "a-only") {
+		t.Errorf("GET under tenant A = %d body=%s, want 200 with a-only", recA.Code, recA.Body.String())
 	}
 }
 

--- a/internal/api/http/snapshots_test.go
+++ b/internal/api/http/snapshots_test.go
@@ -307,7 +307,7 @@ func TestRestoreSnapshot_FromStoredID(t *testing.T) {
 
 	// Seed some state, capture.
 	ctx := httptest.NewRequest("POST", "/", nil).Context()
-	_ = st.MemorySet(ctx, store.MemoryScope("agent"), "a", "k", []byte(`"v"`), 0)
+	_ = st.MemorySet(ctx, "", store.MemoryScope("agent"), "a", "k", []byte(`"v"`), 0)
 
 	createRec := httptest.NewRecorder()
 	srv.handleCreateSnapshot(createRec, httptest.NewRequest("POST", "/v1/_snapshots", http.NoBody))

--- a/internal/api/webhook/oncomplete.go
+++ b/internal/api/webhook/oncomplete.go
@@ -130,5 +130,5 @@ func (rec *Receiver) dispatchOnCompleteMemorySet(ctx context.Context, name strin
 		return fmt.Errorf("marshal payload: %w", err)
 	}
 	// ttl = 0 means no expiry, mirroring the scheduler's memory.set hook.
-	return rec.store.MemorySet(ctx, scope, scopeID, h.Key, value, time.Duration(0))
+	return rec.store.MemorySet(ctx, "", scope, scopeID, h.Key, value, time.Duration(0))
 }

--- a/internal/api/webhook/oncomplete.go
+++ b/internal/api/webhook/oncomplete.go
@@ -28,18 +28,18 @@ import (
 // webhook NAME, matching the scheduler's stable-key choice).
 func (rec *Receiver) dispatchOnComplete(ctx context.Context, name string, wd config.Webhook, runID, agentID, userID string) {
 	for i, h := range wd.OnComplete {
-		if err := rec.dispatchOneOnComplete(ctx, name, h, runID, agentID, userID); err != nil {
+		if err := rec.dispatchOneOnComplete(ctx, name, wd.TenantID, h, runID, agentID, userID); err != nil {
 			rec.logf("webhook %q: on_complete[%d] (%s) failed: %v", name, i, h.Kind, err)
 		}
 	}
 }
 
-func (rec *Receiver) dispatchOneOnComplete(ctx context.Context, name string, h config.ScheduledRunHook, runID, agentID, userID string) error {
+func (rec *Receiver) dispatchOneOnComplete(ctx context.Context, name, tenantID string, h config.ScheduledRunHook, runID, agentID, userID string) error {
 	switch h.Kind {
 	case "channel.publish":
 		return rec.dispatchOnCompleteChannelPublish(ctx, name, h, runID, agentID, userID)
 	case "memory.set":
-		return rec.dispatchOnCompleteMemorySet(ctx, name, h, userID)
+		return rec.dispatchOnCompleteMemorySet(ctx, name, tenantID, h, userID)
 	case "mcp.call":
 		// The receiver has no MCPCaller wired (exactly like the scheduler's
 		// nil case). Log + skip — never fail the (already-completed) run.
@@ -101,7 +101,7 @@ func (rec *Receiver) dispatchOnCompleteChannelPublish(ctx context.Context, name 
 // scope keys on the webhook NAME (a stable, operator-recognisable key, since
 // a webhook hook doesn't run "as an agent" the way an in-loop tool call
 // does); user scope requires a userID; global has no scope id.
-func (rec *Receiver) dispatchOnCompleteMemorySet(ctx context.Context, name string, h config.ScheduledRunHook, userID string) error {
+func (rec *Receiver) dispatchOnCompleteMemorySet(ctx context.Context, name, tenantID string, h config.ScheduledRunHook, userID string) error {
 	if h.Scope == "" || h.Key == "" {
 		return fmt.Errorf("memory.set missing `scope` or `key`")
 	}
@@ -110,6 +110,11 @@ func (rec *Receiver) dispatchOnCompleteMemorySet(ctx context.Context, name strin
 	}
 	var scope store.MemoryScope
 	scopeID := ""
+	// RFC BL: agent/user-scoped memory is partitioned by the webhook def's tenant
+	// (the spawned run fires as this tenant — sourced from the def row via
+	// migration 0044, NOT a run ctx there is none). global scope is the
+	// cross-tenant shared partition and stays "".
+	memTenant := tenantID
 	switch h.Scope {
 	case "agent":
 		scope = store.MemoryScopeAgent
@@ -122,6 +127,7 @@ func (rec *Receiver) dispatchOnCompleteMemorySet(ctx context.Context, name strin
 		scopeID = userID
 	case "global":
 		scope = store.MemoryScopeGlobal
+		memTenant = ""
 	default:
 		return fmt.Errorf("memory.set: unknown scope %q (must be agent|user|global)", h.Scope)
 	}
@@ -130,5 +136,5 @@ func (rec *Receiver) dispatchOnCompleteMemorySet(ctx context.Context, name strin
 		return fmt.Errorf("marshal payload: %w", err)
 	}
 	// ttl = 0 means no expiry, mirroring the scheduler's memory.set hook.
-	return rec.store.MemorySet(ctx, "", scope, scopeID, h.Key, value, time.Duration(0))
+	return rec.store.MemorySet(ctx, memTenant, scope, scopeID, h.Key, value, time.Duration(0))
 }

--- a/internal/api/webhook/server_test.go
+++ b/internal/api/webhook/server_test.go
@@ -509,7 +509,7 @@ func (f *fakeWebhookStore) ChannelPublish(_ context.Context, msg store.ChannelMe
 	return "msg-1", 0, nil
 }
 
-func (f *fakeWebhookStore) MemorySet(_ context.Context, scope store.MemoryScope, scopeID, key string, value json.RawMessage, _ time.Duration) error {
+func (f *fakeWebhookStore) MemorySet(_ context.Context, _ string, scope store.MemoryScope, scopeID, key string, value json.RawMessage, _ time.Duration) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.memorySets = append(f.memorySets, memorySetCall{scope: scope, scopeID: scopeID, key: key, value: value})
@@ -686,6 +686,6 @@ func (s *raceStore) ChannelPublish(_ context.Context, _ store.ChannelMessage, _ 
 	return "", 0, nil
 }
 
-func (s *raceStore) MemorySet(_ context.Context, _ store.MemoryScope, _, _ string, _ json.RawMessage, _ time.Duration) error {
+func (s *raceStore) MemorySet(_ context.Context, _ string, _ store.MemoryScope, _, _ string, _ json.RawMessage, _ time.Duration) error {
 	return nil
 }

--- a/internal/lookup/webhook.go
+++ b/internal/lookup/webhook.go
@@ -29,7 +29,7 @@ type WebhookStore interface {
 	// interface unchanged; the webhook receiver only needs these two of
 	// the channel/memory surface.
 	ChannelPublish(ctx context.Context, msg store.ChannelMessage, maxMessages int) (id string, dropped int, err error)
-	MemorySet(ctx context.Context, scope store.MemoryScope, scopeID, key string, value json.RawMessage, ttl time.Duration) error
+	MemorySet(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string, value json.RawMessage, ttl time.Duration) error
 }
 
 // Webhook resolves a webhook NAME to its effective config.Webhook within

--- a/internal/lookup/webhook_test.go
+++ b/internal/lookup/webhook_test.go
@@ -45,7 +45,7 @@ func (s *stubWebhookStore) ChannelPublish(_ context.Context, _ store.ChannelMess
 	return "", 0, nil
 }
 
-func (s *stubWebhookStore) MemorySet(_ context.Context, _ store.MemoryScope, _, _ string, _ json.RawMessage, _ time.Duration) error {
+func (s *stubWebhookStore) MemorySet(_ context.Context, _ string, _ store.MemoryScope, _, _ string, _ json.RawMessage, _ time.Duration) error {
 	return nil
 }
 

--- a/internal/memory/backends/inprocess/inprocess.go
+++ b/internal/memory/backends/inprocess/inprocess.go
@@ -39,22 +39,22 @@ func New(s store.Store, e providers.Embedder) *Backend {
 
 // Get delegates to the store.
 func (b *Backend) Get(ctx context.Context, scope store.MemoryScope, scopeID, key string) (store.MemoryEntry, error) {
-	return b.store.MemoryGet(ctx, scope, scopeID, key)
+	return b.store.MemoryGet(ctx, "", scope, scopeID, key)
 }
 
 // Delete delegates to the store.
 func (b *Backend) Delete(ctx context.Context, scope store.MemoryScope, scopeID, key string) (bool, error) {
-	return b.store.MemoryDelete(ctx, scope, scopeID, key)
+	return b.store.MemoryDelete(ctx, "", scope, scopeID, key)
 }
 
 // List delegates to the store.
 func (b *Backend) List(ctx context.Context, scope store.MemoryScope, scopeID, prefix string, limit int) ([]store.MemoryEntry, bool, error) {
-	return b.store.MemoryList(ctx, scope, scopeID, prefix, limit)
+	return b.store.MemoryList(ctx, "", scope, scopeID, prefix, limit)
 }
 
 // Stats delegates to the store.
 func (b *Backend) Stats(ctx context.Context, scope store.MemoryScope) (store.MemoryEmbedStats, error) {
-	return b.store.MemoryEmbedStats(ctx, scope)
+	return b.store.MemoryEmbedStats(ctx, "", scope)
 }
 
 // Set writes the k/v row, then (when opts.Embed) embeds and stores the
@@ -80,7 +80,7 @@ func (b *Backend) Set(ctx context.Context, scope store.MemoryScope, scopeID, key
 		}
 	}
 
-	if err := b.store.MemorySet(ctx, scope, scopeID, key, value, opts.TTL); err != nil {
+	if err := b.store.MemorySet(ctx, "", scope, scopeID, key, value, opts.TTL); err != nil {
 		return memory.SetResult{}, err
 	}
 
@@ -125,7 +125,7 @@ func (b *Backend) persistEmbedding(ctx context.Context, scope store.MemoryScope,
 		EmbedText: text,
 		CreatedAt: time.Now().UTC(),
 	}
-	return b.store.MemoryEmbedSet(ctx, scope, scopeID, key, emb)
+	return b.store.MemoryEmbedSet(ctx, "", scope, scopeID, key, emb)
 }
 
 // Search embeds the query, fetches the cosine pool (with the over-fetch a
@@ -173,7 +173,7 @@ func (b *Backend) Search(ctx context.Context, scope store.MemoryScope, scopeID s
 	// Fetch the candidate pool (cosine-ordered) with a +1 truncation probe:
 	// len(results) > topK distinguishes "more matched than we return" from
 	// "result set fits". Store caps at 51.
-	results, err := b.store.MemoryEmbedSearch(ctx, scope, scopeID, q.Prefix, queryVec, fetch)
+	results, err := b.store.MemoryEmbedSearch(ctx, "", scope, scopeID, q.Prefix, queryVec, fetch)
 	if err != nil {
 		// Pass the error through unwrapped. ErrDimensionMismatch /
 		// ErrVectorUnsupported are user-actionable: the tool's errors.Is

--- a/internal/memory/backends/inprocess/inprocess.go
+++ b/internal/memory/backends/inprocess/inprocess.go
@@ -16,7 +16,16 @@ import (
 	memory "github.com/denn-gubsky/loomcycle/internal/memory"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
+
+// runTenant is the RFC BL isolation axis for base memory: the run's authoritative
+// tenant, sourced from the ctx-carried RunIdentity (server-supplied, never model
+// input). The memory.Backend interface deliberately takes no tenantID param —
+// the base k/v ops key on (scope, scopeID) — so the impl pulls it from ctx here,
+// mirroring how the mem9 backend derives its tenant from the run identity. An
+// empty tenant ("" — open mode / legacy) is the shared/legacy partition.
+func runTenant(ctx context.Context) string { return tools.RunIdentity(ctx).TenantID }
 
 // Backend implements memory.Backend over a store.Store + Embedder.
 //
@@ -39,22 +48,22 @@ func New(s store.Store, e providers.Embedder) *Backend {
 
 // Get delegates to the store.
 func (b *Backend) Get(ctx context.Context, scope store.MemoryScope, scopeID, key string) (store.MemoryEntry, error) {
-	return b.store.MemoryGet(ctx, "", scope, scopeID, key)
+	return b.store.MemoryGet(ctx, runTenant(ctx), scope, scopeID, key)
 }
 
 // Delete delegates to the store.
 func (b *Backend) Delete(ctx context.Context, scope store.MemoryScope, scopeID, key string) (bool, error) {
-	return b.store.MemoryDelete(ctx, "", scope, scopeID, key)
+	return b.store.MemoryDelete(ctx, runTenant(ctx), scope, scopeID, key)
 }
 
 // List delegates to the store.
 func (b *Backend) List(ctx context.Context, scope store.MemoryScope, scopeID, prefix string, limit int) ([]store.MemoryEntry, bool, error) {
-	return b.store.MemoryList(ctx, "", scope, scopeID, prefix, limit)
+	return b.store.MemoryList(ctx, runTenant(ctx), scope, scopeID, prefix, limit)
 }
 
 // Stats delegates to the store.
 func (b *Backend) Stats(ctx context.Context, scope store.MemoryScope) (store.MemoryEmbedStats, error) {
-	return b.store.MemoryEmbedStats(ctx, "", scope)
+	return b.store.MemoryEmbedStats(ctx, runTenant(ctx), scope)
 }
 
 // Set writes the k/v row, then (when opts.Embed) embeds and stores the
@@ -80,7 +89,7 @@ func (b *Backend) Set(ctx context.Context, scope store.MemoryScope, scopeID, key
 		}
 	}
 
-	if err := b.store.MemorySet(ctx, "", scope, scopeID, key, value, opts.TTL); err != nil {
+	if err := b.store.MemorySet(ctx, runTenant(ctx), scope, scopeID, key, value, opts.TTL); err != nil {
 		return memory.SetResult{}, err
 	}
 
@@ -125,7 +134,7 @@ func (b *Backend) persistEmbedding(ctx context.Context, scope store.MemoryScope,
 		EmbedText: text,
 		CreatedAt: time.Now().UTC(),
 	}
-	return b.store.MemoryEmbedSet(ctx, "", scope, scopeID, key, emb)
+	return b.store.MemoryEmbedSet(ctx, runTenant(ctx), scope, scopeID, key, emb)
 }
 
 // Search embeds the query, fetches the cosine pool (with the over-fetch a
@@ -173,7 +182,7 @@ func (b *Backend) Search(ctx context.Context, scope store.MemoryScope, scopeID s
 	// Fetch the candidate pool (cosine-ordered) with a +1 truncation probe:
 	// len(results) > topK distinguishes "more matched than we return" from
 	// "result set fits". Store caps at 51.
-	results, err := b.store.MemoryEmbedSearch(ctx, "", scope, scopeID, q.Prefix, queryVec, fetch)
+	results, err := b.store.MemoryEmbedSearch(ctx, runTenant(ctx), scope, scopeID, q.Prefix, queryVec, fetch)
 	if err != nil {
 		// Pass the error through unwrapped. ErrDimensionMismatch /
 		// ErrVectorUnsupported are user-actionable: the tool's errors.Is

--- a/internal/memory/backends/inprocess/inprocess_test.go
+++ b/internal/memory/backends/inprocess/inprocess_test.go
@@ -115,14 +115,14 @@ func vsKey(scope store.MemoryScope, id, key string) string {
 
 func (v *vectorStore) SupportsVectors() bool { return true }
 
-func (v *vectorStore) MemoryEmbedSet(_ context.Context, scope store.MemoryScope, id, key string, e store.MemoryEmbedding) error {
+func (v *vectorStore) MemoryEmbedSet(_ context.Context, _ string, scope store.MemoryScope, id, key string, e store.MemoryEmbedding) error {
 	v.mu.Lock()
 	defer v.mu.Unlock()
 	v.embeds[vsKey(scope, id, key)] = e
 	return nil
 }
 
-func (v *vectorStore) MemoryEmbedSearch(ctx context.Context, scope store.MemoryScope, id, keyPrefix string, query []float32, topK int) ([]store.MemorySearchEntry, error) {
+func (v *vectorStore) MemoryEmbedSearch(ctx context.Context, _ string, scope store.MemoryScope, id, keyPrefix string, query []float32, topK int) ([]store.MemorySearchEntry, error) {
 	v.mu.Lock()
 	defer v.mu.Unlock()
 	if topK > 51 {
@@ -151,7 +151,7 @@ func (v *vectorStore) MemoryEmbedSearch(ctx context.Context, scope store.MemoryS
 	}
 	out := make([]store.MemorySearchEntry, 0, len(rows))
 	for _, r := range rows {
-		entry, err := v.Store.MemoryGet(ctx, scope, id, r.key)
+		entry, err := v.Store.MemoryGet(ctx, "", scope, id, r.key)
 		if err != nil {
 			continue
 		}

--- a/internal/memory/eval/store.go
+++ b/internal/memory/eval/store.go
@@ -40,7 +40,7 @@ func vsKey(scope store.MemoryScope, id, key string) string {
 
 func (v *vectorStore) SupportsVectors() bool { return true }
 
-func (v *vectorStore) MemoryEmbedSet(_ context.Context, scope store.MemoryScope, id, key string, e store.MemoryEmbedding) error {
+func (v *vectorStore) MemoryEmbedSet(_ context.Context, _ string, scope store.MemoryScope, id, key string, e store.MemoryEmbedding) error {
 	v.mu.Lock()
 	defer v.mu.Unlock()
 	v.embeds[vsKey(scope, id, key)] = e
@@ -51,7 +51,7 @@ func (v *vectorStore) MemoryEmbedSet(_ context.Context, scope store.MemoryScope,
 // returning each row's stored vector on the entry (so the in-process
 // backend's MR-5 dedup pass has vectors to compare — same contract as the
 // real sqlite/pgvector stores after the MR-5 change).
-func (v *vectorStore) MemoryEmbedSearch(ctx context.Context, scope store.MemoryScope, id, keyPrefix string, query []float32, topK int) ([]store.MemorySearchEntry, error) {
+func (v *vectorStore) MemoryEmbedSearch(ctx context.Context, _ string, scope store.MemoryScope, id, keyPrefix string, query []float32, topK int) ([]store.MemorySearchEntry, error) {
 	v.mu.Lock()
 	defer v.mu.Unlock()
 	if topK > 51 {
@@ -94,7 +94,7 @@ func (v *vectorStore) MemoryEmbedSearch(ctx context.Context, scope store.MemoryS
 	}
 	out := make([]store.MemorySearchEntry, 0, len(rows))
 	for _, r := range rows {
-		entry, err := v.Store.MemoryGet(ctx, scope, id, r.key)
+		entry, err := v.Store.MemoryGet(ctx, "", scope, id, r.key)
 		if err != nil {
 			continue
 		}

--- a/internal/retention/sweeper.go
+++ b/internal/retention/sweeper.go
@@ -644,7 +644,7 @@ func (s *Sweeper) memEligible(ctx context.Context) (pass1 []memTarget, pass2 []s
 // most-recently-updated scopes and so would miss a stale retired agent). Used by
 // the dry-run + report count so they match what the real sweep would drop.
 func (s *Sweeper) hasBaseMemory(ctx context.Context, name string) bool {
-	entries, _, err := s.store.MemoryList(ctx, store.MemoryScopeAgent, name, "", 1)
+	entries, _, err := s.store.MemoryList(ctx, "", store.MemoryScopeAgent, name, "", 1)
 	return err == nil && len(entries) > 0
 }
 
@@ -714,7 +714,7 @@ func (s *Sweeper) reclaimBaseMemory(ctx context.Context, name string) bool {
 			return false
 		}
 	}
-	n, err := s.store.MemoryDeleteScope(ctx, store.MemoryScopeAgent, name)
+	n, err := s.store.MemoryDeleteScope(ctx, "", store.MemoryScopeAgent, name)
 	if err != nil {
 		s.logf("retention: delete agent memory %q failed: %v", name, err)
 		return false
@@ -752,7 +752,7 @@ func (s *Sweeper) exportDirents(ctx context.Context, tenant, name string) error 
 // more than it exported. Such an agent (>memExportKeyCap keys) is retried each
 // tick, staying put with a loud warning rather than losing the un-exported tail.
 func (s *Sweeper) exportBaseMemory(ctx context.Context, name string) error {
-	entries, truncated, err := s.store.MemoryList(ctx, store.MemoryScopeAgent, name, "", memExportKeyCap)
+	entries, truncated, err := s.store.MemoryList(ctx, "", store.MemoryScopeAgent, name, "", memExportKeyCap)
 	if err != nil {
 		return err
 	}

--- a/internal/retention/sweeper.go
+++ b/internal/retention/sweeper.go
@@ -101,9 +101,12 @@ type Config struct {
 	// (LiveVersionCount==0) + old agent: its SQL-Memory scope (SQL tables +
 	// document structure) and its dirents (Path names) — both tenant-qualified, so
 	// dropped per (tenant, name) — plus its base-memory k/v (chunk bodies +
-	// learned facts), which is keyed by the BARE agent name (the memory table has
-	// no tenant column), so it is only dropped when the name is retired in EVERY
-	// tenant (globally dead) to avoid deleting a live same-named agent's memory.
+	// learned facts), which is keyed by the BARE agent name under scope=agent
+	// (RFC BL partitioned it by tenant_id, so one name can span several tenant
+	// partitions). Base memory is dropped only when the name is retired in EVERY
+	// tenant (globally dead), then reclaimed across all of its tenant partitions —
+	// the globally-dead gate is preserved so a live same-named agent in another
+	// tenant is never affected.
 	MemMode string
 
 	// MemMaxAge is the age cutoff for reclamation: an agent whose latest def
@@ -516,10 +519,13 @@ func (s *Sweeper) sweepChatsOnce(parent context.Context) (int, error) {
 //	(tenant, "agent", name), so dropping tenant A's copy never touches tenant B's.
 //
 //	Pass 2 (per name, globally-dead only): drop the agent's base-memory k/v
-//	(document chunk bodies + learned facts). Base memory is keyed by the BARE
-//	agent name (the memory table has no tenant column), so it is SHARED by
-//	same-named agents across tenants — dropping it is safe ONLY when the name is
-//	retired in EVERY tenant. A name live in any tenant keeps its base memory.
+//	(document chunk bodies + learned facts). Base memory keys on the BARE agent
+//	name under scope=agent; RFC BL partitioned it by tenant_id, so one name can
+//	span several tenant partitions. The globally-dead gate is preserved: base
+//	memory is dropped ONLY when the name is retired in EVERY tenant, and
+//	reclaimBaseMemory then fans out across all of that name's tenant partitions
+//	(pre-BL this was one tenant-blind delete). A name live in any tenant keeps its
+//	base memory in every partition.
 //
 // Own 2-minute deadline; per-agent failures are logged + skipped (retried next
 // tick); a failed SQL-Memory scope drop aborts that agent's dirent drop so names
@@ -639,13 +645,18 @@ func (s *Sweeper) memEligible(ctx context.Context) (pass1 []memTarget, pass2 []s
 	return pass1, pass2, nil
 }
 
-// hasBaseMemory reports whether a name holds ANY base-memory k/v, via a limit-1
-// existence probe (NOT MemoryListScopeIDs, which is capped at the 200
+// hasBaseMemory reports whether a name holds ANY base-memory k/v under ANY
+// tenant partition (NOT MemoryListScopeIDs, which is capped at the 200
 // most-recently-updated scopes and so would miss a stale retired agent). Used by
 // the dry-run + report count so they match what the real sweep would drop.
+//
+// RFC BL tenant-partition adjustment: base memory gained a tenant_id, so a
+// globally-dead name can hold rows under several tenants; a non-empty partition
+// list means there is something to reclaim, so this now probes tenants rather
+// than the "" partition alone.
 func (s *Sweeper) hasBaseMemory(ctx context.Context, name string) bool {
-	entries, _, err := s.store.MemoryList(ctx, "", store.MemoryScopeAgent, name, "", 1)
-	return err == nil && len(entries) > 0
+	tenants, err := s.store.MemoryListTenantsForScope(ctx, store.MemoryScopeAgent, name)
+	return err == nil && len(tenants) > 0
 }
 
 // reclaimAgentScope drops one fully-retired agent's TENANT-QUALIFIED per-scope
@@ -701,25 +712,49 @@ func (s *Sweeper) reclaimAgentScope(ctx context.Context, tenant, name string, ha
 }
 
 // reclaimBaseMemory drops a globally-dead agent's base-memory k/v (every key
-// under scope=agent, scope_id=name). The caller MUST have verified the name is
-// retired in every tenant (base memory has no tenant column). export+prune dumps
-// the entries first. Under DryRun it reports would-reclaim without touching rows.
+// under scope=agent, scope_id=name) across EVERY tenant partition. The caller
+// MUST have verified the name is retired in every tenant.
+//
+// RFC BL tenant-partition adjustment: base memory gained a tenant_id, so a
+// globally-dead name can hold rows under several tenants (and the legacy "").
+// Pre-BL this was ONE tenant-blind delete of the bare name; post-partition a
+// single MemoryDeleteScope(ctx, "", ...) would touch only the "" partition and
+// strand every other tenant's rows. We now enumerate the partitions and reclaim
+// each so the memory is still fully reclaimed for the dead agent — just
+// tenant-correctly. export+prune dumps each partition before deleting it. Counts
+// as ONE reclamation unit per name (an activity gauge) regardless of how many
+// tenant partitions it spans. Under DryRun it reports would-reclaim without
+// touching rows.
 func (s *Sweeper) reclaimBaseMemory(ctx context.Context, name string) bool {
-	if s.dryRun {
-		return s.hasBaseMemory(ctx, name) // count only names that actually have memory
-	}
-	if s.memMode == "export+prune" {
-		if err := s.exportBaseMemory(ctx, name); err != nil {
-			s.logf("retention: export agent memory %q failed, skipping: %v", name, err)
-			return false
-		}
-	}
-	n, err := s.store.MemoryDeleteScope(ctx, "", store.MemoryScopeAgent, name)
+	tenants, err := s.store.MemoryListTenantsForScope(ctx, store.MemoryScopeAgent, name)
 	if err != nil {
-		s.logf("retention: delete agent memory %q failed: %v", name, err)
+		s.logf("retention: list memory tenants %q failed: %v", name, err)
 		return false
 	}
-	return n > 0
+	if len(tenants) == 0 {
+		return false // no base memory under any tenant → nothing to reclaim
+	}
+	if s.dryRun {
+		return true // >=1 partition holds memory → count one would-reclaim unit
+	}
+	did := false
+	for _, tenant := range tenants {
+		if s.memMode == "export+prune" {
+			if err := s.exportBaseMemory(ctx, tenant, name); err != nil {
+				s.logf("retention: export agent memory %q (tenant %q) failed, skipping: %v", name, tenant, err)
+				continue
+			}
+		}
+		n, err := s.store.MemoryDeleteScope(ctx, tenant, store.MemoryScopeAgent, name)
+		if err != nil {
+			s.logf("retention: delete agent memory %q (tenant %q) failed: %v", name, tenant, err)
+			continue
+		}
+		if n > 0 {
+			did = true
+		}
+	}
+	return did
 }
 
 // exportSQLMemScope dumps one agent SQL-Memory scope to
@@ -745,24 +780,27 @@ func (s *Sweeper) exportDirents(ctx context.Context, tenant, name string) error 
 	return s.writeMemExport("dirents", tenant, name, rows)
 }
 
-// exportBaseMemory dumps one globally-dead agent's base-memory k/v before it is
-// deleted. Bucketed under agent-memory/ with NO tenant segment (base memory is
-// cross-tenant-shared). If the entry set is truncated at the cap, it returns an
-// ERROR so the caller skips the delete — export-then-delete must never delete
-// more than it exported. Such an agent (>memExportKeyCap keys) is retried each
-// tick, staying put with a loud warning rather than losing the un-exported tail.
-func (s *Sweeper) exportBaseMemory(ctx context.Context, name string) error {
-	entries, truncated, err := s.store.MemoryList(ctx, "", store.MemoryScopeAgent, name, "", memExportKeyCap)
+// exportBaseMemory dumps one tenant partition of a globally-dead agent's
+// base-memory k/v before it is deleted. Bucketed under agent-memory/ with the
+// tenant as the export-file's leading segment (RFC BL: base memory is now
+// tenant-partitioned, so a globally-dead name may span several tenants — each is
+// exported to its own file). If the entry set is truncated at the cap, it
+// returns an ERROR so the caller skips the delete — export-then-delete must
+// never delete more than it exported. Such a partition (>memExportKeyCap keys)
+// is retried each tick, staying put with a loud warning rather than losing the
+// un-exported tail.
+func (s *Sweeper) exportBaseMemory(ctx context.Context, tenant, name string) error {
+	entries, truncated, err := s.store.MemoryList(ctx, tenant, store.MemoryScopeAgent, name, "", memExportKeyCap)
 	if err != nil {
 		return err
 	}
 	if truncated {
-		return fmt.Errorf("agent memory %q exceeds the %d-key export cap — refusing to delete more than exported", name, memExportKeyCap)
+		return fmt.Errorf("agent memory %q (tenant %q) exceeds the %d-key export cap — refusing to delete more than exported", name, tenant, memExportKeyCap)
 	}
 	if len(entries) == 0 {
 		return nil
 	}
-	return s.writeMemExport("agent-memory", "", name, entries)
+	return s.writeMemExport("agent-memory", tenant, name, entries)
 }
 
 // writeMemExport marshals one reclamation-export payload to

--- a/internal/retention/sweeper_test.go
+++ b/internal/retention/sweeper_test.go
@@ -814,3 +814,61 @@ func TestSweeper_MemRunsBeforeDefsPurge(t *testing.T) {
 		t.Errorf("base memory NOT reclaimed (keys=%d) — the defs purge removed the agent before the mem sweep saw it", n)
 	}
 }
+
+// memKeyCountTenant counts base-memory keys under (tenant, scope=agent, name) —
+// the per-tenant variant of memKeyCount (which reads only the "" partition).
+func memKeyCountTenant(t *testing.T, st *sqlite.Store, tenant, name string) int {
+	t.Helper()
+	entries, _, err := st.MemoryList(context.Background(), tenant, store.MemoryScopeAgent, name, "", 1000)
+	if err != nil {
+		t.Fatalf("memory list %s/%q: %v", tenant, name, err)
+	}
+	return len(entries)
+}
+
+// TestRetentionSweep_PerTenantFanout is the RFC BL fan-out regression: a
+// globally-dead agent whose base memory spans TWO tenant partitions is reclaimed
+// in BOTH, while a live agent's memory survives. Fails on the pre-fan-out code,
+// whose single MemoryDeleteScope(ctx, "", ...) touched only the "" partition and
+// stranded tenants A and B.
+func TestRetentionSweep_PerTenantFanout(t *testing.T) {
+	ctx := context.Background()
+	st, err := sqlite.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+
+	// "dead" is globally dead: retired in BOTH tenant A and tenant B, live nowhere.
+	seedRetiredAgent(t, st, "A", "dead", 1)
+	seedRetiredAgent(t, st, "B", "dead", 1)
+	// Its base memory exists in each tenant's own partition (post-RFC-BL).
+	if err := st.MemorySet(ctx, "A", store.MemoryScopeAgent, "dead", "k1", json.RawMessage(`1`), 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.MemorySet(ctx, "B", store.MemoryScopeAgent, "dead", "k1", json.RawMessage(`1`), 0); err != nil {
+		t.Fatal(err)
+	}
+	// A live agent in tenant A with its own memory — must survive untouched.
+	seedLiveAgent(t, st, "A", "alive")
+	if err := st.MemorySet(ctx, "A", store.MemoryScopeAgent, "alive", "k1", json.RawMessage(`1`), 0); err != nil {
+		t.Fatal(err)
+	}
+
+	sw := New(st, Config{MemMode: "prune", Logger: quietLogger, Now: futureHour})
+	if _, err := sw.sweepOnce(ctx); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	// BOTH tenant partitions of the dead agent's base memory are reclaimed.
+	if n := memKeyCountTenant(t, st, "A", "dead"); n != 0 {
+		t.Errorf("tenant A dead-agent memory = %d, want 0 (fan-out must reclaim it)", n)
+	}
+	if n := memKeyCountTenant(t, st, "B", "dead"); n != 0 {
+		t.Errorf("tenant B dead-agent memory = %d, want 0 (fan-out must reclaim it)", n)
+	}
+	// The live agent's memory is intact.
+	if n := memKeyCountTenant(t, st, "A", "alive"); n != 1 {
+		t.Errorf("live agent memory = %d, want 1 (must not be reclaimed)", n)
+	}
+}

--- a/internal/retention/sweeper_test.go
+++ b/internal/retention/sweeper_test.go
@@ -479,7 +479,7 @@ func sqlScopeExists(t *testing.T, sm *sqlmem.Manager, tenant, name string) bool 
 
 func memKeyCount(t *testing.T, st *sqlite.Store, name string) int {
 	t.Helper()
-	entries, _, err := st.MemoryList(context.Background(), store.MemoryScopeAgent, name, "", 1000)
+	entries, _, err := st.MemoryList(context.Background(), "", store.MemoryScopeAgent, name, "", 1000)
 	if err != nil {
 		t.Fatalf("memory list %q: %v", name, err)
 	}
@@ -501,14 +501,14 @@ func TestSweeper_MemReclaimsRetiredAgent(t *testing.T) {
 	seedRetiredAgent(t, st, "acme", "dead", 2)
 	seedAgentSQLScope(t, sm, "acme", "dead")
 	seedAgentDirent(t, st, "acme", "dead")
-	if err := st.MemorySet(ctx, store.MemoryScopeAgent, "dead", "k1", json.RawMessage(`1`), 0); err != nil {
+	if err := st.MemorySet(ctx, "", store.MemoryScopeAgent, "dead", "k1", json.RawMessage(`1`), 0); err != nil {
 		t.Fatal(err)
 	}
 	// Live agent — must be untouched.
 	seedLiveAgent(t, st, "acme", "alive")
 	seedAgentSQLScope(t, sm, "acme", "alive")
 	seedAgentDirent(t, st, "acme", "alive")
-	if err := st.MemorySet(ctx, store.MemoryScopeAgent, "alive", "k1", json.RawMessage(`1`), 0); err != nil {
+	if err := st.MemorySet(ctx, "", store.MemoryScopeAgent, "alive", "k1", json.RawMessage(`1`), 0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -564,7 +564,7 @@ func TestSweeper_MemBaseMemoryOnlyDroppedWhenGloballyDead(t *testing.T) {
 	seedAgentDirent(t, st, "A", "shared")
 	seedAgentDirent(t, st, "B", "shared")
 	// Base memory is keyed by the bare name — a single partition both share.
-	if err := st.MemorySet(ctx, store.MemoryScopeAgent, "shared", "k1", json.RawMessage(`1`), 0); err != nil {
+	if err := st.MemorySet(ctx, "", store.MemoryScopeAgent, "shared", "k1", json.RawMessage(`1`), 0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -609,7 +609,7 @@ func TestSweeper_MemExportThenDelete(t *testing.T) {
 	seedRetiredAgent(t, st, "acme", "dead", 1)
 	seedAgentSQLScope(t, sm, "acme", "dead")
 	seedAgentDirent(t, st, "acme", "dead")
-	if err := st.MemorySet(ctx, store.MemoryScopeAgent, "dead", "k1", json.RawMessage(`1`), 0); err != nil {
+	if err := st.MemorySet(ctx, "", store.MemoryScopeAgent, "dead", "k1", json.RawMessage(`1`), 0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -705,7 +705,7 @@ func TestSweeper_MemDryRunCounts(t *testing.T) {
 
 	seedRetiredAgent(t, st, "acme", "dead", 1)
 	seedAgentSQLScope(t, sm, "acme", "dead")
-	if err := st.MemorySet(ctx, store.MemoryScopeAgent, "dead", "k1", json.RawMessage(`1`), 0); err != nil {
+	if err := st.MemorySet(ctx, "", store.MemoryScopeAgent, "dead", "k1", json.RawMessage(`1`), 0); err != nil {
 		t.Fatal(err)
 	}
 	seedLiveAgent(t, st, "acme", "alive")
@@ -746,19 +746,19 @@ func TestSweeper_MemBaseMemoryReclaimedBeyondScopeIDsCap(t *testing.T) {
 
 	// The retired agent, with the OLDEST base-memory row.
 	seedRetiredAgent(t, st, "acme", "dead", 1)
-	if err := st.MemorySet(ctx, store.MemoryScopeAgent, "dead", "k1", json.RawMessage(`1`), 0); err != nil {
+	if err := st.MemorySet(ctx, "", store.MemoryScopeAgent, "dead", "k1", json.RawMessage(`1`), 0); err != nil {
 		t.Fatal(err)
 	}
 	// 200 fresher agent-memory scopes (no defs — they exist only to fill the
 	// MemoryListScopeIDs top-200 window and evict "dead" from it).
 	for i := 0; i < 200; i++ {
 		id := "live-" + strconv.Itoa(i)
-		if err := st.MemorySet(ctx, store.MemoryScopeAgent, id, "k", json.RawMessage(`1`), 0); err != nil {
+		if err := st.MemorySet(ctx, "", store.MemoryScopeAgent, id, "k", json.RawMessage(`1`), 0); err != nil {
 			t.Fatal(err)
 		}
 	}
 	// Sanity: "dead" is NOT in the (capped) MemoryListScopeIDs window.
-	ids, err := st.MemoryListScopeIDs(ctx, store.MemoryScopeAgent)
+	ids, err := st.MemoryListScopeIDs(ctx, "", store.MemoryScopeAgent)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -791,7 +791,7 @@ func TestSweeper_MemRunsBeforeDefsPurge(t *testing.T) {
 	defer func() { _ = st.Close() }()
 
 	seedRetiredAgent(t, st, "acme", "dead", 1) // 1 retired, non-active, old version
-	if err := st.MemorySet(ctx, store.MemoryScopeAgent, "dead", "k1", json.RawMessage(`1`), 0); err != nil {
+	if err := st.MemorySet(ctx, "", store.MemoryScopeAgent, "dead", "k1", json.RawMessage(`1`), 0); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/scheduler/dispatch.go
+++ b/internal/scheduler/dispatch.go
@@ -163,7 +163,7 @@ func (s *Scheduler) dispatchMemorySet(ctx context.Context, scheduleName, userID 
 	if err != nil {
 		return fmt.Errorf("marshal payload: %w", err)
 	}
-	return s.store.MemorySet(ctx, scope, scopeID, h.Key, value, 0)
+	return s.store.MemorySet(ctx, "", scope, scopeID, h.Key, value, 0)
 }
 
 func (s *Scheduler) dispatchMCPCall(ctx context.Context, h scheduleHook) error {

--- a/internal/scheduler/dispatch.go
+++ b/internal/scheduler/dispatch.go
@@ -33,19 +33,19 @@ type MCPCaller interface {
 // failed schedule to the hook delivery that follow-on consumed.
 func (s *Scheduler) dispatchHooks(ctx context.Context, scheduleName string, def scheduleDef, runID, agentID string) {
 	for i, h := range def.OnComplete {
-		if err := s.dispatchOneHook(ctx, scheduleName, def.UserID, def.Agent, h, runID, agentID); err != nil {
+		if err := s.dispatchOneHook(ctx, scheduleName, def.UserID, def.Agent, def.TenantID, h, runID, agentID); err != nil {
 			s.logf("scheduler: schedule %q on_complete[%d] (%s) failed: %v",
 				scheduleName, i, h.Kind, err)
 		}
 	}
 }
 
-func (s *Scheduler) dispatchOneHook(ctx context.Context, scheduleName, userID, agentName string, h scheduleHook, runID, agentID string) error {
+func (s *Scheduler) dispatchOneHook(ctx context.Context, scheduleName, userID, agentName, tenantID string, h scheduleHook, runID, agentID string) error {
 	switch h.Kind {
 	case "channel.publish":
 		return s.dispatchChannelPublish(ctx, scheduleName, userID, agentName, h, runID, agentID)
 	case "memory.set":
-		return s.dispatchMemorySet(ctx, scheduleName, userID, h)
+		return s.dispatchMemorySet(ctx, scheduleName, userID, tenantID, h)
 	case "mcp.call":
 		return s.dispatchMCPCall(ctx, h)
 	case "":
@@ -132,12 +132,17 @@ func (s *Scheduler) resolvePublishScope(ctx context.Context, channel, userID, ag
 	}
 }
 
-func (s *Scheduler) dispatchMemorySet(ctx context.Context, scheduleName, userID string, h scheduleHook) error {
+func (s *Scheduler) dispatchMemorySet(ctx context.Context, scheduleName, userID, tenantID string, h scheduleHook) error {
 	if h.Scope == "" || h.Key == "" {
 		return fmt.Errorf("memory.set missing `scope` or `key`")
 	}
 	var scope store.MemoryScope
 	scopeID := ""
+	// RFC BL: agent/user-scoped memory is partitioned by the schedule def's
+	// tenant (the run fires as this tenant — sourced from the def row via
+	// migration 0042, NOT a run ctx there is none). global scope is the
+	// cross-tenant shared partition and stays "".
+	memTenant := tenantID
 	switch h.Scope {
 	case "agent":
 		// Agent-scoped memory uses the agent name as scope_id, but
@@ -156,6 +161,7 @@ func (s *Scheduler) dispatchMemorySet(ctx context.Context, scheduleName, userID 
 		scopeID = userID
 	case "global":
 		scope = store.MemoryScopeGlobal
+		memTenant = ""
 	default:
 		return fmt.Errorf("memory.set: unknown scope %q (must be agent|user|global)", h.Scope)
 	}
@@ -163,7 +169,7 @@ func (s *Scheduler) dispatchMemorySet(ctx context.Context, scheduleName, userID 
 	if err != nil {
 		return fmt.Errorf("marshal payload: %w", err)
 	}
-	return s.store.MemorySet(ctx, "", scope, scopeID, h.Key, value, 0)
+	return s.store.MemorySet(ctx, memTenant, scope, scopeID, h.Key, value, 0)
 }
 
 func (s *Scheduler) dispatchMCPCall(ctx context.Context, h scheduleHook) error {

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -351,7 +351,7 @@ func TestScheduler_OnCompleteMemorySet(t *testing.T) {
 	sched, _, _, _, st := schedulerFixture(t, def, time.Now().Add(-1*time.Minute))
 
 	fireT(t, sched)
-	got, err := st.MemoryGet(context.Background(), store.MemoryScopeUser, "alice", "last_search")
+	got, err := st.MemoryGet(context.Background(), "", store.MemoryScopeUser, "alice", "last_search")
 	if err != nil {
 		t.Fatalf("memory get: %v", err)
 	}

--- a/internal/snapshot/memory_embedding.go
+++ b/internal/snapshot/memory_embedding.go
@@ -55,7 +55,7 @@ func captureEmbedding(ctx context.Context, s store.Store, scope store.MemoryScop
 	if !s.SupportsVectors() {
 		return nil, nil
 	}
-	emb, err := s.MemoryEmbedGet(ctx, scope, scopeID, key)
+	emb, err := s.MemoryEmbedGet(ctx, "", scope, scopeID, key)
 	if err != nil {
 		var nf *store.ErrNotFound
 		if errors.As(err, &nf) {

--- a/internal/snapshot/memory_embedding.go
+++ b/internal/snapshot/memory_embedding.go
@@ -51,11 +51,11 @@ type MemoryEmbeddingSnapshot struct {
 // Capture failures (e.g. a DB error) bubble out so the snapshot
 // fails loudly rather than silently dropping vectors. Operators
 // re-run capture on a healthy DB.
-func captureEmbedding(ctx context.Context, s store.Store, scope store.MemoryScope, scopeID, key string) (*MemoryEmbeddingSnapshot, error) {
+func captureEmbedding(ctx context.Context, s store.Store, tenantID string, scope store.MemoryScope, scopeID, key string) (*MemoryEmbeddingSnapshot, error) {
 	if !s.SupportsVectors() {
 		return nil, nil
 	}
-	emb, err := s.MemoryEmbedGet(ctx, "", scope, scopeID, key)
+	emb, err := s.MemoryEmbedGet(ctx, tenantID, scope, scopeID, key)
 	if err != nil {
 		var nf *store.ErrNotFound
 		if errors.As(err, &nf) {

--- a/internal/snapshot/memory_embedding_test.go
+++ b/internal/snapshot/memory_embedding_test.go
@@ -110,7 +110,7 @@ func vskKey(scope store.MemoryScope, scopeID, key string) string {
 
 func (v *vectorSnapshotStore) SupportsVectors() bool { return v.supports }
 
-func (v *vectorSnapshotStore) MemoryEmbedSet(ctx context.Context, scope store.MemoryScope, scopeID, key string, e store.MemoryEmbedding) error {
+func (v *vectorSnapshotStore) MemoryEmbedSet(ctx context.Context, _ string, scope store.MemoryScope, scopeID, key string, e store.MemoryEmbedding) error {
 	if !v.supports {
 		return store.ErrVectorUnsupported
 	}
@@ -120,7 +120,7 @@ func (v *vectorSnapshotStore) MemoryEmbedSet(ctx context.Context, scope store.Me
 	return nil
 }
 
-func (v *vectorSnapshotStore) MemoryEmbedGet(ctx context.Context, scope store.MemoryScope, scopeID, key string) (store.MemoryEmbedding, error) {
+func (v *vectorSnapshotStore) MemoryEmbedGet(ctx context.Context, _ string, scope store.MemoryScope, scopeID, key string) (store.MemoryEmbedding, error) {
 	if !v.supports {
 		return store.MemoryEmbedding{}, store.ErrVectorUnsupported
 	}
@@ -133,15 +133,15 @@ func (v *vectorSnapshotStore) MemoryEmbedGet(ctx context.Context, scope store.Me
 	return e, nil
 }
 
-func (v *vectorSnapshotStore) MemoryEmbedSearch(ctx context.Context, scope store.MemoryScope, scopeID, keyPrefix string, query []float32, topK int) ([]store.MemorySearchEntry, error) {
+func (v *vectorSnapshotStore) MemoryEmbedSearch(ctx context.Context, _ string, scope store.MemoryScope, scopeID, keyPrefix string, query []float32, topK int) ([]store.MemorySearchEntry, error) {
 	return nil, errors.New("MemoryEmbedSearch not used by snapshot tests")
 }
 
-func (v *vectorSnapshotStore) MemoryEmbedListByModel(ctx context.Context, scope store.MemoryScope, scopeID, currentProvider, currentModel string, limit int) ([]store.MemoryEntry, error) {
+func (v *vectorSnapshotStore) MemoryEmbedListByModel(ctx context.Context, _ string, scope store.MemoryScope, scopeID, currentProvider, currentModel string, limit int) ([]store.MemoryEntry, error) {
 	return nil, errors.New("MemoryEmbedListByModel not used by snapshot tests")
 }
 
-func (v *vectorSnapshotStore) MemoryEmbedStats(ctx context.Context, scope store.MemoryScope) (store.MemoryEmbedStats, error) {
+func (v *vectorSnapshotStore) MemoryEmbedStats(ctx context.Context, _ string, scope store.MemoryScope) (store.MemoryEmbedStats, error) {
 	return store.MemoryEmbedStats{}, errors.New("MemoryEmbedStats not used by snapshot tests")
 }
 
@@ -150,7 +150,7 @@ func (v *vectorSnapshotStore) MemoryEmbedStats(ctx context.Context, scope store.
 func preloadOneEmbedded(t *testing.T, vs *vectorSnapshotStore, scope store.MemoryScope, scopeID, key string, vec []float32) {
 	t.Helper()
 	ctx := context.Background()
-	if err := vs.Store.MemorySet(ctx, scope, scopeID, key, json.RawMessage(`"v"`), 0); err != nil {
+	if err := vs.Store.MemorySet(ctx, "", scope, scopeID, key, json.RawMessage(`"v"`), 0); err != nil {
 		t.Fatal(err)
 	}
 	emb := store.MemoryEmbedding{
@@ -161,7 +161,7 @@ func preloadOneEmbedded(t *testing.T, vs *vectorSnapshotStore, scope store.Memor
 		EmbedText: key,
 		CreatedAt: time.Now().UTC().Truncate(time.Second),
 	}
-	if err := vs.MemoryEmbedSet(ctx, scope, scopeID, key, emb); err != nil {
+	if err := vs.MemoryEmbedSet(ctx, "", scope, scopeID, key, emb); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -198,7 +198,7 @@ func TestCaptureMemory_EmbeddingNullWhenBackendUnsupported(t *testing.T) {
 	defer cleanup()
 	vs := newVectorSnapshotStore(base, false) // unsupported
 
-	if err := base.MemorySet(context.Background(),
+	if err := base.MemorySet(context.Background(), "",
 		store.MemoryScopeAgent, "qa-agent", "rec1", json.RawMessage(`"v"`), 0); err != nil {
 		t.Fatal(err)
 	}
@@ -244,7 +244,7 @@ func TestRestore_EmbeddingRoundTripsToSupportedBackend(t *testing.T) {
 	}
 
 	// Verify the embedding landed in the destination.
-	got, err := dst.MemoryEmbedGet(context.Background(),
+	got, err := dst.MemoryEmbedGet(context.Background(), "",
 		store.MemoryScopeAgent, "qa-agent", "rec1")
 	if err != nil {
 		t.Fatalf("MemoryEmbedGet on dst: %v", err)
@@ -299,7 +299,7 @@ func TestRestore_EmbeddingDroppedWithWarningWhenDstUnsupported(t *testing.T) {
 		t.Errorf("got %d 'embedding dropped' warnings, want 2: %v", embedWarnings, res.Warnings)
 	}
 	// The k/v rows must be retrievable on the destination.
-	got, err := dst.MemoryGet(context.Background(), store.MemoryScopeAgent, "qa-agent", "rec1")
+	got, err := dst.MemoryGet(context.Background(), "", store.MemoryScopeAgent, "qa-agent", "rec1")
 	if err != nil {
 		t.Fatalf("k/v row missing on dst: %v", err)
 	}

--- a/internal/snapshot/restore.go
+++ b/internal/snapshot/restore.go
@@ -427,7 +427,7 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 					EmbedText: e.Embedding.EmbedText,
 					CreatedAt: e.Embedding.CreatedAt,
 				}
-				if err := s.MemoryEmbedSet(ctx, entry.Scope, entry.ScopeID, e.Key, emb); err != nil {
+				if err := s.MemoryEmbedSet(ctx, "", entry.Scope, entry.ScopeID, e.Key, emb); err != nil {
 					result.Warnings = append(result.Warnings,
 						fmt.Sprintf("memory %s/%s/%s embedding write: %v", e.Scope, e.ScopeID, e.Key, err))
 				}

--- a/internal/snapshot/restore.go
+++ b/internal/snapshot/restore.go
@@ -375,8 +375,12 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 				expires = *e.ExpiresAt
 			}
 			entry := store.MemorySnapshotEntry{
-				Scope:   store.MemoryScope(e.Scope),
-				ScopeID: e.ScopeID,
+				// RFC BL: restore into the row's tenant partition. An older
+				// snapshot with no tenant_id decodes e.TenantID as "" (the
+				// legacy tenant), preserving cross-version restore.
+				TenantID: e.TenantID,
+				Scope:    store.MemoryScope(e.Scope),
+				ScopeID:  e.ScopeID,
 				MemoryEntry: store.MemoryEntry{
 					Key:       e.Key,
 					Value:     e.Value,
@@ -427,7 +431,7 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 					EmbedText: e.Embedding.EmbedText,
 					CreatedAt: e.Embedding.CreatedAt,
 				}
-				if err := s.MemoryEmbedSet(ctx, "", entry.Scope, entry.ScopeID, e.Key, emb); err != nil {
+				if err := s.MemoryEmbedSet(ctx, entry.TenantID, entry.Scope, entry.ScopeID, e.Key, emb); err != nil {
 					result.Warnings = append(result.Warnings,
 						fmt.Sprintf("memory %s/%s/%s embedding write: %v", e.Scope, e.ScopeID, e.Key, err))
 				}

--- a/internal/snapshot/restore_test.go
+++ b/internal/snapshot/restore_test.go
@@ -66,7 +66,7 @@ func TestRoundTrip_WithMemoryAndAgentDefs(t *testing.T) {
 
 	// Seed src.
 	for i, key := range []string{"a", "b", "c"} {
-		if err := src.MemorySet(ctx, store.MemoryScope("agent"), "agentX", key, []byte(`"v`+string(rune('0'+i))+`"`), 0); err != nil {
+		if err := src.MemorySet(ctx, "", store.MemoryScope("agent"), "agentX", key, []byte(`"v`+string(rune('0'+i))+`"`), 0); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -360,7 +360,7 @@ func TestRestore_Idempotent_SecondCallNoDuplicates(t *testing.T) {
 	defer dstClose()
 
 	ctx := context.Background()
-	if err := src.MemorySet(ctx, store.MemoryScope("agent"), "a", "k", []byte(`"v"`), 0); err != nil {
+	if err := src.MemorySet(ctx, "", store.MemoryScope("agent"), "a", "k", []byte(`"v"`), 0); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/snapshot/restore_test.go
+++ b/internal/snapshot/restore_test.go
@@ -116,6 +116,57 @@ func TestRoundTrip_WithMemoryAndAgentDefs(t *testing.T) {
 	}
 }
 
+// TestSnapshot_TenantRoundTrip pins RFC BL: capture→restore preserves each
+// base-memory row's tenant partition — two tenants sharing the SAME
+// scope/scope_id/key keep distinct values — and a legacy "" row (whose entry
+// carries no tenant_id, since it's omitempty) restores into the "" tenant.
+// Fails on the pre-turn-on code, whose memory-section DTO dropped tenant_id, so
+// the two rows collapsed onto "" and one clobbered the other (INSERT OR IGNORE).
+func TestSnapshot_TenantRoundTrip(t *testing.T) {
+	src, srcClose := newTestStore(t)
+	defer srcClose()
+	dst, dstClose := newTestStore(t)
+	defer dstClose()
+	ctx := context.Background()
+
+	// Same (scope, scope_id, key) under two tenants with distinct values, plus a
+	// legacy row under the "" tenant (its captured entry omits tenant_id).
+	if err := src.MemorySet(ctx, "A", store.MemoryScopeUser, "u1", "voice", []byte(`"from-a"`), 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := src.MemorySet(ctx, "B", store.MemoryScopeUser, "u1", "voice", []byte(`"from-b"`), 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := src.MemorySet(ctx, "", store.MemoryScopeUser, "u1", "legacy", []byte(`"old"`), 0); err != nil {
+		t.Fatal(err)
+	}
+
+	_, raw, err := Capture(ctx, src, CaptureOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Capture stamps the real tenant into the envelope (the "" row omits it).
+	if !strings.Contains(string(raw), `"tenant_id":"A"`) || !strings.Contains(string(raw), `"tenant_id":"B"`) {
+		t.Errorf("captured snapshot missing per-tenant memory entries: %s", raw)
+	}
+
+	if _, err := Restore(ctx, dst, raw, RestoreOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Each tenant's row round-trips into its own partition with its own value.
+	if got, err := dst.MemoryGet(ctx, "A", store.MemoryScopeUser, "u1", "voice"); err != nil || string(got.Value) != `"from-a"` {
+		t.Errorf("tenant A restored = %q err=%v, want \"from-a\"", got.Value, err)
+	}
+	if got, err := dst.MemoryGet(ctx, "B", store.MemoryScopeUser, "u1", "voice"); err != nil || string(got.Value) != `"from-b"` {
+		t.Errorf("tenant B restored = %q err=%v, want \"from-b\"", got.Value, err)
+	}
+	// The legacy tenant-less entry restores under "" (graceful cross-version).
+	if got, err := dst.MemoryGet(ctx, "", store.MemoryScopeUser, "u1", "legacy"); err != nil || string(got.Value) != `"old"` {
+		t.Errorf("legacy \"\" row = %q err=%v, want \"old\"", got.Value, err)
+	}
+}
+
 // TestRoundTrip_PreservesDefTenantID pins the RFC AP review #2 fix: a snapshot
 // capture→restore must PRESERVE each def's owning tenant. Before the fix the
 // snapshot DTO types dropped tenant_id, so every def (Agent/Skill/Team/MCPServer)

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -411,11 +411,14 @@ func captureMemory(ctx context.Context, s store.Store, out *MemorySection) error
 	}
 	out.Entries = make([]MemoryEntry, 0, len(rows))
 	for _, r := range rows {
-		emb, err := captureEmbedding(ctx, s, r.Scope, r.ScopeID, r.Key)
+		// RFC BL: capture the row's tenant + read its embedding under the same
+		// tenant partition, so a multi-tenant DB round-trips per tenant.
+		emb, err := captureEmbedding(ctx, s, r.TenantID, r.Scope, r.ScopeID, r.Key)
 		if err != nil {
 			return fmt.Errorf("snapshot memory embedding: %w", err)
 		}
 		entry := MemoryEntry{
+			TenantID:  r.TenantID,
 			Scope:     string(r.Scope),
 			ScopeID:   r.ScopeID,
 			Key:       r.Key,

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -126,10 +126,10 @@ func TestCapture_MemoryEmbeddingIsNull_Phase1(t *testing.T) {
 	ctx := context.Background()
 
 	// Seed two memory rows in different scopes.
-	if err := s.MemorySet(ctx, store.MemoryScope("agent"), "agentA", "k1", json.RawMessage(`"v1"`), 0); err != nil {
+	if err := s.MemorySet(ctx, "", store.MemoryScope("agent"), "agentA", "k1", json.RawMessage(`"v1"`), 0); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.MemorySet(ctx, store.MemoryScope("user"), "userB", "k2", json.RawMessage(`"v2"`), 0); err != nil {
+	if err := s.MemorySet(ctx, "", store.MemoryScope("user"), "userB", "k2", json.RawMessage(`"v2"`), 0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -293,7 +293,7 @@ func TestCapture_DeterministicOrderingAcrossCalls(t *testing.T) {
 
 	// Seed in a deliberately scrambled order so ordering matters.
 	for _, k := range []string{"z", "a", "m"} {
-		if err := s.MemorySet(ctx, store.MemoryScope("agent"), "agentX", k, json.RawMessage(`"v"`), 0); err != nil {
+		if err := s.MemorySet(ctx, "", store.MemoryScope("agent"), "agentX", k, json.RawMessage(`"v"`), 0); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/snapshot/types.go
+++ b/internal/snapshot/types.go
@@ -276,6 +276,11 @@ type MemorySection struct {
 // `embedding` field. CreatedAt / UpdatedAt come from MemorySnapshotEntry's
 // embedded MemoryEntry. ExpiresAt is omitted when zero (no TTL).
 type MemoryEntry struct {
+	// TenantID is the row's isolation axis (RFC BL). omitempty so a
+	// single-tenant snapshot stays byte-identical to a pre-RFC-BL one, and a
+	// snapshot written before the column existed decodes to "" (the legacy
+	// tenant) on restore — the graceful cross-version path.
+	TenantID  string                   `json:"tenant_id,omitempty"`
 	Scope     string                   `json:"scope"`
 	ScopeID   string                   `json:"scope_id"`
 	Key       string                   `json:"key"`

--- a/internal/store/postgres/memory_embeddings.go
+++ b/internal/store/postgres/memory_embeddings.go
@@ -41,7 +41,7 @@ func (s *Store) SupportsVectors() bool {
 // MemoryEmbedSet upserts the embedding for one (scope, scope_id, key).
 // The base memory row must exist — the FK enforces this; absent
 // base row surfaces as a Postgres `foreign_key_violation`.
-func (s *Store) MemoryEmbedSet(ctx context.Context, scope store.MemoryScope, scopeID, key string, e store.MemoryEmbedding) error {
+func (s *Store) MemoryEmbedSet(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string, e store.MemoryEmbedding) error {
 	if !s.pgvectorEnabled {
 		return store.ErrVectorUnsupported
 	}
@@ -57,16 +57,16 @@ func (s *Store) MemoryEmbedSet(ctx context.Context, scope store.MemoryScope, sco
 		createdAt = time.Now().UTC()
 	}
 	_, err := s.pool.Exec(ctx,
-		`INSERT INTO memory_embeddings(scope, scope_id, key, provider, model, dimension, embedding, embed_text, created_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7::vector, $8, $9)
-		 ON CONFLICT (scope, scope_id, key) DO UPDATE SET
+		`INSERT INTO memory_embeddings(tenant_id, scope, scope_id, key, provider, model, dimension, embedding, embed_text, created_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8::vector, $9, $10)
+		 ON CONFLICT (tenant_id, scope, scope_id, key) DO UPDATE SET
 		    provider   = excluded.provider,
 		    model      = excluded.model,
 		    dimension  = excluded.dimension,
 		    embedding  = excluded.embedding,
 		    embed_text = excluded.embed_text,
 		    created_at = excluded.created_at`,
-		string(scope), scopeID, key, e.Provider, e.Model, e.Dimension, vecText, e.EmbedText, createdAt,
+		tenantID, string(scope), scopeID, key, e.Provider, e.Model, e.Dimension, vecText, e.EmbedText, createdAt,
 	)
 	if err != nil {
 		return fmt.Errorf("MemoryEmbedSet: %w", err)
@@ -76,7 +76,7 @@ func (s *Store) MemoryEmbedSet(ctx context.Context, scope store.MemoryScope, sco
 
 // MemoryEmbedGet returns the stored embedding, decoding the
 // pgvector text representation back to float32.
-func (s *Store) MemoryEmbedGet(ctx context.Context, scope store.MemoryScope, scopeID, key string) (store.MemoryEmbedding, error) {
+func (s *Store) MemoryEmbedGet(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string) (store.MemoryEmbedding, error) {
 	if !s.pgvectorEnabled {
 		return store.MemoryEmbedding{}, store.ErrVectorUnsupported
 	}
@@ -88,8 +88,8 @@ func (s *Store) MemoryEmbedGet(ctx context.Context, scope store.MemoryScope, sco
 	err := s.pool.QueryRow(ctx,
 		`SELECT provider, model, dimension, embedding::text, embed_text, created_at
 		 FROM memory_embeddings
-		 WHERE scope = $1 AND scope_id = $2 AND key = $3`,
-		string(scope), scopeID, key,
+		 WHERE tenant_id = $1 AND scope = $2 AND scope_id = $3 AND key = $4`,
+		tenantID, string(scope), scopeID, key,
 	).Scan(&provider, &model, &dimension, &embeddingText, &embedText, &createdAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return store.MemoryEmbedding{}, &store.ErrNotFound{Kind: "memory_embedding", ID: key}
@@ -118,7 +118,7 @@ func (s *Store) MemoryEmbedGet(ctx context.Context, scope store.MemoryScope, sco
 //
 // Empty (scope, scope_id) returns ([], nil) — explicit non-error so
 // "no rows yet" doesn't pollute the agent's error path.
-func (s *Store) MemoryEmbedSearch(ctx context.Context, scope store.MemoryScope, scopeID, keyPrefix string, query []float32, topK int) ([]store.MemorySearchEntry, error) {
+func (s *Store) MemoryEmbedSearch(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, keyPrefix string, query []float32, topK int) ([]store.MemorySearchEntry, error) {
 	if !s.pgvectorEnabled {
 		return nil, store.ErrVectorUnsupported
 	}
@@ -143,9 +143,9 @@ func (s *Store) MemoryEmbedSearch(ctx context.Context, scope store.MemoryScope, 
 	var storedDim int
 	err := s.pool.QueryRow(ctx,
 		`SELECT dimension FROM memory_embeddings
-		 WHERE scope = $1 AND scope_id = $2
+		 WHERE tenant_id = $1 AND scope = $2 AND scope_id = $3
 		 LIMIT 1`,
-		string(scope), scopeID,
+		tenantID, string(scope), scopeID,
 	).Scan(&storedDim)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
@@ -167,24 +167,26 @@ func (s *Store) MemoryEmbedSearch(ctx context.Context, scope store.MemoryScope, 
 	// CASCADE handles deletes but not TTL-expired-not-yet-swept.
 	// We JOIN + filter so stale rows don't leak into search results.
 	prefixCondition := ""
-	args := []any{string(scope), scopeID, queryText, topK}
+	args := []any{tenantID, string(scope), scopeID, queryText, topK}
 	if keyPrefix != "" {
-		prefixCondition = " AND me.key LIKE $5"
+		prefixCondition = " AND me.key LIKE $6"
 		args = append(args, keyPrefix+"%")
 	}
 	sql := `SELECT me.key, m.value, m.expires_at, m.created_at, m.updated_at,
-	               1.0 - (me.embedding <=> $3::vector) AS score,
+	               1.0 - (me.embedding <=> $4::vector) AS score,
 	               me.provider, me.model, me.embedding::text AS embedding_text
 	         FROM memory_embeddings me
 	         JOIN memory m
-	            ON me.scope    = m.scope
+	            ON me.tenant_id = m.tenant_id
+	           AND me.scope    = m.scope
 	           AND me.scope_id = m.scope_id
 	           AND me.key      = m.key
-	         WHERE me.scope = $1
-	           AND me.scope_id = $2
+	         WHERE me.tenant_id = $1
+	           AND me.scope = $2
+	           AND me.scope_id = $3
 	           AND (m.expires_at IS NULL OR m.expires_at > now())` + prefixCondition + `
-	         ORDER BY me.embedding <=> $3::vector
-	         LIMIT $4`
+	         ORDER BY me.embedding <=> $4::vector
+	         LIMIT $5`
 	rows, err := s.pool.Query(ctx, sql, args...)
 	if err != nil {
 		return nil, fmt.Errorf("MemoryEmbedSearch query: %w", err)
@@ -239,7 +241,7 @@ func (s *Store) MemoryEmbedSearch(ctx context.Context, scope store.MemoryScope, 
 // MemoryEmbedListByModel returns base-memory rows whose embedding
 // is under a DIFFERENT (provider, model) than the supplied current
 // pair. Drives the reembed admin endpoint (PR 4).
-func (s *Store) MemoryEmbedListByModel(ctx context.Context, scope store.MemoryScope, scopeID, currentProvider, currentModel string, limit int) ([]store.MemoryEntry, error) {
+func (s *Store) MemoryEmbedListByModel(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, currentProvider, currentModel string, limit int) ([]store.MemoryEntry, error) {
 	if !s.pgvectorEnabled {
 		return nil, store.ErrVectorUnsupported
 	}
@@ -250,13 +252,13 @@ func (s *Store) MemoryEmbedListByModel(ctx context.Context, scope store.MemorySc
 		`SELECT me.key, m.value, m.expires_at, m.created_at, m.updated_at
 		 FROM memory_embeddings me
 		 JOIN memory m
-		    ON me.scope = m.scope AND me.scope_id = m.scope_id AND me.key = m.key
-		 WHERE me.scope = $1 AND me.scope_id = $2
-		   AND (me.provider <> $3 OR me.model <> $4)
+		    ON me.tenant_id = m.tenant_id AND me.scope = m.scope AND me.scope_id = m.scope_id AND me.key = m.key
+		 WHERE me.tenant_id = $1 AND me.scope = $2 AND me.scope_id = $3
+		   AND (me.provider <> $4 OR me.model <> $5)
 		   AND (m.expires_at IS NULL OR m.expires_at > now())
 		 ORDER BY me.key
-		 LIMIT $5`,
-		string(scope), scopeID, currentProvider, currentModel, limit,
+		 LIMIT $6`,
+		tenantID, string(scope), scopeID, currentProvider, currentModel, limit,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("MemoryEmbedListByModel: %w", err)
@@ -293,17 +295,17 @@ func (s *Store) MemoryEmbedListByModel(ctx context.Context, scope store.MemorySc
 // as dimension * 4 (float32) per row; not exact (pgvector's on-disk
 // size includes some metadata) but close enough for operator
 // dashboards.
-func (s *Store) MemoryEmbedStats(ctx context.Context, scope store.MemoryScope) (store.MemoryEmbedStats, error) {
+func (s *Store) MemoryEmbedStats(ctx context.Context, tenantID string, scope store.MemoryScope) (store.MemoryEmbedStats, error) {
 	if !s.pgvectorEnabled {
 		return store.MemoryEmbedStats{}, store.ErrVectorUnsupported
 	}
 	rows, err := s.pool.Query(ctx,
 		`SELECT provider, model, dimension, COUNT(*)
 		 FROM memory_embeddings
-		 WHERE scope = $1
+		 WHERE tenant_id = $1 AND scope = $2
 		 GROUP BY provider, model, dimension
 		 ORDER BY provider, model`,
-		string(scope),
+		tenantID, string(scope),
 	)
 	if err != nil {
 		return store.MemoryEmbedStats{}, fmt.Errorf("MemoryEmbedStats: %w", err)

--- a/internal/store/postgres/migrations/0059_memory_tenant_id.down.sql
+++ b/internal/store/postgres/migrations/0059_memory_tenant_id.down.sql
@@ -1,0 +1,64 @@
+-- 0059_memory_tenant_id.down.sql — reverse RFC BL's tenant axis + the
+-- provenance/access columns on the Memory store. Restores the single-tenant
+-- (scope, scope_id, key) PKs + the 3-tuple embeddings FK + the old indexes,
+-- then drops the added columns.
+--
+-- NOTE: down is only safe while every row is tenant_id='' (the single-tenant
+-- / pre-migration state). If real per-tenant rows exist, restoring the
+-- 3-tuple PK would collide on duplicate (scope, scope_id, key) — the operator
+-- must reconcile before rolling back. Same reversal order as the up in
+-- reverse: drop the embeddings FK → revert memory's PK → revert the
+-- embeddings table → drop memory's columns.
+
+-- Drop the 4-tuple embeddings FK FIRST (guarded) so memory's PK can revert.
+DO $migration$
+DECLARE
+    fk_name text;
+BEGIN
+    IF to_regclass('memory_embeddings') IS NOT NULL THEN
+        SELECT conname INTO fk_name
+        FROM pg_constraint
+        WHERE conrelid = 'memory_embeddings'::regclass AND contype = 'f';
+        IF fk_name IS NOT NULL THEN
+            EXECUTE 'ALTER TABLE memory_embeddings DROP CONSTRAINT ' || quote_ident(fk_name);
+        END IF;
+    END IF;
+END
+$migration$;
+
+-- memory: revert the PK to (scope, scope_id, key).
+ALTER TABLE memory DROP CONSTRAINT memory_pkey;
+ALTER TABLE memory ADD PRIMARY KEY (scope, scope_id, key);
+
+-- memory_embeddings (guarded): revert the PK, drop tenant_id, recreate the
+-- 3-tuple FK, and restore the original indexes.
+DO $migration$
+BEGIN
+    IF to_regclass('memory_embeddings') IS NOT NULL THEN
+        ALTER TABLE memory_embeddings DROP CONSTRAINT memory_embeddings_pkey;
+        ALTER TABLE memory_embeddings ADD PRIMARY KEY (scope, scope_id, key);
+        ALTER TABLE memory_embeddings DROP COLUMN tenant_id;
+
+        ALTER TABLE memory_embeddings
+            ADD FOREIGN KEY (scope, scope_id, key)
+            REFERENCES memory(scope, scope_id, key) ON DELETE CASCADE;
+
+        DROP INDEX IF EXISTS memory_embeddings_by_scope;
+        CREATE INDEX IF NOT EXISTS memory_embeddings_by_scope
+            ON memory_embeddings(scope, scope_id);
+
+        DROP INDEX IF EXISTS memory_embeddings_by_model;
+        CREATE INDEX IF NOT EXISTS memory_embeddings_by_model
+            ON memory_embeddings(scope, scope_id, provider, model);
+    END IF;
+END
+$migration$;
+
+-- memory: drop the RFC BL columns.
+ALTER TABLE memory DROP COLUMN last_accessed_at;
+ALTER TABLE memory DROP COLUMN access_count;
+ALTER TABLE memory DROP COLUMN source_run_id;
+ALTER TABLE memory DROP COLUMN source_session_id;
+ALTER TABLE memory DROP COLUMN class;
+ALTER TABLE memory DROP COLUMN origin;
+ALTER TABLE memory DROP COLUMN tenant_id;

--- a/internal/store/postgres/migrations/0059_memory_tenant_id.up.sql
+++ b/internal/store/postgres/migrations/0059_memory_tenant_id.up.sql
@@ -1,0 +1,83 @@
+-- 0059_memory_tenant_id.up.sql — RFC BL: tenant-scope the main Memory
+-- store (the base k/v plane + its pgvector embeddings mirror).
+--
+-- RFC L isolated runs/sessions; RFC N isolated the definition plane. The
+-- base `memory` table stayed tenant-blind: an agent scope_id is the bare
+-- agent name, shared by same-named agents across tenants, so two tenants
+-- writing the same (scope, scope_id, key) collided on one global row. This
+-- migration adds the tenant axis (OQ #7) plus the RFC BL provenance/access
+-- columns the hybrid ranker (PR2) will wire.
+--
+-- '' = the shared/operator/legacy tenant. Existing rows backfill to '' via
+-- the column DEFAULT, so a single-tenant deployment reads exactly as before
+-- (it IS entirely '') — no separate UPDATE needed.
+--
+-- FK lockstep (the sharp edge): memory's PRIMARY KEY cannot be dropped
+-- while memory_embeddings' FK still references the old (scope, scope_id,
+-- key). Order is therefore: add memory's columns → drop the embeddings FK →
+-- swap memory's PK → widen + re-key the embeddings table → recreate the FK
+-- on the 4-tuple. memory_embeddings lives behind a pgvector guard (0017
+-- only creates it when the `vector` extension loaded), so every statement
+-- that touches it runs inside a to_regclass() existence check and is a
+-- clean no-op on a Postgres without pgvector.
+
+-- memory: the tenant axis + RFC BL provenance/access columns. All additive;
+-- the non-tenant columns are nullable/zero-defaulted so legacy rows read the
+-- zero value.
+ALTER TABLE memory ADD COLUMN tenant_id         TEXT        NOT NULL DEFAULT '';
+ALTER TABLE memory ADD COLUMN origin            TEXT;
+ALTER TABLE memory ADD COLUMN class             TEXT;
+ALTER TABLE memory ADD COLUMN source_session_id TEXT;
+ALTER TABLE memory ADD COLUMN source_run_id     TEXT;
+ALTER TABLE memory ADD COLUMN access_count      BIGINT      NOT NULL DEFAULT 0;
+ALTER TABLE memory ADD COLUMN last_accessed_at  TIMESTAMPTZ;
+
+-- Drop the embeddings FK FIRST (guarded — the table only exists when
+-- pgvector loaded) so memory's PK can be dropped below. The 0017 FK was
+-- created inline (unnamed), so we resolve its actual name from the catalog
+-- rather than hard-coding the auto-generated identifier.
+DO $migration$
+DECLARE
+    fk_name text;
+BEGIN
+    IF to_regclass('memory_embeddings') IS NOT NULL THEN
+        SELECT conname INTO fk_name
+        FROM pg_constraint
+        WHERE conrelid = 'memory_embeddings'::regclass AND contype = 'f';
+        IF fk_name IS NOT NULL THEN
+            EXECUTE 'ALTER TABLE memory_embeddings DROP CONSTRAINT ' || quote_ident(fk_name);
+        END IF;
+    END IF;
+END
+$migration$;
+
+-- memory: swap the PK to lead with tenant_id.
+ALTER TABLE memory DROP CONSTRAINT memory_pkey;
+ALTER TABLE memory ADD PRIMARY KEY (tenant_id, scope, scope_id, key);
+
+-- memory_embeddings (guarded): add tenant_id, re-key, recreate the FK on the
+-- 4-tuple (keeping ON DELETE CASCADE), and rebuild the scope/model indexes to
+-- lead with tenant_id. tenant_id backfills to '' via the DEFAULT, matching
+-- memory's backfill, so the FK holds on existing rows with no violation.
+DO $migration$
+BEGIN
+    IF to_regclass('memory_embeddings') IS NOT NULL THEN
+        ALTER TABLE memory_embeddings ADD COLUMN tenant_id TEXT NOT NULL DEFAULT '';
+
+        ALTER TABLE memory_embeddings DROP CONSTRAINT memory_embeddings_pkey;
+        ALTER TABLE memory_embeddings ADD PRIMARY KEY (tenant_id, scope, scope_id, key);
+
+        ALTER TABLE memory_embeddings
+            ADD FOREIGN KEY (tenant_id, scope, scope_id, key)
+            REFERENCES memory(tenant_id, scope, scope_id, key) ON DELETE CASCADE;
+
+        DROP INDEX IF EXISTS memory_embeddings_by_scope;
+        CREATE INDEX IF NOT EXISTS memory_embeddings_by_scope
+            ON memory_embeddings(tenant_id, scope, scope_id);
+
+        DROP INDEX IF EXISTS memory_embeddings_by_model;
+        CREATE INDEX IF NOT EXISTS memory_embeddings_by_model
+            ON memory_embeddings(tenant_id, scope, scope_id, provider, model);
+    END IF;
+END
+$migration$;

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -2076,7 +2076,7 @@ func (s *Store) SnapshotReadMCPServerDefActive(ctx context.Context) ([]store.MCP
 func (s *Store) SnapshotReadMemory(ctx context.Context) ([]store.MemorySnapshotEntry, error) {
 	now := time.Now().UTC()
 	rows, err := s.pool.Query(ctx,
-		`SELECT scope, scope_id, key, value::text, expires_at, created_at, updated_at
+		`SELECT COALESCE(tenant_id, ''), scope, scope_id, key, value::text, expires_at, created_at, updated_at
 		 FROM memory
 		 WHERE expires_at IS NULL OR expires_at > $1
 		 ORDER BY scope ASC, scope_id ASC, key ASC`, now)
@@ -2092,7 +2092,7 @@ func (s *Store) SnapshotReadMemory(ctx context.Context) ([]store.MemorySnapshotE
 			value     string
 			expiresAt *time.Time
 		)
-		if err := rows.Scan(&scopeStr, &e.ScopeID, &e.Key, &value, &expiresAt, &e.CreatedAt, &e.UpdatedAt); err != nil {
+		if err := rows.Scan(&e.TenantID, &scopeStr, &e.ScopeID, &e.Key, &value, &expiresAt, &e.CreatedAt, &e.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan memory: %w", err)
 		}
 		e.Scope = store.MemoryScope(scopeStr)
@@ -2558,10 +2558,10 @@ func (s *Store) SnapshotRestoreMemory(ctx context.Context, e store.MemorySnapsho
 		expiresAt = &t
 	}
 	tag, err := s.pool.Exec(ctx,
-		`INSERT INTO memory(scope, scope_id, key, value, expires_at, created_at, updated_at)
-		 VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7)
-		 ON CONFLICT (scope, scope_id, key) DO NOTHING`,
-		string(e.Scope), e.ScopeID, e.Key, string(e.Value),
+		`INSERT INTO memory(tenant_id, scope, scope_id, key, value, expires_at, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8)
+		 ON CONFLICT (tenant_id, scope, scope_id, key) DO NOTHING`,
+		e.TenantID, string(e.Scope), e.ScopeID, e.Key, string(e.Value),
 		expiresAt, createdAt, updatedAt,
 	)
 	if err != nil {
@@ -3284,7 +3284,7 @@ func (s *Store) Pool() *pgxpool.Pool { return s.pool }
 // the input bytes to ::jsonb in the query so the database validates
 // the JSON shape (an invalid payload surfaces as a SQL error rather
 // than a silently-stored bad row).
-func (s *Store) MemorySet(ctx context.Context, scope store.MemoryScope, scopeID, key string, value json.RawMessage, ttl time.Duration) error {
+func (s *Store) MemorySet(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string, value json.RawMessage, ttl time.Duration) error {
 	now := time.Now().UTC()
 	var expiresAt any
 	if ttl > 0 {
@@ -3300,13 +3300,13 @@ func (s *Store) MemorySet(ctx context.Context, scope store.MemoryScope, scopeID,
 	// transient so the row actually lands.
 	if err := retryOnTransientConn(ctx, func() error {
 		_, err := s.pool.Exec(ctx,
-			`INSERT INTO memory (scope, scope_id, key, value, expires_at, created_at, updated_at)
-			 VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7)
-			 ON CONFLICT (scope, scope_id, key) DO UPDATE SET
+			`INSERT INTO memory (tenant_id, scope, scope_id, key, value, expires_at, created_at, updated_at)
+			 VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8)
+			 ON CONFLICT (tenant_id, scope, scope_id, key) DO UPDATE SET
 			    value = EXCLUDED.value,
 			    expires_at = EXCLUDED.expires_at,
 			    updated_at = EXCLUDED.updated_at`,
-			string(scope), scopeID, key, string(value), expiresAt, now, now,
+			tenantID, string(scope), scopeID, key, string(value), expiresAt, now, now,
 		)
 		return err
 	}); err != nil {
@@ -3318,7 +3318,7 @@ func (s *Store) MemorySet(ctx context.Context, scope store.MemoryScope, scopeID,
 // MemoryGet returns one entry. Expired rows are surfaced as
 // ErrNotFound (the WHERE clause filters them out so the caller never
 // sees a stale value, even if the sweeper is behind).
-func (s *Store) MemoryGet(ctx context.Context, scope store.MemoryScope, scopeID, key string) (store.MemoryEntry, error) {
+func (s *Store) MemoryGet(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string) (store.MemoryEntry, error) {
 	var (
 		valueText []byte
 		expiresAt *time.Time
@@ -3328,9 +3328,9 @@ func (s *Store) MemoryGet(ctx context.Context, scope store.MemoryScope, scopeID,
 	err := s.pool.QueryRow(ctx,
 		`SELECT value::text, expires_at, created_at, updated_at
 		 FROM memory
-		 WHERE scope = $1 AND scope_id = $2 AND key = $3
+		 WHERE tenant_id = $1 AND scope = $2 AND scope_id = $3 AND key = $4
 		   AND (expires_at IS NULL OR expires_at > NOW())`,
-		string(scope), scopeID, key,
+		tenantID, string(scope), scopeID, key,
 	).Scan(&valueText, &expiresAt, &createdAt, &updatedAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return store.MemoryEntry{}, &store.ErrNotFound{Kind: "memory", ID: key}
@@ -3352,10 +3352,10 @@ func (s *Store) MemoryGet(ctx context.Context, scope store.MemoryScope, scopeID,
 
 // MemoryDelete removes a row. The boolean reports whether a row was
 // actually present. Both branches are non-error.
-func (s *Store) MemoryDelete(ctx context.Context, scope store.MemoryScope, scopeID, key string) (bool, error) {
+func (s *Store) MemoryDelete(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string) (bool, error) {
 	tag, err := s.pool.Exec(ctx,
-		`DELETE FROM memory WHERE scope = $1 AND scope_id = $2 AND key = $3`,
-		string(scope), scopeID, key,
+		`DELETE FROM memory WHERE tenant_id = $1 AND scope = $2 AND scope_id = $3 AND key = $4`,
+		tenantID, string(scope), scopeID, key,
 	)
 	if err != nil {
 		return false, fmt.Errorf("memory delete: %w", err)
@@ -3363,13 +3363,13 @@ func (s *Store) MemoryDelete(ctx context.Context, scope store.MemoryScope, scope
 	return tag.RowsAffected() > 0, nil
 }
 
-// MemoryDeleteScope removes every entry under (scope, scopeID) in one statement
-// (RFC BM retention). memory_embeddings rows cascade via their ON DELETE CASCADE
-// FK, mirroring single-key MemoryDelete.
-func (s *Store) MemoryDeleteScope(ctx context.Context, scope store.MemoryScope, scopeID string) (int, error) {
+// MemoryDeleteScope removes every entry under (tenantID, scope, scopeID) in one
+// statement (RFC BM retention). memory_embeddings rows cascade via their ON
+// DELETE CASCADE FK, mirroring single-key MemoryDelete.
+func (s *Store) MemoryDeleteScope(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID string) (int, error) {
 	tag, err := s.pool.Exec(ctx,
-		`DELETE FROM memory WHERE scope = $1 AND scope_id = $2`,
-		string(scope), scopeID,
+		`DELETE FROM memory WHERE tenant_id = $1 AND scope = $2 AND scope_id = $3`,
+		tenantID, string(scope), scopeID,
 	)
 	if err != nil {
 		return 0, fmt.Errorf("memory delete scope: %w", err)
@@ -3380,7 +3380,7 @@ func (s *Store) MemoryDeleteScope(ctx context.Context, scope store.MemoryScope, 
 // MemoryList enumerates entries for a (scope, scopeID), filtered by
 // prefix and capped at limit. The query fetches limit+1 rows so we
 // can report truncated == true without a separate COUNT(*).
-func (s *Store) MemoryList(ctx context.Context, scope store.MemoryScope, scopeID, prefix string, limit int) ([]store.MemoryEntry, bool, error) {
+func (s *Store) MemoryList(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, prefix string, limit int) ([]store.MemoryEntry, bool, error) {
 	if limit <= 0 {
 		limit = 100
 	}
@@ -3388,11 +3388,11 @@ func (s *Store) MemoryList(ctx context.Context, scope store.MemoryScope, scopeID
 	rows, err := s.pool.Query(ctx,
 		`SELECT key, value::text, expires_at, created_at, updated_at
 		 FROM memory
-		 WHERE scope = $1 AND scope_id = $2 AND key LIKE $3 ESCAPE '\'
+		 WHERE tenant_id = $1 AND scope = $2 AND scope_id = $3 AND key LIKE $4 ESCAPE '\'
 		   AND (expires_at IS NULL OR expires_at > NOW())
 		 ORDER BY key ASC
-		 LIMIT $4`,
-		string(scope), scopeID, pattern, limit+1,
+		 LIMIT $5`,
+		tenantID, string(scope), scopeID, pattern, limit+1,
 	)
 	if err != nil {
 		return nil, false, fmt.Errorf("memory list: %w", err)
@@ -3450,7 +3450,7 @@ func (s *Store) MemoryList(ctx context.Context, scope store.MemoryScope, scopeID
 // 2*delta via ON CONFLICT DO UPDATE). Different keys hash to
 // different lock IDs and don't contend. Verified by a 100-goroutine
 // regression test in storetest (all 100 increments must land).
-func (s *Store) MemoryIncrement(ctx context.Context, scope store.MemoryScope, scopeID, key string, delta int64, ttl time.Duration) (int64, error) {
+func (s *Store) MemoryIncrement(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string, delta int64, ttl time.Duration) (int64, error) {
 	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return 0, fmt.Errorf("memory incr begin: %w", err)
@@ -3459,7 +3459,7 @@ func (s *Store) MemoryIncrement(ctx context.Context, scope store.MemoryScope, sc
 
 	if _, err := tx.Exec(ctx,
 		`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`,
-		string(scope)+":"+scopeID+":"+key,
+		tenantID+":"+string(scope)+":"+scopeID+":"+key,
 	); err != nil {
 		return 0, fmt.Errorf("memory incr lock: %w", err)
 	}
@@ -3470,8 +3470,8 @@ func (s *Store) MemoryIncrement(ctx context.Context, scope store.MemoryScope, sc
 	)
 	err = tx.QueryRow(ctx,
 		`SELECT value::text, expires_at FROM memory
-		 WHERE scope = $1 AND scope_id = $2 AND key = $3`,
-		string(scope), scopeID, key,
+		 WHERE tenant_id = $1 AND scope = $2 AND scope_id = $3 AND key = $4`,
+		tenantID, string(scope), scopeID, key,
 	).Scan(&valueText, &expiresAt)
 
 	now := time.Now().UTC()
@@ -3513,13 +3513,13 @@ func (s *Store) MemoryIncrement(ctx context.Context, scope store.MemoryScope, sc
 	}
 
 	if _, err := tx.Exec(ctx,
-		`INSERT INTO memory (scope, scope_id, key, value, expires_at, created_at, updated_at)
-		 VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7)
-		 ON CONFLICT (scope, scope_id, key) DO UPDATE SET
+		`INSERT INTO memory (tenant_id, scope, scope_id, key, value, expires_at, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8)
+		 ON CONFLICT (tenant_id, scope, scope_id, key) DO UPDATE SET
 		    value = EXCLUDED.value,
 		    expires_at = EXCLUDED.expires_at,
 		    updated_at = EXCLUDED.updated_at`,
-		string(scope), scopeID, key, nextText, newExpires, now, now,
+		tenantID, string(scope), scopeID, key, nextText, newExpires, now, now,
 	); err != nil {
 		return 0, fmt.Errorf("memory incr write: %w", err)
 	}
@@ -3539,6 +3539,7 @@ func (s *Store) MemoryIncrement(ctx context.Context, scope store.MemoryScope, sc
 // different keys run in parallel.
 func (s *Store) MemoryAtomicUpdate(
 	ctx context.Context,
+	tenantID string,
 	scope store.MemoryScope,
 	scopeID, key string,
 	ttl time.Duration,
@@ -3552,7 +3553,7 @@ func (s *Store) MemoryAtomicUpdate(
 
 	if _, err := tx.Exec(ctx,
 		`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`,
-		string(scope)+":"+scopeID+":"+key,
+		tenantID+":"+string(scope)+":"+scopeID+":"+key,
 	); err != nil {
 		return nil, fmt.Errorf("memory atomic update lock: %w", err)
 	}
@@ -3563,8 +3564,8 @@ func (s *Store) MemoryAtomicUpdate(
 	)
 	err = tx.QueryRow(ctx,
 		`SELECT value::text, expires_at FROM memory
-		 WHERE scope = $1 AND scope_id = $2 AND key = $3`,
-		string(scope), scopeID, key,
+		 WHERE tenant_id = $1 AND scope = $2 AND scope_id = $3 AND key = $4`,
+		tenantID, string(scope), scopeID, key,
 	).Scan(&valueText, &expiresAt)
 
 	now := time.Now().UTC()
@@ -3602,13 +3603,13 @@ func (s *Store) MemoryAtomicUpdate(
 	}
 
 	if _, err := tx.Exec(ctx,
-		`INSERT INTO memory (scope, scope_id, key, value, expires_at, created_at, updated_at)
-		 VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7)
-		 ON CONFLICT (scope, scope_id, key) DO UPDATE SET
+		`INSERT INTO memory (tenant_id, scope, scope_id, key, value, expires_at, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8)
+		 ON CONFLICT (tenant_id, scope, scope_id, key) DO UPDATE SET
 		    value = EXCLUDED.value,
 		    expires_at = EXCLUDED.expires_at,
 		    updated_at = EXCLUDED.updated_at`,
-		string(scope), scopeID, key, string(next), newExpires, now, now,
+		tenantID, string(scope), scopeID, key, string(next), newExpires, now, now,
 	); err != nil {
 		return nil, fmt.Errorf("memory atomic update write: %w", err)
 	}
@@ -3623,7 +3624,7 @@ func (s *Store) MemoryAtomicUpdate(
 // estimate — JSONB has no LENGTH() in the SQLite sense; the textual
 // representation is what an operator cares about anyway. Capped at
 // 200 rows ordered by updated_at DESC.
-func (s *Store) MemoryListScopeIDs(ctx context.Context, scope store.MemoryScope) ([]store.MemoryScopeIDSummary, error) {
+func (s *Store) MemoryListScopeIDs(ctx context.Context, tenantID string, scope store.MemoryScope) ([]store.MemoryScopeIDSummary, error) {
 	rows, err := s.pool.Query(ctx, `
 		SELECT
 			scope_id,
@@ -3631,11 +3632,11 @@ func (s *Store) MemoryListScopeIDs(ctx context.Context, scope store.MemoryScope)
 			COALESCE(SUM(octet_length(key) + octet_length(value::text)), 0)   AS bytes,
 			MAX(updated_at)                                                   AS updated_at
 		FROM memory
-		WHERE scope = $1 AND (expires_at IS NULL OR expires_at > NOW())
+		WHERE tenant_id = $1 AND scope = $2 AND (expires_at IS NULL OR expires_at > NOW())
 		GROUP BY scope_id
 		ORDER BY updated_at DESC
 		LIMIT 200`,
-		string(scope),
+		tenantID, string(scope),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("memory list scope ids: %w", err)

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -3653,6 +3653,29 @@ func (s *Store) MemoryListScopeIDs(ctx context.Context, tenantID string, scope s
 	return out, rows.Err()
 }
 
+// MemoryListTenantsForScope implements store.Store (RFC BL). DISTINCT over every
+// row for (scope, scopeID) regardless of expiry — reclamation deletes expired
+// rows too, so an all-expired partition must still be enumerated.
+func (s *Store) MemoryListTenantsForScope(ctx context.Context, scope store.MemoryScope, scopeID string) ([]string, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT DISTINCT COALESCE(tenant_id, '') FROM memory WHERE scope = $1 AND scope_id = $2`,
+		string(scope), scopeID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("memory list tenants for scope: %w", err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var t string
+		if err := rows.Scan(&t); err != nil {
+			return nil, fmt.Errorf("memory list tenants for scope scan: %w", err)
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
 // MemorySweep deletes every Memory row whose expires_at has passed.
 // Single atomic DELETE so concurrent sweepers race correctly.
 func (s *Store) MemorySweep(ctx context.Context) (int, error) {

--- a/internal/store/sqlite/memory_embeddings.go
+++ b/internal/store/sqlite/memory_embeddings.go
@@ -32,22 +32,22 @@ func (s *Store) SupportsVectors() bool {
 	return false
 }
 
-func (s *Store) MemoryEmbedSet(ctx context.Context, scope store.MemoryScope, scopeID, key string, e store.MemoryEmbedding) error {
+func (s *Store) MemoryEmbedSet(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string, e store.MemoryEmbedding) error {
 	return store.ErrVectorUnsupported
 }
 
-func (s *Store) MemoryEmbedGet(ctx context.Context, scope store.MemoryScope, scopeID, key string) (store.MemoryEmbedding, error) {
+func (s *Store) MemoryEmbedGet(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string) (store.MemoryEmbedding, error) {
 	return store.MemoryEmbedding{}, store.ErrVectorUnsupported
 }
 
-func (s *Store) MemoryEmbedSearch(ctx context.Context, scope store.MemoryScope, scopeID, keyPrefix string, query []float32, topK int) ([]store.MemorySearchEntry, error) {
+func (s *Store) MemoryEmbedSearch(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, keyPrefix string, query []float32, topK int) ([]store.MemorySearchEntry, error) {
 	return nil, store.ErrVectorUnsupported
 }
 
-func (s *Store) MemoryEmbedListByModel(ctx context.Context, scope store.MemoryScope, scopeID, currentProvider, currentModel string, limit int) ([]store.MemoryEntry, error) {
+func (s *Store) MemoryEmbedListByModel(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, currentProvider, currentModel string, limit int) ([]store.MemoryEntry, error) {
 	return nil, store.ErrVectorUnsupported
 }
 
-func (s *Store) MemoryEmbedStats(ctx context.Context, scope store.MemoryScope) (store.MemoryEmbedStats, error) {
+func (s *Store) MemoryEmbedStats(ctx context.Context, tenantID string, scope store.MemoryScope) (store.MemoryEmbedStats, error) {
 	return store.MemoryEmbedStats{}, store.ErrVectorUnsupported
 }

--- a/internal/store/sqlite/memory_embeddings_vec.go
+++ b/internal/store/sqlite/memory_embeddings_vec.go
@@ -69,22 +69,22 @@ var errVecImplPending = &store.MemoryError{
 		"see internal/store/sqlite/memory_embeddings_vec.go docstring for the per-dim-partitioning design tradeoff)",
 }
 
-func (s *Store) MemoryEmbedSet(ctx context.Context, scope store.MemoryScope, scopeID, key string, e store.MemoryEmbedding) error {
+func (s *Store) MemoryEmbedSet(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string, e store.MemoryEmbedding) error {
 	return errVecImplPending
 }
 
-func (s *Store) MemoryEmbedGet(ctx context.Context, scope store.MemoryScope, scopeID, key string) (store.MemoryEmbedding, error) {
+func (s *Store) MemoryEmbedGet(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string) (store.MemoryEmbedding, error) {
 	return store.MemoryEmbedding{}, errVecImplPending
 }
 
-func (s *Store) MemoryEmbedSearch(ctx context.Context, scope store.MemoryScope, scopeID, keyPrefix string, query []float32, topK int) ([]store.MemorySearchEntry, error) {
+func (s *Store) MemoryEmbedSearch(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, keyPrefix string, query []float32, topK int) ([]store.MemorySearchEntry, error) {
 	return nil, errVecImplPending
 }
 
-func (s *Store) MemoryEmbedListByModel(ctx context.Context, scope store.MemoryScope, scopeID, currentProvider, currentModel string, limit int) ([]store.MemoryEntry, error) {
+func (s *Store) MemoryEmbedListByModel(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, currentProvider, currentModel string, limit int) ([]store.MemoryEntry, error) {
 	return nil, errVecImplPending
 }
 
-func (s *Store) MemoryEmbedStats(ctx context.Context, scope store.MemoryScope) (store.MemoryEmbedStats, error) {
+func (s *Store) MemoryEmbedStats(ctx context.Context, tenantID string, scope store.MemoryScope) (store.MemoryEmbedStats, error) {
 	return store.MemoryEmbedStats{}, errVecImplPending
 }

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -4131,6 +4131,29 @@ func (s *Store) MemoryListScopeIDs(ctx context.Context, tenantID string, scope s
 	return out, rows.Err()
 }
 
+// MemoryListTenantsForScope implements store.Store (RFC BL). DISTINCT over every
+// row for (scope, scopeID) regardless of expiry — reclamation deletes expired
+// rows too, so an all-expired partition must still be enumerated.
+func (s *Store) MemoryListTenantsForScope(ctx context.Context, scope store.MemoryScope, scopeID string) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT DISTINCT COALESCE(tenant_id, '') FROM memory WHERE scope = ? AND scope_id = ?`,
+		string(scope), scopeID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var t string
+		if err := rows.Scan(&t); err != nil {
+			return nil, err
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
 // MemorySweep deletes every Memory row whose expires_at has passed.
 func (s *Store) MemorySweep(ctx context.Context) (int, error) {
 	res, err := s.db.ExecContext(ctx,

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -230,18 +230,35 @@ func (s *Store) migrate(ctx context.Context) error {
 		// The similarity search folds on (tenant_id, user_id, agent) then scans
 		// the most-recent candidates; this covers that owner prefix.
 		`CREATE INDEX IF NOT EXISTS session_embeddings_by_owner ON session_embeddings(tenant_id, user_id, agent)`,
-		// v0.8 Memory tool. PRIMARY KEY (scope, scope_id, key) gives
-		// the natural lookup index; the partial expires_at index keeps
-		// the sweeper's DELETE cheap (no full-table scan).
+		// v0.8 Memory tool. RFC BL: tenant-scoped + provenance/access
+		// columns. On a FRESH DB the PRIMARY KEY (tenant_id, scope,
+		// scope_id, key) isolates same-named agents across tenants; the
+		// partial expires_at index keeps the sweeper's DELETE cheap (no
+		// full-table scan). On an UPGRADED DB the addColumns ALTER adds
+		// tenant_id + the RFC BL columns but SQLite cannot rewrite the PK
+		// in place, so the PK stays (scope, scope_id, key) — byte-equivalent
+		// for single-tenant (everything tenant_id=''), but multi-tenant
+		// memory isolation requires Postgres or a FRESH sqlite DB (mirrors
+		// the agent_def_active precedent above). The runtime upserts'
+		// ON CONFLICT(tenant_id, scope, scope_id, key) target the
+		// uniq_memory_tenant_scope_scope_id_key index in addIndexes below,
+		// which exists on both fresh and upgraded DBs.
 		`CREATE TABLE IF NOT EXISTS memory (
-			scope       TEXT NOT NULL,
-			scope_id    TEXT NOT NULL,
-			key         TEXT NOT NULL,
-			value       TEXT NOT NULL,
-			expires_at  INTEGER,
-			created_at  INTEGER NOT NULL,
-			updated_at  INTEGER NOT NULL,
-			PRIMARY KEY (scope, scope_id, key)
+			scope             TEXT NOT NULL,
+			scope_id          TEXT NOT NULL,
+			key               TEXT NOT NULL,
+			value             TEXT NOT NULL,
+			expires_at        INTEGER,
+			created_at        INTEGER NOT NULL,
+			updated_at        INTEGER NOT NULL,
+			tenant_id         TEXT NOT NULL DEFAULT '',
+			origin            TEXT,
+			class             TEXT,
+			source_session_id TEXT,
+			source_run_id     TEXT,
+			access_count      INTEGER NOT NULL DEFAULT 0,
+			last_accessed_at  INTEGER,
+			PRIMARY KEY (tenant_id, scope, scope_id, key)
 		)`,
 		`CREATE INDEX IF NOT EXISTS memory_by_expires_at ON memory(expires_at) WHERE expires_at IS NOT NULL`,
 		// v0.8.4 Channel tool — see internal/store/postgres/migrations/0004_channels.up.sql
@@ -1002,6 +1019,19 @@ func (s *Store) migrate(ctx context.Context) error {
 		`ALTER TABLE sessions ADD COLUMN archived_at INTEGER`,
 		`ALTER TABLE sessions ADD COLUMN summary TEXT`,
 		`ALTER TABLE sessions ADD COLUMN summary_updated_at INTEGER`,
+		// RFC BL — tenant-scope the Memory store + provenance/access columns.
+		// On an UPGRADED DB these ALTERs add the columns to the existing
+		// memory table; the PK stays (scope, scope_id, key) (SQLite can't
+		// rewrite it in place — see the CREATE TABLE note + the agent_def_active
+		// caveat: multi-tenant memory isolation requires Postgres or a fresh
+		// sqlite DB). DEFAULT '' backfills existing rows to the legacy tenant.
+		`ALTER TABLE memory ADD COLUMN tenant_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE memory ADD COLUMN origin TEXT`,
+		`ALTER TABLE memory ADD COLUMN class TEXT`,
+		`ALTER TABLE memory ADD COLUMN source_session_id TEXT`,
+		`ALTER TABLE memory ADD COLUMN source_run_id TEXT`,
+		`ALTER TABLE memory ADD COLUMN access_count INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE memory ADD COLUMN last_accessed_at INTEGER`,
 	}
 	for _, q := range addColumns {
 		if _, err := s.db.ExecContext(ctx, q); err != nil {
@@ -1161,6 +1191,14 @@ func (s *Store) migrate(ctx context.Context) error {
 		// Webhook plane (RFC N completion) — same in-place-upgrade gap.
 		`CREATE UNIQUE INDEX IF NOT EXISTS uniq_webhook_def_active_tenant_name   ON webhook_def_active(tenant_id, name)`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS uniq_webhook_defs_tenant_name_version ON webhook_defs(tenant_id, name, version)`,
+		// RFC BL — the ON CONFLICT(tenant_id, scope, scope_id, key) target for
+		// the Memory upserts (MemorySet / MemoryIncrement / MemoryAtomicUpdate).
+		// On a FRESH DB it's redundant with the composite PRIMARY KEY; on an
+		// UPGRADED DB the PK stays (scope, scope_id, key) (SQLite can't rewrite
+		// it in place), so this index supplies the ON CONFLICT target — without
+		// it the upserts fail "ON CONFLICT clause does not match ..." even
+		// single-tenant. Mirrors the def-plane indexes above.
+		`CREATE UNIQUE INDEX IF NOT EXISTS uniq_memory_tenant_scope_scope_id_key ON memory(tenant_id, scope, scope_id, key)`,
 	}
 	for _, q := range addIndexes {
 		// Note the asymmetry vs addColumns above: indexes use
@@ -3092,7 +3130,7 @@ func (s *Store) SnapshotReadMCPServerDefActive(ctx context.Context) ([]store.MCP
 func (s *Store) SnapshotReadMemory(ctx context.Context) ([]store.MemorySnapshotEntry, error) {
 	now := time.Now().UnixNano()
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT scope, scope_id, key, value, expires_at, created_at, updated_at
+		`SELECT COALESCE(tenant_id, ''), scope, scope_id, key, value, expires_at, created_at, updated_at
 		 FROM memory
 		 WHERE expires_at IS NULL OR expires_at > ?
 		 ORDER BY scope ASC, scope_id ASC, key ASC`, now)
@@ -3111,7 +3149,7 @@ func (s *Store) SnapshotReadMemory(ctx context.Context) ([]store.MemorySnapshotE
 			updatedNs int64
 		)
 		if err := rows.Scan(
-			&scopeStr, &e.ScopeID, &e.Key, &value,
+			&e.TenantID, &scopeStr, &e.ScopeID, &e.Key, &value,
 			&expiresNs, &createdNs, &updatedNs,
 		); err != nil {
 			return nil, fmt.Errorf("scan memory: %w", err)
@@ -3603,9 +3641,9 @@ func (s *Store) SnapshotRestoreMemory(ctx context.Context, e store.MemorySnapsho
 		expiresNs = e.ExpiresAt.UnixNano()
 	}
 	res, err := s.db.ExecContext(ctx,
-		`INSERT OR IGNORE INTO memory(scope, scope_id, key, value, expires_at, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		string(e.Scope), e.ScopeID, e.Key, string(e.Value), expiresNs, createdNs, updatedNs,
+		`INSERT OR IGNORE INTO memory(tenant_id, scope, scope_id, key, value, expires_at, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		e.TenantID, string(e.Scope), e.ScopeID, e.Key, string(e.Value), expiresNs, createdNs, updatedNs,
 	)
 	if err != nil {
 		return false, fmt.Errorf("snapshot restore memory: %w", err)
@@ -3714,20 +3752,20 @@ func (s *Store) SnapshotRestoreEvaluation(ctx context.Context, r store.Evaluatio
 // type beyond what JSON1 functions consume; the tool layer is the
 // source of truth for shape validation. (We also use the textual
 // representation for the JSON-number parse in MemoryIncrement.)
-func (s *Store) MemorySet(ctx context.Context, scope store.MemoryScope, scopeID, key string, value json.RawMessage, ttl time.Duration) error {
+func (s *Store) MemorySet(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string, value json.RawMessage, ttl time.Duration) error {
 	now := time.Now().UnixNano()
 	var expiresAt any
 	if ttl > 0 {
 		expiresAt = time.Now().Add(ttl).UnixNano()
 	}
 	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO memory(scope, scope_id, key, value, expires_at, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?)
-		 ON CONFLICT(scope, scope_id, key) DO UPDATE SET
+		`INSERT INTO memory(tenant_id, scope, scope_id, key, value, expires_at, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(tenant_id, scope, scope_id, key) DO UPDATE SET
 		    value = excluded.value,
 		    expires_at = excluded.expires_at,
 		    updated_at = excluded.updated_at`,
-		string(scope), scopeID, key, string(value), expiresAt, now, now,
+		tenantID, string(scope), scopeID, key, string(value), expiresAt, now, now,
 	)
 	return err
 }
@@ -3735,7 +3773,7 @@ func (s *Store) MemorySet(ctx context.Context, scope store.MemoryScope, scopeID,
 // MemoryGet returns the entry or *ErrNotFound. Expired rows are
 // surfaced as ErrNotFound regardless of whether the sweeper has
 // reaped them yet.
-func (s *Store) MemoryGet(ctx context.Context, scope store.MemoryScope, scopeID, key string) (store.MemoryEntry, error) {
+func (s *Store) MemoryGet(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string) (store.MemoryEntry, error) {
 	var (
 		valueText string
 		expiresAt sql.NullInt64
@@ -3744,8 +3782,8 @@ func (s *Store) MemoryGet(ctx context.Context, scope store.MemoryScope, scopeID,
 	)
 	err := s.db.QueryRowContext(ctx,
 		`SELECT value, expires_at, created_at, updated_at
-		 FROM memory WHERE scope = ? AND scope_id = ? AND key = ?`,
-		string(scope), scopeID, key,
+		 FROM memory WHERE tenant_id = ? AND scope = ? AND scope_id = ? AND key = ?`,
+		tenantID, string(scope), scopeID, key,
 	).Scan(&valueText, &expiresAt, &createdAt, &updatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return store.MemoryEntry{}, &store.ErrNotFound{Kind: "memory", ID: key}
@@ -3770,10 +3808,10 @@ func (s *Store) MemoryGet(ctx context.Context, scope store.MemoryScope, scopeID,
 
 // MemoryDelete removes a row. Returns whether a row was actually
 // deleted; both outcomes are non-error.
-func (s *Store) MemoryDelete(ctx context.Context, scope store.MemoryScope, scopeID, key string) (bool, error) {
+func (s *Store) MemoryDelete(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string) (bool, error) {
 	res, err := s.db.ExecContext(ctx,
-		`DELETE FROM memory WHERE scope = ? AND scope_id = ? AND key = ?`,
-		string(scope), scopeID, key,
+		`DELETE FROM memory WHERE tenant_id = ? AND scope = ? AND scope_id = ? AND key = ?`,
+		tenantID, string(scope), scopeID, key,
 	)
 	if err != nil {
 		return false, err
@@ -3785,13 +3823,15 @@ func (s *Store) MemoryDelete(ctx context.Context, scope store.MemoryScope, scope
 	return n > 0, nil
 }
 
-// MemoryDeleteScope removes every entry under (scope, scopeID) in one statement
-// (RFC BM retention). memory_embeddings rows cascade via their ON DELETE CASCADE
-// FK (foreign_keys=ON in the driver DSN), mirroring single-key MemoryDelete.
-func (s *Store) MemoryDeleteScope(ctx context.Context, scope store.MemoryScope, scopeID string) (int, error) {
+// MemoryDeleteScope removes every entry under (tenantID, scope, scopeID) in one
+// statement (RFC BM retention). memory_embeddings rows cascade via their ON
+// DELETE CASCADE FK (foreign_keys=ON in the driver DSN), mirroring single-key
+// MemoryDelete. (SQLite has no memory_embeddings table, so the cascade is a
+// Postgres-only concern.)
+func (s *Store) MemoryDeleteScope(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID string) (int, error) {
 	res, err := s.db.ExecContext(ctx,
-		`DELETE FROM memory WHERE scope = ? AND scope_id = ?`,
-		string(scope), scopeID,
+		`DELETE FROM memory WHERE tenant_id = ? AND scope = ? AND scope_id = ?`,
+		tenantID, string(scope), scopeID,
 	)
 	if err != nil {
 		return 0, err
@@ -3807,7 +3847,7 @@ func (s *Store) MemoryDeleteScope(ctx context.Context, scope store.MemoryScope, 
 // prefix and capped at limit rows. Expired rows are filtered in the
 // WHERE clause so callers never see them. truncated == true when the
 // underlying query found at least limit+1 rows.
-func (s *Store) MemoryList(ctx context.Context, scope store.MemoryScope, scopeID, prefix string, limit int) ([]store.MemoryEntry, bool, error) {
+func (s *Store) MemoryList(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, prefix string, limit int) ([]store.MemoryEntry, bool, error) {
 	if limit <= 0 {
 		limit = 100
 	}
@@ -3816,11 +3856,11 @@ func (s *Store) MemoryList(ctx context.Context, scope store.MemoryScope, scopeID
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT key, value, expires_at, created_at, updated_at
 		 FROM memory
-		 WHERE scope = ? AND scope_id = ? AND key LIKE ? ESCAPE '\'
+		 WHERE tenant_id = ? AND scope = ? AND scope_id = ? AND key LIKE ? ESCAPE '\'
 		   AND (expires_at IS NULL OR expires_at > ?)
 		 ORDER BY key ASC
 		 LIMIT ?`,
-		string(scope), scopeID, escapeLikePrefix(prefix)+"%", nowNs, limit+1,
+		tenantID, string(scope), scopeID, escapeLikePrefix(prefix)+"%", nowNs, limit+1,
 	)
 	if err != nil {
 		return nil, false, err
@@ -3874,7 +3914,7 @@ func (s *Store) MemoryList(ctx context.Context, scope store.MemoryScope, scopeID
 // `BEGIN IMMEDIATE` / `COMMIT` raw, scoping the lock-on-BEGIN
 // behaviour to this one operation. Verified by a 100-goroutine
 // regression test in storetest (counter must hit exactly 100).
-func (s *Store) MemoryIncrement(ctx context.Context, scope store.MemoryScope, scopeID, key string, delta int64, ttl time.Duration) (int64, error) {
+func (s *Store) MemoryIncrement(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string, delta int64, ttl time.Duration) (int64, error) {
 	conn, err := s.db.Conn(ctx)
 	if err != nil {
 		return 0, err
@@ -3896,8 +3936,8 @@ func (s *Store) MemoryIncrement(ctx context.Context, scope store.MemoryScope, sc
 		expiresAt sql.NullInt64
 	)
 	err = conn.QueryRowContext(ctx,
-		`SELECT value, expires_at FROM memory WHERE scope = ? AND scope_id = ? AND key = ?`,
-		string(scope), scopeID, key,
+		`SELECT value, expires_at FROM memory WHERE tenant_id = ? AND scope = ? AND scope_id = ? AND key = ?`,
+		tenantID, string(scope), scopeID, key,
 	).Scan(&valueText, &expiresAt)
 	now := time.Now()
 	nowNs := now.UnixNano()
@@ -3941,13 +3981,13 @@ func (s *Store) MemoryIncrement(ctx context.Context, scope store.MemoryScope, sc
 	}
 
 	_, err = conn.ExecContext(ctx,
-		`INSERT INTO memory(scope, scope_id, key, value, expires_at, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?)
-		 ON CONFLICT(scope, scope_id, key) DO UPDATE SET
+		`INSERT INTO memory(tenant_id, scope, scope_id, key, value, expires_at, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(tenant_id, scope, scope_id, key) DO UPDATE SET
 		    value = excluded.value,
 		    expires_at = excluded.expires_at,
 		    updated_at = excluded.updated_at`,
-		string(scope), scopeID, key, nextText, newExpires, nowNs, nowNs,
+		tenantID, string(scope), scopeID, key, nextText, newExpires, nowNs, nowNs,
 	)
 	if err != nil {
 		return 0, err
@@ -3972,6 +4012,7 @@ func (s *Store) MemoryIncrement(ctx context.Context, scope store.MemoryScope, sc
 // concurrency model.
 func (s *Store) MemoryAtomicUpdate(
 	ctx context.Context,
+	tenantID string,
 	scope store.MemoryScope,
 	scopeID, key string,
 	ttl time.Duration,
@@ -3998,8 +4039,8 @@ func (s *Store) MemoryAtomicUpdate(
 		expiresAt sql.NullInt64
 	)
 	err = conn.QueryRowContext(ctx,
-		`SELECT value, expires_at FROM memory WHERE scope = ? AND scope_id = ? AND key = ?`,
-		string(scope), scopeID, key,
+		`SELECT value, expires_at FROM memory WHERE tenant_id = ? AND scope = ? AND scope_id = ? AND key = ?`,
+		tenantID, string(scope), scopeID, key,
 	).Scan(&valueText, &expiresAt)
 	now := time.Now()
 	nowNs := now.UnixNano()
@@ -4035,13 +4076,13 @@ func (s *Store) MemoryAtomicUpdate(
 	}
 
 	_, err = conn.ExecContext(ctx,
-		`INSERT INTO memory(scope, scope_id, key, value, expires_at, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?)
-		 ON CONFLICT(scope, scope_id, key) DO UPDATE SET
+		`INSERT INTO memory(tenant_id, scope, scope_id, key, value, expires_at, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(tenant_id, scope, scope_id, key) DO UPDATE SET
 		    value = excluded.value,
 		    expires_at = excluded.expires_at,
 		    updated_at = excluded.updated_at`,
-		string(scope), scopeID, key, string(next), newExpires, nowNs, nowNs,
+		tenantID, string(scope), scopeID, key, string(next), newExpires, nowNs, nowNs,
 	)
 	if err != nil {
 		return nil, err
@@ -4056,7 +4097,7 @@ func (s *Store) MemoryAtomicUpdate(
 // MemoryListScopeIDs returns distinct scope_ids under scope with
 // summary stats. Excludes expired rows so operators see live state
 // only. Capped at 200 rows ordered by updated_at DESC.
-func (s *Store) MemoryListScopeIDs(ctx context.Context, scope store.MemoryScope) ([]store.MemoryScopeIDSummary, error) {
+func (s *Store) MemoryListScopeIDs(ctx context.Context, tenantID string, scope store.MemoryScope) ([]store.MemoryScopeIDSummary, error) {
 	nowNs := time.Now().UnixNano()
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT
@@ -4065,11 +4106,11 @@ func (s *Store) MemoryListScopeIDs(ctx context.Context, scope store.MemoryScope)
 			COALESCE(SUM(LENGTH(key) + LENGTH(value)), 0)          AS bytes,
 			MAX(updated_at)                                        AS updated_at
 		FROM memory
-		WHERE scope = ? AND (expires_at IS NULL OR expires_at > ?)
+		WHERE tenant_id = ? AND scope = ? AND (expires_at IS NULL OR expires_at > ?)
 		GROUP BY scope_id
 		ORDER BY updated_at DESC
 		LIMIT 200`,
-		string(scope), nowNs,
+		tenantID, string(scope), nowNs,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/store/sqlite/sqlite_test.go
+++ b/internal/store/sqlite/sqlite_test.go
@@ -96,6 +96,47 @@ func TestStore_MemoryTenantIsolation(t *testing.T) {
 	}
 }
 
+// TestStore_MemoryListTenantsForScope: the RFC BL enumeration returns exactly
+// the distinct tenants that hold a row under (scope, scopeID), independent of
+// expiry, and an empty slice for a name with no rows — the primitive the
+// retention sweeper's per-tenant base-memory fan-out rides on.
+func TestStore_MemoryListTenantsForScope(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	scope := store.MemoryScopeAgent
+	const name = "shared-agent"
+
+	// Same (scope, name) under three partitions: "" (legacy), "a", "b".
+	for _, tenant := range []string{"", "a", "b"} {
+		if err := s.MemorySet(ctx, tenant, scope, name, "k1", json.RawMessage(`1`), 0); err != nil {
+			t.Fatalf("MemorySet(%q): %v", tenant, err)
+		}
+	}
+	// A different scope_id must not bleed in.
+	if err := s.MemorySet(ctx, "c", scope, "other-agent", "k1", json.RawMessage(`1`), 0); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.MemoryListTenantsForScope(ctx, scope, name)
+	if err != nil {
+		t.Fatalf("MemoryListTenantsForScope: %v", err)
+	}
+	set := map[string]bool{}
+	for _, tn := range got {
+		set[tn] = true
+	}
+	if len(got) != 3 || !set[""] || !set["a"] || !set["b"] {
+		t.Errorf("tenants = %v, want exactly {\"\",a,b}", got)
+	}
+
+	// A name with no rows returns empty (not an error) — the sweeper treats
+	// this as "nothing to reclaim".
+	empty, err := s.MemoryListTenantsForScope(ctx, scope, "never-written")
+	if err != nil || len(empty) != 0 {
+		t.Errorf("empty scope = %v err=%v, want [] nil", empty, err)
+	}
+}
+
 // ---- SQLite-specific tests below this line ----
 //
 // Tests that verify SQLite-only behaviour (the ALTER-COLUMN idempotency

--- a/internal/store/sqlite/sqlite_test.go
+++ b/internal/store/sqlite/sqlite_test.go
@@ -2,6 +2,8 @@ package sqlite
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"path/filepath"
 	"testing"
 
@@ -31,6 +33,67 @@ func TestStoreContract(t *testing.T) {
 		s := newTestStore(t)
 		return s, func() { _ = s.Close() }
 	})
+}
+
+// TestStore_MemoryTenantIsolation is the RFC BL fail-before guard for the
+// tenant axis threaded through the base Memory store: a key written under
+// tenant "a" must be invisible to tenant "b" (get / list / delete) and stay
+// visible under "a". This is new-and-meaningful — on the pre-RFC-BL code the
+// Memory* methods had no tenant parameter and shared a single keyspace, so
+// tenant "b" would read tenant "a"'s row; the test cannot compile against
+// that signature at all. Runs on a FRESH SQLite DB, where the
+// (tenant_id, scope, scope_id, key) PRIMARY KEY enforces the isolation
+// (an upgraded DB keeps the old 3-tuple PK — see the migrate() note).
+func TestStore_MemoryTenantIsolation(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	const tenantA, tenantB = "a", "b"
+	scope := store.MemoryScopeAgent
+	const scopeID, key = "shared-agent", "note"
+
+	// Same (scope, scope_id, key) under BOTH tenants with distinct values:
+	// no clobber, because tenant_id leads the PK.
+	if err := s.MemorySet(ctx, tenantA, scope, scopeID, key, json.RawMessage(`"from-a"`), 0); err != nil {
+		t.Fatalf("MemorySet(a): %v", err)
+	}
+	if err := s.MemorySet(ctx, tenantB, scope, scopeID, key, json.RawMessage(`"from-b"`), 0); err != nil {
+		t.Fatalf("MemorySet(b): %v", err)
+	}
+
+	// Get: each tenant reads only its own value.
+	if got, err := s.MemoryGet(ctx, tenantA, scope, scopeID, key); err != nil || string(got.Value) != `"from-a"` {
+		t.Errorf("MemoryGet(a) = %q, err=%v; want \"from-a\"", got.Value, err)
+	}
+	if got, err := s.MemoryGet(ctx, tenantB, scope, scopeID, key); err != nil || string(got.Value) != `"from-b"` {
+		t.Errorf("MemoryGet(b) = %q, err=%v; want \"from-b\"", got.Value, err)
+	}
+
+	// A key that exists ONLY under tenant a is invisible to tenant b.
+	if err := s.MemorySet(ctx, tenantA, scope, scopeID, "a-only", json.RawMessage(`1`), 0); err != nil {
+		t.Fatalf("MemorySet(a-only): %v", err)
+	}
+	if _, err := s.MemoryGet(ctx, tenantB, scope, scopeID, "a-only"); !errors.As(err, new(*store.ErrNotFound)) {
+		t.Errorf("tenant b must NOT see tenant a's a-only key; got err=%v", err)
+	}
+
+	// List under b returns only b's row (the shared key), never a-only.
+	if entries, _, err := s.MemoryList(ctx, tenantB, scope, scopeID, "", 100); err != nil || len(entries) != 1 || entries[0].Key != key {
+		t.Errorf("MemoryList(b) = %+v, err=%v; want exactly [%q]", entries, err, key)
+	}
+
+	// Delete under b removes only b's row; a's rows are untouched.
+	if deleted, err := s.MemoryDelete(ctx, tenantB, scope, scopeID, key); err != nil || !deleted {
+		t.Fatalf("MemoryDelete(b): deleted=%v err=%v", deleted, err)
+	}
+	if _, err := s.MemoryGet(ctx, tenantB, scope, scopeID, key); !errors.As(err, new(*store.ErrNotFound)) {
+		t.Errorf("tenant b's key should be gone after its delete; got err=%v", err)
+	}
+	if got, err := s.MemoryGet(ctx, tenantA, scope, scopeID, key); err != nil || string(got.Value) != `"from-a"` {
+		t.Errorf("tenant a's key must survive b's delete; got %q err=%v", got.Value, err)
+	}
+	if entries, _, err := s.MemoryList(ctx, tenantA, scope, scopeID, "", 100); err != nil || len(entries) != 2 {
+		t.Errorf("tenant a should retain 2 keys after b's delete, got %d (err=%v)", len(entries), err)
+	}
 }
 
 // ---- SQLite-specific tests below this line ----

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1491,6 +1491,16 @@ type Store interface {
 	// state only. Capped at 200 rows ordered by updated_at DESC.
 	MemoryListScopeIDs(ctx context.Context, tenantID string, scope MemoryScope) ([]MemoryScopeIDSummary, error)
 
+	// MemoryListTenantsForScope returns the DISTINCT tenant_ids that hold at
+	// least one row under (scope, scopeID), across every tenant partition. RFC
+	// BL partitioned base memory by tenant, so the retention sweeper — reclaiming
+	// a globally-dead agent's cross-tenant base memory — enumerates the partitions
+	// to delete per tenant instead of issuing one tenant-blind DELETE (which now
+	// touches only "" and would strand every other tenant's rows). "" (the
+	// shared/legacy tenant) is a valid element; order is unspecified; a scope with
+	// no rows returns an empty slice, not an error.
+	MemoryListTenantsForScope(ctx context.Context, scope MemoryScope, scopeID string) ([]string, error)
+
 	// SupportsVectors reports whether this backend instance can serve
 	// the MemoryEmbed* family. Backends without a vector index loaded
 	// return false; the Memory tool's `search` op + `embed: true`

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1282,11 +1282,11 @@ type Store interface {
 	// SnapshotReadMCPServerDefActive — v0.9.x mirror.
 	SnapshotReadMCPServerDefActive(ctx context.Context) ([]MCPServerDefActiveEntry, error)
 
-	// SnapshotReadMemory returns every memory row across all scopes,
-	// tagged with scope + scope_id. Ordered by (scope ASC, scope_id
-	// ASC, key ASC). Filters out expired rows (consistent with
-	// MemoryGet's behaviour) so the snapshot doesn't carry
-	// already-stale entries.
+	// SnapshotReadMemory returns every memory row across all scopes and
+	// tenants, tagged with tenant_id + scope + scope_id. Ordered by
+	// (scope ASC, scope_id ASC, key ASC). Filters out expired rows
+	// (consistent with MemoryGet's behaviour) so the snapshot doesn't
+	// carry already-stale entries.
 	SnapshotReadMemory(ctx context.Context) ([]MemorySnapshotEntry, error)
 
 	// SnapshotReadChannelMessages returns every channel_messages row.
@@ -1379,8 +1379,9 @@ type Store interface {
 	SnapshotRestoreMCPServerDefActive(ctx context.Context, entry MCPServerDefActiveEntry) (bool, error)
 
 	// SnapshotRestoreMemory inserts one memory row preserving
-	// CreatedAt + UpdatedAt + ExpiresAt + Value. Idempotent on
-	// (scope, scope_id, key).
+	// TenantID + CreatedAt + UpdatedAt + ExpiresAt + Value. Idempotent
+	// on (tenant_id, scope, scope_id, key). An entry with no TenantID
+	// (an older snapshot) restores under the legacy tenant "".
 	SnapshotRestoreMemory(ctx context.Context, entry MemorySnapshotEntry) (bool, error)
 
 	// SnapshotRestoreChannelMessage inserts one channel_messages row
@@ -1398,43 +1399,51 @@ type Store interface {
 	// on eval_id.
 	SnapshotRestoreEvaluation(ctx context.Context, r EvaluationRow) (bool, error)
 
+	// tenantID is the leading isolation axis on every Memory* method
+	// below (RFC BL). It is server-supplied (from RunIdentity / the def
+	// row / the authenticated principal) — NEVER model- or wire-derived
+	// — and is filtered `WHERE tenant_id = $N` with the row's PK widened
+	// to lead with it, mirroring the definition-plane idiom (migration
+	// 0037). "" is the shared/legacy tenant; a freshly-migrated
+	// single-tenant DB is entirely "" and reads byte-identical to the
+	// pre-RFC-BL behaviour. `global` scope always uses "".
+	//
 	// MemorySet writes a Memory entry. ttl > 0 sets an expiry; ttl <= 0
 	// stores with no expiry (the row's expires_at column is NULL). The
-	// row is upserted on the (scope, scopeID, key) primary key —
+	// row is upserted on the (tenantID, scope, scopeID, key) primary key —
 	// re-writes overwrite the value and bump updated_at. Implementations
 	// are responsible for surfacing wire-level constraints (max value
 	// bytes, scope quota) as ErrMemoryQuotaExceeded — the tool layer
 	// trusts the store's verdict.
-	MemorySet(ctx context.Context, scope MemoryScope, scopeID, key string, value json.RawMessage, ttl time.Duration) error
+	MemorySet(ctx context.Context, tenantID string, scope MemoryScope, scopeID, key string, value json.RawMessage, ttl time.Duration) error
 
 	// MemoryGet reads one entry. Returns *ErrNotFound for both "key
 	// missing" and "key expired" — callers don't need to distinguish.
 	// Implementations MUST treat an entry whose expires_at is in the
 	// past as missing (returns ErrNotFound) regardless of whether the
 	// sweeper has reaped it yet — the sweeper is best-effort.
-	MemoryGet(ctx context.Context, scope MemoryScope, scopeID, key string) (MemoryEntry, error)
+	MemoryGet(ctx context.Context, tenantID string, scope MemoryScope, scopeID, key string) (MemoryEntry, error)
 
 	// MemoryDelete removes an entry. Returns true when a row was
 	// actually deleted, false when the key didn't exist (or had
 	// already expired). Both are non-error paths.
-	MemoryDelete(ctx context.Context, scope MemoryScope, scopeID, key string) (bool, error)
+	MemoryDelete(ctx context.Context, tenantID string, scope MemoryScope, scopeID, key string) (bool, error)
 
-	// MemoryDeleteScope removes EVERY entry under (scope, scopeID) in one
-	// statement and returns the row count deleted (memory_embeddings rows
+	// MemoryDeleteScope removes EVERY entry under (tenantID, scope, scopeID) in
+	// one statement and returns the row count deleted (memory_embeddings rows
 	// cascade via their FK). Used by the RFC BM retention sweeper to reclaim a
-	// fully-retired agent's accumulated base-memory k/v. NOTE: the memory table
-	// has no tenant_id column — an agent scope_id is the bare agent name, shared
-	// by same-named agents across tenants — so the caller MUST only invoke this
-	// for a name that is retired in EVERY tenant (globally dead); the store does
-	// not (cannot) enforce tenant isolation here.
-	MemoryDeleteScope(ctx context.Context, scope MemoryScope, scopeID string) (int, error)
+	// fully-retired agent's accumulated base-memory k/v. It now scopes by
+	// tenantID, so a caller reclaiming an agent name that is dead across
+	// multiple tenants must fan out one call per tenant (or use "" for the
+	// legacy/shared tenant) — a single call touches only the given tenant's rows.
+	MemoryDeleteScope(ctx context.Context, tenantID string, scope MemoryScope, scopeID string) (int, error)
 
 	// MemoryList returns entries for the (scope, scopeID) tuple whose
 	// key starts with prefix. An empty prefix returns every key in the
 	// scope. Capped at limit rows; if more rows would match, callers
 	// see truncated == true. Expired rows are filtered out — callers
 	// never see them.
-	MemoryList(ctx context.Context, scope MemoryScope, scopeID, prefix string, limit int) (entries []MemoryEntry, truncated bool, err error)
+	MemoryList(ctx context.Context, tenantID string, scope MemoryScope, scopeID, prefix string, limit int) (entries []MemoryEntry, truncated bool, err error)
 
 	// MemoryIncrement is an atomic add over the JSON-number value at
 	// (scope, scopeID, key). If the key doesn't exist, it's created
@@ -1442,7 +1451,7 @@ type Store interface {
 	// JSON number, returns ErrMemoryWrongType. Optional ttl sets (or
 	// resets, on a re-incr) the expiry; ttl <= 0 keeps the existing
 	// expiry untouched (or no expiry on a fresh row).
-	MemoryIncrement(ctx context.Context, scope MemoryScope, scopeID, key string, delta int64, ttl time.Duration) (int64, error)
+	MemoryIncrement(ctx context.Context, tenantID string, scope MemoryScope, scopeID, key string, delta int64, ttl time.Duration) (int64, error)
 
 	// MemoryAtomicUpdate runs `reducer` as an atomic read-modify-write
 	// against (scope, scopeID, key). The reducer receives the current
@@ -1462,6 +1471,7 @@ type Store interface {
 	// — the tool layer wraps it for the agent-visible message.
 	MemoryAtomicUpdate(
 		ctx context.Context,
+		tenantID string,
 		scope MemoryScope,
 		scopeID, key string,
 		ttl time.Duration,
@@ -1479,7 +1489,7 @@ type Store interface {
 	// most recent updated_at). Drives the v0.8.0 Web UI's Memory
 	// page picker. Expired rows are excluded — operators see live
 	// state only. Capped at 200 rows ordered by updated_at DESC.
-	MemoryListScopeIDs(ctx context.Context, scope MemoryScope) ([]MemoryScopeIDSummary, error)
+	MemoryListScopeIDs(ctx context.Context, tenantID string, scope MemoryScope) ([]MemoryScopeIDSummary, error)
 
 	// SupportsVectors reports whether this backend instance can serve
 	// the MemoryEmbed* family. Backends without a vector index loaded
@@ -1501,13 +1511,13 @@ type Store interface {
 	//
 	// Embedding bytes do NOT count toward the per-(scope, scopeID)
 	// quota — quota math is k/v-only per the v0.9.0 RFC §8 decision.
-	MemoryEmbedSet(ctx context.Context, scope MemoryScope, scopeID, key string, e MemoryEmbedding) error
+	MemoryEmbedSet(ctx context.Context, tenantID string, scope MemoryScope, scopeID, key string, e MemoryEmbedding) error
 
 	// MemoryEmbedGet returns the stored embedding for one key, or
 	// *ErrNotFound if no embedding exists. Used by the snapshot
 	// Capture path (v0.9.0 PR 5) and the admin reembed endpoint.
 	// ErrVectorUnsupported on backends without a vector index.
-	MemoryEmbedGet(ctx context.Context, scope MemoryScope, scopeID, key string) (MemoryEmbedding, error)
+	MemoryEmbedGet(ctx context.Context, tenantID string, scope MemoryScope, scopeID, key string) (MemoryEmbedding, error)
 
 	// MemoryEmbedSearch runs a Top-K cosine-similarity search over
 	// rows in (scope, scopeID). keyPrefix is optional — empty string
@@ -1525,7 +1535,7 @@ type Store interface {
 	//
 	// Backends MUST honour the base table's expires_at filter — a
 	// matching vector for an expired row MUST NOT appear in results.
-	MemoryEmbedSearch(ctx context.Context, scope MemoryScope, scopeID, keyPrefix string, query []float32, topK int) ([]MemorySearchEntry, error)
+	MemoryEmbedSearch(ctx context.Context, tenantID string, scope MemoryScope, scopeID, keyPrefix string, query []float32, topK int) ([]MemorySearchEntry, error)
 
 	// MemoryEmbedListByModel returns entries whose stored embedding
 	// was produced by a DIFFERENT (provider, model) than the supplied
@@ -1534,13 +1544,13 @@ type Store interface {
 	// my current embedder config." limit <= 0 is treated as 1000.
 	//
 	// Returns ErrVectorUnsupported on backends without vector ops.
-	MemoryEmbedListByModel(ctx context.Context, scope MemoryScope, scopeID, currentProvider, currentModel string, limit int) ([]MemoryEntry, error)
+	MemoryEmbedListByModel(ctx context.Context, tenantID string, scope MemoryScope, scopeID, currentProvider, currentModel string, limit int) ([]MemoryEntry, error)
 
 	// MemoryEmbedStats returns per-(provider, model) row counts and
 	// total embedding bytes for the given scope. Drives the v0.9.0
 	// PR 4 admin endpoint `/v1/_memory/embed_stats`. ErrVectorUnsupported
 	// on backends without vector ops.
-	MemoryEmbedStats(ctx context.Context, scope MemoryScope) (MemoryEmbedStats, error)
+	MemoryEmbedStats(ctx context.Context, tenantID string, scope MemoryScope) (MemoryEmbedStats, error)
 
 	// ChannelPublish appends one message to a channel. The message's
 	// ID is assigned by the store (ULID — sortable by publish time);
@@ -3760,8 +3770,12 @@ type AgentDefActiveEntry struct {
 // scope_id columns. Returned by SnapshotReadMemory so the snapshot
 // envelope can serialise rows without an additional lookup per row.
 type MemorySnapshotEntry struct {
-	Scope   MemoryScope `json:"scope"`
-	ScopeID string      `json:"scope_id"`
+	// TenantID is the row's isolation axis (RFC BL). "" is the
+	// shared/legacy tenant; older snapshots that predate the column
+	// carry no tenant and restore as "".
+	TenantID string      `json:"tenant_id,omitempty"`
+	Scope    MemoryScope `json:"scope"`
+	ScopeID  string      `json:"scope_id"`
 	MemoryEntry
 }
 

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -147,6 +147,7 @@ func Run(t *testing.T, factory Factory) {
 		{"MemoryIncrementOnExpiredKey", testMemoryIncrementOnExpiredKey},
 		{"MemoryScopeIsolation", testMemoryScopeIsolation},
 		{"MemoryListScopeIDs", testMemoryListScopeIDs},
+		{"MemoryListTenantsForScope", testMemoryListTenantsForScope},
 		{"MemoryIncrementIsAtomicUnderConcurrency", testMemoryIncrementIsAtomicUnderConcurrency},
 		// v0.12.x — MemoryAtomicUpdate primitive backing the new
 		// reducer ops (Memory.merge / append_dedupe / bounded_list).
@@ -3535,6 +3536,39 @@ func testMemoryListScopeIDs(t *testing.T, s store.Store) {
 		if u.ScopeID == "transient" {
 			t.Errorf("expired-only scope_id %q should not appear", u.ScopeID)
 		}
+	}
+}
+
+// testMemoryListTenantsForScope pins the RFC BL enumeration primitive (backing
+// the retention sweeper's per-tenant base-memory fan-out): DISTINCT tenants that
+// hold a row under (scope, scopeID), including the legacy "" partition, scoped
+// to the given scope_id, and an empty slice (not an error) for an absent name.
+func testMemoryListTenantsForScope(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	const name = "shared-agent"
+	for _, tenant := range []string{"", "t-a", "t-b"} {
+		if err := s.MemorySet(ctx, tenant, store.MemoryScopeAgent, name, "k", json.RawMessage(`1`), 0); err != nil {
+			t.Fatalf("MemorySet(%q): %v", tenant, err)
+		}
+	}
+	// A different scope_id must not leak into the result.
+	_ = s.MemorySet(ctx, "t-c", store.MemoryScopeAgent, "other-agent", "k", json.RawMessage(`1`), 0)
+
+	got, err := s.MemoryListTenantsForScope(ctx, store.MemoryScopeAgent, name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	set := map[string]bool{}
+	for _, tn := range got {
+		set[tn] = true
+	}
+	if len(got) != 3 || !set[""] || !set["t-a"] || !set["t-b"] {
+		t.Errorf("tenants = %v, want exactly {\"\",t-a,t-b}", got)
+	}
+
+	empty, err := s.MemoryListTenantsForScope(ctx, store.MemoryScopeAgent, "never-written")
+	if err != nil || len(empty) != 0 {
+		t.Errorf("absent scope = %v err=%v, want [] nil", empty, err)
 	}
 }
 

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -2964,11 +2964,11 @@ func testSnapshotReadMemoryEmpty(t *testing.T, s store.Store) {
 func testSnapshotReadMemoryFiltersExpired(t *testing.T, s store.Store) {
 	ctx := context.Background()
 	// Live row.
-	if err := s.MemorySet(ctx, store.MemoryScope("agent"), "agentA", "live", json.RawMessage(`"hello"`), 0); err != nil {
+	if err := s.MemorySet(ctx, "", store.MemoryScope("agent"), "agentA", "live", json.RawMessage(`"hello"`), 0); err != nil {
 		t.Fatal(err)
 	}
 	// Expired row: TTL of 1ns; wait briefly so wall-clock advances past.
-	if err := s.MemorySet(ctx, store.MemoryScope("agent"), "agentA", "expired", json.RawMessage(`"gone"`), time.Nanosecond); err != nil {
+	if err := s.MemorySet(ctx, "", store.MemoryScope("agent"), "agentA", "expired", json.RawMessage(`"gone"`), time.Nanosecond); err != nil {
 		t.Fatal(err)
 	}
 	time.Sleep(10 * time.Millisecond)
@@ -3012,7 +3012,7 @@ func testSnapshotReadMemoryOrdered(t *testing.T, s store.Store) {
 		{store.MemoryScope("agent"), "agentA", "key_a"},
 	}
 	for _, sd := range seeds {
-		if err := s.MemorySet(ctx, sd.scope, sd.sid, sd.key, json.RawMessage(`"x"`), 0); err != nil {
+		if err := s.MemorySet(ctx, "", sd.scope, sd.sid, sd.key, json.RawMessage(`"x"`), 0); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -3170,10 +3170,10 @@ func testTranscriptOrderedAcrossRuns(t *testing.T, s store.Store) {
 func testMemorySetGetRoundTrip(t *testing.T, s store.Store) {
 	ctx := context.Background()
 	value := json.RawMessage(`{"style":"concise","tone":"friendly"}`)
-	if err := s.MemorySet(ctx, store.MemoryScopeUser, "alice", "voice", value, 0); err != nil {
+	if err := s.MemorySet(ctx, "", store.MemoryScopeUser, "alice", "voice", value, 0); err != nil {
 		t.Fatal(err)
 	}
-	got, err := s.MemoryGet(ctx, store.MemoryScopeUser, "alice", "voice")
+	got, err := s.MemoryGet(ctx, "", store.MemoryScopeUser, "alice", "voice")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3200,7 +3200,7 @@ func testMemorySetGetRoundTrip(t *testing.T, s store.Store) {
 }
 
 func testMemoryGetNotFound(t *testing.T, s store.Store) {
-	_, err := s.MemoryGet(context.Background(), store.MemoryScopeAgent, "qa-agent", "missing")
+	_, err := s.MemoryGet(context.Background(), "", store.MemoryScopeAgent, "qa-agent", "missing")
 	var nf *store.ErrNotFound
 	if !errors.As(err, &nf) {
 		t.Errorf("got %v (%T), want *store.ErrNotFound", err, err)
@@ -3209,15 +3209,15 @@ func testMemoryGetNotFound(t *testing.T, s store.Store) {
 
 func testMemoryOverwriteUpdatesValue(t *testing.T, s store.Store) {
 	ctx := context.Background()
-	if err := s.MemorySet(ctx, store.MemoryScopeAgent, "qa", "summary", json.RawMessage(`"v1"`), 0); err != nil {
+	if err := s.MemorySet(ctx, "", store.MemoryScopeAgent, "qa", "summary", json.RawMessage(`"v1"`), 0); err != nil {
 		t.Fatal(err)
 	}
-	first, _ := s.MemoryGet(ctx, store.MemoryScopeAgent, "qa", "summary")
+	first, _ := s.MemoryGet(ctx, "", store.MemoryScopeAgent, "qa", "summary")
 	time.Sleep(2 * time.Millisecond)
-	if err := s.MemorySet(ctx, store.MemoryScopeAgent, "qa", "summary", json.RawMessage(`"v2"`), 0); err != nil {
+	if err := s.MemorySet(ctx, "", store.MemoryScopeAgent, "qa", "summary", json.RawMessage(`"v2"`), 0); err != nil {
 		t.Fatal(err)
 	}
-	second, _ := s.MemoryGet(ctx, store.MemoryScopeAgent, "qa", "summary")
+	second, _ := s.MemoryGet(ctx, "", store.MemoryScopeAgent, "qa", "summary")
 	if string(second.Value) == string(first.Value) {
 		t.Error("overwrite did not change the stored value")
 	}
@@ -3228,16 +3228,16 @@ func testMemoryOverwriteUpdatesValue(t *testing.T, s store.Store) {
 
 func testMemoryDelete(t *testing.T, s store.Store) {
 	ctx := context.Background()
-	_ = s.MemorySet(ctx, store.MemoryScopeUser, "u1", "k", json.RawMessage(`1`), 0)
+	_ = s.MemorySet(ctx, "", store.MemoryScopeUser, "u1", "k", json.RawMessage(`1`), 0)
 
-	deleted, err := s.MemoryDelete(ctx, store.MemoryScopeUser, "u1", "k")
+	deleted, err := s.MemoryDelete(ctx, "", store.MemoryScopeUser, "u1", "k")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !deleted {
 		t.Error("expected deleted=true on a present key")
 	}
-	deleted, err = s.MemoryDelete(ctx, store.MemoryScopeUser, "u1", "k")
+	deleted, err = s.MemoryDelete(ctx, "", store.MemoryScopeUser, "u1", "k")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3252,32 +3252,32 @@ func testMemoryDelete(t *testing.T, s store.Store) {
 func testMemoryDeleteScope(t *testing.T, s store.Store) {
 	ctx := context.Background()
 	// Target scope: three keys under (agent, "reaped").
-	_ = s.MemorySet(ctx, store.MemoryScopeAgent, "reaped", "k1", json.RawMessage(`1`), 0)
-	_ = s.MemorySet(ctx, store.MemoryScopeAgent, "reaped", "k2", json.RawMessage(`2`), 0)
-	_ = s.MemorySet(ctx, store.MemoryScopeAgent, "reaped", "k3", json.RawMessage(`3`), 0)
+	_ = s.MemorySet(ctx, "", store.MemoryScopeAgent, "reaped", "k1", json.RawMessage(`1`), 0)
+	_ = s.MemorySet(ctx, "", store.MemoryScopeAgent, "reaped", "k2", json.RawMessage(`2`), 0)
+	_ = s.MemorySet(ctx, "", store.MemoryScopeAgent, "reaped", "k3", json.RawMessage(`3`), 0)
 	// A sibling agent scope_id and a same-id user scope must survive.
-	_ = s.MemorySet(ctx, store.MemoryScopeAgent, "kept", "k1", json.RawMessage(`9`), 0)
-	_ = s.MemorySet(ctx, store.MemoryScopeUser, "reaped", "k1", json.RawMessage(`8`), 0)
+	_ = s.MemorySet(ctx, "", store.MemoryScopeAgent, "kept", "k1", json.RawMessage(`9`), 0)
+	_ = s.MemorySet(ctx, "", store.MemoryScopeUser, "reaped", "k1", json.RawMessage(`8`), 0)
 
-	n, err := s.MemoryDeleteScope(ctx, store.MemoryScopeAgent, "reaped")
+	n, err := s.MemoryDeleteScope(ctx, "", store.MemoryScopeAgent, "reaped")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if n != 3 {
 		t.Errorf("MemoryDeleteScope deleted %d, want 3", n)
 	}
-	if got, _, _ := s.MemoryList(ctx, store.MemoryScopeAgent, "reaped", "", 100); len(got) != 0 {
+	if got, _, _ := s.MemoryList(ctx, "", store.MemoryScopeAgent, "reaped", "", 100); len(got) != 0 {
 		t.Errorf("target scope still has %d keys after delete", len(got))
 	}
 	// Siblings untouched.
-	if got, _, _ := s.MemoryList(ctx, store.MemoryScopeAgent, "kept", "", 100); len(got) != 1 {
+	if got, _, _ := s.MemoryList(ctx, "", store.MemoryScopeAgent, "kept", "", 100); len(got) != 1 {
 		t.Errorf("sibling agent scope_id lost keys: have %d, want 1", len(got))
 	}
-	if got, _, _ := s.MemoryList(ctx, store.MemoryScopeUser, "reaped", "", 100); len(got) != 1 {
+	if got, _, _ := s.MemoryList(ctx, "", store.MemoryScopeUser, "reaped", "", 100); len(got) != 1 {
 		t.Errorf("same-id user scope lost keys: have %d, want 1", len(got))
 	}
 	// Idempotent: a second delete removes nothing.
-	n, err = s.MemoryDeleteScope(ctx, store.MemoryScopeAgent, "reaped")
+	n, err = s.MemoryDeleteScope(ctx, "", store.MemoryScopeAgent, "reaped")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3295,11 +3295,11 @@ func testMemoryListPrefix(t *testing.T, s store.Store) {
 		"prefs/voice":             `"d"`,
 		"prefs/timezone":          `"e"`,
 	} {
-		if err := s.MemorySet(ctx, store.MemoryScopeUser, "alice", k, json.RawMessage(v), 0); err != nil {
+		if err := s.MemorySet(ctx, "", store.MemoryScopeUser, "alice", k, json.RawMessage(v), 0); err != nil {
 			t.Fatal(err)
 		}
 	}
-	got, truncated, err := s.MemoryList(ctx, store.MemoryScopeUser, "alice", "events/", 50)
+	got, truncated, err := s.MemoryList(ctx, "", store.MemoryScopeUser, "alice", "events/", 50)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3315,7 +3315,7 @@ func testMemoryListPrefix(t *testing.T, s store.Store) {
 		}
 	}
 	// Empty prefix returns everything in the scope.
-	all, _, err := s.MemoryList(ctx, store.MemoryScopeUser, "alice", "", 50)
+	all, _, err := s.MemoryList(ctx, "", store.MemoryScopeUser, "alice", "", 50)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3327,9 +3327,9 @@ func testMemoryListPrefix(t *testing.T, s store.Store) {
 func testMemoryListTruncation(t *testing.T, s store.Store) {
 	ctx := context.Background()
 	for i := 0; i < 5; i++ {
-		_ = s.MemorySet(ctx, store.MemoryScopeAgent, "qa", "key/"+intToKey(i), json.RawMessage(`1`), 0)
+		_ = s.MemorySet(ctx, "", store.MemoryScopeAgent, "qa", "key/"+intToKey(i), json.RawMessage(`1`), 0)
 	}
-	got, truncated, err := s.MemoryList(ctx, store.MemoryScopeAgent, "qa", "key/", 3)
+	got, truncated, err := s.MemoryList(ctx, "", store.MemoryScopeAgent, "qa", "key/", 3)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3347,10 +3347,10 @@ func testMemoryTTLExpiry(t *testing.T, s store.Store) {
 	// confirming Get can never race the expiry: a short-ttl key read on a slow CI
 	// runner could already be gone before the first Get (a MemorySet that itself
 	// takes >ttl under load), which used to flake this test.
-	if err := s.MemorySet(ctx, store.MemoryScopeAgent, "qa", "longlived", json.RawMessage(`"hi"`), time.Hour); err != nil {
+	if err := s.MemorySet(ctx, "", store.MemoryScopeAgent, "qa", "longlived", json.RawMessage(`"hi"`), time.Hour); err != nil {
 		t.Fatal(err)
 	}
-	got, err := s.MemoryGet(ctx, store.MemoryScopeAgent, "qa", "longlived")
+	got, err := s.MemoryGet(ctx, "", store.MemoryScopeAgent, "qa", "longlived")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3361,19 +3361,19 @@ func testMemoryTTLExpiry(t *testing.T, s store.Store) {
 	// Part 2 — a short-ttl key is gone after a sleep well past its ttl. There is
 	// NO Get between the set and the sleep, so runner slowness only makes the key
 	// MORE certainly expired (more wall-clock elapses); this direction can't flake.
-	if err := s.MemorySet(ctx, store.MemoryScopeAgent, "qa", "warning", json.RawMessage(`"hi"`), 50*time.Millisecond); err != nil {
+	if err := s.MemorySet(ctx, "", store.MemoryScopeAgent, "qa", "warning", json.RawMessage(`"hi"`), 50*time.Millisecond); err != nil {
 		t.Fatal(err)
 	}
 	time.Sleep(250 * time.Millisecond)
 
-	_, err = s.MemoryGet(ctx, store.MemoryScopeAgent, "qa", "warning")
+	_, err = s.MemoryGet(ctx, "", store.MemoryScopeAgent, "qa", "warning")
 	var nf *store.ErrNotFound
 	if !errors.As(err, &nf) {
 		t.Errorf("expired key should return ErrNotFound, got %v", err)
 	}
 
 	// MemoryList must filter expired entries even before the sweeper runs.
-	listed, _, err := s.MemoryList(ctx, store.MemoryScopeAgent, "qa", "warning", 10)
+	listed, _, err := s.MemoryList(ctx, "", store.MemoryScopeAgent, "qa", "warning", 10)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3384,8 +3384,8 @@ func testMemoryTTLExpiry(t *testing.T, s store.Store) {
 
 func testMemorySweepReapsExpired(t *testing.T, s store.Store) {
 	ctx := context.Background()
-	_ = s.MemorySet(ctx, store.MemoryScopeUser, "u", "transient", json.RawMessage(`1`), 30*time.Millisecond)
-	_ = s.MemorySet(ctx, store.MemoryScopeUser, "u", "permanent", json.RawMessage(`1`), 0)
+	_ = s.MemorySet(ctx, "", store.MemoryScopeUser, "u", "transient", json.RawMessage(`1`), 30*time.Millisecond)
+	_ = s.MemorySet(ctx, "", store.MemoryScopeUser, "u", "permanent", json.RawMessage(`1`), 0)
 
 	time.Sleep(60 * time.Millisecond)
 	deleted, err := s.MemorySweep(ctx)
@@ -3404,21 +3404,21 @@ func testMemorySweepReapsExpired(t *testing.T, s store.Store) {
 		t.Errorf("second sweep reaped %d, want 0", deleted2)
 	}
 	// Permanent row must survive.
-	if _, err := s.MemoryGet(ctx, store.MemoryScopeUser, "u", "permanent"); err != nil {
+	if _, err := s.MemoryGet(ctx, "", store.MemoryScopeUser, "u", "permanent"); err != nil {
 		t.Errorf("permanent row was reaped: %v", err)
 	}
 }
 
 func testMemoryIncrementOnNewKey(t *testing.T, s store.Store) {
 	ctx := context.Background()
-	got, err := s.MemoryIncrement(ctx, store.MemoryScopeAgent, "qa", "warnings", 1, 0)
+	got, err := s.MemoryIncrement(ctx, "", store.MemoryScopeAgent, "qa", "warnings", 1, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if got != 1 {
 		t.Errorf("incr on new key = %d, want 1", got)
 	}
-	got, err = s.MemoryIncrement(ctx, store.MemoryScopeAgent, "qa", "warnings", 5, 0)
+	got, err = s.MemoryIncrement(ctx, "", store.MemoryScopeAgent, "qa", "warnings", 5, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3429,8 +3429,8 @@ func testMemoryIncrementOnNewKey(t *testing.T, s store.Store) {
 
 func testMemoryIncrementOnExistingNumber(t *testing.T, s store.Store) {
 	ctx := context.Background()
-	_ = s.MemorySet(ctx, store.MemoryScopeAgent, "qa", "n", json.RawMessage(`42`), 0)
-	got, err := s.MemoryIncrement(ctx, store.MemoryScopeAgent, "qa", "n", -10, 0)
+	_ = s.MemorySet(ctx, "", store.MemoryScopeAgent, "qa", "n", json.RawMessage(`42`), 0)
+	got, err := s.MemoryIncrement(ctx, "", store.MemoryScopeAgent, "qa", "n", -10, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3441,8 +3441,8 @@ func testMemoryIncrementOnExistingNumber(t *testing.T, s store.Store) {
 
 func testMemoryIncrementOnNonNumberFails(t *testing.T, s store.Store) {
 	ctx := context.Background()
-	_ = s.MemorySet(ctx, store.MemoryScopeAgent, "qa", "obj", json.RawMessage(`{"hello":"world"}`), 0)
-	_, err := s.MemoryIncrement(ctx, store.MemoryScopeAgent, "qa", "obj", 1, 0)
+	_ = s.MemorySet(ctx, "", store.MemoryScopeAgent, "qa", "obj", json.RawMessage(`{"hello":"world"}`), 0)
+	_, err := s.MemoryIncrement(ctx, "", store.MemoryScopeAgent, "qa", "obj", 1, 0)
 	if !errors.Is(err, store.ErrMemoryWrongType) {
 		t.Errorf("got %v, want ErrMemoryWrongType", err)
 	}
@@ -3450,9 +3450,9 @@ func testMemoryIncrementOnNonNumberFails(t *testing.T, s store.Store) {
 
 func testMemoryIncrementOnExpiredKey(t *testing.T, s store.Store) {
 	ctx := context.Background()
-	_ = s.MemorySet(ctx, store.MemoryScopeAgent, "qa", "k", json.RawMessage(`100`), 30*time.Millisecond)
+	_ = s.MemorySet(ctx, "", store.MemoryScopeAgent, "qa", "k", json.RawMessage(`100`), 30*time.Millisecond)
 	time.Sleep(60 * time.Millisecond)
-	got, err := s.MemoryIncrement(ctx, store.MemoryScopeAgent, "qa", "k", 1, 0)
+	got, err := s.MemoryIncrement(ctx, "", store.MemoryScopeAgent, "qa", "k", 1, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3463,19 +3463,19 @@ func testMemoryIncrementOnExpiredKey(t *testing.T, s store.Store) {
 
 func testMemoryScopeIsolation(t *testing.T, s store.Store) {
 	ctx := context.Background()
-	_ = s.MemorySet(ctx, store.MemoryScopeUser, "alice", "secret", json.RawMessage(`"alice-secret"`), 0)
-	_ = s.MemorySet(ctx, store.MemoryScopeUser, "bob", "secret", json.RawMessage(`"bob-secret"`), 0)
-	_ = s.MemorySet(ctx, store.MemoryScopeAgent, "qa", "secret", json.RawMessage(`"qa-secret"`), 0)
+	_ = s.MemorySet(ctx, "", store.MemoryScopeUser, "alice", "secret", json.RawMessage(`"alice-secret"`), 0)
+	_ = s.MemorySet(ctx, "", store.MemoryScopeUser, "bob", "secret", json.RawMessage(`"bob-secret"`), 0)
+	_ = s.MemorySet(ctx, "", store.MemoryScopeAgent, "qa", "secret", json.RawMessage(`"qa-secret"`), 0)
 
-	a, err := s.MemoryGet(ctx, store.MemoryScopeUser, "alice", "secret")
+	a, err := s.MemoryGet(ctx, "", store.MemoryScopeUser, "alice", "secret")
 	if err != nil {
 		t.Fatal(err)
 	}
-	b, err := s.MemoryGet(ctx, store.MemoryScopeUser, "bob", "secret")
+	b, err := s.MemoryGet(ctx, "", store.MemoryScopeUser, "bob", "secret")
 	if err != nil {
 		t.Fatal(err)
 	}
-	q, err := s.MemoryGet(ctx, store.MemoryScopeAgent, "qa", "secret")
+	q, err := s.MemoryGet(ctx, "", store.MemoryScopeAgent, "qa", "secret")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3484,7 +3484,7 @@ func testMemoryScopeIsolation(t *testing.T, s store.Store) {
 	}
 
 	// Listing one (scope, scopeID) must not surface another's keys.
-	list, _, _ := s.MemoryList(ctx, store.MemoryScopeUser, "alice", "", 100)
+	list, _, _ := s.MemoryList(ctx, "", store.MemoryScopeUser, "alice", "", 100)
 	if len(list) != 1 {
 		t.Errorf("alice-scope list returned %d rows, want 1", len(list))
 	}
@@ -3493,12 +3493,12 @@ func testMemoryScopeIsolation(t *testing.T, s store.Store) {
 func testMemoryListScopeIDs(t *testing.T, s store.Store) {
 	ctx := context.Background()
 	// alice: 2 keys; bob: 1 key; qa-agent: 1 key.
-	_ = s.MemorySet(ctx, store.MemoryScopeUser, "alice", "voice", json.RawMessage(`"a1"`), 0)
-	_ = s.MemorySet(ctx, store.MemoryScopeUser, "alice", "tone", json.RawMessage(`"a2"`), 0)
-	_ = s.MemorySet(ctx, store.MemoryScopeUser, "bob", "voice", json.RawMessage(`"b1"`), 0)
-	_ = s.MemorySet(ctx, store.MemoryScopeAgent, "qa-agent", "warnings", json.RawMessage(`5`), 0)
+	_ = s.MemorySet(ctx, "", store.MemoryScopeUser, "alice", "voice", json.RawMessage(`"a1"`), 0)
+	_ = s.MemorySet(ctx, "", store.MemoryScopeUser, "alice", "tone", json.RawMessage(`"a2"`), 0)
+	_ = s.MemorySet(ctx, "", store.MemoryScopeUser, "bob", "voice", json.RawMessage(`"b1"`), 0)
+	_ = s.MemorySet(ctx, "", store.MemoryScopeAgent, "qa-agent", "warnings", json.RawMessage(`5`), 0)
 
-	users, err := s.MemoryListScopeIDs(ctx, store.MemoryScopeUser)
+	users, err := s.MemoryListScopeIDs(ctx, "", store.MemoryScopeUser)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3519,7 +3519,7 @@ func testMemoryListScopeIDs(t *testing.T, s store.Store) {
 		t.Errorf("user-scope listing should not include agent-scope rows: %v", got)
 	}
 
-	agents, err := s.MemoryListScopeIDs(ctx, store.MemoryScopeAgent)
+	agents, err := s.MemoryListScopeIDs(ctx, "", store.MemoryScopeAgent)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3528,9 +3528,9 @@ func testMemoryListScopeIDs(t *testing.T, s store.Store) {
 	}
 
 	// Expired rows must not surface in the summary.
-	_ = s.MemorySet(ctx, store.MemoryScopeUser, "transient", "k", json.RawMessage(`1`), 30*time.Millisecond)
+	_ = s.MemorySet(ctx, "", store.MemoryScopeUser, "transient", "k", json.RawMessage(`1`), 30*time.Millisecond)
 	time.Sleep(60 * time.Millisecond)
-	users2, _ := s.MemoryListScopeIDs(ctx, store.MemoryScopeUser)
+	users2, _ := s.MemoryListScopeIDs(ctx, "", store.MemoryScopeUser)
 	for _, u := range users2 {
 		if u.ScopeID == "transient" {
 			t.Errorf("expired-only scope_id %q should not appear", u.ScopeID)
@@ -3561,12 +3561,12 @@ func testMemoryIncrementIsAtomicUnderConcurrency(t *testing.T, s store.Store) {
 	for i := 0; i < N; i++ {
 		go func() {
 			defer wg.Done()
-			_, _ = s.MemoryIncrement(ctx, store.MemoryScopeAgent, "qa", "counter", 1, 0)
+			_, _ = s.MemoryIncrement(ctx, "", store.MemoryScopeAgent, "qa", "counter", 1, 0)
 		}()
 	}
 	wg.Wait()
 
-	got, err := s.MemoryGet(ctx, store.MemoryScopeAgent, "qa", "counter")
+	got, err := s.MemoryGet(ctx, "", store.MemoryScopeAgent, "qa", "counter")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3589,7 +3589,7 @@ func mustParseInt(s string) int {
 
 func testMemoryAtomicUpdateOnNewKey(t *testing.T, s store.Store) {
 	ctx := context.Background()
-	got, err := s.MemoryAtomicUpdate(ctx, store.MemoryScopeAgent, "qa", "k1", 0,
+	got, err := s.MemoryAtomicUpdate(ctx, "", store.MemoryScopeAgent, "qa", "k1", 0,
 		func(existing json.RawMessage) (json.RawMessage, error) {
 			if len(existing) != 0 {
 				t.Errorf("reducer existing should be empty on new key, got %q", existing)
@@ -3605,7 +3605,7 @@ func testMemoryAtomicUpdateOnNewKey(t *testing.T, s store.Store) {
 	if v := jsonField(got, "v"); v != float64(1) {
 		t.Errorf("returned value's v = %v, want 1 (raw=%q)", v, got)
 	}
-	entry, err := s.MemoryGet(ctx, store.MemoryScopeAgent, "qa", "k1")
+	entry, err := s.MemoryGet(ctx, "", store.MemoryScopeAgent, "qa", "k1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3629,11 +3629,11 @@ func jsonField(raw json.RawMessage, field string) any {
 func testMemoryAtomicUpdateOnExistingKey(t *testing.T, s store.Store) {
 	ctx := context.Background()
 	// Seed an existing row via MemorySet, then read-modify-write.
-	if err := s.MemorySet(ctx, store.MemoryScopeAgent, "qa", "k2",
+	if err := s.MemorySet(ctx, "", store.MemoryScopeAgent, "qa", "k2",
 		json.RawMessage(`{"x":1}`), 0); err != nil {
 		t.Fatal(err)
 	}
-	got, err := s.MemoryAtomicUpdate(ctx, store.MemoryScopeAgent, "qa", "k2", 0,
+	got, err := s.MemoryAtomicUpdate(ctx, "", store.MemoryScopeAgent, "qa", "k2", 0,
 		func(existing json.RawMessage) (json.RawMessage, error) {
 			if string(existing) != `{"x": 1}` && string(existing) != `{"x":1}` {
 				// Postgres JSONB round-trip adds a space; SQLite preserves
@@ -3647,7 +3647,7 @@ func testMemoryAtomicUpdateOnExistingKey(t *testing.T, s store.Store) {
 	}
 	// Postgres normalises JSONB on write; check via MemoryGet which
 	// goes through the same path the production caller would.
-	entry, err := s.MemoryGet(ctx, store.MemoryScopeAgent, "qa", "k2")
+	entry, err := s.MemoryGet(ctx, "", store.MemoryScopeAgent, "qa", "k2")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3665,12 +3665,12 @@ func testMemoryAtomicUpdateOnExistingKey(t *testing.T, s store.Store) {
 func testMemoryAtomicUpdateOnExpiredKey(t *testing.T, s store.Store) {
 	ctx := context.Background()
 	// Seed with a short-TTL row that expires before the update runs.
-	if err := s.MemorySet(ctx, store.MemoryScopeAgent, "qa", "k3",
+	if err := s.MemorySet(ctx, "", store.MemoryScopeAgent, "qa", "k3",
 		json.RawMessage(`{"old":true}`), 10*time.Millisecond); err != nil {
 		t.Fatal(err)
 	}
 	time.Sleep(60 * time.Millisecond)
-	_, err := s.MemoryAtomicUpdate(ctx, store.MemoryScopeAgent, "qa", "k3", 0,
+	_, err := s.MemoryAtomicUpdate(ctx, "", store.MemoryScopeAgent, "qa", "k3", 0,
 		func(existing json.RawMessage) (json.RawMessage, error) {
 			// Expired row → reducer sees empty (treated as missing).
 			if len(existing) != 0 {
@@ -3686,19 +3686,19 @@ func testMemoryAtomicUpdateOnExpiredKey(t *testing.T, s store.Store) {
 func testMemoryAtomicUpdateReducerErrorRollsBack(t *testing.T, s store.Store) {
 	ctx := context.Background()
 	// Seed a row so we can verify it's unchanged after a failed update.
-	if err := s.MemorySet(ctx, store.MemoryScopeAgent, "qa", "k4",
+	if err := s.MemorySet(ctx, "", store.MemoryScopeAgent, "qa", "k4",
 		json.RawMessage(`{"untouched":true}`), 0); err != nil {
 		t.Fatal(err)
 	}
 	sentinel := errors.New("reducer-said-no")
-	_, err := s.MemoryAtomicUpdate(ctx, store.MemoryScopeAgent, "qa", "k4", 0,
+	_, err := s.MemoryAtomicUpdate(ctx, "", store.MemoryScopeAgent, "qa", "k4", 0,
 		func(existing json.RawMessage) (json.RawMessage, error) {
 			return nil, sentinel
 		})
 	if !errors.Is(err, sentinel) {
 		t.Errorf("err = %v, want sentinel propagation", err)
 	}
-	entry, err := s.MemoryGet(ctx, store.MemoryScopeAgent, "qa", "k4")
+	entry, err := s.MemoryGet(ctx, "", store.MemoryScopeAgent, "qa", "k4")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3711,7 +3711,7 @@ func testMemoryAtomicUpdateReducerErrorRollsBack(t *testing.T, s store.Store) {
 
 func testMemoryAtomicUpdateInvalidJSONRejected(t *testing.T, s store.Store) {
 	ctx := context.Background()
-	_, err := s.MemoryAtomicUpdate(ctx, store.MemoryScopeAgent, "qa", "k5", 0,
+	_, err := s.MemoryAtomicUpdate(ctx, "", store.MemoryScopeAgent, "qa", "k5", 0,
 		func(existing json.RawMessage) (json.RawMessage, error) {
 			return json.RawMessage(`not json {{{`), nil
 		})
@@ -3736,7 +3736,7 @@ func testMemoryAtomicUpdateIsAtomicUnderConcurrency(t *testing.T, s store.Store)
 		i := i
 		go func() {
 			defer wg.Done()
-			_, _ = s.MemoryAtomicUpdate(ctx, store.MemoryScopeAgent, "qa", "list", 0,
+			_, _ = s.MemoryAtomicUpdate(ctx, "", store.MemoryScopeAgent, "qa", "list", 0,
 				func(existing json.RawMessage) (json.RawMessage, error) {
 					var arr []int
 					if len(existing) > 0 {
@@ -3749,7 +3749,7 @@ func testMemoryAtomicUpdateIsAtomicUnderConcurrency(t *testing.T, s store.Store)
 	}
 	wg.Wait()
 
-	entry, err := s.MemoryGet(ctx, store.MemoryScopeAgent, "qa", "list")
+	entry, err := s.MemoryGet(ctx, "", store.MemoryScopeAgent, "qa", "list")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3803,26 +3803,26 @@ func vectorRefusalCheck(t *testing.T, s store.Store) bool {
 		return true
 	}
 	ctx := context.Background()
-	err := s.MemoryEmbedSet(ctx, store.MemoryScopeAgent, "qa", "k", store.MemoryEmbedding{
+	err := s.MemoryEmbedSet(ctx, "", store.MemoryScopeAgent, "qa", "k", store.MemoryEmbedding{
 		Provider: "openai", Model: "text-embedding-3-small", Dimension: 4,
 		Vector: floats32(1, 0, 0, 0), EmbedText: "x", CreatedAt: time.Now(),
 	})
 	if !errors.Is(err, store.ErrVectorUnsupported) {
 		t.Errorf("MemoryEmbedSet on backend without vectors: got %v, want ErrVectorUnsupported", err)
 	}
-	_, err = s.MemoryEmbedGet(ctx, store.MemoryScopeAgent, "qa", "k")
+	_, err = s.MemoryEmbedGet(ctx, "", store.MemoryScopeAgent, "qa", "k")
 	if !errors.Is(err, store.ErrVectorUnsupported) {
 		t.Errorf("MemoryEmbedGet on backend without vectors: got %v, want ErrVectorUnsupported", err)
 	}
-	_, err = s.MemoryEmbedSearch(ctx, store.MemoryScopeAgent, "qa", "", floats32(1, 0, 0, 0), 5)
+	_, err = s.MemoryEmbedSearch(ctx, "", store.MemoryScopeAgent, "qa", "", floats32(1, 0, 0, 0), 5)
 	if !errors.Is(err, store.ErrVectorUnsupported) {
 		t.Errorf("MemoryEmbedSearch on backend without vectors: got %v, want ErrVectorUnsupported", err)
 	}
-	_, err = s.MemoryEmbedListByModel(ctx, store.MemoryScopeAgent, "qa", "openai", "text-embedding-3-large", 10)
+	_, err = s.MemoryEmbedListByModel(ctx, "", store.MemoryScopeAgent, "qa", "openai", "text-embedding-3-large", 10)
 	if !errors.Is(err, store.ErrVectorUnsupported) {
 		t.Errorf("MemoryEmbedListByModel on backend without vectors: got %v, want ErrVectorUnsupported", err)
 	}
-	_, err = s.MemoryEmbedStats(ctx, store.MemoryScopeAgent)
+	_, err = s.MemoryEmbedStats(ctx, "", store.MemoryScopeAgent)
 	if !errors.Is(err, store.ErrVectorUnsupported) {
 		t.Errorf("MemoryEmbedStats on backend without vectors: got %v, want ErrVectorUnsupported", err)
 	}
@@ -3835,7 +3835,7 @@ func testMemoryEmbedSetRoundTrip(t *testing.T, s store.Store) {
 	}
 	ctx := context.Background()
 	// Base memory row must exist (FK CASCADE in the embeddings schema).
-	if err := s.MemorySet(ctx, store.MemoryScopeAgent, "qa", "rec1", json.RawMessage(`"hello"`), 0); err != nil {
+	if err := s.MemorySet(ctx, "", store.MemoryScopeAgent, "qa", "rec1", json.RawMessage(`"hello"`), 0); err != nil {
 		t.Fatal(err)
 	}
 	want := store.MemoryEmbedding{
@@ -3846,10 +3846,10 @@ func testMemoryEmbedSetRoundTrip(t *testing.T, s store.Store) {
 		EmbedText: "hello in agent qa",
 		CreatedAt: time.Now().UTC().Truncate(time.Microsecond),
 	}
-	if err := s.MemoryEmbedSet(ctx, store.MemoryScopeAgent, "qa", "rec1", want); err != nil {
+	if err := s.MemoryEmbedSet(ctx, "", store.MemoryScopeAgent, "qa", "rec1", want); err != nil {
 		t.Fatal(err)
 	}
-	got, err := s.MemoryEmbedGet(ctx, store.MemoryScopeAgent, "qa", "rec1")
+	got, err := s.MemoryEmbedGet(ctx, "", store.MemoryScopeAgent, "qa", "rec1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3881,17 +3881,17 @@ func testMemoryEmbedSearchTopK(t *testing.T, s store.Store) {
 		{"row3", floats32(0, 1, 0, 0)},           // 90° off
 	}
 	for _, r := range rows {
-		if err := s.MemorySet(ctx, store.MemoryScopeAgent, "qa", r.key, json.RawMessage(`"x"`), 0); err != nil {
+		if err := s.MemorySet(ctx, "", store.MemoryScopeAgent, "qa", r.key, json.RawMessage(`"x"`), 0); err != nil {
 			t.Fatal(err)
 		}
-		if err := s.MemoryEmbedSet(ctx, store.MemoryScopeAgent, "qa", r.key, store.MemoryEmbedding{
+		if err := s.MemoryEmbedSet(ctx, "", store.MemoryScopeAgent, "qa", r.key, store.MemoryEmbedding{
 			Provider: "openai", Model: "text-embedding-3-small", Dimension: 4,
 			Vector: r.vec, EmbedText: r.key, CreatedAt: time.Now(),
 		}); err != nil {
 			t.Fatal(err)
 		}
 	}
-	results, err := s.MemoryEmbedSearch(ctx, store.MemoryScopeAgent, "qa", "", floats32(1, 0, 0, 0), 3)
+	results, err := s.MemoryEmbedSearch(ctx, "", store.MemoryScopeAgent, "qa", "", floats32(1, 0, 0, 0), 3)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3914,13 +3914,13 @@ func testMemoryEmbedSearchScopeIsolation(t *testing.T, s store.Store) {
 	}
 	ctx := context.Background()
 	// Write the embedding under agent scope.
-	_ = s.MemorySet(ctx, store.MemoryScopeAgent, "qa", "rec", json.RawMessage(`"x"`), 0)
-	_ = s.MemoryEmbedSet(ctx, store.MemoryScopeAgent, "qa", "rec", store.MemoryEmbedding{
+	_ = s.MemorySet(ctx, "", store.MemoryScopeAgent, "qa", "rec", json.RawMessage(`"x"`), 0)
+	_ = s.MemoryEmbedSet(ctx, "", store.MemoryScopeAgent, "qa", "rec", store.MemoryEmbedding{
 		Provider: "openai", Model: "text-embedding-3-small", Dimension: 4,
 		Vector: floats32(1, 0, 0, 0), EmbedText: "x", CreatedAt: time.Now(),
 	})
 	// Search the same key from user scope — must return empty.
-	results, err := s.MemoryEmbedSearch(ctx, store.MemoryScopeUser, "qa", "", floats32(1, 0, 0, 0), 10)
+	results, err := s.MemoryEmbedSearch(ctx, "", store.MemoryScopeUser, "qa", "", floats32(1, 0, 0, 0), 10)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3934,13 +3934,13 @@ func testMemoryEmbedSearchDimensionMismatch(t *testing.T, s store.Store) {
 		return
 	}
 	ctx := context.Background()
-	_ = s.MemorySet(ctx, store.MemoryScopeAgent, "qa", "rec", json.RawMessage(`"x"`), 0)
-	_ = s.MemoryEmbedSet(ctx, store.MemoryScopeAgent, "qa", "rec", store.MemoryEmbedding{
+	_ = s.MemorySet(ctx, "", store.MemoryScopeAgent, "qa", "rec", json.RawMessage(`"x"`), 0)
+	_ = s.MemoryEmbedSet(ctx, "", store.MemoryScopeAgent, "qa", "rec", store.MemoryEmbedding{
 		Provider: "openai", Model: "text-embedding-3-small", Dimension: 4,
 		Vector: floats32(1, 0, 0, 0), EmbedText: "x", CreatedAt: time.Now(),
 	})
 	// Query with dimension 8 against stored dimension 4.
-	_, err := s.MemoryEmbedSearch(ctx, store.MemoryScopeAgent, "qa", "", floats32(1, 0, 0, 0, 1, 0, 0, 0), 5)
+	_, err := s.MemoryEmbedSearch(ctx, "", store.MemoryScopeAgent, "qa", "", floats32(1, 0, 0, 0, 1, 0, 0, 0), 5)
 	if !errors.Is(err, store.ErrDimensionMismatch) {
 		t.Errorf("dim mismatch: got %v, want ErrDimensionMismatch", err)
 	}
@@ -3951,7 +3951,7 @@ func testMemoryEmbedSearchEmptyScope(t *testing.T, s store.Store) {
 		return
 	}
 	ctx := context.Background()
-	results, err := s.MemoryEmbedSearch(ctx, store.MemoryScopeAgent, "empty", "", floats32(1, 0, 0, 0), 10)
+	results, err := s.MemoryEmbedSearch(ctx, "", store.MemoryScopeAgent, "empty", "", floats32(1, 0, 0, 0), 10)
 	if err != nil {
 		t.Errorf("empty scope search: %v", err)
 	}
@@ -3979,17 +3979,17 @@ func testMemoryEmbedSearchReturnsVectors(t *testing.T, s store.Store) {
 		"north": floats32(0, 1, 0, 0),
 	}
 	for key, vec := range want {
-		if err := s.MemorySet(ctx, store.MemoryScopeAgent, "vecret", key, json.RawMessage(`"x"`), 0); err != nil {
+		if err := s.MemorySet(ctx, "", store.MemoryScopeAgent, "vecret", key, json.RawMessage(`"x"`), 0); err != nil {
 			t.Fatal(err)
 		}
-		if err := s.MemoryEmbedSet(ctx, store.MemoryScopeAgent, "vecret", key, store.MemoryEmbedding{
+		if err := s.MemoryEmbedSet(ctx, "", store.MemoryScopeAgent, "vecret", key, store.MemoryEmbedding{
 			Provider: "openai", Model: "text-embedding-3-small", Dimension: 4,
 			Vector: vec, EmbedText: key, CreatedAt: time.Now(),
 		}); err != nil {
 			t.Fatal(err)
 		}
 	}
-	results, err := s.MemoryEmbedSearch(ctx, store.MemoryScopeAgent, "vecret", "", floats32(1, 0, 0, 0), 5)
+	results, err := s.MemoryEmbedSearch(ctx, "", store.MemoryScopeAgent, "vecret", "", floats32(1, 0, 0, 0), 5)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4012,16 +4012,16 @@ func testMemoryDeleteCascadesEmbedding(t *testing.T, s store.Store) {
 		return
 	}
 	ctx := context.Background()
-	_ = s.MemorySet(ctx, store.MemoryScopeAgent, "qa", "doomed", json.RawMessage(`"x"`), 0)
-	_ = s.MemoryEmbedSet(ctx, store.MemoryScopeAgent, "qa", "doomed", store.MemoryEmbedding{
+	_ = s.MemorySet(ctx, "", store.MemoryScopeAgent, "qa", "doomed", json.RawMessage(`"x"`), 0)
+	_ = s.MemoryEmbedSet(ctx, "", store.MemoryScopeAgent, "qa", "doomed", store.MemoryEmbedding{
 		Provider: "openai", Model: "text-embedding-3-small", Dimension: 4,
 		Vector: floats32(1, 0, 0, 0), EmbedText: "x", CreatedAt: time.Now(),
 	})
 	// Delete the base row — embedding row must vanish via FK CASCADE.
-	if _, err := s.MemoryDelete(ctx, store.MemoryScopeAgent, "qa", "doomed"); err != nil {
+	if _, err := s.MemoryDelete(ctx, "", store.MemoryScopeAgent, "qa", "doomed"); err != nil {
 		t.Fatal(err)
 	}
-	_, err := s.MemoryEmbedGet(ctx, store.MemoryScopeAgent, "qa", "doomed")
+	_, err := s.MemoryEmbedGet(ctx, "", store.MemoryScopeAgent, "qa", "doomed")
 	var nf *store.ErrNotFound
 	if !errors.As(err, &nf) {
 		t.Errorf("after base-row delete: got %v (%T), want *store.ErrNotFound (CASCADE failed)", err, err)
@@ -4035,20 +4035,20 @@ func testMemoryEmbedListByModelFiltersCurrent(t *testing.T, s store.Store) {
 	ctx := context.Background()
 	// Two rows under the OLD model.
 	for _, k := range []string{"old1", "old2"} {
-		_ = s.MemorySet(ctx, store.MemoryScopeAgent, "qa", k, json.RawMessage(`"x"`), 0)
-		_ = s.MemoryEmbedSet(ctx, store.MemoryScopeAgent, "qa", k, store.MemoryEmbedding{
+		_ = s.MemorySet(ctx, "", store.MemoryScopeAgent, "qa", k, json.RawMessage(`"x"`), 0)
+		_ = s.MemoryEmbedSet(ctx, "", store.MemoryScopeAgent, "qa", k, store.MemoryEmbedding{
 			Provider: "openai", Model: "text-embedding-3-small", Dimension: 4,
 			Vector: floats32(1, 0, 0, 0), EmbedText: k, CreatedAt: time.Now(),
 		})
 	}
 	// One row under the NEW model.
-	_ = s.MemorySet(ctx, store.MemoryScopeAgent, "qa", "new1", json.RawMessage(`"x"`), 0)
-	_ = s.MemoryEmbedSet(ctx, store.MemoryScopeAgent, "qa", "new1", store.MemoryEmbedding{
+	_ = s.MemorySet(ctx, "", store.MemoryScopeAgent, "qa", "new1", json.RawMessage(`"x"`), 0)
+	_ = s.MemoryEmbedSet(ctx, "", store.MemoryScopeAgent, "qa", "new1", store.MemoryEmbedding{
 		Provider: "openai", Model: "text-embedding-3-large", Dimension: 8,
 		Vector: floats32(1, 0, 0, 0, 0, 0, 0, 0), EmbedText: "new1", CreatedAt: time.Now(),
 	})
 	// Ask "which rows are NOT on text-embedding-3-large?" — expect old1 + old2.
-	got, err := s.MemoryEmbedListByModel(ctx, store.MemoryScopeAgent, "qa", "openai", "text-embedding-3-large", 100)
+	got, err := s.MemoryEmbedListByModel(ctx, "", store.MemoryScopeAgent, "qa", "openai", "text-embedding-3-large", 100)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4069,18 +4069,18 @@ func testMemoryEmbedStatsReportsPerModelCount(t *testing.T, s store.Store) {
 	ctx := context.Background()
 	// Two rows on model A (dim 4), one row on model B (dim 8).
 	for _, k := range []string{"a1", "a2"} {
-		_ = s.MemorySet(ctx, store.MemoryScopeAgent, "qa", k, json.RawMessage(`"x"`), 0)
-		_ = s.MemoryEmbedSet(ctx, store.MemoryScopeAgent, "qa", k, store.MemoryEmbedding{
+		_ = s.MemorySet(ctx, "", store.MemoryScopeAgent, "qa", k, json.RawMessage(`"x"`), 0)
+		_ = s.MemoryEmbedSet(ctx, "", store.MemoryScopeAgent, "qa", k, store.MemoryEmbedding{
 			Provider: "openai", Model: "text-embedding-3-small", Dimension: 4,
 			Vector: floats32(1, 0, 0, 0), EmbedText: k, CreatedAt: time.Now(),
 		})
 	}
-	_ = s.MemorySet(ctx, store.MemoryScopeAgent, "qa", "b1", json.RawMessage(`"x"`), 0)
-	_ = s.MemoryEmbedSet(ctx, store.MemoryScopeAgent, "qa", "b1", store.MemoryEmbedding{
+	_ = s.MemorySet(ctx, "", store.MemoryScopeAgent, "qa", "b1", json.RawMessage(`"x"`), 0)
+	_ = s.MemoryEmbedSet(ctx, "", store.MemoryScopeAgent, "qa", "b1", store.MemoryEmbedding{
 		Provider: "openai", Model: "text-embedding-3-large", Dimension: 8,
 		Vector: floats32(1, 0, 0, 0, 0, 0, 0, 0), EmbedText: "b1", CreatedAt: time.Now(),
 	})
-	stats, err := s.MemoryEmbedStats(ctx, store.MemoryScopeAgent)
+	stats, err := s.MemoryEmbedStats(ctx, "", store.MemoryScopeAgent)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -299,12 +299,12 @@ type chunkBody struct {
 
 func (d *Document) writeBody(ctx context.Context, mscope store.MemoryScope, scopeID, chunkID, body string, fields json.RawMessage) error {
 	v, _ := json.Marshal(chunkBody{Body: body, Fields: fields})
-	return d.Store.MemorySet(ctx, mscope, scopeID, chunkBodyKey(chunkID), v, 0)
+	return d.Store.MemorySet(ctx, "", mscope, scopeID, chunkBodyKey(chunkID), v, 0)
 }
 
 func (d *Document) readBody(ctx context.Context, mscope store.MemoryScope, scopeID, chunkID string) chunkBody {
 	var cb chunkBody
-	entry, err := d.Store.MemoryGet(ctx, mscope, scopeID, chunkBodyKey(chunkID))
+	entry, err := d.Store.MemoryGet(ctx, "", mscope, scopeID, chunkBodyKey(chunkID))
 	if err == nil {
 		_ = json.Unmarshal(entry.Value, &cb)
 	}
@@ -882,7 +882,7 @@ func (d *Document) deleteDocument(ctx context.Context, key sqlmem.ScopeKey, msco
 	// Bodies AFTER commit (separate store; best-effort — an orphaned body is
 	// invisible dead k/v, never reachable once its chunk row is gone).
 	for _, id := range ids {
-		_, _ = d.Store.MemoryDelete(ctx, mscope, key.ScopeID, chunkBodyKey(id))
+		_, _ = d.Store.MemoryDelete(ctx, "", mscope, key.ScopeID, chunkBodyKey(id))
 	}
 	n := len(ids)
 	// Drop any Path-tree dirent(s) pointing at this document — best-effort, by
@@ -1330,7 +1330,7 @@ func (d *Document) deleteChunk(ctx context.Context, key sqlmem.ScopeKey, mscope 
 	}
 	// Bodies after commit (best-effort; see delete_document).
 	for _, cid := range ids {
-		_, _ = d.Store.MemoryDelete(ctx, mscope, key.ScopeID, chunkBodyKey(cid))
+		_, _ = d.Store.MemoryDelete(ctx, "", mscope, key.ScopeID, chunkBodyKey(cid))
 	}
 	d.publishChange(ctx, mscope, key.ScopeID, row.DocumentID, "delete_chunk", in.ID)
 	return jsonResult(map[string]any{"deleted": true, "cascade_deleted_descendants": len(ids) - 1})

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -299,12 +299,15 @@ type chunkBody struct {
 
 func (d *Document) writeBody(ctx context.Context, mscope store.MemoryScope, scopeID, chunkID, body string, fields json.RawMessage) error {
 	v, _ := json.Marshal(chunkBody{Body: body, Fields: fields})
-	return d.Store.MemorySet(ctx, "", mscope, scopeID, chunkBodyKey(chunkID), v, 0)
+	// RFC BL: key chunk bodies on the same tenant the document's dirent + SQL
+	// structure use (direntTenant = the raw RunIdentity tenant), so bodies and
+	// structure never drift across the tenant axis.
+	return d.Store.MemorySet(ctx, direntTenant(ctx), mscope, scopeID, chunkBodyKey(chunkID), v, 0)
 }
 
 func (d *Document) readBody(ctx context.Context, mscope store.MemoryScope, scopeID, chunkID string) chunkBody {
 	var cb chunkBody
-	entry, err := d.Store.MemoryGet(ctx, "", mscope, scopeID, chunkBodyKey(chunkID))
+	entry, err := d.Store.MemoryGet(ctx, direntTenant(ctx), mscope, scopeID, chunkBodyKey(chunkID))
 	if err == nil {
 		_ = json.Unmarshal(entry.Value, &cb)
 	}
@@ -882,7 +885,7 @@ func (d *Document) deleteDocument(ctx context.Context, key sqlmem.ScopeKey, msco
 	// Bodies AFTER commit (separate store; best-effort — an orphaned body is
 	// invisible dead k/v, never reachable once its chunk row is gone).
 	for _, id := range ids {
-		_, _ = d.Store.MemoryDelete(ctx, "", mscope, key.ScopeID, chunkBodyKey(id))
+		_, _ = d.Store.MemoryDelete(ctx, direntTenant(ctx), mscope, key.ScopeID, chunkBodyKey(id))
 	}
 	n := len(ids)
 	// Drop any Path-tree dirent(s) pointing at this document — best-effort, by
@@ -1330,7 +1333,7 @@ func (d *Document) deleteChunk(ctx context.Context, key sqlmem.ScopeKey, mscope 
 	}
 	// Bodies after commit (best-effort; see delete_document).
 	for _, cid := range ids {
-		_, _ = d.Store.MemoryDelete(ctx, "", mscope, key.ScopeID, chunkBodyKey(cid))
+		_, _ = d.Store.MemoryDelete(ctx, direntTenant(ctx), mscope, key.ScopeID, chunkBodyKey(cid))
 	}
 	d.publishChange(ctx, mscope, key.ScopeID, row.DocumentID, "delete_chunk", in.ID)
 	return jsonResult(map[string]any{"deleted": true, "cascade_deleted_descendants": len(ids) - 1})

--- a/internal/tools/builtin/document_test.go
+++ b/internal/tools/builtin/document_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -45,6 +46,57 @@ func docExec(t *testing.T, d *Document, ctx context.Context, body string) (map[s
 		_ = json.Unmarshal([]byte(res.Text), &out)
 	}
 	return out, res
+}
+
+// TestDocumentBody_TenantIsolated: a chunk body written under tenant A lands in
+// tenant A's base-memory partition (readable by A's get_chunk) and NOT the
+// legacy "" partition where the pre-RFC-BL code wrote every body. Fails on the
+// pre-stamp code (body under "" → the tenant-A probe misses, the "" probe hits).
+func TestDocumentBody_TenantIsolated(t *testing.T) {
+	s, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	mgr, err := sqlmem.New(sqlmem.Config{Root: t.TempDir()})
+	if err != nil {
+		t.Fatalf("sqlmem.New: %v", err)
+	}
+	t.Cleanup(func() { _ = mgr.Close() })
+	d := &Document{Store: s, SqlMem: mgr, Bus: channels.NewBus()}
+
+	ctxA := tools.WithRunIdentity(
+		tools.WithAgentName(context.Background(), "doc-agent"),
+		tools.RunIdentityValue{AgentID: "a", UserID: "u1", TenantID: "A"})
+
+	// Tenant A creates a document + a chunk carrying a body.
+	out, res := docExec(t, d, ctxA, `{"op":"create_document","scope":"agent","title":"D"}`)
+	if res.IsError {
+		t.Fatalf("create_document(A): %s", res.Text)
+	}
+	docID := out["document_id"].(string)
+	root := out["root_chunk_id"].(string)
+	out, res = docExec(t, d, ctxA, `{"op":"create_chunk","scope":"agent","document_id":"`+docID+`","parent_id":"`+root+`","title":"c","body":"SECRET-A"}`)
+	if res.IsError {
+		t.Fatalf("create_chunk(A): %s", res.Text)
+	}
+	cid := out["id"].(string)
+
+	// get_chunk under A returns the body (write + read align within the tenant).
+	out, res = docExec(t, d, ctxA, `{"op":"get_chunk","scope":"agent","id":"`+cid+`"}`)
+	if res.IsError || out["body"] != "SECRET-A" {
+		t.Fatalf("get_chunk(A) body = %v, want SECRET-A (res=%s)", out["body"], res.Text)
+	}
+
+	// The body row lives in tenant A's base-memory partition ...
+	bodyKey := chunkBodyKey(cid)
+	if _, err := s.MemoryGet(context.Background(), "A", store.MemoryScopeAgent, "doc-agent", bodyKey); err != nil {
+		t.Errorf("chunk body not under tenant A partition: %v", err)
+	}
+	// ... and NOT under the legacy "" partition (where the pre-BL code wrote it).
+	if _, err := s.MemoryGet(context.Background(), "", store.MemoryScopeAgent, "doc-agent", bodyKey); !errors.As(err, new(*store.ErrNotFound)) {
+		t.Errorf("chunk body leaked into the \"\" partition; got err=%v", err)
+	}
 }
 
 func TestDocument_EndToEnd(t *testing.T) {

--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -1357,7 +1357,7 @@ func (m *Memory) execIncr(ctx context.Context, scope store.MemoryScope, scopeID 
 		return errResult(err.Error()), nil
 	}
 	ttl := time.Duration(in.TTL) * time.Second
-	next, err := m.Store.MemoryIncrement(ctx, scope, scopeID, in.Key, delta, ttl)
+	next, err := m.Store.MemoryIncrement(ctx, "", scope, scopeID, in.Key, delta, ttl)
 	if err != nil {
 		if errors.Is(err, store.ErrMemoryWrongType) {
 			return errResult("incr: existing value is not a JSON number — use set with a number, or delete first"), nil
@@ -1400,7 +1400,7 @@ func (m *Memory) execMerge(ctx context.Context, scope store.MemoryScope, scopeID
 	}
 
 	ttl := time.Duration(in.TTL) * time.Second
-	final, err := m.Store.MemoryAtomicUpdate(ctx, scope, scopeID, in.Key, ttl,
+	final, err := m.Store.MemoryAtomicUpdate(ctx, "", scope, scopeID, in.Key, ttl,
 		func(existing json.RawMessage) (json.RawMessage, error) {
 			base := map[string]any{}
 			if len(existing) > 0 {
@@ -1456,7 +1456,7 @@ func (m *Memory) execAppendDedupe(ctx context.Context, scope store.MemoryScope, 
 
 	ttl := time.Duration(in.TTL) * time.Second
 	appended := false
-	final, err := m.Store.MemoryAtomicUpdate(ctx, scope, scopeID, in.Key, ttl,
+	final, err := m.Store.MemoryAtomicUpdate(ctx, "", scope, scopeID, in.Key, ttl,
 		func(existing json.RawMessage) (json.RawMessage, error) {
 			var arr []json.RawMessage
 			if len(existing) > 0 {
@@ -1526,7 +1526,7 @@ func (m *Memory) execBoundedList(ctx context.Context, scope store.MemoryScope, s
 
 	ttl := time.Duration(in.TTL) * time.Second
 	var droppedCount int
-	final, err := m.Store.MemoryAtomicUpdate(ctx, scope, scopeID, in.Key, ttl,
+	final, err := m.Store.MemoryAtomicUpdate(ctx, "", scope, scopeID, in.Key, ttl,
 		func(existing json.RawMessage) (json.RawMessage, error) {
 			var arr []json.RawMessage
 			if len(existing) > 0 {

--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -1357,7 +1357,10 @@ func (m *Memory) execIncr(ctx context.Context, scope store.MemoryScope, scopeID 
 		return errResult(err.Error()), nil
 	}
 	ttl := time.Duration(in.TTL) * time.Second
-	next, err := m.Store.MemoryIncrement(ctx, "", scope, scopeID, in.Key, delta, ttl)
+	// RFC BL: the run's authoritative tenant partitions base memory. Server-
+	// sourced from RunIdentity (never tool input) — the same isolation key the
+	// sqlmem/dirent paths in this file already use.
+	next, err := m.Store.MemoryIncrement(ctx, tools.RunIdentity(ctx).TenantID, scope, scopeID, in.Key, delta, ttl)
 	if err != nil {
 		if errors.Is(err, store.ErrMemoryWrongType) {
 			return errResult("incr: existing value is not a JSON number — use set with a number, or delete first"), nil
@@ -1400,7 +1403,8 @@ func (m *Memory) execMerge(ctx context.Context, scope store.MemoryScope, scopeID
 	}
 
 	ttl := time.Duration(in.TTL) * time.Second
-	final, err := m.Store.MemoryAtomicUpdate(ctx, "", scope, scopeID, in.Key, ttl,
+	// RFC BL: partition by the run's authoritative tenant (server-sourced).
+	final, err := m.Store.MemoryAtomicUpdate(ctx, tools.RunIdentity(ctx).TenantID, scope, scopeID, in.Key, ttl,
 		func(existing json.RawMessage) (json.RawMessage, error) {
 			base := map[string]any{}
 			if len(existing) > 0 {
@@ -1456,7 +1460,8 @@ func (m *Memory) execAppendDedupe(ctx context.Context, scope store.MemoryScope, 
 
 	ttl := time.Duration(in.TTL) * time.Second
 	appended := false
-	final, err := m.Store.MemoryAtomicUpdate(ctx, "", scope, scopeID, in.Key, ttl,
+	// RFC BL: partition by the run's authoritative tenant (server-sourced).
+	final, err := m.Store.MemoryAtomicUpdate(ctx, tools.RunIdentity(ctx).TenantID, scope, scopeID, in.Key, ttl,
 		func(existing json.RawMessage) (json.RawMessage, error) {
 			var arr []json.RawMessage
 			if len(existing) > 0 {
@@ -1526,7 +1531,8 @@ func (m *Memory) execBoundedList(ctx context.Context, scope store.MemoryScope, s
 
 	ttl := time.Duration(in.TTL) * time.Second
 	var droppedCount int
-	final, err := m.Store.MemoryAtomicUpdate(ctx, "", scope, scopeID, in.Key, ttl,
+	// RFC BL: partition by the run's authoritative tenant (server-sourced).
+	final, err := m.Store.MemoryAtomicUpdate(ctx, tools.RunIdentity(ctx).TenantID, scope, scopeID, in.Key, ttl,
 		func(existing json.RawMessage) (json.RawMessage, error) {
 			var arr []json.RawMessage
 			if len(existing) > 0 {

--- a/internal/tools/builtin/memory_test.go
+++ b/internal/tools/builtin/memory_test.go
@@ -35,6 +35,52 @@ func memoryFixture(t *testing.T) (*Memory, context.Context, func()) {
 	return tool, ctx, func() { _ = s.Close() }
 }
 
+// TestMemory_TenantIsolation drives the Memory tool under two RunIdentity
+// tenants writing the SAME user-scope key: each reads back only its own value,
+// and a cross-tenant get returns not-found (value:null). RFC BL turn-on — fails
+// on the pre-stamp code where every op keyed tenant "" (b's write clobbers a's,
+// and a-only is cross-tenant visible).
+func TestMemory_TenantIsolation(t *testing.T) {
+	tool, _, cleanup := memoryFixture(t)
+	defer cleanup()
+
+	mkCtx := func(tenant string) context.Context {
+		ctx := tools.WithAgentName(context.Background(), "qa-agent")
+		ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{UserID: "alice", TenantID: tenant})
+		ctx = tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{AllowedScopes: []string{"agent", "user"}})
+		return ctx
+	}
+	ctxA := mkCtx("tenant-a")
+	ctxB := mkCtx("tenant-b")
+
+	// Both tenants write the SAME user-scope key with distinct values.
+	if res, _ := tool.Execute(ctxA, json.RawMessage(`{"op":"set","scope":"user","key":"voice","value":{"who":"a"}}`)); res.IsError {
+		t.Fatalf("set(a): %s", res.Text)
+	}
+	if res, _ := tool.Execute(ctxB, json.RawMessage(`{"op":"set","scope":"user","key":"voice","value":{"who":"b"}}`)); res.IsError {
+		t.Fatalf("set(b): %s", res.Text)
+	}
+
+	// Each reads back ONLY its own value (no clobber across tenants).
+	resA, _ := tool.Execute(ctxA, json.RawMessage(`{"op":"get","scope":"user","key":"voice"}`))
+	if !strings.Contains(resA.Text, `"who":"a"`) || strings.Contains(resA.Text, `"who":"b"`) {
+		t.Errorf("tenant a get = %s, want who:a only", resA.Text)
+	}
+	resB, _ := tool.Execute(ctxB, json.RawMessage(`{"op":"get","scope":"user","key":"voice"}`))
+	if !strings.Contains(resB.Text, `"who":"b"`) || strings.Contains(resB.Text, `"who":"a"`) {
+		t.Errorf("tenant b get = %s, want who:b only", resB.Text)
+	}
+
+	// A key written ONLY under tenant a is invisible to tenant b (opaque miss).
+	if res, _ := tool.Execute(ctxA, json.RawMessage(`{"op":"set","scope":"user","key":"a-only","value":1}`)); res.IsError {
+		t.Fatalf("set(a-only): %s", res.Text)
+	}
+	resMiss, _ := tool.Execute(ctxB, json.RawMessage(`{"op":"get","scope":"user","key":"a-only"}`))
+	if !strings.Contains(resMiss.Text, `"value":null`) {
+		t.Errorf("tenant b must NOT see tenant a's a-only key; got %s", resMiss.Text)
+	}
+}
+
 func TestMemoryTool_SetGetDeleteRoundTrip(t *testing.T) {
 	tool, ctx, cleanup := memoryFixture(t)
 	defer cleanup()

--- a/internal/tools/builtin/memory_vector_test.go
+++ b/internal/tools/builtin/memory_vector_test.go
@@ -48,7 +48,7 @@ func vsKey(scope store.MemoryScope, scopeID, key string) string {
 
 func (v *vectorStore) SupportsVectors() bool { return v.enabled }
 
-func (v *vectorStore) MemoryEmbedSet(ctx context.Context, scope store.MemoryScope, scopeID, key string, e store.MemoryEmbedding) error {
+func (v *vectorStore) MemoryEmbedSet(ctx context.Context, _ string, scope store.MemoryScope, scopeID, key string, e store.MemoryEmbedding) error {
 	if !v.enabled {
 		return store.ErrVectorUnsupported
 	}
@@ -58,7 +58,7 @@ func (v *vectorStore) MemoryEmbedSet(ctx context.Context, scope store.MemoryScop
 	return nil
 }
 
-func (v *vectorStore) MemoryEmbedGet(ctx context.Context, scope store.MemoryScope, scopeID, key string) (store.MemoryEmbedding, error) {
+func (v *vectorStore) MemoryEmbedGet(ctx context.Context, _ string, scope store.MemoryScope, scopeID, key string) (store.MemoryEmbedding, error) {
 	v.mu.Lock()
 	defer v.mu.Unlock()
 	e, ok := v.embeds[vsKey(scope, scopeID, key)]
@@ -100,7 +100,7 @@ func sqrt(x float64) float64 {
 	return z
 }
 
-func (v *vectorStore) MemoryEmbedSearch(ctx context.Context, scope store.MemoryScope, scopeID, keyPrefix string, query []float32, topK int) ([]store.MemorySearchEntry, error) {
+func (v *vectorStore) MemoryEmbedSearch(ctx context.Context, _ string, scope store.MemoryScope, scopeID, keyPrefix string, query []float32, topK int) ([]store.MemorySearchEntry, error) {
 	if !v.enabled {
 		return nil, store.ErrVectorUnsupported
 	}
@@ -148,7 +148,7 @@ func (v *vectorStore) MemoryEmbedSearch(ctx context.Context, scope store.MemoryS
 			continue
 		}
 		// Filter expired base rows.
-		entry, err := v.Store.MemoryGet(ctx, scope, scopeID, key)
+		entry, err := v.Store.MemoryGet(ctx, "", scope, scopeID, key)
 		if err != nil {
 			continue
 		}
@@ -161,7 +161,7 @@ func (v *vectorStore) MemoryEmbedSearch(ctx context.Context, scope store.MemoryS
 	}
 	out := make([]store.MemorySearchEntry, 0, len(rows))
 	for _, r := range rows {
-		entry, err := v.Store.MemoryGet(ctx, scope, scopeID, r.key)
+		entry, err := v.Store.MemoryGet(ctx, "", scope, scopeID, r.key)
 		if err != nil {
 			continue
 		}
@@ -176,11 +176,11 @@ func (v *vectorStore) MemoryEmbedSearch(ctx context.Context, scope store.MemoryS
 	return out, nil
 }
 
-func (v *vectorStore) MemoryEmbedListByModel(ctx context.Context, scope store.MemoryScope, scopeID, currentProvider, currentModel string, limit int) ([]store.MemoryEntry, error) {
+func (v *vectorStore) MemoryEmbedListByModel(ctx context.Context, _ string, scope store.MemoryScope, scopeID, currentProvider, currentModel string, limit int) ([]store.MemoryEntry, error) {
 	return nil, errors.New("MemoryEmbedListByModel not implemented in fake")
 }
 
-func (v *vectorStore) MemoryEmbedStats(ctx context.Context, scope store.MemoryScope) (store.MemoryEmbedStats, error) {
+func (v *vectorStore) MemoryEmbedStats(ctx context.Context, _ string, scope store.MemoryScope) (store.MemoryEmbedStats, error) {
 	return store.MemoryEmbedStats{}, errors.New("MemoryEmbedStats not implemented in fake")
 }
 
@@ -375,7 +375,7 @@ func TestMemoryVector_SetEmbedTrueSucceeds(t *testing.T) {
 	}
 	// Confirm the embedding is stored under the right scope.
 	vs := tool.Store.(*vectorStore)
-	emb, err := vs.MemoryEmbedGet(ctx, store.MemoryScopeUser, "alice", "profile")
+	emb, err := vs.MemoryEmbedGet(ctx, "", store.MemoryScopeUser, "alice", "profile")
 	if err != nil {
 		t.Fatalf("embedding not stored: %v", err)
 	}
@@ -401,7 +401,7 @@ func TestMemoryVector_SetEmbedFalseDoesNotEmbed(t *testing.T) {
 		t.Errorf("response should NOT mention embedded when embed:false: %s", res.Text)
 	}
 	vs := tool.Store.(*vectorStore)
-	if _, err := vs.MemoryEmbedGet(ctx, store.MemoryScopeUser, "alice", "profile"); err == nil {
+	if _, err := vs.MemoryEmbedGet(ctx, "", store.MemoryScopeUser, "alice", "profile"); err == nil {
 		t.Errorf("embedding should NOT have been written when embed:false")
 	}
 }
@@ -447,7 +447,7 @@ func TestMemoryVector_SetEmbedTrueFallsBackToValueAsText(t *testing.T) {
 		t.Fatalf("set: %s", res.Text)
 	}
 	vs := tool.Store.(*vectorStore)
-	emb, err := vs.MemoryEmbedGet(ctx, store.MemoryScopeUser, "alice", "k")
+	emb, err := vs.MemoryEmbedGet(ctx, "", store.MemoryScopeUser, "alice", "k")
 	if err != nil {
 		t.Fatalf("embedding missing: %v", err)
 	}


### PR DESCRIPTION
## Why

RFC L isolated runs/sessions and RFC N isolated the definition plane, but the **base `memory` table stayed tenant-blind**: an agent's `scope_id` is the bare agent name, shared by same-named agents across tenants, so two tenants writing the same `(scope, scope_id, key)` collided on one global row. For the multi-tenant loomcycle.cloud deployment that's a correctness/leak hazard. This PR adds the tenant axis to the base k/v + vector Memory store, and lays the `provenance`/`access` columns the RFC BL hybrid ranker (P2) and background consolidation (P2) will use.

This is **P1 PR1** of RFC BL (agentic memory). The design + phasing live in the RFC and its P1 plan; subsequent PRs (hybrid retrieval, core memory blocks, document-memory tier, help-topic index, dead-link guard) are separate.

## What

Two commits — a behaviour-preserving mechanical pass, then the semantic turn-on:

**Commit 1 — `tenant_id` plumbing (byte-identical):**
- Migration `0059_memory_tenant_id`: adds `tenant_id` (+ `origin`/`class`/`source_session_id`/`source_run_id`/`access_count`/`last_accessed_at`) to `memory`; swaps its PK to `(tenant_id, scope, scope_id, key)`; reworks `memory_embeddings` in lockstep (drop FK → add `tenant_id` → re-key → recreate the FK on the 4-tuple keeping `ON DELETE CASCADE` → rebuild the scope/model indexes), all behind a `to_regclass()` pgvector guard so it's a clean no-op without the extension. `DEFAULT ''` backfills existing rows to the shared/legacy tenant. `.down.sql` reverses in strict order.
- sqlite: fresh DBs get the 4-tuple PK; upgraded DBs get the columns via ALTER and keep the old PK (multi-tenant memory isolation requires Postgres or a fresh sqlite DB — documented, per the existing `agent_def_active` precedent).
- A `tenantID` parameter threaded through all 13 `Memory*` store methods + both backends + `MemorySnapshotEntry`, with every caller passing `""` so behaviour is byte-identical on a freshly-migrated DB.

**Commit 2 — stamp the per-run tenant (isolation goes live):**
- Tenant sourced **server-side** at each call site (never from tool input / request body / URL): Memory tool + in-process backend + Document chunk bodies ← `RunIdentity().TenantID`; scheduler + webhook memory hooks ← the def row's `tenant_id`; HTTP admin endpoints ← the authenticated principal (`tenantFromCtx`); snapshot ← the row/envelope `TenantID`.
- Retention sweeper: new `MemoryListTenantsForScope` store method → the base-KV reclamation for a fully-retired agent now **fans out per tenant** instead of one tenant-blind delete, which also fixes RFC BM Phase-3's bare-name cross-tenant deletion. The globally-dead-agent semantics are preserved.
- `global` scope stays tenant `""` (cross-tenant shared).

## Compatibility

- **Single-tenant / legacy deployments read byte-identical.** The base k/v now sources tenant exactly like the def plane (raw `RunIdentity.TenantID`); migration 0037 backfills the def plane to `''` identically to 0059, and legacy runs already resolve their defs correctly at `''`, so memory inherits that behaviour. (`"default"` is a fixture value + sqlmem's separate `sqlScopeTenant` fallback, not the base k/v path.)
- **loomcycle.cloud caveat:** pre-migration KV had no tenant, so it backfills to `''`; a tenant-scoped read (now filtered) won't see it. Consolidation (P2) regenerates tenant-correct memory from tenant-tagged transcripts; only pre-existing *explicit* KV is stranded under `''`. **Validate against live cloud data before deploying**; an operator `scope_id→tenant` backfill can be run if precise migration is required.

## Tested

- `go build ./...`, `go vet ./...`, `gofmt` — clean.
- `go test ./...` — green; Postgres-backed contract/migration tests skip without a DSN (the `go-postgres` CI job exercises `0059` + the PG impl).
- New: `TestStore_MemoryTenantIsolation`, `TestStore_MemoryListTenantsForScope`, `TestMemory_TenantIsolation`, `TestDocumentBody_TenantIsolated`, `TestRetentionSweep_PerTenantFanout`, `TestSnapshot_TenantRoundTrip` (+ legacy tenant-less restore), `TestHandleMemory_TenantIsolation` — each fails on the pre-change (shared-keyspace) code and passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
