### PR TITLE
fix(memory): three bi-temporal bugs in the entity tier

### DIFF
--- a/internal/tools/builtin/document_entity.go
+++ b/internal/tools/builtin/document_entity.go
@@ -394,6 +394,41 @@ func (d *Document) supersedeChunk(ctx context.Context, key sqlmem.ScopeKey, in d
 		}
 	}
 
+	// A chunk may be retired ONCE. Without this, two different replacements can
+	// each supersede the same fact — both succeed, both stay live, and a recall
+	// returns two contradictory "current" answers. That defeats the entire point of
+	// supersede-not-delete, which is that there is always exactly one current
+	// answer and the old ones remain queryable behind it.
+	//
+	// A correction chain is A -> B -> C: to correct B you supersede B, not A.
+	// Forking A twice is a caller error, so it is refused by NAMING the existing
+	// replacement — that is the id the caller almost certainly meant to pass.
+	//
+	// Re-superseding with the SAME replacement is different: it is genuinely
+	// idempotent, and must be a clean no-op rather than an error. These ops are
+	// driven by a background consolidator that retries after a partial failure, and
+	// a retry that reports failure for work already done is indistinguishable from
+	// one that could not do it. Previously this surfaced the raw PK violation
+	// ("UNIQUE constraint failed: chunk_edges.from_id, ..."), leaking schema
+	// internals into a model-visible result.
+	prior, err := d.query(ctx, key,
+		`SELECT from_id FROM chunk_edges WHERE to_id = ? AND kind = 'supersedes'`, in.SupersedesID)
+	if err != nil {
+		return errResult("supersede_chunk: supersession lookup: " + err.Error()), nil
+	}
+	for _, row := range prior.Rows {
+		existing := asStr(row[0])
+		if existing == in.ID {
+			return okJSON(map[string]any{
+				"id": in.ID, "supersedes": in.SupersedesID, "already": true,
+			})
+		}
+		return errResult(fmt.Sprintf(
+			"supersede_chunk: chunk %q is already superseded by %q. To correct that newer "+
+				"fact, supersede %q instead — superseding the same chunk twice would leave two "+
+				"contradictory current facts.", in.SupersedesID, existing, existing)), nil
+	}
+
 	now := time.Now().UnixNano()
 	txErr := d.withSqlTxn(ctx, key, func(txnID string) error {
 		// The retired row may have no sidecar yet (it predates the entity tier, or

--- a/internal/tools/builtin/document_entity_test.go
+++ b/internal/tools/builtin/document_entity_test.go
@@ -2,8 +2,10 @@ package builtin
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
@@ -266,5 +268,151 @@ func TestEntity_TenantWritesRequireBothGrants(t *testing.T) {
 				t.Errorf("upsert_chunk at tenant scope with both grants: %s", r.Text)
 			}
 		})
+	}
+}
+
+// TestSupersedeChunk_RefusesAForkedCorrectionChain is the invariant the whole
+// supersede mechanism rests on: at any moment ONE fact is current.
+//
+// Nothing previously stopped two different replacements from each superseding the
+// same chunk. Both succeeded, both stayed live, and graph_recall returned both as
+// current — two contradictory answers to the same question, which is precisely
+// what supersede-not-delete exists to prevent. A correction chain is A -> B -> C;
+// to correct B you supersede B, not A.
+func TestSupersedeChunk_RefusesAForkedCorrectionChain(t *testing.T) {
+	d, ctx, docID, root := entityFixture(t)
+	mk := func(key, title string) string {
+		out, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+docID+
+			`","parent_id":"`+root+`","title":"`+title+`","natural_key":"`+key+`"}`)
+		if r.IsError {
+			t.Fatalf("upsert %s: %s", key, r.Text)
+		}
+		return asStr(out["id"])
+	}
+	old := mk("fact:indent|is|tabs", "prefers tabs")
+	b := mk("fact:indent|is|spaces", "prefers spaces")
+	c := mk("fact:indent|is|two", "prefers 2-space indent")
+
+	if _, r := docExec(t, d, ctx, `{"op":"supersede_chunk","scope":"user","id":"`+b+`","supersedes_id":"`+old+`"}`); r.IsError {
+		t.Fatalf("first supersede: %s", r.Text)
+	}
+	_, r := docExec(t, d, ctx, `{"op":"supersede_chunk","scope":"user","id":"`+c+`","supersedes_id":"`+old+`"}`)
+	if !r.IsError {
+		t.Fatalf("a SECOND replacement for the same chunk was accepted — the correction " +
+			"chain forked and two contradictory facts are now both current")
+	}
+	// The refusal must name the existing replacement: that is the id the caller
+	// almost certainly meant to supersede.
+	if !strings.Contains(r.Text, b) {
+		t.Errorf("the refusal does not name the existing replacement %q, so the caller "+
+			"cannot tell what to supersede instead: %s", b, r.Text)
+	}
+	// Exactly one chunk supersedes it.
+	res, err := d.SqlMem.Query(ctx, sidecarScope(t, d, ctx),
+		d.SqlMem.Rebind(`SELECT from_id FROM chunk_edges WHERE to_id = ? AND kind = 'supersedes'`), []any{old})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Rows) != 1 {
+		t.Errorf("%d chunks supersede the retired fact, want 1", len(res.Rows))
+	}
+}
+
+// TestSupersedeChunk_SamePairIsIdempotent — these ops are driven by a background
+// consolidator that retries after a partial failure, so re-superseding with the
+// SAME replacement must be a clean no-op.
+//
+// It previously surfaced the raw engine error ("UNIQUE constraint failed:
+// chunk_edges.from_id, ...") from the edge insert, which both reads as a hard
+// failure to a retrying caller and leaks schema internals into a model-visible
+// tool result.
+func TestSupersedeChunk_SamePairIsIdempotent(t *testing.T) {
+	d, ctx, docID, root := entityFixture(t)
+	mk := func(key, title string) string {
+		out, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+docID+
+			`","parent_id":"`+root+`","title":"`+title+`","natural_key":"`+key+`"}`)
+		if r.IsError {
+			t.Fatalf("upsert: %s", r.Text)
+		}
+		return asStr(out["id"])
+	}
+	old := mk("fact:x", "old")
+	newer := mk("fact:y", "newer")
+
+	for i := 1; i <= 2; i++ {
+		out, r := docExec(t, d, ctx, `{"op":"supersede_chunk","scope":"user","id":"`+newer+`","supersedes_id":"`+old+`"}`)
+		if r.IsError {
+			t.Fatalf("supersede attempt %d failed: %s", i, r.Text)
+		}
+		if i == 2 && out["already"] != true {
+			t.Errorf("the repeat did not report already=true, so a retrying consolidator "+
+				"cannot distinguish 'done' from 'did it again': %v", out)
+		}
+	}
+}
+
+// TestGraphRecall_AFutureEndDateIsStillCurrent — "has an end date" is not "has
+// ended".
+//
+// A fact may carry a KNOWN FUTURE end ("the contract runs until 2027") and be
+// perfectly true right now. The default filter required invalid_at IS NULL, so
+// recording an end date acted as immediate deletion: the fact disappeared from
+// every default recall the moment it was written.
+//
+// The decisive check is the second half. The default IS "as_of now", so it must
+// agree with the as_of predicate given the current time — and it did not, which
+// is what makes this a bug rather than a judgement call.
+func TestGraphRecall_AFutureEndDateIsStillCurrent(t *testing.T) {
+	d, ctx, docID, root := entityFixture(t)
+	future := time.Now().Add(365 * 24 * time.Hour).UnixNano()
+	past := time.Now().Add(-365 * 24 * time.Hour).UnixNano()
+
+	mk := func(key, title string, invalid int64) {
+		t.Helper()
+		body := fmt.Sprintf(`{"op":"upsert_chunk","scope":"user","document_id":"%s","parent_id":"%s",`+
+			`"title":"%s","natural_key":"%s","invalid_at":%d}`, docID, root, title, key, invalid)
+		if _, r := docExec(t, d, ctx, body); r.IsError {
+			t.Fatalf("upsert %s: %s", key, r.Text)
+		}
+	}
+	mk("fact:contract", "contract runs until 2027", future)
+	mk("fact:oldjob", "worked at Initech", past)
+
+	// Whole-word title matching means each fact needs its own query term.
+	recall := func(term, extra string) string {
+		t.Helper()
+		out, r := docExec(t, d, ctx,
+			`{"op":"graph_recall","scope":"user","query":"`+term+`"`+extra+`}`)
+		if r.IsError {
+			t.Fatalf("graph_recall(%s%s): %s", term, extra, r.Text)
+		}
+		return asStr(out)
+	}
+
+	got := recall("contract", "")
+	if !strings.Contains(got, "contract runs until 2027") {
+		t.Errorf("a fact with a FUTURE end date is missing from a default recall — "+
+			"recording an end date deleted it: %s", got)
+	}
+	// A genuinely-ended fact must still be hidden, or the fix has simply disabled
+	// the filter.
+	if ended := recall("worked", ""); strings.Contains(ended, "worked at Initech") {
+		t.Errorf("a fact whose end date has PASSED is being returned as current: %s", ended)
+	}
+	// The label must not contradict the result it decorates.
+	//
+	// Matched against the Go map rendering (retired:true, no quotes) that asStr
+	// produces — an earlier version of this assertion looked for the JSON form
+	// `"retired":true`, which cannot appear in this output and therefore could
+	// never fail.
+	if strings.Contains(got, "retired:true") {
+		t.Errorf("the current fact is labelled retired even though its end date is in "+
+			"the future — the label contradicts the result it decorates: %s", got)
+	}
+	// And the default must agree with as_of=<now>, since that is what it means.
+	asOf := recall("contract", fmt.Sprintf(`,"as_of":%d`, time.Now().UnixNano()))
+	if strings.Contains(asOf, "contract") != strings.Contains(got, "contract") {
+		t.Errorf("the default and as_of=now disagree about the same fact:\n default: %s\n as_of:   %s",
+			got, asOf)
 	}
 }

--- a/internal/tools/builtin/document_graph.go
+++ b/internal/tools/builtin/document_graph.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
@@ -356,7 +357,18 @@ func graphTemporalClause(in docInput) (string, []any) {
 		return `(m.chunk_id IS NULL OR ((m.valid_at IS NULL OR m.valid_at <= ?) AND (m.invalid_at IS NULL OR m.invalid_at > ?)))`,
 			[]any{*in.AsOf, *in.AsOf}
 	}
-	return `(m.chunk_id IS NULL OR m.invalid_at IS NULL)`, nil
+	// invalid_at > now, not merely IS NULL. A fact may carry a KNOWN FUTURE end —
+	// "the contract runs until 2027" — and such a fact is true right now. Treating
+	// any end-date as "not current" made recording one an act of immediate
+	// deletion: the fact vanished from every default recall the moment it was
+	// written.
+	//
+	// The decisive argument is internal consistency rather than taste. The default
+	// IS "as_of now", so it must reduce to the as_of predicate above with the
+	// current time substituted. It did not: a caller passing as_of=<now> got a
+	// different answer than the same caller passing nothing.
+	return `(m.chunk_id IS NULL OR m.invalid_at IS NULL OR m.invalid_at > ?)`,
+		[]any{time.Now().UnixNano()}
 }
 
 func scanGraphRows(rows [][]any, hop int, viaKind, viaID string) []graphChunk {
@@ -385,7 +397,10 @@ func scanGraphRow(r []any) graphChunk {
 	if len(r) > 5 {
 		if v, ok := asInt64(r[5]); ok {
 			c.Invalid = &v
-			c.Retired = true
+			// HAS an end date != HAS ended. A fact valid until 2027 is current, and
+			// labelling it retired told the model the opposite of the truth about
+			// something it was simultaneously being shown as a result.
+			c.Retired = v <= time.Now().UnixNano()
 		}
 	}
 	return c


### PR DESCRIPTION
Memory-review pass 2, over `document_entity.go` and `document_graph.go` — the newest code in the subsystem. All three found by probing behaviour rather than reading, and all three make the store **assert something false**.

## 1 · The correction chain could fork

Nothing stopped two different chunks from each superseding the same fact. Both succeeded, both stayed live, and `graph_recall` returned both as current:

```
chunks superseding old: 2
graph_recall -> "prefers 2-space indent" (retired:false)
                "prefers spaces"         (retired:false)
```

Two contradictory answers to one question — precisely what supersede-not-delete exists to prevent. A correction chain is `A → B → C`: to correct B you supersede B, not A. Now refused, and the refusal **names the existing replacement**, because that's the id the caller almost certainly meant.

## 2 · Re-superseding the same pair leaked a constraint error

```
supersede_chunk: constraint failed: UNIQUE constraint failed: chunk_edges.from_id, ... (1555)
```

These ops are driven by a background consolidator that **retries after partial failure**, and a retry reporting failure for work already done is indistinguishable from one that couldn't do it. Now a clean no-op with `already: true`, and no schema internals in a model-visible result.

## 3 · A known future end date deleted the fact

The default filter required `invalid_at IS NULL`, so *"the contract runs until 2027"* — true right now — vanished from every default recall the moment the end date was written.

The decisive argument is **internal consistency**, not taste. The default *is* "as_of now", so it must reduce to the `as_of` predicate with the current time substituted. It did not:

| query | result |
|---|---|
| default | `chunks: []` |
| `as_of = <now>` | returns the fact |

Fixed to `invalid_at > now`. The `retired` flag likewise now means **has ended** rather than **has an end date** — it was labelling a current fact retired in the same response that returned it.

## Tested

`TestSupersedeChunk_RefusesAForkedCorrectionChain`, `TestSupersedeChunk_SamePairIsIdempotent`, `TestGraphRecall_AFutureEndDateIsStillCurrent` — the last also asserts a genuinely-ended fact stays hidden (so the fix can't pass by disabling the filter) and that default agrees with `as_of=now`. **Fail-before on all three.**

⚠️ One test assertion was initially **vacuous**: it matched `"retired":true`, the JSON form, but the recall output is a Go map rendering, so that string cannot appear and the assertion passed against unfixed code. Now matched against `retired:true` and verified by mutation.

## Reviewed and found sound

- consolidator cursor lease + monotonic watermark advance
- retention sweeper's dry-run fencing on every delete path
- memory-tool capability gates (all 8 consolidation ops gated; `supersede` additionally lease-checked)
- chunk-body tenant/scope handling across all ten cross-plane call sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8