### PR TITLE
fix(sqlmem): enforce the scope-key separator invariant, don't assume it

### DIFF
--- a/internal/sqlmem/postgres.go
+++ b/internal/sqlmem/postgres.go
@@ -249,6 +249,12 @@ func pgScopeNames(key ScopeKey) (schema, role string, err error) {
 		if key.Tenant == "" || key.Scope == "" || key.ScopeID == "" {
 			return "", "", fmt.Errorf("sqlmem: empty scope key component")
 		}
+		// Enforced, not assumed. A component carrying the separator makes this join
+		// ambiguous, so distinct scopes would derive the same schema and the same
+		// LOGIN role — see ScopeKey.validate for why the comment alone was not enough.
+		if err := key.validate(); err != nil {
+			return "", "", err
+		}
 		canon = key.Tenant + "\x1f" + key.Scope + "\x1f" + key.ScopeID
 	}
 	sum := sha256.Sum256([]byte(canon))

--- a/internal/sqlmem/scopekey_test.go
+++ b/internal/sqlmem/scopekey_test.go
@@ -1,0 +1,70 @@
+package sqlmem
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestScopeKey_SeparatorCannotCollideTwoScopes pins the identity invariant the
+// postgres tier derives its schema AND its LOGIN role from.
+//
+// pgScopeNames hashes a 0x1f-joined triple. A component containing that byte makes
+// the join ambiguous, so ("a\x1fb","c","d"), ("a","b\x1fc","d") and
+// ("a","b","c\x1fd") all produced the SAME schema and the SAME role — three
+// scopes sharing one database, which is the exact isolation the per-scope role
+// exists to provide.
+//
+// The sqlite tier never had this problem: its sanitize() appends a hash of the
+// original input, so distinct ids cannot converge. The two tiers made different
+// guarantees about the same keys, and only the weaker one was security-critical.
+func TestScopeKey_SeparatorCannotCollideTwoScopes(t *testing.T) {
+	variants := []ScopeKey{
+		{Tenant: "a\x1fb", Scope: "c", ScopeID: "d"},
+		{Tenant: "a", Scope: "b\x1fc", ScopeID: "d"},
+		{Tenant: "a", Scope: "b", ScopeID: "c\x1fd"},
+	}
+	for _, k := range variants {
+		if _, _, err := pgScopeNames(k); err == nil {
+			t.Errorf("pgScopeNames accepted %+q — it derives a schema and a LOGIN role "+
+				"that another scope also derives", k)
+		} else if !strings.Contains(err.Error(), "separator") {
+			t.Errorf("unexpected error for %+q: %v", k, err)
+		}
+	}
+	// A legitimate key is unaffected.
+	if _, _, err := pgScopeNames(ScopeKey{Tenant: "acme", Scope: "user", ScopeID: "alice"}); err != nil {
+		t.Errorf("a normal key was refused: %v", err)
+	}
+}
+
+// TestScopeKey_ValidatedAtTheManagerEntryPoints — the derivations that consume a
+// ScopeKey are spread across three subsystems (postgres schema/role names, the GC
+// debounce key, and the transaction-registry key), and only the first returns an
+// error. Validating where a key ENTERS the manager is what lets the other two keep
+// building plain strings and still be safe.
+func TestScopeKey_ValidatedAtTheManagerEntryPoints(t *testing.T) {
+	mgr, err := New(Config{Root: t.TempDir()})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = mgr.Close() })
+	ctx := context.Background()
+	bad := ScopeKey{Tenant: "acme", Scope: "user", ScopeID: "alice\x1fagent\x1fcurator"}
+
+	if _, err := mgr.Exec(ctx, bad, `CREATE TABLE t (a TEXT)`, nil, 0); err == nil {
+		t.Error("Exec accepted a separator-bearing scope id")
+	}
+	if _, err := mgr.Query(ctx, bad, `SELECT 1`, nil); err == nil {
+		t.Error("Query accepted a separator-bearing scope id")
+	}
+	if _, err := mgr.DropScope(ctx, bad); err == nil {
+		t.Error("DropScope accepted a separator-bearing scope id")
+	}
+
+	// The same ops on a clean key still work, so the guard has not broken the tier.
+	ok := ScopeKey{Tenant: "acme", Scope: "user", ScopeID: "alice"}
+	if _, err := mgr.Exec(ctx, ok, `CREATE TABLE t (a TEXT)`, nil, 0); err != nil {
+		t.Errorf("a normal Exec was refused: %v", err)
+	}
+}

--- a/internal/sqlmem/sqlmem.go
+++ b/internal/sqlmem/sqlmem.go
@@ -218,6 +218,40 @@ func newManager(d dialect, cfg Config, b backend) *Manager {
 // portable statement with `?`. It is a purely positional replacement and does
 // NOT skip a `?` inside a string literal — call it only on statements you
 // construct yourself (with bound values), never on raw model/user SQL.
+// scopeKeySep is the byte that joins a ScopeKey's components into the canonical
+// strings three subsystems derive identity from: the postgres schema/role names
+// (pgScopeNames), the GC debounce key (touchKey), and the transaction-registry
+// key (txn.go). A component containing it makes those joins ambiguous.
+const scopeKeySep = '\x1f'
+
+// validate rejects a ScopeKey whose components would produce an ambiguous
+// canonical form.
+//
+// THE TWO TIERS DISAGREED ABOUT THIS, which is what makes it worth enforcing
+// rather than documenting. The sqlite tier's sanitize() replaces unsafe
+// characters AND appends a hash of the original, so two distinct scope ids can
+// never land on one file. The postgres tier hashes a separator-joined triple and
+// only ASSERTED, in a comment, that components are separator-free — so
+// ("a\x1fb","c","d"), ("a","b\x1fc","d") and ("a","b","c\x1fd") all derived the
+// SAME schema and the SAME LOGIN role. Three scopes, one database.
+//
+// It is not reachable across a security boundary today, and only by luck: the
+// tenant is always principal-derived and comes FIRST, so a caller who controls
+// only the trailing scope_id (the erasure surface passes ?subject= straight
+// through) cannot forge another tenant's prefix. That safety is an accident of
+// field order, not a design, and a fourth component or a reordering would spend
+// it silently.
+func (k ScopeKey) validate() error {
+	for _, part := range []struct{ name, val string }{
+		{"tenant", k.Tenant}, {"scope", k.Scope}, {"scope_id", k.ScopeID},
+	} {
+		if strings.ContainsRune(part.val, scopeKeySep) {
+			return fmt.Errorf("sqlmem: %s contains the reserved separator (0x1f)", part.name)
+		}
+	}
+	return nil
+}
+
 func (m *Manager) Rebind(sql string) string {
 	if m.dialect != dialectPostgres {
 		return sql
@@ -245,6 +279,9 @@ func (m *Manager) Query(ctx context.Context, key ScopeKey, statement string, arg
 	if err := validateStatementForDialect(statement, true, m.dialect); err != nil {
 		return nil, err
 	}
+	if err := key.validate(); err != nil {
+		return nil, err
+	}
 	defer m.touch(key)
 	return m.backend.query(ctx, key, statement, args)
 }
@@ -254,6 +291,9 @@ func (m *Manager) Query(ctx context.Context, key ScopeKey, statement string, arg
 // enforces the quota + timeout.
 func (m *Manager) Exec(ctx context.Context, key ScopeKey, statement string, args []any, quotaOverride int) (*ExecResult, error) {
 	if err := validateStatementForDialect(statement, false, m.dialect); err != nil {
+		return nil, err
+	}
+	if err := key.validate(); err != nil {
 		return nil, err
 	}
 	defer m.touch(key)
@@ -279,6 +319,9 @@ func (m *Manager) DropScope(ctx context.Context, key ScopeKey) (removed bool, er
 	}
 	if key.Scope == "" || strings.TrimSpace(key.ScopeID) == "" {
 		return false, fmt.Errorf("sqlmem: DropScope requires a non-empty scope and scope_id")
+	}
+	if err := key.validate(); err != nil {
+		return false, err
 	}
 	return m.backend.dropScope(key)
 }


### PR DESCRIPTION
Memory-review **pass 5**, over `sqlmem/postgres.go` — the per-scope LOGIN roles that *are* the SQL Memory isolation boundary, and the highest-stakes file left unread.

## The finding

`pgScopeNames` derives a scope's postgres **schema** and its **LOGIN role** by hashing a `0x1f`-joined `(tenant, scope, scope_id)` triple — and only *asserted in a comment* that components are separator-free. Nothing checks:

```
("a\x1fb", "c",      "d")      -> sqlmem_s_1a84020153d6ff97…
("a",      "b\x1fc", "d")      -> sqlmem_s_1a84020153d6ff97…
("a",      "b",      "c\x1fd") -> sqlmem_s_1a84020153d6ff97…
```

Three distinct scopes → **one schema, one role**. Exactly the isolation the per-scope role exists to provide.

## Why enforce rather than document

**The two tiers disagreed.** The sqlite tier's `sanitize()` replaces unsafe characters *and appends a hash of the original*, so two distinct scope ids can never converge on one file. The postgres tier had no such guarantee.

Same subsystem, same keys — and only the weaker tier is the one where a collision merges two databases.

## Reachability: safe today, by luck

**Not** reachable across a security boundary. The tenant is always principal-derived and comes **first**, so a caller who controls only the trailing `scope_id` — and the erasure surface passes `?subject=` straight through to a `ScopeKey` — cannot forge another tenant's prefix. Verified both ways:

```
cross-tenant reachable via scope_id only: false
cross-scope-class reachable:              false
```

That safety is an **accident of field order**, not a design. A fourth component or a reordering spends it silently.

## Where the check goes

The same separator-joined-triple assumption also backs `gc.go`'s touch-debounce key and `txn.go`'s transaction-registry key — and a collision *there* means one run reaching another scope's open transaction. Only `pgScopeNames` returns an error, so validation goes at the **Manager entry points** (`Query` / `Exec` / `DropScope`) as well as inside `pgScopeNames`. That lets the other two keep building plain strings and still be safe.

## Tested

`TestScopeKey_SeparatorCannotCollideTwoScopes` — all three shapes refused, a normal key unaffected. `TestScopeKey_ValidatedAtTheManagerEntryPoints` — `Exec`/`Query`/`DropScope` refuse, and a clean key still works so the guard hasn't broken the tier. **Fail-before at both layers.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8