### PR TITLE
feat(deploy): self-contained cloud Docker Compose stack (cloud-deployment/)

### DIFF
--- a/cloud-deployment/.env.insecure.example
+++ b/cloud-deployment/.env.insecure.example
@@ -1,0 +1,67 @@
+# .env.insecure — NON-SECRET operational settings (safe to read/commit/review).
+# Copy to `.env.insecure` and adjust. Loaded (a) into loomcycle/migrate via
+# `env_file:` and (b) for `${VAR}` compose interpolation via `--env-file`.
+# NEVER put a secret here — those go in .env.secure.
+
+# ── core ──────────────────────────────────────────────────────────────────────
+LOOMCYCLE_LISTEN_ADDR=0.0.0.0:8787
+LOOMCYCLE_CONFIG_DIR=/config
+LOOMCYCLE_DATA_DIR=/data
+LOOMCYCLE_PRESETS=base,document-agent,chat,agent-teams,team-examples,sandbox,doc-colorizer,memory
+
+# Public identity behind Cloudflare (the tunnel hostname, NOT the internal addr).
+# LOOMCYCLE_PUBLIC_CONFIG=1 lets the landing page's /api/config read GET /v1/config.
+LOOMCYCLE_PUBLIC_URL=https://app.loomcycle.cloud
+LOOMCYCLE_PUBLIC_CONFIG=1
+
+# ── storage (external secrets — the DSNs — live in .env.secure) ────────────────
+LOOMCYCLE_STORAGE_BACKEND=postgres
+LOOMCYCLE_PG_AUTOMIGRATE=0          # the loomcycle-migrate one-shot handles this
+LOOMCYCLE_PGVECTOR_ENABLED=1        # requires pgvector on the PG host (pg18 image has it)
+LOOMCYCLE_SQLMEM_ENABLED=1         # Documents / SQL Memory (needs the sqlmem DSN + CREATEROLE)
+LOOMCYCLE_PG_MAX_OPEN_CONNS=48
+LOOMCYCLE_PG_MIN_IDLE_CONNS=8
+
+# ── ops toggles ────────────────────────────────────────────────────────────────
+LOOMCYCLE_SCHEDULER_ENABLED=1
+LOOMCYCLE_WEBHOOKS_ENABLED=1
+LOOMCYCLE_CODE_AGENTS_ENABLED=1    # REQUIRED by the doc-colorizer + memory bundles (code-js)
+LOOMCYCLE_METRICS_ENABLED=1
+LOOMCYCLE_METRICS_COLLECT_SYSTEM=1
+LOOMCYCLE_METRICS_RETENTION_DAYS=7
+LOOMCYCLE_AUDIT_LOG_PATH=/data/audit.log
+
+# ── code execution (Bashbox in-process + host fallback) ─────────────────────────
+# NOTE: the fallback commands only exist in the runtime container if you use the
+# `denngubsky/loomcycle-toolbox` image; the plain image is minimal. The `sandbox`
+# preset provides a full-toolchain sandbox regardless (see INSTALL.md).
+LOOMCYCLE_BASH_ENABLED=1
+LOOMCYCLE_BASHBOX_ENABLED=1
+LOOMCYCLE_BASHBOX_FALLBACK_ALLOWED_ENV=HOME
+LOOMCYCLE_BASHBOX_FALLBACK_COMMANDS=git,gh,curl,rsync,python3,pip3,go,gofmt,cargo,rustc,node,npm,npx,gcc,g++,cc,c++,clang,clang++,make,cmake,pkg-config
+
+# ── outbound HTTP policy ────────────────────────────────────────────────────────
+# `*` allows WebFetch/HTTP to any host — convenient but permissive on a PUBLIC box.
+# Tighten to a comma-separated allowlist for production.
+LOOMCYCLE_HTTP_HOST_ALLOWLIST=*
+
+# ── local inference (Ollama over Tailscale) ─────────────────────────────────────
+# Use the peer's RAW tailnet IP — MagicDNS is not available in the shared netns.
+# Find it with: docker compose exec tailscale tailscale status
+OLLAMA_BASE_URL=http://100.73.18.51:11434
+LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX=65535
+LOOMCYCLE_OLLAMA_LOCAL_NUM_GPU=99
+LOOMCYCLE_OLLAMA_DEBUG_THINK=0
+
+# ── retention sweeper (RFC BM; opt-in) ──────────────────────────────────────────
+LOOMCYCLE_RETENTION_ENABLED=1
+LOOMCYCLE_RETENTION_INTERVAL_MS=86400000
+LOOMCYCLE_RETENTION_EXPORT_DIR=/data/retention-exports
+LOOMCYCLE_RETENTION_CHATS_MODE=export+prune
+LOOMCYCLE_RETENTION_CHATS_MAX_AGE_MS=7776000000
+LOOMCYCLE_RETENTION_CHATS_INTERNAL_MAX_AGE_MS=259200000
+
+# ── sandbox sidecar (non-secret knobs; the shared token is in .env.secure) ───────
+SANDBOX_IMAGE=denngubsky/loomcycle-sandbox-session:latest
+SANDBOX_MAX_CPUS=2
+SANDBOX_MAX_MEM_MB=2048

