### PR TITLE
feat(store): make provenance searchable, so erasure can be enumerated

### DIFF
--- a/internal/store/postgres/migrations/0065_memory_source_session_index.down.sql
+++ b/internal/store/postgres/migrations/0065_memory_source_session_index.down.sql
@@ -1,0 +1,3 @@
+-- Reverses 0065. Dropping the index makes the provenance lookup a sequential scan
+-- of the memory table; it does not change any answer, only how long it takes.
+DROP INDEX IF EXISTS memory_by_source_session;

--- a/internal/store/postgres/migrations/0065_memory_source_session_index.up.sql
+++ b/internal/store/postgres/migrations/0065_memory_source_session_index.up.sql
@@ -1,0 +1,18 @@
+-- 0065_memory_source_session_index.up.sql — make provenance searchable.
+--
+-- source_session_id has been written on every consolidated fact since the memory
+-- tier's first phase, and read back one row at a time, but never searched. The
+-- decision it exists to serve — "provenance is mandatory for user scope so that
+-- erasure is enumerable" — needs the other direction: given a subject's chats,
+-- which facts anywhere derive from them.
+--
+-- That question cannot be answered from a subject-keyed delete, because a fact
+-- ABOUT someone written into an agent or tenant scope is not keyed to them. Their
+-- chats are, which makes this index the join that reaches the rest.
+--
+-- PARTIAL, because the column is NULL on every row that was not distilled from a
+-- chat — which is most of them. Indexing those would pay for the majority to
+-- support a query that never asks about them.
+CREATE INDEX IF NOT EXISTS memory_by_source_session
+    ON memory (tenant_id, source_session_id)
+    WHERE source_session_id IS NOT NULL;

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -4026,6 +4026,47 @@ func (s *Store) MemoryListScopeIDs(ctx context.Context, tenantID string, scope s
 	return out, rows.Err()
 }
 
+// MemoryListBySourceSessions implements store.Store.
+//
+// The postgres twin uses = ANY($2) rather than an IN list built from the slice:
+// one bind parameter instead of N, so a subject with hundreds of chats cannot blow
+// the parameter limit on the one query an erasure report depends on.
+func (s *Store) MemoryListBySourceSessions(ctx context.Context, tenantID string, sessionIDs []string, limit int) ([]store.MemoryProvenanceRow, error) {
+	if len(sessionIDs) == 0 {
+		return nil, nil // never everything — see the sqlite twin
+	}
+	if limit <= 0 || limit > memoryProvenanceMaxRows {
+		limit = memoryProvenanceMaxRows
+	}
+	rows, err := s.pool.Query(ctx,
+		`SELECT COALESCE(tenant_id, ''), scope, scope_id, key, COALESCE(source_session_id, '')
+		   FROM memory
+		  WHERE COALESCE(tenant_id, '') = $1
+		    AND source_session_id = ANY($2)
+		    AND (expires_at IS NULL OR expires_at > now())
+		    AND superseded_at IS NULL
+		  ORDER BY scope, scope_id, key
+		  LIMIT $3`, tenantID, sessionIDs, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []store.MemoryProvenanceRow
+	for rows.Next() {
+		var r store.MemoryProvenanceRow
+		var scope string
+		if err := rows.Scan(&r.TenantID, &scope, &r.ScopeID, &r.Key, &r.SourceSessionID); err != nil {
+			return nil, err
+		}
+		r.Scope = store.MemoryScope(scope)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// memoryProvenanceMaxRows bounds one provenance read — see the sqlite twin.
+const memoryProvenanceMaxRows = 5000
+
 // MemoryListTenantsForScope implements store.Store (RFC BL). DISTINCT over every
 // row for (scope, scopeID) regardless of expiry — reclamation deletes expired
 // rows too, so an all-expired partition must still be enumerated.

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -261,6 +261,11 @@ func (s *Store) migrate(ctx context.Context) error {
 			superseded_at     INTEGER,
 			PRIMARY KEY (tenant_id, scope, scope_id, key)
 		)`,
+		// Provenance, searchable at last. Mirrors postgres migration 0065: partial,
+		// because source_session_id is NULL on every row not distilled from a chat
+		// and indexing those pays for the majority to serve a query that never asks
+		// about them. See MemoryListBySourceSessions for why the direction matters.
+		`CREATE INDEX IF NOT EXISTS memory_by_source_session ON memory(tenant_id, source_session_id) WHERE source_session_id IS NOT NULL`,
 		`CREATE INDEX IF NOT EXISTS memory_by_expires_at ON memory(expires_at) WHERE expires_at IS NOT NULL`,
 		// RFC BL P2 — the durable consolidation substrate. Mirrors Postgres
 		// migration 0061. memory_pending is the enqueue queue an Add writes to
@@ -4493,6 +4498,66 @@ func (s *Store) MemoryListTenantsForScope(ctx context.Context, scope store.Memor
 	}
 	return out, rows.Err()
 }
+
+// MemoryListBySourceSessions implements store.Store.
+func (s *Store) MemoryListBySourceSessions(ctx context.Context, tenantID string, sessionIDs []string, limit int) ([]store.MemoryProvenanceRow, error) {
+	if len(sessionIDs) == 0 {
+		// An empty request returns nothing, never everything: the caller is an
+		// erasure report, and a permissive default would attribute the whole store to
+		// a subject who happens to have no chats.
+		//
+		// BOTH DIALECTS ALREADY DO THIS, and removing the guard passes every test —
+		// sqlite accepts `IN ()` as false, postgres matches nothing against an empty
+		// array. It stays because that agreement is a coincidence of two dialects
+		// rather than a guarantee: `IN ()` is a SQLite extension that standard SQL
+		// rejects outright, so the safe answer here would be a syntax error on a
+		// third tier, or on a driver that tightened. Making it explicit costs one
+		// branch and removes the need for anyone to know that.
+		return nil, nil
+	}
+	if limit <= 0 || limit > memoryProvenanceMaxRows {
+		limit = memoryProvenanceMaxRows
+	}
+	marks := make([]string, len(sessionIDs))
+	args := []any{tenantID}
+	for i, id := range sessionIDs {
+		marks[i] = "?"
+		args = append(args, id)
+	}
+	args = append(args, limit)
+	// Live rows only: an expired or superseded row is invisible to every read, so
+	// reporting it would overstate what is actually held.
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT COALESCE(tenant_id, ''), scope, scope_id, key, COALESCE(source_session_id, '')
+		   FROM memory
+		  WHERE COALESCE(tenant_id, '') = ?
+		    AND source_session_id IN (`+strings.Join(marks, ",")+`)
+		    AND (expires_at IS NULL OR expires_at > strftime('%s','now'))
+		    AND superseded_at IS NULL
+		  ORDER BY scope, scope_id, key
+		  LIMIT ?`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []store.MemoryProvenanceRow
+	for rows.Next() {
+		var r store.MemoryProvenanceRow
+		var scope string
+		if err := rows.Scan(&r.TenantID, &scope, &r.ScopeID, &r.Key, &r.SourceSessionID); err != nil {
+			return nil, err
+		}
+		r.Scope = store.MemoryScope(scope)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// memoryProvenanceMaxRows bounds one provenance read. An erasure report wants a
+// COUNT and a sample far more than it wants every row, and an unbounded scan over a
+// busy tenant is a foot-gun on the one code path an operator reaches for under
+// time pressure.
+const memoryProvenanceMaxRows = 5000
 
 // memoryOrphanQuerier lets the scan run either standalone or inside the
 // repair's transaction, so the returned report describes the same snapshot the

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1647,6 +1647,30 @@ type Store interface {
 	// no rows returns an empty slice, not an error.
 	MemoryListTenantsForScope(ctx context.Context, scope MemoryScope, scopeID string) ([]string, error)
 
+	// MemoryListBySourceSessions returns the live memory rows DERIVED FROM the
+	// given chats, across every scope in the tenant.
+	//
+	// This is the missing half of a decision the memory RFC locked as "provenance
+	// MANDATORY for user scope, so erasure is enumerable". The provenance was
+	// delivered — every consolidated fact records source_session_id and
+	// source_run_id, and a single-row read returns them — but nothing could ever
+	// search BY it. The column was written on every write and read back one row at
+	// a time, so the enumeration it existed for was impossible.
+	//
+	// It matters because subject-keyed deletion cannot reach a fact ABOUT someone
+	// that was written into an AGENT or TENANT scope: that row is not keyed to them.
+	// Their chats are, and a consolidated fact records which chat it came from — so
+	// walking sessions→facts is the only way to find it. A fact a model wrote
+	// without provenance stays unreachable, which no mechanism can fix and which the
+	// caller must therefore say out loud rather than imply completeness.
+	//
+	// Live rows only (unexpired, not superseded): a superseded row is already
+	// invisible to every read, and reporting it would overstate what is actually
+	// held. Ordered by scope then key so two calls agree. An empty sessionIDs
+	// returns no rows rather than every row — the dangerous default, given the one
+	// caller is an erasure report.
+	MemoryListBySourceSessions(ctx context.Context, tenantID string, sessionIDs []string, limit int) ([]MemoryProvenanceRow, error)
+
 	// MemoryOrphanScan reports memory rows stranded at the legacy "" tenant —
 	// rows a tenant-scoped session cannot reach. Read-only.
 	//
@@ -2772,6 +2796,19 @@ type MemoryEntry struct {
 	ExpiresAt time.Time       `json:"expires_at,omitempty"`
 	CreatedAt time.Time       `json:"created_at"`
 	UpdatedAt time.Time       `json:"updated_at"`
+}
+
+// MemoryProvenanceRow is one memory row located by the chat it was derived from.
+// It carries the coordinate rather than the value: the caller is deciding what to
+// erase or report, not reading content, and a report that echoed the values would
+// reproduce the very data it exists to account for.
+type MemoryProvenanceRow struct {
+	TenantID string      `json:"tenant_id"`
+	Scope    MemoryScope `json:"scope"`
+	ScopeID  string      `json:"scope_id"`
+	Key      string      `json:"key"`
+	// SourceSessionID is which of the requested chats this row came from.
+	SourceSessionID string `json:"source_session_id"`
 }
 
 // MemoryScopeIDSummary is one row of MemoryListScopeIDs' output.

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -148,6 +148,7 @@ func Run(t *testing.T, factory Factory) {
 		{"MemoryScopeIsolation", testMemoryScopeIsolation},
 		{"MemoryListScopeIDs", testMemoryListScopeIDs},
 		{"MemoryListTenantsForScope", testMemoryListTenantsForScope},
+		{"MemoryListBySourceSessions", testMemoryListBySourceSessions},
 		// RFC BL P2: the background-consolidation substrate.
 		{"MemorySupersedeHidesFromReads", testMemorySupersedeHidesFromReads},
 		{"MemorySupersedeIsIdempotent", testMemorySupersedeIsIdempotent},
@@ -10732,5 +10733,85 @@ func testMemoryScopeUsageExcludesNamespace(t *testing.T, s store.Store) {
 	}
 	if keys != 1 {
 		t.Errorf("keys = %d after superseding one of two, want 1 — a soft-archived row must not hold quota", keys)
+	}
+}
+
+// testMemoryListBySourceSessions pins the provenance lookup — the direction that
+// makes erasure enumerable.
+//
+// A fact ABOUT a subject written into an AGENT or TENANT scope is not keyed to that
+// subject, so no subject-keyed delete can reach it. Their chats are keyed to them,
+// and a consolidated fact records which chat it came from, which makes this the only
+// join that reaches the rest. It is asserted as a contract because both backends
+// must agree: an erasure that enumerated differently per tier would be a compliance
+// answer that depends on which database you happen to run.
+func testMemoryListBySourceSessions(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	const tenant = "acme"
+	set := func(scope store.MemoryScope, scopeID, key, session string) {
+		t.Helper()
+		v, _ := json.Marshal("v")
+		if session == "" {
+			if err := s.MemorySet(ctx, tenant, scope, scopeID, key, v, 0); err != nil {
+				t.Fatalf("seed %s: %v", key, err)
+			}
+			return
+		}
+		if err := s.MemorySetProvenance(ctx, tenant, scope, scopeID, key, v, 0,
+			store.MemoryProvenance{SourceSessionID: session}); err != nil {
+			t.Fatalf("seed %s: %v", key, err)
+		}
+	}
+
+	// The subject's own scope, plus facts about them that a shared agent and the
+	// tenant recorded — the rows a subject-keyed delete cannot see.
+	set(store.MemoryScopeUser, "alice", "memory/fact/alice-likes-go", "s_1")
+	set(store.MemoryScopeAgent, "curator", "memory/fact/alice-leads-platform", "s_1")
+	set(store.MemoryScopeTenant, "", "memory/fact/alice-owns-ledger", "s_2")
+	// Someone else's chat, and a row with no provenance at all.
+	set(store.MemoryScopeUser, "bob", "memory/fact/bob-likes-rust", "s_9")
+	set(store.MemoryScopeUser, "alice", "memory/fact/unattributed", "")
+
+	got, err := s.MemoryListBySourceSessions(ctx, tenant, []string{"s_1", "s_2"}, 0)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	keys := map[string]store.MemoryScope{}
+	for _, r := range got {
+		keys[r.Key] = r.Scope
+	}
+	if len(got) != 3 {
+		t.Fatalf("want 3 rows across three scopes, got %d: %v", len(got), keys)
+	}
+	// The point of the whole mechanism: scopes the subject does not own.
+	if keys["memory/fact/alice-leads-platform"] != store.MemoryScopeAgent {
+		t.Error("a fact about the subject in an AGENT scope was not reached — this is what subject-keyed deletion misses")
+	}
+	if keys["memory/fact/alice-owns-ledger"] != store.MemoryScopeTenant {
+		t.Error("a fact about the subject in the TENANT scope was not reached")
+	}
+	if _, leaked := keys["memory/fact/bob-likes-rust"]; leaked {
+		t.Error("another subject's chat was included — an erasure report must not over-claim")
+	}
+	if _, leaked := keys["memory/fact/unattributed"]; leaked {
+		t.Error("a row with no provenance was included; it cannot be attributed to any chat")
+	}
+
+	// An empty request must return NOTHING, never everything. The caller is an
+	// erasure report, so a permissive default would attribute the whole store to a
+	// subject who happens to have no chats.
+	if rows, err := s.MemoryListBySourceSessions(ctx, tenant, nil, 0); err != nil || len(rows) != 0 {
+		t.Errorf("empty sessionIDs must match nothing, got %d rows (err %v)", len(rows), err)
+	}
+	// Tenant isolation: another tenant's identical session id must not match.
+	if rows, _ := s.MemoryListBySourceSessions(ctx, "other-tenant", []string{"s_1", "s_2"}, 0); len(rows) != 0 {
+		t.Errorf("cross-tenant leak: %d rows", len(rows))
+	}
+	// And the source chat is reported, so a caller can say WHICH conversation a
+	// fact came from rather than only that it came from one of several.
+	for _, r := range got {
+		if r.SourceSessionID != "s_1" && r.SourceSessionID != "s_2" {
+			t.Errorf("row %s reports source %q, which was not requested", r.Key, r.SourceSessionID)
+		}
 	}
 }


### PR DESCRIPTION
**RFC BL P5, PR 0c** — the missing half of a decision the RFC locked long ago: *"provenance MANDATORY for user scope, so erasure is enumerable."*

## Half of it shipped, half never did

Every consolidated fact records `source_session_id` and `source_run_id`, and a single-row read returns them. But **nothing could search by those columns** — they were written on every write, read back one row at a time, and the question they exist to answer could not be asked.

That question isn't cosmetic. **A subject-keyed delete cannot reach a fact *about* someone written into an `agent` or `tenant` scope** — that row is keyed to the agent or the tenant, not to them. Their *chats* are keyed to them, and a consolidated fact records which chat it came from, so `sessions → facts` is the only join that reaches the rest.

Without it, an erasure op can only report tier 3 as *"not enumerable"*. With it, as a count.

## What it returns, and doesn't

Coordinates — tenant, scope, scope_id, key, source chat — **not values**. The caller is deciding what to erase or report, and a report that echoed the values would reproduce the very data it exists to account for.

Live rows only: a superseded row is invisible to every read, so counting it would overstate what's held.

Indexed on `(tenant_id, source_session_id)`, **partial** — the column is NULL on every row not distilled from a chat, which is most of them, and indexing those makes the majority pay for a query that never asks about them. Postgres migration **0065** plus the mirrored sqlite index.

## The contract test caught a real bug on the tier I couldn't check by reading

I wrote the sqlite epoch idiom and carried it straight to postgres:

```
list: ERROR: operator does not exist: timestamp with time zone > numeric (SQLSTATE 42883)
```

`expires_at` is an epoch number on sqlite and a `timestamptz` on postgres. This is a **contract** rather than two separate tests precisely because an erasure that enumerated differently per tier would be a compliance answer that depends on which database you happen to run. CI's `Go (Postgres store contract)` job runs the whole contract, so it would have caught this too.

## A fail-before that passed, and why the guard stays anyway

Tenant isolation is fail-before verified. The **empty-request guard's mutation passed** — both dialects already return nothing (sqlite accepts `IN ()` as false, postgres matches nothing against an empty array).

It's kept, with that recorded at the site: the agreement is a *coincidence of two dialects*, not a guarantee — `IN ()` is a SQLite extension that standard SQL rejects, so the "safe" behaviour would become a syntax error on a third tier or a tightened driver.

Second time this session a fail-before has shown a guard redundant-by-measurement. The first (`normalizeSubject`) I deleted; this one I kept. The difference is whether the behaviour is *guaranteed* elsewhere or merely *happens to hold* — `slug()` genuinely normalises, whereas two dialects agreeing is luck.

## No caller yet — deliberately, and stated

**0d (the erasure report) is the caller**, and this lands first because it's what lets that report *count* the residue instead of admitting it can't look. Given this phase's history with capabilities that shipped inert, I'd rather say that plainly than have it noticed later: if 0d doesn't follow, this should be reverted rather than left sitting.

`gofmt` clean · full `go test ./...` green · contract green on **both** tiers (postgres run takes ~4 min locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)