### PR TITLE
docs(release): name the v1.36.3 release notes

### DIFF
--- a/REVISIONS.md
+++ b/REVISIONS.md
@@ -4,7 +4,7 @@ Per-version release notes from v0.4.0 onward. The current and immediately previo
 
 For the **public roadmap** (planned v0.8.16 through v1.0 work — Question tool, Pause / Resume / Snapshot, distribution, operator postures), see [`docs/PLAN.md`](docs/PLAN.md).
 
-## Unreleased
+## What's in v1.36.3
 
 **🚦 The consolidation watermark had never advanced. Not once, on any release — and the reason was that an empty extractor reply was treated as a failure.** The v1.36.2 pass on a wiped store was the best one yet: ten chats read, 18 facts written, four updated in place, **zero** false retirements (three the release before, one of which archived a correct fact), a transient id rejected. It also called `cursor_advance` **zero** times and `cursor_release` twice, and ended `watermark NOT advanced: extractor returned an empty reply`. Every pass since the feature existed has re-read the same page.
 


### PR DESCRIPTION
## Why

The notes for #835 accumulated under `## Unreleased`. Naming the section is the last step before tagging.

**Patch.** All bug fixes against v1.36.2's pipeline — no new primitives, no config surface, nothing on the wire or in the schema.

Worth restating what it unblocks: `cursor_advance` had been called **zero** times in every version, because an empty extractor reply blocked the pass and one chat (a scraped model card with genuinely nothing to extract) returned empty every time. That is now ignored rather than fatal.

## What

`## Unreleased` → `## What's in v1.36.3`. Notes only, no code.

## Tested

Nothing to test — a heading rename. Verified exactly one `## Unreleased` existed before the edit, that the section covers all four changes (empty-reply handling, chat splitting, the question-record fix, the queued-batch ack bug), and that the v1.36.2 / v1.36.1 sections below are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)