### PR TITLE
feat(memory): MemoryEmbedDelete + purge the embeddings of unindexable rows

### DIFF
--- a/internal/api/http/memory_backfill.go
+++ b/internal/api/http/memory_backfill.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/store"
@@ -281,14 +280,20 @@ func (s *Server) handleMemoryBackfillEmbeddings(w http.ResponseWriter, r *http.R
 // index the literal tokens `body` and `fields` alongside the prose, and for a
 // chunk with a short body the envelope could outweigh the content.
 //
-// Ordinary rows keep the existing behaviour: their whole value is the text. So
-// this narrows nothing and only improves the case the prefix targets.
+// Ordinary rows keep the existing behaviour: their whole value is the text. So this
+// narrows nothing and only improves the case the prefix targets.
+//
+// AND IT ROUTES THROUGH builtin.IndexableText, the same predicate the write path
+// applies. Without that this sweep would happily CREATE the markdown-scaffolding
+// embeddings ("```sh", "---") that embedBody rejects — the writer and the sweep
+// disagreeing about what is worth indexing, which also left the purge unable to
+// recognise them. One function, three callers.
 func embedTextForRow(row store.MemoryEntry) string {
 	var env struct {
 		Body *string `json:"body"`
 	}
 	if err := json.Unmarshal(row.Value, &env); err == nil && env.Body != nil {
-		return strings.TrimSpace(*env.Body)
+		return builtin.IndexableText(*env.Body)
 	}
-	return strings.TrimSpace(string(row.Value))
+	return builtin.IndexableText(string(row.Value))
 }

--- a/internal/api/http/memory_purge.go
+++ b/internal/api/http/memory_purge.go
@@ -1,0 +1,184 @@
+package http
+
+// memory_purge.go — POST /v1/_memory/purge_stale_embeddings.
+//
+// Deletes the embeddings of rows that should no longer be searchable at all, leaving
+// the rows themselves alone.
+//
+// WHY THIS EXISTS. The write path learned to reject text that carries no language —
+// markdown scaffolding ("```sh", "---", "#"), which a heading-split import turns into
+// its own chunk. That stops NEW ones. It does nothing about the vectors already in the
+// index, and nothing else could either: the backfill only ever ADDS an embedding, and
+// /v1/_memory/reembed re-derives its text as the raw row value, so re-embedding
+// faithfully reproduces the same junk. Deleting the chunk would work and is too big a
+// hammer — the chunk is legitimate document structure, it simply should not be a
+// search result.
+//
+// Measured on the reference deployment: a document search for "shell script example"
+// returned "```bash" three times at 0.629 and "```sh" at 0.541, above every real hit.
+// A short syntax token embeds near the centroid of everything, so it ranks mid-high
+// for EVERY query.
+//
+// THE SAFETY PROPERTY, and the only one that matters here: an embedding is deleted
+// ONLY when the row's text derives to empty under TODAY'S rules — the same
+// composition the backfill uses to decide whether to CREATE one. The two must agree,
+// because a purge computing "indexable" differently from the writer would delete rows
+// the writer would immediately re-create, or worse, delete rows that are legitimately
+// searchable. It is the inverse of the backfill, not a second opinion.
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
+)
+
+type memoryPurgeResponse struct {
+	Scope   string `json:"scope"`
+	ScopeID string `json:"scope_id"`
+	Prefix  string `json:"prefix,omitempty"`
+	DryRun  bool   `json:"dry_run"`
+
+	// Scanned is how many rows were examined, bounded by limit.
+	Scanned int `json:"scanned"`
+	// Stale is how many of them have no indexable text and therefore should carry no
+	// embedding. Purged is how many embeddings were actually removed (0 on a dry run).
+	Stale  int `json:"stale"`
+	Purged int `json:"purged"`
+	Failed int `json:"failed,omitempty"`
+	// Truncated reports that MORE rows exist beyond limit — the scan is incomplete, so
+	// a zero `stale` does not mean the scope is clean.
+	Truncated bool `json:"truncated"`
+
+	SampleKeys   []string `json:"sample_keys,omitempty"`
+	FailedKeys   []string `json:"failed_keys,omitempty"`
+	FirstFailure string   `json:"first_failure,omitempty"`
+	Notes        []string `json:"notes"`
+}
+
+const memoryPurgeSampleCap = 20
+
+// handleMemoryPurgeStaleEmbeddings serves POST
+// /v1/_memory/purge_stale_embeddings?scope=&scope_id=&tenant=&prefix=&limit=&dry_run=
+func (s *Server) handleMemoryPurgeStaleEmbeddings(w http.ResponseWriter, r *http.Request) {
+	if s.store == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "store_unavailable",
+			"store not configured; purge requires a persistent store")
+		return
+	}
+	scope := r.URL.Query().Get("scope")
+	if !validAdminMemoryScope(scope) {
+		writeJSONError(w, http.StatusBadRequest, "invalid_scope",
+			"scope must be one of: agent, user, tenant")
+		return
+	}
+	scopeID := r.URL.Query().Get("scope_id")
+	if scopeID == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing_scope_id", "scope_id is required")
+		return
+	}
+	// dry_run defaults TRUE. This one DELETES, so the default matters more than on the
+	// sweeps that only add: a bare `curl -X POST` must never remove an index entry.
+	dryRun := true
+	if v := r.URL.Query().Get("dry_run"); v != "" {
+		dryRun = v != "false" && v != "0"
+	}
+	limit := 500
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	prefix := r.URL.Query().Get("prefix")
+
+	tenant, all := s.principalTenantScope(r.Context(), r.URL.Query().Get("tenant"))
+	// Same refusal as the backfill and the erasure surfaces: memory rows are keyed on
+	// the tenant, so an admin naming none resolves to the DEFAULT tenant. On a
+	// DESTRUCTIVE op that is worse than a misleading count — it would purge a tenant
+	// the operator never named.
+	if all && !r.URL.Query().Has("tenant") {
+		writeJSONError(w, http.StatusBadRequest, "tenant_required",
+			"an admin token must name the tenant: memory rows are keyed on it, and this "+
+				"operation DELETES index entries. Pass ?tenant=<id>, or ?tenant= for the "+
+				"default tenant.")
+		return
+	}
+
+	rows, truncated, err := s.store.MemoryList(r.Context(), tenant,
+		store.MemoryScope(scope), scopeID, prefix, limit)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "list_failed", err.Error())
+		return
+	}
+
+	resp := memoryPurgeResponse{
+		Scope: scope, ScopeID: scopeID, Prefix: prefix, DryRun: dryRun,
+		Scanned: len(rows), Truncated: truncated,
+	}
+	resp.Notes = []string{
+		"a row is stale ONLY when its text derives to empty under today's rules — the " +
+			"same composition the backfill uses to decide whether to CREATE an embedding. " +
+			"This is the inverse of the backfill, not a second opinion, so it cannot " +
+			"remove something the writer would immediately put back.",
+		"the ROW is never touched; only its embedding. The chunk stays in its document, " +
+			"it simply stops being a search result.",
+	}
+	if truncated {
+		resp.Notes = append(resp.Notes,
+			"SCAN INCOMPLETE — more rows exist beyond limit, so a low `stale` count is not "+
+				"evidence the scope is clean. Raise limit or narrow with prefix.")
+	}
+
+	for _, row := range rows {
+		if staleEmbeddingText(r.Context(), s, tenant, scope, scopeID, row) != "" {
+			continue // still indexable — leave its embedding alone
+		}
+		resp.Stale++
+		if len(resp.SampleKeys) < memoryPurgeSampleCap {
+			resp.SampleKeys = append(resp.SampleKeys, row.Key)
+		}
+		if dryRun {
+			continue
+		}
+		if err := s.store.MemoryEmbedDelete(r.Context(), tenant,
+			store.MemoryScope(scope), scopeID, row.Key); err != nil {
+			resp.Failed++
+			if len(resp.FailedKeys) < memoryPurgeSampleCap {
+				resp.FailedKeys = append(resp.FailedKeys, row.Key)
+			}
+			if resp.FirstFailure == "" {
+				resp.FirstFailure = err.Error()
+			}
+			continue
+		}
+		resp.Purged++
+	}
+
+	if dryRun {
+		resp.Notes = append(resp.Notes,
+			"DRY RUN — nothing was deleted. Re-send with dry_run=false.")
+	}
+	if resp.Failed > 0 {
+		resp.Notes = append(resp.Notes,
+			"some deletions failed (see failed_keys, first_failure is the diagnostic). "+
+				"They remain stale, so a re-invocation retries exactly those.")
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// staleEmbeddingText returns the text a row WOULD be embedded with today, or "" when
+// it should carry no embedding at all.
+//
+// It composes exactly what the backfill composes — embedTextForRow, then the document
+// title fallback — because the two decisions must be one decision. A purge with its own
+// notion of "indexable" would either delete rows the writer re-creates on the next
+// touch, or delete rows that are legitimately searchable.
+func staleEmbeddingText(ctx context.Context, s *Server, tenant, scope, scopeID string, row store.MemoryEntry) string {
+	if text := embedTextForRow(row); text != "" {
+		return text
+	}
+	return builtin.TitleFallbackForBodyKey(ctx, s.sqlMem, tenant,
+		store.MemoryScope(scope), scopeID, row.Key)
+}

--- a/internal/api/http/memory_purge_test.go
+++ b/internal/api/http/memory_purge_test.go
@@ -1,0 +1,213 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// purgeStore records which embeddings were deleted, and starts with one on every row —
+// the shape a scope has after being swept by a build that predates the scaffold rule.
+type purgeStore struct {
+	store.Store
+	values  map[string]string // key → stored body text
+	embeds  map[string]bool   // key → has an embedding
+	deleted []string
+}
+
+func newPurgeStore(base store.Store, values map[string]string) *purgeStore {
+	p := &purgeStore{Store: base, values: values, embeds: map[string]bool{}}
+	for k := range values {
+		p.embeds[k] = true
+	}
+	return p
+}
+
+func (p *purgeStore) MemoryList(_ context.Context, _ string, _ store.MemoryScope,
+	_, keyPrefix string, limit int) ([]store.MemoryEntry, bool, error) {
+	var out []store.MemoryEntry
+	for k, body := range p.values {
+		if !strings.HasPrefix(k, keyPrefix) {
+			continue
+		}
+		v, _ := json.Marshal(map[string]any{"body": body})
+		out = append(out, store.MemoryEntry{Key: k, Value: v})
+	}
+	if limit > 0 && len(out) > limit {
+		return out[:limit], true, nil
+	}
+	return out, false, nil
+}
+
+func (p *purgeStore) MemoryEmbedDelete(_ context.Context, _ string, _ store.MemoryScope,
+	_, key string) error {
+	p.deleted = append(p.deleted, key)
+	delete(p.embeds, key)
+	return nil
+}
+
+func postPurge(t *testing.T, srv *Server, query string) map[string]any {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost,
+		"/v1/_memory/purge_stale_embeddings?scope=user&scope_id=alice&tenant=&prefix=doc.chunk:"+query, nil).
+		WithContext(auth.WithPrincipal(context.Background(), auth.Principal{
+			Subject: "root", Scopes: []string{auth.ScopeAdmin},
+		}))
+	srv.handleMemoryPurgeStaleEmbeddings(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+	}
+	var out map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &out)
+	return out
+}
+
+// purgeFixture is the measured shape: scaffolding-only bodies that were embedded before
+// the write path rejected them, alongside real prose that must be left alone.
+func purgeFixture(t *testing.T) (*Server, *purgeStore) {
+	t.Helper()
+	srv, _ := makeServer(t, completingProvider(), makeBaseConfig())
+	ps := newPurgeStore(srv.store, map[string]string{
+		"doc.chunk:scaffold-sh":   "```sh",
+		"doc.chunk:scaffold-bash": "```bash",
+		"doc.chunk:scaffold-rule": "---",
+		"doc.chunk:scaffold-hash": "#",
+		"doc.chunk:real-prose":    "SAVEPOINT nesting is LIFO",
+		"doc.chunk:real-fenced":   "```sh\nmake build-all\n```",
+	})
+	srv.store = ps
+	return srv, ps
+}
+
+// TestPurgeStaleEmbeddings_RemovesScaffoldingOnly is the whole point, and the second
+// half is the part that matters: a purge that deleted one row too many would silently
+// un-index real content, which is far worse than the noise it set out to remove.
+func TestPurgeStaleEmbeddings_RemovesScaffoldingOnly(t *testing.T) {
+	srv, ps := purgeFixture(t)
+
+	out := postPurge(t, srv, "&dry_run=false")
+	if n, _ := out["purged"].(float64); n != 4 {
+		t.Errorf("purged = %v, want 4 scaffolding rows: %v", out["purged"], out)
+	}
+	for _, keep := range []string{"doc.chunk:real-prose", "doc.chunk:real-fenced"} {
+		if !ps.embeds[keep] {
+			t.Errorf("%s lost its embedding — real content was un-indexed", keep)
+		}
+	}
+	// A body that merely BEGINS with a fence is a code example, not scaffolding. Getting
+	// that wrong would delete every code sample from the index.
+	for _, d := range ps.deleted {
+		if d == "doc.chunk:real-fenced" {
+			t.Error("a fenced code EXAMPLE was treated as scaffolding")
+		}
+	}
+}
+
+// TestPurgeStaleEmbeddings_DryRunDeletesNothing — this endpoint removes index entries,
+// so the safe default matters more here than on the sweeps that only add.
+func TestPurgeStaleEmbeddings_DryRunDeletesNothing(t *testing.T) {
+	srv, ps := purgeFixture(t)
+
+	out := postPurge(t, srv, "")
+	if out["dry_run"] != true {
+		t.Errorf("dry_run should default TRUE, got %v", out["dry_run"])
+	}
+	if n, _ := out["stale"].(float64); n != 4 {
+		t.Errorf("stale = %v, want 4 — a dry run must still REPORT what it would do", out["stale"])
+	}
+	if n, _ := out["purged"].(float64); n != 0 {
+		t.Errorf("purged = %v on a dry run", out["purged"])
+	}
+	if len(ps.deleted) != 0 {
+		t.Errorf("a dry run deleted %v", ps.deleted)
+	}
+}
+
+// TestPurgeStaleEmbeddings_AgreesWithTheBackfill pins the invariant the two sweeps rest
+// on: whatever the backfill would EMBED, the purge must not remove. They derive text
+// through the same function, so this is a guard against them drifting apart — a purge
+// with its own notion of "indexable" would delete rows the next backfill re-creates,
+// and the pair would fight forever.
+func TestPurgeStaleEmbeddings_AgreesWithTheBackfill(t *testing.T) {
+	// A TABLE, not a tautology. A first version of this compared `text != ""` against
+	// `text == ""` and asserted they differ — which they do by construction, so it
+	// tested nothing. The real question is whether each body lands on the side the
+	// WRITE path puts it on, so the expected classification has to be written down.
+	for _, tc := range []struct {
+		body      string
+		embedable bool
+	}{
+		// Scaffolding: the writer rejects these, so the sweep must not create them and
+		// the purge must remove them. This is the concrete regression — before the
+		// shared predicate the backfill embedded every one.
+		{"```sh", false},
+		{"```bash", false},
+		{"---", false},
+		{"#", false},
+		{"", false},
+		{"   ", false},
+		{"42", false}, // no letters
+		// Real content, including bodies that merely BEGIN with a fence. Treating a code
+		// example as scaffolding would delete every sample from the index.
+		{"SAVEPOINT nesting is LIFO", true},
+		{"```sh\nmake build\n```", true},
+		{"# A real heading", true},
+		{"-- a SQL comment", true},
+	} {
+		v, _ := json.Marshal(map[string]any{"body": tc.body})
+		got := embedTextForRow(store.MemoryEntry{Key: "doc.chunk:x", Value: v}) != ""
+		if got != tc.embedable {
+			verb := "would NOT embed"
+			if got {
+				verb = "WOULD embed"
+			}
+			t.Errorf("the backfill %s %q; the write path disagrees. When the sweep and the "+
+				"writer differ, one creates what the other rejects and the purge cannot tell "+
+				"which is right", verb, tc.body)
+		}
+	}
+}
+
+// TestPurgeStaleEmbeddings_AdminMustNameATenant — the same refusal as the backfill, and
+// it matters more here: this operation DELETES, so resolving to the default tenant would
+// purge a tenant the operator never named.
+func TestPurgeStaleEmbeddings_AdminMustNameATenant(t *testing.T) {
+	srv, _ := purgeFixture(t)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost,
+		"/v1/_memory/purge_stale_embeddings?scope=user&scope_id=alice&prefix=doc.chunk:", nil).
+		WithContext(auth.WithPrincipal(context.Background(), auth.Principal{
+			Subject: "root", Scopes: []string{auth.ScopeAdmin},
+		}))
+	srv.handleMemoryPurgeStaleEmbeddings(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status %d, want 400 when an admin names no tenant", rec.Code)
+	}
+	var e map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &e)
+	if e["code"] != "tenant_required" {
+		t.Errorf("code = %v, want tenant_required", e["code"])
+	}
+}
+
+// TestPurgeStaleEmbeddings_TruncatedScanSaysSo — a low `stale` count on a partial scan
+// is not evidence the scope is clean, and an operator reading it as such would stop
+// sweeping too early.
+func TestPurgeStaleEmbeddings_TruncatedScanSaysSo(t *testing.T) {
+	srv, _ := purgeFixture(t)
+	out := postPurge(t, srv, "&limit=2")
+	if out["truncated"] != true {
+		t.Errorf("truncated = %v with limit=2 over 6 rows", out["truncated"])
+	}
+	body, _ := json.Marshal(out["notes"])
+	if !strings.Contains(string(body), "SCAN INCOMPLETE") {
+		t.Errorf("notes do not warn that the scan was partial: %s", body)
+	}
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -3014,6 +3014,10 @@ func (s *Server) Mux() http.Handler {
 	// (substrate:admin) DELIBERATELY, like backfill_embeddings above: both spend the
 	// operator's model budget per row, so triggering one is an operator decision even
 	// though the data belongs to a tenant.
+	// Purge the embeddings of rows that carry no indexable text (markdown scaffolding
+	// embedded before the write path rejected it). Admin, like its sibling sweeps —
+	// and unlike them it DELETES, so its dry_run default is load-bearing.
+	mux.Handle("POST /v1/_memory/purge_stale_embeddings", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleMemoryPurgeStaleEmbeddings))))
 	mux.Handle("POST /v1/_document/describe_images", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleDescribeImages))))
 	// v0.8.17 Snapshot capture (PR 2). Bearer-authed; same posture
 	// as /v1/_resolver. The full runtime-state JSON envelope; see

