### PR TITLE
feat(document): transclusion — expand ![[...]] embeds in export_md (RFC BS P2b)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
           # and `go test ./...` cannot run both packages against it concurrently.
           # Add every new postgres-tier test in this package here, or it is
           # decoration rather than a gate.
-          go test -count=1 -run 'TestEmbedDirective|TestEncodePgvector|TestResolveEmbedArgs|TestMemorySQL_EmbedDirective|TestDocument_Postgres|TestSidecar_PostgresTierParity|TestUpsert_ReObservation|TestConfidence_' ./internal/tools/builtin/...
+          go test -count=1 -run 'TestEmbedDirective|TestEncodePgvector|TestResolveEmbedArgs|TestMemorySQL_EmbedDirective|TestDocument_Postgres|TestDocumentTags_CoreBothTiers|TestDocumentNameLinks_CoreBothTiers|TestSidecar_PostgresTierParity|TestUpsert_ReObservation|TestConfidence_' ./internal/tools/builtin/...
 
   runtime-codejs:
     name: Runtime suites (code-js)

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -2170,6 +2170,50 @@ func (d *Document) resolveLinkTarget(ctx context.Context, key sqlmem.ScopeKey, t
 	return "", false
 }
 
+// resolveEmbedTarget maps a `![[target]]` embed's inner string to the chunk id
+// whose body is transcluded, CONFINED to the writer's own scope/tenant. It is a
+// superset of resolveLinkTarget (the Phase-2a link resolver): an embed also
+// accepts an exact chunk id and a `/path#Section` anchor, so a document can
+// transclude ONE named chunk — not only a whole document's root. RFC BS Phase 2b.
+//
+// Resolution order:
+//   - an exact chunk id (`![[<chunk-uuid>]]` embeds that chunk directly);
+//   - a `/path#Section` anchor → resolve /path to a document, then its chunk
+//     titled `Section` (lowest position wins on a title tie). An anchor that
+//     names no such chunk stays UNRESOLVED — it does not fall back to the
+//     document root, because the author asked for a specific section;
+//   - otherwise resolveLinkTarget (path→root chunk, or an exact title).
+//
+// ok=false → the caller leaves the `![[…]]` literal.
+func (d *Document) resolveEmbedTarget(ctx context.Context, key sqlmem.ScopeKey, target string) (string, bool) {
+	// An exact chunk id embeds that one chunk directly. Checked first so a
+	// uuid-shaped target is never mistaken for a title.
+	if res, err := d.query(ctx, key, `SELECT id FROM chunks WHERE id = ? LIMIT 1`, target); err == nil && len(res.Rows) > 0 {
+		if id := asStr(res.Rows[0][0]); id != "" {
+			return id, true
+		}
+	}
+	// A `/path#Section` anchor → the named chunk within the path's document.
+	if strings.HasPrefix(target, "/") {
+		if i := strings.IndexByte(target, '#'); i >= 0 {
+			pathPart, anchor := target[:i], strings.TrimSpace(target[i+1:])
+			if anchor != "" {
+				docID, err := d.docIDFromInput(ctx, key, docInput{Path: pathPart})
+				if err == nil && docID != "" {
+					if res, err := d.query(ctx, key, `SELECT id FROM chunks WHERE document_id = ? AND title = ? ORDER BY position LIMIT 1`, docID, anchor); err == nil && len(res.Rows) > 0 {
+						if id := asStr(res.Rows[0][0]); id != "" {
+							return id, true
+						}
+					}
+				}
+				// A `#Section` that matched nothing stays literal (no root fallback).
+				return "", false
+			}
+		}
+	}
+	return d.resolveLinkTarget(ctx, key, target)
+}
+
 // reconcileNameLinks re-derives fromChunkID's inline `[[name]]` link edges from
 // its body on every body write (create_chunk / a body-bearing update_chunk):
 // each resolvable target becomes a `references` edge tagged auto=1. This is the
@@ -2341,6 +2385,71 @@ func (d *Document) documentsUnderPath(ctx context.Context, key sqlmem.ScopeKey, 
 // headingReplacer collapses newlines so a chunk title stays on one heading line.
 var headingReplacer = strings.NewReplacer("\r\n", " ", "\n", " ", "\r", " ")
 
+// embedRe matches a transclusion `![[target]]` — the leading `!` is what
+// distinguishes an EMBED (expanded inline at clean-export time) from a
+// `[[link]]` (Phase-2a: a graph edge, never expanded). The inner target holds
+// no brackets. RFC BS Phase 2b.
+var embedRe = regexp.MustCompile(`!\[\[([^\[\]]+)\]\]`)
+
+// maxEmbedDepth bounds how deep transclusion recurses (a chain of embeds each
+// pulling in another). A cycle is already caught by the chain guard; this cap
+// additionally bounds a very long ACYCLIC chain so export can't run away.
+const maxEmbedDepth = 4
+
+// expandTransclusions returns body with each resolvable `![[target]]` replaced
+// by the target chunk's own (recursively expanded) body. RFC BS Phase 2b.
+//
+// chain holds the chunk ids on the current expansion path (seeded with the
+// chunk being rendered) so a self- or mutual-embed leaves a literal instead of
+// looping; depth caps a long acyclic chain. An unresolved target, a cycle, the
+// depth cap, or a body-read fault all degrade to the LITERAL `![[target]]` —
+// transclusion is a rendering nicety, never a correctness gate, so it must not
+// abort the export walk.
+//
+// Iterates FindAllStringSubmatchIndex rather than ReplaceAllStringFunc because
+// each match needs its own resolve + cycle/depth decision, and the gaps between
+// matches are copied verbatim.
+func (d *Document) expandTransclusions(ctx context.Context, key sqlmem.ScopeKey, mscope store.MemoryScope, body string, chain []string, depth int) string {
+	matches := embedRe.FindAllStringSubmatchIndex(body, -1)
+	if len(matches) == 0 {
+		return body
+	}
+	var b strings.Builder
+	last := 0
+	for _, m := range matches {
+		// m = [matchStart, matchEnd, groupStart, groupEnd].
+		b.WriteString(body[last:m[0]]) // the gap before this embed, verbatim
+		last = m[1]
+		token := body[m[0]:m[1]] // the literal `![[target]]`
+		target := strings.TrimSpace(body[m[2]:m[3]])
+		targetID, ok := d.resolveEmbedTarget(ctx, key, target)
+		switch {
+		case !ok, inChain(chain, targetID), depth >= maxEmbedDepth:
+			// Unresolved, would loop, or too deep → leave the embed literal.
+			b.WriteString(token)
+		default:
+			cb, err := d.readBody(ctx, mscope, key.ScopeID, targetID)
+			if err != nil {
+				b.WriteString(token) // a store fault degrades gracefully
+				continue
+			}
+			b.WriteString(d.expandTransclusions(ctx, key, mscope, cb.Body, append(chain, targetID), depth+1))
+		}
+	}
+	b.WriteString(body[last:]) // the tail after the last embed
+	return b.String()
+}
+
+// inChain reports whether id is already on the expansion path (the cycle guard).
+func inChain(chain []string, id string) bool {
+	for _, c := range chain {
+		if c == id {
+			return true
+		}
+	}
+	return false
+}
+
 // exportMD renders a document to Markdown (RFC AK §4.5 / RFC AM Phase 2).
 // Walks the chunk hierarchy from the root(s) depth-first in position order:
 // each chunk is a heading (level = depth+1, capped at 6) followed by its
@@ -2441,7 +2550,16 @@ func (d *Document) exportMD(ctx context.Context, key sqlmem.ScopeKey, mscope sto
 			}
 		default:
 			if cb.Body != "" {
-				b.WriteString("\n" + cb.Body + "\n")
+				body := cb.Body
+				// RFC BS Phase 2b — expand `![[…]]` embeds ONLY in clean mode.
+				// In metadata/round-trip mode the body stays verbatim, or an
+				// export(include_metadata=true)→import_md would bake the expanded
+				// copy in and lose the embed. The chain seeds with THIS chunk's id
+				// so a chunk embedding itself is caught as a cycle.
+				if !includeMeta {
+					body = d.expandTransclusions(ctx, key, mscope, cb.Body, []string{row.ID}, 0)
+				}
+				b.WriteString("\n" + body + "\n")
 			}
 		}
 		b.WriteString("\n")

--- a/internal/tools/builtin/document_transclusion_test.go
+++ b/internal/tools/builtin/document_transclusion_test.go
@@ -1,0 +1,251 @@
+package builtin
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// RFC BS Phase 2b — transclusion (`![[target]]` embeds) in export_md.
+//
+// A chunk body's `![[target]]` embed is expanded inline to the referenced
+// chunk's (recursively expanded) body — but ONLY in clean export mode
+// (include_metadata=false). In metadata/round-trip mode the body stays verbatim
+// so an export→import cannot bake the expanded copy in and lose the embed; that
+// invariant is the load-bearing one, pinned by
+// TestDocumentTransclusion_MetadataModeKeepsEmbedLiteral. The resolution paths
+// (path→root, `/path#Section` anchor, title, exact chunk id) all touch SQL
+// Memory, so the same assertTransclusionCore body runs on BOTH tiers: the
+// always-on sqlite tier via TestDocumentTransclusion_Core, and the postgres tier
+// via TestDocument_PostgresTransclusion. That second name is deliberate — CI's
+// "SQL Memory postgres tier" step runs builtin tests through an explicit -run
+// allowlist, and only a TestDocument_Postgres* name is inside it, so a
+// Transclusion-prefixed name would skip the postgres tier in CI. The cycle/depth
+// guards are tier-independent Go logic and run sqlite-only.
+
+// setChunkBody rewrites a chunk's body (reading its current revision first). Used
+// to give a target chunk a distinctive body to assert against post-expansion.
+func setChunkBody(t *testing.T, d *Document, ctx context.Context, id, body string) {
+	t.Helper()
+	g, r := docExec(t, d, ctx, `{"op":"get_chunk","scope":"user","id":"`+id+`"}`)
+	if r.IsError {
+		t.Fatalf("get_chunk %s: %s", id, r.Text)
+	}
+	rev := int(g["revision"].(float64))
+	if _, r := docExec(t, d, ctx, `{"op":"update_chunk","scope":"user","id":"`+id+`","revision":`+strconv.Itoa(rev)+`,"body":"`+body+`"}`); r.IsError {
+		t.Fatalf("update_chunk %s: %s", id, r.Text)
+	}
+}
+
+// exportMarkdown runs export_md and returns the rendered markdown; meta selects
+// include_metadata (true = round-trip mode, false = clean mode).
+func exportMarkdown(t *testing.T, d *Document, ctx context.Context, docID string, meta bool) string {
+	t.Helper()
+	flag := "false"
+	if meta {
+		flag = "true"
+	}
+	out, r := docExec(t, d, ctx, `{"op":"export_md","scope":"user","document_id":"`+docID+`","include_metadata":`+flag+`}`)
+	if r.IsError {
+		t.Fatalf("export_md: %s", r.Text)
+	}
+	return out["markdown"].(string)
+}
+
+// --- the tier-portable core (runs on sqlite AND postgres) ---
+
+// assertTransclusionCore exercises the four resolution paths that touch SQL
+// Memory — a path embed (→ document root body), a `/path#Section` anchor embed
+// (→ the titled chunk), a title embed, and an exact chunk-id embed — plus the two
+// "left literal" cases (an unresolved embed and a bare `[[link]]`, which is NOT a
+// transclusion). Called once per SQL Memory tier.
+
+// TestDocumentTransclusion_Core runs the core on the always-on sqlite tier.
+func TestDocumentTransclusion_Core(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	assertTransclusionCore(t, d, ctx)
+}
+
+// TestDocument_PostgresTransclusion runs the SAME core on the postgres SQL Memory
+// tier. Named with the TestDocument_Postgres* prefix so CI's postgres-tier -run
+// allowlist actually gates it (see the file header); skips without the aux DSN.
+func TestDocument_PostgresTransclusion(t *testing.T) {
+	d, ctx := pgDocumentOrSkip(t)
+	assertTransclusionCore(t, d, ctx)
+}
+
+func assertTransclusionCore(t *testing.T, d *Document, ctx context.Context) {
+	t.Helper()
+
+	// Target document, path-named, with a distinctive ROOT body and two children.
+	out, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Alpha","path":"/tr/alpha"}`)
+	if r.IsError {
+		t.Fatalf("create target: %s", r.Text)
+	}
+	tgtDoc, tgtRoot := out["document_id"].(string), out["root_chunk_id"].(string)
+	setChunkBody(t, d, ctx, tgtRoot, "ALPHA-ROOT-BODY")
+
+	out, r = docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+tgtDoc+`","parent_id":"`+tgtRoot+`","title":"Section","body":"SECTION-BODY"}`)
+	if r.IsError {
+		t.Fatalf("create Section: %s", r.Text)
+	}
+	out, r = docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+tgtDoc+`","parent_id":"`+tgtRoot+`","title":"Widget","body":"WIDGET-BODY"}`)
+	if r.IsError {
+		t.Fatalf("create Widget: %s", r.Text)
+	}
+	widgetID := out["id"].(string)
+
+	// Source document whose chunks carry the embeds.
+	out, r = docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Src","path":"/tr/src"}`)
+	if r.IsError {
+		t.Fatalf("create source: %s", r.Text)
+	}
+	srcDoc, srcRoot := out["document_id"].(string), out["root_chunk_id"].(string)
+
+	chunks := []struct{ title, body string }{
+		{"c-path", "see ![[/tr/alpha]] end"},           // path → target root body
+		{"c-anchor", "sec ![[/tr/alpha#Section]] end"}, // /path#Section → the titled chunk
+		{"c-title", "ttl ![[Alpha]] end"},              // title → target root body
+		{"c-id", "wid ![[" + widgetID + "]] end"},      // exact chunk id → that chunk
+		{"c-nope", "x ![[/no/such]] y"},                // unresolved → stays literal
+		{"c-bare", "b [[/tr/alpha]] b"},                // a bare link is NOT an embed
+	}
+	for _, c := range chunks {
+		if _, r := docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+srcDoc+`","parent_id":"`+srcRoot+`","title":"`+c.title+`","body":"`+c.body+`"}`); r.IsError {
+			t.Fatalf("create %s: %s", c.title, r.Text)
+		}
+	}
+
+	md := exportMarkdown(t, d, ctx, srcDoc, false) // clean mode → embeds expand
+
+	// Resolved embeds are replaced by the target bodies.
+	for _, want := range []string{"ALPHA-ROOT-BODY", "SECTION-BODY", "WIDGET-BODY"} {
+		if !strings.Contains(md, want) {
+			t.Errorf("clean export missing expanded body %q\n---\n%s", want, md)
+		}
+	}
+	// Every embed FORM of the target is gone (path / anchor / title all expanded).
+	for _, gone := range []string{"![[/tr/alpha]]", "![[/tr/alpha#Section]]", "![[Alpha]]"} {
+		if strings.Contains(md, gone) {
+			t.Errorf("clean export left an embed unexpanded: %q\n---\n%s", gone, md)
+		}
+	}
+	// An unresolved embed stays literal.
+	if !strings.Contains(md, "![[/no/such]]") {
+		t.Errorf("unresolved embed did not stay literal\n---\n%s", md)
+	}
+	// A bare `[[link]]` is NOT transcluded — its literal survives (only the c-bare
+	// chunk carries `[[/tr/alpha]]`, so its presence proves the bare form was left
+	// alone rather than expanded to ALPHA-ROOT-BODY).
+	if !strings.Contains(md, "[[/tr/alpha]]") {
+		t.Errorf("bare [[link]] was expanded or dropped by transclusion\n---\n%s", md)
+	}
+}
+
+// --- the load-bearing round-trip invariant (sqlite; the includeMeta gate is Go) ---
+
+// TestDocumentTransclusion_MetadataModeKeepsEmbedLiteral pins THE invariant: an
+// embed is expanded only in clean mode. In metadata/round-trip mode the body is
+// emitted verbatim (the `![[…]]` literal preserved) so
+// export(include_metadata=true)→import_md round-trips the EMBED, not a baked-in
+// copy. Fail-before: expanding regardless of includeMeta (dropping the
+// `!includeMeta` guard in exportMD) makes the metadata export contain the target
+// body and lose the literal.
+func TestDocumentTransclusion_MetadataModeKeepsEmbedLiteral(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+
+	out, _ := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Beta","path":"/rt/beta"}`)
+	betaRoot := out["root_chunk_id"].(string)
+	setChunkBody(t, d, ctx, betaRoot, "BETA-BODY")
+
+	out, _ = docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"RTSrc","path":"/rt/src"}`)
+	srcDoc, srcRoot := out["document_id"].(string), out["root_chunk_id"].(string)
+	if _, r := docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+srcDoc+`","parent_id":"`+srcRoot+`","title":"c","body":"pre ![[/rt/beta]] post"}`); r.IsError {
+		t.Fatalf("create c: %s", r.Text)
+	}
+
+	// Metadata mode: the embed MUST stay literal and NOT be expanded.
+	meta := exportMarkdown(t, d, ctx, srcDoc, true)
+	if !strings.Contains(meta, "![[/rt/beta]]") {
+		t.Errorf("metadata export dropped the literal embed (round-trip would lose it)\n---\n%s", meta)
+	}
+	if strings.Contains(meta, "BETA-BODY") {
+		t.Errorf("metadata export expanded the embed (round-trip would bake it in)\n---\n%s", meta)
+	}
+
+	// Clean mode over the SAME fixture DOES expand — proving includeMeta is the
+	// only thing that differs.
+	clean := exportMarkdown(t, d, ctx, srcDoc, false)
+	if !strings.Contains(clean, "BETA-BODY") {
+		t.Errorf("clean export did not expand the embed\n---\n%s", clean)
+	}
+	if strings.Contains(clean, "![[/rt/beta]]") {
+		t.Errorf("clean export left the embed literal\n---\n%s", clean)
+	}
+}
+
+// --- the guards (sqlite; tier-independent recursion logic) ---
+
+// TestDocumentTransclusion_CycleTerminates pins the cycle guard: A embeds B and B
+// embeds A back. Expansion must terminate (no hang / stack blow-up) with the
+// back-reference left literal at the point the cycle would close. Fail-before:
+// removing the inChain guard recurses until the goroutine stack overflows.
+func TestDocumentTransclusion_CycleTerminates(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+
+	outA, _ := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"CycA","path":"/cy/a"}`)
+	aDoc, aRoot := outA["document_id"].(string), outA["root_chunk_id"].(string)
+	outB, _ := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"CycB","path":"/cy/b"}`)
+	bRoot := outB["root_chunk_id"].(string)
+
+	setChunkBody(t, d, ctx, aRoot, "AA ![[/cy/b]] AA")
+	setChunkBody(t, d, ctx, bRoot, "BB ![[/cy/a]] BB")
+
+	md := exportMarkdown(t, d, ctx, aDoc, false)
+	// A expanded once into B (so "BB" is present), but B's back-embed of A is the
+	// cycle and is left literal.
+	if !strings.Contains(md, "AA BB") {
+		t.Errorf("cycle export did not expand one level into B\n---\n%s", md)
+	}
+	if !strings.Contains(md, "![[/cy/a]]") {
+		t.Errorf("cycle back-reference was not left literal\n---\n%s", md)
+	}
+}
+
+// TestDocumentTransclusion_DepthCapStops pins the maxEmbedDepth cap on a long
+// ACYCLIC chain d0→d1→…→d5: expansion inlines up to the cap and leaves the next
+// embed literal (so the deepest body is never read). Fail-before: removing the
+// depth cap expands the whole chain and the deepest body ("L5") appears.
+func TestDocumentTransclusion_DepthCapStops(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+
+	roots := make([]string, 6)
+	docs := make([]string, 6)
+	for i := 0; i < 6; i++ {
+		s := strconv.Itoa(i)
+		out, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"D`+s+`","path":"/dp/d`+s+`"}`)
+		if r.IsError {
+			t.Fatalf("create d%d: %s", i, r.Text)
+		}
+		docs[i], roots[i] = out["document_id"].(string), out["root_chunk_id"].(string)
+	}
+	// d0..d4 each embed the next; d5 is a terminal body.
+	for i := 0; i < 5; i++ {
+		setChunkBody(t, d, ctx, roots[i], "L"+strconv.Itoa(i)+" ![[/dp/d"+strconv.Itoa(i+1)+"]]")
+	}
+	setChunkBody(t, d, ctx, roots[5], "L5 END")
+
+	md := exportMarkdown(t, d, ctx, docs[0], false)
+	// The cap is 4: L0..L4 inline, but the embed of d5 (reached at depth 4) is left
+	// literal, so L5's body is never pulled in.
+	if !strings.Contains(md, "L4") {
+		t.Errorf("depth export stopped too early (L4 missing)\n---\n%s", md)
+	}
+	if !strings.Contains(md, "![[/dp/d5]]") {
+		t.Errorf("depth cap did not leave the over-depth embed literal\n---\n%s", md)
+	}
+	if strings.Contains(md, "L5") {
+		t.Errorf("depth cap did not stop — the deepest body was expanded\n---\n%s", md)
+	}
+}


### PR DESCRIPTION
Phase 2b of **RFC BS — Document structure primitives** (`/loomcycle/rfcs/document-structure-primitives`), completing Phase 2 after P2a name-links (#934). Backend only.

## Why
The other half of Phase 2: a chunk body's `![[target]]` **embed** is expanded inline at `export_md` render time to the referenced chunk's body — so a document composes content from other chunks/documents without duplication. Distinct from a `[[link]]` (P2a, which makes a graph edge and is never expanded).

## What
- **`expandTransclusions`** walks `![[…]]` matches and substitutes each resolved target's (recursively expanded) body. A **cycle** (chain guard), the **depth cap** (`maxEmbedDepth`), an **unresolved** target, or a **body-read fault** all degrade to the literal `![[target]]` — transclusion is a rendering nicety, never a correctness gate, so it never aborts the export walk.
- **`resolveEmbedTarget`** is a scope-confined superset of P2a's `resolveLinkTarget`: it also accepts an exact chunk id and a `/path#Section` anchor (embed one named chunk, not just a document root); an anchor that names nothing stays literal (no silent root fallback).
- Wired into `exportMD`'s plain-body case, expanding **only in clean mode** (`!include_metadata`). **In round-trip/metadata mode the body stays verbatim** — or an `export(include_metadata=true)` → `import_md` would bake the expanded copy in and lose the embed. This is the load-bearing invariant, and it's tested explicitly.

## Also: a CI gate fix (worth a look)
The postgres-tier CI step runs an explicit `-run` allowlist, and P1's `TestDocumentTags_CoreBothTiers` + P2a's `TestDocumentNameLinks_CoreBothTiers` were **never added** — so their postgres subtests have been *decoration, not a gate* (the allowlist's own comment warns of exactly this). This PR adds both, so the whole RFC BS postgres tier now actually runs in CI. The new pg test is named `TestDocument_PostgresTransclusion` to match the existing pattern.

## Tested
`document_transclusion_test.go` — path / `#anchor` / title / chunk-id embeds (sqlite + a now-CI-gated postgres tier), the **round-trip invariant** (metadata mode keeps `![[…]]` literal), cycle termination (no hang/stack blow-up), the depth cap, unresolved-stays-literal, and a bare `[[link]]` is not expanded. Each fail-before verified. `go test ./...` exit 0. Additive — no wire/schema change.

## Scope
Transclusion at `export_md` is the deliverable; expanding embeds in the live viewer is a later UI nicety. Phase 2 (name-links + transclusion) is now complete; next is P3 (history + backlinks/unlinked-mentions/related).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD