### PR TITLE
feat(memory-view): scope-aware scope_id field with pre-fill + suggestions

### DIFF
--- a/packages/memory-view/src/components/SearchPanel.tsx
+++ b/packages/memory-view/src/components/SearchPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { MemorySearchEntry, MemoryScope, MemorySource } from "../types";
 import { useMemoryData } from "../lib/dataLayer";
 import Splitter from "./Splitter";
@@ -51,9 +51,55 @@ export default function SearchPanel({ scope: scopeProp = "user", scopeId: scopeI
   // so a slow earlier search can't overwrite a faster later one.
   const reqRef = useRef(0);
 
+  // scope_id suggestions (optional data-layer methods; absent → free-text only).
+  // identity pre-fills the field + floats "you" to the top of the user list.
+  const [identity, setIdentity] = useState<{ subject: string; tenant: string } | null>(null);
+  const [users, setUsers] = useState<string[]>([]);
+  const [agents, setAgents] = useState<string[]>([]);
+
+  // Fetch the suggestion sources once. Each is optional + best-effort — a failure
+  // (or an unimplemented method) just leaves that scope's field as free text.
+  useEffect(() => {
+    let cancelled = false;
+    data.whoami?.().then((w) => !cancelled && setIdentity(w)).catch(() => {});
+    data.listUserIds?.().then((u) => !cancelled && setUsers(u)).catch(() => {});
+    data.listAgentNames?.().then((a) => !cancelled && setAgents(a)).catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [data]);
+
   // The tenant scope has no scope_id (one tenant-wide keyspace), so it does not
   // require one; every other scope does.
   const needsScopeId = scope !== "tenant";
+
+  // Pre-fill scope_id when the scope changes (or when the data seeding its default
+  // first loads): tenant → the tenant name (shown read-only), user → your own
+  // subject. Split from the agent effect below so an agent-list load never
+  // clobbers a user/tenant value (and vice-versa); once loaded the deps are
+  // stable, so it stops firing and a typed value survives.
+  useEffect(() => {
+    if (scope === "tenant") setScopeId(identity?.tenant ?? "");
+    else if (scope === "user") setScopeId(identity?.subject ?? "");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scope, identity]);
+  useEffect(() => {
+    if (scope === "agent") setScopeId(agents[0] ?? "");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scope, agents]);
+
+  // The scope_id combobox suggestions: users (yourself first) for user scope,
+  // active agents for agent scope, none for tenant (its field is read-only).
+  const scopeIdOptions = useMemo(() => {
+    if (scope === "user") {
+      const me = identity?.subject;
+      const rest = users.filter((u) => u !== me);
+      const ordered = me ? [me, ...rest] : users;
+      return ordered.map((u) => ({ value: u, label: u === me ? `${u} (you)` : u }));
+    }
+    if (scope === "agent") return agents.map((a) => ({ value: a, label: a }));
+    return [];
+  }, [scope, identity, users, agents]);
   const runSearch = async () => {
     if (!query.trim() || (needsScopeId && !scopeId.trim())) return;
     const token = ++reqRef.current;
@@ -105,17 +151,26 @@ export default function SearchPanel({ scope: scopeProp = "user", scopeId: scopeI
           <option value="agent">agent</option>
           <option value="tenant">tenant</option>
         </select>
-        <input
-          type="text"
-          className="search-scopeid-input"
-          placeholder={needsScopeId ? "scope_id (e.g. alice)…" : "tenant-wide (no scope_id)"}
-          value={needsScopeId ? scopeId : ""}
+        {/* scope_id: a combobox pre-filled per scope with suggestions — users
+            (you first) for user, active agents for agent; read-only tenant name
+            for tenant. Still free-text editable for user/agent. */}
+        <Combobox
+          value={scopeId}
+          onChange={setScopeId}
+          options={scopeIdOptions}
+          placeholder={needsScopeId ? "scope_id (e.g. alice)…" : "tenant-wide"}
           disabled={!needsScopeId}
-          onChange={(e) => setScopeId(e.target.value)}
+          ariaLabel="scope id"
         />
         {/* Source: a combobox (visible dropdown of the known kinds + free text).
             Empty = every plane. */}
-        <SourceCombobox value={source} onChange={setSource} />
+        <Combobox
+          value={source}
+          onChange={setSource}
+          options={SOURCE_OPTIONS}
+          placeholder="source: all"
+          ariaLabel="source filter"
+        />
         <input
           type="text"
           className="search-query-input"
@@ -230,15 +285,32 @@ const SOURCE_OPTIONS: { value: string; label: string }[] = [
   { value: "documents", label: "documents" },
 ];
 
-// SourceCombobox — a VISIBLE dropdown of the RFC BW source kinds that is also
-// free-text editable. A bare <datalist> reads as an empty text box (its choices
-// only surface on focus, browser-dependent), so this is an explicit combobox:
-// a text input + a chevron that opens the list on click, with outside-click /
-// Escape to close. Typing passes straight through — an unknown value is dropped
-// server-side, so free text is safe.
-function SourceCombobox({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+// Combobox — a VISIBLE dropdown of suggested values that is also free-text
+// editable. A bare <datalist> reads as an empty text box (its choices only
+// surface on focus, browser-dependent), so this is an explicit combobox: a text
+// input + a chevron that opens the list on click, with outside-click / Escape to
+// close. Typing passes straight through — the server validates/ignores unknowns.
+// Reused by the source filter and the scope_id field. When `disabled` (tenant
+// scope_id) it's a plain read-only input; with no `options` it's a free-text box
+// with no chevron.
+function Combobox({
+  value,
+  onChange,
+  options,
+  placeholder,
+  disabled,
+  ariaLabel,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  options: { value: string; label: string }[];
+  placeholder?: string;
+  disabled?: boolean;
+  ariaLabel?: string;
+}) {
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement>(null);
+  const canOpen = !disabled && options.length > 0;
 
   useEffect(() => {
     if (!open) return;
@@ -250,31 +322,34 @@ function SourceCombobox({ value, onChange }: { value: string; onChange: (v: stri
   }, [open]);
 
   return (
-    <div className="search-source" ref={wrapRef}>
+    <div className="mv-combobox" ref={wrapRef}>
       <input
         type="text"
-        className="search-source-input"
-        placeholder="source: all"
+        className="mv-combobox-input"
+        placeholder={placeholder}
         value={value}
+        disabled={disabled}
         onChange={(e) => onChange(e.target.value)}
-        onFocus={() => setOpen(true)}
+        onFocus={() => canOpen && setOpen(true)}
         onKeyDown={(e) => e.key === "Escape" && setOpen(false)}
-        aria-label="source filter"
+        aria-label={ariaLabel}
       />
-      <button
-        type="button"
-        className="search-source-toggle"
-        aria-label="choose a source"
-        tabIndex={-1}
-        onClick={() => setOpen((o) => !o)}
-      >
-        ▾
-      </button>
-      {open && (
-        <ul className="search-source-menu" role="listbox">
-          {SOURCE_OPTIONS.map((o) => (
+      {canOpen && (
+        <button
+          type="button"
+          className="mv-combobox-toggle"
+          aria-label="show suggestions"
+          tabIndex={-1}
+          onClick={() => setOpen((o) => !o)}
+        >
+          ▾
+        </button>
+      )}
+      {open && canOpen && (
+        <ul className="mv-combobox-menu" role="listbox">
+          {options.map((o) => (
             <li
-              key={o.value || "all"}
+              key={o.value || "__default__"}
               role="option"
               aria-selected={value === o.value}
               className={value === o.value ? "on" : ""}

--- a/packages/memory-view/src/lib/dataLayer.test.ts
+++ b/packages/memory-view/src/lib/dataLayer.test.ts
@@ -26,6 +26,18 @@ function stubClient() {
     .fn()
     .mockResolvedValue({ scope: "user", scope_id: "alice", entries: [], query_embedding_dim: 0, truncated: false });
   const document = vi.fn().mockResolvedValue({ facts: [], count: 0, truncated: false });
+  // Scope-id suggestion sources.
+  const whoami = vi
+    .fn()
+    .mockResolvedValue({ subject: "me", tenant_id: "acme", scopes: [], is_admin: true, legacy: false });
+  const listUsers = vi.fn().mockResolvedValue({ users: [{ user_id: "alice" }, { user_id: "bob" }] });
+  const listLibraryAgents = vi.fn().mockResolvedValue({
+    entries: [
+      { name: "static-agent", in_static: true },
+      { name: "dynamic-active", in_static: false, active_def_id: "d2" },
+      { name: "dynamic-retired", in_static: false },
+    ],
+  });
   const client = {
     listMemoryScopes,
     listMemoryScopeIDs,
@@ -37,6 +49,9 @@ function stubClient() {
     reembedMemory,
     memorySearch,
     document,
+    whoami,
+    listUsers,
+    listLibraryAgents,
   } as unknown as LoomcycleClient;
   return {
     client,
@@ -50,6 +65,9 @@ function stubClient() {
     reembedMemory,
     memorySearch,
     document,
+    whoami,
+    listUsers,
+    listLibraryAgents,
   };
 }
 
@@ -184,5 +202,26 @@ describe("dataLayerFromClient — @loomcycle/client → memory wire mapping", ()
       { op: "get_edges", scope: "user", document_id: "doc-1" },
       { scopeId: "bob" },
     );
+  });
+
+  // ---- scope-id suggestions (RFC BW UI) ----
+  it("whoami maps the client's tenant_id → tenant (and passes subject through)", async () => {
+    const s = stubClient();
+    const who = await dataLayerFromClient(s.client).whoami!();
+    expect(who).toEqual({ subject: "me", tenant: "acme" });
+  });
+
+  it("listUserIds maps users[].user_id", async () => {
+    const s = stubClient();
+    const ids = await dataLayerFromClient(s.client).listUserIds!();
+    expect(ids).toEqual(["alice", "bob"]);
+  });
+
+  it("listAgentNames returns ONLY active agents (in_static || active_def_id), by name", async () => {
+    const s = stubClient();
+    const names = await dataLayerFromClient(s.client).listAgentNames!();
+    // static-agent (in_static) + dynamic-active (has active_def_id) survive;
+    // dynamic-retired (neither) is dropped.
+    expect(names).toEqual(["static-agent", "dynamic-active"]);
   });
 });

--- a/packages/memory-view/src/lib/dataLayer.tsx
+++ b/packages/memory-view/src/lib/dataLayer.tsx
@@ -119,6 +119,21 @@ export interface MemoryDataLayer {
   // document_id, from getChunk, then filters to the edges touching the fact).
   // Carries the supersession chain (kind:"supersedes") + any plain relations.
   getEdges(scope: MemoryScope, documentId: string, opts?: { scopeId?: string }): Promise<DocEdgesResponse>;
+
+  // ---- Scope-id suggestions (OPTIONAL) ---------------------------------
+  // Populate the search panel's scope_id combobox. Optional so a data layer that
+  // only knows memory need not implement them — the field then degrades to a
+  // free-text input. dataLayerFromClient wires them to whoami / the users list /
+  // the Library. None reaches beyond the caller's tenant (server-side scoped).
+
+  /** The current principal — pre-fills scope_id (the tenant name for tenant
+   *  scope, the caller's own subject for user scope) and floats "you" to the top
+   *  of the user suggestions. */
+  whoami?(): Promise<{ subject: string; tenant: string }>;
+  /** The user ids (subjects) whose per-user memory can be browsed. */
+  listUserIds?(): Promise<string[]>;
+  /** The names of ACTIVE, non-retired agents. */
+  listAgentNames?(): Promise<string[]>;
 }
 
 // dataLayerFromClient maps a @loomcycle/client instance onto the MemoryDataLayer.
@@ -169,6 +184,19 @@ export function dataLayerFromClient(client: LoomcycleClient): MemoryDataLayer {
           docOpts(opts?.scopeId),
         )
         .then((r) => r as DocEdgesResponse),
+
+    // ---- Scope-id suggestions ------------------------------------------
+    whoami: () => client.whoami().then((w) => ({ subject: w.subject, tenant: w.tenant_id })),
+    listUserIds: () => client.listUsers().then((r) => (r.users ?? []).map((u) => u.user_id)),
+    listAgentNames: () =>
+      client.listLibraryAgents().then((r) =>
+        (r.entries ?? [])
+          // "active, non-retired": a static agent (statics are never retired) OR
+          // a dynamic agent that still has an active version — retiring the last
+          // version clears active_def_id (v1.6.4 soft-reclaim).
+          .filter((e) => e.in_static || Boolean(e.active_def_id))
+          .map((e) => e.name),
+      ),
   };
 }
 

--- a/packages/memory-view/src/styles.css
+++ b/packages/memory-view/src/styles.css
@@ -995,27 +995,27 @@
   flex: 1;
   min-width: 160px;
 }
-.loomcycle-memory-view .search-scopeid-input {
-  width: 160px;
-  font-family: var(--mono);
-  font-size: 12px;
-}
-/* Source combobox: a text input with a chevron that opens a visible option list
-   (SourceCombobox), instead of a bare <datalist> that reads as an empty box. */
-.loomcycle-memory-view .search-source {
+/* Combobox: a text input with a chevron that opens a visible option list,
+   instead of a bare <datalist> that reads as an empty box. Shared by the search
+   scope_id field and the source filter. */
+.loomcycle-memory-view .mv-combobox {
   position: relative;
   display: inline-block;
-  width: 132px;
+  width: 150px;
   flex-shrink: 0;
 }
-.loomcycle-memory-view .search-source-input {
+.loomcycle-memory-view .mv-combobox-input {
   width: 100%;
   box-sizing: border-box;
   padding-right: 20px;
   font-family: var(--mono);
   font-size: 12px;
 }
-.loomcycle-memory-view .search-source-toggle {
+.loomcycle-memory-view .mv-combobox-input:disabled {
+  opacity: 0.7;
+  cursor: default;
+}
+.loomcycle-memory-view .mv-combobox-toggle {
   position: absolute;
   top: 0;
   right: 0;
@@ -1031,7 +1031,7 @@
   font-size: 10px;
   padding: 0;
 }
-.loomcycle-memory-view .search-source-menu {
+.loomcycle-memory-view .mv-combobox-menu {
   position: absolute;
   top: calc(100% + 2px);
   left: 0;
@@ -1040,22 +1040,27 @@
   margin: 0;
   padding: 4px 0;
   list-style: none;
+  max-height: 240px;
+  overflow-y: auto;
   background: var(--bg-input);
   border: 1px solid var(--border);
   border-radius: 4px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
 }
-.loomcycle-memory-view .search-source-menu li {
+.loomcycle-memory-view .mv-combobox-menu li {
   padding: 4px 10px;
   font-family: var(--mono);
   font-size: 12px;
   color: var(--fg);
   cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
-.loomcycle-memory-view .search-source-menu li:hover {
+.loomcycle-memory-view .mv-combobox-menu li:hover {
   background: var(--bg-soft-2);
 }
-.loomcycle-memory-view .search-source-menu li.on {
+.loomcycle-memory-view .mv-combobox-menu li.on {
   color: var(--accent);
 }
 .loomcycle-memory-view .search-submit-btn {


### PR DESCRIPTION
## Why

The search panel's `scope_id` is a bare text box — you have to *know* the exact user id or agent name to type. This makes it scope-aware: pre-filled on scope change, with a real dropdown of suggestions.

## What

When the scope changes, `scope_id` pre-fills and offers suggestions:

| scope | pre-fill | dropdown |
|---|---|---|
| **tenant** | the current **tenant name**, shown **read-only** (tenant has one keyspace — no scope_id; the search still sends `""`, which the backend forces) | — |
| **user** | your own **subject** | the users list, **you on top** (`… (you)`) |
| **agent** | the first **active** agent | **active, non-retired** agents only |

"Active, non-retired" = a static agent (statics are never retired) **or** a dynamic agent that still has an active version — retiring the last version clears `active_def_id`, so a fully-retired agent drops out.

**Data source:** three **optional** `MemoryDataLayer` methods — `whoami` / `listUserIds` / `listAgentNames` — wired in `dataLayerFromClient` to `client.whoami()` (`tenant_id` → `tenant`), `client.listUsers()` (`user_id[]`), and `client.listLibraryAgents()` (filtered `in_static || active_def_id` → `name[]`). Optional, so a memory-only data layer just degrades to a free-text field. **All three endpoints already exist — no wire change, no client bump.**

**Combobox reuse:** the bare `<datalist>`-turned-`SourceCombobox` from #961 is generalized into one reusable **`Combobox`** (visible chevron + option list + free text; outside-click / Escape close; read-only when `disabled`), now backing **both** the `scope_id` and `source` fields. Two split pre-fill effects (tenant/user keyed on identity, agent on the agent list) ensure one list loading can't clobber another scope's value — or a value you've typed.

## Tested

- Package `typecheck` + `build` + **19 tests** (3 new: `whoami` tenant_id→tenant mapping, `listUserIds`, and `listAgentNames`'s active-only filter), and the web dogfood `typecheck` + `build` — against the published `@loomcycle/client@1.49.0`.

**Note:** the Web UI is embedded in the binary, so a running deployment shows this after `make build-all` + redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
