### PR TITLE
fix(cloud-deployment): landing /v1 proxy is an allowlist, not a bypassable denylist

### DIFF
--- a/cloud-deployment/README.md
+++ b/cloud-deployment/README.md
@@ -32,7 +32,7 @@ compose network `loomnet`:
 | `builder-sidecar` | `denngubsky/loomcycle-builder-docker:1.25.2` | Sandboxed code exec (`mcp__sandbox__*`) via the host Docker socket. |
 | `loomcycle` | `denngubsky/loomcycle:1.38.0` | The runtime. `network_mode: service:tailscale`. |
 | `searxng` | `searxng/searxng` | Keyless search backend (wired via `config/loomcycle.yaml`). |
-| `landing` | Node (`./landing`, built) | Serves `cloud-web/`, proxies public `/v1/*` + `/healthz` (inner links), and mints `substrate:tenant` tokens behind Cloudflare Access. |
+| `landing` | Node (`./landing`, built) | Serves `cloud-web/`, proxies the public reads `/healthz` + `/v1/config` (inner links), and mints `substrate:tenant` tokens behind Cloudflare Access. |
 | `cloudflared` | `cloudflare/cloudflared` | Outbound tunnel; routes managed in the Cloudflare dashboard (token method). |
 
 ### The landing server + self-serve minting
@@ -41,9 +41,13 @@ compose network `loomnet`:
 
 1. **Serves the static marketing site** (`cloud-web/`, bind-mounted at `/srv`, with
    HTTP range so the videos stream).
-2. **Proxies the runtime's public reads as same-origin "inner links"** — `GET
-   /healthz` and `GET /v1/*` go to `http://tailscale:8787`. The operator-admin
-   plane `/v1/_*` is **refused** here (it must never be reachable on the apex).
+2. **Proxies the runtime's public reads as same-origin "inner links"** — a
+   hardcoded **allowlist** (`GET /healthz` + `GET /v1/config`, the only reads the
+   page makes) forwarded to `http://tailscale:8787`. It is deliberately an
+   allowlist forwarding fixed upstream paths — **not** a blanket `/v1/*` proxy with
+   a `/v1/_*` denylist, which a `..`/`%5f` bypass could slip past — so the
+   operator-admin plane is never reachable on the apex. The bearer-gated app API
+   stays on `app.loomcycle.cloud`.
 3. **Mints `substrate:tenant` tokens** for a Cloudflare-Access-authenticated
    visitor. `POST /api/mint` verifies the Access JWT (`Cf-Access-Jwt-Assertion`
    against the team JWKS + AUD), derives a stable `(tenant, subject)` from the

--- a/cloud-deployment/landing/server.js
+++ b/cloud-deployment/landing/server.js
@@ -105,12 +105,6 @@ app.use(express.json({ limit: "16kb" }));
 // Liveness of the landing process itself (does NOT proxy the runtime).
 app.get("/_up", (_req, res) => res.json({ ok: true }));
 
-// Refuse the operator-admin plane on the public apex (minting goes via /api/mint).
-app.use((req, res, next) => {
-  if (req.path.startsWith("/v1/_")) return res.status(404).end();
-  next();
-});
-
 // GET /api/whoami — the sign-in probe. As an XHR it returns the identity as JSON
 // (401 when not signed in); as a full-page navigation (the "Sign in" button, which
 // triggers the Cloudflare Access login) it redirects back to the landing.
@@ -180,11 +174,16 @@ app.post("/api/mint", async (req, res) => {
   }
 });
 
-// Same-origin proxy for the runtime's PUBLIC reads (inner links). GET only — the
-// landing never issues state-changing calls to /v1 (mint goes through /api/mint).
-async function proxyGet(req, res) {
+// Same-origin proxy for the runtime's PUBLIC reads, exposed as inner links. This
+// is an explicit ALLOWLIST that forwards a HARDCODED upstream path — never a path
+// derived from the request — so no percent-encoding (`%5f`) or `..` traversal can
+// smuggle a different upstream target (e.g. the operator-admin plane /v1/_*). A
+// blanket `/v1/*` proxy + a `/v1/_` denylist would be bypassable, because the
+// guard sees one form of the path and the upstream re-normalizes another. The
+// app's bearer-gated API stays on app.loomcycle.cloud, not this public apex.
+async function proxyGet(req, res, upstreamPath) {
   try {
-    const up = await fetch(RUNTIME_URL + req.originalUrl, {
+    const up = await fetch(RUNTIME_URL + upstreamPath, {
       headers: { Accept: req.get("accept") || "application/json" },
     });
     res.status(up.status);
@@ -196,8 +195,8 @@ async function proxyGet(req, res) {
     res.status(502).json({ error: "runtime unreachable" });
   }
 }
-app.get("/healthz", proxyGet);
-app.get(/^\/v1\//, proxyGet);
+app.get("/healthz", (req, res) => proxyGet(req, res, "/healthz"));
+app.get("/v1/config", (req, res) => proxyGet(req, res, "/v1/config"));
 
 // The static marketing site last (index at /, assets, range-served videos).
 app.use(express.static(WEB_ROOT, { index: "index.html", extensions: ["html"] }));

--- a/cloud-deployment/landing/smoke.mjs
+++ b/cloud-deployment/landing/smoke.mjs
@@ -13,28 +13,40 @@ const WEB_ROOT = path.resolve(HERE, "../../cloud-web"); // serve the real landin
 let failures = 0;
 const ok = (c, m) => { console.log((c ? "PASS " : "FAIL ") + m); if (!c) failures++; };
 
-// 1) stub loomcycle upstream — records what /v1/_operatortokendef received.
+// 1) stub loomcycle upstream — records what /v1/_operatortokendef received. It
+// decodes + normalizes the path the way Go's net/http does, so a `..`/`%5f`
+// bypass forwarded by the landing WOULD reach the admin plane here (→ a "leak"
+// the regression catches).
 let mintSaw = null;
 const upstream = http.createServer((req, res) => {
-  if (req.method === "GET" && req.url === "/healthz") {
+  let p;
+  try { p = path.posix.normalize(decodeURIComponent(new URL(req.url, "http://x").pathname)); }
+  catch { p = req.url; }
+  if (req.method === "GET" && p === "/healthz") {
     res.setHeader("content-type", "application/json");
     return res.end(JSON.stringify({ ok: true, version: "test" }));
   }
-  if (req.method === "GET" && req.url === "/v1/config") {
+  if (req.method === "GET" && p === "/v1/config") {
     res.setHeader("content-type", "application/json");
     return res.end(JSON.stringify({ version: "test", features: { sqlmem: true } }));
   }
-  if (req.method === "POST" && req.url === "/v1/_operatortokendef") {
-    let b = ""; req.on("data", (d) => (b += d)); req.on("end", () => {
-      const body = JSON.parse(b || "{}");
-      mintSaw = { auth: req.headers.authorization || "", body };
-      res.setHeader("content-type", "application/json");
-      res.end(JSON.stringify({
-        name: body.name, tenant_id: body.tenant_id, subject: body.subject,
-        allowed_scopes: body.scopes, token: "lc_TESTTOKEN0001", token_suffix: "0001",
-      }));
-    });
-    return;
+  if (p === "/v1/_operatortokendef") {
+    if (req.method === "POST") {
+      let b = ""; req.on("data", (d) => (b += d)); req.on("end", () => {
+        const body = JSON.parse(b || "{}");
+        mintSaw = { auth: req.headers.authorization || "", body };
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify({
+          name: body.name, tenant_id: body.tenant_id, subject: body.subject,
+          allowed_scopes: body.scopes, token: "lc_TESTTOKEN0001", token_suffix: "0001",
+        }));
+      });
+      return;
+    }
+    // reaching the admin plane by any other method means the landing let a bypass
+    // through — a detectable leak.
+    res.statusCode = 200; res.setHeader("content-type", "application/json");
+    return res.end(JSON.stringify({ leaked: true }));
   }
   res.statusCode = 404; res.end("nope");
 });
@@ -71,6 +83,18 @@ try {
   // admin plane blocked on the apex
   const admin = await fetch(base + "/v1/_operatortokendef", { method: "POST", headers: { "content-type": "application/json" }, body: "{}" });
   ok(admin.status === 404, "/v1/_operatortokendef refused on the apex (404)");
+
+  // the /v1 proxy is an ALLOWLIST (not a bypassable /v1/_ denylist): raw requests
+  // that skip fetch's URL normalization — traversal + percent-encoding — must NOT
+  // reach the admin plane or any non-allowlisted endpoint.
+  const rawGet = (pathRaw) => new Promise((resolve) => {
+    const r = http.request({ host: "127.0.0.1", port: 8099, method: "GET", path: pathRaw }, (res) => { res.resume(); resolve(res.statusCode); });
+    r.on("error", () => resolve(0)); r.end();
+  });
+  for (const p of ["/v1/config/../_operatortokendef", "/v1/config/..%2f_operatortokendef", "/v1/%5foperatortokendef", "/v1/runs"]) {
+    const st = await rawGet(p);
+    ok(st === 404, `apex refuses ${p} (allowlist, not a bypassable denylist)`);
+  }
 
   // whoami (dev identity)
   const who = await (await fetch(base + "/api/whoami")).json();


### PR DESCRIPTION
## Security fix (follow-up to #852 / v1.39.0)

A push-time security review flagged an **admin-plane guard bypass** in the landing server.

### The bug
The landing blocked the operator-admin plane with a substring check and then blanket-proxied `/v1/*` by forwarding `req.originalUrl`:
```js
app.use((req,res,next)=>{ if (req.path.startsWith("/v1/_")) return res.status(404).end(); next(); });
app.get(/^\/v1\//, (req,res)=>proxyGet(req,res,req.originalUrl));
```
The guard saw one form of the path and the upstream re-normalized another, so all of these slipped past the denylist and the runtime (Go `net/http`) normalized them back onto `/v1/_*`:
- `GET /v1/config/../_operatortokendef`
- `GET /v1/config/..%2f_operatortokendef`
- `GET /v1/%5foperatortokendef`

No admin bearer leaks (`proxyGet` never adds one, so the upstream still 401s the admin plane), but the guard whose job is to keep `/v1/_*` **off the public apex** was bypassable.

### The fix
Replace the blanket proxy + denylist with an explicit **allowlist that forwards hardcoded upstream paths** — `GET /healthz` and `GET /v1/config` (the only reads the page makes). No path derived from the request reaches the upstream; anything outside those two exact paths 404s at the landing. The bearer-gated app API stays on `app.loomcycle.cloud`.

### Regression
`smoke.mjs` now decodes+normalizes paths in the stub upstream (mimicking Go) and asserts raw traversal/percent-encoding requests are refused. **Fail-before verified** — the old denylist let all three bypass forms reach the admin plane; the allowlist refuses them. All 15 smoke checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)