### PR TITLE
build: forward --show-facts and --effort through the eval target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,9 +118,15 @@ memory-eval-mock:
 # so a run is measured against a number rather than a memory; add MEMEVAL_UPDATE=1
 # to record the result as the new baseline.
 #
-#   make memory-eval-live MEMEVAL_MODEL=qwen3.6:30b
+# MEMEVAL_SHOW_FACTS=1 prints every case's emitted facts, including the ones that
+# passed — worth it on a first measurement, where a surprising result is often a
+# PASS you want to read rather than a failure. MEMEVAL_EFFORT overrides the
+# extractor's configured effort (on Ollama, effort=medium sets think:true, so a
+# model that spends its whole reply reasoning is worth retrying at low).
+#
+#   make memory-eval-live MEMEVAL_MODEL=qwen3.6:27b
 #   make memory-eval-live MEMEVAL_PROVIDER=anthropic MEMEVAL_MODEL=claude-haiku-4-5
-#   make memory-eval-live MEMEVAL_MODEL=qwen3.6:30b MEMEVAL_UPDATE=1
+#   make memory-eval-live MEMEVAL_MODEL=qwen3.6:27b MEMEVAL_SHOW_FACTS=1 MEMEVAL_UPDATE=1
 MEMEVAL_PROVIDER ?= ollama-local
 MEMEVAL_MODEL    ?=
 MEMEVAL_PRESETS  ?= base,memory
@@ -132,6 +138,8 @@ memory-eval-live:
 	LOOMCYCLE_PRESETS=$(MEMEVAL_PRESETS) go run ./cmd/loomcycle memory-eval-live \
 	  --provider $(MEMEVAL_PROVIDER) --model $(MEMEVAL_MODEL) \
 	  --baseline $(MEMEVAL_BASELINE) \
+	  $(if $(MEMEVAL_EFFORT),--effort $(MEMEVAL_EFFORT),) \
+	  $(if $(MEMEVAL_SHOW_FACTS),--show-facts,) \
 	  $(if $(MEMEVAL_UPDATE),--update-baseline $(MEMEVAL_BASELINE),)
 
 # runtime-mock: the fast, deterministic runtime suites (live binary, mock


### PR DESCRIPTION
Two flags the CLI has that `make memory-eval-live` could not reach, and both are what a first measurement needs.

- **`MEMEVAL_SHOW_FACTS=1`** → `--show-facts`. The default report is problem-only. On the most informative run so far the surprising result was a *pass* (property 2/2 on the ability that fails in production), and the emitted facts couldn't be read without bypassing the target entirely.
- **`MEMEVAL_EFFORT=low`** → `--effort`. On Ollama `effort=medium` sets `think:true`, so a model can spend its whole reply on a reasoning trace and never answer. The harness now diagnoses that and suggests `--effort low` — and the target couldn't act on its own advice.

```bash
make memory-eval-live MEMEVAL_MODEL=qwen3.6:27b MEMEVAL_SHOW_FACTS=1 MEMEVAL_UPDATE=1
```

Makefile only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)