### PR TITLE
feat(memory): hybrid vector+full-text retrieval with RRF (RFC BL P1 PR2)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -2963,9 +2963,6 @@ func main() {
 	<-sig
 	log.Println("shutting down…")
 	bgCancel() // tear down sweeper + GC goroutines first
-	// RFC BL: stop the access-count flusher and flush the final window so a
-	// clean shutdown never loses accumulated access counts.
-	accessFlusher.Stop()
 	if heartbeatRunner != nil {
 		heartbeatRunner.Stop()
 	}
@@ -2984,6 +2981,14 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	_ = httpServer.Shutdown(ctx)
+	// RFC BL: stop the access-count flusher and flush the final window AFTER the
+	// HTTP+gRPC servers have finished draining. In-flight Search requests
+	// Record() access bumps right up to the end of that drain window, so the
+	// flusher's final flush must run last to capture them — stopping it earlier
+	// would leave those late bumps with no goroutine left to flush them. The
+	// store closer is deferred (runs after main returns), so the store is still
+	// open for this final write.
+	accessFlusher.Stop()
 	// Flush OTEL spans before exit. The OTLP exporter batches; without this,
 	// in-flight spans never reach the collector. Give it its OWN 5s budget —
 	// sharing the HTTP shutdown's ctx meant a slow in-flight request drain

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -93,6 +93,7 @@ import (
 	loomgrpc "github.com/denn-gubsky/loomcycle/internal/api/grpc"
 	"github.com/denn-gubsky/loomcycle/internal/api/grpc/loomcyclepb"
 	lcmcp "github.com/denn-gubsky/loomcycle/internal/api/mcp"
+	memory "github.com/denn-gubsky/loomcycle/internal/memory"
 	"github.com/denn-gubsky/loomcycle/internal/memory/backends/inprocess"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 	toolsa2a "github.com/denn-gubsky/loomcycle/internal/tools/a2a"
@@ -1390,7 +1391,16 @@ func main() {
 	// as before). MR-3b routes PER-AGENT named backends per-call from
 	// memory.go backend(ctx) via memoryTool.Cfg; MR-4's Mem9 plugs into that
 	// switch. This default assignment stays.
-	memoryTool.Backend = inprocess.New(storeIface, embedder)
+	inProcBackend := inprocess.New(storeIface, embedder)
+	// RFC BL hybrid retrieval (OQ #4): a per-replica batched access-count
+	// flusher. Search records a +1 access for returned entries; the flusher
+	// writes the accumulated deltas additively on a ticker + size trigger, so
+	// the hot search path never blocks on the write. Stopped (with a final
+	// flush) in the graceful-shutdown block below.
+	accessFlusher := memory.NewAccessFlusher(storeIface, 0, 0) // 0,0 → package defaults
+	accessFlusher.Start()
+	inProcBackend.SetAccessFlusher(accessFlusher)
+	memoryTool.Backend = inProcBackend
 	channelTool.Store = storeIface
 	// Wire the pool-stats accessor when the backend is Postgres so
 	// the Channel tool's subscribe-race diagnostic log can correlate
@@ -2953,6 +2963,9 @@ func main() {
 	<-sig
 	log.Println("shutting down…")
 	bgCancel() // tear down sweeper + GC goroutines first
+	// RFC BL: stop the access-count flusher and flush the final window so a
+	// clean shutdown never loses accumulated access counts.
+	accessFlusher.Stop()
 	if heartbeatRunner != nil {
 		heartbeatRunner.Stop()
 	}

--- a/internal/help/builtin/memory-ranking.md
+++ b/internal/help/builtin/memory-ranking.md
@@ -5,11 +5,17 @@ description: Memory retrieval tuning — the hybrid ranker (semantic + recency w
 
 # Memory ranking, dedup & pluggable backends
 
-By default `Memory.search` returns the top-k rows by pure cosine similarity
-to the query embedding — the v0.9.0 Vector Memory behavior. loomcycle adds three
-things on top, all **opt-in and zero-regression**: a hybrid ranker, search-
-time dedup, and a pluggable backend layer (so an agent's memory can live in
-an external store like Mem9 instead of loomcycle's own sqlite-vec/pgvector).
+`Memory.search` retrieves by relevance to the query. On a backend with a
+full-text index (Postgres+pgvector) retrieval is **hybrid by default**: a
+vector (semantic) leg and a keyword (full-text) leg are fused by Reciprocal
+Rank Fusion (RRF), so an entry that lexically matches the query but sits
+outside the nearest-neighbour set still surfaces. A backend **without** a
+full-text index (SQLite) keeps pure cosine similarity — the original Vector
+Memory behavior, with no over-fetch or second round-trip for a plain semantic
+search. On top of retrieval, loomcycle layers three **opt-in** tunables:
+recency/frequency ranking weights, search-time dedup, and a pluggable backend
+layer (so an agent's memory can live in an external store like Mem9 instead of
+loomcycle's own sqlite-vec/pgvector).
 
 ## Why tune retrieval at all
 
@@ -20,9 +26,10 @@ Pure semantic similarity has two failure modes in long-lived agents:
 - **Repetition wastes context.** Three paraphrases of the same fact all match
   and all get returned, burning tokens on redundancy.
 
-The ranker addresses the first (weight recency), dedup the second. Neither
-fires unless you ask for it — an agent that sends no `rank`/`dedup` block sees
-exactly today's behavior.
+The recency/frequency ranking weights address the first, dedup the second.
+Neither fires unless you ask for it — an agent that sends no `rank`/`dedup`
+block gets the default weights (pure semantic) and no dedup. Hybrid fusion
+itself, however, runs by default wherever a full-text index is available.
 
 ## The hybrid ranker
 
@@ -32,38 +39,43 @@ exactly today's behavior.
 {
   "op": "search", "scope": "user", "query": "...", "top_k": 10,
   "rank": {
-    "semantic_weight":        1.0,   // default — pure cosine
+    "semantic_weight":        1.0,   // default — scales the semantic signal
     "recency_weight":         0.0,
     "recency_half_life_hours": 24,
     "source_weight":          0.0,   // reserved (0 today)
-    "frequency_weight":       0.0    // reserved (0 today)
+    "frequency_weight":       0.0    // wired — rewards frequently-recalled rows
   }
 }
 ```
 
-The score is:
+The computed rank is:
 
 ```
-score = semantic_weight·cos_sim
-      + recency_weight·exp(-age·ln2 / recency_half_life_hours)
-      + source_weight·source_score        (reserved)
-      + frequency_weight·log(1+access_count)  (reserved)
+rank_score = semantic_weight·semantic_signal
+           + recency_weight·exp(-age·ln2 / recency_half_life_hours)
+           + source_weight·source_score              (reserved — 0 today)
+           + frequency_weight·log(1+access_count)
 ```
 
-The default `{semantic_weight: 1}` (or omitting the block) reproduces pure
-cosine ordering exactly. A non-zero `recency_weight` blends in an exponential
-recency decay: an entry at one half-life scores 0.5 on that term, so a fresh
-entry can overtake an older, slightly-more-similar one. When a hybrid config
-is set, loomcycle over-fetches a candidate pool and re-ranks it, so recency
-can promote an entry the pure-cosine top-k would have missed.
+`semantic_signal` is the **fused RRF rank** where hybrid retrieval ran, or the
+raw cosine on a pure-vector (no-full-text) backend. A non-zero `recency_weight`
+blends in an exponential recency decay: an entry at one half-life scores 0.5 on
+that term, so a fresh entry can overtake an older, slightly-more-similar one. A
+non-zero `frequency_weight` rewards a frequently-recalled entry (sub-linear, so
+a runaway access count can't dominate the semantic signal). When any of these
+weights is set, loomcycle re-ranks the candidate pool, so recency or frequency
+can promote an entry the semantic top-k would have missed.
 
-Each result carries a `rank_score` (the hybrid score it was ordered by)
-alongside the unchanged `score` (raw cosine).
+Each result carries two distinct fields: **`score`** — always the raw cosine
+similarity, unchanged by fusion or ranking (a stable value you can compare
+across searches) — and **`rank_score`** — the computed rank above (fused
+semantic + recency + frequency) that the results were ordered by.
 
-**Reserved weights.** `source_weight` and `frequency_weight` are part of the
-locked wire shape but contribute 0 today (there's no per-entry source or
-access-count tracking yet). Setting them is accepted, not rejected — the
-response carries a `rank_note` so the weight isn't silently ignored.
+**Reserved weight.** `source_weight` is part of the locked wire shape but
+contributes 0 today (there's no per-entry source-score signal yet). Setting it
+is accepted, not rejected — the response carries a `rank_note` so the weight
+isn't silently ignored. (`frequency_weight` is no longer reserved: it is wired
+to each entry's access count.)
 
 ## Search-time dedup
 

--- a/internal/memory/access.go
+++ b/internal/memory/access.go
@@ -132,12 +132,40 @@ func (f *AccessFlusher) drain() []store.MemoryAccessBump {
 
 // Flush drains the pending bumps and writes them additively. A no-op when
 // nothing is pending. Exposed for tests and the shutdown path.
+//
+// On a write error the drained bumps are RE-MERGED into pending so the next
+// flush retries them. drain() empties the map before the write, so without
+// this a transient store fault (not just a crash) would silently discard the
+// window — contradicting the "a crash drops at most the un-flushed window"
+// contract. Re-merging on the non-crash error path keeps that the only loss.
 func (f *AccessFlusher) Flush(ctx context.Context) error {
 	bumps := f.drain()
 	if len(bumps) == 0 {
 		return nil
 	}
-	return f.store.MemoryBumpAccessBatch(ctx, bumps)
+	if err := f.store.MemoryBumpAccessBatch(ctx, bumps); err != nil {
+		f.remerge(bumps)
+		return err
+	}
+	return nil
+}
+
+// remerge folds drained bumps back into pending after a failed write, summing
+// CountDelta and max-merging LastAccess. Records that arrived during the failed
+// write accumulated into the fresh map; we merge on top of them, so the retry
+// carries the full outstanding delta and no bump is lost to a transient fault.
+func (f *AccessFlusher) remerge(bumps []store.MemoryAccessBump) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, b := range bumps {
+		k := accessKey{tenant: b.TenantID, scope: string(b.Scope), scopeID: b.ScopeID, key: b.Key}
+		d := f.pending[k]
+		d.count += b.CountDelta
+		if b.LastAccess.After(d.lastAccess) {
+			d.lastAccess = b.LastAccess
+		}
+		f.pending[k] = d
+	}
 }
 
 // Start launches the background flush goroutine (ticker + size-trigger).

--- a/internal/memory/access.go
+++ b/internal/memory/access.go
@@ -1,0 +1,188 @@
+package memory
+
+import (
+	"context"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// access.go — RFC BL hybrid retrieval, OQ #4: the batched access-count flush.
+//
+// On every search HIT the in-process backend records a +1 access for the
+// returned entries. Writing that straight to the DB would amplify writes on
+// the hot search path (one UPDATE per result per search), so instead we
+// accumulate per-(tenant,scope,scope_id,key) deltas in a per-replica in-memory
+// map and flush them in batches on a ticker + a size trigger + graceful
+// shutdown. This mirrors the sqlmem debounced-`touch` pattern: the hot path
+// only touches a mutex-guarded map; the DB write is amortised and off-path.
+//
+// Semantics are ADVISORY and per-replica: counts may be a little stale and,
+// across replicas, are summed additively by MemoryBumpAccessBatch (the UPDATE
+// adds the delta), so no count is lost to a lost-update race. A crash drops at
+// most the un-flushed window — acceptable for a ranking signal.
+
+const (
+	// accessFlushDefaultInterval is the ticker period. ~30s keeps counts
+	// fresh enough for ranking while bounding write rate.
+	accessFlushDefaultInterval = 30 * time.Second
+	// accessFlushDefaultMaxBatch triggers an early flush once this many
+	// distinct rows are pending, so a burst of searches doesn't grow the map
+	// unbounded between ticks.
+	accessFlushDefaultMaxBatch = 512
+)
+
+type accessKey struct {
+	tenant  string
+	scope   string
+	scopeID string
+	key     string
+}
+
+type accessDelta struct {
+	count      int64
+	lastAccess time.Time
+}
+
+// AccessFlusher accumulates access-count bumps and flushes them to the store
+// in batches. It is safe for concurrent Record from many search goroutines.
+// Construct with NewAccessFlusher, call Start once, and Stop on shutdown
+// (Stop performs a final flush).
+type AccessFlusher struct {
+	store    store.Store
+	interval time.Duration
+	maxBatch int
+
+	mu      sync.Mutex
+	pending map[accessKey]accessDelta
+
+	flushSignal chan struct{}
+	stop        chan struct{}
+	done        chan struct{}
+}
+
+// NewAccessFlusher builds a flusher over the given store. A non-positive
+// interval or maxBatch falls back to the package defaults.
+func NewAccessFlusher(s store.Store, interval time.Duration, maxBatch int) *AccessFlusher {
+	if interval <= 0 {
+		interval = accessFlushDefaultInterval
+	}
+	if maxBatch <= 0 {
+		maxBatch = accessFlushDefaultMaxBatch
+	}
+	return &AccessFlusher{
+		store:       s,
+		interval:    interval,
+		maxBatch:    maxBatch,
+		pending:     make(map[accessKey]accessDelta),
+		flushSignal: make(chan struct{}, 1),
+	}
+}
+
+// Record accumulates a +1 access for one entry at time `at`. Cheap: one
+// mutex-guarded map touch, no DB I/O. When the pending set crosses maxBatch it
+// nudges the flusher goroutine (non-blocking).
+func (f *AccessFlusher) Record(tenant string, scope store.MemoryScope, scopeID, key string, at time.Time) {
+	k := accessKey{tenant: tenant, scope: string(scope), scopeID: scopeID, key: key}
+	f.mu.Lock()
+	d := f.pending[k]
+	d.count++
+	if at.After(d.lastAccess) {
+		d.lastAccess = at
+	}
+	f.pending[k] = d
+	size := len(f.pending)
+	f.mu.Unlock()
+
+	if size >= f.maxBatch {
+		select {
+		case f.flushSignal <- struct{}{}:
+		default: // a flush is already pending; coalesce
+		}
+	}
+}
+
+// drain atomically swaps out the pending map and returns it as a bump slice.
+// Records during the subsequent DB write accumulate into the fresh map.
+func (f *AccessFlusher) drain() []store.MemoryAccessBump {
+	f.mu.Lock()
+	if len(f.pending) == 0 {
+		f.mu.Unlock()
+		return nil
+	}
+	pend := f.pending
+	f.pending = make(map[accessKey]accessDelta)
+	f.mu.Unlock()
+
+	bumps := make([]store.MemoryAccessBump, 0, len(pend))
+	for k, d := range pend {
+		bumps = append(bumps, store.MemoryAccessBump{
+			TenantID:   k.tenant,
+			Scope:      store.MemoryScope(k.scope),
+			ScopeID:    k.scopeID,
+			Key:        k.key,
+			CountDelta: d.count,
+			LastAccess: d.lastAccess,
+		})
+	}
+	return bumps
+}
+
+// Flush drains the pending bumps and writes them additively. A no-op when
+// nothing is pending. Exposed for tests and the shutdown path.
+func (f *AccessFlusher) Flush(ctx context.Context) error {
+	bumps := f.drain()
+	if len(bumps) == 0 {
+		return nil
+	}
+	return f.store.MemoryBumpAccessBatch(ctx, bumps)
+}
+
+// Start launches the background flush goroutine (ticker + size-trigger).
+// Idempotent guard: a second Start without a Stop is a caller bug; we don't
+// defend against it because main wires exactly one.
+func (f *AccessFlusher) Start() {
+	f.stop = make(chan struct{})
+	f.done = make(chan struct{})
+	stop, done := f.stop, f.done
+	go func() {
+		defer close(done)
+		t := time.NewTicker(f.interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-t.C:
+				f.flushLogErr()
+			case <-f.flushSignal:
+				f.flushLogErr()
+			}
+		}
+	}()
+}
+
+// Stop signals the goroutine, JOINS it, then performs a final flush so a
+// clean shutdown never loses the last window's counts.
+func (f *AccessFlusher) Stop() {
+	if f.stop == nil {
+		return
+	}
+	close(f.stop)
+	<-f.done
+	f.stop = nil
+	f.flushLogErr()
+}
+
+// flushLogErr flushes under a bounded context and logs (never returns) errors
+// — an access-count write is advisory, so a transient store fault must not
+// crash the flush loop.
+func (f *AccessFlusher) flushLogErr() {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := f.Flush(ctx); err != nil {
+		log.Printf("memory: access-count flush: %v", err)
+	}
+}

--- a/internal/memory/access_test.go
+++ b/internal/memory/access_test.go
@@ -1,0 +1,114 @@
+package memory
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// bumpRecorderStore is a minimal store.Store that only implements
+// MemoryBumpAccessBatch, accumulating deltas ADDITIVELY and max-merging the
+// timestamp — the same semantics the real SQL (access_count + delta,
+// GREATEST(last_accessed_at, ts)) provides. Embedding store.Store keeps it
+// compiling as a full Store; every other method is unused here.
+type bumpRecorderStore struct {
+	store.Store
+	mu    sync.Mutex
+	count map[store.MemoryAccessBump]int64     // key fields only carry identity
+	last  map[store.MemoryAccessBump]time.Time // (delta/ts zeroed in the map key)
+}
+
+func newBumpRecorderStore() *bumpRecorderStore {
+	return &bumpRecorderStore{
+		count: map[store.MemoryAccessBump]int64{},
+		last:  map[store.MemoryAccessBump]time.Time{},
+	}
+}
+
+func identity(b store.MemoryAccessBump) store.MemoryAccessBump {
+	return store.MemoryAccessBump{TenantID: b.TenantID, Scope: b.Scope, ScopeID: b.ScopeID, Key: b.Key}
+}
+
+func (s *bumpRecorderStore) MemoryBumpAccessBatch(_ context.Context, bumps []store.MemoryAccessBump) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, b := range bumps {
+		id := identity(b)
+		s.count[id] += b.CountDelta
+		if b.LastAccess.After(s.last[id]) {
+			s.last[id] = b.LastAccess
+		}
+	}
+	return nil
+}
+
+func (s *bumpRecorderStore) get(tenant string, scope store.MemoryScope, scopeID, key string) (int64, time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	id := store.MemoryAccessBump{TenantID: tenant, Scope: scope, ScopeID: scopeID, Key: key}
+	return s.count[id], s.last[id]
+}
+
+// TestAccessCount_BatchedFlushIsAdditive: two flushers over one store flush
+// concurrently; their deltas SUM per key and last_accessed_at takes the max.
+// Run under -race to catch unguarded shared state in Record/drain/Flush.
+func TestAccessCount_BatchedFlushIsAdditive(t *testing.T) {
+	fs := newBumpRecorderStore()
+	f1 := NewAccessFlusher(fs, time.Hour, 1<<30) // huge interval/batch: flush only when we call Flush
+	f2 := NewAccessFlusher(fs, time.Hour, 1<<30)
+
+	early := time.Unix(1_700_000_000, 0).UTC()
+	late := early.Add(time.Hour)
+
+	const (
+		tenant  = "t1"
+		scopeID = "a1"
+	)
+	scope := store.MemoryScopeAgent
+
+	// f1: "hot" ×3 at the EARLY ts, plus "solo" ×1.
+	for i := 0; i < 3; i++ {
+		f1.Record(tenant, scope, scopeID, "hot", early)
+	}
+	f1.Record(tenant, scope, scopeID, "solo", early)
+	// f2: "hot" ×2 at the LATE ts (overlaps f1's key).
+	for i := 0; i < 2; i++ {
+		f2.Record(tenant, scope, scopeID, "hot", late)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); _ = f1.Flush(context.Background()) }()
+	go func() { defer wg.Done(); _ = f2.Flush(context.Background()) }()
+	wg.Wait()
+
+	// "hot": 3 (f1) + 2 (f2) = 5, last = the LATER timestamp.
+	if c, last := fs.get(tenant, scope, scopeID, "hot"); c != 5 || !last.Equal(late) {
+		t.Fatalf("hot: count=%d last=%v, want count=5 last=%v", c, last, late)
+	}
+	// "solo": only f1 touched it, once, at early.
+	if c, last := fs.get(tenant, scope, scopeID, "solo"); c != 1 || !last.Equal(early) {
+		t.Fatalf("solo: count=%d last=%v, want count=1 last=%v", c, last, early)
+	}
+}
+
+// A drained flusher must not re-emit already-flushed deltas (drain swaps the
+// pending map), so a second Flush with no new Records is a clean no-op.
+func TestAccessFlusher_FlushDrainsPending(t *testing.T) {
+	fs := newBumpRecorderStore()
+	f := NewAccessFlusher(fs, time.Hour, 1<<30)
+	now := time.Unix(1_700_000_000, 0).UTC()
+	f.Record("t", store.MemoryScopeUser, "u", "k", now)
+	if err := f.Flush(context.Background()); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	if err := f.Flush(context.Background()); err != nil { // no new records
+		t.Fatalf("second flush: %v", err)
+	}
+	if c, _ := fs.get("t", store.MemoryScopeUser, "u", "k"); c != 1 {
+		t.Fatalf("count = %d, want 1 (second flush must not double-apply)", c)
+	}
+}

--- a/internal/memory/access_test.go
+++ b/internal/memory/access_test.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -17,6 +18,7 @@ import (
 type bumpRecorderStore struct {
 	store.Store
 	mu    sync.Mutex
+	fail  bool                                 // when true, MemoryBumpAccessBatch errors (exercises the re-merge path)
 	count map[store.MemoryAccessBump]int64     // key fields only carry identity
 	last  map[store.MemoryAccessBump]time.Time // (delta/ts zeroed in the map key)
 }
@@ -35,6 +37,9 @@ func identity(b store.MemoryAccessBump) store.MemoryAccessBump {
 func (s *bumpRecorderStore) MemoryBumpAccessBatch(_ context.Context, bumps []store.MemoryAccessBump) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.fail {
+		return errors.New("injected bump-batch write failure")
+	}
 	for _, b := range bumps {
 		id := identity(b)
 		s.count[id] += b.CountDelta
@@ -110,5 +115,38 @@ func TestAccessFlusher_FlushDrainsPending(t *testing.T) {
 	}
 	if c, _ := fs.get("t", store.MemoryScopeUser, "u", "k"); c != 1 {
 		t.Fatalf("count = %d, want 1 (second flush must not double-apply)", c)
+	}
+}
+
+// Fix #3 (RFC BL PR2 review): a transient store write error must NOT lose the
+// drained window. drain() empties pending before the write, so on error the
+// bumps are re-merged and a later successful flush writes the FULL summed
+// total — not just whatever arrived after the failure.
+func TestAccessFlusher_FailedFlushReMergesForRetry(t *testing.T) {
+	fs := newBumpRecorderStore()
+	fs.fail = true
+	f := NewAccessFlusher(fs, time.Hour, 1<<30)
+	now := time.Unix(1_700_000_000, 0).UTC()
+
+	// Two accesses accumulate a delta of 2 before the (failing) flush.
+	f.Record("t", store.MemoryScopeUser, "u", "k", now)
+	f.Record("t", store.MemoryScopeUser, "u", "k", now)
+
+	if err := f.Flush(context.Background()); err == nil {
+		t.Fatal("expected an error from the failing store")
+	}
+	// Nothing was persisted on the failed write.
+	if c, _ := fs.get("t", store.MemoryScopeUser, "u", "k"); c != 0 {
+		t.Fatalf("failed flush must persist nothing, got count=%d", c)
+	}
+
+	// Let the store recover; the retry must write the full re-merged delta (2),
+	// proving the drained bumps were preserved rather than discarded.
+	fs.fail = false
+	if err := f.Flush(context.Background()); err != nil {
+		t.Fatalf("retry flush: %v", err)
+	}
+	if c, _ := fs.get("t", store.MemoryScopeUser, "u", "k"); c != 2 {
+		t.Fatalf("count = %d, want 2 (re-merged bumps must survive the failed flush)", c)
 	}
 }

--- a/internal/memory/backends/inprocess/inprocess.go
+++ b/internal/memory/backends/inprocess/inprocess.go
@@ -146,12 +146,14 @@ func (b *Backend) persistEmbedding(ctx context.Context, scope store.MemoryScope,
 	return b.store.MemoryEmbedSet(ctx, runTenant(ctx), scope, scopeID, key, emb)
 }
 
-// Search embeds the query, runs the vector + full-text retrieval legs, fuses
-// them via RRF, re-ranks (recency/frequency terms), dedups, trims to TopK, and
-// computes the index-aligned rank scores. RFC BL made this hybrid: the vector
-// pool is fused with the keyword (full-text) pool so a lexical-only match can
-// surface, while the default rank config still yields the underlying vector
-// order when the full-text leg is empty (SQLite, or no lexical match).
+// Search embeds the query, retrieves a candidate pool, re-ranks (recency/
+// frequency terms), dedups, trims to TopK, and computes the index-aligned rank
+// scores. RFC BL made retrieval hybrid BY DEFAULT wherever it can contribute:
+// when the store has a full-text index the vector pool is fused with the
+// keyword pool via RRF so a lexical-only match can surface. A pure-semantic
+// search with dedup off against a store WITHOUT full-text (e.g. sqlite-vec, or
+// Postgres without pgvector) takes the cheap pure-vector path instead — one
+// cosine call, no keyword round-trip, raw cosine ordering unchanged.
 func (b *Backend) Search(ctx context.Context, scope store.MemoryScope, scopeID string, q memory.SearchQuery, rank memory.RankConfig, dedup memory.DedupConfig) (memory.SearchResult, error) {
 	if !b.store.SupportsVectors() {
 		return memory.SearchResult{}, store.ErrVectorUnsupported
@@ -161,16 +163,6 @@ func (b *Backend) Search(ctx context.Context, scope store.MemoryScope, scopeID s
 	}
 
 	topK := q.TopK
-
-	// Over-fetch both legs. Hybrid fusion + dedup both need rows below the
-	// caller's top_k: RRF can promote a deeper vector row a lexical match
-	// co-ranks, and dedup collapsing a near-duplicate cluster must back-fill
-	// from below top_k. The pool is bounded by the store's defensive cap
-	// (<=51). The extra rows beyond top_k also serve as the truncation probe.
-	fetch := topK * 4
-	if fetch > 51 {
-		fetch = 51
-	}
 
 	// Embed the query text. Failures here are the embedder's problem —
 	// surface them directly so operators see exactly what went wrong.
@@ -185,38 +177,77 @@ func (b *Backend) Search(ctx context.Context, scope store.MemoryScope, scopeID s
 
 	tenant := runTenant(ctx)
 
-	// Leg 1: vector (cosine-ordered). Pass errors through unwrapped —
-	// ErrDimensionMismatch / ErrVectorUnsupported are user-actionable and the
-	// tool's errors.Is checks match the backend-constructed *MemoryError.
-	vres, err := b.store.MemoryEmbedSearch(ctx, tenant, scope, scopeID, q.Prefix, queryVec, fetch)
-	if err != nil {
-		return memory.SearchResult{}, err
+	// Hybrid (over-fetch + full-text leg + RRF) is the RFC BL default whenever
+	// it can contribute: the store HAS a full-text index, OR the caller's rank/
+	// dedup needs the deeper pool anyway (a non-pure-semantic rank re-scores
+	// rows below top_k; dedup must back-fill a collapsed cluster). Only a
+	// pure-semantic search with dedup off against a store WITHOUT full-text
+	// gains nothing from the keyword round-trip — take the cheap pure-vector
+	// path there (this restores the pre-PR2 zero-cost path for those backends).
+	//
+	// Gated on SupportsFullText, NOT SupportsVectors: SupportsVectors is a
+	// prerequisite already checked above, so it cannot distinguish a
+	// vector-capable store that lacks a full-text index (e.g. a future
+	// sqlite-vec build) — SupportsFullText is the precise capability.
+	// TODO(RFC BL): per-call/opsconfig hybrid opt-out if operators want it.
+	hybrid := b.store.SupportsFullText() || !rank.IsPureSemantic() || dedup.Enabled
+
+	var pool []store.MemorySearchEntry
+	if hybrid {
+		// Over-fetch both legs. RRF can promote a deeper vector row a lexical
+		// match co-ranks, and dedup collapsing a near-duplicate cluster must
+		// back-fill from below top_k. The pool is bounded by the store's
+		// defensive cap (<=51); the rows beyond top_k also probe truncation.
+		fetch := topK * 4
+		if fetch > 51 {
+			fetch = 51
+		}
+		// Leg 1: vector (cosine-ordered). Errors pass through unwrapped —
+		// ErrDimensionMismatch / ErrVectorUnsupported are user-actionable and
+		// the tool's errors.Is checks match the backend-constructed *MemoryError.
+		vres, verr := b.store.MemoryEmbedSearch(ctx, tenant, scope, scopeID, q.Prefix, queryVec, fetch)
+		if verr != nil {
+			return memory.SearchResult{}, verr
+		}
+		// Leg 2: full-text (keyword, ts_rank-ordered). (nil,nil) on a store
+		// without a full-text index, so the fusion collapses to pure-vector.
+		fres, ferr := b.store.MemoryFullTextSearch(ctx, tenant, scope, scopeID, q.Prefix, q.QueryText, fetch)
+		if ferr != nil {
+			return memory.SearchResult{}, ferr
+		}
+		// Fuse by RRF: SemanticScore := the fused rank (the ranker's semantic
+		// input); Score stays each row's raw cosine. With an empty full-text
+		// leg the union is the vector list and its order is preserved.
+		pool = memory.FuseRRF(vres, fres, memory.RRFDefaultK)
+	} else {
+		// Cheap pure-vector path: a single cosine call with a +1 truncation
+		// probe, no keyword round-trip. The semantic signal IS the raw cosine,
+		// so mirror Score into SemanticScore (the ranker reads that) and leave
+		// Score untouched for the tool to render.
+		fetch := topK + 1
+		if fetch > 51 {
+			fetch = 51
+		}
+		vres, verr := b.store.MemoryEmbedSearch(ctx, tenant, scope, scopeID, q.Prefix, queryVec, fetch)
+		if verr != nil {
+			return memory.SearchResult{}, verr
+		}
+		for i := range vres {
+			vres[i].SemanticScore = vres[i].Score
+		}
+		pool = vres
 	}
 
-	// Leg 2: full-text (keyword, ts_rank-ordered). Degrades to empty on
-	// backends without a full-text index (SQLite returns (nil,nil)), so the
-	// fusion below cleanly collapses to pure-vector there.
-	fres, err := b.store.MemoryFullTextSearch(ctx, tenant, scope, scopeID, q.Prefix, q.QueryText, fetch)
-	if err != nil {
-		return memory.SearchResult{}, err
-	}
+	// truncated: more distinct rows matched than the caller's top_k, computed
+	// before the trim.
+	truncated := len(pool) > topK
 
-	// Fuse the two legs by Reciprocal Rank Fusion. FuseRRF writes the fused
-	// value into each entry's Score, so the ranker/dedup/score pipeline below
-	// runs unchanged (it reads Score as the semantic signal). With an empty
-	// full-text leg the union is the vector list and its order is preserved.
-	fused := memory.FuseRRF(vres, fres, memory.RRFDefaultK)
-
-	// truncated: more distinct rows matched (across both legs) than the
-	// caller's top_k, computed before the trim.
-	truncated := len(fused) > topK
-
-	// Re-rank (recency/frequency layer on top of the fused rank), then dedup
-	// on the full pool BEFORE the trim (RFC I Decision 2) so collapsing a
+	// Re-rank (recency/frequency layer on top of the semantic signal), then
+	// dedup on the full pool BEFORE the trim (RFC I Decision 2) so collapsing a
 	// duplicate cluster can promote a distinct entry into the top_k. rank
 	// scores use the SAME `now` as the ranking so the rendered score matches.
 	now := time.Now()
-	ranked := memory.RankCandidates(fused, rank, now)
+	ranked := memory.RankCandidates(pool, rank, now)
 	deduped, dropped := memory.DedupResults(ranked, dedup)
 	if len(deduped) > topK {
 		deduped = deduped[:topK]

--- a/internal/memory/backends/inprocess/inprocess.go
+++ b/internal/memory/backends/inprocess/inprocess.go
@@ -36,6 +36,10 @@ func runTenant(ctx context.Context) string { return tools.RunIdentity(ctx).Tenan
 type Backend struct {
 	store    store.Store
 	embedder providers.Embedder
+	// accessFlusher, when set, records a +1 access for each entry a search
+	// returns (RFC BL hybrid retrieval, OQ #4). nil in tests and when the
+	// server didn't wire it — searches then simply skip access tracking.
+	accessFlusher *memory.AccessFlusher
 }
 
 // New builds the in-process backend. Either argument may be nil at the
@@ -45,6 +49,11 @@ type Backend struct {
 func New(s store.Store, e providers.Embedder) *Backend {
 	return &Backend{store: s, embedder: e}
 }
+
+// SetAccessFlusher wires the batched access-count flusher (RFC BL). Optional;
+// when unset, Search does no access tracking. main wires exactly one flusher
+// shared across the tool's default backend.
+func (b *Backend) SetAccessFlusher(f *memory.AccessFlusher) { b.accessFlusher = f }
 
 // Get delegates to the store.
 func (b *Backend) Get(ctx context.Context, scope store.MemoryScope, scopeID, key string) (store.MemoryEntry, error) {
@@ -137,11 +146,12 @@ func (b *Backend) persistEmbedding(ctx context.Context, scope store.MemoryScope,
 	return b.store.MemoryEmbedSet(ctx, runTenant(ctx), scope, scopeID, key, emb)
 }
 
-// Search embeds the query, fetches the cosine pool (with the over-fetch a
-// hybrid rank needs + a truncation probe), re-ranks via the MR-1 ranker,
-// trims to TopK, and computes the index-aligned rank scores. This is
-// execSearch's data path moved verbatim; the tool keeps validation,
-// top_k clamping, and rendering.
+// Search embeds the query, runs the vector + full-text retrieval legs, fuses
+// them via RRF, re-ranks (recency/frequency terms), dedups, trims to TopK, and
+// computes the index-aligned rank scores. RFC BL made this hybrid: the vector
+// pool is fused with the keyword (full-text) pool so a lexical-only match can
+// surface, while the default rank config still yields the underlying vector
+// order when the full-text leg is empty (SQLite, or no lexical match).
 func (b *Backend) Search(ctx context.Context, scope store.MemoryScope, scopeID string, q memory.SearchQuery, rank memory.RankConfig, dedup memory.DedupConfig) (memory.SearchResult, error) {
 	if !b.store.SupportsVectors() {
 		return memory.SearchResult{}, store.ErrVectorUnsupported
@@ -152,18 +162,12 @@ func (b *Backend) Search(ctx context.Context, scope store.MemoryScope, scopeID s
 
 	topK := q.TopK
 
-	// RFC I hybrid ranking. Pure-semantic config = today's behavior (zero
-	// regression). We over-fetch a candidate pool by cosine when EITHER a
-	// hybrid rank needs to re-score deeper rows (recency promoting an entry
-	// the pure-cosine top-K would miss) OR dedup is enabled (collapsing a
-	// near-duplicate cluster must back-fill from rows below top_k, else the
-	// agent silently gets fewer than top_k results). The pool is bounded by
-	// the store's defensive cap (<=51).
-	pool := topK
-	if !rank.IsPureSemantic() || dedup.Enabled {
-		pool = topK * 4
-	}
-	fetch := pool + 1 // +1 truncation probe
+	// Over-fetch both legs. Hybrid fusion + dedup both need rows below the
+	// caller's top_k: RRF can promote a deeper vector row a lexical match
+	// co-ranks, and dedup collapsing a near-duplicate cluster must back-fill
+	// from below top_k. The pool is bounded by the store's defensive cap
+	// (<=51). The extra rows beyond top_k also serve as the truncation probe.
+	fetch := topK * 4
 	if fetch > 51 {
 		fetch = 51
 	}
@@ -179,38 +183,55 @@ func (b *Backend) Search(ctx context.Context, scope store.MemoryScope, scopeID s
 	}
 	queryVec := vecs[0]
 
-	// Fetch the candidate pool (cosine-ordered) with a +1 truncation probe:
-	// len(results) > topK distinguishes "more matched than we return" from
-	// "result set fits". Store caps at 51.
-	results, err := b.store.MemoryEmbedSearch(ctx, runTenant(ctx), scope, scopeID, q.Prefix, queryVec, fetch)
+	tenant := runTenant(ctx)
+
+	// Leg 1: vector (cosine-ordered). Pass errors through unwrapped —
+	// ErrDimensionMismatch / ErrVectorUnsupported are user-actionable and the
+	// tool's errors.Is checks match the backend-constructed *MemoryError.
+	vres, err := b.store.MemoryEmbedSearch(ctx, tenant, scope, scopeID, q.Prefix, queryVec, fetch)
 	if err != nil {
-		// Pass the error through unwrapped. ErrDimensionMismatch /
-		// ErrVectorUnsupported are user-actionable: the tool's errors.Is
-		// checks match the backend-constructed *MemoryError values (via
-		// MemoryError.Is) and render the migration hint. Other errors are
-		// surfaced by the tool with a generic "search:" prefix.
 		return memory.SearchResult{}, err
 	}
 
-	// truncated reflects the cosine pool (more matched than the caller's
-	// top_k), computed before the re-rank trims the pool.
-	truncated := len(results) > topK
+	// Leg 2: full-text (keyword, ts_rank-ordered). Degrades to empty on
+	// backends without a full-text index (SQLite returns (nil,nil)), so the
+	// fusion below cleanly collapses to pure-vector there.
+	fres, err := b.store.MemoryFullTextSearch(ctx, tenant, scope, scopeID, q.Prefix, q.QueryText, fetch)
+	if err != nil {
+		return memory.SearchResult{}, err
+	}
 
-	// Hybrid re-rank, then dedup, then trim to top_k. Default config is a
-	// no-op reorder (cosine order preserved) and dedup-disabled, so
-	// pure-semantic output is byte-identical to before. Dedup runs on the
-	// full ranked pool BEFORE the trim (RFC I Decision 2) so collapsing a
-	// duplicate cluster can promote a distinct entry into the top_k that the
-	// duplicate would otherwise have crowded out. rank_scores are computed
-	// with the SAME `now` as the ranking so the rendered score matches the
-	// ordering.
+	// Fuse the two legs by Reciprocal Rank Fusion. FuseRRF writes the fused
+	// value into each entry's Score, so the ranker/dedup/score pipeline below
+	// runs unchanged (it reads Score as the semantic signal). With an empty
+	// full-text leg the union is the vector list and its order is preserved.
+	fused := memory.FuseRRF(vres, fres, memory.RRFDefaultK)
+
+	// truncated: more distinct rows matched (across both legs) than the
+	// caller's top_k, computed before the trim.
+	truncated := len(fused) > topK
+
+	// Re-rank (recency/frequency layer on top of the fused rank), then dedup
+	// on the full pool BEFORE the trim (RFC I Decision 2) so collapsing a
+	// duplicate cluster can promote a distinct entry into the top_k. rank
+	// scores use the SAME `now` as the ranking so the rendered score matches.
 	now := time.Now()
-	ranked := memory.RankCandidates(results, rank, now)
+	ranked := memory.RankCandidates(fused, rank, now)
 	deduped, dropped := memory.DedupResults(ranked, dedup)
 	if len(deduped) > topK {
 		deduped = deduped[:topK]
 	}
 	rankScores := memory.ScoreAll(deduped, rank, now)
+
+	// Record a +1 access for the returned entries (batched, off the hot path
+	// — the flusher writes them later). Only when wired; access tracking is
+	// main-store memory only.
+	if b.accessFlusher != nil {
+		at := now.UTC()
+		for i := range deduped {
+			b.accessFlusher.Record(tenant, scope, scopeID, deduped[i].Key, at)
+		}
+	}
 
 	out := memory.SearchResult{
 		Entries:           deduped,
@@ -219,8 +240,8 @@ func (b *Backend) Search(ctx context.Context, scope store.MemoryScope, scopeID s
 		Truncated:         truncated,
 		DedupDropped:      dropped,
 	}
-	if rank.SourceFrequencyReserved() {
-		out.RankNote = "source_weight and frequency_weight are reserved and contribute 0 until source/access_count tracking ships"
+	if rank.SourceReserved() {
+		out.RankNote = "source_weight is reserved and contributes 0 until source-score tracking ships"
 	}
 	return out, nil
 }

--- a/internal/memory/backends/mem9/mem9.go
+++ b/internal/memory/backends/mem9/mem9.go
@@ -171,13 +171,15 @@ type wireStatsResponse struct {
 
 // toSearchEntry maps one assumed wire result onto loomcycle's domain
 // store.MemorySearchEntry. The Score is taken as cosine similarity so the
-// MR-1 ranker (which expects e.Score ∈ [0,1]) operates uniformly across
-// backends.
+// MR-1 ranker operates uniformly across backends. Mem9 doesn't fuse, so the
+// semantic signal the ranker scales (SemanticScore) is the same cosine —
+// set both from w.Score (RFC BL split Score/SemanticScore; without this the
+// ranker would read a zero SemanticScore and collapse every rank_score).
 //
 // ASSUMED Mem9 wire shape — verify against the real
 // github.com/mem9-ai/mem9 v1alpha2 API before production.
 func toSearchEntry(w wireSearchResult) store.MemorySearchEntry {
-	e := store.MemorySearchEntry{Score: w.Score}
+	e := store.MemorySearchEntry{Score: w.Score, SemanticScore: w.Score}
 	e.Key = w.Key
 	e.Value = w.Value
 	e.ExpiresAt = parseWireTime(w.ExpiresAt)

--- a/internal/memory/rank.go
+++ b/internal/memory/rank.go
@@ -22,9 +22,11 @@ import (
 //
 // semantic_signal was raw cosine similarity before RFC BL hybrid retrieval.
 // Post-hybrid, the in-process backend fuses the vector + full-text legs by
-// Reciprocal Rank Fusion first (see FuseRRF) and writes the fused RRF value
-// into each candidate's Score, so semantic_weight then scales that fused
-// rank signal. Backends that don't fuse (Mem9) still pass raw cosine here.
+// Reciprocal Rank Fusion first (see FuseRRF) and carries the fused RRF value
+// in each candidate's SemanticScore, so semantic_weight then scales that
+// fused rank signal. The raw cosine stays in Score (the field the Memory tool
+// renders) and is never overwritten. Backends that don't fuse (Mem9, and the
+// in-process pure-vector fast path) set SemanticScore to the raw cosine.
 //
 // The DEFAULT (semantic=1, all others=0) keeps ordering equal to the
 // underlying retrieval order — operators who don't pass a `rank` block see
@@ -96,11 +98,12 @@ func recencyDecay(createdAt, now time.Time, halfLifeHours float64) float64 {
 	return math.Exp(-ageHours * math.Ln2 / halfLifeHours)
 }
 
-// Score computes the hybrid score for one search candidate. e.Score is the
-// semantic signal — raw cosine for a non-fused backend, or the fused RRF
-// value after FuseRRF has run. See RankConfig for the term weights.
+// Score computes the hybrid score for one search candidate. e.SemanticScore is
+// the semantic signal — raw cosine for a non-fused/pure-vector path, or the
+// fused RRF value after FuseRRF has run; e.Score (raw cosine, rendered by the
+// tool) is deliberately NOT read here. See RankConfig for the term weights.
 func Score(e store.MemorySearchEntry, cfg RankConfig, now time.Time) float64 {
-	s := cfg.SemanticWeight * e.Score
+	s := cfg.SemanticWeight * e.SemanticScore
 	if cfg.RecencyWeight != 0 {
 		s += cfg.RecencyWeight * recencyDecay(e.CreatedAt, now, cfg.RecencyHalfLifeHours)
 	}
@@ -165,17 +168,21 @@ const RRFDefaultK = 60
 // single ranked list via Reciprocal Rank Fusion (RFC BL hybrid retrieval).
 // Each input list MUST be pre-sorted best-first (the store legs are). The
 // returned slice is the UNION keyed by entry Key (unique within a scope),
-// sorted by descending fused score, with each entry's Score REPLACED by its
+// sorted by descending fused score, with each entry's SemanticScore set to its
 // RRF value:  Σ_over-lists-containing-it  1/(k + rank_in_list).
 //
-// Writing the fused value into Score is deliberate: downstream ranking
-// (RankCandidates / Score / ScoreAll) reads Score as the semantic signal, so
-// the recency and frequency terms layer on top of the fused rank exactly as
-// they did on raw cosine before hybrid retrieval — no second code path.
+// The fused value goes into SemanticScore, NOT Score: downstream ranking
+// (RankCandidates / Score / ScoreAll) reads SemanticScore as the semantic
+// signal, so the recency and frequency terms layer on top of the fused rank
+// with no second code path — while Score is left untouched (the raw vector-leg
+// cosine the Memory tool renders as the stable, documented `score` field). A
+// full-text-only hit that never appeared in the vector leg keeps whatever
+// Score its full-text row carried (its natural relevance value); we do NOT
+// fabricate a cosine for it.
 //
 // The vector list is added first, so for an entry present in BOTH legs the
-// vector copy is authoritative for the non-Score fields (its stored Vector,
-// needed for dedup; EmbeddedWith; AccessCount) while still accruing the
+// vector copy is authoritative for its fields (Score = its cosine; the stored
+// Vector, needed for dedup; EmbeddedWith; AccessCount) while still accruing the
 // full-text leg's rank contribution. When the full-text list is empty
 // (SQLite, or a query with no lexical match) the union is exactly the vector
 // list and RRF preserves its order, so pure-vector retrieval still works.
@@ -217,7 +224,9 @@ func FuseRRF(vector, fulltext []store.MemorySearchEntry, k int) []store.MemorySe
 	out := make([]store.MemorySearchEntry, len(accs))
 	for i := range accs {
 		out[i] = accs[i].entry
-		out[i].Score = accs[i].rrf
+		// Carry the fused rank as the semantic signal; leave Score (raw cosine)
+		// intact so the tool still renders the documented-stable `score` field.
+		out[i].SemanticScore = accs[i].rrf
 	}
 	return out
 }

--- a/internal/memory/rank.go
+++ b/internal/memory/rank.go
@@ -15,22 +15,29 @@ import (
 // RankConfig is the per-search hybrid-ranking weight block (RFC I
 // Decision 1). The score of a candidate is:
 //
-//	score = semantic_weight · cos_sim
+//	score = semantic_weight · semantic_signal
 //	      + recency_weight  · exp(-Δt·ln2 / recency_half_life_hours)
 //	      + source_weight   · source_score
 //	      + frequency_weight· log(1 + access_count)
 //
-// The DEFAULT (semantic=1, all others=0) reproduces today's pure-cosine
-// ordering exactly — operators who don't pass a `rank` block see no
-// behavior change and no migration.
+// semantic_signal was raw cosine similarity before RFC BL hybrid retrieval.
+// Post-hybrid, the in-process backend fuses the vector + full-text legs by
+// Reciprocal Rank Fusion first (see FuseRRF) and writes the fused RRF value
+// into each candidate's Score, so semantic_weight then scales that fused
+// rank signal. Backends that don't fuse (Mem9) still pass raw cosine here.
 //
-// Reserved (no-op today): source_weight and frequency_weight are part of
-// the locked wire shape, but the in-process memory entry carries no
-// `source` or `access_count` field yet, so those two terms contribute 0
-// until that tracking lands in a later slice. They are accepted (not
-// rejected) so the wire shape is forward-stable; SourceFrequencyReserved
-// lets the caller surface a note rather than silently ignoring a non-zero
-// weight.
+// The DEFAULT (semantic=1, all others=0) keeps ordering equal to the
+// underlying retrieval order — operators who don't pass a `rank` block see
+// no re-rank and no migration.
+//
+// frequency_weight (RFC BL): now WIRED — access_count rides on each search
+// entry (PR1 added the column; the search legs populate it), so a
+// frequently-recalled entry is rewarded. source_weight stays RESERVED (it
+// contributes 0): P1 exposes no numeric source_score — origin/class are
+// categorical provenance with no ranking semantics until consolidation (P2)
+// defines curated origins. It is accepted (not rejected) so the wire shape
+// is forward-stable; SourceReserved lets the caller surface a note rather
+// than silently ignoring a non-zero source_weight.
 type RankConfig struct {
 	SemanticWeight       float64 `json:"semantic_weight"`
 	RecencyWeight        float64 `json:"recency_weight"`
@@ -58,12 +65,20 @@ func (c RankConfig) IsPureSemantic() bool {
 	return c.SemanticWeight > 0 && c.RecencyWeight == 0 && c.SourceWeight == 0 && c.FrequencyWeight == 0
 }
 
-// SourceFrequencyReserved reports whether the caller set a non-zero
-// source or frequency weight — terms that are reserved but contribute 0
-// today. The Memory tool surfaces this as a note so the weight isn't
-// silently ignored.
+// SourceFrequencyReserved reports whether the caller set a non-zero source
+// OR frequency weight. Retained for backends where BOTH remain no-ops — the
+// Mem9 REST backend returns entries with no access_count, so its
+// frequency_weight contributes 0 just like source_weight. The in-process
+// backend, which now populates access_count, uses SourceReserved instead.
 func (c RankConfig) SourceFrequencyReserved() bool {
 	return c.SourceWeight != 0 || c.FrequencyWeight != 0
+}
+
+// SourceReserved reports whether the caller set a non-zero source_weight —
+// the one term still reserved after RFC BL wired frequency_weight. The
+// Memory tool surfaces this as a note so the weight isn't silently ignored.
+func (c RankConfig) SourceReserved() bool {
+	return c.SourceWeight != 0
 }
 
 // recencyDecay is exp(-age·ln2/halfLife): 1.0 at age 0, 0.5 at one
@@ -82,15 +97,22 @@ func recencyDecay(createdAt, now time.Time, halfLifeHours float64) float64 {
 }
 
 // Score computes the hybrid score for one search candidate. e.Score is the
-// store's cosine similarity in [0,1]. See RankConfig for the reserved
-// source/frequency terms (0 today).
+// semantic signal — raw cosine for a non-fused backend, or the fused RRF
+// value after FuseRRF has run. See RankConfig for the term weights.
 func Score(e store.MemorySearchEntry, cfg RankConfig, now time.Time) float64 {
 	s := cfg.SemanticWeight * e.Score
 	if cfg.RecencyWeight != 0 {
 		s += cfg.RecencyWeight * recencyDecay(e.CreatedAt, now, cfg.RecencyHalfLifeHours)
 	}
-	// source_weight · source_score and frequency_weight · log(1+access_count)
-	// are reserved: no source/access_count on the entry yet → contribute 0.
+	if cfg.FrequencyWeight != 0 {
+		// log1p keeps the term sub-linear so a runaway access_count can't
+		// dominate the semantic signal; a never-accessed entry (count 0)
+		// contributes exactly 0 (log1p(0)=0), so the term is inert unless
+		// both the weight AND real access history are present.
+		s += cfg.FrequencyWeight * math.Log1p(float64(e.AccessCount))
+	}
+	// source_weight · source_score is reserved: P1 has no numeric
+	// source_score signal (see RankConfig), so it contributes 0.
 	return s
 }
 
@@ -129,6 +151,73 @@ func ScoreAll(candidates []store.MemorySearchEntry, cfg RankConfig, now time.Tim
 	out := make([]float64, len(candidates))
 	for i := range candidates {
 		out[i] = Score(candidates[i], cfg, now)
+	}
+	return out
+}
+
+// RRFDefaultK is the Reciprocal Rank Fusion constant (Cormack et al., 2009):
+// score contribution for a list where an item sits at 0-based rank r is
+// 1/(k+r). Larger k flattens the head so no single leg dominates; 60 is the
+// widely-used default and behaves well without per-corpus tuning.
+const RRFDefaultK = 60
+
+// FuseRRF fuses the vector-ranked and full-text-ranked candidate lists into a
+// single ranked list via Reciprocal Rank Fusion (RFC BL hybrid retrieval).
+// Each input list MUST be pre-sorted best-first (the store legs are). The
+// returned slice is the UNION keyed by entry Key (unique within a scope),
+// sorted by descending fused score, with each entry's Score REPLACED by its
+// RRF value:  Σ_over-lists-containing-it  1/(k + rank_in_list).
+//
+// Writing the fused value into Score is deliberate: downstream ranking
+// (RankCandidates / Score / ScoreAll) reads Score as the semantic signal, so
+// the recency and frequency terms layer on top of the fused rank exactly as
+// they did on raw cosine before hybrid retrieval — no second code path.
+//
+// The vector list is added first, so for an entry present in BOTH legs the
+// vector copy is authoritative for the non-Score fields (its stored Vector,
+// needed for dedup; EmbeddedWith; AccessCount) while still accruing the
+// full-text leg's rank contribution. When the full-text list is empty
+// (SQLite, or a query with no lexical match) the union is exactly the vector
+// list and RRF preserves its order, so pure-vector retrieval still works.
+//
+// k <= 0 falls back to RRFDefaultK. The input slices are not mutated.
+func FuseRRF(vector, fulltext []store.MemorySearchEntry, k int) []store.MemorySearchEntry {
+	if k <= 0 {
+		k = RRFDefaultK
+	}
+	type acc struct {
+		entry store.MemorySearchEntry
+		rrf   float64
+		order int // first-seen order, for a stable tie-break
+	}
+	idx := make(map[string]int, len(vector)+len(fulltext))
+	accs := make([]acc, 0, len(vector)+len(fulltext))
+	add := func(list []store.MemorySearchEntry) {
+		for rank, e := range list {
+			contrib := 1.0 / float64(k+rank)
+			if i, ok := idx[e.Key]; ok {
+				accs[i].rrf += contrib
+				continue
+			}
+			idx[e.Key] = len(accs)
+			accs = append(accs, acc{entry: e, rrf: contrib, order: len(accs)})
+		}
+	}
+	add(vector) // first → authoritative for shared entries' fields
+	add(fulltext)
+
+	// Stable by first-seen order on equal fused score: the vector leg is
+	// added first, so ties resolve toward the vector ordering.
+	sort.SliceStable(accs, func(a, b int) bool {
+		if accs[a].rrf != accs[b].rrf {
+			return accs[a].rrf > accs[b].rrf
+		}
+		return accs[a].order < accs[b].order
+	})
+	out := make([]store.MemorySearchEntry, len(accs))
+	for i := range accs {
+		out[i] = accs[i].entry
+		out[i].Score = accs[i].rrf
 	}
 	return out
 }

--- a/internal/memory/rank_test.go
+++ b/internal/memory/rank_test.go
@@ -89,6 +89,49 @@ func TestRankConfig_PureSemanticAndReservedFlags(t *testing.T) {
 	}
 }
 
+// RFC BL wired frequency_weight to access_count: with a non-zero
+// frequency_weight, a more-frequently-accessed entry outranks an
+// equally-similar one that's been accessed less.
+func TestRank_FrequencyWeightAffectsOrder(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	hot := entry("hot", 0.5, 0, now)   // same similarity …
+	cold := entry("cold", 0.5, 0, now) // … but different access history
+	hot.AccessCount = 100
+	cold.AccessCount = 0
+
+	cfg := RankConfig{SemanticWeight: 1.0, FrequencyWeight: 0.1}
+
+	// Feed cold-first to prove the reorder is driven by frequency, not input
+	// order.
+	out := RankCandidates([]store.MemorySearchEntry{cold, hot}, cfg, now)
+	if out[0].Key != "hot" {
+		t.Fatalf("frequency weight did not promote the hot entry: got order %s,%s", out[0].Key, out[1].Key)
+	}
+	// And directly: the frequency term lifts the score above the equal
+	// semantic baseline.
+	if Score(hot, cfg, now) <= Score(cold, cfg, now) {
+		t.Fatalf("hot score %v must exceed cold score %v", Score(hot, cfg, now), Score(cold, cfg, now))
+	}
+	// A zero frequency_weight is inert (no reorder, no score change).
+	zero := RankConfig{SemanticWeight: 1.0}
+	if Score(hot, zero, now) != Score(cold, zero, now) {
+		t.Fatalf("frequency_weight=0 must not change scores: %v vs %v", Score(hot, zero, now), Score(cold, zero, now))
+	}
+}
+
+// SourceReserved flags only source_weight now that frequency_weight is wired.
+func TestRankConfig_SourceReservedFlag(t *testing.T) {
+	if !(RankConfig{SemanticWeight: 1, SourceWeight: 0.3}).SourceReserved() {
+		t.Error("source weight set should flag SourceReserved")
+	}
+	if (RankConfig{SemanticWeight: 1, FrequencyWeight: 0.2}).SourceReserved() {
+		t.Error("frequency weight is wired — must NOT flag SourceReserved")
+	}
+	if DefaultRankConfig().SourceReserved() {
+		t.Error("default config should not flag SourceReserved")
+	}
+}
+
 // Stable sort: equal hybrid scores keep input (cosine) order.
 func TestRankCandidates_StableOnTies(t *testing.T) {
 	now := time.Unix(1_700_000_000, 0)

--- a/internal/memory/rank_test.go
+++ b/internal/memory/rank_test.go
@@ -11,6 +11,11 @@ func entry(key string, score float64, ageHours float64, now time.Time) store.Mem
 	var e store.MemorySearchEntry
 	e.Key = key
 	e.Score = score
+	// The unit ranker reads SemanticScore, not Score (RFC BL split the raw-cosine
+	// display value from the ranker's semantic input). For these tests the
+	// semantic signal IS the cosine, so seed both; FuseRRF overrides
+	// SemanticScore with the fused rank in the hybrid tests.
+	e.SemanticScore = score
 	e.CreatedAt = now.Add(-time.Duration(ageHours) * time.Hour)
 	return e
 }

--- a/internal/memory/rrf_test.go
+++ b/internal/memory/rrf_test.go
@@ -1,0 +1,72 @@
+package memory
+
+import (
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// A keyword-only match — an entry the vector leg ranks LAST — must surface via
+// the full-text leg after Reciprocal Rank Fusion. This is the core hybrid
+// guarantee: a lexical hit a pure-vector top-K would drop is promoted by RRF.
+func TestSearch_RRFSurfacesKeywordOnlyMatch(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	// Vector leg (cosine order, best-first): D is the WORST match (last).
+	vector := []store.MemorySearchEntry{
+		entry("A", 0.90, 0, now),
+		entry("B", 0.80, 0, now),
+		entry("C", 0.70, 0, now),
+		entry("D", 0.10, 0, now), // vector rank 3 → outside a top-2 cut
+	}
+	// Full-text leg: D is the single lexical match (keyword rank 0).
+	fulltext := []store.MemorySearchEntry{
+		entry("D", 0, 0, now),
+	}
+
+	// Sanity: pure-vector top-2 would be [A, B] — D is excluded.
+	if vector[0].Key != "A" || vector[1].Key != "B" {
+		t.Fatalf("fixture: expected pure-vector top-2 A,B, got %s,%s", vector[0].Key, vector[1].Key)
+	}
+
+	fused := FuseRRF(vector, fulltext, RRFDefaultK)
+	if len(fused) != 4 {
+		t.Fatalf("fused union size = %d, want 4 (A,B,C,D)", len(fused))
+	}
+	// D appears in BOTH legs, so its RRF sums 1/(k+3)+1/(k+0) and it leaps to
+	// the top — proving the keyword-only match surfaced past the vector head.
+	if fused[0].Key != "D" {
+		t.Fatalf("keyword-only match did not surface: fused order = %s,%s,%s,%s",
+			fused[0].Key, fused[1].Key, fused[2].Key, fused[3].Key)
+	}
+	// It must land within a top-2 cut (which pure vector denied it).
+	if fused[0].Key != "D" && fused[1].Key != "D" {
+		t.Fatalf("D not in fused top-2: %s,%s", fused[0].Key, fused[1].Key)
+	}
+}
+
+// With an empty full-text leg (SQLite, or no lexical match) the union is
+// exactly the vector list and RRF preserves its order — pure-vector retrieval
+// still works, and the fused Score decreases monotonically with vector rank.
+func TestFuseRRF_EmptyFullTextPreservesVectorOrder(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	vector := []store.MemorySearchEntry{
+		entry("a", 0.9, 0, now),
+		entry("b", 0.8, 0, now),
+		entry("c", 0.7, 0, now),
+	}
+	fused := FuseRRF(vector, nil, RRFDefaultK)
+	if len(fused) != 3 {
+		t.Fatalf("fused size = %d, want 3", len(fused))
+	}
+	want := []string{"a", "b", "c"}
+	for i, w := range want {
+		if fused[i].Key != w {
+			t.Fatalf("order[%d] = %s, want %s (vector order not preserved)", i, fused[i].Key, w)
+		}
+	}
+	// RRF scores strictly decrease with rank.
+	if !(fused[0].Score > fused[1].Score && fused[1].Score > fused[2].Score) {
+		t.Fatalf("fused scores not strictly descending: %v %v %v", fused[0].Score, fused[1].Score, fused[2].Score)
+	}
+}

--- a/internal/memory/rrf_test.go
+++ b/internal/memory/rrf_test.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -65,8 +66,51 @@ func TestFuseRRF_EmptyFullTextPreservesVectorOrder(t *testing.T) {
 			t.Fatalf("order[%d] = %s, want %s (vector order not preserved)", i, fused[i].Key, w)
 		}
 	}
-	// RRF scores strictly decrease with rank.
-	if !(fused[0].Score > fused[1].Score && fused[1].Score > fused[2].Score) {
-		t.Fatalf("fused scores not strictly descending: %v %v %v", fused[0].Score, fused[1].Score, fused[2].Score)
+	// The fused RRF signal (SemanticScore) strictly decreases with rank; Score
+	// stays the raw cosine (not the RRF value), so assert on SemanticScore.
+	if !(fused[0].SemanticScore > fused[1].SemanticScore && fused[1].SemanticScore > fused[2].SemanticScore) {
+		t.Fatalf("fused SemanticScore not strictly descending: %v %v %v",
+			fused[0].SemanticScore, fused[1].SemanticScore, fused[2].SemanticScore)
+	}
+}
+
+// Fix #1 (RFC BL PR2 review): RRF fusion must NOT clobber the raw-cosine Score
+// the Memory tool renders — the fused rank rides SemanticScore instead. Assert
+// each fused entry's Score stays ≈ its vector-leg cosine while the ORDER
+// reflects the RRF fusion (a keyword-only hit is promoted past its vector rank).
+func TestFuseRRF_PreservesRawCosineScore(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	// Vector leg (cosine order): C is the WORST vector match (last).
+	vector := []store.MemorySearchEntry{
+		entry("A", 0.90, 0, now),
+		entry("B", 0.80, 0, now),
+		entry("C", 0.10, 0, now),
+	}
+	// Full-text leg: C is the sole lexical hit (keyword rank 0) — its RRF sums
+	// across both legs and should lift it to the top.
+	fulltext := []store.MemorySearchEntry{
+		entry("C", 0.0, 0, now),
+	}
+
+	fused := FuseRRF(vector, fulltext, RRFDefaultK)
+
+	// Score stays the raw vector cosine for every entry present in the vector
+	// leg — fusion must not overwrite it with the ~1/60 RRF value.
+	wantCosine := map[string]float64{"A": 0.90, "B": 0.80, "C": 0.10}
+	for _, e := range fused {
+		if got := wantCosine[e.Key]; math.Abs(e.Score-got) > 1e-9 {
+			t.Errorf("entry %s: score = %v, want raw cosine %v (fusion clobbered Score)", e.Key, e.Score, got)
+		}
+		// The fused semantic signal lives in SemanticScore: a small positive RRF
+		// value (≈1/(k+rank)), clearly distinct from the cosine in Score.
+		if e.SemanticScore <= 0 || e.SemanticScore > 0.5 {
+			t.Errorf("entry %s: SemanticScore = %v, want a small positive RRF value", e.Key, e.SemanticScore)
+		}
+	}
+	// Order reflects RRF: C, the keyword-only hit, is promoted above its
+	// last-place vector rank because it co-ranks in both legs.
+	if fused[0].Key != "C" {
+		t.Fatalf("RRF did not promote the keyword-only hit: order = %s,%s,%s",
+			fused[0].Key, fused[1].Key, fused[2].Key)
 	}
 }

--- a/internal/store/postgres/memory_embeddings.go
+++ b/internal/store/postgres/memory_embeddings.go
@@ -174,7 +174,8 @@ func (s *Store) MemoryEmbedSearch(ctx context.Context, tenantID string, scope st
 	}
 	sql := `SELECT me.key, m.value, m.expires_at, m.created_at, m.updated_at,
 	               1.0 - (me.embedding <=> $4::vector) AS score,
-	               me.provider, me.model, me.embedding::text AS embedding_text
+	               me.provider, me.model, me.embedding::text AS embedding_text,
+	               m.access_count
 	         FROM memory_embeddings me
 	         JOIN memory m
 	            ON me.tenant_id = m.tenant_id
@@ -204,8 +205,9 @@ func (s *Store) MemoryEmbedSearch(ctx context.Context, tenantID string, scope st
 			score              float64
 			provider, modelStr string
 			embeddingText      string
+			accessCount        int64
 		)
-		if err := rows.Scan(&key, &valueBytes, &expiresAt, &createdAt, &updatedAt, &score, &provider, &modelStr, &embeddingText); err != nil {
+		if err := rows.Scan(&key, &valueBytes, &expiresAt, &createdAt, &updatedAt, &score, &provider, &modelStr, &embeddingText, &accessCount); err != nil {
 			return nil, fmt.Errorf("MemoryEmbedSearch scan: %w", err)
 		}
 		entry := store.MemorySearchEntry{
@@ -215,7 +217,8 @@ func (s *Store) MemoryEmbedSearch(ctx context.Context, tenantID string, scope st
 				CreatedAt: createdAt,
 				UpdatedAt: updatedAt,
 			},
-			Score: score,
+			Score:       score,
+			AccessCount: accessCount,
 		}
 		if expiresAt != nil {
 			entry.ExpiresAt = *expiresAt
@@ -236,6 +239,135 @@ func (s *Store) MemoryEmbedSearch(ctx context.Context, tenantID string, scope st
 		return nil, fmt.Errorf("MemoryEmbedSearch iter: %w", err)
 	}
 	return out, nil
+}
+
+// MemoryFullTextSearch runs the keyword (lexical) retrieval leg over the
+// generated tsvector on memory_embeddings.embed_text (migration 0060),
+// ranked by ts_rank. Same result shape + tenant/prefix/expiry scoping as
+// MemoryEmbedSearch. The in-process backend fuses this ordering with the
+// vector ordering via RRF (rank-based), so ts_rank's magnitude — which is
+// not comparable to cosine — only serves to ORDER this leg.
+//
+// Without pgvector the memory_embeddings table (hence the tsvector column)
+// doesn't exist, so we degrade to (nil, nil) rather than erroring; the
+// caller then runs pure-vector, which is itself unavailable without
+// pgvector, so this path is effectively Postgres+pgvector only.
+func (s *Store) MemoryFullTextSearch(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, keyPrefix, queryText string, topK int) ([]store.MemorySearchEntry, error) {
+	if !s.pgvectorEnabled {
+		return nil, nil
+	}
+	if topK <= 0 {
+		topK = 10
+	}
+	// Match MemoryEmbedSearch's defensive cap so the +1 truncation probe at
+	// the tool boundary still returns the extra row.
+	if topK > 51 {
+		topK = 51
+	}
+
+	prefixCondition := ""
+	args := []any{tenantID, string(scope), scopeID, queryText, topK}
+	if keyPrefix != "" {
+		prefixCondition = " AND me.key LIKE $6"
+		args = append(args, keyPrefix+"%")
+	}
+	// plainto_tsquery normalises arbitrary user text into a safe tsquery
+	// (never errors on input, no injection surface), returning the empty
+	// query — which matches nothing — when the text yields no lexemes.
+	sql := `SELECT me.key, m.value, m.expires_at, m.created_at, m.updated_at,
+	               ts_rank(me.embed_text_tsv, plainto_tsquery('english', $4)) AS score,
+	               me.provider, me.model, me.embedding::text AS embedding_text,
+	               m.access_count
+	         FROM memory_embeddings me
+	         JOIN memory m
+	            ON me.tenant_id = m.tenant_id
+	           AND me.scope    = m.scope
+	           AND me.scope_id = m.scope_id
+	           AND me.key      = m.key
+	         WHERE me.tenant_id = $1
+	           AND me.scope = $2
+	           AND me.scope_id = $3
+	           AND (m.expires_at IS NULL OR m.expires_at > now())
+	           AND me.embed_text_tsv @@ plainto_tsquery('english', $4)` + prefixCondition + `
+	         ORDER BY score DESC
+	         LIMIT $5`
+	rows, err := s.pool.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, fmt.Errorf("MemoryFullTextSearch query: %w", err)
+	}
+	defer rows.Close()
+
+	out := []store.MemorySearchEntry{}
+	for rows.Next() {
+		var (
+			key                string
+			valueBytes         []byte
+			expiresAt          *time.Time
+			createdAt          time.Time
+			updatedAt          time.Time
+			score              float64
+			provider, modelStr string
+			embeddingText      string
+			accessCount        int64
+		)
+		if err := rows.Scan(&key, &valueBytes, &expiresAt, &createdAt, &updatedAt, &score, &provider, &modelStr, &embeddingText, &accessCount); err != nil {
+			return nil, fmt.Errorf("MemoryFullTextSearch scan: %w", err)
+		}
+		entry := store.MemorySearchEntry{
+			MemoryEntry: store.MemoryEntry{
+				Key:       key,
+				Value:     valueBytes,
+				CreatedAt: createdAt,
+				UpdatedAt: updatedAt,
+			},
+			Score:       score,
+			AccessCount: accessCount,
+		}
+		if expiresAt != nil {
+			entry.ExpiresAt = *expiresAt
+		}
+		entry.EmbeddedWith.Provider = provider
+		entry.EmbeddedWith.Model = modelStr
+		// Carry the stored vector so an FTS-only survivor still participates
+		// in the shared dedup pass (mirrors MemoryEmbedSearch). A decode
+		// failure is non-fatal — the entry is simply never deduped.
+		if vec, derr := decodePgvector(embeddingText); derr == nil {
+			entry.Vector = vec
+		}
+		out = append(out, entry)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("MemoryFullTextSearch iter: %w", err)
+	}
+	return out, nil
+}
+
+// MemoryBumpAccessBatch applies access-count deltas additively. See the
+// Store interface for the semantics. Uses a single pipelined batch so a
+// flush of N rows is one round-trip; each per-row UPDATE is atomic, so two
+// replicas' concurrent bumps to the same row sum (row lock serialises them).
+func (s *Store) MemoryBumpAccessBatch(ctx context.Context, bumps []store.MemoryAccessBump) error {
+	if len(bumps) == 0 {
+		return nil
+	}
+	batch := &pgx.Batch{}
+	for _, b := range bumps {
+		batch.Queue(
+			`UPDATE memory
+			    SET access_count = access_count + $5,
+			        last_accessed_at = GREATEST(last_accessed_at, $6)
+			  WHERE tenant_id = $1 AND scope = $2 AND scope_id = $3 AND key = $4`,
+			b.TenantID, string(b.Scope), b.ScopeID, b.Key, b.CountDelta, b.LastAccess,
+		)
+	}
+	br := s.pool.SendBatch(ctx, batch)
+	defer br.Close()
+	for range bumps {
+		if _, err := br.Exec(); err != nil {
+			return fmt.Errorf("MemoryBumpAccessBatch: %w", err)
+		}
+	}
+	return nil
 }
 
 // MemoryEmbedListByModel returns base-memory rows whose embedding

--- a/internal/store/postgres/memory_embeddings.go
+++ b/internal/store/postgres/memory_embeddings.go
@@ -38,6 +38,14 @@ func (s *Store) SupportsVectors() bool {
 	return s.pgvectorEnabled
 }
 
+// SupportsFullText reports whether the keyword (full-text) retrieval leg is
+// available (RFC BL). It tracks SupportsVectors exactly: migration 0060's
+// tsvector index lives on memory_embeddings, which exists only behind the
+// pgvector guard, so full-text is available precisely when pgvector is.
+func (s *Store) SupportsFullText() bool {
+	return s.pgvectorEnabled
+}
+
 // MemoryEmbedSet upserts the embedding for one (scope, scope_id, key).
 // The base memory row must exist — the FK enforces this; absent
 // base row surfaces as a Postgres `foreign_key_violation`.

--- a/internal/store/postgres/migrations/0060_memory_embeddings_fts.down.sql
+++ b/internal/store/postgres/migrations/0060_memory_embeddings_fts.down.sql
@@ -1,0 +1,11 @@
+-- 0060_memory_embeddings_fts.down.sql — reverse the full-text leg: drop the
+-- GIN index and the generated tsvector column. Guarded like the up so it's a
+-- clean no-op on a Postgres without pgvector (no memory_embeddings table).
+DO $migration$
+BEGIN
+    IF to_regclass('memory_embeddings') IS NOT NULL THEN
+        DROP INDEX IF EXISTS memory_embeddings_fts;
+        ALTER TABLE memory_embeddings DROP COLUMN IF EXISTS embed_text_tsv;
+    END IF;
+END
+$migration$;

--- a/internal/store/postgres/migrations/0060_memory_embeddings_fts.up.sql
+++ b/internal/store/postgres/migrations/0060_memory_embeddings_fts.up.sql
@@ -1,0 +1,27 @@
+-- 0060_memory_embeddings_fts.up.sql — RFC BL P1 PR2: the full-text
+-- (keyword) retrieval leg of hybrid memory search.
+--
+-- memory_embeddings.embed_text is the canonical searchable text — the same
+-- text the vector leg embedded — so a tsvector over it covers exactly the
+-- embedded-entry population MemoryEmbedSearch ranks. We add a STORED
+-- generated column (kept in lockstep with embed_text automatically, no
+-- application write path) plus a GIN index; the in-process backend then runs
+-- vector ∥ full-text and fuses the two orderings via Reciprocal Rank Fusion.
+--
+-- memory_embeddings lives behind the pgvector guard (0017 creates it only
+-- when the `vector` extension loaded), so every statement runs inside a
+-- to_regclass() existence check and is a clean no-op on a Postgres without
+-- pgvector. embed_text is TEXT NOT NULL (0017), so to_tsvector has no NULL
+-- to guard against.
+DO $migration$
+BEGIN
+    IF to_regclass('memory_embeddings') IS NOT NULL THEN
+        ALTER TABLE memory_embeddings
+            ADD COLUMN IF NOT EXISTS embed_text_tsv tsvector
+            GENERATED ALWAYS AS (to_tsvector('english', embed_text)) STORED;
+
+        CREATE INDEX IF NOT EXISTS memory_embeddings_fts
+            ON memory_embeddings USING GIN (embed_text_tsv);
+    END IF;
+END
+$migration$;

--- a/internal/store/sqlite/memory_access_test.go
+++ b/internal/store/sqlite/memory_access_test.go
@@ -1,0 +1,79 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// MemoryBumpAccessBatch must add deltas (not overwrite) and max-merge
+// last_accessed_at — the real-SQL counterpart to the in-process flusher's
+// additive contract. Sequential here (SQLite serialises writers); the
+// concurrent-flusher additivity is covered in internal/memory.
+func TestMemoryBumpAccessBatch_AdditiveAndMax(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	const (
+		tenant  = "t1"
+		scopeID = "a1"
+		key     = "k"
+	)
+	scope := store.MemoryScopeAgent
+
+	if err := s.MemorySet(ctx, tenant, scope, scopeID, key, json.RawMessage(`1`), 0); err != nil {
+		t.Fatalf("MemorySet: %v", err)
+	}
+
+	early := time.Unix(1_700_000_000, 0).UTC()
+	late := early.Add(time.Hour)
+
+	// First flush: +3 at the LATE ts.
+	if err := s.MemoryBumpAccessBatch(ctx, []store.MemoryAccessBump{
+		{TenantID: tenant, Scope: scope, ScopeID: scopeID, Key: key, CountDelta: 3, LastAccess: late},
+	}); err != nil {
+		t.Fatalf("bump 1: %v", err)
+	}
+	// Second flush: +2 at the EARLY ts — count must sum to 5, ts stay at late.
+	if err := s.MemoryBumpAccessBatch(ctx, []store.MemoryAccessBump{
+		{TenantID: tenant, Scope: scope, ScopeID: scopeID, Key: key, CountDelta: 2, LastAccess: early},
+	}); err != nil {
+		t.Fatalf("bump 2: %v", err)
+	}
+
+	count, lastNanos := readAccess(t, s, tenant, string(scope), scopeID, key)
+	if count != 5 {
+		t.Errorf("access_count = %d, want 5 (additive)", count)
+	}
+	if lastNanos != late.UnixNano() {
+		t.Errorf("last_accessed_at = %d, want %d (max)", lastNanos, late.UnixNano())
+	}
+}
+
+// A bump for a row that doesn't exist is a clean no-op (0 rows), not an error.
+func TestMemoryBumpAccessBatch_MissingRowNoOp(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.MemoryBumpAccessBatch(context.Background(), []store.MemoryAccessBump{
+		{TenantID: "t", Scope: store.MemoryScopeUser, ScopeID: "nope", Key: "gone", CountDelta: 1, LastAccess: time.Now()},
+	}); err != nil {
+		t.Fatalf("bump on missing row must be a no-op, got %v", err)
+	}
+}
+
+func readAccess(t *testing.T, s *Store, tenant, scope, scopeID, key string) (int64, int64) {
+	t.Helper()
+	var count int64
+	var last sql.NullInt64
+	err := s.db.QueryRowContext(context.Background(),
+		`SELECT access_count, last_accessed_at FROM memory
+		  WHERE tenant_id = ? AND scope = ? AND scope_id = ? AND key = ?`,
+		tenant, scope, scopeID, key,
+	).Scan(&count, &last)
+	if err != nil {
+		t.Fatalf("readAccess: %v", err)
+	}
+	return count, last.Int64
+}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -4163,6 +4163,14 @@ func (s *Store) MemoryFullTextSearch(ctx context.Context, tenantID string, scope
 	return nil, nil
 }
 
+// SupportsFullText reports false for SQLite regardless of build tag — it ships
+// no tsvector index (RFC BL adds full-text only on Postgres+pgvector), so the
+// in-process backend takes the cheap pure-vector path rather than paying for a
+// keyword round-trip that would always return (nil, nil).
+func (s *Store) SupportsFullText() bool {
+	return false
+}
+
 // MemoryBumpAccessBatch applies access-count deltas additively (RFC BL
 // hybrid retrieval, OQ #4). See the Store interface for the semantics.
 // SQLite's memory table carries access_count/last_accessed_at (PR1), so this

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -4154,6 +4154,52 @@ func (s *Store) MemoryListTenantsForScope(ctx context.Context, scope store.Memor
 	return out, rows.Err()
 }
 
+// MemoryFullTextSearch is the RFC BL keyword-retrieval leg. SQLite ships no
+// tsvector index (the vectors themselves are Postgres-only), so per the
+// documented degrade posture this returns (nil, nil) rather than erroring —
+// the in-process backend then falls back to pure-vector fusion. We do NOT add
+// full-text infra to SQLite.
+func (s *Store) MemoryFullTextSearch(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, keyPrefix, queryText string, topK int) ([]store.MemorySearchEntry, error) {
+	return nil, nil
+}
+
+// MemoryBumpAccessBatch applies access-count deltas additively (RFC BL
+// hybrid retrieval, OQ #4). See the Store interface for the semantics.
+// SQLite's memory table carries access_count/last_accessed_at (PR1), so this
+// is a real update even though SQLite has no vector search: it's wired
+// unconditionally and simply never receives bumps when search is unavailable.
+// One transaction per flush; each per-row UPDATE reads-then-adds, so
+// sequential flushes sum. SQLite serialises writers, so a bump for a row that
+// was concurrently deleted is a clean 0-row no-op.
+func (s *Store) MemoryBumpAccessBatch(ctx context.Context, bumps []store.MemoryAccessBump) error {
+	if len(bumps) == 0 {
+		return nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("MemoryBumpAccessBatch begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	for _, b := range bumps {
+		ts := b.LastAccess.UnixNano()
+		// MAX(COALESCE(last_accessed_at, ts), ts): a NULL last_accessed_at
+		// collapses to ts, otherwise take the later of the two.
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE memory
+			    SET access_count = access_count + ?,
+			        last_accessed_at = MAX(COALESCE(last_accessed_at, ?), ?)
+			  WHERE tenant_id = ? AND scope = ? AND scope_id = ? AND key = ?`,
+			b.CountDelta, ts, ts, b.TenantID, string(b.Scope), b.ScopeID, b.Key,
+		); err != nil {
+			return fmt.Errorf("MemoryBumpAccessBatch update: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("MemoryBumpAccessBatch commit: %w", err)
+	}
+	return nil
+}
+
 // MemorySweep deletes every Memory row whose expires_at has passed.
 func (s *Store) MemorySweep(ctx context.Context) (int, error) {
 	res, err := s.db.ExecContext(ctx,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1501,6 +1501,22 @@ type Store interface {
 	// no rows returns an empty slice, not an error.
 	MemoryListTenantsForScope(ctx context.Context, scope MemoryScope, scopeID string) ([]string, error)
 
+	// MemoryBumpAccessBatch applies a batch of access-count deltas to the
+	// base memory table (RFC BL hybrid retrieval, OQ #4). For each bump it
+	// runs, per row, an ADDITIVE update:
+	//
+	//	access_count = access_count + delta
+	//	last_accessed_at = GREATEST(last_accessed_at, ts)
+	//
+	// so two replicas' (or two concurrent flushers') deltas SUM and the
+	// timestamp takes the max. Rows are matched on the full
+	// (tenant_id, scope, scope_id, key) key; a bump whose row no longer
+	// exists is a silent no-op (0 rows affected — a row can expire or be
+	// deleted between a search hit and the deferred flush). An empty slice
+	// is a no-op. Backends that don't track access simply update the two
+	// columns PR1 added to the memory table (both sqlite + postgres do).
+	MemoryBumpAccessBatch(ctx context.Context, bumps []MemoryAccessBump) error
+
 	// SupportsVectors reports whether this backend instance can serve
 	// the MemoryEmbed* family. Backends without a vector index loaded
 	// return false; the Memory tool's `search` op + `embed: true`
@@ -1546,6 +1562,24 @@ type Store interface {
 	// Backends MUST honour the base table's expires_at filter — a
 	// matching vector for an expired row MUST NOT appear in results.
 	MemoryEmbedSearch(ctx context.Context, tenantID string, scope MemoryScope, scopeID, keyPrefix string, query []float32, topK int) ([]MemorySearchEntry, error)
+
+	// MemoryFullTextSearch runs the keyword (lexical) retrieval leg of RFC
+	// BL hybrid retrieval: a Top-K full-text match over the same embedded
+	// entry population MemoryEmbedSearch ranks (memory_embeddings.embed_text
+	// is the canonical searchable text). Same signature-shape and
+	// MemorySearchEntry result as MemoryEmbedSearch, tenant-scoped, honouring
+	// the base row's expires_at and the optional keyPrefix. Results are
+	// ordered best-first by the backend's text relevance (Postgres: ts_rank);
+	// the in-process backend fuses this ordering with the vector ordering via
+	// Reciprocal Rank Fusion, so only the RANK POSITION is load-bearing (the
+	// raw relevance magnitude is not comparable to cosine).
+	//
+	// Empty results return (nil, nil) — NOT an error — and a backend without a
+	// full-text index degrades to (nil, nil) as well (sqlite has no tsvector),
+	// so the caller cleanly falls back to pure-vector retrieval rather than
+	// failing the whole search. Backends MUST populate MemorySearchEntry.Vector
+	// (for the shared dedup pass) and AccessCount when they can.
+	MemoryFullTextSearch(ctx context.Context, tenantID string, scope MemoryScope, scopeID, keyPrefix, queryText string, topK int) ([]MemorySearchEntry, error)
 
 	// MemoryEmbedListByModel returns entries whose stored embedding
 	// was produced by a DIFFERENT (provider, model) than the supplied
@@ -2485,6 +2519,27 @@ type MemorySearchEntry struct {
 		Model    string `json:"model"`
 	} `json:"embedded_with"`
 	Vector []float32 `json:"-"`
+	// AccessCount is the base row's access_count (RFC BL). Populated by the
+	// search legs so the hybrid ranker's frequency_weight term can reward
+	// frequently-recalled entries. Zero when the backend doesn't track it
+	// (e.g. the Mem9 REST backend), which makes the frequency term a no-op
+	// for that entry. json:"-": it feeds ranking, not the agent-facing row.
+	AccessCount int64 `json:"-"`
+}
+
+// MemoryAccessBump is one row's pending access delta for
+// Store.MemoryBumpAccessBatch (RFC BL hybrid retrieval, OQ #4). The
+// in-process backend accumulates these per replica on a search hit and a
+// flusher applies them in batches, so the hot search path never blocks on
+// the access-count write. CountDelta is added to the row's access_count;
+// LastAccess is max-merged into last_accessed_at.
+type MemoryAccessBump struct {
+	TenantID   string
+	Scope      MemoryScope
+	ScopeID    string
+	Key        string
+	CountDelta int64
+	LastAccess time.Time
 }
 
 // MemoryEmbedStats summarises the embedded rows under one scope.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1527,6 +1527,16 @@ type Store interface {
 	// support deferred to v0.9.1).
 	SupportsVectors() bool
 
+	// SupportsFullText reports whether the backend can contribute a
+	// keyword (full-text) retrieval leg via MemoryFullTextSearch. Today
+	// only Postgres+pgvector can (migration 0060 adds the tsvector index
+	// behind the pgvector guard); SQLite returns false regardless of build
+	// tag (no tsvector index). It is a NARROWER capability than
+	// SupportsVectors: a store may support vectors but have no full-text
+	// index, in which case a pure-semantic search skips the wasted keyword
+	// round-trip. The in-process backend gates its hybrid over-fetch on this.
+	SupportsFullText() bool
+
 	// MemoryEmbedSet writes the embedding vector for the (scope,
 	// scopeID, key) tuple. Idempotent — re-writes overwrite the
 	// existing embedding row. Returns ErrVectorUnsupported when the
@@ -2519,6 +2529,14 @@ type MemorySearchEntry struct {
 		Model    string `json:"model"`
 	} `json:"embedded_with"`
 	Vector []float32 `json:"-"`
+	// SemanticScore is the semantic signal the hybrid ranker scales
+	// (SemanticWeight · SemanticScore) — SEPARATE from Score so ranking never
+	// clobbers the raw-cosine Score the tool renders (RFC BL). For pure-vector
+	// retrieval it equals the cosine; after RRF fusion it is the fused RRF
+	// value (see memory.FuseRRF), while Score stays the raw vector-leg cosine.
+	// Producers (the fusion step, the pure-vector fast path, the mem9 backend)
+	// set it explicitly; json:"-": it feeds ranking, not the agent-facing row.
+	SemanticScore float64 `json:"-"`
 	// AccessCount is the base row's access_count (RFC BL). Populated by the
 	// search legs so the hybrid ranker's frequency_weight term can reward
 	// frequently-recalled entries. Zero when the backend doesn't track it

--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -1163,8 +1163,8 @@ func (m *Memory) execSearch(ctx context.Context, scope store.MemoryScope, scopeI
 		entries = append(entries, map[string]any{
 			"key":        r.Key,
 			"value":      r.Value,
-			"score":      r.Score,           // cosine similarity (unchanged field)
-			"rank_score": res.RankScores[i], // hybrid score this result was ordered by
+			"score":      r.Score,           // raw cosine similarity — NEVER touched by hybrid fusion or ranking (stable across searches)
+			"rank_score": res.RankScores[i], // computed rank the result was ordered by: fused-semantic (RRF) + recency + frequency
 			"embedded_with": map[string]any{
 				"provider": r.EmbeddedWith.Provider,
 				"model":    r.EmbeddedWith.Model,


### PR DESCRIPTION
**Stacked on #801 (RFC BL P1 PR1, merged). Base: `main`.** Second of the P1 PR series (agentic memory).

## Why

`Memory search` was vector-only, so a memory whose text lexically matches a query but isn't the nearest embedding was missed. This adds a **hybrid** retrieval path (dense vector ∥ Postgres full-text, fused with Reciprocal Rank Fusion) and activates the **frequency** ranking signal over the `access_count`/`last_accessed_at` columns PR1 added — both LLM-free, on the read path.

## What

- **Full-text leg:** migration `0060` adds a generated `tsvector` column (`to_tsvector('english', embed_text)` STORED) + a GIN index to `memory_embeddings`, behind the same `to_regclass()` pgvector guard as 0017/0059 (clean no-op without pgvector). New store method `MemoryFullTextSearch` (tenant-scoped, `plainto_tsquery` — fully parameterized).
- **RRF fusion:** `rank.FuseRRF` (k=60) unions the vector + full-text legs by key. The fused value feeds the **`rank_score`** path (semantic + recency + frequency); the wire-visible **`score` field stays the raw vector cosine** (unchanged contract — carried separately as `SemanticScore json:"-"`).
- **Frequency weight:** `rank_score` adds `frequency_weight · log1p(access_count)`; counts are maintained by a batched, additive **`AccessFlusher`** (per-replica map → `access_count += Σdelta, last_accessed_at = GREATEST(ts)` on a ticker/size/shutdown trigger, off the hot path, re-queues on transient write failure).
- **Capability-gated:** hybrid runs where full-text is available (`SupportsFullText()` → Postgres+pgvector); on SQLite / no-pgvector the cheap pure-vector path is preserved (byte-identical, no over-fetch, no extra query).
- `source_weight` remains reserved (contributes 0) — P1 has no numeric source signal; only `frequency_weight` has data until consolidation (P2).

## For reviewer attention

- **Hybrid is ON by default where full-text is available** (the RFC intent). This changes what results a default (no-`rank`-block) search returns on Postgres, and adds one GIN `ts_rank` query per search. A per-call / ops opt-out is marked `TODO(RFC BL)` — flagging in case you'd prefer hybrid be opt-in or want the opt-out in this PR.
- **Pre-merge:** the `tsvector`/`ts_rank` path and migration `0060` are exercised only by the PG-gated CI job (no local pgvector DSN here) — worth confirming that check is green, plus a quick live 2-entry hybrid query.

## Commits

1. `cdd4a74c` — implementation.
2. `6f9a8792` — addresses an independent code review (4 findings): restored the raw-cosine `score` contract (fusion → `SemanticScore`/`rank_score`, not `score`); capability-gated the hybrid path so pure-semantic callers without full-text keep today's cheap behavior; made `AccessFlusher.Flush` re-queue on transient write error; fixed shutdown ordering so the final access flush runs after the HTTP/gRPC drain.

## Tested

- `go build ./...`, `go vet`, `gofmt` — clean. `go test ./...` — 86 pkg ok, 0 fail (PG DSN-gated tests skip; `go-postgres` CI exercises `0060`). `-race` clean on `internal/memory/...`.
- Fail-before verified: `TestSearch_RRFSurfacesKeywordOnlyMatch`, `TestRank_FrequencyWeightAffectsOrder`, `TestAccessCount_BatchedFlushIsAdditive` (`-race`), `TestFuseRRF_PreservesRawCosineScore`, `TestAccessFlusher_FailedFlushReMergesForRetry`, + sqlite `TestMemoryBumpAccessBatch_*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
