### PR TITLE
fix(memory): the eval never sent the ontology it was scoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,7 @@ memory-eval-live:
 	  --provider $(MEMEVAL_PROVIDER) --model $(MEMEVAL_MODEL) \
 	  --baseline $(MEMEVAL_BASELINE) \
 	  $(if $(MEMEVAL_EFFORT),--effort $(MEMEVAL_EFFORT),) \
+	  $(if $(MEMEVAL_ONTOLOGY_TERMS),--ontology-terms $(MEMEVAL_ONTOLOGY_TERMS),) \
 	  $(if $(MEMEVAL_SHOW_FACTS),--show-facts,) \
 	  $(if $(MEMEVAL_UPDATE),--update-baseline $(MEMEVAL_BASELINE),)
 

--- a/internal/cli/memory_eval_live.go
+++ b/internal/cli/memory_eval_live.go
@@ -5,8 +5,11 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	meminject "github.com/denn-gubsky/loomcycle/internal/memory"
 	"io"
 	"os"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/memory/eval"
@@ -64,6 +67,10 @@ func RunMemoryEvalLive(args []string, stdout, stderr io.Writer) int {
 	timeout := fs.Duration("timeout", 5*time.Minute, "wall clock PER CASE (not for the whole run)")
 	maxTokens := fs.Int("max-tokens", 0, "per-call max_tokens (0 = provider default)")
 	noGate := fs.Bool("no-gate", false, "report only; exit 0 even when the gate fails")
+	ontologyTerms := fs.String("ontology-terms", "",
+		"comma-separated tenant entity types to add to the base seed when expanding "+
+			"{{memory:ontology}} (a deployment with a CONFIRMED tenant ontology adds its own; "+
+			"empty = the base seed alone, which is what an unconfirmed deployment gets)")
 	showFacts := fs.Bool("show-facts", false, "print every case's emitted facts, including the ones that passed")
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -95,6 +102,24 @@ func RunMemoryEvalLive(args []string, stdout, stderr io.Writer) int {
 		*effort = agent.Effort
 	}
 
+	// EXPAND THE PLACEHOLDERS THE RUNTIME WOULD EXPAND, or the eval scores a prompt
+	// nobody runs — the exact failure the bundle drift-test was built to prevent,
+	// arriving by a route that test cannot see.
+	//
+	// The drift test compares this harness's copy against the bundle's, and both
+	// have been identical throughout. What differs is that the RUNTIME expands
+	// {{memory:ontology}} into ~520 characters of entity types before the model sees
+	// it, and this path sent the nineteen literal characters. So since the ontology
+	// landed in the extractor prompt, every score here was measured against a prompt
+	// telling the model to "use one of the types above" where above was a
+	// placeholder — which is a complete explanation for the eval's finding that half
+	// the emitted types were outside the ontology, and for why the live deployment,
+	// where expansion does happen, used its ontology's types correctly.
+	systemPrompt, err := expandEvalPlaceholders(agent.SystemPrompt, *ontologyTerms)
+	if err != nil {
+		return fail(stderr, "memory-eval-live: %v", err)
+	}
+
 	prov, err := providerbuild.Provider(cfg, *providerID)
 	if err != nil {
 		return fail(stderr, "memory-eval-live: %v", err)
@@ -108,7 +133,7 @@ func RunMemoryEvalLive(args []string, stdout, stderr io.Writer) int {
 	rep, err := eval.RunExtraction(context.Background(), prov, eval.ExtractionInput{
 		CaseTimeout:  *timeout,
 		Corpus:       eval.ExtractionFixture(),
-		SystemPrompt: agent.SystemPrompt,
+		SystemPrompt: systemPrompt,
 		Provider:     *providerID,
 		Model:        *model,
 		Effort:       *effort,
@@ -341,3 +366,43 @@ func splitWords(s string) []string {
 	}
 	return out
 }
+
+// expandEvalPlaceholders renders the {{memory:...}} placeholders the RUNTIME would
+// render, and refuses a prompt still carrying one.
+//
+// Only `ontology` is expandable here, and that is a real limit rather than an
+// oversight: the other variants read a live store (a user's core blocks, a tenant's
+// deployment-context document) that a CLI with no store cannot produce. A prompt
+// referencing one of those is therefore not scoreable — and it fails LOUDLY rather
+// than being sent with the literal text, which is what quietly happened to
+// `ontology` and cost a whole baseline's worth of meaning.
+//
+// tenantTerms lets a run reproduce a deployment whose operator has CONFIRMED an
+// ontology. Empty is the unconfirmed case — the base seed alone — and the two give
+// materially different results, which is the entire question the flag exists to ask.
+func expandEvalPlaceholders(prompt, tenantTerms string) (string, error) {
+	var extra []meminject.OntologyTerm
+	for _, name := range strings.Split(tenantTerms, ",") {
+		if name = strings.TrimSpace(name); name != "" {
+			extra = append(extra, meminject.OntologyTerm{Name: name})
+		}
+	}
+	// confirmed=true only when terms were supplied: EffectiveOntology discards a
+	// tenant layer that is not confirmed, so passing true with no terms would render
+	// the "this deployment has confirmed additions" wording over the bare seed.
+	body := meminject.RenderOntology(
+		meminject.EffectiveOntology(extra, len(extra) > 0), len(extra) > 0)
+	out := strings.ReplaceAll(prompt, "{{memory:"+string(meminject.VariantOntology)+"}}", body)
+
+	// Anything left is a variant this harness cannot render. Refusing is the point:
+	// sending it verbatim scores a prompt the runtime never produces, and the score
+	// looks entirely normal.
+	if m := unexpandedPlaceholder.FindString(out); m != "" {
+		return "", fmt.Errorf("the extractor prompt still contains %s, which this harness cannot render "+
+			"(it reads a live store). Scoring it would measure a prompt the runtime never sends", m)
+	}
+	return out, nil
+}
+
+// unexpandedPlaceholder matches any surviving {{...}} of either family.
+var unexpandedPlaceholder = regexp.MustCompile(`\{\{\s*(memory|tool)\s*:[^}]*\}\}`)

--- a/internal/cli/memory_eval_placeholders_test.go
+++ b/internal/cli/memory_eval_placeholders_test.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	meminject "github.com/denn-gubsky/loomcycle/internal/memory"
+)
+
+// TestExpandEvalPlaceholders_RendersTheOntology is the defect this exists for.
+//
+// The runtime turns {{memory:ontology}} into ~520 characters of entity types before
+// the model sees the prompt; this harness sent the nineteen literal characters. So
+// every score taken since the ontology landed in the extractor prompt measured a
+// prompt telling the model to "use one of the types above" where above was a
+// placeholder — a complete explanation for the eval's own finding that half the
+// emitted types fell outside the ontology.
+//
+// The bundle drift test could never catch it: the harness's copy and the bundle's
+// were identical throughout. What differed was the bundle's prompt versus what the
+// RUNTIME sends.
+func TestExpandEvalPlaceholders_RendersTheOntology(t *testing.T) {
+	got, err := expandEvalPlaceholders("You extract facts.\n\n{{memory:ontology}}\n\nRules.", "")
+	if err != nil {
+		t.Fatalf("expand: %v", err)
+	}
+	if strings.Contains(got, "{{memory:") {
+		t.Fatalf("the placeholder survived:\n%s", got)
+	}
+	// The seed types must actually be named — a rendering that produced an empty
+	// string would also "expand" and would be just as meaningless.
+	for _, want := range []string{"person", "organization", "Entity types"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expansion is missing %q:\n%s", want, got)
+		}
+	}
+	if len(got) < len("You extract facts.\n\n{{memory:ontology}}\n\nRules.")+300 {
+		t.Errorf("expansion added almost nothing — the model sees a fraction of what the runtime sends:\n%s", got)
+	}
+}
+
+// TestExpandEvalPlaceholders_ConfirmedTenantTermsChangeThePrompt. The whole point of
+// the flag: an unconfirmed deployment gets the seed alone, a confirmed one gets its
+// own types too, and the two produce materially different prompts. Scoring only the
+// first would answer a question nobody asked about a deployment that has confirmed.
+func TestExpandEvalPlaceholders_ConfirmedTenantTermsChangeThePrompt(t *testing.T) {
+	seed, err := expandEvalPlaceholders("{{memory:ontology}}", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	withTenant, err := expandEvalPlaceholders("{{memory:ontology}}", "project, incident ,constraint")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"project", "incident", "constraint"} {
+		if !strings.Contains(withTenant, want) {
+			t.Errorf("tenant term %q missing:\n%s", want, withTenant)
+		}
+		if strings.Contains(seed, want) {
+			t.Errorf("seed-only expansion should NOT carry tenant term %q", want)
+		}
+	}
+	// And the unconfirmed wording must not appear once terms ARE supplied, or the
+	// prompt would tell the model to ignore the very types it just listed.
+	if strings.Contains(withTenant, "has not confirmed") {
+		t.Errorf("a confirmed expansion still says the deployment has not confirmed:\n%s", withTenant)
+	}
+	if !strings.Contains(seed, "has not confirmed") {
+		t.Errorf("the seed-only expansion should say so:\n%s", seed)
+	}
+}
+
+// TestExpandEvalPlaceholders_RefusesWhatItCannotRender. user_info and tenant_info
+// read a live store this CLI does not have. Sending them verbatim is what already
+// happened to `ontology` and cost a baseline's worth of meaning, so an unrenderable
+// variant fails loudly instead.
+func TestExpandEvalPlaceholders_RefusesWhatItCannotRender(t *testing.T) {
+	for _, v := range []meminject.Variant{
+		meminject.VariantUserInfo, meminject.VariantTenantInfo, meminject.VariantCoreBlocks,
+	} {
+		_, err := expandEvalPlaceholders("prompt {{memory:"+string(v)+"}}", "")
+		if err == nil {
+			t.Errorf("%s must be refused, not sent literally", v)
+			continue
+		}
+		if !strings.Contains(err.Error(), string(v)) {
+			t.Errorf("the refusal should name the variant; got %v", err)
+		}
+	}
+	// The tool family too — same hazard, same silence.
+	if _, err := expandEvalPlaceholders("prompt {{tool:Context.tools}}", ""); err == nil {
+		t.Error("a {{tool:...}} placeholder must be refused")
+	}
+}
+
+// TestExpandEvalPlaceholders_LeavesAPlainPromptAlone: no placeholder, no change.
+func TestExpandEvalPlaceholders_LeavesAPlainPromptAlone(t *testing.T) {
+	const plain = "You extract durable facts from ONE chat transcript."
+	got, err := expandEvalPlaceholders(plain, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != plain {
+		t.Errorf("a prompt with no placeholder must be byte-identical:\n%q", got)
+	}
+}


### PR DESCRIPTION
`memory-eval-live` passed the extractor's system prompt to the model **verbatim**. The runtime expands `{{memory:ontology}}` into ~520 characters of entity types first; the eval sent the **nineteen literal characters**.

## What that invalidates

Every score taken since the ontology landed in that prompt was measured against a prompt telling the model to *"use one of the entity types above"* — where above was a placeholder.

That's a complete explanation for the eval's own headline finding. **"Half the emitted types are outside the ontology" wasn't a model ignoring its instructions — it was a model never given any.** `profession`, `setting`, `process`, `task` weren't defiance; they were invention in the absence of a vocabulary.

And it reconciles the contradiction I flagged after the live pass: on the deployment, where expansion *does* happen, the extractor used `person`/`project`/`constraint` correctly. Both observations were right. The instrument was wrong.

## Why the drift test didn't catch it

`TestExtractionPrompt_MatchesBundle` exists for exactly this hazard — *"a harness that scores its own copy reports on a prompt nobody runs"* — and it passed throughout, because the harness's copy and the bundle's **were** identical.

The gap: the bundle's prompt isn't what the runtime *sends*. The drift test pins harness-vs-source; nothing pinned source-vs-**rendered**. Placeholders opened a second gap of the same shape, underneath the guard built for the first.

## The fix, and the loud failure

Expansion covers `ontology` and **refuses everything else**. `user_info`, `tenant_info` and `core_blocks` read a live store a CLI doesn't have — and sending them verbatim is precisely what silently happened to `ontology`, so an unrenderable variant now errors with the variant named. The `{{tool:…}}` family is refused on the same grounds.

## `--ontology-terms`, which makes your deferred question answerable

A run can now reproduce a deployment whose operator has **confirmed** an ontology, not just the unconfirmed base-seed case. The two produce materially different prompts — and **the reference deployment has a confirmed ontology, so every score to date modelled a deployment without one.**

`confirmed` is derived from whether terms were supplied, so the seed-only rendering can't claim additions it doesn't have.

## Tested

4 tests: the ontology actually renders (and adds >300 chars — an expansion to empty would also "succeed" and be just as meaningless), confirmed-vs-seed produce different prompts *and* different wording, unrenderable variants are refused by name, and a placeholder-free prompt is byte-identical.

`gofmt` clean · full `go test ./...` green.

## ⚠️ The baseline is invalidated again

And rightly — it measured a prompt the runtime never sends. I'm running both conditions against qwen3.6 now (same corpus, same model, one variable) and will reseed from whichever matches the deployment, with the comparison as the record of what the ontology is actually worth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)