### PR TITLE
feat(auth): substrate:user scope + isolated-user enforcement (RFC BX P2b)

### DIFF
--- a/internal/a2a/auth.go
+++ b/internal/a2a/auth.go
@@ -93,6 +93,28 @@ func OperatorKeyRestrictedFrom(ctx context.Context) bool {
 	return v
 }
 
+// isolatedKeyType keys the RFC BX P2b isolation bit the A2A frontier interceptor
+// derived from the authenticated peer's OWN scopes (auth.IsIsolated). The
+// interceptor stamps it on the request ctx (WithIsolated); the executor reads it
+// in buildRunInput and copies it onto RunInput so a substrate:user A2A peer's
+// run stays data-scope-confined (anti-bypass: it can't launder an unconfined run
+// through the A2A trigger). Mirrors operatorKeyRestrictedKeyType.
+type isolatedKeyType struct{}
+
+// WithIsolated stamps the RFC BX P2b isolation bit onto ctx. The A2A principal
+// interceptor calls this from its Before with the value it derived from the
+// peer's resolved scopes; the returned ctx flows to the executor.
+func WithIsolated(ctx context.Context, isolated bool) context.Context {
+	return context.WithValue(ctx, isolatedKeyType{}, isolated)
+}
+
+// IsolatedFrom returns the RFC BX P2b isolation bit the interceptor stamped, or
+// false when absent (fail-open — an un-stamped path is unconfined).
+func IsolatedFrom(ctx context.Context) bool {
+	v, _ := ctx.Value(isolatedKeyType{}).(bool)
+	return v
+}
+
 // principalFromContext extracts the authenticated principal from the
 // SDK CallContext on ctx, combined with the request tenant. The tenant
 // argument is the SDK-carried value (SendMessageRequest.Tenant /

--- a/internal/a2a/executor.go
+++ b/internal/a2a/executor.go
@@ -439,6 +439,10 @@ func (e *Executor) buildRunInput(ctx context.Context, execCtx *a2asrv.ExecutorCo
 		// interceptor derived from THIS peer's own scopes, so a restricted A2A
 		// peer's run is restricted at admission (RunOnce reads this off RunInput).
 		OperatorKeyRestricted: OperatorKeyRestrictedFrom(ctx),
+		// RFC BX P2b anti-bypass: carry the isolation bit the frontier interceptor
+		// derived from THIS peer's own scopes, so a substrate:user A2A peer's run is
+		// data-scope-confined at admission (RunOnce reads this off RunInput).
+		Isolated: IsolatedFrom(ctx),
 	}, nil
 }
 

--- a/internal/api/a2a/auth.go
+++ b/internal/api/a2a/auth.go
@@ -37,25 +37,25 @@ func FrontierAuthenticator(
 	resolve func(context.Context, string) (auth.Principal, bool),
 	operatorKeyGateOn bool,
 ) Authenticator {
-	return func(h http.Header) (string, bool, bool) {
+	return func(h http.Header) (string, bool, bool, bool) {
 		ctx := context.Background()
 		// Per-request open-mode check: no auth configured ⇒ anonymous, matching
 		// HTTP. Evaluated every call so a runtime-minted admin token flips A2A
-		// closed without a restart. Open mode is never restricted (fail-open).
+		// closed without a restart. Open mode is never restricted/isolated (fail-open).
 		if authConfigured == nil || !authConfigured(ctx) {
-			return "anonymous", false, true
+			return "anonymous", false, false, true
 		}
 		got := h.Get("Authorization")
 		const pfx = "Bearer "
 		if len(got) <= len(pfx) || !strings.EqualFold(got[:len(pfx)], pfx) {
-			return "", false, false
+			return "", false, false, false
 		}
 		if resolve == nil {
-			return "", false, false
+			return "", false, false, false
 		}
 		p, ok := resolve(ctx, got[len(pfx):])
 		if !ok {
-			return "", false, false
+			return "", false, false, false
 		}
 		// RFC AX: derive the operator-key restriction from the peer's OWN
 		// resolved scopes — the SAME auth.OperatorKeyRestricted used on the
@@ -63,11 +63,15 @@ func FrontierAuthenticator(
 		// that lacks providers:operator-key is restricted; a legacy peer / one
 		// holding the scope / the gate-off case all fail open (false).
 		restricted := auth.OperatorKeyRestricted(p, ok, operatorKeyGateOn)
+		// RFC BX P2b: derive the isolation bit from the peer's OWN resolved scopes
+		// — the SAME auth.IsIsolated used on the HTTP plane. A substrate:user peer
+		// is isolated; admin/tenant/legacy/open-mode all fail open (false).
+		isolated := auth.IsIsolated(p, ok)
 		// Attribution name only. Preserve the legacy peer's historical
 		// "a2a-peer" name; attribute operator-token peers by their subject.
 		if p.Legacy || p.Subject == "" {
-			return "a2a-peer", restricted, true
+			return "a2a-peer", restricted, isolated, true
 		}
-		return p.Subject, restricted, true
+		return p.Subject, restricted, isolated, true
 	}
 }

--- a/internal/api/a2a/auth_test.go
+++ b/internal/api/a2a/auth_test.go
@@ -24,17 +24,17 @@ func TestFrontierAuthenticator_OperatorTokenOnlyIsGated(t *testing.T) {
 	authn := FrontierAuthenticator(authConfigured, resolve, false)
 
 	// No credential → rejected (the interceptor turns this into ErrUnauthenticated).
-	if _, _, ok := authn(http.Header{}); ok {
+	if _, _, _, ok := authn(http.Header{}); ok {
 		t.Error("operator-token-only mode: missing bearer must be rejected, got ok=true (A2A open!)")
 	}
 	// Wrong credential → rejected.
 	bad := http.Header{"Authorization": []string{"Bearer nope"}}
-	if _, _, ok := authn(bad); ok {
+	if _, _, _, ok := authn(bad); ok {
 		t.Error("operator-token-only mode: invalid bearer must be rejected")
 	}
 	// Valid operator token → accepted, attributed by subject.
 	good := http.Header{"Authorization": []string{"Bearer lct_alice"}}
-	name, _, ok := authn(good)
+	name, _, _, ok := authn(good)
 	if !ok || name != "alice" {
 		t.Errorf("valid operator token: name=%q ok=%v, want (\"alice\", true)", name, ok)
 	}
@@ -60,16 +60,16 @@ func TestFrontierAuthenticator_RestrictionDerivedFromScopes(t *testing.T) {
 
 	// Gate ON: granular peer is restricted; keyed peer is not.
 	on := FrontierAuthenticator(authConfigured, resolve, true)
-	if _, restricted, ok := on(hdr("granular")); !ok || !restricted {
+	if _, restricted, _, ok := on(hdr("granular")); !ok || !restricted {
 		t.Errorf("gate on, granular peer: (restricted=%v, ok=%v), want (true, true)", restricted, ok)
 	}
-	if _, restricted, ok := on(hdr("keyed")); !ok || restricted {
+	if _, restricted, _, ok := on(hdr("keyed")); !ok || restricted {
 		t.Errorf("gate on, keyed peer: (restricted=%v, ok=%v), want (false, true)", restricted, ok)
 	}
 
 	// Gate OFF: nobody is restricted (byte-identical to pre-RFC-AX).
 	off := FrontierAuthenticator(authConfigured, resolve, false)
-	if _, restricted, ok := off(hdr("granular")); !ok || restricted {
+	if _, restricted, _, ok := off(hdr("granular")); !ok || restricted {
 		t.Errorf("gate off, granular peer: (restricted=%v, ok=%v), want (false, true)", restricted, ok)
 	}
 }
@@ -79,7 +79,7 @@ func TestFrontierAuthenticator_RestrictionDerivedFromScopes(t *testing.T) {
 // mirroring the HTTP authMiddleware.
 func TestFrontierAuthenticator_OpenModeAnonymous(t *testing.T) {
 	authn := FrontierAuthenticator(func(context.Context) bool { return false }, nil, true)
-	name, restricted, ok := authn(http.Header{})
+	name, restricted, _, ok := authn(http.Header{})
 	if !ok || name != "anonymous" || restricted {
 		t.Errorf("open mode: name=%q restricted=%v ok=%v, want (\"anonymous\", false, true)", name, restricted, ok)
 	}
@@ -98,7 +98,7 @@ func TestFrontierAuthenticator_LegacyPeerKeepsName(t *testing.T) {
 	}
 	// Gate ON to also prove a legacy peer is never restricted (fail-open).
 	authn := FrontierAuthenticator(func(context.Context) bool { return true }, resolve, true)
-	name, restricted, ok := authn(http.Header{"Authorization": []string{"Bearer legacy-secret"}})
+	name, restricted, _, ok := authn(http.Header{"Authorization": []string{"Bearer legacy-secret"}})
 	if !ok || name != "a2a-peer" || restricted {
 		t.Errorf("legacy peer: name=%q restricted=%v ok=%v, want (\"a2a-peer\", false, true)", name, restricted, ok)
 	}

--- a/internal/api/a2a/routing.go
+++ b/internal/api/a2a/routing.go
@@ -36,7 +36,7 @@ func (p *principalInterceptor) Before(ctx context.Context, callCtx *a2asrv.CallC
 		callCtx.User = a2asrv.NewAuthenticatedUser("anonymous", nil)
 		return ctx, nil, nil
 	}
-	name, restricted, ok := p.auth(serviceParamsToHeader(callCtx.ServiceParams()))
+	name, restricted, isolated, ok := p.auth(serviceParamsToHeader(callCtx.ServiceParams()))
 	if !ok {
 		// Auth is configured but the request carried no valid credential.
 		// REJECT at the frontier: returning a non-nil error from a
@@ -52,9 +52,12 @@ func (p *principalInterceptor) Before(ctx context.Context, callCtx *a2asrv.CallC
 		return ctx, nil, a2asdk.ErrUnauthenticated
 	}
 	callCtx.User = a2asrv.NewAuthenticatedUser(name, nil)
-	// RFC AX: thread the peer-derived operator-key restriction to the executor
-	// (the returned ctx propagates to the handler → buildRunInput → RunInput).
-	return bridge.WithOperatorKeyRestricted(ctx, restricted), nil, nil
+	// RFC AX + RFC BX P2b: thread the peer-derived operator-key restriction AND
+	// isolation bit to the executor (the returned ctx propagates to the handler →
+	// buildRunInput → RunInput).
+	ctx = bridge.WithOperatorKeyRestricted(ctx, restricted)
+	ctx = bridge.WithIsolated(ctx, isolated)
+	return ctx, nil, nil
 }
 
 // serviceParamsToHeader projects the SDK ServiceParams (request headers,

--- a/internal/api/a2a/routing_auth_test.go
+++ b/internal/api/a2a/routing_auth_test.go
@@ -27,7 +27,7 @@ func TestPrincipalInterceptor_RejectsUnauthenticated(t *testing.T) {
 
 	// Auth configured but the credential is rejected → ErrUnauthenticated,
 	// principal left unauthenticated.
-	denied := principalInterceptor{auth: func(http.Header) (string, bool, bool) { return "", false, false }}
+	denied := principalInterceptor{auth: func(http.Header) (string, bool, bool, bool) { return "", false, false, false }}
 	cc := newCtx()
 	if _, _, err := denied.Before(context.Background(), cc, &a2asrv.Request{}); !errors.Is(err, a2asdk.ErrUnauthenticated) {
 		t.Fatalf("Before err = %v, want ErrUnauthenticated", err)
@@ -38,7 +38,7 @@ func TestPrincipalInterceptor_RejectsUnauthenticated(t *testing.T) {
 
 	// Auth configured and the credential is accepted → no error, principal
 	// stamped with the resolved name.
-	ok := principalInterceptor{auth: func(http.Header) (string, bool, bool) { return "alice", false, true }}
+	ok := principalInterceptor{auth: func(http.Header) (string, bool, bool, bool) { return "alice", false, false, true }}
 	cc = newCtx()
 	newCtxOut, _, err := ok.Before(context.Background(), cc, &a2asrv.Request{})
 	if err != nil {
@@ -53,7 +53,7 @@ func TestPrincipalInterceptor_RejectsUnauthenticated(t *testing.T) {
 	}
 
 	// A RESTRICTED peer → the returned ctx carries the bit for the executor.
-	restricted := principalInterceptor{auth: func(http.Header) (string, bool, bool) { return "bob", true, true }}
+	restricted := principalInterceptor{auth: func(http.Header) (string, bool, bool, bool) { return "bob", true, false, true }}
 	cc = newCtx()
 	rctx, _, err := restricted.Before(context.Background(), cc, &a2asrv.Request{})
 	if err != nil {
@@ -61,6 +61,22 @@ func TestPrincipalInterceptor_RejectsUnauthenticated(t *testing.T) {
 	}
 	if !bridge.OperatorKeyRestrictedFrom(rctx) {
 		t.Error("restricted peer must stamp OperatorKeyRestricted=true on the ctx")
+	}
+	// RFC BX P2b: a restricted-but-not-isolated peer stamps Isolated=false.
+	if bridge.IsolatedFrom(rctx) {
+		t.Error("restricted (non-isolated) peer must stamp Isolated=false")
+	}
+
+	// RFC BX P2b: an ISOLATED peer (substrate:user) → the returned ctx carries the
+	// isolation bit for the executor's buildRunInput.
+	isolated := principalInterceptor{auth: func(http.Header) (string, bool, bool, bool) { return "carol", false, true, true }}
+	cc = newCtx()
+	ictx, _, err := isolated.Before(context.Background(), cc, &a2asrv.Request{})
+	if err != nil {
+		t.Fatalf("Before err = %v, want nil on accepted (isolated) auth", err)
+	}
+	if !bridge.IsolatedFrom(ictx) {
+		t.Error("isolated peer must stamp Isolated=true on the ctx")
 	}
 
 	// No authenticator (open/dev mode) → anonymous authenticated, no error.

--- a/internal/api/a2a/server.go
+++ b/internal/api/a2a/server.go
@@ -33,10 +33,16 @@ import (
 // providers:operator-key). The interceptor stamps it on ctx so the executor's
 // buildRunInput can copy it onto RunInput — anti-bypass for the A2A trigger.
 //
+// isolated (RFC BX P2b) is likewise meaningful only when ok is true: the
+// single-resolve derivation of "is this peer an isolated member (substrate:user)"
+// (auth.IsIsolated; false in open mode / for a legacy peer). The interceptor
+// stamps it on ctx so buildRunInput copies it onto RunInput — anti-bypass so a
+// substrate:user peer's run stays data-scope-confined.
+//
 // This is the bearer-header check at the A2A frontier, reusing the same
 // constant-time comparison loomcycle's HTTP authMiddleware uses. It is
 // injected so tests can supply a deterministic fake.
-type Authenticator func(h http.Header) (name string, restricted bool, ok bool)
+type Authenticator func(h http.Header) (name string, restricted bool, isolated bool, ok bool)
 
 // CardAndRunStore is the narrow store surface the A2A server needs: the
 // active-server-card resolver path (lookup), the run-table reader the
@@ -420,6 +426,6 @@ func (s *Server) adminAuthed(r *http.Request) bool {
 		// authorized, matching authMiddleware's open-mode behaviour.
 		return true
 	}
-	_, _, ok := s.deps.Auth(r.Header)
+	_, _, _, ok := s.deps.Auth(r.Header)
 	return ok
 }

--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -325,6 +325,31 @@ func (s *Server) operatorKeyRestrictedForCtx(ctx context.Context) bool {
 	return auth.OperatorKeyRestricted(p, ok, s.cfg.Env.OperatorKeyRestriction)
 }
 
+// isolatedForCtx computes the RFC BX P2b isolation bit from the LIVE principal on
+// ctx — the run-start path for surfaces that carry an auth.Principal (HTTP, and
+// gRPC/MCP/connector via applyPrincipal). Server-derived only (never a wire/body/
+// model field). Fail-open: no principal (open mode) / a principal whose authority
+// is tenant/admin all yield false (unconfined). See auth.IsIsolated. Sibling of
+// operatorKeyRestrictedForCtx; unlike that one there is NO deployment gate —
+// substrate:user is always enforced when present.
+func (s *Server) isolatedForCtx(ctx context.Context) bool {
+	p, ok := auth.PrincipalFromContext(ctx)
+	return auth.IsIsolated(p, ok)
+}
+
+// isolatedOrCaptured is the RunOnce variant (sibling of
+// operatorKeyRestrictedOrCaptured): use the live principal when one is on ctx
+// (gRPC/MCP/connector), else fall back to the bit CAPTURED on a trigger def by a
+// non-principal path (scheduler/webhook/A2A supply it via RunInput.Isolated).
+// RFC BX P2b anti-bypass: an isolated member's captured confinement must ride the
+// trigger def since no token is present at fire time.
+func (s *Server) isolatedOrCaptured(ctx context.Context, captured bool) bool {
+	if p, ok := auth.PrincipalFromContext(ctx); ok {
+		return auth.IsIsolated(p, ok)
+	}
+	return captured
+}
+
 // operatorKeyRestrictedOrCaptured is the RunOnce variant: use the live principal
 // when one is on ctx (gRPC/MCP/connector), else fall back to the bit CAPTURED on
 // a trigger def by a non-principal path (scheduler/webhook/A2A supply it via

--- a/internal/api/http/resume.go
+++ b/internal/api/http/resume.go
@@ -253,6 +253,11 @@ func (s *Server) resumePausedRun(ctx context.Context, run store.Run) error {
 		// column — the original principal isn't on ctx for a resumed/crash-
 		// recovered run, so the durable bit is the authority.
 		OperatorKeyRestricted: run.OperatorKeyRestricted,
+		// RFC BX P2b: RESTORE the isolation confinement from the persisted runs
+		// column — same rationale: no principal on ctx for a resumed run, so the
+		// durable bit is the authority. Without this a paused isolated run could
+		// escape its data-scope confinement on resume.
+		Isolated: run.Isolated,
 	}
 	// Store-only emit (no live client to forward to) — the resumed turns
 	// append to the same run's transcript so a re-attaching operator tails them.

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -892,6 +892,9 @@ func (s *Server) admitTeamRun(ctx context.Context) (context.Context, error) {
 	}
 	restricted := s.operatorKeyRestrictedOrCaptured(ctx, id.OperatorKeyRestricted)
 	id.OperatorKeyRestricted = restricted
+	// RFC BX P2b: re-derive the isolation bit (live principal wins; else the bit
+	// inherited on the ctx RunIdentity) so a team run's tools stay confined.
+	id.Isolated = s.isolatedOrCaptured(ctx, id.Isolated)
 	ctx = tools.WithRunIdentity(ctx, id)
 	ctx = providers.WithOperatorKeyAllowed(ctx, !restricted)
 	ctx = builtin.IncrementAgentDepth(ctx)
@@ -2197,6 +2200,10 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	// continuation recomputes from the presenting principal (current token is
 	// authority), matching handleMessages.
 	operatorKeyRestricted := s.operatorKeyRestrictedOrCaptured(ctx, in.OperatorKeyRestricted)
+	// RFC BX P2b: same posture — live principal (gRPC/MCP/connector) wins, else the
+	// bit CAPTURED on the trigger def and supplied via RunInput.Isolated. Confines
+	// the fired run's data tools to its own user/agent scope (anti-bypass).
+	isolated := s.isolatedOrCaptured(ctx, in.Isolated)
 
 	if effectiveAgentName == "" {
 		return fmt.Errorf("%w: agent is required", runner.ErrInvalidArgument)
@@ -2330,7 +2337,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	}
 
 	// ---- Session+run creation ----
-	identity := store.RunIdentity{AgentID: agentID, UserID: effectiveUserID, TenantID: effectiveTenantID, UserTier: in.UserTier, Model: model, ReplicaID: s.replicaID, ParentContext: in.ParentContext, IdempotencyKey: in.IdempotencyKey, Interactive: in.Interactive, OperatorKeyRestricted: operatorKeyRestricted}
+	identity := store.RunIdentity{AgentID: agentID, UserID: effectiveUserID, TenantID: effectiveTenantID, UserTier: in.UserTier, Model: model, ReplicaID: s.replicaID, ParentContext: in.ParentContext, IdempotencyKey: in.IdempotencyKey, Interactive: in.Interactive, OperatorKeyRestricted: operatorKeyRestricted, Isolated: isolated}
 	sessionID, runID, sessErr := s.openOrCreateSessionAndRun(ctx, in.SessionID, effectiveAgentName, effectiveTenantID, effectiveUserID, identity)
 	if sessErr != nil {
 		var nf *store.ErrNotFound
@@ -2441,6 +2448,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 		UserCredentials:       in.UserCredentials, // v1.x RFC F: per-tool named credentials
 		ParentContext:         in.ParentContext,   // v0.12.x: opaque tracking lineage, inherited by sub-agents
 		OperatorKeyRestricted: operatorKeyRestricted,
+		Isolated:              isolated, // RFC BX P2b: confine data tools to own scope
 	}
 	emit := s.makeRecordingEmit(ctx, runID, rid, sessionID, func(ev providers.Event) {
 		if cb.OnEvent != nil {
@@ -3635,6 +3643,10 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	// Fail-open when the gate is off or no principal is present (stage 1 threads
 	// it; enforcement is stage 2).
 	operatorKeyRestricted := s.operatorKeyRestrictedForCtx(r.Context())
+	// RFC BX P2b: derive the isolation bit from the live principal (server
+	// authority) so the run identity / row / ctx all agree and the data tools
+	// confine an isolated member to its own user/agent scope.
+	isolated := s.isolatedForCtx(r.Context())
 
 	// Existence-check the agent at the run's authoritative tenant.
 	agentDef, ok := s.lookupAgent(r.Context(), req.TenantID, req.Agent)
@@ -3829,7 +3841,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	// emitted event through the store before forwarding to SSE. With
 	// s.store == nil the recording becomes a no-op so v0.2 callers see no
 	// behaviour change.
-	identity := store.RunIdentity{AgentID: agentID, UserID: req.UserID, TenantID: req.TenantID, UserTier: req.UserTier, Model: model, ReplicaID: s.replicaID, ParentContext: req.ParentContext, Interactive: req.Interactive, OperatorKeyRestricted: operatorKeyRestricted}
+	identity := store.RunIdentity{AgentID: agentID, UserID: req.UserID, TenantID: req.TenantID, UserTier: req.UserTier, Model: model, ReplicaID: s.replicaID, ParentContext: req.ParentContext, Interactive: req.Interactive, OperatorKeyRestricted: operatorKeyRestricted, Isolated: isolated}
 	sessionID, runID, sessErr := s.openOrCreateSessionAndRun(r.Context(), req.SessionID, req.Agent, req.TenantID, req.UserID, identity)
 	if sessErr != nil {
 		var nf *store.ErrNotFound
@@ -4001,6 +4013,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		UserCredentials:       req.UserCredentials, // v1.x RFC F: per-tool named credentials
 		ParentContext:         req.ParentContext,   // v0.12.x: opaque tracking lineage, inherited by sub-agents
 		OperatorKeyRestricted: operatorKeyRestricted,
+		Isolated:              isolated, // RFC BX P2b: confine data tools to own scope
 	}
 	// Persist under runCtx so events survive a client disconnect on an
 	// interactive run (runCtx tracks the request for a normal run).
@@ -4361,6 +4374,9 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	// decision, not the original run's bit). Computed here so credential-aware
 	// routing (resolveAgent) and the fallback cascade both honor it.
 	operatorKeyRestricted := s.operatorKeyRestrictedForCtx(r.Context())
+	// RFC BX P2b: recompute isolation from the PRESENTING principal (the current
+	// token is authority on a continuation, mirroring operatorKeyRestricted).
+	isolated := s.isolatedForCtx(r.Context())
 	providerID, model, effort, err := s.resolveAgent(r.Context(), sess.TenantID, sess.UserID, sess.Agent, body.UserTier, operatorKeyRestricted)
 	if err != nil {
 		writeResolveError(w, err)
@@ -4488,6 +4504,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		ReplicaID:             s.replicaID,
 		ParentContext:         body.ParentContext, // v0.12.x: tracking lineage for this continuation + its sub-agents
 		OperatorKeyRestricted: operatorKeyRestricted,
+		Isolated:              isolated, // RFC BX P2b: confine data tools to own scope
 	})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -4588,6 +4605,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		UserCredentials:       body.UserCredentials, // v1.x RFC F: per-tool named credentials
 		ParentContext:         body.ParentContext,   // v0.12.x: opaque tracking lineage, inherited by sub-agents
 		OperatorKeyRestricted: operatorKeyRestricted,
+		Isolated:              isolated, // RFC BX P2b: confine data tools to own scope
 	}
 	emit := s.makeRecordingEmit(r.Context(), run.ID, rid, id, stream.send)
 	// RFC AW: emit any soft budget crossings found at admission so the warning
@@ -5603,6 +5621,9 @@ func (s *Server) prepareSubRun(ctx context.Context, name, prompt, defID string, 
 		// RFC AX: a child INHERITS the parent's operator-key restriction — it
 		// cannot escape by spawning. Persisted so a resumed sub-run keeps it.
 		OperatorKeyRestricted: parentIdentity.OperatorKeyRestricted,
+		// RFC BX P2b: a child INHERITS the parent's isolation confinement — it
+		// cannot escape by spawning. Persisted so a resumed sub-run keeps it.
+		Isolated: parentIdentity.Isolated,
 	}
 	subSessionID, subRunID, err := s.openOrCreateSessionAndRun(ctx, "", name, parentIdentity.TenantID, parentIdentity.UserID, subIdentity)
 	if err != nil {
@@ -5795,6 +5816,9 @@ func (s *Server) prepareSubRun(ctx context.Context, name, prompt, defID string, 
 		// escape). The providers ctx value inherits automatically via
 		// subRunCtx←ctx (same as WithCredentialResolver), so no re-stamp needed.
 		OperatorKeyRestricted: parentIdentity.OperatorKeyRestricted,
+		// RFC BX P2b: inherit the parent's isolation confinement (a child cannot
+		// escape by spawning). Read from ctx RunIdentity by the data tools.
+		Isolated: parentIdentity.Isolated,
 	}
 	// Sub-emit records to the sub's transcript only — the parent's SSE
 	// stream is fwd=no-op so sub events don't bleed into the parent's

--- a/internal/api/http/users.go
+++ b/internal/api/http/users.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 )
 
@@ -92,6 +93,21 @@ func (s *Server) handleListUsers(w http.ResponseWriter, r *http.Request) {
 			AccessMode:  rec.AccessMode,
 			Status:      rec.Status,
 		})
+	}
+	// RFC BX P2b: an ISOLATED member (substrate:user) may see ONLY its own user
+	// record — never the tenant roster (that is tenant-shared information an
+	// isolated member has no authority over). Server-derived from the principal;
+	// the roster fetched above was already tenant-scoped, so this narrows to self
+	// before anything is written. Admin / tenant / open-mode are unaffected.
+	if s.isolatedForCtx(r.Context()) {
+		p, _ := auth.PrincipalFromContext(r.Context())
+		selfOnly := make([]wireUserSummary, 0, 1)
+		for _, u := range resp.Users {
+			if u.UserID == p.Subject {
+				selfOnly = append(selfOnly, u)
+			}
+		}
+		resp.Users = selfOnly
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)

--- a/internal/api/http/users_isolated_test.go
+++ b/internal/api/http/users_isolated_test.go
@@ -1,0 +1,138 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// RFC BX P2b: the run-start derivation used at every principal-bearing run entry
+// (RunOnce / handleRun / handleMessages / admitTeamRun). isolatedForCtx stamps
+// RunIdentity.Isolated=true for a substrate:user principal and false for tenant /
+// admin / open mode. isolatedOrCaptured additionally honours a bit CAPTURED on a
+// trigger def when no principal is present (scheduler/webhook/A2A fire path).
+func TestIsolatedForCtx_Matrix(t *testing.T) {
+	s := &Server{cfg: &config.Config{}}
+	ctxWith := func(scopes ...string) context.Context {
+		return auth.WithPrincipal(context.Background(), auth.Principal{TenantID: "acme", Subject: "x", Scopes: scopes})
+	}
+	cases := []struct {
+		name string
+		ctx  context.Context
+		want bool
+	}{
+		{"substrate:user", ctxWith(auth.ScopeUser), true},
+		{"substrate:tenant", ctxWith(auth.ScopeTenant), false},
+		{"substrate:admin", ctxWith(auth.ScopeAdmin), false},
+		{"user+tenant not isolated", ctxWith(auth.ScopeUser, auth.ScopeTenant), false},
+		{"open mode (no principal)", context.Background(), false},
+	}
+	for _, c := range cases {
+		if got := s.isolatedForCtx(c.ctx); got != c.want {
+			t.Errorf("%s: isolatedForCtx = %v, want %v", c.name, got, c.want)
+		}
+	}
+
+	// isolatedOrCaptured: a live principal wins; with NO principal the captured
+	// trigger-def bit is authority (anti-bypass for scheduler/webhook/A2A).
+	userCtx := ctxWith(auth.ScopeUser)
+	if !s.isolatedOrCaptured(userCtx, false) {
+		t.Error("isolatedOrCaptured: live substrate:user principal must yield true even when captured=false")
+	}
+	if s.isolatedOrCaptured(ctxWith(auth.ScopeTenant), true) {
+		t.Error("isolatedOrCaptured: live tenant principal must yield false even when captured=true (live principal wins)")
+	}
+	if !s.isolatedOrCaptured(context.Background(), true) {
+		t.Error("isolatedOrCaptured: no principal must fall back to captured=true")
+	}
+	if s.isolatedOrCaptured(context.Background(), false) {
+		t.Error("isolatedOrCaptured: no principal + captured=false must yield false")
+	}
+}
+
+// RFC BX P2b: a substrate:user (isolated member) principal does NOT satisfy the
+// ScopeTenant gate on the operator/tenant-plane routes, so the authMiddleware
+// 403s it before any handler runs; it DOES satisfy the run routes (userImplied).
+// This is the route-level half of the confinement (the data-tool half is in
+// internal/tools/builtin).
+func TestRequiredScope_IsolatedUserDeniedTenantRoutes(t *testing.T) {
+	user := []string{auth.ScopeUser}
+
+	// Tenant/operator-plane routes → the isolated member is refused.
+	denied := []struct{ method, path string }{
+		{"GET", "/v1/_memory/scopes"},
+		{"GET", "/v1/_channels"},
+		{"POST", "/v1/_agentdef"},
+		{"GET", "/v1/_usage"},
+		{"GET", "/v1/_tenants"}, // ScopeAdmin — also refused
+	}
+	for _, rt := range denied {
+		req := requiredScopeFor(rt.method, rt.path)
+		if req == "" {
+			t.Fatalf("%s %s has no required scope — test premise is stale", rt.method, rt.path)
+		}
+		if auth.HasScope(user, req) {
+			t.Errorf("substrate:user must be DENIED %s %s (requires %q)", rt.method, rt.path, req)
+		}
+	}
+
+	// Run routes → the isolated member is allowed (userImplied).
+	allowed := []struct{ method, path string }{
+		{"POST", "/v1/runs"},
+		{"GET", "/v1/runs/abc123"},
+	}
+	for _, rt := range allowed {
+		req := requiredScopeFor(rt.method, rt.path)
+		if !auth.HasScope(user, req) {
+			t.Errorf("substrate:user must be ALLOWED %s %s (requires %q)", rt.method, rt.path, req)
+		}
+	}
+}
+
+// RFC BX P2b: GET /v1/_users returns ONLY the caller's own record for an isolated
+// member — never the tenant roster. A substrate:tenant operator still sees the
+// whole tenant (regression).
+func TestHandleListUsers_IsolatedSeesOnlySelf(t *testing.T) {
+	s, st := tokenAuthServer(t, "legacy")
+	ctx := context.Background()
+	// Three registered users in one tenant.
+	for _, subj := range []string{"alice", "bob", "carol"} {
+		if err := st.UserCreate(ctx, store.UserRow{TenantID: "acme", Subject: subj, AccessMode: "tenant", Status: "active"}); err != nil {
+			t.Fatalf("seed acme/%s: %v", subj, err)
+		}
+	}
+
+	listFor := func(p auth.Principal) []wireUserSummary {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/v1/_users", nil)
+		req = req.WithContext(auth.WithPrincipal(req.Context(), p))
+		s.handleListUsers(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("list status %d: %s", rec.Code, rec.Body.String())
+		}
+		var resp listUsersResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return resp.Users
+	}
+
+	// Isolated alice → sees ONLY alice.
+	isolated := auth.Principal{TenantID: "acme", Subject: "alice", Scopes: []string{auth.ScopeUser}}
+	got := listFor(isolated)
+	if len(got) != 1 || got[0].UserID != "alice" {
+		t.Errorf("isolated alice list = %+v, want exactly [alice]", got)
+	}
+
+	// Tenant operator → sees the whole tenant roster (regression: not narrowed).
+	op := auth.Principal{TenantID: "acme", Subject: "ops", Scopes: []string{auth.ScopeTenant}}
+	if n := len(listFor(op)); n != 3 {
+		t.Errorf("tenant operator list = %d users, want 3 (whole tenant)", n)
+	}
+}

--- a/internal/api/webhook/runinput.go
+++ b/internal/api/webhook/runinput.go
@@ -177,6 +177,9 @@ func buildRunInput(w config.Webhook, proj projectResult, envAllowlist map[string
 		// RFC AX: the captured operator-key restriction — no principal is on ctx
 		// at delivery time, so the def's captured bit is authority (anti-bypass).
 		OperatorKeyRestricted: w.OperatorKeyRestricted,
+		// RFC BX P2b: the captured isolation bit — same anti-bypass rationale as
+		// OperatorKeyRestricted (no principal at delivery time).
+		Isolated: w.Isolated,
 		// IdempotencyKey is set by the caller (deliverSpawn) to the
 		// delivery id, keeping this builder's signature focused on the
 		// Def + projected payload. See RFC H Decision 10 "Layer 2".

--- a/internal/auth/scopes.go
+++ b/internal/auth/scopes.go
@@ -22,6 +22,18 @@ const (
 	// RFC L "principal-wins tenant" rule, extended from reads to writes).
 	ScopeTenant = "substrate:tenant"
 
+	// ScopeUser (RFC BX P2b) is the ISOLATED-MEMBER scope: operate within the
+	// principal's own tenant but confined to the caller's OWN user-scope
+	// (scope=user, scope_id=<my subject>) and own agents — NO access to the
+	// tenant's shared (tenant/global) data, no other users, no operator plane.
+	// It is DELIBERATELY NOT tenant-implied: unlike substrate:tenant it does not
+	// satisfy ScopeTenant/ScopeAdmin (so every /v1/_* tenant-admin route
+	// auto-denies it), and the data tools additionally refuse the tenant/global
+	// keyspace for a run stamped isolated (see tools.ConfineIsolatedScope). It
+	// implies only runs:create/runs:read (userImplied) — an isolated member must
+	// be able to run + read their own runs.
+	ScopeUser = "substrate:user"
+
 	ScopeRunsCreate     = "runs:create"
 	ScopeRunsRead       = "runs:read"
 	ScopeChannelPublish = "channel:publish"
@@ -51,6 +63,7 @@ const (
 var scopeCatalog = map[string]struct{}{
 	ScopeAdmin:                {},
 	ScopeTenant:               {},
+	ScopeUser:                 {},
 	ScopeRunsCreate:           {},
 	ScopeRunsRead:             {},
 	ScopeChannelPublish:       {},
@@ -70,6 +83,18 @@ var tenantImplied = map[string]struct{}{
 	ScopeChannelPublish:       {},
 	ScopeChannelRead:          {},
 	ScopeProvidersOperatorKey: {},
+}
+
+// userImplied is the set ScopeUser satisfies (RFC BX P2b). An isolated member
+// may create + read their OWN runs (subject-stamped; the data tools confine the
+// scope_id). It DELIBERATELY does NOT contain ScopeTenant, ScopeAdmin, or the
+// channel scopes — an isolated member has no tenant-shared authority, so it must
+// not satisfy any tenant-plane gate. ScopeUser satisfies itself (present here) so
+// a substrate:user token passes an explicit substrate:user check.
+var userImplied = map[string]struct{}{
+	ScopeUser:       {},
+	ScopeRunsCreate: {},
+	ScopeRunsRead:   {},
 }
 
 // ValidScope reports whether s is in the closed catalog.
@@ -107,8 +132,35 @@ func HasScope(granted []string, want string) bool {
 				return true
 			}
 		}
+		// RFC BX P2b: ScopeUser satisfies ONLY the userImplied set (itself +
+		// runs:create/read). It intentionally does NOT satisfy ScopeTenant or
+		// ScopeAdmin — an isolated member is auto-denied every tenant-plane /
+		// operator-plane gate.
+		if g == ScopeUser {
+			if _, ok := userImplied[want]; ok {
+				return true
+			}
+		}
 	}
 	return false
+}
+
+// IsIsolated reports whether principal p is an ISOLATED MEMBER (RFC BX P2b): its
+// authority tops out at substrate:user — it holds ScopeUser but neither
+// ScopeTenant nor ScopeAdmin. The isolation decision is SERVER-DERIVED from the
+// resolved principal's scopes, never from a request body / URL / model text. ok
+// is the PrincipalFromContext presence bool (false = open mode → never isolated).
+//
+// Note HasScope treats substrate:admin as satisfying every scope, so an admin
+// would pass HasScope(_, ScopeUser); the explicit !HasScope(_, ScopeAdmin) /
+// !HasScope(_, ScopeTenant) guards below exclude admin + tenant, leaving exactly
+// the substrate:user-topped principals. A token holding BOTH substrate:user and
+// substrate:tenant is NOT isolated (it has tenant-shared authority).
+func IsIsolated(p Principal, ok bool) bool {
+	return ok &&
+		HasScope(p.Scopes, ScopeUser) &&
+		!HasScope(p.Scopes, ScopeTenant) &&
+		!HasScope(p.Scopes, ScopeAdmin)
 }
 
 // OperatorKeyRestricted reports whether a run under principal p must be denied

--- a/internal/auth/scopes_test.go
+++ b/internal/auth/scopes_test.go
@@ -68,6 +68,77 @@ func TestHasScope_ProvidersOperatorKey(t *testing.T) {
 	}
 }
 
+// TestHasScope_UserImplication locks RFC BX P2b's scope semantics: substrate:user
+// satisfies ONLY itself + runs:create/runs:read, and NOT the tenant plane
+// (substrate:tenant), the operator plane (substrate:admin), or the channel
+// scopes. It is also in the closed catalog (grantable at mint).
+func TestHasScope_UserImplication(t *testing.T) {
+	if !ValidScope(ScopeUser) {
+		t.Fatal("substrate:user must be a valid catalog scope (grantable)")
+	}
+	if bad := UnknownScopes([]string{ScopeUser, ScopeRunsCreate}); bad != nil {
+		t.Errorf("UnknownScopes flagged valid scopes: %v", bad)
+	}
+
+	user := []string{ScopeUser}
+	// An isolated member may create + read their own runs, and satisfies itself.
+	for _, want := range []string{ScopeUser, ScopeRunsCreate, ScopeRunsRead} {
+		if !HasScope(user, want) {
+			t.Errorf("substrate:user should satisfy %q", want)
+		}
+	}
+	// But NOT the tenant plane, the operator plane, or the channel scopes — the
+	// whole point of the isolated-member scope.
+	for _, want := range []string{ScopeTenant, ScopeAdmin, ScopeChannelPublish, ScopeChannelRead, ScopeProvidersOperatorKey} {
+		if HasScope(user, want) {
+			t.Errorf("substrate:user must NOT satisfy %q (would widen an isolated member)", want)
+		}
+	}
+	// substrate:admin remains the superuser — satisfies substrate:user too.
+	if !HasScope([]string{ScopeAdmin}, ScopeUser) {
+		t.Error("substrate:admin should satisfy substrate:user (superuser)")
+	}
+	// substrate:tenant does NOT satisfy substrate:user (it is not tenant-implied).
+	if HasScope([]string{ScopeTenant}, ScopeUser) {
+		t.Error("substrate:tenant must NOT satisfy substrate:user (a separate axis)")
+	}
+}
+
+// TestIsIsolated_Matrix pins the RFC BX P2b isolation predicate: true iff the
+// principal is present AND holds substrate:user AND neither substrate:tenant nor
+// substrate:admin. Every other combination (tenant, admin, open mode, a
+// user+tenant token) is NOT isolated.
+func TestIsIsolated_Matrix(t *testing.T) {
+	userP := Principal{TenantID: "acme", Subject: "alice", Scopes: []string{ScopeUser}}
+	userRunsP := Principal{TenantID: "acme", Subject: "bob", Scopes: []string{ScopeUser, ScopeRunsCreate}}
+	tenantP := Principal{TenantID: "acme", Subject: "op", Scopes: []string{ScopeTenant}}
+	adminP := Principal{TenantID: "", Subject: "root", Scopes: []string{ScopeAdmin}}
+	userAndTenantP := Principal{TenantID: "acme", Subject: "hybrid", Scopes: []string{ScopeUser, ScopeTenant}}
+	legacyP := Principal{TenantID: "default", Subject: "default", Scopes: []string{ScopeAdmin}, Legacy: true}
+
+	cases := []struct {
+		name string
+		p    Principal
+		ok   bool
+		want bool
+	}{
+		{"user_only", userP, true, true},
+		{"user_plus_runs", userRunsP, true, true},
+		{"tenant", tenantP, true, false},
+		{"admin", adminP, true, false},
+		{"user_plus_tenant_not_isolated", userAndTenantP, true, false},
+		{"legacy_admin", legacyP, true, false},
+		{"open_mode_no_principal", Principal{}, false, false},
+		// Present bool false always wins, even if the principal happens to carry user.
+		{"present_false_with_user", userP, false, false},
+	}
+	for _, c := range cases {
+		if got := IsIsolated(c.p, c.ok); got != c.want {
+			t.Errorf("%s: IsIsolated = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
 // TestOperatorKeyRestricted_Matrix pins the RFC AX helper: restricted only when
 // the gate is on AND a real (non-legacy, non-admin, un-scoped) principal is
 // present AND lacks the scope. Every other combination is fail-OPEN (false =

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2102,6 +2102,13 @@ type Webhook struct {
 	// false (the operator is unrestricted). Flows write→read→consumer alongside
 	// TenantID; drift-tested against mergedWebhookDef / SubstrateWebhookDef.
 	OperatorKeyRestricted bool `json:"operator_key_restricted,omitempty" yaml:"operator_key_restricted"`
+	// Isolated is the RFC BX P2b confinement bit. For a DYNAMIC WebhookDef it is
+	// CAPTURED from the authoring principal (server authority); the receiver copies
+	// it into RunInput so the fired run keeps its creator's confinement. A static
+	// operator-authored yaml webhook leaves it false (the operator is unconfined).
+	// Flows write→read→consumer alongside OperatorKeyRestricted; drift-tested
+	// against mergedWebhookDef / SubstrateWebhookDef.
+	Isolated bool `json:"isolated,omitempty" yaml:"isolated"`
 }
 
 // WebhookAuth declares how inbound webhook requests are authenticated.

--- a/internal/lookup/schedule.go
+++ b/internal/lookup/schedule.go
@@ -120,6 +120,12 @@ type SubstrateScheduleDef struct {
 	// ToConfigDef — so config.ScheduledRun deliberately carries no such field.
 	// Present here only to keep the three JSON mirrors drift-parity-clean.
 	OperatorKeyRestricted bool `json:"operator_key_restricted,omitempty"`
+	// Isolated (RFC BX P2b) mirrors mergedScheduleDef so the def round-trips
+	// losslessly through the lookup. Like OperatorKeyRestricted, the scheduler fire
+	// path reads it via scheduler.scheduleDef (unmarshalDef → buildRunInput), NOT
+	// via a config projection — present here only to keep the JSON mirrors
+	// drift-parity-clean.
+	Isolated bool `json:"isolated,omitempty"`
 }
 
 // SubstratePromptSegment mirrors config.ScheduledRunSegment with

--- a/internal/lookup/schedule_test.go
+++ b/internal/lookup/schedule_test.go
@@ -203,6 +203,10 @@ func TestSchedule_DriftDetection(t *testing.T) {
 		// NOT on config.ScheduledRun — the scheduler fire path reads it via
 		// scheduler.scheduleDef (unmarshalDef→buildRunInput), not ToConfigDef.
 		"operator_key_restricted": true,
+		// RFC BX P2b: captured isolation bit (anti-bypass). Like
+		// operator_key_restricted, deliberately NOT on config.ScheduledRun — the
+		// scheduler fire path reads it via scheduler.scheduleDef, not ToConfigDef.
+		"isolated": true,
 	}
 	have := scheduleJsonTagsOf(reflect.TypeOf(lookup.SubstrateScheduleDef{}))
 	for tag := range want {

--- a/internal/lookup/webhook.go
+++ b/internal/lookup/webhook.go
@@ -112,6 +112,9 @@ type SubstrateWebhookDef struct {
 	// OperatorKeyRestricted (RFC AX) mirrors mergedWebhookDef — captured from the
 	// authoring principal, projected onto config.Webhook for the receiver.
 	OperatorKeyRestricted bool `json:"operator_key_restricted,omitempty"`
+	// Isolated (RFC BX P2b) mirrors mergedWebhookDef — captured from the authoring
+	// principal, projected onto config.Webhook for the receiver.
+	Isolated bool `json:"isolated,omitempty"`
 }
 
 // SubstrateWebhookAuth mirrors config.WebhookAuth.
@@ -172,5 +175,6 @@ func (s SubstrateWebhookDef) ToConfigDef() config.Webhook {
 		},
 		OnComplete:            s.OnComplete,
 		OperatorKeyRestricted: s.OperatorKeyRestricted,
+		Isolated:              s.Isolated,
 	}
 }

--- a/internal/lookup/webhook_test.go
+++ b/internal/lookup/webhook_test.go
@@ -156,6 +156,7 @@ func TestWebhook_DriftDetection(t *testing.T) {
 		"sync_response":             true,
 		"on_complete":               true,
 		"operator_key_restricted":   true, // RFC AX: captured operator-key restriction (anti-bypass)
+		"isolated":                  true, // RFC BX P2b: captured isolation bit (anti-bypass)
 	}
 	have := a2aJSONTagsOf(reflect.TypeOf(lookup.SubstrateWebhookDef{}))
 	assertTagSetsEqual(t, "SubstrateWebhookDef", want, have)

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -281,6 +281,15 @@ type RunInput struct {
 	// live token. false = allowed (fail-open); the principal-on-ctx paths ignore
 	// this field and compute restriction from the live principal instead.
 	OperatorKeyRestricted bool
+
+	// Isolated is the RFC BX P2b confinement bit for the NON-principal trigger
+	// paths (scheduler / webhook / A2A). Those paths capture the creating
+	// principal's substrate:user status on the trigger def and pass it here so
+	// RunOnce stamps the run confined without a live token (anti-bypass: an
+	// isolated member cannot launder an unconfined run through a trigger). false =
+	// unconfined (fail-open); the principal-on-ctx paths ignore this and derive
+	// isolation from the live principal instead.
+	Isolated bool
 }
 
 // RunCallbacks is how the wire surfaces observe the run.

--- a/internal/scheduler/runinput.go
+++ b/internal/scheduler/runinput.go
@@ -42,6 +42,9 @@ type scheduleDef struct {
 	// OperatorKeyRestricted is the RFC AX bit captured on the def at authoring;
 	// copied into RunInput so the fired run keeps the creator's restriction.
 	OperatorKeyRestricted bool `json:"operator_key_restricted,omitempty"`
+	// Isolated is the RFC BX P2b confinement bit captured on the def at authoring;
+	// copied into RunInput so the fired run keeps the creator's confinement.
+	Isolated bool `json:"isolated,omitempty"`
 }
 
 type schedulePromptSeg struct {
@@ -148,5 +151,8 @@ func buildRunInput(def scheduleDef, envAllowlist map[string]bool, logf func(form
 		// RFC AX: carry the captured operator-key restriction into the run — no
 		// principal is on ctx at fire time, so the def's captured bit is authority.
 		OperatorKeyRestricted: def.OperatorKeyRestricted,
+		// RFC BX P2b: carry the captured isolation bit into the run — same
+		// no-principal-at-fire-time rationale as OperatorKeyRestricted.
+		Isolated: def.Isolated,
 	}
 }

--- a/internal/store/postgres/migrations/0069_runs_isolated.down.sql
+++ b/internal/store/postgres/migrations/0069_runs_isolated.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE runs DROP COLUMN IF EXISTS isolated;

--- a/internal/store/postgres/migrations/0069_runs_isolated.up.sql
+++ b/internal/store/postgres/migrations/0069_runs_isolated.up.sql
@@ -1,0 +1,10 @@
+-- RFC BX P2b: persist whether a run belongs to an ISOLATED MEMBER (a
+-- substrate:user principal). The confinement is computed at run-start from the
+-- principal's scopes (auth.IsIsolated) — never a wire/body/model field — and
+-- rides the run row so a resumed / snapshot-restored / crash-recovered run
+-- reconstructs its data-scope confinement (the tenant-shared + cross-tenant
+-- global keyspaces are refused for an isolated run) without the original
+-- principal on ctx (the same reason `operator_key_restricted`, `interactive`,
+-- and `tenant_id` are denormalised here). Additive default-false column; legacy
+-- rows + every pre-P2b deployment read false (fail-open). CreateRun stamps it.
+ALTER TABLE runs ADD COLUMN IF NOT EXISTS isolated BOOLEAN NOT NULL DEFAULT FALSE;

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -375,8 +375,8 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 		_, err := s.pool.Exec(ctx,
 			`INSERT INTO runs (
 				id, session_id, status, started_at,
-				agent_id, parent_agent_id, parent_run_id, user_id, tenant_id, user_tier, agent_def_id, model, replica_id, parent_context, idempotency_key, interactive, operator_key_restricted
-			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
+				agent_id, parent_agent_id, parent_run_id, user_id, tenant_id, user_tier, agent_def_id, model, replica_id, parent_context, idempotency_key, interactive, operator_key_restricted, isolated
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)`,
 			id, sessionID, string(store.RunRunning), now,
 			nullableText(identity.AgentID),
 			nullableText(identity.ParentAgentID),
@@ -391,6 +391,7 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 			nullableText(identity.IdempotencyKey),
 			identity.Interactive,
 			identity.OperatorKeyRestricted,
+			identity.Isolated,
 		)
 		return err
 	}); err != nil {
@@ -426,6 +427,7 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 		IdempotencyKey:        identity.IdempotencyKey,
 		Interactive:           identity.Interactive,
 		OperatorKeyRestricted: identity.OperatorKeyRestricted,
+		Isolated:              identity.Isolated,
 	}, nil
 }
 
@@ -1055,7 +1057,7 @@ func (s *Store) RunsForSession(ctx context.Context, sessionID string) ([]store.R
 		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 		        r.model, r.provider, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive, r.operator_key_restricted,
+		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive, r.operator_key_restricted, r.isolated,
 		        r.cost, r.cost_currency, r.credential_source, r.credential_scope_id,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
@@ -1529,7 +1531,7 @@ func (s *Store) GetRunByAgentID(ctx context.Context, agentID string) (store.Run,
 		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 		        r.model, r.provider, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive, r.operator_key_restricted,
+		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive, r.operator_key_restricted, r.isolated,
 		        r.cost, r.cost_currency, r.credential_source, r.credential_scope_id,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
@@ -1559,7 +1561,7 @@ func (s *Store) RunByIdempotencyKey(ctx context.Context, key string) (store.Run,
 		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 		        r.model, r.provider, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive, r.operator_key_restricted,
+		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive, r.operator_key_restricted, r.isolated,
 		        r.cost, r.cost_currency, r.credential_source, r.credential_scope_id,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
@@ -1585,7 +1587,7 @@ func (s *Store) GetRun(ctx context.Context, runID string) (store.Run, error) {
 		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 		        r.model, r.provider, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive, r.operator_key_restricted,
+		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive, r.operator_key_restricted, r.isolated,
 		        r.cost, r.cost_currency, r.credential_source, r.credential_scope_id,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
@@ -1658,7 +1660,7 @@ func (s *Store) ListActiveRunsByUser(ctx context.Context, userID string, status 
 			        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 			        r.model, r.provider, r.error,
 			        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-			        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive, r.operator_key_restricted,
+			        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive, r.operator_key_restricted, r.isolated,
 		        r.cost, r.cost_currency, r.credential_source, r.credential_scope_id,
 			        s.agent
 			 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
@@ -1670,7 +1672,7 @@ func (s *Store) ListActiveRunsByUser(ctx context.Context, userID string, status 
 			        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 			        r.model, r.provider, r.error,
 			        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-			        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive, r.operator_key_restricted,
+			        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive, r.operator_key_restricted, r.isolated,
 		        r.cost, r.cost_currency, r.credential_source, r.credential_scope_id,
 			        s.agent
 			 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
@@ -1696,7 +1698,7 @@ func (s *Store) ListRunsByParentAgentID(ctx context.Context, parentAgentID strin
 		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 		        r.model, r.provider, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive, r.operator_key_restricted,
+		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive, r.operator_key_restricted, r.isolated,
 		        r.cost, r.cost_currency, r.credential_source, r.credential_scope_id,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
@@ -1798,7 +1800,7 @@ func (s *Store) ListPausedRuns(ctx context.Context) ([]store.Run, error) {
 		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 		        r.model, r.provider, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive, r.operator_key_restricted,
+		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive, r.operator_key_restricted, r.isolated,
 		        r.cost, r.cost_currency, r.credential_source, r.credential_scope_id,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
@@ -2556,15 +2558,15 @@ func (s *Store) SnapshotRestoreRun(ctx context.Context, r store.Run) (bool, erro
 			input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
 			model, provider, error,
 			agent_id, parent_agent_id, parent_run_id, user_id, last_heartbeat_at,
-			user_tier, agent_def_id, pause_state, parent_context, interactive, operator_key_restricted
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24)
+			user_tier, agent_def_id, pause_state, parent_context, interactive, operator_key_restricted, isolated
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25)
 		 ON CONFLICT (id) DO NOTHING`,
 		r.ID, r.SessionID, status, startedAt, completedAt, nullIfEmpty(r.StopReason),
 		r.InputTokens, r.OutputTokens, r.CacheCreationTokens, r.CacheReadTokens,
 		nullIfEmpty(r.Model), nullIfEmpty(r.Provider), nullIfEmpty(r.ErrorMsg),
 		nullIfEmpty(r.AgentID), nullIfEmpty(r.ParentAgentID), nullIfEmpty(r.ParentRunID),
 		nullIfEmpty(r.UserID), lastHbAt,
-		nullIfEmpty(r.UserTier), nullIfEmpty(r.AgentDefID), pauseState, pcVal, r.Interactive, r.OperatorKeyRestricted,
+		nullIfEmpty(r.UserTier), nullIfEmpty(r.AgentDefID), pauseState, pcVal, r.Interactive, r.OperatorKeyRestricted, r.Isolated,
 	)
 	if err != nil {
 		return false, fmt.Errorf("snapshot restore run: %w", err)
@@ -7985,6 +7987,7 @@ func scanRun(r rowScanner) (store.Run, error) {
 
 		interactive           bool
 		operatorKeyRestricted bool
+		isolated              bool
 		statusStr             string
 	)
 	if err := r.Scan(
@@ -7994,7 +7997,7 @@ func scanRun(r rowScanner) (store.Run, error) {
 		&agentID, &parentAgentID, &parentRunID, &userID, &lastHeartbeatAt,
 		&userTier,
 		&agentDefID, &pauseState, &replicaID, &parentContext, &idempotencyKey, &tenantID,
-		&interactive, &operatorKeyRestricted,
+		&interactive, &operatorKeyRestricted, &isolated,
 		&cost, &costCurrency, &credentialSource, &credentialScopeID,
 		&sessAgent,
 	); err != nil {
@@ -8059,6 +8062,7 @@ func scanRun(r rowScanner) (store.Run, error) {
 	}
 	out.Interactive = interactive
 	out.OperatorKeyRestricted = operatorKeyRestricted
+	out.Isolated = isolated
 	if cost != nil {
 		out.Cost = cost
 	}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -1082,6 +1082,11 @@ func (s *Store) migrate(ctx context.Context) error {
 		// at CreateRun from the principal + gate; read back on resume/restore so a
 		// re-dispatched run keeps its restriction. 0 on legacy rows (fail-open).
 		`ALTER TABLE runs ADD COLUMN operator_key_restricted INTEGER NOT NULL DEFAULT 0`,
+		// RFC BX P2b — the isolated-member confinement bit (0 = unconfined). Stamped
+		// at CreateRun from the substrate:user principal; read back on resume/restore
+		// so a re-dispatched run keeps its data-scope confinement. 0 on legacy rows
+		// (fail-open). See internal/store/postgres/migrations/0069_runs_isolated.
+		`ALTER TABLE runs ADD COLUMN isolated INTEGER NOT NULL DEFAULT 0`,
 		// RFC BE — human/organizational chat metadata on the session row (the
 		// History tool's browse/search/annotate surface). All additive + nullable
 		// so legacy rows read the zero value. tags is a JSON array (NULL = never
@@ -1430,8 +1435,8 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 		pcVal = pcJSON
 	}
 	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO runs(id, session_id, status, started_at, agent_id, parent_agent_id, parent_run_id, user_id, tenant_id, user_tier, agent_def_id, model, parent_context, idempotency_key, interactive, operator_key_restricted)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO runs(id, session_id, status, started_at, agent_id, parent_agent_id, parent_run_id, user_id, tenant_id, user_tier, agent_def_id, model, parent_context, idempotency_key, interactive, operator_key_restricted, isolated)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		id, sessionID, store.RunRunning, now.UnixNano(),
 		nilIfEmpty(identity.AgentID),
 		nilIfEmpty(identity.ParentAgentID),
@@ -1445,6 +1450,7 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 		nilIfEmpty(identity.IdempotencyKey),
 		boolToInt(identity.Interactive),
 		boolToInt(identity.OperatorKeyRestricted),
+		boolToInt(identity.Isolated),
 	)
 	if err != nil {
 		// RFC H Decision 10: a collision on the runs_idempotency_key
@@ -1477,6 +1483,7 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 		IdempotencyKey:        identity.IdempotencyKey,
 		Interactive:           identity.Interactive,
 		OperatorKeyRestricted: identity.OperatorKeyRestricted,
+		Isolated:              identity.Isolated,
 	}, nil
 }
 
@@ -2507,6 +2514,7 @@ func scanRun(scanner interface{ Scan(...any) error }) (store.Run, error) {
 	var tenantID sql.NullString
 	var interactive sql.NullInt64
 	var operatorKeyRestricted sql.NullInt64
+	var isolated sql.NullInt64
 	var cost sql.NullFloat64
 	var costCurrency, credentialSource, credentialScopeID sql.NullString
 	var sessAgent sql.NullString
@@ -2519,7 +2527,7 @@ func scanRun(scanner interface{ Scan(...any) error }) (store.Run, error) {
 		&agentID, &parentAgentID, &parentRunID, &userID, &lastHbNs,
 		&userTier,
 		&agentDefID, &pauseState, &parentContext, &idempotencyKey, &tenantID,
-		&interactive, &operatorKeyRestricted,
+		&interactive, &operatorKeyRestricted, &isolated,
 		&cost, &costCurrency, &credentialSource, &credentialScopeID,
 		&sessAgent,
 	); err != nil {
@@ -2583,6 +2591,7 @@ func scanRun(scanner interface{ Scan(...any) error }) (store.Run, error) {
 	}
 	r.Interactive = interactive.Valid && interactive.Int64 != 0
 	r.OperatorKeyRestricted = operatorKeyRestricted.Valid && operatorKeyRestricted.Int64 != 0
+	r.Isolated = isolated.Valid && isolated.Int64 != 0
 	if cost.Valid {
 		v := cost.Float64
 		r.Cost = &v
@@ -2617,7 +2626,7 @@ const runColumns = `r.id, r.session_id, r.status, r.started_at, r.completed_at,
 		r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at,
 		r.user_tier,
 		r.agent_def_id, r.pause_state, r.parent_context, r.idempotency_key, r.tenant_id,
-		r.interactive, r.operator_key_restricted,
+		r.interactive, r.operator_key_restricted, r.isolated,
 		r.cost, r.cost_currency, r.credential_source, r.credential_scope_id,
 		s.agent`
 
@@ -3659,15 +3668,15 @@ func (s *Store) SnapshotRestoreRun(ctx context.Context, r store.Run) (bool, erro
 			input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
 			model, provider, error,
 			agent_id, parent_agent_id, parent_run_id, user_id, last_heartbeat_at,
-			user_tier, agent_def_id, pause_state, parent_context, interactive, operator_key_restricted
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			user_tier, agent_def_id, pause_state, parent_context, interactive, operator_key_restricted, isolated
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		r.ID, r.SessionID, status, startedNs, completedNs, nilIfEmpty(r.StopReason),
 		r.InputTokens, r.OutputTokens, r.CacheCreationTokens, r.CacheReadTokens,
 		nilIfEmpty(r.Model), nilIfEmpty(r.Provider), nilIfEmpty(r.ErrorMsg),
 		nilIfEmpty(r.AgentID), nilIfEmpty(r.ParentAgentID), nilIfEmpty(r.ParentRunID),
 		nilIfEmpty(r.UserID), lastHbNs,
 		nilIfEmpty(r.UserTier), nilIfEmpty(r.AgentDefID), pauseState, pcVal,
-		boolToInt(r.Interactive), boolToInt(r.OperatorKeyRestricted),
+		boolToInt(r.Interactive), boolToInt(r.OperatorKeyRestricted), boolToInt(r.Isolated),
 	)
 	if err != nil {
 		return false, fmt.Errorf("snapshot restore run: %w", err)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -416,6 +416,14 @@ type Run struct {
 	// zero value), so legacy rows + every unstamped path fail OPEN.
 	OperatorKeyRestricted bool `json:"operator_key_restricted,omitempty"`
 
+	// Isolated is the RFC BX P2b confinement bit: true = this run belongs to an
+	// isolated member (a substrate:user principal). Persisted to runs.isolated and
+	// restored on resume so a snapshotted / crash-recovered run keeps its data-
+	// scope confinement without the original principal on ctx (the same reason
+	// operator_key_restricted rides the row). false on legacy rows + every
+	// unstamped path (fail-open).
+	Isolated bool `json:"isolated,omitempty"`
+
 	// --- RFC AV: per-run cost + credential-source summary. ---
 	// Cost is nil when the run was never priced (legacy rows, or an unknown
 	// model absent from the pricing table). CredentialSource is the primary key
@@ -736,6 +744,13 @@ type RunIdentity struct {
 	// original principal on ctx. Additive; false on legacy rows + every path
 	// that doesn't stamp it (fail-open, matching the scope's default-off gate).
 	OperatorKeyRestricted bool
+
+	// Isolated is the RFC BX P2b confinement bit captured on the run at creation
+	// and persisted to runs.isolated, so a resumed / snapshot-restored run
+	// reconstructs its data-scope confinement (tenant/global refused) without the
+	// original substrate:user principal on ctx. Additive; false on legacy rows +
+	// every unstamped path (fail-open).
+	Isolated bool
 }
 
 // ParentContext is the typed caller-tracking lineage attached to a run

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -114,6 +114,7 @@ func Run(t *testing.T, factory Factory) {
 		{"SweepStaleRunsSkipsPaused", testSweepStaleRunsSkipsPaused},
 		{"CreateRunInteractiveRoundTrip", testCreateRunInteractiveRoundTrip},
 		{"CreateRunOperatorKeyRestrictedRoundTrip", testCreateRunOperatorKeyRestrictedRoundTrip},
+		{"CreateRunIsolatedRoundTrip", testCreateRunIsolatedRoundTrip},
 		{"SetRunPauseStateRoundTrip", testSetRunPauseStateRoundTrip},
 		{"SetRunPauseStateUnknownStateRefused", testSetRunPauseStateUnknownStateRefused},
 		{"SetRunPauseStateMissingRunReturnsNotFound", testSetRunPauseStateMissingRunReturnsNotFound},
@@ -3151,6 +3152,31 @@ func testCreateRunOperatorKeyRestrictedRoundTrip(t *testing.T, s store.Store) {
 	got, _ := s.GetRun(ctx, restricted.ID)
 	if !got.OperatorKeyRestricted {
 		t.Errorf("restricted run OperatorKeyRestricted=false on read-back (did not persist)")
+	}
+}
+
+// RFC BX P2b: the isolated column round-trips on both backends — false by
+// default (fail-open), true when stamped, and it survives a fresh read (so a
+// resumed / snapshot-restored run reconstructs its data-scope confinement).
+func testCreateRunIsolatedRoundTrip(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	sess, _ := s.CreateSession(ctx, "t", "a", "u")
+
+	unconfined, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_iso_default"})
+	if unconfined.Isolated {
+		t.Errorf("default Isolated = true, want false (fail-open)")
+	}
+	if got, _ := s.GetRun(ctx, unconfined.ID); got.Isolated {
+		t.Errorf("default run Isolated = true on read-back, want false")
+	}
+
+	isolated, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_iso_confined", Isolated: true})
+	if !isolated.Isolated {
+		t.Errorf("CreateRun returned Isolated=false for an isolated run")
+	}
+	got, _ := s.GetRun(ctx, isolated.ID)
+	if !got.Isolated {
+		t.Errorf("isolated run Isolated=false on read-back (did not persist)")
 	}
 }
 

--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -188,6 +188,19 @@ func operatorKeyRestrictedFromCtx(ctx context.Context, cfg *config.Config) bool 
 	return auth.OperatorKeyRestricted(p, ok, gate)
 }
 
+// isolatedFromCtx captures the RFC BX P2b isolation bit from the authoring
+// principal on ctx, mirroring operatorKeyRestrictedFromCtx: a run-triggering def
+// (Schedule / Webhook) captures it so the scheduler/webhook executor stamps the
+// fired run confined without a token on ctx (anti-bypass: an isolated member
+// can't launder an unconfined run through a trigger). SERVER authority — the
+// model must NOT set it via the overlay, so write sites stamp it unconditionally
+// after applying the overlay. Unlike the operator-key bit it has NO deployment
+// gate: substrate:user is always enforced when present. false when no principal /
+// non-isolated (fail-open).
+func isolatedFromCtx(ctx context.Context) bool {
+	return auth.IsIsolated(auth.PrincipalFromContext(ctx))
+}
+
 func (a *AgentDef) execCreate(ctx context.Context, policy tools.AgentDefPolicyValue, in agentDefInput) (tools.Result, error) {
 	if in.Name == "" {
 		return errResult("create: missing required field: name"), nil

--- a/internal/tools/builtin/channel.go
+++ b/internal/tools/builtin/channel.go
@@ -212,6 +212,14 @@ func (c *Channel) resolveChannel(ctx context.Context, policy tools.ChannelPolicy
 		return tools.ChannelDef{}, "", "", fmt.Errorf("Channel tool: %s not allowed on channel %q (agent allowlist: %v)", side, name, allowed)
 	}
 
+	// RFC BX P2b: an isolated member (substrate:user) may use only its own
+	// user/agent-scoped channels — refuse a tenant-shared or cross-tenant global
+	// channel even when the agent's channel allowlist permits it. Server-derived
+	// from the run's Isolated bit; a non-isolated run is unaffected.
+	if err := tools.ConfineIsolatedScope(ctx, store.MemoryScope(def.Scope)); err != nil {
+		return tools.ChannelDef{}, "", "", err
+	}
+
 	switch def.Scope {
 	case "agent":
 		agentName := tools.AgentName(ctx)

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -445,6 +445,13 @@ func (d *Document) resolveScope(ctx context.Context, requested string) (sqlmem.S
 	if requested == "" {
 		requested = "user"
 	}
+	// RFC BX P2b: an isolated member (substrate:user) may author/read only its own
+	// user/agent-scoped documents — refuse the tenant-shared scope even when the
+	// agent holds the tenant grants below. Server-derived from the run's Isolated
+	// bit; a non-isolated run is unaffected.
+	if err := tools.ConfineIsolatedScope(ctx, store.MemoryScope(requested)); err != nil {
+		return sqlmem.ScopeKey{}, "", err
+	}
 	switch requested {
 	case "agent":
 		name := tools.AgentName(ctx)

--- a/internal/tools/builtin/isolated_scope_test.go
+++ b/internal/tools/builtin/isolated_scope_test.go
@@ -1,0 +1,121 @@
+package builtin
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// RFC BX P2b: the data tools confine an ISOLATED run (RunIdentity.Isolated, set
+// from a substrate:user principal) to its own user/agent scope — the
+// tenant-shared and cross-tenant global keyspaces are refused for read + write.
+// A non-isolated run behaves exactly as before (regression). These exercise the
+// scope-resolution choke point of each tool directly (no store needed); the
+// refusal error carries "isolated" so a policy refusal can't masquerade as one.
+
+// isoScopeCtx builds a run ctx with the given isolation bit, an agent name, and a
+// user_id/tenant so the own-scope (user/agent) resolutions succeed.
+func isoScopeCtx(isolated bool) context.Context {
+	ctx := tools.WithAgentName(context.Background(), "agent-1")
+	return tools.WithRunIdentity(ctx, tools.RunIdentityValue{
+		UserID: "alice", AgentID: "a_test", TenantID: "acme", Isolated: isolated,
+	})
+}
+
+func TestMemory_IsolatedConfinesScope(t *testing.T) {
+	m := &Memory{}
+	// The agent GRANTS tenant so the refusal proves ConfineIsolatedScope fires,
+	// not the memory_scopes ACL.
+	policy := tools.MemoryPolicyValue{AllowedScopes: []string{"agent", "user", "tenant"}}
+
+	iso := tools.WithMemoryPolicy(isoScopeCtx(true), policy)
+	if _, _, err := m.resolveScope(iso, "tenant"); err == nil || !strings.Contains(err.Error(), "isolated") {
+		t.Errorf("isolated resolveScope(tenant) err=%v, want isolated-confinement refusal", err)
+	}
+	for _, sc := range []string{"user", "agent"} {
+		if _, _, err := m.resolveScope(iso, sc); err != nil {
+			t.Errorf("isolated resolveScope(%s) err=%v, want ok (own scope)", sc, err)
+		}
+	}
+
+	// Non-isolated: tenant resolves fine (regression — unchanged behaviour).
+	non := tools.WithMemoryPolicy(isoScopeCtx(false), policy)
+	if _, _, err := m.resolveScope(non, "tenant"); err != nil {
+		t.Errorf("non-isolated resolveScope(tenant) err=%v, want ok", err)
+	}
+}
+
+func TestPath_IsolatedConfinesScope(t *testing.T) {
+	p := &Path{}
+
+	iso := isoScopeCtx(true)
+	if _, _, _, err := p.resolveScope(iso, "tenant"); err == nil || !strings.Contains(err.Error(), "isolated") {
+		t.Errorf("isolated Path.resolveScope(tenant) err=%v, want isolated-confinement refusal", err)
+	}
+	for _, sc := range []string{"user", "agent"} {
+		if _, _, _, err := p.resolveScope(iso, sc); err != nil {
+			t.Errorf("isolated Path.resolveScope(%s) err=%v, want ok (own scope)", sc, err)
+		}
+	}
+
+	non := isoScopeCtx(false)
+	if _, _, _, err := p.resolveScope(non, "tenant"); err != nil {
+		t.Errorf("non-isolated Path.resolveScope(tenant) err=%v, want ok", err)
+	}
+}
+
+func TestDocument_IsolatedConfinesScope(t *testing.T) {
+	d := &Document{}
+	// Grant tenant on BOTH planes so the isolated refusal proves ConfineIsolatedScope
+	// fires BEFORE (and regardless of) the tenant grant check.
+	grant := func(ctx context.Context) context.Context {
+		ctx = tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{AllowedScopes: []string{"agent", "user", "tenant"}})
+		return tools.WithSqlMemPolicy(ctx, tools.SqlMemPolicyValue{AllowedScopes: []string{"agent", "user", "tenant"}})
+	}
+
+	iso := grant(isoScopeCtx(true))
+	if _, _, err := d.resolveScope(iso, "tenant"); err == nil || !strings.Contains(err.Error(), "isolated") {
+		t.Errorf("isolated Document.resolveScope(tenant) err=%v, want isolated-confinement refusal even with grants", err)
+	}
+	if _, _, err := d.resolveScope(iso, "user"); err != nil {
+		t.Errorf("isolated Document.resolveScope(user) err=%v, want ok (own scope)", err)
+	}
+
+	non := grant(isoScopeCtx(false))
+	if _, _, err := d.resolveScope(non, "tenant"); err != nil {
+		t.Errorf("non-isolated Document.resolveScope(tenant) err=%v, want ok (granted)", err)
+	}
+}
+
+func TestChannel_IsolatedConfinesScope(t *testing.T) {
+	c := &Channel{}
+	// The channel is on the publish allowlist so the refusal proves
+	// ConfineIsolatedScope fires, not the channel ACL.
+	policy := tools.ChannelPolicyValue{
+		Publish: []string{"team", "world", "mine"},
+		Channels: map[string]tools.ChannelDef{
+			"team":  {Name: "team", Scope: "tenant"},
+			"world": {Name: "world", Scope: "global"},
+			"mine":  {Name: "mine", Scope: "user"},
+		},
+	}
+
+	iso := isoScopeCtx(true)
+	for _, name := range []string{"team", "world"} {
+		if _, _, _, err := c.resolveChannel(iso, policy, "publish", name); err == nil || !strings.Contains(err.Error(), "isolated") {
+			t.Errorf("isolated resolveChannel(%s) err=%v, want isolated-confinement refusal", name, err)
+		}
+	}
+	if _, _, _, err := c.resolveChannel(iso, policy, "publish", "mine"); err != nil {
+		t.Errorf("isolated resolveChannel(mine=user) err=%v, want ok (own scope)", err)
+	}
+
+	non := isoScopeCtx(false)
+	for _, name := range []string{"team", "world"} {
+		if _, _, _, err := c.resolveChannel(non, policy, "publish", name); err != nil {
+			t.Errorf("non-isolated resolveChannel(%s) err=%v, want ok", name, err)
+		}
+	}
+}

--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -524,6 +524,14 @@ func (m *Memory) resolveScope(ctx context.Context, requested string) (store.Memo
 		return "", "", fmt.Errorf("Memory tool: scope %q not in this agent's memory_scopes %v", requested, policy.AllowedScopes)
 	}
 
+	// RFC BX P2b: an isolated member (substrate:user) may address only its own
+	// user/agent scope — refuse the tenant-shared / global keyspace even when the
+	// agent's memory_scopes would otherwise permit it. Server-derived from the
+	// run's Isolated bit; a non-isolated run is unaffected.
+	if err := tools.ConfineIsolatedScope(ctx, store.MemoryScope(requested)); err != nil {
+		return "", "", err
+	}
+
 	switch store.MemoryScope(requested) {
 	case store.MemoryScopeAgent:
 		name := tools.AgentName(ctx)
@@ -584,6 +592,12 @@ func (m *Memory) resolveSqlScope(ctx context.Context, requested string) (scope, 
 	}
 	if !contains(pol.AllowedScopes, requested) {
 		return "", "", fmt.Errorf("Memory tool: sql scope %q not in this agent's sql_scopes %v", requested, pol.AllowedScopes)
+	}
+	// RFC BX P2b: an isolated member may not reach the tenant-shared SQL keyspace.
+	// The {agent, user, run} scopes are own-scoped and pass through unaffected
+	// (ConfineIsolatedScope only refuses tenant/global).
+	if err := tools.ConfineIsolatedScope(ctx, store.MemoryScope(requested)); err != nil {
+		return "", "", err
 	}
 	switch requested {
 	case "agent":

--- a/internal/tools/builtin/pathtool.go
+++ b/internal/tools/builtin/pathtool.go
@@ -102,6 +102,12 @@ func (p *Path) resolveScope(ctx context.Context, requested string) (tenantID, sc
 	if requested == "" {
 		requested = "agent"
 	}
+	// RFC BX P2b: an isolated member (substrate:user) may name only its own
+	// user/agent-scoped Path entries — refuse the tenant-shared scope. Server-
+	// derived from the run's Isolated bit; a non-isolated run is unaffected.
+	if err := tools.ConfineIsolatedScope(ctx, store.MemoryScope(requested)); err != nil {
+		return "", "", "", err
+	}
 	switch requested {
 	case "agent":
 		name := tools.AgentName(ctx)

--- a/internal/tools/builtin/scheduledef.go
+++ b/internal/tools/builtin/scheduledef.go
@@ -191,6 +191,9 @@ func (s *ScheduleDef) execCreate(ctx context.Context, policy tools.ScheduleDefPo
 	// authority — unconditional so the overlay can't set it) so the scheduler
 	// stamps the fired run with the creator's grant.
 	def.OperatorKeyRestricted = operatorKeyRestrictedFromCtx(ctx, s.Cfg)
+	// RFC BX P2b: capture the authoring principal's isolation status (server
+	// authority) so the scheduler stamps the fired run confined.
+	def.Isolated = isolatedFromCtx(ctx)
 	if err := validateScheduleDef(def); err != nil {
 		return errResult(fmt.Sprintf("create: %s", err)), nil
 	}
@@ -340,6 +343,9 @@ func (s *ScheduleDef) execFork(ctx context.Context, policy tools.ScheduleDefPoli
 	// RFC AX: re-capture the forking principal's operator-key restriction (server
 	// authority) — a fork is a new version, its authority is the forker's grant.
 	def.OperatorKeyRestricted = operatorKeyRestrictedFromCtx(ctx, s.Cfg)
+	// RFC BX P2b: capture the authoring principal's isolation status (server
+	// authority) so the scheduler stamps the fired run confined.
+	def.Isolated = isolatedFromCtx(ctx)
 	if err := validateScheduleDef(def); err != nil {
 		return errResult(fmt.Sprintf("fork: %s", err)), nil
 	}
@@ -1022,6 +1028,13 @@ type mergedScheduleDef struct {
 	// restriction (anti-bypass). NOT part of any content hash (schedules have no
 	// content_sha256); omitempty keeps gate-off def bodies byte-identical.
 	OperatorKeyRestricted bool `json:"operator_key_restricted,omitempty"`
+	// Isolated is the RFC BX P2b confinement bit CAPTURED from the authoring
+	// principal at create/fork (server authority, NOT overlay-set). The scheduler
+	// copies it into RunInput so a fired run keeps its creator's confinement
+	// (anti-bypass). NOT part of any content hash; omitempty keeps pre-P2b def
+	// bodies byte-identical. Drift-tested against scheduler.scheduleDef /
+	// SubstrateScheduleDef.
+	Isolated bool `json:"isolated,omitempty"`
 }
 
 // mergedSchedulePromptSeg mirrors config.ScheduledRunSegment with JSON tags.

--- a/internal/tools/builtin/webhookdef.go
+++ b/internal/tools/builtin/webhookdef.go
@@ -162,6 +162,9 @@ func (s *WebhookDef) execCreate(ctx context.Context, policy tools.WebhookDefPoli
 	// authority — unconditional so the payload/overlay can't set it) so the
 	// webhook receiver stamps the fired run with the creator's grant.
 	def.OperatorKeyRestricted = operatorKeyRestrictedFromCtx(ctx, s.Cfg)
+	// RFC BX P2b: capture the authoring principal's isolation status (server
+	// authority) so the webhook receiver stamps the fired run confined.
+	def.Isolated = isolatedFromCtx(ctx)
 	defJSON, err := json.Marshal(def)
 	if err != nil {
 		return errResult(fmt.Sprintf("create: marshal: %s", err)), nil
@@ -305,6 +308,9 @@ func (s *WebhookDef) execFork(ctx context.Context, policy tools.WebhookDefPolicy
 	// RFC AX: re-capture the forking principal's operator-key restriction (server
 	// authority) — a fork is a new version, its authority is the forker's grant.
 	def.OperatorKeyRestricted = operatorKeyRestrictedFromCtx(ctx, s.Cfg)
+	// RFC BX P2b: capture the authoring principal's isolation status (server
+	// authority) so the webhook receiver stamps the fired run confined.
+	def.Isolated = isolatedFromCtx(ctx)
 	defJSON, err := json.Marshal(def)
 	if err != nil {
 		return errResult(fmt.Sprintf("fork: marshal: %s", err)), nil
@@ -720,6 +726,12 @@ type mergedWebhookDef struct {
 	// restriction. No content_sha256 for webhooks; omitempty keeps gate-off
 	// bodies byte-identical.
 	OperatorKeyRestricted bool `json:"operator_key_restricted,omitempty"`
+	// Isolated is the RFC BX P2b confinement bit CAPTURED from the authoring
+	// principal at create/fork (server authority, NOT payload/overlay-set); the
+	// webhook receiver copies it into RunInput so a fired run keeps its creator's
+	// confinement. Mirrors OperatorKeyRestricted; omitempty keeps pre-P2b bodies
+	// byte-identical. Drift-tested against config.Webhook / SubstrateWebhookDef.
+	Isolated bool `json:"isolated,omitempty"`
 }
 
 // mergedWebhookAuth mirrors config.WebhookAuth.

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -474,6 +474,18 @@ type RunIdentityValue struct {
 	// (a child cannot escape its parent's restriction). Stage 1 only threads
 	// it; enforcement (resolver routing + driver backstop) lands in stage 2.
 	OperatorKeyRestricted bool
+
+	// Isolated is the RFC BX P2b confinement bit: true = this run belongs to an
+	// ISOLATED MEMBER (a substrate:user principal — see auth.IsIsolated) and the
+	// data tools must refuse the tenant-shared / cross-tenant-global keyspace,
+	// leaving only the run's own user + agent scope reachable (see
+	// ConfineIsolatedScope). Computed once at run-start from the principal (never
+	// a wire/body/model field) and carried here so it survives to the tool
+	// dispatch and INHERITS to sub-agents unchanged (a child cannot escape its
+	// parent's confinement). false (the zero value) = unconfined, so every
+	// unstamped path fails OPEN — matching the OperatorKeyRestricted posture and
+	// keeping existing runs byte-identical until a substrate:user token is minted.
+	Isolated bool
 }
 
 // WithRunIdentity attaches the current run's identity to ctx. The
@@ -521,6 +533,26 @@ func WithRunIdentity(ctx context.Context, ident RunIdentityValue) context.Contex
 func RunIdentity(ctx context.Context) RunIdentityValue {
 	v, _ := ctx.Value(ctxKeyRunIdentity{}).(RunIdentityValue)
 	return v
+}
+
+// ConfineIsolatedScope enforces the RFC BX P2b data-scope confinement for an
+// ISOLATED run (RunIdentity(ctx).Isolated — set from a substrate:user principal
+// at run-start, never from a wire/body/model field). An isolated member may
+// address only its OWN user/agent scope; the tenant-SHARED (MemoryScopeTenant)
+// and cross-tenant GLOBAL (MemoryScopeGlobal) keyspaces are refused for both
+// read and write. The scope-resolution path of each data tool (Memory / Channel
+// / Document / Path) calls this and surfaces the returned error as a tool_result
+// (never a panic). A non-isolated run (the default) is unaffected.
+//
+// First cut is STRICT: tenant AND global are refused outright. Using bundled
+// agents/skills is unaffected — those are run DEFINITIONS, not scoped tool data.
+// A future refinement may allow READ-ONLY global/bundled access for an isolated
+// member; that is intentionally NOT implemented here.
+func ConfineIsolatedScope(ctx context.Context, scope store.MemoryScope) error {
+	if RunIdentity(ctx).Isolated && (scope == store.MemoryScopeTenant || scope == store.MemoryScopeGlobal) {
+		return fmt.Errorf("isolated user: access to the shared %q scope is not permitted", scope)
+	}
+	return nil
 }
 
 // ctxKeyAgentName is the context key under which the runtime stores the


### PR DESCRIPTION
**RFC BX Phase 2, slice 2 of 3.** The `isolated` half of the per-user access dial: an isolated member operates only in its OWN user-scope (+ its own agents), with no access to the tenant's shared data, other users, or the operator plane.

> **Stacked on #967 (P2a — users table).** This branch descends from it, so the diff below includes #967 until it merges; then I'll rebase. Review/merge order: #967 → **this** → P2c (delegated minting + Users console). P2a files are unchanged here.

## Why
RFC BX gives a tenant a two-way per-user dial. `tenant`-mode members already work via the existing whole-tenant model; this adds the `isolated` half + the scope that carries it.

## What
- **`substrate:user` scope** (`internal/auth/scopes.go`) + `userImplied = {substrate:user, runs:create, runs:read}`. `HasScope` lets it satisfy ONLY that set — **not** `substrate:tenant`/`admin`, so every `/v1/_*` tenant-admin route auto-denies an isolated member. `IsIsolated(p, ok)` = authority tops out at `substrate:user` (server-derived from the principal, never the wire).
- **The `Isolated` run bit** — mirrors the RFC AX `OperatorKeyRestricted` plumbing exactly: `RunIdentityValue.Isolated` + a `runs.isolated` column (**migration 0069**, `ADD COLUMN IF NOT EXISTS` → replay-safe) so a paused isolated run stays confined on resume; set at every principal-bearing run-start site (RunOnce/handleRun/continue/team/sub-agent + resume-restore) and captured+replayed on the scheduler/webhook/A2A trigger carriers. Sub-agents inherit it.
- **Enforcement**: `tools.ConfineIsolatedScope` refuses `scope=tenant` and `scope=global` for an isolated run — applied in the scope resolution of **Memory (k/v + SQL), Channel, Document, Path**. Only the run's own user/agent scope survives; non-isolated runs are unaffected. Strict first cut (tenant+global refused read+write; bundled agents/skills still usable — they're run definitions, not scoped tool data; read-only bundled/global access is a noted follow-up).
- **HTTP**: `GET /v1/_users` returns only the caller's own record for an isolated principal.

## Tested
- auth catalog/HasScope/IsIsolated truth tables; tool confinement (isolated refuses tenant/global, allows own; non-isolated regression) with a **fail-before** check; `CreateRunIsolatedRoundTrip` green on **sqlite + real Postgres**; migration 0069 applies + double-apply is a clean no-op; full store PG suite green; api/http route-denial matrix + self-only user list; `go test ./...` + `go build ./...` clean.

## Notes
- The Web UI mint dropdown doesn't yet offer `substrate:user` (it IS mintable via the API now); that UI entry lands with **P2c**.
- A2A "isolated run with no principal authors a trigger def" edge keeps parity with the identical RFC AX edge (derives from the principal only) — deliberately not diverged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)