### PR TITLE
ci(release): publish the tag's notes, not the commit message

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,12 @@ jobs:
           # goreleaser needs full git history for the version
           # template + commit-date stamp.
           fetch-depth: 0
+          # On a tag push, checkout materializes the triggering ref from
+          # GITHUB_SHA, which yields a LIGHTWEIGHT tag pointing at the
+          # commit — the annotated tag OBJECT (and therefore its message,
+          # which is our release body) never reaches the runner. See the
+          # pre-create step below, which force-refetches and verifies.
+          fetch-tags: true
 
       - uses: actions/setup-go@v5
         with:
@@ -121,12 +127,27 @@ jobs:
         run: |
           set -euo pipefail
           TAG="${GITHUB_REF_NAME}"
+          # Force-refetch the tag so we hold the annotated tag OBJECT, not
+          # the lightweight ref checkout materializes from GITHUB_SHA on a
+          # tag push. Without this, `%(contents)` silently falls back to the
+          # COMMIT message and the release ships the squash-merge body —
+          # which is exactly what happened to v1.34.0 (and, unnoticed, the
+          # two releases before it).
+          git fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}"
+          # Verify it is a real annotated tag BEFORE reading its message.
+          # The old emptiness check could never fire: a lightweight tag's
+          # %(contents) is the commit message, which is never empty, so the
+          # wrong body sailed through the guard. Check the object TYPE
+          # instead — "tag" = annotated, "commit" = lightweight.
+          OBJ_TYPE="$(git cat-file -t "$TAG")"
+          if [ "$OBJ_TYPE" != "tag" ]; then
+            echo "::error::Tag $TAG is lightweight (object type: $OBJ_TYPE), so it carries no release notes — reading it would publish the commit message instead. Re-tag annotated: git tag -a $TAG -F notes.md && git push --force origin $TAG"
+            exit 1
+          fi
           # Extract the annotated tag's message as the release body.
-          # Empty body = unannotated tag → fail loud so we don't ship
-          # a release with no notes.
           git tag -l --format='%(contents)' "$TAG" > /tmp/release-notes.md
           if [ ! -s /tmp/release-notes.md ]; then
-            echo "::error::Tag $TAG has no annotated message. Push annotated tag (git tag -a $TAG -m ...) before triggering the release workflow."
+            echo "::error::Tag $TAG has an empty annotated message. Re-tag with notes before triggering the release workflow."
             exit 1
           fi
           # Skip if release already exists (manual pre-create or retry).


### PR DESCRIPTION
## Why

The GitHub release body has silently been the **squash-merge commit message** instead of the curated notes in the annotated tag. v1.34.0 shipped that way and I repaired it by hand with `gh release edit`. Checking back, the two releases before it were repaired the same way — the symptom was known and worked around each time, but the cause was never found.

**The cause.** On a tag push, `actions/checkout` materializes the triggering ref from `GITHUB_SHA`, which produces a **lightweight** tag pointing at the commit. The annotated tag *object* never reaches the runner. And `git tag -l --format='%(contents)'` on a lightweight tag returns the **commit** message — so the pre-create step wrote the squash body into `/tmp/release-notes.md` and published it as the release notes.

**Why the guard never fired.** The step already tried to protect against this:

```sh
git tag -l --format='%(contents)' "$TAG" > /tmp/release-notes.md
if [ ! -s /tmp/release-notes.md ]; then   # empty = unannotated
```

But it tested for *emptiness*, and a commit message is never empty. The wrong body passed the check every single time. The guard was structurally incapable of failing, which is exactly why this recurred across three releases instead of being caught on the first.

Reproduced locally, and the first line of the published v1.34.0 body matched byte-for-byte:

```
$ git tag lw-probe 81a53ca8            # lightweight
$ git cat-file -t lw-probe             # commit
$ git tag -l --format='%(contents)' lw-probe | head -1
fix: stop discarding operator intent silently; add build + capability introspection (v1.34.0) (#821)
```

## What

**Get the annotated object onto the runner** — `fetch-tags: true` on checkout, plus a `git fetch --force origin "refs/tags/$TAG:refs/tags/$TAG"` in the step itself. Belt and braces on purpose: the refetch keeps this working even if checkout's ref handling changes again, which is the thing that silently broke it in the first place.

**Make the guard capable of failing** — check the object **type** before reading the message (`tag` = annotated, `commit` = lightweight) and fail loud with the remedy in the error text. The emptiness check stays as a second line of defence for a genuinely empty annotation.

## Tested

Both branches exercised against a throwaway repo whose commit subject imitates a squash merge:

```
lightweight tag:  REJECTED (type=commit)
annotated tag:    ACCEPTED -> body starts: Real release notes here
```

Workflow YAML parses (`yaml.safe_load`) and the extracted `run:` block passes `bash -n`.

**Note:** this cannot be fully verified until the next `v*` tag actually fires the workflow. The failure mode is now loud rather than silent, which is the point — a future release will fail the job rather than quietly publish the wrong notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)