### PR TITLE
docs(release): name the v1.36.4 release notes

### DIFF
--- a/REVISIONS.md
+++ b/REVISIONS.md
@@ -4,7 +4,7 @@ Per-version release notes from v0.4.0 onward. The current and immediately previo
 
 For the **public roadmap** (planned v0.8.16 through v1.0 work — Question tool, Pause / Resume / Snapshot, distribution, operator postures), see [`docs/PLAN.md`](docs/PLAN.md).
 
-## Unreleased
+## What's in v1.36.4
 
 **🩸 A consolidation merge was destroying facts, and one cosine number was the whole of the authority required to do it.** v1.36.3's pass reported `updated in place 21`. Some of those were not merges. Two rows in the resulting store say so by themselves — `memory/fact/user-downloaded-qwen3-6-27b-q4` now holds *"The user's model is gemma-4-12b-it-UD-Q4_K_XL.gguf."*, and `memory/fact/user-s-llama-cpp-server-running` now holds *"The user has an AMD GPU for GPU acceleration."* Each key names the subject its row was minted for; each value is a fact about something else. **A merge writes the incoming fact under the neighbour's key, so the neighbour's text is simply gone** — no supersede row, no audit trail, nothing to notice it by except a key that quietly lies about its own contents. It is the one unrecoverable step in a pipeline where everything else either adds a row or soft-archives one a later pass can revive.
 


### PR DESCRIPTION
## Why

The notes for #837 accumulated under `## Unreleased`. Naming the section is the last step before tagging.

**Patch.** A bug fix plus a new calibration dataset — no new primitives, no config surface, nothing on the wire or in the schema.

Worth restating what it closes: `update` writes to the neighbour's key, so a wrong merge decision **destroys** a fact rather than duplicating it. A live pass did that twice, leaving keys that lied about their own contents. Retirement was gated on the same single similarity number and is closed by the same filter.

## What

`## Unreleased` → `## What's in v1.36.4`. Notes only, no code.

## Tested

Nothing to test — a heading rename. Verified exactly one `## Unreleased` existed before the edit, and that the v1.36.3 / v1.36.2 sections below are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)