### PR TITLE
feat(ontology): close out RFC BZ — measure hierarchy use, pin the tier types, advise on names

### DIFF
--- a/internal/api/http/ontology_admin.go
+++ b/internal/api/http/ontology_admin.go
@@ -203,7 +203,21 @@ func (s *Server) ontologyState(ctx context.Context, tenant string) (ontologyResp
 		// effective one. Without this the panel's "this deployment defines" column
 		// shows a subclass with no sign of what it inherits, which is exactly the
 		// question an operator has when looking at a subclass that declares one field.
-		resp.Terms = meminject.ResolveInheritance(terms)
+		reported, rerooted := meminject.EnforcePinnedRoots(terms)
+		reported = meminject.ResolveInheritance(reported)
+		for i := range reported {
+			reported[i].NameIssue = meminject.OntologyNameIssue(reported[i].Name)
+		}
+		resp.Terms = reported
+		if len(rerooted) > 0 {
+			// Said out loud because the nesting was accepted by the document and then
+			// dropped here. An operator who nested `preference` under something and saw
+			// their document keep it would otherwise believe it took effect.
+			notes = append(notes, "These are the memory tier's own structural types and "+
+				"cannot be nested under another type, so they were kept as roots: "+
+				strings.Join(rerooted, ", ")+". Subclassing them is fine — it is giving "+
+				"them a parent that is not.")
+		}
 	}
 	resp.Confirmed = confirmed
 	resp.Notes = notes

--- a/internal/cli/memory_eval_live.go
+++ b/internal/cli/memory_eval_live.go
@@ -70,7 +70,12 @@ func RunMemoryEvalLive(args []string, stdout, stderr io.Writer) int {
 	ontologyTerms := fs.String("ontology-terms", "",
 		"comma-separated tenant entity types to add to the base seed when expanding "+
 			"{{memory:ontology}} (a deployment with a CONFIRMED tenant ontology adds its own; "+
-			"empty = the base seed alone, which is what an unconfirmed deployment gets)")
+			"empty = the base seed alone, which is what an unconfirmed deployment gets). "+
+			"A slash declares a subclass: event/incident puts incident under event")
+	corpusName := fs.String("corpus", "default",
+		"which fixture set to score: default | hierarchy. hierarchy measures whether the "+
+			"model picks the most specific type that fits, and REQUIRES an -ontology-terms "+
+			"carrying the matching hierarchy (it is defaulted for you when omitted)")
 	showFacts := fs.Bool("show-facts", false, "print every case's emitted facts, including the ones that passed")
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -115,6 +120,25 @@ func RunMemoryEvalLive(args []string, stdout, stderr io.Writer) int {
 	// placeholder — which is a complete explanation for the eval's finding that half
 	// the emitted types were outside the ontology, and for why the live deployment,
 	// where expansion does happen, used its ontology's types correctly.
+	// THE CORPUS CHOOSES THE ONTOLOGY when the operator did not, and this is the one
+	// pairing the harness must not leave to the invocation. Scoring the hierarchy cases
+	// against the flat seed asks the model to pick a subtype it was never shown, and
+	// reports its failure to do so as a model weakness — a wrong number that looks
+	// entirely normal.
+	var corpus eval.ExtractionCorpus
+	switch *corpusName {
+	case "default", "":
+		corpus = eval.ExtractionFixture()
+	case "hierarchy":
+		corpus = eval.ExtractionHierarchyFixture()
+		if strings.TrimSpace(*ontologyTerms) == "" {
+			*ontologyTerms = eval.HierarchyOntologyTerms
+			fmt.Fprintf(stdout, "corpus=hierarchy: using -ontology-terms %q\n", *ontologyTerms)
+		}
+	default:
+		return fail(stderr, "memory-eval-live: unknown --corpus %q (default | hierarchy)", *corpusName)
+	}
+
 	systemPrompt, err := expandEvalPlaceholders(agent.SystemPrompt, *ontologyTerms)
 	if err != nil {
 		return fail(stderr, "memory-eval-live: %v", err)
@@ -132,7 +156,7 @@ func RunMemoryEvalLive(args []string, stdout, stderr io.Writer) int {
 	// measured should not depend on where the wall clock happens to land.
 	rep, err := eval.RunExtraction(context.Background(), prov, eval.ExtractionInput{
 		CaseTimeout:  *timeout,
-		Corpus:       eval.ExtractionFixture(),
+		Corpus:       corpus,
 		SystemPrompt: systemPrompt,
 		Provider:     *providerID,
 		Model:        *model,
@@ -392,13 +416,65 @@ func splitWords(s string) []string {
 // tenantTerms lets a run reproduce a deployment whose operator has CONFIRMED an
 // ontology. Empty is the unconfirmed case — the base seed alone — and the two give
 // materially different results, which is the entire question the flag exists to ask.
+// dedupeOntologyTerms keeps the FIRST declaration of each name.
+//
+// Paths overlap by design ("event/incident" and "event/incident/outage" both declare
+// event), and EffectiveOntology is a map keyed by name, so duplicates would not corrupt
+// the render — but they would corrupt the reported term COUNT, and a flag that says it
+// declared six types when it declared four is a flag nobody trusts twice.
+func dedupeOntologyTerms(in []meminject.OntologyTerm) []meminject.OntologyTerm {
+	seen := map[string]bool{}
+	out := make([]meminject.OntologyTerm, 0, len(in))
+	for _, t := range in {
+		if seen[t.Name] {
+			continue
+		}
+		seen[t.Name] = true
+		out = append(out, t)
+	}
+	return out
+}
+
 func expandEvalPlaceholders(prompt, tenantTerms string) (string, error) {
 	var extra []meminject.OntologyTerm
-	for _, name := range strings.Split(tenantTerms, ",") {
-		if name = strings.TrimSpace(name); name != "" {
-			extra = append(extra, meminject.OntologyTerm{Name: name})
+	for _, seg := range strings.Split(tenantTerms, ",") {
+		if seg = strings.TrimSpace(seg); seg == "" {
+			continue
+		}
+		// A SLASH DECLARES A SUBCLASS: "event/incident" is incident under event, and
+		// "event/incident/outage" names the whole chain so the intermediate term does
+		// not have to be listed separately to be a parent. Only the last segment is the
+		// term being declared; the one before it is its parent.
+		//
+		// A path rather than a "child:parent" pair because that is the direction the
+		// hierarchy reads in every other surface (the document, the panel, the prompt),
+		// and because a shell needs no quoting for it.
+		parts := strings.Split(seg, "/")
+		name := strings.TrimSpace(parts[len(parts)-1])
+		if name == "" {
+			return "", fmt.Errorf("ontology term %q ends in a slash, so it names nothing", seg)
+		}
+		parent := ""
+		if len(parts) > 1 {
+			parent = strings.TrimSpace(parts[len(parts)-2])
+		}
+		extra = append(extra, meminject.OntologyTerm{Name: name, Parent: parent})
+		// Declare each ancestor the path names, once, so a chain works without also
+		// listing every prefix — otherwise a dangling parent silently drops the
+		// hierarchy back to flat and the run measures nothing it claims to.
+		for i := len(parts) - 2; i >= 0; i-- {
+			anc := strings.TrimSpace(parts[i])
+			if anc == "" {
+				return "", fmt.Errorf("ontology term %q has an empty path segment", seg)
+			}
+			ancParent := ""
+			if i > 0 {
+				ancParent = strings.TrimSpace(parts[i-1])
+			}
+			extra = append(extra, meminject.OntologyTerm{Name: anc, Parent: ancParent})
 		}
 	}
+	extra = dedupeOntologyTerms(extra)
 	// confirmed=true only when terms were supplied: EffectiveOntology discards a
 	// tenant layer that is not confirmed, so passing true with no terms would render
 	// the "this deployment has confirmed additions" wording over the bare seed.

--- a/internal/cli/memory_eval_placeholders_test.go
+++ b/internal/cli/memory_eval_placeholders_test.go
@@ -1,10 +1,15 @@
 package cli
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
 	meminject "github.com/denn-gubsky/loomcycle/internal/memory"
+	"github.com/denn-gubsky/loomcycle/internal/memory/eval"
 )
 
 // TestExpandEvalPlaceholders_RendersTheOntology is the defect this exists for.
@@ -102,5 +107,106 @@ func TestExpandEvalPlaceholders_LeavesAPlainPromptAlone(t *testing.T) {
 	}
 	if got != plain {
 		t.Errorf("a prompt with no placeholder must be byte-identical:\n%q", got)
+	}
+}
+
+// TestExpandEvalPlaceholders_SeedOnlyPromptStillMatchesTheRecordedBaseline answers a
+// question the ontology-hierarchy work raised, with a fact instead of a belief.
+//
+// Adding subclasses changed how the ontology renders — but only when a hierarchy is
+// actually present. The eval expands the SEED alone, whose types are all roots, so it
+// takes the flat path and the prompt should be byte-identical to the one the committed
+// numbers were measured against. "Should be" is exactly the kind of claim that turns
+// out to be wrong, and the cost of being wrong is silent: the baseline keys on the
+// prompt digest, so a changed prompt does not fail — it un-gates every model at once
+// and the next run reports a clean pass with nothing behind it.
+//
+// So: recompute the digest from the SHIPPED bundle prompt and require it to still match
+// a recorded entry. If someone edits the seed, the renderer, or the extractor prompt,
+// this fails and names re-measurement as the cost, rather than letting the gate expire
+// unnoticed.
+func TestExpandEvalPlaceholders_SeedOnlyPromptStillMatchesTheRecordedBaseline(t *testing.T) {
+	t.Setenv("LOOMCYCLE_PRESETS", "base,memory")
+	t.Setenv("LOOMCYCLE_CONFIG_DIR", "")
+	t.Setenv("LOOMCYCLE_CONFIG_FILES", "")
+	cfg, err := loadLayeredConfig("")
+	if err != nil {
+		t.Fatalf("loadLayeredConfig: %v", err)
+	}
+	agent, ok := cfg.Agents[extractorAgentName]
+	if !ok {
+		t.Fatalf("the %s bundle did not provide %q", "memory", extractorAgentName)
+	}
+	prompt, err := expandEvalPlaceholders(agent.SystemPrompt, "")
+	if err != nil {
+		t.Fatalf("expand: %v", err)
+	}
+	sum := sha256.Sum256([]byte(prompt))
+	got := hex.EncodeToString(sum[:])
+
+	base, err := eval.LoadBaseline(filepath.Join("..", "memory", "eval", "extraction-baseline.json"))
+	if err != nil {
+		t.Fatalf("load baseline: %v", err)
+	}
+	if len(base.Entries) == 0 {
+		t.Skip("no recorded baseline to compare against")
+	}
+	recorded := map[string]bool{}
+	for _, e := range base.Entries {
+		recorded[e.SystemPromptSHA256] = true
+	}
+	if !recorded[got] {
+		have := make([]string, 0, len(recorded))
+		for k := range recorded {
+			have = append(have, k[:12])
+		}
+		sort.Strings(have)
+		t.Errorf("the seed-only extractor prompt now digests to %s, which no recorded baseline "+
+			"entry was measured against (recorded: %v).\n\nEvery stored score is now ungated: "+
+			"EntryFor keys on this digest, so a mismatch reports as \"no baseline\" rather than as "+
+			"a regression. Re-measure with `make memory-eval-live` and commit the new entries.",
+			got[:12], have)
+	}
+}
+
+// TestExpandEvalPlaceholders_SlashDeclaresASubclass — the hierarchy corpus is
+// unscoreable without this, and a silently-flat expansion would score the model on
+// subtypes it was never shown.
+func TestExpandEvalPlaceholders_SlashDeclaresASubclass(t *testing.T) {
+	got, err := expandEvalPlaceholders("{{memory:ontology}}", "event/incident/outage,person")
+	if err != nil {
+		t.Fatalf("expand: %v", err)
+	}
+	// The rendered form must be the TREE, not a flat list — indentation is how the
+	// prompt conveys specificity, and the "most specific type" instruction is what
+	// makes the ladder get used at all.
+	if !strings.Contains(got, "  - **incident**") {
+		t.Errorf("incident is not nested under event:\n%s", got)
+	}
+	if !strings.Contains(got, "    - **outage**") {
+		t.Errorf("outage is not nested under incident:\n%s", got)
+	}
+	if !strings.Contains(got, "MOST SPECIFIC") {
+		t.Errorf("the specificity instruction is missing, so the ladder has no caller:\n%s", got)
+	}
+	// An INTERMEDIATE ancestor must be declared by the path alone. If it were not, its
+	// child's parent would dangle, the render would fall back to flat, and the run would
+	// measure nothing it claims to — while looking completely normal.
+	if !strings.Contains(got, "- **event**") {
+		t.Errorf("the path did not declare its ancestor:\n%s", got)
+	}
+	// And a term outside the chain stays a root.
+	if !strings.Contains(got, "\n- **person**") {
+		t.Errorf("an unrelated term was pulled into the tree:\n%s", got)
+	}
+}
+
+// TestExpandEvalPlaceholders_RefusesAMalformedPath: a trailing slash names nothing, and
+// silently dropping it would flatten the hierarchy the run depends on.
+func TestExpandEvalPlaceholders_RefusesAMalformedPath(t *testing.T) {
+	for _, bad := range []string{"event/", "event//incident"} {
+		if _, err := expandEvalPlaceholders("{{memory:ontology}}", bad); err == nil {
+			t.Errorf("%q should have been refused", bad)
+		}
 	}
 }

--- a/internal/memory/eval/extraction.go
+++ b/internal/memory/eval/extraction.go
@@ -618,6 +618,13 @@ func scoreCase(res *CaseResult, cs ExtractionCase, facts []ExtractedFact) {
 // same fact.
 func matchExpected(w ExpectedFact, facts []ExtractedFact) int {
 	for i, f := range facts {
+		// Type is a HARD filter, checked before the text markers: a fact about the
+		// right thing carrying the wrong type has not satisfied a specificity
+		// expectation, and letting the text alone match would report the failure this
+		// ability measures as a success.
+		if w.Type != "" && !strings.EqualFold(strings.TrimSpace(f.Type), w.Type) {
+			continue
+		}
 		hay := normalizeForMatch(f.Text)
 		ok := true
 		for _, m := range w.AllOf {

--- a/internal/memory/eval/extraction_fixtures.go
+++ b/internal/memory/eval/extraction_fixtures.go
@@ -71,12 +71,23 @@ const (
 	// that must never be stored. Scored by violations, not recall: the correct
 	// answer is often the empty array.
 	AbilityAbstention Ability = "abstention"
+	// AbilitySpecificity — the model is given a type HIERARCHY and must pick the most
+	// specific type that fits, WITHOUT reaching past what the transcript supports.
+	//
+	// Two failure directions, and a corpus that measured only one would be worse than
+	// none. Under-specifying wastes the taxonomy: the operator classified incidents and
+	// gets everything back as `event`. Over-specifying is the more dangerous direction,
+	// because the extra precision is fabricated — a birthday party typed `incident`
+	// reads as a real claim about what happened, and subtype-expanded retrieval will
+	// keep surfacing it under a filter it does not belong to.
+	AbilitySpecificity Ability = "specificity"
 )
 
 // AllAbilities is the fixed report order — stable so two runs' output diffs
 // cleanly.
 func AllAbilities() []Ability {
-	return []Ability{AbilityExtraction, AbilityProperty, AbilityTemporal, AbilityUpdate, AbilityAbstention}
+	return []Ability{AbilityExtraction, AbilityProperty, AbilityTemporal, AbilityUpdate,
+		AbilityAbstention, AbilitySpecificity}
 }
 
 // ExpectedFact is one fact the extractor MUST produce for a case.
@@ -110,6 +121,13 @@ type ExpectedFact struct {
 	// reported but does NOT fail the fact — classification is softer than
 	// capture, and a mis-classed fact is still recorded and recallable.
 	Class string
+	// Type, when set, is the entity type the fact MUST carry, and unlike Class it is
+	// hard: a fact with the wrong type does not satisfy the expectation.
+	//
+	// Hard because for a hierarchy case the type IS the measurement. Scoring it softly
+	// would report full recall for a model that captured every fact and ignored the
+	// taxonomy entirely — which is the exact outcome this ability exists to detect.
+	Type string
 }
 
 // ExtractionCase is one transcript plus what the extractor must and must not
@@ -534,6 +552,13 @@ func (c ExtractionCorpus) Digest() string {
 			fmt.Fprintf(h, "want\x00%s\x00%s\x00%s\x00%s\x00%s\x00",
 				w.Why, strings.Join(w.AllOf, "|"), strings.Join(w.AnyOf, "|"),
 				strings.Join(w.NoneOf, "|"), w.Class)
+			// APPENDED ONLY WHEN SET. An unset field must contribute nothing, or adding
+			// it to the struct would re-digest every existing case and silently expire
+			// the gate on every recorded baseline entry — the failure the digest was
+			// put in the key to prevent, arriving through the digest itself.
+			if w.Type != "" {
+				fmt.Fprintf(h, "wanttype\x00%s\x00", w.Type)
+			}
 		}
 		for _, f := range cs.Forbid {
 			fmt.Fprintf(h, "forbid\x00%s\x00%s\x00%s\x00", f.Kind, f.Marker, f.Key)
@@ -547,12 +572,10 @@ func (c ExtractionCorpus) Digest() string {
 // case has turns, every ability is represented, and no expected fact is empty.
 func (c ExtractionCorpus) Validate() error {
 	canaries := 0
-	seen := map[Ability]bool{}
 	for _, cs := range c.Cases {
 		if cs.Canary {
 			canaries++
 		}
-		seen[cs.Ability] = true
 		if len(cs.Turns) == 0 {
 			return fmt.Errorf("case %q has no turns", cs.Name)
 		}
@@ -571,10 +594,29 @@ func (c ExtractionCorpus) Validate() error {
 	if canaries != 1 {
 		return fmt.Errorf("corpus must carry exactly 1 canary case, found %d", canaries)
 	}
-	for _, a := range AllAbilities() {
-		if !seen[a] {
-			return fmt.Errorf("no case covers ability %q, so its score would be vacuous", a)
-		}
-	}
+	// ABILITY COVERAGE IS NOT CHECKED HERE, and moving it out was the point.
+	//
+	// "Every ability must be covered" is a property of the corpus we SHIP as canonical,
+	// not of every corpus that can be run. Enforcing it here made Validate refuse a
+	// purpose-built corpus — the specificity fixture, which deliberately covers one
+	// ability because it is the only one its paired ontology can score. The rule now
+	// lives where its subject does, on the shipped fixture, in
+	// TestExtractionFixture_CoversEveryAbility.
+	//
+	// Nothing is lost: that test fails if the shipped corpus stops covering something,
+	// which is the case the rule was written for. What is gained is that a caller may
+	// legitimately score a narrow corpus.
 	return nil
 }
+
+// optionalAbility reports whether the SHIPPED corpus may omit an ability.
+//
+// Only specificity, and for a reason the shipped corpus cannot fix: scoring it requires
+// a type hierarchy in the rendered ontology, and the default invocation renders the seed
+// alone, whose types are all roots. A specificity case there would ask the model to
+// choose a subtype it was never shown and score it for failing.
+//
+// It is measured in ExtractionHierarchyFixture instead, and
+// TestHierarchyFixture_IsWhereTheOptionalAbilityIsActuallyMeasured asserts that —
+// "optional" must not quietly become "measured nowhere".
+func optionalAbility(a Ability) bool { return a == AbilitySpecificity }

--- a/internal/memory/eval/extraction_hierarchy_fixtures.go
+++ b/internal/memory/eval/extraction_hierarchy_fixtures.go
@@ -28,6 +28,23 @@ package eval
 //     and subtype-expanded retrieval will keep surfacing it under a filter it does not
 //     belong to. The RFC's own risk note calls this out: given a ladder, a model tends
 //     to climb it further than the evidence goes.
+//
+// HOW TO READ A MISS, and this matters because the extractor's `type` is OPTIONAL by
+// design ("emit both or neither, and only when the fact is clearly about one named
+// thing"). A miss here means one of two things, and the report's `typed` column tells
+// them apart:
+//
+//   - typed high → the model emitted types and chose the wrong rung. That is the
+//     specificity failure this ability names.
+//   - typed low → the model mostly declined to type at all. That is not a hierarchy
+//     failure; the taxonomy simply never engaged, and no amount of prompt wording about
+//     specificity will move it.
+//
+// Every transcript here is written so its durable statement is unmistakably ABOUT the
+// event — "last Tuesday's checkout outage ran forty minutes", not "the checkout service
+// went down". The first phrasing was tried and the model typed it `object:checkout
+// service`, which is correct for what that sentence is about, and told us nothing about
+// which rung of the ladder it would pick.
 
 // HierarchyOntologyTerms is the -ontology-terms value these cases are scored against.
 //
@@ -49,8 +66,8 @@ func ExtractionHierarchyFixture() ExtractionCorpus {
 			Name:    "specific-subtype-when-it-fits",
 			Ability: AbilitySpecificity,
 			Turns: []string{
-				"The checkout service went down on Tuesday for about forty minutes. " +
-					"Turned out to be a bad config push, and rolling it back fixed it.",
+				"Last Tuesday's checkout outage ran about forty minutes. A bad config " +
+					"push caused it and a rollback ended it.",
 				"That sounds rough.",
 			},
 			Want: []ExpectedFact{{
@@ -69,8 +86,8 @@ func ExtractionHierarchyFixture() ExtractionCorpus {
 			Name:    "middle-of-the-ladder",
 			Ability: AbilitySpecificity,
 			Turns: []string{
-				"We had an incident last month where a deploy corrupted some user avatars. " +
-					"Nothing was ever unavailable, but we spent a day restoring them.",
+				"Last month's avatar corruption incident took a day to clean up. " +
+					"Nothing was ever unavailable — a deploy just mangled the files.",
 				"Understood.",
 			},
 			Want: []ExpectedFact{{

--- a/internal/memory/eval/extraction_hierarchy_fixtures.go
+++ b/internal/memory/eval/extraction_hierarchy_fixtures.go
@@ -1,0 +1,118 @@
+package eval
+
+// extraction_hierarchy_fixtures.go — the corpus that measures whether a model uses a
+// type HIERARCHY correctly (RFC BZ §8).
+//
+// WHY A SEPARATE CORPUS instead of cases added to the canonical one. The baseline keys
+// on the corpus digest, so appending to the shipped fixture would expire the gate on
+// every recorded entry at once and demand a re-measurement of all of them. A distinct
+// corpus gets distinct keys: the existing numbers stay valid and comparable, and these
+// cases accumulate their own history.
+//
+// It also has to be separate for a correctness reason. These cases can only be scored
+// when the rendered ontology actually CONTAINS the hierarchy — run them against the
+// flat seed and you are asking the model to choose a subtype it was never shown, and
+// scoring it for failing. The harness cannot enforce that pairing, so the invocation
+// carries it:
+//
+//	loomcycle memory-eval-live --provider ollama-local --model qwen3.6:latest \
+//	  --corpus hierarchy --ontology-terms "event,event/incident,event/incident/outage,person"
+//
+// WHAT IT MEASURES, in both directions, because a corpus that measured one would be
+// worse than none:
+//
+//   - under-specifying wastes the taxonomy — the operator classified incidents and gets
+//     everything back as `event`.
+//   - over-specifying FABRICATES precision, and is the more dangerous direction. A
+//     birthday party typed `incident` is a claim about what happened that nobody made,
+//     and subtype-expanded retrieval will keep surfacing it under a filter it does not
+//     belong to. The RFC's own risk note calls this out: given a ladder, a model tends
+//     to climb it further than the evidence goes.
+
+// HierarchyOntologyTerms is the -ontology-terms value these cases are scored against.
+//
+// Exported so the invocation and the fixture cannot drift apart: a case expecting
+// `outage` is meaningless unless `outage` is in the prompt, and the two living in
+// different files is exactly how that stops being true.
+const HierarchyOntologyTerms = "event,event/incident,event/incident/outage,person"
+
+// ExtractionHierarchyFixture returns the specificity corpus.
+func ExtractionHierarchyFixture() ExtractionCorpus {
+	return ExtractionCorpus{Cases: []ExtractionCase{
+		// The canary is the harness's own self-check and every corpus needs exactly
+		// one — a corpus whose transcripts never reached the model must fail as a
+		// harness fault, not as a model that types badly.
+		ExtractionCanary(),
+
+		// ---- the subtype is right, and available ----
+		{
+			Name:    "specific-subtype-when-it-fits",
+			Ability: AbilitySpecificity,
+			Turns: []string{
+				"The checkout service went down on Tuesday for about forty minutes. " +
+					"Turned out to be a bad config push, and rolling it back fixed it.",
+				"That sounds rough.",
+			},
+			Want: []ExpectedFact{{
+				Why: "an outage is available in the ontology and the transcript describes one — " +
+					"typing this `event` throws away the classification the operator built",
+				Type:  "outage",
+				AnyOf: []string{"checkout", "down", "outage"},
+			}},
+		},
+
+		// ---- the MIDDLE of the ladder is right ----
+		//
+		// A separate case from the one above because the two failures are different:
+		// this one catches a model that has learned "always take the deepest type".
+		{
+			Name:    "middle-of-the-ladder",
+			Ability: AbilitySpecificity,
+			Turns: []string{
+				"We had an incident last month where a deploy corrupted some user avatars. " +
+					"Nothing was ever unavailable, but we spent a day restoring them.",
+				"Understood.",
+			},
+			Want: []ExpectedFact{{
+				Why: "an incident that explicitly was NOT an outage — `incident` is the most " +
+					"specific type the transcript supports, and `outage` would be invented precision",
+				Type:  "incident",
+				AnyOf: []string{"avatar", "deploy", "corrupt"},
+			}},
+		},
+
+		// ---- the PARENT is right: the over-specification trap ----
+		{
+			Name:    "general-when-no-subtype-fits",
+			Ability: AbilitySpecificity,
+			Turns: []string{
+				"My daughter's birthday party is on the 14th, we're doing it at the bowling alley.",
+				"Sounds fun.",
+			},
+			Want: []ExpectedFact{{
+				Why: "a birthday party is an event and nothing more specific applies — typing it " +
+					"`incident` or `outage` invents a claim the transcript never made",
+				Type:  "event",
+				AnyOf: []string{"birthday", "party"},
+			}},
+		},
+
+		// ---- a ROOT outside the ladder, unaffected by it ----
+		//
+		// Present because a hierarchy must not distort typing elsewhere: a model handed a
+		// ladder sometimes starts reading everything as a rung.
+		{
+			Name:    "unrelated-root-is-untouched",
+			Ability: AbilitySpecificity,
+			Turns: []string{
+				"My colleague Ada runs the platform team — she's the one to ask about deploys.",
+				"Noted.",
+			},
+			Want: []ExpectedFact{{
+				Why:   "a person is a person; the event ladder must not pull unrelated facts into it",
+				Type:  "person",
+				AllOf: []string{"ada"},
+			}},
+		},
+	}}
+}

--- a/internal/memory/eval/extraction_test.go
+++ b/internal/memory/eval/extraction_test.go
@@ -1286,3 +1286,39 @@ func perfectReplies() map[string]string {
 		"instruction-inside-the-transcript": `[]`,
 	}
 }
+
+// TestMatchExpected_TypeIsAHardFilter pins the behaviour the live runs did not exercise.
+//
+// Against the local model every specificity miss was an ABSENT type, never a wrong one —
+// so the branch that actually detects over-specification (a fact typed at the wrong rung
+// of the ladder) went unexercised by the measurement it exists for. A capability only
+// observed failing one way is a capability half-tested.
+func TestMatchExpected_TypeIsAHardFilter(t *testing.T) {
+	want := ExpectedFact{Why: "w", AnyOf: []string{"birthday"}, Type: "event"}
+	cases := []struct {
+		name  string
+		facts []ExtractedFact
+		match bool
+	}{
+		{"right type", []ExtractedFact{{Text: "the birthday party is on the 14th", Type: "event"}}, true},
+		{"case-insensitive", []ExtractedFact{{Text: "the birthday party is on the 14th", Type: "Event"}}, true},
+		// OVER-SPECIFICATION: the text is right and the rung is invented. This must miss,
+		// or the ability reports the failure it was created to catch as a success.
+		{"over-specified", []ExtractedFact{{Text: "the birthday party is on the 14th", Type: "incident"}}, false},
+		// UNDER-SPECIFICATION, the mirror image.
+		{"absent type", []ExtractedFact{{Text: "the birthday party is on the 14th"}}, false},
+		// And the type alone is not enough — the fact still has to be the right fact.
+		{"right type wrong fact", []ExtractedFact{{Text: "the deploy was rolled back", Type: "event"}}, false},
+		// A correctly-typed fact further down the list must still be found.
+		{"found past a wrong one", []ExtractedFact{
+			{Text: "the birthday party is on the 14th", Type: "incident"},
+			{Text: "the birthday party is at the bowling alley", Type: "event"},
+		}, true},
+	}
+	for _, c := range cases {
+		got := matchExpected(want, c.facts) >= 0
+		if got != c.match {
+			t.Errorf("%s: matched=%v, want %v", c.name, got, c.match)
+		}
+	}
+}

--- a/internal/memory/eval/extraction_test.go
+++ b/internal/memory/eval/extraction_test.go
@@ -462,9 +462,61 @@ func TestExtractionFixture_Validates(t *testing.T) {
 func TestExtractionFixture_CoversEveryAbility(t *testing.T) {
 	byAbility := ExtractionFixture().CasesByAbility()
 	for _, a := range AllAbilities() {
+		if optionalAbility(a) {
+			continue
+		}
 		if len(byAbility[a]) == 0 {
 			t.Errorf("ability %q has no cases, so its score would be vacuous", a)
 		}
+	}
+}
+
+// TestHierarchyFixture_IsWhereTheOptionalAbilityIsActuallyMeasured.
+//
+// "Optional" must not become "measured nowhere". The default corpus is allowed to omit
+// specificity because it is scored against a flat ontology — so the counterpart
+// assertion belongs here: the corpus that DOES supply a hierarchy must cover it, and
+// must cover it in both directions. A corpus with only subtype-is-right cases would
+// score a model that always takes the deepest type as perfect, which is the failure the
+// ability was created to catch.
+func TestHierarchyFixture_IsWhereTheOptionalAbilityIsActuallyMeasured(t *testing.T) {
+	corpus := ExtractionHierarchyFixture()
+	if err := corpus.Validate(); err != nil {
+		t.Fatalf("the hierarchy corpus must be coherent: %v", err)
+	}
+	byAbility := corpus.CasesByAbility()
+	if len(byAbility[AbilitySpecificity]) == 0 {
+		t.Fatal("the hierarchy corpus does not cover specificity — then nothing does")
+	}
+	// Every expected type must be a type the paired -ontology-terms actually renders,
+	// or the case asks for a subtype the model was never shown and scores it as a miss.
+	declared := map[string]bool{}
+	for _, seg := range strings.Split(HierarchyOntologyTerms, ",") {
+		parts := strings.Split(strings.TrimSpace(seg), "/")
+		declared[parts[len(parts)-1]] = true
+	}
+	wantTypes := map[string]bool{}
+	for _, cs := range byAbility[AbilitySpecificity] {
+		for _, w := range cs.Want {
+			if w.Type == "" {
+				t.Errorf("case %q asserts no type, so it measures nothing about specificity", cs.Name)
+				continue
+			}
+			if !declared[w.Type] {
+				t.Errorf("case %q expects type %q, which HierarchyOntologyTerms does not declare — "+
+					"the model would be scored on a type it was never shown", cs.Name, w.Type)
+			}
+			wantTypes[w.Type] = true
+		}
+	}
+	// BOTH DIRECTIONS: at least one case whose answer is a leaf subtype, and at least
+	// one whose answer is the root. Otherwise the corpus only measures one failure.
+	if !wantTypes["outage"] && !wantTypes["incident"] {
+		t.Error("no case expects a SUBtype — under-specification would go unmeasured")
+	}
+	if !wantTypes["event"] {
+		t.Error("no case expects the ROOT type — over-specification, the more dangerous " +
+			"direction, would go unmeasured")
 	}
 }
 
@@ -482,7 +534,10 @@ func TestExtractionFixture_ValidateCatchesAVacuousCorpus(t *testing.T) {
 			ExtractionCanary(),
 			{Name: "a", Ability: AbilityUpdate, Turns: []string{"t"}, Want: []ExpectedFact{{Why: "w"}}},
 		}}},
-		{"missing ability", ExtractionCorpus{Cases: []ExtractionCase{ExtractionCanary()}}},
+		// NO "missing ability" case: coverage is no longer Validate's job — it is a
+		// property of the SHIPPED corpus and is asserted in
+		// TestExtractionFixture_CoversEveryAbility. A narrow, purpose-built corpus is
+		// legitimate, and Validate refusing one was the bug.
 	}
 	for _, c := range cases {
 		if err := c.corpus.Validate(); err == nil {

--- a/internal/memory/ontology.go
+++ b/internal/memory/ontology.go
@@ -16,6 +16,7 @@ package memory
 import (
 	_ "embed"
 	"encoding/json"
+	"regexp"
 	"sort"
 	"strings"
 )
@@ -67,6 +68,11 @@ type OntologyTerm struct {
 	// to show which fields a subclass actually declared. Merging would make the
 	// panel's "this deployment defines" column claim fields nobody wrote there.
 	Inherited []string `json:"inherited,omitempty"`
+	// NameIssue is an operator-facing advisory about the name itself — spaces, capitals,
+	// odd characters. Advisory only: the type is fully in force. Per-TERM rather than a
+	// document-level note so the panel can point at the offender instead of asking the
+	// operator to find it.
+	NameIssue string `json:"name_issue,omitempty"`
 	// Parent is the NAME of the entity this one subclasses, or "" for a root
 	// (RFC BZ). A name rather than a chunk id because the ontology is consumed by
 	// name everywhere downstream — the prompt, the stored fact's type, the retrieval
@@ -136,6 +142,9 @@ func EffectiveOntology(tenantTerms []OntologyTerm, tenantConfirmed bool) []Ontol
 		out = append(out, t)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	// Pinned roots are re-rooted BEFORE inheritance, so a wrongly-nested tier type does
+	// not also inherit a domain type's fields on its way through.
+	out, _ = EnforcePinnedRoots(out)
 	// AFTER layering, so a subclass inherits what its parent effectively HAS — if the
 	// parent overrode a standard type, the child gets the override, not the seed.
 	return ResolveInheritance(out)
@@ -211,6 +220,73 @@ func joinComma(ss []string) string {
 		out += s
 	}
 	return out
+}
+
+// PinnedOntologyRoots are the memory tier's own structural types, which a tenant may
+// not re-parent (RFC BZ §10.3, decided here rather than left to discovery).
+//
+// They may still be SUBCLASSED — `dietary-preference` under `preference` is a good idea
+// and stays legal. What is refused is giving them a parent, because that inverts the
+// tier: make `preference` a subclass of some domain type and, with subtype-expanded
+// retrieval, a query for that domain type starts sweeping in every preference the user
+// ever expressed. The tier stops meaning what every other surface assumes it means.
+//
+// Enforced by clearing the parent rather than by rejecting the document, so an operator
+// who nests one by accident loses the nesting and keeps their ontology. The panel says
+// what happened; silence would leave them believing it took.
+func PinnedOntologyRoots() []string { return []string{"preference", "fact"} }
+
+// EnforcePinnedRoots clears the parent of any pinned root and reports which were
+// re-rooted, so the caller can tell the operator rather than let them discover it.
+func EnforcePinnedRoots(terms []OntologyTerm) ([]OntologyTerm, []string) {
+	pinned := map[string]bool{}
+	for _, n := range PinnedOntologyRoots() {
+		pinned[n] = true
+	}
+	var rerooted []string
+	out := make([]OntologyTerm, 0, len(terms))
+	for _, t := range terms {
+		if t.Parent != "" && pinned[strings.ToLower(t.Name)] {
+			rerooted = append(rerooted, t.Name)
+			t.Parent = ""
+		}
+		out = append(out, t)
+	}
+	return out, rerooted
+}
+
+// ontologyNameRe is the identifier shape an entity name should take.
+var ontologyNameRe = regexp.MustCompile(`^[a-z0-9]([a-z0-9_-]*[a-z0-9])?$`)
+
+// OntologyNameIssue returns an operator-facing warning when a name is awkward as a type,
+// or "" when it is fine (RFC BZ §10.2).
+//
+// WARN, NEVER NORMALISE, and never reject. Any free-text heading is a legal type name
+// today, so rewriting or refusing one would silently change — or break — an ontology that
+// already works, and a name is a fact's natural key: normalising `Notes on naming` into
+// `notes-on-naming` after facts were stored under the old spelling splits the type in
+// half. The cost of a bad name is friction in a prompt, not corruption, so the right
+// response is to point at it.
+//
+// Deliberately not applied to the seed: its names are already in this shape, and a
+// warning on a name the operator cannot edit is noise.
+func OntologyNameIssue(name string) string {
+	n := strings.TrimSpace(name)
+	if n == "" || ontologyNameRe.MatchString(n) {
+		return ""
+	}
+	switch {
+	case strings.ContainsAny(n, " \t"):
+		return "contains spaces — a type name is used inside a prompt and as part of a " +
+			"fact's key, where a phrase reads as prose rather than as a type. Prefer " +
+			"lowercase words joined by - or _."
+	case n != strings.ToLower(n):
+		return "has capitals — type names are matched case-insensitively, so two spellings " +
+			"of the same type are easy to create by accident. Prefer lowercase."
+	default:
+		return "has characters outside a-z, 0-9, - and _, which are awkward in a prompt " +
+			"and in a fact's key."
+	}
 }
 
 // ResolveInheritance fills each term's Inherited from its ancestors.

--- a/internal/memory/ontology_test.go
+++ b/internal/memory/ontology_test.go
@@ -340,3 +340,92 @@ func TestEffectiveOntology_InheritanceUsesTheOverriddenParent(t *testing.T) {
 	}
 	t.Fatal("incident missing from the effective ontology")
 }
+
+// TestEnforcePinnedRoots_TierTypesCannotBeNestedButCanBeSubclassed.
+//
+// The asymmetry is the whole rule. Subclassing `preference` is a good idea and stays
+// legal; giving it a parent inverts the tier, and with subtype-expanded retrieval a query
+// for that parent would start sweeping in every preference the user ever expressed.
+func TestEnforcePinnedRoots_TierTypesCannotBeNestedButCanBeSubclassed(t *testing.T) {
+	got, rerooted := EnforcePinnedRoots([]OntologyTerm{
+		{Name: "signal", Fields: []string{"kind"}},
+		{Name: "preference", Parent: "signal"},
+		{Name: "dietary-preference", Parent: "preference", Fields: []string{"restriction"}},
+		{Name: "fact", Parent: "signal"},
+		{Name: "project", Parent: "signal", Fields: []string{"status"}},
+	})
+	byName := map[string]OntologyTerm{}
+	for _, tm := range got {
+		byName[tm.Name] = tm
+	}
+	if byName["preference"].Parent != "" || byName["fact"].Parent != "" {
+		t.Errorf("a tier type kept a parent: preference=%q fact=%q",
+			byName["preference"].Parent, byName["fact"].Parent)
+	}
+	// SUBCLASSING one is untouched.
+	if byName["dietary-preference"].Parent != "preference" {
+		t.Errorf("subclassing a tier type must stay legal, got parent %q",
+			byName["dietary-preference"].Parent)
+	}
+	// And an ordinary type is not swept up by the rule.
+	if byName["project"].Parent != "signal" {
+		t.Errorf("an unrelated type was re-rooted: %q", byName["project"].Parent)
+	}
+	if len(rerooted) != 2 {
+		t.Errorf("both re-rootings must be reported so the operator is told, got %v", rerooted)
+	}
+	// Nothing is DROPPED — the operator keeps their ontology, they just lose the nesting.
+	if len(got) != 5 {
+		t.Errorf("want all five terms, got %d", len(got))
+	}
+}
+
+// TestEffectiveOntology_PinnedRootIsEnforcedBeforeInheritance: a wrongly-nested tier type
+// must not inherit its would-be parent's fields on the way through.
+func TestEffectiveOntology_PinnedRootIsEnforcedBeforeInheritance(t *testing.T) {
+	for _, term := range EffectiveOntology([]OntologyTerm{
+		{Name: "signal", Fields: []string{"kind", "weight"}},
+		{Name: "preference", Parent: "signal"},
+	}, true) {
+		if term.Name != "preference" {
+			continue
+		}
+		if len(term.Inherited) != 0 {
+			t.Errorf("preference inherited %v — the pin must apply before inheritance", term.Inherited)
+		}
+		if term.Parent != "" {
+			t.Errorf("preference kept parent %q in the effective ontology", term.Parent)
+		}
+	}
+}
+
+// TestOntologyNameIssue_WarnsWithoutRewriting (RFC BZ §10.2).
+//
+// Warn-only is the decision, not a first step toward normalising. A name is part of a
+// stored fact's key, so rewriting `Notes on naming` into `notes-on-naming` after facts
+// exist under the old spelling splits the type in half — the cost of a bad name is
+// friction in a prompt, not corruption.
+func TestOntologyNameIssue_WarnsWithoutRewriting(t *testing.T) {
+	fine := []string{"event", "security-incident", "work_item", "p", "x9"}
+	for _, n := range fine {
+		if got := OntologyNameIssue(n); got != "" {
+			t.Errorf("%q should be accepted quietly, got %q", n, got)
+		}
+	}
+	awkward := []string{"Notes on naming", "Event", "type:thing", "trailing-"}
+	for _, n := range awkward {
+		if OntologyNameIssue(n) == "" {
+			t.Errorf("%q should have produced an advisory", n)
+		}
+	}
+	// The SEED must be quiet — a warning on a name the operator cannot edit is noise.
+	for _, term := range BaseSeedOntology() {
+		if got := OntologyNameIssue(term.Name); got != "" {
+			t.Errorf("seed term %q warns: %q", term.Name, got)
+		}
+	}
+	// An empty name is not an advisory case: it is dropped elsewhere as nameless.
+	if OntologyNameIssue("  ") != "" {
+		t.Error("an empty name should not produce a name advisory")
+	}
+}

--- a/internal/memory/templates/ontology.md
+++ b/internal/memory/templates/ontology.md
@@ -22,6 +22,11 @@ one, and you can then nest beneath your copy.
 An inherited field cannot be removed — a subclass that lacks its parent's fields
 is not a subclass. If you want a type without them, make it a sibling instead.
 
+`preference` and `fact` are the memory tier's own types and always stay
+top-level. You may nest your types *under* them, but nesting them under one of
+yours is ignored. Names work best lowercase, as `a-z0-9-_` — a name with spaces
+still works, it just reads as prose inside a prompt.
+
 ## project
 
 A body of work with a lifecycle of its own. Worth its own type when memory

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -2714,6 +2714,12 @@ export interface OntologyTerm {
    * rather than claiming they wrote the inherited ones.
    */
   inherited?: string[];
+  /**
+   * An advisory about the NAME itself (spaces, capitals, odd characters). The type is
+   * fully in force regardless — names are never rewritten, because a name is part of a
+   * stored fact's key and normalising one would split the type in half.
+   */
+  name_issue?: string;
 }
 
 export interface OntologyResponse {

--- a/web/src/pages/SettingsView.tsx
+++ b/web/src/pages/SettingsView.tsx
@@ -501,6 +501,12 @@ function OntologyFieldSummary({ term, isLeaf }: { term: OntologyNode; isLeaf: bo
           · declares no fields of its own — a section heading rather than a type?
         </span>
       )}
+      {term.name_issue && (
+        <span className="ontology-warn">
+          {" "}
+          · name {term.name_issue}
+        </span>
+      )}
     </span>
   );
 }
@@ -639,7 +645,9 @@ function OntologySection() {
           general type also finds the specific ones. Nest up to four levels. To
           subclass a <em>standard</em> type, give it a <code>##</code> heading of
           its own first — that overrides the standard one — then nest beneath your
-          copy.
+          copy. <code>preference</code> and <code>fact</code> are the memory tier's
+          own types and always stay top-level: you may nest types <em>under</em> them,
+          but not them under something else.
         </p>
       </details>
 


### PR DESCRIPTION
## Why

The three items RFC BZ left open: §8's eval measurement (deferred through P2–P4), §10.3 whether the tier types are pinned as roots, and §10.2 name validation.

## §8 — the measurement, and the question it actually answered

**First: the recorded baseline was never invalidated, and that is now asserted rather than believed.** The eval expands the seed alone, whose types are all roots, so the prompt takes P2's flat path and still digests to a value a recorded entry was measured against. This matters because the failure is *silent*: the baseline keys on the prompt digest, so a changed prompt doesn't fail — it un-gates every model at once and the next run reports a clean pass with nothing behind it. `TestExpandEvalPlaceholders_SeedOnlyPromptStillMatchesTheRecordedBaseline` now fails the day someone changes the seed, the renderer, or the extractor prompt, and names re-measurement as the cost.

**Then the measurement:** a `specificity` ability, a hard `ExpectedFact.Type` assertion, and a **separate** `ExtractionHierarchyFixture` behind `--corpus hierarchy`, with `-ontology-terms` gaining a slash syntax (`event/incident/outage`) so a prompt can carry a hierarchy at all. Separate corpus because the baseline keys on the corpus digest — appending to the shipped fixture would expire the gate on all four recorded entries. Both directions are covered and a test enforces that, since a corpus measuring only "subtype is right" scores a model that always takes the deepest type as perfect.

### What the live runs found

Four runs against `ollama-local qwen3.6:latest` (effort=low), which is where the interesting part is:

| | specificity recall | typed |
|---|---|---|
| run 1 | 1.00 | 1.00 |
| run 2 | 0.25 | 1.00 |
| run 3 | 0.50 | 0.70 |
| run 4 | 0.50 | 0.44 |

**The RFC's assumed risk is not the observed one.** §8 worried about over-specification — "given a ladder, a model may reach for `incident` where `event` was right." Across every run this model never once climbed past the evidence: it typed the birthday party `event`, correctly, and never invented `incident` or `outage`. What it does instead is **decline to type at all** on the subtype cases, falling back to the standard roots it knows. Under-engagement, not over-reach.

**I did not record a baseline entry, deliberately.** Four cases swinging 0.25–1.00 cannot support a 0.15 recall tolerance; committing that number creates a gate that flaps and teaches people to pass `--no-gate` — which this codebase explicitly warns about. The corpus needs more cases per direction before it can gate. The harness, the fixture and the finding are the deliverable; the gate is not yet earned.

Running it also **corrected the fixture**: "the checkout service went down" got typed `object:checkout service`, which is right for what that sentence is about and useless as a specificity probe. The transcripts now make the event the subject. And a unit test covers the branch no live run exercised — a fact typed at the *wrong rung*, which is the over-specification detector itself.

## §10.3 — the tier types are pinned as roots

`preference` and `fact` may not be re-parented. The asymmetry is the rule: subclassing one stays legal (`dietary-preference` under `preference` is a good idea), but giving one a parent inverts the tier — and now that a type filter expands to subtypes, a query for that parent would sweep in every preference the user ever expressed.

Enforced by clearing the parent, not rejecting the document, so an accident costs the nesting and not the ontology. Applied *before* inheritance, so a wrongly-nested tier type doesn't pick up a domain type's fields on the way through. The panel says what happened.

## §10.2 — warn, never rewrite

An awkward name gets an advisory beside the type it describes. **Warn-only is the decision, not a first step toward normalising:** a name is part of a stored fact's key, so rewriting `Notes on naming` into `notes-on-naming` after facts exist under the old spelling splits the type in half. The cost of a bad name is friction inside a prompt, not corruption. The seed is deliberately quiet — a warning on a name nobody can edit is noise.

## Tested

`go test ./...` clean, `npx tsc --noEmit` clean, `make build-ui` builds.

New: `TestEnforcePinnedRoots_TierTypesCannotBeNestedButCanBeSubclassed`, `TestEffectiveOntology_PinnedRootIsEnforcedBeforeInheritance`, `TestOntologyNameIssue_WarnsWithoutRewriting`, `TestMatchExpected_TypeIsAHardFilter`, `TestHierarchyFixture_IsWhereTheOptionalAbilityIsActuallyMeasured`, `TestExpandEvalPlaceholders_{SlashDeclaresASubclass,RefusesAMalformedPath,SeedOnlyPromptStillMatchesTheRecordedBaseline}`.

Verified by rendering the panel against a local build: both notes appear, `preference` sits back at the top level, and the name advisory shows beside its type. Screenshot in the conversation.

One structural change to flag: ability coverage moved out of `ExtractionCorpus.Validate()`. "Every ability is covered" is a property of the corpus we *ship*, not of every corpus runnable — enforcing it there refused the purpose-built narrow one. It now lives on the shipped fixture, where a dedicated test already asserted it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8