### PR TITLE
fix(routing): empty tier cascade must serialize as [] not null (blank routing page)

### DIFF
--- a/internal/api/http/routing.go
+++ b/internal/api/http/routing.go
@@ -150,7 +150,9 @@ func (s *Server) handleRouting(w http.ResponseWriter, r *http.Request) {
 	}
 	for _, ut := range utNames {
 		overlay := s.userTierOverlay(ut)
-		rut := routingUserTier{Name: ut}
+		// Non-nil so an empty tier set serializes as [] not null (the routing-view
+		// UI does [...ut.tiers] / tier.cascade.length and blanks on a null).
+		rut := routingUserTier{Name: ut, Tiers: []routingTier{}}
 		for _, tier := range tierNames {
 			req := resolve.AgentRequest{Name: "routing-view", Tier: tier, UserTier: overlay}
 			casc := s.resolver.Cascade(req)
@@ -167,7 +169,10 @@ func (s *Server) handleRouting(w http.ResponseWriter, r *http.Request) {
 					keyableUnion[p] = true
 				}
 			}
-			rt := routingTier{Tier: tier}
+			// Non-nil cascade so a tier with zero resolved candidates (a valid
+			// config state) serializes as [] not null — a null crashes the routing
+			// view's TierCard (tier.cascade.length).
+			rt := routingTier{Tier: tier, Cascade: []routingCandidate{}}
 			selectedMarked := false
 			for _, c := range casc {
 				if restricted && !keyable[c.Provider] {

--- a/internal/api/http/routing_test.go
+++ b/internal/api/http/routing_test.go
@@ -59,6 +59,52 @@ func routingFor(t *testing.T, srv *Server, scopes []string) routingResponse {
 	return resp
 }
 
+// TestRouting_EmptyCascadeSerializesAsArray: a tier that is configured (so it
+// appears in the routing view) but resolves to ZERO candidates must serialize
+// its cascade as [] — NOT null. A JSON null decodes to a nil slice and, in the
+// web UI, TierCard does tier.cascade.length on it, which throws and blanks the
+// whole routing page. Regression for that blank-page bug.
+func TestRouting_EmptyCascadeSerializesAsArray(t *testing.T) {
+	cfg := &config.Config{
+		ProviderPriority: []string{"deepseek"},
+		Tiers: map[string][]config.TierCandidate{
+			"middle": {{Provider: "deepseek", Model: "deepseek-v4-pro"}},
+			// "high" is configured (→ shown in the routing view) but the resolver
+			// below has no "high" candidates, so its cascade resolves empty.
+			"high": {{Provider: "deepseek", Model: "deepseek-v4-pro"}},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 1, MaxQueueDepth: 1, QueueTimeoutMS: 100},
+	}
+	cfg.Env.AuthToken = ""
+	srv := New(cfg, &stubResolver{}, nil, concurrency.New(1, 1, time.Second), nil)
+	res := resolve.NewResolver([]string{"deepseek"}, map[string][]resolve.Candidate{
+		"middle": {{Provider: "deepseek", Model: "deepseek-v4-pro"}},
+	})
+	srv.SetResolver(res)
+
+	resp := routingFor(t, srv, []string{auth.ScopeAdmin})
+	if len(resp.UserTiers) == 0 {
+		t.Fatal("no user_tiers in response")
+	}
+	var high *routingTier
+	for i := range resp.UserTiers[0].Tiers {
+		if resp.UserTiers[0].Tiers[i].Tier == "high" {
+			high = &resp.UserTiers[0].Tiers[i]
+		}
+	}
+	if high == nil {
+		t.Fatal("high tier missing from routing response")
+	}
+	// A JSON "cascade": null decodes to a nil slice; "cascade": [] to a non-nil
+	// empty slice. This is exactly the distinction the UI crashes on.
+	if high.Cascade == nil {
+		t.Errorf("empty high cascade decoded to nil (serialized as null) — the UI blanks; want [] (non-nil)")
+	}
+	if len(high.Cascade) != 0 {
+		t.Errorf("high cascade = %d candidates, want 0", len(high.Cascade))
+	}
+}
+
 // TestRouting_AdminSeesCascadeAndAvailability: an admin gets the ordered cascade
 // (deepseek primary, anthropic fallback) with live-availability fields populated
 // and the active-providers header.

--- a/web/src/pages/RoutingView.tsx
+++ b/web/src/pages/RoutingView.tsx
@@ -54,8 +54,10 @@ export default function RoutingView() {
   // presence — a redacted/filtered tenant payload still shows what it has.
   const hasAvailability =
     (!!resp?.providers && resp.providers.length > 0) ||
-    !!resp?.user_tiers.some((ut) =>
-      ut.tiers.some((t) => t.cascade.some((c) => c.available !== undefined)),
+    !!(resp?.user_tiers ?? []).some((ut) =>
+      (ut.tiers ?? []).some((t) =>
+        (t.cascade ?? []).some((c) => c.available !== undefined),
+      ),
     );
 
   return (
@@ -146,7 +148,7 @@ export default function RoutingView() {
               )}
             </h2>
             <div className="routing-tier-grid">
-              {[...ut.tiers]
+              {[...(ut.tiers ?? [])]
                 .sort((a, b) => tierRank(a.tier) - tierRank(b.tier))
                 .map((t) => (
                   <TierCard key={t.tier} tier={t} />
@@ -219,14 +221,17 @@ function searchStatusText(sp: SearchRoutingProvider): string {
 }
 
 function TierCard({ tier }: { tier: RoutingTier }) {
+  // Defensive: the backend now serializes an empty cascade as [], but guard null
+  // too so a single tier can never blank the whole routing view.
+  const cascade = tier.cascade ?? [];
   return (
     <div className="routing-tier-card">
       <div className="routing-tier-title">{tier.tier}</div>
-      {tier.cascade.length === 0 ? (
+      {cascade.length === 0 ? (
         <div className="routing-tier-empty">no candidates</div>
       ) : (
         <ol className="routing-cascade">
-          {tier.cascade.map((c, i) => (
+          {cascade.map((c, i) => (
             <CandidateRow key={`${c.provider}/${c.model}/${i}`} c={c} />
           ))}
         </ol>


### PR DESCRIPTION
## Why

The **Settings → Routing** page goes blank on a real deployment. Diagnosed on the loomcycle.cloud instance: `GET /v1/_routing` returned, for the `high` user-tier's `high` tier, `"cascade": null`.

`handleRouting` builds each tier's cascade by appending to a **nil slice** (`rt := routingTier{Tier: tier}`), so a `user_tier × tier` that resolves to **zero candidates** — a perfectly valid config state — serializes as JSON `null`. In the web UI, `TierCard` does `tier.cascade.length` on it → `null.length` throws → React unmounts → the whole page is blank. Exactly the class of bug fixed for `/v1/_usage` in #647.

## What

- **Backend (`routing.go`):** initialize `Tiers` and `Cascade` to non-nil empty slices, so an empty resolve serializes as `[]`.
- **Frontend (`RoutingView.tsx`):** defensive `?? []` guards on `user_tiers` / `tiers` / `cascade` so a single bad tier can never blank the page again (defense in depth).

## Tested

- **Regression** `TestRouting_EmptyCascadeSerializesAsArray`: a configured tier with no resolver candidates decodes to a non-nil (empty) cascade. **Verified fail-before** (reverting just the init line → `empty high cascade decoded to nil (serialized as null) — the UI blanks`) / **pass-after**.
- `go test ./internal/api/http/ -run TestRouting` green; package builds.
- Confirmed against the live payload: the offending tier is `user_tier "high" → tier "high"` (empty cascade because it resolves to no candidates).

## Deploy note

The live app.loomcycle.cloud runs the released v1.53.0 image, so it needs a rebuilt runtime to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)