### PR TITLE
feat(webui): URL-free login (POST /ui/session + postMessage handoff) — secure option b

### DIFF
--- a/cloud-deployment/.env.insecure.example
+++ b/cloud-deployment/.env.insecure.example
@@ -79,3 +79,8 @@ MINT_SCOPES=substrate:tenant,runs:create
 MINT_TENANT_PREFIX=t_
 # CSRF origin check for POST /api/mint (the public landing origin).
 LANDING_ORIGIN=https://loomcycle.cloud
+# Web UI URL-free sign-in: the first-party origin(s) the runtime's /ui may accept
+# a bearer handoff FROM over postMessage (the landing that mints tenant tokens),
+# comma-separated. Empty ⇒ the postMessage login receiver stays disabled. Set to
+# your landing origin so "Sign in" hands the token to /ui WITHOUT a ?token= URL.
+LOOMCYCLE_UI_LOGIN_ORIGINS=https://loomcycle.cloud

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -3108,9 +3108,15 @@ func (s *Server) Mux() http.Handler {
 	// — the SPA shell is public; it pulls protected data from
 	// /v1/* which DOES go through authMiddleware. Standard SPA-on-
 	// API split.
-	uiHandler := webui.Handler("/ui", false)
+	uiHandler := webui.Handler("/ui", false, s.cfg.Env.UILoginOrigins)
 	mux.Handle("GET /ui", recoveryMiddleware(uiHandler))
 	mux.Handle("GET /ui/", recoveryMiddleware(uiHandler))
+	// POST /ui/session — the URL-free login (Authorization: Bearer -> session
+	// cookie), used by the SPA's paste-token form + its postMessage handoff
+	// receiver. Unauthenticated like GET /ui (it ESTABLISHES the session); the
+	// handler enforces the same-origin login-CSRF guard. The GET-only /ui routes
+	// above don't match a POST, so it needs its own registration.
+	mux.Handle("POST /ui/session", recoveryMiddleware(uiHandler))
 	// v1.x RFC G A2A — additive routes (well-known AgentCard + REST /
 	// JSON-RPC binding mounts) registered by an external hook so the
 	// A2A package stays decoupled from this one. The hook also receives

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2358,7 +2358,14 @@ type Env struct {
 	// decoded bytes, so the request cap is the binding one on upload.
 	// LOOMCYCLE_MAX_DOCUMENT_ASSET_BYTES (bytes; <=0 ignored, default kept).
 	MaxDocumentAssetBytes int64
-	AuthToken             string
+	// UILoginOrigins (LOOMCYCLE_UI_LOGIN_ORIGINS, comma-separated) are the
+	// first-party origins the Web UI's postMessage login receiver may accept a
+	// bearer handoff FROM — e.g. "https://loomcycle.cloud" for the landing that
+	// mints tenant tokens. Empty ⇒ the receiver stays disabled (no cross-origin
+	// handoff), so a deployment without a configured landing can't be handed a
+	// token by any page. Non-secret.
+	UILoginOrigins []string
+	AuthToken      string
 	// OperatorTokenPepper is prepended to a bearer before SHA-256 when
 	// hashing OperatorTokenDef tokens (RFC L). A stolen DB dump without
 	// the pepper yields no usable token lookup. Secret — never logged.
@@ -3279,6 +3286,19 @@ func Load(paths ...string) (*Config, error) {
 // historical byte-identical fast path; everything else goes through the RFC AN
 // merge. Downstream — AGENTS_ROOT discovery, system_prompt_file resolution, the
 // env block, validate() — runs once over the assembled whole, unchanged.
+// splitCommaTrim splits a comma-separated env value into trimmed, non-empty
+// entries with any trailing slash removed (so an origin compares exactly).
+// Returns nil for an empty/blank input.
+func splitCommaTrim(s string) []string {
+	var out []string
+	for _, part := range strings.Split(s, ",") {
+		if v := strings.TrimRight(strings.TrimSpace(part), "/"); v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
 func LoadLayers(layers ...Layer) (*Config, error) {
 	cfg := &Config{
 		Concurrency: Concurrency{
@@ -3396,6 +3416,7 @@ func LoadLayers(layers ...Layer) (*Config, error) {
 		GeminiBaseURL:               os.Getenv("GEMINI_BASE_URL"),
 		ListenAddr:                  getenvDefault("LOOMCYCLE_LISTEN_ADDR", "127.0.0.1:8787"),
 		PublicURL:                   strings.TrimRight(strings.TrimSpace(os.Getenv("LOOMCYCLE_PUBLIC_URL")), "/"),
+		UILoginOrigins:              splitCommaTrim(os.Getenv("LOOMCYCLE_UI_LOGIN_ORIGINS")),
 		AuthToken:                   os.Getenv("LOOMCYCLE_AUTH_TOKEN"),
 		OperatorTokenPepper:         os.Getenv("LOOMCYCLE_OPERATOR_TOKEN_PEPPER"),
 		SecretKey:                   os.Getenv("LOOMCYCLE_SECRET_KEY"),

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -14,6 +14,7 @@ package webui
 
 import (
 	"embed"
+	"encoding/json"
 	"fmt"
 	"io/fs"
 	"net/http"
@@ -46,25 +47,71 @@ var uiAssets embed.FS
 // The `secureCookie` flag forces the Secure attribute on the
 // session cookie. Operators behind TLS terminators that don't set
 // r.TLS should pass true.
-func Handler(prefix string, secureCookie bool) http.Handler {
+func Handler(prefix string, secureCookie bool, loginOrigins []string) http.Handler {
 	prefix = strings.TrimRight(prefix, "/")
 	mux := http.NewServeMux()
 
+	setSession := func(w http.ResponseWriter, r *http.Request, token string) {
+		http.SetCookie(w, &http.Cookie{
+			Name:     SessionCookie,
+			Value:    token,
+			Path:     "/",
+			HttpOnly: true,
+			SameSite: http.SameSiteStrictMode,
+			Secure:   secureCookie || r.TLS != nil,
+		})
+	}
+
 	mux.HandleFunc(fmt.Sprintf("GET %s", prefix), func(w http.ResponseWriter, r *http.Request) {
-		// Token-set redirect — operator's first load.
+		// Token-set redirect — operator's first load. Kept for backward
+		// compatibility (bookmarks, the CLI hint). The POST /session route below
+		// is the preferred, URL-free path.
 		if token := r.URL.Query().Get("token"); token != "" {
-			http.SetCookie(w, &http.Cookie{
-				Name:     SessionCookie,
-				Value:    token,
-				Path:     "/",
-				HttpOnly: true,
-				SameSite: http.SameSiteStrictMode,
-				Secure:   secureCookie || r.TLS != nil,
-			})
+			setSession(w, r, token)
 			http.Redirect(w, r, prefix, http.StatusFound)
 			return
 		}
 		serveFile(w, "index.html")
+	})
+
+	// POST <prefix>/session — set the session cookie from an Authorization: Bearer
+	// header instead of a ?token= query, so the bearer never appears in a URL,
+	// browser history, or an access log. Used by (1) the SPA's paste-token form and
+	// (2) its postMessage receiver, which accepts a bearer handed off from an
+	// allowed first-party origin (e.g. the loomcycle.cloud landing) and posts it
+	// here same-origin. LOGIN-CSRF GUARD: require Sec-Fetch-Site: same-origin so
+	// only THIS app's own /ui page can set the cookie — a cross-site page cannot
+	// force a victim's browser to adopt an attacker's token (and a cross-origin
+	// fetch cannot set the Authorization header without a CORS grant we never make).
+	mux.HandleFunc(fmt.Sprintf("POST %s/session", prefix), func(w http.ResponseWriter, r *http.Request) {
+		if sfs := r.Header.Get("Sec-Fetch-Site"); sfs != "" && sfs != "same-origin" {
+			writeJSONErr(w, http.StatusForbidden, "cross_site_login_refused",
+				"session login must be same-origin")
+			return
+		}
+		token := bearerToken(r.Header.Get("Authorization"))
+		if token == "" {
+			writeJSONErr(w, http.StatusBadRequest, "missing_bearer",
+				"Authorization: Bearer <token> required")
+			return
+		}
+		setSession(w, r, token)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	// GET <prefix>/login-config.json — the non-secret origins the SPA's
+	// postMessage login receiver may accept a bearer handoff FROM (set via
+	// LOOMCYCLE_UI_LOGIN_ORIGINS). Empty list ⇒ the receiver stays disabled, so a
+	// deployment that doesn't configure a landing origin can't be handed a token
+	// by any page. Never secret; safe to serve unauthenticated.
+	mux.HandleFunc(fmt.Sprintf("GET %s/login-config.json", prefix), func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "no-store")
+		origins := loginOrigins
+		if origins == nil {
+			origins = []string{}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"login_origins": origins})
 	})
 
 	// Logout — clears the session cookie and bounces to the login page. The
@@ -107,6 +154,24 @@ func Handler(prefix string, secureCookie bool) http.Handler {
 	})
 
 	return mux
+}
+
+// bearerToken extracts the token from an "Authorization: Bearer <token>" header
+// value (scheme match is case-insensitive per RFC 7235). Returns "" when the
+// header is absent or not a Bearer credential.
+func bearerToken(authHeader string) string {
+	const p = "bearer "
+	if len(authHeader) <= len(p) || !strings.EqualFold(authHeader[:len(p)], p) {
+		return ""
+	}
+	return strings.TrimSpace(authHeader[len(p):])
+}
+
+// writeJSONErr writes a {code,error} JSON body with the given status.
+func writeJSONErr(w http.ResponseWriter, status int, code, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"code": code, "error": msg})
 }
 
 // serveFile reads a file from the embedded fs and writes it with a

--- a/internal/webui/webui_test.go
+++ b/internal/webui/webui_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestHandler_TokenQueryRedirectsAndSetsCookie(t *testing.T) {
-	h := Handler("/ui", false)
+	h := Handler("/ui", false, nil)
 	req := httptest.NewRequest("GET", "/ui?token=secret-token-123", nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
@@ -44,7 +44,7 @@ func TestHandler_TokenQueryRedirectsAndSetsCookie(t *testing.T) {
 }
 
 func TestHandler_LogoutClearsCookieAndRedirects(t *testing.T) {
-	h := Handler("/ui", false)
+	h := Handler("/ui", false, nil)
 	req := httptest.NewRequest("GET", "/ui/logout", nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
@@ -73,7 +73,7 @@ func TestHandler_LogoutClearsCookieAndRedirects(t *testing.T) {
 func TestHandler_SecureCookieFlag(t *testing.T) {
 	// secureCookie=true forces the Secure attribute even when r.TLS is
 	// nil — covers the operator behind a TLS terminator.
-	h := Handler("/ui", true)
+	h := Handler("/ui", true, nil)
 	req := httptest.NewRequest("GET", "/ui?token=x", nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
@@ -90,7 +90,7 @@ func TestHandler_IndexReturns503WhenUINotBuilt(t *testing.T) {
 	// dist/ in the source tree contains only .gitkeep at this point
 	// (assuming tests run before `make build-ui`). Hitting /ui without
 	// an index.html should produce the documented diagnostic.
-	h := Handler("/ui", false)
+	h := Handler("/ui", false, nil)
 	req := httptest.NewRequest("GET", "/ui", nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
@@ -123,5 +123,90 @@ func TestContentType(t *testing.T) {
 		if got := contentType(name); got != want {
 			t.Errorf("contentType(%q) = %q, want %q", name, got, want)
 		}
+	}
+}
+
+// TestPostSession_SetsCookieFromBearer: the URL-free login (RFC — secure
+// handoff). A same-origin POST /ui/session with Authorization: Bearer <token>
+// sets the loomcycle_session cookie (HttpOnly, SameSite=Strict) and 204s — the
+// bearer never appears in a URL.
+func TestPostSession_SetsCookieFromBearer(t *testing.T) {
+	h := Handler("/ui", true, []string{"https://loomcycle.cloud"})
+	req := httptest.NewRequest("POST", "/ui/session", nil)
+	req.Header.Set("Authorization", "Bearer secret-token-123")
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body=%s", rec.Code, rec.Body.String())
+	}
+	var found *http.Cookie
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == SessionCookie {
+			found = c
+		}
+	}
+	if found == nil || found.Value != "secret-token-123" {
+		t.Fatalf("session cookie = %+v, want value secret-token-123", found)
+	}
+	if !found.HttpOnly || found.SameSite != http.SameSiteStrictMode || !found.Secure {
+		t.Errorf("cookie attrs weak: HttpOnly=%v SameSite=%v Secure=%v", found.HttpOnly, found.SameSite, found.Secure)
+	}
+}
+
+// TestPostSession_RejectsCrossSite: the login-CSRF guard. A cross-site POST
+// (Sec-Fetch-Site: cross-site) is refused, so no page can force a victim's
+// browser to adopt an attacker's token.
+func TestPostSession_RejectsCrossSite(t *testing.T) {
+	h := Handler("/ui", false, nil)
+	req := httptest.NewRequest("POST", "/ui/session", nil)
+	req.Header.Set("Authorization", "Bearer x")
+	req.Header.Set("Sec-Fetch-Site", "cross-site")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("cross-site POST status = %d, want 403", rec.Code)
+	}
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == SessionCookie {
+			t.Fatalf("cross-site request must NOT set a session cookie")
+		}
+	}
+}
+
+// TestPostSession_RejectsMissingBearer: no bearer → 400, no cookie.
+func TestPostSession_RejectsMissingBearer(t *testing.T) {
+	h := Handler("/ui", false, nil)
+	req := httptest.NewRequest("POST", "/ui/session", nil)
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("missing-bearer status = %d, want 400", rec.Code)
+	}
+}
+
+// TestLoginConfig_ServesConfiguredOrigins: the SPA reads the allowed handoff
+// origins here; an unconfigured deployment returns an empty list (receiver
+// disabled).
+func TestLoginConfig_ServesConfiguredOrigins(t *testing.T) {
+	h := Handler("/ui", false, []string{"https://loomcycle.cloud"})
+	req := httptest.NewRequest("GET", "/ui/login-config.json", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "https://loomcycle.cloud") || !strings.Contains(body, "login_origins") {
+		t.Errorf("login-config body = %s, want login_origins incl. the landing origin", body)
+	}
+
+	// Unconfigured → empty array, not null (so the SPA gets a definite disabled state).
+	h2 := Handler("/ui", false, nil)
+	rec2 := httptest.NewRecorder()
+	h2.ServeHTTP(rec2, httptest.NewRequest("GET", "/ui/login-config.json", nil))
+	if body := strings.TrimSpace(rec2.Body.String()); !strings.Contains(body, "[]") {
+		t.Errorf("unconfigured login-config = %s, want an empty [] list", body)
 	}
 }

--- a/web/src/pages/LoginView.tsx
+++ b/web/src/pages/LoginView.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 // LoginView is the token-entry auth page (multi-tenant UI authz). loomcycle
 // authenticates by bearer token, not username/password — paste an
@@ -7,21 +7,72 @@ import { useState } from "react";
 //   - a substrate:admin token → super-admin (sees/edits all tenants);
 //   - any other token → that token's tenant workspace only.
 //
-// Submitting navigates to /ui?token=… — the Go handler (internal/webui)
-// sets the HttpOnly loomcycle_session cookie and 302s back to /ui, so the
-// token never lives in JS storage. This is also where a 401 bounces to.
+// Two URL-free ways in, both via POST /ui/session (the bearer travels in an
+// Authorization header, never a query string, so it stays out of history,
+// Referer, and access logs). The server sets the HttpOnly loomcycle_session
+// cookie; we then reload /ui so the SPA re-boots with the cookie present.
+//   1. Paste a token into the form below.
+//   2. A configured first-party origin (LOOMCYCLE_UI_LOGIN_ORIGINS — e.g. the
+//      loomcycle.cloud landing that mints tenant tokens) hands a bearer over an
+//      origin-pinned postMessage; the receiver below exchanges it for the cookie.
+// GET /ui?token= still works (bookmarks / the CLI hint) but keeps the token in
+// the URL, so it is not used here.
+
+// establishSession swaps a bearer for the HttpOnly session cookie without ever
+// putting it in a URL. Returns true on success (204).
+async function establishSession(token: string): Promise<boolean> {
+  const r = await fetch("/ui/session", {
+    method: "POST",
+    credentials: "same-origin",
+    headers: { Authorization: "Bearer " + token },
+  });
+  return r.status === 204;
+}
+
 export default function LoginView() {
   const [token, setToken] = useState("");
+  const [error, setError] = useState("");
 
-  const submit = (e: React.FormEvent) => {
+  // postMessage login handoff: accept a bearer from an ALLOWED first-party
+  // origin and exchange it for the session cookie. The origin pin is the
+  // login-CSRF guard — an unlisted page's message is ignored, so no site can
+  // force this browser to adopt an attacker's token.
+  useEffect(() => {
+    let allowed: string[] = [];
+    fetch("/ui/login-config.json", { credentials: "same-origin" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((c) => {
+        if (c && Array.isArray(c.login_origins)) allowed = c.login_origins;
+      })
+      .catch(() => {});
+    const onMessage = async (e: MessageEvent) => {
+      if (allowed.length === 0 || !allowed.includes(e.origin)) return;
+      const d = e.data as { type?: string; token?: unknown } | null;
+      if (!d || d.type !== "loomcycle.login" || typeof d.token !== "string") return;
+      if (await establishSession(d.token)) {
+        // ack the opener so it can stop retrying / avoid the URL fallback.
+        try {
+          (e.source as Window | null)?.postMessage({ type: "loomcycle.login.ok" }, e.origin);
+        } catch {
+          /* opener gone — harmless */
+        }
+        window.location.href = "/ui";
+      }
+    };
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, []);
+
+  const submit = async (e: React.FormEvent) => {
     e.preventDefault();
     const t = token.trim();
     if (!t) return;
-    // The server's ?token= landing handler sets the cookie + redirects
-    // back to /ui (stripping the token from the URL so a refresh doesn't
-    // re-set it). Full navigation, not a router push — we want the Go
-    // handler to run and the SPA to re-boot with the cookie present.
-    window.location.href = "/ui?token=" + encodeURIComponent(t);
+    setError("");
+    if (await establishSession(t)) {
+      window.location.href = "/ui";
+    } else {
+      setError("That token was not accepted — check it and try again.");
+    }
   };
 
   return (
@@ -44,6 +95,7 @@ export default function LoginView() {
           spellCheck={false}
           autoComplete="off"
         />
+        {error && <p className="login-error" role="alert">{error}</p>}
         <button className="login-btn" type="submit" disabled={token.trim() === ""}>
           Sign in
         </button>


### PR DESCRIPTION
The runtime-side **secure sign-in handoff** so a bearer never touches a URL — the "option (b)" follow-up to the interim `/ui?token=` fix (#987). Ships in the next build.

## Why
The Web UI logs in via `GET /ui?token=`, which puts the bearer in a URL (browser history + Cloudflare/runtime access logs — flagged twice by the background security review). This adds a URL-free path so the `loomcycle.cloud` landing can hand a minted tenant token to `app.loomcycle.cloud/ui` without the token appearing in a URL.

## What
**Runtime (`internal/webui`):**
- **`POST /ui/session`** — sets the `loomcycle_session` cookie from an `Authorization: Bearer` header (not a query). **Login-CSRF guard:** requires `Sec-Fetch-Site: same-origin`, so only this app's own `/ui` page can set the cookie (and a cross-origin fetch can't set `Authorization` without a CORS grant we never make).
- **`GET /ui/login-config.json`** — the allowed handoff origins for the SPA's `postMessage` receiver; empty ⇒ receiver disabled (a deployment without a configured landing can't be handed a token).
- New non-secret env **`LOOMCYCLE_UI_LOGIN_ORIGINS`** (comma list) → `webui.Handler`. `GET ?token=` kept for backward compat.

**SPA (`LoginView`):** an **origin-pinned** `message` listener exchanges a handed-off bearer via `POST /ui/session`; the manual paste-token form now uses the same POST (no `?token=` URL).

**Deployment:** `.env.insecure.example` documents `LOOMCYCLE_UI_LOGIN_ORIGINS` (the loomcycle service loads it via `env_file`).

## Follow-up at next-build deploy (NOT in this PR)
Switch `cloud-web`'s `handoff()` to open `/ui` + `postMessage` the token (with a graceful fallback to `/ui?token=` against an older runtime), and restore the "never in a URL" copy. **Deploy this runtime image first**, then the cloud-web switch. Until then the interim `/ui?token=` (#987) stands. Kept out of this PR to avoid conflicting with #987 and to enforce the deploy order.

## Tested
New `internal/webui` tests: `POST /ui/session` sets the cookie from a same-origin bearer, refuses cross-site (403) + missing bearer (400); `login-config.json` serves the origins (`[]` when unconfigured). `go build ./...` clean; web `tsc --noEmit` clean.

> Note: the cross-origin `postMessage` handoff needs a real two-origin browser test before it's relied on in production — that's part of the next-build validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)