### PR TITLE
feat(ontology): proposals that are inert, and adopt-a-standard-type (RFC CA P1)

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -625,7 +625,12 @@ func requiredScopeFor(method, path string) string {
 	// token can already write the same root-chunk status through /v1/_document
 	// update_chunk — so gating the write harder here would deny the intended actor
 	// without closing anything. ScopeAdmin also satisfies it (+ ?tenant= focus).
-	case path == "/v1/_ontology":
+	// RFC CA: /proposals (accept/reject) and /adopt sit with it. Same reasoning — one
+	// document per tenant, the tenant derived from the principal and never the wire —
+	// and both are strictly NARROWER than what this token can already do through
+	// /v1/_document, which is the point of having them as dedicated ops.
+	case path == "/v1/_ontology" ||
+		path == "/v1/_ontology/proposals" || path == "/v1/_ontology/adopt":
 		return auth.ScopeTenant
 	// RFC AS: the Web UI schedules surface (list-all + per-def state / run-now /
 	// pause / resume). list-all is tenant-scoped (the handler filters substrate

--- a/internal/api/http/ontology_admin.go
+++ b/internal/api/http/ontology_admin.go
@@ -72,6 +72,16 @@ type ontologyResponse struct {
 	// Surfaced rather than logged because the consequence lands on the operator's
 	// data, not on the server.
 	Notes []string `json:"notes,omitempty"`
+	// Proposals are entities present in the document but NOT in force — a curator's
+	// suggestions and the operator's rejections (RFC CA). Reported from the same read
+	// that produced Terms, so the two cannot disagree.
+	Proposals []meminject.OntologyProposal `json:"proposals,omitempty"`
+	// Adoptable names the standard types this document does not declare — the ones the
+	// adopt action can copy in. Computed server-side because the answer is "in the
+	// effective set and not in the document", which the UI would otherwise re-derive
+	// from two lists and get subtly wrong (a tenant term that overrides a standard name
+	// is NOT adoptable).
+	Adoptable []string `json:"adoptable,omitempty"`
 }
 
 // handleOntology serves GET /v1/_ontology — the tenant ontology's state.
@@ -137,7 +147,7 @@ func (s *Server) handleOntologySetStatus(w http.ResponseWriter, r *http.Request)
 		writeJSONError(w, http.StatusServiceUnavailable, "ontology_unavailable", err.Error())
 		return
 	}
