### PR TITLE
fix(dev-exec): return per-command output in final_text (v1.42.1)

### DIFF
--- a/REVISIONS.md
+++ b/REVISIONS.md
@@ -4,6 +4,12 @@ Per-version release notes from v0.4.0 onward. The current and immediately previo
 
 For the **public roadmap** (planned v0.8.16 through v1.0 work — Question tool, Pause / Resume / Snapshot, distribution, operator postures), see [`docs/PLAN.md`](docs/PLAN.md).
 
+## What's in v1.42.1
+
+**🖨️ `dev/exec` returned only a summary, so a delegating caller couldn't see what a command actually printed.** The code-js provider surfaces ONLY a run's `final_text`, and `dev/exec`'s `final_text` was the one-line summary ("ran N command(s): X ok, Y failed") — the per-command outputs sat in the `results` array, which a blocking `spawn_run` / `Agent`-spawn never hands back. So the whole "caller reads the results, decides the fix, re-sends" model was broken: the caller got "1 failed" with no error text to act on. Found while verifying v1.42.0 against the live server — the run itself was correct (deterministic, zero-token, every command ran), but the outputs never reached the caller. `final_text` now renders each command with its **output, tail-capped** (a failure's message is at the end, so the tail is the part worth keeping; default 4000 chars, override per-run with `output_cap`), plus any `read` artifacts and browser results — so a blocking caller sees exactly what ran and why anything failed. An execution test asserts the output actually appears in `final_text` and that an over-cap output is tail-truncated with a marker. **Streaming consumers were already fine** — the `/run` terminal, SSE, and gRPC see each command as a live `tool_result` event as it happens; this only fixes the blocking/delegated path.
+
+No migration, no schema/wire change; adapters unchanged. It is a code-js-body + test change embedded in the loomcycle binary, so rebuild/redeploy the loomcycle image to pick it up.
+
 ## What's in v1.42.0
 
 **🧠 The entity tier — bi-temporal facts, a graph-expanded recall, and a tenant vocabulary the operator turns on. Plus a reaper for what supersession leaves behind.** Completes the memory roadmap's fourth phase (RFC BL P4c + P4d). One main-store migration (**0064**, a data repair — see the last paragraph), additive per-scope DDL, additive Document ops on every transport.

--- a/bundles/dev-exec/loomcycle.yaml
+++ b/bundles/dev-exec/loomcycle.yaml
@@ -49,6 +49,7 @@ agents:
       //   files       array   [{path, content, encoding?}] written before commands
       //   commands    array   ordered shell commands; stop at first failure unless continue_on_error
       //   continue_on_error bool  run every command even after a failure (default false)
+      //   output_cap  number  per-command/artifact tail-cap in final_text (default 4000)
       //   timeout_seconds, max_output_bytes  numbers  per-exec bounds (clamped)
       //   read        array   artifacts to read back: "path" or {path, encoding?}
       //   keep_open   bool    do not close the session (leave it for follow-ups)
@@ -57,7 +58,8 @@ agents:
       //                       (op: navigate|get_text|snapshot|screenshot|click|type|press|wait)
       //
       // Returns { final_text, ok, session_id, kept_open, files_written, results,
-      //           artifacts, browser }.
+      //           artifacts, browser }. final_text carries the per-command OUTPUT
+      //           (tail-capped), because a blocking caller only ever sees final_text.
 
       function run(input) {
         var env = parseEnvelope(input);
@@ -111,8 +113,12 @@ agents:
           try { mcp__sandbox__sandbox_close({ session_id: sid }); closed = true; } catch (e) {}
         }
 
+        // final_text carries each command's OUTPUT (tail-capped), not just a summary:
+        // a blocking spawn_run / Agent-delegation surfaces ONLY final_text, so the
+        // caller must be able to read what a command printed and why it failed.
+        var cap = (typeof env.output_cap === "number" && env.output_cap > 0) ? env.output_cap : 4000;
         return {
-          final_text: summarize(results, browser, sid, failed, !closed),
+          final_text: report(results, artifacts, browser, sid, failed, !closed, cap),
           ok: !failed, session_id: sid, kept_open: !closed,
           files_written: wrote, results: results, artifacts: artifacts, browser: browser
         };
