### PR TITLE
feat(directory): report tenants and inspect a subject over MCP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,26 @@ jobs:
         env:
           LOOMCYCLE_TEST_PG_DSN: postgres://loomcycle:loomcycle@127.0.0.1:5432/loomcycle_test?sslmode=disable
           LOOMCYCLE_TEST_PG_VECTOR: "1"
-        run: go test -count=1 ./internal/store/...
+        # Explicit -timeout. This step had NONE, so it inherited Go's 600s default
+        # while the postgres contract already ran ~497s locally on an idle box —
+        # 83% of the budget, before pgvector was even enabled above. One added
+        # contract test pushed it past 600s, and the failure is maximally confusing:
+        # `FAIL ... 600.6s` with ZERO `--- FAIL` lines reads like a hung test rather
+        # than an exhausted deadline. Every case still passed given time.
+        #
+        # 1800s because this suite is inherently slow (a per-test schema, migrated
+        # from scratch, against a real database) and CI contention makes it slower
+        # still. A genuinely hung test fails, just later.
+        #
+        # A timeout here is also WORSE than a normal failure, which is the real
+        # argument for the headroom: the deadline kills tests mid-flight so their
+        # cleanups never drop their schemas, and the schema name is
+        # lct_<test-name-truncated-to-40>_<counter> where the counter restarts at 1
+        # in each process. So the next run against the same database regenerates the
+        # same names and dies on "schema already exists" — a timeout does not just
+        # fail, it poisons the database for the following run in a way that looks
+        # like an unrelated bug.
+        run: go test -count=1 -timeout 1800s ./internal/store/...
 
       # RFC AA SQL Memory postgres tier: provision a SEPARATE aux DB reached by a
       # NON-superuser CREATEROLE admin (exactly the production provisioning), so

--- a/internal/api/grpc/parity_test.go
+++ b/internal/api/grpc/parity_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/denn-gubsky/loomcycle/internal/api/grpc/loomcyclepb"
 	"github.com/denn-gubsky/loomcycle/internal/connector"
+	"github.com/denn-gubsky/loomcycle/internal/directory"
 	"github.com/denn-gubsky/loomcycle/internal/erasure"
 )
 
@@ -426,4 +427,16 @@ func (m *parityMock) ErasureReport(context.Context, string, string) (erasure.Rep
 
 func (m *parityMock) ErasureExecute(context.Context, erasure.ExecuteRequest) (erasure.Result, error) {
 	return erasure.Result{}, nil
+}
+
+func (m *parityMock) DirectoryUsers(context.Context, string) ([]directory.UserRow, error) {
+	return nil, nil
+}
+
+func (m *parityMock) DirectoryInspect(context.Context, string, string) (directory.Inspection, error) {
+	return directory.Inspection{}, nil
+}
+
+func (m *parityMock) DirectoryTenants(context.Context) ([]directory.TenantRow, error) {
+	return nil, nil
 }

--- a/internal/api/grpc/server_test.go
+++ b/internal/api/grpc/server_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/api/grpc/loomcyclepb"
 	"github.com/denn-gubsky/loomcycle/internal/cancel"
 	"github.com/denn-gubsky/loomcycle/internal/connector"
+	"github.com/denn-gubsky/loomcycle/internal/directory"
 	"github.com/denn-gubsky/loomcycle/internal/erasure"
 	"github.com/denn-gubsky/loomcycle/internal/hooks"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
@@ -1227,4 +1228,16 @@ func TestGrpc_ResolveProbe_UnavailableMapsToUnavailable(t *testing.T) {
 	if status.Code(err) != codes.Unavailable {
 		t.Errorf("status code = %v, want Unavailable", status.Code(err))
 	}
+}
+
+func (m *mockConnector) DirectoryUsers(context.Context, string) ([]directory.UserRow, error) {
+	return nil, nil
+}
+
+func (m *mockConnector) DirectoryInspect(context.Context, string, string) (directory.Inspection, error) {
+	return directory.Inspection{}, nil
+}
+
+func (m *mockConnector) DirectoryTenants(context.Context) ([]directory.TenantRow, error) {
+	return nil, nil
 }

--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -600,6 +600,17 @@ func requiredScopeFor(method, path string) string {
 	// The protection against an accidental erasure is NOT the scope (an admin
 	// token would be no less able to do it): it is dry_run defaulting true via a
 	// *bool, and confirm having to equal subject on a live run.
+	// The per-subject aggregate view. ScopeTenant like the /v1/_users list it drills
+	// into: everything it aggregates is already readable by this principal through
+	// /v1/_usage, /v1/_limits and the memory surfaces, so it saves five calls
+	// without granting new reach. principalTenantScope confines it.
+	case strings.HasPrefix(path, "/v1/_users/"):
+		return auth.ScopeTenant
+	// Tenant enumeration. ScopeAdmin, and the HANDLER re-checks: the counts are
+	// unremarkable but the LIST ITSELF is cross-tenant information, which is
+	// exactly what a tenant-confined principal must not learn.
+	case path == "/v1/_tenants":
+		return auth.ScopeAdmin
 	case path == "/v1/_erasure":
 		return auth.ScopeTenant
 	// RFC BM: the data-retention view. Tenant-readable so a tenant operator's UI

--- a/internal/api/http/directory.go
+++ b/internal/api/http/directory.go
@@ -1,0 +1,117 @@
+package http
+
+// directory.go — the HTTP face of the derived directory.
+//
+//	GET /v1/_users/{subject}   one subject's aggregate view (ScopeTenant)
+//	GET /v1/_tenants           tenants with derived counts (ADMIN ONLY)
+//
+// There is no create/update/delete here, deliberately. A "user" in loomcycle is
+// derived from runs.user_id — there is no row to write. The delete half of "user
+// CRUD" is the subject-erasure surface, which is the only thing that removes a
+// person's footprint coherently across four planes.
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/directory"
+)
+
+func (s *Server) directoryService() *directory.Service {
+	return &directory.Service{Store: s.store, SqlMem: s.sqlMem}
+}
+
+// handleInspectUser serves GET /v1/_users/{subject}.
+//
+// Gated ScopeTenant like the list it drills into: everything it aggregates is
+// already readable by this principal through /v1/_usage, /v1/_limits and the
+// memory surfaces. It saves five calls; it grants no new reach.
+func (s *Server) handleInspectUser(w http.ResponseWriter, r *http.Request) {
+	if s.store == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "store_unavailable",
+			"store not configured; the directory requires a persistent store")
+		return
+	}
+	subject := strings.TrimSpace(r.PathValue("subject"))
+	tenant, all := s.principalTenantScope(r.Context(), r.URL.Query().Get("tenant"))
+	// Same refusal as the erasure surface, for the same reason: a subject id is
+	// only unique within a tenant, so an admin who names none would be answered
+	// about the DEFAULT tenant's `alice` rather than told the question is ambiguous.
+	if all && !r.URL.Query().Has("tenant") {
+		writeJSONError(w, http.StatusBadRequest, "tenant_required",
+			"an admin token must name the tenant: a subject id is only unique within one. "+
+				"Pass ?tenant=<id>, or ?tenant= for the default tenant.")
+		return
+	}
+	ins, err := s.directoryService().Inspect(r.Context(), tenant, subject)
+	if errors.Is(err, directory.ErrNoSubject) {
+		writeJSONError(w, http.StatusBadRequest, "missing_subject", "subject is required")
+		return
+	}
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "inspect_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, ins)
+}
+
+// handleListTenants serves GET /v1/_tenants.
+//
+// ADMIN ONLY, and the check is here rather than left to the route table because
+// the reason is easy to lose: the counts are unremarkable, but THE LIST ITSELF is
+// the disclosure. Which tenants exist is precisely what a tenant-confined
+// principal must not learn — which is why every other cross-tenant read in this
+// codebase answers with an opaque not-found rather than a filtered list.
+func (s *Server) handleListTenants(w http.ResponseWriter, r *http.Request) {
+	if s.store == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "store_unavailable",
+			"store not configured; tenant listing requires a persistent store")
+		return
+	}
+	if p, ok := auth.PrincipalFromContext(r.Context()); ok && !auth.HasScope(p.Scopes, auth.ScopeAdmin) {
+		writeJSONError(w, http.StatusForbidden, "admin_required",
+			"listing tenants requires an operator-admin token: the list of tenants is itself "+
+				"cross-tenant information")
+		return
+	}
+	rows, err := s.directoryService().Tenants(r.Context())
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "list_tenants_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"tenants": rows,
+		"notes": []string{
+			"derived from runs, so a tenant that has never started a run does not appear — " +
+				"an empty list means no ACTIVITY, not no tenants.",
+		},
+	})
+}
+
+// DirectoryUsers implements connector.Connector.
+func (s *Server) DirectoryUsers(ctx context.Context, tenant string) ([]directory.UserRow, error) {
+	if s.store == nil {
+		return nil, errors.New("no store configured")
+	}
+	return s.directoryService().Users(ctx, tenant)
+}
+
+// DirectoryInspect implements connector.Connector.
+func (s *Server) DirectoryInspect(ctx context.Context, tenant, subject string) (directory.Inspection, error) {
+	if s.store == nil {
+		return directory.Inspection{}, errors.New("no store configured")
+	}
+	return s.directoryService().Inspect(ctx, tenant, subject)
+}
+
+// DirectoryTenants implements connector.Connector. The ADMIN check lives at each
+// transport, not here — this is the raw read.
+func (s *Server) DirectoryTenants(ctx context.Context) ([]directory.TenantRow, error) {
+	if s.store == nil {
+		return nil, errors.New("no store configured")
+	}
+	return s.directoryService().Tenants(ctx)
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2721,6 +2721,8 @@ func (s *Server) Mux() http.Handler {
 	// operator confirms its OWN tenant's ontology; the GET provisions the document
 	// on first reference so it can be authored before any run needs it. Authoring
 	// itself stays in the Path/Document browser. Scope-gated in requiredScopeFor.
+	mux.Handle("GET /v1/_tenants", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListTenants))))
+	mux.Handle("GET /v1/_users/{subject}", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleInspectUser))))
 	mux.Handle("GET /v1/_erasure", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleErasureReport))))
 	mux.Handle("POST /v1/_erasure", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleErasureExecute))))
 	mux.Handle("GET /v1/_ontology", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleOntology))))

--- a/internal/api/mcp/directory_authz_test.go
+++ b/internal/api/mcp/directory_authz_test.go
@@ -1,0 +1,90 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	loommcp "github.com/denn-gubsky/loomcycle/internal/tools/mcp"
+)
+
+// TestDirectory_TenantsIsRefusedForANonAdmin pins the one sub-op that is
+// cross-tenant.
+//
+// `directory` is classified tenant-confinable so its useful ops stay reachable —
+// the handler takes the tenant from the principal and offers no wire field, so
+// op=users and op=inspect physically cannot escape. But op=tenants IS cross-tenant
+// information, and it is REFUSED for a non-admin rather than filtered: an empty
+// list would be a lie, and a one-entry list would still confirm the caller's own
+// tenant in a shape they cannot distinguish from "you are the only tenant".
+func TestDirectory_TenantsIsRefusedForANonAdmin(t *testing.T) {
+	env := &handlerEnv{connector: &mockConnector{}, logf: func(string, ...any) {}}
+
+	tenantCtx := auth.WithPrincipal(context.Background(), auth.Principal{
+		TenantID: "acme", Subject: "op", Scopes: []string{auth.ScopeTenant},
+	})
+	res, err := handleDirectory(tenantCtx, env, json.RawMessage(`{"op":"tenants"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Fatal("a substrate:tenant principal enumerated tenants — the list itself is " +
+			"cross-tenant information")
+	}
+	txt := dirText(res)
+	if !strings.Contains(txt, "operator-admin") {
+		t.Errorf("the refusal does not say what is required: %s", txt)
+	}
+
+	// The confined ops stay reachable for that same principal — a refusal that took
+	// the whole tool with it would be the wrong fix.
+	for _, args := range []string{`{"op":"users"}`, `{"op":"inspect","subject":"alice"}`} {
+		res, err := handleDirectory(tenantCtx, env, json.RawMessage(args))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if res.IsError {
+			t.Errorf("%s was refused for a tenant principal: %s", args, dirText(res))
+		}
+	}
+
+	// An admin may enumerate.
+	adminCtx := auth.WithPrincipal(context.Background(), auth.Principal{
+		TenantID: "ops", Subject: "root", Scopes: []string{auth.ScopeAdmin},
+	})
+	res, err = handleDirectory(adminCtx, env, json.RawMessage(`{"op":"tenants"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Errorf("an admin was refused op=tenants: %s", dirText(res))
+	}
+}
+
+// TestDirectory_TenantComesFromThePrincipal — the handler must not accept a tenant
+// argument, because a subject id is only unique within one tenant.
+func TestDirectory_TenantComesFromThePrincipal(t *testing.T) {
+	mc := &mockConnector{}
+	env := &handlerEnv{connector: mc, logf: func(string, ...any) {}}
+	ctx := auth.WithPrincipal(context.Background(), auth.Principal{
+		TenantID: "acme", Subject: "op", Scopes: []string{auth.ScopeTenant},
+	})
+	// A wire tenant is passed and must be IGNORED, not honoured.
+	if _, err := handleDirectory(ctx, env,
+		json.RawMessage(`{"op":"inspect","subject":"alice","tenant":"globex"}`)); err != nil {
+		t.Fatal(err)
+	}
+	if got := mc.dirTenant.Load(); got != nil && got.(string) != "acme" {
+		t.Errorf("connector saw tenant %q — a wire field overrode the principal", got)
+	}
+}
+
+// dirText pulls the first content block's text from a tool result.
+func dirText(res *loommcp.CallToolResult) string {
+	if res == nil || len(res.Content) == 0 {
+		return ""
+	}
+	return res.Content[0].Text
+}

--- a/internal/api/mcp/handlers.go
+++ b/internal/api/mcp/handlers.go
@@ -45,6 +45,7 @@ var handlersByName = map[string]toolHandler{
 	"cancel_run":  handleCancelRun,
 	"get_run":     handleGetRun,
 	"compact_run": handleCompactRun,
+	"directory":   handleDirectory,
 	"erasure":     handleErasure,
 	"list_runs":   handleListRuns,
 
@@ -1101,5 +1102,76 @@ func handleErasure(ctx context.Context, env *handlerEnv, args json.RawMessage) (
 		return toolResultJSON(res), nil
 	default:
 		return toolErr(`erasure: unknown op "` + p.Op + `" (must be one of: report, execute)`), nil
+	}
+}
+
+// handleDirectory serves the `directory` tool: op=users | inspect | tenants.
+//
+// READ-ONLY, and there is no create/update/delete because there is nothing to
+// write: a "user" is derived from runs.user_id, not stored. Deleting a subject's
+// footprint is the `erasure` tool, which is the only thing that does it coherently
+// across four planes.
+//
+// THE TENANT COMES FROM THE PRINCIPAL, NEVER THE WIRE — a subject id is only
+// unique within one tenant, so a tenant argument would let a session inspect
+// someone else's. There is deliberately no such field.
+//
+// op=tenants is ADMIN-ONLY and refused here rather than filtered: the counts are
+// unremarkable, but the LIST is cross-tenant information. Returning an empty list
+// to a tenant principal would be a lie; returning a filtered one would still
+// confirm its own tenant's existence in a shape the caller can't distinguish.
+func handleDirectory(ctx context.Context, env *handlerEnv, args json.RawMessage) (*loommcp.CallToolResult, error) {
+	var p struct {
+		Op      string `json:"op"`
+		Subject string `json:"subject"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return toolErr("invalid directory arguments: " + err.Error()), nil
+	}
+	var tenant string
+	isAdmin := false
+	if pr, ok := auth.PrincipalFromContext(ctx); ok {
+		tenant = pr.TenantID
+		isAdmin = auth.HasScope(pr.Scopes, auth.ScopeAdmin)
+	} else {
+		// Open mode: no principal, so no confinement to enforce and nothing to
+		// withhold.
+		isAdmin = true
+	}
+
+	switch p.Op {
+	case "", "users":
+		rows, err := env.connector.DirectoryUsers(ctx, tenant)
+		if err != nil {
+			return toolErr("directory users: " + err.Error()), nil
+		}
+		return toolResultJSON(map[string]any{"tenant": tenant, "users": rows}), nil
+	case "inspect":
+		if p.Subject == "" {
+			return toolErr("directory: op=inspect requires a subject"), nil
+		}
+		ins, err := env.connector.DirectoryInspect(ctx, tenant, p.Subject)
+		if err != nil {
+			return toolErr("directory inspect: " + err.Error()), nil
+		}
+		return toolResultJSON(ins), nil
+	case "tenants":
+		if !isAdmin {
+			return toolErr("directory: op=tenants requires an operator-admin token — " +
+				"the list of tenants is itself cross-tenant information"), nil
+		}
+		rows, err := env.connector.DirectoryTenants(ctx)
+		if err != nil {
+			return toolErr("directory tenants: " + err.Error()), nil
+		}
+		return toolResultJSON(map[string]any{
+			"tenants": rows,
+			"notes": []string{
+				"derived from runs, so a tenant that has never started a run does not " +
+					"appear — an empty list means no ACTIVITY, not no tenants.",
+			},
+		}), nil
+	default:
+		return toolErr(`directory: unknown op "` + p.Op + `" (must be one of: users, inspect, tenants)`), nil
 	}
 }

--- a/internal/api/mcp/http_transport_test.go
+++ b/internal/api/mcp/http_transport_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/connector"
+	"github.com/denn-gubsky/loomcycle/internal/directory"
 	"github.com/denn-gubsky/loomcycle/internal/erasure"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/runner"
@@ -678,4 +679,16 @@ func (m *httpMockConnector) ErasureReport(context.Context, string, string) (eras
 
 func (m *httpMockConnector) ErasureExecute(context.Context, erasure.ExecuteRequest) (erasure.Result, error) {
 	return erasure.Result{}, nil
+}
+
+func (m *httpMockConnector) DirectoryUsers(context.Context, string) ([]directory.UserRow, error) {
+	return nil, nil
+}
+
+func (m *httpMockConnector) DirectoryInspect(context.Context, string, string) (directory.Inspection, error) {
+	return directory.Inspection{}, nil
+}
+
+func (m *httpMockConnector) DirectoryTenants(context.Context) ([]directory.TenantRow, error) {
+	return nil, nil
 }

--- a/internal/api/mcp/server_test.go
+++ b/internal/api/mcp/server_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/connector"
+	"github.com/denn-gubsky/loomcycle/internal/directory"
 	"github.com/denn-gubsky/loomcycle/internal/erasure"
 	"github.com/denn-gubsky/loomcycle/internal/hooks"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
@@ -28,6 +29,7 @@ import (
 // the ones explicitly exercised. Lets tests focus on what they care
 // about without faking unrelated surfaces.
 type mockConnector struct {
+	dirTenant      atomic.Value
 	erasureTenant  atomic.Value
 	erasureSubject atomic.Value
 	erasureDryRun  atomic.Value
@@ -434,8 +436,8 @@ func TestServer_ToolsList_ReturnsFullCatalogue(t *testing.T) {
 	if err := json.Unmarshal(resps[0].Result, &result); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if len(result.Tools) != 50 {
-		t.Errorf("got %d tools, want 50 (+erasure on top of the history/teamdef/credentialdef/path/document/volumedef list)", len(result.Tools))
+	if len(result.Tools) != 51 {
+		t.Errorf("got %d tools, want 51 (+directory on top of the erasure/history/teamdef/credentialdef/path/document/volumedef list)", len(result.Tools))
 	}
 	names := map[string]bool{}
 	for _, td := range result.Tools {
@@ -1713,4 +1715,18 @@ func TestServer_SpawnRunNoTimeoutByDefault(t *testing.T) {
 	if got.Status != "completed" {
 		t.Fatalf("spawn_run status = %q; want \"completed\" (no timeout by default)", got.Status)
 	}
+}
+
+func (m *mockConnector) DirectoryUsers(_ context.Context, tenant string) ([]directory.UserRow, error) {
+	m.dirTenant.Store(tenant)
+	return nil, nil
+}
+
+func (m *mockConnector) DirectoryInspect(_ context.Context, tenant, _ string) (directory.Inspection, error) {
+	m.dirTenant.Store(tenant)
+	return directory.Inspection{}, nil
+}
+
+func (m *mockConnector) DirectoryTenants(context.Context) ([]directory.TenantRow, error) {
+	return nil, nil
 }

--- a/internal/api/mcp/toolauthz.go
+++ b/internal/api/mcp/toolauthz.go
@@ -29,6 +29,13 @@ const mcpErrForbidden = -32001
 // authz that keeps it confined: a tenant session lists + may call only these
 // tools; the admin-only ones are filtered out + 403'd by principalMayCallTool.
 var tenantConfinableTools = map[string]bool{
+	// directory: a read-only derived view of who is in the caller's OWN tenant.
+	// Tenant-confinable because the handler takes the tenant from the PRINCIPAL and
+	// offers no wire field, so a tenant session cannot inspect another tenant's
+	// subject. Its op=tenants sub-op is separately refused for a non-admin inside
+	// the handler — that one op IS cross-tenant, and the tool is listed here rather
+	// than in adminOnlyTools so the useful ops stay reachable.
+	"directory": true,
 	// erasure: a data-subject report/erasure confined to the caller's own tenant.
 	// Tenant-confinable rather than admin-only because the handler takes the
 	// tenant from the PRINCIPAL and offers no wire field for it, so a tenant

--- a/internal/api/mcp/tools.go
+++ b/internal/api/mcp/tools.go
@@ -122,6 +122,27 @@ func toolDescriptors() []loommcp.ToolDescriptor {
 			}`),
 		},
 		{
+			Name: "directory",
+			Description: "Who is in this deployment, and what is held for them. READ-ONLY. " +
+				"op=users (default) lists the subjects with activity in your tenant; " +
+				"op=inspect with a subject aggregates that one subject's activity, chats, memory rows, " +
+				"documents, token budget and usage in a single call. " +
+				"op=tenants enumerates tenants with counts and requires an operator-admin token. " +
+				"There is no create/update/delete: a user is DERIVED from run activity, not a stored " +
+				"record, so there is nothing to write — to remove a subject's footprint use the " +
+				"`erasure` tool, which is the only thing that does it across every plane. " +
+				"Tenant listings are derived from runs, so a tenant with no runs does not appear " +
+				"(an empty list means no ACTIVITY, not no tenants). " +
+				"The tenant is taken from your credentials and cannot be passed.",
+			InputSchema: rawJSON(`{
+				"type": "object",
+				"properties": {
+					"op":      {"type": "string", "enum": ["users", "inspect", "tenants"], "description": "users (default) | inspect | tenants (admin only)."},
+					"subject": {"type": "string", "description": "inspect only: the user id to aggregate."}
+				}
+			}`),
+		},
+		{
 			Name: "erasure",
 			Description: "Report or erase everything this deployment holds about one SUBJECT (a user id), " +
 				"scoped to your own tenant. op=report (default) is read-only and returns three tiers: " +

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -30,6 +30,7 @@ package connector
 import (
 	"context"
 	"encoding/json"
+	"github.com/denn-gubsky/loomcycle/internal/directory"
 	"github.com/denn-gubsky/loomcycle/internal/erasure"
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
@@ -77,6 +78,21 @@ type Connector interface {
 	// live run must be parked; a mid-turn run is refused. Cross-tenant is an
 	// opaque not-found.
 	CompactRun(ctx context.Context, runID string) (CompactResult, error)
+
+	// DirectoryUsers lists the subjects with activity in one tenant, and
+	// DirectoryInspect aggregates what one subject has across activity, chats,
+	// memory, documents, budget and usage. Both are READ-ONLY and derived — a
+	// "user" is a GROUP BY over runs.user_id, not a stored row, so there is no
+	// create or update. Deleting a subject's footprint is ErasureExecute.
+	//
+	// tenant is authoritative and already resolved by the transport.
+	DirectoryUsers(ctx context.Context, tenant string) ([]directory.UserRow, error)
+	DirectoryInspect(ctx context.Context, tenant, subject string) (directory.Inspection, error)
+
+	// DirectoryTenants enumerates tenants with derived counts. ADMIN ONLY at every
+	// transport: the counts are unremarkable, but the LIST is cross-tenant
+	// information a confined principal must not learn.
+	DirectoryTenants(ctx context.Context) ([]directory.TenantRow, error)
 
 	// ErasureReport enumerates what this deployment holds about one subject, in
 	// three tiers separated by what they GUARANTEE — deletable / subject-keyed

--- a/internal/directory/directory.go
+++ b/internal/directory/directory.go
@@ -1,0 +1,242 @@
+package directory
+
+// Package directory answers "who is in this deployment, and what do we hold for
+// them" — without inventing a users table.
+//
+// A "user" in loomcycle is DERIVED, not stored: ListUsers is a GROUP BY over
+// runs.user_id. That is deliberate and this package keeps it that way. There is no
+// row to create and none to delete, so there is no create/update here; the delete
+// half of "user CRUD" already exists as the subject-erasure surface, which is the
+// only thing that can remove a person's footprint coherently across four planes.
+//
+// What was missing is the READ: an operator could see that `alice` has 12 runs, but
+// answering "what does alice actually have here" meant five separate calls against
+// five surfaces, each with its own tenant-scoping rule. Inspect is that one call.
+//
+// Extracted as a service rather than written into a handler for the same reason
+// erasure was: MCP and HTTP must not drift on a tenant-scoping decision. Tenant
+// arrives ALREADY RESOLVED from the caller's principal — this package never guesses
+// it, because a subject id is only unique within one tenant.
+
+import (
+	"context"
+	"errors"
+	"sort"
+
+	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// ErrNoSubject is returned when no subject was named. A sentinel so each transport
+// maps it to its own status code without string-matching.
+var ErrNoSubject = errors.New("subject is required")
+
+// Service reads the derived directory. SqlMem may be nil; the document counts are
+// then reported as unexamined rather than zero.
+type Service struct {
+	Store  store.Store
+	SqlMem *sqlmem.Manager
+}
+
+// UserRow is one derived user: activity only, which is all runs.user_id supports.
+type UserRow struct {
+	Subject       string `json:"subject"`
+	RunningCount  int    `json:"running_count"`
+	TotalCount    int    `json:"total_count"`
+	LastStartedAt string `json:"last_started_at,omitempty"`
+}
+
+// Inspection is the aggregate per-subject view — the five surfaces an operator
+// previously had to visit separately.
+type Inspection struct {
+	Tenant  string `json:"tenant"`
+	Subject string `json:"subject"`
+
+	Activity  UserRow          `json:"activity"`
+	Chats     int              `json:"chats"`
+	Memory    map[string]int64 `json:"memory"`
+	Documents *int             `json:"documents,omitempty"`
+	Budget    *BudgetView      `json:"budget,omitempty"`
+	Usage     UsageView        `json:"usage"`
+
+	// Errors names planes that could not be read. A plane that FAILED is not a
+	// plane that is empty, and an operational view that cannot tell them apart
+	// invites the wrong conclusion — the same reason the erasure report carries
+	// this field.
+	Errors []string `json:"errors,omitempty"`
+	Notes  []string `json:"notes,omitempty"`
+}
+
+// BudgetView carries POINTERS because nil and zero mean different things here:
+// nil is "no ceiling at this tier", zero would be a ceiling that refuses everything.
+type BudgetView struct {
+	SoftLimit *int64 `json:"soft_limit,omitempty"`
+	HardLimit *int64 `json:"hard_limit,omitempty"`
+}
+
+type UsageView struct {
+	Calls int64   `json:"calls"`
+	Cost  float64 `json:"cost"`
+}
+
+// TenantRow is one tenant with derived counts.
+type TenantRow struct {
+	Tenant string `json:"tenant"`
+	Users  int    `json:"users"`
+	Runs   int    `json:"runs"`
+}
+
+// Users lists the subjects with activity in one tenant.
+func (s *Service) Users(ctx context.Context, tenant string) ([]UserRow, error) {
+	rows, err := s.Store.ListUsers(ctx, tenant)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]UserRow, 0, len(rows))
+	for _, u := range rows {
+		r := UserRow{Subject: u.UserID, RunningCount: u.RunningCount, TotalCount: u.TotalCount}
+		if !u.LastStartedAt.IsZero() {
+			r.LastStartedAt = u.LastStartedAt.UTC().Format("2006-01-02T15:04:05Z")
+		}
+		out = append(out, r)
+	}
+	return out, nil
+}
+
+// Tenants enumerates tenants with derived per-tenant counts.
+//
+// Admin-only at every transport, and not because the counts are secret: the LIST
+// ITSELF is the disclosure. Knowing which tenants exist is exactly what a
+// tenant-confined principal must not learn, and it is the reason every other
+// cross-tenant read in this codebase is opaque-404 rather than filtered.
+//
+// Derived from runs, so a tenant that has never run anything does not appear. That
+// is stated in the notes rather than papered over — an empty result means "no
+// activity", not "no tenants".
+func (s *Service) Tenants(ctx context.Context) ([]TenantRow, error) {
+	rows, err := s.Store.ListTenants(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]TenantRow, 0, len(rows))
+	for _, t := range rows {
+		out = append(out, TenantRow{Tenant: t.TenantID, Users: t.UserCount, Runs: t.TotalCount})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Tenant < out[j].Tenant })
+	return out, nil
+}
+
+// Inspect aggregates what one subject has in one tenant.
+//
+// Every read is best-effort so a single broken plane does not deny the whole view,
+// but each fault is NAMED — an all-zero inspection assembled from failed queries
+// would read as "this user has nothing", which is the one answer this must never
+// give silently.
+func (s *Service) Inspect(ctx context.Context, tenant, subject string) (Inspection, error) {
+	if subject == "" {
+		return Inspection{}, ErrNoSubject
+	}
+	ins := Inspection{Tenant: tenant, Subject: subject, Memory: map[string]int64{}}
+	fail := func(plane string, err error) { ins.Errors = append(ins.Errors, plane+": "+err.Error()) }
+
+	if rows, err := s.Users(ctx, tenant); err != nil {
+		fail("activity", err)
+	} else {
+		for _, r := range rows {
+			if r.Subject == subject {
+				ins.Activity = r
+				break
+			}
+		}
+	}
+
+	// ListSessions returns the total as its second value, so one page of size 1 is
+	// enough for a count — no need to walk pages.
+	if _, total, err := s.Store.ListSessions(ctx,
+		store.SessionFilter{TenantID: tenant, UserID: subject}, 1, 0); err != nil {
+		fail("chats", err)
+	} else {
+		ins.Chats = int(total)
+	}
+
+	// Memory is reported PER SCOPE rather than as one number: a subject's own
+	// user-scope rows and the facts a shared agent holds about them are different
+	// things, and collapsing them hides exactly the distinction the erasure
+	// surface exists to make.
+	if entries, _, err := s.Store.MemoryList(ctx, tenant, store.MemoryScopeUser, subject, "", 0); err != nil {
+		fail("memory", err)
+	} else {
+		ins.Memory["user_scope_rows"] = int64(len(entries))
+	}
+
+	if s.SqlMem != nil {
+		if scopes, err := s.SqlMem.ListScopes(ctx); err != nil {
+			fail("documents", err)
+		} else {
+			n := 0
+			want := sqlScopeTenant(tenant)
+			for _, sk := range scopes {
+				// Tenant-compared, because ListScopes spans every tenant — the same
+				// trap that produced a cross-tenant oracle in the erasure report.
+				if sk.Tenant == want && sk.Scope == "user" && sk.ScopeID == subject {
+					n++
+				}
+			}
+			ins.Documents = &n
+		}
+	} else {
+		ins.Notes = append(ins.Notes,
+			"SQL Memory is not configured, so the document plane was NOT examined — its "+
+				"absence here is not evidence that it is empty.")
+	}
+
+	if limits, err := s.Store.TokenLimitsAll(ctx); err != nil {
+		fail("budget", err)
+	} else {
+		for _, l := range limits {
+			if l.TenantID == tenant && l.Scope == "user" && l.ScopeID == subject {
+				// Both are *int64: nil means "no ceiling at this tier", which is
+				// different from zero (a zero hard limit would refuse every run).
+				b := BudgetView{}
+				if l.SoftLimit != nil {
+					b.SoftLimit = l.SoftLimit
+				}
+				if l.HardLimit != nil {
+					b.HardLimit = l.HardLimit
+				}
+				ins.Budget = &b
+				break
+			}
+		}
+	}
+
+	if agg, err := s.Store.UsageReport(ctx, store.UsageQuery{
+		TenantID: tenant, GroupBy: []store.UsageDimension{store.UsageByUser},
+	}); err != nil {
+		fail("usage", err)
+	} else {
+		for _, a := range agg {
+			if a.UserID == subject {
+				ins.Usage.Calls += a.CallCount
+				ins.Usage.Cost += a.Cost
+			}
+		}
+	}
+
+	if len(ins.Errors) > 0 {
+		ins.Notes = append(ins.Notes,
+			"one or more planes could not be read (see errors) — every count here is a LOWER BOUND.")
+	}
+	return ins, nil
+}
+
+// sqlScopeTenant maps the raw principal tenant onto SQL Memory's spelling: it
+// refuses an empty tenant and stores the default one as "default", while the k/v
+// plane keeps the raw "". Same rule as builtin.sqlScopeTenant and the erasure
+// service — getting it wrong here would count another tenant's documents.
+func sqlScopeTenant(tenant string) string {
+	if tenant != "" {
+		return tenant
+	}
+	return "default"
+}

--- a/internal/directory/directory_test.go
+++ b/internal/directory/directory_test.go
@@ -1,0 +1,158 @@
+package directory_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/directory"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+)
+
+func newSvc(t *testing.T) *directory.Service {
+	t.Helper()
+	st, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return &directory.Service{Store: st}
+}
+
+// seed creates a run (and its session) for one subject in one tenant.
+func seed(t *testing.T, s *directory.Service, tenant, subject string) {
+	t.Helper()
+	ctx := context.Background()
+	sess, err := s.Store.CreateSession(ctx, tenant, "chat", subject)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if _, err := s.Store.CreateRun(ctx, sess.ID, store.RunIdentity{
+		AgentID: "a_dir", UserID: subject, TenantID: tenant,
+	}); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+}
+
+// TestInspect_IsConfinedToTheGivenTenant is the property the whole service exists
+// to get right once instead of five times.
+//
+// Inspect aggregates five surfaces, each with its own tenant-scoping rule. Before
+// this, an operator answering "what does alice have" made five calls and had to get
+// the scoping right in all five. The failure mode of getting one wrong is not an
+// error — it is a plausible number from the wrong tenant.
+func TestInspect_IsConfinedToTheGivenTenant(t *testing.T) {
+	s := newSvc(t)
+	ctx := context.Background()
+	const subject = "alice"
+	// The same subject id exists in BOTH tenants, which is legal: a subject is only
+	// unique within a tenant.
+	seed(t, s, "acme", subject)
+	seed(t, s, "globex", subject)
+	seed(t, s, "globex", subject)
+
+	// And a memory row that belongs only to globex's alice.
+	v, _ := json.Marshal("globex-only")
+	if err := s.Store.MemorySet(ctx, "globex", store.MemoryScopeUser, subject, "memory/fact/x", v, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	acme, err := s.Inspect(ctx, "acme", subject)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(acme.Errors) > 0 {
+		t.Fatalf("planes faulted: %v", acme.Errors)
+	}
+	if acme.Activity.TotalCount != 1 {
+		t.Errorf("acme activity total = %d, want 1 — globex's runs leaked in",
+			acme.Activity.TotalCount)
+	}
+	if acme.Chats != 1 {
+		t.Errorf("acme chats = %d, want 1", acme.Chats)
+	}
+	if got := acme.Memory["user_scope_rows"]; got != 0 {
+		t.Errorf("acme memory rows = %d, want 0 — the row belongs to globex's alice", got)
+	}
+
+	globex, err := s.Inspect(ctx, "globex", subject)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if globex.Activity.TotalCount != 2 || globex.Chats != 2 {
+		t.Errorf("globex = %d runs / %d chats, want 2/2", globex.Activity.TotalCount, globex.Chats)
+	}
+	if got := globex.Memory["user_scope_rows"]; got != 1 {
+		t.Errorf("globex memory rows = %d, want 1", got)
+	}
+}
+
+// TestInspect_RequiresASubject — an empty subject must be refused, not answered
+// with a zero-filled view that reads as "this person has nothing".
+func TestInspect_RequiresASubject(t *testing.T) {
+	s := newSvc(t)
+	if _, err := s.Inspect(context.Background(), "acme", ""); err != directory.ErrNoSubject {
+		t.Fatalf("err = %v, want ErrNoSubject", err)
+	}
+}
+
+// TestInspect_UnexaminedDocumentPlaneIsDeclared — with SqlMem nil the document
+// plane is NOT examined, and saying nothing would be indistinguishable from
+// "examined, found none". Same rule the erasure report follows.
+func TestInspect_UnexaminedDocumentPlaneIsDeclared(t *testing.T) {
+	s := newSvc(t) // SqlMem is nil
+	seed(t, s, "acme", "alice")
+	ins, err := s.Inspect(context.Background(), "acme", "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ins.Documents != nil {
+		t.Errorf("documents reported as %v with no SQL Memory configured", *ins.Documents)
+	}
+	var declared bool
+	for _, n := range ins.Notes {
+		if len(n) > 0 && contains(n, "NOT examined") {
+			declared = true
+		}
+	}
+	if !declared {
+		t.Errorf("the unexamined document plane was not declared, so its absence reads "+
+			"as zero; notes: %v", ins.Notes)
+	}
+}
+
+// TestTenants_CountsDistinctSubjects — the tenant list is derived, so its user
+// count must be distinct SUBJECTS rather than run rows, and a tenant with no runs
+// must be absent rather than reported empty.
+func TestTenants_CountsDistinctSubjects(t *testing.T) {
+	s := newSvc(t)
+	seed(t, s, "acme", "u_a")
+	seed(t, s, "acme", "u_a")
+	seed(t, s, "acme", "u_b")
+	seed(t, s, "globex", "u_c")
+
+	rows, err := s.Tenants(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]directory.TenantRow{}
+	for _, r := range rows {
+		got[r.Tenant] = r
+	}
+	if a := got["acme"]; a.Users != 2 || a.Runs != 3 {
+		t.Errorf("acme = %d users / %d runs, want 2/3 (distinct subjects, all runs)", a.Users, a.Runs)
+	}
+	if _, present := got["never_ran"]; present {
+		t.Error("a tenant with no runs appeared — the list is derived from runs")
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -8124,3 +8124,38 @@ func (s *Store) InterruptDeleteAllByUser(ctx context.Context, userID, tenantID s
 	}
 	return int(tag.RowsAffected()), nil
 }
+
+// ListTenants enumerates tenants with derived activity counts. See the Store
+// interface for why there is no tenants table and why this is admin-only; see the
+// sqlite twin for the COUNT(DISTINCT …) shape.
+func (s *Store) ListTenants(ctx context.Context) ([]store.TenantSummary, error) {
+	const q = `
+		SELECT
+			tenant_id,
+			COUNT(DISTINCT CASE WHEN user_id IS NOT NULL AND user_id <> '' THEN user_id END) AS user_count,
+			COUNT(CASE WHEN status = 'running' THEN 1 END) AS running_count,
+			COUNT(*) AS total_count,
+			MAX(started_at) AS last_started_at
+		FROM runs
+		GROUP BY tenant_id
+		ORDER BY last_started_at DESC NULLS LAST
+		LIMIT 500`
+	rows, err := s.pool.Query(ctx, q)
+	if err != nil {
+		return nil, fmt.Errorf("list tenants: %w", err)
+	}
+	defer rows.Close()
+	out := []store.TenantSummary{}
+	for rows.Next() {
+		var t store.TenantSummary
+		var last *time.Time
+		if err := rows.Scan(&t.TenantID, &t.UserCount, &t.RunningCount, &t.TotalCount, &last); err != nil {
+			return nil, fmt.Errorf("list tenants scan: %w", err)
+		}
+		if last != nil {
+			t.LastStartedAt = *last
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -9386,3 +9386,41 @@ func (s *Store) InterruptDeleteAllByUser(ctx context.Context, userID, tenantID s
 	}
 	return int(n), nil
 }
+
+// ListTenants enumerates tenants with derived activity counts. See the Store
+// interface for why there is no tenants table and why this is admin-only.
+func (s *Store) ListTenants(ctx context.Context) ([]store.TenantSummary, error) {
+	// COUNT(DISTINCT user_id) for the user tally: a tenant's user count is how many
+	// distinct subjects ran there, not how many rows exist.
+	const q = `
+		SELECT
+			tenant_id,
+			COUNT(DISTINCT CASE WHEN user_id IS NOT NULL AND user_id != '' THEN user_id END) AS user_count,
+			COUNT(CASE WHEN status = 'running' THEN 1 END) AS running_count,
+			COUNT(*) AS total_count,
+			MAX(started_at) AS last_started_at
+		FROM runs
+		GROUP BY tenant_id
+		ORDER BY last_started_at DESC
+		LIMIT 500`
+	rows, err := s.db.QueryContext(ctx, q)
+	if err != nil {
+		return nil, fmt.Errorf("list tenants: %w", err)
+	}
+	defer rows.Close()
+	out := []store.TenantSummary{}
+	for rows.Next() {
+		var t store.TenantSummary
+		// started_at is stored as unix NANOS on this tier, so MAX() comes back as an
+		// int64 — scanning it as a time fails. Same shape as ListUsers.
+		var lastNanos int64
+		if err := rows.Scan(&t.TenantID, &t.UserCount, &t.RunningCount, &t.TotalCount, &lastNanos); err != nil {
+			return nil, fmt.Errorf("list tenants scan: %w", err)
+		}
+		if lastNanos != 0 {
+			t.LastStartedAt = time.Unix(0, lastNanos).UTC()
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -966,6 +966,15 @@ type UserSummary struct {
 	LastStartedAt time.Time `json:"last_started_at"`
 }
 
+// TenantSummary is one tenant's derived activity, from ListTenants.
+type TenantSummary struct {
+	TenantID      string    `json:"tenant_id"`
+	UserCount     int       `json:"user_count"`
+	RunningCount  int       `json:"running_count"`
+	TotalCount    int       `json:"total_count"`
+	LastStartedAt time.Time `json:"last_started_at"`
+}
+
 // Store is the persistence backend. SQLite is the default; Postgres / Redis
 // adapters slot in behind this interface in v0.4.
 //
@@ -1275,6 +1284,20 @@ type Store interface {
 	// workspace + the super-admin tenant-focus), filtering on the
 	// denormalised runs.tenant_id; "" returns all tenants.
 	ListUsers(ctx context.Context, tenantID string) ([]UserSummary, error)
+
+	// ListTenants enumerates tenants that have RUN something, with derived
+	// per-tenant counts. A GROUP BY over runs.tenant_id, mirroring ListUsers —
+	// there is no tenants table, and this deliberately does not create one.
+	//
+	// Consequence stated rather than hidden: a tenant that exists (has a minted
+	// token, or defs) but has never started a run does NOT appear. An empty result
+	// means "no activity", not "no tenants".
+	//
+	// ADMIN-ONLY at every transport. Not because the counts are sensitive but
+	// because the LIST ITSELF is: which tenants exist is precisely what a
+	// tenant-confined principal must not learn, which is why every other
+	// cross-tenant read here is an opaque not-found rather than a filtered list.
+	ListTenants(ctx context.Context) ([]TenantSummary, error)
 
 	// UpdateHeartbeat sets last_heartbeat_at on a run to the current
 	// time. Called by the loop at each iteration. No-op if the run

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -150,6 +150,7 @@ func Run(t *testing.T, factory Factory) {
 		{"MemoryListTenantsForScope", testMemoryListTenantsForScope},
 		{"MemoryListBySourceSessions", testMemoryListBySourceSessions},
 		{"InterruptDeleteAllByUser", testInterruptDeleteAllByUser},
+		{"ListTenants", testListTenants},
 		// RFC BL P2: the background-consolidation substrate.
 		{"MemorySupersedeHidesFromReads", testMemorySupersedeHidesFromReads},
 		{"MemorySupersedeIsIdempotent", testMemorySupersedeIsIdempotent},
@@ -10939,5 +10940,58 @@ func testMemoryEmbedSearchMixedDimensions(t *testing.T, s store.Store) {
 	_, err := s.MemoryEmbedSearch(ctx, "", store.MemoryScopeAgent, sid, "", floats32(1, 0), 10)
 	if !errors.Is(err, store.ErrDimensionMismatch) {
 		t.Errorf("no-matching-dimension search: got %v, want ErrDimensionMismatch", err)
+	}
+}
+
+// testListTenants pins the derived tenant enumeration.
+//
+// There is no tenants table — this is a GROUP BY over runs.tenant_id — so the
+// contract is about what DERIVATION means: a tenant appears once it has run
+// something, its user count is DISTINCT subjects rather than rows, and a tenant
+// with no activity is absent (an empty result means no activity, not no tenants).
+func testListTenants(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	mk := func(tenant, user string) {
+		t.Helper()
+		sess, err := s.CreateSession(ctx, tenant, "chat", user)
+		if err != nil {
+			t.Fatalf("CreateSession %s/%s: %v", tenant, user, err)
+		}
+		if _, err := s.CreateRun(ctx, sess.ID, store.RunIdentity{
+			AgentID: "a_tn", UserID: user, TenantID: tenant,
+		}); err != nil {
+			t.Fatalf("CreateRun %s/%s: %v", tenant, user, err)
+		}
+	}
+	// acme: two runs for ONE subject + one for another => 2 distinct users, 3 runs.
+	mk("tn_acme", "u_a")
+	mk("tn_acme", "u_a")
+	mk("tn_acme", "u_b")
+	mk("tn_globex", "u_c")
+
+	rows, err := s.ListTenants(ctx)
+	if err != nil {
+		t.Fatalf("ListTenants: %v", err)
+	}
+	got := map[string]store.TenantSummary{}
+	for _, r := range rows {
+		got[r.TenantID] = r
+	}
+	acme, ok := got["tn_acme"]
+	if !ok {
+		t.Fatalf("tn_acme absent from %d tenant(s): %+v", len(rows), rows)
+	}
+	if acme.UserCount != 2 {
+		t.Errorf("tn_acme user_count = %d, want 2 — DISTINCT subjects, not run rows", acme.UserCount)
+	}
+	if acme.TotalCount != 3 {
+		t.Errorf("tn_acme total_count = %d, want 3", acme.TotalCount)
+	}
+	if g, ok := got["tn_globex"]; !ok || g.UserCount != 1 {
+		t.Errorf("tn_globex = %+v, want 1 user", g)
+	}
+	// A tenant with no runs must NOT appear — the enumeration is derived.
+	if _, present := got["tn_never_ran"]; present {
+		t.Error("a tenant with no runs appeared; the list is derived from runs")
 	}
 }


### PR DESCRIPTION
Adds a `directory` MCP tool — `op=users`, `op=inspect`, `op=tenants`. Read-only and **derived**: no new table, no migration.

## Why there's no create or update

A "user" in loomcycle isn't stored — `ListUsers` is a `GROUP BY` over `runs.user_id`. There's no row to write, so "user CRUD" has no create/update half, and the delete half already exists as the **subject-erasure** surface, the only thing that removes a footprint coherently across four planes. This keeps that model rather than inventing a users table to match the shape of the request.

## What was actually missing: the read

An operator could see *alice has 12 runs*, but answering **"what does alice actually have here"** meant five calls against five surfaces, each with its own tenant-scoping rule — and getting one wrong doesn't error, it returns a plausible number from the wrong tenant.

`op=inspect` is that one call: activity, chats, memory rows, documents, budget, usage. In a shared `internal/directory` service, for the reason erasure has one — MCP and HTTP must not drift on a tenant-scoping decision.

## `op=tenants`: refuse, don't filter

Admin-only, and **refused** for a non-admin rather than filtered. The counts are unremarkable; the **list** is the disclosure. An empty list would be a lie; a one-entry list would still confirm the caller's own tenant in a shape indistinguishable from *"you are the only tenant"*. That's why every other cross-tenant read here is an opaque not-found.

The tool stays in `tenantConfinableTools`, not `adminOnlyTools`, so `users`/`inspect` remain reachable — they can't escape, because the handler takes the tenant from the **principal** and offers no wire field at all.

## New store method

`ListTenants` on both backends + contract. `UserSummary` carries no tenant, so tenants can't be derived from `ListUsers`. A tenant appears once it has run something; user count is **distinct subjects**; a tenant with no runs is absent — which the response states, since an empty list means no *activity*, not no tenants.

⚠️ The sqlite tier stores `started_at` as unix **nanos**, so `MAX()` returns an int64 and scanning it as a time fails. Postgres returns a timestamp. Same query, two scan shapes.

## A CI fix that turned out to be required

The postgres store step had **no `-timeout`**, so it inherited Go's 600s default — while this suite measures **740s** on a clean database. It would have failed.

A timeout there is worse than an ordinary failure, and that's the real argument for headroom: the deadline kills tests mid-flight so their cleanups never drop their per-test schemas, and the name is `lct_<name-truncated-to-40>_<counter>` with the counter **restarting each process**. The next run regenerates the same names and dies on `schema already exists` — so a timeout doesn't just fail, it **poisons the database for the following run** in a way that reads as an unrelated bug. I diagnosed it by hitting exactly that, and mistaking it for a flaky test until I read the error.

## Tested

Four service tests — tenant confinement with the **same subject id in two tenants**, empty-subject refusal, an unexamined document plane *declared* rather than reported as zero, distinct-subject counting. Two MCP authz tests — `op=tenants` refused for `substrate:tenant` while `users`/`inspect` stay reachable, and a wire tenant ignored in favour of the principal. Plus the `ListTenants` contract on **both tiers**, verified against a real pgvector container: `ok 740.483s`, zero failures. Fail-before on the admin gate and on honouring a wire tenant.

## Not included

**gRPC and the adapters** — the ask was the MCP surface; parity is a follow-up.

**No RFC.** The design fork an RFC exists to surface — what a "user" *is* — was settled directly, and what remained is additive read-only aggregation with no new primitive. Flagging that as a judgement call you may want to overrule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8