### PR TITLE
feat(memory): backfill embeddings for rows that never had one

### DIFF
--- a/internal/api/http/memory_backfill.go
+++ b/internal/api/http/memory_backfill.go
@@ -1,0 +1,191 @@
+package http
+
+// memory_backfill.go — POST /v1/_memory/backfill_embeddings (RFC BU phase 2).
+//
+// Embeds live memory rows that have NO embedding, optionally under a key prefix.
+// The motivating case is `doc.chunk:` — phase 1 embeds bodies on write, so a
+// deployment's existing documents stay unsearchable until they are swept once.
+//
+// WHY THIS IS NOT THE EXISTING /v1/_memory/reembed. That endpoint walks rows whose
+// stored embedder DIFFERS from the configured one, and its candidate query starts
+// FROM memory_embeddings and INNER JOINs memory — a row with no embedding row is
+// structurally invisible to it. Backfill is the inverse direction, so it needs its
+// own query and gets its own route rather than a mode flag on a differently-shaped
+// one.
+//
+// WHY NOT A MIGRATION. A boot-time sweep would make thousands of embedder calls
+// while the runtime is trying to start, and on a metered embedder that is a
+// surprise bill nobody approved. It is an operator action, invoked when they choose.
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+type memoryBackfillResponse struct {
+	Scope   string `json:"scope"`
+	ScopeID string `json:"scope_id"`
+	Prefix  string `json:"prefix,omitempty"`
+	DryRun  bool   `json:"dry_run"`
+
+	// Candidates is how many unembedded rows this call SAW, bounded by limit.
+	Candidates int `json:"candidates"`
+	// Embedded / Failed describe a live run.
+	Embedded int `json:"embedded,omitempty"`
+	Failed   int `json:"failed,omitempty"`
+	// FailedKeys is capped — a systematic failure (embedder down) would otherwise
+	// return one line per row.
+	FailedKeys []string `json:"failed_keys,omitempty"`
+	// SampleKeys shows what a dry run would touch.
+	SampleKeys []string `json:"sample_keys,omitempty"`
+
+	CurrentEmbedder memoryReembedConfigured `json:"current_embedder"`
+	Notes           []string                `json:"notes"`
+}
+
+const backfillFailedKeyCap = 20
+
+// handleMemoryBackfillEmbeddings serves POST
+// /v1/_memory/backfill_embeddings?scope=&scope_id=&prefix=&limit=&dry_run=
+//
+// RESUMABLE WITHOUT STATE. Every row embedded drops out of the candidate query, so
+// a call that dies half-way leaves the rest still listed — an operator re-invokes
+// until `candidates` reaches zero. There is no cursor to persist, and therefore no
+// way for a crash to double-embed a row or skip one.
+func (s *Server) handleMemoryBackfillEmbeddings(w http.ResponseWriter, r *http.Request) {
+	if s.store == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "store_unavailable",
+			"store not configured; backfill requires a persistent store")
+		return
+	}
+	if s.embedder == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "embedder_not_configured",
+			"no embedder configured; set memory.embedder in operator yaml")
+		return
+	}
+	scope := r.URL.Query().Get("scope")
+	scopeID := r.URL.Query().Get("scope_id")
+	if !validAdminMemoryScope(scope) {
+		writeJSONError(w, http.StatusBadRequest, "invalid_scope",
+			"scope must be one of: agent, user, tenant")
+		return
+	}
+	if scopeID == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing_scope_id", "scope_id is required")
+		return
+	}
+	// dry_run defaults TRUE, matching /v1/_memory/reembed: an operator typing a
+	// bare `curl -X POST` gets a preview, not thousands of embedder calls.
+	dryRun := true
+	if v := r.URL.Query().Get("dry_run"); v != "" {
+		dryRun = v != "false" && v != "0"
+	}
+	limit := 200
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	prefix := r.URL.Query().Get("prefix")
+	tenant, _ := s.principalTenantScope(r.Context(), r.URL.Query().Get("tenant"))
+
+	rows, err := s.store.MemoryEmbedListMissing(r.Context(), tenant,
+		store.MemoryScope(scope), scopeID, prefix, limit)
+	if err != nil {
+		// ErrVectorUnsupported / the vec-tier pending error are the honest answers
+		// on a tier without this capability — surface them rather than reporting
+		// "0 candidates", which would read as "nothing to do".
+		writeJSONError(w, http.StatusServiceUnavailable, "backfill_unavailable", err.Error())
+		return
+	}
+
+	resp := memoryBackfillResponse{
+		Scope: scope, ScopeID: scopeID, Prefix: prefix, DryRun: dryRun,
+		Candidates: len(rows),
+		CurrentEmbedder: memoryReembedConfigured{
+			Provider:  s.embedder.Provider(),
+			Model:     s.embedder.Model(),
+			Dimension: s.embedder.Dimension(),
+		},
+	}
+	resp.Notes = []string{
+		"candidates is bounded by limit — a non-zero count after a live run means " +
+			"MORE remain; re-invoke until it reaches 0. Every embedded row leaves the " +
+			"candidate set, so re-invoking is safe and resumes rather than restarts.",
+	}
+
+	if dryRun {
+		for i, row := range rows {
+			if i == backfillFailedKeyCap {
+				break
+			}
+			resp.SampleKeys = append(resp.SampleKeys, row.Key)
+		}
+		resp.Notes = append(resp.Notes, "DRY RUN — nothing was embedded. Re-send with dry_run=false.")
+		writeJSON(w, http.StatusOK, resp)
+		return
+	}
+
+	for _, row := range rows {
+		// Embed the row's VALUE text. A document chunk body is a JSON envelope, so
+		// embedText unwraps it — embedding the raw JSON would index the field names.
+		text := embedTextForRow(row)
+		if text == "" {
+			continue
+		}
+		vecs, err := s.embedder.Embed(r.Context(), []string{text})
+		if err != nil || len(vecs) == 0 {
+			resp.Failed++
+			if len(resp.FailedKeys) < backfillFailedKeyCap {
+				resp.FailedKeys = append(resp.FailedKeys, row.Key)
+			}
+			continue
+		}
+		if err := s.store.MemoryEmbedSet(r.Context(), tenant, store.MemoryScope(scope), scopeID, row.Key,
+			store.MemoryEmbedding{
+				Provider:  s.embedder.Provider(),
+				Model:     s.embedder.Model(),
+				Dimension: len(vecs[0]),
+				Vector:    vecs[0],
+				EmbedText: text,
+				CreatedAt: time.Now().UTC(),
+			}); err != nil {
+			resp.Failed++
+			if len(resp.FailedKeys) < backfillFailedKeyCap {
+				resp.FailedKeys = append(resp.FailedKeys, row.Key)
+			}
+			continue
+		}
+		resp.Embedded++
+	}
+	if resp.Failed > 0 {
+		resp.Notes = append(resp.Notes,
+			"some rows failed (see failed_keys, capped). They remain candidates, so a "+
+				"re-invocation retries exactly those — nothing is lost by a partial failure.")
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// embedTextForRow extracts the text worth embedding from a stored row value.
+//
+// A document chunk body is a JSON envelope — {"body": "...", "fields": {...}} —
+// so embedding row.Value verbatim (which is what /v1/_memory/reembed does) would
+// index the literal tokens `body` and `fields` alongside the prose, and for a
+// chunk with a short body the envelope could outweigh the content.
+//
+// Ordinary rows keep the existing behaviour: their whole value is the text. So
+// this narrows nothing and only improves the case the prefix targets.
+func embedTextForRow(row store.MemoryEntry) string {
+	var env struct {
+		Body *string `json:"body"`
+	}
+	if err := json.Unmarshal(row.Value, &env); err == nil && env.Body != nil {
+		return strings.TrimSpace(*env.Body)
+	}
+	return strings.TrimSpace(string(row.Value))
+}

--- a/internal/api/http/memory_backfill_test.go
+++ b/internal/api/http/memory_backfill_test.go
@@ -1,0 +1,161 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// backfillEmbedder is a deterministic stub; the vector content is irrelevant here,
+// only whether rows were embedded at all.
+type backfillEmbedder struct{ calls int }
+
+func (e *backfillEmbedder) Embed(_ context.Context, texts []string) ([][]float32, error) {
+	e.calls += len(texts)
+	out := make([][]float32, len(texts))
+	for i := range texts {
+		out[i] = []float32{1, 0, 0, 0}
+	}
+	return out, nil
+}
+func (e *backfillEmbedder) Dimension() int   { return 4 }
+func (e *backfillEmbedder) Model() string    { return "stub" }
+func (e *backfillEmbedder) Provider() string { return "test" }
+
+// TestBackfillEmbeddings_UnsupportedTierSaysSoRatherThanReportingZero is what
+// actually runs on the sqlite test store, and it is the more important assertion.
+//
+// sqlite has no vector support, so the candidate query refuses. The endpoint must
+// SURFACE that refusal: reporting "0 candidates" would read as "nothing to
+// backfill, you are done" to an operator whose 3,114 chunks are all unembedded.
+// A capability that is absent and a corpus that is already swept must not look
+// alike.
+func TestBackfillEmbeddings_UnsupportedTierSaysSoRatherThanReportingZero(t *testing.T) {
+	srv, _ := makeServer(t, completingProvider(), makeBaseConfig())
+	emb := &backfillEmbedder{}
+	srv.embedder = emb
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost,
+		"/v1/_memory/backfill_embeddings?scope=user&scope_id=alice&prefix=doc.chunk:&dry_run=false", nil).
+		WithContext(auth.WithPrincipal(context.Background(), auth.Principal{
+			Subject: "root", Scopes: []string{auth.ScopeAdmin},
+		}))
+	srv.handleMemoryBackfillEmbeddings(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 on a tier without vectors; body: %s",
+			rec.Code, rec.Body.String())
+	}
+	var e map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &e)
+	if e["code"] != "backfill_unavailable" {
+		t.Errorf("code = %v, want backfill_unavailable", e["code"])
+	}
+	// And nothing was embedded — a refused tier must not have spent embedder calls.
+	if emb.calls != 0 {
+		t.Errorf("embedder called %d times on a tier that cannot store the result", emb.calls)
+	}
+}
+
+// TestBackfillEmbeddings_DefaultsToDryRun covers the safety default: an operator
+// typing a bare `curl -X POST` gets a preview, not thousands of embedder calls
+// against a metered provider. Matches /v1/_memory/reembed's posture.
+//
+// SKIPS rather than silently passing on a tier without vectors — the sqlite test
+// store refuses at the candidate query, so the 200 path is unreachable there. A
+// visible skip is the honest outcome; asserting nothing and reporting PASS is how
+// a suite comes to look like coverage it does not have.
+func TestBackfillEmbeddings_DefaultsToDryRun(t *testing.T) {
+	srv, _ := makeServer(t, completingProvider(), makeBaseConfig())
+	emb := &backfillEmbedder{}
+	srv.embedder = emb
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost,
+		"/v1/_memory/backfill_embeddings?scope=user&scope_id=alice&prefix=doc.chunk:", nil).
+		WithContext(auth.WithPrincipal(context.Background(), auth.Principal{
+			Subject: "root", Scopes: []string{auth.ScopeAdmin},
+		}))
+	srv.handleMemoryBackfillEmbeddings(rec, req)
+
+	if rec.Code == http.StatusServiceUnavailable {
+		t.Skip("this store tier has no vector support, so the dry-run path is " +
+			"unreachable here; the refusal is covered by " +
+			"TestBackfillEmbeddings_UnsupportedTierSaysSoRatherThanReportingZero")
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp memoryBackfillResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if !resp.DryRun {
+		t.Error("an omitted dry_run performed a LIVE backfill")
+	}
+	if emb.calls != 0 {
+		t.Errorf("a dry run called the embedder %d times", emb.calls)
+	}
+}
+
+// TestBackfillEmbeddings_RefusesWithoutAnEmbedder — the endpoint's whole job needs
+// one, and reporting 0 candidates would look like success.
+func TestBackfillEmbeddings_RefusesWithoutAnEmbedder(t *testing.T) {
+	srv, _ := makeServer(t, completingProvider(), makeBaseConfig())
+	srv.embedder = nil
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost,
+		"/v1/_memory/backfill_embeddings?scope=user&scope_id=alice", nil).
+		WithContext(auth.WithPrincipal(context.Background(), auth.Principal{
+			Subject: "root", Scopes: []string{auth.ScopeAdmin},
+		}))
+	srv.handleMemoryBackfillEmbeddings(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+}
+
+// TestBackfillEmbeddings_ValidatesScope — scope_id is required because a backfill
+// with an empty one would sweep whatever the store treats as the empty scope,
+// which is not what any operator means.
+func TestBackfillEmbeddings_ValidatesScope(t *testing.T) {
+	srv, _ := makeServer(t, completingProvider(), makeBaseConfig())
+	srv.embedder = &backfillEmbedder{}
+	for _, q := range []string{
+		"?scope=bogus&scope_id=alice",
+		"?scope=user",
+	} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/v1/_memory/backfill_embeddings"+q, nil).
+			WithContext(auth.WithPrincipal(context.Background(), auth.Principal{
+				Subject: "root", Scopes: []string{auth.ScopeAdmin},
+			}))
+		srv.handleMemoryBackfillEmbeddings(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("%s: status = %d, want 400", q, rec.Code)
+		}
+	}
+}
+
+// TestEmbedTextForRow_UnwrapsAChunkBody — a chunk body is a JSON envelope, and
+// /v1/_memory/reembed embeds row.Value verbatim. Doing that here would index the
+// literal tokens `body` and `fields`, which for a short chunk could outweigh the
+// prose itself.
+func TestEmbedTextForRow_UnwrapsAChunkBody(t *testing.T) {
+	body := `{"body":"SAVEPOINT nesting is LIFO.","fields":null}`
+	got := embedTextForRow(store.MemoryEntry{Key: "doc.chunk:x", Value: json.RawMessage(body)})
+	if got != "SAVEPOINT nesting is LIFO." {
+		t.Errorf("got %q, want the unwrapped body", got)
+	}
+	// An ordinary row keeps the existing behaviour — its whole value is the text.
+	plain := embedTextForRow(store.MemoryEntry{Key: "memory/fact/x", Value: json.RawMessage(`"a fact"`)})
+	if plain != `"a fact"` {
+		t.Errorf("ordinary row = %q, want the raw value (unchanged behaviour)", plain)
+	}
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -3004,6 +3004,7 @@ func (s *Server) Mux() http.Handler {
 	// support OR no embedder is configured.
 	mux.Handle("GET /v1/_memory/embed_stats", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleMemoryEmbedStats))))
 	mux.Handle("POST /v1/_memory/reembed", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleMemoryReembed))))
+	mux.Handle("POST /v1/_memory/backfill_embeddings", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleMemoryBackfillEmbeddings))))
 	// v0.8.17 Snapshot capture (PR 2). Bearer-authed; same posture
 	// as /v1/_resolver. The full runtime-state JSON envelope; see
 	// internal/snapshot/snapshot.go for the wire shape.

--- a/internal/store/postgres/memory_embeddings.go
+++ b/internal/store/postgres/memory_embeddings.go
@@ -550,3 +550,61 @@ func decodePgvector(s string) ([]float32, error) {
 	}
 	return out, nil
 }
+
+// MemoryEmbedListMissing returns live rows with NO embedding, optionally under a
+// key prefix. See the Store interface for why MemoryEmbedListByModel cannot serve
+// this (it INNER JOINs the table these rows are absent from) and why paging by
+// re-calling is resumable without a cursor.
+func (s *Store) MemoryEmbedListMissing(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, keyPrefix string, limit int) ([]store.MemoryEntry, error) {
+	if !s.pgvectorEnabled {
+		return nil, store.ErrVectorUnsupported
+	}
+	if limit <= 0 || limit > 1000 {
+		limit = 200
+	}
+	// LEFT JOIN + IS NULL, the inverse of MemoryEmbedListByModel's inner join.
+	// Ordered by key so successive pages are stable while rows are being embedded
+	// out from under the query — an unordered scan could revisit or skip.
+	sql := `SELECT m.key, m.value, m.expires_at, m.created_at, m.updated_at
+	          FROM memory m
+	          LEFT JOIN memory_embeddings me
+	            ON me.tenant_id = m.tenant_id
+	           AND me.scope     = m.scope
+	           AND me.scope_id  = m.scope_id
+	           AND me.key       = m.key
+	         WHERE m.tenant_id = $1 AND m.scope = $2 AND m.scope_id = $3
+	           AND me.key IS NULL
+	           AND (m.expires_at IS NULL OR m.expires_at > now())
+	           AND m.superseded_at IS NULL`
+	args := []any{tenantID, string(scope), scopeID}
+	if keyPrefix != "" {
+		sql += ` AND m.key LIKE $4`
+		args = append(args, keyPrefix+"%")
+	}
+	sql += ` ORDER BY m.key LIMIT ` + strconv.Itoa(limit)
+
+	rows, err := s.pool.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, fmt.Errorf("MemoryEmbedListMissing query: %w", err)
+	}
+	defer rows.Close()
+	out := []store.MemoryEntry{}
+	for rows.Next() {
+		var (
+			e         store.MemoryEntry
+			valueByte []byte
+			expiresAt *time.Time
+		)
+		if err := rows.Scan(&e.Key, &valueByte, &expiresAt, &e.CreatedAt, &e.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("MemoryEmbedListMissing scan: %w", err)
+		}
+		e.Value = valueByte
+		// ExpiresAt is a plain time.Time; NULL stays the zero value, which is how
+		// the rest of this tier represents "no expiry".
+		if expiresAt != nil {
+			e.ExpiresAt = *expiresAt
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}

--- a/internal/store/sqlite/memory_embeddings.go
+++ b/internal/store/sqlite/memory_embeddings.go
@@ -51,3 +51,9 @@ func (s *Store) MemoryEmbedListByModel(ctx context.Context, tenantID string, sco
 func (s *Store) MemoryEmbedStats(ctx context.Context, tenantID string, scope store.MemoryScope) (store.MemoryEmbedStats, error) {
 	return store.MemoryEmbedStats{}, store.ErrVectorUnsupported
 }
+
+// MemoryEmbedListMissing — the non-vec sqlite tier has no embeddings at all, so
+// there is nothing to backfill.
+func (s *Store) MemoryEmbedListMissing(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, keyPrefix string, limit int) ([]store.MemoryEntry, error) {
+	return nil, store.ErrVectorUnsupported
+}

--- a/internal/store/sqlite/memory_embeddings_vec.go
+++ b/internal/store/sqlite/memory_embeddings_vec.go
@@ -88,3 +88,10 @@ func (s *Store) MemoryEmbedListByModel(ctx context.Context, tenantID string, sco
 func (s *Store) MemoryEmbedStats(ctx context.Context, tenantID string, scope store.MemoryScope) (store.MemoryEmbedStats, error) {
 	return store.MemoryEmbedStats{}, errVecImplPending
 }
+
+// MemoryEmbedListMissing — pending on the vec tier, matching the rest of the
+// reembed-listing family (MemoryEmbedListByModel, MemoryEmbedStats). The backfill
+// admin surface is postgres-only until that lands.
+func (s *Store) MemoryEmbedListMissing(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, keyPrefix string, limit int) ([]store.MemoryEntry, error) {
+	return nil, errVecImplPending
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1928,6 +1928,25 @@ type Store interface {
 	// Returns ErrVectorUnsupported on backends without vector ops.
 	MemoryEmbedListByModel(ctx context.Context, tenantID string, scope MemoryScope, scopeID, currentProvider, currentModel string, limit int) ([]MemoryEntry, error)
 
+	// MemoryEmbedListMissing returns live memory rows that have NO embedding at
+	// all, optionally restricted to a key prefix.
+	//
+	// Distinct from MemoryEmbedListByModel, which cannot serve this: that query
+	// starts FROM memory_embeddings and INNER JOINs memory, so it finds rows whose
+	// embedder differs — a row with no embedding row is invisible to it. Backfill
+	// needs the opposite direction, a LEFT JOIN with the embedding absent.
+	//
+	// The prefix is what makes a targeted backfill possible: "doc.chunk:" embeds
+	// document bodies without touching a scope's ordinary key/value rows, which an
+	// operator may deliberately have left unembedded.
+	//
+	// RESUMABILITY IS INHERENT rather than bookkept. Every embedded row drops out
+	// of this candidate set, so a sweep that dies at row 2,000 simply finds 1,114
+	// remaining on the next call — there is no cursor to persist and no way for a
+	// crash to double-embed or skip. Callers page by re-calling until the count is
+	// zero.
+	MemoryEmbedListMissing(ctx context.Context, tenantID string, scope MemoryScope, scopeID, keyPrefix string, limit int) ([]MemoryEntry, error)
+
 	// MemoryEmbedStats returns per-(provider, model) row counts and
 	// total embedding bytes for the given scope. Drives the v0.9.0
 	// PR 4 admin endpoint `/v1/_memory/embed_stats`. ErrVectorUnsupported

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -152,6 +153,7 @@ func Run(t *testing.T, factory Factory) {
 		{"InterruptDeleteAllByUser", testInterruptDeleteAllByUser},
 		{"ListTenants", testListTenants},
 		{"MemoryEmbedCascadesOnDelete", testMemoryEmbedCascadesOnDelete},
+		{"MemoryEmbedListMissing", testMemoryEmbedListMissing},
 		// RFC BL P2: the background-consolidation substrate.
 		{"MemorySupersedeHidesFromReads", testMemorySupersedeHidesFromReads},
 		{"MemorySupersedeIsIdempotent", testMemorySupersedeIsIdempotent},
@@ -11056,5 +11058,83 @@ func testMemoryEmbedCascadesOnDelete(t *testing.T, s store.Store) {
 	if _, err := s.MemoryEmbedGet(ctx, "", store.MemoryScopeUser, sid, key); err == nil {
 		t.Error("the embedding survived a scope-wide delete — an erasure would leave " +
 			"the subject's vectors behind")
+	}
+}
+
+// testMemoryEmbedListMissing pins the backfill candidate query (RFC BU phase 2).
+//
+// MemoryEmbedListByModel cannot serve a backfill: it starts FROM
+// memory_embeddings and INNER JOINs memory, so a row with NO embedding is
+// invisible to it. This is the inverse direction, and the test asserts the three
+// properties the backfill depends on: it finds unembedded rows, it EXCLUDES
+// already-embedded ones (which is what makes re-running safe), and the prefix
+// targets document bodies without touching a scope's ordinary key/value rows an
+// operator may have deliberately left unembedded.
+func testMemoryEmbedListMissing(t *testing.T, s store.Store) {
+	if !vectorRefusalCheck(t, s) {
+		return
+	}
+	ctx := context.Background()
+	const sid = "backfill"
+	v, _ := json.Marshal("prose")
+	set := func(key string, embed bool) {
+		t.Helper()
+		if err := s.MemorySet(ctx, "", store.MemoryScopeUser, sid, key, v, 0); err != nil {
+			t.Fatalf("MemorySet %s: %v", key, err)
+		}
+		if !embed {
+			return
+		}
+		if err := s.MemoryEmbedSet(ctx, "", store.MemoryScopeUser, sid, key, store.MemoryEmbedding{
+			Provider: "test", Model: "m", Dimension: 4,
+			Vector: floats32(1, 0, 0, 0), EmbedText: key, CreatedAt: time.Now(),
+		}); err != nil {
+			t.Fatalf("MemoryEmbedSet %s: %v", key, err)
+		}
+	}
+	set("doc.chunk:a", false)   // needs backfill
+	set("doc.chunk:b", false)   // needs backfill
+	set("doc.chunk:c", true)    // already embedded
+	set("memory/fact/x", false) // an ordinary row — must NOT be swept by a prefixed run
+
+	keysOf := func(rows []store.MemoryEntry) []string {
+		out := make([]string, 0, len(rows))
+		for _, r := range rows {
+			out = append(out, r.Key)
+		}
+		sort.Strings(out)
+		return out
+	}
+
+	got, err := s.MemoryEmbedListMissing(ctx, "", store.MemoryScopeUser, sid, "doc.chunk:", 100)
+	if err != nil {
+		t.Fatalf("MemoryEmbedListMissing: %v", err)
+	}
+	want := []string{"doc.chunk:a", "doc.chunk:b"}
+	if !reflect.DeepEqual(keysOf(got), want) {
+		t.Errorf("prefixed candidates = %v, want %v (c is embedded; the fact row is "+
+			"outside the prefix)", keysOf(got), want)
+	}
+
+	// Embedding one candidate must REMOVE it from the set — this is the whole
+	// resumability story: no cursor, the candidate set shrinks as work completes,
+	// so a sweep that dies mid-way resumes by simply asking again.
+	set("doc.chunk:a", true)
+	got2, err := s.MemoryEmbedListMissing(ctx, "", store.MemoryScopeUser, sid, "doc.chunk:", 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(keysOf(got2), []string{"doc.chunk:b"}) {
+		t.Errorf("after embedding one, candidates = %v, want just doc.chunk:b — an "+
+			"embedded row that stays a candidate would be re-embedded forever", keysOf(got2))
+	}
+
+	// No prefix sweeps the whole scope, including the ordinary row.
+	all, err := s.MemoryEmbedListMissing(ctx, "", store.MemoryScopeUser, sid, "", 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(keysOf(all), []string{"doc.chunk:b", "memory/fact/x"}) {
+		t.Errorf("unprefixed candidates = %v, want both remaining rows", keysOf(all))
 	}
 }


### PR DESCRIPTION
**RFC BU phase 2.** Phase 1 embeds chunk bodies on write, so a deployment's *existing* documents stay unsearchable until swept once — **3,114 chunks** on the reference deployment.

## Why not `/v1/_memory/reembed`

Not for want of a flag. Its candidate query starts `FROM memory_embeddings` and **INNER JOINs** memory, so it finds rows whose embedder *differs*. A row with **no** embedding row is structurally invisible to it.

`MemoryEmbedListMissing` is the inverse — a LEFT JOIN with the embedding absent — so it gets its own route rather than a mode flag on a differently-shaped one.

## Resumable without state

Every embedded row **drops out of the candidate query**. A sweep that dies at row 2,000 finds 1,114 remaining on the next call. No cursor to persist, so no way for a crash to double-embed or skip; the operator re-invokes until `candidates` is 0.

Idempotence and resumability are the same property here, not two features.

## Operator-facing, not a migration

Thousands of embedder calls while the runtime is starting is the wrong place for them, and on a metered embedder it's a bill nobody approved. `dry_run` defaults **true**, matching reembed.

```
POST /v1/_memory/backfill_embeddings?scope=user&scope_id=alice&prefix=doc.chunk:
```

The prefix makes it targeted — sweeps document bodies without touching ordinary key/value rows an operator may deliberately have left unembedded.

## Two smaller decisions

**`embedTextForRow` unwraps the chunk-body envelope.** reembed embeds `row.Value` verbatim; here that would index the literal tokens `body` and `fields` alongside the prose, and for a short chunk the envelope could outweigh the content. Ordinary rows keep existing behaviour.

**An unsupported tier refuses rather than reporting zero.** Reporting `0 candidates` would read as *"nothing to backfill, you're done"* to an operator whose entire corpus is unembedded. A missing capability and a swept corpus must not look alike. sqlite returns `ErrVectorUnsupported` / the vec-tier pending error — matching `MemoryEmbedListByModel` and `MemoryEmbedStats`, which are also postgres-only today.

## Tested

`testMemoryEmbedListMissing` asserts the three properties the sweep depends on: it finds unembedded rows, **excludes already-embedded ones** (embedding one removes it from the set — the resumability proof), and the prefix doesn't sweep ordinary rows. Verified on **real pgvector, 5.3s of work, not a skip.**

Plus handler tests for the unsupported-tier refusal, missing embedder, scope validation, and the envelope unwrap.

⚠️ One test now **SKIPS visibly** instead of passing. `TestBackfillEmbeddings_DefaultsToDryRun` previously returned 503, took the refusal branch, and reported PASS having asserted nothing about the dry-run default — the exact shape of false coverage this codebase has produced repeatedly. The refusal now has its own named test; the dry-run assertion runs only where the 200 path is reachable.

## Using it

```
# preview
curl -XPOST '…/v1/_memory/backfill_embeddings?scope=user&scope_id=<subject>&prefix=doc.chunk:'
# commit, repeat until candidates == 0
curl -XPOST '…&dry_run=false&limit=200'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8