### PR TITLE
fix(sqlmem): the SQL validator's scanners were dialect-blind

### DIFF
--- a/internal/sqlmem/validate.go
+++ b/internal/sqlmem/validate.go
@@ -113,7 +113,13 @@ func validateStatement(raw string, readOnly bool) error {
 // load_extension anywhere → check the leading keyword against the deny-set and
 // the per-op allow-set → apply the dialect's extra denies.
 func validateStatementForDialect(raw string, readOnly bool, d dialect) error {
-	stripped := stripComments(raw)
+	// Dollar quoting is a POSTGRES string form, and the two scanners below must know
+	// about it on that tier: without it, a legitimate `VALUES ($$x; y$$)` was refused
+	// as multi-statement, and a `$$--$$` hid a real separator from the guard (safe
+	// today only because pgx's extended protocol rejects multi-statement strings —
+	// an implicit dependency this removes).
+	dollarQuotes := d == dialectPostgres
+	stripped := stripComments(raw, dollarQuotes)
 	trimmed := strings.TrimSpace(stripped)
 	if trimmed == "" {
 		return refuse("empty SQL statement")
@@ -128,7 +134,7 @@ func validateStatementForDialect(raw string, readOnly bool, d dialect) error {
 	// the deferred-payload-via-trigger escape (a trigger that ATTACHes on later
 	// fire). Anyone relaxing the multi-statement rule to support triggers MUST
 	// add a trigger-body scan first.
-	if idx := indexOfStatementSeparator(trimmed); idx >= 0 {
+	if idx := indexOfStatementSeparator(trimmed, dollarQuotes); idx >= 0 {
 		rest := strings.TrimSpace(trimmed[idx+1:])
 		if rest != "" {
 			return refuse("only one SQL statement per call is allowed (found a ';' separating multiple statements)")
@@ -189,7 +195,7 @@ func validateStatementForDialect(raw string, readOnly bool, d dialect) error {
 // inside '...' or "..." is data, not a comment). Conservative: when in doubt it
 // keeps text (the leading-keyword + deny checks still apply to whatever
 // remains).
-func stripComments(s string) string {
+func stripComments(s string, dollarQuotes bool) string {
 	var b strings.Builder
 	b.Grow(len(s))
 	const (
@@ -206,6 +212,18 @@ func stripComments(s string) string {
 		c := s[i]
 		switch state {
 		case normal:
+			// A dollar-quoted body is data: copy it through verbatim so a `--` or a
+			// `/*` inside it is never mistaken for a comment. Postgres tier only.
+			if dollarQuotes && c == '$' {
+				if tag, ok := dollarTagAt(s, i); ok {
+					if end := strings.Index(s[i+len(tag):], tag); end >= 0 {
+						stop := i + len(tag) + end + len(tag)
+						b.WriteString(s[i:stop])
+						i = stop - 1
+						continue
+					}
+				}
+			}
 			switch {
 			case c == '-' && i+1 < len(s) && s[i+1] == '-':
 				state = inLine
@@ -294,7 +312,36 @@ func maskStringLiterals(s string) string {
 // indexOfStatementSeparator returns the index of the first ';' that is NOT
 // inside a string/identifier literal, or -1. Used to detect multi-statement
 // input. Mirrors stripComments' literal-awareness so a ';' inside '…' is data.
-func indexOfStatementSeparator(s string) int {
+// dollarTagAt reads a postgres dollar-quote delimiter starting at s[i] (which must
+// be '$'), returning the full delimiter (e.g. "$$" or "$tag$") and true.
+//
+// The tag rule is postgres's: $ then an optional identifier that does NOT start
+// with a digit, then $. That exclusion is what keeps a POSITIONAL PARAMETER ($1,
+// $2 — which the scope tier uses for every bind) from being mistaken for the start
+// of a quoted string, which would swallow the rest of the statement.
+func dollarTagAt(s string, i int) (string, bool) {
+	if i >= len(s) || s[i] != '$' {
+		return "", false
+	}
+	j := i + 1
+	for j < len(s) {
+		c := s[j]
+		switch {
+		case c == '$':
+			return s[i : j+1], true
+		case c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'):
+			j++
+		case c >= '0' && c <= '9' && j > i+1:
+			// A digit is legal INSIDE a tag but not as its first character.
+			j++
+		default:
+			return "", false
+		}
+	}
+	return "", false
+}
+
+func indexOfStatementSeparator(s string, dollarQuotes bool) int {
 	const (
 		normal = iota
 		inSingle
@@ -307,6 +354,20 @@ func indexOfStatementSeparator(s string) int {
 		c := s[i]
 		switch state {
 		case normal:
+			// Postgres dollar quoting, on that tier only: sqlite has no $tag$ string
+			// form ($name is a bind parameter there), so scanning for it would
+			// mis-tokenize valid sqlite.
+			if dollarQuotes && c == '$' {
+				if tag, ok := dollarTagAt(s, i); ok {
+					if end := strings.Index(s[i+len(tag):], tag); end >= 0 {
+						i += len(tag) + end + len(tag) - 1
+						continue
+					}
+					// Unterminated: the engine will reject the statement, and treating
+					// the remainder as quoted would hide a real separator from this scan.
+					// Fall through and keep scanning.
+				}
+			}
 			switch c {
 			case ';':
 				return i

--- a/internal/sqlmem/validate_dollarquote_test.go
+++ b/internal/sqlmem/validate_dollarquote_test.go
@@ -1,0 +1,94 @@
+package sqlmem
+
+import "testing"
+
+// TestValidate_DollarQuotesArePostgresData covers the two scanners that decide
+// whether a statement is single — stripComments and indexOfStatementSeparator —
+// which were dialect-BLIND while the validator around them is dialect-aware.
+//
+// Two consequences, one user-visible and one latent.
+//
+// VISIBLE: a legitimate `VALUES ($$x; y$$)` was refused as multi-statement, so an
+// agent could not store any text containing a semicolon via dollar quoting.
+//
+// LATENT: `$$--$$` made the stripper delete to end-of-line, hiding a REAL
+// separator from the guard the file itself calls load-bearing. That was safe only
+// because pgx runs the extended protocol, which rejects multi-statement strings —
+// an implicit dependency on a driver detail nobody had written down, and one a
+// QueryExecMode change would have spent silently.
+func TestValidate_DollarQuotesArePostgresData(t *testing.T) {
+	t.Run("valid postgres is accepted", func(t *testing.T) {
+		for _, sql := range []string{
+			`INSERT INTO t (a) VALUES ($$x; y$$)`,
+			`UPDATE t SET a = $$; DROP$$ WHERE a = 1`,
+			`INSERT INTO t (a) VALUES ($tag$x; y$tag$)`,
+			`INSERT INTO t (a) VALUES ($$a--b$$)`,
+		} {
+			if err := validateStatementForDialect(sql, false, dialectPostgres); err != nil {
+				t.Errorf("refused valid postgres %q: %v", sql, err)
+			}
+		}
+	})
+
+	t.Run("a real separator is still refused", func(t *testing.T) {
+		for _, sql := range []string{
+			`SELECT 1 $$--$$ ; DROP TABLE t`, // the latent bypass
+			`SELECT $$a ; DROP TABLE t`,      // unterminated tag must not swallow it
+			`SELECT $tag$a ; DROP TABLE t`,
+			`SELECT 1; DROP TABLE t`,
+			`SELECT * FROM t WHERE a = $1; DROP TABLE t`,
+		} {
+			if err := validateStatementForDialect(sql, true, dialectPostgres); err == nil {
+				t.Errorf("accepted a second statement in %q", sql)
+			}
+		}
+	})
+
+	t.Run("positional parameters are not quotes", func(t *testing.T) {
+		// $1 is a BIND PARAMETER, used by every scope-tier call. Treating it as an
+		// opening delimiter would swallow the rest of the statement, so the tag rule
+		// must reject a leading digit.
+		for _, sql := range []string{
+			`SELECT * FROM t WHERE a = $1`,
+			`SELECT $$x$$, $1 FROM t`,
+			`SELECT $a$ $b$ $a$`,
+		} {
+			if err := validateStatementForDialect(sql, true, dialectPostgres); err != nil {
+				t.Errorf("refused %q: %v", sql, err)
+			}
+		}
+		// The cases above pass even WITHOUT the leading-digit rule, because each $N
+		// lacks a closing $ and the unterminated path falls through to keep scanning.
+		// This one is what actually exercises the rule: with a digit-led tag accepted,
+		// $1$ … $1$ becomes a quoted span and the ';' inside it disappears.
+		if err := validateStatementForDialect(
+			`SELECT $1$ ; DROP TABLE t $1$`, true, dialectPostgres); err == nil {
+			t.Error("a digit-led $1$ was treated as a quote delimiter, hiding a real " +
+				"separator — the tag rule must reject a leading digit")
+		}
+	})
+
+	t.Run("sqlite is unchanged", func(t *testing.T) {
+		// sqlite has no $tag$ string form — $name is a bind parameter — so scanning
+		// for dollar quotes there would mis-tokenize valid sqlite. It must keep
+		// treating the ';' as a separator.
+		if err := validateStatementForDialect(`SELECT $$a;b$$`, true, dialectSQLite); err == nil {
+			t.Error("the sqlite tier applied postgres dollar-quote rules")
+		}
+		if err := validateStatementForDialect(`SELECT 1; DROP TABLE t`, true, dialectSQLite); err == nil {
+			t.Error("sqlite accepted a second statement")
+		}
+	})
+
+	t.Run("stripComments leaves dollar bodies intact", func(t *testing.T) {
+		got := stripComments(`SELECT $$a--b; DROP TABLE t$$`, true)
+		if got != `SELECT $$a--b; DROP TABLE t$$` {
+			t.Errorf("stripped inside a dollar-quoted body: %q", got)
+		}
+		// With the dialect flag off, the old behaviour stands — the flag is what
+		// makes this postgres-only.
+		if off := stripComments(`SELECT $$a--b$$`, false); off == `SELECT $$a--b$$` {
+			t.Error("dollar handling applied even with dollarQuotes=false")
+		}
+	})
+}

--- a/internal/sqlmem/validate_test.go
+++ b/internal/sqlmem/validate_test.go
@@ -133,8 +133,8 @@ func TestStripComments_LiteralAware(t *testing.T) {
 		`INSERT INTO t VALUES ('a;b')`: `INSERT INTO t VALUES ('a;b')`,
 	}
 	for in, want := range cases {
-		if got := stripComments(in); got != want {
-			t.Errorf("stripComments(%q) = %q, want %q", in, got, want)
+		if got := stripComments(in, false); got != want {
+			t.Errorf("stripComments(%q, false) = %q, want %q", in, got, want)
 		}
 	}
 	// A ';' inside a string literal is NOT a statement separator.


### PR DESCRIPTION
Memory-review **pass 7**, over `sqlmem/validate.go` — the statement-validator floor.

`validateStatementForDialect` is dialect-aware and applies postgres-specific denies. The two scanners it runs **first** — `stripComments` and `indexOfStatementSeparator` — were not, and neither knew about postgres dollar quoting.

## Visible, and broken today

A legitimate statement whose dollar-quoted literal contains a semicolon was refused as multi-statement:

```sql
INSERT INTO t (a) VALUES ($$x; y$$)   -- valid postgres, could not be run
UPDATE t SET a = $$; DROP$$ WHERE a = 1
INSERT INTO t (a) VALUES ($tag$x; y$tag$)
```

An agent could not store *any* text containing a semicolon through that form. Four such statements were refused; they now pass.

## Latent

`$$--$$` made the stripper treat the `--` as a comment and delete to end-of-line, **hiding a real statement separator** from the guard this file itself calls load-bearing:

```sql
SELECT 1 $$--$$ ; DROP TABLE t     -- validated clean
```

Safe only because the postgres backend runs `database/sql` + pgx with no `QueryExecMode` override, so the extended protocol rejects multi-statement strings — an implicit dependency on a driver detail nobody had written down, and one a protocol change or a raw-conn path would have spent silently. Now closed at the validator, where the guarantee belongs.

## The fix

Both scanners take a `dollarQuotes` flag, set **only** for postgres: sqlite has no `$tag$` string form (`$name` is a bind parameter there), so scanning for it would mis-tokenize valid sqlite.

`dollarTagAt` implements postgres's tag rule including that a tag may not **start with a digit** — which is what stops a positional parameter (`$1`, `$2`, used by every bind) from opening a span that swallows the rest of the statement. An unterminated tag deliberately falls through and keeps scanning rather than treating the remainder as quoted.

## Tested

`TestValidate_DollarQuotesArePostgresData`, five subtests: valid postgres accepted, a real separator still refused (including the latent bypass and unterminated tags), positional parameters unaffected, **sqlite unchanged**, and `stripComments` leaving dollar bodies intact. **Fail-before on both directions.**

⚠️ The positional-parameter cases initially passed even with the digit rule removed — each `$N` lacks a closing `$`, so the unterminated path saved them and they never exercised the rule. Added `SELECT $1$ ; DROP TABLE t $1$`, which does, and verified by mutation.

## Probed and found sound

- the multi-statement guard against **fourteen** smuggling attempts, verified by **execution** on sqlite — zero smuggled tables created; the two that passed validation were malformed and the engine rejected them
- `stripComments` with comment markers inside single/double/bracket/backtick quotes and doubled quotes
- the read-only path's `SELECT … INTO` refusal, which already had the right note about explicit read-write transactions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8