### PR TITLE
fix(memory,document): both v1.46.0 upgrade sweeps were broken in practice

### DIFF
--- a/REVISIONS.md
+++ b/REVISIONS.md
@@ -44,7 +44,9 @@ POST /v1/_document/describe_images?scope=user&scope_id=<subject>&dry_run=false
 
 Both are resumable with no cursor: an embedded row or a described image drops out of its candidate set, so re-invoke until `candidates` reaches 0. Every chunk write now makes an embedder call — best-effort, so a cold or absent embedder logs and moves on rather than failing an author's write. Expect per-scope vector growth roughly equal to the chunk count, which brings the existing per-scope quota closer.
 
-Adapters: `@loomcycle/client` **1.46.0**, `loomcycle` (PyPI) **1.46.0** — the Python adapter had been pinned at 1.38.0, so this release publishes its erasure and directory methods. `@loomcycle/explorer` **0.6.0** (tag editing in the chunk editor).
+**The shared document viewer surfaces all of it.** `@loomcycle/explorer` gains read-only tag chips, a **Connections** panel with three lazily-fetched lists (backlinks — marking which edges came from `[[name]]` parsing — plus related and unlinked mentions, the three reads under `Promise.allSettled` so one failure never blanks the others, and a missing embedder showing a muted "not configured" note rather than an error), a **History** modal with the revision list, one revision's exact body and a unified diff, and a **Download .canvas** button beside Download .md. Board, kanban and spatial views stay a loomboard concern.
+
+Adapters: `@loomcycle/client` **1.46.0**, `loomcycle` (PyPI) **1.46.0** — the Python adapter had been pinned at 1.38.0, so this release publishes its erasure and directory methods — and `@loomcycle/explorer` **0.6.0**.
 
 ## What's in v1.45.0
 

--- a/REVISIONS.md
+++ b/REVISIONS.md
@@ -4,6 +4,29 @@ Per-version release notes from v0.4.0 onward. The current and immediately previo
 
 For the **public roadmap** (planned v0.8.16 through v1.0 work — Question tool, Pause / Resume / Snapshot, distribution, operator postures), see [`docs/PLAN.md`](docs/PLAN.md).
 
+## What's in v1.46.1
+
+**🩹 Both v1.46.0 upgrade sweeps were broken in practice.** Patch release — no new surface, no schema change. Found by running the sweeps against a real deployment (154 documents, 3,143 chunks, 2 images); neither fault was visible from the unit tests, because each needs scale or a real model to appear.
+
+**The embedding backfill starved instead of finishing.** Throughput decayed 189 / 179 / 169 / 160 / 147 embedded per 200-row window, heading for zero with ~2,300 rows still unembedded. `limit` bounded how many rows were *looked at*, not how many were embedded — and a row with no body text (a document root, a section heading) can never gain an embedding, so it stays a candidate forever. Because the query is `ORDER BY key`, those rows accumulate at the *front* of the window: the residue obeys `R' = R + p·(limit − R)`, whose fixed point is `R = limit`. Eventually the window is entirely rows that cannot be embedded and the sweep does nothing, while its own notes promise "re-invoke until candidates reaches 0" — a state it can never reach. `MemoryEmbedListMissing` now takes a keyset cursor and the handler pages with it until it has *embedded* `limit` rows, reporting `skipped_empty` and `more`.
+
+Widening the window did not help either: the store reset a limit over 1000 back to the 200 default, so asking for 5000 returned a **smaller** page than asking for 1000. That is now a clamp.
+
+**The describe pass truncated before it said anything.** The image sweep reported 0 failures and both images as answered-empty. The model was fine — asked directly, `qwen3.6` describes the image in 198 characters. The token ceiling was 300, and a thinking model emits its reasoning trace *first*: 1281 characters of it, `done_reason=length`, and no description at all. 300 looked ample because the same prompt answers in 84 tokens with thinking off.
+
+Worse than a failed call: the pass recorded it as answered-empty and stamped `described_at`, whose whole purpose is to separate "a model looked and found nothing" from "nothing has looked yet" — so a code bug became a permanent fact about the data that no re-run would revisit. A turn that stopped at the ceiling is now a **failure**, left retryable, with the reason named. The ceiling is 1500, and it is a ceiling rather than a target, so a generous value costs nothing on a normal call. Deliberately *not* fixed by forcing `effort: low` (which the Ollama driver maps to `think:false`): that flag errors on a model which cannot reason, so it would break a non-thinking vision model such as llava to accommodate a thinking one.
+
+**Also:** an admin token that names no tenant on the backfill is refused with `400 tenant_required`, mirroring the erasure, directory and orphan-repair surfaces. Memory rows are keyed on the tenant, so omitting it resolved to the *default* tenant and reported a truthful-looking `candidates: 0` against a tenant the operator never meant — demonstrated on a three-tenant deployment, where the same request with and without `?tenant=` returned 200 candidates and 0.
+
+**Upgrade note.** If you already ran the v1.46.0 sweeps, re-run the backfill — it will now finish rather than stall. Images stamped by the buggy describe pass need clearing to become candidates again:
+
+```sql
+UPDATE chunk_assets SET described_at = NULL
+ WHERE described_at IS NOT NULL AND coalesce(description,'') = '';
+```
+
+Adapters unchanged from v1.46.0: `@loomcycle/client` 1.46.0, `loomcycle` (PyPI) 1.46.0, `@loomcycle/explorer` 0.6.0.
+
 ## What's in v1.46.0
 
 **📄 Documents became a searchable, linked knowledge store.** Two RFCs completed end to end — **RFC BS** (structure primitives: tags, links, transclusion, history, discovery, canvas) and **RFC BU** (searchable bodies: embed-on-write per chunk type, backfill, diagram and image handling) — plus a **directory** surface on every transport. No schema migration on the main store; the document scopes self-provision their own tables.

--- a/internal/api/http/document_describe.go
+++ b/internal/api/http/document_describe.go
@@ -45,10 +45,21 @@ import (
 // and a local model at middle keeps the pass free.
 const describeImagesDefaultTier = "middle"
 
-// describeMaxTokens bounds the description. A search index wants a couple of
-// sentences; an essay dilutes the embedding, because a vector is an average and
-// every extra clause pulls it toward the generic.
-const describeMaxTokens = 300
+// describeMaxTokens bounds the description.
+//
+// It is a CEILING, not a target: a model stops when it has answered, so a generous
+// value costs nothing on a normal call. It is generous because of a failure measured
+// on the reference deployment — a thinking-capable vision model (qwen3.6) emits its
+// reasoning trace FIRST, and at 300 tokens the trace consumed the entire budget:
+// done_reason=length, eval_count=300, and ZERO characters of description. With
+// thinking off the same request answers in 84 tokens, so 300 looked ample and was
+// not.
+//
+// A budget rather than forcing `effort: low` (which the Ollama driver maps to
+// think:false) DELIBERATELY: that flag errors on a model which cannot reason, so
+// forcing it would break a non-thinking vision model such as llava to accommodate a
+// thinking one. A ceiling is model-agnostic.
+const describeMaxTokens = 1500
 
 // describeCallTimeout bounds ONE vision call, not the sweep. A cold local vision
 // model can take tens of seconds on its first request, so it is generous. The
@@ -340,12 +351,17 @@ func (s *Server) describeOneImage(ctx context.Context, providerID string, prov p
 	}
 	var b strings.Builder
 	var callErr error
+	stopReason := ""
 	// Drain to completion even after an error: abandoning the channel leaves the
 	// driver's goroutine blocked on a send.
 	for ev := range ch {
 		switch ev.Type {
 		case providers.EventText:
 			b.WriteString(ev.Text)
+		case providers.EventDone:
+			if ev.StopReason != "" {
+				stopReason = ev.StopReason
+			}
 		case providers.EventError:
 			if callErr == nil {
 				callErr = errors.New(ev.Error)
@@ -355,5 +371,19 @@ func (s *Server) describeOneImage(ctx context.Context, providerID string, prov p
 	if callErr != nil {
 		return "", callErr
 	}
-	return strings.TrimSpace(b.String()), nil
+	out := strings.TrimSpace(b.String())
+	// EMPTY BECAUSE TRUNCATED IS A FAILURE, NOT AN EMPTY ANSWER, and the distinction
+	// decides whether the image is ever looked at again: an empty answer is stamped
+	// examined and never retried. A run that hit the token ceiling produced nothing
+	// because it ran out of room — on a thinking model the reasoning trace comes
+	// first and can consume the whole budget — which is a configuration problem the
+	// operator can fix, so it must stay retryable. Recording it as "the model had
+	// nothing to say" is how a code bug becomes a permanent fact about the data.
+	if out == "" && stopReason == "max_tokens" {
+		return "", fmt.Errorf("the model hit the %d-token ceiling before producing any "+
+			"description (on a thinking model the reasoning trace is emitted first and can "+
+			"consume the whole budget); not marked examined, so it will be retried",
+			describeMaxTokens)
+	}
+	return out, nil
 }

--- a/internal/api/http/document_describe_test.go
+++ b/internal/api/http/document_describe_test.go
@@ -30,6 +30,9 @@ type visionProvider struct {
 	reply   string
 	canSee  bool
 	failErr string
+	// stopReason overrides the terminal EventDone reason, so a test can reproduce a
+	// turn that ran out of token budget before saying anything.
+	stopReason string
 }
 
 func (v *visionProvider) ID() string                    { return "vis" }
@@ -50,7 +53,11 @@ func (v *visionProvider) Call(_ context.Context, req providers.Request) (<-chan 
 	} else {
 		ch <- providers.Event{Type: providers.EventText, Text: v.reply}
 	}
-	ch <- providers.Event{Type: providers.EventDone, StopReason: "end_turn"}
+	stop := v.stopReason
+	if stop == "" {
+		stop = "end_turn"
+	}
+	ch <- providers.Event{Type: providers.EventDone, StopReason: stop}
 	close(ch)
 	return ch, nil
 }
@@ -355,4 +362,53 @@ func (r *recordingHTTPEmbedder) seen() []string {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return append([]string(nil), r.texts...)
+}
+
+// TestDescribeImages_TruncatedAnswerIsRetryableNotEmpty is the regression test for a
+// bug found by running the pass against a live deployment.
+//
+// describeMaxTokens was 300 and qwen3.6 is a thinking model: it emits its reasoning
+// trace FIRST, which consumed the entire budget (done_reason=length, eval_count=300)
+// and produced ZERO characters of description. The pass recorded that as an
+// answered-empty image and stamped described_at — so a CODE bug became a permanent
+// fact about the data, and no re-run would ever revisit it.
+//
+// An empty answer that stopped at the ceiling is a configuration problem the operator
+// can fix, so it must be reported as a FAILURE and left retryable.
+func TestDescribeImages_TruncatedAnswerIsRetryableNotEmpty(t *testing.T) {
+	prov := &visionProvider{reply: "", canSee: true, stopReason: "max_tokens"}
+	srv, _, _, _ := describeFixture(t, prov)
+
+	_, out := postDescribe(t, srv, "&dry_run=false")
+	if n, _ := out["empty"].(float64); n != 0 {
+		t.Errorf("empty = %v, want 0 — a truncated turn is not an answered-empty image, "+
+			"and marking it examined retires it forever", out["empty"])
+	}
+	if n, _ := out["failed"].(float64); n != 1 {
+		t.Fatalf("failed = %v, want 1: %v", out["failed"], out)
+	}
+	if ff, _ := out["first_failure"].(string); !strings.Contains(ff, "ceiling") {
+		t.Errorf("first_failure should explain the token ceiling, got %q", ff)
+	}
+	// Still a candidate: the next pass retries it.
+	prov.stopReason, prov.reply = "", "a described image"
+	_, out2 := postDescribe(t, srv, "&dry_run=false")
+	if n, _ := out2["candidates"].(float64); n != 1 {
+		t.Fatalf("a TRUNCATED image was retired from the candidate set (candidates=%v)",
+			out2["candidates"])
+	}
+	if n, _ := out2["described"].(float64); n != 1 {
+		t.Errorf("the retry did not describe it: %v", out2)
+	}
+}
+
+// TestDescribeImages_BudgetLeavesRoomForAThinkingTrace pins the ceiling itself. A
+// thinking model's trace measured ~1281 characters (~320 tokens) BEFORE any content,
+// so a budget near that is the bug this constant exists to avoid.
+func TestDescribeImages_BudgetLeavesRoomForAThinkingTrace(t *testing.T) {
+	if describeMaxTokens < 1000 {
+		t.Errorf("describeMaxTokens = %d — a thinking model emits its reasoning trace "+
+			"first (~320 tokens measured) and will consume the whole budget before "+
+			"producing any description", describeMaxTokens)
+	}
 }

--- a/internal/api/http/memory_backfill.go
+++ b/internal/api/http/memory_backfill.go
@@ -38,6 +38,17 @@ type memoryBackfillResponse struct {
 	// Embedded / Failed describe a live run.
 	Embedded int `json:"embedded,omitempty"`
 	Failed   int `json:"failed,omitempty"`
+	// SkippedEmpty counts rows with NO text to embed — a document root or a
+	// section heading legitimately has an empty body. They are neither embedded
+	// nor failed, and they PERMANENTLY remain candidates, which is why they have
+	// to be reported: without this the operator sees `candidates` stop falling
+	// with `embedded` at 0 and no stated reason.
+	SkippedEmpty int `json:"skipped_empty,omitempty"`
+	// More reports that the caller's limit was reached with candidates still
+	// outstanding, so another call has work to do. It is the honest replacement for
+	// "re-invoke until candidates reaches 0", which unembeddable rows make
+	// unreachable.
+	More bool `json:"more,omitempty"`
 	// FailedKeys is capped — a systematic failure (embedder down) would otherwise
 	// return one line per row.
 	FailedKeys []string `json:"failed_keys,omitempty"`
@@ -92,10 +103,22 @@ func (s *Server) handleMemoryBackfillEmbeddings(w http.ResponseWriter, r *http.R
 		}
 	}
 	prefix := r.URL.Query().Get("prefix")
-	tenant, _ := s.principalTenantScope(r.Context(), r.URL.Query().Get("tenant"))
+	tenant, all := s.principalTenantScope(r.Context(), r.URL.Query().Get("tenant"))
+	// Same refusal as the erasure, directory and orphan-repair surfaces, for the same
+	// reason: an admin naming no tenant resolves to the DEFAULT tenant, and memory
+	// rows are keyed on the raw tenant — so the sweep would report a truthful-looking
+	// "candidates: 0" against a tenant the operator never meant and leave the intended
+	// one untouched. Verified live on a three-tenant deployment.
+	if all && !r.URL.Query().Has("tenant") {
+		writeJSONError(w, http.StatusBadRequest, "tenant_required",
+			"an admin token must name the tenant: memory rows are keyed on it, so omitting "+
+				"it silently targets the default tenant and reports 0 candidates. "+
+				"Pass ?tenant=<id>, or ?tenant= for the default tenant.")
+		return
+	}
 
 	rows, err := s.store.MemoryEmbedListMissing(r.Context(), tenant,
-		store.MemoryScope(scope), scopeID, prefix, limit)
+		store.MemoryScope(scope), scopeID, prefix, "", limit)
 	if err != nil {
 		// ErrVectorUnsupported / the vec-tier pending error are the honest answers
 		// on a tier without this capability — surface them rather than reporting
@@ -114,9 +137,14 @@ func (s *Server) handleMemoryBackfillEmbeddings(w http.ResponseWriter, r *http.R
 		},
 	}
 	resp.Notes = []string{
-		"candidates is bounded by limit — a non-zero count after a live run means " +
-			"MORE remain; re-invoke until it reaches 0. Every embedded row leaves the " +
-			"candidate set, so re-invoking is safe and resumes rather than restarts.",
+		"candidates is bounded by limit — a non-zero count after a live run means MORE " +
+			"remain. Every embedded row leaves the candidate set, so re-invoking is safe " +
+			"and resumes rather than restarts.",
+		"RE-INVOKE WHILE `more` IS TRUE. Do not wait for candidates to reach 0: a row " +
+			"with no text to embed (a document root, a section heading) never gains an " +
+			"embedding, so it stays a candidate permanently and candidates converges to " +
+			"skipped_empty instead. `limit` bounds how many rows are EMBEDDED, not how " +
+			"many are examined — the sweep pages past what it cannot embed.",
 	}
 
 	if dryRun {
@@ -131,20 +159,19 @@ func (s *Server) handleMemoryBackfillEmbeddings(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	for _, row := range rows {
-		// Embed the row's VALUE text. A document chunk body is a JSON envelope, so
-		// embedText unwraps it — embedding the raw JSON would index the field names.
-		text := embedTextForRow(row)
-		if text == "" {
-			continue
-		}
-		vecs, err := s.embedder.Embed(r.Context(), []string{text})
-		if err != nil || len(vecs) == 0 {
+	// embedOne does the per-row work. A closure so the paging loop below stays about
+	// paging.
+	embedOne := func(row store.MemoryEntry, text string) {
+		markFailed := func() {
 			resp.Failed++
 			if len(resp.FailedKeys) < backfillFailedKeyCap {
 				resp.FailedKeys = append(resp.FailedKeys, row.Key)
 			}
-			continue
+		}
+		vecs, err := s.embedder.Embed(r.Context(), []string{text})
+		if err != nil || len(vecs) == 0 {
+			markFailed()
+			return
 		}
 		if err := s.store.MemoryEmbedSet(r.Context(), tenant, store.MemoryScope(scope), scopeID, row.Key,
 			store.MemoryEmbedding{
@@ -155,18 +182,73 @@ func (s *Server) handleMemoryBackfillEmbeddings(w http.ResponseWriter, r *http.R
 				EmbedText: text,
 				CreatedAt: time.Now().UTC(),
 			}); err != nil {
-			resp.Failed++
-			if len(resp.FailedKeys) < backfillFailedKeyCap {
-				resp.FailedKeys = append(resp.FailedKeys, row.Key)
-			}
-			continue
+			markFailed()
+			return
 		}
 		resp.Embedded++
 	}
+
+	// PAGE PAST WHAT WE CANNOT EMBED. `limit` bounds how many rows get EMBEDDED, not
+	// how many are looked at, and that difference is what makes the sweep finish.
+	//
+	// A row with no body text never gains an embedding, so it stays a candidate
+	// forever. With a single fixed window those rows accumulate at the front of the
+	// key order until they fill it, and throughput reaches ZERO with work still
+	// outstanding — the residue obeys R' = R + p·(limit − R), whose fixed point is
+	// R = limit. Measured live on a 3,143-chunk scope before this loop existed:
+	// 189 / 179 / 169 / 160 / 147 embedded per 200-row window, heading for 0. The
+	// keyset cursor steps over them.
+	page := rows
+	lastKey := ""
+	for {
+		for _, row := range page {
+			// Advance the cursor for EVERY row seen, embedded or not — that is the
+			// whole point.
+			lastKey = row.Key
+			// A document chunk body is a JSON envelope, so embedTextForRow unwraps it;
+			// embedding the raw JSON would index the field names.
+			text := embedTextForRow(row)
+			if text == "" {
+				// Nothing to embed, ever. Counted rather than silently passed over.
+				resp.SkippedEmpty++
+				continue
+			}
+			embedOne(row, text)
+			if resp.Embedded+resp.Failed >= limit {
+				break
+			}
+		}
+		if resp.Embedded+resp.Failed >= limit {
+			// Hit the caller's budget. There may be more, so say so.
+			resp.More = true
+			break
+		}
+		if len(page) < limit {
+			// A short page means the candidate set is exhausted — nothing to step to.
+			break
+		}
+		var perr error
+		page, perr = s.store.MemoryEmbedListMissing(r.Context(), tenant,
+			store.MemoryScope(scope), scopeID, prefix, lastKey, limit)
+		if perr != nil {
+			resp.Notes = append(resp.Notes, "paging stopped early: "+perr.Error())
+			resp.More = true
+			break
+		}
+		if len(page) == 0 {
+			break
+		}
+	}
+
 	if resp.Failed > 0 {
 		resp.Notes = append(resp.Notes,
 			"some rows failed (see failed_keys, capped). They remain candidates, so a "+
 				"re-invocation retries exactly those — nothing is lost by a partial failure.")
+	}
+	if resp.SkippedEmpty > 0 {
+		resp.Notes = append(resp.Notes,
+			"skipped_empty rows have no text to embed (a document root, a section heading). "+
+				"They stay candidates permanently — that is expected, not a failure.")
 	}
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/internal/api/http/memory_backfill_test.go
+++ b/internal/api/http/memory_backfill_test.go
@@ -3,8 +3,12 @@ package http
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sort"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/denn-gubsky/loomcycle/internal/auth"
@@ -42,7 +46,7 @@ func TestBackfillEmbeddings_UnsupportedTierSaysSoRatherThanReportingZero(t *test
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost,
-		"/v1/_memory/backfill_embeddings?scope=user&scope_id=alice&prefix=doc.chunk:&dry_run=false", nil).
+		"/v1/_memory/backfill_embeddings?scope=user&scope_id=alice&tenant=&prefix=doc.chunk:&dry_run=false", nil).
 		WithContext(auth.WithPrincipal(context.Background(), auth.Principal{
 			Subject: "root", Scopes: []string{auth.ScopeAdmin},
 		}))
@@ -78,7 +82,10 @@ func TestBackfillEmbeddings_DefaultsToDryRun(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost,
-		"/v1/_memory/backfill_embeddings?scope=user&scope_id=alice&prefix=doc.chunk:", nil).
+		// ?tenant= is EXPLICIT: an admin naming no tenant at all is refused as
+		// ambiguous (see TestBackfillEmbeddings_AdminMustNameATenant), and this test
+		// is about the dry-run default rather than about tenant resolution.
+		"/v1/_memory/backfill_embeddings?scope=user&scope_id=alice&tenant=&prefix=doc.chunk:", nil).
 		WithContext(auth.WithPrincipal(context.Background(), auth.Principal{
 			Subject: "root", Scopes: []string{auth.ScopeAdmin},
 		}))
@@ -157,5 +164,163 @@ func TestEmbedTextForRow_UnwrapsAChunkBody(t *testing.T) {
 	plain := embedTextForRow(store.MemoryEntry{Key: "memory/fact/x", Value: json.RawMessage(`"a fact"`)})
 	if plain != `"a fact"` {
 		t.Errorf("ordinary row = %q, want the raw value (unchanged behaviour)", plain)
+	}
+}
+
+// pagingStore is a store whose vector half is real enough to exercise the sweep:
+// it honours the afterKey cursor and records what was embedded. Everything else
+// delegates to the embedded store.
+//
+// Needed because the sqlite test tier has no vector support, so the live embedding
+// path — where the starvation bug lived — is unreachable on it.
+type pagingStore struct {
+	store.Store
+	keys     []string // sorted; the scope's memory keys
+	bodies   map[string]string
+	embedded map[string]bool
+}
+
+func newPagingStore(base store.Store, bodies map[string]string) *pagingStore {
+	p := &pagingStore{Store: base, bodies: bodies, embedded: map[string]bool{}}
+	for k := range bodies {
+		p.keys = append(p.keys, k)
+	}
+	sort.Strings(p.keys)
+	return p
+}
+
+func (p *pagingStore) MemoryEmbedListMissing(_ context.Context, _ string, _ store.MemoryScope,
+	_, keyPrefix, afterKey string, limit int) ([]store.MemoryEntry, error) {
+	if limit <= 0 {
+		limit = 200
+	}
+	if limit > 1000 {
+		limit = 1000 // clamp, never reset to a smaller default
+	}
+	var out []store.MemoryEntry
+	for _, k := range p.keys {
+		if p.embedded[k] || !strings.HasPrefix(k, keyPrefix) || k <= afterKey {
+			continue
+		}
+		out = append(out, store.MemoryEntry{
+			Key:   k,
+			Value: json.RawMessage(`{"body":` + strconv.Quote(p.bodies[k]) + `}`),
+		})
+		if len(out) == limit {
+			break
+		}
+	}
+	return out, nil
+}
+
+func (p *pagingStore) MemoryEmbedSet(_ context.Context, _ string, _ store.MemoryScope,
+	_, key string, _ store.MemoryEmbedding) error {
+	p.embedded[key] = true
+	return nil
+}
+
+// TestBackfillEmbeddings_PagesPastRowsItCannotEmbed is the regression test for a
+// bug found by running the sweep on a live 3,143-chunk scope.
+//
+// A row with no body text never gains an embedding, so it stays a candidate
+// forever. When `limit` bounded how many rows were LOOKED AT, those rows piled up
+// at the front of the key order until they filled the whole window and throughput
+// reached zero with thousands of rows still unembedded — the residue obeys
+// R' = R + p·(limit − R), whose fixed point is R = limit. Observed decay per
+// 200-row window: 189 / 179 / 169 / 160 / 147.
+//
+// FAIL-BEFORE: make the handler read only the first page (drop the paging loop) and
+// this reports embedded=0 with 5 embeddable rows sitting just past the empties.
+func TestBackfillEmbeddings_PagesPastRowsItCannotEmbed(t *testing.T) {
+	srv, _ := makeServer(t, completingProvider(), makeBaseConfig())
+	emb := &backfillEmbedder{}
+	srv.embedder = emb
+
+	// The first `limit` rows by key are ALL unembeddable; the real work sits behind
+	// them. This is the shape a document scope actually has (roots and headings sort
+	// among the bodies), concentrated so a small limit reproduces it.
+	bodies := map[string]string{}
+	for i := 0; i < 4; i++ {
+		bodies[fmt.Sprintf("doc.chunk:a%02d", i)] = "" // no text to embed, ever
+	}
+	for i := 0; i < 5; i++ {
+		bodies[fmt.Sprintf("doc.chunk:b%02d", i)] = fmt.Sprintf("body number %d", i)
+	}
+	ps := newPagingStore(srv.store, bodies)
+	srv.store = ps
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost,
+		"/v1/_memory/backfill_embeddings?scope=user&scope_id=alice&tenant=&prefix=doc.chunk:&limit=4&dry_run=false", nil).
+		WithContext(auth.WithPrincipal(context.Background(), auth.Principal{
+			Subject: "root", Scopes: []string{auth.ScopeAdmin},
+		}))
+	srv.handleMemoryBackfillEmbeddings(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", rec.Code, rec.Body.String())
+	}
+	var got map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &got)
+
+	// limit=4 bounds how many are EMBEDDED. All four unembeddable rows come first, so
+	// a single-window implementation embeds nothing at all.
+	if n, _ := got["embedded"].(float64); n != 4 {
+		t.Errorf("embedded = %v, want 4 — the sweep must page PAST the %d rows it "+
+			"cannot embed, or it starves; full body: %s", got["embedded"], 4, rec.Body.String())
+	}
+	if n, _ := got["skipped_empty"].(float64); n != 4 {
+		t.Errorf("skipped_empty = %v, want 4 — rows with no text must be reported, not "+
+			"silently passed over", got["skipped_empty"])
+	}
+	// One embeddable row is left over, so the caller must be told to come back.
+	if got["more"] != true {
+		t.Errorf("more = %v, want true with a 5th embeddable row outstanding", got["more"])
+	}
+	if emb.calls != 4 {
+		t.Errorf("embedder called %d times, want 4 — an empty body must not reach the "+
+			"embedder", emb.calls)
+	}
+}
+
+// TestBackfillEmbeddings_AdminMustNameATenant — memory rows are keyed on the
+// tenant, so an admin token that names none resolves to the DEFAULT tenant and the
+// sweep reports a truthful-looking "candidates: 0" against a tenant the operator
+// never meant, leaving the intended one untouched. Verified live on a three-tenant
+// deployment before this refusal existed. Mirrors the erasure, directory and
+// orphan-repair surfaces.
+func TestBackfillEmbeddings_AdminMustNameATenant(t *testing.T) {
+	srv, _ := makeServer(t, completingProvider(), makeBaseConfig())
+	srv.embedder = &backfillEmbedder{}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost,
+		"/v1/_memory/backfill_embeddings?scope=user&scope_id=alice&prefix=doc.chunk:", nil).
+		WithContext(auth.WithPrincipal(context.Background(), auth.Principal{
+			Subject: "root", Scopes: []string{auth.ScopeAdmin},
+		}))
+	srv.handleMemoryBackfillEmbeddings(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 when an admin names no tenant; body: %s",
+			rec.Code, rec.Body.String())
+	}
+	var e map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &e)
+	if e["code"] != "tenant_required" {
+		t.Errorf("code = %v, want tenant_required", e["code"])
+	}
+	// An EXPLICIT empty tenant is a legitimate target (the default partition), so it
+	// must NOT be refused — otherwise the default tenant becomes unreachable.
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPost,
+		"/v1/_memory/backfill_embeddings?scope=user&scope_id=alice&tenant=&prefix=doc.chunk:", nil).
+		WithContext(auth.WithPrincipal(context.Background(), auth.Principal{
+			Subject: "root", Scopes: []string{auth.ScopeAdmin},
+		}))
+	srv.handleMemoryBackfillEmbeddings(rec2, req2)
+	if rec2.Code == http.StatusBadRequest && strings.Contains(rec2.Body.String(), "tenant_required") {
+		t.Error("an explicit ?tenant= (the default partition) was refused; that makes the " +
+			"default tenant unsweepable")
 	}
 }

--- a/internal/store/postgres/memory_embeddings.go
+++ b/internal/store/postgres/memory_embeddings.go
@@ -555,12 +555,19 @@ func decodePgvector(s string) ([]float32, error) {
 // key prefix. See the Store interface for why MemoryEmbedListByModel cannot serve
 // this (it INNER JOINs the table these rows are absent from) and why paging by
 // re-calling is resumable without a cursor.
-func (s *Store) MemoryEmbedListMissing(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, keyPrefix string, limit int) ([]store.MemoryEntry, error) {
+func (s *Store) MemoryEmbedListMissing(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, keyPrefix, afterKey string, limit int) ([]store.MemoryEntry, error) {
 	if !s.pgvectorEnabled {
 		return nil, store.ErrVectorUnsupported
 	}
-	if limit <= 0 || limit > 1000 {
+	// CLAMP, do not reset. This used to send limit>1000 back to the 200 default, so
+	// asking for a bigger page silently returned a SMALLER one — a caller widening
+	// the window to escape the starvation described on the interface got the
+	// opposite of what it asked for.
+	if limit <= 0 {
 		limit = 200
+	}
+	if limit > 1000 {
+		limit = 1000
 	}
 	// LEFT JOIN + IS NULL, the inverse of MemoryEmbedListByModel's inner join.
 	// Ordered by key so successive pages are stable while rows are being embedded
@@ -578,8 +585,12 @@ func (s *Store) MemoryEmbedListMissing(ctx context.Context, tenantID string, sco
 	           AND m.superseded_at IS NULL`
 	args := []any{tenantID, string(scope), scopeID}
 	if keyPrefix != "" {
-		sql += ` AND m.key LIKE $4`
 		args = append(args, keyPrefix+"%")
+		sql += ` AND m.key LIKE $` + strconv.Itoa(len(args))
+	}
+	if afterKey != "" {
+		args = append(args, afterKey)
+		sql += ` AND m.key > $` + strconv.Itoa(len(args))
 	}
 	sql += ` ORDER BY m.key LIMIT ` + strconv.Itoa(limit)
 

--- a/internal/store/sqlite/memory_embeddings.go
+++ b/internal/store/sqlite/memory_embeddings.go
@@ -54,6 +54,6 @@ func (s *Store) MemoryEmbedStats(ctx context.Context, tenantID string, scope sto
 
 // MemoryEmbedListMissing — the non-vec sqlite tier has no embeddings at all, so
 // there is nothing to backfill.
-func (s *Store) MemoryEmbedListMissing(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, keyPrefix string, limit int) ([]store.MemoryEntry, error) {
+func (s *Store) MemoryEmbedListMissing(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, keyPrefix, afterKey string, limit int) ([]store.MemoryEntry, error) {
 	return nil, store.ErrVectorUnsupported
 }

--- a/internal/store/sqlite/memory_embeddings_vec.go
+++ b/internal/store/sqlite/memory_embeddings_vec.go
@@ -92,6 +92,6 @@ func (s *Store) MemoryEmbedStats(ctx context.Context, tenantID string, scope sto
 // MemoryEmbedListMissing — pending on the vec tier, matching the rest of the
 // reembed-listing family (MemoryEmbedListByModel, MemoryEmbedStats). The backfill
 // admin surface is postgres-only until that lands.
-func (s *Store) MemoryEmbedListMissing(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, keyPrefix string, limit int) ([]store.MemoryEntry, error) {
+func (s *Store) MemoryEmbedListMissing(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, keyPrefix, afterKey string, limit int) ([]store.MemoryEntry, error) {
 	return nil, errVecImplPending
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1940,12 +1940,18 @@ type Store interface {
 	// document bodies without touching a scope's ordinary key/value rows, which an
 	// operator may deliberately have left unembedded.
 	//
-	// RESUMABILITY IS INHERENT rather than bookkept. Every embedded row drops out
-	// of this candidate set, so a sweep that dies at row 2,000 simply finds 1,114
-	// remaining on the next call — there is no cursor to persist and no way for a
-	// crash to double-embed or skip. Callers page by re-calling until the count is
-	// zero.
-	MemoryEmbedListMissing(ctx context.Context, tenantID string, scope MemoryScope, scopeID, keyPrefix string, limit int) ([]MemoryEntry, error)
+	// afterKey is a KEYSET cursor: only rows with key > afterKey are returned ("" =
+	// from the start). It exists because "every embedded row drops out of this set"
+	// is not enough on its own — a row the caller CANNOT embed (a document root or a
+	// section heading has no body text) never drops out, accumulates at the front of
+	// the key order, and eventually fills the whole limit window, at which point the
+	// sweep makes no progress with thousands of rows still unembedded. Observed live:
+	// throughput decayed 189/179/169/160/147 per 200-row window before stalling. The
+	// cursor lets a caller step past what it skipped.
+	//
+	// Ordered by key so successive pages are stable while rows are embedded out from
+	// under the query, and so the cursor is meaningful.
+	MemoryEmbedListMissing(ctx context.Context, tenantID string, scope MemoryScope, scopeID, keyPrefix, afterKey string, limit int) ([]MemoryEntry, error)
 
 	// MemoryEmbedStats returns per-(provider, model) row counts and
 	// total embedding bytes for the given scope. Drives the v0.9.0

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -11106,7 +11106,7 @@ func testMemoryEmbedListMissing(t *testing.T, s store.Store) {
 		return out
 	}
 
-	got, err := s.MemoryEmbedListMissing(ctx, "", store.MemoryScopeUser, sid, "doc.chunk:", 100)
+	got, err := s.MemoryEmbedListMissing(ctx, "", store.MemoryScopeUser, sid, "doc.chunk:", "", 100)
 	if err != nil {
 		t.Fatalf("MemoryEmbedListMissing: %v", err)
 	}
@@ -11120,7 +11120,7 @@ func testMemoryEmbedListMissing(t *testing.T, s store.Store) {
 	// resumability story: no cursor, the candidate set shrinks as work completes,
 	// so a sweep that dies mid-way resumes by simply asking again.
 	set("doc.chunk:a", true)
-	got2, err := s.MemoryEmbedListMissing(ctx, "", store.MemoryScopeUser, sid, "doc.chunk:", 100)
+	got2, err := s.MemoryEmbedListMissing(ctx, "", store.MemoryScopeUser, sid, "doc.chunk:", "", 100)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -11129,8 +11129,45 @@ func testMemoryEmbedListMissing(t *testing.T, s store.Store) {
 			"embedded row that stays a candidate would be re-embedded forever", keysOf(got2))
 	}
 
+	// The afterKey CURSOR is what lets a sweep step past a row it cannot embed.
+	// Without it, an unembeddable row (no body text) stays at the front of the key
+	// order, accumulates, and eventually fills the whole limit window — the sweep
+	// then makes no progress with rows still unembedded. Observed live before the
+	// cursor existed: throughput decayed 189/179/169/160/147 per 200-row window.
+	set("doc.chunk:a", false) // put it back so both are candidates again
+	bothAgain, err := s.MemoryEmbedListMissing(ctx, "", store.MemoryScopeUser, sid, "doc.chunk:", "", 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(keysOf(bothAgain), []string{"doc.chunk:a", "doc.chunk:b"}) {
+		t.Fatalf("cursor precondition: %v", keysOf(bothAgain))
+	}
+	after, err := s.MemoryEmbedListMissing(ctx, "", store.MemoryScopeUser, sid, "doc.chunk:", "doc.chunk:a", 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(keysOf(after), []string{"doc.chunk:b"}) {
+		t.Errorf("afterKey=doc.chunk:a returned %v, want just doc.chunk:b — the cursor is "+
+			"EXCLUSIVE, so a caller that skipped a row can advance past it", keysOf(after))
+	}
+	// Past the end is empty, not an error: that is how a caller detects exhaustion.
+	if past, err := s.MemoryEmbedListMissing(ctx, "", store.MemoryScopeUser, sid, "doc.chunk:", "doc.chunk:z", 100); err != nil {
+		t.Fatal(err)
+	} else if len(past) != 0 {
+		t.Errorf("afterKey past the last row returned %v, want empty", keysOf(past))
+	}
+	// A limit ABOVE the backend cap must clamp, never reset to a smaller default:
+	// a caller widening the window to escape starvation must not get less.
+	if wide, err := s.MemoryEmbedListMissing(ctx, "", store.MemoryScopeUser, sid, "doc.chunk:", "", 5000); err != nil {
+		t.Fatal(err)
+	} else if len(wide) != 2 {
+		t.Errorf("limit=5000 returned %d rows, want 2 — a limit over the cap must clamp "+
+			"to the cap, not fall back to the default page size", len(wide))
+	}
+	set("doc.chunk:a", true) // restore the state the assertions below assume
+
 	// No prefix sweeps the whole scope, including the ordinary row.
-	all, err := s.MemoryEmbedListMissing(ctx, "", store.MemoryScopeUser, sid, "", 100)
+	all, err := s.MemoryEmbedListMissing(ctx, "", store.MemoryScopeUser, sid, "", "", 100)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -11129,25 +11129,37 @@ func testMemoryEmbedListMissing(t *testing.T, s store.Store) {
 			"embedded row that stays a candidate would be re-embedded forever", keysOf(got2))
 	}
 
+	// No prefix sweeps the whole scope, including the ordinary row.
+	all, err := s.MemoryEmbedListMissing(ctx, "", store.MemoryScopeUser, sid, "", "", 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(keysOf(all), []string{"doc.chunk:b", "memory/fact/x"}) {
+		t.Errorf("unprefixed candidates = %v, want both remaining rows", keysOf(all))
+	}
+
 	// The afterKey CURSOR is what lets a sweep step past a row it cannot embed.
 	// Without it, an unembeddable row (no body text) stays at the front of the key
-	// order, accumulates, and eventually fills the whole limit window — the sweep
-	// then makes no progress with rows still unembedded. Observed live before the
-	// cursor existed: throughput decayed 189/179/169/160/147 per 200-row window.
-	set("doc.chunk:a", false) // put it back so both are candidates again
-	bothAgain, err := s.MemoryEmbedListMissing(ctx, "", store.MemoryScopeUser, sid, "doc.chunk:", "", 100)
+	// order, accumulates, and eventually fills the whole limit window — the sweep then
+	// makes no progress with rows still unembedded. Observed live before the cursor
+	// existed: throughput decayed 189/179/169/160/147 per 200-row window.
+	//
+	// Uses a FRESH key rather than un-embedding an existing one: set(key, false) only
+	// writes the row and returns, so it does not remove an embedding already there.
+	set("doc.chunk:d", false)
+	pre, err := s.MemoryEmbedListMissing(ctx, "", store.MemoryScopeUser, sid, "doc.chunk:", "", 100)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(keysOf(bothAgain), []string{"doc.chunk:a", "doc.chunk:b"}) {
-		t.Fatalf("cursor precondition: %v", keysOf(bothAgain))
+	if !reflect.DeepEqual(keysOf(pre), []string{"doc.chunk:b", "doc.chunk:d"}) {
+		t.Fatalf("cursor precondition: candidates = %v, want b and d", keysOf(pre))
 	}
-	after, err := s.MemoryEmbedListMissing(ctx, "", store.MemoryScopeUser, sid, "doc.chunk:", "doc.chunk:a", 100)
+	after, err := s.MemoryEmbedListMissing(ctx, "", store.MemoryScopeUser, sid, "doc.chunk:", "doc.chunk:b", 100)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(keysOf(after), []string{"doc.chunk:b"}) {
-		t.Errorf("afterKey=doc.chunk:a returned %v, want just doc.chunk:b — the cursor is "+
+	if !reflect.DeepEqual(keysOf(after), []string{"doc.chunk:d"}) {
+		t.Errorf("afterKey=doc.chunk:b returned %v, want just doc.chunk:d — the cursor is "+
 			"EXCLUSIVE, so a caller that skipped a row can advance past it", keysOf(after))
 	}
 	// Past the end is empty, not an error: that is how a caller detects exhaustion.
@@ -11156,22 +11168,13 @@ func testMemoryEmbedListMissing(t *testing.T, s store.Store) {
 	} else if len(past) != 0 {
 		t.Errorf("afterKey past the last row returned %v, want empty", keysOf(past))
 	}
-	// A limit ABOVE the backend cap must clamp, never reset to a smaller default:
-	// a caller widening the window to escape starvation must not get less.
+	// A limit ABOVE the backend cap must clamp, never fall back to a smaller default:
+	// a caller widening the window to escape starvation must not get LESS than it
+	// would have at the cap.
 	if wide, err := s.MemoryEmbedListMissing(ctx, "", store.MemoryScopeUser, sid, "doc.chunk:", "", 5000); err != nil {
 		t.Fatal(err)
 	} else if len(wide) != 2 {
 		t.Errorf("limit=5000 returned %d rows, want 2 — a limit over the cap must clamp "+
 			"to the cap, not fall back to the default page size", len(wide))
-	}
-	set("doc.chunk:a", true) // restore the state the assertions below assume
-
-	// No prefix sweeps the whole scope, including the ordinary row.
-	all, err := s.MemoryEmbedListMissing(ctx, "", store.MemoryScopeUser, sid, "", "", 100)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(keysOf(all), []string{"doc.chunk:b", "memory/fact/x"}) {
-		t.Errorf("unprefixed candidates = %v, want both remaining rows", keysOf(all))
 	}
 }


### PR DESCRIPTION
Two bugs, both found by actually running the v1.46.0 upgrade sweeps against the reference deployment (154 documents, 3,143 chunks, 2 images). Neither was visible from the code or the unit tests.

## 1. The embedding backfill starved instead of finishing (`651f19a`)

Throughput decayed **189 / 179 / 169 / 160 / 147** embedded per 200-row window and was heading for zero with ~2,300 rows still unembedded.

`limit` bounded how many rows were **looked at**. A row with no body text — a document root, a section heading — can never gain an embedding, so it stays a candidate forever, and since the query is `ORDER BY key` those rows accumulate at the **front** of the window. The residue obeys `R' = R + p·(limit − R)`, whose fixed point is **R = limit**: eventually the window is entirely rows that cannot be embedded and the sweep does nothing — while its own notes promise "re-invoke until candidates reaches 0", a state it can never reach.

Widening the window didn't help either: the store did `if limit > 1000 { limit = 200 }`, so asking for 5000 silently returned a **smaller** page than asking for 1000. I hit that live while trying to work around the first bug. Now a clamp.

**Fix.** `MemoryEmbedListMissing` takes an `afterKey` keyset cursor, and the handler pages with it until it has *embedded* `limit` rows or the source is exhausted — so `limit` bounds work done rather than rows glanced at, and the sweep steps over what it cannot embed. The response reports `skipped_empty` and `more`, and the notes say to re-invoke while `more` is true.

Also: an admin token naming **no** tenant is refused with 400 `tenant_required`, mirroring erasure / directory / orphan-repair. Memory rows are keyed on the tenant, so omitting it resolved to the *default* tenant. Demonstrated live on the three-tenant deployment — the same request with and without `?tenant=` returned **200 candidates** and **0**. An explicit `?tenant=` still targets the default partition, or it would become unsweepable.

## 2. The describe pass truncated before it said anything (`f7e9119`)

The image sweep reported 2 candidates, 0 failures, and **both** as answered-empty. The model was fine — asked directly, qwen3.6 describes the image in 198 characters.

`describeMaxTokens` was 300, and qwen3.6 is a thinking model that emits its reasoning trace **first**. Reproduced straight against Ollama:

| request | content | thinking | done_reason |
|---|---|---|---|
| `num_predict=300`, think default | **0** | 1281 chars | **length** |
| `num_predict=300`, `think=false` | 448 | 0 | stop |

300 looked ample because the same prompt answers in 84 tokens with thinking off.

**Worse than a failed call.** The pass recorded it as answered-empty and stamped `described_at` — whose entire purpose is to separate "a model looked and found nothing" from "nothing has looked yet". So a code bug became a permanent fact about the data, and no re-run would ever revisit it. A turn that stopped at the ceiling is now a **failure**, left retryable, with the reason named.

The ceiling is 1500 — a ceiling, not a target, so a generous value costs nothing on a normal call. Deliberately **not** fixed by forcing `effort: low` (which the Ollama driver maps to `think:false`): that flag errors on a model which cannot reason, so it would break a non-thinking vision model like llava to accommodate a thinking one. A budget is model-agnostic.

## What was tested

- `TestBackfillEmbeddings_PagesPastRowsItCannotEmbed` — four unembeddable rows ahead of five embeddable ones at `limit=4`. The old single-window code embeds **0**; this embeds 4 and reports `more=true`.
- `TestBackfillEmbeddings_AdminMustNameATenant` — the refusal *and* the explicit-empty carve-out.
- Store contract, both tiers — the cursor is exclusive, past-the-end is empty rather than an error, and a limit over the cap clamps instead of falling back to the default page size.
- `TestDescribeImages_TruncatedAnswerIsRetryableNotEmpty` — `failed=1` / `empty=0`, the diagnostic names the ceiling, and a second pass still finds the image and describes it.
- `TestDescribeImages_BudgetLeavesRoomForAThinkingTrace` — pins the constant against the measured trace.

**Fail-before verified on both.** Reverting the paging loop reports `embedded=0`; disabling the truncation check reports `empty=1` and retires the image. Two existing backfill tests now name the tenant explicitly, since they relied on the ambiguous form.

`go test ./...` clean.

## Deployment note

The sweep itself completed — **2,814 chunk bodies embedded**, documents are semantically searchable now (verified: the query that returned `{"entries":[]}` before the sweep now returns the exact section at 0.62 similarity). 187 rows are the expected unembeddable residue.

After this deploys, the two images stamped by the buggy pass need clearing to become candidates again:

```sql
UPDATE chunk_assets SET described_at = NULL
 WHERE described_at IS NOT NULL AND coalesce(description,'') = '';
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8