### PR TITLE
feat(memory): the layered entity ontology, inert until confirmed (RFC BL P4c PR 3)

### DIFF
--- a/internal/api/http/meminject.go
+++ b/internal/api/http/meminject.go
@@ -114,6 +114,14 @@ func (s *Server) applyMemoryInjection(ctx context.Context, agentDef config.Agent
 	if body := s.renderSearchRequest(ctx, mi); body != "" {
 		sections[meminject.VariantSearchRequest] = body
 	}
+	// ontology: gated on an actual reference, like user_info, because rendering it
+	// PROVISIONS the tenant's ontology document. A prompt that never mentions the
+	// ontology must not create one as a side effect of being assembled.
+	if meminject.ReferencesVariant(agentDef.SystemPrompt, meminject.VariantOntology) {
+		if body := s.renderOntology(ctx, mi); body != "" {
+			sections[meminject.VariantOntology] = body
+		}
+	}
 	// consolidation_bands is pure config — no store read, no tenant scope, so
 	// it is rendered unconditionally and costs nothing for a prompt that never
 	// places the placeholder (Expand only substitutes what it finds, and this
@@ -125,8 +133,8 @@ func (s *Server) applyMemoryInjection(ctx context.Context, agentDef config.Agent
 		relatedBand = s.cfg.Memory.Consolidation.EffectiveRelatedThreshold()
 	}
 	sections[meminject.VariantConsolidationBands] = meminject.ConsolidationBands(mergeBand, relatedBand)
-	// tenant_info / ontology are accepted variants but resolve to empty in P1
-	// (they need tenant scope + the entity tier — a later phase).
+	// tenant_info is still an accepted-but-empty variant (it needs the tenant-root
+	// document, a later deliverable). ontology is live — see renderOntology.
 
 	out := agentDef
 	out.SystemPrompt = meminject.Expand(agentDef.SystemPrompt, meminject.ExpandInput{

--- a/internal/api/http/ontology.go
+++ b/internal/api/http/ontology.go
@@ -1,0 +1,171 @@
+// ontology.go — SERVER side of the layered entity-tier ontology (RFC BL P4c PR 3).
+//
+// The pure layering + seed live in internal/memory; this file provisions the
+// tenant's ontology document, reads its terms back, and composes the effective
+// ontology for {{memory:ontology}}.
+//
+// PROVISIONING IS LAZY-ON-FIRST-REFERENCE, not eager at tenant creation, and that
+// is a deliberate departure from how it was specified.
+//
+// There IS no tenant-creation event to hang it on: a tenant exists the moment a
+// token names one, and nothing in the runtime observes that transition. Hooking
+// token mint would have covered tenants minted from then on and MISSED every
+// tenant that already exists — including, on the reference deployment, the only
+// one. Lazy provisioning covers both, and it reuses the race-safety already proven
+// on the user-root path: an in-process singleflight collapses a concurrent burst,
+// and a PG advisory lock admits one replica in a cluster.
+//
+// The operator-visible behaviour is the same either way — the document is there
+// the first time anything looks — and until its status is `confirmed` it changes
+// nothing, so provisioning early buys no correctness.
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	meminject "github.com/denn-gubsky/loomcycle/internal/memory"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
+)
+
+// renderOntology composes the {{memory:ontology}} body for a run: the base seed
+// layered with the tenant's terms when — and only when — the tenant has confirmed
+// them.
+//
+// Best-effort throughout. No SQL Memory, no tenant, an unreadable document: the
+// run continues on the base seed rather than failing, because an ontology is
+// guidance and a run that dies for want of it is worse than a run using the
+// standard types.
+func (s *Server) renderOntology(ctx context.Context, mi memInject) string {
+	terms, confirmed := s.tenantOntologyTerms(ctx, mi)
+	return meminject.RenderOntology(meminject.EffectiveOntology(terms, confirmed), confirmed)
+}
+
+// tenantOntologyTerms reads the tenant's ontology document, provisioning it on
+// first reference, and reports its terms plus whether the operator has confirmed
+// them.
+//
+// A tenant layer is returned ONLY alongside confirmed=true; an unconfirmed
+// document's terms are still returned so a caller can show them, but
+// EffectiveOntology discards them. Keeping the discard in one place means no caller
+// can accidentally honour a draft.
+func (s *Server) tenantOntologyTerms(ctx context.Context, mi memInject) (terms []meminject.OntologyTerm, confirmed bool) {
+	if s.store == nil || s.sqlMem == nil {
+		return nil, false
+	}
+	s.ensureOntologyDoc(ctx, mi)
+
+	doc := &builtin.Document{Store: s.store, SqlMem: s.sqlMem}
+	dctx := s.docToolCtx(ctx, mi)
+	// The ontology lives at TENANT scope, so the read has to be granted it. This is
+	// a server-side read of operator-authored config on the run's own tenant, not an
+	// agent reaching tenant memory, so the policy is stamped here rather than
+	// requiring every agent that renders the placeholder to hold the tenant grant.
+	dctx = tools.WithMemoryPolicy(dctx, tools.MemoryPolicyValue{AllowedScopes: []string{"tenant"}})
+	dctx = tools.WithSqlMemPolicy(dctx, tools.SqlMemPolicyValue{AllowedScopes: []string{"tenant"}})
+
+	// The GATE is the root chunk's status, which get_document reports directly.
+	// (It does NOT return a chunk list — an earlier draft of this read expected one
+	// and silently found zero terms, which the wiring test caught.)
+	req, _ := json.Marshal(map[string]any{
+		"op": "get_document", "scope": "tenant", "path": meminject.OntologyPath,
+	})
+	res, _ := doc.Execute(dctx, req)
+	if res.IsError {
+		return nil, false
+	}
+	var meta struct {
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal([]byte(res.Text), &meta); err != nil {
+		return nil, false
+	}
+	confirmed = strings.EqualFold(strings.TrimSpace(meta.Status), meminject.OntologyConfirmedStatus)
+
+	// The TERMS come from export_md — one call for the whole document, in exactly
+	// the shape the operator authored it. Reading the Markdown rather than the
+	// materialized types keeps a single authority: the document is the source, and
+	// anything derived from it is a cache.
+	exp, _ := json.Marshal(map[string]any{
+		"op": "export_md", "scope": "tenant", "path": meminject.OntologyPath,
+		"include_metadata": false,
+	})
+	eres, _ := doc.Execute(dctx, exp)
+	if eres.IsError {
+		return nil, confirmed
+	}
+	var body struct {
+		Markdown string `json:"markdown"`
+	}
+	if err := json.Unmarshal([]byte(eres.Text), &body); err != nil {
+		return nil, confirmed
+	}
+	return meminject.ParseOntologyMarkdown(body.Markdown), confirmed
+}
+
+// ensureOntologyDoc provisions the tenant's ontology document from the embedded
+// template on first reference. Mirrors ensureUserRootDoc's race safety: a
+// singleflight per tenant collapses a concurrent burst, and a PG advisory lock
+// admits one replica in a cluster.
+//
+// Best-effort and idempotent — a failure leaves nothing cached, so the next
+// reference retries.
+func (s *Server) ensureOntologyDoc(ctx context.Context, mi memInject) {
+	if s.store == nil || s.sqlMem == nil {
+		return
+	}
+	_, _, _ = s.userRootProvisionSF.Do("ontology\x00"+mi.Tenant, func() (any, error) {
+		s.provisionOntologyDoc(ctx, mi)
+		return nil, nil
+	})
+}
+
+func (s *Server) provisionOntologyDoc(ctx context.Context, mi memInject) {
+	if s.sessionLockPG != nil {
+		// NUL-free lock id (pg text params reject 0x00). Keyed on the tenant alone:
+		// the ontology is one document per tenant, unlike the per-principal user root.
+		release, ok := s.sessionLockPG.TryLock(ctx, "memory:ontology:"+mi.Tenant)
+		if !ok {
+			return
+		}
+		defer release()
+	}
+
+	doc := &builtin.Document{Store: s.store, SqlMem: s.sqlMem}
+	dctx := s.docToolCtx(ctx, mi)
+	dctx = tools.WithMemoryPolicy(dctx, tools.MemoryPolicyValue{AllowedScopes: []string{"tenant"}})
+	dctx = tools.WithSqlMemPolicy(dctx, tools.SqlMemPolicyValue{AllowedScopes: []string{"tenant"}})
+
+	probe, _ := json.Marshal(map[string]any{
+		"op": "get_document", "scope": "tenant", "path": meminject.OntologyPath,
+	})
+	if res, _ := doc.Execute(dctx, probe); !res.IsError {
+		return // already provisioned, here or by another replica
+	}
+
+	create, _ := json.Marshal(map[string]any{
+		"op": "import_md", "scope": "tenant", "path": meminject.OntologyPath,
+		"markdown": meminject.OntologyTemplate(),
+	})
+	res, _ := doc.Execute(dctx, create)
+	if res.IsError {
+		return // best-effort; the next reference retries
+	}
+	// Stamp the root chunk `draft`. import_md leaves status unset, and an unset
+	// status is NOT confirmed — so the gate already holds — but writing it makes the
+	// state legible to an operator opening the document, who would otherwise have to
+	// know that blank means draft.
+	var created struct {
+		RootChunkID string `json:"root_chunk_id"`
+	}
+	if err := json.Unmarshal([]byte(res.Text), &created); err != nil || created.RootChunkID == "" {
+		return
+	}
+	stamp, _ := json.Marshal(map[string]any{
+		"op": "update_chunk", "scope": "tenant", "id": created.RootChunkID,
+		"status": meminject.OntologyDraftStatus, "revision": 1,
+	})
+	_, _ = doc.Execute(dctx, stamp)
+}

--- a/internal/api/http/ontology_test.go
+++ b/internal/api/http/ontology_test.go
@@ -1,0 +1,200 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	meminject "github.com/denn-gubsky/loomcycle/internal/memory"
+	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
+)
+
+// TestOntology_ReachesTheAssembledPromptAndStartsInert is the wiring plus the gate,
+// in one pass over the path a run actually takes.
+//
+// A capability with no caller passes every test it has — this subsystem has shipped
+// that mistake twice — so the assertion is on the prompt the run gets, not on the
+// renderer in isolation.
+func TestOntology_ReachesTheAssembledPromptAndStartsInert(t *testing.T) {
+	s, mi := ontologyFixture(t)
+	def := config.AgentDef{SystemPrompt: "You extract entities.\n\n{{memory:ontology}}"}
+
+	got, _ := s.applyMemoryInjection(context.Background(), def, mi)
+
+	// The seed reached the prompt.
+	for _, want := range []string{"Entity types", "person", "organization", "preference", "fact"} {
+		if !strings.Contains(got.SystemPrompt, want) {
+			t.Errorf("missing %q in the assembled prompt:\n%s", want, got.SystemPrompt)
+		}
+	}
+	if strings.Contains(got.SystemPrompt, "{{memory:") {
+		t.Errorf("placeholder left unexpanded:\n%s", got.SystemPrompt)
+	}
+	// UNFRAMED — it is a schema to apply, not data to distrust.
+	if strings.Contains(got.SystemPrompt, `<memory source="ontology">`) {
+		t.Errorf("ontology must render unframed:\n%s", got.SystemPrompt)
+	}
+	// And a freshly provisioned deployment is INERT: the document exists, its terms
+	// are not applied, and the prompt says so.
+	if !strings.Contains(got.SystemPrompt, "has not confirmed") {
+		t.Errorf("a newly provisioned tenant should read as unconfirmed:\n%s", got.SystemPrompt)
+	}
+	if strings.Contains(got.SystemPrompt, "incident") {
+		t.Errorf("the template's sample terms applied while still draft:\n%s", got.SystemPrompt)
+	}
+}
+
+// TestOntology_ProvisionsTheDocumentOnFirstReference: lazily, because there is no
+// tenant-creation event to hang it on — a tenant exists the moment a token names
+// one, and nothing observes that transition. Hooking token mint would have missed
+// every tenant that already exists.
+func TestOntology_ProvisionsTheDocumentOnFirstReference(t *testing.T) {
+	s, mi := ontologyFixture(t)
+	def := config.AgentDef{SystemPrompt: "{{memory:ontology}}"}
+	s.applyMemoryInjection(context.Background(), def, mi)
+
+	terms, confirmed := s.tenantOntologyTerms(context.Background(), mi)
+	if confirmed {
+		t.Error("a provisioned document must start unconfirmed")
+	}
+	// The template's three worked examples are present as terms, ready to edit —
+	// they are just not in force yet.
+	names := map[string]bool{}
+	for _, term := range terms {
+		names[strings.ToLower(term.Name)] = true
+	}
+	for _, want := range []string{"project", "incident", "constraint"} {
+		if !names[want] {
+			t.Errorf("the provisioned document should carry the %q sample term (have %v)", want, names)
+		}
+	}
+}
+
+// TestOntology_NotReferencedNeverProvisions: rendering PROVISIONS a document, so a
+// prompt that never mentions the ontology must not create one as a side effect of
+// being assembled. The same rule user_info follows.
+func TestOntology_NotReferencedNeverProvisions(t *testing.T) {
+	s, mi := ontologyFixture(t)
+	def := config.AgentDef{SystemPrompt: "A prompt with no placeholders."}
+
+	got, _ := s.applyMemoryInjection(context.Background(), def, mi)
+	if got.SystemPrompt != def.SystemPrompt {
+		t.Errorf("the fast path should return byte-identical, got:\n%s", got.SystemPrompt)
+	}
+	if s.ontologyDocExists(t, mi) {
+		t.Error("an unreferenced ontology must not be provisioned")
+	}
+}
+
+// TestOntology_ConfirmedLayerApplies closes the loop: flip the root chunk to
+// confirmed and the operator's terms take effect. Without this the gate is only
+// proven in one direction, which is how a gate that never opens ships.
+func TestOntology_ConfirmedLayerApplies(t *testing.T) {
+	s, mi := ontologyFixture(t)
+	def := config.AgentDef{SystemPrompt: "{{memory:ontology}}"}
+	s.applyMemoryInjection(context.Background(), def, mi) // provision
+
+	s.confirmOntology(t, mi)
+
+	got, _ := s.applyMemoryInjection(context.Background(), def, mi)
+	if strings.Contains(got.SystemPrompt, "has not confirmed") {
+		t.Errorf("a confirmed deployment should not read as unconfirmed:\n%s", got.SystemPrompt)
+	}
+	for _, want := range []string{"project", "incident", "constraint"} {
+		if !strings.Contains(got.SystemPrompt, want) {
+			t.Errorf("confirmed tenant term %q missing from the prompt:\n%s", want, got.SystemPrompt)
+		}
+	}
+	// The seed survives alongside the tenant layer — this is a layering, not a
+	// replacement.
+	if !strings.Contains(got.SystemPrompt, "person") {
+		t.Errorf("the base seed was lost when the tenant layer activated:\n%s", got.SystemPrompt)
+	}
+}
+
+// ---- fixture + helpers ----
+
+// ontologyFixture builds a Server with a real store and a real SQL Memory manager
+// — the ontology lives in a tenant-scope Document, so a stub would prove nothing
+// about the path a run takes.
+func ontologyFixture(t *testing.T) (*Server, memInject) {
+	t.Helper()
+	st, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	mgr, err := sqlmem.New(sqlmem.Config{Root: t.TempDir()})
+	if err != nil {
+		t.Fatalf("sqlmem.New: %v", err)
+	}
+	t.Cleanup(func() { _ = mgr.Close() })
+
+	s := &Server{store: st, sqlMem: mgr}
+	return s, memInject{Tenant: "acme", UserID: "alice", AgentName: "curator"}
+}
+
+// ontologyDocExists reports whether the tenant's ontology document is present,
+// WITHOUT provisioning it — a probe that provisioned would make
+// TestOntology_NotReferencedNeverProvisions vacuous.
+func (s *Server) ontologyDocExists(t *testing.T, mi memInject) bool {
+	t.Helper()
+	doc := &builtin.Document{Store: s.store, SqlMem: s.sqlMem}
+	dctx := tools.WithMemoryPolicy(s.docToolCtx(context.Background(), mi),
+		tools.MemoryPolicyValue{AllowedScopes: []string{"tenant"}})
+	dctx = tools.WithSqlMemPolicy(dctx, tools.SqlMemPolicyValue{AllowedScopes: []string{"tenant"}})
+	req, _ := json.Marshal(map[string]any{
+		"op": "get_document", "scope": "tenant", "path": meminject.OntologyPath,
+	})
+	res, _ := doc.Execute(dctx, req)
+	return !res.IsError
+}
+
+// confirmOntology flips the root chunk to `confirmed`, which is what an operator
+// does in the Web UI.
+func (s *Server) confirmOntology(t *testing.T, mi memInject) {
+	t.Helper()
+	doc := &builtin.Document{Store: s.store, SqlMem: s.sqlMem}
+	dctx := tools.WithMemoryPolicy(s.docToolCtx(context.Background(), mi),
+		tools.MemoryPolicyValue{AllowedScopes: []string{"tenant"}})
+	dctx = tools.WithSqlMemPolicy(dctx, tools.SqlMemPolicyValue{AllowedScopes: []string{"tenant"}})
+
+	get, _ := json.Marshal(map[string]any{
+		"op": "get_document", "scope": "tenant", "path": meminject.OntologyPath,
+	})
+	res, _ := doc.Execute(dctx, get)
+	if res.IsError {
+		t.Fatalf("confirmOntology: get: %s", res.Text)
+	}
+	var meta struct {
+		RootChunkID string `json:"root_chunk_id"`
+	}
+	if err := json.Unmarshal([]byte(res.Text), &meta); err != nil {
+		t.Fatalf("confirmOntology: decode: %v", err)
+	}
+	// The revision comes from get_chunk: get_document does not return one, and
+	// provisioning already bumped the root to 2 by stamping `draft`.
+	gc, _ := json.Marshal(map[string]any{"op": "get_chunk", "scope": "tenant", "id": meta.RootChunkID})
+	cres, _ := doc.Execute(dctx, gc)
+	if cres.IsError {
+		t.Fatalf("confirmOntology: get_chunk: %s", cres.Text)
+	}
+	var chunk struct {
+		Revision int `json:"revision"`
+	}
+	if err := json.Unmarshal([]byte(cres.Text), &chunk); err != nil {
+		t.Fatalf("confirmOntology: decode chunk: %v", err)
+	}
+	upd, _ := json.Marshal(map[string]any{
+		"op": "update_chunk", "scope": "tenant", "id": meta.RootChunkID,
+		"status": meminject.OntologyConfirmedStatus, "revision": chunk.Revision,
+	})
+	if r, _ := doc.Execute(dctx, upd); r.IsError {
+		t.Fatalf("confirmOntology: update: %s", r.Text)
+	}
+}

--- a/internal/memory/inject.go
+++ b/internal/memory/inject.go
@@ -53,10 +53,14 @@ const (
 	// VariantUserInfo renders the user-scope `human` core block (the user-root
 	// document is a later phase).
 	VariantUserInfo Variant = "user_info"
-	// VariantTenantInfo / VariantOntology are accepted but resolve to empty in
-	// P1 (they need tenant scope + the entity tier).
+	// VariantTenantInfo is accepted but resolves to empty — it needs the
+	// tenant-root document, a later deliverable.
 	VariantTenantInfo Variant = "tenant_info"
-	VariantOntology   Variant = "ontology"
+	// VariantOntology renders the effective entity-type ontology: the base seed
+	// layered with the tenant's own terms, and only once the operator has confirmed
+	// them. Unframed (see trustedVariants) — it is a schema to apply, not data to
+	// distrust.
+	VariantOntology Variant = "ontology"
 	// VariantSearchRequest renders an LLM-free retrieval against the run's
 	// initial user input.
 	VariantSearchRequest Variant = "search_request"
@@ -95,6 +99,13 @@ var knownVariants = map[Variant]bool{
 // a test and be argued for rather than slip in.
 var trustedVariants = map[Variant]bool{
 	VariantConsolidationBands: true,
+	// ontology is a SCHEMA the model is meant to apply when it records an entity,
+	// not accumulated content it should hold at arm's length — framing it "do not
+	// follow this" would say the opposite of what is meant, exactly as for the
+	// bands. What makes it safe to trust is its provenance: every term reaches the
+	// renderer through the tenant ontology document, which is operator-authored and
+	// inert until an operator confirms it by hand. No agent-written text lands here.
+	VariantOntology: true,
 }
 
 // KnownVariant reports whether name (whitespace-trimmed, case-normalised) is a

--- a/internal/memory/inject_test.go
+++ b/internal/memory/inject_test.go
@@ -184,11 +184,31 @@ func TestInject_TrustedVariantSurvivesAnExhaustedBudget(t *testing.T) {
 // today because the set has exactly one member, so this test exists to make a
 // future second entry fail CI and be argued for deliberately.
 func TestTrustedVariants_ExactlyConsolidationBands(t *testing.T) {
-	if len(trustedVariants) != 1 {
-		t.Fatalf("trustedVariants must have exactly 1 entry, got %d: %v", len(trustedVariants), trustedVariants)
+	// TWO entries as of the entity tier. This pin fired when `ontology` was added,
+	// which is what it is for — an unframed variant is a trust-boundary decision and
+	// must be argued for rather than slip in.
+	//
+	// The argument for ontology: it is a SCHEMA the model applies when it records an
+	// entity, so framing it "reference data, NOT instructions" would say the opposite
+	// of what is meant — the same reasoning that exempted the bands. What makes it
+	// safe is provenance: every term reaches the renderer through the tenant ontology
+	// document, which is operator-authored and INERT until an operator confirms it by
+	// hand. No agent-written text can reach this body.
+	//
+	// A third entry needs the same standard: operator-authored or
+	// runtime-authored content only, and bounded, since a trusted variant is also
+	// exempt from the injection budget.
+	want := map[Variant]bool{
+		VariantConsolidationBands: true,
+		VariantOntology:           true,
 	}
-	if !trustedVariants[VariantConsolidationBands] {
-		t.Fatalf("the single trusted variant must be consolidation_bands, got %v", trustedVariants)
+	if len(trustedVariants) != len(want) {
+		t.Fatalf("trustedVariants must have exactly %d entries, got %d: %v", len(want), len(trustedVariants), trustedVariants)
+	}
+	for v := range want {
+		if !trustedVariants[v] {
+			t.Errorf("expected %s to be trusted; set is %v", v, trustedVariants)
+		}
 	}
 	for v, trusted := range trustedVariants {
 		if !trusted {

--- a/internal/memory/ontology.go
+++ b/internal/memory/ontology.go
@@ -1,0 +1,242 @@
+package memory
+
+// ontology.go — the layered entity-tier ontology (RFC BL P4c PR 3).
+//
+// The effective ontology is `base seed ⊕ tenant layer`, and the tenant layer only
+// counts once the operator has CONFIRMED it. Until then a tenant runs on the seed
+// alone, which means provisioning the document changes nothing on its own — the
+// operator's flip is what activates it.
+//
+// That document-level gate replaced a per-term propose/approve queue during
+// design, and the reason is worth keeping: a queue accumulates `pending` terms and
+// the effective ontology silently stops growing, so the failure mode is invisible.
+// A single draft→confirmed flip cannot rot that way — before it, nothing changed;
+// after it, everything the operator wrote applies.
+
+import (
+	_ "embed"
+	"encoding/json"
+	"sort"
+	"strings"
+)
+
+//go:embed templates/ontology.md
+var ontologyTemplate string
+
+// OntologyTemplate returns the import_md-shaped Markdown used to seed a tenant's
+// ontology document. Compile-time constant, so provisioning is deterministic.
+//
+// It ships with THREE worked examples rather than a blank page: an operator
+// editing `project`, `incident` and `constraint` into their own vocabulary starts
+// from something that already reads correctly, and the difference between a
+// feature people fill in and one they leave empty is usually whether the first
+// screen shows them the shape.
+func OntologyTemplate() string { return ontologyTemplate }
+
+// OntologyPath is the canonical Path-tree location, in the TENANT scope, of the
+// operator-editable ontology document.
+const OntologyPath = "/memory/ontology"
+
+// OntologyTitle MUST match the template's first heading — import_md makes the
+// first heading the root chunk and the document title.
+const OntologyTitle = "Tenant Ontology"
+
+// OntologyConfirmedStatus is the root-chunk status that ACTIVATES the tenant
+// layer. Any other value (including the provisioned default, `draft`) leaves the
+// tenant running on the base seed alone.
+const OntologyConfirmedStatus = "confirmed"
+
+// OntologyDraftStatus is what a freshly provisioned document carries.
+const OntologyDraftStatus = "draft"
+
+// OntologyTerm is one type in the ontology: a name plus the fields an instance of
+// it carries.
+type OntologyTerm struct {
+	Name   string   `json:"name"`
+	Fields []string `json:"fields"`
+	// Source is "base" for a seed term and "tenant" for one the operator added or
+	// overrode. Reported so a reader can tell which half of the layering they are
+	// looking at without diffing against the seed.
+	Source string `json:"source"`
+}
+
+// BaseSeedOntology is the ontology every tenant starts with: POLE+O — person,
+// object, location, event, organization — plus the two the memory tier itself
+// needs, `preference` and `fact`.
+//
+// POLE+O is borrowed rather than invented. It is the schema intelligence analysts
+// have used for decades because those five cover most of what one says about the
+// world, and a tenant that never edits this file still gets something usable.
+//
+// Returned as a fresh slice each call: a shared package-level slice would let one
+// caller's append or sort reorder every other caller's ontology.
+func BaseSeedOntology() []OntologyTerm {
+	return []OntologyTerm{
+		{Name: "person", Fields: []string{"name", "role", "aliases"}, Source: "base"},
+		{Name: "object", Fields: []string{"name", "kind", "identifier"}, Source: "base"},
+		{Name: "location", Fields: []string{"name", "kind", "region"}, Source: "base"},
+		{Name: "event", Fields: []string{"name", "occurred_at", "participants"}, Source: "base"},
+		{Name: "organization", Fields: []string{"name", "kind", "domain"}, Source: "base"},
+		// The memory tier's own two. `preference` carries a confidence because a
+		// preference is inferred more often than stated; `fact` is the subject /
+		// predicate / object triple the natural key for a fact is built from.
+		{Name: "preference", Fields: []string{"category", "statement", "context", "confidence"}, Source: "base"},
+		{Name: "fact", Fields: []string{"subject", "predicate", "object"}, Source: "base"},
+	}
+}
+
+// EffectiveOntology layers a tenant's terms over the base seed.
+//
+// tenantConfirmed is the gate: when false the tenant's terms are DISCARDED and the
+// result is the seed alone. That is the whole point of the draft state — a
+// half-written ontology must not steer extraction just because it exists on disk.
+//
+// A tenant term with a seed term's name OVERRIDES it (same name, tenant fields),
+// rather than merging field lists. Merging would produce a type the operator never
+// wrote and could not remove a field from; overriding means what the document says
+// is what applies.
+//
+// The result is sorted by name so materialization and prompt rendering are stable
+// — an ontology that reordered between runs would churn the system prompt and cost
+// a provider prompt-cache hit on every call.
+func EffectiveOntology(tenantTerms []OntologyTerm, tenantConfirmed bool) []OntologyTerm {
+	byName := make(map[string]OntologyTerm, len(tenantTerms)+8)
+	for _, t := range BaseSeedOntology() {
+		byName[t.Name] = t
+	}
+	if tenantConfirmed {
+		for _, t := range tenantTerms {
+			if t.Name == "" {
+				continue
+			}
+			t.Source = "tenant"
+			byName[t.Name] = t
+		}
+	}
+	out := make([]OntologyTerm, 0, len(byName))
+	for _, t := range byName {
+		out = append(out, t)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// FieldsJSON renders a term's fields for the chunk_types row. define_type stores
+// fields as an opaque JSON string, so the shape here is what a later reader gets.
+func (t OntologyTerm) FieldsJSON() string {
+	if len(t.Fields) == 0 {
+		return "[]"
+	}
+	b, err := json.Marshal(t.Fields)
+	if err != nil {
+		return "[]"
+	}
+	return string(b)
+}
+
+// RenderOntology composes the {{memory:ontology}} body: the effective terms as a
+// compact list an extractor can apply.
+//
+// UNFRAMED at the injection site (see trustedVariants) because this is a schema
+// the model is meant to USE, not accumulated content it should distrust — the same
+// reasoning as the consolidation bands. What makes that safe is that every term
+// name and field reaching here has passed through the ontology document, which is
+// tenant-operator-authored and confirmed by hand.
+//
+// HOUSE RULE: model-visible text — no internal RFC citations.
+func RenderOntology(terms []OntologyTerm, tenantConfirmed bool) string {
+	if len(terms) == 0 {
+		return ""
+	}
+	b := "# Entity types\n\n" +
+		"When you record an entity or a fact, use one of these types and fill the fields it lists.\n\n"
+	for _, t := range terms {
+		b += "- **" + t.Name + "**"
+		if len(t.Fields) > 0 {
+			b += " — " + joinComma(t.Fields)
+		}
+		b += "\n"
+	}
+	if !tenantConfirmed {
+		// Said plainly because the difference is invisible otherwise: an operator
+		// who edited the document and did not confirm it would see their terms
+		// missing here with no explanation.
+		b += "\nThese are the standard types. This deployment has not confirmed any " +
+			"additions of its own, so use these as they are.\n"
+	}
+	return b
+}
+
+func joinComma(ss []string) string {
+	out := ""
+	for i, s := range ss {
+		if i > 0 {
+			out += ", "
+		}
+		out += s
+	}
+	return out
+}
+
+// ParseOntologyMarkdown extracts terms from the ontology document's Markdown.
+//
+// It reads the format the TEMPLATE writes and an operator edits: a `## name`
+// heading per term, and field names as the first backticked token on each bullet
+// beneath it.
+//
+//	## incident
+//	- `summary` — one sentence on what happened
+//	- `cause` — what turned out to be responsible
+//
+// Parsing the Markdown rather than a structured `fields` map is deliberate: this is
+// hand-edited operator content, and the template's own form is prose with
+// backticks. Requiring JSON would mean the document an operator is invited to edit
+// and the document the runtime can read are different documents.
+//
+// Deliberately lenient. A heading with no bullets is a term with no fields, a
+// bullet with no backticks is skipped, and unparseable prose is ignored rather than
+// failing the read — an ontology that dropped a term over punctuation would be
+// worse than one that occasionally misses a field list. The `#` title heading and
+// any `---` trailer are skipped.
+func ParseOntologyMarkdown(md string) []OntologyTerm {
+	var out []OntologyTerm
+	var cur *OntologyTerm
+	flush := func() {
+		if cur != nil && cur.Name != "" {
+			out = append(out, *cur)
+		}
+		cur = nil
+	}
+	for _, line := range strings.Split(md, "\n") {
+		t := strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(t, "## "):
+			flush()
+			name := strings.TrimSpace(strings.TrimPrefix(t, "## "))
+			cur = &OntologyTerm{Name: name, Source: "tenant"}
+		case strings.HasPrefix(t, "# "):
+			// The document title, not a term.
+			flush()
+		case cur != nil && strings.HasPrefix(t, "- "):
+			if f := firstBackticked(t); f != "" {
+				cur.Fields = append(cur.Fields, f)
+			}
+		}
+	}
+	flush()
+	return out
+}
+
+// firstBackticked returns the first `backticked` token in s, or "".
+func firstBackticked(s string) string {
+	i := strings.Index(s, "`")
+	if i < 0 {
+		return ""
+	}
+	rest := s[i+1:]
+	j := strings.Index(rest, "`")
+	if j <= 0 {
+		return ""
+	}
+	return strings.TrimSpace(rest[:j])
+}

--- a/internal/memory/ontology_test.go
+++ b/internal/memory/ontology_test.go
@@ -1,0 +1,172 @@
+package memory
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestEffectiveOntology_DraftIsInactive is the operator's gate, and the whole
+// reason the ontology ships as a document rather than a config block.
+//
+// An unconfirmed document must change NOTHING. A half-written ontology sitting on
+// disk must not steer extraction just because it exists — before the flip the
+// tenant runs on the seed alone, after it everything the operator wrote applies.
+func TestEffectiveOntology_DraftIsInactive(t *testing.T) {
+	tenant := []OntologyTerm{
+		{Name: "incident", Fields: []string{"summary", "cause"}},
+		{Name: "project", Fields: []string{"name"}},
+	}
+
+	draft := EffectiveOntology(tenant, false)
+	if len(draft) != len(BaseSeedOntology()) {
+		t.Fatalf("an unconfirmed tenant layer must be discarded: got %d terms, want the %d seed terms",
+			len(draft), len(BaseSeedOntology()))
+	}
+	for _, term := range draft {
+		if term.Name == "incident" || term.Name == "project" {
+			t.Errorf("tenant term %q applied while the document was still draft", term.Name)
+		}
+	}
+
+	confirmed := EffectiveOntology(tenant, true)
+	if len(confirmed) != len(BaseSeedOntology())+2 {
+		t.Errorf("a confirmed layer must add its terms: got %d, want %d",
+			len(confirmed), len(BaseSeedOntology())+2)
+	}
+}
+
+// TestEffectiveOntology_TenantOverridesSeedRatherThanMerging: a tenant term with a
+// seed term's name REPLACES it. Merging field lists would produce a type the
+// operator never wrote and give them no way to remove a seed field — what the
+// document says has to be what applies.
+func TestEffectiveOntology_TenantOverridesSeedRatherThanMerging(t *testing.T) {
+	got := EffectiveOntology([]OntologyTerm{
+		{Name: "person", Fields: []string{"full_name", "employee_id"}},
+	}, true)
+
+	var person OntologyTerm
+	for _, term := range got {
+		if term.Name == "person" {
+			person = term
+		}
+	}
+	if len(person.Fields) != 2 {
+		t.Fatalf("person should carry exactly the tenant's 2 fields, got %v", person.Fields)
+	}
+	for _, f := range person.Fields {
+		if f == "role" || f == "aliases" {
+			t.Errorf("seed field %q survived an override — the fields were merged, not replaced", f)
+		}
+	}
+	if person.Source != "tenant" {
+		t.Errorf("an overridden term should report source=tenant, got %q", person.Source)
+	}
+	// And the override must not change the term COUNT.
+	if len(got) != len(BaseSeedOntology()) {
+		t.Errorf("overriding a seed term changed the term count: %d vs %d", len(got), len(BaseSeedOntology()))
+	}
+}
+
+// TestEffectiveOntology_IsStablyOrdered: the ontology is injected into a system
+// prompt, which must stay byte-stable across runs or every call misses the
+// provider prompt-cache on the whole prefix. Map iteration is not ordered, so the
+// sort is load-bearing rather than cosmetic.
+func TestEffectiveOntology_IsStablyOrdered(t *testing.T) {
+	tenant := []OntologyTerm{{Name: "zeta"}, {Name: "alpha"}, {Name: "mid"}}
+	first := RenderOntology(EffectiveOntology(tenant, true), true)
+	for i := 0; i < 20; i++ {
+		if got := RenderOntology(EffectiveOntology(tenant, true), true); got != first {
+			t.Fatalf("ontology rendering is not byte-stable across calls:\n%q\nvs\n%q", first, got)
+		}
+	}
+}
+
+// TestBaseSeedOntology_IsNotSharedState: a package-level slice would let one
+// caller's sort or append reorder every other caller's ontology.
+func TestBaseSeedOntology_IsNotSharedState(t *testing.T) {
+	a := BaseSeedOntology()
+	a[0].Name = "clobbered"
+	a[0].Fields = append(a[0].Fields, "injected")
+	b := BaseSeedOntology()
+	if b[0].Name == "clobbered" {
+		t.Error("BaseSeedOntology returns shared state — one caller mutated another's seed")
+	}
+	for _, f := range b[0].Fields {
+		if f == "injected" {
+			t.Error("BaseSeedOntology's field slices are shared")
+		}
+	}
+}
+
+// TestBaseSeedOntology_CoversPOLEPlusTheMemoryTypes: the seed is what a tenant
+// that never edits the document gets, so its coverage is the floor.
+func TestBaseSeedOntology_CoversPOLEPlusTheMemoryTypes(t *testing.T) {
+	have := map[string][]string{}
+	for _, term := range BaseSeedOntology() {
+		have[term.Name] = term.Fields
+	}
+	for _, want := range []string{"person", "object", "location", "event", "organization", "preference", "fact"} {
+		if _, ok := have[want]; !ok {
+			t.Errorf("the base seed is missing %q", want)
+		}
+	}
+	// `fact`'s three fields are what a fact's natural key is built from, so their
+	// names are not decoration.
+	for _, want := range []string{"subject", "predicate", "object"} {
+		found := false
+		for _, f := range have["fact"] {
+			if f == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("fact is missing the %q field its natural key is built from", want)
+		}
+	}
+}
+
+// TestOntologyTemplate_IsUsableAndSaysItIsInert. Two properties an operator's
+// first screen has to have: worked examples rather than a blank page, and a plain
+// statement that nothing happens until they confirm it — otherwise an operator
+// edits the document, sees no change, and concludes the feature is broken.
+func TestOntologyTemplate_IsUsableAndSaysItIsInert(t *testing.T) {
+	tpl := OntologyTemplate()
+	if !strings.HasPrefix(strings.TrimSpace(tpl), "# "+OntologyTitle) {
+		t.Errorf("the template's first heading must match OntologyTitle (%s) — import_md makes it the root chunk", OntologyTitle)
+	}
+	// Three worked examples.
+	for _, sample := range []string{"## project", "## incident", "## constraint"} {
+		if !strings.Contains(tpl, sample) {
+			t.Errorf("the template should ship a worked %q example", sample)
+		}
+	}
+	// And it must say, in the operator's words, that it is inert until confirmed.
+	if !strings.Contains(tpl, OntologyConfirmedStatus) || !strings.Contains(tpl, "draft") {
+		t.Error("the template must tell the operator it does nothing until confirmed, naming both states")
+	}
+	// House rule: operator-visible seed content cites no internal RFC letters.
+	if strings.Contains(tpl, "RFC") {
+		t.Error("the template must not cite internal RFC letters")
+	}
+}
+
+// TestRenderOntology_ExplainsAnUnconfirmedDeployment: without this line an
+// operator who edited the document and forgot to confirm it would see their terms
+// simply absent, with nothing to explain why.
+func TestRenderOntology_ExplainsAnUnconfirmedDeployment(t *testing.T) {
+	unconfirmed := RenderOntology(EffectiveOntology(nil, false), false)
+	if !strings.Contains(unconfirmed, "has not confirmed") {
+		t.Errorf("an unconfirmed render should say so:\n%s", unconfirmed)
+	}
+	confirmed := RenderOntology(EffectiveOntology([]OntologyTerm{{Name: "project"}}, true), true)
+	if strings.Contains(confirmed, "has not confirmed") {
+		t.Errorf("a confirmed render must not claim otherwise:\n%s", confirmed)
+	}
+	if !strings.Contains(confirmed, "project") {
+		t.Errorf("a confirmed render should list the tenant's terms:\n%s", confirmed)
+	}
+	// Model-visible text.
+	if strings.Contains(confirmed, "RFC") {
+		t.Error("rendered ontology must not cite internal RFC letters")
+	}
+}

--- a/internal/memory/templates/ontology.md
+++ b/internal/memory/templates/ontology.md
@@ -1,0 +1,49 @@
+# Tenant Ontology
+
+The entity types this deployment records memory against. Everything here is
+yours to edit.
+
+**This document does nothing until you confirm it.** While its status is
+`draft`, agents use the standard types alone and ignore what is written below.
+Set the status to `confirmed` when you are happy with it, and these definitions
+apply from the next run onward.
+
+The standard types are always available and do not need repeating here:
+`person`, `object`, `location`, `event`, `organization`, `preference`, `fact`.
+Add a type below only when your work needs something they do not cover — or
+reuse a standard name to override its fields.
+
+## project
+
+A body of work with a lifecycle of its own. Worth its own type when memory
+needs to attach decisions and constraints to something narrower than the
+organization.
+
+- `name` — what people call it in conversation, not its formal title
+- `status` — active, paused, shipped, abandoned
+- `repository` — where the code lives, if it has any
+- `owner` — the person accountable for it
+
+## incident
+
+Something that went wrong and was worth remembering. A useful type because the
+lesson usually outlives the event, and a bare `event` loses the cause.
+
+- `summary` — one sentence on what happened
+- `occurred_at` — when it started
+- `cause` — what turned out to be responsible
+- `resolution` — what actually fixed it
+
+## constraint
+
+A rule that limits how work may be done. Distinct from a `preference`: a
+preference can be overridden with a reason, a constraint cannot.
+
+- `statement` — the rule, in the imperative
+- `scope` — what it applies to
+- `rationale` — why it exists, so a later reader can tell whether it still does
+
+---
+
+Delete the examples above once you have your own. An ontology of three types you
+actually use is worth more than a dozen you copied.


### PR DESCRIPTION
Third of four. The effective ontology is `base seed ⊕ tenant layer`, and the tenant layer only counts once you've confirmed it.

## The seed

POLE+O — `person`, `object`, `location`, `event`, `organization` — plus the two the memory tier itself needs, `preference` and `fact`. Borrowed rather than invented: it's what intelligence analysts have used for decades because those five cover most of what anyone says about the world, so a tenant that never edits anything still gets something usable. `fact`'s `subject`/`predicate`/`object` are the three a fact's natural key is built from, so those names are load-bearing rather than illustrative.

## Your draft → confirmed gate, and why it beat what I proposed

I'd planned a per-term propose/approve queue. Yours is better and the difference is structural: a queue accumulates `pending` terms while the effective ontology silently stops growing — a failure with no symptom. A single document-level flip can't rot that way. Before it nothing changed; after it everything you wrote applies; and it's **one** decision rather than N.

The provisioned document says this in its own text, because an operator who edits it and sees no effect would otherwise reasonably conclude the feature is broken.

A tenant term with a seed term's name **overrides** it rather than merging field lists — merging would produce a type you never wrote and give you no way to remove a seed field.

## One departure from your instruction, deliberately

You said the document should be created **on tenant creation**. **There is no tenant-creation event.** A tenant exists the moment a token names one, and nothing in the runtime observes that transition.

Hooking token mint would have covered tenants minted from then on and **missed every tenant that already exists** — including, on your deployment, the only one. So provisioning is lazy-on-first-reference, reusing the race safety already proven on the user-root path (singleflight per tenant, PG advisory lock per replica).

The operator-visible behaviour is identical — the document is there the first time anything looks — and since it's inert until confirmed, provisioning earlier buys no correctness.

## Three implementation notes

**It renders unframed, which tripped the `trustedVariants` pin.** That's the pin working: it exists so an unframed variant is an argued decision rather than a slipped one. The argument is that this is a *schema the model applies*, so framing it "reference data, NOT instructions" would say the opposite of what's meant — and its provenance is safe, since every term arrives through an operator-authored document that's inert until confirmed by hand. No agent-written text can reach that body.

**The template ships three worked examples** (`project`, `incident`, `constraint`) rather than a blank page. Whether a feature gets filled in usually depends on whether the first screen shows the shape.

**Terms are parsed from the document's Markdown** — a `## name` heading per term, field names from the first backticked token on each bullet. That's the form the template writes and you edit. Requiring structured JSON would mean the document you're invited to edit and the document the runtime can read are different documents.

## A bug the wiring test caught

My first read expected `get_document` to return a chunk list. It doesn't — it returns document metadata plus the root chunk's status — so the read silently found **zero terms** while every unit test on the layering passed. That's the argument for asserting on the assembled prompt rather than the renderer alone, and it's the third time in this series that a test on the real path caught something the unit tests couldn't.

## What was tested

Full suite green; CI's two postgres steps reproduced green. `gofmt` clean.

**Fail-before verified:** with the confirmed check bypassed, the draft layer applies and both the unit inertness test and the end-to-end one fail.

New: `TestEffectiveOntology_DraftIsInactive`, `_TenantOverridesSeedRatherThanMerging`, `_IsStablyOrdered` (prompt-cache stability — map iteration isn't ordered, so the sort is load-bearing), `TestBaseSeedOntology_IsNotSharedState`, `_CoversPOLEPlusTheMemoryTypes`, `TestOntologyTemplate_IsUsableAndSaysItIsInert`, `TestRenderOntology_ExplainsAnUnconfirmedDeployment`, and four server-side tests covering the assembled prompt, lazy provisioning, never-provision-when-unreferenced, and the confirm flip.

## Still open from your decisions

The **UI** half — flipping `draft → confirmed` from the Web UI — isn't in this PR. The runtime honours the flip and the tests drive it through `update_chunk`, so it's operable via API today. Say whether you want the UI surface as its own PR before or after PR 4 (graph-expanded retrieval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)