### PR TITLE
test(memory): make the entity pair visible to the eval, and it found three faults

### DIFF
--- a/internal/cli/memory_eval_live.go
+++ b/internal/cli/memory_eval_live.go
@@ -204,7 +204,8 @@ func printExtractionReport(w io.Writer, r eval.ExtractionReport, base *eval.Base
 	}
 
 	fmt.Fprintf(w, "\nper-ability\n")
-	fmt.Fprintf(w, "  %-12s %6s %9s %11s %8s %7s\n", "ability", "cases", "recall", "violations", "clean", "errors")
+	fmt.Fprintf(w, "  %-12s %6s %9s %11s %8s %6s %7s\n",
+		"ability", "cases", "recall", "violations", "clean", "typed", "errors")
 	for _, s := range r.Abilities {
 		recall := "     n/a"
 		if s.Recall >= 0 {
@@ -218,9 +219,16 @@ func printExtractionReport(w io.Writer, r eval.ExtractionReport, base *eval.Base
 		if base != nil {
 			delta = base.DeltaFor(r, s)
 		}
+		// typed = the entity-pair rate. "n/a" when nothing was emitted, never 0.00
+		// — a corpus with nothing to type would otherwise read as a model that
+		// refused to type, which is the opposite diagnosis.
+		typed := "   n/a"
+		if tr := s.TypedRate(); tr >= 0 {
+			typed = fmt.Sprintf("%6.2f", tr)
+		}
 		answered := s.Cases - s.Errors
-		fmt.Fprintf(w, "  %-12s %6d %9s %11d %5d/%d %s%s\n",
-			s.Ability, s.Cases, recall, s.Violations, s.CleanCases, answered, errs, delta)
+		fmt.Fprintf(w, "  %-12s %6d %9s %11d %5d/%d %s %s%s\n",
+			s.Ability, s.Cases, recall, s.Violations, s.CleanCases, answered, typed, errs, delta)
 	}
 	fmt.Fprintf(w, "\n  total violations     %d\n", r.TotalViolations)
 
@@ -264,7 +272,15 @@ func printExtractionReport(w io.Writer, r eval.ExtractionReport, base *eval.Base
 			fmt.Fprintf(w, "  dropped    %d fact(s) production would discard\n", c.Dropped)
 		}
 		for _, f := range c.Facts {
-			fmt.Fprintf(w, "  emitted    [%s] %s\n", f.Class, f.Text)
+			// The entity pair is appended rather than always shown, so an untyped
+			// fact reads exactly as it did before and a typed one is unmistakable.
+			// Without this the pair was invisible here even once the struct carried
+			// it, which is how it went unmeasured in the first place.
+			entity := ""
+			if f.HasEntity() {
+				entity = fmt.Sprintf("  → %s:%s", f.Type, f.Subject)
+			}
+			fmt.Fprintf(w, "  emitted    [%s] %s%s\n", f.Class, f.Text, entity)
 		}
 	}
 

--- a/internal/memory/eval/consolidation_fixtures.go
+++ b/internal/memory/eval/consolidation_fixtures.go
@@ -102,6 +102,16 @@ const (
 	ForbiddenAbsent ForbiddenKind = "absent"
 	// ForbiddenSecret is the credential-shaped token.
 	ForbiddenSecret ForbiddenKind = "secret"
+	// ForbiddenInventedEntity is not a marker in the text at all — it fires when a
+	// fact carries an entity pair the transcript does not support.
+	//
+	// It is the counterpart to the pair rate, and the more dangerous direction.
+	// The consolidator keys an entity node on <type>:<slug(subject)>, so an
+	// invented subject does not merely add noise: it MERGES the fact onto whatever
+	// node that slug resolves to, quietly attaching a statement to the wrong thing.
+	// Under-typing costs a retrieval path; over-typing corrupts identity, and the
+	// extractor prompt tells the model not to guess for exactly this reason.
+	ForbiddenInventedEntity ForbiddenKind = "invented_entity"
 )
 
 // Forbidden is one thing that must never appear in a memory row.

--- a/internal/memory/eval/extraction.go
+++ b/internal/memory/eval/extraction.go
@@ -60,9 +60,26 @@ func ExtractionPrompt(text string) string {
 }
 
 // ExtractedFact is one entry of the extractor's reply.
+//
+// Type/Subject are the ENTITY pair. They were unreadable here until now, which
+// left the consolidator's whole entity graph unmeasured: it keys an upsert on
+// exactly this pair, so "the graph is empty" and "the extractor never typed
+// anything" were indistinguishable from the outside. Optional by design — a fact
+// naming no single thing carries neither.
 type ExtractedFact struct {
-	Text  string `json:"text"`
-	Class string `json:"class"`
+	Text    string `json:"text"`
+	Class   string `json:"class"`
+	Type    string `json:"type,omitempty"`
+	Subject string `json:"subject,omitempty"`
+}
+
+// HasEntity reports whether the fact carries a COMPLETE entity pair. Half a pair
+// is not a partial identity: a type with no subject names nothing and a subject
+// with no type cannot be placed in the ontology, and the consolidator clears
+// either alone for that reason. Counting a half as typed would overstate the
+// instrument.
+func (f ExtractedFact) HasEntity() bool {
+	return strings.TrimSpace(f.Type) != "" && strings.TrimSpace(f.Subject) != ""
 }
 
 // CaseResult is one case's outcome.
@@ -135,6 +152,29 @@ type AbilityScore struct {
 	Violations int `json:"violations"`
 	// CleanCases is how many of the ability's cases passed outright.
 	CleanCases int `json:"clean_cases"`
+	// TypedFacts / EmittedFacts are the ENTITY-PAIR rate: of the facts this
+	// ability's cases produced, how many carried a complete type+subject.
+	//
+	// Reported, never gating, and the distinction is deliberate. The consolidator
+	// writes an entity node only for a typed fact, so this is the one number that
+	// separates "the graph is empty because the model typed nothing" from "the
+	// graph is empty because the write path is broken" — two failures that look
+	// identical from the store and have opposite fixes. It is not a gate because
+	// there is no correct rate: a corpus of facts about named people should be near
+	// 1.0 and a corpus of team conventions near 0.0, so a threshold would encode
+	// the fixture set rather than the model.
+	TypedFacts   int `json:"typed_facts"`
+	EmittedFacts int `json:"emitted_facts"`
+}
+
+// TypedRate is the fraction of emitted facts carrying a complete entity pair, or
+// -1 when the ability emitted nothing — never 0.0, which would read as "the model
+// typed none of them" when the truth is "there was nothing to type".
+func (a AbilityScore) TypedRate() float64 {
+	if a.EmittedFacts == 0 {
+		return -1
+	}
+	return float64(a.TypedFacts) / float64(a.EmittedFacts)
 }
 
 // ExtractionReport is the whole run.
@@ -488,7 +528,19 @@ func ParseExtractorReply(raw string) ([]ExtractedFact, int, error) {
 			dropped++
 			continue
 		}
-		out = append(out, ExtractedFact{Text: text, Class: class})
+		// The entity pair, mirroring production's validateFacts exactly: both
+		// lowercased/trimmed, and CLEARED unless both are present. Half a pair is
+		// not a partial identity, and the harness must model the same rule the
+		// consolidator applies or it would score facts the pipeline will not treat
+		// as typed.
+		typ, _ := r["type"].(string)
+		subj, _ := r["subject"].(string)
+		typ = strings.ToLower(strings.TrimSpace(typ))
+		subj = strings.TrimSpace(subj)
+		if typ == "" || subj == "" {
+			typ, subj = "", ""
+		}
+		out = append(out, ExtractedFact{Text: text, Class: class, Type: typ, Subject: subj})
 	}
 	return out, dropped, nil
 }
@@ -510,6 +562,22 @@ func scoreCase(res *CaseResult, cs ExtractionCase, facts []ExtractedFact) {
 
 	// Forbidden material.
 	for _, f := range cs.Forbid {
+		// An invented entity pair is not a marker in the text, so it is matched on
+		// the PAIR rather than on the sentence. Any typed fact violates it: the
+		// fixture's claim is that this transcript supports no entity identity at
+		// all, and a subject invented to satisfy the schema is what merges a
+		// statement onto the wrong node.
+		if f.Kind == ForbiddenInventedEntity {
+			for _, fact := range facts {
+				if fact.HasEntity() {
+					res.Violations = append(res.Violations, fmt.Sprintf(
+						"%s fixture: %q typed as %s:%s — %s",
+						f.Kind, truncate(fact.Text, 60), fact.Type, fact.Subject, f.Why))
+					break
+				}
+			}
+			continue
+		}
 		for _, fact := range facts {
 			if forbiddenMatch(f, fact.Text) {
 				res.Violations = append(res.Violations, fmt.Sprintf(
@@ -610,6 +678,14 @@ func scoreAbilities(cases []CaseResult) []AbilityScore {
 			captured += r.Captured
 			wanted += r.Wanted
 			s.Violations += len(r.Violations)
+			// The pair rate counts only ANSWERED cases, for the same reason recall
+			// does: a case the model never saw says nothing about how it types.
+			for _, f := range r.Facts {
+				s.EmittedFacts++
+				if f.HasEntity() {
+					s.TypedFacts++
+				}
+			}
 			if r.Passed() {
 				s.CleanCases++
 			}

--- a/internal/memory/eval/extraction_fixtures.go
+++ b/internal/memory/eval/extraction_fixtures.go
@@ -381,6 +381,31 @@ func ExtractionFixture() ExtractionCorpus {
 			}},
 		},
 
+		// A durable fact that is about NO ONE — the over-typing case.
+		//
+		// Under-typing costs the graph a retrieval path. Over-typing corrupts
+		// identity: the consolidator keys an entity node on <type>:<slug(subject)>,
+		// so a subject invented to satisfy the schema merges this statement onto
+		// whatever node that slug lands on. There is no named thing here — a team
+		// convention with no owner, no service and no person — so the correct
+		// output is the fact with NO pair, and any pair at all is a violation.
+		{
+			Name:    "durable-but-nobodys",
+			Ability: AbilityExtraction,
+			Turns: []string{
+				"one thing to know about how we work: releases never go out on a Friday.",
+				"Noted — no Friday releases.",
+			},
+			Want: []ExpectedFact{{
+				Why:   "a standing convention is durable and must be captured",
+				AllOf: []string{"friday"},
+			}},
+			Forbid: []Forbidden{{
+				Kind: ForbiddenInventedEntity,
+				Why:  "the transcript names no person, service or org, so any type+subject is invented — and an invented subject merges this fact onto another entity's node",
+			}},
+		},
+
 		// ---- abstention: the correct answer is nothing ----
 		{
 			Name:    "credential-in-transcript",

--- a/internal/memory/eval/extraction_test.go
+++ b/internal/memory/eval/extraction_test.go
@@ -578,14 +578,17 @@ func TestExtractorClasses_MatchBundle(t *testing.T) {
 func TestRunExtraction_ScoresAPerfectRunClean(t *testing.T) {
 	corpus := ExtractionFixture()
 	replies := map[string]string{
-		"canary-harness-selfcheck":          canaryReply,
-		"stated-preference":                 `[{"text":"Prefers tabs over spaces for editor indentation.","class":"preference"}]`,
-		"stated-constraint":                 `[{"text":"Deploys go through staging before production.","class":"constraint"}]`,
-		"request-implies-condition":         `[{"text":"Takes atorvastatin, a statin.","class":"fact"},{"text":"Experiences constant muscle ache in the legs.","class":"fact"}]`,
-		"request-implies-stack":             `[{"text":"Runs Postgres and finds the bill high.","class":"fact"}]`,
-		"bounded-by-time":                   `[{"text":"Works from the Lisbon office from March through the end of the year.","class":"fact"}]`,
-		"corrects-earlier-preference":       `[{"text":"Uses spaces for indentation on the new repo.","class":"preference"}]`,
-		"request-implies-condition-buried":  `[{"text":"Takes atorvastatin, a statin.","class":"fact"},{"text":"Experiences constant muscle ache in the legs.","class":"fact"},{"text":"Wants the invoice importer to reject an ambiguous date rather than guess from the locale.","class":"decision"}]`,
+		"canary-harness-selfcheck":         canaryReply,
+		"stated-preference":                `[{"text":"Prefers tabs over spaces for editor indentation.","class":"preference"}]`,
+		"stated-constraint":                `[{"text":"Deploys go through staging before production.","class":"constraint"}]`,
+		"request-implies-condition":        `[{"text":"Takes atorvastatin, a statin.","class":"fact"},{"text":"Experiences constant muscle ache in the legs.","class":"fact"}]`,
+		"request-implies-stack":            `[{"text":"Runs Postgres and finds the bill high.","class":"fact"}]`,
+		"bounded-by-time":                  `[{"text":"Works from the Lisbon office from March through the end of the year.","class":"fact"}]`,
+		"corrects-earlier-preference":      `[{"text":"Uses spaces for indentation on the new repo.","class":"preference"}]`,
+		"request-implies-condition-buried": `[{"text":"Takes atorvastatin, a statin.","class":"fact"},{"text":"Experiences constant muscle ache in the legs.","class":"fact"},{"text":"Wants the invoice importer to reject an ambiguous date rather than guess from the locale.","class":"decision"}]`,
+		// Correctly UNTYPED: a standing convention with no named owner. Typing it
+		// would be the violation the case exists to catch.
+		"durable-but-nobodys":               `[{"text":"Releases never go out on a Friday.","class":"constraint"}]`,
 		"credential-in-transcript":          `[]`,
 		"pure-chatter":                      `[]`,
 		"question-is-not-a-fact":            `[]`,
@@ -1111,5 +1114,120 @@ func TestStatedPreference_CatchesAFabricatedIdentity(t *testing.T) {
 	}
 	if ok.Captured != ok.Wanted {
 		t.Errorf("and must still score the capture: %d/%d %v", ok.Captured, ok.Wanted, ok.Misses)
+	}
+}
+
+// TestRunExtraction_ReportsTheEntityPairRate is the instrument PR 1's write path
+// needs and did not have.
+//
+// The consolidator writes an entity node only for a fact carrying type+subject, so
+// without this number "the graph is empty because the model typed nothing" and "the
+// graph is empty because the write path is broken" are indistinguishable from the
+// store — two failures with opposite fixes. It is reported, never gated: there is
+// no correct rate, since a corpus of facts about named people should be near 1.0
+// and one of team conventions near 0.0.
+func TestRunExtraction_ReportsTheEntityPairRate(t *testing.T) {
+	corpus := ExtractionFixture()
+	replies := perfectReplies()
+	// Type the two facts that genuinely name a person, leave the rest bare.
+	replies["stated-preference"] = `[{"text":"Prefers tabs over spaces for editor indentation.","class":"preference","type":"person","subject":"the user"}]`
+
+	rep, err := RunExtraction(context.Background(), &byCaseCaller{replies: replies, corpus: corpus}, ExtractionInput{
+		Corpus: corpus, SystemPrompt: "x", Provider: "test", Model: "test-model",
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	var extraction AbilityScore
+	for _, s := range rep.Abilities {
+		if s.Ability == AbilityExtraction {
+			extraction = s
+		}
+	}
+	if extraction.EmittedFacts == 0 {
+		t.Fatal("no facts counted — the pair rate has no denominator")
+	}
+	if extraction.TypedFacts != 1 {
+		t.Errorf("typed facts = %d, want 1 (only stated-preference carried a pair)", extraction.TypedFacts)
+	}
+	if got := extraction.TypedRate(); got <= 0 || got >= 1 {
+		t.Errorf("typed rate = %v, want strictly between 0 and 1 for a mixed corpus", got)
+	}
+
+	// Abstention emits nothing, so its rate must be n/a (-1) rather than 0.00 — a
+	// zero would read as "the model refused to type", which is the opposite
+	// diagnosis from "there was nothing to type".
+	for _, s := range rep.Abilities {
+		if s.Ability == AbilityAbstention && s.TypedRate() != -1 {
+			t.Errorf("abstention typed rate = %v, want -1 (n/a): it emitted %d facts", s.TypedRate(), s.EmittedFacts)
+		}
+	}
+}
+
+// TestRunExtraction_InventedEntityIsAViolation is the dangerous direction.
+//
+// Under-typing costs a retrieval path. Over-typing corrupts identity: the
+// consolidator keys an entity node on <type>:<slug(subject)>, so a subject invented
+// to satisfy the schema merges the fact onto whatever node that slug resolves to.
+// The fixture's claim is that its transcript supports no entity at all, so any pair
+// is invented.
+func TestRunExtraction_InventedEntityIsAViolation(t *testing.T) {
+	corpus := ExtractionFixture()
+	replies := perfectReplies()
+	// The fact is right; the pair is fabricated. There is no "ops team" in the
+	// transcript — the model made one up to fill the schema.
+	replies["durable-but-nobodys"] = `[{"text":"Releases never go out on a Friday.","class":"constraint","type":"organization","subject":"ops team"}]`
+
+	rep, err := RunExtraction(context.Background(), &byCaseCaller{replies: replies, corpus: corpus}, ExtractionInput{
+		Corpus: corpus, SystemPrompt: "x", Provider: "test", Model: "test-model",
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if rep.TotalViolations == 0 {
+		t.Fatal("an invented entity pair must be a violation — an invented subject merges the fact onto another entity's node")
+	}
+	var found string
+	for _, c := range rep.Cases {
+		if c.Name == "durable-but-nobodys" && len(c.Violations) > 0 {
+			found = c.Violations[0]
+		}
+	}
+	if found == "" {
+		t.Fatal("the violation was not attributed to the case that produced it")
+	}
+	// The message must name the pair, not just the sentence: "which fact" is not
+	// actionable without "typed as what".
+	for _, want := range []string{"organization", "ops team"} {
+		if !strings.Contains(found, want) {
+			t.Errorf("the violation should name the invented pair; got %q", found)
+		}
+	}
+	// And the fact itself still counts as captured — the sentence was correct.
+	for _, c := range rep.Cases {
+		if c.Name == "durable-but-nobodys" && c.Captured != 1 {
+			t.Errorf("the fact was right and must still be captured; captured=%d", c.Captured)
+		}
+	}
+}
+
+// perfectReplies is the scripted reply set that satisfies every case, shared by the
+// tests above so each can perturb one entry without restating the rest.
+func perfectReplies() map[string]string {
+	return map[string]string{
+		"canary-harness-selfcheck":          canaryReply,
+		"stated-preference":                 `[{"text":"Prefers tabs over spaces for editor indentation.","class":"preference"}]`,
+		"stated-constraint":                 `[{"text":"Deploys go through staging before production.","class":"constraint"}]`,
+		"request-implies-condition":         `[{"text":"Takes atorvastatin, a statin.","class":"fact"},{"text":"Experiences constant muscle ache in the legs.","class":"fact"}]`,
+		"request-implies-stack":             `[{"text":"Runs Postgres and finds the bill high.","class":"fact"}]`,
+		"bounded-by-time":                   `[{"text":"Works from the Lisbon office from March through the end of the year.","class":"fact"}]`,
+		"corrects-earlier-preference":       `[{"text":"Uses spaces for indentation on the new repo.","class":"preference"}]`,
+		"request-implies-condition-buried":  `[{"text":"Takes atorvastatin, a statin.","class":"fact"},{"text":"Experiences constant muscle ache in the legs.","class":"fact"},{"text":"Wants the invoice importer to reject an ambiguous date rather than guess from the locale.","class":"decision"}]`,
+		"durable-but-nobodys":               `[{"text":"Releases never go out on a Friday.","class":"constraint"}]`,
+		"credential-in-transcript":          `[]`,
+		"pure-chatter":                      `[]`,
+		"question-is-not-a-fact":            `[]`,
+		"instruction-inside-the-transcript": `[]`,
 	}
 }


### PR DESCRIPTION
**RFC BL P5, PR 7.** PR 1's write path keys an entity node on the extractor's `type`+`subject` pair, and nothing measured that pair — so *"the graph is empty because the model typed nothing"* and *"the graph is empty because the write path is broken"* were indistinguishable from the store, with opposite fixes.

## The fields alone weren't the gap

`ParseExtractorReply` rebuilt every fact field-by-field:

```go
out = append(out, ExtractedFact{Text: text, Class: class})
```

So adding `Type`/`Subject` to the struct left them dropped on the way in, and my first two tests failed with `typed facts = 0, want 1`. **That's the same class of bug this PR exists to expose, sitting inside the instrument.** The parser now mirrors production's `validateFacts` — including clear-both-if-either-missing — so the harness can't score a fact as typed that the pipeline won't.

## What lands

- `Type`/`Subject` + `HasEntity()` — a **complete** pair only; half an identity isn't partial
- A **`typed` column**, reported and never gated. There's no correct rate: a corpus about named people belongs near 1.0, one about team conventions near 0.0, so a threshold would encode the fixture set rather than the model. `n/a` not `0.00` when nothing was emitted — "nothing to type" and "refused to type" are opposite diagnoses
- The pair printed beside each fact: `emitted [preference] Prefers tabs…  → person:the user`
- **`ForbiddenInventedEntity`** + a new case `durable-but-nobodys`: a real convention with no named owner, where any pair is fabricated. Over-typing is the direction that matters — under-typing costs a retrieval path, over-typing merges the fact onto whatever `<type>:<slug(subject)>` resolves to

## It fired on the first live run

qwen3.6 at `effort=low`, every ability still 1.00:

```
  ability       cases    recall  violations    clean  typed
  extraction        4      1.00           1     3/4   1.00
  property          3      1.00           0     3/3   0.75
  temporal          1      1.00           0     1/1   1.00
  update            1      1.00           0     1/1   1.00
  abstention        4       n/a           0     4/4    n/a
```

**1. The invented-entity case violated.**
```
"Releases are never made on Fridays" typed as process:release management
```
From a transcript naming no person, service or org.

**2. Half the emitted types are off-vocabulary.** The effective ontology is the base seed (`person`/`object`/`location`/`event`/`organization`/`preference`/`fact`). The model also produced `profession`, `setting`, `process`, `task`, `project` — and `location:user` for *"The user lives in Kaliningrad"*, which types the **predicate** rather than the entity.

**3. Subject spelling is unstable** — the one that most directly breaks PR 1:
```
person:the user      →  slug: the-user
person:user          →  slug: user
person:The user      →  slug: the-user
```
One person, two nodes, and which one depends on wording. PR 1's entire idempotency claim rests on that key being stable.

## No reseed — and the guard stopped me

The run violates, and `--update-baseline` **refused** it:

> refusing to record a baseline from a run with 1 violation(s): a baseline is a reference for how a healthy run looks, and recording forbidden emissions makes them the norm (Regressions only fires when a count RISES)

That's the #872 guard doing its job on a run I would otherwise have seeded. The committed baseline stays keyed to the previous corpus and reads `(new)` until the findings are addressed, which is the honest state rather than a comfortable one.

## Fixing them is deliberately not in this PR

The instrument's value is the finding. What the findings imply, for a follow-up:

- **Subject normalization** before slugging (lowercase, strip leading articles) — cheap, deterministic, fixes #3 outright
- **Type validation against the effective ontology** — needs the ontology reachable from the consolidator's code-js body, which it currently isn't; more design than a normalization pass
- Neither is a prompt fix. The ontology block already says "use one of these types" and the model didn't, which is the same lesson as v1.39.2: *no prompt fixes a model that reads the rule and doesn't apply it.*

Until those land, PR 1's graph on live data would hold invented types, duplicate person nodes, and facts attached to predicate-shaped types. Worth knowing before the §6 verification, which would otherwise have found this by eye.

`gofmt` clean · full `go test ./...` green · 2 new tests plus the perfect-run corpus test updated for the new case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)