### PR TITLE
test(store): derive SweepStaleRuns' cutoff from the rows, not the clock

### DIFF
--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -2824,12 +2824,47 @@ func testSweepStaleRuns(t *testing.T, s store.Store) {
 	terminalRun, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_terminal"})
 	_ = s.FinishRun(ctx, terminalRun.ID, store.RunCompleted, "end_turn", store.Usage{}, "")
 
-	// Cutoff: between the stale row's last activity and the fresh
-	// row's. 100ms-back keeps the stale + noHB rows clearly past the
-	// cutoff (200ms ago) while the fresh row (just heartbeated)
-	// stays clearly after it. 100ms margin survives -race scheduling
-	// slowdown.
-	cutoff := time.Now().Add(-100 * time.Millisecond)
+	// Cutoff: derived from the rows' RECORDED timestamps, not from the wall
+	// clock.
+	//
+	// This is the third time this assertion has flaked (PR #224, PR #232, and a
+	// -race run on PR #897), and the first two answers were to widen the margin —
+	// 30ms, then 100ms. That treats the symptom. The cause is that a
+	// `time.Now()`-relative cutoff measures the gap between the fresh row's
+	// heartbeat and THE MOMENT THIS LINE RUNS, so any scheduling stall in between
+	// (creating and finishing the terminal row, under -race, on a loaded runner)
+	// ages the fresh row past the cutoff and it gets swept. No constant fixes
+	// that: a big enough stall beats any margin, and a bigger margin just makes
+	// the flake rarer and slower to diagnose.
+	//
+	// The gap the test actually needs is between the rows themselves, and both
+	// endpoints are already persisted. Reading them back and splitting the
+	// difference makes the cutoff exact whatever the scheduler did — the sleep
+	// above still creates the gap, but nothing after the fresh heartbeat can
+	// close it.
+	staleRow, err := s.GetRunByAgentID(ctx, "a_stale")
+	if err != nil {
+		t.Fatalf("read back the stale row: %v", err)
+	}
+	noHBRow, err := s.GetRunByAgentID(ctx, "a_no_hb")
+	if err != nil {
+		t.Fatalf("read back the no-heartbeat row: %v", err)
+	}
+	freshRow, err := s.GetRunByAgentID(ctx, "a_fresh")
+	if err != nil {
+		t.Fatalf("read back the fresh row: %v", err)
+	}
+	// The sweeper compares last_heartbeat_at when a row has one and started_at
+	// when it does not, so the cutoff must clear BOTH of the doomed rows' clocks.
+	doomed := staleRow.LastHeartbeatAt
+	if noHBRow.StartedAt.After(doomed) {
+		doomed = noHBRow.StartedAt
+	}
+	if !freshRow.LastHeartbeatAt.After(doomed) {
+		t.Fatalf("fixture: the fresh row (%v) must be strictly newer than the doomed rows (%v) — the sleep above did not create a gap",
+			freshRow.LastHeartbeatAt, doomed)
+	}
+	cutoff := doomed.Add(freshRow.LastHeartbeatAt.Sub(doomed) / 2)
 
 	swept, err := s.SweepStaleRuns(ctx, cutoff)
 	if err != nil {


### PR DESCRIPTION
**Unblocks #897**, whose CI failed on this. One file, test-only, no production code.

## Third time, same assertion

`TestStoreContract/SweepStaleRuns` has now flaked on PR #224, PR #232, and a `-race` run on #897. The test's own comment records the first two fixes — margin 30ms → 100ms. Both treated the symptom.

```
SweepStaleRuns returned 3, want 2 (stale + noHB)
fresh row was swept: status="failed", want running
```

## Why widening the margin can't work

The cutoff was `time.Now().Add(-100 * time.Millisecond)`. That measures the gap between the fresh row's heartbeat and **the moment the cutoff line executes** — not the gap between the rows. Anything that stalls in between (creating and finishing the terminal row, under `-race`, on a loaded runner) ages the fresh row past the cutoff and it gets swept.

No constant fixes that. A large enough stall beats any margin, and a larger margin only makes the flake rarer and slower to diagnose — which is what the last two bumps bought.

## The fix

The gap the test needs is between the **rows**, and both endpoints are already persisted. Read them back, split the difference:

```go
doomed := staleRow.LastHeartbeatAt
if noHBRow.StartedAt.After(doomed) { doomed = noHBRow.StartedAt }
cutoff := doomed.Add(freshRow.LastHeartbeatAt.Sub(doomed) / 2)
```

Exact whatever the scheduler did. The 200ms sleep stays — it's what *creates* the gap — but nothing after the fresh heartbeat can close it.

Two details worth review:

- **The cutoff clears both doomed rows.** The sweeper compares `last_heartbeat_at` when a row has one and `started_at` when it doesn't, so taking only the stale row's heartbeat would leave the no-heartbeat row's clock unaccounted for.
- **A fixture guard fails loudly** if the sleep ever stops producing a gap, rather than letting the midpoint collapse onto a single instant and assert nothing. A time-based test that silently stops discriminating is worse than one that flakes.

## Reproduced before fixing

Injecting a 150ms sleep after the fresh heartbeat gives CI's failure **verbatim** on the old cutoff:

```
contract.go:2853: SweepStaleRuns returned 3, want 2 (stale + noHB)
```

and passes under the same stall with the new one.

Verified on **both** implementations of the contract: sqlite under `-race`, ×2 (391s), and postgres. `gofmt` clean.

## Note on #897

#897 (tenant core blocks) touches only `internal/api/http` and is unrelated to this failure. Once this merges it needs a re-run — I'd rather rebase it onto this than have it pass by luck on a retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)