@@ -178,21 +184,50 @@ agents:
         return m;
       }
 
-      function summarize(results, browser, sid, failed, kept) {
+      // report renders the full result INTO final_text: a summary header, then each
+      // command with its OUTPUT (tail-capped), then any read artifacts and browser
+      // results. The code-js provider surfaces ONLY final_text, so this is how a
+      // delegating caller sees what actually happened + why a step failed.
+      function report(results, artifacts, browser, sid, failed, kept, cap) {
         var ok = 0, bad = 0, skip = 0;
         for (var i = 0; i < results.length; i++) {
           if (results[i].skipped) skip++; else if (results[i].ok) ok++; else bad++;
         }
-        var s = "ran " + results.length + " command(s): " + ok + " ok, " + bad + " failed";
-        if (skip) s += ", " + skip + " skipped";
-        if (browser && browser.length) s += "; " + browser.length + " browser step(s)";
-        s += "; session " + sid + (kept ? " (kept open)" : " (closed)");
-        if (failed) {
-          for (var j = 0; j < results.length; j++) {
-            if (results[j].ok === false) { s += " :: first failure: " + results[j].command; break; }
+        var lines = ["ran " + results.length + " command(s): " + ok + " ok, " + bad + " failed" +
+          (skip ? (", " + skip + " skipped") : "") +
+          "; session " + sid + (kept ? " (kept open)" : " (closed)")];
+        for (var j = 0; j < results.length; j++) {
+          var r = results[j];
+          var tag = r.skipped ? "SKIPPED" : (r.ok ? "ok" : "FAILED");
+          lines.push("");
+          lines.push("$ " + r.command + "   [" + tag + "]");
+          if (!r.skipped) lines.push(tailCap(r.output, cap));
+        }
+        for (var a = 0; artifacts && a < artifacts.length; a++) {
+          var art = artifacts[a];
+          lines.push("");
+          if (art.ok) {
+            lines.push("# read " + art.path + " (" + String(art.content || "").length + " bytes)");
+            lines.push(tailCap(art.content, cap));
+          } else {
+            lines.push("# read " + art.path + "   [FAILED] " + (art.error || ""));
           }
         }
-        return s;
+        for (var b = 0; browser && b < browser.length; b++) {
+          var bs = browser[b];
+          lines.push("");
+          lines.push("[browser " + bs.op + "]   [" + (bs.ok ? "ok" : "FAILED") + "] " + (bs.ok ? "" : (bs.error || "")));
+          if (bs.ok && bs.result) lines.push(tailCap(bs.result, cap));
+        }
+        return lines.join("\n");
+      }
+
+      // tailCap keeps the LAST n chars of s (a failure's message is at the end),
+      // prefixed with a note when it clipped.
+      function tailCap(s, n) {
+        s = (s === undefined || s === null) ? "" : String(s);
+        if (s.length <= n) return s;
+        return "…[truncated: showing last " + n + " of " + s.length + " chars]\n" + s.substring(s.length - n);
       }
 
       function asText(x) {

--- a/bundles/sandbox/loomcycle.yaml
+++ b/bundles/sandbox/loomcycle.yaml
@@ -52,9 +52,11 @@ skills:
           "close": false                       // force-close a reused session
         }
       Commands run in order and STOP at the first failure unless continue_on_error.
-      The result carries { ok, session_id, results:[{command, ok, output}], artifacts }.
-      Authenticated git "just works" when the operator configured a `sandbox_github`
-      credential (dev/exec runs `gh auth setup-git` at open).
+      dev/exec's reply is a summary header ("ran N command(s): X ok, Y failed …") plus
+      each command's OUTPUT (tail-capped; set `output_cap` to change the cap) and any
+      `read` artifacts — read it to see what ran and why anything failed, and to get
+      the `session_id` to reuse. Authenticated git "just works" when the operator
+      configured a `sandbox_github` credential (dev/exec runs `gh auth setup-git` at open).
 
       ## One-shot
         Agent {op:"spawn", name:"dev/exec",

--- a/cmd/loomcycle/embedded/bundles/dev-exec.yaml
+++ b/cmd/loomcycle/embedded/bundles/dev-exec.yaml
@@ -49,6 +49,7 @@ agents:
       //   files       array   [{path, content, encoding?}] written before commands
       //   commands    array   ordered shell commands; stop at first failure unless continue_on_error
       //   continue_on_error bool  run every command even after a failure (default false)
+      //   output_cap  number  per-command/artifact tail-cap in final_text (default 4000)
       //   timeout_seconds, max_output_bytes  numbers  per-exec bounds (clamped)
       //   read        array   artifacts to read back: "path" or {path, encoding?}
       //   keep_open   bool    do not close the session (leave it for follow-ups)
@@ -57,7 +58,8 @@ agents:
       //                       (op: navigate|get_text|snapshot|screenshot|click|type|press|wait)
       //
       // Returns { final_text, ok, session_id, kept_open, files_written, results,
-      //           artifacts, browser }.
+      //           artifacts, browser }. final_text carries the per-command OUTPUT
+      //           (tail-capped), because a blocking caller only ever sees final_text.
 
       function run(input) {
         var env = parseEnvelope(input);
@@ -111,8 +113,12 @@ agents:
           try { mcp__sandbox__sandbox_close({ session_id: sid }); closed = true; } catch (e) {}
         }
 
+        // final_text carries each command's OUTPUT (tail-capped), not just a summary:
+        // a blocking spawn_run / Agent-delegation surfaces ONLY final_text, so the
+        // caller must be able to read what a command printed and why it failed.
+        var cap = (typeof env.output_cap === "number" && env.output_cap > 0) ? env.output_cap : 4000;
         return {
-          final_text: summarize(results, browser, sid, failed, !closed),
+          final_text: report(results, artifacts, browser, sid, failed, !closed, cap),
           ok: !failed, session_id: sid, kept_open: !closed,
           files_written: wrote, results: results, artifacts: artifacts, browser: browser
         };
@@ -178,21 +184,50 @@ agents:
         return m;
       }
 
-      function summarize(results, browser, sid, failed, kept) {
+      // report renders the full result INTO final_text: a summary header, then each
+      // command with its OUTPUT (tail-capped), then any read artifacts and browser
+      // results. The code-js provider surfaces ONLY final_text, so this is how a
+      // delegating caller sees what actually happened + why a step failed.
+      function report(results, artifacts, browser, sid, failed, kept, cap) {
         var ok = 0, bad = 0, skip = 0;
         for (var i = 0; i < results.length; i++) {
           if (results[i].skipped) skip++; else if (results[i].ok) ok++; else bad++;
         }
-        var s = "ran " + results.length + " command(s): " + ok + " ok, " + bad + " failed";
-        if (skip) s += ", " + skip + " skipped";
-        if (browser && browser.length) s += "; " + browser.length + " browser step(s)";
-        s += "; session " + sid + (kept ? " (kept open)" : " (closed)");
-        if (failed) {
-          for (var j = 0; j < results.length; j++) {
-            if (results[j].ok === false) { s += " :: first failure: " + results[j].command; break; }
+        var lines = ["ran " + results.length + " command(s): " + ok + " ok, " + bad + " failed" +
+          (skip ? (", " + skip + " skipped") : "") +
+          "; session " + sid + (kept ? " (kept open)" : " (closed)")];
+        for (var j = 0; j < results.length; j++) {
+          var r = results[j];
+          var tag = r.skipped ? "SKIPPED" : (r.ok ? "ok" : "FAILED");
+          lines.push("");
+          lines.push("$ " + r.command + "   [" + tag + "]");
+          if (!r.skipped) lines.push(tailCap(r.output, cap));
+        }
+        for (var a = 0; artifacts && a < artifacts.length; a++) {
+          var art = artifacts[a];
+          lines.push("");
+          if (art.ok) {
+            lines.push("# read " + art.path + " (" + String(art.content || "").length + " bytes)");
+            lines.push(tailCap(art.content, cap));
+          } else {
+            lines.push("# read " + art.path + "   [FAILED] " + (art.error || ""));
           }
         }
-        return s;
+        for (var b = 0; browser && b < browser.length; b++) {
+          var bs = browser[b];
+          lines.push("");
+          lines.push("[browser " + bs.op + "]   [" + (bs.ok ? "ok" : "FAILED") + "] " + (bs.ok ? "" : (bs.error || "")));
+          if (bs.ok && bs.result) lines.push(tailCap(bs.result, cap));
+        }
+        return lines.join("\n");
+      }
+
+      // tailCap keeps the LAST n chars of s (a failure's message is at the end),
+      // prefixed with a note when it clipped.
+      function tailCap(s, n) {
+        s = (s === undefined || s === null) ? "" : String(s);
+        if (s.length <= n) return s;
+        return "…[truncated: showing last " + n + " of " + s.length + " chars]\n" + s.substring(s.length - n);
       }
 
       function asText(x) {

--- a/cmd/loomcycle/embedded/bundles/sandbox.yaml
+++ b/cmd/loomcycle/embedded/bundles/sandbox.yaml
@@ -52,9 +52,11 @@ skills:
           "close": false                       // force-close a reused session
         }
       Commands run in order and STOP at the first failure unless continue_on_error.
-      The result carries { ok, session_id, results:[{command, ok, output}], artifacts }.
-      Authenticated git "just works" when the operator configured a `sandbox_github`
-      credential (dev/exec runs `gh auth setup-git` at open).
+      dev/exec's reply is a summary header ("ran N command(s): X ok, Y failed …") plus
+      each command's OUTPUT (tail-capped; set `output_cap` to change the cap) and any
+      `read` artifacts — read it to see what ran and why anything failed, and to get
+      the `session_id` to reuse. Authenticated git "just works" when the operator
+      configured a `sandbox_github` credential (dev/exec runs `gh auth setup-git` at open).
 
       ## One-shot
         Agent {op:"spawn", name:"dev/exec",

--- a/cmd/loomcycle/presets_devexec_codejs_test.go
+++ b/cmd/loomcycle/presets_devexec_codejs_test.go
@@ -24,11 +24,14 @@ import (
 type fakeSandbox struct {
 	calls   []recordedCall
 	openN   int
-	openNet []string        // network arg of each sandbox_open
-	execErr map[string]bool // commands whose exec should return IsError
+	openNet []string          // network arg of each sandbox_open
+	execErr map[string]bool   // commands whose exec should return IsError
+	execOut map[string]string // commands whose exec returns a scripted output
 }
 
-func newFakeSandbox() *fakeSandbox { return &fakeSandbox{execErr: map[string]bool{}} }
+func newFakeSandbox() *fakeSandbox {
+	return &fakeSandbox{execErr: map[string]bool{}, execOut: map[string]string{}}
+}
 
 func (s *fakeSandbox) execs() []string {
 	var out []string
@@ -76,6 +79,9 @@ func (t *sbxTool) Execute(_ context.Context, raw json.RawMessage) (tools.Result,
 		if t.s.execErr[cmd] {
 			// Mirror the real tool: a non-zero exit is IsError with the output.
 			return tools.Result{IsError: true, Text: "boom\n[exit: 1]"}, nil
+		}
+		if out, ok := t.s.execOut[cmd]; ok {
+			return tools.Result{Text: out}, nil // scripted output (e.g. a long one)
 		}
 		return tools.Result{Text: "ok: " + cmd}, nil // raw command output (not JSON)
 	case "mcp__sandbox__sandbox_write":
@@ -170,9 +176,15 @@ func TestDevExec_RunsEnvelopeOpenWriteExecReadClose(t *testing.T) {
 	if res.StopReason != "end_turn" {
 		t.Errorf("stop reason = %q, want end_turn", res.StopReason)
 	}
-	// The structured result reports both commands succeeded.
+	// final_text reports the counts AND carries each command's OUTPUT (v1.42.1) — a
+	// blocking caller only ever sees final_text, so the outputs must be in it.
 	if !strings.Contains(res.FinalText, "2 ok, 0 failed") {
 		t.Errorf("final_text = %q, want it to report 2 ok / 0 failed", res.FinalText)
+	}
+	for _, want := range []string{"ok: echo hi", "ok: go build ./...", "file-contents"} {
+		if !strings.Contains(res.FinalText, want) {
+			t.Errorf("final_text must include the command/artifact output %q; got:\n%s", want, res.FinalText)
+		}
 	}
 }
 
@@ -195,8 +207,13 @@ func TestDevExec_StopsAtFirstFailingCommand(t *testing.T) {
 	if !s.hasTool("mcp__sandbox__sandbox_close") {
 		t.Errorf("the session must still close after a failing command")
 	}
-	if !strings.Contains(res.FinalText, "1 failed") || !strings.Contains(res.FinalText, "first failure: boom") {
-		t.Errorf("final_text = %q, want it to report the failure + which command", res.FinalText)
+	if !strings.Contains(res.FinalText, "1 failed") {
+		t.Errorf("final_text = %q, want it to report the failure count", res.FinalText)
+	}
+	// The failing command's block must carry its OUTPUT (+ a FAILED tag) so the
+	// caller can diagnose — "[exit: 1]" appears only in the command output.
+	if !strings.Contains(res.FinalText, "[exit: 1]") || !strings.Contains(res.FinalText, "[FAILED]") {
+		t.Errorf("final_text must include the failed command's output + a FAILED tag; got:\n%s", res.FinalText)
 	}
 }
 
@@ -236,6 +253,24 @@ func TestDevExec_EmptyEnvelopeDoesNothing(t *testing.T) {
 	}
 	if !strings.Contains(res.FinalText, "nothing to do") {
 		t.Errorf("final_text = %q, want a usage/nothing-to-do message", res.FinalText)
+	}
+}
+
+// TestDevExec_TailCapsLongOutput: a per-command output longer than output_cap is
+// truncated to its TAIL (a failure's message is at the end), with a marker.
+func TestDevExec_TailCapsLongOutput(t *testing.T) {
+	s := newFakeSandbox()
+	s.execOut["big"] = "UNIQUEHEAD" + strings.Repeat("x", 200) + "UNIQUETAIL"
+	res := runDevExec(t, s, `{"output_cap":20,"commands":["big"]}`)
+
+	if !strings.Contains(res.FinalText, "truncated") {
+		t.Errorf("expected a truncation marker; got:\n%s", res.FinalText)
+	}
+	if !strings.Contains(res.FinalText, "UNIQUETAIL") {
+		t.Errorf("tail-cap must keep the output TAIL; got:\n%s", res.FinalText)
+	}
+	if strings.Contains(res.FinalText, "UNIQUEHEAD") {
+		t.Errorf("tail-cap must drop the output HEAD; got:\n%s", res.FinalText)
 	}
 }
 


### PR DESCRIPTION
## Why

Verifying v1.42.0 on the live server surfaced a real gap: `dev/exec` ran deterministically and every command executed, but the caller only ever got the **summary** ("ran N command(s): X ok, Y failed"). loomcycle's code-js provider returns only a run's `final_text`, and `dev/exec`'s `final_text` was that summary — the per-command outputs sat in the `results` array, which a blocking `spawn_run` / `Agent`-spawn never hands back. So "read the results, decide the fix, re-send" — the whole point of the executor — was impossible: the caller couldn't see *what* a command printed or *why* it failed.

## What

- **`dev-exec` bundle** (embedded + source): `final_text` now renders each command with its **output, tail-capped** — a failure's message is at the end, so the tail is what's kept (default 4000 chars, override per-run with `output_cap`) — plus any `read` artifacts and browser results. `summarize()` → `report()` + `tailCap()`.
- **`sandbox` bundle**: the `dev/sandbox-usage` skill now describes the summary+outputs reply shape instead of a `results` array that never arrives.
- **Test**: `presets_devexec_codejs_test.go` (real loop, fake `mcp__sandbox__*`) now asserts the command/artifact output appears in `final_text`, the failed command's output + a `[FAILED]` tag are present, and an over-cap output is tail-truncated with a marker (`TestDevExec_TailCapsLongOutput`).

**Streaming consumers were already fine** — the `/run` terminal, SSE, and gRPC see each command as a live `tool_result` event; this only fixes the blocking/delegated path.

## Tested

`go test ./...` all pass; `go build ./...` + `gofmt` clean. Bundle source==embedded verified.

## Deploy

Code-js-body + test change embedded in the loomcycle binary — no wire/schema change, adapters unchanged. Rebuild/redeploy the loomcycle image (v1.42.1) to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD