### PR TITLE
feat(ontology): the panel renders the taxonomy as a tree, and the depth cap announces itself (RFC BZ P4)

### DIFF
--- a/internal/api/http/ontology.go
+++ b/internal/api/http/ontology.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"encoding/json"
 	"log"
+	"strconv"
 	"strings"
 
 	meminject "github.com/denn-gubsky/loomcycle/internal/memory"
@@ -52,9 +53,9 @@ func (s *Server) renderOntology(ctx context.Context, mi memInject) string {
 // document's terms are still returned so a caller can show them, but
 // EffectiveOntology discards them. Keeping the discard in one place means no caller
 // can accidentally honour a draft.
-func (s *Server) tenantOntologyTerms(ctx context.Context, mi memInject) (terms []meminject.OntologyTerm, confirmed bool, note string) {
+func (s *Server) tenantOntologyTerms(ctx context.Context, mi memInject) (terms []meminject.OntologyTerm, confirmed bool, notes []string) {
 	if s.store == nil || s.sqlMem == nil {
-		return nil, false, ""
+		return nil, false, nil
 	}
 	s.ensureOntologyDoc(ctx, mi)
 
@@ -75,13 +76,13 @@ func (s *Server) tenantOntologyTerms(ctx context.Context, mi memInject) (terms [
 	})
 	res, _ := doc.Execute(dctx, req)
 	if res.IsError {
-		return nil, false, ""
+		return nil, false, nil
 	}
 	var meta struct {
 		Status string `json:"status"`
 	}
 	if err := json.Unmarshal([]byte(res.Text), &meta); err != nil {
-		return nil, false, ""
+		return nil, false, nil
 	}
 	confirmed = strings.EqualFold(strings.TrimSpace(meta.Status), meminject.OntologyConfirmedStatus)
 
@@ -93,8 +94,15 @@ func (s *Server) tenantOntologyTerms(ctx context.Context, mi memInject) (terms [
 	// It also ends a silent data loss: the markdown parser matched only "## ", so
 	// every nested type an operator wrote was dropped without a word.
 	tree, terr := doc.OntologyTermsFromTree(dctx, "tenant", meminject.OntologyPath)
-	if terr == nil && len(tree) > 0 {
-		return tree, confirmed, ""
+	if terr == nil && len(tree.Terms) > 0 {
+		if tree.DepthCapped {
+			notes = append(notes, "This document nests deeper than "+
+				strconv.Itoa(meminject.OntologyMaxDepth)+" levels. The types below that "+
+				"depth are still in force, but they were flattened onto level "+
+				strconv.Itoa(meminject.OntologyMaxDepth)+" — the tree shown here is what "+
+				"agents are told, not the shape of the document.")
+		}
+		return tree.Terms, confirmed, notes
 	}
 
 	// FALLBACK, deliberately narrow: only when the tree yielded NOTHING.
@@ -112,17 +120,17 @@ func (s *Server) tenantOntologyTerms(ctx context.Context, mi memInject) (terms [
 	})
 	eres, _ := doc.Execute(dctx, exp)
 	if eres.IsError {
-		return nil, confirmed, ""
+		return nil, confirmed, nil
 	}
 	var body struct {
 		Markdown string `json:"markdown"`
 	}
 	if err := json.Unmarshal([]byte(eres.Text), &body); err != nil {
-		return nil, confirmed, ""
+		return nil, confirmed, nil
 	}
 	flat := meminject.ParseOntologyMarkdown(body.Markdown)
 	if len(flat) == 0 {
-		return nil, confirmed, ""
+		return nil, confirmed, nil
 	}
 	// The note must state the cause it actually established. A tree read that FAILED
 	// and one that legitimately found no chunks lead here identically, and telling an
@@ -134,13 +142,13 @@ func (s *Server) tenantOntologyTerms(ctx context.Context, mi memInject) (terms [
 		// operator needs to know their subclasses are not in force, not where the
 		// database lives.
 		log.Printf("ontology: chunk-tree read failed for tenant %q, falling back to flat markdown: %v", mi.Tenant, terr)
-		return flat, confirmed, "The document's chunk structure could not be read, so " +
+		return flat, confirmed, []string{"The document's chunk structure could not be read, so " +
 			"it was read as flat Markdown — subclasses are not in force until this " +
-			"resolves. See the server log for the cause."
+			"resolves. See the server log for the cause."}
 	}
-	return flat, confirmed, "This ontology was read as flat Markdown because the " +
+	return flat, confirmed, []string{"This ontology was read as flat Markdown because the " +
 		"document has no per-entity chunks. Split each entity into its own chunk to " +
-		"use subclasses — a child chunk is a subclass of its parent."
+		"use subclasses — a child chunk is a subclass of its parent."}
 }
 
 // ensureOntologyDoc provisions the tenant's ontology document from the embedded

--- a/internal/api/http/ontology_admin.go
+++ b/internal/api/http/ontology_admin.go
@@ -63,11 +63,15 @@ type ontologyResponse struct {
 	// applied only if Confirmed. Each term carries its own source, so the UI can
 	// mark which half it came from without diffing against the seed.
 	Effective []meminject.OntologyTerm `json:"effective"`
-	// Note carries a reader-level caveat the operator has to know to act on — today
-	// only "this document had no per-entity chunks, so it was read flat and cannot
-	// express subclasses". Surfaced rather than logged because the consequence lands
-	// on the operator's data, not on the server.
-	Note string `json:"note,omitempty"`
+	// Notes carries reader-level caveats the operator has to act on: the document had
+	// no per-entity chunks and was read flat, or it nests deeper than the cap and was
+	// flattened. A LIST because those conditions are independent and more than one can
+	// hold at once — folded into one string, the panel could not render them
+	// separately and each new case would make it worse.
+	//
+	// Surfaced rather than logged because the consequence lands on the operator's
+	// data, not on the server.
+	Notes []string `json:"notes,omitempty"`
 }
 
 // handleOntology serves GET /v1/_ontology — the tenant ontology's state.
@@ -182,7 +186,7 @@ func (s *Server) ontologyState(ctx context.Context, tenant string) (ontologyResp
 	}
 
 	mi := memInject{Tenant: tenant}
-	terms, confirmed, note := s.tenantOntologyTerms(ctx, mi)
+	terms, confirmed, notes := s.tenantOntologyTerms(ctx, mi)
 
 	doc := &builtin.Document{Store: s.store, SqlMem: s.sqlMem}
 	dctx := s.ontologyDocCtx(ctx, mi)
@@ -202,7 +206,7 @@ func (s *Server) ontologyState(ctx context.Context, tenant string) (ontologyResp
 		resp.Terms = meminject.ResolveInheritance(terms)
 	}
 	resp.Confirmed = confirmed
-	resp.Note = note
+	resp.Notes = notes
 	resp.Effective = meminject.EffectiveOntology(terms, confirmed)
 	return resp, nil
 }

--- a/internal/api/http/ontology_test.go
+++ b/internal/api/http/ontology_test.go
@@ -210,7 +210,7 @@ func TestOntology_NestedChunkReachesTheEffectiveOntology(t *testing.T) {
 		t.Fatalf("create_chunk: %v %s", cerr, cres.Text)
 	}
 
-	terms, _, note := s.tenantOntologyTerms(context.Background(), mi)
+	terms, _, notes := s.tenantOntologyTerms(context.Background(), mi)
 	var found *meminject.OntologyTerm
 	for i := range terms {
 		if terms[i].Name == "internal-project" {
@@ -233,8 +233,8 @@ func TestOntology_NestedChunkReachesTheEffectiveOntology(t *testing.T) {
 	// The tree read succeeded, so the flat-Markdown fallback must NOT have reported
 	// itself — a note here would mean the tree path silently lost and the caveat is
 	// the only thing telling anyone.
-	if note != "" {
-		t.Errorf("unexpected fallback note: %q", note)
+	if len(notes) != 0 {
+		t.Errorf("unexpected notes: %v", notes)
 	}
 }
 

--- a/internal/tools/builtin/document_ontology.go
+++ b/internal/tools/builtin/document_ontology.go
@@ -51,16 +51,32 @@ type ontologyChunk struct {
 // DEPTH-FIRST IN POSITION ORDER, so the returned slice reads like the document: a
 // parent immediately followed by its subclasses. EffectiveOntology sorts by name for
 // rendering, but a caller showing the tree (the Settings panel) wants document order.
-func (d *Document) OntologyTermsFromTree(ctx context.Context, scope, path string) ([]memrank.OntologyTerm, error) {
+func (d *Document) OntologyTermsFromTree(ctx context.Context, scope, path string) (OntologyRead, error) {
 	if d.Store == nil || d.SqlMem == nil {
-		return nil, fmt.Errorf("ontology: requires SQL Memory (set LOOMCYCLE_SQLMEM_ENABLED=1)")
+		return OntologyRead{}, fmt.Errorf("ontology: requires SQL Memory (set LOOMCYCLE_SQLMEM_ENABLED=1)")
 	}
 	key, mscope, err := d.resolveScope(ctx, scope)
 	if err != nil {
-		return nil, err
+		return OntologyRead{}, err
 	}
-	terms, _, err := d.ontologyForKey(ctx, key, mscope, path)
-	return terms, err
+	return d.ontologyForKey(ctx, key, mscope, path)
+}
+
+// OntologyRead is one read of the ontology document.
+//
+// A struct rather than a growing return list: the read already reports terms and the
+// confirm gate, and DepthCapped is the third thing a caller has to know. Each addition
+// as a positional return is one more call site that can silently pass the wrong slot.
+type OntologyRead struct {
+	Terms     []memrank.OntologyTerm
+	Confirmed bool
+	// DepthCapped is true when the document nests deeper than OntologyMaxDepth, so
+	// some types were flattened onto the cap rather than kept at their written depth.
+	//
+	// REPORTED because the flattening was otherwise invisible: an operator whose
+	// level-5 type quietly became a level-4 sibling had no way to know their document
+	// and their ontology disagreed — the exact failure this file was written to end.
+	DepthCapped bool
 }
 
 // ontologyForKey is the reader proper: terms plus the document's confirmed status.
@@ -68,7 +84,7 @@ func (d *Document) OntologyTermsFromTree(ctx context.Context, scope, path string
 // Split out from OntologyTermsFromTree so the retrieval-side expansion can reuse it
 // with a tenant key it built itself. One reader, two callers — the alternative was a
 // second tree walk, and two walks of the same tree eventually disagree about it.
-func (d *Document) ontologyForKey(ctx context.Context, key sqlmem.ScopeKey, mscope store.MemoryScope, path string) ([]memrank.OntologyTerm, bool, error) {
+func (d *Document) ontologyForKey(ctx context.Context, key sqlmem.ScopeKey, mscope store.MemoryScope, path string) (OntologyRead, error) {
 	// DELIBERATELY NO ensureSchema. Reading must not provision.
 	//
 	// This is called from a query path, so ensuring here would mean an agent running
@@ -83,14 +99,14 @@ func (d *Document) ontologyForKey(ctx context.Context, key sqlmem.ScopeKey, msco
 	// and the caller reads it as "no tenant layer", which is the truth.
 	docID, err := d.docIDFromInput(ctx, key, docInput{Path: path})
 	if err != nil {
-		return nil, false, nil // no such document — no tenant layer
+		return OntologyRead{}, nil // no such document — no tenant layer
 	}
 	var rootID, status string
 	if res, qerr := d.query(ctx, key,
 		`SELECT root_chunk_id, coalesce(status, '') FROM documents WHERE id = ? LIMIT 1`, docID); qerr != nil {
-		return nil, false, qerr
+		return OntologyRead{}, qerr
 	} else if len(res.Rows) == 0 || len(res.Rows[0]) < 2 {
-		return nil, false, nil
+		return OntologyRead{}, nil
 	} else {
 		rootID, status = asStr(res.Rows[0][0]), asStr(res.Rows[0][1])
 	}
@@ -100,7 +116,7 @@ func (d *Document) ontologyForKey(ctx context.Context, key sqlmem.ScopeKey, msco
 		`SELECT id, coalesce(parent_id, ''), coalesce(title, ''), position
 		   FROM chunks WHERE document_id = ? ORDER BY position`, docID)
 	if err != nil {
-		return nil, confirmed, err
+		return OntologyRead{Confirmed: confirmed}, err
 	}
 	kids := map[string][]ontologyChunk{}
 	for _, row := range res.Rows {
@@ -120,6 +136,7 @@ func (d *Document) ontologyForKey(ctx context.Context, key sqlmem.ScopeKey, msco
 	}
 
 	var out []memrank.OntologyTerm
+	depthCapped := false
 	// The walk starts at the ROOT CHUNK'S CHILDREN: the root is the document's title
 	// ("Tenant Ontology"), not an entity. Including it would invent a type nobody
 	// declared and make every real entity its subclass.
@@ -148,12 +165,15 @@ func (d *Document) ontologyForKey(ctx context.Context, key sqlmem.ScopeKey, msco
 			childParent := name
 			if depth >= memrank.OntologyMaxDepth {
 				childParent = parentName
+				if len(kids[c.id]) > 0 {
+					depthCapped = true
+				}
 			}
 			walk(c.id, childParent, depth+1)
 		}
 	}
 	walk(rootID, "", 1)
-	return out, confirmed, nil
+	return OntologyRead{Terms: out, Confirmed: confirmed, DepthCapped: depthCapped}, nil
 }
 
 // ontologyEntityName resolves an entity's name: the chunk's title, or — when the title
@@ -257,14 +277,14 @@ func (d *Document) tenantOntologyForRun(ctx context.Context) ([]memrank.Ontology
 		Scope:   "tenant",
 		ScopeID: sqlScopeTenant(ctx),
 	}
-	terms, confirmed, err := d.ontologyForKey(ctx, key, store.MemoryScopeTenant, memrank.OntologyPath)
+	read, err := d.ontologyForKey(ctx, key, store.MemoryScopeTenant, memrank.OntologyPath)
 	if err != nil {
 		// Best-effort, exactly as the prompt-side render is: a store fault must not
 		// turn a retrieval into an error. The unexpanded filter still answers the
 		// question that was asked, just narrowly.
 		return nil, false
 	}
-	return memrank.ResolveInheritance(terms), confirmed
+	return memrank.ResolveInheritance(read.Terms), read.Confirmed
 }
 
 // typeFilterSQL renders an expanded type filter as a WHERE fragment plus its args.

--- a/internal/tools/builtin/document_ontology_test.go
+++ b/internal/tools/builtin/document_ontology_test.go
@@ -65,8 +65,8 @@ func readTerms(t *testing.T, d *Document, ctx context.Context, path string) []on
 	if err != nil {
 		t.Fatalf("OntologyTermsFromTree: %v", err)
 	}
-	out := make([]ontologyTermForTest, 0, len(got))
-	for _, g := range got {
+	out := make([]ontologyTermForTest, 0, len(got.Terms))
+	for _, g := range got.Terms {
 		out = append(out, ontologyTermForTest{Name: g.Name, Parent: g.Parent, Fields: g.Fields})
 	}
 	return out
@@ -205,12 +205,12 @@ func TestOntologyTree_DepthBeyondTheCapIsFlattenedNotDropped(t *testing.T) {
 // mentions the ontology.
 func TestOntologyTree_AbsentDocumentIsNotAnError(t *testing.T) {
 	d, ctx, _ := documentFixture(t)
-	terms, err := d.OntologyTermsFromTree(ctx, "user", "/test/nope")
+	read, err := d.OntologyTermsFromTree(ctx, "user", "/test/nope")
 	if err != nil {
 		t.Fatalf("absent document should read as empty, got %v", err)
 	}
-	if len(terms) != 0 {
-		t.Errorf("want no terms, got %v", terms)
+	if len(read.Terms) != 0 {
+		t.Errorf("want no terms, got %v", read.Terms)
 	}
 }
 
@@ -499,5 +499,35 @@ func TestSubtypeExpansion_NoOntologyDocumentIsTheCommonCase(t *testing.T) {
 	})
 	if len(provisioned) > 0 {
 		t.Errorf("the ontology read provisioned the tenant scope: %v", provisioned)
+	}
+}
+
+// TestOntologyTree_ReportsThatItFlattenedTheDepth.
+//
+// The flattening itself was already correct — nothing is dropped — but it was SILENT,
+// so an operator whose level-5 type quietly became a level-4 sibling had no way to know
+// their document and their ontology disagreed. That is the same class of failure this
+// reader was written to end, so the cap has to announce itself.
+func TestOntologyTree_ReportsThatItFlattenedTheDepth(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+
+	shallow := ontologyDocFixture(t, d, ctx, "# Tenant Ontology\n\n## a\n\n### b\n\n#### c\n\n##### d\n")
+	if read, err := d.OntologyTermsFromTree(ctx, "user", shallow); err != nil {
+		t.Fatalf("read: %v", err)
+	} else if read.DepthCapped {
+		t.Errorf("a document AT the cap must not report flattening (%d terms)", len(read.Terms))
+	}
+
+	deep := ontologyDocFixture(t, d, ctx, "# Tenant Ontology\n\n## a\n\n### b\n\n#### c\n\n##### d\n\n###### e\n")
+	read, err := d.OntologyTermsFromTree(ctx, "user", deep)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !read.DepthCapped {
+		t.Error("a document nesting past the cap must report that it was flattened")
+	}
+	// And still nothing lost.
+	if len(read.Terms) != 5 {
+		t.Errorf("want all five types, got %d", len(read.Terms))
 	}
 }

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -2732,10 +2732,11 @@ export interface OntologyResponse {
   /** What a run gets right now: the seed, plus the tenant layer if confirmed. */
   effective: OntologyTerm[];
   /**
-   * A reader-level caveat the operator has to act on — today only "this document
-   * has no per-entity chunks, so it was read flat and cannot express subclasses".
+   * Reader-level caveats the operator has to act on: the document had no per-entity
+   * chunks and was read flat, or it nests deeper than the cap and was flattened. A
+   * list because those are independent and more than one can hold at once.
    */
-  note?: string;
+  notes?: string[];
 }
 
 export function getOntology(tenant?: string): Promise<OntologyResponse> {

--- a/web/src/pages/SettingsView.tsx
+++ b/web/src/pages/SettingsView.tsx
@@ -21,6 +21,7 @@ import {
   resumeRuntime,
   setOntologyStatus,
   showPreset,
+  OntologyTerm,
 } from "../api";
 import { usePrincipal } from "../components/Layout";
 import LimitsView from "./LimitsView";
@@ -444,6 +445,96 @@ function PresetsSection() {
 // collision-aware UPDATE against a live database.
 // ─── Ontology ────────────────────────────────────────────────────────────────
 
+// ─── Ontology tree rendering (RFC BZ P4) ─────────────────────────────────────
+
+// OntologyNode is a term with its subclasses attached.
+type OntologyNode = OntologyTerm & { children: OntologyNode[] };
+
+// buildOntologyTree assembles the parent/child tree the panel renders.
+//
+// An ORPHAN — a term whose named parent is absent — is rendered at the root rather
+// than dropped, matching what the prompt renderer does with the same input. A type
+// missing from this panel is a type the operator cannot see is in force, which is the
+// silent-loss failure the whole feature exists to end.
+function buildOntologyTree(terms: OntologyTerm[]): OntologyNode[] {
+  const byName = new Map<string, OntologyNode>();
+  terms.forEach((t) => byName.set(t.name, { ...t, children: [] }));
+  const roots: OntologyNode[] = [];
+  byName.forEach((n) => {
+    const parent = n.parent ? byName.get(n.parent) : undefined;
+    if (parent && parent !== n) parent.children.push(n);
+    else roots.push(n);
+  });
+  return roots;
+}
+
+// ontologyFieldSummary describes a type's fields the way an operator needs to judge it:
+// how many there are in total, which the type declared, and which it inherited.
+function OntologyFieldSummary({ term, isLeaf }: { term: OntologyNode; isLeaf: boolean }) {
+  const declared = term.fields ?? [];
+  const inherited = term.inherited ?? [];
+  const total = declared.length + inherited.length;
+  // THE PHANTOM TEST IS ON DECLARED FIELDS, NOT ON THE TOTAL, and getting this wrong
+  // would have missed the exact case worth warning about. The scenario is an operator
+  // adding a section chunk for readability — "Notes on naming" under `project` — which
+  // silently becomes a subclass. It INHERITS its parent's fields, so a total-based test
+  // sees a well-formed type and says nothing. A leaf that declares nothing of its own
+  // is a folder, not a class.
+  //
+  // A node with CHILDREN that declares nothing is different and fine: that is a
+  // deliberate abstract grouping type (`work item` over `project` and `task`).
+  const phantom = declared.length === 0 && isLeaf;
+  return (
+    <span className="settings-muted">
+      {" "}
+      {total === 0 ? "no fields" : `${total} field${total === 1 ? "" : "s"}`}
+      {declared.length > 0 && <> — {declared.join(", ")}</>}
+      {inherited.length > 0 && (
+        <span className="ontology-inherited">
+          {" "}
+          · inherited: {inherited.join(", ")}
+        </span>
+      )}
+      {phantom && (
+        <span className="ontology-warn">
+          {" "}
+          · declares no fields of its own — a section heading rather than a type?
+        </span>
+      )}
+    </span>
+  );
+}
+
+// OntologyTermTree renders the nodes, recursing into subclasses.
+//
+// Depth-bounded even though the chunk tree cannot cycle: a malformed term list must not
+// be able to hang the operator's browser on the one page they would use to fix it.
+function OntologyTermTree({
+  nodes,
+  depth = 0,
+  markSource = false,
+}: {
+  nodes: OntologyNode[];
+  depth?: number;
+  markSource?: boolean;
+}) {
+  if (nodes.length === 0 || depth > 8) return null;
+  return (
+    <ul className="ontology-tree">
+      {nodes.map((n) => (
+        <li key={n.name}>
+          <code>{n.name}</code>
+          {markSource && n.source === "tenant" && (
+            <span className="settings-flash"> yours</span>
+          )}
+          <OntologyFieldSummary term={n} isLeaf={n.children.length === 0} />
+          <OntologyTermTree nodes={n.children} depth={depth + 1} markSource={markSource} />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
 // OntologySection is the operator control for the tenant's entity types.
 //
 // The failure this exists to prevent is not an error message: it is an operator
@@ -541,6 +632,15 @@ function OntologySection() {
           them is documentation and is ignored. Reuse a standard type's name to
           override its fields.
         </p>
+        <p>
+          <strong>Nest a heading to make a subclass.</strong> A{" "}
+          <code>### incident</code> under <code>## event</code> is a kind of event:
+          it inherits every field above it and adds its own, and a search for the
+          general type also finds the specific ones. Nest up to four levels. To
+          subclass a <em>standard</em> type, give it a <code>##</code> heading of
+          its own first — that overrides the standard one — then nest beneath your
+          copy.
+        </p>
       </details>
 
       {err && <div className="settings-error">{err}</div>}
@@ -575,7 +675,11 @@ function OntologySection() {
             )}
           </div>
 
-          {state.note && <p className="settings-help">{state.note}</p>}
+          {(state.notes ?? []).map((n) => (
+            <p className="settings-help" key={n}>
+              {n}
+            </p>
+          ))}
 
           {oddStatus && (
             <p className="settings-help">
@@ -598,7 +702,7 @@ function OntologySection() {
           )}
 
           <div className="settings-row">
-            <table className="settings-table">
+            <table className="settings-table ontology-compare">
               <thead>
                 <tr>
                   <th>this deployment defines</th>
@@ -611,48 +715,14 @@ function OntologySection() {
                     {tenantTerms.length === 0 ? (
                       <span className="settings-muted">none yet</span>
                     ) : (
-                      tenantTerms.map((t) => (
-                        <div key={t.name} style={t.parent ? { paddingLeft: "1em" } : undefined}>
-                          {t.parent && <span className="settings-muted">↳ </span>}
-                          <code>{t.name}</code>
-                          {t.parent && (
-                            <span className="settings-muted">
-                              {" "}
-                              subclass of <code>{t.parent}</code>
-                            </span>
-                          )}
-                          {t.fields && t.fields.length > 0 && (
-                            <span className="settings-muted">
-                              {" "}
-                              — {t.fields.join(", ")}
-                            </span>
-                          )}
-                          {t.inherited && t.inherited.length > 0 && (
-                            <span className="settings-muted">
-                              {" "}
-                              (inherits {t.inherited.join(", ")})
-                            </span>
-                          )}
-                        </div>
-                      ))
+                      <OntologyTermTree nodes={buildOntologyTree(tenantTerms)} />
                     )}
                   </td>
                   <td>
-                    {(state.effective ?? []).map((t) => (
-                      <div key={t.name} style={t.parent ? { paddingLeft: "1em" } : undefined}>
-                        {t.parent && <span className="settings-muted">↳ </span>}
-                        <code>{t.name}</code>
-                        {t.source === "tenant" && (
-                          <span className="settings-flash"> yours</span>
-                        )}
-                        {((t.inherited?.length ?? 0) + (t.fields?.length ?? 0) > 0) && (
-                          <span className="settings-muted">
-                            {" "}
-                            — {[...(t.inherited ?? []), ...(t.fields ?? [])].join(", ")}
-                          </span>
-                        )}
-                      </div>
-                    ))}
+                    <OntologyTermTree
+                      nodes={buildOntologyTree(state.effective ?? [])}
+                      markSource
+                    />
                   </td>
                 </tr>
               </tbody>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5736,6 +5736,46 @@ button.primary:disabled {
   border-bottom: 1px solid var(--lc-rule);
   vertical-align: middle;
 }
+/* The ontology tree (RFC BZ P4). A taxonomy read as a flat list with one level of
+   indent is a taxonomy nobody can check — the operator has to see which type is a
+   kind of which, because that is now what steers extraction AND what widens a
+   retrieval filter. Real nesting, with a guide rule so depth is legible at a glance. */
+/* The ontology comparison table puts two trees of different heights side by side, and
+   the shared .settings-table rule centres cells vertically — which floats the shorter
+   column into the middle of the taller one and reads as a rendering fault. Top-align
+   this table only, so the two trees start on the same line and the gap between them
+   stays legible as "these types are not in force". */
+.ontology-compare td {
+  vertical-align: top;
+}
+.ontology-tree {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.ontology-tree .ontology-tree {
+  margin-left: var(--lc-space-1);
+  padding-left: var(--lc-space-2);
+  border-left: 1px solid var(--lc-rule);
+}
+.ontology-tree li {
+  padding: 1px 0;
+  line-height: 1.5;
+}
+/* Inherited fields, dimmer than declared ones: the operator asked "what did I write
+   here", and the answer is the part that is NOT this colour. */
+.ontology-inherited {
+  color: var(--lc-text-faint);
+  font-style: italic;
+}
+/* A fieldless LEAF — nothing can be recorded as it, so it is almost always an
+   accidental section chunk quietly steering extraction. Amber rather than red: the
+   operator may have meant it, and the design system's warning colour is --lc-running,
+   which is defined in both themes. */
+.ontology-warn {
+  color: var(--lc-running);
+}
+
 .settings-row-actions {
   display: flex;
   gap: var(--lc-space-1);


### PR DESCRIPTION
## Why

A taxonomy shown as a flat list with one level of indent is a taxonomy nobody can check. After P2 and P3 the hierarchy decides what extraction is told *and* which rows a type filter returns, so the operator has to be able to see which type is a kind of which.

And one thing was still silent: the depth cap. Nothing is dropped — a type nesting past level 4 is flattened onto the cap — but an operator whose level-5 type quietly became a level-4 sibling had no way to know their document and their ontology disagreed. That is the same class of failure this whole RFC exists to end.

## What

- **Both columns become real trees** with guide rules. Each node shows its field count, declared fields plainly, inherited ones dimmed and italic — the question at a subclass is "what did I actually write here", and the answer is the part that isn't italic.
- **The depth cap reports itself**, surfaced as a note above the table.
- The format explainer now teaches nesting, inheritance, and override-then-nest. The panel is where an operator looks first, and the premise of this RFC is that they tried a hierarchy and got silence.
- Rendering is depth-bounded: a malformed term list must not hang the operator's browser on the one page they'd use to fix it. Orphans render at the root, matching the prompt renderer given the same input.

**Two columns are kept, against §7's wording.** The gap between "this deployment defines" and "in force now" is the only visible evidence that a draft is inert, which is what this panel was built for — collapsing to a single tree would trade a real signal for a tidier layout. Each column became a tree instead.

Two shape changes fall out of the note: the reader returns an `OntologyRead` struct rather than a third positional value (each addition as a positional return is one more call site that can pass the wrong slot), and the API's `note` becomes `notes` — the flat-Markdown fallback and the depth cap are independent and can both hold at once.

## Verified by rendering it

I built the binary, booted it locally with SQL Memory, seeded a 5-level ontology over `/v1/_mcp`, and looked at the panel. That caught two things no build check would have.

**The phantom-type warning was testing the wrong predicate.** §5 wants a fieldless leaf flagged because it's almost always a section chunk that silently became a subclass — and the canonical example, `Notes on naming` under `project`, **inherits** its parent's four fields. My `declared + inherited === 0` test saw a well-formed type and said nothing, missing the only case worth warning about. Now tested on **declared** fields: a leaf that declares nothing of its own is a folder, not a class; a node *with children* that declares nothing is a legitimate abstract grouping type and stays unflagged.

**The shared `.settings-table` rule centres cells vertically**, floating the shorter column into the middle of the taller one — it read as a rendering fault. Top-aligned for this table only.

(A third thing the render caught, about my own process rather than the code: `kill %1` doesn't work across separate shell invocations, so I spent a screenshot looking at a stale server serving the pre-fix bundle.)

## Tested

`go test ./...` clean, `npx tsc --noEmit` clean, `make build-ui` builds.

- `TestOntologyTree_ReportsThatItFlattenedTheDepth` asserts **both** directions — a document exactly at the cap must not report flattening — so a hardcoded answer fails one half or the other.
- Manually: the note renders; the two level-5 types come back as siblings under `data-breach`, which is the flattening the note describes; the amber warning fires on `Notes on naming`; inherited chains accumulate correctly (`pii-breach` shows 7 fields, one declared).

Screenshot of the rendered panel is in the conversation.

## RFC BZ after this

All four phases are in. Still open: **§8's eval re-baseline** (deferred through P2 and P3 for the same reason — hierarchy fixtures shift `ExtractionCorpus.Digest()` and invalidate 3 of 4 stored entries; zero API cost since all are `ollama-local`), and the two questions the RFC left open — §10.2 name validation strictness (`Notes on naming` is a legal type name today, which this PR now at least makes *visible*) and §10.3 whether `preference`/`fact` are pinned as roots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8