### PR TITLE
test(provider-gate): deflake ZeroOverheadWhenUnconfigured

### DIFF
--- a/internal/api/http/provider_gate_admission_test.go
+++ b/internal/api/http/provider_gate_admission_test.go
@@ -243,7 +243,14 @@ func TestProviderGate_OverCapReturns429(t *testing.T) {
 // concurrent runs to the same provider all admit (only the global cap applies),
 // and the gate holder is a noop.
 func TestProviderGate_ZeroOverheadWhenUnconfigured(t *testing.T) {
-	prov := &countingProvider{delay: 20 * time.Millisecond}
+	const n = 5
+	// holdUntil=n makes the n admitted calls RENDEZVOUS in provider.Call so the
+	// observed peak deterministically reaches n regardless of CI scheduling
+	// jitter. Without it a loaded race-runner can stagger the admitted requests
+	// so only one is ever in Call at a time — a false peak=1 that flaked this
+	// test in CI. A genuine under-admit still fails: fewer than n arrive, the 2s
+	// safety valve fires, and peak stays < 2.
+	prov := &countingProvider{delay: 20 * time.Millisecond, holdUntil: n}
 	cfg := gateTestConfig()
 	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "zero.db"))
 	if err != nil {
@@ -262,7 +269,6 @@ func TestProviderGate_ZeroOverheadWhenUnconfigured(t *testing.T) {
 	ts := httptest.NewServer(srv.Mux())
 	defer ts.Close()
 
-	const n = 5
 	var wg sync.WaitGroup
 	for i := 0; i < n; i++ {
 		wg.Add(1)


### PR DESCRIPTION
## Why
`TestProviderGate_ZeroOverheadWhenUnconfigured` is a concurrency-*overlap* timing assertion: it fires 5 concurrent runs and requires them to overlap in `provider.Call` (`peak > 1`). It used a bare 20ms delay with no rendezvous, so a loaded CI runner could stagger the admitted requests enough that only one was ever in `Call` at a time — a false `peak=1`. It failed exactly this way on a recent PR's `Go 1.26.x` job (all other checks green).

## What
`countingProvider` already ships a `holdUntil` rendezvous built for precisely this: an admitted call blocks until `holdUntil` calls are simultaneously in-flight (or a 2s safety valve fires), so the observed peak deterministically reaches the target regardless of scheduling jitter. The test just wasn't opting in. Set `holdUntil=n`.

A genuine under-admit bug still fails the test — fewer than `n` arrive, the safety valve fires, and `peak` stays `< 2`. The global cap (8) exceeds `n` (5), so all admit and the barrier releases (no deadlock).

## What was tested
Test-only change. Verified `-count=20` clean, `-race -count=5` clean, and the whole `TestProviderGate*` suite unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)