### PR TITLE
feat(memory): read-time dead-link guard + retrieval OTEL metrics (RFC BL P1 PR6)

### DIFF
--- a/internal/api/http/metrics_prom.go
+++ b/internal/api/http/metrics_prom.go
@@ -64,6 +64,13 @@ func (s *Server) handleMetricsProm(w http.ResponseWriter, _ *http.Request) {
 		"Runs waiting in the queue for a slot (semaphore queued count).",
 		replicaLabels, float64(queued))
 
+	// TODO(RFC BL): per-scope memory footprint gauge (row count / bytes per
+	// scope). Deferred from PR6 — there is no cheap all-scopes footprint source:
+	// store.MemoryEmbedStats is per-(tenant,scope) and would require enumerating
+	// every scope_id at scrape time, i.e. the hot per-scrape scan this
+	// substrate-only, live-read endpoint must avoid (see the file-header lock).
+	// Wire it once a cached per-scope sampler exists (RFC BL P2).
+
 	// Per-user series — only emitted when per-user cap is engaged,
 	// otherwise the cardinality of `user_id` could explode on anonymous
 	// workloads. We can't directly observe the cap value from Stats(),

--- a/internal/help/index.go
+++ b/internal/help/index.go
@@ -36,6 +36,7 @@ import (
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/memory"
+	lcotel "github.com/denn-gubsky/loomcycle/internal/otel"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 )
@@ -247,6 +248,7 @@ func ReconcileIndex(ctx context.Context, set *Set, st IndexStore, emb providers.
 	}
 	if st == nil || emb == nil || !st.SupportsVectors() {
 		stats.Degraded = true
+		lcotel.RecordHelpReconcile(ctx, stats.Written, stats.Pruned, stats.Unchanged, stats.Failed, stats.Degraded)
 		return stats, nil
 	}
 
@@ -372,6 +374,10 @@ func ReconcileIndex(ctx context.Context, set *Set, st IndexStore, emb providers.
 		stats.Pruned++
 	}
 
+	// RFC BL PR6: emit the reconcile outcome once at the successful end so a
+	// downstream connector derives written/pruned/unchanged/failed counters +
+	// the degraded gauge. No-op-safe when OTEL is unconfigured.
+	lcotel.RecordHelpReconcile(ctx, stats.Written, stats.Pruned, stats.Unchanged, stats.Failed, stats.Degraded)
 	return stats, nil
 }
 
@@ -411,9 +417,8 @@ func QueryIndex(ctx context.Context, set *Set, st IndexStore, emb providers.Embe
 	}
 
 	if st != nil && emb != nil && st.SupportsVectors() {
-		hits, err := hybridQuery(ctx, st, emb, query, topK)
-		switch {
-		case err != nil:
+		hits, deadDropped, err := hybridQuery(ctx, set, st, emb, query, topK)
+		if err != nil {
 			// A hybrid failure must NOT hard-fail the caller — query's contract
 			// is "always returns useful results". Two real cases hit this exactly
 			// when the fallback should kick in: a transient embedder API error on
@@ -424,25 +429,33 @@ func QueryIndex(ctx context.Context, set *Set, st IndexStore, emb providers.Embe
 			// against the stale rows). Warn and fall through to the substring scan,
 			// exactly as the empty-index case below does.
 			log.Printf("help query: hybrid path failed, degrading to substring: %v", err)
-		case len(hits) > 0:
-			return QueryResults{Mode: "hybrid", Results: hits}, nil
+		} else {
+			// Record dead-link drops even when every hit was dead (so the signal
+			// is emitted before falling through to the substring scan). No-op-safe.
+			lcotel.RecordDeadlinkDroppedCtx(ctx, deadDropped)
+			if len(hits) > 0 {
+				return QueryResults{Mode: "hybrid", Results: hits}, nil
+			}
 		}
-		// Hybrid error OR empty index (reconcile not done / no match) → fall
-		// through to the substring scan so the caller still gets something.
+		// Hybrid error OR empty index (reconcile not done / no match / all hits
+		// were dead links) → fall through to the substring scan over the live
+		// in-memory Set, which can never surface a dead link.
 	}
 	return QueryResults{Mode: "substring", Results: substringQuery(set, query, topK)}, nil
 }
 
 // hybridQuery embeds the query and fuses the vector + full-text legs via RRF over
 // the reserved help namespace. Mirrors the in-process Memory backend's hybrid
-// retrieval so help search behaves like memory search.
-func hybridQuery(ctx context.Context, st IndexStore, emb providers.Embedder, query string, topK int) ([]QueryResult, error) {
+// retrieval so help search behaves like memory search. It also applies the RFC
+// BL §2.10 read-time dead-link guard (see the filter loop below) and returns the
+// number of hits it dropped so the caller can emit the dead-link signal.
+func hybridQuery(ctx context.Context, set *Set, st IndexStore, emb providers.Embedder, query string, topK int) ([]QueryResult, int, error) {
 	vecs, err := emb.Embed(ctx, []string{query})
 	if err != nil {
-		return nil, fmt.Errorf("help query: embed: %w", err)
+		return nil, 0, fmt.Errorf("help query: embed: %w", err)
 	}
 	if len(vecs) != 1 {
-		return nil, fmt.Errorf("help query: embed returned %d vectors, want 1", len(vecs))
+		return nil, 0, fmt.Errorf("help query: embed returned %d vectors, want 1", len(vecs))
 	}
 	fetch := topK * 4
 	if fetch < topK {
@@ -453,23 +466,37 @@ func hybridQuery(ctx context.Context, st IndexStore, emb providers.Embedder, que
 	}
 	vres, err := st.MemoryEmbedSearch(ctx, helpTenant, helpScope, HelpNamespaceScopeID, "", vecs[0], fetch)
 	if err != nil {
-		return nil, fmt.Errorf("help query: vector leg: %w", err)
+		return nil, 0, fmt.Errorf("help query: vector leg: %w", err)
 	}
 	// (nil, nil) when the store has no full-text index — the fusion then
 	// collapses to pure-vector.
 	fres, err := st.MemoryFullTextSearch(ctx, helpTenant, helpScope, HelpNamespaceScopeID, "", query, fetch)
 	if err != nil {
-		return nil, fmt.Errorf("help query: full-text leg: %w", err)
+		return nil, 0, fmt.Errorf("help query: full-text leg: %w", err)
 	}
 	fused := memory.FuseRRF(vres, fres, memory.RRFDefaultK)
 	if len(fused) > topK {
 		fused = fused[:topK]
 	}
 	out := make([]QueryResult, 0, len(fused))
+	dead := 0
 	for _, e := range fused {
 		var v indexValue
 		if json.Unmarshal(e.Value, &v) != nil {
 			continue // not one of our rows / unparseable — skip defensively
+		}
+		// RFC BL §2.10 read-time dead-link guard: an index row can outlive its
+		// topic in the window between a new-binary boot that dropped the topic
+		// from the go:embed corpus and the backgrounded reconcile pruning the
+		// stale row. Drop any hit whose topic is no longer in the live in-memory
+		// Set so a query never points an agent at a topic it can't fetch. The
+		// reconcile prune remains the authoritative cleanup; this is the read-
+		// time floor. Counting is the bounded, non-blocking cleanup signal — no
+		// store write on the read path.
+		if _, ok := set.Get(v.TopicSlug); !ok {
+			dead++
+			log.Printf("help query: dropped dead-link hit topic=%q heading=%q (topic no longer in corpus)", v.TopicSlug, v.Heading)
+			continue
 		}
 		out = append(out, QueryResult{
 			TopicSlug: v.TopicSlug,
@@ -480,7 +507,7 @@ func hybridQuery(ctx context.Context, st IndexStore, emb providers.Embedder, que
 			Score: e.SemanticScore,
 		})
 	}
-	return out, nil
+	return out, dead, nil
 }
 
 // substringQuery scans the in-memory Set for sections containing the query terms

--- a/internal/help/index_test.go
+++ b/internal/help/index_test.go
@@ -10,7 +10,11 @@ import (
 	"testing"
 	"time"
 
+	lcotel "github.com/denn-gubsky/loomcycle/internal/otel"
 	"github.com/denn-gubsky/loomcycle/internal/store"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 // ---- test fixtures ----
@@ -578,5 +582,116 @@ func TestHelpIndex_SingletonUnderConcurrentBoot(t *testing.T) {
 		if !ok {
 			t.Fatalf("desired section %q missing from store", s.Key)
 		}
+	}
+}
+
+// ---- RFC BL PR6: read-time dead-link guard + reconcile OTEL metric ----
+
+func withInMemoryExporter(t *testing.T) *tracetest.InMemoryExporter {
+	t.Helper()
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	cleanup := lcotel.SetTracerProviderForTest(tp)
+	t.Cleanup(func() {
+		cleanup()
+		_ = tp.Shutdown(context.Background())
+	})
+	return exp
+}
+
+// TestHelpQuery_DeadLinkDroppedFromResults pins the RFC BL §2.10 read-time
+// dead-link floor for the help case: an index row can outlive its topic in the
+// window between a new-binary boot that dropped the topic from the corpus and
+// the backgrounded reconcile pruning the stale row. A hybrid hit whose topic is
+// no longer in the live in-memory Set is dropped from results; a live hit is
+// kept. FAIL-BEFORE: without the guard the query returns the dropped topic's
+// section, so the "alpha absent" assertion fails.
+func TestHelpQuery_DeadLinkDroppedFromResults(t *testing.T) {
+	// Both topics share the "sprocket" token so one query matches both.
+	alpha := &Topic{Name: "alpha", Description: "d", Content: "## Widgets\nThe sprocket assembles widgets.\n"}
+	beta := &Topic{Name: "beta", Description: "d", Content: "## Gadgets\nThe sprocket drives gadgets.\n"}
+	full := newHelpTestSet(alpha, beta)
+	st := newHelpFakeStore()
+	emb := newHelpFakeEmbedder("sprocket", "assembles", "widgets", "drives", "gadgets")
+	ctx := context.Background()
+
+	// Index BOTH topics — the store now holds alpha's section rows.
+	if _, err := ReconcileIndex(ctx, full, st, emb); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	// A NEW binary boots with a corpus that dropped `alpha` (the reconcile that
+	// would prune alpha's stale rows hasn't run yet). Query against the same
+	// store with the reduced live Set.
+	live := newHelpTestSet(beta)
+	res, err := QueryIndex(ctx, live, st, emb, "sprocket", 5)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if res.Mode != "hybrid" {
+		t.Fatalf("mode = %q, want hybrid", res.Mode)
+	}
+	if len(res.Results) == 0 {
+		t.Fatalf("no results; the live beta hit should survive")
+	}
+	for _, r := range res.Results {
+		if r.TopicSlug == "alpha" {
+			t.Fatalf("dead-link hit for dropped topic %q not filtered: %+v", "alpha", res.Results)
+		}
+	}
+	var sawBeta bool
+	for _, r := range res.Results {
+		if r.TopicSlug == "beta" {
+			sawBeta = true
+		}
+	}
+	if !sawBeta {
+		t.Fatalf("live hit for beta not kept: %+v", res.Results)
+	}
+}
+
+// TestMetrics_HelpReconcileEmitted pins the RFC BL PR6 reconcile telemetry: a
+// boot reconcile emits one loomcycle.help.reconcile span carrying the
+// written/pruned/unchanged/failed counts + the degraded flag. FAIL-BEFORE:
+// without RecordHelpReconcile no such span is emitted (spans==0).
+func TestMetrics_HelpReconcileEmitted(t *testing.T) {
+	exp := withInMemoryExporter(t)
+	topic := &Topic{Name: "alpha", Description: "d", Content: "## Widgets\nThe sprocket assembles widgets.\n\n## Sprockets\nA sprocket spins.\n"}
+	set := newHelpTestSet(topic)
+	st := newHelpFakeStore()
+	emb := newHelpFakeEmbedder("sprocket", "assembles", "widgets", "spins")
+	ctx := context.Background()
+
+	want := len(AllSections(set)) // 2
+	stats, err := ReconcileIndex(ctx, set, st, emb)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if stats.Written != want {
+		t.Fatalf("precondition: Written=%d, want %d", stats.Written, want)
+	}
+
+	var rec *tracetest.SpanStub
+	for i := range exp.GetSpans() {
+		s := exp.GetSpans()[i]
+		if s.Name == lcotel.SpanHelpReconcile {
+			rec = &s
+			break
+		}
+	}
+	if rec == nil {
+		t.Fatalf("no %q span recorded; got %d spans", lcotel.SpanHelpReconcile, len(exp.GetSpans()))
+	}
+	ints := map[string]int64{}
+	bools := map[string]bool{}
+	for _, kv := range rec.Attributes {
+		ints[string(kv.Key)] = kv.Value.AsInt64()
+		bools[string(kv.Key)] = kv.Value.AsBool()
+	}
+	if ints[lcotel.AttrHelpWritten] != int64(want) {
+		t.Errorf("%s = %d, want %d", lcotel.AttrHelpWritten, ints[lcotel.AttrHelpWritten], want)
+	}
+	if bools[lcotel.AttrHelpDegraded] {
+		t.Errorf("%s = true, want false", lcotel.AttrHelpDegraded)
 	}
 }

--- a/internal/memory/backends/inprocess/inprocess.go
+++ b/internal/memory/backends/inprocess/inprocess.go
@@ -11,9 +11,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"time"
 
 	memory "github.com/denn-gubsky/loomcycle/internal/memory"
+	lcotel "github.com/denn-gubsky/loomcycle/internal/otel"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
@@ -162,6 +164,15 @@ func (b *Backend) Search(ctx context.Context, scope store.MemoryScope, scopeID s
 		return memory.SearchResult{}, store.ErrEmbedderNotConfigured
 	}
 
+	// RFC BL PR6: one loomcycle.memory.search span per retrieval — the span
+	// duration is the retrieval latency (the loomcycle.memory.search.latency
+	// histogram derives from it downstream), and it carries the mode + dead-link
+	// counts set at the end. Opened AFTER the two pre-flight refusals so the
+	// latency series measures real retrieval, not an instantaneous config error.
+	// No-op-safe: a no-op tracer when OTEL is unconfigured.
+	ctx, span := lcotel.RecordMemorySearch(ctx, "inprocess")
+	defer span.End()
+
 	topK := q.TopK
 
 	// Embed the query text. Failures here are the embedder's problem —
@@ -252,6 +263,14 @@ func (b *Backend) Search(ctx context.Context, scope store.MemoryScope, scopeID s
 	if len(deduped) > topK {
 		deduped = deduped[:topK]
 	}
+
+	// RFC BL §2.10 read-time dead-link guard: drop any surviving hit whose
+	// backing resource no longer resolves, BEFORE scoring/access-recording so a
+	// dead link is never scored, never access-bumped, never returned. Runs only
+	// over the trimmed top-k, so it is cheap and no-ops when everything resolves
+	// (the common case — the vector population FK-cascades in P1).
+	deduped, deadDropped := dropDeadLinks(deduped)
+
 	rankScores := memory.ScoreAll(deduped, rank, now)
 
 	// Record a +1 access for the returned entries (batched, off the hot path
@@ -264,6 +283,12 @@ func (b *Backend) Search(ctx context.Context, scope store.MemoryScope, scopeID s
 		}
 	}
 
+	mode := "vector"
+	if hybrid {
+		mode = "hybrid"
+	}
+	lcotel.SetMemorySearchResult(span, mode, topK, deadDropped)
+
 	out := memory.SearchResult{
 		Entries:           deduped,
 		RankScores:        rankScores,
@@ -275,6 +300,35 @@ func (b *Backend) Search(ctx context.Context, scope store.MemoryScope, scopeID s
 		out.RankNote = "source_weight is reserved and contributes 0 until source-score tracking ships"
 	}
 	return out, nil
+}
+
+// dropDeadLinks is the RFC BL §2.10 read-time dead-link floor for the memory
+// tier: it removes ranked hits whose backing resource no longer resolves and
+// reports how many were dropped. A hit whose backing k/v body is gone comes
+// back with an empty Value (the embedding outlived its base row — e.g. a
+// doc.chunk:<id> body that was removed); that is the dead link. In P1 the
+// vector population FK-cascades with its body, so this no-ops for a consistent
+// store — it is the cheap, correct safety net for the doc-memory / entity tiers
+// as they grow.
+//
+// The cleanup signal is bounded and never blocks the read path: dropped hits
+// are counted (surfaced as the loomcycle.memory.deadlink.dropped span event by
+// the caller) and logged, with NO unbounded map and NO store write on the read
+// path. The authoritative sweep of orphaned index rows is deferred to RFC BL P2.
+func dropDeadLinks(entries []store.MemorySearchEntry) ([]store.MemorySearchEntry, int) {
+	dropped := 0
+	kept := make([]store.MemorySearchEntry, 0, len(entries))
+	for _, e := range entries {
+		if len(e.Value) == 0 {
+			dropped++
+			// Debug-level: dead links are rare (a store-consistency window), so
+			// this stays quiet in steady state. No secrets — key only.
+			log.Printf("memory.search: dropped dead-link hit key=%q (backing value no longer resolves)", e.Key)
+			continue
+		}
+		kept = append(kept, e)
+	}
+	return kept, dropped
 }
 
 var _ memory.Backend = (*Backend)(nil)

--- a/internal/memory/backends/inprocess/inprocess.go
+++ b/internal/memory/backends/inprocess/inprocess.go
@@ -179,10 +179,14 @@ func (b *Backend) Search(ctx context.Context, scope store.MemoryScope, scopeID s
 	// surface them directly so operators see exactly what went wrong.
 	vecs, err := b.embedder.Embed(ctx, []string{q.QueryText})
 	if err != nil {
-		return memory.SearchResult{}, fmt.Errorf("embed query: %w", err)
+		err = fmt.Errorf("embed query: %w", err)
+		lcotel.SetSpanError(span, err)
+		return memory.SearchResult{}, err
 	}
 	if len(vecs) != 1 {
-		return memory.SearchResult{}, fmt.Errorf("embed query: got %d vectors, want 1", len(vecs))
+		err = fmt.Errorf("embed query: got %d vectors, want 1", len(vecs))
+		lcotel.SetSpanError(span, err)
+		return memory.SearchResult{}, err
 	}
 	queryVec := vecs[0]
 
@@ -218,12 +222,14 @@ func (b *Backend) Search(ctx context.Context, scope store.MemoryScope, scopeID s
 		// the tool's errors.Is checks match the backend-constructed *MemoryError.
 		vres, verr := b.store.MemoryEmbedSearch(ctx, tenant, scope, scopeID, q.Prefix, queryVec, fetch)
 		if verr != nil {
+			lcotel.SetSpanError(span, verr)
 			return memory.SearchResult{}, verr
 		}
 		// Leg 2: full-text (keyword, ts_rank-ordered). (nil,nil) on a store
 		// without a full-text index, so the fusion collapses to pure-vector.
 		fres, ferr := b.store.MemoryFullTextSearch(ctx, tenant, scope, scopeID, q.Prefix, q.QueryText, fetch)
 		if ferr != nil {
+			lcotel.SetSpanError(span, ferr)
 			return memory.SearchResult{}, ferr
 		}
 		// Fuse by RRF: SemanticScore := the fused rank (the ranker's semantic
@@ -241,6 +247,7 @@ func (b *Backend) Search(ctx context.Context, scope store.MemoryScope, scopeID s
 		}
 		vres, verr := b.store.MemoryEmbedSearch(ctx, tenant, scope, scopeID, q.Prefix, queryVec, fetch)
 		if verr != nil {
+			lcotel.SetSpanError(span, verr)
 			return memory.SearchResult{}, verr
 		}
 		for i := range vres {

--- a/internal/memory/backends/inprocess/inprocess_test.go
+++ b/internal/memory/backends/inprocess/inprocess_test.go
@@ -11,8 +11,12 @@ import (
 
 	memory "github.com/denn-gubsky/loomcycle/internal/memory"
 	"github.com/denn-gubsky/loomcycle/internal/memory/backends/inprocess"
+	lcotel "github.com/denn-gubsky/loomcycle/internal/otel"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 // These tests cover the in-process backend in isolation (the Memory tool
@@ -103,6 +107,11 @@ type vectorStore struct {
 	store.Store
 	mu     sync.Mutex
 	embeds map[string]store.MemoryEmbedding
+	// extra, when non-nil, is appended to every MemoryEmbedSearch result verbatim
+	// — a hook for the dead-link tests to inject an ORPHAN hit (an embedding row
+	// whose backing k/v body is gone, surfaced as an empty Value) that the real
+	// JOIN-based store would normally never return. Default nil → no effect.
+	extra []store.MemorySearchEntry
 }
 
 func newVectorStore(s store.Store) *vectorStore {
@@ -164,6 +173,7 @@ func (v *vectorStore) MemoryEmbedSearch(ctx context.Context, _ string, scope sto
 		se.Vector = r.emb.Vector
 		out = append(out, se)
 	}
+	out = append(out, v.extra...)
 	return out, nil
 }
 
@@ -447,5 +457,123 @@ func TestInProcess_SetNoEmbedWorksWithoutVectorStack(t *testing.T) {
 	b := inprocess.New(s, nil) // bare sqlite: SupportsVectors() == false
 	if _, err := b.Set(context.Background(), store.MemoryScopeUser, "u1", "k", json.RawMessage(`{"v":1}`), memory.SetOptions{}); err != nil {
 		t.Fatalf("non-embed set should succeed on bare store: %v", err)
+	}
+}
+
+// ---- RFC BL PR6: read-time dead-link guard + retrieval OTEL metrics ----
+
+// withInMemoryExporter installs an in-memory span exporter as the global tracer
+// for the duration of t and returns it, so a test can assert what spans landed.
+// Mirrors the canonical harness in internal/otel's recorder_test.go.
+func withInMemoryExporter(t *testing.T) *tracetest.InMemoryExporter {
+	t.Helper()
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	cleanup := lcotel.SetTracerProviderForTest(tp)
+	t.Cleanup(func() {
+		cleanup()
+		_ = tp.Shutdown(context.Background())
+	})
+	return exp
+}
+
+// TestSearch_DeadLinkDroppedFromResults pins the RFC BL §2.10 read-time
+// dead-link floor for the memory tier: a hit whose backing k/v body no longer
+// resolves (surfaced as an empty Value — the embedding outlived its base row,
+// e.g. a removed doc.chunk:<id>) is dropped from the results, while a live hit
+// is kept. FAIL-BEFORE: without dropDeadLinks the orphan is returned as a
+// zero-body entry, so `len==2` / the orphan key is present.
+func TestSearch_DeadLinkDroppedFromResults(t *testing.T) {
+	b, vs, _, cleanup := vectorFixture(t)
+	defer cleanup()
+	ctx := context.Background()
+	scope, id := store.MemoryScopeAgent, "a1"
+
+	// One live, embedded, resolvable row.
+	if r, err := b.Set(ctx, scope, id, "live", json.RawMessage(`{"n":1}`), memory.SetOptions{Embed: true, EmbedText: "alice go"}); err != nil || !r.Embedded {
+		t.Fatalf("set live: r=%+v err=%v", r, err)
+	}
+
+	// Inject an ORPHAN hit: an embedding row whose backing body is gone (empty
+	// Value). A high score puts it inside the top_k so the guard must drop it.
+	vs.extra = []store.MemorySearchEntry{{
+		MemoryEntry: store.MemoryEntry{Key: "doc.chunk:gone" /* Value zero-length */},
+		Score:       0.99,
+	}}
+
+	res, err := b.Search(ctx, scope, id, memory.SearchQuery{QueryText: "alice go", TopK: 10}, memory.DefaultRankConfig(), memory.DedupConfig{})
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if got := countKeyPrefix(res.Entries, "doc.chunk:"); got != 0 {
+		t.Fatalf("dead-link orphan not dropped: %d doc.chunk hit(s) in results %+v", got, res.Entries)
+	}
+	if countKeyPrefix(res.Entries, "live") != 1 {
+		t.Fatalf("live hit was not kept: results %+v", res.Entries)
+	}
+}
+
+// TestMetrics_RetrievalLatencyEmitted pins the RFC BL PR6 retrieval telemetry:
+// a memory search records the loomcycle.memory.search span (its duration is the
+// latency histogram source), labeled by backend + mode, and the dead-link guard
+// increments the deadlink-dropped attribute/event when it drops a hit.
+// FAIL-BEFORE: without RecordMemorySearch/SetMemorySearchResult no such span is
+// emitted (spans==0) and the deadlink attribute is absent.
+func TestMetrics_RetrievalLatencyEmitted(t *testing.T) {
+	exp := withInMemoryExporter(t)
+	b, vs, _, cleanup := vectorFixture(t)
+	defer cleanup()
+	ctx := context.Background()
+	scope, id := store.MemoryScopeAgent, "a1"
+
+	if r, err := b.Set(ctx, scope, id, "live", json.RawMessage(`{"n":1}`), memory.SetOptions{Embed: true, EmbedText: "alice go"}); err != nil || !r.Embedded {
+		t.Fatalf("set live: r=%+v err=%v", r, err)
+	}
+	vs.extra = []store.MemorySearchEntry{{
+		MemoryEntry: store.MemoryEntry{Key: "doc.chunk:gone"},
+		Score:       0.99,
+	}}
+
+	if _, err := b.Search(ctx, scope, id, memory.SearchQuery{QueryText: "alice go", TopK: 5}, memory.DefaultRankConfig(), memory.DedupConfig{}); err != nil {
+		t.Fatalf("search: %v", err)
+	}
+
+	spans := exp.GetSpans()
+	var search *tracetest.SpanStub
+	for i := range spans {
+		if spans[i].Name == lcotel.SpanMemorySearch {
+			search = &spans[i]
+			break
+		}
+	}
+	if search == nil {
+		t.Fatalf("no %q span recorded; got %d spans", lcotel.SpanMemorySearch, len(spans))
+	}
+
+	attrs := map[string]string{}
+	ints := map[string]int64{}
+	for _, kv := range search.Attributes {
+		attrs[string(kv.Key)] = kv.Value.AsString()
+		ints[string(kv.Key)] = kv.Value.AsInt64()
+	}
+	if attrs[lcotel.AttrMemoryBackend] != "inprocess" {
+		t.Errorf("%s = %q, want inprocess", lcotel.AttrMemoryBackend, attrs[lcotel.AttrMemoryBackend])
+	}
+	if m := attrs[lcotel.AttrMemoryMode]; m != "hybrid" && m != "vector" {
+		t.Errorf("%s = %q, want hybrid|vector", lcotel.AttrMemoryMode, m)
+	}
+	if ints[lcotel.AttrDeadlinkDropped] != 1 {
+		t.Errorf("%s = %d, want 1 (one orphan dropped)", lcotel.AttrDeadlinkDropped, ints[lcotel.AttrDeadlinkDropped])
+	}
+
+	// The deadlink drop is also a span event — the downstream counter source.
+	var sawEvent bool
+	for _, ev := range search.Events {
+		if ev.Name == lcotel.EventDeadlinkDropped {
+			sawEvent = true
+		}
+	}
+	if !sawEvent {
+		t.Errorf("no %q span event; events=%+v", lcotel.EventDeadlinkDropped, search.Events)
 	}
 }

--- a/internal/memory/backends/inprocess/inprocess_test.go
+++ b/internal/memory/backends/inprocess/inprocess_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
 
+	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
@@ -575,5 +576,41 @@ func TestMetrics_RetrievalLatencyEmitted(t *testing.T) {
 	}
 	if !sawEvent {
 		t.Errorf("no %q span event; events=%+v", lcotel.EventDeadlinkDropped, search.Events)
+	}
+}
+
+// TestMetrics_FailedSearchMarksSpanErrored pins the RFC BL PR6 span-status
+// floor: when a retrieval fails while the loomcycle.memory.search span is open,
+// the span is marked Error (mirroring Dispatcher.Execute) — otherwise a failed
+// retrieval reads as a success in traces and skews the derived error series. The
+// embed leg is the induced failure here (fakeEmbedder.failNext); the same
+// SetSpanError guards cover the vector/full-text legs.
+// FAIL-BEFORE: without lcotel.SetSpanError on the error path the span ends with
+// the default Unset status, so Status.Code != codes.Error and this fails.
+func TestMetrics_FailedSearchMarksSpanErrored(t *testing.T) {
+	exp := withInMemoryExporter(t)
+	b, _, emb, cleanup := vectorFixture(t)
+	defer cleanup()
+
+	emb.failNext = true // force the query-embed leg to error
+	_, err := b.Search(context.Background(), store.MemoryScopeAgent, "a1",
+		memory.SearchQuery{QueryText: "alice go", TopK: 5}, memory.DefaultRankConfig(), memory.DedupConfig{})
+	if err == nil {
+		t.Fatal("Search: want error from injected embed failure, got nil")
+	}
+
+	spans := exp.GetSpans()
+	var search *tracetest.SpanStub
+	for i := range spans {
+		if spans[i].Name == lcotel.SpanMemorySearch {
+			search = &spans[i]
+			break
+		}
+	}
+	if search == nil {
+		t.Fatalf("no %q span recorded; got %d spans", lcotel.SpanMemorySearch, len(spans))
+	}
+	if search.Status.Code != codes.Error {
+		t.Errorf("span Status.Code = %v, want Error (failed retrieval must not read as success)", search.Status.Code)
 	}
 }

--- a/internal/memory/backends/mem9/mem9.go
+++ b/internal/memory/backends/mem9/mem9.go
@@ -497,8 +497,8 @@ func (b *Backend) Search(ctx context.Context, scope store.MemoryScope, scopeID s
 	ctx, span := lcotel.Tracer().Start(ctx, "loomcycle.memory.search")
 	defer span.End()
 	span.SetAttributes(
-		attribute.String("memory.backend", "mem9"),
-		attribute.Int("memory.top_k", q.TopK),
+		attribute.String(lcotel.AttrMemoryBackend, "mem9"),
+		attribute.Int(lcotel.AttrMemoryTopK, q.TopK),
 	)
 	if b.name != "" {
 		span.SetAttributes(attribute.String("memory.backend_name", b.name))

--- a/internal/memory/backends/mem9/mem9_test.go
+++ b/internal/memory/backends/mem9/mem9_test.go
@@ -11,7 +11,11 @@ import (
 
 	memory "github.com/denn-gubsky/loomcycle/internal/memory"
 	"github.com/denn-gubsky/loomcycle/internal/memory/backends/mem9"
+	lcotel "github.com/denn-gubsky/loomcycle/internal/otel"
 	"github.com/denn-gubsky/loomcycle/internal/store"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 // IMPORTANT — what these tests prove and what they do NOT:
@@ -347,4 +351,65 @@ func keysOf(m map[string]json.RawMessage) []string {
 		out = append(out, k)
 	}
 	return out
+}
+
+// TestMem9_SearchSpanUsesSharedAttrKeys pins that the mem9 backend's
+// loomcycle.memory.search span labels backend/top_k with the SAME shared
+// lcotel constants the in-process backend uses (TestMetrics_RetrievalLatencyEmitted
+// asserts the identical keys), so a spanmetrics grouping by
+// lcotel.AttrMemoryBackend covers BOTH backends as one series. Before this fix
+// mem9 used the unprefixed literals "memory.backend"/"memory.top_k" and silently
+// dropped out of a loomcycle.memory.backend grouping.
+func TestMem9_SearchSpanUsesSharedAttrKeys(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	restore := lcotel.SetTracerProviderForTest(tp)
+	t.Cleanup(func() {
+		restore()
+		_ = tp.Shutdown(context.Background())
+	})
+
+	s := newStub(t)
+	b := newBackend(s, mem9.Tenancy{})
+	s.searchHits = []stubResult{{key: "user/bob/c0", value: `{"n":0}`, score: 0.9}}
+	if _, err := b.Search(context.Background(), store.MemoryScopeUser, "bob",
+		memory.SearchQuery{QueryText: "q", TopK: 7}, memory.DefaultRankConfig(), memory.DedupConfig{}); err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+
+	spans := exp.GetSpans()
+	var search *tracetest.SpanStub
+	for i := range spans {
+		if spans[i].Name == lcotel.SpanMemorySearch {
+			search = &spans[i]
+			break
+		}
+	}
+	if search == nil {
+		t.Fatalf("no %q span recorded; got %d spans", lcotel.SpanMemorySearch, len(spans))
+	}
+
+	var backend string
+	var topK int64
+	var sawBackendKey, sawTopKKey bool
+	for _, kv := range search.Attributes {
+		switch string(kv.Key) {
+		case lcotel.AttrMemoryBackend:
+			backend, sawBackendKey = kv.Value.AsString(), true
+		case lcotel.AttrMemoryTopK:
+			topK, sawTopKKey = kv.Value.AsInt64(), true
+		}
+	}
+	if !sawBackendKey {
+		t.Errorf("span missing shared backend key %q; attrs=%+v", lcotel.AttrMemoryBackend, search.Attributes)
+	}
+	if backend != "mem9" {
+		t.Errorf("%s = %q, want mem9", lcotel.AttrMemoryBackend, backend)
+	}
+	if !sawTopKKey {
+		t.Errorf("span missing shared top_k key %q; attrs=%+v", lcotel.AttrMemoryTopK, search.Attributes)
+	}
+	if topK != 7 {
+		t.Errorf("%s = %d, want 7", lcotel.AttrMemoryTopK, topK)
+	}
 }

--- a/internal/otel/recorder.go
+++ b/internal/otel/recorder.go
@@ -246,6 +246,126 @@ func RecordCompactionCtx(ctx context.Context, trigger string, before, after int)
 	RecordCompaction(trace.SpanFromContext(ctx), trigger, before, after)
 }
 
+// --- RFC BL P1 retrieval telemetry ---
+//
+// Per-op memory-retrieval shape (latency, dead-link drops, boot reconcile)
+// flows through OTEL, NOT the in-process /metrics endpoint: that endpoint is
+// substrate-only by architectural lock (RFC observability-profiles Decision 1
+// — process + concurrency state only), and per-op shape is aggregated
+// downstream from spans by the OTEL Collector's spanmetrics connector. These
+// recorders mirror the mem9 backend's existing loomcycle.memory.search span so
+// the two memory backends produce one consistent series. All are no-op-safe:
+// with OTEL unconfigured Tracer() is a no-op and every call here costs nothing.
+
+// SpanMemorySearch is one memory retrieval. The span DURATION is the retrieval
+// latency, so a downstream spanmetrics connector derives the
+// loomcycle.memory.search.latency histogram (p50/p95) from it, labeled by the
+// backend + mode attributes below.
+const SpanMemorySearch = "loomcycle.memory.search"
+
+// SpanHelpReconcile is the one-shot boot reconcile of the help-topic search
+// index (RFC BL PR5). Its attributes carry the ReconcileStats counts.
+const SpanHelpReconcile = "loomcycle.help.reconcile"
+
+const (
+	// AttrMemoryBackend labels a memory.search span by backend ("inprocess" |
+	// "mem9") so operators can split latency/error series per backend.
+	AttrMemoryBackend = "loomcycle.memory.backend"
+	// AttrMemoryMode is the hybrid-vs-degrade dimension: "hybrid" (vector +
+	// full-text fused by RRF) or "vector" (the cheap pure-vector path).
+	AttrMemoryMode = "loomcycle.memory.mode"
+	// AttrMemoryTopK is the retrieval's requested top_k.
+	AttrMemoryTopK = "loomcycle.memory.top_k"
+	// AttrDeadlinkDropped is the number of hits the read-time dead-link guard
+	// dropped on this retrieval (RFC BL §2.10). The downstream
+	// loomcycle.memory.deadlink.dropped counter derives from the same-named
+	// span event.
+	AttrDeadlinkDropped = "loomcycle.memory.deadlink_dropped"
+
+	// AttrHelpWritten / Pruned / Unchanged / Failed / Degraded mirror the
+	// help.ReconcileStats fields (RFC BL PR5) so the counters + degraded gauge
+	// derive from the reconcile span.
+	AttrHelpWritten   = "loomcycle.help.written"
+	AttrHelpPruned    = "loomcycle.help.pruned"
+	AttrHelpUnchanged = "loomcycle.help.unchanged"
+	AttrHelpFailed    = "loomcycle.help.failed"
+	AttrHelpDegraded  = "loomcycle.help.degraded"
+)
+
+// EventDeadlinkDropped is the span event emitted when the read-time dead-link
+// guard drops at least one hit. A downstream connector counts it into the
+// loomcycle.memory.deadlink.dropped metric.
+const EventDeadlinkDropped = "loomcycle.memory.deadlink.dropped"
+
+// RecordMemorySearch opens loomcycle.memory.search for one retrieval; the span
+// duration IS the retrieval latency. `backend` labels the series. Caller defers
+// span.End() and calls SetMemorySearchResult once mode/top_k/dead-link counts
+// are known.
+func RecordMemorySearch(ctx context.Context, backend string) (context.Context, trace.Span) {
+	var kvs []attribute.KeyValue
+	if backend != "" {
+		kvs = append(kvs, attribute.String(AttrMemoryBackend, backend))
+	}
+	return Tracer().Start(ctx, SpanMemorySearch, trace.WithAttributes(kvs...))
+}
+
+// SetMemorySearchResult stamps the retrieval's mode + top_k on the span, and —
+// when the dead-link guard dropped hits — records the count as both an attribute
+// and a span event (the loomcycle.memory.deadlink.dropped counter source).
+// No-op on a nil / non-recording span.
+func SetMemorySearchResult(span trace.Span, mode string, topK, deadlinkDropped int) {
+	if span == nil || !span.IsRecording() {
+		return
+	}
+	kvs := []attribute.KeyValue{attribute.Int(AttrMemoryTopK, topK)}
+	if mode != "" {
+		kvs = append(kvs, attribute.String(AttrMemoryMode, mode))
+	}
+	if deadlinkDropped > 0 {
+		kvs = append(kvs, attribute.Int(AttrDeadlinkDropped, deadlinkDropped))
+	}
+	span.SetAttributes(kvs...)
+	if deadlinkDropped > 0 {
+		span.AddEvent(EventDeadlinkDropped,
+			trace.WithAttributes(attribute.Int(AttrDeadlinkDropped, deadlinkDropped)))
+	}
+}
+
+// RecordDeadlinkDropped records a dead-link drop count on `span` (attribute +
+// event) when n > 0 — for call sites that ride an enclosing span rather than
+// opening their own memory.search span (the help query path rides the
+// loomcycle.tool.call span). No-op when n <= 0 or the span isn't recording.
+func RecordDeadlinkDropped(span trace.Span, n int) {
+	if span == nil || n <= 0 || !span.IsRecording() {
+		return
+	}
+	span.SetAttributes(attribute.Int(AttrDeadlinkDropped, n))
+	span.AddEvent(EventDeadlinkDropped, trace.WithAttributes(attribute.Int(AttrDeadlinkDropped, n)))
+}
+
+// RecordDeadlinkDroppedCtx is RecordDeadlinkDropped against the current span on
+// ctx — for callers (the help query path) that hold a ctx but not the span.
+func RecordDeadlinkDroppedCtx(ctx context.Context, n int) {
+	RecordDeadlinkDropped(trace.SpanFromContext(ctx), n)
+}
+
+// RecordHelpReconcile emits a one-shot loomcycle.help.reconcile span carrying
+// the boot-reconcile outcome (RFC BL PR5 ReconcileStats). Opened + ended here
+// because reconcile runs once at boot, off any request span. The counts land
+// as attributes so a downstream connector derives written/pruned/unchanged/
+// failed counters + a degraded gauge.
+func RecordHelpReconcile(ctx context.Context, written, pruned, unchanged, failed int, degraded bool) {
+	_, span := Tracer().Start(ctx, SpanHelpReconcile)
+	span.SetAttributes(
+		attribute.Int(AttrHelpWritten, written),
+		attribute.Int(AttrHelpPruned, pruned),
+		attribute.Int(AttrHelpUnchanged, unchanged),
+		attribute.Int(AttrHelpFailed, failed),
+		attribute.Bool(AttrHelpDegraded, degraded),
+	)
+	span.End()
+}
+
 // SetSpanError marks a span as failed with the given error. The message
 // is truncated to a sane length so a noisy provider error doesn't blow
 // up Jaeger storage.


### PR DESCRIPTION
**Stacked PR — base is `feature-rfc-bl-p5-help-index` (PR #805).** Final PR of the RFC BL P1 series. Review/merge in order: #801 → #802 → #803 → #804 → #805 → this.

## Why

Two read-path finishers for P1: a **read-time dead-link guard** so a search never returns a hit whose backing resource is gone, and **retrieval telemetry** so operators can see memory-search latency/error/dead-link rates.

## What

- **Dead-link guard (read-time floor; the periodic GC sweeper is deferred to P2).** After a search ranks/dedups/trims, hits whose backing resource no longer resolves are dropped before return, tenant/scope-correct, over the trimmed top-k only, with a dropped-counter + debug log (no orphan queue — nothing consumes one in P1):
  - **Help query:** a fused hit whose `topic_slug` is gone from the live in-memory `Set` (the boot→reconcile window) is dropped; if all hits are dead, `QueryIndex` falls through to the substring scan (which can't surface a dead link).
  - **Memory/doc (forward-looking):** a hit whose k/v body is gone is dropped. In P1 the vector population is `INNER JOIN`-backed + FK-cascaded, so this is a verified no-op today (an orphan is never returned); it's the correct floor for the non-FK-cascading tiers RFC BL adds later.
- **Retrieval OTEL metrics**, on the existing span surface (no new metrics stack; `/metrics` stays substrate-only per the observability lock — per-op shape flows via spans, mirroring the mem9/compaction precedent):
  - `loomcycle.memory.search` span from the in-process backend (its duration is the latency histogram source), labeled `memory.backend` + `memory.mode` (hybrid|vector) + `memory.top_k`, and now **marked errored on every `Search` failure path** so failed retrievals don't read as successes.
  - `loomcycle.memory.deadlink.dropped` counter/event; `loomcycle.help.reconcile` span (written/pruned/unchanged/failed/degraded from `ReconcileStats`).
  - The mem9 backend's pre-existing `loomcycle.memory.search` span was aligned to the **same shared attribute-key constants**, so both backends now form one consistent series.
  - Per-scope footprint gauge left as a documented `TODO(RFC BL)` (no cheap all-scopes source without a hot per-scrape scan).
  - All no-op-safe: an OTEL-unconfigured deployment records nothing and pays nothing.

## Commits

1. `50593487` — implementation.
2. `7fc30105` — addresses an independent review: aligned mem9's span attr keys to the shared `loomcycle.*` constants (the "one consistent series" the comment promised), and marked the in-process `loomcycle.memory.search` span errored on all five `Search` failure paths (mirroring the `tool.call` convention). Review confirmed the "empty value ⇒ dead" heuristic is unreachable in production (INNER-JOIN search + `JSONB NOT NULL` value + `set` refusing empty), and guard ordering, read-path cost, no-op safety, help fall-through, and zero-regression all clean.

## Tested

- `go build ./...`, `go vet`, `gofmt` clean. `go test ./...` green (PG DSN-gated skip). `-race` clean on the touched packages.
- Fail-before verified: `TestSearch_DeadLinkDroppedFromResults`, `TestMetrics_RetrievalLatencyEmitted`, `TestHelpQuery_DeadLinkDroppedFromResults`, `TestMetrics_HelpReconcileEmitted`, `TestMetrics_FailedSearchMarksSpanErrored`, `TestMem9_SearchSpanUsesSharedAttrKeys`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
