### PR TITLE
fix(eval): say when the baseline gate has silently expired

### DIFF
--- a/internal/cli/memory_eval_live.go
+++ b/internal/cli/memory_eval_live.go
@@ -174,6 +174,18 @@ func RunMemoryEvalLive(args []string, stdout, stderr io.Writer) int {
 	fails := eval.DefaultGate().Check(rep)
 	if base != nil {
 		fails = append(fails, base.Regressions(rep)...)
+		// Say when the baseline gate is NOT active for this configuration although
+		// it once was. A prompt or corpus change un-gates every measured
+		// model/effort at once, and Regressions is silent about it by design — so
+		// without this the run reports a clean pass with no comparison behind it.
+		if stale, had := base.StaleMatch(rep); had {
+			fmt.Fprintf(stderr,
+				"\nNOTE: no baseline for this exact configuration, so NOTHING was compared.\n"+
+					"      %s/%s effort=%q was measured on %s under a different prompt/corpus\n"+
+					"      (prompt %s… vs now %s…). Re-record with --update-baseline to gate it again.\n",
+				rep.Provider, rep.Model, rep.Effort, stale.MeasuredAt,
+				shortSHA(stale.SystemPromptSHA256), shortSHA(rep.SystemPromptSHA256))
+		}
 	}
 	if rep.HarnessFault != "" {
 		fmt.Fprintf(stderr, "\nHARNESS FAULT: %s\n", rep.HarnessFault)

--- a/internal/memory/eval/baseline_stale_test.go
+++ b/internal/memory/eval/baseline_stale_test.go
@@ -1,0 +1,114 @@
+package eval
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestBaseline_StaleMatchNamesAnExpiredGate covers the difference between two
+// states that EntryFor collapses into one silent "no baseline".
+//
+// EntryFor keys on provider+model+effort+prompt_sha+corpus_sha, and a run with no
+// exact match is deliberately NOT a regression — blocking an unmeasured model would
+// block every new candidate's first run. But that policy also hides the case where
+// a configuration WAS measured and its gate expired because the extractor prompt
+// changed: editing that prompt un-gates every model/effort at once, invisibly, and
+// the next run reports a clean pass with nothing behind it.
+//
+// This is not hypothetical. It is the state of the recorded baseline: effort=medium
+// was measured under one prompt, the prompt changed, and medium runs have been
+// ungated since — reported as neither a regression nor a gap.
+func TestBaseline_StaleMatchNamesAnExpiredGate(t *testing.T) {
+	b := Baseline{
+		RecallTolerance: 0.15,
+		Entries: []BaselineEntry{{
+			Provider: "ollama-local", Model: "m", Effort: "medium",
+			SystemPromptSHA256: "OLDPROMPT", CorpusSHA256: "CORPUS",
+			MeasuredAt: "2026-07-29T00:00:00Z",
+			Recall:     map[string]float64{"extraction": 1},
+			Violations: map[string]int{"extraction": 0},
+		}},
+	}
+	// Same configuration, NEW prompt: no exact match, so nothing is compared.
+	cur := ExtractionReport{
+		Provider: "ollama-local", Model: "m", Effort: "medium",
+		SystemPromptSHA256: "NEWPROMPT", CorpusSHA256: "CORPUS",
+		Abilities: []AbilityScore{{Ability: AbilityExtraction, Recall: 0.1, Violations: 9}},
+	}
+	if regs := b.Regressions(cur); len(regs) != 0 {
+		t.Fatalf("precondition: expected the gate to be silent, got %v", regs)
+	}
+	stale, had := b.StaleMatch(cur)
+	if !had {
+		t.Fatal("a configuration measured under a DIFFERENT prompt was not reported as " +
+			"stale, so an expired gate is indistinguishable from a never-measured one")
+	}
+	if stale.SystemPromptSHA256 != "OLDPROMPT" {
+		t.Errorf("stale entry = %q, want the previously-measured prompt", stale.SystemPromptSHA256)
+	}
+
+	// An EXACT match must not be called stale — that would cry wolf on every run.
+	exact := cur
+	exact.SystemPromptSHA256 = "OLDPROMPT"
+	if _, had := b.StaleMatch(exact); had {
+		t.Error("an exactly-matching configuration was reported stale")
+	}
+	// And a genuinely new model is not stale either: it was never measured, which
+	// is the case the no-block policy is FOR.
+	fresh := cur
+	fresh.Model = "never-seen"
+	if _, had := b.StaleMatch(fresh); had {
+		t.Error("an unmeasured model was reported as having an expired gate")
+	}
+}
+
+// TestBaseline_RecordedFileHasAnUngatedEffort documents the live state of the
+// checked-in baseline, so the gap is visible rather than folklore. It is
+// intentionally not a failure: re-recording is an operator decision that needs a
+// model run, not something a unit test can do.
+func TestBaseline_RecordedFileHasAnUngatedEffort(t *testing.T) {
+	b, err := LoadBaseline(filepath.Join("extraction-baseline.json"))
+	if err != nil {
+		t.Skipf("baseline not readable: %v", err)
+	}
+	if len(b.Entries) == 0 {
+		t.Skip("no baseline entries recorded")
+	}
+	newest := b.Entries[0]
+	for _, e := range b.Entries {
+		if e.MeasuredAt > newest.MeasuredAt {
+			newest = e
+		}
+	}
+	gated, measured := map[string]bool{}, map[string]bool{}
+	for _, e := range b.Entries {
+		measured[e.Effort] = true
+		if e.SystemPromptSHA256 == newest.SystemPromptSHA256 {
+			gated[e.Effort] = true
+		}
+	}
+	for eff := range measured {
+		if !gated[eff] {
+			t.Logf("effort=%q has a baseline but NOT under the newest prompt (%s…) — "+
+				"runs at that effort are currently ungated; re-record to restore it",
+				eff, shortSHAForTest(newest.SystemPromptSHA256))
+		}
+	}
+	t.Logf("efforts measured=%v gated-under-newest-prompt=%v", effortKeys(measured), effortKeys(gated))
+}
+
+func shortSHAForTest(s string) string {
+	if len(s) > 12 {
+		return s[:12]
+	}
+	return s
+}
+
+// effortKeys is local to this file; consolidation_test.go already has a keysOf.
+func effortKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/memory/eval/extraction.go
+++ b/internal/memory/eval/extraction.go
@@ -547,7 +547,19 @@ func ParseExtractorReply(raw string) ([]ExtractedFact, int, error) {
 
 // scoreCase fills in captures, misses and violations.
 func scoreCase(res *CaseResult, cs ExtractionCase, facts []ExtractedFact) {
-	// Positive expectations: each must be satisfied by a SINGLE fact.
+	// Positive expectations: each must be satisfied by a SINGLE fact — but ONE FACT
+	// MAY SATISFY SEVERAL EXPECTATIONS, and that is deliberate rather than an
+	// accounting slip.
+	//
+	// A Want is an assertion about content that must appear, not a demand for a
+	// separate row. The request-implies-condition fixtures depend on it: the desired
+	// output there is one durable fact carrying BOTH the medication and the symptom
+	// it caused, because connecting them is the ability under test. Scoring that as
+	// 1/2 would mark the correct answer a miss — extraction_test.go asserts exactly
+	// this ("a faithful phrasing must not be a miss").
+	//
+	// Recorded because it reads like double-counting on first inspection. A review
+	// pass changed this to one-fact-one-want and the fixtures immediately refuted it.
 	for _, w := range cs.Want {
 		if idx := matchExpected(w, facts); idx >= 0 {
 			res.Captured++

--- a/internal/memory/eval/extraction_baseline.go
+++ b/internal/memory/eval/extraction_baseline.go
@@ -102,6 +102,34 @@ func (b Baseline) EntryFor(r ExtractionReport) (BaselineEntry, bool) {
 	return BaselineEntry{}, false
 }
 
+// StaleMatch reports a baseline entry recorded for this SAME provider/model/effort
+// but under a different system prompt or corpus, when there is no exact match.
+//
+// EntryFor requires all five fields, and a run with no exact match is deliberately
+// not a regression — an unmeasured model must not be blocked. But that policy hides
+// a second, very different situation: a configuration that WAS measured and whose
+// gate silently expired because the extractor prompt changed. Editing that prompt
+// un-gates every model/effort combination at once, invisibly, and the next run
+// reports a clean pass because there is nothing to compare against.
+//
+// Observed in the recorded baseline: effort=medium was measured under prompt
+// 7104816985db9c7c, the prompt then changed to cf2736fd62c80291, and a medium run
+// has been ungated since — reported as neither a regression nor a gap.
+//
+// This does not block. It exists so the difference between "never measured" and
+// "no longer gated" is visible at the point the gate would have spoken.
+func (b Baseline) StaleMatch(r ExtractionReport) (BaselineEntry, bool) {
+	if _, exact := b.EntryFor(r); exact {
+		return BaselineEntry{}, false
+	}
+	for _, e := range b.Entries {
+		if e.Provider == r.Provider && e.Model == r.Model && e.Effort == r.Effort {
+			return e, true
+		}
+	}
+	return BaselineEntry{}, false
+}
+
 // Regressions reports every ability that got WORSE than the baseline, beyond
 // tolerance. A run with no matching baseline entry reports nothing: an unmeasured
 // model is not a regression, and pretending otherwise would block the first run


### PR DESCRIPTION
Memory-review **pass 10**, over `memory/eval/*` and the remaining bulk of `document.go` / `memory.go`. One real finding, one hypothesis of mine the tests refuted, and several negative results.

## The finding: a prompt change un-gates everything, invisibly

`EntryFor` keys a baseline on provider+model+effort+**prompt_sha**+corpus_sha, and `Regressions` returns nothing without an exact match. That policy is right — blocking an unmeasured model would block every new candidate's first run — but it collapses two very different states into one silence:

- **never measured** (correctly silent)
- **measured, then un-gated because the prompt changed**

The second is the live state of the checked-in baseline:

```
efforts measured                  : [low medium]
efforts gated under newest prompt : [low]
=> UNGATED: [medium]
```

`effort=medium` was measured under prompt `7104816985db9c7c`; the prompt then changed to `cf2736fd62c80291`, and medium runs have been ungated since — reported as neither a regression nor a gap, so the run looks like a clean pass with nothing behind it.

`Baseline.StaleMatch` now reports an entry for the same provider/model/effort under a different prompt/corpus, and `memory-eval-live` prints it as a NOTE. **It does not block** — re-recording needs a model run, which is an operator decision, not something a gate should force.

## What I got wrong

`scoreCase` lets **one fact satisfy several `Want` entries**. I read that as double-counting and changed it to one-fact-one-want. The existing fixtures immediately refuted it:

> `request-implies-condition`: *"The user is taking atorvastatin and experiences constant leg aches"* scored 1/2 — **"a faithful phrasing must not be a miss"**

A `Want` is an assertion about content that must appear, not a demand for a separate row — and connecting the medication to the symptom in *one* durable fact is the ability under test. Reverted, and the intent is now a comment so the next reader doesn't repeat it.

My reachability check had been wrong too: it compared only `AllOf` marker sets and reported zero co-satisfiable pairs across a corpus full of them via `AnyOf`.

## Reviewed and found sound

- `precisionAtK`'s `k` denominator (documented convention) and `recallAtK`, including `intersectionCount` deduplicating retrieved keys
- the baseline writer's four refusals (harness fault, no scores, incomplete run, any violation) and its **unconditional** write of zero violation counts — that is what keeps *"a new violation is always a regression"* true. Had zeros been omitted, the whole violation gate would have been dead, since the recorded baseline is all-zero. I chased this specifically and it holds.
- `Memory`'s `incr` plus the three compound read-modify-write ops (`merge` / `append_dedupe` / `bounded_list`) — all route through one atomic `MemoryAtomicUpdate` rather than read-then-write
- `query_chunks`' raw-SQL escape hatch: bypassing `under_path` is harmless because scope isolation is the **connection** (per-scope file, or per-scope schema + LOGIN role), not the query text
- `set_asset`'s size cap behind the request-body limit

## Tested

`TestBaseline_StaleMatchNamesAnExpiredGate` (expired gate reported; exact match not; unmeasured model not) and `TestBaseline_RecordedFileHasAnUngatedEffort`, which **logs** the live gap rather than failing on it. Fail-before on `StaleMatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8