### PR TITLE
feat(memory): report one subject's footprint across all three tiers

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -582,6 +582,19 @@ func requiredScopeFor(method, path string) string {
 	// ScopeAdmin also satisfies. Read-only GET.
 	case path == "/v1/_usage":
 		return auth.ScopeTenant
+	// The per-subject erasure report (GET). Tenant-readable, and deliberately so:
+	// answering "what do you hold about this person" is the tenant OPERATOR's job
+	// — they are the controller for their own tenant's subjects — and requiring
+	// operator-admin would put a routine data-subject request behind a token that
+	// can read every OTHER tenant too. principalTenantScope confines the walk to
+	// the caller's tenant; admin additionally gets the ?tenant= focus.
+	//
+	// Not narrower than ScopeTenant despite reading across scopes: everything it
+	// counts is already listable by this principal through /v1/_usage,
+	// /v1/_credentialdef and the Path/Memory surfaces. It aggregates a view that
+	// is reachable today, rather than granting new reach.
+	case path == "/v1/_erasure":
+		return auth.ScopeTenant
 	// RFC BM: the data-retention view. Tenant-readable so a tenant operator's UI
 	// can see whether retention is enabled + how it's tuned; the HANDLER strips
 	// the cross-tenant purgeable counts + the export dir for a non-admin caller

--- a/internal/api/http/erasure_report.go
+++ b/internal/api/http/erasure_report.go
@@ -1,0 +1,273 @@
+package http
+
+// erasure_report.go — what this deployment holds about one subject.
+//
+// Read-only, deliberately, and shipped before the deletion half. Two reasons.
+//
+// It is useful on its own: "what do you hold about me" is a request in its own
+// right, asked far more often than "delete it", and answering it should not require
+// arming something destructive.
+//
+// And it is the honest order. An erasure op that cannot enumerate what it will miss
+// reads as completeness, which is worse than an honest gap: a subject-keyed delete
+// that silently leaves facts ABOUT the subject in a shared scope looks like
+// compliance from the outside. Naming that residue is the more valuable half.
+//
+// THREE TIERS, kept apart because they carry different guarantees rather than
+// because they are three lists:
+//
+//   1. Subject-keyed, and existing primitives already delete it.
+//   2. Subject-keyed, and NOTHING deletes it today.
+//   3. Not subject-keyed at all: a fact about the subject that a shared agent or the
+//      tenant recorded. Reachable only through provenance, and only for rows that
+//      carry it.
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// erasureReport is the wire shape of GET /v1/_erasure.
+type erasureReport struct {
+	Tenant  string `json:"tenant"`
+	Subject string `json:"subject"`
+
+	Tier1 erasureTier    `json:"tier1_covered"`
+	Tier2 erasureTier    `json:"tier2_uncovered"`
+	Tier3 erasureResidue `json:"tier3_residue"`
+
+	// Notes carry limits a count cannot express, so the numbers are not mistaken
+	// for the whole truth.
+	Notes []string `json:"notes"`
+	// Errors names planes that could not be read. A plane that FAILED is not a
+	// plane that is empty, and a report that cannot tell them apart is unusable
+	// for the question it exists to answer.
+	Errors []string `json:"errors,omitempty"`
+}
+
+type erasureTier struct {
+	Counts map[string]int64 `json:"counts"`
+	Total  int64            `json:"total"`
+}
+
+// erasureResidue is what a subject-keyed delete cannot reach.
+type erasureResidue struct {
+	Rows int `json:"rows"`
+	// Scopes names WHERE those rows are: "3 rows somewhere" is not actionable,
+	// "3 rows in agent:curator" is.
+	Scopes []string `json:"scopes"`
+	// SessionsExamined is how many chats the walk traced from. A residue of 0
+	// across 0 sessions means "nothing to trace from" — a different statement from
+	// "nothing derives from them".
+	SessionsExamined int `json:"sessions_examined"`
+	// Truncated reports the provenance read hit its bound, making the count a floor.
+	Truncated bool `json:"truncated"`
+}
+
+func (t *erasureTier) set(name string, n int64) {
+	t.Counts[name] = n
+	t.Total += n
+}
+
+// handleErasureReport serves GET /v1/_erasure?subject=…
+//
+// Admin-only via the /v1/_* catch-all, and correctly so: it enumerates one
+// subject's footprint across every scope in the tenant, including scopes that
+// subject cannot read. An operator's view of a person, not a person's view of
+// themselves.
+func (s *Server) handleErasureReport(w http.ResponseWriter, r *http.Request) {
+	subject := strings.TrimSpace(r.URL.Query().Get("subject"))
+	if subject == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing_subject",
+			"pass ?subject=<user id> — the principal whose footprint to report")
+		return
+	}
+	if s.store == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "no_store", "no store configured")
+		return
+	}
+	ctx := r.Context()
+	tenant, all := s.principalTenantScope(ctx, r.URL.Query().Get("tenant"))
+	// An admin with no ?tenant= means "all tenants" everywhere else in this API,
+	// and here that cannot be served: a subject id is only meaningful WITHIN a
+	// tenant — the same string in two tenants is two different footprints, and
+	// merging them would report one person's residue as another's.
+	//
+	// Refusing rather than defaulting, because the default is the trap: `all` also
+	// carries tenant "", which every store read below would happily interpret as
+	// the DEFAULT tenant and answer confidently about the wrong people.
+	//
+	// Has() rather than != "": it distinguishes an explicit `?tenant=` (the default
+	// tenant, which is the whole deployment on a single-tenant install) from an
+	// omitted one. Without that, a single-tenant admin could not ask at all.
+	if all && !r.URL.Query().Has("tenant") {
+		writeJSONError(w, http.StatusBadRequest, "tenant_required",
+			"an admin token must name the tenant: a subject id is only unique within one. "+
+				"Pass ?tenant=<id>, or ?tenant= for the default tenant.")
+		return
+	}
+
+	rep := erasureReport{
+		Tenant:  tenant,
+		Subject: subject,
+		Tier1:   erasureTier{Counts: map[string]int64{}},
+		Tier2:   erasureTier{Counts: map[string]int64{}},
+	}
+	// fail records a plane it could not read. Every read below is best-effort so
+	// one broken plane does not deny the whole report — but a silent skip would
+	// UNDERCOUNT, which is the one failure mode this report must not have.
+	fail := func(plane string, err error) {
+		rep.Errors = append(rep.Errors, plane+": "+err.Error())
+	}
+
+	// ---- tier 1: subject-keyed, and already deletable ----
+	sessions, err := s.subjectSessions(ctx, tenant, subject)
+	if err != nil {
+		fail("chats", err)
+	}
+	rep.Tier1.set("chats", int64(len(sessions)))
+
+	if entries, _, err := s.store.MemoryList(ctx, tenant, store.MemoryScopeUser, subject, "", 0); err != nil {
+		fail("memory", err)
+	} else {
+		rep.Tier1.set("memory_rows", int64(len(entries)))
+	}
+	if s.sqlMem != nil {
+		// A user-scope SQL Memory database holds the entity graph and every document
+		// this subject authored; DropScope removes it whole.
+		if scopes, err := s.sqlMem.ListScopes(ctx); err != nil {
+			fail("sql_memory", err)
+		} else {
+			for _, sk := range scopes {
+				if sk.Scope == "user" && sk.ScopeID == subject {
+					rep.Tier1.set("sql_memory_scopes", 1)
+					break
+				}
+			}
+		}
+	}
+	if rows, err := s.store.DirentListUnder(ctx, tenant, "user", subject, "/"); err != nil {
+		fail("paths", err)
+	} else {
+		rep.Tier1.set("path_entries", int64(len(rows)))
+	}
+
+	// ---- tier 2: subject-keyed, and nothing deletes it ----
+	//
+	// Its own tier rather than folded in, because the difference is not how many
+	// rows there are but whether anything can remove them. A subject's ENCRYPTED
+	// CREDENTIALS surviving an "erasure" is the worst entry on this list, and it is
+	// invisible unless something counts it.
+	if creds, err := s.store.CredentialDefList(ctx, tenant, "user", subject); err != nil {
+		fail("credentials", err)
+	} else {
+		rep.Tier2.set("credentials", int64(len(creds)))
+	}
+	if limits, err := s.store.TokenLimitsAll(ctx); err != nil {
+		fail("token_limits", err)
+	} else {
+		var n int64
+		for _, l := range limits {
+			if l.TenantID == tenant && l.Scope == "user" && l.ScopeID == subject {
+				n++
+			}
+		}
+		rep.Tier2.set("token_limits", n)
+	}
+	if ints, err := s.store.InterruptListByUser(ctx, subject, tenant, ""); err != nil {
+		fail("interrupts", err)
+	} else {
+		rep.Tier2.set("interrupts", int64(len(ints)))
+	}
+	if agg, err := s.store.UsageReport(ctx, store.UsageQuery{
+		TenantID: tenant, GroupBy: []store.UsageDimension{store.UsageByUser},
+	}); err != nil {
+		fail("usage", err)
+	} else {
+		var calls int64
+		for _, a := range agg {
+			if a.UserID == subject {
+				calls += a.CallCount
+			}
+		}
+		rep.Tier2.set("usage_ledger_calls", calls)
+	}
+
+	// ---- tier 3: not subject-keyed at all ----
+	rep.Tier3, err = s.erasureResidueFor(ctx, tenant, subject, sessions)
+	if err != nil {
+		fail("provenance", err)
+	}
+
+	rep.Notes = []string{
+		"tier1 is deletable with existing primitives. tier2 is subject-keyed but nothing deletes it yet — the credential rows are the ones that matter.",
+		"tier3 is found through provenance, so it covers only facts that RECORDED the chat they came from. A fact written about this subject WITHOUT provenance is not reachable by any mechanism, and is not counted here.",
+		"counts are live rows: expired and superseded rows are excluded, because they are invisible to every read and counting them would overstate what is held.",
+	}
+	if rep.Tier3.Truncated {
+		rep.Notes = append(rep.Notes,
+			"the provenance walk hit its row bound, so tier3 is a FLOOR rather than a total.")
+	}
+	if len(rep.Errors) > 0 {
+		rep.Notes = append(rep.Notes,
+			"one or more planes could not be read (see errors) — every count here is a LOWER BOUND.")
+	}
+	writeJSON(w, http.StatusOK, rep)
+}
+
+// subjectSessions lists the subject's chats — the handle tier 3 is traced from.
+func (s *Server) subjectSessions(ctx context.Context, tenant, subject string) ([]string, error) {
+	var out []string
+	const page = 500
+	for offset := 0; ; offset += page {
+		rows, _, err := s.store.ListSessions(ctx,
+			store.SessionFilter{TenantID: tenant, UserID: subject}, page, offset)
+		if err != nil {
+			return out, err
+		}
+		for _, r := range rows {
+			out = append(out, r.SessionID)
+		}
+		if len(rows) < page {
+			return out, nil
+		}
+	}
+}
+
+// erasureResidueFor walks the subject's chats to the facts derived from them —
+// the only route to a fact about them living in a scope they do not own.
+func (s *Server) erasureResidueFor(ctx context.Context, tenant, subject string, sessions []string) (erasureResidue, error) {
+	res := erasureResidue{SessionsExamined: len(sessions), Scopes: []string{}}
+	if len(sessions) == 0 {
+		return res, nil
+	}
+	const bound = 5000
+	rows, err := s.store.MemoryListBySourceSessions(ctx, tenant, sessions, bound)
+	if err != nil {
+		return res, err
+	}
+	seen := map[string]bool{}
+	for _, row := range rows {
+		// The subject's OWN user scope is tier 1 — already counted, already
+		// deletable. Every other scope is residue, INCLUDING another user's scope:
+		// a fact about this subject filed under a different person is exactly what
+		// a subject-keyed delete misses, and is the case most worth surfacing.
+		if row.Scope == store.MemoryScopeUser && row.ScopeID == subject {
+			continue
+		}
+		res.Rows++
+		label := string(row.Scope)
+		if row.ScopeID != "" {
+			label += ":" + row.ScopeID
+		}
+		if !seen[label] {
+			seen[label] = true
+			res.Scopes = append(res.Scopes, label)
+		}
+	}
+	res.Truncated = len(rows) == bound
+	return res, nil
+}

--- a/internal/api/http/erasure_report_test.go
+++ b/internal/api/http/erasure_report_test.go
@@ -1,0 +1,182 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// TestErasureReport_CountsResidueOutsideTheSubjectsOwnScope is the behaviour the
+// whole report exists for.
+//
+// A subject-keyed delete finds the fact in the subject's OWN user scope and stops.
+// It cannot find a fact ABOUT them that a shared agent filed under itself, or that
+// another user's scope holds — those rows are not keyed to the subject at all, and
+// the only thing connecting them is the chat they were derived from.
+//
+// So the assertion is not "the report returns numbers". It is that the two
+// unreachable rows are counted SEPARATELY from the reachable one, and that the
+// scopes holding them are named. A report that summed all three would read as
+// "3 rows, all deletable" — precisely the false-completeness this is built to
+// prevent.
+func TestErasureReport_CountsResidueOutsideTheSubjectsOwnScope(t *testing.T) {
+	srv, _ := makeServer(t, completingProvider(), makeBaseConfig())
+	ctx := context.Background()
+	const tenant, subject = "acme", "alice"
+
+	// A chat owned by the subject: the handle every derived fact is traced from.
+	sess, err := srv.store.CreateSession(ctx, tenant, "chat", subject)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prov := store.MemoryProvenance{Origin: "consolidator", SourceSessionID: sess.ID}
+	val := json.RawMessage(`{"text":"alice prefers async review"}`)
+
+	// Three facts, all derived from that one chat, differing only in WHERE they
+	// were filed — which is the entire difference between reachable and not.
+	for _, w := range []struct {
+		scope   store.MemoryScope
+		scopeID string
+	}{
+		{store.MemoryScopeUser, subject},    // tier 1 — the subject's own scope
+		{store.MemoryScopeAgent, "curator"}, // tier 3 — a shared agent's scope
+		{store.MemoryScopeUser, "bob"},      // tier 3 — ANOTHER user's scope
+	} {
+		if err := srv.store.MemorySetProvenance(ctx, tenant, w.scope, w.scopeID,
+			"memory/fact/alice-review", val, 0, prov); err != nil {
+			t.Fatalf("seed %s/%s: %v", w.scope, w.scopeID, err)
+		}
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/_erasure?tenant="+tenant+"&subject="+subject, nil).
+		WithContext(auth.WithPrincipal(ctx, auth.Principal{
+			TenantID: tenant, Subject: "root", Scopes: []string{auth.ScopeAdmin},
+		}))
+	srv.handleErasureReport(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	var rep erasureReport
+	if err := json.Unmarshal(rec.Body.Bytes(), &rep); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(rep.Errors) > 0 {
+		t.Fatalf("planes failed to read, so every count is a lower bound: %v", rep.Errors)
+	}
+
+	// The subject's own fact is reachable, and is NOT residue.
+	if got := rep.Tier1.Counts["memory_rows"]; got != 1 {
+		t.Errorf("tier1 memory_rows = %d, want 1 (the fact in the subject's own scope)", got)
+	}
+	// The other two are residue: a subject-keyed delete leaves them behind.
+	if rep.Tier3.Rows != 2 {
+		t.Errorf("tier3 rows = %d, want 2 (agent:curator + user:bob); "+
+			"a residue count that misses these makes the report claim completeness it does not have",
+			rep.Tier3.Rows)
+	}
+	// And the report must say WHERE, or an operator cannot act on it.
+	want := map[string]bool{"agent:curator": true, "user:bob": true}
+	for _, s := range rep.Tier3.Scopes {
+		delete(want, s)
+	}
+	if len(want) > 0 {
+		t.Errorf("tier3 scopes = %v, missing %v", rep.Tier3.Scopes, want)
+	}
+	if rep.Tier3.SessionsExamined != 1 {
+		t.Errorf("sessions_examined = %d, want 1", rep.Tier3.SessionsExamined)
+	}
+}
+
+// TestErasureReport_UnreadablePlaneIsReportedNotSilentlyZero locks the failure
+// mode that would make this report dangerous.
+//
+// Every plane read is best-effort so one broken store does not deny the whole
+// answer. The hazard in that choice is that a plane which ERRORS looks exactly
+// like a plane that is EMPTY — and "we hold nothing about you" derived from a
+// failed query is the worst possible wrong answer here.
+func TestErasureReport_UnreadablePlaneIsReportedNotSilentlyZero(t *testing.T) {
+	srv, _ := makeServer(t, completingProvider(), makeBaseConfig())
+	ctx := context.Background()
+
+	// Close the store out from under the handler so its reads fault.
+	if closer, ok := srv.store.(interface{ Close() error }); ok {
+		if err := closer.Close(); err != nil {
+			t.Fatalf("close store: %v", err)
+		}
+	} else {
+		t.Skip("store has no Close; cannot simulate a read fault")
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/_erasure?tenant=acme&subject=alice", nil).
+		WithContext(auth.WithPrincipal(ctx, auth.Principal{
+			TenantID: "acme", Subject: "root", Scopes: []string{auth.ScopeAdmin},
+		}))
+	srv.handleErasureReport(rec, req)
+
+	var rep erasureReport
+	if err := json.Unmarshal(rec.Body.Bytes(), &rep); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(rep.Errors) == 0 {
+		t.Fatalf("a report built from failed reads returned no errors — "+
+			"an all-zero report would be indistinguishable from 'nothing is held'; body: %s",
+			rec.Body.String())
+	}
+	var sawBound bool
+	for _, n := range rep.Notes {
+		if len(n) > 0 && containsLowerBound(n) {
+			sawBound = true
+		}
+	}
+	if !sawBound {
+		t.Errorf("errors were reported but no note warns the counts are a lower bound: %v", rep.Notes)
+	}
+}
+
+// TestErasureReport_AdminMustNameTheTenant locks the refusal.
+//
+// Everywhere else in this API an admin omitting ?tenant= means "all tenants". Here
+// it cannot: `all` carries tenant "", which every store read would answer for the
+// DEFAULT tenant — producing a confident report about a different set of people
+// than the one asked about. Refusing is the only answer that cannot be wrong.
+func TestErasureReport_AdminMustNameTheTenant(t *testing.T) {
+	srv, _ := makeServer(t, completingProvider(), makeBaseConfig())
+	adminCtx := auth.WithPrincipal(context.Background(), auth.Principal{
+		TenantID: "ops", Subject: "root", Scopes: []string{auth.ScopeAdmin},
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/_erasure?subject=alice", nil).WithContext(adminCtx)
+	srv.handleErasureReport(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("omitted tenant: status = %d, want 400 — an unnamed tenant would be "+
+			"silently answered as the default one; body: %s", rec.Code, rec.Body.String())
+	}
+
+	// An EXPLICIT empty tenant is a real request: on a single-tenant install the
+	// default tenant is the whole deployment, and refusing it would lock the
+	// admin out of their own data.
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/v1/_erasure?tenant=&subject=alice", nil).WithContext(adminCtx)
+	srv.handleErasureReport(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("explicit ?tenant=: status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func containsLowerBound(s string) bool {
+	const want = "LOWER BOUND"
+	for i := 0; i+len(want) <= len(s); i++ {
+		if s[i:i+len(want)] == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2721,6 +2721,7 @@ func (s *Server) Mux() http.Handler {
 	// operator confirms its OWN tenant's ontology; the GET provisions the document
 	// on first reference so it can be authored before any run needs it. Authoring
 	// itself stays in the Path/Document browser. Scope-gated in requiredScopeFor.
+	mux.Handle("GET /v1/_erasure", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleErasureReport))))
 	mux.Handle("GET /v1/_ontology", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleOntology))))
 	mux.Handle("POST /v1/_ontology", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleOntologySetStatus))))
 	// RFC BK P3: resident interactive sub-agent visibility + operator control.


### PR DESCRIPTION
## Why

RFC BL P5 **0d** — and the caller [#910](https://github.com/denn-gubsky/loomcycle/pull/910) was committed to. `GET /v1/_erasure?tenant=&subject=` answers *"what does this deployment hold about this person"*, and the half that matters: **what a subject-keyed delete would miss**.

The report ships before the deletion because an erasure op that cannot enumerate its own gaps reads as completeness — worse than an honest gap. A delete that leaves facts about the subject in a shared agent's scope looks like compliance from the outside. And "what do you hold about me" is asked far more often than "delete it"; answering it shouldn't require arming something destructive.

## What

Three tiers, kept apart because they carry different **guarantees**, not because they're three lists:

| tier | what | deletable today |
|---|---|---|
| 1 | chats, user-scope memory, the user's SQL Memory scope, path entries | ✅ existing primitives |
| 2 | credentials, token limits, interrupts, usage ledger | ❌ **nothing** |
| 3 | facts about the subject in a shared agent's or another user's scope | ❌ not even addressable |

Tier 2 is separate because the difference isn't row count but whether anything can remove them. A subject's **encrypted credentials** surviving an "erasure" is the worst entry on that list, and it's invisible unless something counts it.

Tier 3 is what #910's `MemoryListBySourceSessions` was built for. This is its caller.

## Two designed-against failure modes

Both would produce a *confident wrong answer* rather than an error:

- **A plane that fails to read looks exactly like a plane that is empty.** Reads stay best-effort so one broken store doesn't deny the whole report — but each fault is named in `errors`, and every count is then declared a lower bound. Without this, an all-zero report reads as "we hold nothing about you" when in fact every query failed.
- **An admin omitting `?tenant=`** means "all tenants" everywhere else in this API. Here it can't: `all` carries tenant `""`, which every read below would answer for the *default* tenant. Refused with 400. `Has()` rather than `!= ""`, so an explicit `?tenant=` still works on a single-tenant install.

## Scope gate

`ScopeTenant`, not `ScopeAdmin`. Answering a data-subject request is the tenant operator's job; requiring operator-admin would put routine compliance work behind a token that reads every *other* tenant too. It aggregates a view this principal can already reach rather than granting new reach, and `principalTenantScope` confines the walk. Both the handler and the route are gated — the #577 lesson.

## Tested

- `TestErasureReport_CountsResidueOutsideTheSubjectsOwnScope` — one fact in each of the subject's own scope, a shared agent's, and **another user's**; asserts the latter two land in tier 3 with scopes named. **Fail-before:** treating all user-scope rows as tier 1 (my first draft's bug) drops tier3 to 1.
- `TestErasureReport_UnreadablePlaneIsReportedNotSilentlyZero` — closes the store, asserts faults surface. **Fail-before** yields exactly the artifact this must never produce: `{"tier1":{"total":0},"tier3":{"rows":0}}`.
- `TestErasureReport_AdminMustNameTheTenant` — the refusal *and* the explicit-empty case.

Full suite green. Postgres tier is covered in CI (`pgvector/pgvector:pg16`); the local PG box lacks pgvector, so every fresh-database test fails there identically on main (13 before, 13 after) — including #910's contract subtest, which did run on postgres at the time (that's how it caught the `timestamptz` bug).

## Not in this PR

The **deletion** half. Tier 1 has primitives; tier 2 needs ~5 new store methods × 2 backends. That's its own PR, and it should land behind a `dry_run` default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8