### PR TITLE
fix(memory): exclude Document chunk bodies from the per-scope memory quota

### DIFF
--- a/internal/memory/backends/inprocess/inprocess.go
+++ b/internal/memory/backends/inprocess/inprocess.go
@@ -519,3 +519,23 @@ var (
 	_ memory.MemoryLayer = (*Backend)(nil)
 	_ memory.Capable     = (*Backend)(nil)
 )
+
+// ScopeUsage reports the scope's live memory footprint EXCLUDING Document chunk
+// bodies (RFC AK stores them in this same keyspace under a reserved prefix).
+//
+// It satisfies the optional capability the Memory tool's quota check probes for.
+// The old check listed the scope with a 1000-key cap and treated truncation as a
+// refusal — correct in spirit (undercounting would let a thousand-tiny-key agent
+// slip the cap) but wrong here: a scope holding thousands of document chunks
+// truncated before reaching the agent's own rows, so every write was refused with
+// "more than 1000 keys" while the real memory footprint was a few kilobytes. That
+// is not a hypothetical; it locked out a live deployment whose user scope held
+// 2,998 chunk bodies against 38 facts.
+//
+// Documents ALWAYS write chunk bodies to the main store, never to a remote
+// backend, which is why only this backend implements the capability — a remote
+// backend's keyspace cannot contain them, so its List-based count is already
+// right.
+func (b *Backend) ScopeUsage(ctx context.Context, scope store.MemoryScope, scopeID string) (int, int, error) {
+	return b.store.MemoryScopeUsage(ctx, runTenant(ctx), scope, scopeID, memory.DocumentChunkKeyPrefix)
+}

--- a/internal/memory/inject.go
+++ b/internal/memory/inject.go
@@ -31,6 +31,19 @@ import (
 // injection reader.
 const CoreBlockKeyPrefix = "core/"
 
+// DocumentChunkKeyPrefix is the reserved KV Memory namespace for RFC AK Document
+// chunk BODIES: a chunk's body lives at `doc.chunk:<uuid>` in the same
+// (tenant, scope, scope_id) partition as an agent's own memory.
+//
+// That sharing is what makes this a single source of truth rather than a detail.
+// Chunk bodies are Document storage — written by the Document tool, governed by
+// its own quota — but they sit in the memory keyspace, so anything reasoning about
+// "how much memory does this agent have" MUST exclude them. A user with a few
+// thousand document chunks is a normal, intended state (a chunked-graph store
+// scaling to thousands of chunks is the point of the feature), and counting those
+// against the per-scope memory quota locks the agent out of writing memory at all.
+const DocumentChunkKeyPrefix = "doc.chunk:"
+
 // Variant is one of the closed set of {{memory:<variant>}} placeholders.
 type Variant string
 

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -4181,6 +4181,34 @@ func anyScopeIDs(scopeIDs []string) []any {
 	return []any{scopeIDs}
 }
 
+// MemoryScopeUsage sums the scope's live footprint in SQL, excluding a namespace.
+// The live predicate mirrors MemoryList exactly (unexpired + not superseded) so
+// the quota measures what a read would actually surface. `value` is jsonb here, so
+// the byte length is taken from its text rendering to match the sqlite tier.
+func (s *Store) MemoryScopeUsage(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, excludeKeyPrefix string) (int, int, error) {
+	// The exclusion is a CONDITIONAL clause, not a sentinel value: an empty prefix
+	// must exclude NOTHING, and that is simply a different query. A NUL sentinel is
+	// not even representable here — Postgres rejects it with "invalid byte sequence
+	// for encoding UTF8: 0x00", which is how the first cut was caught — and any
+	// printable one is a value a key could theoretically hold.
+	q := `SELECT COUNT(*), COALESCE(SUM(LENGTH(key) + LENGTH(value::text)), 0)
+		   FROM memory
+		  WHERE tenant_id = $1 AND scope = $2 AND scope_id = $3
+		    AND (expires_at IS NULL OR expires_at > NOW())
+		    AND superseded_at IS NULL`
+	args := []any{tenantID, string(scope), scopeID}
+	if excludeKeyPrefix != "" {
+		q += ` AND key NOT LIKE $4 ESCAPE '\'`
+		args = append(args, escapeLikePrefix(excludeKeyPrefix)+"%")
+	}
+	var keys, bytes int64
+	err := s.pool.QueryRow(ctx, q, args...).Scan(&keys, &bytes)
+	if err != nil {
+		return 0, 0, fmt.Errorf("memory scope usage: %w", err)
+	}
+	return int(keys), int(bytes), nil
+}
+
 // MemorySweep deletes every Memory row whose expires_at has passed.
 // Single atomic DELETE so concurrent sweepers race correctly.
 func (s *Store) MemorySweep(ctx context.Context) (int, error) {

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -4610,6 +4610,33 @@ func placeholders(n int) string {
 	return strings.TrimSuffix(strings.Repeat("?,", n), ",")
 }
 
+// MemoryScopeUsage sums the scope's live footprint in SQL, excluding a namespace.
+// The live predicate mirrors MemoryList exactly (unexpired + not superseded) so
+// the quota measures what a read would actually surface.
+func (s *Store) MemoryScopeUsage(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, excludeKeyPrefix string) (int, int, error) {
+	// The exclusion is a CONDITIONAL clause, not a sentinel value. An earlier cut
+	// used an impossible-string sentinel to keep the query shape fixed; Postgres
+	// rejected it outright ("invalid byte sequence for encoding UTF8: 0x00"), and
+	// any PRINTABLE sentinel is a value a key could theoretically hold. An empty
+	// prefix must exclude NOTHING, and that is simply a different query.
+	q := `SELECT COUNT(*), COALESCE(SUM(LENGTH(key) + LENGTH(value)), 0)
+		   FROM memory
+		  WHERE tenant_id = ? AND scope = ? AND scope_id = ?
+		    AND (expires_at IS NULL OR expires_at > ?)
+		    AND superseded_at IS NULL`
+	args := []any{tenantID, string(scope), scopeID, time.Now().UnixNano()}
+	if excludeKeyPrefix != "" {
+		q += ` AND key NOT LIKE ? ESCAPE '\'`
+		args = append(args, escapeLikePrefix(excludeKeyPrefix)+"%")
+	}
+	var keys, bytes sql.NullInt64
+	err := s.db.QueryRowContext(ctx, q, args...).Scan(&keys, &bytes)
+	if err != nil {
+		return 0, 0, err
+	}
+	return int(keys.Int64), int(bytes.Int64), nil
+}
+
 // MemoryFullTextSearch is the RFC BL keyword-retrieval leg. SQLite ships no
 // tsvector index (the vectors themselves are Postgres-only), so per the
 // documented degrade posture this returns (nil, nil) rather than erroring —

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1752,6 +1752,21 @@ type Store interface {
 	// Returns *ErrNotFound when no such row is visible to the caller.
 	MemoryPendingGet(ctx context.Context, tenantID string, scope MemoryScope, scopeID, id string) (MemoryPendingRow, error)
 
+	// MemoryScopeUsage sums a scope's live key count and byte footprint
+	// (len(key)+len(value)) server-side, EXCLUDING keys under excludeKeyPrefix.
+	//
+	// It exists because the quota check cannot be done by listing. Listing is
+	// capped, and a scope holding thousands of Document chunk bodies truncates
+	// before the agent's own memory rows are reached — so the check refused every
+	// write with "more than N keys" while the actual memory footprint was a few
+	// kilobytes. Summing in SQL has no cap and needs one round trip, which also
+	// retires the "if we ever need to scale this" note on the old path.
+	//
+	// excludeKeyPrefix is a caller-supplied namespace (the Document chunk-body
+	// prefix in practice); empty counts everything. Expired and superseded rows
+	// are excluded, matching what a read would actually surface.
+	MemoryScopeUsage(ctx context.Context, tenantID string, scope MemoryScope, scopeID, excludeKeyPrefix string) (keys int, bytes int, err error)
+
 	// MemoryCursorGet returns the consolidation cursor for a target. It is a
 	// GET-OR-DEFAULT: a target with no row yet returns a zero-watermark,
 	// unleased MemoryCursorRow (TenantID/Scope/ScopeID populated, everything

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -154,6 +154,7 @@ func Run(t *testing.T, factory Factory) {
 		{"MemorySupersedeRevivedByWrite", testMemorySupersedeRevivedByWrite},
 		{"MemoryPendingEnqueueDrainAck", testMemoryPendingEnqueueDrainAck},
 		{"MemoryPendingOriginRoundTripsAndIsScoped", testMemoryPendingOriginRoundTripsAndIsScoped},
+		{"MemoryScopeUsageExcludesNamespace", testMemoryScopeUsageExcludesNamespace},
 		{"MemoryCursorGetDefault", testMemoryCursorGetDefault},
 		{"MemoryCursorLeaseCAS", testMemoryCursorLeaseCAS},
 		{"MemoryCursorAdvanceMonotonicAndOwner", testMemoryCursorAdvanceMonotonicAndOwner},
@@ -10634,5 +10635,67 @@ func testMemoryPendingOriginRoundTripsAndIsScoped(t *testing.T, s store.Store) {
 		if !errors.As(err, &nf) {
 			t.Errorf("%s: got err %v, want *ErrNotFound — the lookup tuple must be the authz check", bad.name, err)
 		}
+	}
+}
+
+// testMemoryScopeUsageExcludesNamespace: the quota's accounting primitive. It must
+// sum in SQL (no list cap — the whole reason it exists) and honour the exclusion,
+// with the same live-row predicate MemoryList uses so the quota measures what a
+// read would surface.
+func testMemoryScopeUsageExcludesNamespace(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	const (
+		tenant  = "acme"
+		scopeID = "u1"
+	)
+	scope := store.MemoryScopeUser
+
+	// Two real memory rows...
+	for _, k := range []string{"memory/fact/a", "memory/fact/b"} {
+		if err := s.MemorySet(ctx, tenant, scope, scopeID, k, json.RawMessage(`"vv"`), 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// ...and MORE than the old 1000-key list cap of excluded rows, which is the
+	// case that broke: listing truncated before the memory rows were reached.
+	for i := 0; i < 1100; i++ {
+		k := "doc.chunk:" + strconv.Itoa(i)
+		if err := s.MemorySet(ctx, tenant, scope, scopeID, k, json.RawMessage(`"body"`), 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	keys, bytes, err := s.MemoryScopeUsage(ctx, tenant, scope, scopeID, "doc.chunk:")
+	if err != nil {
+		t.Fatalf("MemoryScopeUsage: %v", err)
+	}
+	if keys != 2 {
+		t.Errorf("keys = %d, want 2 — the excluded namespace leaked into the count (or the sum is list-capped)", keys)
+	}
+	if bytes <= 0 {
+		t.Errorf("bytes = %d, want the two memory rows' footprint", bytes)
+	}
+	// Sanity: the exclusion is doing work, not returning everything.
+	allKeys, allBytes, err := s.MemoryScopeUsage(ctx, tenant, scope, scopeID, "")
+	if err != nil {
+		t.Fatalf("MemoryScopeUsage(no exclusion): %v", err)
+	}
+	if allKeys != 1102 {
+		t.Errorf("unfiltered keys = %d, want 1102 — an empty prefix must exclude NOTHING (a `%%` sentinel would zero this)", allKeys)
+	}
+	if allBytes <= bytes {
+		t.Errorf("unfiltered bytes %d should exceed filtered %d", allBytes, bytes)
+	}
+
+	// A superseded row drops out, matching MemoryList's live predicate.
+	if err := s.MemorySupersede(ctx, tenant, scope, scopeID, "memory/fact/a"); err != nil {
+		t.Fatalf("supersede: %v", err)
+	}
+	keys, _, err = s.MemoryScopeUsage(ctx, tenant, scope, scopeID, "doc.chunk:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if keys != 1 {
+		t.Errorf("keys = %d after superseding one of two, want 1 — a soft-archived row must not hold quota", keys)
 	}
 }

--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -2119,6 +2119,14 @@ func bytesEqual(a, b []byte) bool {
 //
 // 0 quota = "no cap" (matches the env var convention for "feature
 // disabled"). The check short-circuits then.
+// scopeUsageCounter is the optional backend capability that sums a scope's memory
+// footprint server-side, excluding namespaces that are not agent memory. Only the
+// in-process backend implements it, because only the main store can hold Document
+// chunk bodies; a remote backend keeps the list-based path.
+type scopeUsageCounter interface {
+	ScopeUsage(ctx context.Context, scope store.MemoryScope, scopeID string) (keys int, bytes int, err error)
+}
+
 func (m *Memory) checkQuota(ctx context.Context, scope store.MemoryScope, scopeID, key string, addBytes int) error {
 	policy := tools.MemoryPolicy(ctx)
 	quota := policy.QuotaBytes
@@ -2129,6 +2137,37 @@ func (m *Memory) checkQuota(ctx context.Context, scope store.MemoryScope, scopeI
 		return nil
 	}
 
+	// Preferred path: ask the backend to sum the scope in one query, excluding
+	// the Document chunk-body namespace. RFC AK stores chunk bodies in this same
+	// keyspace, and a scope holding thousands of them truncated the list below
+	// before the agent's own rows were reached — refusing every write with "more
+	// than 1000 keys" while the real memory footprint was kilobytes. Documents
+	// are governed by their own quota; counting them here conflated two
+	// subsystems and produced an error that named the wrong problem ("delete
+	// unused keys first" would have an operator deleting their documents).
+	if sc, ok := m.backend(ctx).(scopeUsageCounter); ok {
+		_, used, err := sc.ScopeUsage(ctx, scope, scopeID)
+		if err != nil {
+			return fmt.Errorf("quota check: %w", err)
+		}
+		// An overwrite replaces the existing row, so its bytes are not additive.
+		if existing, gerr := m.backend(ctx).Get(ctx, scope, scopeID, key); gerr == nil {
+			used -= len(key) + len(existing.Value)
+			if used < 0 {
+				used = 0
+			}
+		}
+		if projected := used + len(key) + addBytes; projected > quota {
+			return fmt.Errorf("Memory.set: scope %q quota %d bytes would be exceeded by this write (current=%d, after=%d)",
+				scope, quota, used, projected)
+		}
+		return nil
+	}
+
+	// Fallback for a REMOTE backend, which cannot host Document chunk bodies
+	// (Documents always write to the main store) — so its list-based count is
+	// already correct, and the truncation refusal below is a real signal there.
+	//
 	// Sum existing bytes (key + value) across the whole scope. The
 	// list call is expected to be small for a well-behaved agent — a
 	// noisy agent that writes thousands of keys hits the quota cap

--- a/internal/tools/builtin/memory_provenance_test.go
+++ b/internal/tools/builtin/memory_provenance_test.go
@@ -3,9 +3,11 @@ package builtin
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
+	memrank "github.com/denn-gubsky/loomcycle/internal/memory"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
@@ -407,5 +409,82 @@ func TestMemoryAdd_StampsAgentExplicitOrigin(t *testing.T) {
 	if rows[0].Origin != store.PendingOriginAgentExplicit {
 		t.Errorf("enqueued origin = %q, want %q — an agent reaching `add` IS an explicit agent write, and the value must come from the server rather than the tool input",
 			rows[0].Origin, store.PendingOriginAgentExplicit)
+	}
+}
+
+// TestMemoryQuota_DocumentChunksDoNotLockOutMemoryWrites reproduces a live
+// production lockout, exactly.
+//
+// RFC AK stores Document chunk BODIES in the memory keyspace as
+// `doc.chunk:<uuid>`, in the same (tenant, scope, scope_id) partition as an
+// agent's own memory. The quota check listed that scope with a 1000-key cap and
+// treated truncation as a refusal — so a user scope holding 2,998 chunk bodies
+// against 38 facts refused EVERY memory write with "more than 1000 keys; delete
+// unused keys first", while the actual memory footprint was a few kilobytes. The
+// consolidator read ten chats, extracted five facts, and wrote none of them.
+//
+// Two things are asserted, because fixing only the first would leave the quota
+// silently wrong: the write must SUCCEED past the old truncation wall, and the
+// chunk bodies must not COUNT toward the byte quota either.
+//
+// Fails before the fix with the "more than 1000 keys" refusal.
+func TestMemoryQuota_DocumentChunksDoNotLockOutMemoryWrites(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t)
+	defer cleanup()
+	// A small quota: 4 KB of real memory. The chunk bodies below are ~100 KB
+	// total, so if they were counted the write would fail on bytes even after the
+	// key-count wall is gone.
+	tool.DefaultQuotaBytes = 4096
+
+	// 1200 document chunks — past the old 1000-key list cap.
+	for i := 0; i < 1200; i++ {
+		key := memrank.DocumentChunkKeyPrefix + fmt.Sprintf("%032x", i)
+		body := json.RawMessage(`{"body":"` + strings.Repeat("x", 80) + `"}`)
+		if err := tool.Store.MemorySet(context.Background(), "", store.MemoryScopeAgent, "qa-agent", key, body, 0); err != nil {
+			t.Fatalf("seed chunk %d: %v", i, err)
+		}
+	}
+
+	res, _ := tool.Execute(ctx, json.RawMessage(
+		`{"op":"set","scope":"agent","key":"memory/fact/user-runs-rocm","value":"The user runs ROCm on an AMD card."}`))
+	if res.IsError {
+		t.Fatalf("a memory write was refused because the scope holds Document chunk bodies: %s", res.Text)
+	}
+
+	// The fact really landed.
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"get","scope":"agent","key":"memory/fact/user-runs-rocm"}`))
+	if res.IsError || decodeResult(t, res.Text)["value"] == nil {
+		t.Fatalf("the write reported success but nothing is readable: %s", res.Text)
+	}
+
+	// And chunk bytes are excluded from the quota, not merely from the key count:
+	// ~100 KB of bodies against a 4 KB quota would otherwise refuse this.
+	res, _ = tool.Execute(ctx, json.RawMessage(
+		`{"op":"set","scope":"agent","key":"memory/fact/second","value":"Another durable fact."}`))
+	if res.IsError {
+		t.Errorf("Document chunk bytes are being counted toward the memory quota: %s", res.Text)
+	}
+}
+
+// TestMemoryQuota_StillRefusesRealMemoryOverrun: the fix must not disarm the cap
+// it was narrowing. Agent-written keys still count, and a genuine overrun is still
+// refused — otherwise excluding one namespace would have removed the quota.
+func TestMemoryQuota_StillRefusesRealMemoryOverrun(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t)
+	defer cleanup()
+	tool.DefaultQuotaBytes = 2048
+
+	big := strings.Repeat("y", 1500)
+	if res, _ := tool.Execute(ctx, json.RawMessage(
+		`{"op":"set","scope":"agent","key":"memory/fact/a","value":"`+big+`"}`)); res.IsError {
+		t.Fatalf("first write should fit: %s", res.Text)
+	}
+	res, _ := tool.Execute(ctx, json.RawMessage(
+		`{"op":"set","scope":"agent","key":"memory/fact/b","value":"`+big+`"}`))
+	if !res.IsError {
+		t.Error("two 1500-byte facts fit under a 2048-byte quota; the cap is not being enforced")
+	}
+	if !strings.Contains(res.Text, "quota") {
+		t.Errorf("refusal does not name the quota: %s", res.Text)
 	}
 }


### PR DESCRIPTION
## The symptom, from a live deployment

The consolidator read ten chats, extracted five facts, and wrote **none** of them:

```
Memory.set: scope "user" has more than 1000 keys; quota check cannot run
accurately — delete unused keys first
```

That scope held **3,036 keys: 38 agent facts and 2,998 Document chunk bodies.**

## Why it's structural, not tuning

RFC AK stores chunk **bodies** in the memory keyspace as `doc.chunk:<uuid>`, in the same `(tenant, scope, scope_id)` partition as an agent's own memory. The quota check counted them together — conflating two subsystems. The quota bounds an *agent's* k/v growth; chunk bodies are Document storage under the Document tool's own quota.

A user with a few thousand document chunks is a **normal, intended** state — a chunked-graph store scaling to thousands of chunks is the point of the feature. So raising the cap only moves the wall. The message named the wrong problem too: "delete unused keys first" would have an operator deleting their documents.

## Post-filtering the list cannot fix it

The old check listed the scope with a 1000-key cap and treated truncation as a refusal — right in spirit, since undercounting would let a thousand-tiny-key agent slip the cap. But the list truncated **on chunk bodies before reaching the agent's rows**, so filtering afterwards helps nothing.

`MemoryScopeUsage` sums count+bytes server-side with the namespace excluded: no cap, one round trip, and it retires the "if we ever need to scale this, we'll add a cached counter" note the old path carried.

## Two details worth reviewing

**The exclusion is a conditional clause, not a sentinel.** My first cut used an impossible-string sentinel to keep one query shape. Postgres rejected it outright — `invalid byte sequence for encoding UTF8: 0x00` — and any *printable* sentinel is a value a key could theoretically hold. An empty prefix must exclude nothing, and that's simply a different query. Caught by running the contract arm on both tiers rather than one.

**Scoped as an optional backend capability.** Only the in-process backend implements it, because Documents always write chunk bodies to the main store — a remote memory backend's keyspace *cannot* contain them, so its list-based count is already correct and the truncation refusal stays a real signal there.

The live predicate mirrors `MemoryList` (unexpired + not superseded), so the quota measures what a read would surface; a soft-archived row no longer holds quota, asserted in the contract.

## Tested

`go test ./...` clean · contract arm green on **both** tiers (Postgres against the real fixture).

Both halves verified fail-before:

| reverted | result |
|---|---|
| back to the list path | reproduces the production refusal verbatim |
| count chunk bodies in the sum | still refuses — `current=159600` vs a 4096-byte quota |

That second one is why the regression asserts **both** that the write succeeds *and* that chunk bytes don't count: fixing only the key-count wall leaves the quota silently wrong. A third test pins that the cap still refuses a genuine overrun, so narrowing one namespace didn't disarm it.

## After this deploys

The compaction-banked row from the `chat/local` pass is **still queued, undrained** — the pass left it alone rather than acking it away, so re-running the consolidator should pick up those 16 turns and write the facts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)