### PR TITLE
fix(bundle): relay the drained pending id so a compaction-sourced fact says so

### DIFF
--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -817,7 +817,13 @@ agents:
         // items the model never examined is not bounded and not recoverable, so
         // here the same answer means the batch simply stays queued.
         if (st.batch_empty) { return []; }
-        if (!applyFacts(st, facts, "")) { return []; }
+        // Attribute the batch ONLY when it is a single item. Several items are
+        // rendered into one text, so a fact from a multi-item batch cannot honestly
+        // be traced to one of them — and a wrong citation is worse than none. A
+        // compaction banks one span, so the case this exists for is the single one.
+        var attributeTo = (taken.length === 1 && taken[0] && typeof taken[0].id === "string")
+          ? taken[0].id : "";
+        if (!applyFacts(st, facts, "", attributeTo)) { return []; }
 
         var ids = [];
         for (var i = 0; i < taken.length; i++) {
@@ -865,10 +871,10 @@ agents:
       // ---------------------------------------------------------------- write
 
       // applyFacts returns true only when every write it attempted landed.
-      function applyFacts(st, facts, sourceID) {
+      function applyFacts(st, facts, sourceID, pendingID) {
         var ok = true;
         for (var i = 0; i < facts.length; i++) {
-          if (!applyOne(st, facts[i], sourceID)) { ok = false; }
+          if (!applyOne(st, facts[i], sourceID, pendingID)) { ok = false; }
         }
         return ok;
       }
@@ -890,7 +896,7 @@ agents:
       // nothing else. There is nowhere structured to put the linkage — the
       // provenance block's schema is closed (class + source ids only) — and it is
       // not worth a corrupted value, so it is gone.
-      function applyOne(st, fact, sourceID) {
+      function applyOne(st, fact, sourceID, pendingID) {
         var neighbours = recall(st, fact.text);
         var dupes = [];
 
@@ -925,12 +931,12 @@ agents:
           // are queued, and retire() applies the pass-wide cap once. Superseding
           // them is what collapses the pile back to one canonical row.
           for (var d = 1; d < dupes.length; d++) { st.supersede_queue.push(dupes[d].id); }
-          if (!write(st, primary.id, fact, sourceID)) { return false; }
+          if (!write(st, primary.id, fact, sourceID, pendingID)) { return false; }
           st.updated++;
           return true;
         }
 
-        if (!write(st, factKey(fact), fact, sourceID)) { return false; }
+        if (!write(st, factKey(fact), fact, sourceID, pendingID)) { return false; }
         st.written++;
         return true;
       }
@@ -1034,7 +1040,7 @@ agents:
       // stored ones silently moves every fact off that calibration and the
       // deduplication above quietly stops firing. A test asserts the two are
       // byte-identical on every write.
-      function write(st, key, fact, sourceID) {
+      function write(st, key, fact, sourceID, pendingID) {
         var args = {
           scope: CONFIG.scope,
           key: key,
@@ -1044,6 +1050,13 @@ agents:
           provenance: sourceID ? { "class": fact.cls, source_session_id: sourceID }
                                : { "class": fact.cls }
         };
+        // A fact distilled from a QUEUED item relays that item's id so the server
+        // resolves its origin + source ids from the pending row. We cannot author
+        // origin ourselves — it is server-stamped precisely so an agent cannot
+        // label its own writes — so without this the fact lands origin=consolidator
+        // and is indistinguishable from one read out of an ordinary transcript,
+        // which is the whole thing the pending origin column exists to tell apart.
+        if (pendingID) { args.from_pending = pendingID; }
         try {
           Memory.set(args);
         } catch (e) {

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -817,7 +817,13 @@ agents:
         // items the model never examined is not bounded and not recoverable, so
         // here the same answer means the batch simply stays queued.
         if (st.batch_empty) { return []; }
-        if (!applyFacts(st, facts, "")) { return []; }
+        // Attribute the batch ONLY when it is a single item. Several items are
+        // rendered into one text, so a fact from a multi-item batch cannot honestly
+        // be traced to one of them — and a wrong citation is worse than none. A
+        // compaction banks one span, so the case this exists for is the single one.
+        var attributeTo = (taken.length === 1 && taken[0] && typeof taken[0].id === "string")
+          ? taken[0].id : "";
+        if (!applyFacts(st, facts, "", attributeTo)) { return []; }
 
         var ids = [];
         for (var i = 0; i < taken.length; i++) {
@@ -865,10 +871,10 @@ agents:
       // ---------------------------------------------------------------- write
 
       // applyFacts returns true only when every write it attempted landed.
-      function applyFacts(st, facts, sourceID) {
+      function applyFacts(st, facts, sourceID, pendingID) {
         var ok = true;
         for (var i = 0; i < facts.length; i++) {
-          if (!applyOne(st, facts[i], sourceID)) { ok = false; }
+          if (!applyOne(st, facts[i], sourceID, pendingID)) { ok = false; }
         }
         return ok;
       }
@@ -890,7 +896,7 @@ agents:
       // nothing else. There is nowhere structured to put the linkage — the
       // provenance block's schema is closed (class + source ids only) — and it is
       // not worth a corrupted value, so it is gone.
-      function applyOne(st, fact, sourceID) {
+      function applyOne(st, fact, sourceID, pendingID) {
         var neighbours = recall(st, fact.text);
         var dupes = [];
 
@@ -925,12 +931,12 @@ agents:
           // are queued, and retire() applies the pass-wide cap once. Superseding
           // them is what collapses the pile back to one canonical row.
           for (var d = 1; d < dupes.length; d++) { st.supersede_queue.push(dupes[d].id); }
-          if (!write(st, primary.id, fact, sourceID)) { return false; }
+          if (!write(st, primary.id, fact, sourceID, pendingID)) { return false; }
           st.updated++;
           return true;
         }
 
-        if (!write(st, factKey(fact), fact, sourceID)) { return false; }
+        if (!write(st, factKey(fact), fact, sourceID, pendingID)) { return false; }
         st.written++;
         return true;
       }
@@ -1034,7 +1040,7 @@ agents:
       // stored ones silently moves every fact off that calibration and the
       // deduplication above quietly stops firing. A test asserts the two are
       // byte-identical on every write.
-      function write(st, key, fact, sourceID) {
+      function write(st, key, fact, sourceID, pendingID) {
         var args = {
           scope: CONFIG.scope,
           key: key,
@@ -1044,6 +1050,13 @@ agents:
           provenance: sourceID ? { "class": fact.cls, source_session_id: sourceID }
                                : { "class": fact.cls }
         };
+        // A fact distilled from a QUEUED item relays that item's id so the server
+        // resolves its origin + source ids from the pending row. We cannot author
+        // origin ourselves — it is server-stamped precisely so an agent cannot
+        // label its own writes — so without this the fact lands origin=consolidator
+        // and is indistinguishable from one read out of an ordinary transcript,
+        // which is the whole thing the pending origin column exists to tell apart.
+        if (pendingID) { args.from_pending = pendingID; }
         try {
           Memory.set(args);
         } catch (e) {

--- a/cmd/loomcycle/presets_memory_codejs_test.go
+++ b/cmd/loomcycle/presets_memory_codejs_test.go
@@ -2419,3 +2419,64 @@ func lastCall(t *testing.T, f *fakeToolset, want string) recordedCall {
 	t.Fatalf("no %s call in the sequence %v", want, seq)
 	return recordedCall{}
 }
+
+// TestConsolidator_QueuedFactRelaysThePendingID is the test that should have
+// existed when `from_pending` was added, and did not.
+//
+// The field was built, unit-tested at the tool boundary, and never wired into the
+// bundle — so on a live pass the compaction-banked span was consumed and every
+// resulting fact landed `origin=consolidator`, indistinguishable from one read out
+// of an ordinary transcript. The capability had no caller, which no test noticed
+// because none of them drove the real bundle's write path for a queued item.
+//
+// The pass cannot author `origin` itself (it is server-stamped so an agent cannot
+// label its own writes), so relaying the drained row's id is the ONLY way a fact
+// records that it came from a compaction.
+func TestConsolidator_QueuedFactRelaysThePendingID(t *testing.T) {
+	f := newFakeToolset()
+	// No chats — only the queue, so every Memory.set comes from the queued item
+	// and the assertion cannot be satisfied by a transcript-sourced write.
+	f.pending = []map[string]any{{
+		"id":     "mp_banked_span",
+		"origin": "compaction",
+		"payload": map[string]any{"messages": []any{
+			map[string]any{"role": "user", "content": "I'm in Cluj-Napoca and I take rosuvastatin."},
+		}},
+	}}
+	f.factsJSON = `[{"text":"The user is located in Cluj-Napoca.","class":"fact"}]`
+
+	runConsolidator(t, f)
+
+	set := lastCall(t, f, "Memory.set")
+	if got := set.Input["from_pending"]; got != "mp_banked_span" {
+		t.Errorf("Memory.set carried from_pending=%v, want %q — without it the fact lands origin=consolidator and the compaction it came from is unrecoverable",
+			got, "mp_banked_span")
+	}
+	// The item is still acked: attribution must not change the queue contract.
+	if !f.has("Memory.pending_ack") {
+		t.Errorf("the queued item was not acked; sequence %v", f.ops())
+	}
+}
+
+// TestConsolidator_MultiItemBatchIsNotFalselyAttributed: several queued items are
+// rendered into ONE extractor call, so a fact from that call cannot honestly be
+// traced to one of them. A wrong citation is worse than none — it would point an
+// operator at a conversation the fact did not come from — so attribution is
+// omitted rather than guessed at the first id.
+func TestConsolidator_MultiItemBatchIsNotFalselyAttributed(t *testing.T) {
+	f := newFakeToolset()
+	f.pending = []map[string]any{
+		{"id": "mp_one", "origin": "agent_explicit",
+			"payload": map[string]any{"messages": []any{map[string]any{"role": "user", "content": "I use ROCm."}}}},
+		{"id": "mp_two", "origin": "compaction",
+			"payload": map[string]any{"messages": []any{map[string]any{"role": "user", "content": "I live in Cluj."}}}},
+	}
+	f.factsJSON = `[{"text":"The user runs ROCm.","class":"fact"}]`
+
+	runConsolidator(t, f)
+
+	set := lastCall(t, f, "Memory.set")
+	if got, present := set.Input["from_pending"]; present && got != "" {
+		t.Errorf("a multi-item batch attributed its fact to %v; with two items rendered into one call the source is genuinely unknown, and a wrong citation is worse than an absent one", got)
+	}
+}


### PR DESCRIPTION
## The gap

`from_pending` shipped in #848, was unit-tested at the tool boundary, and **had no caller.** The bundle never sent it.

So on the first live pass the compaction-banked span was consumed correctly — 17 facts written, row acked, watermark advanced — and every fact landed `origin=consolidator`, indistinguishable from one read out of an ordinary transcript. The column the whole provenance change exists to populate stayed empty, and I could not tell from the store which facts came from the banked span.

The pass cannot author `origin` itself; it's server-stamped precisely so an agent can't label its own writes as machine-distilled. Relaying the drained row's id is the only route, and threading it was three lines #848 never wrote.

## Attribution only when it's honest

Several queued items are rendered into **one** extractor call, so a fact from a multi-item batch cannot be traced to one of them. A wrong citation is worse than none — it points an operator at a conversation the fact didn't come from. So the id is relayed only for a **single-item** batch, which is the case this exists for anyway: a compaction banks one span.

Transcript-sourced facts are unaffected — they already carried `source_session_id`.

## Tested

`go test ./...` clean. Two tests, both verified fail-before **against the embedded bundle** — the only copy that ships, since patching the source tree alone changes nothing at runtime (`TestConsolidatorBundle_SourceMatchesEmbedded` already guards that trap, and I walked into it during verification).

| reverted | test says |
|---|---|
| unwire the relay | `Memory.set carried from_pending=<nil>, want "mp_banked_span"` |
| attribute a 2-item batch to the first id | `attributed its fact to mp_one; the source is genuinely unknown` |

The first drives a **queue-only** pass, so every `Memory.set` must come from the queued item and the assertion can't be satisfied by a transcript write.

## Worth recording

This is the same shape twice in one line. PR #850's fail-before check caught exactly it — deleting a server-set stamp broke nothing because no test drove the real path — and I didn't carry the lesson forward one PR. A capability with no caller passes every test it has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)