### PR TITLE
feat(memory): tenant scope for Memory, SQL Memory and Documents (RFC BL P4b)

### DIFF
--- a/internal/api/mcp/context.go
+++ b/internal/api/mcp/context.go
@@ -112,9 +112,34 @@ func grantOperatorPolicies(ctx context.Context, agentName string, isAdmin bool) 
 	// actual run, and this plane has no run id. An operator writing a fact by hand
 	// is not a machine distilling one from a transcript, and the column has to stay
 	// a trustworthy filter for the latter. See builtin.provenanceForSet.
+	//
+	// `tenant` (RFC BL P4b) is granted here for BOTH admin and tenant principals.
+	// This plane IS the operator — a substrate:tenant token is the tenant operator,
+	// with full power inside its own tenant — and curating tenant-shared reference
+	// material is exactly what it is for. Confinement is the TenantID stamped from
+	// the principal, so a tenant token reaches only ITS tenant's tenant scope; the
+	// scope list is not what keeps tenants apart.
+	//
+	// It is deliberately WIDER than an ordinary agent's grant, because the trust is
+	// different in kind: an agent gets `tenant` only when an operator lists it in
+	// yaml, whereas this session is the operator, authenticated as themselves.
 	ctx = tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{
-		AllowedScopes: []string{"agent", "user", "global"},
+		AllowedScopes: []string{"agent", "user", "tenant", "global"},
 		Consolidation: true,
+	})
+	// SQL Memory: never stamped before, which meant EVERY sql_* op over MCP failed
+	// default-deny with "this agent has no sql_scopes configured" — at any scope,
+	// since v1.2.0. Verified against a live deployment rather than inferred.
+	//
+	// Documents hid the gap: the Document tool talks to sqlmem directly instead of
+	// through the Memory tool's policy check, so document ops over MCP worked while
+	// the SQL ops beside them did not.
+	//
+	// `run` is omitted on purpose: an MCP-direct call has no run, so granting it
+	// would trade a clear "not configured" refusal for a confusing "requires an
+	// active run" one.
+	ctx = tools.WithSqlMemPolicy(ctx, tools.SqlMemPolicyValue{
+		AllowedScopes: []string{"agent", "user", "tenant"},
 	})
 	// Channel: open ACL ("*" matches every channel name).
 	ctx = tools.WithChannelPolicy(ctx, tools.ChannelPolicyValue{

--- a/internal/api/mcp/context_test.go
+++ b/internal/api/mcp/context_test.go
@@ -238,3 +238,76 @@ func TestOperatorCtx_PreservesParentValues(t *testing.T) {
 		t.Errorf("operatorCtx dropped parent ctx value; got %q want %q", got, "parent-marker")
 	}
 }
+
+// TestMCPPolicies_TenantTokenMayWriteMemorySqlAndDocuments pins the capability an
+// operator asked for by name: an MCP session on a substrate:tenant token can write
+// to Memory, SQL Memory and Documents at TENANT scope.
+//
+// Both halves of this were broken, and one had been broken since v1.2.0:
+//
+//   - MemoryPolicy granted [agent, user, global] — no `tenant`, so the tenant
+//     keyspace was unreachable.
+//   - SqlMemPolicy was NEVER stamped, so every sql_* op over MCP failed
+//     default-deny with "this agent has no sql_scopes configured", at ANY scope.
+//     Verified against a live deployment, not inferred. Documents hid it, because
+//     the Document tool talks to sqlmem directly rather than through the Memory
+//     tool's policy check.
+//
+// A tenant-scoped Document needs BOTH grants (structure in SQL Memory, bodies in
+// k/v Memory), so this asserts them together.
+func TestMCPPolicies_TenantTokenMayWriteMemorySqlAndDocuments(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		scopes []string
+	}{
+		{"tenant token", []string{auth.ScopeTenant}},
+		{"admin token", []string{auth.ScopeAdmin}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := auth.Principal{TenantID: "acme", Subject: "alice", Scopes: tc.scopes}
+			ctx := mcpPrincipalCtx(auth.WithPrincipal(context.Background(), p))
+
+			mem := tools.MemoryPolicy(ctx).AllowedScopes
+			if !containsStr(mem, "tenant") {
+				t.Errorf("memory_scopes = %v, missing `tenant` — the tenant keyspace is unreachable", mem)
+			}
+			sql := tools.SqlMemPolicy(ctx).AllowedScopes
+			if len(sql) == 0 {
+				t.Fatalf("sql_scopes is EMPTY — every sql_* op over MCP fails default-deny")
+			}
+			if !containsStr(sql, "tenant") {
+				t.Errorf("sql_scopes = %v, missing `tenant` — a tenant Document's structure cannot be written", sql)
+			}
+			for _, want := range []string{"agent", "user"} {
+				if !containsStr(sql, want) {
+					t.Errorf("sql_scopes = %v, missing %q", sql, want)
+				}
+			}
+
+			// Confinement is the TENANT STAMP, not the scope list — a tenant token
+			// reaches only its own tenant's tenant scope.
+			if got := tools.RunIdentity(ctx).TenantID; got != "acme" {
+				t.Errorf("TenantID = %q, want the principal's tenant; without it the scope list would not confine anything", got)
+			}
+		})
+	}
+}
+
+// TestMCPPolicies_SqlScopesOmitsRun: an MCP-direct call has no run, so granting
+// `run` would trade a clear "not configured" refusal for a confusing "requires an
+// active run" one.
+func TestMCPPolicies_SqlScopesOmitsRun(t *testing.T) {
+	ctx := operatorCtx(context.Background())
+	if containsStr(tools.SqlMemPolicy(ctx).AllowedScopes, "run") {
+		t.Error("sql_scopes should not include `run` on a plane that has no run")
+	}
+}
+
+func containsStr(hay []string, needle string) bool {
+	for _, h := range hay {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/mcp/tools.go
+++ b/internal/api/mcp/tools.go
@@ -281,7 +281,7 @@ func toolDescriptors() []loommcp.ToolDescriptor {
 		},
 		{
 			Name:        "document",
-			Description: "Document tool ops (create_document/get_document/delete_document, create_chunk/get_chunk/update_chunk/delete_chunk/move_chunk, link_chunks/unlink_chunks, query_chunks, define_type/list_types). RFC AK chunked-graph documents — each chunk is a first-class unit (UUID, hierarchy, type, fields, edges, Markdown body). Requires SQL Memory. Scope agent/user (tenant deferred); tenant-isolated. Pass-through.",
+			Description: "Document tool ops (create_document/get_document/delete_document, create_chunk/get_chunk/update_chunk/delete_chunk/move_chunk, link_chunks/unlink_chunks, query_chunks, define_type/list_types). RFC AK chunked-graph documents — each chunk is a first-class unit (UUID, hierarchy, type, fields, edges, Markdown body). Requires SQL Memory. Scope agent/user/tenant (tenant = shared across the whole tenant); tenant-isolated. Pass-through.",
 			InputSchema: builtinSchema("document"),
 		},
 		{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5185,20 +5185,28 @@ var validEffortLevels = map[string]bool{
 }
 
 // validMemoryScopes is the closed set of Memory tool scope names
-// accepted in agent yaml. v0.8.0 ships agent + user; future versions
-// may add session / tenant.
+// accepted in agent yaml.
+//
+// `tenant` is SHARED-WRITE across every user and agent in the tenant, so an
+// agent granted it can store state that every other agent and user then reads
+// as ground truth. That is the poisoning surface the memory design flags, and
+// the grant IS the gate — there is deliberately no second mechanism, because two
+// places to get this wrong is worse than one. Grant it to curator-shaped agents,
+// not to anything that ingests untrusted text.
 var validMemoryScopes = map[string]bool{
-	"agent": true,
-	"user":  true,
+	"agent":  true,
+	"user":   true,
+	"tenant": true,
 }
 
 // validSqlScopes is the closed set of RFC AA SQL Memory scope names
 // accepted in agent yaml. Unlike Memory's k/v scopes it also includes
 // `run` — an ephemeral per-run database dropped at run completion.
 var validSqlScopes = map[string]bool{
-	"agent": true,
-	"user":  true,
-	"run":   true,
+	"agent":  true,
+	"user":   true,
+	"run":    true,
+	"tenant": true, // shared-write across the tenant — see validMemoryScopes
 }
 
 // validChannelScopes is the closed set of Channel tool scope names

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -364,6 +364,10 @@ agents:
 // — silent drop would let a typoed `memmory_scopes: [agnet]` produce
 // an agent that calls Memory.set with no policy applied at runtime.
 func TestMemoryScopesValidation(t *testing.T) {
+	// `tenant` used to be the rejected example here; it is a real scope now, so the
+	// rejection is asserted against a scope that genuinely does not exist. A
+	// validation test whose invalid input later becomes valid stops testing
+	// anything, and silently.
 	tmp := t.TempDir()
 	yamlPath := filepath.Join(tmp, "c.yaml")
 	os.WriteFile(yamlPath, []byte(`
@@ -371,14 +375,40 @@ defaults: { provider: anthropic, model: claude-sonnet-4-6 }
 agents:
   bad:
     model: claude-sonnet-4-6
-    memory_scopes: [agent, tenant]
+    memory_scopes: [agent, session]
 `), 0o600)
 	_, err := Load(yamlPath)
 	if err == nil {
 		t.Fatal("expected error for unknown memory scope")
 	}
-	if !strings.Contains(err.Error(), "tenant") {
+	if !strings.Contains(err.Error(), "session") {
 		t.Errorf("error should name the offending scope: %v", err)
+	}
+}
+
+// TestMemoryScopesTenantAccepted: `tenant` is a granted, shared-write scope as of
+// RFC BL P4b. The grant IS the gate, so an operator must be able to declare it.
+func TestMemoryScopesTenantAccepted(t *testing.T) {
+	tmp := t.TempDir()
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  curator:
+    model: claude-sonnet-4-6
+    memory_scopes: [agent, user, tenant]
+    sql_scopes: [tenant]
+`), 0o600)
+	cfg, err := Load(yamlPath)
+	if err != nil {
+		t.Fatalf("tenant must be a valid grant: %v", err)
+	}
+	a := cfg.Agents["curator"]
+	if len(a.MemoryScopes) != 3 || a.MemoryScopes[2] != "tenant" {
+		t.Errorf("memory_scopes = %v, want the tenant grant preserved", a.MemoryScopes)
+	}
+	if len(a.SqlScopes) != 1 || a.SqlScopes[0] != "tenant" {
+		t.Errorf("sql_scopes = %v, want [tenant]", a.SqlScopes)
 	}
 }
 

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -160,7 +160,7 @@ type Connector interface {
 
 	// Document — RFC AK chunked-graph documents. Op-discriminated (13 ops:
 	// document/chunk lifecycle, edges, query_chunks, type defs). Scope-aware
-	// (agent / user; tenant deferred) and tenant-isolated via the SQL Memory
+	// (agent / user / tenant) and tenant-isolated via the SQL Memory
 	// scope key; gated by the agent's tools. Requires SQL Memory.
 	// Reachable via POST /v1/_document, the gRPC Document RPC, the LoomCycle
 	// MCP meta-tool `document`, and the TS/Python adapters' client.document()

--- a/internal/sqlmem/sqlmem.go
+++ b/internal/sqlmem/sqlmem.go
@@ -156,8 +156,20 @@ type Manager struct {
 // name-hashed defensively by each backend before they touch the filesystem
 // (sqlite) or become a postgres identifier (postgres).
 type ScopeKey struct {
-	Tenant  string
-	Scope   string // "agent" | "user" | "run"
+	Tenant string
+	// Scope is "agent" | "user" | "tenant" | "run".
+	//
+	// Nothing in this package validates the value — pgScopeNames hashes the
+	// triple, the sqlite backend joins root/<tenant>/<scope>/<id>.db, and
+	// scope_registry records it verbatim — so a new scope needs no plumbing here.
+	// The list is documentation, not enforcement; the closed set that matters is
+	// the per-agent grant in config (validMemoryScopes / validSqlScopes).
+	Scope string
+	// ScopeID must be NON-EMPTY for every durable scope, including `tenant`, where
+	// it repeats the tenant. pgScopeNames rejects an empty component because the
+	// value becomes half of a schema + LOGIN role name. Note the k/v Memory plane
+	// uses an EMPTY scope_id for its tenant scope for the opposite reason — its
+	// tenant_id column already carries the identity.
 	ScopeID string
 }
 

--- a/internal/sqlmem/tenant_scope_test.go
+++ b/internal/sqlmem/tenant_scope_test.go
@@ -1,0 +1,180 @@
+package sqlmem
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestTenantScope_ProvisionsThroughTheExistingPath is the load-bearing claim of
+// RFC BL P4b's sqlmem half: the package is GENERIC over the scope string, so a
+// tenant scope needs no new plumbing.
+//
+// If that is wrong, it is wrong at provisioning time — a schema/role naming or
+// path-fence rejection — not at review time, which is why it is asserted rather
+// than assumed.
+func TestTenantScope_ProvisionsThroughTheExistingPath(t *testing.T) {
+	m := newTestManager(t, Config{Root: t.TempDir()})
+	ctx := context.Background()
+
+	// ScopeID repeats the tenant: pgScopeNames rejects an empty component because
+	// the value becomes half of a schema + LOGIN role name.
+	key := ScopeKey{Tenant: "acme", Scope: "tenant", ScopeID: "acme"}
+
+	if _, err := m.Exec(ctx, key, `CREATE TABLE IF NOT EXISTS house (k TEXT PRIMARY KEY, v TEXT)`, nil, 0); err != nil {
+		t.Fatalf("tenant scope must provision through the existing path: %v", err)
+	}
+	if _, err := m.Exec(ctx, key, `INSERT INTO house (k, v) VALUES ('style', 'tabs')`, nil, 0); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	got, err := m.Query(ctx, key, `SELECT v FROM house WHERE k = 'style'`, nil)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(got.Rows) != 1 || got.Rows[0][0] != "tabs" {
+		t.Fatalf("round trip failed: %+v", got.Rows)
+	}
+}
+
+// TestTenantScope_IsolatedFromUserAndOtherTenants pins the two isolation axes that
+// make the scope safe to grant. `{t, tenant, t}` must not alias `{t, user, t}` —
+// they differ only in the scope segment of the hashed name, which is exactly the
+// kind of thing a naming refactor breaks silently.
+func TestTenantScope_IsolatedFromUserAndOtherTenants(t *testing.T) {
+	m := newTestManager(t, Config{Root: t.TempDir()})
+	ctx := context.Background()
+
+	tenantKey := ScopeKey{Tenant: "acme", Scope: "tenant", ScopeID: "acme"}
+	// Same tenant AND same scope id, differing only in the scope segment.
+	userKey := ScopeKey{Tenant: "acme", Scope: "user", ScopeID: "acme"}
+	otherTenant := ScopeKey{Tenant: "globex", Scope: "tenant", ScopeID: "globex"}
+
+	for _, k := range []ScopeKey{tenantKey, userKey, otherTenant} {
+		if _, err := m.Exec(ctx, k, `CREATE TABLE IF NOT EXISTS t (v TEXT)`, nil, 0); err != nil {
+			t.Fatalf("create in %+v: %v", k, err)
+		}
+	}
+	if _, err := m.Exec(ctx, tenantKey, `INSERT INTO t (v) VALUES ('tenant-row')`, nil, 0); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	for _, k := range []ScopeKey{userKey, otherTenant} {
+		got, err := m.Query(ctx, k, `SELECT v FROM t`, nil)
+		if err != nil {
+			t.Fatalf("query %+v: %v", k, err)
+		}
+		if len(got.Rows) != 0 {
+			t.Errorf("LEAK: %+v sees the tenant scope's rows: %+v", k, got.Rows)
+		}
+	}
+}
+
+// TestTenantScope_EmptyScopeIDRefused: an empty component would collapse the
+// derived schema/role name, so it must fail loudly rather than provision something
+// degenerate. This is the guard that makes "ScopeID repeats the tenant" a rule
+// instead of a convention.
+func TestTenantScope_EmptyScopeIDRefused(t *testing.T) {
+	if _, _, err := pgScopeNames(ScopeKey{Tenant: "acme", Scope: "tenant", ScopeID: ""}); err == nil {
+		t.Fatal("an empty ScopeID must be refused for a durable scope")
+	} else if !strings.Contains(err.Error(), "empty scope key component") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestTenantScope_NameDiffersFromUserScope: belt-and-braces on the hash, asserted
+// directly so a change to the canonical form is caught here rather than as a
+// cross-scope data leak.
+func TestTenantScope_NameDiffersFromUserScope(t *testing.T) {
+	tSchema, tRole, err := pgScopeNames(ScopeKey{Tenant: "acme", Scope: "tenant", ScopeID: "acme"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	uSchema, uRole, err := pgScopeNames(ScopeKey{Tenant: "acme", Scope: "user", ScopeID: "acme"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tSchema == uSchema || tRole == uRole {
+		t.Errorf("tenant and user scopes with the same id derive the same identifiers (%s / %s) — they would share a database", tSchema, uSchema)
+	}
+}
+
+// TestTenantScope_PostgresProvisionsSchemaAndRole is the verification the P4b plan
+// asked for by name: the tenant scope creates a DATABASE ROLE, and getting that
+// wrong fails at provisioning time with a permission error rather than at review
+// time. The sqlite tier cannot show this — it provisions a file.
+//
+// Skipped without LOOMCYCLE_TEST_SQLMEM_PG_DSN; CI runs it in the go-postgres job.
+func TestTenantScope_PostgresProvisionsSchemaAndRole(t *testing.T) {
+	m, raw := pgTestManager(t, Config{})
+	ctx := context.Background()
+	key := ScopeKey{Tenant: "acme", Scope: "tenant", ScopeID: "acme"}
+
+	if _, err := m.Exec(ctx, key, `CREATE TABLE IF NOT EXISTS house (k TEXT PRIMARY KEY, v TEXT)`, nil, 0); err != nil {
+		t.Fatalf("tenant scope must provision a schema + LOGIN role: %v\n"+
+			"a permission error here means the DSN role lacks CREATEROLE", err)
+	}
+	if _, err := m.Exec(ctx, key, `INSERT INTO house (k, v) VALUES ('style', 'tabs')`, nil, 0); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	got, err := m.Query(ctx, key, `SELECT v FROM house WHERE k = 'style'`, nil)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(got.Rows) != 1 || got.Rows[0][0] != "tabs" {
+		t.Fatalf("round trip failed: %+v", got.Rows)
+	}
+
+	schema, role, err := pgScopeNames(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var n int
+	if err := raw.QueryRowContext(ctx, `SELECT count(*) FROM information_schema.schemata WHERE schema_name = $1`, schema).Scan(&n); err != nil {
+		t.Fatalf("schema probe: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("schema %s was not created", schema)
+	}
+	if err := raw.QueryRowContext(ctx, `SELECT count(*) FROM pg_roles WHERE rolname = $1`, role).Scan(&n); err != nil {
+		t.Fatalf("role probe: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("LOGIN role %s was not created — the per-scope isolation is not in place", role)
+	}
+
+	// And it must be recorded for snapshot capture, or a tenant scope would be
+	// silently omitted from a snapshot.
+	if err := raw.QueryRowContext(ctx, `SELECT count(*) FROM sqlmem_meta.scope_registry WHERE schema_name = $1`, schema).Scan(&n); err != nil {
+		t.Fatalf("registry probe: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("scope %s is not in scope_registry — snapshot capture would skip it", schema)
+	}
+}
+
+// TestTenantScope_PostgresDropScopeReclaimsIt: DropScope refuses an empty ScopeID,
+// so the tenant scope's non-empty id is what makes it reclaimable at all.
+func TestTenantScope_PostgresDropScopeReclaimsIt(t *testing.T) {
+	m, raw := pgTestManager(t, Config{})
+	ctx := context.Background()
+	key := ScopeKey{Tenant: "acme", Scope: "tenant", ScopeID: "acme"}
+
+	if _, err := m.Exec(ctx, key, `CREATE TABLE IF NOT EXISTS t (v TEXT)`, nil, 0); err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+	removed, err := m.DropScope(ctx, key)
+	if err != nil {
+		t.Fatalf("DropScope: %v", err)
+	}
+	if !removed {
+		t.Error("DropScope reported the tenant scope as absent")
+	}
+	schema, _, _ := pgScopeNames(key)
+	var n int
+	if err := raw.QueryRowContext(ctx, `SELECT count(*) FROM information_schema.schemata WHERE schema_name = $1`, schema).Scan(&n); err != nil {
+		t.Fatalf("schema probe: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("schema %s survived DropScope", schema)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2740,6 +2740,26 @@ const (
 	// cursor regardless of agent or user. Reserved for cross-tenant
 	// fan-out streams the operator has reviewed.
 	MemoryScopeGlobal MemoryScope = "global"
+	// MemoryScopeTenant — one keyspace per TENANT, shared by every user
+	// and agent inside it (scope_id = ""; the tenant_id column already
+	// carries the identity, exactly as for global).
+	//
+	// Distinct from global in the axis it shares along: global is one
+	// keyspace across ALL tenants, this is one per tenant. A row here is
+	// (tenant_id='t1', scope='tenant', scope_id=''), which cannot collide
+	// with a global row (tenant_id='', scope='global') under the
+	// (tenant_id, scope, scope_id, key) primary key.
+	//
+	// It is SHARED-WRITE, which is the poisoning surface: anything an
+	// agent stores here is read by every other agent and user in the
+	// tenant. It is therefore default-deny and reachable only when the
+	// operator lists `tenant` in an agent's memory_scopes — the same
+	// per-agent allowlist that gates the other scopes, deliberately not a
+	// second mechanism.
+	//
+	// No DDL was needed to add it: `scope` is a plain text column with no
+	// CHECK constraint, and the tenant axis arrived with migration 0059.
+	MemoryScopeTenant MemoryScope = "tenant"
 )
 
 // MemoryEntry is one row in the memory table. ExpiresAt is zero when

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -263,9 +263,28 @@ func (d *Document) resolveScope(ctx context.Context, requested string) (sqlmem.S
 		//           identity, matching global's convention and the Path tree's
 		//           tenant dirent.
 		//
-		// A tenant document is readable AND writable by every user and agent in the
-		// tenant, so it is reachable only when the operator lists `tenant` in the
-		// agent's sql_scopes (structure) and memory_scopes (chunk bodies).
+		// GATED, unlike agent and user above. A tenant document is readable AND
+		// writable by every user and agent in the tenant, so an ungated one lets any
+		// agent holding `tools: [Document]` publish state the whole tenant then reads
+		// as ground truth — which is the poisoning surface, reached without the
+		// operator ever granting anything.
+		//
+		// The check is deliberately scoped to `tenant` and does NOT retrofit onto
+		// agent/user. Those have been ungated on this path since the tool shipped, so
+		// requiring a grant for them would break every existing agent that holds
+		// Document without declaring scopes; that is a separate, breaking change and
+		// does not belong in the commit that introduces a new scope. What must not
+		// happen is a NEW, cross-user scope inheriting the ungated posture.
+		//
+		// memory_scopes is the gate because it governs the tenant keyspace itself.
+		// Document also writes structure into SQL Memory under the same tenant, so a
+		// later consistency pass may require sql_scopes here too; today that would
+		// demand two grants for one operation with no extra safety.
+		if !contains(tools.MemoryPolicy(ctx).AllowedScopes, "tenant") {
+			return sqlmem.ScopeKey{}, "", fmt.Errorf("Document: scope=tenant is not granted to this agent — " +
+				"a tenant document is readable and writable by every user and agent in the tenant, so the " +
+				"operator must opt in with `memory_scopes: [tenant]` on the agent")
+		}
 		return sqlmem.ScopeKey{Tenant: sqlTenant, Scope: "tenant", ScopeID: sqlTenant}, store.MemoryScopeTenant, nil
 	default:
 		return sqlmem.ScopeKey{}, "", fmt.Errorf("Document: unknown scope %q (agent | user | tenant)", requested)

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -54,7 +54,7 @@ const documentInputSchema = `{
 	"type": "object",
 	"properties": {
 		"op":          {"type": "string", "enum": ["create_document","get_document","documents_summary","delete_document","set_path","create_chunk","get_chunk","update_chunk","delete_chunk","move_chunk","reorder_chunk","link_chunks","unlink_chunks","get_edges","query_chunks","define_type","list_types","set_asset","get_asset","export_md","import_md"]},
-		"scope":       {"type": "string", "enum": ["agent","user","tenant"], "description": "Which store (default user). agent = this agent; user = this end-user (needs a user_id on the run); tenant = shared by every user and agent in the tenant — anything written here is read by all of them, so use it for curated reference material, not for anything derived from untrusted text. Each requires the operator to grant that scope."},
+		"scope":       {"type": "string", "enum": ["agent","user","tenant"], "description": "Which store (default user). agent = this agent; user = this end-user (needs a user_id on the run); tenant = shared by every user and agent in the tenant — anything written here is read by all of them, so use it for curated reference material, not for anything derived from untrusted text. tenant requires the operator to grant BOTH memory_scopes and sql_scopes with the tenant value."},
 		"id":          {"type": "string", "description": "Document id (get/delete_document, set_path) or chunk id (get/update/delete/move_chunk)."},
 		"path":        {"type": "string", "description": "create_document: name the doc in the Path tree (default /documents/<title> if omitted). set_path: the path to attach to an existing document (by id). get/delete_document: address by path instead of id."},
 		"title":       {"type": "string"},
@@ -276,14 +276,29 @@ func (d *Document) resolveScope(ctx context.Context, requested string) (sqlmem.S
 		// does not belong in the commit that introduces a new scope. What must not
 		// happen is a NEW, cross-user scope inheriting the ungated posture.
 		//
-		// memory_scopes is the gate because it governs the tenant keyspace itself.
-		// Document also writes structure into SQL Memory under the same tenant, so a
-		// later consistency pass may require sql_scopes here too; today that would
-		// demand two grants for one operation with no extra safety.
+		// BOTH grants are required, because a document write touches BOTH planes: the
+		// chunk structure goes to SQL Memory (sql_scopes) and the chunk bodies to k/v
+		// Memory (memory_scopes). Granting one and not the other would let an agent
+		// reach half of a tenant store — and a half-written document is not a partial
+		// failure, it is structure with no text, which is the shape this store has
+		// already been broken into once.
+		//
+		// Requiring both also keeps one rule for the whole tenant scope: whichever
+		// tool an operator reasons about, the same two lines of yaml are what opens
+		// it. A single-grant gate here would mean Document needed less authority than
+		// the Memory tool does for the same data.
+		missing := make([]string, 0, 2)
 		if !contains(tools.MemoryPolicy(ctx).AllowedScopes, "tenant") {
-			return sqlmem.ScopeKey{}, "", fmt.Errorf("Document: scope=tenant is not granted to this agent — " +
-				"a tenant document is readable and writable by every user and agent in the tenant, so the " +
-				"operator must opt in with `memory_scopes: [tenant]` on the agent")
+			missing = append(missing, "memory_scopes: [tenant]")
+		}
+		if !contains(tools.SqlMemPolicy(ctx).AllowedScopes, "tenant") {
+			missing = append(missing, "sql_scopes: [tenant]")
+		}
+		if len(missing) > 0 {
+			return sqlmem.ScopeKey{}, "", fmt.Errorf("Document: scope=tenant is not granted to this agent — "+
+				"a tenant document is readable and writable by every user and agent in the tenant, so the "+
+				"operator must opt in. Missing on the agent: %s (a document needs both — structure lives in "+
+				"SQL Memory, chunk bodies in Memory)", strings.Join(missing, " and "))
 		}
 		return sqlmem.ScopeKey{Tenant: sqlTenant, Scope: "tenant", ScopeID: sqlTenant}, store.MemoryScopeTenant, nil
 	default:

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -54,7 +54,7 @@ const documentInputSchema = `{
 	"type": "object",
 	"properties": {
 		"op":          {"type": "string", "enum": ["create_document","get_document","documents_summary","delete_document","set_path","create_chunk","get_chunk","update_chunk","delete_chunk","move_chunk","reorder_chunk","link_chunks","unlink_chunks","get_edges","query_chunks","define_type","list_types","set_asset","get_asset","export_md","import_md"]},
-		"scope":       {"type": "string", "enum": ["agent","user"], "description": "Which store (default user). agent = this agent; user = this end-user (needs a user_id on the run). tenant scope is not yet supported."},
+		"scope":       {"type": "string", "enum": ["agent","user","tenant"], "description": "Which store (default user). agent = this agent; user = this end-user (needs a user_id on the run); tenant = shared by every user and agent in the tenant — anything written here is read by all of them, so use it for curated reference material, not for anything derived from untrusted text. Each requires the operator to grant that scope."},
 		"id":          {"type": "string", "description": "Document id (get/delete_document, set_path) or chunk id (get/update/delete/move_chunk)."},
 		"path":        {"type": "string", "description": "create_document: name the doc in the Path tree (default /documents/<title> if omitted). set_path: the path to attach to an existing document (by id). get/delete_document: address by path instead of id."},
 		"title":       {"type": "string"},
@@ -253,9 +253,22 @@ func (d *Document) resolveScope(ctx context.Context, requested string) (sqlmem.S
 		}
 		return sqlmem.ScopeKey{Tenant: sqlTenant, Scope: "user", ScopeID: uid}, store.MemoryScopeUser, nil
 	case "tenant":
-		return sqlmem.ScopeKey{}, "", fmt.Errorf("Document: scope=tenant is not yet supported (SQL Memory has no tenant scope); use agent or user")
+		// The two planes take DIFFERENT scope ids for the same logical scope, and
+		// the asymmetry is load-bearing rather than an oversight:
+		//
+		//   sqlmem  ScopeID = the tenant — pgScopeNames hashes
+		//           sha256(tenant \x1f scope \x1f scope_id) into a schema + LOGIN
+		//           role name and REJECTS an empty component.
+		//   Memory  scope_id = ""       — the tenant_id column already carries the
+		//           identity, matching global's convention and the Path tree's
+		//           tenant dirent.
+		//
+		// A tenant document is readable AND writable by every user and agent in the
+		// tenant, so it is reachable only when the operator lists `tenant` in the
+		// agent's sql_scopes (structure) and memory_scopes (chunk bodies).
+		return sqlmem.ScopeKey{Tenant: sqlTenant, Scope: "tenant", ScopeID: sqlTenant}, store.MemoryScopeTenant, nil
 	default:
-		return sqlmem.ScopeKey{}, "", fmt.Errorf("Document: unknown scope %q (agent | user)", requested)
+		return sqlmem.ScopeKey{}, "", fmt.Errorf("Document: unknown scope %q (agent | user | tenant)", requested)
 	}
 }
 

--- a/internal/tools/builtin/document_test.go
+++ b/internal/tools/builtin/document_test.go
@@ -258,10 +258,63 @@ func TestDocument_ScopeTenantIsolation(t *testing.T) {
 	}
 }
 
-func TestDocument_TenantScopeRefused(t *testing.T) {
+// TestDocument_TenantScopeRoundTrips replaces TestDocument_TenantScopeRefused:
+// scope=tenant is real as of RFC BL P4b.
+//
+// A document is split across two planes — structure in SQL Memory, chunk BODIES
+// in k/v Memory — and the two take DIFFERENT scope ids for the tenant scope (the
+// tenant vs ""), each for its own reason. This asserts the round trip through both
+// halves, because a mismatch between them shows up as a document whose structure
+// exists and whose text is empty, which is exactly the failure this store has
+// already had once.
+func TestDocument_TenantScopeRoundTrips(t *testing.T) {
 	d, ctx, _ := documentFixture(t)
-	if _, r := docExec(t, d, ctx, `{"op":"create_document","scope":"tenant","title":"x"}`); !r.IsError || !strings.Contains(r.Text, "not yet supported") {
-		t.Errorf("scope=tenant should be refused; got %q", r.Text)
+
+	out, r := docExec(t, d, ctx, `{"op":"create_document","scope":"tenant","title":"Tenant handbook"}`)
+	if r.IsError {
+		t.Fatalf("create_document scope=tenant: %s", r.Text)
+	}
+	docID, _ := out["document_id"].(string)
+	rootID, _ := out["root_chunk_id"].(string)
+	if docID == "" {
+		t.Fatalf("no document id in %v", out)
+	}
+
+	// A body write + read exercises the Memory half under the tenant partition.
+	if rootID != "" {
+		if _, r := docExec(t, d, ctx, `{"op":"update_chunk","scope":"tenant","id":"`+rootID+`","body":"shared reference text","revision":1}`); r.IsError {
+			t.Fatalf("update_chunk scope=tenant: %s", r.Text)
+		}
+		got, r := docExec(t, d, ctx, `{"op":"get_chunk","scope":"tenant","id":"`+rootID+`"}`)
+		if r.IsError {
+			t.Fatalf("get_chunk scope=tenant: %s", r.Text)
+		}
+		if body, _ := got["body"].(string); !strings.Contains(body, "shared reference text") {
+			t.Errorf("the chunk body did not survive the tenant round trip: %q — the two planes' scope ids disagree", body)
+		}
+	}
+
+	// And it must be visible via the tenant scope, not the user scope.
+	if _, r := docExec(t, d, ctx, `{"op":"get_document","scope":"tenant","id":"`+docID+`"}`); r.IsError {
+		t.Errorf("get_document scope=tenant: %s", r.Text)
+	}
+	if _, r := docExec(t, d, ctx, `{"op":"get_document","scope":"user","id":"`+docID+`"}`); !r.IsError {
+		t.Error("a tenant document must NOT be reachable through the user scope — the scopes would not be isolated")
+	}
+}
+
+// TestDocument_UnknownScopeRefused: the closed set still refuses anything outside
+// it, and the message names what IS valid.
+func TestDocument_UnknownScopeRefused(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	_, r := docExec(t, d, ctx, `{"op":"create_document","scope":"session","title":"x"}`)
+	if !r.IsError {
+		t.Fatal("an unknown scope must be refused")
+	}
+	for _, want := range []string{"agent", "user", "tenant"} {
+		if !strings.Contains(r.Text, want) {
+			t.Errorf("the refusal should list %q as valid: %q", want, r.Text)
+		}
 	}
 }
 

--- a/internal/tools/builtin/document_test.go
+++ b/internal/tools/builtin/document_test.go
@@ -269,8 +269,10 @@ func TestDocument_ScopeTenantIsolation(t *testing.T) {
 // already had once.
 func TestDocument_TenantScopeRoundTrips(t *testing.T) {
 	d, ctx, _ := documentFixture(t)
-	// The tenant scope is GATED; the round trip needs the operator's grant.
+	// The tenant scope is GATED on BOTH planes — structure in SQL Memory, chunk
+	// bodies in Memory — so the round trip needs both grants.
 	ctx = tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{AllowedScopes: []string{"agent", "user", "tenant"}})
+	ctx = tools.WithSqlMemPolicy(ctx, tools.SqlMemPolicyValue{AllowedScopes: []string{"agent", "user", "tenant"}})
 
 	out, r := docExec(t, d, ctx, `{"op":"create_document","scope":"tenant","title":"Tenant handbook"}`)
 	if r.IsError {
@@ -1474,35 +1476,78 @@ func TestExportMd_StoreFaultFailsLoudly(t *testing.T) {
 	}
 }
 
-// TestDocument_TenantScopeDeniedWithoutTheGrant is the gate.
+// TestDocument_TenantScopeRequiresBothGrants is the gate.
 //
-// It is asserted here rather than assumed because this path had NO grant check at
-// all when the tenant scope was first written: documentFixture stamps no policy,
-// and the round-trip test above passed anyway — an agent holding
-// `tools: [Document]` could publish state the entire tenant reads as ground truth
-// without the operator granting anything.
+// A document write touches BOTH planes — chunk structure in SQL Memory, chunk
+// bodies in k/v Memory — so both grants are required. Half a grant would let an
+// agent reach half a tenant store, and a document with structure and no text is
+// the exact shape this store has already been broken into once.
 //
-// agent and user scope remain ungated on this path (pre-existing since the tool
-// shipped); what must not happen is a NEW cross-user scope inheriting that.
-func TestDocument_TenantScopeDeniedWithoutTheGrant(t *testing.T) {
-	d, ctx, _ := documentFixture(t) // no memory policy stamped at all
+// Asserted rather than assumed because this path had NO grant check at all when
+// the tenant scope was first written: documentFixture stamps no policy, and the
+// round-trip test passed anyway. A test that passes without the grant IS the proof
+// the grant is not required.
+func TestDocument_TenantScopeRequiresBothGrants(t *testing.T) {
+	tenantOnly := []string{"agent", "user", "tenant"}
+	withoutTenant := []string{"agent", "user"}
 
-	_, r := docExec(t, d, ctx, `{"op":"create_document","scope":"tenant","title":"x"}`)
-	if !r.IsError {
-		t.Fatal("an agent with no memory_scopes grant must NOT reach the tenant scope")
-	}
-	if !strings.Contains(r.Text, "memory_scopes: [tenant]") {
-		t.Errorf("the refusal must name the grant an operator has to add: %q", r.Text)
+	cases := []struct {
+		name       string
+		mem, sql   []string
+		wantAllow  bool
+		wantNaming []string
+	}{
+		{
+			name: "neither grant", mem: withoutTenant, sql: withoutTenant,
+			wantNaming: []string{"memory_scopes: [tenant]", "sql_scopes: [tenant]"},
+		},
+		{
+			name: "memory only", mem: tenantOnly, sql: withoutTenant,
+			wantNaming: []string{"sql_scopes: [tenant]"},
+		},
+		{
+			name: "sql only", mem: withoutTenant, sql: tenantOnly,
+			wantNaming: []string{"memory_scopes: [tenant]"},
+		},
+		{
+			name: "both grants", mem: tenantOnly, sql: tenantOnly, wantAllow: true,
+		},
 	}
 
-	// A grant that omits tenant is still a denial.
-	partial := tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{AllowedScopes: []string{"agent", "user"}})
-	if _, r := docExec(t, d, partial, `{"op":"create_document","scope":"tenant","title":"x"}`); !r.IsError {
-		t.Error("memory_scopes without `tenant` must not grant the tenant scope")
-	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			d, ctx, _ := documentFixture(t)
+			ctx = tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{AllowedScopes: c.mem})
+			ctx = tools.WithSqlMemPolicy(ctx, tools.SqlMemPolicyValue{AllowedScopes: c.sql})
 
-	// And the pre-existing scopes are unaffected by the new check.
-	if _, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"ok"}`); r.IsError {
-		t.Errorf("the tenant gate must not change the user scope's behaviour: %s", r.Text)
+			_, r := docExec(t, d, ctx, `{"op":"create_document","scope":"tenant","title":"x"}`)
+			if c.wantAllow {
+				if r.IsError {
+					t.Fatalf("both grants present, must be allowed: %s", r.Text)
+				}
+				return
+			}
+			if !r.IsError {
+				t.Fatal("a partial or absent grant must NOT reach the tenant scope")
+			}
+			for _, want := range c.wantNaming {
+				if !strings.Contains(r.Text, want) {
+					t.Errorf("the refusal must name the missing grant %q: %q", want, r.Text)
+				}
+			}
+		})
+	}
+}
+
+// TestDocument_TenantGateLeavesOtherScopesAlone: agent and user have been ungated
+// on this path since the tool shipped, and retrofitting a grant onto them would
+// break every existing agent that holds Document without declaring scopes. That is
+// a separate, breaking change; this pins that the new check did not smuggle it in.
+func TestDocument_TenantGateLeavesOtherScopesAlone(t *testing.T) {
+	d, ctx, _ := documentFixture(t) // no policies stamped at all
+	for _, scope := range []string{"user", "agent"} {
+		if _, r := docExec(t, d, ctx, `{"op":"create_document","scope":"`+scope+`","title":"ok"}`); r.IsError {
+			t.Errorf("scope=%s must be unaffected by the tenant gate: %s", scope, r.Text)
+		}
 	}
 }

--- a/internal/tools/builtin/document_test.go
+++ b/internal/tools/builtin/document_test.go
@@ -269,6 +269,8 @@ func TestDocument_ScopeTenantIsolation(t *testing.T) {
 // already had once.
 func TestDocument_TenantScopeRoundTrips(t *testing.T) {
 	d, ctx, _ := documentFixture(t)
+	// The tenant scope is GATED; the round trip needs the operator's grant.
+	ctx = tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{AllowedScopes: []string{"agent", "user", "tenant"}})
 
 	out, r := docExec(t, d, ctx, `{"op":"create_document","scope":"tenant","title":"Tenant handbook"}`)
 	if r.IsError {
@@ -1469,5 +1471,38 @@ func TestExportMd_StoreFaultFailsLoudly(t *testing.T) {
 	}
 	if strings.Contains(res.Text, "CONTENT") {
 		t.Errorf("export leaked partial content: %s", res.Text)
+	}
+}
+
+// TestDocument_TenantScopeDeniedWithoutTheGrant is the gate.
+//
+// It is asserted here rather than assumed because this path had NO grant check at
+// all when the tenant scope was first written: documentFixture stamps no policy,
+// and the round-trip test above passed anyway — an agent holding
+// `tools: [Document]` could publish state the entire tenant reads as ground truth
+// without the operator granting anything.
+//
+// agent and user scope remain ungated on this path (pre-existing since the tool
+// shipped); what must not happen is a NEW cross-user scope inheriting that.
+func TestDocument_TenantScopeDeniedWithoutTheGrant(t *testing.T) {
+	d, ctx, _ := documentFixture(t) // no memory policy stamped at all
+
+	_, r := docExec(t, d, ctx, `{"op":"create_document","scope":"tenant","title":"x"}`)
+	if !r.IsError {
+		t.Fatal("an agent with no memory_scopes grant must NOT reach the tenant scope")
+	}
+	if !strings.Contains(r.Text, "memory_scopes: [tenant]") {
+		t.Errorf("the refusal must name the grant an operator has to add: %q", r.Text)
+	}
+
+	// A grant that omits tenant is still a denial.
+	partial := tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{AllowedScopes: []string{"agent", "user"}})
+	if _, r := docExec(t, d, partial, `{"op":"create_document","scope":"tenant","title":"x"}`); !r.IsError {
+		t.Error("memory_scopes without `tenant` must not grant the tenant scope")
+	}
+
+	// And the pre-existing scopes are unaffected by the new check.
+	if _, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"ok"}`); r.IsError {
+		t.Errorf("the tenant gate must not change the user scope's behaviour: %s", r.Text)
 	}
 }

--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -209,7 +209,7 @@ const memoryInputSchema = `{
   "type": "object",
   "properties": {
     "op":         {"type": "string", "enum": ["get","set","delete","list","incr","search","merge","append_dedupe","bounded_list","add","recall","sql_query","sql_exec","sql_begin","sql_commit","sql_rollback","cursor_get","cursor_scan","cursor_lease","cursor_advance","cursor_release","supersede","pending_drain","pending_ack"], "description": "Which operation to perform. Families: key/value (get,set,delete,list,incr,merge,append_dedupe,bounded_list,search); memory-layer (add,recall — add enqueues for background consolidation, recall needs the vector stack); SQL (sql_query,sql_exec,sql_begin,sql_commit,sql_rollback — a per-scope SQL database, gated separately by sql_scopes); consolidation (cursor_get,cursor_scan,cursor_lease,cursor_advance,cursor_release,supersede,pending_drain,pending_ack — background memory consolidation, gated separately by a dedicated grant)."},
-    "scope":      {"type": "string", "enum": ["agent","user","run"], "description": "Which keyspace/database. agent: this agent's (cross-run, cross-user). user: this end-user's (cross-agent). run: ephemeral per-run, dropped at run end — SQL ops only."},
+    "scope":      {"type": "string", "enum": ["agent","user","tenant","run"], "description": "Which keyspace/database. agent: this agent's (cross-run, cross-user). user: this end-user's (cross-agent). tenant: shared by every user and agent in the tenant — what you write here, they all read. run: ephemeral per-run, dropped at run end — SQL ops only."},
     "key":        {"type": "string", "description": "The entry's key. Required for get / set / delete / incr / merge / append_dedupe / bounded_list."},
     "value":      {"description": "The JSON value. Required for set / merge / append_dedupe / bounded_list. For merge: a JSON object whose fields overlay the existing object. For append_dedupe / bounded_list: the item to append."},
     "delta":      {"type": "integer", "description": "Increment delta for incr (default 1, may be negative)."},
@@ -513,7 +513,7 @@ func (m *Memory) resolveScope(ctx context.Context, requested string) (store.Memo
 	}
 	if !contains(policy.AllowedScopes, requested) {
 		if len(policy.AllowedScopes) == 0 {
-			return "", "", fmt.Errorf("Memory tool: this agent has no memory_scopes configured — add `memory_scopes: [agent]` (or [user], or both) to the agent yaml")
+			return "", "", fmt.Errorf("Memory tool: this agent has no memory_scopes configured — add `memory_scopes: [agent]` (and/or user, tenant) to the agent yaml")
 		}
 		return "", "", fmt.Errorf("Memory tool: scope %q not in this agent's memory_scopes %v", requested, policy.AllowedScopes)
 	}
@@ -531,8 +531,20 @@ func (m *Memory) resolveScope(ctx context.Context, requested string) (store.Memo
 			return "", "", fmt.Errorf("Memory tool: scope=user requires a user_id on the run (caller must supply user_id when starting the run)")
 		}
 		return store.MemoryScopeUser, ident.UserID, nil
+	case store.MemoryScopeTenant:
+		// scope_id is EMPTY on purpose: the tenant_id column already carries the
+		// identity, so a second copy here would be redundant and would make the
+		// retention fan-out ambiguous about which column is authoritative. Matches
+		// the global scope's convention and the Path tree's tenant dirent.
+		//
+		// The tenant itself needs no presence check: it is stamped on every run's
+		// identity from server-side auth (never the wire), and the single-tenant /
+		// open-mode value "" is a legitimate tenant, not a missing one. Requiring
+		// non-empty here would make the scope unusable in exactly the deployment
+		// where it is least dangerous.
+		return store.MemoryScopeTenant, "", nil
 	default:
-		return "", "", fmt.Errorf("Memory tool: unknown scope %q (only agent / user are supported in v0.8.0)", requested)
+		return "", "", fmt.Errorf("Memory tool: unknown scope %q (want one of: agent, user, tenant)", requested)
 	}
 }
 
@@ -562,7 +574,7 @@ func (m *Memory) resolveSqlScope(ctx context.Context, requested string) (scope, 
 	}
 	pol := tools.SqlMemPolicy(ctx)
 	if len(pol.AllowedScopes) == 0 {
-		return "", "", fmt.Errorf("Memory tool: this agent has no sql_scopes configured — add `sql_scopes: [agent]` (and/or user, run) to the agent yaml")
+		return "", "", fmt.Errorf("Memory tool: this agent has no sql_scopes configured — add `sql_scopes: [agent]` (and/or user, run, tenant) to the agent yaml")
 	}
 	if !contains(pol.AllowedScopes, requested) {
 		return "", "", fmt.Errorf("Memory tool: sql scope %q not in this agent's sql_scopes %v", requested, pol.AllowedScopes)
@@ -592,8 +604,18 @@ func (m *Memory) resolveSqlScope(ctx context.Context, requested string) (scope, 
 			return "", "", fmt.Errorf("Memory tool: sql scope=run requires an active run (no run id on the context)")
 		}
 		return "run", rid, nil
+	case "tenant":
+		// scope_id is the TENANT here, NOT empty — the opposite of the k/v tenant
+		// scope above, and deliberately so. sqlmem derives a postgres schema + LOGIN
+		// role from sha256(tenant \x1f scope \x1f scope_id) and rejects an empty
+		// component, so the id has to be non-empty; {t, tenant, t} still hashes
+		// distinctly from {t, user, t} because the scope segment differs.
+		//
+		// The k/v plane has no such constraint and uses "" so its tenant_id column
+		// stays the single source of identity. Two conventions, one reason each.
+		return "tenant", sqlScopeTenant(ctx), nil
 	default:
-		return "", "", fmt.Errorf("Memory tool: unknown sql scope %q (want one of: agent, user, run)", requested)
+		return "", "", fmt.Errorf("Memory tool: unknown sql scope %q (want one of: agent, user, run, tenant)", requested)
 	}
 }
 

--- a/internal/tools/builtin/memory_tenant_scope_test.go
+++ b/internal/tools/builtin/memory_tenant_scope_test.go
@@ -1,0 +1,125 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// tenantMemFixture builds a Memory tool whose agent is granted the tenant scope,
+// running as (tenant, user).
+func tenantMemFixture(t *testing.T, tenant, user string, scopes ...string) (*Memory, context.Context, store.Store) {
+	t.Helper()
+	s, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	if len(scopes) == 0 {
+		scopes = []string{"agent", "user", "tenant"}
+	}
+	ctx := tools.WithAgentName(context.Background(), "curator")
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a", UserID: user, TenantID: tenant})
+	ctx = tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{AllowedScopes: scopes})
+	return &Memory{Store: s}, ctx, s
+}
+
+func memExecJSON(t *testing.T, m *Memory, ctx context.Context, body string) tools.Result {
+	t.Helper()
+	res, err := m.Execute(ctx, json.RawMessage(body))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	return res
+}
+
+// TestMemoryTenantScope_SharedAcrossUsers is the scope's whole purpose: two
+// different users in the SAME tenant see one keyspace.
+func TestMemoryTenantScope_SharedAcrossUsers(t *testing.T) {
+	m, ctxA, s := tenantMemFixture(t, "acme", "alice")
+	if r := memExecJSON(t, m, ctxA, `{"op":"set","scope":"tenant","key":"house/style","value":"tabs"}`); r.IsError {
+		t.Fatalf("set: %s", r.Text)
+	}
+
+	// A second user in the same tenant, same store.
+	ctxB := tools.WithAgentName(context.Background(), "curator")
+	ctxB = tools.WithRunIdentity(ctxB, tools.RunIdentityValue{AgentID: "b", UserID: "bob", TenantID: "acme"})
+	ctxB = tools.WithMemoryPolicy(ctxB, tools.MemoryPolicyValue{AllowedScopes: []string{"tenant"}})
+	m2 := &Memory{Store: s}
+
+	r := memExecJSON(t, m2, ctxB, `{"op":"get","scope":"tenant","key":"house/style"}`)
+	if r.IsError {
+		t.Fatalf("a second user in the same tenant must read the shared row: %s", r.Text)
+	}
+	if !strings.Contains(r.Text, "tabs") {
+		t.Errorf("want the shared value, got %q", r.Text)
+	}
+}
+
+// TestMemoryTenantScope_IsolatedAcrossTenants is the property that makes it safe
+// to grant at all. A shared-write scope that leaked between tenants would be the
+// worst possible version of this feature.
+func TestMemoryTenantScope_IsolatedAcrossTenants(t *testing.T) {
+	m, ctxAcme, s := tenantMemFixture(t, "acme", "alice")
+	if r := memExecJSON(t, m, ctxAcme, `{"op":"set","scope":"tenant","key":"house/style","value":"acme-only"}`); r.IsError {
+		t.Fatalf("set: %s", r.Text)
+	}
+
+	ctxOther := tools.WithAgentName(context.Background(), "curator")
+	ctxOther = tools.WithRunIdentity(ctxOther, tools.RunIdentityValue{AgentID: "c", UserID: "carol", TenantID: "globex"})
+	ctxOther = tools.WithMemoryPolicy(ctxOther, tools.MemoryPolicyValue{AllowedScopes: []string{"tenant"}})
+
+	r := memExecJSON(t, &Memory{Store: s}, ctxOther, `{"op":"get","scope":"tenant","key":"house/style"}`)
+	if !r.IsError && strings.Contains(r.Text, "acme-only") {
+		t.Fatalf("CROSS-TENANT LEAK: globex read acme's tenant-scoped row: %q", r.Text)
+	}
+}
+
+// TestMemoryTenantScope_DefaultDeniedWithoutTheGrant: the per-agent allowlist IS
+// the gate — there is deliberately no second mechanism, so it has to hold.
+func TestMemoryTenantScope_DefaultDeniedWithoutTheGrant(t *testing.T) {
+	m, ctx, _ := tenantMemFixture(t, "acme", "alice", "agent", "user")
+	r := memExecJSON(t, m, ctx, `{"op":"set","scope":"tenant","key":"k","value":"v"}`)
+	if !r.IsError {
+		t.Fatal("an agent without the tenant grant must not reach the tenant scope")
+	}
+	if !strings.Contains(r.Text, "memory_scopes") {
+		t.Errorf("the refusal should point at the grant: %q", r.Text)
+	}
+}
+
+// TestMemoryTenantScope_DoesNotCollideWithGlobal: both use scope_id="", so the
+// only thing separating them is the scope column plus the tenant partition. A
+// collision here would silently merge a per-tenant keyspace into the cross-tenant
+// one.
+func TestMemoryTenantScope_DoesNotCollideWithGlobal(t *testing.T) {
+	_, _, s := tenantMemFixture(t, "acme", "alice")
+	ctx := context.Background()
+
+	if err := s.MemorySet(ctx, "acme", store.MemoryScopeTenant, "", "shared/key", json.RawMessage(`"tenant-value"`), 0); err != nil {
+		t.Fatalf("tenant set: %v", err)
+	}
+	if err := s.MemorySet(ctx, "", store.MemoryScopeGlobal, "", "shared/key", json.RawMessage(`"global-value"`), 0); err != nil {
+		t.Fatalf("global set: %v", err)
+	}
+
+	got, err := s.MemoryGet(ctx, "acme", store.MemoryScopeTenant, "", "shared/key")
+	if err != nil {
+		t.Fatalf("tenant get: %v", err)
+	}
+	if string(got.Value) != `"tenant-value"` {
+		t.Errorf("tenant row = %s, want the tenant value — global overwrote it", got.Value)
+	}
+	g, err := s.MemoryGet(ctx, "", store.MemoryScopeGlobal, "", "shared/key")
+	if err != nil {
+		t.Fatalf("global get: %v", err)
+	}
+	if string(g.Value) != `"global-value"` {
+		t.Errorf("global row = %s, want the global value — tenant overwrote it", g.Value)
+	}
+}


### PR DESCRIPTION
The prerequisite the rest of P4 sits on: a **tenant scope** — one keyspace per tenant, shared by every user and agent inside it — alongside the existing per-agent and per-user scopes.

## The architecture pass moved most of the work

**sqlmem needed almost no code.** It's already fully generic over the scope string: nothing in the package validates it, `pgScopeNames` hashes `sha256(tenant \x1f scope \x1f scope_id)` for any scope, the sqlite backend joins `root/<tenant>/<scope>/<id>.db`, and `scope_registry` records it verbatim. A tenant scope flows through the existing provisioning path untouched.

**The real gap was that k/v Memory had no tenant scope at all.** RFC AK splits a Document across two planes — structure in SQL Memory, chunk **bodies** in Memory at `doc.chunk:<uuid>` — so a tenant-scoped Document needs a tenant-scoped Memory partition for its bodies. That makes this three planes, not two. No DDL: `memory.scope` is a plain text column with no CHECK, and the tenant axis arrived with migration 0059.

**The two planes need different scope ids for the same logical scope**, and the asymmetry is load-bearing:

| plane | scope_id | why |
|---|---|---|
| sqlmem | the tenant | `pgScopeNames` **rejects** an empty component, and the value becomes half of a schema + LOGIN role name |
| Memory | `""` | the `tenant_id` column already carries the identity; a second copy leaves the retention fan-out ambiguous about which is authoritative. Matches global's convention and the Path tree's tenant dirent |

Both sites say so with the reason, because the next reader will otherwise "fix" one of them.

## Authority — the grant is the gate, deliberately

A tenant scope is shared-**write**: anything an agent stores is read by every other agent and user in the tenant. That's the poisoning surface the memory research flags. It stays default-deny through `memory_scopes:` / `sql_scopes:`, the same per-agent allowlists that gate the other scopes.

**No second mechanism was added.** The RFC's "agents propose, operator approves" is about the *ontology* (a P4c concern); a parallel gate here would leave two places to get wrong instead of one. `validMemoryScopes`'s own comment had already anticipated the value: *"future versions may add session / tenant"*.

## Nothing enumerating scopes needed changing — verified, not assumed

Snapshot capture reads every row and passes the scope through as a string; retention targets the agent scope specifically (a tenant scope has no retirement event to sweep on); the quota and GC paths take the scope triple generically.

## Two tests encoded the pre-P4b state

Replaced, not deleted. `TestMemoryScopesValidation` used `tenant` as its example of an **invalid** scope, so it now rejects a genuinely unknown one (`session`) — a validation test whose bad input later becomes valid stops testing anything, silently. `TestDocument_TenantScopeRefused` becomes `TestDocument_TenantScopeRoundTrips`.

## What was tested — both tiers

**Postgres, against a real aux DB** (the plan named per-tenant role creation as the sharp risk precisely because it fails at provisioning time rather than review time, so it's asserted):

- the schema **and** the LOGIN role are created
- the scope lands in `scope_registry`, so snapshot capture cannot skip it
- `DropScope` reclaims it — which only works because the tenant scope's id is non-empty

**sqlite**: provisioning, cross-scope and cross-tenant isolation, and that `{t,tenant,t}` does not alias `{t,user,t}` — they differ only in the hashed name's scope segment, which is exactly what a naming refactor breaks silently.

**Memory level**: shared-across-users (the scope's purpose), isolated-across-tenants (what makes it safe to grant), default-denied-without-the-grant (the gate holding), and no-collision-with-global — both use `scope_id=""`, separated only by the scope column and the tenant partition.

**Document level**: a tenant document round-trips through *both* planes including its chunk body, and is not reachable through the user scope. A mismatch between the planes would present as a document whose structure exists and whose text is empty — a failure this store has already had once.

`go test ./...` green on both tiers, including the 262s Postgres store contract. `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)