### PR TITLE
feat(memory): collect the chunk references nothing can reach

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -2538,6 +2538,56 @@ func main() {
 		log.Printf("memory: sweeper disabled (LOOMCYCLE_MEMORY_SWEEP_MS=0 or no Store)")
 	}
 
+	// Dead-link reconciliation: the only layer that actually COLLECTS chunk
+	// references nothing can reach.
+	//
+	// The other two layers are incomplete by construction. delete_chunk cleans every
+	// reference, but the body delete runs after the transaction commits because it
+	// is a different store — so a crash in that window leaves an orphan. And the
+	// read-time guard HIDES an orphan, which is right for a read and is exactly why
+	// nothing ever notices one is there. An out-of-band delete bypasses both.
+	//
+	// On by default, unlike retention, because everything it removes is unreachable:
+	// it restores an invariant rather than enacting a policy.
+	if cfg.Env.DeadLinkGCInterval > 0 && storeIface != nil && sqlMemMgr != nil {
+		docTool := &builtin.Document{Store: storeIface, SqlMem: sqlMemMgr}
+		go runAdvisoryGatedSweeper(bgCtx, cfg.Env.DeadLinkGCInterval, advisoryLock, coord.LockKeyDeadLinkGC, "deadlink",
+			func(ctx context.Context) {
+				scopes, err := sqlMemMgr.ListScopes(ctx)
+				if err != nil {
+					log.Printf("deadlink gc: list scopes: %v", err)
+					return
+				}
+				for _, sk := range scopes {
+					// A run scope is dropped whole at run end, so reconciling it is
+					// work with no beneficiary — and it has no durable body partition
+					// to reconcile against.
+					ms, ok := deadLinkMemoryScope(sk.Scope)
+					if !ok {
+						continue
+					}
+					rep, err := docTool.ReconcileDeadLinks(ctx, sk, ms, cfg.Env.DeadLinkGCDryRun)
+					if err != nil {
+						// Per-scope: one unreadable scope must not stop the sweep.
+						log.Printf("deadlink gc: %s/%s/%s: %v", sk.Tenant, sk.Scope, sk.ScopeID, err)
+						continue
+					}
+					if !rep.Empty() {
+						verb := "collected"
+						if cfg.Env.DeadLinkGCDryRun {
+							verb = "would collect"
+						}
+						log.Printf("deadlink gc: %s %s", verb, rep)
+					}
+				}
+			})
+		log.Printf("deadlink gc: interval=%s dry_run=%v", cfg.Env.DeadLinkGCInterval, cfg.Env.DeadLinkGCDryRun)
+	} else if storeIface != nil && sqlMemMgr == nil {
+		log.Printf("deadlink gc: disabled (no SQL Memory — no chunk tables to reconcile)")
+	} else {
+		log.Printf("deadlink gc: disabled (LOOMCYCLE_DEADLINK_GC_MS=0 or no Store)")
+	}
+
 	// Channel tool TTL sweeper (v0.8.4). Same shape as MemorySweeper.
 	if cfg.Env.ChannelsSweepInterval > 0 && storeIface != nil {
 		go runAdvisoryGatedSweeper(bgCtx, cfg.Env.ChannelsSweepInterval, advisoryLock, coord.LockKeyChannelsSweeper, "channels",
@@ -3941,4 +3991,23 @@ func buildSearchProviders(cfg *config.Config) (*search.Registry, *search.Resolve
 		priority = ids
 	}
 	return reg, search.NewResolver(priority), hostKeys
+}
+
+// deadLinkMemoryScope maps a SQL-Memory scope onto the Memory scope its chunk
+// bodies live in, and reports whether the scope is worth reconciling at all.
+//
+// `run` is excluded: an ephemeral scope is dropped whole at run end, so collecting
+// its orphans is work with no beneficiary — and it has no durable body partition to
+// reconcile against, so guessing one risks deleting another scope's bodies. The same
+// exclusion the retention content-prune makes, for the same reason.
+func deadLinkMemoryScope(scope string) (store.MemoryScope, bool) {
+	switch scope {
+	case "agent":
+		return store.MemoryScopeAgent, true
+	case "user":
+		return store.MemoryScopeUser, true
+	case "tenant":
+		return store.MemoryScopeTenant, true
+	}
+	return "", false
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2930,6 +2930,25 @@ type Env struct {
 	// Env: LOOMCYCLE_MEMORY_MAX_SCOPE_BYTES.
 	MemoryMaxScopeBytes int
 
+	// DeadLinkGCInterval is how often the dead-link reconciliation runs — the layer
+	// that collects chunk references nothing can reach (a body whose chunk is gone,
+	// an edge to a chunk that does not exist).
+	//
+	// ON BY DEFAULT, unlike the retention sweeper, because everything it deletes is
+	// unreachable by definition: it restores an invariant rather than applying a
+	// policy. Hourly rather than every fifteen minutes because an orphan costs
+	// nothing while it sits there — the read-time guard already hides it — so this
+	// is about not accumulating forever, not about latency.
+	// Env: LOOMCYCLE_DEADLINK_GC_MS (0 disables).
+	DeadLinkGCInterval time.Duration
+
+	// DeadLinkGCDryRun makes the reconciliation COUNT without deleting, so an
+	// operator can see what it would collect before letting it. Reported at the same
+	// log level either way, which is the point: a dry run that logged nothing would
+	// be indistinguishable from a clean store.
+	// Env: LOOMCYCLE_DEADLINK_GC_DRY_RUN=1.
+	DeadLinkGCDryRun bool
+
 	// MemorySweepInterval is how often the TTL reaper goroutine
 	// runs MemorySweep on the store. Default 15 minutes. Set to 0
 	// to disable (operators with an external reaper, or tests that
@@ -3815,6 +3834,17 @@ func LoadLayers(layers ...Layer) (*Config, error) {
 			}
 		}
 	}
+	cfg.Env.DeadLinkGCInterval = time.Hour
+	if v := os.Getenv("LOOMCYCLE_DEADLINK_GC_MS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			if n <= 0 {
+				cfg.Env.DeadLinkGCInterval = 0
+			} else {
+				cfg.Env.DeadLinkGCInterval = time.Duration(n) * time.Millisecond
+			}
+		}
+	}
+	cfg.Env.DeadLinkGCDryRun = os.Getenv("LOOMCYCLE_DEADLINK_GC_DRY_RUN") == "1"
 	cfg.Env.MemorySweepInterval = 15 * time.Minute
 	if v := os.Getenv("LOOMCYCLE_MEMORY_SWEEP_MS"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {

--- a/internal/coord/advisory_lock.go
+++ b/internal/coord/advisory_lock.go
@@ -140,6 +140,20 @@ var (
 	// runs once per boot; the content-hash gate makes an unchanged corpus a
 	// zero-embed no-op even on the replica that wins the lock.
 	LockKeyHelpIndexReconcile int64
+	// LockKeyDeadLinkGC gates the dead-link reconciliation — the layer that
+	// collects chunk references nothing can reach any more (a body whose chunk is
+	// gone, an edge to a chunk that does not exist).
+	//
+	// ITS OWN KEY, deliberately, and this was a corrected design slip: the original
+	// note put it on LockKeyMemorySweeper, which already belongs to the SQL-Memory
+	// scope GC. Sharing a key does not serialise two subsystems politely — it makes
+	// each tick of one starve the other, silently, and the symptom would be
+	// "integrity ran less often than configured" with nothing to point at.
+	//
+	// Distinct from LockKeyRetentionSweeper for the same reason it is a distinct
+	// subsystem: retention deletes REACHABLE data because an operator asked, and is
+	// off by default; this deletes only the unreachable, and is always on.
+	LockKeyDeadLinkGC int64
 )
 
 // MemoryConsolidatorLockKey derives the RFC BL P2 consolidation fan-out's
@@ -174,6 +188,7 @@ func init() {
 	LockKeyUsageSweeper = fnvKey("usage_sweeper")
 	LockKeyRetentionSweeper = fnvKey("retention_sweeper")
 	LockKeyHelpIndexReconcile = fnvKey("help_index_reconcile")
+	LockKeyDeadLinkGC = fnvKey("deadlink_gc")
 }
 
 // fnvKey hashes a sweeper-name string to a stable int64 lock key.

--- a/internal/tools/builtin/document_deadlink.go
+++ b/internal/tools/builtin/document_deadlink.go
@@ -1,0 +1,230 @@
+package builtin
+
+// document_deadlink.go — the authoritative dead-link reconciliation for one scope.
+//
+// A chunk is referenced from five places: chunk_edges (both endpoints),
+// chunk_assets, chunk_memory_meta, its own row, and its BODY in the Memory k/v
+// plane. delete_chunk and delete_document clean all of them, and the read-time
+// guard hides a hit whose chunk or body has gone. Neither is complete, which is
+// why this exists:
+//
+//   - The body delete runs AFTER the transaction commits, deliberately (it is a
+//     different store, so it cannot join the txn). A crash in that window leaves a
+//     body whose chunk is gone.
+//   - An out-of-band delete — a repair script, a restore, an operator with psql —
+//     bypasses the tool entirely and leaves every reference behind.
+//   - The read-time guard makes an orphan invisible, which is the right behaviour
+//     for a read and is precisely why nothing ever notices the orphan is there.
+//
+// So this is the only layer that actually collects them, and it is always-on
+// integrity rather than opt-in policy: everything it deletes is UNREACHABLE by
+// definition — a body no chunk points at, an edge to a chunk that does not exist.
+// That is the line between this and the retention sweeper, which deletes reachable
+// data because an operator asked it to, and is off by default for that reason.
+//
+// It has its OWN advisory key. LockKeyMemorySweeper belongs to the SQL-Memory
+// scope GC; sharing it would make one subsystem's tick silently starve the other.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// DeadLinkReport is one scope's reconciliation outcome.
+//
+// The reaped classes are separated from the reported ones because they carry
+// different authority. A dangling edge is unreachable and deleting it restores an
+// invariant; a chunk whose DOCUMENT has gone is a different thing — it may be a
+// tree an operator can still recover, and destroying it to tidy a count is not
+// this sweeper's call. Reported, so it is visible, and left alone.
+type DeadLinkReport struct {
+	Scope sqlmem.ScopeKey
+
+	// Reaped (or, in a dry run, reapable).
+	Bodies   int // doc.chunk:<id> in Memory with no chunks row
+	Sidecars int // chunk_memory_meta rows with no chunks row
+	Edges    int // chunk_edges with a missing endpoint
+	Assets   int // chunk_assets rows with no chunks row
+
+	// Reported only, never deleted.
+	OrphanChunks int // chunks whose document_id has no documents row
+
+	// Skipped explains a scope this pass declined to touch. Non-empty means
+	// NOTHING was deleted for it.
+	Skipped string
+}
+
+// Total is the reaped count across every class.
+func (r DeadLinkReport) Total() int { return r.Bodies + r.Sidecars + r.Edges + r.Assets }
+
+// Empty reports whether there is nothing worth logging.
+func (r DeadLinkReport) Empty() bool {
+	return r.Total() == 0 && r.OrphanChunks == 0 && r.Skipped == ""
+}
+
+func (r DeadLinkReport) String() string {
+	if r.Skipped != "" {
+		return fmt.Sprintf("%s/%s/%s: skipped (%s)", r.Scope.Tenant, r.Scope.Scope, r.Scope.ScopeID, r.Skipped)
+	}
+	s := fmt.Sprintf("%s/%s/%s: %d body, %d sidecar, %d edge, %d asset",
+		r.Scope.Tenant, r.Scope.Scope, r.Scope.ScopeID, r.Bodies, r.Sidecars, r.Edges, r.Assets)
+	if r.OrphanChunks > 0 {
+		s += fmt.Sprintf(" (+%d chunk(s) whose document is gone — reported, not deleted)", r.OrphanChunks)
+	}
+	return s
+}
+
+// ReconcileDeadLinks collects one scope's unreachable chunk references.
+//
+// dryRun counts without deleting, which is how an operator sizes the problem
+// before arming the sweeper — and how the sweeper itself reports when configured
+// to observe only.
+func (d *Document) ReconcileDeadLinks(ctx context.Context, key sqlmem.ScopeKey, mscope store.MemoryScope, dryRun bool) (DeadLinkReport, error) {
+	rep := DeadLinkReport{Scope: key}
+
+	// THE LIVE CHUNK-ID SET IS THE WHOLE BASIS OF EVERY DECISION BELOW, so a fault
+	// reading it aborts the scope rather than proceeding.
+	//
+	// This is the guard that matters most here. If the read failed and were treated
+	// as "no chunks exist", every body in the scope would look orphaned and the
+	// sweeper would delete the lot. A transient SQL error, a scope resolved with the
+	// wrong id, a schema not yet provisioned — this subsystem has produced all three
+	// — would each turn an integrity pass into data loss.
+	live, err := d.liveChunkIDs(ctx, key)
+	if err != nil {
+		return rep, err
+	}
+
+	// And a second guard on the same failure shape, for the case where the read
+	// SUCCEEDS but against the wrong place: a scope holding chunk bodies but zero
+	// chunk rows is either mid-provisioning or a mis-resolved scope key, not a scope
+	// whose every chunk was deleted. Refusing costs one skipped tick; being wrong
+	// costs every body in the scope.
+	bodies, err := d.chunkBodyKeys(ctx, key, mscope)
+	if err != nil {
+		return rep, err
+	}
+	if len(live) == 0 && len(bodies) > 0 {
+		rep.Skipped = fmt.Sprintf("%d chunk bodies but no chunk rows — refusing to treat that as a fully-deleted scope", len(bodies))
+		return rep, nil
+	}
+
+	// --- the SQL-side anti-joins, all within one database so a subquery works ---
+	//
+	// NOT IN is safe against NULLs here because chunks.id is the primary key and
+	// can never be null; a NULL on the right of NOT IN would otherwise make the
+	// whole predicate unknown and silently match nothing.
+	for _, c := range []struct {
+		into  *int
+		table string
+		where string
+	}{
+		{&rep.Sidecars, "chunk_memory_meta", "chunk_id NOT IN (SELECT id FROM chunks)"},
+		{&rep.Assets, "chunk_assets", "chunk_id NOT IN (SELECT id FROM chunks)"},
+		{&rep.Edges, "chunk_edges", "from_id NOT IN (SELECT id FROM chunks) OR to_id NOT IN (SELECT id FROM chunks)"},
+	} {
+		n, err := d.countWhere(ctx, key, c.table, c.where)
+		if err != nil {
+			return rep, err
+		}
+		*c.into = n
+		if n > 0 && !dryRun {
+			if err := d.exec(ctx, key, `DELETE FROM `+c.table+` WHERE `+c.where); err != nil {
+				return rep, err
+			}
+		}
+	}
+
+	// Reported, not reaped — see DeadLinkReport.
+	if n, err := d.countWhere(ctx, key, "chunks", "document_id NOT IN (SELECT id FROM documents)"); err == nil {
+		rep.OrphanChunks = n
+	} else {
+		return rep, err
+	}
+
+	// --- the cross-plane pass: bodies in Memory, chunks in SQL Memory ---
+	//
+	// Not expressible as a join: the two live in different stores. Which is also
+	// why this class exists at all, since a cross-store delete cannot be
+	// transactional.
+	for _, b := range bodies {
+		if live[b.chunkID] {
+			continue
+		}
+		rep.Bodies++
+		if dryRun {
+			continue
+		}
+		// bodyTenantsFor mirrors the prune's two-try lookup: sqlmem needs a
+		// non-empty tenant so the single-tenant default is "default", while the k/v
+		// plane wrote those same rows under "". Try both; the first hit wins.
+		for _, tenant := range bodyTenantsFor(key.Tenant) {
+			if removed, _ := d.Store.MemoryDelete(ctx, tenant, mscope, key.ScopeID, b.key); removed {
+				break
+			}
+		}
+	}
+	return rep, nil
+}
+
+// liveChunkIDs reads the scope's chunk ids as a set.
+func (d *Document) liveChunkIDs(ctx context.Context, key sqlmem.ScopeKey) (map[string]bool, error) {
+	res, err := d.query(ctx, key, `SELECT id FROM chunks`)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]bool, len(res.Rows))
+	for _, r := range res.Rows {
+		if id := asStr(r[0]); id != "" {
+			out[id] = true
+		}
+	}
+	return out, nil
+}
+
+type chunkBodyRow struct {
+	key     string
+	chunkID string
+}
+
+// chunkBodyKeys lists the scope's chunk-body keys from the Memory plane.
+func (d *Document) chunkBodyKeys(ctx context.Context, key sqlmem.ScopeKey, mscope store.MemoryScope) ([]chunkBodyRow, error) {
+	const prefix = "doc.chunk:"
+	var out []chunkBodyRow
+	for _, tenant := range bodyTenantsFor(key.Tenant) {
+		entries, _, err := d.Store.MemoryList(ctx, tenant, mscope, key.ScopeID, prefix, 0)
+		if err != nil {
+			return nil, err
+		}
+		for _, e := range entries {
+			if id := strings.TrimPrefix(e.Key, prefix); id != e.Key && id != "" {
+				out = append(out, chunkBodyRow{key: e.Key, chunkID: id})
+			}
+		}
+		if len(out) > 0 {
+			// The bodies live under ONE of the candidate tenants, never split across
+			// them. Stopping at the first non-empty answer keeps a scope from being
+			// counted twice on the tier where both spellings resolve.
+			break
+		}
+	}
+	return out, nil
+}
+
+// countWhere counts rows matching a predicate. The predicate is a compile-time
+// constant from the table above, never caller input.
+func (d *Document) countWhere(ctx context.Context, key sqlmem.ScopeKey, table, where string) (int, error) {
+	res, err := d.query(ctx, key, `SELECT count(*) FROM `+table+` WHERE `+where)
+	if err != nil {
+		return 0, err
+	}
+	if len(res.Rows) == 0 || len(res.Rows[0]) == 0 {
+		return 0, nil
+	}
+	n, _ := asInt64(res.Rows[0][0])
+	return int(n), nil
+}

