### PR TITLE
fix(memory): teach the Memory tool, and stop embedding markdown scaffolding

### DIFF
--- a/bundles/chat/loomcycle.yaml
+++ b/bundles/chat/loomcycle.yaml
@@ -74,13 +74,20 @@ agents:
       - Memory / Document / Path: durable facts across turns go in Memory (user
         scope), structured chunked material in a Document, and Path navigates
         both.
-      - Recalling what you know about a THING: `Memory recall` matches words;
-        `Document graph_recall` follows the relations between facts. Reach for
-        graph_recall when the question names a thing rather than a phrase —
-        "what do we know about Acme", "who else worked on this" — because facts
-        recorded in different words still share an entity and a word match misses
-        them. `as_of` answers as of a past moment, recovering a fact since
-        corrected.
+      - Recalling what you know about the user or a THING starts with ONE call:
+        `Memory op=recall scope=user query="<the question in your own words>"`.
+        Both `scope` and `query` are required, and recall is the only semantic
+        search over remembered facts. Every tool here takes an `op`; when unsure
+        of a tool's arguments, `Context op=doc name=<Tool>` prints its schema
+        instead of making you learn it from errors.
+      - `Document graph_recall` is the SECOND step, not the first. It follows the
+        relations between facts, so it finds facts recorded in different words
+        that share an entity — but it walks out from facts carrying entity
+        metadata, so on a store without those it returns `seeds: 0` and tells you
+        nothing. Use it to expand a fact recall already found, not to go looking.
+        `as_of` answers as of a past moment, recovering a fact since corrected.
+      - Searching document TEXT rather than facts is
+        `Memory op=search scope=user prefix="doc.chunk:" query="..."`.
 
       ## Style
       - Be concise and concrete; lead with the answer, then the reasoning.
@@ -122,9 +129,18 @@ agents:
         hatch.
       - Memory / Document / Path: durable user-scope facts in Memory, structured
         material in a Document, and Path navigates both.
-      - Asked about a named thing ("what do we know about Acme")? Use `Document
-        graph_recall` — it follows relations, so it finds facts worded
-        differently that `Memory recall` would miss.
+      - "What do I know about the user / what did they tell me?" — that is a
+        SEMANTIC MEMORY SEARCH, and it is one call:
+        `Memory op=recall scope=user query="<the question in your own words>"`.
+        Both `scope` and `query` are required; recall is the ONLY semantic search
+        over remembered facts. Do not guess at argument names — every tool here
+        takes an `op`, and `Context op=doc name=<Tool>` prints its exact schema.
+      - `Document graph_recall` is NOT the entry point for that. It walks
+        RELATIONS out from facts that already carry entity metadata, so on a
+        store without those it returns `seeds: 0` and tells you nothing. Reach
+        for it only after `Memory op=recall` gave you a fact worth expanding.
+      - Searching document TEXT (not facts) is
+        `Memory op=search scope=user prefix="doc.chunk:" query="..."`.
 
       ## Style
       - Be concise and concrete; lead with the answer, then the reasoning.
@@ -166,9 +182,18 @@ agents:
         hatch.
       - Memory / Document / Path: durable user-scope facts in Memory, structured
         material in a Document, and Path navigates both.
-      - Asked about a named thing ("what do we know about Acme")? Use `Document
-        graph_recall` — it follows relations, so it finds facts worded
-        differently that `Memory recall` would miss.
+      - "What do I know about the user / what did they tell me?" — that is a
+        SEMANTIC MEMORY SEARCH, and it is one call:
+        `Memory op=recall scope=user query="<the question in your own words>"`.
+        Both `scope` and `query` are required; recall is the ONLY semantic search
+        over remembered facts. Do not guess at argument names — every tool here
+        takes an `op`, and `Context op=doc name=<Tool>` prints its exact schema.
+      - `Document graph_recall` is NOT the entry point for that. It walks
+        RELATIONS out from facts that already carry entity metadata, so on a
+        store without those it returns `seeds: 0` and tells you nothing. Reach
+        for it only after `Memory op=recall` gave you a fact worth expanding.
+      - Searching document TEXT (not facts) is
+        `Memory op=search scope=user prefix="doc.chunk:" query="..."`.
 
       ## Style
       - Be concise and concrete; lead with the answer, then the reasoning.

--- a/cmd/loomcycle/embedded/bundles/chat.yaml
+++ b/cmd/loomcycle/embedded/bundles/chat.yaml
@@ -74,13 +74,20 @@ agents:
       - Memory / Document / Path: durable facts across turns go in Memory (user
         scope), structured chunked material in a Document, and Path navigates
         both.
-      - Recalling what you know about a THING: `Memory recall` matches words;
-        `Document graph_recall` follows the relations between facts. Reach for
-        graph_recall when the question names a thing rather than a phrase —
-        "what do we know about Acme", "who else worked on this" — because facts
-        recorded in different words still share an entity and a word match misses
-        them. `as_of` answers as of a past moment, recovering a fact since
-        corrected.
+      - Recalling what you know about the user or a THING starts with ONE call:
+        `Memory op=recall scope=user query="<the question in your own words>"`.
+        Both `scope` and `query` are required, and recall is the only semantic
+        search over remembered facts. Every tool here takes an `op`; when unsure
+        of a tool's arguments, `Context op=doc name=<Tool>` prints its schema
+        instead of making you learn it from errors.
+      - `Document graph_recall` is the SECOND step, not the first. It follows the
+        relations between facts, so it finds facts recorded in different words
+        that share an entity — but it walks out from facts carrying entity
+        metadata, so on a store without those it returns `seeds: 0` and tells you
+        nothing. Use it to expand a fact recall already found, not to go looking.
+        `as_of` answers as of a past moment, recovering a fact since corrected.
+      - Searching document TEXT rather than facts is
+        `Memory op=search scope=user prefix="doc.chunk:" query="..."`.
 
       ## Style
       - Be concise and concrete; lead with the answer, then the reasoning.
@@ -122,9 +129,18 @@ agents:
         hatch.
       - Memory / Document / Path: durable user-scope facts in Memory, structured
         material in a Document, and Path navigates both.
-      - Asked about a named thing ("what do we know about Acme")? Use `Document
-        graph_recall` — it follows relations, so it finds facts worded
-        differently that `Memory recall` would miss.
+      - "What do I know about the user / what did they tell me?" — that is a
+        SEMANTIC MEMORY SEARCH, and it is one call:
+        `Memory op=recall scope=user query="<the question in your own words>"`.
+        Both `scope` and `query` are required; recall is the ONLY semantic search
+        over remembered facts. Do not guess at argument names — every tool here
+        takes an `op`, and `Context op=doc name=<Tool>` prints its exact schema.
+      - `Document graph_recall` is NOT the entry point for that. It walks
+        RELATIONS out from facts that already carry entity metadata, so on a
+        store without those it returns `seeds: 0` and tells you nothing. Reach
+        for it only after `Memory op=recall` gave you a fact worth expanding.
+      - Searching document TEXT (not facts) is
+        `Memory op=search scope=user prefix="doc.chunk:" query="..."`.
 
       ## Style
       - Be concise and concrete; lead with the answer, then the reasoning.
@@ -166,9 +182,18 @@ agents:
         hatch.
       - Memory / Document / Path: durable user-scope facts in Memory, structured
         material in a Document, and Path navigates both.
-      - Asked about a named thing ("what do we know about Acme")? Use `Document
-        graph_recall` — it follows relations, so it finds facts worded
-        differently that `Memory recall` would miss.
+      - "What do I know about the user / what did they tell me?" — that is a
+        SEMANTIC MEMORY SEARCH, and it is one call:
+        `Memory op=recall scope=user query="<the question in your own words>"`.
+        Both `scope` and `query` are required; recall is the ONLY semantic search
+        over remembered facts. Do not guess at argument names — every tool here
+        takes an `op`, and `Context op=doc name=<Tool>` prints its exact schema.
+      - `Document graph_recall` is NOT the entry point for that. It walks
+        RELATIONS out from facts that already carry entity metadata, so on a
+        store without those it returns `seeds: 0` and tells you nothing. Reach
+        for it only after `Memory op=recall` gave you a fact worth expanding.
+      - Searching document TEXT (not facts) is
+        `Memory op=search scope=user prefix="doc.chunk:" query="..."`.
 
       ## Style
       - Be concise and concrete; lead with the answer, then the reasoning.

--- a/cmd/loomcycle/presets_chat_test.go
+++ b/cmd/loomcycle/presets_chat_test.go
@@ -89,21 +89,27 @@ func TestChatBundle_PromptsDoNotHandWriteAToolList(t *testing.T) {
 	}
 }
 
-// TestChatBundle_PromptsPointAtGraphRecall pins the guidance that makes the entity
-// graph reachable in practice.
+// TestChatBundle_PromptsTeachMemoryRecall pins the guidance that makes remembered
+// facts reachable in practice.
 //
-// The tool grant is not what makes a capability usable. `Document` has been in
-// these agents' tools since the bundle shipped, and `graph_recall` has existed
-// since v1.42.0 — but nothing told a model when to prefer it over `Memory recall`,
-// so it went unused. That is the same "capability with no caller" shape as the
-// entity tier having no producer, one layer up: reachable in principle, invisible
-// in practice.
+// The tool grant is not what makes a capability usable — `Memory` and `Document`
+// have been in these agents' tools since the bundle shipped. What decides whether a
+// model can answer "which medicine do I take" is whether the prompt names the OP and
+// its required arguments.
 //
-// The distinction the guidance has to carry is the load-bearing one: word matching
-// versus following relations. Two facts about Acme recorded in different words are
-// found by graph_recall and missed by recall, which is precisely when a model
-// should reach for it.
-func TestChatBundle_PromptsPointAtGraphRecall(t *testing.T) {
+// THIS TEST PREVIOUSLY ASSERTED THE OPPOSITE EMPHASIS, and a live transcript
+// disproved it. It required the prompt to point at `Document graph_recall` for
+// "what do we know about X", on the reasoning that following relations beats matching
+// words. In practice graph_recall walks out from facts carrying entity metadata, so
+// on a store without those it returns `seeds: 0` — and an agent sent there first
+// concluded there was nothing remembered, then spent four calls guessing argument
+// names ("missing required field: op", "missing required field: scope", "missing
+// required field: query") before stumbling onto `Memory op=recall`. The relation
+// advantage is real but it is a SECOND step, not the entry point.
+//
+// So the invariants are now: teach `Memory op=recall` with scope AND query, and keep
+// graph_recall explained but positioned after it.
+func TestChatBundle_PromptsTeachMemoryRecall(t *testing.T) {
 	cfg := chatBundleConfig(t)
 	found := 0
 	for name, agent := range cfg.Agents {
@@ -111,18 +117,36 @@ func TestChatBundle_PromptsPointAtGraphRecall(t *testing.T) {
 			continue
 		}
 		found++
-		if !strings.Contains(agent.SystemPrompt, "graph_recall") {
-			t.Errorf("%s never mentions graph_recall — the entity graph is granted but unreachable in practice", name)
+		prompt := agent.SystemPrompt
+		low := strings.ToLower(prompt)
+
+		// The entry point, named as an invocation rather than a capability. An agent
+		// that has to discover `op`/`scope`/`query` from error messages burns its turn
+		// budget before it retrieves anything.
+		if !strings.Contains(prompt, "op=recall") {
+			t.Errorf("%s never names `Memory op=recall` — the only semantic search over "+
+				"remembered facts, and the op an agent otherwise has to guess", name)
+		}
+		for _, arg := range []string{"scope", "query"} {
+			if !strings.Contains(low, arg) {
+				t.Errorf("%s does not mention recall's required %q argument", name, arg)
+			}
+		}
+
+		// graph_recall stays explained — the relation advantage is real — but must not
+		// be the first thing reached for.
+		if !strings.Contains(prompt, "graph_recall") {
+			t.Errorf("%s never mentions graph_recall — the entity graph is granted but "+
+				"unreachable in practice", name)
 			continue
 		}
-		// Naming the op is not enough; the prompt must say WHEN, or it reads as
-		// one more entry in a list the model already has from Context.tools.
-		if !strings.Contains(agent.SystemPrompt, "relation") {
-			t.Errorf("%s names graph_recall but not what distinguishes it (following relations vs matching words)", name)
+		if !strings.Contains(low, "relation") {
+			t.Errorf("%s names graph_recall but not what distinguishes it (following "+
+				"relations rather than matching words)", name)
 		}
-		// And the tool it needs must actually be granted.
 		if !hasToolPreset(agent.Tools, "Document") {
-			t.Errorf("%s is told to use graph_recall but does not grant Document; tools=%v", name, agent.Tools)
+			t.Errorf("%s is told about graph_recall but does not grant Document; tools=%v",
+				name, agent.Tools)
 		}
 	}
 	if found == 0 {
@@ -130,19 +154,6 @@ func TestChatBundle_PromptsPointAtGraphRecall(t *testing.T) {
 	}
 }
 
-// TestChatBundle_PromptsInjectTenantContext pins the CONSUMER of
-// {{memory:tenant_info}}.
-//
-// The variant existed and validated for four phases while rendering nothing,
-// because the document behind it was never built — and once built it would have
-// been just as inert if no shipped prompt referenced it. That is the failure this
-// phase exists to fix and the reason the plan says: wire a placeholder in the same
-// PR that adds it, or do not ship it.
-//
-// The chat agents are the right consumer: they are the interactive surface, they
-// already read the per-user root, and deployment vocabulary is exactly the context
-// they lack. They stay `memory_scopes: [user]` — the read stamps the tenant grants
-// server-side, so consuming it costs no widening.
 func TestChatBundle_PromptsInjectTenantContext(t *testing.T) {
 	cfg := chatBundleConfig(t)
 	found := 0

--- a/internal/help/builtin/memory-layer.md
+++ b/internal/help/builtin/memory-layer.md
@@ -12,6 +12,34 @@ no longer require a special external backend.
 | "what notes are *close* to X?" | `search` (`embed: true` on `set`) | an embedder + a vector-capable store |
 | "remember this conversation; recall what you learned" | `add` / `recall` | `add`: any backend · `recall`: the vector stack |
 
+## Calling them (the exact shape)
+
+Both ops take a `scope`, and `recall` also requires a `query`. Omitting either
+is the most common way an agent stalls here, so:
+
+```
+Memory op=recall scope=user query="which medicine does the user take"
+Memory op=add    scope=user messages=[{"role":"user","content":"..."}]
+```
+
+`recall` is the ONLY semantic search over remembered facts. Two things it is
+often confused with:
+
+- **`Document graph_recall` is not a substitute.** It walks *relations* out from
+  facts that already carry entity metadata, so on a store without those it
+  returns `seeds: 0` and tells you nothing — which reads like "there is nothing
+  remembered" when there is. Use it *after* `recall` hands you a fact worth
+  expanding.
+- **Document TEXT is a different surface.** Chunk bodies live in the same
+  keyspace under a reserved `doc.chunk:` prefix, and the way to search them on
+  purpose is `Memory op=search scope=user prefix="doc.chunk:" query="..."`.
+  Because they share the keyspace, `recall` currently *can* surface a chunk body
+  alongside consolidated facts — a `doc.chunk:` id in a recall result is document
+  prose, not something the user told you, so weigh it accordingly.
+
+If you are unsure of any tool's arguments, `Context op=doc name=Memory` prints
+the schema rather than making you guess from an error message.
+
 ## What the memory-layer paradigm is
 
 A key/value store is faithful: you `set` a key, you `get` exactly that

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -780,7 +780,11 @@ func (d *Document) embedBody(ctx context.Context, tenant string, mscope store.Me
 			}
 			text = mermaidEmbedText(src)
 		} else {
-			text = strings.TrimSpace(body)
+			// indexableText drops a body that is nothing but Markdown scaffolding
+			// ("```sh", "---", "#"), which a heading-split import turns into its own
+			// chunk. Such a body ranks mid-high for EVERY query, so it does not just
+			// waste a row — it outranks real answers.
+			text = indexableText(body)
 		}
 	}
 	// FALL BACK TO THE TITLE. A chunk whose body yields no text is usually a heading
@@ -792,7 +796,7 @@ func (d *Document) embedBody(ctx context.Context, tenant string, mscope store.Me
 	// Measured on the reference deployment before adding this: of 20 sampled bodyless
 	// chunks, 18 had meaningful titles. The two that did not were fragments used as
 	// headings (a JSON line). No content heuristic beyond requiring a letter — see
-	// titleEmbedText — because a filter guessing at "meaningful" would drop real
+	// indexableText — because a filter guessing at "meaningful" would drop real
 	// headings to avoid an occasional weak vector, and 18-for-2 is the wrong trade to
 	// optimise against.
 	//
@@ -800,7 +804,7 @@ func (d *Document) embedBody(ctx context.Context, tenant string, mscope store.Me
 	// path (the body was empty), and embedBody already reads SQL for an image's
 	// description, so the seam exists.
 	if text == "" {
-		text = titleEmbedText(d.chunkTitle(ctx, key, chunkID))
+		text = indexableText(d.chunkTitle(ctx, key, chunkID))
 	}
 	// Still nothing: no body text AND no usable title. Embedding punctuation — or a
 	// placeholder — is worse than embedding nothing, because a row that exists ranks
@@ -884,28 +888,6 @@ func (d *Document) chunkTitle(ctx context.Context, key sqlmem.ScopeKey, chunkID 
 	return asStr(res.Rows[0][0])
 }
 
-// titleEmbedText decides whether a title is worth embedding, and is the ONE place
-// that judgement lives so the write path and the backfill cannot disagree.
-//
-// The only requirement is a letter. A title with no letters carries no language —
-// "---", "```sh", "42" — and a vector built from it can only produce false matches,
-// which is the same reasoning the mermaid extractor applies to a label-less diagram.
-// Everything else is kept: a heading is short by nature, so a length threshold would
-// discard "Active RFCs" and "Configuration", both of which are exactly what someone
-// searching a document would type.
-func titleEmbedText(title string) string {
-	t := strings.TrimSpace(title)
-	if t == "" {
-		return ""
-	}
-	if !strings.ContainsFunc(t, func(r rune) bool {
-		return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
-	}) {
-		return ""
-	}
-	return t
-}
-
 // TitleFallbackForBodyKey resolves the title-derived embed text for a bodyless
 // document chunk, given only its k/v key.
 //
@@ -927,7 +909,7 @@ func TitleFallbackForBodyKey(ctx context.Context, mgr *sqlmem.Manager, tenant st
 	}
 	d := &Document{SqlMem: mgr}
 	key := sqlmem.ScopeKey{Tenant: sqlScopeTenantValue(tenant), Scope: string(mscope), ScopeID: scopeID}
-	return titleEmbedText(d.chunkTitle(ctx, key, chunkID))
+	return indexableText(d.chunkTitle(ctx, key, chunkID))
 }
 
 // recordRevision appends a body snapshot to the chunk_revisions log (RFC BS

--- a/internal/tools/builtin/document_image.go
+++ b/internal/tools/builtin/document_image.go
@@ -29,6 +29,7 @@ package builtin
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -80,6 +81,48 @@ func (d *Document) setAssetDescription(ctx context.Context, key sqlmem.ScopeKey,
 	return d.exec(ctx, key,
 		`UPDATE chunk_assets SET description = ?, described_at = ? WHERE chunk_id = ?`,
 		strings.TrimSpace(description), time.Now().UnixNano(), chunkID)
+}
+
+// mdScaffoldOnlyRe matches text that is ENTIRELY Markdown scaffolding: a fence
+// opener/closer with an optional language tag, a horizontal rule, or bare heading
+// hashes. Anchored and whole-string, so text that merely BEGINS with a fence — a real
+// code example — is untouched.
+var mdScaffoldOnlyRe = regexp.MustCompile("(?s)\\A\\s*(?:`{3,}[A-Za-z0-9_+-]*|~{3,}[A-Za-z0-9_+-]*|-{3,}|\\*{3,}|_{3,}|#{1,6})\\s*\\z")
+
+// indexableText is the ONE test for whether a string is worth embedding, applied to a
+// chunk body and to a title fallback alike. Returns the trimmed text, or "" when
+// there is nothing a query could meaningfully match.
+//
+// TWO REJECTIONS, both learned from real data rather than reasoned into:
+//
+//  1. Markdown scaffolding. A heading-split import turns a fence line into its own
+//     chunk, so corpora contain chunks whose whole body is "```sh", "---" or "#".
+//     Measured on the reference deployment, a user asking "which medicine do I take"
+//     got "---" (0.477), "```sh" (0.452) and "#" (0.451) ranked ABOVE the fact naming
+//     their medication (0.434). A short token embeds near the centroid of everything,
+//     so it ranks mid-high for EVERY query — it does not merely waste a row, it
+//     outranks real answers.
+//  2. No letters — "42", "1.2.3", "..." carry no language.
+//
+// Neither rejection subsumes the other, which is why both are here: "```sh" HAS
+// letters, so the letter test alone lets it through; "42" is not scaffolding, so the
+// scaffold test alone lets it through.
+//
+// ONE function on purpose. When a body is rejected the caller falls back to the
+// TITLE, and a chunk whose body is a fence line usually has a scaffold-ish title too
+// — applying a weaker rule there would just move the noise from one field to the
+// other, which is exactly what a first attempt here did.
+func indexableText(s string) string {
+	t := strings.TrimSpace(s)
+	if t == "" || mdScaffoldOnlyRe.MatchString(t) {
+		return ""
+	}
+	if !strings.ContainsFunc(t, func(r rune) bool {
+		return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
+	}) {
+		return ""
+	}
+	return t
 }
 
 // UndescribedAsset is one image awaiting a description: enough to make the vision

--- a/internal/tools/builtin/document_image_test.go
+++ b/internal/tools/builtin/document_image_test.go
@@ -248,7 +248,7 @@ func TestEmbedBody_UncaptionedImageStillEmbedsItsDescription(t *testing.T) {
 // deployment: of 20 sampled bodyless chunks, 18 had meaningful titles and the
 // shortest were "Active RFCs" (11) and "Configuration" (13) — a length filter would
 // discard exactly what someone searching a document would type.
-func TestTitleEmbedText_KeepsHeadingsDropsNonLanguage(t *testing.T) {
+func TestIndexableText_KeepsHeadingsDropsNonLanguage(t *testing.T) {
 	for _, keep := range []string{
 		"Active RFCs",
 		"Configuration",
@@ -256,8 +256,8 @@ func TestTitleEmbedText_KeepsHeadingsDropsNonLanguage(t *testing.T) {
 		"RFC BE — History Tool (browse / search / rename / annotate past chats)",
 		`"replica_id": "replica-a",`, // a fragment used as a heading — weak, but language
 	} {
-		if got := titleEmbedText(keep); got == "" {
-			t.Errorf("titleEmbedText(%q) dropped a title that carries language", keep)
+		if got := indexableText(keep); got == "" {
+			t.Errorf("indexableText(%q) dropped a title that carries language", keep)
 		}
 	}
 	for _, drop := range []string{
@@ -267,13 +267,13 @@ func TestTitleEmbedText_KeepsHeadingsDropsNonLanguage(t *testing.T) {
 		"...",   // punctuation
 		"1.2.3", // a version fragment
 	} {
-		if got := titleEmbedText(drop); got != "" {
-			t.Errorf("titleEmbedText(%q) = %q, want \"\" — no letters means no language, "+
+		if got := indexableText(drop); got != "" {
+			t.Errorf("indexableText(%q) = %q, want \"\" — no letters means no language, "+
 				"and a vector built from it can only produce false matches", drop, got)
 		}
 	}
 	// Trimmed, not reformatted: the title is the author's text.
-	if got := titleEmbedText("  Active RFCs  "); got != "Active RFCs" {
+	if got := indexableText("  Active RFCs  "); got != "Active RFCs" {
 		t.Errorf("got %q, want the trimmed title verbatim", got)
 	}
 }
@@ -356,5 +356,87 @@ func TestChunkIDFromBodyKey_OnlyMatchesChunkBodies(t *testing.T) {
 		if got := ChunkIDFromBodyKey(notAChunk); got != "" {
 			t.Errorf("ChunkIDFromBodyKey(%q) = %q, want \"\"", notAChunk, got)
 		}
+	}
+}
+
+// TestProseEmbedText_DropsScaffoldOnlyBodies is measured, not hypothetical. On the
+// reference deployment a user asking "which medicine do I take" got these ranked
+// ABOVE the fact naming their medication (0.434):
+//
+//	"---"      0.477
+//	"```sh"    0.452
+//	"#"        0.451
+//
+// A short syntax token embeds near the centroid of everything, so it ranks mid-high
+// for every query. A heading-split import creates these by turning a fence line into
+// its own chunk.
+func TestIndexableText_DropsScaffoldOnlyText(t *testing.T) {
+	for _, drop := range []string{
+		"```sh", "```bash", "```", "```go",
+		"~~~", "~~~python",
+		"---", "----", "***", "___",
+		"#", "##", "######",
+		"  ```sh  ", "\n---\n", "",
+	} {
+		if got := indexableText(drop); got != "" {
+			t.Errorf("indexableText(%q) = %q, want \"\" — scaffolding outranks real "+
+				"answers because a short syntax token sits near every query", drop, got)
+		}
+	}
+	// The two rejections are independent, and this is why BOTH are needed: a letter
+	// test alone would accept "```sh" (it contains "sh"), and a scaffold test alone
+	// would accept "42". Neither subsumes the other.
+	if strings.ContainsAny("```sh", "abcdefghijklmnopqrstuvwxyz") == false {
+		t.Fatal("precondition: \"```sh\" is expected to contain letters")
+	}
+	if mdScaffoldOnlyRe.MatchString("42") {
+		t.Error("precondition: \"42\" is not scaffolding, so only the letter rule can " +
+			"reject it — if the scaffold rule matches it, this test no longer shows why " +
+			"both rejections exist")
+	}
+}
+
+// TestProseEmbedText_KeepsRealProseIncludingFencedContent — the predicate is anchored
+// and whole-string, so a body that merely CONTAINS or BEGINS with a fence is real
+// content and must survive. Getting this wrong would silently delete every code
+// example from the index.
+func TestIndexableText_KeepsRealProseIncludingFencedContent(t *testing.T) {
+	for _, keep := range []string{
+		"```sh\nmake build-all\n```",
+		"---\ntitle: front matter\n---",
+		"# A real heading with text",
+		"SAVEPOINT nesting is LIFO",
+		"## Setup\n\nRun the installer.",
+		"-- a SQL comment",
+		"#tag",
+	} {
+		if got := indexableText(keep); got == "" {
+			t.Errorf("indexableText(%q) dropped real content", keep)
+		}
+	}
+	// Trimmed, not rewritten.
+	if got := indexableText("  real body  "); got != "real body" {
+		t.Errorf("got %q, want the trimmed body", got)
+	}
+}
+
+// TestEmbedBody_ScaffoldOnlyBodyEmbedsNothing wires the predicate to the write path,
+// and pins that it does NOT then fall through to the title: a chunk whose body is a
+// fence line usually has a scaffold-ish title too, and embedding one to replace the
+// other just moves the noise.
+func TestEmbedBody_ScaffoldOnlyBodyEmbedsNothing(t *testing.T) {
+	d, vs, ctx := mermaidDocFixture(t, "sh", "bash", "code")
+
+	res, _ := d.Execute(ctx, json.RawMessage(`{"op":"create_document","title":"Doc"}`))
+	docID := resultField(res, "document_id")
+	body, _ := json.Marshal(map[string]any{
+		"op": "create_chunk", "document_id": docID, "title": "```sh", "body": "```sh",
+	})
+	res, err := d.Execute(ctx, body)
+	if err != nil || res.IsError {
+		t.Fatalf("create_chunk: %v %s", err, res.Text)
+	}
+	if got := embeddedTextFor(t, vs, resultField(res, "id")); got != "" {
+		t.Errorf("a scaffolding-only chunk embedded %q", got)
 	}
 }


### PR DESCRIPTION
From your transcript. An agent asked to "do a semantic memory search" burned four calls on missing-required-field errors, and the answer it eventually returned ranked **fifth**, under `"---"` and `` "```sh" ``.

Two causes, both ours. A third — the deeper one — is diagnosed below and **not** fixed here.

## 1. The prompt sent it to the wrong tool

All three `chat/*` agents said:

> Asked about a named thing? Use `Document graph_recall` — it follows relations, so it finds facts worded differently that `Memory recall` would miss.

The relation advantage is real, but `graph_recall` walks out from facts carrying entity metadata, so on a store without those it returns `seeds: 0` — which the agent read as "nothing is remembered". And nothing named `Memory op=recall` or its required `scope`+`query`, so it guessed its way there: missing `op`, then missing `scope`, then missing `query`.

Fixed in the bundle **and the embedded copy** — only the embedded one ships. `chat/medium` needed a separate edit because its wording differed, and the guard test caught that I'd updated two of three agents.

**`TestChatBundle_PromptsPointAtGraphRecall` asserted the opposite emphasis** and real usage disproved its premise, so it is now `TestChatBundle_PromptsTeachMemoryRecall`: require `op=recall` with `scope` and `query`, keep graph_recall explained but positioned after it. The old rationale is preserved in the comment alongside what actually happened.

`memory-layer.md` gains the exact invocation and the `Context op=doc name=Memory` pointer.

## 2. Markdown scaffolding was embedded and outranked real facts

A heading-split import turns a fence line into its own chunk, so the corpus holds chunks whose entire body is `` ```sh ``, `---` or `#`. Measured on the deployment for *"which medicine do I take"*:

| content | score |
|---|---|
| `"---"` | 0.477 |
| `` "```sh" `` | 0.452 |
| `"#"` | 0.451 |
| **the fact naming the medication** | **0.434** |

A short token embeds near the centroid of everything, so it ranks mid-high for *every* query. It doesn't waste a row — it buries answers.

`indexableText` is now the single test for embeddable text, applied to a body **and** the title fallback: reject scaffolding, reject letterless. Neither subsumes the other (`` ```sh `` has letters; `42` isn't scaffolding). It's one function because my first attempt rejected the body and then fell through to an equally scaffold-ish *title* — moving the noise instead of removing it. There's a test pinning that.

## 3. Not fixed here: `recall` reaches document chunks at all

**7 of 10** hits in your transcript were `doc.chunk:` rows. RFC BU §6 — which I wrote — says this must not happen:

> `recall` deliberately does NOT reach documents. Folding prose into the fact-recall surface would put design statements alongside consolidated truths with no way to tell them apart — the same noise-swamps-signal failure that motivated restricting `graph_recall`.

That was true only because documents weren't embedded. My phase 1+2 work put ~2,900 document vectors into the plane `recall` searches, so the statement became false and the predicted failure is what you saw. Fixing scaffolding removes 5 of the 7, but legitimate document prose will still appear beside facts.

**The fix needs a store change and I want your call first.** `Recall` calls `Search` with no key prefix, `SearchQuery.Prefix` is inclusive-only, and the pool is **capped at 51** — so over-fetch-and-filter cannot work: with ~2,900 chunks against ~42 facts, a 51-row pool may contain almost no facts. The exclusion has to happen in SQL, threading an exclude-prefix through `MemoryEmbedSearch` and `MemoryFullTextSearch`, both backends, and the contract test. Note `/v1/_memory/search` from #947 deliberately spans both, so it must stay opt-in per caller rather than global.

The precedent for excluding this namespace already exists — the per-scope quota excludes `doc.chunk:` for the same reason, documented on the constant itself: *"anything reasoning about how much memory does this agent have MUST exclude them."* "What does this agent remember" is the same question.

Say go and I'll do it as its own PR.

## Tested

`indexableText` drops 16 scaffolding shapes and keeps real fenced content — the match is anchored and whole-string, so a body *containing* a fence survives; getting that wrong would silently delete every code example from the index. Fail-before verified. `go test ./...` clean, and the bundle/embedded copies verified identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8