### PR TITLE
docs(release): name the v1.36.0 release notes

### DIFF
--- a/REVISIONS.md
+++ b/REVISIONS.md
@@ -4,7 +4,7 @@ Per-version release notes from v0.4.0 onward. The current and immediately previo
 
 For the **public roadmap** (planned v0.8.16 through v1.0 work — Question tool, Pause / Resume / Snapshot, distribution, operator postures), see [`docs/PLAN.md`](docs/PLAN.md).
 
-## Unreleased
+## What's in v1.36.0
 
 **🤖 The consolidation pass is now a deterministic `code-js` agent that calls a model for exactly one step — and it is UNVALIDATED against a live deployment.** Read that qualifier first, the same way v1.35.0's had to be read. Nothing here has been driven end-to-end by any model, local or hosted. What changed is the *shape* of the thing, and the argument for the shape; the consolidator should not be assumed to work until a run transcript shows it did.
 


### PR DESCRIPTION
## Why

Notes for #828 and #829 accumulated under `## Unreleased`. Naming the section is the last step before tagging.

**Minor, not patch:** #829 replaces the consolidator's entire implementation — an LLM-prompt pipeline becomes a deterministic `code-js` agent — and adds a new bundled agent, `memory/extractor`. That is a behaviour change for anyone running the memory bundle, even though no wire, schema or migration changes and both primitives it composes (`code-js`, `Agent`) already shipped.

## What

`## Unreleased` → `## What's in v1.36.0`. Notes only, no code.

## Tested

Nothing to test — a heading rename. Verified exactly one `## Unreleased` existed before the edit, that the section covers both merged PRs (code-js consolidator, extractor agent, fan-out serialisation, the History scope fix), and that the v1.35.0 / v1.34.0 sections below are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)