### PR TITLE
feat(memory): the bi-temporal sidecar, its keys and its cascade (RFC BL P4c PR 1)

### DIFF
--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -147,8 +147,53 @@ var docSchemaDDL = []string{
 	`CREATE TABLE IF NOT EXISTS chunk_types (
 		document_id TEXT NOT NULL, name TEXT NOT NULL, fields TEXT NOT NULL,
 		created_at BIGINT NOT NULL, PRIMARY KEY (document_id, name))`,
+	// chunk_memory_meta — the bi-temporal + provenance sidecar for the entity tier.
+	// Created UNCONDITIONALLY: the tier is opt-in at the level of "does this scope
+	// have entities", not at the level of "does this scope have the table". Gating
+	// the DDL would let a scope exist in two shapes and force every later read to
+	// ask which one it got; one empty table per scope is the cheaper answer.
+	//
+	// TWO timelines, which is the whole point:
+	//   valid_at / invalid_at    — when the fact was true IN THE WORLD
+	//   created_at / expired_at  — when the SYSTEM learned and retired it
+	// Keeping them apart is what lets "as of June…" stay answerable after a
+	// correction: a contradicting fact closes the old row's invalid_at/expired_at
+	// and links `supersedes`, rather than deleting it.
+	//
+	// natural_key is the idempotency handle ({scope}:{type}:{canonical-name} for an
+	// entity, {subject}|{predicate}|{object} for a fact). It lives HERE, in SQL,
+	// rather than in the chunk's `fields` as the design first specified — `fields`
+	// is stored inside the chunkBody JSON blob in the Memory k/v plane, so
+	// "does this entity already exist?" would have meant reading every chunk body
+	// out of Memory and parsing it: O(n) on the one operation an entity graph does
+	// constantly.
+	//
+	// No foreign key, matching the rest of this schema — cascade is explicit in Go
+	// (see deleteChunk / delete_document) so it also cleans the Memory bodies and
+	// does not depend on per-backend FK enforcement.
+	`CREATE TABLE IF NOT EXISTS chunk_memory_meta (
+		chunk_id TEXT PRIMARY KEY,
+		valid_at BIGINT, invalid_at BIGINT,
+		created_at BIGINT, expired_at BIGINT,
+		class TEXT, origin TEXT, confidence REAL,
+		session_id TEXT, run_id TEXT, event_seq BIGINT,
+		natural_key TEXT)`,
+	// UNIQUE per SCOPE, not per document: each scope owns its own database (a
+	// sqlite file / a postgres schema), so a bare UNIQUE index on the column IS
+	// scope-wide — one entity per tenant regardless of which document holds it.
+	//
+	// The column is NULLABLE and almost every chunk leaves it unset. Both tiers
+	// treat NULLs as DISTINCT in a unique index, so ordinary chunks never collide;
+	// that portability assumption is asserted by a test rather than trusted.
+	`CREATE UNIQUE INDEX IF NOT EXISTS chunk_memory_meta_natural_key ON chunk_memory_meta(natural_key)`,
 	`CREATE INDEX IF NOT EXISTS chunks_doc_parent_pos ON chunks(document_id, parent_id, position)`,
 	`CREATE INDEX IF NOT EXISTS chunks_doc_type_status ON chunks(document_id, type, status)`,
+	// The REVERSE edge index. chunk_edges' primary key (from_id, to_id, kind)
+	// serves a forward walk only, so every reverse hop of a graph expansion would
+	// scan the scope's whole edge table. Absent this, retrieval degrades only once
+	// the graph is large enough to matter — the failure that shows up in
+	// production and not in a test.
+	`CREATE INDEX IF NOT EXISTS chunk_edges_to_kind ON chunk_edges(to_id, kind)`,
 }
 
 // maxChunkDepth caps the ancestor walk in move_chunk (cycle detection) so a
@@ -944,6 +989,14 @@ func (d *Document) deleteDocument(ctx context.Context, key sqlmem.ScopeKey, msco
 		if err := d.execTxn(ctx, txnID, `DELETE FROM chunk_assets WHERE chunk_id IN (SELECT id FROM chunks WHERE document_id = ?)`, docID); err != nil {
 			return err
 		}
+		// Same ordering constraint for the entity-tier sidecar, and the same reason
+		// it is done here rather than by a foreign key: an orphaned temporal row is
+		// invisible. No read filters it and no sweeper reaps it, so it would sit in
+		// the scope forever pointing at a chunk that no longer exists — the dead-link
+		// class this schema's explicit-cascade discipline exists to prevent.
+		if err := d.execTxn(ctx, txnID, `DELETE FROM chunk_memory_meta WHERE chunk_id IN (SELECT id FROM chunks WHERE document_id = ?)`, docID); err != nil {
+			return err
+		}
 		if err := d.execTxn(ctx, txnID, `DELETE FROM chunks WHERE document_id = ?`, docID); err != nil {
 			return err
 		}
@@ -1417,6 +1470,13 @@ func (d *Document) deleteChunk(ctx context.Context, key sqlmem.ScopeKey, mscope 
 				return err
 			}
 			if err := d.execTxn(ctx, txnID, `DELETE FROM chunk_assets WHERE chunk_id = ?`, cid); err != nil {
+				return err
+			}
+			// The sidecar's SECOND cascade site. Both are required: delete_document
+			// walks by document, this walks the descendant set of one chunk, and a
+			// sidecar row reachable only through the path that was missed is an orphan
+			// nothing can see.
+			if err := d.execTxn(ctx, txnID, `DELETE FROM chunk_memory_meta WHERE chunk_id = ?`, cid); err != nil {
 				return err
 			}
 			if err := d.execTxn(ctx, txnID, `DELETE FROM chunks WHERE id = ?`, cid); err != nil {

--- a/internal/tools/builtin/document_entity_sidecar_test.go
+++ b/internal/tools/builtin/document_entity_sidecar_test.go
@@ -1,0 +1,333 @@
+package builtin
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/channels"
+	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// ---- helpers ----
+//
+// These reach the scope's SQL database through the Document's OWN sqlmem manager
+// and resolved ScopeKey, so a test writes to exactly the database the tool writes
+// to. query_chunks cannot be used for the writes: it is read-only by design
+// (SELECT / WITH ... SELECT only, validator-gated), which is the correct posture
+// for a model-facing escape hatch and the reason the writes go around it here.
+
+func sidecarScope(t *testing.T, d *Document, ctx context.Context) sqlmem.ScopeKey {
+	t.Helper()
+	key, _, err := d.resolveScope(ctx, "user")
+	if err != nil {
+		t.Fatalf("resolveScope: %v", err)
+	}
+	return key
+}
+
+// sidecarInsert writes one sidecar row. An EMPTY naturalKey is bound as SQL NULL,
+// which is the case that matters most: almost every chunk leaves the column unset,
+// so NULLs must not collide under the unique index.
+func sidecarInsert(t *testing.T, d *Document, ctx context.Context, chunkID, naturalKey string) error {
+	t.Helper()
+	var nk any
+	if naturalKey != "" {
+		nk = naturalKey
+	}
+	// Rebind is the portable seam: pgx does NOT accept `?`, so a helper that writes
+	// its own SQL has to go through it exactly as the tool does. Skipping it passed
+	// on sqlite and failed on postgres with a bare syntax error — which is what the
+	// parity test below exists to catch.
+	stmt := d.SqlMem.Rebind(
+		`INSERT INTO chunk_memory_meta (chunk_id, valid_at, created_at, class, origin, natural_key)
+		 VALUES (?, ?, ?, ?, ?, ?)`)
+	_, err := d.SqlMem.Exec(ctx, sidecarScope(t, d, ctx), stmt,
+		[]any{chunkID, int64(1), int64(1), "derived", "consolidator", nk}, 0)
+	return err
+}
+
+// sidecarRowsFor counts sidecar rows for ONE chunk id. Preferred over a whole-table
+// count when a test also seeds rows with invented chunk ids: those are legitimately
+// untouched by a cascade that walks real chunks.
+func sidecarRowsFor(t *testing.T, d *Document, ctx context.Context, chunkID string) int {
+	t.Helper()
+	res, err := d.SqlMem.Query(ctx, sidecarScope(t, d, ctx),
+		d.SqlMem.Rebind(`SELECT count(*) FROM chunk_memory_meta WHERE chunk_id = ?`), []any{chunkID})
+	if err != nil {
+		t.Fatalf("count for %s: %v", chunkID, err)
+	}
+	return scanCount(res.Rows)
+}
+
+func sidecarCount(t *testing.T, d *Document, ctx context.Context) int {
+	t.Helper()
+	res, err := d.SqlMem.Query(ctx, sidecarScope(t, d, ctx), `SELECT count(*) FROM chunk_memory_meta`, nil)
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	return scanCount(res.Rows)
+}
+
+// scanCount normalizes a COUNT(*) cell across tiers — sqlite-under-modernc and
+// postgres-under-pgx do not agree on whether it arrives as an integer or text.
+func scanCount(rows [][]any) int {
+	if len(rows) == 0 {
+		return 0
+	}
+	switch v := rows[0][0].(type) {
+	case int64:
+		return int(v)
+	case int:
+		return v
+	case string:
+		n := 0
+		for _, c := range v {
+			if c >= '0' && c <= '9' {
+				n = n*10 + int(c-'0')
+			}
+		}
+		return n
+	}
+	return -1
+}
+
+// The entity-tier sidecar (RFC BL P4c PR1). No entity semantics yet — this PR is
+// the schema, the two indexes and the cascade, so it is exercised through the
+// scope's own SQL surface rather than through a new Document op.
+
+// TestSidecar_CreatedUnconditionally: the table exists as soon as a scope has any
+// document at all. Operator decision — the tier is opt-in at the level of "does
+// this scope have entities", never at the level of "does the table exist", because
+// a gated DDL lets a scope exist in two shapes and forces every later read to ask
+// which one it got.
+func TestSidecar_CreatedUnconditionally(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	// An ordinary document — nothing entity-related requested.
+	if _, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"plain"}`); r.IsError {
+		t.Fatalf("create_document: %s", r.Text)
+	}
+	out, r := docExec(t, d, ctx, `{"op":"query_chunks","scope":"user","sql":"SELECT count(*) AS n FROM chunk_memory_meta"}`)
+	if r.IsError {
+		t.Fatalf("chunk_memory_meta should exist for any scope with a document: %s", r.Text)
+	}
+	if out == nil {
+		t.Fatal("no result")
+	}
+}
+
+// TestSidecar_HasBothTimelinesAndTheNaturalKey pins the columns the entity tier
+// depends on. Two timelines is the whole point: valid_at/invalid_at is when a fact
+// was true in the WORLD, created_at/expired_at is when the SYSTEM learned and
+// retired it. Collapsing them would make "as of June…" unanswerable after a
+// correction.
+func TestSidecar_HasBothTimelinesAndTheNaturalKey(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	if _, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"x"}`); r.IsError {
+		t.Fatalf("create: %s", r.Text)
+	}
+	// Selecting every column by name fails loudly if one is missing or renamed.
+	const cols = "chunk_id, valid_at, invalid_at, created_at, expired_at, class, origin, confidence, session_id, run_id, event_seq, natural_key"
+	if _, r := docExec(t, d, ctx, `{"op":"query_chunks","scope":"user","sql":"SELECT `+cols+` FROM chunk_memory_meta"}`); r.IsError {
+		t.Fatalf("the sidecar is missing a column the entity tier needs: %s", r.Text)
+	}
+}
+
+// TestSidecar_NaturalKeyUniquePerScope_ButNullsDoNotCollide is the portability
+// assertion behind the operator's "unique per scope" decision.
+//
+// Each scope owns its own database, so a bare UNIQUE index on the column IS
+// scope-wide. The subtlety is that the column is NULLABLE and almost every chunk
+// leaves it unset: if a tier treated NULLs as equal, the SECOND ordinary chunk in
+// any scope would fail to insert. Both tiers treat them as distinct — asserted
+// here rather than trusted, because the failure would be immediate and total.
+func TestSidecar_NaturalKeyUniquePerScope_ButNullsDoNotCollide(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	if _, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"x"}`); r.IsError {
+		t.Fatalf("create: %s", r.Text)
+	}
+
+	// Many NULL natural_keys must coexist.
+	for i, cid := range []string{"c1", "c2", "c3"} {
+		if err := sidecarInsert(t, d, ctx, cid, ""); err != nil {
+			t.Fatalf("NULL natural_key #%d must be allowed (both tiers treat NULLs as distinct): %v", i+1, err)
+		}
+	}
+
+	// A real key inserts once...
+	if err := sidecarInsert(t, d, ctx, "e1", "user:person:ada"); err != nil {
+		t.Fatalf("first natural_key insert: %v", err)
+	}
+	// ...and a SECOND row claiming the same key must be refused. That refusal is
+	// what makes upsert-by-natural-key idempotent instead of duplicating entities.
+	if err := sidecarInsert(t, d, ctx, "e2", "user:person:ada"); err == nil {
+		t.Error("a duplicate natural_key must be refused — without it the same entity accumulates a row per mention")
+	}
+}
+
+// TestSidecar_CascadesOnChunkDelete + ...OnDocumentDelete cover BOTH cascade
+// sites. Both are required and neither substitutes for the other: delete_document
+// walks by document, delete_chunk walks one chunk's descendant set. A sidecar row
+// reachable only through the path that was missed is an orphan nothing can see —
+// no read filters it, no sweeper reaps it.
+func TestSidecar_CascadesOnChunkDelete(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	out, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"x"}`)
+	if r.IsError {
+		t.Fatalf("create: %s", r.Text)
+	}
+	root, _ := out["root_chunk_id"].(string)
+	child, r := docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+asStr(out["document_id"])+`","parent_id":"`+root+`","title":"child"}`)
+	if r.IsError {
+		t.Fatalf("create_chunk: %s", r.Text)
+	}
+	cid, _ := child["id"].(string)
+	if cid == "" {
+		t.Fatalf("no chunk id in %v", child)
+	}
+	if err := sidecarInsert(t, d, ctx, cid, "user:person:grace"); err != nil {
+		t.Fatalf("seed sidecar: %v", err)
+	}
+
+	if _, r := docExec(t, d, ctx, `{"op":"delete_chunk","scope":"user","id":"`+cid+`"}`); r.IsError {
+		t.Fatalf("delete_chunk: %s", r.Text)
+	}
+	if n := sidecarCount(t, d, ctx); n != 0 {
+		t.Errorf("delete_chunk left %d orphaned sidecar row(s) — invisible to every read and every sweeper", n)
+	}
+}
+
+func TestSidecar_CascadesOnDocumentDelete(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	out, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"x"}`)
+	if r.IsError {
+		t.Fatalf("create: %s", r.Text)
+	}
+	docID := asStr(out["document_id"])
+	root, _ := out["root_chunk_id"].(string)
+	if err := sidecarInsert(t, d, ctx, root, "user:person:alan"); err != nil {
+		t.Fatalf("seed sidecar: %v", err)
+	}
+
+	if _, r := docExec(t, d, ctx, `{"op":"delete_document","scope":"user","id":"`+docID+`"}`); r.IsError {
+		t.Fatalf("delete_document: %s", r.Text)
+	}
+	if n := sidecarCount(t, d, ctx); n != 0 {
+		t.Errorf("delete_document left %d orphaned sidecar row(s)", n)
+	}
+}
+
+// TestSidecar_ReverseEdgeIndexExists: chunk_edges' primary key (from_id, to_id,
+// kind) serves a FORWARD walk only, so without this index every reverse hop of a
+// graph expansion scans the scope's whole edge table. It degrades only once the
+// graph is big — which is to say, only in production.
+func TestSidecar_ReverseEdgeIndexExists(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	if _, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"x"}`); r.IsError {
+		t.Fatalf("create: %s", r.Text)
+	}
+	out, r := docExec(t, d, ctx,
+		`{"op":"query_chunks","scope":"user","sql":"SELECT name FROM sqlite_master WHERE type='index' AND name='chunk_edges_to_kind'"}`)
+	if r.IsError {
+		t.Fatalf("index probe: %s", r.Text)
+	}
+	rows, _ := out["rows"].([]any)
+	if len(rows) != 1 {
+		t.Errorf("chunk_edges_to_kind index missing — every reverse graph hop would table-scan; got %v", out)
+	}
+}
+
+// TestSidecar_PostgresTierParity re-runs the two tier-sensitive assertions against
+// a REAL postgres aux database.
+//
+// The NULL-distinctness of a UNIQUE index is a per-tier property, and the whole
+// "unique per scope" decision rests on it: if postgres treated NULLs as equal, the
+// SECOND ordinary chunk in any scope would fail to insert — an immediate, total
+// break that the sqlite tier would never reveal. The reverse-edge index probe is
+// also tier-specific (sqlite_master vs pg_indexes), so it is asserted here in its
+// postgres form rather than assumed portable.
+//
+// Skipped without LOOMCYCLE_TEST_SQLMEM_PG_DSN; CI runs it in the go-postgres job.
+func TestSidecar_PostgresTierParity(t *testing.T) {
+	dsn := os.Getenv("LOOMCYCLE_TEST_SQLMEM_PG_DSN")
+	if dsn == "" {
+		t.Skip("set LOOMCYCLE_TEST_SQLMEM_PG_DSN to run the sidecar postgres-tier parity test")
+	}
+	raw, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("open raw: %v", err)
+	}
+	dropAllSqlmemScopes(t, raw)
+	mgr, err := sqlmem.NewPostgres(context.Background(), sqlmem.Config{PgDSN: dsn, StatementTimeoutMS: 30000, MaxRows: 1000})
+	if err != nil {
+		t.Fatalf("NewPostgres: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = mgr.Close()
+		dropAllSqlmemScopes(t, raw)
+		_ = raw.Close()
+	})
+	st, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	d := &Document{Store: st, SqlMem: mgr, Bus: channels.NewBus()}
+	ctx := tools.WithAgentName(context.Background(), "pg-sidecar")
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{UserID: "u1", TenantID: "tnt"})
+
+	out, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"PG sidecar"}`)
+	if r.IsError {
+		t.Fatalf("create_document(pg): %s", r.Text)
+	}
+	docID := asStr(out["document_id"])
+
+	// NULLs must remain distinct on this tier too.
+	for i, cid := range []string{"c1", "c2", "c3"} {
+		if err := sidecarInsert(t, d, ctx, cid, ""); err != nil {
+			t.Fatalf("postgres: NULL natural_key #%d must be allowed: %v", i+1, err)
+		}
+	}
+	if err := sidecarInsert(t, d, ctx, "e1", "user:person:ada"); err != nil {
+		t.Fatalf("postgres: first natural_key: %v", err)
+	}
+	if err := sidecarInsert(t, d, ctx, "e2", "user:person:ada"); err == nil {
+		t.Error("postgres: a duplicate natural_key must be refused")
+	}
+
+	// The reverse-edge index, in its postgres form.
+	res, err := mgr.Query(ctx, sidecarScope(t, d, ctx),
+		`SELECT indexname FROM pg_indexes WHERE indexname = 'chunk_edges_to_kind'`, nil)
+	if err != nil {
+		t.Fatalf("postgres index probe: %v", err)
+	}
+	if len(res.Rows) != 1 {
+		t.Error("postgres: chunk_edges_to_kind index missing — every reverse graph hop would seq-scan")
+	}
+
+	// And the cascade, on the tier where a real transaction is involved.
+	//
+	// Asserted against a row keyed to the document's REAL root chunk, not against
+	// the table emptying. The rows above carry invented chunk ids that were never
+	// attached to a chunk, so the cascade correctly leaves them — a first draft of
+	// this test asserted count==0 and "failed" on the cascade doing the right thing.
+	root := asStr(out["root_chunk_id"])
+	if root == "" {
+		t.Fatal("no root chunk id")
+	}
+	if err := sidecarInsert(t, d, ctx, root, "user:person:grace"); err != nil {
+		t.Fatalf("postgres: seed sidecar on the real root chunk: %v", err)
+	}
+	if n := sidecarRowsFor(t, d, ctx, root); n != 1 {
+		t.Fatalf("postgres: seeded row not found (got %d)", n)
+	}
+	if _, r := docExec(t, d, ctx, `{"op":"delete_document","scope":"user","id":"`+docID+`"}`); r.IsError {
+		t.Fatalf("delete_document(pg): %s", r.Text)
+	}
+	if n := sidecarRowsFor(t, d, ctx, root); n != 0 {
+		t.Errorf("postgres: delete_document left the root chunk's sidecar row orphaned (%d)", n)
+	}
+}


### PR DESCRIPTION
First of four in the P4c series — the foundation the entity tier sits on. Schema, two indexes, the cascade. **No entity semantics and no new tool surface**, so there is nothing here to argue about except the two index decisions, which are the expensive-to-change ones once a graph exists.

Plan: `/loomcycle/docs/plans/rfc-bl-p4c-plan`.

## Two timelines, which is the point of the tier

```sql
valid_at   / invalid_at   -- when the fact was true IN THE WORLD
created_at / expired_at   -- when the SYSTEM learned and retired it
```

Keeping them apart is what leaves *"as of June…"* answerable after a correction: a contradicting fact closes the old row rather than deleting it.

## Three design points, all from the architecture pass rather than the spec

**`natural_key` is a SQL column, not a chunk `field`.** The RFC specified idempotent upsert via natural keys *"carried in chunk `fields`"* — not implementable. `fields` isn't a column; it lives inside the `chunkBody` JSON blob in the Memory k/v plane. *"Does this entity already exist?"* would have meant reading every chunk body out of Memory and parsing it: **O(n) on the one operation an entity graph performs constantly.**

UNIQUE **per scope** per your decision. Each scope owns its own database, so a bare unique index on the column *is* scope-wide. The column is nullable and almost every chunk leaves it unset, which makes NULL-distinctness load-bearing — if a tier treated NULLs as equal, the **second** ordinary chunk in any scope would fail to insert. Asserted on both tiers.

**Created unconditionally**, per your decision. The tier is opt-in at the level of "does this scope have entities", not "does the table exist". A gated DDL would let a scope exist in two shapes and force every later read to ask which.

**`chunk_edges` gains a reverse index.** Its PK `(from_id, to_id, kind)` serves a forward walk only, so without `(to_id, kind)` every reverse hop of a graph expansion scans the scope's entire edge table — degrading only once the graph is large enough to matter.

## The cascade has two sites and both are required

`delete_document` walks by document; `delete_chunk` walks one chunk's descendant set. Neither substitutes for the other, and a sidecar row reachable only through the path that was missed is an orphan **nothing can see** — no read filters it, no sweeper reaps it. That's the dead-link class this schema's no-foreign-keys discipline exists to prevent.

## No migration

Per-scope SQL Memory table created lazily by `ensureSchema`, not a main-store table. No golang-migrate step, no `VerifySchemaCurrent` gate, no upgrade ordering. Worth saying because a new table normally implies a migration here and this one doesn't.

## What was tested

`go test ./...` — 85 packages green on both tiers. `gofmt` clean.

**Fail-before verified three times:** each cascade site disabled → the corresponding test reports orphaned rows; the unique index dropped → the duplicate `natural_key` stops being refused.

**The postgres parity test earned its place immediately**, catching two things the sqlite tier waved through:

1. my helper writing `?` placeholders, which pgx rejects — the tool goes through `Manager.Rebind` and my helper had bypassed it
2. **my own assertion being wrong** — a first draft asserted the whole sidecar table empties after `delete_document`, and it "failed" on the cascade doing the *right* thing, correctly leaving rows whose invented chunk ids were never attached to a chunk. It now asserts against the real root chunk's row.

## Next

PR 2 is the entity/fact write path **with the curator gate in the same PR** — deliberately coupled, because P4b shipped a tenant scope whose Document path had no grant check and it took two rounds of you asking to surface it. A write surface and its authority are one change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)