### PR TITLE
feat(sandbox): headless browser (PinchTab) for the dev sandbox — cloud deployment

### DIFF
--- a/cloud-deployment/INSTALL.md
+++ b/cloud-deployment/INSTALL.md
@@ -53,7 +53,7 @@ Then, on the host, create the runtime sub-directories + set ownership (`-t` give
 
 ```bash
 ssh -t "$HOST" "cd '$DEPLOY' && \
-  mkdir -p data config work pgdata ts-state searxng web retention-exports && \
+  mkdir -p data config work pgdata ts-state searxng web retention-exports pinchtab-data && \
   sudo chown -R 65532:65532 data work retention-exports"
 ```
 
@@ -158,6 +158,7 @@ SANDBOX_AUTH_TOKEN=REPLACE_ME                # openssl rand -hex 32 (shared with
 TS_AUTHKEY=tskey-auth-REPLACE_ME             # Phase 3 (reusable, tagged)
 CLOUDFLARE_TUNNEL_TOKEN=REPLACE_ME           # Phase 4
 SEARXNG_SECRET=REPLACE_ME                    # openssl rand -hex 32
+PINCHTAB_TOKEN=REPLACE_ME                    # openssl rand -hex 32 (dev/sandbox headless browser)
 # ── provider keys — at least one your tiers route to ──
 ANTHROPIC_API_KEY=
 OPENAI_API_KEY=
@@ -171,6 +172,13 @@ Notes:
   NOT mint a dedicated `substrate:admin` token for it — that disables the
   `LOOMCYCLE_AUTH_TOKEN` login (no-lockout gate).
 - The DSN host is **`postgres`** (the compose service) — don't change it.
+- **Headless browser (dev/sandbox):** the `pinchtab` sidecar gives the dev agent
+  `mcp__browser__*` tools. PinchTab's MCP is stdio-only, so loomcycle uses a derived
+  image (`loomcycle.Dockerfile`) that bakes in the pinchtab MCP client — `make up`
+  therefore BUILDS the loomcycle image (first run is slower; needs Docker Hub
+  access). The sidecar is internal-only (no published port), and PinchTab keeps
+  browsing **local-only** until you widen its domain allowlist (IDPI) — to test
+  external sites or your own deployment, follow the pinchtab security guide.
 
 ---
 

--- a/cloud-deployment/config/loomcycle.yaml
+++ b/cloud-deployment/config/loomcycle.yaml
@@ -10,3 +10,21 @@ search_providers:
   brave: {}
 
 search_priority: [searxng, brave]
+
+# ── Headless browser (PinchTab) for the dev/sandbox agent (cloud deployment only) ─
+# PinchTab's MCP is stdio-only, so loomcycle spawns the pinchtab client (baked into
+# the derived image, loomcycle.Dockerfile) as a stdio MCP bridge to the `pinchtab`
+# server sidecar. The child inherits PINCHTAB_TOKEN from loomcycle's env, so no
+# ${...} interpolation is needed here. This overlay layers OVER the embedded
+# `sandbox` preset (presets → CONFIG_DIR), adding the browser server and widening
+# the dev/sandbox tool ceiling to include mcp__browser__* (the list is restated in
+# full because a sequence override replaces, not appends).
+mcp_servers:
+  browser:
+    transport: stdio
+    command: /usr/local/bin/pinchtab
+    args: ["--server", "http://pinchtab:9867", "mcp"]
+
+agents:
+  dev/sandbox:
+    tools: [mcp__sandbox__*, mcp__browser__*, Interruption]

--- a/cloud-deployment/docker-compose.yaml
+++ b/cloud-deployment/docker-compose.yaml
@@ -118,7 +118,16 @@ services:
 
   # ── The loomcycle runtime — shares the tailscale netns (no own DNS name / ports) ──
   loomcycle:
-    image: denngubsky/loomcycle:1.38.0
+    # Derived image = official loomcycle + the PinchTab MCP client binary, so the
+    # runtime can spawn `pinchtab … mcp` (stdio) against the pinchtab sidecar. See
+    # loomcycle.Dockerfile. (loomcycle-migrate keeps the plain image — it needs no
+    # browser.)
+    build:
+      context: .
+      dockerfile: loomcycle.Dockerfile
+      args:
+        LOOMCYCLE_TAG: "1.38.0"
+        PINCHTAB_TAG: "0.15.0"
     restart: unless-stopped
     user: "65532:65532"
     network_mode: "service:tailscale"   # → reachable at http://tailscale:8787
@@ -140,6 +149,9 @@ services:
       GEMINI_API_KEY: ${GEMINI_API_KEY:-}
       DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY:-}
       BRAVE_API_KEY: ${BRAVE_API_KEY:-}
+      # Auth for the pinchtab MCP stdio bridge → the pinchtab sidecar. The stdio
+      # child inherits loomcycle's env, so no config interpolation is needed.
+      PINCHTAB_TOKEN: ${PINCHTAB_TOKEN:-}
     volumes:
       - ./data:/data
       - ./config:/config:ro
@@ -176,6 +188,30 @@ services:
       timeout: 5s
       retries: 12
       start_period: 15s
+
+  # ── Headless browser (PinchTab) — internal MCP browser for the dev/sandbox agent.
+  #    stdio-only MCP, so loomcycle spawns `pinchtab … mcp` (client baked into its
+  #    derived image) against THIS server; Chromium lives here, not in loomcycle.
+  #    Internal ONLY — no published port (pinchtab's control plane is not for public
+  #    exposure). Widen its browsing domain allowlist (IDPI) per your needs — see
+  #    INSTALL.md and the pinchtab security guide.
+  pinchtab:
+    image: pinchtab/pinchtab:0.15.0
+    restart: unless-stopped
+    networks: [loomnet]
+    environment:
+      PINCHTAB_TOKEN: ${PINCHTAB_TOKEN}   # SAME secret loomcycle presents on the MCP bridge
+    volumes:
+      - ./pinchtab-data:/data             # HOME/config + Chrome profile (rootfs is read-only)
+    shm_size: "2gb"                       # Chrome stability
+    read_only: true
+    tmpfs:
+      - /tmp:size=512m,noexec,nosuid,nodev
+      - /run:size=64m,noexec,nosuid,nodev
+    security_opt:
+      - no-new-privileges:true
+    cap_drop: [ALL]
+    mem_limit: 2g
 
   # ── Landing (Node) — serves cloud-web/, proxies public /v1 reads (inner links),
   #    and mints substrate:tenant tokens behind Cloudflare Access (admin token

--- a/cloud-deployment/loomcycle.Dockerfile
+++ b/cloud-deployment/loomcycle.Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1
+#
+# Derived loomcycle image for the cloud deployment: the official distroless
+# loomcycle + the PinchTab CLIENT binary.
+#
+# Why: PinchTab's MCP server is stdio-only (`pinchtab mcp` speaks JSON-RPC over
+# stdio), so loomcycle drives the browser by SPAWNING `pinchtab --server
+# http://pinchtab:9867 mcp` as a stdio MCP subprocess — which needs the pinchtab
+# binary present in loomcycle's own container. Chromium stays in the separate
+# `pinchtab` server sidecar; only this ~28 MB client binary (no browser) is added.
+ARG LOOMCYCLE_TAG=1.38.0
+ARG PINCHTAB_TAG=0.15.0
+
+FROM pinchtab/pinchtab:${PINCHTAB_TAG} AS pinchtab
+
+FROM denngubsky/loomcycle:${LOOMCYCLE_TAG}
+# Distroless base: no shell, but a plain COPY of an already-executable binary is
+# fine. /usr/local/bin is on the image PATH; the config references the full path.
+COPY --from=pinchtab /usr/local/bin/pinchtab /usr/local/bin/pinchtab


### PR DESCRIPTION
## Why

Give the `dev/sandbox` agent a headless browser for ad-hoc web-UI testing
(`mcp__browser__*`), using PinchTab (bundled Chromium, built for AI agents).

Follow-up to #867 (the authenticated-git dev sandbox); this is the browser piece
of RFC BQ.

## What (and why cloud-only)

PinchTab's MCP server is **stdio-only** (`pinchtab mcp` speaks JSON-RPC over
stdio) — there is no HTTP MCP endpoint. So loomcycle must **spawn `pinchtab …
mcp`** as a stdio subprocess, which means the pinchtab client binary has to live
in loomcycle's container. To keep the official image and the default `sandbox`
bundle clean (most deployments don't run pinchtab), this is confined to the
**cloud deployment**:

- **`cloud-deployment/loomcycle.Dockerfile`** — derived image = official loomcycle
  + the pinchtab client binary (`COPY --from=pinchtab/pinchtab:0.15.0`). Chromium
  stays in the separate `pinchtab` server sidecar; only a ~28 MB client (no
  browser) is added.
- **`docker-compose.yaml`** — the loomcycle runtime builds that derived image
  (migrate keeps the plain image); a new **internal** `pinchtab` sidecar
  (Chromium, `shm 2gb`, `read_only` + tmpfs + `cap_drop: ALL` +
  `no-new-privileges`, **no published port** — its control plane must not be
  public); loomcycle gets `PINCHTAB_TOKEN` (the stdio child inherits loomcycle's
  env, so no config interpolation is needed).
- **`config/loomcycle.yaml`** overlay — `mcp_servers.browser` (stdio →
  `pinchtab --server http://pinchtab:9867 mcp`) + widens the `dev/sandbox` tool
  ceiling to `mcp__browser__*`. The overlay deep-merges over the embedded `sandbox`
  preset (presets → CONFIG_DIR), keeping the agent's tier/skills/prompt (verified
  against `internal/config/layering.go` `mergeNodes`).
- **`INSTALL.md`** — the `PINCHTAB_TOKEN` secret, the `pinchtab-data` host dir, and
  build-on-`make up` + IDPI (domain-allowlist) notes.

## Tested

- `docker-compose.yaml` + the config overlay parse; the compose has the pinchtab
  service, loomcycle on `build:`, migrate on `image:`, and `PINCHTAB_TOKEN` wired.
- The overlay's `agents.dev/sandbox.tools` override deep-merges (adds
  `mcp__browser__*`, keeps tier/skills/prompt, other agents preserved) — confirmed
  from the layering merge code.
- No runtime Go changes (loomcycle already supports static stdio MCP servers);
  `go build ./...` unaffected.

## Notes / scope

- Runs a `build:` for the loomcycle image (first `make up` is slower; needs Docker
  Hub access to pull `pinchtab/pinchtab` + `denngubsky/loomcycle`).
- Scope: **reachable URLs** (public sites / the deployment / preview URLs). Driving
  a server bound *inside* the throwaway session container needs shared networking —
  a follow-up.
- PinchTab keeps browsing local-only until its domain allowlist (IDPI) is widened —
  an operator step, documented, not defaulted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD
