### PR TITLE
fix(document): an uncaptioned image could never be embedded

### DIFF
--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -753,16 +753,18 @@ func (d *Document) embedBody(ctx context.Context, tenant string, mscope store.Me
 	if d.Embedder == nil {
 		return
 	}
-	text := strings.TrimSpace(body)
-	if text == "" {
-		return
-	}
+	// DERIVE THE TEXT FIRST, THEN CHECK IT — never guard on the raw body. An earlier
+	// version returned early on an empty body before this switch ran, which made an
+	// UNCAPTIONED image permanently unsearchable: its body is empty by definition, so
+	// the generated description was never consulted no matter how many times a
+	// describe pass wrote one. The body is only one of the sources here; for an image
+	// it may not be a source at all.
+	var text string
 	switch chunkType {
 	case "image":
-		// The body IS the caption (export renders it as the alt text). The
-		// generated description is added by the describe pass, which re-embeds —
-		// it is not available here, and waiting for it would leave every image
-		// unsearchable until an operator sweeps.
+		// The body is the CAPTION (export renders it as the alt text) and the
+		// description comes from the asset row, so an image with neither is what
+		// yields "" — not an image with no caption.
 		text = imageEmbedText(body, d.assetDescription(ctx, key, chunkID))
 	case "mermaid":
 		text = mermaidEmbedText(body)
@@ -775,10 +777,14 @@ func (d *Document) embedBody(ctx context.Context, tenant string, mscope store.Me
 				return
 			}
 			text = mermaidEmbedText(src)
+		} else {
+			text = strings.TrimSpace(body)
 		}
 	}
-	// A diagram with no extractable label embeds nothing rather than embedding
-	// punctuation: a vector built from syntax can only produce false matches.
+	// Nothing to index: an empty prose body, a diagram with no extractable label, or
+	// an image with neither caption nor description. Embedding punctuation — or a
+	// placeholder — is worse than embedding nothing, because a row that exists ranks
+	// against every query.
 	if text == "" {
 		return
 	}

--- a/internal/tools/builtin/document_image_test.go
+++ b/internal/tools/builtin/document_image_test.go
@@ -171,3 +171,64 @@ func TestAssetDescription_MissingRowIsEmptyNotAnError(t *testing.T) {
 		t.Errorf("want \"\" for a chunk with no asset, got %q", got)
 	}
 }
+
+// TestEmbedBody_UncaptionedImageStillEmbedsItsDescription is the regression test for
+// a bug found on the live deployment, after the describe pass reported success.
+//
+// embedBody guarded on the RAW body — `if strings.TrimSpace(body) == "" { return }`
+// — BEFORE the per-type switch. An image's body is its caption, so an UNCAPTIONED
+// image returned early and its generated description was never consulted. The
+// describe pass then persisted a description, reported described=2, and the images
+// stayed unsearchable: `get_asset` showed a description, the sweep showed success,
+// and the candidate count never moved. Correct-looking from every surface.
+//
+// Both pre-existing image tests used a CAPTIONED chunk, which is why the case went
+// uncovered — and an uncaptioned image is the common one for an uploaded asset.
+//
+// FAIL-BEFORE: restoring the raw-body guard ahead of the switch makes this embed
+// nothing at all.
+func TestEmbedBody_UncaptionedImageStillEmbedsItsDescription(t *testing.T) {
+	d, vs, ctx := mermaidDocFixture(t, "image", "five", "round", "characters", "circuit", "board")
+
+	res, _ := d.Execute(ctx, json.RawMessage(`{"op":"create_document","title":"Logos"}`))
+	docID := resultField(res, "document_id")
+	// NO caption — exactly the shape of an uploaded asset.
+	body, _ := json.Marshal(map[string]any{
+		"op": "create_chunk", "document_id": docID, "title": "Logo",
+		"type": "image", "body": "",
+	})
+	res, err := d.Execute(ctx, body)
+	if err != nil || res.IsError {
+		t.Fatalf("create_chunk: %v %s", err, res.Text)
+	}
+	chunkID := resultField(res, "id")
+
+	png, _ := base64.StdEncoding.DecodeString(
+		"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFAAH/q842iQAAAABJRU5ErkJggg==")
+	sa, _ := json.Marshal(map[string]any{
+		"op": "set_asset", "id": chunkID,
+		"media_type": "image/png", "data": base64.StdEncoding.EncodeToString(png),
+	})
+	if r, err := d.Execute(ctx, sa); err != nil || r.IsError {
+		t.Fatalf("set_asset: %v %s", err, r.Text)
+	}
+
+	// Precondition: with neither caption nor description there is nothing to index.
+	if got := embeddedTextFor(t, vs, chunkID); got != "" {
+		t.Fatalf("precondition: an image with no caption and no description embedded %q", got)
+	}
+
+	// The describe pass persists a description and re-embeds.
+	if err := d.SetAssetDescription(ctx, "user", chunkID, "five round characters on a circuit board"); err != nil {
+		t.Fatalf("SetAssetDescription: %v", err)
+	}
+	got := embeddedTextFor(t, vs, chunkID)
+	if got == "" {
+		t.Fatal("an uncaptioned image was NOT embedded after a description was persisted — " +
+			"the description sits in the database while the image stays unsearchable, and " +
+			"every surface an operator checks reports success")
+	}
+	if !strings.Contains(got, "five round characters") {
+		t.Errorf("embed text does not carry the description: %q", got)
+	}
+}


### PR DESCRIPTION
Found by verifying the v1.46.1 deploy sweeps rather than trusting their output.

## What happened

The describe pass reported complete success — `candidates=2 described=2 empty=0 failed=0`, with two accurate descriptions persisted (472 and 379 characters). The images were still **unsearchable**, and the backfill's candidate count never moved off 188.

## Why

`embedBody` guarded on the **raw body**, before the per-type switch:

```go
text := strings.TrimSpace(body)
if text == "" { return }          // <-- an image's body IS its caption
switch chunkType {
case "image":
    text = imageEmbedText(body, d.assetDescription(...))   // never reached
```

An image with **no caption** returned early, so its generated description was never consulted — no matter how many times a describe pass wrote one. The body is only *one* of the sources for an image, and may not be a source at all.

This is precisely the failure mode `SetAssetDescription`'s own comment warns about, reached by a different route than the one it guards:

> without it the description sits in the database, `get_asset` reports the image as described, and it is still unsearchable — a state that looks correct from every surface an operator would check

Which is exactly what happened. `get_asset` showed a description, the sweep showed success, the SQL row showed 472 characters — and nothing was indexed.

## Why the tests missed it

Both pre-existing image tests used a **captioned** chunk (`body: "the login screen"`), so `body` was non-empty and the guard never fired. An uncaptioned image is the *common* case for an uploaded asset — both real ones here have no caption.

Worth noting: `TestDescribeImages_DescriptionReachesTheSearchIndex` asserts the text reached the **embedder**, not that a vector was **stored**. That was enough to catch a missing re-embed call, but not enough to catch this — the embedder was never reached at all.

## Fix

Derive the text first, then check it. Never guard on the raw body. Prose and mermaid behaviour is unchanged: an empty prose body and a label-less diagram both still embed nothing.

## Tested

`TestEmbedBody_UncaptionedImageStillEmbedsItsDescription` creates an image chunk with an empty body, asserts nothing is embedded while it has neither caption nor description, then persists a description via `SetAssetDescription` and asserts the embedding carries it.

**Fail-before verified** — restoring the raw-body guard ahead of the switch embeds nothing. `go test ./...` clean.

## Remediation for a deployment already swept

No vision call needed — the descriptions are already persisted. Rewriting the chunk body (`update_chunk` with the same body) re-enters `embedBody` and indexes it. Re-running the describe pass also works but pays the model again.

Note that the **embedding backfill cannot fix this**: `embedTextForRow` reads the chunk-body envelope from the memory plane and has no view of `chunk_assets`, so an uncaptioned image is invisible to it. The describe-pass re-embed is the only path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8