### PR TITLE
build: remove the Postgres fixture's data volume with its container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ pg-up:
 
 pg-down:
 	@if docker ps -a --format '{{.Names}}' | grep -q '^$(PG_CONTAINER)$$'; then \
-		docker rm -f $(PG_CONTAINER) >/dev/null && echo "$(PG_CONTAINER) removed"; \
+		docker rm -f -v $(PG_CONTAINER) >/dev/null && echo "$(PG_CONTAINER) removed"; \
 	else \
 		echo "$(PG_CONTAINER) not running"; \
 	fi


### PR DESCRIPTION
## Why

`postgres:16-alpine` declares `VOLUME /var/lib/postgresql/data`, so every `docker run` mints an anonymous volume. `pg-down` used `docker rm -f` **without `-v`**, so each pg-down/pg-up cycle orphaned a full Postgres data directory rather than reclaiming it.

On one developer machine this reached **12 orphaned volumes and 7.5 GB of a 23.5 GB VM disk**.

**This is not a tidiness problem.** Once the disk tightens, Postgres fails writes with `SQLSTATE 53100 — no space left on device`, and that surfaces as migration failures and `connection reset by peer` in **unrelated** contract subtests. A full run degraded to **155 failures**, and — because the leak grows per cycle — the failing set grew each time the suite was run.

That pattern reads exactly like a regression in whatever branch happens to be checked out. It misdirected two separate investigations before the cause was found: one branch touching zero channel code appeared to break channel tests, and I incorrectly told the author their diff had introduced a Postgres regression on the strength of a "clean on main, fails on branch" comparison that was really measuring VM disk state at two different moments.

**CI never sees it** — a fresh service container per run — so the leak only bites a developer running the local fixture, and it bites them in a way that blames their own work.

## What

`docker rm -f` → `docker rm -f -v` in `pg-down`.

## Tested

Before: the dangling-volume count rose by one per `pg-down`/`pg-up` cycle. After: it holds steady and the data volume is removed with its container.

Verified on the affected machine — 13 dangling volumes enumerated, of which 12 were leaked fixture data directories.

## Note for anyone reclaiming existing orphans

`docker volume prune` removes **all** dangling volumes, which may include named ones unrelated to this repo. On the machine where this was found the dangling list also contained a project database from another repo. Enumerate with `docker volume ls -qf dangling=true` before pruning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)