### PR TITLE
feat(memory): fact entity block, list_facts, and off-run unified memory search

### DIFF
--- a/internal/api/http/memory_search.go
+++ b/internal/api/http/memory_search.go
@@ -1,0 +1,171 @@
+package http
+
+// memory_search.go — POST /v1/_memory/search (RFC BV phase 1).
+//
+// An OFF-RUN unified semantic search over a scope's memory: it runs with an
+// EMPTY key prefix so results span BOTH plain k/v entries AND document-chunk
+// bodies (doc.chunk:<id>), which the memory view needs to answer "where did I
+// record this" across the whole stack in one query. The in-band Memory tool's
+// `search` op is prefix-scoped and run-bound; this is its off-run twin for the
+// admin/operator surface, matching the HTTP-only posture of the sibling
+// /v1/_memory/* endpoints. Admin-only in this phase (the /v1/_* catch-all gates
+// it at ScopeAdmin); a later phase re-gates the family to the tenant axis.
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"strings"
+
+	memrank "github.com/denn-gubsky/loomcycle/internal/memory"
+	"github.com/denn-gubsky/loomcycle/internal/memory/backends/inprocess"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// docChunkKeyPrefix is the Memory keyspace namespace the Document tool writes
+// chunk bodies under (builtin.chunkBodyKey). A hit on such a key is a document
+// chunk, not a plain memory entry — kept as a literal here to avoid importing
+// internal/tools/builtin into the HTTP layer.
+const docChunkKeyPrefix = "doc.chunk:"
+
+type memorySearchRequest struct {
+	Query   string               `json:"query"`
+	Scope   string               `json:"scope"`
+	ScopeID string               `json:"scope_id"`
+	TopK    int                  `json:"top_k"`
+	Rank    *memrank.RankConfig  `json:"rank"`
+	Dedup   *memrank.DedupConfig `json:"dedup"`
+}
+
+type memorySearchEmbeddedWith struct {
+	Provider string `json:"provider"`
+	Model    string `json:"model"`
+}
+
+type memorySearchResultEntry struct {
+	Key          string                   `json:"key"`
+	Value        json.RawMessage          `json:"value"`
+	Score        float64                  `json:"score"`      // raw cosine similarity
+	RankScore    float64                  `json:"rank_score"` // hybrid rank the row was ordered by
+	EmbeddedWith memorySearchEmbeddedWith `json:"embedded_with"`
+	// Kind distinguishes a plain memory entry ("memory") from a document chunk
+	// body ("document"); a document hit also carries chunk_id so the viewer can
+	// fetch its entity block via the Document tool's get_chunk.
+	Kind    string `json:"kind"`
+	ChunkID string `json:"chunk_id,omitempty"`
+}
+
+type memorySearchResponse struct {
+	Scope             string                    `json:"scope"`
+	ScopeID           string                    `json:"scope_id"`
+	Entries           []memorySearchResultEntry `json:"entries"`
+	QueryEmbeddingDim int                       `json:"query_embedding_dim"`
+	Truncated         bool                      `json:"truncated"`
+}
+
+// handleMemorySearch serves POST /v1/_memory/search.
+func (s *Server) handleMemorySearch(w http.ResponseWriter, r *http.Request) {
+	if s.store == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "store_unavailable",
+			"store not configured; Memory admin requires a persistent store")
+		return
+	}
+
+	// A query string is small; cap the body so an off-run caller can't stream a
+	// large payload into an admin endpoint.
+	var body memorySearchRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&body); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_body",
+			"request body must be valid JSON: "+err.Error())
+		return
+	}
+	if strings.TrimSpace(body.Query) == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing_query", "query is required")
+		return
+	}
+	if !validAdminMemoryScope(body.Scope) {
+		writeJSONError(w, http.StatusBadRequest, "invalid_scope", "scope must be one of: agent, user")
+		return
+	}
+	if strings.TrimSpace(body.ScopeID) == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing_scope_id", "scope_id is required")
+		return
+	}
+
+	topK := body.TopK
+	if topK <= 0 {
+		topK = 10
+	}
+	if topK > 50 {
+		topK = 50
+	}
+	rankCfg := memrank.DefaultRankConfig()
+	if body.Rank != nil {
+		rankCfg = *body.Rank
+	}
+	var dedupCfg memrank.DedupConfig
+	if body.Dedup != nil {
+		dedupCfg = *body.Dedup
+	}
+
+	// TENANT STAMPING — security-critical. The in-process backend resolves the
+	// tenant from tools.RunIdentity(ctx).TenantID ONLY (backends/inprocess.runTenant).
+	// Off-run there is no RunIdentity, so without stamping the authenticated
+	// principal's tenant the search would run at the shared "" tenant and could
+	// read/return another tenant's rows. tenantFromCtx is caller/config-
+	// authoritative — never a request-body field.
+	ctx := tools.WithRunIdentity(r.Context(), tools.RunIdentityValue{TenantID: tenantFromCtx(r.Context())})
+
+	// Empty Prefix so the search spans both k/v entries and doc.chunk bodies.
+	backend := inprocess.New(s.store, s.embedder)
+	res, err := backend.Search(ctx, store.MemoryScope(body.Scope), body.ScopeID,
+		memrank.SearchQuery{QueryText: body.Query, Prefix: "", TopK: topK}, rankCfg, dedupCfg)
+	if err != nil {
+		// The three typed refusals are operator-actionable (no embedder / no
+		// vector index / a model swap left the stored dimension stale), so surface
+		// them verbatim as a 400 rather than a blind 500.
+		if errors.Is(err, store.ErrDimensionMismatch) ||
+			errors.Is(err, store.ErrVectorUnsupported) ||
+			errors.Is(err, store.ErrEmbedderNotConfigured) {
+			writeJSONError(w, http.StatusBadRequest, "search_unavailable", err.Error())
+			return
+		}
+		log.Printf("memory search failed (scope=%s scope_id=%s): %v", body.Scope, body.ScopeID, err)
+		writeJSONError(w, http.StatusInternalServerError, "internal", "search failed")
+		return
+	}
+
+	entries := make([]memorySearchResultEntry, 0, len(res.Entries))
+	for i, e := range res.Entries {
+		entry := memorySearchResultEntry{
+			Key:       e.Key,
+			Value:     e.Value,
+			Score:     e.Score,
+			RankScore: res.RankScores[i],
+			EmbeddedWith: memorySearchEmbeddedWith{
+				Provider: e.EmbeddedWith.Provider,
+				Model:    e.EmbeddedWith.Model,
+			},
+			Kind: "memory",
+		}
+		// A doc.chunk hit may be an entity fact OR a plain document chunk; the
+		// viewer calls get_chunk to see its entity block. No per-hit sidecar
+		// lookup here — the sidecar lives in SQL Memory, a different plane; this
+		// handler stays store-only.
+		if strings.HasPrefix(e.Key, docChunkKeyPrefix) {
+			entry.Kind = "document"
+			entry.ChunkID = strings.TrimPrefix(e.Key, docChunkKeyPrefix)
+		}
+		entries = append(entries, entry)
+	}
+
+	writeJSON(w, http.StatusOK, memorySearchResponse{
+		Scope:             body.Scope,
+		ScopeID:           body.ScopeID,
+		Entries:           entries,
+		QueryEmbeddingDim: res.QueryEmbeddingDim,
+		Truncated:         res.Truncated,
+	})
+}

--- a/internal/api/http/memory_search_test.go
+++ b/internal/api/http/memory_search_test.go
@@ -1,0 +1,222 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+)
+
+// searchVectorStore wraps a real Store with an in-memory embedding map and
+// reports SupportsVectors()=true, so the /v1/_memory/search handler can be
+// exercised without a Postgres+pgvector container. MemoryEmbedSearch returns the
+// live k/v values (read from the wrapped store) for every embedded key under the
+// requested (tenant, scope, scope_id) — this double tests the HANDLER's
+// kind/chunk_id mapping and tenant routing, not the store's cosine math (covered
+// by the store contract suite). It partitions by tenant so the isolation test
+// can prove the handler stamps the principal's tenant.
+type searchVectorStore struct {
+	store.Store
+	mu     sync.Mutex
+	embeds map[string]store.MemoryEmbedding // "tenant|scope|scopeID|key" → embedding
+}
+
+func newSearchVectorStore(s store.Store) *searchVectorStore {
+	return &searchVectorStore{Store: s, embeds: map[string]store.MemoryEmbedding{}}
+}
+
+func (v *searchVectorStore) SupportsVectors() bool { return true }
+
+func (v *searchVectorStore) MemoryEmbedSet(_ context.Context, tenantID string, scope store.MemoryScope, scopeID, key string, e store.MemoryEmbedding) error {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.embeds[tenantID+"|"+string(scope)+"|"+scopeID+"|"+key] = e
+	return nil
+}
+
+func (v *searchVectorStore) MemoryEmbedSearch(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, keyPrefix string, _ []float32, topK int) ([]store.MemorySearchEntry, error) {
+	v.mu.Lock()
+	prefix := tenantID + "|" + string(scope) + "|" + scopeID + "|"
+	keys := []string{}
+	models := map[string]store.MemoryEmbedding{}
+	for k, e := range v.embeds {
+		if !strings.HasPrefix(k, prefix) {
+			continue
+		}
+		key := strings.TrimPrefix(k, prefix)
+		if keyPrefix != "" && !strings.HasPrefix(key, keyPrefix) {
+			continue
+		}
+		keys = append(keys, key)
+		models[key] = e
+	}
+	v.mu.Unlock()
+
+	// Deterministic order (by key) so the test is stable; cosine order is not
+	// what this double is asserting.
+	sort.Strings(keys)
+	out := make([]store.MemorySearchEntry, 0, len(keys))
+	for i, key := range keys {
+		// Read the live value so dropDeadLinks (which drops empty-Value hits)
+		// keeps it — mirrors a consistent store where the body outlives nothing.
+		entry, err := v.Store.MemoryGet(ctx, tenantID, scope, scopeID, key)
+		if err != nil {
+			continue
+		}
+		se := store.MemorySearchEntry{MemoryEntry: entry, Score: 1.0 - float64(i)*0.01}
+		se.EmbeddedWith.Provider = models[key].Provider
+		se.EmbeddedWith.Model = models[key].Model
+		out = append(out, se)
+		if topK > 0 && len(out) >= topK {
+			break
+		}
+	}
+	return out, nil
+}
+
+func memorySearchServer(t *testing.T) (*Server, *searchVectorStore) {
+	t.Helper()
+	base, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = base.Close() })
+	vs := newSearchVectorStore(base)
+	return &Server{store: vs, embedder: &backfillEmbedder{}}, vs
+}
+
+// seedSearchRow writes a k/v value AND its embedding under one tenant so the
+// double's MemoryEmbedSearch returns it.
+func seedSearchRow(t *testing.T, vs *searchVectorStore, tenant, scopeID, key, value string) {
+	t.Helper()
+	if err := vs.MemorySet(context.Background(), tenant, store.MemoryScopeUser, scopeID, key, []byte(value), 0); err != nil {
+		t.Fatalf("MemorySet(%s/%s): %v", tenant, key, err)
+	}
+	if err := vs.MemoryEmbedSet(context.Background(), tenant, store.MemoryScopeUser, scopeID, key,
+		store.MemoryEmbedding{Provider: "test", Model: "stub", Dimension: 4, Vector: []float32{1, 0, 0, 0}}); err != nil {
+		t.Fatalf("MemoryEmbedSet(%s/%s): %v", tenant, key, err)
+	}
+}
+
+func postMemorySearch(s *Server, tenant, body string) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/_memory/search", strings.NewReader(body)).
+		WithContext(auth.WithPrincipal(context.Background(), auth.Principal{
+			TenantID: tenant, Subject: "op", Scopes: []string{auth.ScopeAdmin},
+		}))
+	s.handleMemorySearch(rec, req)
+	return rec
+}
+
+// TestMemorySearch_UnifiedKvAndDocChunk: one search spans BOTH a plain k/v entry
+// (kind=memory) and a document-chunk body (kind=document, carrying chunk_id) —
+// the whole reason the endpoint runs with an empty key prefix.
+func TestMemorySearch_UnifiedKvAndDocChunk(t *testing.T) {
+	s, vs := memorySearchServer(t)
+	seedSearchRow(t, vs, "A", "alice", "voice", `"warm and direct"`)
+	seedSearchRow(t, vs, "A", "alice", "doc.chunk:chunk-1", `{"body":"Ada was a mathematician","fields":null}`)
+
+	rec := postMemorySearch(s, "A", `{"query":"ada","scope":"user","scope_id":"alice"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp memorySearchResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	var gotMemory, gotDocument bool
+	var docChunkID string
+	for _, e := range resp.Entries {
+		switch e.Kind {
+		case "memory":
+			gotMemory = true
+			if e.ChunkID != "" {
+				t.Errorf("a memory hit must not carry chunk_id: %+v", e)
+			}
+		case "document":
+			gotDocument = true
+			docChunkID = e.ChunkID
+		default:
+			t.Errorf("unexpected kind %q", e.Kind)
+		}
+	}
+	if !gotMemory {
+		t.Errorf("no kind=memory hit for the k/v entry: %+v", resp.Entries)
+	}
+	if !gotDocument {
+		t.Errorf("no kind=document hit for the doc.chunk body: %+v", resp.Entries)
+	}
+	if docChunkID != "chunk-1" {
+		t.Errorf("document hit chunk_id = %q, want chunk-1", docChunkID)
+	}
+}
+
+// TestMemorySearch_TenantIsolation is the security regression: a search as
+// principal A must return ONLY A's rows, never B's — even when B holds the SAME
+// (scope, scope_id, key). This FAILS if the handler's tools.WithRunIdentity
+// tenant stamp is removed (the in-process backend would then run at the shared
+// "" tenant), which is the whole reason the stamp exists.
+func TestMemorySearch_TenantIsolation(t *testing.T) {
+	s, vs := memorySearchServer(t)
+	seedSearchRow(t, vs, "A", "alice", "voice", `"alice-A-voice"`)
+	seedSearchRow(t, vs, "B", "alice", "voice", `"bob-B-voice"`)
+
+	rec := postMemorySearch(s, "A", `{"query":"voice","scope":"user","scope_id":"alice"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp memorySearchResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	var sawA bool
+	for _, e := range resp.Entries {
+		if strings.Contains(string(e.Value), "bob-B-voice") {
+			t.Errorf("tenant A's search returned tenant B's row: %s", string(e.Value))
+		}
+		if strings.Contains(string(e.Value), "alice-A-voice") {
+			sawA = true
+		}
+	}
+	if !sawA {
+		t.Fatalf("tenant A's own row was not returned — the principal tenant was not stamped onto the search; entries: %+v", resp.Entries)
+	}
+}
+
+// TestMemorySearch_MissingQuery: an empty query is a 400, not an embed of "".
+func TestMemorySearch_MissingQuery(t *testing.T) {
+	s, _ := memorySearchServer(t)
+	rec := postMemorySearch(s, "A", `{"scope":"user","scope_id":"alice"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body: %s", rec.Code, rec.Body.String())
+	}
+	var e map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &e)
+	if e["code"] != "missing_query" {
+		t.Errorf("code = %v, want missing_query", e["code"])
+	}
+}
+
+// TestMemorySearch_InvalidScope: only the closed admin scope set is accepted.
+func TestMemorySearch_InvalidScope(t *testing.T) {
+	s, _ := memorySearchServer(t)
+	rec := postMemorySearch(s, "A", `{"query":"x","scope":"tenant","scope_id":"alice"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body: %s", rec.Code, rec.Body.String())
+	}
+	var e map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &e)
+	if e["code"] != "invalid_scope" {
+		t.Errorf("code = %v, want invalid_scope", e["code"])
+	}
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -3004,6 +3004,10 @@ func (s *Server) Mux() http.Handler {
 	// support OR no embedder is configured.
 	mux.Handle("GET /v1/_memory/embed_stats", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleMemoryEmbedStats))))
 	mux.Handle("POST /v1/_memory/reembed", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleMemoryReembed))))
+	// RFC BV phase 1 — off-run unified semantic search over a scope's k/v entries
+	// AND document-chunk bodies. Admin-only via the /v1/_* catch-all (a later
+	// phase re-gates the /v1/_memory/* family to the tenant axis).
+	mux.Handle("POST /v1/_memory/search", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleMemorySearch))))
 	mux.Handle("POST /v1/_memory/backfill_embeddings", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleMemoryBackfillEmbeddings))))
 	// RFC BU phase 4b — generate vision descriptions for image chunks that have
 	// none, then re-embed so they become searchable. Left on the /v1/_* catch-all

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -68,7 +68,7 @@ func (d *Document) Description() string {
 const documentInputSchema = `{
 	"type": "object",
 	"properties": {
-		"op":          {"type": "string", "enum": ["create_document","get_document","documents_summary","query_documents","delete_document","set_path","create_chunk","upsert_chunk","get_chunk","update_chunk","delete_chunk","supersede_chunk","graph_recall","move_chunk","reorder_chunk","link_chunks","unlink_chunks","get_edges","query_chunks","add_tags","remove_tags","list_tags","define_type","list_types","set_asset","get_asset","export_md","import_md","export_canvas","import_canvas","history","get_version","diff","backlinks","related","unlinked_mentions"]},
+		"op":          {"type": "string", "enum": ["create_document","get_document","documents_summary","query_documents","delete_document","set_path","create_chunk","upsert_chunk","get_chunk","update_chunk","delete_chunk","supersede_chunk","graph_recall","list_facts","move_chunk","reorder_chunk","link_chunks","unlink_chunks","get_edges","query_chunks","add_tags","remove_tags","list_tags","define_type","list_types","set_asset","get_asset","export_md","import_md","export_canvas","import_canvas","history","get_version","diff","backlinks","related","unlinked_mentions"]},
 		"scope":       {"type": "string", "enum": ["agent","user","tenant"], "description": "Which store (default user). agent = this agent; user = this end-user (needs a user_id on the run); tenant = shared by every user and agent in the tenant — anything written here is read by all of them, so use it for curated reference material, not for anything derived from untrusted text. tenant requires the operator to grant BOTH memory_scopes and sql_scopes with the tenant value."},
 		"id":          {"type": "string", "description": "Document id (get/delete_document, set_path) or chunk id (get/update/delete/move_chunk)."},
 		"path":        {"type": "string", "description": "create_document: name the doc in the Path tree (default /documents/<title> if omitted). set_path: the path to attach to an existing document (by id). get/delete_document: address by path instead of id."},
@@ -79,19 +79,19 @@ const documentInputSchema = `{
 		"new_parent_id": {"type": "string", "description": "move_chunk: the new parent."},
 		"after_id":    {"type": "string", "description": "create_chunk: insert the new chunk immediately AFTER this sibling (same parent; shifts later siblings). Overrides parent_id/position."},
 		"direction":   {"type": "string", "enum": ["up","down"], "description": "reorder_chunk: move the chunk up or down within its current level."},
-		"type":        {"type": "string", "description": "Optional supertag-like chunk type."},
+		"type":        {"type": "string", "description": "Optional supertag-like chunk type. list_facts (browse the scope's facts — chunks that carry entity metadata — newest first, metadata only, no bodies): return only facts of this type."},
 		"body":        {"type": "string", "description": "Markdown body."},
 		"seed_ids":  {"type": "array", "items": {"type": "string"}, "description": "graph_recall: chunk ids to start from. Use this to hand in results you already found some other way (a Memory search, a previous recall) and follow the graph out from them."},
 		"query":     {"type": "string", "description": "graph_recall: find starting chunks whose title matches this text. Use seed_ids instead when you already know where to start."},
 		"hops":      {"type": "integer", "description": "graph_recall: how far to follow relations from each starting chunk. 0 = the starting chunks only, 1 = their neighbours (default), 2 = the maximum."},
-		"as_of":     {"type": "integer", "description": "graph_recall: answer as of this moment (unix nanos) instead of now — returns what was true then, including facts since corrected."},
-		"include_retired": {"type": "boolean", "description": "graph_recall: also return facts that have been superseded. Off by default, so you get only what is currently true."},
+		"as_of":     {"type": "integer", "description": "graph_recall / list_facts: answer as of this moment (unix nanos) instead of now — returns what was true then, including facts since corrected."},
+		"include_retired": {"type": "boolean", "description": "graph_recall / list_facts: also return facts that have been superseded. Off by default, so you get only what is currently true."},
 		"limit":     {"type": "integer", "description": "graph_recall: maximum chunks returned (default 50)."},
 		"natural_key": {"type": "string", "description": "upsert_chunk: the stable identity of this entity or fact. Upserting twice with the same key updates ONE chunk instead of adding a second — use a derived form such as person:ada-lovelace, or subject|predicate|object for a fact. Unique within the scope."},
 		"supersedes_id": {"type": "string", "description": "supersede_chunk: the id of the chunk being RETIRED by this one. The retired chunk is not deleted — it stays queryable so that questions about an earlier point in time still have an answer."},
 		"valid_at":   {"type": "integer", "description": "When the fact became true IN THE WORLD (unix nanos). Defaults to now. Distinct from when it was recorded."},
 		"invalid_at": {"type": "integer", "description": "When the fact STOPPED being true in the world (unix nanos). Leave unset for something still true."},
-		"class":      {"type": "string", "enum": ["derived","evidential"], "description": "derived = distilled from something else (the default). evidential = source material, exempt from age-based pruning."},
+		"class":      {"type": "string", "enum": ["derived","evidential"], "description": "derived = distilled from something else (the default). evidential = source material, exempt from age-based pruning. list_facts: filter to facts of this class."},
 		"confidence": {"type": "number", "description": "0..1, how sure you are of this fact."},
 		"fields":      {"type": "object", "description": "Type-specific structured fields."},
 		"status":      {"type": "string"},
@@ -382,6 +382,8 @@ func (d *Document) Execute(ctx context.Context, raw json.RawMessage) (tools.Resu
 		return d.supersedeChunk(ctx, key, in)
 	case "graph_recall":
 		return d.graphRecall(ctx, key, in)
+	case "list_facts":
+		return d.listFacts(ctx, key, in)
 	case "link_chunks":
 		return d.linkChunks(ctx, key, in)
 	case "unlink_chunks":
@@ -1689,6 +1691,14 @@ func (d *Document) getChunk(ctx context.Context, key sqlmem.ScopeKey, mscope sto
 	// come from GET /v1/_document/asset/{id}) so a viewer knows to render an img.
 	if mt, sz, ok := d.assetMeta(ctx, key, in.ID); ok {
 		resp["asset"] = map[string]any{"media_type": mt, "size": sz}
+	}
+	// RFC BV: when the chunk is a fact (has a chunk_memory_meta sidecar), surface
+	// the bi-temporal / provenance block so the memory view reads it typed —
+	// without it, a fact and a plain chunk are indistinguishable on read.
+	if meta, ok, merr := d.readChunkMeta(ctx, key, in.ID); merr != nil {
+		return errResult("get_chunk: entity: " + merr.Error()), nil
+	} else if ok {
+		resp["entity"] = chunkMetaToJSON(meta)
 	}
 	return jsonResult(resp)
 }

--- a/internal/tools/builtin/document_entity.go
+++ b/internal/tools/builtin/document_entity.go
@@ -190,6 +190,150 @@ func (d *Document) readChunkMeta(ctx context.Context, key sqlmem.ScopeKey, chunk
 	}, true, nil
 }
 
+// chunkMetaToJSON renders a fact's sidecar row as the get_chunk / list_facts
+// `entity` block. Timestamps stay raw unix-nanos int64 (lossless — the UI
+// formats them), matching graph_recall's valid_at/invalid_at output. Nil/empty
+// fields are omitted (as graphChunk omits nil timestamps), EXCEPT `retired`,
+// which is always present so a reader never has to infer it from an absent key.
+//
+// `retired` keys on expired_at (SYSTEM time), not invalid_at: the supersede path
+// closes expired_at and the retired predicate keys on it (see writeChunkMeta). A
+// future world-time invalid_at is a still-current fact with a known end, so
+// keying `retired` on invalid_at would report such a fact as retired.
+func chunkMetaToJSON(m chunkMetaRow) map[string]any {
+	out := map[string]any{"retired": m.ExpiredAt != nil}
+	if m.ValidAt != nil {
+		out["valid_at"] = *m.ValidAt
+	}
+	if m.InvalidAt != nil {
+		out["invalid_at"] = *m.InvalidAt
+	}
+	if m.CreatedAt != nil {
+		out["created_at"] = *m.CreatedAt
+	}
+	if m.ExpiredAt != nil {
+		out["expired_at"] = *m.ExpiredAt
+	}
+	if m.Class != "" {
+		out["class"] = m.Class
+	}
+	if m.Origin != "" {
+		out["origin"] = m.Origin
+	}
+	if m.NaturalKey != "" {
+		out["natural_key"] = m.NaturalKey
+	}
+	if m.Confidence != nil {
+		out["confidence"] = *m.Confidence
+	}
+	if m.SessionID != "" {
+		out["session_id"] = m.SessionID
+	}
+	if m.RunID != "" {
+		out["run_id"] = m.RunID
+	}
+	if m.EventSeq != nil {
+		out["event_seq"] = *m.EventSeq
+	}
+	return out
+}
+
+// listFacts returns the scope's facts — chunks that HAVE a chunk_memory_meta
+// sidecar — as metadata only, no bodies. It is the browse surface behind the
+// human-facing memory view: a viewer fetches a fact's body via get_chunk on
+// click, exactly as graph_recall returns no body. The INNER JOIN is what makes
+// "fact" mean "has a sidecar" rather than "any chunk".
+func (d *Document) listFacts(ctx context.Context, key sqlmem.ScopeKey, in docInput) (tools.Result, error) {
+	if in.Class != "" && !entityClasses[in.Class] {
+		return errResult("list_facts: class must be one of: derived, evidential"), nil
+	}
+	// Same default/cap as graph_recall — a fact list is a browse surface, so the
+	// bound is a page size, not a correctness limit.
+	limit := graphDefaultLimit
+	if in.Limit > 0 {
+		limit = in.Limit
+	}
+	if limit > graphMaxLimit {
+		limit = graphMaxLimit
+	}
+
+	where := []string{}
+	args := []any{}
+	if in.Type != "" {
+		where = append(where, "c.type = ?")
+		args = append(args, in.Type)
+	}
+	if in.Class != "" {
+		where = append(where, "m.class = ?")
+		args = append(args, in.Class)
+	}
+	if in.DocumentID != "" {
+		where = append(where, "c.document_id = ?")
+		args = append(args, in.DocumentID)
+	}
+	// Reuse graph_recall's temporal filter so "currently true" means the same
+	// thing on both surfaces. The INNER JOIN makes m.chunk_id non-null, so the
+	// clause's `m.chunk_id IS NULL OR ...` disjunct is inert here (which is
+	// correct: a JOINed row always has a sidecar). Empty when include_retired.
+	if temporal, targs := graphTemporalClause(in); temporal != "" {
+		where = append(where, temporal)
+		args = append(args, targs...)
+	}
+
+	stmt := `SELECT c.id, c.document_id, c.parent_id, c.position, c.title, c.type, c.status, c.revision,
+	                m.valid_at, m.invalid_at, m.created_at, m.expired_at, m.class, m.origin, m.confidence,
+	                m.session_id, m.run_id, m.event_seq, m.natural_key
+	           FROM chunks c JOIN chunk_memory_meta m ON m.chunk_id = c.id`
+	if len(where) > 0 {
+		stmt += " WHERE " + strings.Join(where, " AND ")
+	}
+	// Over-fetch by one to detect truncation without a second COUNT round trip.
+	stmt += " ORDER BY m.created_at DESC LIMIT ?"
+	args = append(args, limit+1)
+
+	res, err := d.query(ctx, key, stmt, args...)
+	if err != nil {
+		return errResult("list_facts: " + err.Error()), nil
+	}
+	truncated := len(res.Rows) > limit
+	rows := res.Rows
+	if truncated {
+		rows = rows[:limit]
+	}
+
+	facts := make([]map[string]any, 0, len(rows))
+	for _, r := range rows {
+		// Scan the m.* columns back into a chunkMetaRow so the per-fact `entity`
+		// block is byte-identical to get_chunk's — one formatter, no drift.
+		meta := chunkMetaRow{
+			ValidAt: asInt64Ptr(r[8]), InvalidAt: asInt64Ptr(r[9]),
+			CreatedAt: asInt64Ptr(r[10]), ExpiredAt: asInt64Ptr(r[11]),
+			Class: asStr(r[12]), Origin: asStr(r[13]), Confidence: asFloat64Ptr(r[14]),
+			SessionID: asStr(r[15]), RunID: asStr(r[16]), EventSeq: asInt64Ptr(r[17]),
+			NaturalKey: asStr(r[18]),
+		}
+		fact := map[string]any{
+			"id":          asStr(r[0]),
+			"document_id": asStr(r[1]),
+			"position":    asInt(r[3]),
+			"title":       asStr(r[4]),
+			"revision":    asInt(r[7]),
+			"entity":      chunkMetaToJSON(meta),
+		}
+		if pid := asStr(r[2]); pid != "" {
+			fact["parent_id"] = pid
+		}
+		if typ := asStr(r[5]); typ != "" {
+			fact["type"] = typ
+		}
+		if status := asStr(r[6]); status != "" {
+			fact["status"] = status
+		}
+		facts = append(facts, fact)
+	}
+	return okJSON(map[string]any{"facts": facts, "count": len(facts), "truncated": truncated})
+}
+
 // writeChunkMeta upserts the sidecar row, PRESERVING every field the caller did not
 // supply.
 //

--- a/internal/tools/builtin/document_facts_test.go
+++ b/internal/tools/builtin/document_facts_test.go
@@ -1,0 +1,216 @@
+package builtin
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// decodeUseNumber re-parses a tool result with json.Number so a unix-nanos
+// timestamp survives the check: default map[string]any decoding lands large
+// int64s in a float64, which loses precision above 2^53 (~9e15) — and unix-nanos
+// are ~1.7e18, so an exact == on the float form would fail even on correct code.
+func decodeUseNumber(t *testing.T, s string) map[string]any {
+	t.Helper()
+	dec := json.NewDecoder(strings.NewReader(s))
+	dec.UseNumber()
+	var m map[string]any
+	if err := dec.Decode(&m); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return m
+}
+
+func numInt64(t *testing.T, v any) int64 {
+	t.Helper()
+	n, ok := v.(json.Number)
+	if !ok {
+		t.Fatalf("value %v (%T) is not a json.Number", v, v)
+	}
+	i, err := n.Int64()
+	if err != nil {
+		t.Fatalf("json.Number %v to int64: %v", n, err)
+	}
+	return i
+}
+
+// TestGetChunk_ReturnsEntityBlockForFact: a chunk with a sidecar reads back with
+// a typed entity block; a plain chunk carries none — the read-side distinction
+// the memory view is built on.
+func TestGetChunk_ReturnsEntityBlockForFact(t *testing.T) {
+	d, ctx, docID, root := entityFixture(t)
+
+	validAt := time.Now().Add(-24 * time.Hour).UnixNano()
+	up, r := docExec(t, d, ctx, fmt.Sprintf(
+		`{"op":"upsert_chunk","scope":"user","document_id":"%s","parent_id":"%s",`+
+			`"title":"Ada Lovelace","natural_key":"person:ada-lovelace","type":"person",`+
+			`"class":"evidential","valid_at":%d}`, docID, root, validAt))
+	if r.IsError {
+		t.Fatalf("upsert: %s", r.Text)
+	}
+	factID := asStr(up["id"])
+
+	_, r = docExec(t, d, ctx, `{"op":"get_chunk","scope":"user","id":"`+factID+`"}`)
+	if r.IsError {
+		t.Fatalf("get_chunk: %s", r.Text)
+	}
+	got := decodeUseNumber(t, r.Text)
+	ent, ok := got["entity"].(map[string]any)
+	if !ok {
+		t.Fatalf("get_chunk on a fact has no entity block: %v", got)
+	}
+	if ent["class"] != "evidential" {
+		t.Errorf("entity.class = %v, want evidential", ent["class"])
+	}
+	if ent["natural_key"] != "person:ada-lovelace" {
+		t.Errorf("entity.natural_key = %v, want person:ada-lovelace", ent["natural_key"])
+	}
+	if ent["retired"] != false {
+		t.Errorf("entity.retired = %v, want false (a live fact)", ent["retired"])
+	}
+	if va := numInt64(t, ent["valid_at"]); va != validAt {
+		t.Errorf("entity.valid_at = %d, want %d (raw unix-nanos must round-trip losslessly)", va, validAt)
+	}
+
+	// A plain chunk (no sidecar) must NOT carry an entity block, or a reader
+	// cannot tell a fact from an ordinary section.
+	plain, r := docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+docID+
+		`","parent_id":"`+root+`","title":"plain section"}`)
+	if r.IsError {
+		t.Fatalf("create_chunk: %s", r.Text)
+	}
+	pg, r := docExec(t, d, ctx, `{"op":"get_chunk","scope":"user","id":"`+asStr(plain["id"])+`"}`)
+	if r.IsError {
+		t.Fatalf("get_chunk plain: %s", r.Text)
+	}
+	if _, has := pg["entity"]; has {
+		t.Errorf("a plain chunk must not carry an entity block: %v", pg["entity"])
+	}
+}
+
+// factIDByKey maps each returned fact's natural_key → id, and asserts every fact
+// carries an entity block (the whole point of list_facts).
+func factIDByKey(t *testing.T, out map[string]any) map[string]string {
+	t.Helper()
+	byKey := map[string]string{}
+	arr, _ := out["facts"].([]any)
+	for _, f := range arr {
+		m, _ := f.(map[string]any)
+		ent, ok := m["entity"].(map[string]any)
+		if !ok {
+			t.Errorf("a fact in list_facts is missing its entity block: %v", m)
+			continue
+		}
+		byKey[asStr(ent["natural_key"])] = asStr(m["id"])
+	}
+	return byKey
+}
+
+// TestListFacts_FiltersAndShape: list_facts returns only chunks that have a
+// sidecar (facts), narrows by type/class, and honors the retirement filter.
+func TestListFacts_FiltersAndShape(t *testing.T) {
+	d, ctx, docID, root := entityFixture(t)
+
+	mkFact := func(key, title, typ, class string) string {
+		t.Helper()
+		out, r := docExec(t, d, ctx, fmt.Sprintf(
+			`{"op":"upsert_chunk","scope":"user","document_id":"%s","parent_id":"%s",`+
+				`"title":"%s","natural_key":"%s","type":"%s","class":"%s"}`,
+			docID, root, title, key, typ, class))
+		if r.IsError {
+			t.Fatalf("upsert %s: %s", key, r.Text)
+		}
+		return asStr(out["id"])
+	}
+
+	aID := mkFact("person:ada", "Ada", "person", "derived")
+	mkFact("place:london", "London", "place", "evidential")
+	// A plain chunk (no sidecar) must never appear in list_facts.
+	plain, r := docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+docID+
+		`","parent_id":"`+root+`","title":"just a section"}`)
+	if r.IsError {
+		t.Fatalf("create_chunk: %s", r.Text)
+	}
+	plainID := asStr(plain["id"])
+
+	// No filter → both facts, never the plain chunk.
+	all, r := docExec(t, d, ctx, `{"op":"list_facts","scope":"user"}`)
+	if r.IsError {
+		t.Fatalf("list_facts: %s", r.Text)
+	}
+	byKey := factIDByKey(t, all)
+	if len(byKey) != 2 {
+		t.Errorf("list_facts returned %d facts, want 2 (the plain chunk must be excluded): %v", len(byKey), all["facts"])
+	}
+	for _, id := range byKey {
+		if id == plainID {
+			t.Errorf("list_facts returned the plain chunk %s — it has no sidecar and is not a fact", plainID)
+		}
+	}
+	if _, ok := byKey["person:ada"]; !ok {
+		t.Errorf("list_facts is missing the person fact: %v", all["facts"])
+	}
+
+	// type filter narrows to one.
+	byType, r := docExec(t, d, ctx, `{"op":"list_facts","scope":"user","type":"person"}`)
+	if r.IsError {
+		t.Fatalf("list_facts type: %s", r.Text)
+	}
+	if k := factIDByKey(t, byType); len(k) != 1 || k["person:ada"] == "" {
+		t.Errorf("type=person did not narrow to the one person fact: %v", byType["facts"])
+	}
+
+	// class filter narrows to the other.
+	byClass, r := docExec(t, d, ctx, `{"op":"list_facts","scope":"user","class":"evidential"}`)
+	if r.IsError {
+		t.Fatalf("list_facts class: %s", r.Text)
+	}
+	if k := factIDByKey(t, byClass); len(k) != 1 || k["place:london"] == "" {
+		t.Errorf("class=evidential did not narrow to the one evidential fact: %v", byClass["facts"])
+	}
+
+	// An unknown class is refused, naming the valid set.
+	if _, r := docExec(t, d, ctx, `{"op":"list_facts","scope":"user","class":"permanent"}`); !r.IsError ||
+		!strings.Contains(r.Text, "derived") {
+		t.Errorf("an unknown class must be refused naming the valid set: %q", r.Text)
+	}
+
+	// Retire the person fact: a replacement supersedes it.
+	cID := mkFact("person:ada-corrected", "Ada Lovelace", "person", "derived")
+	if _, r := docExec(t, d, ctx, `{"op":"supersede_chunk","scope":"user","id":"`+cID+
+		`","supersedes_id":"`+aID+`"}`); r.IsError {
+		t.Fatalf("supersede: %s", r.Text)
+	}
+
+	// Default list excludes the retired fact.
+	def, r := docExec(t, d, ctx, `{"op":"list_facts","scope":"user"}`)
+	if r.IsError {
+		t.Fatalf("list_facts default: %s", r.Text)
+	}
+	if k := factIDByKey(t, def); k["person:ada"] != "" {
+		t.Errorf("a superseded fact must be excluded by default: %v", def["facts"])
+	} else if k["person:ada-corrected"] == "" {
+		t.Errorf("the replacement fact should be current: %v", def["facts"])
+	}
+
+	// include_retired brings it back.
+	withRetired, r := docExec(t, d, ctx, `{"op":"list_facts","scope":"user","include_retired":true}`)
+	if r.IsError {
+		t.Fatalf("list_facts include_retired: %s", r.Text)
+	}
+	k := factIDByKey(t, withRetired)
+	if k["person:ada"] == "" {
+		t.Errorf("include_retired must return the superseded fact: %v", withRetired["facts"])
+	}
+	// The retired fact's entity block must SAY it is retired.
+	dec := decodeUseNumber(t, r.Text)
+	for _, f := range dec["facts"].([]any) {
+		m := f.(map[string]any)
+		ent := m["entity"].(map[string]any)
+		if asStr(ent["natural_key"]) == "person:ada" && ent["retired"] != true {
+			t.Errorf("the superseded fact's entity.retired = %v, want true", ent["retired"])
+		}
+	}
+}


### PR DESCRIPTION
## Why

loomcycle has a rich memory stack — k/v Vector Memory plus the entity-tier "fact" (a Document chunk + a `chunk_memory_meta` bi-temporal/provenance sidecar) — but a **human** can't use most of it. The only memory UI is an admin-only k/v console: the bi-temporal facts are invisible, and there is no way to search memory off-run (semantic `search`/`recall` live only inside the Memory tool, which needs a run context). This is the backend that a shareable memory-view surface (fact viewer + manual semantic search, shared with loomboard) will sit on. It is the memory analog of the document-structure + explorer-viewer work.

This is **phase 1 of 4** (backend only). Later phases: the access re-gate (tenant operators), the SDK, and the `@loomcycle/memory-view` component.

## What

Three additive backend changes — no wire/proto churn, no gRPC changes (matches the HTTP-only posture of the existing `/v1/_memory/*` admin surface):

1. **`get_chunk` returns an `entity` block for facts** — when a chunk has a `chunk_memory_meta` sidecar, `get_chunk` now surfaces it (two time axes, class, confidence, provenance, natural_key, and a `retired` flag). `retired` keys on `expired_at` (system-time retirement — the supersede path sets it), not a future world-time `invalid_at`. Without this, a fact and a plain chunk are indistinguishable on read.
2. **`list_facts` op (Document tool)** — a browse surface returning the scope's facts (chunks that *have* a sidecar — an INNER JOIN is what makes "fact" mean "has a sidecar") filtered by `type` / `class` / `document_id` / `as_of` / `include_retired`, newest first, metadata only (no bodies — the viewer fetches a body via `get_chunk` on click, like `graph_recall`). Reuses `graphTemporalClause` so "currently true" means the same thing on both surfaces, and the shared `chunkMetaToJSON` formatter so a fact's `entity` block is byte-identical to `get_chunk`'s. No new `docInput` fields.
3. **`POST /v1/_memory/search`** — an off-run **unified** semantic search: it runs the in-process memory backend with an **empty key prefix**, so one query spans BOTH plain k/v entries and document-chunk bodies (`doc.chunk:<id>`, which `writeBody` persists to the k/v plane alongside the embedding). Each hit is tagged `kind: "memory" | "document"`; a document hit also carries `chunk_id` so a viewer can fetch its entity block via `get_chunk`. Admin-only in this phase (falls through to the `/v1/_*` → `ScopeAdmin` catch-all); a later phase re-gates the family to the tenant axis.

### Security note — tenant stamping

The in-process backend resolves the tenant from `RunIdentity` only, which is absent off-run. The handler therefore stamps the authenticated principal's tenant (`tenantFromCtx`, caller/config-authoritative — never a request-body field) onto the context before searching. Without it the search would run at the shared `""` tenant and could return another tenant's rows. `TestMemorySearch_TenantIsolation` is a regression that seeds the *same* `(scope, scope_id, key)` under two tenants and proves a search as A returns only A's row — it fails if the stamp is removed.

## Tested

- `go test ./...` green (87 packages, race detector); `go build -o bin/loomcycle ./cmd/loomcycle`; `gofmt`/`go vet` clean.
- New tests (each verified to fail on the unfixed code via `cp` backup/restore):
  - `TestGetChunk_ReturnsEntityBlockForFact` — a fact carries `entity`; a plain chunk carries none.
  - `TestListFacts_FiltersAndShape` — only sidecar-bearing chunks returned; `type`/`class` narrow; unknown class refused; superseded fact excluded by default, returned + marked `retired:true` with `include_retired:true`.
  - `TestMemorySearch_UnifiedKvAndDocChunk` — one search returns both a `kind:"memory"` and a `kind:"document"` (with `chunk_id`) hit.
  - `TestMemorySearch_TenantIsolation` — a search as A returns only A's rows (fails without the RunIdentity stamp).
  - `TestMemorySearch_MissingQuery` / `TestMemorySearch_InvalidScope` — the 400 paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
