### PR TITLE
feat(memory-view): source selector + labelled kinds in the search panel (RFC BW UI)

### DIFF
--- a/packages/memory-view/package-lock.json
+++ b/packages/memory-view/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@loomcycle/client": "^1.48.0",
+        "@loomcycle/client": "^1.49.0",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -21,7 +21,7 @@
         "vitest": "^3.0.0"
       },
       "peerDependencies": {
-        "@loomcycle/client": "^1.48.0",
+        "@loomcycle/client": "^1.49.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
       }
@@ -751,9 +751,9 @@
       }
     },
     "node_modules/@loomcycle/client": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/@loomcycle/client/-/client-1.48.0.tgz",
-      "integrity": "sha512-rWj8g2s9UUkwL7YzEwrik5W5xMC8/TH0kOJr3Ug/ypV9zU11INezmRgItLrViQUtYALTB00ZoMOOqeQ79yfxwA==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/@loomcycle/client/-/client-1.49.0.tgz",
+      "integrity": "sha512-qiK9jgktJANI9WKOEBABjxSq1nEKIRnUNrjacDBd3Wz7//o6vTcLbpPVsYzvS4bO/fUCsKg+dW1dYg0X+zS3Kw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {

--- a/packages/memory-view/package.json
+++ b/packages/memory-view/package.json
@@ -48,12 +48,12 @@
     "test:watch": "vitest"
   },
   "peerDependencies": {
-    "@loomcycle/client": "^1.48.0",
+    "@loomcycle/client": "^1.49.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
-    "@loomcycle/client": "^1.48.0",
+    "@loomcycle/client": "^1.49.0",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/packages/memory-view/src/components/SearchPanel.tsx
+++ b/packages/memory-view/src/components/SearchPanel.tsx
@@ -1,14 +1,16 @@
 import { useRef, useState } from "react";
-import type { MemorySearchEntry, MemoryScope } from "../types";
+import type { MemorySearchEntry, MemoryScope, MemorySource } from "../types";
 import { useMemoryData } from "../lib/dataLayer";
 import Splitter from "./Splitter";
 import ChunkDetailPanel from "./ChunkDetailPanel";
 
 // SearchPanel — the off-run UNIFIED semantic search (POST /v1/_memory/search). One
-// ranked list spanning both plain k/v entries (kind:"memory") and document-chunk
-// bodies (kind:"document"). A document hit opens the shared ChunkDetailPanel (its
-// entity block via get_chunk); a memory hit deep-links back to the k/v console
-// through the onSelectEntry callback.
+// ranked list; each hit is labelled by kind (RFC BW): "fact" (a consolidator
+// distilled it), "note" (an agent wrote it directly), or "document" (a Document
+// chunk body). A document hit opens the shared ChunkDetailPanel (its entity block
+// via get_chunk); a fact/note hit shows its key + value and can deep-link back to
+// the k/v console via onSelectEntry. The `source` field narrows which kinds come
+// back (facts / notes / documents; empty = all planes).
 //
 // Search needs an embedder + a vector store. When the deployment has neither (or
 // a stale dimension) the server returns 400 `search_unavailable`; we render a
@@ -30,6 +32,11 @@ export default function SearchPanel({ scope: scopeProp = "user", scopeId: scopeI
   const [query, setQuery] = useState("");
   const [scope, setScope] = useState<MemoryScope>(scopeProp);
   const [scopeId, setScopeId] = useState(scopeIdProp);
+  // RFC BW `sources` selector (facts | notes | documents). Empty = every plane.
+  // A single-value field never hits the invalid_sources 400 (which only rejects
+  // mixing "documents" with just ONE of facts/notes). Free text is accepted — the
+  // datalist suggests the valid values and the server drops anything unknown.
+  const [source, setSource] = useState("");
   const [results, setResults] = useState<MemorySearchEntry[] | null>(null);
   // The (scope, scope_id) the current `results` were fetched under — snapshotted
   // at search time so the detail panel + deep-link use the scope the hits came
@@ -56,7 +63,14 @@ export default function SearchPanel({ scope: scopeProp = "user", scopeId: scopeI
     setUnavailable(false);
     setSelected("");
     try {
-      const resp = await data.search({ query: query.trim(), scope: target.scope, scopeId: target.scopeId });
+      const resp = await data.search({
+        query: query.trim(),
+        scope: target.scope,
+        scopeId: target.scopeId,
+        // A free-typed unknown source is dropped server-side (→ all planes), so
+        // the cast is safe: the datalist offers the valid values, the server validates.
+        sources: source.trim() ? [source.trim() as MemorySource] : undefined,
+      });
       if (token !== reqRef.current) return; // a newer search superseded this one
       setResults(resp.entries ?? []);
       setSearched(target);
@@ -99,6 +113,22 @@ export default function SearchPanel({ scope: scopeProp = "user", scopeId: scopeI
           disabled={!needsScopeId}
           onChange={(e) => setScopeId(e.target.value)}
         />
+        {/* Source: an editable combobox (dropdown of the known kinds + free text).
+            Empty by default → every plane. */}
+        <input
+          type="text"
+          className="search-source-input"
+          list="memory-source-options"
+          placeholder="source (all)…"
+          value={source}
+          onChange={(e) => setSource(e.target.value)}
+          title="Narrow to a source — facts, notes, or documents. Empty searches every plane."
+        />
+        <datalist id="memory-source-options">
+          <option value="facts" />
+          <option value="notes" />
+          <option value="documents" />
+        </datalist>
         <input
           type="text"
           className="search-query-input"
@@ -143,7 +173,7 @@ export default function SearchPanel({ scope: scopeProp = "user", scopeId: scopeI
                     onClick={() => setSelected(rowKey)}
                   >
                     <div className="search-hit-head">
-                      <span className={"search-kind-badge " + (isDoc ? "search-kind-doc" : "search-kind-mem")}>
+                      <span className={`search-kind-badge search-kind-${hit.kind}`}>
                         {hit.kind}
                       </span>
                       <span className="search-hit-key">

--- a/packages/memory-view/src/index.ts
+++ b/packages/memory-view/src/index.ts
@@ -38,6 +38,7 @@ export type {
   MemorySearchInput,
   MemorySearchEntry,
   MemorySearchResponse,
+  MemorySource,
   FactEntity,
   FactRow,
   FactListResponse,

--- a/packages/memory-view/src/lib/dataLayer.test.ts
+++ b/packages/memory-view/src/lib/dataLayer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import type { LoomcycleClient } from "@loomcycle/client";
+import type { LoomcycleClient, MemorySearchInput } from "@loomcycle/client";
 import { dataLayerFromClient } from "./dataLayer";
 
 // A recording stub for the eight off-run memory admin methods the data layer
@@ -123,9 +123,9 @@ describe("dataLayerFromClient — @loomcycle/client → memory wire mapping", ()
 
   // ---- P4b: unified search + entity/fact tier ----
 
-  it("search forwards the MemorySearchInput to client.memorySearch unchanged", async () => {
+  it("search forwards the MemorySearchInput (incl. the RFC BW sources selector) unchanged", async () => {
     const s = stubClient();
-    const input = { query: "rate limits", scope: "user", scopeId: "alice", topK: 5 };
+    const input: MemorySearchInput = { query: "rate limits", scope: "user", scopeId: "alice", topK: 5, sources: ["facts"] };
     await dataLayerFromClient(s.client).search(input);
     expect(s.memorySearch).toHaveBeenCalledWith(input);
   });

--- a/packages/memory-view/src/styles.css
+++ b/packages/memory-view/src/styles.css
@@ -1000,6 +1000,11 @@
   font-family: var(--mono);
   font-size: 12px;
 }
+.loomcycle-memory-view .search-source-input {
+  width: 120px;
+  font-family: var(--mono);
+  font-size: 12px;
+}
 .loomcycle-memory-view .search-submit-btn {
   background: var(--accent);
   border: 1px solid var(--accent);
@@ -1060,11 +1065,17 @@
   letter-spacing: 0.04em;
   flex-shrink: 0;
 }
-.loomcycle-memory-view .search-kind-doc {
+/* Per-kind result badges (RFC BW): a document is prose written down, a fact was
+   distilled by the consolidator, a note is an agent's own jotting. */
+.loomcycle-memory-view .search-kind-document {
   border-color: var(--accent);
   color: var(--accent);
 }
-.loomcycle-memory-view .search-kind-mem {
+.loomcycle-memory-view .search-kind-fact {
+  border-color: var(--success, var(--accent));
+  color: var(--success, var(--accent));
+}
+.loomcycle-memory-view .search-kind-note {
   color: var(--fg-soft);
 }
 .loomcycle-memory-view .search-hit-key {

--- a/packages/memory-view/src/types.ts
+++ b/packages/memory-view/src/types.ts
@@ -24,9 +24,12 @@ export type {
   SetMemoryEntryOptions,
   SetMemoryEntryResponse,
   // P4b — the off-run unified semantic search shapes (POST /v1/_memory/search).
+  // MemorySource (RFC BW) is the `sources` selector value: "facts" | "notes" |
+  // "documents". MemorySearchEntry.kind is the labelled result class.
   MemorySearchInput,
   MemorySearchEntry,
   MemorySearchResponse,
+  MemorySource,
 } from "@loomcycle/client";
 
 // MemoryScope selects WHICH scope's rows to browse (agent / user — or whatever

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,7 +11,7 @@
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
         "@fontsource-variable/outfit": "^5.2.8",
-        "@loomcycle/client": "^1.48.0",
+        "@loomcycle/client": "^1.49.0",
         "js-yaml": "^4.2.0",
         "lucide-react": "^0.460.0",
         "mermaid": "^11.16.0",
@@ -876,9 +876,9 @@
       }
     },
     "node_modules/@loomcycle/client": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/@loomcycle/client/-/client-1.48.0.tgz",
-      "integrity": "sha512-rWj8g2s9UUkwL7YzEwrik5W5xMC8/TH0kOJr3Ug/ypV9zU11INezmRgItLrViQUtYALTB00ZoMOOqeQ79yfxwA==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/@loomcycle/client/-/client-1.49.0.tgz",
+      "integrity": "sha512-qiK9jgktJANI9WKOEBABjxSq1nEKIRnUNrjacDBd3Wz7//o6vTcLbpPVsYzvS4bO/fUCsKg+dW1dYg0X+zS3Kw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"

--- a/web/package.json
+++ b/web/package.json
@@ -15,7 +15,7 @@
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@fontsource-variable/outfit": "^5.2.8",
-    "@loomcycle/client": "^1.48.0",
+    "@loomcycle/client": "^1.49.0",
     "js-yaml": "^4.2.0",
     "lucide-react": "^0.460.0",
     "mermaid": "^11.16.0",


### PR DESCRIPTION
## Why

RFC BW (#956–#959, shipped v1.49.0) added a **`sources`** selector to memory search — a caller names *what kind* of remembered thing it wants (`facts` / `notes` / `documents`) instead of spelling a key prefix — and refined each result's `kind` from `memory|document` to `fact|note|document`. This surfaces that in the `@loomcycle/memory-view` SearchPanel so an operator can drive it from the UI, per the "search panel should have a source field" request.

## What

- **A "source" field** on the SearchPanel — an editable combobox (`<input list>` + `<datalist>`): **empty by default** (search every plane), a **dropdown** of the known sources (`facts` / `notes` / `documents`), and **free-text entry**. It's passed through as the `sources` selector on `POST /v1/_memory/search`.
  - A single value never trips the `invalid_sources` 400 (which only rejects mixing `documents` with *one* of facts/notes), and an unknown free-typed value is dropped server-side (→ all planes) — so free-edit is safe.
- **Labelled result kinds** — RFC BW changed a hit's `kind` `memory|document` → `fact|note|document`; the SearchPanel badge now styles **per-kind** (fact = distilled by the consolidator, note = an agent's own jotting, document = prose) instead of the stale binary. A document hit still opens the `ChunkDetailPanel`; a fact/note hit shows its key + value.
- Re-export `MemorySource`; the dataLayer forwards `sources` unchanged.
- **Pin `@loomcycle/client` `^1.49.0`** (the version carrying the RFC BW client surface) in the package + web, with regenerated lockfiles.

## Tested

- Package `typecheck` + `build` + **16 tests** (the dataLayer test now asserts the `sources` selector round-trips), and the **web dogfood** `typecheck` + `build` — all against the **real published `@loomcycle/client@1.49.0`**.
- The diff is exactly the UI source + the pin/lockfile bumps; no stray package churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
