### PR TITLE
feat(memory): document op=search, honest embed_stats, image title as a third source

### DIFF
--- a/internal/api/http/memory_admin.go
+++ b/internal/api/http/memory_admin.go
@@ -28,9 +28,18 @@ import (
 //	    returns rows_reembedded.
 
 type memoryEmbedStatsResponse struct {
-	Scope               string                        `json:"scope"`
+	Scope string `json:"scope"`
+	// Tenant names WHICH tenant was measured, and it is not decoration.
+	//
+	// This endpoint reported `models: [], total_embedding_bytes: 0` for a scope holding
+	// ~2,900 embeddings, because it resolved the tenant from the caller's principal and
+	// an admin's own tenant is not the one being inspected. A zero with no tenant beside
+	// it reads as "this scope is unembedded" when it actually means "you measured
+	// somewhere else" — so the answer now carries the question it answered.
+	Tenant              string                        `json:"tenant"`
 	Models              []store.MemoryEmbedModelStats `json:"models"`
 	TotalEmbeddingBytes int64                         `json:"total_embedding_bytes"`
+	Notes               []string                      `json:"notes,omitempty"`
 }
 
 type memoryReembedDryRunResponse struct {
@@ -60,10 +69,29 @@ type memoryReembedConfigured struct {
 	Dimension int    `json:"dimension"`
 }
 
-// handleMemoryEmbedStats serves GET /v1/_memory/embed_stats?scope=.
-// Returns per-(provider, model, dimension) row counts + total
-// embedding bytes for the scope. Operators (and the UI) use this to
-// spot multi-model scopes BEFORE running reembed.
+// quoteTenant renders a tenant for a message, naming the default partition rather than
+// showing an empty string — "" in prose reads as a missing value rather than a real one.
+func quoteTenant(t string) string {
+	if t == "" {
+		return `"" (the default partition)`
+	}
+	return `"` + t + `"`
+}
+
+// handleMemoryEmbedStats serves GET /v1/_memory/embed_stats?scope=&tenant=.
+// Returns per-(provider, model, dimension) row counts + total embedding bytes.
+// Operators (and the UI) use this to spot multi-model scopes BEFORE running reembed.
+//
+// ?tenant= IS HONOURED FOR AN ADMIN, which it was not. The tenant came from the
+// caller's principal alone, so an admin inspecting another tenant's scope measured
+// their OWN and got zeros — indistinguishable from an unembedded scope. A tenant
+// operator is still confined to its own tenant (principalTenantScope ignores the
+// override), so this widens nothing.
+//
+// AGGREGATES ACROSS EVERY scope_id in the (tenant, scope) partition — there is no
+// scope_id filter, and a caller expecting one subject's numbers would otherwise read
+// the whole tenant's as that subject's. Stated in the response notes rather than left
+// to be inferred.
 func (s *Server) handleMemoryEmbedStats(w http.ResponseWriter, r *http.Request) {
 	if s.store == nil {
 		writeJSONError(w, http.StatusServiceUnavailable, "store_unavailable",
@@ -81,8 +109,12 @@ func (s *Server) handleMemoryEmbedStats(w http.ResponseWriter, r *http.Request) 
 			"scope must be one of: agent, user, tenant")
 		return
 	}
-	// RFC BL: tenant from the authenticated principal (server-sourced).
-	stats, err := s.store.MemoryEmbedStats(r.Context(), tenantFromCtx(r.Context()), store.MemoryScope(scope))
+	// principalTenantScope keeps a non-admin confined to its own tenant while letting an
+	// admin name one. Unlike the destructive sweeps this is a READ, so an admin naming
+	// none is not refused — it resolves to the default partition and the response says
+	// so, which is the ambiguity this endpoint used to have.
+	tenant, _ := s.principalTenantScope(r.Context(), r.URL.Query().Get("tenant"))
+	stats, err := s.store.MemoryEmbedStats(r.Context(), tenant, store.MemoryScope(scope))
 	if err != nil {
 		// Vector-unsupported can also surface here from refusal-stub
 		// backends — treat as 503 for consistency with the upfront
@@ -100,11 +132,23 @@ func (s *Server) handleMemoryEmbedStats(w http.ResponseWriter, r *http.Request) 
 		stats.Models = []store.MemoryEmbedModelStats{}
 	}
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(memoryEmbedStatsResponse{
+	resp := memoryEmbedStatsResponse{
 		Scope:               scope,
+		Tenant:              tenant,
 		Models:              stats.Models,
 		TotalEmbeddingBytes: stats.TotalEmbeddingBytes,
-	})
+		Notes: []string{
+			"counts aggregate every scope_id in this (tenant, scope) partition — there is " +
+				"no per-subject filter, so this is not one user's total.",
+		},
+	}
+	if len(stats.Models) == 0 {
+		resp.Notes = append(resp.Notes,
+			"zero rows for tenant "+quoteTenant(tenant)+" — check that this is the tenant you "+
+				"meant before concluding the scope is unembedded. Pass ?tenant=<id> to measure "+
+				"another one (admin only).")
+	}
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
 // handleMemoryReembed serves POST /v1/_memory/reembed.

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -58,7 +58,7 @@ type Document struct {
 func (d *Document) Name() string { return "Document" }
 
 func (d *Document) Description() string {
-	return "A chunked-graph document: each chunk is a first-class unit (UUID, hierarchy, type, fields, graph edges, Markdown body) that agents and humans co-author and query. Ops: create_document/get_document/documents_summary (per-document type/status + display metadata for a set of ids or a Path subtree)/query_documents (filter documents by type/status/tag/under_path)/delete_document/set_path, create_chunk (optional after_id inserts right after a sibling)/get_chunk/update_chunk/delete_chunk/move_chunk/reorder_chunk (move up|down within a level), link_chunks/unlink_chunks/get_edges (the cross-reference edges touching a document, each enriched with its endpoints' titles/types/statuses)/backlinks (the chunks that link TO a chunk — both manual links and inline [[name]] links)/related (the chunks whose bodies are semantically closest to a chunk's — ranked by score; needs a configured embedder)/unlinked_mentions (the chunks whose body text mentions a chunk's title but do NOT already link to it), history/get_version/diff (a chunk's body-change log: list the revisions its body changed at, read one revision's exact body, or unified-diff two of them), query_chunks (structured filters incl. tag/tag_prefix + a raw sql escape hatch), add_tags/remove_tags (incremental tags on a chunk (id) or document (document_id))/list_tags (distinct tags + counts for a chunk, a document, or the whole scope), define_type/list_types, set_asset (attach an image's bytes to a chunk → type=image, served by GET /v1/_document/asset/{id})/get_asset (asset metadata), export_md (render the document to Markdown), import_md (build a document from export_md-shaped Markdown), export_canvas (render the document as a JSON Canvas v1.0 spatial graph — content chunks as nodes + their cross-reference edges, for Obsidian Canvas / spatial views)/import_canvas (build a new document from a JSON Canvas). Scope is agent or user; documents are named in the Path tree (path:) — create_document defaults to /documents/<title> if you omit one, and set_path attaches/re-homes a path for an existing document."
+	return "A chunked-graph document: each chunk is a first-class unit (UUID, hierarchy, type, fields, graph edges, Markdown body) that agents and humans co-author and query. Ops: create_document/get_document/documents_summary (per-document type/status + display metadata for a set of ids or a Path subtree)/query_documents (filter documents by type/status/tag/under_path)/delete_document/set_path, create_chunk (optional after_id inserts right after a sibling)/get_chunk/update_chunk/delete_chunk/move_chunk/reorder_chunk (move up|down within a level), link_chunks/unlink_chunks/get_edges (the cross-reference edges touching a document, each enriched with its endpoints' titles/types/statuses)/backlinks (the chunks that link TO a chunk — both manual links and inline [[name]] links)/related (the chunks whose bodies are semantically closest to a chunk's — ranked by score; needs a configured embedder)/unlinked_mentions (the chunks whose body text mentions a chunk's title but do NOT already link to it), history/get_version/diff (a chunk's body-change log: list the revisions its body changed at, read one revision's exact body, or unified-diff two of them), search (semantic search over chunk BODIES for free text — the entry point when you do not know which document holds the answer; returns chunk_id + title/type/document_id, so no key format to learn), query_chunks (structured filters incl. tag/tag_prefix + a raw sql escape hatch), add_tags/remove_tags (incremental tags on a chunk (id) or document (document_id))/list_tags (distinct tags + counts for a chunk, a document, or the whole scope), define_type/list_types, set_asset (attach an image's bytes to a chunk → type=image, served by GET /v1/_document/asset/{id})/get_asset (asset metadata), export_md (render the document to Markdown), import_md (build a document from export_md-shaped Markdown), export_canvas (render the document as a JSON Canvas v1.0 spatial graph — content chunks as nodes + their cross-reference edges, for Obsidian Canvas / spatial views)/import_canvas (build a new document from a JSON Canvas). Scope is agent or user; documents are named in the Path tree (path:) — create_document defaults to /documents/<title> if you omit one, and set_path attaches/re-homes a path for an existing document."
 }
 
 // documentInputSchema is a package const so the LoomCycle MCP server can
@@ -68,7 +68,7 @@ func (d *Document) Description() string {
 const documentInputSchema = `{
 	"type": "object",
 	"properties": {
-		"op":          {"type": "string", "enum": ["create_document","get_document","documents_summary","query_documents","delete_document","set_path","create_chunk","upsert_chunk","get_chunk","update_chunk","delete_chunk","supersede_chunk","graph_recall","list_facts","move_chunk","reorder_chunk","link_chunks","unlink_chunks","get_edges","query_chunks","add_tags","remove_tags","list_tags","define_type","list_types","set_asset","get_asset","export_md","import_md","export_canvas","import_canvas","history","get_version","diff","backlinks","related","unlinked_mentions"]},
+		"op":          {"type": "string", "enum": ["create_document","get_document","documents_summary","query_documents","delete_document","set_path","create_chunk","upsert_chunk","get_chunk","update_chunk","delete_chunk","supersede_chunk","graph_recall","list_facts","move_chunk","reorder_chunk","link_chunks","unlink_chunks","get_edges","query_chunks","add_tags","remove_tags","list_tags","define_type","list_types","set_asset","get_asset","export_md","import_md","export_canvas","import_canvas","history","get_version","diff","backlinks","search","related","unlinked_mentions"]},
 		"scope":       {"type": "string", "enum": ["agent","user","tenant"], "description": "Which store (default user). agent = this agent; user = this end-user (needs a user_id on the run); tenant = shared by every user and agent in the tenant — anything written here is read by all of them, so use it for curated reference material, not for anything derived from untrusted text. tenant requires the operator to grant BOTH memory_scopes and sql_scopes with the tenant value."},
 		"id":          {"type": "string", "description": "Document id (get/delete_document, set_path) or chunk id (get/update/delete/move_chunk)."},
 		"path":        {"type": "string", "description": "create_document: name the doc in the Path tree (default /documents/<title> if omitted). set_path: the path to attach to an existing document (by id). get/delete_document: address by path instead of id."},
@@ -82,7 +82,7 @@ const documentInputSchema = `{
 		"type":        {"type": "string", "description": "Optional supertag-like chunk type. list_facts (browse the scope's facts — chunks that carry entity metadata — newest first, metadata only, no bodies): return only facts of this type."},
 		"body":        {"type": "string", "description": "Markdown body."},
 		"seed_ids":  {"type": "array", "items": {"type": "string"}, "description": "graph_recall: chunk ids to start from. Use this to hand in results you already found some other way (a Memory search, a previous recall) and follow the graph out from them."},
-		"query":     {"type": "string", "description": "graph_recall: find starting chunks whose title matches this text. Use seed_ids instead when you already know where to start."},
+		"query":     {"type": "string", "description": "search: free text matched semantically against chunk BODIES — the way into a document when you do not know where to look. graph_recall: find starting chunks whose title matches this text (use seed_ids instead when you already know where to start)."},
 		"hops":      {"type": "integer", "description": "graph_recall: how far to follow relations from each starting chunk. 0 = the starting chunks only, 1 = their neighbours (default), 2 = the maximum."},
 		"as_of":     {"type": "integer", "description": "graph_recall / list_facts: answer as of this moment (unix nanos) instead of now — returns what was true then, including facts since corrected."},
 		"include_retired": {"type": "boolean", "description": "graph_recall / list_facts: also return facts that have been superseded. Off by default, so you get only what is currently true."},
@@ -422,6 +422,8 @@ func (d *Document) Execute(ctx context.Context, raw json.RawMessage) (tools.Resu
 		return d.diffVersions(ctx, key, in)
 	case "backlinks":
 		return d.backlinks(ctx, key, in)
+	case "search":
+		return d.searchChunks(ctx, key, mscope, in)
 	case "related":
 		return d.related(ctx, key, mscope, in)
 	case "unlinked_mentions":
@@ -767,7 +769,11 @@ func (d *Document) embedBody(ctx context.Context, tenant string, mscope store.Me
 		// The body is the CAPTION (export renders it as the alt text) and the
 		// description comes from the asset row, so an image with neither is what
 		// yields "" — not an image with no caption.
-		text = imageEmbedText(body, d.assetDescription(ctx, key, chunkID))
+		// The TITLE is a third source for an image, not a fallback — see imageEmbedText.
+		// It costs one query on a type that is rare, and it is the only place the brand
+		// or filename a vision model cannot infer becomes searchable.
+		text = imageEmbedText(d.chunkTitle(ctx, key, chunkID), body,
+			d.assetDescription(ctx, key, chunkID))
 	case "mermaid":
 		text = mermaidEmbedText(body)
 	default:
@@ -2651,6 +2657,87 @@ func (d *Document) chunkMetaByIDs(ctx context.Context, key sqlmem.ScopeKey, ids 
 		out[asStr(r[0])] = chunkMeta{title: asStr(r[1]), typ: asStr(r[2]), documentID: asStr(r[3])}
 	}
 	return out, nil
+}
+
+// searchChunks finds the chunks whose bodies best match a free-text query — the
+// convenience wrapper RFC BU §6 deferred.
+//
+// WHY IT EARNS ITS PLACE rather than being sugar. Without it the entry point into a
+// document is `memory op=search prefix="doc.chunk:"`, which asks a caller to know three
+// things that are not its business: that chunk bodies live in the memory keyspace, that
+// the reserved prefix is spelled exactly "doc.chunk:", and that the chunk id must be cut
+// back off the returned key. A live transcript showed an agent failing at precisely that
+// class of thing — it did not know a reserved string, so it guessed, and concluded
+// nothing was remembered. This op takes a query and returns chunks.
+//
+// It also RETURNS MORE than the raw search can: title, type and document_id per hit, so
+// a result is navigable without a second round trip. The raw form stays available for a
+// caller that wants the memory row itself.
+//
+// Scope-confined exactly like `related`, whose machinery this reuses — same embedder,
+// same prefixed vector search, same enrichment. One mechanism, two entry points.
+func (d *Document) searchChunks(ctx context.Context, key sqlmem.ScopeKey, mscope store.MemoryScope, in docInput) (tools.Result, error) {
+	q := strings.TrimSpace(in.Query)
+	if q == "" {
+		return errResult("search: missing required field: query (the text to match against chunk bodies)"), nil
+	}
+	if d.Embedder == nil {
+		return errResult("search: requires a configured embedder / vector memory"), nil
+	}
+	topK := 10
+	if in.Limit > 0 {
+		topK = in.Limit
+	}
+	if topK > 50 {
+		topK = 50
+	}
+	vec, err := d.Embedder.Embed(ctx, []string{q})
+	if err != nil {
+		return errResult("search: embed: " + err.Error()), nil
+	}
+	if len(vec) == 0 {
+		return errResult("search: embed: embedder returned no vector"), nil
+	}
+	// No topK+1 here, unlike `related`: there is no self-hit to drop when the query is
+	// text the caller typed rather than a chunk that is already in the index.
+	entries, err := d.Store.MemoryEmbedSearch(ctx, direntTenant(ctx), mscope, key.ScopeID,
+		store.MemorySearchFilter{KeyPrefix: chunkBodyKeyPrefix}, vec[0], topK)
+	if err != nil {
+		return errResult("search: " + err.Error()), nil
+	}
+	ids := make([]string, 0, len(entries))
+	scores := make(map[string]float64, len(entries))
+	for _, e := range entries {
+		cid := ChunkIDFromBodyKey(e.Key)
+		if cid == "" {
+			continue
+		}
+		ids = append(ids, cid)
+		scores[cid] = e.Score
+	}
+	meta, err := d.chunkMetaByIDs(ctx, key, ids)
+	if err != nil {
+		return errResult("search: enrich: " + err.Error()), nil
+	}
+	out := make([]map[string]any, 0, len(ids))
+	for _, cid := range ids {
+		m := map[string]any{"chunk_id": cid, "score": scores[cid]}
+		if md, ok := meta[cid]; ok {
+			if md.title != "" {
+				m["title"] = md.title
+			}
+			if md.typ != "" {
+				m["type"] = md.typ
+			}
+			if md.documentID != "" {
+				m["document_id"] = md.documentID
+			}
+		}
+		out = append(out, m)
+	}
+	// Ordered by score, and the enrichment loop preserves that order — a caller reading
+	// the first element must get the best match, not whatever the metadata query returned.
+	return jsonResult(map[string]any{"chunks": out})
 }
 
 // related returns the chunks whose bodies embed CLOSEST to a chunk's — its

--- a/internal/tools/builtin/document_image.go
+++ b/internal/tools/builtin/document_image.go
@@ -234,12 +234,22 @@ func (d *Document) SetAssetDescription(ctx context.Context, scope, chunkID, desc
 
 // imageEmbedText composes the searchable text for an image chunk.
 //
-// Returns "" when there is nothing to index — no caption and no description yet.
+// Returns "" when there is nothing to index — no title, no caption, no description.
 // The caller then stores no vector at all, which is the honest state: the image is
-// unsearchable but not lost, and it becomes searchable when a describe pass fills
-// the description in. Embedding a placeholder would be worse than embedding
-// nothing, because a row that exists ranks against every query.
-func imageEmbedText(caption, description string) string {
+// unsearchable but not lost, and it becomes searchable when any of the three arrives.
+// Embedding a placeholder would be worse than embedding nothing, because a row that
+// exists ranks against every query.
+//
+// THE TITLE IS INCLUDED HERE, NOT USED AS A FALLBACK, and an image is the one type
+// where that is right. Everywhere else the title is a fallback because a body usually
+// RESTATES its heading, so appending both double-weights the same words. An image has
+// no body to restate it — its "body" is the caption — so that rationale simply does not
+// apply. And the title routinely carries what a vision model provably cannot know:
+// "Loomcycle Logo 1280x640" tells you whose logo it is, while the generated description
+// says "five round characters around a central spool". Dropping the title to preserve a
+// rule whose reason is absent would lose the only searchable mention of the brand.
+func imageEmbedText(title, caption, description string) string {
+	title = strings.TrimSpace(title)
 	caption = strings.TrimSpace(caption)
 	description = strings.TrimSpace(description)
 	// A data URI is not a caption. An image chunk can transiently hold the rendered
@@ -249,16 +259,27 @@ func imageEmbedText(caption, description string) string {
 	if typ, _, _, _ := classifyMediaBody(caption); typ == "image" {
 		caption = ""
 	}
+	// A scaffold-only or letterless title is no more useful here than anywhere else.
+	title = indexableText(title)
+
+	// Appended rather than substituted, and deduped case-insensitively: each of the
+	// three can be the one that matches a query, so dropping one for tidiness trades
+	// recall away — but repeating the same words inflates their weight in the vector.
 	parts := make([]string, 0, 3)
-	if caption != "" {
-		parts = append(parts, caption)
+	add := func(v string) {
+		if v == "" {
+			return
+		}
+		for _, have := range parts {
+			if strings.EqualFold(have, v) {
+				return
+			}
+		}
+		parts = append(parts, v)
 	}
-	// Appended, not substituted. A caption is what the author chose to say and a
-	// description is what a model saw; either alone can be the one that matches, so
-	// dropping one to avoid duplication would trade recall for tidiness.
-	if description != "" && !strings.EqualFold(description, caption) {
-		parts = append(parts, description)
-	}
+	add(title)
+	add(caption)
+	add(description)
 	if len(parts) == 0 {
 		return ""
 	}

--- a/internal/tools/builtin/document_image_test.go
+++ b/internal/tools/builtin/document_image_test.go
@@ -11,35 +11,62 @@ import (
 // directly, including the ones whose absence would be invisible in an integration
 // test: the empty result that must stay empty, and the data-URI-is-not-a-caption
 // case.
-func TestImageEmbedText_ComposesCaptionAndDescription(t *testing.T) {
+func TestImageEmbedText_ComposesTitleCaptionAndDescription(t *testing.T) {
 	const dataURI = "![alt](data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==)"
 	for _, tc := range []struct {
-		name, caption, description, want string
+		name, title, caption, description, want string
 	}{
-		{"caption only", "the login screen", "", "image: the login screen"},
-		{"description only", "", "a form with two fields", "image: a form with two fields"},
+		{"caption only", "", "the login screen", "", "image: the login screen"},
+		{"description only", "", "", "a form with two fields", "image: a form with two fields"},
 		{
-			"both are kept", "login screen", "a form with two fields",
+			"caption and description are both kept", "", "login screen", "a form with two fields",
 			"image: login screen a form with two fields",
 		},
 		{
 			// Identical text twice would double-weight it in the vector.
-			"identical halves collapse", "a login form", "A LOGIN FORM",
+			"identical halves collapse", "", "a login form", "A LOGIN FORM",
 			"image: a login form",
 		},
 		// Nothing to index must be "" so the caller stores NO vector. A row that
 		// exists ranks against every query, so a placeholder is worse than absence.
-		{"neither", "", "", ""},
-		{"whitespace only", "   ", "\n\t", ""},
+		{"nothing at all", "", "", "", ""},
+		{"whitespace only", "  ", "   ", "\n\t", ""},
 		// A data URI is not a caption: an image chunk can transiently hold the
 		// rendered markdown form as its body, and base64 indexes nothing.
-		{"data uri is not a caption", dataURI, "", ""},
-		{"data uri body with a description", dataURI, "a red square", "image: a red square"},
+		{"data uri is not a caption", "", dataURI, "", ""},
+		{"data uri body with a description", "", dataURI, "a red square", "image: a red square"},
+
+		// The TITLE as a third source. This is the case the deferred refinement was
+		// about: the description cannot know WHOSE logo it is, so without the title the
+		// brand has no searchable mention anywhere.
+		{
+			"title carries what the model cannot know",
+			"Loomcycle Logo 1280x640", "", "five round characters around a spool",
+			"image: Loomcycle Logo 1280x640 five round characters around a spool",
+		},
+		{
+			"all three, in title-caption-description order",
+			"Logo", "the mark", "a spool",
+			"image: Logo the mark a spool",
+		},
+		{
+			// The dedupe spans all three, not just caption vs description.
+			"a title equal to the caption is not repeated",
+			"login screen", "Login Screen", "a form",
+			"image: login screen a form",
+		},
+		{
+			// A scaffold-only or letterless title is no more useful here than anywhere.
+			"a scaffolding title is dropped", "---", "", "a red square",
+			"image: a red square",
+		},
+		{"title alone is enough", "Loomcycle Logo", "", "", "image: Loomcycle Logo"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := imageEmbedText(tc.caption, tc.description); got != tc.want {
-				t.Errorf("imageEmbedText(%q, %q)\n want %q\n  got %q",
-					tc.caption, tc.description, tc.want, got)
+			got := imageEmbedText(tc.title, tc.caption, tc.description)
+			if got != tc.want {
+				t.Errorf("imageEmbedText(%q, %q, %q)\n want %q\n  got %q",
+					tc.title, tc.caption, tc.description, tc.want, got)
 			}
 		})
 	}
@@ -67,9 +94,11 @@ func TestEmbedBody_ImageCaptionIsEmbeddedWithoutAModel(t *testing.T) {
 	if err != nil || res.IsError {
 		t.Fatalf("create_chunk: %v %s", err, res.Text)
 	}
+	// Title AND caption: an image's title is a third source rather than a fallback
+	// (see imageEmbedText), because an image has no body to restate its heading.
 	got := embeddedTextFor(t, vs, resultField(res, "id"))
-	if got != "image: the login screen" {
-		t.Errorf("caption was not embedded on write: %q", got)
+	if got != "image: Login the login screen" {
+		t.Errorf("caption was not embedded on write with its title: %q", got)
 	}
 }
 
@@ -96,9 +125,11 @@ func TestEmbedBody_ImageDataURIBodyIsNeverIndexedAsBase64(t *testing.T) {
 	if strings.Contains(got, "iVBOR") || strings.Contains(got, "base64") {
 		t.Errorf("base64 reached the embedder: %q", got)
 	}
-	// The title carries it instead — the data URI contributed nothing.
-	if got != "Raw" {
-		t.Errorf("embed text = %q, want the chunk title \"Raw\"", got)
+	// The title carries it instead — the data URI contributed nothing. It arrives
+	// through imageEmbedText now rather than the generic title fallback, so it is
+	// labelled like every other image row.
+	if got != "image: Raw" {
+		t.Errorf("embed text = %q, want the labelled chunk title \"image: Raw\"", got)
 	}
 }
 
@@ -221,8 +252,8 @@ func TestEmbedBody_UncaptionedImageStillEmbedsItsDescription(t *testing.T) {
 
 	// Precondition: with no caption and no description yet, the chunk is searchable by
 	// its TITLE (the fallback) — and notably NOT by anything describing the picture.
-	if got := embeddedTextFor(t, vs, chunkID); got != "Logo" {
-		t.Fatalf("precondition: want the title-only fallback %q, got %q", "Logo", got)
+	if got := embeddedTextFor(t, vs, chunkID); got != "image: Logo" {
+		t.Fatalf("precondition: want the title-only text %q, got %q", "image: Logo", got)
 	}
 
 	// The describe pass persists a description and re-embeds.

--- a/internal/tools/builtin/document_search_test.go
+++ b/internal/tools/builtin/document_search_test.go
@@ -1,0 +1,131 @@
+package builtin
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestDocumentSearch_FindsChunksByFreeTextWithoutAKeyFormat is the reason this op
+// exists (RFC BU §6). Without it the way into a document is
+// `memory op=search prefix="doc.chunk:"`, which requires knowing that chunk bodies
+// live in the memory keyspace, the exact spelling of a reserved prefix, and that the
+// chunk id must be cut back off the key. A live transcript showed an agent failing at
+// exactly that: it did not know a reserved string, guessed, and concluded nothing was
+// remembered.
+func TestDocumentSearch_FindsChunksByFreeTextWithoutAKeyFormat(t *testing.T) {
+	d, _, ctx := mermaidDocFixture(t, "savepoint", "nesting", "lifo", "deploy", "runbook")
+
+	res, _ := d.Execute(ctx, json.RawMessage(`{"op":"create_document","title":"Ops"}`))
+	docID := resultField(res, "document_id")
+	mk := func(title, body string) string {
+		b, _ := json.Marshal(map[string]any{
+			"op": "create_chunk", "document_id": docID, "title": title, "body": body,
+		})
+		r, err := d.Execute(ctx, b)
+		if err != nil || r.IsError {
+			t.Fatalf("create_chunk %q: %v %s", title, err, r.Text)
+		}
+		return resultField(r, "id")
+	}
+	wantID := mk("Transactions", "SAVEPOINT nesting is LIFO")
+	mk("Deploys", "the deploy runbook")
+
+	out, err := d.Execute(ctx, json.RawMessage(`{"op":"search","query":"savepoint nesting"}`))
+	if err != nil || out.IsError {
+		t.Fatalf("search: %v %s", err, out.Text)
+	}
+	var got struct {
+		Chunks []struct {
+			ChunkID    string  `json:"chunk_id"`
+			Score      float64 `json:"score"`
+			Title      string  `json:"title"`
+			DocumentID string  `json:"document_id"`
+		} `json:"chunks"`
+	}
+	if err := json.Unmarshal([]byte(out.Text), &got); err != nil {
+		t.Fatalf("unmarshal: %v — %s", err, out.Text)
+	}
+	if len(got.Chunks) == 0 {
+		t.Fatal("no chunks returned")
+	}
+	if got.Chunks[0].ChunkID != wantID {
+		t.Errorf("best match = %s, want %s (the SAVEPOINT chunk)", got.Chunks[0].ChunkID, wantID)
+	}
+	// ENRICHED, which is the other half of the value: a hit is navigable without a
+	// second round trip, and no caller has to parse a key.
+	if got.Chunks[0].Title != "Transactions" {
+		t.Errorf("hit carries no title (%q) — a caller would need another call to know "+
+			"what it found", got.Chunks[0].Title)
+	}
+	if got.Chunks[0].DocumentID != docID {
+		t.Errorf("hit carries document_id %q, want %q", got.Chunks[0].DocumentID, docID)
+	}
+	// And the raw key never leaks: the caller asked for chunks, not memory rows.
+	if strings.Contains(out.Text, "doc.chunk:") {
+		t.Errorf("the reserved key prefix leaked into the result: %s", out.Text)
+	}
+}
+
+// TestDocumentSearch_RefusesWithoutAQueryOrAnEmbedder — both refusals name what is
+// missing. A semantic search with no embedder is a deployment state, not a bug, and
+// saying so beats returning an empty list that reads as "nothing matches".
+func TestDocumentSearch_RefusesWithoutAQueryOrAnEmbedder(t *testing.T) {
+	d, _, ctx := mermaidDocFixture(t, "anything")
+
+	res, err := d.Execute(ctx, json.RawMessage(`{"op":"search"}`))
+	if err != nil {
+		t.Fatalf("hard error: %v", err)
+	}
+	if !res.IsError || !strings.Contains(res.Text, "query") {
+		t.Errorf("a search with no query should refuse and name the field, got: %s", res.Text)
+	}
+
+	d.Embedder = nil
+	res, err = d.Execute(ctx, json.RawMessage(`{"op":"search","query":"anything"}`))
+	if err != nil {
+		t.Fatalf("hard error: %v", err)
+	}
+	if !res.IsError || !strings.Contains(res.Text, "embedder") {
+		t.Errorf("a search with no embedder should refuse and say so rather than return "+
+			"an empty set, got: %s", res.Text)
+	}
+}
+
+// TestDocumentSearch_OrderIsByScore guards the enrichment loop: metadata is fetched in
+// one batch keyed by id, so rebuilding results from that map would return them in map
+// order. A caller reading the first element must get the best match.
+func TestDocumentSearch_OrderIsByScore(t *testing.T) {
+	d, _, ctx := mermaidDocFixture(t, "alpha", "beta", "gamma", "delta", "epsilon")
+
+	res, _ := d.Execute(ctx, json.RawMessage(`{"op":"create_document","title":"Words"}`))
+	docID := resultField(res, "document_id")
+	for _, w := range []string{"alpha", "beta", "gamma", "delta", "epsilon"} {
+		b, _ := json.Marshal(map[string]any{
+			"op": "create_chunk", "document_id": docID, "title": w, "body": w,
+		})
+		if r, err := d.Execute(ctx, b); err != nil || r.IsError {
+			t.Fatalf("create_chunk: %v %s", err, r.Text)
+		}
+	}
+	out, err := d.Execute(ctx, json.RawMessage(`{"op":"search","query":"gamma"}`))
+	if err != nil || out.IsError {
+		t.Fatalf("search: %v %s", err, out.Text)
+	}
+	var got struct {
+		Chunks []struct {
+			Score float64 `json:"score"`
+			Title string  `json:"title"`
+		} `json:"chunks"`
+	}
+	_ = json.Unmarshal([]byte(out.Text), &got)
+	if len(got.Chunks) < 2 {
+		t.Skipf("need at least 2 hits to check ordering, got %d", len(got.Chunks))
+	}
+	for i := 1; i < len(got.Chunks); i++ {
+		if got.Chunks[i].Score > got.Chunks[i-1].Score {
+			t.Errorf("results are not score-ordered: %v at %d beats %v at %d",
+				got.Chunks[i].Score, i, got.Chunks[i-1].Score, i-1)
+		}
+	}
+}

--- a/internal/tools/builtin/memory_vector_test.go
+++ b/internal/tools/builtin/memory_vector_test.go
@@ -100,7 +100,7 @@ func sqrt(x float64) float64 {
 	return z
 }
 
-func (v *vectorStore) MemoryEmbedSearch(ctx context.Context, _ string, scope store.MemoryScope, scopeID string, filter store.MemorySearchFilter, query []float32, topK int) ([]store.MemorySearchEntry, error) {
+func (v *vectorStore) MemoryEmbedSearch(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID string, filter store.MemorySearchFilter, query []float32, topK int) ([]store.MemorySearchEntry, error) {
 	if !v.enabled {
 		return nil, store.ErrVectorUnsupported
 	}
@@ -148,7 +148,7 @@ func (v *vectorStore) MemoryEmbedSearch(ctx context.Context, _ string, scope sto
 			continue
 		}
 		// Filter expired base rows.
-		entry, err := v.Store.MemoryGet(ctx, "", scope, scopeID, key)
+		entry, err := v.Store.MemoryGet(ctx, tenantID, scope, scopeID, key)
 		if err != nil {
 			continue
 		}
@@ -161,7 +161,7 @@ func (v *vectorStore) MemoryEmbedSearch(ctx context.Context, _ string, scope sto
 	}
 	out := make([]store.MemorySearchEntry, 0, len(rows))
 	for _, r := range rows {
-		entry, err := v.Store.MemoryGet(ctx, "", scope, scopeID, r.key)
+		entry, err := v.Store.MemoryGet(ctx, tenantID, scope, scopeID, r.key)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
The three remaining open items from the memory epic's own deferral list. Independent mechanisms; one PR because each is small and they close the same list.

*(The fourth item — `memory-view`'s `^1.48.0` client dep — was already bumped to `^1.49.0` by the UI work in #960/#961, so that risk is closed.)*

## 1. `document op=search` — the wrapper RFC BU §6 deferred

Without it, the way into a document is `memory op=search prefix="doc.chunk:"`, which asks a caller to know three things that aren't its business: that chunk bodies live in the memory keyspace, the exact spelling of a reserved prefix, and that the chunk id must be trimmed back off the key. **A live transcript showed an agent failing at exactly that class of thing** — it didn't know a reserved string, guessed, and concluded nothing was remembered.

It also returns more than the raw search can — `title`, `type`, `document_id` per hit — so a result is navigable without a second round trip. It reuses `related`'s machinery (same embedder, same prefixed search, same enrichment), so this is one mechanism with two entry points rather than a parallel implementation.

## 2. `embed_stats` stops reporting zero for a full scope

It resolved the tenant from the caller's principal alone, so an admin inspecting another tenant measured their **own** and got `models: [], total_embedding_bytes: 0` — indistinguishable from an unembedded scope. That's how I first misread a scope holding ~2,900 embeddings.

Now `?tenant=` is honoured (a tenant operator stays confined — `principalTenantScope` ignores the override), the response **carries the tenant it measured**, and a zero says which tenant it was zero *for*. It also states that counts aggregate every `scope_id` in the partition, since a caller expecting one subject's numbers would otherwise read the whole tenant's as that subject's.

## 3. An image composes title + caption + description

This was the deferred refinement, and it lands **not as a special case but because the rule's reason doesn't hold for images.**

"Fallback, never an addition" is justified by redundancy — *a body usually restates its heading*. An image has **no body to restate it**; its body *is* the caption. So appending the title double-weights nothing. Meanwhile the title carries what a vision model provably cannot know: `Loomcycle Logo 1280x640` names whose logo it is, while the generated description says *"five round characters around a central spool"*. The fallback rule would have left the brand with no searchable mention anywhere in the corpus.

Deduped case-insensitively across all three — each can be the one that matches, but repeating words inflates their weight. One visible consequence: an image's text now always carries the `image:` prefix, where an uncaptioned one previously fell through to the generic fallback unlabelled. More uniform, not less.

RFC BU's amendment records this, including the generalisation: **a rule earns an exception when its rationale is absent, not when the case feels special.**

## Also: a test fake that had diverged from the store it stands in for

`vectorStore.MemoryEmbedSearch` hardcoded tenant `""` on its base-row lookups, so it silently discarded every row written under a non-empty tenant. That's worse than having no fake — it makes a test pass on a query the real store answers differently. Fixing it is what surfaced the new search op working at all.

## Tested

- search finds the right chunk by free text, carries `title` + `document_id`, **never leaks the reserved key**, refuses with a named field when query or embedder is missing, and returns score-ordered results (the enrichment fetches metadata as a map, so rebuilding from it would return map order)
- the image composition table covers all three sources, the three-way dedupe, a scaffolding title, and title-alone
- **fail-before verified** on both new behaviours; three existing image expectations updated as the documented consequence

`go test ./...` clean.

## Still open, and neither is a code change

- **`internal/sqlmem/postgres.go`** (967 lines, per-scope LOGIN-role provisioning) — the highest-stakes surface in the epic with no dedicated review pass. Happy to take it.
- The **scaffolding purge** needs #962 deployed, then one sweep to clear the live index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8