### PR TITLE
fix(memory-view): make the search source field a visible dropdown combobox

### DIFF
--- a/packages/memory-view/src/components/SearchPanel.tsx
+++ b/packages/memory-view/src/components/SearchPanel.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { MemorySearchEntry, MemoryScope, MemorySource } from "../types";
 import { useMemoryData } from "../lib/dataLayer";
 import Splitter from "./Splitter";
@@ -113,22 +113,9 @@ export default function SearchPanel({ scope: scopeProp = "user", scopeId: scopeI
           disabled={!needsScopeId}
           onChange={(e) => setScopeId(e.target.value)}
         />
-        {/* Source: an editable combobox (dropdown of the known kinds + free text).
-            Empty by default → every plane. */}
-        <input
-          type="text"
-          className="search-source-input"
-          list="memory-source-options"
-          placeholder="source (all)…"
-          value={source}
-          onChange={(e) => setSource(e.target.value)}
-          title="Narrow to a source — facts, notes, or documents. Empty searches every plane."
-        />
-        <datalist id="memory-source-options">
-          <option value="facts" />
-          <option value="notes" />
-          <option value="documents" />
-        </datalist>
+        {/* Source: a combobox (visible dropdown of the known kinds + free text).
+            Empty = every plane. */}
+        <SourceCombobox value={source} onChange={setSource} />
         <input
           type="text"
           className="search-query-input"
@@ -230,6 +217,79 @@ export default function SearchPanel({ scope: scopeProp = "user", scopeId: scopeI
               })()}
           </div>
         </Splitter>
+      )}
+    </div>
+  );
+}
+
+// The RFC BW source kinds, plus an explicit "all" (empty selector = every plane).
+const SOURCE_OPTIONS: { value: string; label: string }[] = [
+  { value: "", label: "all sources" },
+  { value: "facts", label: "facts" },
+  { value: "notes", label: "notes" },
+  { value: "documents", label: "documents" },
+];
+
+// SourceCombobox — a VISIBLE dropdown of the RFC BW source kinds that is also
+// free-text editable. A bare <datalist> reads as an empty text box (its choices
+// only surface on focus, browser-dependent), so this is an explicit combobox:
+// a text input + a chevron that opens the list on click, with outside-click /
+// Escape to close. Typing passes straight through — an unknown value is dropped
+// server-side, so free text is safe.
+function SourceCombobox({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [open]);
+
+  return (
+    <div className="search-source" ref={wrapRef}>
+      <input
+        type="text"
+        className="search-source-input"
+        placeholder="source: all"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onFocus={() => setOpen(true)}
+        onKeyDown={(e) => e.key === "Escape" && setOpen(false)}
+        aria-label="source filter"
+      />
+      <button
+        type="button"
+        className="search-source-toggle"
+        aria-label="choose a source"
+        tabIndex={-1}
+        onClick={() => setOpen((o) => !o)}
+      >
+        ▾
+      </button>
+      {open && (
+        <ul className="search-source-menu" role="listbox">
+          {SOURCE_OPTIONS.map((o) => (
+            <li
+              key={o.value || "all"}
+              role="option"
+              aria-selected={value === o.value}
+              className={value === o.value ? "on" : ""}
+              // onMouseDown + preventDefault so the pick registers before the
+              // input's blur would close the menu.
+              onMouseDown={(e) => {
+                e.preventDefault();
+                onChange(o.value);
+                setOpen(false);
+              }}
+            >
+              {o.label}
+            </li>
+          ))}
+        </ul>
       )}
     </div>
   );

--- a/packages/memory-view/src/styles.css
+++ b/packages/memory-view/src/styles.css
@@ -1000,10 +1000,63 @@
   font-family: var(--mono);
   font-size: 12px;
 }
+/* Source combobox: a text input with a chevron that opens a visible option list
+   (SourceCombobox), instead of a bare <datalist> that reads as an empty box. */
+.loomcycle-memory-view .search-source {
+  position: relative;
+  display: inline-block;
+  width: 132px;
+  flex-shrink: 0;
+}
 .loomcycle-memory-view .search-source-input {
-  width: 120px;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 20px;
   font-family: var(--mono);
   font-size: 12px;
+}
+.loomcycle-memory-view .search-source-toggle {
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 100%;
+  width: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  color: var(--fg-soft);
+  cursor: pointer;
+  font-size: 10px;
+  padding: 0;
+}
+.loomcycle-memory-view .search-source-menu {
+  position: absolute;
+  top: calc(100% + 2px);
+  left: 0;
+  right: 0;
+  z-index: 20;
+  margin: 0;
+  padding: 4px 0;
+  list-style: none;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+.loomcycle-memory-view .search-source-menu li {
+  padding: 4px 10px;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--fg);
+  cursor: pointer;
+}
+.loomcycle-memory-view .search-source-menu li:hover {
+  background: var(--bg-soft-2);
+}
+.loomcycle-memory-view .search-source-menu li.on {
+  color: var(--accent);
 }
 .loomcycle-memory-view .search-submit-btn {
   background: var(--accent);


### PR DESCRIPTION
## Why

The RFC BW `source` field (#960) shipped as a bare `<input list>` + `<datalist>`. A datalist renders as a **plain empty text box** — its `facts`/`notes`/`documents` choices only appear when the field is focused, and the dropdown affordance is subtle/browser-dependent — so an operator reads it as an empty, non-functional field (reported: "seems to be an empty field… did you even commit it?").

## What

Replace the datalist with an explicit **`SourceCombobox`**: a text input with a visible **▾ chevron** that opens a real option list — **all sources / facts / notes / documents** — on click, closing on outside-click or `Escape`. It stays **free-text editable** (typing passes straight through; an unknown value is dropped server-side, so free text is safe), and the explicit "all sources" row makes clearing the filter obvious.

**No wire change** — it drives the same `sources` selector on `POST /v1/_memory/search` exactly as before; only the control's presentation changed.

## Tested

- Package `typecheck` + `build` + 16 tests; web dogfood `typecheck` + `build` — all green against the published `@loomcycle/client@1.49.0`.
- Verified no ancestor `overflow: hidden` clips the absolutely-positioned menu; scoped `.loomcycle-memory-view` styles, dual light/dark via the existing `--*` tokens.

**Note:** the Web UI is embedded in the binary (`go:embed`), so a running deployment shows this only after `make build-all` + redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
