### PR TITLE
feat(users): tenant-owned users table + lifecycle CRUD (RFC BX P2a)

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -493,10 +493,20 @@ func requiredScopeFor(method, path string) string {
 	// identity (the Web UI's role source); a tenant token needs it too.
 	case path == "/v1/_me":
 		return ""
-	// User listing — any authenticated principal; the handler tenant-scopes
-	// the result (a tenant sees only its tenant's users; admin sees all /
-	// can focus via ?tenant=). The UI's per-tenant workspace picker needs it.
+	// The /v1/_users collection, method-aware (RFC BX P2a):
+	//   - GET (list) — any authenticated principal; the handler tenant-scopes
+	//     the result (a tenant sees only its tenant's users; admin sees all /
+	//     can focus via ?tenant=). The UI's per-tenant workspace picker needs it.
+	//   - POST (create a first-class user) — a tenant-operator action; only a
+	//     substrate:tenant operator (or admin, which also satisfies) may
+	//     register a user. The handler stamps the authoritative principal tenant.
+	// PATCH/DELETE /v1/_users/{subject} (update / delete) fall through to the
+	// strings.HasPrefix(path, "/v1/_users/") case below, which already returns
+	// ScopeTenant — so all three mutating ops are tenant-operator-gated.
 	case path == "/v1/_users":
+		if method == http.MethodPost {
+			return auth.ScopeTenant
+		}
 		return ""
 	// RFC BC: the client-tool host WebSocket. A client registers tools it runs on
 	// the user's own machine; the connection serves ONLY its own principal's runs

--- a/internal/api/http/directory.go
+++ b/internal/api/http/directory.go
@@ -5,10 +5,13 @@ package http
 //	GET /v1/_users/{subject}   one subject's aggregate view (ScopeTenant)
 //	GET /v1/_tenants           tenants with derived counts (ADMIN ONLY)
 //
-// There is no create/update/delete here, deliberately. A "user" in loomcycle is
-// derived from runs.user_id — there is no row to write. The delete half of "user
-// CRUD" is the subject-erasure surface, which is the only thing that removes a
-// person's footprint coherently across four planes.
+// There is no create/update/delete HERE, deliberately: these two endpoints
+// are the DERIVED directory (aggregated from runs.user_id + memory). Since RFC
+// BX P2a there is also a first-class, tenant-owned `users` table whose CRUD
+// lives in users_crud.go — a managed identity record, distinct from this
+// activity-derived view. Deleting that record is NOT the same as removing a
+// person's footprint: the subject-erasure surface remains the only thing that
+// clears a footprint coherently across all planes.
 
 import (
 	"context"

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2760,6 +2760,14 @@ func (s *Server) Mux() http.Handler {
 	// user_ids that have runs in the store. Bearer-authed; drives
 	// the Web UI's run-list user dropdown.
 	mux.Handle("GET /v1/_users", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListUsers))))
+	// RFC BX P2a — the tenant-owned first-class users table. Create /
+	// update / delete are tenant-operator actions (substrate:tenant, admin
+	// also satisfies); the handlers derive the authoritative tenant from the
+	// principal (never the wire) and 404 cross-tenant. Scope-gated in
+	// requiredScopeFor (POST here; PATCH/DELETE via the /v1/_users/ prefix).
+	mux.Handle("POST /v1/_users", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleCreateUser))))
+	mux.Handle("PATCH /v1/_users/{subject}", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleUpdateUser))))
+	mux.Handle("DELETE /v1/_users/{subject}", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleDeleteUser))))
 	// v0.8.6 system channels admin endpoint. Bearer-authed publish to
 	// _system/* channels. Used by external monitoring (push alerts in
 	// via webhook), ops dashboards (operator-issued alarms), and

--- a/internal/api/http/users.go
+++ b/internal/api/http/users.go
@@ -18,6 +18,15 @@ type wireUserSummary struct {
 	RunningCount  int       `json:"running_count"`
 	TotalCount    int       `json:"total_count"`
 	LastStartedAt time.Time `json:"last_started_at"`
+	// RFC BX P2a — the first-class users-table fields, merged over the
+	// run-derived activity above. `Registered` distinguishes a managed user
+	// row (true) from a subject seen only in runs (false); the record fields
+	// are empty for the latter. Additive — the base four fields are
+	// unchanged so the Web UI's picker keeps working.
+	Registered  bool   `json:"registered"`
+	DisplayName string `json:"display_name"`
+	AccessMode  string `json:"access_mode"`
+	Status      string `json:"status"`
 }
 
 // handleListUsers serves GET /v1/_users — distinct user_ids with
@@ -46,9 +55,43 @@ func (s *Server) handleListUsers(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusInternalServerError, "internal", err.Error())
 		return
 	}
-	resp := listUsersResponse{Users: make([]wireUserSummary, 0, len(users))}
+	// RFC BX P2a: merge the first-class users-table rows over the run-derived
+	// activity so the response is authoritative about who is REGISTERED while
+	// staying an activity lens. Both sources are scoped by the SAME tenantID:
+	//   - a subject with runs but no record → registered:false, empty fields;
+	//   - a registered subject with no runs → appears with zero activity;
+	//   - a subject in both               → activity + record fields merged.
+	records, err := s.store.UserList(r.Context(), tenantID)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	resp := listUsersResponse{Users: make([]wireUserSummary, 0, len(users)+len(records))}
+	// Index by user_id to fold records onto activity rows. In the admin
+	// all-tenants view (tenantID=="") ListUsers already collapses a subject
+	// across tenants (GROUP BY user_id), so this lens does too; the exact
+	// per-tenant view is the tenant-scoped read.
+	idx := map[string]int{}
 	for _, u := range users {
+		idx[u.UserID] = len(resp.Users)
 		resp.Users = append(resp.Users, toWireUser(u))
+	}
+	for _, rec := range records {
+		if i, ok := idx[rec.Subject]; ok {
+			resp.Users[i].Registered = true
+			resp.Users[i].DisplayName = rec.DisplayName
+			resp.Users[i].AccessMode = rec.AccessMode
+			resp.Users[i].Status = rec.Status
+			continue
+		}
+		idx[rec.Subject] = len(resp.Users)
+		resp.Users = append(resp.Users, wireUserSummary{
+			UserID:      rec.Subject,
+			Registered:  true,
+			DisplayName: rec.DisplayName,
+			AccessMode:  rec.AccessMode,
+			Status:      rec.Status,
+		})
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)

--- a/internal/api/http/users_crud.go
+++ b/internal/api/http/users_crud.go
@@ -1,0 +1,205 @@
+package http
+
+// users_crud.go — RFC BX P2a: create / update / delete for the tenant-owned
+// first-class `users` table. The GET list (handleListUsers) + per-subject
+// inspect (handleInspectUser) live in users.go / directory.go.
+//
+// Trust boundary: the tenant a row belongs to is ALWAYS derived server-side
+// from the principal (tenantFromCtx), NEVER from the request body or the URL.
+// A tenant operator therefore manages ONLY its own tenant's users; a
+// cross-tenant update/delete is an opaque 404, never an existence oracle.
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// createUserRequest is the wire body of POST /v1/_users. `tenant` is
+// deliberately NOT a field — the tenant is server-derived.
+type createUserRequest struct {
+	Subject     string `json:"subject"`
+	DisplayName string `json:"display_name"`
+	AccessMode  string `json:"access_mode"`
+	Status      string `json:"status"`
+}
+
+// updateUserRequest is the wire body of PATCH /v1/_users/{subject}. Pointer
+// fields so an omitted key leaves the column unchanged; a present key (even
+// the empty string) is applied.
+type updateUserRequest struct {
+	DisplayName *string `json:"display_name"`
+	AccessMode  *string `json:"access_mode"`
+	Status      *string `json:"status"`
+}
+
+// wireUserRecord is the response shape of a single first-class user row.
+type wireUserRecord struct {
+	TenantID    string    `json:"tenant_id"`
+	Subject     string    `json:"subject"`
+	DisplayName string    `json:"display_name"`
+	AccessMode  string    `json:"access_mode"`
+	Status      string    `json:"status"`
+	CreatedAt   time.Time `json:"created_at"`
+	CreatedBy   string    `json:"created_by"`
+}
+
+func toWireUserRecord(r store.UserRow) wireUserRecord {
+	return wireUserRecord{
+		TenantID:    r.TenantID,
+		Subject:     r.Subject,
+		DisplayName: r.DisplayName,
+		AccessMode:  r.AccessMode,
+		Status:      r.Status,
+		CreatedAt:   r.CreatedAt,
+		CreatedBy:   r.CreatedBy,
+	}
+}
+
+// handleCreateUser serves POST /v1/_users. Registers a first-class user in
+// the caller's own tenant. 409 on a duplicate (tenant, subject); 400 on a
+// missing subject or a bad access_mode / status.
+func (s *Server) handleCreateUser(w http.ResponseWriter, r *http.Request) {
+	if s.store == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "store_unavailable",
+			"store not configured; user management requires a persistent store")
+		return
+	}
+	var req createUserRequest
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_body", "invalid request body: "+err.Error())
+		return
+	}
+	subject := strings.TrimSpace(req.Subject)
+	if subject == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing_subject", "subject is required")
+		return
+	}
+	// Apply the RFC BX defaults BEFORE validating so an omitted dial means
+	// "full whole-tenant collaboration" (today's behaviour), not a rejection.
+	accessMode := strings.TrimSpace(req.AccessMode)
+	if accessMode == "" {
+		accessMode = "tenant"
+	}
+	status := strings.TrimSpace(req.Status)
+	if status == "" {
+		status = "active"
+	}
+	if !store.ValidUserAccessMode(accessMode) {
+		writeJSONError(w, http.StatusBadRequest, "invalid_access_mode",
+			"access_mode must be one of tenant|isolated")
+		return
+	}
+	if !store.ValidUserStatus(status) {
+		writeJSONError(w, http.StatusBadRequest, "invalid_status",
+			"status must be one of active|disabled")
+		return
+	}
+	row := store.UserRow{
+		TenantID:    tenantFromCtx(r.Context()), // authoritative principal tenant
+		Subject:     subject,
+		DisplayName: strings.TrimSpace(req.DisplayName),
+		AccessMode:  accessMode,
+		Status:      status,
+		CreatedAt:   time.Now().UTC(),
+		CreatedBy:   principalSubject(r.Context()),
+	}
+	if err := s.store.UserCreate(r.Context(), row); err != nil {
+		var conflict *store.ErrConflict
+		if errors.As(err, &conflict) {
+			writeJSONError(w, http.StatusConflict, "user_exists",
+				"a user with that subject already exists in this tenant")
+			return
+		}
+		writeJSONError(w, http.StatusInternalServerError, "user_create_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, toWireUserRecord(row))
+}
+
+// handleUpdateUser serves PATCH /v1/_users/{subject}. Patches mutable fields
+// on a user in the caller's own tenant. A cross-tenant target is an opaque
+// 404 (no existence oracle); a bad access_mode / status is a 400.
+func (s *Server) handleUpdateUser(w http.ResponseWriter, r *http.Request) {
+	if s.store == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "store_unavailable",
+			"store not configured; user management requires a persistent store")
+		return
+	}
+	subject := strings.TrimSpace(r.PathValue("subject"))
+	if subject == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing_subject", "subject is required")
+		return
+	}
+	var req updateUserRequest
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+	if r.ContentLength != 0 {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSONError(w, http.StatusBadRequest, "invalid_body", "invalid request body: "+err.Error())
+			return
+		}
+	}
+	if req.AccessMode != nil && !store.ValidUserAccessMode(*req.AccessMode) {
+		writeJSONError(w, http.StatusBadRequest, "invalid_access_mode",
+			"access_mode must be one of tenant|isolated")
+		return
+	}
+	if req.Status != nil && !store.ValidUserStatus(*req.Status) {
+		writeJSONError(w, http.StatusBadRequest, "invalid_status",
+			"status must be one of active|disabled")
+		return
+	}
+	tenant := tenantFromCtx(r.Context())
+	patch := store.UserPatch{
+		DisplayName: req.DisplayName,
+		AccessMode:  req.AccessMode,
+		Status:      req.Status,
+	}
+	if err := s.store.UserUpdate(r.Context(), tenant, subject, patch); err != nil {
+		var notFound *store.ErrNotFound
+		if errors.As(err, &notFound) {
+			writeJSONError(w, http.StatusNotFound, "user_not_found", "no such user in this tenant")
+			return
+		}
+		writeJSONError(w, http.StatusInternalServerError, "user_update_failed", err.Error())
+		return
+	}
+	// Re-read so the response reflects the post-patch state.
+	updated, err := s.store.UserGet(r.Context(), tenant, subject)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "user_reread_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, toWireUserRecord(updated))
+}
+
+// handleDeleteUser serves DELETE /v1/_users/{subject}. Hard-deletes a user in
+// the caller's own tenant; 404 if no such row. Owned data (runs / sessions /
+// memory) is left intact — deleting the identity record is not erasure.
+func (s *Server) handleDeleteUser(w http.ResponseWriter, r *http.Request) {
+	if s.store == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "store_unavailable",
+			"store not configured; user management requires a persistent store")
+		return
+	}
+	subject := strings.TrimSpace(r.PathValue("subject"))
+	if subject == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing_subject", "subject is required")
+		return
+	}
+	removed, err := s.store.UserDelete(r.Context(), tenantFromCtx(r.Context()), subject)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "user_delete_failed", err.Error())
+		return
+	}
+	if !removed {
+		writeJSONError(w, http.StatusNotFound, "user_not_found", "no such user in this tenant")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/api/http/users_crud_test.go
+++ b/internal/api/http/users_crud_test.go
@@ -1,0 +1,177 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// bodyReq builds a request carrying a JSON body + a stamped principal (what
+// the middleware does in production). key/val set a path value when non-empty
+// (Go 1.22+ req.SetPathValue, since these handlers read r.PathValue).
+func bodyReq(method, target, body string, p auth.Principal, key, val string) *http.Request {
+	req := httptest.NewRequest(method, target, strings.NewReader(body))
+	if key != "" {
+		req.SetPathValue(key, val)
+	}
+	return req.WithContext(auth.WithPrincipal(req.Context(), p))
+}
+
+// A substrate:tenant operator manages ONLY its own tenant's users: create
+// stamps the principal's authoritative tenant, and update/delete of another
+// tenant's user is an opaque 404 that leaves the target untouched.
+func TestHandleUsersCRUD_TenantOperatorConfined(t *testing.T) {
+	s, st := tokenAuthServer(t, "legacy")
+	ctx := context.Background()
+	acme := auth.Principal{TenantID: "acme", Subject: "ops", Scopes: []string{auth.ScopeTenant}}
+
+	// A user in tenant "other", seeded directly, is the cross-tenant target.
+	if err := st.UserCreate(ctx, store.UserRow{TenantID: "other", Subject: "carol", AccessMode: "tenant", Status: "active"}); err != nil {
+		t.Fatalf("seed other/carol: %v", err)
+	}
+
+	// create — tenant is server-derived (never from the body); created_by is
+	// the principal subject.
+	rec := httptest.NewRecorder()
+	s.handleCreateUser(rec, bodyReq("POST", "/v1/_users", `{"subject":"alice","display_name":"Alice","access_mode":"isolated"}`, acme, "", ""))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create status %d: %s", rec.Code, rec.Body.String())
+	}
+	var created wireUserRecord
+	_ = json.Unmarshal(rec.Body.Bytes(), &created)
+	if created.TenantID != "acme" || created.Subject != "alice" || created.AccessMode != "isolated" || created.CreatedBy != "ops" {
+		t.Errorf("created = %+v, want acme/alice/isolated created_by=ops", created)
+	}
+
+	// duplicate → 409.
+	rec = httptest.NewRecorder()
+	s.handleCreateUser(rec, bodyReq("POST", "/v1/_users", `{"subject":"alice"}`, acme, "", ""))
+	if rec.Code != http.StatusConflict {
+		t.Errorf("duplicate create = %d, want 409", rec.Code)
+	}
+
+	// bad access_mode → 400.
+	rec = httptest.NewRecorder()
+	s.handleCreateUser(rec, bodyReq("POST", "/v1/_users", `{"subject":"x","access_mode":"wat"}`, acme, "", ""))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("bad access_mode = %d, want 400", rec.Code)
+	}
+
+	// cross-tenant update → opaque 404; other/carol untouched.
+	rec = httptest.NewRecorder()
+	s.handleUpdateUser(rec, bodyReq("PATCH", "/v1/_users/carol", `{"status":"disabled"}`, acme, "subject", "carol"))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("cross-tenant update = %d, want 404", rec.Code)
+	}
+	if carol, _ := st.UserGet(ctx, "other", "carol"); carol.Status != "active" {
+		t.Errorf("other/carol.status = %q after acme's cross-tenant PATCH, want active (untouched)", carol.Status)
+	}
+
+	// own-tenant update — changes apply, unspecified fields preserved.
+	rec = httptest.NewRecorder()
+	s.handleUpdateUser(rec, bodyReq("PATCH", "/v1/_users/alice", `{"status":"disabled","display_name":"Alice A."}`, acme, "subject", "alice"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("own update status %d: %s", rec.Code, rec.Body.String())
+	}
+	var updated wireUserRecord
+	_ = json.Unmarshal(rec.Body.Bytes(), &updated)
+	if updated.Status != "disabled" || updated.DisplayName != "Alice A." || updated.AccessMode != "isolated" {
+		t.Errorf("updated = %+v, want status+name changed, access_mode preserved", updated)
+	}
+
+	// cross-tenant delete → opaque 404; other/carol survives.
+	rec = httptest.NewRecorder()
+	s.handleDeleteUser(rec, bodyReq("DELETE", "/v1/_users/carol", "", acme, "subject", "carol"))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("cross-tenant delete = %d, want 404", rec.Code)
+	}
+	if _, err := st.UserGet(ctx, "other", "carol"); err != nil {
+		t.Errorf("other/carol gone after acme's cross-tenant DELETE: %v", err)
+	}
+
+	// own delete → 204; a second delete → 404.
+	rec = httptest.NewRecorder()
+	s.handleDeleteUser(rec, bodyReq("DELETE", "/v1/_users/alice", "", acme, "subject", "alice"))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("own delete = %d, want 204", rec.Code)
+	}
+	rec = httptest.NewRecorder()
+	s.handleDeleteUser(rec, bodyReq("DELETE", "/v1/_users/alice", "", acme, "subject", "alice"))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("second delete = %d, want 404", rec.Code)
+	}
+}
+
+// GET /v1/_users merges the users-table rows over the run-derived activity:
+// a subject in both is enriched, a run-only subject is registered:false with
+// empty record fields, and a registered subject with no runs still appears.
+func TestHandleListUsers_MergesTableAndRunRows(t *testing.T) {
+	s, st := tokenAuthServer(t, "legacy")
+	ctx := context.Background()
+
+	// alice + bob have runs in tenant acme.
+	sessA, _ := st.CreateSession(ctx, "acme", "echo", "alice")
+	_, _ = st.CreateRun(ctx, sessA.ID, store.RunIdentity{AgentID: "a1", UserID: "alice", TenantID: "acme"})
+	sessB, _ := st.CreateSession(ctx, "acme", "echo", "bob")
+	_, _ = st.CreateRun(ctx, sessB.ID, store.RunIdentity{AgentID: "a2", UserID: "bob", TenantID: "acme"})
+
+	// alice is ALSO registered (merge); carol is registered with NO runs.
+	if err := st.UserCreate(ctx, store.UserRow{TenantID: "acme", Subject: "alice", DisplayName: "Alice", AccessMode: "isolated", Status: "active"}); err != nil {
+		t.Fatalf("register alice: %v", err)
+	}
+	if err := st.UserCreate(ctx, store.UserRow{TenantID: "acme", Subject: "carol", DisplayName: "Carol", AccessMode: "tenant", Status: "disabled"}); err != nil {
+		t.Fatalf("register carol: %v", err)
+	}
+
+	acme := auth.Principal{TenantID: "acme", Subject: "ops", Scopes: []string{auth.ScopeTenant}}
+	rec := httptest.NewRecorder()
+	s.handleListUsers(rec, principalReq("GET", "/v1/_users", acme))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list status %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Users []wireUserSummary `json:"users"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	byID := map[string]wireUserSummary{}
+	for _, u := range resp.Users {
+		byID[u.UserID] = u
+	}
+
+	// alice: activity AND record fields merged onto one row.
+	if a := byID["alice"]; !a.Registered || a.DisplayName != "Alice" || a.AccessMode != "isolated" || a.TotalCount != 1 {
+		t.Errorf("alice = %+v, want registered w/ record fields AND total=1", a)
+	}
+	// bob: runs only — not registered, empty record fields.
+	if b := byID["bob"]; b.Registered || b.DisplayName != "" || b.AccessMode != "" || b.TotalCount != 1 {
+		t.Errorf("bob = %+v, want registered=false, empty record fields, total=1", b)
+	}
+	// carol: registered only — appears with zero activity.
+	if c := byID["carol"]; !c.Registered || c.Status != "disabled" || c.TotalCount != 0 {
+		t.Errorf("carol = %+v, want registered w/ status=disabled AND zero activity", c)
+	}
+}
+
+// The POST /v1/_users gate is tenant-operator-scoped while GET stays open to
+// any authenticated principal; the /v1/_users/ prefix (PATCH/DELETE) is
+// tenant-operator-scoped too (RFC BX P2a).
+func TestRequiredScopeFor_UsersCRUDGate(t *testing.T) {
+	if got := requiredScopeFor("GET", "/v1/_users"); got != "" {
+		t.Errorf("GET /v1/_users = %q, want \"\" (any authenticated)", got)
+	}
+	if got := requiredScopeFor("POST", "/v1/_users"); got != auth.ScopeTenant {
+		t.Errorf("POST /v1/_users = %q, want %q", got, auth.ScopeTenant)
+	}
+	if got := requiredScopeFor("PATCH", "/v1/_users/alice"); got != auth.ScopeTenant {
+		t.Errorf("PATCH /v1/_users/{subject} = %q, want %q", got, auth.ScopeTenant)
+	}
+	if got := requiredScopeFor("DELETE", "/v1/_users/alice"); got != auth.ScopeTenant {
+		t.Errorf("DELETE /v1/_users/{subject} = %q, want %q", got, auth.ScopeTenant)
+	}
+}

--- a/internal/store/postgres/migrations/0068_users.down.sql
+++ b/internal/store/postgres/migrations/0068_users.down.sql
@@ -1,0 +1,4 @@
+-- 0068_users.down.sql — drop the tenant-owned users table. Owned data
+-- (the subjects' runs / sessions / memory) lives in other tables with no FK
+-- to here, so dropping this table removes only the identity records.
+DROP TABLE IF EXISTS users;

--- a/internal/store/postgres/migrations/0068_users.up.sql
+++ b/internal/store/postgres/migrations/0068_users.up.sql
@@ -1,0 +1,36 @@
+-- 0068_users.up.sql — the tenant-owned first-class `users` table (RFC BX
+-- Phase 2 / P2a).
+--
+-- Until now a "user" in loomcycle was DERIVED: it existed only as the
+-- distinct set of runs.user_id values (see directory.go / ListUsers). There
+-- was no row to name, so a tenant operator could not register a subject
+-- ahead of its first run, give it a display name, disable it, or mark it as
+-- sandboxed. This table makes user identity first-class and tenant-owned so
+-- a substrate:tenant operator can manage its OWN tenant's users.
+--
+-- access_mode is the RFC BX binary collaboration dial:
+--   'tenant'   = full whole-tenant collaboration (every subject in the
+--                tenant shares its workspace) — today's behaviour, hence the
+--                DEFAULT, so nothing changes for existing deployments;
+--   'isolated' = the subject is sandboxed to its own scope.
+-- status is the lifecycle flag ('active' | 'disabled'). Neither is enforced
+-- here (P2a is the table + CRUD only); auth/minting integration is a later PR.
+--
+-- '' = the shared/operator/legacy tenant, matching runs/sessions/channels.
+-- The PK is (tenant_id, subject) so two tenants can each own a same-named
+-- subject and every read is tenant-confinable.
+--
+-- IF NOT EXISTS keeps the migration re-runnable: the migration test suite
+-- rewinds the version pointer and replays MigrateUp, so each migration must
+-- no-op cleanly on a second pass (mirrors 0066/0067).
+
+CREATE TABLE IF NOT EXISTS users (
+    tenant_id    TEXT        NOT NULL DEFAULT '',
+    subject      TEXT        NOT NULL,
+    display_name TEXT        NOT NULL DEFAULT '',
+    access_mode  TEXT        NOT NULL DEFAULT 'tenant',   -- 'tenant' | 'isolated'
+    status       TEXT        NOT NULL DEFAULT 'active',    -- 'active' | 'disabled'
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    created_by   TEXT,
+    PRIMARY KEY (tenant_id, subject)
+);

--- a/internal/store/postgres/users.go
+++ b/internal/store/postgres/users.go
@@ -1,0 +1,175 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// users.go — RFC BX P2a tenant-owned user-identity CRUD against the `users`
+// table. Sibling of internal/store/sqlite/users.go; both keep the same
+// contract (see internal/store/storetest testUserCRUD / testUserTenantIsolation).
+
+// UserCreate inserts a first-class identity row. Returns
+// *store.ErrConflict{Kind:"user", ID:subject} on a (tenant, subject) PK
+// violation (Postgres SQLSTATE 23505 = unique_violation).
+func (s *Store) UserCreate(ctx context.Context, row store.UserRow) error {
+	if !store.ValidUserAccessMode(row.AccessMode) {
+		return fmt.Errorf("user create: access_mode must be one of tenant|isolated, got %q", row.AccessMode)
+	}
+	if !store.ValidUserStatus(row.Status) {
+		return fmt.Errorf("user create: status must be one of active|disabled, got %q", row.Status)
+	}
+	createdAt := row.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO users (
+			tenant_id, subject, display_name, access_mode, status, created_at, created_by
+		) VALUES ($1, $2, $3, $4, $5, $6, $7)
+	`,
+		row.TenantID, row.Subject, row.DisplayName, row.AccessMode, row.Status, createdAt, row.CreatedBy,
+	)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return &store.ErrConflict{Kind: "user", ID: row.Subject}
+		}
+		return fmt.Errorf("user create: %w", err)
+	}
+	return nil
+}
+
+// UserGet returns one identity row. Returns *store.ErrNotFound{Kind:"user"}
+// when the (tenantID, subject) row is absent.
+func (s *Store) UserGet(ctx context.Context, tenantID, subject string) (store.UserRow, error) {
+	var r store.UserRow
+	var createdAt time.Time
+	var createdBy *string
+	err := s.pool.QueryRow(ctx, `
+		SELECT tenant_id, subject, display_name, access_mode, status, created_at, created_by
+		FROM users
+		WHERE tenant_id = $1 AND subject = $2
+	`, tenantID, subject).Scan(
+		&r.TenantID, &r.Subject, &r.DisplayName, &r.AccessMode, &r.Status, &createdAt, &createdBy,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return store.UserRow{}, &store.ErrNotFound{Kind: "user", ID: subject}
+	}
+	if err != nil {
+		return store.UserRow{}, fmt.Errorf("user get: %w", err)
+	}
+	r.CreatedAt = createdAt.UTC()
+	if createdBy != nil {
+		r.CreatedBy = *createdBy
+	}
+	return r, nil
+}
+
+// UserList returns every identity row for tenantID ordered by
+// (tenant_id, subject). tenantID "" returns ALL tenants' rows (super-admin).
+// Empty slice (not nil) when none match.
+func (s *Store) UserList(ctx context.Context, tenantID string) ([]store.UserRow, error) {
+	q := `
+		SELECT tenant_id, subject, display_name, access_mode, status, created_at, created_by
+		FROM users`
+	args := []any{}
+	if tenantID != "" {
+		q += ` WHERE tenant_id = $1`
+		args = append(args, tenantID)
+	}
+	q += ` ORDER BY tenant_id, subject`
+	rows, err := s.pool.Query(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("user list: %w", err)
+	}
+	defer rows.Close()
+	out := []store.UserRow{}
+	for rows.Next() {
+		var r store.UserRow
+		var createdAt time.Time
+		var createdBy *string
+		if err := rows.Scan(
+			&r.TenantID, &r.Subject, &r.DisplayName, &r.AccessMode, &r.Status, &createdAt, &createdBy,
+		); err != nil {
+			return nil, fmt.Errorf("user list scan: %w", err)
+		}
+		r.CreatedAt = createdAt.UTC()
+		if createdBy != nil {
+			r.CreatedBy = *createdBy
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// UserUpdate patches mutable fields. Nil patch fields leave the corresponding
+// column unchanged. Returns *store.ErrNotFound{Kind:"user"} when the row is
+// absent, and rejects a bad access_mode / status.
+func (s *Store) UserUpdate(ctx context.Context, tenantID, subject string, patch store.UserPatch) error {
+	if patch.AccessMode != nil && !store.ValidUserAccessMode(*patch.AccessMode) {
+		return fmt.Errorf("user update: access_mode must be one of tenant|isolated, got %q", *patch.AccessMode)
+	}
+	if patch.Status != nil && !store.ValidUserStatus(*patch.Status) {
+		return fmt.Errorf("user update: status must be one of active|disabled, got %q", *patch.Status)
+	}
+	sets := []string{}
+	args := []any{}
+	idx := 1
+	if patch.DisplayName != nil {
+		sets = append(sets, fmt.Sprintf("display_name = $%d", idx))
+		args = append(args, *patch.DisplayName)
+		idx++
+	}
+	if patch.AccessMode != nil {
+		sets = append(sets, fmt.Sprintf("access_mode = $%d", idx))
+		args = append(args, *patch.AccessMode)
+		idx++
+	}
+	if patch.Status != nil {
+		sets = append(sets, fmt.Sprintf("status = $%d", idx))
+		args = append(args, *patch.Status)
+		idx++
+	}
+	if len(sets) == 0 {
+		// Nothing to update — verify existence and return.
+		var one int
+		if err := s.pool.QueryRow(ctx, `SELECT 1 FROM users WHERE tenant_id = $1 AND subject = $2`, tenantID, subject).Scan(&one); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return &store.ErrNotFound{Kind: "user", ID: subject}
+			}
+			return fmt.Errorf("user update existence: %w", err)
+		}
+		return nil
+	}
+	args = append(args, tenantID, subject)
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE users SET `+strings.Join(sets, ", ")+fmt.Sprintf(` WHERE tenant_id = $%d AND subject = $%d`, idx, idx+1),
+		args...,
+	)
+	if err != nil {
+		return fmt.Errorf("user update: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return &store.ErrNotFound{Kind: "user", ID: subject}
+	}
+	return nil
+}
+
+// UserDelete hard-deletes one identity row and reports whether a row was
+// removed. Owned data (runs / sessions / memory) has no FK here and stays.
+func (s *Store) UserDelete(ctx context.Context, tenantID, subject string) (bool, error) {
+	tag, err := s.pool.Exec(ctx, `DELETE FROM users WHERE tenant_id = $1 AND subject = $2`, tenantID, subject)
+	if err != nil {
+		return false, fmt.Errorf("user delete: %w", err)
+	}
+	return tag.RowsAffected() > 0, nil
+}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -365,6 +365,24 @@ func (s *Store) migrate(ctx context.Context) error {
 			tenant_id    TEXT    NOT NULL DEFAULT '',
 			PRIMARY KEY (tenant_id, name)
 		)`,
+		// RFC BX Phase 2 / P2a — the tenant-owned first-class users table.
+		// Mirrors postgres migration 0068. A "user" was previously derived
+		// from runs.user_id (no row to write); this makes identity a real,
+		// tenant-owned record a substrate:tenant operator can manage.
+		// access_mode is the collaboration dial ('tenant' = whole-tenant
+		// collaboration, the default preserving today's behaviour; 'isolated'
+		// = sandboxed); status is 'active' | 'disabled'. unix-nano created_at
+		// stamped in code (sqlite has no now() default idiom here).
+		`CREATE TABLE IF NOT EXISTS users (
+			tenant_id    TEXT    NOT NULL DEFAULT '',
+			subject      TEXT    NOT NULL,
+			display_name TEXT    NOT NULL DEFAULT '',
+			access_mode  TEXT    NOT NULL DEFAULT 'tenant',
+			status       TEXT    NOT NULL DEFAULT 'active',
+			created_at   INTEGER NOT NULL,
+			created_by   TEXT,
+			PRIMARY KEY (tenant_id, subject)
+		)`,
 		// v0.8.5 Self-Evolution Substrate — see
 		// internal/store/postgres/migrations/0006_agent_defs.up.sql for
 		// the full design rationale. SQLite mirrors the shape; INTEGER

--- a/internal/store/sqlite/users.go
+++ b/internal/store/sqlite/users.go
@@ -1,0 +1,173 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// users.go — RFC BX P2a tenant-owned user-identity CRUD against the `users`
+// table. Sibling of internal/store/postgres/users.go; both keep the same
+// contract (see internal/store/storetest testUserCRUD / testUserTenantIsolation).
+
+// UserCreate inserts a first-class identity row. Returns
+// *store.ErrConflict{Kind:"user", ID:subject} on a (tenant, subject) PK
+// violation (modernc.org/sqlite surfaces it as "UNIQUE constraint failed").
+func (s *Store) UserCreate(ctx context.Context, row store.UserRow) error {
+	if !store.ValidUserAccessMode(row.AccessMode) {
+		return fmt.Errorf("user create: access_mode must be one of tenant|isolated, got %q", row.AccessMode)
+	}
+	if !store.ValidUserStatus(row.Status) {
+		return fmt.Errorf("user create: status must be one of active|disabled, got %q", row.Status)
+	}
+	createdAt := row.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO users (
+			tenant_id, subject, display_name, access_mode, status, created_at, created_by
+		) VALUES (?, ?, ?, ?, ?, ?, ?)
+	`,
+		row.TenantID, row.Subject, row.DisplayName, row.AccessMode, row.Status,
+		createdAt.UnixNano(), row.CreatedBy,
+	)
+	if err != nil {
+		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
+			return &store.ErrConflict{Kind: "user", ID: row.Subject}
+		}
+		return fmt.Errorf("user create: %w", err)
+	}
+	return nil
+}
+
+// UserGet returns one identity row. Returns *store.ErrNotFound{Kind:"user"}
+// when the (tenantID, subject) row is absent.
+func (s *Store) UserGet(ctx context.Context, tenantID, subject string) (store.UserRow, error) {
+	var r store.UserRow
+	var createdNano int64
+	var createdBy sql.NullString
+	err := s.db.QueryRowContext(ctx, `
+		SELECT tenant_id, subject, display_name, access_mode, status, created_at, created_by
+		FROM users
+		WHERE tenant_id = ? AND subject = ?
+	`, tenantID, subject).Scan(
+		&r.TenantID, &r.Subject, &r.DisplayName, &r.AccessMode, &r.Status, &createdNano, &createdBy,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return store.UserRow{}, &store.ErrNotFound{Kind: "user", ID: subject}
+	}
+	if err != nil {
+		return store.UserRow{}, fmt.Errorf("user get: %w", err)
+	}
+	r.CreatedAt = time.Unix(0, createdNano).UTC()
+	r.CreatedBy = createdBy.String
+	return r, nil
+}
+
+// UserList returns every identity row for tenantID ordered by
+// (tenant_id, subject). tenantID "" returns ALL tenants' rows (super-admin).
+// Empty slice (not nil) when none match.
+func (s *Store) UserList(ctx context.Context, tenantID string) ([]store.UserRow, error) {
+	q := `
+		SELECT tenant_id, subject, display_name, access_mode, status, created_at, created_by
+		FROM users`
+	args := []any{}
+	if tenantID != "" {
+		q += ` WHERE tenant_id = ?`
+		args = append(args, tenantID)
+	}
+	q += ` ORDER BY tenant_id, subject`
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("user list: %w", err)
+	}
+	defer rows.Close()
+	out := []store.UserRow{}
+	for rows.Next() {
+		var r store.UserRow
+		var createdNano int64
+		var createdBy sql.NullString
+		if err := rows.Scan(
+			&r.TenantID, &r.Subject, &r.DisplayName, &r.AccessMode, &r.Status, &createdNano, &createdBy,
+		); err != nil {
+			return nil, fmt.Errorf("user list scan: %w", err)
+		}
+		r.CreatedAt = time.Unix(0, createdNano).UTC()
+		r.CreatedBy = createdBy.String
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// UserUpdate patches mutable fields. Nil patch fields leave the corresponding
+// column unchanged. Returns *store.ErrNotFound{Kind:"user"} when the row is
+// absent, and rejects a bad access_mode / status.
+func (s *Store) UserUpdate(ctx context.Context, tenantID, subject string, patch store.UserPatch) error {
+	if patch.AccessMode != nil && !store.ValidUserAccessMode(*patch.AccessMode) {
+		return fmt.Errorf("user update: access_mode must be one of tenant|isolated, got %q", *patch.AccessMode)
+	}
+	if patch.Status != nil && !store.ValidUserStatus(*patch.Status) {
+		return fmt.Errorf("user update: status must be one of active|disabled, got %q", *patch.Status)
+	}
+	sets := []string{}
+	args := []any{}
+	if patch.DisplayName != nil {
+		sets = append(sets, "display_name = ?")
+		args = append(args, *patch.DisplayName)
+	}
+	if patch.AccessMode != nil {
+		sets = append(sets, "access_mode = ?")
+		args = append(args, *patch.AccessMode)
+	}
+	if patch.Status != nil {
+		sets = append(sets, "status = ?")
+		args = append(args, *patch.Status)
+	}
+	if len(sets) == 0 {
+		// Nothing to update — verify existence and return.
+		var one int
+		if err := s.db.QueryRowContext(ctx, `SELECT 1 FROM users WHERE tenant_id = ? AND subject = ?`, tenantID, subject).Scan(&one); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return &store.ErrNotFound{Kind: "user", ID: subject}
+			}
+			return fmt.Errorf("user update existence: %w", err)
+		}
+		return nil
+	}
+	args = append(args, tenantID, subject)
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE users SET `+strings.Join(sets, ", ")+` WHERE tenant_id = ? AND subject = ?`,
+		args...,
+	)
+	if err != nil {
+		return fmt.Errorf("user update: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("user update rows-affected: %w", err)
+	}
+	if n == 0 {
+		return &store.ErrNotFound{Kind: "user", ID: subject}
+	}
+	return nil
+}
+
+// UserDelete hard-deletes one identity row and reports whether a row was
+// removed. Owned data (runs / sessions / memory) has no FK here and stays.
+func (s *Store) UserDelete(ctx context.Context, tenantID, subject string) (bool, error) {
+	res, err := s.db.ExecContext(ctx, `DELETE FROM users WHERE tenant_id = ? AND subject = ?`, tenantID, subject)
+	if err != nil {
+		return false, fmt.Errorf("user delete: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("user delete rows-affected: %w", err)
+	}
+	return n > 0, nil
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -966,6 +966,45 @@ type UserSummary struct {
 	LastStartedAt time.Time `json:"last_started_at"`
 }
 
+// UserRow is one row of the tenant-owned `users` table (RFC BX Phase 2 /
+// P2a). Unlike UserSummary — which is DERIVED from runs.user_id — this is a
+// first-class identity record a tenant operator explicitly manages.
+//
+// AccessMode is the RFC BX collaboration dial: "tenant" (full whole-tenant
+// collaboration, the default that preserves today's behaviour) or "isolated"
+// (the subject is sandboxed to its own scope). Status is "active" |
+// "disabled". TenantID "" is the shared/legacy tenant. CreatedBy is the
+// principal subject that registered the row (non-secret; "" in open mode).
+type UserRow struct {
+	TenantID    string
+	Subject     string
+	DisplayName string
+	AccessMode  string
+	Status      string
+	CreatedAt   time.Time
+	CreatedBy   string
+}
+
+// UserPatch carries the subset of fields UserUpdate can modify. Pointer
+// fields so nil = "leave unchanged"; non-nil = set to the dereferenced value
+// (including the empty string, e.g. clearing a display name).
+type UserPatch struct {
+	DisplayName *string
+	AccessMode  *string
+	Status      *string
+}
+
+// ValidUserAccessMode / ValidUserStatus are the shared enum checks both store
+// backends AND the HTTP handler use, so the accepted set can't drift between
+// the two backends or between the store and the wire layer (RFC BX P2a).
+func ValidUserAccessMode(mode string) bool {
+	return mode == "tenant" || mode == "isolated"
+}
+
+func ValidUserStatus(status string) bool {
+	return status == "active" || status == "disabled"
+}
+
 // TenantSummary is one tenant's derived activity, from ListTenants.
 type TenantSummary struct {
 	TenantID      string    `json:"tenant_id"`
@@ -1284,6 +1323,36 @@ type Store interface {
 	// workspace + the super-admin tenant-focus), filtering on the
 	// denormalised runs.tenant_id; "" returns all tenants.
 	ListUsers(ctx context.Context, tenantID string) ([]UserSummary, error)
+
+	// UserCreate inserts a first-class user identity row (RFC BX P2a).
+	// Returns *ErrConflict{Kind:"user", ID:subject} on a (tenant, subject)
+	// PK collision. Stamps CreatedAt to now if the caller left it zero.
+	// Rejects an AccessMode / Status outside the shared enum (so a direct
+	// store caller can't persist a value the wire layer would refuse).
+	UserCreate(ctx context.Context, row UserRow) error
+
+	// UserGet returns one identity row by (tenantID, subject). Returns
+	// *ErrNotFound{Kind:"user", ID:subject} when the row is absent — so a
+	// cross-tenant probe is an opaque miss, never an existence oracle.
+	UserGet(ctx context.Context, tenantID, subject string) (UserRow, error)
+
+	// UserList returns every identity row for tenantID ordered by
+	// (tenant_id, subject); tenantID "" returns ALL tenants' rows (the
+	// super-admin path — mirrors ListUsers' "" = all-tenants convention).
+	// Empty slice (not nil) when none match.
+	UserList(ctx context.Context, tenantID string) ([]UserRow, error)
+
+	// UserUpdate patches mutable fields on one identity row. Nil patch
+	// fields leave the corresponding column unchanged. Returns
+	// *ErrNotFound{Kind:"user"} when the (tenant, subject) row is absent,
+	// and rejects an AccessMode / Status outside the shared enum.
+	UserUpdate(ctx context.Context, tenantID, subject string, patch UserPatch) error
+
+	// UserDelete hard-deletes one identity row and reports whether a row
+	// was removed (false = the row did not exist). The subject's OWNED data
+	// (runs / sessions / memory) has no FK to this table and is left intact
+	// — deleting the identity record is not the erasure surface.
+	UserDelete(ctx context.Context, tenantID, subject string) (bool, error)
 
 	// ListTenants enumerates tenants that have RUN something, with derived
 	// per-tenant counts. A GROUP BY over runs.tenant_id, mirroring ListUsers —

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -98,6 +98,11 @@ func Run(t *testing.T, factory Factory) {
 		{"SessionEmbedUpsertSearch", testSessionEmbedUpsertSearch},
 		{"SessionEmbedSearchTenantFold", testSessionEmbedSearchTenantFold},
 		{"ListUsers", testListUsers},
+		// RFC BX P2a: the tenant-owned first-class users table (create / get /
+		// list / update / delete + enum validation, and (tenant, subject) PK
+		// isolation). sqlite always; Postgres when a DSN is set.
+		{"UserCRUD", testUserCRUD},
+		{"UserTenantIsolation", testUserTenantIsolation},
 		{"ListRunsByParentAgentID", testListRunsByParentAgentID},
 		{"UpdateHeartbeat", testUpdateHeartbeat},
 		{"FinishRunCancelledTerminal", testFinishRunCancelledTerminal},
@@ -2718,6 +2723,150 @@ func testListUsers(t *testing.T, s store.Store) {
 	}
 	if len(none) != 0 {
 		t.Errorf("ListUsers(nonexistent) = %d users, want 0", len(none))
+	}
+}
+
+// testUserCRUD pins the RFC BX P2a first-class users-table contract:
+// create→get→list→update→delete, ErrConflict on a duplicate, ErrNotFound on
+// a missing row, created_at stamped when left zero, and access_mode/status
+// enum validation on both create and update.
+func testUserCRUD(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	var nf *store.ErrNotFound
+	var conflict *store.ErrConflict
+
+	// Get / list on an empty table.
+	if _, err := s.UserGet(ctx, "t", "alice"); !errors.As(err, &nf) {
+		t.Fatalf("UserGet(absent) err = %v, want *store.ErrNotFound", err)
+	}
+	if rows, err := s.UserList(ctx, "t"); err != nil || rows == nil || len(rows) != 0 {
+		t.Fatalf("UserList(empty) = %v, %v; want empty NON-nil slice", rows, err)
+	}
+
+	// Create with CreatedAt left zero — the store must stamp it.
+	row := store.UserRow{TenantID: "t", Subject: "alice", DisplayName: "Alice", AccessMode: "tenant", Status: "active", CreatedBy: "ops"}
+	if err := s.UserCreate(ctx, row); err != nil {
+		t.Fatalf("UserCreate: %v", err)
+	}
+	got, err := s.UserGet(ctx, "t", "alice")
+	if err != nil {
+		t.Fatalf("UserGet: %v", err)
+	}
+	if got.Subject != "alice" || got.DisplayName != "Alice" || got.AccessMode != "tenant" || got.Status != "active" || got.CreatedBy != "ops" {
+		t.Errorf("UserGet = %+v, want the created row", got)
+	}
+	if got.CreatedAt.IsZero() {
+		t.Errorf("UserCreate left created_at zero; the store must stamp it")
+	}
+
+	// Duplicate (tenant, subject) → ErrConflict.
+	if err := s.UserCreate(ctx, row); !errors.As(err, &conflict) {
+		t.Fatalf("UserCreate(dup) err = %v, want *store.ErrConflict", err)
+	}
+
+	// Enum validation on create — both fields, rejected before insert.
+	if err := s.UserCreate(ctx, store.UserRow{TenantID: "t", Subject: "bad", AccessMode: "wat", Status: "active"}); err == nil {
+		t.Errorf("UserCreate(bad access_mode) err = nil, want rejection")
+	}
+	if err := s.UserCreate(ctx, store.UserRow{TenantID: "t", Subject: "bad", AccessMode: "tenant", Status: "wat"}); err == nil {
+		t.Errorf("UserCreate(bad status) err = nil, want rejection")
+	}
+
+	// List returns the one committed row.
+	rows, err := s.UserList(ctx, "t")
+	if err != nil || len(rows) != 1 || rows[0].Subject != "alice" {
+		t.Fatalf("UserList = %+v, %v; want exactly [alice]", rows, err)
+	}
+
+	// Update: change display_name + status; leave access_mode untouched.
+	newName, newStatus := "Alice A.", "disabled"
+	if err := s.UserUpdate(ctx, "t", "alice", store.UserPatch{DisplayName: &newName, Status: &newStatus}); err != nil {
+		t.Fatalf("UserUpdate: %v", err)
+	}
+	got, _ = s.UserGet(ctx, "t", "alice")
+	if got.DisplayName != "Alice A." || got.Status != "disabled" || got.AccessMode != "tenant" {
+		t.Errorf("after update = %+v, want name+status changed, access_mode preserved", got)
+	}
+
+	// Enum validation on update.
+	badMode := "nope"
+	if err := s.UserUpdate(ctx, "t", "alice", store.UserPatch{AccessMode: &badMode}); err == nil {
+		t.Errorf("UserUpdate(bad access_mode) err = nil, want rejection")
+	}
+	badStatus := "nope"
+	if err := s.UserUpdate(ctx, "t", "alice", store.UserPatch{Status: &badStatus}); err == nil {
+		t.Errorf("UserUpdate(bad status) err = nil, want rejection")
+	}
+
+	// Update a missing row → ErrNotFound.
+	if err := s.UserUpdate(ctx, "t", "ghost", store.UserPatch{DisplayName: &newName}); !errors.As(err, &nf) {
+		t.Errorf("UserUpdate(absent) err = %v, want *store.ErrNotFound", err)
+	}
+
+	// Delete returns whether a row went; the second delete reports false.
+	removed, err := s.UserDelete(ctx, "t", "alice")
+	if err != nil || !removed {
+		t.Fatalf("UserDelete = %v, %v; want true, nil", removed, err)
+	}
+	if again, _ := s.UserDelete(ctx, "t", "alice"); again {
+		t.Errorf("UserDelete(second) = true, want false (already gone)")
+	}
+	if _, err := s.UserGet(ctx, "t", "alice"); !errors.As(err, &nf) {
+		t.Errorf("UserGet after delete err = %v, want *store.ErrNotFound", err)
+	}
+}
+
+// testUserTenantIsolation pins that the users table is keyed on
+// (tenant_id, subject): two tenants own a same-named subject independently, a
+// third tenant sees neither, a list is confined to its tenant, and deleting
+// one tenant's row leaves the other's intact. tenantID "" reads all tenants.
+func testUserTenantIsolation(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	var nf *store.ErrNotFound
+
+	if err := s.UserCreate(ctx, store.UserRow{TenantID: "t1", Subject: "alice", DisplayName: "T1 Alice", AccessMode: "tenant", Status: "active"}); err != nil {
+		t.Fatalf("create t1/alice: %v", err)
+	}
+	if err := s.UserCreate(ctx, store.UserRow{TenantID: "t2", Subject: "alice", DisplayName: "T2 Alice", AccessMode: "isolated", Status: "active"}); err != nil {
+		t.Fatalf("create t2/alice (same subject, different tenant must be allowed): %v", err)
+	}
+
+	// A third tenant sees neither — an opaque miss, no existence oracle.
+	if _, err := s.UserGet(ctx, "t3", "alice"); !errors.As(err, &nf) {
+		t.Errorf("UserGet(t3,alice) err = %v, want *store.ErrNotFound (cross-tenant invisible)", err)
+	}
+
+	// Each tenant's list contains only its own row.
+	t1rows, _ := s.UserList(ctx, "t1")
+	if len(t1rows) != 1 || t1rows[0].DisplayName != "T1 Alice" {
+		t.Errorf("UserList(t1) = %+v, want only t1's alice", t1rows)
+	}
+	t2rows, _ := s.UserList(ctx, "t2")
+	if len(t2rows) != 1 || t2rows[0].AccessMode != "isolated" {
+		t.Errorf("UserList(t2) = %+v, want only t2's alice (isolated)", t2rows)
+	}
+
+	// Deleting t1's alice leaves t2's alice intact (delete is tenant-scoped).
+	if removed, err := s.UserDelete(ctx, "t1", "alice"); err != nil || !removed {
+		t.Fatalf("UserDelete(t1,alice) = %v, %v; want true", removed, err)
+	}
+	if _, err := s.UserGet(ctx, "t2", "alice"); err != nil {
+		t.Errorf("t2's alice gone after deleting t1's alice: %v (delete must be tenant-scoped)", err)
+	}
+	if _, err := s.UserGet(ctx, "t1", "alice"); !errors.As(err, &nf) {
+		t.Errorf("t1's alice still present after its own delete: %v", err)
+	}
+
+	// tenantID "" reads across all tenants, ordered by (tenant_id, subject).
+	if err := s.UserCreate(ctx, store.UserRow{TenantID: "t1", Subject: "alice", AccessMode: "tenant", Status: "active"}); err != nil {
+		t.Fatalf("recreate t1/alice: %v", err)
+	}
+	all, err := s.UserList(ctx, "")
+	if err != nil {
+		t.Fatalf("UserList(all): %v", err)
+	}
+	if len(all) != 2 || all[0].TenantID != "t1" || all[1].TenantID != "t2" {
+		t.Fatalf("UserList(\"\") = %+v, want [t1/alice, t2/alice] in tenant order", all)
 	}
 }
 


### PR DESCRIPTION
**RFC BX Phase 2, slice 1 of 3.** First-class, tenant-owned users. Table + lifecycle CRUD only — no auth/minting changes (that's P2b) and `access_mode` is stored but not yet enforced (that's P2c).

> Stacked series: **P2a (this)** → P2b (delegated token minting + Web UI) → P2c (`substrate:user` isolated enforcement). Merge in order.

## Why
A "user" was a free-form `subject` derived from run rows (`GET /v1/_users` = `GROUP BY runs.user_id`) — nothing a tenant owned, could manage, or attach a policy to. This makes `user` a first-class, tenant-owned identity.

## What
- **Migration 0068** (both backends): `users(tenant_id, subject)` PK + `display_name`, `access_mode ∈ {tenant,isolated}` (default `tenant` — preserves today's whole-tenant behaviour), `status ∈ {active,disabled}`, `created_at`, `created_by`. `CREATE TABLE IF NOT EXISTS` so migration-replay re-runs cleanly.
- **Store**: `UserRow`/`UserPatch` + `UserCreate/Get/List/Update/Delete` on both backends, every query keyed on `(tenant_id, subject)`; `UserList("")` = all tenants (admin). `access_mode`/`status` enum-validated in one shared helper.
- **Routes**: `POST /v1/_users`, `PATCH`/`DELETE /v1/_users/{subject}`. The `/v1/_users` gate is now **method-aware** — GET stays any-authed (handler tenant-scopes), POST → `substrate:tenant`; PATCH/DELETE fall through the existing `/v1/_users/` → `substrate:tenant` case. Tenant is **server-derived** (`tenantFromCtx`), never the wire; cross-tenant mutate = opaque-404.
- **GET /v1/_users** now **merges** the users table over the run-derived activity lens — additive fields (`registered`/`display_name`/`access_mode`/`status`) so the Web UI picker keeps working.

## Tested
- storetest contract `UserCRUD` + `UserTenantIsolation` — green on **sqlite and real Postgres**.
- api/http tenant-operator confinement + list-merge + the method-aware gate (with a fail-before check).
- `go test ./...` clean; full store + api/http suites green on real PG; migration 0068 applies + is replay-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)