### PR TITLE
ci(browser): publish a loomcycle-browser image (loomcycle + pinchtab client)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -225,6 +225,49 @@ dockers:
       - "--label=org.opencontainers.image.licenses=Apache-2.0"
     goarch: arm64
 
+  # loomcycle-browser — the distroless loomcycle image + the PinchTab MCP client
+  # binary, so the runtime can spawn `pinchtab … mcp` (stdio) against a pinchtab
+  # server sidecar and expose mcp__browser__* to agents. Reuses the same pre-built
+  # binary (ids: [loomcycle]); Dockerfile.browser adds only the ~28MB client
+  # (Chromium stays in the sidecar), so BOTH arches are a trivial COPY — no
+  # QEMU-slow layers like the toolbox. See docs/SANDBOX.md.
+  - id: loomcycle-browser-amd64
+    ids:
+      - loomcycle
+    image_templates:
+      - "denngubsky/loomcycle-browser:{{ .Version }}-amd64"
+      - "denngubsky/loomcycle-browser:latest-amd64"
+    dockerfile: Dockerfile.browser
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.title=loomcycle-browser"
+      - "--label=org.opencontainers.image.description=loomcycle + the PinchTab MCP client for headless-browser (mcp__browser__*) agents"
+      - "--label=org.opencontainers.image.url=https://github.com/denn-gubsky/loomcycle"
+      - "--label=org.opencontainers.image.source=https://github.com/denn-gubsky/loomcycle"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.licenses=Apache-2.0"
+    goarch: amd64
+  - id: loomcycle-browser-arm64
+    ids:
+      - loomcycle
+    image_templates:
+      - "denngubsky/loomcycle-browser:{{ .Version }}-arm64"
+      - "denngubsky/loomcycle-browser:latest-arm64"
+    dockerfile: Dockerfile.browser
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.title=loomcycle-browser"
+      - "--label=org.opencontainers.image.description=loomcycle + the PinchTab MCP client for headless-browser (mcp__browser__*) agents"
+      - "--label=org.opencontainers.image.url=https://github.com/denn-gubsky/loomcycle"
+      - "--label=org.opencontainers.image.source=https://github.com/denn-gubsky/loomcycle"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.licenses=Apache-2.0"
+    goarch: arm64
+
 # docker_manifests joins per-arch images into one multi-arch manifest
 # the operator pulls with `docker pull denngubsky/loomcycle:vX.Y.Z`
 # regardless of their host arch.
@@ -245,3 +288,11 @@ docker_manifests:
     image_templates:
       - "denngubsky/loomcycle-toolbox:latest-amd64"
       - "denngubsky/loomcycle-toolbox:latest-arm64"
+  - name_template: "denngubsky/loomcycle-browser:{{ .Version }}"
+    image_templates:
+      - "denngubsky/loomcycle-browser:{{ .Version }}-amd64"
+      - "denngubsky/loomcycle-browser:{{ .Version }}-arm64"
+  - name_template: "denngubsky/loomcycle-browser:latest"
+    image_templates:
+      - "denngubsky/loomcycle-browser:latest-amd64"
+      - "denngubsky/loomcycle-browser:latest-arm64"

--- a/Dockerfile.browser
+++ b/Dockerfile.browser
@@ -1,0 +1,27 @@
+# Dockerfile.browser — goreleaser variant: the distroless loomcycle image + the
+# PinchTab MCP CLIENT binary.
+#
+# Why: PinchTab's MCP server is stdio-only, so loomcycle drives a browser by
+# SPAWNING `pinchtab --server http://<pinchtab-server>:9867 mcp` as a stdio MCP
+# subprocess — which needs the pinchtab client binary in loomcycle's OWN container.
+# Chromium stays in a separate `pinchtab/pinchtab` server sidecar; only the ~28 MB
+# client (no browser) is added here, so this image stays distroless + tiny.
+#
+# Wire it: run a `pinchtab/pinchtab` server sidecar, add an mcp_servers.browser
+# (transport: stdio, command: /usr/local/bin/pinchtab, args: [--server,
+# http://pinchtab:9867, mcp]) and grant the agent mcp__browser__* — see
+# docs/SANDBOX.md.
+#
+# Same pre-built binary as Dockerfile.release (goreleaser builds every arch in its
+# `builds:` stage; this only COPYs it). pinchtab/pinchtab is multi-arch, so the
+# `FROM` resolves per target platform under buildx. Published to
+# docker.io/denngubsky/loomcycle-browser.
+FROM pinchtab/pinchtab:0.15.0 AS pinchtab
+
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY loomcycle /usr/local/bin/loomcycle
+COPY --from=pinchtab /usr/local/bin/pinchtab /usr/local/bin/pinchtab
+USER nonroot
+EXPOSE 8787
+ENTRYPOINT ["/usr/local/bin/loomcycle"]

