### PR TITLE
feat: loomboard on loomcycle.cloud — landing section, hosting, vault handoff

### DIFF
--- a/cloud-deployment/docker-compose.yaml
+++ b/cloud-deployment/docker-compose.yaml
@@ -276,10 +276,26 @@ services:
       tailscale:
         condition: service_healthy
 
-  # ── Cloudflare tunnel (token method) — app.loomcycle.cloud + loomcycle.cloud ──
+  # ── Hosted loomboard browser app — board.loomcycle.cloud ──
+  #    Serves the standalone SPA (connect-handoff allowlist baked in) + proxies
+  #    /v1/* to the runtime. Tunnel route: board.loomcycle.cloud → loomboard:8080.
+  loomboard:
+    build:
+      context: ./loomboard
+      args:
+        LOOMBOARD_REF: feature-connect-handoff
+        CONNECT_ORIGINS: https://loomcycle.cloud
+    restart: unless-stopped
+    networks: [loomnet]
+    depends_on:
+      tailscale:
+        condition: service_healthy
+
+  # ── Cloudflare tunnel (token method) — app + loomcycle + board.loomcycle.cloud ──
   #    Dashboard routes: app.loomcycle.cloud → http://tailscale:8787 (the runtime),
-  #    loomcycle.cloud → http://landing:8080 (this stack). Protect /api/* on
-  #    loomcycle.cloud with a Cloudflare Access (Google) policy — see INSTALL.md.
+  #    loomcycle.cloud → http://landing:8080 (this stack),
+  #    board.loomcycle.cloud → http://loomboard:8080 (the hosted loomboard).
+  #    Protect /api/* on loomcycle.cloud with a Cloudflare Access (Google) policy — see INSTALL.md.
   cloudflared:
     image: cloudflare/cloudflared:latest
     restart: unless-stopped

--- a/cloud-deployment/loomboard/Dockerfile
+++ b/cloud-deployment/loomboard/Dockerfile
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1
+# Hosted loomboard browser app for loomcycle.cloud. Clones loomboard, builds the
+# standalone (proxy-mode) SPA with the connect-handoff origin allowlist baked in,
+# then serves it with a tiny dependency-free Node server (serve.mjs) that also
+# reverse-proxies /v1/* to the loomcycle runtime (same-origin — loomcycle emits no
+# CORS). The upstream is PINNED, so the app's x-loomcycle-target header is ignored
+# and this is never an open relay.
+#
+# The serving stage reuses the node:22 build image so hosting needs NO extra
+# registry pull (Docker Hub anonymous pulls rate-limit this host; caddy:2-alpine
+# 429'd). Bump LOOMBOARD_REF to a tag / `main` once the connect-handoff PR merges.
+ARG LOOMBOARD_REF=feature-connect-handoff
+ARG CONNECT_ORIGINS=https://loomcycle.cloud
+
+FROM node:22 AS build
+ARG LOOMBOARD_REF
+ARG CONNECT_ORIGINS
+WORKDIR /app
+RUN git clone --depth 1 --branch "${LOOMBOARD_REF}" \
+      https://github.com/denn-gubsky/loomboard.git .
+RUN npm ci
+RUN VITE_LOOMBOARD_CONNECT_ORIGINS="${CONNECT_ORIGINS}" npm run build:standalone
+
+FROM node:22-alpine
+COPY --from=build /app/cli/public /srv
+COPY serve.mjs /serve.mjs
+ENV PORT=8080 SRV_ROOT=/srv LOOMCYCLE_UPSTREAM=http://tailscale:8787
+EXPOSE 8080
+CMD ["node", "/serve.mjs"]

