### PR TITLE
feat(document): JSON Canvas import/export (RFC BS P4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
           # and `go test ./...` cannot run both packages against it concurrently.
           # Add every new postgres-tier test in this package here, or it is
           # decoration rather than a gate.
-          go test -count=1 -run 'TestEmbedDirective|TestEncodePgvector|TestResolveEmbedArgs|TestMemorySQL_EmbedDirective|TestDocument_Postgres|TestDocumentTags_CoreBothTiers|TestDocumentNameLinks_CoreBothTiers|TestDocumentHistory_|TestDocumentBacklinks_|TestDocumentUnlinkedMentions_|TestSidecar_PostgresTierParity|TestUpsert_ReObservation|TestConfidence_' ./internal/tools/builtin/...
+          go test -count=1 -run 'TestEmbedDirective|TestEncodePgvector|TestResolveEmbedArgs|TestMemorySQL_EmbedDirective|TestDocument_Postgres|TestDocumentTags_CoreBothTiers|TestDocumentNameLinks_CoreBothTiers|TestDocumentHistory_|TestDocumentBacklinks_|TestDocumentUnlinkedMentions_|TestDocumentCanvas_|TestSidecar_PostgresTierParity|TestUpsert_ReObservation|TestConfidence_' ./internal/tools/builtin/...
 
   runtime-codejs:
     name: Runtime suites (code-js)

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -58,7 +58,7 @@ type Document struct {
 func (d *Document) Name() string { return "Document" }
 
 func (d *Document) Description() string {
-	return "A chunked-graph document: each chunk is a first-class unit (UUID, hierarchy, type, fields, graph edges, Markdown body) that agents and humans co-author and query. Ops: create_document/get_document/documents_summary (per-document type/status + display metadata for a set of ids or a Path subtree)/query_documents (filter documents by type/status/tag/under_path)/delete_document/set_path, create_chunk (optional after_id inserts right after a sibling)/get_chunk/update_chunk/delete_chunk/move_chunk/reorder_chunk (move up|down within a level), link_chunks/unlink_chunks/get_edges (the cross-reference edges touching a document, each enriched with its endpoints' titles/types/statuses)/backlinks (the chunks that link TO a chunk — both manual links and inline [[name]] links)/related (the chunks whose bodies are semantically closest to a chunk's — ranked by score; needs a configured embedder)/unlinked_mentions (the chunks whose body text mentions a chunk's title but do NOT already link to it), history/get_version/diff (a chunk's body-change log: list the revisions its body changed at, read one revision's exact body, or unified-diff two of them), query_chunks (structured filters incl. tag/tag_prefix + a raw sql escape hatch), add_tags/remove_tags (incremental tags on a chunk (id) or document (document_id))/list_tags (distinct tags + counts for a chunk, a document, or the whole scope), define_type/list_types, set_asset (attach an image's bytes to a chunk → type=image, served by GET /v1/_document/asset/{id})/get_asset (asset metadata), export_md (render the document to Markdown), import_md (build a document from export_md-shaped Markdown). Scope is agent or user; documents are named in the Path tree (path:) — create_document defaults to /documents/<title> if you omit one, and set_path attaches/re-homes a path for an existing document."
+	return "A chunked-graph document: each chunk is a first-class unit (UUID, hierarchy, type, fields, graph edges, Markdown body) that agents and humans co-author and query. Ops: create_document/get_document/documents_summary (per-document type/status + display metadata for a set of ids or a Path subtree)/query_documents (filter documents by type/status/tag/under_path)/delete_document/set_path, create_chunk (optional after_id inserts right after a sibling)/get_chunk/update_chunk/delete_chunk/move_chunk/reorder_chunk (move up|down within a level), link_chunks/unlink_chunks/get_edges (the cross-reference edges touching a document, each enriched with its endpoints' titles/types/statuses)/backlinks (the chunks that link TO a chunk — both manual links and inline [[name]] links)/related (the chunks whose bodies are semantically closest to a chunk's — ranked by score; needs a configured embedder)/unlinked_mentions (the chunks whose body text mentions a chunk's title but do NOT already link to it), history/get_version/diff (a chunk's body-change log: list the revisions its body changed at, read one revision's exact body, or unified-diff two of them), query_chunks (structured filters incl. tag/tag_prefix + a raw sql escape hatch), add_tags/remove_tags (incremental tags on a chunk (id) or document (document_id))/list_tags (distinct tags + counts for a chunk, a document, or the whole scope), define_type/list_types, set_asset (attach an image's bytes to a chunk → type=image, served by GET /v1/_document/asset/{id})/get_asset (asset metadata), export_md (render the document to Markdown), import_md (build a document from export_md-shaped Markdown), export_canvas (render the document as a JSON Canvas v1.0 spatial graph — content chunks as nodes + their cross-reference edges, for Obsidian Canvas / spatial views)/import_canvas (build a new document from a JSON Canvas). Scope is agent or user; documents are named in the Path tree (path:) — create_document defaults to /documents/<title> if you omit one, and set_path attaches/re-homes a path for an existing document."
 }
 
 // documentInputSchema is a package const so the LoomCycle MCP server can
@@ -68,7 +68,7 @@ func (d *Document) Description() string {
 const documentInputSchema = `{
 	"type": "object",
 	"properties": {
-		"op":          {"type": "string", "enum": ["create_document","get_document","documents_summary","query_documents","delete_document","set_path","create_chunk","upsert_chunk","get_chunk","update_chunk","delete_chunk","supersede_chunk","graph_recall","move_chunk","reorder_chunk","link_chunks","unlink_chunks","get_edges","query_chunks","add_tags","remove_tags","list_tags","define_type","list_types","set_asset","get_asset","export_md","import_md","history","get_version","diff","backlinks","related","unlinked_mentions"]},
+		"op":          {"type": "string", "enum": ["create_document","get_document","documents_summary","query_documents","delete_document","set_path","create_chunk","upsert_chunk","get_chunk","update_chunk","delete_chunk","supersede_chunk","graph_recall","move_chunk","reorder_chunk","link_chunks","unlink_chunks","get_edges","query_chunks","add_tags","remove_tags","list_tags","define_type","list_types","set_asset","get_asset","export_md","import_md","export_canvas","import_canvas","history","get_version","diff","backlinks","related","unlinked_mentions"]},
 		"scope":       {"type": "string", "enum": ["agent","user","tenant"], "description": "Which store (default user). agent = this agent; user = this end-user (needs a user_id on the run); tenant = shared by every user and agent in the tenant — anything written here is read by all of them, so use it for curated reference material, not for anything derived from untrusted text. tenant requires the operator to grant BOTH memory_scopes and sql_scopes with the tenant value."},
 		"id":          {"type": "string", "description": "Document id (get/delete_document, set_path) or chunk id (get/update/delete/move_chunk)."},
 		"path":        {"type": "string", "description": "create_document: name the doc in the Path tree (default /documents/<title> if omitted). set_path: the path to attach to an existing document (by id). get/delete_document: address by path instead of id."},
@@ -113,7 +113,8 @@ const documentInputSchema = `{
 		"limit":       {"type": "integer"},
 		"name":        {"type": "string", "description": "define/list_types: the type name."},
 		"include_metadata": {"type": "boolean", "description": "export_md: embed round-trippable chunk metadata + edges as HTML comments (default true). false = clean human-facing Markdown."},
-		"markdown":    {"type": "string", "description": "import_md: an export_md-shaped Markdown document (headings = hierarchy; <!-- loom: ... --> metadata; <!-- loom-edges: ... --> trailer). Omit document_id to create a new document; pass document_id (+ optional parent_id) to import under an existing chunk."}
+		"markdown":    {"type": "string", "description": "import_md: an export_md-shaped Markdown document (headings = hierarchy; <!-- loom: ... --> metadata; <!-- loom-edges: ... --> trailer). Omit document_id to create a new document; pass document_id (+ optional parent_id) to import under an existing chunk."},
+		"canvas":      {"type": "object", "description": "import_canvas: a JSON Canvas v1.0 object ({\"nodes\":[...],\"edges\":[...]}) — e.g. the contents of an Obsidian .canvas file. Each node becomes a chunk (positioned via its x/y/width/height); each edge becomes a link. Pass title/path to name the new document."}
 	},
 	"required": ["op"]
 }`
@@ -198,6 +199,11 @@ type docInput struct {
 	IncludeMetadata *bool `json:"include_metadata"`
 	// Markdown is the import_md source (an export_md-shaped document).
 	Markdown string `json:"markdown"`
+	// Canvas is the import_canvas source: a JSON Canvas v1.0 object
+	// ({"nodes":[...],"edges":[...]}). Kept as RawMessage so a caller can hand in
+	// an object verbatim (e.g. the contents of an Obsidian .canvas file) and it is
+	// decoded into the canvas struct in import_canvas.
+	Canvas json.RawMessage `json:"canvas"`
 }
 
 // docSchemaDDL is portable across SQL Memory's sqlite + postgres tiers: BIGINT
@@ -303,6 +309,18 @@ var docSchemaDDL = []string{
 		chunk_id TEXT NOT NULL, revision INTEGER NOT NULL, created_at BIGINT NOT NULL,
 		actor TEXT, body TEXT NOT NULL, PRIMARY KEY (chunk_id, revision))`,
 	`CREATE INDEX IF NOT EXISTS chunk_revisions_chunk ON chunk_revisions(chunk_id)`,
+	// chunk_layout — a chunk's spatial coordinates for the JSON Canvas view
+	// (export_canvas / import_canvas). This is VIEW metadata (where a node sits on
+	// a canvas), NOT a query axis, so it is its own thin table rather than a
+	// chunks column: a chunk without a layout row is the normal case (export
+	// falls back to a deterministic auto-grid), and only a chunk placed on a
+	// canvas ever gets a row. x/y/width/height are integers per the JSON Canvas
+	// spec; color is a nullable preset id ("1".."6") or hex ("#RRGGBB"). No
+	// foreign key — cascade is explicit in Go (deleteChunk / deleteDocument),
+	// matching the rest of this schema.
+	`CREATE TABLE IF NOT EXISTS chunk_layout (
+		chunk_id TEXT PRIMARY KEY, x INTEGER NOT NULL, y INTEGER NOT NULL,
+		width INTEGER NOT NULL, height INTEGER NOT NULL, color TEXT)`,
 }
 
 // maxChunkDepth caps the ancestor walk in move_chunk (cycle detection) so a
@@ -390,6 +408,10 @@ func (d *Document) Execute(ctx context.Context, raw json.RawMessage) (tools.Resu
 		return d.exportMD(ctx, key, mscope, in)
 	case "import_md":
 		return d.importMD(ctx, key, mscope, in)
+	case "export_canvas":
+		return d.exportCanvas(ctx, key, mscope, in)
+	case "import_canvas":
+		return d.importCanvas(ctx, key, mscope, in)
 	case "history":
 		return d.chunkHistory(ctx, key, in)
 	case "get_version":
@@ -1416,6 +1438,13 @@ func (d *Document) deleteDocument(ctx context.Context, key sqlmem.ScopeKey, msco
 		if err := d.execTxn(ctx, txnID, `DELETE FROM chunk_revisions WHERE chunk_id IN (SELECT id FROM chunks WHERE document_id = ?)`, docID); err != nil {
 			return err
 		}
+		// Canvas layout rows for every chunk in the document — resolved via the
+		// chunks subquery so they go before the chunk rows. An orphaned layout row
+		// is invisible dead data nothing reaps, the same class the explicit-cascade
+		// discipline exists to prevent.
+		if err := d.execTxn(ctx, txnID, `DELETE FROM chunk_layout WHERE chunk_id IN (SELECT id FROM chunks WHERE document_id = ?)`, docID); err != nil {
+			return err
+		}
 		if err := d.execTxn(ctx, txnID, `DELETE FROM chunks WHERE document_id = ?`, docID); err != nil {
 			return err
 		}
@@ -2004,6 +2033,11 @@ func (d *Document) deleteChunk(ctx context.Context, key sqlmem.ScopeKey, mscope 
 			// row goes, like the other per-chunk cascades — an orphaned revision row
 			// is invisible dead data nothing reaps.
 			if err := d.execTxn(ctx, txnID, `DELETE FROM chunk_revisions WHERE chunk_id = ?`, cid); err != nil {
+				return err
+			}
+			// The canvas layout row for this chunk — the descendant-walk cascade site
+			// (delete_document walks by document; this walks one chunk's subtree).
+			if err := d.execTxn(ctx, txnID, `DELETE FROM chunk_layout WHERE chunk_id = ?`, cid); err != nil {
 				return err
 			}
 			if err := d.execTxn(ctx, txnID, `DELETE FROM chunks WHERE id = ?`, cid); err != nil {
@@ -3483,6 +3517,276 @@ func titleOrUntitled(s string) string {
 		return "Untitled"
 	}
 	return s
+}
+
+// --- ops: JSON Canvas import/export ---
+//
+// JSON Canvas is the open, spatial-graph interchange format Obsidian Canvas
+// reads/writes (a top-level {"nodes":[...],"edges":[...]}). export_canvas renders
+// a document's CONTENT chunks as canvas nodes + their cross-reference edges;
+// import_canvas builds a new document from a canvas. The two are a round-trip:
+// export→import→export lands the same node texts, layouts, and edges.
+
+// canvasNode is one JSON Canvas v1.0 node. x/y/width/height are integers per the
+// spec and always emitted (0,0 is a valid position, so no omitempty). The
+// type-specific fields (text/file/url/label) carry omitempty so a text node
+// doesn't emit an empty "file", etc. This tool only ever WRITES "text" nodes on
+// export, but the full field set lets import accept a real Obsidian canvas.
+type canvasNode struct {
+	ID     string `json:"id"`
+	Type   string `json:"type"`
+	X      int    `json:"x"`
+	Y      int    `json:"y"`
+	Width  int    `json:"width"`
+	Height int    `json:"height"`
+	Color  string `json:"color,omitempty"`
+	Text   string `json:"text,omitempty"`
+	File   string `json:"file,omitempty"`
+	URL    string `json:"url,omitempty"`
+	Label  string `json:"label,omitempty"`
+}
+
+// canvasEdge is one JSON Canvas v1.0 edge. Only fromNode/toNode are mandatory;
+// the side/end/color/label fields are optional and omitted when empty. export
+// sets toEnd="arrow" (the spec default, made explicit) and label=the edge kind.
+type canvasEdge struct {
+	ID       string `json:"id"`
+	FromNode string `json:"fromNode"`
+	ToNode   string `json:"toNode"`
+	FromSide string `json:"fromSide,omitempty"`
+	ToSide   string `json:"toSide,omitempty"`
+	FromEnd  string `json:"fromEnd,omitempty"`
+	ToEnd    string `json:"toEnd,omitempty"`
+	Color    string `json:"color,omitempty"`
+	Label    string `json:"label,omitempty"`
+}
+
+// canvasDoc is the top-level JSON Canvas object.
+type canvasDoc struct {
+	Nodes []canvasNode `json:"nodes"`
+	Edges []canvasEdge `json:"edges"`
+}
+
+// Auto-grid defaults for a content chunk with no stored layout: a deterministic
+// row-major grid so an un-placed document still exports to a readable canvas and
+// re-exports to the SAME coordinates (the round-trip relies on this).
+const (
+	canvasGridCols = 4
+	canvasNodeW    = 400
+	canvasNodeH    = 200
+	canvasNodeGap  = 50
+	// canvasTitleMax caps a node-derived chunk title (rune-safe) so a long node
+	// body doesn't become an unwieldy title.
+	canvasTitleMax = 120
+)
+
+// canvasLayout is a stored spatial position for a chunk (a chunk_layout row).
+type canvasLayout struct {
+	x, y, w, h int
+	color      string
+}
+
+// canvasNodeTitle derives a chunk title from a node's primary text: the first
+// non-empty line, trimmed and rune-capped, else "node <id>" — createChunk
+// requires a non-empty title, so this must never return "".
+func canvasNodeTitle(text, id string) string {
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if r := []rune(line); len(r) > canvasTitleMax {
+			line = string(r[:canvasTitleMax])
+		}
+		return line
+	}
+	return "node " + id
+}
+
+// exportCanvas renders a document as a JSON Canvas v1.0 graph.
+//
+// Nodes are the document's NON-ROOT (content) chunks — the root container chunk
+// holds the doc title/type, not canvas content, so skipping it keeps a
+// round-trip from accreting an empty node. Each content chunk becomes a "text"
+// node whose text is its body (or its title when the body is empty), positioned
+// from its stored chunk_layout row or, absent one, a deterministic auto-grid by
+// export order. Edges are the within-document chunk_edges whose BOTH endpoints
+// are content nodes (so an edge to the root, or a cross-document endpoint, is
+// dropped).
+func (d *Document) exportCanvas(ctx context.Context, key sqlmem.ScopeKey, mscope store.MemoryScope, in docInput) (tools.Result, error) {
+	docID := in.DocumentID
+	if docID == "" {
+		var err error
+		docID, err = d.docIDFromInput(ctx, key, in)
+		if err != nil {
+			return errResult("export_canvas: " + err.Error()), nil
+		}
+	}
+	dres, err := d.query(ctx, key, `SELECT root_chunk_id FROM documents WHERE id = ? LIMIT 1`, docID)
+	if err != nil {
+		return errResult("export_canvas: " + err.Error()), nil
+	}
+	if len(dres.Rows) == 0 {
+		return errResult("export_canvas: no such document: " + docID), nil
+	}
+	rootID := asStr(dres.Rows[0][0])
+
+	// Content chunks in the SAME deterministic order export_md walks
+	// (parent_id, position, id) so the auto-grid index is stable across exports.
+	cres, err := d.query(ctx, key, `SELECT `+chunkSelectCols+` FROM chunks WHERE document_id = ? ORDER BY parent_id, position, id`, docID)
+	if err != nil {
+		return errResult("export_canvas: " + err.Error()), nil
+	}
+
+	// Stored layouts for this document's chunks in one query.
+	layouts := map[string]canvasLayout{}
+	lres, err := d.query(ctx, key, `SELECT chunk_id, x, y, width, height, color FROM chunk_layout WHERE chunk_id IN (SELECT id FROM chunks WHERE document_id = ?)`, docID)
+	if err != nil {
+		return errResult("export_canvas: layout: " + err.Error()), nil
+	}
+	for _, r := range lres.Rows {
+		layouts[asStr(r[0])] = canvasLayout{x: asInt(r[1]), y: asInt(r[2]), w: asInt(r[3]), h: asInt(r[4]), color: asStr(r[5])}
+	}
+
+	nodes := []canvasNode{}
+	nodeSet := map[string]bool{}
+	i := 0
+	for _, r := range cres.Rows {
+		row := scanChunkRow(cres.Columns, r)
+		if row.ID == rootID {
+			continue // the root container is not canvas content
+		}
+		cb, rerr := d.readBody(ctx, mscope, key.ScopeID, row.ID)
+		if rerr != nil {
+			return errResult("export_canvas: body: " + rerr.Error()), nil
+		}
+		text := cb.Body
+		if strings.TrimSpace(text) == "" {
+			text = row.Title
+		}
+		n := canvasNode{ID: row.ID, Type: "text", Text: text}
+		if lay, ok := layouts[row.ID]; ok {
+			n.X, n.Y, n.Width, n.Height, n.Color = lay.x, lay.y, lay.w, lay.h, lay.color
+		} else {
+			n.X = (i % canvasGridCols) * (canvasNodeW + canvasNodeGap)
+			n.Y = (i / canvasGridCols) * (canvasNodeH + canvasNodeGap)
+			n.Width = canvasNodeW
+			n.Height = canvasNodeH
+		}
+		nodes = append(nodes, n)
+		nodeSet[row.ID] = true
+		i++
+	}
+
+	// Within-document edges whose BOTH endpoints are content nodes. The SQL
+	// restricts to this document; the nodeSet check then drops any edge touching
+	// the root (the one in-document chunk that is not a node).
+	eres, err := d.query(ctx, key, `SELECT from_id, to_id, kind FROM chunk_edges WHERE from_id IN (SELECT id FROM chunks WHERE document_id = ?) AND to_id IN (SELECT id FROM chunks WHERE document_id = ?) ORDER BY from_id, to_id, kind`, docID, docID)
+	if err != nil {
+		return errResult("export_canvas: edges: " + err.Error()), nil
+	}
+	edges := []canvasEdge{}
+	for _, r := range eres.Rows {
+		from, to, kind := asStr(r[0]), asStr(r[1]), asStr(r[2])
+		if !nodeSet[from] || !nodeSet[to] {
+			continue
+		}
+		edges = append(edges, canvasEdge{
+			ID: from + "-" + to + "-" + kind, FromNode: from, ToNode: to,
+			Label: kind, ToEnd: "arrow",
+		})
+	}
+
+	return jsonResult(map[string]any{"canvas": canvasDoc{Nodes: nodes, Edges: edges}, "document_id": docID})
+}
+
+// importCanvas builds a NEW document from a JSON Canvas graph.
+//
+// Each node becomes a child chunk of the new document's root, its coordinates
+// recorded in chunk_layout, and each edge becomes a manual chunk_edge (auto=0 —
+// an imported explicit edge is authored, not parser-derived). Node→chunk id
+// mapping remaps the edges; an edge whose endpoint node is absent is skipped
+// (defensive). Node bodies are ordinary data — the normal createChunk path runs,
+// so an imported [[name]] in a body reconciles into edges exactly as a typed one
+// would.
+func (d *Document) importCanvas(ctx context.Context, key sqlmem.ScopeKey, mscope store.MemoryScope, in docInput) (tools.Result, error) {
+	if len(in.Canvas) == 0 {
+		return errResult("import_canvas: missing required field: canvas"), nil
+	}
+	var cv canvasDoc
+	if err := json.Unmarshal(in.Canvas, &cv); err != nil {
+		return errResult("import_canvas: invalid canvas JSON: " + err.Error()), nil
+	}
+	title := in.Title
+	if strings.TrimSpace(title) == "" {
+		title = "Imported canvas"
+	}
+	cd, _ := d.createDocument(ctx, key, mscope, docInput{Title: title, Path: in.Path})
+	if cd.IsError {
+		return cd, nil
+	}
+	docID := resultField(cd, "document_id")
+	rootID := resultField(cd, "root_chunk_id")
+
+	nodeToChunk := map[string]string{}
+	created := 0
+	for _, n := range cv.Nodes {
+		var body, chunkTitle string
+		switch n.Type {
+		case "file":
+			body = "[file: " + n.File + "]"
+			chunkTitle = canvasNodeTitle(n.File, n.ID)
+		case "link":
+			body = n.URL
+			chunkTitle = canvasNodeTitle(n.URL, n.ID)
+		case "group":
+			chunkTitle = strings.TrimSpace(n.Label)
+			if chunkTitle == "" {
+				chunkTitle = "group"
+			}
+		default:
+			// "text" and any forward-compat/unknown node type: keep the node (so its
+			// edges still resolve) with its text as the body.
+			body = n.Text
+			chunkTitle = canvasNodeTitle(n.Text, n.ID)
+		}
+		cc, _ := d.createChunk(ctx, key, mscope, docInput{
+			DocumentID: docID, ParentID: rootID, Title: chunkTitle, Body: body,
+		})
+		if cc.IsError {
+			return cc, nil
+		}
+		newID := resultField(cc, "id")
+		nodeToChunk[n.ID] = newID
+		if err := d.exec(ctx, key, `INSERT INTO chunk_layout (chunk_id, x, y, width, height, color) VALUES (?, ?, ?, ?, ?, ?)`,
+			newID, n.X, n.Y, n.Width, n.Height, nullIfEmpty(n.Color)); err != nil {
+			return errResult("import_canvas: layout: " + err.Error()), nil
+		}
+		created++
+	}
+
+	edgesCreated := 0
+	for _, e := range cv.Edges {
+		from, ok1 := nodeToChunk[e.FromNode]
+		to, ok2 := nodeToChunk[e.ToNode]
+		if !ok1 || !ok2 {
+			continue
+		}
+		kind := strings.TrimSpace(e.Label)
+		if kind == "" {
+			kind = "references"
+		}
+		lr, _ := d.linkChunks(ctx, key, docInput{FromID: from, ToID: to, Kind: kind})
+		if lr.IsError {
+			return lr, nil
+		}
+		edgesCreated++
+	}
+
+	return jsonResult(map[string]any{
+		"document_id": docID, "root_chunk_id": rootID,
+		"chunks_created": created, "edges_created": edgesCreated,
+	})
 }
 
 // --- ops: type definitions ---

--- a/internal/tools/builtin/document_canvas_test.go
+++ b/internal/tools/builtin/document_canvas_test.go
@@ -1,0 +1,426 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// JSON Canvas import/export (RFC BS Phase 4).
+//
+// export_canvas renders a document's CONTENT chunks (never the root container) as
+// JSON Canvas v1.0 "text" nodes + their within-document cross-reference edges;
+// import_canvas builds a new document from a canvas. These pin: the export→import
+// →export round-trip (same node texts + layouts, same edge multiset), spec
+// conformance (integer coords, type "text", toEnd "arrow"), a hand-written
+// Obsidian-style canvas import (bodies == node texts, layout rows == node coords,
+// label → edge kind), and auto-grid determinism (an un-placed chunk exports to a
+// deterministic grid slot that survives a round-trip).
+//
+// Every case touches SQL Memory, so all run on BOTH tiers via historyBothTiers
+// (sqlite + postgres, the pg half skipped without the aux DSN). The top-level
+// name carries the TestDocumentCanvas_ prefix the CI postgres-tier -run filter
+// keys on — a postgres-tier test absent from that filter never runs in CI.
+
+func TestDocumentCanvas_CoreBothTiers(t *testing.T) {
+	historyBothTiers(t, func(t *testing.T, d *Document, ctx context.Context) {
+		t.Run("round_trip", func(t *testing.T) { assertCanvasRoundTrip(t, d, ctx) })
+		t.Run("spec_conformance", func(t *testing.T) { assertCanvasSpecConformance(t, d, ctx) })
+		t.Run("obsidian_import", func(t *testing.T) { assertCanvasObsidianImport(t, d, ctx) })
+		t.Run("auto_grid", func(t *testing.T) { assertCanvasAutoGrid(t, d, ctx) })
+		t.Run("delete_cascade", func(t *testing.T) { assertCanvasDeleteCascade(t, d, ctx) })
+	})
+}
+
+// --- op wrappers (user scope) ---
+
+func canvasCreateDoc(t *testing.T, d *Document, ctx context.Context, title string) (docID, rootID string) {
+	t.Helper()
+	out, r := docExec(t, d, ctx, fmt.Sprintf(`{"op":"create_document","scope":"user","title":%q}`, title))
+	if r.IsError {
+		t.Fatalf("create_document(%s): %s", title, r.Text)
+	}
+	return out["document_id"].(string), out["root_chunk_id"].(string)
+}
+
+func canvasCreateChunk(t *testing.T, d *Document, ctx context.Context, docID, rootID, title, body string) string {
+	t.Helper()
+	out, r := docExec(t, d, ctx, fmt.Sprintf(
+		`{"op":"create_chunk","scope":"user","document_id":%q,"parent_id":%q,"title":%q,"body":%q}`,
+		docID, rootID, title, body))
+	if r.IsError {
+		t.Fatalf("create_chunk(%s): %s", title, r.Text)
+	}
+	return out["id"].(string)
+}
+
+func canvasLink(t *testing.T, d *Document, ctx context.Context, from, to, kind string) {
+	t.Helper()
+	_, r := docExec(t, d, ctx, fmt.Sprintf(
+		`{"op":"link_chunks","scope":"user","from_id":%q,"to_id":%q,"kind":%q}`, from, to, kind))
+	if r.IsError {
+		t.Fatalf("link_chunks(%s->%s): %s", from, to, r.Text)
+	}
+}
+
+// canvasStoreLayout writes a chunk_layout row directly (there is no dedicated op
+// — a layout is authored on the import side or by a spatial UI). It resolves the
+// same scope key the tool ops use, so the row lands where export_canvas reads.
+func canvasStoreLayout(t *testing.T, d *Document, ctx context.Context, chunkID string, x, y, w, h int, color string) {
+	t.Helper()
+	key, _, err := d.resolveScope(ctx, "user")
+	if err != nil {
+		t.Fatalf("resolveScope: %v", err)
+	}
+	if err := d.exec(ctx, key,
+		`INSERT INTO chunk_layout (chunk_id, x, y, width, height, color) VALUES (?, ?, ?, ?, ?, ?)`,
+		chunkID, x, y, w, h, nullIfEmpty(color)); err != nil {
+		t.Fatalf("store layout: %v", err)
+	}
+}
+
+func canvasExport(t *testing.T, d *Document, ctx context.Context, docID string) canvasDoc {
+	t.Helper()
+	out, r := docExec(t, d, ctx, fmt.Sprintf(`{"op":"export_canvas","scope":"user","document_id":%q}`, docID))
+	if r.IsError {
+		t.Fatalf("export_canvas(%s): %s", docID, r.Text)
+	}
+	raw, _ := json.Marshal(out["canvas"])
+	var cv canvasDoc
+	if err := json.Unmarshal(raw, &cv); err != nil {
+		t.Fatalf("decode canvas: %v (raw=%s)", err, raw)
+	}
+	return cv
+}
+
+func canvasImport(t *testing.T, d *Document, ctx context.Context, cv canvasDoc, title string) map[string]any {
+	t.Helper()
+	body, _ := json.Marshal(cv)
+	req, _ := json.Marshal(map[string]any{"op": "import_canvas", "scope": "user", "title": title, "canvas": json.RawMessage(body)})
+	out, r := docExec(t, d, ctx, string(req))
+	if r.IsError {
+		t.Fatalf("import_canvas(%s): %s", title, r.Text)
+	}
+	return out
+}
+
+// --- comparators ---
+
+// nodeLayoutByText keys a canvas's nodes by their text → (x,y,width,height). The
+// test bodies are all distinct, so text is a stable identity across a round-trip
+// (ids and the skipped root differ, coords must not).
+func nodeLayoutByText(cv canvasDoc) map[string][4]int {
+	m := map[string][4]int{}
+	for _, n := range cv.Nodes {
+		m[n.Text] = [4]int{n.X, n.Y, n.Width, n.Height}
+	}
+	return m
+}
+
+// edgeKeysByText renders each edge as "label|fromText->toText" (sorted) so two
+// canvases compare as an edge MULTISET independent of node ids.
+func edgeKeysByText(cv canvasDoc) []string {
+	idText := map[string]string{}
+	for _, n := range cv.Nodes {
+		idText[n.ID] = n.Text
+	}
+	keys := make([]string, 0, len(cv.Edges))
+	for _, e := range cv.Edges {
+		keys = append(keys, e.Label+"|"+idText[e.FromNode]+"->"+idText[e.ToNode])
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// --- cases ---
+
+// assertCanvasRoundTrip: a document (root + 3 content chunks with distinct
+// bodies, one carrying a stored layout, + 2 edges among them) → export C1 →
+// import → export C2, with C1 and C2 equal by node-text→layout and edge multiset.
+// The root is skipped both ways, so counts stay 3 nodes / 2 edges each direction.
+func assertCanvasRoundTrip(t *testing.T, d *Document, ctx context.Context) {
+	docID, rootID := canvasCreateDoc(t, d, ctx, "RT source")
+	c1 := canvasCreateChunk(t, d, ctx, docID, rootID, "C1", "body one")
+	c2 := canvasCreateChunk(t, d, ctx, docID, rootID, "C2", "body two")
+	c3 := canvasCreateChunk(t, d, ctx, docID, rootID, "C3", "body three")
+	// A stored layout on c2, with coordinates no auto-grid slot would produce, so
+	// "the stored row was used" is unambiguous. Includes a color.
+	canvasStoreLayout(t, d, ctx, c2, 1234, 5678, 321, 222, "#ff0000")
+	canvasLink(t, d, ctx, c1, c2, "supports")
+	canvasLink(t, d, ctx, c2, c3, "refines")
+
+	cv1 := canvasExport(t, d, ctx, docID)
+	if len(cv1.Nodes) != 3 {
+		t.Fatalf("C1 nodes = %d, want 3 (root must be skipped): %+v", len(cv1.Nodes), cv1.Nodes)
+	}
+	if len(cv1.Edges) != 2 {
+		t.Fatalf("C1 edges = %d, want 2: %+v", len(cv1.Edges), cv1.Edges)
+	}
+	// The stored layout is what got exported for c2's body.
+	if got := nodeLayoutByText(cv1)["body two"]; got != [4]int{1234, 5678, 321, 222} {
+		t.Errorf("stored layout not exported: got %v, want [1234 5678 321 222]", got)
+	}
+
+	imp := canvasImport(t, d, ctx, cv1, "RT imported")
+	if int(imp["chunks_created"].(float64)) != 3 {
+		t.Errorf("chunks_created = %v, want 3", imp["chunks_created"])
+	}
+	if int(imp["edges_created"].(float64)) != 2 {
+		t.Errorf("edges_created = %v, want 2", imp["edges_created"])
+	}
+	newDoc := imp["document_id"].(string)
+	if newDoc == "" || newDoc == docID {
+		t.Fatalf("import made no fresh document: %v", imp["document_id"])
+	}
+
+	cv2 := canvasExport(t, d, ctx, newDoc)
+	if len(cv2.Nodes) != 3 || len(cv2.Edges) != 2 {
+		t.Fatalf("C2 = %d nodes / %d edges, want 3 / 2", len(cv2.Nodes), len(cv2.Edges))
+	}
+	if !reflect.DeepEqual(nodeLayoutByText(cv1), nodeLayoutByText(cv2)) {
+		t.Errorf("node text→layout differs across round-trip:\n C1=%v\n C2=%v", nodeLayoutByText(cv1), nodeLayoutByText(cv2))
+	}
+	if !reflect.DeepEqual(edgeKeysByText(cv1), edgeKeysByText(cv2)) {
+		t.Errorf("edge multiset differs across round-trip:\n C1=%v\n C2=%v", edgeKeysByText(cv1), edgeKeysByText(cv2))
+	}
+	// The stored layout + color survives the full round-trip (color is carried
+	// even though the set comparison above only pins x/y/w/h).
+	for _, n := range cv2.Nodes {
+		if n.Text == "body two" {
+			if n.X != 1234 || n.Y != 5678 || n.Width != 321 || n.Height != 222 || n.Color != "#ff0000" {
+				t.Errorf("stored layout+color did not round-trip: %+v", n)
+			}
+		}
+	}
+}
+
+// assertCanvasSpecConformance decodes the raw export and pins the JSON Canvas
+// v1.0 wire contract: nodes are type "text" with INTEGER x/y/width/height, edges
+// carry fromNode/toNode and toEnd "arrow". Coordinates are checked as literal
+// json.Number strings so a float like "400.0" (which would decode fine into an
+// int field) is caught.
+func assertCanvasSpecConformance(t *testing.T, d *Document, ctx context.Context) {
+	docID, rootID := canvasCreateDoc(t, d, ctx, "spec")
+	a := canvasCreateChunk(t, d, ctx, docID, rootID, "A", "alpha")
+	b := canvasCreateChunk(t, d, ctx, docID, rootID, "B", "beta")
+	canvasLink(t, d, ctx, a, b, "cites")
+
+	_, res := docExec(t, d, ctx, fmt.Sprintf(`{"op":"export_canvas","scope":"user","document_id":%q}`, docID))
+	if res.IsError {
+		t.Fatalf("export_canvas: %s", res.Text)
+	}
+	var parsed struct {
+		Canvas struct {
+			Nodes []struct {
+				ID     string      `json:"id"`
+				Type   string      `json:"type"`
+				X      json.Number `json:"x"`
+				Y      json.Number `json:"y"`
+				Width  json.Number `json:"width"`
+				Height json.Number `json:"height"`
+			} `json:"nodes"`
+			Edges []struct {
+				ID       string `json:"id"`
+				FromNode string `json:"fromNode"`
+				ToNode   string `json:"toNode"`
+				ToEnd    string `json:"toEnd"`
+			} `json:"edges"`
+		} `json:"canvas"`
+	}
+	if err := json.Unmarshal([]byte(res.Text), &parsed); err != nil {
+		t.Fatalf("unmarshal export: %v (text=%s)", err, res.Text)
+	}
+	if len(parsed.Canvas.Nodes) != 2 {
+		t.Fatalf("nodes = %d, want 2", len(parsed.Canvas.Nodes))
+	}
+	for _, n := range parsed.Canvas.Nodes {
+		if n.Type != "text" {
+			t.Errorf("node %s type = %q, want text", n.ID, n.Type)
+		}
+		for name, num := range map[string]json.Number{"x": n.X, "y": n.Y, "width": n.Width, "height": n.Height} {
+			s := num.String()
+			if s == "" || strings.ContainsAny(s, ".eE") {
+				t.Errorf("node %s %s = %q, want an integer literal", n.ID, name, s)
+			}
+		}
+	}
+	if len(parsed.Canvas.Edges) != 1 {
+		t.Fatalf("edges = %d, want 1", len(parsed.Canvas.Edges))
+	}
+	if e := parsed.Canvas.Edges[0]; e.FromNode == "" || e.ToNode == "" || e.ToEnd != "arrow" {
+		t.Errorf("edge = %+v, want non-empty fromNode/toNode and toEnd=arrow", e)
+	}
+}
+
+// assertCanvasObsidianImport imports a hand-written JSON Canvas (two text nodes
+// at real coordinates + one labelled edge) and verifies via re-export that the
+// bodies == the node texts, the layout rows == the node coordinates, and the one
+// edge carries the label as its kind.
+func assertCanvasObsidianImport(t *testing.T, d *Document, ctx context.Context) {
+	canvasJSON := `{
+	  "nodes": [
+	    {"id":"n1","type":"text","text":"First note","x":100,"y":200,"width":300,"height":150},
+	    {"id":"n2","type":"text","text":"Second note","x":500,"y":220,"width":260,"height":180}
+	  ],
+	  "edges": [
+	    {"id":"e1","fromNode":"n1","toNode":"n2","label":"leads to"}
+	  ]
+	}`
+	req, _ := json.Marshal(map[string]any{"op": "import_canvas", "scope": "user", "title": "Obsidian", "canvas": json.RawMessage(canvasJSON)})
+	out, r := docExec(t, d, ctx, string(req))
+	if r.IsError {
+		t.Fatalf("import_canvas: %s", r.Text)
+	}
+	if int(out["chunks_created"].(float64)) != 2 {
+		t.Errorf("chunks_created = %v, want 2", out["chunks_created"])
+	}
+	if int(out["edges_created"].(float64)) != 1 {
+		t.Errorf("edges_created = %v, want 1", out["edges_created"])
+	}
+	docID := out["document_id"].(string)
+
+	cv := canvasExport(t, d, ctx, docID)
+	if len(cv.Nodes) != 2 {
+		t.Fatalf("re-export nodes = %d, want 2: %+v", len(cv.Nodes), cv.Nodes)
+	}
+	byText := map[string]canvasNode{}
+	for _, n := range cv.Nodes {
+		byText[n.Text] = n
+	}
+	n1, ok := byText["First note"]
+	if !ok {
+		t.Fatalf("body != node text: 'First note' missing from %+v", cv.Nodes)
+	}
+	if n1.X != 100 || n1.Y != 200 || n1.Width != 300 || n1.Height != 150 {
+		t.Errorf("n1 layout = (%d,%d %dx%d), want (100,200 300x150)", n1.X, n1.Y, n1.Width, n1.Height)
+	}
+	n2, ok := byText["Second note"]
+	if !ok {
+		t.Fatalf("body != node text: 'Second note' missing from %+v", cv.Nodes)
+	}
+	if n2.X != 500 || n2.Y != 220 || n2.Width != 260 || n2.Height != 180 {
+		t.Errorf("n2 layout = (%d,%d %dx%d), want (500,220 260x180)", n2.X, n2.Y, n2.Width, n2.Height)
+	}
+	if len(cv.Edges) != 1 {
+		t.Fatalf("edges = %d, want 1", len(cv.Edges))
+	}
+	if cv.Edges[0].Label != "leads to" {
+		t.Errorf("edge kind (label) = %q, want 'leads to'", cv.Edges[0].Label)
+	}
+}
+
+// assertCanvasAutoGrid: content chunks with NO stored layout export to a
+// deterministic row-major grid (4 cols, 400x200 + 50 gap) by export order, and
+// those coordinates survive an import→re-export unchanged.
+func assertCanvasAutoGrid(t *testing.T, d *Document, ctx context.Context) {
+	docID, rootID := canvasCreateDoc(t, d, ctx, "grid")
+	const n = 6
+	for i := 0; i < n; i++ {
+		canvasCreateChunk(t, d, ctx, docID, rootID, fmt.Sprintf("g%d", i), fmt.Sprintf("grid body %d", i))
+	}
+	cv := canvasExport(t, d, ctx, docID)
+	if len(cv.Nodes) != n {
+		t.Fatalf("nodes = %d, want %d", len(cv.Nodes), n)
+	}
+	// The node whose body is "grid body i" must sit at the grid slot for index i
+	// (which also proves export order == creation/position order).
+	for i := 0; i < n; i++ {
+		wantX := (i % canvasGridCols) * (canvasNodeW + canvasNodeGap)
+		wantY := (i / canvasGridCols) * (canvasNodeH + canvasNodeGap)
+		got := nodeLayoutByText(cv)[fmt.Sprintf("grid body %d", i)]
+		if got != [4]int{wantX, wantY, canvasNodeW, canvasNodeH} {
+			t.Errorf("auto-grid node %d = %v, want [%d %d %d %d]", i, got, wantX, wantY, canvasNodeW, canvasNodeH)
+		}
+	}
+	// Import stores every exported coordinate, so a re-export reads them back
+	// identically — the auto-grid layout is stable through a round-trip.
+	imp := canvasImport(t, d, ctx, cv, "grid imported")
+	cv2 := canvasExport(t, d, ctx, imp["document_id"].(string))
+	if !reflect.DeepEqual(nodeLayoutByText(cv), nodeLayoutByText(cv2)) {
+		t.Errorf("auto-grid layout did not survive round-trip:\n c1=%v\n c2=%v", nodeLayoutByText(cv), nodeLayoutByText(cv2))
+	}
+}
+
+// countLayout counts chunk_layout rows for a literal set of chunk ids — literal,
+// NOT via a `document_id` subquery, so it still finds ORPHAN rows after the
+// chunks themselves are deleted (the whole point of a cascade test).
+func countLayout(t *testing.T, d *Document, ctx context.Context, ids []string) int {
+	t.Helper()
+	key, _, err := d.resolveScope(ctx, "user")
+	if err != nil {
+		t.Fatalf("resolveScope: %v", err)
+	}
+	ph, args := inPlaceholders(ids)
+	res, err := d.query(ctx, key, `SELECT COUNT(*) FROM chunk_layout WHERE chunk_id IN (`+ph+`)`, args...)
+	if err != nil {
+		t.Fatalf("count layout: %v", err)
+	}
+	if len(res.Rows) == 0 {
+		return 0
+	}
+	return asInt(res.Rows[0][0])
+}
+
+// assertCanvasDeleteCascade pins BOTH cascade sites: import_canvas writes a
+// chunk_layout row per node, delete_chunk drops the row for the deleted chunk
+// (leaving its sibling's), and delete_document drops the rest. Queried by literal
+// chunk id so a MISSING cascade shows up as an orphaned row rather than passing
+// vacuously once the chunks are gone.
+func assertCanvasDeleteCascade(t *testing.T, d *Document, ctx context.Context) {
+	canvasJSON := `{
+	  "nodes": [
+	    {"id":"a","type":"text","text":"cascade a","x":10,"y":20,"width":30,"height":40},
+	    {"id":"b","type":"text","text":"cascade b","x":50,"y":60,"width":70,"height":80}
+	  ],
+	  "edges": []
+	}`
+	req, _ := json.Marshal(map[string]any{"op": "import_canvas", "scope": "user", "title": "cascade", "canvas": json.RawMessage(canvasJSON)})
+	out, r := docExec(t, d, ctx, string(req))
+	if r.IsError {
+		t.Fatalf("import_canvas: %s", r.Text)
+	}
+	docID := out["document_id"].(string)
+
+	// The content chunks (children of the root) carry the layout rows.
+	key, _, err := d.resolveScope(ctx, "user")
+	if err != nil {
+		t.Fatalf("resolveScope: %v", err)
+	}
+	cres, err := d.query(ctx, key, `SELECT id FROM chunks WHERE document_id = ? AND parent_id IS NOT NULL`, docID)
+	if err != nil {
+		t.Fatalf("query content chunks: %v", err)
+	}
+	var ids []string
+	for _, row := range cres.Rows {
+		ids = append(ids, asStr(row[0]))
+	}
+	if len(ids) != 2 {
+		t.Fatalf("content chunks = %d, want 2", len(ids))
+	}
+	if n := countLayout(t, d, ctx, ids); n != 2 {
+		t.Fatalf("layout rows after import = %d, want 2", n)
+	}
+
+	// delete_chunk one leaf → only its layout row goes.
+	if _, dr := docExec(t, d, ctx, fmt.Sprintf(`{"op":"delete_chunk","scope":"user","id":%q}`, ids[0])); dr.IsError {
+		t.Fatalf("delete_chunk: %s", dr.Text)
+	}
+	if n := countLayout(t, d, ctx, ids[:1]); n != 0 {
+		t.Errorf("orphan layout row for deleted chunk = %d, want 0", n)
+	}
+	if n := countLayout(t, d, ctx, ids[1:]); n != 1 {
+		t.Errorf("sibling layout row = %d, want 1 (a sibling delete must not touch it)", n)
+	}
+
+	// delete_document → the remaining layout row goes too.
+	if _, dr := docExec(t, d, ctx, fmt.Sprintf(`{"op":"delete_document","scope":"user","id":%q}`, docID)); dr.IsError {
+		t.Fatalf("delete_document: %s", dr.Text)
+	}
+	if n := countLayout(t, d, ctx, ids); n != 0 {
+		t.Errorf("orphan layout rows after delete_document = %d, want 0", n)
+	}
+}


### PR DESCRIPTION
The **final phase of RFC BS — Document structure primitives** (`/loomcycle/rfcs/document-structure-primitives`), after P1–P3 (#932/#934/#935/#937/#940). Backend only.

## Why
Round-trip a document to/from **JSON Canvas v1.0** — the open, MIT spatial-graph format Obsidian Canvas uses. This gives Obsidian-Canvas interop and the interchange format loomboard's spatial view will render.

## What
- **`chunk_layout`** (`chunk_id, x, y, width, height, color`) — a chunk's canvas position (view metadata, not a query axis), self-provisioned in `ensureSchema` and cascaded on `delete_chunk`/`delete_document`.
- **`export_canvas`** — a document → JSON Canvas. Nodes are the document's **non-root content chunks** (skipping the root container keeps a round-trip from accreting an empty node); each a `text` node with its body (title fallback), positioned from its `chunk_layout` row or a **deterministic auto-grid** by export order. Edges are within-document `chunk_edges` whose both endpoints are content nodes (root/cross-doc endpoints dropped). Spec-valid **integer** coords.
- **`import_canvas`** — a JSON Canvas → a **new** document: each node becomes a child chunk (text/file/link/group **all** mapped, so no node is lost), its coords stored in `chunk_layout`, and node→chunk ids remap the edges (kind = the edge label, else `references`; manual `auto=0`). Imported bodies run the normal create path, so a `[[name]]` in a body reconciles into an edge as usual.

## Tested
`document_canvas_test.go` (sqlite + postgres) — **structural round-trip** (node text + layout + edge multiset equal across export→import→export; stored layout+color survive), **spec conformance** (integer coords, `text` nodes, `toEnd` arrow), an **Obsidian-authored `.canvas` imports** to the right chunks/layout/edge, **auto-grid determinism**, and **delete-cascade leaves no orphan layout rows**. Each fail-before verified. `go test ./...` exit 0. Added `TestDocumentCanvas_` to the postgres-tier allowlist so it gates. Additive — no wire break.

## RFC BS is now complete
| Phase | | PR |
|---|---|---|
| P1 tags + doc facets | ✅ | #932 |
| P2a name-links | ✅ | #934 |
| P2b transclusion | ✅ | #935 |
| P3a history + backlinks | ✅ | #937 |
| P3b related + unlinked_mentions | ✅ | #940 |
| **P4 JSON Canvas** | **this** | — |

Tracked follow-ups (noted across the PRs, not silently dropped): a document/path-bounded `unlinked_mentions`; snapshotting `upsert`/`import_md`/`set_asset` body writes into history; an in-viewer transclusion render. Next major line: **loomboard (RFC BT)** — the view surfaces that consume these primitives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD