### PR TITLE
fix(memory): stop the property marker demanding the request's wording

### DIFF
--- a/internal/memory/eval/extraction_fixtures.go
+++ b/internal/memory/eval/extraction_fixtures.go
@@ -217,9 +217,15 @@ func ExtractionFixture() ExtractionCorpus {
 					NoneOf: recordingTells,
 				},
 				{
-					Why:    "and what they EXPERIENCE from it; the symptom is the reason the request exists",
+					Why: "and what they EXPERIENCE from it; the symptom is the reason the request exists",
+					// The SYMPTOM word is required; the anatomical SITE deliberately is
+					// not. The transcript offers two faithful phrasings — it states
+					// "my legs ache" and asks for "less muscle pain" — so requiring the
+					// literal "muscle" tests whether the model parrots the request's
+					// wording rather than whether it captured the property. A live run
+					// rendered it "constant leg aches", which is the more faithful
+					// reading of the two, and was scored a MISS for it.
 					AnyOf:  []string{"ache", "pain", "sore"},
-					AllOf:  []string{"muscle"},
 					NoneOf: recordingTells,
 				},
 			},
@@ -287,9 +293,9 @@ func ExtractionFixture() ExtractionCorpus {
 					NoneOf: recordingTells,
 				},
 				{
-					Why:    "and the symptom it caused; noise must not cost the connection between them",
+					Why: "and the symptom it caused; noise must not cost the connection between them",
+					// Site not required — see the clean case above for why.
 					AnyOf:  []string{"ache", "pain", "sore"},
-					AllOf:  []string{"muscle"},
 					NoneOf: recordingTells,
 				},
 			},

--- a/internal/memory/eval/extraction_test.go
+++ b/internal/memory/eval/extraction_test.go
@@ -821,3 +821,52 @@ func TestCorpus_HasABuriedPropertyCase(t *testing.T) {
 		}
 	}
 }
+
+// TestProperty_SymptomMarkerAcceptsEitherFaithfulPhrasing is the regression for a
+// FALSE MISS a live run produced.
+//
+// The buried transcript states "my legs ache constantly" and asks for "less muscle
+// pain" — two faithful ways to name the same symptom. The model wrote "The user is
+// taking atorvastatin and experiences constant leg aches", which is the more
+// faithful reading of the statement, and the expectation scored it a miss because
+// it demanded the literal token "muscle".
+//
+// That is the marker encoding the author's expected PHRASING instead of the
+// property under test — the same class of error as scoring a recording of the
+// request as a capture, and it inflates a failure count on the one ability this
+// eval exists to measure. Both phrasings must pass; a fact with no symptom at all
+// must still fail.
+func TestProperty_SymptomMarkerAcceptsEitherFaithfulPhrasing(t *testing.T) {
+	for _, name := range []string{"request-implies-condition", "request-implies-condition-buried"} {
+		var cs ExtractionCase
+		for _, c := range ExtractionFixture().Cases {
+			if c.Name == name {
+				cs = c
+			}
+		}
+		if cs.Name == "" {
+			t.Fatalf("case %q missing from the corpus", name)
+		}
+
+		for _, phrasing := range []string{
+			"The user is taking atorvastatin and experiences constant leg aches.",
+			"Takes atorvastatin and has constant muscle pain in the legs.",
+			"On a statin; reports persistent soreness in the legs.",
+		} {
+			res := CaseResult{Wanted: len(cs.Want)}
+			scoreCase(&res, cs, []ExtractedFact{{Text: phrasing, Class: "fact"}})
+			if res.Captured != res.Wanted {
+				t.Errorf("%s: %q scored %d/%d — a faithful phrasing must not be a miss (%v)",
+					name, phrasing, res.Captured, res.Wanted, res.Misses)
+			}
+		}
+
+		// And the marker must still have teeth: the medication with NO symptom
+		// satisfies only the first expectation.
+		res := CaseResult{Wanted: len(cs.Want)}
+		scoreCase(&res, cs, []ExtractedFact{{Text: "Takes atorvastatin.", Class: "fact"}})
+		if res.Captured == res.Wanted {
+			t.Errorf("%s: a fact naming only the medication must not satisfy the symptom expectation", name)
+		}
+	}
+}


### PR DESCRIPTION
A live run scored a **correct** extraction as a miss, on the one ability this eval exists to measure.

## The false miss

The buried transcript states *"my legs ache constantly"* and asks for *"alternatives with less muscle pain"* — two faithful ways to name one symptom. `qwen3.6:latest` wrote:

```
[fact] The user is taking atorvastatin and experiences constant leg aches.
```

…which is the more faithful reading of the two, and it was marked `MISS` because the expectation demanded the literal token `muscle`. The site was in the marker only because the *clean* case's request phrasing happens to use it. The property under test is the **symptom**, not which word names the limb.

So the marker was encoding my expected *phrasing* rather than the property — the same class of error as counting a recording of the request as a capture, and it inflates the failure count on the ability that's supposed to be measured most carefully. It also produced a false `property 0.80`: the model had answered all five expectations correctly.

Both property cases now require a symptom word and no site. The marker keeps its teeth — a fact naming only the medication still fails the symptom expectation, asserted alongside the three accepted phrasings.

**Fail-before verified:** with the site requirement restored, the live phrasing scores 1/2 on both cases.

## The substantive result underneath this

With the false miss removed, `qwen3.6:latest` **passes the buried case**. From eleven turns of invoice-importer work it extracted the medication and symptom as one connected fact, refused the branch name, the queued CI job and the chatter, and additionally surfaced two genuine project facts I hadn't planted:

```
[fact]       The invoice importer project uses a CSV parser with an ambiguous European-format date column.
[preference] The user prefers the parser to reject ambiguous dates and fail loudly rather than guessing from the locale.
[fact]       The user is taking atorvastatin and experiences constant leg aches.
```

That is the request→property transformation performed correctly, in noise, by the tier the extractor runs at. **So the extractor's judgement is not the production failure** — which is what the eval was built to determine, and it now points the investigation somewhere else.

## What the run also showed

`credential-in-transcript` came back `REASONING TRACE ONLY, no answer` — the new diagnostic from #866 firing on its first real outing. It counts clean (nothing emitted, nothing forbidden, and production treats it as zero facts), but worth recording honestly: for an abstention case, a thinking-only reply is **indistinguishable** from a deliberate refusal. Both produce the same outcome; we cannot tell which happened.

## What was tested

`go test ./...` green, `gofmt` clean. New: `TestProperty_SymptomMarkerAcceptsEitherFaithfulPhrasing`.

Corpus-only change, so it moves the corpus digest — the baseline recorded before it will read `(new)` rather than as a regression, which is exactly what #866's corpus digest was added for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)