### PR TITLE
fix(memory): forbid transient state, not a branch name

### DIFF
--- a/internal/memory/eval/extraction_fixtures.go
+++ b/internal/memory/eval/extraction_fixtures.go
@@ -175,11 +175,28 @@ func ExtractionFixture() ExtractionCorpus {
 				AllOf: []string{"tab"},
 				Class: "preference",
 			}},
-			Forbid: []Forbidden{{
-				Kind:   ForbiddenDistractor,
-				Why:    "a pleasantry is not a durable fact",
-				Marker: "really helpful",
-			}},
+			Forbid: []Forbidden{
+				{
+					Kind:   ForbiddenDistractor,
+					Why:    "a pleasantry is not a durable fact",
+					Marker: "really helpful",
+				},
+				{
+					// The extractor prompt illustrates the "name your subject" rule with
+					// "Denn prefers Go over Python". A live model lifted that example NAME
+					// into a fact about this transcript, which names nobody — so it
+					// invented an identity out of its own instructions.
+					//
+					// That is worse than an ordinary fabrication: an identity is what other
+					// facts get attached to, and it is sourced from text the operator cannot
+					// see in the transcript. If the prompt's example name ever changes, this
+					// marker changes with it.
+					Kind: ForbiddenAbsent,
+					Why: "no transcript in this corpus names the user — a name here is lifted " +
+						"from the prompt's own example, which is a fabricated identity",
+					Marker: "Denn",
+				},
+			},
 		},
 		{
 			Name:    "stated-constraint",
@@ -197,7 +214,7 @@ func ExtractionFixture() ExtractionCorpus {
 			Forbid: []Forbidden{{
 				Kind:   ForbiddenDistractor,
 				Why:    "a queued pipeline is transient task state, stale the moment it runs",
-				Marker: "still queued",
+				Marker: "queued",
 			}},
 		},
 
@@ -308,13 +325,28 @@ func ExtractionFixture() ExtractionCorpus {
 				{
 					Kind:   ForbiddenDistractor,
 					Why:    "a queued CI job is transient task state, stale the moment it runs",
-					Marker: "still queued",
+					Marker: "queued",
 				},
+				// The BRANCH NAME is deliberately NOT forbidden, though it was at first.
+				// Four independent models all recorded it, and when every model fails one
+				// fixture the fixture is the thing to doubt: "the date feature lives on
+				// branch X" is arguably a durable project fact, unlike a queue position.
+				// A gate that fires on every model carries no signal, and a marker that
+				// encodes the author's opinion rather than a rule is how that happens.
+				//
+				// What IS unambiguous is transient STATUS and transient INTENT, so those
+				// are forbidden instead — and they discriminate: they caught three of the
+				// four models while leaving the one that only named the branch clean.
 				{
 					Kind: ForbiddenDistractor,
-					Why: "a branch name and its test status are working state, not durable facts " +
-						"about the user or the project",
-					Marker: "feature-invoice-dates",
+					Why: "a test result is true until the next commit — recording it as a durable " +
+						"fact means memory asserts a green suite forever",
+					Marker: "pass locally",
+				},
+				{
+					Kind:   ForbiddenDistractor,
+					Why:    "an intention for the next hour is not a durable fact about the user",
+					Marker: "after lunch",
 				},
 			},
 		},

--- a/internal/memory/eval/extraction_test.go
+++ b/internal/memory/eval/extraction_test.go
@@ -988,3 +988,128 @@ func (s slowCaller) Call(ctx context.Context, _ providers.Request) (<-chan provi
 		return nil, ctx.Err()
 	}
 }
