### PR TITLE
fix(store): repair memory_embeddings when pgvector is installed late

### DIFF
--- a/docs/POSTGRES.md
+++ b/docs/POSTGRES.md
@@ -54,6 +54,32 @@ PostgreSQL 13–18, so install the extension package matching your server's majo
 (e.g. `postgresql-18-pgvector`, or a `pgvector/pgvector:pg18` image). Without
 pgvector, the embeddings table is skipped gracefully and everything else runs.
 
+### Adding pgvector to an existing database
+
+**Install pgvector before you upgrade.** Migration `0017` creates the
+`memory_embeddings` table only if `CREATE EXTENSION vector` succeeds, and
+golang-migrate tracks a single version pointer — it only applies migrations
+*above* it. So a database that already migrated past `0017` without pgvector
+will never re-run `0017`, however many times you run `loomcycle migrate up`.
+
+Migration `0062_memory_embeddings_repair` is the supported repair path: it
+creates the table (in its fully-migrated shape) when pgvector is present and
+the table is missing. Because it too runs only once, the ordering matters:
+
+| Order | Result |
+|---|---|
+| Install pgvector, **then** upgrade + `migrate up` | ✅ `0062` creates the table; Vector Memory works |
+| Upgrade past `0062` first, **then** install pgvector | ⚠️ table stays absent; Vector Memory stays disabled |
+
+In the second case nothing crashes — `Open()` probes for the table (not just
+the extension) and disables Vector Memory and hybrid (full-text) recall, so
+memory ops refuse with `vector_unsupported` and plain key/value memory is
+unaffected. loomcycle logs one warning at boot naming the fix. There is
+deliberately no boot-time self-healing DDL: loomcycle never issues schema
+changes outside the migration set. To recover, install pgvector and then
+either restore from a dump into a database migrated in the right order, or
+apply the `0062` DDL by hand (see the migration file for the exact statements).
+
 ## Schema migrations
 
 Migrations are embedded in the binary via `golang-migrate/migrate v4`. Two policies:

--- a/internal/store/postgres/memory_embeddings.go
+++ b/internal/store/postgres/memory_embeddings.go
@@ -31,17 +31,23 @@ import (
 // a typed ErrDimensionMismatch instead of pgvector's opaque
 // "different vector dimensions" runtime error.
 
-// SupportsVectors reports whether vector ops are available. True
-// only when both Config.PgvectorEnabled was set AND the post-
-// migration extension probe in Open() saw `vector` loaded.
+// SupportsVectors reports whether vector ops are available. True only when
+// Config.PgvectorEnabled was set AND Open()'s probes saw BOTH the `vector`
+// extension loaded AND the memory_embeddings table present. The table is a
+// distinct condition, not a redundant one: a deployment that installed
+// pgvector after already migrating past 0017 has the extension but no table
+// (0017 skipped it and golang-migrate never re-applies a migration — see
+// migration 0062), and reporting true there would send every query at a
+// relation that does not exist.
 func (s *Store) SupportsVectors() bool {
 	return s.pgvectorEnabled
 }
 
 // SupportsFullText reports whether the keyword (full-text) retrieval leg is
 // available (RFC BL). It tracks SupportsVectors exactly: migration 0060's
-// tsvector index lives on memory_embeddings, which exists only behind the
-// pgvector guard, so full-text is available precisely when pgvector is.
+// tsvector column and its GIN index live ON memory_embeddings, so full-text
+// is available precisely when that table is — including the extension-present-
+// but-table-missing case, where both correctly report false.
 func (s *Store) SupportsFullText() bool {
 	return s.pgvectorEnabled
 }

--- a/internal/store/postgres/memory_embeddings_repair_test.go
+++ b/internal/store/postgres/memory_embeddings_repair_test.go
@@ -1,0 +1,497 @@
+package postgres
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// Regression coverage for the pgvector-installed-late upgrade path.
+//
+// Migration 0017 creates memory_embeddings only when `CREATE EXTENSION
+// vector` succeeded. golang-migrate tracks ONE monotonic version pointer and
+// only applies migrations above it, so a database that migrated past 0017
+// without pgvector never re-runs 0017 — the table was unreachable forever.
+// Migration 0062 is the repair path, and Open() must probe the TABLE (not
+// just the extension) so the interim state degrades to the typed
+// store.ErrVectorUnsupported refusal instead of raw "relation does not
+// exist" errors (or, before the fix, a refusal to boot at all).
+
+// pgvectorInstallable reports whether the test Postgres can install pgvector.
+//
+// Auto-detected from pg_available_extensions rather than gated behind an
+// opt-in env var: these tests are the only coverage of the late-install
+// upgrade path, so they must run wherever the capability actually exists
+// (e.g. CI on a pgvector/pgvector image) without anyone remembering a flag.
+// On a plain postgres:16-alpine fixture they skip cleanly.
+func pgvectorInstallable(t *testing.T, dsn string) bool {
+	t.Helper()
+	pool := rawPool(t, dsn)
+	defer pool.Close()
+	var ok bool
+	if err := pool.QueryRow(context.Background(),
+		`SELECT EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'vector')`,
+	).Scan(&ok); err != nil {
+		t.Fatalf("probe pg_available_extensions: %v", err)
+	}
+	return ok
+}
+
+// rawPool opens a short-lived pool on dsn for the direct DDL/catalog work
+// these tests need (the store.Store interface deliberately exposes none of
+// it). Caller must Close.
+func rawPool(t *testing.T, dsn string) *pgxpool.Pool {
+	t.Helper()
+	cfg, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		t.Fatalf("parse DSN: %v", err)
+	}
+	cfg.MaxConns = 2
+	pool, err := pgxpool.NewWithConfig(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("dial postgres: %v", err)
+	}
+	return pool
+}
+
+// syncBuffer is a mutex-guarded log sink — Open() is not the only thing that
+// may write to the default logger while a test runs.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// assertVectorOpsRefuse asserts every vector op returns the TYPED
+// store.ErrVectorUnsupported. Pointer identity (errors.Is against the
+// sentinel) is the point: a raw pgx "relation memory_embeddings does not
+// exist" would satisfy "returns an error" but fail this.
+func assertVectorOpsRefuse(t *testing.T, s store.Store) {
+	t.Helper()
+	ctx := context.Background()
+	const (
+		tenant  = ""
+		scopeID = "agent-x"
+		key     = "k1"
+	)
+	scope := store.MemoryScopeAgent
+
+	if err := s.MemoryEmbedSet(ctx, tenant, scope, scopeID, key, store.MemoryEmbedding{
+		Provider: "p", Model: "m", Dimension: 3, Vector: []float32{1, 2, 3}, EmbedText: "hello",
+	}); !errors.Is(err, store.ErrVectorUnsupported) {
+		t.Errorf("MemoryEmbedSet: want ErrVectorUnsupported, got %v", err)
+	}
+	if _, err := s.MemoryEmbedGet(ctx, tenant, scope, scopeID, key); !errors.Is(err, store.ErrVectorUnsupported) {
+		t.Errorf("MemoryEmbedGet: want ErrVectorUnsupported, got %v", err)
+	}
+	if _, err := s.MemoryEmbedSearch(ctx, tenant, scope, scopeID, "", []float32{1, 2, 3}, 5); !errors.Is(err, store.ErrVectorUnsupported) {
+		t.Errorf("MemoryEmbedSearch: want ErrVectorUnsupported, got %v", err)
+	}
+	if _, err := s.MemoryEmbedListByModel(ctx, tenant, scope, scopeID, "p", "m", 10); !errors.Is(err, store.ErrVectorUnsupported) {
+		t.Errorf("MemoryEmbedListByModel: want ErrVectorUnsupported, got %v", err)
+	}
+	if _, err := s.MemoryEmbedStats(ctx, tenant, scope); !errors.Is(err, store.ErrVectorUnsupported) {
+		t.Errorf("MemoryEmbedStats: want ErrVectorUnsupported, got %v", err)
+	}
+	// The full-text leg degrades to (nil, nil) by contract — the hybrid
+	// ranker treats "no full-text rows" as a missing leg, not a failure.
+	rows, err := s.MemoryFullTextSearch(ctx, tenant, scope, scopeID, "", "hello", 5)
+	if err != nil {
+		t.Errorf("MemoryFullTextSearch: want nil error, got %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("MemoryFullTextSearch: want no rows, got %d", len(rows))
+	}
+}
+
+// TestOpen_ExtensionPresentButTableMissingDisablesVectorSupport is the core
+// regression: with the `vector` extension loaded but memory_embeddings
+// absent, Open() must SUCCEED and report both capabilities as false so every
+// memory op takes the typed-refusal path.
+//
+// Fail-before: prior to the fix Open() hard-failed in this exact state
+// ("pgvector is installed but the `memory_embeddings` table is missing"),
+// blocking boot entirely and telling the operator to re-run `migrate up` —
+// which can never re-apply 0017.
+func TestOpen_ExtensionPresentButTableMissingDisablesVectorSupport(t *testing.T) {
+	dsn := pgDSNFromEnv(t)
+	if !pgvectorInstallable(t, dsn) {
+		t.Skip("test Postgres cannot install pgvector; cannot stage extension-present + table-missing")
+	}
+
+	fix := freshSchemaWithVectors(t, dsn, true)
+	defer fix.cleanup()
+
+	// Guard: the reference state must really have the table, otherwise the
+	// staging below is vacuous and this test would pass on nothing.
+	if !fix.store.SupportsVectors() {
+		t.Fatalf("fixture did not come up with vector support; cannot stage the missing-table case")
+	}
+	if err := fix.store.Close(); err != nil {
+		t.Fatalf("close fixture store: %v", err)
+	}
+
+	// Stage the broken deployment: extension stays loaded, table goes away.
+	pool := rawPool(t, fix.storeDSN)
+	if _, err := pool.Exec(context.Background(), `DROP TABLE memory_embeddings CASCADE`); err != nil {
+		pool.Close()
+		t.Fatalf("drop memory_embeddings: %v", err)
+	}
+	var extLoaded bool
+	if err := pool.QueryRow(context.Background(),
+		`SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'vector')`).Scan(&extLoaded); err != nil {
+		pool.Close()
+		t.Fatalf("probe pg_extension: %v", err)
+	}
+	pool.Close()
+	if !extLoaded {
+		t.Fatalf("staging invalid: `vector` extension is not loaded")
+	}
+
+	var logs syncBuffer
+	prev := log.Writer()
+	log.SetOutput(&logs)
+	defer log.SetOutput(prev)
+
+	s, err := Open(context.Background(), Config{
+		DSN:             fix.storeDSN,
+		MaxOpenConns:    4,
+		AutoMigrate:     false,
+		PgvectorEnabled: true,
+	})
+	if err != nil {
+		t.Fatalf("Open with extension present but table missing: want success (degrade), got error: %v", err)
+	}
+	defer func() {
+		if cerr := s.Close(); cerr != nil {
+			t.Errorf("close store: %v", cerr)
+		}
+	}()
+
+	if s.SupportsVectors() {
+		t.Error("SupportsVectors() = true; want false when memory_embeddings is missing")
+	}
+	if s.SupportsFullText() {
+		t.Error("SupportsFullText() = true; want false when memory_embeddings is missing")
+	}
+	assertVectorOpsRefuse(t, s)
+
+	// The one silent-but-degraded state must be loudly actionable.
+	got := logs.String()
+	for _, want := range []string{"memory_embeddings", "0062", "migrate up"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("Open() log does not mention %q; operator has no guidance. Got: %s", want, got)
+		}
+	}
+}
+
+// TestMigrate0062_RepairedTableMatchesFromScratchShape is the real
+// correctness property: a database that reaches memory_embeddings via the
+// 0062 repair must end up with a table indistinguishable from one built by
+// the 0017 → 0059 → 0060 path — same columns in the same ordinal positions,
+// same PK/FK, same indexes.
+//
+// Both shapes are taken in ONE schema, before and after replacing the table
+// via the repair path. That is deliberate: it controls for schema name,
+// collation and catalog defaults so the only variable is which migration
+// created the table. (It also sidesteps a fixture hazard — `CREATE EXTENSION
+// IF NOT EXISTS vector` is database-wide, so a second per-test schema no-ops
+// on it and then cannot resolve the `vector` type from its own search_path.)
+func TestMigrate0062_RepairedTableMatchesFromScratchShape(t *testing.T) {
+	dsn := pgDSNFromEnv(t)
+	if !pgvectorInstallable(t, dsn) {
+		t.Skip("test Postgres cannot install pgvector; cannot compare repaired vs from-scratch shape")
+	}
+
+	// Reference: built by the 0017 → 0059 → 0060 path (0062 no-opped because
+	// the table already existed).
+	fix := freshSchemaWithVectors(t, dsn, true)
+	defer fix.cleanup()
+	fromScratch := snapshotMemoryEmbeddings(t, fix.storeDSN)
+	if len(fromScratch.columns) == 0 {
+		t.Fatalf("fixture has no memory_embeddings table; the comparison would be vacuous")
+	}
+
+	// Now reproduce a deployment that installed pgvector after migrating past
+	// 0017: drop the table and rewind the version pointer to 61, so the next
+	// MigrateUp applies ONLY the 0062 repair.
+	rewindToBeforeRepair(t, fix.storeDSN)
+	if got := snapshotMemoryEmbeddings(t, fix.storeDSN); len(got.columns) != 0 {
+		t.Fatalf("staging invalid: memory_embeddings still present before repair")
+	}
+	if err := MigrateUp(fix.storeDSN); err != nil {
+		t.Fatalf("MigrateUp (repair): %v", err)
+	}
+	repaired := snapshotMemoryEmbeddings(t, fix.storeDSN)
+	if len(repaired.columns) == 0 {
+		t.Fatalf("0062 did not create memory_embeddings")
+	}
+
+	assertShapesEqual(t, fromScratch, repaired)
+}
+
+// TestMigrate0062_IsNoOpWhenTableAlreadyExists pins the idempotency arm: on
+// the overwhelmingly common deployment (0017 created the table), 0062 must
+// touch nothing — same shape AND existing rows intact.
+func TestMigrate0062_IsNoOpWhenTableAlreadyExists(t *testing.T) {
+	dsn := pgDSNFromEnv(t)
+	if !pgvectorInstallable(t, dsn) {
+		t.Skip("test Postgres cannot install pgvector; memory_embeddings never exists to no-op over")
+	}
+
+	fix := freshSchemaWithVectors(t, dsn, true)
+	defer fix.cleanup()
+	if !fix.store.SupportsVectors() {
+		t.Fatalf("fixture did not come up with vector support")
+	}
+
+	// A real row, so a drop-and-recreate would be visible as data loss
+	// rather than only as a shape difference.
+	ctx := context.Background()
+	scope, scopeID, key := store.MemoryScopeAgent, "agent-noop", "k1"
+	if err := fix.store.MemorySet(ctx, "", scope, scopeID, key, []byte(`"v"`), 0); err != nil {
+		t.Fatalf("MemorySet: %v", err)
+	}
+	if err := fix.store.MemoryEmbedSet(ctx, "", scope, scopeID, key, store.MemoryEmbedding{
+		Provider: "p", Model: "m", Dimension: 3, Vector: []float32{1, 2, 3}, EmbedText: "hello world",
+	}); err != nil {
+		t.Fatalf("MemoryEmbedSet: %v", err)
+	}
+
+	before := snapshotMemoryEmbeddings(t, fix.storeDSN)
+	if len(before.columns) == 0 {
+		t.Fatalf("memory_embeddings missing; nothing to no-op over")
+	}
+
+	// Rewind the pointer only — leave the table in place — so 0062 re-runs
+	// against an existing table.
+	forceMigrationVersion(t, fix.storeDSN, 61)
+	if err := MigrateUp(fix.storeDSN); err != nil {
+		t.Fatalf("MigrateUp (re-run 0062 over existing table): %v", err)
+	}
+
+	assertShapesEqual(t, before, snapshotMemoryEmbeddings(t, fix.storeDSN))
+
+	got, err := fix.store.MemoryEmbedGet(ctx, "", scope, scopeID, key)
+	if err != nil {
+		t.Fatalf("MemoryEmbedGet after re-running 0062: %v (0062 must not recreate the table)", err)
+	}
+	if got.EmbedText != "hello world" {
+		t.Errorf("EmbedText = %q, want %q", got.EmbedText, "hello world")
+	}
+}
+
+// TestMigrate_WithoutPgvectorAppliesFullSetAndRefusesVectorOps covers the
+// tolerance arm that must stay a clean no-op: on a Postgres without pgvector
+// the whole set (0017 and 0062 included) applies to the newest version, the
+// table is absent, and vector ops refuse with the typed error.
+func TestMigrate_WithoutPgvectorAppliesFullSetAndRefusesVectorOps(t *testing.T) {
+	dsn := pgDSNFromEnv(t)
+
+	fix := freshSchema(t, dsn) // PgvectorEnabled=false
+	defer fix.cleanup()
+
+	version, dirty, err := MigrateStatus(fix.storeDSN)
+	if err != nil {
+		t.Fatalf("MigrateStatus: %v", err)
+	}
+	if dirty {
+		t.Fatalf("schema is dirty at version %d", version)
+	}
+	want, err := highestEmbeddedVersion()
+	if err != nil {
+		t.Fatalf("highestEmbeddedVersion: %v", err)
+	}
+	if version != want {
+		t.Errorf("migrated to version %d, want %d", version, want)
+	}
+
+	if fix.store.SupportsVectors() {
+		t.Error("SupportsVectors() = true with PgvectorEnabled=false")
+	}
+	if fix.store.SupportsFullText() {
+		t.Error("SupportsFullText() = true with PgvectorEnabled=false")
+	}
+	assertVectorOpsRefuse(t, fix.store)
+
+	// Only meaningful where pgvector genuinely cannot load: there, 0017 and
+	// 0062 must both have skipped the table without failing the migration.
+	if !pgvectorInstallable(t, dsn) {
+		if shape := snapshotMemoryEmbeddings(t, fix.storeDSN); len(shape.columns) != 0 {
+			t.Errorf("memory_embeddings exists on a Postgres without pgvector")
+		}
+	}
+}
+
+// ---- shape snapshot helpers ----
+
+// tableShape is a normalised, comparable description of memory_embeddings.
+// Every entry is schema-name-stripped so two per-test schemas compare equal.
+type tableShape struct {
+	columns     []string
+	constraints []string
+	indexes     []string
+}
+
+// snapshotMemoryEmbeddings reads the table's columns, constraints and indexes
+// out of the catalog. Returns a zero tableShape when the table is absent.
+func snapshotMemoryEmbeddings(t *testing.T, storeDSN string) tableShape {
+	t.Helper()
+	pool := rawPool(t, storeDSN)
+	defer pool.Close()
+	ctx := context.Background()
+
+	// current_schema() is the per-test schema (search_path is set on the
+	// DSN), so every query below is scoped to this fixture alone.
+	var schema string
+	if err := pool.QueryRow(ctx, `SELECT current_schema()`).Scan(&schema); err != nil {
+		t.Fatalf("current_schema: %v", err)
+	}
+	norm := func(s string) string { return strings.ReplaceAll(s, schema, "<schema>") }
+
+	var out tableShape
+
+	// Columns, including ordinal_position — the 0017/0059/0060 append order
+	// is part of the contract, so a reordered-but-equivalent table must fail.
+	rows, err := pool.Query(ctx,
+		`SELECT ordinal_position, column_name, data_type, udt_name, is_nullable,
+		        coalesce(column_default, ''), is_generated, coalesce(generation_expression, '')
+		   FROM information_schema.columns
+		  WHERE table_schema = $1 AND table_name = 'memory_embeddings'
+		  ORDER BY ordinal_position`, schema)
+	if err != nil {
+		t.Fatalf("query columns: %v", err)
+	}
+	for rows.Next() {
+		var (
+			pos                                                    int
+			name, dataType, udt, nullable, def, generated, genExpr string
+		)
+		if err := rows.Scan(&pos, &name, &dataType, &udt, &nullable, &def, &generated, &genExpr); err != nil {
+			rows.Close()
+			t.Fatalf("scan column: %v", err)
+		}
+		out.columns = append(out.columns, norm(strings.Join([]string{
+			strconv.Itoa(pos), name, dataType, udt, nullable, def, generated, genExpr,
+		}, "|")))
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate columns: %v", err)
+	}
+
+	// Constraints: PK + FK, by name and by definition.
+	rows, err = pool.Query(ctx,
+		`SELECT c.conname, c.contype::text, pg_get_constraintdef(c.oid)
+		   FROM pg_constraint c
+		   JOIN pg_class cl ON cl.oid = c.conrelid
+		   JOIN pg_namespace n ON n.oid = cl.relnamespace
+		  WHERE n.nspname = $1 AND cl.relname = 'memory_embeddings'
+		  ORDER BY c.conname`, schema)
+	if err != nil {
+		t.Fatalf("query constraints: %v", err)
+	}
+	for rows.Next() {
+		var name, ctype, def string
+		if err := rows.Scan(&name, &ctype, &def); err != nil {
+			rows.Close()
+			t.Fatalf("scan constraint: %v", err)
+		}
+		out.constraints = append(out.constraints, norm(name+"|"+ctype+"|"+def))
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate constraints: %v", err)
+	}
+
+	rows, err = pool.Query(ctx,
+		`SELECT indexname, indexdef FROM pg_indexes
+		  WHERE schemaname = $1 AND tablename = 'memory_embeddings'
+		  ORDER BY indexname`, schema)
+	if err != nil {
+		t.Fatalf("query indexes: %v", err)
+	}
+	for rows.Next() {
+		var name, def string
+		if err := rows.Scan(&name, &def); err != nil {
+			rows.Close()
+			t.Fatalf("scan index: %v", err)
+		}
+		out.indexes = append(out.indexes, norm(name+"|"+def))
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate indexes: %v", err)
+	}
+
+	return out
+}
+
+func assertShapesEqual(t *testing.T, want, got tableShape) {
+	t.Helper()
+	cmp := func(label string, a, b []string) {
+		if len(a) != len(b) {
+			t.Errorf("%s: count %d != %d\n want: %v\n  got: %v", label, len(a), len(b), a, b)
+			return
+		}
+		for i := range a {
+			if a[i] != b[i] {
+				t.Errorf("%s[%d] mismatch:\n want: %s\n  got: %s", label, i, a[i], b[i])
+			}
+		}
+	}
+	cmp("columns", want.columns, got.columns)
+	cmp("constraints", want.constraints, got.constraints)
+	cmp("indexes", want.indexes, got.indexes)
+}
+
+// forceMigrationVersion rewrites golang-migrate's version pointer so a
+// subsequent MigrateUp re-applies everything above `version`. This is how we
+// replay a single migration against a chosen starting state.
+func forceMigrationVersion(t *testing.T, storeDSN string, version int) {
+	t.Helper()
+	pool := rawPool(t, storeDSN)
+	defer pool.Close()
+	tag, err := pool.Exec(context.Background(),
+		`UPDATE schema_migrations SET version = $1, dirty = false`, version)
+	if err != nil {
+		t.Fatalf("rewind schema_migrations to %d: %v", version, err)
+	}
+	if tag.RowsAffected() != 1 {
+		t.Fatalf("rewind schema_migrations: updated %d rows, want 1", tag.RowsAffected())
+	}
+}
+
+// rewindToBeforeRepair reproduces "installed pgvector after migrating past
+// 0017": the table is gone and the version pointer sits at 61, so the next
+// MigrateUp applies only the 0062 repair.
+func rewindToBeforeRepair(t *testing.T, storeDSN string) {
+	t.Helper()
+	pool := rawPool(t, storeDSN)
+	if _, err := pool.Exec(context.Background(), `DROP TABLE memory_embeddings CASCADE`); err != nil {
+		pool.Close()
+		t.Fatalf("drop memory_embeddings: %v", err)
+	}
+	pool.Close()
+	forceMigrationVersion(t, storeDSN, 61)
+}

--- a/internal/store/postgres/migrations/0017_memory_embeddings.up.sql
+++ b/internal/store/postgres/migrations/0017_memory_embeddings.up.sql
@@ -29,10 +29,22 @@
 -- The CREATE TABLE uses EXECUTE so the planner doesn't resolve the
 -- `vector` type at parse time (which would fail before the EXCEPTION
 -- branch could run). Operators upgrading from v0.8.x without
--- pgvector get a clean migration; they can install pgvector and
--- re-run `migrate up` later to bring the table into existence. The
--- runtime SupportsVectors() check refuses vector ops when the table
--- is missing, so this is safe.
+-- pgvector get a clean migration.
+--
+-- Installing pgvector LATER does NOT re-run this migration —
+-- golang-migrate tracks one monotonic version pointer and only
+-- applies migrations above it, so a database already past 0017 will
+-- never come back here however many times `loomcycle migrate up`
+-- runs. Migration 0062_memory_embeddings_repair is the supported
+-- repair path: it creates the table (in its post-0060 shape) when
+-- pgvector is present and the table is missing.
+--
+-- Until that repair migration applies, the extension can be loaded
+-- while this table is absent. Open() probes for the TABLE — not just
+-- the extension — and degrades SupportsVectors()/SupportsFullText()
+-- to false in that state, so memory ops refuse with the typed
+-- store.ErrVectorUnsupported rather than hitting a nonexistent
+-- relation. That probe is what makes skipping the table here safe.
 
 DO $migration$
 DECLARE

--- a/internal/store/postgres/migrations/0062_memory_embeddings_repair.down.sql
+++ b/internal/store/postgres/migrations/0062_memory_embeddings_repair.down.sql
@@ -1,0 +1,20 @@
+-- 0062_memory_embeddings_repair.down.sql — DELIBERATE NO-OP.
+--
+-- The up migration creates `memory_embeddings` only when the table was
+-- missing, so the honest inverse would be "drop it only if WE created it".
+-- Nothing in the schema records that: after the fact, a table created by
+-- 0062 is indistinguishable from one created by 0017 on a deployment that
+-- had pgvector from the start. A `DROP TABLE memory_embeddings` here would
+-- therefore destroy every embedding on the majority of deployments (the ones
+-- where 0017 created it) to unwind a migration that did nothing on them.
+--
+-- Down-migrating past 62 is consequently a no-op, and that is safe: 0062 adds
+-- no column, index, or constraint that 0017/0059/0060 don't already own, so
+-- continuing down through 0060 → 0059 → 0017 unwinds the table exactly as it
+-- would on a from-scratch-with-pgvector database. The only visible residue of
+-- a `down 1` from 62 is that Vector Memory keeps working — which is what an
+-- operator rolling back one version wants anyway.
+--
+-- golang-migrate requires the file to exist; an empty statement body is a
+-- valid, successful migration.
+SELECT 1;

--- a/internal/store/postgres/migrations/0062_memory_embeddings_repair.up.sql
+++ b/internal/store/postgres/migrations/0062_memory_embeddings_repair.up.sql
@@ -1,0 +1,90 @@
+-- 0062_memory_embeddings_repair.up.sql — create `memory_embeddings` on a
+-- deployment that installed pgvector AFTER it had already migrated past 0017.
+--
+-- WHY THIS EXISTS (it looks redundant next to 0017 — it is not):
+--
+-- 0017 creates memory_embeddings only when `CREATE EXTENSION vector`
+-- succeeded, and skips it with a RAISE NOTICE otherwise. That tolerance is
+-- correct — a Postgres without pgvector must still migrate. But 0017's
+-- comment used to tell operators they could "install pgvector and re-run
+-- `loomcycle migrate up` later to bring the table into existence", and that
+-- is FALSE: golang-migrate tracks a single monotonic version pointer and
+-- only applies migrations strictly ABOVE it. A database sitting at version
+-- 58 will never re-run 0017, so the table was unreachable FOREVER — the
+-- operator had no supported path to enable Vector Memory short of hand-
+-- writing the DDL. This migration is that path: a version ABOVE any shipped
+-- pointer, so `migrate up` actually runs it.
+--
+-- It creates the table in its FULLY-MIGRATED post-0060 shape, because the
+-- 0059 (tenant_id) and 0060 (embed_text_tsv) migrations are themselves
+-- guarded on `to_regclass('memory_embeddings') IS NOT NULL` and were clean
+-- no-ops on this deployment. Column order matters: 0017 creates the nine
+-- base columns, 0059 APPENDS tenant_id, 0060 APPENDS embed_text_tsv, so a
+-- from-scratch-with-pgvector database has ordinal_position 1..11 in exactly
+-- the order below. Listing them in that order makes both paths converge on a
+-- byte-identical table (asserted by
+-- TestMigrate0062_RepairedTableMatchesFromScratchShape).
+--
+-- There is no partial-state case to handle: 0059/0060 either both ran (table
+-- present, already complete → this migration no-ops) or both no-opped (table
+-- absent → this migration creates it complete). The table can never exist in
+-- a half-migrated shape.
+--
+-- Tolerance, mirroring 0017 exactly: the CREATE EXTENSION lives in a
+-- sub-block whose EXCEPTION clause swallows the failure, and the DDL runs
+-- via EXECUTE so the planner never resolves the `vector` type at parse time
+-- (which would fail before the EXCEPTION branch could run). On a Postgres
+-- without pgvector this migration applies successfully and does nothing.
+--
+-- ORDERING CAVEAT (be honest with operators): this migration runs ONCE, when
+-- the version pointer crosses 62. Installing pgvector BEFORE upgrading to a
+-- build carrying it is the clean path. An operator who installs pgvector
+-- AFTER already being at version >= 62 is back in the same hole — the table
+-- stays absent. That state is no longer a crash: Open() probes for the table
+-- and degrades SupportsVectors()/SupportsFullText() to false (so memory ops
+-- return the typed store.ErrVectorUnsupported), and logs one loud line
+-- telling the operator what to do. There is deliberately NO boot-time
+-- self-healing DDL path — loomcycle does not issue schema changes outside
+-- the migration set.
+
+DO $migration$
+DECLARE
+    has_vector boolean := false;
+BEGIN
+    BEGIN
+        CREATE EXTENSION IF NOT EXISTS vector;
+        has_vector := true;
+    EXCEPTION WHEN OTHERS THEN
+        RAISE NOTICE 'pgvector extension not available; memory_embeddings remains absent and Vector Memory stays disabled. Install pgvector (apt install postgresql-<ver>-pgvector or use the pgvector/pgvector docker image) BEFORE upgrading to this build so this migration can create the table.';
+    END;
+
+    -- to_regclass (not information_schema) so the check honours search_path:
+    -- deployments and the test fixture both run under a non-default schema.
+    IF has_vector AND to_regclass('memory_embeddings') IS NULL THEN
+        RAISE NOTICE 'pgvector is present but memory_embeddings is missing (0017 ran in tolerant-skip mode before pgvector was installed); creating it now in its post-0060 shape.';
+        EXECUTE $sql$
+            CREATE TABLE memory_embeddings (
+                scope          TEXT        NOT NULL,
+                scope_id       TEXT        NOT NULL,
+                key            TEXT        NOT NULL,
+                provider       TEXT        NOT NULL,
+                model          TEXT        NOT NULL,
+                dimension      INTEGER     NOT NULL,
+                embedding      vector      NOT NULL,
+                embed_text     TEXT        NOT NULL,
+                created_at     TIMESTAMPTZ NOT NULL,
+                tenant_id      TEXT        NOT NULL DEFAULT '',
+                embed_text_tsv tsvector GENERATED ALWAYS AS (to_tsvector('english', embed_text)) STORED,
+                PRIMARY KEY (tenant_id, scope, scope_id, key),
+                FOREIGN KEY (tenant_id, scope, scope_id, key)
+                    REFERENCES memory(tenant_id, scope, scope_id, key) ON DELETE CASCADE
+            )
+        $sql$;
+        -- Same three indexes the 0017 → 0059 → 0060 path ends up with, same
+        -- names and same leading-tenant_id column order.
+        EXECUTE 'CREATE INDEX memory_embeddings_by_scope ON memory_embeddings(tenant_id, scope, scope_id)';
+        EXECUTE 'CREATE INDEX memory_embeddings_by_model ON memory_embeddings(tenant_id, scope, scope_id, provider, model)';
+        EXECUTE 'CREATE INDEX memory_embeddings_fts ON memory_embeddings USING GIN (embed_text_tsv)';
+    END IF;
+END
+$migration$;

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -83,9 +83,14 @@ type Config struct {
 type Store struct {
 	pool *pgxpool.Pool
 
-	// pgvectorEnabled is set in Open() from Config.PgvectorEnabled
-	// AND the post-migration `SELECT FROM pg_extension WHERE
-	// extname='vector'` probe. SupportsVectors() returns this.
+	// pgvectorEnabled means "vector ops are actually serviceable on this
+	// database". Open() sets it only when ALL THREE hold:
+	// Config.PgvectorEnabled, the `vector` extension is loaded, and the
+	// `memory_embeddings` table exists. The table is a separate condition
+	// because migration 0017 skips it when pgvector was absent at migrate
+	// time and golang-migrate never re-applies it (see Open() and migration
+	// 0062). SupportsVectors()/SupportsFullText() return this, and every
+	// MemoryEmbed* op refuses with store.ErrVectorUnsupported when false.
 	pgvectorEnabled bool
 
 	// channelDebug is captured from Config.ChannelDebug at Open()
@@ -184,26 +189,40 @@ func Open(ctx context.Context, cfg Config) (*Store, error) {
 			pool.Close()
 			return nil, errors.New("postgres: LOOMCYCLE_PGVECTOR_ENABLED=1 but the `vector` extension is not loaded. Install pgvector on your Postgres (`apt install postgresql-<ver>-pgvector` or use the pgvector/pgvector docker image), then restart loomcycle")
 		}
-		// The migration 0017 wraps CREATE TABLE inside a conditional
-		// IF has_vector block. Operators who installed pgvector AFTER
-		// first running migrations would pass the extension probe
-		// above (extension present) but lack the table itself
-		// (migration ran in tolerant-skip mode). Detect that here so
-		// the first vector op doesn't crash with a raw pgx
-		// "relation does not exist" error.
+		// Extension loaded is NOT sufficient: migration 0017 wraps its
+		// CREATE TABLE in an `IF has_vector` block, so a deployment that
+		// installed pgvector AFTER it had already migrated past 0017 passes
+		// the probe above (extension present) while lacking the table
+		// itself. golang-migrate only applies migrations above its single
+		// version pointer, so 0017 never re-runs — migration 0062 is the
+		// repair path that creates the table on such a deployment.
+		//
+		// We must therefore gate on the TABLE, not the extension: with the
+		// table missing, every vector op and the hybrid full-text leg would
+		// otherwise hit a raw pgx "relation does not exist". Degrading
+		// pgvectorEnabled to false routes them all through the typed
+		// store.ErrVectorUnsupported refusal the design already handles
+		// gracefully — this is what makes 0017's safety claim true.
+		//
+		// to_regclass (not information_schema.tables) so the probe honours
+		// search_path: an unqualified information_schema scan matches the
+		// table in ANY schema, which would report a false positive for a
+		// deployment — or a test — running under its own search_path.
 		var tableExists bool
 		err = pool.QueryRow(probeCtx,
-			`SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'memory_embeddings')`,
+			`SELECT to_regclass('memory_embeddings') IS NOT NULL`,
 		).Scan(&tableExists)
 		if err != nil {
 			pool.Close()
 			return nil, fmt.Errorf("postgres: probe memory_embeddings table: %w", err)
 		}
-		if !tableExists {
-			pool.Close()
-			return nil, errors.New("postgres: pgvector is installed but the `memory_embeddings` table is missing. This means the 0017 migration ran in tolerant-skip mode before pgvector was available. Re-run `loomcycle migrate up` (or restart with LOOMCYCLE_PG_AUTOMIGRATE=1) to create the table")
+		if tableExists {
+			s.pgvectorEnabled = true
+		} else {
+			// The one state that would otherwise be silent-but-degraded, so
+			// say it loudly and actionably exactly once, at boot.
+			log.Printf("postgres: WARNING — pgvector is installed but the `memory_embeddings` table is missing, so Vector Memory and hybrid (full-text) memory recall are DISABLED (memory ops refuse with ErrVectorUnsupported; plain key/value memory is unaffected). Migration 0017 skipped the table because pgvector was not yet installed when it ran, and golang-migrate never re-applies an already-applied migration. Fix: upgrade to a loomcycle build whose migration set includes 0062_memory_embeddings_repair and run `loomcycle migrate up` (or restart with LOOMCYCLE_PG_AUTOMIGRATE=1).")
 		}
-		s.pgvectorEnabled = true
 	}
 
 	return s, nil

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -56,9 +56,16 @@ type Config struct {
 	// When true, Open() verifies pgvector is installed (the migration
 	// set's 0017_memory_embeddings.up.sql does the CREATE EXTENSION;
 	// Open() re-checks pg_extension after migrations run and refuses
-	// to start if the extension is missing) and SupportsVectors()
-	// returns true. When false, vector ops refuse with
-	// ErrVectorUnsupported regardless of whether the migration ran.
+	// to start if the extension is missing). When false, vector ops
+	// refuse with ErrVectorUnsupported regardless of whether the
+	// migration ran.
+	//
+	// Opting in is necessary but not sufficient: Open() also requires
+	// the `memory_embeddings` table to exist before SupportsVectors()
+	// reports true. See Open() and migration 0062 — a database that
+	// installed pgvector after migrating past 0017 has the extension
+	// but no table, and degrades to the refusal path rather than
+	// failing to boot.
 	//
 	// The pgvector extension itself must be installable on the host
 	// Postgres (`apt install postgresql-16-pgvector` or the


### PR DESCRIPTION
## Why

A Postgres deployment that installs pgvector **after** loomcycle has already migrated past `0017` can never obtain the `memory_embeddings` table — and the runtime then **refuses to boot**.

Found while preparing a real upgrade: a live deployment at schema version 58, 2,954 memory rows, Postgres 18.4, no pgvector. The intended remedy ("swap in a pgvector image, `CREATE EXTENSION vector`") would have taken that server down.

Three things compound:

1. **`0017` skips the table when pgvector is absent** — deliberate and correct, so a no-pgvector operator gets a clean migration.
2. **Its comment then claims** the operator can *"install pgvector and re-run `loomcycle migrate up` later to bring the table into existence."* **False.** golang-migrate tracks a single version pointer and only applies migrations *above* it. At version 58, `migrate up` will never re-run `0017`. The table is unreachable forever.
3. **`Open()` hard-fails in that state.** It probes for the table and, when pgvector is loaded but the table is missing, does `pool.Close()` and returns an error — *instructing the operator to run the very migration that cannot help*:

```
postgres: pgvector is installed but the `memory_embeddings` table is missing …
Re-run `loomcycle migrate up` … to create the table
```

So the failure mode is not degraded search. It is **the process not starting**, with unactionable advice. `CREATE EXTENSION vector` on any already-migrated deployment is a hard outage trigger.

## What

**`0062_memory_embeddings_repair`** — creates `memory_embeddings` when pgvector is loaded *and* the table is missing. A clean no-op when the table already exists, and (like `0017`) it still migrates successfully on a Postgres without pgvector: `CREATE EXTENSION` sits in an `EXCEPTION`-swallowing sub-block and the DDL runs via `EXECUTE` so the planner never resolves the `vector` type at parse time.

The table is built to the **exact shape** the `0017 → 0059 → 0060` path produces, including logical column order (`0059` appends `tenant_id`, `0060` appends `embed_text_tsv`), the `(tenant_id, scope, scope_id, key)` PK, the 4-tuple FK with `ON DELETE CASCADE`, and all three indexes. `down` is a documented **no-op**: a table created by `0062` is indistinguishable afterwards from one created by `0017`, so dropping it would destroy embeddings on every deployment that had pgvector from the start.

**`SupportsVectors()` / `SupportsFullText()` now degrade instead of aborting.** `Open()` keeps the table probe but, on extension-present-table-missing, logs one loud actionable warning and continues with vector support off. Callers get the typed `store.ErrVectorUnsupported` the design already handles gracefully — a clean `503 vector_unsupported` rather than a boot failure or a raw `relation does not exist`.

**`0017`'s two false comments corrected** (comment text only — its DDL is immutable), pointing at `0062`.

## The ordering caveat, stated honestly

`0062` runs once. **Install pgvector *before* upgrading** and it creates the extension and the table in one pass — no manual `CREATE EXTENSION` needed at all. Install it *after*, and `0062` has already no-op'd: the table stays absent, which is now a clean refusal rather than an outage, and the startup warning tells the operator what to do. Documented at the migration and in `docs/POSTGRES.md`.

## Verified against real production data

Rehearsed on a `pg_dump` restore of the affected deployment (Postgres 18.4 + pgvector image, version 58, extension available but not installed, table absent — production's exact state):

- `migrate up` → **version 62, `dirty=false`, in 1.24 s** including process start.
- pgvector extension **auto-installed (0.8.5)**; `memory_embeddings` **created**.
- **2,954 memory rows intact**, all backfilled to `tenant_id = ''`; `memory` PK correctly swapped; `superseded_at` present.
- Column ordinals, PK, FK (`memory_embeddings_tenant_id_scope_scope_id_key_fkey`, same auto-generated name and `pg_get_constraintdef`) and all three `indexdef`s **identical** to the with-pgvector-from-scratch path.

## Fail-before evidence (production code broken, not assertions)

1. Restored the pre-fix hard failure → `Open` returns `pgvector is installed but the memory_embeddings table is missing` where the test wants a successful degrade.
2. Made `Open()` ignore the table probe → reproduced `relation "memory_embeddings" does not exist (SQLSTATE 42P01)` across all six vector/full-text ops, with both `Supports*` reading `true`. Pointer-identity assertions against `store.ErrVectorUnsupported` are what catch this; "returns an error" would not.
3. Reordered `tenant_id` in `0062` → the shape-equivalence assertion failed on all 11 columns, proving it is load-bearing.

Shape equivalence is compared **within one schema** (snapshot → drop → rewind the version pointer → `migrate up` → snapshot), because `CREATE EXTENSION` is database-wide: a second per-test schema no-ops on it and then cannot resolve the `vector` type from its own `search_path`. Single-schema is also the stronger test — it controls for collation and catalog defaults.

## Manual verification with the binary

Fresh `migrate up` with pgvector → 62 + table. Staged the actual bug (drop table, rewind to 61) → `migrate up` → **table created**. Staged the residual case (table absent, pointer already 62) → correctly no-ops. Booted the server against that state: **it started** (pre-fix it would not), logged the warning exactly once, and `GET /v1/_memory/embed_stats` returned a clean `503 {"code":"vector_unsupported"}`.

## Tested

`go test ./...` green, `gofmt -l` / `go vet ./...` / `go build ./...` clean. Full pgvector contract suite from a pristine database: 0 failures on this branch and on `main`, identical.

*(Note for reviewers running the suite locally: `internal/cli` and `internal/coord` fail if `LOOMCYCLE_PG_DSN` is exported in your shell — the "missing DSN" case can't be staged when the environment supplies one. Both pass with it unset; not related to this change.)*

## Known residue

- **`0017`'s `RAISE NOTICE`** still carries the same false "re-run `loomcycle migrate up`" advice. It lives inside the `DO` block — i.e. DDL of an applied migration — so it was deliberately left alone.
- **`main.go` logs `pgvector=true`** from the *config* flag one line below the new warning saying vector support is disabled. Defensible as a config echo, but misleading to someone grepping `pgvector=`. One-line follow-up if wanted.
- `docs/POSTGRES.md` was edited directly; that section should be mirrored into the authoritative doc store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
