### PR TITLE
docs(release): name the v1.47.0 release notes

### DIFF
--- a/REVISIONS.md
+++ b/REVISIONS.md
@@ -4,6 +4,28 @@ Per-version release notes from v0.4.0 onward. The current and immediately previo
 
 For the **public roadmap** (planned v0.8.16 through v1.0 work — Question tool, Pause / Resume / Snapshot, distribution, operator postures), see [`docs/PLAN.md`](docs/PLAN.md).
 
+## What's in v1.47.0
+
+**🔎 A human-facing memory view, and the last of the RFC BU sweep fixes.** Minor rather than a patch because RFC BV Phase 1 adds new surface: one HTTP endpoint and two Document ops. No schema change, no wire/proto change, no adapter change.
+
+**RFC BV Phase 1 — reading the memory plane like a human would.** The entity tier stores a fact as a chunk plus a `chunk_memory_meta` sidecar (bi-temporal timelines + provenance), but nothing could *read* that sidecar in a typed way: `get_chunk` returned a chunk with no way to tell a fact from a plain section, and nothing enumerated facts for a browse surface.
+
+- `get_chunk` now attaches an **`entity`** block when the chunk has a sidecar (omitted otherwise): raw unix-nanos timestamps, so the viewer formats them rather than the server guessing, and an always-present `retired` bool keyed on *system* time (`expired_at`) so a future world-time `invalid_at` is not misreported as retired.
+- **`list_facts`** browses the scope's facts newest-first, metadata only — the viewer fetches a body on click — filterable by type/class/document_id and using the same temporal filter `graph_recall` does. Its per-fact `entity` block reuses the same renderer, so the two surfaces cannot drift.
+- **`POST /v1/_memory/search`** is an off-run semantic search with an empty key prefix, so one query spans both plain k/v entries and document-chunk bodies — what answers "where did I record this" across the whole stack. Each hit is tagged `kind=memory` or `kind=document` (+`chunk_id`) so a document hit can be followed to `get_chunk`.
+
+  Security-critical detail: the in-process backend resolves the tenant from the *run* identity, and off-run there is none — so the handler stamps the authenticated principal's tenant before searching. Without it the search would run at the shared `""` tenant and could read another tenant's rows. `TestMemorySearch_TenantIsolation` fails if the stamp is removed.
+
+**An uncaptioned image could never be embedded.** Found by verifying the v1.46.1 deploy rather than trusting its output: the describe pass reported `described=2 failed=0` with two accurate descriptions persisted, and the images stayed unsearchable while the backfill's candidate count never moved.
+
+`embedBody` guarded on the **raw body** before the per-type switch — and an image's body *is* its caption, so an image with no caption returned early and its generated description was never consulted, no matter how many times a describe pass wrote one. The body is only one of the sources for an image, and may not be a source at all.
+
+This is the failure mode `SetAssetDescription`'s own comment warns about, reached by a different route: `get_asset` shows a description, the sweep reports success, the row holds 472 characters — and nothing is indexed. Correct-looking from every surface an operator would check. Both existing image tests used a *captioned* chunk, which is why it went uncovered, and an uncaptioned image is the common case for an uploaded asset. The fix derives the text first and checks it after; prose and diagram behaviour is unchanged.
+
+**Upgrade note.** If a describe pass already ran on v1.46.0/v1.46.1, its descriptions are persisted and need no second vision call — rewriting each image chunk's body re-enters the embed path and indexes it. The embedding backfill *cannot* do this: it reads the chunk-body envelope from the memory plane and has no view of `chunk_assets`, so an uncaptioned image is invisible to it.
+
+Adapters unchanged: `@loomcycle/client` 1.46.0, `loomcycle` (PyPI) 1.46.0, `@loomcycle/explorer` 0.6.0.
+
 ## What's in v1.46.1
 
 **🩹 Both v1.46.0 upgrade sweeps were broken in practice.** Patch release — no new surface, no schema change. Found by running the sweeps against a real deployment (154 documents, 3,143 chunks, 2 images); neither fault was visible from the unit tests, because each needs scale or a real model to appear.


### PR DESCRIPTION
Release prep. Notes only — no code, no version bumps beyond the tag.

## Why v1.47.0 and not v1.46.2

You asked for a subversion, and I'd have agreed if #948 were the only thing unreleased. But **#947 landed in parallel and adds new surface**:

- `POST /v1/_memory/search` — a new HTTP endpoint
- `list_facts` — a new Document op
- an `entity` block on `get_chunk`

Shipping a new endpoint under a patch version misreports it to every consumer reading semver, so I've named this **v1.47.0**. Happy to cut `v1.46.2` instead if you'd rather — say so and I'll adjust the notes before tagging. Nothing is tagged yet.

## What's in it

**RFC BV Phase 1 (#947)** — reading the memory plane like a human would. The entity tier stores a fact as a chunk plus a `chunk_memory_meta` sidecar, but nothing could read that sidecar in a typed way. Now `get_chunk` attaches an `entity` block, `list_facts` browses a scope's facts, and `/v1/_memory/search` spans both k/v entries and document-chunk bodies in one query so "where did I record this" has an answer.

The security-critical detail is worth surfacing in the notes: the in-process backend takes its tenant from the *run* identity, and off-run there is none — so the handler stamps the authenticated principal's tenant before searching. Without it the search runs at the shared `""` tenant and can read another tenant's rows. `TestMemorySearch_TenantIsolation` fails if the stamp is removed.

**#948** — the last RFC BU sweep fix. An uncaptioned image could never be embedded: `embedBody` guarded on the raw body before the per-type switch, and an image's body *is* its caption. Found by checking the candidate count after a "successful" describe pass rather than trusting its output.

## Upgrade note

If a describe pass already ran on v1.46.0/v1.46.1, its descriptions are persisted and need **no second vision call** — rewriting each image chunk's body re-enters the embed path and indexes it. The embedding backfill cannot do this: it reads the chunk-body envelope from the memory plane and has no view of `chunk_assets`.

## Adapters

Unchanged — no adapter code in either PR. `@loomcycle/client` 1.46.0, PyPI `loomcycle` 1.46.0, `@loomcycle/explorer` 0.6.0; their publishes will skip-but-green on this tag, which is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8