### PR TITLE
feat(memory): consolidation substrate — cursors, pending queue, soft-archive + grant (RFC BL P2 PR1)

### DIFF
--- a/internal/agents/loader.go
+++ b/internal/agents/loader.go
@@ -98,6 +98,7 @@ type Agent struct {
 	InheritCoreBlocks     bool
 	MemoryInjectMaxTokens int
 	MemoryProtocol        bool
+	MemoryConsolidation   bool
 	MemoryIndexMaxBytes   int
 	MemoryRoots           string
 	// Channels is the v0.8.4 Channel-tool ACL. Empty Publish /
@@ -329,6 +330,7 @@ type frontmatter struct {
 	InheritCoreBlocks     bool                       `yaml:"inherit_core_blocks"`      // RFC BL P1
 	MemoryInjectMaxTokens int                        `yaml:"memory_inject_max_tokens"` // RFC BL P1
 	MemoryProtocol        bool                       `yaml:"memory_protocol"`          // RFC BL P1
+	MemoryConsolidation   bool                       `yaml:"memory_consolidation"`     // RFC BL P2
 	MemoryIndexMaxBytes   int                        `yaml:"memory_index_max_bytes"`   // RFC BL P1
 	MemoryRoots           string                     `yaml:"memory_roots"`             // RFC BL P1
 	Channels              AgentChannelACL            `yaml:"channels"`
@@ -404,6 +406,7 @@ func parseAgent(raw []byte) (*Agent, error) {
 	a.InheritCoreBlocks = fm.InheritCoreBlocks
 	a.MemoryInjectMaxTokens = fm.MemoryInjectMaxTokens
 	a.MemoryProtocol = fm.MemoryProtocol
+	a.MemoryConsolidation = fm.MemoryConsolidation
 	a.MemoryIndexMaxBytes = fm.MemoryIndexMaxBytes
 	a.MemoryRoots = fm.MemoryRoots
 	a.Channels = fm.Channels

--- a/internal/agents/sign.go
+++ b/internal/agents/sign.go
@@ -134,6 +134,12 @@ type AgentContent struct {
 	MaxIterations         int                   `json:"max_iterations,omitempty"`
 	MaxTokens             int                   `json:"max_tokens,omitempty"`
 	MemoryBackend         string                `json:"memory_backend,omitempty"`
+	// MemoryConsolidation is the RFC BL P2 capability grant, content-identifying
+	// like MemoryProtocol. Its tag sorts between memory_backend and
+	// memory_index_max_bytes, so it is declared here to keep the alphabetical
+	// invariant (declaration order = JSON emit order = the hash input); omitempty
+	// keeps an agent that never sets it byte-stable against pre-feature rows.
+	MemoryConsolidation bool `json:"memory_consolidation,omitempty"`
 	// MemoryIndexMaxBytes / MemoryInjectMaxTokens / MemoryProtocol / MemoryRoots
 	// (RFC BL P1) are content-identifying. Tags are kept in alphabetical order:
 	// memory_index_max_bytes < memory_inject_max_tokens < memory_protocol, and
@@ -314,6 +320,7 @@ func FromYAMLAgent(a *Agent) AgentContent {
 		InheritCoreBlocks:     a.InheritCoreBlocks,
 		MemoryInjectMaxTokens: a.MemoryInjectMaxTokens,
 		MemoryProtocol:        a.MemoryProtocol,
+		MemoryConsolidation:   a.MemoryConsolidation,
 		MemoryIndexMaxBytes:   a.MemoryIndexMaxBytes,
 		MemoryRoots:           a.MemoryRoots,
 	}

--- a/internal/agents/sign_test.go
+++ b/internal/agents/sign_test.go
@@ -36,6 +36,22 @@ func TestSign_UnboundedIterations_IsContentIdentifying(t *testing.T) {
 	}
 }
 
+// TestSign_MemoryConsolidation_IsContentIdentifying pins the RFC BL P2 grant as
+// content-identifying (a fork that toggles it mints a distinct def_id) while
+// staying byte-stable against pre-feature rows when unset (omitempty).
+func TestSign_MemoryConsolidation_IsContentIdentifying(t *testing.T) {
+	base := AgentContent{Name: "consolidator", SystemPrompt: "fold raw memory"}
+	withGrant := base
+	withGrant.MemoryConsolidation = true
+
+	if Sign(base) == Sign(withGrant) {
+		t.Error("MemoryConsolidation not content-identifying: enabling it did not change the hash")
+	}
+	if got, want := Sign(base), Sign(AgentContent{Name: "consolidator", SystemPrompt: "fold raw memory", MemoryConsolidation: false}); got != want {
+		t.Errorf("unset MemoryConsolidation changed the hash (omitempty broken): %s vs %s", got, want)
+	}
+}
+
 func TestSign_DeterministicAcrossCalls(t *testing.T) {
 	c := AgentContent{
 		Name:         "researcher",

--- a/internal/api/grpc/substrate.go
+++ b/internal/api/grpc/substrate.go
@@ -54,8 +54,11 @@ func substrateGRPCCtx(ctx context.Context) context.Context {
 	// refusing "caller's effective tools not on ctx". Per-run contexts
 	// keep the agent's actual list, so the in-loop escalation guard is unchanged.
 	ctx = tools.WithAgentTools(ctx, []string{"*"})
+	// RFC BL P2: the operator substrate plane also gets the consolidation grant
+	// (own-scope, tenant-confined), consistent with the open memory scope here.
 	ctx = tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{
 		AllowedScopes: []string{"agent", "user", "global"},
+		Consolidation: true,
 	})
 	ctx = tools.WithChannelPolicy(ctx, tools.ChannelPolicyValue{
 		Publish:   []string{"*"},

--- a/internal/api/http/resume.go
+++ b/internal/api/http/resume.go
@@ -272,6 +272,7 @@ func (s *Server) resumePausedRun(ctx context.Context, run store.Run) error {
 		AllowedScopes: agentDef.MemoryScopes,
 		QuotaBytes:    agentDef.MemoryQuotaBytes,
 		Backend:       agentDef.MemoryBackend,
+		Consolidation: agentDef.MemoryConsolidation,
 	})
 	// RFC BL P1: re-stamp the run's core blocks (Memory-tool enforcement +
 	// sub-agent inherit) — lost across pause/snapshot/resume otherwise.

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2449,6 +2449,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 		AllowedScopes: agentDef.MemoryScopes,
 		QuotaBytes:    agentDef.MemoryQuotaBytes,
 		Backend:       agentDef.MemoryBackend,
+		Consolidation: agentDef.MemoryConsolidation,
 	})
 	// RFC BL P1: the run's resolved core blocks — read by the Memory tool to
 	// enforce read_only/limit_bytes, and inherited by an inherit_core_blocks
@@ -3957,6 +3958,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		AllowedScopes: agentDef.MemoryScopes,
 		QuotaBytes:    agentDef.MemoryQuotaBytes,
 		Backend:       agentDef.MemoryBackend,
+		Consolidation: agentDef.MemoryConsolidation,
 	})
 	// RFC BL P1: run's resolved core blocks (Memory-tool enforcement + inherit).
 	loopCtx = tools.WithCoreBlocksPolicy(loopCtx, tools.CoreBlocksPolicyValue{Blocks: coreBlocks})
@@ -4534,6 +4536,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		AllowedScopes: agentDef.MemoryScopes,
 		QuotaBytes:    agentDef.MemoryQuotaBytes,
 		Backend:       agentDef.MemoryBackend,
+		Consolidation: agentDef.MemoryConsolidation,
 	})
 	// RFC BL P1: run's resolved core blocks (Memory-tool enforcement + inherit).
 	loopCtx = tools.WithCoreBlocksPolicy(loopCtx, tools.CoreBlocksPolicyValue{Blocks: coreBlocks})
@@ -5732,6 +5735,7 @@ func (s *Server) prepareSubRun(ctx context.Context, name, prompt, defID string, 
 		AllowedScopes: def.MemoryScopes,
 		QuotaBytes:    def.MemoryQuotaBytes,
 		Backend:       def.MemoryBackend,
+		Consolidation: def.MemoryConsolidation,
 	})
 	// RFC BL P1: the sub-agent's effective core blocks (its own + any inherited
 	// user/tenant blocks). Replaces the parent's policy on subCtx so the Memory

--- a/internal/api/http/substrate_admin.go
+++ b/internal/api/http/substrate_admin.go
@@ -308,8 +308,11 @@ func substrateAdminCtx(ctx context.Context) context.Context {
 	ctx = tools.WithAgentTools(ctx, []string{"*"})
 	// Memory: full scope access. QuotaBytes=0 falls back to the
 	// global default (LOOMCYCLE_MEMORY_MAX_SCOPE_BYTES).
+	// RFC BL P2: the operator substrate-admin plane also gets the consolidation
+	// grant (own-scope, tenant-confined), consistent with the open scope here.
 	ctx = tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{
 		AllowedScopes: []string{"agent", "user", "global"},
+		Consolidation: true,
 	})
 	// Channel: "*" wildcard matches every channel name.
 	ctx = tools.WithChannelPolicy(ctx, tools.ChannelPolicyValue{

--- a/internal/api/mcp/context.go
+++ b/internal/api/mcp/context.go
@@ -103,9 +103,13 @@ func grantOperatorPolicies(ctx context.Context, agentName string, isAdmin bool) 
 	// /v1/_agentdef admin path uses (substrateAdminCtx).
 	ctx = tools.WithAgentTools(ctx, []string{"*"})
 
-	// Memory: full scope access (QuotaBytes=0 → global default cap).
+	// Memory: full scope access (QuotaBytes=0 → global default cap). RFC BL P2:
+	// the operator plane also gets the consolidation grant — a session with open
+	// memory scope can drive the cursor/pending/supersede ops on its OWN
+	// (tenant-confined) scopes, consistent with the wildcard posture here.
 	ctx = tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{
 		AllowedScopes: []string{"agent", "user", "global"},
+		Consolidation: true,
 	})
 	// Channel: open ACL ("*" matches every channel name).
 	ctx = tools.WithChannelPolicy(ctx, tools.ChannelPolicyValue{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1010,6 +1010,13 @@ type AgentDef struct {
 	// Behaviour-bearing, so content-identifying.
 	MemoryProtocol bool `yaml:"memory_protocol"`
 
+	// MemoryConsolidation grants the agent the memory consolidation control ops
+	// (the cursor/lease/watermark, pending-queue drain/ack, and supersede ops on
+	// the Memory tool). Default-deny like every capability gate: without it those
+	// ops refuse regardless of memory_scopes. Behaviour-bearing → content-
+	// identifying (a fork that toggles it mints a distinct content_sha256).
+	MemoryConsolidation bool `yaml:"memory_consolidation"`
+
 	// MemoryIndexMaxBytes is the soft size cap the memory protocol surfaces to
 	// the agent for its /memory/index document — the agent is asked to keep the
 	// index under it and move detail into /memory/topics/<slug>. 0 = the
@@ -4525,6 +4532,7 @@ func agentFromDiscovered(d *agents.Agent) AgentDef {
 		InheritCoreBlocks:     d.InheritCoreBlocks,
 		MemoryInjectMaxTokens: d.MemoryInjectMaxTokens,
 		MemoryProtocol:        d.MemoryProtocol,
+		MemoryConsolidation:   d.MemoryConsolidation,
 		MemoryIndexMaxBytes:   d.MemoryIndexMaxBytes,
 		MemoryRoots:           d.MemoryRoots,
 		Channels: AgentChannelACL{
@@ -4666,6 +4674,9 @@ func mergeAgentDef(base, override AgentDef) AgentDef {
 	}
 	if override.MemoryProtocol {
 		out.MemoryProtocol = true
+	}
+	if override.MemoryConsolidation {
+		out.MemoryConsolidation = true
 	}
 	if override.MemoryIndexMaxBytes != 0 {
 		out.MemoryIndexMaxBytes = override.MemoryIndexMaxBytes
@@ -5077,6 +5088,14 @@ func agentGateWarnings(name string, a AgentDef) []string {
 	if len(a.CoreBlocks) > 0 || a.MemoryProtocol {
 		if !has("Memory") || len(a.MemoryScopes) == 0 {
 			w = append(w, fmt.Sprintf("agent %q: core_blocks/memory_protocol is set but Memory is not in tools (or memory_scopes is empty) — core blocks won't be readable/writable and {{memory:...}} will render empty; add Memory to tools and memory_scopes: [agent] and/or [user]", name))
+		}
+	}
+	// RFC BL P2: the consolidation control ops need Memory in tools AND a
+	// matching memory_scopes, or the grant is inert (every consolidation op
+	// default-denies) — a silent no-op like the core_blocks trap above.
+	if a.MemoryConsolidation {
+		if !has("Memory") || len(a.MemoryScopes) == 0 {
+			w = append(w, fmt.Sprintf("agent %q: memory_consolidation is set but Memory is not in tools (or memory_scopes is empty) — the consolidation control ops will default-deny; add Memory to tools and memory_scopes: [agent] and/or [user]", name))
 		}
 	}
 	if has("Evaluation") && len(a.EvaluationScopes) == 0 {

--- a/internal/config/coreblock_test.go
+++ b/internal/config/coreblock_test.go
@@ -105,6 +105,7 @@ agents:
     inherit_core_blocks: true
     memory_inject_max_tokens: 512
     memory_protocol: true
+    memory_consolidation: true
     core_blocks:
       - { label: human, scope: user, read_only: true }
       - { label: notes, scope: agent, limit_bytes: 2048 }
@@ -120,10 +121,29 @@ agents:
 	if !def.InheritCoreBlocks || def.MemoryInjectMaxTokens != 512 || !def.MemoryProtocol {
 		t.Errorf("scalar core-block fields didn't round-trip: %+v", def)
 	}
+	if !def.MemoryConsolidation {
+		t.Errorf("memory_consolidation didn't round-trip from yaml: %+v", def)
+	}
 	if def.CoreBlocks[0].Label != "human" || !def.CoreBlocks[0].ReadOnly {
 		t.Errorf("block[0] round-trip: %+v", def.CoreBlocks[0])
 	}
 	if def.CoreBlocks[1].LimitBytes != 2048 {
 		t.Errorf("block[1] limit_bytes: %+v", def.CoreBlocks[1])
+	}
+}
+
+// TestMergeAgentDef_MemoryConsolidationOrsIn pins the RFC BL P2 grant's overlay
+// semantics: an override enables it, and it OR-s in (never disables a base grant
+// that the override leaves unset) — mirroring memory_protocol / interruption.
+func TestMergeAgentDef_MemoryConsolidationOrsIn(t *testing.T) {
+	// Override enables the grant on a base that lacked it.
+	got := mergeAgentDef(AgentDef{}, AgentDef{MemoryConsolidation: true})
+	if !got.MemoryConsolidation {
+		t.Error("override memory_consolidation=true did not OR into the merged def")
+	}
+	// An override that leaves it unset never disables a base grant.
+	got = mergeAgentDef(AgentDef{MemoryConsolidation: true}, AgentDef{})
+	if !got.MemoryConsolidation {
+		t.Error("base memory_consolidation was dropped by an override that didn't set it")
 	}
 }

--- a/internal/lookup/agent.go
+++ b/internal/lookup/agent.go
@@ -230,6 +230,7 @@ type SubstrateAgentDef struct {
 	InheritCoreBlocks     bool               `json:"inherit_core_blocks,omitempty"`
 	MemoryInjectMaxTokens int                `json:"memory_inject_max_tokens,omitempty"`
 	MemoryProtocol        bool               `json:"memory_protocol,omitempty"`
+	MemoryConsolidation   bool               `json:"memory_consolidation,omitempty"` // RFC BL P2 grant
 	MemoryIndexMaxBytes   int                `json:"memory_index_max_bytes,omitempty"`
 	MemoryRoots           string             `json:"memory_roots,omitempty"`
 	// RetryAttempts mirrors config.AgentDef.RetryAttempts — per-agent
@@ -292,6 +293,7 @@ func (s SubstrateAgentDef) ToConfigDef() config.AgentDef {
 		InheritCoreBlocks:     s.InheritCoreBlocks,
 		MemoryInjectMaxTokens: s.MemoryInjectMaxTokens,
 		MemoryProtocol:        s.MemoryProtocol,
+		MemoryConsolidation:   s.MemoryConsolidation,
 		MemoryIndexMaxBytes:   s.MemoryIndexMaxBytes,
 		MemoryRoots:           s.MemoryRoots,
 		RetryAttempts:         s.RetryAttempts,

--- a/internal/lookup/agent_test.go
+++ b/internal/lookup/agent_test.go
@@ -304,6 +304,7 @@ func TestAgent_DriftDetection(t *testing.T) {
 		"inherit_core_blocks":      true,
 		"memory_inject_max_tokens": true,
 		"memory_protocol":          true,
+		"memory_consolidation":     true, // RFC BL P2 — consolidation control-ops grant (content-identifying)
 		"memory_index_max_bytes":   true, // RFC BL P1 — /memory/index soft cap surfaced to the agent
 		"memory_roots":             true, // RFC BL P1 — user-root provisioning control (lazy|force|suppress)
 		"retry_attempts":           true,

--- a/internal/store/postgres/memory_embeddings.go
+++ b/internal/store/postgres/memory_embeddings.go
@@ -193,7 +193,8 @@ func (s *Store) MemoryEmbedSearch(ctx context.Context, tenantID string, scope st
 	         WHERE me.tenant_id = $1
 	           AND me.scope = $2
 	           AND me.scope_id = $3
-	           AND (m.expires_at IS NULL OR m.expires_at > now())` + prefixCondition + `
+	           AND (m.expires_at IS NULL OR m.expires_at > now())
+	           AND m.superseded_at IS NULL` + prefixCondition + `
 	         ORDER BY me.embedding <=> $4::vector
 	         LIMIT $5`
 	rows, err := s.pool.Query(ctx, sql, args...)
@@ -296,6 +297,7 @@ func (s *Store) MemoryFullTextSearch(ctx context.Context, tenantID string, scope
 	           AND me.scope = $2
 	           AND me.scope_id = $3
 	           AND (m.expires_at IS NULL OR m.expires_at > now())
+	           AND m.superseded_at IS NULL
 	           AND me.embed_text_tsv @@ plainto_tsquery('english', $4)` + prefixCondition + `
 	         ORDER BY score DESC
 	         LIMIT $5`

--- a/internal/store/postgres/migrations/0061_memory_consolidation_substrate.down.sql
+++ b/internal/store/postgres/migrations/0061_memory_consolidation_substrate.down.sql
@@ -1,0 +1,5 @@
+-- 0061_memory_consolidation_substrate.down.sql — reverse the RFC BL P2 PR1
+-- consolidation substrate: drop the two tables and the soft-archive column.
+DROP TABLE IF EXISTS memory_cursors;
+DROP TABLE IF EXISTS memory_pending;
+ALTER TABLE memory DROP COLUMN IF EXISTS superseded_at;

--- a/internal/store/postgres/migrations/0061_memory_consolidation_substrate.up.sql
+++ b/internal/store/postgres/migrations/0061_memory_consolidation_substrate.up.sql
@@ -1,0 +1,49 @@
+-- 0061_memory_consolidation_substrate.up.sql — RFC BL P2 PR1: the durable
+-- substrate for background memory consolidation.
+--
+-- Three additions, all additive and safe on an existing single-tenant DB:
+--
+--   1. memory.superseded_at — a soft-archive marker. A consolidated raw memory
+--      row is stamped (not deleted): every recall/get/list/search path filters
+--      `superseded_at IS NULL`, so a superseded row is invisible to the agent
+--      but retained for audit/rollback. NULL = live (every legacy row).
+--
+--   2. memory_pending — the durable enqueue queue an Add writes to and the
+--      consolidator drains. drained_at is a soft-drain marker (idempotent drain
+--      + TTL sweeping): a drained row is retained until swept, never re-drained.
+--
+--   3. memory_cursors — the per-target consolidation watermark + lease. The
+--      composite watermark (watermark_completed_at, watermark_session_id)
+--      advances monotonically; the lease (leased_by, lease_expires_at) lets one
+--      replica own consolidation for a (tenant, scope, scope_id) at a time.
+
+ALTER TABLE memory ADD COLUMN superseded_at TIMESTAMPTZ;
+
+CREATE TABLE IF NOT EXISTS memory_pending (
+    id                TEXT        PRIMARY KEY,
+    tenant_id         TEXT        NOT NULL DEFAULT '',
+    scope             TEXT        NOT NULL,
+    scope_id          TEXT        NOT NULL,
+    payload           JSONB       NOT NULL,
+    source_session_id TEXT,
+    source_run_id     TEXT,
+    created_at        TIMESTAMPTZ NOT NULL,
+    drained_at        TIMESTAMPTZ
+);
+
+-- The consolidator drains un-drained rows for one target oldest-first; the TTL
+-- sweeper reaps drained rows. Both key on (tenant, scope, scope_id, drained_at).
+CREATE INDEX IF NOT EXISTS memory_pending_by_target
+    ON memory_pending(tenant_id, scope, scope_id, drained_at);
+
+CREATE TABLE IF NOT EXISTS memory_cursors (
+    tenant_id              TEXT        NOT NULL DEFAULT '',
+    scope                  TEXT        NOT NULL,
+    scope_id               TEXT        NOT NULL,
+    watermark_completed_at TIMESTAMPTZ,
+    watermark_session_id   TEXT        NOT NULL DEFAULT '',
+    leased_by              TEXT        NOT NULL DEFAULT '',
+    lease_expires_at       TIMESTAMPTZ,
+    updated_at             TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, scope, scope_id)
+);

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -3290,6 +3290,11 @@ func (s *Store) MemorySet(ctx context.Context, tenantID string, scope store.Memo
 	if ttl > 0 {
 		expiresAt = now.Add(ttl)
 	}
+	// superseded_at = NULL on the DO UPDATE: a fresh write REVIVES a soft-archived
+	// row. supersede() only stamps the marker (every read filters superseded_at IS
+	// NULL); without the reset an upsert onto a superseded key would land the value
+	// but leave it hidden — a silent black-hole. A new explicit write is live data.
+	// Mirrored in MemoryIncrement / MemoryAtomicUpdate (and the sqlite twin).
 	// Wrapped in retryOnTransientConn because this is the call that
 	// produced the silent regressions on the v0.12.8 baseline x1000
 	// (2026-05-27): when the researcher's Memory.set fired during
@@ -3305,7 +3310,8 @@ func (s *Store) MemorySet(ctx context.Context, tenantID string, scope store.Memo
 			 ON CONFLICT (tenant_id, scope, scope_id, key) DO UPDATE SET
 			    value = EXCLUDED.value,
 			    expires_at = EXCLUDED.expires_at,
-			    updated_at = EXCLUDED.updated_at`,
+			    updated_at = EXCLUDED.updated_at,
+			    superseded_at = NULL`,
 			tenantID, string(scope), scopeID, key, string(value), expiresAt, now, now,
 		)
 		return err
@@ -3520,7 +3526,8 @@ func (s *Store) MemoryIncrement(ctx context.Context, tenantID string, scope stor
 		 ON CONFLICT (tenant_id, scope, scope_id, key) DO UPDATE SET
 		    value = EXCLUDED.value,
 		    expires_at = EXCLUDED.expires_at,
-		    updated_at = EXCLUDED.updated_at`,
+		    updated_at = EXCLUDED.updated_at,
+		    superseded_at = NULL`,
 		tenantID, string(scope), scopeID, key, nextText, newExpires, now, now,
 	); err != nil {
 		return 0, fmt.Errorf("memory incr write: %w", err)
@@ -3610,7 +3617,8 @@ func (s *Store) MemoryAtomicUpdate(
 		 ON CONFLICT (tenant_id, scope, scope_id, key) DO UPDATE SET
 		    value = EXCLUDED.value,
 		    expires_at = EXCLUDED.expires_at,
-		    updated_at = EXCLUDED.updated_at`,
+		    updated_at = EXCLUDED.updated_at,
+		    superseded_at = NULL`,
 		tenantID, string(scope), scopeID, key, string(next), newExpires, now, now,
 	); err != nil {
 		return nil, fmt.Errorf("memory atomic update write: %w", err)
@@ -3789,13 +3797,15 @@ func (s *Store) MemoryPendingDrain(ctx context.Context, tenantID string, scope s
 // MemoryPendingAck marks the given ids drained. `AND drained_at IS NULL` keeps
 // it idempotent — an already-acked row is not re-stamped; an unknown id is
 // silently skipped. An empty slice is a no-op.
-func (s *Store) MemoryPendingAck(ctx context.Context, ids []string) error {
+func (s *Store) MemoryPendingAck(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID string, ids []string) error {
 	if len(ids) == 0 {
 		return nil
 	}
 	_, err := s.pool.Exec(ctx,
-		`UPDATE memory_pending SET drained_at = $1 WHERE id = ANY($2) AND drained_at IS NULL`,
-		time.Now().UTC(), ids,
+		`UPDATE memory_pending SET drained_at = $1
+		 WHERE tenant_id = $2 AND scope = $3 AND scope_id = $4
+		   AND id = ANY($5) AND drained_at IS NULL`,
+		time.Now().UTC(), tenantID, string(scope), scopeID, ids,
 	)
 	if err != nil {
 		return fmt.Errorf("memory pending ack: %w", err)

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -3329,7 +3329,8 @@ func (s *Store) MemoryGet(ctx context.Context, tenantID string, scope store.Memo
 		`SELECT value::text, expires_at, created_at, updated_at
 		 FROM memory
 		 WHERE tenant_id = $1 AND scope = $2 AND scope_id = $3 AND key = $4
-		   AND (expires_at IS NULL OR expires_at > NOW())`,
+		   AND (expires_at IS NULL OR expires_at > NOW())
+		   AND superseded_at IS NULL`,
 		tenantID, string(scope), scopeID, key,
 	).Scan(&valueText, &expiresAt, &createdAt, &updatedAt)
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -3390,6 +3391,7 @@ func (s *Store) MemoryList(ctx context.Context, tenantID string, scope store.Mem
 		 FROM memory
 		 WHERE tenant_id = $1 AND scope = $2 AND scope_id = $3 AND key LIKE $4 ESCAPE '\'
 		   AND (expires_at IS NULL OR expires_at > NOW())
+		   AND superseded_at IS NULL
 		 ORDER BY key ASC
 		 LIMIT $5`,
 		tenantID, string(scope), scopeID, pattern, limit+1,
@@ -3686,6 +3688,223 @@ func (s *Store) MemorySweep(ctx context.Context) (int, error) {
 		return 0, fmt.Errorf("memory sweep: %w", err)
 	}
 	return int(tag.RowsAffected()), nil
+}
+
+// ---- RFC BL P2: background memory consolidation substrate ----
+
+// MemorySupersede soft-archives one base-memory row. The WHERE clause's
+// `superseded_at IS NULL` makes it idempotent — a re-supersede does not
+// re-stamp the timestamp — and a missing key is a clean 0-row no-op.
+func (s *Store) MemorySupersede(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string) error {
+	_, err := s.pool.Exec(ctx,
+		`UPDATE memory SET superseded_at = $5
+		 WHERE tenant_id = $1 AND scope = $2 AND scope_id = $3 AND key = $4
+		   AND superseded_at IS NULL`,
+		tenantID, string(scope), scopeID, key, time.Now().UTC(),
+	)
+	if err != nil {
+		return fmt.Errorf("memory supersede: %w", err)
+	}
+	return nil
+}
+
+// MemoryPendingEnqueue appends one durable consolidation-queue row. ID is
+// generated when empty; CreatedAt defaults to now(); an empty payload stores
+// JSON null so the NOT NULL JSONB constraint holds.
+func (s *Store) MemoryPendingEnqueue(ctx context.Context, row store.MemoryPendingRow) error {
+	if row.ID == "" {
+		row.ID = newID("mp_")
+	}
+	createdAt := row.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+	payload := row.Payload
+	if len(payload) == 0 {
+		payload = json.RawMessage("null")
+	}
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO memory_pending
+		   (id, tenant_id, scope, scope_id, payload, source_session_id, source_run_id, created_at)
+		 VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8)`,
+		row.ID, row.TenantID, string(row.Scope), row.ScopeID, string(payload),
+		nullableString(row.SourceSessionID), nullableString(row.SourceRunID), createdAt,
+	)
+	if err != nil {
+		return fmt.Errorf("memory pending enqueue: %w", err)
+	}
+	return nil
+}
+
+// MemoryPendingDrain returns up to limit un-drained rows oldest-first. It does
+// NOT mark them drained (ack is separate — at-least-once).
+func (s *Store) MemoryPendingDrain(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID string, limit int) ([]store.MemoryPendingRow, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := s.pool.Query(ctx,
+		`SELECT id, tenant_id, scope, scope_id, payload::text, source_session_id, source_run_id, created_at, drained_at
+		 FROM memory_pending
+		 WHERE tenant_id = $1 AND scope = $2 AND scope_id = $3 AND drained_at IS NULL
+		 ORDER BY created_at ASC, id ASC
+		 LIMIT $4`,
+		tenantID, string(scope), scopeID, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("memory pending drain: %w", err)
+	}
+	defer rows.Close()
+	var out []store.MemoryPendingRow
+	for rows.Next() {
+		var (
+			r           store.MemoryPendingRow
+			scopeStr    string
+			payloadText []byte
+			srcSession  *string
+			srcRun      *string
+			drainedAt   *time.Time
+		)
+		if err := rows.Scan(&r.ID, &r.TenantID, &scopeStr, &r.ScopeID, &payloadText, &srcSession, &srcRun, &r.CreatedAt, &drainedAt); err != nil {
+			return nil, fmt.Errorf("memory pending drain scan: %w", err)
+		}
+		r.Scope = store.MemoryScope(scopeStr)
+		r.Payload = json.RawMessage(payloadText)
+		if srcSession != nil {
+			r.SourceSessionID = *srcSession
+		}
+		if srcRun != nil {
+			r.SourceRunID = *srcRun
+		}
+		if drainedAt != nil {
+			r.DrainedAt = *drainedAt
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("memory pending drain iter: %w", err)
+	}
+	return out, nil
+}
+
+// MemoryPendingAck marks the given ids drained. `AND drained_at IS NULL` keeps
+// it idempotent — an already-acked row is not re-stamped; an unknown id is
+// silently skipped. An empty slice is a no-op.
+func (s *Store) MemoryPendingAck(ctx context.Context, ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	_, err := s.pool.Exec(ctx,
+		`UPDATE memory_pending SET drained_at = $1 WHERE id = ANY($2) AND drained_at IS NULL`,
+		time.Now().UTC(), ids,
+	)
+	if err != nil {
+		return fmt.Errorf("memory pending ack: %w", err)
+	}
+	return nil
+}
+
+// MemoryCursorGet is a get-or-default: a target with no row returns a
+// zero-watermark, unleased row rather than ErrNotFound.
+func (s *Store) MemoryCursorGet(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID string) (store.MemoryCursorRow, error) {
+	out := store.MemoryCursorRow{TenantID: tenantID, Scope: scope, ScopeID: scopeID}
+	var (
+		completedAt *time.Time
+		expiresAt   *time.Time
+	)
+	err := s.pool.QueryRow(ctx,
+		`SELECT watermark_completed_at, watermark_session_id, leased_by, lease_expires_at, updated_at
+		 FROM memory_cursors WHERE tenant_id = $1 AND scope = $2 AND scope_id = $3`,
+		tenantID, string(scope), scopeID,
+	).Scan(&completedAt, &out.WatermarkSessionID, &out.LeasedBy, &expiresAt, &out.UpdatedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return out, nil
+	}
+	if err != nil {
+		return store.MemoryCursorRow{}, fmt.Errorf("memory cursor get: %w", err)
+	}
+	if completedAt != nil {
+		out.WatermarkCompletedAt = *completedAt
+	}
+	if expiresAt != nil {
+		out.LeaseExpiresAt = *expiresAt
+	}
+	return out, nil
+}
+
+// MemoryCursorLease atomically acquires the lease via a single conditional
+// upsert: a fresh INSERT always wins; an existing row is updated only when the
+// DO UPDATE WHERE holds (unleased, expired, or already owner). RowsAffected == 1
+// ⇒ acquired. Two replicas racing the same target can never both acquire.
+func (s *Store) MemoryCursorLease(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, owner string, now time.Time, ttl time.Duration) (store.MemoryCursorRow, bool, error) {
+	expires := now.Add(ttl)
+	tag, err := s.pool.Exec(ctx,
+		`INSERT INTO memory_cursors (tenant_id, scope, scope_id, leased_by, lease_expires_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6)
+		 ON CONFLICT (tenant_id, scope, scope_id) DO UPDATE SET
+		    leased_by = EXCLUDED.leased_by,
+		    lease_expires_at = EXCLUDED.lease_expires_at,
+		    updated_at = EXCLUDED.updated_at
+		 WHERE memory_cursors.leased_by = ''
+		    OR memory_cursors.lease_expires_at IS NULL
+		    OR memory_cursors.lease_expires_at <= $6
+		    OR memory_cursors.leased_by = $4`,
+		tenantID, string(scope), scopeID, owner, expires, now,
+	)
+	if err != nil {
+		return store.MemoryCursorRow{}, false, fmt.Errorf("memory cursor lease: %w", err)
+	}
+	acquired := tag.RowsAffected() > 0
+	row, gerr := s.MemoryCursorGet(ctx, tenantID, scope, scopeID)
+	if gerr != nil {
+		return store.MemoryCursorRow{}, acquired, gerr
+	}
+	return row, acquired, nil
+}
+
+// MemoryCursorAdvance advances the composite watermark monotonically IFF owner
+// holds a non-expired lease. The ownership predicate is the UPDATE's WHERE
+// (RowsAffected == 0 ⇒ "not lease owner"); the monotonic guard lives in the SET
+// CASE so a backward/equal advance while the lease is held is a clean no-op.
+func (s *Store) MemoryCursorAdvance(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, owner string, completedAt time.Time, sessionID string) error {
+	now := time.Now().UTC()
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE memory_cursors SET
+		    watermark_completed_at = CASE
+		      WHEN watermark_completed_at IS NULL
+		        OR $5 > watermark_completed_at
+		        OR ($5 = watermark_completed_at AND $6 > watermark_session_id)
+		      THEN $5 ELSE watermark_completed_at END,
+		    watermark_session_id = CASE
+		      WHEN watermark_completed_at IS NULL
+		        OR $5 > watermark_completed_at
+		        OR ($5 = watermark_completed_at AND $6 > watermark_session_id)
+		      THEN $6 ELSE watermark_session_id END,
+		    updated_at = $7
+		 WHERE tenant_id = $1 AND scope = $2 AND scope_id = $3
+		   AND leased_by = $4 AND lease_expires_at > $7`,
+		tenantID, string(scope), scopeID, owner, completedAt, sessionID, now,
+	)
+	if err != nil {
+		return fmt.Errorf("memory cursor advance: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("memory cursor advance: not lease owner (owner=%q)", owner)
+	}
+	return nil
+}
+
+// MemoryCursorRelease clears the lease IFF held by owner. Idempotent no-op
+// otherwise; the watermark is untouched.
+func (s *Store) MemoryCursorRelease(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, owner string) error {
+	_, err := s.pool.Exec(ctx,
+		`UPDATE memory_cursors SET leased_by = '', lease_expires_at = NULL, updated_at = $4
+		 WHERE tenant_id = $1 AND scope = $2 AND scope_id = $3 AND leased_by = $5`,
+		tenantID, string(scope), scopeID, time.Now().UTC(), owner,
+	)
+	if err != nil {
+		return fmt.Errorf("memory cursor release: %w", err)
+	}
+	return nil
 }
 
 // ---- v0.8.4 Channel tool ----

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -3800,7 +3800,8 @@ func (s *Store) MemorySet(ctx context.Context, tenantID string, scope store.Memo
 		 ON CONFLICT(tenant_id, scope, scope_id, key) DO UPDATE SET
 		    value = excluded.value,
 		    expires_at = excluded.expires_at,
-		    updated_at = excluded.updated_at`,
+		    updated_at = excluded.updated_at,
+		    superseded_at = NULL`,
 		tenantID, string(scope), scopeID, key, string(value), expiresAt, now, now,
 	)
 	return err
@@ -4024,7 +4025,8 @@ func (s *Store) MemoryIncrement(ctx context.Context, tenantID string, scope stor
 		 ON CONFLICT(tenant_id, scope, scope_id, key) DO UPDATE SET
 		    value = excluded.value,
 		    expires_at = excluded.expires_at,
-		    updated_at = excluded.updated_at`,
+		    updated_at = excluded.updated_at,
+		    superseded_at = NULL`,
 		tenantID, string(scope), scopeID, key, nextText, newExpires, nowNs, nowNs,
 	)
 	if err != nil {
@@ -4119,7 +4121,8 @@ func (s *Store) MemoryAtomicUpdate(
 		 ON CONFLICT(tenant_id, scope, scope_id, key) DO UPDATE SET
 		    value = excluded.value,
 		    expires_at = excluded.expires_at,
-		    updated_at = excluded.updated_at`,
+		    updated_at = excluded.updated_at,
+		    superseded_at = NULL`,
 		tenantID, string(scope), scopeID, key, string(next), newExpires, nowNs, nowNs,
 	)
 	if err != nil {
@@ -4355,20 +4358,21 @@ func (s *Store) MemoryPendingDrain(ctx context.Context, tenantID string, scope s
 
 // MemoryPendingAck marks the given ids drained. `drained_at IS NULL` keeps it
 // idempotent; an unknown id is skipped; an empty slice is a no-op.
-func (s *Store) MemoryPendingAck(ctx context.Context, ids []string) error {
+func (s *Store) MemoryPendingAck(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID string, ids []string) error {
 	if len(ids) == 0 {
 		return nil
 	}
 	placeholders := make([]string, len(ids))
-	args := make([]any, 0, len(ids)+1)
-	args = append(args, time.Now().UnixNano())
+	args := make([]any, 0, len(ids)+4)
+	args = append(args, time.Now().UnixNano(), tenantID, string(scope), scopeID)
 	for i, id := range ids {
 		placeholders[i] = "?"
 		args = append(args, id)
 	}
 	_, err := s.db.ExecContext(ctx,
 		`UPDATE memory_pending SET drained_at = ?
-		 WHERE drained_at IS NULL AND id IN (`+strings.Join(placeholders, ",")+`)`,
+		 WHERE tenant_id = ? AND scope = ? AND scope_id = ?
+		   AND drained_at IS NULL AND id IN (`+strings.Join(placeholders, ",")+`)`,
 		args...,
 	)
 	return err

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -258,9 +258,40 @@ func (s *Store) migrate(ctx context.Context) error {
 			source_run_id     TEXT,
 			access_count      INTEGER NOT NULL DEFAULT 0,
 			last_accessed_at  INTEGER,
+			superseded_at     INTEGER,
 			PRIMARY KEY (tenant_id, scope, scope_id, key)
 		)`,
 		`CREATE INDEX IF NOT EXISTS memory_by_expires_at ON memory(expires_at) WHERE expires_at IS NOT NULL`,
+		// RFC BL P2 — the durable consolidation substrate. Mirrors Postgres
+		// migration 0061. memory_pending is the enqueue queue an Add writes to
+		// and the consolidator drains (drained_at = soft-drain marker for
+		// idempotent drain + TTL sweeping); memory_cursors is the per-target
+		// watermark + lease (composite watermark = (watermark_completed_at,
+		// watermark_session_id)). Timestamps are unix-nano like the rest of the
+		// sqlite schema; payload is TEXT-encoded JSON (no native JSONB).
+		`CREATE TABLE IF NOT EXISTS memory_pending (
+			id                TEXT    PRIMARY KEY,
+			tenant_id         TEXT    NOT NULL DEFAULT '',
+			scope             TEXT    NOT NULL,
+			scope_id          TEXT    NOT NULL,
+			payload           TEXT    NOT NULL,
+			source_session_id TEXT,
+			source_run_id     TEXT,
+			created_at        INTEGER NOT NULL,
+			drained_at        INTEGER
+		)`,
+		`CREATE INDEX IF NOT EXISTS memory_pending_by_target ON memory_pending(tenant_id, scope, scope_id, drained_at)`,
+		`CREATE TABLE IF NOT EXISTS memory_cursors (
+			tenant_id              TEXT    NOT NULL DEFAULT '',
+			scope                  TEXT    NOT NULL,
+			scope_id               TEXT    NOT NULL,
+			watermark_completed_at INTEGER,
+			watermark_session_id   TEXT    NOT NULL DEFAULT '',
+			leased_by              TEXT    NOT NULL DEFAULT '',
+			lease_expires_at       INTEGER,
+			updated_at             INTEGER NOT NULL,
+			PRIMARY KEY (tenant_id, scope, scope_id)
+		)`,
 		// v0.8.4 Channel tool — see internal/store/postgres/migrations/0004_channels.up.sql
 		// for the full rationale. SQLite mirrors the shape: TEXT id (ULID-like prefix
 		// "msg_<unixnano>_<rand>" — sortable by publish time), per-(channel, scope,
@@ -1032,6 +1063,11 @@ func (s *Store) migrate(ctx context.Context) error {
 		`ALTER TABLE memory ADD COLUMN source_run_id TEXT`,
 		`ALTER TABLE memory ADD COLUMN access_count INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE memory ADD COLUMN last_accessed_at INTEGER`,
+		// RFC BL P2 — the soft-archive marker. NULL on every legacy row (live);
+		// the consolidator stamps it to hide a consolidated raw row from recall
+		// while retaining it. memory_pending / memory_cursors are pure CREATE
+		// TABLE (no ALTER needed) so they land via the schema block above.
+		`ALTER TABLE memory ADD COLUMN superseded_at INTEGER`,
 	}
 	for _, q := range addColumns {
 		if _, err := s.db.ExecContext(ctx, q); err != nil {

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -3818,7 +3818,8 @@ func (s *Store) MemoryGet(ctx context.Context, tenantID string, scope store.Memo
 	)
 	err := s.db.QueryRowContext(ctx,
 		`SELECT value, expires_at, created_at, updated_at
-		 FROM memory WHERE tenant_id = ? AND scope = ? AND scope_id = ? AND key = ?`,
+		 FROM memory WHERE tenant_id = ? AND scope = ? AND scope_id = ? AND key = ?
+		   AND superseded_at IS NULL`,
 		tenantID, string(scope), scopeID, key,
 	).Scan(&valueText, &expiresAt, &createdAt, &updatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -3894,6 +3895,7 @@ func (s *Store) MemoryList(ctx context.Context, tenantID string, scope store.Mem
 		 FROM memory
 		 WHERE tenant_id = ? AND scope = ? AND scope_id = ? AND key LIKE ? ESCAPE '\'
 		   AND (expires_at IS NULL OR expires_at > ?)
+		   AND superseded_at IS NULL
 		 ORDER BY key ASC
 		 LIMIT ?`,
 		tenantID, string(scope), scopeID, escapeLikePrefix(prefix)+"%", nowNs, limit+1,
@@ -4258,6 +4260,286 @@ func (s *Store) MemorySweep(ctx context.Context) (int, error) {
 		return 0, nil
 	}
 	return int(n), nil
+}
+
+// ---- RFC BL P2: background memory consolidation substrate ----
+//
+// Timestamps are unix-nano INTEGER (like expires_at / last_accessed_at) and
+// nullable timestamps use sql.NullInt64. payload is TEXT-encoded JSON. The
+// lease + watermark ops that need a read-decide-write take a pinned connection
+// with `BEGIN IMMEDIATE` (a write lock at BEGIN) so the CAS is atomic — same
+// pattern MemoryIncrement uses; modernc/sqlite does not map an isolation level
+// to BEGIN IMMEDIATE, so we issue it raw.
+
+// MemorySupersede soft-archives one base-memory row. `superseded_at IS NULL`
+// makes it idempotent; a missing key is a clean 0-row no-op.
+func (s *Store) MemorySupersede(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE memory SET superseded_at = ?
+		 WHERE tenant_id = ? AND scope = ? AND scope_id = ? AND key = ?
+		   AND superseded_at IS NULL`,
+		time.Now().UnixNano(), tenantID, string(scope), scopeID, key,
+	)
+	return err
+}
+
+// MemoryPendingEnqueue appends one durable consolidation-queue row. ID is
+// generated when empty; CreatedAt defaults to now(); an empty payload stores
+// JSON null.
+func (s *Store) MemoryPendingEnqueue(ctx context.Context, row store.MemoryPendingRow) error {
+	if row.ID == "" {
+		row.ID = newID("mp_")
+	}
+	createdAt := row.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now()
+	}
+	payload := row.Payload
+	if len(payload) == 0 {
+		payload = json.RawMessage("null")
+	}
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO memory_pending
+		   (id, tenant_id, scope, scope_id, payload, source_session_id, source_run_id, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		row.ID, row.TenantID, string(row.Scope), row.ScopeID, string(payload),
+		row.SourceSessionID, row.SourceRunID, createdAt.UnixNano(),
+	)
+	return err
+}
+
+// MemoryPendingDrain returns up to limit un-drained rows oldest-first without
+// marking them drained (ack is separate — at-least-once).
+func (s *Store) MemoryPendingDrain(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID string, limit int) ([]store.MemoryPendingRow, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, tenant_id, scope, scope_id, payload, source_session_id, source_run_id, created_at, drained_at
+		 FROM memory_pending
+		 WHERE tenant_id = ? AND scope = ? AND scope_id = ? AND drained_at IS NULL
+		 ORDER BY created_at ASC, id ASC
+		 LIMIT ?`,
+		tenantID, string(scope), scopeID, limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []store.MemoryPendingRow
+	for rows.Next() {
+		var (
+			r          store.MemoryPendingRow
+			scopeStr   string
+			payload    string
+			srcSession sql.NullString
+			srcRun     sql.NullString
+			createdNs  int64
+			drainedNs  sql.NullInt64
+		)
+		if err := rows.Scan(&r.ID, &r.TenantID, &scopeStr, &r.ScopeID, &payload, &srcSession, &srcRun, &createdNs, &drainedNs); err != nil {
+			return nil, err
+		}
+		r.Scope = store.MemoryScope(scopeStr)
+		r.Payload = json.RawMessage(payload)
+		r.SourceSessionID = srcSession.String
+		r.SourceRunID = srcRun.String
+		r.CreatedAt = time.Unix(0, createdNs)
+		if drainedNs.Valid {
+			r.DrainedAt = time.Unix(0, drainedNs.Int64)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// MemoryPendingAck marks the given ids drained. `drained_at IS NULL` keeps it
+// idempotent; an unknown id is skipped; an empty slice is a no-op.
+func (s *Store) MemoryPendingAck(ctx context.Context, ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	placeholders := make([]string, len(ids))
+	args := make([]any, 0, len(ids)+1)
+	args = append(args, time.Now().UnixNano())
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args = append(args, id)
+	}
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE memory_pending SET drained_at = ?
+		 WHERE drained_at IS NULL AND id IN (`+strings.Join(placeholders, ",")+`)`,
+		args...,
+	)
+	return err
+}
+
+// MemoryCursorGet is a get-or-default: a target with no row returns a
+// zero-watermark, unleased row rather than ErrNotFound.
+func (s *Store) MemoryCursorGet(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID string) (store.MemoryCursorRow, error) {
+	out := store.MemoryCursorRow{TenantID: tenantID, Scope: scope, ScopeID: scopeID}
+	var (
+		wmComp    sql.NullInt64
+		leaseExp  sql.NullInt64
+		updatedNs int64
+	)
+	err := s.db.QueryRowContext(ctx,
+		`SELECT watermark_completed_at, watermark_session_id, leased_by, lease_expires_at, updated_at
+		 FROM memory_cursors WHERE tenant_id = ? AND scope = ? AND scope_id = ?`,
+		tenantID, string(scope), scopeID,
+	).Scan(&wmComp, &out.WatermarkSessionID, &out.LeasedBy, &leaseExp, &updatedNs)
+	if errors.Is(err, sql.ErrNoRows) {
+		return out, nil
+	}
+	if err != nil {
+		return store.MemoryCursorRow{}, err
+	}
+	if wmComp.Valid {
+		out.WatermarkCompletedAt = time.Unix(0, wmComp.Int64)
+	}
+	if leaseExp.Valid {
+		out.LeaseExpiresAt = time.Unix(0, leaseExp.Int64)
+	}
+	out.UpdatedAt = time.Unix(0, updatedNs)
+	return out, nil
+}
+
+// MemoryCursorLease acquires (or re-acquires) the lease inside a BEGIN
+// IMMEDIATE transaction so the read-decide-write CAS is atomic against a
+// racing replica. Acquires iff unleased, expired, or already owner.
+func (s *Store) MemoryCursorLease(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, owner string, now time.Time, ttl time.Duration) (store.MemoryCursorRow, bool, error) {
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return store.MemoryCursorRow{}, false, err
+	}
+	defer conn.Close()
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return store.MemoryCursorRow{}, false, err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.Background(), "ROLLBACK")
+		}
+	}()
+
+	nowNs := now.UnixNano()
+	expNs := now.Add(ttl).UnixNano()
+	var (
+		leasedBy string
+		leaseExp sql.NullInt64
+	)
+	err = conn.QueryRowContext(ctx,
+		`SELECT leased_by, lease_expires_at FROM memory_cursors
+		 WHERE tenant_id = ? AND scope = ? AND scope_id = ?`,
+		tenantID, string(scope), scopeID,
+	).Scan(&leasedBy, &leaseExp)
+	exists := !errors.Is(err, sql.ErrNoRows)
+	if exists && err != nil {
+		return store.MemoryCursorRow{}, false, err
+	}
+	canAcquire := !exists || leasedBy == "" || !leaseExp.Valid || leaseExp.Int64 <= nowNs || leasedBy == owner
+	acquired := false
+	if canAcquire {
+		if exists {
+			if _, err := conn.ExecContext(ctx,
+				`UPDATE memory_cursors SET leased_by = ?, lease_expires_at = ?, updated_at = ?
+				 WHERE tenant_id = ? AND scope = ? AND scope_id = ?`,
+				owner, expNs, nowNs, tenantID, string(scope), scopeID,
+			); err != nil {
+				return store.MemoryCursorRow{}, false, err
+			}
+		} else {
+			if _, err := conn.ExecContext(ctx,
+				`INSERT INTO memory_cursors (tenant_id, scope, scope_id, leased_by, lease_expires_at, updated_at)
+				 VALUES (?, ?, ?, ?, ?, ?)`,
+				tenantID, string(scope), scopeID, owner, expNs, nowNs,
+			); err != nil {
+				return store.MemoryCursorRow{}, false, err
+			}
+		}
+		acquired = true
+	}
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return store.MemoryCursorRow{}, false, err
+	}
+	committed = true
+
+	row, gerr := s.MemoryCursorGet(ctx, tenantID, scope, scopeID)
+	if gerr != nil {
+		return store.MemoryCursorRow{}, acquired, gerr
+	}
+	return row, acquired, nil
+}
+
+// MemoryCursorAdvance advances the composite watermark monotonically IFF owner
+// holds a non-expired lease. Uses a BEGIN IMMEDIATE transaction: the ownership
+// check errors with "not lease owner"; a backward/equal advance is a no-op.
+func (s *Store) MemoryCursorAdvance(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, owner string, completedAt time.Time, sessionID string) error {
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.Background(), "ROLLBACK")
+		}
+	}()
+
+	nowNs := time.Now().UnixNano()
+	var (
+		leasedBy string
+		leaseExp sql.NullInt64
+		wmComp   sql.NullInt64
+		wmSess   string
+	)
+	err = conn.QueryRowContext(ctx,
+		`SELECT leased_by, lease_expires_at, watermark_completed_at, watermark_session_id
+		 FROM memory_cursors WHERE tenant_id = ? AND scope = ? AND scope_id = ?`,
+		tenantID, string(scope), scopeID,
+	).Scan(&leasedBy, &leaseExp, &wmComp, &wmSess)
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("memory cursor advance: not lease owner (owner=%q, no lease)", owner)
+	}
+	if err != nil {
+		return err
+	}
+	if leasedBy != owner || !leaseExp.Valid || leaseExp.Int64 <= nowNs {
+		return fmt.Errorf("memory cursor advance: not lease owner (owner=%q)", owner)
+	}
+	completedNs := completedAt.UnixNano()
+	monotonic := !wmComp.Valid || completedNs > wmComp.Int64 ||
+		(completedNs == wmComp.Int64 && sessionID > wmSess)
+	if monotonic {
+		if _, err := conn.ExecContext(ctx,
+			`UPDATE memory_cursors SET watermark_completed_at = ?, watermark_session_id = ?, updated_at = ?
+			 WHERE tenant_id = ? AND scope = ? AND scope_id = ?`,
+			completedNs, sessionID, nowNs, tenantID, string(scope), scopeID,
+		); err != nil {
+			return err
+		}
+	}
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return err
+	}
+	committed = true
+	return nil
+}
+
+// MemoryCursorRelease clears the lease IFF held by owner. Idempotent no-op
+// otherwise; the watermark is untouched.
+func (s *Store) MemoryCursorRelease(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, owner string) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE memory_cursors SET leased_by = '', lease_expires_at = NULL, updated_at = ?
+		 WHERE tenant_id = ? AND scope = ? AND scope_id = ? AND leased_by = ?`,
+		time.Now().UnixNano(), tenantID, string(scope), scopeID, owner,
+	)
+	return err
 }
 
 // ---- v0.8.4 Channel tool ----

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1544,10 +1544,13 @@ type Store interface {
 	MemoryPendingDrain(ctx context.Context, tenantID string, scope MemoryScope, scopeID string, limit int) ([]MemoryPendingRow, error)
 
 	// MemoryPendingAck marks the given pending rows drained (drained_at =
-	// now()), so a subsequent MemoryPendingDrain never re-returns them.
-	// Idempotent: acking an already-drained id does not move drained_at; an
-	// unknown id is silently skipped. An empty slice is a no-op.
-	MemoryPendingAck(ctx context.Context, ids []string) error
+	// now()), so a subsequent MemoryPendingDrain never re-returns them. The ack
+	// is confined to (tenantID, scope, scopeID) — symmetric with the scoped
+	// Drain that produced the ids — so an id from another tenant/scope can never
+	// be acked even if it leaked. Idempotent: acking an already-drained id does
+	// not move drained_at; an unknown or out-of-scope id is silently skipped. An
+	// empty slice is a no-op.
+	MemoryPendingAck(ctx context.Context, tenantID string, scope MemoryScope, scopeID string, ids []string) error
 
 	// MemoryCursorGet returns the consolidation cursor for a target. It is a
 	// GET-OR-DEFAULT: a target with no row yet returns a zero-watermark,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1517,6 +1517,69 @@ type Store interface {
 	// columns PR1 added to the memory table (both sqlite + postgres do).
 	MemoryBumpAccessBatch(ctx context.Context, bumps []MemoryAccessBump) error
 
+	// --- RFC BL P2: background memory consolidation substrate ---
+	//
+	// MemorySupersede soft-archives one base-memory row: it sets
+	// superseded_at = now() for (tenantID, scope, scopeID, key). A superseded
+	// row is RETAINED (audit/rollback) but INVISIBLE to every recall path
+	// (MemoryGet / MemoryList / MemoryEmbedSearch / MemoryFullTextSearch all
+	// filter superseded_at IS NULL). Idempotent: re-superseding an already-
+	// superseded row is a no-op (superseded_at is not re-stamped). A missing
+	// key is a clean no-op (no error) — the consolidator may race a delete.
+	MemorySupersede(ctx context.Context, tenantID string, scope MemoryScope, scopeID, key string) error
+
+	// MemoryPendingEnqueue appends one durable consolidation-queue row. The
+	// consolidator drains these oldest-first (MemoryPendingDrain) and acks them
+	// after a successful consolidation (MemoryPendingAck). Row.ID is generated
+	// when empty; CreatedAt is set to now() when zero. DrainedAt is ignored on
+	// input (a fresh row is always un-drained).
+	MemoryPendingEnqueue(ctx context.Context, row MemoryPendingRow) error
+
+	// MemoryPendingDrain returns up to limit UN-DRAINED rows for the target
+	// (tenantID, scope, scopeID), oldest-first (created_at ASC, id ASC as a
+	// stable tie-break). It does NOT mark them drained — the ack is a separate
+	// step (MemoryPendingAck) so a crash between drain and consolidation
+	// re-delivers the batch (at-least-once). limit <= 0 is treated as a small
+	// default. An empty queue returns (nil, nil).
+	MemoryPendingDrain(ctx context.Context, tenantID string, scope MemoryScope, scopeID string, limit int) ([]MemoryPendingRow, error)
+
+	// MemoryPendingAck marks the given pending rows drained (drained_at =
+	// now()), so a subsequent MemoryPendingDrain never re-returns them.
+	// Idempotent: acking an already-drained id does not move drained_at; an
+	// unknown id is silently skipped. An empty slice is a no-op.
+	MemoryPendingAck(ctx context.Context, ids []string) error
+
+	// MemoryCursorGet returns the consolidation cursor for a target. It is a
+	// GET-OR-DEFAULT: a target with no row yet returns a zero-watermark,
+	// unleased MemoryCursorRow (TenantID/Scope/ScopeID populated, everything
+	// else zero) — never ErrNotFound.
+	MemoryCursorGet(ctx context.Context, tenantID string, scope MemoryScope, scopeID string) (MemoryCursorRow, error)
+
+	// MemoryCursorLease atomically acquires (or re-acquires) the consolidation
+	// lease for a target. It succeeds — as a SINGLE conditional upsert, so two
+	// replicas can't both acquire — iff the target is currently unleased, its
+	// lease has expired (lease_expires_at <= now), or it is already held by
+	// owner (re-entrant refresh). On success it sets leased_by = owner,
+	// lease_expires_at = now + ttl and returns (row, true, nil). On failure
+	// (a live lease held by someone else) it returns the current row with
+	// acquired = false and no error.
+	MemoryCursorLease(ctx context.Context, tenantID string, scope MemoryScope, scopeID, owner string, now time.Time, ttl time.Duration) (MemoryCursorRow, bool, error)
+
+	// MemoryCursorAdvance advances the target's composite watermark to
+	// (completedAt, sessionID) IFF owner currently holds a non-expired lease;
+	// otherwise it returns an error whose message contains "not lease owner".
+	// The watermark is monotonic non-decreasing on the composite key
+	// (completed_at, then session_id) — a backward or equal advance while the
+	// lease is held is a clean no-op (not an error), so the watermark never
+	// moves back.
+	MemoryCursorAdvance(ctx context.Context, tenantID string, scope MemoryScope, scopeID, owner string, completedAt time.Time, sessionID string) error
+
+	// MemoryCursorRelease clears the lease (leased_by = '', lease_expires_at =
+	// NULL) IFF it is currently held by owner. Idempotent: releasing a lease
+	// not held by owner (already released, expired, or held by another) is a
+	// clean no-op. The watermark is untouched.
+	MemoryCursorRelease(ctx context.Context, tenantID string, scope MemoryScope, scopeID, owner string) error
+
 	// SupportsVectors reports whether this backend instance can serve
 	// the MemoryEmbed* family. Backends without a vector index loaded
 	// return false; the Memory tool's `search` op + `embed: true`
@@ -2558,6 +2621,41 @@ type MemoryAccessBump struct {
 	Key        string
 	CountDelta int64
 	LastAccess time.Time
+}
+
+// MemoryPendingRow is one durable consolidation-queue record (RFC BL P2). An
+// Add enqueues the raw messages + metadata to consolidate; the consolidator
+// drains oldest-first and acks after folding them into consolidated memory.
+// DrainedAt is the zero time until MemoryPendingAck stamps it (soft-drain — the
+// row is retained for TTL sweeping, never re-drained). Payload is opaque to the
+// store (JSONB on Postgres, TEXT-encoded JSON on sqlite).
+type MemoryPendingRow struct {
+	ID              string
+	TenantID        string
+	Scope           MemoryScope
+	ScopeID         string
+	Payload         json.RawMessage
+	SourceSessionID string
+	SourceRunID     string
+	CreatedAt       time.Time
+	DrainedAt       time.Time // zero = not yet drained
+}
+
+// MemoryCursorRow is the per-target consolidation watermark + lease (RFC BL
+// P2). The composite watermark (WatermarkCompletedAt, WatermarkSessionID)
+// records how far consolidation has progressed and advances monotonically; the
+// lease (LeasedBy, LeaseExpiresAt) lets one replica own a target's
+// consolidation at a time. A zero WatermarkCompletedAt means "never advanced";
+// an empty LeasedBy (or a zero LeaseExpiresAt) means "unleased".
+type MemoryCursorRow struct {
+	TenantID             string
+	Scope                MemoryScope
+	ScopeID              string
+	WatermarkCompletedAt time.Time // zero = never advanced
+	WatermarkSessionID   string
+	LeasedBy             string
+	LeaseExpiresAt       time.Time // zero = unleased
+	UpdatedAt            time.Time
 }
 
 // MemoryEmbedStats summarises the embedded rows under one scope.

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -148,6 +148,13 @@ func Run(t *testing.T, factory Factory) {
 		{"MemoryScopeIsolation", testMemoryScopeIsolation},
 		{"MemoryListScopeIDs", testMemoryListScopeIDs},
 		{"MemoryListTenantsForScope", testMemoryListTenantsForScope},
+		// RFC BL P2: the background-consolidation substrate.
+		{"MemorySupersedeHidesFromReads", testMemorySupersedeHidesFromReads},
+		{"MemorySupersedeIsIdempotent", testMemorySupersedeIsIdempotent},
+		{"MemoryPendingEnqueueDrainAck", testMemoryPendingEnqueueDrainAck},
+		{"MemoryCursorGetDefault", testMemoryCursorGetDefault},
+		{"MemoryCursorLeaseCAS", testMemoryCursorLeaseCAS},
+		{"MemoryCursorAdvanceMonotonicAndOwner", testMemoryCursorAdvanceMonotonicAndOwner},
 		{"MemoryIncrementIsAtomicUnderConcurrency", testMemoryIncrementIsAtomicUnderConcurrency},
 		// v0.12.x — MemoryAtomicUpdate primitive backing the new
 		// reducer ops (Memory.merge / append_dedupe / bounded_list).
@@ -3284,6 +3291,293 @@ func testMemoryDeleteScope(t *testing.T, s store.Store) {
 	}
 	if n != 0 {
 		t.Errorf("second MemoryDeleteScope deleted %d, want 0", n)
+	}
+}
+
+// testMemorySupersedeHidesFromReads is the RFC BL P2 soft-archive: a superseded
+// row disappears from get + list but is RETAINED (still counted by the operator
+// scope-size summary, which does not filter superseded rows).
+func testMemorySupersedeHidesFromReads(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_ = s.MemorySet(ctx, "", store.MemoryScopeAgent, "consol", "raw-1", json.RawMessage(`"one"`), 0)
+	_ = s.MemorySet(ctx, "", store.MemoryScopeAgent, "consol", "raw-2", json.RawMessage(`"two"`), 0)
+
+	if err := s.MemorySupersede(ctx, "", store.MemoryScopeAgent, "consol", "raw-1"); err != nil {
+		t.Fatalf("MemorySupersede: %v", err)
+	}
+
+	// get: the superseded key is now invisible (surfaced as not-found).
+	if _, err := s.MemoryGet(ctx, "", store.MemoryScopeAgent, "consol", "raw-1"); err == nil {
+		t.Error("MemoryGet returned a superseded row; want not-found")
+	} else {
+		var nf *store.ErrNotFound
+		if !errors.As(err, &nf) {
+			t.Errorf("MemoryGet(superseded) err = %v (%T), want *store.ErrNotFound", err, err)
+		}
+	}
+	// The non-superseded sibling is still readable.
+	if _, err := s.MemoryGet(ctx, "", store.MemoryScopeAgent, "consol", "raw-2"); err != nil {
+		t.Errorf("MemoryGet(live sibling): %v", err)
+	}
+
+	// list: only the live key.
+	got, _, err := s.MemoryList(ctx, "", store.MemoryScopeAgent, "consol", "", 100)
+	if err != nil {
+		t.Fatalf("MemoryList: %v", err)
+	}
+	if len(got) != 1 || got[0].Key != "raw-2" {
+		t.Errorf("MemoryList after supersede = %+v, want only raw-2", got)
+	}
+
+	// Retention: the row is kept — the operator scope-size summary (which does
+	// NOT filter superseded rows) still counts both keys.
+	sums, err := s.MemoryListScopeIDs(ctx, "", store.MemoryScopeAgent)
+	if err != nil {
+		t.Fatalf("MemoryListScopeIDs: %v", err)
+	}
+	var count int
+	for _, sum := range sums {
+		if sum.ScopeID == "consol" {
+			count = sum.KeyCount
+		}
+	}
+	if count != 2 {
+		t.Errorf("scope key_count = %d after superseding 1 of 2; want 2 (row retained)", count)
+	}
+}
+
+// testMemorySupersedeIsIdempotent: re-superseding an already-superseded row and
+// superseding a missing key are both clean no-ops.
+func testMemorySupersedeIsIdempotent(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_ = s.MemorySet(ctx, "", store.MemoryScopeUser, "u-consol", "k", json.RawMessage(`1`), 0)
+	if err := s.MemorySupersede(ctx, "", store.MemoryScopeUser, "u-consol", "k"); err != nil {
+		t.Fatalf("first supersede: %v", err)
+	}
+	if err := s.MemorySupersede(ctx, "", store.MemoryScopeUser, "u-consol", "k"); err != nil {
+		t.Fatalf("second supersede (idempotent) should not error: %v", err)
+	}
+	if err := s.MemorySupersede(ctx, "", store.MemoryScopeUser, "u-consol", "missing"); err != nil {
+		t.Fatalf("supersede of a missing key should be a no-op: %v", err)
+	}
+}
+
+// testMemoryPendingEnqueueDrainAck exercises the durable consolidation queue:
+// enqueue oldest-first, drain (capped, does NOT mark drained), ack (idempotent),
+// and re-drain (acked rows excluded).
+func testMemoryPendingEnqueueDrainAck(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	base := time.Now().UTC().Truncate(time.Second)
+	mk := func(id string, ageSecs int, body string) store.MemoryPendingRow {
+		return store.MemoryPendingRow{
+			ID:        id,
+			Scope:     store.MemoryScopeAgent,
+			ScopeID:   "pending-agent",
+			Payload:   json.RawMessage(body),
+			CreatedAt: base.Add(time.Duration(ageSecs) * time.Second),
+		}
+	}
+	// Enqueue out of order; drain must return oldest-first by created_at.
+	if err := s.MemoryPendingEnqueue(ctx, mk("mp_c", 2, `{"n":3}`)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.MemoryPendingEnqueue(ctx, mk("mp_a", 0, `{"n":1}`)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.MemoryPendingEnqueue(ctx, mk("mp_b", 1, `{"n":2}`)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Drain capped at 2 → the two oldest, in order.
+	batch, err := s.MemoryPendingDrain(ctx, "", store.MemoryScopeAgent, "pending-agent", 2)
+	if err != nil {
+		t.Fatalf("MemoryPendingDrain: %v", err)
+	}
+	if len(batch) != 2 {
+		t.Fatalf("drain(limit=2) returned %d rows, want 2", len(batch))
+	}
+	if batch[0].ID != "mp_a" || batch[1].ID != "mp_b" {
+		t.Errorf("drain order = [%s, %s], want [mp_a, mp_b] (oldest-first)", batch[0].ID, batch[1].ID)
+	}
+	if string(batch[0].Payload) == "" || !strings.Contains(string(batch[0].Payload), `"n"`) {
+		t.Errorf("payload not round-tripped: %q", batch[0].Payload)
+	}
+
+	// Drain does NOT mark rows drained (at-least-once): re-draining returns them.
+	again, err := s.MemoryPendingDrain(ctx, "", store.MemoryScopeAgent, "pending-agent", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(again) != 2 {
+		t.Fatalf("re-drain before ack returned %d, want 2 (drain must not mark drained)", len(again))
+	}
+
+	// Ack the two oldest; the third remains.
+	if err := s.MemoryPendingAck(ctx, []string{"mp_a", "mp_b"}); err != nil {
+		t.Fatalf("MemoryPendingAck: %v", err)
+	}
+	rest, err := s.MemoryPendingDrain(ctx, "", store.MemoryScopeAgent, "pending-agent", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rest) != 1 || rest[0].ID != "mp_c" {
+		t.Errorf("drain after ack = %+v, want only mp_c", rest)
+	}
+
+	// Ack idempotency: re-acking already-drained ids is a clean no-op and does
+	// not resurrect or re-drain anything.
+	if err := s.MemoryPendingAck(ctx, []string{"mp_a", "mp_b"}); err != nil {
+		t.Fatalf("re-ack should be a no-op: %v", err)
+	}
+	if err := s.MemoryPendingAck(ctx, nil); err != nil {
+		t.Fatalf("empty ack should be a no-op: %v", err)
+	}
+	rest2, _ := s.MemoryPendingDrain(ctx, "", store.MemoryScopeAgent, "pending-agent", 10)
+	if len(rest2) != 1 || rest2[0].ID != "mp_c" {
+		t.Errorf("drain after re-ack = %+v, want still only mp_c", rest2)
+	}
+}
+
+// testMemoryCursorGetDefault: an unseen target returns a zero-watermark,
+// unleased row — not an error.
+func testMemoryCursorGetDefault(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	row, err := s.MemoryCursorGet(ctx, "", store.MemoryScopeAgent, "never-consolidated")
+	if err != nil {
+		t.Fatalf("MemoryCursorGet(default): %v", err)
+	}
+	if !row.WatermarkCompletedAt.IsZero() || row.WatermarkSessionID != "" {
+		t.Errorf("default watermark not zero: %+v", row)
+	}
+	if row.LeasedBy != "" || !row.LeaseExpiresAt.IsZero() {
+		t.Errorf("default lease not empty: %+v", row)
+	}
+	if row.ScopeID != "never-consolidated" || row.Scope != store.MemoryScopeAgent {
+		t.Errorf("default row target fields not populated: %+v", row)
+	}
+}
+
+// testMemoryCursorLeaseCAS: the lease is a real compare-and-set — a second
+// owner fails while the lease is held, and succeeds once it has expired.
+func testMemoryCursorLeaseCAS(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	const scopeID = "lease-agent"
+	now := time.Now().UTC()
+
+	// A acquires an unleased target.
+	row, ok, err := s.MemoryCursorLease(ctx, "", store.MemoryScopeAgent, scopeID, "owner-A", now, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || row.LeasedBy != "owner-A" {
+		t.Fatalf("A first lease: acquired=%v leasedBy=%q, want true/owner-A", ok, row.LeasedBy)
+	}
+
+	// B cannot acquire while A holds a live lease.
+	row, ok, err = s.MemoryCursorLease(ctx, "", store.MemoryScopeAgent, scopeID, "owner-B", now, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Error("B acquired a lease A still holds")
+	}
+	if row.LeasedBy != "owner-A" {
+		t.Errorf("held lease owner = %q, want owner-A", row.LeasedBy)
+	}
+
+	// A re-acquires re-entrantly.
+	if _, ok, err = s.MemoryCursorLease(ctx, "", store.MemoryScopeAgent, scopeID, "owner-A", now, time.Hour); err != nil || !ok {
+		t.Fatalf("A re-entrant lease: acquired=%v err=%v, want true/nil", ok, err)
+	}
+
+	// A force-expires its own lease (negative ttl → lease_expires_at in the past).
+	if _, ok, err = s.MemoryCursorLease(ctx, "", store.MemoryScopeAgent, scopeID, "owner-A", now, -time.Hour); err != nil || !ok {
+		t.Fatalf("A expire-own lease: acquired=%v err=%v", ok, err)
+	}
+
+	// B now acquires the expired lease.
+	row, ok, err = s.MemoryCursorLease(ctx, "", store.MemoryScopeAgent, scopeID, "owner-B", time.Now().UTC(), time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || row.LeasedBy != "owner-B" {
+		t.Errorf("B acquire-after-expiry: acquired=%v leasedBy=%q, want true/owner-B", ok, row.LeasedBy)
+	}
+
+	// Release by A (not the holder) is a no-op; release by B clears it.
+	if err := s.MemoryCursorRelease(ctx, "", store.MemoryScopeAgent, scopeID, "owner-A"); err != nil {
+		t.Fatalf("release by non-holder should be a no-op: %v", err)
+	}
+	if r, _ := s.MemoryCursorGet(ctx, "", store.MemoryScopeAgent, scopeID); r.LeasedBy != "owner-B" {
+		t.Errorf("non-holder release cleared the lease: %+v", r)
+	}
+	if err := s.MemoryCursorRelease(ctx, "", store.MemoryScopeAgent, scopeID, "owner-B"); err != nil {
+		t.Fatal(err)
+	}
+	if r, _ := s.MemoryCursorGet(ctx, "", store.MemoryScopeAgent, scopeID); r.LeasedBy != "" {
+		t.Errorf("lease not cleared after holder release: %+v", r)
+	}
+}
+
+// testMemoryCursorAdvanceMonotonicAndOwner: advance requires the lease and
+// never moves the composite watermark backward.
+func testMemoryCursorAdvanceMonotonicAndOwner(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	const scopeID = "advance-agent"
+	t1 := time.Now().UTC().Truncate(time.Second)
+	t2 := t1.Add(time.Minute)
+
+	// No lease yet → advance refused.
+	if err := s.MemoryCursorAdvance(ctx, "", store.MemoryScopeAgent, scopeID, "owner-A", t2, "s2"); err == nil ||
+		!strings.Contains(err.Error(), "not lease owner") {
+		t.Errorf("advance without a lease err = %v, want 'not lease owner'", err)
+	}
+
+	// A leases the target.
+	if _, ok, err := s.MemoryCursorLease(ctx, "", store.MemoryScopeAgent, scopeID, "owner-A", time.Now().UTC(), time.Hour); err != nil || !ok {
+		t.Fatalf("A lease: acquired=%v err=%v", ok, err)
+	}
+
+	// B (not the lease owner) cannot advance.
+	if err := s.MemoryCursorAdvance(ctx, "", store.MemoryScopeAgent, scopeID, "owner-B", t2, "s2"); err == nil ||
+		!strings.Contains(err.Error(), "not lease owner") {
+		t.Errorf("advance by non-owner err = %v, want 'not lease owner'", err)
+	}
+
+	// A advances to (t2, s2).
+	if err := s.MemoryCursorAdvance(ctx, "", store.MemoryScopeAgent, scopeID, "owner-A", t2, "s2"); err != nil {
+		t.Fatalf("A advance to t2: %v", err)
+	}
+	row, _ := s.MemoryCursorGet(ctx, "", store.MemoryScopeAgent, scopeID)
+	if !row.WatermarkCompletedAt.Equal(t2) || row.WatermarkSessionID != "s2" {
+		t.Fatalf("watermark = (%v, %q), want (t2, s2)", row.WatermarkCompletedAt, row.WatermarkSessionID)
+	}
+
+	// A backward advance (t1 < t2) is a monotonic no-op, not an error.
+	if err := s.MemoryCursorAdvance(ctx, "", store.MemoryScopeAgent, scopeID, "owner-A", t1, "s1"); err != nil {
+		t.Fatalf("backward advance should be a no-op, got err: %v", err)
+	}
+	row, _ = s.MemoryCursorGet(ctx, "", store.MemoryScopeAgent, scopeID)
+	if !row.WatermarkCompletedAt.Equal(t2) || row.WatermarkSessionID != "s2" {
+		t.Errorf("watermark moved backward: (%v, %q), want (t2, s2)", row.WatermarkCompletedAt, row.WatermarkSessionID)
+	}
+
+	// Same timestamp, higher session id → advances on the composite tie-break.
+	if err := s.MemoryCursorAdvance(ctx, "", store.MemoryScopeAgent, scopeID, "owner-A", t2, "s3"); err != nil {
+		t.Fatal(err)
+	}
+	row, _ = s.MemoryCursorGet(ctx, "", store.MemoryScopeAgent, scopeID)
+	if row.WatermarkSessionID != "s3" {
+		t.Errorf("composite advance session = %q, want s3", row.WatermarkSessionID)
+	}
+
+	// Same timestamp, lower session id → no-op.
+	if err := s.MemoryCursorAdvance(ctx, "", store.MemoryScopeAgent, scopeID, "owner-A", t2, "s0"); err != nil {
+		t.Fatal(err)
+	}
+	row, _ = s.MemoryCursorGet(ctx, "", store.MemoryScopeAgent, scopeID)
+	if row.WatermarkSessionID != "s3" {
+		t.Errorf("watermark session moved backward to %q, want s3", row.WatermarkSessionID)
 	}
 }
 

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -151,6 +151,7 @@ func Run(t *testing.T, factory Factory) {
 		// RFC BL P2: the background-consolidation substrate.
 		{"MemorySupersedeHidesFromReads", testMemorySupersedeHidesFromReads},
 		{"MemorySupersedeIsIdempotent", testMemorySupersedeIsIdempotent},
+		{"MemorySupersedeRevivedByWrite", testMemorySupersedeRevivedByWrite},
 		{"MemoryPendingEnqueueDrainAck", testMemoryPendingEnqueueDrainAck},
 		{"MemoryCursorGetDefault", testMemoryCursorGetDefault},
 		{"MemoryCursorLeaseCAS", testMemoryCursorLeaseCAS},
@@ -3362,6 +3363,49 @@ func testMemorySupersedeIsIdempotent(t *testing.T, s store.Store) {
 	}
 }
 
+// testMemorySupersedeRevivedByWrite: a fresh write to a superseded key REVIVES
+// it (clears superseded_at). set, incr, and the atomic-update ops must never
+// black-hole a live write behind a stale supersede marker — a new explicit
+// write is live data. Fail-before: without superseded_at=NULL on the upsert the
+// value lands but stays hidden, so the post-write MemoryGet returns not-found.
+func testMemorySupersedeRevivedByWrite(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	const scopeID = "revive"
+
+	// set → supersede → set: the row comes back with the NEW value.
+	_ = s.MemorySet(ctx, "", store.MemoryScopeAgent, scopeID, "k", json.RawMessage(`"old"`), 0)
+	if err := s.MemorySupersede(ctx, "", store.MemoryScopeAgent, scopeID, "k"); err != nil {
+		t.Fatalf("supersede: %v", err)
+	}
+	if err := s.MemorySet(ctx, "", store.MemoryScopeAgent, scopeID, "k", json.RawMessage(`"new"`), 0); err != nil {
+		t.Fatalf("re-set: %v", err)
+	}
+	got, err := s.MemoryGet(ctx, "", store.MemoryScopeAgent, scopeID, "k")
+	if err != nil {
+		t.Fatalf("MemoryGet after re-set must find the revived row: %v", err)
+	}
+	if string(got.Value) != `"new"` {
+		t.Errorf("revived value = %s, want \"new\"", got.Value)
+	}
+
+	// incr also revives: supersede a counter, then incr — the row must be visible
+	// again and continue from the archived value.
+	_ = s.MemorySet(ctx, "", store.MemoryScopeAgent, scopeID, "c", json.RawMessage(`5`), 0)
+	if err := s.MemorySupersede(ctx, "", store.MemoryScopeAgent, scopeID, "c"); err != nil {
+		t.Fatalf("supersede counter: %v", err)
+	}
+	n, err := s.MemoryIncrement(ctx, "", store.MemoryScopeAgent, scopeID, "c", 1, 0)
+	if err != nil {
+		t.Fatalf("incr after supersede: %v", err)
+	}
+	if n != 6 {
+		t.Errorf("incr revived counter = %d, want 6 (continue from archived 5)", n)
+	}
+	if _, err := s.MemoryGet(ctx, "", store.MemoryScopeAgent, scopeID, "c"); err != nil {
+		t.Errorf("incr did not revive the row (still hidden): %v", err)
+	}
+}
+
 // testMemoryPendingEnqueueDrainAck exercises the durable consolidation queue:
 // enqueue oldest-first, drain (capped, does NOT mark drained), ack (idempotent),
 // and re-drain (acked rows excluded).
@@ -3412,8 +3456,22 @@ func testMemoryPendingEnqueueDrainAck(t *testing.T, s store.Store) {
 		t.Fatalf("re-drain before ack returned %d, want 2 (drain must not mark drained)", len(again))
 	}
 
-	// Ack the two oldest; the third remains.
-	if err := s.MemoryPendingAck(ctx, []string{"mp_a", "mp_b"}); err != nil {
+	// An ack under a DIFFERENT scope/scope_id must NOT touch these rows — the ack
+	// is confined to (tenant, scope, scope_id) symmetric with drain, so a leaked
+	// id can't be acked cross-scope. mp_a must survive this wrong-scope ack.
+	if err := s.MemoryPendingAck(ctx, "", store.MemoryScopeUser, "someone-else", []string{"mp_a", "mp_b"}); err != nil {
+		t.Fatalf("wrong-scope ack should be a no-op, not an error: %v", err)
+	}
+	stillThere, err := s.MemoryPendingDrain(ctx, "", store.MemoryScopeAgent, "pending-agent", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stillThere) != 3 {
+		t.Fatalf("wrong-scope ack drained rows it shouldn't: drain returned %d, want 3", len(stillThere))
+	}
+
+	// Ack the two oldest (correct scope); the third remains.
+	if err := s.MemoryPendingAck(ctx, "", store.MemoryScopeAgent, "pending-agent", []string{"mp_a", "mp_b"}); err != nil {
 		t.Fatalf("MemoryPendingAck: %v", err)
 	}
 	rest, err := s.MemoryPendingDrain(ctx, "", store.MemoryScopeAgent, "pending-agent", 10)
@@ -3426,10 +3484,10 @@ func testMemoryPendingEnqueueDrainAck(t *testing.T, s store.Store) {
 
 	// Ack idempotency: re-acking already-drained ids is a clean no-op and does
 	// not resurrect or re-drain anything.
-	if err := s.MemoryPendingAck(ctx, []string{"mp_a", "mp_b"}); err != nil {
+	if err := s.MemoryPendingAck(ctx, "", store.MemoryScopeAgent, "pending-agent", []string{"mp_a", "mp_b"}); err != nil {
 		t.Fatalf("re-ack should be a no-op: %v", err)
 	}
-	if err := s.MemoryPendingAck(ctx, nil); err != nil {
+	if err := s.MemoryPendingAck(ctx, "", store.MemoryScopeAgent, "pending-agent", nil); err != nil {
 		t.Fatalf("empty ack should be a no-op: %v", err)
 	}
 	rest2, _ := s.MemoryPendingDrain(ctx, "", store.MemoryScopeAgent, "pending-agent", 10)

--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -894,6 +894,7 @@ type mergedDef struct {
 	InheritCoreBlocks     bool               `json:"inherit_core_blocks,omitempty"`
 	MemoryInjectMaxTokens int                `json:"memory_inject_max_tokens,omitempty"`
 	MemoryProtocol        bool               `json:"memory_protocol,omitempty"`
+	MemoryConsolidation   bool               `json:"memory_consolidation,omitempty"` // RFC BL P2 grant; content-identifying
 	MemoryIndexMaxBytes   int                `json:"memory_index_max_bytes,omitempty"`
 	MemoryRoots           string             `json:"memory_roots,omitempty"`
 	Description           string             `json:"description,omitempty"`
@@ -1017,6 +1018,9 @@ func (d *mergedDef) applyOverlay(ov mergedDef) {
 	if ov.MemoryProtocol {
 		d.MemoryProtocol = true
 	}
+	if ov.MemoryConsolidation {
+		d.MemoryConsolidation = true
+	}
 	if ov.MemoryIndexMaxBytes != 0 {
 		d.MemoryIndexMaxBytes = ov.MemoryIndexMaxBytes
 	}
@@ -1113,6 +1117,7 @@ func staticToMergedDef(s config.AgentDef) mergedDef {
 		InheritCoreBlocks:     s.InheritCoreBlocks,
 		MemoryInjectMaxTokens: s.MemoryInjectMaxTokens,
 		MemoryProtocol:        s.MemoryProtocol,
+		MemoryConsolidation:   s.MemoryConsolidation,
 		MemoryIndexMaxBytes:   s.MemoryIndexMaxBytes,
 		MemoryRoots:           s.MemoryRoots,
 		RetryAttempts:         s.RetryAttempts,
@@ -1209,6 +1214,7 @@ func signFromMergedDef(name string, def mergedDef) string {
 		InheritCoreBlocks:     def.InheritCoreBlocks,
 		MemoryInjectMaxTokens: def.MemoryInjectMaxTokens,
 		MemoryProtocol:        def.MemoryProtocol,
+		MemoryConsolidation:   def.MemoryConsolidation,
 		MemoryIndexMaxBytes:   def.MemoryIndexMaxBytes,
 		MemoryRoots:           def.MemoryRoots,
 		// RFC BA: skills: is the agent's pattern-allowlist ACL (authority, not

--- a/internal/tools/builtin/agentdef_capability_test.go
+++ b/internal/tools/builtin/agentdef_capability_test.go
@@ -25,6 +25,7 @@ func TestAgentDefTool_CreateWithCapabilityFields_RoundTrips(t *testing.T) {
 		"system_prompt":"coordinate the loop",
 		"tools":["Memory","Channel","Evaluation","Interruption"],
 		"memory_scopes":["user"],
+		"memory_consolidation":true,
 		"evaluation_scopes":["submit_self","read_any"],
 		"max_iterations":42,
 		"channels":{"publish":["findings"],"subscribe":["tasks"]},
@@ -49,5 +50,9 @@ func TestAgentDefTool_CreateWithCapabilityFields_RoundTrips(t *testing.T) {
 	}
 	if i := def.Interruption; !i.Enabled || i.MaxPending != 3 || len(i.Kinds) != 1 || i.Kinds[0] != "question" {
 		t.Errorf("Interruption = %+v, want {enabled:true kinds:[question] max_pending:3}", def.Interruption)
+	}
+	// RFC BL P2: the consolidation grant must survive overlay → persist → resolve.
+	if !def.MemoryConsolidation {
+		t.Error("MemoryConsolidation grant did not round-trip through create+promote+resolve")
 	}
 }

--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -391,7 +391,7 @@ const memoryDescription = `Persistent key/value storage scoped to this agent or 
 const memoryInputSchema = `{
   "type": "object",
   "properties": {
-    "op":         {"type": "string", "enum": ["get","set","delete","list","incr","search","merge","append_dedupe","bounded_list","add","recall","sql_query","sql_exec","sql_begin","sql_commit","sql_rollback"], "description": "Which operation to perform. Families: key/value (get,set,delete,list,incr,merge,append_dedupe,bounded_list,search); memory-layer (add,recall — mem9 backends only); SQL (sql_query,sql_exec,sql_begin,sql_commit,sql_rollback — a per-scope SQL database, gated separately by sql_scopes)."},
+    "op":         {"type": "string", "enum": ["get","set","delete","list","incr","search","merge","append_dedupe","bounded_list","add","recall","sql_query","sql_exec","sql_begin","sql_commit","sql_rollback","cursor_get","cursor_lease","cursor_advance","cursor_release","supersede","pending_drain","pending_ack"], "description": "Which operation to perform. Families: key/value (get,set,delete,list,incr,merge,append_dedupe,bounded_list,search); memory-layer (add,recall — mem9 backends only); SQL (sql_query,sql_exec,sql_begin,sql_commit,sql_rollback — a per-scope SQL database, gated separately by sql_scopes); consolidation (cursor_get,cursor_lease,cursor_advance,cursor_release,supersede,pending_drain,pending_ack — background memory consolidation, gated separately by a dedicated grant)."},
     "scope":      {"type": "string", "enum": ["agent","user","run"], "description": "Which keyspace/database. agent: this agent's (cross-run, cross-user). user: this end-user's (cross-agent). run: ephemeral per-run, dropped at run end — SQL ops only."},
     "key":        {"type": "string", "description": "The entry's key. Required for get / set / delete / incr / merge / append_dedupe / bounded_list."},
     "value":      {"description": "The JSON value. Required for set / merge / append_dedupe / bounded_list. For merge: a JSON object whose fields overlay the existing object. For append_dedupe / bounded_list: the item to append."},
@@ -411,7 +411,11 @@ const memoryInputSchema = `{
     "threshold":  {"type": "number", "description": "recall-only: 0..1 relevance floor for returned facts (0 = backend default)."},
     "statement":  {"type": "string", "description": "sql_query / sql_exec: ONE SQL statement. sql_query is read-only (SELECT / WITH … SELECT); sql_exec is DDL/DML (CREATE/INSERT/UPDATE/DELETE/etc.). ATTACH, PRAGMA, load_extension, transactions, and multiple statements are refused."},
     "args":       {"type": "array", "description": "sql_query / sql_exec: positional bind parameters for ? placeholders. An element of the form {\"$embed\": \"text\"} is replaced server-side by the embedding of that text as a pgvector value (reference it with a ::vector cast, e.g. ... ORDER BY embedding <=> ?::vector); requires the postgres tier with pgvector + a configured embedder.", "items": {}},
-    "timeout_ms": {"type": "integer", "description": "sql_query / sql_exec: reserved — the server-configured statement timeout is authoritative in this version."}
+    "timeout_ms": {"type": "integer", "description": "sql_query / sql_exec: reserved — the server-configured statement timeout is authoritative in this version."},
+    "lease_ttl_ms":  {"type": "integer", "description": "cursor_lease: how long to hold the consolidation lease, in milliseconds (0 = default; clamped to a maximum). The lease auto-expires so a crashed consolidator never wedges a target."},
+    "completed_at":  {"type": "string", "description": "cursor_advance: the watermark timestamp (RFC3339). With session_id it forms the composite watermark; the watermark only ever moves forward."},
+    "session_id":    {"type": "string", "description": "cursor_advance: the watermark session id — the composite tie-break paired with completed_at."},
+    "ids":           {"type": "array", "description": "pending_ack: the pending-row ids to mark drained (as returned by pending_drain).", "items": {"type": "string"}}
   },
   "required": ["op","scope"],
   "additionalProperties": false
@@ -467,6 +471,19 @@ type memoryInput struct {
 	// authoritative (a per-call override that could only ever tighten, never
 	// widen, is a Phase-2 refinement). Accepted so the wire shape is stable.
 	TimeoutMs int `json:"timeout_ms,omitempty"`
+
+	// --- RFC BL P2 consolidation control ops ---
+	// LeaseTTLMs is the cursor_lease hold duration in milliseconds. 0 = the
+	// default; clamped to a maximum. The lease auto-expires so a crashed
+	// consolidator never wedges a target.
+	LeaseTTLMs int64 `json:"lease_ttl_ms,omitempty"`
+	// CompletedAt is the cursor_advance watermark timestamp (RFC3339). Paired
+	// with SessionID as the composite watermark.
+	CompletedAt string `json:"completed_at,omitempty"`
+	// SessionID is the cursor_advance watermark session id (composite tie-break).
+	SessionID string `json:"session_id,omitempty"`
+	// IDs are the pending_ack row ids (returned earlier by pending_drain).
+	IDs []string `json:"ids,omitempty"`
 }
 
 // Name implements tools.Tool.
@@ -535,10 +552,24 @@ func (m *Memory) Execute(ctx context.Context, raw json.RawMessage) (tools.Result
 		return m.execAdd(ctx, scope, scopeID, in)
 	case "recall":
 		return m.execRecall(ctx, scope, scopeID, in)
+	case "cursor_get":
+		return m.execCursorGet(ctx, scope, scopeID, in)
+	case "cursor_lease":
+		return m.execCursorLease(ctx, scope, scopeID, in)
+	case "cursor_advance":
+		return m.execCursorAdvance(ctx, scope, scopeID, in)
+	case "cursor_release":
+		return m.execCursorRelease(ctx, scope, scopeID, in)
+	case "supersede":
+		return m.execSupersede(ctx, scope, scopeID, in)
+	case "pending_drain":
+		return m.execPendingDrain(ctx, scope, scopeID, in)
+	case "pending_ack":
+		return m.execPendingAck(ctx, scope, scopeID, in)
 	case "":
 		return errResult("missing required field: op"), nil
 	default:
-		return errResult(fmt.Sprintf("unknown op %q (must be one of: get, set, delete, list, incr, search, merge, append_dedupe, bounded_list, add, recall, sql_query, sql_exec, sql_begin, sql_commit, sql_rollback)", in.Op)), nil
+		return errResult(fmt.Sprintf("unknown op %q (must be one of: get, set, delete, list, incr, search, merge, append_dedupe, bounded_list, add, recall, cursor_get, cursor_lease, cursor_advance, cursor_release, supersede, pending_drain, pending_ack, sql_query, sql_exec, sql_begin, sql_commit, sql_rollback)", in.Op)), nil
 	}
 }
 
@@ -1360,6 +1391,180 @@ func (m *Memory) execRecall(ctx context.Context, scope store.MemoryScope, scopeI
 		facts = append(facts, fact)
 	}
 	return okJSON(map[string]any{"facts": facts})
+}
+
+// --- RFC BL P2 consolidation control ops ---
+//
+// Every op below is gated by BOTH resolveScope (the memory_scopes ACL, already
+// applied before dispatch) AND the memory_consolidation grant (consolidationGate).
+// The (scope, scopeID) are server-resolved; the tenant comes from RunIdentity —
+// the model never supplies a target scope_id or tenant.
+
+const (
+	// defaultConsolidationLeaseTTL is the cursor_lease hold when lease_ttl_ms is
+	// unset; maxConsolidationLeaseTTL caps it so a runaway value can't wedge a
+	// target far into the future (the lease auto-expires regardless).
+	defaultConsolidationLeaseTTL = 60 * time.Second
+	maxConsolidationLeaseTTL     = time.Hour
+)
+
+// consolidationGate returns a refusal Result (and true) when the run lacks the
+// memory_consolidation grant. Default-deny: the grant is a SEPARATE gate from
+// memory_scopes, so a scope-authorized agent still cannot run these ops without it.
+func consolidationGate(ctx context.Context, op string) (tools.Result, bool) {
+	if tools.MemoryPolicy(ctx).Consolidation {
+		return tools.Result{}, false
+	}
+	return errResult(fmt.Sprintf("memory: %s requires the memory_consolidation grant (add memory_consolidation: true to the agent config)", op)), true
+}
+
+// consolidationOwner is the stable lease-owner identity for this run — the run
+// id when present (survives across a run's turns), else the agent name. Never
+// model-supplied.
+func consolidationOwner(ctx context.Context) string {
+	if id := tools.RunID(ctx); id != "" {
+		return id
+	}
+	return tools.AgentName(ctx)
+}
+
+// cursorJSON renders a cursor row for the agent (non-secret watermark + lease
+// fields). Zero timestamps render as null via expiresAtRFC3339.
+func cursorJSON(row store.MemoryCursorRow) map[string]any {
+	return map[string]any{
+		"watermark_completed_at": expiresAtRFC3339(row.WatermarkCompletedAt),
+		"watermark_session_id":   row.WatermarkSessionID,
+		"leased_by":              row.LeasedBy,
+		"lease_expires_at":       expiresAtRFC3339(row.LeaseExpiresAt),
+	}
+}
+
+func (m *Memory) execCursorGet(ctx context.Context, scope store.MemoryScope, scopeID string, in memoryInput) (tools.Result, error) {
+	if res, denied := consolidationGate(ctx, "cursor_get"); denied {
+		return res, nil
+	}
+	row, err := m.Store.MemoryCursorGet(ctx, tools.RunIdentity(ctx).TenantID, scope, scopeID)
+	if err != nil {
+		return errResult(fmt.Sprintf("cursor_get: %s", err)), nil
+	}
+	return okJSON(cursorJSON(row))
+}
+
+func (m *Memory) execCursorLease(ctx context.Context, scope store.MemoryScope, scopeID string, in memoryInput) (tools.Result, error) {
+	if res, denied := consolidationGate(ctx, "cursor_lease"); denied {
+		return res, nil
+	}
+	owner := consolidationOwner(ctx)
+	if owner == "" {
+		return errResult("cursor_lease: no stable run/agent identity to own the lease"), nil
+	}
+	ttl := defaultConsolidationLeaseTTL
+	if in.LeaseTTLMs > 0 {
+		ttl = time.Duration(in.LeaseTTLMs) * time.Millisecond
+	}
+	if ttl > maxConsolidationLeaseTTL {
+		ttl = maxConsolidationLeaseTTL
+	}
+	row, acquired, err := m.Store.MemoryCursorLease(ctx, tools.RunIdentity(ctx).TenantID, scope, scopeID, owner, time.Now().UTC(), ttl)
+	if err != nil {
+		return errResult(fmt.Sprintf("cursor_lease: %s", err)), nil
+	}
+	out := cursorJSON(row)
+	out["acquired"] = acquired
+	out["owner"] = owner
+	return okJSON(out)
+}
+
+func (m *Memory) execCursorAdvance(ctx context.Context, scope store.MemoryScope, scopeID string, in memoryInput) (tools.Result, error) {
+	if res, denied := consolidationGate(ctx, "cursor_advance"); denied {
+		return res, nil
+	}
+	owner := consolidationOwner(ctx)
+	if owner == "" {
+		return errResult("cursor_advance: no stable run/agent identity to own the lease"), nil
+	}
+	if in.CompletedAt == "" {
+		return errResult("cursor_advance: missing required field: completed_at"), nil
+	}
+	completedAt, perr := time.Parse(time.RFC3339Nano, in.CompletedAt)
+	if perr != nil {
+		return errResult(fmt.Sprintf("cursor_advance: completed_at must be an RFC3339 timestamp: %s", perr)), nil
+	}
+	if err := m.Store.MemoryCursorAdvance(ctx, tools.RunIdentity(ctx).TenantID, scope, scopeID, owner, completedAt, in.SessionID); err != nil {
+		return errResult(fmt.Sprintf("cursor_advance: %s", err)), nil
+	}
+	return okJSON(map[string]any{"ok": true})
+}
+
+func (m *Memory) execCursorRelease(ctx context.Context, scope store.MemoryScope, scopeID string, in memoryInput) (tools.Result, error) {
+	if res, denied := consolidationGate(ctx, "cursor_release"); denied {
+		return res, nil
+	}
+	owner := consolidationOwner(ctx)
+	if owner == "" {
+		return errResult("cursor_release: no stable run/agent identity to own the lease"), nil
+	}
+	if err := m.Store.MemoryCursorRelease(ctx, tools.RunIdentity(ctx).TenantID, scope, scopeID, owner); err != nil {
+		return errResult(fmt.Sprintf("cursor_release: %s", err)), nil
+	}
+	return okJSON(map[string]any{"ok": true})
+}
+
+func (m *Memory) execSupersede(ctx context.Context, scope store.MemoryScope, scopeID string, in memoryInput) (tools.Result, error) {
+	if res, denied := consolidationGate(ctx, "supersede"); denied {
+		return res, nil
+	}
+	if in.Key == "" {
+		return errResult("supersede: missing required field: key"), nil
+	}
+	if err := m.Store.MemorySupersede(ctx, tools.RunIdentity(ctx).TenantID, scope, scopeID, in.Key); err != nil {
+		return errResult(fmt.Sprintf("supersede: %s", err)), nil
+	}
+	return okJSON(map[string]any{"ok": true})
+}
+
+func (m *Memory) execPendingDrain(ctx context.Context, scope store.MemoryScope, scopeID string, in memoryInput) (tools.Result, error) {
+	if res, denied := consolidationGate(ctx, "pending_drain"); denied {
+		return res, nil
+	}
+	limit := in.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 200 {
+		limit = 200
+	}
+	rows, err := m.Store.MemoryPendingDrain(ctx, tools.RunIdentity(ctx).TenantID, scope, scopeID, limit)
+	if err != nil {
+		return errResult(fmt.Sprintf("pending_drain: %s", err)), nil
+	}
+	items := make([]map[string]any, 0, len(rows))
+	for _, r := range rows {
+		items = append(items, map[string]any{
+			"id":                r.ID,
+			"payload":           json.RawMessage(r.Payload),
+			"source_session_id": r.SourceSessionID,
+			"source_run_id":     r.SourceRunID,
+			"created_at":        r.CreatedAt.UTC().Format(time.RFC3339Nano),
+		})
+	}
+	return okJSON(map[string]any{"pending": items})
+}
+
+func (m *Memory) execPendingAck(ctx context.Context, scope store.MemoryScope, scopeID string, in memoryInput) (tools.Result, error) {
+	if res, denied := consolidationGate(ctx, "pending_ack"); denied {
+		return res, nil
+	}
+	// ids are opaque, unguessable (128-bit) tokens the caller obtained from its
+	// OWN tenant/scope-scoped pending_drain — a capability-token: possession
+	// authorizes the ack. The store method acks by id (at-least-once semantics).
+	if len(in.IDs) == 0 {
+		return errResult("pending_ack: missing required field: ids"), nil
+	}
+	if err := m.Store.MemoryPendingAck(ctx, in.IDs); err != nil {
+		return errResult(fmt.Sprintf("pending_ack: %s", err)), nil
+	}
+	return okJSON(map[string]any{"ok": true, "acked": len(in.IDs)})
 }
 
 func (m *Memory) execDelete(ctx context.Context, scope store.MemoryScope, scopeID string, in memoryInput) (tools.Result, error) {

--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -1460,10 +1460,15 @@ func (m *Memory) execCursorLease(ctx context.Context, scope store.MemoryScope, s
 	}
 	ttl := defaultConsolidationLeaseTTL
 	if in.LeaseTTLMs > 0 {
-		ttl = time.Duration(in.LeaseTTLMs) * time.Millisecond
-	}
-	if ttl > maxConsolidationLeaseTTL {
-		ttl = maxConsolidationLeaseTTL
+		// Clamp in millisecond space BEFORE converting: a huge lease_ttl_ms
+		// (≳9.2e12) would overflow int64 in the *time.Millisecond multiply and
+		// wrap negative, silently skipping a post-multiply max check. Negatives
+		// never reach here (the > 0 guard falls through to the default).
+		ms := in.LeaseTTLMs
+		if maxMs := int64(maxConsolidationLeaseTTL / time.Millisecond); ms > maxMs {
+			ms = maxMs
+		}
+		ttl = time.Duration(ms) * time.Millisecond
 	}
 	row, acquired, err := m.Store.MemoryCursorLease(ctx, tools.RunIdentity(ctx).TenantID, scope, scopeID, owner, time.Now().UTC(), ttl)
 	if err != nil {
@@ -1555,13 +1560,14 @@ func (m *Memory) execPendingAck(ctx context.Context, scope store.MemoryScope, sc
 	if res, denied := consolidationGate(ctx, "pending_ack"); denied {
 		return res, nil
 	}
-	// ids are opaque, unguessable (128-bit) tokens the caller obtained from its
-	// OWN tenant/scope-scoped pending_drain — a capability-token: possession
-	// authorizes the ack. The store method acks by id (at-least-once semantics).
+	// The ack is confined server-side to this run's resolved (tenant, scope,
+	// scopeID) — symmetric with the scoped pending_drain that surfaced the ids —
+	// so a leaked or guessed id from another tenant/scope is a no-op, never a
+	// cross-tenant ack. ids come from the caller's own drain; ack is at-least-once.
 	if len(in.IDs) == 0 {
 		return errResult("pending_ack: missing required field: ids"), nil
 	}
-	if err := m.Store.MemoryPendingAck(ctx, in.IDs); err != nil {
+	if err := m.Store.MemoryPendingAck(ctx, tools.RunIdentity(ctx).TenantID, scope, scopeID, in.IDs); err != nil {
 		return errResult(fmt.Sprintf("pending_ack: %s", err)), nil
 	}
 	return okJSON(map[string]any{"ok": true, "acked": len(in.IDs)})

--- a/internal/tools/builtin/memory_consolidation_test.go
+++ b/internal/tools/builtin/memory_consolidation_test.go
@@ -1,0 +1,196 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// grantedConsolidationCtx layers the memory_consolidation grant onto the
+// standard fixture ctx (which already carries AgentName + RunIdentity + the
+// agent/user memory scopes).
+func grantedConsolidationCtx(ctx context.Context) context.Context {
+	return tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{
+		AllowedScopes: []string{"agent", "user"},
+		Consolidation: true,
+	})
+}
+
+// TestMemory_SchemaIsValidJSON guards the hand-written input schema after the
+// consolidation-op additions — a malformed schema only fails at runtime.
+func TestMemory_SchemaIsValidJSON(t *testing.T) {
+	if !json.Valid([]byte(memoryInputSchema)) {
+		t.Fatal("memoryInputSchema is not valid JSON")
+	}
+}
+
+// TestMemory_CursorOpsRequireConsolidationGrant proves the SEPARATE gate: an
+// agent with memory_scopes but WITHOUT the grant is refused every consolidation
+// op, while a granted agent is admitted. Fails-before if consolidationGate is
+// absent (the ops would run under scope-only authorization).
+func TestMemory_CursorOpsRequireConsolidationGrant(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t) // fixture ctx grants scopes, NOT consolidation
+	defer cleanup()
+
+	denied := []string{
+		`{"op":"cursor_get","scope":"agent"}`,
+		`{"op":"cursor_lease","scope":"agent"}`,
+		`{"op":"cursor_advance","scope":"agent","completed_at":"2026-07-24T00:00:00Z","session_id":"s1"}`,
+		`{"op":"cursor_release","scope":"agent"}`,
+		`{"op":"supersede","scope":"agent","key":"k"}`,
+		`{"op":"pending_drain","scope":"agent"}`,
+		`{"op":"pending_ack","scope":"agent","ids":["mp_x"]}`,
+	}
+	for _, in := range denied {
+		res, _ := tool.Execute(ctx, json.RawMessage(in))
+		if !res.IsError || !strings.Contains(res.Text, "memory_consolidation grant") {
+			t.Errorf("%s: got (IsError=%v) %q, want a memory_consolidation refusal", in, res.IsError, res.Text)
+		}
+	}
+
+	// Granted → admitted (cursor_get on a fresh target succeeds).
+	gctx := grantedConsolidationCtx(ctx)
+	res, _ := tool.Execute(gctx, json.RawMessage(`{"op":"cursor_get","scope":"agent"}`))
+	if res.IsError {
+		t.Fatalf("granted cursor_get refused: %s", res.Text)
+	}
+	if !strings.Contains(res.Text, `"leased_by":""`) {
+		t.Errorf("cursor_get default = %s, want an unleased zero-watermark row", res.Text)
+	}
+}
+
+// TestMemory_SupersedeHidesFromReads: a superseded key vanishes from get + list
+// (the store read-filter) while its sibling remains.
+func TestMemory_SupersedeHidesFromReads(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t)
+	defer cleanup()
+	gctx := grantedConsolidationCtx(ctx)
+
+	if res, _ := tool.Execute(gctx, json.RawMessage(`{"op":"set","scope":"agent","key":"raw-1","value":"one"}`)); res.IsError {
+		t.Fatal(res.Text)
+	}
+	if res, _ := tool.Execute(gctx, json.RawMessage(`{"op":"set","scope":"agent","key":"raw-2","value":"two"}`)); res.IsError {
+		t.Fatal(res.Text)
+	}
+
+	if res, _ := tool.Execute(gctx, json.RawMessage(`{"op":"supersede","scope":"agent","key":"raw-1"}`)); res.IsError {
+		t.Fatalf("supersede: %s", res.Text)
+	}
+
+	// get(raw-1) → value:null (opaque miss).
+	res, _ := tool.Execute(gctx, json.RawMessage(`{"op":"get","scope":"agent","key":"raw-1"}`))
+	if res.IsError || !strings.Contains(res.Text, `"value":null`) {
+		t.Errorf("get(superseded) = %q, want value:null", res.Text)
+	}
+	// list → only raw-2.
+	res, _ = tool.Execute(gctx, json.RawMessage(`{"op":"list","scope":"agent"}`))
+	if res.IsError || strings.Contains(res.Text, "raw-1") || !strings.Contains(res.Text, "raw-2") {
+		t.Errorf("list after supersede = %q, want only raw-2", res.Text)
+	}
+}
+
+// TestMemory_CursorLeaseAndAdvance: lease → advance → the watermark is
+// observable via cursor_get, and a non-lease-holder cannot advance.
+func TestMemory_CursorLeaseAndAdvance(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t)
+	defer cleanup()
+	gctx := grantedConsolidationCtx(ctx)
+
+	// Lease the agent-scope target (owner = agent name "qa-agent").
+	res, _ := tool.Execute(gctx, json.RawMessage(`{"op":"cursor_lease","scope":"agent","lease_ttl_ms":60000}`))
+	if res.IsError || !strings.Contains(res.Text, `"acquired":true`) {
+		t.Fatalf("cursor_lease = %q, want acquired:true", res.Text)
+	}
+
+	// Advance the watermark.
+	adv := `{"op":"cursor_advance","scope":"agent","completed_at":"2026-07-24T10:30:00Z","session_id":"sess-42"}`
+	if res, _ := tool.Execute(gctx, json.RawMessage(adv)); res.IsError {
+		t.Fatalf("cursor_advance: %s", res.Text)
+	}
+
+	// cursor_get reflects the advanced watermark.
+	res, _ = tool.Execute(gctx, json.RawMessage(`{"op":"cursor_get","scope":"agent"}`))
+	if res.IsError {
+		t.Fatal(res.Text)
+	}
+	if !strings.Contains(res.Text, `"watermark_session_id":"sess-42"`) ||
+		!strings.Contains(res.Text, "2026-07-24T10:30:00") {
+		t.Errorf("cursor_get after advance = %q, want the sess-42 / 2026-07-24T10:30 watermark", res.Text)
+	}
+
+	// A backward advance is a monotonic no-op (not an error); the watermark holds.
+	back := `{"op":"cursor_advance","scope":"agent","completed_at":"2026-07-24T09:00:00Z","session_id":"sess-01"}`
+	if res, _ := tool.Execute(gctx, json.RawMessage(back)); res.IsError {
+		t.Fatalf("backward advance should be a no-op, got: %s", res.Text)
+	}
+	res, _ = tool.Execute(gctx, json.RawMessage(`{"op":"cursor_get","scope":"agent"}`))
+	if !strings.Contains(res.Text, `"watermark_session_id":"sess-42"`) {
+		t.Errorf("watermark moved backward: %q", res.Text)
+	}
+
+	// Release, then a fresh cursor_get shows an unleased target.
+	if res, _ := tool.Execute(gctx, json.RawMessage(`{"op":"cursor_release","scope":"agent"}`)); res.IsError {
+		t.Fatalf("cursor_release: %s", res.Text)
+	}
+	res, _ = tool.Execute(gctx, json.RawMessage(`{"op":"cursor_get","scope":"agent"}`))
+	if !strings.Contains(res.Text, `"leased_by":""`) {
+		t.Errorf("cursor_get after release = %q, want leased_by empty", res.Text)
+	}
+}
+
+// TestMemory_PendingDrainAck seeds the queue via the store (the tool exposes no
+// enqueue op in PR1), then drains + acks through the tool: drain returns rows
+// oldest-first, and acked rows are excluded from the next drain.
+func TestMemory_PendingDrainAck(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t)
+	defer cleanup()
+	gctx := grantedConsolidationCtx(ctx)
+
+	// The tool's agent-scope target resolves to (tenant "", scope agent,
+	// scope_id "qa-agent") — seed the store there directly.
+	base := time.Now().UTC().Truncate(time.Second)
+	seed := func(id string, ageSecs int) {
+		if err := tool.Store.MemoryPendingEnqueue(context.Background(), store.MemoryPendingRow{
+			ID:        id,
+			Scope:     store.MemoryScopeAgent,
+			ScopeID:   "qa-agent",
+			Payload:   json.RawMessage(`{"turn":"` + id + `"}`),
+			CreatedAt: base.Add(time.Duration(ageSecs) * time.Second),
+		}); err != nil {
+			t.Fatalf("seed %s: %v", id, err)
+		}
+	}
+	seed("mp_older", 0)
+	seed("mp_newer", 5)
+
+	// Drain via the tool → both rows, oldest-first.
+	res, _ := tool.Execute(gctx, json.RawMessage(`{"op":"pending_drain","scope":"agent"}`))
+	if res.IsError {
+		t.Fatalf("pending_drain: %s", res.Text)
+	}
+	var drained struct {
+		Pending []struct {
+			ID string `json:"id"`
+		} `json:"pending"`
+	}
+	if err := json.Unmarshal([]byte(res.Text), &drained); err != nil {
+		t.Fatalf("decode drain result: %v (%s)", err, res.Text)
+	}
+	if len(drained.Pending) != 2 || drained.Pending[0].ID != "mp_older" || drained.Pending[1].ID != "mp_newer" {
+		t.Fatalf("drain order = %+v, want [mp_older, mp_newer]", drained.Pending)
+	}
+
+	// Ack the older row → the next drain returns only the newer.
+	if res, _ := tool.Execute(gctx, json.RawMessage(`{"op":"pending_ack","scope":"agent","ids":["mp_older"]}`)); res.IsError {
+		t.Fatalf("pending_ack: %s", res.Text)
+	}
+	res, _ = tool.Execute(gctx, json.RawMessage(`{"op":"pending_drain","scope":"agent"}`))
+	if strings.Contains(res.Text, "mp_older") || !strings.Contains(res.Text, "mp_newer") {
+		t.Errorf("drain after ack = %q, want only mp_newer", res.Text)
+	}
+}

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -568,6 +568,13 @@ type MemoryPolicyValue struct {
 	AllowedScopes []string
 	QuotaBytes    int
 	Backend       string
+	// Consolidation is the RFC BL P2 `memory_consolidation` grant — it gates the
+	// Memory tool's consolidation control ops (cursor lease/advance, pending
+	// drain/ack, supersede) SEPARATELY from AllowedScopes. Default-deny: false
+	// (the zero value) refuses those ops even when the scope is allowed. Sourced
+	// operator-side from the agent def — never model-supplied, same trust posture
+	// as AllowedScopes.
+	Consolidation bool
 }
 
 // WithMemoryPolicy attaches the agent's resolved Memory policy to ctx.


### PR DESCRIPTION
## Why

The agentic-memory work (P2) turns session transcripts into durable, deduplicated, provenance-tagged memory **in the background** — never in the hot tool-use loop. That needs a durable substrate first: a place to enqueue "note this" items, a per-target watermark + cross-replica lease so exactly one consolidator owns a target at a time, a soft-archive marker so a superseded fact disappears from recall without being destroyed, and a capability grant that keeps all of this default-deny. This PR is that substrate. Nothing consumes it yet — the native `MemoryLayer` (PR2) and the consolidator bundle (PR4) build on it.

## What

**Migration `0061`** (Postgres `.sql` up/down + the inline sqlite mirror; additive, safe on an existing DB):
- `memory.superseded_at TIMESTAMPTZ` (nullable) — a soft-archive marker. Every agent-facing read (`MemoryGet`/`MemoryList`/vector `MemoryEmbedSearch`/full-text `MemoryFullTextSearch`) filters `superseded_at IS NULL`, so a superseded row is invisible to the agent but **retained** for audit/erasure. NULL = live (every legacy row).
- `memory_pending` — the durable enqueue queue an `add` writes to (PR2) and the consolidator drains (PR4). `drained_at` gives idempotent at-least-once drain (drain reads un-acked oldest-first; a separate ack stamps `drained_at`).
- `memory_cursors` — the per-target consolidation watermark + lease, PK `(tenant_id, scope, scope_id)`. Composite watermark `(watermark_completed_at, watermark_session_id)`; the lease is `leased_by`/`lease_expires_at` columns + **compare-and-set** (there is no advisory-lock-with-TTL in `coord`, so the lease is a conditional upsert — cross-replica-safe, TTL-expiring).

**Store surface** (both backends + the shared `storetest/contract.go`): `MemorySupersede`; `MemoryPendingEnqueue`/`Drain`/`Ack`; `MemoryCursorGet` (get-or-default) / `Lease` (CAS) / `Advance` (owner-gated + monotonic) / `Release`.

**Memory tool** — 7 consolidation-control ops (`cursor_get`/`cursor_lease`/`cursor_advance`/`cursor_release`/`supersede`/`pending_drain`/`pending_ack`), each **default-deny** behind the net-new **`memory_consolidation`** per-agent grant, gated *before* any store call. Trust boundary: the target `(tenant, scope, scope_id)` is resolved server-side via the existing `resolveScope` + `RunIdentity` — the model supplies only the scope *selector*, never a `scope_id`/tenant; the lease owner is server-derived (run id, else agent name).

**`memory_consolidation` grant** — mirrors the `memory_protocol` bool across config / policy-ctx / all 8 `WithMemoryPolicy` sites (primary run, resume, sub-agent, gRPC, MCP, admin) / loader / `sign.go` (content-identifying, `omitempty` so existing agent rows stay byte-stable) / the AgentDef overlay (OR-in) / lookup. A validator advisory warns when it's set without the Memory tool.

Sub-agents read their own def's grant (a sub-agent doesn't inherit the parent's). The three operator-planes (gRPC/MCP/admin) grant it as they already grant open scopes — the ops are strictly weaker than the `delete`/`delete_scope` those planes already hold, and remain confined to the caller's own tenant/scope.

## Code review

An independent reviewer + a self-review pass. The high-risk items — the lease compare-and-set, the `superseded_at` read-filter completeness, and the grant/trust-boundary — all **passed**. Three fixes were found and committed (`b0ad4819`):

1. **Important — revive-on-write.** `supersede` stamps `superseded_at`, but `MemorySet`/`MemoryIncrement`/`MemoryAtomicUpdate` didn't clear it on `ON CONFLICT DO UPDATE` — so a later write to a superseded key landed the value yet stayed hidden from every read (a silent black-hole; incr/atomic-update even read the hidden value and wrote it back still-hidden). Fixed: the upserts reset `superseded_at = NULL` — a fresh explicit write is live data. Both backends.
2. **Low — `pending_ack` scope confinement.** The ack is now confined to `(tenant, scope, scope_id)`, symmetric with the scoped drain, so a leaked/guessed id from another tenant or scope is a no-op, never a cross-tenant ack.
3. **Low — `lease_ttl_ms` overflow.** Clamped in millisecond-space before the `*time.Millisecond` multiply (a huge value could overflow int64 and wrap negative, skipping the max check).

**Deferred (reviewer-agreed, non-blocking):** `MemoryDeleteScope` doesn't yet delete `memory_pending`/`memory_cursors` rows for a reclaimed scope (orphans + a stale watermark on recreate). Nothing writes those tables until PR2, so this lands with PR2 rather than expanding this PR into the RFC BM retention method.

## Tested

- `go test ./...` clean from the repo root.
- New store-contract tests (both backends): `MemorySupersedeHidesFromReads`, `MemorySupersedeIsIdempotent`, `MemorySupersedeRevivedByWrite`, `MemoryPendingEnqueueDrainAck` (incl. a wrong-scope-ack no-op assertion), `MemoryCursorGetDefault`, `MemoryCursorLeaseCAS`, `MemoryCursorAdvanceMonotonicAndOwner`.
- Grant round-trip: `TestSign_MemoryConsolidation_IsContentIdentifying` (def_id changes on toggle, byte-stable via `omitempty`), `TestMergeAgentDef_MemoryConsolidationOrsIn`, the yaml + `SubstrateAgentDef` drift + create→promote→resolve round-trip.
- Tool: `CursorOpsRequireConsolidationGrant` (default-deny), `SupersedeHidesFromReads`, `CursorLeaseAndAdvance`, `PendingDrainAck`, `SchemaIsValidJSON`.
- **Fail-before verified** on the key fix: reverting `superseded_at = NULL` makes `MemorySupersedeRevivedByWrite` fail with `memory not found` after the re-set; the fix makes it pass.
- Postgres path compiles + `go vet` clean; the shared contract runs on sqlite locally and on Postgres in CI (the Go-Postgres store-contract job). The migration is a plain nullable `ADD COLUMN` + two `CREATE TABLE` — no PK surgery, safe on existing DBs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
