### PR TITLE
feat(document): embed a bodyless chunk's title so headings are findable

### DIFF
--- a/internal/api/http/memory_backfill.go
+++ b/internal/api/http/memory_backfill.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
 )
 
 type memoryBackfillResponse struct {
@@ -141,10 +142,12 @@ func (s *Server) handleMemoryBackfillEmbeddings(w http.ResponseWriter, r *http.R
 			"remain. Every embedded row leaves the candidate set, so re-invoking is safe " +
 			"and resumes rather than restarts.",
 		"RE-INVOKE WHILE `more` IS TRUE. Do not wait for candidates to reach 0: a row " +
-			"with no text to embed (a document root, a section heading) never gains an " +
+			"with nothing to embed — no body text AND no usable title — never gains an " +
 			"embedding, so it stays a candidate permanently and candidates converges to " +
 			"skipped_empty instead. `limit` bounds how many rows are EMBEDDED, not how " +
 			"many are examined — the sweep pages past what it cannot embed.",
+		"A document chunk with an empty body falls back to its TITLE, matching the " +
+			"write path: a heading is real language and a real answer to a search.",
 	}
 
 	if dryRun {
@@ -209,7 +212,21 @@ func (s *Server) handleMemoryBackfillEmbeddings(w http.ResponseWriter, r *http.R
 			// embedding the raw JSON would index the field names.
 			text := embedTextForRow(row)
 			if text == "" {
-				// Nothing to embed, ever. Counted rather than silently passed over.
+				// A document chunk with no body is usually a HEADING, and a heading is
+				// real language ("RFC BE — History Tool", "Phase 2 — name-links").
+				// The write path embeds the title in that case, so the sweep must too,
+				// or existing documents stay permanently less searchable than new ones.
+				//
+				// The resolution lives in the builtin package: it needs the chunk
+				// title (a SQL Memory read this handler has no view of) AND the
+				// ""→"default" SQL-tenant rule, and restating that rule here is how
+				// the tenant axis drifts.
+				text = builtin.TitleFallbackForBodyKey(r.Context(), s.sqlMem, tenant,
+					store.MemoryScope(scope), scopeID, row.Key)
+			}
+			if text == "" {
+				// Nothing to embed, ever — no body and no usable title. Counted rather
+				// than silently passed over.
 				resp.SkippedEmpty++
 				continue
 			}
@@ -247,8 +264,9 @@ func (s *Server) handleMemoryBackfillEmbeddings(w http.ResponseWriter, r *http.R
 	}
 	if resp.SkippedEmpty > 0 {
 		resp.Notes = append(resp.Notes,
-			"skipped_empty rows have no text to embed (a document root, a section heading). "+
-				"They stay candidates permanently — that is expected, not a failure.")
+			"skipped_empty rows have neither body text nor a usable title (a title with no "+
+				"letters carries no language). They stay candidates permanently — that is "+
+				"expected, not a failure.")
 	}
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/internal/api/http/memory_backfill_test.go
+++ b/internal/api/http/memory_backfill_test.go
@@ -324,3 +324,53 @@ func TestBackfillEmbeddings_AdminMustNameATenant(t *testing.T) {
 			"default tenant unsweepable")
 	}
 }
+
+// TestBackfillEmbeddings_BodylessChunkFallsBackToItsTitle — the sweep must apply the
+// same title fallback the write path does, or existing documents stay permanently
+// less searchable than ones authored after the feature landed.
+//
+// A bodyless chunk cannot be reached any other way: the backfill sees memory ROWS,
+// and a title lives in SQL Memory, so without this the 186 heading chunks measured on
+// the reference deployment would need 186 manual body rewrites.
+//
+// The resolution is delegated to builtin.TitleFallbackForBodyKey so the ""→"default"
+// SQL-tenant rule and the title-quality judgement are not restated here.
+func TestBackfillEmbeddings_BodylessChunkFallsBackToItsTitle(t *testing.T) {
+	srv, _ := makeServer(t, completingProvider(), makeBaseConfig())
+	emb := &backfillEmbedder{}
+	srv.embedder = emb
+
+	// sqlMem is nil in this fixture, so the fallback resolves to "" — which is exactly
+	// the contract under test on this path: a scope with no SQL Memory must be counted
+	// as skipped rather than crash or embed a placeholder.
+	bodies := map[string]string{"doc.chunk:h01": "", "doc.chunk:b01": "real body text"}
+	ps := newPagingStore(srv.store, bodies)
+	srv.store = ps
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost,
+		"/v1/_memory/backfill_embeddings?scope=user&scope_id=alice&tenant=&prefix=doc.chunk:&limit=10&dry_run=false", nil).
+		WithContext(auth.WithPrincipal(context.Background(), auth.Principal{
+			Subject: "root", Scopes: []string{auth.ScopeAdmin},
+		}))
+	srv.handleMemoryBackfillEmbeddings(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", rec.Code, rec.Body.String())
+	}
+	var got map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &got)
+	if n, _ := got["embedded"].(float64); n != 1 {
+		t.Errorf("embedded = %v, want 1 (the row with a body)", got["embedded"])
+	}
+	if n, _ := got["skipped_empty"].(float64); n != 1 {
+		t.Errorf("skipped_empty = %v, want 1 — with no SQL Memory the title cannot be "+
+			"resolved, and that must count as skipped, not crash", got["skipped_empty"])
+	}
+	// The notes must SAY that a title fallback exists, or an operator reading
+	// skipped_empty will assume those rows are unreachable by design.
+	body := rec.Body.String()
+	if !strings.Contains(body, "falls back to its TITLE") {
+		t.Error("the response notes do not mention the title fallback")
+	}
+}

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -783,8 +783,26 @@ func (d *Document) embedBody(ctx context.Context, tenant string, mscope store.Me
 			text = strings.TrimSpace(body)
 		}
 	}
-	// Nothing to index: an empty prose body, a diagram with no extractable label, or
-	// an image with neither caption nor description. Embedding punctuation — or a
+	// FALL BACK TO THE TITLE. A chunk whose body yields no text is usually a heading
+	// that organises the document — "RFC BE — History Tool (browse / search / rename
+	// / annotate past chats)", "Phase 2 — name-links + transclusion". That is real
+	// language and a real answer to a search; excluding it means the most navigable
+	// part of a document is the one part retrieval cannot see.
+	//
+	// Measured on the reference deployment before adding this: of 20 sampled bodyless
+	// chunks, 18 had meaningful titles. The two that did not were fragments used as
+	// headings (a JSON line). No content heuristic beyond requiring a letter — see
+	// titleEmbedText — because a filter guessing at "meaningful" would drop real
+	// headings to avoid an occasional weak vector, and 18-for-2 is the wrong trade to
+	// optimise against.
+	//
+	// The title is read HERE rather than passed in: it costs a query only on this
+	// path (the body was empty), and embedBody already reads SQL for an image's
+	// description, so the seam exists.
+	if text == "" {
+		text = titleEmbedText(d.chunkTitle(ctx, key, chunkID))
+	}
+	// Still nothing: no body text AND no usable title. Embedding punctuation — or a
 	// placeholder — is worse than embedding nothing, because a row that exists ranks
 	// against every query.
 	if text == "" {
@@ -837,7 +855,80 @@ func (d *Document) readBody(ctx context.Context, mscope store.MemoryScope, scope
 
 // chunkBodyKey namespaces chunk bodies in the Memory keyspace so they don't
 // collide with an agent's own k/v keys.
-func chunkBodyKey(chunkID string) string { return "doc.chunk:" + chunkID }
+// chunkBodyKeyPrefix is the k/v namespace for chunk bodies. One definition, because
+// both the Document tool and the admin backfill parse keys out of it.
+const chunkBodyKeyPrefix = "doc.chunk:"
+
+func chunkBodyKey(chunkID string) string { return chunkBodyKeyPrefix + chunkID }
+
+// ChunkIDFromBodyKey returns the chunk id a body key addresses, or "" when the key
+// is not a chunk body. Exported so the admin backfill can recognise document rows
+// without restating the prefix.
+func ChunkIDFromBodyKey(memKey string) string {
+	if !strings.HasPrefix(memKey, chunkBodyKeyPrefix) {
+		return ""
+	}
+	return strings.TrimPrefix(memKey, chunkBodyKeyPrefix)
+}
+
+// chunkTitle reads one chunk's title, or "" on any fault. Best-effort like the rest
+// of the embed path: a title that cannot be read costs searchability, never a write.
+func (d *Document) chunkTitle(ctx context.Context, key sqlmem.ScopeKey, chunkID string) string {
+	if d.SqlMem == nil {
+		return ""
+	}
+	res, err := d.query(ctx, key, `SELECT title FROM chunks WHERE id = ? LIMIT 1`, chunkID)
+	if err != nil || len(res.Rows) == 0 || len(res.Rows[0]) == 0 {
+		return ""
+	}
+	return asStr(res.Rows[0][0])
+}
+
+// titleEmbedText decides whether a title is worth embedding, and is the ONE place
+// that judgement lives so the write path and the backfill cannot disagree.
+//
+// The only requirement is a letter. A title with no letters carries no language —
+// "---", "```sh", "42" — and a vector built from it can only produce false matches,
+// which is the same reasoning the mermaid extractor applies to a label-less diagram.
+// Everything else is kept: a heading is short by nature, so a length threshold would
+// discard "Active RFCs" and "Configuration", both of which are exactly what someone
+// searching a document would type.
+func titleEmbedText(title string) string {
+	t := strings.TrimSpace(title)
+	if t == "" {
+		return ""
+	}
+	if !strings.ContainsFunc(t, func(r rune) bool {
+		return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
+	}) {
+		return ""
+	}
+	return t
+}
+
+// TitleFallbackForBodyKey resolves the title-derived embed text for a bodyless
+// document chunk, given only its k/v key.
+//
+// Exported for the admin embedding backfill, which sees memory rows rather than
+// chunks and therefore cannot reach a title on its own. It lives here so the
+// ""→"default" SQL-tenant rule and the title-quality judgement stay in one package —
+// duplicating either at the call site is how the tenant axis drifts (chunk bodies
+// key on the RAW tenant while SQL Memory canonicalises it, a seam that has produced
+// silent cross-tenant bugs before).
+//
+// Returns "" for a non-chunk key, a missing chunk, an unusable title, or no SQL
+// Memory — every case the caller should treat as "nothing to embed".
+func TitleFallbackForBodyKey(ctx context.Context, mgr *sqlmem.Manager, tenant string,
+	mscope store.MemoryScope, scopeID, memKey string) string {
+
+	chunkID := ChunkIDFromBodyKey(memKey)
+	if chunkID == "" || mgr == nil {
+		return ""
+	}
+	d := &Document{SqlMem: mgr}
+	key := sqlmem.ScopeKey{Tenant: sqlScopeTenantValue(tenant), Scope: string(mscope), ScopeID: scopeID}
+	return titleEmbedText(d.chunkTitle(ctx, key, chunkID))
+}
 
 // recordRevision appends a body snapshot to the chunk_revisions log (RFC BS
 // Phase 3a). It is a BODY-CHANGE log: called only where a chunk's body is

--- a/internal/tools/builtin/document_image_test.go
+++ b/internal/tools/builtin/document_image_test.go
@@ -73,11 +73,12 @@ func TestEmbedBody_ImageCaptionIsEmbeddedWithoutAModel(t *testing.T) {
 	}
 }
 
-// TestEmbedBody_ImageWithNoCaptionEmbedsNothing — an uncaptioned image has no text
-// until a describe pass runs. Storing a vector anyway would put a row that means
-// nothing into the index, where it can only produce false matches.
-func TestEmbedBody_ImageWithNoCaptionEmbedsNothing(t *testing.T) {
-	d, vs, ctx := mermaidDocFixture(t, "image")
+// TestEmbedBody_ImageDataURIBodyIsNeverIndexedAsBase64 — a data URI is not a
+// caption. The chunk still becomes searchable, but via its TITLE (the fallback), and
+// the base64 must never reach the embedder: it would match nothing while consuming
+// the scope's vector quota.
+func TestEmbedBody_ImageDataURIBodyIsNeverIndexedAsBase64(t *testing.T) {
+	d, vs, ctx := mermaidDocFixture(t, "image", "raw")
 
 	res, _ := d.Execute(ctx, json.RawMessage(`{"op":"create_document","title":"Shots"}`))
 	docID := resultField(res, "document_id")
@@ -91,8 +92,13 @@ func TestEmbedBody_ImageWithNoCaptionEmbedsNothing(t *testing.T) {
 	if err != nil || res.IsError {
 		t.Fatalf("create_chunk: %v %s", err, res.Text)
 	}
-	if got := embeddedTextFor(t, vs, resultField(res, "id")); got != "" {
-		t.Errorf("an uncaptioned image was embedded: %q", got)
+	got := embeddedTextFor(t, vs, resultField(res, "id"))
+	if strings.Contains(got, "iVBOR") || strings.Contains(got, "base64") {
+		t.Errorf("base64 reached the embedder: %q", got)
+	}
+	// The title carries it instead — the data URI contributed nothing.
+	if got != "Raw" {
+		t.Errorf("embed text = %q, want the chunk title \"Raw\"", got)
 	}
 }
 
@@ -185,8 +191,8 @@ func TestAssetDescription_MissingRowIsEmptyNotAnError(t *testing.T) {
 // Both pre-existing image tests used a CAPTIONED chunk, which is why the case went
 // uncovered — and an uncaptioned image is the common one for an uploaded asset.
 //
-// FAIL-BEFORE: restoring the raw-body guard ahead of the switch makes this embed
-// nothing at all.
+// FAIL-BEFORE: restoring the raw-body guard ahead of the switch makes this fall
+// through to the title alone, never reaching the description.
 func TestEmbedBody_UncaptionedImageStillEmbedsItsDescription(t *testing.T) {
 	d, vs, ctx := mermaidDocFixture(t, "image", "five", "round", "characters", "circuit", "board")
 
@@ -213,9 +219,10 @@ func TestEmbedBody_UncaptionedImageStillEmbedsItsDescription(t *testing.T) {
 		t.Fatalf("set_asset: %v %s", err, r.Text)
 	}
 
-	// Precondition: with neither caption nor description there is nothing to index.
-	if got := embeddedTextFor(t, vs, chunkID); got != "" {
-		t.Fatalf("precondition: an image with no caption and no description embedded %q", got)
+	// Precondition: with no caption and no description yet, the chunk is searchable by
+	// its TITLE (the fallback) — and notably NOT by anything describing the picture.
+	if got := embeddedTextFor(t, vs, chunkID); got != "Logo" {
+		t.Fatalf("precondition: want the title-only fallback %q, got %q", "Logo", got)
 	}
 
 	// The describe pass persists a description and re-embeds.
@@ -230,5 +237,124 @@ func TestEmbedBody_UncaptionedImageStillEmbedsItsDescription(t *testing.T) {
 	}
 	if !strings.Contains(got, "five round characters") {
 		t.Errorf("embed text does not carry the description: %q", got)
+	}
+}
+
+// TestTitleEmbedText_KeepsHeadingsDropsNonLanguage pins the one judgement the title
+// fallback makes. Both surfaces (the write path and the admin backfill) route through
+// this, so they cannot disagree about what a usable title is.
+//
+// The threshold is "contains a letter", NOT a length. Measured on the reference
+// deployment: of 20 sampled bodyless chunks, 18 had meaningful titles and the
+// shortest were "Active RFCs" (11) and "Configuration" (13) — a length filter would
+// discard exactly what someone searching a document would type.
+func TestTitleEmbedText_KeepsHeadingsDropsNonLanguage(t *testing.T) {
+	for _, keep := range []string{
+		"Active RFCs",
+		"Configuration",
+		"2. Backend additions (loomcycle core)",
+		"RFC BE — History Tool (browse / search / rename / annotate past chats)",
+		`"replica_id": "replica-a",`, // a fragment used as a heading — weak, but language
+	} {
+		if got := titleEmbedText(keep); got == "" {
+			t.Errorf("titleEmbedText(%q) dropped a title that carries language", keep)
+		}
+	}
+	for _, drop := range []string{
+		"", "   ", "\n\t",
+		"---",   // a rule used as a heading
+		"42",    // a bare number
+		"...",   // punctuation
+		"1.2.3", // a version fragment
+	} {
+		if got := titleEmbedText(drop); got != "" {
+			t.Errorf("titleEmbedText(%q) = %q, want \"\" — no letters means no language, "+
+				"and a vector built from it can only produce false matches", drop, got)
+		}
+	}
+	// Trimmed, not reformatted: the title is the author's text.
+	if got := titleEmbedText("  Active RFCs  "); got != "Active RFCs" {
+		t.Errorf("got %q, want the trimmed title verbatim", got)
+	}
+}
+
+// TestEmbedBody_BodylessChunkFallsBackToItsTitle is the feature: a heading chunk is
+// the most navigable part of a document and was the one part retrieval could not see,
+// because only bodies were embedded.
+//
+// FAIL-BEFORE: removing the fallback makes this embed nothing.
+func TestEmbedBody_BodylessChunkFallsBackToItsTitle(t *testing.T) {
+	d, vs, ctx := mermaidDocFixture(t, "phase", "name-links", "transclusion", "backend", "additions")
+
+	res, _ := d.Execute(ctx, json.RawMessage(`{"op":"create_document","title":"Plan"}`))
+	docID := resultField(res, "document_id")
+	body, _ := json.Marshal(map[string]any{
+		"op": "create_chunk", "document_id": docID,
+		"title": "Phase 2 — name-links + transclusion", "body": "",
+	})
+	res, err := d.Execute(ctx, body)
+	if err != nil || res.IsError {
+		t.Fatalf("create_chunk: %v %s", err, res.Text)
+	}
+	got := embeddedTextFor(t, vs, resultField(res, "id"))
+	if got != "Phase 2 — name-links + transclusion" {
+		t.Errorf("a bodyless heading embedded %q, want its title — a heading organises "+
+			"the document and is exactly what a searcher types", got)
+	}
+}
+
+// TestEmbedBody_BodyWinsOverTitle — the title is a FALLBACK, never an addition.
+// Appending it would double-weight whatever the author happened to put in the
+// heading, on every chunk in the corpus.
+func TestEmbedBody_BodyWinsOverTitle(t *testing.T) {
+	d, vs, ctx := mermaidDocFixture(t, "savepoint", "nesting", "heading", "words")
+
+	res, _ := d.Execute(ctx, json.RawMessage(`{"op":"create_document","title":"Doc"}`))
+	docID := resultField(res, "document_id")
+	body, _ := json.Marshal(map[string]any{
+		"op": "create_chunk", "document_id": docID,
+		"title": "heading words", "body": "SAVEPOINT nesting is LIFO",
+	})
+	res, err := d.Execute(ctx, body)
+	if err != nil || res.IsError {
+		t.Fatalf("create_chunk: %v %s", err, res.Text)
+	}
+	got := embeddedTextFor(t, vs, resultField(res, "id"))
+	if got != "SAVEPOINT nesting is LIFO" {
+		t.Errorf("embed text = %q, want the body alone; the title must not be appended", got)
+	}
+}
+
+// TestEmbedBody_TitlelessBodylessChunkEmbedsNothing — the floor. A chunk with no body
+// and no usable title must store NO vector, because a row that exists ranks against
+// every query.
+func TestEmbedBody_TitlelessBodylessChunkEmbedsNothing(t *testing.T) {
+	d, vs, ctx := mermaidDocFixture(t, "anything")
+
+	res, _ := d.Execute(ctx, json.RawMessage(`{"op":"create_document","title":"Doc"}`))
+	docID := resultField(res, "document_id")
+	body, _ := json.Marshal(map[string]any{
+		"op": "create_chunk", "document_id": docID, "title": "---", "body": "",
+	})
+	res, err := d.Execute(ctx, body)
+	if err != nil || res.IsError {
+		t.Fatalf("create_chunk: %v %s", err, res.Text)
+	}
+	if got := embeddedTextFor(t, vs, resultField(res, "id")); got != "" {
+		t.Errorf("a chunk with no body and a letterless title embedded %q", got)
+	}
+}
+
+// TestChunkIDFromBodyKey_OnlyMatchesChunkBodies guards the exported key parser the
+// backfill relies on: an ordinary memory row must not be mistaken for a chunk and
+// sent looking for a title.
+func TestChunkIDFromBodyKey_OnlyMatchesChunkBodies(t *testing.T) {
+	if got := ChunkIDFromBodyKey("doc.chunk:abc123"); got != "abc123" {
+		t.Errorf("got %q, want abc123", got)
+	}
+	for _, notAChunk := range []string{"", "memory/fact/x", "doc.chunkabc", "chunk:abc"} {
+		if got := ChunkIDFromBodyKey(notAChunk); got != "" {
+			t.Errorf("ChunkIDFromBodyKey(%q) = %q, want \"\"", notAChunk, got)
+		}
 	}
 }

--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -711,8 +711,17 @@ func (m *Memory) execSqlExec(ctx context.Context, in memoryInput) (tools.Result,
 // across both). A real (non-empty) tenant is used verbatim; the run scope is not
 // tenant-keyed, so this is a no-op there.
 func sqlScopeTenant(ctx context.Context) string {
-	if t := tools.RunIdentity(ctx).TenantID; t != "" {
-		return t
+	return sqlScopeTenantValue(tools.RunIdentity(ctx).TenantID)
+}
+
+// sqlScopeTenantValue is the same rule for a tenant already in hand. SQL Memory
+// rejects an empty tenant (it sanitizes the value into a path/identifier), so the
+// default partition is stored as "default" while the k/v and dirent planes keep the
+// raw "". Both forms must go through here — a restated ""→"default" at a call site
+// is how the tenant axis drifts.
+func sqlScopeTenantValue(tenant string) string {
+	if tenant != "" {
+		return tenant
 	}
 	return "default"
 }


### PR DESCRIPTION
A chunk whose body yields no text was excluded from semantic search entirely, because every embedding policy derives from the *body*. That silently removed the most navigable part of a document from retrieval — on the reference deployment **186 of ~3,000 chunks are heading-only**:

```
"RFC BE — History Tool (browse / search / rename / annotate past chats)"
"Phase 2 — name-links + transclusion (unblocks loomboard graph)"
"2. Backend additions (loomcycle core)"          "Active RFCs"
```

## Measured before building

I sampled 20 bodyless chunks from the live scope rather than guessing:

| | count |
|---|---|
| meaningful titles | **18** |
| fragments used as headings (a JSON line) | 2 |

That ratio decided the design. **No content heuristic beyond requiring a letter** — a filter guessing at "meaningful" would drop real headings to avoid an occasional weak vector, and 18-for-2 is the wrong trade to optimise against. **Length is explicitly disqualified**: the shortest sampled titles were `Active RFCs` (11 chars) and `Configuration` (13), which are exactly what someone searching a document would type. `---`, `42`, `...`, `1.2.3` carry no language and are dropped.

## The rule

Applied uniformly *after* the per-type switch:

| condition | embedded text |
|---|---|
| derived text non-empty | that text — unchanged |
| derived text empty, title has a letter | the **title**, trimmed |
| neither | nothing; **no vector stored** |

**Fallback, never an addition.** Appending the title would double-weight whatever the author put in the heading on every chunk in the corpus, and for prose the body usually restates the heading anyway. There's a test pinning that a body wins.

**Uniform, so media benefits too** — a diagram whose labels were all syntax, and an image with neither caption nor description, now fall back. That would have made the deployment's two images findable *before* any vision call.

## Both surfaces, one judgement

The admin backfill needs this or existing documents stay permanently less searchable than ones authored after the feature lands — and a bodyless chunk is unreachable any other way, since the sweep sees memory **rows** while a title lives in SQL Memory. Without it, those 186 would need 186 manual body rewrites.

It calls `builtin.TitleFallbackForBodyKey` rather than resolving titles itself, so the `""`→`"default"` SQL-tenant rule and the title-quality judgement stay in one package. Restating that rule at a call site is how the tenant axis drifts — chunk bodies key on the **raw** tenant while SQL Memory canonicalises it, a seam that has produced silent cross-tenant bugs here before. `sqlScopeTenant` gains a value-form sibling instead of an inline copy.

The title read costs a query only on the fallback path, and `embedBody` already reads SQL for an image's description, so the seam existed.

## What was tested

- `titleEmbedText` keeps all five sampled shapes, drops `---` / `42` / `...` / `1.2.3` / blanks, and trims without reformatting
- a bodyless heading embeds its title; a **body wins** over the title; a chunk with neither embeds nothing
- `ChunkIDFromBodyKey` refuses a non-chunk row, so an ordinary memory row is never sent looking for a title
- the backfill applies the fallback, mentions it in its notes, and counts an unresolvable title as `skipped_empty` rather than crashing

**Fail-before verified** on the write path — with the fallback disabled both the heading and the data-URI cases embed nothing.

Two image tests were **updated rather than preserved**: asserting "an uncaptioned image embeds nothing" is precisely the behaviour this changes. The data-URI test now pins the part that still matters — base64 never reaches the embedder — while the title carries the row.

`go test ./...` clean, `go vet` clean. RFC BU §3 amended in the doc store with the measurement and the reasoning.

## Deferred, deliberately

For an **image**, the title often carries what the vision description cannot ("Loomcycle Logo 1280x640" — the model doesn't know whose logo it is), so title **plus** description would strictly beat description-alone *there*. That breaks the fallback-not-addition rule for one type, so I left it out rather than special-casing it. Happy to do it as a follow-up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8