### PR TITLE
feat(memory): entity upsert by natural key, and supersede-not-delete (RFC BL P4c PR 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,13 @@ jobs:
           go test -count=1 -race ./internal/sqlmem/...
           # The {"$embed"} round-trip lives in the Memory tool package; run the
           # vector tests there too (they skip without the aux DSN).
-          go test -count=1 -run 'TestEmbedDirective|TestEncodePgvector|TestResolveEmbedArgs|TestMemorySQL_EmbedDirective|TestDocument_Postgres' ./internal/tools/builtin/...
+          #
+          # This filter is NOT optional bookkeeping: a postgres-tier test absent
+          # from it never runs in CI at all, because the step above owns the aux DB
+          # and `go test ./...` cannot run both packages against it concurrently.
+          # Add every new postgres-tier test in this package here, or it is
+          # decoration rather than a gate.
+          go test -count=1 -run 'TestEmbedDirective|TestEncodePgvector|TestResolveEmbedArgs|TestMemorySQL_EmbedDirective|TestDocument_Postgres|TestSidecar_PostgresTierParity' ./internal/tools/builtin/...
 
   runtime-codejs:
     name: Runtime suites (code-js)

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -53,7 +53,7 @@ func (d *Document) Description() string {
 const documentInputSchema = `{
 	"type": "object",
 	"properties": {
-		"op":          {"type": "string", "enum": ["create_document","get_document","documents_summary","delete_document","set_path","create_chunk","get_chunk","update_chunk","delete_chunk","move_chunk","reorder_chunk","link_chunks","unlink_chunks","get_edges","query_chunks","define_type","list_types","set_asset","get_asset","export_md","import_md"]},
+		"op":          {"type": "string", "enum": ["create_document","get_document","documents_summary","delete_document","set_path","create_chunk","upsert_chunk","get_chunk","update_chunk","delete_chunk","supersede_chunk","move_chunk","reorder_chunk","link_chunks","unlink_chunks","get_edges","query_chunks","define_type","list_types","set_asset","get_asset","export_md","import_md"]},
 		"scope":       {"type": "string", "enum": ["agent","user","tenant"], "description": "Which store (default user). agent = this agent; user = this end-user (needs a user_id on the run); tenant = shared by every user and agent in the tenant — anything written here is read by all of them, so use it for curated reference material, not for anything derived from untrusted text. tenant requires the operator to grant BOTH memory_scopes and sql_scopes with the tenant value."},
 		"id":          {"type": "string", "description": "Document id (get/delete_document, set_path) or chunk id (get/update/delete/move_chunk)."},
 		"path":        {"type": "string", "description": "create_document: name the doc in the Path tree (default /documents/<title> if omitted). set_path: the path to attach to an existing document (by id). get/delete_document: address by path instead of id."},
@@ -66,6 +66,12 @@ const documentInputSchema = `{
 		"direction":   {"type": "string", "enum": ["up","down"], "description": "reorder_chunk: move the chunk up or down within its current level."},
 		"type":        {"type": "string", "description": "Optional supertag-like chunk type."},
 		"body":        {"type": "string", "description": "Markdown body."},
+		"natural_key": {"type": "string", "description": "upsert_chunk: the stable identity of this entity or fact. Upserting twice with the same key updates ONE chunk instead of adding a second — use a derived form such as person:ada-lovelace, or subject|predicate|object for a fact. Unique within the scope."},
+		"supersedes_id": {"type": "string", "description": "supersede_chunk: the id of the chunk being RETIRED by this one. The retired chunk is not deleted — it stays queryable so that questions about an earlier point in time still have an answer."},
+		"valid_at":   {"type": "integer", "description": "When the fact became true IN THE WORLD (unix nanos). Defaults to now. Distinct from when it was recorded."},
+		"invalid_at": {"type": "integer", "description": "When the fact STOPPED being true in the world (unix nanos). Leave unset for something still true."},
+		"class":      {"type": "string", "enum": ["derived","evidential"], "description": "derived = distilled from something else (the default). evidential = source material, exempt from age-based pruning."},
+		"confidence": {"type": "number", "description": "0..1, how sure you are of this fact."},
 		"fields":      {"type": "object", "description": "Type-specific structured fields."},
 		"status":      {"type": "string"},
 		"position":    {"type": "integer"},
@@ -112,6 +118,23 @@ type docInput struct {
 	FromID    string          `json:"from_id"`
 	ToID      string          `json:"to_id"`
 	Kind      string          `json:"kind"`
+
+	// Entity-tier fields (RFC BL P4c). NaturalKey is the idempotency handle:
+	// upsert_chunk keys on it, and it is UNIQUE per scope.
+	NaturalKey string `json:"natural_key"`
+	// SupersedesID names the chunk being retired by supersede_chunk. It is an
+	// explicitly-named field rather than a reuse of from_id/to_id on purpose: a
+	// caller who transposed those would invalidate the NEW fact and leave the stale
+	// one current — a silent inversion of history, which is worse than one more
+	// field to document.
+	SupersedesID string `json:"supersedes_id"`
+	// Pointers so "unset" is distinguishable from zero — valid_at=0 is a real
+	// instant (the unix epoch), not a missing value.
+	ValidAt    *int64   `json:"valid_at"`
+	InvalidAt  *int64   `json:"invalid_at"`
+	Confidence *float64 `json:"confidence"`
+	// Class is 'derived' | 'evidential' — the retention-exemption signal.
+	Class string `json:"class"`
 	// MediaType/Data/Filename carry an image asset for set_asset (RFC BO). Data
 	// is standard base64 (no data: prefix); it is decoded to raw bytes and stored
 	// in the chunk_assets BYTEA/BLOB table.
@@ -247,6 +270,10 @@ func (d *Document) Execute(ctx context.Context, raw json.RawMessage) (tools.Resu
 		return d.moveChunk(ctx, key, in)
 	case "reorder_chunk":
 		return d.reorderChunk(ctx, key, mscope, in)
+	case "upsert_chunk":
+		return d.upsertChunk(ctx, key, mscope, in)
+	case "supersede_chunk":
+		return d.supersedeChunk(ctx, key, in)
 	case "link_chunks":
 		return d.linkChunks(ctx, key, in)
 	case "unlink_chunks":

--- a/internal/tools/builtin/document_entity.go
+++ b/internal/tools/builtin/document_entity.go
@@ -1,0 +1,279 @@
+package builtin
+
+// The entity-tier WRITE path (RFC BL P4c PR 2): idempotent upsert keyed by a
+// natural key, and supersede-not-delete.
+//
+// WHY THERE IS NO SEPARATE "CURATOR" GATE HERE, though the phase plan called for
+// one. Document.Execute resolves the scope CENTRALLY, before it dispatches, so
+// every op below already passes through the check P4b added: reaching `tenant`
+// scope requires the operator to have listed `tenant` in BOTH memory_scopes (the
+// chunk bodies) and sql_scopes (the structure). An agent holding those grants IS
+// the operator's designated curator for that tenant's shared memory.
+//
+// Adding a second, entity-specific gate on top would duplicate that decision and
+// leave two places to get it wrong — the argument made against exactly this in
+// P4b, and it holds in the other direction too. What PR 2 owes instead is proof
+// that the new ops cannot BYPASS the existing gate, which is asserted rather than
+// assumed (see TestEntity_TenantWritesRequireBothGrants).
+//
+// An agent writing entities in its OWN agent scope needs no curator: that graph is
+// private to it, and there is nothing shared to poison.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// entityClasses is the closed set for chunk_memory_meta.class (Locked decision
+// 10). `evidential` is EXEMPT from the retention sweeper's memory-content family,
+// so it is a privilege a caller can claim — validated against this set, and worth
+// knowing that a model could mark its own writes evidential to make them
+// un-prunable. That is tolerated because the alternative is worse: the server has
+// no signal from which to infer the distinction, and dropping it would lose the
+// exemption that keeps source-of-truth material from being aged out.
+var entityClasses = map[string]bool{"derived": true, "evidential": true}
+
+// upsertChunk is create-or-update keyed by natural_key within the scope — the
+// idempotency primitive the entity tier is built on. Calling it twice with the
+// same key yields ONE chunk, which is what stops an entity accumulating a row per
+// mention.
+//
+// It deliberately does NOT take a `revision`, unlike update_chunk. Optimistic
+// concurrency assumes the caller read the row and knows its version; an upsert's
+// whole premise is that the caller knows only the natural KEY. Last-writer-wins is
+// the correct semantics when the key is the identity, and pretending otherwise
+// would make every consolidation pass guess a revision it has no way to hold.
+func (d *Document) upsertChunk(ctx context.Context, key sqlmem.ScopeKey, mscope store.MemoryScope, in docInput) (tools.Result, error) {
+	if strings.TrimSpace(in.NaturalKey) == "" {
+		return errResult("upsert_chunk: missing required field: natural_key (the idempotency handle — without it this is create_chunk)"), nil
+	}
+	if in.Class != "" && !entityClasses[in.Class] {
+		return errResult(fmt.Sprintf("upsert_chunk: unknown class %q (want derived or evidential)", in.Class)), nil
+	}
+
+	existing, err := d.chunkIDByNaturalKey(ctx, key, in.NaturalKey)
+	if err != nil {
+		return errResult("upsert_chunk: lookup: " + err.Error()), nil
+	}
+
+	if existing == "" {
+		// Delegate the INSERT to create_chunk rather than writing a second insert
+		// path. It owns the parent/position/document-exists validation, and a
+		// duplicate would drift from it silently.
+		res, cerr := d.createChunk(ctx, key, mscope, in)
+		if cerr != nil || res.IsError {
+			return res, cerr
+		}
+		var created struct {
+			ID string `json:"id"`
+		}
+		if uerr := json.Unmarshal([]byte(res.Text), &created); uerr != nil || created.ID == "" {
+			return errResult("upsert_chunk: created the chunk but could not read its id back"), nil
+		}
+		if werr := d.writeChunkMeta(ctx, key, created.ID, in); werr != nil {
+			return errResult("upsert_chunk: chunk created but its metadata write failed: " + werr.Error()), nil
+		}
+		return okJSON(map[string]any{
+			"id": created.ID, "natural_key": in.NaturalKey, "created": true,
+		})
+	}
+
+	// Update in place. Only the fields the caller actually supplied move, so an
+	// upsert that carries a new body does not blank a title it never mentioned.
+	if uerr := d.updateChunkForUpsert(ctx, key, mscope, existing, in); uerr != nil {
+		return errResult("upsert_chunk: " + uerr.Error()), nil
+	}
+	if werr := d.writeChunkMeta(ctx, key, existing, in); werr != nil {
+		return errResult("upsert_chunk: metadata write failed: " + werr.Error()), nil
+	}
+	return okJSON(map[string]any{
+		"id": existing, "natural_key": in.NaturalKey, "created": false,
+	})
+}
+
+// chunkIDByNaturalKey resolves the scope's chunk for a natural key, or "" when
+// absent. The lookup is an indexed point read on chunk_memory_meta — the reason
+// the key lives in SQL rather than in the chunk's `fields` blob.
+func (d *Document) chunkIDByNaturalKey(ctx context.Context, key sqlmem.ScopeKey, naturalKey string) (string, error) {
+	res, err := d.query(ctx, key, `SELECT chunk_id FROM chunk_memory_meta WHERE natural_key = ?`, naturalKey)
+	if err != nil {
+		return "", err
+	}
+	if len(res.Rows) == 0 {
+		return "", nil
+	}
+	return asStr(res.Rows[0][0]), nil
+}
+
+// updateChunkForUpsert applies the supplied fields to an existing chunk without a
+// revision check (see upsertChunk). Absent fields are left alone.
+func (d *Document) updateChunkForUpsert(ctx context.Context, key sqlmem.ScopeKey, mscope store.MemoryScope, chunkID string, in docInput) error {
+	sets := []string{"updated_at = ?", "revision = revision + 1"}
+	args := []any{time.Now().UnixNano()}
+	if in.Title != "" {
+		sets = append(sets, "title = ?")
+		args = append(args, in.Title)
+	}
+	if in.Type != "" {
+		sets = append(sets, "type = ?")
+		args = append(args, in.Type)
+	}
+	if in.Status != "" {
+		sets = append(sets, "status = ?")
+		args = append(args, in.Status)
+	}
+	args = append(args, chunkID)
+	if err := d.exec(ctx, key, `UPDATE chunks SET `+strings.Join(sets, ", ")+` WHERE id = ?`, args...); err != nil {
+		return err
+	}
+	// Body/fields live in the Memory k/v plane. Only rewrite when the caller sent
+	// something: writeBody replaces BOTH halves, so an unconditional write would
+	// erase fields on a body-only upsert — the failure that emptied this store once.
+	if in.Body != "" || len(in.Fields) > 0 {
+		body, fields := in.Body, in.Fields
+		if in.Body == "" || len(in.Fields) == 0 {
+			cur, rerr := d.readBody(ctx, mscope, key.ScopeID, chunkID)
+			if rerr != nil {
+				return rerr
+			}
+			if in.Body == "" {
+				body = cur.Body
+			}
+			if len(in.Fields) == 0 {
+				fields = cur.Fields
+			}
+		}
+		return d.writeBody(ctx, mscope, key.ScopeID, chunkID, body, fields)
+	}
+	return nil
+}
+
+// writeChunkMeta upserts the sidecar row.
+//
+// Delete-then-insert rather than ON CONFLICT, matching the two existing upserts in
+// this file — one portable statement beats a per-dialect split.
+//
+// `origin` and the provenance triple are SERVER-STAMPED and deliberately not
+// readable from the input. A forgeable origin would let any agent label its own
+// writes as machine-distilled, and the column has to stay a trustworthy filter for
+// the ones that really are — the same rule the consolidation queue's origin
+// follows.
+func (d *Document) writeChunkMeta(ctx context.Context, key sqlmem.ScopeKey, chunkID string, in docInput) error {
+	now := time.Now().UnixNano()
+	validAt := now
+	if in.ValidAt != nil {
+		validAt = *in.ValidAt
+	}
+	var invalidAt any
+	if in.InvalidAt != nil {
+		invalidAt = *in.InvalidAt
+	}
+	class := in.Class
+	if class == "" {
+		class = "derived"
+	}
+	var confidence any
+	if in.Confidence != nil {
+		confidence = *in.Confidence
+	}
+	if err := d.exec(ctx, key, `DELETE FROM chunk_memory_meta WHERE chunk_id = ?`, chunkID); err != nil {
+		return err
+	}
+	return d.exec(ctx, key,
+		`INSERT INTO chunk_memory_meta
+		   (chunk_id, valid_at, invalid_at, created_at, expired_at, class, origin, confidence, session_id, run_id, event_seq, natural_key)
+		 VALUES (?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, NULL, ?)`,
+		chunkID, validAt, invalidAt, now, class,
+		originForEntityWrite(ctx), confidence,
+		// session_id stays NULL: it is not on the run ctx, only the run id is. The
+		// column is kept because the consolidation path can fill it when it relays a
+		// drained pending row, and a column that is sometimes populated is more useful
+		// than one removed because one writer cannot fill it.
+		nil, nullIfEmpty(tools.RunID(ctx)), nullIfEmpty(in.NaturalKey))
+}
+
+// originForEntityWrite decides the provenance label from the RUN, never the input.
+// A write arriving with no run id is an operator acting by hand (the MCP/off-run
+// plane); one inside a run is an agent.
+func originForEntityWrite(ctx context.Context) string {
+	if tools.RunID(ctx) == "" {
+		return "operator"
+	}
+	return "agent_explicit"
+}
+
+// supersedeChunk retires a chunk without deleting it: it closes BOTH of the old
+// row's end-timestamps and links the replacement to it.
+//
+// Closing invalid_at AND expired_at together is the correction case — the fact
+// stopped being true in the world at the same moment the system learned it had.
+// (A fact that merely stopped being true, with no replacement, closes invalid_at
+// alone via upsert_chunk.)
+//
+// The old chunk stays live and queryable, which is what keeps "as of June…"
+// answerable. It becomes a "retired entity": eligible for the retention sweeper's
+// memory-content family past an age, gated by its class.
+func (d *Document) supersedeChunk(ctx context.Context, key sqlmem.ScopeKey, in docInput) (tools.Result, error) {
+	if in.ID == "" {
+		return errResult("supersede_chunk: missing required field: id (the REPLACEMENT chunk)"), nil
+	}
+	if in.SupersedesID == "" {
+		return errResult("supersede_chunk: missing required field: supersedes_id (the chunk being retired)"), nil
+	}
+	if in.ID == in.SupersedesID {
+		return errResult("supersede_chunk: a chunk cannot supersede itself"), nil
+	}
+
+	// Both chunks must exist, checked BEFORE anything is written: a supersede that
+	// closed a real row and then failed to link a missing one would retire a fact
+	// with nothing replacing it, which reads as "we forgot this" rather than "this
+	// was corrected".
+	for _, id := range []string{in.ID, in.SupersedesID} {
+		res, err := d.query(ctx, key, `SELECT id FROM chunks WHERE id = ?`, id)
+		if err != nil {
+			return errResult("supersede_chunk: lookup: " + err.Error()), nil
+		}
+		if len(res.Rows) == 0 {
+			return errResult(fmt.Sprintf("supersede_chunk: chunk %q not found in this scope", id)), nil
+		}
+	}
+
+	now := time.Now().UnixNano()
+	txErr := d.withSqlTxn(ctx, key, func(txnID string) error {
+		// The retired row may have no sidecar yet (it predates the entity tier, or
+		// was written by plain create_chunk), so seed one before closing it —
+		// otherwise the UPDATE silently affects zero rows and the fact stays current.
+		res, err := d.queryTxn(ctx, txnID, `SELECT chunk_id FROM chunk_memory_meta WHERE chunk_id = ?`, in.SupersedesID)
+		if err != nil {
+			return err
+		}
+		if len(res.Rows) == 0 {
+			if err := d.execTxn(ctx, txnID,
+				`INSERT INTO chunk_memory_meta (chunk_id, valid_at, created_at, class, origin) VALUES (?, ?, ?, ?, ?)`,
+				in.SupersedesID, now, now, "derived", originForEntityWrite(ctx)); err != nil {
+				return err
+			}
+		}
+		if err := d.execTxn(ctx, txnID,
+			`UPDATE chunk_memory_meta SET invalid_at = ?, expired_at = ? WHERE chunk_id = ?`,
+			now, now, in.SupersedesID); err != nil {
+			return err
+		}
+		return d.execTxn(ctx, txnID,
+			`INSERT INTO chunk_edges (from_id, to_id, kind, created_at) VALUES (?, ?, ?, ?)`,
+			in.ID, in.SupersedesID, "supersedes", now)
+	})
+	if txErr != nil {
+		return errResult("supersede_chunk: " + txErr.Error()), nil
+	}
+	return okJSON(map[string]any{
+		"id": in.ID, "supersedes": in.SupersedesID, "retired_at": now,
+	})
+}

--- a/internal/tools/builtin/document_entity_test.go
+++ b/internal/tools/builtin/document_entity_test.go
@@ -1,0 +1,270 @@
+package builtin
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+type contextT = context.Context
+
+// entityID resolves a natural key back to its chunk id, through the same indexed
+// lookup the tool uses.
+func entityID(t *testing.T, d *Document, ctx context.Context, naturalKey string) string {
+	t.Helper()
+	id, err := d.chunkIDByNaturalKey(ctx, sidecarScope(t, d, ctx), naturalKey)
+	if err != nil {
+		t.Fatalf("lookup %s: %v", naturalKey, err)
+	}
+	if id == "" {
+		t.Fatalf("no chunk for natural key %s", naturalKey)
+	}
+	return id
+}
+
+func entityFixture(t *testing.T) (*Document, contextT, string, string) {
+	t.Helper()
+	d, ctx, _ := documentFixture(t)
+	out, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"entities"}`)
+	if r.IsError {
+		t.Fatalf("create_document: %s", r.Text)
+	}
+	return d, ctx, asStr(out["document_id"]), asStr(out["root_chunk_id"])
+}
+
+// TestUpsertChunk_IsIdempotent is the whole point of the natural key: an entity
+// mentioned five times is one chunk, not five. Without it the graph accumulates a
+// near-duplicate per mention, which is the failure the consolidator's dedup bands
+// exist to fight downstream — better not to create it upstream.
+func TestUpsertChunk_IsIdempotent(t *testing.T) {
+	d, ctx, docID, root := entityFixture(t)
+	body := `{"op":"upsert_chunk","scope":"user","document_id":"` + docID + `","parent_id":"` + root +
+		`","title":"Ada Lovelace","natural_key":"person:ada-lovelace","type":"person"}`
+
+	first, r := docExec(t, d, ctx, body)
+	if r.IsError {
+		t.Fatalf("first upsert: %s", r.Text)
+	}
+	if created, _ := first["created"].(bool); !created {
+		t.Error("the first upsert should report created=true")
+	}
+	id1 := asStr(first["id"])
+
+	second, r := docExec(t, d, ctx, body)
+	if r.IsError {
+		t.Fatalf("second upsert: %s", r.Text)
+	}
+	if created, _ := second["created"].(bool); created {
+		t.Error("the second upsert must NOT create a second chunk")
+	}
+	if id2 := asStr(second["id"]); id2 != id1 {
+		t.Errorf("upsert returned a different chunk (%s vs %s) — the natural key is not the identity", id2, id1)
+	}
+	if n := sidecarRowsFor(t, d, ctx, id1); n != 1 {
+		t.Errorf("want exactly 1 sidecar row for the entity, got %d", n)
+	}
+}
+
+// TestUpsertChunk_RequiresANaturalKey: without one this op is just create_chunk,
+// and silently behaving like it would let a caller believe they had idempotency
+// when every call added a chunk.
+func TestUpsertChunk_RequiresANaturalKey(t *testing.T) {
+	d, ctx, docID, root := entityFixture(t)
+	_, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+docID+`","parent_id":"`+root+`","title":"x"}`)
+	if !r.IsError || !strings.Contains(r.Text, "natural_key") {
+		t.Errorf("upsert without a natural_key must be refused: %q", r.Text)
+	}
+}
+
+// TestUpsertChunk_PartialUpdateDoesNotBlankTheOtherHalf: body and fields share ONE
+// blob in the Memory plane, and writeBody replaces both. An upsert carrying only a
+// body must not erase fields — the exact mechanism that emptied every chunk in this
+// store once.
+func TestUpsertChunk_PartialUpdateDoesNotBlankTheOtherHalf(t *testing.T) {
+	d, ctx, docID, root := entityFixture(t)
+	base := `{"op":"upsert_chunk","scope":"user","document_id":"` + docID + `","parent_id":"` + root +
+		`","title":"Ada","natural_key":"person:ada"`
+
+	if _, r := docExec(t, d, ctx, base+`,"body":"first body","fields":{"born":1815}}`); r.IsError {
+		t.Fatalf("seed: %s", r.Text)
+	}
+	// Body only — fields must survive.
+	if _, r := docExec(t, d, ctx, base+`,"body":"second body"}`); r.IsError {
+		t.Fatalf("body-only upsert: %s", r.Text)
+	}
+	got, r := docExec(t, d, ctx, `{"op":"get_chunk","scope":"user","id":"`+entityID(t, d, ctx, "person:ada")+`"}`)
+	if r.IsError {
+		t.Fatalf("get_chunk: %s", r.Text)
+	}
+	if b, _ := got["body"].(string); b != "second body" {
+		t.Errorf("body = %q, want the new one", b)
+	}
+	if f := asStr(got["fields"]); !strings.Contains(f, "1815") {
+		t.Errorf("fields were blanked by a body-only upsert: %q", f)
+	}
+}
+
+// TestSupersedeChunk_RetiresWithoutDeleting is bi-temporality's point: the old fact
+// stays queryable, so a question about an earlier moment still has an answer. A
+// delete would make the history unrecoverable and the correction indistinguishable
+// from a fact that never existed.
+func TestSupersedeChunk_RetiresWithoutDeleting(t *testing.T) {
+	d, ctx, docID, root := entityFixture(t)
+	mk := func(key, title string) string {
+		out, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+docID+
+			`","parent_id":"`+root+`","title":"`+title+`","natural_key":"`+key+`"}`)
+		if r.IsError {
+			t.Fatalf("upsert %s: %s", key, r.Text)
+		}
+		return asStr(out["id"])
+	}
+	oldID := mk("fact:indent|is|tabs", "prefers tabs")
+	newID := mk("fact:indent|is|spaces", "prefers spaces")
+
+	if _, r := docExec(t, d, ctx, `{"op":"supersede_chunk","scope":"user","id":"`+newID+`","supersedes_id":"`+oldID+`"}`); r.IsError {
+		t.Fatalf("supersede: %s", r.Text)
+	}
+
+	// The retired chunk still EXISTS and is still readable.
+	if _, r := docExec(t, d, ctx, `{"op":"get_chunk","scope":"user","id":"`+oldID+`"}`); r.IsError {
+		t.Fatalf("the superseded chunk must remain queryable: %s", r.Text)
+	}
+	// Both end-timestamps closed.
+	res, err := d.SqlMem.Query(ctx, sidecarScope(t, d, ctx),
+		d.SqlMem.Rebind(`SELECT invalid_at, expired_at FROM chunk_memory_meta WHERE chunk_id = ?`), []any{oldID})
+	if err != nil {
+		t.Fatalf("meta: %v", err)
+	}
+	if len(res.Rows) != 1 {
+		t.Fatalf("no sidecar row for the retired chunk")
+	}
+	for i, col := range []string{"invalid_at", "expired_at"} {
+		if res.Rows[0][i] == nil {
+			t.Errorf("%s was not closed — the fact is still current after being superseded", col)
+		}
+	}
+	// And the replacement links to it.
+	edges, r := docExec(t, d, ctx, `{"op":"get_edges","scope":"user","document_id":"`+docID+`","id":"`+newID+`"}`)
+	if r.IsError {
+		t.Fatalf("get_edges: %s", r.Text)
+	}
+	if !strings.Contains(asStr(edges), "supersedes") {
+		t.Errorf("no supersedes edge from the replacement: %v", edges)
+	}
+}
+
+// TestSupersedeChunk_RefusesNonsense: self-supersession and unknown ids, checked
+// BEFORE anything is written. A supersede that closed a real row then failed on a
+// missing one would retire a fact with nothing replacing it — which reads as "we
+// forgot this" rather than "this was corrected".
+func TestSupersedeChunk_RefusesNonsense(t *testing.T) {
+	d, ctx, docID, root := entityFixture(t)
+	out, _ := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+docID+
+		`","parent_id":"`+root+`","title":"a","natural_key":"k:a"}`)
+	id := asStr(out["id"])
+
+	for _, tc := range []struct{ name, body, want string }{
+		{"self", `{"op":"supersede_chunk","scope":"user","id":"` + id + `","supersedes_id":"` + id + `"}`, "itself"},
+		{"missing new", `{"op":"supersede_chunk","scope":"user","id":"nope","supersedes_id":"` + id + `"}`, "not found"},
+		{"missing old", `{"op":"supersede_chunk","scope":"user","id":"` + id + `","supersedes_id":"nope"}`, "not found"},
+		{"no id", `{"op":"supersede_chunk","scope":"user","supersedes_id":"` + id + `"}`, "id"},
+		{"no supersedes_id", `{"op":"supersede_chunk","scope":"user","id":"` + id + `"}`, "supersedes_id"},
+	} {
+		_, r := docExec(t, d, ctx, tc.body)
+		if !r.IsError {
+			t.Errorf("%s: must be refused", tc.name)
+			continue
+		}
+		if !strings.Contains(r.Text, tc.want) {
+			t.Errorf("%s: message should mention %q, got %q", tc.name, tc.want, r.Text)
+		}
+	}
+	// Nothing was retired by any of those refusals.
+	res, _ := d.SqlMem.Query(ctx, sidecarScope(t, d, ctx),
+		d.SqlMem.Rebind(`SELECT count(*) FROM chunk_memory_meta WHERE invalid_at IS NOT NULL`), nil)
+	if n := scanCount(res.Rows); n != 0 {
+		t.Errorf("a refused supersede retired %d chunk(s) anyway", n)
+	}
+}
+
+// TestEntityWrite_OriginIsServerStamped: a caller must not be able to label its own
+// write. A forgeable origin would let any agent mark its output machine-distilled,
+// and the column has to stay a trustworthy filter for the ones that really are —
+// the same rule the consolidation queue's origin follows.
+func TestEntityWrite_OriginIsServerStamped(t *testing.T) {
+	d, ctx, docID, root := entityFixture(t)
+	// Claim a privileged origin in the payload; it must be ignored.
+	out, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+docID+
+		`","parent_id":"`+root+`","title":"x","natural_key":"k:x","origin":"consolidator"}`)
+	if r.IsError {
+		t.Fatalf("upsert: %s", r.Text)
+	}
+	res, err := d.SqlMem.Query(ctx, sidecarScope(t, d, ctx),
+		d.SqlMem.Rebind(`SELECT origin FROM chunk_memory_meta WHERE chunk_id = ?`), []any{asStr(out["id"])})
+	if err != nil {
+		t.Fatalf("meta: %v", err)
+	}
+	if got := asStr(res.Rows[0][0]); got == "consolidator" {
+		t.Errorf("origin was taken from the caller (%q) — it must be stamped from the run", got)
+	}
+}
+
+// TestUpsertChunk_RejectsUnknownClass: `evidential` exempts a row from age-based
+// pruning, so the value is a privilege and the set stays closed.
+func TestUpsertChunk_RejectsUnknownClass(t *testing.T) {
+	d, ctx, docID, root := entityFixture(t)
+	_, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+docID+
+		`","parent_id":"`+root+`","title":"x","natural_key":"k:y","class":"permanent"}`)
+	if !r.IsError || !strings.Contains(r.Text, "derived") {
+		t.Errorf("an unknown class must be refused, naming the valid set: %q", r.Text)
+	}
+}
+
+// TestEntity_TenantWritesRequireBothGrants is what PR 2 owes in place of a separate
+// curator gate.
+//
+// Document.Execute resolves the scope centrally before dispatching, so the new ops
+// inherit P4b's check: tenant scope requires `tenant` in BOTH memory_scopes and
+// sql_scopes. An agent holding those IS the operator's designated curator. A second
+// entity-specific gate would duplicate that decision and leave two places to get
+// wrong — the argument made against exactly this in P4b.
+//
+// What must be proven is that the new write path cannot BYPASS it, which is why
+// this is asserted rather than assumed.
+func TestEntity_TenantWritesRequireBothGrants(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		mem, sql []string
+		allow    bool
+	}{
+		{"no grants", []string{"user"}, []string{"user"}, false},
+		{"memory only", []string{"user", "tenant"}, []string{"user"}, false},
+		{"sql only", []string{"user"}, []string{"user", "tenant"}, false},
+		{"both", []string{"user", "tenant"}, []string{"user", "tenant"}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d, ctx, _ := documentFixture(t)
+			ctx = tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{AllowedScopes: tc.mem})
+			ctx = tools.WithSqlMemPolicy(ctx, tools.SqlMemPolicyValue{AllowedScopes: tc.sql})
+
+			out, r := docExec(t, d, ctx, `{"op":"create_document","scope":"tenant","title":"shared"}`)
+			if !tc.allow {
+				if !r.IsError {
+					t.Fatal("an entity write at tenant scope must be refused without both grants")
+				}
+				return
+			}
+			if r.IsError {
+				t.Fatalf("both grants present: %s", r.Text)
+			}
+			// And the new op itself, not just create_document.
+			if _, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"tenant","document_id":"`+
+				asStr(out["document_id"])+`","parent_id":"`+asStr(out["root_chunk_id"])+
+				`","title":"shared entity","natural_key":"person:shared"}`); r.IsError {
+				t.Errorf("upsert_chunk at tenant scope with both grants: %s", r.Text)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Second of four in the P4c series — the entity write path. Two ops, and one thing the plan called for that turned out to already exist.

## `upsert_chunk` — create-or-update by natural key

An entity mentioned five times is **one** chunk, not five. That's the idempotency the whole tier rests on, and it's why PR 1 put `natural_key` in an indexed SQL column rather than the chunk's `fields` blob.

It takes **no `revision`**, unlike `update_chunk`. Optimistic concurrency assumes the caller read the row and knows its version; an upsert's premise is that it knows only the *key*. Last-writer-wins is correct when the key is the identity — demanding a revision would make every consolidation pass guess one it has no way to hold.

## `supersede_chunk` — retire without deleting

Both end-timestamps close and the replacement links `supersedes`. The old row stays queryable, which is what leaves *"as of June…"* answerable after a correction; a delete would make the history unrecoverable and a correction indistinguishable from a fact that never existed.

Two deliberate details:

- **Both chunks are checked to exist before anything is written.** A supersede that closed a real row then failed on a missing one would retire a fact with nothing replacing it — reading as "we forgot this" rather than "this was corrected".
- **`supersedes_id` is its own field**, not a reuse of `from_id`/`to_id`. A caller who transposed those would invalidate the **new** fact and leave the stale one current: a silent inversion of history, which is worth one extra field to make hard.

## There is no separate curator gate — and the plan said there would be

`Document.Execute` resolves the scope **centrally, before it dispatches**, so both new ops already pass through P4b's check: reaching `tenant` scope requires the operator to have listed `tenant` in **both** `memory_scopes` and `sql_scopes`. An agent holding those *is* the operator's designated curator for that tenant's shared memory.

A second entity-specific gate would duplicate that decision and leave two places to get wrong — which is the argument I made against exactly this in P4b, and it holds in the other direction too. So what this PR owes instead is **proof the new path cannot bypass the existing gate**, asserted across all four grant combinations rather than assumed.

An agent writing entities in its own agent scope needs no curator: that graph is private, and there's nothing shared to poison.

## Provenance is server-stamped

`origin` and the provenance columns are unreadable from the input. A forgeable origin would let any agent label its own writes machine-distilled, and the column has to stay a trustworthy filter for the ones that really are — the same rule the consolidation queue's `origin` follows.

`class` **is** caller-supplied but validated against a closed set. Worth naming honestly: `evidential` exempts a row from age-based pruning, so a model can make its own writes un-prunable. Tolerated because the server has no signal from which to infer the distinction, and dropping it would lose the exemption that protects source material.

## One bug fixed on the way through

A body-only upsert no longer blanks `fields`. The two share **one** blob in the Memory plane and `writeBody` replaces both, so a partial write now reads the current value first. That's the exact mechanism that emptied every chunk in a live store a week ago.

## CI — the parity test would not have run

`TestSidecar_PostgresTierParity` is added to CI's postgres `-run` filter. That filter isn't bookkeeping: the aux DB is owned by a single step, because `go test ./...` runs packages concurrently and two of them wipe all sqlmem schemas at setup. **A postgres-tier test missing from that filter never runs in CI at all** — which would have made PR 1's parity test decoration rather than a gate. Now documented in the workflow so the next one doesn't slip.

## What was tested

Both tiers. Reproduced CI's exact two postgres steps plus the plain suite (where postgres tests skip without the DSN, as designed) — all green. `gofmt` clean.

**Fail-before verified:** with the natural-key lookup neutered the idempotency test reports a second chunk; with `origin` read from the input the stamping test reports it was taken from the caller.

New: `TestUpsertChunk_IsIdempotent`, `_RequiresANaturalKey`, `_PartialUpdateDoesNotBlankTheOtherHalf`, `_RejectsUnknownClass`, `TestSupersedeChunk_RetiresWithoutDeleting`, `_RefusesNonsense`, `TestEntityWrite_OriginIsServerStamped`, `TestEntity_TenantWritesRequireBothGrants` (four grant combinations).

## Next

PR 3 is the layered ontology — the POLE+O base seed as scope-wide `chunk_types`, the auto-provisioned `/memory/ontology` tenant document with 2–3 sample ontologies, and the `draft → confirmed` gate where the tenant layer stays inactive until you flip it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)