### PR TITLE
feat(ontology): an agent may propose a type, never decide one (RFC CA P2)

### DIFF
--- a/internal/api/http/ontology_admin.go
+++ b/internal/api/http/ontology_admin.go
@@ -258,7 +258,10 @@ func (s *Server) ontologyState(ctx context.Context, tenant string) (ontologyResp
 // reaching tenant memory, so it does not require the caller to hold the agent-side
 // tenant grants. The tenant itself is principal-derived and never from the wire.
 func (s *Server) ontologyDocCtx(ctx context.Context, mi memInject) context.Context {
-	dctx := s.docToolCtx(ctx, mi)
+	// RFC CA: these routes ARE the operator surface — the confirm toggle, accept/reject,
+	// adopt. Marked so the ontology guard admits them while refusing an agent's tool call
+	// (which is never stamped, because there is no wire field for it).
+	dctx := tools.WithSubstrateOperator(s.docToolCtx(ctx, mi))
 	dctx = tools.WithMemoryPolicy(dctx, tools.MemoryPolicyValue{AllowedScopes: []string{"tenant"}})
 	dctx = tools.WithSqlMemPolicy(dctx, tools.SqlMemPolicyValue{AllowedScopes: []string{"tenant"}})
 	return dctx

--- a/internal/api/http/substrate_admin.go
+++ b/internal/api/http/substrate_admin.go
@@ -287,6 +287,11 @@ func substrateAdminCtx(ctx context.Context) context.Context {
 	// "" when no principal (legacy LOOMCYCLE_AUTH_TOKEN / open mode) →
 	// shared tenant, which is the correct single-tenant behavior.
 	principal, _ := auth.PrincipalFromContext(ctx)
+	// RFC CA: mark this as the OPERATOR's own off-run call. Stamped here, at the single
+	// root of every substrate admin dispatch, so no route can forget it; and it is a
+	// dedicated marker rather than the synthetic agent id below, because that id is
+	// caller-supplied on POST /v1/runs and a run could claim it.
+	ctx = tools.WithSubstrateOperator(ctx)
 	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{
 		UserID:   substrateAdminUserID,
 		AgentID:  substrateAdminAgentID,

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -68,13 +68,14 @@ func (d *Document) Description() string {
 const documentInputSchema = `{
 	"type": "object",
 	"properties": {
-		"op":          {"type": "string", "enum": ["create_document","get_document","documents_summary","query_documents","delete_document","set_path","create_chunk","upsert_chunk","get_chunk","update_chunk","delete_chunk","supersede_chunk","graph_recall","list_facts","move_chunk","reorder_chunk","link_chunks","unlink_chunks","get_edges","query_chunks","add_tags","remove_tags","list_tags","define_type","list_types","set_asset","get_asset","export_md","import_md","export_canvas","import_canvas","history","get_version","diff","backlinks","search","related","unlinked_mentions"]},
+		"op":          {"type": "string", "enum": ["create_document","get_document","documents_summary","query_documents","delete_document","set_path","create_chunk","propose_entity","upsert_chunk","get_chunk","update_chunk","delete_chunk","supersede_chunk","graph_recall","list_facts","move_chunk","reorder_chunk","link_chunks","unlink_chunks","get_edges","query_chunks","add_tags","remove_tags","list_tags","define_type","list_types","set_asset","get_asset","export_md","import_md","export_canvas","import_canvas","history","get_version","diff","backlinks","search","related","unlinked_mentions"]},
 		"scope":       {"type": "string", "enum": ["agent","user","tenant"], "description": "Which store (default user). agent = this agent; user = this end-user (needs a user_id on the run); tenant = shared by every user and agent in the tenant — anything written here is read by all of them, so use it for curated reference material, not for anything derived from untrusted text. tenant requires the operator to grant BOTH memory_scopes and sql_scopes with the tenant value."},
 		"id":          {"type": "string", "description": "Document id (get/delete_document, set_path) or chunk id (get/update/delete/move_chunk)."},
 		"path":        {"type": "string", "description": "create_document: name the doc in the Path tree (default /documents/<title> if omitted). set_path: the path to attach to an existing document (by id). get/delete_document: address by path instead of id."},
 		"title":       {"type": "string"},
 		"document_id": {"type": "string"},
 		"document_ids": {"type": "array", "items": {"type": "string"}, "description": "documents_summary: the document ids to summarize (combine with or instead of under_path)."},
+		"parent":      {"type": "string", "description": "propose_entity: the IN-FORCE entity type this one is a kind of, BY NAME (omit for a new top-level type). Use a name from the entity types listed in your instructions."},
 		"parent_id":   {"type": "string", "description": "create_chunk: parent chunk (omit for a child of the root)."},
 		"new_parent_id": {"type": "string", "description": "move_chunk: the new parent."},
 		"after_id":    {"type": "string", "description": "create_chunk: insert the new chunk immediately AFTER this sibling (same parent; shifts later siblings). Overrides parent_id/position."},
@@ -140,8 +141,11 @@ type docInput struct {
 	Body      string          `json:"body"`
 	Fields    json.RawMessage `json:"fields"`
 	Status    string          `json:"status"`
-	Position  *int            `json:"position"`
-	Revision  *int            `json:"revision"`
+	// Parent names an entity by NAME (propose_entity). Distinct from ParentID, which
+	// addresses a chunk: a curator knows the type it read in its prompt, not a uuid.
+	Parent   string `json:"parent"`
+	Position *int   `json:"position"`
+	Revision *int   `json:"revision"`
 	// FromRevision / ToRevision select the two body-change revisions to diff (RFC
 	// BS Phase 3a). Pointers so an omitted bound is distinguishable from a value
 	// (the log is 1-based, so 0 is never a real revision, but the pointer keeps the
@@ -350,6 +354,13 @@ func (d *Document) Execute(ctx context.Context, raw json.RawMessage) (tools.Resu
 	if err := d.ensureSchema(ctx, key); err != nil {
 		return errResult("document: schema init: " + err.Error()), nil
 	}
+	// RFC CA: an agent may PROPOSE an ontology entity, never decide one. Checked at the
+	// single dispatch point rather than inside each op — a per-op check is one op away
+	// from being forgotten, and the ops that would need it (create/update/delete/move/
+	// reorder) are exactly the ones a future change is likely to add a sibling to.
+	if refused := d.guardOntologyWrite(ctx, key, in.Op, in); refused != nil {
+		return *refused, nil
+	}
 
 	switch in.Op {
 	case "create_document":
@@ -364,6 +375,10 @@ func (d *Document) Execute(ctx context.Context, raw json.RawMessage) (tools.Resu
 		return d.deleteDocument(ctx, key, mscope, in)
 	case "set_path":
 		return d.setPath(ctx, key, in)
+	case "propose_entity":
+		// RFC CA: files an INERT ontology proposal. Resolves its own tenant scope, so it
+		// is deliberately not routed through the caller's `scope` argument.
+		return d.proposeEntity(ctx, in)
 	case "create_chunk":
 		return d.createChunk(ctx, key, mscope, in)
 	case "get_chunk":

--- a/internal/tools/builtin/document_ontology_guard.go
+++ b/internal/tools/builtin/document_ontology_guard.go
@@ -1,0 +1,254 @@
+package builtin
+
+// document_ontology_guard.go — an agent may PROPOSE an entity type, never decide one
+// (RFC CA phase 2).
+//
+// THE HOLE THIS CLOSES. Phase 1 made a proposal inert and gave the operator accept /
+// reject on a dedicated route. That narrowing was real for the UI and unenforced
+// underneath: `scope=tenant` on the Document tool is write authority over the whole
+// ontology document, so an agent holding it could create a live type outright, or clear
+// its own proposal's status and call the result reviewed. A review gate that the thing
+// being reviewed can open is ceremony.
+//
+// So on the TENANT ONTOLOGY DOCUMENT, and only there, an agent's tool call may:
+//
+//	create_chunk  — only with status `proposed` (an inert suggestion)
+//	update_chunk  — refused
+//	delete_chunk  — refused
+//
+// The operator's own surfaces are unaffected: the confirm toggle, accept/reject, adopt,
+// and the Web UI's document editor all run with the operator marker stamped, which no
+// run path sets and no wire field can claim.
+//
+// WHY NOT KEY ON THE IDENTITY the off-run path already stamps: it uses a synthetic agent
+// id, and `POST /v1/runs` accepts a caller-supplied `agent_id`, so a run could claim that
+// value and be read as the operator. The marker is a context value with no wire form.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	memrank "github.com/denn-gubsky/loomcycle/internal/memory"
+	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// refusal wraps an error result so the guard reads as a gate rather than a failure.
+func refusal(msg string) *tools.Result {
+	r := errResult(msg)
+	return &r
+}
+
+// proposalBodyMax bounds the evidence a single proposal can carry.
+//
+// The body reaches an operator's config document and the panel renders it, so an
+// unbounded one is a way to make the ontology page unreadable. Generous enough for
+// counts and a few example facts, which is what evidence looks like.
+const proposalBodyMax = 4000
+
+// guardOntologyWrite refuses an agent's attempt to author or resolve a live entity.
+//
+// Returns a non-nil result when the call must be refused. Cheap on the common path: the
+// ontology document only exists at tenant scope, so a call on any other scope returns
+// immediately without touching the store.
+func (d *Document) guardOntologyWrite(ctx context.Context, key sqlmem.ScopeKey, op string, in docInput) *tools.Result {
+	if tools.IsSubstrateOperator(ctx) || key.Scope != "tenant" {
+		return nil
+	}
+	docID := d.ontologyDocumentID(ctx, key)
+	if docID == "" {
+		return nil // no ontology document in this tenant — nothing to protect
+	}
+	// Which document does this call touch? Three addressings, and missing one is how a
+	// guard gets bypassed: create/import name the document, the chunk ops name a chunk
+	// whose document must be looked up, and delete_document/set_path put the DOCUMENT id
+	// in `id` — where a chunk lookup returns nothing and the check would sail past.
+	target := strings.TrimSpace(in.DocumentID)
+	if target == "" && in.ID != "" {
+		if target = d.documentIDForChunk(ctx, key, in.ID); target == "" {
+			target = strings.TrimSpace(in.ID)
+		}
+	}
+	if target != docID {
+		return nil
+	}
+
+	switch op {
+	case "create_chunk", "upsert_chunk":
+		if !strings.EqualFold(strings.TrimSpace(in.Status), memrank.OntologyStatusProposed) {
+			return refusal("an agent may only add a PROPOSED entity to the ontology: pass " +
+				"status=\"" + memrank.OntologyStatusProposed + "\" (or use op=propose_entity, which " +
+				"does it for you). An entity that is in force is the operator's decision, and " +
+				"accepting a proposal is a separate operator action.")
+		}
+		return nil
+	// EVERY op that can create, alter, retire or re-home an entity — audited from the op
+	// list rather than from the obvious ones. The first version of this guard covered the
+	// five chunk mutations and missed four routes to the same effect: import_md and
+	// import_canvas author chunks wholesale, supersede_chunk both creates and retires, and
+	// delete_document / set_path reach the WHOLE ontology (set_path by re-homing
+	// /memory/ontology so the reader resolves somewhere else entirely).
+	case "update_chunk", "delete_chunk", "move_chunk", "reorder_chunk",
+		"supersede_chunk", "import_md", "import_canvas", "delete_document", "set_path":
+		return refusal("an agent may not modify the ontology document — it may only add a " +
+			"proposal (op=propose_entity). Resolving one, editing a live entity, importing " +
+			"over the document, re-homing it, or removing anything is the operator's decision.")
+	default:
+		return nil
+	}
+}
+
+// ontologyDocumentID resolves the tenant ontology document, or "" when there is none.
+func (d *Document) ontologyDocumentID(ctx context.Context, key sqlmem.ScopeKey) string {
+	id, err := d.docIDFromInput(ctx, key, docInput{Path: memrank.OntologyPath})
+	if err != nil {
+		return ""
+	}
+	return id
+}
+
+// documentIDForChunk returns the document a chunk belongs to, or "".
+func (d *Document) documentIDForChunk(ctx context.Context, key sqlmem.ScopeKey, chunkID string) string {
+	res, err := d.query(ctx, key, `SELECT document_id FROM chunks WHERE id = ? LIMIT 1`, chunkID)
+	if err != nil || len(res.Rows) == 0 || len(res.Rows[0]) == 0 {
+		return ""
+	}
+	return asStr(res.Rows[0][0])
+}
+
+// proposeEntity files an inert entity proposal against the tenant ontology.
+//
+// The ergonomic front door to what create_chunk can already do under the guard above,
+// and it exists because the fiddly parts are exactly where a curator would get it wrong:
+// finding the ontology document, addressing the parent, and remembering the status. It
+// takes the parent by NAME — which is what the agent read in its prompt — rather than by
+// chunk id, which it has no way to know.
+//
+// NO TENANT GRANT REQUIRED, deliberately. A proposal cannot change what any run is told,
+// so it does not need the authority that live authoring needs; requiring the grant would
+// mean only an agent that could already author live types could suggest one, which
+// inverts the point. The tenant comes from the run's server-stamped identity, so nothing
+// here crosses a tenant.
+func (d *Document) proposeEntity(ctx context.Context, in docInput) (tools.Result, error) {
+	name := memrank.TrimOntologyName(in.Name)
+	if name == "" {
+		name = memrank.TrimOntologyName(in.Title)
+	}
+	if name == "" {
+		return errResult("propose_entity: name is required — it becomes the entity type's name"), nil
+	}
+	if len(in.Body) > proposalBodyMax {
+		return errResult(fmt.Sprintf("propose_entity: body is %d bytes, over the %d-byte limit — "+
+			"keep the evidence to counts and a few examples", len(in.Body), proposalBodyMax)), nil
+	}
+
+	key, mscope, err := d.ontologyTenantKey(ctx)
+	if err != nil {
+		return errResult("propose_entity: " + err.Error()), nil
+	}
+	read, err := d.ontologyForKey(ctx, key, mscope, memrank.OntologyPath)
+	if err != nil {
+		return errResult("propose_entity: " + err.Error()), nil
+	}
+	if read.DocumentID == "" || read.RootChunkID == "" {
+		return errResult("propose_entity: this tenant has no ontology document yet — an " +
+			"operator opens Settings → Ontology once to create it"), nil
+	}
+	for _, t := range read.Terms {
+		if strings.EqualFold(t.Name, name) {
+			return errResult("propose_entity: " + name + " is already in force — propose a " +
+				"SUBTYPE of it (parent=\"" + t.Name + "\") or leave it alone"), nil
+		}
+	}
+	for _, p := range read.Proposals {
+		if strings.EqualFold(p.Name, name) {
+			// Naming the status matters: a `rejected` twin means the operator already
+			// said no, and re-filing it is the nagging the tombstone exists to prevent.
+			return errResult("propose_entity: " + name + " is already " + p.Status +
+				" — an operator has seen it"), nil
+		}
+	}
+
+	// The parent is resolved by NAME against what is IN FORCE. A proposal under a
+	// proposal would be a suggestion contingent on another suggestion, which the
+	// operator cannot evaluate on its own.
+	parentChunk := read.RootChunkID
+	if want := memrank.TrimOntologyName(in.Parent); want != "" {
+		id := d.chunkIDForEntity(ctx, key, read.DocumentID, want)
+		if id == "" {
+			names := make([]string, 0, len(read.Terms))
+			for _, t := range read.Terms {
+				names = append(names, t.Name)
+			}
+			return errResult("propose_entity: no entity named " + want + " is in force in this " +
+				"tenant's ontology (have: " + strings.Join(names, ", ") + "). A subtype must " +
+				"hang off a type the operator has already accepted"), nil
+		}
+		parentChunk = id
+	}
+	return d.createOntologyProposal(ctx, key, mscope, read.DocumentID, parentChunk, name, in.Body)
+}
+
+// chunkIDForEntity finds the chunk backing an in-force entity by name.
+func (d *Document) chunkIDForEntity(ctx context.Context, key sqlmem.ScopeKey, docID, name string) string {
+	res, err := d.query(ctx, key,
+		`SELECT id, coalesce(status, '') FROM chunks
+		  WHERE document_id = ? AND lower(coalesce(title, '')) = lower(?) LIMIT 1`, docID, name)
+	if err != nil || len(res.Rows) == 0 || len(res.Rows[0]) < 2 {
+		return ""
+	}
+	if memrank.IsInertEntityStatus(asStr(res.Rows[0][1])) {
+		return "" // an inert chunk is not a parent an operator can reason about
+	}
+	return asStr(res.Rows[0][0])
+}
+
+// ontologyTenantKey builds the tenant scope key WITHOUT the scope=tenant grant check.
+//
+// Same carve-out the retrieval-side ontology read uses, for the same reason: the tenant
+// comes from the run's server-stamped identity, and what is reached is operator-authored
+// config that already appears in the agent's own prompt. What differs is the WRITE, which
+// is bounded to inert proposals by the guard above — an agent cannot use this to author a
+// live type.
+func (d *Document) ontologyTenantKey(ctx context.Context) (sqlmem.ScopeKey, store.MemoryScope, error) {
+	if d.Store == nil || d.SqlMem == nil {
+		return sqlmem.ScopeKey{}, "", fmt.Errorf("the ontology needs SQL Memory (set LOOMCYCLE_SQLMEM_ENABLED=1)")
+	}
+	t := sqlScopeTenant(ctx)
+	return sqlmem.ScopeKey{Tenant: t, Scope: "tenant", ScopeID: t}, store.MemoryScopeTenant, nil
+}
+
+// createOntologyProposal writes the inert chunk.
+//
+// Status is stamped HERE rather than taken from the caller: propose_entity's whole
+// contract is that what it produces is not in force, and a status argument would be a way
+// to spell that contract wrong.
+func (d *Document) createOntologyProposal(ctx context.Context, key sqlmem.ScopeKey, mscope store.MemoryScope, docID, parentID, name, body string) (tools.Result, error) {
+	req, _ := json.Marshal(map[string]any{
+		"op": "create_chunk", "scope": "tenant",
+		"document_id": docID, "parent_id": parentID,
+		"title": name, "status": memrank.OntologyStatusProposed, "body": body,
+	})
+	// Routed through the tool's own dispatch so a proposal is an ordinary chunk written
+	// the ordinary way — position, body storage, embedding all behave as they do for
+	// anything else. The guard admits it because the status is `proposed`.
+	res, err := d.Execute(ctx, req)
+	if err != nil {
+		return errResult("propose_entity: " + err.Error()), nil
+	}
+	if res.IsError {
+		return res, nil
+	}
+	var out map[string]any
+	_ = json.Unmarshal([]byte(res.Text), &out)
+	return jsonResult(map[string]any{
+		"proposed":  name,
+		"chunk_id":  out["id"],
+		"parent_id": parentID,
+		"note": "Filed as a suggestion, not in force. An operator accepts or rejects it in " +
+			"Settings → Ontology; nothing changes for any run until they do.",
+	})
+}

--- a/internal/tools/builtin/document_ontology_test.go
+++ b/internal/tools/builtin/document_ontology_test.go
@@ -225,6 +225,11 @@ func ontologyRetrievalFixture(t *testing.T, confirm bool) (*Document, context.Co
 	d, ctx, _ := documentFixture(t)
 	ctx = tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{AllowedScopes: []string{"tenant"}})
 	ctx = tools.WithSqlMemPolicy(ctx, tools.SqlMemPolicyValue{AllowedScopes: []string{"tenant"}})
+	// SETUP ACTS AS THE OPERATOR. Building the fixture means writing the ontology
+	// document and flipping its confirm status, which RFC CA's guard reserves for the
+	// operator surfaces — an agent context is refused, correctly. That refusal is what
+	// TestOntologyGuard_* asserts; here it would only be testing the fixture.
+	ctx = tools.WithSubstrateOperator(ctx)
 
 	md := "# Tenant Ontology\n\n## event\n- `occurred_at`\n\n### incident\n- `severity`\n\n#### outage\n- `minutes_down`\n\n## person\n- `name`\n"
 	mj, _ := json.Marshal(md)
@@ -656,4 +661,239 @@ func TestOntologyTree_RejectingAParentDoesNotSwitchOffLiveChildren(t *testing.T)
 	if inc.Parent != "" {
 		t.Errorf("incident.Parent = %q — it should attach to the nearest IN-FORCE ancestor (the root)", inc.Parent)
 	}
+}
+
+// ontologyAgentFixture returns an operator ctx (for setup) and an AGENT ctx (for the
+// calls under test) over the same tenant ontology, with tenant grants on both.
+//
+// The grants are on the agent ctx DELIBERATELY: the point of the guard is that full
+// tenant Document authority is still not authority over the ontology's type system.
+// Testing it with an under-granted agent would prove nothing.
+func ontologyAgentFixture(t *testing.T) (*Document, context.Context, context.Context) {
+	t.Helper()
+	d, base, _ := documentFixture(t)
+	base = tools.WithMemoryPolicy(base, tools.MemoryPolicyValue{AllowedScopes: []string{"tenant"}})
+	base = tools.WithSqlMemPolicy(base, tools.SqlMemPolicyValue{AllowedScopes: []string{"tenant"}})
+	opCtx := tools.WithSubstrateOperator(base)
+
+	md := "# Tenant Ontology\n\n## event\n- `occurred_at`\n"
+	mj, _ := json.Marshal(md)
+	out, r := docExec(t, d, opCtx, `{"op":"import_md","scope":"tenant","markdown":`+string(mj)+`}`)
+	if r.IsError {
+		t.Fatalf("import_md: %s", r.Text)
+	}
+	docID, _ := out["document_id"].(string)
+	pj, _ := json.Marshal(memrank.OntologyPath)
+	if _, r = docExec(t, d, opCtx,
+		`{"op":"set_path","scope":"tenant","id":"`+docID+`","path":`+string(pj)+`}`); r.IsError {
+		t.Fatalf("set_path: %s", r.Text)
+	}
+	return d, opCtx, base
+}
+
+// TestOntologyGuard_AnAgentMayProposeButNotDecide is the phase-2 claim.
+//
+// Phase 1's review gate was unenforced underneath: an agent holding tenant Document
+// authority could create a live type outright, or clear its own proposal's status and
+// call that reviewed. A gate the reviewed thing can open is ceremony.
+func TestOntologyGuard_AnAgentMayProposeButNotDecide(t *testing.T) {
+	d, opCtx, agentCtx := ontologyAgentFixture(t)
+
+	read, err := d.OntologyTermsFromTree(opCtx, "tenant", memrank.OntologyPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	docID, rootID := read.DocumentID, read.RootChunkID
+	eventID := d.chunkIDForEntity(opCtx, mustTenantKey(t, d, opCtx), docID, "event")
+	if eventID == "" {
+		t.Fatal("no `event` chunk in the fixture")
+	}
+
+	// PROPOSE: allowed, and inert.
+	out, r := docExec(t, d, agentCtx,
+		`{"op":"propose_entity","name":"outage","parent":"event","body":"- `+"`minutes_down`"+`\n\nSeen 9 times.\n"}`)
+	if r.IsError {
+		t.Fatalf("propose_entity should be allowed to an agent: %s", r.Text)
+	}
+	proposedID, _ := out["chunk_id"].(string)
+	if proposedID == "" {
+		t.Fatalf("propose_entity returned no chunk id: %v", out)
+	}
+	after, _ := d.OntologyTermsFromTree(opCtx, "tenant", memrank.OntologyPath)
+	for _, term := range after.Terms {
+		if term.Name == "outage" {
+			t.Fatal("a proposal went into force — it must be inert until an operator accepts")
+		}
+	}
+	if len(after.Proposals) != 1 || after.Proposals[0].Name != "outage" {
+		t.Fatalf("the proposal was not recorded: %+v", after.Proposals)
+	}
+	// It hangs off the named parent, resolved from a name the agent could actually know.
+	if after.Proposals[0].Parent != "event" {
+		t.Errorf("proposal parent = %q, want event", after.Proposals[0].Parent)
+	}
+
+	// DECIDE: refused, in every spelling.
+	refusals := []struct {
+		name string
+		req  string
+	}{
+		{"clear its own proposal's status", fmt.Sprintf(
+			`{"op":"update_chunk","scope":"tenant","id":"%s","status":"","revision":1}`, proposedID)},
+		{"confirm the whole document", fmt.Sprintf(
+			`{"op":"update_chunk","scope":"tenant","id":"%s","status":"confirmed","revision":1}`, rootID)},
+		{"delete an entity", fmt.Sprintf(`{"op":"delete_chunk","scope":"tenant","id":"%s"}`, proposedID)},
+		{"create a LIVE entity", fmt.Sprintf(
+			`{"op":"create_chunk","scope":"tenant","document_id":"%s","parent_id":"%s","title":"decided","body":""}`,
+			docID, rootID)},
+		{"move an entity", fmt.Sprintf(
+			`{"op":"move_chunk","scope":"tenant","id":"%s","new_parent_id":"%s"}`, proposedID, rootID)},
+		// The four routes the first version of this guard missed. Each reaches the same
+		// effect by a different op, which is why the refused set was audited from the op
+		// list instead of from the obvious mutations.
+		{"import live types over the document", fmt.Sprintf(
+			`{"op":"import_md","scope":"tenant","document_id":"%s","markdown":"## decided\n"}`, docID)},
+		{"import a canvas over the document", fmt.Sprintf(
+			`{"op":"import_canvas","scope":"tenant","document_id":"%s","canvas":{"nodes":[],"edges":[]}}`, docID)},
+		// A VALID supersede: the proposal replaces the live `event`, retiring it. The
+		// first version of this case omitted `id` and failed input validation instead of
+		// the guard — an assertion that passes because the call was malformed proves
+		// nothing about the gate.
+		{"supersede a live entity", fmt.Sprintf(
+			`{"op":"supersede_chunk","scope":"tenant","document_id":"%s","id":"%s","supersedes_id":"%s","natural_key":"k"}`,
+			docID, proposedID, eventID)},
+		{"delete the whole ontology", fmt.Sprintf(
+			`{"op":"delete_document","scope":"tenant","id":"%s"}`, docID)},
+		{"re-home the ontology path", fmt.Sprintf(
+			`{"op":"set_path","scope":"tenant","id":"%s","path":"/elsewhere/onto"}`, docID)},
+	}
+	for _, c := range refusals {
+		if _, rr := docExec(t, d, agentCtx, c.req); !rr.IsError {
+			t.Errorf("an agent was allowed to %s", c.name)
+		}
+	}
+	// Nothing leaked through: still one proposal, still no `decided` type.
+	final, _ := d.OntologyTermsFromTree(opCtx, "tenant", memrank.OntologyPath)
+	for _, term := range final.Terms {
+		if term.Name == "decided" || term.Name == "outage" {
+			t.Errorf("a refused write took effect anyway: %q is in force", term.Name)
+		}
+	}
+
+	// THE OPERATOR is unaffected — same calls, allowed. Without this the guard could be
+	// "refuse everyone", which passes every assertion above and breaks the product.
+	rev := 1
+	if g, gr := docExec(t, d, opCtx, `{"op":"get_chunk","scope":"tenant","id":"`+proposedID+`"}`); !gr.IsError {
+		rev = int(g["revision"].(float64))
+	}
+	if _, rr := docExec(t, d, opCtx, fmt.Sprintf(
+		`{"op":"update_chunk","scope":"tenant","id":"%s","status":"","revision":%d}`, proposedID, rev)); rr.IsError {
+		t.Fatalf("the operator must still be able to accept: %s", rr.Text)
+	}
+	accepted, _ := d.OntologyTermsFromTree(opCtx, "tenant", memrank.OntologyPath)
+	var found bool
+	for _, term := range accepted.Terms {
+		if term.Name == "outage" {
+			found = true
+			if term.Parent != "event" {
+				t.Errorf("accepted outage.Parent = %q, want event — accepting must not move it", term.Parent)
+			}
+		}
+	}
+	if !found {
+		t.Error("the operator's accept did not put the entity in force")
+	}
+}
+
+// TestOntologyGuard_LeavesOtherDocumentsAlone.
+//
+// The guard is scoped to ONE document. If it caught every tenant-scope document, an agent
+// with tenant Document grants would lose the ability to write ordinary shared documents —
+// a much larger change than RFC CA describes, arriving as a side effect.
+func TestOntologyGuard_LeavesOtherDocumentsAlone(t *testing.T) {
+	d, _, agentCtx := ontologyAgentFixture(t)
+
+	out, r := docExec(t, d, agentCtx,
+		`{"op":"create_document","scope":"tenant","title":"Team notes","body":""}`)
+	if r.IsError {
+		t.Fatalf("an agent must still be able to create a tenant document: %s", r.Text)
+	}
+	docID, _ := out["document_id"].(string)
+	root, _ := out["root_chunk_id"].(string)
+	c, r := docExec(t, d, agentCtx, `{"op":"create_chunk","scope":"tenant","document_id":"`+docID+
+		`","parent_id":"`+root+`","title":"a note","body":"text"}`)
+	if r.IsError {
+		t.Fatalf("an agent must still be able to write a live chunk elsewhere: %s", r.Text)
+	}
+	id, _ := c["id"].(string)
+	g, _ := docExec(t, d, agentCtx, `{"op":"get_chunk","scope":"tenant","id":"`+id+`"}`)
+	rev := int(g["revision"].(float64))
+	if _, r = docExec(t, d, agentCtx, fmt.Sprintf(
+		`{"op":"update_chunk","scope":"tenant","id":"%s","status":"final","revision":%d}`, id, rev)); r.IsError {
+		t.Errorf("an agent must still be able to set a status elsewhere: %s", r.Text)
+	}
+}
+
+// TestProposeEntity_RefusesWhatAnOperatorHasAlreadySeen.
+//
+// A curator that re-files the same suggestion every run turns the review surface into
+// noise, which is the whole reason a rejection is kept rather than deleted.
+func TestProposeEntity_RefusesWhatAnOperatorHasAlreadySeen(t *testing.T) {
+	d, opCtx, agentCtx := ontologyAgentFixture(t)
+
+	// Already IN FORCE → refused, and pointed at the useful move instead.
+	_, r := docExec(t, d, agentCtx, `{"op":"propose_entity","name":"event"}`)
+	if !r.IsError || !strings.Contains(r.Text, "already in force") {
+		t.Errorf("proposing a live type should be refused: %s", r.Text)
+	}
+	// Already PROPOSED → refused.
+	if _, rr := docExec(t, d, agentCtx, `{"op":"propose_entity","name":"outage","parent":"event"}`); rr.IsError {
+		t.Fatalf("first proposal: %s", rr.Text)
+	}
+	_, r = docExec(t, d, agentCtx, `{"op":"propose_entity","name":"outage","parent":"event"}`)
+	if !r.IsError || !strings.Contains(r.Text, "proposed") {
+		t.Errorf("a duplicate proposal should be refused: %s", r.Text)
+	}
+	// REJECTED → still refused, which is what the tombstone is for.
+	read, _ := d.OntologyTermsFromTree(opCtx, "tenant", memrank.OntologyPath)
+	var pid string
+	for _, p := range read.Proposals {
+		if p.Name == "outage" {
+			pid = p.ChunkID
+		}
+	}
+	g, _ := docExec(t, d, opCtx, `{"op":"get_chunk","scope":"tenant","id":"`+pid+`"}`)
+	rev := int(g["revision"].(float64))
+	if _, rr := docExec(t, d, opCtx, fmt.Sprintf(
+		`{"op":"update_chunk","scope":"tenant","id":"%s","status":"rejected","revision":%d}`, pid, rev)); rr.IsError {
+		t.Fatalf("operator reject: %s", rr.Text)
+	}
+	_, r = docExec(t, d, agentCtx, `{"op":"propose_entity","name":"outage","parent":"event"}`)
+	if !r.IsError || !strings.Contains(r.Text, "rejected") {
+		t.Errorf("a rejected type must not be re-proposable, and the refusal should say so: %s", r.Text)
+	}
+
+	// An unknown parent is refused rather than silently filed at the top level, where an
+	// operator would see a root type they never asked for.
+	_, r = docExec(t, d, agentCtx, `{"op":"propose_entity","name":"thing","parent":"nonesuch"}`)
+	if !r.IsError || !strings.Contains(r.Text, "no entity named") {
+		t.Errorf("an unknown parent should be refused: %s", r.Text)
+	}
+	// And the evidence body is bounded.
+	big, _ := json.Marshal(strings.Repeat("x", proposalBodyMax+1))
+	_, r = docExec(t, d, agentCtx, `{"op":"propose_entity","name":"huge","body":`+string(big)+`}`)
+	if !r.IsError || !strings.Contains(r.Text, "limit") {
+		t.Errorf("an oversized proposal body should be refused: %s", r.Text)
+	}
+}
+
+// mustTenantKey exposes the tenant scope key for a test that needs to address chunks
+// directly.
+func mustTenantKey(t *testing.T, d *Document, ctx context.Context) sqlmem.ScopeKey {
+	t.Helper()
+	key, _, err := d.ontologyTenantKey(ctx)
+	if err != nil {
+		t.Fatalf("ontologyTenantKey: %v", err)
+	}
+	return key
 }

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -794,6 +794,31 @@ type ctxKeyDispatcher struct{}
 // WithDispatcher attaches the run's Dispatcher to ctx. Called at run
 // start in the HTTP server (same locations as WithRunID /
 // WithRunIdentity).
+type ctxKeySubstrateOperator struct{}
+
+// WithSubstrateOperator marks a context as the OPERATOR's own off-run substrate call —
+// the Web UI and the admin HTTP routes, not an agent's tool call inside a run.
+//
+// EXPLICIT DISCRIMINATOR, deliberately, rather than inferring it from the identity the
+// off-run path already stamps. That path uses a synthetic agent id (`a_http-admin`), and
+// reading authorization off it would be a hole: `POST /v1/runs` accepts a caller-supplied
+// `agent_id`, so a run could claim that value and be mistaken for the operator. A marker
+// with no wire field cannot be claimed.
+//
+// Absent means "not the operator", so anything that has not been explicitly stamped —
+// every run path, every sub-agent, every MCP session — is treated as an agent. A
+// no-op-on-empty setter here would silently widen, which is the failure mode this
+// codebase has already paid for once.
+func WithSubstrateOperator(ctx context.Context) context.Context {
+	return context.WithValue(ctx, ctxKeySubstrateOperator{}, true)
+}
+
+// IsSubstrateOperator reports whether ctx is an operator's own off-run call.
+func IsSubstrateOperator(ctx context.Context) bool {
+	v, _ := ctx.Value(ctxKeySubstrateOperator{}).(bool)
+	return v
+}
+
 func WithDispatcher(ctx context.Context, d *Dispatcher) context.Context {
 	if d == nil {
 		return ctx


### PR DESCRIPTION
## Why

Phase 1 gave you accept/reject on a dedicated route and made a proposal inert. That narrowing was real for the UI and **unenforced underneath**: `scope=tenant` on the Document tool is write authority over the whole ontology document, so an agent holding it could create a live type outright, or clear its own proposal's status and call the result reviewed. A gate the reviewed thing can open is ceremony.

You flagged this ordering concern when P1 merged; this closes it before the curator exists to exploit it.

## What

On the tenant ontology document, and only there, an agent's tool call may add a chunk with status `proposed` — and nothing else.

**`propose_entity`** is the ergonomic front door. It resolves the ontology document, takes the parent **by name** (what the agent read in its prompt — it has no way to know a chunk id), stamps the status so the contract can't be spelled wrong, bounds the evidence body, and refuses a name that's already in force, already proposed, or already **rejected** — the last being exactly what the tombstone is for.

It needs no tenant grant, deliberately: a proposal can't change what any run is told, so requiring the authority live authoring needs would mean only an agent that could *already* author live types could suggest one.

## The two things that would have been holes

**The discriminator had to be explicit.** The off-run operator path already stamps a synthetic agent id, and my first instinct was to key on it — but `POST /v1/runs` accepts a **caller-supplied `agent_id`**, so a run could claim that value and be read as the operator. Authorization now keys on a context marker with no wire form, stamped at the two operator roots and set by nothing else.

**The refused set had to be audited from the op list**, not from the obvious mutations. My first version covered the five chunk writes and left five routes to the same effect open:

| op | what it reaches |
|---|---|
| `import_md` / `import_canvas` | authors chunks wholesale |
| `supersede_chunk` | retires a live entity, installs a replacement |
| `delete_document` | removes the whole ontology |
| `set_path` | re-homes `/memory/ontology` so the reader resolves elsewhere |

The last two also needed a fix to how the target document is identified — they put the *document* id in `id`, where a chunk lookup returns nothing and the check sailed past.

## Tested

`go test ./...` clean.

- `TestOntologyGuard_AnAgentMayProposeButNotDecide` — ten refusals, and **each was verified to fail on the unguarded code**. Two of those checks were vacuous on first write and got fixed: `supersede_chunk` was malformed (failing input validation, not the guard), and `set_path` only appeared refused because an earlier case in the same list had already deleted the document. I probed both by confirming the operator succeeds at them.
- Same test asserts the **operator can still accept**, and `TestOntologyGuard_LeavesOtherDocumentsAlone` asserts an agent can still write ordinary tenant documents. Without those two, "refuse everyone" would pass every negative assertion and break the product.
- `TestProposeEntity_RefusesWhatAnOperatorHasAlreadySeen` — in force / proposed / rejected, unknown parent, oversized body.

## One consequence worth knowing

An MCP session is an agent surface, so **an operator driving the thin client can no longer flip the ontology's confirm status or author live entities there**. The Web UI and `POST /v1/_ontology` remain the operator path. That follows from the decision that accepting is narrower than document write, but it is a behaviour change for anyone who was setting up an ontology over MCP — tell me if you want the MCP-with-a-`substrate:tenant`-token case treated as operator instead, since that's a defensible reading I deliberately didn't take.

Phase 3 (the curator agent) is next: it now has a narrow op to file through and nothing else it can touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8