### PR TITLE
fix(webui): make the ontology edit path an affordance, not prose

### DIFF
--- a/.github/workflows/publish-sandbox-images.yml
+++ b/.github/workflows/publish-sandbox-images.yml
@@ -40,12 +40,49 @@ permissions:
   contents: read
 
 jobs:
+  # FULL vs LEAN, mirroring release.yml: the sandbox images are FULL-build-only.
+  # A minor/major tag (vX.Y.0) or a manual dispatch builds them; a patch tag
+  # (vX.Y.Z, Z>0) SKIPS them — a bugfix release rebuilds only loomcycle-browser
+  # (see release.yml's browser-patch job). Operators wanting the sandbox images
+  # at a patch version run this workflow via workflow_dispatch.
+  classify:
+    name: classify release
+    runs-on: ubuntu-latest
+    outputs:
+      full: ${{ steps.c.outputs.full }}
+    steps:
+      - id: c
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "full=true" >> "$GITHUB_OUTPUT"   # manual → always build
+            exit 0
+          fi
+          VER="${REF_NAME#v}"
+          case "$VER" in
+            *.*.*)
+              PATCH="${VER##*.}"
+              if [ "$PATCH" = "0" ]; then
+                echo "full=true" >> "$GITHUB_OUTPUT"
+              else
+                echo "full=false" >> "$GITHUB_OUTPUT"
+                echo "::notice::patch tag $REF_NAME — sandbox images skipped (build on the next minor, or via workflow_dispatch)"
+              fi
+              ;;
+            *) echo "full=true" >> "$GITHUB_OUTPUT" ;;
+          esac
+
   publish:
     name: build + push sandbox images
+    needs: classify
     runs-on: ubuntu-latest
     # Same explicit gate as goreleaser's docker publish: skip cleanly until the
-    # operator sets DOCKER_PUBLISH_ENABLED and the Docker Hub credentials.
-    if: vars.DOCKER_PUBLISH_ENABLED == 'true'
+    # operator sets DOCKER_PUBLISH_ENABLED and the Docker Hub credentials. Plus
+    # the FULL-build gate — a patch tag skips the sandbox images.
+    if: vars.DOCKER_PUBLISH_ENABLED == 'true' && needs.classify.outputs.full == 'true'
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,16 @@ on:
   push:
     tags:
       - "v*"
+  # Escape hatch: force the FULL build (binaries + Homebrew + every image)
+  # regardless of the tag shape. Use it to give a patch tag the full treatment
+  # when a minor's worth of artifacts is needed (e.g. an arm64 or Homebrew fix
+  # shipped as a patch). Dispatch this workflow on the tag ref with force_full=true.
+  workflow_dispatch:
+    inputs:
+      force_full:
+        description: "Force the full build even on a patch tag (true/false)"
+        required: false
+        default: "false"
 
 # Run JavaScript-based actions (checkout, setup-go/node, docker/*,
 # goreleaser-action) on Node.js 24. GitHub forces this default 2026-06-16
@@ -51,8 +61,58 @@ permissions:
   contents: write  # needed for goreleaser to upload release assets
 
 jobs:
+  # Decide FULL vs LEAN from the tag shape (the release-cadence rule):
+  #   vX.Y.0 (patch component 0) or a major, or a force_full dispatch → FULL
+  #   build (binaries + Homebrew + every image variant, as before).
+  #   vX.Y.Z with Z>0 (a patch / subversion) → LEAN build: only the
+  #   loomcycle-browser linux/amd64 image (see the browser-patch job). A
+  #   non-semver ref defaults to FULL (safe).
+  classify:
+    name: classify release
+    runs-on: ubuntu-latest
+    outputs:
+      full: ${{ steps.c.outputs.full }}
+      version: ${{ steps.c.outputs.version }}
+    steps:
+      - id: c
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          FORCE_FULL: ${{ github.event.inputs.force_full }}
+        run: |
+          set -euo pipefail
+          VER="${REF_NAME#v}"          # v1.51.1 -> 1.51.1
+          # Charset-validate before it flows into a docker tag downstream.
+          if ! printf '%s' "$VER" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$'; then
+            echo "::error::Invalid version '$VER' (a docker tag must match [A-Za-z0-9._-])"
+            exit 1
+          fi
+          echo "version=$VER" >> "$GITHUB_OUTPUT"
+          if [ "${FORCE_FULL:-false}" = "true" ]; then
+            echo "full=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::force_full requested — running the FULL build"
+            exit 0
+          fi
+          case "$VER" in
+            *.*.*)
+              PATCH="${VER##*.}"       # 1.51.1 -> 1 ; 1.51.0 -> 0
+              if [ "$PATCH" = "0" ]; then
+                echo "full=true" >> "$GITHUB_OUTPUT"
+                echo "::notice::$REF_NAME is a minor/major — FULL build (all variants)"
+              else
+                echo "full=false" >> "$GITHUB_OUTPUT"
+                echo "::notice::$REF_NAME is a patch — LEAN build (loomcycle-browser linux/amd64 only)"
+              fi
+              ;;
+            *)
+              echo "full=true" >> "$GITHUB_OUTPUT"
+              echo "::notice::$REF_NAME is not X.Y.Z — defaulting to FULL build"
+              ;;
+          esac
+
   goreleaser:
     name: goreleaser
+    needs: classify
+    if: needs.classify.outputs.full == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -189,3 +249,107 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+  # LEAN patch path: on a vX.Y.Z (Z>0) tag, publish ONLY the loomcycle-browser
+  # linux/amd64 image — the deployable variant — and skip the binaries,
+  # Homebrew, the other images, and the sandbox images (publish-sandbox-images
+  # skips itself on a patch too). Adapters publish independently, gated on their
+  # own version-match ("if changed"). This turns a 30+ min full build into a few
+  # minutes for a bugfix release. Force the full build on a patch with a
+  # workflow_dispatch (force_full=true).
+  browser-patch:
+    name: patch — loomcycle-browser (linux/amd64)
+    needs: classify
+    if: needs.classify.outputs.full == 'false'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # pre-create the GitHub release from the annotated tag
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      # A patch still gets a GitHub release page carrying the annotated-tag
+      # notes (no binaries attached — those are a full-build artifact). Same
+      # annotated-tag verification as the goreleaser path, so a lightweight tag
+      # (no notes) fails loudly instead of publishing the commit message.
+      - name: Pre-create GitHub release with annotated tag body
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          git fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}"
+          OBJ_TYPE="$(git cat-file -t "$TAG")"
+          if [ "$OBJ_TYPE" != "tag" ]; then
+            echo "::error::Tag $TAG is lightweight (object type: $OBJ_TYPE) — it carries no release notes. Re-tag annotated: git tag -a $TAG -F notes.md && git push --force origin $TAG"
+            exit 1
+          fi
+          git tag -l --format='%(contents)' "$TAG" > /tmp/release-notes.md
+          if [ ! -s /tmp/release-notes.md ]; then
+            echo "::error::Tag $TAG has an empty annotated message."
+            exit 1
+          fi
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "::notice::Release $TAG already exists — skipping pre-create."
+            exit 0
+          fi
+          gh release create "$TAG" --notes-file /tmp/release-notes.md --latest --verify-tag --title "$TAG"
+
+      # The image build is gated on DOCKER_PUBLISH_ENABLED, exactly like the
+      # goreleaser docker stage. A patch's only artifact IS the image, so with
+      # docker publishing off there is nothing more to do (the release page
+      # above is still created).
+      - uses: actions/setup-go@v5
+        if: vars.DOCKER_PUBLISH_ENABLED == 'true'
+        with:
+          go-version: "1.26"
+          cache: true
+      - uses: actions/setup-node@v5
+        if: vars.DOCKER_PUBLISH_ENABLED == 'true'
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - name: Build embedded Web UI
+        if: vars.DOCKER_PUBLISH_ENABLED == 'true'
+        run: make build-ui
+
+      - name: Build the linux/amd64 loomcycle binary
+        if: vars.DOCKER_PUBLISH_ENABLED == 'true'
+        # Dockerfile.browser COPYs a pre-built binary from the context (the same
+        # contract goreleaser's dockers stage uses), so build it here with the
+        # SAME ldflag vars cmd/loomcycle/main.go reads (buildVersion / buildCommit
+        # / buildTime), then leave it at the context root for the buildx step.
+        run: |
+          set -euo pipefail
+          VER="${GITHUB_REF_NAME#v}"
+          COMMIT="$(git rev-parse --short HEAD)"
+          BUILD_TIME="$(git log -1 --format=%cI)"
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+            -trimpath \
+            -ldflags "-s -w -X main.buildVersion=${VER} -X main.buildCommit=${COMMIT} -X main.buildTime=${BUILD_TIME}" \
+            -o ./loomcycle ./cmd/loomcycle
+
+      - name: Set up Docker Buildx
+        if: vars.DOCKER_PUBLISH_ENABLED == 'true'
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to Docker Hub
+        if: vars.DOCKER_PUBLISH_ENABLED == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build + push loomcycle-browser (linux/amd64)
+        if: vars.DOCKER_PUBLISH_ENABLED == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.browser
+          platforms: linux/amd64
+          push: true
+          tags: |
+            denngubsky/loomcycle-browser:${{ needs.classify.outputs.version }}
+            denngubsky/loomcycle-browser:latest

--- a/web/src/pages/SettingsView.tsx
+++ b/web/src/pages/SettingsView.tsx
@@ -499,12 +499,49 @@ function OntologySection() {
       <h2>Ontology</h2>
       <p className="settings-help">
         The entity types agents extract against. Every tenant starts from a
-        standard set; types you define in{" "}
-        <Link to="/paths">{state?.path ?? "/memory/ontology"}</Link> (tenant
-        scope) are layered on top — but only once you confirm them. Until then
-        your edits are stored and inert, so you can draft an ontology without
-        changing what any running agent is told.
+        standard set; the types you define are layered on top — but only once
+        you confirm them below. Until then your edits are stored and inert, so
+        you can draft an ontology without changing what any running agent is
+        told.
       </p>
+
+      {/* THE EDIT AFFORDANCE, and it is deliberately a button rather than the
+          path in prose. An operator reported being unable to find any way to
+          change the ontology: this panel renders types and offers "Revert to
+          draft", so it reads as the place you edit them, while the only route in
+          was a sentence linking to the Paths browser — a file tree, from which
+          you still had to know which document to open. A labelled action that
+          lands ON the document removes the guess.
+
+          Links by document_id when the API returned one (it is provisioned and
+          the caller may read it); falls back to the Paths browser only when
+          there is no id to address, which is the un-provisioned case the panel
+          already explains below. */}
+      <p className="settings-help">
+        {state?.document_id ? (
+          <Link className="settings-action-link" to={`/documents/${state.document_id}`}>
+            Edit ontology →
+          </Link>
+        ) : (
+          <Link to="/paths">{state?.path ?? "/memory/ontology"}</Link>
+        )}
+        {" "}
+        <span className="settings-muted-inline">
+          {state?.path ?? "/memory/ontology"} (tenant scope)
+        </span>
+      </p>
+
+      {/* The format, stated here rather than left to be inferred from the
+          template. Guessing it was the second half of the same report. */}
+      <details className="settings-help">
+        <summary>How the document is written</summary>
+        <p>
+          Each section is one entity type: the <code>## heading</code> names it,
+          and each <code>- `field`</code> bullet declares a field. Prose around
+          them is documentation and is ignored. Reuse a standard type's name to
+          override its fields.
+        </p>
+      </details>
 
       {err && <div className="settings-error">{err}</div>}
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5678,6 +5678,32 @@ button.primary:disabled {
   color: var(--lc-text-faint);
   font-size: var(--lc-text-sm);
 }
+/* The ontology panel's edit affordance. Weighted like an action rather than a
+   link in prose — the report that prompted it was an operator unable to find any
+   way to change the ontology, and a path mentioned mid-sentence does not read as
+   "click here to edit". Uses the same accent + border tokens as the rest of the
+   settings surface so it stays inside the design system. */
+.settings-action-link {
+  display: inline-block;
+  color: var(--lc-accent);
+  font-size: var(--lc-text-sm);
+  font-weight: 500;
+  text-decoration: none;
+  border: 1px solid var(--lc-rule);
+  border-radius: var(--lc-radius-sm);
+  padding: 2px var(--lc-space-2);
+  background: var(--lc-surface-2);
+}
+.settings-action-link:hover {
+  border-color: var(--lc-accent);
+}
+/* The document path beside the action: present for orientation, not competing
+   with it for attention. */
+.settings-muted-inline {
+  color: var(--lc-text-faint);
+  font-size: var(--lc-text-sm);
+  font-family: var(--lc-font-mono);
+}
 .settings-error {
   color: var(--lc-failed);
   background: rgba(255, 93, 104, 0.1);


### PR DESCRIPTION
From the report that "there is no way to alter [the ontology] or include/exclude new entities or build a hierarchy". Two of those are real gaps — covered by **RFC BZ** (`/loomcycle/rfcs/ontology-hierarchy`, now confirmed). The first was purely this panel, and it shouldn't wait for the RFC.

## The problem

The panel renders the types in force and offers **"Revert to draft"**, so it reads as the place you'd edit them. The only route in was a path mentioned mid-sentence, linking to `/paths` — a file browser, from which you still had to know which document to open and what shape it takes.

Nothing was broken. Nothing said what to click.

## The change

A labelled **"Edit ontology →"** action that lands *on* the document, using the `document_id` the `/v1/_ontology` response already returns — it was in the API *and* the TS type, just never used. The path stays beside it for orientation, weighted down so it doesn't compete.

When there's no `document_id` — the un-provisioned / no-SQL-Memory case the panel already explains below — it falls back to the `/paths` link rather than offering a dead action.

Plus a collapsed **"How the document is written"**: `## heading` names a type, each `` - `field` `` bullet declares a field, surrounding prose is documentation, and reusing a standard name overrides it. Having to infer the format from the template was the second half of the same report.

## Two notes

**Styles reuse existing tokens** (`--lc-accent` / `--lc-rule` / `--lc-surface-2`) rather than introducing values. My first pass referenced `--lc-border`, which **doesn't exist** in `tokens.css` — the panel itself uses `--lc-rule`. Every token is now verified present, so this can't ship an invisible border.

**Verification is the build, not tests.** `web/` has two lib-level unit tests and no component-test harness, so `tsc --noEmit` + `vite build` (both clean) is the honest extent of it. I'd rather say that than imply coverage. Presentational change; no API, no Go, and `internal/webui/dist` stays gitignored for CI to rebuild.

## Related

RFC BZ is confirmed with **§10.1 decided: override then nest** — to subclass a standard type, declare it as a root chunk (which already overrides the seed by name) and nest beneath your own copy. No new mechanism; the cost is restating the seed's fields, which the provisioning template should turn into a copy-paste.

RFC BZ phase 1 also fixes a **live silent-loss bug**: `ParseOntologyMarkdown` matches only `"## "`, so a nested `### incident` is dropped with no error — anyone who has organised their ontology into a tree has types that aren't in force.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8