### PR TITLE
feat(memory): facts vs notes, labelled results, honest backend contract (RFC BW P2+P3)

### DIFF
--- a/adapters/ts/src/client.ts
+++ b/adapters/ts/src/client.ts
@@ -999,6 +999,9 @@ export class LoomcycleClient {
     if (input.topK !== undefined) body.top_k = input.topK;
     if (input.rank !== undefined) body.rank = input.rank;
     if (input.dedup !== undefined) body.dedup = input.dedup;
+    // Sent only when set, so an omitted selector keeps the endpoint's
+    // span-everything default rather than encoding one here (RFC BW).
+    if (input.sources !== undefined) body.sources = input.sources;
     return postJSON<MemorySearchResponse>(this.ctx, "/v1/_memory/search", body, {
       signal: opts?.signal,
     });

--- a/adapters/ts/src/index.ts
+++ b/adapters/ts/src/index.ts
@@ -196,6 +196,7 @@ export type {
   MemoryScopesResponse,
   // Memory view (RFC BV): off-run search + embed admin
   MemorySearchInput,
+  MemorySource,
   MemorySearchEntry,
   MemorySearchResponse,
   MemoryEmbedModelStats,

--- a/adapters/ts/src/types.ts
+++ b/adapters/ts/src/types.ts
@@ -899,12 +899,37 @@ export interface MemorySearchInput {
   topK?: number;
   rank?: Record<string, unknown>;
   dedup?: Record<string, unknown>;
+  /** Which kinds of remembered thing to return (RFC BW). Omit to span every
+   *  plane — this endpoint exists to answer "where did I record this", so
+   *  unlike the in-band `recall` it does not default to facts.
+   *
+   *  Mixing `"documents"` with only ONE of `"facts"`/`"notes"` is rejected
+   *  (400 `invalid_sources`): the namespace and the provenance split are
+   *  independent dimensions, so that combination would need a disjunction the
+   *  store does not build. Use `["facts"]`, `["notes"]`,
+   *  `["facts","notes"]`, `["documents"]`, or all three. */
+  sources?: MemorySource[];
 }
 
-/** One hit in a {@link MemorySearchResponse}. `kind` distinguishes a
- *  plain k/v memory entry ("memory") from a document-chunk body
- *  ("document"); a document hit also carries `chunk_id` so the viewer
- *  can fetch its entity block via document({ op: "get_chunk" }).
+/** A kind of remembered thing (RFC BW).
+ *
+ *  - `facts` — memory a consolidator distilled; provenance is server-stamped.
+ *  - `notes` — memory an agent wrote directly with `set`.
+ *  - `documents` — Document chunk bodies, which share the memory keyspace. */
+export type MemorySource = "facts" | "notes" | "documents";
+
+/** One hit in a {@link MemorySearchResponse}.
+ *
+ *  `kind` is the row's class: `"fact"` (a consolidator distilled it),
+ *  `"note"` (an agent wrote it directly) or `"document"` (a Document chunk
+ *  body). A document hit also carries `chunk_id` so the viewer can fetch its
+ *  entity block via document({ op: "get_chunk" }).
+ *
+ *  **Changed in 1.49.0 (RFC BW):** this was `"memory" | "document"`. Code
+ *  switching on `"document"` is unaffected; code comparing against
+ *  `"memory"` must move to `"fact" | "note"`. The split is the point — "the
+ *  user told me this" and "an agent jotted this down" are different claims.
+ *
  *  Field casing mirrors the wire JSON (snake_case). */
 export interface MemorySearchEntry {
   key: string;
@@ -914,7 +939,7 @@ export interface MemorySearchEntry {
   /** hybrid rank the row was ordered by */
   rank_score: number;
   embedded_with: { provider: string; model: string };
-  kind: "memory" | "document";
+  kind: "fact" | "note" | "document";
   chunk_id?: string;
 }
 

--- a/adapters/ts/tests/memory-search.test.ts
+++ b/adapters/ts/tests/memory-search.test.ts
@@ -14,7 +14,7 @@ import type {
 } from "../src/index.js";
 
 describe("memorySearch", () => {
-  it("POSTs snake_case body (scopeId→scope_id, topK→top_k) and parses both kinds", async () => {
+  it("POSTs snake_case body (scopeId→scope_id, topK→top_k) and parses every kind", async () => {
     const { client, fetchMock } = makeClient([
       jsonResponse({
         scope: "user",
@@ -35,7 +35,9 @@ describe("memorySearch", () => {
             score: 0.77,
             rank_score: 0.72,
             embedded_with: { provider: "openai", model: "text-embedding-3-small" },
-            kind: "memory",
+            // RFC BW refined this union: "memory" became "fact" | "note". A k/v row
+            // with no server-stamped provenance is a note.
+            kind: "note",
           },
         ],
         query_embedding_dim: 1536,
@@ -56,7 +58,7 @@ describe("memorySearch", () => {
     expect(resp.entries).toHaveLength(2);
     expect(resp.entries[0]!.kind).toBe("document");
     expect(resp.entries[0]!.chunk_id).toBe("c123");
-    expect(resp.entries[1]!.kind).toBe("memory");
+    expect(resp.entries[1]!.kind).toBe("note");
     expect(resp.entries[1]!.chunk_id).toBeUndefined();
     expect(resp.query_embedding_dim).toBe(1536);
     expect(resp.truncated).toBe(false);
@@ -185,5 +187,84 @@ describe("reembedMemory", () => {
     const url = new URL(fetchMock.mock.calls[0]![0] as string);
     expect(url.searchParams.get("dry_run")).toBe("false");
     expect(url.searchParams.get("limit")).toBe("500");
+  });
+});
+
+describe("memorySearch sources (RFC BW)", () => {
+  it("sends sources only when set, so an omitted selector keeps the span-everything default", async () => {
+    const empty = () =>
+      jsonResponse({
+        scope: "user",
+        scope_id: "u1",
+        entries: [],
+        query_embedding_dim: 3,
+        truncated: false,
+      } satisfies MemorySearchResponse);
+    const { client, fetchMock } = makeClient([empty(), empty(), empty()]);
+
+    await client.memorySearch({ query: "q", scope: "user", scopeId: "u1" });
+    const first = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
+    expect("sources" in first).toBe(false);
+
+    await client.memorySearch({ query: "q", scope: "user", scopeId: "u1", sources: ["facts"] });
+    expect(JSON.parse(String(fetchMock.mock.calls[1][1]?.body)).sources).toEqual(["facts"]);
+
+    await client.memorySearch({
+      query: "q",
+      scope: "user",
+      scopeId: "u1",
+      sources: ["facts", "notes", "documents"],
+    });
+    expect(JSON.parse(String(fetchMock.mock.calls[2][1]?.body)).sources).toEqual([
+      "facts",
+      "notes",
+      "documents",
+    ]);
+  });
+
+  it("round-trips the refined kind taxonomy", async () => {
+    // RFC BW §7 changed `kind` from "memory" | "document" to
+    // "fact" | "note" | "document". Code switching on "document" is unaffected;
+    // this pins that the finer values survive the parse, and that only a document
+    // hit carries chunk_id — which is what makes it followable to get_chunk.
+    const { client } = makeClient([
+      jsonResponse({
+        scope: "user",
+        scope_id: "u1",
+        query_embedding_dim: 3,
+        truncated: false,
+        entries: [
+          {
+            key: "memory/fact/x",
+            value: "distilled",
+            score: 0.9,
+            rank_score: 0.9,
+            embedded_with: { provider: "p", model: "m" },
+            kind: "fact",
+          },
+          {
+            key: "scratch/y",
+            value: "jotted",
+            score: 0.8,
+            rank_score: 0.8,
+            embedded_with: { provider: "p", model: "m" },
+            kind: "note",
+          },
+          {
+            key: "doc.chunk:z",
+            value: "prose",
+            score: 0.7,
+            rank_score: 0.7,
+            embedded_with: { provider: "p", model: "m" },
+            kind: "document",
+            chunk_id: "z",
+          },
+        ],
+      } satisfies MemorySearchResponse),
+    ]);
+    const res = await client.memorySearch({ query: "q", scope: "user", scopeId: "u1" });
+    expect(res.entries.map((e) => e.kind)).toEqual(["fact", "note", "document"]);
+    expect(res.entries[2].chunk_id).toBe("z");
+    expect(res.entries[0].chunk_id).toBeUndefined();
   });
 });

--- a/internal/api/http/memory_search.go
+++ b/internal/api/http/memory_search.go
@@ -24,6 +24,28 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
 
+// parseMemorySources maps the wire strings onto the typed selector. Unknown values are
+// dropped rather than rejected, matching the in-band tool: the enum is documented, and
+// rejecting an unrecognised value would make a future source name break an older
+// runtime.
+func parseMemorySources(in []string) []memrank.Source {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]memrank.Source, 0, len(in))
+	for _, v := range in {
+		switch memrank.Source(strings.ToLower(strings.TrimSpace(v))) {
+		case memrank.SourceFacts:
+			out = append(out, memrank.SourceFacts)
+		case memrank.SourceNotes:
+			out = append(out, memrank.SourceNotes)
+		case memrank.SourceDocuments:
+			out = append(out, memrank.SourceDocuments)
+		}
+	}
+	return out
+}
+
 // docChunkKeyPrefix is the Memory keyspace namespace the Document tool writes
 // chunk bodies under (builtin.chunkBodyKey). A hit on such a key is a document
 // chunk, not a plain memory entry — kept as a literal here to avoid importing
@@ -37,6 +59,10 @@ type memorySearchRequest struct {
 	TopK    int                  `json:"top_k"`
 	Rank    *memrank.RankConfig  `json:"rank"`
 	Dedup   *memrank.DedupConfig `json:"dedup"`
+	// Sources narrows which kinds of remembered thing come back (RFC BW). Empty
+	// keeps this endpoint's purpose: it exists to answer "where did I record this"
+	// across BOTH planes, so unlike the in-band recall it does not default to facts.
+	Sources []string `json:"sources"`
 }
 
 type memorySearchEmbeddedWith struct {
@@ -50,9 +76,15 @@ type memorySearchResultEntry struct {
 	Score        float64                  `json:"score"`      // raw cosine similarity
 	RankScore    float64                  `json:"rank_score"` // hybrid rank the row was ordered by
 	EmbeddedWith memorySearchEmbeddedWith `json:"embedded_with"`
-	// Kind distinguishes a plain memory entry ("memory") from a document chunk
-	// body ("document"); a document hit also carries chunk_id so the viewer can
-	// fetch its entity block via the Document tool's get_chunk.
+	// Kind is the row's class: "fact" (a consolidator distilled it), "note" (an agent
+	// wrote it directly) or "document" (a Document chunk body). A document hit also
+	// carries chunk_id so the viewer can fetch its entity block via get_chunk.
+	//
+	// WIRE CHANGE (RFC BW §7): this used to be "memory" | "document". A reader that
+	// switches on "document" is unaffected; one asserting kind == "memory" must move to
+	// fact/note. The refinement is the point — "the user told me this" and "an agent
+	// jotted this down" are different claims, and collapsing them is what let document
+	// prose read as remembered fact.
 	Kind    string `json:"kind"`
 	ChunkID string `json:"chunk_id,omitempty"`
 }
@@ -121,14 +153,22 @@ func (s *Server) handleMemorySearch(w http.ResponseWriter, r *http.Request) {
 	// authoritative — never a request-body field.
 	ctx := tools.WithRunIdentity(r.Context(), tools.RunIdentityValue{TenantID: tenantFromCtx(r.Context())})
 
-	// Empty Prefix so the search spans both k/v entries and doc.chunk bodies.
+	// Empty Prefix so the search spans both k/v entries and doc.chunk bodies unless the
+	// caller narrows it with sources.
 	backend := inprocess.New(s.store, s.embedder)
 	res, err := backend.Search(ctx, store.MemoryScope(body.Scope), storeScopeID,
-		memrank.SearchQuery{QueryText: body.Query, Prefix: "", TopK: topK}, rankCfg, dedupCfg)
+		memrank.SearchQuery{
+			QueryText: body.Query, Prefix: "", TopK: topK,
+			Sources: parseMemorySources(body.Sources),
+		}, rankCfg, dedupCfg)
 	if err != nil {
 		// The three typed refusals are operator-actionable (no embedder / no
 		// vector index / a model swap left the stored dimension stale), so surface
 		// them verbatim as a 400 rather than a blind 500.
+		if errors.Is(err, memrank.ErrSourcesNotExpressible) {
+			writeJSONError(w, http.StatusBadRequest, "invalid_sources", err.Error())
+			return
+		}
 		if errors.Is(err, store.ErrDimensionMismatch) ||
 			errors.Is(err, store.ErrVectorUnsupported) ||
 			errors.Is(err, store.ErrEmbedderNotConfigured) {
@@ -151,14 +191,15 @@ func (s *Server) handleMemorySearch(w http.ResponseWriter, r *http.Request) {
 				Provider: e.EmbeddedWith.Provider,
 				Model:    e.EmbeddedWith.Model,
 			},
-			Kind: "memory",
+			// Classified by the SAME function the in-band tool and the filter use, so
+			// the label cannot disagree with what the selector selected.
+			Kind: string(memrank.Class(e)),
 		}
 		// A doc.chunk hit may be an entity fact OR a plain document chunk; the
 		// viewer calls get_chunk to see its entity block. No per-hit sidecar
 		// lookup here — the sidecar lives in SQL Memory, a different plane; this
 		// handler stays store-only.
-		if strings.HasPrefix(e.Key, docChunkKeyPrefix) {
-			entry.Kind = "document"
+		if entry.Kind == string(store.MemoryRowDocument) {
 			entry.ChunkID = strings.TrimPrefix(e.Key, docChunkKeyPrefix)
 		}
 		entries = append(entries, entry)

--- a/internal/api/http/memory_search_test.go
+++ b/internal/api/http/memory_search_test.go
@@ -137,7 +137,12 @@ func TestMemorySearch_UnifiedKvAndDocChunk(t *testing.T) {
 	var docChunkID string
 	for _, e := range resp.Entries {
 		switch e.Kind {
-		case "memory":
+		// RFC BW §7 REFINED THIS WIRE FIELD: "memory" became "fact" | "note". The
+		// distinction is the point — a consolidator distilling something is a
+		// different claim from an agent jotting it down, and collapsing them is what
+		// let document prose read as remembered fact. This fixture's k/v row carries
+		// no provenance, so it is a note.
+		case "fact", "note":
 			gotMemory = true
 			if e.ChunkID != "" {
 				t.Errorf("a memory hit must not carry chunk_id: %+v", e)
@@ -150,7 +155,7 @@ func TestMemorySearch_UnifiedKvAndDocChunk(t *testing.T) {
 		}
 	}
 	if !gotMemory {
-		t.Errorf("no kind=memory hit for the k/v entry: %+v", resp.Entries)
+		t.Errorf("no fact/note hit for the k/v entry: %+v", resp.Entries)
 	}
 	if !gotDocument {
 		t.Errorf("no kind=document hit for the doc.chunk body: %+v", resp.Entries)

--- a/internal/memory/backend.go
+++ b/internal/memory/backend.go
@@ -3,6 +3,7 @@ package memory
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/store"
@@ -133,38 +134,78 @@ type Source string
 const (
 	// SourceFacts is the agent's own memory: consolidated facts and notes it wrote.
 	SourceFacts Source = "facts"
+	// SourceNotes is memory an agent wrote directly with `set` — no provenance, so no
+	// server-known writer distilled it.
+	SourceNotes Source = "notes"
 	// SourceDocuments is Document chunk bodies — prose written down in a document,
 	// which is NOT the same claim as something the user said.
 	SourceDocuments Source = "documents"
 )
 
+// ErrSourcesNotExpressible is returned for a source set that cannot be rendered as a
+// single conjunctive predicate — see SearchQuery.Filter.
+var ErrSourcesNotExpressible = errors.New(
+	"memory: this combination of sources cannot be filtered in one query. " +
+		"The document namespace and the provenance split are independent dimensions, so " +
+		"mixing documents with only ONE of facts/notes would need a disjunction the store " +
+		"does not build. Use [facts], [notes], [facts,notes], [documents], or all three")
+
 // Filter renders the requested sources as the store-level predicate.
 //
-// Only the exclusive combinations are expressible today: facts-only excludes the
-// document namespace, documents-only restricts to it, and both (or neither) constrain
-// nothing. Splitting facts from notes is RFC BW phase 2 and needs the provenance
-// columns, so "facts" here still means "everything that is not a document".
-func (q SearchQuery) Filter() store.MemorySearchFilter {
+// The two dimensions are INDEPENDENT: whether a row is in the document namespace (a
+// key prefix) and whether it carries provenance (a column). Every combination this
+// returns is therefore a conjunction, which is what a single indexed query can apply
+// with the LIMIT after the predicate.
+//
+// TWO COMBINATIONS ARE REFUSED rather than approximated: documents together with only
+// ONE of facts/notes needs `(key LIKE doc) OR (key NOT LIKE doc AND provenance…)` — a
+// disjunction across both dimensions. It could be built, and it is deliberately not,
+// because the honest alternatives were worse: silently widening to "everything" would
+// hand back rows the caller excluded while it believed the filter applied, which is
+// the failure RFC BW §6 exists to prevent. Refusing names the supported sets instead.
+// Both refused combinations are also odd requests ("my facts and my documents but not
+// my notes"); if one turns out to be real, the disjunction is the fix.
+func (q SearchQuery) Filter() (store.MemorySearchFilter, error) {
 	f := store.MemorySearchFilter{KeyPrefix: q.Prefix}
-	wantFacts, wantDocs := false, false
+	var facts, notes, docs bool
 	for _, s := range q.Sources {
 		switch s {
 		case SourceFacts:
-			wantFacts = true
+			facts = true
+		case SourceNotes:
+			notes = true
 		case SourceDocuments:
-			wantDocs = true
+			docs = true
 		}
 	}
+	if !facts && !notes && !docs {
+		return f, nil // no selector: constrain nothing
+	}
+	memory := facts || notes
+	if docs && memory && !(facts && notes) {
+		return store.MemorySearchFilter{}, ErrSourcesNotExpressible
+	}
 	switch {
-	case wantFacts && !wantDocs:
-		f.ExcludeKeyPrefix = DocumentChunkKeyPrefix
-	case wantDocs && !wantFacts:
+	case docs && !memory:
 		// An explicit prefix wins if the caller set one; otherwise scope to documents.
 		if f.KeyPrefix == "" {
 			f.KeyPrefix = DocumentChunkKeyPrefix
 		}
+	case memory && !docs:
+		f.ExcludeKeyPrefix = DocumentChunkKeyPrefix
+		if facts && !notes {
+			f.Provenance = store.ProvenanceRequired
+		} else if notes && !facts {
+			f.Provenance = store.ProvenanceAbsent
+		}
 	}
-	return f
+	// docs && facts && notes → everything; the zero filter already says that.
+	return f, nil
+}
+
+// Class labels a result row so a caller can tell what it got (RFC BW §4b).
+func Class(e store.MemorySearchEntry) store.MemoryRowClass {
+	return store.ClassifyMemoryRow(e.Key, e.Origin, DocumentChunkKeyPrefix)
 }
 
 // SearchResult is the ranked output of Backend.Search. Entries are
@@ -185,5 +226,16 @@ type SearchResult struct {
 	QueryEmbeddingDim int
 	Truncated         bool
 	RankNote          string
-	DedupDropped      int
+
+	// SourcesApplied reports that the backend actually honoured SearchQuery.Sources
+	// (RFC BW phase 3).
+	//
+	// FALSE IS THE ZERO VALUE ON PURPOSE. A backend that ignores the selector — an
+	// external memory-layer service with its own namespaces — must not be able to do
+	// so silently, because the caller would then trust a label the result does not
+	// deserve: it asked for facts and is reading document prose. Defaulting to false
+	// means the honest answer is what you get for free, and honouring the selector is
+	// the thing you have to declare.
+	SourcesApplied bool
+	DedupDropped   int
 }

--- a/internal/memory/backends/inprocess/inprocess.go
+++ b/internal/memory/backends/inprocess/inprocess.go
@@ -214,6 +214,15 @@ func (b *Backend) Search(ctx context.Context, scope store.MemoryScope, scopeID s
 	// vector-capable store that lacks a full-text index (e.g. a future
 	// sqlite-vec build) — SupportsFullText is the precise capability.
 	// TODO(RFC BL): per-call/opsconfig hybrid opt-out if operators want it.
+	// Resolve the source selector BEFORE either leg: an unsupported combination must
+	// refuse without having run a query, and both legs must be given the SAME
+	// predicate — RRF fuses them, so filtering one filters nothing.
+	filter, ferr := q.Filter()
+	if ferr != nil {
+		lcotel.SetSpanError(span, ferr)
+		return memory.SearchResult{}, ferr
+	}
+
 	hybrid := b.store.SupportsFullText() || !rank.IsPureSemantic() || dedup.Enabled
 
 	var pool []store.MemorySearchEntry
@@ -229,14 +238,14 @@ func (b *Backend) Search(ctx context.Context, scope store.MemoryScope, scopeID s
 		// Leg 1: vector (cosine-ordered). Errors pass through unwrapped —
 		// ErrDimensionMismatch / ErrVectorUnsupported are user-actionable and
 		// the tool's errors.Is checks match the backend-constructed *MemoryError.
-		vres, verr := b.store.MemoryEmbedSearch(ctx, tenant, scope, scopeID, q.Filter(), queryVec, fetch)
+		vres, verr := b.store.MemoryEmbedSearch(ctx, tenant, scope, scopeID, filter, queryVec, fetch)
 		if verr != nil {
 			lcotel.SetSpanError(span, verr)
 			return memory.SearchResult{}, verr
 		}
 		// Leg 2: full-text (keyword, ts_rank-ordered). (nil,nil) on a store
 		// without a full-text index, so the fusion collapses to pure-vector.
-		fres, ferr := b.store.MemoryFullTextSearch(ctx, tenant, scope, scopeID, q.Filter(), q.QueryText, fetch)
+		fres, ferr := b.store.MemoryFullTextSearch(ctx, tenant, scope, scopeID, filter, q.QueryText, fetch)
 		if ferr != nil {
 			lcotel.SetSpanError(span, ferr)
 			return memory.SearchResult{}, ferr
@@ -254,7 +263,7 @@ func (b *Backend) Search(ctx context.Context, scope store.MemoryScope, scopeID s
 		if fetch > 51 {
 			fetch = 51
 		}
-		vres, verr := b.store.MemoryEmbedSearch(ctx, tenant, scope, scopeID, q.Filter(), queryVec, fetch)
+		vres, verr := b.store.MemoryEmbedSearch(ctx, tenant, scope, scopeID, filter, queryVec, fetch)
 		if verr != nil {
 			lcotel.SetSpanError(span, verr)
 			return memory.SearchResult{}, verr
@@ -311,6 +320,10 @@ func (b *Backend) Search(ctx context.Context, scope store.MemoryScope, scopeID s
 		QueryEmbeddingDim: len(queryVec),
 		Truncated:         truncated,
 		DedupDropped:      dropped,
+		// This backend renders the selector into SQL (see SearchQuery.Filter), so it
+		// can declare that it was honoured. A backend that cannot must leave this
+		// false rather than let a caller trust a label it did not earn.
+		SourcesApplied: true,
 	}
 	if rank.SourceReserved() {
 		out.RankNote = "source_weight is reserved and contributes 0 until source-score tracking ships"
@@ -505,7 +518,7 @@ func (b *Backend) Recall(ctx context.Context, scope store.MemoryScope, scopeID s
 	if len(facts) > topK {
 		facts = facts[:topK]
 	}
-	return memory.RecallResult{Facts: facts}, nil
+	return memory.RecallResult{Facts: facts, SourcesApplied: true}, nil
 }
 
 // recallText renders a stored value as human text: a JSON string round-trips to

--- a/internal/memory/layer.go
+++ b/internal/memory/layer.go
@@ -167,4 +167,10 @@ type RecallFact struct {
 // the backend.
 type RecallResult struct {
 	Facts []RecallFact
+
+	// SourcesApplied mirrors SearchResult.SourcesApplied — false unless the backend
+	// declares it honoured the source selector (RFC BW phase 3). Recall is where this
+	// matters most: its default EXCLUDES documents, so a backend that ignored the
+	// selector would return exactly the prose the default exists to keep out.
+	SourcesApplied bool
 }

--- a/internal/memory/sources_test.go
+++ b/internal/memory/sources_test.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/denn-gubsky/loomcycle/internal/store"
@@ -26,26 +27,48 @@ func TestSearchQueryFilter_SourcesMapToPredicate(t *testing.T) {
 			comment: "every pre-RFC-BW caller lands here, so behaviour is unchanged " +
 				"unless a selector is passed",
 		},
-		{
-			name: "facts excludes the document namespace",
-			q:    SearchQuery{Sources: []Source{SourceFacts}},
-			want: store.MemorySearchFilter{ExcludeKeyPrefix: DocumentChunkKeyPrefix},
-		},
+
 		{
 			name: "documents restricts to it",
 			q:    SearchQuery{Sources: []Source{SourceDocuments}},
 			want: store.MemorySearchFilter{KeyPrefix: DocumentChunkKeyPrefix},
 		},
 		{
-			name: "both is the same as neither",
-			q:    SearchQuery{Sources: []Source{SourceFacts, SourceDocuments}},
+			name: "all three is the same as neither",
+			q:    SearchQuery{Sources: []Source{SourceFacts, SourceNotes, SourceDocuments}},
 			want: store.MemorySearchFilter{},
 			comment: "asking for everything must not produce a contradictory predicate " +
 				"(exclude AND require the same prefix), which would return nothing",
 		},
 		{
-			name: "an explicit prefix survives facts-only",
-			q:    SearchQuery{Prefix: "proj/", Sources: []Source{SourceFacts}},
+			name: "facts only requires provenance",
+			q:    SearchQuery{Sources: []Source{SourceFacts}},
+			want: store.MemorySearchFilter{
+				ExcludeKeyPrefix: DocumentChunkKeyPrefix,
+				Provenance:       store.ProvenanceRequired,
+			},
+			comment: "origin is server-stamped, so it is the unforgeable discriminator " +
+				"(RFC BW §9 Q1) — class is model-supplied and would let an agent promote " +
+				"its own note to a fact",
+		},
+		{
+			name: "notes only excludes provenance",
+			q:    SearchQuery{Sources: []Source{SourceNotes}},
+			want: store.MemorySearchFilter{
+				ExcludeKeyPrefix: DocumentChunkKeyPrefix,
+				Provenance:       store.ProvenanceAbsent,
+			},
+		},
+		{
+			name: "facts+notes is memory with no provenance constraint",
+			q:    SearchQuery{Sources: []Source{SourceFacts, SourceNotes}},
+			want: store.MemorySearchFilter{ExcludeKeyPrefix: DocumentChunkKeyPrefix},
+			comment: "the recall default: everything the agent remembers, documents " +
+				"excluded",
+		},
+		{
+			name: "an explicit prefix survives a source selector",
+			q:    SearchQuery{Prefix: "proj/", Sources: []Source{SourceFacts, SourceNotes}},
 			want: store.MemorySearchFilter{KeyPrefix: "proj/", ExcludeKeyPrefix: DocumentChunkKeyPrefix},
 		},
 		{
@@ -57,7 +80,10 @@ func TestSearchQueryFilter_SourcesMapToPredicate(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := tc.q.Filter()
+			got, err := tc.q.Filter()
+			if err != nil {
+				t.Fatalf("Filter() error = %v", err)
+			}
 			if got != tc.want {
 				t.Errorf("Filter() = %+v, want %+v\n%s", got, tc.want, tc.comment)
 			}
@@ -69,12 +95,78 @@ func TestSearchQueryFilter_SourcesMapToPredicate(t *testing.T) {
 // closed rather than open: requiring AND excluding the same prefix matches no row, so
 // a caller asking for facts AND documents would get an empty result.
 func TestSearchQueryFilter_BothSourcesIsNotContradictory(t *testing.T) {
-	f := SearchQuery{Sources: []Source{SourceDocuments, SourceFacts}}.Filter()
+	f, err := SearchQuery{Sources: []Source{SourceDocuments, SourceFacts, SourceNotes}}.Filter()
+	if err != nil {
+		t.Fatalf("all three sources should be expressible: %v", err)
+	}
 	if f.KeyPrefix == DocumentChunkKeyPrefix && f.ExcludeKeyPrefix == DocumentChunkKeyPrefix {
 		t.Fatal("asking for both sources produced require-and-exclude on the same prefix, " +
 			"which matches nothing — the widest request would return the narrowest result")
 	}
 	if !f.IsZero() {
 		t.Errorf("both sources should constrain nothing, got %+v", f)
+	}
+}
+
+// TestSearchQueryFilter_RefusesInexpressibleCombinations pins the deliberate limit.
+//
+// Documents-plus-only-one-of-facts/notes needs a DISJUNCTION across two independent
+// dimensions — `(key LIKE doc) OR (key NOT LIKE doc AND provenance…)`. It could be
+// built and is deliberately not; the alternative that matters is what happens instead.
+// Silently widening to "everything" would hand back rows the caller excluded while it
+// believed the filter applied, which is the exact failure RFC BW §6 exists to prevent:
+// a result trusted for a label it did not earn.
+func TestSearchQueryFilter_RefusesInexpressibleCombinations(t *testing.T) {
+	for _, srcs := range [][]Source{
+		{SourceFacts, SourceDocuments},
+		{SourceNotes, SourceDocuments},
+	} {
+		got, err := (SearchQuery{Sources: srcs}).Filter()
+		if !errors.Is(err, ErrSourcesNotExpressible) {
+			t.Errorf("Filter(%v) err = %v, want ErrSourcesNotExpressible — silently widening "+
+				"would return rows the caller excluded", srcs, err)
+		}
+		if !got.IsZero() {
+			t.Errorf("Filter(%v) returned a usable filter %+v alongside the error; a caller "+
+				"ignoring the error would then run an unintended query", srcs, got)
+		}
+	}
+	// And the supported sets must NOT refuse.
+	for _, srcs := range [][]Source{
+		nil,
+		{SourceFacts},
+		{SourceNotes},
+		{SourceFacts, SourceNotes},
+		{SourceDocuments},
+		{SourceFacts, SourceNotes, SourceDocuments},
+	} {
+		if _, err := (SearchQuery{Sources: srcs}).Filter(); err != nil {
+			t.Errorf("Filter(%v) refused a supported set: %v", srcs, err)
+		}
+	}
+}
+
+// TestClass_LabelsRowsFromTheirOwnColumns — the label a result carries must be derived
+// from the same inputs the filter selects on, or `kind` becomes a claim the filter does
+// not back.
+func TestClass_LabelsRowsFromTheirOwnColumns(t *testing.T) {
+	for _, tc := range []struct {
+		key, origin string
+		want        store.MemoryRowClass
+	}{
+		{"doc.chunk:abc", "", store.MemoryRowDocument},
+		{"doc.chunk:abc", "consolidator", store.MemoryRowDocument}, // namespace wins
+		{"memory/fact/x", "consolidator", store.MemoryRowFact},
+		{"memory/fact/x", "", store.MemoryRowNote}, // no writer stamped
+		{"scratch/todo", "", store.MemoryRowNote},
+		{"scratch/todo", "  ", store.MemoryRowNote}, // whitespace is not an origin
+	} {
+		got := Class(store.MemorySearchEntry{
+			MemoryEntry: store.MemoryEntry{Key: tc.key},
+			Origin:      tc.origin,
+		})
+		if got != tc.want {
+			t.Errorf("Class(key=%q origin=%q) = %q, want %q", tc.key, tc.origin, got, tc.want)
+		}
 	}
 }

--- a/internal/store/postgres/memory_embeddings.go
+++ b/internal/store/postgres/memory_embeddings.go
@@ -132,6 +132,20 @@ func (s *Store) MemoryEmbedGet(ctx context.Context, tenantID string, scope store
 //
 // Empty (scope, scope_id) returns ([], nil) — explicit non-error so
 // "no rows yet" doesn't pollute the agent's error path.
+// provenanceCondition renders the RFC BW phase-2 provenance constraint.
+//
+// coalesce, because `origin` is nullable: legacy rows predate the column and a bare
+// `origin <> ”` would silently drop every one of them from a facts-only search.
+func provenanceCondition(c store.MemoryProvenanceConstraint) string {
+	switch c {
+	case store.ProvenanceRequired:
+		return " AND coalesce(m.origin, '') <> ''"
+	case store.ProvenanceAbsent:
+		return " AND coalesce(m.origin, '') = ''"
+	}
+	return ""
+}
+
 // likePrefixPattern turns a literal key prefix into a LIKE pattern.
 //
 // ESCAPED, because a prefix is caller-supplied and LIKE treats % and _ as wildcards:
@@ -230,10 +244,11 @@ func (s *Store) MemoryEmbedSearch(ctx context.Context, tenantID string, scope st
 		args = append(args, likePrefixPattern(filter.ExcludeKeyPrefix))
 		prefixCondition += " AND me.key NOT LIKE $" + strconv.Itoa(len(args))
 	}
+	prefixCondition += provenanceCondition(filter.Provenance)
 	sql := `SELECT me.key, m.value, m.expires_at, m.created_at, m.updated_at,
 	               1.0 - (me.embedding <=> $4::vector) AS score,
 	               me.provider, me.model, me.embedding::text AS embedding_text,
-	               m.access_count
+	               m.access_count, coalesce(m.origin, '') AS origin
 	         FROM memory_embeddings me
 	         JOIN memory m
 	            ON me.tenant_id = m.tenant_id
@@ -266,8 +281,9 @@ func (s *Store) MemoryEmbedSearch(ctx context.Context, tenantID string, scope st
 			provider, modelStr string
 			embeddingText      string
 			accessCount        int64
+			origin             string
 		)
-		if err := rows.Scan(&key, &valueBytes, &expiresAt, &createdAt, &updatedAt, &score, &provider, &modelStr, &embeddingText, &accessCount); err != nil {
+		if err := rows.Scan(&key, &valueBytes, &expiresAt, &createdAt, &updatedAt, &score, &provider, &modelStr, &embeddingText, &accessCount, &origin); err != nil {
 			return nil, fmt.Errorf("MemoryEmbedSearch scan: %w", err)
 		}
 		entry := store.MemorySearchEntry{
@@ -279,6 +295,7 @@ func (s *Store) MemoryEmbedSearch(ctx context.Context, tenantID string, scope st
 			},
 			Score:       score,
 			AccessCount: accessCount,
+			Origin:      origin,
 		}
 		if expiresAt != nil {
 			entry.ExpiresAt = *expiresAt
@@ -337,13 +354,14 @@ func (s *Store) MemoryFullTextSearch(ctx context.Context, tenantID string, scope
 		args = append(args, likePrefixPattern(filter.ExcludeKeyPrefix))
 		prefixCondition += " AND me.key NOT LIKE $" + strconv.Itoa(len(args))
 	}
+	prefixCondition += provenanceCondition(filter.Provenance)
 	// plainto_tsquery normalises arbitrary user text into a safe tsquery
 	// (never errors on input, no injection surface), returning the empty
 	// query — which matches nothing — when the text yields no lexemes.
 	sql := `SELECT me.key, m.value, m.expires_at, m.created_at, m.updated_at,
 	               ts_rank(me.embed_text_tsv, plainto_tsquery('english', $4)) AS score,
 	               me.provider, me.model, me.embedding::text AS embedding_text,
-	               m.access_count
+	               m.access_count, coalesce(m.origin, '') AS origin
 	         FROM memory_embeddings me
 	         JOIN memory m
 	            ON me.tenant_id = m.tenant_id
@@ -376,8 +394,9 @@ func (s *Store) MemoryFullTextSearch(ctx context.Context, tenantID string, scope
 			provider, modelStr string
 			embeddingText      string
 			accessCount        int64
+			origin             string
 		)
-		if err := rows.Scan(&key, &valueBytes, &expiresAt, &createdAt, &updatedAt, &score, &provider, &modelStr, &embeddingText, &accessCount); err != nil {
+		if err := rows.Scan(&key, &valueBytes, &expiresAt, &createdAt, &updatedAt, &score, &provider, &modelStr, &embeddingText, &accessCount, &origin); err != nil {
 			return nil, fmt.Errorf("MemoryFullTextSearch scan: %w", err)
 		}
 		entry := store.MemorySearchEntry{
@@ -389,6 +408,7 @@ func (s *Store) MemoryFullTextSearch(ctx context.Context, tenantID string, scope
 			},
 			Score:       score,
 			AccessCount: accessCount,
+			Origin:      origin,
 		}
 		if expiresAt != nil {
 			entry.ExpiresAt = *expiresAt

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2876,6 +2876,57 @@ type MemorySearchFilter struct {
 	//
 	// Composes with KeyPrefix as an AND. Both being set is unusual but well-defined.
 	ExcludeKeyPrefix string
+
+	// Provenance splits an agent's own memory into consolidated FACTS and plain
+	// NOTES (RFC BW phase 2). Zero value constrains nothing, so every existing
+	// caller is unaffected.
+	Provenance MemoryProvenanceConstraint
+}
+
+// MemoryProvenanceConstraint selects rows by whether they carry provenance.
+//
+// The discriminator is `origin`, NOT `class` (RFC BW §9 Q1). Both are provenance
+// columns, but origin is stamped by the server from the writer's identity while class
+// is model-supplied on `op=set` — so keying "is this a consolidated fact" off class
+// would let an agent promote its own note to a fact by labelling it. class remains
+// useful as a filter dimension; it is not the class boundary.
+type MemoryProvenanceConstraint uint8
+
+const (
+	// ProvenanceAny is the zero value: no constraint.
+	ProvenanceAny MemoryProvenanceConstraint = iota
+	// ProvenanceRequired matches rows with a non-empty origin — distilled by a
+	// known writer (the consolidator).
+	ProvenanceRequired
+	// ProvenanceAbsent matches rows with no origin — written directly by an agent.
+	ProvenanceAbsent
+)
+
+// MemoryRowClass labels what kind of remembered thing a row is, so a caller can tell
+// "the user told me this" from "this is written down in a document" (RFC BW §4b).
+type MemoryRowClass string
+
+const (
+	MemoryRowFact     MemoryRowClass = "fact"
+	MemoryRowNote     MemoryRowClass = "note"
+	MemoryRowDocument MemoryRowClass = "document"
+)
+
+// ClassifyMemoryRow derives a row's class. ONE definition, because the filter that
+// selects a class and the label that reports it must agree — a search that returned
+// rows labelled `note` when the caller asked for `facts` would make the label a lie
+// rather than a refinement.
+//
+// documentKeyPrefix is passed rather than hardcoded: the namespace belongs to the
+// Document tool, and storage should not know its spelling.
+func ClassifyMemoryRow(key, origin, documentKeyPrefix string) MemoryRowClass {
+	if documentKeyPrefix != "" && strings.HasPrefix(key, documentKeyPrefix) {
+		return MemoryRowDocument
+	}
+	if strings.TrimSpace(origin) != "" {
+		return MemoryRowFact
+	}
+	return MemoryRowNote
 }
 
 // IsZero reports whether the filter constrains nothing — the signal that a backend
@@ -3003,6 +3054,10 @@ type MemorySearchEntry struct {
 	// Producers (the fusion step, the pure-vector fast path, a remote backend)
 	// set it explicitly; json:"-": it feeds ranking, not the agent-facing row.
 	SemanticScore float64 `json:"-"`
+	// Origin is the base row's provenance writer (RFC BL), carried so a result can be
+	// CLASSIFIED as a consolidated fact rather than an agent note. json:"-": callers
+	// render the derived `kind`, not the raw column, so the taxonomy stays one thing.
+	Origin string `json:"-"`
 	// AccessCount is the base row's access_count (RFC BL). Populated by the
 	// search legs so the hybrid ranker's frequency_weight term can reward
 	// frequently-recalled entries. Zero when the backend doesn't track it

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -11154,6 +11154,54 @@ func testMemorySearchFilterExcludesPrefix(t *testing.T, s store.Store) {
 			"fields must compose as an AND rather than one silently winning", keysOf(none))
 	}
 
+	// RFC BW phase 2: the provenance split. `origin` is the discriminator because it is
+	// server-stamped (§9 Q1) — keying off the model-supplied `class` would let an agent
+	// promote its own note to a fact by labelling it.
+	if err := s.MemorySetProvenance(ctx, "", store.MemoryScopeUser, sid, "memory/fact/distilled", v, 0,
+		store.MemoryProvenance{Origin: "consolidator", Class: "preference"}); err != nil {
+		t.Fatalf("MemorySetProvenance: %v", err)
+	}
+	if err := s.MemoryEmbedSet(ctx, "", store.MemoryScopeUser, sid, "memory/fact/distilled", store.MemoryEmbedding{
+		Provider: "test", Model: "m", Dimension: 4,
+		Vector: floats32(1, 0, 0, 0), EmbedText: "distilled", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("MemoryEmbedSet: %v", err)
+	}
+
+	onlyFacts, err := s.MemoryEmbedSearch(ctx, "", store.MemoryScopeUser, sid,
+		store.MemorySearchFilter{
+			ExcludeKeyPrefix: "doc.chunk:",
+			Provenance:       store.ProvenanceRequired,
+		}, q, 10)
+	if err != nil {
+		t.Fatalf("facts only: %v", err)
+	}
+	if !reflect.DeepEqual(keysOf(onlyFacts), []string{"memory/fact/distilled"}) {
+		t.Errorf("ProvenanceRequired returned %v, want only the consolidated row", keysOf(onlyFacts))
+	}
+	// The row must also CARRY its origin, or a result cannot be labelled `fact` and the
+	// selector and the label would disagree.
+	for _, r := range onlyFacts {
+		if r.Origin == "" {
+			t.Errorf("%s came back with no Origin — the label `kind` is derived from it, so "+
+				"without it a caller cannot tell a distilled fact from a note", r.Key)
+		}
+	}
+
+	onlyNotes, err := s.MemoryEmbedSearch(ctx, "", store.MemoryScopeUser, sid,
+		store.MemorySearchFilter{
+			ExcludeKeyPrefix: "doc.chunk:",
+			Provenance:       store.ProvenanceAbsent,
+		}, q, 10)
+	if err != nil {
+		t.Fatalf("notes only: %v", err)
+	}
+	if !reflect.DeepEqual(keysOf(onlyNotes), []string{"memory/fact/a"}) {
+		t.Errorf("ProvenanceAbsent returned %v, want only the un-stamped row — a LEGACY row "+
+			"predating the origin column must count as a note rather than vanishing from "+
+			"both halves of the split", keysOf(onlyNotes))
+	}
+
 	// The LEXICAL leg must apply the same exclusion: the backend fuses both by RRF, so
 	// a document row admitted by either one still reaches the caller.
 	if s.SupportsFullText() {

--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -215,7 +215,7 @@ const memoryInputSchema = `{
     "delta":      {"type": "integer", "description": "Increment delta for incr (default 1, may be negative)."},
     "ttl":        {"type": "integer", "description": "Optional time-to-live in seconds. Applies to write ops; 0 means no expiry (or keep existing on update)."},
     "prefix":     {"type": "string", "description": "Optional key prefix filter for list / search."},
-    "sources":    {"type": "array", "items": {"type": "string", "enum": ["facts","documents"]}, "description": "search / recall: which kinds of remembered thing to return. \"facts\" = your own memory; \"documents\" = Document chunk bodies, which share the memory keyspace. recall defaults to facts only (document prose is not something you were told); search defaults to both. Use this instead of guessing key prefixes."},
+    "sources":    {"type": "array", "items": {"type": "string", "enum": ["facts","notes","documents"]}, "description": "search / recall: which kinds of remembered thing to return. \"facts\" = memory a consolidator distilled; \"notes\" = memory an agent wrote directly; \"documents\" = Document chunk bodies, which share the memory keyspace. recall defaults to facts+notes (document prose is not something you were told); search defaults to everything. Each result carries a matching \"kind\". Mixing documents with only ONE of facts/notes is refused — use [facts], [notes], [facts,notes], [documents], or all three. Use this instead of guessing key prefixes."},
     "limit":      {"type": "integer", "description": "list: max entries returned (default 100). bounded_list: keep the N most recent items (required, >= 1). cursor_scan: max chats returned in one page (default 10, max 50)."},
     "embed":      {"type": "boolean", "description": "v0.9.0 set-only: when true, also generates and stores an embedding so this row is reachable via op=search."},
     "embed_text": {"type": "string", "description": "v0.9.0 set-only: the text to embed when embed=true. Defaults to the JSON-stringified value when omitted."},
@@ -1308,13 +1308,20 @@ func (m *Memory) execSearch(ctx context.Context, scope store.MemoryScope, scopeI
 			errors.Is(err, store.ErrEmbedderNotConfigured) {
 			return errResult(err.Error()), nil
 		}
+		if errors.Is(err, memrank.ErrSourcesNotExpressible) {
+			return errResult(err.Error()), nil
+		}
 		return errResult(fmt.Sprintf("search: %s", err)), nil
 	}
 
 	entries := make([]map[string]any, 0, len(res.Entries))
 	for i, r := range res.Entries {
 		entries = append(entries, map[string]any{
-			"key":        r.Key,
+			"key": r.Key,
+			// kind tells a caller WHAT it got: a document hit is prose written down
+			// somewhere, not something the user said, and weighing them alike is how
+			// a fence marker outranks a medication (RFC BW §4b).
+			"kind":       string(memrank.Class(r)),
 			"value":      r.Value,
 			"score":      r.Score,           // raw cosine similarity — NEVER touched by hybrid fusion or ranking (stable across searches)
 			"rank_score": res.RankScores[i], // computed rank the result was ordered by: fused-semantic (RRF) + recency + frequency
@@ -1329,6 +1336,14 @@ func (m *Memory) execSearch(ctx context.Context, scope store.MemoryScope, scopeI
 		"entries":             entries,
 		"query_embedding_dim": res.QueryEmbeddingDim,
 		"truncated":           res.Truncated,
+	}
+	// Only when a selector was actually requested: a caller that passed none has
+	// nothing to be warned about, and an always-present key would change the response
+	// shape for every existing search (RFC BW §6).
+	if len(in.Sources) > 0 && !res.SourcesApplied {
+		out["sources_applied"] = false
+		out["note"] = "this memory backend did not apply the source selector, so these " +
+			"results are NOT restricted to the kinds you asked for"
 	}
 	// Surface dedup_dropped ONLY when the caller opted into dedup. A search
 	// with no `dedup` block keeps the pre-MR-5 response shape byte-for-byte
@@ -1452,7 +1467,18 @@ func (m *Memory) execRecall(ctx context.Context, scope store.MemoryScope, scopeI
 		}
 		facts = append(facts, fact)
 	}
-	return okJSON(map[string]any{"facts": facts})
+	out := map[string]any{"facts": facts}
+	// A BACKEND THAT IGNORED THE SELECTOR MUST NOT LOOK LIKE ONE THAT HONOURED IT
+	// (RFC BW §6). Recall's default EXCLUDES document prose, so a backend that dropped
+	// the selector returns exactly what the default exists to keep out — and the caller
+	// would read it as remembered fact. Say so rather than refuse: refusing would make
+	// a backend swap break working agents.
+	if !res.SourcesApplied {
+		out["sources_applied"] = false
+		out["note"] = "this memory backend did not apply the source selector, so these " +
+			"results may include document prose rather than only remembered facts"
+	}
+	return okJSON(out)
 }
 
 // --- RFC BL P2 consolidation control ops ---


### PR DESCRIPTION
Completes RFC BW. P2 splits memory into **facts** and **notes**, labels every result, and lands adapter parity; P3 makes a backend that ignores the selector **say so** instead of looking like one that honoured it.

## §9 Q1 settled as the RFC recommended

**`origin` is the discriminator, not `class`.** Both are provenance columns, but `origin` is stamped by the server from the writer's identity while `class` is model-supplied on `op=set` — so keying "is this a consolidated fact" off `class` would let an agent promote its own note to a fact by labelling it. `class` stays useful as a filter dimension; it isn't the boundary.

`coalesce` on origin, because the column is nullable: a bare `origin <> ''` would silently drop every row predating it. A legacy row counts as a **note** rather than vanishing from both halves of the split, and the contract asserts that directly.

## Two source combinations are refused, and the refusal is the point

`documents` together with only **one** of facts/notes needs a disjunction across two independent dimensions — a key namespace and a column. It could be built and deliberately isn't, because what matters is the alternative: silently widening to "everything" hands back rows the caller excluded **while it believes the filter applied**, which is precisely the failure RFC BW §6 exists to prevent. The error names the supported sets.

Both refused sets are also odd requests ("my facts and my documents but not my notes"). If one turns out to be real, the disjunction is the fix.

There's a test asserting the refusal returns **no usable filter** alongside the error, so a caller that ignores the error can't run an unintended query.

## Results say what they are

`kind` is `fact` | `note` | `document`, derived by **one** function from the same inputs the filter selects on — a label computed differently from the predicate would be a claim the filter doesn't back. That's why the search row had to start carrying `origin`: without it a result can't be classified and `kind` would be a guess.

This also removed a duplicated taxonomy: `/v1/_memory/search` had its own `docChunkKeyPrefix` constant *and* its own prefix check for `kind` — a second definition of the same boundary, which is how the two drift.

## P3: false is the zero value on purpose

`SearchResult`/`RecallResult` gain `SourcesApplied`. A backend that ignores the selector — an external memory-layer service with its own namespaces — must not be able to do so silently, because the caller would then trust a label the result doesn't deserve: it asked for facts and is reading document prose. **The honest answer is what you get for free; honouring the selector is what you have to declare.**

The tool surfaces `sources_applied: false` plus a note rather than refusing — refusing would make a backend swap break working agents. Recall is where it matters most: its default excludes documents, so a backend that dropped the selector returns exactly what the default exists to keep out.

## Wire change (RFC BW §7, taken deliberately)

`kind` on `/v1/_memory/search` was `"memory" | "document"`, now `"fact" | "note" | "document"`. Code switching on `"document"` is unaffected; code comparing against `"memory"` must move. `@loomcycle/client` moves in lockstep — types, the `sources` passthrough, and the `MemorySource` export.

The endpoint keeps its **span-everything default** rather than adopting recall's facts-only one: it exists to answer "where did I record this" across both planes, so narrowing it would break what #947 shipped.

## Tested

- the full source→predicate matrix, both refused sets, and the label derivation (namespace wins over a stamped origin; whitespace is not an origin)
- store contract on **both tiers** for `ProvenanceRequired`/`Absent`, the legacy-row case, and that the row carries `origin` at all
- **fail-before verified on pgvector**: dropping the provenance predicate returns both rows
- adapter — `sources` sent only when set, all three kinds round-trip, only a document hit carries `chunk_id`

Two existing fixtures moved off `kind:"memory"`; that's the documented break, not an incidental edit. `go test ./...` clean, 268 adapter tests pass.

## Note

`@loomcycle/client` is at **1.48.0** (published). If this ships as 1.49.0 the package version needs bumping in the release PR, or the publish skips — the trap from two releases ago.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8