### PR TITLE
feat(memory): graph-expanded, time-aware recall (RFC BL P4c PR 4)

### DIFF
--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -53,7 +53,7 @@ func (d *Document) Description() string {
 const documentInputSchema = `{
 	"type": "object",
 	"properties": {
-		"op":          {"type": "string", "enum": ["create_document","get_document","documents_summary","delete_document","set_path","create_chunk","upsert_chunk","get_chunk","update_chunk","delete_chunk","supersede_chunk","move_chunk","reorder_chunk","link_chunks","unlink_chunks","get_edges","query_chunks","define_type","list_types","set_asset","get_asset","export_md","import_md"]},
+		"op":          {"type": "string", "enum": ["create_document","get_document","documents_summary","delete_document","set_path","create_chunk","upsert_chunk","get_chunk","update_chunk","delete_chunk","supersede_chunk","graph_recall","move_chunk","reorder_chunk","link_chunks","unlink_chunks","get_edges","query_chunks","define_type","list_types","set_asset","get_asset","export_md","import_md"]},
 		"scope":       {"type": "string", "enum": ["agent","user","tenant"], "description": "Which store (default user). agent = this agent; user = this end-user (needs a user_id on the run); tenant = shared by every user and agent in the tenant — anything written here is read by all of them, so use it for curated reference material, not for anything derived from untrusted text. tenant requires the operator to grant BOTH memory_scopes and sql_scopes with the tenant value."},
 		"id":          {"type": "string", "description": "Document id (get/delete_document, set_path) or chunk id (get/update/delete/move_chunk)."},
 		"path":        {"type": "string", "description": "create_document: name the doc in the Path tree (default /documents/<title> if omitted). set_path: the path to attach to an existing document (by id). get/delete_document: address by path instead of id."},
@@ -66,6 +66,12 @@ const documentInputSchema = `{
 		"direction":   {"type": "string", "enum": ["up","down"], "description": "reorder_chunk: move the chunk up or down within its current level."},
 		"type":        {"type": "string", "description": "Optional supertag-like chunk type."},
 		"body":        {"type": "string", "description": "Markdown body."},
+		"seed_ids":  {"type": "array", "items": {"type": "string"}, "description": "graph_recall: chunk ids to start from. Use this to hand in results you already found some other way (a Memory search, a previous recall) and follow the graph out from them."},
+		"query":     {"type": "string", "description": "graph_recall: find starting chunks whose title matches this text. Use seed_ids instead when you already know where to start."},
+		"hops":      {"type": "integer", "description": "graph_recall: how far to follow relations from each starting chunk. 0 = the starting chunks only, 1 = their neighbours (default), 2 = the maximum."},
+		"as_of":     {"type": "integer", "description": "graph_recall: answer as of this moment (unix nanos) instead of now — returns what was true then, including facts since corrected."},
+		"include_retired": {"type": "boolean", "description": "graph_recall: also return facts that have been superseded. Off by default, so you get only what is currently true."},
+		"limit":     {"type": "integer", "description": "graph_recall: maximum chunks returned (default 50)."},
 		"natural_key": {"type": "string", "description": "upsert_chunk: the stable identity of this entity or fact. Upserting twice with the same key updates ONE chunk instead of adding a second — use a derived form such as person:ada-lovelace, or subject|predicate|object for a fact. Unique within the scope."},
 		"supersedes_id": {"type": "string", "description": "supersede_chunk: the id of the chunk being RETIRED by this one. The retired chunk is not deleted — it stays queryable so that questions about an earlier point in time still have an answer."},
 		"valid_at":   {"type": "integer", "description": "When the fact became true IN THE WORLD (unix nanos). Defaults to now. Distinct from when it was recorded."},
@@ -135,6 +141,13 @@ type docInput struct {
 	Confidence *float64 `json:"confidence"`
 	// Class is 'derived' | 'evidential' — the retention-exemption signal.
 	Class string `json:"class"`
+
+	// graph_recall inputs.
+	SeedIDs        []string `json:"seed_ids"`
+	Query          string   `json:"query"`
+	Hops           *int     `json:"hops"`
+	AsOf           *int64   `json:"as_of"`
+	IncludeRetired bool     `json:"include_retired"`
 	// MediaType/Data/Filename carry an image asset for set_asset (RFC BO). Data
 	// is standard base64 (no data: prefix); it is decoded to raw bytes and stored
 	// in the chunk_assets BYTEA/BLOB table.
@@ -274,6 +287,8 @@ func (d *Document) Execute(ctx context.Context, raw json.RawMessage) (tools.Resu
 		return d.upsertChunk(ctx, key, mscope, in)
 	case "supersede_chunk":
 		return d.supersedeChunk(ctx, key, in)
+	case "graph_recall":
+		return d.graphRecall(ctx, key, in)
 	case "link_chunks":
 		return d.linkChunks(ctx, key, in)
 	case "unlink_chunks":

--- a/internal/tools/builtin/document_graph.go
+++ b/internal/tools/builtin/document_graph.go
@@ -1,0 +1,333 @@
+package builtin
+
+// document_graph.go — graph-expanded, time-aware recall over the entity tier
+// (RFC BL P4c PR 4).
+//
+// WHAT IS NEW HERE, AND WHAT IS DELIBERATELY NOT. The genuinely new parts are the
+// BOUNDED EXPANSION over typed edges and the TEMPORAL filter. Hybrid seed
+// retrieval — vector ∥ full-text fused by RRF — already exists on the Memory tool's
+// recall path, and is NOT reimplemented: a caller runs whatever retrieval it likes
+// and hands the chunk ids in via seed_ids. Composition rather than a second ranker
+// that would drift from the first.
+//
+// `query` is offered as a convenience for the common case, and it is honest about
+// being a TITLE match in SQL rather than a semantic search. For an entity graph
+// that is more useful than it sounds — an entity's title IS its name — and it needs
+// no embedder, so it works identically on both tiers and in deployments with no
+// vector stack at all.
+//
+// NO GRAPH DATABASE. Expansion is a bounded breadth-first walk in SQL over
+// chunk_edges, one round trip per hop, capped at two hops. Two is not arbitrary:
+// each hop multiplies the frontier by the average degree, and past two the result
+// stops being "related to what you asked" and becomes "most of the graph".
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+const (
+	graphMaxHops      = 2
+	graphDefaultHops  = 1
+	graphDefaultLimit = 50
+	graphMaxLimit     = 200
+	// graphFrontierCap bounds ONE hop's frontier. Without it a single
+	// heavily-connected entity turns hop 2 into a scan of the scope's edges, and
+	// the caller sees a slow recall rather than a truncated one.
+	graphFrontierCap = 500
+)
+
+// graphChunk is one row of the answer, carrying HOW it was reached. A caller that
+// cannot tell a seed from a two-hop neighbour cannot tell a direct answer from an
+// association, which is the difference between recall and free association.
+type graphChunk struct {
+	ID       string `json:"id"`
+	Title    string `json:"title"`
+	Type     string `json:"type,omitempty"`
+	Status   string `json:"status,omitempty"`
+	Hop      int    `json:"hop"`
+	ViaKind  string `json:"via_kind,omitempty"`
+	ViaID    string `json:"via_id,omitempty"`
+	ValidAt  *int64 `json:"valid_at,omitempty"`
+	Invalid  *int64 `json:"invalid_at,omitempty"`
+	Retired  bool   `json:"retired"`
+	Superset bool   `json:"-"`
+}
+
+func (d *Document) graphRecall(ctx context.Context, key sqlmem.ScopeKey, in docInput) (tools.Result, error) {
+	hops := graphDefaultHops
+	if in.Hops != nil {
+		hops = *in.Hops
+	}
+	if hops < 0 || hops > graphMaxHops {
+		return errResult(fmt.Sprintf("graph_recall: hops must be 0..%d (got %d) — past two hops a result stops describing what you asked about", graphMaxHops, hops)), nil
+	}
+	// docInput.Limit is shared with the other list-shaped ops (a plain int, 0 =
+	// unset), so it is reused rather than shadowed with a second limit field.
+	limit := graphDefaultLimit
+	if in.Limit > 0 {
+		limit = in.Limit
+	}
+	if limit > graphMaxLimit {
+		limit = graphMaxLimit
+	}
+	if len(in.SeedIDs) == 0 && strings.TrimSpace(in.Query) == "" {
+		return errResult("graph_recall: give either seed_ids (chunks to start from) or query (match starting chunks by title)"), nil
+	}
+
+	seeds, err := d.graphSeeds(ctx, key, in, limit)
+	if err != nil {
+		return errResult("graph_recall: seeds: " + err.Error()), nil
+	}
+	if len(seeds) == 0 {
+		return okJSON(map[string]any{"chunks": []graphChunk{}, "seeds": 0, "hops": hops, "truncated": false})
+	}
+
+	// Breadth-first, one round trip per hop. `seen` is keyed on chunk id so a
+	// diamond in the graph is visited once and the SHALLOWEST path wins — reporting
+	// a chunk as two hops away when a one-hop path exists would overstate its
+	// distance from the question.
+	seen := make(map[string]graphChunk, len(seeds))
+	order := make([]string, 0, len(seeds))
+	frontier := make([]string, 0, len(seeds))
+	for _, c := range seeds {
+		if _, dup := seen[c.ID]; dup {
+			continue
+		}
+		seen[c.ID] = c
+		order = append(order, c.ID)
+		frontier = append(frontier, c.ID)
+	}
+
+	truncated := false
+	for hop := 1; hop <= hops && len(frontier) > 0; hop++ {
+		if len(frontier) > graphFrontierCap {
+			frontier = frontier[:graphFrontierCap]
+			truncated = true
+		}
+		next, nerr := d.graphNeighbours(ctx, key, frontier, hop, in)
+		if nerr != nil {
+			return errResult("graph_recall: hop " + fmt.Sprint(hop) + ": " + nerr.Error()), nil
+		}
+		frontier = frontier[:0]
+		for _, c := range next {
+			if _, dup := seen[c.ID]; dup {
+				continue
+			}
+			seen[c.ID] = c
+			order = append(order, c.ID)
+			frontier = append(frontier, c.ID)
+		}
+	}
+
+	out := make([]graphChunk, 0, len(order))
+	for _, id := range order {
+		if len(out) >= limit {
+			truncated = true
+			break
+		}
+		out = append(out, seen[id])
+	}
+	return okJSON(map[string]any{
+		"chunks": out, "seeds": len(seeds), "hops": hops, "truncated": truncated,
+	})
+}
+
+// graphSeeds resolves the starting set: explicit ids when given, else a title
+// match. Both go through the same temporal filter as the expansion, so a
+// superseded fact cannot enter as a seed while being excluded as a neighbour.
+func (d *Document) graphSeeds(ctx context.Context, key sqlmem.ScopeKey, in docInput, limit int) ([]graphChunk, error) {
+	where := []string{}
+	args := []any{}
+	if len(in.SeedIDs) > 0 {
+		where = append(where, "c.id IN ("+placeholders(len(in.SeedIDs))+")")
+		for _, id := range in.SeedIDs {
+			args = append(args, id)
+		}
+	} else {
+		// Case-insensitive contains. LOWER on both sides rather than ILIKE, which is
+		// postgres-only.
+		where = append(where, "LOWER(c.title) LIKE ?")
+		args = append(args, "%"+strings.ToLower(strings.TrimSpace(in.Query))+"%")
+	}
+	if in.DocumentID != "" {
+		where = append(where, "c.document_id = ?")
+		args = append(args, in.DocumentID)
+	}
+	// The temporal filter governs what is DISCOVERED, not what the caller NAMED.
+	//
+	// Explicit seed_ids are an assertion about where to start, so they are returned
+	// as asked. Filtering them made as_of unusable: an entity is typically timeless
+	// while the FACTS about it have validity windows, so an entity created today has
+	// a valid_at of today and "as of June, what did we know about Ada?" excluded Ada
+	// herself and returned nothing at all. Filtering the wrong noun.
+	//
+	// A `query` seed IS discovery, so it is filtered like the expansion.
+	if len(in.SeedIDs) == 0 {
+		temporal, targs := graphTemporalClause(in)
+		if temporal != "" {
+			where = append(where, temporal)
+			args = append(args, targs...)
+		}
+	}
+
+	stmt := `SELECT c.id, c.title, c.type, c.status, m.valid_at, m.invalid_at
+	           FROM chunks c LEFT JOIN chunk_memory_meta m ON m.chunk_id = c.id
+	          WHERE ` + strings.Join(where, " AND ") + `
+	          ORDER BY c.title LIMIT ?`
+	args = append(args, limit)
+	res, err := d.query(ctx, key, stmt, args...)
+	if err != nil {
+		return nil, err
+	}
+	return scanGraphRows(res.Rows, 0, "", ""), nil
+}
+
+// graphNeighbours returns the chunks one edge away from the frontier, in EITHER
+// direction. Both directions matter: an entity is as related to the fact that
+// points at it as to the ones it points at, and a forward-only walk would answer
+// half the question. The reverse leg is what PR 1's chunk_edges(to_id, kind) index
+// exists for.
+func (d *Document) graphNeighbours(ctx context.Context, key sqlmem.ScopeKey, frontier []string, hop int, in docInput) ([]graphChunk, error) {
+	marks := placeholders(len(frontier))
+	temporal, targs := graphTemporalClause(in)
+	extra := ""
+	if temporal != "" {
+		extra = " AND " + temporal
+	}
+
+	// Argument order must follow the statement's PLACEHOLDER order, and the
+	// temporal clause appears in BOTH union branches — so the sequence is
+	// frontier, temporal, frontier, temporal, not both frontiers followed by one
+	// temporal. Getting that wrong surfaced as "missing argument with index 5"
+	// rather than as wrong rows, which is the good failure of the two.
+	args := make([]any, 0, (len(frontier)+len(targs))*2)
+	for _, id := range frontier {
+		args = append(args, id)
+	}
+	args = append(args, targs...)
+	for _, id := range frontier {
+		args = append(args, id)
+	}
+	args = append(args, targs...)
+
+	// One statement per hop, both directions unioned. `via` carries the edge kind
+	// and the neighbour it was reached from, so the caller can see the shape of the
+	// association rather than just its endpoint.
+	stmt := `SELECT c.id, c.title, c.type, c.status, m.valid_at, m.invalid_at, e.kind, e.from_id
+	           FROM chunk_edges e
+	           JOIN chunks c ON c.id = e.to_id
+	           LEFT JOIN chunk_memory_meta m ON m.chunk_id = c.id
+	          WHERE e.from_id IN (` + marks + `)` + extra + `
+	         UNION
+	         SELECT c.id, c.title, c.type, c.status, m.valid_at, m.invalid_at, e.kind, e.to_id
+	           FROM chunk_edges e
+	           JOIN chunks c ON c.id = e.from_id
+	           LEFT JOIN chunk_memory_meta m ON m.chunk_id = c.id
+	          WHERE e.to_id IN (` + marks + `)` + extra
+	res, err := d.query(ctx, key, stmt, args...)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]graphChunk, 0, len(res.Rows))
+	for _, r := range res.Rows {
+		c := scanGraphRow(r)
+		c.Hop = hop
+		if len(r) > 6 {
+			c.ViaKind = asStr(r[6])
+		}
+		if len(r) > 7 {
+			c.ViaID = asStr(r[7])
+		}
+		out = append(out, c)
+	}
+	return out, nil
+}
+
+// graphTemporalClause builds the time filter.
+//
+// The DEFAULT is "what is true now": a superseded fact is excluded, because a
+// recall that returned both a fact and its correction with no way to tell them
+// apart is worse than one that returned neither.
+//
+// as_of asks the other question — what was true THEN — and needs both halves of
+// the interval: the fact must have become true at or before that moment, and must
+// not have stopped being true before it. Checking only invalid_at would return
+// facts the system had not yet learned.
+//
+// A chunk with NO sidecar row (an ordinary chunk, or one predating the entity
+// tier) is always current: it has no temporal claim to violate, and excluding it
+// would make graph_recall blind to the rest of the document.
+func graphTemporalClause(in docInput) (string, []any) {
+	if in.IncludeRetired {
+		return "", nil
+	}
+	if in.AsOf != nil {
+		return `(m.chunk_id IS NULL OR ((m.valid_at IS NULL OR m.valid_at <= ?) AND (m.invalid_at IS NULL OR m.invalid_at > ?)))`,
+			[]any{*in.AsOf, *in.AsOf}
+	}
+	return `(m.chunk_id IS NULL OR m.invalid_at IS NULL)`, nil
+}
+
+func scanGraphRows(rows [][]any, hop int, viaKind, viaID string) []graphChunk {
+	out := make([]graphChunk, 0, len(rows))
+	for _, r := range rows {
+		c := scanGraphRow(r)
+		c.Hop, c.ViaKind, c.ViaID = hop, viaKind, viaID
+		out = append(out, c)
+	}
+	return out
+}
+
+func scanGraphRow(r []any) graphChunk {
+	c := graphChunk{ID: asStr(r[0]), Title: asStr(r[1])}
+	if len(r) > 2 {
+		c.Type = asStr(r[2])
+	}
+	if len(r) > 3 {
+		c.Status = asStr(r[3])
+	}
+	if len(r) > 4 {
+		if v, ok := asInt64(r[4]); ok {
+			c.ValidAt = &v
+		}
+	}
+	if len(r) > 5 {
+		if v, ok := asInt64(r[5]); ok {
+			c.Invalid = &v
+			c.Retired = true
+		}
+	}
+	return c
+}
+
+// asInt64 reads a nullable timestamp cell. It reports presence SEPARATELY from
+// value, unlike asInt, because a NULL and a real 0 mean different things here: NULL
+// is "no temporal claim", 0 is the unix epoch. Collapsing them would make a chunk
+// with no sidecar row look like one valid since 1970.
+func asInt64(v any) (int64, bool) {
+	switch t := v.(type) {
+	case nil:
+		return 0, false
+	case int64:
+		return t, true
+	case int:
+		return int64(t), true
+	case float64:
+		return int64(t), true
+	}
+	return 0, false
+}
+
+// placeholders renders n `?` marks. Rebind converts them per dialect at the
+// d.query boundary.
+func placeholders(n int) string {
+	if n <= 0 {
+		return "NULL"
+	}
+	return strings.TrimSuffix(strings.Repeat("?,", n), ",")
+}

--- a/internal/tools/builtin/document_graph_test.go
+++ b/internal/tools/builtin/document_graph_test.go
@@ -1,0 +1,311 @@
+package builtin
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// graphFixture builds a small entity graph:
+//
+//	Ada --works_at--> Analytical Engine Co
+//	Ada --knows-----> Charles
+//	Analytical Engine Co --located_in--> London     (2 hops from Ada)
+//
+// Ada is the seed in most tests, so Charles and the company are one hop and London
+// is two — which is what makes the hop bound observable.
+func graphFixture(t *testing.T) (*Document, contextT, string, map[string]string) {
+	t.Helper()
+	d, ctx, docID, root := entityFixture(t)
+	ids := map[string]string{}
+	mk := func(name, typ string) string {
+		out, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+docID+
+			`","parent_id":"`+root+`","title":"`+name+`","type":"`+typ+`","natural_key":"`+typ+`:`+name+`"}`)
+		if r.IsError {
+			t.Fatalf("upsert %s: %s", name, r.Text)
+		}
+		id := asStr(out["id"])
+		ids[name] = id
+		return id
+	}
+	link := func(from, to, kind string) {
+		if _, r := docExec(t, d, ctx, `{"op":"link_chunks","scope":"user","document_id":"`+docID+
+			`","from_id":"`+ids[from]+`","to_id":"`+ids[to]+`","kind":"`+kind+`"}`); r.IsError {
+			t.Fatalf("link %s->%s: %s", from, to, r.Text)
+		}
+	}
+	mk("Ada", "person")
+	mk("Charles", "person")
+	mk("Analytical Engine Co", "organization")
+	mk("London", "location")
+	link("Ada", "Analytical Engine Co", "works_at")
+	link("Ada", "Charles", "knows")
+	link("Analytical Engine Co", "London", "located_in")
+	return d, ctx, docID, ids
+}
+
+func graphIDs(out map[string]any) map[string]int {
+	got := map[string]int{}
+	chunks, _ := out["chunks"].([]any)
+	for _, c := range chunks {
+		m, _ := c.(map[string]any)
+		title, _ := m["title"].(string)
+		hop := 0
+		if h, ok := m["hop"].(float64); ok {
+			hop = int(h)
+		}
+		got[title] = hop
+	}
+	return got
+}
+
+// TestGraphRecall_HopBoundIsObservable: 0 hops is the seed alone, 1 reaches its
+// neighbours, 2 reaches theirs. Without a bound each hop multiplies the frontier by
+// the average degree, and the result stops describing what was asked.
+func TestGraphRecall_HopBoundIsObservable(t *testing.T) {
+	d, ctx, docID, ids := graphFixture(t)
+	for _, tc := range []struct {
+		hops int
+		want []string
+		deny []string
+	}{
+		{0, []string{"Ada"}, []string{"Charles", "London"}},
+		{1, []string{"Ada", "Charles", "Analytical Engine Co"}, []string{"London"}},
+		{2, []string{"Ada", "Charles", "Analytical Engine Co", "London"}, nil},
+	} {
+		t.Run(fmt.Sprintf("hops=%d", tc.hops), func(t *testing.T) {
+			out, r := docExec(t, d, ctx, fmt.Sprintf(
+				`{"op":"graph_recall","scope":"user","document_id":"%s","seed_ids":["%s"],"hops":%d}`,
+				docID, ids["Ada"], tc.hops))
+			if r.IsError {
+				t.Fatalf("graph_recall: %s", r.Text)
+			}
+			got := graphIDs(out)
+			for _, w := range tc.want {
+				if _, ok := got[w]; !ok {
+					t.Errorf("hops=%d should reach %q; got %v", tc.hops, w, got)
+				}
+			}
+			for _, dn := range tc.deny {
+				if _, ok := got[dn]; ok {
+					t.Errorf("hops=%d must NOT reach %q (that is %d+ hops away); got %v", tc.hops, dn, tc.hops+1, got)
+				}
+			}
+		})
+	}
+}
+
+// TestGraphRecall_WalksBothDirections: an entity is as related to the facts that
+// point AT it as to the ones it points at, so a forward-only walk answers half the
+// question. This is what PR 1's chunk_edges(to_id, kind) index exists for.
+func TestGraphRecall_WalksBothDirections(t *testing.T) {
+	d, ctx, docID, ids := graphFixture(t)
+	// London is only ever an edge TARGET. Seeding from it must still find the company.
+	out, r := docExec(t, d, ctx, `{"op":"graph_recall","scope":"user","document_id":"`+docID+
+		`","seed_ids":["`+ids["London"]+`"],"hops":1}`)
+	if r.IsError {
+		t.Fatalf("graph_recall: %s", r.Text)
+	}
+	got := graphIDs(out)
+	if _, ok := got["Analytical Engine Co"]; !ok {
+		t.Errorf("a reverse hop was not followed — seeding from an edge TARGET found nothing: %v", got)
+	}
+}
+
+// TestGraphRecall_ShallowestPathWins: a diamond must report a chunk at its nearest
+// distance. Reporting two hops when a one-hop path exists overstates how far the
+// chunk is from the question.
+func TestGraphRecall_ShallowestPathWins(t *testing.T) {
+	d, ctx, docID, ids := graphFixture(t)
+	// Add Ada --lives_in--> London, so London is reachable at 1 AND 2 hops.
+	if _, r := docExec(t, d, ctx, `{"op":"link_chunks","scope":"user","document_id":"`+docID+
+		`","from_id":"`+ids["Ada"]+`","to_id":"`+ids["London"]+`","kind":"lives_in"}`); r.IsError {
+		t.Fatalf("link: %s", r.Text)
+	}
+	out, r := docExec(t, d, ctx, `{"op":"graph_recall","scope":"user","document_id":"`+docID+
+		`","seed_ids":["`+ids["Ada"]+`"],"hops":2}`)
+	if r.IsError {
+		t.Fatalf("graph_recall: %s", r.Text)
+	}
+	if hop := graphIDs(out)["London"]; hop != 1 {
+		t.Errorf("London is one hop away via lives_in but was reported at hop %d", hop)
+	}
+}
+
+// TestGraphRecall_ExcludesSupersededByDefault is the temporal default: a recall
+// that returned both a fact and its correction, with no way to tell them apart, is
+// worse than one that returned neither.
+func TestGraphRecall_ExcludesSupersededByDefault(t *testing.T) {
+	d, ctx, docID, ids := graphFixture(t)
+	// Charles is corrected by a replacement.
+	out, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+docID+
+		`","parent_id":"`+ids["Ada"]+`","title":"Charles Babbage","natural_key":"person:charles-babbage"}`)
+	if r.IsError {
+		t.Fatalf("upsert: %s", r.Text)
+	}
+	newID := asStr(out["id"])
+	if _, r := docExec(t, d, ctx, `{"op":"supersede_chunk","scope":"user","id":"`+newID+
+		`","supersedes_id":"`+ids["Charles"]+`"}`); r.IsError {
+		t.Fatalf("supersede: %s", r.Text)
+	}
+
+	cur, r := docExec(t, d, ctx, `{"op":"graph_recall","scope":"user","document_id":"`+docID+
+		`","seed_ids":["`+ids["Ada"]+`"],"hops":1}`)
+	if r.IsError {
+		t.Fatalf("graph_recall: %s", r.Text)
+	}
+	if _, ok := graphIDs(cur)["Charles"]; ok {
+		t.Error("a superseded chunk was returned as current")
+	}
+
+	// include_retired asks the other question.
+	all, r := docExec(t, d, ctx, `{"op":"graph_recall","scope":"user","document_id":"`+docID+
+		`","seed_ids":["`+ids["Ada"]+`"],"hops":1,"include_retired":true}`)
+	if r.IsError {
+		t.Fatalf("graph_recall(include_retired): %s", r.Text)
+	}
+	if _, ok := graphIDs(all)["Charles"]; !ok {
+		t.Error("include_retired should return the superseded chunk")
+	}
+}
+
+// TestGraphRecall_AsOfNeedsBothHalvesOfTheInterval. "What was true then" requires
+// the fact to have become true at or before that moment AND not to have stopped
+// before it. Checking only invalid_at would return facts the system had not yet
+// learned — a memory that answers a question about June with something recorded in
+// July.
+func TestGraphRecall_AsOfNeedsBothHalvesOfTheInterval(t *testing.T) {
+	d, ctx, docID, ids := graphFixture(t)
+	seed := ids["Ada"]
+
+	// The facts are LINKED to Ada, not merely parented under her. parent_id is
+	// document-tree containment; the graph walk follows chunk_edges. Keeping them
+	// separate is what makes a hop count mean something — if the tree counted, a
+	// document's entire subtree would be one hop from its root.
+	fact := func(title, key string, extra string) string {
+		out, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+docID+
+			`","parent_id":"`+seed+`","title":"`+title+`","natural_key":"`+key+`"`+extra+`}`)
+		if r.IsError {
+			t.Fatalf("upsert %s: %s", title, r.Text)
+		}
+		id := asStr(out["id"])
+		if _, r := docExec(t, d, ctx, `{"op":"link_chunks","scope":"user","document_id":"`+docID+
+			`","from_id":"`+seed+`","to_id":"`+id+`","kind":"about"}`); r.IsError {
+			t.Fatalf("link %s: %s", title, r.Text)
+		}
+		return id
+	}
+	// Valid only in a past window, and one that only became true later.
+	fact("Lived in Turin", "fact:turin", `,"valid_at":1000,"invalid_at":2000`)
+	fact("Lived in Turin later", "fact:turin2", `,"valid_at":5000`)
+
+	at1500, r := docExec(t, d, ctx, `{"op":"graph_recall","scope":"user","document_id":"`+docID+
+		`","seed_ids":["`+seed+`"],"hops":1,"as_of":1500}`)
+	if r.IsError {
+		t.Fatalf("graph_recall(as_of): %s", r.Text)
+	}
+	got := graphIDs(at1500)
+	if _, ok := got["Lived in Turin"]; !ok {
+		t.Errorf("as_of=1500 should see a fact valid 1000..2000: %v", got)
+	}
+	if _, ok := got["Lived in Turin later"]; ok {
+		t.Errorf("as_of=1500 must NOT see a fact that only became true at 5000 — that is answering June with July: %v", got)
+	}
+}
+
+// TestGraphRecall_ChunksWithNoSidecarAreCurrent: an ordinary chunk, or one written
+// before the entity tier existed, has no temporal claim to violate. Excluding it
+// would make graph_recall blind to the rest of the document.
+func TestGraphRecall_ChunksWithNoSidecarAreCurrent(t *testing.T) {
+	d, ctx, docID, ids := graphFixture(t)
+	// A plain create_chunk — no natural key, so no sidecar row.
+	out, r := docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+docID+
+		`","parent_id":"`+ids["Ada"]+`","title":"Plain note"}`)
+	if r.IsError {
+		t.Fatalf("create_chunk: %s", r.Text)
+	}
+	if _, r := docExec(t, d, ctx, `{"op":"link_chunks","scope":"user","document_id":"`+docID+
+		`","from_id":"`+ids["Ada"]+`","to_id":"`+asStr(out["id"])+`","kind":"notes"}`); r.IsError {
+		t.Fatalf("link: %s", r.Text)
+	}
+	res, r := docExec(t, d, ctx, `{"op":"graph_recall","scope":"user","document_id":"`+docID+
+		`","seed_ids":["`+ids["Ada"]+`"],"hops":1}`)
+	if r.IsError {
+		t.Fatalf("graph_recall: %s", r.Text)
+	}
+	if _, ok := graphIDs(res)["Plain note"]; !ok {
+		t.Error("a chunk with no sidecar row was treated as retired")
+	}
+}
+
+// TestGraphRecall_QuerySeedsByTitle: the convenience path, honest about being a
+// title match rather than a semantic search — for an entity graph the title IS the
+// name, and it needs no embedder so it behaves identically on both tiers.
+func TestGraphRecall_QuerySeedsByTitle(t *testing.T) {
+	d, ctx, docID, _ := graphFixture(t)
+	out, r := docExec(t, d, ctx, `{"op":"graph_recall","scope":"user","document_id":"`+docID+
+		`","query":"analytical","hops":1}`)
+	if r.IsError {
+		t.Fatalf("graph_recall(query): %s", r.Text)
+	}
+	got := graphIDs(out)
+	if hop, ok := got["Analytical Engine Co"]; !ok || hop != 0 {
+		t.Errorf("case-insensitive title match should seed the company at hop 0: %v", got)
+	}
+	if _, ok := got["Ada"]; !ok {
+		t.Errorf("its neighbour Ada should be reached in one hop: %v", got)
+	}
+}
+
+// TestGraphRecall_RefusesNonsense: no starting point, and hops outside the bound.
+func TestGraphRecall_RefusesNonsense(t *testing.T) {
+	d, ctx, docID, ids := graphFixture(t)
+	for _, tc := range []struct{ name, body, want string }{
+		{"no seed", `{"op":"graph_recall","scope":"user","document_id":"` + docID + `"}`, "seed_ids"},
+		{"too many hops", `{"op":"graph_recall","scope":"user","seed_ids":["` + ids["Ada"] + `"],"hops":3}`, "0..2"},
+		{"negative hops", `{"op":"graph_recall","scope":"user","seed_ids":["` + ids["Ada"] + `"],"hops":-1}`, "0..2"},
+	} {
+		_, r := docExec(t, d, ctx, tc.body)
+		if !r.IsError {
+			t.Errorf("%s: must be refused", tc.name)
+			continue
+		}
+		if !strings.Contains(r.Text, tc.want) {
+			t.Errorf("%s: message should mention %q, got %q", tc.name, tc.want, r.Text)
+		}
+	}
+}
+
+// TestGraphRecall_ReportsHowEachChunkWasReached: a caller that cannot tell a seed
+// from a two-hop neighbour cannot tell a direct answer from an association.
+func TestGraphRecall_ReportsHowEachChunkWasReached(t *testing.T) {
+	d, ctx, docID, ids := graphFixture(t)
+	out, r := docExec(t, d, ctx, `{"op":"graph_recall","scope":"user","document_id":"`+docID+
+		`","seed_ids":["`+ids["Ada"]+`"],"hops":1}`)
+	if r.IsError {
+		t.Fatalf("graph_recall: %s", r.Text)
+	}
+	chunks, _ := out["chunks"].([]any)
+	sawVia := false
+	for _, c := range chunks {
+		m, _ := c.(map[string]any)
+		title, _ := m["title"].(string)
+		hop, _ := m["hop"].(float64)
+		kind, _ := m["via_kind"].(string)
+		if title == "Ada" && hop != 0 {
+			t.Errorf("the seed should be hop 0, got %v", hop)
+		}
+		if title == "Charles" {
+			if hop != 1 {
+				t.Errorf("Charles should be hop 1, got %v", hop)
+			}
+			if kind != "knows" {
+				t.Errorf("Charles should report the edge kind it was reached by, got %q", kind)
+			}
+			sawVia = true
+		}
+	}
+	if !sawVia {
+		t.Error("no neighbour reported its edge kind")
+	}
+}


### PR DESCRIPTION
Last of four. A `graph_recall` op: start from some chunks, follow typed relations a bounded distance, and see only what was true at the moment you asked about.

## Hybrid seeding is composed, not reimplemented

Vector ∥ full-text fused by RRF already exists on the Memory tool's recall path. A caller runs whatever retrieval it likes and hands the ids in via `seed_ids` — rather than a second ranker that would drift from the first.

`query` is offered for the common case and is **honest about being a title match in SQL**. For an entity graph that's more useful than it sounds — an entity's title *is* its name — and it needs no embedder, so it behaves identically on both tiers and in deployments with no vector stack at all.

## No graph database

A bounded breadth-first walk in SQL, one round trip per hop, capped at **two**. Two isn't arbitrary: each hop multiplies the frontier by the average degree, and past two the result stops describing what was asked and starts describing most of the graph. A per-hop frontier cap keeps one heavily-connected entity from turning hop 2 into a scan.

The walk goes **both directions** — an entity is as related to the facts pointing at it as to the ones it points at, so a forward-only walk answers half the question. That's what PR 1's `chunk_edges(to_id, kind)` index exists for. A diamond resolves to the **shallowest** path, and every row reports how it was reached (hop, edge kind, source neighbour): a caller that can't tell a seed from a two-hop neighbour can't tell an answer from an association.

