### PR TITLE
fix(webui): make the ontology actually editable — nesting, and a link that works

### DIFF
--- a/packages/explorer/src/components/DocumentViewerBody.tsx
+++ b/packages/explorer/src/components/DocumentViewerBody.tsx
@@ -417,6 +417,35 @@ export default function DocumentViewerBody({
     }
   }, [data, documentId, scope, browse, selectedId, selectedIsRoot, rootChunkId, refresh]);
 
+  // "+ child": a chunk NESTED UNDER the selected one.
+  //
+  // The viewer had no way to do this. "+ text" inserts a SIBLING (after_id), which is
+  // right for prose flow and wrong for structure — so a document's hierarchy could only
+  // ever be created by import_md or by an agent, and every attempt to nest something
+  // through the UI silently produced a sibling instead. That made the ontology's
+  // subclasses (a child chunk is a subclass) unauthorable by the operator who owns them:
+  // selecting `project` and adding a type put it BESIDE project, at the top level.
+  //
+  // Passing parent_id with no after_id appends it as the selection's last child.
+  const addChild = useCallback(async () => {
+    if (!data.documentCreateChunk || !selectedId) return;
+    setErr(null);
+    try {
+      const created = await data.documentCreateChunk(
+        documentId,
+        selectedId,
+        { title: "Text", body: "" },
+        scope,
+        browse,
+      );
+      refresh();
+      setSelectedId(created.id);
+      setEditing(created);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    }
+  }, [data, documentId, scope, browse, selectedId, refresh]);
+
   // RFC BP — the selected chunk's siblings (same parent) in position order, to
   // gate the up/down buttons at the level boundaries.
   const siblingBounds = useMemo(() => {
@@ -500,9 +529,21 @@ export default function DocumentViewerBody({
               <button
                 type="button"
                 onClick={() => void addText()}
-                title="Add a text chunk after the selected chunk"
+                title="Add a text chunk AFTER the selected chunk, at the same level"
               >
                 + text
+              </button>
+              <button
+                type="button"
+                onClick={() => void addChild()}
+                disabled={!selectedId}
+                title={
+                  selectedId
+                    ? "Add a chunk NESTED UNDER the selected chunk (in the ontology, a child is a subclass)"
+                    : "Select a chunk first — this nests a new chunk under it"
+                }
+              >
+                + child
               </button>
               <button
                 type="button"

--- a/web/src/lib/ontologyEditHref.test.ts
+++ b/web/src/lib/ontologyEditHref.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { ontologyEditHref } from "./ontologyEditHref";
+
+describe("ontologyEditHref", () => {
+  // The regression. Without scope=tenant the viewer opens the tenant document at user
+  // scope, the read 422s, and the panel's edit affordance lands on an empty page with no
+  // create buttons — which is indistinguishable, to an operator, from "editing is not
+  // possible here".
+  it("carries scope=tenant, because the ontology is a tenant document", () => {
+    expect(ontologyEditHref("abc123")).toBe("/documents/abc123?scope=tenant");
+  });
+
+  it("escapes the id rather than interpolating it raw", () => {
+    expect(ontologyEditHref("a/b?c")).toBe("/documents/a%2Fb%3Fc?scope=tenant");
+  });
+});

--- a/web/src/lib/ontologyEditHref.ts
+++ b/web/src/lib/ontologyEditHref.ts
@@ -1,0 +1,14 @@
+// ontologyEditHref builds the Settings panel's "Edit ontology →" target.
+//
+// EXTRACTED BECAUSE THE MISSING PIECE WAS A QUERY PARAM, and a query param is exactly
+// what disappears in a template literal without anyone noticing. The panel linked to
+// `/documents/<id>` with no scope; the ontology lives at TENANT scope and the viewer
+// folds an absent scope to `user`, so the link opened the right document id in the wrong
+// store, the read 422'd, and the operator got "No chunks" and no create buttons. The
+// affordance existed and led nowhere — most of why the ontology UI was reported unusable.
+//
+// A function with a test, rather than an inline string, so the scope cannot be dropped
+// again silently.
+export function ontologyEditHref(documentId: string): string {
+  return `/documents/${encodeURIComponent(documentId)}?scope=tenant`;
+}

--- a/web/src/pages/SettingsView.tsx
+++ b/web/src/pages/SettingsView.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState, type FormEvent } from "react";
 import { Link } from "react-router-dom";
+import { ontologyEditHref } from "../lib/ontologyEditHref";
 import {
   CredentialMeta,
   CredentialScope,
@@ -613,10 +614,17 @@ function OntologySection() {
           Links by document_id when the API returned one (it is provisioned and
           the caller may read it); falls back to the Paths browser only when
           there is no id to address, which is the un-provisioned case the panel
-          already explains below. */}
+          already explains below.
+
+          ?scope=tenant IS LOAD-BEARING. The ontology lives at tenant scope, and
+          the viewer folds an absent scope to `user` — so without it this link
+          opened the right document id in the wrong store, the read 422'd, and the
+          operator got "No chunks" and no create buttons. The affordance existed
+          and led nowhere, which is most of why the ontology UI was reported
+          unusable. */}
       <p className="settings-help">
         {state?.document_id ? (
-          <Link className="settings-action-link" to={`/documents/${state.document_id}`}>
+          <Link className="settings-action-link" to={ontologyEditHref(state.document_id)}>
             Edit ontology →
           </Link>
         ) : (
@@ -648,6 +656,14 @@ function OntologySection() {
           copy. <code>preference</code> and <code>fact</code> are the memory tier's
           own types and always stay top-level: you may nest types <em>under</em> them,
           but not them under something else.
+        </p>
+        <p>
+          <strong>In the editor:</strong> select the type you want to extend, then
+          use <strong>+ child</strong> to nest a subtype under it (<strong>+ text</strong>{" "}
+          adds a sibling at the same level instead). Rename it in the dialog that
+          opens — a type's name is its heading — and list its own fields as
+          backticked bullets in the body. Changes take effect on the next run once
+          the document is confirmed.
         </p>
       </details>
 


### PR DESCRIPTION
## Why

You reported the ontology UI as unusable: entities can't be manipulated, and adding a sub-item to a type lands it in the document rather than under the type. Both are real. Between them they made RFC BZ's premise — *a child chunk is a subclass* — unauthorable by the person who owns the taxonomy.

I shipped four phases of that feature and never walked the path an operator walks. Doing it once found both bugs in about ten minutes.

## Bug 1 — the viewer could not nest anything, anywhere

`+ text` inserts a **sibling** (`after_id`), which is right for prose flow and wrong for structure. So the only ways a hierarchy could ever be created were `import_md` or an agent. Selecting `project` and adding a type put it **beside** project at the top level — exactly what you saw.

There is now a **`+ child`** action that passes `parent_id`, appending the new chunk under the selection, with the editor opening on it so it can be renamed immediately (a type's name is its heading). `+ text` keeps its sibling behaviour, and the tooltips now say which is which.

## Bug 2 — the panel's "Edit ontology →" link never worked

It pointed at `/documents/<id>` with **no scope**. The ontology lives at *tenant* scope and the viewer folds an absent scope to `user`, so the link opened the right document id in the wrong store, the read `422`'d, and the page showed **"No chunks" with no create buttons at all**.

That is the larger half of "unusable": an affordance that lands on an empty page is indistinguishable from "editing is not possible here". I added that link in #976 and never followed it.

The URL is now built by a small tested helper rather than an inline template literal, because a dropped query param is exactly what nobody notices in a string.

## Verified by walking it, not by reasoning about it

Against a local build, in a browser, the whole path: Settings → Ontology → **Edit ontology** → select `project` → **+ child** → name it `research` → save.

```
(root) → project             declared [name, status, repository, owner]
project → research           declared [question, outcome]  inherited [name, status, repository, owner]
```

Your exact scenario. The panel now also spells out those steps — "select a type, then + child" is not guessable.

I also audited the rest: this was the **only** `/documents/` deep link in the codebase, so no other surface carried the same missing scope.

## Tested

`go test ./...` clean (unchanged), `npx tsc --noEmit` clean for both `web` and `packages/explorer`, `npm test` in web green (40 tests, including the two new href assertions — one pins `scope=tenant`, the other that the id is escaped rather than interpolated raw).

## Two things I did not do, deliberately

**The panel is still read-only** — no add/rename/delete of entities in Settings itself. With both bugs fixed the intended flow works, and building a second chunk editor inside the settings panel would duplicate the document editor (fields, bodies, reordering, history). If you'd rather manipulate the taxonomy without leaving the panel, say so and I'll add per-entity `+ subtype` / rename / delete there as a follow-up — it's a contained change now that the underlying ops are proven.

**`@loomcycle/explorer` is not version-bumped.** The Web UI consumes the package source through a Vite alias, so it gets `+ child` from this PR alone; external consumers of the published `0.6.0` won't until it's tagged. Bumping without tagging is what stranded the TS adapter earlier, so I left the version alone — tell me if you want `explorer-v0.7.0` cut and I'll do the bump and tag together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8