### PR TITLE
feat(help): boot-reconciled hybrid help-topic search index (RFC BL P1 PR5)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -2629,8 +2629,8 @@ func main() {
 				switch {
 				case stats.Degraded:
 					log.Printf("help index: no embedder/vector support — query uses in-memory substring scan")
-				case stats.Written > 0 || stats.Pruned > 0:
-					log.Printf("help index: reconciled (%d written, %d pruned, %d unchanged)", stats.Written, stats.Pruned, stats.Unchanged)
+				case stats.Written > 0 || stats.Pruned > 0 || stats.Failed > 0:
+					log.Printf("help index: reconciled (%d written, %d pruned, %d unchanged, %d failed)", stats.Written, stats.Pruned, stats.Unchanged, stats.Failed)
 				default:
 					log.Printf("help index: up to date (%d sections, 0 embed calls)", stats.Unchanged)
 				}

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1561,6 +1561,10 @@ func main() {
 	skillTool.Store = storeIface
 	evaluationTool.Store = storeIface
 	contextTool.Store = storeIface
+	// RFC BL P1: the SAME embedder the Memory tool uses powers the help op's
+	// `query` search mode; nil (no embedder configured) makes query degrade to
+	// a substring scan over the in-memory help set.
+	contextTool.Embedder = embedder
 	interruptionTool.Store = storeIface
 	mcpServerDefTool.Store = storeIface
 
@@ -2602,6 +2606,42 @@ func main() {
 				}
 			} else {
 				_ = resume(bgCtx)
+			}
+		}()
+	}
+
+	// RFC BL P1: reconcile the boot-time help-topic search index. The go:embed
+	// help corpus is immutable in-process (no hot-reload), so this is one-shot at
+	// boot. Content-hash gated — an unchanged corpus re-embeds nothing; only
+	// changed/new sections are re-embedded and removed sections pruned. No-op
+	// without an embedder or vector support (help search then degrades to an
+	// in-memory substring scan). Backgrounded so a first-boot full embed never
+	// blocks the rest of boot; advisory-gated in a cluster so exactly ONE replica
+	// re-embeds. Non-fatal: on any error help search just degrades.
+	if storeIface != nil && helpSet != nil {
+		go func() {
+			reconcile := func(ctx context.Context) error {
+				stats, err := help.ReconcileIndex(ctx, helpSet, storeIface, embedder)
+				if err != nil {
+					log.Printf("help index: reconcile failed (search degrades): %v", err)
+					return nil // non-fatal — degrade, don't fail boot
+				}
+				switch {
+				case stats.Degraded:
+					log.Printf("help index: no embedder/vector support — query uses in-memory substring scan")
+				case stats.Written > 0 || stats.Pruned > 0:
+					log.Printf("help index: reconciled (%d written, %d pruned, %d unchanged)", stats.Written, stats.Pruned, stats.Unchanged)
+				default:
+					log.Printf("help index: up to date (%d sections, 0 embed calls)", stats.Unchanged)
+				}
+				return nil
+			}
+			if advisoryLock != nil {
+				if _, err := advisoryLock.TryRun(bgCtx, coord.LockKeyHelpIndexReconcile, reconcile); err != nil {
+					log.Printf("help index: advisory-gated reconcile failed: %v", err)
+				}
+			} else {
+				_ = reconcile(bgCtx)
 			}
 		}()
 	}

--- a/internal/coord/advisory_lock.go
+++ b/internal/coord/advisory_lock.go
@@ -133,6 +133,13 @@ var (
 	// one replica per tick exports + purges retired-and-old substrate def
 	// versions (agent/skill/team/mcp_server/schedule/a2a/webhook/memory_backend).
 	LockKeyRetentionSweeper int64
+	// LockKeyHelpIndexReconcile gates the one-shot boot-time reconcile of the
+	// help-topic search index (RFC BL P1) so exactly ONE replica re-embeds the
+	// changed/new help sections into the reserved global namespace — not a
+	// periodic sweep. The go:embed help corpus is immutable in-process, so this
+	// runs once per boot; the content-hash gate makes an unchanged corpus a
+	// zero-embed no-op even on the replica that wins the lock.
+	LockKeyHelpIndexReconcile int64
 )
 
 func init() {
@@ -147,6 +154,7 @@ func init() {
 	LockKeyEphemeralVolumeSweeper = fnvKey("ephemeral_volume_sweeper")
 	LockKeyUsageSweeper = fnvKey("usage_sweeper")
 	LockKeyRetentionSweeper = fnvKey("retention_sweeper")
+	LockKeyHelpIndexReconcile = fnvKey("help_index_reconcile")
 }
 
 // fnvKey hashes a sweeper-name string to a stable int64 lock key.

--- a/internal/help/index.go
+++ b/internal/help/index.go
@@ -118,6 +118,11 @@ type ReconcileStats struct {
 	Pruned int
 	// Unchanged is the number of sections whose content hash already matched.
 	Unchanged int
+	// Failed is the number of sections whose embed-set failed after the base
+	// row was written; they keep the sentinel (empty) hash so the next reconcile
+	// re-attempts them rather than leaving them permanently indexed without a
+	// vector/full-text row.
+	Failed int
 	// Degraded is true when there is no embedder or no vector support, so the
 	// index was left untouched and help search degrades to the in-memory scan.
 	Degraded bool
@@ -301,17 +306,27 @@ func ReconcileIndex(ctx context.Context, set *Set, st IndexStore, emb providers.
 		}
 		now := time.Now().UTC()
 		for i, p := range changed {
-			val, mErr := json.Marshal(indexValue{
+			// Two-phase write so a section is NEVER hash-marked "done" without its
+			// embedding. The base row is the FK parent of the embedding, so it must
+			// exist first — but the two writes are not transactional, so if we
+			// stored the real content hash on the base row up front and the
+			// embed-set then failed, the hash would match on the next pass and the
+			// section would be marked Unchanged forever with no vector/full-text row
+			// (a silent precision loss; substring still finds it, so no outage).
+			// Instead: phase 1 writes the base row with an EMPTY sentinel hash
+			// (contentHash never returns "", so it always re-triggers a rewrite);
+			// phase 2 records the real hash only after the embed-set also succeeds.
+			base := indexValue{
 				TopicSlug: p.sec.TopicSlug,
 				Heading:   p.sec.Heading,
 				Snippet:   p.sec.Snippet,
-				Hash:      p.hash,
-			})
+				Hash:      "", // withheld until BOTH writes succeed
+			}
+			pendingVal, mErr := json.Marshal(base)
 			if mErr != nil {
 				return stats, fmt.Errorf("help index: marshal %q: %w", p.sec.Key, mErr)
 			}
-			// Base row first — MemoryEmbedSet's FK requires it.
-			if err := st.MemorySet(ctx, helpTenant, helpScope, HelpNamespaceScopeID, p.sec.Key, val, 0); err != nil {
+			if err := st.MemorySet(ctx, helpTenant, helpScope, HelpNamespaceScopeID, p.sec.Key, pendingVal, 0); err != nil {
 				return stats, fmt.Errorf("help index: set %q: %w", p.sec.Key, err)
 			}
 			if err := st.MemoryEmbedSet(ctx, helpTenant, helpScope, HelpNamespaceScopeID, p.sec.Key, store.MemoryEmbedding{
@@ -322,7 +337,23 @@ func ReconcileIndex(ctx context.Context, set *Set, st IndexStore, emb providers.
 				EmbedText: p.sec.Text,
 				CreatedAt: now,
 			}); err != nil {
-				return stats, fmt.Errorf("help index: embed-set %q: %w", p.sec.Key, err)
+				// Embed-set can fail transiently while the base write succeeds.
+				// The section keeps its "" sentinel hash, so it is re-attempted on
+				// the next reconcile; count it failed and keep indexing the rest
+				// rather than aborting the whole index.
+				log.Printf("help index: embed-set %q failed, will retry next reconcile: %v", p.sec.Key, err)
+				stats.Failed++
+				continue
+			}
+			// Phase 2: both writes landed — record the real content hash so the
+			// section is recognized as Unchanged (zero work) next reconcile.
+			base.Hash = p.hash
+			finalVal, mErr := json.Marshal(base)
+			if mErr != nil {
+				return stats, fmt.Errorf("help index: marshal %q: %w", p.sec.Key, mErr)
+			}
+			if err := st.MemorySet(ctx, helpTenant, helpScope, HelpNamespaceScopeID, p.sec.Key, finalVal, 0); err != nil {
+				return stats, fmt.Errorf("help index: finalize %q: %w", p.sec.Key, err)
 			}
 			stats.Written++
 		}
@@ -381,14 +412,23 @@ func QueryIndex(ctx context.Context, set *Set, st IndexStore, emb providers.Embe
 
 	if st != nil && emb != nil && st.SupportsVectors() {
 		hits, err := hybridQuery(ctx, st, emb, query, topK)
-		if err != nil {
-			return QueryResults{}, err
-		}
-		if len(hits) > 0 {
+		switch {
+		case err != nil:
+			// A hybrid failure must NOT hard-fail the caller — query's contract
+			// is "always returns useful results". Two real cases hit this exactly
+			// when the fallback should kick in: a transient embedder API error on
+			// the query-embed, and the dimension-mismatch window during an
+			// embedder swap (the provider+model-salted content hash forces a
+			// re-embed, but until the advisory-lock-gated boot reconcile catches
+			// up, MemoryEmbedSearch returns ErrDimensionMismatch for every query
+			// against the stale rows). Warn and fall through to the substring scan,
+			// exactly as the empty-index case below does.
+			log.Printf("help query: hybrid path failed, degrading to substring: %v", err)
+		case len(hits) > 0:
 			return QueryResults{Mode: "hybrid", Results: hits}, nil
 		}
-		// Empty index (reconcile not done / no match) → fall through to the
-		// substring scan so the caller still gets something.
+		// Hybrid error OR empty index (reconcile not done / no match) → fall
+		// through to the substring scan so the caller still gets something.
 	}
 	return QueryResults{Mode: "substring", Results: substringQuery(set, query, topK)}, nil
 }

--- a/internal/help/index.go
+++ b/internal/help/index.go
@@ -1,0 +1,494 @@
+package help
+
+// Boot-reconciled, hybrid-searchable index of Context op=help topics
+// (RFC BL P1). Each topic is split by `##` heading section — one searchable
+// unit — and stored as rows in the existing Memory + memory_embeddings tables
+// at a RESERVED, isolated global namespace so help never pollutes (nor is
+// polluted by) user/agent/tenant memory search:
+//
+//	tenant_id = ""                       (the shared/legacy partition)
+//	scope     = store.MemoryScopeGlobal
+//	scope_id  = HelpNamespaceScopeID ("__help__")  — a sentinel no ordinary
+//	          Memory op produces (the Memory tool doesn't even expose the
+//	          `global` scope), so the reserved rows are invisible to every
+//	          user-facing memory enumeration/erasure path (those key on real
+//	          scope_ids: user_id, agent name, tenant id).
+//
+// Reuse — not a new table — because the reuse is clean: MemoryEmbedSet already
+// carries the section text in embed_text, which drives BOTH the vector embedding
+// and the generated full-text tsvector, so the PR2 hybrid legs (MemoryEmbedSearch
+// ∥ MemoryFullTextSearch → FuseRRF) work over help sections with zero new schema.
+//
+// The index is read-only from an agent's perspective (only this reconcile writes
+// it), shared across tenants, and exempt from provenance/erasure — it is embedded
+// documentation, not user content.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/memory"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+const (
+	// HelpNamespaceScopeID is the sentinel scope_id the help index lives under
+	// (scope=global, tenant=""). Chosen so it can never collide with a real
+	// Memory scope_id — the Memory tool doesn't expose the global scope at all,
+	// so nothing an agent does ever writes or reads this bucket.
+	HelpNamespaceScopeID = "__help__"
+
+	// helpTenant is the tenant partition the shared help index lives in. The
+	// index is deliberately cross-tenant (embedded docs, identical for everyone),
+	// so it lives in the "" shared/legacy partition.
+	helpTenant = ""
+
+	// helpListLimit bounds the existing-row enumeration used for the prune pass.
+	// The bundled corpus is tens of topics × a handful of sections each (low
+	// hundreds of rows), so this is comfortably above any real corpus; a
+	// truncation is logged so an unexpectedly huge corpus is visible.
+	helpListLimit = 10000
+
+	helpQueryDefaultTopK = 5
+	helpQueryMaxTopK     = 20
+)
+
+// helpScope is the reserved scope the index rows use.
+const helpScope = store.MemoryScopeGlobal
+
+// Section is one searchable unit of a help topic — a single `##` heading
+// section, or the pre-first-heading preamble (Heading == ""). Text is the full
+// section body INCLUDING the heading line and any fenced content (e.g. a
+// ```mermaid diagram's source, which is already text and stays searchable — a
+// node label is a lexeme like any other; RFC BL §2.9). Key is the reserved-
+// namespace memory key, assigned by AllSections so it is unique across the
+// corpus even when two sections share a (topic, heading).
+type Section struct {
+	TopicSlug string
+	Heading   string
+	Text      string
+	Snippet   string
+	Key       string
+}
+
+// keyBase is the natural key for a section before duplicate-heading
+// disambiguation: "<topic>#<heading>". Topic names are unique and headings are
+// almost always unique within a topic, so this is normally already the Key.
+func (s Section) keyBase() string { return s.TopicSlug + "#" + s.Heading }
+
+// IndexStore is the minimal subset of store.Store the help index needs. Declared
+// here (rather than taking the full store.Store) so the storage surface is
+// explicit and tests can supply a tiny fake instead of stubbing the whole Store.
+// store.Store satisfies it structurally, so callers pass their live store as-is.
+type IndexStore interface {
+	SupportsVectors() bool
+	SupportsFullText() bool
+	MemoryList(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, prefix string, limit int) ([]store.MemoryEntry, bool, error)
+	MemorySet(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string, value json.RawMessage, ttl time.Duration) error
+	MemoryEmbedSet(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string, e store.MemoryEmbedding) error
+	MemoryDelete(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string) (bool, error)
+	MemoryEmbedSearch(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, keyPrefix string, query []float32, topK int) ([]store.MemorySearchEntry, error)
+	MemoryFullTextSearch(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, keyPrefix, queryText string, topK int) ([]store.MemorySearchEntry, error)
+}
+
+// indexValue is the JSON stored in each reserved-namespace memory row. Hash is
+// the content-hash gate for reconcile (see reconcile); the other fields are what
+// a query surfaces without a second lookup.
+type indexValue struct {
+	TopicSlug string `json:"topic_slug"`
+	Heading   string `json:"heading"`
+	Snippet   string `json:"snippet"`
+	Hash      string `json:"hash"`
+}
+
+// ReconcileStats reports what a reconcile did, for the boot log.
+type ReconcileStats struct {
+	// Written is the number of new-or-changed sections re-embedded + rewritten.
+	Written int
+	// Pruned is the number of stale sections deleted (topic/heading gone).
+	Pruned int
+	// Unchanged is the number of sections whose content hash already matched.
+	Unchanged int
+	// Degraded is true when there is no embedder or no vector support, so the
+	// index was left untouched and help search degrades to the in-memory scan.
+	Degraded bool
+}
+
+// sectionsForTopic splits a topic's markdown into `##` sections. Content before
+// the first `##` heading is the preamble (Heading == ""). A `## ` line inside a
+// fenced code block (``` … ```) is NOT a heading — tracked so a mermaid/code
+// fence containing `##` can't spuriously split a section.
+func sectionsForTopic(t *Topic) []Section {
+	if t == nil {
+		return nil
+	}
+	lines := strings.Split(t.Content, "\n")
+	var (
+		secs       []Section
+		curHeading string // "" == preamble
+		curBody    []string
+		inFence    bool
+	)
+	flush := func() {
+		body := strings.Join(curBody, "\n")
+		var full string
+		if curHeading != "" {
+			full = "## " + curHeading + "\n" + body
+		} else {
+			full = body
+		}
+		full = strings.TrimSpace(full)
+		if full == "" {
+			return // empty preamble, or empty section — nothing to index
+		}
+		secs = append(secs, Section{
+			TopicSlug: t.Name,
+			Heading:   curHeading,
+			Text:      full,
+			Snippet:   snippet(body),
+		})
+	}
+	for _, ln := range lines {
+		if strings.HasPrefix(strings.TrimSpace(ln), "```") {
+			inFence = !inFence
+			curBody = append(curBody, ln)
+			continue
+		}
+		// A level-2 ATX heading at column 0, outside a code fence, starts a new
+		// section. "### x" is level-3 and stays inside the current `##` section
+		// (HasPrefix("### x", "## ") is false).
+		if !inFence && strings.HasPrefix(ln, "## ") {
+			flush()
+			curHeading = strings.TrimSpace(strings.TrimPrefix(ln, "## "))
+			curBody = nil
+			continue
+		}
+		curBody = append(curBody, ln)
+	}
+	flush()
+	return secs
+}
+
+// snippet collapses whitespace and trims a section body to a short preview for
+// query results. Full content is fetched via op=help topic=<slug>.
+func snippet(body string) string {
+	const max = 200
+	s := strings.Join(strings.Fields(body), " ")
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return strings.TrimSpace(string(r[:max])) + "…"
+}
+
+// AllSections returns every section of every topic, with Key assigned and
+// disambiguated so duplicate (topic, heading) pairs still get unique, stable
+// keys ("<base>#2", "#3", …). Deterministic for a given corpus, so an unchanged
+// corpus yields identical keys across boots — the basis for the zero-write gate.
+func AllSections(set *Set) []Section {
+	if set == nil {
+		return nil
+	}
+	var all []Section
+	seen := map[string]int{}
+	for _, t := range set.All() { // All() is sorted by topic name
+		for _, s := range sectionsForTopic(t) {
+			base := s.keyBase()
+			n := seen[base]
+			seen[base]++
+			if n == 0 {
+				s.Key = base
+			} else {
+				s.Key = fmt.Sprintf("%s#%d", base, n+1)
+			}
+			all = append(all, s)
+		}
+	}
+	return all
+}
+
+// contentHash is the reconcile gate. It folds the embedder identity in with the
+// text so swapping the embedder (provider/model) re-embeds the corpus even when
+// the text is byte-identical — otherwise stale vectors (or a dimension mismatch)
+// would linger. For an unchanged corpus + unchanged embedder the hash is stable,
+// so reconcile makes zero embed calls.
+func contentHash(salt, text string) string {
+	h := sha256.Sum256([]byte(salt + "\x00" + text))
+	return hex.EncodeToString(h[:])
+}
+
+// ReconcileIndex brings the reserved help namespace in line with the current
+// go:embed corpus: it re-embeds only new/changed sections (content-hash gated),
+// leaves unchanged sections untouched (zero embed calls), and prunes rows whose
+// topic/heading no longer exists. It is a NO-OP (Degraded=true) when there is no
+// embedder or the store has no vector support — help search then degrades to the
+// in-memory substring scan, so there is nothing to index.
+//
+// Idempotent and safe to call repeatedly; the boot wiring runs it once, advisory-
+// lock-gated in a cluster so only one replica does the work.
+func ReconcileIndex(ctx context.Context, set *Set, st IndexStore, emb providers.Embedder) (ReconcileStats, error) {
+	var stats ReconcileStats
+	if set == nil {
+		return stats, nil
+	}
+	if st == nil || emb == nil || !st.SupportsVectors() {
+		stats.Degraded = true
+		return stats, nil
+	}
+
+	salt := emb.Provider() + "\n" + emb.Model()
+
+	desired := AllSections(set)
+	desiredByKey := make(map[string]struct{}, len(desired))
+	for _, s := range desired {
+		desiredByKey[s.Key] = struct{}{}
+	}
+
+	existing, truncated, err := st.MemoryList(ctx, helpTenant, helpScope, HelpNamespaceScopeID, "", helpListLimit)
+	if err != nil {
+		return stats, fmt.Errorf("help index: list existing: %w", err)
+	}
+	if truncated {
+		log.Printf("help index: existing-row list truncated at %d; prune may be incomplete", helpListLimit)
+	}
+	existingHash := make(map[string]string, len(existing))
+	for _, e := range existing {
+		var v indexValue
+		if json.Unmarshal(e.Value, &v) == nil {
+			existingHash[e.Key] = v.Hash
+		} else {
+			existingHash[e.Key] = "" // unparseable → force a rewrite
+		}
+	}
+
+	// Collect the sections that actually changed, then embed them in ONE batch
+	// (the driver batches internally). An unchanged corpus collects nothing, so
+	// no Embed call is made at all.
+	type pending struct {
+		sec  Section
+		hash string
+	}
+	var changed []pending
+	for _, s := range desired {
+		h := contentHash(salt, s.Text)
+		if prev, ok := existingHash[s.Key]; ok && prev == h {
+			stats.Unchanged++
+			continue
+		}
+		changed = append(changed, pending{sec: s, hash: h})
+	}
+
+	if len(changed) > 0 {
+		texts := make([]string, len(changed))
+		for i := range changed {
+			texts[i] = changed[i].sec.Text
+		}
+		vecs, err := emb.Embed(ctx, texts)
+		if err != nil {
+			return stats, fmt.Errorf("help index: embed %d section(s): %w", len(texts), err)
+		}
+		if len(vecs) != len(texts) {
+			return stats, fmt.Errorf("help index: embed returned %d vectors, want %d", len(vecs), len(texts))
+		}
+		now := time.Now().UTC()
+		for i, p := range changed {
+			val, mErr := json.Marshal(indexValue{
+				TopicSlug: p.sec.TopicSlug,
+				Heading:   p.sec.Heading,
+				Snippet:   p.sec.Snippet,
+				Hash:      p.hash,
+			})
+			if mErr != nil {
+				return stats, fmt.Errorf("help index: marshal %q: %w", p.sec.Key, mErr)
+			}
+			// Base row first — MemoryEmbedSet's FK requires it.
+			if err := st.MemorySet(ctx, helpTenant, helpScope, HelpNamespaceScopeID, p.sec.Key, val, 0); err != nil {
+				return stats, fmt.Errorf("help index: set %q: %w", p.sec.Key, err)
+			}
+			if err := st.MemoryEmbedSet(ctx, helpTenant, helpScope, HelpNamespaceScopeID, p.sec.Key, store.MemoryEmbedding{
+				Provider:  emb.Provider(),
+				Model:     emb.Model(),
+				Dimension: len(vecs[i]),
+				Vector:    vecs[i],
+				EmbedText: p.sec.Text,
+				CreatedAt: now,
+			}); err != nil {
+				return stats, fmt.Errorf("help index: embed-set %q: %w", p.sec.Key, err)
+			}
+			stats.Written++
+		}
+	}
+
+	// Prune sections that no longer exist. On Postgres the embedding row cascades
+	// via its ON DELETE CASCADE FK; SQLite has no embeddings table (and thus no
+	// vector support, so this path never runs there).
+	for key := range existingHash {
+		if _, ok := desiredByKey[key]; ok {
+			continue
+		}
+		if _, err := st.MemoryDelete(ctx, helpTenant, helpScope, HelpNamespaceScopeID, key); err != nil {
+			return stats, fmt.Errorf("help index: prune %q: %w", key, err)
+		}
+		stats.Pruned++
+	}
+
+	return stats, nil
+}
+
+// QueryResult is one hit from QueryIndex — enough to decide whether to fetch the
+// full topic via op=help topic=<topic_slug>.
+type QueryResult struct {
+	TopicSlug string  `json:"topic_slug"`
+	Heading   string  `json:"heading"`
+	Snippet   string  `json:"snippet"`
+	Score     float64 `json:"score"`
+}
+
+// QueryResults wraps the hits with the mode that produced them so a caller can
+// tell a full-strength hybrid result from a degraded substring scan.
+type QueryResults struct {
+	Mode    string        `json:"mode"` // "hybrid" | "substring"
+	Results []QueryResult `json:"results"`
+}
+
+// QueryIndex runs an LLM-free search over help sections and returns the top-k
+// matches. When embeddings are available (an embedder + a vector-capable store)
+// it runs the PR2 hybrid path — vector ∥ full-text fused by RRF — over the
+// reserved namespace. Otherwise, or when the index is not yet populated / returns
+// nothing, it degrades to a substring/keyword scan over the in-memory Set (which
+// always exists). Either way query always returns useful results — just less
+// precisely without the index.
+func QueryIndex(ctx context.Context, set *Set, st IndexStore, emb providers.Embedder, query string, topK int) (QueryResults, error) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return QueryResults{}, errors.New("help query: empty query")
+	}
+	if topK <= 0 {
+		topK = helpQueryDefaultTopK
+	}
+	if topK > helpQueryMaxTopK {
+		topK = helpQueryMaxTopK
+	}
+
+	if st != nil && emb != nil && st.SupportsVectors() {
+		hits, err := hybridQuery(ctx, st, emb, query, topK)
+		if err != nil {
+			return QueryResults{}, err
+		}
+		if len(hits) > 0 {
+			return QueryResults{Mode: "hybrid", Results: hits}, nil
+		}
+		// Empty index (reconcile not done / no match) → fall through to the
+		// substring scan so the caller still gets something.
+	}
+	return QueryResults{Mode: "substring", Results: substringQuery(set, query, topK)}, nil
+}
+
+// hybridQuery embeds the query and fuses the vector + full-text legs via RRF over
+// the reserved help namespace. Mirrors the in-process Memory backend's hybrid
+// retrieval so help search behaves like memory search.
+func hybridQuery(ctx context.Context, st IndexStore, emb providers.Embedder, query string, topK int) ([]QueryResult, error) {
+	vecs, err := emb.Embed(ctx, []string{query})
+	if err != nil {
+		return nil, fmt.Errorf("help query: embed: %w", err)
+	}
+	if len(vecs) != 1 {
+		return nil, fmt.Errorf("help query: embed returned %d vectors, want 1", len(vecs))
+	}
+	fetch := topK * 4
+	if fetch < topK {
+		fetch = topK
+	}
+	if fetch > 51 {
+		fetch = 51 // the store's defensive per-search cap
+	}
+	vres, err := st.MemoryEmbedSearch(ctx, helpTenant, helpScope, HelpNamespaceScopeID, "", vecs[0], fetch)
+	if err != nil {
+		return nil, fmt.Errorf("help query: vector leg: %w", err)
+	}
+	// (nil, nil) when the store has no full-text index — the fusion then
+	// collapses to pure-vector.
+	fres, err := st.MemoryFullTextSearch(ctx, helpTenant, helpScope, HelpNamespaceScopeID, "", query, fetch)
+	if err != nil {
+		return nil, fmt.Errorf("help query: full-text leg: %w", err)
+	}
+	fused := memory.FuseRRF(vres, fres, memory.RRFDefaultK)
+	if len(fused) > topK {
+		fused = fused[:topK]
+	}
+	out := make([]QueryResult, 0, len(fused))
+	for _, e := range fused {
+		var v indexValue
+		if json.Unmarshal(e.Value, &v) != nil {
+			continue // not one of our rows / unparseable — skip defensively
+		}
+		out = append(out, QueryResult{
+			TopicSlug: v.TopicSlug,
+			Heading:   v.Heading,
+			Snippet:   v.Snippet,
+			// SemanticScore carries the fused RRF value after FuseRRF (Score
+			// stays the raw cosine, which is meaningless for a full-text-only hit).
+			Score: e.SemanticScore,
+		})
+	}
+	return out, nil
+}
+
+// substringQuery scans the in-memory Set for sections containing the query terms
+// (case-insensitive), scored by total term-occurrence count. This is the always-
+// available fallback (the Set always exists); it also naturally searches any
+// mermaid/code source in a section since Text is never stripped.
+func substringQuery(set *Set, query string, topK int) []QueryResult {
+	if set == nil {
+		return nil
+	}
+	terms := strings.Fields(strings.ToLower(query))
+	if len(terms) == 0 {
+		return nil
+	}
+	type scored struct {
+		r QueryResult
+		s int
+	}
+	var hits []scored
+	for _, sec := range AllSections(set) {
+		lower := strings.ToLower(sec.Text)
+		score := 0
+		for _, t := range terms {
+			score += strings.Count(lower, t)
+		}
+		if score == 0 {
+			continue
+		}
+		hits = append(hits, scored{
+			r: QueryResult{TopicSlug: sec.TopicSlug, Heading: sec.Heading, Snippet: sec.Snippet, Score: float64(score)},
+			s: score,
+		})
+	}
+	sort.SliceStable(hits, func(i, j int) bool {
+		if hits[i].s != hits[j].s {
+			return hits[i].s > hits[j].s
+		}
+		if hits[i].r.TopicSlug != hits[j].r.TopicSlug {
+			return hits[i].r.TopicSlug < hits[j].r.TopicSlug
+		}
+		return hits[i].r.Heading < hits[j].r.Heading
+	})
+	if len(hits) > topK {
+		hits = hits[:topK]
+	}
+	out := make([]QueryResult, len(hits))
+	for i := range hits {
+		out[i] = hits[i].r
+	}
+	return out
+}

--- a/internal/help/index_test.go
+++ b/internal/help/index_test.go
@@ -1,0 +1,463 @@
+package help
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// ---- test fixtures ----
+
+// newHelpTestSet builds a *Set directly from in-memory topics (white-box), so a
+// test controls the exact section shape without the go:embed corpus.
+func newHelpTestSet(topics ...*Topic) *Set {
+	s := &Set{topics: map[string]*Topic{}}
+	for _, t := range topics {
+		if t.Source == "" {
+			t.Source = "bundled"
+		}
+		s.topics[t.Name] = t
+	}
+	s.reindex()
+	return s
+}
+
+// helpFakeEmbedder one-hot encodes tokens against a fixed vocab and counts calls
+// + total texts embedded, so a test can assert reconcile made zero embed calls.
+type helpFakeEmbedder struct {
+	vocab      map[string]int
+	embedCalls int
+	embedTexts int
+}
+
+func newHelpFakeEmbedder(tokens ...string) *helpFakeEmbedder {
+	v := map[string]int{}
+	for i, t := range tokens {
+		v[t] = i
+	}
+	return &helpFakeEmbedder{vocab: v}
+}
+
+func (f *helpFakeEmbedder) Embed(_ context.Context, texts []string) ([][]float32, error) {
+	f.embedCalls++
+	f.embedTexts += len(texts)
+	out := make([][]float32, len(texts))
+	for i, txt := range texts {
+		vec := make([]float32, len(f.vocab))
+		for _, tok := range strings.FieldsFunc(strings.ToLower(txt), func(r rune) bool {
+			return !(r >= 'a' && r <= 'z') && !(r >= '0' && r <= '9')
+		}) {
+			if idx, ok := f.vocab[tok]; ok {
+				vec[idx] = 1
+			}
+		}
+		out[i] = vec
+	}
+	return out, nil
+}
+
+func (f *helpFakeEmbedder) Provider() string { return "fake" }
+func (f *helpFakeEmbedder) Model() string    { return "fake-001" }
+func (f *helpFakeEmbedder) Dimension() int   { return len(f.vocab) }
+
+// helpFakeStore implements help.IndexStore in memory, mutex-guarded so the
+// concurrency test is race-clean. It counts base/embedding writes + deletes.
+type helpFakeStore struct {
+	mu       sync.Mutex
+	rows     map[string]*helpFakeRow // key -> row
+	vectors  bool
+	fullText bool
+
+	setCount      int
+	embedSetCount int
+	deleteCount   int
+}
+
+type helpFakeRow struct {
+	value     json.RawMessage
+	vector    []float32
+	embedText string
+}
+
+func newHelpFakeStore() *helpFakeStore {
+	return &helpFakeStore{rows: map[string]*helpFakeRow{}, vectors: true, fullText: true}
+}
+
+func (s *helpFakeStore) SupportsVectors() bool  { return s.vectors }
+func (s *helpFakeStore) SupportsFullText() bool { return s.fullText }
+
+func (s *helpFakeStore) MemoryList(_ context.Context, _ string, _ store.MemoryScope, _, prefix string, _ int) ([]store.MemoryEntry, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]store.MemoryEntry, 0, len(s.rows))
+	for k, r := range s.rows {
+		if prefix != "" && !strings.HasPrefix(k, prefix) {
+			continue
+		}
+		out = append(out, store.MemoryEntry{Key: k, Value: append(json.RawMessage(nil), r.value...)})
+	}
+	return out, false, nil
+}
+
+func (s *helpFakeStore) MemorySet(_ context.Context, _ string, _ store.MemoryScope, _, key string, value json.RawMessage, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.setCount++
+	r := s.rows[key]
+	if r == nil {
+		r = &helpFakeRow{}
+		s.rows[key] = r
+	}
+	r.value = append(json.RawMessage(nil), value...)
+	return nil
+}
+
+func (s *helpFakeStore) MemoryEmbedSet(_ context.Context, _ string, _ store.MemoryScope, _, key string, e store.MemoryEmbedding) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.embedSetCount++
+	r := s.rows[key]
+	if r == nil {
+		// Mirror the real FK: base row must exist first.
+		r = &helpFakeRow{}
+		s.rows[key] = r
+	}
+	r.vector = e.Vector
+	r.embedText = e.EmbedText
+	return nil
+}
+
+func (s *helpFakeStore) MemoryDelete(_ context.Context, _ string, _ store.MemoryScope, _, key string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.deleteCount++
+	_, ok := s.rows[key]
+	delete(s.rows, key) // cascades the embedding, as Postgres' FK does
+	return ok, nil
+}
+
+func (s *helpFakeStore) MemoryEmbedSearch(_ context.Context, _ string, _ store.MemoryScope, _, keyPrefix string, query []float32, topK int) ([]store.MemorySearchEntry, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	type scored struct {
+		key string
+		r   *helpFakeRow
+		s   float64
+	}
+	var rows []scored
+	for k, r := range s.rows {
+		if keyPrefix != "" && !strings.HasPrefix(k, keyPrefix) {
+			continue
+		}
+		rows = append(rows, scored{key: k, r: r, s: helpCosine(query, r.vector)})
+	}
+	sortScoredDesc(rows, func(i int) (float64, string) { return rows[i].s, rows[i].key })
+	if len(rows) > topK {
+		rows = rows[:topK]
+	}
+	out := make([]store.MemorySearchEntry, 0, len(rows))
+	for _, sc := range rows {
+		out = append(out, store.MemorySearchEntry{
+			MemoryEntry: store.MemoryEntry{Key: sc.key, Value: append(json.RawMessage(nil), sc.r.value...)},
+			Score:       sc.s,
+		})
+	}
+	return out, nil
+}
+
+func (s *helpFakeStore) MemoryFullTextSearch(_ context.Context, _ string, _ store.MemoryScope, _, keyPrefix, queryText string, topK int) ([]store.MemorySearchEntry, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.fullText {
+		return nil, nil
+	}
+	terms := strings.Fields(strings.ToLower(queryText))
+	type scored struct {
+		key string
+		r   *helpFakeRow
+		s   float64
+	}
+	var rows []scored
+	for k, r := range s.rows {
+		if keyPrefix != "" && !strings.HasPrefix(k, keyPrefix) {
+			continue
+		}
+		lower := strings.ToLower(r.embedText)
+		hits := 0
+		for _, t := range terms {
+			hits += strings.Count(lower, t)
+		}
+		if hits == 0 {
+			continue
+		}
+		rows = append(rows, scored{key: k, r: r, s: float64(hits)})
+	}
+	sortScoredDesc(rows, func(i int) (float64, string) { return rows[i].s, rows[i].key })
+	if len(rows) > topK {
+		rows = rows[:topK]
+	}
+	out := make([]store.MemorySearchEntry, 0, len(rows))
+	for _, sc := range rows {
+		out = append(out, store.MemorySearchEntry{
+			MemoryEntry: store.MemoryEntry{Key: sc.key, Value: append(json.RawMessage(nil), sc.r.value...)},
+			Score:       sc.s,
+		})
+	}
+	return out, nil
+}
+
+// sortScoredDesc sorts a []scored (accessed via key(i)=(score,tiebreak)) by
+// descending score, then ascending key for stability. Generic over the slice by
+// index so both search legs reuse it.
+func sortScoredDesc[T any](rows []T, key func(i int) (float64, string)) {
+	// insertion sort is fine — the test corpora are tiny.
+	for i := 1; i < len(rows); i++ {
+		for j := i; j > 0; j-- {
+			sj, kj := key(j)
+			sp, kp := key(j - 1)
+			less := sj > sp || (sj == sp && kj < kp)
+			if !less {
+				break
+			}
+			rows[j], rows[j-1] = rows[j-1], rows[j]
+		}
+	}
+}
+
+func helpCosine(a, b []float32) float64 {
+	if len(a) != len(b) || len(a) == 0 {
+		return 0
+	}
+	var dot, na, nb float64
+	for i := range a {
+		dot += float64(a[i]) * float64(b[i])
+		na += float64(a[i]) * float64(a[i])
+		nb += float64(b[i]) * float64(b[i])
+	}
+	if na == 0 || nb == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(na) * math.Sqrt(nb))
+}
+
+// ---- tests ----
+
+// TestHelpIndex_ReconcileReembedsOnlyChanged asserts the content-hash gate: an
+// unchanged corpus makes zero embed writes; a changed section re-writes ONLY
+// itself; a removed section is pruned.
+func TestHelpIndex_ReconcileReembedsOnlyChanged(t *testing.T) {
+	topicA := &Topic{Name: "alpha", Description: "d", Content: "## Widgets\nThe frobnicator assembles widgets.\n\n## Sprockets\nA sprocket spins.\n"}
+	topicB := &Topic{Name: "beta", Description: "d", Content: "## Gadgets\nA sprocket drives gadgets.\n"}
+	set := newHelpTestSet(topicA, topicB)
+	st := newHelpFakeStore()
+	emb := newHelpFakeEmbedder("frobnicator", "assembles", "widgets", "sprocket", "spins", "drives", "gadgets")
+	ctx := context.Background()
+
+	total := len(AllSections(set)) // 3: alpha#Widgets, alpha#Sprockets, beta#Gadgets
+	if total != 3 {
+		t.Fatalf("expected 3 sections, got %d", total)
+	}
+
+	// Reconcile #1: full index.
+	stats, err := ReconcileIndex(ctx, set, st, emb)
+	if err != nil {
+		t.Fatalf("reconcile #1: %v", err)
+	}
+	if stats.Written != total || stats.Pruned != 0 || stats.Unchanged != 0 {
+		t.Fatalf("reconcile #1 stats = %+v, want Written=%d Pruned=0 Unchanged=0", stats, total)
+	}
+	if st.embedSetCount != total {
+		t.Fatalf("reconcile #1 embedSet calls = %d, want %d", st.embedSetCount, total)
+	}
+
+	// Reconcile #2: unchanged corpus => ZERO embed calls / writes.
+	st.embedSetCount, st.setCount, st.deleteCount = 0, 0, 0
+	emb.embedCalls, emb.embedTexts = 0, 0
+	stats, err = ReconcileIndex(ctx, set, st, emb)
+	if err != nil {
+		t.Fatalf("reconcile #2: %v", err)
+	}
+	if stats.Written != 0 || stats.Unchanged != total || stats.Pruned != 0 {
+		t.Fatalf("reconcile #2 stats = %+v, want Written=0 Unchanged=%d Pruned=0", stats, total)
+	}
+	if emb.embedCalls != 0 || emb.embedTexts != 0 || st.embedSetCount != 0 || st.setCount != 0 {
+		t.Fatalf("reconcile #2 did work on an unchanged corpus: embedCalls=%d embedTexts=%d embedSet=%d set=%d",
+			emb.embedCalls, emb.embedTexts, st.embedSetCount, st.setCount)
+	}
+
+	// Change ONE section's body (same heading => same key). Only it re-writes.
+	topicA.Content = "## Widgets\nThe frobnicator now assembles many widgets carefully.\n\n## Sprockets\nA sprocket spins.\n"
+	st.embedSetCount, st.setCount, st.deleteCount = 0, 0, 0
+	emb.embedCalls, emb.embedTexts = 0, 0
+	stats, err = ReconcileIndex(ctx, set, st, emb)
+	if err != nil {
+		t.Fatalf("reconcile #3: %v", err)
+	}
+	if stats.Written != 1 || stats.Unchanged != total-1 || stats.Pruned != 0 {
+		t.Fatalf("reconcile #3 stats = %+v, want Written=1 Unchanged=%d Pruned=0", stats, total-1)
+	}
+	if emb.embedTexts != 1 || st.embedSetCount != 1 {
+		t.Fatalf("reconcile #3 re-embedded more than the changed section: embedTexts=%d embedSet=%d", emb.embedTexts, st.embedSetCount)
+	}
+
+	// Remove a section (drop alpha#Sprockets) => it is pruned.
+	topicA.Content = "## Widgets\nThe frobnicator now assembles many widgets carefully.\n"
+	st.embedSetCount, st.setCount, st.deleteCount = 0, 0, 0
+	emb.embedCalls, emb.embedTexts = 0, 0
+	stats, err = ReconcileIndex(ctx, set, st, emb)
+	if err != nil {
+		t.Fatalf("reconcile #4: %v", err)
+	}
+	if stats.Pruned != 1 || stats.Written != 0 {
+		t.Fatalf("reconcile #4 stats = %+v, want Pruned=1 Written=0", stats)
+	}
+	if st.deleteCount != 1 {
+		t.Fatalf("reconcile #4 delete calls = %d, want 1", st.deleteCount)
+	}
+	if _, ok := st.rows["alpha#Sprockets"]; ok {
+		t.Fatalf("alpha#Sprockets was not pruned from the store")
+	}
+}
+
+// TestHelpQuery_HybridSurfacesSection asserts the hybrid (vector ∥ full-text →
+// RRF) path surfaces the right topic/section.
+func TestHelpQuery_HybridSurfacesSection(t *testing.T) {
+	topicA := &Topic{Name: "alpha", Description: "d", Content: "## Widgets\nThe frobnicator assembles widgets neatly.\n"}
+	topicB := &Topic{Name: "beta", Description: "d", Content: "## Gadgets\nA sprocket drives gadgets.\n"}
+	set := newHelpTestSet(topicA, topicB)
+	st := newHelpFakeStore()
+	emb := newHelpFakeEmbedder("frobnicator", "assembles", "widgets", "neatly", "sprocket", "drives", "gadgets")
+	ctx := context.Background()
+
+	if _, err := ReconcileIndex(ctx, set, st, emb); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	res, err := QueryIndex(ctx, set, st, emb, "frobnicator widgets", 5)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if res.Mode != "hybrid" {
+		t.Fatalf("mode = %q, want hybrid", res.Mode)
+	}
+	if len(res.Results) == 0 {
+		t.Fatalf("no results")
+	}
+	if res.Results[0].TopicSlug != "alpha" || res.Results[0].Heading != "Widgets" {
+		t.Fatalf("top hit = %+v, want alpha#Widgets", res.Results[0])
+	}
+	if res.Results[0].Snippet == "" {
+		t.Fatalf("top hit has empty snippet")
+	}
+}
+
+// TestHelpQuery_DegradesToSubstringWithoutIndex asserts query still works with no
+// embedder/store — a substring scan over the in-memory Set.
+func TestHelpQuery_DegradesToSubstringWithoutIndex(t *testing.T) {
+	topicA := &Topic{Name: "alpha", Description: "d", Content: "## Widgets\nThe frobnicator assembles widgets neatly.\n"}
+	topicB := &Topic{Name: "beta", Description: "d", Content: "## Gadgets\nA sprocket drives gadgets.\n"}
+	set := newHelpTestSet(topicA, topicB)
+
+	// No store, no embedder → degrade path.
+	res, err := QueryIndex(context.Background(), set, nil, nil, "frobnicator", 5)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if res.Mode != "substring" {
+		t.Fatalf("mode = %q, want substring", res.Mode)
+	}
+	if len(res.Results) != 1 {
+		t.Fatalf("results = %d, want 1", len(res.Results))
+	}
+	if res.Results[0].TopicSlug != "alpha" || res.Results[0].Heading != "Widgets" {
+		t.Fatalf("hit = %+v, want alpha#Widgets", res.Results[0])
+	}
+}
+
+// TestHelpQuery_MermaidSourceSearchable asserts a mermaid diagram's SOURCE (a
+// node label) is indexed as text and thus searchable (RFC BL §2.9), and that a
+// `## ` inside a fenced block does NOT spuriously split a section.
+func TestHelpQuery_MermaidSourceSearchable(t *testing.T) {
+	content := "## Flow\n" +
+		"Here is the pipeline:\n\n" +
+		"```mermaid\n" +
+		"graph TD\n" +
+		"  A[\"Frobnicator Pipeline\"] --> B[Sink]\n" +
+		"```\n\n" +
+		"Example config:\n\n" +
+		"```yaml\n" +
+		"## NotAHeading inside a fence\n" +
+		"key: value\n" +
+		"```\n"
+	topic := &Topic{Name: "diagrams", Description: "d", Content: content}
+	set := newHelpTestSet(topic)
+
+	// Section splitter: exactly one `##` section, its Text keeps the mermaid
+	// source, and the fenced `## NotAHeading` did not create a section.
+	secs := sectionsForTopic(topic)
+	if len(secs) != 1 {
+		t.Fatalf("expected 1 section, got %d: %+v", len(secs), secs)
+	}
+	if secs[0].Heading != "Flow" {
+		t.Fatalf("heading = %q, want Flow", secs[0].Heading)
+	}
+	if !strings.Contains(secs[0].Text, "Frobnicator Pipeline") {
+		t.Fatalf("mermaid node label was stripped from section text")
+	}
+
+	// Query (degrade path) matches the mermaid label.
+	res, err := QueryIndex(context.Background(), set, nil, nil, "Frobnicator", 5)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(res.Results) != 1 || res.Results[0].TopicSlug != "diagrams" || res.Results[0].Heading != "Flow" {
+		t.Fatalf("results = %+v, want one diagrams#Flow hit", res.Results)
+	}
+}
+
+// TestHelpIndex_SingletonUnderConcurrentBoot runs two reconciles concurrently
+// (exercised under `go test -race`) and asserts the store ends in the exact
+// desired state — no duplicate/racy writes. (Cluster-wide single-runner-ness is
+// the advisory lock's job, integration-tested with Postgres; this asserts the
+// reconcile itself is internally race-safe + idempotent.)
+func TestHelpIndex_SingletonUnderConcurrentBoot(t *testing.T) {
+	topicA := &Topic{Name: "alpha", Description: "d", Content: "## Widgets\nThe frobnicator assembles widgets.\n\n## Sprockets\nA sprocket spins.\n"}
+	topicB := &Topic{Name: "beta", Description: "d", Content: "## Gadgets\nA sprocket drives gadgets.\n"}
+	set := newHelpTestSet(topicA, topicB)
+	st := newHelpFakeStore()
+	emb := newHelpFakeEmbedder("frobnicator", "assembles", "widgets", "sprocket", "spins", "drives", "gadgets")
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := ReconcileIndex(ctx, set, st, emb); err != nil {
+				t.Errorf("concurrent reconcile: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	want := AllSections(set)
+	st.mu.Lock()
+	got := len(st.rows)
+	st.mu.Unlock()
+	if got != len(want) {
+		t.Fatalf("store has %d rows, want exactly %d (no duplicates)", got, len(want))
+	}
+	for _, s := range want {
+		st.mu.Lock()
+		_, ok := st.rows[s.Key]
+		st.mu.Unlock()
+		if !ok {
+			t.Fatalf("desired section %q missing from store", s.Key)
+		}
+	}
+}

--- a/internal/help/index_test.go
+++ b/internal/help/index_test.go
@@ -3,6 +3,7 @@ package help
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"math"
 	"strings"
 	"sync"
@@ -30,8 +31,12 @@ func newHelpTestSet(topics ...*Topic) *Set {
 
 // helpFakeEmbedder one-hot encodes tokens against a fixed vocab and counts calls
 // + total texts embedded, so a test can assert reconcile made zero embed calls.
+// The counters are mutex-guarded so the concurrent-boot test is race-clean under
+// `go test -race` (vocab is set once at construction and only read).
 type helpFakeEmbedder struct {
-	vocab      map[string]int
+	vocab map[string]int
+
+	mu         sync.Mutex
 	embedCalls int
 	embedTexts int
 }
@@ -45,8 +50,10 @@ func newHelpFakeEmbedder(tokens ...string) *helpFakeEmbedder {
 }
 
 func (f *helpFakeEmbedder) Embed(_ context.Context, texts []string) ([][]float32, error) {
+	f.mu.Lock()
 	f.embedCalls++
 	f.embedTexts += len(texts)
+	f.mu.Unlock()
 	out := make([][]float32, len(texts))
 	for i, txt := range texts {
 		vec := make([]float32, len(f.vocab))
@@ -77,6 +84,12 @@ type helpFakeStore struct {
 	setCount      int
 	embedSetCount int
 	deleteCount   int
+
+	// Error injection for the degrade/atomic-write tests. When set, the
+	// corresponding op returns the error instead of doing its work — modelling a
+	// transient embedder/store fault (dimension-mismatch window, embed-set flake).
+	embedSearchErr error
+	embedSetErr    error
 }
 
 type helpFakeRow struct {
@@ -121,6 +134,9 @@ func (s *helpFakeStore) MemorySet(_ context.Context, _ string, _ store.MemorySco
 func (s *helpFakeStore) MemoryEmbedSet(_ context.Context, _ string, _ store.MemoryScope, _, key string, e store.MemoryEmbedding) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.embedSetErr != nil {
+		return s.embedSetErr // base row already written by the caller's MemorySet
+	}
 	s.embedSetCount++
 	r := s.rows[key]
 	if r == nil {
@@ -145,6 +161,9 @@ func (s *helpFakeStore) MemoryDelete(_ context.Context, _ string, _ store.Memory
 func (s *helpFakeStore) MemoryEmbedSearch(_ context.Context, _ string, _ store.MemoryScope, _, keyPrefix string, query []float32, topK int) ([]store.MemorySearchEntry, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.embedSearchErr != nil {
+		return nil, s.embedSearchErr
+	}
 	type scored struct {
 		key string
 		r   *helpFakeRow
@@ -376,6 +395,106 @@ func TestHelpQuery_DegradesToSubstringWithoutIndex(t *testing.T) {
 	}
 	if res.Results[0].TopicSlug != "alpha" || res.Results[0].Heading != "Widgets" {
 		t.Fatalf("hit = %+v, want alpha#Widgets", res.Results[0])
+	}
+}
+
+// TestHelpQuery_DegradesToSubstringOnHybridError asserts that when the hybrid
+// path errors (e.g. a transient embedder failure, or the dimension-mismatch
+// window during an embedder swap before the boot reconcile catches up), query
+// does NOT hard-fail — it warns and degrades to the substring scan so the caller
+// still gets useful results (query's "always returns something" contract).
+func TestHelpQuery_DegradesToSubstringOnHybridError(t *testing.T) {
+	topicA := &Topic{Name: "alpha", Description: "d", Content: "## Widgets\nThe frobnicator assembles widgets neatly.\n"}
+	topicB := &Topic{Name: "beta", Description: "d", Content: "## Gadgets\nA sprocket drives gadgets.\n"}
+	set := newHelpTestSet(topicA, topicB)
+	st := newHelpFakeStore()
+	emb := newHelpFakeEmbedder("frobnicator", "assembles", "widgets", "neatly", "sprocket", "drives", "gadgets")
+	ctx := context.Background()
+
+	if _, err := ReconcileIndex(ctx, set, st, emb); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	// Model the dimension-mismatch window: the vector leg errors for every query
+	// until the boot reconcile re-embeds the stale rows.
+	st.embedSearchErr = errors.New("memory: query embedding dimension 8 does not match stored rows' dimension 16")
+
+	res, err := QueryIndex(ctx, set, st, emb, "frobnicator widgets", 5)
+	if err != nil {
+		t.Fatalf("query hard-failed on a hybrid error; want graceful degrade: %v", err)
+	}
+	if res.Mode != "substring" {
+		t.Fatalf("mode = %q, want substring (degraded)", res.Mode)
+	}
+	if len(res.Results) == 0 || res.Results[0].TopicSlug != "alpha" || res.Results[0].Heading != "Widgets" {
+		t.Fatalf("degraded results = %+v, want alpha#Widgets", res.Results)
+	}
+}
+
+// TestHelpIndex_ReconcileEmbedFailureNotMarkedDone asserts the atomic-write
+// invariant: when the embed-set fails after the base row is written, the section
+// is NOT recorded as done (it keeps the empty sentinel hash), so the next
+// reconcile re-attempts it rather than leaving it permanently un-embedded.
+func TestHelpIndex_ReconcileEmbedFailureNotMarkedDone(t *testing.T) {
+	topic := &Topic{Name: "alpha", Description: "d", Content: "## Widgets\nThe frobnicator assembles widgets.\n"}
+	set := newHelpTestSet(topic)
+	st := newHelpFakeStore()
+	emb := newHelpFakeEmbedder("frobnicator", "assembles", "widgets")
+	ctx := context.Background()
+
+	total := len(AllSections(set)) // 1
+	if total != 1 {
+		t.Fatalf("expected 1 section, got %d", total)
+	}
+
+	// Reconcile #1: the embed-set fails. The section must be counted failed and
+	// left WITHOUT a matching hash (so it is retried), not abort the whole index.
+	st.embedSetErr = errors.New("simulated embed-set failure")
+	stats, err := ReconcileIndex(ctx, set, st, emb)
+	if err != nil {
+		t.Fatalf("reconcile #1 must not abort on a per-section embed failure: %v", err)
+	}
+	if stats.Written != 0 || stats.Failed != total {
+		t.Fatalf("reconcile #1 stats = %+v, want Written=0 Failed=%d", stats, total)
+	}
+	// The base row exists (FK parent) but carries the "" sentinel hash — so the
+	// next pass re-attempts it rather than treating it as Unchanged.
+	st.mu.Lock()
+	row, ok := st.rows["alpha#Widgets"]
+	var stored json.RawMessage
+	if ok {
+		stored = append(json.RawMessage(nil), row.value...)
+	}
+	st.mu.Unlock()
+	if !ok {
+		t.Fatalf("base row missing after the phase-1 write")
+	}
+	var v indexValue
+	if err := json.Unmarshal(stored, &v); err != nil {
+		t.Fatalf("unmarshal stored row: %v", err)
+	}
+	if v.Hash != "" {
+		t.Fatalf("stored hash = %q, want empty sentinel (a failed section must not be marked done)", v.Hash)
+	}
+
+	// Reconcile #2: embed-set now succeeds → the section is re-attempted (its
+	// stored "" hash won't match the desired hash), written, and NOT Unchanged.
+	st.embedSetErr = nil
+	stats, err = ReconcileIndex(ctx, set, st, emb)
+	if err != nil {
+		t.Fatalf("reconcile #2: %v", err)
+	}
+	if stats.Written != total || stats.Unchanged != 0 || stats.Failed != 0 {
+		t.Fatalf("reconcile #2 stats = %+v, want Written=%d Unchanged=0 Failed=0", stats, total)
+	}
+
+	// Reconcile #3: the real hash is now recorded → a clean no-op.
+	stats, err = ReconcileIndex(ctx, set, st, emb)
+	if err != nil {
+		t.Fatalf("reconcile #3: %v", err)
+	}
+	if stats.Unchanged != total || stats.Written != 0 {
+		t.Fatalf("reconcile #3 stats = %+v, want Unchanged=%d Written=0", stats, total)
 	}
 }
 

--- a/internal/tools/builtin/context.go
+++ b/internal/tools/builtin/context.go
@@ -71,6 +71,12 @@ type Context struct {
 	// the `help` op refuses with "not configured" (e.g. a test
 	// fixture that didn't wire it).
 	Help *help.Set
+
+	// Embedder powers the `help` op's `query` search mode (RFC BL P1) — the
+	// SAME embedder the Memory tool uses. When nil (or the store has no vector
+	// support), help query degrades to a substring scan over the in-memory
+	// Help set, so query still works. Late-bound in main.go alongside Store.
+	Embedder providers.Embedder
 }
 
 const contextDescription = `Read-only runtime introspection. ` +
@@ -83,7 +89,8 @@ const contextDescription = `Read-only runtime introspection. ` +
 	`Useful for self-evolving agents that build their own task plans and want to inspect ` +
 	`their environment before deciding what to do. ` +
 	`Tip: start with op=help (no topic) to see the topic index, then op=help with topic=<name> ` +
-	`for narrative guidance on cross-cutting patterns like scopes, sub-agents, experimentation.`
+	`for narrative guidance on cross-cutting patterns like scopes, sub-agents, experimentation. ` +
+	`Or op=help with query=<text> to search topic sections directly, then fetch the winning topic.`
 
 const contextInputSchema = `{
   "type": "object",
@@ -94,7 +101,8 @@ const contextInputSchema = `{
     "def_id":          {"type": "string", "description": "lineage / evaluations: the agent_defs row id to inspect. Use Context.agents to discover def_ids first."},
     "depth":           {"type": "integer", "description": "lineage only: max depth to walk in each direction (default 10, cap 100)."},
     "include_lineage": {"type": "boolean", "description": "evaluations only: include ancestors' evaluations in the aggregate (default false)."},
-    "topic":           {"type": "string", "description": "help only: the topic name to fetch detailed content for. Omitted = return the topic index (name + description for each available topic)."}
+    "topic":           {"type": "string", "description": "help only: the topic name to fetch detailed content for. Omitted = return the topic index (name + description for each available topic)."},
+    "query":           {"type": "string", "description": "help only: hybrid search across help topic SECTIONS; returns the top matches as {topic_slug, heading, snippet, score}. Then fetch a match's full content with topic=<topic_slug>. When set, topic is ignored."}
   },
   "required": ["op"],
   "additionalProperties": false
@@ -108,6 +116,7 @@ type contextInput struct {
 	Depth          int    `json:"depth,omitempty"`
 	IncludeLineage bool   `json:"include_lineage,omitempty"`
 	Topic          string `json:"topic,omitempty"`
+	Query          string `json:"query,omitempty"`
 }
 
 // Name implements tools.Tool.
@@ -791,9 +800,25 @@ func filterWildcards(xs []string) []string {
 
 // ---- help ----
 
-func (c *Context) execHelp(_ context.Context, in contextInput) (tools.Result, error) {
+func (c *Context) execHelp(ctx context.Context, in contextInput) (tools.Result, error) {
 	if c.Help == nil {
 		return errResult("help: not configured (no Help registry; operator misconfiguration)"), nil
+	}
+	// Query mode (RFC BL P1): hybrid section search over the help index. Takes
+	// precedence over topic — an agent that knows what it's looking for but not
+	// which topic searches first, then fetches the winning topic by slug.
+	if q := strings.TrimSpace(in.Query); q != "" {
+		res, err := help.QueryIndex(ctx, c.Help, c.Store, c.Embedder, q, 0)
+		if err != nil {
+			return errResult(fmt.Sprintf("help query: %s", err)), nil
+		}
+		return okJSON(map[string]any{
+			"query":   q,
+			"mode":    res.Mode, // "hybrid" (indexed) | "substring" (degraded)
+			"results": res.Results,
+			"count":   len(res.Results),
+			"hint":    "Call help with topic=<topic_slug> to read a matching topic's full content.",
+		})
 	}
 	if in.Topic == "" {
 		// Index mode: return all topics' name + description +

--- a/internal/tools/builtin/memory_test.go
+++ b/internal/tools/builtin/memory_test.go
@@ -81,6 +81,39 @@ func TestMemory_TenantIsolation(t *testing.T) {
 	}
 }
 
+// TestMemory_RejectsGlobalScope pins the isolation invariant the help index
+// (RFC BL P1) depends on: the Memory tool never exposes the reserved `global`
+// scope, so no wire path can reach the reserved `__help__` namespace where the
+// help index lives. resolveScope refuses it both at the ACL gate (default
+// policy) AND at the switch (even a misconfigured policy that lists "global").
+func TestMemory_RejectsGlobalScope(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t)
+	defer cleanup()
+
+	// Default policy is {agent, user}; global is refused at the ACL gate.
+	res, err := tool.Execute(ctx, json.RawMessage(`{"op":"get","scope":"global","key":"__help__"}`))
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("scope=global was accepted; the reserved __help__ namespace must be unreachable")
+	}
+
+	// Defense in depth: even if a policy erroneously lists "global", resolveScope's
+	// switch has no global case, so it still refuses — the reserved namespace
+	// stays unreachable across any future policy refactor.
+	ctx2 := tools.WithAgentName(context.Background(), "qa-agent")
+	ctx2 = tools.WithRunIdentity(ctx2, tools.RunIdentityValue{UserID: "alice"})
+	ctx2 = tools.WithMemoryPolicy(ctx2, tools.MemoryPolicyValue{AllowedScopes: []string{"agent", "user", "global"}})
+	res2, err := tool.Execute(ctx2, json.RawMessage(`{"op":"get","scope":"global","key":"__help__"}`))
+	if err != nil {
+		t.Fatalf("execute (policy-allows-global): %v", err)
+	}
+	if !res2.IsError {
+		t.Fatalf("scope=global accepted via resolveScope switch; reserved namespace reachable")
+	}
+}
+
 func TestMemoryTool_SetGetDeleteRoundTrip(t *testing.T) {
 	tool, ctx, cleanup := memoryFixture(t)
 	defer cleanup()


### PR DESCRIPTION
**Stacked PR — base is `feature-rfc-bl-p4-doc-tier` (PR #804).** Review/merge in order: #801 → #802 → #803 → #804 → this. Fifth of the RFC BL P1 series.

## Why

`Context op=help` requires an agent to already know a topic slug, and loading several topics to find the right one wastes context. This makes the help corpus **searchable** — an agent runs `Context op=help query:"…"`, gets ranked sections, then fetches the one it wants — reusing the PR2 hybrid retrieval stack, LLM-free.

## What

- **Store-backed help index, zero new schema.** Each help topic is split by `##` heading (fence-aware — a `##` inside a ```mermaid/code fence never splits, so diagram source stays in-section and searchable) and indexed into the existing `memory`+`memory_embeddings` tables at a **reserved global namespace** (`tenant_id=""`, `scope=global`, `scope_id="__help__"`, key `<slug>#<heading>`). `embed_text` drives both the vector embedding and the migration-0060 tsvector, so the PR2 hybrid legs work unchanged. The sentinel scope_id is unproducible by any agent Memory/Document op (both `resolveScope`s are a closed agent/user switch), so help never mixes with user/agent/tenant memory in either direction.
- **Boot reconcile (no hot-reload).** At startup, a content+embedder-identity hash per section drives an incremental reconcile: re-embed only changed/new sections, prune removed ones (embedding FK-cascades). An unchanged corpus + unchanged embedder ⇒ **zero embed calls**. Backgrounded, non-fatal, and singleton across replicas via the new `coord.LockKeyHelpIndexReconcile`. Each section is written base-row-first (sentinel hash) → embed → real hash, so a partial write is retried rather than silently left vector-less.
- **`Context op=help query:` mode.** Hybrid (vector ∥ full-text → `FuseRRF`) over the reserved namespace → top-k `{topic_slug, heading, snippet, score}`; **always degrades to an in-memory substring scan** when embeddings/full-text are unavailable OR a hybrid leg errors (transient embedder failure, or the dimension-mismatch window during an embedder swap). `op=help topic:`/index modes unchanged; no cost when `query` is unset.

## Commits

1. `ea59dc90` — implementation.
2. `327a268e` — addresses an independent review: (a) `query:` degrades to substring on a hybrid error instead of hard-failing; (b) reconcile records a section's content-hash only after both the base-row and embedding writes succeed (no "done"-without-vector on partial failure); (c) adds `TestMemory_RejectsGlobalScope` pinning the isolation invariant the help namespace relies on; and fixes an unguarded test-double counter that raced under `-race`. (Review confirmed reserved-namespace isolation both directions, reconcile gating/pruning, hybrid reuse, splitter correctness, determinism, and zero-regression all clean.)

## Tested

- `go build ./...`, `go vet`, `gofmt` clean. `go test ./...` green (PG DSN-gated skip). `-race` clean on `internal/help` incl. the concurrent-boot test.
- Fail-before verified: `TestHelpIndex_ReconcileReembedsOnlyChanged`, `TestHelpQuery_HybridSurfacesSection`, `TestHelpQuery_DegradesToSubstringWithoutIndex`, `TestHelpQuery_DegradesToSubstringOnHybridError`, `TestHelpQuery_MermaidSourceSearchable`, `TestHelpIndex_ReconcileEmbedFailureNotMarkedDone`, `TestHelpIndex_SingletonUnderConcurrentBoot` (`-race`).

## For reviewer attention

The hybrid path is exercised only by fake-store/stub-embedder unit tests here (no live embedder + pgvector in the build env); the live `query:` path (real embeddings + tsvector) runs under the `go-postgres` CI job. Reconcile is best-effort per-section (a single section's embed failure is logged + counted, not fatal to the pass) — say if you'd prefer fail-loud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