--- a/cloud-deployment/loomboard/serve.mjs
+++ b/cloud-deployment/loomboard/serve.mjs
@@ -1,0 +1,97 @@
+// Tiny dependency-free static server + loomcycle API proxy for the hosted
+// loomboard SPA. Static files under SRV_ROOT with SPA history fallback; /v1/*
+// reverse-proxied to a PINNED upstream (the loomcycle runtime). The upstream is
+// fixed here, so the app's x-loomcycle-target header is never honored — this is
+// not an open relay. No npm deps (Node http + fs only).
+import http from "node:http";
+import { stat } from "node:fs/promises";
+import { createReadStream } from "node:fs";
+import { extname, join, resolve, sep } from "node:path";
+
+const ROOT = resolve(process.env.SRV_ROOT || "/srv");
+const UP = new URL(process.env.LOOMCYCLE_UPSTREAM || "http://tailscale:8787");
+const PORT = Number(process.env.PORT || 8080);
+
+const MIME = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".ico": "image/x-icon",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+  ".ttf": "font/ttf",
+  ".map": "application/json",
+  ".txt": "text/plain; charset=utf-8",
+  ".wasm": "application/wasm",
+  ".mp4": "video/mp4",
+  ".webmanifest": "application/manifest+json",
+};
+
+function sendFile(res, file) {
+  const ct = MIME[extname(file).toLowerCase()] || "application/octet-stream";
+  const stream = createReadStream(file);
+  stream.on("open", () => res.writeHead(200, { "content-type": ct }));
+  stream.on("error", () => {
+    if (!res.headersSent) res.writeHead(404);
+    res.end("not found");
+  });
+  stream.pipe(res);
+}
+
+const server = http.createServer((req, res) => {
+  const url = req.url || "/";
+
+  // API — reverse-proxy /v1/* to the pinned runtime upstream (whoami is /v1/_me,
+  // and every @loomcycle/client call lives under /v1).
+  if (url === "/v1" || url.startsWith("/v1/")) {
+    const headers = { ...req.headers, host: UP.host };
+    const up = http.request(
+      {
+        hostname: UP.hostname,
+        port: UP.port || 80,
+        path: url,
+        method: req.method,
+        headers,
+      },
+      (r) => {
+        res.writeHead(r.statusCode || 502, r.headers);
+        r.pipe(res);
+      },
+    );
+    up.on("error", () => {
+      if (!res.headersSent) res.writeHead(502);
+      res.end("upstream error");
+    });
+    req.pipe(up);
+    return;
+  }
+
+  // Static + SPA history fallback, contained to ROOT.
+  let pathname = "/";
+  try {
+    pathname = decodeURIComponent(new URL(url, "http://x").pathname);
+  } catch {
+    /* keep default */
+  }
+  const target = resolve(ROOT, "." + pathname);
+  if (target !== ROOT && !target.startsWith(ROOT + sep)) {
+    res.writeHead(400);
+    res.end("bad path");
+    return;
+  }
+  stat(target)
+    .then((s) => sendFile(res, s.isFile() ? target : join(ROOT, "index.html")))
+    .catch(() => sendFile(res, join(ROOT, "index.html")));
+});
+
+server.listen(PORT, () =>
+  console.log(`loomboard: serving ${ROOT} on :${PORT}, /v1 -> ${UP.href}`),
+);

--- a/cloud-web/index.html
+++ b/cloud-web/index.html
@@ -552,6 +552,7 @@ table.models tr[data-dim] td { color: color-mix(in srgb, var(--color-text) 45%, 
   <a href="#how">How it works</a>
   <a href="#trust">Isolation</a>
   <a href="#plugin">Claude Plugin</a>
+  <a href="#loomboard">loomboard</a>
   <a href="#quickstart">Quickstart</a>
   <button type="button" class="btn btn-primary" data-open-console>Sign in</button>
 </nav>
@@ -800,6 +801,54 @@ loomcycle mcp --upstream https://app.loomcycle.cloud/v1/_mcp</pre>
     </div>
 
     <p class="fineprint rise" style="margin-top:var(--leading)">The plugin does not bundle or start a runtime — with loomcycle.cloud you do not need one locally. Source and issues: <a href="https://github.com/denn-gubsky/claude-code-plugin-loomcycle">denn-gubsky/claude-code-plugin-loomcycle</a>.</p>
+  </section>
+
+  <hr class="rule2" />
+
+  <section class="code-sec" id="loomboard">
+    <div class="code-head">
+      <div class="rise">
+        <span class="kicker">loomboard</span>
+        <h2 class="r-title" style="font-size:26px">A chat app for your cloud tenant — desktop or browser</h2>
+      </div>
+    </div>
+
+    <p class="rise" style="margin:0 0 var(--half)">A thin-client chat UI for loomcycle — runs, streaming, history, documents, memory — Apache-2.0. Native desktop app, latest <code class="inline-code">v0.1.2</code>:</p>
+    <p class="rise" style="margin:0 0 var(--leading)">
+      <a href="https://github.com/denn-gubsky/loomboard/releases/download/v0.1.2/loomboard_0.1.2_universal.dmg">macOS · DMG</a> &nbsp;·&nbsp;
+      <a href="https://github.com/denn-gubsky/loomboard/releases/download/v0.1.2/loomboard_0.1.2_x64-setup.exe">Windows · EXE</a> &nbsp;·&nbsp;
+      <a href="https://github.com/denn-gubsky/loomboard/releases/download/v0.1.2/loomboard_0.1.2_amd64.AppImage">Linux · AppImage</a> &nbsp;·&nbsp;
+      <a href="https://github.com/denn-gubsky/loomboard/releases">all builds (.deb / .msi) →</a>
+    </p>
+
+    <pre class="code rise"><span class="c"># or run it locally — serves the app + reverse-proxies /v1 to your tenant</span>
+npm install -g @loomboard/app
+
+<span class="c"># or embed the chat as a React component</span>
+npm install @loomboard/chat</pre>
+
+    <div class="rows" style="padding-top:calc(1.5 * var(--leading));padding-bottom:0">
+      <div class="row-item rise">
+        <p class="r-num">01</p>
+        <h2 class="r-title">Thin client, your loop</h2>
+        <p class="r-copy">No loomboard backend — it talks straight to your tenant over loomcycle&rsquo;s <code>/v1</code> wire with <code>@loomcycle/client</code>. Anything it writes (runs, documents, memory) lands where your Web UI reads it.</p>
+      </div>
+      <div class="row-item rise">
+        <p class="r-num">02</p>
+        <h2 class="r-title">Open in your browser</h2>
+        <p class="r-copy">No install: <a href="https://board.loomcycle.cloud" target="_blank" rel="noopener">board.loomcycle.cloud</a> runs the same app, hosted next to your runtime. Sign in from your token vault and it hands loomboard your bearer over an origin-checked postMessage — the same posture as the Web UI login, never in the URL.</p>
+      </div>
+      <div class="row-item rise">
+        <p class="r-num">03</p>
+        <h2 class="r-title">One token, everywhere</h2>
+        <p class="r-copy">Desktop, CLI, and browser all authenticate with a bearer from your vault against <code>https://app.loomcycle.cloud</code>. Desktop keeps it in the OS keychain; the hosted app in browser storage — loomcycle owns real persistence.</p>
+      </div>
+    </div>
+
+    <div class="sheet-actions rise" style="margin-top:var(--leading)">
+      <button type="button" class="btn btn-primary" data-open-board>Open loomboard in your browser →</button>
+    </div>
+    <p class="fineprint rise" style="margin-top:var(--half)">Downloads are GitHub releases of <a href="https://github.com/denn-gubsky/loomboard">denn-gubsky/loomboard</a>; the hosted browser app is the same source, served alongside your runtime.</p>
   </section>
 
   <hr class="rule2" />
@@ -1520,6 +1569,10 @@ loomcycle mcp --upstream https://app.loomcycle.cloud/v1/_mcp</pre>
     lastFocus?.focus();
   }
   document.querySelectorAll('[data-open-console]').forEach((b) => b.addEventListener('click', open));
+  // Open the hosted loomboard. Phase 1: plain new-tab open (the app prompts for a
+  // token). The token-from-vault handoff lands once board.loomcycle.cloud is up.
+  document.querySelectorAll('[data-open-board]').forEach((b) =>
+    b.addEventListener('click', () => window.open('https://board.loomcycle.cloud', '_blank', 'noopener')));
   document.querySelectorAll('[data-close-console]').forEach((b) => b.addEventListener('click', close));
   sheet.addEventListener('click', (e) => { if (e.target === sheet) close(); });
   addEventListener('keydown', (e) => { if (e.key === 'Escape' && !sheet.hidden) close(); });

--- a/cloud-web/index.html
+++ b/cloud-web/index.html
@@ -846,7 +846,7 @@ npm install @loomboard/chat</pre>
     </div>
 
     <div class="sheet-actions rise" style="margin-top:var(--leading)">
-      <button type="button" class="btn btn-primary" data-open-board>Open loomboard in your browser →</button>
+      <button type="button" class="btn btn-primary" data-open-console>Open loomboard — sign in from your vault →</button>
     </div>
     <p class="fineprint rise" style="margin-top:var(--half)">Downloads are GitHub releases of <a href="https://github.com/denn-gubsky/loomboard">denn-gubsky/loomboard</a>; the hosted browser app is the same source, served alongside your runtime.</p>
   </section>
@@ -1546,6 +1546,27 @@ loomcycle mcp --upstream https://app.loomcycle.cloud/v1/_mcp</pre>
     send();
   }
 
+  // Hand the SAME vault bearer to the hosted loomboard over its origin-allowlisted
+  // postMessage receiver ({type:'loomboard.connect'}); baseUrl:'' rides board's
+  // same-origin /v1 proxy. Same popup-safe shape as openApp/handoff. loomboard has
+  // no ?token= URL ingestion, so a blocked popup falls back to a bare same-tab open
+  // (the user pastes into loomboard's own connect screen).
+  const BOARD = 'https://board.loomcycle.cloud';
+  function openBoard() { return window.open(BOARD, 'loomboard-app'); }
+  function handoffBoard(w, token) {
+    if (!w || !token) return;
+    let done = false, iv = 0, to = 0;
+    const send = () => { try { w.postMessage({ type: 'loomboard.connect', baseUrl: '', token: token }, BOARD); } catch (_) {} };
+    const stop = () => { clearInterval(iv); clearTimeout(to); removeEventListener('message', onAck); };
+    const onAck = (e) => {
+      if (e.origin === BOARD && e.data && e.data.type === 'loomboard.connect.ok') { done = true; stop(); }
+    };
+    addEventListener('message', onAck);
+    iv = setInterval(send, 300);   /* loomboard needs a moment to mount its receiver — resend until acked */
+    to = setTimeout(() => { if (done) return; stop(); }, 8000);  /* no ack → leave board open for a manual paste */
+    send();
+  }
+
   function go(step) {
     document.querySelectorAll('[data-pane]').forEach((p) => { p.hidden = p.dataset.pane !== String(step); });
     document.querySelectorAll('[data-rail]').forEach((r) => {
@@ -1569,10 +1590,6 @@ loomcycle mcp --upstream https://app.loomcycle.cloud/v1/_mcp</pre>
     lastFocus?.focus();
   }
   document.querySelectorAll('[data-open-console]').forEach((b) => b.addEventListener('click', open));
-  // Open the hosted loomboard. Phase 1: plain new-tab open (the app prompts for a
-  // token). The token-from-vault handoff lands once board.loomcycle.cloud is up.
-  document.querySelectorAll('[data-open-board]').forEach((b) =>
-    b.addEventListener('click', () => window.open('https://board.loomcycle.cloud', '_blank', 'noopener')));
   document.querySelectorAll('[data-close-console]').forEach((b) => b.addEventListener('click', close));
   sheet.addEventListener('click', (e) => { if (e.target === sheet) close(); });
   addEventListener('keydown', (e) => { if (e.key === 'Escape' && !sheet.hidden) close(); });
@@ -1642,13 +1659,26 @@ loomcycle mcp --upstream https://app.loomcycle.cloud/v1/_mcp</pre>
         }
         catch (err) { console.error('vault', err); if (w) w.close(); vaultError('Could not unwrap that token.'); }
       });
+      const board = document.createElement('button');
+      board.type = 'button'; board.className = 'use'; board.textContent = 'loomboard →';
+      board.disabled = !unlocked;
+      board.title = unlocked ? 'Open this token in loomboard (board.loomcycle.cloud)' : 'Unlock the vault first';
+      board.addEventListener('click', async () => {
+        const w = openBoard();   /* open in the click gesture; null if the browser blocked it */
+        try {
+          const token = await Vault.reveal(it.id);
+          if (w) handoffBoard(w, token);       /* popup allowed → postMessage handoff (no token in URL) */
+          else window.location.href = BOARD;    /* popup blocked → bare board; paste in its connect screen */
+        }
+        catch (err) { console.error('vault', err); if (w) w.close(); vaultError('Could not unwrap that token.'); }
+      });
       const rm = document.createElement('button');
       rm.type = 'button'; rm.className = 'rm'; rm.textContent = 'Remove';
       rm.addEventListener('click', async () => {
         try { await Vault.remove(it.id); } catch (err) { console.error('vault', err); }
         render();
       });
-      box.append(use, rm); act.appendChild(box);
+      box.append(use, board, rm); act.appendChild(box);
       rows.appendChild(tr);
     }
     document.getElementById('quota-text').textContent = items.length + ' of ' + LIMIT + ' tokens in use';


### PR DESCRIPTION
Brings **loomboard** (the thin-client chat app for loomcycle) to loomcycle.cloud: a download section on the landing, a **hosted** browser build at `board.loomcycle.cloud`, and a one-click **token handoff** from the vault so it opens already-connected. Companion PR (loomboard repo, the postMessage receiver): denn-gubsky/loomboard#42.

## What

- **Landing `#loomboard` section** (`cloud-web/index.html`) + nav link: native downloads (macOS/Windows/Linux from the v0.1.2 release), `@loomboard/app` / `@loomboard/chat`, and an "Open loomboard — sign in from your vault" CTA.
- **Hosting** (`cloud-deployment/`): a `loomboard` compose service — a Dockerfile that builds loomboard's standalone (proxy-mode) SPA from source with the connect-handoff allowlist baked in (`VITE_LOOMBOARD_CONNECT_ORIGINS=https://loomcycle.cloud`), served by a tiny dependency-free Node server (`serve.mjs`) that also reverse-proxies `/v1/*` to the runtime on the shared tailscale netns (same-origin — loomcycle emits no CORS; **pinned upstream**, so the app's `x-loomcycle-target` is ignored — not an open relay). Exposed via the existing cloudflared tunnel: `board.loomcycle.cloud → loomboard:8080`.
- **Vault handoff button**: a per-token **"loomboard →"** action beside "Sign in →" hands the same bearer to `board.loomcycle.cloud` over an origin-checked postMessage (`{type:'loomboard.connect', baseUrl:'', token}`); loomboard's receiver exchanges it and auto-connects — no re-paste, no token in the URL. Same popup-safe shape as the `/ui` handoff, with a blocked-popup fallback.

## Tested

- `board.loomcycle.cloud/` → **200** (serves the SPA, `<title>loomboard</title>`, assets load); `board.loomcycle.cloud/v1/_me` → **401** (the `/v1` proxy reaches the runtime, auth required).
- Landing section + handoff deployed live to the cloud-home landing (edge-verified).
- loomboard SPA build (`npm ci` + `build:standalone`) passes; the allowlist is baked into the served bundle.

## Note

`LOOMBOARD_REF` is pinned to `feature-connect-handoff` (the receiver branch) — bump it to a tag / `main` once denn-gubsky/loomboard#42 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)