### PR TITLE
fix(memory): import_md must not read fenced code as document structure

### DIFF
--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -2130,6 +2130,43 @@ func classifyMediaBody(body string) (typ, mediaType, assetData, newBody string) 
 // right after a heading carries id/type/status/fields, and a trailing
 // `<!-- loom-edges: … -->` block carries the graph edges. Lines between
 // headings (minus the loom comment) are the chunk body.
+// mdFence describes an open fenced code block: which character opened it and how
+// long the run was. CommonMark closes a fence only with the SAME character and a
+// run at least as long as the opener, which is what lets a ```-fenced block
+// contain a shorter ``` run as literal text.
+type mdFence struct {
+	char byte
+	run  int
+}
+
+// mdFenceDelim reads a line as a fence delimiter, returning the character and run
+// length, or run 0 if the line is not one.
+//
+// Up to three leading spaces are allowed (four would make it an indented code
+// block, which is a different construct and needs no tracking here because it
+// cannot contain an ATX heading either).
+func mdFenceDelim(line string) (byte, int) {
+	i := 0
+	for i < len(line) && i < 3 && line[i] == ' ' {
+		i++
+	}
+	if i >= len(line) || (line[i] != '`' && line[i] != '~') {
+		return 0, 0
+	}
+	c := line[i]
+	run := 0
+	for i+run < len(line) && line[i+run] == c {
+		run++
+	}
+	if run < 3 {
+		return 0, 0
+	}
+	// A ``` opener may carry an info string, but a closer may not contain a
+	// backtick. Not enforced here: treating an info-bearing line as a delimiter is
+	// correct for openers, and for closers the run/char match below is what decides.
+	return c, run
+}
+
 func parseLoomMarkdown(md string) ([]mdChunk, []mdEdge) {
 	lines := strings.Split(strings.ReplaceAll(md, "\r\n", "\n"), "\n")
 	var chunks []mdChunk
@@ -2153,9 +2190,41 @@ func parseLoomMarkdown(md string) ([]mdChunk, []mdEdge) {
 		cur = nil
 		bodyLines = nil
 	}
+	// FENCED CODE BLOCKS ARE LITERAL, and tracking that is the whole reason this
+	// state exists. Without it a body containing a Markdown sample — which is most
+	// technical documentation, including this project's own RFCs — was re-parsed on
+	// import: its "## Example" lines became real chunks, the surrounding body was
+	// truncated at the fence, and the document came back with more chunks than it
+	// had. export_md was already correct (it emits the body verbatim); the asymmetry
+	// meant export -> import silently restructured the tree.
+	var fence mdFence
+
 	for i := 0; i < len(lines); i++ {
 		line := lines[i]
 		trimmed := strings.TrimSpace(line)
+
+		if c, run := mdFenceDelim(line); run > 0 {
+			switch {
+			case fence.run == 0:
+				fence = mdFence{char: c, run: run}
+			case c == fence.char && run >= fence.run:
+				fence = mdFence{}
+			}
+			if cur != nil {
+				bodyLines = append(bodyLines, line)
+			}
+			continue
+		}
+		// Inside a fence every line is content — headings, loom comments and the
+		// edges trailer alike. An unterminated fence therefore runs to the end of
+		// the document, which is also what CommonMark specifies.
+		if fence.run > 0 {
+			if cur != nil {
+				bodyLines = append(bodyLines, line)
+			}
+			continue
+		}
+
 		// Edges trailer — consume to its closing "-->".
 		if strings.HasPrefix(trimmed, "<!-- loom-edges:") {
 			for i++; i < len(lines) && !strings.Contains(lines[i], "-->"); i++ {

--- a/internal/tools/builtin/document_md_roundtrip_test.go
+++ b/internal/tools/builtin/document_md_roundtrip_test.go
@@ -1,0 +1,106 @@
+package builtin
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestMarkdownRoundTrip_FencedHeadingsAreNotStructure is the invariant export_md
+// and import_md exist to uphold: exporting a document and importing the result
+// reproduces it.
+//
+// It failed for any document whose body contained a Markdown sample — which is
+// most technical documentation, including this project's own RFCs and guides.
+// export_md was already right (it emits the body verbatim); import_md matched
+// headings line-by-line with no awareness of fenced code blocks, so the sample's
+// "## Example" lines became real chunks and the surrounding body was truncated at
+// the fence. The document came back with MORE chunks than it had.
+func TestMarkdownRoundTrip_FencedHeadingsAreNotStructure(t *testing.T) {
+	d, ctx, docID, root := entityFixture(t)
+
+	body := "Here is a config sample:\n\n```markdown\n## Not A Heading\n\nsome text\n" +
+		"### Deeper Not A Heading\n```\n\nTrailing prose."
+	bj, _ := json.Marshal(body)
+	if _, r := docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+docID+
+		`","parent_id":"`+root+`","title":"Section One","body":`+string(bj)+`}`); r.IsError {
+		t.Fatalf("create one: %s", r.Text)
+	}
+	// A real sibling, so fabricated structure is distinguishable from real structure.
+	if _, r := docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+docID+
+		`","parent_id":"`+root+`","title":"Section Two"}`); r.IsError {
+		t.Fatalf("create two: %s", r.Text)
+	}
+
+	md, r := docExec(t, d, ctx, `{"op":"export_md","scope":"user","id":"`+docID+`"}`)
+	if r.IsError {
+		t.Fatalf("export: %s", r.Text)
+	}
+	exported := asStr(md["markdown"])
+
+	ij, _ := json.Marshal(exported)
+	out, r2 := docExec(t, d, ctx, `{"op":"import_md","scope":"user","markdown":`+string(ij)+`}`)
+	if r2.IsError {
+		t.Fatalf("import: %s", r2.Text)
+	}
+	// root + Section One + Section Two. Anything more is fabricated from the fence.
+	if n := asInt(out["chunks_created"]); n != 3 {
+		t.Errorf("re-import created %d chunks, want 3 — the fenced sample's headings were "+
+			"parsed as document structure", n)
+	}
+
+	// And the shape is stable: a second export matches the first once ids are
+	// stripped (they are freshly minted per import and are not structure).
+	md2, _ := docExec(t, d, ctx,
+		`{"op":"export_md","scope":"user","id":"`+asStr(out["document_id"])+`"}`)
+	if a, b := stripLoomMeta(exported), stripLoomMeta(asStr(md2["markdown"])); a != b {
+		t.Errorf("round-trip is not stable:\n--- first ---\n%s\n--- second ---\n%s", a, b)
+	}
+
+	// The body must survive whole — the fence content included.
+	if !strings.Contains(asStr(md2["markdown"]), "### Deeper Not A Heading") {
+		t.Errorf("the fenced sample was lost from the body: %s", asStr(md2["markdown"]))
+	}
+	if !strings.Contains(asStr(md2["markdown"]), "Trailing prose.") {
+		t.Errorf("body after the fence was truncated: %s", asStr(md2["markdown"]))
+	}
+}
+
+// TestMarkdownRoundTrip_TildeAndNestedFences covers the delimiter rules the fix
+// relies on: ~~~ fences, and a shorter run INSIDE a longer one staying literal.
+func TestMarkdownRoundTrip_TildeAndNestedFences(t *testing.T) {
+	d, ctx, docID, root := entityFixture(t)
+
+	// A ````-opened block containing a ``` run and a heading: the inner run is too
+	// short to close the outer fence, so everything stays body.
+	body := "~~~\n## Tilde Fenced\n~~~\n\n````\n```\n## Still Not A Heading\n```\n````"
+	bj, _ := json.Marshal(body)
+	if _, r := docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+docID+
+		`","parent_id":"`+root+`","title":"Fences","body":`+string(bj)+`}`); r.IsError {
+		t.Fatalf("create: %s", r.Text)
+	}
+	md, _ := docExec(t, d, ctx, `{"op":"export_md","scope":"user","id":"`+docID+`"}`)
+	ij, _ := json.Marshal(asStr(md["markdown"]))
+	out, r := docExec(t, d, ctx, `{"op":"import_md","scope":"user","markdown":`+string(ij)+`}`)
+	if r.IsError {
+		t.Fatalf("import: %s", r.Text)
+	}
+	if n := asInt(out["chunks_created"]); n != 2 {
+		t.Errorf("re-import created %d chunks, want 2 (root + Fences) — a fenced heading "+
+			"became structure", n)
+	}
+}
+
+// stripLoomMeta drops the per-chunk metadata comments, whose ids are freshly
+// minted on every import and are therefore not part of the structure being
+// compared.
+func stripLoomMeta(s string) string {
+	var out []string
+	for _, ln := range strings.Split(s, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(ln), "<!-- loom:") {
+			continue
+		}
+		out = append(out, ln)
+	}
+	return strings.Join(out, "\n")
+}


### PR DESCRIPTION
Memory-review **pass 4**, over the `export_md` / `import_md` round-trip.

## The bug

`export_md` emits a chunk body verbatim — correct. `import_md` matched headings line-by-line with **no awareness of fenced code blocks**. So any body containing a Markdown sample was re-parsed on import: its `## Example` lines became real chunks, the body was truncated at the fence, and the document came back with more chunks than it had.

| case | expected | got |
|---|---|---|
| root + 2 sections, one with a fenced sample | 3 chunks | **5** |
| tilde + nested fences | 2 chunks | **4** |

## Why it matters here specifically

The loomcycle document store is the **primary home for its own RFCs and guides**, which are full of Markdown and YAML samples. Every one of them would have round-tripped into a different document.

The asymmetry is what made it invisible: export was correct, so a single export looked fine. Only `export → import → export` showed the drift.

## The fix

`parseLoomMarkdown` now tracks fence state per CommonMark:

- ``` ``` ``` or `~~~` with a run of 3+, up to three leading spaces
- closed only by the **same character** with a run **at least as long** — which is what lets a ` ```` `-fenced block contain a literal ` ``` ` run
- inside a fence every line is content: headings, `<!-- loom: -->` metadata and the edges trailer alike
- an unterminated fence runs to end-of-document, also per CommonMark

## Tested

`TestMarkdownRoundTrip_FencedHeadingsAreNotStructure` — chunk count, second export matches first, and both the fenced sample *and* the prose after it survive whole. `TestMarkdownRoundTrip_TildeAndNestedFences` — `~~~` plus a short run nested in a longer one. **Fail-before on both.**

⚠️ **Verified unaffected:** the RFC BO media path, whose mermaid and image bodies are themselves fenced — `TestDocument_ExportImport_MediaChunks` and `TestDocument_ImageAssetRoundTrip` both still pass. That was the plausible way this fix could have broken something.

Tests are in their own file rather than appended to `document_entity_test.go`, because appending to a shared test file across concurrent branches is exactly what produced #919's conflict.

## Probed and sound

- a body containing a `<!-- loom: -->` comment or an edges-trailer lookalike stays **body**, not metadata
- blank-line runs survive

One benign difference deliberately **not** changed: a title's trailing whitespace is trimmed on import, which markdown headings do anyway. It stabilizes after one pass (`export2 == export3`), so it's normalization rather than drift — and preserving it would be the wrong reading of the format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8