### PR TITLE
feat(chat): tell the chat agents when to walk the entity graph

### DIFF
--- a/bundles/chat/loomcycle.yaml
+++ b/bundles/chat/loomcycle.yaml
@@ -33,7 +33,12 @@ agents:
     unbounded_iterations: true              # interactive chat parks at end_turn
     tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, HTTP, Bashbox, Bash, Document, Memory, Path, Skill, SkillDef, Agent, Interruption]
     memory_scopes: [user]
-    sql_scopes: [user]                      # Document is SQL-Memory-backed
+    # sql_scopes grants `Memory sql_query`/`sql_exec` — NOT Document, whose
+    # structure writes are its own trusted SQL and which checks sql_scopes only at
+    # TENANT scope. The comment here used to claim otherwise. Kept because an
+    # interactive operator agent having a queryable per-user database is plausibly
+    # wanted; drop it if you would rather chat could not run raw SQL.
+    sql_scopes: [user]
     sampling:
       temperature: 0.7
     compaction:
@@ -67,6 +72,13 @@ agents:
       - Memory / Document / Path: durable facts across turns go in Memory (user
         scope), structured chunked material in a Document, and Path navigates
         both.
+      - Recalling what you know about a THING: `Memory recall` matches words;
+        `Document graph_recall` follows the relations between facts. Reach for
+        graph_recall when the question names a thing rather than a phrase —
+        "what do we know about Acme", "who else worked on this" — because facts
+        recorded in different words still share an entity and a word match misses
+        them. `as_of` answers as of a past moment, recovering a fact since
+        corrected.
 
       ## Style
       - Be concise and concrete; lead with the answer, then the reasoning.
@@ -106,6 +118,9 @@ agents:
         hatch.
       - Memory / Document / Path: durable user-scope facts in Memory, structured
         material in a Document, and Path navigates both.
+      - Asked about a named thing ("what do we know about Acme")? Use `Document
+        graph_recall` — it follows relations, so it finds facts worded
+        differently that `Memory recall` would miss.
 
       ## Style
       - Be concise and concrete; lead with the answer, then the reasoning.
@@ -145,6 +160,9 @@ agents:
         hatch.
       - Memory / Document / Path: durable user-scope facts in Memory, structured
         material in a Document, and Path navigates both.
+      - Asked about a named thing ("what do we know about Acme")? Use `Document
+        graph_recall` — it follows relations, so it finds facts worded
+        differently that `Memory recall` would miss.
 
       ## Style
       - Be concise and concrete; lead with the answer, then the reasoning.

--- a/cmd/loomcycle/embedded/bundles/chat.yaml
+++ b/cmd/loomcycle/embedded/bundles/chat.yaml
@@ -33,7 +33,12 @@ agents:
     unbounded_iterations: true              # interactive chat parks at end_turn
     tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, HTTP, Bashbox, Bash, Document, Memory, Path, Skill, SkillDef, Agent, Interruption]
     memory_scopes: [user]
-    sql_scopes: [user]                      # Document is SQL-Memory-backed
+    # sql_scopes grants `Memory sql_query`/`sql_exec` — NOT Document, whose
+    # structure writes are its own trusted SQL and which checks sql_scopes only at
+    # TENANT scope. The comment here used to claim otherwise. Kept because an
+    # interactive operator agent having a queryable per-user database is plausibly
+    # wanted; drop it if you would rather chat could not run raw SQL.
+    sql_scopes: [user]
     sampling:
       temperature: 0.7
     compaction:
@@ -67,6 +72,13 @@ agents:
       - Memory / Document / Path: durable facts across turns go in Memory (user
         scope), structured chunked material in a Document, and Path navigates
         both.
+      - Recalling what you know about a THING: `Memory recall` matches words;
+        `Document graph_recall` follows the relations between facts. Reach for
+        graph_recall when the question names a thing rather than a phrase —
+        "what do we know about Acme", "who else worked on this" — because facts
+        recorded in different words still share an entity and a word match misses
+        them. `as_of` answers as of a past moment, recovering a fact since
+        corrected.
 
       ## Style
       - Be concise and concrete; lead with the answer, then the reasoning.
@@ -106,6 +118,9 @@ agents:
         hatch.
       - Memory / Document / Path: durable user-scope facts in Memory, structured
         material in a Document, and Path navigates both.
+      - Asked about a named thing ("what do we know about Acme")? Use `Document
+        graph_recall` — it follows relations, so it finds facts worded
+        differently that `Memory recall` would miss.
 
       ## Style
       - Be concise and concrete; lead with the answer, then the reasoning.
@@ -145,6 +160,9 @@ agents:
         hatch.
       - Memory / Document / Path: durable user-scope facts in Memory, structured
         material in a Document, and Path navigates both.
+      - Asked about a named thing ("what do we know about Acme")? Use `Document
+        graph_recall` — it follows relations, so it finds facts worded
+        differently that `Memory recall` would miss.
 
       ## Style
       - Be concise and concrete; lead with the answer, then the reasoning.

--- a/cmd/loomcycle/presets_chat_test.go
+++ b/cmd/loomcycle/presets_chat_test.go
@@ -88,3 +88,44 @@ func TestChatBundle_PromptsDoNotHandWriteAToolList(t *testing.T) {
 		}
 	}
 }
+
+// TestChatBundle_PromptsPointAtGraphRecall pins the guidance that makes the entity
+// graph reachable in practice.
+//
+// The tool grant is not what makes a capability usable. `Document` has been in
+// these agents' tools since the bundle shipped, and `graph_recall` has existed
+// since v1.42.0 — but nothing told a model when to prefer it over `Memory recall`,
+// so it went unused. That is the same "capability with no caller" shape as the
+// entity tier having no producer, one layer up: reachable in principle, invisible
+// in practice.
+//
+// The distinction the guidance has to carry is the load-bearing one: word matching
+// versus following relations. Two facts about Acme recorded in different words are
+// found by graph_recall and missed by recall, which is precisely when a model
+// should reach for it.
+func TestChatBundle_PromptsPointAtGraphRecall(t *testing.T) {
+	cfg := chatBundleConfig(t)
+	found := 0
+	for name, agent := range cfg.Agents {
+		if !strings.HasPrefix(name, "chat/") {
+			continue
+		}
+		found++
+		if !strings.Contains(agent.SystemPrompt, "graph_recall") {
+			t.Errorf("%s never mentions graph_recall — the entity graph is granted but unreachable in practice", name)
+			continue
+		}
+		// Naming the op is not enough; the prompt must say WHEN, or it reads as
+		// one more entry in a list the model already has from Context.tools.
+		if !strings.Contains(agent.SystemPrompt, "relation") {
+			t.Errorf("%s names graph_recall but not what distinguishes it (following relations vs matching words)", name)
+		}
+		// And the tool it needs must actually be granted.
+		if !hasToolPreset(agent.Tools, "Document") {
+			t.Errorf("%s is told to use graph_recall but does not grant Document; tools=%v", name, agent.Tools)
+		}
+	}
+	if found == 0 {
+		t.Fatal("no chat/* agents found — the bundle was renamed and this test now checks nothing")
+	}
+}


### PR DESCRIPTION
**RFC BL P5, PR 3.** The last link: PR 2 made the extractor emit typed facts, PR 1 made the consolidator build a graph from them, and this makes something read it.

## The grant was never the missing piece

`Document` has been in the chat agents' tools since the bundle shipped, and `graph_recall` has existed since v1.42.0. What was missing is the only thing that makes a capability usable — telling the model **when** to reach for it.

That's the same "capability with no caller" shape as the entity tier having no producer, one layer up: reachable in principle, invisible in practice. A tool in `tools:` that no prompt distinguishes is a tool the model already sees in `{{tool:Context.tools}}` and has no reason to prefer.

## What the guidance says

The distinction, not the op name:

> `Memory recall` matches **words**; `Document graph_recall` follows the **relations** between facts. Reach for graph_recall when the question names a thing rather than a phrase — *"what do we know about Acme"*, *"who else worked on this"* — because facts recorded in different words still share an entity and a word match misses them. `as_of` answers as of a past moment, recovering a fact since corrected.

Two facts about Acme worded differently share a subject node, so the graph finds both and recall finds one. That's the case worth switching tools for, and `as_of` gets a mention because recovering a since-corrected fact is something recall cannot do at all.

All three agents, worded to tier: the fuller form on `chat/medium`, two terse lines on the local pair whose prompts are deliberately shorter.

Per **D5** this stays an *explicit* tool rather than auto-expansion inside `recall` — the graph earns that by being used, and auto-expansion would put latency on every retrieval for a benefit nothing has demonstrated yet.

## A false comment corrected

Beside the chat agents' `sql_scopes: [user]` sat:

```yaml
sql_scopes: [user]    # Document is SQL-Memory-backed
```

That reason is wrong — Document issues its own trusted SQL and checks `sql_scopes` only at **tenant** scope, which is exactly what the consolidator's grant review established one PR ago (and what `TestConsolidatorBundle_Validates` caught me on).

**The grant is kept**, not removed: an interactive operator agent having a queryable per-user database is plausibly wanted, and silently revoking a capability someone may use isn't mine to do. But it now states what it actually grants — `Memory sql_query`/`sql_exec` — so the decision to keep or drop it can be made on the real reason. **Say the word if you'd rather chat couldn't run raw SQL.**

## Tested

`TestChatBundle_PromptsPointAtGraphRecall` — every `chat/*` agent mentions `graph_recall`, says what distinguishes it (`relation`), and actually grants `Document`. It also fails loudly if the bundle is renamed and the test silently starts checking nothing.

**Fail-before verified** — with the guidance stripped, all three fail:

```
chat/medium never mentions graph_recall — the entity graph is granted but unreachable in practice
chat/local ...
chat/local-small ...
```

`gofmt` clean · full `go test ./...` green · full default preset stack validates · embedded bundle synced.

## P5 status after this

Done: **0** (erasure assessment), **0b** (docs correction), **2** (extractor), **1** (consolidator writes), **3** (chat reads).

Remaining: **4** tenant-root doc + `{{memory:tenant_info}}`, **5** tenant core blocks, **6** GC reconciliation, plus **0c** the provenance lister and **0d** the erasure op that the assessment split out.

Once this is deployed the whole chain is live end to end, and the §6 check becomes possible for real: a scheduled pass writes entities, and a chat agent answers a "what do we know about X" question from the graph rather than from a word match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)