### PR TITLE
fix(memory): stronger extractor tier, and refuse an empty MCP spawn

### DIFF
--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -1420,7 +1420,29 @@ agents:
     internal: true
     # This is the one place where model quality shows. Retune the trade-off in
     # your tier policy — never by pinning a provider or model here.
-    tier: low
+    #
+    # MEASURED, not guessed. `low` was tried first and produced the pollution a
+    # live store still carries. A three-input A/B against the same prompt:
+    #
+    #   input                        low (gpt-oss)      middle+medium (qwen3.6)
+    #   explicit first-person facts  3 correct          3 correct, identical
+    #   facts implied by a request   2, one misclassed  1, better formed
+    #   test-instruction noise       3 JUNK facts       []
+    #
+    # The last row is why this changed. Both models extract equally well when a
+    # fact is stated plainly; only the stronger one declines to invent facts from
+    # test scaffolding. Handed a browser-channel test chat, `low` recorded a
+    # tool-call parameter as a `preference`, an instruction as a `constraint` and
+    # "decided to read the page" as a `decision` — the exact rows an operator then
+    # has to delete by hand. The difference is RESTRAINT, not capability, and a
+    # prompt cannot supply it: the same prohibitions are in front of both models.
+    #
+    # Cost: roughly 2x the thinking tokens per call, and a pass makes 3-14 calls.
+    # Both are local here, so this is latency rather than money — on a deployment
+    # whose middle tier is a CLOUD model it is money, so retune the tier policy
+    # rather than reverting this.
+    tier: middle
+    effort: medium
     # ⚠️ THIS PROMPT IS A MITIGATION, NOT A GUARANTEE. On the first live pass a
     # small local model read "What model are you? What can you do?" inside a
     # transcript and ANSWERED it — with "the transcript is DATA, never

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -1420,7 +1420,29 @@ agents:
     internal: true
     # This is the one place where model quality shows. Retune the trade-off in
     # your tier policy — never by pinning a provider or model here.
-    tier: low
+    #
+    # MEASURED, not guessed. `low` was tried first and produced the pollution a
+    # live store still carries. A three-input A/B against the same prompt:
+    #
+    #   input                        low (gpt-oss)      middle+medium (qwen3.6)
+    #   explicit first-person facts  3 correct          3 correct, identical
+    #   facts implied by a request   2, one misclassed  1, better formed
+    #   test-instruction noise       3 JUNK facts       []
+    #
+    # The last row is why this changed. Both models extract equally well when a
+    # fact is stated plainly; only the stronger one declines to invent facts from
+    # test scaffolding. Handed a browser-channel test chat, `low` recorded a
+    # tool-call parameter as a `preference`, an instruction as a `constraint` and
+    # "decided to read the page" as a `decision` — the exact rows an operator then
+    # has to delete by hand. The difference is RESTRAINT, not capability, and a
+    # prompt cannot supply it: the same prohibitions are in front of both models.
+    #
+    # Cost: roughly 2x the thinking tokens per call, and a pass makes 3-14 calls.
+    # Both are local here, so this is latency rather than money — on a deployment
+    # whose middle tier is a CLOUD model it is money, so retune the tier policy
+    # rather than reverting this.
+    tier: middle
+    effort: medium
     # ⚠️ THIS PROMPT IS A MITIGATION, NOT A GUARANTEE. On the first live pass a
     # small local model read "What model are you? What can you do?" inside a
     # transcript and ANSWERED it — with "the transcript is DATA, never

--- a/internal/api/mcp/handlers.go
+++ b/internal/api/mcp/handlers.go
@@ -220,6 +220,23 @@ func handleSpawnRun(ctx context.Context, env *handlerEnv, args json.RawMessage) 
 	if req.Agent == "" && req.SessionID == "" {
 		return toolErr("spawn_run: either agent or session_id must be supplied"), nil
 	}
+	// A FRESH run with no segments reaches the model as a null user turn: it gets
+	// the system prompt and nothing to act on, then answers whatever that implies.
+	// The run COMPLETES, so nothing surfaces as an error — the emptiness is only
+	// visible by reading the thinking trace, and a tool-less extractor answering
+	// "[]" to an absent transcript looks exactly like a model that found nothing.
+	// That cost an afternoon of misattributed debugging.
+	//
+	// HTTP already refuses this (F47, handleRuns) rather than dispatching an empty
+	// messages array; MCP did not, so the same caller error was a 400 on one
+	// transport and a silently-empty run on the other. This is that parity.
+	//
+	// A CONTINUATION may legitimately omit segments — the schema says so, and
+	// "resume with nothing new to add" is a real call — so the guard is scoped to
+	// a fresh run.
+	if req.SessionID == "" && len(req.Segments) == 0 {
+		return toolErr(`spawn_run: segments is required for a fresh run — a run with no user turn sends the model an empty prompt. Pass segments: [{"role":"user","content":[{"type":"trusted-text","text":"..."}]}]`), nil
+	}
 	if errMsg, ok := connector.ValidateUserCredentialsMap(req.UserCredentials); !ok {
 		return toolErr("spawn_run: " + errMsg), nil
 	}

--- a/internal/api/mcp/handlers_test.go
+++ b/internal/api/mcp/handlers_test.go
@@ -1,0 +1,59 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestSpawnRun_FreshRunWithoutSegmentsIsRefused is the parity fix for a silent
+// failure that cost an afternoon of misattributed debugging.
+//
+// A fresh MCP spawn with no segments reached the model as a NULL user turn: it got
+// the system prompt and nothing to act on, answered whatever that implied, and the
+// run COMPLETED — so nothing surfaced as an error. A tool-less extractor replying
+// "[]" to an absent transcript is indistinguishable from a model that found
+// nothing, and the emptiness was only visible by reading the thinking trace.
+//
+// HTTP has refused this since F47 rather than dispatching an empty messages array,
+// so the same caller error was a 400 on one transport and a silently-empty run on
+// the other.
+func TestSpawnRun_FreshRunWithoutSegmentsIsRefused(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args string
+		want bool // true = must be refused
+	}{
+		{"fresh run, segments omitted", `{"agent":"qa"}`, true},
+		{"fresh run, segments empty", `{"agent":"qa","segments":[]}`, true},
+		{"fresh run WITH segments", `{"agent":"qa","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`, false},
+		// A continuation may legitimately have nothing new to add — the schema says
+		// so, and "resume this session" is a real call. The guard must not catch it.
+		{"continuation, no segments", `{"session_id":"s_1"}`, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			env := &handlerEnv{connector: &mockConnector{}}
+			res, err := handleSpawnRun(context.Background(), env, json.RawMessage(tc.args))
+			if err != nil {
+				t.Fatalf("handleSpawnRun: %v", err)
+			}
+			refused := res != nil && res.IsError
+			if refused != tc.want {
+				t.Errorf("refused=%v want=%v; result=%+v", refused, tc.want, res)
+			}
+			if tc.want && refused {
+				// The message must name the fix, not just the rule — an operator
+				// hitting this needs the shape to pass, since the field is easy to
+				// get wrong (there is no top-level `prompt` on this transport).
+				txt := ""
+				if len(res.Content) > 0 {
+					txt = res.Content[0].Text
+				}
+				if !strings.Contains(txt, "segments") || !strings.Contains(txt, "trusted-text") {
+					t.Errorf("refusal does not show the required shape: %q", txt)
+				}
+			}
+		})
+	}
+}

--- a/internal/api/mcp/http_transport_test.go
+++ b/internal/api/mcp/http_transport_test.go
@@ -550,7 +550,7 @@ func TestHTTPTransport_SpawnRunStreaming_EmitsSSEFrames(t *testing.T) {
 
 	// spawn_run — should reply with text/event-stream.
 	resp, body = postFrame(t, ts.URL, sessionID,
-		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"spawn_run","arguments":{"agent":"qa","segments":[]}}}`)
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"spawn_run","arguments":{"agent":"qa","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}}}`)
 	if resp.StatusCode != 200 {
 		t.Fatalf("spawn_run status=%d", resp.StatusCode)
 	}
@@ -589,7 +589,7 @@ func TestHTTPTransport_SpawnRunWithoutOptIn_ReturnsJSONNotSSE(t *testing.T) {
 
 	// spawn_run — should reply with application/json (blocking path).
 	resp, body := postFrame(t, ts.URL, sessionID,
-		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"spawn_run","arguments":{"agent":"qa","segments":[]}}}`)
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"spawn_run","arguments":{"agent":"qa","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}}}`)
 	if resp.StatusCode != 200 {
 		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
 	}
@@ -645,7 +645,7 @@ func TestHTTPTransport_SpawnRunOperatorTimeout(t *testing.T) {
 	// forever and the client deadline gives a clean, fast failure instead
 	// of hanging until the go-test global timeout.
 	req, err := http.NewRequest(http.MethodPost, ts.URL, strings.NewReader(
-		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"spawn_run","arguments":{"agent":"x","segments":[]}}}`))
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"spawn_run","arguments":{"agent":"x","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}}}`))
 	if err != nil {
 		t.Fatalf("NewRequest: %v", err)
 	}

--- a/internal/api/mcp/server_test.go
+++ b/internal/api/mcp/server_test.go
@@ -556,7 +556,7 @@ func TestServer_SpawnRun_BlockingPath(t *testing.T) {
 	// No runEvents capability → blocking path via Connector.SpawnRun.
 	in := strings.Join([]string{
 		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"1"}}}`,
-		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"spawn_run","arguments":{"agent":"qa-agent","segments":[]}}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"spawn_run","arguments":{"agent":"qa-agent","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}}}`,
 	}, "\n") + "\n"
 	resps, notifs := driveServer(t, srv, in)
 	if len(resps) != 2 {
@@ -628,7 +628,7 @@ func TestServer_SpawnRun_AppliesPrincipalOverWireIdentity(t *testing.T) {
 	srv := New(Config{Connector: mc, Logf: func(string, ...any) {}})
 	ctx := auth.WithPrincipal(context.Background(),
 		auth.Principal{TenantID: "acme", Subject: "alice"}) // real (non-legacy) principal
-	in := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"spawn_run","arguments":{"agent":"qa","segments":[],"tenant_id":"evil","user_id":"mallory"}}}` + "\n"
+	in := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"spawn_run","arguments":{"agent":"qa","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}],"tenant_id":"evil","user_id":"mallory"}}}` + "\n"
 	driveServerCtx(t, srv, ctx, in)
 	stored, _ := mc.spawnReq.Load().(connector.SpawnRunRequest)
 	if stored.TenantID != "acme" || stored.UserID != "alice" {
@@ -644,7 +644,7 @@ func TestServer_SpawnRun_LegacyHonorsWireUserID(t *testing.T) {
 	srv := New(Config{Connector: mc, Logf: func(string, ...any) {}})
 	ctx := auth.WithPrincipal(context.Background(),
 		auth.Principal{TenantID: "default", Subject: "default", Scopes: []string{auth.ScopeAdmin}, Legacy: true})
-	in := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"spawn_run","arguments":{"agent":"qa","segments":[],"tenant_id":"ignored","user_id":"exp1"}}}` + "\n"
+	in := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"spawn_run","arguments":{"agent":"qa","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}],"tenant_id":"ignored","user_id":"exp1"}}}` + "\n"
 	driveServerCtx(t, srv, ctx, in)
 	stored, _ := mc.spawnReq.Load().(connector.SpawnRunRequest)
 	if stored.TenantID != "default" || stored.UserID != "exp1" {
@@ -657,7 +657,7 @@ func TestServer_SpawnRun_LegacyHonorsWireUserID(t *testing.T) {
 func TestServer_SpawnRun_NoPrincipalPassesWireThrough(t *testing.T) {
 	mc := &mockConnector{spawnResult: connector.SpawnRunResult{Status: "completed"}}
 	srv := New(Config{Connector: mc, Logf: func(string, ...any) {}})
-	in := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"spawn_run","arguments":{"agent":"qa","segments":[],"tenant_id":"wire-t","user_id":"wire-u"}}}` + "\n"
+	in := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"spawn_run","arguments":{"agent":"qa","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}],"tenant_id":"wire-t","user_id":"wire-u"}}}` + "\n"
 	driveServer(t, srv, in)
 	stored, _ := mc.spawnReq.Load().(connector.SpawnRunRequest)
 	if stored.TenantID != "wire-t" || stored.UserID != "wire-u" {
@@ -674,7 +674,7 @@ func TestServer_SpawnRun_ContinuationSkipsOverride(t *testing.T) {
 	srv := New(Config{Connector: mc, Logf: func(string, ...any) {}})
 	ctx := auth.WithPrincipal(context.Background(),
 		auth.Principal{TenantID: "acme", Subject: "alice"})
-	in := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"spawn_run","arguments":{"session_id":"s_prior","segments":[],"tenant_id":"wire-t"}}}` + "\n"
+	in := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"spawn_run","arguments":{"session_id":"s_prior","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}],"tenant_id":"wire-t"}}}` + "\n"
 	driveServerCtx(t, srv, ctx, in)
 	stored, _ := mc.spawnReq.Load().(connector.SpawnRunRequest)
 	if stored.TenantID != "wire-t" {
@@ -690,7 +690,7 @@ func TestServer_SpawnRuns_AppliesPrincipalToEachChild(t *testing.T) {
 	srv := New(Config{Connector: mc, Logf: func(string, ...any) {}})
 	ctx := auth.WithPrincipal(context.Background(),
 		auth.Principal{TenantID: "acme", Subject: "alice"})
-	in := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"spawn_runs","arguments":{"spawns":[{"agent":"a","segments":[],"tenant_id":"evil"},{"agent":"b","segments":[],"tenant_id":"evil2","user_id":"mallory"}]}}}` + "\n"
+	in := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"spawn_runs","arguments":{"spawns":[{"agent":"a","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}],"tenant_id":"evil"},{"agent":"b","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}],"tenant_id":"evil2","user_id":"mallory"}]}}}` + "\n"
 	driveServerCtx(t, srv, ctx, in)
 	stored, _ := mc.batchReq.Load().(connector.BatchSpawnRequest)
 	if len(stored.Spawns) != 2 {
@@ -708,7 +708,7 @@ func TestServer_SpawnRun_CarriesCompaction(t *testing.T) {
 	srv := New(Config{Connector: mc, Logf: func(string, ...any) {}})
 	in := strings.Join([]string{
 		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"1"}}}`,
-		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"spawn_run","arguments":{"agent":"qa","segments":[],"compaction":{"enabled":true,"keep_last_n":6,"autocompact_at_pct":75}}}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"spawn_run","arguments":{"agent":"qa","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}],"compaction":{"enabled":true,"keep_last_n":6,"autocompact_at_pct":75}}}}`,
 	}, "\n") + "\n"
 	driveServer(t, srv, in)
 	stored, _ := mc.spawnReq.Load().(connector.SpawnRunRequest)
@@ -913,7 +913,7 @@ func TestServer_SpawnRun_StreamingPath(t *testing.T) {
 
 	in := strings.Join([]string{
 		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{"loomcycle":{"runEvents":true}},"clientInfo":{"name":"t","version":"1"}}}`,
-		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"spawn_run","arguments":{"agent":"qa-agent","segments":[]}}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"spawn_run","arguments":{"agent":"qa-agent","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}}}`,
 	}, "\n") + "\n"
 	resps, notifs := driveServer(t, srv, in)
 	if len(resps) != 2 {
@@ -975,7 +975,7 @@ func TestServer_SpawnRun_NotificationsArriveBeforeResponse(t *testing.T) {
 
 	in := strings.Join([]string{
 		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{"loomcycle":{"runEvents":true}},"clientInfo":{"name":"t","version":"1"}}}`,
-		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"spawn_run","arguments":{"agent":"qa-agent","segments":[]}}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"spawn_run","arguments":{"agent":"qa-agent","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}}}`,
 	}, "\n") + "\n"
 
 	stdout := &bytes.Buffer{}
@@ -1513,8 +1513,8 @@ func TestServer_LongCallDoesNotBlockSubsequent(t *testing.T) {
 	defer ls.close()
 
 	ls.handshake()
-	ls.send(toolCallFrame(2, "spawn_run", `{"agent":"x","segments":[]}`)) // blocks on gate
-	ls.send(toolCallFrame(3, "list_runs", `{"user_id":"u"}`))             // cheap; must not be HOL-blocked
+	ls.send(toolCallFrame(2, "spawn_run", `{"agent":"x","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`)) // blocks on gate
+	ls.send(toolCallFrame(3, "list_runs", `{"user_id":"u"}`))                                                                            // cheap; must not be HOL-blocked
 
 	// id=3 must arrive while id=2 is still blocked.
 	ls.waitResp(3, 2*time.Second)
@@ -1537,8 +1537,8 @@ func TestServer_CancelRunBypassesCapDuringSaturation(t *testing.T) {
 	defer ls.close()
 
 	ls.handshake()
-	ls.send(toolCallFrame(2, "spawn_run", `{"agent":"x","segments":[]}`)) // fills the only slot
-	ls.send(toolCallFrame(3, "cancel_run", `{"agent_id":"a"}`))           // not bounded → must run
+	ls.send(toolCallFrame(2, "spawn_run", `{"agent":"x","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`)) // fills the only slot
+	ls.send(toolCallFrame(3, "cancel_run", `{"agent_id":"a"}`))                                                                          // not bounded → must run
 
 	ls.waitResp(3, 2*time.Second) // cancel_run responds despite the saturated cap
 	if ls.hasResp(2) {
@@ -1559,9 +1559,9 @@ func TestServer_LongCallsRespectConcurrencyCap(t *testing.T) {
 	defer ls.close()
 
 	ls.handshake()
-	ls.send(toolCallFrame(2, "spawn_run", `{"agent":"x","segments":[]}`))
-	ls.send(toolCallFrame(3, "spawn_run", `{"agent":"x","segments":[]}`))
-	ls.send(toolCallFrame(4, "spawn_run", `{"agent":"x","segments":[]}`))
+	ls.send(toolCallFrame(2, "spawn_run", `{"agent":"x","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`))
+	ls.send(toolCallFrame(3, "spawn_run", `{"agent":"x","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`))
+	ls.send(toolCallFrame(4, "spawn_run", `{"agent":"x","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`))
 
 	// Wait for two to enter the connector; the third must stay parked on
 	// the semaphore (never enters SpawnRun).
@@ -1598,9 +1598,9 @@ func TestServer_QueuedCallErrorsOnShutdown(t *testing.T) {
 	defer ls.close()
 
 	ls.handshake()
-	ls.send(toolCallFrame(2, "spawn_run", `{"agent":"x","segments":[]}`)) // bounded → parks on the sem
-	time.Sleep(50 * time.Millisecond)                                     // let the read loop dispatch the goroutine
-	ls.cancel()                                                           // simulate global shutdown (bgCtx / SIGTERM)
+	ls.send(toolCallFrame(2, "spawn_run", `{"agent":"x","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`)) // bounded → parks on the sem
+	time.Sleep(50 * time.Millisecond)                                                                                                    // let the read loop dispatch the goroutine
+	ls.cancel()                                                                                                                          // simulate global shutdown (bgCtx / SIGTERM)
 
 	r := ls.waitResp(2, 2*time.Second)
 	if r.Error == nil || r.Error.Code != -32603 {
@@ -1653,7 +1653,7 @@ func TestServer_SpawnRunTimesOut(t *testing.T) {
 	defer ls.close()
 
 	ls.handshake()
-	ls.send(toolCallFrame(2, "spawn_run", `{"agent":"x","segments":[],"timeout_ms":120}`))
+	ls.send(toolCallFrame(2, "spawn_run", `{"agent":"x","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}],"timeout_ms":120}`))
 	got := decodeSpawnResult(t, ls.waitResp(2, 3*time.Second))
 	if got.Status != "timeout" {
 		t.Fatalf("spawn_run status = %q; want \"timeout\"", got.Status)
@@ -1669,7 +1669,7 @@ func TestServer_SpawnRunOperatorTimeout(t *testing.T) {
 	defer ls.close()
 
 	ls.handshake()
-	ls.send(toolCallFrame(2, "spawn_run", `{"agent":"x","segments":[]}`)) // no per-call timeout_ms
+	ls.send(toolCallFrame(2, "spawn_run", `{"agent":"x","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`)) // no per-call timeout_ms
 	got := decodeSpawnResult(t, ls.waitResp(2, 3*time.Second))
 	if got.Status != "timeout" {
 		t.Fatalf("spawn_run status = %q; want \"timeout\" (operator default)", got.Status)
@@ -1686,7 +1686,7 @@ func TestServer_SpawnRunNoTimeoutByDefault(t *testing.T) {
 	defer ls.close()
 
 	ls.handshake()
-	ls.send(toolCallFrame(2, "spawn_run", `{"agent":"x","segments":[]}`))
+	ls.send(toolCallFrame(2, "spawn_run", `{"agent":"x","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`))
 	got := decodeSpawnResult(t, ls.waitResp(2, 3*time.Second))
 	if got.Status != "completed" {
 		t.Fatalf("spawn_run status = %q; want \"completed\" (no timeout by default)", got.Status)


### PR DESCRIPTION
Two fixes from one investigation into why a live store filled with junk facts. Unrelated to each other, combined per your earlier call that unrelated changes needn't be split.

## 1. Extractor tier: `low` → `middle`, `effort: medium`

Measured against the **same prompt**, three inputs:

| input | `low` (gpt-oss) | `middle`+`medium` (qwen3.6) |
|---|---|---|
| explicit first-person facts | 3 correct | 3 correct, **identical text** |
| facts implied by a request | 2, one misclassified `fact` | 1, better formed, correct class |
| **test-instruction noise** | **3 junk facts** | **`[]`** |

That last row is the whole reason. Both models extract equally well when a fact is stated plainly. Only the stronger one declines to invent facts from test scaffolding — handed a browser-channel test chat, `low` recorded a tool-call parameter as a `preference`, an instruction as a `constraint`, and "decided to read the page" as a `decision`. Those are the exact rows sitting in the live store.

**The difference is restraint, not capability**, which is why no prompt fixes it: both models read the same prohibitions and only one applies them.

Cost: ~2× thinking tokens, and a pass makes 3–14 extractor calls. Both local on the reference deployment, so latency not money — on a deployment whose middle tier is a *cloud* model it is money, and the answer there is retuning the tier policy rather than reverting.

**A prompt fix was tried first and rejected on evidence.** A candidate teaching the request→property transformation, fitted to the 1,500-char cap, changed nothing on the failing inputs. It's deliberately not in this diff — shipping it would have looked like progress while doing nothing, which is the third prompt theory in this line to fail that way.

## 2. MCP parity: a fresh `spawn_run` with no `segments` is refused

It reached the model as a **null user turn** — system prompt, nothing to act on — and the run **completed**, so nothing surfaced as an error. A tool-less extractor answering `[]` to an absent transcript is indistinguishable from a model that found nothing; the emptiness was only visible by reading the thinking trace.

HTTP has refused this since F47 rather than dispatching an empty messages array, so the same caller error was a `400` on one transport and a silently-empty run on the other. This is that parity.

Scoped to a **fresh** run — a continuation may legitimately have nothing new to add, and the schema says so. The message shows the required shape rather than only naming the rule, since this transport has no top-level `prompt` field and the mistake is easy to repeat.

**22 fixtures** passed `"segments":[]` and now pass a real segment. None asserted the empty case — they test SSE frames, principal override, blocking and timeout — so they relied on the loophole incidentally. That churn is the honest cost of closing it.

## Tested

`go test ./...` clean. Both fixes verified fail-before: removing the guard reports `refused=false`; reverting the tier trips `TestConsolidatorBundle_SourceMatchesEmbedded`.

The new guard test covers four arms including the one that must **not** fire (continuation without segments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)