### PR TITLE
feat(document): related + unlinked_mentions discovery (RFC BS P3b)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
           # and `go test ./...` cannot run both packages against it concurrently.
           # Add every new postgres-tier test in this package here, or it is
           # decoration rather than a gate.
-          go test -count=1 -run 'TestEmbedDirective|TestEncodePgvector|TestResolveEmbedArgs|TestMemorySQL_EmbedDirective|TestDocument_Postgres|TestDocumentTags_CoreBothTiers|TestDocumentNameLinks_CoreBothTiers|TestDocumentHistory_|TestDocumentBacklinks_|TestSidecar_PostgresTierParity|TestUpsert_ReObservation|TestConfidence_' ./internal/tools/builtin/...
+          go test -count=1 -run 'TestEmbedDirective|TestEncodePgvector|TestResolveEmbedArgs|TestMemorySQL_EmbedDirective|TestDocument_Postgres|TestDocumentTags_CoreBothTiers|TestDocumentNameLinks_CoreBothTiers|TestDocumentHistory_|TestDocumentBacklinks_|TestDocumentUnlinkedMentions_|TestSidecar_PostgresTierParity|TestUpsert_ReObservation|TestConfidence_' ./internal/tools/builtin/...
 
   runtime-codejs:
     name: Runtime suites (code-js)

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -58,7 +58,7 @@ type Document struct {
 func (d *Document) Name() string { return "Document" }
 
 func (d *Document) Description() string {
-	return "A chunked-graph document: each chunk is a first-class unit (UUID, hierarchy, type, fields, graph edges, Markdown body) that agents and humans co-author and query. Ops: create_document/get_document/documents_summary (per-document type/status + display metadata for a set of ids or a Path subtree)/query_documents (filter documents by type/status/tag/under_path)/delete_document/set_path, create_chunk (optional after_id inserts right after a sibling)/get_chunk/update_chunk/delete_chunk/move_chunk/reorder_chunk (move up|down within a level), link_chunks/unlink_chunks/get_edges (the cross-reference edges touching a document, each enriched with its endpoints' titles/types/statuses)/backlinks (the chunks that link TO a chunk — both manual links and inline [[name]] links), history/get_version/diff (a chunk's body-change log: list the revisions its body changed at, read one revision's exact body, or unified-diff two of them), query_chunks (structured filters incl. tag/tag_prefix + a raw sql escape hatch), add_tags/remove_tags (incremental tags on a chunk (id) or document (document_id))/list_tags (distinct tags + counts for a chunk, a document, or the whole scope), define_type/list_types, set_asset (attach an image's bytes to a chunk → type=image, served by GET /v1/_document/asset/{id})/get_asset (asset metadata), export_md (render the document to Markdown), import_md (build a document from export_md-shaped Markdown). Scope is agent or user; documents are named in the Path tree (path:) — create_document defaults to /documents/<title> if you omit one, and set_path attaches/re-homes a path for an existing document."
+	return "A chunked-graph document: each chunk is a first-class unit (UUID, hierarchy, type, fields, graph edges, Markdown body) that agents and humans co-author and query. Ops: create_document/get_document/documents_summary (per-document type/status + display metadata for a set of ids or a Path subtree)/query_documents (filter documents by type/status/tag/under_path)/delete_document/set_path, create_chunk (optional after_id inserts right after a sibling)/get_chunk/update_chunk/delete_chunk/move_chunk/reorder_chunk (move up|down within a level), link_chunks/unlink_chunks/get_edges (the cross-reference edges touching a document, each enriched with its endpoints' titles/types/statuses)/backlinks (the chunks that link TO a chunk — both manual links and inline [[name]] links)/related (the chunks whose bodies are semantically closest to a chunk's — ranked by score; needs a configured embedder)/unlinked_mentions (the chunks whose body text mentions a chunk's title but do NOT already link to it), history/get_version/diff (a chunk's body-change log: list the revisions its body changed at, read one revision's exact body, or unified-diff two of them), query_chunks (structured filters incl. tag/tag_prefix + a raw sql escape hatch), add_tags/remove_tags (incremental tags on a chunk (id) or document (document_id))/list_tags (distinct tags + counts for a chunk, a document, or the whole scope), define_type/list_types, set_asset (attach an image's bytes to a chunk → type=image, served by GET /v1/_document/asset/{id})/get_asset (asset metadata), export_md (render the document to Markdown), import_md (build a document from export_md-shaped Markdown). Scope is agent or user; documents are named in the Path tree (path:) — create_document defaults to /documents/<title> if you omit one, and set_path attaches/re-homes a path for an existing document."
 }
 
 // documentInputSchema is a package const so the LoomCycle MCP server can
@@ -68,7 +68,7 @@ func (d *Document) Description() string {
 const documentInputSchema = `{
 	"type": "object",
 	"properties": {
-		"op":          {"type": "string", "enum": ["create_document","get_document","documents_summary","query_documents","delete_document","set_path","create_chunk","upsert_chunk","get_chunk","update_chunk","delete_chunk","supersede_chunk","graph_recall","move_chunk","reorder_chunk","link_chunks","unlink_chunks","get_edges","query_chunks","add_tags","remove_tags","list_tags","define_type","list_types","set_asset","get_asset","export_md","import_md","history","get_version","diff","backlinks"]},
+		"op":          {"type": "string", "enum": ["create_document","get_document","documents_summary","query_documents","delete_document","set_path","create_chunk","upsert_chunk","get_chunk","update_chunk","delete_chunk","supersede_chunk","graph_recall","move_chunk","reorder_chunk","link_chunks","unlink_chunks","get_edges","query_chunks","add_tags","remove_tags","list_tags","define_type","list_types","set_asset","get_asset","export_md","import_md","history","get_version","diff","backlinks","related","unlinked_mentions"]},
 		"scope":       {"type": "string", "enum": ["agent","user","tenant"], "description": "Which store (default user). agent = this agent; user = this end-user (needs a user_id on the run); tenant = shared by every user and agent in the tenant — anything written here is read by all of them, so use it for curated reference material, not for anything derived from untrusted text. tenant requires the operator to grant BOTH memory_scopes and sql_scopes with the tenant value."},
 		"id":          {"type": "string", "description": "Document id (get/delete_document, set_path) or chunk id (get/update/delete/move_chunk)."},
 		"path":        {"type": "string", "description": "create_document: name the doc in the Path tree (default /documents/<title> if omitted). set_path: the path to attach to an existing document (by id). get/delete_document: address by path instead of id."},
@@ -398,6 +398,10 @@ func (d *Document) Execute(ctx context.Context, raw json.RawMessage) (tools.Resu
 		return d.diffVersions(ctx, key, in)
 	case "backlinks":
 		return d.backlinks(ctx, key, in)
+	case "related":
+		return d.related(ctx, key, mscope, in)
+	case "unlinked_mentions":
+		return d.unlinkedMentions(ctx, key, mscope, in)
 	case "":
 		return errResult("missing required field: op"), nil
 	default:
@@ -2392,6 +2396,229 @@ ORDER BY e.kind, e.created_at`, in.ID)
 		links = append(links, bl)
 	}
 	return jsonResult(map[string]any{"backlinks": links})
+}
+
+// --- discovery: related (semantic) + unlinked_mentions (textual) ---
+
+// chunkMeta is the small display tuple related/unlinked_mentions enrich a bare
+// chunk id with, so a caller renders a hit without a per-id get_chunk.
+type chunkMeta struct {
+	title      string
+	typ        string
+	documentID string
+}
+
+// chunkMetaByIDs fetches title/type/document_id for a set of chunk ids in ONE
+// IN(...) query, keyed by id. Ids the query does not return are simply absent
+// from the map (a hit whose structure row vanished still lists its id). An empty
+// input is a no-op. Portable `?` placeholders → the postgres tier Rebinds them.
+func (d *Document) chunkMetaByIDs(ctx context.Context, key sqlmem.ScopeKey, ids []string) (map[string]chunkMeta, error) {
+	out := map[string]chunkMeta{}
+	if len(ids) == 0 {
+		return out, nil
+	}
+	placeholders := make([]string, len(ids))
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	res, err := d.query(ctx, key,
+		"SELECT id, title, type, document_id FROM chunks WHERE id IN ("+strings.Join(placeholders, ",")+")", args...)
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range res.Rows {
+		out[asStr(r[0])] = chunkMeta{title: asStr(r[1]), typ: asStr(r[2]), documentID: asStr(r[3])}
+	}
+	return out, nil
+}
+
+// related returns the chunks whose bodies embed CLOSEST to a chunk's — its
+// semantic neighbours, ranked by cosine score (RFC BS Phase 3b). It reuses the
+// per-chunk-body embeddings writeBody already indexes on write (keyed
+// "doc.chunk:<id>" in the k/v Memory plane, under the chunk's scope + the raw
+// direntTenant), so nothing about the write path changes. Scope-confined: the
+// vector search is bounded to the caller's own tenant/scope/scope_id.
+func (d *Document) related(ctx context.Context, key sqlmem.ScopeKey, mscope store.MemoryScope, in docInput) (tools.Result, error) {
+	if in.ID == "" {
+		return errResult("related: missing required field: id"), nil
+	}
+	// Semantic neighbours need both a vector index and something to turn the query
+	// body into a vector. No embedder → there is no vector plane to search.
+	if d.Embedder == nil {
+		return errResult("related: requires a configured embedder / vector memory"), nil
+	}
+	topK := 10
+	if in.Limit > 0 {
+		topK = in.Limit
+	}
+	if topK > 50 {
+		topK = 50
+	}
+	// The query text is the chunk's own body. An empty or media body has nothing
+	// to embed — the same predicate embedBody skips on write — so it has no
+	// neighbours; return an empty set rather than an error (a section/parent chunk
+	// legitimately has no body).
+	cb, err := d.readBody(ctx, mscope, key.ScopeID, in.ID)
+	if err != nil {
+		return errResult("related: body: " + err.Error()), nil
+	}
+	body := strings.TrimSpace(cb.Body)
+	if body == "" {
+		return jsonResult(map[string]any{"related": []map[string]any{}})
+	}
+	if typ, _, _, _ := classifyMediaBody(cb.Body); typ != "" {
+		return jsonResult(map[string]any{"related": []map[string]any{}})
+	}
+	vec, err := d.Embedder.Embed(ctx, []string{body})
+	if err != nil {
+		return errResult("related: embed: " + err.Error()), nil
+	}
+	if len(vec) == 0 {
+		return errResult("related: embed: embedder returned no vector"), nil
+	}
+	// topK+1: a chunk is its own nearest neighbour, so the search ranks self first;
+	// ask for one extra to leave room to drop it and still return topK others.
+	entries, err := d.Store.MemoryEmbedSearch(ctx, direntTenant(ctx), mscope, key.ScopeID, "doc.chunk:", vec[0], topK+1)
+	if err != nil {
+		return errResult("related: search: " + err.Error()), nil
+	}
+	type hit struct {
+		id    string
+		score float64
+	}
+	hits := make([]hit, 0, len(entries))
+	ids := make([]string, 0, len(entries))
+	for _, e := range entries {
+		cid := strings.TrimPrefix(e.Key, "doc.chunk:")
+		if cid == in.ID {
+			continue // the query chunk itself is never its own neighbour
+		}
+		hits = append(hits, hit{id: cid, score: e.Score})
+		ids = append(ids, cid)
+		if len(hits) >= topK {
+			break
+		}
+	}
+	meta, err := d.chunkMetaByIDs(ctx, key, ids)
+	if err != nil {
+		return errResult("related: enrich: " + err.Error()), nil
+	}
+	out := make([]map[string]any, 0, len(hits))
+	for _, h := range hits {
+		m := map[string]any{"chunk_id": h.id, "score": h.score}
+		if md, ok := meta[h.id]; ok {
+			if md.title != "" {
+				m["title"] = md.title
+			}
+			if md.typ != "" {
+				m["type"] = md.typ
+			}
+			if md.documentID != "" {
+				m["document_id"] = md.documentID
+			}
+		}
+		out = append(out, m)
+	}
+	return jsonResult(map[string]any{"related": out})
+}
+
+// unlinkedMentionScanCap bounds the body scan unlinked_mentions performs. The op
+// is an O(scope-chunk-count) scan of every chunk body in the scope (it reads text
+// SQL cannot reach), so the cap keeps one very large scope from turning a single
+// call into an unbounded read. A document- or path-bounded variant is a follow-up.
+const unlinkedMentionScanCap = 5000
+
+// unlinkedMentions finds the chunks whose body text MENTIONS a target chunk's
+// title but do NOT already link to it (RFC BS Phase 3b) — the "you wrote the name
+// but never made it a link" surface. Both a manual link_chunks edge and an inline
+// [[name]] parser edge count as "already linked" (they both land in chunk_edges),
+// and the target's own body mentioning its own title is excluded. Scope-confined.
+func (d *Document) unlinkedMentions(ctx context.Context, key sqlmem.ScopeKey, mscope store.MemoryScope, in docInput) (tools.Result, error) {
+	if in.ID == "" {
+		return errResult("unlinked_mentions: missing required field: id"), nil
+	}
+	limit := 50
+	if in.Limit > 0 {
+		limit = in.Limit
+	}
+	if limit > 200 {
+		limit = 200
+	}
+	// Resolve the target's title — the text to look for in other bodies.
+	tres, err := d.query(ctx, key, `SELECT title FROM chunks WHERE id = ? LIMIT 1`, in.ID)
+	if err != nil {
+		return errResult("unlinked_mentions: " + err.Error()), nil
+	}
+	if len(tres.Rows) == 0 {
+		return errResult("unlinked_mentions: no such chunk: " + in.ID), nil
+	}
+	title := strings.TrimSpace(asStr(tres.Rows[0][0]))
+	if title == "" {
+		return errResult("unlinked_mentions: target chunk has no title to match on"), nil
+	}
+	// The already-linked set: every chunk that already references the target
+	// (manual OR [[name]] edge — both live in chunk_edges as from→to). A mention
+	// from a chunk that already links is not "unlinked".
+	linked := map[string]bool{}
+	lres, err := d.query(ctx, key, `SELECT from_id FROM chunk_edges WHERE to_id = ?`, in.ID)
+	if err != nil {
+		return errResult("unlinked_mentions: edges: " + err.Error()), nil
+	}
+	for _, r := range lres.Rows {
+		linked[asStr(r[0])] = true
+	}
+	// Scan chunk bodies from the k/v Memory plane, keyed on the SAME
+	// tenant/scope/scope_id writeBody wrote them under (direntTenant + mscope +
+	// key.ScopeID) — reading a different plane would silently return zero hits.
+	entries, listTruncated, err := d.Store.MemoryList(ctx, direntTenant(ctx), mscope, key.ScopeID, "doc.chunk:", unlinkedMentionScanCap)
+	if err != nil {
+		return errResult("unlinked_mentions: scan: " + err.Error()), nil
+	}
+	needle := strings.ToLower(title)
+	matchIDs := make([]string, 0, limit)
+	hitCap := false
+	for _, e := range entries {
+		cid := strings.TrimPrefix(e.Key, "doc.chunk:")
+		if cid == in.ID || linked[cid] {
+			continue // self / already-linked
+		}
+		var cb chunkBody
+		if json.Unmarshal(e.Value, &cb) != nil {
+			continue
+		}
+		if !strings.Contains(strings.ToLower(cb.Body), needle) {
+			continue
+		}
+		matchIDs = append(matchIDs, cid)
+		if len(matchIDs) >= limit {
+			hitCap = true
+			break
+		}
+	}
+	meta, err := d.chunkMetaByIDs(ctx, key, matchIDs)
+	if err != nil {
+		return errResult("unlinked_mentions: enrich: " + err.Error()), nil
+	}
+	out := make([]map[string]any, 0, len(matchIDs))
+	for _, cid := range matchIDs {
+		m := map[string]any{"chunk_id": cid}
+		if md, ok := meta[cid]; ok {
+			if md.title != "" {
+				m["title"] = md.title
+			}
+			if md.documentID != "" {
+				m["document_id"] = md.documentID
+			}
+		}
+		out = append(out, m)
+	}
+	// Never silently under-report the scan's completeness: it is bounded three
+	// ways — the store had more bodies than the cap (listTruncated), we filled the
+	// result limit and stopped early (hitCap), or the scan itself hit its own cap.
+	truncated := listTruncated || hitCap || len(entries) >= unlinkedMentionScanCap
+	return jsonResult(map[string]any{"unlinked_mentions": out, "truncated": truncated})
 }
 
 // --- inline [[name]] links → typed edges (RFC BS Phase 2a) ---

--- a/internal/tools/builtin/document_discovery_test.go
+++ b/internal/tools/builtin/document_discovery_test.go
@@ -1,0 +1,263 @@
+package builtin
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/channels"
+	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// RFC BS Phase 3b — discovery: `related` (semantic neighbours of a chunk) and
+// `unlinked_mentions` (chunks whose body text names a chunk's title but never
+// link it).
+//
+// `related` needs a vector-capable store + an embedder, so it reuses the same
+// in-memory vectorStore + fakeEmbedder fakes the Memory-tool vector tests use
+// (memory_vector_test.go). That fake filters search hits at tenant "", so the
+// related fixture runs on sqlite only, with an EMPTY tenant — a real
+// pgvector-backed postgres tier is exercised elsewhere.
+//
+// `unlinked_mentions` is pure SQL (chunk_edges) + a k/v Memory body scan (no
+// vectors), so it runs on BOTH SQL Memory tiers via pgDocumentOrSkip, proving the
+// IN(...) enrichment's `?` rebind and the edge query on postgres too.
+
+// relatedFixture builds a Document backed by the in-memory vector store + fake
+// embedder, with an EMPTY tenant. The vectorStore fake filters search hits via
+// MemoryGet at tenant "" (see memory_vector_test.go), so chunk bodies must be
+// written under the "" partition for it to find them — direntTenant("")→"" makes
+// writeBody store there.
+func relatedFixture(t *testing.T) (*Document, context.Context) {
+	t.Helper()
+	s, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	vs := newVectorStore(s)
+	mgr, err := sqlmem.New(sqlmem.Config{Root: t.TempDir()})
+	if err != nil {
+		t.Fatalf("sqlmem.New: %v", err)
+	}
+	t.Cleanup(func() { _ = mgr.Close() })
+	emb := newFakeEmbedder("fake", "fake-embed-001",
+		"go", "rust", "systems", "programming", "concurrency",
+		"python", "data", "science", "pandas")
+	d := &Document{Store: vs, SqlMem: mgr, Bus: channels.NewBus(), Embedder: emb}
+	ctx := tools.WithAgentName(context.Background(), "rel-agent")
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a", UserID: "u1"})
+	return d, ctx
+}
+
+// TestDocumentRelated_RanksNeighboursAndExcludesSelf: a chunk whose body shares
+// tokens with the query chunk ranks as a neighbour; a token-disjoint chunk ranks
+// below it; and the query chunk is NEVER returned as its own neighbour. Each hit
+// carries its score + enriched title/document_id.
+func TestDocumentRelated_RanksNeighboursAndExcludesSelf(t *testing.T) {
+	d, ctx := relatedFixture(t)
+
+	out, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Rel","path":"/rel/one"}`)
+	if r.IsError {
+		t.Fatalf("create_document: %s", r.Text)
+	}
+	docID := out["document_id"].(string)
+
+	mk := func(title, body string) string {
+		o, rr := docExec(t, d, ctx, fmt.Sprintf(
+			`{"op":"create_chunk","scope":"user","document_id":%q,"title":%q,"body":%q}`, docID, title, body))
+		if rr.IsError {
+			t.Fatalf("create_chunk(%s): %s", title, rr.Text)
+		}
+		return o["id"].(string)
+	}
+	idA := mk("A", "go rust systems programming") // the query chunk
+	idB := mk("B", "go rust systems concurrency") // shares 3 tokens with A
+	idC := mk("C", "python data science pandas")  // token-disjoint from A
+
+	out, r = docExec(t, d, ctx, fmt.Sprintf(`{"op":"related","scope":"user","id":%q}`, idA))
+	if r.IsError {
+		t.Fatalf("related: %s", r.Text)
+	}
+	rel, _ := out["related"].([]any)
+	if len(rel) == 0 {
+		t.Fatalf("related returned no neighbours: %s", r.Text)
+	}
+
+	var order []string
+	byID := map[string]map[string]any{}
+	lastScore := 1e9
+	for _, e := range rel {
+		m := e.(map[string]any)
+		cid := m["chunk_id"].(string)
+		order = append(order, cid)
+		byID[cid] = m
+		// The query chunk is never its own neighbour.
+		if cid == idA {
+			t.Fatalf("related must exclude the query chunk itself; got order %v", order)
+		}
+		// Scores must be present and non-increasing (MemoryEmbedSearch ranks desc).
+		sc, ok := m["score"].(float64)
+		if !ok {
+			t.Fatalf("hit %s missing float score: %v", cid, m)
+		}
+		if sc > lastScore {
+			t.Fatalf("scores not descending at %s (%.4f > %.4f); order %v", cid, sc, lastScore, order)
+		}
+		lastScore = sc
+	}
+
+	posB, posC := indexOf(order, idB), indexOf(order, idC)
+	if posB < 0 {
+		t.Fatalf("related must surface the token-sharing neighbour B; got %v", order)
+	}
+	if posC >= 0 && posB > posC {
+		t.Fatalf("B (shared tokens) must rank above C (disjoint); order %v", order)
+	}
+	// B is enriched with its structure + carries a positive similarity.
+	bm := byID[idB]
+	if bm["title"] != "B" {
+		t.Errorf("neighbour B title = %v, want B", bm["title"])
+	}
+	if bm["document_id"] != docID {
+		t.Errorf("neighbour B document_id = %v, want %s", bm["document_id"], docID)
+	}
+	if sc := bm["score"].(float64); sc <= 0 {
+		t.Errorf("neighbour B score = %v, want > 0", sc)
+	}
+}
+
+// TestDocumentRelated_RefusesWithoutEmbedder: related must fail with a clear
+// message when the Document has no embedder wired (there is no vector plane).
+func TestDocumentRelated_RefusesWithoutEmbedder(t *testing.T) {
+	d, ctx, _ := documentFixture(t) // documentFixture wires no Embedder (nil)
+	_, r := docExec(t, d, ctx, `{"op":"related","scope":"user","id":"any-chunk-id"}`)
+	if !r.IsError {
+		t.Fatalf("expected an error without an embedder, got: %s", r.Text)
+	}
+	if !strings.Contains(r.Text, "embedder") {
+		t.Fatalf("expected an embedder-required message, got: %s", r.Text)
+	}
+}
+
+// TestDocumentUnlinkedMentions_CoreBothTiers exercises the whole op on BOTH SQL
+// Memory tiers: the edge exclusion, the case-insensitive body scan, self- and
+// already-linked exclusion, a non-mentioner staying out, and truncation.
+func TestDocumentUnlinkedMentions_CoreBothTiers(t *testing.T) {
+	t.Run("sqlite", func(t *testing.T) {
+		d, ctx, _ := documentFixture(t)
+		assertUnlinkedMentions(t, d, ctx)
+	})
+	t.Run("postgres", func(t *testing.T) {
+		d, ctx := pgDocumentOrSkip(t)
+		assertUnlinkedMentions(t, d, ctx)
+	})
+}
+
+func assertUnlinkedMentions(t *testing.T, d *Document, ctx context.Context) {
+	t.Helper()
+
+	out, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Catalog","path":"/cat/one"}`)
+	if r.IsError {
+		t.Fatalf("create_document: %s", r.Text)
+	}
+	docID := out["document_id"].(string)
+
+	mk := func(title, body string) string {
+		o, rr := docExec(t, d, ctx, fmt.Sprintf(
+			`{"op":"create_chunk","scope":"user","document_id":%q,"title":%q,"body":%q}`, docID, title, body))
+		if rr.IsError {
+			t.Fatalf("create_chunk(%s): %s", title, rr.Text)
+		}
+		return o["id"].(string)
+	}
+
+	// The target chunk. Its own body mentions its own title → must be excluded.
+	target := mk("Widget", "The Widget is the core primitive.")
+	// Two unlinked mentioners (one exact-case, one lower-case → case-insensitive).
+	m1 := mk("M1", "the Widget is great to use")
+	m2 := mk("M2", "we depend on the widget here")
+	// A chunk that mentions Widget via an inline [[name]] link → auto edge → excluded.
+	linkedInline := mk("LinkedInline", "see [[Widget]] for the full spec")
+	// A chunk that mentions Widget and is manually linked → excluded.
+	linkedManual := mk("LinkedManual", "the Widget really rocks")
+	// A chunk that does not mention it at all → never returned.
+	noMention := mk("None", "nothing relevant here")
+
+	// Manual link LinkedManual → target.
+	if _, rr := docExec(t, d, ctx, fmt.Sprintf(
+		`{"op":"link_chunks","scope":"user","from_id":%q,"to_id":%q,"kind":"references"}`, linkedManual, target)); rr.IsError {
+		t.Fatalf("link_chunks: %s", rr.Text)
+	}
+
+	// The [[Widget]] inline link must have materialized an auto edge to the target.
+	// (Guards against the substring match silently including it.)
+	blOut, rr := docExec(t, d, ctx, fmt.Sprintf(`{"op":"backlinks","scope":"user","id":%q}`, target))
+	if rr.IsError {
+		t.Fatalf("backlinks: %s", rr.Text)
+	}
+	froms := map[string]bool{}
+	for _, e := range blOut["backlinks"].([]any) {
+		froms[e.(map[string]any)["from_id"].(string)] = true
+	}
+	if !froms[linkedInline] || !froms[linkedManual] {
+		t.Fatalf("precondition: expected inline+manual edges into target; backlinks froms=%v", froms)
+	}
+
+	out, r = docExec(t, d, ctx, fmt.Sprintf(`{"op":"unlinked_mentions","scope":"user","id":%q}`, target))
+	if r.IsError {
+		t.Fatalf("unlinked_mentions: %s", r.Text)
+	}
+	got := map[string]map[string]any{}
+	for _, e := range out["unlinked_mentions"].([]any) {
+		m := e.(map[string]any)
+		got[m["chunk_id"].(string)] = m
+	}
+
+	// Exactly the two unlinked mentioners, nothing else.
+	if len(got) != 2 {
+		t.Fatalf("unlinked_mentions = %d entries, want 2 (M1,M2); got ids %v", len(got), keysOf(got))
+	}
+	for _, want := range []string{m1, m2} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("expected %s among unlinked mentions; got %v", want, keysOf(got))
+		}
+	}
+	for _, excluded := range []string{target, linkedInline, linkedManual, noMention} {
+		if _, ok := got[excluded]; ok {
+			t.Errorf("chunk %s must be excluded from unlinked_mentions; got %v", excluded, keysOf(got))
+		}
+	}
+	// Enrichment: each hit carries its title + document_id.
+	if got[m1]["title"] != "M1" || got[m1]["document_id"] != docID {
+		t.Errorf("m1 enrichment = %v, want title M1 / document_id %s", got[m1], docID)
+	}
+	// Not truncated when the limit comfortably exceeds the match count.
+	if out["truncated"] != false {
+		t.Errorf("truncated = %v, want false", out["truncated"])
+	}
+
+	// A low limit must report truncated=true and return exactly one match.
+	out, r = docExec(t, d, ctx, fmt.Sprintf(`{"op":"unlinked_mentions","scope":"user","id":%q,"limit":1}`, target))
+	if r.IsError {
+		t.Fatalf("unlinked_mentions(limit=1): %s", r.Text)
+	}
+	if n := len(out["unlinked_mentions"].([]any)); n != 1 {
+		t.Errorf("unlinked_mentions(limit=1) returned %d, want 1", n)
+	}
+	if out["truncated"] != true {
+		t.Errorf("unlinked_mentions(limit=1) truncated = %v, want true", out["truncated"])
+	}
+}
+
+// keysOf returns the keys of a result map (for readable failure messages).
+func keysOf(m map[string]map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
Phase 3b of **RFC BS — Document structure primitives** (`/loomcycle/rfcs/document-structure-primitives`), completing Phase 3's §3.2 discovery after P3a (#937). Backend only.

## Good news vs P3a's warning
P3a flagged that `related` would need an embedding lift and `unlinked_mentions` a body scan. Since then, **chunk bodies are already embedded on write** (`writeBody`→`embedBody`, keyed `doc.chunk:`), so `related` is a straight reuse of `MemoryEmbedSearch` — no new infra, no write-path change.

## What
- **`related`** — a chunk's semantic neighbours: embed its body, `MemoryEmbedSearch` the `doc.chunk:` prefix (same tenant/scope/scope_id `writeBody` keys under), drop self, return topK by cosine score, enriched with `title`/`type`/`document_id`. Refuses without an embedder; an empty/media body (the same skip rule `embedBody` uses) returns `[]`. topK default 10, cap 50.
- **`unlinked_mentions`** — chunks whose body text mentions a target chunk's title but do **not** already link to it (both a manual `link_chunks` edge and an inline `[[name]]` edge count as linked, via `chunk_edges.to_id`). Case-insensitive scan of the scope's chunk bodies (`MemoryList "doc.chunk:"`, bounded by `unlinkedMentionScanCap=5000`, with an honest `truncated`); self + already-linked excluded; enriched. limit 50/200.
- **`chunkMetaByIDs`** — shared `IN(...)` enrichment (empty-ids guarded, Rebind-portable).

The keying matches `writeBody` exactly (`direntTenant(ctx)`, `mscope`, `key.ScopeID`) — reading a different plane would silently return zero hits; noted at both read sites.

## Deferred (noted, not silently dropped)
A document/path-bounded `unlinked_mentions` (today it's an O(scope) scan, capped); snapshotting the `upsert`/`import_md`/`set_asset` body writes remains the Phase-3a follow-up.

## CI
Added `TestDocumentUnlinkedMentions_` to the postgres-tier `-run` allowlist. `related` is sqlite-only in tests (the vector fake wraps sqlite, mirroring the Memory-tool vector tests), so it needs no pg entry; its shared SQL surface (`chunkMetaByIDs`' `IN`+Rebind) is still exercised on postgres by the `unlinked_mentions` test.

## Tested
`document_discovery_test.go` — `related` ranks a token-sharing neighbour above a disjoint one, excludes self, and refuses without an embedder; `unlinked_mentions` returns exactly the unlinked mentioners (excluding an inline-linked chunk, a manually-linked chunk, the self-mention, and a non-mentioner) on **sqlite + postgres**, with `truncated` honouring a low cap. Each fail-before verified. `go test ./...` exit 0. Additive — no wire break.

## RFC BS status
P1 ✅ · P2a ✅ · P2b ✅ · P3a ✅ · **P3b — this** → Phase 3 complete. Remaining: **P4** (JSON Canvas import/export).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD