### PR TITLE
feat(config): add compaction.memory_flush, plumbed but not yet read (P3 PR 1/4)

### DIFF
--- a/internal/agents/loader.go
+++ b/internal/agents/loader.go
@@ -185,6 +185,12 @@ type Compaction struct {
 	KeepFirst        *bool   `json:"keep_first,omitempty"`
 	AutoCompactAtPct *int    `json:"autocompact_at_pct,omitempty"`
 	Model            *string `json:"model,omitempty"`
+	// MemoryFlush is content-identifying: it changes what every run of the def
+	// DOES — whether a compaction banks the discarded span into memory — which is
+	// behaviour rather than authority, so it belongs in content_sha256. Same call
+	// as `internal:`, and the opposite of the `*_def_scopes` gates. `omitempty` on
+	// the nil default keeps every existing agent row byte-stable.
+	MemoryFlush *bool `json:"memory_flush,omitempty"`
 }
 
 // CoreBlock mirrors config.CoreBlock locally so the agents package stays

--- a/internal/agents/sign.go
+++ b/internal/agents/sign.go
@@ -320,7 +320,8 @@ func normalize(c *AgentContent) {
 	// def yields `"compaction":{}`) → hashes identically to a pre-feature row.
 	if c.Compaction != nil && c.Compaction.Enabled == nil && c.Compaction.TargetPercentage == nil &&
 		c.Compaction.KeepLastN == nil && c.Compaction.KeepFirst == nil &&
-		c.Compaction.AutoCompactAtPct == nil && c.Compaction.Model == nil {
+		c.Compaction.AutoCompactAtPct == nil && c.Compaction.Model == nil &&
+		c.Compaction.MemoryFlush == nil {
 		c.Compaction = nil
 	}
 

--- a/internal/config/compaction_test.go
+++ b/internal/config/compaction_test.go
@@ -1,6 +1,9 @@
 package config
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func ptrB(b bool) *bool     { return &b }
 func ptrI2(i int) *int      { return &i }
@@ -60,4 +63,107 @@ func TestCompaction_Validate(t *testing.T) {
 	if (*Compaction)(nil).Validate() != nil {
 		t.Error("nil compaction should validate")
 	}
+}
+
+// nonZeroCompaction sets EVERY field to a non-zero value via reflection, so a
+// newly added field is populated without anyone remembering to add it here. That
+// is the whole point: a hand-written literal is exactly what goes stale.
+func nonZeroCompaction(t *testing.T) *Compaction {
+	t.Helper()
+	c := &Compaction{}
+	v := reflect.ValueOf(c).Elem()
+	for i := 0; i < v.NumField(); i++ {
+		f := v.Field(i)
+		if f.Kind() != reflect.Ptr {
+			t.Fatalf("Compaction.%s is not a pointer; this test's non-zero strategy assumes the all-pointer shape that makes unset distinguishable from zero",
+				v.Type().Field(i).Name)
+		}
+		elem := reflect.New(f.Type().Elem())
+		switch elem.Elem().Kind() {
+		case reflect.Bool:
+			elem.Elem().SetBool(true)
+		case reflect.Int:
+			// In-range for every int field (target_percentage 10..50,
+			// autocompact_at_pct 50..95) so Validate() passes too.
+			elem.Elem().SetInt(50)
+		case reflect.String:
+			elem.Elem().SetString("x")
+		default:
+			t.Fatalf("Compaction.%s has unhandled kind %s — extend this helper", v.Type().Field(i).Name, elem.Elem().Kind())
+		}
+		f.Set(elem)
+	}
+	return c
+}
+
+// TestCompaction_CloneAndMergeCoverEveryField guards the sub-struct drift the
+// AgentDef-level coverage test cannot see. mergeAgentDef and
+// lookup.SubstrateAgentDef both carry *Compaction WHOLESALE, so a field added to
+// the struct but forgotten in Clone or MergeCompaction is silently dropped on
+// every fork and every spawn-inherited override — with no compile error and no
+// warning, which is the failure mode that cost twelve AgentDef fields once.
+//
+// Reflective on purpose: it fails for a field nobody remembered to add.
+func TestCompaction_CloneAndMergeCoverEveryField(t *testing.T) {
+	full := nonZeroCompaction(t)
+	ft := reflect.TypeOf(Compaction{})
+
+	t.Run("Clone", func(t *testing.T) {
+		got := reflect.ValueOf(full.Clone()).Elem()
+		want := reflect.ValueOf(full).Elem()
+		for i := 0; i < ft.NumField(); i++ {
+			name := ft.Field(i).Name
+			g, w := got.Field(i), want.Field(i)
+			if g.IsNil() {
+				t.Errorf("Clone() dropped Compaction.%s — a fork of an agent setting it loses the setting", name)
+				continue
+			}
+			if !reflect.DeepEqual(g.Elem().Interface(), w.Elem().Interface()) {
+				t.Errorf("Clone() Compaction.%s = %v, want %v", name, g.Elem(), w.Elem())
+			}
+			// Deep copy, not aliased: mutating the clone must not reach the source.
+			if g.Pointer() == w.Pointer() {
+				t.Errorf("Clone() aliased Compaction.%s instead of copying it", name)
+			}
+		}
+	})
+
+	t.Run("MergeCompaction", func(t *testing.T) {
+		got := reflect.ValueOf(MergeCompaction(&Compaction{}, full)).Elem()
+		want := reflect.ValueOf(full).Elem()
+		for i := 0; i < ft.NumField(); i++ {
+			name := ft.Field(i).Name
+			g := got.Field(i)
+			if g.IsNil() {
+				t.Errorf("MergeCompaction() never overlays Compaction.%s — an override of it is SILENTLY DISCARDED", name)
+				continue
+			}
+			if !reflect.DeepEqual(g.Elem().Interface(), want.Field(i).Elem().Interface()) {
+				t.Errorf("MergeCompaction() Compaction.%s = %v, want %v", name, g.Elem(), want.Field(i).Elem())
+			}
+		}
+	})
+
+	t.Run("IsZero", func(t *testing.T) {
+		// Each field ALONE must defeat IsZero. A field missing from IsZero collapses
+		// a def that sets only that field to nil, so it hashes as a no-compaction
+		// def and a create changing only it deduplicates away.
+		fv := reflect.ValueOf(full).Elem()
+		for i := 0; i < ft.NumField(); i++ {
+			only := &Compaction{}
+			reflect.ValueOf(only).Elem().Field(i).Set(fv.Field(i))
+			if only.IsZero() {
+				t.Errorf("IsZero() ignores Compaction.%s — a def setting only that field collapses to nil", ft.Field(i).Name)
+			}
+		}
+		if !(&Compaction{}).IsZero() || !(*Compaction)(nil).IsZero() {
+			t.Error("an all-unset / nil Compaction must be zero, or every pre-feature agent re-hashes")
+		}
+	})
+
+	t.Run("Validate accepts the all-set form", func(t *testing.T) {
+		if err := full.Validate(); err != nil {
+			t.Errorf("the all-fields-set Compaction failed Validate: %v", err)
+		}
+	})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1492,6 +1492,27 @@ type Compaction struct {
 	// Model optionally runs the summary call on a cheaper/faster model SERVED BY
 	// THE SAME PROVIDER (e.g. a haiku-class model). "" / nil = the run's model.
 	Model *string `json:"model,omitempty" yaml:"model"`
+	// MemoryFlush banks the span a compaction is about to discard into the same
+	// pending queue `Memory op=add infer=true` writes to, so the consolidator
+	// extracts durable facts from it on its next pass (RFC BL P3). Default off.
+	//
+	// It exists for a coverage gap, not a capability gap: consolidation only
+	// selects sessions whose runs are all terminal, so an interactive or
+	// long-running agent that compacts repeatedly is never consolidated from
+	// transcript at all. This puts those conversations on the queue.
+	//
+	// It BANKS, it does not flush — facts land when the consolidator next runs,
+	// the same eventual consistency the `add` queue already documents.
+	//
+	// Per-agent ONLY, deliberately not a per-run override like the fields above.
+	// Those are tuning; this decides whether conversation content becomes durable
+	// memory, so a wire caller could otherwise make an agent persist what its def
+	// never authorized. Mirrors `memory_consolidation`, the other memory-authority
+	// field, which is likewise per-agent only.
+	//
+	// The bridge that reads this lands separately; the field is plumbed first so
+	// the overlay/hash plumbing is reviewable on its own.
+	MemoryFlush *bool `json:"memory_flush,omitempty" yaml:"memory_flush"`
 }
 
 // Compaction defaults — applied at use-time when a field is unset.
@@ -1506,7 +1527,8 @@ const (
 // stable content hashes for agents that don't configure compaction).
 func (c *Compaction) IsZero() bool {
 	return c == nil || (c.Enabled == nil && c.TargetPercentage == nil && c.KeepLastN == nil &&
-		c.KeepFirst == nil && c.AutoCompactAtPct == nil && c.Model == nil)
+		c.KeepFirst == nil && c.AutoCompactAtPct == nil && c.Model == nil &&
+		c.MemoryFlush == nil)
 }
 
 // Clone deep-copies (every field is a pointer) so a merge never aliases an input.
@@ -1538,6 +1560,10 @@ func (c *Compaction) Clone() *Compaction {
 	if c.Model != nil {
 		v := *c.Model
 		out.Model = &v
+	}
+	if c.MemoryFlush != nil {
+		v := *c.MemoryFlush
+		out.MemoryFlush = &v
 	}
 	return out
 }
@@ -1581,6 +1607,10 @@ func MergeCompaction(base, over *Compaction) *Compaction {
 	if over.Model != nil {
 		v := *over.Model
 		out.Model = &v
+	}
+	if over.MemoryFlush != nil {
+		v := *over.MemoryFlush
+		out.MemoryFlush = &v
 	}
 	return out
 }

--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -1386,6 +1386,7 @@ func signFromMergedDef(name string, def mergedDef) string {
 			KeepFirst:        cp.KeepFirst,
 			AutoCompactAtPct: cp.AutoCompactAtPct,
 			Model:            cp.Model,
+			MemoryFlush:      cp.MemoryFlush,
 		}
 	}
 	return agents.Sign(c)

--- a/internal/tools/builtin/agentdef_test.go
+++ b/internal/tools/builtin/agentdef_test.go
@@ -1087,3 +1087,65 @@ func TestAgentDefTool_ListIncludesDefinition(t *testing.T) {
 	// surfaces as a JSON-decoded object. Either shape is acceptable —
 	// what matters is that the field is non-null.
 }
+
+// TestAgentDefTool_MemoryFlushRoundTripsAndAffectsContentSHA is the P3 field's
+// end-to-end plumbing gate, covering both halves of the failure this class has
+// produced before.
+//
+// ROUND-TRIP: `compaction.memory_flush` set through the create overlay must come
+// back on the persisted def. mergeAgentDef and lookup.SubstrateAgentDef both
+// carry *Compaction wholesale, so this really tests Clone/MergeCompaction — a
+// field they forget is dropped with no compile error and no warning.
+//
+// HASH: it must be content-identifying. It changes what every run of the def
+// DOES, which is behaviour rather than authority, so unlike the *_def_scopes
+// gates it belongs in content_sha256. If it were excluded, a create that flipped
+// only this field would come back `deduplicated: true` with the OLD def — the
+// v1.34.0 hole, here on a field that decides whether conversations become
+// durable memory.
+func TestAgentDefTool_MemoryFlushRoundTripsAndAffectsContentSHA(t *testing.T) {
+	tool, ctx, cleanup := agentDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"banker","overlay":{"system_prompt":"chat"}}`))
+	if res.IsError {
+		t.Fatalf("create: %s", res.Text)
+	}
+	parentSHA, _ := decodeResult(t, res.Text)["content_sha256"].(string)
+
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"fork","name":"banker","overlay":{"compaction":{"memory_flush":true}}}`))
+	if res.IsError {
+		t.Fatalf("fork: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	forkSHA, _ := out["content_sha256"].(string)
+
+	if parentSHA == "" || forkSHA == "" {
+		t.Fatalf("missing content_sha256: parent=%q fork=%q", parentSHA, forkSHA)
+	}
+	if parentSHA == forkSHA {
+		t.Errorf("a fork setting only compaction.memory_flush produced the SAME content_sha256 %q — the field is not in the hash basis, so a create flipping it would dedup to the old def", parentSHA)
+	}
+
+	// The value survives the round-trip through the persisted overlay.
+	defID, _ := out["def_id"].(string)
+	if defID == "" {
+		t.Fatalf("fork returned no def_id: %v", out)
+	}
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"get","def_id":"`+defID+`"}`))
+	if res.IsError {
+		t.Fatalf("get: %s", res.Text)
+	}
+	got := decodeResult(t, res.Text)
+	def, ok := got["definition"].(map[string]any)
+	if !ok {
+		t.Fatalf("get returned no definition: %v", got)
+	}
+	cp, ok := def["compaction"].(map[string]any)
+	if !ok {
+		t.Fatalf("compaction absent from the persisted def — the overlay was dropped: %v", def)
+	}
+	if cp["memory_flush"] != true {
+		t.Errorf("compaction.memory_flush = %v, want true (dropped by Clone or MergeCompaction)", cp["memory_flush"])
+	}
+}


### PR DESCRIPTION
First of four PRs for the RFC BL P3 compaction→memory bridge. Plan: `/loomcycle/docs/plans/rfc-bl-p3-plan`.

**This PR threads the field and nothing else.** The bridge that reads it lands in PR 3, so the overlay and hash plumbing is reviewable on its own rather than inside a diff that also changes runtime behaviour. Nothing in this PR alters what any agent does.

## Why the field exists

`compaction.memory_flush` will bank the span a compaction is about to discard into the same pending queue `Memory op=add infer=true` writes to, so the consolidator extracts durable facts from it on its next pass.

It closes a **coverage** gap, not a capability gap. Consolidation only selects sessions whose runs are all terminal — so an interactive or long-running agent that compacts repeatedly is never consolidated from transcript at all. P2's own known-gaps list says it: *"Interactive/parked runs stay `status='running'`… Only the `add` queue covers those conversations."* This is what puts them on the queue.

## Two decisions worth reviewing

**Per-agent only — deliberately NOT a per-run override**, unlike every other field in the `compaction` block. Those are tuning; this one decides whether conversation content becomes durable memory, so a wire caller could otherwise make an agent persist what its def never authorized. It mirrors `memory_consolidation`, the other memory-authority field, which is likewise per-agent only. Consequence: the gRPC per-run compaction path is untouched and **the proto is unchanged**.

**Content-IDENTIFYING.** It changes what every run of the def *does* — behaviour, not authority — so unlike the `*_def_scopes` gates it belongs in `content_sha256`. Same call as `internal:` in v1.36.0. `omitempty` on the nil default keeps every existing agent row byte-stable.

## Ported at six sites, found by grep rather than by reading

The struct, `Clone`, `MergeCompaction`, `IsZero`, the `agents.Compaction` hash mirror, and `AgentContent`'s population.

`mergeAgentDef` and `lookup.SubstrateAgentDef` needed **no** change — both carry `*Compaction` wholesale, which is precisely why `Clone` and `MergeCompaction` are the load-bearing ones and why a sub-struct field is easy to drop silently.

The sixth site is the easiest to miss and the worst to get wrong: **`sign.go`'s all-nil collapse**. Without the new field it flattens a `memory_flush`-only def to `nil` and hashes it as a no-compaction def — so the field would round-trip correctly and still be invisible to the hash.

## What was tested

`go test ./...` clean.

`TestCompaction_CloneAndMergeCoverEveryField` is **reflective**, and covers the sub-struct drift the existing `AgentDef`-level coverage test structurally cannot see. It populates every field by reflection, so it fails for a field nobody remembered to add — a hand-written literal is exactly what goes stale. It asserts `Clone` deep-copies rather than aliases, `MergeCompaction` overlays, and that each field **alone** defeats `IsZero`.

`TestAgentDefTool_MemoryFlushRoundTripsAndAffectsContentSHA` proves it end-to-end: the overlay survives a fork, and a fork changing only this field mints a different hash. Without that, a create flipping it would return the OLD def as `deduplicated: true` — the v1.34.0 hole, on a field that decides whether conversations become durable memory.

**Fail-before verified at all five threading sites**, each reverted individually against the committed tests:

| reverted | test says |
|---|---|
| `MergeCompaction` | `never overlays Compaction.MemoryFlush — an override of it is SILENTLY DISCARDED` |
| `Clone` | `dropped Compaction.MemoryFlush — a fork of an agent setting it loses the setting` |
| `IsZero` | `ignores Compaction.MemoryFlush — a def setting only that field collapses to nil` |
| `AgentContent` | `SAME content_sha256 … not in the hash basis` |
| `sign.go` collapse | same — which is the point: two different omissions, one symptom |

🤖 Generated with [Claude Code](https://claude.com/claude-code)