### PR TITLE
feat(memory): re-gate /v1/_memory/* to tenant operators

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -647,6 +647,26 @@ func requiredScopeFor(method, path string) string {
 	// can see + reap its own runs' resident children; ScopeAdmin also satisfies.
 	case path == "/v1/_resident" || strings.HasPrefix(path, "/v1/_resident/"):
 		return auth.ScopeTenant
+	// repair-tenant rewrites memory rows across EVERY scope in one statement to
+	// re-stamp the legacy "" partition — a cross-tenant bulk rewrite that is not a
+	// tenant operator's authority even over its own tenant. It STAYS operator-admin.
+	// MUST precede the memory-family case below, which it would otherwise match on
+	// the /v1/_memory/ prefix.
+	case path == "/v1/_memory/repair-tenant":
+		return auth.ScopeAdmin
+	// The memory browse / search / embed-admin family (RFC BV). memory rows carry a
+	// tenant_id (RFC BL added the tenant axis), and every handler already sources
+	// the tenant from the authenticated principal (tenantFromCtx /
+	// principalTenantScope), never the wire — so a substrate:tenant operator is
+	// confined to its own tenant's memory and admin keeps its view. The routes were
+	// pinned to ScopeAdmin by the /v1/_* catch-all below, so a tenant token 403'd
+	// before the tenant-scoped handler ran (the same gap #575/#577 fixed for the
+	// Library). Grant ScopeTenant so the reads/writes are reachable; the handlers
+	// still confine. ScopeAdmin also satisfies. Note /v1/_memorybackenddef (a def
+	// family, already ScopeTenant via isTenantConfinedDefPath) does NOT match this
+	// prefix — it has no slash after "memory".
+	case strings.HasPrefix(path, "/v1/_memory/"):
+		return auth.ScopeTenant
 	// Everything else under /v1/_* is OPERATOR-admin: token minting
 	// (_operatortokendef), runtime admin (pause/resume/state/snapshots/metrics),
 	// resolver, cross-tenant user focus.

--- a/internal/api/http/auth_principal_test.go
+++ b/internal/api/http/auth_principal_test.go
@@ -263,6 +263,27 @@ func TestRequiredScopeFor(t *testing.T) {
 		// Configured model aliases — tenant-readable so a tenant operator's UI
 		// can offer aliases in a model picker (non-secret global config).
 		{"GET", "/v1/_models", auth.ScopeTenant},
+		// RFC BV: the memory browse/search/embed-admin family is tenant-confined
+		// (memory rows carry a tenant_id; every handler sources the tenant from the
+		// principal). The def family /v1/_memorybackenddef is ScopeTenant via a
+		// DIFFERENT path (isTenantConfinedDefPath) and must not be swept up here.
+		{"GET", "/v1/_memory/scopes", auth.ScopeTenant},
+		{"GET", "/v1/_memory/scopes/user", auth.ScopeTenant},
+		{"GET", "/v1/_memory/scopes/user/alice/keys", auth.ScopeTenant},
+		{"GET", "/v1/_memory/scopes/user/alice/keys/voice", auth.ScopeTenant},
+		{"PUT", "/v1/_memory/scopes/user/alice/keys/voice", auth.ScopeTenant},
+		{"DELETE", "/v1/_memory/scopes/user/alice/keys/voice", auth.ScopeTenant},
+		{"GET", "/v1/_memory/embed_stats", auth.ScopeTenant},
+		{"POST", "/v1/_memory/reembed", auth.ScopeTenant},
+		{"POST", "/v1/_memory/backfill_embeddings", auth.ScopeTenant},
+		{"POST", "/v1/_memory/search", auth.ScopeTenant},
+		// repair-tenant is a cross-tenant bulk rewrite — STAYS operator-admin even
+		// though it matches the /v1/_memory/ prefix (it is excluded first).
+		{"POST", "/v1/_memory/repair-tenant", auth.ScopeAdmin},
+		// The MemoryBackendDef def family stays tenant via isTenantConfinedDefPath,
+		// NOT via the /v1/_memory/ prefix (no slash after "memory").
+		{"POST", "/v1/_memorybackenddef", auth.ScopeTenant},
+		{"GET", "/v1/_memorybackenddef/names", auth.ScopeTenant},
 		// RFC AF: hooks are tenant-confined now that the registry is
 		// tenant-isolated (stamp on register, tenant-filtered Match, scoped
 		// List/Delete). substrate:admin still satisfies.

--- a/internal/api/http/memory_test.go
+++ b/internal/api/http/memory_test.go
@@ -101,6 +101,50 @@ func TestHandleMemory_TenantIsolation(t *testing.T) {
 	}
 }
 
+// TestHandleMemory_TenantOperatorConfined proves the RFC BV route re-gate is
+// safe: a NON-admin substrate:tenant operator — the principal the re-gate newly
+// admits — reaching a memory route sees ONLY its own tenant's rows, and a
+// ?tenant= naming another tenant is IGNORED (the handlers source the tenant from
+// the principal via tenantFromCtx, never the wire). This is the invariant the
+// re-gate rests on: opening the gate to ScopeTenant did not open cross-tenant
+// reads. The prior TenantIsolation test used ADMIN principals; this covers the
+// tenant-operator path the re-gate actually enables.
+func TestHandleMemory_TenantOperatorConfined(t *testing.T) {
+	s := memoryAdminFixture(t)
+	ctx := t.Context()
+	// The same (scope, scope_id, key) under two tenants — the strongest case: a
+	// leak would surface the other tenant's value at an identical address.
+	if err := s.store.MemorySet(ctx, "acme", store.MemoryScopeUser, "carol", "voice", []byte(`"acme-voice"`), 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.store.MemorySet(ctx, "other", store.MemoryScopeUser, "carol", "voice", []byte(`"other-voice"`), 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// A tenant operator: ScopeTenant, NOT ScopeAdmin, confined to "acme".
+	op := func(r *http.Request) *http.Request {
+		return r.WithContext(auth.WithPrincipal(r.Context(), auth.Principal{
+			TenantID: "acme", Subject: "op", Scopes: []string{auth.ScopeTenant},
+		}))
+	}
+	// List carol's keys AND try to escape confinement via ?tenant=other.
+	req := httptest.NewRequest("GET", "/v1/_memory/scopes/user/carol/keys?tenant=other", nil)
+	req.SetPathValue("scope", "user")
+	req.SetPathValue("scope_id", "carol")
+	rec := httptest.NewRecorder()
+	s.handleListMemoryEntries(rec, op(req))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "acme-voice") {
+		t.Errorf("operator did not see its own tenant's row: %s", body)
+	}
+	if strings.Contains(body, "other-voice") {
+		t.Errorf("tenant operator escaped confinement via ?tenant=other — saw another tenant's row: %s", body)
+	}
+}
+
 func TestHandleListMemoryScopes_ReturnsConstantSet(t *testing.T) {
 	s := memoryAdminFixture(t)
 	rec := httptest.NewRecorder()

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -45,11 +45,13 @@ const SIDEBAR_KEY = "loomcycle.sidebar.collapsed";
 // library (#575/#577), integrations + schedules (the *def/names + scheduledef
 // def plane, #576 / isTenantConfinedDefPath), volumes (/v1/_volumes), paths
 // (/v1/_path), interrupts (/v1/users/{id}/interrupts — runs:read, tenantImplied).
-// channels (/v1/_channels) and memory (/v1/_memory/*) DELIBERATELY stay "admin":
-// their store rows carry no tenant column, so the routes are pinned to ScopeAdmin
-// (the /v1/_* catch-all) — a tenant token would 403. This narrows RFC AS §4's
-// channels+memory="tenant" to match the shipped backend; revisit if those
-// primitives gain a tenant axis (a schema migration, its own RFC).
+// memory (/v1/_memory/*) is "tenant": RFC BL gave memory rows a tenant_id, every
+// handler sources the tenant from the principal (a tenant operator sees only its
+// own tenant's memory), and RFC BV re-gated the routes to ScopeTenant — so the
+// item lights up for a tenant operator. channels (/v1/_channels) DELIBERATELY
+// stays "admin": its store rows still carry no tenant column, so the routes are
+// pinned to ScopeAdmin (the /v1/_* catch-all) and a tenant token would 403.
+// Revisit channels when it gains a tenant axis (a schema migration, its own RFC).
 type Visibility = "all" | "tenant" | "admin";
 interface NavItem {
   to: string;
@@ -68,7 +70,7 @@ const NAV_ITEMS: NavItem[] = [
   { to: "/schedules", label: "schedules", Icon: CalendarClock, vis: "tenant" },
   { to: "/teams", label: "teams", Icon: Workflow, vis: "tenant" },
   { to: "/interrupts", label: "interrupts", Icon: Bell, vis: "tenant" },
-  { to: "/memory", label: "memory", Icon: Brain, vis: "admin" },
+  { to: "/memory", label: "memory", Icon: Brain, vis: "tenant" },
   { to: "/snapshots", label: "snapshots", Icon: Camera, vis: "admin" },
   // audit is tenant-visible (RFC AS): handleListEvents tenant-scopes the result
   // via the event's owning session, so a tenant sees only its own events.


### PR DESCRIPTION
## Why

Phase 1 (#947) added the memory fact/entity reads and an off-run unified search, but they — and the whole existing `/v1/_memory/*` admin family — sit behind the `/v1/_*` → `ScopeAdmin` catch-all in `requiredScopeFor`. So a `substrate:tenant` operator **403s at the gate** and can't reach its own tenant's memory at all, even though the handlers already tenant-confine. This is the same gap #575/#577 fixed for the Library: the handler confines, but the route never lets a tenant token reach it.

The stale rationale for keeping memory admin-only was "its store rows carry no tenant column" — but **RFC BL gave memory rows a `tenant_id`**, and every memory handler already sources the tenant from the authenticated principal (`tenantFromCtx` / `principalTenantScope`), never the wire. So the confinement is already in place; only the route gate was holding tenant operators out.

This is **phase 2 of 4** (the access re-gate). Phases 3–4: the SDK, then the `@loomcycle/memory-view` component.

## What

- **Re-gate the routes** — `requiredScopeFor` now returns `ScopeTenant` for `/v1/_memory/*` (browse / get / put / delete / embed_stats / reembed / backfill / search). `ScopeAdmin` still satisfies it, so admin is unchanged. The handlers still confine a non-admin to its own tenant.
- **`repair-tenant` stays operator-admin** — it rewrites rows across *every* scope in one statement to re-stamp the legacy `""` partition, a cross-tenant bulk rewrite that is not a tenant operator's authority. An explicit case (placed before the family prefix, which it would otherwise match) keeps it `ScopeAdmin`.
- **`/v1/_memorybackenddef` is untouched** — it's a def family, already `ScopeTenant` via `isTenantConfinedDefPath`, and does not match the `/v1/_memory/` prefix (no slash after "memory"). Asserted by a regression row.
- **Web nav** — the `memory` nav item flips `admin` → `tenant` and the stale comment is corrected (channels stays `admin`; it still has no tenant column). The existing `MemoryView` page needs no change — all its calls are now tenant-confined server-side.

### Scope decision

This PR deliberately does **not** change the handlers themselves — `tenantFromCtx` already confines non-admins and preserves admin's current behavior, so opening the gate is the whole security-relevant change (minimal, auditable). Admin `?tenant=` cross-tenant *focus* for the read/write handlers is deferred (backfill already has it); it can come with the P4 UI tenant picker if wanted.

## Tested

- `go build`; full `internal/api/http` suite green (`go test ./internal/api/http/`, race).
- `TestRequiredScopeFor` gains the memory family — **verified it fails on the pre-change code** (the catch-all returned `substrate:admin` for `/v1/_memory/scopes`, `/reembed`, `/search`, …), passes after. Restored via `cp` backup, never `git checkout`.
- `TestHandleMemory_TenantOperatorConfined` (new) — a non-admin `substrate:tenant` operator, seeded with the *same* `(scope, scope_id, key)` under two tenants, sees only its own tenant's row and a `?tenant=other` is ignored. This is the invariant the re-gate rests on.
- Existing guards preserved: `TestHandleMemory_TenantIsolation` (admin cross-tenant 404) and the `repair-tenant → ScopeAdmin` assertion in `memory_orphan_repair_test.go`.
- Web: the nav change is a single valid `Visibility` literal + comment; CI's web-ui job rebuilds the SPA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
