### PR TITLE
feat(sandbox): authenticated real-dev sandbox — egress + credential injection + GitHub App tokens

### DIFF
--- a/bundles/sandbox/loomcycle.yaml
+++ b/bundles/sandbox/loomcycle.yaml
@@ -57,8 +57,10 @@ agents:
       ## Notes
       - The sandbox has Python, Go, Rust, C/C++, and Node preinstalled. /work is an
         in-memory workspace that vanishes when the session closes — nothing persists.
-      - By default the sandbox has NO network. If a step must fetch dependencies and
-        the operator enabled it, open the session with network:"egress".
+      - Open with network:"egress" for real dev work (cloning repos, fetching
+        dependencies) — this is a networked dev sandbox. Use network:"none" only for
+        purely offline compute. (If the operator hasn't enabled egress the session
+        silently falls back to no network.)
       - Resource limits (cpu/mem/pids/tmpfs) are capped by the operator; ask for less
         when a task is small, never more than you need.
       - If the sandbox tools are unavailable, the builder sidecar isn't deployed —
@@ -107,8 +109,9 @@ skills:
       - If a caller GIVES you a session_id, reuse it (don't open a new one); if asked to
         KEEP a session open for follow-up, report the session_id and leave it open — a
         parent agent may drive several commands against the same container.
-      - Default to network:"none"; use "egress" only when a step must fetch something
-        and the operator enabled egress.
+      - Default to network:"egress" for dev work (clone/fetch deps); use "none" only
+        for offline compute. (Egress needs the operator's SANDBOX_ALLOW_EGRESS; if it
+        isn't enabled, the session falls back to no network.)
       - Keepalive: if you'll leave a session idle across a gap with no commands (a
         parent is thinking between steps), sandbox_touch {session_id} resets its idle
         timer so it isn't reaped — a normal sandbox_exec already resets it.

--- a/bundles/sandbox/loomcycle.yaml
+++ b/bundles/sandbox/loomcycle.yaml
@@ -9,6 +9,9 @@
 #   - LOOMCYCLE_SANDBOX_TOKEN set to the SAME shared secret as the sidecar's
 #     SANDBOX_AUTH_TOKEN (the mcp_servers header below consumes it).
 #   - a `low` tier — select `base` alongside, or supply your own.
+#   - (optional) authenticated git/gh: set SANDBOX_ALLOW_ENV_INJECTION=1 on the
+#     sidecar and store a `sandbox_github` credential (a GitHub token) via
+#     `credentialdef op=create` — it is injected into the session as GH_TOKEN.
 # Without the sidecar the mcp__sandbox__* tools are registered-but-unreachable
 # (the MCP pool retries lazily); nothing else in the bundle is affected.
 #
@@ -61,6 +64,9 @@ agents:
         dependencies) — this is a networked dev sandbox. Use network:"none" only for
         purely offline compute. (If the operator hasn't enabled egress the session
         silently falls back to no network.)
+      - For git/gh, run `gh auth setup-git` once at session start: a GitHub token
+        (GH_TOKEN) is injected when the operator configured one, letting you clone
+        and push PRIVATE repos over HTTPS. Never paste a token yourself.
       - Resource limits (cpu/mem/pids/tmpfs) are capped by the operator; ask for less
         when a task is small, never more than you need.
       - If the sandbox tools are unavailable, the builder sidecar isn't deployed —
@@ -102,6 +108,16 @@ skills:
         then re-run "go build ./... && go test ./..."
       - sandbox_read {session_id, path:"bin/app"} to pull the built binary
       - sandbox_close {session_id}
+
+      ## Git / GitHub (authenticated)
+      When the operator configured a GitHub token it is injected into the session as
+      GH_TOKEN. To use it for git over HTTPS, run this ONCE per session first:
+        sandbox_exec {session_id, command:"gh auth setup-git && git config --global user.name loomcycle && git config --global user.email loomcycle@users.noreply.github.com"}
+      (gh already reads GH_TOKEN; `gh auth setup-git` makes git use it too.) Then
+      clone/push private repos over HTTPS:
+        sandbox_exec {session_id, command:"git clone https://github.com/OWNER/PRIVATE ."}
+      If `gh auth status` reports no token, the operator hasn't configured one — only
+      public repos will clone. Never paste a token yourself; tell the human.
 
       ## Rules
       - Reuse ONE session for a task — don't open a new one per command (you'd lose the
@@ -213,3 +229,11 @@ mcp_servers:
       # run-liveness GC + sandbox_close_run (empty when the run carries none).
       X-Loom-Root-Run: "${run.root_run_id}"
       X-Loom-Tenant: "${run.tenant_id}"
+      # A GitHub token for authenticated git/gh inside the session, resolved from
+      # the per-tenant/user CredentialDef `sandbox_github` (store a PAT/fine-grained
+      # token, or a GitHub App token). The sidecar maps this header to GH_TOKEN in
+      # the session env; the value is resolved server-side so it never reaches the
+      # model. Unresolved -> the header is dropped -> git runs unauthenticated
+      # (public repos still clone). Requires SANDBOX_ALLOW_ENV_INJECTION=1 on the
+      # sidecar.
+      X-Loom-Sandbox-Env-Gh-Token: "$cred:sandbox_github"

--- a/cloud-deployment/docker-compose.yaml
+++ b/cloud-deployment/docker-compose.yaml
@@ -106,6 +106,7 @@ services:
       SANDBOX_MAX_CPUS: "2"
       SANDBOX_MAX_MEM_MB: "2048"
       SANDBOX_ALLOW_EGRESS: "1"          # permit network:"egress" sessions (git clone / fetch deps)
+      SANDBOX_ALLOW_ENV_INJECTION: "1"   # permit X-Loom-Sandbox-Env-* -> session env (git/gh token)
       SANDBOX_AUTH_TOKEN: ${SANDBOX_AUTH_TOKEN}   # SAME secret loomcycle presents
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/cloud-deployment/docker-compose.yaml
+++ b/cloud-deployment/docker-compose.yaml
@@ -105,6 +105,7 @@ services:
                                          # HOST path here — see INSTALL.md.
       SANDBOX_MAX_CPUS: "2"
       SANDBOX_MAX_MEM_MB: "2048"
+      SANDBOX_ALLOW_EGRESS: "1"          # permit network:"egress" sessions (git clone / fetch deps)
       SANDBOX_AUTH_TOKEN: ${SANDBOX_AUTH_TOKEN}   # SAME secret loomcycle presents
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/cmd/loomcycle/embedded/bundles/sandbox.yaml
+++ b/cmd/loomcycle/embedded/bundles/sandbox.yaml
@@ -57,8 +57,10 @@ agents:
       ## Notes
       - The sandbox has Python, Go, Rust, C/C++, and Node preinstalled. /work is an
         in-memory workspace that vanishes when the session closes — nothing persists.
-      - By default the sandbox has NO network. If a step must fetch dependencies and
-        the operator enabled it, open the session with network:"egress".
+      - Open with network:"egress" for real dev work (cloning repos, fetching
+        dependencies) — this is a networked dev sandbox. Use network:"none" only for
+        purely offline compute. (If the operator hasn't enabled egress the session
+        silently falls back to no network.)
       - Resource limits (cpu/mem/pids/tmpfs) are capped by the operator; ask for less
         when a task is small, never more than you need.
       - If the sandbox tools are unavailable, the builder sidecar isn't deployed —
@@ -107,8 +109,9 @@ skills:
       - If a caller GIVES you a session_id, reuse it (don't open a new one); if asked to
         KEEP a session open for follow-up, report the session_id and leave it open — a
         parent agent may drive several commands against the same container.
-      - Default to network:"none"; use "egress" only when a step must fetch something
-        and the operator enabled egress.
+      - Default to network:"egress" for dev work (clone/fetch deps); use "none" only
+        for offline compute. (Egress needs the operator's SANDBOX_ALLOW_EGRESS; if it
+        isn't enabled, the session falls back to no network.)
       - Keepalive: if you'll leave a session idle across a gap with no commands (a
         parent is thinking between steps), sandbox_touch {session_id} resets its idle
         timer so it isn't reaped — a normal sandbox_exec already resets it.

--- a/cmd/loomcycle/embedded/bundles/sandbox.yaml
+++ b/cmd/loomcycle/embedded/bundles/sandbox.yaml
@@ -9,6 +9,9 @@
 #   - LOOMCYCLE_SANDBOX_TOKEN set to the SAME shared secret as the sidecar's
 #     SANDBOX_AUTH_TOKEN (the mcp_servers header below consumes it).
 #   - a `low` tier — select `base` alongside, or supply your own.
+#   - (optional) authenticated git/gh: set SANDBOX_ALLOW_ENV_INJECTION=1 on the
+#     sidecar and store a `sandbox_github` credential (a GitHub token) via
+#     `credentialdef op=create` — it is injected into the session as GH_TOKEN.
 # Without the sidecar the mcp__sandbox__* tools are registered-but-unreachable
 # (the MCP pool retries lazily); nothing else in the bundle is affected.
 #
@@ -61,6 +64,9 @@ agents:
         dependencies) — this is a networked dev sandbox. Use network:"none" only for
         purely offline compute. (If the operator hasn't enabled egress the session
         silently falls back to no network.)
+      - For git/gh, run `gh auth setup-git` once at session start: a GitHub token
+        (GH_TOKEN) is injected when the operator configured one, letting you clone
+        and push PRIVATE repos over HTTPS. Never paste a token yourself.
       - Resource limits (cpu/mem/pids/tmpfs) are capped by the operator; ask for less
         when a task is small, never more than you need.
       - If the sandbox tools are unavailable, the builder sidecar isn't deployed —
@@ -102,6 +108,16 @@ skills:
         then re-run "go build ./... && go test ./..."
       - sandbox_read {session_id, path:"bin/app"} to pull the built binary
       - sandbox_close {session_id}
+
+      ## Git / GitHub (authenticated)
+      When the operator configured a GitHub token it is injected into the session as
+      GH_TOKEN. To use it for git over HTTPS, run this ONCE per session first:
+        sandbox_exec {session_id, command:"gh auth setup-git && git config --global user.name loomcycle && git config --global user.email loomcycle@users.noreply.github.com"}
+      (gh already reads GH_TOKEN; `gh auth setup-git` makes git use it too.) Then
+      clone/push private repos over HTTPS:
+        sandbox_exec {session_id, command:"git clone https://github.com/OWNER/PRIVATE ."}
+      If `gh auth status` reports no token, the operator hasn't configured one — only
+      public repos will clone. Never paste a token yourself; tell the human.
 
       ## Rules
       - Reuse ONE session for a task — don't open a new one per command (you'd lose the
@@ -213,3 +229,11 @@ mcp_servers:
       # run-liveness GC + sandbox_close_run (empty when the run carries none).
       X-Loom-Root-Run: "${run.root_run_id}"
       X-Loom-Tenant: "${run.tenant_id}"
+      # A GitHub token for authenticated git/gh inside the session, resolved from
+      # the per-tenant/user CredentialDef `sandbox_github` (store a PAT/fine-grained
+      # token, or a GitHub App token). The sidecar maps this header to GH_TOKEN in
+      # the session env; the value is resolved server-side so it never reaches the
+      # model. Unresolved -> the header is dropped -> git runs unauthenticated
+      # (public repos still clone). Requires SANDBOX_ALLOW_ENV_INJECTION=1 on the
+      # sidecar.
+      X-Loom-Sandbox-Env-Gh-Token: "$cred:sandbox_github"

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1429,6 +1429,18 @@ func main() {
 	}
 	credEngine := credential.NewEngine(storeIface, credSealer)
 	credentialDefTool.Engine = credEngine
+	// $ghapp:<name> — mint a short-lived GitHub App installation token from a
+	// stored App config (the private key never leaves loomcycle; only the ~1h,
+	// repo-scoped token is substituted). Resolves the App config through the same
+	// scope-precedence credential lookup as $cred:.
+	ghAppMinter := credential.NewGitHubAppMinter(
+		func(ctx context.Context, tenantID, agentName, userID, name string) (string, bool, error) {
+			res, found, err := credEngine.Resolve(ctx, tenantID, agentName, userID, name)
+			if err != nil || !found {
+				return "", found, err
+			}
+			return res.Value, true, nil
+		}, nil)
 	// srv is assigned below at lchttp.New; the credential closures capture it by
 	// reference so a resolved value can be registered in the server's redactor.
 	// registerSecret is only CALLED during a run (long after srv exists), so the
@@ -1450,13 +1462,24 @@ func main() {
 	// a pooled client binds each request's own user-scoped token.
 	credSubstitute = func(ctx context.Context, s string) (string, []string, error) {
 		// Fast-path: when nothing can resolve (no KEK / no external backend) skip
-		// the store reads. Report any $cred: refs as unresolved so the caller still
-		// drops them (never send a literal token downstream).
+		// the store reads. Report any $cred: / $ghapp: refs as unresolved so the
+		// caller still drops them (never send a literal token downstream).
 		if !credEngine.CanResolve() {
-			return s, credential.RefNames(s), nil
+			return s, append(credential.RefNames(s), credential.GHAppRefNames(s)...), nil
 		}
 		ri := tools.RunIdentity(ctx)
-		return credEngine.Substitute(ctx, ri.TenantID, tools.AgentName(ctx), ri.UserID, s, registerSecret)
+		// $ghapp: (mint an installation token) then $cred: (durable secret). The two
+		// syntaxes don't overlap; each drops its own header on an unresolved/failed
+		// ref, and a mint/resolve error aborts so no literal token is sent.
+		out, un1, err := ghAppMinter.Substitute(ctx, ri.TenantID, tools.AgentName(ctx), ri.UserID, s, registerSecret)
+		if err != nil {
+			return "", nil, err
+		}
+		out, un2, err := credEngine.Substitute(ctx, ri.TenantID, tools.AgentName(ctx), ri.UserID, out, registerSecret)
+		if err != nil {
+			return "", nil, err
+		}
+		return out, append(un1, un2...), nil
 	}
 	// RFC AR: resolve a tenant/user credential by env-var NAME (ANTHROPIC_API_KEY,
 	// BRAVE_API_KEY, …) for the run's identity, so a tenant's own key overrides

--- a/deploy/builder/README.md
+++ b/deploy/builder/README.md
@@ -122,6 +122,8 @@ secret — forwarding it would 401).
 | `SANDBOX_RUNTIME` | `""` | OCI runtime: `""`\|`runc`\|`crun`\|`runsc`\|`kata`. |
 | `SANDBOX_CONTAINER_USER` | `1000:1000` | In-container user (never root). |
 | `SANDBOX_ALLOW_EGRESS` | `0` | `1` permits `network:"egress"` sessions. |
+| `SANDBOX_ALLOW_ENV_INJECTION` | `0` | `1` permits **env injection** — `X-Loom-Sandbox-Env-<Name>` request headers (value resolved by loomcycle from `$cred:`/`$ghapp:`, so a secret never reaches the model) are injected as `--env` into the session container, e.g. a GitHub token for authenticated `git`/`gh`. Off = the headers are ignored. |
+| `SANDBOX_MAX_ENV_VARS` / `SANDBOX_MAX_ENV_VALUE_BYTES` | `32` / `65536` | Caps on injected env: max var count per open + max value bytes. |
 | `SANDBOX_WORKSPACE_ROOT` | (unset) | Absolute host dir enabling **durable workspaces** — a session opened with `workspace:<name>` bind-mounts `<root>/<principal>/<name>` at `/work` instead of tmpfs (see below). Unset = tmpfs-only. |
 | `SANDBOX_DEFAULT_TMPFS_MB` / `SANDBOX_MAX_TMPFS_MB` | `512` / `2048` | Workspace tmpfs size + ceiling. |
 | `SANDBOX_MAX_CPUS` / `SANDBOX_MAX_MEM_MB` / `SANDBOX_MAX_PIDS` | `2` / `2048` / `512` | Per-session resource ceilings. |
@@ -129,6 +131,28 @@ secret — forwarding it would 401).
 | `SANDBOX_GC_INTERVAL` | `1m` | GC tick. |
 | `SANDBOX_MAX_SESSIONS` | `32` | Concurrent session cap. |
 | `SANDBOX_MAX_OUTPUT_BYTES` | `1048576` | Per-exec output cap. |
+
+## Env injection (credentials into a session)
+
+By default a session container gets only a fixed, non-secret env (cache-dir
+redirects). To do real dev — clone/push a private repo, use `gh` — a session
+needs a credential. `SANDBOX_ALLOW_ENV_INJECTION=1` turns on a header→env seam:
+
+- loomcycle carries the secret in an `X-Loom-Sandbox-Env-<Name>` request header
+  whose value it resolves **server-side** from a stored credential (`$cred:` /
+  `$ghapp:`), so the token is never in a tool argument and never reaches the
+  model. The header name maps to an env var name (strip the prefix, uppercase,
+  `-`→`_`): `X-Loom-Sandbox-Env-Gh-Token` → `GH_TOKEN`.
+- On `sandbox_open` the sidecar validates each name (`[A-Z_][A-Z0-9_]*`, and
+  rejects reserved/toolchain names — `HOME`, `PATH`, `LD_*`, the cache vars — plus
+  `LOOMCYCLE_*` / `PG_DSN`), caps count + value size, and injects the rest as
+  `--env`. `docker exec` inherits them, so `git`/`gh` in a later `sandbox_exec`
+  see the token. Injected values are **never logged**.
+- Trust model: the env value is visible to the session's own process (that's the
+  point) and to anyone with host-Docker access (the operator, who already holds
+  the credential). With `network:"egress"` a token in env is an exfiltration
+  surface under prompt injection — prefer short-lived, repo-scoped tokens (a
+  GitHub App installation token) over a broad PAT.
 
 ## Durable workspaces (persistent `/work`)
 

--- a/deploy/builder/config.go
+++ b/deploy/builder/config.go
@@ -39,6 +39,15 @@ type Config struct {
 	// network:"egress" only when the operator opts in.
 	AllowEgress bool // SANDBOX_ALLOW_EGRESS=1
 
+	// Env injection. When enabled, X-Loom-Sandbox-Env-<Name> request headers
+	// loomcycle fills — the value substituted server-side from $cred:/$ghapp:, so a
+	// secret never touches the model — are injected as --env into the session
+	// container (e.g. a GitHub token for authenticated git/gh). Off by default: a
+	// generic header->env seam is a capability the operator opts into.
+	AllowEnvInjection bool // SANDBOX_ALLOW_ENV_INJECTION=1
+	MaxEnvVars        int  // SANDBOX_MAX_ENV_VARS (default 32)
+	MaxEnvValueBytes  int  // SANDBOX_MAX_ENV_VALUE_BYTES (default 65536)
+
 	// Resource ceilings (per session container) + defaults when the caller
 	// omits a value.
 	DefTmpfsMB int64 // SANDBOX_DEFAULT_TMPFS_MB (default 512)
@@ -67,27 +76,30 @@ type Config struct {
 // validating the security-critical invariants.
 func LoadConfig() (*Config, error) {
 	c := &Config{
-		ListenAddr:     envStr("SANDBOX_LISTEN_ADDR", ":9000"),
-		AuthToken:      os.Getenv("SANDBOX_AUTH_TOKEN"),
-		AllowAnon:      os.Getenv("SANDBOX_ALLOW_ANON") == "1",
-		PodmanBin:      envStr("SANDBOX_PODMAN_BIN", "podman"),
-		Image:          os.Getenv("SANDBOX_IMAGE"),
-		Runtime:        os.Getenv("SANDBOX_RUNTIME"),
-		CtrUser:        envStr("SANDBOX_CONTAINER_USER", "1000:1000"),
-		WorkspaceRoot:  os.Getenv("SANDBOX_WORKSPACE_ROOT"),
-		AllowEgress:    os.Getenv("SANDBOX_ALLOW_EGRESS") == "1",
-		DefTmpfsMB:     envInt("SANDBOX_DEFAULT_TMPFS_MB", 512),
-		MaxTmpfsMB:     envInt("SANDBOX_MAX_TMPFS_MB", 2048),
-		MaxCPUs:        envFloat("SANDBOX_MAX_CPUS", 2),
-		MaxMemMB:       envInt("SANDBOX_MAX_MEM_MB", 2048),
-		MaxPids:        envInt("SANDBOX_MAX_PIDS", 512),
-		DefTimeout:     30 * time.Second,
-		MaxTimeout:     5 * time.Minute,
-		MaxOutBytes:    envInt("SANDBOX_MAX_OUTPUT_BYTES", 1<<20),
-		SessionIdleTTL: envDur("SANDBOX_SESSION_IDLE_TTL", 15*time.Minute),
-		SessionMaxTTL:  envDur("SANDBOX_SESSION_MAX_TTL", time.Hour),
-		GCInterval:     envDur("SANDBOX_GC_INTERVAL", time.Minute),
-		MaxSessions:    int(envInt("SANDBOX_MAX_SESSIONS", 32)),
+		ListenAddr:        envStr("SANDBOX_LISTEN_ADDR", ":9000"),
+		AuthToken:         os.Getenv("SANDBOX_AUTH_TOKEN"),
+		AllowAnon:         os.Getenv("SANDBOX_ALLOW_ANON") == "1",
+		PodmanBin:         envStr("SANDBOX_PODMAN_BIN", "podman"),
+		Image:             os.Getenv("SANDBOX_IMAGE"),
+		Runtime:           os.Getenv("SANDBOX_RUNTIME"),
+		CtrUser:           envStr("SANDBOX_CONTAINER_USER", "1000:1000"),
+		WorkspaceRoot:     os.Getenv("SANDBOX_WORKSPACE_ROOT"),
+		AllowEgress:       os.Getenv("SANDBOX_ALLOW_EGRESS") == "1",
+		AllowEnvInjection: os.Getenv("SANDBOX_ALLOW_ENV_INJECTION") == "1",
+		MaxEnvVars:        int(envInt("SANDBOX_MAX_ENV_VARS", 32)),
+		MaxEnvValueBytes:  int(envInt("SANDBOX_MAX_ENV_VALUE_BYTES", 64<<10)),
+		DefTmpfsMB:        envInt("SANDBOX_DEFAULT_TMPFS_MB", 512),
+		MaxTmpfsMB:        envInt("SANDBOX_MAX_TMPFS_MB", 2048),
+		MaxCPUs:           envFloat("SANDBOX_MAX_CPUS", 2),
+		MaxMemMB:          envInt("SANDBOX_MAX_MEM_MB", 2048),
+		MaxPids:           envInt("SANDBOX_MAX_PIDS", 512),
+		DefTimeout:        30 * time.Second,
+		MaxTimeout:        5 * time.Minute,
+		MaxOutBytes:       envInt("SANDBOX_MAX_OUTPUT_BYTES", 1<<20),
+		SessionIdleTTL:    envDur("SANDBOX_SESSION_IDLE_TTL", 15*time.Minute),
+		SessionMaxTTL:     envDur("SANDBOX_SESSION_MAX_TTL", time.Hour),
+		GCInterval:        envDur("SANDBOX_GC_INTERVAL", time.Minute),
+		MaxSessions:       int(envInt("SANDBOX_MAX_SESSIONS", 32)),
 	}
 	// Per-session defaults are the ceilings unless separately narrowed — a
 	// caller asking for less is honoured, more is clamped (see clampOpen).

--- a/deploy/builder/engine.go
+++ b/deploy/builder/engine.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -68,6 +69,11 @@ type openOpts struct {
 	MemMB   int64
 	Pids    int64
 	Image   string
+	// Env is operator-injected session environment (validated, non-reserved names
+	// mapped from X-Loom-Sandbox-Env-* headers — e.g. a GitHub token). Empty unless
+	// env injection is enabled. Emitted BEFORE sessionEnv so the toolchain/cache
+	// vars always win on a collision. Values are secrets — never logged.
+	Env map[string]string
 	// WorkspaceHostDir, when set, is a persistent host directory bind-mounted at
 	// /work (durable workspace, RFC BI P2a) instead of the in-memory tmpfs. It is
 	// a resolved + fenced path (see Dispatcher.resolveWorkspaceDir) — never a raw
@@ -122,6 +128,20 @@ func (e *Engine) runArgs(name string, o openOpts) []string {
 		"--cpus", strconv.FormatFloat(o.CPUs, 'f', -1, 64),
 		"--workdir", workDir,
 	)
+	// Operator-injected session env (e.g. a GitHub token for git/gh). Emitted
+	// BEFORE sessionEnv so the read-only-rootfs toolchain/cache vars always win on
+	// a collision (reserved names are rejected at validation; this is belt-and-
+	// suspenders). Sorted for a deterministic argv.
+	if len(o.Env) > 0 {
+		keys := make([]string, 0, len(o.Env))
+		for k := range o.Env {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			a = append(a, "--env", k+"="+o.Env[k])
+		}
+	}
 	for _, kv := range sessionEnv() {
 		a = append(a, "--env", kv)
 	}

--- a/deploy/builder/engine_test.go
+++ b/deploy/builder/engine_test.go
@@ -32,6 +32,7 @@ func testCfg() *Config {
 		DefMemMB: 2048, MaxMemMB: 2048, DefPids: 512, MaxPids: 512,
 		DefTimeout: 30 * time.Second, MaxTimeout: 5 * time.Minute, MaxOutBytes: 1 << 20,
 		SessionIdleTTL: 15 * time.Minute, SessionMaxTTL: time.Hour, MaxSessions: 32,
+		MaxEnvVars: 32, MaxEnvValueBytes: 1 << 16,
 	}
 }
 

--- a/deploy/builder/envinject_test.go
+++ b/deploy/builder/envinject_test.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// indexOfPair returns the index of flag when immediately followed by value, or -1.
+func indexOfPair(args []string, flag, value string) int {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag && args[i+1] == value {
+			return i
+		}
+	}
+	return -1
+}
+
+// argvContains reports whether any recorded call contains the exact arg v.
+func argvContains(calls [][]string, v string) bool {
+	for _, c := range calls {
+		for _, a := range c {
+			if a == v {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func TestEngine_RunArgs_InjectsEnvBeforeSessionEnv(t *testing.T) {
+	e := NewEngine(testCfg(), &fakeRunner{})
+	args := e.runArgs("n", openOpts{
+		Network: "egress", TmpfsMB: 512, CPUs: 1, MemMB: 512, Pids: 100, Image: "img:latest",
+		Env: map[string]string{"GH_TOKEN": "ghp_secret", "GIT_TERMINAL_PROMPT": "0"},
+	})
+	if !hasPair(args, "--env", "GH_TOKEN=ghp_secret") {
+		t.Errorf("injected env missing: %v", args)
+	}
+	// Injected env must precede sessionEnv so HOME/cache always win on any collision.
+	iTok := indexOfPair(args, "--env", "GH_TOKEN=ghp_secret")
+	iHome := indexOfPair(args, "--env", "HOME="+workDir)
+	if iTok < 0 || iHome < 0 || iTok > iHome {
+		t.Errorf("injected env must precede sessionEnv (token@%d home@%d): %v", iTok, iHome, args)
+	}
+}
+
+func TestCollectEnvHeaders_MapsNames(t *testing.T) {
+	h := http.Header{}
+	h.Set("X-Loom-Sandbox-Env-Gh-Token", "ghp_x")
+	h.Set("X-Loom-Sandbox-Env-My-Var", "v")
+	h.Set("Authorization", "Bearer y")
+	h.Set("X-Loom-Root-Run", "r")
+	env := collectEnvHeaders(h)
+	if env["GH_TOKEN"] != "ghp_x" || env["MY_VAR"] != "v" {
+		t.Errorf("name mapping wrong: %v", env)
+	}
+	if len(env) != 2 {
+		t.Errorf("should ignore non-env headers, got %v", env)
+	}
+	if collectEnvHeaders(http.Header{}) != nil {
+		t.Errorf("no env headers should return nil")
+	}
+}
+
+func TestValidateInjectedEnv_AcceptsAndRejects(t *testing.T) {
+	got, err := validateInjectedEnv(map[string]string{"GH_TOKEN": "ghp_x", "MY_VAR2": "v"}, 32, 1024)
+	if err != nil || got["GH_TOKEN"] != "ghp_x" || len(got) != 2 {
+		t.Fatalf("valid env should pass: got %v err %v", got, err)
+	}
+	// An empty value (an unresolved $cred:) is dropped, not an error.
+	if got, err := validateInjectedEnv(map[string]string{"GH_TOKEN": ""}, 32, 1024); err != nil || len(got) != 0 {
+		t.Errorf("empty value should drop silently: got %v err %v", got, err)
+	}
+	rejects := map[string]map[string]string{
+		"lowercase+dash":  {"gh-token": "x"},
+		"leading digit":   {"1FOO": "x"},
+		"reserved HOME":   {"HOME": "/x"},
+		"reserved PATH":   {"PATH": "/x"},
+		"reserved cache":  {"GOCACHE": "/x"},
+		"loomcycle infra": {"LOOMCYCLE_AUTH_TOKEN": "x"},
+		"pg dsn":          {"PG_DSN": "postgres://x"},
+		"oversize value":  {"BIG": strings.Repeat("a", 2000)},
+		"newline value":   {"NL": "a\nb"},
+	}
+	for name, env := range rejects {
+		if _, err := validateInjectedEnv(env, 32, 1024); err == nil {
+			t.Errorf("%s: expected rejection, got none", name)
+		}
+	}
+	// Over the per-open var cap.
+	many := make(map[string]string, 40)
+	for i := 0; i < 40; i++ {
+		many[fmt.Sprintf("V%d", i)] = "x"
+	}
+	if _, err := validateInjectedEnv(many, 32, 1024); err == nil {
+		t.Errorf("over-cap var count should be rejected")
+	}
+}
+
+func TestOpen_EnvInjectionGate(t *testing.T) {
+	mk := func(allow bool) (*Dispatcher, *fakeRunner) {
+		fr := &fakeRunner{}
+		cfg := testCfg()
+		cfg.AllowEnvInjection = allow
+		return NewDispatcher(cfg, NewEngine(cfg, fr), NewStore(cfg.SessionIdleTTL, cfg.SessionMaxTTL)), fr
+	}
+	env := map[string]string{"GH_TOKEN": "ghp_secret"}
+
+	// Gate OFF → the token is dropped, but the open still succeeds.
+	d, fr := mk(false)
+	if _, isErr, err := d.Call(context.Background(), caller{Principal: "p", Env: env}, "sandbox_open", json.RawMessage(`{}`)); err != nil || isErr {
+		t.Fatalf("gate-off open failed: err=%v isErr=%v", err, isErr)
+	}
+	if argvContains(fr.calls, "GH_TOKEN=ghp_secret") {
+		t.Errorf("gate off: token must NOT be injected: %v", fr.calls)
+	}
+
+	// Gate ON → the token is injected as --env.
+	d, fr = mk(true)
+	if _, isErr, err := d.Call(context.Background(), caller{Principal: "p", Env: env}, "sandbox_open", json.RawMessage(`{}`)); err != nil || isErr {
+		t.Fatalf("gate-on open failed: err=%v isErr=%v", err, isErr)
+	}
+	if !argvContains(fr.calls, "GH_TOKEN=ghp_secret") {
+		t.Errorf("gate on: token should be injected: %v", fr.calls)
+	}
+}
+
+// TestMCP_EnvHeader_NoLeakInResponse is the secret-never-in-model regression: a
+// token delivered via the X-Loom-Sandbox-Env-* header reaches the container env
+// but must never appear in the model-facing MCP response body.
+func TestMCP_EnvHeader_NoLeakInResponse(t *testing.T) {
+	fr := &fakeRunner{}
+	cfg := testCfg()
+	cfg.AuthToken = "secret-token"
+	cfg.AllowEnvInjection = true
+	d := NewDispatcher(cfg, NewEngine(cfg, fr), NewStore(cfg.SessionIdleTTL, cfg.SessionMaxTTL))
+	h := NewMCPHandler(cfg, d, "test")
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp",
+		strings.NewReader(`{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"sandbox_open","arguments":{}}}`))
+	req.Header.Set("Authorization", "Bearer secret-token")
+	req.Header.Set("X-Loom-Sandbox-Env-Gh-Token", "ghp_supersecret")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status %d", rr.Code)
+	}
+	// The token reaches the container env...
+	if !argvContains(fr.calls, "GH_TOKEN=ghp_supersecret") {
+		t.Errorf("token should reach the container env: %v", fr.calls)
+	}
+	// ...but must NOT appear in the model-facing response body.
+	if strings.Contains(rr.Body.String(), "ghp_supersecret") {
+		t.Errorf("secret leaked into the MCP response body: %s", rr.Body.String())
+	}
+}

--- a/deploy/builder/mcp.go
+++ b/deploy/builder/mcp.go
@@ -101,6 +101,7 @@ func (h *MCPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			Principal: principal,
 			RootRun:   strings.TrimSpace(r.Header.Get("X-Loom-Root-Run")),
 			Tenant:    strings.TrimSpace(r.Header.Get("X-Loom-Tenant")),
+			Env:       collectEnvHeaders(r.Header),
 		}
 		text, isErr, cerr := h.disp.Call(r.Context(), c, p.Name, p.Arguments)
 		if cerr != nil {
@@ -143,6 +144,36 @@ func (h *MCPHandler) authenticate(r *http.Request) (principal string, ok bool) {
 func principalFromToken(tok string) string {
 	sum := sha256.Sum256([]byte(tok))
 	return "op:" + hex.EncodeToString(sum[:8])
+}
+
+// envHeaderPrefix is the canonical prefix loomcycle uses to inject session env
+// into a sandbox: an X-Loom-Sandbox-Env-<Name> header whose value is the (already
+// server-side-resolved) secret. Carried out-of-band from tool args so it never
+// reaches the model.
+const envHeaderPrefix = "X-Loom-Sandbox-Env-"
+
+// collectEnvHeaders extracts injected session env from the request headers. The
+// header name maps to an env var name (strip the prefix, uppercase, '-' -> '_') —
+// e.g. X-Loom-Sandbox-Env-Gh-Token -> GH_TOKEN. Only sandbox_open consumes it;
+// the operator gate + name validation live at open time (Dispatcher.open). Returns
+// nil when no env headers are present.
+func collectEnvHeaders(h http.Header) map[string]string {
+	var env map[string]string
+	for k, vals := range h {
+		ck := http.CanonicalHeaderKey(k)
+		if len(vals) == 0 || len(ck) <= len(envHeaderPrefix) || !strings.HasPrefix(ck, envHeaderPrefix) {
+			continue
+		}
+		name := strings.ToUpper(strings.ReplaceAll(ck[len(envHeaderPrefix):], "-", "_"))
+		if name == "" {
+			continue
+		}
+		if env == nil {
+			env = make(map[string]string)
+		}
+		env[name] = vals[0]
+	}
+	return env
 }
 
 const sessionHeaderName = "Mcp-Session-Id"

--- a/deploy/builder/tools.go
+++ b/deploy/builder/tools.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -61,6 +62,10 @@ type caller struct {
 	Principal string
 	RootRun   string
 	Tenant    string
+	// Env is operator-injected session env from X-Loom-Sandbox-Env-* headers,
+	// consumed only by sandbox_open. Nil when none, or when the operator hasn't
+	// enabled injection. Values are secrets (e.g. a token) — never logged.
+	Env map[string]string
 }
 
 // Call dispatches a tools/call. It returns model-facing text and an isError flag
@@ -106,6 +111,23 @@ func (d *Dispatcher) open(ctx context.Context, c caller, raw json.RawMessage) (s
 	}
 	o := clampOpen(d.cfg, in.Network, in.TmpfsMB, in.CPUs, in.MemMB, in.Pids)
 	o.Image = d.cfg.Image
+
+	// Operator-injected session env: e.g. a GitHub token for git/gh, delivered as
+	// X-Loom-Sandbox-Env-* headers whose values loomcycle already resolved from
+	// $cred:/$ghapp: — so the secret rides the transport, never a tool arg (never
+	// the model). Gated by SANDBOX_ALLOW_ENV_INJECTION; when off we drop it and the
+	// run just runs unauthenticated (like egress silently downgrades).
+	if len(c.Env) > 0 {
+		if !d.cfg.AllowEnvInjection {
+			log.Printf("sandbox: %d injected env var(s) ignored (SANDBOX_ALLOW_ENV_INJECTION not set)", len(c.Env))
+		} else {
+			env, verr := validateInjectedEnv(c.Env, d.cfg.MaxEnvVars, d.cfg.MaxEnvValueBytes)
+			if verr != nil {
+				return verr.Error(), true, nil
+			}
+			o.Env = env
+		}
+	}
 
 	// RFC BI P2a — a named durable workspace: bind-mount a persistent host dir at
 	// /work instead of tmpfs, so a checkout + build cache survive container churn.
@@ -463,6 +485,61 @@ func clampOpen(cfg *Config, network string, tmpfsMB int64, cpus float64, memMB, 
 		o.Pids = cfg.MaxPids
 	}
 	return o
+}
+
+// reservedEnvNames are session-integrity vars that injection must never set:
+// overriding them could break the read-only-rootfs toolchain (HOME/cache dirs),
+// the image PATH the toolchain lives on, or slip in a loader hook. (sessionEnv's
+// cache vars also always win by emit order, but rejecting them is clearer.)
+var reservedEnvNames = map[string]bool{
+	"HOME": true, "PATH": true, "TMPDIR": true,
+	"LD_PRELOAD": true, "LD_LIBRARY_PATH": true,
+	"XDG_CACHE_HOME": true, "GOCACHE": true, "GOPATH": true,
+	"GOMODCACHE": true, "CARGO_HOME": true, "PIP_CACHE_DIR": true,
+}
+
+// validateInjectedEnv checks operator-injected session env against the operator
+// caps + a reserved/infra denylist. An empty value is dropped, not an error (a
+// $cred: that resolved to nothing → the run simply runs unauthenticated). Returns
+// the vars to inject, or an error that becomes a tool-level failure.
+func validateInjectedEnv(in map[string]string, maxVars, maxValBytes int) (map[string]string, error) {
+	if len(in) > maxVars {
+		return nil, fmt.Errorf("too many injected env vars (%d > max %d)", len(in), maxVars)
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		if v == "" {
+			continue // an unresolved credential — inject nothing, degrade gracefully
+		}
+		if !validEnvName(k) {
+			return nil, fmt.Errorf("invalid injected env name %q (must match [A-Z_][A-Z0-9_]*)", k)
+		}
+		if reservedEnvNames[k] || strings.HasPrefix(k, "LOOMCYCLE_") || k == "PG_DSN" {
+			return nil, fmt.Errorf("injected env name %q is reserved and cannot be set", k)
+		}
+		if len(v) > maxValBytes {
+			return nil, fmt.Errorf("injected env %q value too large (%d > %d bytes)", k, len(v), maxValBytes)
+		}
+		if strings.ContainsAny(v, "\n\r\x00") {
+			return nil, fmt.Errorf("injected env %q value contains a control character", k)
+		}
+		out[k] = v
+	}
+	return out, nil
+}
+
+// validEnvName enforces POSIX-ish names [A-Z_][A-Z0-9_]* — upper only, since
+// collectEnvHeaders uppercases header-derived names.
+func validEnvName(s string) bool {
+	for i, r := range s {
+		switch {
+		case r == '_' || (r >= 'A' && r <= 'Z'):
+		case i > 0 && r >= '0' && r <= '9':
+		default:
+			return false
+		}
+	}
+	return s != ""
 }
 
 // safeRelPath validates a caller-supplied workspace path. It must be a relative

--- a/docs/CREDENTIALS.md
+++ b/docs/CREDENTIALS.md
@@ -71,6 +71,45 @@ unresolved `$cred:` ref drops the header (no literal token is ever sent).
 > can't carry per-user tokens. Use an http MCP server (token as a per-request
 > header) for the per-user case.
 
+## Minting a GitHub App token — `$ghapp:<name>`
+
+For **short-lived, repo-scoped** git auth (preferred over a long-lived PAT), store
+a **GitHub App** config instead of a token and reference it with `$ghapp:<name>`.
+loomcycle mints a fresh installation access token (an RS256 JWT exchanged at
+GitHub's installation-token API), caches it until ~5 min before it expires (~1 h
+TTL), and substitutes it exactly like `$cred:`. **The App private key never leaves
+loomcycle — only the minted, scoped token is ever sent.**
+
+Store the App config as a credential whose value is a JSON object:
+
+```jsonc
+// value is a JSON string; app_id/installation_id/private_key are required.
+// repositories + permissions are optional and DOWN-SCOPE the minted token.
+{
+  "app_id": "123456",
+  "installation_id": "7654321",
+  "private_key": "-----BEGIN RSA PRIVATE KEY-----\n…\n-----END RSA PRIVATE KEY-----\n",
+  "repositories": ["my-repo"],
+  "permissions": {"contents": "write"},
+  "base_url": "https://api.github.com"   // optional; GitHub Enterprise Server, https only
+}
+```
+
+```jsonc
+// create it (the value is the JSON above, as a single JSON-escaped string)
+credentialdef  op=create  scope=user  name=sandbox_github_app  value='{"app_id":"123456",…}'
+```
+
+Then reference it in an http-MCP header, the same place a `$cred:` would go:
+
+```yaml
+headers:
+  Authorization: "Bearer $ghapp:my_github_app"   # or X-Loom-Sandbox-Env-Gh-Token for the dev sandbox
+```
+
+An unresolved ref — or a mint failure (bad key, network) — **drops the header**
+(no literal token is ever sent).
+
 ## Overriding a provider / tool API key by its env-var name
 
 Some credentials aren't referenced with `$cred:` — they **override the operator's

--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -99,6 +99,27 @@ workspace root into the sidecar at the **same host path** so the dir the sidecar
 creates is the dir the host engine bind-mounts. Full detail:
 [`../deploy/builder/README.md`](../deploy/builder/README.md#durable-workspaces-persistent-work).
 
+### Authenticated git / gh (private repos)
+
+By default a session has no credentials, so only **public** repos clone. To do
+real dev — clone/push a **private** repo, use `gh` — inject a GitHub token:
+
+1. Enable env injection on the sidecar: `SANDBOX_ALLOW_ENV_INJECTION=1`.
+2. Store the token as a per-tenant/user credential named **`sandbox_github`**
+   (`credentialdef op=create scope=user name=sandbox_github value=<token>`) — a
+   PAT/fine-grained token, or a GitHub App token (see below).
+3. The `sandbox` bundle already forwards it: `mcp_servers.sandbox.headers` carries
+   `X-Loom-Sandbox-Env-Gh-Token: "$cred:sandbox_github"`, which loomcycle resolves
+   **server-side** (never in the model) and the sidecar maps to `GH_TOKEN` in the
+   session env. In-session, `dev/sandbox` runs `gh auth setup-git` so `git` over
+   HTTPS uses it too.
+
+Unresolved (no such credential, or injection disabled) → the header is dropped →
+git runs unauthenticated, public repos still work. Because the token lives in the
+session env with egress on, prefer a **short-lived, repo-scoped GitHub App token**
+over a broad PAT. Full mechanism + caps:
+[`../deploy/builder/README.md`](../deploy/builder/README.md#env-injection-credentials-into-a-session).
+
 ## Delegating from other agents
 
 An agent doesn't hold the `mcp__sandbox__*` tools directly (by design — tool ceilings

--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -107,7 +107,9 @@ real dev — clone/push a **private** repo, use `gh` — inject a GitHub token:
 1. Enable env injection on the sidecar: `SANDBOX_ALLOW_ENV_INJECTION=1`.
 2. Store the token as a per-tenant/user credential named **`sandbox_github`**
    (`credentialdef op=create scope=user name=sandbox_github value=<token>`) — a
-   PAT/fine-grained token, or a GitHub App token (see below).
+   PAT / fine-grained token. For a **short-lived, repo-scoped** token instead,
+   store a GitHub App config and reference it with `$ghapp:<name>` (see
+   [CREDENTIALS.md](CREDENTIALS.md#minting-a-github-app-token----ghappname)).
 3. The `sandbox` bundle already forwards it: `mcp_servers.sandbox.headers` carries
    `X-Loom-Sandbox-Env-Gh-Token: "$cred:sandbox_github"`, which loomcycle resolves
    **server-side** (never in the model) and the sidecar maps to `GH_TOKEN` in the
@@ -117,7 +119,8 @@ real dev — clone/push a **private** repo, use `gh` — inject a GitHub token:
 Unresolved (no such credential, or injection disabled) → the header is dropped →
 git runs unauthenticated, public repos still work. Because the token lives in the
 session env with egress on, prefer a **short-lived, repo-scoped GitHub App token**
-over a broad PAT. Full mechanism + caps:
+(`$ghapp:` — overlay the header value to `$ghapp:sandbox_github_app`) over a broad
+PAT. Full mechanism + caps:
 [`../deploy/builder/README.md`](../deploy/builder/README.md#env-injection-credentials-into-a-session).
 
 ## Delegating from other agents

--- a/internal/credential/githubapp.go
+++ b/internal/credential/githubapp.go
@@ -1,0 +1,336 @@
+package credential
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ghAppTokenRe matches a $ghapp:<name> reference — the sibling of $cred: for a
+// GitHub App. The referenced credential holds an App config (JSON), and the
+// resolver mints a short-lived installation ACCESS TOKEN from it: the App private
+// key never leaves loomcycle, only the ~1h, repo-scoped token is substituted.
+var ghAppTokenRe = regexp.MustCompile(`\$ghapp:([A-Za-z0-9_-]{1,128})`)
+
+// HasGHAppRef reports whether s contains any $ghapp:<name> token.
+func HasGHAppRef(s string) bool { return ghAppTokenRe.MatchString(s) }
+
+// GHAppRefNames returns the <name> of every $ghapp:<name> token in s (nil when
+// none) — so a caller with no resolver still drops those headers instead of
+// sending a literal "$ghapp:foo" downstream (mirrors RefNames).
+func GHAppRefNames(s string) []string {
+	ms := ghAppTokenRe.FindAllStringSubmatch(s, -1)
+	if len(ms) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(ms))
+	for _, m := range ms {
+		out = append(out, m[1])
+	}
+	return out
+}
+
+// ConfigResolver returns the stored App-config JSON for a credential name, using
+// the same scope precedence as Engine.Resolve (agent > user > tenant). main.go
+// wires it to Engine.Resolve; tests pass a fake.
+type ConfigResolver func(ctx context.Context, tenantID, agentName, userID, name string) (config string, found bool, err error)
+
+// GitHubAppMinter resolves $ghapp:<name> tokens by minting a GitHub App
+// installation access token from the stored App config, cached until shortly
+// before it expires. Safe for concurrent use.
+type GitHubAppMinter struct {
+	resolve ConfigResolver
+	http    *http.Client
+	now     func() time.Time
+
+	mu    sync.Mutex
+	cache map[string]cachedGHToken
+}
+
+type cachedGHToken struct {
+	token string
+	exp   time.Time
+}
+
+// NewGitHubAppMinter builds a minter. A nil httpClient gets a sane default with a
+// timeout (the mint is a server-side call to api.github.com).
+func NewGitHubAppMinter(resolve ConfigResolver, httpClient *http.Client) *GitHubAppMinter {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 15 * time.Second}
+	}
+	return &GitHubAppMinter{resolve: resolve, http: httpClient, now: time.Now, cache: map[string]cachedGHToken{}}
+}
+
+// Substitute replaces every $ghapp:<name> token in s with a freshly-minted (or
+// cached) installation access token for the run identity. Mirrors
+// Engine.Substitute: unresolved names are returned in `unresolved` (caller drops
+// the header); a hard error (bad config / mint failure) aborts and is returned so
+// the caller drops the header rather than sending a literal token.
+func (m *GitHubAppMinter) Substitute(ctx context.Context, tenantID, agentName, userID, s string, register func(string)) (out string, unresolved []string, err error) {
+	if !ghAppTokenRe.MatchString(s) {
+		return s, nil, nil
+	}
+	var firstErr error
+	out = ghAppTokenRe.ReplaceAllStringFunc(s, func(tok string) string {
+		name := ghAppTokenRe.FindStringSubmatch(tok)[1]
+		cfgJSON, found, rerr := m.resolve(ctx, tenantID, agentName, userID, name)
+		if rerr != nil {
+			if firstErr == nil {
+				firstErr = rerr
+			}
+			return tok
+		}
+		if !found {
+			unresolved = append(unresolved, name)
+			return tok
+		}
+		access, terr := m.token(ctx, cfgJSON)
+		if terr != nil {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("github app %q: %w", name, terr)
+			}
+			return tok
+		}
+		if register != nil {
+			register(access)
+		}
+		return access
+	})
+	if firstErr != nil {
+		return "", nil, firstErr
+	}
+	return out, unresolved, nil
+}
+
+// flexString unmarshals a JSON string OR number into a string, so app_id /
+// installation_id may be written either way in the stored config.
+type flexString string
+
+func (f *flexString) UnmarshalJSON(b []byte) error {
+	s := strings.TrimSpace(string(b))
+	s = strings.Trim(s, `"`)
+	*f = flexString(s)
+	return nil
+}
+
+// ghAppConfig is the stored credential value for a $ghapp: reference.
+type ghAppConfig struct {
+	AppID          flexString        `json:"app_id"`
+	InstallationID flexString        `json:"installation_id"`
+	PrivateKey     string            `json:"private_key"`
+	Repositories   []string          `json:"repositories,omitempty"` // optional down-scope to specific repos
+	Permissions    map[string]string `json:"permissions,omitempty"`  // optional down-scope of permissions
+	BaseURL        string            `json:"base_url,omitempty"`     // GitHub Enterprise; default api.github.com
+}
+
+// token returns a valid installation access token for the given App config,
+// minting a new one (and caching it) when none is cached or the cached one is
+// within 5 minutes of expiry.
+func (m *GitHubAppMinter) token(ctx context.Context, cfgJSON string) (string, error) {
+	var cfg ghAppConfig
+	if err := json.Unmarshal([]byte(cfgJSON), &cfg); err != nil {
+		return "", fmt.Errorf("credential is not a GitHub App config (expected JSON with app_id, private_key, installation_id): %w", err)
+	}
+	if cfg.AppID == "" || cfg.PrivateKey == "" || cfg.InstallationID == "" {
+		return "", errors.New("github app config requires app_id, private_key, and installation_id")
+	}
+	key := ghCacheKey(cfg)
+	m.mu.Lock()
+	if c, ok := m.cache[key]; ok && m.now().Before(c.exp.Add(-5*time.Minute)) {
+		tok := c.token
+		m.mu.Unlock()
+		return tok, nil
+	}
+	m.mu.Unlock()
+
+	// Mint outside the lock so a slow GitHub call doesn't serialise unrelated
+	// resolutions; a rare concurrent double-mint is harmless (both tokens valid).
+	tok, exp, err := m.mint(ctx, cfg)
+	if err != nil {
+		return "", err
+	}
+	m.mu.Lock()
+	m.cache[key] = cachedGHToken{token: tok, exp: exp}
+	m.mu.Unlock()
+	return tok, nil
+}
+
+// mint builds the App JWT and exchanges it for an installation access token.
+func (m *GitHubAppMinter) mint(ctx context.Context, cfg ghAppConfig) (string, time.Time, error) {
+	inst := string(cfg.InstallationID)
+	if !isDigits(inst) {
+		return "", time.Time{}, fmt.Errorf("installation_id must be numeric, got %q", inst)
+	}
+	jwt, err := buildAppJWT(string(cfg.AppID), cfg.PrivateKey, m.now())
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	base := strings.TrimRight(cfg.BaseURL, "/")
+	if base == "" {
+		base = "https://api.github.com"
+	}
+	if !strings.HasPrefix(base, "https://") {
+		return "", time.Time{}, fmt.Errorf("base_url must be https, got %q", base)
+	}
+	url := base + "/app/installations/" + inst + "/access_tokens"
+
+	var body io.Reader
+	if len(cfg.Repositories) > 0 || len(cfg.Permissions) > 0 {
+		payload := map[string]any{}
+		if len(cfg.Repositories) > 0 {
+			payload["repositories"] = cfg.Repositories
+		}
+		if len(cfg.Permissions) > 0 {
+			payload["permissions"] = cfg.Permissions
+		}
+		b, _ := json.Marshal(payload)
+		body = bytes.NewReader(b)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+jwt)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := m.http.Do(req)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	defer resp.Body.Close()
+	rb, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode != http.StatusCreated {
+		return "", time.Time{}, fmt.Errorf("installation token request: HTTP %d: %s", resp.StatusCode, truncateGH(string(rb), 200))
+	}
+	var out struct {
+		Token     string    `json:"token"`
+		ExpiresAt time.Time `json:"expires_at"`
+	}
+	if err := json.Unmarshal(rb, &out); err != nil {
+		return "", time.Time{}, fmt.Errorf("parse installation token response: %w", err)
+	}
+	if out.Token == "" {
+		return "", time.Time{}, errors.New("installation token response had no token")
+	}
+	if out.ExpiresAt.IsZero() {
+		out.ExpiresAt = m.now().Add(time.Hour) // GitHub tokens last ~1h; be conservative if absent
+	}
+	return out.Token, out.ExpiresAt, nil
+}
+
+// buildAppJWT builds the RS256 App JWT (iss=app_id, iat backdated 60s for clock
+// skew, exp +9m — under GitHub's 10m cap). Hand-rolled on stdlib (no JWT dep).
+func buildAppJWT(appID, pemKey string, now time.Time) (string, error) {
+	key, err := parseRSAPrivateKey(pemKey)
+	if err != nil {
+		return "", err
+	}
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	claims := map[string]any{
+		"iat": now.Add(-60 * time.Second).Unix(),
+		"exp": now.Add(9 * time.Minute).Unix(),
+	}
+	// iss is the App ID (numeric) or a Client ID (string). Emit numeric when it
+	// looks numeric so classic App-ID auth keeps working.
+	if isDigits(appID) {
+		n, _ := strconv.ParseInt(appID, 10, 64)
+		claims["iss"] = n
+	} else {
+		claims["iss"] = appID
+	}
+	cb, err := json.Marshal(claims)
+	if err != nil {
+		return "", err
+	}
+	signingInput := header + "." + base64.RawURLEncoding.EncodeToString(cb)
+	digest := sha256.Sum256([]byte(signingInput))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, digest[:])
+	if err != nil {
+		return "", fmt.Errorf("sign app jwt: %w", err)
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sig), nil
+}
+
+// parseRSAPrivateKey accepts a PKCS#1 ("RSA PRIVATE KEY") or PKCS#8 ("PRIVATE
+// KEY") PEM — GitHub App keys are usually PKCS#1.
+func parseRSAPrivateKey(pemStr string) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode([]byte(pemStr))
+	if block == nil {
+		return nil, errors.New("private_key is not a PEM block")
+	}
+	if k, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return k, nil
+	}
+	keyAny, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse private_key (not PKCS#1 or PKCS#8 RSA): %w", err)
+	}
+	rk, ok := keyAny.(*rsa.PrivateKey)
+	if !ok {
+		return nil, errors.New("private_key is not an RSA key")
+	}
+	return rk, nil
+}
+
+// ghCacheKey keys the token cache by the token's SCOPE (app + installation +
+// repos + permissions), not the private key — a key rotation reuses a still-valid
+// token, while a different app/installation/scope re-mints.
+func ghCacheKey(cfg ghAppConfig) string {
+	h := sha256.New()
+	fmt.Fprintf(h, "%s\x00%s\x00", cfg.AppID, cfg.InstallationID)
+	repos := append([]string(nil), cfg.Repositories...)
+	sort.Strings(repos)
+	for _, r := range repos {
+		io.WriteString(h, r)
+		h.Write([]byte{0})
+	}
+	pkeys := make([]string, 0, len(cfg.Permissions))
+	for k := range cfg.Permissions {
+		pkeys = append(pkeys, k)
+	}
+	sort.Strings(pkeys)
+	for _, k := range pkeys {
+		fmt.Fprintf(h, "%s=%s\x00", k, cfg.Permissions[k])
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func isDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func truncateGH(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/internal/credential/githubapp_test.go
+++ b/internal/credential/githubapp_test.go
@@ -1,0 +1,195 @@
+package credential
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// testKeyPEM generates a throwaway RSA key and returns it as a PKCS#1 PEM.
+func testKeyPEM(t *testing.T) (*rsa.PrivateKey, string) {
+	t.Helper()
+	k, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(k)})
+	return k, string(pemBytes)
+}
+
+func TestBuildAppJWT_SignedRS256(t *testing.T) {
+	key, keyPEM := testKeyPEM(t)
+	now := time.Unix(1_800_000_000, 0)
+	tok, err := buildAppJWT("12345", keyPEM, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parts := strings.Split(tok, ".")
+	if len(parts) != 3 {
+		t.Fatalf("jwt must have 3 parts, got %d", len(parts))
+	}
+	// Header.
+	hb, _ := base64.RawURLEncoding.DecodeString(parts[0])
+	var hdr struct{ Alg, Typ string }
+	if err := json.Unmarshal(hb, &hdr); err != nil {
+		t.Fatal(err)
+	}
+	if hdr.Alg != "RS256" || hdr.Typ != "JWT" {
+		t.Errorf("header = %+v, want RS256/JWT", hdr)
+	}
+	// Claims: iss numeric, iat backdated, exp within 10m.
+	cb, _ := base64.RawURLEncoding.DecodeString(parts[1])
+	var claims struct {
+		Iss int64 `json:"iss"`
+		Iat int64 `json:"iat"`
+		Exp int64 `json:"exp"`
+	}
+	if err := json.Unmarshal(cb, &claims); err != nil {
+		t.Fatal(err)
+	}
+	if claims.Iss != 12345 {
+		t.Errorf("iss = %d, want 12345", claims.Iss)
+	}
+	if claims.Iat != now.Add(-60*time.Second).Unix() {
+		t.Errorf("iat not backdated 60s: %d", claims.Iat)
+	}
+	if claims.Exp <= claims.Iat || claims.Exp-now.Unix() > 600 {
+		t.Errorf("exp must be after iat and within 10m: iat=%d exp=%d", claims.Iat, claims.Exp)
+	}
+	// Signature verifies against the public key.
+	digest := sha256.Sum256([]byte(parts[0] + "." + parts[1]))
+	sig, _ := base64.RawURLEncoding.DecodeString(parts[2])
+	if err := rsa.VerifyPKCS1v15(&key.PublicKey, crypto.SHA256, digest[:], sig); err != nil {
+		t.Errorf("signature does not verify: %v", err)
+	}
+}
+
+func TestMinter_MintCacheAndRefresh(t *testing.T) {
+	_, keyPEM := testKeyPEM(t)
+	var hits int
+	// A fake GitHub installations endpoint.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		if r.URL.Path != "/app/installations/999/access_tokens" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		if !strings.HasPrefix(r.Header.Get("Authorization"), "Bearer ") {
+			t.Errorf("missing bearer jwt")
+		}
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprintf(w, `{"token":"ghs_minted_%d","expires_at":%q}`, hits, time.Unix(1_800_003_600, 0).UTC().Format(time.RFC3339))
+	}))
+	defer srv.Close()
+
+	m := NewGitHubAppMinter(nil, srv.Client())
+	clock := time.Unix(1_800_000_000, 0)
+	m.now = func() time.Time { return clock }
+
+	cfg := fmt.Sprintf(`{"app_id":12345,"installation_id":"999","private_key":%q,"base_url":%q}`, keyPEM, srv.URL)
+
+	// First mint.
+	tok1, err := m.token(context.Background(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok1 != "ghs_minted_1" || hits != 1 {
+		t.Fatalf("first mint: tok=%q hits=%d", tok1, hits)
+	}
+	// Cached — no new HTTP call.
+	tok2, err := m.token(context.Background(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok2 != "ghs_minted_1" || hits != 1 {
+		t.Fatalf("cache miss: tok=%q hits=%d (want cached, 1 hit)", tok2, hits)
+	}
+	// Advance to within 5m of expiry → refresh.
+	clock = time.Unix(1_800_003_600, 0).Add(-4 * time.Minute)
+	tok3, err := m.token(context.Background(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok3 != "ghs_minted_2" || hits != 2 {
+		t.Fatalf("expected refresh near expiry: tok=%q hits=%d", tok3, hits)
+	}
+}
+
+func TestMinter_Substitute(t *testing.T) {
+	_, keyPEM := testKeyPEM(t)
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprintf(w, `{"token":"ghs_abc","expires_at":%q}`, time.Now().Add(time.Hour).UTC().Format(time.RFC3339))
+	}))
+	defer srv.Close()
+
+	cfg := fmt.Sprintf(`{"app_id":"1","installation_id":"2","private_key":%q,"base_url":%q}`, keyPEM, srv.URL)
+	resolve := func(_ context.Context, _, _, _, name string) (string, bool, error) {
+		if name == "myapp" {
+			return cfg, true, nil
+		}
+		return "", false, nil
+	}
+	m := NewGitHubAppMinter(resolve, srv.Client())
+
+	var registered []string
+	out, unresolved, err := m.Substitute(context.Background(), "t", "a", "u", "$ghapp:myapp", func(s string) { registered = append(registered, s) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "ghs_abc" {
+		t.Errorf("substitute = %q, want ghs_abc", out)
+	}
+	if len(unresolved) != 0 {
+		t.Errorf("unexpected unresolved: %v", unresolved)
+	}
+	if len(registered) != 1 || registered[0] != "ghs_abc" {
+		t.Errorf("token should be registered with the redactor: %v", registered)
+	}
+
+	// Unresolved name → left literal, reported, no error.
+	out, unresolved, err = m.Substitute(context.Background(), "t", "a", "u", "$ghapp:missing", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "$ghapp:missing" || len(unresolved) != 1 || unresolved[0] != "missing" {
+		t.Errorf("unresolved handling wrong: out=%q unresolved=%v", out, unresolved)
+	}
+}
+
+func TestGHAppRefNames(t *testing.T) {
+	if !HasGHAppRef("$ghapp:foo") || HasGHAppRef("$cred:foo") {
+		t.Errorf("HasGHAppRef mis-detects")
+	}
+	names := GHAppRefNames("a $ghapp:one b $ghapp:two-3 c")
+	if len(names) != 2 || names[0] != "one" || names[1] != "two-3" {
+		t.Errorf("GHAppRefNames = %v", names)
+	}
+}
+
+func TestMinter_BadConfig(t *testing.T) {
+	m := NewGitHubAppMinter(nil, nil)
+	if _, err := m.token(context.Background(), "not json"); err == nil {
+		t.Errorf("non-JSON config should error")
+	}
+	if _, err := m.token(context.Background(), `{"app_id":"1"}`); err == nil {
+		t.Errorf("missing fields should error")
+	}
+	// Non-numeric installation_id is rejected before any network call.
+	_, keyPEM := testKeyPEM(t)
+	bad := fmt.Sprintf(`{"app_id":"1","installation_id":"abc","private_key":%q}`, keyPEM)
+	if _, err := m.token(context.Background(), bad); err == nil {
+		t.Errorf("non-numeric installation_id should error")
+	}
+}


### PR DESCRIPTION
## Why

The `dev/sandbox` sandbox worked only for **public, unauthenticated, offline**
work — it couldn't clone/push a private repo or use `gh`, and had no network by
default. This turns it into a real, isolated dev workspace: network egress, and a
credential path that reaches a throwaway container **without the secret ever
entering the model's context**.

Design of record: RFC BQ (`/loomcycle/rfcs/sandbox-dev-environment` in the doc
store).

## What

Four dependency-ordered commits:

- **Egress** — `SANDBOX_ALLOW_EGRESS=1` on the cloud builder-sidecar; the
  `dev/sandbox` agent + skill default to `network:"egress"` (degrades to
  no-network when the operator hasn't enabled it).
- **Sidecar env-injection seam** (`deploy/builder`) — `X-Loom-Sandbox-Env-<Name>`
  request headers → validated session `--env` on `sandbox_open`, gated by
  `SANDBOX_ALLOW_ENV_INJECTION`, log-scrubbed, reserved/infra names rejected. The
  sidecar stays domain-agnostic.
- **PAT wiring** — the sandbox bundle forwards
  `X-Loom-Sandbox-Env-Gh-Token: "$cred:sandbox_github"` (resolved server-side,
  never in the model); the skill runs `gh auth setup-git`. Private clone/push
  works.
- **GitHub App minting** — a new `$ghapp:<name>` resolver mints a short-lived,
  repo-scoped installation token (RS256 JWT on stdlib crypto, cached ~1h). The App
  private key never leaves loomcycle.

The secret-never-in-model invariant rides loomcycle's existing per-request header
substitution (`internal/tools/mcp/http/client.go`); a token only ever exists in an
internal HTTP header and the container env.

## Tested

- `go test ./...` — all pass; the `deploy/builder` module tests pass; `go build
  ./...` clean; `gofmt` / `go vet` clean.
- New tests: sidecar env-injection + validation + a no-leak-in-response regression
  (`TestMCP_EnvHeader_NoLeakInResponse`); GitHub App JWT signature + mint
  cache/refresh + substitute (`internal/credential/githubapp_test.go`).
- Proven end-to-end earlier: the `dev/sandbox` agent executes verified code in a
  throwaway container via the loomcycle MCP.

## Notes / follow-ups

- The builder-sidecar image must be rebuilt + published for the env-injection seam
  to take effect on a live deployment (it's a separate Go module → its own image).
- **Browser (PinchTab) support is a separate follow-up:** pinchtab's MCP is
  stdio-only, so it needs a cloud-only derived image + config overlay (not in this
  PR).
- Open egress + a token in env is an exfiltration surface under prompt injection;
  prefer short-lived gh-App tokens; an allowlisted-egress proxy is future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD
