### PR TITLE
feat(memory): record what produced a pending item, and resolve fact origins (P3 PR 2/4)

### DIFF
--- a/internal/memory/backends/inprocess/inprocess.go
+++ b/internal/memory/backends/inprocess/inprocess.go
@@ -409,6 +409,12 @@ func (b *Backend) Add(ctx context.Context, scope store.MemoryScope, scopeID stri
 			Scope:    scope,
 			ScopeID:  scopeID,
 			Payload:  payload,
+			// RFC BL P3: WHAT enqueued this, server-set. An agent reaching `add`
+			// is by definition an explicit agent write; the compaction bridge
+			// stamps its own value. Never a tool argument — origin is what a
+			// consolidated fact's provenance is resolved FROM, so a forgeable one
+			// would let an agent dictate how its own writes are labelled.
+			Origin: store.PendingOriginAgentExplicit,
 			// No session-id ctx helper today (RunIdentityValue carries no
 			// session id), so SourceSessionID stays empty; SourceRunID is enough
 			// to correlate the enqueue back to the run that produced it.

--- a/internal/store/postgres/migrations/0063_memory_pending_origin.down.sql
+++ b/internal/store/postgres/migrations/0063_memory_pending_origin.down.sql
@@ -1,0 +1,3 @@
+-- Reverses 0063. Dropping the column loses producer attribution on every row
+-- that carried it; the queue itself and its payloads are unaffected.
+ALTER TABLE memory_pending DROP COLUMN IF EXISTS origin;

--- a/internal/store/postgres/migrations/0063_memory_pending_origin.up.sql
+++ b/internal/store/postgres/migrations/0063_memory_pending_origin.up.sql
@@ -1,0 +1,16 @@
+-- 0063_memory_pending_origin.up.sql — RFC BL P3 (compaction→memory bridge).
+--
+-- What enqueued a pending row: 'agent_explicit' (Memory op=add) or 'compaction'
+-- (a compaction banked the span it was about to discard). Server-set at enqueue,
+-- never from a tool argument.
+--
+-- Why the column is needed at all: origin on the `memory` table is stamped from
+-- the WRITER's identity, and the writer is the consolidator either way — so
+-- without this there is no way for a consolidated fact to record that it came
+-- from a compaction flush rather than a scheduled transcript pass.
+--
+-- Nullable with NO backfill. A row enqueued before this column existed has an
+-- unknown producer, and guessing one would make the column lie on exactly the
+-- rows an operator is most likely to be auditing. Mirrors how memory.origin
+-- treats its own legacy rows.
+ALTER TABLE memory_pending ADD COLUMN IF NOT EXISTS origin TEXT;

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -4228,10 +4228,10 @@ func (s *Store) MemoryPendingEnqueue(ctx context.Context, row store.MemoryPendin
 	}
 	_, err := s.pool.Exec(ctx,
 		`INSERT INTO memory_pending
-		   (id, tenant_id, scope, scope_id, payload, source_session_id, source_run_id, created_at)
-		 VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8)`,
+		   (id, tenant_id, scope, scope_id, payload, origin, source_session_id, source_run_id, created_at)
+		 VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9)`,
 		row.ID, row.TenantID, string(row.Scope), row.ScopeID, string(payload),
-		nullableString(row.SourceSessionID), nullableString(row.SourceRunID), createdAt,
+		nullableString(row.Origin), nullableString(row.SourceSessionID), nullableString(row.SourceRunID), createdAt,
 	)
 	if err != nil {
 		return fmt.Errorf("memory pending enqueue: %w", err)
@@ -4246,7 +4246,7 @@ func (s *Store) MemoryPendingDrain(ctx context.Context, tenantID string, scope s
 		limit = 100
 	}
 	rows, err := s.pool.Query(ctx,
-		`SELECT id, tenant_id, scope, scope_id, payload::text, source_session_id, source_run_id, created_at, drained_at
+		`SELECT id, tenant_id, scope, scope_id, payload::text, origin, source_session_id, source_run_id, created_at, drained_at
 		 FROM memory_pending
 		 WHERE tenant_id = $1 AND scope = $2 AND scope_id = $3 AND drained_at IS NULL
 		 ORDER BY created_at ASC, id ASC
@@ -4263,15 +4263,19 @@ func (s *Store) MemoryPendingDrain(ctx context.Context, tenantID string, scope s
 			r           store.MemoryPendingRow
 			scopeStr    string
 			payloadText []byte
+			origin      *string
 			srcSession  *string
 			srcRun      *string
 			drainedAt   *time.Time
 		)
-		if err := rows.Scan(&r.ID, &r.TenantID, &scopeStr, &r.ScopeID, &payloadText, &srcSession, &srcRun, &r.CreatedAt, &drainedAt); err != nil {
+		if err := rows.Scan(&r.ID, &r.TenantID, &scopeStr, &r.ScopeID, &payloadText, &origin, &srcSession, &srcRun, &r.CreatedAt, &drainedAt); err != nil {
 			return nil, fmt.Errorf("memory pending drain scan: %w", err)
 		}
 		r.Scope = store.MemoryScope(scopeStr)
 		r.Payload = json.RawMessage(payloadText)
+		if origin != nil {
+			r.Origin = *origin
+		}
 		if srcSession != nil {
 			r.SourceSessionID = *srcSession
 		}
@@ -4287,6 +4291,49 @@ func (s *Store) MemoryPendingDrain(ctx context.Context, tenantID string, scope s
 		return nil, fmt.Errorf("memory pending drain iter: %w", err)
 	}
 	return out, nil
+}
+
+// MemoryPendingGet is a point lookup by id within (tenant, scope, scopeID).
+// Those three ARE the authorization check — a foreign row is simply not found.
+// Deliberately no drained_at filter: the caller resolving provenance has already
+// drained the row it is asking about.
+func (s *Store) MemoryPendingGet(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, id string) (store.MemoryPendingRow, error) {
+	var (
+		r           store.MemoryPendingRow
+		scopeStr    string
+		payloadText []byte
+		origin      *string
+		srcSession  *string
+		srcRun      *string
+		drainedAt   *time.Time
+	)
+	err := s.pool.QueryRow(ctx,
+		`SELECT id, tenant_id, scope, scope_id, payload::text, origin, source_session_id, source_run_id, created_at, drained_at
+		 FROM memory_pending
+		 WHERE id = $1 AND tenant_id = $2 AND scope = $3 AND scope_id = $4`,
+		id, tenantID, string(scope), scopeID,
+	).Scan(&r.ID, &r.TenantID, &scopeStr, &r.ScopeID, &payloadText, &origin, &srcSession, &srcRun, &r.CreatedAt, &drainedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return store.MemoryPendingRow{}, &store.ErrNotFound{Kind: "memory_pending", ID: id}
+	}
+	if err != nil {
+		return store.MemoryPendingRow{}, fmt.Errorf("memory pending get: %w", err)
+	}
+	r.Scope = store.MemoryScope(scopeStr)
+	r.Payload = json.RawMessage(payloadText)
+	if origin != nil {
+		r.Origin = *origin
+	}
+	if srcSession != nil {
+		r.SourceSessionID = *srcSession
+	}
+	if srcRun != nil {
+		r.SourceRunID = *srcRun
+	}
+	if drainedAt != nil {
+		r.DrainedAt = *drainedAt
+	}
+	return r, nil
 }
 
 // MemoryPendingAck marks the given ids drained. `AND drained_at IS NULL` keeps

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -275,6 +275,7 @@ func (s *Store) migrate(ctx context.Context) error {
 			scope             TEXT    NOT NULL,
 			scope_id          TEXT    NOT NULL,
 			payload           TEXT    NOT NULL,
+			origin            TEXT,
 			source_session_id TEXT,
 			source_run_id     TEXT,
 			created_at        INTEGER NOT NULL,
@@ -1065,9 +1066,14 @@ func (s *Store) migrate(ctx context.Context) error {
 		`ALTER TABLE memory ADD COLUMN last_accessed_at INTEGER`,
 		// RFC BL P2 — the soft-archive marker. NULL on every legacy row (live);
 		// the consolidator stamps it to hide a consolidated raw row from recall
-		// while retaining it. memory_pending / memory_cursors are pure CREATE
-		// TABLE (no ALTER needed) so they land via the schema block above.
+		// while retaining it.
 		`ALTER TABLE memory ADD COLUMN superseded_at INTEGER`,
+		// RFC BL P3 — what enqueued a pending row (agent_explicit | compaction),
+		// server-set. memory_pending arrived as a pure CREATE TABLE in P2, so an
+		// upgraded DB has the table but not this column and needs the ALTER; a
+		// fresh DB gets it from the schema block above. NULL on rows enqueued
+		// before it existed — deliberately not backfilled to a guess.
+		`ALTER TABLE memory_pending ADD COLUMN origin TEXT`,
 	}
 	for _, q := range addColumns {
 		if _, err := s.db.ExecContext(ctx, q); err != nil {
@@ -4712,10 +4718,10 @@ func (s *Store) MemoryPendingEnqueue(ctx context.Context, row store.MemoryPendin
 	}
 	_, err := s.db.ExecContext(ctx,
 		`INSERT INTO memory_pending
-		   (id, tenant_id, scope, scope_id, payload, source_session_id, source_run_id, created_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		   (id, tenant_id, scope, scope_id, payload, origin, source_session_id, source_run_id, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		row.ID, row.TenantID, string(row.Scope), row.ScopeID, string(payload),
-		row.SourceSessionID, row.SourceRunID, createdAt.UnixNano(),
+		row.Origin, row.SourceSessionID, row.SourceRunID, createdAt.UnixNano(),
 	)
 	return err
 }
@@ -4727,7 +4733,7 @@ func (s *Store) MemoryPendingDrain(ctx context.Context, tenantID string, scope s
 		limit = 100
 	}
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, tenant_id, scope, scope_id, payload, source_session_id, source_run_id, created_at, drained_at
+		`SELECT id, tenant_id, scope, scope_id, payload, origin, source_session_id, source_run_id, created_at, drained_at
 		 FROM memory_pending
 		 WHERE tenant_id = ? AND scope = ? AND scope_id = ? AND drained_at IS NULL
 		 ORDER BY created_at ASC, id ASC
@@ -4744,16 +4750,18 @@ func (s *Store) MemoryPendingDrain(ctx context.Context, tenantID string, scope s
 			r          store.MemoryPendingRow
 			scopeStr   string
 			payload    string
+			origin     sql.NullString
 			srcSession sql.NullString
 			srcRun     sql.NullString
 			createdNs  int64
 			drainedNs  sql.NullInt64
 		)
-		if err := rows.Scan(&r.ID, &r.TenantID, &scopeStr, &r.ScopeID, &payload, &srcSession, &srcRun, &createdNs, &drainedNs); err != nil {
+		if err := rows.Scan(&r.ID, &r.TenantID, &scopeStr, &r.ScopeID, &payload, &origin, &srcSession, &srcRun, &createdNs, &drainedNs); err != nil {
 			return nil, err
 		}
 		r.Scope = store.MemoryScope(scopeStr)
 		r.Payload = json.RawMessage(payload)
+		r.Origin = origin.String
 		r.SourceSessionID = srcSession.String
 		r.SourceRunID = srcRun.String
 		r.CreatedAt = time.Unix(0, createdNs)
@@ -4763,6 +4771,45 @@ func (s *Store) MemoryPendingDrain(ctx context.Context, tenantID string, scope s
 		out = append(out, r)
 	}
 	return out, rows.Err()
+}
+
+// MemoryPendingGet is a point lookup by id within (tenant, scope, scopeID).
+// Those three ARE the authorization check — a foreign row is simply not found.
+// Deliberately no drained_at filter: the caller resolving provenance has already
+// drained the row it is asking about.
+func (s *Store) MemoryPendingGet(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, id string) (store.MemoryPendingRow, error) {
+	var (
+		r          store.MemoryPendingRow
+		scopeStr   string
+		payload    string
+		origin     sql.NullString
+		srcSession sql.NullString
+		srcRun     sql.NullString
+		createdNs  int64
+		drainedNs  sql.NullInt64
+	)
+	err := s.db.QueryRowContext(ctx,
+		`SELECT id, tenant_id, scope, scope_id, payload, origin, source_session_id, source_run_id, created_at, drained_at
+		 FROM memory_pending
+		 WHERE id = ? AND tenant_id = ? AND scope = ? AND scope_id = ?`,
+		id, tenantID, string(scope), scopeID,
+	).Scan(&r.ID, &r.TenantID, &scopeStr, &r.ScopeID, &payload, &origin, &srcSession, &srcRun, &createdNs, &drainedNs)
+	if errors.Is(err, sql.ErrNoRows) {
+		return store.MemoryPendingRow{}, &store.ErrNotFound{Kind: "memory_pending", ID: id}
+	}
+	if err != nil {
+		return store.MemoryPendingRow{}, err
+	}
+	r.Scope = store.MemoryScope(scopeStr)
+	r.Payload = json.RawMessage(payload)
+	r.Origin = origin.String
+	r.SourceSessionID = srcSession.String
+	r.SourceRunID = srcRun.String
+	r.CreatedAt = time.Unix(0, createdNs)
+	if drainedNs.Valid {
+		r.DrainedAt = time.Unix(0, drainedNs.Int64)
+	}
+	return r, nil
 }
 
 // MemoryPendingAck marks the given ids drained. `drained_at IS NULL` keeps it

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1739,6 +1739,19 @@ type Store interface {
 	// empty slice is a no-op.
 	MemoryPendingAck(ctx context.Context, tenantID string, scope MemoryScope, scopeID string, ids []string) error
 
+	// MemoryPendingGet is a point lookup by id, scoped to (tenant, scope,
+	// scopeID) — which IS the authorization check: a row belonging to another
+	// tenant or another target simply is not found, so a caller cannot resolve
+	// provenance it does not own (RFC BL P3).
+	//
+	// UNLIKE Drain it deliberately does NOT filter on drained_at. The consolidator
+	// resolves provenance while writing the facts it distilled from a row it has
+	// already drained, so excluding drained rows would make the lookup useless in
+	// the only case that uses it.
+	//
+	// Returns *ErrNotFound when no such row is visible to the caller.
+	MemoryPendingGet(ctx context.Context, tenantID string, scope MemoryScope, scopeID, id string) (MemoryPendingRow, error)
+
 	// MemoryCursorGet returns the consolidation cursor for a target. It is a
 	// GET-OR-DEFAULT: a target with no row yet returns a zero-watermark,
 	// unleased MemoryCursorRow (TenantID/Scope/ScopeID populated, everything
@@ -2875,16 +2888,35 @@ func (p MemoryProvenance) IsZero() bool {
 // row is retained for TTL sweeping, never re-drained). Payload is opaque to the
 // store (JSONB on Postgres, TEXT-encoded JSON on sqlite).
 type MemoryPendingRow struct {
-	ID              string
-	TenantID        string
-	Scope           MemoryScope
-	ScopeID         string
-	Payload         json.RawMessage
+	ID       string
+	TenantID string
+	Scope    MemoryScope
+	ScopeID  string
+	Payload  json.RawMessage
+	// Origin names WHAT enqueued this row, server-set at enqueue and never
+	// derived from a tool argument (RFC BL P3). It is the only way a fact
+	// consolidated from this row can record that it came from a compaction flush
+	// rather than a scheduled transcript pass — origin on the `memory` table is
+	// stamped from the WRITER's identity, which is `consolidator` either way.
+	//
+	// Empty on rows enqueued before the column existed; they are deliberately not
+	// backfilled to a guess, matching how `memory.origin` treats legacy rows.
+	Origin          string
 	SourceSessionID string
 	SourceRunID     string
 	CreatedAt       time.Time
 	DrainedAt       time.Time // zero = not yet drained
 }
+
+// Pending-queue origins. The taxonomy matches `memory.origin`; these are the two
+// values a producer can be, and both are set by the server at enqueue.
+const (
+	// PendingOriginAgentExplicit — an agent called `Memory op=add infer=true`.
+	PendingOriginAgentExplicit = "agent_explicit"
+	// PendingOriginCompaction — a compaction banked the span it was about to
+	// discard (RFC BL P3).
+	PendingOriginCompaction = "compaction"
+)
 
 // MemoryCursorRow is the per-target consolidation watermark + lease (RFC BL
 // P2). The composite watermark (WatermarkCompletedAt, WatermarkSessionID)

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -153,6 +153,7 @@ func Run(t *testing.T, factory Factory) {
 		{"MemorySupersedeIsIdempotent", testMemorySupersedeIsIdempotent},
 		{"MemorySupersedeRevivedByWrite", testMemorySupersedeRevivedByWrite},
 		{"MemoryPendingEnqueueDrainAck", testMemoryPendingEnqueueDrainAck},
+		{"MemoryPendingOriginRoundTripsAndIsScoped", testMemoryPendingOriginRoundTripsAndIsScoped},
 		{"MemoryCursorGetDefault", testMemoryCursorGetDefault},
 		{"MemoryCursorLeaseCAS", testMemoryCursorLeaseCAS},
 		{"MemoryCursorAdvanceMonotonicAndOwner", testMemoryCursorAdvanceMonotonicAndOwner},
@@ -10533,5 +10534,105 @@ func testMemoryLegacyTenantStatsOnlyMixed(t *testing.T, s store.Store) {
 	}
 	if legacy2 != legacy {
 		t.Errorf("legacyRows went %d → %d after adding a global row; global must not count", legacy, legacy2)
+	}
+}
+
+// ─── Pending-queue origin (RFC BL P3) ────────────────────────────────────────
+
+// testMemoryPendingOriginRoundTripsAndIsScoped: the producer attribution has to
+// survive enqueue→drain→get on BOTH tiers, and the point lookup's
+// (tenant, scope, scope_id) tuple has to BE the authorization check.
+//
+// The lookup deliberately does not filter drained_at, because the only caller —
+// a consolidator resolving provenance for facts it distilled — asks about a row
+// it has already drained. A drained-row filter would make it useless exactly
+// when it is used, which is the kind of thing that passes a naive test.
+func testMemoryPendingOriginRoundTripsAndIsScoped(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	const (
+		tenant  = "acme"
+		scopeID = "u1"
+	)
+	scope := store.MemoryScopeUser
+
+	if err := s.MemoryPendingEnqueue(ctx, store.MemoryPendingRow{
+		ID: "mp_compaction", TenantID: tenant, Scope: scope, ScopeID: scopeID,
+		Payload: json.RawMessage(`{"messages":[]}`),
+		Origin:  store.PendingOriginCompaction, SourceRunID: "run_1",
+	}); err != nil {
+		t.Fatalf("enqueue compaction row: %v", err)
+	}
+	if err := s.MemoryPendingEnqueue(ctx, store.MemoryPendingRow{
+		ID: "mp_explicit", TenantID: tenant, Scope: scope, ScopeID: scopeID,
+		Payload: json.RawMessage(`{"messages":[]}`),
+		Origin:  store.PendingOriginAgentExplicit,
+	}); err != nil {
+		t.Fatalf("enqueue explicit row: %v", err)
+	}
+	// A row with NO origin: legacy rows predate the column and must stay readable
+	// rather than being coerced to a guess.
+	if err := s.MemoryPendingEnqueue(ctx, store.MemoryPendingRow{
+		ID: "mp_legacy", TenantID: tenant, Scope: scope, ScopeID: scopeID,
+		Payload: json.RawMessage(`{"messages":[]}`),
+	}); err != nil {
+		t.Fatalf("enqueue legacy row: %v", err)
+	}
+
+	// Drain surfaces origin, so the consolidator can see what produced each item.
+	drained, err := s.MemoryPendingDrain(ctx, tenant, scope, scopeID, 10)
+	if err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	got := map[string]string{}
+	for _, r := range drained {
+		got[r.ID] = r.Origin
+	}
+	if got["mp_compaction"] != store.PendingOriginCompaction {
+		t.Errorf("drained origin = %q, want %q", got["mp_compaction"], store.PendingOriginCompaction)
+	}
+	if got["mp_explicit"] != store.PendingOriginAgentExplicit {
+		t.Errorf("drained origin = %q, want %q", got["mp_explicit"], store.PendingOriginAgentExplicit)
+	}
+	if got["mp_legacy"] != "" {
+		t.Errorf("legacy row origin = %q, want empty (not backfilled to a guess)", got["mp_legacy"])
+	}
+
+	// Get resolves it by id within the target.
+	row, err := s.MemoryPendingGet(ctx, tenant, scope, scopeID, "mp_compaction")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if row.Origin != store.PendingOriginCompaction || row.SourceRunID != "run_1" {
+		t.Errorf("get returned origin=%q run=%q, want %q/run_1", row.Origin, row.SourceRunID, store.PendingOriginCompaction)
+	}
+
+	// ...and STILL resolves it after the row is acked/drained, which is the only
+	// state the real caller ever sees it in.
+	if err := s.MemoryPendingAck(ctx, tenant, scope, scopeID, []string{"mp_compaction"}); err != nil {
+		t.Fatalf("ack: %v", err)
+	}
+	if row, err = s.MemoryPendingGet(ctx, tenant, scope, scopeID, "mp_compaction"); err != nil {
+		t.Fatalf("get after ack: %v — a drained_at filter would break the only real use", err)
+	}
+	if row.DrainedAt.IsZero() {
+		t.Error("get after ack reports DrainedAt zero; the ack did not land or is not returned")
+	}
+
+	// The scoping tuple IS the authorization check: each axis alone hides the row.
+	for _, bad := range []struct {
+		name                string
+		tenant, scopeID, id string
+		scope               store.MemoryScope
+	}{
+		{"foreign tenant", "evil", scopeID, "mp_compaction", scope},
+		{"foreign scope_id", tenant, "someone-else", "mp_compaction", scope},
+		{"foreign scope", tenant, scopeID, "mp_compaction", store.MemoryScopeAgent},
+		{"unknown id", tenant, scopeID, "mp_does-not-exist", scope},
+	} {
+		_, err := s.MemoryPendingGet(ctx, bad.tenant, bad.scope, bad.scopeID, bad.id)
+		var nf *store.ErrNotFound
+		if !errors.As(err, &nf) {
+			t.Errorf("%s: got err %v, want *ErrNotFound — the lookup tuple must be the authz check", bad.name, err)
+		}
 	}
 }

--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -233,7 +233,9 @@ const memoryInputSchema = `{
     "completed_at":  {"type": "string", "description": "cursor_advance: the watermark timestamp (RFC3339), copied verbatim from the cursor_scan row you consolidated. With session_id it forms the composite watermark; the watermark only ever moves forward, and the server refuses a timestamp that does not match that chat's real finish time."},
     "session_id":    {"type": "string", "description": "cursor_advance: the watermark session id, copied verbatim from the same cursor_scan row as completed_at (required — the pair travels together). Must be a real, finished chat belonging to this memory target."},
     "ids":           {"type": "array", "description": "pending_ack: the pending-row ids to mark drained (as returned by pending_drain).", "items": {"type": "string"}},
-    "provenance":    {"type": "object", "description": "set-only: where this fact came from, recorded alongside the row. class is a short label for the kind of fact (e.g. preference, fact, decision, correction); source_session_id / source_run_id name the chat and run it was distilled from (relay them from pending_drain or the transcript you read). Descriptive only — it never changes what the write can reach. The writer identity is stamped server-side.", "properties": {"class": {"type": "string"}, "source_session_id": {"type": "string"}, "source_run_id": {"type": "string"}}, "additionalProperties": false}
+    "provenance":    {"type": "object", "description": "set-only: where this fact came from, recorded alongside the row. class is a short label for the kind of fact (e.g. preference, fact, decision, correction); source_session_id / source_run_id name the chat and run it was distilled from (relay them from pending_drain or the transcript you read). Descriptive only — it never changes what the write can reach. The writer identity is stamped server-side.", "properties": {"class": {"type": "string"}, "source_session_id": {"type": "string"}, "source_run_id": {"type": "string"}}, "additionalProperties": false},
+    "from_pending":  {"type": "string", "description": "set-only: the id of a pending item you drained, so this fact records what produced it. Pass the id and the server fills in the origin and source ids from that row — you cannot set those yourself. Unknown or unowned ids are ignored and the write still succeeds. Prefer this over filling source_session_id / source_run_id by hand when the fact came from a drained item."},
+    "include_provenance": {"type": "boolean", "description": "get-only: also return where the fact came from, and whether that origin is still readable (origin_available). A false origin_available means the chat has since been deleted — the fact is still valid, you just cannot go re-read its source."}
   },
   "required": ["op","scope"],
   "additionalProperties": false
@@ -306,6 +308,22 @@ type memoryInput struct {
 	// Only class / source_session_id / source_run_id are model-supplied; the
 	// origin is stamped server-side (see provenanceForSet).
 	Provenance *memoryProvenanceInput `json:"provenance,omitempty"`
+	// FromPending attributes this write to a pending-queue row the caller
+	// drained (RFC BL P3). The model supplies a POINTER; the server supplies the
+	// VALUES — origin, source_session_id and source_run_id are read off that row,
+	// which is why `origin` can stay unforgeable while still recording that a
+	// fact came from a compaction flush rather than a scheduled pass.
+	//
+	// The id is resolved within the caller's own (tenant, scope, scope_id), so an
+	// unowned row is not found. A miss is IGNORED, not refused: a stale reference
+	// must not fail an otherwise-correct write, and refusing would turn the field
+	// into a probe for which ids exist. It grants nothing — the caller was
+	// already authorized to write this key.
+	FromPending string `json:"from_pending,omitempty"`
+	// IncludeProvenance asks `get` to also return where the fact came from, plus
+	// whether that origin is still inspectable (RFC BL P3). Opt-in: it costs a
+	// second read, and the default output stays byte-identical.
+	IncludeProvenance bool `json:"include_provenance,omitempty"`
 }
 
 // memoryProvenanceInput is the model-supplied half of store.MemoryProvenance.
@@ -350,6 +368,39 @@ func provenanceForSet(ctx context.Context, in memoryInput) store.MemoryProvenanc
 	}
 	if tools.RunID(ctx) != "" && tools.MemoryPolicy(ctx).Consolidation {
 		prov.Origin = memoryOriginConsolidator
+	}
+	return prov
+}
+
+// resolveFromPending overlays server-authoritative provenance from the pending
+// row `in.FromPending` names (RFC BL P3), leaving `prov` untouched when the field
+// is absent or the row is not visible to this caller.
+//
+// The lookup's (tenant, scope, scopeID) tuple is the authorization check, so a
+// foreign row is simply not found. A miss returns prov UNCHANGED and no error:
+// the write is legal either way, and distinguishing "no such row" from "not
+// yours" would leak which ids exist.
+//
+// What it overrides and what it does not: the pending row's origin and source ids
+// WIN over the model's block, because that is the whole point — a server-recorded
+// producer beats a model-asserted one. Class is untouched; it is the model's
+// judgement about the fact, not a fact about where the fact came from.
+func (m *Memory) resolveFromPending(ctx context.Context, scope store.MemoryScope, scopeID string, in memoryInput, prov store.MemoryProvenance) store.MemoryProvenance {
+	if in.FromPending == "" || m.Store == nil {
+		return prov
+	}
+	row, err := m.Store.MemoryPendingGet(ctx, tools.RunIdentity(ctx).TenantID, scope, scopeID, in.FromPending)
+	if err != nil {
+		return prov
+	}
+	if row.Origin != "" {
+		prov.Origin = row.Origin
+	}
+	if row.SourceSessionID != "" {
+		prov.SourceSessionID = row.SourceSessionID
+	}
+	if row.SourceRunID != "" {
+		prov.SourceRunID = row.SourceRunID
 	}
 	return prov
 }
@@ -863,10 +914,80 @@ func (m *Memory) execGet(ctx context.Context, scope store.MemoryScope, scopeID s
 		}
 		return errResult(fmt.Sprintf("get: %s", err)), nil
 	}
-	return okJSON(map[string]any{
+	out := map[string]any{
 		"value":      entry.Value,
 		"expires_at": expiresAtRFC3339(entry.ExpiresAt),
-	})
+	}
+	if in.IncludeProvenance {
+		out["provenance"] = m.provenanceView(ctx, scope, scopeID, in.Key)
+	}
+	return okJSON(out)
+}
+
+// provenanceView renders a fact's recorded origin plus whether that origin is
+// STILL inspectable (RFC BL P3). Returns nil when the row carries no provenance,
+// so a caller can tell "unattributed" from "attributed to something gone".
+//
+// origin_available answers "can I go read the conversation this came from". It is
+// resolved live rather than stored, because a stored flag would be wrong the
+// moment the retention sweeper next ran and would then need its own
+// reconciliation — the classic cache-invalidation trap.
+//
+// The recorded ids are returned VERBATIM whether or not they resolve. A dead
+// citation is still the honest record of where the fact came from, and it is what
+// an audit needs after the chat is gone. Nothing here rewrites or clears them,
+// and nothing anywhere prunes a fact for having an unresolvable origin: RFC BM
+// retention deletes chats on a clock, so origin links are EXPECTED to go dead,
+// and pruning on that would make retention silently destroy memory.
+func (m *Memory) provenanceView(ctx context.Context, scope store.MemoryScope, scopeID, key string) map[string]any {
+	if m.Store == nil {
+		return nil
+	}
+	tenant := tools.RunIdentity(ctx).TenantID
+	prov, err := m.Store.MemoryProvenanceGet(ctx, tenant, scope, scopeID, key)
+	if err != nil || prov.IsZero() {
+		return nil
+	}
+	out := map[string]any{}
+	if prov.Origin != "" {
+		out["origin"] = prov.Origin
+	}
+	if prov.Class != "" {
+		out["class"] = prov.Class
+	}
+	if prov.SourceSessionID != "" {
+		out["source_session_id"] = prov.SourceSessionID
+	}
+	if prov.SourceRunID != "" {
+		out["source_run_id"] = prov.SourceRunID
+	}
+	if prov.SourceSessionID != "" || prov.SourceRunID != "" {
+		out["origin_available"] = m.originAvailable(ctx, tenant, prov)
+	}
+	return out
+}
+
+// originAvailable reports whether the conversation a fact was distilled from can
+// still be read, checking the session first and falling back to the run (today's
+// `add` path records only a run id — RunIdentity carries no session id).
+//
+// Both arms compare the fetched row's tenant to the caller's. The ids on a
+// pre-P3 fact are model-supplied, so without that comparison this would answer
+// "does id X exist" for an arbitrary id — a cross-tenant existence oracle. With
+// it, the question collapses to "does this id exist in MY tenant", which leaks
+// nothing the caller could not already determine.
+func (m *Memory) originAvailable(ctx context.Context, tenant string, prov store.MemoryProvenance) bool {
+	if id := prov.SourceSessionID; id != "" {
+		if sess, err := m.Store.GetSession(ctx, id); err == nil && sess.TenantID == tenant {
+			return true
+		}
+	}
+	if id := prov.SourceRunID; id != "" {
+		if run, err := m.Store.GetRun(ctx, id); err == nil && run.TenantID == tenant {
+			return true
+		}
+	}
+	return false
 }
 
 // coreBlockKeyPrefix is the reserved KV namespace for RFC BL P1 core memory
@@ -967,7 +1088,7 @@ func (m *Memory) execSet(ctx context.Context, scope store.MemoryScope, scopeID s
 		TTL:        ttl,
 		Embed:      in.Embed,
 		EmbedText:  in.EmbedText,
-		Provenance: provenanceForSet(ctx, in),
+		Provenance: m.resolveFromPending(ctx, scope, scopeID, in, provenanceForSet(ctx, in)),
 	})
 	if err != nil {
 		if errors.Is(err, store.ErrEmbedderNotConfigured) || errors.Is(err, store.ErrVectorUnsupported) {
@@ -1602,8 +1723,14 @@ func (m *Memory) execPendingDrain(ctx context.Context, scope store.MemoryScope, 
 	items := make([]map[string]any, 0, len(rows))
 	for _, r := range rows {
 		items = append(items, map[string]any{
-			"id":                r.ID,
-			"payload":           json.RawMessage(r.Payload),
+			"id":      r.ID,
+			"payload": json.RawMessage(r.Payload),
+			// origin is what produced this item (agent_explicit | compaction),
+			// server-recorded at enqueue. Surfaced so a pass can see what it is
+			// holding; relaying the row's `id` back on `set` as `from_pending` is
+			// what actually attributes the resulting fact, since the model cannot
+			// author origin itself. Empty on rows enqueued before the column.
+			"origin":            r.Origin,
 			"source_session_id": r.SourceSessionID,
 			"source_run_id":     r.SourceRunID,
 			"created_at":        r.CreatedAt.UTC().Format(time.RFC3339Nano),

--- a/internal/tools/builtin/memory_provenance_test.go
+++ b/internal/tools/builtin/memory_provenance_test.go
@@ -214,3 +214,198 @@ func TestMemoryProvenanceGet_SupersededRowIsOpaque(t *testing.T) {
 		t.Error("MemoryProvenanceGet returned a superseded row; want ErrNotFound")
 	}
 }
+
+// enqueuePending seeds a pending-queue row for the fixture's target
+// (tenant "", scope agent, scope_id "qa-agent") with a server-set origin.
+func enqueuePending(t *testing.T, tool *Memory, id, origin, sessionID, runID string) {
+	t.Helper()
+	if err := tool.Store.MemoryPendingEnqueue(context.Background(), store.MemoryPendingRow{
+		ID: id, TenantID: "", Scope: store.MemoryScopeAgent, ScopeID: "qa-agent",
+		Payload: json.RawMessage(`{"messages":[]}`),
+		Origin:  origin, SourceSessionID: sessionID, SourceRunID: runID,
+	}); err != nil {
+		t.Fatalf("enqueue pending %s: %v", id, err)
+	}
+}
+
+// TestMemorySet_FromPendingResolvesProvenanceServerSide is the RFC BL P3 write
+// path: the model supplies a POINTER to a row it drained, and the SERVER supplies
+// the values. That is what lets `origin` stay unforgeable while still recording
+// that a fact came from a compaction flush rather than a scheduled pass —
+// provenanceForSet alone would stamp `consolidator` for both.
+//
+// Fails-before: without resolveFromPending the row lands origin=consolidator and
+// no source ids, indistinguishable from any other consolidated fact.
+func TestMemorySet_FromPendingResolvesProvenanceServerSide(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t)
+	defer cleanup()
+	gctx := grantedConsolidationCtx(ctx)
+
+	enqueuePending(t, tool, "mp_1", store.PendingOriginCompaction, "sess-compact", "run-compact")
+
+	in := `{"op":"set","scope":"agent","key":"fact/from-compaction","value":"user runs ROCm",
+	        "from_pending":"mp_1"}`
+	if res, _ := tool.Execute(gctx, json.RawMessage(in)); res.IsError {
+		t.Fatalf("set from_pending: %s", res.Text)
+	}
+
+	got := provenanceOf(t, tool, "fact/from-compaction")
+	want := store.MemoryProvenance{
+		Origin:          store.PendingOriginCompaction,
+		SourceSessionID: "sess-compact",
+		SourceRunID:     "run-compact",
+	}
+	if got != want {
+		t.Errorf("stored provenance = %+v, want %+v — the pending row's server-recorded origin must win over the writer-identity stamp", got, want)
+	}
+}
+
+// TestMemorySet_FromPendingUnownedIsIgnoredAndIndistinguishable is the forgery
+// arm. A pending id the caller does not own must neither attribute the write nor
+// refuse it — and crucially, an unowned id and a nonexistent one must be
+// INDISTINGUISHABLE, or `from_pending` becomes a probe for which ids exist.
+//
+// Ignoring rather than refusing is deliberate: a stale reference must not fail an
+// otherwise-correct write, and the field grants nothing anyway — the caller was
+// already authorized to write this key.
+func TestMemorySet_FromPendingUnownedIsIgnoredAndIndistinguishable(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t)
+	defer cleanup()
+	gctx := grantedConsolidationCtx(ctx)
+
+	// A real row belonging to a DIFFERENT target (another scope_id in the same
+	// tenant) — the id exists, but not for this caller.
+	if err := tool.Store.MemoryPendingEnqueue(context.Background(), store.MemoryPendingRow{
+		ID: "mp_foreign", TenantID: "", Scope: store.MemoryScopeAgent, ScopeID: "someone-else",
+		Payload: json.RawMessage(`{"messages":[]}`),
+		Origin:  store.PendingOriginCompaction, SourceRunID: "run-theirs",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	foreign, _ := tool.Execute(gctx, json.RawMessage(
+		`{"op":"set","scope":"agent","key":"fact/a","value":"x","from_pending":"mp_foreign"}`))
+	unknown, _ := tool.Execute(gctx, json.RawMessage(
+		`{"op":"set","scope":"agent","key":"fact/b","value":"x","from_pending":"mp_nope"}`))
+
+	if foreign.IsError || unknown.IsError {
+		t.Fatalf("an unresolvable from_pending must not fail the write: foreign=%q unknown=%q", foreign.Text, unknown.Text)
+	}
+	if foreign.Text != unknown.Text {
+		t.Errorf("an unowned id and an unknown id produced DIFFERENT responses:\n foreign=%s\n unknown=%s\nthat makes from_pending an existence probe", foreign.Text, unknown.Text)
+	}
+	// Neither write borrowed the foreign row's provenance.
+	for _, key := range []string{"fact/a", "fact/b"} {
+		got := provenanceOf(t, tool, key)
+		if got.SourceRunID == "run-theirs" || got.Origin == store.PendingOriginCompaction {
+			t.Errorf("%s borrowed provenance from a row the caller does not own: %+v", key, got)
+		}
+		// It still gets the ordinary identity-derived stamp — the field is not a
+		// gate, so the write proceeds exactly as it would without it.
+		if got.Origin != "consolidator" {
+			t.Errorf("%s origin = %q, want the ordinary consolidator stamp", key, got.Origin)
+		}
+	}
+}
+
+// TestMemoryGet_OriginAvailableFalseWhenChatDeleted is the Decision 4 invariant,
+// and the one most likely to be implemented wrongly.
+//
+// RFC BM retention deletes chats on a clock, so a fact's origin link is EXPECTED
+// to go dead. When it does, the fact must still be returned, must still carry its
+// recorded ids verbatim, and must simply report origin_available=false. Anything
+// that pruned or blanked the fact here would let retention silently destroy
+// memory — deleting a 3-day-old chat would delete what was learned from it.
+func TestMemoryGet_OriginAvailableFalseWhenChatDeleted(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t)
+	defer cleanup()
+	gctx := grantedConsolidationCtx(ctx)
+
+	// A real session in the fixture's tenant (""), so the link resolves at first.
+	sess, err := tool.Store.CreateSession(context.Background(), "", "qa-agent", "u1")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	sessID := sess.ID
+	enqueuePending(t, tool, "mp_live", store.PendingOriginCompaction, sessID, "")
+	if res, _ := tool.Execute(gctx, json.RawMessage(
+		`{"op":"set","scope":"agent","key":"fact/sourced","value":"v","from_pending":"mp_live"}`)); res.IsError {
+		t.Fatalf("set: %s", res.Text)
+	}
+
+	read := func() map[string]any {
+		res, _ := tool.Execute(gctx, json.RawMessage(
+			`{"op":"get","scope":"agent","key":"fact/sourced","include_provenance":true}`))
+		if res.IsError {
+			t.Fatalf("get: %s", res.Text)
+		}
+		out := decodeResult(t, res.Text)
+		prov, ok := out["provenance"].(map[string]any)
+		if !ok {
+			t.Fatalf("get returned no provenance block: %v", out)
+		}
+		return prov
+	}
+
+	prov := read()
+	if prov["origin_available"] != true {
+		t.Errorf("origin_available = %v with the session present, want true", prov["origin_available"])
+	}
+	if prov["source_session_id"] != sessID || prov["origin"] != store.PendingOriginCompaction {
+		t.Errorf("provenance = %v, want session %q + compaction origin", prov, sessID)
+	}
+
+	// Retention deletes the chat.
+	if err := tool.Store.DeleteSessionCascade(context.Background(), sessID); err != nil {
+		t.Fatalf("delete session: %v", err)
+	}
+
+	prov = read()
+	if prov["origin_available"] != false {
+		t.Errorf("origin_available = %v after the chat was deleted, want false", prov["origin_available"])
+	}
+	// The ids are NOT rewritten or cleared — a dead citation is still the honest
+	// record of where the fact came from, and it is what an audit needs.
+	if prov["source_session_id"] != sessID {
+		t.Errorf("source_session_id = %v, want the id retained verbatim (%q)", prov["source_session_id"], sessID)
+	}
+	// And the fact itself survives.
+	res, _ := tool.Execute(gctx, json.RawMessage(`{"op":"get","scope":"agent","key":"fact/sourced"}`))
+	if res.IsError {
+		t.Fatalf("the fact did not survive its origin being deleted: %s", res.Text)
+	}
+	if v, _ := decodeResult(t, res.Text)["value"]; v == nil {
+		t.Error("the fact's value was blanked when its origin went away")
+	}
+}
+
+// TestMemoryAdd_StampsAgentExplicitOrigin covers the real `add` path, which the
+// other tests in this file bypass by seeding pending rows directly.
+//
+// That gap was found by fail-before verification: removing the stamp from
+// inprocess.Add broke NOTHING, because every other test enqueued through the
+// store. An origin the server sets is only trustworthy if something asserts the
+// server actually sets it on the path an agent uses.
+func TestMemoryAdd_StampsAgentExplicitOrigin(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t)
+	defer cleanup()
+	gctx := grantedConsolidationCtx(ctx)
+
+	in := `{"op":"add","scope":"agent","infer":true,
+	        "messages":[{"role":"user","content":"I use ROCm on an AMD card"}]}`
+	if res, _ := tool.Execute(gctx, json.RawMessage(in)); res.IsError {
+		t.Fatalf("add: %s", res.Text)
+	}
+
+	rows, err := tool.Store.MemoryPendingDrain(context.Background(), "", store.MemoryScopeAgent, "qa-agent", 10)
+	if err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("drain returned %d rows, want 1", len(rows))
+	}
+	if rows[0].Origin != store.PendingOriginAgentExplicit {
+		t.Errorf("enqueued origin = %q, want %q — an agent reaching `add` IS an explicit agent write, and the value must come from the server rather than the tool input",
+			rows[0].Origin, store.PendingOriginAgentExplicit)
+	}
+}


### PR DESCRIPTION
Second of four PRs for the RFC BL P3 compaction→memory bridge. Plan: `/loomcycle/docs/plans/rfc-bl-p3-plan` (Decisions 2 + 4, both confirmed). The bridge lands next; this makes somewhere for it to record itself, and makes what it records readable.

## The problem

`origin` on the `memory` table is stamped from the **writer's** identity — and the writer is the consolidator whether the material came from a scheduled transcript pass or a compaction flush. So a consolidated fact could not say where it came from. And `memory_pending` had no `origin` at all: shipped P2 diverged from the RFC's §3.2 shape, which listed one.

## The model supplies a pointer, the server supplies the value

`memory_pending` gains an additive `origin` (migration `0063` + the sqlite `ALTER`; nullable, **not** backfilled — guessing a producer would make the column lie on exactly the rows an operator is most likely auditing). Enqueue stamps it server-side; `pending_drain` surfaces it. `Memory op=set` gains `from_pending`, whose *only* effect is to let the server read origin + source ids **off that row**.

That keeps `origin` unforgeable, which P2 locked deliberately — a forgeable one lets any agent label its own writes machine-distilled. A pending id is a reference the server checks, not a claim it believes, and `MemoryPendingGet`'s `(tenant, scope, scope_id)` tuple **is** the authorization check: a foreign row simply isn't found.

An unresolvable id is **ignored, not refused** — a stale reference must not fail an otherwise-correct write, the field grants nothing (the caller could already write that key), and refusing would make it a probe for which ids exist. A test asserts the unowned and unknown responses are byte-identical.

## Three things found while building this

**`MemoryPendingGet` must NOT filter `drained_at`.** Its only caller resolves provenance for facts distilled from a row it has *already* drained — so a drained-row filter makes the lookup useless in the one case that uses it, and would pass a naive test. The contract arm acks a row and re-reads it.

**`Memory op=get` did not expose provenance at all** — `MemoryProvenanceGet` had no caller outside tests. So "reads resolve liveness" first meant exposing provenance on reads, behind an opt-in `include_provenance` so the default output stays byte-identical.

**Fail-before verification found a real gap in my own tests.** Deleting the `agent_explicit` stamp from `inprocess.Add` broke *nothing*, because every test seeded pending rows through the store and bypassed the `add` path. A server-set origin is only trustworthy if something asserts the server sets it on the path an agent actually uses, so `TestMemoryAdd_StampsAgentExplicitOrigin` now drives the tool.

## Liveness — and the invariant that matters most

`origin_available` answers "can I still go read the conversation this came from", resolved **live** rather than stored: a stored flag would be wrong the moment the retention sweeper next ran, and would then need its own reconciliation.

The recorded ids are returned **verbatim** whether or not they resolve, and **nothing prunes a fact for having a dead origin.** RFC BM retention deletes chats on a clock — 3 days for internal ones — so origin links are *expected* to go dead. Pruning on that would let retention silently destroy the memory learned from a chat, inverting the point of consolidation. A dead citation is still the honest record of where a fact came from, and it's what an audit needs after the chat is gone.

Liveness is **tenant-gated** by comparing the fetched session/run's tenant to the caller's. Pre-P3 facts carry model-supplied ids, so without that comparison this would answer "does id X exist" for an arbitrary id — a cross-tenant existence oracle. With it, the question is "does this id exist in MY tenant", which leaks nothing.

`recall` is deliberately untouched: provenance-per-row would be an N+1 on the hot retrieval path, and the auditing question this serves is a `get`.

## What was tested

`go test ./...` clean · Postgres contract verified against the real `make pg-up` fixture (migration 0063 applies cleanly).

A **store-contract arm** so both tiers agree: round-trip, the no-backfill posture for legacy rows, get-after-ack, and all four ways the scoping tuple hides a row.

Four tool tests, **all verified fail-before**:

| reverted | test says |
|---|---|
| the `add` stamp | `enqueued origin = "" , want "agent_explicit"` |
| `resolveFromPending` | `stored provenance = {Origin:consolidator …}, want {Origin:compaction …}` |
| add a `drained_at` filter to `MemoryPendingGet` | `get after ack: … — a drained_at filter would break the only real use` |
| — | plus the forgery/indistinguishability arm and the delete-the-chat invariant |

🤖 Generated with [Claude Code](https://claude.com/claude-code)