### PR TITLE
feat(memory): the deployment-context document, with a reader

### DIFF
--- a/bundles/chat/loomcycle.yaml
+++ b/bundles/chat/loomcycle.yaml
@@ -58,6 +58,8 @@ agents:
       answer questions, reason through problems, and reach for your tools when
       they make the answer better or are needed to act.
 
+      {{memory:tenant_info}}
+
       ## Tools
       {{tool:Context.tools}}
 
@@ -106,6 +108,8 @@ agents:
       you run entirely on the operator's LOCAL model (ollama-local) — nothing you
       process leaves the box. Favor this for private or offline work.
 
+      {{memory:tenant_info}}
+
       ## Tools
       {{tool:Context.tools}}
 
@@ -147,6 +151,8 @@ agents:
       You are CHAT-LOCAL, the same helpful general-purpose assistant as CHAT, but
       you run entirely on the operator's LOCAL model (ollama-local) — nothing you
       process leaves the box. Favor this for private or offline work.
+
+      {{memory:tenant_info}}
 
       ## Tools
       {{tool:Context.tools}}

--- a/cmd/loomcycle/embedded/bundles/chat.yaml
+++ b/cmd/loomcycle/embedded/bundles/chat.yaml
@@ -58,6 +58,8 @@ agents:
       answer questions, reason through problems, and reach for your tools when
       they make the answer better or are needed to act.
 
+      {{memory:tenant_info}}
+
       ## Tools
       {{tool:Context.tools}}
 
@@ -106,6 +108,8 @@ agents:
       you run entirely on the operator's LOCAL model (ollama-local) — nothing you
       process leaves the box. Favor this for private or offline work.
 
+      {{memory:tenant_info}}
+
       ## Tools
       {{tool:Context.tools}}
 
@@ -147,6 +151,8 @@ agents:
       You are CHAT-LOCAL, the same helpful general-purpose assistant as CHAT, but
       you run entirely on the operator's LOCAL model (ollama-local) — nothing you
       process leaves the box. Favor this for private or offline work.
+
+      {{memory:tenant_info}}
 
       ## Tools
       {{tool:Context.tools}}

--- a/cmd/loomcycle/presets_chat_test.go
+++ b/cmd/loomcycle/presets_chat_test.go
@@ -129,3 +129,39 @@ func TestChatBundle_PromptsPointAtGraphRecall(t *testing.T) {
 		t.Fatal("no chat/* agents found — the bundle was renamed and this test now checks nothing")
 	}
 }
+
+// TestChatBundle_PromptsInjectTenantContext pins the CONSUMER of
+// {{memory:tenant_info}}.
+//
+// The variant existed and validated for four phases while rendering nothing,
+// because the document behind it was never built — and once built it would have
+// been just as inert if no shipped prompt referenced it. That is the failure this
+// phase exists to fix and the reason the plan says: wire a placeholder in the same
+// PR that adds it, or do not ship it.
+//
+// The chat agents are the right consumer: they are the interactive surface, they
+// already read the per-user root, and deployment vocabulary is exactly the context
+// they lack. They stay `memory_scopes: [user]` — the read stamps the tenant grants
+// server-side, so consuming it costs no widening.
+func TestChatBundle_PromptsInjectTenantContext(t *testing.T) {
+	cfg := chatBundleConfig(t)
+	found := 0
+	for name, agent := range cfg.Agents {
+		if !strings.HasPrefix(name, "chat/") {
+			continue
+		}
+		found++
+		if !strings.Contains(agent.SystemPrompt, "{{memory:tenant_info}}") {
+			t.Errorf("%s does not inject {{memory:tenant_info}} — the deployment-context document would ship with no reader", name)
+		}
+		// Consuming it must NOT have required widening the agent to tenant scope.
+		for _, scope := range agent.MemoryScopes {
+			if scope == "tenant" {
+				t.Errorf("%s was widened to tenant memory scope; tenant_info is read with server-stamped grants and needs no such widening", name)
+			}
+		}
+	}
+	if found == 0 {
+		t.Fatal("no chat/* agents found — the bundle was renamed and this test now checks nothing")
+	}
+}

--- a/internal/api/http/meminject.go
+++ b/internal/api/http/meminject.go
@@ -111,6 +111,16 @@ func (s *Server) applyMemoryInjection(ctx context.Context, agentDef config.Agent
 			sections[meminject.VariantUserInfo] = body
 		}
 	}
+	// tenant_info: gated on an actual reference for the same reason as user_info
+	// and ontology — rendering it PROVISIONS the tenant's deployment-context
+	// document, and a prompt that never mentions it must not create one.
+	// suppressRoots covers it too: `memory_roots: suppress` means an agent wants no
+	// root documents injected, and the tenant root is one.
+	if !suppressRoots && meminject.ReferencesVariant(agentDef.SystemPrompt, meminject.VariantTenantInfo) {
+		if body := s.renderTenantInfo(ctx, mi); body != "" {
+			sections[meminject.VariantTenantInfo] = body
+		}
+	}
 	if body := s.renderSearchRequest(ctx, mi); body != "" {
 		sections[meminject.VariantSearchRequest] = body
 	}
@@ -133,8 +143,6 @@ func (s *Server) applyMemoryInjection(ctx context.Context, agentDef config.Agent
 		relatedBand = s.cfg.Memory.Consolidation.EffectiveRelatedThreshold()
 	}
 	sections[meminject.VariantConsolidationBands] = meminject.ConsolidationBands(mergeBand, relatedBand)
-	// tenant_info is still an accepted-but-empty variant (it needs the tenant-root
-	// document, a later deliverable). ontology is live — see renderOntology.
 
 	out := agentDef
 	out.SystemPrompt = meminject.Expand(agentDef.SystemPrompt, meminject.ExpandInput{

--- a/internal/api/http/tenantroot.go
+++ b/internal/api/http/tenantroot.go
@@ -1,0 +1,118 @@
+package http
+
+// tenantroot.go — the deployment-context Document behind {{memory:tenant_info}}.
+//
+// The tenant twin of the user-root document: same lazy-provision-then-export
+// shape, one scope up. What differs is who it is for. The user root is what the
+// agent should know about the PERSON; this is what every agent in the tenant should
+// know about the DEPLOYMENT — the service names, the vocabulary, the conventions
+// that are equally true whichever user is asking.
+//
+// Two documents rather than two sections of one, because they have different blast
+// radius: anything here is read by every user of the tenant, and an operator
+// deciding what goes where should be making that call at the level of a document
+// they can point at.
+//
+// The tenant grants are stamped SERVER-SIDE, exactly as renderOntology does. This
+// is a server-side read of operator-authored config on the run's own tenant, not an
+// agent reaching tenant memory, so an agent injecting the placeholder does not need
+// to hold `tenant` in memory_scopes/sql_scopes — which matters, because the chat
+// agents that consume it are deliberately user-scoped.
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	meminject "github.com/denn-gubsky/loomcycle/internal/memory"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
+)
+
+// renderTenantInfo composes the {{memory:tenant_info}} body: the tenant's
+// deployment-context document as clean Markdown, provisioning it from the embedded
+// template on first reference.
+//
+// Best-effort throughout. No store, no SQL Memory, no tenant, an unreadable
+// document: the run continues with the section empty rather than failing. Context
+// is help, and a run that dies for want of it is worse than one without it.
+func (s *Server) renderTenantInfo(ctx context.Context, mi memInject) string {
+	if s.store == nil || s.sqlMem == nil {
+		return ""
+	}
+	s.ensureTenantRootDoc(ctx, mi)
+	return s.readTenantRootMarkdown(ctx, mi)
+}
+
+// tenantRootCtx stamps the tenant identity plus the tenant-scope grants the read
+// needs (see the file comment on why they are server-side).
+func (s *Server) tenantRootCtx(ctx context.Context, mi memInject) context.Context {
+	dctx := s.docToolCtx(ctx, mi)
+	dctx = tools.WithMemoryPolicy(dctx, tools.MemoryPolicyValue{AllowedScopes: []string{"tenant"}})
+	dctx = tools.WithSqlMemPolicy(dctx, tools.SqlMemPolicyValue{AllowedScopes: []string{"tenant"}})
+	return dctx
+}
+
+// ensureTenantRootDoc provisions the document on first reference. Mirrors
+// ensureUserRootDoc's race safety: an in-process singleflight collapses a
+// concurrent burst, and a PG advisory lock admits one replica in a cluster.
+//
+// Keyed on the tenant alone — one document per tenant, unlike the per-principal
+// user root.
+func (s *Server) ensureTenantRootDoc(ctx context.Context, mi memInject) {
+	if s.store == nil || s.sqlMem == nil {
+		return
+	}
+	_, _, _ = s.userRootProvisionSF.Do("tenantroot\x00"+mi.Tenant, func() (any, error) {
+		s.provisionTenantRootDoc(ctx, mi)
+		return nil, nil
+	})
+}
+
+func (s *Server) provisionTenantRootDoc(ctx context.Context, mi memInject) {
+	if s.sessionLockPG != nil {
+		// NUL-free lock id (pg text params reject 0x00).
+		release, ok := s.sessionLockPG.TryLock(ctx, "memory:tenantroot:"+mi.Tenant)
+		if !ok {
+			return
+		}
+		defer release()
+	}
+
+	doc := &builtin.Document{Store: s.store, SqlMem: s.sqlMem}
+	dctx := s.tenantRootCtx(ctx, mi)
+
+	probe, _ := json.Marshal(map[string]any{
+		"op": "get_document", "scope": "tenant", "path": meminject.TenantRootPath,
+	})
+	if res, _ := doc.Execute(dctx, probe); !res.IsError {
+		return // already provisioned, here or by another replica
+	}
+
+	create, _ := json.Marshal(map[string]any{
+		"op": "import_md", "scope": "tenant", "path": meminject.TenantRootPath,
+		"markdown": meminject.TenantRootTemplate(),
+	})
+	_, _ = doc.Execute(dctx, create) // best-effort; the next reference retries
+}
+
+// readTenantRootMarkdown exports the document to clean Markdown for injection.
+func (s *Server) readTenantRootMarkdown(ctx context.Context, mi memInject) string {
+	doc := &builtin.Document{Store: s.store, SqlMem: s.sqlMem}
+	dctx := s.tenantRootCtx(ctx, mi)
+	req, _ := json.Marshal(map[string]any{
+		"op": "export_md", "scope": "tenant", "path": meminject.TenantRootPath,
+		"include_metadata": false,
+	})
+	res, _ := doc.Execute(dctx, req)
+	if res.IsError {
+		return ""
+	}
+	var out struct {
+		Markdown string `json:"markdown"`
+	}
+	if err := json.Unmarshal([]byte(res.Text), &out); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(out.Markdown)
+}

--- a/internal/api/http/tenantroot_test.go
+++ b/internal/api/http/tenantroot_test.go
@@ -1,0 +1,91 @@
+package http
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	meminject "github.com/denn-gubsky/loomcycle/internal/memory"
+)
+
+// TestTenantInfo_ReachesTheAssembledPromptAndProvisions is the wiring, asserted on
+// the prompt a run actually gets.
+//
+// `tenant_info` was an ACCEPTED-BUT-EMPTY variant for four phases: the name
+// validated, the placeholder expanded, and it always rendered nothing because the
+// document behind it was never built. A prompt referencing it looked correct and
+// carried no content — which is why this asserts on the assembled prompt rather
+// than on the renderer.
+func TestTenantInfo_ReachesTheAssembledPromptAndProvisions(t *testing.T) {
+	s, mi := ontologyFixture(t)
+	def := config.AgentDef{SystemPrompt: "You are CHAT.\n\n{{memory:tenant_info}}"}
+
+	got, _ := s.applyMemoryInjection(context.Background(), def, mi)
+
+	if strings.Contains(got.SystemPrompt, "{{memory:") {
+		t.Errorf("placeholder left unexpanded:\n%s", got.SystemPrompt)
+	}
+	// The template's own headings, so this fails if the document was provisioned
+	// from something else or not at all.
+	for _, want := range []string{"Deployment Context", "Systems and vocabulary", "Standing conventions"} {
+		if !strings.Contains(got.SystemPrompt, want) {
+			t.Errorf("missing %q from the assembled prompt — tenant_info rendered empty:\n%s", want, got.SystemPrompt)
+		}
+	}
+	// FRAMED, unlike the ontology: this is operator-authored prose, not a schema
+	// the model applies, so it goes in as content the model should treat as data.
+	if !strings.Contains(got.SystemPrompt, "<memory source=\"tenant_info\">") {
+		t.Errorf("tenant_info must be framed as untrusted content:\n%s", got.SystemPrompt)
+	}
+}
+
+// TestTenantInfo_NotReferencedNeverProvisions: rendering PROVISIONS a document, so a
+// prompt that never mentions it must not create one as a side effect of being
+// assembled. The same rule user_info and ontology follow.
+func TestTenantInfo_NotReferencedNeverProvisions(t *testing.T) {
+	s, mi := ontologyFixture(t)
+	def := config.AgentDef{SystemPrompt: "A prompt with no placeholders."}
+
+	got, _ := s.applyMemoryInjection(context.Background(), def, mi)
+	if got.SystemPrompt != def.SystemPrompt {
+		t.Errorf("the fast path should return byte-identical, got:\n%s", got.SystemPrompt)
+	}
+	if s.readTenantRootMarkdown(context.Background(), mi) != "" {
+		t.Error("an unreferenced tenant root must not be provisioned")
+	}
+}
+
+// TestTenantInfo_IsTenantScopedNotPerUser: two users of one tenant must read the
+// SAME document. If it were provisioned per-principal the deployment's vocabulary
+// would fork silently, one copy per person, and an operator editing "the" document
+// would fix it for exactly one of them.
+func TestTenantInfo_IsTenantScopedNotPerUser(t *testing.T) {
+	s, mi := ontologyFixture(t)
+	def := config.AgentDef{SystemPrompt: "{{memory:tenant_info}}"}
+
+	s.applyMemoryInjection(context.Background(), def, mi) // provisions for alice
+
+	other := mi
+	other.UserID = "bob"
+	body := s.readTenantRootMarkdown(context.Background(), other)
+	if body == "" {
+		t.Fatal("a second user of the same tenant reads nothing — the document forked per user")
+	}
+	if !strings.Contains(body, meminject.TenantRootTitle) {
+		t.Errorf("bob read something other than the tenant root:\n%s", body)
+	}
+}
+
+// TestTenantInfo_NeedsNoTenantGrantOnTheAgent: the chat agents that consume this are
+// deliberately user-scoped (`memory_scopes: [user]`). The read stamps the tenant
+// grants server-side because it is operator-authored config on the run's own
+// tenant, not the agent reaching tenant memory — so requiring the grant would mean
+// widening every consuming agent to tenant scope to read a paragraph of prose.
+func TestTenantInfo_NeedsNoTenantGrantOnTheAgent(t *testing.T) {
+	s, mi := ontologyFixture(t)
+	// No policy stamped on the context at all — the weakest possible caller.
+	if body := s.renderTenantInfo(context.Background(), mi); body == "" {
+		t.Error("tenant_info must render for an agent holding no tenant grant")
+	}
+}

--- a/internal/memory/templates.go
+++ b/internal/memory/templates.go
@@ -23,3 +23,25 @@ var userRootTemplate string
 // user-root Document on first reference. It is a compile-time constant, so
 // provisioning is deterministic (no random content).
 func UserRootTemplate() string { return userRootTemplate }
+
+// TenantRootPath is the canonical Path-tree location, in the TENANT scope, of the
+// operator-authored deployment-context Document that composes into
+// {{memory:tenant_info}}.
+//
+// Tenant scope, not user: this is what every agent in the tenant shares, and the
+// per-person half already exists at UserRootPath. The two are separate documents
+// rather than sections of one because they have different audiences and different
+// blast radius — anything here is read by every user of the tenant.
+const TenantRootPath = "/memory/tenant_root"
+
+// TenantRootTitle MUST match the template's first heading (import_md makes the
+// first heading the root chunk / document title).
+const TenantRootTitle = "Deployment Context"
+
+//go:embed templates/tenant_root.md
+var tenantRootTemplate string
+
+// TenantRootTemplate returns the import_md-shaped Markdown used to seed an empty
+// tenant-root Document on first reference. Compile-time constant, so provisioning
+// is deterministic.
+func TenantRootTemplate() string { return tenantRootTemplate }

--- a/internal/memory/templates/tenant_root.md
+++ b/internal/memory/templates/tenant_root.md
@@ -1,0 +1,28 @@
+# Deployment Context
+
+Operator-authored context every agent in this tenant shares. Edit this document to
+give agents stable facts about the DEPLOYMENT rather than about one person — the
+things that are equally true whichever user is asking.
+
+It is read by every agent whose prompt injects it, so keep it short and factual.
+This is reference data agents read, not instructions they must obey, and anything
+here is visible to every user of the tenant — do not put per-user detail or
+anything you would not show all of them.
+
+## What this deployment is for
+
+The team or product this runtime serves, and what agents here are expected to do.
+(for example: "Platform team's internal assistant; code review, incident
+write-ups and release notes for the payments stack.")
+
+## Systems and vocabulary
+
+Names an agent will meet that it cannot infer — services, repositories,
+environments, and any term this team uses in a specific way. (for example:
+"`ledger` is the double-entry service, not the reporting DB. `prod-eu` is the
+only tenant-facing environment.")
+
+## Standing conventions
+
+Durable, cross-user working rules for this deployment. (for example: "Release
+notes cite the PR number. Never open a PR against `main` directly.")


### PR DESCRIPTION
**RFC BL P5, PR 4.** `{{memory:tenant_info}}` has been an **accepted-but-empty variant since P1** — the name validated, the placeholder expanded, and it always rendered nothing, because the document behind it was never built. A prompt referencing it looked correct and carried no content.

## What it is

The tenant twin of the user root, one scope up at `/memory/tenant_root`. Same lazy-provision-then-export shape; what differs is the audience.

| | |
|---|---|
| user root | what an agent should know about the **person** |
| tenant root | what every agent should know about the **deployment** — service names, vocabulary a team uses in a specific way, standing conventions |

Two documents rather than two sections of one, because they have different blast radius: anything here is read by **every user of the tenant**. The template says so in as many words, since that's the mistake an operator would otherwise make once.

## The grants are server-side, and that's load-bearing

The read stamps `tenant` on memory + SQL policies itself, exactly as `renderOntology` does — this is operator-authored config on the run's own tenant, not an agent reaching tenant memory.

That isn't tidiness. The chat agents that consume it are deliberately `memory_scopes: [user]`, and requiring the grant would mean **widening every consuming agent to tenant scope to read a paragraph of prose**. A test asserts the widening did not happen.

Rendering is gated on an actual reference (like `user_info` and `ontology`) because it *provisions* — a prompt that never mentions it must not create a document as a side effect of being assembled. `memory_roots: suppress` covers it too.

## It ships with a reader, in the same PR

The plan's own §7 risk note:

> PR 4 and 5 add placeholders; if no shipped prompt uses them they repeat the pattern this phase exists to fix. Either wire them in the same PR or do not ship them.

Which is precisely what `tenant_info` has been doing for four phases. All three `chat/*` prompts now inject it — they're the interactive surface, they already read the per-user root, and deployment vocabulary is exactly the context they lack. `TestChatBundle_PromptsInjectTenantContext` pins that, so the reader can't quietly disappear later.

Framed as untrusted content, unlike the ontology: operator prose is data the model reads, not a schema it applies.

## Tested

Four tests in `internal/api/http/tenantroot_test.go`, asserted on the **assembled prompt** rather than the renderer — that distinction is the whole reason this variant stayed broken so long:

- reaches the prompt and provisions from the template
- unreferenced → never provisions
- **tenant-scoped, not per-user** — a second user of the same tenant reads the *same* document. Provisioned per-principal it would fork silently, one copy per person, and an operator editing "the" document would fix it for exactly one of them.
- renders for an agent holding **no** tenant grant

Plus the consumer check in the chat bundle.

**Fail-before verified twice:**

```
restore the accepted-but-empty stub → "missing 'Deployment Context' … tenant_info rendered empty"
drop the placeholder from chat/*    → "the deployment-context document would ship with no reader"
```

`gofmt` clean · full `go test ./...` green · full default preset stack validates · embedded bundle synced.

## P5 status

Done: **0**, **0b**, **2**, **1**, **3**, **4**. Remaining: **5** tenant core blocks, **6** GC reconciliation, **0c** provenance lister, **0d** erasure op.

Worth noting for PR 5: with this landed, the obvious question is whether tenant core blocks are still wanted, or whether the tenant root document covers the same need more legibly. I'll look at that before building rather than assuming the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)