## Temporal behaviour

Default is *what is true now* — a superseded fact is excluded, because returning both a fact and its correction with no way to distinguish them is worse than returning neither. `include_retired` asks the other question.

`as_of` needs **both halves** of the interval. The test caught the version that had one: checking only `invalid_at` returns facts the system hadn't yet learned — answering a question about June with something recorded in July.

## Two things the tests changed about the design

**The temporal filter governs what is DISCOVERED, not what the caller NAMED.** Filtering explicit `seed_ids` made `as_of` unusable: an entity is typically timeless while the *facts* about it have validity windows, so an entity created today has a `valid_at` of today — and *"as of June, what did we know about Ada?"* excluded Ada herself and returned nothing. Filtering the wrong noun. A `query` seed is discovery, so it stays filtered.

**The walk follows `chunk_edges` only, never `parent_id`.** Document-tree containment is a different relation, and counting it would make hop numbers meaningless — a document's entire subtree would sit one hop from its root. **Worth knowing for whoever writes the consolidator: a fact must be linked to its entity, not merely parented under it.** My own test made that mistake first.

## A bug the as_of test surfaced

The temporal clause appears in *both* union branches, so the argument sequence is `frontier, temporal, frontier, temporal` — not both frontiers followed by one temporal. It failed loudly as `missing argument with index 5` rather than as quietly wrong rows, which is the better of the two failures.

## Still deliberately absent

Ontology materialization into scope-wide `chunk_types`. Nothing reads it — chunks carry their own `type` column, so type filtering needs no cache, and a cache with no consumer is a second source of truth waiting to drift. If a future consumer appears it can land with that consumer.

## What was tested

Full suite green; CI's two postgres steps reproduced green. `gofmt` clean.

**Fail-before verified three times:** reverse leg disabled → seeding from an edge target finds nothing; temporal default removed → a superseded chunk returns as current; `as_of` reduced to one half → a fact that only became true later is returned for an earlier moment.

New: `TestGraphRecall_HopBoundIsObservable` (0/1/2 hops), `_WalksBothDirections`, `_ShallowestPathWins`, `_ExcludesSupersededByDefault`, `_AsOfNeedsBothHalvesOfTheInterval`, `_ChunksWithNoSidecarAreCurrent`, `_QuerySeedsByTitle`, `_RefusesNonsense`, `_ReportsHowEachChunkWasReached`.

## P4c after this

Four PRs done: the sidecar, the write path, the ontology, the read path. Two things named as out of scope along the way and worth deciding on:

1. **The ontology's `draft → confirmed` UI flip.** Operable by API today; you said the ontology is UI-gated, so the surface is still owed.
2. **P4d** — retention for the `mem_content` family, which prunes what P4c creates.

Neither is blocking, and the tier is usable without them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)