### PR TITLE
fix(memory): pass scope on the consolidator's History call

### DIFF
--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -170,8 +170,9 @@ agents:
          Memory {"op":"cursor_release","scope":"user"}
          Reply "nothing new" and stop.
 
-      5. For each session_id from step 2:
-         History {"op":"get","session_id":"<id>","format":"markdown"}
+      5. For each session_id from step 2, ONE call each — never re-read a
+         session you have already read:
+         History {"op":"get","scope":"user","session_id":"<id>","format":"markdown"}
 
       6. For each distinct topic you read (one per topic, not per sentence):
          Memory {"op":"recall","scope":"user","query":"<topic>","top_k":8}

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -170,8 +170,9 @@ agents:
          Memory {"op":"cursor_release","scope":"user"}
          Reply "nothing new" and stop.
 
-      5. For each session_id from step 2:
-         History {"op":"get","session_id":"<id>","format":"markdown"}
+      5. For each session_id from step 2, ONE call each — never re-read a
+         session you have already read:
+         History {"op":"get","scope":"user","session_id":"<id>","format":"markdown"}
 
       6. For each distinct topic you read (one per topic, not per sentence):
          Memory {"op":"recall","scope":"user","query":"<topic>","top_k":8}

--- a/cmd/loomcycle/presets_memory_test.go
+++ b/cmd/loomcycle/presets_memory_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -193,7 +194,7 @@ func TestConsolidatorBundle_SystemPromptEncodesThePipeline(t *testing.T) {
 		`{"op":"cursor_lease","scope":"user","lease_ttl_ms":600000}`, // step 1 — one pass per target
 		"If acquired is false",                                // ...and the not-acquired stop
 		`{"op":"cursor_scan","scope":"user","limit":10}`,      // step 2 — the ONLY safe chat-discovery read
-		`{"op":"get","session_id":`,                           // step 5 — then read each scanned chat's turns
+		`{"op":"get","scope":"user","session_id":`,            // step 5 — read each scanned chat (scope is load-bearing: the default is self, which is denied)
 		`{"op":"pending_drain","scope":"user","limit":50}`,    // step 3 — the queue
 		`{"op":"cursor_release","scope":"user"}`,              // step 4 / 10 — always give the lease back
 		`{"op":"recall","scope":"user","query":`,              // step 6 — the neighbour set for dedup
@@ -518,4 +519,43 @@ func tierNames(cfg *config.Config) []string {
 		out = append(out, n)
 	}
 	return out
+}
+
+// TestConsolidatorBundle_EveryToolCallCarriesScope: every tool call the
+// procedure prescribes must pass an explicit scope.
+//
+// Live evidence, v1.35.0 on gpt-oss:latest. Step 5's History call omitted it:
+//
+//	History {"op":"get","session_id":"<id>","format":"markdown"}
+//
+// History defaults to scope "self" and the consolidator is granted
+// history_scope: [user], so every first attempt failed with
+//
+//	history: scope "self" not permitted (allowed: user)
+//
+// The model recovered by retrying with scope, but the wasted turns and the
+// error text cost it the thread: it re-read the same chat six times, then
+// restarted the whole procedure from step 1 and did it again — 15 tool calls,
+// 3,666 thinking events, never reaching the extract/write steps. The pass
+// livelocked without a single fact written.
+//
+// The omission predates the compact rewrite (v1.34.0's prompt had it too); it
+// was simply invisible while the agent made no tool calls at all. Asserting the
+// whole class rather than that one line, since a default-deny gate reached by a
+// scopeless call fails the same way for every op.
+func TestConsolidatorBundle_EveryToolCallCarriesScope(t *testing.T) {
+	cfg := memoryBundleConfig(t)
+	prompt := cfg.Agents["memory/consolidator"].SystemPrompt
+
+	// Steps are written either as `N. Memory {...}` or, for a continuation
+	// line, as bare `Memory {...}` — match both.
+	calls := regexp.MustCompile(`(?m)^\s*(?:\d+\.\s+)?(Memory|History|Document) \{"op":"(\w+)"[^\n]*`).FindAllString(prompt, -1)
+	if len(calls) < 10 {
+		t.Fatalf("found only %d prescribed tool calls; the procedure should prescribe ~11 — did the prompt format change?", len(calls))
+	}
+	for _, c := range calls {
+		if !strings.Contains(c, `"scope":`) {
+			t.Errorf("prescribed call omits an explicit scope, so it inherits the tool default and hits a default-deny gate:\n  %s", strings.TrimSpace(c))
+		}
+	}
 }


### PR DESCRIPTION
## Why

The first v1.35.0 pass **drove the pipeline correctly and still wrote nothing.** It livelocked.

v1.35.0 fixed the tool-calling failure — against the same `gpt-oss:latest` that four times produced only prose, the consolidator opened `cursor_lease → cursor_scan → pending_drain → History get` with real arguments. Then it hit this:

```
history: scope "self" not permitted (allowed: user)
```

Step 5 prescribed `History {"op":"get","session_id":…}` with **no scope**. History defaults to `self`; the consolidator is granted `history_scope: [user]`. Every first attempt failed.

The model recovered by retrying *with* the scope, but the wasted turns and the error text cost it the thread: it re-read the same chat six times, restarted the whole procedure from step 1, and did it again. **Fifteen tool calls, 3,666 thinking events**, never reaching the extract/write steps, transport timeout, watermark untouched.

**This is not from the compact rewrite** — v1.34.0's prompt omitted `scope` too. It was invisible while the agent made no tool calls at all. Fixing the first failure is what exposed it.

## What

Adds `"scope":"user"` to step 5, and tells the model to read each session **once** — re-reading was the proximate cost here, taking input from 4,828 to 9,281 tokens on a single retrieved transcript.

The guard asserts the **whole class**, not this one line: every prescribed call must carry an explicit scope, because a default-deny gate reached by a scopeless call fails identically for every op. All eleven prescribed calls now pass; History was the only omission.

## Tested

`env -u LOOMCYCLE_PG_DSN go test ./...` green, `gofmt` clean, both bundle copies byte-identical, parsed prompt 3,133 chars (under the 4,000 guard).

**Fail-before** verified against the shipped v1.35.0 prompt:

```
--- FAIL: TestConsolidatorBundle_EveryToolCallCarriesScope
    prescribed call omits an explicit scope, so it inherits the tool
    default and hits a default-deny gate
```

One existing assertion pinned the old literal `{"op":"get","session_id":` and was updated to the corrected call rather than relaxed.

## Scope

This makes the LLM consolidator correct-in-principle; it does **not** prove a pass completes. `cursor_scan` returns up to 10 sessions and step 5 reads each in full — one chat in this deployment is 195K characters. That bounding problem is untouched here, and is the motivation for reformulating the pipeline as a deterministic `code-js` agent, which is being designed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)