### PR TITLE
fix(memory): an entity upsert must preserve what it was not given

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
           # and `go test ./...` cannot run both packages against it concurrently.
           # Add every new postgres-tier test in this package here, or it is
           # decoration rather than a gate.
-          go test -count=1 -run 'TestEmbedDirective|TestEncodePgvector|TestResolveEmbedArgs|TestMemorySQL_EmbedDirective|TestDocument_Postgres|TestSidecar_PostgresTierParity' ./internal/tools/builtin/...
+          go test -count=1 -run 'TestEmbedDirective|TestEncodePgvector|TestResolveEmbedArgs|TestMemorySQL_EmbedDirective|TestDocument_Postgres|TestSidecar_PostgresTierParity|TestUpsert_ReObservation' ./internal/tools/builtin/...
 
   runtime-codejs:
     name: Runtime suites (code-js)

--- a/internal/tools/builtin/document_entity.go
+++ b/internal/tools/builtin/document_entity.go
@@ -155,48 +155,188 @@ func (d *Document) updateChunkForUpsert(ctx context.Context, key sqlmem.ScopeKey
 	return nil
 }
 
-// writeChunkMeta upserts the sidecar row.
+// chunkMetaRow is a sidecar row as stored. Nullable columns are pointers so
+// "absent" survives a read/write round trip — writing 0 where NULL was is the
+// difference between "never retired" and "retired at the unix epoch".
+type chunkMetaRow struct {
+	ValidAt    *int64
+	InvalidAt  *int64
+	CreatedAt  *int64
+	ExpiredAt  *int64
+	Class      string
+	Origin     string
+	Confidence *float64
+	SessionID  string
+	RunID      string
+	EventSeq   *int64
+	NaturalKey string
+}
+
+// readChunkMeta returns the chunk's sidecar row, or found=false when it has none.
+func (d *Document) readChunkMeta(ctx context.Context, key sqlmem.ScopeKey, chunkID string) (row chunkMetaRow, found bool, err error) {
+	res, err := d.query(ctx, key,
+		`SELECT valid_at, invalid_at, created_at, expired_at, class, origin, confidence, session_id, run_id, event_seq, natural_key
+		   FROM chunk_memory_meta WHERE chunk_id = ?`, chunkID)
+	if err != nil || len(res.Rows) == 0 {
+		return chunkMetaRow{}, false, err
+	}
+	r := res.Rows[0]
+	return chunkMetaRow{
+		ValidAt: asInt64Ptr(r[0]), InvalidAt: asInt64Ptr(r[1]),
+		CreatedAt: asInt64Ptr(r[2]), ExpiredAt: asInt64Ptr(r[3]),
+		Class: asStr(r[4]), Origin: asStr(r[5]), Confidence: asFloat64Ptr(r[6]),
+		SessionID: asStr(r[7]), RunID: asStr(r[8]), EventSeq: asInt64Ptr(r[9]),
+		NaturalKey: asStr(r[10]),
+	}, true, nil
+}
+
+// writeChunkMeta upserts the sidecar row, PRESERVING every field the caller did not
+// supply.
+//
+// The preservation is the whole point and it was missing. `upsertChunk` already
+// takes care not to blank a title an upsert never mentioned — then called this,
+// which rebuilt the sidecar from defaults. So the two halves of one operation had
+// opposite semantics, and a re-observation of an existing fact silently:
+//
+//   - dropped `class: evidential` back to `derived`, defeating the retention
+//     exemption that keeps source-of-truth material from being aged out;
+//   - reset `created_at`, so "when did we first believe this" became "when did we
+//     last write it" — the bi-temporal record erased by re-observation;
+//   - cleared `invalid_at` and `expired_at`, UN-RETIRING a superseded fact. The
+//     stale row came back as current beside the one that replaced it, while the
+//     `supersedes` edge still said it had been replaced. Two contradictory facts,
+//     both live, in a store other agents read as ground truth.
+//
+// That last one is the failure supersede-not-delete exists to prevent, and a
+// consolidator upserts by natural key on EVERY pass — so corrections were
+// impermanent by construction.
+//
+// Reviving a retired fact must therefore be explicit: pass `invalid_at` yourself.
+// It is not something a routine re-observation should do as a side effect.
 //
 // Delete-then-insert rather than ON CONFLICT, matching the two existing upserts in
 // this file — one portable statement beats a per-dialect split.
 //
-// `origin` and the provenance triple are SERVER-STAMPED and deliberately not
+// `origin` and the provenance triple stay SERVER-STAMPED and deliberately not
 // readable from the input. A forgeable origin would let any agent label its own
 // writes as machine-distilled, and the column has to stay a trustworthy filter for
-// the ones that really are — the same rule the consolidation queue's origin
-// follows.
+// the ones that really are — the same rule the consolidation queue's origin follows.
 func (d *Document) writeChunkMeta(ctx context.Context, key sqlmem.ScopeKey, chunkID string, in docInput) error {
 	now := time.Now().UnixNano()
+	prev, hadPrev, err := d.readChunkMeta(ctx, key, chunkID)
+	if err != nil {
+		// Refuse rather than fall back to defaults. Falling back is exactly the bug
+		// above: a read fault would silently un-retire a fact and strip its class.
+		return err
+	}
+
+	// valid_at — caller, else what was already believed, else now.
 	validAt := now
+	if hadPrev && prev.ValidAt != nil {
+		validAt = *prev.ValidAt
+	}
 	if in.ValidAt != nil {
 		validAt = *in.ValidAt
 	}
-	var invalidAt any
+	// invalid_at — caller, else preserved. Preserving is what keeps a retirement
+	// retired across a re-observation.
+	invalidAt := int64Arg(prev.InvalidAt)
 	if in.InvalidAt != nil {
 		invalidAt = *in.InvalidAt
 	}
-	class := in.Class
+	// created_at / expired_at are SYSTEM time and never caller-settable: the first
+	// is when the store began believing this, the second when it stopped. Only a
+	// first write sets one and only supersede sets the other.
+	createdAt := now
+	if hadPrev && prev.CreatedAt != nil {
+		createdAt = *prev.CreatedAt
+	}
+	expiredAt := int64Arg(prev.ExpiredAt)
+
+	class := prev.Class
+	if in.Class != "" {
+		class = in.Class
+	}
 	if class == "" {
 		class = "derived"
 	}
-	var confidence any
+	confidence := float64Arg(prev.Confidence)
 	if in.Confidence != nil {
 		confidence = *in.Confidence
 	}
+	// The provenance triple is preserved when this write cannot supply it — an
+	// operator editing a fact an agent recorded should not erase which run recorded
+	// it. `origin` DOES re-stamp, because it describes whoever wrote the content
+	// that is there now.
+	runID := tools.RunID(ctx)
+	if runID == "" {
+		runID = prev.RunID
+	}
+	naturalKey := in.NaturalKey
+	if naturalKey == "" {
+		naturalKey = prev.NaturalKey
+	}
+
 	if err := d.exec(ctx, key, `DELETE FROM chunk_memory_meta WHERE chunk_id = ?`, chunkID); err != nil {
 		return err
 	}
 	return d.exec(ctx, key,
 		`INSERT INTO chunk_memory_meta
 		   (chunk_id, valid_at, invalid_at, created_at, expired_at, class, origin, confidence, session_id, run_id, event_seq, natural_key)
-		 VALUES (?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, NULL, ?)`,
-		chunkID, validAt, invalidAt, now, class,
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		chunkID, validAt, invalidAt, createdAt, expiredAt, class,
 		originForEntityWrite(ctx), confidence,
-		// session_id stays NULL: it is not on the run ctx, only the run id is. The
-		// column is kept because the consolidation path can fill it when it relays a
-		// drained pending row, and a column that is sometimes populated is more useful
-		// than one removed because one writer cannot fill it.
-		nil, nullIfEmpty(tools.RunID(ctx)), nullIfEmpty(in.NaturalKey))
+		// session_id has no writer yet: it is not on the run ctx, only the run id is.
+		// Preserved rather than nulled so the consolidation path — which CAN fill it
+		// when it relays a drained pending row — does not lose it to the next upsert.
+		nullIfEmpty(prev.SessionID), nullIfEmpty(runID), int64Arg(prev.EventSeq),
+		nullIfEmpty(naturalKey))
+}
+
+// int64Arg / float64Arg turn a nullable read back into a bind arg that round-trips
+// NULL as NULL. A plain zero would assert an instant (the unix epoch) or a
+// confidence of 0 where the column said "unknown".
+func int64Arg(v *int64) any {
+	if v == nil {
+		return nil
+	}
+	return *v
+}
+
+func float64Arg(v *float64) any {
+	if v == nil {
+		return nil
+	}
+	return *v
+}
+
+// asInt64Ptr / asFloat64Ptr read a nullable numeric cell as a pointer, so a NULL
+// survives the round trip. asInt64Ptr reuses asInt64's presence/value split (see
+// its comment: NULL and a real 0 are different claims here).
+func asInt64Ptr(v any) *int64 {
+	if n, ok := asInt64(v); ok {
+		return &n
+	}
+	return nil
+}
+
+func asFloat64Ptr(v any) *float64 {
+	switch t := v.(type) {
+	case nil:
+		return nil
+	case float64:
+		return &t
+	case float32:
+		f := float64(t)
+		return &f
+	case int64:
+		f := float64(t)
+		return &f
+	case int:
+		f := float64(t)
+		return &f
+	}
+	return nil
 }
 
 // originForEntityWrite decides the provenance label from the RUN, never the input.

--- a/internal/tools/builtin/document_entity_preserve_test.go
+++ b/internal/tools/builtin/document_entity_preserve_test.go
@@ -1,0 +1,271 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// The regression suite for the sidecar-preservation bug, found by driving the
+// shipped ops against a live deployment rather than by any test here.
+//
+// One mechanism, three failures. writeChunkMeta rebuilt the sidecar row from
+// defaults on every upsert, so a re-observation of an existing fact silently
+// discarded whatever it was not handed — while the chunk half of the SAME operation
+// carefully preserved a title the caller never mentioned. Two halves, opposite
+// semantics.
+//
+// A consolidator upserts by natural key on every pass, so none of this needed an
+// unusual caller: re-observation is the normal case.
+
+// TestUpsert_ReObservationKeepsAFactRetired is the severe one.
+//
+// A superseded fact came back as CURRENT beside the fact that replaced it, while the
+// `supersedes` edge still recorded that it had been replaced. Two contradictory facts
+// live at once in a store other agents read as ground truth — the exact failure
+// supersede-not-delete exists to prevent, reachable by simply seeing the old fact
+// again.
+func TestUpsert_ReObservationKeepsAFactRetired(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	docID := newEntityDoc(t, d, ctx)
+
+	stale := upsert(t, d, ctx, docID, "office", "office location", "The office is in Berlin.", "")
+	fresh := upsert(t, d, ctx, docID, "office-v2", "office location (corrected)", "The office moved to Hamburg.", "")
+	supersede(t, d, ctx, fresh, stale)
+
+	before := metaOf(t, d, ctx, stale)
+	if before.InvalidAt == nil || before.ExpiredAt == nil {
+		t.Fatalf("fixture: supersede should have stamped both end-timestamps, got %+v", before)
+	}
+
+	// The re-observation: same natural key, a fresher wording, nothing else said.
+	upsert(t, d, ctx, docID, "office", "", "The office is in Berlin. (seen again)", "")
+
+	after := metaOf(t, d, ctx, stale)
+	if after.InvalidAt == nil {
+		t.Error("a re-observation un-retired the fact in world time (invalid_at cleared)")
+	}
+	if after.ExpiredAt == nil {
+		t.Error("a re-observation un-retired the fact in system time (expired_at cleared)")
+	}
+	if after.InvalidAt != nil && *after.InvalidAt != *before.InvalidAt {
+		t.Errorf("invalid_at moved: %d → %d", *before.InvalidAt, *after.InvalidAt)
+	}
+	if after.ExpiredAt != nil && *after.ExpiredAt != *before.ExpiredAt {
+		t.Errorf("expired_at moved: %d → %d", *before.ExpiredAt, *after.ExpiredAt)
+	}
+}
+
+// TestUpsert_ReObservationKeepsTheEvidentialClass: `evidential` is the retention
+// exemption that keeps source-of-truth material from being aged out. Silently
+// dropping it back to `derived` hands the prune the one thing it must never take —
+// and the prune is off by default, so nobody would notice until it was on.
+func TestUpsert_ReObservationKeepsTheEvidentialClass(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	docID := newEntityDoc(t, d, ctx)
+
+	id := upsert(t, d, ctx, docID, "evidence", "evidence", "Raw source material.", "evidential")
+	if got := metaOf(t, d, ctx, id).Class; got != "evidential" {
+		t.Fatalf("fixture: class = %q, want evidential", got)
+	}
+
+	upsert(t, d, ctx, docID, "evidence", "", "Raw source material, seen again.", "")
+
+	if got := metaOf(t, d, ctx, id).Class; got != "evidential" {
+		t.Errorf("a re-observation downgraded the class to %q — the retention exemption is lost", got)
+	}
+}
+
+// TestUpsert_ReObservationKeepsTheFirstBeliefTime: created_at is SYSTEM time — when
+// the store began believing the fact. Resetting it on every write turns it into
+// "when we last wrote this", which is what updated_at already is, and erases the
+// axis that makes the store bi-temporal at all.
+func TestUpsert_ReObservationKeepsTheFirstBeliefTime(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	docID := newEntityDoc(t, d, ctx)
+
+	id := upsert(t, d, ctx, docID, "rotation", "rotation", "Weekly, on Mondays.", "")
+	first := metaOf(t, d, ctx, id)
+	if first.CreatedAt == nil || first.ValidAt == nil {
+		t.Fatalf("fixture: a fresh row should carry both start-timestamps, got %+v", first)
+	}
+
+	upsert(t, d, ctx, docID, "rotation", "", "Weekly, on Mondays at 10:00 UTC.", "")
+
+	after := metaOf(t, d, ctx, id)
+	if after.CreatedAt == nil || *after.CreatedAt != *first.CreatedAt {
+		t.Errorf("created_at moved on re-observation: %d → %d", *first.CreatedAt, deref(after.CreatedAt))
+	}
+	// valid_at is WORLD time: when the fact was true. Seeing it again is not new
+	// information about when it became true.
+	if after.ValidAt == nil || *after.ValidAt != *first.ValidAt {
+		t.Errorf("valid_at moved on re-observation: %d → %d", *first.ValidAt, deref(after.ValidAt))
+	}
+}
+
+// TestUpsert_ExplicitFieldsStillWin: preservation must not become immutability. The
+// caller remains able to correct any of these — including reviving a retired fact,
+// which is now something you have to ask for rather than something a routine write
+// does behind your back.
+func TestUpsert_ExplicitFieldsStillWin(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	docID := newEntityDoc(t, d, ctx)
+
+	id := upsert(t, d, ctx, docID, "thing", "thing", "A fact.", "evidential")
+
+	// Correct the class, the world-time validity and the confidence in one write.
+	validAt := int64(1_700_000_000_000_000_000)
+	conf := 0.42
+	res, err := d.Execute(ctx, entityJSON(map[string]any{
+		"op": "upsert_chunk", "scope": "user", "document_id": docID,
+		"natural_key": "thing", "class": "derived",
+		"valid_at": validAt, "confidence": conf,
+	}))
+	if err != nil || res.IsError {
+		t.Fatalf("upsert: %v %s", err, res.Text)
+	}
+	got := metaOf(t, d, ctx, id)
+	if got.Class != "derived" {
+		t.Errorf("an explicit class must win: %q", got.Class)
+	}
+	if got.ValidAt == nil || *got.ValidAt != validAt {
+		t.Errorf("an explicit valid_at must win: %d", deref(got.ValidAt))
+	}
+	if got.Confidence == nil || *got.Confidence != conf {
+		t.Errorf("an explicit confidence must win: %v", got.Confidence)
+	}
+
+	// And an explicit revival: clearing a retirement is allowed, just not implicit.
+	other := upsert(t, d, ctx, docID, "other", "other", "Replacement.", "")
+	supersede(t, d, ctx, other, id)
+	if metaOf(t, d, ctx, id).InvalidAt == nil {
+		t.Fatal("fixture: supersede did not retire")
+	}
+	res, err = d.Execute(ctx, entityJSON(map[string]any{
+		"op": "upsert_chunk", "scope": "user", "document_id": docID,
+		"natural_key": "thing", "invalid_at": 0,
+	}))
+	if err != nil || res.IsError {
+		t.Fatalf("revive: %v %s", err, res.Text)
+	}
+	if iv := metaOf(t, d, ctx, id).InvalidAt; iv == nil || *iv != 0 {
+		t.Errorf("an explicit invalid_at must win, got %d", deref(iv))
+	}
+}
+
+// TestUpsert_CreateIsUnchanged pins the create path: preservation reads a row that
+// does not exist yet, so a first write must still land today's defaults rather than
+// inheriting anything or refusing.
+func TestUpsert_CreateIsUnchanged(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	docID := newEntityDoc(t, d, ctx)
+
+	id := upsert(t, d, ctx, docID, "fresh", "fresh", "First sighting.", "")
+	got := metaOf(t, d, ctx, id)
+	if got.Class != "derived" {
+		t.Errorf("a fresh row defaults to derived, got %q", got.Class)
+	}
+	if got.ValidAt == nil || got.CreatedAt == nil {
+		t.Errorf("a fresh row stamps both start-timestamps, got %+v", got)
+	}
+	if got.InvalidAt != nil || got.ExpiredAt != nil {
+		t.Errorf("a fresh row is not retired, got invalid_at=%d expired_at=%d",
+			deref(got.InvalidAt), deref(got.ExpiredAt))
+	}
+	if got.NaturalKey != "fresh" {
+		t.Errorf("natural_key = %q", got.NaturalKey)
+	}
+}
+
+// ---- helpers ----
+
+func newEntityDoc(t *testing.T, d *Document, ctx context.Context) string {
+	t.Helper()
+	res, err := d.Execute(ctx, entityJSON(map[string]any{
+		"op": "create_document", "scope": "user", "title": "entities", "path": "/t/entities",
+	}))
+	if err != nil || res.IsError {
+		t.Fatalf("create_document: %v %s", err, res.Text)
+	}
+	var out struct {
+		DocumentID string `json:"document_id"`
+	}
+	if err := json.Unmarshal([]byte(res.Text), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return out.DocumentID
+}
+
+// upsert returns the chunk id. A blank title is omitted entirely, which is how a
+// re-observation that only carries a body reaches the tool.
+func upsert(t *testing.T, d *Document, ctx context.Context, docID, key, title, body, class string) string {
+	t.Helper()
+	in := map[string]any{
+		"op": "upsert_chunk", "scope": "user", "document_id": docID,
+		"natural_key": key, "body": body,
+	}
+	if title != "" {
+		in["title"] = title
+	}
+	if class != "" {
+		in["class"] = class
+	}
+	res, err := d.Execute(ctx, entityJSON(in))
+	if err != nil || res.IsError {
+		t.Fatalf("upsert_chunk %q: %v %s", key, err, res.Text)
+	}
+	var out struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(res.Text), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return out.ID
+}
+
+func supersede(t *testing.T, d *Document, ctx context.Context, newID, oldID string) {
+	t.Helper()
+	res, err := d.Execute(ctx, entityJSON(map[string]any{
+		"op": "supersede_chunk", "scope": "user", "id": newID, "supersedes_id": oldID,
+	}))
+	if err != nil || res.IsError {
+		t.Fatalf("supersede_chunk: %v %s", err, res.Text)
+	}
+}
+
+// metaOf reads the sidecar THROUGH the tool's own reader, so the test cannot pass
+// against a shape the tool does not actually produce.
+func metaOf(t *testing.T, d *Document, ctx context.Context, chunkID string) chunkMetaRow {
+	t.Helper()
+	key, _, err := d.resolveScope(ctx, "user")
+	if err != nil {
+		t.Fatalf("resolveScope: %v", err)
+	}
+	row, found, err := d.readChunkMeta(ctx, key, chunkID)
+	if err != nil {
+		t.Fatalf("readChunkMeta: %v", err)
+	}
+	if !found {
+		t.Fatalf("no sidecar row for chunk %s", chunkID)
+	}
+	return row
+}
+
+// entityJSON marshals a tool input. Named for this file: the package already has a
+// mustJSON with a different signature.
+func entityJSON(v map[string]any) []byte {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+// deref prints a nullable timestamp as a number (-1 for NULL). A %v on the pointer
+// prints its ADDRESS, which is what the first run of these tests reported.
+func deref(v *int64) int64 {
+	if v == nil {
+		return -1
+	}
+	return *v
+}


### PR DESCRIPTION
## Why

A re-observation of an existing fact silently discarded every sidecar field the caller didn't restate. **Found by driving the shipped ops against the live v1.42.0 deployment**, not by any test in the repo.

One mechanism, three failures, worst first.

**1. It un-retired superseded facts.** Measured on the deployment:

```
upsert  test:res:stale   → "The office is in Berlin."
upsert  test:res:current → "The office moved to Hamburg."
supersede current over stale → stale: invalid_at=…860, expired_at=…860   ✅
upsert  test:res:stale (re-observed, no other args)
                         → stale: invalid_at=NULL, expired_at=NULL       ✗

graph_recall "office location":
  "office location"             retired:false
  "office location (corrected)" retired:false   ← both current
```

Two contradictory facts live at once in a store other agents read as ground truth — while the `supersedes` edge still recorded that one had replaced the other. Internally contradictory, and the exact failure supersede-not-delete exists to prevent.

**2. It dropped `class: evidential` back to `derived`**, defeating the retention exemption whose entire job is keeping source-of-truth material from being aged out. The prune is off by default, so nobody would have noticed until it was on — and then it would have taken the one thing it must never take.

**3. It reset `created_at`**, so "when did the store first believe this" became "when did it last write this" — which `updated_at` already answers. The axis that makes the store bi-temporal, erased by re-observation. `valid_at` moved too, so world-time validity shifted because a fact was seen again.

**A consolidator upserts by natural key on every pass**, so none of this needed an unusual caller. Re-observation is the normal case, which means corrections were impermanent by construction.

## What

The cause is that the two halves of one operation had **opposite semantics**. `upsertChunk` already takes care not to blank a title an upsert never mentioned — that guard is three lines above the call — and then handed the sidecar to a function that rebuilt it from defaults:

```go
// before: every unspecified field became a default
validAt := now; if in.ValidAt != nil { validAt = *in.ValidAt }
class := in.Class; if class == "" { class = "derived" }
INSERT … created_at=now, expired_at=NULL, invalid_at=<caller-or-NULL>
```

`writeChunkMeta` now reads the existing row and preserves anything the caller didn't supply. Specifics worth reviewing:

- **`created_at` / `expired_at` are never caller-settable.** They're *system* time — only a first write sets one, only `supersede` sets the other.
- **The provenance triple is preserved** when a write can't supply it, so an operator editing a fact an agent recorded doesn't erase which run recorded it. **`origin` still re-stamps**, because it describes whoever wrote the content that's there now.
- **Reviving a retired fact stays possible and becomes explicit** — pass `invalid_at` yourself. It shouldn't be something a routine write does behind your back. Pinned by a test.
- **A read fault refuses** rather than falling back to defaults. Falling back *is* the bug: it would silently un-retire a fact and strip its class.
- **The create path is unchanged** (no existing row → today's defaults), pinned by a test, since that's the path every existing fixture exercises.

## Tested

5 tests in `internal/tools/builtin/document_entity_preserve_test.go`. **Fail-before verified** — with the preservation removed, all three failures reproduce exactly as measured live:

```
a re-observation un-retired the fact in world time (invalid_at cleared)
a re-observation un-retired the fact in system time (expired_at cleared)
a re-observation downgraded the class to "derived" — the retention exemption is lost
created_at moved on re-observation: 1785… → 1785…
valid_at moved on re-observation:  1785… → 1785…
```

Added `TestUpsert_ReObservation` to CI's postgres `-run` filter — a test missing from it never runs on that tier. `gofmt` clean, full `go test ./...` green, both CI postgres steps reproduced locally.

## My miss, named

I hit this exact behaviour during P4d. My notes from then read *"upsert resurrects a retired chunk (writeChunkMeta is delete-then-insert)"* — and I fixed the **test fixture** around it instead of the behaviour, because the test was about pruning and I read the resurrection as a fixture artifact. It was the bug, one release earlier.

## Deploy note

`LOOMCYCLE_RETENTION_MEM_CONTENT_MODE=prune` with `DRY_RUN=1` is currently the only thing standing between failure 2 and real data loss on the reference deployment. Worth keeping dry-run until this lands.

Any fact whose `class` was already downgraded stays downgraded — this fixes the write path, it can't recover a marker that was overwritten. Re-upsert with `class: evidential` to restore one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)