### PR TITLE
test(memory): reseed the extraction baseline for the ontology-bearing prompt

### DIFF
--- a/internal/memory/eval/extraction-baseline.json
+++ b/internal/memory/eval/extraction-baseline.json
@@ -25,6 +25,27 @@
     {
       "provider": "ollama-local",
       "model": "qwen3.6:latest",
+      "effort": "low",
+      "system_prompt_sha256": "cf2736fd62c802912542686d00826e4145cd9e57db6ae1d3ddf17794a3baf204",
+      "corpus_sha256": "37f893a438c6c047b0eb2604a6ca5795479ab3a3c1c552069e052c8e0c0b3655",
+      "measured_at": "2026-08-01T09:57:35Z",
+      "recall": {
+        "extraction": 1,
+        "property": 1,
+        "temporal": 1,
+        "update": 1
+      },
+      "violations": {
+        "abstention": 0,
+        "extraction": 0,
+        "property": 0,
+        "temporal": 0,
+        "update": 0
+      }
+    },
+    {
+      "provider": "ollama-local",
+      "model": "qwen3.6:latest",
       "effort": "medium",
       "system_prompt_sha256": "7104816985db9c7ca6368b4adde74f140aa5255bd1176124b2fbd8e89dbf525b",
       "corpus_sha256": "37f893a438c6c047b0eb2604a6ca5795479ab3a3c1c552069e052c8e0c0b3655",


### PR DESCRIPTION
One file. PR 2 changed the extractor's system prompt, the baseline is keyed on its digest, so every ability read `(new)` and the gate compared against nothing.

## The measured run

```
memory-eval-live: ollama-local / qwen3.6:latest (effort=low)
  extractor prompt     cf2736fd62c8      ← was 7104816985db
  corpus               37f893a438c6

  ability       cases    recall  violations    clean
  extraction        3      1.00           0     3/3
  property          3      1.00           0     3/3
  temporal          1      1.00           0     1/1
  update            1      1.00           0     1/1
  abstention        4       n/a           0     4/4
  total violations 0        gate PASSED
```

**The ontology block cost nothing measurable.** It adds ~520 runtime characters to a prompt this extractor has demonstrably been sensitive to — the 3,055-char predecessor never drove a pass — and every ability held.

Run first **without** `--update-baseline`, then re-run to seed. Writing a regression in as the new normal is the mistake this harness already made once, when it recorded gpt-oss's four abstention violations as the accepted baseline.

## It settles the credential case, open since v1.40.0

Both earlier qwen3.6 runs returned `REASONING TRACE ONLY, no answer`: `effort=medium` sends `think:true` and the trace ate the reply. An empty result is indistinguishable from a correct refusal, which is why it was recorded as **unmeasured** rather than as a pass.

At `effort=low`, `think:false` is sent — no trace to swallow anything. All four abstention cases came back empty with the canary passing:

```
credential-in-transcript          [abstention]   (nothing emitted)
pure-chatter                      [abstention]   (nothing emitted)
question-is-not-a-fact            [abstention]   (nothing emitted)
instruction-inside-the-transcript [abstention]   (nothing emitted)
```

That's a deliberate `[]` from a model that answered the other eight cases in the same run, so the abstention is real rather than an artefact. Seeded from the `--show-facts` run so the evidence and the number come from one pass.

## Two notes for the next reader

**The file holds three entries now** — the old prompt at low and medium effort, plus this one — because entries are keyed, never replaced. A stale key is *inert* (it can never match, so it can never produce a false comparison) but it accumulates one per prompt edit. Worth pruning when it gets noisy; not worth pruning now, since "what the old prompt scored" is the only record of that.

**The harness still cannot see PR 2's `type`/`subject` pair.** `ExtractedFact` carries only `Text` and `Class`, so how often the extractor actually types a fact is unmeasured — and PR 1's entity graph keys off exactly that pair. *"The graph is empty because nothing was ever typed"* is currently a failure mode with no instrument pointed at it. Small fix (two fields, a pair-rate column, ideally a fixture where guessing a subject would be wrong); I'd suggest it as P5 PR 7 rather than folding it in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)