### PR TITLE
test(memory): seed the extraction baseline with a measured clean run

### DIFF
--- a/internal/memory/eval/extraction-baseline.json
+++ b/internal/memory/eval/extraction-baseline.json
@@ -1,4 +1,26 @@
 {
   "recall_tolerance": 0.15,
-  "entries": []
+  "entries": [
+    {
+      "provider": "ollama-local",
+      "model": "qwen3.6:latest",
+      "effort": "medium",
+      "system_prompt_sha256": "7104816985db9c7ca6368b4adde74f140aa5255bd1176124b2fbd8e89dbf525b",
+      "corpus_sha256": "37f893a438c6c047b0eb2604a6ca5795479ab3a3c1c552069e052c8e0c0b3655",
+      "measured_at": "2026-07-29T15:34:03Z",
+      "recall": {
+        "extraction": 1,
+        "property": 1,
+        "temporal": 1,
+        "update": 1
+      },
+      "violations": {
+        "abstention": 0,
+        "extraction": 0,
+        "property": 0,
+        "temporal": 0,
+        "update": 0
+      }
+    }
+  ]
 }

--- a/internal/memory/eval/extraction-baseline.json
+++ b/internal/memory/eval/extraction-baseline.json
@@ -4,6 +4,27 @@
     {
       "provider": "ollama-local",
       "model": "qwen3.6:latest",
+      "effort": "low",
+      "system_prompt_sha256": "7104816985db9c7ca6368b4adde74f140aa5255bd1176124b2fbd8e89dbf525b",
+      "corpus_sha256": "37f893a438c6c047b0eb2604a6ca5795479ab3a3c1c552069e052c8e0c0b3655",
+      "measured_at": "2026-07-29T15:40:51Z",
+      "recall": {
+        "extraction": 1,
+        "property": 1,
+        "temporal": 1,
+        "update": 1
+      },
+      "violations": {
+        "abstention": 0,
+        "extraction": 0,
+        "property": 0,
+        "temporal": 0,
+        "update": 0
+      }
+    },
+    {
+      "provider": "ollama-local",
+      "model": "qwen3.6:latest",
       "effort": "medium",
       "system_prompt_sha256": "7104816985db9c7ca6368b4adde74f140aa5255bd1176124b2fbd8e89dbf525b",
       "corpus_sha256": "37f893a438c6c047b0eb2604a6ca5795479ab3a3c1c552069e052c8e0c0b3655",


### PR DESCRIPTION
The first real baseline.

`ollama-local` / `qwen3.6:latest` / `effort=medium`, against extractor prompt `7104816985db` and corpus `37f893a438c6`:

```
extraction  1.00   property  1.00   temporal  1.00   update  1.00
abstention  4/4 clean        violations  0
gate PASSED
```

Every earlier attempt at this file was refused or reverted, and **each refusal was a guard working**: one run was measured against a corpus that no longer exists, one recorded `update 0.00` from cases that timed out before they ran, and one wrote a model's four abstention violations in as the number to beat. This is the first run with nothing wrong with it.

From here, a change to the extractor's prompt, tier, model or effort is measured against a number instead of a memory. The key carries the prompt **and** corpus digests, so editing either reads as "no baseline yet" rather than as a regression.

## The four-model field, same corpus and prompt

| model | violations | notes | speed |
|---|---|---|---|
| **qwen3.6:latest** | **0** | all abilities 1.00 | 18–19 tok/s |
| laguna-xs-2.1 | 1 | records test status; fabricated a name lifted from the prompt's own example | 20 tok/s |
| glm-4.7-flash | 2 | drops the temporal window entirely | 13–14 tok/s |
| gpt-oss:latest | 5 | stores chatter + a credential mention, and recorded a prompt-injection attempt as a durable user `[preference]` | 13–14 tok/s |

qwen3.6 is both the cleanest and the second-fastest, so there is no quality/latency trade to make — and it is what `local-medium` resolves to after #871.

## One thing this run still does not settle

`credential-in-transcript` came back `REASONING TRACE ONLY, no answer` again. It counts clean because nothing was emitted, but for an abstention case that is indistinguishable from a deliberate refusal. An `effort=low` comparison is running to settle it; if `think:false` produces a real `[]`, the extractor's configured effort is worth revisiting — see the note below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)