### PR TITLE
fix(memory): refuse a chunk parent that would make it unreachable

### DIFF
--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -1159,6 +1159,34 @@ func (d *Document) createChunk(ctx context.Context, key sqlmem.ScopeKey, mscope 
 	// siblings by +1 (in one txn) so the new chunk lands at afterPos+1 with no
 	// tie. Overrides parent_id/position.
 	parentID := in.ParentID
+	// A directly-supplied parent_id gets the SAME validation after_id already had
+	// below — it must exist, and it must be in this document.
+	//
+	// Without it, create_chunk returned success (with a fresh id and revision) for
+	// a chunk nothing could ever reach: no walk descends to it from the root, so it
+	// was absent from get_document and export_md the instant it was written.
+	// Writing content, being told it worked, and never seeing it again is a worse
+	// outcome than an error, and it is invisible to the dead-link sweeper, which
+	// looks for a missing DOCUMENT rather than a missing PARENT.
+	//
+	// An empty parent_id still means "child of the root", so nothing legitimate is
+	// narrowed.
+	if in.ParentID != "" {
+		par, ok, perr := d.getChunkRow(ctx, key, in.ParentID)
+		if perr != nil {
+			return errResult("create_chunk: parent lookup: " + perr.Error()), nil
+		}
+		if !ok {
+			return errResult("create_chunk: no such parent_id: " + in.ParentID +
+				" (the chunk would be unreachable from the document root; omit parent_id " +
+				"to attach it to the root)"), nil
+		}
+		if par.DocumentID != in.DocumentID {
+			return errResult(fmt.Sprintf(
+				"create_chunk: parent_id %q belongs to document %q, not %q — a chunk cannot be "+
+					"parented across documents", in.ParentID, par.DocumentID, in.DocumentID)), nil
+		}
+	}
 	pos := 0
 	if in.AfterID != "" {
 		sib, ok, err := d.getChunkRow(ctx, key, in.AfterID)
@@ -1627,6 +1655,36 @@ func (d *Document) moveChunk(ctx context.Context, key sqlmem.ScopeKey, in docInp
 	if in.NewParentID != "" {
 		if in.NewParentID == in.ID {
 			return errResult("move_chunk: cannot move a chunk under itself"), nil
+		}
+		// The new parent must EXIST, and must live in the same document.
+		//
+		// Neither was checked, and both failures reported ok:true. A missing parent
+		// silently orphaned the chunk: the row survives but nothing walks to it from
+		// the root, so it vanishes from get_document and export_md while still
+		// occupying the scope — invisible loss, which is worse than an error. And the
+		// dead-link sweeper does not catch this class: it reports a chunk whose
+		// DOCUMENT is gone, not one whose PARENT is.
+		//
+		// A cross-document parent is the same corruption from the other side: the
+		// chunk keeps its own document_id while its parent_id points into another
+		// tree, so the two documents disagree about who owns it.
+		//
+		// Moving to the ROOT level is still expressed by an empty new_parent_id, so
+		// this narrows nothing a caller could legitimately want.
+		newParent, found, perr := d.getChunkRow(ctx, key, in.NewParentID)
+		if perr != nil {
+			return errResult("move_chunk: new parent lookup: " + perr.Error()), nil
+		}
+		if !found {
+			return errResult("move_chunk: no such new_parent_id: " + in.NewParentID +
+				" (moving under a parent that does not exist would orphan the chunk; " +
+				"pass an empty new_parent_id to move it to the root level)"), nil
+		}
+		if newParent.DocumentID != row.DocumentID {
+			return errResult(fmt.Sprintf(
+				"move_chunk: new_parent_id %q belongs to document %q, but this chunk is in %q — "+
+					"a chunk cannot be parented across documents",
+				in.NewParentID, newParent.DocumentID, row.DocumentID)), nil
 		}
 		cur := in.NewParentID
 		for i := 0; cur != "" && i <= maxChunkDepth; i++ {

--- a/internal/tools/builtin/document_entity_test.go
+++ b/internal/tools/builtin/document_entity_test.go
@@ -416,3 +416,85 @@ func TestGraphRecall_AFutureEndDateIsStillCurrent(t *testing.T) {
 			got, asOf)
 	}
 }
+
+// TestChunkParentage_RefusesAnUnreachableParent covers create_chunk and
+// move_chunk together, because they had the SAME hole and it produces the same
+// outcome: a chunk that exists and cannot be reached.
+//
+// Neither validated a directly-supplied parent. Both returned ok/success. And the
+// chunk then vanished from get_document and export_md, because every walk
+// descends from the root and nothing led to it — so a caller wrote content, was
+// told it worked, and never saw it again. That is worse than an error, and the
+// dead-link sweeper does not catch it: it looks for a chunk whose DOCUMENT is
+// missing, not one whose PARENT is.
+//
+// Cross-document parentage is the same corruption from the other side — the
+// chunk keeps its own document_id while its parent_id points into another tree.
+func TestChunkParentage_RefusesAnUnreachableParent(t *testing.T) {
+	d, ctx, docID, root := entityFixture(t)
+	const ghost = "deadbeefdeadbeefdeadbeefdeadbeef"
+
+	other, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"other doc"}`)
+	if r.IsError {
+		t.Fatalf("create other doc: %s", r.Text)
+	}
+	otherRoot := asStr(other["root_chunk_id"])
+
+	t.Run("create under a missing parent", func(t *testing.T) {
+		_, r := docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+docID+
+			`","parent_id":"`+ghost+`","title":"orphan-at-birth"}`)
+		if !r.IsError {
+			t.Fatal("accepted a non-existent parent_id — the chunk is written and " +
+				"immediately unreachable from the document root")
+		}
+	})
+	t.Run("create under another document", func(t *testing.T) {
+		_, r := docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+docID+
+			`","parent_id":"`+otherRoot+`","title":"cross-doc-child"}`)
+		if !r.IsError {
+			t.Fatal("accepted a parent in a different document")
+		}
+	})
+
+	// The document must be unchanged by the refusals.
+	md, _ := docExec(t, d, ctx, `{"op":"export_md","scope":"user","id":"`+docID+`"}`)
+	for _, ghostTitle := range []string{"orphan-at-birth", "cross-doc-child"} {
+		if strings.Contains(asStr(md), ghostTitle) {
+			t.Errorf("a refused create still wrote %q", ghostTitle)
+		}
+	}
+
+	victim, vr := docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+docID+
+		`","parent_id":"`+root+`","title":"movable"}`)
+	if vr.IsError {
+		t.Fatalf("create movable: %s", vr.Text)
+	}
+	vid := asStr(victim["id"])
+
+	t.Run("move under a missing parent", func(t *testing.T) {
+		_, r := docExec(t, d, ctx, `{"op":"move_chunk","scope":"user","id":"`+vid+
+			`","new_parent_id":"`+ghost+`"}`)
+		if !r.IsError {
+			t.Fatal("accepted a non-existent new_parent_id — the chunk is orphaned")
+		}
+	})
+	t.Run("move under another document", func(t *testing.T) {
+		_, r := docExec(t, d, ctx, `{"op":"move_chunk","scope":"user","id":"`+vid+
+			`","new_parent_id":"`+otherRoot+`"}`)
+		if !r.IsError {
+			t.Fatal("accepted a cross-document new_parent_id")
+		}
+	})
+
+	// The chunk survived both refusals AND is still reachable.
+	md2, _ := docExec(t, d, ctx, `{"op":"export_md","scope":"user","id":"`+docID+`"}`)
+	if !strings.Contains(asStr(md2), "movable") {
+		t.Errorf("the chunk is no longer reachable after the refused moves: %s", asStr(md2))
+	}
+
+	// And moving to the ROOT level is still allowed — the fix must not narrow that.
+	if _, r := docExec(t, d, ctx, `{"op":"move_chunk","scope":"user","id":"`+vid+
+		`","new_parent_id":""}`); r.IsError {
+		t.Errorf("moving to the root level was refused: %s", r.Text)
+	}
+}


### PR DESCRIPTION
Memory-review **pass 3**, over `document.go`'s chunk-mutation paths. Two ops shared one hole with the same outcome: **a chunk that exists and cannot be reached.**

## The hole

`create_chunk` validated `after_id` (exists + same document) but **not** a directly supplied `parent_id`. `move_chunk` validated neither. Both returned success:

```
(c) create under NON-EXISTENT parent: isError=false  id:b1e7e0…  revision:1
    export contains 'orphan-at-birth': false
```

A caller writes content, gets a fresh id and revision back, and the content is **never visible again** — every walk descends from the root and nothing leads to it.

## Why that's worse than an error

The content still occupies the scope, and **nothing reports it**. The dead-link sweeper looks for a chunk whose *document* is missing, not one whose *parent* is — so this orphan class was invisible to the one subsystem built specifically to find unreachable rows.

Cross-document parentage is the same corruption from the other side: the chunk keeps its own `document_id` while `parent_id` points into another tree, so the two documents disagree about who owns it.

## The fix

Both ops now validate before writing, mirroring the `after_id` checks `create_chunk` already had. An empty `parent_id` / `new_parent_id` still means the root level, so nothing legitimate is narrowed — **the test asserts that explicitly**, because a fix that made root-level moves impossible would trade one bug for a worse one.

## Tested

`TestChunkParentage_RefusesAnUnreachableParent` — four subtests across both ops, plus assertions that a refused create wrote nothing, a refused move left the chunk reachable, and moving to the root still works. **Fail-before on all four.**

## Reviewed and found sound

- `update_chunk`'s optimistic concurrency — revision required, pre-checked, then atomic `UPDATE … WHERE revision = ?` with a `RowsAffected==0` conflict bail
- `move_chunk`'s cycle guard — walks up from the new parent, depth-bounded
- `reorder_chunk`'s contiguous renumbering (self-heals pre-existing ties/gaps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8