### PR TITLE
feat(channels): add the tenant axis to the Channel primitive

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -667,6 +667,19 @@ func requiredScopeFor(method, path string) string {
 	// prefix — it has no slash after "memory".
 	case strings.HasPrefix(path, "/v1/_memory/"):
 		return auth.ScopeTenant
+	// The channel admin family (list/create/patch/delete/purge/publish/
+	// subscribe/peek/ack/_await/_broadcast). channel_messages/_cursors/
+	// the channels def table now carry a tenant_id (migration 0066), and
+	// every handler sources the tenant from the authenticated principal
+	// (tenantFromCtx / principalTenantScope), never the wire — so a
+	// substrate:tenant operator is confined to its own tenant's channels
+	// (list filters by tenant; the `global` cross-tenant scope stays
+	// admin-only to create). The routes were pinned to ScopeAdmin by the
+	// /v1/_* catch-all below; grant ScopeTenant so they're reachable, the
+	// handlers still confine. ScopeAdmin also satisfies. (Matches the
+	// RFC BV memory re-gate above; closes the RFC AS channels carve-out.)
+	case strings.HasPrefix(path, "/v1/_channels"):
+		return auth.ScopeTenant
 	// Everything else under /v1/_* is OPERATOR-admin: token minting
 	// (_operatortokendef), runtime admin (pause/resume/state/snapshots/metrics),
 	// resolver, cross-tenant user focus.

--- a/internal/api/http/auth_principal_test.go
+++ b/internal/api/http/auth_principal_test.go
@@ -280,6 +280,16 @@ func TestRequiredScopeFor(t *testing.T) {
 		// repair-tenant is a cross-tenant bulk rewrite — STAYS operator-admin even
 		// though it matches the /v1/_memory/ prefix (it is excluded first).
 		{"POST", "/v1/_memory/repair-tenant", auth.ScopeAdmin},
+		// Migration 0066: the channel admin family is tenant-confined (channel
+		// rows carry a tenant_id; handlers source the tenant from the principal,
+		// list filters by tenant, cross-tenant `global` create stays admin-only).
+		// Re-gated off the /v1/_* catch-all to ScopeTenant (mirrors memory/RFC BV).
+		{"GET", "/v1/_channels", auth.ScopeTenant},
+		{"POST", "/v1/_channels", auth.ScopeTenant},
+		{"POST", "/v1/_channels/team-updates/publish", auth.ScopeTenant},
+		{"POST", "/v1/_channels/team-updates/subscribe", auth.ScopeTenant},
+		{"DELETE", "/v1/_channels/team-updates", auth.ScopeTenant},
+		{"POST", "/v1/_channels/team-updates/purge", auth.ScopeTenant},
 		// The MemoryBackendDef def family stays tenant via isTenantConfinedDefPath,
 		// NOT via the /v1/_memory/ prefix (no slash after "memory").
 		{"POST", "/v1/_memorybackenddef", auth.ScopeTenant},

--- a/internal/api/http/channels_crud_test.go
+++ b/internal/api/http/channels_crud_test.go
@@ -35,6 +35,10 @@ func channelCRUDFixture(t *testing.T) (*Server, store.Store, func()) {
 			"inbox":        {Scope: "user", Semantic: "broadcast", MaxMessages: 100},
 		},
 		Env: config.Env{
+			// Authed requests below run as the legacy LOOMCYCLE_AUTH_TOKEN
+			// principal, whose tenant is "default" (auth_principal.go). RFC N:
+			// the wire publish path stamps that tenant, so direct-store
+			// readbacks in these tests read under tenant "default".
 			AuthToken:             "test-token",
 			ChannelsMaxValueBytes: 64 * 1024,
 			ChannelsLongPollCapMS: 1000,
@@ -102,7 +106,7 @@ func TestChannelPurge_AllowedOnYamlChannel(t *testing.T) {
 	}
 
 	// The channel is now empty but still declared (peek works, returns 0).
-	rows, err := s.ChannelPeek(t.Context(), "team-updates", store.MemoryScopeGlobal, "", "", 10)
+	rows, err := s.ChannelPeek(t.Context(), "default", "team-updates", store.MemoryScopeGlobal, "", "", 10)
 	if err != nil {
 		t.Fatalf("ChannelPeek after purge: %v", err)
 	}
@@ -152,7 +156,7 @@ func TestAdminChannelPublish_HappyPath(t *testing.T) {
 	}
 
 	// Verify the row landed at scope=global, scope_id="".
-	rows, err := s.ChannelPeek(t.Context(), "team-updates", store.MemoryScopeGlobal, "", "", 10)
+	rows, err := s.ChannelPeek(t.Context(), "default", "team-updates", store.MemoryScopeGlobal, "", "", 10)
 	if err != nil {
 		t.Fatalf("ChannelPeek: %v", err)
 	}
@@ -187,8 +191,11 @@ func TestAdminChannelPublish_AllowedOnRuntimeChannel(t *testing.T) {
 	srv, s, cleanup := channelCRUDFixture(t)
 	defer cleanup()
 
+	// Create under tenant "default" — the tenant the authed publish resolves
+	// under (legacy LOOMCYCLE_AUTH_TOKEN principal), so requireChannelDeclared
+	// finds it (RFC N).
 	if err := s.ChannelsCreate(t.Context(), store.ChannelRow{
-		Name: "runtime-ch", Scope: "global", Semantic: "broadcast", MaxMessages: 50,
+		Name: "runtime-ch", TenantID: "default", Scope: "global", Semantic: "broadcast", MaxMessages: 50,
 	}); err != nil {
 		t.Fatalf("ChannelsCreate: %v", err)
 	}
@@ -201,7 +208,7 @@ func TestAdminChannelPublish_AllowedOnRuntimeChannel(t *testing.T) {
 		t.Fatalf("publish to runtime channel: status %d, want 200 (F29); body=%s", rec.Code, rec.Body.String())
 	}
 
-	rows, err := s.ChannelPeek(t.Context(), "runtime-ch", store.MemoryScopeGlobal, "", "", 10)
+	rows, err := s.ChannelPeek(t.Context(), "default", "runtime-ch", store.MemoryScopeGlobal, "", "", 10)
 	if err != nil {
 		t.Fatalf("ChannelPeek: %v", err)
 	}
@@ -341,7 +348,7 @@ func TestUserChannelPublish_ScopesByPath(t *testing.T) {
 	}
 
 	// Check scope=user, scope_id="alice".
-	rows, err := s.ChannelPeek(t.Context(), "inbox", store.MemoryScopeUser, "alice", "", 10)
+	rows, err := s.ChannelPeek(t.Context(), "default", "inbox", store.MemoryScopeUser, "alice", "", 10)
 	if err != nil {
 		t.Fatalf("ChannelPeek scope=user alice: %v", err)
 	}
@@ -350,7 +357,7 @@ func TestUserChannelPublish_ScopesByPath(t *testing.T) {
 	}
 
 	// And the global scope row should NOT have this message.
-	rowsG, _ := s.ChannelPeek(t.Context(), "inbox", store.MemoryScopeGlobal, "", "", 10)
+	rowsG, _ := s.ChannelPeek(t.Context(), "default", "inbox", store.MemoryScopeGlobal, "", "", 10)
 	if len(rowsG) != 0 {
 		t.Errorf("scope=global rows = %d, want 0 (per-user routes must scope by URL path)", len(rowsG))
 	}

--- a/internal/api/http/connector_impl.go
+++ b/internal/api/http/connector_impl.go
@@ -1092,6 +1092,7 @@ func (s *Server) InterruptionResolve(ctx context.Context, req connector.Interrup
 		_, _ = s.systemPublisher.PublishNow(
 			ctx,
 			"_system/interrupts/resolved",
+			tenantFromCtx(ctx), // RFC N: authoritative principal tenant
 			store.MemoryScopeUser, row.UserID,
 			payload, channels.SystemPublisherUserID, 0, 0,
 		)

--- a/internal/api/http/connector_impl_channels.go
+++ b/internal/api/http/connector_impl_channels.go
@@ -39,6 +39,10 @@ func resolveChannelScope(scopeStr, scopeID string) (store.MemoryScope, string, e
 			return "", "", fmt.Errorf("%w: scope=user requires scope_id", connector.ErrChannelScopeInvalid)
 		}
 		return store.MemoryScopeUser, scopeID, nil
+	case "tenant":
+		// Tenant-scoped: shared across the whole tenant (scope_id ""),
+		// isolated from other tenants by the store's tenant_id column.
+		return store.MemoryScopeTenant, "", nil
 	default:
 		return "", "", fmt.Errorf("%w: got %q", connector.ErrChannelScopeInvalid, scopeStr)
 	}
@@ -64,7 +68,7 @@ func (s *Server) requireChannelDeclared(ctx context.Context, name string) (chann
 		// publish/subscribe/peek/ack), and propagate a genuine store fault
 		// instead of swallowing it — the old `if err == nil` masked any
 		// transient error as a spurious channel_not_declared denial.
-		row, err := s.store.ChannelGet(ctx, name)
+		row, err := s.store.ChannelGet(ctx, tenantFromCtx(ctx), name)
 		switch {
 		case err == nil:
 			return channelDef{
@@ -136,7 +140,10 @@ func (s *Server) PublishChannel(ctx context.Context, req connector.ChannelPublis
 		publishedBy = scopeID
 	}
 
-	msg, err := s.systemPublisher.Publish(ctx, req.Channel, scope, scopeID,
+	// RFC N: the owning tenant is derived from the authenticated principal,
+	// never from the request body or scope_id.
+	tenantID := tenantFromCtx(ctx)
+	msg, err := s.systemPublisher.Publish(ctx, req.Channel, tenantID, scope, scopeID,
 		req.Payload, deliverAt, publishedBy, def.MaxMessages, def.DefaultTTL)
 	if err != nil {
 		return connector.ChannelPublishResult{}, fmt.Errorf("publish: %w", err)
@@ -178,9 +185,13 @@ func (s *Server) SubscribeChannel(ctx context.Context, req connector.ChannelSubs
 		limit = 100
 	}
 
+	// RFC N: capture the principal's tenant once so the long-poll read
+	// closure below uses the same authoritative value on the re-read.
+	tenantID := tenantFromCtx(ctx)
+
 	from := req.FromCursor
 	if from == "" {
-		committed, err := s.store.ChannelCommittedCursor(ctx, req.Channel, scope, scopeID)
+		committed, err := s.store.ChannelCommittedCursor(ctx, tenantID, req.Channel, scope, scopeID)
 		if err != nil {
 			return connector.ChannelSubscribeResult{}, fmt.Errorf("subscribe: read committed cursor: %w", err)
 		}
@@ -188,7 +199,7 @@ func (s *Server) SubscribeChannel(ctx context.Context, req connector.ChannelSubs
 	}
 
 	read := func() ([]store.ChannelMessage, string, error) {
-		return s.store.ChannelSubscribe(ctx, req.Channel, scope, scopeID, from, limit)
+		return s.store.ChannelSubscribe(ctx, tenantID, req.Channel, scope, scopeID, from, limit)
 	}
 	msgs, next, err := read()
 	if err != nil {
@@ -231,7 +242,7 @@ func (s *Server) SubscribeChannel(ctx context.Context, req connector.ChannelSubs
 	// error is a transient store fault — log + return the batch anyway
 	// (caller will re-receive on next subscribe; not silent data loss).
 	if next != "" && len(msgs) > 0 {
-		if ackErr := s.store.ChannelAck(ctx, req.Channel, scope, scopeID, next); ackErr != nil {
+		if ackErr := s.store.ChannelAck(ctx, tenantID, req.Channel, scope, scopeID, next); ackErr != nil {
 			if !errors.Is(ackErr, store.ErrChannelCursorRegression) {
 				// Same logging path as the in-band tool. The audit hole
 				// is documented in channel.go:execSubscribe; the wire
@@ -266,7 +277,8 @@ func (s *Server) PeekChannel(ctx context.Context, req connector.ChannelPeekReque
 		limit = 100
 	}
 
-	msgs, err := s.store.ChannelPeek(ctx, req.Channel, scope, scopeID, req.FromCursor, limit)
+	tenantID := tenantFromCtx(ctx) // RFC N: authoritative principal tenant
+	msgs, err := s.store.ChannelPeek(ctx, tenantID, req.Channel, scope, scopeID, req.FromCursor, limit)
 	if err != nil {
 		return connector.ChannelPeekResult{}, fmt.Errorf("peek: %w", err)
 	}
@@ -305,7 +317,7 @@ func (s *Server) AckChannel(ctx context.Context, req connector.ChannelAckRequest
 		return connector.ChannelAckResult{}, err
 	}
 
-	if err := s.store.ChannelAck(ctx, req.Channel, scope, scopeID, req.Cursor); err != nil {
+	if err := s.store.ChannelAck(ctx, tenantFromCtx(ctx), req.Channel, scope, scopeID, req.Cursor); err != nil {
 		if errors.Is(err, store.ErrChannelCursorRegression) {
 			return connector.ChannelAckResult{}, connector.ErrChannelCursorRegression
 		}
@@ -377,9 +389,10 @@ func (s *Server) BroadcastChannels(ctx context.Context, req connector.ChannelBro
 	if scope == store.MemoryScopeUser {
 		publishedBy = scopeID
 	}
+	tenantID := tenantFromCtx(ctx) // RFC N: authoritative principal tenant
 	out := connector.ChannelBroadcastResult{Results: make([]connector.ChannelBroadcastEntry, 0, len(targets))}
 	for _, t := range targets {
-		msg, perr := s.systemPublisher.Publish(ctx, t.name, scope, scopeID,
+		msg, perr := s.systemPublisher.Publish(ctx, t.name, tenantID, scope, scopeID,
 			req.Payload, deliverAt, publishedBy, t.def.MaxMessages, t.def.DefaultTTL)
 		if perr != nil {
 			out.Failed++
@@ -439,6 +452,10 @@ func (s *Server) AwaitChannels(ctx context.Context, req connector.ChannelAwaitRe
 		limit = 100
 	}
 
+	// RFC N: capture the principal's tenant once so every read closure
+	// (initial + long-poll re-read) uses the same authoritative value.
+	tenantID := tenantFromCtx(ctx)
+
 	type chanState struct {
 		name string
 		from string
@@ -457,7 +474,7 @@ func (s *Server) AwaitChannels(ctx context.Context, req connector.ChannelAwaitRe
 		}
 		from := req.FromCursor
 		if from == "" {
-			committed, cerr := s.store.ChannelCommittedCursor(ctx, name, scope, scopeID)
+			committed, cerr := s.store.ChannelCommittedCursor(ctx, tenantID, name, scope, scopeID)
 			if cerr != nil {
 				return connector.ChannelAwaitResult{}, fmt.Errorf("await: read committed cursor for %q: %w", name, cerr)
 			}
@@ -467,7 +484,7 @@ func (s *Server) AwaitChannels(ctx context.Context, req connector.ChannelAwaitRe
 	}
 
 	readChan := func(st *chanState) error {
-		msgs, next, rerr := s.store.ChannelSubscribe(ctx, st.name, scope, scopeID, st.from, limit)
+		msgs, next, rerr := s.store.ChannelSubscribe(ctx, tenantID, st.name, scope, scopeID, st.from, limit)
 		if rerr != nil {
 			return rerr
 		}

--- a/internal/api/http/connector_impl_channels_crud.go
+++ b/internal/api/http/connector_impl_channels_crud.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/connector"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 )
@@ -89,9 +90,20 @@ func (s *Server) CreateChannel(ctx context.Context, req connector.ChannelCreateR
 		scope = "global"
 	}
 	switch scope {
-	case "global", "agent", "user":
+	case "global", "agent", "user", "tenant":
 	default:
-		return connector.ChannelDescriptor{}, fmt.Errorf("create channel: scope must be one of global|agent|user, got %q", scope)
+		return connector.ChannelDescriptor{}, fmt.Errorf("create channel: scope must be one of global|tenant|user|agent, got %q", scope)
+	}
+	// A global channel is a single cross-tenant keyspace (tenant_id="", see
+	// store.ChannelScopeTenant): its messages are shared across every
+	// tenant. Only an operator/admin may create one at runtime; a tenant
+	// operator is confined to its own tenant and must use tenant|user|agent
+	// scope (all partitioned by its tenant). Open mode (no principal) is
+	// single-tenant and unrestricted.
+	if scope == "global" {
+		if p, ok := auth.PrincipalFromContext(ctx); ok && !auth.HasScope(p.Scopes, auth.ScopeAdmin) {
+			return connector.ChannelDescriptor{}, fmt.Errorf("create channel: scope=global requires operator (admin) scope; a tenant operator may create tenant|user|agent channels")
+		}
 	}
 
 	semantic := strings.TrimSpace(req.Semantic)
@@ -109,6 +121,7 @@ func (s *Server) CreateChannel(ctx context.Context, req connector.ChannelCreateR
 
 	row := store.ChannelRow{
 		Name:        name,
+		TenantID:    tenantFromCtx(ctx), // RFC N: authoritative principal tenant
 		Description: req.Description,
 		Scope:       scope,
 		Semantic:    semantic,
@@ -160,7 +173,7 @@ func (s *Server) UpdateChannel(ctx context.Context, name string, req connector.C
 		MaxMessages: req.MaxMessages,
 		Semantic:    req.Semantic,
 	}
-	if err := s.store.ChannelsUpdate(ctx, name, patch); err != nil {
+	if err := s.store.ChannelsUpdate(ctx, tenantFromCtx(ctx), name, patch); err != nil {
 		var notFound *store.ErrNotFound
 		if errors.As(err, &notFound) {
 			return connector.ChannelDescriptor{}, fmt.Errorf("%w: %q", connector.ErrChannelNotFound, name)
@@ -175,9 +188,13 @@ func (s *Server) UpdateChannel(ctx context.Context, name string, req connector.C
 	if err != nil {
 		return connector.ChannelDescriptor{}, fmt.Errorf("update channel re-read: %w", err)
 	}
+	// ChannelsList returns every tenant's rows; tenant operators see only
+	// their own channels, admin sees all. Scope the re-read so a same-named
+	// channel in another tenant can't be picked up.
+	tenantID, all := s.principalTenantScope(ctx, "")
 	var match *store.ChannelRow
 	for i := range rows {
-		if rows[i].Name == name {
+		if rows[i].Name == name && (all || rows[i].TenantID == tenantID) {
 			match = &rows[i]
 			break
 		}
@@ -210,7 +227,7 @@ func (s *Server) DeleteChannel(ctx context.Context, name string) error {
 	if !validChannelName(name) {
 		return fmt.Errorf("delete channel: name must match [A-Za-z0-9_-]{1,128}")
 	}
-	if err := s.store.ChannelsDelete(ctx, name); err != nil {
+	if err := s.store.ChannelsDelete(ctx, tenantFromCtx(ctx), name); err != nil {
 		var notFound *store.ErrNotFound
 		if errors.As(err, &notFound) {
 			return fmt.Errorf("%w: %q", connector.ErrChannelNotFound, name)
@@ -229,7 +246,15 @@ func (s *Server) DeleteChannel(ctx context.Context, name string) error {
 // yaml-declared nor present in the runtime substrate.
 func (s *Server) PurgeChannel(ctx context.Context, name string) (connector.ChannelPurgeResult, error) {
 	name = strings.TrimSpace(name)
-	if _, isYaml := s.cfg.Channels[name]; !isYaml {
+	// The channel's declared SCOPE determines which tenant keyspace its
+	// messages live in (global => "", every other scope => the caller's
+	// tenant; see store.ChannelScopeTenant). Purge must target that
+	// keyspace, not blindly the caller's tenant — otherwise a global
+	// channel's messages (at "") are never drained.
+	declaredScope := ""
+	if yamlCh, isYaml := s.cfg.Channels[name]; isYaml {
+		declaredScope = yamlCh.Scope
+	} else {
 		// Only the runtime plane obeys the strict name shape — yaml
 		// channels may use exotic names (slashes etc.) the runtime
 		// allow-set forbids, and we must still let those be purged.
@@ -240,10 +265,15 @@ func (s *Server) PurgeChannel(ctx context.Context, name string) (connector.Chann
 		if err != nil {
 			return connector.ChannelPurgeResult{}, fmt.Errorf("purge channel existence check: %w", err)
 		}
+		// ChannelsList returns every tenant's rows; tenant operators see only
+		// their own channels, admin sees all — so a cross-tenant name can't be
+		// treated as "exists" here.
+		tenantID, all := s.principalTenantScope(ctx, "")
 		found := false
 		for i := range rows {
-			if rows[i].Name == name {
+			if rows[i].Name == name && (all || rows[i].TenantID == tenantID) {
 				found = true
+				declaredScope = rows[i].Scope
 				break
 			}
 		}
@@ -251,7 +281,8 @@ func (s *Server) PurgeChannel(ctx context.Context, name string) (connector.Chann
 			return connector.ChannelPurgeResult{}, fmt.Errorf("%w: %q", connector.ErrChannelNotFound, name)
 		}
 	}
-	n, err := s.store.ChannelPurge(ctx, name)
+	msgTenant := store.ChannelScopeTenant(tenantFromCtx(ctx), store.MemoryScope(declaredScope))
+	n, err := s.store.ChannelPurge(ctx, msgTenant, name)
 	if err != nil {
 		return connector.ChannelPurgeResult{}, fmt.Errorf("purge channel: %w", err)
 	}

--- a/internal/api/http/connector_impl_channels_test.go
+++ b/internal/api/http/connector_impl_channels_test.go
@@ -19,7 +19,7 @@ type channelGetErrStore struct {
 	err error
 }
 
-func (s channelGetErrStore) ChannelGet(context.Context, string) (store.ChannelRow, error) {
+func (s channelGetErrStore) ChannelGet(context.Context, string, string) (store.ChannelRow, error) {
 	return store.ChannelRow{}, s.err
 }
 

--- a/internal/api/http/connector_impl_interactive.go
+++ b/internal/api/http/connector_impl_interactive.go
@@ -300,6 +300,7 @@ func (s *Server) ResolveInterrupt(ctx context.Context, runID, interruptID, kind,
 		_, _ = s.systemPublisher.PublishNow(
 			ctx,
 			"_system/interrupts/resolved",
+			tenantFromCtx(ctx), // RFC N: authoritative principal/run tenant
 			store.MemoryScopeUser, row.UserID,
 			payload, channels.SystemPublisherUserID, 0, 0,
 		)

--- a/internal/api/http/connector_impl_n8n.go
+++ b/internal/api/http/connector_impl_n8n.go
@@ -68,7 +68,13 @@ func (s *Server) ListChannels(ctx context.Context) (connector.ListChannelsRespon
 	if runtimeErr != nil {
 		return connector.ListChannelsResponse{}, runtimeErr
 	}
+	// ChannelsList returns every tenant's rows; tenant operators see only
+	// their own channels, admin sees all.
+	tenantID, all := s.principalTenantScope(ctx, "")
 	for _, r := range runtimeRows {
+		if !all && r.TenantID != tenantID {
+			continue
+		}
 		if _, yaml := s.cfg.Channels[r.Name]; yaml {
 			continue
 		}

--- a/internal/api/http/library_admin.go
+++ b/internal/api/http/library_admin.go
@@ -193,7 +193,7 @@ func (s *Server) handleAgentChannels(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, "invalid_agent_name", err.Error())
 		return
 	}
-	rows, err := s.store.ChannelListCursorsForScope(r.Context(), store.MemoryScopeAgent, agentName)
+	rows, err := s.store.ChannelListCursorsForScope(r.Context(), tenantFromCtx(r.Context()), store.MemoryScopeAgent, agentName)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "store_error", err.Error())
 		return

--- a/internal/api/http/library_admin_test.go
+++ b/internal/api/http/library_admin_test.go
@@ -243,14 +243,17 @@ func TestAgentChannels_HappyPath(t *testing.T) {
 	defer cleanup()
 	ctx := t.Context()
 
+	// The GET endpoint reads cursors under the authed principal's tenant
+	// ("default" for the legacy LOOMCYCLE_AUTH_TOKEN, auth_principal.go), so
+	// seed the cursor rows under that same tenant (RFC N).
 	for _, ch := range []string{"team-updates", "findings"} {
 		_, _, _ = s.ChannelPublish(ctx, store.ChannelMessage{
-			Channel: ch, Scope: store.MemoryScopeAgent, ScopeID: "alice",
+			Channel: ch, TenantID: "default", Scope: store.MemoryScopeAgent, ScopeID: "alice",
 			Payload: []byte(`{}`),
 		}, 0)
 		time.Sleep(time.Microsecond)
-		_, next, _ := s.ChannelSubscribe(ctx, ch, store.MemoryScopeAgent, "alice", "", 1)
-		_ = s.ChannelAck(ctx, ch, store.MemoryScopeAgent, "alice", next)
+		_, next, _ := s.ChannelSubscribe(ctx, "default", ch, store.MemoryScopeAgent, "alice", "", 1)
+		_ = s.ChannelAck(ctx, "default", ch, store.MemoryScopeAgent, "alice", next)
 	}
 
 	req := authedRequest("GET", "/v1/agents/alice/channels", nil)
@@ -295,13 +298,15 @@ func TestAgentChannels_SlashGroupedName(t *testing.T) {
 	ctx := t.Context()
 
 	const agentName = "doc/manager"
+	// Seed under tenant "default" — the tenant the authed GET endpoint reads
+	// (legacy LOOMCYCLE_AUTH_TOKEN principal, auth_principal.go; RFC N).
 	_, _, _ = s.ChannelPublish(ctx, store.ChannelMessage{
-		Channel: "findings", Scope: store.MemoryScopeAgent, ScopeID: agentName,
+		Channel: "findings", TenantID: "default", Scope: store.MemoryScopeAgent, ScopeID: agentName,
 		Payload: []byte(`{}`),
 	}, 0)
 	time.Sleep(time.Microsecond)
-	_, next, _ := s.ChannelSubscribe(ctx, "findings", store.MemoryScopeAgent, agentName, "", 1)
-	_ = s.ChannelAck(ctx, "findings", store.MemoryScopeAgent, agentName, next)
+	_, next, _ := s.ChannelSubscribe(ctx, "default", "findings", store.MemoryScopeAgent, agentName, "", 1)
+	_ = s.ChannelAck(ctx, "default", "findings", store.MemoryScopeAgent, agentName, next)
 
 	// The Web UI encodes the name; the `/` becomes %2F in the path.
 	req := authedRequest("GET", "/v1/agents/doc%2Fmanager/channels", nil)

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1968,7 +1968,14 @@ func (s *Server) mergedChannelDefs(ctx context.Context, includeRuntime bool) map
 	}
 	if includeRuntime && s.store != nil {
 		if rows, err := s.store.ChannelsList(ctx); err == nil {
+			// runtime channels are per-tenant; yaml channels stay
+			// operator-global. Skip runtime rows owned by another tenant so an
+			// agent only resolves the channels its own tenant declared.
+			callerTenant := tenantFromCtx(ctx)
 			for _, r := range rows {
+				if r.TenantID != callerTenant {
+					continue
+				}
 				if _, exists := channels[r.Name]; exists {
 					continue // yaml takes precedence on a name collision
 				}
@@ -3345,7 +3352,10 @@ func (s *Server) handleSystemChannelPublish(w http.ResponseWriter, r *http.Reque
 	// isn't a run-bound request), so we fall back to "_admin".
 	publishedBy := "_admin"
 
-	msg, err := s.systemPublisher.Publish(r.Context(), fullName, scope, scopeID,
+	// RFC N: the owning tenant is derived from the authenticated principal,
+	// never from the request body.
+	tenantID := tenantFromCtx(r.Context())
+	msg, err := s.systemPublisher.Publish(r.Context(), fullName, tenantID, scope, scopeID,
 		body.Payload, deliverAt, publishedBy, def.MaxMessages, def.DefaultTTL)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "publish_failed", fmt.Sprintf("publish failed: %s", err))

--- a/internal/api/http/system_channels_test.go
+++ b/internal/api/http/system_channels_test.go
@@ -105,8 +105,10 @@ func TestSystemChannelPublish_HappyPath(t *testing.T) {
 		t.Errorf("response msg_id = %v, want msg_ prefix", resp["msg_id"])
 	}
 
-	// Verify the message landed in storage with the admin sentinel.
-	msgs, _, err := s.ChannelSubscribe(context.Background(),
+	// Verify the message landed in storage with the admin sentinel. The
+	// authed publish runs as the legacy LOOMCYCLE_AUTH_TOKEN principal, whose
+	// tenant is "default" (auth_principal.go), so read back under that tenant.
+	msgs, _, err := s.ChannelSubscribe(context.Background(), "default",
 		"_system/alarms/critical", store.MemoryScopeGlobal, "", "", 10)
 	if err != nil || len(msgs) != 1 {
 		t.Fatalf("readback: msgs=%d err=%v", len(msgs), err)

--- a/internal/api/webhook/oncomplete.go
+++ b/internal/api/webhook/oncomplete.go
@@ -37,7 +37,7 @@ func (rec *Receiver) dispatchOnComplete(ctx context.Context, name string, wd con
 func (rec *Receiver) dispatchOneOnComplete(ctx context.Context, name, tenantID string, h config.ScheduledRunHook, runID, agentID, userID string) error {
 	switch h.Kind {
 	case "channel.publish":
-		return rec.dispatchOnCompleteChannelPublish(ctx, name, h, runID, agentID, userID)
+		return rec.dispatchOnCompleteChannelPublish(ctx, name, tenantID, h, runID, agentID, userID)
 	case "memory.set":
 		return rec.dispatchOnCompleteMemorySet(ctx, name, tenantID, h, userID)
 	case "mcp.call":
@@ -60,7 +60,7 @@ func (rec *Receiver) dispatchOneOnComplete(ctx context.Context, name, tenantID s
 // The published payload carries the webhook name + run/agent ids alongside
 // the operator-declared hook payload so a downstream consumer can correlate
 // the delivery to the run that produced it.
-func (rec *Receiver) dispatchOnCompleteChannelPublish(ctx context.Context, name string, h config.ScheduledRunHook, runID, agentID, userID string) error {
+func (rec *Receiver) dispatchOnCompleteChannelPublish(ctx context.Context, name, tenantID string, h config.ScheduledRunHook, runID, agentID, userID string) error {
 	if h.Channel == "" {
 		return fmt.Errorf("channel.publish missing `channel`")
 	}
@@ -83,7 +83,10 @@ func (rec *Receiver) dispatchOnCompleteChannelPublish(ctx context.Context, name 
 		scopeID = userID
 	}
 	msg := store.ChannelMessage{
-		Channel:           h.Channel,
+		Channel: h.Channel,
+		// RFC N: the owning tenant comes from the webhook def (wd.TenantID),
+		// threaded down from dispatchOnComplete — never from the hook payload.
+		TenantID:          tenantID,
 		Scope:             scope,
 		ScopeID:           scopeID,
 		Payload:           payload,

--- a/internal/api/webhook/server.go
+++ b/internal/api/webhook/server.go
@@ -285,7 +285,9 @@ func (rec *Receiver) deliverChannel(ctx context.Context, w http.ResponseWriter, 
 	// Publish under the global scope — a webhook is an operator-level
 	// ingress, not bound to a user/agent keyspace. maxMessages/TTL default
 	// to 0 (the channel's own config / store defaults govern retention).
-	_, err := rec.publisher.PublishNow(ctx, wd.Channel, store.MemoryScopeGlobal, "",
+	// RFC N: the owning tenant comes from the webhook def (wd.TenantID),
+	// never from the request body.
+	_, err := rec.publisher.PublishNow(ctx, wd.Channel, wd.TenantID, store.MemoryScopeGlobal, "",
 		json.RawMessage(body), channels.SystemPublisherUserID, 0, 0)
 	if err != nil {
 		rec.finish(span, name, did, "rejected_publish", "")

--- a/internal/api/webhook/server_test.go
+++ b/internal/api/webhook/server_test.go
@@ -65,27 +65,29 @@ func (f *fakeRunner) wasCalled() bool {
 
 // fakePublisher records channel publishes.
 type fakePublisher struct {
-	mu      sync.Mutex
-	channel string
-	payload json.RawMessage
-	called  bool
+	mu       sync.Mutex
+	channel  string
+	tenantID string
+	payload  json.RawMessage
+	called   bool
 }
 
-func (p *fakePublisher) Publish(ctx context.Context, channel string, scope store.MemoryScope, scopeID string,
+func (p *fakePublisher) Publish(ctx context.Context, channel, tenantID string, scope store.MemoryScope, scopeID string,
 	payload json.RawMessage, deliverAt time.Time, publishedByUserID string, maxMessages, defaultTTLSeconds int,
 ) (store.ChannelMessage, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.channel = channel
+	p.tenantID = tenantID
 	p.payload = payload
 	p.called = true
 	return store.ChannelMessage{ID: "msg-1"}, nil
 }
 
-func (p *fakePublisher) PublishNow(ctx context.Context, channel string, scope store.MemoryScope, scopeID string,
+func (p *fakePublisher) PublishNow(ctx context.Context, channel, tenantID string, scope store.MemoryScope, scopeID string,
 	payload json.RawMessage, publishedByUserID string, maxMessages, defaultTTLSeconds int,
 ) (store.ChannelMessage, error) {
-	return p.Publish(ctx, channel, scope, scopeID, payload, time.Time{}, publishedByUserID, maxMessages, defaultTTLSeconds)
+	return p.Publish(ctx, channel, tenantID, scope, scopeID, payload, time.Time{}, publishedByUserID, maxMessages, defaultTTLSeconds)
 }
 
 // newTestReceiver wires a Receiver against a yaml-only config (no store),

--- a/internal/channels/heartbeat.go
+++ b/internal/channels/heartbeat.go
@@ -145,7 +145,10 @@ func (h *HeartbeatRunner) run(ctx context.Context, spec HeartbeatSpec) {
 				log.Printf("heartbeat %s: marshal: %v", spec.Name, err)
 				continue
 			}
-			if _, err := h.publisher.PublishNow(ctx, spec.Name, store.MemoryScopeGlobal, "",
+			// Heartbeats are operator-global infrastructure (MemoryScopeGlobal,
+			// no run/principal in scope), so they belong to the shared/legacy
+			// tenant "" rather than any one tenant.
+			if _, err := h.publisher.PublishNow(ctx, spec.Name, "", store.MemoryScopeGlobal, "",
 				body, SystemPublisherUserID, spec.MaxMessages, spec.DefaultTTL); err != nil {
 				// ctx-cancel during publish = clean shutdown; don't
 				// noisy-log.

--- a/internal/channels/heartbeat_test.go
+++ b/internal/channels/heartbeat_test.go
@@ -32,7 +32,7 @@ func TestHeartbeatRunner_EmitsAtCadence(t *testing.T) {
 	time.Sleep(350 * time.Millisecond)
 	runner.Stop()
 
-	msgs, _, err := s.ChannelSubscribe(context.Background(),
+	msgs, _, err := s.ChannelSubscribe(context.Background(), "",
 		"_system/heartbeat-test", store.MemoryScopeGlobal, "", "cur_0", 100)
 	if err != nil {
 		t.Fatalf("subscribe: %v", err)

--- a/internal/channels/system.go
+++ b/internal/channels/system.go
@@ -26,17 +26,19 @@ import (
 // publishers bypass that gate by design.
 type SystemPublisher interface {
 	// Publish writes a message to a channel with optional future
-	// deliver time. publishedByUserID is the audit attribution
-	// ("_system" for internal, bearer-user-id for admin endpoint).
-	// Returns the persisted ChannelMessage row.
-	Publish(ctx context.Context, channel string, scope store.MemoryScope, scopeID string,
+	// deliver time. tenantID is the caller-authoritative owning tenant
+	// (RFC L authority model — derived from the principal / run, never
+	// from the wire or model). publishedByUserID is the audit
+	// attribution ("_system" for internal, bearer-user-id for admin
+	// endpoint). Returns the persisted ChannelMessage row.
+	Publish(ctx context.Context, channel, tenantID string, scope store.MemoryScope, scopeID string,
 		payload json.RawMessage, deliverAt time.Time, publishedByUserID string,
 		maxMessages int, defaultTTLSeconds int,
 	) (store.ChannelMessage, error)
 
 	// PublishNow is the convenience for "publish immediately" — same
 	// as Publish with a zero deliverAt.
-	PublishNow(ctx context.Context, channel string, scope store.MemoryScope, scopeID string,
+	PublishNow(ctx context.Context, channel, tenantID string, scope store.MemoryScope, scopeID string,
 		payload json.RawMessage, publishedByUserID string,
 		maxMessages int, defaultTTLSeconds int,
 	) (store.ChannelMessage, error)
@@ -59,7 +61,7 @@ type StorePublisher struct {
 const SystemPublisherUserID = "_system"
 
 // Publish implements SystemPublisher.
-func (p *StorePublisher) Publish(ctx context.Context, channel string, scope store.MemoryScope, scopeID string,
+func (p *StorePublisher) Publish(ctx context.Context, channel, tenantID string, scope store.MemoryScope, scopeID string,
 	payload json.RawMessage, deliverAt time.Time, publishedByUserID string,
 	maxMessages int, defaultTTLSeconds int,
 ) (store.ChannelMessage, error) {
@@ -82,6 +84,7 @@ func (p *StorePublisher) Publish(ctx context.Context, channel string, scope stor
 
 	msg := store.ChannelMessage{
 		Channel:           channel,
+		TenantID:          tenantID,
 		Scope:             scope,
 		ScopeID:           scopeID,
 		Payload:           payload,
@@ -119,9 +122,9 @@ func (p *StorePublisher) Publish(ctx context.Context, channel string, scope stor
 }
 
 // PublishNow implements SystemPublisher.
-func (p *StorePublisher) PublishNow(ctx context.Context, channel string, scope store.MemoryScope, scopeID string,
+func (p *StorePublisher) PublishNow(ctx context.Context, channel, tenantID string, scope store.MemoryScope, scopeID string,
 	payload json.RawMessage, publishedByUserID string,
 	maxMessages int, defaultTTLSeconds int,
 ) (store.ChannelMessage, error) {
-	return p.Publish(ctx, channel, scope, scopeID, payload, time.Time{}, publishedByUserID, maxMessages, defaultTTLSeconds)
+	return p.Publish(ctx, channel, tenantID, scope, scopeID, payload, time.Time{}, publishedByUserID, maxMessages, defaultTTLSeconds)
 }

--- a/internal/channels/system_test.go
+++ b/internal/channels/system_test.go
@@ -21,7 +21,7 @@ func TestStorePublisher_PublishNowImmediate(t *testing.T) {
 	pub := &StorePublisher{Store: s, Bus: bus}
 	ctx := context.Background()
 
-	msg, err := pub.PublishNow(ctx, "_system/test", store.MemoryScopeGlobal, "",
+	msg, err := pub.PublishNow(ctx, "_system/test", "", store.MemoryScopeGlobal, "",
 		json.RawMessage(`{"k":"v"}`), SystemPublisherUserID, 0, 0)
 	if err != nil {
 		t.Fatalf("publish: %v", err)
@@ -34,7 +34,7 @@ func TestStorePublisher_PublishNowImmediate(t *testing.T) {
 	}
 
 	// Read back via store directly.
-	msgs, _, err := s.ChannelSubscribe(ctx, "_system/test", store.MemoryScopeGlobal, "", "", 10)
+	msgs, _, err := s.ChannelSubscribe(ctx, "", "_system/test", store.MemoryScopeGlobal, "", "", 10)
 	if err != nil {
 		t.Fatalf("subscribe: %v", err)
 	}
@@ -59,7 +59,7 @@ func TestStorePublisher_PublishDeferredArmsScheduler(t *testing.T) {
 	ctx := context.Background()
 
 	deferTo := time.Now().Add(120 * time.Millisecond)
-	msg, err := pub.Publish(ctx, "_system/test", store.MemoryScopeGlobal, "",
+	msg, err := pub.Publish(ctx, "_system/test", "", store.MemoryScopeGlobal, "",
 		json.RawMessage(`{}`), deferTo, "alice", 0, 0)
 	if err != nil {
 		t.Fatalf("publish: %v", err)
@@ -73,7 +73,7 @@ func TestStorePublisher_PublishDeferredArmsScheduler(t *testing.T) {
 
 	// Wait past deferTo; subscribe should see the message.
 	time.Sleep(180 * time.Millisecond)
-	msgs, _, err := s.ChannelSubscribe(ctx, "_system/test", store.MemoryScopeGlobal, "", "", 10)
+	msgs, _, err := s.ChannelSubscribe(ctx, "", "_system/test", store.MemoryScopeGlobal, "", "", 10)
 	if err != nil {
 		t.Fatalf("subscribe: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestStorePublisher_PublishDeferredArmsScheduler(t *testing.T) {
 
 func TestStorePublisher_NoStoreErrors(t *testing.T) {
 	pub := &StorePublisher{}
-	_, err := pub.PublishNow(context.Background(), "_system/test", store.MemoryScopeGlobal, "",
+	_, err := pub.PublishNow(context.Background(), "_system/test", "", store.MemoryScopeGlobal, "",
 		json.RawMessage(`{}`), SystemPublisherUserID, 0, 0)
 	if err == nil {
 		t.Error("publish with no Store should error")
@@ -101,13 +101,13 @@ func TestStorePublisher_DefaultTTLApplied(t *testing.T) {
 	pub := &StorePublisher{Store: s}
 	ctx := context.Background()
 
-	msg, err := pub.PublishNow(ctx, "_system/test", store.MemoryScopeGlobal, "",
+	msg, err := pub.PublishNow(ctx, "_system/test", "", store.MemoryScopeGlobal, "",
 		json.RawMessage(`{}`), SystemPublisherUserID, 0, 60) // 60 sec TTL
 	if err != nil {
 		t.Fatalf("publish: %v", err)
 	}
 	// Verify the row carries an expires_at via re-read.
-	msgs, _, _ := s.ChannelSubscribe(ctx, "_system/test", store.MemoryScopeGlobal, "", "", 10)
+	msgs, _, _ := s.ChannelSubscribe(ctx, "", "_system/test", store.MemoryScopeGlobal, "", "", 10)
 	if len(msgs) != 1 {
 		t.Fatalf("subscribe len = %d, want 1", len(msgs))
 	}

--- a/internal/scheduler/dispatch.go
+++ b/internal/scheduler/dispatch.go
@@ -43,7 +43,7 @@ func (s *Scheduler) dispatchHooks(ctx context.Context, scheduleName string, def 
 func (s *Scheduler) dispatchOneHook(ctx context.Context, scheduleName, userID, agentName, tenantID string, h scheduleHook, runID, agentID string) error {
 	switch h.Kind {
 	case "channel.publish":
-		return s.dispatchChannelPublish(ctx, scheduleName, userID, agentName, h, runID, agentID)
+		return s.dispatchChannelPublish(ctx, scheduleName, userID, agentName, tenantID, h, runID, agentID)
 	case "memory.set":
 		return s.dispatchMemorySet(ctx, scheduleName, userID, tenantID, h)
 	case "mcp.call":
@@ -55,7 +55,7 @@ func (s *Scheduler) dispatchOneHook(ctx context.Context, scheduleName, userID, a
 	}
 }
 
-func (s *Scheduler) dispatchChannelPublish(ctx context.Context, scheduleName, userID, agentName string, h scheduleHook, runID, agentID string) error {
+func (s *Scheduler) dispatchChannelPublish(ctx context.Context, scheduleName, userID, agentName, tenantID string, h scheduleHook, runID, agentID string) error {
 	if h.Channel == "" {
 		return fmt.Errorf("channel.publish missing `channel`")
 	}
@@ -73,7 +73,10 @@ func (s *Scheduler) dispatchChannelPublish(ctx context.Context, scheduleName, us
 		return err
 	}
 	msg := store.ChannelMessage{
-		Channel:           h.Channel,
+		Channel: h.Channel,
+		// RFC N: the owning tenant comes from the schedule def (def.TenantID),
+		// threaded down from dispatchHooks — never from the hook payload.
+		TenantID:          tenantID,
 		Scope:             scope,
 		ScopeID:           scopeID,
 		Payload:           payload,

--- a/internal/scheduler/dispatch_test.go
+++ b/internal/scheduler/dispatch_test.go
@@ -14,7 +14,7 @@ import (
 // scope-blind ChannelStats can't give.
 func peekScopeCount(t *testing.T, st store.Store, channel string, scope store.MemoryScope, scopeID string) int {
 	t.Helper()
-	msgs, err := st.ChannelPeek(context.Background(), channel, scope, scopeID, "", 100)
+	msgs, err := st.ChannelPeek(context.Background(), "", channel, scope, scopeID, "", 100)
 	if err != nil {
 		t.Fatalf("ChannelPeek(%s/%s): %v", scope, scopeID, err)
 	}

--- a/internal/store/postgres/channel_clock_test.go
+++ b/internal/store/postgres/channel_clock_test.go
@@ -53,7 +53,7 @@ func TestChannelPublish_ImmediateIsVisibleDespiteHostClockAhead(t *testing.T) {
 		t.Fatalf("publish: %v", err)
 	}
 
-	msgs, _, err := s.ChannelSubscribe(ctx, "clock-ahead", store.MemoryScopeAgent, "x", "", 10)
+	msgs, _, err := s.ChannelSubscribe(ctx, "", "clock-ahead", store.MemoryScopeAgent, "x", "", 10)
 	if err != nil {
 		t.Fatalf("subscribe: %v", err)
 	}
@@ -82,7 +82,7 @@ func TestChannelPublish_ImmediateIsVisibleDespiteHostClockBehind(t *testing.T) {
 		t.Fatalf("publish: %v", err)
 	}
 
-	msgs, _, err := s.ChannelSubscribe(ctx, "clock-behind", store.MemoryScopeAgent, "x", "", 10)
+	msgs, _, err := s.ChannelSubscribe(ctx, "", "clock-behind", store.MemoryScopeAgent, "x", "", 10)
 	if err != nil {
 		t.Fatalf("subscribe: %v", err)
 	}
@@ -116,7 +116,7 @@ func TestChannelPublish_DeferredKeepsCallerSuppliedVisibleAt(t *testing.T) {
 		t.Fatalf("publish deferred: %v", err)
 	}
 
-	msgs, _, err := s.ChannelSubscribe(ctx, "deferred", store.MemoryScopeAgent, "x", "", 10)
+	msgs, _, err := s.ChannelSubscribe(ctx, "", "deferred", store.MemoryScopeAgent, "x", "", 10)
 	if err != nil {
 		t.Fatalf("subscribe: %v", err)
 	}
@@ -126,7 +126,7 @@ func TestChannelPublish_DeferredKeepsCallerSuppliedVisibleAt(t *testing.T) {
 	}
 
 	// And it is stored at the caller's instant, not clamped to NOW().
-	rows, err := s.ChannelPeek(ctx, "deferred", store.MemoryScopeAgent, "x", "cur_0", 10)
+	rows, err := s.ChannelPeek(ctx, "", "deferred", store.MemoryScopeAgent, "x", "cur_0", 10)
 	if err != nil {
 		t.Fatalf("peek: %v", err)
 	}
@@ -153,7 +153,7 @@ func TestChannelPublish_PastVisibleAtClampsToServerNow(t *testing.T) {
 		t.Fatalf("publish: %v", err)
 	}
 
-	msgs, _, err := s.ChannelSubscribe(ctx, "past", store.MemoryScopeAgent, "x", "", 10)
+	msgs, _, err := s.ChannelSubscribe(ctx, "", "past", store.MemoryScopeAgent, "x", "", 10)
 	if err != nil {
 		t.Fatalf("subscribe: %v", err)
 	}

--- a/internal/store/postgres/channel_race_test.go
+++ b/internal/store/postgres/channel_race_test.go
@@ -76,7 +76,7 @@ func TestChannelSubscribe_ConcurrentPublishRace(t *testing.T) {
 					return
 				}
 				totalReads.Add(1)
-				msgs, _, err := s.ChannelSubscribe(ctx, "race-test",
+				msgs, _, err := s.ChannelSubscribe(ctx, "", "race-test",
 					store.MemoryScopeGlobal, "", "cur_0", 5000)
 				if err != nil {
 					t.Errorf("subscribe (worker %d msg %d): %v", workerID, j, err)
@@ -85,7 +85,7 @@ func TestChannelSubscribe_ConcurrentPublishRace(t *testing.T) {
 				if !containsMsg(msgs, msgID) {
 					missesOnFirstRead.Add(1)
 					time.Sleep(30 * time.Millisecond)
-					msgs2, _, err := s.ChannelSubscribe(ctx, "race-test",
+					msgs2, _, err := s.ChannelSubscribe(ctx, "", "race-test",
 						store.MemoryScopeGlobal, "", "cur_0", 5000)
 					if err != nil {
 						t.Errorf("subscribe retry (worker %d msg %d): %v",
@@ -194,7 +194,7 @@ func TestChannelSubscribe_CursorAdvanceRace(t *testing.T) {
 					return
 				default:
 				}
-				msgs, next, err := s.ChannelSubscribe(ctx, "cursor-race",
+				msgs, next, err := s.ChannelSubscribe(ctx, "", "cursor-race",
 					store.MemoryScopeGlobal, "", cursor, readBatchLimit)
 				if err != nil {
 					t.Errorf("subscribe: %v", err)

--- a/internal/store/postgres/channels.go
+++ b/internal/store/postgres/channels.go
@@ -22,10 +22,10 @@ import (
 // name. Empty slice when no runtime channels exist (vs nil on error).
 func (s *Store) ChannelsList(ctx context.Context) ([]store.ChannelRow, error) {
 	rows, err := s.pool.Query(ctx, `
-		SELECT name, description, scope, semantic,
+		SELECT name, tenant_id, description, scope, semantic,
 		       default_ttl, max_messages, publisher, period, created_at
 		FROM channels
-		ORDER BY name
+		ORDER BY tenant_id, name
 	`)
 	if err != nil {
 		return nil, fmt.Errorf("channels list: %w", err)
@@ -36,7 +36,7 @@ func (s *Store) ChannelsList(ctx context.Context) ([]store.ChannelRow, error) {
 		var r store.ChannelRow
 		var createdAt time.Time
 		if err := rows.Scan(
-			&r.Name, &r.Description, &r.Scope, &r.Semantic,
+			&r.Name, &r.TenantID, &r.Description, &r.Scope, &r.Semantic,
 			&r.DefaultTTL, &r.MaxMessages, &r.Publisher, &r.Period,
 			&createdAt,
 		); err != nil {
@@ -53,16 +53,16 @@ func (s *Store) ChannelsList(ctx context.Context) ([]store.ChannelRow, error) {
 // (exp7 I5: a point lookup for the hot declared-check, so a real query
 // fault surfaces as an error instead of an empty scan masquerading as
 // "not declared").
-func (s *Store) ChannelGet(ctx context.Context, name string) (store.ChannelRow, error) {
+func (s *Store) ChannelGet(ctx context.Context, tenantID, name string) (store.ChannelRow, error) {
 	var r store.ChannelRow
 	var createdAt time.Time
 	err := s.pool.QueryRow(ctx, `
-		SELECT name, description, scope, semantic,
+		SELECT name, tenant_id, description, scope, semantic,
 		       default_ttl, max_messages, publisher, period, created_at
 		FROM channels
-		WHERE name = $1
-	`, name).Scan(
-		&r.Name, &r.Description, &r.Scope, &r.Semantic,
+		WHERE tenant_id = $1 AND name = $2
+	`, tenantID, name).Scan(
+		&r.Name, &r.TenantID, &r.Description, &r.Scope, &r.Semantic,
 		&r.DefaultTTL, &r.MaxMessages, &r.Publisher, &r.Period,
 		&createdAt,
 	)
@@ -87,11 +87,11 @@ func (s *Store) ChannelsCreate(ctx context.Context, row store.ChannelRow) error 
 	_, err := s.pool.Exec(ctx, `
 		INSERT INTO channels (
 			name, description, scope, semantic,
-			default_ttl, max_messages, publisher, period, created_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+			default_ttl, max_messages, publisher, period, created_at, tenant_id
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 	`,
 		row.Name, row.Description, row.Scope, row.Semantic,
-		row.DefaultTTL, row.MaxMessages, row.Publisher, row.Period, createdAt,
+		row.DefaultTTL, row.MaxMessages, row.Publisher, row.Period, createdAt, row.TenantID,
 	)
 	if err != nil {
 		var pgErr *pgconn.PgError
@@ -107,7 +107,7 @@ func (s *Store) ChannelsCreate(ctx context.Context, row store.ChannelRow) error 
 // pointers in `patch` leave the corresponding field unchanged.
 // Returns *store.ErrNotFound{Kind:"channel"} when the name isn't in
 // the runtime table.
-func (s *Store) ChannelsUpdate(ctx context.Context, name string, patch store.ChannelPatch) error {
+func (s *Store) ChannelsUpdate(ctx context.Context, tenantID, name string, patch store.ChannelPatch) error {
 	sets := []string{}
 	args := []any{}
 	idx := 1
@@ -134,7 +134,7 @@ func (s *Store) ChannelsUpdate(ctx context.Context, name string, patch store.Cha
 	if len(sets) == 0 {
 		// Nothing to update — verify existence and return.
 		var one int
-		if err := s.pool.QueryRow(ctx, `SELECT 1 FROM channels WHERE name = $1`, name).Scan(&one); err != nil {
+		if err := s.pool.QueryRow(ctx, `SELECT 1 FROM channels WHERE tenant_id = $1 AND name = $2`, tenantID, name).Scan(&one); err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				return &store.ErrNotFound{Kind: "channel", ID: name}
 			}
@@ -142,9 +142,9 @@ func (s *Store) ChannelsUpdate(ctx context.Context, name string, patch store.Cha
 		}
 		return nil
 	}
-	args = append(args, name)
+	args = append(args, tenantID, name)
 	tag, err := s.pool.Exec(ctx,
-		`UPDATE channels SET `+strings.Join(sets, ", ")+fmt.Sprintf(` WHERE name = $%d`, idx),
+		`UPDATE channels SET `+strings.Join(sets, ", ")+fmt.Sprintf(` WHERE tenant_id = $%d AND name = $%d`, idx, idx+1),
 		args...,
 	)
 	if err != nil {
@@ -160,24 +160,33 @@ func (s *Store) ChannelsUpdate(ctx context.Context, name string, patch store.Cha
 // its persisted messages + cursors in one transaction. Returns
 // *store.ErrNotFound{Kind:"channel"} when the name isn't in the
 // runtime table.
-func (s *Store) ChannelsDelete(ctx context.Context, name string) error {
+func (s *Store) ChannelsDelete(ctx context.Context, tenantID, name string) error {
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("channels delete begin tx: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	tag, err := tx.Exec(ctx, `DELETE FROM channels WHERE name = $1`, name)
-	if err != nil {
+	// Read the def's scope first: the cascade must delete messages/cursors
+	// from the keyspace they actually live in — global => tenant_id="",
+	// every other scope => this tenant (store.ChannelScopeTenant).
+	var scope string
+	if err := tx.QueryRow(ctx, `SELECT scope FROM channels WHERE tenant_id = $1 AND name = $2`, tenantID, name).Scan(&scope); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return &store.ErrNotFound{Kind: "channel", ID: name}
+		}
+		return fmt.Errorf("channels delete scope lookup: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM channels WHERE tenant_id = $1 AND name = $2`, tenantID, name); err != nil {
 		return fmt.Errorf("channels delete: %w", err)
 	}
-	if tag.RowsAffected() == 0 {
-		return &store.ErrNotFound{Kind: "channel", ID: name}
-	}
-	if _, err := tx.Exec(ctx, `DELETE FROM channel_messages WHERE channel = $1`, name); err != nil {
+	// Cascade scoped by the message keyspace's tenant so deleting one
+	// tenant's channel never touches another tenant's same-named channel.
+	msgTenant := store.ChannelScopeTenant(tenantID, store.MemoryScope(scope))
+	if _, err := tx.Exec(ctx, `DELETE FROM channel_messages WHERE tenant_id = $1 AND channel = $2`, msgTenant, name); err != nil {
 		return fmt.Errorf("channels delete messages cascade: %w", err)
 	}
-	if _, err := tx.Exec(ctx, `DELETE FROM channel_cursors WHERE channel = $1`, name); err != nil {
+	if _, err := tx.Exec(ctx, `DELETE FROM channel_cursors WHERE tenant_id = $1 AND channel = $2`, msgTenant, name); err != nil {
 		return fmt.Errorf("channels delete cursors cascade: %w", err)
 	}
 	if err := tx.Commit(ctx); err != nil {
@@ -189,8 +198,8 @@ func (s *Store) ChannelsDelete(ctx context.Context, name string) error {
 // ChannelPurge deletes every channel_messages row for `name` and
 // returns the count. Leaves the channels row + channel_cursors intact
 // — see store.Store.ChannelPurge. One DELETE; no transaction needed.
-func (s *Store) ChannelPurge(ctx context.Context, name string) (int, error) {
-	tag, err := s.pool.Exec(ctx, `DELETE FROM channel_messages WHERE channel = $1`, name)
+func (s *Store) ChannelPurge(ctx context.Context, tenantID, name string) (int, error) {
+	tag, err := s.pool.Exec(ctx, `DELETE FROM channel_messages WHERE tenant_id = $1 AND channel = $2`, tenantID, name)
 	if err != nil {
 		return 0, fmt.Errorf("channel purge: %w", err)
 	}

--- a/internal/store/postgres/migrations/0066_channels_tenant_id.down.sql
+++ b/internal/store/postgres/migrations/0066_channels_tenant_id.down.sql
@@ -1,0 +1,22 @@
+-- 0066_channels_tenant_id.down.sql — reverse the channel tenant axis.
+--
+-- SAFE ONLY while every row is tenant_id='' (a single-tenant deployment, or
+-- one that never wrote a non-'' tenant). If real per-tenant rows exist,
+-- restoring the tenant-blind (channel, scope, scope_id[, id]) / (name) PKs
+-- would collide across tenants and the migration would fail — the operator
+-- must consolidate to one tenant first. Mirrors the 0037/0059 down caveat.
+
+ALTER TABLE channels DROP CONSTRAINT channels_pkey;
+ALTER TABLE channels ADD PRIMARY KEY (name);
+ALTER TABLE channels DROP COLUMN tenant_id;
+
+ALTER TABLE channel_cursors DROP CONSTRAINT channel_cursors_pkey;
+ALTER TABLE channel_cursors ADD PRIMARY KEY (channel, scope, scope_id);
+ALTER TABLE channel_cursors DROP COLUMN tenant_id;
+
+DROP INDEX IF EXISTS channel_messages_by_visible;
+ALTER TABLE channel_messages DROP CONSTRAINT channel_messages_pkey;
+ALTER TABLE channel_messages ADD PRIMARY KEY (channel, scope, scope_id, id);
+ALTER TABLE channel_messages DROP COLUMN tenant_id;
+CREATE INDEX channel_messages_by_visible
+    ON channel_messages(channel, scope, scope_id, visible_at, id);

--- a/internal/store/postgres/migrations/0066_channels_tenant_id.up.sql
+++ b/internal/store/postgres/migrations/0066_channels_tenant_id.up.sql
@@ -22,8 +22,15 @@
 
 -- channel_messages: the tenant axis, leading the PK so per-subscriber range
 -- scans stay index lookups within a tenant.
-ALTER TABLE channel_messages ADD COLUMN tenant_id TEXT NOT NULL DEFAULT '';
-ALTER TABLE channel_messages DROP CONSTRAINT channel_messages_pkey;
+--
+-- IF NOT EXISTS / IF EXISTS make this migration re-runnable over an
+-- already-migrated DB: the migration test suite rewinds the version pointer
+-- (forceMigrationVersion) and re-applies every migration above 61, so each
+-- must no-op cleanly on a second pass (mirrors 0063's ADD COLUMN IF NOT
+-- EXISTS). The DROP-then-ADD-PRIMARY-KEY pair is idempotent because the
+-- guarded DROP always clears the current pkey first.
+ALTER TABLE channel_messages ADD COLUMN IF NOT EXISTS tenant_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE channel_messages DROP CONSTRAINT IF EXISTS channel_messages_pkey;
 ALTER TABLE channel_messages ADD PRIMARY KEY (tenant_id, channel, scope, scope_id, id);
 
 -- The visible-order read index must lead with tenant_id to match the
@@ -34,12 +41,12 @@ CREATE INDEX channel_messages_by_visible
     ON channel_messages(tenant_id, channel, scope, scope_id, visible_at, id);
 
 -- channel_cursors: the per-subscriber committed read position, tenant-keyed.
-ALTER TABLE channel_cursors ADD COLUMN tenant_id TEXT NOT NULL DEFAULT '';
-ALTER TABLE channel_cursors DROP CONSTRAINT channel_cursors_pkey;
+ALTER TABLE channel_cursors ADD COLUMN IF NOT EXISTS tenant_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE channel_cursors DROP CONSTRAINT IF EXISTS channel_cursors_pkey;
 ALTER TABLE channel_cursors ADD PRIMARY KEY (tenant_id, channel, scope, scope_id);
 
 -- channels: the runtime-declared def table. (tenant_id, name) so two tenants
 -- can each own a same-named channel and ChannelGet is tenant-confinable.
-ALTER TABLE channels ADD COLUMN tenant_id TEXT NOT NULL DEFAULT '';
-ALTER TABLE channels DROP CONSTRAINT channels_pkey;
+ALTER TABLE channels ADD COLUMN IF NOT EXISTS tenant_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE channels DROP CONSTRAINT IF EXISTS channels_pkey;
 ALTER TABLE channels ADD PRIMARY KEY (tenant_id, name);

--- a/internal/store/postgres/migrations/0066_channels_tenant_id.up.sql
+++ b/internal/store/postgres/migrations/0066_channels_tenant_id.up.sql
@@ -1,0 +1,45 @@
+-- 0066_channels_tenant_id.up.sql — tenant-scope the Channel primitive
+-- (the message log, the per-subscriber cursors, and the runtime-declared
+-- channel definitions).
+--
+-- RFC L isolated runs/sessions; RFC N isolated the definition plane; 0059
+-- isolated the base Memory store. Channels stayed tenant-blind: the message
+-- + cursor tables key on (channel, scope, scope_id) with no tenant axis, and
+-- the `channels` def table keys on a bare `name`. An agent scope_id is the
+-- bare agent name, so two tenants running a same-named agent collided on one
+-- global (channel, scope, scope_id) keyspace, and two tenants could not each
+-- own a channel of the same name. This migration adds the tenant axis so the
+-- routes can move off the substrate:admin catch-all onto substrate:tenant.
+--
+-- '' = the shared/operator/legacy tenant. Existing rows backfill to '' via
+-- the column DEFAULT, so a single-tenant deployment reads exactly as before
+-- (it IS entirely '') — no separate UPDATE needed.
+--
+-- Unlike 0059 (Memory), the channel tables carry NO foreign keys between
+-- channel_messages/channel_cursors and the `channels` def table (the cascade
+-- is application code — see ChannelsDelete), so there is no FK-lockstep
+-- dance: each table's PK swaps independently.
+
+-- channel_messages: the tenant axis, leading the PK so per-subscriber range
+-- scans stay index lookups within a tenant.
+ALTER TABLE channel_messages ADD COLUMN tenant_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE channel_messages DROP CONSTRAINT channel_messages_pkey;
+ALTER TABLE channel_messages ADD PRIMARY KEY (tenant_id, channel, scope, scope_id, id);
+
+-- The visible-order read index must lead with tenant_id to match the
+-- tenant-qualified WHERE clause; the expires_at partial sweeper index is
+-- tenant-agnostic (it deletes across all tenants) and stays as-is.
+DROP INDEX IF EXISTS channel_messages_by_visible;
+CREATE INDEX channel_messages_by_visible
+    ON channel_messages(tenant_id, channel, scope, scope_id, visible_at, id);
+
+-- channel_cursors: the per-subscriber committed read position, tenant-keyed.
+ALTER TABLE channel_cursors ADD COLUMN tenant_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE channel_cursors DROP CONSTRAINT channel_cursors_pkey;
+ALTER TABLE channel_cursors ADD PRIMARY KEY (tenant_id, channel, scope, scope_id);
+
+-- channels: the runtime-declared def table. (tenant_id, name) so two tenants
+-- can each own a same-named channel and ChannelGet is tenant-confinable.
+ALTER TABLE channels ADD COLUMN tenant_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE channels DROP CONSTRAINT channels_pkey;
+ALTER TABLE channels ADD PRIMARY KEY (tenant_id, name);

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -2371,10 +2371,10 @@ func (s *Store) SnapshotReadMemory(ctx context.Context) ([]store.MemorySnapshotE
 func (s *Store) SnapshotReadChannelMessages(ctx context.Context) ([]store.ChannelMessage, error) {
 	now := time.Now().UTC()
 	rows, err := s.pool.Query(ctx,
-		`SELECT id, channel, scope, scope_id, payload::text, published_at, expires_at, visible_at, published_by_user_id
+		`SELECT id, channel, tenant_id, scope, scope_id, payload::text, published_at, expires_at, visible_at, published_by_user_id
 		 FROM channel_messages
 		 WHERE expires_at IS NULL OR expires_at > $1
-		 ORDER BY channel ASC, scope ASC, scope_id ASC, visible_at ASC, id ASC`, now)
+		 ORDER BY tenant_id ASC, channel ASC, scope ASC, scope_id ASC, visible_at ASC, id ASC`, now)
 	if err != nil {
 		return nil, fmt.Errorf("snapshot read channel_messages: %w", err)
 	}
@@ -2389,7 +2389,7 @@ func (s *Store) SnapshotReadChannelMessages(ctx context.Context) ([]store.Channe
 			visibleAt   *time.Time
 			publishedBy *string
 		)
-		if err := rows.Scan(&m.ID, &m.Channel, &scopeStr, &m.ScopeID, &payload, &m.PublishedAt, &expiresAt, &visibleAt, &publishedBy); err != nil {
+		if err := rows.Scan(&m.ID, &m.Channel, &m.TenantID, &scopeStr, &m.ScopeID, &payload, &m.PublishedAt, &expiresAt, &visibleAt, &publishedBy); err != nil {
 			return nil, fmt.Errorf("scan channel_message: %w", err)
 		}
 		m.Scope = store.MemoryScope(scopeStr)
@@ -2411,9 +2411,9 @@ func (s *Store) SnapshotReadChannelMessages(ctx context.Context) ([]store.Channe
 // SnapshotReadChannelCursors implements store.Store.
 func (s *Store) SnapshotReadChannelCursors(ctx context.Context) ([]store.ChannelCursorEntry, error) {
 	rows, err := s.pool.Query(ctx,
-		`SELECT channel, scope, scope_id, cursor, updated_at
+		`SELECT channel, tenant_id, scope, scope_id, cursor, updated_at
 		 FROM channel_cursors
-		 ORDER BY channel ASC, scope ASC, scope_id ASC`)
+		 ORDER BY tenant_id ASC, channel ASC, scope ASC, scope_id ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("snapshot read channel_cursors: %w", err)
 	}
@@ -2424,7 +2424,7 @@ func (s *Store) SnapshotReadChannelCursors(ctx context.Context) ([]store.Channel
 			c        store.ChannelCursorEntry
 			scopeStr string
 		)
-		if err := rows.Scan(&c.Channel, &scopeStr, &c.ScopeID, &c.Cursor, &c.UpdatedAt); err != nil {
+		if err := rows.Scan(&c.Channel, &c.TenantID, &scopeStr, &c.ScopeID, &c.Cursor, &c.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan channel_cursor: %w", err)
 		}
 		c.Scope = store.MemoryScope(scopeStr)
@@ -2850,11 +2850,11 @@ func (s *Store) SnapshotRestoreChannelMessage(ctx context.Context, m store.Chann
 		visibleAt = publishedAt
 	}
 	tag, err := s.pool.Exec(ctx,
-		`INSERT INTO channel_messages(id, channel, scope, scope_id, payload, published_at, expires_at, visible_at, published_by_user_id)
-		 VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9)
-		 ON CONFLICT (id) DO NOTHING`,
+		`INSERT INTO channel_messages(id, channel, scope, scope_id, payload, published_at, expires_at, visible_at, published_by_user_id, tenant_id)
+		 VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10)
+		 ON CONFLICT (tenant_id, channel, scope, scope_id, id) DO NOTHING`,
 		m.ID, m.Channel, string(m.Scope), m.ScopeID, string(m.Payload),
-		publishedAt, expiresAt, visibleAt, nullIfEmpty(m.PublishedByUserID),
+		publishedAt, expiresAt, visibleAt, nullIfEmpty(m.PublishedByUserID), m.TenantID,
 	)
 	if err != nil {
 		return false, fmt.Errorf("snapshot restore channel_message: %w", err)
@@ -2875,9 +2875,9 @@ func (s *Store) SnapshotRestoreChannelCursor(ctx context.Context, c store.Channe
 		updatedAt = time.Now().UTC()
 	}
 	tag, err := s.pool.Exec(ctx,
-		`INSERT INTO channel_cursors(channel, scope, scope_id, cursor, updated_at) VALUES ($1, $2, $3, $4, $5)
-		 ON CONFLICT (channel, scope, scope_id) DO NOTHING`,
-		c.Channel, string(c.Scope), c.ScopeID, c.Cursor, updatedAt,
+		`INSERT INTO channel_cursors(channel, scope, scope_id, cursor, updated_at, tenant_id) VALUES ($1, $2, $3, $4, $5, $6)
+		 ON CONFLICT (tenant_id, channel, scope, scope_id) DO NOTHING`,
+		c.Channel, string(c.Scope), c.ScopeID, c.Cursor, updatedAt, c.TenantID,
 	)
 	if err != nil {
 		return false, fmt.Errorf("snapshot restore channel_cursor: %w", err)
@@ -4562,6 +4562,7 @@ func (s *Store) MemoryCursorRelease(ctx context.Context, tenantID string, scope 
 // Go-side comparison would need a client-clock `now` to compare against
 // and would reintroduce the straddle it is meant to remove.
 func (s *Store) ChannelPublish(ctx context.Context, msg store.ChannelMessage, maxMessages int) (string, int, error) {
+	msg.TenantID = store.ChannelScopeTenant(msg.TenantID, msg.Scope) // global => "" (cross-tenant keyspace)
 	now := s.now().UTC()
 	msg.ID = store.MintChannelMessageID(now)
 	msg.PublishedAt = now
@@ -4599,10 +4600,10 @@ func (s *Store) ChannelPublish(ctx context.Context, msg store.ChannelMessage, ma
 	defer func() { _ = tx.Rollback(ctx) }()
 
 	if _, err := tx.Exec(ctx,
-		`INSERT INTO channel_messages (id, channel, scope, scope_id, payload, published_at, expires_at, visible_at, published_by_user_id)
-		 VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, GREATEST(NOW(), COALESCE($8::timestamptz, NOW())), $9)`,
+		`INSERT INTO channel_messages (id, channel, scope, scope_id, payload, published_at, expires_at, visible_at, published_by_user_id, tenant_id)
+		 VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, GREATEST(NOW(), COALESCE($8::timestamptz, NOW())), $9, $10)`,
 		msg.ID, msg.Channel, string(msg.Scope), msg.ScopeID, string(msg.Payload),
-		now, expiresAt, visibleAt, publishedByUserID,
+		now, expiresAt, visibleAt, publishedByUserID, msg.TenantID,
 	); err != nil {
 		return "", 0, fmt.Errorf("channel publish insert: %w", err)
 	}
@@ -4633,15 +4634,15 @@ func (s *Store) ChannelPublish(ctx context.Context, msg store.ChannelMessage, ma
 		// drop the deferred row before it became deliverable.
 		tag, err := tx.Exec(ctx,
 			`DELETE FROM channel_messages
-			 WHERE channel = $1 AND scope = $2 AND scope_id = $3
+			 WHERE tenant_id = $6 AND channel = $1 AND scope = $2 AND scope_id = $3
 			   AND id != $5
 			   AND id NOT IN (
 			     SELECT id FROM channel_messages
-			      WHERE channel = $1 AND scope = $2 AND scope_id = $3
+			      WHERE tenant_id = $6 AND channel = $1 AND scope = $2 AND scope_id = $3
 			      ORDER BY visible_at DESC, id DESC
 			      LIMIT $4
 			   )`,
-			msg.Channel, string(msg.Scope), msg.ScopeID, maxMessages, msg.ID,
+			msg.Channel, string(msg.Scope), msg.ScopeID, maxMessages, msg.ID, msg.TenantID,
 		)
 		if err != nil {
 			return "", 0, fmt.Errorf("channel publish trim: %w", err)
@@ -4671,25 +4672,25 @@ func (s *Store) ChannelPublish(ctx context.Context, msg store.ChannelMessage, ma
 
 // ChannelSubscribe reads up to `limit` messages newer than fromCursor.
 // fromCursor == "" || "cur_0" → from the oldest non-expired row.
-func (s *Store) ChannelSubscribe(ctx context.Context, channel string, scope store.MemoryScope, scopeID, fromCursor string, limit int) ([]store.ChannelMessage, string, error) {
-	return s.channelRead(ctx, channel, scope, scopeID, fromCursor, limit)
+func (s *Store) ChannelSubscribe(ctx context.Context, tenantID, channel string, scope store.MemoryScope, scopeID, fromCursor string, limit int) ([]store.ChannelMessage, string, error) {
+	return s.channelRead(ctx, tenantID, channel, scope, scopeID, fromCursor, limit)
 }
 
 // ChannelPeek is identical to Subscribe at the storage layer — the
 // difference is purely semantic (whether the tool layer commits the
 // returned cursor on the next call).
-func (s *Store) ChannelPeek(ctx context.Context, channel string, scope store.MemoryScope, scopeID, fromCursor string, limit int) ([]store.ChannelMessage, error) {
-	msgs, _, err := s.channelRead(ctx, channel, scope, scopeID, fromCursor, limit)
+func (s *Store) ChannelPeek(ctx context.Context, tenantID, channel string, scope store.MemoryScope, scopeID, fromCursor string, limit int) ([]store.ChannelMessage, error) {
+	msgs, _, err := s.channelRead(ctx, tenantID, channel, scope, scopeID, fromCursor, limit)
 	return msgs, err
 }
 
 func (s *Store) ChannelStats(ctx context.Context) ([]store.ChannelStats, error) {
 	rows, err := s.pool.Query(ctx, `
-		SELECT channel, COUNT(*), MIN(visible_at), MAX(visible_at)
+		SELECT tenant_id, channel, COUNT(*), MIN(visible_at), MAX(visible_at)
 		FROM channel_messages
 		WHERE (expires_at IS NULL OR expires_at > NOW())
-		GROUP BY channel
-		ORDER BY channel`)
+		GROUP BY tenant_id, channel
+		ORDER BY tenant_id, channel`)
 	if err != nil {
 		return nil, fmt.Errorf("channel stats query: %w", err)
 	}
@@ -4698,14 +4699,15 @@ func (s *Store) ChannelStats(ctx context.Context) ([]store.ChannelStats, error) 
 	var out []store.ChannelStats
 	for rows.Next() {
 		var (
+			tenantID       string
 			name           string
 			count          int64
 			oldest, newest *time.Time
 		)
-		if err := rows.Scan(&name, &count, &oldest, &newest); err != nil {
+		if err := rows.Scan(&tenantID, &name, &count, &oldest, &newest); err != nil {
 			return nil, fmt.Errorf("channel stats scan: %w", err)
 		}
-		st := store.ChannelStats{Channel: name, MessageCount: count}
+		st := store.ChannelStats{Channel: name, TenantID: tenantID, MessageCount: count}
 		if oldest != nil {
 			st.OldestVisibleAt = oldest.UTC()
 		}
@@ -4837,7 +4839,8 @@ func (s *Store) backfillContentSHA256(ctx context.Context, table string, signFn 
 // disagree about whether the same message is visible; the database is
 // the one clock every replica already shares. See ChannelPublish for the
 // write half.
-func (s *Store) channelRead(ctx context.Context, channel string, scope store.MemoryScope, scopeID, fromCursor string, limit int) ([]store.ChannelMessage, string, error) {
+func (s *Store) channelRead(ctx context.Context, tenantID, channel string, scope store.MemoryScope, scopeID, fromCursor string, limit int) ([]store.ChannelMessage, string, error) {
+	tenantID = store.ChannelScopeTenant(tenantID, scope) // global => "" (cross-tenant keyspace)
 	if limit <= 0 {
 		limit = 10
 	}
@@ -4857,24 +4860,24 @@ func (s *Store) channelRead(ctx context.Context, channel string, scope store.Mem
 			rows, qErr = s.pool.Query(ctx,
 				`SELECT id, payload::text, published_at, expires_at, visible_at, published_by_user_id
 				 FROM channel_messages
-				 WHERE channel = $1 AND scope = $2 AND scope_id = $3
+				 WHERE tenant_id = $5 AND channel = $1 AND scope = $2 AND scope_id = $3
 				   AND visible_at <= NOW()
 				   AND (expires_at IS NULL OR expires_at > NOW())
 				 ORDER BY visible_at ASC, id ASC
 				 LIMIT $4`,
-				channel, string(scope), scopeID, limit)
+				channel, string(scope), scopeID, limit, tenantID)
 		} else {
 			rows, qErr = s.pool.Query(ctx,
 				`SELECT id, payload::text, published_at, expires_at, visible_at, published_by_user_id
 				 FROM channel_messages
-				 WHERE channel = $1 AND scope = $2 AND scope_id = $3
+				 WHERE tenant_id = $7 AND channel = $1 AND scope = $2 AND scope_id = $3
 				   AND visible_at <= NOW()
 				   AND (expires_at IS NULL OR expires_at > NOW())
 				   AND (visible_at > $4 OR (visible_at = $4 AND id > $5))
 				 ORDER BY visible_at ASC, id ASC
 				 LIMIT $6`,
 				channel, string(scope), scopeID,
-				cursorVisibleAt.UTC(), cursorMsgID, limit)
+				cursorVisibleAt.UTC(), cursorMsgID, limit, tenantID)
 		}
 		return qErr
 	}); err != nil {
@@ -4900,6 +4903,7 @@ func (s *Store) channelRead(ctx context.Context, channel string, scope store.Mem
 		msg := store.ChannelMessage{
 			ID:          id,
 			Channel:     channel,
+			TenantID:    tenantID,
 			Scope:       scope,
 			ScopeID:     scopeID,
 			Payload:     json.RawMessage(payloadText),
@@ -4930,7 +4934,8 @@ func (s *Store) channelRead(ctx context.Context, channel string, scope store.Mem
 // cursor values older than the currently committed one (lexicographic
 // order matches tuple order because the v0.8.6 cursor format encodes
 // visible_at as a fixed-width hex prefix). Idempotent on re-ack.
-func (s *Store) ChannelAck(ctx context.Context, channel string, scope store.MemoryScope, scopeID, cursor string) error {
+func (s *Store) ChannelAck(ctx context.Context, tenantID, channel string, scope store.MemoryScope, scopeID, cursor string) error {
+	tenantID = store.ChannelScopeTenant(tenantID, scope) // global => "" (cross-tenant keyspace)
 	if cursor == "" || cursor == "cur_0" {
 		return nil
 	}
@@ -4947,8 +4952,8 @@ func (s *Store) ChannelAck(ctx context.Context, channel string, scope store.Memo
 
 	var existing string
 	err = tx.QueryRow(ctx,
-		`SELECT cursor FROM channel_cursors WHERE channel = $1 AND scope = $2 AND scope_id = $3`,
-		channel, string(scope), scopeID,
+		`SELECT cursor FROM channel_cursors WHERE tenant_id = $4 AND channel = $1 AND scope = $2 AND scope_id = $3`,
+		channel, string(scope), scopeID, tenantID,
 	).Scan(&existing)
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		return fmt.Errorf("channel ack lookup: %w", err)
@@ -4962,12 +4967,12 @@ func (s *Store) ChannelAck(ctx context.Context, channel string, scope store.Memo
 
 	now := time.Now().UTC()
 	if _, err := tx.Exec(ctx,
-		`INSERT INTO channel_cursors (channel, scope, scope_id, cursor, updated_at)
-		 VALUES ($1, $2, $3, $4, $5)
-		 ON CONFLICT (channel, scope, scope_id) DO UPDATE SET
+		`INSERT INTO channel_cursors (channel, scope, scope_id, cursor, updated_at, tenant_id)
+		 VALUES ($1, $2, $3, $4, $5, $6)
+		 ON CONFLICT (tenant_id, channel, scope, scope_id) DO UPDATE SET
 		    cursor = EXCLUDED.cursor,
 		    updated_at = EXCLUDED.updated_at`,
-		channel, string(scope), scopeID, cursor, now,
+		channel, string(scope), scopeID, cursor, now, tenantID,
 	); err != nil {
 		return fmt.Errorf("channel ack upsert: %w", err)
 	}
@@ -4975,11 +4980,12 @@ func (s *Store) ChannelAck(ctx context.Context, channel string, scope store.Memo
 }
 
 // ChannelCommittedCursor returns the most recent ack'd cursor, or "".
-func (s *Store) ChannelCommittedCursor(ctx context.Context, channel string, scope store.MemoryScope, scopeID string) (string, error) {
+func (s *Store) ChannelCommittedCursor(ctx context.Context, tenantID, channel string, scope store.MemoryScope, scopeID string) (string, error) {
+	tenantID = store.ChannelScopeTenant(tenantID, scope) // global => "" (cross-tenant keyspace)
 	var cursor string
 	err := s.pool.QueryRow(ctx,
-		`SELECT cursor FROM channel_cursors WHERE channel = $1 AND scope = $2 AND scope_id = $3`,
-		channel, string(scope), scopeID,
+		`SELECT cursor FROM channel_cursors WHERE tenant_id = $4 AND channel = $1 AND scope = $2 AND scope_id = $3`,
+		channel, string(scope), scopeID, tenantID,
 	).Scan(&cursor)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return "", nil
@@ -4991,13 +4997,14 @@ func (s *Store) ChannelCommittedCursor(ctx context.Context, channel string, scop
 }
 
 // ChannelListCursorsForScope — see store.Store doc. v0.9.x introspection.
-func (s *Store) ChannelListCursorsForScope(ctx context.Context, scope store.MemoryScope, scopeID string) ([]store.ChannelCursorEntry, error) {
+func (s *Store) ChannelListCursorsForScope(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID string) ([]store.ChannelCursorEntry, error) {
+	tenantID = store.ChannelScopeTenant(tenantID, scope) // global => "" (cross-tenant keyspace)
 	rows, err := s.pool.Query(ctx,
 		`SELECT channel, scope, scope_id, cursor, updated_at
 		 FROM channel_cursors
-		 WHERE scope = $1 AND scope_id = $2
+		 WHERE tenant_id = $3 AND scope = $1 AND scope_id = $2
 		 ORDER BY channel ASC`,
-		string(scope), scopeID,
+		string(scope), scopeID, tenantID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("list channel cursors: %w", err)

--- a/internal/store/sqlite/channels.go
+++ b/internal/store/sqlite/channels.go
@@ -19,10 +19,10 @@ import (
 // name. Empty slice when no runtime channels exist (vs nil on error).
 func (s *Store) ChannelsList(ctx context.Context) ([]store.ChannelRow, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT name, description, scope, semantic,
+		SELECT name, tenant_id, description, scope, semantic,
 		       default_ttl, max_messages, publisher, period, created_at
 		FROM channels
-		ORDER BY name
+		ORDER BY tenant_id, name
 	`)
 	if err != nil {
 		return nil, fmt.Errorf("channels list: %w", err)
@@ -33,7 +33,7 @@ func (s *Store) ChannelsList(ctx context.Context) ([]store.ChannelRow, error) {
 		var r store.ChannelRow
 		var createdNano int64
 		if err := rows.Scan(
-			&r.Name, &r.Description, &r.Scope, &r.Semantic,
+			&r.Name, &r.TenantID, &r.Description, &r.Scope, &r.Semantic,
 			&r.DefaultTTL, &r.MaxMessages, &r.Publisher, &r.Period,
 			&createdNano,
 		); err != nil {
@@ -50,16 +50,16 @@ func (s *Store) ChannelsList(ctx context.Context) ([]store.ChannelRow, error) {
 // (exp7 I5: a point lookup for the hot declared-check, so a real query
 // fault surfaces as an error instead of an empty scan masquerading as
 // "not declared").
-func (s *Store) ChannelGet(ctx context.Context, name string) (store.ChannelRow, error) {
+func (s *Store) ChannelGet(ctx context.Context, tenantID, name string) (store.ChannelRow, error) {
 	var r store.ChannelRow
 	var createdNano int64
 	err := s.db.QueryRowContext(ctx, `
-		SELECT name, description, scope, semantic,
+		SELECT name, tenant_id, description, scope, semantic,
 		       default_ttl, max_messages, publisher, period, created_at
 		FROM channels
-		WHERE name = ?
-	`, name).Scan(
-		&r.Name, &r.Description, &r.Scope, &r.Semantic,
+		WHERE tenant_id = ? AND name = ?
+	`, tenantID, name).Scan(
+		&r.Name, &r.TenantID, &r.Description, &r.Scope, &r.Semantic,
 		&r.DefaultTTL, &r.MaxMessages, &r.Publisher, &r.Period,
 		&createdNano,
 	)
@@ -84,12 +84,12 @@ func (s *Store) ChannelsCreate(ctx context.Context, row store.ChannelRow) error 
 	_, err := s.db.ExecContext(ctx, `
 		INSERT INTO channels (
 			name, description, scope, semantic,
-			default_ttl, max_messages, publisher, period, created_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+			default_ttl, max_messages, publisher, period, created_at, tenant_id
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		row.Name, row.Description, row.Scope, row.Semantic,
 		row.DefaultTTL, row.MaxMessages, row.Publisher, row.Period,
-		row.CreatedAt.UnixNano(),
+		row.CreatedAt.UnixNano(), row.TenantID,
 	)
 	if err != nil {
 		// modernc.org/sqlite surfaces UNIQUE-constraint failures
@@ -107,7 +107,7 @@ func (s *Store) ChannelsCreate(ctx context.Context, row store.ChannelRow) error 
 // pointers in `patch` leave the corresponding field unchanged.
 // Returns *store.ErrNotFound{Kind:"channel"} when the name isn't in
 // the runtime table.
-func (s *Store) ChannelsUpdate(ctx context.Context, name string, patch store.ChannelPatch) error {
+func (s *Store) ChannelsUpdate(ctx context.Context, tenantID, name string, patch store.ChannelPatch) error {
 	// Build the SET clause dynamically — sqlite doesn't have COALESCE
 	// + named-params ergonomics for partial updates, so we just
 	// stitch the patch.
@@ -132,7 +132,7 @@ func (s *Store) ChannelsUpdate(ctx context.Context, name string, patch store.Cha
 	if len(sets) == 0 {
 		// Nothing to update — verify existence and return.
 		var one int
-		if err := s.db.QueryRowContext(ctx, `SELECT 1 FROM channels WHERE name = ?`, name).Scan(&one); err != nil {
+		if err := s.db.QueryRowContext(ctx, `SELECT 1 FROM channels WHERE tenant_id = ? AND name = ?`, tenantID, name).Scan(&one); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				return &store.ErrNotFound{Kind: "channel", ID: name}
 			}
@@ -140,9 +140,9 @@ func (s *Store) ChannelsUpdate(ctx context.Context, name string, patch store.Cha
 		}
 		return nil
 	}
-	args = append(args, name)
+	args = append(args, tenantID, name)
 	res, err := s.db.ExecContext(ctx,
-		`UPDATE channels SET `+strings.Join(sets, ", ")+` WHERE name = ?`,
+		`UPDATE channels SET `+strings.Join(sets, ", ")+` WHERE tenant_id = ? AND name = ?`,
 		args...,
 	)
 	if err != nil {
@@ -164,28 +164,33 @@ func (s *Store) ChannelsUpdate(ctx context.Context, name string, patch store.Cha
 // application code — one transaction). Returns
 // *store.ErrNotFound{Kind:"channel"} when the name isn't in the
 // runtime table.
-func (s *Store) ChannelsDelete(ctx context.Context, name string) error {
+func (s *Store) ChannelsDelete(ctx context.Context, tenantID, name string) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("channels delete begin tx: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	res, err := tx.ExecContext(ctx, `DELETE FROM channels WHERE name = ?`, name)
-	if err != nil {
+	// Read the def's scope first: the cascade must delete messages/cursors
+	// from the keyspace they actually live in — global => tenant_id="",
+	// every other scope => this tenant (store.ChannelScopeTenant).
+	var scope string
+	if err := tx.QueryRowContext(ctx, `SELECT scope FROM channels WHERE tenant_id = ? AND name = ?`, tenantID, name).Scan(&scope); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return &store.ErrNotFound{Kind: "channel", ID: name}
+		}
+		return fmt.Errorf("channels delete scope lookup: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM channels WHERE tenant_id = ? AND name = ?`, tenantID, name); err != nil {
 		return fmt.Errorf("channels delete: %w", err)
 	}
-	n, err := res.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("channels delete rows-affected: %w", err)
-	}
-	if n == 0 {
-		return &store.ErrNotFound{Kind: "channel", ID: name}
-	}
-	if _, err := tx.ExecContext(ctx, `DELETE FROM channel_messages WHERE channel = ?`, name); err != nil {
+	// Cascade scoped by the message keyspace's tenant so deleting one
+	// tenant's channel never touches another tenant's same-named channel.
+	msgTenant := store.ChannelScopeTenant(tenantID, store.MemoryScope(scope))
+	if _, err := tx.ExecContext(ctx, `DELETE FROM channel_messages WHERE tenant_id = ? AND channel = ?`, msgTenant, name); err != nil {
 		return fmt.Errorf("channels delete messages cascade: %w", err)
 	}
-	if _, err := tx.ExecContext(ctx, `DELETE FROM channel_cursors WHERE channel = ?`, name); err != nil {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM channel_cursors WHERE tenant_id = ? AND channel = ?`, msgTenant, name); err != nil {
 		return fmt.Errorf("channels delete cursors cascade: %w", err)
 	}
 	if err := tx.Commit(); err != nil {
@@ -197,8 +202,8 @@ func (s *Store) ChannelsDelete(ctx context.Context, name string) error {
 // ChannelPurge deletes every channel_messages row for `name` and
 // returns the count. Leaves the channels row + channel_cursors intact
 // — see store.Store.ChannelPurge. One DELETE; no transaction needed.
-func (s *Store) ChannelPurge(ctx context.Context, name string) (int, error) {
-	res, err := s.db.ExecContext(ctx, `DELETE FROM channel_messages WHERE channel = ?`, name)
+func (s *Store) ChannelPurge(ctx context.Context, tenantID, name string) (int, error) {
+	res, err := s.db.ExecContext(ctx, `DELETE FROM channel_messages WHERE tenant_id = ? AND channel = ?`, tenantID, name)
 	if err != nil {
 		return 0, fmt.Errorf("channel purge: %w", err)
 	}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -307,6 +307,12 @@ func (s *Store) migrate(ctx context.Context) error {
 		// v0.8.6 system channels: visible_at + published_by_user_id columns
 		// land via the addColumns block below (idempotent ALTER pattern,
 		// works against both fresh + existing v0.8.4 schemas).
+		// tenant_id (leading the PK) isolates same-named agents/users
+		// across tenants — same rationale + SQLite upgrade caveat as the
+		// memory table above (fresh DB gets the tenant-leading PK; an
+		// UPGRADED DB keeps the old PK because SQLite can't rewrite it in
+		// place — byte-equivalent for single-tenant, Postgres for real
+		// multi-tenant isolation).
 		`CREATE TABLE IF NOT EXISTS channel_messages (
 			id                   TEXT    NOT NULL,
 			channel              TEXT    NOT NULL,
@@ -317,7 +323,8 @@ func (s *Store) migrate(ctx context.Context) error {
 			expires_at           INTEGER,
 			visible_at           INTEGER NOT NULL DEFAULT 0,
 			published_by_user_id TEXT,
-			PRIMARY KEY (channel, scope, scope_id, id)
+			tenant_id            TEXT    NOT NULL DEFAULT '',
+			PRIMARY KEY (tenant_id, channel, scope, scope_id, id)
 		)`,
 		`CREATE INDEX IF NOT EXISTS channel_messages_by_expires_at ON channel_messages(expires_at) WHERE expires_at IS NOT NULL`,
 		// NOTE: channel_messages_by_visible is created in `addIndexes`
@@ -334,7 +341,8 @@ func (s *Store) migrate(ctx context.Context) error {
 			scope_id   TEXT    NOT NULL,
 			cursor     TEXT    NOT NULL,
 			updated_at INTEGER NOT NULL,
-			PRIMARY KEY (channel, scope, scope_id)
+			tenant_id  TEXT    NOT NULL DEFAULT '',
+			PRIMARY KEY (tenant_id, channel, scope, scope_id)
 		)`,
 		// v0.11.5 runtime-declared channels. yaml-declared channels
 		// stay in cfg.Channels (in-memory only); this table holds
@@ -345,7 +353,7 @@ func (s *Store) migrate(ctx context.Context) error {
 		// here — yaml channels never had a parent row, so the table
 		// can't have a FK to itself).
 		`CREATE TABLE IF NOT EXISTS channels (
-			name         TEXT    PRIMARY KEY,
+			name         TEXT    NOT NULL,
 			description  TEXT    NOT NULL DEFAULT '',
 			scope        TEXT    NOT NULL,
 			semantic     TEXT    NOT NULL,
@@ -353,7 +361,9 @@ func (s *Store) migrate(ctx context.Context) error {
 			max_messages INTEGER NOT NULL DEFAULT 0,
 			publisher    TEXT    NOT NULL DEFAULT '',
 			period       TEXT    NOT NULL DEFAULT '',
-			created_at   INTEGER NOT NULL
+			created_at   INTEGER NOT NULL,
+			tenant_id    TEXT    NOT NULL DEFAULT '',
+			PRIMARY KEY (tenant_id, name)
 		)`,
 		// v0.8.5 Self-Evolution Substrate — see
 		// internal/store/postgres/migrations/0006_agent_defs.up.sql for
@@ -952,6 +962,16 @@ func (s *Store) migrate(ctx context.Context) error {
 		// them and the duplicate-column-name guard short-circuits these.
 		`ALTER TABLE channel_messages ADD COLUMN visible_at INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE channel_messages ADD COLUMN published_by_user_id TEXT`,
+		// Channel tenant axis. Idempotent ALTER for existing DBs; the
+		// fresh CREATE TABLE above already declares the column (the
+		// duplicate-column guard short-circuits these on fresh deploys).
+		// SQLite can't rewrite the PK in place, so an upgraded DB keeps
+		// its old (channel, scope, scope_id[, id]) / (name) PK — the
+		// ON CONFLICT upsert targets a dedicated uniq index (added in
+		// addIndexes) that exists on both fresh + upgraded DBs.
+		`ALTER TABLE channel_messages ADD COLUMN tenant_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE channel_cursors ADD COLUMN tenant_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE channels ADD COLUMN tenant_id TEXT NOT NULL DEFAULT ''`,
 		// v0.9.x content_sha256 — see internal/store/postgres/migrations/
 		// 0018_agent_defs_content_sha256.up.sql for the rationale. NULL
 		// until the boot-time backfill walks pre-migration rows.
@@ -1156,7 +1176,14 @@ func (s *Store) migrate(ctx context.Context) error {
 		// index is created. Required for the upgrade path
 		// v0.8.4/v0.8.5 → v0.8.6+ (channel_messages table exists
 		// from v0.8.4 without visible_at).
-		`CREATE INDEX IF NOT EXISTS channel_messages_by_visible ON channel_messages(channel, scope, scope_id, visible_at, id)`,
+		`CREATE INDEX IF NOT EXISTS channel_messages_by_visible ON channel_messages(tenant_id, channel, scope, scope_id, visible_at, id)`,
+		// The channel_cursors upsert (ChannelAck) targets this uniq index
+		// via ON CONFLICT(tenant_id, channel, scope, scope_id). It exists
+		// on BOTH a fresh DB (where it duplicates the PK) and an upgraded
+		// DB (where the PK stays the old tenant-blind tuple), so the ack
+		// path works regardless of when the DB was created — mirrors
+		// uniq_memory_tenant_scope_scope_id_key.
+		`CREATE UNIQUE INDEX IF NOT EXISTS uniq_channel_cursors_tenant ON channel_cursors(tenant_id, channel, scope, scope_id)`,
 		// v0.8.x process_samples_by_sampled_at. Drives the read
 		// path for /v1/_metrics/samples (window scan) and the
 		// sweep DELETE WHERE sampled_at < cutoff.
@@ -3422,10 +3449,10 @@ func (s *Store) SnapshotReadMemory(ctx context.Context) ([]store.MemorySnapshotE
 func (s *Store) SnapshotReadChannelMessages(ctx context.Context) ([]store.ChannelMessage, error) {
 	now := time.Now().UnixNano()
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, channel, scope, scope_id, payload, published_at, expires_at, visible_at, published_by_user_id
+		`SELECT id, channel, tenant_id, scope, scope_id, payload, published_at, expires_at, visible_at, published_by_user_id
 		 FROM channel_messages
 		 WHERE expires_at IS NULL OR expires_at > ?
-		 ORDER BY channel ASC, scope ASC, scope_id ASC, visible_at ASC, id ASC`, now)
+		 ORDER BY tenant_id ASC, channel ASC, scope ASC, scope_id ASC, visible_at ASC, id ASC`, now)
 	if err != nil {
 		return nil, fmt.Errorf("snapshot read channel_messages: %w", err)
 	}
@@ -3442,7 +3469,7 @@ func (s *Store) SnapshotReadChannelMessages(ctx context.Context) ([]store.Channe
 			publishedBy sql.NullString
 		)
 		if err := rows.Scan(
-			&m.ID, &m.Channel, &scopeStr, &m.ScopeID, &payload,
+			&m.ID, &m.Channel, &m.TenantID, &scopeStr, &m.ScopeID, &payload,
 			&publishedNs, &expiresNs, &visibleNs, &publishedBy,
 		); err != nil {
 			return nil, fmt.Errorf("scan channel_message: %w", err)
@@ -3467,9 +3494,9 @@ func (s *Store) SnapshotReadChannelMessages(ctx context.Context) ([]store.Channe
 // SnapshotReadChannelCursors implements store.Store.
 func (s *Store) SnapshotReadChannelCursors(ctx context.Context) ([]store.ChannelCursorEntry, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT channel, scope, scope_id, cursor, updated_at
+		`SELECT channel, tenant_id, scope, scope_id, cursor, updated_at
 		 FROM channel_cursors
-		 ORDER BY channel ASC, scope ASC, scope_id ASC`)
+		 ORDER BY tenant_id ASC, channel ASC, scope ASC, scope_id ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("snapshot read channel_cursors: %w", err)
 	}
@@ -3481,7 +3508,7 @@ func (s *Store) SnapshotReadChannelCursors(ctx context.Context) ([]store.Channel
 			scopeStr  string
 			updatedNs int64
 		)
-		if err := rows.Scan(&c.Channel, &scopeStr, &c.ScopeID, &c.Cursor, &updatedNs); err != nil {
+		if err := rows.Scan(&c.Channel, &c.TenantID, &scopeStr, &c.ScopeID, &c.Cursor, &updatedNs); err != nil {
 			return nil, fmt.Errorf("scan channel_cursor: %w", err)
 		}
 		c.Scope = store.MemoryScope(scopeStr)
@@ -3923,10 +3950,10 @@ func (s *Store) SnapshotRestoreChannelMessage(ctx context.Context, m store.Chann
 		visibleNs = publishedNs
 	}
 	res, err := s.db.ExecContext(ctx,
-		`INSERT OR IGNORE INTO channel_messages(id, channel, scope, scope_id, payload, published_at, expires_at, visible_at, published_by_user_id)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT OR IGNORE INTO channel_messages(id, channel, scope, scope_id, payload, published_at, expires_at, visible_at, published_by_user_id, tenant_id)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		m.ID, m.Channel, string(m.Scope), m.ScopeID, string(m.Payload),
-		publishedNs, expiresNs, visibleNs, nilIfEmpty(m.PublishedByUserID),
+		publishedNs, expiresNs, visibleNs, nilIfEmpty(m.PublishedByUserID), m.TenantID,
 	)
 	if err != nil {
 		return false, fmt.Errorf("snapshot restore channel_message: %w", err)
@@ -3948,8 +3975,8 @@ func (s *Store) SnapshotRestoreChannelCursor(ctx context.Context, c store.Channe
 		updatedNs = time.Now().UnixNano()
 	}
 	res, err := s.db.ExecContext(ctx,
-		`INSERT OR IGNORE INTO channel_cursors(channel, scope, scope_id, cursor, updated_at) VALUES (?, ?, ?, ?, ?)`,
-		c.Channel, string(c.Scope), c.ScopeID, c.Cursor, updatedNs,
+		`INSERT OR IGNORE INTO channel_cursors(channel, scope, scope_id, cursor, updated_at, tenant_id) VALUES (?, ?, ?, ?, ?, ?)`,
+		c.Channel, string(c.Scope), c.ScopeID, c.Cursor, updatedNs, c.TenantID,
 	)
 	if err != nil {
 		return false, fmt.Errorf("snapshot restore channel_cursor: %w", err)
@@ -5135,6 +5162,7 @@ func (s *Store) MemoryCursorRelease(ctx context.Context, tenantID string, scope 
 // scheduler schedules a Bus.Notify(channel) at visible_at so
 // long-poll subscribers wake on time.
 func (s *Store) ChannelPublish(ctx context.Context, msg store.ChannelMessage, maxMessages int) (string, int, error) {
+	msg.TenantID = store.ChannelScopeTenant(msg.TenantID, msg.Scope) // global => "" (cross-tenant keyspace)
 	now := time.Now()
 	msg.ID = store.MintChannelMessageID(now)
 	msg.PublishedAt = now
@@ -5158,10 +5186,10 @@ func (s *Store) ChannelPublish(ctx context.Context, msg store.ChannelMessage, ma
 	defer func() { _ = tx.Rollback() }()
 
 	if _, err := tx.ExecContext(ctx,
-		`INSERT INTO channel_messages(id, channel, scope, scope_id, payload, published_at, expires_at, visible_at, published_by_user_id)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO channel_messages(id, channel, scope, scope_id, payload, published_at, expires_at, visible_at, published_by_user_id, tenant_id)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		msg.ID, msg.Channel, string(msg.Scope), msg.ScopeID, string(msg.Payload),
-		now.UnixNano(), expiresAt, msg.VisibleAt.UnixNano(), publishedByUserID,
+		now.UnixNano(), expiresAt, msg.VisibleAt.UnixNano(), publishedByUserID, msg.TenantID,
 	); err != nil {
 		return "", 0, err
 	}
@@ -5198,16 +5226,16 @@ func (s *Store) ChannelPublish(ctx context.Context, msg store.ChannelMessage, ma
 		// subscriber will eventually want to see.
 		res, err := tx.ExecContext(ctx,
 			`DELETE FROM channel_messages
-			 WHERE channel = ? AND scope = ? AND scope_id = ?
+			 WHERE tenant_id = ? AND channel = ? AND scope = ? AND scope_id = ?
 			   AND id != ?
 			   AND id NOT IN (
 			     SELECT id FROM channel_messages
-			      WHERE channel = ? AND scope = ? AND scope_id = ?
+			      WHERE tenant_id = ? AND channel = ? AND scope = ? AND scope_id = ?
 			      ORDER BY visible_at DESC, id DESC
 			      LIMIT ?
 			   )`,
-			msg.Channel, string(msg.Scope), msg.ScopeID, msg.ID,
-			msg.Channel, string(msg.Scope), msg.ScopeID,
+			msg.TenantID, msg.Channel, string(msg.Scope), msg.ScopeID, msg.ID,
+			msg.TenantID, msg.Channel, string(msg.Scope), msg.ScopeID,
 			maxMessages,
 		)
 		if err != nil {
@@ -5237,27 +5265,27 @@ func (s *Store) ChannelPublish(ctx context.Context, msg store.ChannelMessage, ma
 // ChannelSubscribe reads up to `limit` messages newer than fromCursor.
 // fromCursor == "" || "cur_0" → from the oldest non-expired row.
 // Returns the batch + the id of the LAST message as nextCursor.
-func (s *Store) ChannelSubscribe(ctx context.Context, channel string, scope store.MemoryScope, scopeID, fromCursor string, limit int) ([]store.ChannelMessage, string, error) {
-	return s.channelRead(ctx, channel, scope, scopeID, fromCursor, limit)
+func (s *Store) ChannelSubscribe(ctx context.Context, tenantID, channel string, scope store.MemoryScope, scopeID, fromCursor string, limit int) ([]store.ChannelMessage, string, error) {
+	return s.channelRead(ctx, tenantID, channel, scope, scopeID, fromCursor, limit)
 }
 
 // ChannelPeek is identical to ChannelSubscribe (non-consuming — the
 // cursor table is never touched on either path). The semantic
 // difference lives entirely in the tool layer: Subscribe optionally
 // commits the returned cursor on the next call, Peek never does.
-func (s *Store) ChannelPeek(ctx context.Context, channel string, scope store.MemoryScope, scopeID, fromCursor string, limit int) ([]store.ChannelMessage, error) {
-	msgs, _, err := s.channelRead(ctx, channel, scope, scopeID, fromCursor, limit)
+func (s *Store) ChannelPeek(ctx context.Context, tenantID, channel string, scope store.MemoryScope, scopeID, fromCursor string, limit int) ([]store.ChannelMessage, error) {
+	msgs, _, err := s.channelRead(ctx, tenantID, channel, scope, scopeID, fromCursor, limit)
 	return msgs, err
 }
 
 func (s *Store) ChannelStats(ctx context.Context) ([]store.ChannelStats, error) {
 	now := time.Now().UnixNano()
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT channel, COUNT(*), MIN(visible_at), MAX(visible_at)
+		SELECT tenant_id, channel, COUNT(*), MIN(visible_at), MAX(visible_at)
 		FROM channel_messages
 		WHERE (expires_at IS NULL OR expires_at > ?)
-		GROUP BY channel
-		ORDER BY channel`, now)
+		GROUP BY tenant_id, channel
+		ORDER BY tenant_id, channel`, now)
 	if err != nil {
 		return nil, fmt.Errorf("channel stats query: %w", err)
 	}
@@ -5266,14 +5294,15 @@ func (s *Store) ChannelStats(ctx context.Context) ([]store.ChannelStats, error) 
 	var out []store.ChannelStats
 	for rows.Next() {
 		var (
+			tenantID         string
 			name             string
 			count            int64
 			oldestNS, newest sql.NullInt64
 		)
-		if err := rows.Scan(&name, &count, &oldestNS, &newest); err != nil {
+		if err := rows.Scan(&tenantID, &name, &count, &oldestNS, &newest); err != nil {
 			return nil, fmt.Errorf("channel stats scan: %w", err)
 		}
-		st := store.ChannelStats{Channel: name, MessageCount: count}
+		st := store.ChannelStats{Channel: name, TenantID: tenantID, MessageCount: count}
 		if oldestNS.Valid {
 			st.OldestVisibleAt = time.Unix(0, oldestNS.Int64).UTC()
 		}
@@ -5407,7 +5436,8 @@ func (s *Store) backfillContentSHA256(ctx context.Context, table string, signFn 
 // so subscribers can pick up exactly where they left off, including
 // deferred messages that become visible later than other messages
 // published in between.
-func (s *Store) channelRead(ctx context.Context, channel string, scope store.MemoryScope, scopeID, fromCursor string, limit int) ([]store.ChannelMessage, string, error) {
+func (s *Store) channelRead(ctx context.Context, tenantID, channel string, scope store.MemoryScope, scopeID, fromCursor string, limit int) ([]store.ChannelMessage, string, error) {
+	tenantID = store.ChannelScopeTenant(tenantID, scope) // global => "" (cross-tenant keyspace)
 	if limit <= 0 {
 		limit = 10
 	}
@@ -5425,25 +5455,25 @@ func (s *Store) channelRead(ctx context.Context, channel string, scope store.Mem
 	if fromOldest {
 		query = `SELECT id, payload, published_at, expires_at, visible_at, published_by_user_id
 			 FROM channel_messages
-			 WHERE channel = ? AND scope = ? AND scope_id = ?
+			 WHERE tenant_id = ? AND channel = ? AND scope = ? AND scope_id = ?
 			   AND visible_at <= ?
 			   AND (expires_at IS NULL OR expires_at > ?)
 			 ORDER BY visible_at ASC, id ASC
 			 LIMIT ?`
 		rows, qErr = s.db.QueryContext(ctx, query,
-			channel, string(scope), scopeID, now, now, limit)
+			tenantID, channel, string(scope), scopeID, now, now, limit)
 	} else {
 		// Strictly-greater-than tuple comparison: (visible_at, id) > (cv, cid).
 		query = `SELECT id, payload, published_at, expires_at, visible_at, published_by_user_id
 			 FROM channel_messages
-			 WHERE channel = ? AND scope = ? AND scope_id = ?
+			 WHERE tenant_id = ? AND channel = ? AND scope = ? AND scope_id = ?
 			   AND visible_at <= ?
 			   AND (expires_at IS NULL OR expires_at > ?)
 			   AND (visible_at > ? OR (visible_at = ? AND id > ?))
 			 ORDER BY visible_at ASC, id ASC
 			 LIMIT ?`
 		rows, qErr = s.db.QueryContext(ctx, query,
-			channel, string(scope), scopeID, now, now,
+			tenantID, channel, string(scope), scopeID, now, now,
 			cursorVisibleAt.UnixNano(), cursorVisibleAt.UnixNano(), cursorMsgID,
 			limit)
 	}
@@ -5470,6 +5500,7 @@ func (s *Store) channelRead(ctx context.Context, channel string, scope store.Mem
 		msg := store.ChannelMessage{
 			ID:          id,
 			Channel:     channel,
+			TenantID:    tenantID,
 			Scope:       scope,
 			ScopeID:     scopeID,
 			Payload:     json.RawMessage(payload),
@@ -5501,7 +5532,8 @@ func (s *Store) channelRead(ctx context.Context, channel string, scope store.Mem
 // matches tuple order because the v0.8.6 cursor format encodes
 // visible_at as a fixed-width hex prefix). Idempotent re-ack of the
 // SAME cursor is a no-op.
-func (s *Store) ChannelAck(ctx context.Context, channel string, scope store.MemoryScope, scopeID, cursor string) error {
+func (s *Store) ChannelAck(ctx context.Context, tenantID, channel string, scope store.MemoryScope, scopeID, cursor string) error {
+	tenantID = store.ChannelScopeTenant(tenantID, scope) // global => "" (cross-tenant keyspace)
 	if cursor == "" || cursor == "cur_0" {
 		return nil // nothing to commit
 	}
@@ -5518,8 +5550,8 @@ func (s *Store) ChannelAck(ctx context.Context, channel string, scope store.Memo
 
 	var existing string
 	err = tx.QueryRowContext(ctx,
-		`SELECT cursor FROM channel_cursors WHERE channel = ? AND scope = ? AND scope_id = ?`,
-		channel, string(scope), scopeID,
+		`SELECT cursor FROM channel_cursors WHERE tenant_id = ? AND channel = ? AND scope = ? AND scope_id = ?`,
+		tenantID, channel, string(scope), scopeID,
 	).Scan(&existing)
 	if err != nil && err != sql.ErrNoRows {
 		return err
@@ -5532,13 +5564,16 @@ func (s *Store) ChannelAck(ctx context.Context, channel string, scope store.Memo
 	}
 
 	now := time.Now().UnixNano()
+	// ON CONFLICT targets uniq_channel_cursors_tenant (added in addIndexes)
+	// so the upsert works on both a fresh DB (new PK) and an upgraded DB
+	// (old PK) — see the memory upsert precedent.
 	if _, err := tx.ExecContext(ctx,
-		`INSERT INTO channel_cursors(channel, scope, scope_id, cursor, updated_at)
-		 VALUES (?, ?, ?, ?, ?)
-		 ON CONFLICT(channel, scope, scope_id) DO UPDATE SET
+		`INSERT INTO channel_cursors(channel, scope, scope_id, cursor, updated_at, tenant_id)
+		 VALUES (?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(tenant_id, channel, scope, scope_id) DO UPDATE SET
 		    cursor = excluded.cursor,
 		    updated_at = excluded.updated_at`,
-		channel, string(scope), scopeID, cursor, now,
+		channel, string(scope), scopeID, cursor, now, tenantID,
 	); err != nil {
 		return err
 	}
@@ -5547,11 +5582,12 @@ func (s *Store) ChannelAck(ctx context.Context, channel string, scope store.Memo
 
 // ChannelCommittedCursor returns the last cursor ack'd for a
 // subscriber, or empty string when none.
-func (s *Store) ChannelCommittedCursor(ctx context.Context, channel string, scope store.MemoryScope, scopeID string) (string, error) {
+func (s *Store) ChannelCommittedCursor(ctx context.Context, tenantID, channel string, scope store.MemoryScope, scopeID string) (string, error) {
+	tenantID = store.ChannelScopeTenant(tenantID, scope) // global => "" (cross-tenant keyspace)
 	var cursor string
 	err := s.db.QueryRowContext(ctx,
-		`SELECT cursor FROM channel_cursors WHERE channel = ? AND scope = ? AND scope_id = ?`,
-		channel, string(scope), scopeID,
+		`SELECT cursor FROM channel_cursors WHERE tenant_id = ? AND channel = ? AND scope = ? AND scope_id = ?`,
+		tenantID, channel, string(scope), scopeID,
 	).Scan(&cursor)
 	if err == sql.ErrNoRows {
 		return "", nil
@@ -5564,13 +5600,14 @@ func (s *Store) ChannelCommittedCursor(ctx context.Context, channel string, scop
 
 // ChannelListCursorsForScope — see store.Store doc. v0.9.x
 // introspection. Ordered by channel ASC for deterministic UI render.
-func (s *Store) ChannelListCursorsForScope(ctx context.Context, scope store.MemoryScope, scopeID string) ([]store.ChannelCursorEntry, error) {
+func (s *Store) ChannelListCursorsForScope(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID string) ([]store.ChannelCursorEntry, error) {
+	tenantID = store.ChannelScopeTenant(tenantID, scope) // global => "" (cross-tenant keyspace)
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT channel, scope, scope_id, cursor, updated_at
 		 FROM channel_cursors
-		 WHERE scope = ? AND scope_id = ?
+		 WHERE tenant_id = ? AND scope = ? AND scope_id = ?
 		 ORDER BY channel ASC`,
-		string(scope), scopeID,
+		tenantID, string(scope), scopeID,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2002,20 +2002,20 @@ type Store interface {
 	// nextCursor is the id of the LAST message in the returned batch
 	// (empty when batch is empty); committing it via ChannelAck
 	// advances the per-subscriber position.
-	ChannelSubscribe(ctx context.Context, channel string, scope MemoryScope, scopeID, fromCursor string, limit int) (msgs []ChannelMessage, nextCursor string, err error)
+	ChannelSubscribe(ctx context.Context, tenantID, channel string, scope MemoryScope, scopeID, fromCursor string, limit int) (msgs []ChannelMessage, nextCursor string, err error)
 
 	// ChannelAck advances the committed cursor for one subscriber to
 	// the supplied cursor value. Idempotent — re-acking the same
 	// cursor is a no-op. Acking a cursor older than the current
 	// committed value is rejected with ErrChannelCursorRegression so
 	// out-of-order acks from buggy agents can't rewind delivery.
-	ChannelAck(ctx context.Context, channel string, scope MemoryScope, scopeID, cursor string) error
+	ChannelAck(ctx context.Context, tenantID, channel string, scope MemoryScope, scopeID, cursor string) error
 
 	// ChannelCommittedCursor returns the most recent cursor a
 	// subscriber acked, or empty string when no ack has happened
 	// yet (= read from oldest non-expired). Used by ChannelSubscribe
 	// when callers omit fromCursor — "pick up where I left off".
-	ChannelCommittedCursor(ctx context.Context, channel string, scope MemoryScope, scopeID string) (string, error)
+	ChannelCommittedCursor(ctx context.Context, tenantID, channel string, scope MemoryScope, scopeID string) (string, error)
 
 	// ChannelListCursorsForScope returns every channel_cursors row
 	// matching (scope, scope_id). v0.9.x introspection — drives the
@@ -2025,7 +2025,7 @@ type Store interface {
 	// (scope, scope_id) tuple has no cursors. Returns the full set so
 	// the UI can render "all channels this agent has ack'd on"
 	// without N+1 per-channel queries.
-	ChannelListCursorsForScope(ctx context.Context, scope MemoryScope, scopeID string) ([]ChannelCursorEntry, error)
+	ChannelListCursorsForScope(ctx context.Context, tenantID string, scope MemoryScope, scopeID string) ([]ChannelCursorEntry, error)
 
 	// ChannelSweepExpired deletes every channel_messages row whose
 	// expires_at has passed. Returns the deleted row count for the
@@ -2037,7 +2037,7 @@ type Store interface {
 	// but never updates a cursor and never auto-advances. Powers
 	// the tool's "peek" op for debugging — operators can replay
 	// from cur_0 without disturbing the consumer's position.
-	ChannelPeek(ctx context.Context, channel string, scope MemoryScope, scopeID, fromCursor string, limit int) ([]ChannelMessage, error)
+	ChannelPeek(ctx context.Context, tenantID, channel string, scope MemoryScope, scopeID, fromCursor string, limit int) ([]ChannelMessage, error)
 
 	// ChannelStats returns one row per channel that has at least one
 	// non-expired message, with the aggregate count + oldest/newest
@@ -2763,7 +2763,7 @@ type Store interface {
 	// peek/ack declared-check doesn't scan the whole table per op, and
 	// so a real store fault surfaces as an error instead of an empty
 	// list that masquerades as "not declared" (exp7 I5).
-	ChannelGet(ctx context.Context, name string) (ChannelRow, error)
+	ChannelGet(ctx context.Context, tenantID, name string) (ChannelRow, error)
 
 	// ChannelsCreate inserts a new runtime channel. Returns
 	// *ErrConflict{Kind:"channel"} when a runtime row with the
@@ -2774,12 +2774,12 @@ type Store interface {
 	// ChannelsUpdate patches mutable fields on a runtime channel
 	// (description, default_ttl, max_messages, semantic). Returns
 	// ErrNotFound when the name isn't in the runtime table.
-	ChannelsUpdate(ctx context.Context, name string, patch ChannelPatch) error
+	ChannelsUpdate(ctx context.Context, tenantID, name string, patch ChannelPatch) error
 
 	// ChannelsDelete removes a runtime channel + cascades deletion
 	// of its persisted messages + cursors. Returns ErrNotFound when
 	// the name isn't in the runtime table.
-	ChannelsDelete(ctx context.Context, name string) error
+	ChannelsDelete(ctx context.Context, tenantID, name string) error
 
 	// ChannelPurge deletes all buffered messages for a channel WITHOUT
 	// removing the channel definition or subscriber cursors — the
@@ -2789,7 +2789,7 @@ type Store interface {
 	// channel_messages table. Idempotent — purging a channel with no
 	// messages returns (0, nil) rather than ErrNotFound; existence is
 	// the caller's concern. Returns the number of messages deleted.
-	ChannelPurge(ctx context.Context, name string) (int, error)
+	ChannelPurge(ctx context.Context, tenantID, name string) (int, error)
 
 	// Close releases backend resources. Idempotent.
 	Close() error
@@ -2803,6 +2803,7 @@ type Store interface {
 // cfg.Channels at merge time.
 type ChannelRow struct {
 	Name        string
+	TenantID    string // RFC L/N owning tenant; "" = shared/legacy
 	Description string
 	Scope       string
 	Semantic    string
@@ -2868,6 +2869,23 @@ const (
 	// CHECK constraint, and the tenant axis arrived with migration 0059.
 	MemoryScopeTenant MemoryScope = "tenant"
 )
+
+// ChannelScopeTenant normalizes the tenant for a channel access. The
+// `global` scope is a single keyspace shared across ALL tenants
+// (tenant_id="", per the MemoryScopeGlobal contract above), so a global
+// access always resolves to "" regardless of the caller's tenant; every
+// other scope is partitioned by the caller's tenant. Centralizing the
+// rule here makes "global is cross-tenant" an unbreakable invariant — no
+// caller can accidentally tenant-partition a global channel, which would
+// desync a tenant agent (or a legacy operator whose tenant is "default")
+// from operator/infra publishes such as heartbeats. Channel store methods
+// apply this to the (tenant, scope) they receive before touching a row.
+func ChannelScopeTenant(tenantID string, scope MemoryScope) string {
+	if scope == MemoryScopeGlobal {
+		return ""
+	}
+	return tenantID
+}
 
 // MemorySearchFilter narrows which memory rows a vector or full-text search may
 // return. It replaces the bare keyPrefix argument both search methods used to take
@@ -3300,8 +3318,12 @@ func (e *MemoryError) Is(target error) bool {
 //     from the run's UserID; system publishes use the "_system"
 //     sentinel; admin-endpoint publishes use the bearer's user.
 type ChannelMessage struct {
-	ID                string          `json:"id"`
-	Channel           string          `json:"channel"`
+	ID      string `json:"id"`
+	Channel string `json:"channel"`
+	// TenantID is the server-derived owning tenant (RFC L authority model
+	// — never caller-supplied). "" = the shared/legacy tenant; omitempty
+	// keeps single-tenant wire + snapshot bytes unchanged.
+	TenantID          string          `json:"tenant_id,omitempty"`
 	Scope             MemoryScope     `json:"scope"` // re-uses MemoryScope so operators don't track two enums
 	ScopeID           string          `json:"scope_id"`
 	Payload           json.RawMessage `json:"payload"`
@@ -3317,6 +3339,7 @@ type ChannelMessage struct {
 // admin listing reflects what subscribers would actually receive.
 type ChannelStats struct {
 	Channel         string    `json:"channel"`
+	TenantID        string    `json:"tenant_id,omitempty"` // owning tenant; stats are aggregated per (tenant, channel)
 	MessageCount    int64     `json:"message_count"`
 	OldestVisibleAt time.Time `json:"oldest_visible_at,omitempty"`
 	NewestVisibleAt time.Time `json:"newest_visible_at,omitempty"`
@@ -4488,6 +4511,7 @@ type MemorySnapshotEntry struct {
 // cursor field is the opaque string form ack'd by the subscriber.
 type ChannelCursorEntry struct {
 	Channel   string      `json:"channel"`
+	TenantID  string      `json:"tenant_id,omitempty"`
 	Scope     MemoryScope `json:"scope"`
 	ScopeID   string      `json:"scope_id"`
 	Cursor    string      `json:"cursor"`

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -207,6 +207,7 @@ func Run(t *testing.T, factory Factory) {
 		{"ChannelSweepReapsExpired", testChannelSweepReapsExpired},
 		{"ChannelMaxMessagesTrimsOldest", testChannelMaxMessagesTrimsOldest},
 		{"ChannelScopeIsolation", testChannelScopeIsolation},
+		{"ChannelTenantIsolation", testChannelTenantIsolation},
 		{"ChannelPurge", testChannelPurge},
 		{"ChannelPeekDoesNotConsume", testChannelPeekDoesNotConsume},
 		{"ChannelReplayFromCursorZero", testChannelReplayFromCursorZero},
@@ -5074,7 +5075,7 @@ func testChannelPublishSubscribeRoundTrip(t *testing.T, s store.Store) {
 		// monotonic even on platforms with coarse time resolution.
 		time.Sleep(time.Microsecond)
 	}
-	msgs, next, err := s.ChannelSubscribe(ctx, "findings", store.MemoryScopeAgent, "researcher", "", 10)
+	msgs, next, err := s.ChannelSubscribe(ctx, "", "findings", store.MemoryScopeAgent, "researcher", "", 10)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -5100,7 +5101,7 @@ func testChannelPublishSubscribeRoundTrip(t *testing.T, s store.Store) {
 
 func testChannelSubscribeEmptyChannel(t *testing.T, s store.Store) {
 	ctx := context.Background()
-	msgs, next, err := s.ChannelSubscribe(ctx, "unused", store.MemoryScopeAgent, "x", "", 10)
+	msgs, next, err := s.ChannelSubscribe(ctx, "", "unused", store.MemoryScopeAgent, "x", "", 10)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -5124,7 +5125,7 @@ func testChannelCursorAdvancesAcrossSubscribes(t *testing.T, s store.Store) {
 		time.Sleep(time.Microsecond)
 	}
 	// First page of 2.
-	msgs, next, err := s.ChannelSubscribe(ctx, "ch", store.MemoryScopeAgent, "x", "", 2)
+	msgs, next, err := s.ChannelSubscribe(ctx, "", "ch", store.MemoryScopeAgent, "x", "", 2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -5133,10 +5134,10 @@ func testChannelCursorAdvancesAcrossSubscribes(t *testing.T, s store.Store) {
 		t.Fatalf("page1: msgs=%d next=%q (want 2/%s)", len(msgs), next, wantNext1)
 	}
 	// Commit + read next page.
-	if err := s.ChannelAck(ctx, "ch", store.MemoryScopeAgent, "x", next); err != nil {
+	if err := s.ChannelAck(ctx, "", "ch", store.MemoryScopeAgent, "x", next); err != nil {
 		t.Fatal(err)
 	}
-	committed, err := s.ChannelCommittedCursor(ctx, "ch", store.MemoryScopeAgent, "x")
+	committed, err := s.ChannelCommittedCursor(ctx, "", "ch", store.MemoryScopeAgent, "x")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -5144,7 +5145,7 @@ func testChannelCursorAdvancesAcrossSubscribes(t *testing.T, s store.Store) {
 		t.Errorf("committed = %q, want %q", committed, wantNext1)
 	}
 	// Read from committed cursor.
-	msgs, next, err = s.ChannelSubscribe(ctx, "ch", store.MemoryScopeAgent, "x", committed, 10)
+	msgs, next, err = s.ChannelSubscribe(ctx, "", "ch", store.MemoryScopeAgent, "x", committed, 10)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -5165,14 +5166,14 @@ func testChannelAckIsIdempotent(t *testing.T, s store.Store) {
 	}, 0)
 	// v0.8.6: ChannelAck takes the tuple cursor returned by Subscribe,
 	// not a raw msg_id. Fetch the cursor through Subscribe.
-	msgs, cursor, err := s.ChannelSubscribe(ctx, "ch", store.MemoryScopeAgent, "x", "", 10)
+	msgs, cursor, err := s.ChannelSubscribe(ctx, "", "ch", store.MemoryScopeAgent, "x", "", 10)
 	if err != nil || len(msgs) != 1 {
 		t.Fatalf("setup subscribe: msgs=%d err=%v", len(msgs), err)
 	}
-	if err := s.ChannelAck(ctx, "ch", store.MemoryScopeAgent, "x", cursor); err != nil {
+	if err := s.ChannelAck(ctx, "", "ch", store.MemoryScopeAgent, "x", cursor); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.ChannelAck(ctx, "ch", store.MemoryScopeAgent, "x", cursor); err != nil {
+	if err := s.ChannelAck(ctx, "", "ch", store.MemoryScopeAgent, "x", cursor); err != nil {
 		t.Errorf("second ack of same cursor: %v (want nil — idempotent)", err)
 	}
 }
@@ -5190,19 +5191,19 @@ func testChannelAckRejectsCursorRegression(t *testing.T, s store.Store) {
 	}, 0)
 	// Get the two tuple cursors via Subscribe (one at a time, so each
 	// `next` reflects the per-message cursor).
-	msgs1, cur1, err := s.ChannelSubscribe(ctx, "ch", store.MemoryScopeAgent, "x", "", 1)
+	msgs1, cur1, err := s.ChannelSubscribe(ctx, "", "ch", store.MemoryScopeAgent, "x", "", 1)
 	if err != nil || len(msgs1) != 1 {
 		t.Fatalf("page1: %v / %d", err, len(msgs1))
 	}
-	msgs2, cur2, err := s.ChannelSubscribe(ctx, "ch", store.MemoryScopeAgent, "x", cur1, 1)
+	msgs2, cur2, err := s.ChannelSubscribe(ctx, "", "ch", store.MemoryScopeAgent, "x", cur1, 1)
 	if err != nil || len(msgs2) != 1 {
 		t.Fatalf("page2: %v / %d", err, len(msgs2))
 	}
-	if err := s.ChannelAck(ctx, "ch", store.MemoryScopeAgent, "x", cur2); err != nil {
+	if err := s.ChannelAck(ctx, "", "ch", store.MemoryScopeAgent, "x", cur2); err != nil {
 		t.Fatal(err)
 	}
 	// Trying to commit cur1 (older) must fail with ErrChannelCursorRegression.
-	err = s.ChannelAck(ctx, "ch", store.MemoryScopeAgent, "x", cur1)
+	err = s.ChannelAck(ctx, "", "ch", store.MemoryScopeAgent, "x", cur1)
 	if !errors.Is(err, store.ErrChannelCursorRegression) {
 		t.Errorf("got %v, want ErrChannelCursorRegression", err)
 	}
@@ -5229,18 +5230,18 @@ func testChannelListCursorsForScope(t *testing.T, s store.Store) {
 	}
 	// Alice acks both channels; bob acks only channel-a.
 	for _, ch := range []string{"channel-a", "channel-b"} {
-		_, next, _ := s.ChannelSubscribe(ctx, ch, store.MemoryScopeAgent, "alice", "", 1)
+		_, next, _ := s.ChannelSubscribe(ctx, "", ch, store.MemoryScopeAgent, "alice", "", 1)
 		if next != "" {
-			_ = s.ChannelAck(ctx, ch, store.MemoryScopeAgent, "alice", next)
+			_ = s.ChannelAck(ctx, "", ch, store.MemoryScopeAgent, "alice", next)
 		}
 	}
-	_, next, _ := s.ChannelSubscribe(ctx, "channel-a", store.MemoryScopeAgent, "bob", "", 1)
+	_, next, _ := s.ChannelSubscribe(ctx, "", "channel-a", store.MemoryScopeAgent, "bob", "", 1)
 	if next != "" {
-		_ = s.ChannelAck(ctx, "channel-a", store.MemoryScopeAgent, "bob", next)
+		_ = s.ChannelAck(ctx, "", "channel-a", store.MemoryScopeAgent, "bob", next)
 	}
 
 	// Alice's view: two rows, ordered ASC.
-	aliceRows, err := s.ChannelListCursorsForScope(ctx, store.MemoryScopeAgent, "alice")
+	aliceRows, err := s.ChannelListCursorsForScope(ctx, "", store.MemoryScopeAgent, "alice")
 	if err != nil {
 		t.Fatalf("alice list: %v", err)
 	}
@@ -5263,7 +5264,7 @@ func testChannelListCursorsForScope(t *testing.T, s store.Store) {
 	}
 
 	// Bob's view: one row (channel-a only).
-	bobRows, err := s.ChannelListCursorsForScope(ctx, store.MemoryScopeAgent, "bob")
+	bobRows, err := s.ChannelListCursorsForScope(ctx, "", store.MemoryScopeAgent, "bob")
 	if err != nil {
 		t.Fatalf("bob list: %v", err)
 	}
@@ -5272,7 +5273,7 @@ func testChannelListCursorsForScope(t *testing.T, s store.Store) {
 	}
 
 	// Mismatched scope: scope=user, scope_id=alice. No rows.
-	userRows, err := s.ChannelListCursorsForScope(ctx, store.MemoryScopeUser, "alice")
+	userRows, err := s.ChannelListCursorsForScope(ctx, "", store.MemoryScopeUser, "alice")
 	if err != nil {
 		t.Fatalf("user-scope list: %v", err)
 	}
@@ -5304,7 +5305,7 @@ func testChannelTTLFilteredAtRead(t *testing.T, s store.Store) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	msgs, _, err := s.ChannelSubscribe(ctx, "ch", store.MemoryScopeAgent, "x", "", 10)
+	msgs, _, err := s.ChannelSubscribe(ctx, "", "ch", store.MemoryScopeAgent, "x", "", 10)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -5360,7 +5361,7 @@ func testChannelMaxMessagesTrimsOldest(t *testing.T, s store.Store) {
 	if droppedTotal != 2 {
 		t.Errorf("total trimmed = %d, want 2", droppedTotal)
 	}
-	msgs, _, _ := s.ChannelSubscribe(ctx, "ch", store.MemoryScopeAgent, "x", "", 10)
+	msgs, _, _ := s.ChannelSubscribe(ctx, "", "ch", store.MemoryScopeAgent, "x", "", 10)
 	if len(msgs) != 3 {
 		t.Errorf("post-trim msgs = %d, want 3 (the cap)", len(msgs))
 	}
@@ -5378,13 +5379,101 @@ func testChannelScopeIsolation(t *testing.T, s store.Store) {
 		Channel: "shared", Scope: store.MemoryScopeAgent, ScopeID: "agent-b",
 		Payload: json.RawMessage(`{"from":"b"}`),
 	}, 0)
-	msgs, _, _ := s.ChannelSubscribe(ctx, "shared", store.MemoryScopeAgent, "agent-a", "", 10)
+	msgs, _, _ := s.ChannelSubscribe(ctx, "", "shared", store.MemoryScopeAgent, "agent-a", "", 10)
 	if len(msgs) != 1 || !jsonEqual(msgs[0].Payload, `{"from":"a"}`) {
 		t.Errorf("agent-a sees: %+v, want only its own message", msgs)
 	}
-	msgs, _, _ = s.ChannelSubscribe(ctx, "shared", store.MemoryScopeAgent, "agent-b", "", 10)
+	msgs, _, _ = s.ChannelSubscribe(ctx, "", "shared", store.MemoryScopeAgent, "agent-b", "", 10)
 	if len(msgs) != 1 || !jsonEqual(msgs[0].Payload, `{"from":"b"}`) {
 		t.Errorf("agent-b sees: %+v, want only its own message", msgs)
+	}
+}
+
+// testChannelTenantIsolation pins the tenant axis (migration 0066): two
+// tenants using the SAME (channel, scope, scope_id) never see each other's
+// messages or cursors, the runtime def table is keyed per tenant, deleting
+// one tenant's channel leaves another tenant's same-named channel intact,
+// and the `global` scope stays a single cross-tenant keyspace. Fails on the
+// pre-0066 tenant-blind store (every read would leak across tenants).
+func testChannelTenantIsolation(t *testing.T, s store.Store) {
+	ctx := context.Background()
+
+	// ---- message-plane isolation: same (channel, scope, scope_id), two tenants
+	if _, _, err := s.ChannelPublish(ctx, store.ChannelMessage{
+		Channel: "t-iso", TenantID: "t1", Scope: store.MemoryScopeAgent, ScopeID: "x",
+		Payload: json.RawMessage(`{"t":"1"}`),
+	}, 0); err != nil {
+		t.Fatalf("publish t1: %v", err)
+	}
+	if _, _, err := s.ChannelPublish(ctx, store.ChannelMessage{
+		Channel: "t-iso", TenantID: "t2", Scope: store.MemoryScopeAgent, ScopeID: "x",
+		Payload: json.RawMessage(`{"t":"2"}`),
+	}, 0); err != nil {
+		t.Fatalf("publish t2: %v", err)
+	}
+	m1, _, _ := s.ChannelSubscribe(ctx, "t1", "t-iso", store.MemoryScopeAgent, "x", "", 10)
+	if len(m1) != 1 || !jsonEqual(m1[0].Payload, `{"t":"1"}`) {
+		t.Errorf("t1 sees %+v, want only its own message (no cross-tenant leak)", m1)
+	}
+	m2, next2, _ := s.ChannelSubscribe(ctx, "t2", "t-iso", store.MemoryScopeAgent, "x", "", 10)
+	if len(m2) != 1 || !jsonEqual(m2[0].Payload, `{"t":"2"}`) {
+		t.Errorf("t2 sees %+v, want only its own message (no cross-tenant leak)", m2)
+	}
+
+	// ---- cursor-plane isolation: t2 acks; t1's committed cursor is untouched
+	if err := s.ChannelAck(ctx, "t2", "t-iso", store.MemoryScopeAgent, "x", next2); err != nil {
+		t.Fatalf("ack t2: %v", err)
+	}
+	c1, _ := s.ChannelCommittedCursor(ctx, "t1", "t-iso", store.MemoryScopeAgent, "x")
+	if c1 != "" {
+		t.Errorf("t1 committed cursor = %q after t2 ack, want empty (cursors are per-tenant)", c1)
+	}
+
+	// ---- def-plane isolation: both tenants own a same-named channel independently
+	if err := s.ChannelsCreate(ctx, store.ChannelRow{Name: "dup", TenantID: "t1", Scope: "agent", Semantic: "queue"}); err != nil {
+		t.Fatalf("create dup t1: %v", err)
+	}
+	if err := s.ChannelsCreate(ctx, store.ChannelRow{Name: "dup", TenantID: "t2", Scope: "user", Semantic: "queue"}); err != nil {
+		t.Fatalf("create dup t2 (same name, different tenant must be allowed): %v", err)
+	}
+	var nf *store.ErrNotFound
+	if _, err := s.ChannelGet(ctx, "t3", "dup"); !errors.As(err, &nf) {
+		t.Errorf("ChannelGet(t3,dup) err = %v, want *store.ErrNotFound (cross-tenant def must be invisible)", err)
+	}
+	rowT1, err := s.ChannelGet(ctx, "t1", "dup")
+	if err != nil || rowT1.Scope != "agent" {
+		t.Errorf("ChannelGet(t1,dup) = %+v err=%v, want t1's own row (scope=agent)", rowT1, err)
+	}
+
+	// ---- delete-cascade isolation: deleting t1's channel keeps t2's messages
+	if err := s.ChannelsCreate(ctx, store.ChannelRow{Name: "del", TenantID: "t1", Scope: "agent", Semantic: "queue"}); err != nil {
+		t.Fatalf("create del t1: %v", err)
+	}
+	if err := s.ChannelsCreate(ctx, store.ChannelRow{Name: "del", TenantID: "t2", Scope: "agent", Semantic: "queue"}); err != nil {
+		t.Fatalf("create del t2: %v", err)
+	}
+	_, _, _ = s.ChannelPublish(ctx, store.ChannelMessage{Channel: "del", TenantID: "t1", Scope: store.MemoryScopeAgent, ScopeID: "y", Payload: json.RawMessage(`{}`)}, 0)
+	_, _, _ = s.ChannelPublish(ctx, store.ChannelMessage{Channel: "del", TenantID: "t2", Scope: store.MemoryScopeAgent, ScopeID: "y", Payload: json.RawMessage(`{}`)}, 0)
+	if err := s.ChannelsDelete(ctx, "t1", "del"); err != nil {
+		t.Fatalf("delete del t1: %v", err)
+	}
+	survivors, _, _ := s.ChannelSubscribe(ctx, "t2", "del", store.MemoryScopeAgent, "y", "", 10)
+	if len(survivors) != 1 {
+		t.Errorf("t2 del messages after t1 delete = %d, want 1 (cascade must be tenant-scoped)", len(survivors))
+	}
+
+	// ---- global scope is a single cross-tenant keyspace (tenant_id forced "")
+	if _, _, err := s.ChannelPublish(ctx, store.ChannelMessage{
+		Channel: "g", TenantID: "t1", Scope: store.MemoryScopeGlobal, ScopeID: "",
+		Payload: json.RawMessage(`{"g":true}`),
+	}, 0); err != nil {
+		t.Fatalf("publish global t1: %v", err)
+	}
+	// A different tenant reading the SAME global channel must see it — global
+	// is shared across tenants (operator/infra broadcast), unlike agent/user.
+	gmsgs, _, _ := s.ChannelSubscribe(ctx, "t2", "g", store.MemoryScopeGlobal, "", "", 10)
+	if len(gmsgs) != 1 || !jsonEqual(gmsgs[0].Payload, `{"g":true}`) {
+		t.Errorf("t2 global read = %+v, want t1's global message (global is cross-tenant)", gmsgs)
 	}
 }
 
@@ -5404,19 +5493,19 @@ func testChannelPurge(t *testing.T, s store.Store) {
 		}
 	}
 
-	n, err := s.ChannelPurge(ctx, "purge-ch")
+	n, err := s.ChannelPurge(ctx, "", "purge-ch")
 	if err != nil {
 		t.Fatalf("purge: %v", err)
 	}
 	if n != 3 {
 		t.Errorf("purge returned %d, want 3", n)
 	}
-	if msgs, _, _ := s.ChannelSubscribe(ctx, "purge-ch", store.MemoryScopeAgent, "x", "", 10); len(msgs) != 0 {
+	if msgs, _, _ := s.ChannelSubscribe(ctx, "", "purge-ch", store.MemoryScopeAgent, "x", "", 10); len(msgs) != 0 {
 		t.Errorf("post-purge msgs = %d, want 0 (queue drained)", len(msgs))
 	}
 
 	// Idempotent on an already-empty channel.
-	n2, err := s.ChannelPurge(ctx, "purge-ch")
+	n2, err := s.ChannelPurge(ctx, "", "purge-ch")
 	if err != nil {
 		t.Fatalf("purge empty: %v", err)
 	}
@@ -5424,7 +5513,7 @@ func testChannelPurge(t *testing.T, s store.Store) {
 		t.Errorf("purge empty returned %d, want 0", n2)
 	}
 	// Idempotent on a never-seen channel (existence is the caller's concern).
-	if n3, err := s.ChannelPurge(ctx, "never-existed"); err != nil || n3 != 0 {
+	if n3, err := s.ChannelPurge(ctx, "", "never-existed"); err != nil || n3 != 0 {
 		t.Errorf("purge unknown channel = (%d, %v), want (0, nil)", n3, err)
 	}
 
@@ -5435,7 +5524,7 @@ func testChannelPurge(t *testing.T, s store.Store) {
 	}, 0); err != nil {
 		t.Fatalf("publish after purge: %v", err)
 	}
-	if msgs, _, _ := s.ChannelSubscribe(ctx, "purge-ch", store.MemoryScopeAgent, "x", "", 10); len(msgs) != 1 {
+	if msgs, _, _ := s.ChannelSubscribe(ctx, "", "purge-ch", store.MemoryScopeAgent, "x", "", 10); len(msgs) != 1 {
 		t.Errorf("post-purge-republish msgs = %d, want 1", len(msgs))
 	}
 }
@@ -5447,10 +5536,10 @@ func testChannelPeekDoesNotConsume(t *testing.T, s store.Store) {
 		Payload: json.RawMessage(`{}`),
 	}, 0)
 	// Peek does not modify the committed cursor.
-	if msgs, err := s.ChannelPeek(ctx, "ch", store.MemoryScopeAgent, "x", "", 10); err != nil || len(msgs) != 1 || msgs[0].ID != id {
+	if msgs, err := s.ChannelPeek(ctx, "", "ch", store.MemoryScopeAgent, "x", "", 10); err != nil || len(msgs) != 1 || msgs[0].ID != id {
 		t.Fatalf("peek: msgs=%+v err=%v want one msg with id %q", msgs, err, id)
 	}
-	committed, err := s.ChannelCommittedCursor(ctx, "ch", store.MemoryScopeAgent, "x")
+	committed, err := s.ChannelCommittedCursor(ctx, "", "ch", store.MemoryScopeAgent, "x")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -5520,7 +5609,7 @@ func testChannelGetPointLookup(t *testing.T, s store.Store) {
 		t.Fatalf("ChannelsCreate: %v", err)
 	}
 
-	got, err := s.ChannelGet(ctx, "cg-point")
+	got, err := s.ChannelGet(ctx, "", "cg-point")
 	if err != nil {
 		t.Fatalf("ChannelGet(existing): %v", err)
 	}
@@ -5529,7 +5618,7 @@ func testChannelGetPointLookup(t *testing.T, s store.Store) {
 		t.Errorf("ChannelGet round-trip mismatch: %+v", got)
 	}
 
-	_, err = s.ChannelGet(ctx, "cg-absent")
+	_, err = s.ChannelGet(ctx, "", "cg-absent")
 	var nf *store.ErrNotFound
 	if !errors.As(err, &nf) {
 		t.Errorf("ChannelGet(missing): got %v (%T), want *store.ErrNotFound", err, err)
@@ -5546,13 +5635,13 @@ func testChannelReplayFromCursorZero(t *testing.T, s store.Store) {
 		time.Sleep(time.Microsecond)
 	}
 	// Drain + commit.
-	msgs, next, _ := s.ChannelSubscribe(ctx, "ch", store.MemoryScopeAgent, "x", "", 10)
+	msgs, next, _ := s.ChannelSubscribe(ctx, "", "ch", store.MemoryScopeAgent, "x", "", 10)
 	if len(msgs) != 3 {
 		t.Fatalf("drain: got %d, want 3", len(msgs))
 	}
-	_ = s.ChannelAck(ctx, "ch", store.MemoryScopeAgent, "x", next)
+	_ = s.ChannelAck(ctx, "", "ch", store.MemoryScopeAgent, "x", next)
 	// from_cursor=cur_0 replays everything regardless of committed.
-	msgs, _, _ = s.ChannelSubscribe(ctx, "ch", store.MemoryScopeAgent, "x", "cur_0", 10)
+	msgs, _, _ = s.ChannelSubscribe(ctx, "", "ch", store.MemoryScopeAgent, "x", "cur_0", 10)
 	if len(msgs) != 3 {
 		t.Errorf("replay: got %d, want 3 (cur_0 must ignore committed cursor)", len(msgs))
 	}
@@ -5576,7 +5665,7 @@ func testChannelDeferredHiddenUntilVisible(t *testing.T, s store.Store) {
 	if err != nil {
 		t.Fatalf("publish deferred: %v", err)
 	}
-	msgs, _, err := s.ChannelSubscribe(ctx, "ch", store.MemoryScopeAgent, "x", "", 10)
+	msgs, _, err := s.ChannelSubscribe(ctx, "", "ch", store.MemoryScopeAgent, "x", "", 10)
 	if err != nil {
 		t.Fatalf("immediate subscribe: %v", err)
 	}
@@ -5585,7 +5674,7 @@ func testChannelDeferredHiddenUntilVisible(t *testing.T, s store.Store) {
 	}
 	// Wait past visible_at, then verify it shows up.
 	time.Sleep(200 * time.Millisecond)
-	msgs, _, err = s.ChannelSubscribe(ctx, "ch", store.MemoryScopeAgent, "x", "", 10)
+	msgs, _, err = s.ChannelSubscribe(ctx, "", "ch", store.MemoryScopeAgent, "x", "", 10)
 	if err != nil {
 		t.Fatalf("post-visible subscribe: %v", err)
 	}
@@ -5618,7 +5707,7 @@ func testChannelDeferredDeliversAfterProgressedCursor(t *testing.T, s store.Stor
 		Payload: json.RawMessage(`"C"`),
 	}, 0)
 	// First subscribe: A and C only. B is not yet visible.
-	msgs, next, err := s.ChannelSubscribe(ctx, "ch", store.MemoryScopeAgent, "x", "", 10)
+	msgs, next, err := s.ChannelSubscribe(ctx, "", "ch", store.MemoryScopeAgent, "x", "", 10)
 	if err != nil {
 		t.Fatalf("page1: %v", err)
 	}
@@ -5629,7 +5718,7 @@ func testChannelDeferredDeliversAfterProgressedCursor(t *testing.T, s store.Stor
 		t.Errorf("page1 order = %s, %s; want A, C", msgs[0].Payload, msgs[1].Payload)
 	}
 	// Commit cursor past C.
-	if err := s.ChannelAck(ctx, "ch", store.MemoryScopeAgent, "x", next); err != nil {
+	if err := s.ChannelAck(ctx, "", "ch", store.MemoryScopeAgent, "x", next); err != nil {
 		t.Fatal(err)
 	}
 	// Wait past visible_at for B.
@@ -5638,7 +5727,7 @@ func testChannelDeferredDeliversAfterProgressedCursor(t *testing.T, s store.Stor
 	// msg_id is < C's. This is the (visible_at, id) tuple-ordering
 	// invariant that prevents silent skip-on-progress for deferred
 	// messages.
-	msgs, _, err = s.ChannelSubscribe(ctx, "ch", store.MemoryScopeAgent, "x", next, 10)
+	msgs, _, err = s.ChannelSubscribe(ctx, "", "ch", store.MemoryScopeAgent, "x", next, 10)
 	if err != nil {
 		t.Fatalf("page2: %v", err)
 	}
@@ -5667,7 +5756,7 @@ func testChannelDeferredTTLCountsFromPublished(t *testing.T, s store.Store) {
 	// expired AND become visible — the read-path filter should
 	// hide it because expires_at <= now.
 	time.Sleep(250 * time.Millisecond)
-	msgs, _, _ := s.ChannelSubscribe(ctx, "ch", store.MemoryScopeAgent, "x", "cur_0", 10)
+	msgs, _, _ := s.ChannelSubscribe(ctx, "", "ch", store.MemoryScopeAgent, "x", "cur_0", 10)
 	if len(msgs) != 0 {
 		t.Errorf("expired-before-visible delivered %d msgs, want 0", len(msgs))
 	}
@@ -5681,7 +5770,7 @@ func testChannelDeferredPastDeliverAtTreatedAsNow(t *testing.T, s store.Store) {
 		Payload:   json.RawMessage(`"past"`),
 		VisibleAt: time.Now().Add(-10 * time.Second),
 	}, 0)
-	msgs, _, _ := s.ChannelSubscribe(ctx, "ch", store.MemoryScopeAgent, "x", "", 10)
+	msgs, _, _ := s.ChannelSubscribe(ctx, "", "ch", store.MemoryScopeAgent, "x", "", 10)
 	if len(msgs) != 1 {
 		t.Errorf("past visible_at delivered %d, want 1", len(msgs))
 	}
@@ -5696,14 +5785,14 @@ func testChannelDeferredAckCommitsTupleCursor(t *testing.T, s store.Store) {
 		VisibleAt: deferTo,
 	}, 0)
 	time.Sleep(120 * time.Millisecond)
-	msgs, next, _ := s.ChannelSubscribe(ctx, "ch", store.MemoryScopeAgent, "x", "", 10)
+	msgs, next, _ := s.ChannelSubscribe(ctx, "", "ch", store.MemoryScopeAgent, "x", "", 10)
 	if len(msgs) != 1 {
 		t.Fatalf("subscribe len = %d, want 1", len(msgs))
 	}
-	if err := s.ChannelAck(ctx, "ch", store.MemoryScopeAgent, "x", next); err != nil {
+	if err := s.ChannelAck(ctx, "", "ch", store.MemoryScopeAgent, "x", next); err != nil {
 		t.Fatal(err)
 	}
-	committed, _ := s.ChannelCommittedCursor(ctx, "ch", store.MemoryScopeAgent, "x")
+	committed, _ := s.ChannelCommittedCursor(ctx, "", "ch", store.MemoryScopeAgent, "x")
 	if committed != next {
 		t.Errorf("committed = %q, want %q", committed, next)
 	}
@@ -5746,7 +5835,7 @@ func testChannelMaxMessagesTrimPreservesDeferred(t *testing.T, s store.Store) {
 
 	// Peek from cur_0 to see ALL non-expired rows regardless of
 	// visibility — we want to confirm B (deferred) is still there.
-	rows, err := s.ChannelPeek(ctx, "ch", store.MemoryScopeAgent, "x", "cur_0", 100)
+	rows, err := s.ChannelPeek(ctx, "", "ch", store.MemoryScopeAgent, "x", "cur_0", 100)
 	if err != nil {
 		t.Fatalf("peek: %v", err)
 	}
@@ -5810,7 +5899,7 @@ func testChannelPublishedByUserIDRoundTrip(t *testing.T, s store.Store) {
 		Payload:           json.RawMessage(`"hi"`),
 		PublishedByUserID: "alice",
 	}, 0)
-	msgs, _, _ := s.ChannelSubscribe(ctx, "ch", store.MemoryScopeAgent, "x", "", 10)
+	msgs, _, _ := s.ChannelSubscribe(ctx, "", "ch", store.MemoryScopeAgent, "x", "", 10)
 	if len(msgs) != 1 {
 		t.Fatalf("subscribe len = %d, want 1", len(msgs))
 	}

--- a/internal/tools/builtin/channel.go
+++ b/internal/tools/builtin/channel.go
@@ -228,6 +228,10 @@ func (c *Channel) resolveChannel(ctx context.Context, policy tools.ChannelPolicy
 	case "global":
 		// Single shared cursor for the channel — empty scope_id.
 		return def, store.MemoryScopeGlobal, "", nil
+	case "tenant":
+		// Tenant-scoped: shared across the whole tenant (scope_id ""),
+		// isolated from other tenants by the store's tenant_id column.
+		return def, store.MemoryScopeTenant, "", nil
 	default:
 		return tools.ChannelDef{}, "", "", fmt.Errorf("Channel tool: channel %q has unknown scope %q (operator config bug)", name, def.Scope)
 	}
@@ -359,6 +363,7 @@ func (c *Channel) storeAndNotify(ctx context.Context, channel string, def tools.
 
 	id, dropped, err := c.Store.ChannelPublish(ctx, store.ChannelMessage{
 		Channel:           channel,
+		TenantID:          tools.RunIdentity(ctx).TenantID, // RFC N: authoritative run tenant
 		Scope:             scope,
 		ScopeID:           scopeID,
 		Payload:           value,
@@ -481,6 +486,9 @@ func (c *Channel) execSubscribe(ctx context.Context, policy tools.ChannelPolicyV
 	if err != nil {
 		return errResult(err.Error()), nil
 	}
+	// RFC N: the authoritative run tenant, captured once so the long-poll
+	// read closure below uses the same value across retries.
+	tenantID := tools.RunIdentity(ctx).TenantID
 	limit := in.MaxMessages
 	if limit <= 0 {
 		limit = 10
@@ -492,7 +500,7 @@ func (c *Channel) execSubscribe(ctx context.Context, policy tools.ChannelPolicyV
 	// from_cursor precedence: explicit > committed.
 	from := in.FromCursor
 	if from == "" {
-		committed, err := c.Store.ChannelCommittedCursor(ctx, in.Channel, scope, scopeID)
+		committed, err := c.Store.ChannelCommittedCursor(ctx, tenantID, in.Channel, scope, scopeID)
 		if err != nil {
 			return errResult(fmt.Sprintf("subscribe: read committed cursor: %s", err)), nil
 		}
@@ -500,7 +508,7 @@ func (c *Channel) execSubscribe(ctx context.Context, policy tools.ChannelPolicyV
 	}
 
 	read := func() ([]store.ChannelMessage, string, error) {
-		return c.Store.ChannelSubscribe(ctx, in.Channel, scope, scopeID, from, limit)
+		return c.Store.ChannelSubscribe(ctx, tenantID, in.Channel, scope, scopeID, from, limit)
 	}
 
 	// Long-poll pattern: when long-poll is enabled, register the
@@ -637,7 +645,7 @@ func (c *Channel) execSubscribe(ctx context.Context, policy tools.ChannelPolicyV
 	// explicit `ack` once processing is durable. The two-step
 	// pattern is documented in docs/TOOLS.md.
 	if next != "" {
-		if err := c.Store.ChannelAck(ctx, in.Channel, scope, scopeID, next); err != nil {
+		if err := c.Store.ChannelAck(ctx, tenantID, in.Channel, scope, scopeID, next); err != nil {
 			// Cursor regression on auto-commit is impossible by
 			// construction (we just read this cursor in the same
 			// txn, so it's always >= the previous committed value).
@@ -817,6 +825,11 @@ func (c *Channel) execAwait(ctx context.Context, policy tools.ChannelPolicyValue
 		limit = 100
 	}
 
+	// RFC N: capture the run tenant ONCE here so the read closures below
+	// (and the long-poll re-read) all use the same authoritative value —
+	// never re-derive tenant inside a closure from a possibly-different ctx.
+	tenantID := tools.RunIdentity(ctx).TenantID
+
 	// Resolve + dedup every channel up front. Each goes through the
 	// SUBSCRIBE ACL + scope resolution (resolveChannel side="subscribe"),
 	// so await can't read a channel the agent can't subscribe to, and
@@ -843,7 +856,7 @@ func (c *Channel) execAwait(ctx context.Context, policy tools.ChannelPolicyValue
 		}
 		from := in.FromCursor
 		if from == "" {
-			committed, err := c.Store.ChannelCommittedCursor(ctx, name, scope, scopeID)
+			committed, err := c.Store.ChannelCommittedCursor(ctx, tenantID, name, scope, scopeID)
 			if err != nil {
 				return errResult(fmt.Sprintf("await: read committed cursor for %q: %s", name, err)), nil
 			}
@@ -853,7 +866,7 @@ func (c *Channel) execAwait(ctx context.Context, policy tools.ChannelPolicyValue
 	}
 
 	readChan := func(st *chanState) error {
-		msgs, next, err := c.Store.ChannelSubscribe(ctx, st.name, st.scope, st.scopeID, st.from, limit)
+		msgs, next, err := c.Store.ChannelSubscribe(ctx, tenantID, st.name, st.scope, st.scopeID, st.from, limit)
 		if err != nil {
 			return err
 		}
@@ -966,7 +979,7 @@ func (c *Channel) execAwait(ctx context.Context, policy tools.ChannelPolicyValue
 				diag.poolTotal, diag.poolAcquired, diag.poolIdle = c.PoolStatsFn()
 			}
 			msgs, next, err := readWithRetry(func() ([]store.ChannelMessage, string, error) {
-				return c.Store.ChannelSubscribe(ctx, st.name, st.scope, st.scopeID, st.from, limit)
+				return c.Store.ChannelSubscribe(ctx, tenantID, st.name, st.scope, st.scopeID, st.from, limit)
 			}, st.name, diag)
 			if err != nil {
 				return errResult(fmt.Sprintf("await: read %q (after wake): %s", st.name, err)), nil
@@ -1024,7 +1037,8 @@ func (c *Channel) execAck(ctx context.Context, policy tools.ChannelPolicyValue, 
 	if in.Cursor == "" {
 		return errResult("ack: missing required field: cursor"), nil
 	}
-	if err := c.Store.ChannelAck(ctx, in.Channel, scope, scopeID, in.Cursor); err != nil {
+	tenantID := tools.RunIdentity(ctx).TenantID // RFC N: authoritative run tenant
+	if err := c.Store.ChannelAck(ctx, tenantID, in.Channel, scope, scopeID, in.Cursor); err != nil {
 		if errors.Is(err, store.ErrChannelCursorRegression) {
 			return errResult(fmt.Sprintf("ack: %s", err)), nil
 		}
@@ -1045,8 +1059,9 @@ func (c *Channel) execPeek(ctx context.Context, policy tools.ChannelPolicyValue,
 	if limit > 100 {
 		limit = 100
 	}
-	from := in.FromCursor // peek defaults to cur_0 (replay) when caller omits.
-	msgs, err := c.Store.ChannelPeek(ctx, in.Channel, scope, scopeID, from, limit)
+	from := in.FromCursor                       // peek defaults to cur_0 (replay) when caller omits.
+	tenantID := tools.RunIdentity(ctx).TenantID // RFC N: authoritative run tenant
+	msgs, err := c.Store.ChannelPeek(ctx, tenantID, in.Channel, scope, scopeID, from, limit)
 	if err != nil {
 		return errResult(fmt.Sprintf("peek: %s", err)), nil
 	}

--- a/internal/tools/builtin/channel_test.go
+++ b/internal/tools/builtin/channel_test.go
@@ -490,7 +490,7 @@ func TestChannelTool_PublishedByUserIDFromCtx(t *testing.T) {
 		t.Fatalf("publish: %s", res.Text)
 	}
 	// Read back via subscribe + verify the store's row carries user_id.
-	msgs, _, err := tool.Store.ChannelSubscribe(ctx, "findings", store.MemoryScopeAgent, "researcher", "", 10)
+	msgs, _, err := tool.Store.ChannelSubscribe(ctx, "", "findings", store.MemoryScopeAgent, "researcher", "", 10)
 	if err != nil || len(msgs) != 1 {
 		t.Fatalf("read back: msgs=%d err=%v", len(msgs), err)
 	}

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -4320,7 +4320,8 @@ func (d *Document) publishChange(ctx context.Context, mscope store.MemoryScope, 
 	// subscriber/declared channel must never fail a chunk mutation. The Web UI
 	// subscriber arrives in a later phase.
 	_, _, _ = d.Store.ChannelPublish(ctx, store.ChannelMessage{
-		Channel: channel, Scope: mscope, ScopeID: scopeID, Payload: payload,
+		Channel: channel, TenantID: tools.RunIdentity(ctx).TenantID, // RFC N: authoritative run tenant
+		Scope: mscope, ScopeID: scopeID, Payload: payload,
 		PublishedByUserID: tools.RunIdentity(ctx).UserID,
 	}, 256)
 	d.Bus.Notify(channel)

--- a/internal/tools/builtin/interruption.go
+++ b/internal/tools/builtin/interruption.go
@@ -305,6 +305,7 @@ func (it *Interruption) execAsk(ctx context.Context, policy tools.InterruptionPo
 		_, _ = it.SystemPublisher.PublishNow(
 			ctx,
 			"_system/interrupts/pending",
+			ident.TenantID, // RFC N: authoritative run tenant
 			store.MemoryScopeUser, ident.UserID,
 			payload, channels.SystemPublisherUserID,
 			0, // maxMessages — operator yaml configures
@@ -499,6 +500,7 @@ func (it *Interruption) execNotify(ctx context.Context, policy tools.Interruptio
 		_, _ = it.SystemPublisher.PublishNow(
 			ctx,
 			"_system/interrupts/pending",
+			ident.TenantID, // RFC N: authoritative run tenant
 			store.MemoryScopeUser, ident.UserID,
 			payload, channels.SystemPublisherUserID, 0, 0,
 		)

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -48,10 +48,11 @@ const SIDEBAR_KEY = "loomcycle.sidebar.collapsed";
 // memory (/v1/_memory/*) is "tenant": RFC BL gave memory rows a tenant_id, every
 // handler sources the tenant from the principal (a tenant operator sees only its
 // own tenant's memory), and RFC BV re-gated the routes to ScopeTenant — so the
-// item lights up for a tenant operator. channels (/v1/_channels) DELIBERATELY
-// stays "admin": its store rows still carry no tenant column, so the routes are
-// pinned to ScopeAdmin (the /v1/_* catch-all) and a tenant token would 403.
-// Revisit channels when it gains a tenant axis (a schema migration, its own RFC).
+// item lights up for a tenant operator. channels (/v1/_channels) is now "tenant"
+// too: migration 0066 gave channel_messages/_cursors/channels a tenant_id, the
+// handlers source the tenant from the principal (list filters by tenant; the
+// cross-tenant `global` scope stays admin-only to create), and the routes were
+// re-gated to ScopeTenant — closing the earlier admin-only carve-out.
 type Visibility = "all" | "tenant" | "admin";
 interface NavItem {
   to: string;
@@ -66,7 +67,7 @@ const NAV_ITEMS: NavItem[] = [
   { to: "/integrations/webhooks", label: "integrations", Icon: Plug, vis: "tenant" },
   { to: "/volumes/persistent", label: "volumes", Icon: HardDrive, vis: "tenant" },
   { to: "/paths", label: "paths", Icon: FolderTree, vis: "tenant" },
-  { to: "/channels", label: "channels", Icon: Radio, vis: "admin" },
+  { to: "/channels", label: "channels", Icon: Radio, vis: "tenant" },
   { to: "/schedules", label: "schedules", Icon: CalendarClock, vis: "tenant" },
   { to: "/teams", label: "teams", Icon: Workflow, vis: "tenant" },
   { to: "/interrupts", label: "interrupts", Icon: Bell, vis: "tenant" },


### PR DESCRIPTION
## Why

Channels were the last first-class primitive whose store rows were **tenant-blind**. `channel_messages` / `channel_cursors` / the `channels` def table keyed on `(channel, scope, scope_id)` / `name` with **no `tenant_id`**, and the in-band tool resolved `scope_id` to the *bare* agent name / user subject — so two tenants running a same-named agent collided on one global keyspace, and two tenants couldn't each own a channel of the same name. That's why the admin routes stayed pinned to `substrate:admin` and the Web UI kept channels admin-only.

This is the first implementation step of the unified-scoping direction: it brings channels onto the `(tenant_id, scope, scope_id)` house pattern that memory / paths / credentials / limits already use, and re-gates the surface to `substrate:tenant` so a tenant operator can manage its own channels.

## What

- **Migration 0066 (postgres) + sqlite DDL/ALTER/index:** add `tenant_id NOT NULL DEFAULT ''` to all three channel tables, lead every PK/index with it, backfill existing rows to the shared tenant `""`. No FK-lockstep (the channel tables carry no FK). SQLite upgraded DBs keep the old PK (can't rewrite in place); a `uniq_channel_cursors_tenant` index backs the ack `ON CONFLICT` on both fresh + upgraded DBs.
- **Store:** thread `tenantID` through every `Channel*` method (both backends) + snapshot read/restore; `TenantID` added to `ChannelMessage` / `ChannelRow` / `ChannelStats` / `ChannelCursorEntry` (json `omitempty` → single-tenant wire + snapshot bytes unchanged).
- **`global` is a single cross-tenant keyspace:** `store.ChannelScopeTenant` forces `tenant_id=""` for `scope=global` everywhere — an unbreakable invariant so a tenant agent / legacy operator can't desync from operator+infra publishes (e.g. heartbeats). `user`/`agent`/`tenant` are tenant-partitioned. A new `tenant` scope (per-tenant shared) is accepted by the tool + connector.
- **Stamping (trust boundary):** the in-band tool derives the tenant from `RunIdentity(ctx)`; the wire (connector / admin handlers / n8n / library) from `tenantFromCtx(ctx)`; the scheduler + webhook on-complete publishes from the owning def's tenant — **never** from a request body or model text.
- **Guards:** runtime creation of a `global`-scoped channel now requires admin scope (a tenant operator uses `tenant|user|agent`, all confined to its tenant); purge/delete resolve the channel's declared scope so a global channel's `""` messages are actually drained and the delete cascade is scope-correct.
- **Routes + UI:** `/v1/_channels` re-gated off the `/v1/_*` catch-all to `substrate:tenant` (handlers source the tenant from the principal + list filters by tenant; admin still sees all). Web UI channels nav flipped `admin` → `tenant`.

## What was tested

- **`storetest` `ChannelTenantIsolation` (new)** — message + cursor + def isolation, same-name-per-tenant, tenant-scoped delete cascade, and global-is-cross-tenant; green on **both sqlite and postgres**.
- `auth_principal_test` `requiredScopeFor` asserts the `/v1/_channels` family is now `ScopeTenant`; `channels_crud` / `system_channels` / `library_admin` tests aligned to the authoritative principal tenant.
- `go test ./...` clean; `make build-all` clean.
- Manual: booted on sqlite (0066 applied clean at boot), then curl list / publish / subscribe round-trip on a yaml-global + a runtime channel, plus admin creation of a global runtime channel.

## Notes / follow-ups

- Adapters (gRPC/TS/Python) need **no** change: the tenant is server-derived (never a request field) and `tenant_id` on returned messages is additive `omitempty`. No wire break.
- On an **upgrade**, pre-existing channel rows backfill to `""`; authed (legacy-token) access resolves tenant `"default"`, so pre-upgrade messages aren't visible to post-upgrade authed reads. Channels are ephemeral (TTL/capped), so no repair step is provided — this mirrors the memory tenant-axis migration.
- Same-named **runtime** `global` channels across tenants share the `""` message keyspace by design (global = operator broadcast); runtime `global` creation is admin-gated to keep this operator-sanctioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)