### PR TITLE
feat(ontology): a type filter matches its subtypes (RFC BZ P3)

### DIFF
--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -79,7 +79,7 @@ const documentInputSchema = `{
 		"new_parent_id": {"type": "string", "description": "move_chunk: the new parent."},
 		"after_id":    {"type": "string", "description": "create_chunk: insert the new chunk immediately AFTER this sibling (same parent; shifts later siblings). Overrides parent_id/position."},
 		"direction":   {"type": "string", "enum": ["up","down"], "description": "reorder_chunk: move the chunk up or down within its current level."},
-		"type":        {"type": "string", "description": "Optional supertag-like chunk type. list_facts (browse the scope's facts — chunks that carry entity metadata — newest first, metadata only, no bodies): return only facts of this type."},
+		"type":        {"type": "string", "description": "Optional supertag-like chunk type. list_facts (browse the scope's facts — chunks that carry entity metadata — newest first, metadata only, no bodies): return only facts of this type. On list_facts and query_chunks the filter INCLUDES SUBTYPES — asking for a general type also returns the more specific kinds of it, so filter by the broadest type that still answers your question. The response reports type_expanded_to when this widened the filter."},
 		"body":        {"type": "string", "description": "Markdown body."},
 		"seed_ids":  {"type": "array", "items": {"type": "string"}, "description": "graph_recall: chunk ids to start from. Use this to hand in results you already found some other way (a Memory search, a previous recall) and follow the graph out from them."},
 		"query":     {"type": "string", "description": "search: free text matched semantically against chunk BODIES — the way into a document when you do not know where to look. graph_recall: find starting chunks whose title matches this text (use seed_ids instead when you already know where to start)."},
@@ -3150,9 +3150,11 @@ func (d *Document) queryChunks(ctx context.Context, key sqlmem.ScopeKey, in docI
 		where += " AND document_id = ?"
 		args = append(args, in.DocumentID)
 	}
-	if in.Type != "" {
-		where += " AND type = ?"
-		args = append(args, in.Type)
+	// RFC BZ subtype expansion: `type=event` also matches its subclasses.
+	typeExpansion := d.expandTypeFilter(ctx, in.Type)
+	if frag, targs := typeFilterSQL("type", typeExpansion); frag != "" {
+		where += " AND " + frag
+		args = append(args, targs...)
 	}
 	if in.Status != "" {
 		where += " AND status = ?"
@@ -3197,7 +3199,14 @@ func (d *Document) queryChunks(ctx context.Context, key sqlmem.ScopeKey, in docI
 		}
 		chunks = append(chunks, m)
 	}
-	return jsonResult(map[string]any{"chunks": chunks})
+	out := map[string]any{"chunks": chunks}
+	// REPORTED, not silent. The filter the caller asked for is not the filter that
+	// ran, and a reader comparing counts across two deployments needs to know which
+	// subclasses were folded in — a wider answer with no explanation reads as a bug.
+	if len(typeExpansion) > 1 {
+		out["type_expanded_to"] = typeExpansion
+	}
+	return jsonResult(out)
 }
 
 // documentsUnderPath returns the document ids named at/under a Path-tree path

--- a/internal/tools/builtin/document_entity.go
+++ b/internal/tools/builtin/document_entity.go
@@ -259,9 +259,12 @@ func (d *Document) listFacts(ctx context.Context, key sqlmem.ScopeKey, in docInp
 
 	where := []string{}
 	args := []any{}
-	if in.Type != "" {
-		where = append(where, "c.type = ?")
-		args = append(args, in.Type)
+	// RFC BZ subtype expansion: listing facts of type `event` must also list the
+	// `incident` facts, or the taxonomy an operator built changes no answers.
+	typeExpansion := d.expandTypeFilter(ctx, in.Type)
+	if frag, targs := typeFilterSQL("c.type", typeExpansion); frag != "" {
+		where = append(where, frag)
+		args = append(args, targs...)
 	}
 	if in.Class != "" {
 		where = append(where, "m.class = ?")
@@ -331,7 +334,14 @@ func (d *Document) listFacts(ctx context.Context, key sqlmem.ScopeKey, in docInp
 		}
 		facts = append(facts, fact)
 	}
-	return okJSON(map[string]any{"facts": facts, "count": len(facts), "truncated": truncated})
+	out := map[string]any{"facts": facts, "count": len(facts), "truncated": truncated}
+	// REPORTED for the same reason query_chunks reports it: the filter that ran is
+	// wider than the one that was asked for, and a count nobody can account for reads
+	// as a bug rather than as a working taxonomy.
+	if len(typeExpansion) > 1 {
+		out["type_expanded_to"] = typeExpansion
+	}
+	return okJSON(out)
 }
 
 // writeChunkMeta upserts the sidecar row, PRESERVING every field the caller did not

--- a/internal/tools/builtin/document_ontology.go
+++ b/internal/tools/builtin/document_ontology.go
@@ -27,6 +27,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 
 	memrank "github.com/denn-gubsky/loomcycle/internal/memory"
 	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
@@ -58,28 +59,48 @@ func (d *Document) OntologyTermsFromTree(ctx context.Context, scope, path string
 	if err != nil {
 		return nil, err
 	}
-	if err := d.ensureSchema(ctx, key); err != nil {
-		return nil, err
-	}
+	terms, _, err := d.ontologyForKey(ctx, key, mscope, path)
+	return terms, err
+}
+
+// ontologyForKey is the reader proper: terms plus the document's confirmed status.
+//
+// Split out from OntologyTermsFromTree so the retrieval-side expansion can reuse it
+// with a tenant key it built itself. One reader, two callers — the alternative was a
+// second tree walk, and two walks of the same tree eventually disagree about it.
+func (d *Document) ontologyForKey(ctx context.Context, key sqlmem.ScopeKey, mscope store.MemoryScope, path string) ([]memrank.OntologyTerm, bool, error) {
+	// DELIBERATELY NO ensureSchema. Reading must not provision.
+	//
+	// This is called from a query path, so ensuring here would mean an agent running
+	// `query_chunks type=x` CREATES its tenant's SQL-Memory schema — and on the
+	// Postgres tier a per-scope LOGIN role — for a tenant that has no tenant documents
+	// at all. A read that builds infrastructure can also FAIL to build it (the role
+	// needs CREATEROLE), turning a working query into an error over a taxonomy the
+	// tenant never had.
+	//
+	// Callers that legitimately provision (the server's ontology endpoints) do it
+	// themselves before they get here. With no schema the lookup below simply errors
+	// and the caller reads it as "no tenant layer", which is the truth.
 	docID, err := d.docIDFromInput(ctx, key, docInput{Path: path})
 	if err != nil {
-		return nil, nil // no such document — no tenant layer
+		return nil, false, nil // no such document — no tenant layer
 	}
-	var rootID string
+	var rootID, status string
 	if res, qerr := d.query(ctx, key,
-		`SELECT root_chunk_id FROM documents WHERE id = ? LIMIT 1`, docID); qerr != nil {
-		return nil, qerr
-	} else if len(res.Rows) == 0 || len(res.Rows[0]) == 0 {
-		return nil, nil
+		`SELECT root_chunk_id, coalesce(status, '') FROM documents WHERE id = ? LIMIT 1`, docID); qerr != nil {
+		return nil, false, qerr
+	} else if len(res.Rows) == 0 || len(res.Rows[0]) < 2 {
+		return nil, false, nil
 	} else {
-		rootID = asStr(res.Rows[0][0])
+		rootID, status = asStr(res.Rows[0][0]), asStr(res.Rows[0][1])
 	}
+	confirmed := strings.EqualFold(strings.TrimSpace(status), memrank.OntologyConfirmedStatus)
 
 	res, err := d.query(ctx, key,
 		`SELECT id, coalesce(parent_id, ''), coalesce(title, ''), position
 		   FROM chunks WHERE document_id = ? ORDER BY position`, docID)
 	if err != nil {
-		return nil, err
+		return nil, confirmed, err
 	}
 	kids := map[string][]ontologyChunk{}
 	for _, row := range res.Rows {
@@ -132,7 +153,7 @@ func (d *Document) OntologyTermsFromTree(ctx context.Context, scope, path string
 		}
 	}
 	walk(rootID, "", 1)
-	return out, nil
+	return out, confirmed, nil
 }
 
 // ontologyEntityName resolves an entity's name: the chunk's title, or — when the title
@@ -152,4 +173,112 @@ func (d *Document) ontologyEntityName(ctx context.Context, mscope store.MemorySc
 		return ""
 	}
 	return memrank.FirstHeadingName(body.Body)
+}
+
+// expandTypeFilter turns a type filter into the type plus every type that is a
+// SUBCLASS of it in the tenant's confirmed ontology.
+//
+// THIS IS THE POINT OF THE HIERARCHY. Without it a taxonomy is decorative: an
+// operator gains a tidy document and no new answers, because a search for `event`
+// still misses every `incident` they carefully classified. Storage keeps the CONCRETE
+// type only and expansion happens here, at query time — materialising ancestors into
+// each stored row would mean re-parenting a type silently invalidates history, since
+// facts recorded before the move would still claim the old ancestor and need a
+// backfill nobody will run. Expanding at query time makes a correction take effect
+// immediately and retroactively, which is what an operator fixing their taxonomy
+// expects.
+//
+// Returns nil for an empty filter, and a single-element slice when there is nothing to
+// expand — the caller then emits the same `type = ?` SQL it always did.
+//
+// ONLY WHEN CONFIRMED. A draft ontology is inert everywhere else, and retrieval must
+// not be the one surface where an unconfirmed edit quietly changes answers.
+func (d *Document) expandTypeFilter(ctx context.Context, typ string) []string {
+	typ = strings.TrimSpace(typ)
+	if typ == "" || d.Store == nil || d.SqlMem == nil {
+		return nil
+	}
+	terms, confirmed := d.tenantOntologyForRun(ctx)
+	if !confirmed || len(terms) == 0 {
+		return []string{typ}
+	}
+	kids := make(map[string][]string, len(terms))
+	for _, t := range terms {
+		if t.Parent != "" {
+			kids[t.Parent] = append(kids[t.Parent], t.Name)
+		}
+	}
+	out := []string{typ}
+	seen := map[string]bool{typ: true}
+	// Breadth-first with a visited set, bounded by the depth cap. The chunk tree
+	// cannot cycle, but this runs inside a query path and a cycle here would hang the
+	// request rather than return a wrong row.
+	frontier := []string{typ}
+	for depth := 0; depth < memrank.OntologyMaxDepth && len(frontier) > 0; depth++ {
+		var next []string
+		for _, name := range frontier {
+			for _, kid := range kids[name] {
+				if seen[kid] {
+					continue
+				}
+				seen[kid] = true
+				out = append(out, kid)
+				next = append(next, kid)
+			}
+		}
+		frontier = next
+	}
+	sort.Strings(out[1:]) // stable output; the requested type stays first
+	return out
+}
+
+// tenantOntologyForRun reads the run's tenant ontology for retrieval purposes.
+//
+// The tenant key is built HERE rather than through resolveScope, deliberately
+// skipping the `scope=tenant` grant check, and that is not a hole:
+//
+//   - The tenant comes from the run's server-stamped identity. Nothing the model says
+//     reaches it.
+//   - The ontology is operator-authored CONFIG, not tenant data. It already reaches
+//     the agent — the server renders it into the system prompt with grants it stamps
+//     itself, for exactly this reason.
+//   - Nothing from the tenant scope is returned. The only effect is which of the
+//     agent's OWN rows, in the scope it already queried, match its filter.
+//
+// Requiring the grant instead would mean subtype expansion worked only for agents
+// holding tenant-write authority — so the operators most careful about scoping would
+// be the ones whose taxonomy silently did nothing.
+//
+// Not cached: an operator who fixes their taxonomy expects the next query to reflect
+// it, and the read is two point lookups on a filter that is not on any hot path.
+func (d *Document) tenantOntologyForRun(ctx context.Context) ([]memrank.OntologyTerm, bool) {
+	key := sqlmem.ScopeKey{
+		Tenant:  sqlScopeTenant(ctx),
+		Scope:   "tenant",
+		ScopeID: sqlScopeTenant(ctx),
+	}
+	terms, confirmed, err := d.ontologyForKey(ctx, key, store.MemoryScopeTenant, memrank.OntologyPath)
+	if err != nil {
+		// Best-effort, exactly as the prompt-side render is: a store fault must not
+		// turn a retrieval into an error. The unexpanded filter still answers the
+		// question that was asked, just narrowly.
+		return nil, false
+	}
+	return memrank.ResolveInheritance(terms), confirmed
+}
+
+// typeFilterSQL renders an expanded type filter as a WHERE fragment plus its args.
+//
+// Emits `= ?` for a single type so the common, hierarchy-free case produces byte-identical
+// SQL to what it did before subclasses existed — no new query plan for a deployment that
+// never nests anything.
+func typeFilterSQL(column string, types []string) (string, []any) {
+	if len(types) == 0 {
+		return "", nil
+	}
+	if len(types) == 1 {
+		return column + " = ?", []any{types[0]}
+	}
+	ph, args := inPlaceholders(types)
+	return column + " IN (" + ph + ")", args
 }

--- a/internal/tools/builtin/document_ontology_test.go
+++ b/internal/tools/builtin/document_ontology_test.go
@@ -3,8 +3,17 @@ package builtin
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"io/fs"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/channels"
+	memrank "github.com/denn-gubsky/loomcycle/internal/memory"
+	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
 
 // ontologyDocFixture imports a nested ontology document and returns its path.
@@ -202,5 +211,293 @@ func TestOntologyTree_AbsentDocumentIsNotAnError(t *testing.T) {
 	}
 	if len(terms) != 0 {
 		t.Errorf("want no terms, got %v", terms)
+	}
+}
+
+// ontologyRetrievalFixture builds a tenant ontology with `event` → `incident` →
+// `outage`, plus user-scope chunks of each type, and returns the tool + a context
+// holding the tenant grants the SETUP needs.
+//
+// The grants are for the setup only. The expansion path deliberately does not require
+// them, and TestSubtypeExpansion_WorksWithoutTenantGrants covers that.
+func ontologyRetrievalFixture(t *testing.T, confirm bool) (*Document, context.Context) {
+	t.Helper()
+	d, ctx, _ := documentFixture(t)
+	ctx = tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{AllowedScopes: []string{"tenant"}})
+	ctx = tools.WithSqlMemPolicy(ctx, tools.SqlMemPolicyValue{AllowedScopes: []string{"tenant"}})
+
+	md := "# Tenant Ontology\n\n## event\n- `occurred_at`\n\n### incident\n- `severity`\n\n#### outage\n- `minutes_down`\n\n## person\n- `name`\n"
+	mj, _ := json.Marshal(md)
+	out, r := docExec(t, d, ctx, `{"op":"import_md","scope":"tenant","markdown":`+string(mj)+`}`)
+	if r.IsError {
+		t.Fatalf("import_md: %s", r.Text)
+	}
+	docID, _ := out["document_id"].(string)
+	pj, _ := json.Marshal(memrank.OntologyPath)
+	if _, r = docExec(t, d, ctx,
+		`{"op":"set_path","scope":"tenant","id":"`+docID+`","path":`+string(pj)+`}`); r.IsError {
+		t.Fatalf("set_path: %s", r.Text)
+	}
+	status := "draft"
+	if confirm {
+		status = memrank.OntologyConfirmedStatus
+	}
+	root, _ := out["root_chunk_id"].(string)
+	g, _ := docExec(t, d, ctx, `{"op":"get_chunk","scope":"tenant","id":"`+root+`"}`)
+	rev := int(g["revision"].(float64))
+	if _, r = docExec(t, d, ctx, fmt.Sprintf(
+		`{"op":"update_chunk","scope":"tenant","id":"%s","status":"%s","revision":%d}`,
+		root, status, rev)); r.IsError {
+		t.Fatalf("update_chunk status: %s", r.Text)
+	}
+
+	// The DATA lives in the user scope — the point is that a user-scope query is
+	// widened by a tenant-scope taxonomy.
+	dout, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Log","body":""}`)
+	if r.IsError {
+		t.Fatalf("create_document: %s", r.Text)
+	}
+	logID, _ := dout["document_id"].(string)
+	logRoot, _ := dout["root_chunk_id"].(string)
+	for _, c := range []struct{ title, typ string }{
+		{"the outage last friday", "outage"},
+		{"the deploy incident", "incident"},
+		{"the all-hands", "event"},
+		{"ada", "person"},
+	} {
+		if _, r = docExec(t, d, ctx, fmt.Sprintf(
+			`{"op":"create_chunk","scope":"user","document_id":"%s","parent_id":"%s","title":"%s","type":"%s","body":"x"}`,
+			logID, logRoot, c.title, c.typ)); r.IsError {
+			t.Fatalf("create_chunk %s: %s", c.typ, r.Text)
+		}
+	}
+	return d, ctx
+}
+
+func queryChunkTypes(t *testing.T, d *Document, ctx context.Context, typ string) (map[string]bool, []string) {
+	t.Helper()
+	out, r := docExec(t, d, ctx, `{"op":"query_chunks","scope":"user","type":"`+typ+`"}`)
+	if r.IsError {
+		t.Fatalf("query_chunks: %s", r.Text)
+	}
+	got := map[string]bool{}
+	rows, _ := out["chunks"].([]any)
+	for _, row := range rows {
+		m, _ := row.(map[string]any)
+		if s, _ := m["type"].(string); s != "" {
+			got[s] = true
+		}
+	}
+	// Tolerate the key being ABSENT rather than asserting on it: when the expansion
+	// is not working, absent is exactly what it will be, and a panic here would bury
+	// the real failure under a type-assertion trace.
+	var expanded []string
+	if raw, ok := out["type_expanded_to"].([]any); ok {
+		for _, v := range raw {
+			if s, ok := v.(string); ok {
+				expanded = append(expanded, s)
+			}
+		}
+	}
+	return got, expanded
+}
+
+// TestSubtypeExpansion_QueryChunksMatchesSubclasses is the payoff.
+//
+// Without it the hierarchy is decorative — an operator gains a tidy document and no
+// new answers, because a search for `event` still misses every `incident` they
+// classified. FAILS before this change: only the exact type matched.
+func TestSubtypeExpansion_QueryChunksMatchesSubclasses(t *testing.T) {
+	d, ctx := ontologyRetrievalFixture(t, true)
+
+	got, expanded := queryChunkTypes(t, d, ctx, "event")
+	for _, want := range []string{"event", "incident", "outage"} {
+		if !got[want] {
+			t.Errorf("type=event did not match %q — have %v", want, got)
+		}
+	}
+	// TRANSITIVE but not indiscriminate: a sibling root must not be dragged in.
+	if got["person"] {
+		t.Error("type=event matched an unrelated root type")
+	}
+	if len(expanded) != 3 {
+		t.Errorf("type_expanded_to = %v, want the three-type chain", expanded)
+	}
+	if len(expanded) > 0 && expanded[0] != "event" {
+		t.Errorf("the requested type must stay first, got %v", expanded)
+	}
+
+	// Asking for the LEAF stays narrow. Expansion goes down the tree, never up:
+	// `outage` must not start matching every `event`.
+	leaf, _ := docExec(t, d, ctx, `{"op":"query_chunks","scope":"user","type":"outage"}`)
+	rows, _ := leaf["chunks"].([]any)
+	if len(rows) != 1 {
+		t.Errorf("type=outage should match only itself, got %d rows", len(rows))
+	}
+	if _, reported := leaf["type_expanded_to"]; reported {
+		t.Error("a leaf type must not report an expansion")
+	}
+}
+
+// TestSubtypeExpansion_DraftOntologyDoesNotWidenRetrieval.
+//
+// A draft ontology is inert on every other surface by design. Retrieval must not be
+// the one place an unconfirmed edit quietly changes answers — an operator drafting a
+// taxonomy would otherwise see their queries shift before they ever confirmed it.
+func TestSubtypeExpansion_DraftOntologyDoesNotWidenRetrieval(t *testing.T) {
+	d, ctx := ontologyRetrievalFixture(t, false)
+
+	out, r := docExec(t, d, ctx, `{"op":"query_chunks","scope":"user","type":"event"}`)
+	if r.IsError {
+		t.Fatalf("query_chunks: %s", r.Text)
+	}
+	rows, _ := out["chunks"].([]any)
+	if len(rows) != 1 {
+		t.Errorf("a draft ontology widened retrieval: got %d rows, want only the exact type", len(rows))
+	}
+	if _, reported := out["type_expanded_to"]; reported {
+		t.Error("a draft ontology reported an expansion")
+	}
+}
+
+// TestSubtypeExpansion_ListFactsMatchesSubclasses — the second call site, asserted
+// separately because one wired site tells you nothing about the other.
+func TestSubtypeExpansion_ListFactsMatchesSubclasses(t *testing.T) {
+	d, ctx := ontologyRetrievalFixture(t, true)
+	// list_facts reads the entity tier, so the rows need entity metadata — upsert
+	// with a natural_key is what puts them there.
+	fout, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Facts","body":""}`)
+	if r.IsError {
+		t.Fatalf("create_document: %s", r.Text)
+	}
+	fdoc, _ := fout["document_id"].(string)
+	froot, _ := fout["root_chunk_id"].(string)
+	for _, f := range []struct{ key, typ string }{
+		{"incident:deploy", "incident"},
+		{"event:all-hands", "event"},
+		{"person:ada", "person"},
+	} {
+		if _, r := docExec(t, d, ctx, fmt.Sprintf(
+			`{"op":"upsert_chunk","scope":"user","document_id":"%s","parent_id":"%s",`+
+				`"natural_key":"%s","title":"%s","type":"%s","body":"x"}`,
+			fdoc, froot, f.key, f.key, f.typ)); r.IsError {
+			t.Fatalf("upsert_chunk %s: %s", f.key, r.Text)
+		}
+	}
+
+	out, r2 := docExec(t, d, ctx, `{"op":"list_facts","scope":"user","type":"event"}`)
+	if r2.IsError {
+		t.Fatalf("list_facts: %s", r2.Text)
+	}
+	types := map[string]bool{}
+	facts, _ := out["facts"].([]any)
+	for _, f := range facts {
+		m, _ := f.(map[string]any)
+		if s, _ := m["type"].(string); s != "" {
+			types[s] = true
+		}
+	}
+	if !types["event"] || !types["incident"] {
+		t.Errorf("list_facts type=event missed a subclass — have %v", types)
+	}
+	if types["person"] {
+		t.Error("list_facts type=event matched an unrelated root")
+	}
+	if _, reported := out["type_expanded_to"]; !reported {
+		t.Error("list_facts did not report the expansion")
+	}
+}
+
+// TestSubtypeExpansion_WorksWithoutTenantGrants.
+//
+// Expansion reads the tenant ontology through a key it builds itself, skipping the
+// scope=tenant grant check. That is deliberate: requiring the grant would mean subtype
+// expansion worked only for agents holding tenant-WRITE authority, so the operators
+// most careful about scoping would be the ones whose taxonomy silently did nothing.
+//
+// Safe because the tenant comes from the run's server-stamped identity, the ontology is
+// operator config that already reaches the prompt, and nothing tenant-scoped is
+// returned — only which of the agent's own rows match.
+func TestSubtypeExpansion_WorksWithoutTenantGrants(t *testing.T) {
+	d, setupCtx := ontologyRetrievalFixture(t, true)
+
+	// A context with NO tenant grants at all, same identity.
+	bare := tools.WithAgentName(context.Background(), "doc-agent")
+	bare = tools.WithRunIdentity(bare, tools.RunIdentityValue{AgentID: "a", UserID: "u1", TenantID: "tnt"})
+	_ = setupCtx
+
+	// The tenant scope itself must still be refused — the carve-out is for the
+	// internal ontology read, not for the agent.
+	if _, r := docExec(t, d, bare, `{"op":"query_chunks","scope":"tenant"}`); !r.IsError {
+		t.Error("an ungranted agent reached the tenant scope")
+	}
+	got, expanded := queryChunkTypes(t, d, bare, "event")
+	if !got["incident"] || !got["outage"] {
+		t.Errorf("expansion required tenant grants — have %v", got)
+	}
+	if len(expanded) != 3 {
+		t.Errorf("type_expanded_to = %v", expanded)
+	}
+}
+
+// TestSubtypeExpansion_NoOntologyDocumentIsTheCommonCase.
+//
+// Most deployments have no tenant ontology at all. A type-filtered query must behave
+// exactly as it always did: same rows, no error, no expansion reported — and, because
+// the expansion reads the TENANT scope, it must not provision that scope's schema as a
+// side effect of a read. The subdirectory assertion is the part that would otherwise go
+// unnoticed: creating a schema here also creates a per-scope LOGIN role on the Postgres
+// tier, which needs CREATEROLE and can fail.
+func TestSubtypeExpansion_NoOntologyDocumentIsTheCommonCase(t *testing.T) {
+	root := t.TempDir()
+	st, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	mgr, err := sqlmem.New(sqlmem.Config{Root: root})
+	if err != nil {
+		t.Fatalf("sqlmem.New: %v", err)
+	}
+	t.Cleanup(func() { _ = mgr.Close() })
+	d := &Document{Store: st, SqlMem: mgr, Bus: channels.NewBus()}
+	ctx := tools.WithAgentName(context.Background(), "doc-agent")
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a", UserID: "u1", TenantID: "tnt"})
+
+	out, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Log","body":""}`)
+	if r.IsError {
+		t.Fatalf("create_document: %s", r.Text)
+	}
+	docID, _ := out["document_id"].(string)
+	rootChunk, _ := out["root_chunk_id"].(string)
+	if _, r = docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+docID+
+		`","parent_id":"`+rootChunk+`","title":"a note","type":"note","body":"x"}`); r.IsError {
+		t.Fatalf("create_chunk: %s", r.Text)
+	}
+
+	got, r := docExec(t, d, ctx, `{"op":"query_chunks","scope":"user","type":"note"}`)
+	if r.IsError {
+		t.Fatalf("a type filter must still work with no ontology: %s", r.Text)
+	}
+	rows, _ := got["chunks"].([]any)
+	if len(rows) != 1 {
+		t.Errorf("want the one matching chunk, got %d", len(rows))
+	}
+	if _, reported := got["type_expanded_to"]; reported {
+		t.Error("an expansion was reported with no ontology present")
+	}
+	// The read must not have PROVISIONED the tenant scope. sqlite lays scopes out as
+	// <root>/<tenant>/<scope>/<id>.db, so a `tenant` directory appearing here is a
+	// read that built a store — the sqlite-tier symptom of the Postgres-tier failure
+	// (a per-scope LOGIN role, which needs CREATEROLE and can be refused).
+	var provisioned []string
+	_ = filepath.WalkDir(root, func(path string, e fs.DirEntry, err error) error {
+		if err == nil && e.IsDir() && e.Name() == "tenant" {
+			provisioned = append(provisioned, path)
+		}
+		return nil
+	})
+	if len(provisioned) > 0 {
+		t.Errorf("the ontology read provisioned the tenant scope: %v", provisioned)
 	}
 }


### PR DESCRIPTION
## Why

This is the payoff phase. P1 read the hierarchy, P2 taught the model to use it — and retrieval still ignored it. A search for `event` missed every `incident` an operator had carefully classified, so the taxonomy was a tidy document that changed no answers. RFC BZ §4b: *"Without this the hierarchy is decorative."*

## What

`list_facts` and `query_chunks` expand a type filter to the type plus its subclasses — transitively, and **downward only**: `event` finds `incident` and `outage`; `outage` still finds only outages.

- **Query-time, not stored.** Storage keeps the concrete type only. Materialising ancestors into each row means re-parenting a type silently invalidates history — facts written before the move still claim the old ancestor and need a backfill nobody runs. Query-time expansion makes a correction retroactive, which is what an operator fixing their taxonomy expects.
- **Only when confirmed.** A draft ontology is inert on every other surface. Retrieval must not be the one place an unconfirmed edit quietly changes answers while someone is still drafting.
- **Reported, not silent.** The response carries `type_expanded_to` when the filter widened. The filter that ran is not the filter that was asked for, and a wider answer with no explanation reads as a bug.
- Single-type filters emit the same `type = ?` SQL as before — no new query plan for deployments that never nest.

### Scope corrections to the RFC

`graph_recall` is **not** included, contrary to §4b's list: its seeds are selected by title text or explicit ids, and it has no type filter to expand. `query_documents`' `type` is a different vocabulary (`rfc`/`research`/`publication`), so it stays out too. I audited every `type = ?` in the tool rather than trusting the RFC's enumeration; the rest are writes.

## Two judgement calls worth your review

**The tenant ontology is read through a key built in the tool, skipping the `scope=tenant` grant check.** The tenant comes from the run's server-stamped identity, the ontology is operator config that already reaches the agent's prompt (the server stamps its own grants to render it), and nothing tenant-scoped is returned — only which of the agent's *own* rows match its *own* filter. Requiring the grant would mean expansion worked only for agents holding tenant-**write** authority, so the operators most careful about scoping would be the ones whose taxonomy silently did nothing. The tenant *scope* itself stays refused, and `TestSubtypeExpansion_WorksWithoutTenantGrants` asserts both halves.

**The read deliberately does not `ensureSchema`.** I added that first and then caught what it meant: ensuring on a query path makes `query_chunks type=x` create its tenant's SQL-Memory schema — and a per-scope LOGIN role on the Postgres tier — for a tenant with no tenant documents at all, turning a working query into a `CREATEROLE` failure over a taxonomy that was never there. A read must not provision.

## Tested

`go test ./...` clean.

- `TestSubtypeExpansion_{QueryChunksMatchesSubclasses,ListFactsMatchesSubclasses,WorksWithoutTenantGrants}` — **fail-before verified**, and the message is the symptom itself: `type=event did not match "incident" — have map[event:true]`. Both call sites asserted separately, because one wired site tells you nothing about the other.
- `TestSubtypeExpansion_NoOntologyDocumentIsTheCommonCase` — same rows, no error, no expansion, **and no tenant scope provisioned**. That last assertion is **fail-before verified** too: restoring `ensureSchema` makes it report the created `tnt/tenant` directory.
- `TestSubtypeExpansion_DraftOntologyDoesNotWidenRetrieval` — the fail-safe.

Sibling roots are asserted *not* to be dragged in, and a leaf type is asserted not to report an expansion.

## Still open from RFC BZ

- **P4** — the panel's full tree view (P1/P2 already indent and name parents; the remaining work is the interactive tree).
- **§8 eval re-baseline** — still not run, for the reason given in #978: hierarchy fixtures shift `ExtractionCorpus.Digest()` and invalidate 3 of 4 stored entries. Now that expansion exists, this is the phase where re-measuring is actually meaningful, and it costs no API spend (all entries are `ollama-local`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8