### PR TITLE
fix(cloud-web): sign-in opens /ui?token= (was 404) + honest copy

### DIFF
--- a/cloud-web/index.html
+++ b/cloud-web/index.html
@@ -726,7 +726,7 @@ table.models tr[data-dim] td { color: color-mix(in srgb, var(--color-text) 45%, 
     <div class="row-item rise">
       <p class="r-num">Step 03</p>
       <h2 class="r-title">Pick a token and sign in</h2>
-      <p class="r-copy">Pick a token by name and sign in. The bearer is handed to the app over an origin-pinned <code>postMessage</code> — never a <code>?token=</code> query string, so it stays out of browser history, out of the <code>Referer</code> header, and out of every Cloudflare and nginx access log. The runtime itself sits behind a reverse proxy on its own VPS.</p>
+      <p class="r-copy">Pick a token by name and sign in — it opens <code>app.loomcycle.cloud/ui</code> already authenticated: the runtime consumes the bearer, sets an HttpOnly session cookie, and drops it from the address bar. The runtime itself sits behind a reverse proxy on its own VPS.</p>
     </div>
   </section>
 
@@ -1013,7 +1013,7 @@ loomcycle mcp --upstream https://app.loomcycle.cloud/v1/_mcp</pre>
           <button type="button" class="btn btn-ghost" data-back-tokens>Back to the vault</button>
           <span class="copied" id="copied-flag">Copied</span>
         </div>
-        <p class="fineprint" style="margin-top:var(--half)">The bearer is handed to the app over <code class="inline-code">postMessage</code>, origin-pinned to <code class="inline-code">https://app.loomcycle.cloud</code> — it never appears in a URL, in browser history, or in a Cloudflare or nginx access log.</p>
+        <p class="fineprint" style="margin-top:var(--half)">Signing in opens <code class="inline-code">app.loomcycle.cloud/ui</code> with your bearer; the runtime consumes it, sets an HttpOnly session cookie, and 302s to a clean URL. (A postMessage handoff that keeps the token out of the URL entirely is coming in the next runtime build.)</p>
       </div>
     </div>
   </div>

--- a/cloud-web/index.html
+++ b/cloud-web/index.html
@@ -1452,21 +1452,14 @@ loomcycle mcp --upstream https://app.loomcycle.cloud/v1/_mcp</pre>
     return { list, add, reveal, remove };
   })();
 
-  /* the bearer goes to the app over an origin-pinned postMessage — never in a
-     URL, so it stays out of history, Referer, and every proxy access log */
+  /* Sign in to the runtime UI via its own login URL: the Go handler
+     (internal/webui) consumes /ui?token=<bearer>, sets the HttpOnly
+     loomcycle_session cookie, and 302s to /ui — dropping the token from the
+     address bar. The runtime UI is served at /ui (its root 404s), and it has no
+     postMessage receiver, so open the login URL directly. */
   function handoff(token) {
-    const w = window.open(APP, 'loomcycle-app');
-    if (!w) { alert('Allow the popup to hand the token to app.loomcycle.cloud.'); return; }
-    let n = 0;
-    const t = setInterval(() => {
-      if (n++ > 40) return clearInterval(t);
-      try { w.postMessage({ type: 'loomcycle.login', token }, APP); } catch (_) {}
-    }, 250);
-    /* the app replies once it has stored the bearer */
-    addEventListener('message', function ack(e) {
-      if (e.origin !== APP || e.data?.type !== 'loomcycle.login.ok') return;
-      clearInterval(t); removeEventListener('message', ack);
-    });
+    const w = window.open(APP + '/ui?token=' + encodeURIComponent(token), 'loomcycle-app');
+    if (!w) { alert('Allow the popup to sign in to app.loomcycle.cloud.'); }
   }
 
   function go(step) {


### PR DESCRIPTION
The landing's "Sign in to app.loomcycle.cloud" button was broken: `handoff(token)` opened `https://app.loomcycle.cloud` (the runtime **root**, which 404s — the UI is served at `/ui`) and then passed the bearer via `postMessage`, but the runtime Web UI logs in via `/ui?token=` and has **no postMessage receiver**. So it was doubly broken: wrong path + a message nothing listens for.

**Fix:** open the runtime's real login URL — `https://app.loomcycle.cloud/ui?token=<bearer>` — which `internal/webui` consumes to set the `loomcycle_session` cookie and 302 to `/ui` (dropping the token from the address bar). Verified live.

**Copy honesty:** the fineprint + step-03 text claimed the bearer is handed over `postMessage` and "never appears in a URL / out of every access log" — false with `?token=`. Rewritten to describe the actual flow, with a note that the postMessage handoff is coming next build.

### Security note (surfaced + accepted)
`?token=` puts a scoped, revocable `substrate:tenant` bearer in the URL (browser history + access logs) — the same mechanism the runtime UI's own login form already uses. Two background security reviews flagged this; it's a deliberate interim. The **secure handoff** (a runtime-side `postMessage` receiver / header-based login so the token never touches a URL) is being prepared as a separate PR for the next runtime build.

Deployed live to `cloud-home:~/work/loomcycle-cloud/web/` (the landing serves it from the read-only mount).