### PR TITLE
feat(explorer): surface the RFC BS primitives in the document viewer

### DIFF
--- a/adapters/ts/src/types.ts
+++ b/adapters/ts/src/types.ts
@@ -1238,7 +1238,21 @@ export type DocumentToolInput = {
     | "set_asset"
     | "get_asset"
     | "export_md"
-    | "import_md";
+    | "import_md"
+    // RFC BS — document connections (backlinks / vector-related / unlinked
+    // mentions), per-chunk edit history (history / get_version / diff), and the
+    // node-edge canvas graph (export_canvas / import_canvas). Appended (not
+    // interleaved) because these were added to the backend enum after the ops
+    // above; the union order is only for type-completeness — the wire passthrough
+    // carries any `op` verbatim.
+    | "backlinks"
+    | "related"
+    | "unlinked_mentions"
+    | "history"
+    | "get_version"
+    | "diff"
+    | "export_canvas"
+    | "import_canvas";
   scope?: "agent" | "user" | "tenant";
   /** Document id (get/delete_document) or chunk id (get/update/delete/move_chunk). */
   id?: string;
@@ -1261,8 +1275,16 @@ export type DocumentToolInput = {
   /** query_chunks: match this tag OR anything nested under it (prefix + '/'). */
   tag_prefix?: string;
   position?: number;
-  /** update_chunk: the chunk's current revision (optimistic concurrency). */
+  /** update_chunk: the chunk's current revision (optimistic concurrency).
+   *  get_version: the historical revision to fetch. */
   revision?: number;
+  /** diff (RFC BS): the two chunk revisions to compare (from_revision →
+   *  to_revision), producing a unified-diff text. */
+  from_revision?: number;
+  to_revision?: number;
+  /** import_canvas (RFC BS): a node/edge canvas graph to build a document from
+   *  (the shape export_canvas emits). Opaque here; the backend owns the schema. */
+  canvas?: unknown;
   from_id?: string;
   to_id?: string;
   kind?: string;

--- a/packages/explorer/src/components/Connections.tsx
+++ b/packages/explorer/src/components/Connections.tsx
@@ -1,0 +1,229 @@
+import { useEffect, useState } from "react";
+import type {
+  Backlink,
+  BrowseScope,
+  DocScope,
+  RelatedChunk,
+  UnlinkedMention,
+} from "../types";
+import { useExplorerData } from "../lib/dataLayer";
+
+// Connections is the RFC BS per-chunk connection surface, a collapsible companion
+// to CrossReferences. It shows three lists for the SELECTED chunk, each fetched
+// lazily (only once the section is expanded, and refetched when the selection
+// changes while open — collapsed keeps the viewer quiet):
+//   - Backlinks         — chunks that link TO this one ("what links here").
+//   - Related           — semantic neighbours (vector similarity). REFUSES with no
+//                          embedder configured → a muted note, not an error.
+//   - Unlinked mentions — chunks that name this one but don't link it (candidates).
+// A same-document target is clickable (navigates via onSelectChunk); a
+// cross-document one is labeled ↗ and not navigable from this single-doc viewer —
+// the same rule CrossReferences uses.
+export interface ConnectionsProps {
+  documentId: string;
+  selectedId?: string;
+  scope: DocScope;
+  browse?: BrowseScope;
+  onSelectChunk: (id: string) => void;
+}
+
+const RELATED_LIMIT = 8;
+const MENTIONS_LIMIT = 20;
+
+// isEmbedderError recognizes the `related` op's refusal when the deployment has no
+// embedder/vector backend, so the UI can say "not configured" rather than surface
+// a raw error — related is a best-effort enhancement, never load-bearing.
+function isEmbedderError(msg: string): boolean {
+  return /embedder|embedding|vector|semantic|not configured/i.test(msg);
+}
+
+export default function Connections({
+  documentId,
+  selectedId,
+  scope,
+  browse,
+  onSelectChunk,
+}: ConnectionsProps) {
+  const data = useExplorerData();
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [loadedId, setLoadedId] = useState<string | undefined>(undefined);
+  const [backlinks, setBacklinks] = useState<Backlink[]>([]);
+  const [related, setRelated] = useState<RelatedChunk[]>([]);
+  const [relatedNote, setRelatedNote] = useState<string | null>(null);
+  const [mentions, setMentions] = useState<UnlinkedMention[]>([]);
+  const [mentionsTruncated, setMentionsTruncated] = useState(false);
+
+  // Fetch only while expanded AND a chunk is selected; the three reads are
+  // independent (allSettled) so a `related` refusal never blanks backlinks/
+  // mentions. Cancelled on unmount / re-selection so a stale resolution can't
+  // clobber the newer one.
+  useEffect(() => {
+    if (!open || !selectedId) return;
+    const id = selectedId;
+    let cancelled = false;
+    setLoading(true);
+    Promise.allSettled([
+      data.documentBacklinks(id, scope, browse),
+      data.documentRelated(id, scope, browse, RELATED_LIMIT),
+      data.documentUnlinkedMentions(id, scope, browse, MENTIONS_LIMIT),
+    ]).then(([b, r, m]) => {
+      if (cancelled) return;
+      setBacklinks(b.status === "fulfilled" ? b.value.backlinks ?? [] : []);
+      if (r.status === "fulfilled") {
+        setRelated(r.value.related ?? []);
+        setRelatedNote(null);
+      } else {
+        setRelated([]);
+        const msg = r.reason instanceof Error ? r.reason.message : String(r.reason);
+        setRelatedNote(isEmbedderError(msg) ? "semantic search not configured" : msg);
+      }
+      if (m.status === "fulfilled") {
+        setMentions(m.value.unlinked_mentions ?? []);
+        setMentionsTruncated(!!m.value.truncated);
+      } else {
+        setMentions([]);
+        setMentionsTruncated(false);
+      }
+      setLoadedId(id);
+      setLoading(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [data, open, selectedId, scope, browse]);
+
+  const isCrossDoc = (otherDoc?: string) => !!otherDoc && otherDoc !== documentId;
+  // Data is current only when it was fetched for THIS selection and no fetch is in
+  // flight — otherwise show "loading…" (this also covers the first frame after
+  // expanding, before the effect sets loading, so no stale "none" flashes).
+  const ready = !!(open && selectedId && !loading && loadedId === selectedId);
+
+  return (
+    <div className="doc-conn">
+      <button
+        type="button"
+        className="doc-conn-toggle"
+        onClick={() => setOpen((o) => !o)}
+      >
+        {open ? "▼" : "▶"} Connections
+      </button>
+      {open && (
+        <div className="doc-conn-body">
+          {!selectedId ? (
+            <p className="doc-conn-empty">Select a chunk.</p>
+          ) : !ready ? (
+            <p className="doc-conn-empty">loading…</p>
+          ) : (
+            <>
+              <div className="doc-conn-group">
+                <h5>Backlinks</h5>
+                {backlinks.length === 0 ? (
+                  <p className="doc-conn-empty">none</p>
+                ) : (
+                  <ul className="doc-conn-list">
+                    {backlinks.map((e, i) => (
+                      <li className="doc-conn-row" key={`${e.from_id}-${e.kind}-${i}`}>
+                        <Target
+                          id={e.from_id}
+                          title={e.from_title}
+                          crossDoc={isCrossDoc(e.from_document_id)}
+                          onSelect={onSelectChunk}
+                        />
+                        <span className="doc-ref-kind">{e.kind}</span>
+                        {e.auto && (
+                          <span className="doc-conn-auto" title="Auto-linked from a [[wikilink]]">
+                            auto
+                          </span>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+
+              <div className="doc-conn-group">
+                <h5>Related</h5>
+                {relatedNote ? (
+                  <p className="doc-conn-empty">{relatedNote}</p>
+                ) : related.length === 0 ? (
+                  <p className="doc-conn-empty">none</p>
+                ) : (
+                  <ul className="doc-conn-list">
+                    {related.map((r, i) => (
+                      <li className="doc-conn-row" key={`${r.chunk_id}-${i}`}>
+                        <Target
+                          id={r.chunk_id}
+                          title={r.title}
+                          crossDoc={isCrossDoc(r.document_id)}
+                          onSelect={onSelectChunk}
+                        />
+                        <span className="doc-conn-score" title="similarity score">
+                          {r.score.toFixed(2)}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+
+              <div className="doc-conn-group">
+                <h5>Unlinked mentions</h5>
+                {mentions.length === 0 ? (
+                  <p className="doc-conn-empty">none</p>
+                ) : (
+                  <ul className="doc-conn-list">
+                    {mentions.map((m, i) => (
+                      <li className="doc-conn-row" key={`${m.chunk_id}-${i}`}>
+                        <Target
+                          id={m.chunk_id}
+                          title={m.title}
+                          crossDoc={isCrossDoc(m.document_id)}
+                          onSelect={onSelectChunk}
+                        />
+                      </li>
+                    ))}
+                    {mentionsTruncated && (
+                      <li className="doc-conn-more" aria-hidden>
+                        (more…)
+                      </li>
+                    )}
+                  </ul>
+                )}
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Target renders a connection's far endpoint: a same-document chunk is a clickable
+// navigation button; a cross-document one is a non-navigable ↗ label (mirrors
+// CrossReferences' RefRow). Falls back to a short id when the title is absent.
+function Target({
+  id,
+  title,
+  crossDoc,
+  onSelect,
+}: {
+  id: string;
+  title?: string;
+  crossDoc: boolean;
+  onSelect: (id: string) => void;
+}) {
+  const label = title || id.slice(0, 8);
+  if (crossDoc) {
+    return (
+      <span className="doc-ref-target external" title="In another document">
+        {label} ↗
+      </span>
+    );
+  }
+  return (
+    <button type="button" className="doc-ref-target" onClick={() => onSelect(id)}>
+      {label}
+    </button>
+  );
+}

--- a/packages/explorer/src/components/DocumentViewerBody.tsx
+++ b/packages/explorer/src/components/DocumentViewerBody.tsx
@@ -23,7 +23,9 @@ import DocumentChunkTree, {
 } from "./DocumentChunkTree";
 import ChunkEditorModal from "./ChunkEditorModal";
 import ColorSchemeEditor from "./ColorSchemeEditor";
+import Connections from "./Connections";
 import CrossReferences from "./CrossReferences";
+import HistoryModal from "./HistoryModal";
 import Markdown from "./Markdown";
 import MermaidDiagram from "./Mermaid";
 
@@ -98,6 +100,7 @@ export default function DocumentViewerBody({
   const [imageErr, setImageErr] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null); // hidden upload input (RFC BO)
   const [editing, setEditing] = useState<ChunkDetail | null>(null);
+  const [historyOpen, setHistoryOpen] = useState(false); // RFC BS chunk history modal
   const [confirmDelete, setConfirmDelete] = useState(false); // RFC BP delete confirm
   const [err, setErr] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -319,6 +322,26 @@ export default function DocumentViewerBody({
     }
   }, [data, documentId, scope, browse]);
 
+  // RFC BS — download the whole document as a `.canvas` (JSON) node/edge graph,
+  // mirroring the .md download above. The canvas shape is backend-owned; the
+  // viewer only serializes it.
+  const downloadCanvas = useCallback(async () => {
+    try {
+      const r = await data.documentExportCanvas(documentId, scope, browse);
+      const blob = new Blob([JSON.stringify(r.canvas, null, 2)], {
+        type: "application/json",
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = (rootTitle || "document").replace(/[^\w.-]+/g, "_") + ".canvas";
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    }
+  }, [data, documentId, scope, browse, rootTitle]);
+
   // RFC BO authoring — create a media chunk under the selected chunk (or the
   // root). The runtime marks type=image via set_asset; a diagram is a plain
   // type=mermaid chunk whose body is the source.
@@ -509,6 +532,13 @@ export default function DocumentViewerBody({
           <button type="button" onClick={() => void download()} title="Download the whole document as Markdown (.md)">
             ↓ .md
           </button>
+          <button
+            type="button"
+            onClick={() => void downloadCanvas()}
+            title="Download the whole document as a node/edge canvas graph (.canvas)"
+          >
+            ↓ .canvas
+          </button>
           {renderAssistant && (
             <button
               type="button"
@@ -553,6 +583,13 @@ export default function DocumentViewerBody({
                     <span className="chunk-badge chunk-status">{selectedDetail.status}</span>
                   )}
                   <span className="chunk-rev">rev {selectedDetail.revision}</span>
+                  {/* RFC BS — read-only tag chips (editing lives in ChunkEditorModal).
+                      Nested tags (area/sub) are shown verbatim. */}
+                  {selectedDetail.tags?.map((t) => (
+                    <span className="chunk-tag" key={t}>
+                      {t}
+                    </span>
+                  ))}
                 </div>
                 <div className="doc-content-controls">
                   {/* The chunk/markdown switch is per-selected-chunk: markdown
@@ -582,6 +619,14 @@ export default function DocumentViewerBody({
                   </div>
                   <button type="button" onClick={() => setEditing(selectedDetail)}>
                     edit
+                  </button>
+                  {/* RFC BS — read-only edit history (revisions + version view + diff). */}
+                  <button
+                    type="button"
+                    onClick={() => setHistoryOpen(true)}
+                    title="View this chunk's edit history + diffs"
+                  >
+                    history
                   </button>
                   {/* RFC BP — reorder within the level + delete (not for the root). */}
                   {!selectedIsRoot && (
@@ -661,6 +706,15 @@ export default function DocumentViewerBody({
                 selectedId={selectedId}
                 onSelectChunk={setSelectedId}
               />
+              {/* RFC BS — backlinks / related / unlinked mentions for the selected
+                  chunk, lazily fetched when its section is expanded. */}
+              <Connections
+                documentId={documentId}
+                selectedId={selectedId}
+                scope={scope}
+                browse={browse}
+                onSelectChunk={setSelectedId}
+              />
             </>
           ) : (
             <div className="empty">
@@ -688,6 +742,15 @@ export default function DocumentViewerBody({
           browse={browse}
           onClose={() => setEditing(null)}
           onSaved={refresh}
+        />
+      )}
+      {historyOpen && selectedDetail && (
+        <HistoryModal
+          chunkId={selectedDetail.id}
+          chunkTitle={selectedDetail.title}
+          scope={scope}
+          browse={browse}
+          onClose={() => setHistoryOpen(false)}
         />
       )}
       {colorsOpen && rootChunkId && (

--- a/packages/explorer/src/components/HistoryModal.tsx
+++ b/packages/explorer/src/components/HistoryModal.tsx
@@ -1,0 +1,229 @@
+import { useEffect, useState } from "react";
+import type { BrowseScope, ChunkRevision, DocScope } from "../types";
+import { useExplorerData } from "../lib/dataLayer";
+
+// HistoryModal is the RFC BS read-only edit-history surface for one chunk. It
+// lists the chunk's revisions (number + time + actor); clicking a revision shows
+// that version's body verbatim, and a from→to picker renders a unified diff
+// between any two. Restore is deliberately NOT here (this pass is read-only) —
+// mirroring ChunkEditorModal, which owns the write path.
+export interface HistoryModalProps {
+  chunkId: string;
+  chunkTitle?: string;
+  scope: DocScope;
+  // browse (RFC AS) — read the history under the browsed subject's document.
+  browse?: BrowseScope;
+  onClose: () => void;
+}
+
+// Which output pane is showing: a single version's body, or a two-revision diff.
+type OutputMode = "none" | "version" | "diff";
+
+// formatTs renders a revision timestamp. `created_at` is Unix NANOSECONDS (RFC BS
+// history), so divide by 1e6 for a JS Date; a stray string is tolerated via
+// Date.parse. Falls back to the raw value when it isn't a usable instant.
+function formatTs(createdAt: number): string {
+  const ms = typeof createdAt === "number" ? createdAt / 1e6 : Date.parse(String(createdAt));
+  if (!Number.isFinite(ms) || ms <= 0) return String(createdAt ?? "");
+  return new Date(ms).toLocaleString();
+}
+
+export default function HistoryModal({
+  chunkId,
+  chunkTitle,
+  scope,
+  browse,
+  onClose,
+}: HistoryModalProps) {
+  const data = useExplorerData();
+  const [revisions, setRevisions] = useState<ChunkRevision[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+
+  const [mode, setMode] = useState<OutputMode>("none");
+  const [selectedRev, setSelectedRev] = useState<number | null>(null);
+  const [body, setBody] = useState<string>("");
+  const [busy, setBusy] = useState(false); // a version/diff fetch is in flight
+
+  const [fromRev, setFromRev] = useState<number | null>(null);
+  const [toRev, setToRev] = useState<number | null>(null);
+  const [diff, setDiff] = useState<string>("");
+
+  // Load the revision list on open. Default the diff picker to the full span
+  // (oldest → newest) so a single "diff" click is meaningful without fiddling.
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setErr(null);
+    data
+      .documentHistory(chunkId, scope, browse)
+      .then((r) => {
+        if (cancelled) return;
+        const revs = r.revisions ?? [];
+        setRevisions(revs);
+        if (revs.length >= 2) {
+          const nums = revs.map((x) => x.revision);
+          setFromRev(Math.min(...nums));
+          setToRev(Math.max(...nums));
+        }
+      })
+      .catch((e) => !cancelled && setErr(e instanceof Error ? e.message : String(e)))
+      .finally(() => !cancelled && setLoading(false));
+    return () => {
+      cancelled = true;
+    };
+  }, [data, chunkId, scope, browse]);
+
+  const viewVersion = async (rev: number) => {
+    setErr(null);
+    setBusy(true);
+    setSelectedRev(rev);
+    setMode("version");
+    try {
+      const r = await data.documentGetVersion(chunkId, rev, scope, browse);
+      setBody(r.body ?? "");
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const runDiff = async () => {
+    if (fromRev === null || toRev === null) return;
+    setErr(null);
+    setBusy(true);
+    setMode("diff");
+    try {
+      const r = await data.documentDiff(chunkId, fromRev, toRev, scope, browse);
+      setDiff(r.diff ?? "");
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal history-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-header sticky-top">
+          <h3>History{chunkTitle ? ` — ${chunkTitle}` : ""}</h3>
+          <div className="modal-buttons modal-buttons-top">
+            <button type="button" onClick={onClose}>
+              close
+            </button>
+          </div>
+        </div>
+        {err && <div className="modal-err">{err}</div>}
+
+        {loading ? (
+          <p className="doc-empty-body">loading…</p>
+        ) : revisions.length === 0 ? (
+          <p className="doc-empty-body">No history recorded for this chunk.</p>
+        ) : (
+          <>
+            <div className="doc-hist-revs">
+              {revisions.map((rev) => (
+                <button
+                  key={rev.revision}
+                  type="button"
+                  className={
+                    "doc-hist-rev" +
+                    (mode === "version" && selectedRev === rev.revision ? " active" : "")
+                  }
+                  onClick={() => void viewVersion(rev.revision)}
+                >
+                  <span className="doc-hist-rev-num">rev {rev.revision}</span>
+                  <span className="doc-hist-rev-time">{formatTs(rev.created_at)}</span>
+                  <span className="doc-hist-rev-actor">{rev.actor || "unknown"}</span>
+                </button>
+              ))}
+            </div>
+
+            {revisions.length >= 2 && (
+              <div className="doc-hist-diffbar">
+                <span>Compare</span>
+                <select
+                  value={fromRev ?? ""}
+                  onChange={(e) => setFromRev(e.target.value === "" ? null : Number(e.target.value))}
+                  aria-label="diff from revision"
+                >
+                  {revisions.map((r) => (
+                    <option key={r.revision} value={r.revision}>
+                      rev {r.revision}
+                    </option>
+                  ))}
+                </select>
+                <span aria-hidden>→</span>
+                <select
+                  value={toRev ?? ""}
+                  onChange={(e) => setToRev(e.target.value === "" ? null : Number(e.target.value))}
+                  aria-label="diff to revision"
+                >
+                  {revisions.map((r) => (
+                    <option key={r.revision} value={r.revision}>
+                      rev {r.revision}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  onClick={() => void runDiff()}
+                  disabled={busy || fromRev === null || toRev === null}
+                >
+                  diff
+                </button>
+              </div>
+            )}
+
+            <div className="doc-hist-output">
+              {busy ? (
+                <p className="doc-empty-body">loading…</p>
+              ) : mode === "diff" ? (
+                <DiffView text={diff} />
+              ) : mode === "version" ? (
+                <pre className="md-pre doc-hist-version">
+                  <code>{body || "(empty)"}</code>
+                </pre>
+              ) : (
+                <p className="doc-empty-body">
+                  Select a revision to view it, or compare two.
+                </p>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// DiffView renders a unified diff, coloring added (+) / removed (-) / hunk (@@)
+// lines. `+++`/`---` file headers stay neutral so they don't read as content
+// changes. Line breaks come from the explicit "\n" text nodes inside the <pre>,
+// so spacing stays single (a per-line <div> would double it).
+function DiffView({ text }: { text: string }) {
+  if (!text.trim()) return <p className="doc-empty-body">(no differences)</p>;
+  const lines = text.split("\n");
+  return (
+    <pre className="md-pre doc-hist-diff">
+      {lines.map((ln, i) => {
+        const cls =
+          ln.startsWith("+") && !ln.startsWith("+++")
+            ? "diff-add"
+            : ln.startsWith("-") && !ln.startsWith("---")
+              ? "diff-del"
+              : ln.startsWith("@@")
+                ? "diff-hunk"
+                : "";
+        return (
+          <span key={i} className={cls}>
+            {ln}
+            {"\n"}
+          </span>
+        );
+      })}
+    </pre>
+  );
+}

--- a/packages/explorer/src/index.ts
+++ b/packages/explorer/src/index.ts
@@ -20,6 +20,11 @@ export type {
   ChunkRow,
   ChunkDetail,
   DocEdge,
+  Backlink,
+  RelatedChunk,
+  UnlinkedMention,
+  ChunkRevision,
+  CanvasDoc,
   Principal,
   AssistantContext,
 } from "./types";

--- a/packages/explorer/src/lib/dataLayer.test.ts
+++ b/packages/explorer/src/lib/dataLayer.test.ts
@@ -168,3 +168,76 @@ describe("tenant document scope reaches the wire", () => {
     expect(sent.scope).toBe("tenant");
   });
 });
+
+// RFC BS document-viewer ops: connections (backlinks / related / unlinked
+// mentions), per-chunk history (history / get_version / diff), and the canvas
+// export. Locks the op name + arg mapping + browse passthrough, same as the ops
+// above — these route through the `as unknown as DocumentToolInput` passthrough,
+// so the wire shape is what the assertion guards.
+describe("RFC BS connections / history / canvas ops → wire mapping", () => {
+  it("documentBacklinks sends the chunk id", async () => {
+    const s = stubClient();
+    await dataLayerFromClient(s.client).documentBacklinks("c1", "user", BROWSE);
+    expect(s.document).toHaveBeenCalledWith({ op: "backlinks", id: "c1", scope: "user" }, BROWSE);
+  });
+
+  it("documentRelated carries the limit when given", async () => {
+    const s = stubClient();
+    await dataLayerFromClient(s.client).documentRelated("c1", "user", BROWSE, 8);
+    expect(s.document).toHaveBeenCalledWith(
+      { op: "related", id: "c1", scope: "user", limit: 8 },
+      BROWSE,
+    );
+  });
+
+  it("documentRelated omits the limit when unset", async () => {
+    const s = stubClient();
+    await dataLayerFromClient(s.client).documentRelated("c1", "user");
+    expect(s.document).toHaveBeenCalledWith({ op: "related", id: "c1", scope: "user" }, undefined);
+  });
+
+  it("documentUnlinkedMentions carries id + limit", async () => {
+    const s = stubClient();
+    await dataLayerFromClient(s.client).documentUnlinkedMentions("c1", "tenant", BROWSE, 20);
+    expect(s.document).toHaveBeenCalledWith(
+      { op: "unlinked_mentions", id: "c1", scope: "tenant", limit: 20 },
+      BROWSE,
+    );
+  });
+
+  it("documentHistory carries id + limit", async () => {
+    const s = stubClient();
+    await dataLayerFromClient(s.client).documentHistory("c1", "user", BROWSE, 50);
+    expect(s.document).toHaveBeenCalledWith(
+      { op: "history", id: "c1", scope: "user", limit: 50 },
+      BROWSE,
+    );
+  });
+
+  it("documentGetVersion carries the revision", async () => {
+    const s = stubClient();
+    await dataLayerFromClient(s.client).documentGetVersion("c1", 3, "user", BROWSE);
+    expect(s.document).toHaveBeenCalledWith(
+      { op: "get_version", id: "c1", revision: 3, scope: "user" },
+      BROWSE,
+    );
+  });
+
+  it("documentDiff carries from_revision + to_revision", async () => {
+    const s = stubClient();
+    await dataLayerFromClient(s.client).documentDiff("c1", 2, 5, "user", BROWSE);
+    expect(s.document).toHaveBeenCalledWith(
+      { op: "diff", id: "c1", from_revision: 2, to_revision: 5, scope: "user" },
+      BROWSE,
+    );
+  });
+
+  it("documentExportCanvas carries the document_id", async () => {
+    const s = stubClient();
+    await dataLayerFromClient(s.client).documentExportCanvas("d1", "user", BROWSE);
+    expect(s.document).toHaveBeenCalledWith(
+      { op: "export_canvas", document_id: "d1", scope: "user" },
+      BROWSE,
+    );
+  });
+});

--- a/packages/explorer/src/lib/dataLayer.tsx
+++ b/packages/explorer/src/lib/dataLayer.tsx
@@ -1,13 +1,18 @@
 import { createContext, useContext, type ReactNode } from "react";
 import type { LoomcycleClient, DocumentToolInput } from "@loomcycle/client";
 import type {
+  Backlink,
   BrowseScope,
+  CanvasDoc,
   ChunkDetail,
+  ChunkRevision,
   ChunkRow,
   DocEdge,
   DocScope,
   PathEntry,
   PathScope,
+  RelatedChunk,
+  UnlinkedMention,
 } from "../types";
 import type { DocSummary, DocumentMeta } from "./colorScheme";
 import type { AssetFetch } from "./createClient";
@@ -160,6 +165,68 @@ export interface ExplorerDataLayer {
     includeMetadata: boolean,
     browse?: BrowseScope,
   ): Promise<{ markdown: string; title: string; document_id: string }>;
+  // documentBacklinks returns the chunks that link TO this chunk (RFC BS) — the
+  // "what links here" list, each enriched with the source's title/type/status +
+  // whether the edge was auto-derived from a [[name]] wikilink.
+  documentBacklinks(
+    id: string,
+    scope: DocScope,
+    browse?: BrowseScope,
+  ): Promise<{ backlinks: Backlink[] }>;
+  // documentRelated returns semantic neighbours of a chunk (RFC BS, vector
+  // similarity). It REFUSES when no embedder is configured — the caller catches
+  // the error and shows a "semantic search not configured" note. limit caps the
+  // result count (server default when omitted).
+  documentRelated(
+    id: string,
+    scope: DocScope,
+    browse?: BrowseScope,
+    limit?: number,
+  ): Promise<{ related: RelatedChunk[] }>;
+  // documentUnlinkedMentions returns chunks that mention this chunk's title but
+  // don't link to it (RFC BS) — candidate links. `truncated` flags an elided tail.
+  documentUnlinkedMentions(
+    id: string,
+    scope: DocScope,
+    browse?: BrowseScope,
+    limit?: number,
+  ): Promise<{ unlinked_mentions: UnlinkedMention[]; truncated: boolean }>;
+  // documentHistory returns a chunk's edit history (RFC BS) — revision numbers +
+  // timestamps + actors, newest-relevant first as the server orders them.
+  documentHistory(
+    id: string,
+    scope: DocScope,
+    browse?: BrowseScope,
+    limit?: number,
+  ): Promise<{ chunk_id: string; revisions: ChunkRevision[] }>;
+  // documentGetVersion returns one historical revision's body verbatim (RFC BS).
+  documentGetVersion(
+    id: string,
+    revision: number,
+    scope: DocScope,
+    browse?: BrowseScope,
+  ): Promise<{ chunk_id: string; revision: number; body: string }>;
+  // documentDiff returns a unified-diff text between two revisions of a chunk
+  // (RFC BS) — from_revision → to_revision.
+  documentDiff(
+    id: string,
+    fromRevision: number,
+    toRevision: number,
+    scope: DocScope,
+    browse?: BrowseScope,
+  ): Promise<{
+    chunk_id: string;
+    from_revision: number;
+    to_revision: number;
+    diff: string;
+  }>;
+  // documentExportCanvas returns the whole document as a node/edge canvas graph
+  // (RFC BS), downloaded as a `.canvas` (JSON) file by the viewer.
+  documentExportCanvas(
+    documentId: string,
+    scope: DocScope,
+    browse?: BrowseScope,
+  ): Promise<{ canvas: CanvasDoc; document_id: string }>;
 }
 
 // dataLayerFromClient maps a @loomcycle/client instance onto the
@@ -291,6 +358,72 @@ export function dataLayerFromClient(client: LoomcycleClient, assetFetch?: AssetF
         } as unknown as DocumentToolInput,
         browse,
       ) as Promise<{ markdown: string; title: string; document_id: string }>,
+    // RFC BS document-connections + history + canvas ops. Same `as unknown as
+    // DocumentToolInput` passthrough as documentGetEdges — new wire ops the pinned
+    // SDK type doesn't enumerate; the /v1/_document passthrough accepts them
+    // verbatim (adapters/ts is fixed at source, so the casts come out on the next
+    // client publish).
+    documentBacklinks: (id, scope, browse) =>
+      client.document(
+        { op: "backlinks", id, scope } as unknown as DocumentToolInput,
+        browse,
+      ) as Promise<{ backlinks: Backlink[] }>,
+    documentRelated: (id, scope, browse, limit) =>
+      client.document(
+        {
+          op: "related",
+          id,
+          scope,
+          ...(limit ? { limit } : {}),
+        } as unknown as DocumentToolInput,
+        browse,
+      ) as Promise<{ related: RelatedChunk[] }>,
+    documentUnlinkedMentions: (id, scope, browse, limit) =>
+      client.document(
+        {
+          op: "unlinked_mentions",
+          id,
+          scope,
+          ...(limit ? { limit } : {}),
+        } as unknown as DocumentToolInput,
+        browse,
+      ) as Promise<{ unlinked_mentions: UnlinkedMention[]; truncated: boolean }>,
+    documentHistory: (id, scope, browse, limit) =>
+      client.document(
+        {
+          op: "history",
+          id,
+          scope,
+          ...(limit ? { limit } : {}),
+        } as unknown as DocumentToolInput,
+        browse,
+      ) as Promise<{ chunk_id: string; revisions: ChunkRevision[] }>,
+    documentGetVersion: (id, revision, scope, browse) =>
+      client.document(
+        { op: "get_version", id, revision, scope } as unknown as DocumentToolInput,
+        browse,
+      ) as Promise<{ chunk_id: string; revision: number; body: string }>,
+    documentDiff: (id, fromRevision, toRevision, scope, browse) =>
+      client.document(
+        {
+          op: "diff",
+          id,
+          from_revision: fromRevision,
+          to_revision: toRevision,
+          scope,
+        } as unknown as DocumentToolInput,
+        browse,
+      ) as Promise<{
+        chunk_id: string;
+        from_revision: number;
+        to_revision: number;
+        diff: string;
+      }>,
+    documentExportCanvas: (documentId, scope, browse) =>
+      client.document(
+        { op: "export_canvas", document_id: documentId, scope } as unknown as DocumentToolInput,
+        browse,
+      ) as Promise<{ canvas: CanvasDoc; document_id: string }>,
     // Present only when an AssetFetch was supplied (the connection path); a bare
     // client can't do the raw binary GET, so the op is omitted and the viewer
     // shows a placeholder.

--- a/packages/explorer/src/styles.css
+++ b/packages/explorer/src/styles.css
@@ -1033,6 +1033,177 @@
 }
 
 /* ============================================================
+   RFC BS — tag chips, connections panel, chunk history modal
+   ============================================================ */
+/* Read-only tag chips in the selected-chunk meta row (edit lives in the chunk
+   editor). Accent-tinted to distinguish them from the type/status badges. */
+.loomcycle-explorer .chunk-tag {
+  font-size: var(--lc-text-xs);
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  color: var(--accent);
+}
+
+/* Connections panel (backlinks / related / unlinked mentions) — sits under the
+   References panel, sharing the .doc-ref-* row/target styles for the endpoints. */
+.loomcycle-explorer .doc-conn {
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+}
+.loomcycle-explorer .doc-conn-toggle {
+  background: none;
+  border: none;
+  color: var(--fg-soft);
+  cursor: pointer;
+  padding: 2px 0;
+  font: inherit;
+  font-size: var(--lc-text-sm);
+}
+.loomcycle-explorer .doc-conn-toggle:hover {
+  color: var(--accent);
+}
+.loomcycle-explorer .doc-conn-body {
+  margin-top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.loomcycle-explorer .doc-conn-group h5 {
+  margin: 0 0 4px 0;
+  font-size: var(--lc-text-xs);
+  color: var(--fg-soft);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.loomcycle-explorer .doc-conn-empty {
+  color: var(--fg-soft);
+  font-size: var(--lc-text-sm);
+  margin: 0;
+}
+.loomcycle-explorer .doc-conn-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.loomcycle-explorer .doc-conn-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--lc-text-sm);
+}
+.loomcycle-explorer .doc-conn-score {
+  font-family: var(--mono);
+  font-size: var(--lc-text-xs);
+  color: var(--fg-muted);
+}
+.loomcycle-explorer .doc-conn-auto {
+  font-size: var(--lc-text-xs);
+  color: var(--fg-soft);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 0 4px;
+}
+.loomcycle-explorer .doc-conn-more {
+  list-style: none;
+  color: var(--fg-muted);
+  font-size: var(--lc-text-xs);
+  font-style: italic;
+}
+
+/* Chunk history modal — revisions list + version/diff output. */
+.loomcycle-explorer .modal.history-modal {
+  max-width: 720px;
+  width: 92vw;
+}
+.loomcycle-explorer .doc-hist-revs {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 220px;
+  overflow: auto;
+  margin-bottom: 12px;
+}
+.loomcycle-explorer .doc-hist-rev {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  text-align: left;
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 5px 8px;
+  cursor: pointer;
+  color: var(--fg);
+}
+.loomcycle-explorer .doc-hist-rev:hover {
+  border-color: var(--accent);
+}
+.loomcycle-explorer .doc-hist-rev.active {
+  border-color: var(--accent);
+  background: var(--bg);
+}
+.loomcycle-explorer .doc-hist-rev-num {
+  font-family: var(--mono);
+  font-size: var(--lc-text-xs);
+  color: var(--accent);
+}
+.loomcycle-explorer .doc-hist-rev-time {
+  font-size: var(--lc-text-xs);
+  color: var(--fg-soft);
+}
+.loomcycle-explorer .doc-hist-rev-actor {
+  font-size: var(--lc-text-xs);
+  color: var(--fg-muted);
+  margin-left: auto;
+}
+.loomcycle-explorer .doc-hist-diffbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: var(--lc-text-sm);
+  color: var(--fg-soft);
+  margin-bottom: 12px;
+}
+.loomcycle-explorer .doc-hist-diffbar button {
+  padding: 4px 12px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--fg);
+  border-radius: 4px;
+  cursor: pointer;
+}
+.loomcycle-explorer .doc-hist-diffbar button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.loomcycle-explorer .doc-hist-output {
+  max-height: 40vh;
+  overflow: auto;
+}
+.loomcycle-explorer .doc-hist-version,
+.loomcycle-explorer .doc-hist-diff {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.loomcycle-explorer .doc-hist-diff .diff-add {
+  color: var(--accent);
+}
+.loomcycle-explorer .doc-hist-diff .diff-del {
+  color: var(--failed);
+}
+.loomcycle-explorer .doc-hist-diff .diff-hunk {
+  color: var(--fg-muted);
+}
+
+/* ============================================================
    RFC BO — image & diagram chunks
    ============================================================ */
 .loomcycle-explorer .chunk-type-icon {

--- a/packages/explorer/src/types.ts
+++ b/packages/explorer/src/types.ts
@@ -85,6 +85,62 @@ export interface DocEdge {
   to_document_id?: string;
 }
 
+// Backlink is one incoming link to the selected chunk, from `backlinks` (RFC BS):
+// the linking (source) chunk enriched with its title/type/status/document_id, the
+// edge `kind`, and `auto` — true when the link came from a `[[name]]` wikilink in
+// the source body (vs a manually-authored edge). from_document_id ≠ the current
+// document marks a cross-document backlink (labeled, not navigable in this
+// single-document viewer). Endpoint fields are omitted when empty.
+export interface Backlink {
+  from_id: string;
+  kind: string;
+  auto: boolean;
+  from_title?: string;
+  from_type?: string;
+  from_status?: string;
+  from_document_id?: string;
+}
+
+// RelatedChunk is one semantic-neighbour of the selected chunk, from `related`
+// (RFC BS) — a vector-similarity match. `score` is the similarity (higher = closer).
+// The `related` op REFUSES when the deployment has no embedder configured; the
+// viewer surfaces that as a muted note rather than an error.
+export interface RelatedChunk {
+  chunk_id: string;
+  score: number;
+  title?: string;
+  type?: string;
+  document_id?: string;
+}
+
+// UnlinkedMention is a chunk whose body mentions the selected chunk's title but
+// carries no explicit link to it, from `unlinked_mentions` (RFC BS) — a candidate
+// link the author might want to formalize. The list is capped; the response's
+// `truncated` flag (not on the row) signals more were elided.
+export interface UnlinkedMention {
+  chunk_id: string;
+  title?: string;
+  document_id?: string;
+}
+
+// ChunkRevision is one entry in a chunk's edit history, from `history` (RFC BS):
+// the monotonic `revision` number, `created_at` (Unix nanoseconds — divide by 1e6
+// for a JS Date), and the `actor` who wrote it. Fetch a revision's body with
+// documentGetVersion, or a unified diff between two with documentDiff.
+export interface ChunkRevision {
+  revision: number;
+  created_at: number;
+  actor: string;
+}
+
+// CanvasDoc is the whole-document node/edge graph from `export_canvas` (RFC BS),
+// downloadable as a `.canvas` (JSON) file. The node/edge shapes are backend-owned
+// and opaque to the viewer (it only serializes them), so they stay `unknown[]`.
+export interface CanvasDoc {
+  nodes: unknown[];
+  edges: unknown[];
+}
+
 // Principal is the authenticated identity behind the session (resolved by the
 // host, e.g. via GET /v1/_me). The explorer only reads `subject` — it is passed
 // into the renderAssistant slot's context so a host-provided Document Assistant


### PR DESCRIPTION
The shared **`@loomcycle/explorer` document viewer** (used by loomcycle, and the shared surface loomboard will build on) now exposes the RFC BS primitives — as **minimal viewer elements only**. The kanban / board / table / spatial-canvas views are deliberately **out of scope** (a separate loomboard concern, the loomcycle team's).

## Four viewer elements
- **Tags** — read-only tag chips on the selected chunk (P1; editing already lives in the chunk editor).
- **Connections** — a collapsible per-chunk panel with three lazily-fetched lists:
  - **Backlinks** ("what links here", with an `auto`=`[[name]]` marker vs a manual link),
  - **Related** (semantic neighbours — a missing embedder shows a muted "semantic search not configured" note, never an error),
  - **Unlinked mentions** (with a `(more…)` hint when truncated).
  The three reads run under `Promise.allSettled` so one failure never blanks the others; same-document targets navigate, cross-document ones are labeled `↗` (P2a / P3a / P3b).
- **History** — a read-only modal: the chunk's revision list (rev / time / actor), view a revision's body (`get_version`), and a unified `diff` of two revisions with `+`/`-` line coloring (P3a).
- **Download .canvas** — a toolbar button beside "Download .md", exporting the document as JSON Canvas (P4).

## Plumbing
7 `ExplorerDataLayer` methods (`documentBacklinks`/`Related`/`UnlinkedMentions`/`History`/`GetVersion`/`Diff`/`ExportCanvas`) mirroring `documentGetEdges`' passthrough, their result types, and the `@loomcycle/client` `DocumentToolInput` op-union synced to the RFC BS ops (type-completeness; the passthrough already carried them).

## Tested
`packages/explorer` `tsc --noEmit` clean + `vitest` (21, incl. **8 new** dataLayer wire-mapping tests); `adapters/ts` `tsc` clean; **`make build-ui` builds the SPA clean** (the real integration check — it compiles the web app that consumes explorer from source). `internal/webui/dist` is gitignored. No backend, no `web/src`, no board views touched.

Completes the loomcycle-side viewer surface for RFC BS; loomboard consumes the same viewer + the primitives for its richer views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD