### PR TITLE
feat(document): embed prose chunk bodies so documents become searchable

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -966,7 +966,15 @@ func main() {
 	// below; SqlMem bound in the SQL Memory block (Document requires it); Bus
 	// for change events. MaxAssetBytes (RFC BO) caps a stored image's decoded
 	// size (0 → the tool's built-in default).
-	documentTool := &builtin.Document{Bus: channelBus, MaxAssetBytes: int(cfg.Env.MaxDocumentAssetBytes)}
+	// Embedder (RFC BU phase 1) makes chunk BODIES semantically searchable via
+	// `memory op=search` with prefix "doc.chunk:". Nil when the operator declared
+	// no embedder block — bodies are then written exactly as before, unsearchable
+	// but never lost, so authoring never depends on an embedder being reachable.
+	documentTool := &builtin.Document{
+		Bus:           channelBus,
+		MaxAssetBytes: int(cfg.Env.MaxDocumentAssetBytes),
+		Embedder:      embedder,
+	}
 	allTools = append(allTools, documentTool)
 
 	// RFC BE — the History tool (browse/search/annotate past chats). Store

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -151,6 +151,7 @@ func Run(t *testing.T, factory Factory) {
 		{"MemoryListBySourceSessions", testMemoryListBySourceSessions},
 		{"InterruptDeleteAllByUser", testInterruptDeleteAllByUser},
 		{"ListTenants", testListTenants},
+		{"MemoryEmbedCascadesOnDelete", testMemoryEmbedCascadesOnDelete},
 		// RFC BL P2: the background-consolidation substrate.
 		{"MemorySupersedeHidesFromReads", testMemorySupersedeHidesFromReads},
 		{"MemorySupersedeIsIdempotent", testMemorySupersedeIsIdempotent},
@@ -10993,5 +10994,67 @@ func testListTenants(t *testing.T, s store.Store) {
 	// A tenant with no runs must NOT appear — the enumeration is derived.
 	if _, present := got["tn_never_ran"]; present {
 		t.Error("a tenant with no runs appeared; the list is derived from runs")
+	}
+}
+
+// testMemoryEmbedCascadesOnDelete proves the claim RFC BU relies on rather than
+// assuming it: deleting an embedded memory row leaves no embedding behind.
+//
+// memory_embeddings has ON DELETE CASCADE to memory on postgres, and the
+// vec-enabled sqlite driver sets _foreign_keys=on in its DSN — so the cascade is
+// enforced wherever an embedding can exist. That makes embedding CLEANUP free for
+// document chunk bodies: delete_chunk, delete_document, the retention prune and
+// the dead-link GC all delete the body, and the vector goes with it.
+//
+// Free, but untested — and a documented invariant with no test is precisely how
+// the scope-key separator rule and the postgres-tier -run filter both drifted in
+// this codebase. If this ever fails it is a latent orphan-vector bug, not a
+// documentation problem.
+func testMemoryEmbedCascadesOnDelete(t *testing.T, s store.Store) {
+	if !vectorRefusalCheck(t, s) {
+		return
+	}
+	ctx := context.Background()
+	const sid, key = "cascade", "doc.chunk:abc123"
+	v, _ := json.Marshal(map[string]string{"body": "prose"})
+	if err := s.MemorySet(ctx, "", store.MemoryScopeUser, sid, key, v, 0); err != nil {
+		t.Fatalf("MemorySet: %v", err)
+	}
+	if err := s.MemoryEmbedSet(ctx, "", store.MemoryScopeUser, sid, key, store.MemoryEmbedding{
+		Provider: "test", Model: "m", Dimension: 4,
+		Vector: floats32(1, 0, 0, 0), EmbedText: "prose", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("MemoryEmbedSet: %v", err)
+	}
+	// Precondition: the embedding is really there, so a later absence means the
+	// cascade fired rather than the write having silently no-opped.
+	if _, err := s.MemoryEmbedGet(ctx, "", store.MemoryScopeUser, sid, key); err != nil {
+		t.Fatalf("precondition: embedding not readable after set: %v", err)
+	}
+
+	if _, err := s.MemoryDelete(ctx, "", store.MemoryScopeUser, sid, key); err != nil {
+		t.Fatalf("MemoryDelete: %v", err)
+	}
+	if _, err := s.MemoryEmbedGet(ctx, "", store.MemoryScopeUser, sid, key); err == nil {
+		t.Error("the embedding SURVIVED its memory row — every document body delete " +
+			"would leave an orphan vector, searchable and pointing at nothing")
+	}
+
+	// And the scope-wide delete path, which is what an erasure uses.
+	if err := s.MemorySet(ctx, "", store.MemoryScopeUser, sid, key, v, 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.MemoryEmbedSet(ctx, "", store.MemoryScopeUser, sid, key, store.MemoryEmbedding{
+		Provider: "test", Model: "m", Dimension: 4,
+		Vector: floats32(1, 0, 0, 0), EmbedText: "prose", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.MemoryDeleteScope(ctx, "", store.MemoryScopeUser, sid); err != nil {
+		t.Fatalf("MemoryDeleteScope: %v", err)
+	}
+	if _, err := s.MemoryEmbedGet(ctx, "", store.MemoryScopeUser, sid, key); err == nil {
+		t.Error("the embedding survived a scope-wide delete — an erasure would leave " +
+			"the subject's vectors behind")
 	}
 }

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -7,11 +7,13 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"log"
 	"regexp"
 	"strings"
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/channels"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
@@ -38,6 +40,17 @@ type Document struct {
 	// conservative built-in default. The wire (base64) payload is bounded
 	// separately by the /v1/_document request-body cap. RFC BO.
 	MaxAssetBytes int
+	// Embedder makes chunk BODIES semantically searchable: a prose chunk's body
+	// is embedded on write, so `memory op=search` with prefix "doc.chunk:" finds
+	// it. Before this, the searchable half of a document (the SQL chunks table)
+	// held no body text while the half holding the text (the k/v plane) had no
+	// index — so document prose was unreachable by any agent-visible search.
+	//
+	// OPTIONAL, and deliberately so. Nil means bodies are written exactly as
+	// before: unsearchable, never lost. Several internal construction sites
+	// (ontology provisioning, the tenant-root probe) neither need nor have an
+	// embedder, and a required field would force them to fabricate one.
+	Embedder providers.Embedder
 }
 
 func (d *Document) Name() string { return "Document" }
@@ -602,7 +615,64 @@ func (d *Document) writeBody(ctx context.Context, mscope store.MemoryScope, scop
 	// RFC BL: key chunk bodies on the same tenant the document's dirent + SQL
 	// structure use (direntTenant = the raw RunIdentity tenant), so bodies and
 	// structure never drift across the tenant axis.
-	return d.Store.MemorySet(ctx, direntTenant(ctx), mscope, scopeID, chunkBodyKey(chunkID), v, 0)
+	tenant := direntTenant(ctx)
+	key := chunkBodyKey(chunkID)
+	if err := d.Store.MemorySet(ctx, tenant, mscope, scopeID, key, v, 0); err != nil {
+		return err
+	}
+	// The body is durable at this point. Embedding is a SEPARATE, best-effort
+	// step and its failure is never returned: an unembedded chunk is
+	// unsearchable, but a chunk whose write was rejected because an embedder was
+	// cold is lost work the author has to redo. Authoring must not become
+	// embedder-dependent.
+	d.embedBody(ctx, tenant, mscope, scopeID, key, chunkID, body)
+	return nil
+}
+
+// embedBody indexes a chunk body for semantic search, best-effort.
+//
+// WHAT text gets embedded is per chunk type, and phase 1 handles prose only:
+//
+//   - prose  → the body verbatim
+//   - image  → SKIPPED. The body is a rendered media form (a data URI or an
+//     asset reference); embedding it would index base64, which matches nothing
+//     and costs a vector row. A generated description is the planned input.
+//   - mermaid → SKIPPED. Diagram source tokenises to `graph TD`, `-->`, `[`,
+//     which carry no meaning. Deterministic label extraction is the planned
+//     input, and it needs no model — mermaid is text pretending to be a picture.
+//
+// Skipping is not a silent no-op waiting to be forgotten: classifyMediaBody is
+// the same predicate export/import uses to recognise these forms, so a media
+// chunk that becomes embeddable later changes in one place.
+func (d *Document) embedBody(ctx context.Context, tenant string, mscope store.MemoryScope, scopeID, key, chunkID, body string) {
+	if d.Embedder == nil {
+		return
+	}
+	text := strings.TrimSpace(body)
+	if text == "" {
+		return
+	}
+	if typ, _, _, _ := classifyMediaBody(body); typ != "" {
+		return
+	}
+	vec, err := d.Embedder.Embed(ctx, []string{text})
+	if err != nil || len(vec) == 0 {
+		// One log line, not a returned error — see writeBody. The admin re-embed
+		// surface is how an operator recovers a scope that was written while the
+		// embedder was down.
+		log.Printf("document: embed body failed for chunk %s: %v", chunkID, err)
+		return
+	}
+	if err := d.Store.MemoryEmbedSet(ctx, tenant, mscope, scopeID, key, store.MemoryEmbedding{
+		Provider:  d.Embedder.Provider(),
+		Model:     d.Embedder.Model(),
+		Dimension: len(vec[0]),
+		Vector:    vec[0],
+		EmbedText: text,
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		log.Printf("document: store embedding failed for chunk %s: %v", chunkID, err)
+	}
 }
 
 // readBody loads a chunk's body + fields from Memory.

--- a/internal/tools/builtin/document_embed_test.go
+++ b/internal/tools/builtin/document_embed_test.go
@@ -1,0 +1,147 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// recordingEmbedder captures what text was handed to the embedder, so a test can
+// assert on the DECISION (embed this, skip that) without needing a vector-capable
+// store. The plain :memory: sqlite the document fixture uses has no vector
+// support, so MemoryEmbedSet would refuse — but whether we CALL the embedder, and
+// with what, is the thing phase 1 is actually deciding.
+type recordingEmbedder struct {
+	mu    sync.Mutex
+	texts []string
+	fail  error
+}
+
+func (e *recordingEmbedder) Embed(_ context.Context, texts []string) ([][]float32, error) {
+	e.mu.Lock()
+	e.texts = append(e.texts, texts...)
+	e.mu.Unlock()
+	if e.fail != nil {
+		return nil, e.fail
+	}
+	out := make([][]float32, len(texts))
+	for i := range texts {
+		out[i] = []float32{1, 0, 0, 0}
+	}
+	return out, nil
+}
+
+func (e *recordingEmbedder) Dimension() int   { return 4 }
+func (e *recordingEmbedder) Model() string    { return "recording-stub" }
+func (e *recordingEmbedder) Provider() string { return "test" }
+
+func (e *recordingEmbedder) seen() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return append([]string{}, e.texts...)
+}
+
+// TestEmbedBody_ProseIsEmbeddedWithItsBodyText is the phase-1 deliverable: a prose
+// chunk's body reaches the embedder, so `memory op=search` with prefix
+// "doc.chunk:" can find it. Before this the searchable half of a document (the SQL
+// chunks table) held no body text, while the half holding the text (the k/v plane)
+// had no index — document prose was unreachable by any agent-visible search.
+func TestEmbedBody_ProseIsEmbeddedWithItsBodyText(t *testing.T) {
+	d, ctx, docID, root := entityFixture(t)
+	emb := &recordingEmbedder{}
+	d.Embedder = emb
+
+	const body = "SAVEPOINT nesting is LIFO; the same three ops work at any depth."
+	bj, _ := json.Marshal(body)
+	if _, r := docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+docID+
+		`","parent_id":"`+root+`","title":"Nested transactions","body":`+string(bj)+`}`); r.IsError {
+		t.Fatalf("create_chunk: %s", r.Text)
+	}
+
+	seen := emb.seen()
+	var found bool
+	for _, s := range seen {
+		if strings.Contains(s, "SAVEPOINT nesting is LIFO") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("the body was never handed to the embedder, so the chunk is not "+
+			"searchable; embedder saw %d text(s): %q", len(seen), seen)
+	}
+}
+
+// TestEmbedBody_MediaBodiesAreSkipped — an image body is a rendered media form (a
+// data URI) and a mermaid body is diagram source. Embedding either indexes noise:
+// base64 matches nothing, and `graph TD` / `-->` / `[` carry no meaning while
+// dominating the tokens. Both get their own policy in later phases (a generated
+// description; deterministic label extraction), so phase 1 must SKIP them rather
+// than index garbage and call documents searchable.
+func TestEmbedBody_MediaBodiesAreSkipped(t *testing.T) {
+	for _, tc := range []struct{ name, body string }{
+		{"mermaid", "```mermaid\ngraph TD; A[User] -->|reads| B[(Memory)]\n```"},
+		{"image", "![diagram](data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==)"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d, ctx, docID, root := entityFixture(t)
+			emb := &recordingEmbedder{}
+			d.Embedder = emb
+			bj, _ := json.Marshal(tc.body)
+			if _, r := docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+docID+
+				`","parent_id":"`+root+`","title":"media","body":`+string(bj)+`}`); r.IsError {
+				t.Fatalf("create_chunk: %s", r.Text)
+			}
+			if seen := emb.seen(); len(seen) != 0 {
+				t.Errorf("a %s body was embedded: %q — media needs its own policy, "+
+					"not the raw form", tc.name, seen)
+			}
+		})
+	}
+}
+
+// TestEmbedBody_WriteSurvivesAnEmbedderFailure is the guarantee that keeps
+// authoring independent of the embedder.
+//
+// An unembedded chunk is unsearchable; a REJECTED write is lost work the author
+// has to redo. A cold embedder must therefore never fail the write — and this is
+// not hypothetical: a 24.9 GB local model returning `unexpected EOF` on cold load
+// is exactly the failure this session hit while running the memory eval.
+func TestEmbedBody_WriteSurvivesAnEmbedderFailure(t *testing.T) {
+	d, ctx, docID, root := entityFixture(t)
+	d.Embedder = &recordingEmbedder{fail: context.DeadlineExceeded}
+
+	out, r := docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+docID+
+		`","parent_id":"`+root+`","title":"Survives","body":"durable prose"}`)
+	if r.IsError {
+		t.Fatalf("a failing embedder rejected the write: %s", r.Text)
+	}
+	id := asStr(out["id"])
+
+	// And the body is readable, so nothing was half-written.
+	got, r2 := docExec(t, d, ctx, `{"op":"get_chunk","scope":"user","id":"`+id+`"}`)
+	if r2.IsError {
+		t.Fatalf("get_chunk: %s", r2.Text)
+	}
+	if asStr(got["body"]) != "durable prose" {
+		t.Errorf("body = %q, want it stored despite the embedder failing", asStr(got["body"]))
+	}
+}
+
+// TestEmbedBody_NilEmbedderIsAClean NoOp — most internal construction sites
+// (ontology provisioning, the tenant-root probe) have no embedder, and a required
+// dependency would force them to fabricate one. Nil must behave exactly as before.
+func TestEmbedBody_NilEmbedderIsACleanNoOp(t *testing.T) {
+	d, ctx, docID, root := entityFixture(t)
+	d.Embedder = nil // explicit: this is the state most call sites are in
+	out, r := docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+docID+
+		`","parent_id":"`+root+`","title":"No embedder","body":"still stored"}`)
+	if r.IsError {
+		t.Fatalf("nil embedder broke the write: %s", r.Text)
+	}
+	got, _ := docExec(t, d, ctx, `{"op":"get_chunk","scope":"user","id":"`+asStr(out["id"])+`"}`)
+	if asStr(got["body"]) != "still stored" {
+		t.Errorf("body = %q, want it stored", asStr(got["body"]))
+	}
+}


### PR DESCRIPTION
**RFC BU phase 1.** Document bodies were unreachable by any agent-visible search, and the cause was a *seam* rather than a bug.

## The gap

| plane | holds | searchable by |
|---|---|---|
| SQL `chunks` table | title, type, hierarchy | SQL — **no body column** |
| k/v `doc.chunk:<id>` | the **body text** | nothing — written with plain `MemorySet` |

And the keyword leg doesn't rescue it: `MemoryFullTextSearch` ranks `me.embed_text_tsv` **on the embeddings table**, so a row without an embedding is invisible to full-text *and* vector search. Measured on the reference deployment — `memory search prefix="doc.chunk:"` returned zero against 3,114 chunks.

## The fix

`writeBody` embeds the body. `memory op=search` with `prefix:"doc.chunk:"` now finds chunk bodies, and the key carries the chunk id — so the existing `get_chunk` → siblings/`get_edges` → `export_md` path takes over. **No new tool.**

**Embedding is best-effort and its failure is never returned.** An unembedded chunk is unsearchable; a *rejected* write is lost work the author has to redo. Not hypothetical: a 24.9 GB local model returning `unexpected EOF` on cold load is the failure this was written after hitting.

`Embedder` is **optional** on the struct — nil writes bodies exactly as before. Several internal sites (ontology provisioning, the tenant-root probe) neither need nor have one, and a required field would force them to fabricate it. Only the agent-facing tool is wired.

## Media bodies are skipped

Via the same `classifyMediaBody` predicate export/import already uses, so when a media type becomes embeddable it changes in one place.

- **image** → the body is a data URI; embedding it indexes base64, which matches nothing and costs a vector row
- **mermaid** → tokenises to `graph TD`, `-->`, `[`

Both get their own policy in later phases — a persisted generated description, and deterministic label extraction that needs no model because *mermaid is text pretending to be a picture*.

## The RFC's cascade claim is now proven, not assumed

`testMemoryEmbedCascadesOnDelete` asserts a deleted memory row leaves no embedding, on both the per-key and scope-wide paths. `memory_embeddings` has `ON DELETE CASCADE` on postgres and the vec-enabled sqlite driver sets `_foreign_keys=on`, so cleanup is free for `delete_chunk`, `delete_document`, the retention prune and the dead-link GC.

Free-but-untested is how the scope-key separator rule and the postgres-tier `-run` filter both drifted here. So it's a contract test — **verified on real pgvector (6.3s of work, not a skip)** and shown non-vacuous by inverting its assertion, which fails as expected.

## Tested

`TestEmbedBody_{ProseIsEmbeddedWithItsBodyText, MediaBodiesAreSkipped (mermaid + image), WriteSurvivesAnEmbedderFailure, NilEmbedderIsACleanNoOp}` with a recording embedder — plain `:memory:` sqlite has no vector support, so the assertion is on the **decision** (embed this, skip that) rather than a stored vector.

## Next

Phase 2 (backfill over `doc.chunk:`) is what makes the existing 3,114 chunks findable — until then only new and edited chunks are searchable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8