### PR TITLE
feat(memory): the consolidator writes the entity graph

### DIFF
--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -175,7 +175,11 @@ agents:
     # calls them, and an unused grant is the capability an injected instruction
     # reaches for. `Path op=rm` in particular is a HARD delete inside an agent
     # whose central rule is that consolidation never destroys history.
-    tools: [Memory, History, Agent, Context]
+    # Document is here for the ENTITY half: the same facts written to k/v are also
+    # written as typed, linked chunks so a graph walk can reach them. It is added
+    # rather than swapped in — the k/v rows stay the recall path, and the entity
+    # graph is what k/v cannot express (relations between facts).
+    tools: [Memory, History, Agent, Context, Document]
     # Deny-all skills: the runtime auto-adds the Skill tool to every agent that
     # does not deny all skills, so dropping an allowlist alone leaves the tool in
     # place. A code agent has no use for it — it reads no prompt.
@@ -198,6 +202,12 @@ agents:
     # pointed at a differently-named agent would not exclude it at all.
     internal: true
     memory_scopes: [agent, user]  # user = the fan-out target; agent = its own bookkeeping
+    # NO sql_scopes, deliberately, even though the entity half writes chunk
+    # STRUCTURE into SQL Memory. The Document tool issues its own trusted SQL and
+    # checks `sql_scopes` only for TENANT scope — agent and user are ungated — so
+    # granting it here would buy nothing and hand an injected instruction the raw
+    # `Memory sql_exec` surface. The absence is what keeps the consolidator unable
+    # to write the tenant-shared store at all, whatever a transcript asks for.
     memory_consolidation: true    # the cursor / supersede / pending-queue control ops
     history_scope: [user]         # narrowest scope that can read the target user's chats
     # ⚠️ MUST STAY BELOW the LEASE_TTL_MS literal in the body below. A pass that
@@ -389,7 +399,13 @@ agents:
           merge_refused_subject: 0, // above the band, but about a different subject
           merge_refused_class: 0,   // above the band, but filed under another class
           supersede_queue: [],      // neighbour keys judged duplicates of a kept row
+          supersede_keeper: {},     // retired key -> the key that survived it (entity half)
           written_keys: {},         // never retire a row this pass just wrote
+          entities_doc: null,       // the /memory/entities document id, resolved once
+          entity_ids: {},           // natural_key -> chunk id, for this pass
+          entity_nodes: 0,          // distinct subjects given an entity chunk
+          entity_facts: 0,          // facts mirrored into the graph
+          entity_failed: 0,         // entity writes that failed (k/v still landed)
           watermark: null,          // the LAST scan row actually consolidated, by reference
           advanced: null,
           advance_blocked: false,
@@ -938,7 +954,13 @@ agents:
           // fired at all. The highest-scoring row is kept and rewritten; the rest
           // are queued, and retire() applies the pass-wide cap once. Superseding
           // them is what collapses the pile back to one canonical row.
-          for (var d = 1; d < dupes.length; d++) { st.supersede_queue.push(dupes[d].id); }
+          for (var d = 1; d < dupes.length; d++) {
+            st.supersede_queue.push(dupes[d].id);
+            // The entity half needs the SURVIVOR too: supersede_chunk records which
+            // chunk replaced which, so a retirement with no replacement cannot be
+            // expressed. dupes[0] is the row being kept and rewritten.
+            st.supersede_keeper[dupes[d].id] = dupes[0].id;
+          }
           if (!write(st, primary.id, fact, sourceID, pendingID)) { return false; }
           st.updated++;
           return true;
@@ -1072,7 +1094,153 @@ agents:
           return false;
         }
         st.written_keys[key] = true;
+        // The entity graph mirrors the fact AFTER the authoritative write lands, so
+        // a graph failure can never cost a fact.
+        mirrorEntity(st, key, fact);
         return true;
+      }
+
+      // ------------------------------------------------------- the entity half
+      //
+      // Every fact the extractor typed is ALSO written as a chunk graph: one node
+      // per distinct subject, one node per fact, an `about` edge between them. That
+      // shape is the point — a flat set of typed facts is just k/v with extra
+      // steps, and graph_recall would have nothing to walk. Facts about the same
+      // subject share an entity node, which is what makes "what else do we know
+      // about Denn" answerable from any one of them.
+      //
+      // BEST-EFFORT, ALWAYS. A failure here never fails the pass and never blocks
+      // the watermark: the k/v row is the authoritative memory and it has already
+      // landed by the time any of this runs. The graph is an index over facts, so
+      // a missing edge costs a retrieval path, not a fact. Failures are counted and
+      // reported rather than thrown.
+      //
+      // The natural key of a FACT chunk is the k/v key verbatim. One key space for
+      // both stores is what stops them drifting: the same merge decision that
+      // rewrites a k/v row in place updates its chunk in place, and there is no
+      // second dedupe mechanism to fall out of step with the first.
+
+      // entitiesDoc resolves (and on first use creates) the scope's canonical
+      // /memory/entities document. Provisioned here rather than server-side
+      // because nothing on the server has a reason to touch it — the consolidator
+      // is its only writer.
+      function entitiesDoc(st) {
+        if (st.entities_doc !== null) { return st.entities_doc; }
+        var path = "/memory/entities";
+        try {
+          var got = JSON.parse(Document({ op: "get_document", scope: CONFIG.scope, path: path }));
+          st.entities_doc = got.document_id || "";
+        } catch (e) {
+          try {
+            var made = JSON.parse(Document({
+              op: "create_document", scope: CONFIG.scope,
+              title: "Entities", path: path
+            }));
+            st.entities_doc = made.document_id || "";
+          } catch (e2) {
+            st.entities_doc = ""; // give up for this pass; k/v is unaffected
+          }
+        }
+        return st.entities_doc;
+      }
+
+      // entityKey is the natural key of a SUBJECT node: type plus a slug of the
+      // name. Two facts naming "Denn" and "denn " land on one node; two different
+      // people with the same name land on one node too, which is a known limit of
+      // name-as-identity and the reason the extractor is told not to guess.
+      function entityKey(type, subject) { return type + ":" + slug(subject); }
+
+      // upsertEntityChunk writes one chunk and returns its id, or "" on failure.
+      function upsertEntityChunk(st, docID, naturalKey, args) {
+        if (st.entity_ids[naturalKey]) { return st.entity_ids[naturalKey]; }
+        try {
+          args.op = "upsert_chunk";
+          args.scope = CONFIG.scope;
+          args.document_id = docID;
+          args.natural_key = naturalKey;
+          var res = JSON.parse(Document(args));
+          if (res && res.id) { st.entity_ids[naturalKey] = res.id; return res.id; }
+        } catch (e) {
+          st.entity_failed++;
+        }
+        return "";
+      }
+
+      // mirrorEntity writes the subject node, the fact node and the edge between
+      // them. Called after the k/v write has already succeeded.
+      function mirrorEntity(st, key, fact) {
+        if (!fact.type || !fact.subject) { return; } // untyped fact: k/v only (by design)
+        var docID = entitiesDoc(st);
+        if (!docID) { return; }
+
+        var subjKey = entityKey(fact.type, fact.subject);
+        var isNewSubject = !st.entity_ids[subjKey];
+        var subjID = upsertEntityChunk(st, docID, subjKey, {
+          title: fact.subject, type: fact.type
+        });
+        if (!subjID) { return; }
+        if (isNewSubject) { st.entity_nodes++; }
+
+        // The fact node carries the sentence; its title is the sentence too,
+        // trimmed, because a chunk with no title is unreadable in the Path browser.
+        var factID = upsertEntityChunk(st, docID, key, {
+          title: fact.text.length > 80 ? fact.text.slice(0, 77) + "..." : fact.text,
+          type: "fact", body: fact.text
+        });
+        if (!factID) { return; }
+        st.entity_facts++;
+
+        try {
+          Document({ op: "link_chunks", scope: CONFIG.scope,
+                     from_id: factID, to_id: subjID, kind: "about" });
+        } catch (e) {
+          st.entity_failed++; // the nodes exist; only the edge is missing
+        }
+      }
+
+      // retireEntity mirrors a k/v supersession onto the graph. supersede_chunk
+      // needs BOTH sides, so a retirement whose survivor is unknown is skipped
+      // rather than guessed — marking a fact retired with no replacement would
+      // assert that we stopped believing it for no recorded reason.
+      function retireEntity(st, retiredKey) {
+        var keeperKey = st.supersede_keeper[retiredKey];
+        if (!keeperKey) { return; }
+        var docID = entitiesDoc(st);
+        if (!docID) { return; }
+        var oldID = entityIDByKey(st, retiredKey), newID = entityIDByKey(st, keeperKey);
+        if (!oldID || !newID) { return; } // neither was ever mirrored — nothing to retire
+        try {
+          Document({ op: "supersede_chunk", scope: CONFIG.scope,
+                     id: newID, supersedes_id: oldID });
+        } catch (e) {
+          st.entity_failed++;
+        }
+      }
+
+      // entityIDByKey resolves a natural key to a chunk id, including one written
+      // by an EARLIER pass (this pass's cache only holds what it wrote itself).
+      //
+      // The key is interpolated rather than bound because query_chunks' sql escape
+      // hatch takes no parameters. That is safe HERE and only here: every natural
+      // key this file produces comes from slug() or entityKey(), whose output is
+      // [a-z0-9:-] by construction, so no quote can occur. Do not extend this to a
+      // key from anywhere else.
+      function entityIDByKey(st, naturalKey) {
+        if (st.entity_ids[naturalKey]) { return st.entity_ids[naturalKey]; }
+        if (!/^[a-z0-9:_/-]+$/.test(naturalKey)) { return ""; }
+        try {
+          var res = JSON.parse(Document({
+            op: "query_chunks", scope: CONFIG.scope,
+            sql: "SELECT chunk_id FROM chunk_memory_meta WHERE natural_key = '" + naturalKey + "'"
+          }));
+          if (res && res.rows && res.rows.length && res.rows[0].length) {
+            st.entity_ids[naturalKey] = String(res.rows[0][0]);
+            return st.entity_ids[naturalKey];
+          }
+        } catch (e) {
+          st.entity_failed++;
+        }
+        return "";
       }
 
       // retire applies the ONLY destructive-ish op in the pipeline, capped.
@@ -1093,6 +1261,7 @@ agents:
           try {
             Memory.supersede({ scope: CONFIG.scope, key: capped[j] });
             st.superseded++;
+            retireEntity(st, capped[j]);
           } catch (e) {
             block(st, "supersede failed for " + capped[j] + ": " + errText(e));
           }
@@ -1230,6 +1399,15 @@ agents:
         if (st.merge_refused_class > 0) {
           parts.push("merge refused on class " + st.merge_refused_class +
             " (a neighbour scored as a duplicate but is filed under a different class, or under a key this pass did not mint — written as a new row instead)");
+        }
+
+        // The entity half, reported even when zero: a pass that mirrored nothing
+        // because no fact was typed looks identical to one where every Document
+        // call failed, and those need different fixes.
+        if (st.entity_facts || st.entity_nodes || st.entity_failed) {
+          var ent = "entities " + st.entity_facts + " fact(s) across " + st.entity_nodes + " subject(s)";
+          if (st.entity_failed) { ent += ", " + st.entity_failed + " graph write(s) failed"; }
+          parts.push(ent);
         }
 
         if (st.advanced) {

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -175,7 +175,11 @@ agents:
     # calls them, and an unused grant is the capability an injected instruction
     # reaches for. `Path op=rm` in particular is a HARD delete inside an agent
     # whose central rule is that consolidation never destroys history.
-    tools: [Memory, History, Agent, Context]
+    # Document is here for the ENTITY half: the same facts written to k/v are also
+    # written as typed, linked chunks so a graph walk can reach them. It is added
+    # rather than swapped in — the k/v rows stay the recall path, and the entity
+    # graph is what k/v cannot express (relations between facts).
+    tools: [Memory, History, Agent, Context, Document]
     # Deny-all skills: the runtime auto-adds the Skill tool to every agent that
     # does not deny all skills, so dropping an allowlist alone leaves the tool in
     # place. A code agent has no use for it — it reads no prompt.
@@ -198,6 +202,12 @@ agents:
     # pointed at a differently-named agent would not exclude it at all.
     internal: true
     memory_scopes: [agent, user]  # user = the fan-out target; agent = its own bookkeeping
+    # NO sql_scopes, deliberately, even though the entity half writes chunk
+    # STRUCTURE into SQL Memory. The Document tool issues its own trusted SQL and
+    # checks `sql_scopes` only for TENANT scope — agent and user are ungated — so
+    # granting it here would buy nothing and hand an injected instruction the raw
+    # `Memory sql_exec` surface. The absence is what keeps the consolidator unable
+    # to write the tenant-shared store at all, whatever a transcript asks for.
     memory_consolidation: true    # the cursor / supersede / pending-queue control ops
     history_scope: [user]         # narrowest scope that can read the target user's chats
     # ⚠️ MUST STAY BELOW the LEASE_TTL_MS literal in the body below. A pass that
@@ -389,7 +399,13 @@ agents:
           merge_refused_subject: 0, // above the band, but about a different subject
           merge_refused_class: 0,   // above the band, but filed under another class
           supersede_queue: [],      // neighbour keys judged duplicates of a kept row
+          supersede_keeper: {},     // retired key -> the key that survived it (entity half)
           written_keys: {},         // never retire a row this pass just wrote
+          entities_doc: null,       // the /memory/entities document id, resolved once
+          entity_ids: {},           // natural_key -> chunk id, for this pass
+          entity_nodes: 0,          // distinct subjects given an entity chunk
+          entity_facts: 0,          // facts mirrored into the graph
+          entity_failed: 0,         // entity writes that failed (k/v still landed)
           watermark: null,          // the LAST scan row actually consolidated, by reference
           advanced: null,
           advance_blocked: false,
@@ -938,7 +954,13 @@ agents:
           // fired at all. The highest-scoring row is kept and rewritten; the rest
           // are queued, and retire() applies the pass-wide cap once. Superseding
           // them is what collapses the pile back to one canonical row.
-          for (var d = 1; d < dupes.length; d++) { st.supersede_queue.push(dupes[d].id); }
+          for (var d = 1; d < dupes.length; d++) {
+            st.supersede_queue.push(dupes[d].id);
+            // The entity half needs the SURVIVOR too: supersede_chunk records which
+            // chunk replaced which, so a retirement with no replacement cannot be
+            // expressed. dupes[0] is the row being kept and rewritten.
+            st.supersede_keeper[dupes[d].id] = dupes[0].id;
+          }
           if (!write(st, primary.id, fact, sourceID, pendingID)) { return false; }
           st.updated++;
           return true;
@@ -1072,7 +1094,153 @@ agents:
           return false;
         }
         st.written_keys[key] = true;
+        // The entity graph mirrors the fact AFTER the authoritative write lands, so
+        // a graph failure can never cost a fact.
+        mirrorEntity(st, key, fact);
         return true;
+      }
+
+      // ------------------------------------------------------- the entity half
+      //
+      // Every fact the extractor typed is ALSO written as a chunk graph: one node
+      // per distinct subject, one node per fact, an `about` edge between them. That
+      // shape is the point — a flat set of typed facts is just k/v with extra
+      // steps, and graph_recall would have nothing to walk. Facts about the same
+      // subject share an entity node, which is what makes "what else do we know
+      // about Denn" answerable from any one of them.
+      //
+      // BEST-EFFORT, ALWAYS. A failure here never fails the pass and never blocks
+      // the watermark: the k/v row is the authoritative memory and it has already
+      // landed by the time any of this runs. The graph is an index over facts, so
+      // a missing edge costs a retrieval path, not a fact. Failures are counted and
+      // reported rather than thrown.
+      //
+      // The natural key of a FACT chunk is the k/v key verbatim. One key space for
+      // both stores is what stops them drifting: the same merge decision that
+      // rewrites a k/v row in place updates its chunk in place, and there is no
+      // second dedupe mechanism to fall out of step with the first.
+
+      // entitiesDoc resolves (and on first use creates) the scope's canonical
+      // /memory/entities document. Provisioned here rather than server-side
+      // because nothing on the server has a reason to touch it — the consolidator
+      // is its only writer.
+      function entitiesDoc(st) {
+        if (st.entities_doc !== null) { return st.entities_doc; }
+        var path = "/memory/entities";
+        try {
+          var got = JSON.parse(Document({ op: "get_document", scope: CONFIG.scope, path: path }));
+          st.entities_doc = got.document_id || "";
+        } catch (e) {
+          try {
+            var made = JSON.parse(Document({
+              op: "create_document", scope: CONFIG.scope,
+              title: "Entities", path: path
+            }));
+            st.entities_doc = made.document_id || "";
+          } catch (e2) {
+            st.entities_doc = ""; // give up for this pass; k/v is unaffected
+          }
+        }
+        return st.entities_doc;
+      }
+
+      // entityKey is the natural key of a SUBJECT node: type plus a slug of the
+      // name. Two facts naming "Denn" and "denn " land on one node; two different
+      // people with the same name land on one node too, which is a known limit of
+      // name-as-identity and the reason the extractor is told not to guess.
+      function entityKey(type, subject) { return type + ":" + slug(subject); }
+
+      // upsertEntityChunk writes one chunk and returns its id, or "" on failure.
+      function upsertEntityChunk(st, docID, naturalKey, args) {
+        if (st.entity_ids[naturalKey]) { return st.entity_ids[naturalKey]; }
+        try {
+          args.op = "upsert_chunk";
+          args.scope = CONFIG.scope;
+          args.document_id = docID;
+          args.natural_key = naturalKey;
+          var res = JSON.parse(Document(args));
+          if (res && res.id) { st.entity_ids[naturalKey] = res.id; return res.id; }
+        } catch (e) {
+          st.entity_failed++;
+        }
+        return "";
+      }
+
+      // mirrorEntity writes the subject node, the fact node and the edge between
+      // them. Called after the k/v write has already succeeded.
+      function mirrorEntity(st, key, fact) {
+        if (!fact.type || !fact.subject) { return; } // untyped fact: k/v only (by design)
+        var docID = entitiesDoc(st);
+        if (!docID) { return; }
+
+        var subjKey = entityKey(fact.type, fact.subject);
+        var isNewSubject = !st.entity_ids[subjKey];
+        var subjID = upsertEntityChunk(st, docID, subjKey, {
+          title: fact.subject, type: fact.type
+        });
+        if (!subjID) { return; }
+        if (isNewSubject) { st.entity_nodes++; }
+
+        // The fact node carries the sentence; its title is the sentence too,
+        // trimmed, because a chunk with no title is unreadable in the Path browser.
+        var factID = upsertEntityChunk(st, docID, key, {
+          title: fact.text.length > 80 ? fact.text.slice(0, 77) + "..." : fact.text,
+          type: "fact", body: fact.text
+        });
+        if (!factID) { return; }
+        st.entity_facts++;
+
+        try {
+          Document({ op: "link_chunks", scope: CONFIG.scope,
+                     from_id: factID, to_id: subjID, kind: "about" });
+        } catch (e) {
+          st.entity_failed++; // the nodes exist; only the edge is missing
+        }
+      }
+
+      // retireEntity mirrors a k/v supersession onto the graph. supersede_chunk
+      // needs BOTH sides, so a retirement whose survivor is unknown is skipped
+      // rather than guessed — marking a fact retired with no replacement would
+      // assert that we stopped believing it for no recorded reason.
+      function retireEntity(st, retiredKey) {
+        var keeperKey = st.supersede_keeper[retiredKey];
+        if (!keeperKey) { return; }
+        var docID = entitiesDoc(st);
+        if (!docID) { return; }
+        var oldID = entityIDByKey(st, retiredKey), newID = entityIDByKey(st, keeperKey);
+        if (!oldID || !newID) { return; } // neither was ever mirrored — nothing to retire
+        try {
+          Document({ op: "supersede_chunk", scope: CONFIG.scope,
+                     id: newID, supersedes_id: oldID });
+        } catch (e) {
+          st.entity_failed++;
+        }
+      }
+
+      // entityIDByKey resolves a natural key to a chunk id, including one written
+      // by an EARLIER pass (this pass's cache only holds what it wrote itself).
+      //
+      // The key is interpolated rather than bound because query_chunks' sql escape
+      // hatch takes no parameters. That is safe HERE and only here: every natural
+      // key this file produces comes from slug() or entityKey(), whose output is
+      // [a-z0-9:-] by construction, so no quote can occur. Do not extend this to a
+      // key from anywhere else.
+      function entityIDByKey(st, naturalKey) {
+        if (st.entity_ids[naturalKey]) { return st.entity_ids[naturalKey]; }
+        if (!/^[a-z0-9:_/-]+$/.test(naturalKey)) { return ""; }
+        try {
+          var res = JSON.parse(Document({
+            op: "query_chunks", scope: CONFIG.scope,
+            sql: "SELECT chunk_id FROM chunk_memory_meta WHERE natural_key = '" + naturalKey + "'"
+          }));
+          if (res && res.rows && res.rows.length && res.rows[0].length) {
+            st.entity_ids[naturalKey] = String(res.rows[0][0]);
+            return st.entity_ids[naturalKey];
+          }
+        } catch (e) {
+          st.entity_failed++;
+        }
+        return "";
       }
 
       // retire applies the ONLY destructive-ish op in the pipeline, capped.
@@ -1093,6 +1261,7 @@ agents:
           try {
             Memory.supersede({ scope: CONFIG.scope, key: capped[j] });
             st.superseded++;
+            retireEntity(st, capped[j]);
           } catch (e) {
             block(st, "supersede failed for " + capped[j] + ": " + errText(e));
           }
@@ -1230,6 +1399,15 @@ agents:
         if (st.merge_refused_class > 0) {
           parts.push("merge refused on class " + st.merge_refused_class +
             " (a neighbour scored as a duplicate but is filed under a different class, or under a key this pass did not mint — written as a new row instead)");
+        }
+
+        // The entity half, reported even when zero: a pass that mirrored nothing
+        // because no fact was typed looks identical to one where every Document
+        // call failed, and those need different fixes.
+        if (st.entity_facts || st.entity_nodes || st.entity_failed) {
+          var ent = "entities " + st.entity_facts + " fact(s) across " + st.entity_nodes + " subject(s)";
+          if (st.entity_failed) { ent += ", " + st.entity_failed + " graph write(s) failed"; }
+          parts.push(ent);
         }
 
         if (st.advanced) {

--- a/cmd/loomcycle/presets_memory_codejs_test.go
+++ b/cmd/loomcycle/presets_memory_codejs_test.go
@@ -50,6 +50,14 @@ type recordedCall struct {
 type fakeToolset struct {
 	calls []recordedCall
 
+	// The entity half, filled by fakeDocument.
+	entitiesDocID    string
+	chunks           map[string]string // natural_key -> chunk id
+	chunkTypes       map[string]string // natural_key -> type
+	edges            []string          // "from-kind->to"
+	supersededChunks []string          // "old by new"
+	failEntityKeys   map[string]bool
+
 	leaseAcquired bool
 	sessions      []map[string]any
 	pending       []map[string]any
@@ -110,9 +118,12 @@ type fakeToolset struct {
 
 func newFakeToolset() *fakeToolset {
 	return &fakeToolset{
-		leaseAcquired: true,
-		bands:         map[string]any{"merge_threshold": 0.9, "related_threshold": 0.5},
-		failSetKeys:   map[string]bool{},
+		leaseAcquired:  true,
+		bands:          map[string]any{"merge_threshold": 0.9, "related_threshold": 0.5},
+		failSetKeys:    map[string]bool{},
+		chunks:         map[string]string{},
+		chunkTypes:     map[string]string{},
+		failEntityKeys: map[string]bool{},
 		// Source of truth for this format: formatSubAgentOutput in
 		// internal/api/http/resume.go. Nothing links them — grep that name.
 		subAgentHeader: "[sub-agent agent_id=a_test000000000000]\n",
@@ -195,6 +206,69 @@ func (m *fakeMemory) Execute(_ context.Context, raw json.RawMessage) (tools.Resu
 		return okResult(map[string]any{"ok": true})
 	}
 	return tools.Result{IsError: true, Text: fmt.Sprintf("unexpected Memory op %v", in["op"])}, nil
+}
+
+// --- Document (the entity half) ---------------------------------------------
+
+// fakeDocument is a minimal chunk store: enough to observe the graph the pass
+// builds — which natural keys became chunks, and which edges joined them —
+// without reimplementing the Document tool.
+type fakeDocument struct {
+	f *fakeToolset
+}
+
+func (d *fakeDocument) Name() string                 { return "Document" }
+func (d *fakeDocument) Description() string          { return "document (test double)" }
+func (d *fakeDocument) InputSchema() json.RawMessage { return json.RawMessage(`{"type":"object"}`) }
+
+func (d *fakeDocument) Execute(_ context.Context, raw json.RawMessage) (tools.Result, error) {
+	in := d.f.record("Document", raw)
+	switch in["op"] {
+	case "get_document":
+		if d.f.entitiesDocID == "" {
+			return tools.Result{IsError: true, Text: "get_document: no such path"}, nil
+		}
+		return okResult(map[string]any{"document_id": d.f.entitiesDocID})
+	case "create_document":
+		d.f.entitiesDocID = "doc-entities"
+		return okResult(map[string]any{"document_id": d.f.entitiesDocID, "root_chunk_id": "root"})
+	case "upsert_chunk":
+		key, _ := in["natural_key"].(string)
+		if d.f.failEntityKeys[key] {
+			return tools.Result{IsError: true, Text: "upsert_chunk: write failed for " + key}, nil
+		}
+		id, existed := d.f.chunks[key]
+		if !existed {
+			id = fmt.Sprintf("chunk-%d", len(d.f.chunks)+1)
+			d.f.chunks[key] = id
+		}
+		if typ, ok := in["type"].(string); ok && typ != "" {
+			d.f.chunkTypes[key] = typ
+		}
+		return okResult(map[string]any{"id": id, "natural_key": key, "created": !existed})
+	case "link_chunks":
+		from, _ := in["from_id"].(string)
+		to, _ := in["to_id"].(string)
+		kind, _ := in["kind"].(string)
+		d.f.edges = append(d.f.edges, from+"-"+kind+"->"+to)
+		return okResult(map[string]any{"ok": true})
+	case "supersede_chunk":
+		id, _ := in["id"].(string)
+		old, _ := in["supersedes_id"].(string)
+		d.f.supersededChunks = append(d.f.supersededChunks, old+" by "+id)
+		return okResult(map[string]any{"ok": true})
+	case "query_chunks":
+		// Only the natural-key point lookup is used; answer from the same map
+		// upsert_chunk fills so a cross-pass resolve is observable.
+		sql, _ := in["sql"].(string)
+		for key, id := range d.f.chunks {
+			if strings.Contains(sql, "'"+key+"'") {
+				return okResult(map[string]any{"columns": []string{"chunk_id"}, "rows": [][]any{{id}}})
+			}
+		}
+		return okResult(map[string]any{"columns": []string{"chunk_id"}, "rows": [][]any{}})
+	}
+	return tools.Result{IsError: true, Text: fmt.Sprintf("unexpected Document op %v", in["op"])}, nil
 }
 
 // --- History ----------------------------------------------------------------
@@ -324,7 +398,7 @@ func runConsolidator(t *testing.T, f *fakeToolset) loop.RunResult {
 		t.Fatalf("memory/consolidator not registered (agents: %v)", agentNames(cfg))
 	}
 
-	set := []tools.Tool{&fakeMemory{f: f}, &fakeHistory{f: f}, &fakeAgent{f: f}, &fakeContext{f: f}}
+	set := []tools.Tool{&fakeMemory{f: f}, &fakeHistory{f: f}, &fakeAgent{f: f}, &fakeContext{f: f}, &fakeDocument{f: f}}
 	prov := codejs.New(codejs.Config{CodeRoot: t.TempDir(), RunTimeout: 30 * time.Second})
 
 	res, err := loop.Run(context.Background(), loop.RunOptions{
@@ -811,7 +885,7 @@ func TestConsolidator_ReleasesTheLeaseWhenThePipelineThrows(t *testing.T) {
 	// the t.Fatal-on-error helper.
 	cfg := memoryBundleConfig(t)
 	agent := cfg.Agents["memory/consolidator"]
-	set := []tools.Tool{&fakeMemory{f: f}, &fakeHistory{f: f}, &fakeAgent{f: f}, &fakeContext{f: f}}
+	set := []tools.Tool{&fakeMemory{f: f}, &fakeHistory{f: f}, &fakeAgent{f: f}, &fakeContext{f: f}, &fakeDocument{f: f}}
 	prov := codejs.New(codejs.Config{CodeRoot: t.TempDir(), RunTimeout: 30 * time.Second})
 	_, err := loop.Run(context.Background(), loop.RunOptions{
 		Provider:   prov,
@@ -2534,5 +2608,111 @@ func TestConsolidator_CarriesTheEntityPairOrNeither(t *testing.T) {
 	}
 	if strings.Contains(res.FinalText, "malformed") && !strings.Contains(res.FinalText, "malformed entries dropped 0") {
 		t.Errorf("a fact without the entity pair is not malformed; got %q", res.FinalText)
+	}
+}
+
+// TestConsolidator_MirrorsTypedFactsIntoAGraph is the point of the entity half:
+// the pass must produce a GRAPH, not a second flat pile of facts.
+//
+// Two facts about one subject share an entity node, which is what makes "what else
+// do we know about Denn" answerable from either of them. A flat set of typed chunks
+// would be k/v with extra steps and graph_recall would have nothing to walk.
+func TestConsolidator_MirrorsTypedFactsIntoAGraph(t *testing.T) {
+	f := newFakeToolset()
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	f.transcript = "user: hi\nassistant: hello"
+	f.factsJSON = "```json\n" + `[
+		{"text":"Denn prefers Go for backend services.","class":"preference","type":"person","subject":"Denn"},
+		{"text":"Denn works in the Berlin office.","class":"fact","type":"person","subject":"Denn"},
+		{"text":"Acme runs on Postgres.","class":"fact","type":"organization","subject":"Acme"}
+	]` + "\n```"
+
+	res := runConsolidator(t, f)
+
+	// Every fact still lands in k/v — the graph is additive.
+	if n := f.countOp("Memory.set"); n != 3 {
+		t.Errorf("k/v writes = %d, want 3; the graph must not replace the authoritative store", n)
+	}
+	// TWO subject nodes for three facts: Denn is one node, not two.
+	if got := f.chunkTypes["person:denn"]; got != "person" {
+		t.Errorf("no person:denn entity node (types=%v)", f.chunkTypes)
+	}
+	if got := f.chunkTypes["organization:acme"]; got != "organization" {
+		t.Errorf("no organization:acme entity node (types=%v)", f.chunkTypes)
+	}
+	subjects := 0
+	for k := range f.chunkTypes {
+		if !strings.HasPrefix(k, "memory/") {
+			subjects++
+		}
+	}
+	if subjects != 2 {
+		t.Errorf("got %d subject nodes, want 2 — two facts about Denn must share one node; keys=%v", subjects, f.chunkTypes)
+	}
+	// Three fact nodes, keyed by the SAME key as the k/v row so the two stores
+	// share one key space and cannot drift.
+	factNodes := 0
+	for k := range f.chunks {
+		if strings.HasPrefix(k, "memory/") {
+			factNodes++
+		}
+	}
+	if factNodes != 3 {
+		t.Errorf("got %d fact nodes, want 3 (natural_key must be the k/v key); keys=%v", factNodes, f.chunks)
+	}
+	// And the edges that make it a graph.
+	if len(f.edges) != 3 {
+		t.Errorf("got %d `about` edges, want 3 — without them graph_recall has nothing to walk; edges=%v", len(f.edges), f.edges)
+	}
+	if !strings.Contains(res.FinalText, "entities 3 fact(s) across 2 subject(s)") {
+		t.Errorf("the entity half must be reported; got %q", res.FinalText)
+	}
+}
+
+// TestConsolidator_UntypedFactsStayKeyValueOnly: the entity pair is optional, and a
+// fact naming no single thing must not be forced into the graph. Inventing a subject
+// to make one fit is how two different things end up merged onto one node.
+func TestConsolidator_UntypedFactsStayKeyValueOnly(t *testing.T) {
+	f := newFakeToolset()
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	f.transcript = "user: hi\nassistant: hello"
+	f.factsJSON = "```json\n" + `[
+		{"text":"The team ships on Tuesdays.","class":"decision"},
+		{"text":"Releases are never cut on a Friday.","class":"constraint"}
+	]` + "\n```"
+
+	runConsolidator(t, f)
+
+	if n := f.countOp("Memory.set"); n != 2 {
+		t.Errorf("k/v writes = %d, want 2 — an untyped fact is still a fact", n)
+	}
+	if n := f.countOp("Document.upsert_chunk"); n != 0 {
+		t.Errorf("wrote %d chunks for untyped facts, want 0; keys=%v", n, f.chunks)
+	}
+}
+
+// TestConsolidator_AGraphFailureNeverCostsAFact is the safety property. The k/v row
+// is the authoritative memory and the graph is an index over it, so a Document
+// failure must degrade to "no edge" and never to "no fact" — and must never block
+// the watermark, which would make the pass re-read the chat forever.
+func TestConsolidator_AGraphFailureNeverCostsAFact(t *testing.T) {
+	f := newFakeToolset()
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	f.transcript = "user: hi\nassistant: hello"
+	f.factsJSON = "```json\n" + `[
+		{"text":"Denn prefers Go for backend services.","class":"preference","type":"person","subject":"Denn"}
+	]` + "\n```"
+	f.failEntityKeys = map[string]bool{"person:denn": true} // the subject node cannot be written
+
+	res := runConsolidator(t, f)
+
+	if n := f.countOp("Memory.set"); n != 1 {
+		t.Errorf("the fact must still be stored when the graph write fails; k/v writes=%d", n)
+	}
+	if !f.has("Memory.cursor_advance") {
+		t.Errorf("a graph failure must not block the watermark; sequence %v", f.ops())
+	}
+	if !strings.Contains(res.FinalText, "graph write(s) failed") {
+		t.Errorf("a silent graph failure is the worst outcome — it must be reported; got %q", res.FinalText)
 	}
 }

--- a/cmd/loomcycle/presets_memory_test.go
+++ b/cmd/loomcycle/presets_memory_test.go
@@ -45,13 +45,20 @@ func TestConsolidatorBundle_Validates(t *testing.T) {
 			t.Errorf("memory/consolidator should grant %q; tools=%v", want, agent.Tools)
 		}
 	}
-	// Document / Skill / Path must NOT be granted. Nothing in the code body calls
-	// any of them, and an unused grant is not free: it is the capability an
-	// injected instruction reaches for. `Path op=rm recursive=true` in particular
-	// is a HARD delete sitting inside an agent whose one central safety rule is
-	// that consolidation never destroys history — it would bypass the soft
-	// archive (supersede) the whole pipeline is built around.
-	for _, denied := range []string{"Document", "Skill", "Path"} {
+	// Document IS granted now: the entity half mirrors each typed fact into a chunk
+	// graph, which is the whole of RFC BL P5 PR 1. Its ops are additive and
+	// supersede-not-delete like the rest of the pipeline — there is no Document op
+	// that hard-deletes a fact the way `Path op=rm` would.
+	if !hasToolPreset(agent.Tools, "Document") {
+		t.Errorf("memory/consolidator must grant Document — the entity graph is written through it; tools=%v", agent.Tools)
+	}
+	// Skill / Path must NOT be granted. Nothing in the code body calls either, and
+	// an unused grant is not free: it is the capability an injected instruction
+	// reaches for. `Path op=rm recursive=true` in particular is a HARD delete
+	// sitting inside an agent whose one central safety rule is that consolidation
+	// never destroys history — it would bypass the soft archive (supersede) the
+	// whole pipeline is built around.
+	for _, denied := range []string{"Skill", "Path"} {
 		if hasToolPreset(agent.Tools, denied) {
 			t.Errorf("memory/consolidator grants %q but the code body never calls it; tools=%v", denied, agent.Tools)
 		}
@@ -95,10 +102,12 @@ func TestConsolidatorBundle_Validates(t *testing.T) {
 	if !containsString(agent.HistoryScope, "user") {
 		t.Errorf("history_scope should include user (the narrowest scope that reads the target's chats); got %v", agent.HistoryScope)
 	}
-	// sql_scopes is now GONE. It was carried "pending verification" through the
-	// prompt rewrite because revoking a capability is wider than editing text —
-	// but the pipeline is code now, and the code demonstrably never issues a SQL
-	// op. There is nothing left to verify.
+	// sql_scopes stays GONE even though the entity half writes chunk structure into
+	// SQL Memory. The Document tool issues its own trusted SQL and checks
+	// `sql_scopes` only for TENANT scope — agent and user are ungated — so the
+	// grant would buy nothing while handing an injected instruction the raw
+	// `Memory sql_exec` surface. Its absence is also what makes a tenant-scope
+	// Document write impossible here, whatever a transcript asks for.
 	if len(agent.SqlScopes) != 0 {
 		t.Errorf("memory/consolidator still grants sql_scopes=%v — the code body issues no SQL op, and an unused grant is the capability an injection reaches for", agent.SqlScopes)
 	}


### PR DESCRIPTION
**RFC BL P5, PR 1.** The entity tier shipped in v1.42.0 with no caller in anything loomcycle ships. This is the caller.

## What it builds

Every fact the extractor typed (PR 2) is **also** written as a chunk graph:

```
memory/preference/denn-prefers-go-backend  --about-->  person:denn
memory/fact/denn-works-berlin-office       --about-->  person:denn
memory/fact/acme-runs-postgres             --about-->  organization:acme
```

**The shape is the deliverable.** A flat set of typed chunks would be k/v with extra steps and `graph_recall` would have nothing to walk. Two facts about Denn sharing one subject node is what makes *"what else do we know about Denn"* answerable from either of them.

## The key decision: one key space, not two

A **fact** chunk's `natural_key` is the k/v key **verbatim** (`memory/<class>/<slug>`).

That was D1's whole risk — two stores with two supersede mechanisms drifting apart. This removes it rather than mitigating it: the same merge decision that rewrites a k/v row in place updates its chunk in place, and there's no second dedupe to fall out of step with the first. A **subject** node keys on `<type>:<slug(subject)>`, which is what collapses many facts onto one entity.

Untyped facts stay k/v-only (D1 selective). Inventing a subject to make a fact fit is how two different things merge onto one node — which is why the extractor is told not to guess and why half a pair is cleared upstream.

## Best-effort throughout

The k/v row is the authoritative memory and lands **before** any `Document` call runs. The graph is an index over facts, so a failure costs a retrieval path, never a fact — and never blocks the watermark, which would make the pass re-read the chat forever. Failures are counted and surfaced in the report, because a silent graph failure looks exactly like a pass with nothing to mirror.

## Grants — and a test that caught me over-granting

`Document` is added. **`sql_scopes` deliberately is not**, even though the entity half writes chunk structure into SQL Memory: the Document tool issues its own trusted SQL and checks `sql_scopes` only for **tenant** scope — agent and user are ungated. Granting it buys nothing while handing an injected instruction the raw `Memory sql_exec` surface, and its absence is what makes a tenant-scope write impossible here whatever a transcript asks for.

`TestConsolidatorBundle_Validates` flagged it on the first run:

```
memory/consolidator still grants sql_scopes=[agent user] — the code body issues
no SQL op, and an unused grant is the capability an injection reaches for
```

That test's `Document` denial was premised on *"nothing in the code body calls it"*, which is no longer true — it's now a positive assertion with the reason it changed, and `Skill`/`Path` stay denied.

The one raw-SQL call is a natural-key point lookup for the cross-pass supersede resolve, interpolated because `query_chunks`' escape hatch takes no parameters. Safe **here and only here**: every natural key this file produces comes from `slug()` or `entityKey()`, whose output is `[a-z0-9:-]` by construction, and the reader is regex-guarded besides. Noted at the call site so it isn't copied.

## Tested

`fakeDocument` — a minimal chunk store that observes which natural keys became chunks and which edges joined them, without reimplementing the tool. Three new tests:

- **`MirrorsTypedFactsIntoAGraph`** — 3 facts → 3 k/v writes, **2** subject nodes (Denn is one node, not two), 3 fact nodes keyed by the k/v key, 3 `about` edges, and the report line
- **`UntypedFactsStayKeyValueOnly`** — 2 k/v writes, 0 chunks
- **`AGraphFailureNeverCostsAFact`** — subject write fails → fact still stored, watermark still advances, failure reported

**Fail-before verified twice:**

```
drop the edge          → "got 0 `about` edges, want 3 — without them graph_recall has nothing to walk"
unguard a graph write  → the fact is lost and the watermark stalls
```

All 20-odd existing consolidator tests pass unchanged with the graph writing. `gofmt` clean · full `go test ./...` green · the full default preset stack validates · embedded bundle synced.

## After deploying

This is the first pass that writes entities, so it's worth watching the first scheduled run's report line — `entities N fact(s) across M subject(s)` — and then checking the graph is real:

```
document op=graph_recall scope=user query="<a subject you expect>"
path     op=ls scope=user path=/memory/entities
```

§6 of the plan calls for exactly that: entity chunks with natural keys and bi-temporal stamps observed **in the store**, not in a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)