### PR TITLE
fix(deploy): bump the sandbox sidecar pin so expose works + multi-arch build guidance

### DIFF
--- a/cloud-deployment/INSTALL.md
+++ b/cloud-deployment/INSTALL.md
@@ -184,9 +184,22 @@ Notes:
   dedicated `loom-dev` bridge network with pinchtab attached and
   `SANDBOX_EXPOSE_NETWORK=loom-dev` on the builder-sidecar. A `dev/exec` envelope
   with `expose:<alias>` then attaches its session there, reachable from the browser
-  at `http://<alias>:<port>`. Add each alias to PinchTab's IDPI allowlist first
+  at `http://<alias>:<port>`. This needs the **runtime AND sidecar at ≥ 1.43.0** (the
+  expose seam) — the images pin to `1.43.0` above; the sidecar is a separate,
+  multi-arch image (`docker pull` a `linux/amd64` tag on TrueNAS, not a hand-built
+  single-arch one). Add each alias to PinchTab's IDPI allowlist first
   (`pinchtab config set security.allowedDomains "127.0.0.1,localhost,::1,<alias>"`,
   then restart the sidecar) — see [`../docs/SANDBOX.md`](../docs/SANDBOX.md).
+- **PinchTab allowlist — persistence & declarative option:** `pinchtab config set`
+  writes to `/data/.config/pinchtab/config.json`, which is the `./pinchtab-data`
+  bind mount, so **the allowlist already survives restarts and reboots** (the "restart
+  to apply" only reloads the running server). To manage it declaratively instead —
+  version-controlled, no manual `config set` on a fresh volume — copy
+  `pinchtab-config.json.example` to `pinchtab-config.json`, then uncomment
+  `PINCHTAB_CONFIG` + the read-only config mount in the `pinchtab` service. There is
+  **no env var for `allowedDomains`** (pinchtab exposes only `PINCHTAB_CONFIG`,
+  `PINCHTAB_TOKEN`, `PINCHTAB_RATE_LIMIT_MAX`); the token stays in the env var while
+  the mounted file carries only the non-secret allowlist.
 
 ---
 

--- a/cloud-deployment/docker-compose.yaml
+++ b/cloud-deployment/docker-compose.yaml
@@ -63,7 +63,7 @@ services:
 
   # ── One-shot schema migration for the MAIN db (SQL Memory self-provisions at runtime) ──
   loomcycle-migrate:
-    image: denngubsky/loomcycle:1.38.0
+    image: denngubsky/loomcycle:1.43.0
     command: ["migrate", "up"]
     restart: "no"
     user: "65532:65532"
@@ -107,8 +107,13 @@ services:
     #   - "127.0.0.1:8787:8787"
 
   # ── Code-execution sandbox sidecar (host-Docker-socket model) ──
+  # The sidecar is a SEPARATE image from the runtime, lockstep-versioned with it and
+  # published MULTI-ARCH (amd64+arm64) by the `publish-sandbox-images` workflow on each
+  # release tag. Session exposure (SANDBOX_EXPOSE_NETWORK, below) needs the seam that
+  # shipped in 1.43.0 — keep this pin in step with the runtime tag, and never hand-push
+  # a single-arch build over the tag (a linux/amd64 host then can't pull it).
   builder-sidecar:
-    image: denngubsky/loomcycle-builder-docker:1.25.2
+    image: denngubsky/loomcycle-builder-docker:1.43.0
     restart: unless-stopped
     networks: [loomnet]
     environment:
@@ -144,7 +149,7 @@ services:
       context: .
       dockerfile: loomcycle.Dockerfile
       args:
-        LOOMCYCLE_TAG: "1.38.0"
+        LOOMCYCLE_TAG: "1.43.0"
         PINCHTAB_TAG: "0.15.0"
     restart: unless-stopped
     user: "65532:65532"
@@ -223,8 +228,15 @@ services:
     networks: [loomnet, loom-dev]
     environment:
       PINCHTAB_TOKEN: ${PINCHTAB_TOKEN}   # SAME secret loomcycle presents on the MCP bridge
+      # `pinchtab config set` persists to ./pinchtab-data (below), so the allowlist
+      # ALREADY survives restarts + reboots. To manage it DECLARATIVELY instead (one
+      # version-controlled file, no manual `config set`), uncomment PINCHTAB_CONFIG +
+      # the read-only mount below and edit pinchtab-config.json (see pinchtab-config.json.example).
+      # The token stays in the env var — the file carries only non-secret settings.
+      # PINCHTAB_CONFIG: /etc/pinchtab/config.json
     volumes:
       - ./pinchtab-data:/data             # HOME/config + Chrome profile (rootfs is read-only)
+      # - ./pinchtab-config.json:/etc/pinchtab/config.json:ro   # declarative allowlist (with PINCHTAB_CONFIG)
     shm_size: "2gb"                       # Chrome stability
     read_only: true
     tmpfs:

--- a/cloud-deployment/pinchtab-config.json.example
+++ b/cloud-deployment/pinchtab-config.json.example
@@ -1,0 +1,5 @@
+{
+  "security": {
+    "allowedDomains": ["127.0.0.1", "localhost", "::1", "devsrv"]
+  }
+}

--- a/deploy/builder/INSTALL.md
+++ b/deploy/builder/INSTALL.md
@@ -52,23 +52,34 @@ in [§ Alternative: nested podman](#alternative-nested-rootless-podman).
 
 ## Phase 1 — Build + push the two images
 
+The release CI (`publish-sandbox-images` workflow) already builds these **multi-arch**
+(amd64+arm64) on every `v*` tag, so normally you just pull the published tag. Build by
+hand only for a private namespace or an unreleased change — and when you do, **use
+`buildx --platform … --push`, not plain `docker build`**: a plain build bakes only your
+host arch, so an image built on Apple Silicon is arm64-only and a linux/amd64 host
+(e.g. TrueNAS) then fails with `no matching manifest for linux/amd64`. Never hand-push
+a single-arch build over a tag the CI publishes multi-arch.
+
 Two images are involved: the **sidecar** (runs the MCP server + drives the engine)
 and the **session** image (the toolchain each sandbox runs). From a checkout of
-this repo on your Docker box:
+this repo on your Docker box (`docker buildx create --use --bootstrap` once if you
+have no multi-arch builder):
 
 ```sh
-VER=1.23.1     # match your loomcycle version, or any tag you like
+VER=1.43.0     # match your loomcycle release tag
 
 # 1) the sidecar — host-Docker-socket variant (Dockerfile.docker)
-docker build -t denngubsky/loomcycle-builder-docker:$VER \
-  -f deploy/builder/Dockerfile.docker --build-arg VERSION=$VER deploy/builder
-docker push denngubsky/loomcycle-builder-docker:$VER
+docker buildx build --platform linux/amd64,linux/arm64 \
+  -t denngubsky/loomcycle-builder-docker:$VER \
+  -f deploy/builder/Dockerfile.docker --build-arg VERSION=$VER --push deploy/builder
 
 # 2) the session toolchain image (python/go/rust/c++/node, uid 1000)
-docker build -t denngubsky/loomcycle-sandbox-session:$VER deploy/builder/session
-docker push denngubsky/loomcycle-sandbox-session:$VER
+docker buildx build --platform linux/amd64,linux/arm64 \
+  -t denngubsky/loomcycle-sandbox-session:$VER --push deploy/builder/session
 ```
 
+- Multi-arch requires `--push` (buildx cannot `--load` a multi-platform image locally);
+  amd64 builds under QEMU emulation on an arm64 host, which is slower but works.
 - Replace `denngubsky/…` with your own registry namespace if not using Docker Hub.
 - The **session image is pulled by the host Docker** (it runs the siblings), so it
   must be reachable from TrueNAS. If your registry is private, `docker login` on the


### PR DESCRIPTION
## Why

Follow-up to #891 (RFC BR session exposure). That PR set `SANDBOX_EXPOSE_NETWORK=loom-dev` on the builder-sidecar but left the sidecar image pinned at **`1.25.2`** — a tag that *predates the expose seam #891 added in the same PR*. The old sidecar silently drops the unknown `expose` field, opens a plain session **not** on `loom-dev`, and returns no `exposed_host`. Net effect: a serve-and-test run "succeeds" (server runs, local `curl` works) but the browser gets `could not resolve navigation host` because the `<alias>` was never attached to the network. Verified live against the deployed server — the tell is the missing `reachable at http://<alias>:<port>` line.

The whole loomcycle family in this reference compose had also drifted (runtime + migrate at `1.38.0`), so the runtime lacked the `dev/exec` expose bundle too — expose was unusable end-to-end here regardless of the sidecar.

Separately surfaced while deploying: a hand-built sidecar image on Apple Silicon is **arm64-only**, so a `linux/amd64` host (TrueNAS) fails to pull it (`no matching manifest for linux/amd64`). The INSTALL build commands used plain `docker build`, which bakes only the host arch.

## What

- **Pin the sidecar, runtime, and migrate images to `1.43.0`** (the release carrying the expose seam). They're lockstep-versioned; a compose comment records that and warns against hand-pushing a single-arch build over the tag.
- **`deploy/builder/INSTALL.md`**: manual build commands now use `docker buildx build --platform linux/amd64,linux/arm64 --push` instead of plain `docker build`, with a note that the CI `publish-sandbox-images` workflow already builds these multi-arch on each `v*` tag (so normally you just pull).
- **PinchTab allowlist persistence** (operator question): documented that `pinchtab config set` writes to `/data/.config/pinchtab/config.json` — the `./pinchtab-data` bind mount — so **the allowlist already survives reboots**. Added an opt-in *declarative* alternative: a commented `PINCHTAB_CONFIG` env + read-only config mount, plus **`pinchtab-config.json.example`**, so the allowlist can be version-controlled. There is no env var for `allowedDomains`; the token stays in `PINCHTAB_TOKEN`.

## Operator note (not blocking this PR)

The published `loomcycle-builder-docker:1.43.0` tag was accidentally overwritten with an arm64-only manual push. To restore it multi-arch, re-run the CI workflow (`gh workflow run publish-sandbox-images.yml -f version=1.43.0`) or use the buildx command above. `loomcycle-builder-docker:1.43.1` is already published multi-arch as an immediate alternative.

## Tested

- `docker-compose.yaml` + `pinchtab-config.json.example` validated (YAML/JSON parse clean).
- Docker Hub tag/arch state confirmed via the registry API (runtime `1.43.0` multi-arch; builder `1.43.1` multi-arch).
- No runtime code change — documentation + compose pins only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD