### PR TITLE
feat(memory): bank the span a compaction discards (P3 PR 3/4)

### DIFF
--- a/internal/api/http/bank_compaction.go
+++ b/internal/api/http/bank_compaction.go
@@ -1,0 +1,66 @@
+package http
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	memrank "github.com/denn-gubsky/loomcycle/internal/memory"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// bankCompactedSpanFn builds the loop's RFC BL P3 banking callback, or nil when
+// the agent has not opted in — which is the default, so an unopted agent's
+// compaction path is byte-identical to before.
+//
+// Scope resolution mirrors `Memory op=add`, with one hard requirement:
+// **user scope**. That is not a preference. The consolidator fans out over user
+// scopes only — `resolveScope("agent")` would resolve to the CONSOLIDATOR's own
+// name, so an agent-scope fan-out points every child at one keyspace — which means
+// a pending row banked at agent scope would be enqueued and then never drained by
+// anything. Banked and silently forgotten is worse than not banked, so this
+// refuses instead, by name.
+//
+// The callback is installed whenever `memory_flush` is set, even when it cannot
+// bank. Returning nil for a misconfigured agent would make the misconfiguration
+// invisible; an error in the compaction marker on every pass is noisy in exactly
+// the way an operator needs.
+func (s *Server) bankCompactedSpanFn(agentDef config.AgentDef, tenantID, userID, agentName, runID, sessionID string) func(context.Context, []providers.Message) (string, error) {
+	if agentDef.Compaction == nil || agentDef.Compaction.MemoryFlush == nil || !*agentDef.Compaction.MemoryFlush {
+		return nil
+	}
+	return func(ctx context.Context, dropped []providers.Message) (string, error) {
+		if s.store == nil {
+			return "", fmt.Errorf("memory_flush: no persistent store on this instance")
+		}
+		if !containsString(agentDef.MemoryScopes, "user") {
+			return "", fmt.Errorf("memory_flush is set but agent %q has no `user` in memory_scopes; consolidation only drains user scopes, so a banked span would never be consolidated", agentName)
+		}
+		if userID == "" {
+			return "", fmt.Errorf("memory_flush is set but this run carries no user_id, so there is no user scope to bank into")
+		}
+		msgs := memrank.ConversationFromMessages(dropped)
+		return memrank.BankSpan(ctx, s.store, memrank.BankSpanRequest{
+			TenantID:  tenantID,
+			Scope:     "user",
+			ScopeID:   userID,
+			RunID:     runID,
+			SessionID: sessionID,
+			Messages:  msgs,
+			// Metadata rides into the payload the consolidator reads. `source`
+			// tells a pass (and an operator reading a queue row) that these turns
+			// were rescued from a compaction rather than volunteered by an agent.
+			Metadata: map[string]string{"source": "compaction", "agent": agentName},
+		})
+	}
+}
+
+// containsString is a local membership check for the scope allowlist.
+func containsString(hay []string, needle string) bool {
+	for _, v := range hay {
+		if v == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/http/resume.go
+++ b/internal/api/http/resume.go
@@ -327,31 +327,36 @@ func (s *Server) resumePausedRun(ctx context.Context, run store.Run) error {
 	loopCtx = tools.WithPauseGate(loopCtx, gate)
 
 	runOpts := loop.RunOptions{
-		Provider:               provider,
-		Model:                  model,
-		Tools:                  allowedTools,
-		Dispatcher:             dispatcher,
-		Segments:               segments,
-		PriorMessages:          priorMessages,
-		OnEvent:                emit,
-		OnHeartbeat:            heartbeat,
-		MaxTokens:              agentDef.MaxTokens,
-		MaxIterations:          agentDef.MaxIterations,
-		UnboundedIterations:    agentDef.UnboundedIterations,
-		SteerQueue:             steerQ,
-		OnSteer:                onSteer,
-		Effort:                 effort,
-		MarkStalled:            s.markStalledFn(providerID, model),
-		MarkRateLimited:        s.markRateLimitedFn(run.UserTier),
-		ClearStall:             s.clearStallFn(providerID, model),
-		ToolParallelism:        s.cfg.Env.ToolParallelism,
-		AgentName:              run.Agent,
-		CodeBody:               agentDef.Code,
-		RunTimeoutSeconds:      agentDef.RunTimeoutSeconds, // per-run override not snapshotted
-		Interactive:            run.Interactive,
-		Sampling:               agentDef.Sampling,   // per-run override not snapshotted
-		Compaction:             agentDef.Compaction, // per-run override not snapshotted
-		ContextPlugins:         s.contextPlugins,    // RFC Z runtime-wide chain (code-js exempt in the loop)
+		Provider:            provider,
+		Model:               model,
+		Tools:               allowedTools,
+		Dispatcher:          dispatcher,
+		Segments:            segments,
+		PriorMessages:       priorMessages,
+		OnEvent:             emit,
+		OnHeartbeat:         heartbeat,
+		MaxTokens:           agentDef.MaxTokens,
+		MaxIterations:       agentDef.MaxIterations,
+		UnboundedIterations: agentDef.UnboundedIterations,
+		SteerQueue:          steerQ,
+		OnSteer:             onSteer,
+		Effort:              effort,
+		MarkStalled:         s.markStalledFn(providerID, model),
+		MarkRateLimited:     s.markRateLimitedFn(run.UserTier),
+		ClearStall:          s.clearStallFn(providerID, model),
+		ToolParallelism:     s.cfg.Env.ToolParallelism,
+		AgentName:           run.Agent,
+		CodeBody:            agentDef.Code,
+		RunTimeoutSeconds:   agentDef.RunTimeoutSeconds, // per-run override not snapshotted
+		Interactive:         run.Interactive,
+		Sampling:            agentDef.Sampling,   // per-run override not snapshotted
+		Compaction:          agentDef.Compaction, // per-run override not snapshotted
+		// BankCompactedSpan is deliberately ABSENT (RFC BL P3). A resumed run
+		// replays a compaction that already happened, and its span was banked when
+		// it first ran — wiring it here would re-bank the same conversation on
+		// every resume, quietly duplicating candidates for the dedup band to
+		// absorb. TestReplayCompaction_DoesNotRebank pins this.
+		ContextPlugins:         s.contextPlugins, // RFC Z runtime-wide chain (code-js exempt in the loop)
 		UserTier:               run.UserTier,
 		FallbackPolicy:         fbPolicy,
 		ReResolve:              fbReResolve,

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2528,34 +2528,37 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	loopCtx = s.heldSlotCtx(loopCtx, provSlot)
 	fbPolicy, fbReResolve := s.fallbackForRun(effectiveTenantID, effectiveUserID, effectiveAgentName, in.UserTier, operatorKeyRestricted, provSlot)
 	res, runErr := loop.Run(loopCtx, loop.RunOptions{
-		Provider:               provider,
-		Model:                  model,
-		Tools:                  allowedTools,
-		Dispatcher:             dispatcher,
-		Segments:               injectMetadataSegments(segments, provider.Capabilities().MetadataViaInput, in.Metadata, in.PayloadMetadata),
-		PriorMessages:          priorMessages,
-		PauseGate:              gate,
-		OnEvent:                emit,
-		OnHeartbeat:            heartbeat,
-		MaxTokens:              agentDef.MaxTokens,
-		MaxIterations:          agentDef.MaxIterations, // 0 → loop default (16)
-		UnboundedIterations:    agentDef.UnboundedIterations,
-		SteerQueue:             steerQ,
-		OnSteer:                onSteer,
-		Effort:                 effort,
-		MarkStalled:            s.markStalledFn(providerID, model),
-		MarkRateLimited:        s.markRateLimitedFn(in.UserTier),
-		ClearStall:             s.clearStallFn(providerID, model),
-		ToolParallelism:        s.cfg.Env.ToolParallelism,
-		AgentName:              effectiveAgentName,
-		CodeBody:               agentDef.Code, // inline code-js body (RFC J); "" → FS fallback
-		Metadata:               in.Metadata,
-		PayloadMetadata:        in.PayloadMetadata,
-		RunTimeoutSeconds:      pickRunTimeout(in.RunTimeoutSeconds, agentDef.RunTimeoutSeconds),
-		Interactive:            in.Interactive,
-		Sampling:               config.MergeSampling(agentDef.Sampling, in.Sampling),       // per-run wins per field
-		Compaction:             config.MergeCompaction(agentDef.Compaction, in.Compaction), // per-run wins per field
-		ContextPlugins:         s.contextPlugins,                                           // RFC Z runtime-wide chain (code-js exempt in the loop)
+		Provider:            provider,
+		Model:               model,
+		Tools:               allowedTools,
+		Dispatcher:          dispatcher,
+		Segments:            injectMetadataSegments(segments, provider.Capabilities().MetadataViaInput, in.Metadata, in.PayloadMetadata),
+		PriorMessages:       priorMessages,
+		PauseGate:           gate,
+		OnEvent:             emit,
+		OnHeartbeat:         heartbeat,
+		MaxTokens:           agentDef.MaxTokens,
+		MaxIterations:       agentDef.MaxIterations, // 0 → loop default (16)
+		UnboundedIterations: agentDef.UnboundedIterations,
+		SteerQueue:          steerQ,
+		OnSteer:             onSteer,
+		Effort:              effort,
+		MarkStalled:         s.markStalledFn(providerID, model),
+		MarkRateLimited:     s.markRateLimitedFn(in.UserTier),
+		ClearStall:          s.clearStallFn(providerID, model),
+		ToolParallelism:     s.cfg.Env.ToolParallelism,
+		AgentName:           effectiveAgentName,
+		CodeBody:            agentDef.Code, // inline code-js body (RFC J); "" → FS fallback
+		Metadata:            in.Metadata,
+		PayloadMetadata:     in.PayloadMetadata,
+		RunTimeoutSeconds:   pickRunTimeout(in.RunTimeoutSeconds, agentDef.RunTimeoutSeconds),
+		Interactive:         in.Interactive,
+		Sampling:            config.MergeSampling(agentDef.Sampling, in.Sampling),       // per-run wins per field
+		Compaction:          config.MergeCompaction(agentDef.Compaction, in.Compaction), // per-run wins per field
+		// RFC BL P3: nil unless the agent set compaction.memory_flush, so an
+		// unopted agent's compaction path is byte-identical.
+		BankCompactedSpan:      s.bankCompactedSpanFn(agentDef, rid.TenantID, effectiveUserID, in.Agent, runID, sessionID),
+		ContextPlugins:         s.contextPlugins, // RFC Z runtime-wide chain (code-js exempt in the loop)
 		UserTier:               in.UserTier,
 		FallbackPolicy:         fbPolicy,
 		ReResolve:              fbReResolve,
@@ -4042,31 +4045,33 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	}
 	fbPolicy, fbReResolve := s.fallbackForRun(req.TenantID, req.UserID, req.Agent, req.UserTier, operatorKeyRestricted, fbSlot)
 	runOpts := loop.RunOptions{
-		Provider:               provider,
-		Model:                  model,
-		Tools:                  allowedTools,
-		Dispatcher:             dispatcher,
-		Segments:               injectMetadataSegments(req.Segments, provider.Capabilities().MetadataViaInput, req.Metadata, nil),
-		OnEvent:                emit,
-		OnHeartbeat:            heartbeat,
-		MaxTokens:              agentDef.MaxTokens,     // 0 → driver default
-		MaxIterations:          agentDef.MaxIterations, // 0 → loop default (16)
-		UnboundedIterations:    agentDef.UnboundedIterations,
-		SteerQueue:             steerQ,
-		OnSteer:                onSteer,
-		Effort:                 effort,
-		MarkStalled:            s.markStalledFn(providerID, model),
-		MarkRateLimited:        s.markRateLimitedFn(req.UserTier),
-		ClearStall:             s.clearStallFn(providerID, model),
-		ToolParallelism:        s.cfg.Env.ToolParallelism,
-		AgentName:              req.Agent,
-		CodeBody:               agentDef.Code, // inline code-js body (RFC J); "" → FS fallback
-		Metadata:               req.Metadata,  // direct /v1/runs caller is first-party → trusted; no payload_metadata
-		RunTimeoutSeconds:      pickRunTimeout(req.RunTimeoutSeconds, agentDef.RunTimeoutSeconds),
-		Interactive:            req.Interactive,
-		Sampling:               config.MergeSampling(agentDef.Sampling, req.Sampling),       // per-run wins per field
-		Compaction:             config.MergeCompaction(agentDef.Compaction, req.Compaction), // per-run wins per field
-		ContextPlugins:         s.contextPlugins,                                            // RFC Z runtime-wide chain (code-js exempt in the loop)
+		Provider:            provider,
+		Model:               model,
+		Tools:               allowedTools,
+		Dispatcher:          dispatcher,
+		Segments:            injectMetadataSegments(req.Segments, provider.Capabilities().MetadataViaInput, req.Metadata, nil),
+		OnEvent:             emit,
+		OnHeartbeat:         heartbeat,
+		MaxTokens:           agentDef.MaxTokens,     // 0 → driver default
+		MaxIterations:       agentDef.MaxIterations, // 0 → loop default (16)
+		UnboundedIterations: agentDef.UnboundedIterations,
+		SteerQueue:          steerQ,
+		OnSteer:             onSteer,
+		Effort:              effort,
+		MarkStalled:         s.markStalledFn(providerID, model),
+		MarkRateLimited:     s.markRateLimitedFn(req.UserTier),
+		ClearStall:          s.clearStallFn(providerID, model),
+		ToolParallelism:     s.cfg.Env.ToolParallelism,
+		AgentName:           req.Agent,
+		CodeBody:            agentDef.Code, // inline code-js body (RFC J); "" → FS fallback
+		Metadata:            req.Metadata,  // direct /v1/runs caller is first-party → trusted; no payload_metadata
+		RunTimeoutSeconds:   pickRunTimeout(req.RunTimeoutSeconds, agentDef.RunTimeoutSeconds),
+		Interactive:         req.Interactive,
+		Sampling:            config.MergeSampling(agentDef.Sampling, req.Sampling),       // per-run wins per field
+		Compaction:          config.MergeCompaction(agentDef.Compaction, req.Compaction), // per-run wins per field
+		// RFC BL P3: nil unless the agent set compaction.memory_flush.
+		BankCompactedSpan:      s.bankCompactedSpanFn(agentDef, rid.TenantID, req.UserID, req.Agent, runID, sessionID),
+		ContextPlugins:         s.contextPlugins, // RFC Z runtime-wide chain (code-js exempt in the loop)
 		UserTier:               req.UserTier,
 		FallbackPolicy:         fbPolicy,
 		ReResolve:              fbReResolve,
@@ -6670,6 +6675,23 @@ func (s *Server) compactRunWithSource(ctx context.Context, runID, source string)
 	summary = strings.TrimSpace(summary)
 	if summary == "" {
 		return connector.CompactResult{}, &compactErr{status: http.StatusBadGateway, msg: "summarization produced no text"}
+	}
+	// RFC BL P3: bank the span this compaction discards, for the manual path
+	// (POST /v1/runs/{id}/compact + Context op=compact). AFTER a successful
+	// summary, mirroring the auto path — a failed summarization discards nothing,
+	// so there is nothing to rescue.
+	//
+	// Banked HERE rather than in the loop because this path summarizes outside the
+	// loop and pushes the finished summary; the loop's applyCompactSummary only
+	// swaps history and never calls maybeAutoCompact, so this cannot double-bank.
+	// It covers the terminal case too, which never reaches the loop at all.
+	//
+	// Best-effort exactly like the auto path: a compact must not fail because a
+	// queue write did.
+	if bank := s.bankCompactedSpanFn(agentDef, run.TenantID, run.UserID, run.Agent, runID, run.SessionID); bank != nil {
+		if _, berr := bank(summCtx, msgs[firstIdx:cut]); berr != nil {
+			log.Printf("compact %s: memory_flush did not bank: %v", runID, berr)
+		}
 	}
 	keepN := len(msgs) - cut
 	pinned := ""

--- a/internal/loop/compact_test.go
+++ b/internal/loop/compact_test.go
@@ -2,6 +2,7 @@ package loop
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync"
 	"testing"
@@ -375,5 +376,147 @@ func TestCapKeptTailToWindow(t *testing.T) {
 	huge := []providers.Message{userMsg("task"), big}
 	if got := capKeptTailToWindow(huge, 1, 50); got != 1 {
 		t.Errorf("irreducible tail: cut = %d, want 1 (kept, not emptied)", got)
+	}
+}
+
+// ─── RFC BL P3: banking the discarded span ───────────────────────────────────
+
+// TestMaybeAutoCompact_BanksDiscardedSpan: with the callback wired, a compaction
+// hands it EXACTLY the turns it is about to drop, and reports the outcome on the
+// marker so a pass is auditable from the transcript rather than from a log.
+//
+// The span identity assertion is the load-bearing one: banking the kept tail
+// would duplicate what is still in context, and banking the whole history would
+// re-bank the pinned task on every compaction.
+func TestMaybeAutoCompact_BanksDiscardedSpan(t *testing.T) {
+	msgs := []providers.Message{userMsg("the task"), asstMsg("a1"), userMsg("q2"), asstMsg("a2"), userMsg("q3"), asstMsg("a3")}
+	var got []providers.Message
+	opts := RunOptions{
+		Provider:   &steerProvider{},
+		Model:      "x",
+		Compaction: &config.Compaction{KeepLastN: cptr(2), KeepFirst: cptr(true), TargetPercentage: cptr(10)},
+		BankCompactedSpan: func(_ context.Context, dropped []providers.Message) (string, error) {
+			got = dropped
+			return "mp_banked", nil
+		},
+	}
+	var info *providers.ContextCompactionEventInfo
+	_, did := maybeAutoCompact(context.Background(), opts, msgs, 0, func(ev providers.Event) {
+		if ev.Type == providers.EventContextCompaction {
+			info = ev.ContextCompaction
+		}
+	}, "auto")
+	if !did {
+		t.Fatal("expected compaction to happen")
+	}
+
+	// Dropped = everything between the pinned first turn and the kept tail.
+	want := []string{"a1", "q2", "a2"}
+	if len(got) != len(want) {
+		t.Fatalf("banked %d messages, want %d — the span must be exactly what was discarded, not the kept tail or the whole history: %+v", len(got), len(want), got)
+	}
+	for i, w := range want {
+		if got[i].Content[0].Text != w {
+			t.Errorf("banked[%d] = %q, want %q", i, got[i].Content[0].Text, w)
+		}
+	}
+
+	if info == nil || info.MemoryBanked == nil {
+		t.Fatalf("the compaction marker carries no memory_banked block: %+v", info)
+	}
+	if info.MemoryBanked.PendingID != "mp_banked" || info.MemoryBanked.Messages != 3 {
+		t.Errorf("marker = %+v, want pending_id mp_banked / messages 3", info.MemoryBanked)
+	}
+	if info.MemoryBanked.Error != "" {
+		t.Errorf("marker carries an error on the success path: %q", info.MemoryBanked.Error)
+	}
+}
+
+// TestMaybeAutoCompact_NoBankWithoutTheCallback: the default is byte-identical.
+// A nil callback is how "the agent did not opt in", "it has no writable memory
+// scope", and "there is no store" all arrive, so the marker must carry no
+// memory_banked block at all rather than an empty one — an absent field is what
+// tells a consumer the feature is off.
+func TestMaybeAutoCompact_NoBankWithoutTheCallback(t *testing.T) {
+	msgs := []providers.Message{userMsg("the task"), asstMsg("a1"), userMsg("q2"), asstMsg("a2"), userMsg("q3"), asstMsg("a3")}
+	opts := RunOptions{
+		Provider:   &steerProvider{},
+		Model:      "x",
+		Compaction: &config.Compaction{KeepLastN: cptr(2), KeepFirst: cptr(true), TargetPercentage: cptr(10)},
+	}
+	var info *providers.ContextCompactionEventInfo
+	_, did := maybeAutoCompact(context.Background(), opts, msgs, 0, func(ev providers.Event) {
+		if ev.Type == providers.EventContextCompaction {
+			info = ev.ContextCompaction
+		}
+	}, "auto")
+	if !did || info == nil {
+		t.Fatal("expected compaction + a marker")
+	}
+	if info.MemoryBanked != nil {
+		t.Errorf("memory_banked present with no callback wired: %+v", info.MemoryBanked)
+	}
+}
+
+// TestMaybeAutoCompact_SurvivesBankFailure is the invariant that outranks the
+// feature: compaction exists to keep a run alive, so a failed queue write must
+// name itself on the marker and change nothing else. A compaction that refused to
+// complete because banking failed would trade a live run for a memory nicety.
+func TestMaybeAutoCompact_SurvivesBankFailure(t *testing.T) {
+	msgs := []providers.Message{userMsg("the task"), asstMsg("a1"), userMsg("q2"), asstMsg("a2"), userMsg("q3"), asstMsg("a3")}
+	opts := RunOptions{
+		Provider:   &steerProvider{},
+		Model:      "x",
+		Compaction: &config.Compaction{KeepLastN: cptr(2), KeepFirst: cptr(true), TargetPercentage: cptr(10)},
+		BankCompactedSpan: func(_ context.Context, _ []providers.Message) (string, error) {
+			return "", errors.New("enqueue: database is locked")
+		},
+	}
+	var info *providers.ContextCompactionEventInfo
+	out, did := maybeAutoCompact(context.Background(), opts, msgs, 0, func(ev providers.Event) {
+		if ev.Type == providers.EventContextCompaction {
+			info = ev.ContextCompaction
+		}
+	}, "auto")
+	if !did {
+		t.Fatal("a failed bank aborted the compaction — the run keeps its full context and will hit the window")
+	}
+	// The compacted history is exactly what it would be without banking at all.
+	if len(out) != 4 || out[2].Content[0].Text != "q3" {
+		t.Errorf("a failed bank changed the compacted history: %+v", out)
+	}
+	if info == nil || info.MemoryBanked == nil || info.MemoryBanked.Error == "" {
+		t.Fatalf("the failure is not named on the marker: %+v", info)
+	}
+	if info.MemoryBanked.PendingID != "" {
+		t.Errorf("a failed bank reported a pending id: %+v", info.MemoryBanked)
+	}
+}
+
+// TestMaybeAutoCompact_ToolOnlySpanReportsNothingToBank: a span with no dialogue
+// (pure tool traffic — the converter drops it) must be distinguishable from the
+// feature being off, or an operator debugging "why is nothing being banked" cannot
+// tell a filtered span from an unset flag.
+func TestMaybeAutoCompact_ToolOnlySpanReportsNothingToBank(t *testing.T) {
+	msgs := []providers.Message{userMsg("the task"), asstMsg("a1"), userMsg("q2"), asstMsg("a2"), userMsg("q3"), asstMsg("a3")}
+	opts := RunOptions{
+		Provider:   &steerProvider{},
+		Model:      "x",
+		Compaction: &config.Compaction{KeepLastN: cptr(2), KeepFirst: cptr(true), TargetPercentage: cptr(10)},
+		BankCompactedSpan: func(_ context.Context, _ []providers.Message) (string, error) {
+			return "", nil // BankSpan's nothing-to-bank: no id, no error
+		},
+	}
+	var info *providers.ContextCompactionEventInfo
+	_, did := maybeAutoCompact(context.Background(), opts, msgs, 0, func(ev providers.Event) {
+		if ev.Type == providers.EventContextCompaction {
+			info = ev.ContextCompaction
+		}
+	}, "auto")
+	if !did || info == nil || info.MemoryBanked == nil {
+		t.Fatalf("expected a marker with a memory_banked block: %+v", info)
+	}
+	if info.MemoryBanked.PendingID != "" || info.MemoryBanked.Error == "" {
+		t.Errorf("marker = %+v, want no pending id and a named reason", info.MemoryBanked)
 	}
 }

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -91,6 +91,22 @@ type RunOptions struct {
 	// tolerate failures" contract as OnHeartbeat.
 	OnSteer func(steer.Message)
 
+	// BankCompactedSpan, when non-nil, banks the span a compaction is about to
+	// DISCARD onto the consolidation queue, so the pass can extract durable facts
+	// from it later (RFC BL P3). It receives the messages being dropped and
+	// returns a correlation id for the transcript marker.
+	//
+	// A CALLBACK rather than a store handle because the loop is deliberately
+	// store-free: resolving the agent's memory scope, its tenant, and whether
+	// `compaction.memory_flush` is even set all live where the store already
+	// does. Nil therefore covers every "do not bank" case at once — the flag is
+	// off, the agent has no writable memory scope, or there is no store — and the
+	// loop does not have to know which.
+	//
+	// Errors are for the marker only. Compaction exists to keep a run alive;
+	// banking is strictly secondary and must never be able to fail it.
+	BankCompactedSpan func(ctx context.Context, dropped []providers.Message) (string, error)
+
 	// Interactive makes this a PERSISTENT run: instead of terminating when the
 	// model ends its turn, the loop parks on SteerQueue waiting for the
 	// operator's next instruction (resuming on it, ending only on Cancel).
@@ -1071,6 +1087,17 @@ func Summarize(ctx context.Context, provider providers.Provider, model string, m
 // keepFirst taken verbatim from the control, and emits the persisted marker. The
 // loop trusts keepN (the server snapped it on the same in-memory==transcript
 // history). Used by drainSteer + parkForInput.
+//
+// INVARIANT — it takes no RunOptions, and must not start to (RFC BL P3). That is
+// what makes memory banking unreachable from here, which matters because this
+// function runs on paths where the span has ALREADY been banked or must not be:
+// the manual compact banks server-side before pushing the control, and a resumed
+// run replays a compaction that happened once. Give this access to
+// BankCompactedSpan and both become double-banks that no error surfaces —
+// duplicate candidates for the dedup band to absorb, on every resume. Banking
+// belongs in maybeAutoCompact, which is the only path that discards a span nobody
+// has seen yet. loop.Summarize is RunOptions-free for the same reason: it also
+// serves History `recap`, which summarizes without discarding anything.
 func applyCompactSummary(messages []providers.Message, summary string, keepN int, keepFirst bool, emit func(providers.Event)) []providers.Message {
 	before := estimateMessageTokens(messages)
 	if keepN < 0 {
@@ -1197,12 +1224,40 @@ func maybeAutoCompact(ctx context.Context, opts RunOptions, messages []providers
 	}
 	out := CompactionMessages(pinned, strings.TrimSpace(summary), messages[cut:])
 	after := estimateMessageTokens(out)
-	emit(providers.Event{Type: providers.EventContextCompaction,
-		ContextCompaction: &providers.ContextCompactionEventInfo{
-			Summary: strings.TrimSpace(summary), KeepN: len(messages) - cut, KeepFirst: firstIdx > 0,
-			BeforeTokens: before, AfterTokens: after, Trigger: trigger}})
+	info := &providers.ContextCompactionEventInfo{
+		Summary: strings.TrimSpace(summary), KeepN: len(messages) - cut, KeepFirst: firstIdx > 0,
+		BeforeTokens: before, AfterTokens: after, Trigger: trigger}
+	// RFC BL P3: bank the span we are about to drop, if the agent asked for it.
+	// AFTER the summary succeeded and BEFORE the messages are replaced, because
+	// this is the last moment the discarded turns exist. Never fatal — see
+	// RunOptions.BankCompactedSpan.
+	info.MemoryBanked = bankDiscardedSpan(ctx, opts, messages[firstIdx:cut])
+	emit(providers.Event{Type: providers.EventContextCompaction, ContextCompaction: info})
 	lcotel.RecordCompactionCtx(ctx, trigger, before, after) // per-run-shape metric via OTEL span event
 	return out, true
+}
+
+// bankDiscardedSpan hands the span a compaction is dropping to the banking
+// callback, and reports the outcome for the transcript marker. Returns nil when
+// the agent did not opt in, so the marker field stays absent by default.
+//
+// Every failure path returns an Error rather than propagating: the caller has
+// already produced a valid summary, and refusing to complete the compaction
+// because a queue write failed would trade a live run for a memory nicety.
+func bankDiscardedSpan(ctx context.Context, opts RunOptions, dropped []providers.Message) *providers.MemoryBankedInfo {
+	if opts.BankCompactedSpan == nil || len(dropped) == 0 {
+		return nil
+	}
+	id, err := opts.BankCompactedSpan(ctx, dropped)
+	if err != nil {
+		return &providers.MemoryBankedInfo{Error: err.Error()}
+	}
+	if id == "" {
+		// Nothing conversational in the span (all tool traffic) — a legitimate
+		// nothing-to-bank, reported so it is not mistaken for the flag being off.
+		return &providers.MemoryBankedInfo{Error: "no conversational content in the discarded span"}
+	}
+	return &providers.MemoryBankedInfo{PendingID: id, Messages: len(dropped)}
 }
 
 func Run(ctx context.Context, opts RunOptions) (RunResult, error) {

--- a/internal/memory/backends/inprocess/inprocess.go
+++ b/internal/memory/backends/inprocess/inprocess.go
@@ -368,10 +368,11 @@ func (b *Backend) Capabilities() memory.Capabilities {
 // memory_pending. It carries enough to reconstruct the conversation turns when
 // the consolidator (a later RFC BL P2 PR) drains and folds them, without a
 // back-reference to the originating run.
-type pendingPayload struct {
-	Messages []memory.LayerMessage `json:"messages"`
-	Metadata map[string]string     `json:"metadata,omitempty"`
-}
+// pendingPayload is an ALIAS, not a second declaration: the consolidator parses
+// this shape, so one mismatch between two copies would fail silently (the pass
+// reads a payload it cannot interpret and extracts nothing). Add's behaviour is
+// unchanged — this is the same struct under the same name.
+type pendingPayload = memory.PendingPayload
 
 // Add ingests conversation messages under (scope, scopeID). The tenant is the
 // run's authoritative tenant (ctx-carried RunIdentity, server-supplied — never

--- a/internal/memory/bank.go
+++ b/internal/memory/bank.go
@@ -1,0 +1,145 @@
+package memory
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// PendingPayload is the wire shape of a `memory_pending` row's payload:
+// `{messages:[{role,content}], metadata}`. The consolidator bundle parses exactly
+// this, so it has ONE definition — the in-process backend aliases it rather than
+// declaring its own, because two structs describing one wire shape is a drift
+// waiting to happen and a mismatch here fails silently (the pass reads a payload
+// it cannot interpret and extracts nothing).
+type PendingPayload struct {
+	Messages []LayerMessage    `json:"messages"`
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+// BankSpanMaxBytes bounds a single banked payload. It is a runaway guard, not a
+// quality knob: an oversized span is REFUSED and named rather than truncated,
+// because silently dropping part of a conversation is the failure mode this line
+// has spent several releases eliminating, and a refusal is visible in the marker
+// while a truncation is not. Extraction is bounded downstream anyway — the
+// consolidator splits a payload into at most four 12,000-char parts.
+const BankSpanMaxBytes = 1 << 20
+
+// BankSpanRequest is one span to bank. Every field is server-supplied; nothing
+// here is reachable from model input.
+type BankSpanRequest struct {
+	TenantID string
+	Scope    store.MemoryScope
+	ScopeID  string
+	// RunID / SessionID become the fact's origin link — what `include_provenance`
+	// later resolves to answer "can I still read the conversation this came from".
+	RunID     string
+	SessionID string
+	Messages  []LayerMessage
+	Metadata  map[string]string
+}
+
+// BankSpan enqueues a compaction-discarded span onto the consolidation queue so
+// the pass extracts durable facts from it later (RFC BL P3).
+//
+// It BANKS, it does not flush: nothing is extracted here. That is deliberate —
+// asking the summarizer's call to also emit facts is two objectives on one reply,
+// which is the shape that had the LLM consolidator at 0-for-5 before v1.36.0
+// reduced the model's job to one narrow tool-less call.
+//
+// It writes the queue row DIRECTLY rather than through MemoryLayer.Add, because
+// Add hardcodes `origin=agent_explicit` — correctly, since an agent reaching it
+// IS an explicit agent write. A compaction is not, and telling those apart is the
+// entire point of the origin column. The cost of bypassing the tool path is its
+// size cap, which is why BankSpanMaxBytes exists here.
+//
+// Returns the pending row's id. Every error is the CALLER's to swallow: banking
+// memory is strictly secondary to keeping a run alive, so a compaction must
+// complete whether or not this succeeds.
+func BankSpan(ctx context.Context, st store.Store, req BankSpanRequest) (string, error) {
+	if st == nil {
+		return "", fmt.Errorf("bank span: no store")
+	}
+	if len(req.Messages) == 0 {
+		// Not an error: a span with no conversational content (all tool traffic,
+		// say) is a legitimate nothing-to-bank rather than a failure.
+		return "", nil
+	}
+	if req.ScopeID == "" {
+		return "", fmt.Errorf("bank span: no writable memory scope")
+	}
+	payload, err := json.Marshal(PendingPayload{Messages: req.Messages, Metadata: req.Metadata})
+	if err != nil {
+		return "", fmt.Errorf("bank span: marshal payload: %w", err)
+	}
+	if len(payload) > BankSpanMaxBytes {
+		return "", fmt.Errorf("bank span: payload %d bytes exceeds the %d-byte guard; not banked (the compaction itself is unaffected)",
+			len(payload), BankSpanMaxBytes)
+	}
+	// The store mints an id when the row carries none but does not return it, so
+	// mint here to hand back a correlation handle for the transcript marker.
+	row := store.MemoryPendingRow{
+		ID:              "mp_" + bankRandHex(),
+		TenantID:        req.TenantID,
+		Scope:           req.Scope,
+		ScopeID:         req.ScopeID,
+		Payload:         payload,
+		Origin:          store.PendingOriginCompaction, // server-set; the reason this exists
+		SourceSessionID: req.SessionID,
+		SourceRunID:     req.RunID,
+	}
+	if err := st.MemoryPendingEnqueue(ctx, row); err != nil {
+		return "", fmt.Errorf("bank span: enqueue: %w", err)
+	}
+	return row.ID, nil
+}
+
+func bankRandHex() string {
+	var b [12]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "0000000000000000000000000000"
+	}
+	return hex.EncodeToString(b[:])
+}
+
+// ConversationFromMessages renders provider messages as the turns worth banking,
+// keeping ONLY dialogue and dropping everything that is loop plumbing.
+//
+// Tool calls and tool results are excluded deliberately. v1.36.5 measured what
+// happens when the extractor is fed loomcycle's own scaffolding: handed a
+// markdown export that dumped tool_call / tool_result / usage rows as raw JSON, a
+// model whose single instruction is "a durable fact is never a fact ABOUT the
+// conversation" extracted the transcript's own metadata as its first fact. The
+// fix there was to filter by event TYPE rather than by pattern, and this is the
+// same filter one layer down — a user turn that happens to contain JSON is
+// content and survives verbatim.
+//
+// A message whose blocks yield no text is dropped entirely rather than banked as
+// an empty turn, so a span of pure tool traffic returns nothing and BankSpan
+// treats that as a legitimate nothing-to-bank.
+func ConversationFromMessages(msgs []providers.Message) []LayerMessage {
+	out := make([]LayerMessage, 0, len(msgs))
+	for _, m := range msgs {
+		var b strings.Builder
+		for _, c := range m.Content {
+			// "text" only. tool_use / tool_result / thinking are the run's
+			// mechanics, not what was said.
+			if c.Type == "text" && c.Text != "" {
+				if b.Len() > 0 {
+					b.WriteString("\n\n")
+				}
+				b.WriteString(c.Text)
+			}
+		}
+		if text := strings.TrimSpace(b.String()); text != "" {
+			out = append(out, LayerMessage{Role: m.Role, Content: text})
+		}
+	}
+	return out
+}

--- a/internal/memory/bank_test.go
+++ b/internal/memory/bank_test.go
@@ -1,0 +1,181 @@
+package memory
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+func textMsg(role, text string) providers.Message {
+	return providers.Message{Role: role, Content: []providers.ContentBlock{{Type: "text", Text: text}}}
+}
+
+// TestConversationFromMessages_DropsToolTraffic is the v1.36.5 lesson enforced one
+// layer down. Handed loomcycle's own scaffolding, the extractor extracted the
+// scaffolding — so the bridge banks dialogue and nothing else.
+//
+// Filtering is by block TYPE, never by pattern: a user turn that happens to
+// contain JSON is content and must survive verbatim.
+func TestConversationFromMessages_DropsToolTraffic(t *testing.T) {
+	msgs := []providers.Message{
+		textMsg("user", "I run ROCm on an AMD card"),
+		{Role: "assistant", Content: []providers.ContentBlock{
+			{Type: "text", Text: "Noted."},
+			{Type: "tool_use", ToolName: "Bash", ToolInput: json.RawMessage(`{"cmd":"rocminfo"}`)},
+		}},
+		// A pure tool_result turn: no dialogue at all → dropped entirely.
+		{Role: "user", Content: []providers.ContentBlock{{Type: "tool_result", Text: "gfx1100"}}},
+		// A user turn that legitimately contains JSON — content, not plumbing.
+		textMsg("user", `my config is {"num_ctx": 131072}`),
+		// Thinking is run mechanics.
+		{Role: "assistant", Content: []providers.ContentBlock{{Type: "thinking", Text: "hmm"}}},
+	}
+
+	got := ConversationFromMessages(msgs)
+	if len(got) != 3 {
+		t.Fatalf("got %d turns, want 3 (two user turns + one assistant): %+v", len(got), got)
+	}
+	if got[0].Content != "I run ROCm on an AMD card" || got[0].Role != "user" {
+		t.Errorf("turn 0 = %+v", got[0])
+	}
+	// The assistant turn keeps its text and loses the tool_use beside it.
+	if got[1].Content != "Noted." {
+		t.Errorf("turn 1 = %q, want just the text half of a mixed turn", got[1].Content)
+	}
+	if got[2].Content != `my config is {"num_ctx": 131072}` {
+		t.Errorf("a user turn containing JSON was altered: %q", got[2].Content)
+	}
+	blob, _ := json.Marshal(got)
+	for _, banned := range []string{"rocminfo", "gfx1100", "tool_use", "tool_result", "hmm"} {
+		if strings.Contains(string(blob), banned) {
+			t.Errorf("banked payload leaked run mechanics %q: %s", banned, blob)
+		}
+	}
+}
+
+// TestConversationFromMessages_ToolOnlySpanIsEmpty: a span of pure tool traffic
+// yields nothing, which BankSpan then treats as a legitimate nothing-to-bank
+// rather than enqueueing an empty conversation for the extractor to puzzle over.
+func TestConversationFromMessages_ToolOnlySpanIsEmpty(t *testing.T) {
+	msgs := []providers.Message{
+		{Role: "assistant", Content: []providers.ContentBlock{{Type: "tool_use", ToolName: "Read"}}},
+		{Role: "user", Content: []providers.ContentBlock{{Type: "tool_result", Text: "file contents"}}},
+	}
+	if got := ConversationFromMessages(msgs); len(got) != 0 {
+		t.Errorf("got %d turns from a tool-only span, want 0: %+v", len(got), got)
+	}
+}
+
+// TestBankSpan_RefusesWithoutAWritableScope: an agent with no resolvable user
+// scope must get a NAMED refusal, not a silent no-op. Consolidation drains user
+// scopes only, so banking anywhere else would enqueue a row nothing ever reads —
+// and "banked and silently forgotten" is worse than "not banked".
+func TestBankSpan_RefusesWithoutAWritableScope(t *testing.T) {
+	_, err := BankSpan(context.Background(), nil, BankSpanRequest{
+		Messages: []LayerMessage{{Role: "user", Content: "x"}},
+	})
+	if err == nil {
+		t.Fatal("banking with no store succeeded")
+	}
+	// And with a store but no scope id, the refusal names the scope.
+	_, err = BankSpan(context.Background(), stubPendingStore{}, BankSpanRequest{
+		Messages: []LayerMessage{{Role: "user", Content: "x"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "scope") {
+		t.Errorf("err = %v, want a refusal naming the missing scope", err)
+	}
+}
+
+// TestBankSpan_EmptySpanIsNotAnError: nothing to bank is a normal outcome (the
+// converter dropped a tool-only span), distinguishable from a failure because it
+// returns neither an id nor an error.
+func TestBankSpan_EmptySpanIsNotAnError(t *testing.T) {
+	id, err := BankSpan(context.Background(), stubPendingStore{}, BankSpanRequest{ScopeID: "u1"})
+	if err != nil || id != "" {
+		t.Errorf("got id=%q err=%v, want both empty", id, err)
+	}
+}
+
+// TestBankSpan_OversizedSpanIsRefusedNotTruncated: the guard REFUSES and names the
+// size. Truncating would silently drop part of a conversation, which is the exact
+// failure mode several releases went into eliminating, and it would be invisible.
+func TestBankSpan_OversizedSpanIsRefusedNotTruncated(t *testing.T) {
+	st := &recordingPendingStore{}
+	huge := strings.Repeat("x", BankSpanMaxBytes+1)
+	id, err := BankSpan(context.Background(), st, BankSpanRequest{
+		ScopeID:  "u1",
+		Messages: []LayerMessage{{Role: "user", Content: huge}},
+	})
+	if err == nil {
+		t.Fatal("an oversized span was accepted")
+	}
+	if id != "" || st.calls != 0 {
+		t.Errorf("an oversized span reached the store (id=%q calls=%d) — it must be refused before the write, not truncated into one", id, st.calls)
+	}
+	if !strings.Contains(err.Error(), "unaffected") {
+		t.Errorf("err = %v; it should say the compaction itself is unaffected, since that is the operator's first question", err)
+	}
+}
+
+// TestBankSpan_StampsCompactionOriginAndProvenance: the row must carry the origin
+// that makes a consolidated fact traceable to a compaction, plus the run/session
+// that become its origin link.
+func TestBankSpan_StampsCompactionOriginAndProvenance(t *testing.T) {
+	st := &recordingPendingStore{}
+	id, err := BankSpan(context.Background(), st, BankSpanRequest{
+		TenantID: "acme", Scope: "user", ScopeID: "u1",
+		RunID: "run-1", SessionID: "sess-1",
+		Messages: []LayerMessage{{Role: "user", Content: "I use ROCm"}},
+		Metadata: map[string]string{"source": "compaction"},
+	})
+	if err != nil {
+		t.Fatalf("BankSpan: %v", err)
+	}
+	if id == "" || st.calls != 1 {
+		t.Fatalf("id=%q calls=%d, want an id and exactly one enqueue", id, st.calls)
+	}
+	row := st.last
+	if row.Origin != "compaction" {
+		t.Errorf("origin = %q, want compaction — otherwise the fact is indistinguishable from a scheduled pass", row.Origin)
+	}
+	if row.TenantID != "acme" || row.ScopeID != "u1" || row.SourceRunID != "run-1" || row.SourceSessionID != "sess-1" {
+		t.Errorf("row = %+v, want the tenant/scope/run/session threaded through", row)
+	}
+	if row.ID != id {
+		t.Errorf("returned id %q does not match the enqueued row %q", id, row.ID)
+	}
+	// The payload must be the shape the consolidator parses.
+	var p PendingPayload
+	if err := json.Unmarshal(row.Payload, &p); err != nil {
+		t.Fatalf("payload is not a PendingPayload: %v (%s)", err, row.Payload)
+	}
+	if len(p.Messages) != 1 || p.Messages[0].Content != "I use ROCm" || p.Metadata["source"] != "compaction" {
+		t.Errorf("payload = %+v", p)
+	}
+}
+
+// The stubs embed store.Store (nil) so only the one method BankSpan calls is
+// defined — implementing the full interface in a test would be pages of noise,
+// and any accidental call to another method panics loudly rather than silently
+// returning a zero value.
+type stubPendingStore struct{ store.Store }
+
+func (stubPendingStore) MemoryPendingEnqueue(context.Context, store.MemoryPendingRow) error {
+	return nil
+}
+
+type recordingPendingStore struct {
+	store.Store
+	calls int
+	last  store.MemoryPendingRow
+}
+
+func (r *recordingPendingStore) MemoryPendingEnqueue(_ context.Context, row store.MemoryPendingRow) error {
+	r.calls++
+	r.last = row
+	return nil
+}

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -836,6 +836,26 @@ type ContextCompactionEventInfo struct {
 	// Trigger is "manual" | "auto" | "self" — which path fired the compaction.
 	// Surfaced for metrics + the UI; not used by replay.
 	Trigger string `json:"trigger,omitempty"`
+	// MemoryBanked records that the discarded span was queued for consolidation
+	// (RFC BL P3 `compaction.memory_flush`). Absent when the agent has not opted
+	// in, which is the default. Additive and ignored by replay — banking already
+	// happened when the compaction first ran, so a rebuild must not repeat it.
+	MemoryBanked *MemoryBankedInfo `json:"memory_banked,omitempty"`
+}
+
+// MemoryBankedInfo is the outcome of a compaction's memory flush. It is on the
+// transcript rather than only in a log because five consolidator runs proved a
+// prose report is not evidence — an operator has to be able to read what actually
+// happened out of the run.
+type MemoryBankedInfo struct {
+	// PendingID is the queue row, empty when nothing was banked.
+	PendingID string `json:"pending_id,omitempty"`
+	// Messages counts the conversational turns queued — tool traffic is excluded
+	// before banking, so this is smaller than the span that was dropped.
+	Messages int `json:"messages,omitempty"`
+	// Error names why banking did not happen. Its presence is NOT a failed
+	// compaction: the compaction completed either way, which is the invariant.
+	Error string `json:"error,omitempty"`
 }
 
 // LimitInfo is the structured payload on EventLimit (RFC AW — per-scope token


### PR DESCRIPTION
Third of four PRs for RFC BL P3. Plan: `/loomcycle/docs/plans/rfc-bl-p3-plan`. `compaction.memory_flush` now does something.

## What it closes

Consolidation only selects sessions whose runs are **all terminal** — so an interactive agent that compacts repeatedly and never finishes was never consolidated from transcript at all. Its conversations were reachable only via the `add` queue, and nothing put them there. This does.

It **banks**, it does not flush. Nothing is extracted at compaction time: asking the summarizer's call to also emit facts is two objectives on one reply — the shape that had the LLM consolidator at 0-for-5 before v1.36.0 cut the model's job to one narrow tool-less call. The existing pipeline runs unchanged on its own schedule.

## Where the hook goes is the whole design

`loop.Summarize` has four callers and **only two discard context**:

| caller | banks? | why |
|---|---|---|
| `maybeAutoCompact` | ✅ | auto + self; discards a span nobody has seen |
| `compactRunWithSource` | ✅ | server-side before pushing the control — also covers the terminal case, which never reaches the loop |
| `RecapSession` | ❌ | summarizes **without discarding anything** |
| `computeReplayCompaction` / resume | ❌ | replays a compaction that already banked once |

Hooking `Summarize` would have banked on every recap and **re-banked on every resume** — both silent, both producing duplicate candidates for the dedup band to absorb.

Those two are now unreachable **by construction, not by test**: neither `Summarize` nor `applyCompactSummary` takes `RunOptions`, so neither can see the callback. Both carry an invariant comment saying so, because the guarantee is a type signature and the next person to widen it needs to know what they'd break. `resume.go`'s omission is commented for the same reason.

The loop stays store-free — banking arrives as `RunOptions.BankCompactedSpan`, wired where the store and scope resolution already live. `nil` covers every "do not bank" case at once (flag off, no writable scope, no store), so the loop never learns which, and an unopted agent's path is byte-identical.

## Two things found while building it

**Banking must target `user` scope, and refuse by name otherwise.** Consolidation fans out over user scopes only, so a row banked at agent scope would be enqueued and then **never drained by anything** — banked and silently forgotten, which is worse than not banked. The callback is therefore installed whenever `memory_flush` is set *even when it cannot bank*, so a misconfigured agent gets a named error on every compaction marker instead of silence.

**Tool traffic is filtered out before banking.** v1.36.5 measured what happens when the extractor is fed loomcycle's own scaffolding: it extracted the scaffolding. The filter is by block **type**, never by pattern — a user turn containing JSON is content and survives verbatim, and a span of pure tool traffic yields nothing, which `BankSpan` reports as a legitimate nothing-to-bank rather than a failure.

## Smaller calls worth a look

`BankSpan` writes the queue row **directly** rather than via `MemoryLayer.Add`, because `Add` hardcodes `origin=agent_explicit` — correctly, since an agent reaching it *is* an explicit agent write (and you asked to leave that as-is). Bypassing the tool path costs its size cap, so `BankSpanMaxBytes` replaces it: an oversized span is **refused and named, never truncated**, because silently dropping part of a conversation is the failure this line keeps eliminating, and a refusal is visible in the marker while a truncation is not.

The pending payload shape now has **one** definition (`memory.PendingPayload`), with the in-process backend aliasing it. Two structs describing one wire shape is a drift whose failure is silent — the pass reads a payload it cannot interpret and extracts nothing. `Add`'s behaviour is unchanged.

Outcome rides the existing compaction marker as an additive `memory_banked` block rather than a new event type — on the transcript, because five consolidator runs proved a prose report is not evidence.

## What was tested

`go test ./...` clean · `make build-all`.

5 loop cases, 6 memory cases. **Four verified fail-before:**

| reverted | test says |
|---|---|
| bank the kept tail instead of the dropped span | `banked 2 messages, want 3 — must be exactly what was discarded` |
| let a bank failure abort the compaction | compaction aborts; the run keeps its full context |
| truncate an oversized span instead of refusing | `an oversized span reached the store — must be refused before the write` |
| bank tool traffic too | `got 5 turns, want 3` and queues `gfx1100` (a tool_result) as dialogue |

🤖 Generated with [Claude Code](https://claude.com/claude-code)