### PR TITLE
feat(memory): execute a subject erasure over tiers 1 and 2

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -593,6 +593,13 @@ func requiredScopeFor(method, path string) string {
 	// counts is already listable by this principal through /v1/_usage,
 	// /v1/_credentialdef and the Path/Memory surfaces. It aggregates a view that
 	// is reachable today, rather than granting new reach.
+	//
+	// POST (the erasure itself) shares the gate for the same reason — executing a
+	// data-subject request is the same operator's job as answering one, and every
+	// plane it deletes is already deletable by this principal one call at a time.
+	// The protection against an accidental erasure is NOT the scope (an admin
+	// token would be no less able to do it): it is dry_run defaulting true via a
+	// *bool, and confirm having to equal subject on a live run.
 	case path == "/v1/_erasure":
 		return auth.ScopeTenant
 	// RFC BM: the data-retention view. Tenant-readable so a tenant operator's UI

--- a/internal/api/http/erasure_execute.go
+++ b/internal/api/http/erasure_execute.go
@@ -1,0 +1,280 @@
+package http
+
+// erasure_execute.go — the deletion half of RFC BL P5 0d.
+//
+// POST /v1/_erasure removes what the GET report calls tier 1 and tier 2, reports
+// what it cannot reach, and defaults to doing nothing.
+//
+// THE RESIDUE REPORT IS ONE-SHOT, and this is the sharpest thing to understand
+// about the whole operation.
+//
+// Tier 3 is reachable ONLY by tracing provenance from the subject's sessions. This
+// call deletes those sessions. So the moment it succeeds, the trace handle is gone
+// and no future query can find the residue again — a report run afterwards returns
+// `residue: 0` while the facts are still sitting in a shared agent's scope. Not a
+// bug to be fixed here: it is what "the subject's chats are deleted" MEANS when
+// chats are the only index into derived facts.
+//
+// Two consequences the code owes the caller:
+//
+//   - The residue is measured BEFORE anything is deleted, and the session ids are
+//     captured up front rather than re-derived, so the measurement is unaffected by
+//     the deletions that follow.
+//   - THE RESPONSE IS THE ONLY DURABLE RECORD OF THE RESIDUE. Said in `notes`,
+//     because an operator who discards it has destroyed the sole evidence of what
+//     the erasure did not reach.
+//
+// The GET report closes the matching lie from its side: with zero sessions to trace
+// from it reports residue-undeterminable rather than residue-zero.
+//
+// Chats still go LAST, but for the weaker reason only — transcripts are the
+// recovery record, so a crash mid-erasure should leave them standing.
+//
+// WHAT IT DELIBERATELY DOES NOT DELETE is as much the point as what it does. The
+// usage/cost ledger is retained, not erased — those rows are accounting records an
+// operator may be under a legal obligation to keep, and the right treatment is to
+// break the personal linkage rather than destroy the totals. That is a merge, not a
+// delete (usage_archive keys user_id inside its PRIMARY KEY, so anonymising means
+// folding rows into the '' bucket and summing), and it deserves its own change
+// rather than being swept in here. Reported under `retained` with the reason, so it
+// is a stated decision rather than a silent gap.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+type erasureRequest struct {
+	Subject string `json:"subject"`
+	// DryRun defaults TRUE via the pointer: an omitted field must mean "do
+	// nothing". A plain bool would make the zero value destructive, so a caller
+	// who forgot the field — or sent {} — would erase.
+	DryRun *bool `json:"dry_run"`
+	// Confirm must equal Subject on a live run. A typo'd subject that matches
+	// nothing is harmless; one that matches the WRONG person is not, and this is
+	// the cheapest guard that catches it.
+	Confirm string `json:"confirm"`
+}
+
+type erasureResult struct {
+	Tenant  string `json:"tenant"`
+	Subject string `json:"subject"`
+	DryRun  bool   `json:"dry_run"`
+
+	// Deleted is per-plane counts — what went, or what WOULD go on a dry run.
+	Deleted map[string]int `json:"deleted"`
+	// Retained is plane → why it was kept. Never empty: the residue is always
+	// reported, because an erasure that lists only its successes reads as
+	// complete.
+	Retained map[string]string `json:"retained"`
+	// Residue is the tier-3 report, carried through unchanged.
+	Residue erasureResidue `json:"residue"`
+
+	Errors []string `json:"errors,omitempty"`
+	Notes  []string `json:"notes"`
+}
+
+// handleErasureExecute serves POST /v1/_erasure.
+func (s *Server) handleErasureExecute(w http.ResponseWriter, r *http.Request) {
+	var req erasureRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<16)).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "bad_request", "decode body: "+err.Error())
+		return
+	}
+	subject := strings.TrimSpace(req.Subject)
+	if subject == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing_subject", "subject is required")
+		return
+	}
+	if s.store == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "no_store", "no store configured")
+		return
+	}
+	dryRun := true
+	if req.DryRun != nil {
+		dryRun = *req.DryRun
+	}
+	if !dryRun && req.Confirm != subject {
+		writeJSONError(w, http.StatusBadRequest, "confirm_mismatch",
+			"a live erasure requires confirm to equal subject — this is irreversible")
+		return
+	}
+
+	ctx := r.Context()
+	tenant, all := s.principalTenantScope(ctx, r.URL.Query().Get("tenant"))
+	// Same refusal as the GET, and it matters more here: tenant "" would not merely
+	// report the wrong people, it would DELETE them.
+	if all && !r.URL.Query().Has("tenant") {
+		writeJSONError(w, http.StatusBadRequest, "tenant_required",
+			"an admin token must name the tenant: a subject id is only unique within one. "+
+				"Pass ?tenant=<id>, or ?tenant= for the default tenant.")
+		return
+	}
+
+	res := erasureResult{
+		Tenant: tenant, Subject: subject, DryRun: dryRun,
+		Deleted:  map[string]int{},
+		Retained: map[string]string{},
+	}
+	fail := func(plane string, err error) {
+		res.Errors = append(res.Errors, plane+": "+err.Error())
+	}
+
+	// The session list is read FIRST and used LAST: it is both the tier-3 trace
+	// handle and the final thing deleted.
+	sessions, err := s.subjectSessions(ctx, tenant, subject)
+	if err != nil {
+		fail("chats", err)
+	}
+
+	// Measured BEFORE anything is deleted, from session ids already captured — see
+	// the file header on why this number can never be recovered afterwards.
+	res.Residue, err = s.erasureResidueFor(ctx, tenant, subject, sessions)
+	if err != nil {
+		fail("provenance", err)
+	}
+
+	// ---- tier 2 first: no other plane depends on it ----
+	if creds, err := s.store.CredentialDefList(ctx, tenant, "user", subject); err != nil {
+		fail("credentials", err)
+	} else {
+		for _, c := range creds {
+			if dryRun {
+				res.Deleted["credentials"]++
+				continue
+			}
+			if ok, err := s.store.CredentialDefDelete(ctx, tenant, "user", subject, c.Name); err != nil {
+				fail("credentials", err)
+			} else if ok {
+				res.Deleted["credentials"]++
+			}
+		}
+	}
+	if limits, err := s.store.TokenLimitsAll(ctx); err != nil {
+		fail("token_limits", err)
+	} else {
+		for _, l := range limits {
+			if l.TenantID != tenant || l.Scope != "user" || l.ScopeID != subject {
+				continue
+			}
+			if dryRun {
+				res.Deleted["token_limits"]++
+				continue
+			}
+			if err := s.store.TokenLimitDelete(ctx, tenant, "user", subject); err != nil {
+				fail("token_limits", err)
+			} else {
+				res.Deleted["token_limits"]++
+			}
+		}
+	}
+	if dryRun {
+		if ints, err := s.store.InterruptListByUser(ctx, subject, tenant, ""); err != nil {
+			fail("interrupts", err)
+		} else {
+			res.Deleted["interrupts"] = len(ints)
+		}
+	} else if n, err := s.store.InterruptDeleteAllByUser(ctx, subject, tenant); err != nil {
+		fail("interrupts", err)
+	} else {
+		res.Deleted["interrupts"] = n
+	}
+
+	// ---- tier 1, chats excepted ----
+	if dryRun {
+		if entries, _, err := s.store.MemoryList(ctx, tenant, store.MemoryScopeUser, subject, "", 0); err != nil {
+			fail("memory", err)
+		} else {
+			res.Deleted["memory_rows"] = len(entries)
+		}
+	} else if n, err := s.store.MemoryDeleteScope(ctx, tenant, store.MemoryScopeUser, subject); err != nil {
+		fail("memory", err)
+	} else {
+		res.Deleted["memory_rows"] = n
+	}
+
+	if s.sqlMem != nil {
+		key := sqlmem.ScopeKey{Tenant: tenant, Scope: "user", ScopeID: subject}
+		if dryRun {
+			if scopes, err := s.sqlMem.ListScopes(ctx); err != nil {
+				fail("sql_memory", err)
+			} else {
+				for _, sk := range scopes {
+					if sk.Scope == "user" && sk.ScopeID == subject {
+						res.Deleted["sql_memory_scopes"] = 1
+						break
+					}
+				}
+			}
+		} else if removed, err := s.sqlMem.DropScope(ctx, key); err != nil {
+			fail("sql_memory", err)
+		} else if removed {
+			res.Deleted["sql_memory_scopes"] = 1
+		}
+	}
+
+	if rows, err := s.store.DirentListUnder(ctx, tenant, "user", subject, "/"); err != nil {
+		fail("paths", err)
+	} else {
+		for _, d := range rows {
+			if dryRun {
+				res.Deleted["path_entries"]++
+				continue
+			}
+			if ok, err := s.store.DirentDelete(ctx, tenant, "user", subject, d.ParentPath, d.Name); err != nil {
+				fail("paths", err)
+			} else if ok {
+				res.Deleted["path_entries"]++
+			}
+		}
+	}
+
+	// ---- chats LAST — see the file header ----
+	if dryRun {
+		res.Deleted["chats"] = len(sessions)
+	} else {
+		for _, id := range sessions {
+			if err := s.store.DeleteSessionCascade(ctx, id); err != nil {
+				fail("chats", err)
+				continue
+			}
+			res.Deleted["chats"]++
+		}
+	}
+
+	// ---- what was deliberately kept ----
+	res.Retained["usage_ledger"] = "retained by design: cost rows are accounting records an " +
+		"operator may be legally required to keep. The correct treatment is to break the personal " +
+		"linkage rather than destroy the totals, which is a row merge (usage_archive keys user_id " +
+		"in its primary key) and is not implemented yet."
+	if res.Residue.Rows > 0 {
+		res.Retained["tier3_residue"] = fmt.Sprintf(
+			"%d fact(s) about this subject live in scope(s) they do not own (%s). They are not "+
+				"keyed to the subject, so no subject-keyed delete reaches them; removing them is a "+
+				"judgement call about someone else's scope, not a mechanical erasure.",
+			res.Residue.Rows, strings.Join(res.Residue.Scopes, ", "))
+	}
+
+	res.Notes = []string{
+		"tier-3 residue is traceable ONLY through the subject's chats, which this operation " +
+			"deletes. It is measured before anything is removed — but once the chats are gone " +
+			"no later query can find it again, and a report run afterwards will show residue 0 " +
+			"while the facts remain. THIS RESPONSE IS THE ONLY DURABLE RECORD OF WHAT WAS NOT " +
+			"REACHED — retain it.",
+	}
+	if dryRun {
+		res.Notes = append(res.Notes,
+			"DRY RUN — nothing was deleted. Re-send with dry_run:false and confirm:<subject> to execute.")
+	}
+	if len(res.Errors) > 0 {
+		res.Notes = append(res.Notes,
+			"one or more planes faulted (see errors). This erasure is INCOMPLETE — re-run it; "+
+				"the operation is idempotent.")
+	}
+	writeJSON(w, http.StatusOK, res)
+}

--- a/internal/api/http/erasure_execute_test.go
+++ b/internal/api/http/erasure_execute_test.go
@@ -1,0 +1,234 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// erasePost drives POST /v1/_erasure and decodes the result.
+func erasePost(t *testing.T, srv *Server, tenant string, body map[string]any) (*httptest.ResponseRecorder, erasureResult) {
+	t.Helper()
+	b, _ := json.Marshal(body)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/_erasure?tenant="+tenant, bytes.NewReader(b)).
+		WithContext(auth.WithPrincipal(context.Background(), auth.Principal{
+			TenantID: tenant, Subject: "root", Scopes: []string{auth.ScopeAdmin},
+		}))
+	srv.handleErasureExecute(rec, req)
+	var res erasureResult
+	_ = json.Unmarshal(rec.Body.Bytes(), &res)
+	return rec, res
+}
+
+// seedSubject plants one fact in the subject's own scope and one in a shared
+// agent's, both derived from a chat the subject owns.
+func seedSubject(t *testing.T, srv *Server, tenant, subject string) string {
+	t.Helper()
+	ctx := context.Background()
+	sess, err := srv.store.CreateSession(ctx, tenant, "chat", subject)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prov := store.MemoryProvenance{Origin: "consolidator", SourceSessionID: sess.ID}
+	val := json.RawMessage(`{"text":"alice lives at 12 Elm St"}`)
+	for _, w := range []struct {
+		scope   store.MemoryScope
+		scopeID string
+	}{
+		{store.MemoryScopeUser, subject},
+		{store.MemoryScopeAgent, "curator"},
+	} {
+		if err := srv.store.MemorySetProvenance(ctx, tenant, w.scope, w.scopeID,
+			"memory/fact/addr", val, 0, prov); err != nil {
+			t.Fatalf("seed %s: %v", w.scope, err)
+		}
+	}
+	return sess.ID
+}
+
+// TestErasureExecute_DefaultsToDryRun locks the safety default.
+//
+// An omitted dry_run must mean "do nothing". The field is a *bool precisely so
+// the zero value cannot be destructive: with a plain bool, POST {} — a caller who
+// forgot the field, or a client with a buggy serializer — would erase a person.
+func TestErasureExecute_DefaultsToDryRun(t *testing.T) {
+	srv, _ := makeServer(t, completingProvider(), makeBaseConfig())
+	const tenant, subject = "acme", "alice"
+	seedSubject(t, srv, tenant, subject)
+
+	rec, res := erasePost(t, srv, tenant, map[string]any{"subject": subject})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	if !res.DryRun {
+		t.Fatal("an omitted dry_run executed a LIVE erasure — the default must be inert")
+	}
+	if res.Deleted["memory_rows"] != 1 {
+		t.Errorf("dry run should still COUNT what it would delete; memory_rows = %d, want 1",
+			res.Deleted["memory_rows"])
+	}
+	// And nothing actually went.
+	entries, _, err := srv.store.MemoryList(context.Background(), tenant, store.MemoryScopeUser, subject, "", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("the dry run DELETED %d row(s); it must be inert", 1-len(entries))
+	}
+}
+
+// TestErasureExecute_LiveRunRequiresMatchingConfirm locks the typo guard.
+//
+// A subject id that matches nothing is harmless. One that matches the WRONG
+// person is irreversible, and confirm is the cheapest thing that catches it.
+func TestErasureExecute_LiveRunRequiresMatchingConfirm(t *testing.T) {
+	srv, _ := makeServer(t, completingProvider(), makeBaseConfig())
+	const tenant, subject = "acme", "alice"
+	seedSubject(t, srv, tenant, subject)
+
+	for _, tc := range []struct{ name, confirm string }{
+		{"absent", ""},
+		{"mismatched", "alicia"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec, _ := erasePost(t, srv, tenant, map[string]any{
+				"subject": subject, "dry_run": false, "confirm": tc.confirm,
+			})
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400 — a live erasure with a %s confirm must be refused",
+					rec.Code, tc.name)
+			}
+		})
+	}
+	// The data is untouched after both refusals.
+	entries, _, _ := srv.store.MemoryList(context.Background(), tenant, store.MemoryScopeUser, subject, "", 0)
+	if len(entries) != 1 {
+		t.Errorf("a refused erasure still deleted data: %d rows remain, want 1", len(entries))
+	}
+}
+
+// TestErasureExecute_ReportsResidueItIsAboutToMakeUnfindable locks the property
+// that makes this operation's response irreplaceable.
+//
+// Tier-3 residue is reachable only by tracing provenance from the subject's chats,
+// and this call deletes those chats. So the count in THIS response can never be
+// recovered afterwards — see TestErasureExecute_ResidueBecomesUnfindableAfterwards
+// for the other half. The erasure must therefore report the residue it is about to
+// orphan, and must not delete it.
+func TestErasureExecute_ReportsResidueItIsAboutToMakeUnfindable(t *testing.T) {
+	srv, _ := makeServer(t, completingProvider(), makeBaseConfig())
+	ctx := context.Background()
+	const tenant, subject = "acme", "alice"
+	seedSubject(t, srv, tenant, subject)
+
+	rec, res := erasePost(t, srv, tenant, map[string]any{
+		"subject": subject, "dry_run": false, "confirm": subject,
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	if len(res.Errors) > 0 {
+		t.Fatalf("planes faulted: %v", res.Errors)
+	}
+
+	// The subject's own plane is gone.
+	if res.Deleted["memory_rows"] != 1 || res.Deleted["chats"] != 1 {
+		t.Errorf("deleted = %v, want memory_rows=1 chats=1", res.Deleted)
+	}
+	entries, _, _ := srv.store.MemoryList(ctx, tenant, store.MemoryScopeUser, subject, "", 0)
+	if len(entries) != 0 {
+		t.Errorf("%d user-scope row(s) survived a live erasure", len(entries))
+	}
+
+	// The residue was measured, and REPORTED, despite the chats being deleted in
+	// the same call.
+	if res.Residue.Rows != 1 {
+		t.Errorf("residue rows = %d, want 1 — measured before the chats went, or not at all",
+			res.Residue.Rows)
+	}
+	if _, ok := res.Retained["tier3_residue"]; !ok {
+		t.Errorf("residue was counted but not named in retained: %v", res.Retained)
+	}
+	// The agent-scope fact is genuinely still there — the residue is real, not a
+	// bookkeeping artifact.
+	agentRows, _, _ := srv.store.MemoryList(ctx, tenant, store.MemoryScopeAgent, "curator", "", 0)
+	if len(agentRows) != 1 {
+		t.Errorf("agent-scope fact count = %d, want 1 (it must NOT be deleted)", len(agentRows))
+	}
+}
+
+// TestErasureExecute_ResidueBecomesUnfindableAfterwards pins the uncomfortable
+// truth, so it stays a DOCUMENTED property rather than becoming a surprise.
+//
+// Deleting the subject's chats destroys the only index into facts derived from
+// them. A report run after an erasure therefore finds nothing to trace and would
+// naturally render `residue: 0` — a false all-clear, at the exact moment someone is
+// most likely to read it as confirmation the job is done.
+//
+// The assertion is not that the residue is gone (it is NOT — the agent-scope fact
+// is still there). It is that the report refuses to present its zero as a clean
+// result, and says the number is undeterminable instead.
+func TestErasureExecute_ResidueBecomesUnfindableAfterwards(t *testing.T) {
+	srv, _ := makeServer(t, completingProvider(), makeBaseConfig())
+	ctx := context.Background()
+	const tenant, subject = "acme", "alice"
+	seedSubject(t, srv, tenant, subject)
+	erasePost(t, srv, tenant, map[string]any{
+		"subject": subject, "dry_run": false, "confirm": subject,
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/_erasure?tenant="+tenant+"&subject="+subject, nil).
+		WithContext(auth.WithPrincipal(ctx, auth.Principal{
+			TenantID: tenant, Subject: "root", Scopes: []string{auth.ScopeAdmin},
+		}))
+	srv.handleErasureReport(rec, req)
+	var rep erasureReport
+	if err := json.Unmarshal(rec.Body.Bytes(), &rep); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// The fact really is still there — the residue is real, only unfindable.
+	agentRows, _, _ := srv.store.MemoryList(ctx, tenant, store.MemoryScopeAgent, "curator", "", 0)
+	if len(agentRows) != 1 {
+		t.Fatalf("precondition: agent-scope fact count = %d, want 1", len(agentRows))
+	}
+	if rep.Tier3.Rows != 0 || rep.Tier3.SessionsExamined != 0 {
+		t.Fatalf("precondition: expected an untraceable post-erasure state, got rows=%d sessions=%d",
+			rep.Tier3.Rows, rep.Tier3.SessionsExamined)
+	}
+
+	var warned bool
+	for _, n := range rep.Notes {
+		if strings.Contains(n, "UNDETERMINABLE") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Errorf("a post-erasure report rendered residue 0 with no warning that it is "+
+			"undeterminable — a false all-clear while the fact is still stored. notes: %v",
+			rep.Notes)
+	}
+}
+
+// TestErasureExecute_AlwaysReportsRetainedPlanes locks the honesty requirement.
+//
+// An erasure that lists only what it removed reads as complete. The usage ledger
+// is kept on purpose — cost rows are accounting records — and a caller must be
+// told that even when there is no tier-3 residue at all.
+func TestErasureExecute_AlwaysReportsRetainedPlanes(t *testing.T) {
+	srv, _ := makeServer(t, completingProvider(), makeBaseConfig())
+	_, res := erasePost(t, srv, "acme", map[string]any{"subject": "nobody-at-all"})
+	if _, ok := res.Retained["usage_ledger"]; !ok {
+		t.Errorf("a subject with NOTHING stored still got no retained-plane disclosure: %v",
+			res.Retained)
+	}
+}

--- a/internal/api/http/erasure_report.go
+++ b/internal/api/http/erasure_report.go
@@ -211,6 +211,20 @@ func (s *Server) handleErasureReport(w http.ResponseWriter, r *http.Request) {
 		rep.Notes = append(rep.Notes,
 			"the provenance walk hit its row bound, so tier3 is a FLOOR rather than a total.")
 	}
+	// With no sessions there is nothing to trace from, so tier3's 0 means UNKNOWN,
+	// not NONE — and the difference is the whole value of the number.
+	//
+	// This is the state a subject is left in AFTER an erasure, which is exactly
+	// when someone is most likely to re-run the report and read 0 as confirmation
+	// that nothing remains. Facts derived from those chats can still be sitting in
+	// a shared agent's scope; deleting the chats destroyed the only index to them.
+	if rep.Tier3.SessionsExamined == 0 {
+		rep.Notes = append(rep.Notes,
+			"this subject has NO chats, so tier3 is UNDETERMINABLE rather than zero: derived "+
+				"facts are found only by tracing provenance from a chat. If the subject was "+
+				"previously erased, residue may exist that nothing can now locate — the erasure "+
+				"response is the only record of it.")
+	}
 	if len(rep.Errors) > 0 {
 		rep.Notes = append(rep.Notes,
 			"one or more planes could not be read (see errors) — every count here is a LOWER BOUND.")

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2722,6 +2722,7 @@ func (s *Server) Mux() http.Handler {
 	// on first reference so it can be authored before any run needs it. Authoring
 	// itself stays in the Path/Document browser. Scope-gated in requiredScopeFor.
 	mux.Handle("GET /v1/_erasure", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleErasureReport))))
+	mux.Handle("POST /v1/_erasure", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleErasureExecute))))
 	mux.Handle("GET /v1/_ontology", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleOntology))))
 	mux.Handle("POST /v1/_ontology", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleOntologySetStatus))))
 	// RFC BK P3: resident interactive sub-agent visibility + operator control.

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -8107,3 +8107,20 @@ func newID(prefix string) string {
 	}
 	return prefix + hex.EncodeToString(b[:])
 }
+
+// InterruptDeleteAllByUser removes every interrupt raised for a user. See the
+// Store interface for why this deletes rather than anonymizes; see the sqlite
+// twin for why the tenant predicate is a subquery rather than a JOIN.
+func (s *Store) InterruptDeleteAllByUser(ctx context.Context, userID, tenantID string) (int, error) {
+	q := `DELETE FROM interrupts WHERE user_id = $1`
+	args := []any{userID}
+	if tenantID != "" {
+		q += ` AND run_id IN (SELECT id FROM runs WHERE tenant_id = $2)`
+		args = append(args, tenantID)
+	}
+	tag, err := s.pool.Exec(ctx, q, args...)
+	if err != nil {
+		return 0, fmt.Errorf("interrupts: delete by user: %w", err)
+	}
+	return int(tag.RowsAffected()), nil
+}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -9356,3 +9356,33 @@ func newID(prefix string) string {
 	_, _ = rand.Read(b[:])
 	return prefix + hex.EncodeToString(b[:])
 }
+
+// InterruptDeleteAllByUser removes every interrupt raised for a user. See the
+// Store interface for why this deletes rather than anonymizes.
+func (s *Store) InterruptDeleteAllByUser(ctx context.Context, userID, tenantID string) (int, error) {
+	// Subquery rather than a JOIN: sqlite and postgres spell DELETE...JOIN
+	// differently, and `run_id IN (SELECT …)` is the form both accept unchanged —
+	// worth more here than a marginally better plan, because a delete that
+	// diverges between backends is a compliance answer that depends on which
+	// database the operator happens to run.
+	//
+	// The tenant predicate mirrors InterruptListByUser's JOIN exactly, so what the
+	// erasure REPORT counts and what this DELETES can never disagree. Both skip an
+	// interrupt whose owning run row is gone; that is a residue, but a CONSISTENT
+	// one, which is the property that matters.
+	q := `DELETE FROM interrupts WHERE user_id = ?`
+	args := []any{userID}
+	if tenantID != "" {
+		q += ` AND run_id IN (SELECT id FROM runs WHERE tenant_id = ?)`
+		args = append(args, tenantID)
+	}
+	res, err := s.db.ExecContext(ctx, q, args...)
+	if err != nil {
+		return 0, fmt.Errorf("interrupts: delete by user: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("interrupts: delete by user rows: %w", err)
+	}
+	return int(n), nil
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2643,6 +2643,22 @@ type Store interface {
 	// Capped at 200 rows.
 	InterruptListByUser(ctx context.Context, userID, tenantID, statusFilter string) ([]InterruptRow, error)
 
+	// InterruptDeleteAllByUser removes every interrupt raised for a user,
+	// regardless of status, and returns how many rows went. Erasure (RFC BL P5):
+	// an interrupt row carries the model's QUESTION and the user's free-text
+	// ANSWER, which is some of the most directly personal content the runtime
+	// stores — a subject-keyed delete that skipped it would leave the transcript
+	// of a conversation behind while claiming the user's data was gone.
+	//
+	// Unlike the lister this is NOT capped: a partial delete would report success
+	// while leaving rows, which is the one outcome an erasure must never produce.
+	//
+	// tenantID scopes via the owning run exactly as InterruptListByUser does, so
+	// the delete can never reach across a tenant boundary; "" = all tenants
+	// (open mode). Deletes rather than anonymizes because, unlike the usage
+	// ledger, nothing downstream aggregates over interrupts.
+	InterruptDeleteAllByUser(ctx context.Context, userID, tenantID string) (int, error)
+
 	// InterruptCountPendingByRun returns the count of status=pending
 	// interrupts for the given run_id. Drives max_pending enforcement
 	// at the tool layer (the count check is a single round trip; the

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -149,6 +149,7 @@ func Run(t *testing.T, factory Factory) {
 		{"MemoryListScopeIDs", testMemoryListScopeIDs},
 		{"MemoryListTenantsForScope", testMemoryListTenantsForScope},
 		{"MemoryListBySourceSessions", testMemoryListBySourceSessions},
+		{"InterruptDeleteAllByUser", testInterruptDeleteAllByUser},
 		// RFC BL P2: the background-consolidation substrate.
 		{"MemorySupersedeHidesFromReads", testMemorySupersedeHidesFromReads},
 		{"MemorySupersedeIsIdempotent", testMemorySupersedeIsIdempotent},
@@ -10813,5 +10814,70 @@ func testMemoryListBySourceSessions(t *testing.T, s store.Store) {
 		if r.SourceSessionID != "s_1" && r.SourceSessionID != "s_2" {
 			t.Errorf("row %s reports source %q, which was not requested", r.Key, r.SourceSessionID)
 		}
+	}
+}
+
+// testInterruptDeleteAllByUser pins the erasure delete: it must remove EVERY
+// interrupt for the subject regardless of status, and must not cross a tenant
+// boundary while doing it.
+//
+// The status dimension is the point. The lister's callers care about pending
+// work, so it is tempting to reuse their filtering here — but a resolved
+// interrupt still holds the question AND the user's free-text answer, which is
+// exactly the content an erasure exists to remove. Deleting only the pending
+// ones would report success having left the conversation behind.
+func testInterruptDeleteAllByUser(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	const subject = "u_erase_me"
+
+	mk := func(tenant, user, status string) string {
+		t.Helper()
+		runID := makeRunForInterruptTenant(t, s, tenant, user, "a_erase", "batch")
+		id := store.MintInterruptID(time.Now())
+		if _, err := s.InterruptCreate(ctx, store.InterruptRow{
+			InterruptID: id, RunID: runID, UserID: user,
+			Question: "what is your address?", Priority: store.InterruptPriorityNormal,
+			CreatedAt: time.Now(),
+		}); err != nil {
+			t.Fatalf("seed %s/%s: %v", tenant, user, err)
+		}
+		if status != "pending" {
+			if err := s.InterruptResolve(ctx, id, "12 Elm St", "u_erase_me", nil); err != nil {
+				t.Fatalf("resolve %s: %v", id, err)
+			}
+		}
+		return id
+	}
+
+	mk("acme", subject, "pending")
+	resolved := mk("acme", subject, "resolved") // the one a status filter would miss
+	otherTenant := mk("globex", subject, "pending")
+	otherUser := mk("acme", "u_keep", "pending")
+
+	n, err := s.InterruptDeleteAllByUser(ctx, subject, "acme")
+	if err != nil {
+		t.Fatalf("InterruptDeleteAllByUser: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("deleted %d, want 2 (pending AND resolved) — a resolved interrupt still "+
+			"holds the question and the user's answer", n)
+	}
+	if _, err := s.InterruptGet(ctx, resolved); err == nil {
+		t.Errorf("the RESOLVED interrupt survived; erasure must not filter by status")
+	}
+
+	// Tenant isolation: same subject id, different tenant, untouched.
+	if _, err := s.InterruptGet(ctx, otherTenant); err != nil {
+		t.Errorf("another tenant's interrupt for the same user id was deleted: %v", err)
+	}
+	// And another user in the SAME tenant is untouched.
+	if _, err := s.InterruptGet(ctx, otherUser); err != nil {
+		t.Errorf("another user's interrupt was deleted: %v", err)
+	}
+
+	// Idempotent: erasure is re-runnable, and a second pass must be a clean no-op
+	// rather than an error an operator has to interpret.
+	if n, err := s.InterruptDeleteAllByUser(ctx, subject, "acme"); err != nil || n != 0 {
+		t.Errorf("second pass: n=%d err=%v, want 0/nil", n, err)
 	}
 }


### PR DESCRIPTION
## Why

RFC BL P5 **0d**, the deletion half. #911 answers *"what do you hold about this person"*; this removes it.

`POST /v1/_erasure` deletes tier 1 + tier 2, reports what it cannot reach, and **defaults to doing nothing**.

## Safety lives in the defaults, not the scope gate

`dry_run` is a `*bool`, so an omitted field — or `POST {}` from a client with a buggy serializer — means *do nothing*. A plain `bool` would make the zero value destructive. A live run additionally requires `confirm == subject`: a subject id matching nothing is harmless; one matching the **wrong person** is irreversible.

The admin `?tenant=` refusal carries over from the GET, and matters more here — tenant `""` wouldn't just report the wrong people, it would delete them.

## The residue report is one-shot

The sharpest property of the operation, and it needs to be understood before this is used in anger.

Tier 3 is reachable **only** by tracing provenance from the subject's chats. This call deletes those chats. So afterwards the trace handle is gone:

```
POST-ERASURE report: residue=0 sessions=0 | agent-scope rows STILL PRESENT=1
```

A report run after an erasure says **zero while the facts are still stored**. That isn't a bug to fix here — it's what "the subject's chats are deleted" *means* when chats are the only index into derived facts. Three things now make it explicit:

- The residue is measured **before** anything is removed, from session ids captured up front.
- The response states in `notes` that **it is the only durable record** of what was not reached.
- The GET report closes the matching lie from its side: with zero sessions to trace from it now renders tier 3 **UNDETERMINABLE** rather than `0` — precisely the state a subject is left in *after* an erasure, and precisely when someone would read `0` as confirmation the job is done.

## Retained by design

The usage/cost ledger is **kept**, and says so under `retained` rather than being a silent gap. Cost rows are accounting records an operator may be legally required to retain, and the right treatment is to break the personal linkage, not destroy the totals. That's a row *merge* — `usage_archive` keys `user_id` inside its `PRIMARY KEY`, so anonymising means folding rows into the `''` bucket and summing — and it deserves its own change.

## One new store method

`InterruptDeleteAllByUser`. An interrupt holds the model's **question** and the user's free-text **answer**, so status-filtering it (the tempting reuse of the lister's semantics) would report success having left the conversation behind. Uncapped, unlike the lister — a partial delete reporting success is the one outcome an erasure must never produce. The tenant predicate is a subquery rather than a JOIN so both backends run the identical statement, and it mirrors the lister's JOIN exactly, so what the report **counts** and what this **deletes** can never disagree.

## Tested

`TestErasureExecute_{DefaultsToDryRun, LiveRunRequiresMatchingConfirm, ReportsResidueItIsAboutToMakeUnfindable, ResidueBecomesUnfindableAfterwards, AlwaysReportsRetainedPlanes}` + the `InterruptDeleteAllByUser` store contract (status-blind, tenant-isolated, idempotent).

**Fail-before on all of:** `dry_run`→false, the confirm guard, the undeterminable warning, a status-filtered delete (removes 1 of 2), a dropped tenant predicate (removes another tenant's row).

## A correction worth recording

An earlier draft claimed chats-last was required to keep the residue measurable. **Mutating the order did not fail the test** — session ids are captured into a slice before any delete, so the claim was wrong and the test that "verified" it was vacuous. Both were replaced with the property that is actually true (above). Chats still go last, but only for the weaker reason: transcripts are the recovery record, so a crash mid-erasure should leave them standing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8