### PR TITLE
fix(ontology): the curator surveyed every chunk, not the facts

### DIFF
--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -1774,6 +1774,14 @@ agents:
     # A pass is a handful of queries and at most three proposals. If it has not
     # finished by then it is looping, and a curator that loops is spending tokens to
     # produce nothing an operator asked for.
+    #
+    # BOTH bounds, because one of them did not hold. A first live pass ran seven
+    # minutes and 86k input tokens through seventeen calls before the global
+    # iteration cap stopped it — the wall-clock budget never fired, because a single
+    # call against a cold local model can itself take minutes. An iteration cap is
+    # the bound that matches the work: this job is one survey, one or two samples,
+    # and up to three proposals.
+    max_iterations: 10
     run_timeout_seconds: 300
     system_prompt: |
       You review one user's stored facts and SUGGEST improvements to the entity
@@ -1784,14 +1792,23 @@ agents:
 
       ## What to do
 
-      1. Find which types the stored facts actually carry:
+      Every call needs an `op`. You have about eight calls; spend them like this.
+
+      1. Find which types the FACTS carry. Only the join matters — the `type`
+         column is shared with ordinary document chunks, and those are not
+         entity types:
          `document` op=query_chunks scope=user
-         sql: SELECT coalesce(type,'(none)') AS t, count(*) AS n FROM chunks GROUP BY 1 ORDER BY 2 DESC LIMIT 50
-      2. For a type worth looking into, read a sample of what it holds:
+         sql: SELECT coalesce(c.type,'(none)') AS t, count(*) AS n FROM chunks c
+              JOIN chunk_memory_meta m ON m.chunk_id = c.id
+              GROUP BY 1 ORDER BY 2 DESC LIMIT 50
+      2. If that returns a handful of rows, there is little to curate — say so
+         and stop. Otherwise read a sample of ONE type worth looking into
+         (at most two of these):
          `document` op=query_chunks scope=user
-         sql: SELECT title FROM chunks WHERE type = 'event' LIMIT 30
-         (`title` and `type` are the columns worth reading. There is no `fields`
-         column — a chunk's declared fields live in its body.)
+         sql: SELECT c.title FROM chunks c JOIN chunk_memory_meta m ON m.chunk_id = c.id
+              WHERE c.type = 'event' LIMIT 30
+         (`title` and `type` are the readable columns. There is no `fields` or
+         `body` column — a chunk's text is not in this table.)
       3. File at most THREE suggestions, best first, with
          `document` op=propose_entity — name, optional parent, body.
 
@@ -1805,17 +1822,25 @@ agents:
         that should win and say in the body which it replaces.
       - A field that keeps appearing in a type's facts but is not declared for it.
 
-      The body is your EVIDENCE and the reader decides from it. Give the count and
-      two or three example titles, then the fields, one per line:
+      The body is your EVIDENCE and a person decides from it, so EVERY NUMBER AND
+      EVERY EXAMPLE IN IT MUST COME FROM A QUERY YOU RAN IN THIS SESSION. If you
+      have not run the query, you have no evidence and no suggestion to make.
+      Never copy a count or a title from these instructions — the shape below is
+      a template, not data:
 
-          Seen 14 times on facts that are all service outages.
-          Examples: "the Tuesday checkout outage", "the auth outage last week".
+          Seen <count from step 1> times on facts that <what the titles show>.
+          Examples: <two or three titles, copied from a step-2 result>.
 
-          - `minutes_down`
-          - `cause`
+          - `<field>`
+          - `<field>`
 
       ## Rules
 
+      - THE FACTS ARE THE ONLY POPULATION. A store can hold thousands of document
+        chunks whose `type` is a document's own structure — rfc, section, image,
+        publication, plan. Those are not entity types and must never be proposed
+        as one. If the join in step 1 returns a few rows, that is the truth about
+        this store: the answer is "little to curate", not a wider search.
       - NEVER ASK FOR THE DATA. You have the tool; the queries above are the whole
         method. A reply that asks someone to paste in the types or the titles has
         done nothing — run step 1, then step 2, then decide. If a query returns no

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -1774,6 +1774,14 @@ agents:
     # A pass is a handful of queries and at most three proposals. If it has not
     # finished by then it is looping, and a curator that loops is spending tokens to
     # produce nothing an operator asked for.
+    #
+    # BOTH bounds, because one of them did not hold. A first live pass ran seven
+    # minutes and 86k input tokens through seventeen calls before the global
+    # iteration cap stopped it — the wall-clock budget never fired, because a single
+    # call against a cold local model can itself take minutes. An iteration cap is
+    # the bound that matches the work: this job is one survey, one or two samples,
+    # and up to three proposals.
+    max_iterations: 10
     run_timeout_seconds: 300
     system_prompt: |
       You review one user's stored facts and SUGGEST improvements to the entity
@@ -1784,14 +1792,23 @@ agents:
 
       ## What to do
 
-      1. Find which types the stored facts actually carry:
+      Every call needs an `op`. You have about eight calls; spend them like this.
+
+      1. Find which types the FACTS carry. Only the join matters — the `type`
+         column is shared with ordinary document chunks, and those are not
+         entity types:
          `document` op=query_chunks scope=user
-         sql: SELECT coalesce(type,'(none)') AS t, count(*) AS n FROM chunks GROUP BY 1 ORDER BY 2 DESC LIMIT 50
-      2. For a type worth looking into, read a sample of what it holds:
+         sql: SELECT coalesce(c.type,'(none)') AS t, count(*) AS n FROM chunks c
+              JOIN chunk_memory_meta m ON m.chunk_id = c.id
+              GROUP BY 1 ORDER BY 2 DESC LIMIT 50
+      2. If that returns a handful of rows, there is little to curate — say so
+         and stop. Otherwise read a sample of ONE type worth looking into
+         (at most two of these):
          `document` op=query_chunks scope=user
-         sql: SELECT title FROM chunks WHERE type = 'event' LIMIT 30
-         (`title` and `type` are the columns worth reading. There is no `fields`
-         column — a chunk's declared fields live in its body.)
+         sql: SELECT c.title FROM chunks c JOIN chunk_memory_meta m ON m.chunk_id = c.id
+              WHERE c.type = 'event' LIMIT 30
+         (`title` and `type` are the readable columns. There is no `fields` or
+         `body` column — a chunk's text is not in this table.)
       3. File at most THREE suggestions, best first, with
          `document` op=propose_entity — name, optional parent, body.
 
@@ -1805,17 +1822,25 @@ agents:
         that should win and say in the body which it replaces.
       - A field that keeps appearing in a type's facts but is not declared for it.
 
-      The body is your EVIDENCE and the reader decides from it. Give the count and
-      two or three example titles, then the fields, one per line:
+      The body is your EVIDENCE and a person decides from it, so EVERY NUMBER AND
+      EVERY EXAMPLE IN IT MUST COME FROM A QUERY YOU RAN IN THIS SESSION. If you
+      have not run the query, you have no evidence and no suggestion to make.
+      Never copy a count or a title from these instructions — the shape below is
+      a template, not data:
 
-          Seen 14 times on facts that are all service outages.
-          Examples: "the Tuesday checkout outage", "the auth outage last week".
+          Seen <count from step 1> times on facts that <what the titles show>.
+          Examples: <two or three titles, copied from a step-2 result>.
 
-          - `minutes_down`
-          - `cause`
+          - `<field>`
+          - `<field>`
 
       ## Rules
 
+      - THE FACTS ARE THE ONLY POPULATION. A store can hold thousands of document
+        chunks whose `type` is a document's own structure — rfc, section, image,
+        publication, plan. Those are not entity types and must never be proposed
+        as one. If the join in step 1 returns a few rows, that is the truth about
+        this store: the answer is "little to curate", not a wider search.
       - NEVER ASK FOR THE DATA. You have the tool; the queries above are the whole
         method. A reply that asks someone to paste in the types or the titles has
         done nothing — run step 1, then step 2, then decide. If a query returns no

--- a/cmd/loomcycle/presets_memory_test.go
+++ b/cmd/loomcycle/presets_memory_test.go
@@ -375,3 +375,63 @@ func TestOntologist_HasWhatItNeedsAndNothingMore(t *testing.T) {
 		}
 	}
 }
+
+// TestOntologist_SurveysFactsNotEveryChunk is the regression for a live failure.
+//
+// The first pass on a real deployment surveyed `SELECT type, count(*) FROM chunks` and
+// got 3,148 rows across 17 types — because that column is shared: a fact carries an
+// ENTITY type, and every ordinary document chunk carries its own structural type (rfc,
+// section, image, publication, plan). The ontology governed SIX facts. The curator spent
+// seventeen calls and 86k input tokens wandering through document types looking for
+// entity types, and stopped on the iteration cap having filed nothing.
+//
+// The survey must join the fact table, so the population is the one the ontology governs.
+func TestOntologist_SurveysFactsNotEveryChunk(t *testing.T) {
+	agent, ok := memoryBundleConfig(t).Agents["memory/ontologist"]
+	if !ok {
+		t.Fatal("memory/ontologist not registered")
+	}
+	p := agent.SystemPrompt
+	if !strings.Contains(p, "chunk_memory_meta") {
+		t.Error("the survey does not join the fact table — it would count every document " +
+			"chunk in the scope as a candidate entity type")
+	}
+	// The un-joined form must not appear at all: a model handed both will pick one.
+	if strings.Contains(p, "count(*) AS n FROM chunks GROUP BY") {
+		t.Error("the prompt still offers the un-joined survey over every chunk")
+	}
+	// The bound that actually held. Wall-clock did not: one call against a cold local
+	// model can take minutes, so 300s never fired before the global iteration cap.
+	if agent.MaxIterations == 0 || agent.MaxIterations > 16 {
+		t.Errorf("max_iterations = %d — this job is one survey, ≤2 samples and ≤3 proposals; "+
+			"an unbounded curator burned 86k tokens before stopping", agent.MaxIterations)
+	}
+}
+
+// TestOntologist_EvidenceMustComeFromAQuery.
+//
+// On that same pass the model's FIRST two calls proposed types with entirely invented
+// evidence — counts and example titles lifted from the worked example in its own prompt,
+// describing facts that do not exist in that store. They failed only because both omitted
+// `op`. Had they not, two fictional suggestions would be sitting in an operator's ontology
+// with counts attached, which is worse than no curator at all: the evidence is the only
+// reason to trust a proposal.
+//
+// So the prompt must state where evidence may come from, and must not contain a worked
+// example that reads as data.
+func TestOntologist_EvidenceMustComeFromAQuery(t *testing.T) {
+	p := memoryBundleConfig(t).Agents["memory/ontologist"].SystemPrompt
+	if !strings.Contains(p, "MUST COME FROM A QUERY YOU RAN") {
+		t.Error("the prompt does not require evidence to come from a query run in the session")
+	}
+	// The old example's literal strings were what the model copied. If any of them come
+	// back, the copyable-example failure comes back with them.
+	for _, fabricated := range []string{
+		"Seen 14 times", "the Tuesday checkout outage", "the auth outage last week",
+	} {
+		if strings.Contains(p, fabricated) {
+			t.Errorf("the prompt contains %q — a concrete count or title in the instructions is "+
+				"something a model will file as evidence", fabricated)
+		}
+	}
+}


### PR DESCRIPTION
## The report

`memory/ontologist` hit `max_iterations` on your deployment: **7 minutes, 86k input tokens, 17 tool calls, nothing filed.** The iteration cap was the symptom. Reading the transcript found three faults.

## 1. It surveyed the wrong population

The survey was `SELECT type, count(*) FROM chunks` — and that column is **shared**. A fact carries an *entity* type; every ordinary document chunk carries its own *structural* type. On your store:

| what it surveyed | what the ontology governs |
|---|---|
| **3,148 chunks · 17 types** — `rfc` 69, `document` 63, `publication` 32, `PR` 21, `research` 11, `section` 6, `plan` 5, `image` 2… | **6 facts · 4 types** — `fact` 3, `constraint` 1, `person` 1, `project` 1 |

So it went hunting for entity types among your documentation's structure types, wandering through `rfc`, `publication`, `PR`, `measurement`, and `publication` again when it ran out of iterations. The survey now joins `chunk_memory_meta`; the same store answers in four rows. The prompt also states that document types are not entity types, and that a small result **is** the answer rather than a reason to search wider.

## 2. It fabricated its evidence — the serious one

Its **first two calls**, before running any query, proposed `service-outage` and `policy` with counts and example titles describing facts that do not exist in your store:

> `"Seen 41 times on facts that represent organizational standards… Examples: \"all code must use the standard auth library\""`

Those were copied from the **worked example in its own prompt**. They failed only because both omitted `op` — had they not, two fictional suggestions would be sitting in your ontology with counts attached. That is worse than no curator at all, because the evidence is the only reason to trust a proposal.

The prompt now requires every number and title to come from a query run in that session, and its template contains nothing copyable as data. A test fails if the old example's literal strings ever reappear.

## 3. The wall-clock bound never fired

`run_timeout_seconds: 300` did not stop a 7-minute pass, because a single call against a cold local model can itself take minutes — the first tool call landed 5 minutes in. Added `max_iterations: 10`, the bound that matches the work: one survey, one or two samples, up to three proposals.

## Tested

`go test ./...` clean. Two regressions in `presets_memory_test.go`: one requires the survey to join the fact table and rejects the un-joined form outright, one requires the evidence rule and fails on the old example's literal counts and titles.

## What this means for your deployment

With 6 facts, the honest answer is **"little to curate"** — and after this fix that is what a pass will say, in one query instead of seventeen. The curator becomes useful once extraction is actually typing facts at volume; right now your store is overwhelmingly documents, which the ontology doesn't govern.

Worth noting the two failed calls also tell us something about the tool surface: the model built `propose_entity` arguments correctly but omitted the `op` discriminator. That's the cost of a mega-tool with an op field, and it's the second time this session a model reached for a field name it knew from elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8