### PR TITLE
fix(memory): tenant core blocks were dropped one boolean before the read

### DIFF
--- a/internal/api/http/coreblock_tenant_test.go
+++ b/internal/api/http/coreblock_tenant_test.go
@@ -1,0 +1,170 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	meminject "github.com/denn-gubsky/loomcycle/internal/memory"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
+)
+
+// TestCoreBlock_TenantScopeIsSharedAcrossUsers is the P4 "tenant core blocks"
+// deliverable, asserted rather than built.
+//
+// `tenant` has been in validCoreBlockScopes since P1, so a tenant block loads and
+// validates — but coreBlockScopeID returned "" for it under a comment reading
+// "tenant scope has no scope_id convention in P1 (the entity tier lands later)".
+// That comment is what made the deliverable look unbuilt. It is stale: "" IS the
+// tenant convention in the k/v plane, where the tenant_id COLUMN carries the
+// identity and scope_id is empty — the same asymmetry P4b settled for Memory
+// against SQL Memory, which needs a non-empty id because it becomes a schema name.
+//
+// So this asserts the behaviour the deliverable asked for, in the only way that
+// distinguishes "works" from "loads": two DIFFERENT users of one tenant must read
+// the SAME block.
+func TestCoreBlock_TenantScopeIsSharedAcrossUsers(t *testing.T) {
+	s, mi := ontologyFixture(t)
+	ctx := context.Background()
+
+	// Seed the block the way an operator would: out-of-band, at tenant scope with
+	// the k/v plane's empty scope_id.
+	val, _ := json.Marshal("Deploys go through staging. Never push to main.")
+	if err := s.store.MemorySet(ctx, mi.Tenant, store.MemoryScopeTenant, "",
+		meminject.CoreBlockKeyPrefix+"conventions", val, 0); err != nil {
+		t.Fatalf("seed tenant core block: %v", err)
+	}
+
+	def := config.AgentDef{
+		SystemPrompt: "You are an agent.\n\n{{memory:core_blocks}}",
+		CoreBlocks: []config.CoreBlock{
+			{Label: "conventions", Scope: "tenant", ReadOnly: true},
+		},
+	}
+
+	// alice reads it...
+	got, _ := s.applyMemoryInjection(ctx, def, mi)
+	if !strings.Contains(got.SystemPrompt, "Never push to main") {
+		t.Fatalf("the tenant core block never reached alice's prompt:\n%s", got.SystemPrompt)
+	}
+
+	// ...and so does bob, from the same tenant. This is the assertion that a
+	// per-user scope_id would fail: the block would fork one copy per person and an
+	// operator editing "the" block would fix it for exactly one of them.
+	other := mi
+	other.UserID = "bob"
+	gotBob, _ := s.applyMemoryInjection(ctx, def, other)
+	if !strings.Contains(gotBob.SystemPrompt, "Never push to main") {
+		t.Errorf("a second user of the same tenant did not read the block — it forked per user:\n%s", gotBob.SystemPrompt)
+	}
+}
+
+// TestCoreBlock_TenantScopeIsTenantIsolated: shared across the tenant is the point;
+// shared across TENANTS would be a cross-tenant leak of operator config. The
+// tenant_id column is what separates them, so this is the assertion that it is
+// actually being used rather than incidentally empty.
+func TestCoreBlock_TenantScopeIsTenantIsolated(t *testing.T) {
+	s, mi := ontologyFixture(t)
+	ctx := context.Background()
+
+	val, _ := json.Marshal("acme-only convention")
+	if err := s.store.MemorySet(ctx, mi.Tenant, store.MemoryScopeTenant, "",
+		meminject.CoreBlockKeyPrefix+"conventions", val, 0); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	def := config.AgentDef{
+		SystemPrompt: "{{memory:core_blocks}}",
+		CoreBlocks:   []config.CoreBlock{{Label: "conventions", Scope: "tenant"}},
+	}
+	stranger := mi
+	stranger.Tenant = "other-tenant"
+
+	got, _ := s.applyMemoryInjection(ctx, def, stranger)
+	if strings.Contains(got.SystemPrompt, "acme-only convention") {
+		t.Errorf("another tenant read this tenant's core block — the tenant_id column is not isolating:\n%s", got.SystemPrompt)
+	}
+}
+
+// TestCoreBlock_TenantScopeIDIsEmptyByConvention pins the mapping itself, because
+// it is the piece most likely to be "fixed" by a future reader who sees "" and
+// assumes it is a stub.
+//
+// SQL Memory refuses an empty scope id (it becomes half a schema name and a
+// database role); the k/v plane requires it for tenant, because tenant_id already
+// carries the identity there. Two planes, two conventions, both correct — the
+// asymmetry that produced the invisible-dirent bug when one leaked into the other.
+func TestCoreBlock_TenantScopeIDIsEmptyByConvention(t *testing.T) {
+	mi := memInject{Tenant: "acme", UserID: "alice", AgentName: "curator"}
+	cases := []struct {
+		scope  string
+		wantID string
+		wantOK bool
+		why    string
+	}{
+		{"agent", "curator", true, "the agent name locates the block"},
+		{"user", "alice", true, "the user id locates the block"},
+		{"tenant", "", true, "EMPTY BY CONVENTION and resolvable — tenant_id carries the identity"},
+		{"nonsense", "", false, "an unknown scope is not resolvable"},
+	}
+	for _, c := range cases {
+		gotID, gotOK := coreBlockScopeID(c.scope, mi)
+		if gotID != c.wantID || gotOK != c.wantOK {
+			t.Errorf("coreBlockScopeID(%q) = (%q, %v), want (%q, %v) — %s",
+				c.scope, gotID, gotOK, c.wantID, c.wantOK, c.why)
+		}
+	}
+
+	// The identity being MISSING is a different thing from tenant's empty id, and
+	// must still be unresolvable — otherwise an agent-scope block on a run with no
+	// agent name would read whatever sits at scope_id "".
+	empty := memInject{Tenant: "acme"}
+	for _, scope := range []string{"agent", "user"} {
+		if _, ok := coreBlockScopeID(scope, empty); ok {
+			t.Errorf("%s scope with no identity must be unresolvable, not a read at scope_id \"\"", scope)
+		}
+	}
+}
+
+// TestCoreBlock_TenantWriteStillNeedsTheGrant is the safety half, and the reason a
+// tenant core block is not simply "a user block with a wider audience".
+//
+// Everything written here is read by every other agent and user in the tenant — the
+// poisoning surface tenant scope was made default-deny for. READING one is safe
+// (the operator authored it, and the render path is a server-side read). WRITING
+// one must still pass the same `memory_scopes: [tenant]` gate every other tenant
+// memory write does, and the rendering fix must not have opened a back door.
+//
+// Asserted against the Memory TOOL, which is where the gate lives — not against the
+// injector, which has no say in it.
+func TestCoreBlock_TenantWriteStillNeedsTheGrant(t *testing.T) {
+	s, mi := ontologyFixture(t)
+	mem := &builtin.Memory{Store: s.store}
+
+	write, _ := json.Marshal(map[string]any{
+		"op": "set", "scope": "tenant",
+		"key": meminject.CoreBlockKeyPrefix + "conventions", "value": "injected",
+	})
+
+	// No tenant grant: the fixture's agent declares none.
+	ctx := tools.WithRunIdentity(context.Background(),
+		tools.RunIdentityValue{UserID: mi.UserID, TenantID: mi.Tenant})
+	res, err := mem.Execute(ctx, write)
+	if err == nil && !res.IsError {
+		t.Fatal("an ungranted agent wrote a TENANT core block — every agent in the tenant reads that")
+	}
+
+	// With the grant it succeeds, so the refusal above is the gate and not some
+	// unrelated failure. A test that only proves "it errored" would pass against a
+	// typo in the op name.
+	granted := tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{
+		AllowedScopes: []string{"agent", "user", "tenant"},
+	})
+	if res, err := mem.Execute(granted, write); err != nil || res.IsError {
+		t.Errorf("the same write must succeed WITH the grant: %v %s", err, res.Text)
+	}
+}

--- a/internal/api/http/meminject.go
+++ b/internal/api/http/meminject.go
@@ -213,8 +213,8 @@ func (s *Server) renderCoreBlocks(ctx context.Context, mi memInject, blocks []co
 	}
 	var b strings.Builder
 	for _, blk := range blocks {
-		scopeID := coreBlockScopeID(blk.Scope, mi)
-		if scopeID == "" {
+		scopeID, ok := coreBlockScopeID(blk.Scope, mi)
+		if !ok {
 			continue
 		}
 		val, ok := s.readCoreBlock(ctx, mi.Tenant, blk.Scope, scopeID, blk.Label)
@@ -477,16 +477,34 @@ func (s *Server) readCoreBlock(ctx context.Context, tenant, scope, scopeID, labe
 	return renderMemoryValue(entry.Value), true
 }
 
-// coreBlockScopeID maps a block scope to its server-sourced scope_id. tenant
-// scope has no scope_id convention in P1 (the entity tier lands later) → "".
-func coreBlockScopeID(scope string, mi memInject) string {
+// coreBlockScopeID maps a block scope to its server-sourced scope_id, and reports
+// whether the block is RESOLVABLE at all.
+//
+// The second return is the whole point. An empty scope_id means two different
+// things depending on the scope, and collapsing them silently dropped every
+// tenant-scope block: for agent/user it means the identity is missing (no agent
+// name on the run, no user_id) and the block genuinely cannot be located; for
+// TENANT it is the correct value, because the k/v plane carries tenant identity in
+// the tenant_id COLUMN and leaves scope_id empty. SQL Memory is the opposite — it
+// refuses an empty scope id, since that string becomes half a schema name and a
+// database role — and that asymmetry is deliberate on both sides.
+//
+// So `tenant` was accepted by validCoreBlockScopes, mapped correctly here, and then
+// discarded by a caller that read "" as "unresolvable". The deliverable looked
+// unbuilt when it was one boolean away.
+func coreBlockScopeID(scope string, mi memInject) (string, bool) {
 	switch scope {
 	case "agent":
-		return mi.AgentName
+		return mi.AgentName, mi.AgentName != ""
 	case "user":
-		return mi.UserID
-	default: // tenant (P1) — not resolvable yet
-		return ""
+		return mi.UserID, mi.UserID != ""
+	case "tenant":
+		// Empty BY CONVENTION, and resolvable. Do not "fix" this to mi.Tenant:
+		// that is the SQL-Memory convention and would key these rows somewhere
+		// no reader looks.
+		return "", true
+	default:
+		return "", false
 	}
 }
 


### PR DESCRIPTION
**RFC BL P5, PR 5** — and it turned out to be an assessment rather than a build, which is why I said I'd look before writing code.

## Almost all of it already existed

`tenant` has been in `validCoreBlockScopes` since P1. `CoreBlock.Scope` documents `agent | user | tenant`. `coreBlockScopeID` mapped tenant to `""` — **which is correct**: in the k/v plane the `tenant_id` *column* carries identity and `scope_id` is empty. SQL Memory is the opposite and refuses an empty id, because there that string becomes half a schema name and a database login role.

Two planes, two conventions, both right. Same asymmetry P4b settled, and the same one whose leak made tenant documents invisible to the Path tree in v1.42.0.

Then `renderCoreBlocks` did this:

```go
scopeID := coreBlockScopeID(blk.Scope, mi)
if scopeID == "" { continue }
```

An empty scope_id means **two different things** and that collapsed them:

| scope | `""` means | correct action |
|---|---|---|
| agent / user | the identity is missing — no agent name, no `user_id` | skip, it can't be located |
| **tenant** | **the value** | **read it** |

So every tenant-scope core block validated at config load, mapped correctly, and was discarded before it was ever read. The deliverable looked unbuilt because its one caller read `""` as "unresolvable".

`coreBlockScopeID` now returns `(id, resolvable)`, with a do-not-"fix"-this note at the definition: keying tenant blocks on `mi.Tenant` would be the SQL-Memory convention and would put them where no reader looks.

## The safety half is asserted, not assumed

A tenant core block is **not** "a user block with a wider audience". Everything in it is read by every agent and user in the tenant — the poisoning surface tenant scope is default-deny for.

Reading one is a server-side read of operator content. **Writing** one still has to pass the same `memory_scopes: [tenant]` gate as any other tenant write, and the rendering fix must not have opened a back door. The test drives the Memory **tool**, where the gate actually lives, both without the grant (refused) and with it (succeeds) — a test that only proved "it errored" would pass against a typo in the op name.

I also caught myself shipping a **vacuous** version of that test first: a helper that returned `nil` unconditionally, so the assertion couldn't fail. Replaced before commit. That's the same shape as the P2 supersession invariant that passed under a hard delete.

## Tested

Four tests:
- **shared across two users of one tenant** — a per-user scope_id would fork the block one copy per person, and an operator editing "the" block would fix it for one of them
- **isolated across tenants** — shared within is the point, shared between would be a cross-tenant leak of operator config
- **the mapping**, including that a *missing* agent/user identity stays unresolvable (otherwise an agent-scope block on a run with no agent name would read whatever sits at `scope_id ""`)
- **the write gate**, both directions

**Fail-before verified:** restoring the `empty == unresolvable` guard drops the block before it reaches the prompt.

`gofmt` clean · full `go test ./...` green.

## P5 status

Done: **0**, **0b**, **2**, **1**, **3**, **4**, **5**, plus the baseline reseed.

Remaining: **6** GC reconciliation, **7** teach the eval to see `type`/`subject` (proposed — the graph keys off a pair no instrument measures), **0c** provenance lister, **0d** erasure op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)