### PR TITLE
feat(ontology): read the ontology as a chunk tree — a child chunk is a subclass (RFC BZ P1)

### DIFF
--- a/internal/api/http/ontology.go
+++ b/internal/api/http/ontology.go
@@ -39,7 +39,7 @@ import (
 // guidance and a run that dies for want of it is worse than a run using the
 // standard types.
 func (s *Server) renderOntology(ctx context.Context, mi memInject) string {
-	terms, confirmed := s.tenantOntologyTerms(ctx, mi)
+	terms, confirmed, _ := s.tenantOntologyTerms(ctx, mi)
 	return meminject.RenderOntology(meminject.EffectiveOntology(terms, confirmed), confirmed)
 }
 
@@ -51,9 +51,9 @@ func (s *Server) renderOntology(ctx context.Context, mi memInject) string {
 // document's terms are still returned so a caller can show them, but
 // EffectiveOntology discards them. Keeping the discard in one place means no caller
 // can accidentally honour a draft.
-func (s *Server) tenantOntologyTerms(ctx context.Context, mi memInject) (terms []meminject.OntologyTerm, confirmed bool) {
+func (s *Server) tenantOntologyTerms(ctx context.Context, mi memInject) (terms []meminject.OntologyTerm, confirmed bool, note string) {
 	if s.store == nil || s.sqlMem == nil {
-		return nil, false
+		return nil, false, ""
 	}
 	s.ensureOntologyDoc(ctx, mi)
 
@@ -74,35 +74,58 @@ func (s *Server) tenantOntologyTerms(ctx context.Context, mi memInject) (terms [
 	})
 	res, _ := doc.Execute(dctx, req)
 	if res.IsError {
-		return nil, false
+		return nil, false, ""
 	}
 	var meta struct {
 		Status string `json:"status"`
 	}
 	if err := json.Unmarshal([]byte(res.Text), &meta); err != nil {
-		return nil, false
+		return nil, false, ""
 	}
 	confirmed = strings.EqualFold(strings.TrimSpace(meta.Status), meminject.OntologyConfirmedStatus)
 
-	// The TERMS come from export_md — one call for the whole document, in exactly
-	// the shape the operator authored it. Reading the Markdown rather than the
-	// materialized types keeps a single authority: the document is the source, and
-	// anything derived from it is a cache.
+	// The TERMS come from the CHUNK TREE, not from the exported Markdown.
+	//
+	// The export flattens chunk depth into "#" repetition, which makes a subclass's
+	// title byte-identical to a heading inside a body — so the tree read is not an
+	// optimisation, it is the only way to tell a nested TYPE from a nested COMMENT.
+	// It also ends a silent data loss: the markdown parser matched only "## ", so
+	// every nested type an operator wrote was dropped without a word.
+	tree, terr := doc.OntologyTermsFromTree(dctx, "tenant", meminject.OntologyPath)
+	if terr == nil && len(tree) > 0 {
+		return tree, confirmed, ""
+	}
+
+	// FALLBACK, deliberately narrow: only when the tree yielded NOTHING.
+	//
+	// A document whose entities were typed into one chunk's body — the root's, say,
+	// replacing the provisioned structure — has headings but no child chunks, and the
+	// tree read would correctly report zero while the operator sees a full document.
+	// Emptying someone's ontology on upgrade is a worse failure than carrying a second
+	// reader for one case, so the flat parse still runs, and it reports itself: a
+	// silent fallback would leave the operator's hierarchy quietly inert, which is the
+	// exact bug being fixed here wearing a different hat.
 	exp, _ := json.Marshal(map[string]any{
 		"op": "export_md", "scope": "tenant", "path": meminject.OntologyPath,
 		"include_metadata": false,
 	})
 	eres, _ := doc.Execute(dctx, exp)
 	if eres.IsError {
-		return nil, confirmed
+		return nil, confirmed, ""
 	}
 	var body struct {
 		Markdown string `json:"markdown"`
 	}
 	if err := json.Unmarshal([]byte(eres.Text), &body); err != nil {
-		return nil, confirmed
+		return nil, confirmed, ""
 	}
-	return meminject.ParseOntologyMarkdown(body.Markdown), confirmed
+	flat := meminject.ParseOntologyMarkdown(body.Markdown)
+	if len(flat) == 0 {
+		return nil, confirmed, ""
+	}
+	return flat, confirmed, "This ontology was read as flat Markdown because the " +
+		"document has no per-entity chunks. Split each entity into its own chunk to " +
+		"use subclasses — a child chunk is a subclass of its parent."
 }
 
 // ensureOntologyDoc provisions the tenant's ontology document from the embedded

--- a/internal/api/http/ontology.go
+++ b/internal/api/http/ontology.go
@@ -23,6 +23,7 @@ package http
 import (
 	"context"
 	"encoding/json"
+	"log"
 	"strings"
 
 	meminject "github.com/denn-gubsky/loomcycle/internal/memory"
@@ -122,6 +123,20 @@ func (s *Server) tenantOntologyTerms(ctx context.Context, mi memInject) (terms [
 	flat := meminject.ParseOntologyMarkdown(body.Markdown)
 	if len(flat) == 0 {
 		return nil, confirmed, ""
+	}
+	// The note must state the cause it actually established. A tree read that FAILED
+	// and one that legitimately found no chunks lead here identically, and telling an
+	// operator to split their chunks when the real problem was a store fault sends
+	// them to fix the one thing that was fine.
+	if terr != nil {
+		// The detail is LOGGED, not returned. A store fault's text can carry a DSN or a
+		// filesystem path, and this note renders in a tenant operator's browser — the
+		// operator needs to know their subclasses are not in force, not where the
+		// database lives.
+		log.Printf("ontology: chunk-tree read failed for tenant %q, falling back to flat markdown: %v", mi.Tenant, terr)
+		return flat, confirmed, "The document's chunk structure could not be read, so " +
+			"it was read as flat Markdown — subclasses are not in force until this " +
+			"resolves. See the server log for the cause."
 	}
 	return flat, confirmed, "This ontology was read as flat Markdown because the " +
 		"document has no per-entity chunks. Split each entity into its own chunk to " +

--- a/internal/api/http/ontology_admin.go
+++ b/internal/api/http/ontology_admin.go
@@ -63,6 +63,11 @@ type ontologyResponse struct {
 	// applied only if Confirmed. Each term carries its own source, so the UI can
 	// mark which half it came from without diffing against the seed.
 	Effective []meminject.OntologyTerm `json:"effective"`
+	// Note carries a reader-level caveat the operator has to know to act on — today
+	// only "this document had no per-entity chunks, so it was read flat and cannot
+	// express subclasses". Surfaced rather than logged because the consequence lands
+	// on the operator's data, not on the server.
+	Note string `json:"note,omitempty"`
 }
 
 // handleOntology serves GET /v1/_ontology — the tenant ontology's state.
@@ -177,7 +182,7 @@ func (s *Server) ontologyState(ctx context.Context, tenant string) (ontologyResp
 	}
 
 	mi := memInject{Tenant: tenant}
-	terms, confirmed := s.tenantOntologyTerms(ctx, mi)
+	terms, confirmed, note := s.tenantOntologyTerms(ctx, mi)
 
 	doc := &builtin.Document{Store: s.store, SqlMem: s.sqlMem}
 	dctx := s.ontologyDocCtx(ctx, mi)
@@ -193,6 +198,7 @@ func (s *Server) ontologyState(ctx context.Context, tenant string) (ontologyResp
 		resp.Terms = terms
 	}
 	resp.Confirmed = confirmed
+	resp.Note = note
 	resp.Effective = meminject.EffectiveOntology(terms, confirmed)
 	return resp, nil
 }

--- a/internal/api/http/ontology_test.go
+++ b/internal/api/http/ontology_test.go
@@ -165,3 +165,75 @@ func (s *Server) confirmOntology(t *testing.T, mi memInject) {
 	t.Helper()
 	s.setOntologyStatus(t, mi.Tenant, meminject.OntologyConfirmedStatus, http.StatusOK)
 }
+
+// TestOntology_NestedChunkReachesTheEffectiveOntology is the bug, end to end.
+//
+// The unit test proves the tree reader; this proves the SERVER read uses it. Those are
+// different claims, and this subsystem has already shipped the gap between them twice —
+// a correct component wired to nothing passes all of its own tests.
+//
+// FAILS before the change: the read went through export_md, which flattens chunk depth
+// into "#" repetition, and the parser matched only "## ".
+func TestOntology_NestedChunkReachesTheEffectiveOntology(t *testing.T) {
+	s, mi := ontologyFixture(t)
+	// Provision by rendering once, exactly as a run does.
+	s.applyMemoryInjection(context.Background(), config.AgentDef{
+		SystemPrompt: "{{memory:ontology}}",
+	}, mi)
+
+	doc := &builtin.Document{Store: s.store, SqlMem: s.sqlMem}
+	dctx := s.ontologyDocCtx(context.Background(), mi)
+
+	// Find the sample `project` term's chunk and hang a subclass off it.
+	q, _ := json.Marshal(map[string]any{
+		"op": "query_chunks", "scope": "tenant",
+		"sql": "SELECT id, document_id FROM chunks WHERE title = 'project' LIMIT 1",
+	})
+	qres, err := doc.Execute(dctx, q)
+	if err != nil || qres.IsError {
+		t.Fatalf("query_chunks: %v %s", err, qres.Text)
+	}
+	var qout struct {
+		Rows [][]any `json:"rows"`
+	}
+	if err := json.Unmarshal([]byte(qres.Text), &qout); err != nil || len(qout.Rows) == 0 {
+		t.Fatalf("no `project` chunk to nest under: %v %s", err, qres.Text)
+	}
+	parentID, docID := qout.Rows[0][0].(string), qout.Rows[0][1].(string)
+
+	c, _ := json.Marshal(map[string]any{
+		"op": "create_chunk", "scope": "tenant", "document_id": docID,
+		"parent_id": parentID, "title": "internal-project",
+		"body": "- `cost_center` — who pays\n",
+	})
+	if cres, cerr := doc.Execute(dctx, c); cerr != nil || cres.IsError {
+		t.Fatalf("create_chunk: %v %s", cerr, cres.Text)
+	}
+
+	terms, _, note := s.tenantOntologyTerms(context.Background(), mi)
+	var found *meminject.OntologyTerm
+	for i := range terms {
+		if terms[i].Name == "internal-project" {
+			found = &terms[i]
+		}
+	}
+	if found == nil {
+		names := []string{}
+		for _, tm := range terms {
+			names = append(names, tm.Name)
+		}
+		t.Fatalf("the nested type never reached the server read — have %v", names)
+	}
+	if found.Parent != "project" {
+		t.Errorf("internal-project.Parent = %q, want project", found.Parent)
+	}
+	if len(found.Fields) != 1 || found.Fields[0] != "cost_center" {
+		t.Errorf("fields = %v, want [cost_center]", found.Fields)
+	}
+	// The tree read succeeded, so the flat-Markdown fallback must NOT have reported
+	// itself — a note here would mean the tree path silently lost and the caveat is
+	// the only thing telling anyone.
+	if note != "" {
+		t.Errorf("unexpected fallback note: %q", note)
+	}
+}

--- a/internal/api/http/ontology_test.go
+++ b/internal/api/http/ontology_test.go
@@ -59,7 +59,7 @@ func TestOntology_ProvisionsTheDocumentOnFirstReference(t *testing.T) {
 	def := config.AgentDef{SystemPrompt: "{{memory:ontology}}"}
 	s.applyMemoryInjection(context.Background(), def, mi)
 
-	terms, confirmed := s.tenantOntologyTerms(context.Background(), mi)
+	terms, confirmed, _ := s.tenantOntologyTerms(context.Background(), mi)
 	if confirmed {
 		t.Error("a provisioned document must start unconfirmed")
 	}

--- a/internal/memory/ontology.go
+++ b/internal/memory/ontology.go
@@ -58,6 +58,15 @@ type OntologyTerm struct {
 	// overrode. Reported so a reader can tell which half of the layering they are
 	// looking at without diffing against the seed.
 	Source string `json:"source"`
+	// Parent is the NAME of the entity this one subclasses, or "" for a root
+	// (RFC BZ). A name rather than a chunk id because the ontology is consumed by
+	// name everywhere downstream — the prompt, the stored fact's type, the retrieval
+	// filter — and an id would have to be resolved back to a name at each of them.
+	//
+	// Seed terms are always roots: the seed lives in Go and has no chunks to nest
+	// beneath, so subclassing a standard type means overriding it as a root chunk and
+	// nesting under your own copy (RFC BZ §10.1).
+	Parent string `json:"parent,omitempty"`
 }
 
 // BaseSeedOntology is the ontology every tenant starts with: POLE+O — person,
@@ -178,6 +187,62 @@ func joinComma(ss []string) string {
 	return out
 }
 
+// TrimOntologyName normalises a heading line or a chunk title into an entity name.
+//
+// ONE definition, shared by the chunk-tree reader (where the name comes from a title)
+// and the markdown parser (where it comes from a heading), so the same entity cannot end
+// up with two spellings depending on which path read it — the name is a fact's natural
+// key and a retrieval filter, so a stray "#" would split a type in half.
+func TrimOntologyName(s string) string {
+	return strings.TrimSpace(strings.TrimLeft(strings.TrimSpace(s), "#"))
+}
+
+// FirstHeadingName returns the name from the first Markdown heading in a body, or "".
+//
+// The fallback for a chunk with no title: an operator who typed "## incident" into a body
+// through update_chunk named their entity, and dropping it for want of a title column
+// would be the same silent loss RFC BZ exists to remove. Any heading level is accepted
+// because the level a chunk renders at depends on its depth, not on the author.
+func FirstHeadingName(body string) string {
+	for _, line := range strings.Split(body, "\n") {
+		t := strings.TrimSpace(line)
+		if !strings.HasPrefix(t, "#") {
+			continue
+		}
+		// Require the space: "#tag" is not a heading.
+		if i := strings.IndexByte(t, ' '); i > 0 && strings.Trim(t[:i], "#") == "" {
+			if n := TrimOntologyName(t); n != "" {
+				return n
+			}
+		}
+	}
+	return ""
+}
+
+// ParseOntologyFields extracts the field names from ONE entity's body.
+//
+// Exported because RFC BZ reads the chunk tree while the legacy markdown path still
+// exists as a narrow fallback (§2.3), and both must agree on what a field is. Two
+// readers deciding that independently is how they drift — the same failure the
+// embedding predicate had when the writer and the sweep disagreed.
+//
+// A field is the FIRST backticked token on a `- ` bullet. Prose after it is the
+// operator's description and is deliberately ignored, so a field can be documented
+// inline without the documentation becoming part of the name.
+func ParseOntologyFields(body string) []string {
+	var out []string
+	for _, line := range strings.Split(body, "\n") {
+		t := strings.TrimSpace(line)
+		if !strings.HasPrefix(t, "- ") {
+			continue
+		}
+		if f := firstBackticked(t); f != "" {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
 // ParseOntologyMarkdown extracts terms from the ontology document's Markdown.
 //
 // It reads the format the TEMPLATE writes and an operator edits: a `## name`
@@ -212,7 +277,7 @@ func ParseOntologyMarkdown(md string) []OntologyTerm {
 		switch {
 		case strings.HasPrefix(t, "## "):
 			flush()
-			name := strings.TrimSpace(strings.TrimPrefix(t, "## "))
+			name := TrimOntologyName(strings.TrimPrefix(t, "## "))
 			cur = &OntologyTerm{Name: name, Source: "tenant"}
 		case strings.HasPrefix(t, "# "):
 			// The document title, not a term.

--- a/internal/memory/templates/ontology.md
+++ b/internal/memory/templates/ontology.md
@@ -13,6 +13,12 @@ The standard types are always available and do not need repeating here:
 Add a type below only when your work needs something they do not cover — or
 reuse a standard name to override its fields.
 
+**Nesting makes a subclass.** A `### internal-project` under `## project` is a
+kind of project — its own type, recorded as a child of the one above it. Nest as
+deep as four levels. To subclass a *standard* type, first give it a `##` heading
+of its own here: that overrides the standard one, and you can then nest beneath
+your copy.
+
 ## project
 
 A body of work with a lifecycle of its own. Worth its own type when memory

--- a/internal/tools/builtin/document_ontology.go
+++ b/internal/tools/builtin/document_ontology.go
@@ -1,0 +1,163 @@
+package builtin
+
+// document_ontology.go — reading the ontology document as a TREE (RFC BZ phase 1).
+//
+// ONE CHUNK IS ONE ENTITY. Its title names the entity, backticked bullets in its body
+// declare fields, everything else in the body is documentation, and its CHILD CHUNKS
+// are its subclasses. The document's root chunk is not an entity; its children are the
+// root entities.
+//
+// WHY THIS REPLACES READING THE EXPORTED MARKDOWN, which is not a preference but a
+// requirement. export_md renders chunk depth as `strings.Repeat("#", level)`, so after
+// flattening these two lines are the same bytes:
+//
+//	### incident      ← was a child chunk's title (a subclass)
+//	### incident      ← was a line inside a body (a comment)
+//
+// The distinction the rule rests on is destroyed by the export. Reading chunks makes it
+// free: parent_id IS the hierarchy.
+//
+// It also fixes a silent data-loss bug. The markdown parser matched only "## ", so a
+// nested "### incident" was recognised as neither a term nor a title and was dropped —
+// no error, no warning, nothing in the Settings panel. An operator who organised their
+// ontology into a tree, which is the natural move in a document UI, had a document that
+// read correctly and an ontology that did not match it.
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	memrank "github.com/denn-gubsky/loomcycle/internal/memory"
+	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// ontologyMaxDepth bounds how deep a subclass chain may go (RFC BZ §5).
+//
+// The rendered tree goes into every extraction prompt, so depth costs tokens on every
+// call; and a taxonomy deeper than this is usually modelling confusion rather than
+// precision. Deeper nodes are still returned — re-parented to the deepest allowed
+// ancestor rather than dropped, because silently discarding an entity is the bug this
+// file exists to fix.
+const ontologyMaxDepth = 4
+
+// ontologyChunk is one row of the tree walk.
+type ontologyChunk struct {
+	id       string
+	parentID string
+	title    string
+	position int
+}
+
+// OntologyTermsFromTree reads the ontology document at the given path and returns its
+// entities with parentage resolved.
+//
+// Returns (nil, nil) when the document does not exist — provisioning is the caller's
+// concern, and an absent document is "no tenant layer", not an error.
+//
+// DEPTH-FIRST IN POSITION ORDER, so the returned slice reads like the document: a
+// parent immediately followed by its subclasses. EffectiveOntology sorts by name for
+// rendering, but a caller showing the tree (the Settings panel) wants document order.
+func (d *Document) OntologyTermsFromTree(ctx context.Context, scope, path string) ([]memrank.OntologyTerm, error) {
+	if d.Store == nil || d.SqlMem == nil {
+		return nil, fmt.Errorf("ontology: requires SQL Memory (set LOOMCYCLE_SQLMEM_ENABLED=1)")
+	}
+	key, mscope, err := d.resolveScope(ctx, scope)
+	if err != nil {
+		return nil, err
+	}
+	if err := d.ensureSchema(ctx, key); err != nil {
+		return nil, err
+	}
+	docID, err := d.docIDFromInput(ctx, key, docInput{Path: path})
+	if err != nil {
+		return nil, nil // no such document — no tenant layer
+	}
+	var rootID string
+	if res, qerr := d.query(ctx, key,
+		`SELECT root_chunk_id FROM documents WHERE id = ? LIMIT 1`, docID); qerr != nil {
+		return nil, qerr
+	} else if len(res.Rows) == 0 || len(res.Rows[0]) == 0 {
+		return nil, nil
+	} else {
+		rootID = asStr(res.Rows[0][0])
+	}
+
+	res, err := d.query(ctx, key,
+		`SELECT id, coalesce(parent_id, ''), coalesce(title, ''), position
+		   FROM chunks WHERE document_id = ? ORDER BY position`, docID)
+	if err != nil {
+		return nil, err
+	}
+	kids := map[string][]ontologyChunk{}
+	for _, row := range res.Rows {
+		if len(row) < 4 {
+			continue
+		}
+		c := ontologyChunk{
+			id: asStr(row[0]), parentID: asStr(row[1]),
+			title: asStr(row[2]), position: asInt(row[3]),
+		}
+		kids[c.parentID] = append(kids[c.parentID], c)
+	}
+	for k := range kids {
+		sort.SliceStable(kids[k], func(i, j int) bool {
+			return kids[k][i].position < kids[k][j].position
+		})
+	}
+
+	var out []memrank.OntologyTerm
+	// The walk starts at the ROOT CHUNK'S CHILDREN: the root is the document's title
+	// ("Tenant Ontology"), not an entity. Including it would invent a type nobody
+	// declared and make every real entity its subclass.
+	var walk func(parentChunkID, parentName string, depth int)
+	walk = func(parentChunkID, parentName string, depth int) {
+		for _, c := range kids[parentChunkID] {
+			name := d.ontologyEntityName(ctx, mscope, key, c)
+			if name == "" {
+				// No title and no leading heading: nothing names this entity. Its
+				// children are still walked, attached to the nearest NAMED ancestor, so
+				// an unnamed organisational chunk does not orphan a real subclass.
+				walk(c.id, parentName, depth)
+				continue
+			}
+			body, _ := d.readBody(ctx, mscope, key.ScopeID, c.id)
+			out = append(out, memrank.OntologyTerm{
+				Name:   name,
+				Fields: memrank.ParseOntologyFields(body.Body),
+				Source: "tenant",
+				Parent: parentName,
+			})
+			next := depth + 1
+			// At the cap, deeper nodes attach to THIS node's parent chain rather than
+			// growing the tree — they stay in the ontology, just flattened.
+			if next >= ontologyMaxDepth {
+				walk(c.id, name, depth)
+				continue
+			}
+			walk(c.id, name, next)
+		}
+	}
+	walk(rootID, "", 1)
+	return out, nil
+}
+
+// ontologyEntityName resolves an entity's name: the chunk's title, or — when the title
+// is empty — the first `## ` heading in its body.
+//
+// The title is authoritative because import_md already lifts a heading into it, so a
+// document authored the normal way has the name exactly there. The body fallback covers
+// a chunk written directly through update_chunk, where the operator typed a heading and
+// no title was ever set; without it their entity would be nameless and dropped, which
+// is the failure mode this whole change exists to remove.
+func (d *Document) ontologyEntityName(ctx context.Context, mscope store.MemoryScope, key sqlmem.ScopeKey, c ontologyChunk) string {
+	if n := memrank.TrimOntologyName(c.title); n != "" {
+		return n
+	}
+	body, err := d.readBody(ctx, mscope, key.ScopeID, c.id)
+	if err != nil {
+		return ""
+	}
+	return memrank.FirstHeadingName(body.Body)
+}

--- a/internal/tools/builtin/document_ontology.go
+++ b/internal/tools/builtin/document_ontology.go
@@ -129,14 +129,15 @@ func (d *Document) OntologyTermsFromTree(ctx context.Context, scope, path string
 				Source: "tenant",
 				Parent: parentName,
 			})
-			next := depth + 1
-			// At the cap, deeper nodes attach to THIS node's parent chain rather than
-			// growing the tree — they stay in the ontology, just flattened.
-			if next >= ontologyMaxDepth {
-				walk(c.id, name, depth)
-				continue
+			// AT the cap, this node's children are reported with this node's OWN
+			// parent — so a would-be level-5 type lands at level 4 as a sibling, and
+			// every deeper descendant collapses into that same flat set. The chain is
+			// bounded at ontologyMaxDepth levels and nothing is discarded.
+			childParent := name
+			if depth >= ontologyMaxDepth {
+				childParent = parentName
 			}
-			walk(c.id, name, next)
+			walk(c.id, childParent, depth+1)
 		}
 	}
 	walk(rootID, "", 1)

--- a/internal/tools/builtin/document_ontology_test.go
+++ b/internal/tools/builtin/document_ontology_test.go
@@ -1,0 +1,206 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// ontologyDocFixture imports a nested ontology document and returns its path.
+//
+// import_md turns heading depth into chunk depth, which is exactly the authoring path
+// an operator uses, so the tree under test is built the way a real one is rather than
+// assembled row by row.
+func ontologyDocFixture(t *testing.T, d *Document, ctx context.Context, md string) string {
+	t.Helper()
+	mj, _ := json.Marshal(md)
+	out, r := docExec(t, d, ctx, `{"op":"import_md","scope":"user","markdown":`+string(mj)+`}`)
+	if r.IsError {
+		t.Fatalf("import_md: %s", r.Text)
+	}
+	id, _ := out["document_id"].(string)
+	if id == "" {
+		t.Fatalf("import_md returned no document_id: %v", out)
+	}
+	path := "/test/ontology-" + id
+	pj, _ := json.Marshal(path)
+	_, r = docExec(t, d, ctx,
+		`{"op":"set_path","scope":"user","id":"`+id+`","path":`+string(pj)+`}`)
+	if r.IsError {
+		t.Fatalf("set_path: %s", r.Text)
+	}
+	return path
+}
+
+// termsByName indexes a term slice for assertion.
+func termsByName(terms []ontologyTermForTest) map[string]ontologyTermForTest {
+	m := map[string]ontologyTermForTest{}
+	for _, tm := range terms {
+		m[tm.Name] = tm
+	}
+	return m
+}
+
+// ontologyTermForTest mirrors the fields under assertion, keeping the test readable
+// without importing the memory package's full term.
+type ontologyTermForTest struct {
+	Name   string
+	Parent string
+	Fields []string
+}
+
+func readTerms(t *testing.T, d *Document, ctx context.Context, path string) []ontologyTermForTest {
+	t.Helper()
+	got, err := d.OntologyTermsFromTree(ctx, "user", path)
+	if err != nil {
+		t.Fatalf("OntologyTermsFromTree: %v", err)
+	}
+	out := make([]ontologyTermForTest, 0, len(got))
+	for _, g := range got {
+		out = append(out, ontologyTermForTest{Name: g.Name, Parent: g.Parent, Fields: g.Fields})
+	}
+	return out
+}
+
+// TestOntologyTree_NestedChunkIsASubclass is the whole point of reading chunks.
+//
+// This FAILS on the pre-change reader, and not by a near miss: `ParseOntologyMarkdown`
+// matched only "## ", so `incident` was recognised as neither a term nor a title and
+// vanished with no error and nothing in the panel.
+func TestOntologyTree_NestedChunkIsASubclass(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	path := ontologyDocFixture(t, d, ctx, `# Tenant Ontology
+
+## event
+- `+"`occurred_at`"+` — when it happened
+
+### incident
+- `+"`severity`"+` — how bad
+
+## project
+- `+"`status`"+`
+`)
+
+	byName := termsByName(readTerms(t, d, ctx, path))
+
+	inc, ok := byName["incident"]
+	if !ok {
+		t.Fatalf("the nested type was dropped — have %v", byName)
+	}
+	if inc.Parent != "event" {
+		t.Errorf("incident.Parent = %q, want %q", inc.Parent, "event")
+	}
+	if got := strings.Join(inc.Fields, ","); got != "severity" {
+		t.Errorf("incident fields = %q, want severity", got)
+	}
+	// A root stays a root, and the DOCUMENT TITLE is not an entity: including it
+	// would invent a type nobody declared and make everything its subclass.
+	if ev := byName["event"]; ev.Parent != "" {
+		t.Errorf("event.Parent = %q, want root", ev.Parent)
+	}
+	if _, bad := byName["Tenant Ontology"]; bad {
+		t.Error("the document's root chunk was read as an entity")
+	}
+	if len(byName) != 3 {
+		t.Errorf("want exactly event/incident/project, got %v", byName)
+	}
+}
+
+// TestOntologyTree_HeadingInsideABodyIsAComment is the distinction that justifies
+// reading the data model instead of the Markdown.
+//
+// Under a heading rule an operator documenting their type accidentally declares one.
+// Under the chunk rule a heading inside a body is prose, and only a genuine child
+// CHUNK is a subclass — a difference that is invisible in the exported Markdown and
+// unambiguous in the tree.
+func TestOntologyTree_HeadingInsideABodyIsAComment(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	// One chunk, whose body happens to contain a heading-looking line. Built with
+	// create_chunk rather than import_md precisely because import_md would promote
+	// that line to a chunk — the point is a body that carries one.
+	out, r := docExec(t, d, ctx,
+		`{"op":"create_document","scope":"user","title":"Tenant Ontology","body":""}`)
+	if r.IsError {
+		t.Fatalf("create_document: %s", r.Text)
+	}
+	docID, _ := out["document_id"].(string)
+	root, _ := out["root_chunk_id"].(string)
+	body := "- `status`\n\n### Notes on naming\nPrefer lowercase.\n"
+	bj, _ := json.Marshal(body)
+	_, r = docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+docID+
+		`","parent_id":"`+root+`","title":"project","body":`+string(bj)+`}`)
+	if r.IsError {
+		t.Fatalf("create_chunk: %s", r.Text)
+	}
+	path := "/test/ontology-comment"
+	_, r = docExec(t, d, ctx,
+		`{"op":"set_path","scope":"user","id":"`+docID+`","path":"`+path+`"}`)
+	if r.IsError {
+		t.Fatalf("set_path: %s", r.Text)
+	}
+
+	byName := termsByName(readTerms(t, d, ctx, path))
+	if _, bad := byName["Notes on naming"]; bad {
+		t.Error("a heading inside a body was read as an entity — that is documentation")
+	}
+	p, ok := byName["project"]
+	if !ok {
+		t.Fatalf("project missing — have %v", byName)
+	}
+	if got := strings.Join(p.Fields, ","); got != "status" {
+		t.Errorf("project fields = %q, want status", got)
+	}
+}
+
+// TestOntologyTree_DepthBeyondTheCapIsFlattenedNotDropped.
+//
+// The cap bounds prompt growth, but a cap that DELETES an entity would reintroduce
+// the exact silent loss this reader was written to end — one level further down,
+// where it would be harder to notice.
+func TestOntologyTree_DepthBeyondTheCapIsFlattenedNotDropped(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	path := ontologyDocFixture(t, d, ctx, `# Tenant Ontology
+
+## l1
+
+### l2
+
+#### l3
+
+##### l4
+
+###### l5
+`)
+
+	byName := termsByName(readTerms(t, d, ctx, path))
+	for _, want := range []string{"l1", "l2", "l3", "l4", "l5"} {
+		if _, ok := byName[want]; !ok {
+			t.Errorf("%s was dropped by the depth cap — have %v", want, byName)
+		}
+	}
+	// The chain is bounded at four levels: l4 is the deepest allowed, so l5 lands
+	// BESIDE it rather than below it. The assertion is on the parent because that is
+	// what the cap actually changes — a cap that only stalled a counter would leave
+	// the reported tree unbounded while claiming otherwise.
+	if got := byName["l4"].Parent; got != "l3" {
+		t.Errorf("l4.Parent = %q, want l3", got)
+	}
+	if got := byName["l5"].Parent; got != "l3" {
+		t.Errorf("l5.Parent = %q, want l3 (flattened to the cap, a sibling of l4)", got)
+	}
+}
+
+// TestOntologyTree_AbsentDocumentIsNotAnError: no tenant layer, not a failure. The
+// caller renders the base seed, and a 500 here would take down every run whose prompt
+// mentions the ontology.
+func TestOntologyTree_AbsentDocumentIsNotAnError(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	terms, err := d.OntologyTermsFromTree(ctx, "user", "/test/nope")
+	if err != nil {
+		t.Fatalf("absent document should read as empty, got %v", err)
+	}
+	if len(terms) != 0 {
+		t.Errorf("want no terms, got %v", terms)
+	}
+}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -2703,6 +2703,11 @@ export interface OntologyTerm {
   name: string;
   fields?: string[];
   source: "base" | "tenant";
+  /**
+   * The name of the type this one subclasses, absent for a root. Comes from the
+   * document's chunk tree: a child chunk is a subclass of its parent.
+   */
+  parent?: string;
 }
 
 export interface OntologyResponse {
@@ -2720,6 +2725,11 @@ export interface OntologyResponse {
   terms: OntologyTerm[];
   /** What a run gets right now: the seed, plus the tenant layer if confirmed. */
   effective: OntologyTerm[];
+  /**
+   * A reader-level caveat the operator has to act on — today only "this document
+   * has no per-entity chunks, so it was read flat and cannot express subclasses".
+   */
+  note?: string;
 }
 
 export function getOntology(tenant?: string): Promise<OntologyResponse> {

--- a/web/src/pages/SettingsView.tsx
+++ b/web/src/pages/SettingsView.tsx
@@ -538,6 +538,8 @@ function OntologySection() {
             )}
           </div>
 
+          {state.note && <p className="settings-help">{state.note}</p>}
+
           {oddStatus && (
             <p className="settings-help">
               The document's status reads <code>{state.status}</code>, which is
@@ -552,7 +554,9 @@ function OntologySection() {
               Confirmed, but no types were found in the document. Each type needs
               its own <code>## name</code> heading, with field names in backticks
               on the bullets beneath it — anything else is skipped, so a
-              differently-formatted document confirms to nothing.
+              differently-formatted document confirms to nothing. Nest a heading
+              (<code>### name</code>) to make that type a <em>subclass</em> of the
+              one above it.
             </p>
           )}
 
@@ -571,8 +575,15 @@ function OntologySection() {
                       <span className="settings-muted">none yet</span>
                     ) : (
                       tenantTerms.map((t) => (
-                        <div key={t.name}>
+                        <div key={t.name} style={t.parent ? { paddingLeft: "1em" } : undefined}>
+                          {t.parent && <span className="settings-muted">↳ </span>}
                           <code>{t.name}</code>
+                          {t.parent && (
+                            <span className="settings-muted">
+                              {" "}
+                              subclass of <code>{t.parent}</code>
+                            </span>
+                          )}
                           {t.fields && t.fields.length > 0 && (
                             <span className="settings-muted">
                               {" "}
@@ -585,7 +596,8 @@ function OntologySection() {
                   </td>
                   <td>
                     {(state.effective ?? []).map((t) => (
-                      <div key={t.name}>
+                      <div key={t.name} style={t.parent ? { paddingLeft: "1em" } : undefined}>
+                        {t.parent && <span className="settings-muted">↳ </span>}
                         <code>{t.name}</code>
                         {t.source === "tenant" && (
                           <span className="settings-flash"> yours</span>


### PR DESCRIPTION
## Why

An operator organised their ontology into a hierarchy — the natural move in a document UI — and **lost every nested type**. `ParseOntologyMarkdown` matched only `"## "`, so a `### incident` was recognised as neither a term nor a title and was dropped: no error, no warning, nothing in the Settings panel. Their document read correctly and their ontology did not match it.

This also answers the complaint that opened RFC BZ — "there is no way to build a hierarchy" — with the editor that already exists.

## What

**The fix cannot be "also match `###`."** The ontology was read from `export_md`, and that export renders chunk depth as `strings.Repeat("#", level)`. After flattening, a subclass's title and a heading inside a body are the same bytes:

```
### incident      ← was a child chunk's title (a subclass)
### incident      ← was a line inside a body (a comment)
```

The information needed to tell a nested TYPE from a nested COMMENT is destroyed before the parser sees it. So read the chunks: `parent_id` **is** the hierarchy.

- `Document.OntologyTermsFromTree` walks from the document's root-chunk children. One chunk is one entity, its title names it, backticked bullets are its fields, a **child chunk is a subclass**. The root chunk is not an entity — including it would invent a type nobody declared and make everything its subclass.
- `OntologyTerm` gains `Parent` (a name, not an id: the ontology is consumed by name at every downstream site).
- Rendering stays flat, so apart from newly-visible nested types this is behaviour-preserving. Inheritance is P2, retrieval expansion is P3.
- **Panel + template**, not deferred to the UI phase: RFC BZ §6 — this reader change makes previously-dropped types live, so an upgrading deployment *gains* types. A subclass rendered identically to a root leaves that discoverable only through extraction results.

Two decisions worth flagging:

- **The depth cap was inert as first written** — it stalled a counter without changing any reported parent, so the tree it claimed to bound was unbounded. Found by writing the test. A would-be level-5 type now lands at level 4 as a sibling; nothing is discarded, because a cap that *deletes* an entity reintroduces the exact silent loss this reader exists to end, one level down where it is harder to notice.
- **A narrow flat fallback**, for a document whose entities were typed into one body (headings, no child chunks). Emptying an operator's ontology on upgrade is worse than one extra reader for one case — and that path **reports itself** through a new `note`, because a silent fallback leaves their hierarchy quietly inert, which is this bug wearing a different hat. Name normalisation and field parsing are each ONE exported function shared by both readers; two readers deciding independently what a field is, is how they drift.

## Tested

`go test ./...` clean.

- `TestOntology_NestedChunkReachesTheEffectiveOntology` — **fail-before verified**: on the `export_md` path it reports `the nested type never reached the server read — have [project incident constraint]`, the bug exactly as filed.
- `TestOntologyTree_DepthBeyondTheCapIsFlattenedNotDropped` — **fail-before verified** against the inert cap: `l5.Parent = "l4", want l3`.
- `TestOntologyTree_{NestedChunkIsASubclass,HeadingInsideABodyIsAComment,AbsentDocumentIsNotAnError}` — the subclass, the body-heading-is-prose distinction that justifies reading the data model, and absent-document-is-not-an-error.
- Both halves are tested on purpose: a correct reader wired to nothing passes all of its own tests, and this subsystem has shipped that gap twice.
- `npx tsc --noEmit` clean; `make build-ui` builds.

One note for review order: #976 (the "Edit ontology →" link) touches the same panel section. Different hunks, but if it lands first its format `<details>` block wants the nesting sentence too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8