### PR TITLE
chore(explorer): 0.7.0 — the + child nesting fix reaches npm

### DIFF
--- a/packages/explorer/package-lock.json
+++ b/packages/explorer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@loomcycle/explorer",
-  "version": "0.5.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@loomcycle/explorer",
-      "version": "0.5.0",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "react-markdown": "^9.1.0",

--- a/packages/explorer/package.json
+++ b/packages/explorer/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@loomcycle/explorer",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "module",
-  "description": "Embeddable React Path VFS + chunked-graph Document browser for the loomcycle agentic runtime (RFC AL / AK) — a themeable, standalone package: a dirent tree with folder/document CRUD and a chunk-tree Document viewer/editor.",
+  "description": "Embeddable React Path VFS + chunked-graph Document browser for the loomcycle agentic runtime (RFC AL / AK) \u2014 a themeable, standalone package: a dirent tree with folder/document CRUD and a chunk-tree Document viewer/editor.",
   "license": "Apache-2.0",
   "author": "Dennis Gubsky",
   "repository": {


### PR DESCRIPTION
## Why

The published `@loomcycle/explorer@0.6.0` **cannot nest a chunk**: `+ text` inserts a sibling, so a document's hierarchy could only be built by `import_md` or by an agent. The Web UI got the fix immediately because it consumes this package's *source* through a Vite alias — external consumers of the npm package did not.

## Why the bump is its own PR

The bump and the `explorer-v0.7.0` tag have to land together. Bumping *after* a tag is exactly what stranded `@loomcycle/client` earlier in this line: the publish step fires only when `package.json` matches the tag, so a bump on the wrong side of it means that version can never publish. Merge this, and I'll cut the tag against a commit that already says 0.7.0.

## Verified before bumping

- `npm ci`, `npm run build:lib`, `npm test` (21 tests) all clean in an isolated worktree.
- The fix is in the **built bundle**, not just the source.
- `npm pack --dry-run`: 26 files, `dist` only, 164 kB.

Also synced the lockfile's recorded root version, which said **0.5.0** — two releases stale. Harmless (`npm ci` compares dependencies, and 0.6.0 published fine) but it only drifts further. Edited surgically rather than regenerated: a regenerate would move transitive dependencies and turn a version bump into a dependency change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8