### PR TITLE
docs(release): credit the explorer viewer work in the v1.46.0 notes

### DIFF
--- a/REVISIONS.md
+++ b/REVISIONS.md
@@ -44,7 +44,9 @@ POST /v1/_document/describe_images?scope=user&scope_id=<subject>&dry_run=false
 
 Both are resumable with no cursor: an embedded row or a described image drops out of its candidate set, so re-invoke until `candidates` reaches 0. Every chunk write now makes an embedder call — best-effort, so a cold or absent embedder logs and moves on rather than failing an author's write. Expect per-scope vector growth roughly equal to the chunk count, which brings the existing per-scope quota closer.
 
-Adapters: `@loomcycle/client` **1.46.0**, `loomcycle` (PyPI) **1.46.0** — the Python adapter had been pinned at 1.38.0, so this release publishes its erasure and directory methods. `@loomcycle/explorer` **0.6.0** (tag editing in the chunk editor).
+**The shared document viewer surfaces all of it.** `@loomcycle/explorer` gains read-only tag chips, a **Connections** panel with three lazily-fetched lists (backlinks — marking which edges came from `[[name]]` parsing — plus related and unlinked mentions, the three reads under `Promise.allSettled` so one failure never blanks the others, and a missing embedder showing a muted "not configured" note rather than an error), a **History** modal with the revision list, one revision's exact body and a unified diff, and a **Download .canvas** button beside Download .md. Board, kanban and spatial views stay a loomboard concern.
+
+Adapters: `@loomcycle/client` **1.46.0**, `loomcycle` (PyPI) **1.46.0** — the Python adapter had been pinned at 1.38.0, so this release publishes its erasure and directory methods — and `@loomcycle/explorer` **0.6.0**.
 
 ## What's in v1.45.0
 


### PR DESCRIPTION
Small accuracy fix to the v1.46.0 notes.

#943 (`feat(explorer): surface the RFC BS primitives in the document viewer`) merged *between* the commit log I gathered for the release notes and the release commit itself, so `REVISIONS.md` described `@loomcycle/explorer` 0.6.0 as only *"tag editing in the chunk editor"*. It is 983 lines and the most user-visible part of the release:

- **Connections** panel — backlinks (marking which edges came from `[[name]]` parsing), related, and unlinked mentions; the three reads run under `Promise.allSettled` so one failure never blanks the others, and a missing embedder shows a muted "not configured" note rather than an error
- **History** modal — the revision list, one revision's exact body, and a unified diff
- **Download .canvas** beside Download .md

The annotated `v1.46.0` tag and therefore the [GitHub release body](https://github.com/denn-gubsky/loomcycle/releases/tag/v1.46.0) already describe it correctly — this only brings `REVISIONS.md` into line so the permanent record matches. Docs only; no code, no version change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8