### PR TITLE
docs(release): name the v1.36.5 release notes

### DIFF
--- a/REVISIONS.md
+++ b/REVISIONS.md
@@ -4,7 +4,7 @@ Per-version release notes from v0.4.0 onward. The current and immediately previo
 
 For the **public roadmap** (planned v0.8.16 through v1.0 work — Question tool, Pause / Resume / Snapshot, distribution, operator postures), see [`docs/PLAN.md`](docs/PLAN.md).
 
-## Unreleased
+## What's in v1.36.5
 
 **🔁 The consolidator was consolidating its own output, and the loop had no bound.** Every pass spawns one `memory/extractor` child per chat it reads — 13 to 18 of them on a normal page — and each child is a session under the target's own user id whose transcript **contains the chat it was extracting**. Nothing excluded them. `ConsolidatableSessions` took a *single* exclusion and the pass passed its own name, so on the next tick its children came back as work; and because a pass never consolidates them, it never advances over them either, so they accumulate past the watermark permanently. On the live store **7 of the last 8 chats were extractor sessions out of 95 total, growing by roughly 15 a pass**, with every pass re-extracting nested copies of its own input.
 


### PR DESCRIPTION
## Why

The notes for #839–#842 accumulated under `## Unreleased`. Naming the section is the last step before tagging.

**Patch.** Three fixes plus one additive feature — no wire change, no schema change, no new primitives.

The line is worth reading as one story: chasing why a consolidation pass produced junk facts surfaced a self-consuming feedback loop, an extractor being fed loomcycle's own scaffolding, a leaked fixture volume that misdirected two investigations, and underneath all of it a genuine production bug where a channel message could be invisible to its own publisher.

## What

`## Unreleased` → `## What's in v1.36.5`. Notes only, no code.

## Tested

Nothing to test — a heading rename. Verified exactly one `## Unreleased` existed before the edit, that the section covers all four merges, and that the v1.36.4 / v1.36.3 sections below are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)