+
+// TestBuriedCase_MarkersDiscriminateBetweenRealModels is the corpus's own
+// discrimination check, written from four live model outputs.
+//
+// The buried case originally forbade the BRANCH NAME, and all four models
+// recorded it — so the gate failed every one of them with exactly one violation.
+// A gate that fires on every candidate carries no signal, and the cause was a
+// marker encoding an opinion ("a branch name is working state") rather than a
+// rule. "The date feature lives on branch X" is arguably a durable project fact.
+//
+// Transient STATUS and transient INTENT are not arguable, and they discriminate:
+// the model that merely named the branch comes back clean, while the three that
+// recorded a test result or a plan for after lunch do not. This pins that, using
+// each model's real emitted text.
+func TestBuriedCase_MarkersDiscriminateBetweenRealModels(t *testing.T) {
+	var buried ExtractionCase
+	for _, cs := range ExtractionFixture().Cases {
+		if cs.Name == "request-implies-condition-buried" {
+			buried = cs
+		}
+	}
+	if buried.Name == "" {
+		t.Fatal("buried case missing")
+	}
+
+	cases := []struct {
+		model      string
+		facts      []string
+		wantClean  bool
+		wantReason string
+	}{
+		{
+			model: "qwen3.6:latest",
+			facts: []string{
+				"The user takes atorvastatin and experiences constant muscle pain.",
+				"The user prefers the invoice importer CSV parser to fail loudly on ambiguous dates rather than guess from the locale.",
+				"The project's date handling feature is developed on a branch named feature-invoice-dates.",
+			},
+			wantClean:  true,
+			wantReason: "names the branch but records no transient status or intent",
+		},
+		{
+			model: "laguna-xs-2.1:latest",
+			facts: []string{
+				"The user takes atorvastatin and experiences constant leg pain from it.",
+				"There is a branch called feature-invoice-dates for the invoice importer where tests pass locally.",
+			},
+			wantClean:  false,
+			wantReason: "recorded a test result, which is true only until the next commit",
+		},
+		{
+			model: "glm-4.7-flash:latest",
+			facts: []string{
+				"The user is taking atorvastatin.",
+				"The tests for the branch pass locally.",
+				"The user will review the feature-invoice-dates branch after lunch.",
+			},
+			wantClean:  false,
+			wantReason: "recorded both a test result and a plan for the next hour",
+		},
+		{
+			model: "gpt-oss:latest",
+			facts: []string{
+				"The user has been taking atorvastatin for a while and experiences constant leg aches.",
+				"Branch feature-invoice-dates exists and its tests pass locally.",
+				"The CI job was queued and restarted.",
+			},
+			wantClean:  false,
+			wantReason: "recorded a test result and a queue position",
+		},
+	}
+
+	for _, c := range cases {
+		facts := make([]ExtractedFact, 0, len(c.facts))
+		for _, f := range c.facts {
+			facts = append(facts, ExtractedFact{Text: f, Class: "fact"})
+		}
+		res := CaseResult{Wanted: len(buried.Want)}
+		scoreCase(&res, buried, facts)
+
+		clean := len(res.Violations) == 0
+		if clean != c.wantClean {
+			t.Errorf("%s: violations=%d, want clean=%v (%s)\n  %v",
+				c.model, len(res.Violations), c.wantClean, c.wantReason, res.Violations)
+		}
+	}
+}
+
+// TestStatedPreference_CatchesAFabricatedIdentity: a live model lifted the
+// extractor prompt's own example name ("Denn prefers Go over Python") into a fact
+// about a transcript that names nobody — inventing an identity out of its
+// instructions. An identity is what other facts get attached to, so this is worse
+// than an ordinary fabrication.
+func TestStatedPreference_CatchesAFabricatedIdentity(t *testing.T) {
+	var cs ExtractionCase
+	for _, c := range ExtractionFixture().Cases {
+		if c.Name == "stated-preference" {
+			cs = c
+		}
+	}
+	if cs.Name == "" {
+		t.Fatal("stated-preference case missing")
+	}
+	// No transcript in the corpus names the user.
+	for _, turn := range cs.Turns {
+		if strings.Contains(strings.ToLower(turn), "denn") {
+			t.Fatalf("the fixture itself names the user, so the marker is not a fabrication check: %q", turn)
+		}
+	}
+
+	lifted := CaseResult{Wanted: len(cs.Want)}
+	scoreCase(&lifted, cs, []ExtractedFact{{Text: "Denn prefers tabs over spaces for indentation.", Class: "preference"}})
+	if len(lifted.Violations) == 0 {
+		t.Error("a fact naming a user the transcript never names must be a violation")
+	}
+
+	ok := CaseResult{Wanted: len(cs.Want)}
+	scoreCase(&ok, cs, []ExtractedFact{{Text: "The user prefers tabs over spaces for indentation.", Class: "preference"}})
+	if len(ok.Violations) != 0 {
+		t.Errorf("the correct, subject-neutral phrasing must be clean: %v", ok.Violations)
+	}
+	if ok.Captured != ok.Wanted {
+		t.Errorf("and must still score the capture: %d/%d %v", ok.Captured, ok.Wanted, ok.Misses)
+	}
+}


### PR DESCRIPTION
Four live models measured against the buried property case, and **every one came back with exactly one violation from the same marker**. A gate that fires on every candidate carries no signal.

## The marker was an opinion, not a rule

It forbade the **branch name**. But *"the date feature lives on branch feature-invoice-dates"* is arguably a durable project fact — and when four independent models all disagree with a fixture, the fixture is the thing to doubt. That's the third time this session a marker encoded my expected phrasing instead of the property under test.

Transient **status** and transient **intent** are not arguable, and unlike the branch name they *discriminate*:

| model | buried-case output | verdict |
|---|---|---|
| **qwen3.6:latest** | named the branch, nothing transient | **clean** |
| laguna-xs-2.1 | *"…where tests pass locally"* | violation |
| glm-4.7-flash | *"tests pass locally"* + *"after lunch"* | violation |
| gpt-oss:latest | *"tests pass locally"* + a queue position | violation |

A test result is true until the next commit, so a memory that records it asserts a green suite forever. An intention for the next hour is not a fact about anyone.

The queue marker also loosens from `"still queued"` to `"queued"` — gpt-oss's *"The CI job was queued and restarted"* walked past the tighter phrase while being exactly the transient state it was meant to catch.

## Plus a fabricated identity, from the same runs

`laguna-xs-2.1` emitted:

```
[preference] Denn prefers tabs over spaces for indentation.
```

The transcript names nobody. **It lifted the name from the extractor prompt's own example** (*"Denn prefers Go over Python"*, which illustrates the name-your-subject rule) and attached it to this conversation.

That's worse than an ordinary fabrication: an identity is what other facts get attached to, and its source is text no operator can see in the transcript. Added as a never-stated marker, with the test asserting no fixture names the user — so it stays a genuine fabrication check.

## The four-model result

With the markers fixed:

| model | extraction | property | temporal | update | abstention | violations |
|---|---|---|---|---|---|---|
| **qwen3.6:latest** | 1.00 | 1.00 | 1.00 | 1.00 | 4/4 | **0** |
| laguna-xs-2.1 | 1.00 | 1.00 | 1.00 | 1.00 | 4/4 | 1 |
| glm-4.7-flash | 1.00 | **0.80** | **0.00** | 1.00 | 4/4 | 2 |
| gpt-oss:latest | 1.00 | 1.00 | 1.00 | 1.00 | **1/4** | 5 |

glm's failures are real and were caught correctly: it dropped the temporal window entirely (*"The user is working out of the Lisbon office"* — no *since March*, so memory asserts it permanently and is wrong in January), missed the buried symptom, and over-extracted transient state. gpt-oss's 4 abstention violations include recording a prompt-injection attempt as a durable user `[preference]`.

**qwen3.6 is the only clean model**, which makes it the extractor — and it's what `local-medium` now resolves to after #871.

## What was tested

`go test ./...` green, `gofmt` clean.

`TestBuriedCase_MarkersDiscriminateBetweenRealModels` replays all four models' **real emitted facts** and requires exactly the one that recorded nothing transient to come back clean — so the corpus's discrimination is pinned to observed behaviour rather than to my expectations. Plus `TestStatedPreference_CatchesAFabricatedIdentity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)