--- a/cloud-deployment/.gitignore
+++ b/cloud-deployment/.gitignore
@@ -1,0 +1,15 @@
+# Only the *.example templates are committed — never the filled secret/config files.
+.env.secure
+.env.insecure
+
+# Runtime state + data (created on the host; never committed even if the deploy
+# directory lives inside a repo checkout).
+data/
+pgdata/
+work/
+ts-state/
+caddy-data/
+caddy-config/
+web/
+retention-exports/
+searxng/uwsgi.ini

--- a/cloud-deployment/Caddyfile
+++ b/cloud-deployment/Caddyfile
@@ -1,0 +1,31 @@
+# Caddy serves the static landing (cloud-web/ → /srv) and reproduces the two
+# Cloudflare Pages Functions the page calls, proxying them to the loomcycle
+# runtime. loomcycle shares the tailscale netns, so its address is tailscale:8787.
+
+:80 {
+	encode zstd gzip
+
+	# /api/health → loomcycle /healthz (always unauthenticated).
+	handle /api/health {
+		rewrite * /healthz
+		header Cache-Control "public, max-age=30, stale-while-revalidate=60"
+		reverse_proxy tailscale:8787
+	}
+
+	# /api/config → loomcycle GET /v1/config (public view; needs
+	# LOOMCYCLE_PUBLIC_CONFIG=1). Strip any inbound Authorization so we always get
+	# the public disclosure view, never a bearer error.
+	handle /api/config {
+		rewrite * /v1/config
+		header Cache-Control "public, max-age=60, stale-while-revalidate=300"
+		reverse_proxy tailscale:8787 {
+			header_up -Authorization
+		}
+	}
+
+	# Everything else: the static marketing site.
+	handle {
+		root * /srv
+		file_server
+	}
+}

--- a/cloud-deployment/INSTALL.md
+++ b/cloud-deployment/INSTALL.md
@@ -1,0 +1,181 @@
+# loomcycle cloud deployment — install runbook
+
+Target: **Ubuntu 25.04** (`cloud-home.local`), deploy directory
+`/home/denn/work/loomcycle-cloud/`. Everything runs in one Docker Compose stack;
+loomcycle is exposed at `app.loomcycle.cloud` and the landing page at
+`loomcycle.cloud`, both through a Cloudflare tunnel (no open host ports).
+
+---
+
+## Phase 0 — Host prerequisites
+
+```bash
+# Docker Engine + the compose plugin
+sudo apt-get update && sudo apt-get install -y docker.io docker-compose-v2 make
+sudo usermod -aG docker "$USER"     # log out/in so `docker` works without sudo
+ls /dev/net/tun                      # must exist (kernel-mode tailscale needs it)
+```
+
+You also need, ahead of time:
+- A **Tailscale** account with the local Ollama box already on the tailnet.
+- A **Cloudflare** account with the `loomcycle.cloud` zone.
+- At least one **LLM provider API key** (Anthropic/OpenAI/…), unless you route only
+  to the local Ollama.
+
+---
+
+## Phase 1 — Lay down the deploy directory
+
+Copy this `cloud-deployment/` directory to the host deploy path and create the
+runtime sub-directories:
+
+```bash
+mkdir -p /home/denn/work/loomcycle-cloud
+cp -r cloud-deployment/* cloud-deployment/.gitignore /home/denn/work/loomcycle-cloud/
+cd /home/denn/work/loomcycle-cloud
+
+mkdir -p data config work pgdata ts-state searxng web caddy-data caddy-config retention-exports
+# loomcycle + its migrate run as uid:gid 65532; give them their writable dirs.
+sudo chown -R 65532:65532 data work retention-exports
+```
+
+`config/loomcycle.yaml` (SearXNG wiring), `searxng/settings.yml`, `Caddyfile`, and
+`postgres/initdb.d/00-init.sql` came with the copy — leave them in place.
+
+---
+
+## Phase 2 — Landing page
+
+Copy the drafted static site into `web/` (Caddy serves it; the `functions/` dir is
+unused because Caddy reproduces those two proxies):
+
+```bash
+cp -r /path/to/loomcycle/cloud-web/* /home/denn/work/loomcycle-cloud/web/
+```
+
+---
+
+## Phase 3 — Tailscale auth key
+
+Tailscale **admin console → Settings → Keys → Generate auth key**: make it
+**reusable** and (recommended) **tagged** (e.g. `tag:cloud`). Copy the
+`tskey-auth-…` value into `TS_AUTHKEY` in `.env.secure` (Phase 5).
+
+Find the local Ollama's tailnet IP after the stack is up (`make` step) — or from
+any tailnet device: `tailscale status | grep -i ollama-host`. You'll put it in
+`OLLAMA_BASE_URL` as a **raw IP** (e.g. `http://100.73.18.51:11434`).
+
+---
+
+## Phase 4 — Cloudflare tunnel + DNS
+
+1. **Zero Trust → Networks → Tunnels → Create a tunnel** (type *Cloudflared*).
+   Copy the **tunnel token** (`eyJ…`) → `CLOUDFLARE_TUNNEL_TOKEN` in `.env.secure`.
+2. Add **two Public Hostnames** on that tunnel:
+
+   | Hostname | Service |
+   |---|---|
+   | `app.loomcycle.cloud` | `http://tailscale:8787` |
+   | `loomcycle.cloud`     | `http://landing:80` |
+
+   > ⚠️ **The app hostname points at `tailscale:8787`, NOT `loomcycle:8787`.**
+   > loomcycle shares the tailscale netns and has no DNS name of its own.
+
+3. Cloudflare auto-creates the proxied DNS records for the tunnel. (Optional but
+   recommended: add a **Cloudflare Access** application over `app.loomcycle.cloud`.)
+
+---
+
+## Phase 5 — Env files
+
+```bash
+cp .env.insecure.example .env.insecure
+cp .env.secure.example   .env.secure
+chmod 600 .env.secure
+```
+
+Edit **`.env.insecure`** (non-secret):
+- `OLLAMA_BASE_URL` → the Ollama tailnet **IP** (Phase 3).
+- `LOOMCYCLE_PUBLIC_URL=https://app.loomcycle.cloud` (already set).
+- Adjust presets / retention / GPU knobs to taste.
+
+Edit **`.env.secure`** (secrets — fill every `REPLACE_ME`):
+- Generate tokens: `openssl rand -hex 32` for `LOOMCYCLE_AUTH_TOKEN`,
+  `LOOMCYCLE_OPERATOR_TOKEN_PEPPER`, `SANDBOX_AUTH_TOKEN`, `SEARXNG_SECRET`.
+- `POSTGRES_PASSWORD` and the password embedded in **both**
+  `LOOMCYCLE_PG_DSN` + `LOOMCYCLE_SQLMEM_PG_DSN` **must match**.
+- `TS_AUTHKEY` (Phase 3), `CLOUDFLARE_TUNNEL_TOKEN` (Phase 4).
+- At least one provider key; `BRAVE_API_KEY` only if you want a paid search fallback.
+
+The DSN host is **`postgres`** (the compose service) — don't change it.
+
+---
+
+## Phase 6 — Bring it up
+
+```bash
+make config      # render + validate the merged compose (no secrets printed as values)
+make up
+make ps          # all services `running`/`healthy`; loomcycle-migrate `exited (0)`
+```
+
+`make` wraps `docker compose --env-file .env.insecure --env-file .env.secure …`.
+
+---
+
+## Phase 7 — Verify
+
+1. **Migrate**: `make logs S=loomcycle-migrate` → runs and exits 0.
+2. **Runtime**: `make logs S=loomcycle` → `listening on 0.0.0.0:8787`, presets
+   layered, **no** `permission denied to create role` and **no** pgvector refusal.
+3. **Tailnet**: `docker compose exec tailscale tailscale status` → connected;
+   `docker compose exec tailscale wget -qO- http://100.x.x.x:11434/api/tags` → Ollama models.
+4. **In-network**: `docker compose exec landing wget -qO- http://tailscale:8787/healthz` → ok;
+   SearXNG: `docker compose exec searxng wget -qO- http://localhost:8080/healthz` → ok.
+5. **Public**: `curl -s https://app.loomcycle.cloud/healthz` and
+   `curl -s https://loomcycle.cloud/api/health` (landing → live status strip). Then
+   browse `https://app.loomcycle.cloud/ui` and sign in with `LOOMCYCLE_AUTH_TOKEN`.
+6. **Functional**: run a `chat/medium` agent that uses WebSearch (proves SearXNG),
+   a `dev/sandbox` run (proves the builder sidecar via `mcp__sandbox__*`), and a
+   Document op (proves SQL Memory + pgvector).
+
+---
+
+## Upgrade
+
+Bump the image tags in `docker-compose.yaml` (keep `loomcycle` + `loomcycle-migrate`
+in lockstep), then `make pull && make up`. If the new version bumped the schema,
+`loomcycle-migrate` re-runs automatically on the next `up`.
+
+---
+
+## Durable sandbox workspaces (advanced, optional)
+
+The sandbox uses per-session tmpfs `/work` by default (nothing persists). Durable
+**named** workspaces (`sandbox_open {workspace:…}`) require the sidecar's
+`SANDBOX_WORKSPACE_ROOT` to be an **absolute host path bind-mounted into the
+sidecar at the identical path** (the sidecar drives the host Docker engine, so the
+path it creates must equal the path the host mounts). To enable, set in the
+`builder-sidecar` service:
+
+```yaml
+environment:
+  SANDBOX_WORKSPACE_ROOT: /home/denn/work/loomcycle-cloud/work
+volumes:
+  - ./work:/home/denn/work/loomcycle-cloud/work
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `loomcycle-migrate` exits 1, `connection refused` | Postgres not up yet, or the DSN password ≠ `POSTGRES_PASSWORD`. Check `make logs S=postgres`. |
+| runtime logs `sqlmem: … permission denied to create role` | The DSN role lacks `CREATEROLE`. The init makes `loomcycle` a superuser (has it); if you swapped to a non-super role, `ALTER ROLE loomcycle CREATEROLE;`. |
+| runtime refuses to start, pgvector missing | pgvector binaries absent — use the `pgvector/pgvector:pg18` image (it ships them); wipe `pgdata/` and re-init if the first migrate ran before pgvector existed. |
+| `app.loomcycle.cloud` → 502 / 1033 | The tunnel route must target `http://tailscale:8787` (not `loomcycle:…`); confirm `cloudflared` is `running` and the hostname exists in the dashboard. |
+| landing status strip grey / `/api/config` shows "not published" | `LOOMCYCLE_PUBLIC_CONFIG=1` must be set (it is by default); confirm Caddy can reach `tailscale:8787`. |
+| Ollama unreachable from loomcycle | Use the **raw tailnet IP** in `OLLAMA_BASE_URL` (MagicDNS is unavailable in the shared netns); confirm `tailscale status` shows the peer. |
+| `tailscale` unhealthy | Bad/expired `TS_AUTHKEY`, or `/dev/net/tun` missing; check `make logs S=tailscale`. |
+| Bashbox fallback commands (`git`/`go`/…) "not found" | The plain `denngubsky/loomcycle` image is minimal — either switch the `loomcycle` + `loomcycle-migrate` images to `denngubsky/loomcycle-toolbox:<same-tag>`, or rely on the `sandbox` preset (its session image has the full toolchain). |

--- a/cloud-deployment/Makefile
+++ b/cloud-deployment/Makefile
@@ -1,0 +1,24 @@
+# Wrapper so you never have to remember the two --env-file flags (compose needs
+# both files for `${VAR}` interpolation). Run from the deployment directory.
+ENVFILES := --env-file .env.insecure --env-file .env.secure
+COMPOSE  := docker compose $(ENVFILES)
+
+.PHONY: up down restart logs ps pull config migrate psql
+up:      ## start the whole stack
+	$(COMPOSE) up -d
+down:    ## stop + remove containers (volumes/data persist)
+	$(COMPOSE) down
+restart: ## restart all services
+	$(COMPOSE) restart
+logs:    ## follow logs (make logs S=loomcycle for one service)
+	$(COMPOSE) logs -f --tail=200 $(S)
+ps:      ## service status
+	$(COMPOSE) ps
+pull:    ## pull newer images
+	$(COMPOSE) pull
+config:  ## render + validate the merged compose
+	$(COMPOSE) config
+migrate: ## re-run the one-shot schema migration
+	$(COMPOSE) run --rm loomcycle-migrate
+psql:    ## open a psql shell on the main db
+	$(COMPOSE) exec postgres psql -U loomcycle -d loomcycle

--- a/cloud-deployment/README.md
+++ b/cloud-deployment/README.md
@@ -1,0 +1,88 @@
+# loomcycle — cloud deployment (self-contained Docker Compose)
+
+A single Docker Compose stack that runs **everything** loomcycle needs and exposes
+it publicly through Cloudflare — built for `cloud-home.local` (Ubuntu 25.04) but
+portable to any Docker host. Unlike `deploy/truenas/` (which depends on external
+TrueNAS apps for Postgres/SearXNG/Ollama), this bundles Postgres 18 + pgvector,
+SearXNG, the code-exec sandbox, a Tailscale egress sidecar, a Caddy landing
+server, and a Cloudflare tunnel — one `make up`.
+
+> **Step-by-step setup lives in [`INSTALL.md`](INSTALL.md).** This file is the map.
+
+## Architecture
+
+```
+Internet ─▶ Cloudflare edge ─▶ cloudflared ─┬─ app.loomcycle.cloud ─▶ tailscale:8787  (loomcycle UI/API)
+                                             └─ loomcycle.cloud      ─▶ landing:80      (Caddy → cloud-web/)
+
+compose network `loomnet`:
+  postgres(pg18+pgvector)   loomcycle-migrate(one-shot)   builder-sidecar(:9000)
+  searxng(:8080)            landing(caddy:80)             cloudflared
+  tailscale ◀── loomcycle (network_mode: service:tailscale) ──▶ Ollama @ 100.x:11434 (tailnet)
+```
+
+### Services
+
+| Service | Image | Role |
+|---|---|---|
+| `postgres` | `pgvector/pgvector:pg18` | Main store (`loomcycle`) + SQL-Memory aux (`loomcycle_sqlmem`). |
+| `loomcycle-migrate` | `denngubsky/loomcycle:1.38.0` | One-shot `migrate up` on the main db, then exits. |
+| `tailscale` | `tailscale/tailscale` | Kernel-mode egress to the tailnet; **owns the netns loomcycle shares**. |
+| `builder-sidecar` | `denngubsky/loomcycle-builder-docker:1.25.2` | Sandboxed code exec (`mcp__sandbox__*`) via the host Docker socket. |
+| `loomcycle` | `denngubsky/loomcycle:1.38.0` | The runtime. `network_mode: service:tailscale`. |
+| `searxng` | `searxng/searxng` | Keyless search backend (wired via `config/loomcycle.yaml`). |
+| `landing` | `caddy:2` | Serves `cloud-web/` + reproduces the page's `/api/health` + `/api/config` proxies. |
+| `cloudflared` | `cloudflare/cloudflared` | Outbound tunnel; routes managed in the Cloudflare dashboard (token method). |
+
+### The Tailscale netns wiring (important)
+
+`loomcycle` uses `network_mode: service:tailscale` so it can reach a local Ollama
+over the tailnet. Consequences baked into this compose:
+
+- **loomcycle has no compose DNS name of its own** — everything that dials it uses
+  **`http://tailscale:8787`** (the cloudflared dashboard route for
+  `app.loomcycle.cloud`, and Caddy's `/api/*` proxy).
+- loomcycle still reaches `postgres:5432`, `searxng:8080`, `builder-sidecar:9000`
+  by name (tailscale is a normal member of `loomnet`).
+- loomcycle reaches Ollama by **raw tailnet IP** (`OLLAMA_BASE_URL=http://100.x:11434`),
+  not MagicDNS. `TS_ACCEPT_DNS=false` keeps the netns DNS usable for service names.
+- loomcycle can't declare `ports:`; a local-debug `127.0.0.1:8787` (optional) goes
+  on the **tailscale** service.
+
+## Config model
+
+Two env files on the host (see the `.example` templates):
+
+- **`.env.insecure`** — non-secret operational settings (safe to read/commit).
+- **`.env.secure`** — all secrets (`chmod 600`, never committed).
+
+The `Makefile` passes **both** to `docker compose --env-file` so `${VAR}`
+interpolation resolves; each sidecar reads only its own secret, while
+loomcycle/migrate bulk-load both via `env_file:`. SearXNG is wired in
+`config/loomcycle.yaml` (not env). See [`INSTALL.md`](INSTALL.md).
+
+## Security posture (read before exposing publicly)
+
+- **loomcycle stays bearer-authed** (`LOOMCYCLE_AUTH_TOKEN`); the apex landing is
+  public. Consider a **Cloudflare Access** policy over `app.loomcycle.cloud` for
+  defense-in-depth.
+- **`LOOMCYCLE_HTTP_HOST_ALLOWLIST=*`** lets agents fetch any host — permissive on
+  a public box. Tighten for production.
+- **The builder-sidecar has effective host-root via the Docker socket** — it's the
+  one privileged component by design. Kept in-network, bearer-authed, no host port.
+- Real secrets are authored **on the host only**; this directory ships only
+  `.example` templates.
+
+## Quick start
+
+```bash
+# on cloud-home.local, from the deploy directory (e.g. /home/denn/work/loomcycle-cloud)
+cp .env.insecure.example .env.insecure   # edit: OLLAMA_BASE_URL, PUBLIC_URL, …
+cp .env.secure.example   .env.secure     # fill secrets; chmod 600 .env.secure
+mkdir -p data work pgdata ts-state web retention-exports caddy-data caddy-config
+sudo chown -R 65532:65532 data work retention-exports
+cp -r /path/to/loomcycle/cloud-web/* web/    # the landing static files
+make up && make ps
+```
+
+Full walkthrough (Tailscale key, Cloudflare tunnel + DNS, verification): **[`INSTALL.md`](INSTALL.md)**.

--- a/cloud-deployment/config/loomcycle.yaml
+++ b/cloud-deployment/config/loomcycle.yaml
@@ -1,0 +1,12 @@
+# loomcycle config overlay (mounted at /config = LOOMCYCLE_CONFIG_DIR).
+# Deep-merged OVER the embedded presets (RFC AN layering: presets → CONFIG_DIR).
+#
+# SearXNG is wired here, NOT via env — there is no LOOMCYCLE_SEARCH_* var. The
+# base_url is the in-compose service name. `brave` is an optional paid fallback
+# (inert unless BRAVE_API_KEY is set); drop it from search_priority to disable.
+search_providers:
+  searxng:
+    base_url: "http://searxng:8080"
+  brave: {}
+
+search_priority: [searxng, brave]

--- a/cloud-deployment/docker-compose.yaml
+++ b/cloud-deployment/docker-compose.yaml
@@ -1,0 +1,206 @@
+# loomcycle — self-contained cloud deployment (Ubuntu 25.04, Docker Compose)
+#
+# One stack: Postgres 18 + pgvector, the loomcycle runtime + one-shot migrate,
+# the code-exec builder sidecar, SearXNG, a Caddy landing server, a Tailscale
+# egress sidecar (to reach a local Ollama over the tailnet), and a Cloudflare
+# tunnel that exposes app.loomcycle.cloud (the app) + loomcycle.cloud (landing).
+#
+# Run it with BOTH env files so `${VAR}` interpolation resolves (a Makefile wraps
+# this — `make up`):
+#   docker compose --env-file .env.insecure --env-file .env.secure up -d
+#
+# Secrets scoping: each service's `environment:` pulls ONLY the secret it needs
+# via ${VAR}; loomcycle/migrate additionally `env_file:` both files to bulk-load
+# their many LOOMCYCLE_* settings. Never put a secret in an `environment:` literal.
+#
+# NETNS NOTE (Tailscale): the `loomcycle` runtime uses `network_mode:
+# service:tailscale`, so it has NO compose DNS name of its own — everything that
+# dials it targets `http://tailscale:8787`. loomcycle still reaches postgres/
+# searxng/builder-sidecar by service name (the tailscale container is on loomnet),
+# and reaches Ollama by RAW tailnet IP (MagicDNS is not available in the shared
+# netns — see OLLAMA_BASE_URL in .env.insecure).
+
+name: loomcycle
+
+networks:
+  loomnet:
+    driver: bridge
+
+services:
+  # ── Postgres 18 + pgvector — main store (loomcycle) + SQL-Memory aux (loomcycle_sqlmem) ──
+  postgres:
+    image: pgvector/pgvector:pg18
+    restart: unless-stopped
+    networks: [loomnet]
+    environment:
+      POSTGRES_USER: loomcycle
+      POSTGRES_DB: loomcycle
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - ./pgdata:/var/lib/postgresql/data
+      # Runs ONCE on first init: creates loomcycle_sqlmem + the sqlmem pgvector schema.
+      - ./postgres/initdb.d:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U loomcycle -d loomcycle"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 15s
+
+  # ── One-shot schema migration for the MAIN db (SQL Memory self-provisions at runtime) ──
+  loomcycle-migrate:
+    image: denngubsky/loomcycle:1.38.0
+    command: ["migrate", "up"]
+    restart: "no"
+    user: "65532:65532"
+    networks: [loomnet]
+    # Non-secret settings from env_file; only the DSN secret is injected explicitly
+    # (scoped — migrate never needs the sidecar tokens).
+    env_file:
+      - ./.env.insecure
+    environment:
+      LOOMCYCLE_PG_DSN: ${LOOMCYCLE_PG_DSN}
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  # ── Tailscale egress sidecar — kernel mode; owns the netns loomcycle shares ──
+  tailscale:
+    image: tailscale/tailscale:latest
+    restart: unless-stopped
+    hostname: loomcycle-cloud
+    networks: [loomnet]
+    cap_add: [NET_ADMIN]
+    devices:
+      - /dev/net/tun
+    environment:
+      TS_AUTHKEY: ${TS_AUTHKEY}
+      TS_STATE_DIR: /var/lib/tailscale
+      TS_USERSPACE: "false"      # kernel mode → real interface + routes for egress
+      TS_ACCEPT_DNS: "false"     # do NOT let tailscale clobber the netns DNS that
+                                 # loomcycle's service-name resolution depends on
+    volumes:
+      - ./ts-state:/var/lib/tailscale
+    healthcheck:
+      test: ["CMD", "tailscale", "status"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 15s
+    # Optional local-debug port for the loomcycle UI (it lives in THIS netns).
+    # Uncomment to reach it on the host loopback; not needed for the CF tunnel.
+    # ports:
+    #   - "127.0.0.1:8787:8787"
+
+  # ── Code-execution sandbox sidecar (host-Docker-socket model) ──
+  builder-sidecar:
+    image: denngubsky/loomcycle-builder-docker:1.25.2
+    restart: unless-stopped
+    networks: [loomnet]
+    environment:
+      SANDBOX_PODMAN_BIN: docker         # launch sessions as host-Docker siblings
+      SANDBOX_IMAGE: denngubsky/loomcycle-sandbox-session:latest
+      SANDBOX_WORKSPACE_ROOT: /mnt/work  # per-session /work is tmpfs by default;
+                                         # durable named workspaces need the same
+                                         # HOST path here — see INSTALL.md.
+      SANDBOX_MAX_CPUS: "2"
+      SANDBOX_MAX_MEM_MB: "2048"
+      SANDBOX_AUTH_TOKEN: ${SANDBOX_AUTH_TOKEN}   # SAME secret loomcycle presents
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./work:/mnt/work
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:9000/healthz || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 10s
+
+  # ── The loomcycle runtime — shares the tailscale netns (no own DNS name / ports) ──
+  loomcycle:
+    image: denngubsky/loomcycle:1.38.0
+    restart: unless-stopped
+    user: "65532:65532"
+    network_mode: "service:tailscale"   # → reachable at http://tailscale:8787
+    # Non-secret settings via env_file; loomcycle's OWN secrets injected explicitly
+    # so the sidecar tokens (TS/CF/PG/SearXNG) stay OUT of the runtime's env — it
+    # executes agent code, so we keep its blast radius minimal. Optional keys use
+    # ${VAR:-} so an unset one is simply empty (provider excluded), no warning.
+    env_file:
+      - ./.env.insecure
+    environment:
+      LOOMCYCLE_AUTH_TOKEN: ${LOOMCYCLE_AUTH_TOKEN}
+      LOOMCYCLE_OPERATOR_TOKEN_PEPPER: ${LOOMCYCLE_OPERATOR_TOKEN_PEPPER:-}
+      LOOMCYCLE_SECRET_KEY: ${LOOMCYCLE_SECRET_KEY:-}
+      LOOMCYCLE_PG_DSN: ${LOOMCYCLE_PG_DSN}
+      LOOMCYCLE_SQLMEM_PG_DSN: ${LOOMCYCLE_SQLMEM_PG_DSN}
+      SANDBOX_AUTH_TOKEN: ${SANDBOX_AUTH_TOKEN}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY:-}
+      BRAVE_API_KEY: ${BRAVE_API_KEY:-}
+    volumes:
+      - ./data:/data
+      - ./config:/config:ro
+      - ./work:/mnt/work
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/loomcycle", "health"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    depends_on:
+      tailscale:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+      loomcycle-migrate:
+        condition: service_completed_successfully
+      builder-sidecar:
+        condition: service_healthy
+
+  # ── SearXNG — in-network search backend (keyless; wired via config/loomcycle.yaml) ──
+  searxng:
+    image: searxng/searxng:latest
+    restart: unless-stopped
+    networks: [loomnet]
+    environment:
+      SEARXNG_BASE_URL: http://searxng:8080/
+      SEARXNG_SECRET: ${SEARXNG_SECRET}
+    volumes:
+      - ./searxng:/etc/searxng:rw
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/healthz || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 15s
+
+  # ── Landing page (Caddy) — serves cloud-web/ + proxies /api/* to loomcycle ──
+  landing:
+    image: caddy:2
+    restart: unless-stopped
+    networks: [loomnet]
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./web:/srv:ro          # copy of the repo's cloud-web/ (see INSTALL.md)
+      - ./caddy-data:/data
+      - ./caddy-config:/config
+    depends_on:
+      tailscale:
+        condition: service_healthy
+
+  # ── Cloudflare tunnel (token method) — app.loomcycle.cloud + loomcycle.cloud ──
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    restart: unless-stopped
+    networks: [loomnet]
+    command: ["tunnel", "--no-autoupdate", "run"]
+    environment:
+      TUNNEL_TOKEN: ${CLOUDFLARE_TUNNEL_TOKEN}
+    depends_on:
+      tailscale:
+        condition: service_healthy
+      landing:
+        condition: service_started

--- a/cloud-deployment/postgres/initdb.d/00-init.sql
+++ b/cloud-deployment/postgres/initdb.d/00-init.sql
@@ -1,0 +1,18 @@
+-- Runs ONCE, on first postgres init, as the bootstrap superuser `loomcycle`
+-- (POSTGRES_USER). Being a superuser, `loomcycle` already has CREATEROLE, which
+-- the SQL-Memory tier needs at runtime to provision one login role per scope.
+--
+-- The postgres image creates the MAIN database (loomcycle) from POSTGRES_DB.
+-- Here we add the SQL-Memory aux database + its pgvector schema. The MAIN db's
+-- `vector` extension is created later by `loomcycle migrate up` (migration 0017),
+-- so we do NOT create it here.
+
+CREATE DATABASE loomcycle_sqlmem OWNER loomcycle;
+
+\connect loomcycle_sqlmem
+
+-- SQL-Memory expects pgvector installed into a dedicated schema it bakes onto
+-- each per-scope role's search_path. Only needed for vector search INSIDE SQL
+-- Memory; the pgvector/pgvector:pg18 image ships the extension binaries.
+CREATE SCHEMA IF NOT EXISTS sqlmem_ext;
+CREATE EXTENSION IF NOT EXISTS vector SCHEMA sqlmem_ext;

--- a/cloud-deployment/searxng/settings.yml
+++ b/cloud-deployment/searxng/settings.yml
@@ -1,0 +1,14 @@
+# SearXNG — minimal config for loomcycle's search driver.
+# The searxng image's entrypoint substitutes the `ultrasecretkey` sentinel below
+# with the SEARXNG_SECRET env value at startup (set it in .env.secure).
+use_default_settings: true
+
+server:
+  secret_key: "ultrasecretkey"   # replaced from $SEARXNG_SECRET by the entrypoint
+  limiter: false                 # off, or SearXNG 429s loomcycle's plain GET
+
+search:
+  # json is REQUIRED — loomcycle queries /search?format=json; without it → 403.
+  formats:
+    - html
+    - json


### PR DESCRIPTION
## What
A new **`cloud-deployment/`** directory — a one-stack Docker Compose deployment of loomcycle for `cloud-home.local` (Ubuntu 25.04), exposed publicly at `app.loomcycle.cloud` via Cloudflare, with the drafted `cloud-web/` landing at the apex. Unlike `deploy/truenas/` (which depends on external TrueNAS apps for Postgres/SearXNG/Ollama), this **bundles everything**.

## Eight services (one compose network)
`postgres` (pgvector/pg18) + one-shot `loomcycle-migrate` · `loomcycle` runtime · `builder-sidecar` (host-Docker-socket sandbox) · `searxng` · `landing` (Caddy) · `tailscale` (kernel-mode egress) · `cloudflared` (token tunnel).

## Operator decisions baked in
- **Sandbox**: Docker socket + runc (mirrors TrueNAS).
- **Tailscale**: in-compose kernel-mode sidecar; loomcycle shares its netns (`network_mode: service:tailscale`) to reach a local Ollama over the tailnet.
- **Landing**: Caddy self-hosts `cloud-web/` **and** reproduces its `/api/health` + `/api/config` Pages Functions (proxying loomcycle's `/healthz` + `/v1/config`).
- **Cloudflare**: token method; routes in the dashboard.

## Key wiring
- loomcycle has **no compose DNS name** (shares the tailscale netns) → cloudflared (`app.loomcycle.cloud`) and Caddy's `/api/*` both target `http://tailscale:8787`. Ollama is reached by **raw tailnet IP** (MagicDNS unavailable in the shared netns; `TS_ACCEPT_DNS=false`).
- SearXNG wired via `config/loomcycle.yaml` (`search_providers`), not env.
- `postgres/initdb.d` creates the `loomcycle_sqlmem` aux DB + its `sqlmem_ext` pgvector schema; the main DB's vector extension comes from `migrate up`.
- **Two host env files** (`.env.insecure` settings, `.env.secure` secrets); the `Makefile` passes both to `--env-file`. **Secrets are scoped**: loomcycle/migrate get only *their* secrets via explicit `${VAR}` (the sidecar tokens — TS/CF/PG/SearXNG — stay out of the code-executing runtime's env); each sidecar reads just its one secret.

## Safety
- Only `.example` env **templates** are committed (placeholder-only); `.gitignore` protects the filled files + runtime dirs. Security posture (permissive `HTTP_HOST_ALLOWLIST=*`, socket-mount host-root sidecar, optional Cloudflare Access) is documented in `README.md` / `INSTALL.md`.

## Tested
`docker compose --env-file .env.insecure --env-file .env.secure config` renders valid; verified the netns wiring (loomcycle `network_mode: service:tailscale`, no `ports`) and the secret scoping (no TS/CF/PG/SearXNG tokens in loomcycle's env). YAML overlays parse. Full end-to-end verification steps are in `INSTALL.md` (to run on the host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)