### PR TITLE
feat(sandbox): deterministic code-js dev/exec, retiring the LLM dev/sandbox

### DIFF
--- a/bundles/dev-exec/loomcycle.yaml
+++ b/bundles/dev-exec/loomcycle.yaml
@@ -1,0 +1,203 @@
+# RFC AQ embedded bundle: dev-exec
+#
+# Deterministic, zero-token code-js agent (RFC J) that EXECUTES a caller's command
+# envelope in the isolated sandbox (open -> write files -> run commands -> read
+# artifacts -> close). The reliable replacement for the retired LLM dev/sandbox.
+#
+# WHY code-js and not an LLM: the sandbox agent's real job is MECHANISM — translate
+# a caller's commands into sandbox_* tool calls and report the results — not
+# judgment. An LLM there only added token cost, latency, and a flakiness class (on a
+# slow local model it mis-typed args and let sessions get reaped between turns). The
+# code-agent runs the exact open/exec/read/close sequence deterministically and
+# returns structured results; the JUDGMENT (read a failure, decide the fix, re-run)
+# stays with the CALLER, where it belongs.
+#
+# REQUIREMENTS
+#   - LOOMCYCLE_CODE_AGENTS_ENABLED=1 — code agents are opt-in; a `provider: code-js`
+#     agent selected WITHOUT this flag FAILS BOOT by design, so layer this bundle
+#     ONLY with the flag set and never add it to a default preset stack.
+#   - the `sandbox` bundle (or your own mcp_servers.sandbox) — this agent drives the
+#     mcp__sandbox__* tools that bundle serves:  LOOMCYCLE_PRESETS=...,sandbox,dev-exec
+#   - (optional) an mcp__browser__* server (e.g. the pinchtab sidecar) — the optional
+#     `browser` section of the envelope drives it; absent, browser steps report
+#     "unavailable" and everything else still works.
+#
+# The caller-facing `dev/sandbox-usage` skill (in the `sandbox` bundle) documents the
+# command envelope for agents that delegate here via the Agent tool.
+
+agents:
+  dev/exec:
+    provider: code-js
+    description: "Deterministically run a caller's command envelope in the isolated sandbox (open/write/exec/read/close) — zero-token, no LLM (RFC J). Optional browser passthrough."
+    # Globs expand against the connected servers at run time; mcp__sandbox__* is the
+    # core surface, mcp__browser__* an optional add-on when a browser server is up.
+    tools: [mcp__sandbox__*, mcp__browser__*]
+    code: |
+      // dev/exec (RFC J code-js) — a DETERMINISTIC sandbox command executor. The
+      // caller sends a JSON "command envelope" as the run prompt; this runs it via
+      // the mcp__sandbox__* tools and returns structured results. No LLM: the caller
+      // owns the judgment (read a failure -> decide the fix -> re-send commands).
+      //
+      // Envelope (JSON in the run prompt; you need commands, files, read, or browser
+      // for it to do anything):
+      //   session_id  string  reuse an existing session (its lifecycle is the
+      //                       caller's: not opened here, and not closed unless close=true)
+      //   network     string  "egress" (default) | "none"
+      //   workspace   string  durable /work name (needs SANDBOX_WORKSPACE_ROOT)
+      //   cpu,mem_mb,pids,tmpfs_mb  numbers  resource requests (operator-clamped)
+      //   git_setup   bool    run `gh auth setup-git` at open when GH_TOKEN present (default true)
+      //   files       array   [{path, content, encoding?}] written before commands
+      //   commands    array   ordered shell commands; stop at first failure unless continue_on_error
+      //   continue_on_error bool  run every command even after a failure (default false)
+      //   timeout_seconds, max_output_bytes  numbers  per-exec bounds (clamped)
+      //   read        array   artifacts to read back: "path" or {path, encoding?}
+      //   keep_open   bool    do not close the session (leave it for follow-ups)
+      //   close       bool    force-close even a reused (caller-owned) session
+      //   browser     array   optional [{op, args}] steps against mcp__browser__*
+      //                       (op: navigate|get_text|snapshot|screenshot|click|type|press|wait)
+      //
+      // Returns { final_text, ok, session_id, kept_open, files_written, results,
+      //           artifacts, browser }.
+
+      function run(input) {
+        var env = parseEnvelope(input);
+        if (env._error) return { final_text: env._error, ok: false };
+
+        var reused = !!env.session_id;
+        var sid;
+        try { sid = reused ? env.session_id : openSession(env); }
+        catch (e) { return { final_text: "sandbox_open failed: " + errText(e), ok: false }; }
+
+        // Best-effort: wire git-over-HTTPS to the injected GH_TOKEN (if any).
+        if (!reused && env.git_setup !== false) {
+          tryExec(sid, "command -v gh >/dev/null 2>&1 && [ -n \"$GH_TOKEN\" ] && gh auth setup-git >/dev/null 2>&1 || true");
+        }
+
+        var wrote = [];
+        var files = env.files || [];
+        for (var i = 0; i < files.length; i++) {
+          var f = files[i] || {};
+          mcp__sandbox__sandbox_write({ session_id: sid, path: f.path, content: f.content, encoding: f.encoding || "utf8" });
+          wrote.push(f.path);
+        }
+
+        var results = [], failed = false;
+        var cmds = env.commands || [];
+        for (var j = 0; j < cmds.length; j++) {
+          if (failed && !env.continue_on_error) { results.push({ command: cmds[j], skipped: true }); continue; }
+          var a = { session_id: sid, command: cmds[j] };
+          if (env.timeout_seconds) a.timeout_seconds = env.timeout_seconds;
+          if (env.max_output_bytes) a.max_output_bytes = env.max_output_bytes;
+          try { results.push({ command: cmds[j], ok: true, output: asText(mcp__sandbox__sandbox_exec(a)) }); }
+          catch (e) { results.push({ command: cmds[j], ok: false, output: errText(e) }); failed = true; }
+        }
+
+        var artifacts = [];
+        var reads = env.read || [];
+        for (var k = 0; k < reads.length; k++) {
+          var r = (typeof reads[k] === "string") ? { path: reads[k] } : (reads[k] || {});
+          if (!r.path) continue;
+          var ra = { session_id: sid, path: r.path };
+          if (r.encoding) ra.encoding = r.encoding;
+          try { artifacts.push({ path: r.path, ok: true, content: asText(mcp__sandbox__sandbox_read(ra)) }); }
+          catch (e) { artifacts.push({ path: r.path, ok: false, error: errText(e) }); }
+        }
+
+        var browser = runBrowser(env.browser);
+
+        // Close a session we opened (unless keep_open), or a reused one on close=true.
+        var closed = false;
+        if (env.close === true || (!reused && !env.keep_open)) {
+          try { mcp__sandbox__sandbox_close({ session_id: sid }); closed = true; } catch (e) {}
+        }
+
+        return {
+          final_text: summarize(results, browser, sid, failed, !closed),
+          ok: !failed, session_id: sid, kept_open: !closed,
+          files_written: wrote, results: results, artifacts: artifacts, browser: browser
+        };
+      }
+
+      function parseEnvelope(input) {
+        var raw = (input && typeof input.prompt === "string") ? input.prompt : "";
+        var env = {};
+        if (raw && raw.length) {
+          try { env = JSON.parse(raw); }
+          catch (e) { return { _error: "dev/exec expects a JSON command envelope in the prompt, e.g. {\"commands\":[\"go build ./...\"]}. Parse error: " + errText(e) }; }
+        }
+        if (typeof env !== "object" || env === null) return { _error: "envelope must be a JSON object" };
+        var hasWork = (env.commands && env.commands.length) || (env.files && env.files.length) ||
+                      (env.read && env.read.length) || (env.browser && env.browser.length);
+        if (!hasWork) return { _error: "nothing to do: provide commands, files, read, or browser in the envelope" };
+        return env;
+      }
+
+      function openSession(env) {
+        var o = { network: env.network || "egress" };
+        if (env.workspace) o.workspace = env.workspace;
+        if (env.tmpfs_mb) o.tmpfs_mb = env.tmpfs_mb;
+        if (env.cpu) o.cpu = env.cpu;
+        if (env.mem_mb) o.mem_mb = env.mem_mb;
+        if (env.pids) o.pids = env.pids;
+        var res = mcp__sandbox__sandbox_open(o);
+        if (!res || !res.session_id) throw new Error("no session_id returned");
+        return res.session_id;
+      }
+
+      function tryExec(sid, cmd) {
+        try { mcp__sandbox__sandbox_exec({ session_id: sid, command: cmd }); } catch (e) {}
+      }
+
+      // runBrowser dispatches optional browser steps against a connected
+      // mcp__browser__* server. typeof-guarded so a sandbox-only deployment (no
+      // browser server) degrades gracefully instead of throwing.
+      function runBrowser(steps) {
+        if (!steps || !steps.length) return null;
+        var fns = browserFns();
+        var out = [];
+        for (var i = 0; i < steps.length; i++) {
+          var s = steps[i] || {};
+          var fn = fns[s.op];
+          if (!fn) { out.push({ op: s.op, ok: false, error: "unavailable/unsupported browser op (needs an mcp__browser__* server)" }); continue; }
+          try { out.push({ op: s.op, ok: true, result: asText(fn(s.args || {})) }); }
+          catch (e) { out.push({ op: s.op, ok: false, error: errText(e) }); }
+        }
+        return out;
+      }
+
+      function browserFns() {
+        var m = {};
+        if (typeof mcp__browser__pinchtab_navigate   !== "undefined") m.navigate   = mcp__browser__pinchtab_navigate;
+        if (typeof mcp__browser__pinchtab_get_text   !== "undefined") m.get_text   = mcp__browser__pinchtab_get_text;
+        if (typeof mcp__browser__pinchtab_snapshot   !== "undefined") m.snapshot   = mcp__browser__pinchtab_snapshot;
+        if (typeof mcp__browser__pinchtab_screenshot !== "undefined") m.screenshot = mcp__browser__pinchtab_screenshot;
+        if (typeof mcp__browser__pinchtab_click      !== "undefined") m.click      = mcp__browser__pinchtab_click;
+        if (typeof mcp__browser__pinchtab_type       !== "undefined") m.type       = mcp__browser__pinchtab_type;
+        if (typeof mcp__browser__pinchtab_press      !== "undefined") m.press      = mcp__browser__pinchtab_press;
+        if (typeof mcp__browser__pinchtab_wait       !== "undefined") m.wait       = mcp__browser__pinchtab_wait;
+        return m;
+      }
+
+      function summarize(results, browser, sid, failed, kept) {
+        var ok = 0, bad = 0, skip = 0;
+        for (var i = 0; i < results.length; i++) {
+          if (results[i].skipped) skip++; else if (results[i].ok) ok++; else bad++;
+        }
+        var s = "ran " + results.length + " command(s): " + ok + " ok, " + bad + " failed";
+        if (skip) s += ", " + skip + " skipped";
+        if (browser && browser.length) s += "; " + browser.length + " browser step(s)";
+        s += "; session " + sid + (kept ? " (kept open)" : " (closed)");
+        if (failed) {
+          for (var j = 0; j < results.length; j++) {
+            if (results[j].ok === false) { s += " :: first failure: " + results[j].command; break; }
+          }
+        }
+        return s;
+      }
+
+      function asText(x) {
+        if (x === undefined || x === null) return "";
+        return (typeof x === "string") ? x : JSON.stringify(x);
+      }
+
+      function errText(e) { return (e && e.message) ? String(e.message) : String(e); }

--- a/bundles/sandbox/loomcycle.yaml
+++ b/bundles/sandbox/loomcycle.yaml
@@ -1,218 +1,82 @@
 # embedded bundle: sandbox
-# A code-execution agent that runs code in an ISOLATED, ephemeral sandbox
-# container via the builder sidecar — compile, test, and run Python/Go/Rust/C++/
-# Node WITHOUT giving the agent access to loomcycle's own container.
+# The isolated code-execution sandbox WIRING — the mcp__sandbox__* tools served by
+# the builder sidecar — plus a caller-facing skill for delegating code execution to
+# the deterministic `dev/exec` agent.
+#
+# This bundle carries NO agent, so it is flag-independent: layer it to grant your own
+# agents the mcp__sandbox__* tools. For the bundled deterministic executor, also
+# layer the `dev-exec` bundle (which needs LOOMCYCLE_CODE_AGENTS_ENABLED):
+#   LOOMCYCLE_PRESETS=…,sandbox,dev-exec
 #
 # Selected via `LOOMCYCLE_PRESETS=…,sandbox`. Requires:
 #   - the builder sidecar deployed on the app network (deploy/builder/; see
 #     docs/SANDBOX.md) — the mcp__sandbox__* tools are served by it.
-#   - LOOMCYCLE_SANDBOX_TOKEN set to the SAME shared secret as the sidecar's
+#   - SANDBOX_AUTH_TOKEN set to the SAME shared secret as the sidecar's
 #     SANDBOX_AUTH_TOKEN (the mcp_servers header below consumes it).
-#   - a `low` tier — select `base` alongside, or supply your own.
 #   - (optional) authenticated git/gh: set SANDBOX_ALLOW_ENV_INJECTION=1 on the
 #     sidecar and store a `sandbox_github` credential (a GitHub token) via
 #     `credentialdef op=create` — it is injected into the session as GH_TOKEN.
 # Without the sidecar the mcp__sandbox__* tools are registered-but-unreachable
-# (the MCP pool retries lazily); nothing else in the bundle is affected.
+# (the MCP pool retries lazily).
 #
 # The operator overlay can override any field (last layer wins) — e.g. re-declare
 # mcp_servers.sandbox.url if the sidecar isn't at http://builder-sidecar:9000.
 #
-# Besides the dev/sandbox AGENT, this bundle ships a `dev/sandbox-usage` SKILL so any
-# agent with the `Agent` tool (e.g. the chat/* agents) can DELEGATE to dev/sandbox —
-# spawn it for a one-shot task, or drive a multi-step session by sharing a session_id
-# — without holding the powerful mcp__sandbox__* tools itself.
-
-agents:
-  dev/sandbox:
-    tier: low
-    effort: medium
-    # mcp__sandbox__* grants the whole sidecar tool family (prefix glob, matched at
-    # exposure AND the fork/create ceiling check) — so future sandbox_* tools are
-    # picked up without editing the bundle.
-    tools: [mcp__sandbox__*, Interruption]
-    skills: [dev/sandbox]
-    compaction:
-      enabled: true
-      autocompact_at_pct: 80
-    system_prompt: |
-      You are SANDBOX, an agent that writes, compiles, tests, and runs code in an
-      isolated ephemeral sandbox. You never run code on the host — every command
-      runs inside a disposable container reached through your sandbox tools.
-
-      ## How you work
-      1. Open ONE sandbox session at the start (sandbox_open) and reuse it for the
-         whole task — the workspace (/work), installed dependencies, and the build
-         cache persist across commands. Only open another for genuinely separate work.
-      2. Put source in with sandbox_write (paths relative to /work), then build and
-         test with sandbox_exec. Read a non-zero exit + its output, fix, and re-run —
-         that compile→test→fix loop is the core of the job.
-      3. Pull results out with sandbox_read when you need to show an artifact.
-      4. Session lifecycle — follow the caller's intent exactly:
-         - GIVEN a session_id → reuse it; do NOT open a new one, and do NOT close it
-           (the caller owns that session's lifecycle, even when your task is done).
-         - Asked to KEEP the session open (a parent will drive more commands) → leave
-           it open and end your reply with a clear `session_id: <id>` line so the
-           caller can address the next command to the same container.
-         - Otherwise (a self-contained one-shot) → sandbox_close when done so the
-           container doesn't leak.
-
-      ## Notes
-      - The sandbox has Python, Go, Rust, C/C++, and Node preinstalled. /work is an
-        in-memory workspace that vanishes when the session closes — nothing persists.
-      - Open with network:"egress" for real dev work (cloning repos, fetching
-        dependencies) — this is a networked dev sandbox. Use network:"none" only for
-        purely offline compute. (If the operator hasn't enabled egress the session
-        silently falls back to no network.)
-      - For git/gh, run `gh auth setup-git` once at session start: a GitHub token
-        (GH_TOKEN) is injected when the operator configured one, letting you clone
-        and push PRIVATE repos over HTTPS. Never paste a token yourself.
-      - Resource limits (cpu/mem/pids/tmpfs) are capped by the operator; ask for less
-        when a task is small, never more than you need.
-      - If the sandbox tools are unavailable, the builder sidecar isn't deployed —
-        tell the human rather than trying to run code some other way.
-
-      ## Style
-      - Lead with the result (did it build? did tests pass?), then the details.
-      - Show the command you ran and the relevant output, not the whole log.
-      - Ask a clarifying question when the task is ambiguous instead of guessing.
+# (History: the LLM `dev/sandbox` agent + its tool-driving skill were retired in
+# favor of the deterministic code-js `dev/exec` agent — its job was mechanism, not
+# judgment. See the dev-exec bundle + docs/SANDBOX.md.)
 
 skills:
-  dev/sandbox:
-    description: Compile, test, and run code safely in an isolated ephemeral sandbox container (Python/Go/Rust/C++/Node) via the builder sidecar.
-    tools: [mcp__sandbox__*]
-    body: |
-      # Running code in the sandbox
-
-      All code runs INSIDE a disposable container, never on the host. One session =
-      one long-lived container you reuse across a compile→test→fix loop.
-
-      ## Lifecycle
-      1. sandbox_open → returns a session_id; pass it to every later call. Options
-         (all optional, all clamped to operator ceilings): network ("none" default |
-         "egress"), tmpfs_mb, cpu, mem_mb, pids.
-      2. sandbox_write {session_id, path, content} — write a file under /work (parent
-         dirs are created). Use encoding:"base64" for binary content.
-      3. sandbox_exec {session_id, command} — run a shell command in /work. You get
-         combined stdout+stderr and the exit code; a non-zero exit is reported so you
-         can read the error and fix it. timeout_seconds is clamped to the operator max.
-      4. sandbox_read {session_id, path} — read a file back out (encoding:"base64" for
-         binary artifacts).
-      5. sandbox_close {session_id} — destroy the session. Always close when done;
-         sessions also expire on an idle timeout.
-
-      ## Example: clone, build, test (Go)
-      - sandbox_open {network:"egress"} → session_id
-      - sandbox_exec {session_id, command:"git clone https://github.com/OWNER/REPO . && go build ./..."}
-      - if the exit code is non-zero, read the error, fix a file with sandbox_write,
-        then re-run "go build ./... && go test ./..."
-      - sandbox_read {session_id, path:"bin/app"} to pull the built binary
-      - sandbox_close {session_id}
-
-      ## Git / GitHub (authenticated)
-      When the operator configured a GitHub token it is injected into the session as
-      GH_TOKEN. To use it for git over HTTPS, run this ONCE per session first:
-        sandbox_exec {session_id, command:"gh auth setup-git && git config --global user.name loomcycle && git config --global user.email loomcycle@users.noreply.github.com"}
-      (gh already reads GH_TOKEN; `gh auth setup-git` makes git use it too.) Then
-      clone/push private repos over HTTPS:
-        sandbox_exec {session_id, command:"git clone https://github.com/OWNER/PRIVATE ."}
-      If `gh auth status` reports no token, the operator hasn't configured one — only
-      public repos will clone. Never paste a token yourself; tell the human.
-
-      ## Rules
-      - Reuse ONE session for a task — don't open a new one per command (you'd lose the
-        checkout + build cache).
-      - If a caller GIVES you a session_id, reuse it (don't open a new one); if asked to
-        KEEP a session open for follow-up, report the session_id and leave it open — a
-        parent agent may drive several commands against the same container.
-      - Default to network:"egress" for dev work (clone/fetch deps); use "none" only
-        for offline compute. (Egress needs the operator's SANDBOX_ALLOW_EGRESS; if it
-        isn't enabled, the session falls back to no network.)
-      - Keepalive: if you'll leave a session idle across a gap with no commands (a
-        parent is thinking between steps), sandbox_touch {session_id} resets its idle
-        timer so it isn't reaped — a normal sandbox_exec already resets it.
-      - Bulk teardown: sandbox_close_run {root_run_id} closes EVERY session you opened
-        for a run at once — use it when a driving parent asks you to clean up a run's
-        sandboxes, not for a single session (use sandbox_close for that).
-      - Never assume host access — you only have these sandbox tools.
-
   dev/sandbox-usage:
-    description: How to run/compile/test code by delegating to the dev/sandbox agent — a one-shot task, or a multi-step session you drive command by command. For agents that have the Agent tool but not the sandbox tools.
+    description: How to run/compile/test code by delegating to the deterministic dev/exec agent — send a JSON command envelope, read structured results, iterate on failures. For agents that have the Agent tool but not the sandbox tools.
     tools: [Agent]
     body: |
-      # Using the sandbox (delegate to the dev/sandbox agent)
+      # Running code in the sandbox (delegate to dev/exec)
 
       You don't hold the sandbox tools directly — by design. To run, compile, or test
-      code, delegate to the `dev/sandbox` sub-agent (it has an isolated, ephemeral
-      container with a full toolchain). You drive it with the `Agent` tool.
+      code, delegate to the `dev/exec` sub-agent via the `Agent` tool. dev/exec is a
+      DETERMINISTIC executor (no LLM): you send it a JSON command envelope, it runs the
+      steps in an isolated, ephemeral container and returns STRUCTURED results. You own
+      the judgment — read the results, and if a step failed, decide the fix and send a
+      corrected envelope. (Requires the `dev-exec` bundle + LOOMCYCLE_CODE_AGENTS_ENABLED.)
 
-      ## Mental model — there is no live session between your spawns
-      Each `Agent {op:"spawn", name:"dev/sandbox"}` is a FRESH, independent invocation —
-      dev/sandbox does NOT stay running between your calls, and it has no memory of the
-      previous spawn. The only thing that persists is the CONTAINER, which the sandbox
-      holds and addresses by an opaque `session_id`. So YOU are the continuity:
-        - capture the `session_id` dev/sandbox reports on the first spawn,
-        - keep it across your OWN turns (put it in your reply so it survives),
-        - pass it back on EVERY follow-up spawn.
-      Without the id, the next spawn can't find the container and starts from nothing.
+      ## The command envelope (JSON, passed as the spawn prompt)
+        {
+          "commands": ["git clone https://github.com/OWNER/REPO .", "go build ./...", "go test ./..."],
+          "files":    [{"path": "main.go", "content": "package main\n..."}],  // optional; written first
+          "read":     ["bin/app"],            // optional artifacts to read back
+          "network":  "egress",               // default; "none" for offline compute
+          "keep_open": true,                   // keep the container for follow-ups
+          "session_id": "<id>",                // reuse a container from a previous call
+          "continue_on_error": false,          // stop at the first failing command (default)
+          "close": false                       // force-close a reused session
+        }
+      Commands run in order and STOP at the first failure unless continue_on_error.
+      The result carries { ok, session_id, results:[{command, ok, output}], artifacts }.
+      Authenticated git "just works" when the operator configured a `sandbox_github`
+      credential (dev/exec runs `gh auth setup-git` at open).
 
-      ## One-shot task (simplest)
-      When you can describe the whole job upfront, spawn once and let dev/sandbox run
-      the compile→test→fix loop itself:
+      ## One-shot
+        Agent {op:"spawn", name:"dev/exec",
+               prompt:"{\"commands\":[\"git clone https://github.com/OWNER/REPO .\",\"go build ./... && go test ./...\"]}"}
+      Read `results`. If a command failed, decide the fix and spawn again with corrected
+      `commands` (and any `files` to write first) — that fix loop is YOURS now, because
+      dev/exec does not reason, it executes.
 
-        Agent {op:"spawn", name:"dev/sandbox",
-               prompt:"Clone https://github.com/OWNER/REPO, run 'go build ./... && go test ./...', fix any failures, and report the result."}
-
-      It opens a session, iterates, closes it, and returns the result.
-
-      ## Resident session (preferred for interactive, multi-step work)
-      When you'll drive several commands and inspect each result, keep dev/sandbox
-      RESIDENT with the Agent open/send/close ops. The child stays alive between your
-      instructions — its container stays warm and it remembers the conversation, so you
-      never re-thread a session_id:
-
-      1. Open — it runs the first command and parks, holding its container:
-         Agent {op:"open", name:"dev/sandbox",
-                prompt:"Open a sandbox session, keep it open, run: <command>, and report the output."}
-         → capture child_run_id from the returned envelope.
-      2. Each next step — no session_id to pass; it sees its whole prior conversation:
-         Agent {op:"send", child_run_id:"<child_run_id>", prompt:"Now run: <command>."}
-      3. When finished — close it (frees the container):
-         Agent {op:"close", child_run_id:"<child_run_id>"}
-
-      Full lifecycle: Context op=help topic=resident-sub-agents.
-
-      ## Multi-step session without resident ops (fallback)
-      If you can't use open/send/close, you can still keep ONE container alive across
-      plain spawns by sharing its session_id (fragile — you must carry the id yourself):
-
-      1. Open + first command — tell it to KEEP the session open and report the id:
-         Agent {op:"spawn", name:"dev/sandbox",
-                prompt:"Open a sandbox session and KEEP IT OPEN (do not close it). Run: <command>. Report the session_id and the output."}
-         → capture the session_id from the returned text.
-      2. Next commands — reuse that session (same container, state preserved):
-         Agent {op:"spawn", name:"dev/sandbox",
-                prompt:"Reuse sandbox session <session_id> — do not open a new one, do not close it. Run: <command>. Report the output."}
-      3. Shut it down when finished:
-         Agent {op:"spawn", name:"dev/sandbox", prompt:"Close sandbox session <session_id>."}
+      ## Multi-step against one warm container
+      1. First call with "keep_open": true — capture `session_id` from the result.
+      2. Later calls pass that "session_id" (same container, state + build cache preserved).
+         A reused session is NOT auto-closed.
+      3. When done, send a final envelope with that "session_id" and "close": true
+         (or just stop — the idle timeout reaps it).
 
       ## Notes
-      - The container persists between spawns (the sandbox holds it), so the checkout,
-        installed deps, and build cache carry over — as long as you pass the same
-        session_id and don't leave it idle too long.
-      - Idle timeout: the container is reaped after a period with no commands. Across a
-        SHORT gap between your spawns that's fine (each command resets the clock). Across
-        a LONG gap — e.g. you're waiting on the human between turns — it will be reaped:
-        the next spawn should just reopen and start fresh (the previous /work is gone),
-        unless the operator configured a durable workspace. There is no way to keep a
-        container alive across a long human pause from here — that's a limitation of
-        driving the sandbox spawn-by-spawn.
-      - Always close the session when the task is genuinely done; don't leave sandboxes
-        running. (If the human may continue, keep it open and hold onto the session_id.)
-      - Compiled binaries run inside the sandbox (it's a real container), so
-        `./your-binary` works there.
-      - If dev/sandbox reports the sandbox tools are unavailable, the builder sidecar
-        isn't deployed — tell the human rather than trying to run code another way.
+      - The container persists only while warm; a long idle gap reaps it (its /work is
+        gone) unless the operator configured a durable `workspace`.
+      - If dev/exec reports the sandbox tools are unavailable, the builder sidecar isn't
+        deployed — tell the human rather than trying to run code another way.
+      - Compiled binaries run inside the sandbox (a real container), so `./your-binary`
+        works there; pull artifacts out with the envelope's `read`.
 
 mcp_servers:
   sandbox:

--- a/cloud-deployment/.env.insecure.example
+++ b/cloud-deployment/.env.insecure.example
@@ -7,7 +7,7 @@
 LOOMCYCLE_LISTEN_ADDR=0.0.0.0:8787
 LOOMCYCLE_CONFIG_DIR=/config
 LOOMCYCLE_DATA_DIR=/data
-LOOMCYCLE_PRESETS=base,document-agent,chat,agent-teams,team-examples,sandbox,doc-colorizer,memory
+LOOMCYCLE_PRESETS=base,document-agent,chat,agent-teams,team-examples,sandbox,dev-exec,doc-colorizer,memory
 
 # Public identity behind Cloudflare (the tunnel hostname, NOT the internal addr).
 # LOOMCYCLE_PUBLIC_CONFIG=1 lets the landing page's /api/config read GET /v1/config.

--- a/cloud-deployment/INSTALL.md
+++ b/cloud-deployment/INSTALL.md
@@ -158,7 +158,7 @@ SANDBOX_AUTH_TOKEN=REPLACE_ME                # openssl rand -hex 32 (shared with
 TS_AUTHKEY=tskey-auth-REPLACE_ME             # Phase 3 (reusable, tagged)
 CLOUDFLARE_TUNNEL_TOKEN=REPLACE_ME           # Phase 4
 SEARXNG_SECRET=REPLACE_ME                    # openssl rand -hex 32
-PINCHTAB_TOKEN=REPLACE_ME                    # openssl rand -hex 32 (dev/sandbox headless browser)
+PINCHTAB_TOKEN=REPLACE_ME                    # openssl rand -hex 32 (dev/exec headless browser)
 # ── provider keys — at least one your tiers route to ──
 ANTHROPIC_API_KEY=
 OPENAI_API_KEY=
@@ -172,9 +172,10 @@ Notes:
   NOT mint a dedicated `substrate:admin` token for it — that disables the
   `LOOMCYCLE_AUTH_TOKEN` login (no-lockout gate).
 - The DSN host is **`postgres`** (the compose service) — don't change it.
-- **Headless browser (dev/sandbox):** the `pinchtab` sidecar gives the dev agent
-  `mcp__browser__*` tools. PinchTab's MCP is stdio-only, so loomcycle uses a derived
-  image (`loomcycle.Dockerfile`) that bakes in the pinchtab MCP client — `make up`
+- **Headless browser (dev/exec):** the `pinchtab` sidecar gives the deterministic
+  `dev/exec` agent `mcp__browser__*` tools (driven via the envelope's optional
+  `browser` steps). PinchTab's MCP is stdio-only, so loomcycle uses a derived image
+  (`loomcycle.Dockerfile`) that bakes in the pinchtab MCP client — `make up`
   therefore BUILDS the loomcycle image (first run is slower; needs Docker Hub
   access). The sidecar is internal-only (no published port), and PinchTab keeps
   browsing **local-only** until you widen its domain allowlist (IDPI) — to test
@@ -214,8 +215,8 @@ make ps          # all services `running`/`healthy`; loomcycle-migrate `exited (
    lists the new token under its derived `t_…` tenant. (A `curl` to `/api/mint` WITHOUT an
    Access cookie must return `401`.)
 7. **Functional**: run a `chat/medium` agent that uses WebSearch (proves SearXNG),
-   a `dev/sandbox` run (proves the builder sidecar via `mcp__sandbox__*`), and a
-   Document op (proves SQL Memory + pgvector).
+   a `dev/exec` run (proves the builder sidecar via `mcp__sandbox__*` — e.g.
+   `{"commands":["uname -a"]}`), and a Document op (proves SQL Memory + pgvector).
 
 ---
 

--- a/cloud-deployment/config/loomcycle.yaml
+++ b/cloud-deployment/config/loomcycle.yaml
@@ -11,20 +11,15 @@ search_providers:
 
 search_priority: [searxng, brave]
 
-# ── Headless browser (PinchTab) for the dev/sandbox agent (cloud deployment only) ─
-# PinchTab's MCP is stdio-only, so loomcycle spawns the pinchtab client (baked into
-# the derived image, loomcycle.Dockerfile) as a stdio MCP bridge to the `pinchtab`
-# server sidecar. The child inherits PINCHTAB_TOKEN from loomcycle's env, so no
-# ${...} interpolation is needed here. This overlay layers OVER the embedded
-# `sandbox` preset (presets → CONFIG_DIR), adding the browser server and widening
-# the dev/sandbox tool ceiling to include mcp__browser__* (the list is restated in
-# full because a sequence override replaces, not appends).
+# ── Headless browser (PinchTab) for the dev/exec agent (cloud deployment only) ────
+# PinchTab's MCP is stdio-only, so loomcycle spawns the pinchtab client (in the
+# loomcycle-browser image) as a stdio MCP bridge to the `pinchtab` server sidecar.
+# The child inherits PINCHTAB_TOKEN from loomcycle's env, so no ${...} interpolation
+# is needed here. The dev/exec agent (dev-exec bundle) already grants mcp__browser__*
+# in its tool ceiling and drives it via the envelope's optional `browser` steps, so
+# this overlay only needs to DECLARE the server — no agent override.
 mcp_servers:
   browser:
     transport: stdio
     command: /usr/local/bin/pinchtab
     args: ["--server", "http://pinchtab:9867", "mcp"]
-
-agents:
-  dev/sandbox:
-    tools: [mcp__sandbox__*, mcp__browser__*, Interruption]

--- a/cloud-deployment/docker-compose.yaml
+++ b/cloud-deployment/docker-compose.yaml
@@ -191,7 +191,7 @@ services:
       retries: 12
       start_period: 15s
 
-  # ── Headless browser (PinchTab) — internal MCP browser for the dev/sandbox agent.
+  # ── Headless browser (PinchTab) — internal MCP browser for the dev/exec agent.
   #    stdio-only MCP, so loomcycle spawns `pinchtab … mcp` (client baked into its
   #    derived image) against THIS server; Chromium lives here, not in loomcycle.
   #    Internal ONLY — no published port (pinchtab's control plane is not for public

--- a/cmd/loomcycle/embedded/bundles/dev-exec.yaml
+++ b/cmd/loomcycle/embedded/bundles/dev-exec.yaml
@@ -1,0 +1,203 @@
+# RFC AQ embedded bundle: dev-exec
+#
+# Deterministic, zero-token code-js agent (RFC J) that EXECUTES a caller's command
+# envelope in the isolated sandbox (open -> write files -> run commands -> read
+# artifacts -> close). The reliable replacement for the retired LLM dev/sandbox.
+#
+# WHY code-js and not an LLM: the sandbox agent's real job is MECHANISM — translate
+# a caller's commands into sandbox_* tool calls and report the results — not
+# judgment. An LLM there only added token cost, latency, and a flakiness class (on a
+# slow local model it mis-typed args and let sessions get reaped between turns). The
+# code-agent runs the exact open/exec/read/close sequence deterministically and
+# returns structured results; the JUDGMENT (read a failure, decide the fix, re-run)
+# stays with the CALLER, where it belongs.
+#
+# REQUIREMENTS
+#   - LOOMCYCLE_CODE_AGENTS_ENABLED=1 — code agents are opt-in; a `provider: code-js`
+#     agent selected WITHOUT this flag FAILS BOOT by design, so layer this bundle
+#     ONLY with the flag set and never add it to a default preset stack.
+#   - the `sandbox` bundle (or your own mcp_servers.sandbox) — this agent drives the
+#     mcp__sandbox__* tools that bundle serves:  LOOMCYCLE_PRESETS=...,sandbox,dev-exec
+#   - (optional) an mcp__browser__* server (e.g. the pinchtab sidecar) — the optional
+#     `browser` section of the envelope drives it; absent, browser steps report
+#     "unavailable" and everything else still works.
+#
+# The caller-facing `dev/sandbox-usage` skill (in the `sandbox` bundle) documents the
+# command envelope for agents that delegate here via the Agent tool.
+
+agents:
+  dev/exec:
+    provider: code-js
+    description: "Deterministically run a caller's command envelope in the isolated sandbox (open/write/exec/read/close) — zero-token, no LLM (RFC J). Optional browser passthrough."
+    # Globs expand against the connected servers at run time; mcp__sandbox__* is the
+    # core surface, mcp__browser__* an optional add-on when a browser server is up.
+    tools: [mcp__sandbox__*, mcp__browser__*]
+    code: |
+      // dev/exec (RFC J code-js) — a DETERMINISTIC sandbox command executor. The
+      // caller sends a JSON "command envelope" as the run prompt; this runs it via
+      // the mcp__sandbox__* tools and returns structured results. No LLM: the caller
+      // owns the judgment (read a failure -> decide the fix -> re-send commands).
+      //
+      // Envelope (JSON in the run prompt; you need commands, files, read, or browser
+      // for it to do anything):
+      //   session_id  string  reuse an existing session (its lifecycle is the
+      //                       caller's: not opened here, and not closed unless close=true)
+      //   network     string  "egress" (default) | "none"
+      //   workspace   string  durable /work name (needs SANDBOX_WORKSPACE_ROOT)
+      //   cpu,mem_mb,pids,tmpfs_mb  numbers  resource requests (operator-clamped)
+      //   git_setup   bool    run `gh auth setup-git` at open when GH_TOKEN present (default true)
+      //   files       array   [{path, content, encoding?}] written before commands
+      //   commands    array   ordered shell commands; stop at first failure unless continue_on_error
+      //   continue_on_error bool  run every command even after a failure (default false)
+      //   timeout_seconds, max_output_bytes  numbers  per-exec bounds (clamped)
+      //   read        array   artifacts to read back: "path" or {path, encoding?}
+      //   keep_open   bool    do not close the session (leave it for follow-ups)
+      //   close       bool    force-close even a reused (caller-owned) session
+      //   browser     array   optional [{op, args}] steps against mcp__browser__*
+      //                       (op: navigate|get_text|snapshot|screenshot|click|type|press|wait)
+      //
+      // Returns { final_text, ok, session_id, kept_open, files_written, results,
+      //           artifacts, browser }.
+
+      function run(input) {
+        var env = parseEnvelope(input);
+        if (env._error) return { final_text: env._error, ok: false };
+
+        var reused = !!env.session_id;
+        var sid;
+        try { sid = reused ? env.session_id : openSession(env); }
+        catch (e) { return { final_text: "sandbox_open failed: " + errText(e), ok: false }; }
+
+        // Best-effort: wire git-over-HTTPS to the injected GH_TOKEN (if any).
+        if (!reused && env.git_setup !== false) {
+          tryExec(sid, "command -v gh >/dev/null 2>&1 && [ -n \"$GH_TOKEN\" ] && gh auth setup-git >/dev/null 2>&1 || true");
+        }
+
+        var wrote = [];
+        var files = env.files || [];
+        for (var i = 0; i < files.length; i++) {
+          var f = files[i] || {};
+          mcp__sandbox__sandbox_write({ session_id: sid, path: f.path, content: f.content, encoding: f.encoding || "utf8" });
+          wrote.push(f.path);
+        }
+
+        var results = [], failed = false;
+        var cmds = env.commands || [];
+        for (var j = 0; j < cmds.length; j++) {
+          if (failed && !env.continue_on_error) { results.push({ command: cmds[j], skipped: true }); continue; }
+          var a = { session_id: sid, command: cmds[j] };
+          if (env.timeout_seconds) a.timeout_seconds = env.timeout_seconds;
+          if (env.max_output_bytes) a.max_output_bytes = env.max_output_bytes;
+          try { results.push({ command: cmds[j], ok: true, output: asText(mcp__sandbox__sandbox_exec(a)) }); }
+          catch (e) { results.push({ command: cmds[j], ok: false, output: errText(e) }); failed = true; }
+        }
+
+        var artifacts = [];
+        var reads = env.read || [];
+        for (var k = 0; k < reads.length; k++) {
+          var r = (typeof reads[k] === "string") ? { path: reads[k] } : (reads[k] || {});
+          if (!r.path) continue;
+          var ra = { session_id: sid, path: r.path };
+          if (r.encoding) ra.encoding = r.encoding;
+          try { artifacts.push({ path: r.path, ok: true, content: asText(mcp__sandbox__sandbox_read(ra)) }); }
+          catch (e) { artifacts.push({ path: r.path, ok: false, error: errText(e) }); }
+        }
+
+        var browser = runBrowser(env.browser);
+
+        // Close a session we opened (unless keep_open), or a reused one on close=true.
+        var closed = false;
+        if (env.close === true || (!reused && !env.keep_open)) {
+          try { mcp__sandbox__sandbox_close({ session_id: sid }); closed = true; } catch (e) {}
+        }
+
+        return {
+          final_text: summarize(results, browser, sid, failed, !closed),
+          ok: !failed, session_id: sid, kept_open: !closed,
+          files_written: wrote, results: results, artifacts: artifacts, browser: browser
+        };
+      }
+
+      function parseEnvelope(input) {
+        var raw = (input && typeof input.prompt === "string") ? input.prompt : "";
+        var env = {};
+        if (raw && raw.length) {
+          try { env = JSON.parse(raw); }
+          catch (e) { return { _error: "dev/exec expects a JSON command envelope in the prompt, e.g. {\"commands\":[\"go build ./...\"]}. Parse error: " + errText(e) }; }
+        }
+        if (typeof env !== "object" || env === null) return { _error: "envelope must be a JSON object" };
+        var hasWork = (env.commands && env.commands.length) || (env.files && env.files.length) ||
+                      (env.read && env.read.length) || (env.browser && env.browser.length);
+        if (!hasWork) return { _error: "nothing to do: provide commands, files, read, or browser in the envelope" };
+        return env;
+      }
+
+      function openSession(env) {
+        var o = { network: env.network || "egress" };
+        if (env.workspace) o.workspace = env.workspace;
+        if (env.tmpfs_mb) o.tmpfs_mb = env.tmpfs_mb;
+        if (env.cpu) o.cpu = env.cpu;
+        if (env.mem_mb) o.mem_mb = env.mem_mb;
+        if (env.pids) o.pids = env.pids;
+        var res = mcp__sandbox__sandbox_open(o);
+        if (!res || !res.session_id) throw new Error("no session_id returned");
+        return res.session_id;
+      }
+
+      function tryExec(sid, cmd) {
+        try { mcp__sandbox__sandbox_exec({ session_id: sid, command: cmd }); } catch (e) {}
+      }
+
+      // runBrowser dispatches optional browser steps against a connected
+      // mcp__browser__* server. typeof-guarded so a sandbox-only deployment (no
+      // browser server) degrades gracefully instead of throwing.
+      function runBrowser(steps) {
+        if (!steps || !steps.length) return null;
+        var fns = browserFns();
+        var out = [];
+        for (var i = 0; i < steps.length; i++) {
+          var s = steps[i] || {};
+          var fn = fns[s.op];
+          if (!fn) { out.push({ op: s.op, ok: false, error: "unavailable/unsupported browser op (needs an mcp__browser__* server)" }); continue; }
+          try { out.push({ op: s.op, ok: true, result: asText(fn(s.args || {})) }); }
+          catch (e) { out.push({ op: s.op, ok: false, error: errText(e) }); }
+        }
+        return out;
+      }
+
+      function browserFns() {
+        var m = {};
+        if (typeof mcp__browser__pinchtab_navigate   !== "undefined") m.navigate   = mcp__browser__pinchtab_navigate;
+        if (typeof mcp__browser__pinchtab_get_text   !== "undefined") m.get_text   = mcp__browser__pinchtab_get_text;
+        if (typeof mcp__browser__pinchtab_snapshot   !== "undefined") m.snapshot   = mcp__browser__pinchtab_snapshot;
+        if (typeof mcp__browser__pinchtab_screenshot !== "undefined") m.screenshot = mcp__browser__pinchtab_screenshot;
+        if (typeof mcp__browser__pinchtab_click      !== "undefined") m.click      = mcp__browser__pinchtab_click;
+        if (typeof mcp__browser__pinchtab_type       !== "undefined") m.type       = mcp__browser__pinchtab_type;
+        if (typeof mcp__browser__pinchtab_press      !== "undefined") m.press      = mcp__browser__pinchtab_press;
+        if (typeof mcp__browser__pinchtab_wait       !== "undefined") m.wait       = mcp__browser__pinchtab_wait;
+        return m;
+      }
+
+      function summarize(results, browser, sid, failed, kept) {
+        var ok = 0, bad = 0, skip = 0;
+        for (var i = 0; i < results.length; i++) {
+          if (results[i].skipped) skip++; else if (results[i].ok) ok++; else bad++;
+        }
+        var s = "ran " + results.length + " command(s): " + ok + " ok, " + bad + " failed";
+        if (skip) s += ", " + skip + " skipped";
+        if (browser && browser.length) s += "; " + browser.length + " browser step(s)";
+        s += "; session " + sid + (kept ? " (kept open)" : " (closed)");
+        if (failed) {
+          for (var j = 0; j < results.length; j++) {
+            if (results[j].ok === false) { s += " :: first failure: " + results[j].command; break; }
+          }
+        }
+        return s;
+      }
+
+      function asText(x) {
+        if (x === undefined || x === null) return "";
+        return (typeof x === "string") ? x : JSON.stringify(x);
+      }
+
+      function errText(e) { return (e && e.message) ? String(e.message) : String(e); }

--- a/cmd/loomcycle/embedded/bundles/sandbox.yaml
+++ b/cmd/loomcycle/embedded/bundles/sandbox.yaml
@@ -1,218 +1,82 @@
 # embedded bundle: sandbox
-# A code-execution agent that runs code in an ISOLATED, ephemeral sandbox
-# container via the builder sidecar — compile, test, and run Python/Go/Rust/C++/
-# Node WITHOUT giving the agent access to loomcycle's own container.
+# The isolated code-execution sandbox WIRING — the mcp__sandbox__* tools served by
+# the builder sidecar — plus a caller-facing skill for delegating code execution to
+# the deterministic `dev/exec` agent.
+#
+# This bundle carries NO agent, so it is flag-independent: layer it to grant your own
+# agents the mcp__sandbox__* tools. For the bundled deterministic executor, also
+# layer the `dev-exec` bundle (which needs LOOMCYCLE_CODE_AGENTS_ENABLED):
+#   LOOMCYCLE_PRESETS=…,sandbox,dev-exec
 #
 # Selected via `LOOMCYCLE_PRESETS=…,sandbox`. Requires:
 #   - the builder sidecar deployed on the app network (deploy/builder/; see
 #     docs/SANDBOX.md) — the mcp__sandbox__* tools are served by it.
-#   - LOOMCYCLE_SANDBOX_TOKEN set to the SAME shared secret as the sidecar's
+#   - SANDBOX_AUTH_TOKEN set to the SAME shared secret as the sidecar's
 #     SANDBOX_AUTH_TOKEN (the mcp_servers header below consumes it).
-#   - a `low` tier — select `base` alongside, or supply your own.
 #   - (optional) authenticated git/gh: set SANDBOX_ALLOW_ENV_INJECTION=1 on the
 #     sidecar and store a `sandbox_github` credential (a GitHub token) via
 #     `credentialdef op=create` — it is injected into the session as GH_TOKEN.
 # Without the sidecar the mcp__sandbox__* tools are registered-but-unreachable
-# (the MCP pool retries lazily); nothing else in the bundle is affected.
+# (the MCP pool retries lazily).
 #
 # The operator overlay can override any field (last layer wins) — e.g. re-declare
 # mcp_servers.sandbox.url if the sidecar isn't at http://builder-sidecar:9000.
 #
-# Besides the dev/sandbox AGENT, this bundle ships a `dev/sandbox-usage` SKILL so any
-# agent with the `Agent` tool (e.g. the chat/* agents) can DELEGATE to dev/sandbox —
-# spawn it for a one-shot task, or drive a multi-step session by sharing a session_id
-# — without holding the powerful mcp__sandbox__* tools itself.
-
-agents:
-  dev/sandbox:
-    tier: low
-    effort: medium
-    # mcp__sandbox__* grants the whole sidecar tool family (prefix glob, matched at
-    # exposure AND the fork/create ceiling check) — so future sandbox_* tools are
-    # picked up without editing the bundle.
-    tools: [mcp__sandbox__*, Interruption]
-    skills: [dev/sandbox]
-    compaction:
-      enabled: true
-      autocompact_at_pct: 80
-    system_prompt: |
-      You are SANDBOX, an agent that writes, compiles, tests, and runs code in an
-      isolated ephemeral sandbox. You never run code on the host — every command
-      runs inside a disposable container reached through your sandbox tools.
-
-      ## How you work
-      1. Open ONE sandbox session at the start (sandbox_open) and reuse it for the
-         whole task — the workspace (/work), installed dependencies, and the build
-         cache persist across commands. Only open another for genuinely separate work.
-      2. Put source in with sandbox_write (paths relative to /work), then build and
-         test with sandbox_exec. Read a non-zero exit + its output, fix, and re-run —
-         that compile→test→fix loop is the core of the job.
-      3. Pull results out with sandbox_read when you need to show an artifact.
-      4. Session lifecycle — follow the caller's intent exactly:
-         - GIVEN a session_id → reuse it; do NOT open a new one, and do NOT close it
-           (the caller owns that session's lifecycle, even when your task is done).
-         - Asked to KEEP the session open (a parent will drive more commands) → leave
-           it open and end your reply with a clear `session_id: <id>` line so the
-           caller can address the next command to the same container.
-         - Otherwise (a self-contained one-shot) → sandbox_close when done so the
-           container doesn't leak.
-
-      ## Notes
-      - The sandbox has Python, Go, Rust, C/C++, and Node preinstalled. /work is an
-        in-memory workspace that vanishes when the session closes — nothing persists.
-      - Open with network:"egress" for real dev work (cloning repos, fetching
-        dependencies) — this is a networked dev sandbox. Use network:"none" only for
-        purely offline compute. (If the operator hasn't enabled egress the session
-        silently falls back to no network.)
-      - For git/gh, run `gh auth setup-git` once at session start: a GitHub token
-        (GH_TOKEN) is injected when the operator configured one, letting you clone
-        and push PRIVATE repos over HTTPS. Never paste a token yourself.
-      - Resource limits (cpu/mem/pids/tmpfs) are capped by the operator; ask for less
-        when a task is small, never more than you need.
-      - If the sandbox tools are unavailable, the builder sidecar isn't deployed —
-        tell the human rather than trying to run code some other way.
-
-      ## Style
-      - Lead with the result (did it build? did tests pass?), then the details.
-      - Show the command you ran and the relevant output, not the whole log.
-      - Ask a clarifying question when the task is ambiguous instead of guessing.
+# (History: the LLM `dev/sandbox` agent + its tool-driving skill were retired in
+# favor of the deterministic code-js `dev/exec` agent — its job was mechanism, not
+# judgment. See the dev-exec bundle + docs/SANDBOX.md.)
 
 skills:
-  dev/sandbox:
-    description: Compile, test, and run code safely in an isolated ephemeral sandbox container (Python/Go/Rust/C++/Node) via the builder sidecar.
-    tools: [mcp__sandbox__*]
-    body: |
-      # Running code in the sandbox
-
-      All code runs INSIDE a disposable container, never on the host. One session =
-      one long-lived container you reuse across a compile→test→fix loop.
-
-      ## Lifecycle
-      1. sandbox_open → returns a session_id; pass it to every later call. Options
-         (all optional, all clamped to operator ceilings): network ("none" default |
-         "egress"), tmpfs_mb, cpu, mem_mb, pids.
-      2. sandbox_write {session_id, path, content} — write a file under /work (parent
-         dirs are created). Use encoding:"base64" for binary content.
-      3. sandbox_exec {session_id, command} — run a shell command in /work. You get
-         combined stdout+stderr and the exit code; a non-zero exit is reported so you
-         can read the error and fix it. timeout_seconds is clamped to the operator max.
-      4. sandbox_read {session_id, path} — read a file back out (encoding:"base64" for
-         binary artifacts).
-      5. sandbox_close {session_id} — destroy the session. Always close when done;
-         sessions also expire on an idle timeout.
-
-      ## Example: clone, build, test (Go)
-      - sandbox_open {network:"egress"} → session_id
-      - sandbox_exec {session_id, command:"git clone https://github.com/OWNER/REPO . && go build ./..."}
-      - if the exit code is non-zero, read the error, fix a file with sandbox_write,
-        then re-run "go build ./... && go test ./..."
-      - sandbox_read {session_id, path:"bin/app"} to pull the built binary
-      - sandbox_close {session_id}
-
-      ## Git / GitHub (authenticated)
-      When the operator configured a GitHub token it is injected into the session as
-      GH_TOKEN. To use it for git over HTTPS, run this ONCE per session first:
-        sandbox_exec {session_id, command:"gh auth setup-git && git config --global user.name loomcycle && git config --global user.email loomcycle@users.noreply.github.com"}
-      (gh already reads GH_TOKEN; `gh auth setup-git` makes git use it too.) Then
-      clone/push private repos over HTTPS:
-        sandbox_exec {session_id, command:"git clone https://github.com/OWNER/PRIVATE ."}
-      If `gh auth status` reports no token, the operator hasn't configured one — only
-      public repos will clone. Never paste a token yourself; tell the human.
-
-      ## Rules
-      - Reuse ONE session for a task — don't open a new one per command (you'd lose the
-        checkout + build cache).
-      - If a caller GIVES you a session_id, reuse it (don't open a new one); if asked to
-        KEEP a session open for follow-up, report the session_id and leave it open — a
-        parent agent may drive several commands against the same container.
-      - Default to network:"egress" for dev work (clone/fetch deps); use "none" only
-        for offline compute. (Egress needs the operator's SANDBOX_ALLOW_EGRESS; if it
-        isn't enabled, the session falls back to no network.)
-      - Keepalive: if you'll leave a session idle across a gap with no commands (a
-        parent is thinking between steps), sandbox_touch {session_id} resets its idle
-        timer so it isn't reaped — a normal sandbox_exec already resets it.
-      - Bulk teardown: sandbox_close_run {root_run_id} closes EVERY session you opened
-        for a run at once — use it when a driving parent asks you to clean up a run's
-        sandboxes, not for a single session (use sandbox_close for that).
-      - Never assume host access — you only have these sandbox tools.
-
   dev/sandbox-usage:
-    description: How to run/compile/test code by delegating to the dev/sandbox agent — a one-shot task, or a multi-step session you drive command by command. For agents that have the Agent tool but not the sandbox tools.
+    description: How to run/compile/test code by delegating to the deterministic dev/exec agent — send a JSON command envelope, read structured results, iterate on failures. For agents that have the Agent tool but not the sandbox tools.
     tools: [Agent]
     body: |
-      # Using the sandbox (delegate to the dev/sandbox agent)
+      # Running code in the sandbox (delegate to dev/exec)
 
       You don't hold the sandbox tools directly — by design. To run, compile, or test
-      code, delegate to the `dev/sandbox` sub-agent (it has an isolated, ephemeral
-      container with a full toolchain). You drive it with the `Agent` tool.
+      code, delegate to the `dev/exec` sub-agent via the `Agent` tool. dev/exec is a
+      DETERMINISTIC executor (no LLM): you send it a JSON command envelope, it runs the
+      steps in an isolated, ephemeral container and returns STRUCTURED results. You own
+      the judgment — read the results, and if a step failed, decide the fix and send a
+      corrected envelope. (Requires the `dev-exec` bundle + LOOMCYCLE_CODE_AGENTS_ENABLED.)
 
-      ## Mental model — there is no live session between your spawns
-      Each `Agent {op:"spawn", name:"dev/sandbox"}` is a FRESH, independent invocation —
-      dev/sandbox does NOT stay running between your calls, and it has no memory of the
-      previous spawn. The only thing that persists is the CONTAINER, which the sandbox
-      holds and addresses by an opaque `session_id`. So YOU are the continuity:
-        - capture the `session_id` dev/sandbox reports on the first spawn,
-        - keep it across your OWN turns (put it in your reply so it survives),
-        - pass it back on EVERY follow-up spawn.
-      Without the id, the next spawn can't find the container and starts from nothing.
+      ## The command envelope (JSON, passed as the spawn prompt)
+        {
+          "commands": ["git clone https://github.com/OWNER/REPO .", "go build ./...", "go test ./..."],
+          "files":    [{"path": "main.go", "content": "package main\n..."}],  // optional; written first
+          "read":     ["bin/app"],            // optional artifacts to read back
+          "network":  "egress",               // default; "none" for offline compute
+          "keep_open": true,                   // keep the container for follow-ups
+          "session_id": "<id>",                // reuse a container from a previous call
+          "continue_on_error": false,          // stop at the first failing command (default)
+          "close": false                       // force-close a reused session
+        }
+      Commands run in order and STOP at the first failure unless continue_on_error.
+      The result carries { ok, session_id, results:[{command, ok, output}], artifacts }.
+      Authenticated git "just works" when the operator configured a `sandbox_github`
+      credential (dev/exec runs `gh auth setup-git` at open).
 
-      ## One-shot task (simplest)
-      When you can describe the whole job upfront, spawn once and let dev/sandbox run
-      the compile→test→fix loop itself:
+      ## One-shot
+        Agent {op:"spawn", name:"dev/exec",
+               prompt:"{\"commands\":[\"git clone https://github.com/OWNER/REPO .\",\"go build ./... && go test ./...\"]}"}
+      Read `results`. If a command failed, decide the fix and spawn again with corrected
+      `commands` (and any `files` to write first) — that fix loop is YOURS now, because
+      dev/exec does not reason, it executes.
 
-        Agent {op:"spawn", name:"dev/sandbox",
-               prompt:"Clone https://github.com/OWNER/REPO, run 'go build ./... && go test ./...', fix any failures, and report the result."}
-
-      It opens a session, iterates, closes it, and returns the result.
-
-      ## Resident session (preferred for interactive, multi-step work)
-      When you'll drive several commands and inspect each result, keep dev/sandbox
-      RESIDENT with the Agent open/send/close ops. The child stays alive between your
-      instructions — its container stays warm and it remembers the conversation, so you
-      never re-thread a session_id:
-
-      1. Open — it runs the first command and parks, holding its container:
-         Agent {op:"open", name:"dev/sandbox",
-                prompt:"Open a sandbox session, keep it open, run: <command>, and report the output."}
-         → capture child_run_id from the returned envelope.
-      2. Each next step — no session_id to pass; it sees its whole prior conversation:
-         Agent {op:"send", child_run_id:"<child_run_id>", prompt:"Now run: <command>."}
-      3. When finished — close it (frees the container):
-         Agent {op:"close", child_run_id:"<child_run_id>"}
-
-      Full lifecycle: Context op=help topic=resident-sub-agents.
-
-      ## Multi-step session without resident ops (fallback)
-      If you can't use open/send/close, you can still keep ONE container alive across
-      plain spawns by sharing its session_id (fragile — you must carry the id yourself):
-
-      1. Open + first command — tell it to KEEP the session open and report the id:
-         Agent {op:"spawn", name:"dev/sandbox",
-                prompt:"Open a sandbox session and KEEP IT OPEN (do not close it). Run: <command>. Report the session_id and the output."}
-         → capture the session_id from the returned text.
-      2. Next commands — reuse that session (same container, state preserved):
-         Agent {op:"spawn", name:"dev/sandbox",
-                prompt:"Reuse sandbox session <session_id> — do not open a new one, do not close it. Run: <command>. Report the output."}
-      3. Shut it down when finished:
-         Agent {op:"spawn", name:"dev/sandbox", prompt:"Close sandbox session <session_id>."}
+      ## Multi-step against one warm container
+      1. First call with "keep_open": true — capture `session_id` from the result.
+      2. Later calls pass that "session_id" (same container, state + build cache preserved).
+         A reused session is NOT auto-closed.
+      3. When done, send a final envelope with that "session_id" and "close": true
+         (or just stop — the idle timeout reaps it).
 
       ## Notes
-      - The container persists between spawns (the sandbox holds it), so the checkout,
-        installed deps, and build cache carry over — as long as you pass the same
-        session_id and don't leave it idle too long.
-      - Idle timeout: the container is reaped after a period with no commands. Across a
-        SHORT gap between your spawns that's fine (each command resets the clock). Across
-        a LONG gap — e.g. you're waiting on the human between turns — it will be reaped:
-        the next spawn should just reopen and start fresh (the previous /work is gone),
-        unless the operator configured a durable workspace. There is no way to keep a
-        container alive across a long human pause from here — that's a limitation of
-        driving the sandbox spawn-by-spawn.
-      - Always close the session when the task is genuinely done; don't leave sandboxes
-        running. (If the human may continue, keep it open and hold onto the session_id.)
-      - Compiled binaries run inside the sandbox (it's a real container), so
-        `./your-binary` works there.
-      - If dev/sandbox reports the sandbox tools are unavailable, the builder sidecar
-        isn't deployed — tell the human rather than trying to run code another way.
+      - The container persists only while warm; a long idle gap reaps it (its /work is
+        gone) unless the operator configured a durable `workspace`.
+      - If dev/exec reports the sandbox tools are unavailable, the builder sidecar isn't
+        deployed — tell the human rather than trying to run code another way.
+      - Compiled binaries run inside the sandbox (a real container), so `./your-binary`
+        works there; pull artifacts out with the envelope's `read`.
 
 mcp_servers:
   sandbox:

--- a/cmd/loomcycle/embedded/presets_test.go
+++ b/cmd/loomcycle/embedded/presets_test.go
@@ -24,6 +24,7 @@ func TestUnits_RegistryShape(t *testing.T) {
 		"team-examples":  "bundle",
 		"sandbox":        "bundle",
 		"doc-colorizer":  "bundle",
+		"dev-exec":       "bundle",
 	}
 	for name, kind := range want {
 		u, ok := byName[name]

--- a/cmd/loomcycle/presets_devexec_codejs_test.go
+++ b/cmd/loomcycle/presets_devexec_codejs_test.go
@@ -1,0 +1,261 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/loop"
+	"github.com/denn-gubsky/loomcycle/internal/providers/codejs"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// This file EXECUTES dev/exec's shipped code-js body through the REAL agent loop +
+// the real code-js provider, against a fake mcp__sandbox__* toolset that records
+// every dispatch. Grepping the source would only prove the text is present; running
+// it proves the command envelope is translated into the right open→(write)→exec→
+// (read)→close sequence, that a failing command stops the chain, that a reused
+// session is never closed, and that the JS actually COMPILES + RUNS. Hermetic:
+// the code-js provider is in-process and the tools are local fakes.
+
+type fakeSandbox struct {
+	calls   []recordedCall
+	openN   int
+	openNet []string        // network arg of each sandbox_open
+	execErr map[string]bool // commands whose exec should return IsError
+}
+
+func newFakeSandbox() *fakeSandbox { return &fakeSandbox{execErr: map[string]bool{}} }
+
+func (s *fakeSandbox) execs() []string {
+	var out []string
+	for _, c := range s.calls {
+		if c.Tool == "mcp__sandbox__sandbox_exec" {
+			cmd, _ := c.Input["command"].(string)
+			out = append(out, cmd)
+		}
+	}
+	return out
+}
+
+func (s *fakeSandbox) hasTool(name string) bool {
+	for _, c := range s.calls {
+		if c.Tool == name {
+			return true
+		}
+	}
+	return false
+}
+
+// sbxTool is one fake mcp__sandbox__sandbox_* tool, bound by its exact canonical
+// name so code-js reaches it as mcp__sandbox__sandbox_open({...}) etc.
+type sbxTool struct {
+	s    *fakeSandbox
+	name string
+}
+
+func (t *sbxTool) Name() string                 { return t.name }
+func (t *sbxTool) Description() string          { return "sandbox test double" }
+func (t *sbxTool) InputSchema() json.RawMessage { return json.RawMessage(`{"type":"object"}`) }
+
+func (t *sbxTool) Execute(_ context.Context, raw json.RawMessage) (tools.Result, error) {
+	in := map[string]any{}
+	_ = json.Unmarshal(raw, &in)
+	t.s.calls = append(t.s.calls, recordedCall{Tool: t.name, Input: in})
+	switch t.name {
+	case "mcp__sandbox__sandbox_open":
+		t.s.openN++
+		net, _ := in["network"].(string)
+		t.s.openNet = append(t.s.openNet, net)
+		return okResult(map[string]any{"session_id": "s_test", "workspace_path": "/work", "network": net})
+	case "mcp__sandbox__sandbox_exec":
+		cmd, _ := in["command"].(string)
+		if t.s.execErr[cmd] {
+			// Mirror the real tool: a non-zero exit is IsError with the output.
+			return tools.Result{IsError: true, Text: "boom\n[exit: 1]"}, nil
+		}
+		return tools.Result{Text: "ok: " + cmd}, nil // raw command output (not JSON)
+	case "mcp__sandbox__sandbox_write":
+		return tools.Result{Text: "wrote"}, nil
+	case "mcp__sandbox__sandbox_read":
+		return tools.Result{Text: "file-contents"}, nil
+	case "mcp__sandbox__sandbox_close":
+		return tools.Result{Text: "closed " + firstString(in["session_id"])}, nil
+	}
+	return tools.Result{IsError: true, Text: "unexpected tool " + t.name}, nil
+}
+
+func firstString(v any) string { s, _ := v.(string); return s }
+
+func sandboxToolset(s *fakeSandbox) []tools.Tool {
+	names := []string{
+		"mcp__sandbox__sandbox_open", "mcp__sandbox__sandbox_exec",
+		"mcp__sandbox__sandbox_write", "mcp__sandbox__sandbox_read",
+		"mcp__sandbox__sandbox_close",
+	}
+	set := make([]tools.Tool, 0, len(names))
+	for _, n := range names {
+		set = append(set, &sbxTool{s: s, name: n})
+	}
+	return set
+}
+
+// runDevExec drives the SHIPPED dev/exec code-js body through the real loop against
+// the fake sandbox toolset with the given JSON envelope as the prompt.
+func runDevExec(t *testing.T, s *fakeSandbox, envelope string) loop.RunResult {
+	t.Helper()
+	t.Setenv("LOOMCYCLE_SKILLS_ROOT", "")
+	cfg, err := config.LoadLayers(layersFor(t, "base", "sandbox", "dev-exec")...)
+	if err != nil {
+		t.Fatalf("load base+sandbox+dev-exec: %v", err)
+	}
+	agent, ok := cfg.Agents["dev/exec"]
+	if !ok {
+		t.Fatalf("dev/exec not registered (agents: %v)", agentNames(cfg))
+	}
+	set := sandboxToolset(s)
+	prov := codejs.New(codejs.Config{CodeRoot: t.TempDir(), RunTimeout: 30 * time.Second})
+	res, err := loop.Run(context.Background(), loop.RunOptions{
+		Provider:   prov,
+		Model:      "code-js",
+		AgentName:  "dev/exec",
+		CodeBody:   agent.Code,
+		Tools:      set,
+		Dispatcher: tools.NewDispatcher(set),
+		Segments: []loop.PromptSegment{{
+			Role:    "user",
+			Content: []loop.PromptContentBlock{{Type: "trusted-text", Text: envelope}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("loop.Run: %v\ncalls so far: %v", err, s.calls)
+	}
+	return res
+}
+
+// TestDevExec_RunsEnvelopeOpenWriteExecReadClose is the happy path: one session,
+// files written, commands run in order (network defaults to egress), artifacts
+// read, session closed.
+func TestDevExec_RunsEnvelopeOpenWriteExecReadClose(t *testing.T) {
+	s := newFakeSandbox()
+	env := `{"files":[{"path":"main.go","content":"package main"}],` +
+		`"commands":["echo hi","go build ./..."],"read":["bin/app"]}`
+
+	res := runDevExec(t, s, env)
+
+	if s.openN != 1 {
+		t.Fatalf("want exactly 1 sandbox_open, got %d", s.openN)
+	}
+	if len(s.openNet) == 0 || s.openNet[0] != "egress" {
+		t.Errorf("open network = %v, want egress (the dev default)", s.openNet)
+	}
+	if !s.hasTool("mcp__sandbox__sandbox_write") {
+		t.Errorf("files were not written; calls %v", s.execs())
+	}
+	if !s.hasTool("mcp__sandbox__sandbox_read") {
+		t.Errorf("read artifacts were not fetched")
+	}
+	if !s.hasTool("mcp__sandbox__sandbox_close") {
+		t.Errorf("a freshly-opened session must be closed when keep_open is unset")
+	}
+	// The two user commands ran, in order (a best-effort `gh auth setup-git` exec
+	// may precede them — assert order among the user commands, not exact count).
+	execs := s.execs()
+	if !containsInOrder(execs, "echo hi", "go build ./...") {
+		t.Errorf("user commands not run in order; execs=%v", execs)
+	}
+	if res.StopReason != "end_turn" {
+		t.Errorf("stop reason = %q, want end_turn", res.StopReason)
+	}
+	// The structured result reports both commands succeeded.
+	if !strings.Contains(res.FinalText, "2 ok, 0 failed") {
+		t.Errorf("final_text = %q, want it to report 2 ok / 0 failed", res.FinalText)
+	}
+}
+
+// TestDevExec_StopsAtFirstFailingCommand: a non-zero exit halts the chain (the
+// later command never runs), the session still closes, and ok is false.
+func TestDevExec_StopsAtFirstFailingCommand(t *testing.T) {
+	s := newFakeSandbox()
+	s.execErr["boom"] = true
+	env := `{"commands":["ok-1","boom","never"]}`
+
+	res := runDevExec(t, s, env)
+
+	execs := s.execs()
+	if containsStr(execs, "never") {
+		t.Errorf("a command ran after a failure — the chain must stop at the first failure; execs=%v", execs)
+	}
+	if !containsStr(execs, "boom") {
+		t.Errorf("the failing command was never attempted; execs=%v", execs)
+	}
+	if !s.hasTool("mcp__sandbox__sandbox_close") {
+		t.Errorf("the session must still close after a failing command")
+	}
+	if !strings.Contains(res.FinalText, "1 failed") || !strings.Contains(res.FinalText, "first failure: boom") {
+		t.Errorf("final_text = %q, want it to report the failure + which command", res.FinalText)
+	}
+}
+
+// TestDevExec_ReusedSessionIsNotOpenedOrClosed: passing session_id means the caller
+// owns the container's lifecycle — dev/exec neither opens a new one nor closes it.
+func TestDevExec_ReusedSessionIsNotOpenedOrClosed(t *testing.T) {
+	s := newFakeSandbox()
+	env := `{"session_id":"s_external","commands":["echo hi"]}`
+
+	runDevExec(t, s, env)
+
+	if s.openN != 0 {
+		t.Errorf("a reused session must NOT open a new one (opened %d)", s.openN)
+	}
+	if s.hasTool("mcp__sandbox__sandbox_close") {
+		t.Errorf("a reused (caller-owned) session must NOT be closed unless close=true")
+	}
+	// The command ran against the passed-in session id.
+	for _, c := range s.calls {
+		if c.Tool == "mcp__sandbox__sandbox_exec" {
+			if c.Input["session_id"] != "s_external" {
+				t.Errorf("exec ran against %v, want the reused s_external", c.Input["session_id"])
+			}
+		}
+	}
+}
+
+// TestDevExec_EmptyEnvelopeDoesNothing: no commands/files/read/browser → a usage
+// message and NO container is opened (nothing to run).
+func TestDevExec_EmptyEnvelopeDoesNothing(t *testing.T) {
+	s := newFakeSandbox()
+
+	res := runDevExec(t, s, `{}`)
+
+	if s.openN != 0 || len(s.calls) != 0 {
+		t.Errorf("an empty envelope must not touch the sandbox; calls=%v", s.calls)
+	}
+	if !strings.Contains(res.FinalText, "nothing to do") {
+		t.Errorf("final_text = %q, want a usage/nothing-to-do message", res.FinalText)
+	}
+}
+
+func containsStr(hay []string, s string) bool {
+	for _, h := range hay {
+		if h == s {
+			return true
+		}
+	}
+	return false
+}
+
+// containsInOrder reports whether want appears as an ordered (not necessarily
+// contiguous) subsequence of got.
+func containsInOrder(got []string, want ...string) bool {
+	i := 0
+	for _, g := range got {
+		if i < len(want) && g == want[i] {
+			i++
+		}
+	}
+	return i == len(want)
+}

--- a/cmd/loomcycle/presets_integration_test.go
+++ b/cmd/loomcycle/presets_integration_test.go
@@ -124,37 +124,30 @@ func TestEmbedded_DefaultStackValidates(t *testing.T) {
 	}
 }
 
-// TestEmbedded_SandboxBundleValidates: the opt-in sandbox bundle loads +
-// validates on top of base, registering the dev/sandbox agent (with its skill
-// and the mcp__sandbox__* tool grants) and the sandbox MCP server. The bundle is
-// NOT in the default stack (it needs the builder sidecar + a token), so it gets
-// its own guard here — an ACL grant without a matching declaration would fail
-// validate() fatally, exactly as the v1.20.1 default-stack regression did.
+// TestEmbedded_SandboxBundleValidates: the opt-in sandbox bundle loads + validates
+// on top of base. Post-refactor it carries NO agent (the LLM dev/sandbox was retired
+// for the deterministic code-js dev/exec, shipped in the dev-exec bundle) — it ships
+// the sandbox MCP wiring + the caller-facing dev/sandbox-usage delegation skill, so
+// it stays flag-independent (usable without LOOMCYCLE_CODE_AGENTS_ENABLED). An ACL
+// grant without a matching declaration would fail validate() fatally, so this guards
+// the bundle in isolation.
 func TestEmbedded_SandboxBundleValidates(t *testing.T) {
 	t.Setenv("LOOMCYCLE_SKILLS_ROOT", "")
 	cfg, err := config.LoadLayers(layersFor(t, "base", "sandbox")...)
 	if err != nil {
 		t.Fatalf("base + sandbox must load + validate cleanly: %v", err)
 	}
-	agent, ok := cfg.Agents["dev/sandbox"]
-	if !ok {
-		t.Fatalf("dev/sandbox agent not registered (agents: %v)", agentNames(cfg))
+	// The LLM dev/sandbox agent + its tool-driving skill are GONE (replaced by the
+	// code-js dev/exec in the dev-exec bundle).
+	if _, ok := cfg.Agents["dev/sandbox"]; ok {
+		t.Errorf("dev/sandbox agent should be removed from the sandbox bundle")
 	}
-	// The agent grants the whole sandbox tool family via the `mcp__sandbox__*`
-	// prefix glob (auto-includes future sandbox_* tools) + the auto-added Skill tool.
-	for _, want := range []string{"mcp__sandbox__*", "Skill"} {
-		if !hasToolPreset(agent.Tools, want) {
-			t.Errorf("dev/sandbox should grant %q; tools=%v", want, agent.Tools)
-		}
+	if _, ok := cfg.Skills["dev/sandbox"]; ok {
+		t.Errorf("dev/sandbox tool-driving skill should be removed")
 	}
-	// dev/sandbox runs on the low tier (cheap model — it drives a toolchain, not deep
-	// reasoning; the base preset supplies `low`).
-	if agent.Tier != "low" {
-		t.Errorf("dev/sandbox tier = %q, want low", agent.Tier)
-	}
-	// The inline skill is in the on-demand catalog with its body intact.
-	if sk, ok := cfg.Skills["dev/sandbox"]; !ok || strings.TrimSpace(sk.Body) == "" {
-		t.Errorf("dev/sandbox skill missing or empty in cfg.Skills")
+	// The caller-facing delegation skill remains (rewritten to target dev/exec).
+	if sk, ok := cfg.Skills["dev/sandbox-usage"]; !ok || strings.TrimSpace(sk.Body) == "" {
+		t.Errorf("dev/sandbox-usage skill missing or empty in cfg.Skills")
 	}
 	// The MCP server the tools resolve through is declared (http transport + url).
 	sv, ok := cfg.MCPServers["sandbox"]
@@ -164,10 +157,12 @@ func TestEmbedded_SandboxBundleValidates(t *testing.T) {
 	if sv.Transport != "http" || sv.URL == "" {
 		t.Errorf("sandbox MCP server should be http with a url; got transport=%q url=%q", sv.Transport, sv.URL)
 	}
+	// The git-token injection header rides mcp_servers.sandbox (resolved server-side).
+	if got := sv.Headers["X-Loom-Sandbox-Env-Gh-Token"]; got != "$cred:sandbox_github" {
+		t.Errorf("sandbox git-token header = %q, want $cred:sandbox_github", got)
+	}
 	// One shared secret under the sidecar's OWN name: the Authorization header
-	// expands SANDBOX_AUTH_TOKEN from the env (allowlisted) — no LOOMCYCLE_ alias,
-	// and no ${run.user_bearer} prefix (the sidecar does shared-secret auth, so a
-	// per-run bearer would only 401).
+	// expands SANDBOX_AUTH_TOKEN from the env (allowlisted), no ${run.user_bearer}.
 	t.Setenv("SANDBOX_AUTH_TOKEN", "sekret-xyz")
 	cfg2, err := config.LoadLayers(layersFor(t, "base", "sandbox")...)
 	if err != nil {
@@ -175,6 +170,36 @@ func TestEmbedded_SandboxBundleValidates(t *testing.T) {
 	}
 	if got := cfg2.MCPServers["sandbox"].Headers["Authorization"]; got != "Bearer sekret-xyz" {
 		t.Errorf("sandbox Authorization = %q, want \"Bearer sekret-xyz\" (SANDBOX_AUTH_TOKEN expanded, no user_bearer)", got)
+	}
+}
+
+// TestEmbedded_DevExecBundleValidates: the opt-in dev-exec bundle loads + validates
+// on top of base+sandbox, registering the deterministic code-js dev/exec agent with
+// the mcp__sandbox__* ceiling + an inline code body. It is NOT in the default stack
+// (it needs LOOMCYCLE_CODE_AGENTS_ENABLED, boot-fatal when disabled) — but, like
+// doc-colorizer, config load/validate does NOT require the flag (the gate is a
+// server-boot provider-registration check), so this validates in CI unchanged.
+func TestEmbedded_DevExecBundleValidates(t *testing.T) {
+	t.Setenv("LOOMCYCLE_SKILLS_ROOT", "")
+	cfg, err := config.LoadLayers(layersFor(t, "base", "sandbox", "dev-exec")...)
+	if err != nil {
+		t.Fatalf("base + sandbox + dev-exec must load + validate cleanly: %v", err)
+	}
+	agent, ok := cfg.Agents["dev/exec"]
+	if !ok {
+		t.Fatalf("dev/exec agent not registered (agents: %v)", agentNames(cfg))
+	}
+	if agent.Provider != "code-js" {
+		t.Errorf("dev/exec provider = %q, want code-js", agent.Provider)
+	}
+	// It drives the sandbox tool family via the mcp__sandbox__* glob (no LLM tier).
+	if !hasToolPreset(agent.Tools, "mcp__sandbox__*") {
+		t.Errorf("dev/exec should grant mcp__sandbox__*; tools=%v", agent.Tools)
+	}
+	// It ships its logic inline (no filesystem agent_code/ bind) — an empty Code
+	// would mean the bundle shipped nothing.
+	if strings.TrimSpace(agent.Code) == "" {
+		t.Errorf("dev/exec must carry an inline code body")
 	}
 }
 

--- a/deploy/builder/INSTALL.md
+++ b/deploy/builder/INSTALL.md
@@ -175,10 +175,13 @@ warm. Full detail: [`README.md`](README.md#durable-workspaces-persistent-work).
 
 On the **loomcycle** service, two changes:
 
-1. Add the **`sandbox`** bundle to your presets — it registers the `dev/sandbox`
-   agent + skill and the `mcp_servers.sandbox` block that dials the sidecar:
+1. Add the **`sandbox`** bundle (the `mcp_servers.sandbox` wiring + the
+   `dev/sandbox-usage` delegation skill) and the **`dev-exec`** bundle (the
+   deterministic code-js `dev/exec` executor agent — needs
+   `LOOMCYCLE_CODE_AGENTS_ENABLED=1`):
    ```yaml
-   LOOMCYCLE_PRESETS: "base,document-agent,chat,agent-teams,team-examples,sandbox"
+   LOOMCYCLE_PRESETS: "base,document-agent,chat,agent-teams,team-examples,sandbox,dev-exec"
+   LOOMCYCLE_CODE_AGENTS_ENABLED: "1"
    ```
 2. Ensure `SANDBOX_AUTH_TOKEN` is set (Phase 2 added it to
    `loomcycle.secrets.env`, which the loomcycle service already reads via `env_file`).
@@ -209,10 +212,11 @@ to the sidecar (lazy-retries if the sidecar starts a moment later — non-fatal)
    `loomcycle-builder <ver> listening on :9000 (... runtime="" ...)`.
 2. **Tools discovered:** the loomcycle logs show the `sandbox` MCP server connecting
    and registering `mcp__sandbox__*` (or check the Web UI → Integrations / Library).
-3. **End-to-end:** start the **`dev/sandbox`** agent (Web UI `/run`, or `POST /v1/runs`)
-   and ask it to *"open a sandbox, write a Go hello-world, build and run it, and show
-   the output."* It should `sandbox_open` → `sandbox_write` → `sandbox_exec "go run ."`
-   → return the output → `sandbox_close`.
+3. **End-to-end:** spawn the **`dev/exec`** agent (Web UI `/run`, or `POST /v1/runs`)
+   with a command envelope, e.g.
+   `{"files":[{"path":"main.go","content":"package main\nimport \"fmt\"\nfunc main(){fmt.Println(\"hi\")}"}],"commands":["go run ."]}`.
+   It runs `sandbox_open` → `sandbox_write` → `sandbox_exec "go run ."` → `sandbox_close`
+   and returns the `results` (with the `go run` output).
 4. **Isolation spot-check** (on the TrueNAS host shell, during a run):
    ```sh
    docker ps --filter label=loomcycle.managed=1     # a loom-sbx-… sibling appears

--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -62,8 +62,10 @@ builder-sidecar                    ──►  per-session container
    Nested podman needs a capable host runtime — **Sysbox** (secure) is preferred;
    `privileged: true` is the fallback (e.g. on TrueNAS, which lacks Sysbox).
 
-4. **Enable the bundle:** `LOOMCYCLE_PRESETS=base,sandbox`. That registers the
-   `dev/sandbox` agent + skill and the `sandbox` MCP server:
+4. **Enable the bundles:** `LOOMCYCLE_PRESETS=base,sandbox,dev-exec`. `sandbox`
+   registers the `sandbox` MCP server + the `dev/sandbox-usage` delegation skill;
+   `dev-exec` registers the deterministic code-js **`dev/exec`** agent (needs
+   `LOOMCYCLE_CODE_AGENTS_ENABLED=1`):
 
    ```yaml
    mcp_servers:
@@ -77,9 +79,11 @@ builder-sidecar                    ──►  per-session container
    (Selecting the bundle supplies this block; re-declare `url` in your overlay if
    the sidecar isn't at `builder-sidecar:9000`.)
 
-5. **Run it.** Start the `dev/sandbox` agent (or grant `mcp__sandbox__*` to your
-   own agent) and ask it to compile/test something. It opens a session, writes
-   files, builds, tests, reads the artifact, and closes.
+5. **Run it.** Spawn the `dev/exec` agent with a JSON command envelope (or grant
+   `mcp__sandbox__*` to your own agent), e.g.
+   `{"commands":["git clone https://github.com/OWNER/REPO .","go build ./... && go test ./..."]}`.
+   It opens a session, writes any `files`, runs the `commands`, reads back any
+   `read` artifacts, and closes — returning structured `results` for you to act on.
 
 ## Tools
 
@@ -123,7 +127,7 @@ real dev — clone/push a **private** repo, use `gh` — inject a GitHub token:
 3. The `sandbox` bundle already forwards it: `mcp_servers.sandbox.headers` carries
    `X-Loom-Sandbox-Env-Gh-Token: "$cred:sandbox_github"`, which loomcycle resolves
    **server-side** (never in the model) and the sidecar maps to `GH_TOKEN` in the
-   session env. In-session, `dev/sandbox` runs `gh auth setup-git` so `git` over
+   session env. `dev/exec` runs `gh auth setup-git` at session open, so `git` over
    HTTPS uses it too.
 
 Unresolved (no such credential, or injection disabled) → the header is dropped →
@@ -147,16 +151,16 @@ sidecar — Chromium lives only in the sidecar, not in loomcycle.
    hardening (`read_only`, tmpfs, `cap_drop: ALL`, `no-new-privileges`).
 2. Use `denngubsky/loomcycle-browser:<version>` for the loomcycle runtime and give
    it the same `PINCHTAB_TOKEN` (the stdio child inherits loomcycle's env).
-3. Overlay the config (a file in `LOOMCYCLE_CONFIG_DIR`):
+3. Overlay the config (a file in `LOOMCYCLE_CONFIG_DIR`) to DECLARE the browser
+   server — the `dev/exec` agent already grants `mcp__browser__*` in its ceiling and
+   drives it via the envelope's optional `browser` steps, so no agent override is
+   needed:
    ```yaml
    mcp_servers:
      browser:
        transport: stdio
        command: /usr/local/bin/pinchtab
        args: ["--server", "http://pinchtab:9867", "mcp"]
-   agents:
-     dev/sandbox:
-       tools: [mcp__sandbox__*, mcp__browser__*, Interruption]
    ```
 
 Scope: reachable URLs (public sites / your deployment / preview URLs). PinchTab
@@ -166,18 +170,22 @@ example is in [`../cloud-deployment/`](../cloud-deployment/).
 ## Delegating from other agents
 
 An agent doesn't hold the `mcp__sandbox__*` tools directly (by design — tool ceilings
-are per operator-vetted agent, and skills can't widen them). To let a general agent run
-code, it **delegates to `dev/sandbox`** via the `Agent` tool — the sub-agent has the
-sandbox tools; the parent never does. The `sandbox` bundle ships a **`dev/sandbox-usage`
-skill** teaching exactly this, and the bundled **`chat/*` agents get the `Agent` tool**,
-so with `LOOMCYCLE_PRESETS=…,chat,sandbox` a chat agent can:
+are per operator-vetted agent, and skills can't widen them). To run code, it
+**delegates to `dev/exec`** via the `Agent` tool. `dev/exec` is a DETERMINISTIC
+code-js executor (no LLM): you send it a JSON **command envelope** and it runs the
+steps in an isolated container and returns STRUCTURED results — the judgment (read a
+failure, decide the fix, re-send) stays with the caller. The `sandbox` bundle ships a
+**`dev/sandbox-usage` skill** teaching exactly this, and the bundled **`chat/*` agents
+get the `Agent` tool**, so with `LOOMCYCLE_PRESETS=…,chat,sandbox,dev-exec` a chat
+agent can:
 
-- **one-shot:** `Agent {op:"spawn", name:"dev/sandbox", prompt:"clone X, build + test, report"}` — dev/sandbox opens a session, iterates, closes, returns; or
-- **multi-step:** open once telling it to keep the session open + report the `session_id`, then reuse that `session_id` on later spawns (same container, state preserved), and close it at the end.
+- **one-shot:** `Agent {op:"spawn", name:"dev/exec", prompt:"{\"commands\":[\"git clone https://github.com/OWNER/REPO .\",\"go build ./... && go test ./...\"]}"}` — read `results`, and if a command failed, spawn again with corrected `commands`/`files`; or
+- **multi-step:** first envelope with `"keep_open": true` → capture `session_id` → pass it back on later envelopes (same warm container) → finish with `"close": true`.
 
 To let your own agent delegate, grant it the `Agent` tool (and, optionally, put
 `dev/sandbox-usage` in its `skills:`). To let an agent run the sandbox *itself* rather
-than delegate, grant it the `mcp__sandbox__*` tools directly.
+than delegate, grant it the `mcp__sandbox__*` tools directly. (`dev/exec` needs the
+`dev-exec` bundle + `LOOMCYCLE_CODE_AGENTS_ENABLED=1`.)
 
 ## Sidecar configuration
 

--- a/internal/help/builtin/resident-sub-agents.md
+++ b/internal/help/builtin/resident-sub-agents.md
@@ -4,16 +4,16 @@ description: when (and how) to drive a persistent, steerable sub-agent with Agen
 ---
 # Resident sub-agents — open / send / close
 
-Most sub-agent work is one-shot: `Agent {op:"spawn", …}` runs a child to completion and returns its text. But some helpers need to **keep state across many steps** — a warm sandbox container through a compile→test→fix loop, a REPL or debugger, a long multi-turn analysis. Re-spawning throws that state away every call and forces you to re-thread it by hand. The resident ops solve that.
+Most sub-agent work is one-shot: `Agent {op:"spawn", …}` runs a child to completion and returns its text. But some **interactive** helpers need to **keep state across many steps** — a REPL or debugger driven step by step, an interactive review, a long multi-turn analysis. Re-spawning throws that state away every call and forces you to re-thread it by hand. The resident ops solve that. (For deterministic batch work like running commands in a sandbox, prefer the `dev/exec` code-js agent with a `keep_open` + `session_id` envelope — it isn't a resident LLM agent.)
 
 ## The three ops
 
 - **`open`** — start a PERSISTENT child and run its first turn:
   ```
-  Agent {op:"open", name:"dev/sandbox", prompt:"<first instruction>"}
+  Agent {op:"open", name:"chat/medium", prompt:"<first instruction>"}
   → {"child_run_id":"run_…", "state":"awaiting_input", "output":"…"}
   ```
-  Capture the `child_run_id` — it's the handle for everything after. The child then **parks**, resident, waiting for your next instruction. Its conversation and anything it holds (a sandbox container, installed deps, a build cache) stay live.
+  Capture the `child_run_id` — it's the handle for everything after. The child then **parks**, resident, waiting for your next instruction. Its conversation and anything it holds (open files, a REPL session, accumulated analysis context) stays live.
 
 - **`send`** — give the resident child its next instruction and get that turn's output:
   ```
@@ -45,15 +45,15 @@ Most sub-agent work is one-shot: `Agent {op:"spawn", …}` runs a child to compl
 ## When to use resident vs spawn
 
 - **Use `spawn` / `parallel_spawn`** when you can describe the whole job up front, or when N independent specialists run at once. The child is stateless and returns once.
-- **Use `open` / `send` / `close`** when you'll inspect each result and decide the next step, and the child must stay stateful between steps. A compile→test→fix loop against one warm sandbox container is the canonical case: `open` (write + build), `send` ("now run the tests"), `send` ("fix line 42 and re-run") — the container stays hot the whole time; no re-spawn, no session_id to carry.
+- **Use `open` / `send` / `close`** when you'll inspect each result and decide the next step, and the child must stay stateful between steps. An interactive debugging or analysis session is the canonical case: `open` ("load and summarize this dataset"), `send` ("now drill into the outliers"), `send` ("compare against last week") — the child keeps its accumulated context the whole time; no re-spawn, nothing to re-thread. (Batch sandbox work is different — that's `dev/exec` with a `keep_open` + `session_id` envelope, not a resident LLM child.)
 
 ## Keeping a helper resident across a long task
 
-A long-lived agent — an interactive session, or an orchestrator driving many steps or states — can keep ONE helper resident for the whole task: `open` it once, `send` it work as each step arrives (across state transitions, tool loops, whatever), and `close` it at the end. The child is parented to your run, so it stays alive as long as you do (and is reaped automatically if you finish without closing it). This is how you give a multi-step workflow a single warm sandbox / REPL / analysis context instead of standing one up per step.
+A long-lived agent — an interactive session, or an orchestrator driving many steps or states — can keep ONE helper resident for the whole task: `open` it once, `send` it work as each step arrives (across state transitions, tool loops, whatever), and `close` it at the end. The child is parented to your run, so it stays alive as long as you do (and is reaped automatically if you finish without closing it). This is how you give a multi-step workflow a single warm REPL / analysis / review context instead of standing one up per step.
 
 ## Rules & limits
 
 - **You own the lifecycle.** The child stays alive until you `close` it, or it is idle-reaped after a period with no `send` (operator-configured; override per child with `open`'s `idle_ttl_seconds`), or the run that opened it ends.
 - **Bounded.** A run may hold only so many resident children at once (operator cap); exceeding it fails `open` — close one first.
 - **`state`** tells you where the child is: `awaiting_input` (parked, ready for the next `send`), `completed`/`failed` (the child ended — a further `send` will fail), `closed`.
-- **Container caveat:** a resident child keeps its sandbox container warm between closely-spaced sends, but the container has its own idle timeout on the sandbox side — a very long pause (e.g. waiting on a human across many minutes) can still reap it. For a genuinely long-lived workspace, ask the child to use a durable workspace.
+- **Longevity caveat:** a resident child is parented to your run — it stays live as long as you do, holds its state in memory between closely-spaced sends, and is reaped if you finish without closing it. Don't rely on it surviving a very long idle pause (e.g. waiting on a human across many minutes).


### PR DESCRIPTION
## Why

The `dev/sandbox` agent's real job is **mechanism** — translate a caller's commands
into `sandbox_*` tool calls and report results — not judgment. Running that on an LLM
added token cost, latency, and a flakiness class: on a slow local model a smoke test
watched it mis-type `eggress`, let sessions get reaped between its slow turns, and
finally time out with `context deadline exceeded`. Every failure was mechanism, not
reasoning — the same finding that moved `memory/consolidator` to code-js in v1.36.0.

## What (Path B)

Replace the LLM `dev/sandbox` with a **deterministic code-js `dev/exec`** agent, in
its own opt-in bundle so the widely-used `sandbox` bundle stays flag-independent.

- **New `dev-exec` bundle** — `dev/exec` (`provider: code-js`, RFC J) runs a caller's
  **JSON command envelope**: open (default `network:egress`) → write `files` → run
  `commands` (stop at first failure unless `continue_on_error`) → read `read`
  artifacts → close, returning structured `results`. Reuse a container with
  `session_id`, keep it warm with `keep_open`, best-effort `gh auth setup-git` at
  open, optional `browser` passthrough for `mcp__browser__*`. Zero-token,
  deterministic, replay-safe; the **judgment stays with the caller** (read a failure
  → fix → re-send). Opt-in — needs `LOOMCYCLE_CODE_AGENTS_ENABLED` (like
  doc-colorizer/memory), so it never lands in a default stack.
- **`sandbox` bundle** — dropped the LLM `dev/sandbox` agent + its tool-driving
  skill; kept the `mcp_servers.sandbox` wiring (incl. the `$cred:sandbox_github`
  git-token header) and **rewrote `dev/sandbox-usage`** to document the envelope. No
  code-js agent here → still usable **without** the code-agents flag (grant your own
  agent `mcp__sandbox__*`).
- **Reconciled** everything that named the old agent: the cloud overlay (browser now
  just declares the server; `dev-exec` added to presets), `docs/SANDBOX.md`,
  `deploy/builder/INSTALL.md`, `cloud-deployment/INSTALL.md`, and the
  resident-sub-agents help topic (its warm-sandbox example no longer fits a code-js
  agent that runs to completion).

## Tested

- `go test ./...` — all pass; `gofmt`/`go build ./...` clean.
- Config: `TestEmbedded_DevExecBundleValidates` + a rewritten sandbox-bundle test
  (agent/skill gone, wiring + delegation skill remain) + the registry-shape test.
- **Execution:** `presets_devexec_codejs_test.go` runs the shipped code-js body
  through the real loop against a fake `mcp__sandbox__*` toolset — proving the
  envelope→tool translation (open/write/exec/read/close order), stop-at-first-failure,
  reused-session-not-closed, and empty-envelope-noop (not just that the JS parses).

## Migration note (operators)

`LOOMCYCLE_PRESETS=…,sandbox` now needs `,dev-exec` (and `LOOMCYCLE_CODE_AGENTS_ENABLED=1`)
to get the executor agent; callers spawn **`dev/exec`** with a JSON envelope instead
of `dev/sandbox` with a natural-language prompt. Grepping for `name:"dev/sandbox"`
finds the call sites to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD
