### PR TITLE
feat(document): chunk history + backlinks (RFC BS P3a)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
           # and `go test ./...` cannot run both packages against it concurrently.
           # Add every new postgres-tier test in this package here, or it is
           # decoration rather than a gate.
-          go test -count=1 -run 'TestEmbedDirective|TestEncodePgvector|TestResolveEmbedArgs|TestMemorySQL_EmbedDirective|TestDocument_Postgres|TestDocumentTags_CoreBothTiers|TestDocumentNameLinks_CoreBothTiers|TestSidecar_PostgresTierParity|TestUpsert_ReObservation|TestConfidence_' ./internal/tools/builtin/...
+          go test -count=1 -run 'TestEmbedDirective|TestEncodePgvector|TestResolveEmbedArgs|TestMemorySQL_EmbedDirective|TestDocument_Postgres|TestDocumentTags_CoreBothTiers|TestDocumentNameLinks_CoreBothTiers|TestDocumentHistory_|TestDocumentBacklinks_|TestSidecar_PostgresTierParity|TestUpsert_ReObservation|TestConfidence_' ./internal/tools/builtin/...
 
   runtime-codejs:
     name: Runtime suites (code-js)

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/mattn/go-sqlite3 v1.14.44
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/robfig/cron/v3 v3.0.1
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pmezard/go-difflib/difflib"
+
 	"github.com/denn-gubsky/loomcycle/internal/channels"
 	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
 	"github.com/denn-gubsky/loomcycle/internal/store"
