### PR TITLE
fix(memory): count every erasure plane examined, including at zero

### DIFF
--- a/internal/api/http/erasure_execute.go
+++ b/internal/api/http/erasure_execute.go
@@ -121,6 +121,24 @@ func (s *Server) handleErasureExecute(w http.ResponseWriter, r *http.Request) {
 		Deleted:  map[string]int{},
 		Retained: map[string]string{},
 	}
+	// Every plane this operation CONSIDERS is registered at zero up front, so a
+	// key's presence means "examined" and its value means "this many went".
+	//
+	// Without it the accumulating planes below (`++` from an absent key) simply
+	// vanish when they delete nothing, and a caller cannot distinguish "no
+	// credentials existed" from "credentials were never looked at" — which for the
+	// tier-2 entry that matters most is the difference between a clean erasure and
+	// one that left a subject's keys behind. sql_memory is registered only when the
+	// subsystem exists, because there it really is unexamined.
+	for _, plane := range []string{
+		"chats", "memory_rows", "path_entries",
+		"credentials", "token_limits", "interrupts",
+	} {
+		res.Deleted[plane] = 0
+	}
+	if s.sqlMem != nil {
+		res.Deleted["sql_memory_scopes"] = 0
+	}
 	fail := func(plane string, err error) {
 		res.Errors = append(res.Errors, plane+": "+err.Error())
 	}

--- a/internal/api/http/erasure_execute_test.go
+++ b/internal/api/http/erasure_execute_test.go
@@ -232,3 +232,29 @@ func TestErasureExecute_AlwaysReportsRetainedPlanes(t *testing.T) {
 			res.Retained)
 	}
 }
+
+// TestErasureExecute_ReportsEveryPlaneItConsidered mirrors the report's invariant
+// on the deletion side: a plane the operation examined must appear in `deleted`
+// even when it removed nothing.
+//
+// Observed on the live deployment before the fix — a dry run against a real
+// subject returned {"chats":2,"interrupts":0,"memory_rows":2}, with credentials,
+// token_limits and path_entries silently missing because they accumulate from an
+// absent key. An operator reading that cannot tell whether the subject had no
+// credentials or whether credentials were never touched.
+func TestErasureExecute_ReportsEveryPlaneItConsidered(t *testing.T) {
+	srv, _ := makeServer(t, completingProvider(), makeBaseConfig())
+	// Deliberately a subject with NOTHING: the zero case is the one that regressed.
+	_, res := erasePost(t, srv, "acme", map[string]any{"subject": "nobody-at-all"})
+
+	for _, plane := range []string{
+		"chats", "memory_rows", "path_entries",
+		"credentials", "token_limits", "interrupts",
+	} {
+		if _, ok := res.Deleted[plane]; !ok {
+			t.Errorf("plane %q missing from deleted for an empty subject — "+
+				"'examined and found nothing' must not look like 'never examined'; deleted=%v",
+				plane, res.Deleted)
+		}
+	}
+}

--- a/internal/api/http/erasure_report.go
+++ b/internal/api/http/erasure_report.go
@@ -123,6 +123,11 @@ func (s *Server) handleErasureReport(w http.ResponseWriter, r *http.Request) {
 		rep.Errors = append(rep.Errors, plane+": "+err.Error())
 	}
 
+	// sqlMemUnexamined records that SQL Memory is unconfigured, so the plane was
+	// never looked at. Distinct from "looked and found nothing", and surfaced in
+	// the notes below.
+	var sqlMemUnexamined bool
+
 	// ---- tier 1: subject-keyed, and already deletable ----
 	sessions, err := s.subjectSessions(ctx, tenant, subject)
 	if err != nil {
@@ -141,13 +146,24 @@ func (s *Server) handleErasureReport(w http.ResponseWriter, r *http.Request) {
 		if scopes, err := s.sqlMem.ListScopes(ctx); err != nil {
 			fail("sql_memory", err)
 		} else {
+			// Counted into a local first and set UNCONDITIONALLY, including zero.
+			// Setting it only on a hit would make the key's absence mean either "no
+			// scope" or "never looked" — the same ambiguity between failed and empty
+			// that `errors` exists to prevent, reintroduced one field lower down.
+			var n int64
 			for _, sk := range scopes {
 				if sk.Scope == "user" && sk.ScopeID == subject {
-					rep.Tier1.set("sql_memory_scopes", 1)
+					n = 1
 					break
 				}
 			}
+			rep.Tier1.set("sql_memory_scopes", n)
 		}
+	} else {
+		// Deferred to a flag rather than appended here: rep.Notes is ASSIGNED (not
+		// appended to) further down, so a note written now would be silently
+		// discarded.
+		sqlMemUnexamined = true
 	}
 	if rows, err := s.store.DirentListUnder(ctx, tenant, "user", subject, "/"); err != nil {
 		fail("paths", err)
@@ -206,6 +222,11 @@ func (s *Server) handleErasureReport(w http.ResponseWriter, r *http.Request) {
 		"tier1 is deletable with existing primitives. tier2 is subject-keyed but nothing deletes it yet — the credential rows are the ones that matter.",
 		"tier3 is found through provenance, so it covers only facts that RECORDED the chat they came from. A fact written about this subject WITHOUT provenance is not reachable by any mechanism, and is not counted here.",
 		"counts are live rows: expired and superseded rows are excluded, because they are invisible to every read and counting them would overstate what is held.",
+	}
+	if sqlMemUnexamined {
+		rep.Notes = append(rep.Notes,
+			"SQL Memory is not configured on this deployment, so the sql_memory plane was NOT "+
+				"examined — its absence from the counts is not evidence that it is empty.")
 	}
 	if rep.Tier3.Truncated {
 		rep.Notes = append(rep.Notes,

--- a/internal/api/http/erasure_report_test.go
+++ b/internal/api/http/erasure_report_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/denn-gubsky/loomcycle/internal/auth"
@@ -179,4 +180,61 @@ func containsLowerBound(s string) bool {
 		}
 	}
 	return false
+}
+
+// TestErasureReport_EveryExaminedPlaneIsCountedEvenAtZero pins the invariant that
+// a key's PRESENCE means the plane was examined.
+//
+// The regression this guards: sql_memory_scopes was set only when a scope was
+// found, so its absence meant either "no scope" or "never looked". That is the
+// same ambiguity between failed and empty that `errors` exists to prevent,
+// reintroduced one field lower down — and it is worse in a compliance report than
+// anywhere else, because the reader's question is precisely "is this plane clear?"
+func TestErasureReport_EveryExaminedPlaneIsCountedEvenAtZero(t *testing.T) {
+	// ontologyFixture rather than makeServer: it wires a REAL sqlMem, and the
+	// regression being guarded lives entirely inside the `s.sqlMem != nil` branch.
+	// With a nil sqlMem the assertion below passes through the "declared
+	// unexamined" path and never executes the fixed code — a vacuous guard, which
+	// is how the first version of this test passed against the unfixed report.
+	srv, _ := ontologyFixture(t)
+	adminCtx := auth.WithPrincipal(context.Background(), auth.Principal{
+		TenantID: "acme", Subject: "root", Scopes: []string{auth.ScopeAdmin},
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/_erasure?tenant=acme&subject=nobody", nil).
+		WithContext(adminCtx)
+	srv.handleErasureReport(rec, req)
+	var rep erasureReport
+	if err := json.Unmarshal(rec.Body.Bytes(), &rep); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// A subject with nothing stored must still account for every plane examined.
+	for _, k := range []string{"chats", "memory_rows", "path_entries"} {
+		if _, ok := rep.Tier1.Counts[k]; !ok {
+			t.Errorf("tier1 %q absent for an empty subject — absence cannot be "+
+				"distinguished from 'never examined'; counts: %v", k, rep.Tier1.Counts)
+		}
+	}
+	for _, k := range []string{"credentials", "token_limits", "interrupts", "usage_ledger_calls"} {
+		if _, ok := rep.Tier2.Counts[k]; !ok {
+			t.Errorf("tier2 %q absent for an empty subject; counts: %v", k, rep.Tier2.Counts)
+		}
+	}
+
+	// SQL Memory is the conditional one: either it was examined and reported a
+	// count, or it does not exist here and the notes must SAY so. Silence is the
+	// one outcome that is not allowed.
+	_, counted := rep.Tier1.Counts["sql_memory_scopes"]
+	var declared bool
+	for _, n := range rep.Notes {
+		if strings.Contains(n, "SQL Memory is not configured") {
+			declared = true
+		}
+	}
+	if counted == declared {
+		t.Errorf("sql_memory must be either counted (%v) or declared unexamined (%v), "+
+			"exactly one; counts=%v notes=%v", counted, declared, rep.Tier1.Counts, rep.Notes)
+	}
 }


### PR DESCRIPTION
## Found on the live deployment

Driving v1.44.0 against TrueNAS, a dry run for a real subject returned:

```json
{"chats": 2, "interrupts": 0, "memory_rows": 2}
```

`credentials`, `token_limits`, `path_entries` and `sql_memory_scopes` are **all examined on that path**, and all four are missing. An operator reading that cannot tell *"the subject had no credentials"* from *"credentials were never looked at"* — which in a compliance report is the entire question being asked.

It's the same **failed-vs-empty ambiguity** that the `errors` field exists to prevent, reintroduced one field lower down.

## Two causes

**The executor accumulates from an absent key.** `res.Deleted[k]++` leaves no trace when a plane removes nothing. Every considered plane is now registered at zero up front, establishing the invariant: **a key's presence means "examined"; its value means "this many went".**

**The report set `sql_memory_scopes` only on a hit**, so absence meant either no scope or no look. Now set unconditionally from a counted local.

## The one conditional plane

With SQL Memory unconfigured the plane genuinely *is* unexamined — so rather than omit it silently, the report now says so in `notes`. Exactly one of the two must hold, and the test asserts that as an **XOR** rather than checking either alone.

## Tested

`TestErasureReport_EveryExaminedPlaneIsCountedEvenAtZero`, `TestErasureExecute_ReportsEveryPlaneItConsidered`. Fail-before on both — the executor mutation reproduces the live shape verbatim: `map[chats:0 interrupts:0 memory_rows:0]`.

## A vacuous test, recorded

The report test's **first version passed against the unfixed code**. It used `makeServer`, whose `sqlMem` is nil, so the XOR resolved through the declared-unexamined path and never entered the branch being fixed. It now builds on `ontologyFixture`, which wires a real `sqlMem`. Worth noting because a conditional-branch fix needs a fixture that actually enters the branch, and "the test passes" hides that perfectly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8