### PR TITLE
feat(explorer): color plan documents + PR-workflow chunk statuses by default

### DIFF
--- a/bundles/doc-colorizer/loomcycle.yaml
+++ b/bundles/doc-colorizer/loomcycle.yaml
@@ -57,6 +57,11 @@ agents:
         "doc.rfc.review": "#6a7bd6",
         "doc.rfc.confirmed": "#3a9ad6",
         "doc.rfc.done": "#2f8fbf",
+        "doc.plan": "#3a9ad6",
+        "doc.plan.draft": "#c99a3a",
+        "doc.plan.review": "#6a7bd6",
+        "doc.plan.confirmed": "#3a9ad6",
+        "doc.plan.done": "#3aa06a",
         "doc.research": "#8a6ad6",
         "doc.research.done": "#8a6ad6",
         "doc.document": "#3aa06a",
@@ -66,7 +71,10 @@ agents:
         "chunk.draft": "#c99a3a",
         "chunk.review": "#6a7bd6",
         "chunk.confirmed": "#3a9ad6",
-        "chunk.done": "#3aa06a"
+        "chunk.done": "#3aa06a",
+        "chunk.backlog": "#8a8f98",
+        "chunk.implementation": "#d1863a",
+        "chunk.merged": "#3aa06a"
       };
 
       function run(input) {

--- a/cmd/loomcycle/embedded/bundles/doc-colorizer.yaml
+++ b/cmd/loomcycle/embedded/bundles/doc-colorizer.yaml
@@ -58,6 +58,11 @@ agents:
         "doc.rfc.review": "#6a7bd6",
         "doc.rfc.confirmed": "#3a9ad6",
         "doc.rfc.done": "#2f8fbf",
+        "doc.plan": "#3a9ad6",
+        "doc.plan.draft": "#c99a3a",
+        "doc.plan.review": "#6a7bd6",
+        "doc.plan.confirmed": "#3a9ad6",
+        "doc.plan.done": "#3aa06a",
         "doc.research": "#8a6ad6",
         "doc.research.done": "#8a6ad6",
         "doc.document": "#3aa06a",
@@ -67,7 +72,10 @@ agents:
         "chunk.draft": "#c99a3a",
         "chunk.review": "#6a7bd6",
         "chunk.confirmed": "#3a9ad6",
-        "chunk.done": "#3aa06a"
+        "chunk.done": "#3aa06a",
+        "chunk.backlog": "#8a8f98",
+        "chunk.implementation": "#d1863a",
+        "chunk.merged": "#3aa06a"
       };
 
       function run(input) {

--- a/packages/explorer/package-lock.json
+++ b/packages/explorer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@loomcycle/explorer",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@loomcycle/explorer",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "react-markdown": "^9.1.0",

--- a/packages/explorer/package.json
+++ b/packages/explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loomcycle/explorer",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "description": "Embeddable React Path VFS + chunked-graph Document browser for the loomcycle agentic runtime (RFC AL / AK) — a themeable, standalone package: a dirent tree with folder/document CRUD and a chunk-tree Document viewer/editor.",
   "license": "Apache-2.0",

--- a/packages/explorer/src/lib/colorScheme.ts
+++ b/packages/explorer/src/lib/colorScheme.ts
@@ -45,6 +45,11 @@ export const DEFAULT_SCHEME: ColorScheme = {
   "doc.rfc.review": "#6a7bd6",
   "doc.rfc.confirmed": "#3a9ad6",
   "doc.rfc.done": "#3aa06a",
+  // plan documents share the RFC lifecycle vocabulary (draft→review→confirmed→done).
+  "doc.plan.draft": "#c99a3a",
+  "doc.plan.review": "#6a7bd6",
+  "doc.plan.confirmed": "#3a9ad6",
+  "doc.plan.done": "#3aa06a",
   "doc.document.done": "#3aa06a",
   "doc.research.done": "#8a6ad6",
   "doc.publication.draft": "#c99a3a",
@@ -52,6 +57,10 @@ export const DEFAULT_SCHEME: ColorScheme = {
   "chunk.review": "#6a7bd6",
   "chunk.confirmed": "#3a9ad6",
   "chunk.done": "#3aa06a",
+  // PR-workflow chunk statuses (a plan document's PR chunks): queued → active → done.
+  "chunk.backlog": "#8a8f98",
+  "chunk.implementation": "#d1863a",
+  "chunk.merged": "#3aa06a",
 };
 
 // TINT_ALPHA washes every scheme color into a tile background — a tint, not a


### PR DESCRIPTION
## Problem
A color-enabled `type: plan` document (e.g. `/loomcycle/docs/plans/rfc-bl-p1-plan`) rendered **uncolored** — both the document row and its chunk tiles — despite `color_enabled: true`. Root cause is a palette gap in **both** default color schemes, not a UI bug:

- **Document tile:** resolved via `doc.<type>.<status>` → `doc.<type>`. With no `doc.plan.*` key, `docColor("plan", …)` returned `undefined` → no tint.
- **PR chunks:** a plan's PR chunks carry status `backlog` / `implementation` / `merged`, but the palette only had `chunk.{draft,review,confirmed,done}` → `chunkColor(...)` `undefined` → no tint. (Section headings have no status and correctly stay neutral.)

## Fix — take plan files into the loop
Extend both default palettes:
- **`packages/explorer/src/lib/colorScheme.ts`** `DEFAULT_SCHEME` (runtime fallback when a doc is color-enabled but has no stored scheme): `+ doc.plan.{draft,review,confirmed,done}` (RFC lifecycle hues) and `+ chunk.{backlog,implementation,merged}` (grey → orange → green = queued → active → done).
- **`bundles/doc-colorizer/loomcycle.yaml`** + its **embedded copy** (the palette the zero-token colorizer *stamps*): the same additions + a generic `doc.plan` fallback (matching that scheme's `doc.<type>` style). Both copies kept byte-identical in the `DEFAULT_SCHEME` block.

Now a plan document colors like an RFC (blue when confirmed) and its PR chunks tint by workflow state — by default, and durably (re-running the colorizer no longer strips them with a plan-less palette).

## Version
`@loomcycle/explorer` 0.4.0 → 0.5.0 (publishes on its own `explorer-v0.5.0` tag at release).

## Tested
- `go test ./cmd/loomcycle/embedded/...` (doc-colorizer bundle + default-stack validation) — green.
- Explorer typecheck + `make build-ui` (web SPA, source-aliases explorer) — green.
- `dist/` is gitignored (CI rebuilds), not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)