### PR TITLE
feat(document): embed mermaid diagrams as extracted labels (RFC BU phase 3)

### DIFF
--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -642,7 +642,7 @@ type chunkBody struct {
 	Fields json.RawMessage `json:"fields,omitempty"`
 }
 
-func (d *Document) writeBody(ctx context.Context, mscope store.MemoryScope, scopeID, chunkID, body string, fields json.RawMessage) error {
+func (d *Document) writeBody(ctx context.Context, mscope store.MemoryScope, scopeID, chunkID, chunkType, body string, fields json.RawMessage) error {
 	v, _ := json.Marshal(chunkBody{Body: body, Fields: fields})
 	// RFC BL: key chunk bodies on the same tenant the document's dirent + SQL
 	// structure use (direntTenant = the raw RunIdentity tenant), so bodies and
@@ -657,26 +657,28 @@ func (d *Document) writeBody(ctx context.Context, mscope store.MemoryScope, scop
 	// unsearchable, but a chunk whose write was rejected because an embedder was
 	// cold is lost work the author has to redo. Authoring must not become
 	// embedder-dependent.
-	d.embedBody(ctx, tenant, mscope, scopeID, key, chunkID, body)
+	d.embedBody(ctx, tenant, mscope, scopeID, key, chunkID, chunkType, body)
 	return nil
 }
 
 // embedBody indexes a chunk body for semantic search, best-effort.
 //
-// WHAT text gets embedded is per chunk type, and phase 1 handles prose only:
+// WHAT text gets embedded is per chunk type:
 //
-//   - prose  → the body verbatim
-//   - image  → SKIPPED. The body is a rendered media form (a data URI or an
-//     asset reference); embedding it would index base64, which matches nothing
-//     and costs a vector row. A generated description is the planned input.
-//   - mermaid → SKIPPED. Diagram source tokenises to `graph TD`, `-->`, `[`,
-//     which carry no meaning. Deterministic label extraction is the planned
-//     input, and it needs no model — mermaid is text pretending to be a picture.
+//   - prose   → the body verbatim
+//   - mermaid → extracted labels + diagram kind (see document_mermaid.go).
+//     Diagram SOURCE tokenises to `graph TD`, `-->`, `[`, which carry no meaning.
+//   - image   → SKIPPED until phase 4. The body is a caption or a rendered media
+//     form; the searchable text is a generated description that does not exist yet.
 //
-// Skipping is not a silent no-op waiting to be forgotten: classifyMediaBody is
-// the same predicate export/import uses to recognise these forms, so a media
-// chunk that becomes embeddable later changes in one place.
-func (d *Document) embedBody(ctx context.Context, tenant string, mscope store.MemoryScope, scopeID, key, chunkID, body string) {
+// THE TYPE IS PASSED IN, NOT SNIFFED FROM THE BODY. An earlier version classified
+// with classifyMediaBody, which recognises only the ```mermaid FENCED form — but a
+// mermaid chunk STORES its bare source (export re-adds the fence), so a natively
+// created diagram was embedded as raw source while an imported one was skipped.
+// Sniffing cannot be repaired either: `mermaidKindRe` on a first line would match a
+// prose chunk that happens to open with the word "pie". The chunk type is the only
+// authoritative answer, so callers supply it.
+func (d *Document) embedBody(ctx context.Context, tenant string, mscope store.MemoryScope, scopeID, key, chunkID, chunkType, body string) {
 	if d.Embedder == nil {
 		return
 	}
@@ -684,7 +686,25 @@ func (d *Document) embedBody(ctx context.Context, tenant string, mscope store.Me
 	if text == "" {
 		return
 	}
-	if typ, _, _, _ := classifyMediaBody(body); typ != "" {
+	switch chunkType {
+	case "image":
+		return
+	case "mermaid":
+		text = mermaidEmbedText(body)
+	default:
+		// A body that is ENTIRELY a fenced diagram or a data-URL image, on a chunk
+		// whose type was not set: the same predicate export/import uses, so the two
+		// paths cannot disagree about what a media body is.
+		if typ, _, _, src := classifyMediaBody(body); typ != "" {
+			if typ != "mermaid" {
+				return
+			}
+			text = mermaidEmbedText(src)
+		}
+	}
+	// A diagram with no extractable label embeds nothing rather than embedding
+	// punctuation: a vector built from syntax can only produce false matches.
+	if text == "" {
 		return
 	}
 	vec, err := d.Embedder.Embed(ctx, []string{text})
@@ -989,7 +1009,7 @@ func (d *Document) createDocument(ctx context.Context, key sqlmem.ScopeKey, msco
 		rootID, docID, nullIfEmpty(in.Type), nullIfEmpty(in.Status), in.Title, now, now); err != nil {
 		return errResult("create_document: root chunk: " + err.Error()), nil
 	}
-	if err := d.writeBody(ctx, mscope, key.ScopeID, rootID, "", nil); err != nil {
+	if err := d.writeBody(ctx, mscope, key.ScopeID, rootID, "", "", nil); err != nil {
 		return errResult("create_document: root body: " + err.Error()), nil
 	}
 	// A document's tags are its own (independent of the root chunk's tags).
@@ -1531,7 +1551,7 @@ func (d *Document) createChunk(ctx context.Context, key sqlmem.ScopeKey, mscope 
 	if insErr != nil {
 		return errResult("create_chunk: " + insErr.Error()), nil
 	}
-	if err := d.writeBody(ctx, mscope, key.ScopeID, id, in.Body, in.Fields); err != nil {
+	if err := d.writeBody(ctx, mscope, key.ScopeID, id, in.Type, in.Body, in.Fields); err != nil {
 		return errResult("create_chunk: body: " + err.Error()), nil
 	}
 	// Seed the body-change log at revision 1 (RFC BS Phase 3a) — the chunk's body
@@ -1709,7 +1729,7 @@ func (d *Document) setAsset(ctx context.Context, key sqlmem.ScopeKey, mscope sto
 		fields["filename"] = in.Filename
 	}
 	nf, _ := json.Marshal(fields)
-	if err := d.writeBody(ctx, mscope, key.ScopeID, in.ID, cb.Body, nf); err != nil {
+	if err := d.writeBody(ctx, mscope, key.ScopeID, in.ID, "image", cb.Body, nf); err != nil {
 		return errResult("set_asset: fields: " + err.Error()), nil
 	}
 	// set_asset sets type='image' on the chunk; if that chunk is a document's root,
@@ -1833,6 +1853,13 @@ func (d *Document) updateChunk(ctx context.Context, key sqlmem.ScopeKey, mscope 
 	_, hasBody := present["body"]
 	_, hasFields := present["fields"]
 	if hasBody || hasFields {
+		// The type that will be in force AFTER this update decides the embedding
+		// policy — a chunk being turned into a mermaid diagram in the same call
+		// that sets its body must embed as a diagram, not as prose.
+		effType := row.Type
+		if _, has := present["type"]; has {
+			effType = in.Type
+		}
 		var cb chunkBody
 		if !hasBody || !hasFields {
 			// Only one half was supplied, so the other must be preserved from
@@ -1855,7 +1882,7 @@ func (d *Document) updateChunk(ctx context.Context, key sqlmem.ScopeKey, mscope 
 		if hasFields {
 			cb.Fields = in.Fields
 		}
-		if err := d.writeBody(ctx, mscope, key.ScopeID, in.ID, cb.Body, cb.Fields); err != nil {
+		if err := d.writeBody(ctx, mscope, key.ScopeID, in.ID, effType, cb.Body, cb.Fields); err != nil {
 			return errResult("update_chunk: body: " + err.Error()), nil
 		}
 		// Re-derive [[name]] link edges only when the BODY actually changed (RFC BS
@@ -3144,7 +3171,7 @@ func (d *Document) importMD(ctx context.Context, key sqlmem.ScopeKey, mscope sto
 		}
 		docID = resultField(cd, "document_id")
 		rootID = resultField(cd, "root_chunk_id")
-		if err := d.writeBody(ctx, mscope, key.ScopeID, rootID, first.body, first.fields); err != nil {
+		if err := d.writeBody(ctx, mscope, key.ScopeID, rootID, first.typ, first.body, first.fields); err != nil {
 			return errResult("import_md: root body: " + err.Error()), nil
 		}
 		if first.typ != "" || first.status != "" {

--- a/internal/tools/builtin/document_embed_test.go
+++ b/internal/tools/builtin/document_embed_test.go
@@ -73,31 +73,25 @@ func TestEmbedBody_ProseIsEmbeddedWithItsBodyText(t *testing.T) {
 	}
 }
 
-// TestEmbedBody_MediaBodiesAreSkipped — an image body is a rendered media form (a
-// data URI) and a mermaid body is diagram source. Embedding either indexes noise:
-// base64 matches nothing, and `graph TD` / `-->` / `[` carry no meaning while
-// dominating the tokens. Both get their own policy in later phases (a generated
-// description; deterministic label extraction), so phase 1 must SKIP them rather
-// than index garbage and call documents searchable.
-func TestEmbedBody_MediaBodiesAreSkipped(t *testing.T) {
-	for _, tc := range []struct{ name, body string }{
-		{"mermaid", "```mermaid\ngraph TD; A[User] -->|reads| B[(Memory)]\n```"},
-		{"image", "![diagram](data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==)"},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			d, ctx, docID, root := entityFixture(t)
-			emb := &recordingEmbedder{}
-			d.Embedder = emb
-			bj, _ := json.Marshal(tc.body)
-			if _, r := docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+docID+
-				`","parent_id":"`+root+`","title":"media","body":`+string(bj)+`}`); r.IsError {
-				t.Fatalf("create_chunk: %s", r.Text)
-			}
-			if seen := emb.seen(); len(seen) != 0 {
-				t.Errorf("a %s body was embedded: %q — media needs its own policy, "+
-					"not the raw form", tc.name, seen)
-			}
-		})
+// TestEmbedBody_ImageBodiesAreSkipped — an image body is a rendered media form (a
+// data URI): embedding it indexes base64, which matches nothing while consuming the
+// scope's vector quota. The searchable text for an image is a generated description,
+// which phase 4 owns, so it is skipped rather than indexed as garbage.
+//
+// Mermaid was skipped here too until phase 3 gave it deterministic label extraction
+// — see document_mermaid_test.go, which now asserts the opposite for diagrams.
+func TestEmbedBody_ImageBodiesAreSkipped(t *testing.T) {
+	d, ctx, docID, root := entityFixture(t)
+	emb := &recordingEmbedder{}
+	d.Embedder = emb
+	bj, _ := json.Marshal("![diagram](data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==)")
+	if _, r := docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+docID+
+		`","parent_id":"`+root+`","title":"media","body":`+string(bj)+`}`); r.IsError {
+		t.Fatalf("create_chunk: %s", r.Text)
+	}
+	if seen := emb.seen(); len(seen) != 0 {
+		t.Errorf("an image body was embedded: %q — the searchable text for an image is "+
+			"a generated description, not the data URI", seen)
 	}
 }
 

--- a/internal/tools/builtin/document_entity.go
+++ b/internal/tools/builtin/document_entity.go
@@ -150,7 +150,7 @@ func (d *Document) updateChunkForUpsert(ctx context.Context, key sqlmem.ScopeKey
 				fields = cur.Fields
 			}
 		}
-		return d.writeBody(ctx, mscope, key.ScopeID, chunkID, body, fields)
+		return d.writeBody(ctx, mscope, key.ScopeID, chunkID, "", body, fields)
 	}
 	return nil
 }

--- a/internal/tools/builtin/document_mermaid.go
+++ b/internal/tools/builtin/document_mermaid.go
@@ -1,0 +1,233 @@
+package builtin
+
+// document_mermaid.go — what text to embed for a mermaid chunk (RFC BU phase 3).
+//
+// Embedding mermaid SOURCE is poor: `graph TD`, `-->`, `[`, `|` dominate the
+// tokens and carry no meaning, so a diagram about authentication ranks against
+// every other flowchart rather than against the word "authentication".
+//
+// Embedding a RENDERED description would work and is wrong here: it pays a vision
+// call for information that is already text. That is the rule this file exists to
+// apply — USE A MODEL ONLY WHEN THE CONTENT IS NOT ALREADY TEXT. Mermaid is text
+// pretending to be a picture; an image is a picture. Treating them alike would cost
+// a vision call per diagram for a worse result than a regex.
+//
+// ONE EXTRACTOR, NOT EIGHT PARSERS. Mermaid has a dozen dialects and each has its
+// own grammar, but they share how they carry human language: labels sit in
+// brackets, in quotes, after a colon, or between pipes. A per-dialect parser would
+// buy marginal recall for a permanent maintenance burden — every new mermaid
+// release could break one. So this extracts the label-bearing shapes generically
+// and names the diagram kind, which is enough for retrieval and cannot silently
+// stop working when mermaid adds a diagram type.
+
+import (
+	"regexp"
+	"strings"
+)
+
+// mermaidKindRe reads the diagram kind from the first meaningful line.
+var mermaidKindRe = regexp.MustCompile(`^\s*(graph|flowchart|sequenceDiagram|classDiagram|stateDiagram(?:-v2)?|erDiagram|gantt|pie|mindmap|journey|gitGraph|quadrantChart|timeline|C4Context)\b`)
+
+// mermaidLabelRes are the shapes that carry human language, in the order a reader
+// would encounter them. Each capture group is a candidate label.
+var mermaidLabelRes = []*regexp.Regexp{
+	// Bracketed node text, innermost first so [(Memory)] yields "Memory" rather
+	// than "(Memory)". Also covers ((circle)), {rhombus}, >flag], [[subroutine]].
+	regexp.MustCompile(`\[\(([^)\]]+)\)\]`),
+	regexp.MustCompile(`\(\(([^)]+)\)\)`),
+	regexp.MustCompile(`\[\[([^\]]+)\]\]`),
+	regexp.MustCompile(`\[([^\]|]+)\]`),
+	regexp.MustCompile(`\{\{?([^}]+)\}?\}`),
+	regexp.MustCompile(`\(([^)]+)\)`),
+	// Edge labels: -->|text| and -- text -->
+	regexp.MustCompile(`\|([^|]+)\|`),
+	regexp.MustCompile(`--\s+([^->|]+?)\s+--[->]`),
+	// Quoted text (pie slices, C4, quadrant titles).
+	regexp.MustCompile(`"([^"]+)"`),
+	// `participant A as Alice` / `class Foo as Bar` — the alias is the human name.
+	regexp.MustCompile(`\bas\s+([A-Za-z0-9_][^\n;]*)`),
+	// Anything after a colon: sequence messages, state transition labels, gantt
+	// task names, section titles.
+	regexp.MustCompile(`:\s*([^\n:;]+)`),
+}
+
+// mermaidNoise are tokens that survive extraction but say nothing. Matched
+// case-insensitively against a whole candidate, so a label CONTAINING one of these
+// words is kept — only a label that is nothing but syntax is dropped.
+var mermaidNoise = map[string]bool{
+	"td": true, "tb": true, "lr": true, "rl": true, "bt": true,
+	"as": true, "root": true, "of": true, "over": true, "right": true, "left": true,
+	"participant": true, "actor": true, "class": true, "state": true,
+	"section": true, "title": true, "autonumber": true, "direction": true,
+	"subgraph": true, "end": true, "note": true, "loop": true, "alt": true,
+	"else": true, "opt": true, "par": true, "and": true, "rect": true,
+	"activate": true, "deactivate": true, "click": true, "style": true,
+	"classdef": true, "linkstyle": true, "accdescr": true, "acctitle": true,
+	// The diagram keywords themselves: pass 2 sweeps words, and the kind line's
+	// keyword would otherwise appear in the labels (classDiagram leaked this way).
+	"graph": true, "flowchart": true, "sequencediagram": true, "classdiagram": true,
+	"statediagram": true, "statediagram-v2": true, "erdiagram": true, "gantt": true,
+	"pie": true, "mindmap": true, "journey": true, "gitgraph": true,
+	"quadrantchart": true, "timeline": true, "c4context": true,
+	// Common gantt/date noise that survives the letter check.
+	"dateformat": true, "axisformat": true, "todaymarker": true, "excludes": true,
+}
+
+// mermaidStripRe removes syntax so the FALLBACK (an unrecognised diagram kind with
+// no extractable labels) still embeds words rather than punctuation.
+var mermaidStripRe = regexp.MustCompile(`[-=.]{2,}[>ox|]?|[\[\]{}()|;>]+|--`)
+
+// mermaidEmbedText renders a mermaid source into the text worth embedding.
+//
+// TWO PASSES, and the second is what makes this work across dialects.
+//
+// Pass 1 takes bracketed / quoted / piped text as PHRASES, so "Backfill plan"
+// survives as a phrase rather than two tokens where mermaid marks it as one label.
+//
+// Pass 2 sweeps every remaining WORD after syntax removal. That pass is not a
+// fallback — it is load-bearing. A first attempt at this used shape regexes alone
+// and lost the content of half the dialects: erDiagram entity names (CHUNK,
+// EMBEDDING) are bare identifiers, gantt task names sit BEFORE the colon while the
+// metadata sits after it, and mindmap nodes are bare indented words. Anything that
+// is a word survives; anything that is syntax does not.
+//
+// Returns "" when there is nothing to index — an empty diagram, or one that is
+// purely structural. The caller then skips embedding rather than storing a vector
+// for punctuation, which is a row that can only produce false matches.
+func mermaidEmbedText(src string) string {
+	src = strings.TrimSpace(src)
+	if src == "" {
+		return ""
+	}
+	kind := ""
+	var labels []string
+	seen := map[string]bool{}
+	var meaningful []string
+
+	for _, raw := range strings.Split(src, "\n") {
+		line := strings.TrimSpace(raw)
+		// %% is a mermaid comment. Dropped HERE so it cannot reach either pass —
+		// the first version leaked comment text into the word sweep.
+		if line == "" || strings.HasPrefix(line, "%%") {
+			continue
+		}
+		if kind == "" {
+			if m := mermaidKindRe.FindStringSubmatch(line); m != nil {
+				kind = normalizeMermaidKind(m[1])
+				// Drop only the keyword; the rest of the line may carry a title.
+				line = strings.TrimSpace(strings.Replace(line, m[1], "", 1))
+			}
+		}
+		meaningful = append(meaningful, line)
+		for _, re := range mermaidLabelRes {
+			for _, m := range re.FindAllStringSubmatch(line, -1) {
+				addMermaidLabel(&labels, seen, m[1])
+			}
+		}
+	}
+
+	// Pass 2: every word that is not syntax, not a keyword, and not a bare node id.
+	joined := strings.Join(meaningful, " ")
+	for _, w := range strings.Fields(mermaidStripRe.ReplaceAllString(joined, " ")) {
+		addMermaidLabel(&labels, seen, w)
+	}
+
+	if len(labels) == 0 {
+		return ""
+	}
+	body := strings.Join(labels, " ")
+	if kind == "" {
+		return body
+	}
+	// The kind is prefixed rather than dropped: "flowchart" / "sequence diagram" is
+	// itself a useful query term when someone asks for a diagram of something.
+	return kind + ": " + body
+}
+
+// addMermaidLabel appends a cleaned candidate, deduped, preserving reading order.
+func addMermaidLabel(labels *[]string, seen map[string]bool, candidate string) {
+	s := strings.TrimSpace(candidate)
+	s = strings.Trim(s, `"'`)
+	// Mermaid's shape and edge punctuation, plus the member-visibility sigils
+	// classDiagram uses (+writeBody → writeBody).
+	s = strings.Trim(s, "()[]{}<>-|:,+#~*")
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return
+	}
+	// An opening bracket whose partner was trimmed off the end: `MemorySet(body)`
+	// reaches here as `MemorySet(body`. Cut at the bracket rather than keep a
+	// half-token — the inner text was already captured by the bracket regex.
+	if i := strings.IndexAny(s, "([{"); i > 0 && !strings.ContainsAny(s, ")]}") {
+		s = strings.TrimSpace(s[:i])
+		if s == "" {
+			return
+		}
+	}
+	low := strings.ToLower(s)
+	if mermaidNoise[low] {
+		return
+	}
+	// A bare node id says nothing: a single character, or a short all-caps/alnum
+	// token with no vowel-bearing word in it (A1, B, CHUNK is kept because it is
+	// long enough to be a name). The threshold is deliberately generous — a false
+	// keep costs one token of noise, a false drop loses an entity name.
+	if len(s) < 2 {
+		return
+	}
+	if !strings.ContainsFunc(s, func(r rune) bool {
+		return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
+	}) {
+		// Pure numbers / dates / durations: gantt metadata, pie values.
+		return
+	}
+	if seen[low] {
+		return
+	}
+	seen[low] = true
+	// A multi-word PHRASE claims its constituent words too, so the word sweep does
+	// not re-add them individually. Without this, "embedder succeeded" is followed
+	// by "embedder" and "succeeded" — the same content three times, which skews the
+	// embedding toward whatever happens to be bracketed.
+	if fields := strings.Fields(low); len(fields) > 1 {
+		for _, w := range fields {
+			seen[strings.Trim(w, "()[]{}<>-|:,+#~*")] = true
+		}
+	}
+	*labels = append(*labels, s)
+}
+
+// normalizeMermaidKind turns a mermaid keyword into a phrase a human would search
+// for. `graph` becomes "flowchart" because that is what mermaid's own docs call it
+// and what someone looking for one would type.
+func normalizeMermaidKind(kw string) string {
+	switch kw {
+	case "graph", "flowchart":
+		return "flowchart"
+	case "sequenceDiagram":
+		return "sequence diagram"
+	case "classDiagram":
+		return "class diagram"
+	case "stateDiagram", "stateDiagram-v2":
+		return "state diagram"
+	case "erDiagram":
+		return "entity relationship diagram"
+	case "gantt":
+		return "gantt chart"
+	case "pie":
+		return "pie chart"
+	case "mindmap":
+		return "mindmap"
+	case "journey":
+		return "user journey"
+	case "gitGraph":
+		return "git graph"
+	case "quadrantChart":
+		return "quadrant chart"
+	case "timeline":
+		return "timeline"
+	case "C4Context":
+		return "C4 context diagram"
+	}
+	return kw
+}

--- a/internal/tools/builtin/document_mermaid_test.go
+++ b/internal/tools/builtin/document_mermaid_test.go
@@ -1,0 +1,310 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/channels"
+	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// TestMermaidEmbedText_KeepsLanguageDropsSyntax asserts the property that matters
+// for retrieval, per dialect: every human-authored word survives, and no mermaid
+// syntax token does.
+//
+// The `want` lists are the CONTENT of each diagram — an assertion that this
+// extractor loses nothing. That is the axis a regex extractor actually fails on: a
+// first draft here used shape regexes only and silently dropped erDiagram entity
+// names, gantt task names and mindmap nodes, all of which pass a "no syntax
+// leaked" check because what leaked was nothing at all.
+func TestMermaidEmbedText_KeepsLanguageDropsSyntax(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		kind string   // expected diagram-kind prefix
+		want []string // words that MUST survive
+		deny []string // tokens that must NOT appear
+	}{
+		{
+			name: "flowchart",
+			src:  "graph TD\n  A[User] -->|reads| B[(Memory)]",
+			kind: "flowchart",
+			want: []string{"User", "reads", "Memory"},
+			deny: []string{"-->", "[", "|", "TD", "graph"},
+		},
+		{
+			name: "flowchart_decision",
+			src:  "flowchart LR\n  Agent{Decision} -- writes --> Store[[Store]]",
+			kind: "flowchart",
+			want: []string{"Agent", "Decision", "writes", "Store"},
+			deny: []string{"{", "}", "-->", "--", "LR"},
+		},
+		{
+			name: "sequence",
+			src:  "sequenceDiagram\n  participant A as Agent\n  participant S as Store\n  A->>S: MemorySet(body)\n  S-->>A: ok",
+			kind: "sequence diagram",
+			want: []string{"Agent", "Store", "MemorySet", "body", "ok"},
+			deny: []string{"->>", "-->>", "participant", " as "},
+		},
+		{
+			name: "class",
+			src:  "classDiagram\n  class Document {\n    +writeBody()\n  }\n  Document --> Chunk",
+			kind: "class diagram",
+			want: []string{"Document", "writeBody", "Chunk"},
+			// classDiagram is the kind keyword; it must not ALSO appear as a label.
+			deny: []string{"classDiagram", "+", "-->"},
+		},
+		{
+			name: "state",
+			src:  "stateDiagram-v2\n  [*] --> Pending\n  Pending --> Embedded: embedder succeeded",
+			kind: "state diagram",
+			want: []string{"Pending", "Embedded", "embedder succeeded"},
+			deny: []string{"[*]", "-->"},
+		},
+		{
+			// Entity names here are BARE identifiers, not bracketed — the case a
+			// label-shape-only extractor loses entirely.
+			name: "er_bare_entities",
+			src:  "erDiagram\n  CHUNK ||--o{ EMBEDDING : has",
+			kind: "entity relationship diagram",
+			want: []string{"CHUNK", "EMBEDDING", "has"},
+			deny: []string{"||--o{", "{"},
+		},
+		{
+			// gantt task names sit BEFORE the colon while metadata sits after it.
+			name: "gantt_task_names",
+			src:  "gantt\n  title Backfill plan\n  section Phase 1\n  Embed on write :a1, 2026-08-01, 3d",
+			kind: "gantt chart",
+			want: []string{"Backfill plan", "Phase", "Embed on write"},
+			deny: []string{"title", "section"},
+		},
+		{
+			name: "pie",
+			src:  "pie title Embedding coverage\n  \"Embedded\" : 70\n  \"Missing\" : 30",
+			kind: "pie chart",
+			want: []string{"Embedding coverage", "Embedded", "Missing"},
+			deny: []string{"\"", "title"},
+		},
+		{
+			// mindmap nodes are bare INDENTED words with no delimiter at all.
+			name: "mindmap_bare_nodes",
+			src:  "mindmap\n  root((Memory))\n    Facts\n    Documents",
+			kind: "mindmap",
+			want: []string{"Memory", "Facts", "Documents"},
+			deny: []string{"((", "root"},
+		},
+		{
+			// An unrecognised kind must DEGRADE, not vanish: mermaid adds diagram
+			// types, and a new one must still index its words.
+			name: "unknown_kind_degrades",
+			src:  "someNewDiagram\n  Alpha --> Beta",
+			kind: "",
+			want: []string{"Alpha", "Beta"},
+			deny: []string{"-->"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mermaidEmbedText(tc.src)
+			if tc.kind != "" && !strings.HasPrefix(got, tc.kind+": ") {
+				t.Errorf("kind prefix: want %q, got %q", tc.kind+": ", got)
+			}
+			for _, w := range tc.want {
+				if !strings.Contains(got, w) {
+					t.Errorf("LOST content %q\n  got: %q", w, got)
+				}
+			}
+			for _, d := range tc.deny {
+				// The kind prefix legitimately contains its own name, so compare
+				// against the body only.
+				body := got
+				if i := strings.Index(got, ": "); tc.kind != "" && i >= 0 {
+					body = got[i+2:]
+				}
+				if strings.Contains(body, d) {
+					t.Errorf("syntax %q leaked into labels\n  got: %q", d, got)
+				}
+			}
+		})
+	}
+}
+
+// TestMermaidEmbedText_EmptyWhenNothingToIndex — a diagram with no human language
+// must yield "", so embedBody skips it. Embedding punctuation would store a vector
+// that can only ever produce false matches, which is worse than being unsearchable.
+func TestMermaidEmbedText_EmptyWhenNothingToIndex(t *testing.T) {
+	for _, src := range []string{
+		"",
+		"   \n  \n",
+		"%% just a comment\n%% another",
+		"graph TD",
+	} {
+		if got := mermaidEmbedText(src); got != "" {
+			t.Errorf("mermaidEmbedText(%q) = %q, want \"\"", src, got)
+		}
+	}
+}
+
+// TestMermaidEmbedText_DoesNotRepeatPhraseWords — a phrase and its own words must
+// not both appear. Triple-counting whatever happens to be bracketed skews the
+// vector toward it.
+func TestMermaidEmbedText_DoesNotRepeatPhraseWords(t *testing.T) {
+	got := mermaidEmbedText("stateDiagram-v2\n  Pending --> Embedded: embedder succeeded")
+	if n := strings.Count(got, "embedder"); n != 1 {
+		t.Errorf("word 'embedder' appears %d times, want 1: %q", n, got)
+	}
+	if n := strings.Count(got, "succeeded"); n != 1 {
+		t.Errorf("word 'succeeded' appears %d times, want 1: %q", n, got)
+	}
+}
+
+// mermaidDocFixture wires a Document tool to the capturing vector store + fake
+// embedder, so a test can read back the exact text that was embedded.
+func mermaidDocFixture(t *testing.T, vocab ...string) (*Document, *vectorStore, context.Context) {
+	t.Helper()
+	base, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = base.Close() })
+	vs := newVectorStore(base)
+	mgr, err := sqlmem.New(sqlmem.Config{Root: t.TempDir()})
+	if err != nil {
+		t.Fatalf("sqlmem.New: %v", err)
+	}
+	t.Cleanup(func() { _ = mgr.Close() })
+	ctx := tools.WithAgentName(context.Background(), "doc-agent")
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a", UserID: "u1", TenantID: "tnt"})
+	d := &Document{Store: vs, SqlMem: mgr, Bus: channels.NewBus(),
+		Embedder: newFakeEmbedder("fake", "m1", vocab...)}
+	return d, vs, ctx
+}
+
+// embeddedTextFor returns the text that was embedded for a chunk, or "" if none.
+func embeddedTextFor(t *testing.T, vs *vectorStore, chunkID string) string {
+	t.Helper()
+	e, err := vs.MemoryEmbedGet(context.Background(), "", store.MemoryScopeUser, "u1", chunkBodyKey(chunkID))
+	if err != nil {
+		return ""
+	}
+	return e.EmbedText
+}
+
+// TestEmbedBody_MermaidChunkEmbedsLabelsNotSource is the REGRESSION test for the
+// bug this phase found: embedBody classified with classifyMediaBody, which
+// recognises only the ```mermaid FENCED form — but a mermaid chunk STORES its bare
+// source. So a chunk created with type=mermaid was embedded as raw diagram source
+// (`graph`, `TD`, `-->` and all), while the identical diagram arriving through
+// import_md was skipped. The fix threads the authoritative chunk type in.
+//
+// FAIL-BEFORE: reverting embedBody to `if typ,_,_,_ := classifyMediaBody(body);
+// typ != "" { return }` makes this fail with the raw source as embed_text.
+func TestEmbedBody_MermaidChunkEmbedsLabelsNotSource(t *testing.T) {
+	d, vs, ctx := mermaidDocFixture(t, "user", "reads", "memory", "flowchart")
+
+	res, err := d.Execute(ctx, json.RawMessage(`{"op":"create_document","title":"Diagrams"}`))
+	if err != nil || res.IsError {
+		t.Fatalf("create_document: %v %s", err, res.Text)
+	}
+	docID := resultField(res, "document_id")
+
+	src := "graph TD\n  A[User] -->|reads| B[(Memory)]"
+	body, _ := json.Marshal(map[string]any{
+		"op": "create_chunk", "document_id": docID, "title": "Flow",
+		"type": "mermaid", "body": src,
+	})
+	res, err = d.Execute(ctx, body)
+	if err != nil || res.IsError {
+		t.Fatalf("create_chunk: %v %s", err, res.Text)
+	}
+	chunkID := resultField(res, "id")
+	if chunkID == "" {
+		t.Fatalf("no chunk id in %s", res.Text)
+	}
+
+	got := embeddedTextFor(t, vs, chunkID)
+	if got == "" {
+		t.Fatal("mermaid chunk was not embedded at all")
+	}
+	// The words, without the syntax.
+	for _, w := range []string{"User", "reads", "Memory", "flowchart"} {
+		if !strings.Contains(got, w) {
+			t.Errorf("embed text lost %q: %q", w, got)
+		}
+	}
+	if strings.Contains(got, "-->") || strings.Contains(got, "TD") {
+		t.Errorf("embed text is raw diagram source, not labels: %q", got)
+	}
+	// And the BODY is untouched — only the embedded text differs.
+	stored, rerr := d.readBody(ctx, store.MemoryScopeUser, "u1", chunkID)
+	if rerr != nil {
+		t.Fatalf("readBody: %v", rerr)
+	}
+	if stored.Body != src {
+		t.Errorf("stored body was rewritten:\n want %q\n  got %q", src, stored.Body)
+	}
+}
+
+// TestEmbedBody_ImageChunkNotEmbedded — an image body is a caption or a data URL;
+// until phase 4 generates a description there is no text worth indexing, and
+// embedding base64 would match nothing while consuming the scope's vector quota.
+func TestEmbedBody_ImageChunkNotEmbedded(t *testing.T) {
+	d, vs, ctx := mermaidDocFixture(t, "diagram", "screenshot")
+
+	res, _ := d.Execute(ctx, json.RawMessage(`{"op":"create_document","title":"Shots"}`))
+	docID := resultField(res, "document_id")
+	body, _ := json.Marshal(map[string]any{
+		"op": "create_chunk", "document_id": docID, "title": "Shot",
+		"type": "image", "body": "a screenshot of the diagram",
+	})
+	res, err := d.Execute(ctx, body)
+	if err != nil || res.IsError {
+		t.Fatalf("create_chunk: %v %s", err, res.Text)
+	}
+	if got := embeddedTextFor(t, vs, resultField(res, "id")); got != "" {
+		t.Errorf("image chunk was embedded (%q); phase 4 owns image text", got)
+	}
+}
+
+// TestEmbedBody_TypeChangeToMermaidReembedsAsLabels — turning a prose chunk into a
+// diagram in the same update that sets its body must use the NEW type. Reading the
+// pre-update row's type would embed diagram source as prose.
+func TestEmbedBody_TypeChangeToMermaidReembedsAsLabels(t *testing.T) {
+	d, vs, ctx := mermaidDocFixture(t, "user", "reads", "memory", "flowchart", "draft")
+
+	res, _ := d.Execute(ctx, json.RawMessage(`{"op":"create_document","title":"Evolving"}`))
+	docID := resultField(res, "document_id")
+	body, _ := json.Marshal(map[string]any{
+		"op": "create_chunk", "document_id": docID, "title": "Later a diagram",
+		"body": "draft prose",
+	})
+	res, err := d.Execute(ctx, body)
+	if err != nil || res.IsError {
+		t.Fatalf("create_chunk: %v %s", err, res.Text)
+	}
+	chunkID := resultField(res, "id")
+	if got := embeddedTextFor(t, vs, chunkID); got != "draft prose" {
+		t.Fatalf("prose precondition: want %q, got %q", "draft prose", got)
+	}
+
+	upd, _ := json.Marshal(map[string]any{
+		"op": "update_chunk", "id": chunkID, "revision": 1,
+		"type": "mermaid", "body": "graph TD\n  A[User] -->|reads| B[(Memory)]",
+	})
+	res, err = d.Execute(ctx, upd)
+	if err != nil || res.IsError {
+		t.Fatalf("update_chunk: %v %s", err, res.Text)
+	}
+	got := embeddedTextFor(t, vs, chunkID)
+	if strings.Contains(got, "-->") {
+		t.Errorf("embedded as prose using the PRE-update type: %q", got)
+	}
+	if !strings.Contains(got, "User") || !strings.Contains(got, "flowchart") {
+		t.Errorf("not embedded as a diagram: %q", got)
+	}
+}


### PR DESCRIPTION
## Why

A mermaid chunk is not searchable. Phase 1 deliberately skipped diagrams, because embedding their **source** indexes `graph TD`, `-->` and `[` — tokens that dominate the vector and carry no meaning, so a diagram about authentication ranks against every other flowchart rather than against the word "authentication".

## What

Diagrams get a deterministic embedding text: node labels, edge labels, and the diagram kind.

```
graph TD; A[User] -->|reads| B[(Memory)]   →   "flowchart: User reads Memory"
```

**No model call.** That asymmetry with images is the rule the new file exists to apply: *use a model only when the content is not already text.* Mermaid is text pretending to be a picture; an image is a picture. A vision pass per diagram would cost more for a worse result than a regex.

**One extractor, not eight parsers**, in two passes:

- **Pass 1** takes bracketed / quoted / piped text as **phrases**, so a multi-word label survives intact.
- **Pass 2** sweeps every remaining **word** after syntax removal. This is load-bearing rather than a fallback: a first draft used shape regexes alone and silently lost `erDiagram` entity names (bare identifiers), `gantt` task names (they precede the colon while the metadata follows it), and `mindmap` nodes (bare indented words).

A phrase claims its own constituent words, so the two passes cannot triple-count whatever happens to be bracketed.

### It also fixes a real bug the phase surfaced

`embedBody` classified with `classifyMediaBody`, which recognises only the ` ```mermaid ` **fenced** form — but a mermaid chunk **stores its bare source** (export re-adds the fence). So a natively created diagram was embedded as **raw source**, while the identical diagram arriving through `import_md` was skipped. Inconsistent, and the wrong half was the common one.

Sniffing cannot be repaired either: a kind regex on a first line matches a prose chunk that opens with the word "pie". So `writeBody` now takes the **authoritative chunk type**, and `update_chunk` passes the *post*-update type — a prose chunk being turned into a diagram in the same call that sets its body embeds as a diagram.

## Coverage across dialects

| dialect | embedded text |
|---|---|
| `flowchart` | `flowchart: Memory User reads` |
| `sequenceDiagram` | `sequence diagram: Agent Store body MemorySet ok` |
| `classDiagram` | `class diagram: Document writeBody Chunk` |
| `stateDiagram-v2` | `state diagram: embedder succeeded Pending Embedded` |
| `erDiagram` | `entity relationship diagram: has CHUNK EMBEDDING` |
| `gantt` | `gantt chart: … Backfill plan Phase Embed on write` |
| `pie` | `pie chart: Embedded Missing Embedding coverage` |
| `mindmap` | `mindmap: Memory Facts Documents` |
| unknown kind | `someNewDiagram Alpha Beta` (degrades, does not vanish) |
| comments-only / empty | `""` → not embedded at all |

An unrecognised kind degrades rather than vanishing, so a future mermaid diagram type still indexes its words.

## What was tested

`internal/tools/builtin/document_mermaid_test.go`:

- `TestMermaidEmbedText_KeepsLanguageDropsSyntax` — per dialect, every human-authored word survives **and** no syntax token leaks. The `want` half is the important one: losing everything also passes a "nothing leaked" check, which is exactly how the first draft's dropped entity names went unnoticed.
- `TestMermaidEmbedText_EmptyWhenNothingToIndex` — an empty or comments-only diagram embeds nothing. A vector built from punctuation can only produce false matches, which is worse than being unsearchable.
- `TestMermaidEmbedText_DoesNotRepeatPhraseWords` — the phrase/word double-count guard.
- `TestEmbedBody_MermaidChunkEmbedsLabelsNotSource` — reads back the stored `embed_text`; the regression test for the bug above.
- `TestEmbedBody_ImageChunkNotEmbedded` — images stay skipped; phase 4 owns their description.
- `TestEmbedBody_TypeChangeToMermaidReembedsAsLabels` — the post-update type is the one that decides policy.

Phase 1's `TestEmbedBody_MediaBodiesAreSkipped` becomes `TestEmbedBody_ImageBodiesAreSkipped`, since its mermaid assertion is what this phase deliberately inverts.

**Fail-before verified.** Reverting `embedBody` to the phase-1 predicate makes both integration tests fail with `embed_text` = `"graph TD\n  A[User] -->|reads| B[(Memory)]"` — the raw source, demonstrating that the phase-1 skip never fired for a natively created diagram.

`go test ./...` clean.

> Note, unrelated: `internal/cli.TestRunValidate_PostgresMissingDSN` reads the ambient environment, so it fails on any machine with `LOOMCYCLE_PG_DSN` exported (it asserts an *empty* DSN is flagged). Pre-existing, untouched by this branch, passes in CI and with the var unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8