### PR TITLE
feat(truenas): a browser + sandbox deploy variant for serve-and-test

### DIFF
--- a/deploy/truenas/INSTALL.md
+++ b/deploy/truenas/INSTALL.md
@@ -262,11 +262,70 @@ Bump the image tag → new binary → refreshed embedded presets automatically; 
 + overlay persist. If the new version bumped the Postgres schema, the
 `loomcycle-migrate` step re-runs `migrate up` on redeploy.
 
+## Browser + sandbox variant (serve-and-test)
+
+The walkthrough above is the lean, single-tenant toolbox posture. To instead let an
+agent **build a feature in an isolated sandbox, serve it, and test it in a headless
+browser** — all in one run — paste
+[`docker-compose.browser.yaml`](docker-compose.browser.yaml) in Phase 5 instead of the
+inline compose. It runs the distroless **`loomcycle-browser`** image and adds two
+sidecars (a code-execution `builder-sidecar` + a `pinchtab` browser) plus a dedicated
+`loom-dev` network, so a `dev/exec` envelope with `expose:<alias>` reaches its dev
+server from the browser at `http://<alias>:<port>`. It's a **stronger** isolation
+posture than the toolbox image — code runs in throwaway sandbox sessions, not in
+loomcycle's own container — with the sidecar as the one privileged component (host
+Docker socket). Background: [`../../docs/SANDBOX.md`](../../docs/SANDBOX.md).
+
+The deltas from the base install:
+
+1. **Datasets (Phase 2)** — add `pinchtab-data`, owned by **uid 1000** (PinchTab is not
+   the 65532 distroless user, and crash-loops on a root-owned `/data`):
+   ```sh
+   mkdir -p /mnt/APPS2/loomcycle/pinchtab-data
+   chown -R 1000:1000 /mnt/APPS2/loomcycle/pinchtab-data
+   ```
+2. **Overlay (Phase 3)** — copy
+   [`loomcycle.overlay.browser.example.yaml`](loomcycle.overlay.browser.example.yaml)
+   (not the plain one) to `config/loomcycle.yaml`; it declares the `mcp_servers.browser`
+   stdio bridge. The `sandbox` MCP server comes from the preset — nothing to add.
+3. **A second secret file (Phase 4)** — the sidecar and the Chromium container must
+   **not** see the PG DSN or provider keys, so the two sandbox-stack tokens live in
+   their own file:
+   ```sh
+   cat > /mnt/APPS2/loomcycle/config/sandbox.secrets.env <<'EOF'
+   SANDBOX_AUTH_TOKEN=CHANGE_ME   # openssl rand -hex 32
+   PINCHTAB_TOKEN=CHANGE_ME       # openssl rand -hex 32
+   EOF
+   chmod 600 /mnt/APPS2/loomcycle/config/sandbox.secrets.env
+   ```
+   loomcycle reads both `loomcycle.secrets.env` and `sandbox.secrets.env`; the sidecar
+   and pinchtab read only `sandbox.secrets.env`.
+4. **Host Docker socket** — the sidecar spawns sessions as host-Docker siblings, so it
+   bind-mounts `/var/run/docker.sock` (a privileged grant; keep the box trusted). The
+   `loom-dev` network is created automatically when the app comes up. The session image
+   `denngubsky/loomcycle-sandbox-session:1.43.1` is pulled by the **host** Docker on
+   first session (public — no login needed).
+5. **PinchTab allowlist** — PinchTab browses **local-only** until you widen its IDPI
+   allowlist; add each expose alias, then restart the sidecar:
+   ```sh
+   docker exec <pinchtab-container> \
+     pinchtab config set security.allowedDomains "127.0.0.1,localhost,::1,devsrv"
+   docker restart <pinchtab-container>
+   ```
+   The value persists in `pinchtab-data` (it survives reboots); to manage it
+   declaratively see the reference `cloud-deployment/` compose.
+
+Verify end-to-end: spawn `dev/exec` with `{"expose":"devsrv","commands":["nohup python3 -m http.server 8080 &","sleep 1"],"browser":[{"op":"navigate","args":{"url":"http://devsrv:8080/"}},{"op":"get_text"}]}` — the reply should carry `reachable at http://devsrv:<port>` and the fetched page text.
+
 ## Troubleshooting
 
 | Symptom | Cause / fix |
 |---|---|
 | `no config found` at boot | Image predates RFC AQ — pin `denngubsky/loomcycle:1.6.0` or newer. |
+| (browser) pinchtab crash-loops `mkdir: can't create directory '/data/.config': Permission denied` | `pinchtab-data` dataset not owned by 1000 — `chown -R 1000:1000 /mnt/APPS2/loomcycle/pinchtab-data`. |
+| (browser) `dev/exec` expose → `network loom-dev not found` | The sidecar image predates 1.43.0 (no expose seam), or nothing created `loom-dev` — use `docker-compose.browser.yaml` (declares the network + a multi-arch sidecar). |
+| (browser) browser step → `navigation blocked by IDPI: Domain not in allowlist` | Add the alias to PinchTab's allowlist (step 5 above) and restart the sidecar. |
+| (browser) browser step → `could not resolve navigation host` | The session isn't on `loom-dev` (missing `reachable at …` line) — the sidecar isn't honoring expose (old image) or pinchtab isn't on `loom-dev`. |
 | `EACCES` / permission denied on `/data` | Datasets not owned by 65532 — `chown -R 65532:65532 /mnt/APPS2/loomcycle`. |
 | migrate `connection refused` | DSN host/port unreachable from the apps network, or the role/DB doesn't exist (Phase 1). |
 | App healthy but auth fails / no providers wired | The `env_file` didn't load — confirm the **absolute path** in `env_file:` is exact and the file is `chmod 600` (root-readable). Remember an `environment:` key overrides the same key in `env_file`, so don't re-add a secret inline. |

--- a/deploy/truenas/README.md
+++ b/deploy/truenas/README.md
@@ -7,8 +7,10 @@ Compose app engine). **RFC AR.** Two routes — both documented in
 | File | Route | When |
 |---|---|---|
 | [`docker-compose.yaml`](docker-compose.yaml) | **Custom app** (Apps → Discover → ⋮ → *Install via YAML*, paste) | Fastest. Works today; you edit the compose directly. |
+| [`docker-compose.browser.yaml`](docker-compose.browser.yaml) | **Custom app** — the browser + sandbox variant | Serve-and-test: isolated code-exec + a headless browser for the `dev/exec` agent (see INSTALL.md "Browser + sandbox variant"). |
 | [`catalog/`](catalog/) | **Catalog app** (install wizard via `questions.yaml`) | Formal packaging — an install/edit form, published to a train. |
 | [`loomcycle.overlay.example.yaml`](loomcycle.overlay.example.yaml) | the thin overlay (agent `volumes:` block) both routes mount | Copy to your config dataset. |
+| [`loomcycle.overlay.browser.example.yaml`](loomcycle.overlay.browser.example.yaml) | the overlay for the browser variant (adds `mcp_servers.browser`) | Copy to your config dataset for `docker-compose.browser.yaml`. |
 
 Both routes share the same shape: the binary's **embedded presets** (RFC AQ)
 supply the provider/tier matrix (`LOOMCYCLE_PRESETS`); a thin overlay supplies the

--- a/deploy/truenas/docker-compose.browser.yaml
+++ b/deploy/truenas/docker-compose.browser.yaml
@@ -1,0 +1,204 @@
+# loomcycle on TrueNAS SCALE — BROWSER + SANDBOX variant (paste compose).
+#
+# This is the serve-and-test variant of ./docker-compose.yaml: the runtime runs the
+# DISTROLESS **loomcycle-browser** image (loomcycle + the PinchTab MCP client) and the
+# app ships two extra sidecars — a code-execution sandbox (`builder-sidecar`) and a
+# headless browser (`pinchtab`) — wired so an agent can build a feature in an isolated
+# sandbox session, SERVE it, and TEST it in the browser, all in one run.
+#
+# HOW SERVE-AND-TEST WORKS: the `dev/exec` agent opens a throwaway session in the
+# builder-sidecar. With `expose:<alias>` in its envelope the sidecar attaches that
+# session to the dedicated `loom-dev` network under a --network-alias, and pinchtab
+# (also on loom-dev) reaches the session's dev server at http://<alias>:<port>.
+#
+# ── DIFFERENCE FROM ./docker-compose.yaml ─────────────────────────────────────
+#   • Image: loomcycle-browser (distroless + pinchtab client), NOT loomcycle-toolbox.
+#     Distroless has NO shell/toolchain, so there is NO in-container Bash/Bashbox code
+#     execution here — code runs in ISOLATED sandbox sessions instead (stronger
+#     isolation; the sidecar is the one privileged component). See docs/SANDBOX.md.
+#   • Presets add `sandbox,dev-exec` (the sandbox MCP server + the deterministic
+#     dev/exec executor). CODE_AGENTS_ENABLED stays on (dev/exec is a code-js agent).
+#   • Two extra sidecars (builder-sidecar, pinchtab) + a dedicated `loom-dev` network.
+#   • The config overlay adds an mcp_servers.browser block — copy
+#     loomcycle.overlay.browser.example.yaml (NOT the plain overlay example).
+#
+# ── BEFORE YOU INSTALL (see INSTALL.md "Browser + sandbox variant") ───────────
+#   Replace `tank` with your pool throughout, then:
+#   1. Datasets (the distroless runtime is uid 65532; PINCHTAB runs as uid 1000):
+#        mkdir -p /mnt/tank/loomcycle/{data,config,work,pinchtab-data}
+#        chown -R 65532:65532 /mnt/tank/loomcycle
+#        chown -R 1000:1000  /mnt/tank/loomcycle/pinchtab-data   # ← pinchtab crash-loops without this
+#   2. Postgres ≥ 14 with a CREATEROLE login role (as in INSTALL.md Phase 1).
+#   3. The BROWSER overlay at /mnt/tank/loomcycle/config/loomcycle.yaml
+#        (copy loomcycle.overlay.browser.example.yaml — it declares mcp_servers.browser).
+#   4. TWO secret env files under /mnt/tank/loomcycle/config/ (absolute paths; TrueNAS
+#      "Install via YAML" cannot resolve ${VAR}, so env_file is the mechanism):
+#        • loomcycle.secrets.env  — LOOMCYCLE_AUTH_TOKEN, _OPERATOR_TOKEN_PEPPER,
+#          LOOMCYCLE_PG_DSN, LOOMCYCLE_SQLMEM_PG_DSN, provider keys. (INSTALL.md Phase 4.)
+#        • sandbox.secrets.env    — ONLY the two sandbox-stack tokens:
+#              SANDBOX_AUTH_TOKEN=<openssl rand -hex 32>
+#              PINCHTAB_TOKEN=<openssl rand -hex 32>
+#          Kept SEPARATE so the sidecar + the Chromium container never see the PG DSN
+#          or provider keys — they get only these two tokens. loomcycle reads BOTH
+#          files; the sidecar and pinchtab read only sandbox.secrets.env.
+#   5. Fill the placeholders (TRUENAS_HOST, OLLAMA_HOST, the pool) and paste.
+
+name: loomcycle
+
+networks:
+  loomnet:
+    driver: bridge
+  # Dedicated serve-and-test network. A session opened with expose:<alias> is attached
+  # HERE (by the sidecar, on the host Docker daemon) under a --network-alias, so a dev
+  # server it binds is reachable from the pinchtab sidecar at http://<alias>:<port>.
+  # PINNED to `name: loom-dev` because the sidecar launches sessions as host-Docker
+  # siblings and passes this literal name to `docker run --network` — a compose project
+  # prefix would break that. A normal egress-capable bridge (an exposed session still
+  # fetches deps). SECURITY: shared by the browser + every exposed (possibly untrusted)
+  # session, so it stays OFF loomnet; keep exposure opt-in and use a unique alias per
+  # concurrent session.
+  loom-dev:
+    name: loom-dev
+    driver: bridge
+
+services:
+  # One-shot schema migration: runs `loomcycle migrate up`, then exits; the runtime
+  # waits for it. The browser image carries the loomcycle binary, so it runs migrate too.
+  loomcycle-migrate:
+    image: denngubsky/loomcycle-browser:1.43.1   # keep in lockstep with the runtime
+    user: "65532:65532"
+    restart: "no"
+    command: ["migrate", "up"]
+    networks: [loomnet]
+    env_file:
+      # PG DSNs come from here (LOOMCYCLE_PG_DSN / LOOMCYCLE_SQLMEM_PG_DSN).
+      - /mnt/tank/loomcycle/config/loomcycle.secrets.env
+    environment:
+      LOOMCYCLE_STORAGE_BACKEND: postgres
+
+  loomcycle:
+    image: denngubsky/loomcycle-browser:1.43.1
+    user: "65532:65532"
+    restart: unless-stopped
+    networks: [loomnet]
+    depends_on:
+      loomcycle-migrate:
+        condition: service_completed_successfully
+      builder-sidecar:
+        condition: service_healthy
+    ports:
+      # App-network port. Front with your tunnel/proxy — no public bind here.
+      - "8787:8787"
+    env_file:
+      # Main secrets (tokens, PG DSNs, provider keys) + the sandbox-stack tokens.
+      # loomcycle needs BOTH SANDBOX_AUTH_TOKEN (to reach the sidecar) and
+      # PINCHTAB_TOKEN (the stdio pinchtab client inherits it). NEVER put a secret in
+      # `environment:` below (an inline key would also OVERRIDE the env-file value).
+      - /mnt/tank/loomcycle/config/loomcycle.secrets.env
+      - /mnt/tank/loomcycle/config/sandbox.secrets.env
+    environment:
+      # ── core ──────────────────────────────────────────────────────────────
+      LOOMCYCLE_LISTEN_ADDR: "0.0.0.0:8787"
+      LOOMCYCLE_PUBLIC_URL: "http://TRUENAS_HOST:8787"
+      # Presets add `sandbox` (the sandbox MCP server + the dev/sandbox-usage skill)
+      # and `dev-exec` (the deterministic code-js executor the browser steps drive).
+      LOOMCYCLE_PRESETS: "base,document-agent,chat,agent-teams,team-examples,sandbox,dev-exec"
+      LOOMCYCLE_CONFIG_DIR: /config           # the BROWSER overlay (mcp_servers.browser)
+      LOOMCYCLE_DATA_DIR: /data
+
+      # ── storage — your external Postgres (DSNs live in the secrets env file) ──
+      LOOMCYCLE_STORAGE_BACKEND: postgres
+      LOOMCYCLE_PG_AUTOMIGRATE: "0"
+      LOOMCYCLE_SQLMEM_ENABLED: "1"
+      LOOMCYCLE_PG_MAX_OPEN_CONNS: "48"
+      LOOMCYCLE_PG_MIN_IDLE_CONNS: "8"
+
+      # ── operability ───────────────────────────────────────────────────────
+      LOOMCYCLE_SCHEDULER_ENABLED: "1"
+      LOOMCYCLE_WEBHOOKS_ENABLED: "1"
+      LOOMCYCLE_METRICS_ENABLED: "1"
+      LOOMCYCLE_METRICS_COLLECT_SYSTEM: "1"
+      LOOMCYCLE_METRICS_RETENTION_DAYS: "7"
+      LOOMCYCLE_AUDIT_LOG_PATH: /data/audit.log
+      # dev/exec is a code-js (pure-Go, in-process) agent — works on the distroless image.
+      LOOMCYCLE_CODE_AGENTS_ENABLED: "1"
+
+      # ── local models (optional; point at your Ollama) ─────────────────────
+      OLLAMA_BASE_URL: "http://OLLAMA_HOST:11434"
+      LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX: "65535"
+      LOOMCYCLE_OLLAMA_LOCAL_NUM_GPU: "99"
+
+      # ── HTTP / WebFetch host policy ───────────────────────────────────────
+      # "*" allows any host — an SSRF surface, fine for a TRUSTED single-tenant box
+      # behind a private network/tunnel. NARROW it for multi-tenant. Private IPs stay
+      # hard-blocked either way.
+      LOOMCYCLE_HTTP_HOST_ALLOWLIST: "*"
+    volumes:
+      - /mnt/tank/loomcycle/data:/data
+      - /mnt/tank/loomcycle/config:/config:ro
+      # Shared agent-workspace dataset — the sidecar mounts the SAME host path so a
+      # durable named workspace (SANDBOX_WORKSPACE_ROOT) is visible to both.
+      - /mnt/tank/loomcycle/work:/mnt/work
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/loomcycle", "health"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
+  # ── Code-execution sandbox sidecar (host-Docker-socket model) ─────────────────
+  # Spawns each session as a sibling container on the HOST Docker daemon (via the
+  # mounted socket). This is the one PRIVILEGED component — it can control host Docker,
+  # so keep it internal (no published port), bearer-authed, and on a trusted box.
+  # Lockstep-versioned with the runtime and published MULTI-ARCH by the
+  # `publish-sandbox-images` workflow — pull it, don't hand-build a single-arch image.
+  builder-sidecar:
+    image: denngubsky/loomcycle-builder-docker:1.43.1
+    restart: unless-stopped
+    networks: [loomnet]
+    env_file:
+      # ONLY SANDBOX_AUTH_TOKEN + PINCHTAB_TOKEN — never the PG DSN or provider keys.
+      - /mnt/tank/loomcycle/config/sandbox.secrets.env
+    environment:
+      SANDBOX_PODMAN_BIN: docker            # launch sessions as host-Docker siblings
+      SANDBOX_IMAGE: denngubsky/loomcycle-sandbox-session:1.43.1   # the per-session toolchain (host pulls it)
+      SANDBOX_WORKSPACE_ROOT: /mnt/work     # per-session /work is tmpfs; durable named
+                                            # workspaces need this HOST path (see below)
+      SANDBOX_MAX_CPUS: "2"
+      SANDBOX_MAX_MEM_MB: "2048"
+      SANDBOX_ALLOW_EGRESS: "1"             # permit network:"egress" sessions (git clone / deps)
+      SANDBOX_ALLOW_ENV_INJECTION: "1"      # permit X-Loom-Sandbox-Env-* -> session env (git/gh token)
+      SANDBOX_EXPOSE_NETWORK: loom-dev      # permit sandbox_open expose:<alias> onto loom-dev
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock   # PRIVILEGED — host Docker control
+      - /mnt/tank/loomcycle/work:/mnt/work
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:9000/healthz || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 10s
+
+  # ── Headless browser (PinchTab) — internal MCP browser for the dev/exec agent. ──
+  # stdio-only MCP, so loomcycle spawns `pinchtab … mcp` (the client is baked into the
+  # loomcycle-browser image) against THIS server; Chromium lives here, not in loomcycle.
+  # Internal ONLY (no published port — its control plane is not for public exposure).
+  # On loom-dev so it can reach an exposed session's dev server; on loomnet so loomcycle
+  # reaches its MCP. Widen its browsing allowlist (IDPI) per your aliases — see INSTALL.md.
+  pinchtab:
+    image: pinchtab/pinchtab:0.15.0
+    restart: unless-stopped
+    networks: [loomnet, loom-dev]
+    env_file:
+      - /mnt/tank/loomcycle/config/sandbox.secrets.env   # PINCHTAB_TOKEN (same value loomcycle presents)
+    volumes:
+      - /mnt/tank/loomcycle/pinchtab-data:/data          # HOME/config + Chrome profile — CHOWN 1000:1000
+    shm_size: "2gb"                                       # Chrome stability
+    read_only: true
+    tmpfs:
+      - /tmp:size=512m,noexec,nosuid,nodev
+      - /run:size=64m,noexec,nosuid,nodev
+    security_opt:
+      - no-new-privileges:true
+    cap_drop: [ALL]
+    mem_limit: 2g

--- a/deploy/truenas/loomcycle.overlay.browser.example.yaml
+++ b/deploy/truenas/loomcycle.overlay.browser.example.yaml
@@ -1,0 +1,35 @@
+# loomcycle TrueNAS overlay — BROWSER + SANDBOX variant (for docker-compose.browser.yaml).
+#
+# Copy to your config dataset as loomcycle.yaml (the compose mounts that dataset at
+# /config and selects it via LOOMCYCLE_CONFIG_DIR). Layered OVER the embedded presets
+# (RFC AQ): the presets — including `sandbox` + `dev-exec` selected in the compose —
+# supply the sandbox MCP server and the dev/exec agent; this file adds only what's
+# specific to this box: the agent Volumes and the PinchTab browser MCP server.
+#
+# Keep secrets OUT of this file — they're TrueNAS-managed env (the compose). This
+# overlay is non-secret config only.
+
+# Agent filesystem Volumes (RFC AH). Each `path` is the IN-CONTAINER mount point (the
+# right-hand side of the compose volume mount), which the bind mount creates.
+volumes:
+  work:
+    path: /mnt/work        # ← matches the compose mount: /mnt/tank/loomcycle/work:/mnt/work
+    mode: rw
+    default: true
+
+# ── Headless browser (PinchTab) for the dev/exec agent ────────────────────────
+# PinchTab's MCP is stdio-only, so loomcycle spawns the pinchtab client (present in the
+# loomcycle-browser image) as a stdio MCP bridge to the `pinchtab` server sidecar. The
+# child inherits PINCHTAB_TOKEN from loomcycle's env (from sandbox.secrets.env), so no
+# ${...} interpolation is needed here. The dev/exec agent (dev-exec bundle) already
+# grants mcp__browser__* in its tool ceiling and drives it via the envelope's optional
+# `browser` steps, so this overlay only needs to DECLARE the server — no agent override.
+#
+# The `sandbox` MCP server (the builder-sidecar) is declared by the `sandbox` preset at
+# http://builder-sidecar:9000/mcp — no restatement needed here, since the compose names
+# the sidecar `builder-sidecar` and sets the matching SANDBOX_AUTH_TOKEN.
+mcp_servers:
+  browser:
+    transport: stdio
+    command: /usr/local/bin/pinchtab
+    args: ["--server", "http://pinchtab:9867", "mcp"]


### PR DESCRIPTION
## Why

The TrueNAS deploy files shipped only the lean, single-tenant **toolbox** posture (in-container Bashbox, no browser). The serve-and-test flow — build a feature in an isolated sandbox, **serve** it, and **test** it in a headless browser, all in one `dev/exec` run — was reachable only in `cloud-deployment/`. This ports the full stack to the TrueNAS deploy so a fresh TrueNAS install gets it, without the manual `docker network create loom-dev` / `docker network connect` steps we needed during bring-up.

Verified live first: the exact wiring here (sidecar `expose:<alias>` → session on `loom-dev` → PinchTab resolves the alias) round-trips a page from a sandbox-hosted server to the browser.

## What

- **`docker-compose.browser.yaml`** — a complete, paste-able variant on the distroless **`loomcycle-browser`** image (loomcycle + the PinchTab MCP client), adding:
  - a **`builder-sidecar`** (isolated code-exec, host-Docker-socket model) with `SANDBOX_EXPOSE_NETWORK=loom-dev`,
  - a **`pinchtab`** headless browser (internal, hardened) on `[loomnet, loom-dev]`,
  - a dedicated **`loom-dev`** bridge (`name: loom-dev`) so an `expose:<alias>` session is reachable at `http://<alias>:<port>`,
  - presets `+sandbox,dev-exec`. All images pinned to published **multi-arch 1.43.1**.
- **`loomcycle.overlay.browser.example.yaml`** — the overlay declaring `mcp_servers.browser` (the `sandbox` MCP server comes from the preset).
- **`INSTALL.md`** — a "Browser + sandbox variant" section with the deltas from the base install, and four browser-variant troubleshooting rows.
- **`README.md`** — the two new files in the route table.

Because the browser image is distroless (mutually exclusive with the toolbox image's in-container Bashbox), this is a **separate variant file** rather than an edit of the minimal `docker-compose.yaml` — the lean posture stays intact.

## Security posture (stated in-file)

- `loom-dev` is dedicated and **off** the app network — an exposed (possibly untrusted) session reaches only the browser + its siblings, never loomcycle/Postgres/the sidecar.
- Sandbox-stack secrets are minimally scoped: a **separate `sandbox.secrets.env`** holds only `SANDBOX_AUTH_TOKEN` + `PINCHTAB_TOKEN`, so the sidecar and the Chromium container never see the PG DSN or provider keys.
- The sidecar is the one privileged component (host Docker socket) — trusted, single-tenant box only.
- The `pinchtab-data` dataset must be owned by uid 1000 (documented — it crash-loops on a root-owned `/data`).

## Tested

- `docker-compose.browser.yaml` + the overlay validated (YAML parse + `docker compose config` structural check; only the expected absolute-path `env_file` warnings).
- Every pinned image tag confirmed published multi-arch on Docker Hub (`loomcycle-browser:1.43.1`, `loomcycle-builder-docker:1.43.1`, `loomcycle-sandbox-session:1.43.1`).
- No runtime code change — deploy files + docs only.

Independent of #904 (different files); both target main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD