### PR TITLE
fix(memory): score an empty extractor reply the way production does

### DIFF
--- a/internal/cli/memory_eval_live.go
+++ b/internal/cli/memory_eval_live.go
@@ -64,6 +64,7 @@ func RunMemoryEvalLive(args []string, stdout, stderr io.Writer) int {
 	timeout := fs.Duration("timeout", 10*time.Minute, "wall clock for the whole run")
 	maxTokens := fs.Int("max-tokens", 0, "per-call max_tokens (0 = provider default)")
 	noGate := fs.Bool("no-gate", false, "report only; exit 0 even when the gate fails")
+	showFacts := fs.Bool("show-facts", false, "print every case's emitted facts, including the ones that passed")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -130,7 +131,7 @@ func RunMemoryEvalLive(args []string, stdout, stderr io.Writer) int {
 		}
 		fmt.Fprintf(stdout, "wrote report to %s\n", *output)
 	} else {
-		printExtractionReport(stdout, rep, base)
+		printExtractionReport(stdout, rep, base, *showFacts)
 	}
 
 	if *updateBaseline != "" {
@@ -168,13 +169,19 @@ func RunMemoryEvalLive(args []string, stdout, stderr io.Writer) int {
 // printExtractionReport renders the per-ability table plus every miss and
 // violation. Layout mirrors printEvalReport / printCalibrationReport: an operator
 // reads this in a terminal next to the prompt they are about to change.
-func printExtractionReport(w io.Writer, r eval.ExtractionReport, base *eval.Baseline) {
+// showFacts prints the emitted facts for EVERY case, not just the ones with a
+// problem. The default report is problem-only, which is right for a regression
+// check and wrong for the first measurement of a new model: the first live run
+// scored 2/2 on the ability that fails in production, and there was no way to read
+// what the model had actually written without re-running.
+func printExtractionReport(w io.Writer, r eval.ExtractionReport, base *eval.Baseline, showFacts bool) {
 	fmt.Fprintf(w, "memory-eval-live: %s / %s", r.Provider, r.Model)
 	if r.Effort != "" {
 		fmt.Fprintf(w, " (effort=%s)", r.Effort)
 	}
 	fmt.Fprintln(w)
 	fmt.Fprintf(w, "  extractor prompt     %s\n", shortSHA(r.SystemPromptSHA256))
+	fmt.Fprintf(w, "  corpus               %s\n", shortSHA(r.CorpusSHA256))
 
 	if r.HarnessFault != "" {
 		fmt.Fprintf(w, "\n  !! HARNESS FAULT — scores withheld\n")
@@ -202,7 +209,9 @@ func printExtractionReport(w io.Writer, r eval.ExtractionReport, base *eval.Base
 	// explanation is not actionable, and the reason is what tells you whether to
 	// change the prompt or the corpus.
 	for _, c := range r.Cases {
-		if c.Err == "" && len(c.Misses) == 0 && len(c.Violations) == 0 && len(c.ClassMismatches) == 0 {
+		quiet := c.Err == "" && len(c.Misses) == 0 && len(c.Violations) == 0 &&
+			len(c.ClassMismatches) == 0 && !c.EmptyReply
+		if quiet && !showFacts {
 			continue
 		}
 		fmt.Fprintf(w, "\n%s [%s]\n", c.Name, c.Ability)
@@ -220,6 +229,17 @@ func printExtractionReport(w io.Writer, r eval.ExtractionReport, base *eval.Base
 		}
 		for _, m := range c.ClassMismatches {
 			fmt.Fprintf(w, "  class      %s\n", m)
+		}
+		if c.EmptyReply {
+			// Production treats this as zero facts and consolidates the chat, so it
+			// is NOT a failure — but a rising rate is the earliest sign of a
+			// degrading extractor, which is why it is surfaced at all.
+			note := "empty reply (no `[]`) — production counts this and treats it as zero facts"
+			if c.ThinkingOnly {
+				note = "REASONING TRACE ONLY, no answer — on Ollama effort=medium sets think:true; " +
+					"try --effort low or a larger --max-tokens"
+			}
+			fmt.Fprintf(w, "  note       %s\n", wrapText(note, 72, "             "))
 		}
 		if c.Dropped > 0 {
 			fmt.Fprintf(w, "  dropped    %d fact(s) production would discard\n", c.Dropped)

--- a/internal/cli/memory_eval_live_test.go
+++ b/internal/cli/memory_eval_live_test.go
@@ -94,7 +94,7 @@ func TestPrintExtractionReport_WithholdsScoresOnAFault(t *testing.T) {
 		// Deliberately populated: even if scores are present on the struct, a
 		// faulted report must not print them.
 		Abilities: []eval.AbilityScore{{Ability: eval.AbilityExtraction, Recall: 0}},
-	}, nil)
+	}, nil, false)
 	s := out.String()
 	if !strings.Contains(s, "HARNESS FAULT") {
 		t.Errorf("the fault must be prominent: %s", s)
@@ -112,7 +112,7 @@ func TestPrintExtractionReport_SaysWhenThereIsNoBaseline(t *testing.T) {
 	printExtractionReport(&out, eval.ExtractionReport{
 		Provider: "p", Model: "m",
 		Abilities: []eval.AbilityScore{{Ability: eval.AbilityExtraction, Cases: 1, Recall: 1}},
-	}, nil)
+	}, nil, false)
 	if !strings.Contains(out.String(), "compared against nothing") {
 		t.Errorf("the report should say there is no baseline: %s", out.String())
 	}
@@ -133,7 +133,7 @@ func TestPrintExtractionReport_ShowsMissesAndViolationsWithTheirReason(t *testin
 			Violations: []string{"distractor fixture: \"The user asked about alternatives.\" — recording that a question was ASKED"},
 			Facts:      []eval.ExtractedFact{{Text: "The user asked about alternatives.", Class: "fact"}},
 		}},
-	}, nil)
+	}, nil, false)
 	s := out.String()
 	for _, want := range []string{"MISS", "VIOLATION", "statin", "asked", "emitted"} {
 		if !strings.Contains(s, want) {

--- a/internal/memory/eval/extraction.go
+++ b/internal/memory/eval/extraction.go
@@ -87,6 +87,18 @@ type CaseResult struct {
 	// RawReply is kept ONLY when the reply could not be parsed, so a malformed
 	// answer is diagnosable without a re-run. Truncated.
 	RawReply string `json:"raw_reply,omitempty"`
+	// EmptyReply records that the model answered with nothing at all rather than
+	// with `[]`. Production treats the two identically (zero facts), so this is
+	// NOT a failure — but a rising rate is the earliest sign of a degrading
+	// extractor, which is why it is counted rather than folded away.
+	EmptyReply bool `json:"empty_reply,omitempty"`
+	// ThinkingOnly records that the model produced a reasoning trace and NO
+	// answer. On Ollama, effort=medium sets `think:true`, and a model can spend
+	// its whole reply in the thinking channel — which arrives as EventThinking and
+	// is deliberately not accumulated into the answer. "Reasoned and never
+	// answered" is a different diagnosis from "abstained", and without this they
+	// are indistinguishable in the report.
+	ThinkingOnly bool `json:"thinking_only,omitempty"`
 	// Err is a per-case call failure. A cases's error does not abort the run —
 	// one 429 must not discard the other twelve scores.
 	Err string `json:"error,omitempty"`
@@ -122,9 +134,14 @@ type ExtractionReport struct {
 	// is only comparable against another run of the SAME prompt, and this is what
 	// makes "the baseline moved because the prompt changed" visible instead of
 	// mysterious.
-	SystemPromptSHA256 string         `json:"system_prompt_sha256"`
-	Cases              []CaseResult   `json:"cases"`
-	Abilities          []AbilityScore `json:"abilities"`
+	SystemPromptSHA256 string `json:"system_prompt_sha256"`
+	// CorpusSHA256 identifies the fixture set that produced these numbers. Adding
+	// or editing a case moves every recall figure just as surely as editing the
+	// prompt does, so it belongs in the baseline key for the same reason — see
+	// Baseline's header.
+	CorpusSHA256 string         `json:"corpus_sha256"`
+	Cases        []CaseResult   `json:"cases"`
+	Abilities    []AbilityScore `json:"abilities"`
 	// TotalViolations across every ability — the headline safety number.
 	TotalViolations int `json:"total_violations"`
 	// HarnessFault is set when the canary failed. Scores in the same report are
@@ -157,21 +174,28 @@ type Caller interface {
 // empty reply: an empty reply is exactly what the canary exists to disambiguate,
 // and swallowing a 401 into one would make an auth failure look like a model that
 // declined to extract anything.
-func collectReply(ch <-chan providers.Event) (string, error) {
+func collectReply(ch <-chan providers.Event) (reply string, sawThinking bool, err error) {
 	var b strings.Builder
 	for ev := range ch {
 		switch ev.Type {
 		case providers.EventText:
 			b.WriteString(ev.Text)
+		case providers.EventThinking:
+			// Counted, never accumulated. The reasoning trace is not the answer,
+			// but knowing it arrived is what separates "the model reasoned and
+			// never answered" from "the model abstained" when the reply is empty.
+			if strings.TrimSpace(ev.Text) != "" {
+				sawThinking = true
+			}
 		case providers.EventError:
 			msg := ev.Error
 			if msg == "" {
 				msg = ev.Text
 			}
-			return "", fmt.Errorf("provider error: %s", msg)
+			return "", sawThinking, fmt.Errorf("provider error: %s", msg)
 		}
 	}
-	return b.String(), nil
+	return b.String(), sawThinking, nil
 }
 
 // ExtractionInput is everything a run needs.
@@ -205,6 +229,7 @@ func RunExtraction(ctx context.Context, c Caller, in ExtractionInput) (Extractio
 		Model:              in.Model,
 		Effort:             in.Effort,
 		SystemPromptSHA256: sha256Hex(in.SystemPrompt),
+		CorpusSHA256:       in.Corpus.Digest(),
 	}
 
 	// Canary first.
@@ -259,6 +284,12 @@ func canaryFault(r CaseResult) string {
 	if r.Err != "" {
 		return fmt.Sprintf("canary case could not be called (%s) — no scores were produced. "+
 			"Check the provider, model name and credentials before reading anything else.", r.Err)
+	}
+	if len(r.Facts) == 0 && r.ThinkingOnly {
+		return "canary case produced a REASONING TRACE and no answer. Its transcript states one " +
+			"unmissable fact, so the model received it and spent the whole reply thinking. On Ollama, " +
+			"effort=medium sets think:true — try --effort low, or raise --max-tokens so the answer has " +
+			"room after the trace. Scores are withheld."
 	}
 	if len(r.Facts) == 0 {
 		return "canary case returned NO facts. Its transcript states one unmissable fact, so an empty " +
@@ -335,10 +366,14 @@ func runCase(ctx context.Context, c Caller, in ExtractionInput, cs ExtractionCas
 		res.Err = err.Error()
 		return res
 	}
-	reply, err := collectReply(ch)
+	reply, sawThinking, err := collectReply(ch)
 	if err != nil {
 		res.Err = err.Error()
 		return res
+	}
+	if strings.TrimSpace(reply) == "" {
+		res.EmptyReply = true
+		res.ThinkingOnly = sawThinking
 	}
 
 	facts, dropped, parseErr := ParseExtractorReply(reply)
@@ -360,13 +395,28 @@ func runCase(ctx context.Context, c Caller, in ExtractionInput, cs ExtractionCas
 var jsonArrayRe = regexp.MustCompile(`(?s)\[.*\]`)
 
 // ParseExtractorReply parses the extractor's reply into validated facts, applying
-// the SAME validation the bundle's validateFacts applies: drop a non-object, an
-// empty or over-long text, or an unknown class. Returns (facts, dropped, error);
-// an error means the reply held no JSON array at all.
+// the SAME validation production applies — both halves of it.
+//
+// An EMPTY reply is zero facts, not an error. That is production's own semantics:
+//
+//	if (!raw) { st.empty++; return []; }   // "no facts here", said badly
+//
+// The consolidator counts it and consolidates the chat with nothing. Treating it
+// as an error here scored a model that correctly abstained as a harness failure,
+// which is exactly backwards on an ABSTENTION case — and abstention is one of the
+// two gated abilities. The first live run surfaced this: the credential case came
+// back empty (the right answer) and was reported as `ERROR empty reply`.
+//
+// It is still worth COUNTING separately, for the reason the bundle gives: a rising
+// empty rate is how a degrading extractor shows up before anything else notices.
+// That is what EmptyReply on the result carries.
+//
+// Returns (facts, dropped, error); an error now means only that the reply held
+// text which was not a JSON array.
 func ParseExtractorReply(raw string) ([]ExtractedFact, int, error) {
 	s := strings.TrimSpace(raw)
 	if s == "" {
-		return nil, 0, fmt.Errorf("empty reply")
+		return nil, 0, nil
 	}
 	m := jsonArrayRe.FindString(s)
 	if m == "" {

--- a/internal/memory/eval/extraction_baseline.go
+++ b/internal/memory/eval/extraction_baseline.go
@@ -9,12 +9,15 @@ package eval
 // each ability into a number a run can be measured against, and a drop into a
 // gate failure that names the ability and both values.
 //
-// KEYED BY (provider, model, effort, PROMPT DIGEST). The prompt digest is the part
-// that is easy to leave out and expensive to omit: change the extractor prompt and
-// every score legitimately moves, so a baseline that ignored the prompt would
-// either block every prompt change or silently compare across incomparable runs.
-// With the digest in the key, editing the prompt produces "no baseline for this
-// prompt yet" — which is the truth — instead of a spurious regression.
+// KEYED BY (provider, model, effort, PROMPT DIGEST, CORPUS DIGEST). The two
+// digests are the part that is easy to leave out and expensive to omit: change the
+// extractor prompt, or add a case to the corpus, and every score legitimately
+// moves. A baseline that ignored either would block the change as a regression, or
+// worse, silently compare across incomparable runs. With both in the key, editing
+// a prompt or a fixture produces "no baseline for this yet" — which is the truth.
+//
+// The corpus digest was added after the first live run, when adding a realistic
+// case would have silently invalidated a stored figure with nothing to signal it.
 
 import (
 	"encoding/json"
@@ -32,6 +35,8 @@ type BaselineEntry struct {
 	// SystemPromptSHA256 is the extractor prompt these numbers were measured
 	// against. See the file header for why it is part of the key.
 	SystemPromptSHA256 string `json:"system_prompt_sha256"`
+	// CorpusSHA256 is the fixture set these numbers were measured against.
+	CorpusSHA256 string `json:"corpus_sha256"`
 	// MeasuredAt is informational — it tells a reader how stale the number is. It
 	// is NOT part of the key.
 	MeasuredAt string `json:"measured_at,omitempty"`
@@ -43,7 +48,7 @@ type BaselineEntry struct {
 
 // Key identifies the run this entry describes.
 func (e BaselineEntry) Key() string {
-	return e.Provider + "|" + e.Model + "|" + e.Effort + "|" + e.SystemPromptSHA256
+	return e.Provider + "|" + e.Model + "|" + e.Effort + "|" + e.SystemPromptSHA256 + "|" + e.CorpusSHA256
 }
 
 // Baseline is the committed set of measured runs.
@@ -87,7 +92,7 @@ func LoadBaseline(path string) (Baseline, error) {
 func (b Baseline) EntryFor(r ExtractionReport) (BaselineEntry, bool) {
 	want := BaselineEntry{
 		Provider: r.Provider, Model: r.Model, Effort: r.Effort,
-		SystemPromptSHA256: r.SystemPromptSHA256,
+		SystemPromptSHA256: r.SystemPromptSHA256, CorpusSHA256: r.CorpusSHA256,
 	}.Key()
 	for _, e := range b.Entries {
 		if e.Key() == want {
@@ -173,6 +178,7 @@ func SaveBaselineEntry(path string, r ExtractionReport) error {
 	entry := BaselineEntry{
 		Provider: r.Provider, Model: r.Model, Effort: r.Effort,
 		SystemPromptSHA256: r.SystemPromptSHA256,
+		CorpusSHA256:       r.CorpusSHA256,
 		MeasuredAt:         time.Now().UTC().Format(time.RFC3339),
 		Recall:             map[string]float64{},
 		Violations:         map[string]int{},

--- a/internal/memory/eval/extraction_baseline_test.go
+++ b/internal/memory/eval/extraction_baseline_test.go
@@ -122,6 +122,32 @@ func TestBaseline_PromptChangeIsNotARegression(t *testing.T) {
 	}
 }
 
+// TestBaseline_CorpusChangeIsNotARegression is the corpus half of the
+// prompt-digest argument, and it was verified against a real near-miss: a baseline
+// had just been recorded when the buried property case was added. Without the
+// corpus digest in the key, the very next run reported "property recall fell
+// 1.00 -> 0.50" — a spurious regression caused entirely by adding a harder case,
+// which is how a gate teaches people to pass --no-gate.
+func TestBaseline_CorpusChangeIsNotARegression(t *testing.T) {
+	b := Baseline{RecallTolerance: DefaultRecallTolerance, Entries: []BaselineEntry{{
+		Provider: "p", Model: "m", Effort: "medium",
+		SystemPromptSHA256: "sha", CorpusSHA256: "corpus-old",
+		Recall:     map[string]float64{"property": 1.0},
+		Violations: map[string]int{"property": 0},
+	}}}
+	newCorpus := ExtractionReport{
+		Provider: "p", Model: "m", Effort: "medium",
+		SystemPromptSHA256: "sha", CorpusSHA256: "corpus-new",
+		Abilities: []AbilityScore{{Ability: AbilityProperty, Recall: 0.5}},
+	}
+	if got := b.Regressions(newCorpus); len(got) != 0 {
+		t.Fatalf("a different corpus is a different measurement, not a regression: %v", got)
+	}
+	if _, ok := b.EntryFor(newCorpus); ok {
+		t.Error("a run against a new corpus must not match the old entry")
+	}
+}
+
 // TestSaveBaselineEntry_RefusesAFaultedRun: recording scores from a run whose
 // canary failed would bake 0.0 in as the number to beat, and the next run would
 // then look like an improvement.

--- a/internal/memory/eval/extraction_fixtures.go
+++ b/internal/memory/eval/extraction_fixtures.go
@@ -33,6 +33,8 @@ package eval
 // appears that markers cannot express.
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"strings"
 )
@@ -247,6 +249,70 @@ func ExtractionFixture() ExtractionCorpus {
 			}},
 		},
 
+		{
+			Name:    "request-implies-condition-buried",
+			Ability: AbilityProperty,
+			// SAME property signal as request-implies-condition, buried in a
+			// production-shaped transcript.
+			//
+			// The clean version of this case passed 2/2 on the first model measured,
+			// which CONTRADICTS the observed production failure on this exact
+			// ability. The most likely difference is not judgement but INPUT: a real
+			// compaction-banked span is a long working session where the durable
+			// signal is two lines among dozens of task chatter, while a 2-line
+			// fixture puts it under a spotlight. If a model passes the clean case
+			// and fails this one, the failure is localised to signal-in-noise and
+			// the eval becomes predictive of production; if it passes both, the
+			// problem is not the extractor's judgement and we are looking in the
+			// wrong place. Either answer is worth more than another model A/B.
+			Turns: []string{
+				"morning — can we pick up the invoice importer where we left off?",
+				"Sure. Last time we had the CSV parser working but the date column was ambiguous.",
+				"right, the european format one. did you push that branch?",
+				"Yes, it's on feature-invoice-dates. The tests pass locally.",
+				"ok let me pull it. while that's running — I've been on atorvastatin for a while " +
+					"and my legs ache constantly, can you find me alternatives with less muscle pain?",
+				"I can look into that separately. Back to the importer: do you want the parser to " +
+					"reject an ambiguous date, or guess from the locale?",
+				"reject. I'd rather it fail loudly than silently book an invoice to the wrong month.",
+				"Understood — it'll return an error listing the ambiguous rows.",
+				"perfect. also the CI run is still queued, can you kick it?",
+				"Queued job restarted.",
+				"thanks, that's it for now — I'll review the branch after lunch.",
+			},
+			Want: []ExpectedFact{
+				{
+					Why:    "the buried request still reveals what the user TAKES, two lines in among task chatter",
+					AllOf:  []string{"statin"},
+					NoneOf: recordingTells,
+				},
+				{
+					Why:    "and the symptom it caused; noise must not cost the connection between them",
+					AnyOf:  []string{"ache", "pain", "sore"},
+					AllOf:  []string{"muscle"},
+					NoneOf: recordingTells,
+				},
+			},
+			Forbid: []Forbidden{
+				{
+					Kind:   ForbiddenDistractor,
+					Why:    "recording that a question was ASKED is a fact about the conversation",
+					Marker: "asked",
+				},
+				{
+					Kind:   ForbiddenDistractor,
+					Why:    "a queued CI job is transient task state, stale the moment it runs",
+					Marker: "still queued",
+				},
+				{
+					Kind: ForbiddenDistractor,
+					Why: "a branch name and its test status are working state, not durable facts " +
+						"about the user or the project",
+					Marker: "feature-invoice-dates",
+				},
+			},
+		},
+
 		// ---- temporal: the qualifier is load-bearing ----
 		{
 			Name:    "bounded-by-time",
@@ -383,6 +449,34 @@ func (c ExtractionCorpus) CasesByAbility() map[Ability][]ExtractionCase {
 		out[cs.Ability] = append(out[cs.Ability], cs)
 	}
 	return out
+}
+
+// Digest is a stable content hash of the corpus: every case's name, ability,
+// turns, expectations and forbidden markers.
+//
+// It exists so a baseline can be keyed by the fixture set that produced it.
+// Adding a case changes recall denominators, and editing one changes what a
+// number means, so a baseline recorded against an older corpus is not a number
+// the current run can be compared to — the same argument the prompt digest
+// already makes, applied to the other input. Without it, adding a case would
+// silently turn every stored figure into a false regression or a false pass.
+func (c ExtractionCorpus) Digest() string {
+	h := sha256.New()
+	for _, cs := range c.Cases {
+		fmt.Fprintf(h, "case\x00%s\x00%s\x00%t\x00", cs.Name, cs.Ability, cs.Canary)
+		for _, t := range cs.Turns {
+			fmt.Fprintf(h, "turn\x00%s\x00", t)
+		}
+		for _, w := range cs.Want {
+			fmt.Fprintf(h, "want\x00%s\x00%s\x00%s\x00%s\x00%s\x00",
+				w.Why, strings.Join(w.AllOf, "|"), strings.Join(w.AnyOf, "|"),
+				strings.Join(w.NoneOf, "|"), w.Class)
+		}
+		for _, f := range cs.Forbid {
+			fmt.Fprintf(h, "forbid\x00%s\x00%s\x00%s\x00", f.Kind, f.Marker, f.Key)
+		}
+	}
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 // Validate checks the corpus's own coherence, so a fixture typo surfaces as a

--- a/internal/memory/eval/extraction_test.go
+++ b/internal/memory/eval/extraction_test.go
@@ -382,10 +382,27 @@ func TestParseExtractorReply_ToleratesWrappedArray(t *testing.T) {
 	}
 }
 
-func TestParseExtractorReply_EmptyAndMalformed(t *testing.T) {
-	if _, _, err := ParseExtractorReply("   "); err == nil {
-		t.Error("an empty reply must be an error, so it is never silently scored as zero facts")
+// TestParseExtractorReply_EmptyIsZeroFactsNotAnError mirrors production, which
+// does `if (!raw) { st.empty++; return []; }` — an empty reply is "no facts here",
+// said badly, and the chat is consolidated with nothing.
+//
+// This test previously asserted the OPPOSITE and was wrong. The first live run
+// exposed it: the credential-in-transcript abstention case came back empty — the
+// CORRECT answer — and was reported as `ERROR empty reply`, scoring a model that
+// abstained properly as a harness failure on one of the two GATED abilities.
+func TestParseExtractorReply_EmptyIsZeroFactsNotAnError(t *testing.T) {
+	for _, raw := range []string{"", "   ", "\n\t "} {
+		facts, dropped, err := ParseExtractorReply(raw)
+		if err != nil {
+			t.Errorf("ParseExtractorReply(%q) = error %v; production treats an empty reply as zero facts", raw, err)
+		}
+		if len(facts) != 0 || dropped != 0 {
+			t.Errorf("ParseExtractorReply(%q) = %d facts / %d dropped, want 0/0", raw, len(facts), dropped)
+		}
 	}
+}
+
+func TestParseExtractorReply_Malformed(t *testing.T) {
 	if _, _, err := ParseExtractorReply("I could not do that."); err == nil {
 		t.Error("a reply with no array must be an error")
 	}
@@ -567,6 +584,7 @@ func TestRunExtraction_ScoresAPerfectRunClean(t *testing.T) {
 		"request-implies-stack":             `[{"text":"Runs Postgres and finds the bill high.","class":"fact"}]`,
 		"bounded-by-time":                   `[{"text":"Works from the Lisbon office from March through the end of the year.","class":"fact"}]`,
 		"corrects-earlier-preference":       `[{"text":"Uses spaces for indentation on the new repo.","class":"preference"}]`,
+		"request-implies-condition-buried":  `[{"text":"Takes atorvastatin, a statin.","class":"fact"},{"text":"Experiences constant muscle ache in the legs.","class":"fact"},{"text":"Wants the invoice importer to reject an ambiguous date rather than guess from the locale.","class":"decision"}]`,
 		"credential-in-transcript":          `[]`,
 		"pure-chatter":                      `[]`,
 		"question-is-not-a-fact":            `[]`,
@@ -669,6 +687,137 @@ func TestCanary_UnparseableReplyIsADifferentDiagnosis(t *testing.T) {
 	for _, want := range []string{"DID reach the model", "JSON-array", "max_tokens"} {
 		if !strings.Contains(fault, want) {
 			t.Errorf("the message should mention %q:\n%s", want, fault)
+		}
+	}
+}
+
+// TestAbstention_EmptyReplyIsAPassNotAnError is the regression for the bug the
+// first live run exposed.
+//
+// The credential-in-transcript case came back with an entirely empty reply — the
+// CORRECT answer, since the transcript holds only a secret and transient task
+// state — and the harness reported `ERROR empty reply`, marking the case unclean.
+// Abstention is one of the two GATED abilities, so mis-scoring it is the worst
+// place for this to happen. Production's own branch is
+// `if (!raw) { st.empty++; return []; }`.
+func TestAbstention_EmptyReplyIsAPassNotAnError(t *testing.T) {
+	var credCase ExtractionCase
+	for _, cs := range ExtractionFixture().Cases {
+		if cs.Name == "credential-in-transcript" {
+			credCase = cs
+		}
+	}
+	if credCase.Name == "" {
+		t.Fatal("the credential case is missing from the corpus")
+	}
+
+	res := runCase(context.Background(), alwaysCaller{reply: ""}, canaryOnlyInput(), credCase)
+	if res.Err != "" {
+		t.Errorf("an empty reply must not be an error: %s", res.Err)
+	}
+	if len(res.Violations) != 0 {
+		t.Errorf("abstaining must produce no violations: %v", res.Violations)
+	}
+	if !res.Passed() {
+		t.Errorf("a correct abstention must count as a clean case (err=%q violations=%v)", res.Err, res.Violations)
+	}
+	if !res.EmptyReply {
+		t.Error("the empty reply should still be RECORDED — a rising rate is how a degrading extractor shows up")
+	}
+}
+
+// TestEmptyReply_DistinguishesThinkingOnly: on Ollama, effort=medium sets
+// think:true, so a model can spend its whole reply reasoning and emit no answer.
+// That is a different diagnosis from abstaining and must not be reported as one.
+func TestEmptyReply_DistinguishesThinkingOnly(t *testing.T) {
+	res := runCase(context.Background(), thinkingOnlyCaller{}, canaryOnlyInput(), ExtractionCanary())
+	if !res.EmptyReply {
+		t.Fatal("want EmptyReply")
+	}
+	if !res.ThinkingOnly {
+		t.Fatal("a reasoning trace with no answer must be recorded as ThinkingOnly")
+	}
+	fault := canaryFault(res)
+	if !strings.Contains(fault, "REASONING TRACE") {
+		t.Errorf("the canary fault should name the cause:\n%s", fault)
+	}
+	if !strings.Contains(fault, "think:true") {
+		t.Errorf("the fault should point at the actual knob:\n%s", fault)
+	}
+}
+
+// thinkingOnlyCaller emits a reasoning trace and no answer.
+type thinkingOnlyCaller struct{}
+
+func (thinkingOnlyCaller) Call(_ context.Context, _ providers.Request) (<-chan providers.Event, error) {
+	ch := make(chan providers.Event, 3)
+	ch <- providers.Event{Type: providers.EventThinking, Text: "Let me think about what is durable here..."}
+	ch <- providers.Event{Type: providers.EventText, Text: ""}
+	ch <- providers.Event{Type: providers.EventDone}
+	close(ch)
+	return ch, nil
+}
+
+// TestCorpusDigest_ChangesWithTheFixtures pins why the baseline key carries it:
+// adding or editing a case moves every recall figure, so a stored number measured
+// against a different corpus is not comparable.
+func TestCorpusDigest_ChangesWithTheFixtures(t *testing.T) {
+	base := ExtractionFixture()
+	d1 := base.Digest()
+	if d1 == "" {
+		t.Fatal("digest must not be empty")
+	}
+	if d1 != ExtractionFixture().Digest() {
+		t.Fatal("the digest must be stable for identical fixtures")
+	}
+
+	// Add a case.
+	added := base
+	added.Cases = append(append([]ExtractionCase{}, base.Cases...),
+		ExtractionCase{Name: "extra", Ability: AbilityExtraction, Turns: []string{"t"}})
+	if added.Digest() == d1 {
+		t.Error("adding a case must change the digest — recall denominators moved")
+	}
+
+	// Edit an expectation in place.
+	edited := ExtractionCorpus{Cases: append([]ExtractionCase{}, base.Cases...)}
+	for i := range edited.Cases {
+		if len(edited.Cases[i].Want) > 0 {
+			edited.Cases[i].Want = append([]ExpectedFact{}, edited.Cases[i].Want...)
+			edited.Cases[i].Want[0].AllOf = []string{"something-else"}
+			break
+		}
+	}
+	if edited.Digest() == d1 {
+		t.Error("editing an expectation must change the digest — the number means something different")
+	}
+}
+
+// TestCorpus_HasABuriedPropertyCase: the clean property case passed 2/2 on the
+// first model measured, contradicting the production failure. The buried variant is
+// what distinguishes "the model cannot do the transformation" from "the model
+// cannot find the signal in a real transcript", so its absence would leave the
+// eval unable to tell those apart.
+func TestCorpus_HasABuriedPropertyCase(t *testing.T) {
+	var buried ExtractionCase
+	for _, cs := range ExtractionFixture().Cases {
+		if cs.Name == "request-implies-condition-buried" {
+			buried = cs
+		}
+	}
+	if buried.Name == "" {
+		t.Fatal("no buried property case in the corpus")
+	}
+	if buried.Ability != AbilityProperty {
+		t.Errorf("ability = %q, want %q", buried.Ability, AbilityProperty)
+	}
+	if len(buried.Turns) < 8 {
+		t.Errorf("a buried case needs enough surrounding noise to be buried; got %d turns", len(buried.Turns))
+	}
+	// The signal must not be in the first or last turn, or it is not buried.
+	for _, edge := range []string{buried.Turns[0], buried.Turns[len(buried.Turns)-1]} {
+		if strings.Contains(strings.ToLower(edge), "statin") {
+			t.Errorf("the property signal sits on an edge turn, so it is not buried: %q", edge)
 		}
 	}
 }


### PR DESCRIPTION
Found by the **first live run** of `memory-eval-live` against `qwen3.6:latest`. Four things, all surfaced by that one run.

## 1. The harness mis-scored a correct abstention — on a gated ability

```
abstention        4       n/a           0     3/4
credential-in-transcript [abstention]
  ERROR      empty reply
```

That case's transcript holds only a credential-shaped token and a queued CI job, so **the right answer is nothing**, and the model gave nothing — an empty reply rather than `[]`. Production doesn't treat that as an error:

```js
if (!raw) { st.empty++; return []; }   // "no facts here", said badly
```

It counts it and consolidates the chat with zero facts. My file header claims the harness applies *"the SAME validation the bundle's `validateFacts` applies"* — I ported `validateFacts` and not the branch immediately above it. Abstention is one of the two **gated** abilities, so this was the worst place for it.

Now zero facts, with `EmptyReply` carried on the result rather than folded away, for the reason the bundle itself gives: a rising empty rate is the earliest sign of a degrading extractor.

## 2. "Reasoned and never answered" looked identical to "abstained"

`effort=medium` sets Ollama's `think:true`, and that trace arrives as `EventThinking`, which `collectReply` deliberately does not accumulate into the answer. So a model can spend its entire reply reasoning and emit nothing. `ThinkingOnly` now separates the two, and the canary names the actual knob (`--effort low`, or more `--max-tokens`) when it trips.

## 3. The baseline key was missing a corpus digest — verified against a real near-miss

It had the prompt digest but not one for the fixtures. Adding a case moves every recall denominator, so the same argument applies. This wasn't hypothetical: a baseline had just been recorded, and adding the case in §4 reported

```
property recall fell 1.00 → 0.50 against the baseline
```

against it — a spurious regression caused entirely by making the corpus harder. That is precisely how a gate teaches everyone to pass `--no-gate`. Fail-before verified.

## 4. A buried property case, because the clean one passed and I don't believe it

The first run scored **property 2/2**, which contradicts the observed production failure on that exact ability. The likeliest difference is not judgement but **input**: a real compaction-banked span is a long working session where the durable signal is two lines among dozens of task chatter, while a 2-line fixture puts it under a spotlight.

`request-implies-condition-buried` carries the same signal, buried in eleven turns of unrelated invoice-importer work, with the surrounding noise (a branch name, a queued CI job) as forbidden markers. A model that passes clean and fails buried **localises the failure to signal-in-noise and makes the eval predictive of production**. One that passes both says the problem isn't the extractor's judgement at all, and we've been looking in the wrong place. Either answer is worth more than another model A/B.

Plus `--show-facts`: the default report is problem-only, which is right for a regression check and wrong for the first measurement of a new model — the surprising result was a *pass*, and there was no way to read what the model had actually written without re-running.

## The recorded baseline is emptied

For the record, the first run's numbers (`ollama-local` / `qwen3.6:latest` / `effort=medium`, prompt `7104816985db`):

| ability | recall | violations | clean |
|---|---|---|---|
| extraction | 1.00 | 0 | 3/3 |
| property | 1.00 | 0 | 2/2 |
| temporal | 1.00 | 0 | 1/1 |
| update | 1.00 | 0 | 1/1 |
| abstention | n/a | 0 | 3/4 → **4/4** after fix #1 |

They're kept here as history rather than in the file, because they were measured against the pre-fix abstention scoring and a corpus that no longer exists — and with the corpus digest in the key that entry can never match a run again. A file that means "compare against this" should not hold numbers nothing can be compared to.

**Re-record after merge**, and note `local-medium` resolves to `qwen3.6:27b`, not `:latest` — so scoring `:27b` is what describes the deployment:

```bash
make memory-eval-live MEMEVAL_MODEL=qwen3.6:27b MEMEVAL_UPDATE=1 --show-facts
```

## What was tested

`go test ./...` — 85 packages, zero failures. `gofmt`/`go vet` clean.

Fail-before verified by restoring each old behaviour and watching the test fail:

| Fix | Reverted to | Observed |
|---|---|---|
| empty reply | `return error("empty reply")` | `an empty reply must not be an error` + case marked unclean |
| corpus digest | key without it | `property recall fell 1.00 → 0.50` false regression |

New: `TestAbstention_EmptyReplyIsAPassNotAnError`, `TestBaseline_CorpusChangeIsNotARegression`, `TestEmptyReply_DistinguishesThinkingOnly`, `TestCorpusDigest_ChangesWithTheFixtures`, `TestCorpus_HasABuriedPropertyCase`. `TestParseExtractorReply_EmptyAndMalformed` encoded the bug and is inverted, with the reason recorded.

CLI-only and eval-only — **no runtime change**, so it does not block the v1.40.0 deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)