### PR TITLE
feat(document): RFC BS Phase 1 — tags facet + document-level type/status

### DIFF
--- a/adapters/ts/src/types.ts
+++ b/adapters/ts/src/types.ts
@@ -1213,18 +1213,30 @@ export type DocumentToolInput = {
   op:
     | "create_document"
     | "get_document"
+    | "documents_summary"
+    | "query_documents"
     | "delete_document"
     | "set_path"
     | "create_chunk"
+    | "upsert_chunk"
     | "get_chunk"
     | "update_chunk"
     | "delete_chunk"
+    | "supersede_chunk"
+    | "graph_recall"
     | "move_chunk"
+    | "reorder_chunk"
     | "link_chunks"
     | "unlink_chunks"
+    | "get_edges"
     | "query_chunks"
+    | "add_tags"
+    | "remove_tags"
+    | "list_tags"
     | "define_type"
     | "list_types"
+    | "set_asset"
+    | "get_asset"
     | "export_md"
     | "import_md";
   scope?: "agent" | "user" | "tenant";
@@ -1240,6 +1252,14 @@ export type DocumentToolInput = {
   body?: string;
   fields?: Record<string, unknown>;
   status?: string;
+  /** The chunk's or document's tags (RFC BS). create/update/upsert_chunk +
+   *  create_document replace-set the whole set (omit = unchanged, [] = clear);
+   *  add_tags/remove_tags take the tags to change. Nested tags use a slash. */
+  tags?: string[];
+  /** query_chunks / query_documents: return only items carrying exactly this tag. */
+  tag?: string;
+  /** query_chunks: match this tag OR anything nested under it (prefix + '/'). */
+  tag_prefix?: string;
   position?: number;
   /** update_chunk: the chunk's current revision (optimistic concurrency). */
   revision?: number;

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -43,7 +43,7 @@ type Document struct {
 func (d *Document) Name() string { return "Document" }
 
 func (d *Document) Description() string {
-	return "A chunked-graph document: each chunk is a first-class unit (UUID, hierarchy, type, fields, graph edges, Markdown body) that agents and humans co-author and query. Ops: create_document/get_document/documents_summary (per-document type/status + display metadata for a set of ids or a Path subtree)/delete_document/set_path, create_chunk (optional after_id inserts right after a sibling)/get_chunk/update_chunk/delete_chunk/move_chunk/reorder_chunk (move up|down within a level), link_chunks/unlink_chunks/get_edges (the cross-reference edges touching a document, each enriched with its endpoints' titles/types/statuses), query_chunks (structured filters + a raw sql escape hatch), define_type/list_types, set_asset (attach an image's bytes to a chunk → type=image, served by GET /v1/_document/asset/{id})/get_asset (asset metadata), export_md (render the document to Markdown), import_md (build a document from export_md-shaped Markdown). Scope is agent or user; documents are named in the Path tree (path:) — create_document defaults to /documents/<title> if you omit one, and set_path attaches/re-homes a path for an existing document."
+	return "A chunked-graph document: each chunk is a first-class unit (UUID, hierarchy, type, fields, graph edges, Markdown body) that agents and humans co-author and query. Ops: create_document/get_document/documents_summary (per-document type/status + display metadata for a set of ids or a Path subtree)/query_documents (filter documents by type/status/tag/under_path)/delete_document/set_path, create_chunk (optional after_id inserts right after a sibling)/get_chunk/update_chunk/delete_chunk/move_chunk/reorder_chunk (move up|down within a level), link_chunks/unlink_chunks/get_edges (the cross-reference edges touching a document, each enriched with its endpoints' titles/types/statuses), query_chunks (structured filters incl. tag/tag_prefix + a raw sql escape hatch), add_tags/remove_tags (incremental tags on a chunk (id) or document (document_id))/list_tags (distinct tags + counts for a chunk, a document, or the whole scope), define_type/list_types, set_asset (attach an image's bytes to a chunk → type=image, served by GET /v1/_document/asset/{id})/get_asset (asset metadata), export_md (render the document to Markdown), import_md (build a document from export_md-shaped Markdown). Scope is agent or user; documents are named in the Path tree (path:) — create_document defaults to /documents/<title> if you omit one, and set_path attaches/re-homes a path for an existing document."
 }
 
 // documentInputSchema is a package const so the LoomCycle MCP server can
@@ -53,7 +53,7 @@ func (d *Document) Description() string {
 const documentInputSchema = `{
 	"type": "object",
 	"properties": {
-		"op":          {"type": "string", "enum": ["create_document","get_document","documents_summary","delete_document","set_path","create_chunk","upsert_chunk","get_chunk","update_chunk","delete_chunk","supersede_chunk","graph_recall","move_chunk","reorder_chunk","link_chunks","unlink_chunks","get_edges","query_chunks","define_type","list_types","set_asset","get_asset","export_md","import_md"]},
+		"op":          {"type": "string", "enum": ["create_document","get_document","documents_summary","query_documents","delete_document","set_path","create_chunk","upsert_chunk","get_chunk","update_chunk","delete_chunk","supersede_chunk","graph_recall","move_chunk","reorder_chunk","link_chunks","unlink_chunks","get_edges","query_chunks","add_tags","remove_tags","list_tags","define_type","list_types","set_asset","get_asset","export_md","import_md"]},
 		"scope":       {"type": "string", "enum": ["agent","user","tenant"], "description": "Which store (default user). agent = this agent; user = this end-user (needs a user_id on the run); tenant = shared by every user and agent in the tenant — anything written here is read by all of them, so use it for curated reference material, not for anything derived from untrusted text. tenant requires the operator to grant BOTH memory_scopes and sql_scopes with the tenant value."},
 		"id":          {"type": "string", "description": "Document id (get/delete_document, set_path) or chunk id (get/update/delete/move_chunk)."},
 		"path":        {"type": "string", "description": "create_document: name the doc in the Path tree (default /documents/<title> if omitted). set_path: the path to attach to an existing document (by id). get/delete_document: address by path instead of id."},
@@ -88,7 +88,10 @@ const documentInputSchema = `{
 		"media_type":  {"type": "string", "description": "set_asset: the image MIME type (image/png, image/jpeg, image/gif, image/webp)."},
 		"data":        {"type": "string", "description": "set_asset: the image bytes as standard base64 (no data: prefix)."},
 		"filename":    {"type": "string", "description": "set_asset: an optional original filename (metadata only)."},
-		"under_path":  {"type": "string", "description": "query_chunks / documents_summary: restrict to documents at/under this Path-tree path."},
+		"under_path":  {"type": "string", "description": "query_chunks / query_documents / documents_summary: restrict to documents at/under this Path-tree path."},
+		"tags":        {"type": "array", "items": {"type": "string"}, "description": "The chunk's or document's tags. create_chunk/update_chunk/upsert_chunk/create_document replace-set the whole tag set (omit to leave unchanged; [] to clear). add_tags/remove_tags take the tags to add/remove incrementally. Nested tags use a slash: area/sub/topic."},
+		"tag":         {"type": "string", "description": "query_chunks / query_documents: return only chunks/documents carrying exactly this tag."},
+		"tag_prefix":  {"type": "string", "description": "query_chunks: return chunks whose tag equals this OR is nested under it (prefix + '/'), e.g. tag_prefix=area matches area and area/sub."},
 		"sql":         {"type": "string", "description": "query_chunks: raw read-only SELECT against the chunk tables (escape hatch; validator-gated)."},
 		"limit":       {"type": "integer"},
 		"name":        {"type": "string", "description": "define/list_types: the type name."},
@@ -124,6 +127,15 @@ type docInput struct {
 	FromID    string          `json:"from_id"`
 	ToID      string          `json:"to_id"`
 	Kind      string          `json:"kind"`
+
+	// Tag facet (RFC BS Phase 1). Tags is a plain slice so JSON presence is
+	// self-distinguishing: an omitted `tags` decodes to nil (leave existing tags
+	// untouched), a present `[]` decodes to a non-nil empty slice (clear all) — the
+	// unset-vs-empty distinction update_chunk relies on. Tag/TagPrefix are the
+	// query filters (exact / slash-prefix).
+	Tags      []string `json:"tags"`
+	Tag       string   `json:"tag"`
+	TagPrefix string   `json:"tag_prefix"`
 
 	// Entity-tier fields (RFC BL P4c). NaturalKey is the idempotency handle:
 	// upsert_chunk keys on it, and it is UNIQUE per scope.
@@ -239,6 +251,21 @@ var docSchemaDDL = []string{
 	// the graph is large enough to matter — the failure that shows up in
 	// production and not in a test.
 	`CREATE INDEX IF NOT EXISTS chunk_edges_to_kind ON chunk_edges(to_id, kind)`,
+	// chunk_tags / document_tags — the multi-valued tag facet (RFC BS Phase 1).
+	// Tags are a JOIN table (not a chunk `fields` key) precisely because they are a
+	// query axis: query_chunks / query_documents filter on them, and a `fields` key
+	// lives inside the chunkBody JSON blob in the Memory k/v plane where SQL cannot
+	// reach it. A document's tags are INDEPENDENT of its root chunk's tags — they
+	// live in a separate table. Nested tags (area/sub/topic) are stored as the full
+	// slash string; the hierarchy is a prefix query (query_chunks tag_prefix). No
+	// foreign key — cascade is explicit in Go (deleteChunk / deleteDocument),
+	// matching the rest of this schema.
+	`CREATE TABLE IF NOT EXISTS chunk_tags (
+		chunk_id TEXT NOT NULL, tag TEXT NOT NULL, PRIMARY KEY (chunk_id, tag))`,
+	`CREATE INDEX IF NOT EXISTS chunk_tags_tag ON chunk_tags(tag)`,
+	`CREATE TABLE IF NOT EXISTS document_tags (
+		document_id TEXT NOT NULL, tag TEXT NOT NULL, PRIMARY KEY (document_id, tag))`,
+	`CREATE INDEX IF NOT EXISTS document_tags_tag ON document_tags(tag)`,
 }
 
 // maxChunkDepth caps the ancestor walk in move_chunk (cycle detection) so a
@@ -276,6 +303,8 @@ func (d *Document) Execute(ctx context.Context, raw json.RawMessage) (tools.Resu
 		return d.getDocument(ctx, key, mscope, in)
 	case "documents_summary":
 		return d.documentsSummary(ctx, key, mscope, in)
+	case "query_documents":
+		return d.queryDocuments(ctx, key, in)
 	case "delete_document":
 		return d.deleteDocument(ctx, key, mscope, in)
 	case "set_path":
@@ -293,7 +322,7 @@ func (d *Document) Execute(ctx context.Context, raw json.RawMessage) (tools.Resu
 	case "reorder_chunk":
 		return d.reorderChunk(ctx, key, mscope, in)
 	case "upsert_chunk":
-		return d.upsertChunk(ctx, key, mscope, in)
+		return d.upsertChunkOp(ctx, key, mscope, in, raw)
 	case "supersede_chunk":
 		return d.supersedeChunk(ctx, key, in)
 	case "graph_recall":
@@ -306,6 +335,12 @@ func (d *Document) Execute(ctx context.Context, raw json.RawMessage) (tools.Resu
 		return d.getEdges(ctx, key, in)
 	case "query_chunks":
 		return d.queryChunks(ctx, key, in)
+	case "add_tags":
+		return d.addTags(ctx, key, in)
+	case "remove_tags":
+		return d.removeTags(ctx, key, in)
+	case "list_tags":
+		return d.listTags(ctx, key, in)
 	case "define_type":
 		return d.defineType(ctx, key, in)
 	case "list_types":
@@ -430,7 +465,10 @@ func (d *Document) ensureSchema(ctx context.Context, key sqlmem.ScopeKey) error 
 	if _, err := d.SqlMem.Exec(ctx, key, assetDDL, nil, 0); err != nil {
 		return err
 	}
-	return d.migrateConfidencePrecision(ctx, key)
+	if err := d.migrateConfidencePrecision(ctx, key); err != nil {
+		return err
+	}
+	return d.migrateDocumentFacets(ctx, key)
 }
 
 // migrateConfidencePrecision widens chunk_memory_meta.confidence from postgres
@@ -468,6 +506,66 @@ func (d *Document) migrateConfidencePrecision(ctx context.Context, key sqlmem.Sc
 	_, err = d.SqlMem.Exec(ctx, key,
 		`ALTER TABLE chunk_memory_meta ALTER COLUMN confidence TYPE DOUBLE PRECISION`, nil, 0)
 	return err
+}
+
+// migrateDocumentFacets adds the denormalized `type`/`status` columns to an
+// existing `documents` table (RFC BS Phase 1) and backfills them from each
+// document's root chunk. Like migrateConfidencePrecision it PROBES before it
+// alters, because ensureSchema is on every op's hot path: the fast case is a
+// single 0-row SELECT.
+//
+// Why ALTER rather than declaring the columns in docSchemaDDL's CREATE TABLE? A
+// `CREATE TABLE IF NOT EXISTS` leaves a table provisioned before this change
+// untouched, so an existing scope would keep the old 5-column shape forever. The
+// columns therefore arrive via ALTER on every scope, new and old alike — the one
+// path that reaches both.
+//
+// The column probe is a leading-SELECT (`SELECT <col> FROM documents WHERE 1=0`)
+// rather than a bare `PRAGMA table_info`: the SQL Memory validator denies a
+// leading PRAGMA (see internal/sqlmem/validate.go), and a WHERE-1=0 select is both
+// validator-safe AND tier-portable (no information_schema / pragma-function
+// split), erroring iff the column is absent.
+func (d *Document) migrateDocumentFacets(ctx context.Context, key sqlmem.ScopeKey) error {
+	// Fast path: both columns present → nothing to do (the common case).
+	if _, err := d.query(ctx, key, `SELECT type, status FROM documents WHERE 1=0`); err == nil {
+		return nil
+	}
+	// At least one column is missing — add whichever is absent. Per-column probes
+	// avoid a duplicate-column error when only one is missing (a crash between the
+	// two ALTERs on a prior run).
+	if !d.documentsHasColumn(ctx, key, "type") {
+		if err := d.exec(ctx, key, `ALTER TABLE documents ADD COLUMN type TEXT`); err != nil {
+			return err
+		}
+	}
+	if !d.documentsHasColumn(ctx, key, "status") {
+		if err := d.exec(ctx, key, `ALTER TABLE documents ADD COLUMN status TEXT`); err != nil {
+			return err
+		}
+	}
+	// The composite index only becomes creatable once the columns exist, so it
+	// lives here rather than in docSchemaDDL (which runs before this migration).
+	if err := d.exec(ctx, key, `CREATE INDEX IF NOT EXISTS documents_type_status ON documents(type, status)`); err != nil {
+		return err
+	}
+	// Backfill from each document's root chunk, per column and only where still
+	// NULL — cheap once populated, and crash-safe if a prior run added one column
+	// and backfilled it before adding the other.
+	if err := d.exec(ctx, key,
+		`UPDATE documents SET type = (SELECT type FROM chunks WHERE chunks.id = documents.root_chunk_id) WHERE type IS NULL`); err != nil {
+		return err
+	}
+	return d.exec(ctx, key,
+		`UPDATE documents SET status = (SELECT status FROM chunks WHERE chunks.id = documents.root_chunk_id) WHERE status IS NULL`)
+}
+
+// documentsHasColumn reports whether the documents table has `col` — a
+// validator-safe, tier-portable existence probe (a leading SELECT that errors iff
+// the column is absent). col is a hardcoded literal ("type" | "status"), never
+// caller input.
+func (d *Document) documentsHasColumn(ctx context.Context, key sqlmem.ScopeKey, col string) bool {
+	_, err := d.query(ctx, key, `SELECT `+col+` FROM documents WHERE 1=0`)
+	return err == nil
 }
 
 // --- chunk body (Memory) helpers ---
@@ -710,6 +808,12 @@ func (d *Document) SetChunkStatus(ctx context.Context, scope, chunkID, status st
 	if res.RowsAffected == 0 {
 		return fmt.Errorf("chunk %s: revision conflict setting status (changed by a concurrent write)", chunkID)
 	}
+	// If this board write lands on a document's root chunk, mirror the new status
+	// onto the documents row so get_document / query_documents (which read that
+	// row) stay consistent with the root chunk. A no-op for a non-root chunk.
+	if err := d.mirrorRootFacets(ctx, key, chunkID); err != nil {
+		return err
+	}
 	d.publishChange(ctx, mscope, key.ScopeID, row.DocumentID, "update_chunk", chunkID)
 	return nil
 }
@@ -723,17 +827,26 @@ func (d *Document) createDocument(ctx context.Context, key sqlmem.ScopeKey, msco
 	now := time.Now().UnixNano()
 	docID := newDocID()
 	rootID := newDocID()
-	if err := d.exec(ctx, key, `INSERT INTO documents (id, title, root_chunk_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`,
-		docID, in.Title, rootID, now, now); err != nil {
+	// type/status are set on the root chunk (the authoritative kind/state) AND
+	// mirrored to the documents row (the denormalized copy query_documents /
+	// get_document read). They start in sync here; update_chunk keeps them so.
+	if err := d.exec(ctx, key, `INSERT INTO documents (id, title, root_chunk_id, type, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		docID, in.Title, rootID, nullIfEmpty(in.Type), nullIfEmpty(in.Status), now, now); err != nil {
 		return errResult("create_document: " + err.Error()), nil
 	}
 	// The root chunk anchors the hierarchy (parent_id NULL).
-	if err := d.exec(ctx, key, `INSERT INTO chunks (id, document_id, parent_id, position, type, status, title, created_at, updated_at, revision) VALUES (?, ?, NULL, 0, NULL, NULL, ?, ?, ?, 1)`,
-		rootID, docID, in.Title, now, now); err != nil {
+	if err := d.exec(ctx, key, `INSERT INTO chunks (id, document_id, parent_id, position, type, status, title, created_at, updated_at, revision) VALUES (?, ?, NULL, 0, ?, ?, ?, ?, ?, 1)`,
+		rootID, docID, nullIfEmpty(in.Type), nullIfEmpty(in.Status), in.Title, now, now); err != nil {
 		return errResult("create_document: root chunk: " + err.Error()), nil
 	}
 	if err := d.writeBody(ctx, mscope, key.ScopeID, rootID, "", nil); err != nil {
 		return errResult("create_document: root body: " + err.Error()), nil
+	}
+	// A document's tags are its own (independent of the root chunk's tags).
+	if len(in.Tags) > 0 {
+		if err := d.replaceDocumentTags(ctx, key, docID, in.Tags); err != nil {
+			return errResult("create_document: tags: " + err.Error()), nil
+		}
 	}
 	resp := map[string]any{"document_id": docID, "root_chunk_id": rootID, "title": in.Title}
 	// Path-tree name (RFC AK). An explicit `path` wins; otherwise default to
@@ -908,7 +1021,7 @@ func (d *Document) getDocument(ctx context.Context, key sqlmem.ScopeKey, mscope 
 	if err != nil {
 		return errResult("get_document: " + err.Error()), nil
 	}
-	res, err := d.query(ctx, key, `SELECT id, title, root_chunk_id, created_at, updated_at FROM documents WHERE id = ? LIMIT 1`, docID)
+	res, err := d.query(ctx, key, `SELECT id, title, root_chunk_id, type, status, created_at, updated_at FROM documents WHERE id = ? LIMIT 1`, docID)
 	if err != nil {
 		return errResult("get_document: " + err.Error()), nil
 	}
@@ -924,18 +1037,24 @@ func (d *Document) getDocument(ctx context.Context, key sqlmem.ScopeKey, mscope 
 		"document_id": asStr(m["id"]), "title": asStr(m["title"]),
 		"root_chunk_id": rootID,
 	}
-	// Enrich with the ROOT chunk's type/status (the document's own kind/state)
-	// and its RFC BN color settings (persisted in the root chunk's fields) so the
-	// UI can render a document tile/tree row without a second get_chunk.
+	// type/status come from the documents row (the denormalized mirror of the root
+	// chunk, kept in sync by create_document + the update_chunk/upsert root mirror)
+	// — one read instead of a second get_chunk.
+	if t := asStr(m["type"]); t != "" {
+		resp["type"] = t
+	}
+	if s := asStr(m["status"]); s != "" {
+		resp["status"] = s
+	}
+	// The document's own tags (independent of the root chunk's tags).
+	tags, terr := d.listDocumentTags(ctx, key, docID)
+	if terr != nil {
+		return errResult("get_document: tags: " + terr.Error()), nil
+	}
+	if len(tags) > 0 {
+		resp["tags"] = tags
+	}
 	if rootID != "" {
-		if row, ok, rerr := d.getChunkRow(ctx, key, rootID); rerr == nil && ok {
-			if row.Type != "" {
-				resp["type"] = row.Type
-			}
-			if row.Status != "" {
-				resp["status"] = row.Status
-			}
-		}
 		// Colour is decoration, so a read fault degrades to "no scheme" rather
 		// than failing the whole get — matching the getChunkRow probe above.
 		// Content reads (get_chunk, export_md) propagate instead.
@@ -1102,6 +1221,14 @@ func (d *Document) deleteDocument(ctx context.Context, key sqlmem.ScopeKey, msco
 		if err := d.execTxn(ctx, txnID, `DELETE FROM chunk_assets WHERE chunk_id IN (SELECT id FROM chunks WHERE document_id = ?)`, docID); err != nil {
 			return err
 		}
+		// Tag rows: chunk tags (resolved via the chunks subquery, so before the chunk
+		// rows go) + the document's own tags. RFC BS.
+		if err := d.execTxn(ctx, txnID, `DELETE FROM chunk_tags WHERE chunk_id IN (SELECT id FROM chunks WHERE document_id = ?)`, docID); err != nil {
+			return err
+		}
+		if err := d.execTxn(ctx, txnID, `DELETE FROM document_tags WHERE document_id = ?`, docID); err != nil {
+			return err
+		}
 		// Same ordering constraint for the entity-tier sidecar, and the same reason
 		// it is done here rather than by a foreign key: an orphaned temporal row is
 		// invisible. No read filters it and no sweeper reaps it, so it would sit in
@@ -1251,6 +1378,15 @@ func (d *Document) createChunk(ctx context.Context, key sqlmem.ScopeKey, mscope 
 	}
 	if err := d.writeBody(ctx, mscope, key.ScopeID, id, in.Body, in.Fields); err != nil {
 		return errResult("create_chunk: body: " + err.Error()), nil
+	}
+	// Tags on a fresh chunk (also serves upsert_chunk's create path, which
+	// delegates here). replaceChunkTags is delete-then-insert; on a new id the
+	// delete matches nothing, so len>0 keeps an untagged create from a needless
+	// write.
+	if len(in.Tags) > 0 {
+		if err := d.replaceChunkTags(ctx, key, id, in.Tags); err != nil {
+			return errResult("create_chunk: tags: " + err.Error()), nil
+		}
 	}
 	d.publishChange(ctx, mscope, key.ScopeID, in.DocumentID, "create_chunk", id)
 	return d.getChunk(ctx, key, mscope, docInput{ID: id})
@@ -1404,6 +1540,12 @@ func (d *Document) setAsset(ctx context.Context, key sqlmem.ScopeKey, mscope sto
 	if err := d.writeBody(ctx, mscope, key.ScopeID, in.ID, cb.Body, nf); err != nil {
 		return errResult("set_asset: fields: " + err.Error()), nil
 	}
+	// set_asset sets type='image' on the chunk; if that chunk is a document's root,
+	// mirror it onto the documents row so get_document/query_documents stay in sync
+	// (a no-op for a non-root chunk). RFC BS.
+	if err := d.mirrorRootFacets(ctx, key, in.ID); err != nil {
+		return errResult("set_asset: " + err.Error()), nil
+	}
 	d.publishChange(ctx, mscope, key.ScopeID, row.DocumentID, "set_asset", in.ID)
 	return d.getChunk(ctx, key, mscope, docInput{ID: in.ID})
 }
@@ -1545,6 +1687,22 @@ func (d *Document) updateChunk(ctx context.Context, key sqlmem.ScopeKey, mscope 
 			return errResult("update_chunk: body: " + err.Error()), nil
 		}
 	}
+	// Replace-set the chunk's tags only when `tags` was supplied — a present `[]`
+	// clears, an absent key leaves them untouched (same presence rule as above).
+	if _, has := present["tags"]; has {
+		if err := d.replaceChunkTags(ctx, key, in.ID, in.Tags); err != nil {
+			return errResult("update_chunk: tags: " + err.Error()), nil
+		}
+	}
+	// If this chunk is a document's root and its type/status just changed, mirror
+	// the new facets onto the documents row (a no-op for a non-root chunk).
+	_, hasType := present["type"]
+	_, hasStatus := present["status"]
+	if hasType || hasStatus {
+		if err := d.mirrorRootFacets(ctx, key, in.ID); err != nil {
+			return errResult("update_chunk: " + err.Error()), nil
+		}
+	}
 	d.publishChange(ctx, mscope, key.ScopeID, row.DocumentID, "update_chunk", in.ID)
 	return d.getChunk(ctx, key, mscope, docInput{ID: in.ID})
 }
@@ -1611,6 +1769,9 @@ func (d *Document) deleteChunk(ctx context.Context, key sqlmem.ScopeKey, mscope 
 				return err
 			}
 			if err := d.execTxn(ctx, txnID, `DELETE FROM chunk_assets WHERE chunk_id = ?`, cid); err != nil {
+				return err
+			}
+			if err := d.execTxn(ctx, txnID, `DELETE FROM chunk_tags WHERE chunk_id = ?`, cid); err != nil {
 				return err
 			}
 			// The sidecar's SECOND cascade site. Both are required: delete_document
@@ -1935,6 +2096,19 @@ func (d *Document) queryChunks(ctx context.Context, key sqlmem.ScopeKey, in docI
 	if in.ParentID != "" {
 		where += " AND parent_id = ?"
 		args = append(args, in.ParentID)
+	}
+	// tag: exact membership. tag_prefix: the tag itself OR anything nested under it
+	// (tag_prefix + '/…'). NOTE the LIKE metacharacters '%' and '_' in a prefix are
+	// not escaped (matching the RFC's own SQL) — a false-positive for a prefix that
+	// literally contains one is tolerated for a Phase-1 query filter (no security
+	// impact; tags are normally plain slash-nested identifiers).
+	if in.Tag != "" {
+		where += " AND id IN (SELECT chunk_id FROM chunk_tags WHERE tag = ?)"
+		args = append(args, in.Tag)
+	}
+	if in.TagPrefix != "" {
+		where += " AND id IN (SELECT chunk_id FROM chunk_tags WHERE tag = ? OR tag LIKE ?)"
+		args = append(args, in.TagPrefix, in.TagPrefix+"/%")
 	}
 	args = append(args, limit)
 	res, err := d.query(ctx, key, `SELECT `+chunkSelectCols+` FROM chunks WHERE `+where+` ORDER BY document_id, parent_id, position LIMIT ?`, args...)
@@ -2379,6 +2553,11 @@ func (d *Document) importMD(ctx context.Context, key sqlmem.ScopeKey, mscope sto
 			if err := d.exec(ctx, key, `UPDATE chunks SET type = ?, status = ? WHERE id = ?`, nullIfEmpty(first.typ), nullIfEmpty(first.status), rootID); err != nil {
 				return errResult("import_md: " + err.Error()), nil
 			}
+			// Keep the documents row's mirrored facets in step with the root chunk
+			// (createDocument set them from an empty type/status above).
+			if err := d.mirrorRootFacets(ctx, key, rootID); err != nil {
+				return errResult("import_md: " + err.Error()), nil
+			}
 		}
 		if first.assetData != "" {
 			d.importAsset(ctx, key, mscope, rootID, first)
@@ -2493,6 +2672,325 @@ func (d *Document) listTypes(ctx context.Context, key sqlmem.ScopeKey, in docInp
 		types = append(types, map[string]any{"name": asStr(m["name"]), "document_id": asStr(m["document_id"]), "fields": fields})
 	}
 	return jsonResult(map[string]any{"types": types})
+}
+
+// --- ops: tags + document facets (RFC BS Phase 1) ---
+
+// upsertChunkOp runs upsert_chunk (whose create/update internals live in the
+// entity-tier file) and then applies the Phase-1 facets this change owns. On the
+// CREATE path there is nothing to add here: upsert delegates the insert to
+// createChunk, which already applies `tags`, and never makes a root chunk. On the
+// UPDATE path (updateChunkForUpsert, which does not touch tags) this replace-sets
+// the tags when supplied and mirrors the documents row if the upserted chunk is a
+// root and its type/status was set.
+func (d *Document) upsertChunkOp(ctx context.Context, key sqlmem.ScopeKey, mscope store.MemoryScope, in docInput, raw json.RawMessage) (tools.Result, error) {
+	res, err := d.upsertChunk(ctx, key, mscope, in)
+	if err != nil || res.IsError {
+		return res, err
+	}
+	var meta struct {
+		ID      string `json:"id"`
+		Created bool   `json:"created"`
+	}
+	_ = json.Unmarshal([]byte(res.Text), &meta)
+	if meta.ID == "" || meta.Created {
+		return res, nil
+	}
+	if jsonHasField(raw, "tags") {
+		if terr := d.replaceChunkTags(ctx, key, meta.ID, in.Tags); terr != nil {
+			return errResult("upsert_chunk: tags: " + terr.Error()), nil
+		}
+	}
+	// Only worth a mirror when the upsert could have moved a root chunk's facets
+	// (updateChunkForUpsert sets type/status only when supplied); otherwise it is a
+	// guaranteed 0-row UPDATE on the entity tier's hot path.
+	if in.Type != "" || in.Status != "" {
+		if terr := d.mirrorRootFacets(ctx, key, meta.ID); terr != nil {
+			return errResult("upsert_chunk: " + terr.Error()), nil
+		}
+	}
+	return res, nil
+}
+
+// mirrorRootFacets keeps the documents row's denormalized type/status in step with
+// its root chunk. It is a no-op for a non-root chunk (the WHERE matches nothing),
+// so callers can invoke it unconditionally after a chunk's type/status changes.
+func (d *Document) mirrorRootFacets(ctx context.Context, key sqlmem.ScopeKey, chunkID string) error {
+	return d.exec(ctx, key,
+		`UPDATE documents SET type = (SELECT type FROM chunks WHERE id = ?),
+		                      status = (SELECT status FROM chunks WHERE id = ?),
+		                      updated_at = ?
+		 WHERE root_chunk_id = ?`,
+		chunkID, chunkID, time.Now().UnixNano(), chunkID)
+}
+
+// sanitizeTags trims, drops empties, and de-duplicates a tag list (order
+// preserved). The composite PRIMARY KEY(<owner>, tag) rejects a duplicate insert,
+// so the dedup is what lets a replace-set carry the caller's raw list safely. Tags
+// are stored verbatim otherwise — including any '/', which is the nesting
+// convention a prefix query walks.
+func sanitizeTags(tags []string) []string {
+	seen := make(map[string]bool, len(tags))
+	out := make([]string, 0, len(tags))
+	for _, t := range tags {
+		t = strings.TrimSpace(t)
+		if t == "" || seen[t] {
+			continue
+		}
+		seen[t] = true
+		out = append(out, t)
+	}
+	return out
+}
+
+// replaceChunkTags makes a chunk's tag set exactly `tags` (delete-all then
+// insert). Not wrapped in a txn: chunk_tags rows are independent of the chunk row
+// and the common chunk-write path is itself non-transactional, so this matches the
+// surrounding write's atomicity.
+func (d *Document) replaceChunkTags(ctx context.Context, key sqlmem.ScopeKey, chunkID string, tags []string) error {
+	if err := d.exec(ctx, key, `DELETE FROM chunk_tags WHERE chunk_id = ?`, chunkID); err != nil {
+		return err
+	}
+	for _, t := range sanitizeTags(tags) {
+		if err := d.exec(ctx, key, `INSERT INTO chunk_tags (chunk_id, tag) VALUES (?, ?)`, chunkID, t); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// replaceDocumentTags makes a document's tag set exactly `tags` (delete-all then
+// insert), the document-level twin of replaceChunkTags.
+func (d *Document) replaceDocumentTags(ctx context.Context, key sqlmem.ScopeKey, docID string, tags []string) error {
+	if err := d.exec(ctx, key, `DELETE FROM document_tags WHERE document_id = ?`, docID); err != nil {
+		return err
+	}
+	for _, t := range sanitizeTags(tags) {
+		if err := d.exec(ctx, key, `INSERT INTO document_tags (document_id, tag) VALUES (?, ?)`, docID, t); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// addTagRows inserts tags for a target idempotently (INSERT … WHERE NOT EXISTS —
+// portable, no ON CONFLICT dialect split, mirroring linkChunks' existence-check
+// style). table/keyCol are hardcoded literals ("chunk_tags"/"chunk_id" or
+// "document_tags"/"document_id"), never caller input.
+func (d *Document) addTagRows(ctx context.Context, key sqlmem.ScopeKey, table, keyCol, id string, tags []string) error {
+	for _, t := range sanitizeTags(tags) {
+		stmt := `INSERT INTO ` + table + ` (` + keyCol + `, tag) SELECT ?, ? WHERE NOT EXISTS (SELECT 1 FROM ` + table + ` WHERE ` + keyCol + ` = ? AND tag = ?)`
+		if err := d.exec(ctx, key, stmt, id, t, id, t); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// removeTagRows deletes the given tags from a target (see addTagRows for the
+// hardcoded-identifier note).
+func (d *Document) removeTagRows(ctx context.Context, key sqlmem.ScopeKey, table, keyCol, id string, tags []string) error {
+	for _, t := range sanitizeTags(tags) {
+		if err := d.exec(ctx, key, `DELETE FROM `+table+` WHERE `+keyCol+` = ? AND tag = ?`, id, t); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// listChunkTags / listDocumentTags return a target's tags, sorted.
+func (d *Document) listChunkTags(ctx context.Context, key sqlmem.ScopeKey, chunkID string) ([]string, error) {
+	return d.tagList(ctx, key, `SELECT tag FROM chunk_tags WHERE chunk_id = ? ORDER BY tag`, chunkID)
+}
+
+func (d *Document) listDocumentTags(ctx context.Context, key sqlmem.ScopeKey, docID string) ([]string, error) {
+	return d.tagList(ctx, key, `SELECT tag FROM document_tags WHERE document_id = ? ORDER BY tag`, docID)
+}
+
+func (d *Document) tagList(ctx context.Context, key sqlmem.ScopeKey, stmt, id string) ([]string, error) {
+	res, err := d.query(ctx, key, stmt, id)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(res.Rows))
+	for _, r := range res.Rows {
+		out = append(out, asStr(r[0]))
+	}
+	return out, nil
+}
+
+// documentExists reports whether a document row is present in this scope.
+func (d *Document) documentExists(ctx context.Context, key sqlmem.ScopeKey, docID string) (bool, error) {
+	res, err := d.query(ctx, key, `SELECT 1 FROM documents WHERE id = ? LIMIT 1`, docID)
+	if err != nil {
+		return false, err
+	}
+	return len(res.Rows) > 0, nil
+}
+
+// jsonHasField reports whether a raw JSON object literally contains key — the
+// presence test that distinguishes "field omitted" (leave as-is) from "field
+// present but empty" (e.g. tags:[] clears). Mirrors the `present` map update_chunk
+// builds, for a single-key check.
+func jsonHasField(raw json.RawMessage, key string) bool {
+	var m map[string]json.RawMessage
+	if json.Unmarshal(raw, &m) != nil {
+		return false
+	}
+	_, ok := m[key]
+	return ok
+}
+
+func (d *Document) addTags(ctx context.Context, key sqlmem.ScopeKey, in docInput) (tools.Result, error) {
+	return d.mutateTags(ctx, key, in, true)
+}
+
+func (d *Document) removeTags(ctx context.Context, key sqlmem.ScopeKey, in docInput) (tools.Result, error) {
+	return d.mutateTags(ctx, key, in, false)
+}
+
+// mutateTags is the shared body of add_tags / remove_tags: it targets a chunk
+// (id) or a document (document_id) — verifying the target exists in this scope
+// first so no phantom tag rows are ever written — and returns the target's
+// resulting tag set.
+func (d *Document) mutateTags(ctx context.Context, key sqlmem.ScopeKey, in docInput, add bool) (tools.Result, error) {
+	op := "remove_tags"
+	if add {
+		op = "add_tags"
+	}
+	if len(in.Tags) == 0 {
+		return errResult(op + ": missing required field: tags"), nil
+	}
+	apply := func(table, keyCol, id string) error {
+		if add {
+			return d.addTagRows(ctx, key, table, keyCol, id, in.Tags)
+		}
+		return d.removeTagRows(ctx, key, table, keyCol, id, in.Tags)
+	}
+	switch {
+	case in.ID != "":
+		if _, ok, err := d.getChunkRow(ctx, key, in.ID); err != nil {
+			return errResult(op + ": " + err.Error()), nil
+		} else if !ok {
+			return errResult(op + ": no such chunk: " + in.ID), nil
+		}
+		if err := apply("chunk_tags", "chunk_id", in.ID); err != nil {
+			return errResult(op + ": " + err.Error()), nil
+		}
+		tags, err := d.listChunkTags(ctx, key, in.ID)
+		if err != nil {
+			return errResult(op + ": " + err.Error()), nil
+		}
+		return jsonResult(map[string]any{"chunk_id": in.ID, "tags": tags})
+	case in.DocumentID != "":
+		if ok, err := d.documentExists(ctx, key, in.DocumentID); err != nil {
+			return errResult(op + ": " + err.Error()), nil
+		} else if !ok {
+			return errResult(op + ": no such document: " + in.DocumentID), nil
+		}
+		if err := apply("document_tags", "document_id", in.DocumentID); err != nil {
+			return errResult(op + ": " + err.Error()), nil
+		}
+		tags, err := d.listDocumentTags(ctx, key, in.DocumentID)
+		if err != nil {
+			return errResult(op + ": " + err.Error()), nil
+		}
+		return jsonResult(map[string]any{"document_id": in.DocumentID, "tags": tags})
+	default:
+		return errResult(op + ": target a chunk (id) or a document (document_id)"), nil
+	}
+}
+
+// listTags returns distinct tags with counts, sorted. Target is a chunk (id), a
+// document (document_id), or — with neither — the whole scope, where the count is
+// a tag's total usage across every chunk AND document in the scope.
+func (d *Document) listTags(ctx context.Context, key sqlmem.ScopeKey, in docInput) (tools.Result, error) {
+	var stmt string
+	var args []any
+	switch {
+	case in.ID != "":
+		stmt = `SELECT tag, COUNT(*) AS count FROM chunk_tags WHERE chunk_id = ? GROUP BY tag ORDER BY tag`
+		args = []any{in.ID}
+	case in.DocumentID != "":
+		stmt = `SELECT tag, COUNT(*) AS count FROM document_tags WHERE document_id = ? GROUP BY tag ORDER BY tag`
+		args = []any{in.DocumentID}
+	default:
+		stmt = `SELECT tag, COUNT(*) AS count FROM (SELECT tag FROM chunk_tags UNION ALL SELECT tag FROM document_tags) t GROUP BY tag ORDER BY tag`
+	}
+	res, err := d.query(ctx, key, stmt, args...)
+	if err != nil {
+		return errResult("list_tags: " + err.Error()), nil
+	}
+	tags := make([]map[string]any, 0, len(res.Rows))
+	for _, r := range res.Rows {
+		tags = append(tags, map[string]any{"tag": asStr(r[0]), "count": asInt(r[1])})
+	}
+	return jsonResult(map[string]any{"tags": tags})
+}
+
+// queryDocuments filters the documents table by type / status / tag (via
+// document_tags) / under_path (the Path tree, exactly like query_chunks), and
+// returns the matching document rows.
+func (d *Document) queryDocuments(ctx context.Context, key sqlmem.ScopeKey, in docInput) (tools.Result, error) {
+	limit := in.Limit
+	if limit <= 0 || limit > 1000 {
+		limit = 100
+	}
+	where := "1=1"
+	args := []any{}
+	if in.UnderPath != "" {
+		docIDs, err := d.documentsUnderPath(ctx, key, in.UnderPath)
+		if err != nil {
+			return errResult("query_documents: " + err.Error()), nil
+		}
+		if len(docIDs) == 0 {
+			return jsonResult(map[string]any{"documents": []any{}})
+		}
+		ph, pargs := inPlaceholders(docIDs)
+		where += " AND id IN (" + ph + ")"
+		args = append(args, pargs...)
+	}
+	if in.Type != "" {
+		where += " AND type = ?"
+		args = append(args, in.Type)
+	}
+	if in.Status != "" {
+		where += " AND status = ?"
+		args = append(args, in.Status)
+	}
+	if in.Tag != "" {
+		where += " AND id IN (SELECT document_id FROM document_tags WHERE tag = ?)"
+		args = append(args, in.Tag)
+	}
+	args = append(args, limit)
+	res, err := d.query(ctx, key, `SELECT id, title, type, status, root_chunk_id, created_at, updated_at FROM documents WHERE `+where+` ORDER BY title, id LIMIT ?`, args...)
+	if err != nil {
+		return errResult("query_documents: " + err.Error()), nil
+	}
+	docs := make([]map[string]any, 0, len(res.Rows))
+	for _, r := range res.Rows {
+		m := map[string]any{}
+		for i, c := range res.Columns {
+			if i < len(r) {
+				m[c] = r[i]
+			}
+		}
+		entry := map[string]any{
+			"document_id":   asStr(m["id"]),
+			"title":         asStr(m["title"]),
+			"root_chunk_id": asStr(m["root_chunk_id"]),
+			"created_at":    asInt(m["created_at"]),
+			"updated_at":    asInt(m["updated_at"]),
+		}
+		if t := asStr(m["type"]); t != "" {
+			entry["type"] = t
+		}
+		if s := asStr(m["status"]); s != "" {
+			entry["status"] = s
+		}
+		docs = append(docs, entry)
+	}
+	return jsonResult(map[string]any{"documents": docs})
 }
 
 // --- change events ---

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -1411,6 +1411,13 @@ func (d *Document) getChunk(ctx context.Context, key sqlmem.ScopeKey, mscope sto
 		return errResult("get_chunk: body: " + err.Error()), nil
 	}
 	resp := chunkResponse(row, cb)
+	// The chunk's tags (RFC BS) — the primary read surfaces them so a reader (and
+	// the editor's load) sees a chunk's tags without a separate list_tags call.
+	if tags, terr := d.listChunkTags(ctx, key, in.ID); terr != nil {
+		return errResult("get_chunk: tags: " + terr.Error()), nil
+	} else if len(tags) > 0 {
+		resp["tags"] = tags
+	}
 	// RFC BO: surface an image chunk's stored asset (metadata only — the bytes
 	// come from GET /v1/_document/asset/{id}) so a viewer knows to render an img.
 	if mt, sz, ok := d.assetMeta(ctx, key, in.ID); ok {

--- a/internal/tools/builtin/document_tags_test.go
+++ b/internal/tools/builtin/document_tags_test.go
@@ -300,6 +300,39 @@ func TestDocumentTags_ReplaceSetPresence(t *testing.T) {
 	}
 }
 
+// TestDocumentTags_GetChunkReturnsTags pins that the primary chunk read surfaces
+// the chunk's tags (RFC BS) so a reader / the editor sees them without a separate
+// list_tags call. Fail-before: get_chunk omitted the tags key entirely.
+func TestDocumentTags_GetChunkReturnsTags(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	out, _ := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"D"}`)
+	doc, root := out["document_id"].(string), out["root_chunk_id"].(string)
+	out, _ = docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+doc+`","parent_id":"`+root+`","title":"c","tags":["b/two","a/one"]}`)
+	c := out["id"].(string)
+
+	g, r := docExec(t, d, ctx, `{"op":"get_chunk","scope":"user","id":"`+c+`"}`)
+	if r.IsError {
+		t.Fatalf("get_chunk: %s", r.Text)
+	}
+	raw, ok := g["tags"].([]any)
+	if !ok {
+		t.Fatalf("get_chunk did not return tags: %v", g)
+	}
+	got := make([]string, 0, len(raw))
+	for _, e := range raw {
+		got = append(got, e.(string))
+	}
+	if !eqStrings(got, "a/one", "b/two") { // listChunkTags orders by tag
+		t.Errorf("get_chunk tags = %v, want [a/one b/two] sorted", got)
+	}
+	// An untagged chunk omits the key rather than returning an empty array.
+	out, _ = docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+doc+`","parent_id":"`+root+`","title":"untagged"}`)
+	g, _ = docExec(t, d, ctx, `{"op":"get_chunk","scope":"user","id":"`+out["id"].(string)+`"}`)
+	if _, has := g["tags"]; has {
+		t.Errorf("untagged chunk should omit tags; got %v", g)
+	}
+}
+
 // TestDocumentTags_RootFacetMirror pins the root-chunk → documents-row mirror:
 // editing a document's ROOT chunk's type/status propagates to the documents row
 // that get_document/query_documents read; editing a NON-root chunk does not.

--- a/internal/tools/builtin/document_tags_test.go
+++ b/internal/tools/builtin/document_tags_test.go
@@ -1,0 +1,518 @@
+package builtin
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"sort"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/channels"
+	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// RFC BS Phase 1 — the tags facet + document-level type/status/tags.
+
+// --- small extraction helpers ---
+
+func tagsOf(m map[string]any) []string {
+	raw, _ := m["tags"].([]any)
+	out := make([]string, 0, len(raw))
+	for _, t := range raw {
+		out = append(out, t.(string))
+	}
+	return out
+}
+
+func tagCounts(m map[string]any) map[string]int {
+	raw, _ := m["tags"].([]any)
+	out := map[string]int{}
+	for _, e := range raw {
+		em := e.(map[string]any)
+		out[em["tag"].(string)] = int(em["count"].(float64))
+	}
+	return out
+}
+
+func queryDocIDs(m map[string]any) []string {
+	raw, _ := m["documents"].([]any)
+	out := make([]string, 0, len(raw))
+	for _, e := range raw {
+		out = append(out, e.(map[string]any)["document_id"].(string))
+	}
+	return out
+}
+
+func eqStrings(got []string, want ...string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func eqSet(got []string, want ...string) bool {
+	g := append([]string(nil), got...)
+	w := append([]string(nil), want...)
+	sort.Strings(g)
+	sort.Strings(w)
+	return eqStrings(g, w...)
+}
+
+// chunkTags reads a chunk's tag names (sorted) via list_tags.
+func chunkTags(t *testing.T, d *Document, ctx context.Context, chunkID string) []string {
+	t.Helper()
+	out, r := docExec(t, d, ctx, `{"op":"list_tags","scope":"user","id":"`+chunkID+`"}`)
+	if r.IsError {
+		t.Fatalf("list_tags(%s): %s", chunkID, r.Text)
+	}
+	raw, _ := out["tags"].([]any)
+	names := make([]string, 0, len(raw))
+	for _, e := range raw {
+		names = append(names, e.(map[string]any)["tag"].(string))
+	}
+	return names
+}
+
+// countRows runs a COUNT(*) (or any single-cell SELECT) in the user scope.
+func countRows(t *testing.T, d *Document, ctx context.Context, stmt string, args ...any) int {
+	t.Helper()
+	key, _, err := d.resolveScope(ctx, "user")
+	if err != nil {
+		t.Fatalf("resolveScope: %v", err)
+	}
+	res, err := d.query(ctx, key, stmt, args...)
+	if err != nil {
+		t.Fatalf("count query: %v", err)
+	}
+	if len(res.Rows) == 0 {
+		return 0
+	}
+	return asInt(res.Rows[0][0])
+}
+
+// --- the tier-portable core (runs on sqlite AND postgres) ---
+
+// TestDocumentTags_CoreBothTiers exercises the whole Phase-1 surface — document
+// facets on create/get, chunk add/remove/list, query_chunks tag + tag_prefix, and
+// query_documents — on BOTH SQL Memory tiers, so the new DDL, the `?` rebind, the
+// tag joins, the tag_prefix LIKE, and the scope-wide UNION count are all proven on
+// postgres, not just sqlite. The postgres half is skipped without the aux DSN.
+func TestDocumentTags_CoreBothTiers(t *testing.T) {
+	t.Run("sqlite", func(t *testing.T) {
+		d, ctx, _ := documentFixture(t)
+		assertDocumentTagFacets(t, d, ctx)
+	})
+	t.Run("postgres", func(t *testing.T) {
+		d, ctx := pgDocumentOrSkip(t)
+		assertDocumentTagFacets(t, d, ctx)
+	})
+}
+
+// pgDocumentOrSkip builds a Document on the postgres SQL Memory tier, or skips.
+func pgDocumentOrSkip(t *testing.T) (*Document, context.Context) {
+	t.Helper()
+	dsn := os.Getenv("LOOMCYCLE_TEST_SQLMEM_PG_DSN")
+	if dsn == "" {
+		t.Skip("set LOOMCYCLE_TEST_SQLMEM_PG_DSN to run the postgres-tier parity half")
+	}
+	raw, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("open raw: %v", err)
+	}
+	dropAllSqlmemScopes(t, raw)
+	mgr, err := sqlmem.NewPostgres(context.Background(),
+		sqlmem.Config{PgDSN: dsn, StatementTimeoutMS: 30000, MaxRows: 1000})
+	if err != nil {
+		t.Fatalf("NewPostgres: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = mgr.Close()
+		dropAllSqlmemScopes(t, raw)
+		_ = raw.Close()
+	})
+	st, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	d := &Document{Store: st, SqlMem: mgr, Bus: channels.NewBus()}
+	ctx := tools.WithAgentName(context.Background(), "pg-tags")
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{UserID: "u1", TenantID: "tnt"})
+	return d, ctx
+}
+
+func assertDocumentTagFacets(t *testing.T, d *Document, ctx context.Context) {
+	t.Helper()
+
+	// create_document with type/status/tags → get_document returns all three.
+	out, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"RFC BS","path":"/bs/one","type":"rfc","status":"draft","tags":["area/docs","priority/high"]}`)
+	if r.IsError {
+		t.Fatalf("create_document: %s", r.Text)
+	}
+	doc1 := out["document_id"].(string)
+	root1 := out["root_chunk_id"].(string)
+
+	g, r := docExec(t, d, ctx, `{"op":"get_document","scope":"user","id":"`+doc1+`"}`)
+	if r.IsError {
+		t.Fatalf("get_document: %s", r.Text)
+	}
+	if g["type"] != "rfc" || g["status"] != "draft" {
+		t.Errorf("get_document type/status = %v/%v, want rfc/draft", g["type"], g["status"])
+	}
+	if got := tagsOf(g); !eqStrings(got, "area/docs", "priority/high") {
+		t.Errorf("document tags = %v, want [area/docs priority/high]", got)
+	}
+
+	// A chunk created WITH tags.
+	out, r = docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+doc1+`","parent_id":"`+root1+`","title":"c1","tags":["area/docs","kind/note"]}`)
+	if r.IsError {
+		t.Fatalf("create_chunk: %s", r.Text)
+	}
+	c1 := out["id"].(string)
+
+	// add_tags is incremental + idempotent (re-adding kind/note is a no-op).
+	out, r = docExec(t, d, ctx, `{"op":"add_tags","scope":"user","id":"`+c1+`","tags":["kind/note","urgent"]}`)
+	if r.IsError {
+		t.Fatalf("add_tags: %s", r.Text)
+	}
+	if got := tagsOf(out); !eqStrings(got, "area/docs", "kind/note", "urgent") {
+		t.Errorf("chunk tags after add = %v", got)
+	}
+	// remove_tags.
+	out, r = docExec(t, d, ctx, `{"op":"remove_tags","scope":"user","id":"`+c1+`","tags":["urgent"]}`)
+	if r.IsError {
+		t.Fatalf("remove_tags: %s", r.Text)
+	}
+	if got := tagsOf(out); !eqStrings(got, "area/docs", "kind/note") {
+		t.Errorf("chunk tags after remove = %v", got)
+	}
+
+	// list_tags: chunk, document, scope-wide (chunk+document combined counts).
+	lt, _ := docExec(t, d, ctx, `{"op":"list_tags","scope":"user","id":"`+c1+`"}`)
+	if cc := tagCounts(lt); cc["area/docs"] != 1 || cc["kind/note"] != 1 {
+		t.Errorf("list_tags(chunk) = %v", cc)
+	}
+	lt, _ = docExec(t, d, ctx, `{"op":"list_tags","scope":"user","document_id":"`+doc1+`"}`)
+	if dc := tagCounts(lt); dc["area/docs"] != 1 || dc["priority/high"] != 1 {
+		t.Errorf("list_tags(document) = %v", dc)
+	}
+	lt, _ = docExec(t, d, ctx, `{"op":"list_tags","scope":"user"}`)
+	if sc := tagCounts(lt); sc["area/docs"] != 2 { // on the chunk AND the document
+		t.Errorf("scope-wide count(area/docs) = %d, want 2: %v", sc["area/docs"], sc)
+	}
+
+	// query_chunks by exact tag.
+	q, _ := docExec(t, d, ctx, `{"op":"query_chunks","scope":"user","tag":"kind/note"}`)
+	if rows, _ := q["chunks"].([]any); len(rows) != 1 {
+		t.Errorf("query_chunks tag=kind/note = %d rows, want 1", len(rows))
+	}
+	// tag_prefix "area" matches the nested "area/docs".
+	q, _ = docExec(t, d, ctx, `{"op":"query_chunks","scope":"user","tag_prefix":"area"}`)
+	if rows, _ := q["chunks"].([]any); len(rows) != 1 {
+		t.Errorf("query_chunks tag_prefix=area = %d rows, want 1", len(rows))
+	}
+	// tag_prefix "are" must NOT prefix-match "area/docs" (the boundary is a '/').
+	q, _ = docExec(t, d, ctx, `{"op":"query_chunks","scope":"user","tag_prefix":"are"}`)
+	if rows, _ := q["chunks"].([]any); len(rows) != 0 {
+		t.Errorf("query_chunks tag_prefix=are = %d rows, want 0 (must not match area)", len(rows))
+	}
+
+	// A second document for the query_documents filters.
+	out, r = docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Note two","path":"/bs/two","type":"note","status":"published","tags":["priority/high","kind/misc"]}`)
+	if r.IsError {
+		t.Fatalf("create_document doc2: %s", r.Text)
+	}
+	doc2 := out["document_id"].(string)
+
+	qd, _ := docExec(t, d, ctx, `{"op":"query_documents","scope":"user","type":"rfc"}`)
+	if got := queryDocIDs(qd); !eqSet(got, doc1) {
+		t.Errorf("query_documents type=rfc = %v, want [doc1]", got)
+	}
+	qd, _ = docExec(t, d, ctx, `{"op":"query_documents","scope":"user","status":"published"}`)
+	if got := queryDocIDs(qd); !eqSet(got, doc2) {
+		t.Errorf("query_documents status=published = %v, want [doc2]", got)
+	}
+	qd, _ = docExec(t, d, ctx, `{"op":"query_documents","scope":"user","tag":"priority/high"}`)
+	if got := queryDocIDs(qd); !eqSet(got, doc1, doc2) {
+		t.Errorf("query_documents tag=priority/high = %v, want both", got)
+	}
+	qd, _ = docExec(t, d, ctx, `{"op":"query_documents","scope":"user","under_path":"/bs"}`)
+	if got := queryDocIDs(qd); !eqSet(got, doc1, doc2) {
+		t.Errorf("query_documents under_path=/bs = %v, want both", got)
+	}
+	// Combined filters narrow to doc1.
+	qd, _ = docExec(t, d, ctx, `{"op":"query_documents","scope":"user","type":"rfc","tag":"priority/high"}`)
+	if got := queryDocIDs(qd); !eqSet(got, doc1) {
+		t.Errorf("query_documents type=rfc&tag=priority/high = %v, want [doc1]", got)
+	}
+}
+
+// --- sqlite-only behavioural tests ---
+
+// TestDocumentTags_ReplaceSetPresence pins the unset-vs-empty semantics of the
+// `tags` field on update_chunk: an omitted key leaves the tags untouched, a
+// present `[]` clears them, a present non-empty list replaces the set wholesale.
+// Fail-before: if update_chunk ignored `tags`, both the replace and the clear
+// steps would leave the original [x,y] and the assertions would fail.
+func TestDocumentTags_ReplaceSetPresence(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	out, _ := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"D"}`)
+	doc, root := out["document_id"].(string), out["root_chunk_id"].(string)
+	out, _ = docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+doc+`","parent_id":"`+root+`","title":"c","tags":["x","y"]}`)
+	c := out["id"].(string)
+	rev := int(out["revision"].(float64))
+
+	// Absent tags (only a body change) → tags untouched.
+	out, r := docExec(t, d, ctx, `{"op":"update_chunk","scope":"user","id":"`+c+`","revision":`+strconv.Itoa(rev)+`,"body":"z"}`)
+	if r.IsError {
+		t.Fatalf("update body: %s", r.Text)
+	}
+	rev = int(out["revision"].(float64))
+	if got := chunkTags(t, d, ctx, c); !eqStrings(got, "x", "y") {
+		t.Errorf("absent tags must leave them; got %v", got)
+	}
+
+	// Present non-empty → replace.
+	out, r = docExec(t, d, ctx, `{"op":"update_chunk","scope":"user","id":"`+c+`","revision":`+strconv.Itoa(rev)+`,"tags":["z"]}`)
+	if r.IsError {
+		t.Fatalf("update tags replace: %s", r.Text)
+	}
+	rev = int(out["revision"].(float64))
+	if got := chunkTags(t, d, ctx, c); !eqStrings(got, "z") {
+		t.Errorf("replace-set must yield [z]; got %v", got)
+	}
+
+	// Present empty → clear.
+	if _, r := docExec(t, d, ctx, `{"op":"update_chunk","scope":"user","id":"`+c+`","revision":`+strconv.Itoa(rev)+`,"tags":[]}`); r.IsError {
+		t.Fatalf("update tags clear: %s", r.Text)
+	}
+	if got := chunkTags(t, d, ctx, c); len(got) != 0 {
+		t.Errorf("present-empty tags must clear; got %v", got)
+	}
+}
+
+// TestDocumentTags_RootFacetMirror pins the root-chunk → documents-row mirror:
+// editing a document's ROOT chunk's type/status propagates to the documents row
+// that get_document/query_documents read; editing a NON-root chunk does not.
+// Fail-before: without the mirror, get_document (which reads the documents row)
+// shows no type after the root edit.
+func TestDocumentTags_RootFacetMirror(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	out, _ := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Doc"}`)
+	doc, root := out["document_id"].(string), out["root_chunk_id"].(string)
+
+	// Fresh: the documents row has no type yet.
+	g, _ := docExec(t, d, ctx, `{"op":"get_document","scope":"user","id":"`+doc+`"}`)
+	if _, has := g["type"]; has {
+		t.Errorf("fresh document should have no type: %v", g)
+	}
+
+	// Editing the ROOT chunk mirrors onto the documents row.
+	if _, r := docExec(t, d, ctx, `{"op":"update_chunk","scope":"user","id":"`+root+`","revision":1,"type":"rfc","status":"done"}`); r.IsError {
+		t.Fatalf("update root: %s", r.Text)
+	}
+	g, _ = docExec(t, d, ctx, `{"op":"get_document","scope":"user","id":"`+doc+`"}`)
+	if g["type"] != "rfc" || g["status"] != "done" {
+		t.Errorf("root edit did not mirror onto the documents row: %v", g)
+	}
+	// query_documents (also reads the documents row) sees it too.
+	qd, _ := docExec(t, d, ctx, `{"op":"query_documents","scope":"user","type":"rfc","status":"done"}`)
+	if got := queryDocIDs(qd); !eqSet(got, doc) {
+		t.Errorf("query_documents after mirror = %v, want [doc]", got)
+	}
+
+	// A NON-root chunk's type change must NOT touch the documents row.
+	out, _ = docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+doc+`","parent_id":"`+root+`","title":"c","type":"section"}`)
+	c, crev := out["id"].(string), int(out["revision"].(float64))
+	if _, r := docExec(t, d, ctx, `{"op":"update_chunk","scope":"user","id":"`+c+`","revision":`+strconv.Itoa(crev)+`,"type":"appendix"}`); r.IsError {
+		t.Fatalf("update non-root: %s", r.Text)
+	}
+	g, _ = docExec(t, d, ctx, `{"op":"get_document","scope":"user","id":"`+doc+`"}`)
+	if g["type"] != "rfc" {
+		t.Errorf("a non-root chunk change leaked into the documents row: %v", g)
+	}
+
+	// set_asset also writes chunks.type (='image'); on a root chunk it must mirror
+	// too, or an image-rooted document's get_document type goes stale.
+	const png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8AARgwMDAwMAA8mAf/hZ0ZzAAAAAElFTkSuQmCC"
+	if _, r := docExec(t, d, ctx, `{"op":"set_asset","scope":"user","id":"`+root+`","media_type":"image/png","data":"`+png+`"}`); r.IsError {
+		t.Fatalf("set_asset on root: %s", r.Text)
+	}
+	g, _ = docExec(t, d, ctx, `{"op":"get_document","scope":"user","id":"`+doc+`"}`)
+	if g["type"] != "image" {
+		t.Errorf("set_asset on the root did not mirror type=image onto the documents row: %v", g)
+	}
+}
+
+// TestDocumentFacets_MigrationBackfill pins migrateDocumentFacets: a scope
+// provisioned BEFORE this change (documents has no type/status column) gets the
+// columns added on the next ensureSchema AND backfilled from each document's root
+// chunk. Fail-before: without the migration the SELECT errors (no such column);
+// without the backfill the value reads NULL.
+func TestDocumentFacets_MigrationBackfill(t *testing.T) {
+	s, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	mgr, err := sqlmem.New(sqlmem.Config{Root: t.TempDir()})
+	if err != nil {
+		t.Fatalf("sqlmem.New: %v", err)
+	}
+	t.Cleanup(func() { _ = mgr.Close() })
+	d := &Document{Store: s, SqlMem: mgr, Bus: channels.NewBus()}
+	ctx := tools.WithAgentName(context.Background(), "doc-agent")
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{UserID: "u1", TenantID: "tnt"})
+	key, _, err := d.resolveScope(ctx, "user")
+	if err != nil {
+		t.Fatalf("resolveScope: %v", err)
+	}
+	now := time.Now().UnixNano()
+
+	// Provision the OLD pre-RFC-BS shape directly (documents WITHOUT type/status),
+	// before any ensureSchema runs, so the migration has real work to do.
+	if err := d.exec(ctx, key, `CREATE TABLE documents (id TEXT PRIMARY KEY, title TEXT NOT NULL, root_chunk_id TEXT NOT NULL, created_at BIGINT NOT NULL, updated_at BIGINT NOT NULL)`); err != nil {
+		t.Fatalf("old documents DDL: %v", err)
+	}
+	if err := d.exec(ctx, key, `CREATE TABLE chunks (id TEXT PRIMARY KEY, document_id TEXT NOT NULL, parent_id TEXT, position INTEGER NOT NULL, type TEXT, status TEXT, title TEXT NOT NULL, created_at BIGINT NOT NULL, updated_at BIGINT NOT NULL, revision INTEGER NOT NULL DEFAULT 1)`); err != nil {
+		t.Fatalf("chunks DDL: %v", err)
+	}
+	// A document whose ROOT chunk carries type/status but whose documents row does not.
+	if err := d.exec(ctx, key, `INSERT INTO documents (id, title, root_chunk_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`, "doc1", "Old", "root1", now, now); err != nil {
+		t.Fatalf("insert document: %v", err)
+	}
+	if err := d.exec(ctx, key, `INSERT INTO chunks (id, document_id, parent_id, position, type, status, title, created_at, updated_at, revision) VALUES (?, ?, NULL, 0, ?, ?, ?, ?, ?, 1)`, "root1", "doc1", "rfc", "done", "Old", now, now); err != nil {
+		t.Fatalf("insert root chunk: %v", err)
+	}
+
+	// ensureSchema runs the migration: add the columns + backfill from the root.
+	if err := d.ensureSchema(ctx, key); err != nil {
+		t.Fatalf("ensureSchema: %v", err)
+	}
+	res, err := d.query(ctx, key, `SELECT type, status FROM documents WHERE id = ?`, "doc1")
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if len(res.Rows) != 1 || asStr(res.Rows[0][0]) != "rfc" || asStr(res.Rows[0][1]) != "done" {
+		t.Errorf("backfill did not populate type/status from the root chunk: %v", res.Rows)
+	}
+}
+
+// TestDocumentTags_DeleteCascadeNoOrphans pins the explicit tag-row cascade:
+// delete_chunk removes the deleted subtree's chunk_tags, and delete_document
+// removes both the remaining chunk_tags and the document_tags — no orphan tag
+// rows survive. Fail-before: without the cascade the DELETEs leave rows behind.
+func TestDocumentTags_DeleteCascadeNoOrphans(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	out, _ := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"D","tags":["dtag"]}`)
+	doc, root := out["document_id"].(string), out["root_chunk_id"].(string)
+	out, _ = docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+doc+`","parent_id":"`+root+`","title":"p","tags":["ptag"]}`)
+	p := out["id"].(string)
+	out, _ = docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+doc+`","parent_id":"`+p+`","title":"child","tags":["ctag"]}`)
+	child := out["id"].(string)
+
+	// delete_chunk(p) cascades to child → both chunks' tag rows are gone.
+	if _, r := docExec(t, d, ctx, `{"op":"delete_chunk","scope":"user","id":"`+p+`"}`); r.IsError {
+		t.Fatalf("delete_chunk: %s", r.Text)
+	}
+	if n := countRows(t, d, ctx, `SELECT COUNT(*) FROM chunk_tags WHERE chunk_id IN (?, ?)`, p, child); n != 0 {
+		t.Errorf("chunk_tags orphaned after delete_chunk cascade: %d", n)
+	}
+
+	// delete_document removes the document's own tag + any remaining chunk tags.
+	if _, r := docExec(t, d, ctx, `{"op":"delete_document","scope":"user","id":"`+doc+`"}`); r.IsError {
+		t.Fatalf("delete_document: %s", r.Text)
+	}
+	if n := countRows(t, d, ctx, `SELECT COUNT(*) FROM document_tags WHERE document_id = ?`, doc); n != 0 {
+		t.Errorf("document_tags orphaned after delete_document: %d", n)
+	}
+	if n := countRows(t, d, ctx, `SELECT COUNT(*) FROM chunk_tags`); n != 0 {
+		t.Errorf("chunk_tags survived delete_document: %d", n)
+	}
+}
+
+// TestDocumentTags_UpsertPath pins that upsert_chunk honours `tags` on BOTH its
+// create and update paths (the update path lives in the entity file and does not
+// touch tags, so the dispatch wrapper applies them), and that an upsert onto a
+// root chunk mirrors its type/status onto the documents row.
+func TestDocumentTags_UpsertPath(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	out, _ := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"D"}`)
+	doc, root := out["document_id"].(string), out["root_chunk_id"].(string)
+
+	// First upsert CREATES the chunk (create path → tags applied via createChunk).
+	out, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+doc+`","parent_id":"`+root+`","natural_key":"ent:x","title":"X","tags":["t1"]}`)
+	if r.IsError {
+		t.Fatalf("upsert create: %s", r.Text)
+	}
+	if out["created"] != true {
+		t.Fatalf("first upsert should create: %v", out)
+	}
+	c := out["id"].(string)
+	if got := chunkTags(t, d, ctx, c); !eqStrings(got, "t1") {
+		t.Errorf("upsert-create tags = %v, want [t1]", got)
+	}
+
+	// Second upsert UPDATES the same chunk (update path → the wrapper replace-sets).
+	out, r = docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+doc+`","natural_key":"ent:x","title":"X","tags":["t2","t3"]}`)
+	if r.IsError {
+		t.Fatalf("upsert update: %s", r.Text)
+	}
+	if out["created"] != false {
+		t.Fatalf("second upsert should update: %v", out)
+	}
+	if got := chunkTags(t, d, ctx, c); !eqStrings(got, "t2", "t3") {
+		t.Errorf("upsert-update replace-set tags = %v, want [t2 t3]", got)
+	}
+
+	// Map a natural_key onto the ROOT chunk so an upsert resolves to it, then
+	// upsert type/status → the wrapper must mirror onto the documents row.
+	key, _, err := d.resolveScope(ctx, "user")
+	if err != nil {
+		t.Fatalf("resolveScope: %v", err)
+	}
+	if err := d.exec(ctx, key, `INSERT INTO chunk_memory_meta (chunk_id, natural_key, created_at) VALUES (?, ?, ?)`, root, "ent:root", time.Now().UnixNano()); err != nil {
+		t.Fatalf("seed root natural_key: %v", err)
+	}
+	if _, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","natural_key":"ent:root","title":"Root","type":"rfc","status":"final"}`); r.IsError {
+		t.Fatalf("upsert root: %s", r.Text)
+	}
+	g, _ := docExec(t, d, ctx, `{"op":"get_document","scope":"user","id":"`+doc+`"}`)
+	if g["type"] != "rfc" || g["status"] != "final" {
+		t.Errorf("upsert on the root did not mirror onto the documents row: %v", g)
+	}
+}
+
+// TestDocumentTags_TargetValidation pins that add/remove/list_tags refuse a
+// phantom target (no tag rows written against a non-existent chunk/document) and
+// that add/remove require a `tags` list.
+func TestDocumentTags_TargetValidation(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"D"}`) // ensure schema
+
+	if _, r := docExec(t, d, ctx, `{"op":"add_tags","scope":"user","id":"ghost","tags":["x"]}`); !r.IsError {
+		t.Errorf("add_tags on a non-existent chunk should refuse")
+	}
+	if _, r := docExec(t, d, ctx, `{"op":"add_tags","scope":"user","document_id":"ghost","tags":["x"]}`); !r.IsError {
+		t.Errorf("add_tags on a non-existent document should refuse")
+	}
+	if _, r := docExec(t, d, ctx, `{"op":"add_tags","scope":"user","id":"whatever"}`); !r.IsError {
+		t.Errorf("add_tags without tags should refuse")
+	}
+	// No phantom rows were written for the refused targets.
+	if n := countRows(t, d, ctx, `SELECT COUNT(*) FROM chunk_tags`); n != 0 {
+		t.Errorf("phantom chunk_tags rows written: %d", n)
+	}
+	if n := countRows(t, d, ctx, `SELECT COUNT(*) FROM document_tags`); n != 0 {
+		t.Errorf("phantom document_tags rows written: %d", n)
+	}
+}

--- a/packages/explorer/src/components/ChunkEditorModal.tsx
+++ b/packages/explorer/src/components/ChunkEditorModal.tsx
@@ -29,6 +29,9 @@ export default function ChunkEditorModal({ chunk, scope, browse, onClose, onSave
   const [fieldsText, setFieldsText] = useState(
     chunk.fields ? JSON.stringify(chunk.fields, null, 2) : "",
   );
+  // Tags (RFC BS) edit as a comma-separated list; the editor is authoritative, so
+  // save always replace-sets to this value (empty clears). Nested tags use a slash.
+  const [tagsText, setTagsText] = useState((chunk.tags ?? []).join(", "));
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [conflict, setConflict] = useState(false);
@@ -68,11 +71,14 @@ export default function ChunkEditorModal({ chunk, scope, browse, onClose, onSave
     e.preventDefault();
     setErr(null);
     setConflict(false);
-    const patch: { body: string; title: string; type: string; status: string; fields?: unknown } = {
+    const patch: { body: string; title: string; type: string; status: string; tags: string[]; fields?: unknown } = {
       body,
       title,
       type,
       status,
+      // Parse the comma-separated list; replace-set is intentional (the box shows
+      // the chunk's tags, so saving makes it exactly what's in the box).
+      tags: tagsText.split(",").map((t) => t.trim()).filter((t) => t !== ""),
     };
     // Send fields only when non-empty + valid JSON (a blank box leaves fields
     // untouched rather than clobbering them).
@@ -143,6 +149,15 @@ export default function ChunkEditorModal({ chunk, scope, browse, onClose, onSave
             />
           </label>
         </div>
+        <label className="path-field">
+          <span>Tags</span>
+          <input
+            className="path-modal-input"
+            value={tagsText}
+            placeholder="comma-separated, nest with a slash: area/sub, priority/high"
+            onChange={(e) => setTagsText(e.target.value)}
+          />
+        </label>
         {isImage && (
           <label className="path-field">
             <span>Replace image</span>

--- a/packages/explorer/src/lib/dataLayer.tsx
+++ b/packages/explorer/src/lib/dataLayer.tsx
@@ -21,6 +21,9 @@ export interface ChunkPatch {
   title?: string;
   status?: string;
   type?: string;
+  // tags (RFC BS) replace-set the chunk's whole tag set when present ([] clears);
+  // the editor always sends the parsed set, so it is authoritative for what shows.
+  tags?: string[];
 }
 
 // ExplorerDataLayer is the narrow data contract the Path / Document components

--- a/packages/explorer/src/types.ts
+++ b/packages/explorer/src/types.ts
@@ -57,6 +57,9 @@ export interface ChunkRow {
 export interface ChunkDetail extends ChunkRow {
   body: string;
   fields?: unknown;
+  // tags (RFC BS) — the chunk's tag set, returned by get_chunk (omitted when the
+  // chunk has none). Nested tags use a slash (area/sub/topic).
+  tags?: string[];
   // asset (RFC BO) is present on an image chunk — metadata only; the bytes are
   // fetched from GET /v1/_document/asset/{id} via documentAssetObjectUrl.
   asset?: { media_type: string; size: number };


### PR DESCRIPTION
Phase 1 (the confirmed core) of **RFC BS — Document structure primitives** (`/loomcycle/rfcs/document-structure-primitives`; plan `/loomcycle/docs/plans/rfc-bs-plan`). This is the loomcycle-core **data** half — the queryable primitives loomboard (RFC BT) will render. The runtime UI stays deliberately minimal; boards/graph/canvas are RFC BT.

## Why
A chunk's `fields` live in the Memory k/v blob, unreachable from SQL, so a tag stored there could never be a query axis — tags therefore get their own SQL join tables. And a document's kind/state lived only on its root chunk, so "every draft RFC" meant querying root chunks — awkward for a board of documents.

## What
- **Schema** (self-provisioned in `ensureSchema`): `chunk_tags` + `document_tags` join tables (multi-valued, indexed, nested via a slash convention); `documents.type`/`status` columns via a guarded `migrateDocumentFacets` (probe-before-alter, both tiers, `ADD COLUMN` works on sqlite + postgres) + a backfill from each doc's root chunk.
- **Design as confirmed:** `type`/`status` stay single-valued columns; the root chunk is authoritative and `documents.type/status` is a denormalized mirror kept in sync on every root write (`create_document`, `update_chunk`, `upsert_chunk`, `SetChunkStatus`, `import_md`, and `set_asset`'s `type='image'`).
- **Ops:** tags on `create`/`update`/`upsert_chunk` + `create_document` (replace-set: empty clears, absent leaves); `add_tags`/`remove_tags`/`list_tags` (chunk/document/scope); `query_documents` (type/status/tag/under_path); `query_chunks` `tag` + `tag_prefix`. `delete_chunk`/`delete_document` cascade the tag rows. `get_chunk`/`get_document` return tags.
- **TS adapter** (`@loomcycle/client`): resynced the drifted `DocumentToolInput.op` union to the backend + added the tag fields (type-only; the passthrough already carried them).
- **Python adapter:** no change — `document()` is a dict passthrough, op-agnostic.
- **Minimal UI** (`@loomcycle/explorer`): a Tags field in the chunk editor (comma-separated, slash-nested), replace-set on save.

## Two gaps caught in self-review (both fixed here)
- `set_asset` sets `type='image'` on a chunk with no mirror → an image-rooted document's `get_document` type would go stale. Added the mirror + a fail-before regression assertion.
- The initial backend added tag writes/filters/`list_tags` but `get_chunk` didn't **return** a chunk's tags → a reader/the editor needed a second `list_tags` call. `get_chunk` now surfaces `tags`.

## Tested
- `go test ./...` — exit 0, zero failures. New `document_tags_test.go`: core tier-portable path (sqlite + postgres subtest, runs in CI), replace-set presence, the root-facet mirror (incl. `set_asset` on a root), migration backfill, delete cascade (no orphans), upsert create+update paths, target validation, and `get_chunk` returns tags. Each fail-before verified.
- TS `tsc --noEmit` clean; explorer `vitest` (13) pass; `make build-ui` embeds the SPA clean.

## Notes
- Additive only — no wire break; with no tag/facet fields set, existing calls are byte-identical.
- Out of scope (later RFC BS phases): name-links→edges (P2), history (P3), JSON Canvas (P4). REVISIONS entry lands at release naming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD