### PR TITLE
fix(concurrency): tenant-qualify the per-user concurrency cap

### DIFF
--- a/internal/api/http/embeddings_compat.go
+++ b/internal/api/http/embeddings_compat.go
@@ -101,7 +101,7 @@ func (s *Server) handleEmbeddings(w http.ResponseWriter, r *http.Request) {
 	// present; the wire user is the open/un-authed fallback. Empty
 	// key bypasses the per-user cap. Mirrors the chat-completions
 	// gateway exactly.
-	release, err := s.sem.AcquireForUser(r.Context(), auth.SubjectForFairness(r.Context(), req.User))
+	release, err := s.sem.AcquireForUser(r.Context(), tenantFromCtx(r.Context()), auth.SubjectForFairness(r.Context(), req.User))
 	if err != nil {
 		writeQuotaError(w, err)
 		return

--- a/internal/api/http/llm_gateway.go
+++ b/internal/api/http/llm_gateway.go
@@ -159,7 +159,7 @@ func (s *Server) prepareGatewayDispatch(w http.ResponseWriter, r *http.Request, 
 	// (a caller can't forge a different user_id to dodge their cap); the
 	// wire user_id is only the fallback for open / un-authed mode. Empty
 	// key bypasses the per-user cap (global semaphore only).
-	release, err := s.sem.AcquireForUser(r.Context(), auth.SubjectForFairness(r.Context(), req.UserID))
+	release, err := s.sem.AcquireForUser(r.Context(), tenantFromCtx(r.Context()), auth.SubjectForFairness(r.Context(), req.UserID))
 	if err != nil {
 		provRelease()
 		writeQuotaError(w, err)

--- a/internal/api/http/metrics_prom_test.go
+++ b/internal/api/http/metrics_prom_test.go
@@ -75,7 +75,7 @@ func TestMetricsProm_EmitsExpectedSeries(t *testing.T) {
 func TestMetricsProm_PerUserSeriesOnlyWhenCapEnabled(t *testing.T) {
 	srv := newMetricsPromServer(t, true)
 	// Acquire a slot for a specific user_id so PerUser is populated.
-	rel, err := srv.sem.AcquireForUser(t.Context(), "alice")
+	rel, err := srv.sem.AcquireForUser(t.Context(), "", "alice")
 	if err != nil {
 		t.Fatalf("AcquireForUser failed: %v", err)
 	}

--- a/internal/api/http/resume.go
+++ b/internal/api/http/resume.go
@@ -421,7 +421,7 @@ func (s *Server) resumePausedRun(ctx context.Context, run store.Run) error {
 		// Respect the per-tenant fairness semaphore so a boot that resumes many
 		// runs doesn't blow past MAX_CONCURRENT_RUNS. Acquired inside the
 		// goroutine so the caller's resume loop never blocks.
-		release, aerr := s.sem.AcquireForUser(runCtx, run.UserID)
+		release, aerr := s.sem.AcquireForUser(runCtx, run.TenantID, run.UserID)
 		if aerr != nil {
 			s.finishRunFailedReason(run.ID, "resume: acquire run slot: "+aerr.Error(), meta)
 			return

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2252,7 +2252,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 
 	// ---- Concurrency slot ----
 	acquireStart := time.Now()
-	release, err := s.sem.AcquireForUser(ctx, effectiveUserID)
+	release, err := s.sem.AcquireForUser(ctx, tenantFromCtx(ctx), effectiveUserID)
 	queueWait := time.Since(acquireStart)
 	if err != nil {
 		if concurrency.IsPerUserQuotaExhausted(err) {
@@ -3732,7 +3732,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	// Acquire concurrency slot first so backpressure is reported as 429
 	// before we open the SSE stream.
 	acquireStart := time.Now()
-	release, err := s.sem.AcquireForUser(r.Context(), req.UserID)
+	release, err := s.sem.AcquireForUser(r.Context(), tenantFromCtx(r.Context()), req.UserID)
 	queueWait := time.Since(acquireStart)
 	if err != nil {
 		writeQuotaError(w, err)
@@ -4392,7 +4392,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	// is reported as 429. user_id comes from the session (set at original
 	// creation); continuations don't accept a new user_id.
 	acquireStart := time.Now()
-	release, err := s.sem.AcquireForUser(r.Context(), sess.UserID)
+	release, err := s.sem.AcquireForUser(r.Context(), tenantFromCtx(r.Context()), sess.UserID)
 	queueWait := time.Since(acquireStart)
 	if err != nil {
 		writeQuotaError(w, err)

--- a/internal/concurrency/peruser_race_test.go
+++ b/internal/concurrency/peruser_race_test.go
@@ -31,7 +31,7 @@ func TestAcquireForUser_NoRaceWithCapSet(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for j := 0; j < 300; j++ {
-				rel, err := s.AcquireForUser(context.Background(), "u")
+				rel, err := s.AcquireForUser(context.Background(), "", "u")
 				if err == nil && rel != nil {
 					rel()
 				}

--- a/internal/concurrency/semaphore.go
+++ b/internal/concurrency/semaphore.go
@@ -36,12 +36,16 @@ func (e *BackpressureError) Code() string { return "backpressure" }
 // strategy differs — backpressure is operator-wide load, per-user
 // quota is "you specifically need to wait."
 type ErrPerUserQuotaExhausted struct {
-	UserID string
-	Cap    int
+	TenantID string
+	UserID   string
+	Cap      int
 }
 
 func (e *ErrPerUserQuotaExhausted) Error() string {
-	return fmt.Sprintf("per-user quota exhausted: user=%s cap=%d", e.UserID, e.Cap)
+	if e.TenantID == "" {
+		return fmt.Sprintf("per-user quota exhausted: user=%s cap=%d", e.UserID, e.Cap)
+	}
+	return fmt.Sprintf("per-user quota exhausted: tenant=%s user=%s cap=%d", e.TenantID, e.UserID, e.Cap)
 }
 
 // Code is the typed identifier used in the HTTP error envelope.
@@ -56,9 +60,22 @@ func (e *ErrPerUserQuotaExhausted) Code() string { return "per_user_quota_exhaus
 // TryAcquire returns (acquired, err). false+nil = the user is at cap;
 // false+non-nil = infrastructure error (DB unreachable, etc).
 type userQuotaGate interface {
-	TryAcquire(ctx context.Context, userID string, cap int) (bool, error)
-	Release(ctx context.Context, userID string)
+	TryAcquire(ctx context.Context, tenantID, userID string, cap int) (bool, error)
+	Release(ctx context.Context, tenantID, userID string)
 	Snapshot(ctx context.Context) (map[string]int, error)
+}
+
+// userKey is the per-user fairness identity: a (tenant, user) pair, so
+// same-named subjects in different tenants get independent caps. It
+// replaces the bare user_id the counter keyed on before — a single value
+// still threads through the accounting (map key, release, cancel), just
+// as a struct instead of a string. tenant=="" is the shared/legacy tenant
+// (single-tenant / open mode), for which the fairness identity collapses
+// back to the bare user (see fairnessDisplayKey), keeping that path
+// byte-identical to the pre-tenant behaviour.
+type userKey struct {
+	tenant string
+	user   string
 }
 
 // Semaphore caps concurrent acquisitions. Acquire blocks (with timeout) when
@@ -82,7 +99,7 @@ type Semaphore struct {
 	// untouched — the DB-backed counter is authoritative. Single-
 	// replica deployments (quotaStore == nil) use perUser exactly as
 	// v0.10.1 did.
-	perUser map[string]int
+	perUser map[userKey]int
 	waiters []chan struct{}
 
 	// quotaStore is the v0.12.1 cluster-wide per-user counter. Nil in
@@ -154,7 +171,7 @@ func (s *Semaphore) WithUserQuotaStore(qs userQuotaGate) *Semaphore {
 // accounting. Existing call sites that don't care about per-tenant
 // fairness keep using this entry point.
 func (s *Semaphore) Acquire(ctx context.Context) (release func(), err error) {
-	return s.AcquireForUser(ctx, "")
+	return s.AcquireForUser(ctx, "", "")
 }
 
 // AcquireForUser is Acquire with a per-user cap layered on top. When
@@ -170,7 +187,13 @@ func (s *Semaphore) Acquire(ctx context.Context) (release func(), err error) {
 // 429 + Retry-After: 5). On global-queue rejection or timeout,
 // returns *BackpressureError (HTTP 429). On ctx cancel, returns
 // ctx.Err().
-func (s *Semaphore) AcquireForUser(ctx context.Context, userID string) (release func(), err error) {
+func (s *Semaphore) AcquireForUser(ctx context.Context, tenantID, userID string) (release func(), err error) {
+	// The per-user cap is keyed on the (tenant, user) pair so same-named
+	// subjects in different tenants don't share a counter (migration 0067).
+	// tenant=="" collapses to the bare-user behaviour (single-tenant / open
+	// mode), keeping that path byte-identical.
+	key := userKey{tenant: tenantID, user: userID}
+
 	// v0.12.1: snapshot the quotaStore reference (and cap) outside the
 	// global-state mutex so the cluster-mode DB round-trip doesn't hold
 	// s.mu. Capturing here means a concurrent WithUserQuotaStore call
@@ -184,18 +207,18 @@ func (s *Semaphore) AcquireForUser(ctx context.Context, userID string) (release 
 	cap := s.maxPerUser
 	s.mu.Unlock()
 
-	perUserActive := cap > 0 && userID != ""
+	perUserActive := cap > 0 && key.user != ""
 
 	// Cluster mode: acquire the per-user quota slot FIRST via the DB.
 	// On any later rejection (global-queue full, timeout, cancel), we
 	// compensate-Release so the cluster-wide count stays balanced.
 	if perUserActive && qs != nil {
-		ok, qerr := qs.TryAcquire(ctx, userID, cap)
+		ok, qerr := qs.TryAcquire(ctx, key.tenant, key.user, cap)
 		if qerr != nil {
 			return nil, fmt.Errorf("user_quotas acquire: %w", qerr)
 		}
 		if !ok {
-			return nil, &ErrPerUserQuotaExhausted{UserID: userID, Cap: cap}
+			return nil, &ErrPerUserQuotaExhausted{TenantID: key.tenant, UserID: key.user, Cap: cap}
 		}
 	}
 
@@ -205,30 +228,30 @@ func (s *Semaphore) AcquireForUser(ctx context.Context, userID string) (release 
 	// skip this block — perUser stays untouched.
 	if perUserActive && qs == nil {
 		if s.perUser == nil {
-			s.perUser = map[string]int{}
+			s.perUser = map[userKey]int{}
 		}
 		// Use the locked snapshot `cap` (not s.maxPerUser) — consistent with the
 		// perUserActive gate above, and the error is built AFTER Unlock so a bare
 		// s.maxPerUser read there would be a data race with WithPerUserCap.
-		if s.perUser[userID] >= cap {
+		if s.perUser[key] >= cap {
 			s.mu.Unlock()
-			return nil, &ErrPerUserQuotaExhausted{UserID: userID, Cap: cap}
+			return nil, &ErrPerUserQuotaExhausted{TenantID: key.tenant, UserID: key.user, Cap: cap}
 		}
 	}
 
 	if s.active < s.maxConcurrent {
 		s.active++
 		if perUserActive && qs == nil {
-			s.perUser[userID]++
+			s.perUser[key]++
 		}
 		s.mu.Unlock()
-		return s.releaseFn(userID, qs), nil
+		return s.releaseFn(key, qs), nil
 	}
 	if s.queued >= s.maxQueue {
 		s.mu.Unlock()
 		// Cluster mode: compensate-Release the DB slot we just took.
 		if perUserActive && qs != nil {
-			go releaseInBackground(qs, userID)
+			go releaseInBackground(qs, key)
 		}
 		return nil, &BackpressureError{msg: "queue full"}
 	}
@@ -236,7 +259,7 @@ func (s *Semaphore) AcquireForUser(ctx context.Context, userID string) (release 
 	s.waiters = append(s.waiters, w)
 	s.queued++
 	if perUserActive && qs == nil {
-		s.perUser[userID]++
+		s.perUser[key]++
 	}
 	s.mu.Unlock()
 
@@ -249,12 +272,12 @@ func (s *Semaphore) AcquireForUser(ctx context.Context, userID string) (release 
 		// already promoted us (queued--; active++). Our perUser count
 		// (or DB slot) stays the same — increment happened at enqueue,
 		// decrement happens at release.
-		return s.releaseFn(userID, qs), nil
+		return s.releaseFn(key, qs), nil
 	case <-ctx.Done():
-		s.cancelWaiter(w, userID, qs)
+		s.cancelWaiter(w, key, qs)
 		return nil, ctx.Err()
 	case <-timer.C:
-		s.cancelWaiter(w, userID, qs)
+		s.cancelWaiter(w, key, qs)
 		return nil, &BackpressureError{msg: "queue timeout"}
 	}
 }
@@ -265,10 +288,10 @@ func (s *Semaphore) AcquireForUser(ctx context.Context, userID string) (release 
 // in handler code expects fast return; the Release goroutine carries
 // its own bounded context so a permanently-down DB can't leak
 // goroutines indefinitely.
-func releaseInBackground(qs userQuotaGate, userID string) {
+func releaseInBackground(qs userQuotaGate, key userKey) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	qs.Release(ctx, userID)
+	qs.Release(ctx, key.tenant, key.user)
 }
 
 // Stats returns a snapshot for /metrics or admin views. The PerUser
@@ -286,7 +309,7 @@ func (s *Semaphore) Stats() Stats {
 	if qs == nil && len(s.perUser) > 0 {
 		out.PerUser = make(map[string]int, len(s.perUser))
 		for k, v := range s.perUser {
-			out.PerUser[k] = v
+			out.PerUser[fairnessDisplayKey(k.tenant, k.user)] = v
 		}
 	}
 	s.mu.Unlock()
@@ -312,14 +335,14 @@ func (s *Semaphore) Stats() Stats {
 // WithUserQuotaStore swap can't make a still-in-flight slot decrement
 // against the wrong gate. qs == nil means we used the in-memory path;
 // non-nil means the DB-backed Release fires in a goroutine.
-func (s *Semaphore) releaseFn(userID string, qs userQuotaGate) func() {
+func (s *Semaphore) releaseFn(key userKey, qs userQuotaGate) func() {
 	var once sync.Once
 	return func() {
 		once.Do(func() {
 			s.mu.Lock()
 			s.active--
 			if qs == nil {
-				s.decrementPerUser(userID)
+				s.decrementPerUser(key)
 			}
 			// Wake the next waiter if any. NOTE: the woken waiter's
 			// perUser count (or DB slot) stays as-is — its increment
@@ -339,14 +362,14 @@ func (s *Semaphore) releaseFn(userID string, qs userQuotaGate) func() {
 			// Cluster mode: DB Release after the mutex is released so
 			// the network round-trip doesn't block other Acquire
 			// callers. Background goroutine with a 5s timeout for safety.
-			if qs != nil && userID != "" {
-				go releaseInBackground(qs, userID)
+			if qs != nil && key.user != "" {
+				go releaseInBackground(qs, key)
 			}
 		})
 	}
 }
 
-func (s *Semaphore) cancelWaiter(target chan struct{}, userID string, qs userQuotaGate) {
+func (s *Semaphore) cancelWaiter(target chan struct{}, key userKey, qs userQuotaGate) {
 	s.mu.Lock()
 	needRelease := false
 	for i, w := range s.waiters {
@@ -354,13 +377,13 @@ func (s *Semaphore) cancelWaiter(target chan struct{}, userID string, qs userQuo
 			s.waiters = append(s.waiters[:i], s.waiters[i+1:]...)
 			s.queued--
 			if qs == nil {
-				s.decrementPerUser(userID)
+				s.decrementPerUser(key)
 			} else {
 				needRelease = true
 			}
 			s.mu.Unlock()
-			if needRelease && userID != "" {
-				go releaseInBackground(qs, userID)
+			if needRelease && key.user != "" {
+				go releaseInBackground(qs, key)
 			}
 			return
 		}
@@ -387,13 +410,13 @@ func (s *Semaphore) cancelWaiter(target chan struct{}, userID string, qs userQuo
 	case <-target:
 		s.active--
 		if qs == nil {
-			s.decrementPerUser(userID)
+			s.decrementPerUser(key)
 		} else {
 			needRelease = true
 		}
 		s.mu.Unlock()
-		if needRelease && userID != "" {
-			go releaseInBackground(qs, userID)
+		if needRelease && key.user != "" {
+			go releaseInBackground(qs, key)
 		}
 	default:
 		s.mu.Unlock()
@@ -406,14 +429,30 @@ func (s *Semaphore) cancelWaiter(target chan struct{}, userID string, qs userQuo
 // with Acquire's empty-userID path). Removes the entry when the count
 // hits zero so Stats().PerUser doesn't accumulate stale entries for
 // users no longer in flight.
-func (s *Semaphore) decrementPerUser(userID string) {
-	if userID == "" || s.perUser == nil {
+func (s *Semaphore) decrementPerUser(key userKey) {
+	if key.user == "" || s.perUser == nil {
 		return
 	}
-	s.perUser[userID]--
-	if s.perUser[userID] <= 0 {
-		delete(s.perUser, userID)
+	s.perUser[key]--
+	if s.perUser[key] <= 0 {
+		delete(s.perUser, key)
 	}
+}
+
+// fairnessDisplayKey renders a (tenant, user) pair as the single string
+// used as the map key in Stats().PerUser (the /v1/_concurrency/stats +
+// Prometheus per_user surface). tenant=="" renders as the bare user so
+// the single-tenant stats wire is byte-identical to the pre-tenant shape;
+// a real tenant renders as "tenant/user". DISPLAY ONLY — enforcement keys
+// on the userKey struct, so a "/" in an id can at worst merge two rows in
+// the display, never merge two caps. Kept identical to
+// coord.FairnessDisplayKey (the cluster-mode Snapshot path) so the stats
+// wire is the same across single-replica and cluster modes.
+func fairnessDisplayKey(tenantID, userID string) string {
+	if tenantID == "" {
+		return userID
+	}
+	return tenantID + "/" + userID
 }
 
 // IsBackpressure reports whether err is a BackpressureError.

--- a/internal/concurrency/semaphore_test.go
+++ b/internal/concurrency/semaphore_test.go
@@ -143,11 +143,11 @@ func TestSemaphoreNoLeakOnCancellationRace(t *testing.T) {
 // care about per-tenant fairness see no behavior change.
 func TestAcquireForUser_NoCapBehavesLikeAcquire(t *testing.T) {
 	s := New(2, 4, time.Second) // no WithPerUserCap call
-	r1, err := s.AcquireForUser(context.Background(), "user_a")
+	r1, err := s.AcquireForUser(context.Background(), "", "user_a")
 	if err != nil {
 		t.Fatal(err)
 	}
-	r2, err := s.AcquireForUser(context.Background(), "user_a")
+	r2, err := s.AcquireForUser(context.Background(), "", "user_a")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,7 +168,7 @@ func TestAcquireForUser_EmptyUserIDSkipsCheck(t *testing.T) {
 	s := New(10, 4, time.Second).WithPerUserCap(2)
 	// Three acquires with empty userID should all succeed.
 	for i := 0; i < 3; i++ {
-		r, err := s.AcquireForUser(context.Background(), "")
+		r, err := s.AcquireForUser(context.Background(), "", "")
 		if err != nil {
 			t.Fatalf("empty-userID acquire %d: %v", i, err)
 		}
@@ -185,19 +185,19 @@ func TestAcquireForUser_EmptyUserIDSkipsCheck(t *testing.T) {
 // quota.
 func TestAcquireForUser_CapRefusesAtLimit(t *testing.T) {
 	s := New(10, 4, time.Second).WithPerUserCap(2)
-	r1, err := s.AcquireForUser(context.Background(), "user_a")
+	r1, err := s.AcquireForUser(context.Background(), "", "user_a")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer r1()
-	r2, err := s.AcquireForUser(context.Background(), "user_a")
+	r2, err := s.AcquireForUser(context.Background(), "", "user_a")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer r2()
 
 	// Third acquire by user_a hits the cap.
-	_, err = s.AcquireForUser(context.Background(), "user_a")
+	_, err = s.AcquireForUser(context.Background(), "", "user_a")
 	if !IsPerUserQuotaExhausted(err) {
 		t.Errorf("third acquire: got %v, want *ErrPerUserQuotaExhausted", err)
 	}
@@ -213,7 +213,7 @@ func TestAcquireForUser_CapRefusesAtLimit(t *testing.T) {
 	}
 
 	// user_b is unaffected — independent quota.
-	r3, err := s.AcquireForUser(context.Background(), "user_b")
+	r3, err := s.AcquireForUser(context.Background(), "", "user_b")
 	if err != nil {
 		t.Errorf("user_b first acquire: %v", err)
 	} else {
@@ -236,7 +236,7 @@ func TestAcquireForUser_CapRefusesAtLimit(t *testing.T) {
 // entries for users no longer in flight).
 func TestAcquireForUser_ReleaseDecrementsPerUser(t *testing.T) {
 	s := New(10, 4, time.Second).WithPerUserCap(4)
-	r, _ := s.AcquireForUser(context.Background(), "user_a")
+	r, _ := s.AcquireForUser(context.Background(), "", "user_a")
 	if s.Stats().PerUser["user_a"] != 1 {
 		t.Fatalf("after acquire, expected 1; got %d", s.Stats().PerUser["user_a"])
 	}
@@ -256,7 +256,7 @@ func TestAcquireForUser_QueuedCountsAgainstCap(t *testing.T) {
 	s := New(1, 4, 100*time.Millisecond).WithPerUserCap(2)
 
 	// First acquire by user_a takes the active slot.
-	r1, err := s.AcquireForUser(context.Background(), "user_a")
+	r1, err := s.AcquireForUser(context.Background(), "", "user_a")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -266,14 +266,14 @@ func TestAcquireForUser_QueuedCountsAgainstCap(t *testing.T) {
 	// for user_a, exactly at cap). Run in a goroutine so we don't block.
 	queued := make(chan error, 1)
 	go func() {
-		_, err := s.AcquireForUser(context.Background(), "user_a")
+		_, err := s.AcquireForUser(context.Background(), "", "user_a")
 		queued <- err
 	}()
 	time.Sleep(20 * time.Millisecond) // let it enqueue
 
 	// Third acquire by user_a should be refused — user_a is at cap
 	// (1 active + 1 queued = 2).
-	_, err = s.AcquireForUser(context.Background(), "user_a")
+	_, err = s.AcquireForUser(context.Background(), "", "user_a")
 	if !IsPerUserQuotaExhausted(err) {
 		t.Errorf("third acquire: got %v, want per_user_quota_exhausted", err)
 	}
@@ -286,14 +286,14 @@ func TestAcquireForUser_QueuedCountsAgainstCap(t *testing.T) {
 // must decrement perUser, otherwise stale counts leak.
 func TestAcquireForUser_CancelDecrementsPerUser(t *testing.T) {
 	s := New(1, 4, time.Second).WithPerUserCap(2)
-	r1, _ := s.AcquireForUser(context.Background(), "user_a")
+	r1, _ := s.AcquireForUser(context.Background(), "", "user_a")
 	defer r1()
 
 	// user_a queues a second acquire, then cancels.
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		_, err := s.AcquireForUser(ctx, "user_a")
+		_, err := s.AcquireForUser(ctx, "", "user_a")
 		done <- err
 	}()
 	time.Sleep(20 * time.Millisecond)
@@ -312,24 +312,101 @@ func TestAcquireForUser_CancelDecrementsPerUser(t *testing.T) {
 	}
 }
 
+// TestSemaphore_PerUserCapIsolatedByTenant pins the tenant-aware keying: the
+// in-process per-user cap keys on the (tenant, user) pair, so "alice" in
+// tenant t1 and "alice" in tenant t2 hold INDEPENDENT caps. Under the prior
+// bare-user keying they shared one counter, so t2/alice would have been
+// refused while t1/alice held the only slot — this test fails against that
+// behaviour and passes now.
+//
+// Global capacity is large so the per-(tenant,user) cap of 1 — not the global
+// slot count — is always the limiting factor.
+func TestSemaphore_PerUserCapIsolatedByTenant(t *testing.T) {
+	s := New(100, 4, time.Second).WithPerUserCap(1)
+
+	// t1/alice takes its single slot.
+	r1, err := s.AcquireForUser(context.Background(), "t1", "alice")
+	if err != nil {
+		t.Fatalf("t1/alice first acquire: %v", err)
+	}
+
+	// t2/alice — same subject, different tenant — must succeed: independent cap.
+	r2, err := s.AcquireForUser(context.Background(), "t2", "alice")
+	if err != nil {
+		t.Fatalf("t2/alice acquire (independent tenant): %v", err)
+	}
+
+	// A second t1/alice acquire, while the first t1 slot is still held, is
+	// refused — the per-(tenant,user) cap of 1 is enforced WITHIN t1.
+	_, err = s.AcquireForUser(context.Background(), "t1", "alice")
+	if !IsPerUserQuotaExhausted(err) {
+		t.Errorf("second t1/alice acquire: got %v, want *ErrPerUserQuotaExhausted", err)
+	}
+
+	// Release t1's slot; a subsequent t1/alice acquire succeeds again.
+	r1()
+	r3, err := s.AcquireForUser(context.Background(), "t1", "alice")
+	if err != nil {
+		t.Errorf("t1/alice re-acquire after release: %v", err)
+	} else {
+		r3()
+	}
+	r2()
+}
+
+// TestSemaphore_SingleTenantPerUserUnchanged guards the backward-compat
+// claim: tenant "" is the shared/legacy tenant and must behave exactly like
+// the pre-tenant bare-user path — same cap enforcement, and Stats().PerUser
+// keyed by the bare user (fairnessDisplayKey("", user) == user), never a
+// tenant-prefixed "/user" key.
+func TestSemaphore_SingleTenantPerUserUnchanged(t *testing.T) {
+	s := New(10, 4, time.Second).WithPerUserCap(1)
+
+	r1, err := s.AcquireForUser(context.Background(), "", "alice")
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	defer r1()
+
+	// Second acquire by the same bare user is refused at cap=1.
+	_, err = s.AcquireForUser(context.Background(), "", "alice")
+	if !IsPerUserQuotaExhausted(err) {
+		t.Errorf("second acquire: got %v, want *ErrPerUserQuotaExhausted", err)
+	}
+
+	st := s.Stats()
+	if st.PerUser["alice"] != 1 {
+		t.Errorf("PerUser[alice] = %d, want 1 (bare-user display key)", st.PerUser["alice"])
+	}
+	if _, ok := st.PerUser["/alice"]; ok {
+		t.Errorf("PerUser must not carry a tenant-prefixed key for tenant \"\": %v", st.PerUser)
+	}
+}
+
 // ---- v0.12.1 cluster-mode (userQuotaGate) tests ----
 
 // stubQuotaGate is the in-process fake for the v0.12.1 DB-backed
 // per-user counter. Lets us test Semaphore's cluster-mode dispatch
 // without standing up Postgres.
 type stubQuotaGate struct {
-	mu       sync.Mutex
-	counts   map[string]int
+	mu sync.Mutex
+	// counts keys on the (tenant, user) pair — same as the production
+	// userQuotaGate now does — so same-named subjects in different tenants
+	// can be stubbed independently. tenant=="" collapses to bare-user
+	// behaviour, keeping the single-tenant assertions below unchanged.
+	counts   map[userKey]int
 	failNext bool
-	atCapFor map[string]bool // when true, TryAcquire returns false+nil for this user
+	// atCapFor is a tenant-agnostic test knob keyed by bare userID: when set,
+	// TryAcquire returns false+nil for that user regardless of tenant.
+	atCapFor map[string]bool
 	releases int
 }
 
 func newStubQuotaGate() *stubQuotaGate {
-	return &stubQuotaGate{counts: map[string]int{}, atCapFor: map[string]bool{}}
+	return &stubQuotaGate{counts: map[userKey]int{}, atCapFor: map[string]bool{}}
 }
 
-func (g *stubQuotaGate) TryAcquire(_ context.Context, userID string, _ int) (bool, error) {
+func (g *stubQuotaGate) TryAcquire(_ context.Context, tenantID, userID string, _ int) (bool, error) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	if g.failNext {
@@ -339,15 +416,16 @@ func (g *stubQuotaGate) TryAcquire(_ context.Context, userID string, _ int) (boo
 	if g.atCapFor[userID] {
 		return false, nil
 	}
-	g.counts[userID]++
+	g.counts[userKey{tenant: tenantID, user: userID}]++
 	return true, nil
 }
 
-func (g *stubQuotaGate) Release(_ context.Context, userID string) {
+func (g *stubQuotaGate) Release(_ context.Context, tenantID, userID string) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if g.counts[userID] > 0 {
-		g.counts[userID]--
+	k := userKey{tenant: tenantID, user: userID}
+	if g.counts[k] > 0 {
+		g.counts[k]--
 	}
 	g.releases++
 }
@@ -361,7 +439,9 @@ func (g *stubQuotaGate) Snapshot(_ context.Context) (map[string]int, error) {
 	out := make(map[string]int, len(g.counts))
 	for k, v := range g.counts {
 		if v > 0 {
-			out[k] = v
+			// Render display keys exactly as production Stats/Snapshot does,
+			// so tenant="" stays a bare user in the returned map.
+			out[fairnessDisplayKey(k.tenant, k.user)] = v
 		}
 	}
 	if len(out) == 0 {
@@ -370,10 +450,12 @@ func (g *stubQuotaGate) Snapshot(_ context.Context) (map[string]int, error) {
 	return out, nil
 }
 
+// count returns the active count for a single-tenant (tenant="") user — the
+// bare-user keying the existing assertions rely on.
 func (g *stubQuotaGate) count(userID string) int {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	return g.counts[userID]
+	return g.counts[userKey{user: userID}]
 }
 
 func (g *stubQuotaGate) releaseCount() int {
@@ -392,7 +474,7 @@ func TestSemaphore_ClusterMode_DelegatesToQuotaGate(t *testing.T) {
 	gate := newStubQuotaGate()
 	s := New(10, 10, time.Second).WithPerUserCap(3).WithUserQuotaStore(gate)
 
-	r, err := s.AcquireForUser(context.Background(), "alice")
+	r, err := s.AcquireForUser(context.Background(), "", "alice")
 	if err != nil {
 		t.Fatalf("acquire: %v", err)
 	}
@@ -401,7 +483,7 @@ func TestSemaphore_ClusterMode_DelegatesToQuotaGate(t *testing.T) {
 	}
 	// In-memory map must NOT be touched in cluster mode.
 	s.mu.Lock()
-	got := s.perUser["alice"]
+	got := s.perUser[userKey{user: "alice"}]
 	s.mu.Unlock()
 	if got != 0 {
 		t.Errorf("in-memory perUser[alice] = %d in cluster mode, want 0", got)
@@ -429,7 +511,7 @@ func TestSemaphore_ClusterMode_AtCapReturnsTypedError(t *testing.T) {
 	gate.atCapFor["alice"] = true
 	s := New(10, 10, time.Second).WithPerUserCap(3).WithUserQuotaStore(gate)
 
-	_, err := s.AcquireForUser(context.Background(), "alice")
+	_, err := s.AcquireForUser(context.Background(), "", "alice")
 	if !IsPerUserQuotaExhausted(err) {
 		t.Errorf("got %v, want *ErrPerUserQuotaExhausted", err)
 	}
@@ -462,7 +544,7 @@ func TestSemaphore_ClusterMode_QueueFullCompensateReleases(t *testing.T) {
 
 	// Second acquire (with userID) calls gate.TryAcquire successfully
 	// but then hits queue-full backpressure.
-	_, err = s.AcquireForUser(context.Background(), "alice")
+	_, err = s.AcquireForUser(context.Background(), "", "alice")
 	if !IsBackpressure(err) {
 		t.Fatalf("got %v, want *BackpressureError", err)
 	}
@@ -490,7 +572,7 @@ func TestSemaphore_ClusterMode_GateFailureWrapsError(t *testing.T) {
 	gate.failNext = true
 	s := New(10, 10, time.Second).WithPerUserCap(3).WithUserQuotaStore(gate)
 
-	_, err := s.AcquireForUser(context.Background(), "alice")
+	_, err := s.AcquireForUser(context.Background(), "", "alice")
 	if err == nil {
 		t.Fatal("expected error from gate failure")
 	}
@@ -507,7 +589,7 @@ func TestSemaphore_ClusterMode_StatsFromSnapshot(t *testing.T) {
 	gate := newStubQuotaGate()
 	s := New(10, 10, time.Second).WithPerUserCap(3).WithUserQuotaStore(gate)
 
-	r, _ := s.AcquireForUser(context.Background(), "alice")
+	r, _ := s.AcquireForUser(context.Background(), "", "alice")
 	defer r()
 
 	st := s.Stats()
@@ -540,7 +622,7 @@ func TestSemaphore_ClusterMode_QueuedWaiterWakesAndReleases(t *testing.T) {
 
 	done := make(chan func(), 1)
 	go func() {
-		r, err := s.AcquireForUser(context.Background(), "alice")
+		r, err := s.AcquireForUser(context.Background(), "", "alice")
 		if err != nil {
 			t.Errorf("queued acquire: %v", err)
 			done <- nil

--- a/internal/coord/replicas_sweeper.go
+++ b/internal/coord/replicas_sweeper.go
@@ -224,26 +224,37 @@ func (s *ReplicasSweeper) reapReplica(ctx context.Context, replicaID string) err
 // user_quotas decrement. Extracted from reapReplica so the
 // markedRuns > 0 gate stays clean.
 func (s *ReplicasSweeper) reapQuotas(ctx context.Context, replicaID string) error {
+	// Reconcile per (tenant_id, user_id): the counter is now keyed by the
+	// owning run's tenant (migration 0067), so the leaked-slot count must
+	// be grouped and decremented on the same pair — grouping by bare
+	// user_id would decrement the wrong tenant's row (or none) when two
+	// tenants share a subject.
+	// COALESCE(tenant_id, '') because runs.tenant_id is nullable (migration
+	// 0036) while user_quotas.tenant_id is NOT NULL DEFAULT '' (0067): a run
+	// with no tenant maps to the shared "" quota row. Without the coalesce a
+	// NULL run tenant would GROUP as NULL and the decrement's `tenant_id = $1`
+	// would never match (SQL NULL comparison), leaking the slot.
 	quotaRows, err := s.pool.Query(ctx, `
-		SELECT user_id, COUNT(*) AS leaked
+		SELECT COALESCE(tenant_id, '') AS tenant_id, user_id, COUNT(*) AS leaked
 		  FROM runs
 		 WHERE replica_id = $1
 		   AND status = 'failed'
 		   AND error = 'owner replica died'
 		   AND user_id IS NOT NULL AND user_id != ''
-		 GROUP BY user_id
+		 GROUP BY COALESCE(tenant_id, ''), user_id
 	`, replicaID)
 	if err != nil {
 		return fmt.Errorf("query quota reap: %w", err)
 	}
 	type reap struct {
-		userID string
-		leaked int
+		tenantID string
+		userID   string
+		leaked   int
 	}
 	var reaps []reap
 	for quotaRows.Next() {
 		var r reap
-		if err := quotaRows.Scan(&r.userID, &r.leaked); err != nil {
+		if err := quotaRows.Scan(&r.tenantID, &r.userID, &r.leaked); err != nil {
 			quotaRows.Close()
 			return fmt.Errorf("scan quota reap row: %w", err)
 		}
@@ -256,15 +267,15 @@ func (s *ReplicasSweeper) reapQuotas(ctx context.Context, replicaID string) erro
 	for _, r := range reaps {
 		_, qerr := s.pool.Exec(ctx, `
 			UPDATE user_quotas
-			   SET active_count = GREATEST(0, active_count - $2),
+			   SET active_count = GREATEST(0, active_count - $3),
 			       updated_at   = now()
-			 WHERE user_id = $1
-		`, r.userID, r.leaked)
+			 WHERE tenant_id = $1 AND user_id = $2
+		`, r.tenantID, r.userID, r.leaked)
 		if qerr != nil {
-			s.logf("coord: replicas sweep: quota decrement for user %s by %d: %v", r.userID, r.leaked, qerr)
+			s.logf("coord: replicas sweep: quota decrement for user %s/%s by %d: %v", r.tenantID, r.userID, r.leaked, qerr)
 			continue
 		}
-		s.logf("coord: replicas sweep: quota reap for user %s: decremented by %d", r.userID, r.leaked)
+		s.logf("coord: replicas sweep: quota reap for user %s/%s: decremented by %d", r.tenantID, r.userID, r.leaked)
 	}
 	return nil
 }

--- a/internal/coord/replicas_sweeper_test.go
+++ b/internal/coord/replicas_sweeper_test.go
@@ -55,16 +55,19 @@ func seedRun(t *testing.T, pool *pgxpool.Pool, runID, sessionID, replicaID, user
 
 func seedUserQuota(t *testing.T, pool *pgxpool.Pool, userID string, count int) {
 	t.Helper()
+	// Seed under the shared "" tenant (migration 0067 made the PK
+	// (tenant_id, user_id)); the seeded runs carry a NULL/empty tenant that
+	// the sweeper COALESCEs to "", so the reap decrements this row.
 	_, err := pool.Exec(context.Background(), `
-		INSERT INTO user_quotas (user_id, active_count, updated_at)
-		VALUES ($1, $2, now())
-		ON CONFLICT (user_id) DO UPDATE SET active_count = $2
+		INSERT INTO user_quotas (tenant_id, user_id, active_count, updated_at)
+		VALUES ('', $1, $2, now())
+		ON CONFLICT (tenant_id, user_id) DO UPDATE SET active_count = $2
 	`, userID, count)
 	if err != nil {
 		t.Fatalf("seed quota: %v", err)
 	}
 	t.Cleanup(func() {
-		_, _ = pool.Exec(context.Background(), `DELETE FROM user_quotas WHERE user_id = $1`, userID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM user_quotas WHERE tenant_id = '' AND user_id = $1`, userID)
 	})
 }
 
@@ -107,7 +110,7 @@ func TestReplicasSweeper_ReapsStaleReplica(t *testing.T) {
 	// Quota should be decremented.
 	var quotaCount int
 	_ = pool.QueryRow(context.Background(),
-		`SELECT active_count FROM user_quotas WHERE user_id = $1`, userID).Scan(&quotaCount)
+		`SELECT active_count FROM user_quotas WHERE tenant_id = '' AND user_id = $1`, userID).Scan(&quotaCount)
 	if quotaCount != 0 {
 		t.Errorf("quota = %d, want 0", quotaCount)
 	}
@@ -164,7 +167,7 @@ func TestReplicasSweeper_GreatestZeroClampOnQuota(t *testing.T) {
 	// Quota should stay at 0 (no CHECK violation, no underflow).
 	var quotaCount int
 	_ = pool.QueryRow(context.Background(),
-		`SELECT active_count FROM user_quotas WHERE user_id = $1`, userID).Scan(&quotaCount)
+		`SELECT active_count FROM user_quotas WHERE tenant_id = '' AND user_id = $1`, userID).Scan(&quotaCount)
 	if quotaCount != 0 {
 		t.Errorf("quota = %d, want 0 (GREATEST clamp)", quotaCount)
 	}

--- a/internal/coord/user_quota_store.go
+++ b/internal/coord/user_quota_store.go
@@ -70,23 +70,26 @@ func NewUserQuotaStore(pool *pgxpool.Pool) *UserQuotaStore {
 // The INSERT arm always fires for a new user_id (initial count = 1);
 // the UPDATE arm only fires when the existing count is strictly less
 // than cap. rows_affected discriminates the at-cap case.
-func (s *UserQuotaStore) TryAcquire(ctx context.Context, userID string, cap int) (bool, error) {
+func (s *UserQuotaStore) TryAcquire(ctx context.Context, tenantID, userID string, cap int) (bool, error) {
 	if userID == "" {
 		return false, errors.New("user_id is empty")
 	}
 	if cap <= 0 {
 		return false, fmt.Errorf("cap must be > 0 (got %d)", cap)
 	}
+	// Keyed on (tenant_id, user_id) so same-named subjects in different
+	// tenants get independent caps (migration 0067). tenant_id="" is the
+	// shared/legacy tenant — a single-tenant cluster behaves as before.
 	tag, err := s.pool.Exec(ctx, `
-		INSERT INTO user_quotas (user_id, active_count, updated_at)
-		VALUES ($1, 1, now())
-		ON CONFLICT (user_id) DO UPDATE
+		INSERT INTO user_quotas (tenant_id, user_id, active_count, updated_at)
+		VALUES ($1, $2, 1, now())
+		ON CONFLICT (tenant_id, user_id) DO UPDATE
 		  SET active_count = user_quotas.active_count + 1,
 		      updated_at   = now()
-		  WHERE user_quotas.active_count < $2
-	`, userID, cap)
+		  WHERE user_quotas.active_count < $3
+	`, tenantID, userID, cap)
 	if err != nil {
-		return false, fmt.Errorf("user_quotas upsert %s: %w", userID, err)
+		return false, fmt.Errorf("user_quotas upsert %s/%s: %w", tenantID, userID, err)
 	}
 	return tag.RowsAffected() > 0, nil
 }
@@ -103,7 +106,7 @@ func (s *UserQuotaStore) TryAcquire(ctx context.Context, userID string, cap int)
 // The row with count=0 is a tombstone that costs one Postgres row and
 // is harmless. Phase 5's sweeper can DELETE WHERE active_count = 0 if
 // row count ever becomes a concern.
-func (s *UserQuotaStore) Release(ctx context.Context, userID string) {
+func (s *UserQuotaStore) Release(ctx context.Context, tenantID, userID string) {
 	if userID == "" {
 		return
 	}
@@ -111,14 +114,14 @@ func (s *UserQuotaStore) Release(ctx context.Context, userID string) {
 		UPDATE user_quotas
 		   SET active_count = active_count - 1,
 		       updated_at   = now()
-		 WHERE user_id = $1 AND active_count > 0
-	`, userID)
+		 WHERE tenant_id = $1 AND user_id = $2 AND active_count > 0
+	`, tenantID, userID)
 	if err != nil {
-		log.Printf("coord: user_quotas release %s: %v", userID, err)
+		log.Printf("coord: user_quotas release %s/%s: %v", tenantID, userID, err)
 		return
 	}
 	if tag.RowsAffected() == 0 {
-		log.Printf("coord: user_quotas release %s: no-op (already at 0 — double-release or Phase 5 reap)", userID)
+		log.Printf("coord: user_quotas release %s/%s: no-op (already at 0 — double-release or Phase 5 reap)", tenantID, userID)
 	}
 }
 
@@ -129,7 +132,7 @@ func (s *UserQuotaStore) Release(ctx context.Context, userID string) {
 // omitempty JSON marshal stays consistent across modes).
 func (s *UserQuotaStore) Snapshot(ctx context.Context) (map[string]int, error) {
 	rows, err := s.pool.Query(ctx, `
-		SELECT user_id, active_count
+		SELECT tenant_id, user_id, active_count
 		  FROM user_quotas
 		 WHERE active_count > 0
 	`)
@@ -140,19 +143,37 @@ func (s *UserQuotaStore) Snapshot(ctx context.Context) (map[string]int, error) {
 	var out map[string]int
 	for rows.Next() {
 		var (
-			userID string
-			count  int
+			tenantID string
+			userID   string
+			count    int
 		)
-		if err := rows.Scan(&userID, &count); err != nil {
+		if err := rows.Scan(&tenantID, &userID, &count); err != nil {
 			return nil, fmt.Errorf("scan user_quotas row: %w", err)
 		}
 		if out == nil {
 			out = make(map[string]int)
 		}
-		out[userID] = count
+		out[FairnessDisplayKey(tenantID, userID)] = count
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate user_quotas: %w", err)
 	}
 	return out, nil
+}
+
+// FairnessDisplayKey renders a (tenant, user) pair as the single string
+// used as the map key in the per-user concurrency stats surface
+// (/v1/_concurrency/stats + the Prometheus per_user gauge). tenant=""
+// (the shared/legacy tenant, i.e. a single-tenant deployment) renders as
+// the bare user so the stats wire is byte-identical to the pre-tenant
+// shape; a real tenant renders as "tenant/user". This is DISPLAY ONLY —
+// enforcement keys on the (tenant_id, user_id) columns, so a "/" that
+// happens to appear in an id can at worst merge two rows in the display,
+// never merge two caps. The in-process Semaphore.Stats path uses an
+// identical format; keep the two in sync.
+func FairnessDisplayKey(tenantID, userID string) string {
+	if tenantID == "" {
+		return userID
+	}
+	return tenantID + "/" + userID
 }

--- a/internal/coord/user_quota_store_test.go
+++ b/internal/coord/user_quota_store_test.go
@@ -38,11 +38,11 @@ func TestUserQuotaStore_AcquireReleaseLifecycle(t *testing.T) {
 	})
 	ctx := context.Background()
 
-	ok, err := s.TryAcquire(ctx, user, 2)
+	ok, err := s.TryAcquire(ctx, "", user, 2)
 	if err != nil || !ok {
 		t.Fatalf("first TryAcquire: ok=%v err=%v", ok, err)
 	}
-	ok, err = s.TryAcquire(ctx, user, 2)
+	ok, err = s.TryAcquire(ctx, "", user, 2)
 	if err != nil || !ok {
 		t.Fatalf("second TryAcquire: ok=%v err=%v", ok, err)
 	}
@@ -55,8 +55,8 @@ func TestUserQuotaStore_AcquireReleaseLifecycle(t *testing.T) {
 		t.Errorf("snapshot[%s] = %d, want 2", user, got)
 	}
 
-	s.Release(ctx, user)
-	s.Release(ctx, user)
+	s.Release(ctx, "", user)
+	s.Release(ctx, "", user)
 
 	snap2, _ := s.Snapshot(ctx)
 	if _, present := snap2[user]; present {
@@ -75,14 +75,14 @@ func TestUserQuotaStore_AtCapRejects(t *testing.T) {
 
 	// Fill the cap (cap=3).
 	for i := 0; i < 3; i++ {
-		ok, err := s.TryAcquire(ctx, user, 3)
+		ok, err := s.TryAcquire(ctx, "", user, 3)
 		if err != nil || !ok {
 			t.Fatalf("acquire #%d: ok=%v err=%v", i, ok, err)
 		}
 	}
 
 	// At-cap: ok=false, err=nil (caller maps to ErrPerUserQuotaExhausted).
-	ok, err := s.TryAcquire(ctx, user, 3)
+	ok, err := s.TryAcquire(ctx, "", user, 3)
 	if err != nil {
 		t.Errorf("at-cap should return nil error, got %v", err)
 	}
@@ -106,7 +106,7 @@ func TestUserQuotaStore_FirstAcquireCreatesRow(t *testing.T) {
 		t.Fatalf("user %s present in snapshot before any acquire: %v", user, snap)
 	}
 
-	ok, err := s.TryAcquire(ctx, user, 5)
+	ok, err := s.TryAcquire(ctx, "", user, 5)
 	if err != nil || !ok {
 		t.Fatalf("first acquire: ok=%v err=%v", ok, err)
 	}
@@ -125,13 +125,13 @@ func TestUserQuotaStore_ReleaseUnderflowIsNoop(t *testing.T) {
 	})
 	ctx := context.Background()
 
-	ok, err := s.TryAcquire(ctx, user, 1)
+	ok, err := s.TryAcquire(ctx, "", user, 1)
 	if err != nil || !ok {
 		t.Fatalf("acquire: ok=%v err=%v", ok, err)
 	}
-	s.Release(ctx, user)
+	s.Release(ctx, "", user)
 	// Second Release should be a silent no-op (logs a warning).
-	s.Release(ctx, user)
+	s.Release(ctx, "", user)
 
 	// Check the row went to 0 and stays there (no negative count, no
 	// CHECK constraint violation).
@@ -151,8 +151,8 @@ func TestUserQuotaStore_SnapshotExcludesZeroCounts(t *testing.T) {
 	ctx := context.Background()
 
 	// Acquire-and-release leaves the row at count=0; snapshot must exclude.
-	_, _ = s.TryAcquire(ctx, user, 5)
-	s.Release(ctx, user)
+	_, _ = s.TryAcquire(ctx, "", user, 5)
+	s.Release(ctx, "", user)
 
 	snap, _ := s.Snapshot(ctx)
 	if _, present := snap[user]; present {
@@ -199,7 +199,7 @@ func TestUserQuotaStore_TwoReplicasConcurrent(t *testing.T) {
 		}
 		go func() {
 			defer wg.Done()
-			ok, err := store.TryAcquire(context.Background(), user, cap)
+			ok, err := store.TryAcquire(context.Background(), "", user, cap)
 			if err != nil {
 				t.Errorf("acquire err: %v", err)
 				return
@@ -230,12 +230,70 @@ func TestUserQuotaStore_InvalidCapRejected(t *testing.T) {
 	t.Cleanup(func() {
 		_, _ = pool.Exec(context.Background(), `DELETE FROM user_quotas WHERE user_id = $1`, user)
 	})
-	_, err := s.TryAcquire(context.Background(), user, 0)
+	_, err := s.TryAcquire(context.Background(), "", user, 0)
 	if err == nil {
 		t.Error("TryAcquire with cap=0 should return error")
 	}
-	_, err = s.TryAcquire(context.Background(), "", 5)
+	_, err = s.TryAcquire(context.Background(), "", "", 5)
 	if err == nil {
 		t.Error("TryAcquire with empty userID should return error")
+	}
+}
+
+// TestUserQuotaStore_TenantIsolation pins the (tenant_id, user_id) keying
+// (migration 0067): the same subject in two tenants holds INDEPENDENT caps,
+// and a release in one tenant leaves the other tenant's counter untouched.
+// Against the prior bare-user_id keying t2's acquire would have incremented
+// the same row and been refused at cap — so this test fails there and passes
+// now.
+func TestUserQuotaStore_TenantIsolation(t *testing.T) {
+	pool := freshUserQuotasPool(t, pgDSNFromEnv(t))
+	s := NewUserQuotaStore(pool)
+	user := uniqueUserID(t)
+	// The (tenant_id, user_id) PK makes t1 and t2 distinct rows; user_id is
+	// unique to this test, so deleting all its rows cleans up both tenants.
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM user_quotas WHERE user_id = $1`, user)
+	})
+	ctx := context.Background()
+
+	// t1's user takes its single slot (cap=1).
+	ok, err := s.TryAcquire(ctx, "t1", user, 1)
+	if err != nil || !ok {
+		t.Fatalf("t1 first TryAcquire: ok=%v err=%v", ok, err)
+	}
+
+	// t2's user — same subject, different tenant — is independent: also true.
+	ok, err = s.TryAcquire(ctx, "t2", user, 1)
+	if err != nil || !ok {
+		t.Fatalf("t2 TryAcquire (independent tenant): ok=%v err=%v", ok, err)
+	}
+
+	// A second t1 acquire is refused — t1's user is at cap.
+	ok, err = s.TryAcquire(ctx, "t1", user, 1)
+	if err != nil {
+		t.Errorf("second t1 TryAcquire: unexpected err %v", err)
+	}
+	if ok {
+		t.Errorf("second t1 TryAcquire: ok=true, want false (t1 at cap)")
+	}
+
+	// Releasing t1 frees t1's slot; a subsequent t1 acquire succeeds again.
+	s.Release(ctx, "t1", user)
+	ok, err = s.TryAcquire(ctx, "t1", user, 1)
+	if err != nil || !ok {
+		t.Fatalf("t1 re-acquire after release: ok=%v err=%v", ok, err)
+	}
+
+	// t2's counter was untouched by t1's release — still at 1.
+	snap, err := s.Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if got := snap[FairnessDisplayKey("t2", user)]; got != 1 {
+		t.Errorf("t2 count = %d, want 1 (untouched by t1 release)", got)
+	}
+	if got := snap[FairnessDisplayKey("t1", user)]; got != 1 {
+		t.Errorf("t1 count = %d, want 1 (re-acquired)", got)
 	}
 }

--- a/internal/store/postgres/migrations/0067_user_quotas_tenant_id.down.sql
+++ b/internal/store/postgres/migrations/0067_user_quotas_tenant_id.down.sql
@@ -1,0 +1,11 @@
+-- 0067_user_quotas_tenant_id.down.sql — reverse the user_quotas tenant axis.
+--
+-- SAFE ONLY while every row is tenant_id='' (a single-tenant cluster).
+-- If real per-tenant rows exist, restoring the bare user_id PK would
+-- collide across tenants; the operator must consolidate first. Mirrors
+-- the 0066 down caveat. user_quotas is a transient counter, so the
+-- worst case is a one-time reset of in-flight counts, not data loss.
+
+ALTER TABLE user_quotas DROP CONSTRAINT IF EXISTS user_quotas_pkey;
+ALTER TABLE user_quotas ADD PRIMARY KEY (user_id);
+ALTER TABLE user_quotas DROP COLUMN IF EXISTS tenant_id;

--- a/internal/store/postgres/migrations/0067_user_quotas_tenant_id.up.sql
+++ b/internal/store/postgres/migrations/0067_user_quotas_tenant_id.up.sql
@@ -1,0 +1,25 @@
+-- 0067_user_quotas_tenant_id.up.sql — tenant-scope the per-user
+-- concurrency counter.
+--
+-- user_quotas is the cluster-wide per-user admission gate (0024): one
+-- row per user_id tracking active+queued runs, capped by the operator's
+-- per-user limit. It keyed on the bare user_id, so two tenants whose
+-- subjects collide (e.g. both have an "alice") shared ONE counter and
+-- ONE cap — tenant A's alice contended with tenant B's alice for the
+-- same slots. This adds the tenant axis so the cap is enforced per
+-- (tenant, user), matching how runs/sessions are already partitioned.
+--
+-- '' = the shared/operator/legacy tenant; existing rows backfill to ''
+-- via the column DEFAULT (a single-tenant cluster reads exactly as
+-- before — every row is '' and the bare-user semantics are preserved).
+-- The table is a transient counter (Postgres-cluster-only; the
+-- single-replica path uses an in-process map), so there is nothing
+-- durable to migrate beyond the in-flight counts.
+--
+-- IF NOT EXISTS / IF EXISTS keep the migration re-runnable: the test
+-- suite rewinds the version pointer and replays MigrateUp, so every
+-- migration must no-op cleanly on a second pass (see 0063/0066).
+
+ALTER TABLE user_quotas ADD COLUMN IF NOT EXISTS tenant_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE user_quotas DROP CONSTRAINT IF EXISTS user_quotas_pkey;
+ALTER TABLE user_quotas ADD PRIMARY KEY (tenant_id, user_id);


### PR DESCRIPTION
Second slice of the scope-completion phase (after the channels tenant axis in #965): the remaining under-scoped table with a real isolation bug.

## Why

The per-user admission cap (the "fairness" limit) keyed on the **bare `user_id`** — in both the in-process `Semaphore` (single-replica) and the cluster-wide `user_quotas` counter. Two tenants whose subjects collide (e.g. both have an `alice`) therefore **shared one counter and one cap**: tenant A's `alice` contended with tenant B's `alice` for the same slots. That's a cross-tenant admission-isolation flaw. This keys the cap on the `(tenant, user)` pair, matching how runs/sessions/memory are already partitioned.

## What

- **Migration 0067** (Postgres-only — `user_quotas` is a cluster-mode counter, never created in sqlite): add `tenant_id`, swap the PK to `(tenant_id, user_id)`, backfill `""`. Idempotent (`IF NOT EXISTS`/`IF EXISTS`) so the migration-replay test path re-runs it cleanly (the #965 lesson).
- **`concurrency.Semaphore`**: `AcquireForUser` gains a `tenantID` param; the per-user counter keys on a typed `userKey{tenant,user}` struct threaded through the release/cancel accounting (a type-swap on the single already-threaded value — the locking logic is untouched). `Stats().PerUser` renders a display string (`fairnessDisplayKey`: `tenant=="" → bare user`, else `"tenant/user"`) so `/v1/_concurrency/stats` + the Prometheus gauge are **byte-identical for single-tenant** and informative for multi-tenant.
- **`coord.UserQuotaStore`**: `TryAcquire`/`Release` take `tenantID`; SQL keys on `(tenant_id, user_id)`; `Snapshot` renders the same display key.
- **`coord.ReplicasSweeper.reapQuotas`**: reconcile per `(tenant, user)`, `COALESCE(runs.tenant_id, '')` since `runs.tenant_id` is nullable (0036) while `user_quotas.tenant_id` is `NOT NULL ''` (a null run tenant maps to the shared `""` quota row).
- The **6 admission sites** thread the authoritative tenant — `tenantFromCtx` for the HTTP-principal paths, `run.TenantID` for resume — never a wire/model value.

`tenant==""` (open mode / single-tenant / legacy) collapses to the exact bare-user behaviour, so those deployments are byte-identical.

## Deliberately NOT in this change (kept surgical)

- **Interrupts** already achieve tenant confinement via `InterruptListByUser`'s `JOIN runs … r.tenant_id` (the "keep the join" approach) — no column needed.
- **Evaluations** have no tenant-facing consumer yet, so adding a tenant column now would be speculative; deferred until a tenant eval surface exists.

Together with #965, this completes the meaningful scope-completion work for Phase 1.

## What was tested

- **concurrency**: `TestSemaphore_PerUserCapIsolatedByTenant` (in-process; two tenants, same subject → independent caps; within-tenant cap still enforced) + a single-tenant-unchanged guard; whole package green under `-race`.
- **coord (real Postgres)**: `TestUserQuotaStore_TenantIsolation` + the existing `UserQuotaStore`/`ReplicasSweeper` suites, verified against a **live PG** with migration 0067 applied; 0067 double-apply is a clean no-op (replay-safe); the full `./internal/store/postgres/` suite green.
- `go test ./...` (no DSN, CI Go-job equivalent) green; `go build ./...` clean.

## Note (pre-existing, unrelated)

The coord `postgres_backplane_test.go` / `cancel_coordinator_test.go` PG-gated tests fail locally because their helper builds a replica ID from `time.Now().Format("150405.000")` — the `.` fails the replica-id regex. Untouched by this PR, unrelated to the tenant axis, and not run in CI (no coord DSN). Flagging for a separate one-line test-hygiene fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)