-	rev, err := s.ontologyRootRevision(dctx, doc, rootID)
+	rev, err := s.ontologyChunkRevision(dctx, doc, rootID)
 	if err != nil {
 		writeJSONError(w, http.StatusServiceUnavailable, "ontology_unavailable", err.Error())
 		return
@@ -190,6 +200,9 @@ func (s *Server) ontologyState(ctx context.Context, tenant string) (ontologyResp
 
 	doc := &builtin.Document{Store: s.store, SqlMem: s.sqlMem}
 	dctx := s.ontologyDocCtx(ctx, mi)
+	if read, rerr := doc.OntologyTermsFromTree(dctx, "tenant", meminject.OntologyPath); rerr == nil {
+		resp.Proposals = read.Proposals
+	}
 	rootID, docID, status, err := s.ontologyRoot(dctx, doc)
 	if err == nil {
 		resp.Provisioned = true
@@ -221,6 +234,18 @@ func (s *Server) ontologyState(ctx context.Context, tenant string) (ontologyResp
 	}
 	resp.Confirmed = confirmed
 	resp.Notes = notes
+	// A standard type is adoptable when the document does not already declare it. A
+	// tenant term that overrides a standard name is a declaration, so it drops out here
+	// — offering "adopt" for a type the operator already owns would be a no-op button.
+	declared := make(map[string]bool, len(terms))
+	for _, t := range terms {
+		declared[strings.ToLower(t.Name)] = true
+	}
+	for _, t := range meminject.BaseSeedOntology() {
+		if !declared[strings.ToLower(t.Name)] {
+			resp.Adoptable = append(resp.Adoptable, t.Name)
+		}
+	}
 	resp.Effective = meminject.EffectiveOntology(terms, confirmed)
 	return resp, nil
 }
@@ -266,11 +291,11 @@ func (s *Server) ontologyRoot(dctx context.Context, doc *builtin.Document) (root
 	return meta.RootChunkID, meta.DocumentID, meta.Status, nil
 }
 
-// ontologyRootRevision reads the root chunk's current revision for the
+// ontologyChunkRevision reads a chunk's current revision for the
 // optimistic-concurrency guard on update_chunk.
-func (s *Server) ontologyRootRevision(dctx context.Context, doc *builtin.Document, rootID string) (int, error) {
+func (s *Server) ontologyChunkRevision(dctx context.Context, doc *builtin.Document, chunkID string) (int, error) {
 	req, _ := json.Marshal(map[string]any{
-		"op": "get_chunk", "scope": "tenant", "id": rootID,
+		"op": "get_chunk", "scope": "tenant", "id": chunkID,
 	})
 	res, err := doc.Execute(dctx, req)
 	if err != nil {

--- a/internal/api/http/ontology_admin_test.go
+++ b/internal/api/http/ontology_admin_test.go
@@ -313,3 +313,282 @@ func termNames(terms []meminject.OntologyTerm) []string {
 	}
 	return out
 }
+
+// postOntologyJSON drives one of the RFC CA operator actions.
+func (s *Server) postOntologyJSON(t *testing.T, path, tenant string, payload any, wantCode int) ontologyResponse {
+	t.Helper()
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest(http.MethodPost, path+"?tenant="+tenant, strings.NewReader(string(body)))
+	rec := httptest.NewRecorder()
+	switch path {
+	case "/v1/_ontology/proposals":
+		s.handleOntologyProposal(rec, req)
+	case "/v1/_ontology/adopt":
+		s.handleOntologyAdopt(rec, req)
+	default:
+		t.Fatalf("unknown path %q", path)
+	}
+	if rec.Code != wantCode {
+		t.Fatalf("POST %s %v = %d, want %d: %s", path, payload, rec.Code, wantCode, rec.Body.String())
+	}
+	var got ontologyResponse
+	if wantCode == http.StatusOK {
+		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decode: %v (%s)", err, rec.Body.String())
+		}
+	}
+	return got
+}
+
+// TestOntologyAdopt_CopiesTheStandardTypeWithItsFieldsAndProvenance (RFC CA §3).
+//
+// The transcription this removes is the point: the operator had to read the field names
+// off the panel and retype them to override a standard type. The fields therefore come
+// from the seed SERVER-SIDE — a client-supplied list could disagree with the type it
+// claims to copy, and the disagreement would be invisible in the document.
+func TestOntologyAdopt_CopiesTheStandardTypeWithItsFieldsAndProvenance(t *testing.T) {
+	s, mi := ontologyFixture(t)
+	s.buildVersion = "v9.9.9"
+	s.applyMemoryInjection(context.Background(), config.AgentDef{SystemPrompt: "{{memory:ontology}}"}, mi)
+
+	before := s.ontologyStateOrFail(t, mi.Tenant)
+	if !containsName(before.Adoptable, "event") {
+		t.Fatalf("a standard type the document does not declare must be adoptable: %v", before.Adoptable)
+	}
+
+	after := s.postOntologyJSON(t, "/v1/_ontology/adopt", mi.Tenant, map[string]string{"name": "event"}, http.StatusOK)
+
+	var adopted *meminject.OntologyTerm
+	for i := range after.Terms {
+		if after.Terms[i].Name == "event" {
+			adopted = &after.Terms[i]
+		}
+	}
+	if adopted == nil {
+		names := []string{}
+		for _, tm := range after.Terms {
+			names = append(names, tm.Name)
+		}
+		t.Fatalf("event was not adopted into the document — have %v", names)
+	}
+	// The seed's fields, not an empty shell the operator still has to fill in.
+	var seed meminject.OntologyTerm
+	for _, tm := range meminject.BaseSeedOntology() {
+		if tm.Name == "event" {
+			seed = tm
+		}
+	}
+	if len(seed.Fields) == 0 {
+		t.Fatal("the seed `event` has no fields — this test would be vacuous")
+	}
+	if strings.Join(adopted.Fields, ",") != strings.Join(seed.Fields, ",") {
+		t.Errorf("adopted fields %v, want the seed's %v", adopted.Fields, seed.Fields)
+	}
+	// It is a ROOT, so the operator can nest beneath it — the whole reason to adopt.
+	if adopted.Parent != "" {
+		t.Errorf("an adopted type must be a root, got parent %q", adopted.Parent)
+	}
+	// And it is no longer offered for adoption.
+	if containsName(after.Adoptable, "event") {
+		t.Errorf("event is still adoptable after being adopted: %v", after.Adoptable)
+	}
+	// PROVENANCE (§8.3) is in the chunk's structured fields, not its body — asserted by
+	// reading the column, because the response deliberately does not carry it and a claim
+	// nothing checks is a claim that quietly stops being true. Without this, §3.2's freeze
+	// (an adopted type never sees a later seed field) is undiscoverable after the fact.
+	doc := &builtin.Document{Store: s.store, SqlMem: s.sqlMem}
+	dctx := s.ontologyDocCtx(context.Background(), mi)
+	// The fields JSON travels with the BODY in the k/v plane, not in a SQL column, so
+	// get_chunk is where it surfaces.
+	q, _ := json.Marshal(map[string]any{
+		"op": "query_chunks", "scope": "tenant",
+		"sql": "SELECT id FROM chunks WHERE title = 'event' LIMIT 1",
+	})
+	qres, qerr := doc.Execute(dctx, q)
+	if qerr != nil || qres.IsError {
+		t.Fatalf("locate the adopted chunk: %v %s", qerr, qres.Text)
+	}
+	var qout struct {
+		Rows [][]any `json:"rows"`
+	}
+	if err := json.Unmarshal([]byte(qres.Text), &qout); err != nil || len(qout.Rows) == 0 {
+		t.Fatalf("no adopted chunk row: %v %s", err, qres.Text)
+	}
+	adoptedID, _ := qout.Rows[0][0].(string)
+	g, _ := json.Marshal(map[string]any{"op": "get_chunk", "scope": "tenant", "id": adoptedID})
+	gres, gerr := doc.Execute(dctx, g)
+	if gerr != nil || gres.IsError {
+		t.Fatalf("get_chunk: %v %s", gerr, gres.Text)
+	}
+	var chunk struct {
+		Fields map[string]any `json:"fields"`
+	}
+	if err := json.Unmarshal([]byte(gres.Text), &chunk); err != nil {
+		t.Fatalf("decode chunk: %v (%s)", err, gres.Text)
+	}
+	prov := chunk.Fields
+	if prov == nil {
+		t.Fatalf("the adopted chunk carries no provenance fields: %s", gres.Text)
+	}
+	if prov["adopted_from"] != "event" || prov["adopted_from_source"] != "base" {
+		t.Errorf("provenance = %v, want it to name what was copied and from where", prov)
+	}
+	if prov["adopted_at_version"] != "v9.9.9" {
+		t.Errorf("provenance version = %v, want the running build's", prov["adopted_at_version"])
+	}
+	// And the body stays the OPERATOR'S — the machine-written note must not be a field
+	// bullet, or it would parse as one.
+	if strings.Contains(strings.Join(adopted.Fields, ","), "Adopted") {
+		t.Errorf("the provenance note leaked into the parsed fields: %v", adopted.Fields)
+	}
+
+	// Adopting twice must not silently produce two `event` sections.
+	s.postOntologyJSON(t, "/v1/_ontology/adopt", mi.Tenant, map[string]string{"name": "event"}, http.StatusConflict)
+	// A name that is not a standard type is refused rather than invented.
+	s.postOntologyJSON(t, "/v1/_ontology/adopt", mi.Tenant, map[string]string{"name": "nonesuch"}, http.StatusBadRequest)
+}
+
+// TestOntologyProposal_AcceptPutsItInForceInPlace_RejectKeepsATombstone (RFC CA §2.3, §8.1).
+func TestOntologyProposal_AcceptPutsItInForceInPlace_RejectKeepsATombstone(t *testing.T) {
+	s, mi := ontologyFixture(t)
+	s.applyMemoryInjection(context.Background(), config.AgentDef{SystemPrompt: "{{memory:ontology}}"}, mi)
+	doc := &builtin.Document{Store: s.store, SqlMem: s.sqlMem}
+	dctx := s.ontologyDocCtx(context.Background(), mi)
+
+	// A proposal nested under the template's `incident`, as a curator would file it.
+	q, _ := json.Marshal(map[string]any{
+		"op": "query_chunks", "scope": "tenant",
+		"sql": "SELECT id, document_id FROM chunks WHERE title = 'incident' LIMIT 1",
+	})
+	qres, _ := doc.Execute(dctx, q)
+	var qout struct {
+		Rows [][]any `json:"rows"`
+	}
+	if err := json.Unmarshal([]byte(qres.Text), &qout); err != nil || len(qout.Rows) == 0 {
+		t.Fatalf("no incident chunk: %v %s", err, qres.Text)
+	}
+	parentID, docID := qout.Rows[0][0].(string), qout.Rows[0][1].(string)
+	mkProposal := func(title string) string {
+		c, _ := json.Marshal(map[string]any{
+			"op": "create_chunk", "scope": "tenant", "document_id": docID, "parent_id": parentID,
+			"title": title, "status": meminject.OntologyStatusProposed,
+			"body": "- `severity_scale`\n\nSeen 9 times.\n",
+		})
+		res, err := doc.Execute(dctx, c)
+		if err != nil || res.IsError {
+			t.Fatalf("create proposal: %v %s", err, res.Text)
+		}
+		var out map[string]any
+		_ = json.Unmarshal([]byte(res.Text), &out)
+		id, _ := out["id"].(string)
+		return id
+	}
+	acceptID, rejectID := mkProposal("sev1-incident"), mkProposal("bogus-incident")
+
+	state := s.ontologyStateOrFail(t, mi.Tenant)
+	if len(state.Proposals) != 2 {
+		t.Fatalf("want both proposals reported, got %+v", state.Proposals)
+	}
+	for _, tm := range state.Terms {
+		if tm.Name == "sev1-incident" {
+			t.Fatal("a proposal was in force before it was accepted")
+		}
+	}
+
+	// ACCEPT: in force, in place — still under `incident`, nothing moved.
+	after := s.postOntologyJSON(t, "/v1/_ontology/proposals", mi.Tenant,
+		map[string]string{"chunk_id": acceptID, "action": "accept"}, http.StatusOK)
+	var accepted *meminject.OntologyTerm
+	for i := range after.Terms {
+		if after.Terms[i].Name == "sev1-incident" {
+			accepted = &after.Terms[i]
+		}
+	}
+	if accepted == nil {
+		t.Fatalf("accepting did not put the entity in force: %+v", after.Terms)
+	}
+	if accepted.Parent != "incident" {
+		t.Errorf("accepted.Parent = %q — accepting must not move the entity", accepted.Parent)
+	}
+	if len(accepted.Inherited) == 0 {
+		t.Error("an accepted subclass should inherit its parent's fields like any other")
+	}
+
+	// REJECT: kept as a tombstone, not deleted, so a curator stops re-proposing it.
+	after = s.postOntologyJSON(t, "/v1/_ontology/proposals", mi.Tenant,
+		map[string]string{"chunk_id": rejectID, "action": "reject"}, http.StatusOK)
+	var tomb *meminject.OntologyProposal
+	for i := range after.Proposals {
+		if after.Proposals[i].ChunkID == rejectID {
+			tomb = &after.Proposals[i]
+		}
+	}
+	if tomb == nil || tomb.Status != meminject.OntologyStatusRejected {
+		t.Errorf("a rejection must survive as a tombstone, got %+v", after.Proposals)
+	}
+	for _, tm := range after.Terms {
+		if tm.Name == "bogus-incident" {
+			t.Error("a rejected entity reached the in-force set")
+		}
+	}
+	// Accepting a rejection is a conflict, not a silent un-reject.
+	s.postOntologyJSON(t, "/v1/_ontology/proposals", mi.Tenant,
+		map[string]string{"chunk_id": rejectID, "action": "accept"}, http.StatusConflict)
+}
+
+// TestOntologyProposal_RefusesAChunkThatIsNotAProposal is the narrowing (RFC CA §8.2).
+//
+// The route must not be usable as a general status-writer: accepting is meant to be a
+// strictly smaller capability than writing the document. A live entity's id, and the
+// document ROOT's id (whose status is the confirm gate itself), must both be refused —
+// otherwise "accept a proposal" could confirm the whole ontology.
+func TestOntologyProposal_RefusesAChunkThatIsNotAProposal(t *testing.T) {
+	s, mi := ontologyFixture(t)
+	s.applyMemoryInjection(context.Background(), config.AgentDef{SystemPrompt: "{{memory:ontology}}"}, mi)
+	state := s.ontologyStateOrFail(t, mi.Tenant)
+
+	doc := &builtin.Document{Store: s.store, SqlMem: s.sqlMem}
+	dctx := s.ontologyDocCtx(context.Background(), mi)
+	q, _ := json.Marshal(map[string]any{
+		"op": "query_chunks", "scope": "tenant",
+		"sql": "SELECT id FROM chunks WHERE title = 'project' LIMIT 1",
+	})
+	qres, _ := doc.Execute(dctx, q)
+	var qout struct {
+		Rows [][]any `json:"rows"`
+	}
+	_ = json.Unmarshal([]byte(qres.Text), &qout)
+	if len(qout.Rows) == 0 {
+		t.Fatal("no live `project` chunk to try")
+	}
+	liveID := qout.Rows[0][0].(string)
+
+	for _, id := range []string{liveID, state.RootChunkID, "no-such-chunk"} {
+		s.postOntologyJSON(t, "/v1/_ontology/proposals", mi.Tenant,
+			map[string]string{"chunk_id": id, "action": "accept"}, http.StatusNotFound)
+	}
+	// The confirm gate is untouched by the attempt on the root.
+	if got := s.ontologyStateOrFail(t, mi.Tenant); got.Status != state.Status {
+		t.Errorf("the document status changed from %q to %q", state.Status, got.Status)
+	}
+}
+
+// containsName is a local helper — the package already has a containsString.
+func containsName(hay []string, needle string) bool {
+	for _, h := range hay {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// ontologyStateOrFail reads the state directly, without going through a mutation.
+func (s *Server) ontologyStateOrFail(t *testing.T, tenant string) ontologyResponse {
+	t.Helper()
+	resp, err := s.ontologyState(context.Background(), tenant)
+	if err != nil {
+		t.Fatalf("ontologyState: %v", err)
+	}
+	return resp
+}

--- a/internal/api/http/ontology_proposals.go
+++ b/internal/api/http/ontology_proposals.go
@@ -1,0 +1,261 @@
+package http
+
+// ontology_proposals.go — the two operator actions RFC CA phase 1 adds: resolve a
+// proposal, and adopt a type that is in force but not in the document.
+//
+// BOTH ARE DEDICATED OPERATIONS RATHER THAN DOCUMENT WRITES, and that is the decision
+// worth stating. Every effect here is reachable through the generic /v1/_document route
+// by a caller who knows the chunk shape — clear a status, create a chunk with the right
+// bullets. What these buy is that the operation cannot produce a state the reader
+// silently ignores:
+//
+//   - resolving a proposal accepts only `accept`/`reject`, only on a chunk that is
+//     actually a proposal, and only in the tenant's own ontology document;
+//   - adopting copies the fields from the EFFECTIVE ontology server-side, so an adopted
+//     type cannot drift from the standard one it claims to override, and it records what
+//     it was copied from.
+//
+// The narrowing is the same argument the draft↔confirmed flip already makes: a
+// free-form status write exists elsewhere, and the value of this route is that it
+// cannot spell the status wrong.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	meminject "github.com/denn-gubsky/loomcycle/internal/memory"
+	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
+)
+
+// handleOntologyProposal serves POST /v1/_ontology/proposals — accept or reject one.
+//
+// Accepting CLEARS the status, which puts the entity in force exactly where it already
+// sits in the tree; nothing moves, because a proposal is the entity switched off rather
+// than a copy waiting to be transcribed. Rejecting sets `rejected` and keeps the chunk
+// as a tombstone, so a curator can read it and stop re-proposing what was turned down.
+func (s *Server) handleOntologyProposal(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		ChunkID string `json:"chunk_id"`
+		Action  string `json:"action"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4<<10)).Decode(&body); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_body",
+			"expected {\"chunk_id\": \"…\", \"action\": \"accept\"|\"reject\"}")
+		return
+	}
+	action := strings.ToLower(strings.TrimSpace(body.Action))
+	if action != "accept" && action != "reject" {
+		writeJSONError(w, http.StatusBadRequest, "invalid_action", "action must be \"accept\" or \"reject\"")
+		return
+	}
+	chunkID := strings.TrimSpace(body.ChunkID)
+	if chunkID == "" {
+		writeJSONError(w, http.StatusBadRequest, "invalid_body", "chunk_id is required")
+		return
+	}
+
+	tenant, _ := s.principalTenantScope(r.Context(), r.URL.Query().Get("tenant"))
+	if s.store == nil || s.sqlMem == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "ontology_unavailable",
+			"the ontology needs SQL Memory; none is configured")
+		return
+	}
+	mi := memInject{Tenant: tenant}
+	s.ensureOntologyDoc(r.Context(), mi)
+	doc := &builtin.Document{Store: s.store, SqlMem: s.sqlMem}
+	dctx := s.ontologyDocCtx(r.Context(), mi)
+
+	read, err := doc.OntologyTermsFromTree(dctx, "tenant", meminject.OntologyPath)
+	if err != nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "ontology_unavailable", err.Error())
+		return
+	}
+	// The chunk must be a PROPOSAL IN THIS TENANT'S ontology. Both halves matter: the
+	// first stops this route becoming a general status-writer, and the second stops it
+	// becoming a way to reach another tenant's chunk by id. A miss is an opaque 404 —
+	// "not a proposal here" and "does not exist" are the same answer to a caller who
+	// should not be able to tell them apart.
+	var target *meminject.OntologyProposal
+	for i := range read.Proposals {
+		if read.Proposals[i].ChunkID == chunkID {
+			target = &read.Proposals[i]
+			break
+		}
+	}
+	if target == nil {
+		writeJSONError(w, http.StatusNotFound, "not_a_proposal",
+			"no proposal with that chunk_id in this tenant's ontology")
+		return
+	}
+	if action == "accept" && target.Status != meminject.OntologyStatusProposed {
+		// Re-accepting a rejection would be a silent un-reject. Say what state it is in.
+		writeJSONError(w, http.StatusConflict, "not_pending",
+			fmt.Sprintf("that entity is %q, not %q — clear its status in the document editor if you meant to restore it",
+				target.Status, meminject.OntologyStatusProposed))
+		return
+	}
+
+	newStatus := meminject.OntologyStatusRejected
+	if action == "accept" {
+		newStatus = "" // in force, in place
+	}
+	if err := s.setOntologyChunkStatus(dctx, doc, chunkID, newStatus); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "ontology_write_failed", err.Error())
+		return
+	}
+	s.writeOntologyState(w, r.Context(), tenant)
+}
+
+// handleOntologyAdopt serves POST /v1/_ontology/adopt — take a copy of a standard type
+// into the document so it can be extended or subclassed.
+//
+// The transcription this removes is the whole reason it exists: the documented way to
+// subclass a standard type is to declare it yourself (which overrides the standard one
+// by name) and nest beneath your copy — which meant reading four field names off the
+// panel and retyping them, correctly, by hand.
+func (s *Server) handleOntologyAdopt(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4<<10)).Decode(&body); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_body", "expected {\"name\": \"event\"}")
+		return
+	}
+	name := strings.TrimSpace(body.Name)
+	if name == "" {
+		writeJSONError(w, http.StatusBadRequest, "invalid_body", "name is required")
+		return
+	}
+
+	tenant, _ := s.principalTenantScope(r.Context(), r.URL.Query().Get("tenant"))
+	if s.store == nil || s.sqlMem == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "ontology_unavailable",
+			"the ontology needs SQL Memory; none is configured")
+		return
+	}
+	mi := memInject{Tenant: tenant}
+	s.ensureOntologyDoc(r.Context(), mi)
+	doc := &builtin.Document{Store: s.store, SqlMem: s.sqlMem}
+	dctx := s.ontologyDocCtx(r.Context(), mi)
+
+	// The FIELDS come from the base seed, resolved here rather than sent by the caller.
+	// A client-supplied field list could disagree with the type it claims to be a copy
+	// of, and the disagreement would be invisible: the document would look like an
+	// override of `event` while declaring something else.
+	var source *meminject.OntologyTerm
+	for _, t := range meminject.BaseSeedOntology() {
+		if strings.EqualFold(t.Name, name) {
+			term := t
+			source = &term
+			break
+		}
+	}
+	if source == nil {
+		writeJSONError(w, http.StatusBadRequest, "not_a_standard_type",
+			"only a standard type can be adopted — this one is not in the base set, so it is "+
+				"already yours to edit in the document")
+		return
+	}
+
+	read, err := doc.OntologyTermsFromTree(dctx, "tenant", meminject.OntologyPath)
+	if err != nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "ontology_unavailable", err.Error())
+		return
+	}
+	for _, t := range read.Terms {
+		if strings.EqualFold(t.Name, source.Name) {
+			writeJSONError(w, http.StatusConflict, "already_declared",
+				"your document already declares that type — edit it in the document instead")
+			return
+		}
+	}
+	if read.RootChunkID == "" {
+		writeJSONError(w, http.StatusServiceUnavailable, "ontology_unavailable",
+			"the ontology document has no root chunk")
+		return
+	}
+
+	// PROVENANCE goes in the chunk's structured fields, never the body (RFC CA §8.3).
+	// The body is parsed for the entity's field bullets and belongs to the operator; a
+	// machine-written line in it would be indistinguishable from something they wrote.
+	//
+	// Recorded because adoption FREEZES this copy: an override replaces the standard
+	// term wholesale, so a field a later release adds to the standard `event` never
+	// reaches an operator who adopted it. Without provenance that is undiscoverable
+	// after the fact; with it, a future release can diff the frozen copy against the
+	// current seed and say so.
+	prov, _ := json.Marshal(map[string]any{
+		"adopted_from":        source.Name,
+		"adopted_from_source": "base",
+		"adopted_at_version":  s.buildVersion,
+	})
+	req, _ := json.Marshal(map[string]any{
+		"op": "create_chunk", "scope": "tenant",
+		"document_id": read.DocumentID, "parent_id": read.RootChunkID,
+		"title": source.Name, "body": adoptedBody(*source), "fields": json.RawMessage(prov),
+	})
+	if res, aerr := doc.Execute(dctx, req); aerr != nil || res.IsError {
+		msg := "adopt failed"
+		if aerr != nil {
+			msg = aerr.Error()
+		} else if res.Text != "" {
+			msg = res.Text
+		}
+		writeJSONError(w, http.StatusInternalServerError, "ontology_write_failed", msg)
+		return
+	}
+	s.writeOntologyState(w, r.Context(), tenant)
+}
+
+// adoptedBody renders a standard type's fields the way an operator would have typed
+// them, so the adopted chunk is an ordinary editable section and not a special case.
+func adoptedBody(t meminject.OntologyTerm) string {
+	var b strings.Builder
+	b.WriteString("Adopted from the standard types so it can be extended or subclassed. " +
+		"Your copy now overrides the standard one, wholesale — edit the fields freely.\n\n")
+	for _, f := range meminject.AllFields(t) {
+		b.WriteString("- `" + f + "`\n")
+	}
+	return b.String()
+}
+
+// setOntologyChunkStatus writes one chunk's status, reading its revision first.
+//
+// The revision is read here rather than accepted from the caller for the same reason the
+// confirm toggle reads it: a stale revision from a client would either fail confusingly
+// or, worse, be sent for the wrong chunk.
+func (s *Server) setOntologyChunkStatus(dctx context.Context, doc *builtin.Document, chunkID, status string) error {
+	rev, err := s.ontologyChunkRevision(dctx, doc, chunkID)
+	if err != nil {
+		return err
+	}
+	// Status ONLY — update_chunk is presence-based, so omitting body/fields leaves the
+	// operator's Markdown alone. Sending them would risk blanking an entity to flip a
+	// flag. An empty status is what "in force" looks like, so it is written explicitly.
+	patch, _ := json.Marshal(map[string]any{
+		"op": "update_chunk", "scope": "tenant", "id": chunkID,
+		"status": status, "revision": rev,
+	})
+	res, err := doc.Execute(dctx, patch)
+	if err != nil {
+		return err
+	}
+	if res.IsError {
+		return fmt.Errorf("%s", res.Text)
+	}
+	return nil
+}
+
+// writeOntologyState re-reads and returns the whole state after a mutation, so the
+// response shows the EFFECTIVE result rather than the caller's assumption about it.
+func (s *Server) writeOntologyState(w http.ResponseWriter, ctx context.Context, tenant string) {
+	resp, err := s.ontologyState(ctx, tenant)
+	if err != nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "ontology_unavailable", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2742,6 +2742,10 @@ func (s *Server) Mux() http.Handler {
 	mux.Handle("POST /v1/_erasure", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleErasureExecute))))
 	mux.Handle("GET /v1/_ontology", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleOntology))))
 	mux.Handle("POST /v1/_ontology", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleOntologySetStatus))))
+	// RFC CA phase 1: resolve a proposal, and adopt a standard type into the document.
+	// Both are operator actions on the caller's own ontology, gated with the pair above.
+	mux.Handle("POST /v1/_ontology/proposals", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleOntologyProposal))))
+	mux.Handle("POST /v1/_ontology/adopt", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleOntologyAdopt))))
 	// RFC BK P3: resident interactive sub-agent visibility + operator control.
 	// GET lists (tenant-scoped); POST close/cancel act on one (tenant-gated).
 	// Per-replica (the resident registry is in-process). Scope-gated in

--- a/internal/memory/ontology.go
+++ b/internal/memory/ontology.go
@@ -436,6 +436,57 @@ func renderOntologyTree(terms []OntologyTerm) string {
 // precision. Nothing deeper is DISCARDED: the reader flattens it to the cap.
 const OntologyMaxDepth = 4
 
+// Inert entity statuses (RFC CA §2.1). A chunk carrying one of these is NOT an
+// entity: not returned, not rendered into the prompt, not expanded in retrieval.
+//
+// `rejected` is KEPT rather than deleted (§8.1) so a curator can read it as a
+// tombstone and stop re-proposing a type the operator already turned down. Nagging is
+// how a review surface stops being read.
+const (
+	OntologyStatusProposed = "proposed"
+	OntologyStatusRejected = "rejected"
+)
+
+// IsInertEntityStatus reports whether a chunk status takes the entity out of force.
+//
+// FAIL OPEN, and this is the load-bearing rule of RFC CA. ONLY the two reserved words
+// are inert; every other status — including one this build has never heard of — leaves
+// the entity in force.
+//
+// The tempting inverse ("anything other than blank or confirmed is inert") is a shorter
+// rule that would silently drop types from any document where an operator had used the
+// status field for their own purposes. That is exactly the failure the chunk-tree reader
+// was written to remove: a document that reads correctly and an ontology that does not
+// match it. A new gate must not be able to turn existing types off.
+func IsInertEntityStatus(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case OntologyStatusProposed, OntologyStatusRejected:
+		return true
+	default:
+		return false
+	}
+}
+
+// OntologyProposal is an entity that exists in the document but is not in force — a
+// curator's suggestion, or one the operator rejected.
+//
+// Carries its CHUNK ID, unlike OntologyTerm: accepting a proposal acts on the chunk, and
+// resolving a name back to a chunk at that point would be a second lookup that can
+// disagree with the one that produced the list.
+type OntologyProposal struct {
+	ChunkID string `json:"chunk_id"`
+	Name    string `json:"name"`
+	// Parent is the name of the nearest IN-FORCE ancestor — where this entity would
+	// attach if accepted, which is not always its literal parent chunk (an inert
+	// chunk between them is skipped).
+	Parent string   `json:"parent,omitempty"`
+	Fields []string `json:"fields,omitempty"`
+	Status string   `json:"status"`
+	// Body is the proposal's own text, which for a curator's proposal is its evidence.
+	// Surfaced so the operator judges a case rather than a bare suggestion.
+	Body string `json:"body,omitempty"`
+}
+
 // TrimOntologyName normalises a heading line or a chunk title into an entity name.
 //
 // ONE definition, shared by the chunk-tree reader (where the name comes from a title)

--- a/internal/tools/builtin/document_ontology.go
+++ b/internal/tools/builtin/document_ontology.go
@@ -40,6 +40,7 @@ type ontologyChunk struct {
 	parentID string
 	title    string
 	position int
+	status   string
 }
 
 // OntologyTermsFromTree reads the ontology document at the given path and returns its
@@ -70,6 +71,15 @@ func (d *Document) OntologyTermsFromTree(ctx context.Context, scope, path string
 type OntologyRead struct {
 	Terms     []memrank.OntologyTerm
 	Confirmed bool
+	// Proposals are the entities present but NOT in force — a curator's suggestions and
+	// the operator's rejections. Returned alongside the terms rather than through a
+	// second read, so the panel cannot show a proposal list that disagrees with the
+	// type list it sits next to.
+	Proposals []memrank.OntologyProposal
+	// DocumentID and RootChunkID let a caller act on what it just read (accept a
+	// proposal, adopt a type as a new root) without resolving the path again.
+	DocumentID  string
+	RootChunkID string
 	// DepthCapped is true when the document nests deeper than OntologyMaxDepth, so
 	// some types were flattened onto the cap rather than kept at their written depth.
 	//
@@ -113,19 +123,19 @@ func (d *Document) ontologyForKey(ctx context.Context, key sqlmem.ScopeKey, msco
 	confirmed := strings.EqualFold(strings.TrimSpace(status), memrank.OntologyConfirmedStatus)
 
 	res, err := d.query(ctx, key,
-		`SELECT id, coalesce(parent_id, ''), coalesce(title, ''), position
+		`SELECT id, coalesce(parent_id, ''), coalesce(title, ''), position, coalesce(status, '')
 		   FROM chunks WHERE document_id = ? ORDER BY position`, docID)
 	if err != nil {
 		return OntologyRead{Confirmed: confirmed}, err
 	}
 	kids := map[string][]ontologyChunk{}
 	for _, row := range res.Rows {
-		if len(row) < 4 {
+		if len(row) < 5 {
 			continue
 		}
 		c := ontologyChunk{
 			id: asStr(row[0]), parentID: asStr(row[1]),
-			title: asStr(row[2]), position: asInt(row[3]),
+			title: asStr(row[2]), position: asInt(row[3]), status: asStr(row[4]),
 		}
 		kids[c.parentID] = append(kids[c.parentID], c)
 	}
@@ -136,6 +146,7 @@ func (d *Document) ontologyForKey(ctx context.Context, key sqlmem.ScopeKey, msco
 	}
 
 	var out []memrank.OntologyTerm
+	var proposals []memrank.OntologyProposal
 	depthCapped := false
 	// The walk starts at the ROOT CHUNK'S CHILDREN: the root is the document's title
 	// ("Tenant Ontology"), not an entity. Including it would invent a type nobody
@@ -144,6 +155,24 @@ func (d *Document) ontologyForKey(ctx context.Context, key sqlmem.ScopeKey, msco
 	walk = func(parentChunkID, parentName string, depth int) {
 		for _, c := range kids[parentChunkID] {
 			name := d.ontologyEntityName(ctx, mscope, key, c)
+			// INERT: a proposal (or a rejected one) is in the document and not in force.
+			// Recorded so the operator can act on it, then skipped.
+			if memrank.IsInertEntityStatus(c.status) {
+				if name != "" {
+					body, _ := d.readBody(ctx, mscope, key.ScopeID, c.id)
+					proposals = append(proposals, memrank.OntologyProposal{
+						ChunkID: c.id, Name: name, Parent: parentName,
+						Fields: memrank.ParseOntologyFields(body.Body),
+						Status: strings.ToLower(strings.TrimSpace(c.status)),
+						Body:   body.Body,
+					})
+				}
+				// Its children keep walking against the nearest IN-FORCE ancestor, so
+				// rejecting a parent never silently switches off a live type beneath it.
+				// Turning types off is what this reader exists to prevent.
+				walk(c.id, parentName, depth)
+				continue
+			}
 			if name == "" {
 				// No title and no leading heading: nothing names this entity. Its
 				// children are still walked, attached to the nearest NAMED ancestor, so
@@ -173,7 +202,10 @@ func (d *Document) ontologyForKey(ctx context.Context, key sqlmem.ScopeKey, msco
 		}
 	}
 	walk(rootID, "", 1)
-	return OntologyRead{Terms: out, Confirmed: confirmed, DepthCapped: depthCapped}, nil
+	return OntologyRead{
+		Terms: out, Confirmed: confirmed, DepthCapped: depthCapped,
+		Proposals: proposals, DocumentID: docID, RootChunkID: rootID,
+	}, nil
 }
 
 // ontologyEntityName resolves an entity's name: the chunk's title, or — when the title

--- a/internal/tools/builtin/document_ontology_test.go
+++ b/internal/tools/builtin/document_ontology_test.go
@@ -531,3 +531,129 @@ func TestOntologyTree_ReportsThatItFlattenedTheDepth(t *testing.T) {
 		t.Errorf("want all five types, got %d", len(read.Terms))
 	}
 }
+
+// TestOntologyTree_ProposedIsNotInForceButIsReported (RFC CA §2.1).
+//
+// A proposal has to be BOTH invisible to the runtime and visible to the operator. Half of
+// that is easy to get and useless: a suggestion nothing reports is a suggestion nobody
+// acts on, and a suggestion that steers extraction is not a suggestion.
+func TestOntologyTree_ProposedIsNotInForceButIsReported(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	out, r := docExec(t, d, ctx,
+		`{"op":"create_document","scope":"user","title":"Tenant Ontology","body":""}`)
+	if r.IsError {
+		t.Fatalf("create_document: %s", r.Text)
+	}
+	docID, _ := out["document_id"].(string)
+	root, _ := out["root_chunk_id"].(string)
+	mk := func(title, status, body string) string {
+		bj, _ := json.Marshal(body)
+		res, rr := docExec(t, d, ctx, fmt.Sprintf(
+			`{"op":"create_chunk","scope":"user","document_id":"%s","parent_id":"%s","title":"%s","status":"%s","body":%s}`,
+			docID, root, title, status, string(bj)))
+		if rr.IsError {
+			t.Fatalf("create_chunk %s: %s", title, rr.Text)
+		}
+		id, _ := res["id"].(string)
+		return id
+	}
+	mk("event", "", "- `occurred_at`\n")
+	propID := mk("outage", "proposed", "- `minutes_down`\n\nSeen 12 times as an untyped fact.\n")
+	mk("wontfix", "rejected", "")
+	// An UNKNOWN status must stay in force — the fail-open rule.
+	mk("project", "wip", "- `status`\n")
+
+	path := "/test/ontology-proposals"
+	if _, r = docExec(t, d, ctx,
+		`{"op":"set_path","scope":"user","id":"`+docID+`","path":"`+path+`"}`); r.IsError {
+		t.Fatalf("set_path: %s", r.Text)
+	}
+	read, err := d.OntologyTermsFromTree(ctx, "user", path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	inForce := map[string]bool{}
+	for _, tm := range read.Terms {
+		inForce[tm.Name] = true
+	}
+	if inForce["outage"] || inForce["wontfix"] {
+		t.Errorf("an inert entity reached the in-force set: %v", inForce)
+	}
+	if !inForce["event"] {
+		t.Errorf("a live entity went missing: %v", inForce)
+	}
+	// THE FAIL-OPEN RULE. Only the two reserved words are inert; a status this build has
+	// never heard of must not be able to switch a type off.
+	if !inForce["project"] {
+		t.Error(`a chunk with status "wip" was dropped — only "proposed"/"rejected" are inert`)
+	}
+
+	byName := map[string]memrank.OntologyProposal{}
+	for _, p := range read.Proposals {
+		byName[p.Name] = p
+	}
+	if len(byName) != 2 {
+		t.Fatalf("want outage + wontfix reported, got %v", byName)
+	}
+	if got := byName["outage"]; got.ChunkID != propID || got.Status != "proposed" {
+		t.Errorf("outage proposal = %+v", got)
+	}
+	if len(byName["outage"].Fields) != 1 || byName["outage"].Fields[0] != "minutes_down" {
+		t.Errorf("a proposal must carry its own fields: %v", byName["outage"].Fields)
+	}
+	// The evidence has to survive to the operator, or they are judging a bare name.
+	if !strings.Contains(byName["outage"].Body, "12 times") {
+		t.Errorf("the proposal lost its evidence body: %q", byName["outage"].Body)
+	}
+	if byName["wontfix"].Status != "rejected" {
+		t.Errorf("a rejection must be reported as such (it is a tombstone): %+v", byName["wontfix"])
+	}
+}
+
+// TestOntologyTree_RejectingAParentDoesNotSwitchOffLiveChildren.
+//
+// Children of an inert chunk re-parent to the nearest IN-FORCE ancestor rather than
+// disappearing with it. Turning a live type off as a side effect of rejecting something
+// above it is exactly the silent loss this reader was written to end.
+func TestOntologyTree_RejectingAParentDoesNotSwitchOffLiveChildren(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	out, r := docExec(t, d, ctx,
+		`{"op":"create_document","scope":"user","title":"Tenant Ontology","body":""}`)
+	if r.IsError {
+		t.Fatalf("create_document: %s", r.Text)
+	}
+	docID, _ := out["document_id"].(string)
+	root, _ := out["root_chunk_id"].(string)
+	res, _ := docExec(t, d, ctx, fmt.Sprintf(
+		`{"op":"create_chunk","scope":"user","document_id":"%s","parent_id":"%s","title":"event","status":"rejected","body":""}`,
+		docID, root))
+	evID, _ := res["id"].(string)
+	if _, r = docExec(t, d, ctx, fmt.Sprintf(
+		`{"op":"create_chunk","scope":"user","document_id":"%s","parent_id":"%s","title":"incident","body":"- `+"`severity`"+`\n"}`,
+		docID, evID)); r.IsError {
+		t.Fatalf("create_chunk child: %s", r.Text)
+	}
+	path := "/test/ontology-reject-parent"
+	if _, r = docExec(t, d, ctx,
+		`{"op":"set_path","scope":"user","id":"`+docID+`","path":"`+path+`"}`); r.IsError {
+		t.Fatalf("set_path: %s", r.Text)
+	}
+
+	read, err := d.OntologyTermsFromTree(ctx, "user", path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var inc *memrank.OntologyTerm
+	for i := range read.Terms {
+		if read.Terms[i].Name == "incident" {
+			inc = &read.Terms[i]
+		}
+	}
+	if inc == nil {
+		t.Fatalf("the live child vanished with its rejected parent: %+v", read.Terms)
+	}
+	if inc.Parent != "" {
+		t.Errorf("incident.Parent = %q — it should attach to the nearest IN-FORCE ancestor (the root)", inc.Parent)
+	}
+}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -2722,6 +2722,18 @@ export interface OntologyTerm {
   name_issue?: string;
 }
 
+/** An entity present in the ontology document but NOT in force (RFC CA). */
+export interface OntologyProposal {
+  chunk_id: string;
+  name: string;
+  /** The name of the nearest in-force ancestor — where it would attach if accepted. */
+  parent?: string;
+  fields?: string[];
+  status: "proposed" | "rejected";
+  /** The proposal's own text; for a curator's proposal, its evidence. */
+  body?: string;
+}
+
 export interface OntologyResponse {
   tenant: string;
   path: string;
@@ -2743,6 +2755,32 @@ export interface OntologyResponse {
    * list because those are independent and more than one can hold at once.
    */
   notes?: string[];
+  /** Entities in the document that are not in force: suggestions and rejections. */
+  proposals?: OntologyProposal[];
+  /** Standard type names this document does not declare — what `adopt` can copy in. */
+  adoptable?: string[];
+}
+
+/** Accept (put in force, in place) or reject (keep as a tombstone) a proposal. */
+export function resolveOntologyProposal(
+  chunkId: string,
+  action: "accept" | "reject",
+  tenant?: string,
+): Promise<OntologyResponse> {
+  const q = tenant ? `?tenant=${encodeURIComponent(tenant)}` : "";
+  return postJSON<OntologyResponse>(
+    `/v1/_ontology/proposals${q}`,
+    JSON.stringify({ chunk_id: chunkId, action }),
+  );
+}
+
+/**
+ * Copy a standard type into the document so it can be extended or subclassed. The
+ * fields come from the seed server-side; the caller sends only the name.
+ */
+export function adoptOntologyType(name: string, tenant?: string): Promise<OntologyResponse> {
+  const q = tenant ? `?tenant=${encodeURIComponent(tenant)}` : "";
+  return postJSON<OntologyResponse>(`/v1/_ontology/adopt${q}`, JSON.stringify({ name }));
 }
 
 export function getOntology(tenant?: string): Promise<OntologyResponse> {

--- a/web/src/pages/SettingsView.tsx
+++ b/web/src/pages/SettingsView.tsx
@@ -6,9 +6,11 @@ import {
   CredentialScope,
   HealthResponse,
   MemoryOrphanReport,
+  OntologyProposal,
   OntologyResponse,
   PresetUnit,
   RuntimeStateResponse,
+  adoptOntologyType,
   createCredential,
   deleteCredential,
   getEnvTemplate,
@@ -20,6 +22,7 @@ import {
   pauseRuntime,
   repairTenantMemory,
   resumeRuntime,
+  resolveOntologyProposal,
   setOntologyStatus,
   showPreset,
   OntologyTerm,
@@ -572,6 +575,35 @@ function OntologySection() {
     load();
   }, [load]);
 
+  // RFC CA: accept puts the entity in force where it already sits; reject keeps it as a
+  // tombstone so a curator stops re-proposing it. Both re-read the whole state from the
+  // response, so the panel shows the effective result rather than an optimistic guess.
+  const resolveProposal = async (chunkId: string, action: "accept" | "reject") => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      setState(await resolveOntologyProposal(chunkId, action));
+      setErr(null);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const adopt = async (name: string) => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      setState(await adoptOntologyType(name));
+      setErr(null);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
   const flip = async (status: "confirmed" | "draft") => {
     if (busy) return;
     setBusy(true);
@@ -586,6 +618,12 @@ function OntologySection() {
   };
 
   const tenantTerms = state?.terms ?? [];
+  // Split by status rather than filtering twice at the render site: pending needs a
+  // decision, rejected is a record. Conflating them would put "reject" buttons next to
+  // things already rejected.
+  const allProposals: OntologyProposal[] = state?.proposals ?? [];
+  const pendingProposals = allProposals.filter((p) => p.status === "proposed");
+  const rejectedProposals = allProposals.filter((p) => p.status === "rejected");
   // A status that is neither of the two words the gate accepts — reachable by
   // editing the document's status field by hand. Called out explicitly, because
   // this is precisely the state that looks confirmed and behaves as draft.
@@ -722,6 +760,115 @@ function OntologySection() {
               differently-formatted document confirms to nothing. Nest a heading
               (<code>### name</code>) to make that type a <em>subclass</em> of the
               one above it.
+            </p>
+          )}
+
+          {/* PROPOSALS — entities in the document that are not in force. Above the
+              table on purpose: they are the only thing here that needs a decision,
+              and a pending decision buried under a type listing is a decision nobody
+              makes. Rejected ones are kept as tombstones (so a curator stops
+              re-proposing them) but folded away, since they compete with live types
+              for attention and never need action. */}
+          {pendingProposals.length > 0 && (
+            <div className="settings-row ontology-proposals">
+              <div>
+                <strong>
+                  {pendingProposals.length} suggested type
+                  {pendingProposals.length === 1 ? "" : "s"}
+                </strong>{" "}
+                <span className="settings-muted">
+                  not in force until you accept — accepting keeps each one exactly where
+                  it sits in the document
+                </span>
+                {pendingProposals.map((p) => (
+                  <div className="ontology-proposal" key={p.chunk_id}>
+                    <div>
+                      <code>{p.name}</code>
+                      {p.parent && (
+                        <span className="settings-muted">
+                          {" "}
+                          under <code>{p.parent}</code>
+                        </span>
+                      )}
+                      {p.fields && p.fields.length > 0 && (
+                        <span className="settings-muted"> — {p.fields.join(", ")}</span>
+                      )}
+                    </div>
+                    {/* The evidence, so the operator judges a case and not a name. */}
+                    {p.body && <pre className="ontology-evidence">{p.body.trim()}</pre>}
+                    <div className="settings-row-actions">
+                      <button
+                        type="button"
+                        disabled={busy}
+                        onClick={() => void resolveProposal(p.chunk_id, "accept")}
+                      >
+                        accept
+                      </button>
+                      <button
+                        type="button"
+                        className="ghost-btn"
+                        disabled={busy}
+                        onClick={() => void resolveProposal(p.chunk_id, "reject")}
+                      >
+                        reject
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {rejectedProposals.length > 0 && (
+            <details className="settings-help">
+              <summary>
+                {rejectedProposals.length} rejected type
+                {rejectedProposals.length === 1 ? "" : "s"}
+              </summary>
+              <p>
+                Kept on purpose: a rejection is a record, so an automated curator can
+                see what you already turned down instead of proposing it again. They are
+                not in force, and they never will be unless you clear the status in the
+                document editor.
+              </p>
+              {rejectedProposals.map((p) => (
+                <div key={p.chunk_id}>
+                  <code>{p.name}</code>
+                  {p.parent && (
+                    <span className="settings-muted">
+                      {" "}
+                      under <code>{p.parent}</code>
+                    </span>
+                  )}
+                </div>
+              ))}
+            </details>
+          )}
+
+          {/* ADOPT — the standard types this document does not declare. Offered here
+              because the documented way to subclass one is to declare it yourself
+              first, which otherwise means retyping its field names off the column on
+              the right, by hand, correctly. */}
+          {(state.adoptable ?? []).length > 0 && (
+            <p className="settings-help">
+              <strong>Extend a standard type:</strong> adopting one copies it into your
+              document with its fields, so you can add to it or nest subtypes under it.
+              Your copy then overrides the standard one, wholesale — a field a later
+              loomcycle release adds to it will not reach your copy.
+              <span className="ontology-adopt-row">
+                {(state.adoptable ?? []).map((name) => (
+                  <button
+                    key={name}
+                    type="button"
+                    className="ghost-btn"
+                    disabled={busy}
+                    onClick={() => void adopt(name)}
+                    title={`Copy the standard "${name}" into your document so you can extend or subclass it`}
+                  >
+                    adopt <code>{name}</code>
+                  </button>
+                ))}
+              </span>
             </p>
           )}
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5736,6 +5736,44 @@ button.primary:disabled {
   border-bottom: 1px solid var(--lc-rule);
   vertical-align: middle;
 }
+/* Suggested types (RFC CA). Boxed and accent-edged because it is the only part of
+   this panel that asks for a decision — a pending suggestion styled like the type
+   listing beside it is a decision nobody notices. */
+.ontology-proposals {
+  border: 1px solid var(--lc-rule);
+  border-left: 3px solid var(--lc-accent);
+  border-radius: var(--lc-radius-sm);
+  padding: var(--lc-space-1) var(--lc-space-2);
+  background: var(--lc-surface-2);
+}
+.ontology-proposal {
+  margin-top: var(--lc-space-1);
+  padding-top: var(--lc-space-1);
+  border-top: 1px solid var(--lc-rule);
+  font-size: var(--lc-text-sm);
+}
+/* The evidence a curator filed with its proposal. Monospace + scrollable: it is
+   quoted material (counts, example facts), not prose the panel wrote. */
+.ontology-evidence {
+  margin: var(--lc-space-1) 0;
+  padding: var(--lc-space-1);
+  max-height: 8em;
+  overflow: auto;
+  background: var(--lc-surface-3);
+  border: 1px solid var(--lc-rule);
+  border-radius: var(--lc-radius-sm);
+  font-family: var(--lc-font-mono);
+  font-size: var(--lc-text-sm);
+  color: var(--lc-text-muted);
+  white-space: pre-wrap;
+}
+.ontology-adopt-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--lc-space-1);
+  margin-top: var(--lc-space-1);
+}
+
 /* The ontology tree (RFC BZ P4). A taxonomy read as a flat list with one level of
    indent is a taxonomy nobody can check — the operator has to see which type is a
    kind of which, because that is now what steers extraction AND what widens a


### PR DESCRIPTION
## Why

Two problems, one mechanism.

The ontology had **one gate** — the root chunk's draft/confirmed — so anything appended to a confirmed document is live on the next run. There was nowhere to put a suggestion that is real but not in force, which means an agent could never *suggest* a type, only add one. And overriding a standard type meant reading its field names off the panel and retyping them by hand, which every attempt to subclass a standard type paid.

## The mechanism

**A proposal is the entity in its final place, switched off.** `chunks.status` was already a column the ontology reader ignored, so reserving `proposed` and `rejected` as inert gives per-entity gating for almost nothing — and accepting becomes a one-field flip rather than a transcription out of a staging area. Nothing moves, which is why an accepted subclass lands under the parent it was filed under and inherits its fields like any other.

I considered a separate proposals document and a new table; both make acceptance a copy and lose the structural relationship ("incident under event" becomes prose). The preamble in the RFC has the full argument.

### Fail open is the load-bearing rule

**Only those two words are inert.** Every other status — including one this build has never heard of — leaves the entity in force. The shorter inverse rule ("anything not blank or confirmed is inert") would silently drop types from any document where an operator used the status field for their own purposes: exactly the failure the chunk-tree reader was written to remove. A new gate must not be able to turn existing types off.

Children of an inert chunk re-parent to the nearest in-force ancestor for the same reason — rejecting a parent must not switch off a live type beneath it.

## The three decisions you made

- **`rejected` is kept**, as a tombstone a curator reads so it stops re-proposing what was turned down. Folded behind a disclosure in the panel, since it never needs action.
- **Accepting is narrower than confirming.** It refuses any chunk that is not currently a proposal in the caller's own ontology — *including the document root*, whose status is the confirm gate, so "accept a proposal" can never confirm the whole ontology. Asserted directly.
- **Adoption records provenance** — what was copied, from where, at which build — in the chunk's structured fields, never its body. The body is parsed for field bullets and belongs to the operator; a machine-written line there would be indistinguishable from something they wrote. It exists because adoption **freezes** the copy, which is otherwise undiscoverable after the fact.

Adoption also copies the seed's fields **server-side**: a client-supplied list could disagree with the type it claims to copy, and the document would look like an override of `event` while declaring something else.

## Tested

`go test ./...` clean, `npx tsc --noEmit` clean, web `npm test` green, `make build-ui` builds.

- `TestOntologyTree_ProposedIsNotInForceButIsReported` — inert *and* reported, plus the fail-open case (a chunk with status `wip` stays in force).
- `TestOntologyTree_RejectingAParentDoesNotSwitchOffLiveChildren`.
- `TestOntologyProposal_AcceptPutsItInForceInPlace_RejectKeepsATombstone` — accepting does not move the entity, and re-accepting a rejection is a 409 rather than a silent un-reject.
- `TestOntologyProposal_RefusesAChunkThatIsNotAProposal` — a live entity, the document root, and a bogus id all 404, and the confirm gate is unchanged after the attempt on the root.
- `TestOntologyAdopt_CopiesTheStandardTypeWithItsFieldsAndProvenance` — provenance asserted by reading it back through `get_chunk`, because the response deliberately does not carry it and a claim nothing checks is one that quietly stops being true.

**Clicked through in a browser** against a local build: accepting `sev1-incident` put it in force still under `incident` (own field + four inherited); adopting `event` copied its three seed fields in as a root and dropped it from the adopt row. Screenshots in the conversation.

## What phase 1 does not do

There is still **nothing that creates proposals** — that is phase 2's `propose_entity` op and phase 3's curator agent. Phase 1 is useful on its own for the adopt half, and it means the curator has somewhere to file when it arrives.

Also worth being explicit, as the RFC is: the narrowing is real for the UI but not yet *enforced* against an agent holding `scope=tenant` on the Document tool — such an agent can already author live types directly, so the proposal gate is not what protects you today. Phase 2 closes the generic path on the ontology document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8