### PR TITLE
feat(auth): non-isolated user tokens read+write the tenant plane (RFC CB)

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -63,10 +63,22 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 			return
 		}
 		if required := requiredScopeFor(r.Method, r.URL.Path); required != "" && !auth.HasScope(p.Scopes, required) {
-			// Scope names are public; token state is not.
-			w.Header().Set("WWW-Authenticate", `Bearer scope="`+required+`"`)
-			http.Error(w, "insufficient scope", http.StatusForbidden)
-			return
+			// RFC CB: the scope check failed, but a NON-ISOLATED user token (a
+			// tenant member — runs:*/channel:*, no substrate:tenant) may still
+			// reach a member-accessible tenant surface. Such a token already has
+			// whole-tenant DATA access inside a run (it is not isolated — see
+			// auth/grants.go), so this admits the matching HTTP surfaces for
+			// read+write. Isolated tokens (substrate:user) fail !IsIsolated and
+			// stay 403; the operator-control carve-outs (minting / roster /
+			// budget-write / erasure / hooks) are excluded by
+			// tenantMemberAccessible; and every such handler still confines a
+			// member to its own tenant via principalTenantScope / tenantFromCtx.
+			if !(tenantMemberAccessible(r.Method, r.URL.Path) && !auth.IsIsolated(p, ok)) {
+				// Scope names are public; token state is not.
+				w.Header().Set("WWW-Authenticate", `Bearer scope="`+required+`"`)
+				http.Error(w, "insufficient scope", http.StatusForbidden)
+				return
+			}
 		}
 		next.ServeHTTP(w, r.WithContext(auth.WithPrincipal(r.Context(), p)))
 	})
@@ -841,6 +853,51 @@ func requiredScopeFor(method, path string) string {
 		}
 		return ""
 	}
+}
+
+// tenantMemberAccessible reports whether a NON-ISOLATED user token (a "tenant
+// member" — RFC CB) may reach this route despite lacking substrate:tenant. A
+// member already has whole-tenant DATA access inside a run (it is not isolated;
+// auth/grants.go: "whole-tenant data access is conferred by NOT being isolated"),
+// so this opens the matching HTTP tenant surfaces for read+write. The rule: any
+// route that requires ScopeTenant, MINUS the operator-control carve-outs
+// (memberCarveOut). Routes already at ScopeAdmin (cross-tenant enumeration,
+// runtime admin, token minting via the /v1/_* catch-all) are excluded
+// automatically — they are not ScopeTenant. The middleware still requires the
+// caller to be non-isolated (auth.IsIsolated == false), and every one of these
+// handlers still confines a member to its own tenant (principalTenantScope /
+// tenantFromCtx), so opening the gate here does not widen a member cross-tenant.
+func tenantMemberAccessible(method, path string) bool {
+	if requiredScopeFor(method, path) != auth.ScopeTenant {
+		return false
+	}
+	return !memberCarveOut(method, path)
+}
+
+// memberCarveOut lists the ScopeTenant routes that STAY operator-only (require a
+// real substrate:tenant token) even for a non-isolated member — the operator
+// CONTROLS, not member data (RFC CB §Scope). Opening these to a member would be a
+// privilege / cost-control / destruction hazard:
+//   - user create + roster mutation + user-token minting (/v1/_users*) — escalation
+//   - per-subject erasure (/v1/_erasure) — destructive
+//   - budget WRITES (PUT/DELETE /v1/_limits) — cost-control bypass (GET stays open)
+//   - tool-use hooks (/v1/hooks) — a cross-run control over every one of the
+//     tenant's runs (kept operator-only in the safe direction; not in RFC CB's
+//     explicit opened list)
+func memberCarveOut(method, path string) bool {
+	switch {
+	case path == "/v1/_users" && method == http.MethodPost:
+		return true
+	case strings.HasPrefix(path, "/v1/_users/"):
+		return true
+	case path == "/v1/_erasure":
+		return true
+	case path == "/v1/_limits" && (method == http.MethodPut || method == http.MethodDelete):
+		return true
+	case strings.HasPrefix(path, "/v1/hooks"):
+		return true
+	}
+	return false
 }
 
 // isTenantConfinedDefPath matches the substrate def-authoring families that

--- a/internal/api/http/auth_principal_test.go
+++ b/internal/api/http/auth_principal_test.go
@@ -411,6 +411,96 @@ func TestAuthMiddleware_RFCAFTenantToken(t *testing.T) {
 	}
 }
 
+// runMW drives a (method, path) through the real authMiddleware with the given
+// bearer, returning whether the inner handler was reached + the status code.
+func runMW(t *testing.T, s *Server, method, path, token string) (reached bool, code int) {
+	t.Helper()
+	h := s.authMiddleware(passthroughHandler(&reached))
+	req := httptest.NewRequest(method, path, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return reached, rec.Code
+}
+
+// TestTenantMemberAccessible: the RFC CB member-access predicate — every
+// ScopeTenant collaboration/data route opens; the operator-control carve-outs,
+// the ScopeAdmin routes, and the non-tenant routes do not.
+func TestTenantMemberAccessible(t *testing.T) {
+	open := []struct{ method, path string }{
+		{"GET", "/v1/_library/agents"}, {"POST", "/v1/_agentdef"}, {"GET", "/v1/_agentdef/names"},
+		{"POST", "/v1/_document"}, {"POST", "/v1/_path"}, {"POST", "/v1/_credentialdef"},
+		{"GET", "/v1/_memory/scopes"}, {"POST", "/v1/_memory/search"}, {"GET", "/v1/_schedules/list-all"},
+		{"GET", "/v1/_channels"}, {"POST", "/v1/_channels"}, {"GET", "/v1/_ontology"},
+		{"GET", "/v1/_usage"}, {"GET", "/v1/_routing"}, {"GET", "/v1/_models"}, {"GET", "/v1/_retention"},
+		{"GET", "/v1/_volumes"}, {"POST", "/v1/_mcp"}, {"GET", "/v1/_resident"}, {"GET", "/v1/_limits"},
+	}
+	for _, c := range open {
+		if !tenantMemberAccessible(c.method, c.path) {
+			t.Errorf("tenantMemberAccessible(%s %s) = false, want true (opened)", c.method, c.path)
+		}
+	}
+	closed := []struct{ method, path string }{
+		{"POST", "/v1/_users"}, {"PATCH", "/v1/_users/alice"}, {"DELETE", "/v1/_users/alice"},
+		{"POST", "/v1/_users/alice/tokens"}, {"POST", "/v1/_erasure"}, {"GET", "/v1/_erasure"},
+		{"PUT", "/v1/_limits"}, {"DELETE", "/v1/_limits"}, {"POST", "/v1/hooks"},
+		{"POST", "/v1/_operatortokendef"}, {"GET", "/v1/_tenants"}, {"POST", "/v1/_pause"},
+		{"POST", "/v1/_memory/repair-tenant"}, {"POST", "/v1/runs"}, {"GET", "/v1/_me"},
+	}
+	for _, c := range closed {
+		if tenantMemberAccessible(c.method, c.path) {
+			t.Errorf("tenantMemberAccessible(%s %s) = true, want false", c.method, c.path)
+		}
+	}
+}
+
+// TestAuthMiddleware_RFCCBMember drives the RFC CB gate through the real
+// middleware: a NON-ISOLATED user token (a tenant member — runs:*/channel:*, no
+// substrate:tenant) is ADMITTED on the member-accessible tenant surfaces and
+// REFUSED on the operator-control carve-outs; an ISOLATED token (substrate:user)
+// is refused on every one of them — the isolation floor.
+func TestAuthMiddleware_RFCCBMember(t *testing.T) {
+	s, st := tokenAuthServer(t, "legacy")
+	member := []string{auth.ScopeRunsCreate, auth.ScopeRunsRead, auth.ScopeChannelPublish, auth.ScopeChannelRead}
+	seedToken(t, st, "lct_member", "acme", "alice", member, time.Time{})
+	seedToken(t, st, "lct_isolated", "acme", "bob", []string{auth.ScopeUser}, time.Time{})
+
+	admitted := []struct{ method, path string }{
+		{"GET", "/v1/_library/agents"}, {"POST", "/v1/_agentdef"}, {"POST", "/v1/_document"},
+		{"POST", "/v1/_path"}, {"GET", "/v1/_memory/scopes"}, {"POST", "/v1/_memory/search"},
+		{"GET", "/v1/_schedules/list-all"}, {"POST", "/v1/_channels"}, {"GET", "/v1/_ontology"},
+		{"POST", "/v1/_credentialdef"}, {"GET", "/v1/_usage"}, {"GET", "/v1/_routing"},
+		{"GET", "/v1/_limits"}, {"GET", "/v1/_volumes"}, {"POST", "/v1/_mcp"}, {"GET", "/v1/_resident"},
+	}
+	for _, c := range admitted {
+		reached, code := runMW(t, s, c.method, c.path, "lct_member")
+		if !reached || code == http.StatusForbidden {
+			t.Errorf("member on %s %s: code=%d reached=%v, want admitted", c.method, c.path, code, reached)
+		}
+	}
+
+	refused := []struct{ method, path string }{
+		{"POST", "/v1/_users"}, {"PATCH", "/v1/_users/alice"}, {"POST", "/v1/_users/alice/tokens"},
+		{"POST", "/v1/_erasure"}, {"PUT", "/v1/_limits"}, {"DELETE", "/v1/_limits"},
+		{"POST", "/v1/hooks"}, {"POST", "/v1/_operatortokendef"}, {"POST", "/v1/_pause"},
+		{"GET", "/v1/_tenants"},
+	}
+	for _, c := range refused {
+		reached, code := runMW(t, s, c.method, c.path, "lct_member")
+		if code != http.StatusForbidden || reached {
+			t.Errorf("member on %s %s: code=%d reached=%v, want 403", c.method, c.path, code, reached)
+		}
+	}
+
+	// The isolation floor: an isolated token is refused on every member surface.
+	for _, c := range admitted {
+		reached, code := runMW(t, s, c.method, c.path, "lct_isolated")
+		if code != http.StatusForbidden || reached {
+			t.Errorf("isolated on %s %s: code=%d reached=%v, want 403 (floor)", c.method, c.path, code, reached)
+		}
+	}
+}
+
 func TestAuthMiddleware_StampsPrincipalAndAllowsScopedRoute(t *testing.T) {
 	s, st := tokenAuthServer(t, "legacy")
 	seedToken(t, st, "lct_creator", "acme", "alice", []string{auth.ScopeRunsCreate}, time.Time{})


### PR DESCRIPTION
Implements **RFC CB** (`/loomcycle/rfcs/member-tenant-access`), loomcycle side. Companion follow-ons: loomboard `canTenant` relax (separate repo PR) and gRPC/MCP parity (deferred — see below).

## Why

A **non-isolated user token** (a *tenant member* — `runs:*`/`channel:*`, no `substrate:tenant`) already has **whole-tenant data access inside a run** — loomcycle's own rule is "whole-tenant data access is conferred by NOT being isolated" (`internal/auth/grants.go`). Yet the same token was 403'd at every HTTP `/v1/_*` tenant surface by the route scope-gate alone. So a member couldn't browse or author its tenant's shared **Library / Documents / Memory** over HTTP, and consumers (loomboard) hid those views rather than render a wall of 403s.

## What

`authMiddleware` now admits a non-isolated principal on a member-accessible tenant route:

```go
if required := requiredScopeFor(...); required != "" && !auth.HasScope(p.Scopes, required) {
    if !(tenantMemberAccessible(r.Method, r.URL.Path) && !auth.IsIsolated(p, ok)) { 403 }
}
```

- **`tenantMemberAccessible`** opens any route that requires `ScopeTenant`, **minus** the operator-control carve-outs. `ScopeAdmin` routes (cross-tenant enumeration, runtime admin, `_operatortokendef`) are excluded automatically — they aren't `ScopeTenant`.
- **`memberCarveOut`** (stays operator-only): user create / roster mutation / user-token minting (`/v1/_users*`), erasure (`/v1/_erasure`), **budget writes** (`PUT/DELETE /v1/_limits`; `GET` opens), and **tool-use hooks** (`/v1/hooks`).

**No new scope, no re-mint** — it keys on the existing isolated/non-isolated boundary, generalizing RFC BY's `runnableIncludesTenant` from one route to the route gate.

## The isolation floor is untouched

`substrate:user` still fails `HasScope` for every tenant scope, `auth.IsIsolated` stays `true` for it, and `ConfineIsolatedScope` + the run-start `Isolated` stamps are unchanged. Every opened handler still confines a member to its own tenant via `principalTenantScope`/`tenantFromCtx`, so the gate does not widen a member cross-tenant.

## A note on the carve-outs

The RFC's approved carve-out list is implemented. I additionally kept **`/v1/hooks` operator-only** (a cross-run tool-interception control) — in the safe direction, beyond the RFC's explicit list. Say the word if members should have it.

## Tested

- `TestTenantMemberAccessible` — the predicate (opened vs carve-out vs admin vs non-tenant, incl. the `GET`-opens / `PUT`-DELETE-carves `/v1/_limits` split).
- `TestAuthMiddleware_RFCCBMember` — through the real middleware: a member is admitted on the surfaces and refused on the carve-outs; an **isolated** token is refused on every one (the floor). **Fail-before verified** (neutralizing the branch → member 403 on the opened routes).
- Full `internal/api/http` package green; `go build ./...` clean.

## Scope / follow-ons

HTTP gate only (what loomboard consumes). **gRPC/MCP substrate-plane parity** is deferred (RFC open question #3, HTTP-first) — a member's *runs* already reach tenant data over those planes since they aren't isolated. **loomboard `canTenant` relax** lands as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)