### PR TITLE
fix(store): vector search must degrade in a mixed-dimension scope, not die

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,9 +99,27 @@ jobs:
           go-version: "1.26.x"
           cache: true
 
+      # The pgvector ROUND-TRIP contract (set + search + ordering + dimension
+      # handling + CASCADE) is opt-in behind LOOMCYCLE_TEST_PG_VECTOR, and it was
+      # never enabled here — so the whole vector suite, including the pre-existing
+      # dimension-mismatch test, skipped in CI even though the service image below
+      # is already pgvector/pgvector. A mixed-dimension search bug reached main
+      # because of that. The service image needs the extension CREATEd once; the
+      # per-test schemas keep `public` on their search_path so the unqualified
+      # `vector` type in migration 0017 resolves.
+      - name: Install psql client for the store job
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client
+      - name: Enable pgvector for the store contract
+        env:
+          PGPASSWORD: loomcycle
+        run: |
+          psql -h 127.0.0.1 -U loomcycle -d loomcycle_test -v ON_ERROR_STOP=1 \
+            -c "CREATE EXTENSION IF NOT EXISTS vector;"
+
       - name: Postgres store contract
         env:
           LOOMCYCLE_TEST_PG_DSN: postgres://loomcycle:loomcycle@127.0.0.1:5432/loomcycle_test?sslmode=disable
+          LOOMCYCLE_TEST_PG_VECTOR: "1"
         run: go test -count=1 ./internal/store/...
 
       # RFC AA SQL Memory postgres tier: provision a SEPARATE aux DB reached by a

--- a/internal/store/postgres/memory_embeddings.go
+++ b/internal/store/postgres/memory_embeddings.go
@@ -154,26 +154,47 @@ func (s *Store) MemoryEmbedSearch(ctx context.Context, tenantID string, scope st
 	// Dimension pre-check. Read one row's dimension under (scope,
 	// scope_id). If none exists, return empty results (the "empty
 	// scope" non-error path). If exists, compare against the query.
-	var storedDim int
+	// A scope may hold rows at MORE THAN ONE dimension — migration 0017 calls that
+	// the typical steady state ("migrating from text-embedding-3-small to large;
+	// not everything re-embedded yet") — so this asks two questions: does the scope
+	// have rows at all, and does it have any at the QUERY's dimension.
+	//
+	// Reading one arbitrary row's dimension (LIMIT 1, no ORDER BY) was wrong in both
+	// directions. If that row matched the query, the pre-check passed and the <=>
+	// operator then met a row of another dimension, so postgres aborted the whole
+	// statement with a raw `different vector dimensions 8 and 4` (SQLSTATE 22000) —
+	// recall entirely broken for the scope, surfaced as a driver error instead of
+	// the typed, actionable refusal. If it did not match, the search was refused
+	// even though searchable rows existed. Which happened depended on row order.
+	var total, atDim int
+	var otherDim *int
 	err := s.pool.QueryRow(ctx,
-		`SELECT dimension FROM memory_embeddings
-		 WHERE tenant_id = $1 AND scope = $2 AND scope_id = $3
-		 LIMIT 1`,
-		tenantID, string(scope), scopeID,
-	).Scan(&storedDim)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, nil
-	}
+		`SELECT count(*),
+		        count(*) FILTER (WHERE dimension = $4),
+		        min(dimension) FILTER (WHERE dimension <> $4)
+		   FROM memory_embeddings
+		  WHERE tenant_id = $1 AND scope = $2 AND scope_id = $3`,
+		tenantID, string(scope), scopeID, len(query),
+	).Scan(&total, &atDim, &otherDim)
 	if err != nil {
 		return nil, fmt.Errorf("MemoryEmbedSearch dim probe: %w", err)
 	}
-	if storedDim != len(query) {
+	if total == 0 {
+		return nil, nil
+	}
+	if atDim == 0 {
+		// Rows exist but NONE are searchable at this dimension. Returning empty
+		// would read as "this scope knows nothing" rather than "this scope needs
+		// re-embedding", so this stays the typed refusal.
+		other := 0
+		if otherDim != nil {
+			other = *otherDim
+		}
 		return nil, &store.MemoryError{
 			Code: store.ErrDimensionMismatch.Code,
-			Msg:  fmt.Sprintf("memory: query embedding dimension %d does not match stored rows' dimension %d — run /v1/_memory/reembed to migrate", len(query), storedDim),
+			Msg:  fmt.Sprintf("memory: query embedding dimension %d does not match stored rows' dimension %d — run /v1/_memory/reembed to migrate", len(query), other),
 		}
 	}
-
 	queryText := encodePgvector(query)
 
 	// Filter expired base rows in the WHERE via a JOIN. The base
@@ -181,9 +202,13 @@ func (s *Store) MemoryEmbedSearch(ctx context.Context, tenantID string, scope st
 	// CASCADE handles deletes but not TTL-expired-not-yet-swept.
 	// We JOIN + filter so stale rows don't leak into search results.
 	prefixCondition := ""
-	args := []any{tenantID, string(scope), scopeID, queryText, topK}
+	// Restricting to the query's dimension is what makes a mid-migration scope
+	// DEGRADE instead of failing: rows that can be compared are compared, and the
+	// rest are skipped rather than aborting the statement. Without it, ONE row at
+	// another dimension breaks recall for the whole scope.
+	args := []any{tenantID, string(scope), scopeID, queryText, topK, len(query)}
 	if keyPrefix != "" {
-		prefixCondition = " AND me.key LIKE $6"
+		prefixCondition = " AND me.key LIKE $7"
 		args = append(args, keyPrefix+"%")
 	}
 	sql := `SELECT me.key, m.value, m.expires_at, m.created_at, m.updated_at,
@@ -200,7 +225,8 @@ func (s *Store) MemoryEmbedSearch(ctx context.Context, tenantID string, scope st
 	           AND me.scope = $2
 	           AND me.scope_id = $3
 	           AND (m.expires_at IS NULL OR m.expires_at > now())
-	           AND m.superseded_at IS NULL` + prefixCondition + `
+	           AND m.superseded_at IS NULL
+			   AND me.dimension = $6` + prefixCondition + `
 	         ORDER BY me.embedding <=> $4::vector
 	         LIMIT $5`
 	rows, err := s.pool.Query(ctx, sql, args...)

--- a/internal/store/postgres/postgres_test.go
+++ b/internal/store/postgres/postgres_test.go
@@ -86,7 +86,12 @@ func freshSchemaWithVectors(t *testing.T, dsn string, pgvectorEnabled bool) fres
 	// Step 2: open the Store's own pool with search_path set so every
 	// subsequent statement (including migrations) targets the per-test
 	// schema. AutoMigrate=true so the schema gets the v0001 init.
-	storeDSN := appendOption(dsn, "search_path", schema)
+	// public is kept on the path AFTER the per-test schema so an extension
+	// installed database-wide (pgvector lives in public) resolves, while every
+	// table this suite creates still lands in — and is read from — the temp
+	// schema because it comes first. Without public the pgvector contract cannot
+	// run at all: migration 0017's `vector` column type is unqualified.
+	storeDSN := appendOption(dsn, "search_path", schema+",public")
 	s, err := Open(context.Background(), Config{
 		DSN:             storeDSN,
 		MaxOpenConns:    8,

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -185,6 +185,7 @@ func Run(t *testing.T, factory Factory) {
 		{"MemoryEmbedSearchTopK", testMemoryEmbedSearchTopK},
 		{"MemoryEmbedSearchScopeIsolation", testMemoryEmbedSearchScopeIsolation},
 		{"MemoryEmbedSearchDimensionMismatch", testMemoryEmbedSearchDimensionMismatch},
+		{"MemoryEmbedSearchMixedDimensions", testMemoryEmbedSearchMixedDimensions},
 		{"MemoryEmbedSearchEmptyScope", testMemoryEmbedSearchEmptyScope},
 		{"MemoryEmbedSearchReturnsVectors", testMemoryEmbedSearchReturnsVectors},
 		{"MemoryDeleteCascadesEmbedding", testMemoryDeleteCascadesEmbedding},
@@ -10879,5 +10880,64 @@ func testInterruptDeleteAllByUser(t *testing.T, s store.Store) {
 	// rather than an error an operator has to interpret.
 	if n, err := s.InterruptDeleteAllByUser(ctx, subject, "acme"); err != nil || n != 0 {
 		t.Errorf("second pass: n=%d err=%v, want 0/nil", n, err)
+	}
+}
+
+// testMemoryEmbedSearchMixedDimensions pins search behaviour in a scope holding
+// rows at MORE THAN ONE dimension — which migration 0017 calls the typical steady
+// state ("migrating from text-embedding-3-small to large; not everything
+// re-embedded yet").
+//
+// The dimension pre-check read ONE arbitrary row (LIMIT 1, no ORDER BY) and
+// compared it to the query, so this state was broken in both directions. If that
+// row matched, the check passed and the <=> operator then met a row of the other
+// dimension, aborting the whole statement with a raw `different vector dimensions
+// 8 and 4` (SQLSTATE 22000) — recall entirely dead for the scope, reported as a
+// driver error rather than the typed refusal. If it did not match, the search was
+// refused although searchable rows existed. Which one occurred depended on
+// physical row order, so the same call could succeed or fail run to run.
+func testMemoryEmbedSearchMixedDimensions(t *testing.T, s store.Store) {
+	if !vectorRefusalCheck(t, s) {
+		return
+	}
+	ctx := context.Background()
+	const sid = "mixdim"
+	seed := func(key string, dim int, vec []float32) {
+		t.Helper()
+		if err := s.MemorySet(ctx, "", store.MemoryScopeAgent, sid, key, json.RawMessage(`"v"`), 0); err != nil {
+			t.Fatalf("MemorySet %s: %v", key, err)
+		}
+		if err := s.MemoryEmbedSet(ctx, "", store.MemoryScopeAgent, sid, key, store.MemoryEmbedding{
+			Provider: "openai", Model: "m", Dimension: dim,
+			Vector: vec, EmbedText: key, CreatedAt: time.Now(),
+		}); err != nil {
+			t.Fatalf("MemoryEmbedSet %s (dim %d): %v", key, dim, err)
+		}
+	}
+	seed("small", 4, floats32(1, 0, 0, 0))
+	seed("large", 8, floats32(1, 0, 0, 0, 0, 0, 0, 0))
+
+	// A dim-4 query must return the dim-4 row and SKIP the dim-8 one, rather than
+	// failing the statement. Repeated because the old bug was order-dependent: one
+	// pass could pass by luck.
+	for i := 1; i <= 4; i++ {
+		res, err := s.MemoryEmbedSearch(ctx, "", store.MemoryScopeAgent, sid, "", floats32(1, 0, 0, 0), 10)
+		if err != nil {
+			t.Fatalf("attempt %d: mixed-dimension search failed instead of degrading: %v", i, err)
+		}
+		if len(res) != 1 {
+			t.Fatalf("attempt %d: got %d results, want 1 (only the dim-4 row is comparable)", i, len(res))
+		}
+		if res[0].Key != "small" {
+			t.Errorf("attempt %d: returned %q, want the dim-4 row", i, res[0].Key)
+		}
+	}
+
+	// And when NO row matches the query's dimension, the typed refusal still fires:
+	// returning empty would read as "this scope knows nothing" rather than "this
+	// scope needs re-embedding".
+	_, err := s.MemoryEmbedSearch(ctx, "", store.MemoryScopeAgent, sid, "", floats32(1, 0), 10)
+	if !errors.Is(err, store.ErrDimensionMismatch) {
+		t.Errorf("no-matching-dimension search: got %v, want ErrDimensionMismatch", err)
 	}
 }


### PR DESCRIPTION
Memory-review **pass 9**, over `store/postgres/memory_embeddings.go`. Two findings, and the second explains the first.

## 1 · Mixed-dimension search dies instead of degrading

`MemoryEmbedSearch`'s dimension pre-check read **one arbitrary row** (`LIMIT 1`, no `ORDER BY`) and compared it to the query. Migration 0017 documents a scope holding several dimensions as the *typical* steady state — *"migrating from text-embedding-3-small to large; not everything re-embedded yet"* — and there the check was wrong both ways:

- **sampled row matched** → check passed, then `<=>` met a row of another dimension and postgres aborted the statement: `different vector dimensions 8 and 4` (SQLSTATE 22000). Recall entirely dead for the scope, as a raw driver error rather than the typed refusal carrying the reembed hint.
- **sampled row didn't match** → the search was refused although searchable rows existed.

Which one happened depended on **physical row order**, so the same call could succeed or fail between runs.

Verified on real pgvector — six consecutive searches, before and after:

```
before:  attempt 1..6: rows=0 err=... different vector dimensions 8 and 4
after:   attempt 1..6: rows=1 err=<nil>
```

The search now filters `me.dimension = $6`, so comparable rows are compared and the rest skipped. The pre-check asks two questions instead of one — does the scope have rows, and any at the query's dimension — keeping the typed `ErrDimensionMismatch` for *"rows exist but none searchable"*, because empty there would read as "this scope knows nothing" rather than "this scope needs re-embedding".

## 2 · The pgvector contract never ran in CI

`TestStoreContractWithPgvector` is gated on `LOOMCYCLE_TEST_PG_VECTOR`, which **the workflow never set**. So the entire vector round-trip suite — including the *pre-existing* dimension-mismatch test — skipped on every run, even though the store job's service image is already `pgvector/pgvector:pg16`. The capability was paid for and not used.

It could not have run even with the flag: `freshSchema` pinned `search_path` to the per-test schema alone, and migration 0017's `vector` column type is unqualified, so the type didn't resolve. `public` is now kept on the path **after** the temp schema — extensions resolve, while every table the suite creates still lands in and is read from the temp schema because it comes first. CI gains the `CREATE EXTENSION` step and the flag.

## Tested

`testMemoryEmbedSearchMixedDimensions` in the shared contract: a dim-4 and a dim-8 row in one scope, asserting a dim-4 query returns exactly the dim-4 row across **four attempts** (repeated because the old bug was order-dependent — one pass could pass by luck), plus the typed refusal when nothing matches.

Verified against **real pgvector in a local `pgvector/pgvector:pg16` container**, not by reasoning. Full `TestStoreContractWithPgvector` passes (497s), and the fail-before reproduces `ERROR: different vector dimensions 8 and 4` verbatim.

⚠️ The first fail-before attempt removed only the WHERE clause and failed with `expected 5 arguments, got 6` — an argument-count error, not the bug. Removing the bound argument too was needed to reproduce the prior behaviour faithfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8