--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -133,6 +133,36 @@ session env with egress on, prefer a **short-lived, repo-scoped GitHub App token
 PAT. Full mechanism + caps:
 [`../deploy/builder/README.md`](../deploy/builder/README.md#env-injection-credentials-into-a-session).
 
+### Headless browser (web-UI testing)
+
+To give the agent a browser (`mcp__browser__*`) for ad-hoc web-UI testing, run the
+runtime as the **`denngubsky/loomcycle-browser`** image (the standard loomcycle
+image + the [PinchTab](https://github.com/pinchtab/pinchtab) MCP client, published
+alongside every release) and add a **`pinchtab/pinchtab` server sidecar**. PinchTab's
+MCP is stdio-only, so loomcycle spawns `pinchtab … mcp` as a stdio bridge to the
+sidecar — Chromium lives only in the sidecar, not in loomcycle.
+
+1. Run the sidecar **internal only** (no published port — its control plane is not
+   for public exposure), with `PINCHTAB_TOKEN` set, `shm_size: 2gb`, and the usual
+   hardening (`read_only`, tmpfs, `cap_drop: ALL`, `no-new-privileges`).
+2. Use `denngubsky/loomcycle-browser:<version>` for the loomcycle runtime and give
+   it the same `PINCHTAB_TOKEN` (the stdio child inherits loomcycle's env).
+3. Overlay the config (a file in `LOOMCYCLE_CONFIG_DIR`):
+   ```yaml
+   mcp_servers:
+     browser:
+       transport: stdio
+       command: /usr/local/bin/pinchtab
+       args: ["--server", "http://pinchtab:9867", "mcp"]
+   agents:
+     dev/sandbox:
+       tools: [mcp__sandbox__*, mcp__browser__*, Interruption]
+   ```
+
+Scope: reachable URLs (public sites / your deployment / preview URLs). PinchTab
+keeps browsing local-only until you widen its domain allowlist (IDPI). A full worked
+example is in [`../cloud-deployment/`](../cloud-deployment/).
+
 ## Delegating from other agents
 
 An agent doesn't hold the `mcp__sandbox__*` tools directly (by design — tool ceilings


### PR DESCRIPTION
## Why

PinchTab's MCP is **stdio-only**, so a browser-enabled loomcycle must carry the
pinchtab client binary in its own container. Until now that meant a hand-built
derived image (the `cloud-deployment/loomcycle.Dockerfile` path) — a blocker for
turn-key deployments like TrueNAS. Publish it from CI so `mcp__browser__*` is
pull-and-go.

## What

- **`Dockerfile.browser`** — the distroless release image (`Dockerfile.release`) +
  `COPY --from=pinchtab/pinchtab:0.15.0` the client binary. Chromium is **not**
  included (it stays in the `pinchtab` server sidecar); ~28 MB added, the image
  stays distroless.
- **`.goreleaser.yaml`** — `loomcycle-browser-{amd64,arm64}` `dockers:` entries +
  the multi-arch `docker_manifests`, mirroring `loomcycle-toolbox` and reusing the
  same pre-built `loomcycle` binary (`ids: [loomcycle]`). Because it runs inside the
  goreleaser release, it builds **after** the base image (correct `FROM` ordering)
  and needs no extra credentials/vars.
- **`docs/SANDBOX.md`** — a "Headless browser" section: use
  `denngubsky/loomcycle-browser:<version>` + a pinchtab sidecar + the
  `mcp_servers.browser` overlay.

Result: on the next `v*` tag, `denngubsky/loomcycle-browser:<version>` + `:latest`
publish for `linux/amd64,linux/arm64`.

## Tested

- `goreleaser check`: config **valid** (the `dockers`/`docker_manifests`/`brews`
  deprecation notices are pre-existing across the whole file; the pinned `v2.15.4`
  release path in `release.yml` supports them). The browser entries mirror the
  working toolbox pattern.
- `pinchtab/pinchtab:0.15.0` confirmed multi-arch (amd64 + arm64), so the per-arch
  `FROM` resolves correctly under buildx.
- YAML parses; the 6 docker ids + the browser manifests are present.

## For the operator (e.g. TrueNAS)

After this ships in the next release: point the `loomcycle` service at
`denngubsky/loomcycle-browser:<version>`, run a `pinchtab/pinchtab` server sidecar
(internal, token-authed, `shm_size: 2gb`), and drop in the `mcp_servers.browser`
overlay — no local build.

## Follow-up (not in this PR)

`cloud-deployment/` still builds the derived image via `loomcycle.Dockerfile`; it
can be simplified to pull `loomcycle-browser` once this is released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD
