### PR TITLE
docs(release): name the v1.36.2 release notes

### DIFF
--- a/REVISIONS.md
+++ b/REVISIONS.md
@@ -4,7 +4,7 @@ Per-version release notes from v0.4.0 onward. The current and immediately previo
 
 For the **public roadmap** (planned v0.8.16 through v1.0 work — Question tool, Pause / Resume / Snapshot, distribution, operator postures), see [`docs/PLAN.md`](docs/PLAN.md).
 
-## Unreleased
+## What's in v1.36.2
 
 **🧹 The consolidation pass finally worked, and the 43 facts it wrote showed four things wrong with what it writes.** v1.36.1's pass cleared every bar its predecessors never did — ten chats read, **43 facts written and verified in the store** against a zero baseline, eight of them updated in place, the queue drained and acked, the lease released. The pipeline is right. What it *produced* was not, and none of these were visible until a real model filled the store.
 


### PR DESCRIPTION
## Why

The notes for #833 accumulated under `## Unreleased`. Naming the section is the last step before tagging.

**Patch.** #833 is four fact-quality fixes against v1.36.1's pipeline — no new primitives, no config surface, nothing on the wire or in the schema.

The headline one is worth restating because a live pass demonstrated it: the cross-reference tail nested recursively, and since `embed_text` *is* the stored value, the tail went into the embedding. That both defeated real merges and **manufactured false ones** — a pass archived a correct fact because its `(related: …)` tail made it embed near an unrelated row.

## What

`## Unreleased` → `## What's in v1.36.2`. Notes only, no code.

## Tested

Nothing to test — a heading rename. Verified exactly one `## Unreleased` existed before the edit, and that the v1.36.1 / v1.36.0 sections below are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)