### PR TITLE
feat(memory): a fact records the span it came from (RFC CC P1)

### DIFF
--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -287,6 +287,17 @@ agents:
         // much, since it has to stay under the lease TTL.
         max_parts_per_chat: 4,
         max_fact_chars: 400,
+        // A span may run longer than the one-sentence fact it supports, but it must
+        // not become a way to copy the transcript into the store. Over-long spans are
+        // TRUNCATED rather than dropped: a fact with a clipped quote is still better
+        // evidence than a fact with none, and dropping it would lose the claim over a
+        // formatting excess.
+        max_quote_chars: 800,
+        // Dice floor for accepting a derived span. A fact PARAPHRASES its source, so
+        // this is "clearly about the same thing", not "nearly identical". Set too high
+        // and every fact loses its evidence; too low and a fact gets handed an
+        // unrelated sentence, which is worse than none because it looks like proof.
+        min_span_overlap: 0.25,
         // The SECOND signal an in-place rewrite has to clear, alongside the
         // similarity band — see mergeRefusal for why one number is not enough
         // authority to destroy a fact. It is the Dice overlap between the two
@@ -602,6 +613,10 @@ agents:
         for (var i = 0; i < parts.length; i++) {
           var facts = extract(st, parts[i], sid);
           if (facts === null) { unreadable++; continue; }
+          // Against THIS part, not the whole transcript: the span must come from the
+          // text the extractor actually saw, or a fact could be handed evidence from a
+          // section that was never in front of the model.
+          deriveSpans(facts, parts[i]);
           all = all.concat(facts);
           readable++;
         }
@@ -808,7 +823,7 @@ agents:
           var typ = (typeof f.type === "string") ? f.type.trim().toLowerCase() : "";
           var subj = (typeof f.subject === "string") ? f.subject.trim() : "";
           if (!typ || !subj) { typ = ""; subj = ""; }
-          out.push({ text: text, cls: cls, type: typ, subject: subj });
+          out.push({ text: text, cls: cls, type: typ, subject: subj, quote: "" });
         }
         return out;
       }
@@ -835,7 +850,9 @@ agents:
         // "" marks this as the queued batch rather than a chat: an unreadable
         // batch extraction leaves its items unacked, so they are re-drained next
         // pass on their own and nothing about it should hold the CHAT watermark.
-        var facts = extract(st, renderPending(taken), "");
+        var pendingText = renderPending(taken);
+        var facts = extract(st, pendingText, "");
+        deriveSpans(facts, pendingText);
         if (facts === null) { return []; }
         // An empty reply lets a CHAT through because the cost is bounded — the
         // watermark moves one row past a chat that had nothing to give. Acking
@@ -1056,6 +1073,63 @@ agents:
         return (2 * shared) / (na + nb);
       }
 
+      // deriveSpans attaches, to each fact, the sentence from its SOURCE that best
+      // supports it — the span a later pass checks the claim against.
+      //
+      // DERIVED HERE RATHER THAN ASKED OF THE EXTRACTOR, and that was a measured
+      // decision, not a preference. Adding a required `quote` field to the extractor's
+      // output contract was tried first: across three runs of the extraction eval it
+      // scored 2 violations, then a missed property, then clean, against a recorded
+      // baseline of zero violations and 1.00 recall that the unchanged prompt still
+      // hits. The extractor is at its capacity on a small local model, and a field
+      // added to its contract is paid for out of rule-following.
+      //
+      // Deriving costs the model nothing and cannot be fabricated: a span SELECTED
+      // from the source is in the source by construction, so the "did the model invent
+      // this quote" check the model-supplied version would have needed does not exist.
+      // What is lost is intent — this is the sentence that best supports the claim, not
+      // provably the one the extractor read. For checking whether the source supports
+      // the claim, the strongest candidate is the right thing to check.
+      //
+      // No match above the floor means NO span, which reads as unverified rather than
+      // as refuted. A fact whose support cannot be located is exactly the fact a
+      // verifier should be told nothing about.
+      function deriveSpans(facts, sourceText) {
+        if (!facts || !facts.length || !sourceText) { return facts; }
+        var sentences = splitSentences(sourceText);
+        if (!sentences.length) { return facts; }
+        for (var i = 0; i < facts.length; i++) {
+          var best = "", bestScore = 0;
+          for (var j = 0; j < sentences.length; j++) {
+            var sc = subjectOverlap(facts[i].text, sentences[j]);
+            if (sc > bestScore) { bestScore = sc; best = sentences[j]; }
+          }
+          if (bestScore < CONFIG.min_span_overlap) { continue; }
+          facts[i].quote = best.length > CONFIG.max_quote_chars
+            ? best.slice(0, CONFIG.max_quote_chars) : best;
+        }
+        return facts;
+      }
+
+      // splitSentences cuts a transcript into candidate spans.
+      //
+      // Line breaks count as boundaries, not just sentence punctuation: a transcript is
+      // turns and tool payloads, where a whole line is often one utterance with no
+      // terminator at all. Fragments shorter than a few words are dropped — they cannot
+      // support a claim and they score noisily against short facts.
+      function splitSentences(text) {
+        // NO LOOKBEHIND. The engine here is ES5.1-era and `(?<=…)` is ES2018 — it
+        // parses as a syntax error at load, taking the whole consolidator with it.
+        // Marking the terminator and splitting on the mark is portable.
+        var raw = String(text).replace(/([.!?])\s+/g, "$1\n").split(/\n+/);
+        var out = [];
+        for (var i = 0; i < raw.length; i++) {
+          var t = raw[i].trim();
+          if (t.length >= 12) { out.push(t); }
+        }
+        return out;
+      }
+
       // wordSet collapses a word list to a presence map. `=== true` on lookup
       // and hasOwnProperty on iteration, because a fact may legitimately contain
       // a word like "constructor" that Object.prototype already answers to.
@@ -1219,10 +1293,15 @@ agents:
 
         // The fact node carries the sentence; its title is the sentence too,
         // trimmed, because a chunk with no title is unreadable in the Path browser.
-        var factID = upsertEntityChunk(st, docID, key, {
+        var factArgs = {
           title: fact.text.length > 80 ? fact.text.slice(0, 77) + "..." : fact.text,
           type: "fact", body: fact.text
-        });
+        };
+        // The span goes on the FACT node only. A subject node is an identity, not a
+        // claim — there is nothing about "Denn" for a quote to support, and attaching
+        // one there would make the evidence look like it backed the wrong thing.
+        if (fact.quote) { factArgs.source_quote = fact.quote; }
+        var factID = upsertEntityChunk(st, docID, key, factArgs);
         if (!factID) { return; }
         st.entity_facts++;
 

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -287,6 +287,17 @@ agents:
         // much, since it has to stay under the lease TTL.
         max_parts_per_chat: 4,
         max_fact_chars: 400,
+        // A span may run longer than the one-sentence fact it supports, but it must
+        // not become a way to copy the transcript into the store. Over-long spans are
+        // TRUNCATED rather than dropped: a fact with a clipped quote is still better
+        // evidence than a fact with none, and dropping it would lose the claim over a
+        // formatting excess.
+        max_quote_chars: 800,
+        // Dice floor for accepting a derived span. A fact PARAPHRASES its source, so
+        // this is "clearly about the same thing", not "nearly identical". Set too high
+        // and every fact loses its evidence; too low and a fact gets handed an
+        // unrelated sentence, which is worse than none because it looks like proof.
+        min_span_overlap: 0.25,
         // The SECOND signal an in-place rewrite has to clear, alongside the
         // similarity band — see mergeRefusal for why one number is not enough
         // authority to destroy a fact. It is the Dice overlap between the two
@@ -602,6 +613,10 @@ agents:
         for (var i = 0; i < parts.length; i++) {
           var facts = extract(st, parts[i], sid);
           if (facts === null) { unreadable++; continue; }
+          // Against THIS part, not the whole transcript: the span must come from the
+          // text the extractor actually saw, or a fact could be handed evidence from a
+          // section that was never in front of the model.
+          deriveSpans(facts, parts[i]);
           all = all.concat(facts);
           readable++;
         }
@@ -808,7 +823,7 @@ agents:
           var typ = (typeof f.type === "string") ? f.type.trim().toLowerCase() : "";
           var subj = (typeof f.subject === "string") ? f.subject.trim() : "";
           if (!typ || !subj) { typ = ""; subj = ""; }
-          out.push({ text: text, cls: cls, type: typ, subject: subj });
+          out.push({ text: text, cls: cls, type: typ, subject: subj, quote: "" });
         }
         return out;
       }
@@ -835,7 +850,9 @@ agents:
         // "" marks this as the queued batch rather than a chat: an unreadable
         // batch extraction leaves its items unacked, so they are re-drained next
         // pass on their own and nothing about it should hold the CHAT watermark.
-        var facts = extract(st, renderPending(taken), "");
+        var pendingText = renderPending(taken);
+        var facts = extract(st, pendingText, "");
+        deriveSpans(facts, pendingText);
         if (facts === null) { return []; }
         // An empty reply lets a CHAT through because the cost is bounded — the
         // watermark moves one row past a chat that had nothing to give. Acking
@@ -1056,6 +1073,63 @@ agents:
         return (2 * shared) / (na + nb);
       }
 
+      // deriveSpans attaches, to each fact, the sentence from its SOURCE that best
+      // supports it — the span a later pass checks the claim against.
+      //
+      // DERIVED HERE RATHER THAN ASKED OF THE EXTRACTOR, and that was a measured
+      // decision, not a preference. Adding a required `quote` field to the extractor's
+      // output contract was tried first: across three runs of the extraction eval it
+      // scored 2 violations, then a missed property, then clean, against a recorded
+      // baseline of zero violations and 1.00 recall that the unchanged prompt still
+      // hits. The extractor is at its capacity on a small local model, and a field
+      // added to its contract is paid for out of rule-following.
+      //
+      // Deriving costs the model nothing and cannot be fabricated: a span SELECTED
+      // from the source is in the source by construction, so the "did the model invent
+      // this quote" check the model-supplied version would have needed does not exist.
+      // What is lost is intent — this is the sentence that best supports the claim, not
+      // provably the one the extractor read. For checking whether the source supports
+      // the claim, the strongest candidate is the right thing to check.
+      //
+      // No match above the floor means NO span, which reads as unverified rather than
+      // as refuted. A fact whose support cannot be located is exactly the fact a
+      // verifier should be told nothing about.
+      function deriveSpans(facts, sourceText) {
+        if (!facts || !facts.length || !sourceText) { return facts; }
+        var sentences = splitSentences(sourceText);
+        if (!sentences.length) { return facts; }
+        for (var i = 0; i < facts.length; i++) {
+          var best = "", bestScore = 0;
+          for (var j = 0; j < sentences.length; j++) {
+            var sc = subjectOverlap(facts[i].text, sentences[j]);
+            if (sc > bestScore) { bestScore = sc; best = sentences[j]; }
+          }
+          if (bestScore < CONFIG.min_span_overlap) { continue; }
+          facts[i].quote = best.length > CONFIG.max_quote_chars
+            ? best.slice(0, CONFIG.max_quote_chars) : best;
+        }
+        return facts;
+      }
+
+      // splitSentences cuts a transcript into candidate spans.
+      //
+      // Line breaks count as boundaries, not just sentence punctuation: a transcript is
+      // turns and tool payloads, where a whole line is often one utterance with no
+      // terminator at all. Fragments shorter than a few words are dropped — they cannot
+      // support a claim and they score noisily against short facts.
+      function splitSentences(text) {
+        // NO LOOKBEHIND. The engine here is ES5.1-era and `(?<=…)` is ES2018 — it
+        // parses as a syntax error at load, taking the whole consolidator with it.
+        // Marking the terminator and splitting on the mark is portable.
+        var raw = String(text).replace(/([.!?])\s+/g, "$1\n").split(/\n+/);
+        var out = [];
+        for (var i = 0; i < raw.length; i++) {
+          var t = raw[i].trim();
+          if (t.length >= 12) { out.push(t); }
+        }
+        return out;
+      }
+
       // wordSet collapses a word list to a presence map. `=== true` on lookup
       // and hasOwnProperty on iteration, because a fact may legitimately contain
       // a word like "constructor" that Object.prototype already answers to.
@@ -1219,10 +1293,15 @@ agents:
 
         // The fact node carries the sentence; its title is the sentence too,
         // trimmed, because a chunk with no title is unreadable in the Path browser.
-        var factID = upsertEntityChunk(st, docID, key, {
+        var factArgs = {
           title: fact.text.length > 80 ? fact.text.slice(0, 77) + "..." : fact.text,
           type: "fact", body: fact.text
-        });
+        };
+        // The span goes on the FACT node only. A subject node is an identity, not a
+        // claim — there is nothing about "Denn" for a quote to support, and attaching
+        // one there would make the evidence look like it backed the wrong thing.
+        if (fact.quote) { factArgs.source_quote = fact.quote; }
+        var factID = upsertEntityChunk(st, docID, key, factArgs);
         if (!factID) { return; }
         st.entity_facts++;
 

--- a/cmd/loomcycle/presets_memory_codejs_test.go
+++ b/cmd/loomcycle/presets_memory_codejs_test.go
@@ -54,6 +54,7 @@ type fakeToolset struct {
 	entitiesDocID    string
 	chunks           map[string]string // natural_key -> chunk id
 	chunkTypes       map[string]string // natural_key -> type
+	chunkSpans       map[string]string // natural_key -> source_quote (RFC CC)
 	edges            []string          // "from-kind->to"
 	supersededChunks []string          // "old by new"
 	failEntityKeys   map[string]bool
@@ -123,6 +124,7 @@ func newFakeToolset() *fakeToolset {
 		failSetKeys:    map[string]bool{},
 		chunks:         map[string]string{},
 		chunkTypes:     map[string]string{},
+		chunkSpans:     map[string]string{},
 		failEntityKeys: map[string]bool{},
 		// Source of truth for this format: formatSubAgentOutput in
 		// internal/api/http/resume.go. Nothing links them — grep that name.
@@ -244,6 +246,9 @@ func (d *fakeDocument) Execute(_ context.Context, raw json.RawMessage) (tools.Re
 		}
 		if typ, ok := in["type"].(string); ok && typ != "" {
 			d.f.chunkTypes[key] = typ
+		}
+		if q, ok := in["source_quote"].(string); ok && q != "" {
+			d.f.chunkSpans[key] = q
 		}
 		return okResult(map[string]any{"id": id, "natural_key": key, "created": !existed})
 	case "link_chunks":
@@ -2788,5 +2793,83 @@ func TestConsolidator_RefusesAStatementClassAsAnEntityType(t *testing.T) {
 	// rejected must not look like a pass with nothing to mirror.
 	if !strings.Contains(res.FinalText, "2 refused") {
 		t.Errorf("the refusals must be reported; got %q", res.FinalText)
+	}
+}
+
+// TestConsolidator_DerivesTheSpanAFactCameFrom (RFC CC phase 1).
+//
+// A fact could say who wrote it and never what it was based on, so nothing downstream
+// could ask whether the source supported the claim. The span closes that — and it is
+// DERIVED from the transcript here rather than asked of the extractor, because adding a
+// required field to the extractor's contract measurably cost rule-following on a small
+// model while the unchanged prompt holds a zero-violation baseline.
+//
+// A derived span also cannot be fabricated: it is selected FROM the source, so it is in
+// the source by construction.
+func TestConsolidator_DerivesTheSpanAFactCameFrom(t *testing.T) {
+	f := newFakeToolset()
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	f.transcript = "user: I live in Cluj-Napoca and I work on loomcycle every day.\n" +
+		"assistant: noted.\n" +
+		"user: unrelated chatter about the weather in Berlin this morning."
+	f.factsJSON = `[{"text":"The user lives in Cluj-Napoca.","class":"fact","type":"location","subject":"Cluj-Napoca"}]`
+
+	runConsolidator(t, f)
+
+	span := f.chunkSpans["memory/fact/user-lives-cluj-napoca"]
+	if span == "" {
+		// The key is derived; find whichever fact node got a span.
+		for k, v := range f.chunkSpans {
+			if strings.Contains(k, "fact") {
+				span, _ = v, k
+			}
+		}
+	}
+	if span == "" {
+		t.Fatalf("no fact node carries a span (spans=%v)", f.chunkSpans)
+	}
+	// The RIGHT sentence: the one that supports the claim, not the Berlin chatter.
+	if !strings.Contains(span, "Cluj-Napoca") {
+		t.Errorf("span = %q, want the sentence that supports the claim", span)
+	}
+	if strings.Contains(span, "Berlin") {
+		t.Errorf("span = %q — an unrelated sentence was attached, which is worse than none "+
+			"because it looks like proof", span)
+	}
+	// It must be a real substring of the source, which is the property that makes
+	// fabrication impossible rather than merely unlikely.
+	if !strings.Contains(f.transcript, span) {
+		t.Errorf("span %q is not in the transcript verbatim", span)
+	}
+	// The SUBJECT node must NOT carry it: a subject is an identity, not a claim.
+	for k, v := range f.chunkSpans {
+		if strings.HasPrefix(k, "location:") && v != "" {
+			t.Errorf("subject node %q carries a span (%q) — there is nothing about an "+
+				"identity for evidence to support", k, v)
+		}
+	}
+}
+
+// TestConsolidator_NoSupportingSentenceMeansNoSpan.
+//
+// A fact whose support cannot be located must get NO span, not the least-bad sentence.
+// An unrelated span is worse than an absent one: absent reads as unverified, while a
+// wrong one reads as proof and would be handed to a verifier as the thing to check.
+func TestConsolidator_NoSupportingSentenceMeansNoSpan(t *testing.T) {
+	f := newFakeToolset()
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	// PARTIAL overlap on purpose. A transcript with zero shared words would pass this
+	// test whatever the floor is — the first version did exactly that, and proved
+	// nothing. "importer" is shared, so the best candidate scores above zero and below
+	// the floor, which is the case the floor exists for.
+	f.transcript = "user: the importer felt slow this morning, any idea why\nassistant: not sure."
+	f.factsJSON = `[{"text":"The invoice importer parses CSV date columns using a strict format.","class":"fact","type":"object","subject":"invoice importer"}]`
+
+	runConsolidator(t, f)
+
+	for k, v := range f.chunkSpans {
+		if v != "" {
+			t.Errorf("chunk %q got span %q from a transcript that does not support it", k, v)
+		}
 	}
 }

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -88,6 +88,7 @@ const documentInputSchema = `{
 		"as_of":     {"type": "integer", "description": "graph_recall / list_facts: answer as of this moment (unix nanos) instead of now — returns what was true then, including facts since corrected."},
 		"include_retired": {"type": "boolean", "description": "graph_recall / list_facts: also return facts that have been superseded. Off by default, so you get only what is currently true."},
 		"limit":     {"type": "integer", "description": "graph_recall: maximum chunks returned (default 50)."},
+		"source_quote": {"type": "string", "description": "upsert_chunk: the EXACT text this fact was derived from, copied verbatim from the source you read — not a paraphrase. It is what a later pass checks the claim against, and what an operator sees when they ask why the store believes this. Omit only when there is no source text (material you are recording as evidence in its own right)."},
 		"natural_key": {"type": "string", "description": "upsert_chunk: the stable identity of this entity or fact. Upserting twice with the same key updates ONE chunk instead of adding a second — use a derived form such as person:ada-lovelace, or subject|predicate|object for a fact. Unique within the scope."},
 		"supersedes_id": {"type": "string", "description": "supersede_chunk: the id of the chunk being RETIRED by this one. The retired chunk is not deleted — it stays queryable so that questions about an earlier point in time still have an answer."},
 		"valid_at":   {"type": "integer", "description": "When the fact became true IN THE WORLD (unix nanos). Defaults to now. Distinct from when it was recorded."},
@@ -143,9 +144,13 @@ type docInput struct {
 	Status    string          `json:"status"`
 	// Parent names an entity by NAME (propose_entity). Distinct from ParentID, which
 	// addresses a chunk: a curator knows the type it read in its prompt, not a uuid.
-	Parent   string `json:"parent"`
-	Position *int   `json:"position"`
-	Revision *int   `json:"revision"`
+	Parent string `json:"parent"`
+	// SourceQuote is the span a fact was derived from (upsert_chunk). Persisted on the
+	// entity row so a later pass can check the claim against it, and so an operator
+	// asking "why do you believe this" has an answer.
+	SourceQuote string `json:"source_quote"`
+	Position    *int   `json:"position"`
+	Revision    *int   `json:"revision"`
 	// FromRevision / ToRevision select the two body-change revisions to diff (RFC
 	// BS Phase 3a). Pointers so an omitted bound is distinguishable from a value
 	// (the log is 1-based, so 0 is never a real revision, but the pointer keeps the
@@ -267,7 +272,7 @@ var docSchemaDDL = []string{
 		created_at BIGINT, expired_at BIGINT,
 		class TEXT, origin TEXT, confidence DOUBLE PRECISION,
 		session_id TEXT, run_id TEXT, event_seq BIGINT,
-		natural_key TEXT)`,
+		natural_key TEXT, source_quote TEXT)`,
 	// UNIQUE per SCOPE, not per document: each scope owns its own database (a
 	// sqlite file / a postgres schema), so a bare UNIQUE index on the column IS
 	// scope-wide — one entity per tenant regardless of which document holds it.
@@ -571,7 +576,10 @@ func (d *Document) ensureSchema(ctx context.Context, key sqlmem.ScopeKey) error 
 	if err := d.migrateAssetDescription(ctx, key); err != nil {
 		return err
 	}
-	return d.migrateEdgeAuto(ctx, key)
+	if err := d.migrateEdgeAuto(ctx, key); err != nil {
+		return err
+	}
+	return d.migrateSourceQuote(ctx, key)
 }
 
 // migrateConfidencePrecision widens chunk_memory_meta.confidence from postgres
@@ -723,6 +731,28 @@ func (d *Document) tableHasColumn(ctx context.Context, key sqlmem.ScopeKey, tabl
 // tier-portable; `ADD COLUMN … NOT NULL DEFAULT 0` fills existing rows on both
 // tiers, so every edge predating this migration reads back as manual (auto=0),
 // which is what it is.
+// migrateSourceQuote adds the span a fact was derived from.
+//
+// A fact could say who wrote it (`origin`, `run_id`) but never what it was based on,
+// so nothing downstream could ask whether the source supported the claim — not the
+// consolidator, not retrieval, not an operator reading the memory page. Three separate
+// failures on a live deployment traced to that: a curator inventing counts, an extractor
+// typing the subject of "the user resides in Cluj-Napoca" as a location, and three entity
+// writes refused for a class-where-a-type-belongs. None of them was checkable.
+//
+// NULLABLE, and existing rows stay NULL. A fact written before this column cannot be
+// verified retroactively and must not be treated as if it were: no span means unverified,
+// which is honest, and it stays recallable.
+//
+// PROBES before it alters, like its siblings — ensureSchema is on every op's hot path, so
+// the fast case is one 0-row SELECT.
+func (d *Document) migrateSourceQuote(ctx context.Context, key sqlmem.ScopeKey) error {
+	if _, err := d.query(ctx, key, `SELECT source_quote FROM chunk_memory_meta WHERE 1=0`); err == nil {
+		return nil
+	}
+	return d.exec(ctx, key, `ALTER TABLE chunk_memory_meta ADD COLUMN source_quote TEXT`)
+}
+
 func (d *Document) migrateEdgeAuto(ctx context.Context, key sqlmem.ScopeKey) error {
 	if _, err := d.query(ctx, key, `SELECT auto FROM chunk_edges WHERE 1=0`); err == nil {
 		return nil

--- a/internal/tools/builtin/document_entity.go
+++ b/internal/tools/builtin/document_entity.go
@@ -170,12 +170,16 @@ type chunkMetaRow struct {
 	RunID      string
 	EventSeq   *int64
 	NaturalKey string
+	// SourceQuote is the span the claim was derived from — the text a verifier
+	// checks the claim against. Empty means unverifiable, not false: every fact
+	// written before the column existed has none.
+	SourceQuote string
 }
 
 // readChunkMeta returns the chunk's sidecar row, or found=false when it has none.
 func (d *Document) readChunkMeta(ctx context.Context, key sqlmem.ScopeKey, chunkID string) (row chunkMetaRow, found bool, err error) {
 	res, err := d.query(ctx, key,
-		`SELECT valid_at, invalid_at, created_at, expired_at, class, origin, confidence, session_id, run_id, event_seq, natural_key
+		`SELECT valid_at, invalid_at, created_at, expired_at, class, origin, confidence, session_id, run_id, event_seq, natural_key, coalesce(source_quote, '')
 		   FROM chunk_memory_meta WHERE chunk_id = ?`, chunkID)
 	if err != nil || len(res.Rows) == 0 {
 		return chunkMetaRow{}, false, err
@@ -186,7 +190,7 @@ func (d *Document) readChunkMeta(ctx context.Context, key sqlmem.ScopeKey, chunk
 		CreatedAt: asInt64Ptr(r[2]), ExpiredAt: asInt64Ptr(r[3]),
 		Class: asStr(r[4]), Origin: asStr(r[5]), Confidence: asFloat64Ptr(r[6]),
 		SessionID: asStr(r[7]), RunID: asStr(r[8]), EventSeq: asInt64Ptr(r[9]),
-		NaturalKey: asStr(r[10]),
+		NaturalKey: asStr(r[10]), SourceQuote: asStr(r[11]),
 	}, true, nil
 }
 
@@ -234,6 +238,9 @@ func chunkMetaToJSON(m chunkMetaRow) map[string]any {
 	}
 	if m.EventSeq != nil {
 		out["event_seq"] = *m.EventSeq
+	}
+	if m.SourceQuote != "" {
+		out["source_quote"] = m.SourceQuote
 	}
 	return out
 }
@@ -285,7 +292,7 @@ func (d *Document) listFacts(ctx context.Context, key sqlmem.ScopeKey, in docInp
 
 	stmt := `SELECT c.id, c.document_id, c.parent_id, c.position, c.title, c.type, c.status, c.revision,
 	                m.valid_at, m.invalid_at, m.created_at, m.expired_at, m.class, m.origin, m.confidence,
-	                m.session_id, m.run_id, m.event_seq, m.natural_key
+	                m.session_id, m.run_id, m.event_seq, m.natural_key, coalesce(m.source_quote, '')
 	           FROM chunks c JOIN chunk_memory_meta m ON m.chunk_id = c.id`
 	if len(where) > 0 {
 		stmt += " WHERE " + strings.Join(where, " AND ")
@@ -313,7 +320,7 @@ func (d *Document) listFacts(ctx context.Context, key sqlmem.ScopeKey, in docInp
 			CreatedAt: asInt64Ptr(r[10]), ExpiredAt: asInt64Ptr(r[11]),
 			Class: asStr(r[12]), Origin: asStr(r[13]), Confidence: asFloat64Ptr(r[14]),
 			SessionID: asStr(r[15]), RunID: asStr(r[16]), EventSeq: asInt64Ptr(r[17]),
-			NaturalKey: asStr(r[18]),
+			NaturalKey: asStr(r[18]), SourceQuote: asStr(r[19]),
 		}
 		fact := map[string]any{
 			"id":          asStr(r[0]),
@@ -439,21 +446,28 @@ func (d *Document) writeChunkMeta(ctx context.Context, key sqlmem.ScopeKey, chun
 	if naturalKey == "" {
 		naturalKey = prev.NaturalKey
 	}
+	// PRESERVED when this write cannot supply it, like the provenance triple above.
+	// An operator correcting a fact's wording must not strip the span that fact was
+	// derived from — the evidence outlives the edit.
+	sourceQuote := in.SourceQuote
+	if sourceQuote == "" {
+		sourceQuote = prev.SourceQuote
+	}
 
 	if err := d.exec(ctx, key, `DELETE FROM chunk_memory_meta WHERE chunk_id = ?`, chunkID); err != nil {
 		return err
 	}
 	return d.exec(ctx, key,
 		`INSERT INTO chunk_memory_meta
-		   (chunk_id, valid_at, invalid_at, created_at, expired_at, class, origin, confidence, session_id, run_id, event_seq, natural_key)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		   (chunk_id, valid_at, invalid_at, created_at, expired_at, class, origin, confidence, session_id, run_id, event_seq, natural_key, source_quote)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		chunkID, validAt, invalidAt, createdAt, expiredAt, class,
 		originForEntityWrite(ctx), confidence,
 		// session_id has no writer yet: it is not on the run ctx, only the run id is.
 		// Preserved rather than nulled so the consolidation path — which CAN fill it
 		// when it relays a drained pending row — does not lose it to the next upsert.
 		nullIfEmpty(prev.SessionID), nullIfEmpty(runID), int64Arg(prev.EventSeq),
-		nullIfEmpty(naturalKey))
+		nullIfEmpty(naturalKey), nullIfEmpty(sourceQuote))
 }
 
 // int64Arg / float64Arg turn a nullable read back into a bind arg that round-trips

--- a/internal/tools/builtin/document_source_span_test.go
+++ b/internal/tools/builtin/document_source_span_test.go
@@ -1,0 +1,132 @@
+package builtin
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestSourceSpan_RoundTripsAndSurvivesAnEdit.
+//
+// A fact could say WHO wrote it and never WHAT it was based on, so nothing could ask
+// whether the source supported the claim. Three live failures traced to that. The span
+// closes it — and it has to survive an ordinary edit, or the evidence evaporates the
+// first time someone fixes a typo in the claim.
+func TestSourceSpan_RoundTripsAndSurvivesAnEdit(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	out, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Notes","body":""}`)
+	if r.IsError {
+		t.Fatalf("create_document: %s", r.Text)
+	}
+	docID, _ := out["document_id"].(string)
+	root, _ := out["root_chunk_id"].(string)
+
+	quote := "I live in Cluj-Napoca and I work on loomcycle."
+	qj, _ := json.Marshal(quote)
+	up, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+docID+
+		`","parent_id":"`+root+`","natural_key":"fact:user-city","title":"The user lives in Cluj-Napoca.",`+
+		`"type":"location","source_quote":`+string(qj)+`,"body":"x"}`)
+	if r.IsError {
+		t.Fatalf("upsert_chunk: %s", r.Text)
+	}
+	id, _ := up["id"].(string)
+
+	got, r := docExec(t, d, ctx, `{"op":"get_chunk","scope":"user","id":"`+id+`"}`)
+	if r.IsError {
+		t.Fatalf("get_chunk: %s", r.Text)
+	}
+	entity, _ := got["entity"].(map[string]any)
+	if entity == nil {
+		t.Fatalf("no entity block: %v", got)
+	}
+	if entity["source_quote"] != quote {
+		t.Errorf("source_quote = %v, want the span verbatim", entity["source_quote"])
+	}
+
+	// EDIT the claim without resupplying the span. The evidence must survive: an
+	// operator correcting wording is not withdrawing the basis for the fact.
+	if _, r = docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+docID+
+		`","parent_id":"`+root+`","natural_key":"fact:user-city","title":"The user resides in Cluj-Napoca.","body":"x"}`); r.IsError {
+		t.Fatalf("re-upsert: %s", r.Text)
+	}
+	got, _ = docExec(t, d, ctx, `{"op":"get_chunk","scope":"user","id":"`+id+`"}`)
+	entity, _ = got["entity"].(map[string]any)
+	if entity["source_quote"] != quote {
+		t.Errorf("the span was lost on an edit: %v", entity["source_quote"])
+	}
+	// And it reaches the fact list, which is where an operator or a judge enumerates.
+	facts, r := docExec(t, d, ctx, `{"op":"list_facts","scope":"user"}`)
+	if r.IsError {
+		t.Fatalf("list_facts: %s", r.Text)
+	}
+	listed, _ := json.Marshal(facts)
+	if !strings.Contains(string(listed), quote) {
+		t.Error("list_facts does not carry the span — a judge would have nothing to check against")
+	}
+}
+
+// TestSourceSpan_AbsentMeansUnverifiedNotFalse.
+//
+// Every fact written before this column existed has no span, and the decision is that
+// they stay recallable and honestly labelled. A fact with no span must therefore write
+// and read cleanly rather than erroring or defaulting to something that looks like
+// evidence.
+func TestSourceSpan_AbsentMeansUnverifiedNotFalse(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	out, _ := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Notes","body":""}`)
+	docID, _ := out["document_id"].(string)
+	root, _ := out["root_chunk_id"].(string)
+	up, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+docID+
+		`","parent_id":"`+root+`","natural_key":"fact:no-span","title":"Something recorded without a source.","body":"x"}`)
+	if r.IsError {
+		t.Fatalf("upsert without a span must be allowed: %s", r.Text)
+	}
+	id, _ := up["id"].(string)
+	got, _ := docExec(t, d, ctx, `{"op":"get_chunk","scope":"user","id":"`+id+`"}`)
+	entity, _ := got["entity"].(map[string]any)
+	if _, present := entity["source_quote"]; present {
+		t.Errorf("an absent span must be absent, not empty-but-present: %v", entity)
+	}
+	// It is still a fact and still enumerable — unverified, not withheld.
+	facts, _ := docExec(t, d, ctx, `{"op":"list_facts","scope":"user"}`)
+	if n, _ := facts["count"].(float64); n != 1 {
+		t.Errorf("a span-less fact must stay recallable, got count %v", facts["count"])
+	}
+}
+
+// TestSourceSpan_MigratesAScopeThatPredatesTheColumn.
+//
+// ensureSchema's CREATE TABLE IF NOT EXISTS leaves an existing table untouched, so a
+// store provisioned before this column would never gain it — the write would fail on
+// every fact for every deployment that already exists. The migration is what makes this
+// shippable, and dropping the column back off is the only honest way to test it.
+func TestSourceSpan_MigratesAScopeThatPredatesTheColumn(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	out, _ := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Notes","body":""}`)
+	docID, _ := out["document_id"].(string)
+	root, _ := out["root_chunk_id"].(string)
+
+	key, _, err := d.resolveScope(ctx, "user")
+	if err != nil {
+		t.Fatalf("resolveScope: %v", err)
+	}
+	if err := d.exec(ctx, key, `ALTER TABLE chunk_memory_meta DROP COLUMN source_quote`); err != nil {
+		t.Skipf("this tier cannot drop a column, so the pre-migration state is unreachable: %v", err)
+	}
+	if d.tableHasColumn(ctx, key, "chunk_memory_meta", "source_quote") {
+		t.Fatal("the column survived the drop — the test cannot reach the state it is for")
+	}
+
+	// Any op re-runs ensureSchema, which must add it back.
+	up, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+docID+
+		`","parent_id":"`+root+`","natural_key":"fact:migrated","title":"A claim.","source_quote":"the source said so","body":"x"}`)
+	if r.IsError {
+		t.Fatalf("the migration did not run: %s", r.Text)
+	}
+	id, _ := up["id"].(string)
+	got, _ := docExec(t, d, ctx, `{"op":"get_chunk","scope":"user","id":"`+id+`"}`)
+	entity, _ := got["entity"].(map[string]any)
+	if entity["source_quote"] != "the source said so" {
+		t.Errorf("span not persisted after migration: %v", entity["source_quote"])
+	}
+}


### PR DESCRIPTION
## Why

A fact could say **who** wrote it — `origin`, `run_id` — and never **what it was based on**. So nothing downstream could ask whether the source supported the claim: not the consolidator, not retrieval, not an operator reading the memory page.

Three failures on your deployment traced to exactly that, and one of them reached the tool.

## What

`chunk_memory_meta.source_quote`: persisted, **preserved across an edit** (correcting a fact's wording must not strip the evidence for it), and surfaced on `get_chunk` and `list_facts`. Nullable, migrated by probe-then-`ALTER` — `CREATE TABLE IF NOT EXISTS` leaves an existing scope untouched and every deployment already has one. No span reads as **unverified**, not false, including every fact written before today.

## The design changed mid-implementation, because the measurement said so

I built the obvious version first: a required `quote` field in the extractor's output contract, with the prompt ceiling raised to pay for it. Then the eval:

| | violations | recall |
|---|---|---|
| **main's prompt** | 0 | 1.00 across the board |
| my prompt, run 1 | **2** | 1.00 |
| my prompt, run 2 | 0 | property **0.80** |
| my prompt, run 3 | 0 | 1.00 |

Recorded baselines for this model are all **zero violations, 1.00 recall**. That table is variance overlapping a possible regression — and it is not a thing to ship into the one component every memory write depends on. The extractor is at its capacity on a small local model, and a field added to its contract gets paid for out of rule-following.

**So the span is derived in code from the transcript the consolidator already has**, and the extractor prompt is byte-identical to main — its baseline keeps gating rather than being un-gated by this PR.

Deriving is also strictly stronger in one respect: a span **selected from** the source is in the source by construction, so the "did the model invent this quote" check a model-supplied span would have required does not exist. What's lost is intent — it's the sentence that best supports the claim, not provably the one the extractor read. For asking *does the source support this*, the strongest candidate is the right thing to check.

## Two tests I had to fix before trusting

**The floor test was vacuous.** A transcript with zero shared words yields no span whatever the floor is, so my first version proved nothing. It now uses a *partial*-overlap transcript ("importer" shared, below threshold), verified by dropping the floor to zero and watching it fail with the unrelated sentence attached.

**The migration test needed the pre-migration state**, so it drops the column and re-runs — fail-before confirmed (`no such column: source_quote`).

Also caught while building: the span goes on the **fact** node only, never the subject node (an identity is not a claim — there's nothing about "Denn" for evidence to support); and my first sentence splitter used a lookbehind, which is ES2018 and would have thrown at load in the ES5.1-era engine, taking the whole consolidator with it.

## Tested

`go test ./...` clean. `TestSourceSpan_{RoundTripsAndSurvivesAnEdit,AbsentMeansUnverifiedNotFalse,MigratesAScopeThatPredatesTheColumn}`, `TestConsolidator_{DerivesTheSpanAFactCameFrom,NoSupportingSentenceMeansNoSpan}`. Plus four live extraction-eval runs on `ollama-local qwen3.6` producing the table above.

## Next

Phase 2 is the deterministic gate — and it gets cheaper than the RFC assumed, since a derived span is in the source by construction, so the "quote occurs verbatim" check is free. The remaining checks (type in ontology, type/subject together, subject in span, numbers in span) are where the observed failures actually live.

Worth noting for later: with a derived span, the **backfill** in phase 4 becomes real work rather than labelling — existing facts can get spans from their source transcripts by the same matcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8