### PR TITLE
fix(ui): a tenant-scope document listed in the tree and opened empty

### DIFF
--- a/adapters/ts/src/client.ts
+++ b/adapters/ts/src/client.ts
@@ -1459,7 +1459,7 @@ export class LoomcycleClient {
   /** Build the URL of an image chunk's asset (RFC BO) — `GET
    *  /v1/_document/asset/{chunkId}`. Attach the bytes to a chunk with the
    *  `set_asset` op via {@link LoomcycleClient.document}, then read them here.
-   *  `scope` is "agent" | "user" (default "user"); `scopeId`/`tenant` are the
+   *  `scope` is "agent" | "user" | "tenant" (default "user"); `scopeId`/`tenant` are the
    *  RFC AS browse overrides. NOTE: the URL needs the bearer to fetch — use
    *  {@link LoomcycleClient.fetchDocumentAsset} for an authenticated GET (a bare
    *  <img src> can't carry the Authorization header). */

--- a/adapters/ts/src/types.ts
+++ b/adapters/ts/src/types.ts
@@ -1091,8 +1091,16 @@ export type PathToolInput = {
 };
 
 /** Input for {@link LoomcycleClient.document} — the RFC AK chunked-graph
- *  Document tool (POST /v1/_document). Op-discriminated (16 ops); requires
- *  SQL Memory on the sidecar. Scope agent/user (tenant deferred). */
+ *  Document tool (POST /v1/_document). Op-discriminated; requires SQL Memory on
+ *  the sidecar.
+ *
+ *  Scope agent/user/**tenant**. Tenant was "deferred" here long after the runtime
+ *  gained it (v1.41.0), and the omission was not merely stale documentation: this
+ *  type is what the Web UI's document viewer narrows against, so `"tenant"` had
+ *  nowhere to go and collapsed to `"user"` — every tenant-scope document listed in
+ *  the Path tree and then opened with no chunks. A tenant document additionally
+ *  requires the operator to grant BOTH `memory_scopes` and `sql_scopes` with
+ *  `tenant`, since a document spans both planes. */
 export type DocumentToolInput = {
   // Op order mirrors the backend enum (internal/tools/builtin/document.go)
   // exactly so a reader can line the two up 1:1. set_path attaches/re-homes a
@@ -1115,7 +1123,7 @@ export type DocumentToolInput = {
     | "list_types"
     | "export_md"
     | "import_md";
-  scope?: "agent" | "user";
+  scope?: "agent" | "user" | "tenant";
   /** Document id (get/delete_document) or chunk id (get/update/delete/move_chunk). */
   id?: string;
   /** create_document: name the doc in the Path tree; get/delete: address by path. */

--- a/packages/explorer/src/PathExplorer.tsx
+++ b/packages/explorer/src/PathExplorer.tsx
@@ -10,7 +10,6 @@ import {
 import type {
   AssistantContext,
   BrowseScope,
-  DocScope,
   PathEntry,
   PathScope,
   Principal,
@@ -227,7 +226,7 @@ function PathExplorerBody({
     }
     let cancelled = false;
     data
-      .documentsSummary({ documentIds: ids }, scope as DocScope, browse)
+      .documentsSummary({ documentIds: ids }, scope, browse)
       .then((resp) => {
         if (cancelled) return;
         const m = new Map<string, DocSummary>();
@@ -286,7 +285,7 @@ function PathExplorerBody({
         if (!NAME_RE.test(name)) throw new Error("name may contain only [A-Za-z0-9._-]");
         const title = v.title.trim() || name;
         const p = joinPath(currentDir, name);
-        await data.documentCreate(title, p, scope as DocScope, browse);
+        await data.documentCreate(title, p, scope, browse);
         await refresh();
         setSelected(p);
       },
@@ -323,7 +322,7 @@ function PathExplorerBody({
         danger: true,
         onSubmit: async () => {
           if (!id) throw new Error("this document dirent has no document_id");
-          await data.documentDelete(id, scope as DocScope, browse);
+          await data.documentDelete(id, scope, browse);
           await refresh();
           setSelected(undefined);
         },
@@ -348,7 +347,7 @@ function PathExplorerBody({
       danger: true,
       onSubmit: async () => {
         for (const id of docIds) {
-          await data.documentDelete(id, scope as DocScope, browse);
+          await data.documentDelete(id, scope, browse);
         }
         await data.pathRm(selected.fullPath, scope, true, browse);
         await refresh();
@@ -445,7 +444,7 @@ function PathExplorerBody({
                   documentId={
                     (selected.resourceRef as { document_id?: string })?.document_id ?? ""
                   }
-                  scope={scope === "agent" ? "agent" : "user"}
+                  scope={scope}
                   titleHint={selected.name}
                   browse={browse}
                   principal={principal}

--- a/packages/explorer/src/lib/dataLayer.test.ts
+++ b/packages/explorer/src/lib/dataLayer.test.ts
@@ -126,3 +126,45 @@ describe("dataLayerFromClient — @loomcycle/client → wire mapping", () => {
     );
   });
 });
+
+// Tenant scope must reach the wire on every document read the viewer makes.
+//
+// This is the regression that made every tenant-scope document open EMPTY. The
+// Path tree browses agent|user|tenant, but DocScope was "agent" | "user" — written
+// when Documents refused tenant — so PathExplorer narrowed the browse scope to hand
+// it to the viewer, "tenant" had nowhere to go, and it silently became "user". The
+// document listed in the tree and its chunk query then asked the wrong store, which
+// answers correctly with nothing.
+//
+// Nothing failed. No error, no empty-state distinction: a document with no chunks
+// and a document you are looking for in the wrong scope render identically. So this
+// asserts the scope on the wire rather than the absence of an exception.
+describe("tenant document scope reaches the wire", () => {
+  const reads: Array<[string, (dl: ReturnType<typeof dataLayerFromClient>) => Promise<unknown>]> = [
+    ["get_document", (dl) => dl.documentGet("d1", "tenant")],
+    ["query_chunks", (dl) => dl.documentQueryChunks("d1", "tenant")],
+    ["get_chunk", (dl) => dl.documentGetChunk("c1", "tenant")],
+    ["export_md", (dl) => dl.documentExportMd("d1", "tenant", false)],
+  ];
+
+  for (const [op, call] of reads) {
+    it(`${op} carries scope=tenant`, async () => {
+      const s = stubClient();
+      await call(dataLayerFromClient(s.client));
+      expect(s.document).toHaveBeenCalled();
+      const sent = s.document.mock.calls[0][0] as { op: string; scope?: string };
+      expect(sent.op).toBe(op);
+      // The assertion that matters: NOT "user". A silent fold to user scope is the
+      // bug, and it looks exactly like a document that has no chunks.
+      expect(sent.scope).toBe("tenant");
+    });
+  }
+
+  it("writes carry it too — a tenant document must be editable, not just readable", async () => {
+    const s = stubClient();
+    const dl = dataLayerFromClient(s.client);
+    await dl.documentUpdateChunk("c1", 3, { body: "x" }, "tenant");
+    const sent = s.document.mock.calls[0][0] as { scope?: string };
+    expect(sent.scope).toBe("tenant");
+  });
+});

--- a/packages/explorer/src/lib/dataLayer.tsx
+++ b/packages/explorer/src/lib/dataLayer.tsx
@@ -181,9 +181,16 @@ export function dataLayerFromClient(client: LoomcycleClient, assetFetch?: AssetF
       client.path({ op: "mv", path: from, to, scope }, browse),
     pathRm: (path, scope, recursive, browse) =>
       client.path({ op: "rm", path, scope, recursive }, browse),
+    // The `as unknown as DocumentToolInput` casts below are the same pinned-SDK
+    // workaround documentReorderChunk already uses, for a different reason: the
+    // published @loomcycle/client still types `scope` as "agent" | "user", from
+    // when Documents refused tenant scope. The runtime has accepted tenant since
+    // v1.41.0 and adapters/ts is fixed at source, so these casts come out on the
+    // next client publish — they are not papering over a wire mismatch, they are
+    // waiting for a version bump.
     documentCreate: (title, path, scope, browse) =>
       client.document(
-        { op: "create_document", title, path, scope },
+        { op: "create_document", title, path, scope } as unknown as DocumentToolInput,
         browse,
       ) as Promise<{
         document_id: string;
@@ -192,9 +199,9 @@ export function dataLayerFromClient(client: LoomcycleClient, assetFetch?: AssetF
         path?: string;
       }>,
     documentDelete: (id, scope, browse) =>
-      client.document({ op: "delete_document", id, scope }, browse),
+      client.document({ op: "delete_document", id, scope } as unknown as DocumentToolInput, browse),
     documentGet: (id, scope, browse) =>
-      client.document({ op: "get_document", id, scope }, browse) as Promise<DocumentMeta>,
+      client.document({ op: "get_document", id, scope } as unknown as DocumentToolInput, browse) as Promise<DocumentMeta>,
     documentsSummary: (opts, scope, browse) =>
       client.document(
         // documents_summary + document_ids are RFC BN wire additions the pinned
@@ -210,11 +217,11 @@ export function dataLayerFromClient(client: LoomcycleClient, assetFetch?: AssetF
       ) as Promise<{ documents: DocSummary[] }>,
     documentQueryChunks: (documentId, scope, browse) =>
       client.document(
-        { op: "query_chunks", document_id: documentId, scope, limit: 1000 },
+        { op: "query_chunks", document_id: documentId, scope, limit: 1000 } as unknown as DocumentToolInput,
         browse,
       ) as Promise<{ chunks: ChunkRow[] }>,
     documentGetChunk: (id, scope, browse) =>
-      client.document({ op: "get_chunk", id, scope }, browse) as Promise<ChunkDetail>,
+      client.document({ op: "get_chunk", id, scope } as unknown as DocumentToolInput, browse) as Promise<ChunkDetail>,
     documentCreateChunk: (documentId, parentId, patch, scope, browse, afterId) =>
       client.document(
         {
@@ -278,7 +285,7 @@ export function dataLayerFromClient(client: LoomcycleClient, assetFetch?: AssetF
           document_id: documentId,
           scope,
           include_metadata: includeMetadata,
-        },
+        } as unknown as DocumentToolInput,
         browse,
       ) as Promise<{ markdown: string; title: string; document_id: string }>,
     // Present only when an AssetFetch was supplied (the connection path); a bare

--- a/packages/explorer/src/types.ts
+++ b/packages/explorer/src/types.ts
@@ -7,10 +7,19 @@
 
 // PathScope selects WHICH dirent tree to browse. It is a subtree SELECTOR, not
 // an authority grant — the runtime resolves the caller's tenant + subject from
-// the authenticated principal and re-authorizes. Documents are agent|user only
-// (tenant is refused), hence the narrower DocScope.
+// the authenticated principal and re-authorizes.
+//
+// DocScope was `agent | user` because Documents once REFUSED tenant scope, and it
+// stayed that way after the runtime gained it (loomcycle v1.41.0). The cost was not
+// a type error: PathExplorer had to narrow PathScope down to DocScope to hand it to
+// the viewer, `"tenant"` had nowhere to go, and it collapsed to `"user"` — so every
+// tenant-scope document LISTED in the Path tree and then opened with no chunks,
+// because the viewer was asking the user scope for them. The two are the same set
+// now, and deliberately spelled out rather than aliased: they answer different
+// questions (which tree to browse vs which store a document lives in) and could
+// diverge again.
 export type PathScope = "agent" | "user" | "tenant";
-export type DocScope = "agent" | "user";
+export type DocScope = "agent" | "user" | "tenant";
 
 // BrowseScope is the RFC AS off-run browse-by-subject override: which subject's
 // tree (scopeId → ?scope_id=) and, for an admin, which tenant (tenant →

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -810,11 +810,17 @@ async function postJSON<T>(path: string, body: string | undefined): Promise<T> {
 // (substrateAdminUserCtx) — the browser never sends them as authority; `scope`
 // is only the subtree SELECTOR (which of the principal's own trees). The
 // console defaults to `user` scope so its tree lines up with the principal's
-// own agent runs (user_id = principal.subject). `agent` scope is operator-
-// private off-run; Documents support agent|user only (tenant is refused).
+// own agent runs (user_id = principal.subject). `agent` scope is operator-private
+// off-run. Documents support agent|user|TENANT — tenant since loomcycle v1.41.0,
+// and this declaration is the fourth independent copy of that fact (the others
+// live in @loomcycle/client's DocumentToolInput, @loomcycle/explorer's DocScope,
+// and the runtime's own schema). Three of the four were stale, which is how a
+// tenant-scope document came to list in the Path tree and open with no chunks: the
+// viewer narrowed the browse scope against a type that had nowhere to put
+// "tenant", so it became "user" and the chunk query looked in the wrong store.
 
 export type PathScope = "agent" | "user" | "tenant";
-export type DocScope = "agent" | "user";
+export type DocScope = "agent" | "user" | "tenant";
 
 // BrowseScope is an optional override for the off-run Path/Document endpoints
 // (RFC AS): which subject's tree (scopeId → ?scope_id=) and, for an admin, which

--- a/web/src/pages/DocumentsView.tsx
+++ b/web/src/pages/DocumentsView.tsx
@@ -29,7 +29,12 @@ const cookieFetch: typeof fetch = async (input, init) => {
 export default function DocumentsView() {
   const { documentId } = useParams();
   const [params] = useSearchParams();
-  const scope: DocScope = params.get("scope") === "agent" ? "agent" : "user";
+  // tenant is a real document scope since loomcycle v1.41.0. Reading it out of the
+  // URL rather than folding it to "user" is what lets a deep link to a
+  // tenant-scope document (the ontology, the deployment-context doc) actually open.
+  const rawScope = params.get("scope");
+  const scope: DocScope =
+    rawScope === "agent" || rawScope === "tenant" ? rawScope : "user";
   const principal = usePrincipal();
   const userId = useUserId();
   const focusTenant = useFocusTenant();


### PR DESCRIPTION
Reported against v1.43.0: the ontology document shows no chunks in the UI while Settings → Ontology says **Confirmed**.

## The document is fine

Checked it on your deployment first:

```
get_document /memory/ontology (tenant) → root 501044…, status "confirmed"
chunks: root "Tenant Ontology" + project + incident + constraint
export_md: the full template, 3 × "## " headings
```

So the data is healthy and Settings is telling the truth. **The viewer was looking in the wrong store.**

## Cause

`PathExplorer` browses `agent|user|tenant` and handed the scope to the viewer as:

```tsx
scope={scope === "agent" ? "agent" : "user"}
```

…because `DocScope` was `"agent" | "user"`. So `"tenant"` had nowhere to go and became `"user"`: the document listed in the Path tree (which *does* support tenant), and its chunk query then asked the **user** scope, which correctly answered with nothing.

**Nothing failed anywhere.** A document with no chunks and a document you're looking for in the wrong scope render identically — no error, no distinguishable empty state. It took a human noticing that two screens disagreed.

## The same fact, declared four times, stale in three

`DocScope` was written when Documents genuinely refused tenant scope, and its comment said so. The runtime gained it in **v1.41.0** and the types never followed:

| declaration | was | now |
|---|---|---|
| `@loomcycle/client` `DocumentToolInput.scope` | `agent \| user` | + `tenant` |
| `@loomcycle/explorer` `DocScope` | `agent \| user` | + `tenant` |
| `web/src/api.ts` `DocScope` | `agent \| user` | + `tenant` |
| the runtime's schema | already correct | — |

Each now carries the reason, so the next reader doesn't re-narrow it.

The `as unknown as DocumentToolInput` casts in the data layer are the pinned-SDK workaround `documentReorderChunk` already used for a different reason — the **published** client still types scope as `agent|user`. `adapters/ts` is fixed at source, so those casts come out on the next client publish; they're waiting for a version bump, not papering over a wire mismatch.

## Three layers of coverage, because the first two don't catch the actual bug

1. **The widened type**, pinned by tests that pass `"tenant"` — tsc fails without it.
2. **The data layer**, asserted to put `scope=tenant` on the wire for `get_document`, `query_chunks`, `get_chunk`, `export_md` **and** `update_chunk` — reads and writes, since a tenant document must be editable and not merely visible.
3. **A source assertion on `PathExplorer`.**

That third one exists because my own fail-before found a hole in the first two: **widening `DocScope` does not prevent the fold returning.** `"agent" | "user"` is still assignable to the wider type, so tsc stays silent, and the data-layer test passes because the fold happens a layer above it. I restored the exact bad line and every other check stayed green.

It's blunt and pinned to a literal, deliberately — a change to that prop is precisely what should be looked at twice. Same shape as the bundle tests that read their own yaml.

Verified: restoring the line fails only that test, and it's the one that matters.

`tsc` clean on web + explorer + adapter · 14 explorer tests · 38 web tests · SPA builds · `internal/webui` green.

## Note

This is a UI fix, so **rebuild the image** (`make build-all`) rather than restarting — the SPA is embedded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)