### PR TITLE
feat(memory): the operator control for the tenant ontology, and the two bugs that made it unusable

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -552,6 +552,14 @@ func requiredScopeFor(method, path string) string {
 	// ScopeTenant), not at this path. Mirrors the /v1/_*def/names posture.
 	case path == "/v1/_library/agents" || path == "/v1/_library/skills" || path == "/v1/_library/mcp-servers":
 		return auth.ScopeTenant
+	// The tenant ontology surface (GET state + POST the draft↔confirmed flip).
+	// ScopeTenant on BOTH methods: the ontology is one document per tenant, the
+	// handler derives that tenant from the principal (never the wire), and the same
+	// token can already write the same root-chunk status through /v1/_document
+	// update_chunk — so gating the write harder here would deny the intended actor
+	// without closing anything. ScopeAdmin also satisfies it (+ ?tenant= focus).
+	case path == "/v1/_ontology":
+		return auth.ScopeTenant
 	// RFC AS: the Web UI schedules surface (list-all + per-def state / run-now /
 	// pause / resume). list-all is tenant-scoped (the handler filters substrate
 	// schedules to the caller's tenant; operator-global static crons stay

--- a/internal/api/http/ontology_admin.go
+++ b/internal/api/http/ontology_admin.go
@@ -1,0 +1,261 @@
+package http
+
+// ontology_admin.go — the OPERATOR surface for the tenant ontology: read its
+// state, and flip it between draft and confirmed.
+//
+// The flip was always specified as an operator action rather than something the
+// runtime decides, and until now the only way to perform it was to open the
+// document in the Path browser and type `confirmed` into the root chunk's status
+// box. That works, but it is not a control — nothing tells an operator that the
+// word is load-bearing, that their edits are currently inert, or which types are
+// actually reaching the extractor. A gate nobody can see the state of is a gate
+// that silently stays shut.
+//
+// So this is deliberately a READ plus a two-value WRITE, not a general document
+// editor. Authoring the ontology stays in the Path/Document browser, where editing
+// Markdown belongs; what lives here is the part the browser cannot express — the
+// gate, and the layered result of passing it.
+//
+// Both routes are ScopeTenant. A tenant operator confirming its OWN tenant's
+// ontology is the intended actor, and refusing the write here while
+// POST /v1/_document update_chunk already accepts it from the same token would be
+// theatre rather than a boundary.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	meminject "github.com/denn-gubsky/loomcycle/internal/memory"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
+)
+
+// ontologyResponse is the wire shape of GET/POST /v1/_ontology.
+//
+// It reports the tenant layer and the EFFECTIVE ontology separately, because the
+// difference between them IS the feature: while the document is draft, Terms is
+// what the operator wrote and Effective shows it is not there. Computing both
+// server-side means the UI never reimplements the layering — and cannot drift from
+// what a run actually gets, which is the whole reason for showing it.
+type ontologyResponse struct {
+	Tenant string `json:"tenant"`
+	// Path + DocumentID let the UI deep-link the Path browser for editing rather
+	// than duplicating a Markdown editor here.
+	Path        string `json:"path"`
+	DocumentID  string `json:"document_id,omitempty"`
+	RootChunkID string `json:"root_chunk_id,omitempty"`
+	// Status is the root chunk's raw status; Confirmed is the decision derived from
+	// it. Both, because they can disagree in the one way that matters: a status of
+	// `confirmd` is not confirmed, and reporting only the boolean would hide why.
+	Status    string `json:"status"`
+	Confirmed bool   `json:"confirmed"`
+	// Provisioned is false when the document does not exist yet AND could not be
+	// created (no SQL Memory). Distinguishes "nothing here" from "not available",
+	// which the UI needs in order to say something useful.
+	Provisioned bool `json:"provisioned"`
+	// Terms is the tenant layer as parsed from the document — reported whether or
+	// not it is active, so an operator can see what confirming would do.
+	Terms []meminject.OntologyTerm `json:"terms"`
+	// Effective is what a run gets right now: the base seed, with the tenant layer
+	// applied only if Confirmed. Each term carries its own source, so the UI can
+	// mark which half it came from without diffing against the seed.
+	Effective []meminject.OntologyTerm `json:"effective"`
+}
+
+// handleOntology serves GET /v1/_ontology — the tenant ontology's state.
+//
+// Reading PROVISIONS the document on first reference, which is a real behaviour
+// change and the point of having the route: provisioning was lazy-on-first-run, so
+// an operator who wanted to set up the ontology BEFORE running anything had no
+// document to edit. Now opening the page creates it (as `draft`, changing nothing).
+func (s *Server) handleOntology(w http.ResponseWriter, r *http.Request) {
+	// Admin may focus a tenant via ?tenant= (the UI's tenant switcher); a tenant
+	// operator is pinned to its own and the wire value is ignored. An admin with no
+	// focus operates on the default tenant — the same one its own runs use.
+	tenant, _ := s.principalTenantScope(r.Context(), r.URL.Query().Get("tenant"))
+
+	resp, err := s.ontologyState(r.Context(), tenant)
+	if err != nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "ontology_unavailable", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// handleOntologySetStatus serves POST /v1/_ontology — the draft↔confirmed flip.
+//
+// Accepts ONLY those two values. A free-form status write is already available on
+// the generic document route; the whole value of this one is that it cannot produce
+// a state the gate silently ignores.
+func (s *Server) handleOntologySetStatus(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Status string `json:"status"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4<<10)).Decode(&body); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_body", "expected {\"status\": \"confirmed\"|\"draft\"}")
+		return
+	}
+	status := strings.ToLower(strings.TrimSpace(body.Status))
+	if status != meminject.OntologyConfirmedStatus && status != meminject.OntologyDraftStatus {
+		writeJSONError(w, http.StatusBadRequest, "invalid_status",
+			"status must be \""+meminject.OntologyConfirmedStatus+"\" or \""+meminject.OntologyDraftStatus+"\"")
+		return
+	}
+
+	tenant, _ := s.principalTenantScope(r.Context(), r.URL.Query().Get("tenant"))
+	if s.store == nil || s.sqlMem == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "ontology_unavailable",
+			"the ontology needs SQL Memory; none is configured")
+		return
+	}
+
+	mi := memInject{Tenant: tenant}
+	s.ensureOntologyDoc(r.Context(), mi)
+
+	doc := &builtin.Document{Store: s.store, SqlMem: s.sqlMem}
+	dctx := s.ontologyDocCtx(r.Context(), mi)
+
+	// The gate is the ROOT chunk's status, so the write needs the root's id and its
+	// current revision. Both are read here rather than passed on the wire: the
+	// caller is toggling one bit and should not have to know the document's
+	// internal shape, and a revision that came from the client could be stale in a
+	// way that silently targeted the wrong chunk.
+	rootID, _, _, err := s.ontologyRoot(dctx, doc)
+	if err != nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "ontology_unavailable", err.Error())
+		return
+	}
+	rev, err := s.ontologyRootRevision(dctx, doc, rootID)
+	if err != nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "ontology_unavailable", err.Error())
+		return
+	}
+
+	// Status ONLY. update_chunk is presence-based, so omitting body/fields leaves
+	// the operator's Markdown untouched — sending them would risk blanking the
+	// document to flip a flag.
+	patch, _ := json.Marshal(map[string]any{
+		"op": "update_chunk", "scope": "tenant", "id": rootID,
+		"status": status, "revision": rev,
+	})
+	res, err := doc.Execute(dctx, patch)
+	if err != nil || res.IsError {
+		msg := res.Text
+		if err != nil {
+			msg = err.Error()
+		}
+		writeJSONError(w, http.StatusInternalServerError, "ontology_write_failed", msg)
+		return
+	}
+
+	// Re-read rather than synthesizing the new state: the response then shows the
+	// EFFECTIVE ontology after the flip, which is what the operator wanted to know.
+	resp, err := s.ontologyState(r.Context(), tenant)
+	if err != nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "ontology_unavailable", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// ontologyState composes the read shape for one tenant, provisioning on first
+// reference.
+func (s *Server) ontologyState(ctx context.Context, tenant string) (ontologyResponse, error) {
+	resp := ontologyResponse{
+		Tenant: tenant, Path: meminject.OntologyPath,
+		Status:    meminject.OntologyDraftStatus,
+		Terms:     []meminject.OntologyTerm{},
+		Effective: meminject.EffectiveOntology(nil, false),
+	}
+	if s.store == nil || s.sqlMem == nil {
+		// Degraded, not an error: a deployment with no SQL Memory still runs on the
+		// base seed, and reporting that honestly beats a 503 the UI must special-case.
+		return resp, nil
+	}
+
+	mi := memInject{Tenant: tenant}
+	terms, confirmed := s.tenantOntologyTerms(ctx, mi)
+
+	doc := &builtin.Document{Store: s.store, SqlMem: s.sqlMem}
+	dctx := s.ontologyDocCtx(ctx, mi)
+	rootID, docID, status, err := s.ontologyRoot(dctx, doc)
+	if err == nil {
+		resp.Provisioned = true
+		resp.RootChunkID, resp.DocumentID = rootID, docID
+		if status != "" {
+			resp.Status = status
+		}
+	}
+	if terms != nil {
+		resp.Terms = terms
+	}
+	resp.Confirmed = confirmed
+	resp.Effective = meminject.EffectiveOntology(terms, confirmed)
+	return resp, nil
+}
+
+// ontologyDocCtx stamps the tenant identity plus the tenant-scope grants the
+// ontology read/write needs.
+//
+// The grants are stamped SERVER-SIDE, exactly as renderOntology does: this is an
+// operator acting on operator-authored config in its own tenant, not an agent
+// reaching tenant memory, so it does not require the caller to hold the agent-side
+// tenant grants. The tenant itself is principal-derived and never from the wire.
+func (s *Server) ontologyDocCtx(ctx context.Context, mi memInject) context.Context {
+	dctx := s.docToolCtx(ctx, mi)
+	dctx = tools.WithMemoryPolicy(dctx, tools.MemoryPolicyValue{AllowedScopes: []string{"tenant"}})
+	dctx = tools.WithSqlMemPolicy(dctx, tools.SqlMemPolicyValue{AllowedScopes: []string{"tenant"}})
+	return dctx
+}
+
+// ontologyRoot returns the ontology document's (root chunk id, document id, root
+// status).
+func (s *Server) ontologyRoot(dctx context.Context, doc *builtin.Document) (rootID, docID, status string, err error) {
+	req, _ := json.Marshal(map[string]any{
+		"op": "get_document", "scope": "tenant", "path": meminject.OntologyPath,
+	})
+	res, derr := doc.Execute(dctx, req)
+	if derr != nil {
+		return "", "", "", derr
+	}
+	if res.IsError {
+		return "", "", "", errors.New(res.Text)
+	}
+	var meta struct {
+		DocumentID  string `json:"document_id"`
+		RootChunkID string `json:"root_chunk_id"`
+		Status      string `json:"status"`
+	}
+	if err := json.Unmarshal([]byte(res.Text), &meta); err != nil {
+		return "", "", "", err
+	}
+	if meta.RootChunkID == "" {
+		return "", "", "", errors.New("the ontology document has no root chunk")
+	}
+	return meta.RootChunkID, meta.DocumentID, meta.Status, nil
+}
+
+// ontologyRootRevision reads the root chunk's current revision for the
+// optimistic-concurrency guard on update_chunk.
+func (s *Server) ontologyRootRevision(dctx context.Context, doc *builtin.Document, rootID string) (int, error) {
+	req, _ := json.Marshal(map[string]any{
+		"op": "get_chunk", "scope": "tenant", "id": rootID,
+	})
+	res, err := doc.Execute(dctx, req)
+	if err != nil {
+		return 0, err
+	}
+	if res.IsError {
+		return 0, errors.New(res.Text)
+	}
+	var chunk struct {
+		Revision int `json:"revision"`
+	}
+	if err := json.Unmarshal([]byte(res.Text), &chunk); err != nil {
+		return 0, err
+	}
+	return chunk.Revision, nil
+}

--- a/internal/api/http/ontology_admin_test.go
+++ b/internal/api/http/ontology_admin_test.go
@@ -1,0 +1,315 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	meminject "github.com/denn-gubsky/loomcycle/internal/memory"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
+)
+
+// TestOntologyAPI_ReportsTheGateAndWhatWouldChange is the reason the route exists.
+//
+// The failure it guards against is not a crash: it is an operator who edits the
+// ontology, never learns that editing is not enough, and concludes the feature does
+// nothing. So the read has to report BOTH halves — the terms they wrote, and the
+// types actually in force — because the gap between them is the only visible
+// evidence of the gate.
+func TestOntologyAPI_ReportsTheGateAndWhatWouldChange(t *testing.T) {
+	s, mi := ontologyFixture(t)
+
+	got := s.getOntology(t, mi.Tenant)
+
+	if !got.Provisioned {
+		t.Fatal("the read should provision the document on first reference")
+	}
+	if got.Confirmed {
+		t.Error("a freshly provisioned ontology must report unconfirmed")
+	}
+	if got.Status != meminject.OntologyDraftStatus {
+		t.Errorf("status = %q, want %q", got.Status, meminject.OntologyDraftStatus)
+	}
+	// The tenant's OWN terms are reported even while inert — this is what the
+	// operator is about to activate.
+	if !hasTerm(got.Terms, "incident") {
+		t.Errorf("the template's sample terms should be reported as the tenant layer, got %v", termNames(got.Terms))
+	}
+	// ...and the EFFECTIVE ontology does not contain them, which is the gate.
+	if hasTerm(got.Effective, "incident") {
+		t.Errorf("a draft tenant layer must not be in force, got %v", termNames(got.Effective))
+	}
+	if !hasTerm(got.Effective, "person") {
+		t.Errorf("the base seed should always be in force, got %v", termNames(got.Effective))
+	}
+	for _, term := range got.Effective {
+		if term.Source != "base" {
+			t.Errorf("while draft every effective term must come from the seed; %q says %q", term.Name, term.Source)
+		}
+	}
+}
+
+// TestOntologyAPI_ConfirmAndRevertBothTakeEffect exercises the gate in BOTH
+// directions.
+//
+// One direction is not enough: a gate tested only on opening can ship stuck open,
+// and a confirm an operator cannot undo is a one-way door on a live extractor.
+func TestOntologyAPI_ConfirmAndRevertBothTakeEffect(t *testing.T) {
+	s, mi := ontologyFixture(t)
+	s.getOntology(t, mi.Tenant) // provision
+
+	after := s.setOntologyStatus(t, mi.Tenant, meminject.OntologyConfirmedStatus, http.StatusOK)
+	if !after.Confirmed {
+		t.Fatal("confirm did not take")
+	}
+	if !hasTerm(after.Effective, "incident") {
+		t.Errorf("a confirmed tenant layer should be in force, got %v", termNames(after.Effective))
+	}
+	if !hasTerm(after.Effective, "person") {
+		t.Errorf("the seed must survive the layering, got %v", termNames(after.Effective))
+	}
+	// The response reports WHICH half each type came from, so the UI never has to
+	// diff against the seed to know.
+	for _, term := range after.Effective {
+		if term.Name == "incident" && term.Source != "tenant" {
+			t.Errorf("a tenant term should be sourced 'tenant', got %q", term.Source)
+		}
+		if term.Name == "person" && term.Source != "base" {
+			t.Errorf("a seed term should be sourced 'base', got %q", term.Source)
+		}
+	}
+
+	back := s.setOntologyStatus(t, mi.Tenant, meminject.OntologyDraftStatus, http.StatusOK)
+	if back.Confirmed {
+		t.Error("reverting to draft should deactivate the tenant layer")
+	}
+	if hasTerm(back.Effective, "incident") {
+		t.Errorf("a reverted layer must leave force, got %v", termNames(back.Effective))
+	}
+	// Reverting deactivates; it does not erase. The operator's work is still there.
+	if !hasTerm(back.Terms, "incident") {
+		t.Errorf("revert must not discard the tenant's terms, got %v", termNames(back.Terms))
+	}
+}
+
+// TestOntologyAPI_RefusesAStatusTheGateWouldIgnore is the entire justification for a
+// dedicated route over the generic document editor.
+//
+// The gate matches one exact word. Through update_chunk an operator can type
+// `confirmd` into a free-text status box, see it saved, and get a permanently inert
+// ontology with no error anywhere — the invisible failure this subsystem's design
+// rejected a per-term approval queue to avoid. A two-value endpoint cannot produce
+// that state.
+func TestOntologyAPI_RefusesAStatusTheGateWouldIgnore(t *testing.T) {
+	s, mi := ontologyFixture(t)
+	s.getOntology(t, mi.Tenant)
+
+	for _, bad := range []string{"confirmd", "CONFIRMED!", "active", "", "pending"} {
+		s.setOntologyStatus(t, mi.Tenant, bad, http.StatusBadRequest)
+	}
+	// And nothing moved.
+	got := s.getOntology(t, mi.Tenant)
+	if got.Status != meminject.OntologyDraftStatus || got.Confirmed {
+		t.Errorf("a refused write changed state: status=%q confirmed=%v", got.Status, got.Confirmed)
+	}
+}
+
+// TestOntologyAPI_CaseAndWhitespaceStillConfirm: the two accepted words are matched
+// leniently, because "Confirmed" from a form field is unambiguously the same intent
+// and refusing it would be pedantry that reads as a bug.
+func TestOntologyAPI_CaseAndWhitespaceStillConfirm(t *testing.T) {
+	s, mi := ontologyFixture(t)
+	s.getOntology(t, mi.Tenant)
+
+	got := s.setOntologyStatus(t, mi.Tenant, "  Confirmed ", http.StatusOK)
+	if !got.Confirmed {
+		t.Error("a case/whitespace variant of the accepted word should confirm")
+	}
+	// Normalized on the way in, so the stored status is what the gate matches
+	// exactly — not a variant that happens to work only through this route.
+	if got.Status != meminject.OntologyConfirmedStatus {
+		t.Errorf("stored status = %q, want the canonical %q", got.Status, meminject.OntologyConfirmedStatus)
+	}
+}
+
+// TestOntologyAPI_FlipPreservesTheOperatorsMarkdown guards the exact regression that
+// blanked a document root once before: a partial chunk write that sends body/fields
+// it did not read. Flipping a flag must not cost the operator their ontology.
+func TestOntologyAPI_FlipPreservesTheOperatorsMarkdown(t *testing.T) {
+	s, mi := ontologyFixture(t)
+	before := s.getOntology(t, mi.Tenant)
+	md := s.exportOntologyMD(t, mi)
+	if !strings.Contains(md, "incident") {
+		t.Fatalf("fixture: the provisioned document should carry the template, got:\n%s", md)
+	}
+
+	s.setOntologyStatus(t, mi.Tenant, meminject.OntologyConfirmedStatus, http.StatusOK)
+
+	if after := s.exportOntologyMD(t, mi); after != md {
+		t.Errorf("the flip rewrote the document.\nbefore:\n%s\nafter:\n%s", md, after)
+	}
+	// Same document, not a replacement — a flip that recreated it would orphan every
+	// chunk id anything else holds.
+	if got := s.getOntology(t, mi.Tenant); got.DocumentID != before.DocumentID {
+		t.Errorf("document id changed across the flip: %q → %q", before.DocumentID, got.DocumentID)
+	}
+}
+
+// TestOntologyAPI_ReadingProvisionsSoItCanBeAuthoredFirst: provisioning used to be
+// lazy on the first RUN that referenced the ontology, which left an operator wanting
+// to set it up beforehand with no document to open. The read now creates it — as
+// draft, so creating it still changes nothing.
+func TestOntologyAPI_ReadingProvisionsSoItCanBeAuthoredFirst(t *testing.T) {
+	s, mi := ontologyFixture(t)
+	if s.ontologyDocExists(t, mi) {
+		t.Fatal("fixture: the document should not exist yet")
+	}
+
+	s.getOntology(t, mi.Tenant)
+
+	if !s.ontologyDocExists(t, mi) {
+		t.Error("reading the ontology should provision the document")
+	}
+	// Provisioned ≠ active: a run assembled right now still gets the seed alone.
+	def := config.AgentDef{SystemPrompt: "{{memory:ontology}}"}
+	got, _ := s.applyMemoryInjection(context.Background(), def, mi)
+	if !strings.Contains(got.SystemPrompt, "has not confirmed") {
+		t.Errorf("provisioning must not activate anything:\n%s", got.SystemPrompt)
+	}
+}
+
+// TestOntologyAPI_ConfirmReachesTheRunsPrompt closes the loop the operator cares
+// about: the button changes what the model is told. Asserting on the handler's own
+// response would only prove the handler agrees with itself.
+func TestOntologyAPI_ConfirmReachesTheRunsPrompt(t *testing.T) {
+	s, mi := ontologyFixture(t)
+	s.getOntology(t, mi.Tenant)
+	s.setOntologyStatus(t, mi.Tenant, meminject.OntologyConfirmedStatus, http.StatusOK)
+
+	def := config.AgentDef{SystemPrompt: "You extract entities.\n\n{{memory:ontology}}"}
+	got, _ := s.applyMemoryInjection(context.Background(), def, mi)
+
+	if !strings.Contains(got.SystemPrompt, "incident") {
+		t.Errorf("a confirmed tenant term should reach the prompt:\n%s", got.SystemPrompt)
+	}
+	if strings.Contains(got.SystemPrompt, "has not confirmed") {
+		t.Errorf("the prompt still says unconfirmed after the flip:\n%s", got.SystemPrompt)
+	}
+}
+
+// TestOntologyAPI_IsTenantScopedNotAdminOnly: the ontology is per-tenant config and
+// the tenant operator is the intended actor. Pinning it to substrate:admin would
+// hand the only activation control to someone who does not own the vocabulary — and
+// the same tenant token can already write this status through /v1/_document, so a
+// harder gate here would deny the owner without closing anything.
+func TestOntologyAPI_IsTenantScopedNotAdminOnly(t *testing.T) {
+	for _, method := range []string{http.MethodGet, http.MethodPost} {
+		if got := requiredScopeFor(method, "/v1/_ontology"); got != auth.ScopeTenant {
+			t.Errorf("requiredScopeFor(%s /v1/_ontology) = %q, want %q", method, got, auth.ScopeTenant)
+		}
+	}
+}
+
+// TestOntologyAPI_DegradesWithoutSQLMemory: no SQL Memory means no document, but a
+// deployment in that shape still runs on the base seed. Reporting that honestly beats
+// a 503 the UI has to special-case to show a page that is factually correct.
+func TestOntologyAPI_DegradesWithoutSQLMemory(t *testing.T) {
+	s := &Server{}
+
+	got := s.getOntology(t, "acme")
+
+	if got.Provisioned {
+		t.Error("nothing can be provisioned without SQL Memory")
+	}
+	if !hasTerm(got.Effective, "person") {
+		t.Errorf("the seed applies with or without a document, got %v", termNames(got.Effective))
+	}
+	// The write, by contrast, must fail loudly — silently accepting a flip that
+	// cannot persist would report success for nothing.
+	s.setOntologyStatus(t, "acme", meminject.OntologyConfirmedStatus, http.StatusServiceUnavailable)
+}
+
+// ---- helpers ----
+
+func (s *Server) getOntology(t *testing.T, tenant string) ontologyResponse {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/v1/_ontology?tenant="+tenant, nil)
+	rec := httptest.NewRecorder()
+	s.handleOntology(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /v1/_ontology = %d: %s", rec.Code, rec.Body.String())
+	}
+	var got ontologyResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v (%s)", err, rec.Body.String())
+	}
+	return got
+}
+
+// setOntologyStatus posts a flip and asserts the status code, returning the decoded
+// response on success. wantCode makes the refusal cases assert the code rather than
+// only the absence of a change.
+func (s *Server) setOntologyStatus(t *testing.T, tenant, status string, wantCode int) ontologyResponse {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{"status": status})
+	req := httptest.NewRequest(http.MethodPost, "/v1/_ontology?tenant="+tenant, strings.NewReader(string(body)))
+	rec := httptest.NewRecorder()
+	s.handleOntologySetStatus(rec, req)
+	if rec.Code != wantCode {
+		t.Fatalf("POST /v1/_ontology status=%q = %d, want %d: %s", status, rec.Code, wantCode, rec.Body.String())
+	}
+	var got ontologyResponse
+	if wantCode == http.StatusOK {
+		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decode: %v (%s)", err, rec.Body.String())
+		}
+	}
+	return got
+}
+
+// exportOntologyMD reads the document's Markdown, so a test can prove a write did
+// not disturb it.
+func (s *Server) exportOntologyMD(t *testing.T, mi memInject) string {
+	t.Helper()
+	doc := &builtin.Document{Store: s.store, SqlMem: s.sqlMem}
+	dctx := tools.WithMemoryPolicy(s.docToolCtx(context.Background(), mi),
+		tools.MemoryPolicyValue{AllowedScopes: []string{"tenant"}})
+	dctx = tools.WithSqlMemPolicy(dctx, tools.SqlMemPolicyValue{AllowedScopes: []string{"tenant"}})
+	req, _ := json.Marshal(map[string]any{
+		"op": "export_md", "scope": "tenant", "path": meminject.OntologyPath, "include_metadata": false,
+	})
+	res, _ := doc.Execute(dctx, req)
+	if res.IsError {
+		t.Fatalf("export_md: %s", res.Text)
+	}
+	var body struct {
+		Markdown string `json:"markdown"`
+	}
+	if err := json.Unmarshal([]byte(res.Text), &body); err != nil {
+		t.Fatalf("export_md decode: %v", err)
+	}
+	return body.Markdown
+}
+
+func hasTerm(terms []meminject.OntologyTerm, name string) bool {
+	for _, t := range terms {
+		if strings.EqualFold(t.Name, name) {
+			return true
+		}
+	}
+	return false
+}
+
+func termNames(terms []meminject.OntologyTerm) []string {
+	out := make([]string, 0, len(terms))
+	for _, t := range terms {
+		out = append(out, t.Name)
+	}
+	return out
+}

--- a/internal/api/http/ontology_test.go
+++ b/internal/api/http/ontology_test.go
@@ -3,6 +3,7 @@ package http
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -156,45 +157,11 @@ func (s *Server) ontologyDocExists(t *testing.T, mi memInject) bool {
 }
 
 // confirmOntology flips the root chunk to `confirmed`, which is what an operator
-// does in the Web UI.
+// does in the Web UI — and now literally so: it drives POST /v1/_ontology rather
+// than re-deriving the get_document → get_chunk → update_chunk sequence itself. A
+// helper with its own copy of that sequence would keep passing after the real route
+// broke, which is the wrong way round for the path an operator depends on.
 func (s *Server) confirmOntology(t *testing.T, mi memInject) {
 	t.Helper()
-	doc := &builtin.Document{Store: s.store, SqlMem: s.sqlMem}
-	dctx := tools.WithMemoryPolicy(s.docToolCtx(context.Background(), mi),
-		tools.MemoryPolicyValue{AllowedScopes: []string{"tenant"}})
-	dctx = tools.WithSqlMemPolicy(dctx, tools.SqlMemPolicyValue{AllowedScopes: []string{"tenant"}})
-
-	get, _ := json.Marshal(map[string]any{
-		"op": "get_document", "scope": "tenant", "path": meminject.OntologyPath,
-	})
-	res, _ := doc.Execute(dctx, get)
-	if res.IsError {
-		t.Fatalf("confirmOntology: get: %s", res.Text)
-	}
-	var meta struct {
-		RootChunkID string `json:"root_chunk_id"`
-	}
-	if err := json.Unmarshal([]byte(res.Text), &meta); err != nil {
-		t.Fatalf("confirmOntology: decode: %v", err)
-	}
-	// The revision comes from get_chunk: get_document does not return one, and
-	// provisioning already bumped the root to 2 by stamping `draft`.
-	gc, _ := json.Marshal(map[string]any{"op": "get_chunk", "scope": "tenant", "id": meta.RootChunkID})
-	cres, _ := doc.Execute(dctx, gc)
-	if cres.IsError {
-		t.Fatalf("confirmOntology: get_chunk: %s", cres.Text)
-	}
-	var chunk struct {
-		Revision int `json:"revision"`
-	}
-	if err := json.Unmarshal([]byte(cres.Text), &chunk); err != nil {
-		t.Fatalf("confirmOntology: decode chunk: %v", err)
-	}
-	upd, _ := json.Marshal(map[string]any{
-		"op": "update_chunk", "scope": "tenant", "id": meta.RootChunkID,
-		"status": meminject.OntologyConfirmedStatus, "revision": chunk.Revision,
-	})
-	if r, _ := doc.Execute(dctx, upd); r.IsError {
-		t.Fatalf("confirmOntology: update: %s", r.Text)
-	}
+	s.setOntologyStatus(t, mi.Tenant, meminject.OntologyConfirmedStatus, http.StatusOK)
 }

--- a/internal/api/http/retention_report.go
+++ b/internal/api/http/retention_report.go
@@ -41,7 +41,15 @@ type retentionReportResponse struct {
 	// knobs (config only — tenant-readable).
 	MemMode     string `json:"mem_mode"`
 	MemMaxAgeMS int64  `json:"mem_max_age_ms"`
-	ExportDir   string `json:"export_dir,omitempty"`
+	// MemContentMode / MemContentMaxAgeMS are the retired-entity-content prune knobs
+	// — distinct from MemMode, which reclaims a retired AGENT's whole scope. This one
+	// prunes superseded content out of scopes that are still live, and exempts
+	// `evidential` content at any age. Reported so the report covers every configured
+	// family: an operator reading a report that omits a family it has enabled would
+	// reasonably conclude nothing is deleting their data.
+	MemContentMode     string `json:"mem_content_mode"`
+	MemContentMaxAgeMS int64  `json:"mem_content_max_age_ms"`
+	ExportDir          string `json:"export_dir,omitempty"`
 	// Purgeable is the per-def-type count of versions the CURRENT age + keep-last-N
 	// settings would purge right now, plus an aged-chat-session count under "chats"
 	// and a retired-agent memory-reclamation count under "mem" (all regardless of
@@ -95,6 +103,10 @@ func (s *Server) handleRetentionReport(w http.ResponseWriter, r *http.Request) {
 	if memMode == "" {
 		memMode = "off"
 	}
+	memContentMode := s.cfg.Env.RetentionMemContentMode
+	if memContentMode == "" {
+		memContentMode = "off"
+	}
 	// 0 = inherit the global chat age (never "delete immediately"), resolved the
 	// same way retention.New resolves it.
 	chatsInternalMaxAge := s.cfg.Env.RetentionChatsInternalMaxAge
@@ -113,6 +125,8 @@ func (s *Server) handleRetentionReport(w http.ResponseWriter, r *http.Request) {
 		ChatsInternalMaxAgeMS: chatsInternalMaxAge.Milliseconds(),
 		MemMode:               memMode,
 		MemMaxAgeMS:           s.cfg.Env.RetentionMemMaxAge.Milliseconds(),
+		MemContentMode:        memContentMode,
+		MemContentMaxAgeMS:    s.cfg.Env.RetentionMemContentMaxAge.Milliseconds(),
 	}
 
 	if s.store == nil {

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2716,6 +2716,13 @@ func (s *Server) Mux() http.Handler {
 	// live availability + the active-providers header. Scope-gated in
 	// requiredScopeFor.
 	mux.Handle("GET /v1/_routing", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleRouting))))
+	// The tenant ontology's operator surface: GET reports the gate + the effective
+	// (base ⊕ tenant) types, POST flips draft↔confirmed. Tenant-scoped — a tenant
+	// operator confirms its OWN tenant's ontology; the GET provisions the document
+	// on first reference so it can be authored before any run needs it. Authoring
+	// itself stays in the Path/Document browser. Scope-gated in requiredScopeFor.
+	mux.Handle("GET /v1/_ontology", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleOntology))))
+	mux.Handle("POST /v1/_ontology", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleOntologySetStatus))))
 	// RFC BK P3: resident interactive sub-agent visibility + operator control.
 	// GET lists (tenant-scoped); POST close/cancel act on one (tenant-gated).
 	// Per-replica (the resident registry is in-process). Scope-gated in

--- a/internal/api/http/substrate_admin.go
+++ b/internal/api/http/substrate_admin.go
@@ -312,9 +312,23 @@ func substrateAdminCtx(ctx context.Context) context.Context {
 	// grant (own-scope, tenant-confined), consistent with the open scope here.
 	// It does NOT get the origin=consolidator provenance stamp — that requires an
 	// actual run and this plane has no run id (see builtin.provenanceForSet).
+	// `tenant` joins the list to match the MCP operator plane, which got it when
+	// tenant scope shipped while this plane was missed. Not a widening: `global` is
+	// already here and is strictly broader, and the tenant itself comes from the
+	// principal (dispatchSubstrate's RunIdentity), never the wire. Without it the
+	// Web UI could SEE a tenant document in the Path tree and not open it — which is
+	// how the omission surfaced.
 	ctx = tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{
-		AllowedScopes: []string{"agent", "user", "global"},
+		AllowedScopes: []string{"agent", "user", "tenant", "global"},
 		Consolidation: true,
+	})
+	// SQL Memory: same omission, one layer down. A tenant Document needs BOTH grants
+	// (structure in SQL Memory, chunk bodies in Memory), so stamping only the memory
+	// half above would still refuse. `global` is deliberately absent — SQL Memory has
+	// no global tier, and listing a scope the engine cannot create would turn a clear
+	// refusal into a confusing provisioning error.
+	ctx = tools.WithSqlMemPolicy(ctx, tools.SqlMemPolicyValue{
+		AllowedScopes: []string{"agent", "user", "tenant"},
 	})
 	// Channel: "*" wildcard matches every channel name.
 	ctx = tools.WithChannelPolicy(ctx, tools.ChannelPolicyValue{

--- a/internal/api/http/substrate_tenant_scope_test.go
+++ b/internal/api/http/substrate_tenant_scope_test.go
@@ -1,0 +1,50 @@
+package http
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// TestSubstratePlane_GrantsTenantScopeLikeTheMCPPlane pins the two operator planes
+// to the same memory reach.
+//
+// A tenant document needs BOTH grants — structure lives in SQL Memory, chunk bodies
+// in Memory — and the MCP plane got them when tenant scope shipped while this HTTP
+// plane was missed. The result was a split-brain operator surface: the same tenant
+// document was reachable through an MCP session and refused through the Web UI,
+// which reads the HTTP plane. Worse than either answer, because the UI could list
+// the document in the Path tree and then fail to open it.
+//
+// `global` is intentionally absent from the SQL half: SQL Memory has no global tier,
+// so advertising one would trade a clear refusal for a confusing provisioning error.
+func TestSubstratePlane_GrantsTenantScopeLikeTheMCPPlane(t *testing.T) {
+	ctx := substrateAdminCtx(context.Background())
+
+	mem := tools.MemoryPolicy(ctx).AllowedScopes
+	for _, want := range []string{"agent", "user", "tenant", "global"} {
+		if !containsStr(mem, want) {
+			t.Errorf("memory scope %q missing from the operator plane: %v", want, mem)
+		}
+	}
+	sql := tools.SqlMemPolicy(ctx).AllowedScopes
+	for _, want := range []string{"agent", "user", "tenant"} {
+		if !containsStr(sql, want) {
+			t.Errorf("sql scope %q missing from the operator plane: %v", want, sql)
+		}
+	}
+	if containsStr(sql, "global") {
+		t.Errorf("SQL Memory has no global tier; advertising one misleads: %v", sql)
+	}
+}
+
+func containsStr(ss []string, want string) bool {
+	for _, s := range ss {
+		if strings.EqualFold(s, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/store/postgres/migrations/0064_dirents_tenant_scope_id.down.sql
+++ b/internal/store/postgres/migrations/0064_dirents_tenant_scope_id.down.sql
@@ -1,0 +1,13 @@
+-- Reverses 0064 — except it cannot, and deliberately does not try.
+--
+-- The forward migration moves a tenant dirent from a SQL-Memory-shaped scope_id to
+-- the empty one the dirent plane uses. Reversing it would mean reconstructing which
+-- tenant each row's scope_id used to hold, and that value is exactly what was
+-- overwritten. Guessing it from tenant_id would be right only for deployments where
+-- the two planes happened to agree.
+--
+-- Nothing is lost by leaving the rows re-homed: '' is the coordinate the Path tool
+-- reads, so a rolled-back binary still finds them through Path. Only the Document
+-- tool's own pre-fix path lookups would miss them, and those were already the
+-- broken half.
+SELECT 1;

--- a/internal/store/postgres/migrations/0064_dirents_tenant_scope_id.up.sql
+++ b/internal/store/postgres/migrations/0064_dirents_tenant_scope_id.up.sql
@@ -1,0 +1,31 @@
+-- 0064_dirents_tenant_scope_id.up.sql — re-home tenant-scope dirents onto the
+-- dirent plane's own scope-id convention.
+--
+-- The Document tool wrote a dirent using its SQL-Memory scope key. SQL Memory
+-- requires a non-empty scope id (it becomes half of a schema name and a database
+-- login role), so tenant scope carries the tenant there — while the dirent plane
+-- leaves scope_id EMPTY for tenant and lets tenant_id carry the identity, which is
+-- what the Path tool resolves. The result: a tenant document was named at a
+-- coordinate nothing else reads, so it was invisible in the Path tree and the
+-- browser, with no error on either side.
+--
+-- Data-only. The code fix keys new dirents correctly; this moves the rows written
+-- before it. Rows created by the Path tool already use '' and are untouched by the
+-- scope_id <> '' predicate.
+--
+-- A row whose destination coordinate is ALREADY occupied is left where it is
+-- rather than merged: the '' row is the reachable one, so the stale row is a
+-- duplicate that costs nothing, and choosing which resource_ref survives is not a
+-- decision a migration should make silently. Idempotent — a second run finds only
+-- those collisions and skips them again.
+UPDATE dirents d
+   SET scope_id = ''
+ WHERE d.scope = 'tenant'
+   AND d.scope_id <> ''
+   AND NOT EXISTS (
+         SELECT 1 FROM dirents x
+          WHERE x.tenant_id = d.tenant_id
+            AND x.scope = 'tenant'
+            AND x.scope_id = ''
+            AND x.parent_path = d.parent_path
+            AND x.name = d.name);

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -1100,6 +1100,28 @@ func (s *Store) migrate(ctx context.Context) error {
 		return fmt.Errorf("migrate backfill runs.tenant_id: %w", err)
 	}
 
+	// Re-home tenant-scope dirents onto the dirent plane's own scope-id convention.
+	// Mirrors postgres migration 0064.
+	//
+	// The Document tool wrote a dirent using its SQL-Memory scope key, and SQL
+	// Memory requires a non-empty scope id (it becomes half of a schema name and a
+	// database login role), so tenant scope carried the tenant there. The dirent
+	// plane does the opposite — scope_id is empty for tenant, tenant_id carries the
+	// identity — which is what the Path tool resolves. A tenant document was
+	// therefore named at a coordinate nothing else reads: invisible in the Path tree
+	// and the browser, with no error on either side.
+	//
+	// OR IGNORE leaves a row whose destination is already occupied where it is: the
+	// '' row is the reachable one, so the stale row is a harmless duplicate, and
+	// picking which resource_ref survives is not a decision a migration should make
+	// silently. Idempotent — after the first pass only those collisions remain, and
+	// they are skipped again. Path-created rows already use '' and never match.
+	if _, err := s.db.ExecContext(ctx, `
+		UPDATE OR IGNORE dirents SET scope_id = ''
+		 WHERE scope = 'tenant' AND scope_id <> ''`); err != nil {
+		return fmt.Errorf("migrate re-home tenant dirents: %w", err)
+	}
+
 	addIndexes := []string{
 		// Drives the hot lookup paths for the cancel/get endpoints.
 		// Partial indexes (WHERE ... IS NOT NULL) keep the index small —

--- a/internal/store/sqlite/sqlite_test.go
+++ b/internal/store/sqlite/sqlite_test.go
@@ -927,3 +927,92 @@ func BenchmarkConcurrentRuns(b *testing.B) {
 		_ = s.Close()
 	}
 }
+
+// TestMigrate_ReHomesTenantDirents covers the data repair for tenant-scope dirents
+// written at the SQL-Memory scope id instead of the dirent plane's empty one.
+//
+// Setup writes the three states an upgraded database can be in — a stale tenant row
+// to move, a stale row whose destination is already taken, and a correct row of each
+// other scope — then re-opens the store so migrate() runs, because the repair has to
+// be safe on a database that already holds a mix.
+func TestMigrate_ReHomesTenantDirents(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "dirents.db")
+	s1, err := Open(path)
+	if err != nil {
+		t.Fatalf("first Open: %v", err)
+	}
+	ins := func(tenant, scope, scopeID, parent, name string) {
+		t.Helper()
+		if _, err := s1.db.Exec(
+			`INSERT INTO dirents (tenant_id, scope, scope_id, parent_path, name, kind, resource_ref, created_at, updated_at)
+			 VALUES (?,?,?,?,?, 'document', '{}', 1, 1)`,
+			tenant, scope, scopeID, parent, name); err != nil {
+			t.Fatalf("insert %s/%s/%s%s: %v", scope, scopeID, parent, name, err)
+		}
+	}
+	// Stale: written by the Document tool at its SQL-Memory tenant scope id.
+	ins("acme", "tenant", "acme", "/memory/", "ontology")
+	// Stale AND colliding: a correct '' row already occupies the coordinate.
+	ins("acme", "tenant", "", "/", "notes")
+	ins("acme", "tenant", "acme", "/", "notes")
+	// Other scopes: their two planes already agree, so these must not move.
+	ins("acme", "user", "alice", "/", "diary")
+	ins("acme", "agent", "curator", "/", "scratch")
+	if err := s1.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	s2, err := Open(path) // runs migrate()
+	if err != nil {
+		t.Fatalf("re-open: %v", err)
+	}
+	defer s2.Close()
+
+	scopeIDOf := func(scope, parent, name string) []string {
+		t.Helper()
+		rows, err := s2.db.Query(
+			`SELECT scope_id FROM dirents WHERE scope = ? AND parent_path = ? AND name = ? ORDER BY scope_id`,
+			scope, parent, name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer rows.Close()
+		var out []string
+		for rows.Next() {
+			var v string
+			if err := rows.Scan(&v); err != nil {
+				t.Fatal(err)
+			}
+			out = append(out, v)
+		}
+		return out
+	}
+
+	// Moved onto the coordinate the Path tool reads.
+	if got := scopeIDOf("tenant", "/memory/", "ontology"); len(got) != 1 || got[0] != "" {
+		t.Errorf("the stale tenant dirent was not re-homed: scope_ids = %q", got)
+	}
+	// The collision is left alone rather than merged — both rows survive, and the
+	// reachable '' one is unchanged.
+	if got := scopeIDOf("tenant", "/", "notes"); len(got) != 2 || got[0] != "" {
+		t.Errorf("a colliding row should be skipped, not merged or dropped: scope_ids = %q", got)
+	}
+	// Scopes whose planes already agree are untouched: moving these would break the
+	// rows that were correct all along.
+	if got := scopeIDOf("user", "/", "diary"); len(got) != 1 || got[0] != "alice" {
+		t.Errorf("user dirent should be untouched, got %q", got)
+	}
+	if got := scopeIDOf("agent", "/", "scratch"); len(got) != 1 || got[0] != "curator" {
+		t.Errorf("agent dirent should be untouched, got %q", got)
+	}
+
+	// Idempotent: a third boot changes nothing.
+	if err := s2.Close(); err != nil {
+		t.Fatal(err)
+	}
+	s3, err := Open(path)
+	if err != nil {
+		t.Fatalf("third Open: %v", err)
+	}
+	defer s3.Close()
+}

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -778,6 +778,31 @@ func (d *Document) setPath(ctx context.Context, key sqlmem.ScopeKey, in docInput
 	return jsonResult(map[string]any{"document_id": docID, "path": p})
 }
 
+// direntScopeID maps a SQL-Memory scope key onto the DIRENT plane's scope id.
+//
+// They agree for agent and user scope (the agent name / the user id) and diverge
+// for TENANT, because the two planes key a tenant differently and each is right in
+// its own plane:
+//
+//   - SQL Memory REQUIRES a non-empty scope id — it becomes half of a schema name
+//     and a database login role, so tenant scope carries the tenant there.
+//   - The dirent plane leaves scope_id EMPTY for tenant and lets the tenant_id
+//     column carry the identity. That is what the Path tool resolves, what Memory
+//     does, and what the store's schema defaults to.
+//
+// Writing the SQL-Memory id into a dirent leaks a storage-engine constraint into a
+// plane that does not share it, and the symptom is silent: the Document tool's own
+// path lookups keep working (it reads back at the same wrong coordinate it wrote),
+// while the Path tool — and therefore the whole browser — lists nothing. A
+// document present in one tool's view and absent from the other's, with no error
+// on either side.
+func direntScopeID(key sqlmem.ScopeKey) string {
+	if key.Scope == "tenant" {
+		return ""
+	}
+	return key.ScopeID
+}
+
 // registerDocDirent names a document in the Path tree (a `document` dirent).
 func (d *Document) registerDocDirent(ctx context.Context, key sqlmem.ScopeKey, docID, rawPath string) (string, error) {
 	canonical, err := normalizePath(rawPath)
@@ -790,7 +815,7 @@ func (d *Document) registerDocDirent(ctx context.Context, key sqlmem.ScopeKey, d
 	}
 	ref, _ := json.Marshal(map[string]any{"document_id": docID})
 	if _, err := d.Store.DirentCreate(ctx, store.DirentRow{
-		TenantID: direntTenant(ctx), Scope: key.Scope, ScopeID: key.ScopeID,
+		TenantID: direntTenant(ctx), Scope: key.Scope, ScopeID: direntScopeID(key),
 		ParentPath: parent, Name: name, Kind: "document", ResourceRef: ref,
 	}); err != nil {
 		return "", err
@@ -814,7 +839,7 @@ func (d *Document) docIDFromInput(ctx context.Context, key sqlmem.ScopeKey, in d
 	if isRoot {
 		return "", fmt.Errorf("path may not be the root")
 	}
-	row, err := d.Store.DirentGet(ctx, direntTenant(ctx), key.Scope, key.ScopeID, parent, name)
+	row, err := d.Store.DirentGet(ctx, direntTenant(ctx), key.Scope, direntScopeID(key), parent, name)
 	if err != nil {
 		var nf *store.ErrNotFound
 		if asNotFound(err, &nf) {
@@ -1057,7 +1082,7 @@ func (d *Document) deleteDocument(ctx context.Context, key sqlmem.ScopeKey, msco
 	// document_id (works whether the caller addressed by id or path, so a
 	// delete-by-id never leaves a dangling name). Scans the scope's document
 	// dirents (bounded; a scope's name count is small).
-	if rows, lerr := d.Store.DirentListUnder(ctx, direntTenant(ctx), key.Scope, key.ScopeID, "/"); lerr == nil {
+	if rows, lerr := d.Store.DirentListUnder(ctx, direntTenant(ctx), key.Scope, direntScopeID(key), "/"); lerr == nil {
 		for _, r := range rows {
 			if r.Kind != "document" {
 				continue
@@ -1067,7 +1092,7 @@ func (d *Document) deleteDocument(ctx context.Context, key sqlmem.ScopeKey, msco
 			}
 			_ = json.Unmarshal(r.ResourceRef, &ref)
 			if ref.DocumentID == docID {
-				_, _ = d.Store.DirentDelete(ctx, direntTenant(ctx), key.Scope, key.ScopeID, r.ParentPath, r.Name)
+				_, _ = d.Store.DirentDelete(ctx, direntTenant(ctx), key.Scope, direntScopeID(key), r.ParentPath, r.Name)
 			}
 		}
 	}
@@ -1839,7 +1864,7 @@ func (d *Document) documentsUnderPath(ctx context.Context, key sqlmem.ScopeKey, 
 	if err != nil {
 		return nil, err
 	}
-	rows, err := d.Store.DirentListUnder(ctx, direntTenant(ctx), key.Scope, key.ScopeID, dirPrefix(canonical))
+	rows, err := d.Store.DirentListUnder(ctx, direntTenant(ctx), key.Scope, direntScopeID(key), dirPrefix(canonical))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tools/builtin/document_dirent_scope_test.go
+++ b/internal/tools/builtin/document_dirent_scope_test.go
@@ -1,0 +1,132 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// TestDocument_TenantDirentIsReachableFromThePathTool is the cross-tool agreement
+// the Path tree depends on.
+//
+// The Document tool writes a dirent when it names a document; the Path tool reads
+// dirents. They have to key them identically or a document exists in one tool's
+// view and not the other's — and nothing errors, because a missing dirent is
+// indistinguishable from a document that was never named. The whole failure is an
+// empty listing.
+//
+// Tenant scope is where they diverged. SQL Memory REQUIRES a non-empty scope id
+// (it becomes half of a schema name and a database role), so the tenant scope key
+// carries the tenant there; the dirent plane's convention is the opposite —
+// scope_id is empty for tenant and the tenant_id column carries the identity,
+// which is what Path, Memory and the store's own schema default all do. Writing
+// the SQL-Memory id into a dirent leaks a storage-engine constraint into a plane
+// that does not share it.
+func TestDocument_TenantDirentIsReachableFromThePathTool(t *testing.T) {
+	for _, scope := range []string{"agent", "user", "tenant"} {
+		t.Run(scope, func(t *testing.T) {
+			d, ctx, st := documentDirentFixture(t)
+			p := &Path{Store: st}
+
+			create, _ := json.Marshal(map[string]any{
+				"op": "create_document", "scope": scope,
+				"title": "probe", "path": "/probe",
+			})
+			res, err := d.Execute(ctx, create)
+			if err != nil || res.IsError {
+				t.Fatalf("create_document: %v %s", err, res.Text)
+			}
+
+			ls, _ := json.Marshal(map[string]any{"op": "ls", "scope": scope, "path": "/"})
+			lres, err := p.Execute(ctx, ls)
+			if err != nil || lres.IsError {
+				t.Fatalf("path ls: %v %s", err, lres.Text)
+			}
+			var listing struct {
+				Entries []struct {
+					Name string `json:"name"`
+				} `json:"entries"`
+			}
+			if err := json.Unmarshal([]byte(lres.Text), &listing); err != nil {
+				t.Fatalf("decode listing: %v (%s)", err, lres.Text)
+			}
+			if len(listing.Entries) != 1 || listing.Entries[0].Name != "probe" {
+				t.Fatalf("Path cannot see the document the Document tool just named at scope=%s: %s",
+					scope, lres.Text)
+			}
+		})
+	}
+}
+
+// TestDocument_TenantPathLookupFindsTheDocument: the same divergence, from the
+// other side. Document resolves `path` through a dirent read of its own, so a
+// dirent written at one coordinate and read at another makes a document
+// unreachable by the very path it was created with — while remaining reachable by
+// id, which is how this hides.
+func TestDocument_TenantPathLookupFindsTheDocument(t *testing.T) {
+	d, ctx, st := documentDirentFixture(t)
+	p := &Path{Store: st}
+
+	create, _ := json.Marshal(map[string]any{
+		"op": "create_document", "scope": "tenant", "title": "ontology", "path": "/memory/ontology",
+	})
+	res, _ := d.Execute(ctx, create)
+	if res.IsError {
+		t.Fatalf("create_document: %s", res.Text)
+	}
+	var created struct {
+		DocumentID string `json:"document_id"`
+	}
+	_ = json.Unmarshal([]byte(res.Text), &created)
+
+	get, _ := json.Marshal(map[string]any{
+		"op": "get_document", "scope": "tenant", "path": "/memory/ontology",
+	})
+	gres, _ := d.Execute(ctx, get)
+	if gres.IsError {
+		t.Fatalf("get_document by path: %s", gres.Text)
+	}
+	var got struct {
+		DocumentID string `json:"document_id"`
+	}
+	_ = json.Unmarshal([]byte(gres.Text), &got)
+	if got.DocumentID != created.DocumentID {
+		t.Errorf("path lookup resolved %q, want the created %q", got.DocumentID, created.DocumentID)
+	}
+
+	// And the intermediate directory is walkable, which is what a browser does.
+	ls, _ := json.Marshal(map[string]any{"op": "ls", "scope": "tenant", "path": "/memory"})
+	lres, _ := p.Execute(ctx, ls)
+	if lres.IsError {
+		t.Fatalf("path ls /memory: %s", lres.Text)
+	}
+	var listing struct {
+		Entries []struct {
+			Name string `json:"name"`
+		} `json:"entries"`
+	}
+	_ = json.Unmarshal([]byte(lres.Text), &listing)
+	if len(listing.Entries) != 1 || listing.Entries[0].Name != "ontology" {
+		t.Errorf("ls /memory did not list the document: %s", lres.Text)
+	}
+}
+
+// documentDirentFixture builds a Document + a store sharing one ctx identity, so
+// both tools resolve the same scopes from the same run.
+func documentDirentFixture(t *testing.T) (*Document, context.Context, store.Store) {
+	t.Helper()
+	d, ctx, st := documentFixture(t)
+	// scope=agent needs an agent name on the run; user + tenant come from the
+	// RunIdentity documentFixture already stamps. Tenant scope additionally needs
+	// BOTH grants — a tenant document is shared by every agent in the tenant, so it
+	// is opt-in; this is the state a granted agent runs in.
+	ctx = tools.WithAgentName(ctx, "curator")
+	ctx = tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{
+		AllowedScopes: []string{"agent", "user", "tenant"}})
+	ctx = tools.WithSqlMemPolicy(ctx, tools.SqlMemPolicyValue{
+		AllowedScopes: []string{"agent", "user", "tenant"}})
+	return d, ctx, st
+}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -2561,6 +2561,56 @@ export function getRouting(): Promise<RoutingResponse> {
   return jsonFetch<RoutingResponse>("/v1/_routing");
 }
 
+// ---- Tenant ontology (GET/POST /v1/_ontology) ----
+// The entity types the memory tier extracts against: a base seed every tenant
+// gets, optionally layered with types this tenant defines in a document. The
+// tenant layer is INERT until an operator confirms it, and this is the surface
+// that shows that state and flips it.
+//
+// `terms` and `effective` are both reported because the difference between them
+// IS the gate: while draft, `terms` is what the operator wrote and `effective`
+// shows it isn't applied. The layering is computed server-side so this client
+// can't drift from what a run actually receives.
+export interface OntologyTerm {
+  name: string;
+  fields?: string[];
+  source: "base" | "tenant";
+}
+
+export interface OntologyResponse {
+  tenant: string;
+  path: string;
+  document_id?: string;
+  root_chunk_id?: string;
+  /** The root chunk's raw status — may be any string a document edit left there. */
+  status: string;
+  /** The decision derived from `status`. A typo'd status is not confirmed. */
+  confirmed: boolean;
+  /** False when the document doesn't exist and couldn't be created (no SQL Memory). */
+  provisioned: boolean;
+  /** This tenant's own types, reported whether or not they're in force. */
+  terms: OntologyTerm[];
+  /** What a run gets right now: the seed, plus the tenant layer if confirmed. */
+  effective: OntologyTerm[];
+}
+
+export function getOntology(tenant?: string): Promise<OntologyResponse> {
+  const q = tenant ? `?tenant=${encodeURIComponent(tenant)}` : "";
+  return jsonFetch<OntologyResponse>(`/v1/_ontology${q}`);
+}
+
+/** Flip the tenant layer on or off. The API accepts only these two values. */
+export function setOntologyStatus(
+  status: "confirmed" | "draft",
+  tenant?: string,
+): Promise<OntologyResponse> {
+  const q = tenant ? `?tenant=${encodeURIComponent(tenant)}` : "";
+  return postJSON<OntologyResponse>(
+    `/v1/_ontology${q}`,
+    JSON.stringify({ status }),
+  );
+}
+
 // --- RFC AR: secure credential store (POST /v1/_credentialdef) ---
 
 // CredentialScope buckets a stored secret. tenant = shared across the tenant;

--- a/web/src/pages/SettingsView.tsx
+++ b/web/src/pages/SettingsView.tsx
@@ -5,18 +5,21 @@ import {
   CredentialScope,
   HealthResponse,
   MemoryOrphanReport,
+  OntologyResponse,
   PresetUnit,
   RuntimeStateResponse,
   createCredential,
   deleteCredential,
   getEnvTemplate,
   getHealth,
+  getOntology,
   getRuntimeState,
   listCredentials,
   listPresets,
   pauseRuntime,
   repairTenantMemory,
   resumeRuntime,
+  setOntologyStatus,
   showPreset,
 } from "../api";
 import { usePrincipal } from "../components/Layout";
@@ -30,8 +33,9 @@ import TokenManager from "../components/TokenManager";
 // rendered for both in Layout); the tabs are filtered by scope:
 //   - tenant-visible (admin + substrate:tenant): credentials (enter your own
 //     provider API keys — RFC AR), limits (per-scope token budgets, RFC AW),
-//     routing (the resolved model cascade). Their data is tenant-scoped
-//     server-side — a tenant operator sees only its own tenant.
+//     routing (the resolved model cascade), ontology (the tenant entity types +
+//     the draft→confirmed gate). Their data is tenant-scoped server-side — a
+//     tenant operator sees only its own tenant.
 //   - admin-only: tokens (minting, RFC L), presets (RFC AQ), runtime
 //     (pause/resume), health.
 // The backend gates every surface too (defence in depth). Surfaces with their
@@ -40,6 +44,7 @@ type Section =
   | "credentials"
   | "limits"
   | "routing"
+  | "ontology"
   | "tokens"
   | "presets"
   | "runtime"
@@ -56,6 +61,11 @@ const SECTIONS: SectionDef[] = [
   { id: "credentials", label: "Credentials", admin: false },
   { id: "limits", label: "Limits", admin: false },
   { id: "routing", label: "Routing", admin: false },
+  // Tenant-visible: the ontology is per-tenant config, and the operator who owns
+  // the vocabulary is the one who should activate it. GET/POST /v1/_ontology are
+  // ScopeTenant and derive the tenant from the principal, so a tenant operator
+  // reaches only its own.
+  { id: "ontology", label: "Ontology", admin: false },
   { id: "tokens", label: "Tokens", admin: true },
   { id: "presets", label: "Presets", admin: true },
   { id: "runtime", label: "Runtime", admin: true },
@@ -97,6 +107,7 @@ export default function SettingsView() {
         {section === "credentials" && <CredentialsSection />}
         {section === "limits" && <LimitsView />}
         {section === "routing" && <RoutingView />}
+        {section === "ontology" && <OntologySection />}
         {section === "tokens" && <TokenManager />}
         {section === "presets" && <PresetsSection />}
         {section === "runtime" && <RuntimeSection />}
@@ -431,6 +442,173 @@ function PresetsSection() {
 // This lives in the UI because the deployments most likely to be affected are
 // appliance-style ones with no shell — the alternative is hand-writing a
 // collision-aware UPDATE against a live database.
+// ─── Ontology ────────────────────────────────────────────────────────────────
+
+// OntologySection is the operator control for the tenant's entity types.
+//
+// The failure this exists to prevent is not an error message: it is an operator
+// who edits the ontology document, never learns that editing alone changes
+// nothing, and concludes the feature is broken. So the panel leads with the state
+// of the gate, and shows the tenant's own types NEXT TO the types actually in
+// force — the gap between the two columns is the only visible evidence that a
+// draft is inert.
+//
+// Authoring stays in the Path browser (a Markdown document deserves the document
+// editor); the two things that cannot live there are the gate and the layered
+// result, so those are what this panel is.
+function OntologySection() {
+  const [state, setState] = useState<OntologyResponse | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      setState(await getOntology());
+      setErr(null);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const flip = async (status: "confirmed" | "draft") => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      setState(await setOntologyStatus(status));
+      setErr(null);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const tenantTerms = state?.terms ?? [];
+  // A status that is neither of the two words the gate accepts — reachable by
+  // editing the document's status field by hand. Called out explicitly, because
+  // this is precisely the state that looks confirmed and behaves as draft.
+  const oddStatus =
+    !!state?.status && state.status !== "confirmed" && state.status !== "draft";
+
+  return (
+    <div className="settings-panel">
+      <h2>Ontology</h2>
+      <p className="settings-help">
+        The entity types agents extract against. Every tenant starts from a
+        standard set; types you define in{" "}
+        <Link to="/paths">{state?.path ?? "/memory/ontology"}</Link> (tenant
+        scope) are layered on top — but only once you confirm them. Until then
+        your edits are stored and inert, so you can draft an ontology without
+        changing what any running agent is told.
+      </p>
+
+      {err && <div className="settings-error">{err}</div>}
+
+      {state && !state.provisioned && (
+        <div className="settings-muted">
+          No ontology document — this deployment has no SQL Memory configured, so
+          agents run on the standard types alone.
+        </div>
+      )}
+
+      {state?.provisioned && (
+        <>
+          <div className="settings-row">
+            <span className={state.confirmed ? "settings-flash" : "settings-muted"}>
+              {state.confirmed
+                ? `Confirmed — your ${tenantTerms.length} type(s) are in force.`
+                : `Draft — your ${tenantTerms.length} type(s) are NOT in force.`}
+            </span>
+            {state.confirmed ? (
+              <button type="button" onClick={() => flip("draft")} disabled={busy}>
+                Revert to draft
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() => flip("confirmed")}
+                disabled={busy}
+              >
+                Confirm
+              </button>
+            )}
+          </div>
+
+          {oddStatus && (
+            <p className="settings-help">
+              The document's status reads <code>{state.status}</code>, which is
+              neither <code>draft</code> nor <code>confirmed</code> — the tenant
+              layer is treated as draft. Use the button above rather than editing
+              the status by hand; only the exact word activates it.
+            </p>
+          )}
+
+          {state.confirmed && tenantTerms.length === 0 && (
+            <p className="settings-help">
+              Confirmed, but no types were found in the document. Each type needs
+              its own <code>## name</code> heading, with field names in backticks
+              on the bullets beneath it — anything else is skipped, so a
+              differently-formatted document confirms to nothing.
+            </p>
+          )}
+
+          <div className="settings-row">
+            <table className="settings-table">
+              <thead>
+                <tr>
+                  <th>this deployment defines</th>
+                  <th>in force now</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    {tenantTerms.length === 0 ? (
+                      <span className="settings-muted">none yet</span>
+                    ) : (
+                      tenantTerms.map((t) => (
+                        <div key={t.name}>
+                          <code>{t.name}</code>
+                          {t.fields && t.fields.length > 0 && (
+                            <span className="settings-muted">
+                              {" "}
+                              — {t.fields.join(", ")}
+                            </span>
+                          )}
+                        </div>
+                      ))
+                    )}
+                  </td>
+                  <td>
+                    {(state.effective ?? []).map((t) => (
+                      <div key={t.name}>
+                        <code>{t.name}</code>
+                        {t.source === "tenant" && (
+                          <span className="settings-flash"> yours</span>
+                        )}
+                        {t.fields && t.fields.length > 0 && (
+                          <span className="settings-muted">
+                            {" "}
+                            — {t.fields.join(", ")}
+                          </span>
+                        )}
+                      </div>
+                    ))}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
 function MaintenanceSection() {
   // Deliberately NOT prefilled from the principal. A legacy/open-mode token
   // reports tenant "default", which holds none of the stranded rows — prefilling


### PR DESCRIPTION
## Why

The tenant ontology's `draft → confirmed` flip was specified as an **operator** action — the runtime never decides it. The backend honors `confirmed`; nothing shipped that could set it.

Until now the only way was to open the document in the Path browser and type `confirmed` into the root chunk's free-text status box. That works, and it is not a control. Nothing tells an operator that the word is load-bearing, that their edits are currently inert, or which types are actually reaching the extractor. **A gate whose state you cannot see is a gate that silently stays shut.**

Verifying that by hand surfaced two bugs that made the whole authoring story unusable. Both are in this PR, first, because a Confirm button for a document nobody can open is half a feature.

## The control (commit 3)

`GET /v1/_ontology` reports the gate plus **both** the tenant's own types and the types actually in force. `POST /v1/_ontology` flips between exactly two values. A Settings → **Ontology** tab renders it, tenant-visible.

The gap between those two lists is the point:

| this deployment defines | in force now |
|---|---|
| `project`, `incident`, `constraint` | `event`, `fact`, `location`, `object`, `organization`, `person`, `preference` |

That is a draft. An operator who edits and never confirms sees their types in one column and absent from the other — the only visible evidence that editing alone does nothing.

**The two-value write is the substantive part.** Through `update_chunk` an operator can save `confirmd`, see it stored, and get a permanently inert ontology with no error anywhere — the invisible failure this design rejected a per-term approval queue to avoid. Here is that state, from the fail-before run:

```
{"status":"confirmd","confirmed":false, ... "effective":[ ...seed only... ]}
```

A two-value endpoint cannot produce it. The read also reports the raw status next to the derived boolean, so a hand-edited one is called out rather than silently treated as draft.

Deliberately a read plus a two-value write, **not** a document editor — authoring stays in the Path browser, where editing Markdown belongs. Two smaller calls: the **read provisions** the document (provisioning was lazy on the first run that referenced the ontology, so an operator wanting to set it up beforehand had nothing to open), and the flip sends **status only** (`update_chunk` is presence-based; sending body/fields is the exact shape that blanked a document root once before).

`ScopeTenant` on both methods — the tenant operator owns the vocabulary, and the same token can already write this status through `/v1/_document`, so a harder gate would deny the owner without closing anything.

## Bug 1 — a tenant document was invisible in the Path tree (commit 1)

The Document tool names a document by writing a dirent, and passed its **SQL-Memory** scope key straight through. SQL Memory *requires* a non-empty scope id (it becomes half of a schema name and a database login role), so tenant scope carries the tenant there. The dirent plane does the opposite: `scope_id` is **empty** for tenant and `tenant_id` carries the identity — which is what the Path tool resolves, what Memory does, and what the store's schema defaults to. The write landed at a coordinate nothing else reads.

```
scope    scope_id    parent_path  name        ← as stored by Document
tenant   default     /memory/     ontology
user     http-admin  /            probe       ← agent/user agree, so they worked
```

**It hid because both sides were consistently wrong together.** Document reads a path back through a dirent lookup at the same key it wrote, so its own path lookups kept working; only a cross-tool read failed. And a missing dirent is indistinguishable from a document that was never named — the entire symptom is `{"entries":[]}` with no error on either side.

Fixed with one mapping (`direntScopeID`) at all five dirent call sites: the SQL-Memory id stays SQL Memory's, every other plane gets the k/v convention. Same class as the retention prune deriving a body tenant from a context that had none — a value correct in one plane leaking into another.

Plus the data repair for rows already written that way: postgres migration **0064** + the mirrored sqlite backfill. A row whose destination is already occupied is **left where it is** rather than merged — the `''` row is the reachable one, so the stale row is a harmless duplicate, and choosing which `resource_ref` survives is not a decision a migration should make silently. Idempotent.

## Bug 2 — and then it could be seen but not opened (commit 2)

With the keying fixed, the Path tree listed the ontology and opening it still returned `tool_refused`. The **MCP** operator plane got the tenant grants when tenant scope shipped; this **HTTP** plane was missed — so the same tenant document was reachable through an MCP session and refused through the Web UI, which reads this plane. Worse than either answer alone: a surface that shows you a thing it will not let you have.

Both grants are needed (structure in SQL Memory, bodies in Memory). `SqlMemPolicy` was never stamped on this plane at all, unnoticed because only tenant scope checks it. Not a widening — `global` is already granted here and is strictly broader, and the tenant comes from the principal, never the wire. `global` is deliberately absent from the SQL half: SQL Memory has no global tier, and advertising one trades a clear refusal for a confusing provisioning error. The test pins the two planes to each other, since the failure mode was them drifting apart rather than either being wrong alone.

## Tested

**16 new tests.** Fail-before verified **five** times, each against the committed test:

| mutation | result |
|---|---|
| `direntScopeID` returns the raw id | `Path cannot see the document the Document tool just named at scope=tenant: {"entries":[]}` |
| sqlite backfill removed | `the stale tenant dirent was not re-homed: scope_ids = ["acme"]` |
| two-value validation removed | `POST status="confirmd" = 200, want 400` (+ an inert ontology stored) |
| body sent on the flip patch | `the flip rewrote the document` |
| `Confirmed` hardcoded true | `a freshly provisioned ontology must report unconfirmed` |

The gate is tested in **both** directions — one tested only on opening can ship stuck open, and a confirm an operator cannot undo is a one-way door on a live extractor. The pre-existing `confirmOntology` helper now drives the real route instead of re-deriving the `get_document → get_chunk → update_chunk` sequence, so it can no longer pass while the route is broken.

`gofmt` clean · full `go test ./...` green · both CI postgres steps reproduced locally · `tsc --noEmit` + 38 web tests green · `make build-ui` builds.

**Manual, on a real binary** — the loop an operator now has:

```
1. browse : {"entries":[{"name":"ontology","kind":"document","full_path":"/memory/ontology",...
2. open   : {"document_id":"d4908e92...","root_chunk_id":"731c55b5...","status":"draft"...
3. edit   : markdown chars: 1816
4. confirm: confirmed True | now in force: ['constraint', 'incident', 'project']
```

## Also

`GET /v1/_retention` now reports the `mem_content` family, which shipped without it (commit 4). An operator reading a report that omits a family they enabled would reasonably conclude nothing is deleting their data.

## Note

The dirent repair moves rows on **your dev deployment** — v1.41.0 shipped tenant scope for Documents, so any tenant-scope document created since (including the P4b live verification) has a dirent at the wrong coordinate. It runs at boot, is idempotent, and skips collisions. Nothing is deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)