### PR TITLE
fix(sqlmem): close the four scope-key entry points #921 missed, and pin them

### DIFF
--- a/internal/sqlmem/dump.go
+++ b/internal/sqlmem/dump.go
@@ -80,6 +80,12 @@ func (m *Manager) ExportScope(ctx context.Context, key ScopeKey) (*ScopeDump, er
 	if key.Scope == runScope {
 		return nil, fmt.Errorf("sqlmem: the run scope is not exportable")
 	}
+	// A colliding key would dump ANOTHER scope's rows into this scope's archive,
+	// which is worse than a failed export: the wrong data ends up in a backup and
+	// is replayed on restore.
+	if err := key.validate(); err != nil {
+		return nil, err
+	}
 	return m.backend.exportScope(ctx, key)
 }
 
@@ -92,6 +98,11 @@ func (m *Manager) ExportScope(ctx context.Context, key ScopeKey) (*ScopeDump, er
 func (m *Manager) RestoreScope(ctx context.Context, key ScopeKey, dump *ScopeDump) error {
 	if dump == nil {
 		return nil
+	}
+	// Restore provisions the scope before replaying DDL, so a key that arrived in a
+	// snapshot is untrusted input to the same derivation Begin/Exec guard.
+	if err := key.validate(); err != nil {
+		return err
 	}
 	if key.Scope == runScope {
 		return fmt.Errorf("sqlmem: the run scope is not restorable")

--- a/internal/sqlmem/scopekey_test.go
+++ b/internal/sqlmem/scopekey_test.go
@@ -2,6 +2,11 @@ package sqlmem
 
 import (
 	"context"
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -66,5 +71,126 @@ func TestScopeKey_ValidatedAtTheManagerEntryPoints(t *testing.T) {
 	ok := ScopeKey{Tenant: "acme", Scope: "user", ScopeID: "alice"}
 	if _, err := mgr.Exec(ctx, ok, `CREATE TABLE t (a TEXT)`, nil, 0); err != nil {
 		t.Errorf("a normal Exec was refused: %v", err)
+	}
+}
+
+// TestScopeKey_EveryEntryPointValidates is a drift test over the SOURCE, and it
+// exists because the first attempt at this guard covered three entry points out of
+// seven.
+//
+// The separator invariant is enforced at the doors rather than in one choke point
+// (there isn't one), which makes it exactly the kind of rule that rots: a new
+// Manager method taking a ScopeKey is easy to add and easy to add without the
+// check. Reviewing found the gap once; this makes the next one a test failure.
+//
+// A method may opt out only by appearing in scopeKeyValidationExempt WITH a reason,
+// so skipping the check is a deliberate, reviewable act.
+func TestScopeKey_EveryEntryPointValidates(t *testing.T) {
+	// touch is called only from Query / Exec / BeginTxn, all of which validate
+	// first, so it inherits the guarantee rather than restating it — and it returns
+	// nothing, so it could not report a violation anyway.
+	scopeKeyValidationExempt := map[string]string{
+		"touch": "internal; reached only from Query/Exec/BeginTxn, which validate first",
+	}
+
+	fset := token.NewFileSet()
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var checked int
+	for _, path := range files {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		f, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		for _, decl := range f.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv == nil || fn.Body == nil {
+				continue
+			}
+			// Only methods on *Manager — the public surface a ScopeKey enters through.
+			star, ok := fn.Recv.List[0].Type.(*ast.StarExpr)
+			if !ok {
+				continue
+			}
+			if id, ok := star.X.(*ast.Ident); !ok || id.Name != "Manager" {
+				continue
+			}
+			var takesKey bool
+			for _, p := range fn.Type.Params.List {
+				if id, ok := p.Type.(*ast.Ident); ok && id.Name == "ScopeKey" {
+					takesKey = true
+				}
+			}
+			if !takesKey {
+				continue
+			}
+			checked++
+			if reason, exempt := scopeKeyValidationExempt[fn.Name.Name]; exempt {
+				t.Logf("%s: exempt (%s)", fn.Name.Name, reason)
+				continue
+			}
+			var body strings.Builder
+			if err := printer.Fprint(&body, fset, fn.Body); err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(body.String(), ".validate()") {
+				t.Errorf("Manager.%s takes a ScopeKey but never calls validate() — a "+
+					"separator-bearing key would derive storage shared with another scope. "+
+					"Add the check, or add %q to scopeKeyValidationExempt with a reason.",
+					fn.Name.Name, fn.Name.Name)
+			}
+		}
+	}
+	// Guard the guard: if the AST walk silently matched nothing, the test would
+	// pass while checking nothing at all.
+	if checked < 5 {
+		t.Fatalf("only found %d Manager methods taking a ScopeKey — the AST walk is "+
+			"probably broken, so this test is not actually checking anything", checked)
+	}
+}
+
+// TestScopeKey_ProvisioningPathsRefuse checks the three entry points the first
+// version of this guard missed, behaviourally rather than by source shape.
+//
+// BeginTxn and RestoreScope PROVISION a scope (schema + LOGIN role on postgres);
+// ExportScope reads one, and a collision there is the worst of the three — it
+// dumps another scope's rows into this scope's archive, so the wrong data lands in
+// a backup and is replayed on restore.
+func TestScopeKey_ProvisioningPathsRefuse(t *testing.T) {
+	mgr, err := New(Config{Root: t.TempDir()})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = mgr.Close() })
+	ctx := context.Background()
+	bad := ScopeKey{Tenant: "acme", Scope: "user", ScopeID: "alice\x1fuser\x1fbob"}
+
+	if _, err := mgr.BeginTxn(ctx, BuildTxnID("r1", bad.Scope, bad.ScopeID), "r1", bad); err == nil {
+		t.Error("BeginTxn accepted a separator-bearing key and provisioned the scope")
+	}
+	if _, err := mgr.ExportScope(ctx, bad); err == nil {
+		t.Error("ExportScope accepted a separator-bearing key — another scope's rows " +
+			"could be dumped into this archive")
+	}
+	if err := mgr.RestoreScope(ctx, bad, &ScopeDump{}); err == nil {
+		t.Error("RestoreScope accepted a separator-bearing key")
+	}
+
+	// A clean key still opens a transaction, so the guard has not broken the path.
+	ok := ScopeKey{Tenant: "acme", Scope: "user", ScopeID: "alice"}
+	depth, err := mgr.BeginTxn(ctx, BuildTxnID("r2", ok.Scope, ok.ScopeID), "r2", ok)
+	if err != nil {
+		t.Fatalf("a normal BeginTxn was refused: %v", err)
+	}
+	if depth != 1 {
+		t.Errorf("depth = %d, want 1", depth)
+	}
+	if _, err := mgr.RollbackTxn(BuildTxnID("r2", ok.Scope, ok.ScopeID)); err != nil {
+		t.Errorf("rollback: %v", err)
 	}
 }

--- a/internal/sqlmem/sqlite.go
+++ b/internal/sqlmem/sqlite.go
@@ -118,6 +118,14 @@ func sanitize(s string) (string, error) {
 // or a real id). A run scope is NOT tenant-keyed — run ids are globally
 // unique — which is also what lets DropRunScope target a single subtree.
 func (k ScopeKey) keyPath(root string) (string, error) {
+	// Belt-and-braces alongside the postgres tier's check. sanitize() already makes
+	// two distinct ids land on distinct FILES (it appends a hash of the original), so
+	// this tier cannot collide the way pgScopeNames could — but validating here too
+	// means a future Manager entry point that forgets the door check still cannot
+	// derive storage from an ambiguous key.
+	if err := k.validate(); err != nil {
+		return "", err
+	}
 	id, err := sanitize(k.ScopeID)
 	if err != nil {
 		return "", err

--- a/internal/sqlmem/txn.go
+++ b/internal/sqlmem/txn.go
@@ -179,6 +179,11 @@ func (m *Manager) InTxn(txnID string) bool {
 // Errors if the process-wide MaxOpenTxns cap is reached (new txn) or the
 // per-txn MaxTxnDepth cap is reached (nested).
 func (m *Manager) BeginTxn(ctx context.Context, txnID, rootRunID string, key ScopeKey) (int, error) {
+	// beginTx PROVISIONS the scope (schema + LOGIN role on postgres), so this is a
+	// scope-creating entry point and validates like the others.
+	if err := key.validate(); err != nil {
+		return 0, err
+	}
 	m.txns.mu.Lock()
 	if existing, ok := m.txns.open[txnID]; ok {
 		if existing == nil {


### PR DESCRIPTION
Memory-review **pass 6**, and the finding is about the previous pass.

## #921 closed 3 of 7 doors

It enforced the scope-key separator invariant at `Query`, `Exec` and `DropScope`. There are seven entry points taking a `ScopeKey`:

| entry point | stakes |
|---|---|
| `BeginTxn` | **provisions** the scope (schema + LOGIN role) |
| `RestoreScope` | **provisions**, from a key that arrived in a snapshot |
| `ExportScope` | a collision dumps **another scope's rows into this archive** — wrong data in a backup, replayed on restore |
| `touch` | now documented exempt (reached only from the three above; returns nothing) |

So the previous fix closed the doors it had looked at rather than the invariant. **That's the actual defect being repaired here.**

## Beyond the missing calls

**The sqlite tier's `keyPath` now validates too.** That tier can't collide the way `pgScopeNames` could — `sanitize()` appends a hash of the original — but validating at the **derivation** means a future entry point that forgets the door check still can't derive storage from an ambiguous key. Both tiers refuse now, so the guarantee stops depending on memory.

**`TestScopeKey_EveryEntryPointValidates` is a source drift test.** It walks the AST for `Manager` methods taking a `ScopeKey` and fails any that never calls `validate()`. Opting out requires an entry in `scopeKeyValidationExempt` *with a reason*, so skipping is deliberate and reviewable.

This is the part that matters. The rule is enforced at seven doors with no choke point — exactly the kind of invariant that rots as methods get added. Reviewing caught the gap once; the test catches the next one. It also asserts a floor of 5 matched methods, so a broken AST walk can't pass by checking nothing.

**`TestScopeKey_ProvisioningPathsRefuse`** covers the three missed paths behaviourally rather than by source shape, and asserts a clean key still opens and rolls back a transaction so the guard hasn't broken the path.

**Fail-before:** removing the `BeginTxn` guard is caught by the drift test, by name.

## Reviewed and found sound in `txn.go`

- `pushSavepoint`'s depth cap and its `done`-flag refusal against a racing finish
- `popSavepointLocked`'s commit/rollback asymmetry and deliberate pop-on-error (keeping the name would desync depth from the agent's view — the F2 fix)
- `BeginTxn`'s placeholder reservation against a concurrent begin for the same id

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8