--- a/internal/tools/builtin/document_deadlink_test.go
+++ b/internal/tools/builtin/document_deadlink_test.go
@@ -1,0 +1,211 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// TestDeadLink_CollectsEveryUnreachableClass walks the four classes together,
+// because they arrive together: an out-of-band chunk delete leaves all of them at
+// once, and a reconciliation that cleaned three of four would leave the store
+// looking repaired while a read still stumbled on the fourth.
+func TestDeadLink_CollectsEveryUnreachableClass(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	docID := newEntityDoc(t, d, ctx)
+	key, mscope := deadLinkScope(t, d, ctx)
+
+	// A real chunk with a body, an entity sidecar, an asset and an edge — then the
+	// chunk row is deleted BEHIND the tool's back, the way a repair script or a
+	// restore does it. Every reference survives and nothing can reach any of it.
+	live := upsert(t, d, ctx, docID, "survivor", "survivor", "still here", "")
+	doomed := upsert(t, d, ctx, docID, "doomed", "doomed", "about to be orphaned", "")
+	linkChunks(t, d, ctx, doomed, live)
+	setAsset(t, d, ctx, doomed)
+
+	if err := d.exec(ctx, key, `DELETE FROM chunks WHERE id = ?`, doomed); err != nil {
+		t.Fatalf("out-of-band delete: %v", err)
+	}
+
+	// Dry run first: the counts must be visible WITHOUT deleting, which is how an
+	// operator sizes this before arming it.
+	dry, err := d.ReconcileDeadLinks(ctx, key, mscope, true)
+	if err != nil {
+		t.Fatalf("dry run: %v", err)
+	}
+	if dry.Bodies != 1 || dry.Sidecars != 1 || dry.Edges != 1 || dry.Assets != 1 {
+		t.Errorf("dry run should count one of each class, got %+v", dry)
+	}
+	if got := bodyExists(t, d, ctx, mscope, key, doomed); !got {
+		t.Error("a dry run must not delete — the body is gone")
+	}
+
+	got, err := d.ReconcileDeadLinks(ctx, key, mscope, false)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if got.Total() != 4 {
+		t.Errorf("want 4 collected (body+sidecar+edge+asset), got %d: %+v", got.Total(), got)
+	}
+	if bodyExists(t, d, ctx, mscope, key, doomed) {
+		t.Error("the orphaned body survived — no read returns it and no other sweeper reaps it")
+	}
+	// A second pass finds nothing: the reconciliation is idempotent, so a scope that
+	// is clean does not keep reporting work.
+	again, err := d.ReconcileDeadLinks(ctx, key, mscope, false)
+	if err != nil {
+		t.Fatalf("second pass: %v", err)
+	}
+	if again.Total() != 0 {
+		t.Errorf("a clean scope must report nothing, got %+v", again)
+	}
+}
+
+// TestDeadLink_LeavesLiveReferencesAlone is the property that makes this safe to run
+// unattended. Everything it deletes must be unreachable; touching a live reference
+// would make an integrity pass the thing that breaks integrity.
+func TestDeadLink_LeavesLiveReferencesAlone(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	docID := newEntityDoc(t, d, ctx)
+	key, mscope := deadLinkScope(t, d, ctx)
+
+	a := upsert(t, d, ctx, docID, "a", "a", "body a", "")
+	b := upsert(t, d, ctx, docID, "b", "b", "body b", "")
+	linkChunks(t, d, ctx, a, b)
+	setAsset(t, d, ctx, a)
+
+	got, err := d.ReconcileDeadLinks(ctx, key, mscope, false)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if got.Total() != 0 {
+		t.Fatalf("a healthy scope must lose nothing, got %+v", got)
+	}
+	for _, id := range []string{a, b} {
+		if !bodyExists(t, d, ctx, mscope, key, id) {
+			t.Errorf("live body for %s was deleted", id)
+		}
+	}
+	if n, _ := d.countWhere(ctx, key, "chunk_edges", "1=1"); n != 1 {
+		t.Errorf("live edge count = %d, want 1", n)
+	}
+	if n, _ := d.countWhere(ctx, key, "chunk_assets", "1=1"); n != 1 {
+		t.Errorf("live asset count = %d, want 1", n)
+	}
+	if n, _ := d.countWhere(ctx, key, "chunk_memory_meta", "1=1"); n != 2 {
+		t.Errorf("live sidecar count = %d, want 2", n)
+	}
+}
+
+// TestDeadLink_RefusesAScopeWithBodiesAndNoChunks is the guard that separates an
+// integrity pass from data loss.
+//
+// Every decision here rests on the live chunk-id set. If that set is empty for the
+// WRONG reason — a scope resolved with the wrong id, a schema not yet provisioned,
+// a read that failed and was treated as "nothing there" — then every body in the
+// scope looks orphaned and the sweeper deletes the lot. This subsystem has produced
+// all three of those causes, so the shape is refused rather than trusted: a scope
+// holding bodies but no chunk rows is not a scope whose every chunk was deleted.
+func TestDeadLink_RefusesAScopeWithBodiesAndNoChunks(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	docID := newEntityDoc(t, d, ctx)
+	key, mscope := deadLinkScope(t, d, ctx)
+	id := upsert(t, d, ctx, docID, "only", "only", "the only body", "")
+
+	// Empty the chunk table, leaving the body — the shape of a mis-resolved scope.
+	if err := d.exec(ctx, key, `DELETE FROM chunks`); err != nil {
+		t.Fatalf("empty chunks: %v", err)
+	}
+
+	got, err := d.ReconcileDeadLinks(ctx, key, mscope, false)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if got.Skipped == "" {
+		t.Error("a scope with bodies and no chunk rows must be SKIPPED, not treated as fully deleted")
+	}
+	if got.Total() != 0 {
+		t.Errorf("a skipped scope must delete nothing, got %+v", got)
+	}
+	if !bodyExists(t, d, ctx, mscope, key, id) {
+		t.Error("the body was deleted despite the refusal — this is the data-loss path")
+	}
+}
+
+// TestDeadLink_AChunkWhoseDocumentIsGoneIsReportedNotDeleted. Different authority
+// from a dangling edge: that is unreachable and deleting it restores an invariant,
+// whereas a chunk tree whose document row has gone may still be recoverable, and
+// destroying it to tidy a count is not this sweeper's call.
+func TestDeadLink_AChunkWhoseDocumentIsGoneIsReportedNotDeleted(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	docID := newEntityDoc(t, d, ctx)
+	key, mscope := deadLinkScope(t, d, ctx)
+	id := upsert(t, d, ctx, docID, "stranded", "stranded", "body", "")
+
+	if err := d.exec(ctx, key, `DELETE FROM documents WHERE id = ?`, docID); err != nil {
+		t.Fatalf("delete the document row: %v", err)
+	}
+
+	got, err := d.ReconcileDeadLinks(ctx, key, mscope, false)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if got.OrphanChunks == 0 {
+		t.Error("a chunk whose document is gone must be REPORTED")
+	}
+	if n, _ := d.countWhere(ctx, key, "chunks", "1=1"); n == 0 {
+		t.Error("...and must NOT be deleted — it may still be recoverable")
+	}
+	if !bodyExists(t, d, ctx, mscope, key, id) {
+		t.Error("its body must survive too; the chunk still points at it")
+	}
+}
+
+// ---- helpers ----
+
+func deadLinkScope(t *testing.T, d *Document, ctx context.Context) (sqlmem.ScopeKey, store.MemoryScope) {
+	t.Helper()
+	key, mscope, err := d.resolveScope(ctx, "user")
+	if err != nil {
+		t.Fatalf("resolveScope: %v", err)
+	}
+	return key, mscope
+}
+
+func bodyExists(t *testing.T, d *Document, ctx context.Context, mscope store.MemoryScope, key sqlmem.ScopeKey, chunkID string) bool {
+	t.Helper()
+	for _, tenant := range bodyTenantsFor(key.Tenant) {
+		if _, err := d.Store.MemoryGet(ctx, tenant, mscope, key.ScopeID, chunkBodyKey(chunkID)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func linkChunks(t *testing.T, d *Document, ctx context.Context, from, to string) {
+	t.Helper()
+	res, err := d.Execute(ctx, entityJSON(map[string]any{
+		"op": "link_chunks", "scope": "user", "from_id": from, "to_id": to, "kind": "about",
+	}))
+	if err != nil || res.IsError {
+		t.Fatalf("link_chunks: %v %s", err, res.Text)
+	}
+}
+
+func setAsset(t *testing.T, d *Document, ctx context.Context, chunkID string) {
+	t.Helper()
+	// A 1x1 png, base64 — enough to make a real chunk_assets row.
+	const png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8AARgwMDAwMAA8mAf/hZ0ZzAAAAAElFTkSuQmCC"
+	res, err := d.Execute(ctx, entityJSON(map[string]any{
+		"op": "set_asset", "scope": "user", "id": chunkID,
+		"media_type": "image/png", "data": png,
+	}))
+	if err != nil || res.IsError {
+		t.Fatalf("set_asset: %v %s", err, res.Text)
+	}
+	var out map[string]any
+	_ = json.Unmarshal([]byte(res.Text), &out)
+}


### PR DESCRIPTION
**RFC BL P5, PR 6** — and the §2.10 layer that was deferred out of P1 and never landed.

## Why the two existing layers aren't enough

A chunk is referenced from five places: both endpoints of `chunk_edges`, `chunk_assets`, `chunk_memory_meta`, its own row, and its **body** in the Memory k/v plane.

- **`delete_chunk`/`delete_document` clean all five** — but the body delete runs *after* the transaction commits, deliberately, because it's a different store and can't join the txn. A crash in that window leaves a body whose chunk is gone. And an out-of-band delete (repair script, restore, operator with `psql`) bypasses the tool entirely, leaving everything.
- **The read-time guard hides** a hit whose chunk or body has gone. That's right for a read — and it's precisely why nothing ever notices the orphan is there.

So this is the only layer that actually collects them.

## Always-on, not opt-in — and that's the whole design boundary

Everything it deletes is **unreachable by definition**: a body no chunk points at, an edge to a chunk that doesn't exist. It restores an invariant. That's the line against the retention sweeper, which deletes *reachable* data because an operator asked, and is off by default for exactly that reason.

Four classes reaped — orphan bodies, sidecar rows, edges with a missing endpoint, assets. **One reported and never deleted:** a chunk whose `documents` row has gone. Different authority: a dangling edge is unreachable and removing it restores an invariant, whereas a chunk tree whose document vanished may still be recoverable, and destroying it to tidy a count isn't this sweeper's call.

## Two guards, because the failure mode isn't "misses an orphan"

It's **"deletes a live store."** Every decision rests on the live chunk-id set, so an empty set for the *wrong* reason reaps everything — a read that failed, a scope resolved with the wrong id, a schema not yet provisioned. **This subsystem has produced all three of those causes.**

1. A read fault **aborts the scope** rather than proceeding.
2. A scope holding chunk **bodies** but zero chunk **rows** is **refused outright** — that's the shape of a mis-resolved key, not of a scope whose every chunk was deleted.

Refusing costs one skipped tick. Being wrong costs every body in the scope.

## Its own advisory key — correcting the original slip

The design note put this on `LockKeyMemorySweeper`, which already belongs to the SQL-Memory scope GC. Sharing a key doesn't serialise two subsystems politely — **it makes each tick of one starve the other**, silently, with "integrity ran less often than configured" as the only symptom and nothing to point at.

`run` scopes are skipped: ephemeral, dropped whole at run end, no durable body partition to reconcile against — so guessing one risks deleting another scope's bodies. Same exclusion the content prune makes.

## Config

Hourly by default. An orphan costs nothing while it sits there (the read guard already hides it), so this is about not accumulating forever rather than latency.

- `LOOMCYCLE_DEADLINK_GC_MS=0` disables
- `LOOMCYCLE_DEADLINK_GC_DRY_RUN=1` counts only — and logs at the same level, deliberately: a dry run that logged nothing would be indistinguishable from a clean store

## Tested

4 tests covering all four reaped classes together (they *arrive* together — an out-of-band delete leaves all of them, and cleaning three of four leaves the store looking repaired while a read still stumbles), the live-references-untouched property, both guards, and idempotency.

**Fail-before verified three times:**

```
guard removed        → "the body was deleted despite the refusal — this is the data-loss path"
cross-plane skipped  → "want 4 collected, got 3: 0 body, 1 sidecar, 1 edge, 1 asset"
anti-join inverted   → "a healthy scope must lose nothing, got 2 sidecar"
```

**Booted a real binary on both paths:**

```
deadlink gc: interval=2s dry_run=false
deadlink gc: disabled (no SQL Memory — no chunk tables to reconcile)
```

The disabled path reports itself rather than silently doing nothing — this subsystem's recurring failure has been capabilities that were present and inert.

`gofmt` clean · full `go test ./...` green · both CI postgres steps green · no new advisory-key collision.

## P5 after this

Remaining: **0c** (the provenance lister — the missing half of Q7 and of the erasure story) and **0d** (the erasure admin op). Plus the deferred eval re-run against a *confirmed* ontology, to test the reframed hypothesis from the last live pass before anyone writes type validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)