--- a/internal/store/postgres/memory_embeddings.go
+++ b/internal/store/postgres/memory_embeddings.go
@@ -90,6 +90,24 @@ func (s *Store) MemoryEmbedSet(ctx context.Context, tenantID string, scope store
 
 // MemoryEmbedGet returns the stored embedding, decoding the
 // pgvector text representation back to float32.
+// MemoryEmbedDelete removes one row's embedding, leaving the base memory row. See
+// the Store interface for why this exists and why it is idempotent.
+func (s *Store) MemoryEmbedDelete(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string) error {
+	if !s.pgvectorEnabled {
+		return store.ErrVectorUnsupported
+	}
+	// No rows-affected check: an absent embedding is a successful no-op, so a purge
+	// sweep can walk every row without probing first.
+	if _, err := s.pool.Exec(ctx,
+		`DELETE FROM memory_embeddings
+		  WHERE tenant_id = $1 AND scope = $2 AND scope_id = $3 AND key = $4`,
+		tenantID, string(scope), scopeID, key,
+	); err != nil {
+		return fmt.Errorf("MemoryEmbedDelete: %w", err)
+	}
+	return nil
+}
+
 func (s *Store) MemoryEmbedGet(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string) (store.MemoryEmbedding, error) {
 	if !s.pgvectorEnabled {
 		return store.MemoryEmbedding{}, store.ErrVectorUnsupported

--- a/internal/store/sqlite/memory_embeddings.go
+++ b/internal/store/sqlite/memory_embeddings.go
@@ -36,6 +36,10 @@ func (s *Store) MemoryEmbedSet(ctx context.Context, tenantID string, scope store
 	return store.ErrVectorUnsupported
 }
 
+func (s *Store) MemoryEmbedDelete(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string) error {
+	return store.ErrVectorUnsupported
+}
+
 func (s *Store) MemoryEmbedGet(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string) (store.MemoryEmbedding, error) {
 	return store.MemoryEmbedding{}, store.ErrVectorUnsupported
 }

--- a/internal/store/sqlite/memory_embeddings_vec.go
+++ b/internal/store/sqlite/memory_embeddings_vec.go
@@ -73,6 +73,10 @@ func (s *Store) MemoryEmbedSet(ctx context.Context, tenantID string, scope store
 	return errVecImplPending
 }
 
+func (s *Store) MemoryEmbedDelete(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string) error {
+	return errVecImplPending
+}
+
 func (s *Store) MemoryEmbedGet(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string) (store.MemoryEmbedding, error) {
 	return store.MemoryEmbedding{}, errVecImplPending
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1883,6 +1883,25 @@ type Store interface {
 	// ErrVectorUnsupported on backends without a vector index.
 	MemoryEmbedGet(ctx context.Context, tenantID string, scope MemoryScope, scopeID, key string) (MemoryEmbedding, error)
 
+	// MemoryEmbedDelete removes a row's embedding while LEAVING the row itself.
+	//
+	// The gap it fills: nothing could un-index a row. Deleting the memory row cascades
+	// the embedding away, and re-embedding overwrites one — but a row that should no
+	// longer be searchable AT ALL had no path. That is not hypothetical: markdown
+	// scaffolding ("```sh", "---") was embedded before the write path learned to reject
+	// it, and those vectors sit near the centroid of everything, so they rank mid-high
+	// for EVERY query. Stopping new ones does not remove the old, and re-embedding
+	// faithfully reproduces the same junk text.
+	//
+	// IDEMPOTENT: deleting an absent embedding is a no-op, not an error. A purge sweep
+	// walks rows without knowing which carry one, and making the common case an error
+	// would force every caller to probe first.
+	//
+	// ErrVectorUnsupported on a backend with no vector plane — the same refusal shape
+	// as its Set/Get siblings, so an operator sees one story rather than a silent
+	// success on a store that never had an embedding to remove.
+	MemoryEmbedDelete(ctx context.Context, tenantID string, scope MemoryScope, scopeID, key string) error
+
 	// MemoryEmbedSearch runs a Top-K cosine-similarity search over
 	// rows in (scope, scopeID). keyPrefix is optional — empty string
 	// matches every key. The returned MemorySearchEntry slice is

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -155,6 +155,7 @@ func Run(t *testing.T, factory Factory) {
 		{"MemoryEmbedCascadesOnDelete", testMemoryEmbedCascadesOnDelete},
 		{"MemoryEmbedListMissing", testMemoryEmbedListMissing},
 		{"MemorySearchFilterExcludesPrefix", testMemorySearchFilterExcludesPrefix},
+		{"MemoryEmbedDelete", testMemoryEmbedDelete},
 		// RFC BL P2: the background-consolidation substrate.
 		{"MemorySupersedeHidesFromReads", testMemorySupersedeHidesFromReads},
 		{"MemorySupersedeIsIdempotent", testMemorySupersedeIsIdempotent},
@@ -11080,6 +11081,69 @@ func testMemoryEmbedCascadesOnDelete(t *testing.T, s store.Store) {
 // before filtering may contain almost no facts, so a caller asking for ten would get
 // two. That is why this is a store contract and not a backend unit test: the LIMIT has
 // to apply AFTER the predicate.
+// testMemoryEmbedDelete pins the operation that had no equivalent: un-indexing a row
+// without deleting it.
+//
+// The row must SURVIVE. That is the whole distinction from a cascade — a chunk whose
+// body is markdown scaffolding is legitimate document structure that simply should not
+// be a search result, so removing the document to fix the index would be the wrong
+// trade.
+func testMemoryEmbedDelete(t *testing.T, s store.Store) {
+	if !vectorRefusalCheck(t, s) {
+		return
+	}
+	ctx := context.Background()
+	const sid = "embdel"
+	v, _ := json.Marshal("a body worth keeping")
+	if err := s.MemorySet(ctx, "", store.MemoryScopeUser, sid, "k1", v, 0); err != nil {
+		t.Fatalf("MemorySet: %v", err)
+	}
+	if err := s.MemoryEmbedSet(ctx, "", store.MemoryScopeUser, sid, "k1", store.MemoryEmbedding{
+		Provider: "test", Model: "m", Dimension: 4,
+		Vector: floats32(1, 0, 0, 0), EmbedText: "k1", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("MemoryEmbedSet: %v", err)
+	}
+	if _, err := s.MemoryEmbedGet(ctx, "", store.MemoryScopeUser, sid, "k1"); err != nil {
+		t.Fatalf("precondition: the embedding should exist: %v", err)
+	}
+
+	if err := s.MemoryEmbedDelete(ctx, "", store.MemoryScopeUser, sid, "k1"); err != nil {
+		t.Fatalf("MemoryEmbedDelete: %v", err)
+	}
+	var nf *store.ErrNotFound
+	if _, err := s.MemoryEmbedGet(ctx, "", store.MemoryScopeUser, sid, "k1"); !errors.As(err, &nf) {
+		t.Errorf("the embedding survived the delete (err=%v)", err)
+	}
+	// THE ROW SURVIVES — the point of having this at all.
+	if got, err := s.MemoryGet(ctx, "", store.MemoryScopeUser, sid, "k1"); err != nil {
+		t.Errorf("the base row was removed too: %v — a caller wanting that already has "+
+			"MemoryDelete and its cascade", err)
+	} else if len(got.Value) == 0 {
+		t.Error("the base row came back empty")
+	}
+	// Searchable no more: the row exists but cannot be retrieved semantically.
+	if rows, err := s.MemoryEmbedSearch(ctx, "", store.MemoryScopeUser, sid,
+		store.MemorySearchFilter{}, floats32(1, 0, 0, 0), 10); err != nil {
+		t.Fatalf("search after delete: %v", err)
+	} else {
+		for _, r := range rows {
+			if r.Key == "k1" {
+				t.Error("the purged row is still returned by vector search")
+			}
+		}
+	}
+
+	// IDEMPOTENT: a purge sweep walks rows without knowing which carry an embedding, so
+	// deleting an absent one must be a no-op rather than an error it has to special-case.
+	if err := s.MemoryEmbedDelete(ctx, "", store.MemoryScopeUser, sid, "k1"); err != nil {
+		t.Errorf("second delete errored: %v — a sweep would have to probe first", err)
+	}
+	if err := s.MemoryEmbedDelete(ctx, "", store.MemoryScopeUser, sid, "never-existed"); err != nil {
+		t.Errorf("deleting an unknown key errored: %v", err)
+	}
+}
+
 func testMemorySearchFilterExcludesPrefix(t *testing.T, s store.Store) {
 	if !vectorRefusalCheck(t, s) {
 		return

--- a/internal/tools/builtin/document_image.go
+++ b/internal/tools/builtin/document_image.go
@@ -125,6 +125,15 @@ func indexableText(s string) string {
 	return t
 }
 
+// IndexableText is the exported form, for the admin sweeps.
+//
+// EXPORTED BECAUSE THE JUDGEMENT MUST BE SHARED, and it was not: the write path applied
+// this rule while the embedding backfill derived its text by trimming alone, so the
+// sweep could still CREATE the scaffolding embeddings the writer rejects — and the purge
+// that removes them would then not recognise them either. Three places deciding
+// "indexable" independently is how they drift; one function is the fix.
+func IndexableText(s string) string { return indexableText(s) }
+
 // UndescribedAsset is one image awaiting a description: enough to make the vision
 // call and to know whether it is worth making.
 type UndescribedAsset struct {


### PR DESCRIPTION
Closes the gap I flagged: **nothing could un-index a row.** Deleting the memory row cascades its embedding away and re-embedding overwrites one, but a row that should no longer be searchable *at all* had no path — so the markdown scaffolding embedded before the write path learned to reject it sits in the index permanently.

Measured on the deployment — a document search for "shell script example":

| hit | score |
|---|---|
| `` "```bash" `` ×3 | 0.629 |
| `` "```sh" `` | 0.541 |

Deleting the chunk would fix the index and is the wrong trade: the chunk is legitimate document structure that simply shouldn't be a search result.

## What's here

**`MemoryEmbedDelete`** — removes the embedding, leaves the row. Idempotent, because a purge sweep walks rows without knowing which carry one; making the common case an error would force every caller to probe first.

**`POST /v1/_memory/purge_stale_embeddings`** — walks a prefix, recomputes each row's text under today's rules, deletes the embedding where that text is empty. `dry_run` defaults true, which matters more here than on sweeps that only add. An admin naming no tenant is refused: on a destructive op, resolving to the default tenant would purge one the operator never named.

## It found a live bug, which is the more important half

The write path rejects scaffolding via `indexableText`. **The backfill derived its text by trimming alone** — so the sweep would still *create* the embeddings the writer rejects, and a purge built on the backfill's derivation couldn't recognise them either. Three places deciding "indexable" independently is how they drift.

`indexableText` is now exported and `embedTextForRow` routes through it, so the writer, the backfill and the purge share one judgement — making the purge the exact **inverse** of the backfill rather than a second opinion. Without that, the two would fight: the purge deletes, the next backfill re-creates.

## Tested

- scaffolding is purged while real prose **and a body that merely begins with a fence** survive — treating a code example as scaffolding would delete every sample from the index
- dry-run reports without deleting; the admin tenant refusal; a truncated scan **says so**, because a low `stale` count on a partial scan isn't evidence the scope is clean
- store contract: the **row survives**, vector search no longer returns it, and a repeat delete is a no-op

**One test I had to fix rather than bank:** `AgreesWithTheBackfill` originally compared `text != ""` against `text == ""` and asserted they differ — true by construction, so it tested nothing. It's now a table of expected classifications per body.

**Fail-before verified:** reverting `embedTextForRow` to trimming makes three tests fail.

`go test ./...` clean. Local pgvector verification wasn't available this run (no docker daemon), so the postgres tier of the new contract subtest is covered by CI rather than a local run — flagging that rather than implying I ran it.

## Follow-up after deploy

The scaffolding rows on the reference deployment need the sweep run once:

```
POST /v1/_memory/purge_stale_embeddings?scope=user&scope_id=<subject>&tenant=<t>&prefix=doc.chunk:&limit=4000&dry_run=false
```

Also done separately today: the 186 heading chunks were backfilled — **184 embedded** via the title fallback, verified live (a `body:""` heading now tops its query at 0.771).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8