@@ -43,7 +45,7 @@ type Document struct {
 func (d *Document) Name() string { return "Document" }
 
 func (d *Document) Description() string {
-	return "A chunked-graph document: each chunk is a first-class unit (UUID, hierarchy, type, fields, graph edges, Markdown body) that agents and humans co-author and query. Ops: create_document/get_document/documents_summary (per-document type/status + display metadata for a set of ids or a Path subtree)/query_documents (filter documents by type/status/tag/under_path)/delete_document/set_path, create_chunk (optional after_id inserts right after a sibling)/get_chunk/update_chunk/delete_chunk/move_chunk/reorder_chunk (move up|down within a level), link_chunks/unlink_chunks/get_edges (the cross-reference edges touching a document, each enriched with its endpoints' titles/types/statuses), query_chunks (structured filters incl. tag/tag_prefix + a raw sql escape hatch), add_tags/remove_tags (incremental tags on a chunk (id) or document (document_id))/list_tags (distinct tags + counts for a chunk, a document, or the whole scope), define_type/list_types, set_asset (attach an image's bytes to a chunk → type=image, served by GET /v1/_document/asset/{id})/get_asset (asset metadata), export_md (render the document to Markdown), import_md (build a document from export_md-shaped Markdown). Scope is agent or user; documents are named in the Path tree (path:) — create_document defaults to /documents/<title> if you omit one, and set_path attaches/re-homes a path for an existing document."
+	return "A chunked-graph document: each chunk is a first-class unit (UUID, hierarchy, type, fields, graph edges, Markdown body) that agents and humans co-author and query. Ops: create_document/get_document/documents_summary (per-document type/status + display metadata for a set of ids or a Path subtree)/query_documents (filter documents by type/status/tag/under_path)/delete_document/set_path, create_chunk (optional after_id inserts right after a sibling)/get_chunk/update_chunk/delete_chunk/move_chunk/reorder_chunk (move up|down within a level), link_chunks/unlink_chunks/get_edges (the cross-reference edges touching a document, each enriched with its endpoints' titles/types/statuses)/backlinks (the chunks that link TO a chunk — both manual links and inline [[name]] links), history/get_version/diff (a chunk's body-change log: list the revisions its body changed at, read one revision's exact body, or unified-diff two of them), query_chunks (structured filters incl. tag/tag_prefix + a raw sql escape hatch), add_tags/remove_tags (incremental tags on a chunk (id) or document (document_id))/list_tags (distinct tags + counts for a chunk, a document, or the whole scope), define_type/list_types, set_asset (attach an image's bytes to a chunk → type=image, served by GET /v1/_document/asset/{id})/get_asset (asset metadata), export_md (render the document to Markdown), import_md (build a document from export_md-shaped Markdown). Scope is agent or user; documents are named in the Path tree (path:) — create_document defaults to /documents/<title> if you omit one, and set_path attaches/re-homes a path for an existing document."
 }
 
 // documentInputSchema is a package const so the LoomCycle MCP server can
@@ -53,7 +55,7 @@ func (d *Document) Description() string {
 const documentInputSchema = `{
 	"type": "object",
 	"properties": {
-		"op":          {"type": "string", "enum": ["create_document","get_document","documents_summary","query_documents","delete_document","set_path","create_chunk","upsert_chunk","get_chunk","update_chunk","delete_chunk","supersede_chunk","graph_recall","move_chunk","reorder_chunk","link_chunks","unlink_chunks","get_edges","query_chunks","add_tags","remove_tags","list_tags","define_type","list_types","set_asset","get_asset","export_md","import_md"]},
+		"op":          {"type": "string", "enum": ["create_document","get_document","documents_summary","query_documents","delete_document","set_path","create_chunk","upsert_chunk","get_chunk","update_chunk","delete_chunk","supersede_chunk","graph_recall","move_chunk","reorder_chunk","link_chunks","unlink_chunks","get_edges","query_chunks","add_tags","remove_tags","list_tags","define_type","list_types","set_asset","get_asset","export_md","import_md","history","get_version","diff","backlinks"]},
 		"scope":       {"type": "string", "enum": ["agent","user","tenant"], "description": "Which store (default user). agent = this agent; user = this end-user (needs a user_id on the run); tenant = shared by every user and agent in the tenant — anything written here is read by all of them, so use it for curated reference material, not for anything derived from untrusted text. tenant requires the operator to grant BOTH memory_scopes and sql_scopes with the tenant value."},
 		"id":          {"type": "string", "description": "Document id (get/delete_document, set_path) or chunk id (get/update/delete/move_chunk)."},
 		"path":        {"type": "string", "description": "create_document: name the doc in the Path tree (default /documents/<title> if omitted). set_path: the path to attach to an existing document (by id). get/delete_document: address by path instead of id."},
@@ -81,7 +83,9 @@ const documentInputSchema = `{
 		"fields":      {"type": "object", "description": "Type-specific structured fields."},
 		"status":      {"type": "string"},
 		"position":    {"type": "integer"},
-		"revision":    {"type": "integer", "description": "update_chunk: the chunk's current revision (optimistic concurrency)."},
+		"revision":    {"type": "integer", "description": "update_chunk: the chunk's current revision (optimistic concurrency). get_version: which body-change revision to read."},
+		"from_revision": {"type": "integer", "description": "diff: the earlier revision to compare (from history)."},
+		"to_revision":   {"type": "integer", "description": "diff: the later revision to compare (from history)."},
 		"from_id":     {"type": "string"},
 		"to_id":       {"type": "string"},
 		"kind":        {"type": "string", "description": "link/unlink_chunks: edge kind (promotes/targets/...)."},
@@ -124,9 +128,15 @@ type docInput struct {
 	Status    string          `json:"status"`
 	Position  *int            `json:"position"`
 	Revision  *int            `json:"revision"`
-	FromID    string          `json:"from_id"`
-	ToID      string          `json:"to_id"`
-	Kind      string          `json:"kind"`
+	// FromRevision / ToRevision select the two body-change revisions to diff (RFC
+	// BS Phase 3a). Pointers so an omitted bound is distinguishable from a value
+	// (the log is 1-based, so 0 is never a real revision, but the pointer keeps the
+	// parse honest and the missing-field error precise).
+	FromRevision *int   `json:"from_revision"`
+	ToRevision   *int   `json:"to_revision"`
+	FromID       string `json:"from_id"`
+	ToID         string `json:"to_id"`
+	Kind         string `json:"kind"`
 
 	// Tag facet (RFC BS Phase 1). Tags is a plain slice so JSON presence is
 	// self-distinguishing: an omitted `tags` decodes to nil (leave existing tags
@@ -266,6 +276,20 @@ var docSchemaDDL = []string{
 	`CREATE TABLE IF NOT EXISTS document_tags (
 		document_id TEXT NOT NULL, tag TEXT NOT NULL, PRIMARY KEY (document_id, tag))`,
 	`CREATE INDEX IF NOT EXISTS document_tags_tag ON document_tags(tag)`,
+	// chunk_revisions — the append-only body-change log (RFC BS Phase 3a). The
+	// store's Memory API is OVERWRITE-only: MemorySet upserts and there is no
+	// version-history read, so a chunk's prior BODIES have nowhere to live unless
+	// they are kept here. One row per body WRITE: create_chunk seeds revision 1 and
+	// each body-bearing update_chunk appends the post-bump revision. A metadata-only
+	// update writes no row (its body is unchanged from the last snapshot), so this
+	// table lists exactly the revisions at which the BODY changed. No foreign key —
+	// cascade is explicit in Go (deleteChunk / deleteDocument), matching the rest of
+	// this schema; the (chunk_id, revision) primary key makes a re-run's snapshot
+	// idempotent (recordRevision's guarded INSERT relies on it).
+	`CREATE TABLE IF NOT EXISTS chunk_revisions (
+		chunk_id TEXT NOT NULL, revision INTEGER NOT NULL, created_at BIGINT NOT NULL,
+		actor TEXT, body TEXT NOT NULL, PRIMARY KEY (chunk_id, revision))`,
+	`CREATE INDEX IF NOT EXISTS chunk_revisions_chunk ON chunk_revisions(chunk_id)`,
 }
 
 // maxChunkDepth caps the ancestor walk in move_chunk (cycle detection) so a
@@ -353,6 +377,14 @@ func (d *Document) Execute(ctx context.Context, raw json.RawMessage) (tools.Resu
 		return d.exportMD(ctx, key, mscope, in)
 	case "import_md":
 		return d.importMD(ctx, key, mscope, in)
+	case "history":
+		return d.chunkHistory(ctx, key, in)
+	case "get_version":
+		return d.getVersion(ctx, key, in)
+	case "diff":
+		return d.diffVersions(ctx, key, in)
+	case "backlinks":
+		return d.backlinks(ctx, key, in)
 	case "":
 		return errResult("missing required field: op"), nil
 	default:
@@ -633,6 +665,32 @@ func (d *Document) readBody(ctx context.Context, mscope store.MemoryScope, scope
 // chunkBodyKey namespaces chunk bodies in the Memory keyspace so they don't
 // collide with an agent's own k/v keys.
 func chunkBodyKey(chunkID string) string { return "doc.chunk:" + chunkID }
+
+// recordRevision appends a body snapshot to the chunk_revisions log (RFC BS
+// Phase 3a). It is a BODY-CHANGE log: called only where a chunk's body is
+// actually (re)written — create_chunk (revision 1) and a body-bearing
+// update_chunk (the post-bump revision). A metadata-only update_chunk does NOT
+// call this: its body is unchanged from the last snapshot, so history lists
+// exactly the revisions at which the BODY changed.
+//
+// The INSERT is guarded (SELECT … WHERE NOT EXISTS) so a re-run cannot violate
+// the (chunk_id, revision) primary key — the same portable idempotence pattern
+// addTagRows uses. actor is the acting principal (RunIdentity.UserID), matching
+// publishChange's actor field.
+//
+// Deliberately NOT snapshotting yet (follow-ups): update_chunk-via-upsert_chunk
+// (updateChunkForUpsert writes the body directly), import_md's in-place body
+// writes, set_asset, and createDocument's empty root body do not append a
+// revision. Any body write that flows through create_chunk (incl. upsert_chunk's
+// create path and import_md's child chunks) does seed revision 1 naturally.
+func (d *Document) recordRevision(ctx context.Context, key sqlmem.ScopeKey, chunkID string, revision int, body string) error {
+	actor := tools.RunIdentity(ctx).UserID
+	now := time.Now().UnixNano()
+	stmt := `INSERT INTO chunk_revisions (chunk_id, revision, created_at, actor, body)
+	         SELECT ?, ?, ?, ?, ? WHERE NOT EXISTS (
+	             SELECT 1 FROM chunk_revisions WHERE chunk_id = ? AND revision = ?)`
+	return d.exec(ctx, key, stmt, chunkID, revision, now, actor, body, chunkID, revision)
+}
 
 // --- SQL helpers ---
 
@@ -1259,6 +1317,11 @@ func (d *Document) deleteDocument(ctx context.Context, key sqlmem.ScopeKey, msco
 		if err := d.execTxn(ctx, txnID, `DELETE FROM chunk_memory_meta WHERE chunk_id IN (SELECT id FROM chunks WHERE document_id = ?)`, docID); err != nil {
 			return err
 		}
+		// The body-change log for every chunk in the document (RFC BS Phase 3a),
+		// resolved via the chunks subquery so it runs before the chunk rows go.
+		if err := d.execTxn(ctx, txnID, `DELETE FROM chunk_revisions WHERE chunk_id IN (SELECT id FROM chunks WHERE document_id = ?)`, docID); err != nil {
+			return err
+		}
 		if err := d.execTxn(ctx, txnID, `DELETE FROM chunks WHERE document_id = ?`, docID); err != nil {
 			return err
 		}
@@ -1400,6 +1463,11 @@ func (d *Document) createChunk(ctx context.Context, key sqlmem.ScopeKey, mscope 
 	}
 	if err := d.writeBody(ctx, mscope, key.ScopeID, id, in.Body, in.Fields); err != nil {
 		return errResult("create_chunk: body: " + err.Error()), nil
+	}
+	// Seed the body-change log at revision 1 (RFC BS Phase 3a) — the chunk's body
+	// exists as of now, so it is the first snapshot even when in.Body is empty.
+	if err := d.recordRevision(ctx, key, id, 1, in.Body); err != nil {
+		return errResult("create_chunk: history: " + err.Error()), nil
 	}
 	// Derive this chunk's inline [[name]] link edges from its body (RFC BS Phase
 	// 2a). A body with no resolvable name-links materializes no edges.
@@ -1725,6 +1793,13 @@ func (d *Document) updateChunk(ctx context.Context, key sqlmem.ScopeKey, mscope 
 		// are unchanged — reconciling then would needlessly churn (and, if a linked
 		// target's dirent had since moved, wrongly drop a still-valid edge).
 		if hasBody {
+			// Snapshot the new body at the POST-bump revision (RFC BS Phase 3a).
+			// The guarded UPDATE above advanced revision from *in.Revision to
+			// *in.Revision+1, so that is the revision this body now carries. A
+			// fields-only update skips this branch (its body did not change).
+			if err := d.recordRevision(ctx, key, in.ID, *in.Revision+1, cb.Body); err != nil {
+				return errResult("update_chunk: history: " + err.Error()), nil
+			}
 			if err := d.reconcileNameLinks(ctx, key, in.ID, cb.Body); err != nil {
 				return errResult("update_chunk: name links: " + err.Error()), nil
 			}
@@ -1822,6 +1897,12 @@ func (d *Document) deleteChunk(ctx context.Context, key sqlmem.ScopeKey, mscope 
 			// sidecar row reachable only through the path that was missed is an orphan
 			// nothing can see.
 			if err := d.execTxn(ctx, txnID, `DELETE FROM chunk_memory_meta WHERE chunk_id = ?`, cid); err != nil {
+				return err
+			}
+			// The body-change log for this chunk (RFC BS Phase 3a). Before the chunk
+			// row goes, like the other per-chunk cascades — an orphaned revision row
+			// is invisible dead data nothing reaps.
+			if err := d.execTxn(ctx, txnID, `DELETE FROM chunk_revisions WHERE chunk_id = ?`, cid); err != nil {
 				return err
 			}
 			if err := d.execTxn(ctx, txnID, `DELETE FROM chunks WHERE id = ?`, cid); err != nil {
@@ -2086,6 +2167,161 @@ ORDER BY e.kind, e.created_at`, in.DocumentID, in.DocumentID)
 		edges = append(edges, e)
 	}
 	return jsonResult(map[string]any{"edges": edges})
+}
+
+// --- chunk history + backlinks (RFC BS Phase 3a) ---
+
+// backlinkEndpointFields are the FROM-endpoint columns backlinks surfaces
+// (present only when non-empty) — the linking chunk's title/type/status/document_id,
+// so "what links here" renders without a follow-up get_chunk per source. The
+// mirror of getEdges' edgeEndpointFields, restricted to the from side (backlinks
+// fixes the to side to the queried chunk).
+var backlinkEndpointFields = []string{"from_title", "from_type", "from_status", "from_document_id"}
+
+// chunkHistory lists the revisions at which a chunk's BODY changed, newest
+// first — metadata only (revision / created_at / actor), not the bodies. The
+// body of any listed revision is fetched with get_version.
+func (d *Document) chunkHistory(ctx context.Context, key sqlmem.ScopeKey, in docInput) (tools.Result, error) {
+	if in.ID == "" {
+		return errResult("history: missing required field: id"), nil
+	}
+	limit := 100
+	if in.Limit > 0 {
+		limit = in.Limit
+	}
+	res, err := d.query(ctx, key,
+		`SELECT revision, created_at, actor FROM chunk_revisions WHERE chunk_id = ? ORDER BY revision DESC LIMIT ?`,
+		in.ID, limit)
+	if err != nil {
+		return errResult("history: " + err.Error()), nil
+	}
+	// Positional read: the SELECT fixes the column order (revision, created_at,
+	// actor). created_at is a NOT-NULL unix-nanos BIGINT → asInt64 keeps its full
+	// width; the presence bool is irrelevant (the column is never NULL here).
+	revs := make([]map[string]any, 0, len(res.Rows))
+	for _, r := range res.Rows {
+		createdAt, _ := asInt64(r[1])
+		revs = append(revs, map[string]any{
+			"revision":   asInt(r[0]),
+			"created_at": createdAt,
+			"actor":      asStr(r[2]),
+		})
+	}
+	return jsonResult(map[string]any{"chunk_id": in.ID, "revisions": revs})
+}
+
+// revisionBody reads one revision's stored body. ok=false means that
+// (chunk_id, revision) pair was never recorded.
+func (d *Document) revisionBody(ctx context.Context, key sqlmem.ScopeKey, chunkID string, revision int) (string, bool, error) {
+	res, err := d.query(ctx, key, `SELECT body FROM chunk_revisions WHERE chunk_id = ? AND revision = ?`, chunkID, revision)
+	if err != nil {
+		return "", false, err
+	}
+	if len(res.Rows) == 0 {
+		return "", false, nil
+	}
+	return asStr(res.Rows[0][0]), true, nil
+}
+
+// getVersion returns a single revision's exact body.
+func (d *Document) getVersion(ctx context.Context, key sqlmem.ScopeKey, in docInput) (tools.Result, error) {
+	if in.ID == "" {
+		return errResult("get_version: missing required field: id"), nil
+	}
+	if in.Revision == nil {
+		return errResult("get_version: missing required field: revision"), nil
+	}
+	body, ok, err := d.revisionBody(ctx, key, in.ID, *in.Revision)
+	if err != nil {
+		return errResult("get_version: " + err.Error()), nil
+	}
+	if !ok {
+		return errResult(fmt.Sprintf("get_version: no such revision %d for chunk %s", *in.Revision, in.ID)), nil
+	}
+	return jsonResult(map[string]any{"chunk_id": in.ID, "revision": *in.Revision, "body": body})
+}
+
+// diffVersions returns a unified diff between two revisions' bodies. Either
+// missing revision is a clear error rather than a diff against "".
+func (d *Document) diffVersions(ctx context.Context, key sqlmem.ScopeKey, in docInput) (tools.Result, error) {
+	if in.ID == "" {
+		return errResult("diff: missing required field: id"), nil
+	}
+	if in.FromRevision == nil || in.ToRevision == nil {
+		return errResult("diff: from_revision and to_revision are required"), nil
+	}
+	fromBody, ok, err := d.revisionBody(ctx, key, in.ID, *in.FromRevision)
+	if err != nil {
+		return errResult("diff: " + err.Error()), nil
+	}
+	if !ok {
+		return errResult(fmt.Sprintf("diff: no such revision %d for chunk %s", *in.FromRevision, in.ID)), nil
+	}
+	toBody, ok, err := d.revisionBody(ctx, key, in.ID, *in.ToRevision)
+	if err != nil {
+		return errResult("diff: " + err.Error()), nil
+	}
+	if !ok {
+		return errResult(fmt.Sprintf("diff: no such revision %d for chunk %s", *in.ToRevision, in.ID)), nil
+	}
+	// go-difflib produces a correct, standard unified diff (LCS-aligned hunks with
+	// context). It is preferred over a hand-rolled line differ because a correct
+	// unified diff needs LCS alignment + hunk grouping — more code and more bug
+	// surface than a battle-tested library that is already in the build (a
+	// transitive dep of testify, promoted here to a direct require).
+	text, derr := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+		A:        difflib.SplitLines(fromBody),
+		B:        difflib.SplitLines(toBody),
+		FromFile: fmt.Sprintf("rev %d", *in.FromRevision),
+		ToFile:   fmt.Sprintf("rev %d", *in.ToRevision),
+		Context:  3,
+	})
+	if derr != nil {
+		return errResult("diff: " + derr.Error()), nil
+	}
+	return jsonResult(map[string]any{
+		"chunk_id":      in.ID,
+		"from_revision": *in.FromRevision,
+		"to_revision":   *in.ToRevision,
+		"diff":          text,
+	})
+}
+
+// backlinks returns "what links here": every edge pointing TO the given chunk,
+// each enriched with its FROM endpoint's title/type/status/document_id and the
+// auto flag (true = a parser-generated [[name]]-link edge, false = a manual
+// link_chunks edge). The reverse direction of get_edges, keyed on a single chunk
+// (get_edges is per-document). Served by the chunk_edges_to_kind reverse index.
+func (d *Document) backlinks(ctx context.Context, key sqlmem.ScopeKey, in docInput) (tools.Result, error) {
+	if in.ID == "" {
+		return errResult("backlinks: missing required field: id"), nil
+	}
+	res, err := d.query(ctx, key, `SELECT e.from_id AS from_id, e.kind AS kind, e.auto AS auto,
+       cf.title AS from_title, cf.type AS from_type, cf.status AS from_status, cf.document_id AS from_document_id
+FROM chunk_edges e
+LEFT JOIN chunks cf ON cf.id = e.from_id
+WHERE e.to_id = ?
+ORDER BY e.kind, e.created_at`, in.ID)
+	if err != nil {
+		return errResult("backlinks: " + err.Error()), nil
+	}
+	links := make([]map[string]any, 0, len(res.Rows))
+	for _, r := range res.Rows {
+		m := map[string]any{}
+		for i, c := range res.Columns {
+			if i < len(r) {
+				m[c] = r[i]
+			}
+		}
+		bl := map[string]any{"from_id": asStr(m["from_id"]), "kind": asStr(m["kind"]), "auto": asInt(m["auto"]) == 1}
+		for _, f := range backlinkEndpointFields {
+			if v := asStr(m[f]); v != "" {
+				bl[f] = v
+			}
+		}
+		links = append(links, bl)
+	}
+	return jsonResult(map[string]any{"backlinks": links})
 }
 
 // --- inline [[name]] links → typed edges (RFC BS Phase 2a) ---

--- a/internal/tools/builtin/document_history_test.go
+++ b/internal/tools/builtin/document_history_test.go
@@ -1,0 +1,306 @@
+package builtin
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// RFC BS Phase 3a — the chunk body-change history log + backlinks.
+//
+// The store's Memory API is overwrite-only (no version-history read), so a
+// chunk's prior BODIES live in their own append log (chunk_revisions) written on
+// every body write. These tests pin: the log (create + body updates → newest-first
+// revisions with the right actor), get_version's exact-body read + missing-revision
+// error, diff's unified output, the BODY-CHANGE-ONLY rule (a metadata-only update
+// snapshots nothing), backlinks (manual + [[name]] edges pointing at a chunk, with
+// the auto flag + enriched from-title), and the delete cascades (no orphan rows).
+//
+// Every case touches SQL Memory, so all run on BOTH tiers via the same
+// pgDocumentOrSkip harness the Phase-1 tags + Phase-2a name-link tests use; the
+// postgres half is skipped without the aux DSN.
+
+// historyBothTiers runs fn on sqlite and (if the aux DSN is set) postgres.
+func historyBothTiers(t *testing.T, fn func(*testing.T, *Document, context.Context)) {
+	t.Helper()
+	t.Run("sqlite", func(t *testing.T) {
+		d, ctx, _ := documentFixture(t)
+		fn(t, d, ctx)
+	})
+	t.Run("postgres", func(t *testing.T) {
+		d, ctx := pgDocumentOrSkip(t)
+		fn(t, d, ctx)
+	})
+}
+
+// --- small op wrappers (user scope) ---
+
+func histCreateDocument(t *testing.T, d *Document, ctx context.Context, title, path string) string {
+	t.Helper()
+	out, r := docExec(t, d, ctx, fmt.Sprintf(`{"op":"create_document","scope":"user","title":%q,"path":%q}`, title, path))
+	if r.IsError {
+		t.Fatalf("create_document(%s): %s", title, r.Text)
+	}
+	return out["document_id"].(string)
+}
+
+// histCreateChunk creates a chunk (parentID "" → child of the root) and returns
+// its id. %q renders the ASCII/newline test bodies as valid JSON string literals.
+func histCreateChunk(t *testing.T, d *Document, ctx context.Context, docID, parentID, title, body string) string {
+	t.Helper()
+	req := fmt.Sprintf(`{"op":"create_chunk","scope":"user","document_id":%q,"title":%q,"body":%q`, docID, title, body)
+	if parentID != "" {
+		req += fmt.Sprintf(`,"parent_id":%q`, parentID)
+	}
+	req += `}`
+	out, r := docExec(t, d, ctx, req)
+	if r.IsError {
+		t.Fatalf("create_chunk(%s): %s", title, r.Text)
+	}
+	return out["id"].(string)
+}
+
+// histUpdateBody rewrites a chunk's body at the given current revision and returns
+// the new (post-bump) revision.
+func histUpdateBody(t *testing.T, d *Document, ctx context.Context, id string, rev int, body string) int {
+	t.Helper()
+	out, r := docExec(t, d, ctx, fmt.Sprintf(`{"op":"update_chunk","scope":"user","id":%q,"revision":%d,"body":%q}`, id, rev, body))
+	if r.IsError {
+		t.Fatalf("update_chunk(%s): %s", id, r.Text)
+	}
+	return int(out["revision"].(float64))
+}
+
+// histRevisions returns the history op's revision maps (newest first).
+func histRevisions(t *testing.T, d *Document, ctx context.Context, chunkID string) []map[string]any {
+	t.Helper()
+	out, r := docExec(t, d, ctx, fmt.Sprintf(`{"op":"history","scope":"user","id":%q}`, chunkID))
+	if r.IsError {
+		t.Fatalf("history(%s): %s", chunkID, r.Text)
+	}
+	raw, _ := out["revisions"].([]any)
+	revs := make([]map[string]any, 0, len(raw))
+	for _, e := range raw {
+		revs = append(revs, e.(map[string]any))
+	}
+	return revs
+}
+
+// --- tests ---
+
+// TestDocumentHistory_LogListsBodyChangesNewestFirst pins the log + get_version +
+// diff: two body updates on a chunk produce three revisions (newest first, correct
+// actor), each revision reads back its exact body, a missing revision errors, and a
+// diff between the first and last body shows the changed lines.
+func TestDocumentHistory_LogListsBodyChangesNewestFirst(t *testing.T) {
+	historyBothTiers(t, assertHistoryLog)
+}
+
+func assertHistoryLog(t *testing.T, d *Document, ctx context.Context) {
+	t.Helper()
+	docID := histCreateDocument(t, d, ctx, "Hist Doc", "/hist/log")
+
+	rev1Body := "alpha\nbeta\n"
+	rev2Body := "alpha\nbeta-EDIT\n"
+	rev3Body := "alpha\nGAMMA\n"
+	cid := histCreateChunk(t, d, ctx, docID, "", "Chapter", rev1Body)
+	if got := histUpdateBody(t, d, ctx, cid, 1, rev2Body); got != 2 {
+		t.Fatalf("revision after 1st update = %d, want 2", got)
+	}
+	if got := histUpdateBody(t, d, ctx, cid, 2, rev3Body); got != 3 {
+		t.Fatalf("revision after 2nd update = %d, want 3", got)
+	}
+
+	// history: 3 revisions, newest first, actor u1 (the fixture's UserID).
+	revs := histRevisions(t, d, ctx, cid)
+	if len(revs) != 3 {
+		t.Fatalf("history len = %d, want 3", len(revs))
+	}
+	wantOrder := []int{3, 2, 1}
+	for i, rmap := range revs {
+		if got := int(rmap["revision"].(float64)); got != wantOrder[i] {
+			t.Errorf("history[%d] revision = %d, want %d", i, got, wantOrder[i])
+		}
+		if got, _ := rmap["actor"].(string); got != "u1" {
+			t.Errorf("history[%d] actor = %q, want u1", i, got)
+		}
+		if _, ok := rmap["created_at"]; !ok {
+			t.Errorf("history[%d] missing created_at", i)
+		}
+	}
+
+	// get_version returns each revision's exact body.
+	for rev, want := range map[int]string{1: rev1Body, 2: rev2Body, 3: rev3Body} {
+		out, r := docExec(t, d, ctx, fmt.Sprintf(`{"op":"get_version","scope":"user","id":%q,"revision":%d}`, cid, rev))
+		if r.IsError {
+			t.Fatalf("get_version rev %d: %s", rev, r.Text)
+		}
+		if got := out["body"].(string); got != want {
+			t.Errorf("get_version rev %d body = %q, want %q", rev, got, want)
+		}
+	}
+	// A revision that was never recorded is a clear error, not an empty body.
+	if _, r := docExec(t, d, ctx, fmt.Sprintf(`{"op":"get_version","scope":"user","id":%q,"revision":99}`, cid)); !r.IsError {
+		t.Errorf("get_version rev 99 should error (no such revision)")
+	}
+
+	// diff rev1 → rev3 shows the changed line (removed beta, added GAMMA).
+	out, r := docExec(t, d, ctx, fmt.Sprintf(`{"op":"diff","scope":"user","id":%q,"from_revision":1,"to_revision":3}`, cid))
+	if r.IsError {
+		t.Fatalf("diff: %s", r.Text)
+	}
+	diff := out["diff"].(string)
+	if !strings.Contains(diff, "-beta\n") {
+		t.Errorf("diff missing removed line -beta; got:\n%s", diff)
+	}
+	if !strings.Contains(diff, "+GAMMA\n") {
+		t.Errorf("diff missing added line +GAMMA; got:\n%s", diff)
+	}
+	// diff against a missing revision errors rather than diffing against "".
+	if _, r := docExec(t, d, ctx, fmt.Sprintf(`{"op":"diff","scope":"user","id":%q,"from_revision":1,"to_revision":99}`, cid)); !r.IsError {
+		t.Errorf("diff to a missing revision should error")
+	}
+}
+
+// TestDocumentHistory_MetadataOnlyUpdateDoesNotSnapshot pins the body-change-only
+// rule: a status-only update bumps the chunk's revision but records NO new history
+// row (its body is unchanged), so history lists only the body-change revisions and
+// no body snapshot exists at the metadata-bumped revision.
+func TestDocumentHistory_MetadataOnlyUpdateDoesNotSnapshot(t *testing.T) {
+	historyBothTiers(t, assertMetadataOnlyNoSnapshot)
+}
+
+func assertMetadataOnlyNoSnapshot(t *testing.T, d *Document, ctx context.Context) {
+	t.Helper()
+	docID := histCreateDocument(t, d, ctx, "Meta Doc", "/hist/meta")
+	cid := histCreateChunk(t, d, ctx, docID, "", "Section", "seed\n") // rev 1 snapshot
+	if got := histUpdateBody(t, d, ctx, cid, 1, "seed-2\n"); got != 2 {
+		t.Fatalf("revision after body update = %d, want 2", got)
+	}
+
+	// A metadata-only update (status, no body) bumps the chunk to revision 3 but
+	// must write NO history row.
+	out, r := docExec(t, d, ctx, fmt.Sprintf(`{"op":"update_chunk","scope":"user","id":%q,"revision":2,"status":"reviewed"}`, cid))
+	if r.IsError {
+		t.Fatalf("metadata-only update: %s", r.Text)
+	}
+	if got := int(out["revision"].(float64)); got != 3 {
+		t.Fatalf("revision after metadata update = %d, want 3", got)
+	}
+
+	// history lists only the two body-change revisions [2,1], NOT [3,2,1].
+	revs := histRevisions(t, d, ctx, cid)
+	if len(revs) != 2 {
+		t.Fatalf("history len = %d, want 2 (a metadata-only update must not snapshot)", len(revs))
+	}
+	if r0, r1 := int(revs[0]["revision"].(float64)), int(revs[1]["revision"].(float64)); r0 != 2 || r1 != 1 {
+		t.Errorf("history revisions = [%d %d], want [2 1]", r0, r1)
+	}
+	// No body snapshot exists at the metadata-bumped revision 3.
+	if _, r := docExec(t, d, ctx, fmt.Sprintf(`{"op":"get_version","scope":"user","id":%q,"revision":3}`, cid)); !r.IsError {
+		t.Errorf("get_version rev 3 should error — the metadata-only update wrote no body snapshot")
+	}
+}
+
+// TestDocumentBacklinks_ReturnsManualAndNameLinkSources pins backlinks: a chunk
+// linked to both manually (link_chunks) and via an inline [[name]] link reports
+// both sources, each with the correct auto flag and enriched from-title.
+func TestDocumentBacklinks_ReturnsManualAndNameLinkSources(t *testing.T) {
+	historyBothTiers(t, assertBacklinks)
+}
+
+func assertBacklinks(t *testing.T, d *Document, ctx context.Context) {
+	t.Helper()
+	docID := histCreateDocument(t, d, ctx, "BL Doc", "/hist/bl")
+	target := histCreateChunk(t, d, ctx, docID, "", "Target", "the target chunk\n")
+	manual := histCreateChunk(t, d, ctx, docID, "", "Manual Source", "plain body\n")
+
+	// A manual edge manual → target (auto=0).
+	if _, r := docExec(t, d, ctx, fmt.Sprintf(`{"op":"link_chunks","scope":"user","from_id":%q,"to_id":%q,"kind":"references"}`, manual, target)); r.IsError {
+		t.Fatalf("link_chunks: %s", r.Text)
+	}
+	// A parser edge auto → target from the inline [[Target]] name-link (auto=1).
+	auto := histCreateChunk(t, d, ctx, docID, "", "Auto Source", "see [[Target]] here\n")
+
+	out, r := docExec(t, d, ctx, fmt.Sprintf(`{"op":"backlinks","scope":"user","id":%q}`, target))
+	if r.IsError {
+		t.Fatalf("backlinks: %s", r.Text)
+	}
+	raw, _ := out["backlinks"].([]any)
+	byFrom := map[string]map[string]any{}
+	for _, e := range raw {
+		m := e.(map[string]any)
+		byFrom[m["from_id"].(string)] = m
+	}
+	if len(byFrom) != 2 {
+		t.Fatalf("backlinks count = %d, want 2; got %v", len(byFrom), raw)
+	}
+
+	m := byFrom[manual]
+	if m == nil {
+		t.Fatalf("no backlink from the manual source")
+	}
+	if auto, _ := m["auto"].(bool); auto {
+		t.Errorf("manual edge auto = true, want false")
+	}
+	if ft, _ := m["from_title"].(string); ft != "Manual Source" {
+		t.Errorf("manual from_title = %q, want Manual Source", ft)
+	}
+	if k, _ := m["kind"].(string); k != "references" {
+		t.Errorf("manual kind = %q, want references", k)
+	}
+
+	a := byFrom[auto]
+	if a == nil {
+		t.Fatalf("no backlink from the auto source (the [[Target]] name-link did not materialize an edge)")
+	}
+	if got, _ := a["auto"].(bool); !got {
+		t.Errorf("name-link edge auto = false, want true")
+	}
+	if ft, _ := a["from_title"].(string); ft != "Auto Source" {
+		t.Errorf("auto from_title = %q, want Auto Source", ft)
+	}
+}
+
+// TestDocumentHistory_DeleteCascadesLeaveNoOrphans pins the cascade: delete_chunk
+// (with a descendant) and delete_document both remove the chunk_revisions rows for
+// every affected chunk — no orphaned history survives its chunk.
+func TestDocumentHistory_DeleteCascadesLeaveNoOrphans(t *testing.T) {
+	historyBothTiers(t, assertHistoryCascade)
+}
+
+func assertHistoryCascade(t *testing.T, d *Document, ctx context.Context) {
+	t.Helper()
+
+	// delete_chunk: a parent with two body revisions + a child with one.
+	doc1 := histCreateDocument(t, d, ctx, "Cascade One", "/hist/cascade1")
+	parent := histCreateChunk(t, d, ctx, doc1, "", "Parent", "p-1\n")
+	histUpdateBody(t, d, ctx, parent, 1, "p-2\n") // parent now has 2 revisions
+	child := histCreateChunk(t, d, ctx, doc1, parent, "Child", "c-1\n")
+
+	if got := countRows(t, d, ctx, `SELECT COUNT(*) FROM chunk_revisions WHERE chunk_id = ? OR chunk_id = ?`, parent, child); got != 3 {
+		t.Fatalf("pre-delete_chunk revision rows = %d, want 3", got)
+	}
+	if _, r := docExec(t, d, ctx, fmt.Sprintf(`{"op":"delete_chunk","scope":"user","id":%q}`, parent)); r.IsError {
+		t.Fatalf("delete_chunk: %s", r.Text)
+	}
+	if got := countRows(t, d, ctx, `SELECT COUNT(*) FROM chunk_revisions WHERE chunk_id = ? OR chunk_id = ?`, parent, child); got != 0 {
+		t.Errorf("delete_chunk left %d orphan revision rows, want 0", got)
+	}
+
+	// delete_document: a chunk with two body revisions.
+	doc2 := histCreateDocument(t, d, ctx, "Cascade Two", "/hist/cascade2")
+	only := histCreateChunk(t, d, ctx, doc2, "", "Only", "a\n")
+	histUpdateBody(t, d, ctx, only, 1, "b\n") // 2 revisions
+
+	if got := countRows(t, d, ctx, `SELECT COUNT(*) FROM chunk_revisions WHERE chunk_id = ?`, only); got != 2 {
+		t.Fatalf("pre-delete_document revision rows = %d, want 2", got)
+	}
+	if _, r := docExec(t, d, ctx, fmt.Sprintf(`{"op":"delete_document","scope":"user","id":%q}`, doc2)); r.IsError {
+		t.Fatalf("delete_document: %s", r.Text)
+	}
+	if got := countRows(t, d, ctx, `SELECT COUNT(*) FROM chunk_revisions WHERE chunk_id = ?`, only); got != 0 {
+		t.Errorf("delete_document left %d orphan revision rows, want 0", got)
+	}
+}


### PR DESCRIPTION
Phase 3a of **RFC BS — Document structure primitives** (`/loomcycle/rfcs/document-structure-primitives`), after Phase 2 (#934/#935). Backend only.

## A finding that shaped the scope
The plan's P3 (§3.1 history, §3.2 discovery) assumed history rides "Memory content-addressing" and `related` reuses Vector Memory. Investigating: the store's Memory API is **overwrite-only** (no version-history read), and chunk bodies aren't embedded. So:
- **History** needs its own append log (this PR — the plan's pre-approved fallback).
- **`related`** needs chunk-body embedding infrastructure (embed-on-write + a vector index) — its own phase.
- **`unlinked_mentions`** needs Memory body-scanning — its own step.

This PR ships the two clean, high-value, SQL-backed ops; `related` + `unlinked_mentions` are deferred with their real costs flagged.

## What
- **`chunk_revisions`** — a per-scope body-change log (`chunk_id, revision, created_at, actor, body`), seeded at revision 1 by `create_chunk` and appended by each **body-bearing** `update_chunk` (post-bump revision). A metadata-only update writes no row, so the log is exactly the revisions at which the **body** changed. Guarded insert (idempotent on the PK); cascaded on `delete_chunk`/`delete_document`.
- **`history`** — a chunk's body revisions (`revision`/`created_at`/`actor`), newest first, metadata only.
- **`get_version`** — one revision's exact body.
- **`diff`** — a unified diff between two revisions (go-difflib, promoted from a transitive testify dep to a direct require — a correct unified diff needs LCS alignment + hunk grouping, not worth hand-rolling).
- **`backlinks`** — "what links here": edges pointing **to** a chunk, enriched with the linking chunk's title/type/status/document_id + the `auto` flag, covering both manual `link_chunks` edges and `[[name]]`-parser edges (reverse `chunk_edges` index).

## Deferred (own phases, flagged)
`related` (chunk-body embedding infra), `unlinked_mentions` (Memory body-scanning). Body writes via `upsert`-update / `import_md` / `set_asset` don't snapshot yet (noted in `recordRevision`). A retention sweep for old revisions is a natural follow-up.

## Also: CI gate
Added `TestDocumentHistory_`/`TestDocumentBacklinks_` to the postgres-tier `-run` allowlist so their pg subtests actually gate — the same class of gap #935 fixed for P1/P2a.

## Tested
`document_history_test.go` (sqlite + a now-CI-gated postgres tier) — the log lists body changes newest-first with the right actor; `get_version` returns each exact body and errors on a missing revision; `diff` shows the changed lines; a metadata-only update adds no row; `backlinks` returns manual + name-link sources with the right `auto` flag; deletes leave no orphan revisions. Each fail-before verified. `go test ./...` exit 0; `go mod tidy` consistent. Additive — no wire break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD