### PR TITLE
feat(memory): the subject becomes data, and the ontology gates entity writes (RFC CC P2)

### DIFF
--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -1286,7 +1286,7 @@ agents:
         var subjKey = entityKey(fact.type, fact.subject);
         var isNewSubject = !st.entity_ids[subjKey];
         var subjID = upsertEntityChunk(st, docID, subjKey, {
-          title: fact.subject, type: fact.type
+          title: fact.subject, type: fact.type, subject: fact.subject
         });
         if (!subjID) { return; }
         if (isNewSubject) { st.entity_nodes++; }

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -1286,7 +1286,7 @@ agents:
         var subjKey = entityKey(fact.type, fact.subject);
         var isNewSubject = !st.entity_ids[subjKey];
         var subjID = upsertEntityChunk(st, docID, subjKey, {
-          title: fact.subject, type: fact.type
+          title: fact.subject, type: fact.type, subject: fact.subject
         });
         if (!subjID) { return; }
         if (isNewSubject) { st.entity_nodes++; }

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -88,6 +88,7 @@ const documentInputSchema = `{
 		"as_of":     {"type": "integer", "description": "graph_recall / list_facts: answer as of this moment (unix nanos) instead of now — returns what was true then, including facts since corrected."},
 		"include_retired": {"type": "boolean", "description": "graph_recall / list_facts: also return facts that have been superseded. Off by default, so you get only what is currently true."},
 		"limit":     {"type": "integer", "description": "graph_recall: maximum chunks returned (default 50)."},
+		"subject":      {"type": "string", "description": "upsert_chunk: the thing this entity assertion is ABOUT, paired with type — emit both or neither. type says what kind of thing it is, subject names it. A plain document chunk has no subject; passing the pair is what marks a write as an entity the ontology governs."},
 		"source_quote": {"type": "string", "description": "upsert_chunk: the EXACT text this fact was derived from, copied verbatim from the source you read — not a paraphrase. It is what a later pass checks the claim against, and what an operator sees when they ask why the store believes this. Omit only when there is no source text (material you are recording as evidence in its own right)."},
 		"natural_key": {"type": "string", "description": "upsert_chunk: the stable identity of this entity or fact. Upserting twice with the same key updates ONE chunk instead of adding a second — use a derived form such as person:ada-lovelace, or subject|predicate|object for a fact. Unique within the scope."},
 		"supersedes_id": {"type": "string", "description": "supersede_chunk: the id of the chunk being RETIRED by this one. The retired chunk is not deleted — it stays queryable so that questions about an earlier point in time still have an answer."},
@@ -149,8 +150,12 @@ type docInput struct {
 	// entity row so a later pass can check the claim against it, and so an operator
 	// asking "why do you believe this" has an answer.
 	SourceQuote string `json:"source_quote"`
-	Position    *int   `json:"position"`
-	Revision    *int   `json:"revision"`
+	// Subject is WHAT an entity assertion is about, travelling with Type as a pair.
+	// First-class rather than encoded in the natural key, so it can be read, queried and
+	// checked — and so the tool can tell an entity assertion from a document write.
+	Subject  string `json:"subject"`
+	Position *int   `json:"position"`
+	Revision *int   `json:"revision"`
 	// FromRevision / ToRevision select the two body-change revisions to diff (RFC
 	// BS Phase 3a). Pointers so an omitted bound is distinguishable from a value
 	// (the log is 1-based, so 0 is never a real revision, but the pointer keeps the
@@ -272,7 +277,7 @@ var docSchemaDDL = []string{
 		created_at BIGINT, expired_at BIGINT,
 		class TEXT, origin TEXT, confidence DOUBLE PRECISION,
 		session_id TEXT, run_id TEXT, event_seq BIGINT,
-		natural_key TEXT, source_quote TEXT)`,
+		natural_key TEXT, source_quote TEXT, subject TEXT)`,
 	// UNIQUE per SCOPE, not per document: each scope owns its own database (a
 	// sqlite file / a postgres schema), so a bare UNIQUE index on the column IS
 	// scope-wide — one entity per tenant regardless of which document holds it.
@@ -579,7 +584,10 @@ func (d *Document) ensureSchema(ctx context.Context, key sqlmem.ScopeKey) error 
 	if err := d.migrateEdgeAuto(ctx, key); err != nil {
 		return err
 	}
-	return d.migrateSourceQuote(ctx, key)
+	if err := d.migrateSourceQuote(ctx, key); err != nil {
+		return err
+	}
+	return d.migrateSubject(ctx, key)
 }
 
 // migrateConfidencePrecision widens chunk_memory_meta.confidence from postgres
@@ -746,6 +754,25 @@ func (d *Document) tableHasColumn(ctx context.Context, key sqlmem.ScopeKey, tabl
 //
 // PROBES before it alters, like its siblings — ensureSchema is on every op's hot path, so
 // the fast case is one 0-row SELECT.
+// migrateSubject adds the subject an entity assertion is ABOUT.
+//
+// Until now the subject existed only inside the natural key and the title —
+// `location:user` with title "user" — so nothing could read it as data. Two
+// consequences, both observed: the tool could not tell an entity assertion from an
+// idempotent DOCUMENT write (both carry a type and a natural key, and `type` holds a
+// document's structural vocabulary too), and a mistyped subject was invisible to any
+// query. `location:user`, asserting that the user is a location, is only findable by
+// parsing a key.
+//
+// Nullable. A document write carries no subject and never will, which is exactly what
+// makes the pair a usable discriminator.
+func (d *Document) migrateSubject(ctx context.Context, key sqlmem.ScopeKey) error {
+	if _, err := d.query(ctx, key, `SELECT subject FROM chunk_memory_meta WHERE 1=0`); err == nil {
+		return nil
+	}
+	return d.exec(ctx, key, `ALTER TABLE chunk_memory_meta ADD COLUMN subject TEXT`)
+}
+
 func (d *Document) migrateSourceQuote(ctx context.Context, key sqlmem.ScopeKey) error {
 	if _, err := d.query(ctx, key, `SELECT source_quote FROM chunk_memory_meta WHERE 1=0`); err == nil {
 		return nil

--- a/internal/tools/builtin/document_entity.go
+++ b/internal/tools/builtin/document_entity.go
@@ -57,6 +57,11 @@ func (d *Document) upsertChunk(ctx context.Context, key sqlmem.ScopeKey, mscope 
 	if in.Class != "" && !entityClasses[in.Class] {
 		return errResult(fmt.Sprintf("upsert_chunk: unknown class %q (want derived or evidential)", in.Class)), nil
 	}
+	// The ontology governs what an entity assertion may be about, so every writer is
+	// held to it here rather than only the one that carries its own list.
+	if refused := d.gateEntityType(ctx, in); refused != nil {
+		return *refused, nil
+	}
 
 	existing, err := d.chunkIDByNaturalKey(ctx, key, in.NaturalKey)
 	if err != nil {
@@ -174,12 +179,15 @@ type chunkMetaRow struct {
 	// checks the claim against. Empty means unverifiable, not false: every fact
 	// written before the column existed has none.
 	SourceQuote string
+	// Subject is what the assertion is about. Paired with the chunk's type; a document
+	// chunk has neither.
+	Subject string
 }
 
 // readChunkMeta returns the chunk's sidecar row, or found=false when it has none.
 func (d *Document) readChunkMeta(ctx context.Context, key sqlmem.ScopeKey, chunkID string) (row chunkMetaRow, found bool, err error) {
 	res, err := d.query(ctx, key,
-		`SELECT valid_at, invalid_at, created_at, expired_at, class, origin, confidence, session_id, run_id, event_seq, natural_key, coalesce(source_quote, '')
+		`SELECT valid_at, invalid_at, created_at, expired_at, class, origin, confidence, session_id, run_id, event_seq, natural_key, coalesce(source_quote, ''), coalesce(subject, '')
 		   FROM chunk_memory_meta WHERE chunk_id = ?`, chunkID)
 	if err != nil || len(res.Rows) == 0 {
 		return chunkMetaRow{}, false, err
@@ -190,7 +198,7 @@ func (d *Document) readChunkMeta(ctx context.Context, key sqlmem.ScopeKey, chunk
 		CreatedAt: asInt64Ptr(r[2]), ExpiredAt: asInt64Ptr(r[3]),
 		Class: asStr(r[4]), Origin: asStr(r[5]), Confidence: asFloat64Ptr(r[6]),
 		SessionID: asStr(r[7]), RunID: asStr(r[8]), EventSeq: asInt64Ptr(r[9]),
-		NaturalKey: asStr(r[10]), SourceQuote: asStr(r[11]),
+		NaturalKey: asStr(r[10]), SourceQuote: asStr(r[11]), Subject: asStr(r[12]),
 	}, true, nil
 }
 
@@ -242,6 +250,9 @@ func chunkMetaToJSON(m chunkMetaRow) map[string]any {
 	if m.SourceQuote != "" {
 		out["source_quote"] = m.SourceQuote
 	}
+	if m.Subject != "" {
+		out["subject"] = m.Subject
+	}
 	return out
 }
 
@@ -292,7 +303,7 @@ func (d *Document) listFacts(ctx context.Context, key sqlmem.ScopeKey, in docInp
 
 	stmt := `SELECT c.id, c.document_id, c.parent_id, c.position, c.title, c.type, c.status, c.revision,
 	                m.valid_at, m.invalid_at, m.created_at, m.expired_at, m.class, m.origin, m.confidence,
-	                m.session_id, m.run_id, m.event_seq, m.natural_key, coalesce(m.source_quote, '')
+	                m.session_id, m.run_id, m.event_seq, m.natural_key, coalesce(m.source_quote, ''), coalesce(m.subject, '')
 	           FROM chunks c JOIN chunk_memory_meta m ON m.chunk_id = c.id`
 	if len(where) > 0 {
 		stmt += " WHERE " + strings.Join(where, " AND ")
@@ -320,7 +331,7 @@ func (d *Document) listFacts(ctx context.Context, key sqlmem.ScopeKey, in docInp
 			CreatedAt: asInt64Ptr(r[10]), ExpiredAt: asInt64Ptr(r[11]),
 			Class: asStr(r[12]), Origin: asStr(r[13]), Confidence: asFloat64Ptr(r[14]),
 			SessionID: asStr(r[15]), RunID: asStr(r[16]), EventSeq: asInt64Ptr(r[17]),
-			NaturalKey: asStr(r[18]), SourceQuote: asStr(r[19]),
+			NaturalKey: asStr(r[18]), SourceQuote: asStr(r[19]), Subject: asStr(r[20]),
 		}
 		fact := map[string]any{
 			"id":          asStr(r[0]),
@@ -453,21 +464,27 @@ func (d *Document) writeChunkMeta(ctx context.Context, key sqlmem.ScopeKey, chun
 	if sourceQuote == "" {
 		sourceQuote = prev.SourceQuote
 	}
+	// Preserved on absence, like the span: an edit that does not restate the subject is
+	// not withdrawing it.
+	subject := in.Subject
+	if subject == "" {
+		subject = prev.Subject
+	}
 
 	if err := d.exec(ctx, key, `DELETE FROM chunk_memory_meta WHERE chunk_id = ?`, chunkID); err != nil {
 		return err
 	}
 	return d.exec(ctx, key,
 		`INSERT INTO chunk_memory_meta
-		   (chunk_id, valid_at, invalid_at, created_at, expired_at, class, origin, confidence, session_id, run_id, event_seq, natural_key, source_quote)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		   (chunk_id, valid_at, invalid_at, created_at, expired_at, class, origin, confidence, session_id, run_id, event_seq, natural_key, source_quote, subject)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		chunkID, validAt, invalidAt, createdAt, expiredAt, class,
 		originForEntityWrite(ctx), confidence,
 		// session_id has no writer yet: it is not on the run ctx, only the run id is.
 		// Preserved rather than nulled so the consolidation path — which CAN fill it
 		// when it relays a drained pending row — does not lose it to the next upsert.
 		nullIfEmpty(prev.SessionID), nullIfEmpty(runID), int64Arg(prev.EventSeq),
-		nullIfEmpty(naturalKey), nullIfEmpty(sourceQuote))
+		nullIfEmpty(naturalKey), nullIfEmpty(sourceQuote), nullIfEmpty(subject))
 }
 
 // int64Arg / float64Arg turn a nullable read back into a bind arg that round-trips

--- a/internal/tools/builtin/document_entity_gate_test.go
+++ b/internal/tools/builtin/document_entity_gate_test.go
@@ -1,0 +1,171 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"strings"
+	"testing"
+
+	memrank "github.com/denn-gubsky/loomcycle/internal/memory"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// gateFixture gives an agent ctx over a tenant with a CONFIRMED ontology that declares
+// one type of its own (`research` under `project`), so the gate is exercised against a
+// real effective set rather than the bare seed.
+func gateFixture(t *testing.T) (*Document, context.Context) {
+	t.Helper()
+	d, base, _ := documentFixture(t)
+	base = tools.WithMemoryPolicy(base, tools.MemoryPolicyValue{AllowedScopes: []string{"tenant"}})
+	base = tools.WithSqlMemPolicy(base, tools.SqlMemPolicyValue{AllowedScopes: []string{"tenant"}})
+	op := tools.WithSubstrateOperator(base)
+
+	md := "# Tenant Ontology\n\n## project\n- `status`\n\n### research\n- `question`\n"
+	mj, _ := json.Marshal(md)
+	out, r := docExec(t, d, op, `{"op":"import_md","scope":"tenant","markdown":`+string(mj)+`}`)
+	if r.IsError {
+		t.Fatalf("import_md: %s", r.Text)
+	}
+	id, _ := out["document_id"].(string)
+	pj, _ := json.Marshal(memrank.OntologyPath)
+	if _, r = docExec(t, d, op, `{"op":"set_path","scope":"tenant","id":"`+id+`","path":`+string(pj)+`}`); r.IsError {
+		t.Fatalf("set_path: %s", r.Text)
+	}
+	root, _ := out["root_chunk_id"].(string)
+	g, _ := docExec(t, d, op, `{"op":"get_chunk","scope":"tenant","id":"`+root+`"}`)
+	rev := int(g["revision"].(float64))
+	if _, r = docExec(t, d, op, `{"op":"update_chunk","scope":"tenant","id":"`+root+
+		`","status":"confirmed","revision":`+strconv.Itoa(rev)+`}`); r.IsError {
+		t.Fatalf("confirm: %s", r.Text)
+	}
+	return d, base
+}
+
+// TestEntityGate_RefusesATypeTheOntologyDoesNotDeclare.
+//
+// An invented type becomes an entity node nobody declared and nothing can find. The
+// consolidator refuses two such names, but that reaches one writer — every other path
+// (an agent's upsert_chunk, an MCP session, a curator) had no check at all.
+func TestEntityGate_RefusesATypeTheOntologyDoesNotDeclare(t *testing.T) {
+	d, ctx := gateFixture(t)
+	out, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Facts","body":""}`)
+	if r.IsError {
+		t.Fatalf("create_document: %s", r.Text)
+	}
+	doc, _ := out["document_id"].(string)
+	root, _ := out["root_chunk_id"].(string)
+	mk := func(typ, subject string) tools.Result {
+		body := `{"op":"upsert_chunk","scope":"user","document_id":"` + doc + `","parent_id":"` + root +
+			`","natural_key":"k:` + typ + `-` + subject + `","title":"t","type":"` + typ + `"`
+		if subject != "" {
+			body += `,"subject":"` + subject + `"`
+		}
+		_, res := docExec(t, d, ctx, body+`}`)
+		return res
+	}
+
+	// An invented type, WITH a subject → refused, and the message names the alternatives.
+	r = mk("process", "deploy")
+	if !r.IsError {
+		t.Fatal("an undeclared entity type was accepted")
+	}
+	for _, want := range []string{"project", "research", "person", "propose_entity"} {
+		if !strings.Contains(r.Text, want) {
+			t.Errorf("the refusal does not mention %q, so it is not actionable: %s", want, r.Text)
+		}
+	}
+	// A SEED type → allowed.
+	if r = mk("person", "ada"); r.IsError {
+		t.Errorf("a seed type was refused: %s", r.Text)
+	}
+	// The tenant's OWN declared subtype → allowed. A gate that only knew the seed would
+	// refuse the vocabulary the operator curated, which is worse than no gate.
+	if r = mk("research", "memory-survey"); r.IsError {
+		t.Errorf("a confirmed tenant type was refused: %s", r.Text)
+	}
+}
+
+// TestEntityGate_LeavesDocumentWritesAlone is the regression that killed the first
+// version of this gate.
+//
+// `type` holds TWO vocabularies: an entity's type and a document chunk's own structure
+// (rfc, section, image). Keying the gate on "a natural_key is present" refused an
+// idempotent DOCUMENT write — legitimate, already tested, and on a real deployment it
+// would have blocked a documentation store for using its own words. The pair is the
+// discriminator: a document carries no subject.
+func TestEntityGate_LeavesDocumentWritesAlone(t *testing.T) {
+	d, ctx := gateFixture(t)
+	out, _ := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Docs","body":""}`)
+	doc, _ := out["document_id"].(string)
+	root, _ := out["root_chunk_id"].(string)
+
+	// A document type the ontology has never heard of, with NO subject → allowed.
+	for _, typ := range []string{"rfc", "section", "publication", "image"} {
+		if _, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+doc+
+			`","parent_id":"`+root+`","natural_key":"doc:`+typ+`","title":"T","type":"`+typ+`"}`); r.IsError {
+			t.Errorf("a document write with type %q was refused — the gate is judging the wrong "+
+				"population: %s", typ, r.Text)
+		}
+	}
+	// And the consolidator's own STATEMENT node: type "fact", no subject. A deny-list on
+	// `fact` would break the pipeline this gate exists to protect.
+	if _, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+doc+
+		`","parent_id":"`+root+`","natural_key":"memory/fact/x","title":"A claim.","type":"fact"}`); r.IsError {
+		t.Errorf("the statement node was refused: %s", r.Text)
+	}
+}
+
+// TestEntityGate_FailsOpenWithNoOntology: a deployment with no ontology document must
+// write exactly as it does today. A verification feature that refuses writes when it
+// cannot verify is an outage.
+func TestEntityGate_FailsOpenWithNoOntology(t *testing.T) {
+	d, ctx, _ := documentFixture(t) // no tenant ontology at all
+	out, _ := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Facts","body":""}`)
+	doc, _ := out["document_id"].(string)
+	root, _ := out["root_chunk_id"].(string)
+	if _, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+doc+
+		`","parent_id":"`+root+`","natural_key":"k:1","title":"t","type":"whatever","subject":"thing"}`); r.IsError {
+		t.Errorf("the gate refused a write with no ontology to check against: %s", r.Text)
+	}
+}
+
+// TestSubject_IsStoredAndSurfaced — the subject is data now, not something recoverable
+// by parsing a natural key. That is what makes `location:user` findable by a query
+// instead of by reading keys.
+func TestSubject_IsStoredAndSurfaced(t *testing.T) {
+	d, ctx := gateFixture(t)
+	out, _ := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Facts","body":""}`)
+	doc, _ := out["document_id"].(string)
+	root, _ := out["root_chunk_id"].(string)
+	up, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+doc+
+		`","parent_id":"`+root+`","natural_key":"person:ada","title":"Ada","type":"person","subject":"Ada Lovelace"}`)
+	if r.IsError {
+		t.Fatalf("upsert: %s", r.Text)
+	}
+	id, _ := up["id"].(string)
+	got, _ := docExec(t, d, ctx, `{"op":"get_chunk","scope":"user","id":"`+id+`"}`)
+	entity, _ := got["entity"].(map[string]any)
+	if entity["subject"] != "Ada Lovelace" {
+		t.Errorf("subject = %v, want it stored verbatim", entity["subject"])
+	}
+	// Preserved when an edit does not restate it.
+	if _, r = docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+doc+
+		`","parent_id":"`+root+`","natural_key":"person:ada","title":"Ada L."}`); r.IsError {
+		t.Fatalf("re-upsert: %s", r.Text)
+	}
+	got, _ = docExec(t, d, ctx, `{"op":"get_chunk","scope":"user","id":"`+id+`"}`)
+	entity, _ = got["entity"].(map[string]any)
+	if entity["subject"] != "Ada Lovelace" {
+		t.Errorf("the subject was lost on an edit: %v", entity["subject"])
+	}
+	// And it is queryable as a column, which is the point of making it data.
+	key, _, _ := d.resolveScope(ctx, "user")
+	res, err := d.query(ctx, key, `SELECT subject FROM chunk_memory_meta WHERE subject IS NOT NULL`)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(res.Rows) != 1 || asStr(res.Rows[0][0]) != "Ada Lovelace" {
+		t.Errorf("subject is not queryable: %v", res.Rows)
+	}
+}

--- a/internal/tools/builtin/document_ontology.go
+++ b/internal/tools/builtin/document_ontology.go
@@ -304,6 +304,18 @@ func (d *Document) expandTypeFilter(ctx context.Context, typ string) []string {
 // Not cached: an operator who fixes their taxonomy expects the next query to reflect
 // it, and the read is two point lookups on a filter that is not on any hot path.
 func (d *Document) tenantOntologyForRun(ctx context.Context) ([]memrank.OntologyTerm, bool) {
+	terms, confirmed, _ := d.tenantOntologyState(ctx)
+	return terms, confirmed
+}
+
+// tenantOntologyState additionally reports whether the tenant HAS an ontology document.
+//
+// That third value matters to the write gate and not to retrieval. The seed is compiled
+// in, so the effective set is never empty and "no terms" cannot distinguish a tenant that
+// never opened the ontology from one whose layer is empty. A gate reading only the terms
+// would enforce a vocabulary nobody chose to curate, changing behaviour for every
+// deployment that has not opted in.
+func (d *Document) tenantOntologyState(ctx context.Context) (terms []memrank.OntologyTerm, confirmed, exists bool) {
 	key := sqlmem.ScopeKey{
 		Tenant:  sqlScopeTenant(ctx),
 		Scope:   "tenant",
@@ -314,9 +326,9 @@ func (d *Document) tenantOntologyForRun(ctx context.Context) ([]memrank.Ontology
 		// Best-effort, exactly as the prompt-side render is: a store fault must not
 		// turn a retrieval into an error. The unexpanded filter still answers the
 		// question that was asked, just narrowly.
-		return nil, false
+		return nil, false, false
 	}
-	return memrank.ResolveInheritance(read.Terms), read.Confirmed
+	return memrank.ResolveInheritance(read.Terms), read.Confirmed, read.DocumentID != ""
 }
 
 // typeFilterSQL renders an expanded type filter as a WHERE fragment plus its args.

--- a/internal/tools/builtin/document_ontology_guard.go
+++ b/internal/tools/builtin/document_ontology_guard.go
@@ -28,6 +28,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
+	"strconv"
 	"strings"
 
 	memrank "github.com/denn-gubsky/loomcycle/internal/memory"
@@ -255,4 +257,62 @@ func (d *Document) createOntologyProposal(ctx context.Context, key sqlmem.ScopeK
 		"note": "Filed as a suggestion, not in force. An operator accepts or rejects it in " +
 			"Settings → Ontology; nothing changes for any run until they do.",
 	})
+}
+
+// gateEntityType refuses an entity assertion typed as something the ontology does not
+// declare.
+//
+// GATED ON THE PAIR — type AND subject — which is the discriminator this check needs and
+// the reason `subject` is now a field. The first version keyed on "a natural_key is
+// present, therefore this is a fact", and the existing suite refused it inside one run:
+// an idempotent DOCUMENT write carries a natural key and a type too, because `type` holds
+// a document's own structural vocabulary (rfc, section, image) in the same column. That
+// gate would have refused a documentation store for using its own words.
+//
+// A document write carries no subject and never will, so the pair separates the two
+// populations by construction rather than by heuristic.
+//
+// WHY IN THE TOOL. The consolidator already refuses two statement classes as entity
+// types, and that reaches exactly one writer — an agent calling upsert_chunk, an MCP
+// session or a curator writes an entity node with no check at all. A rule one caller
+// enforces is a convention; the tool is where it becomes a rule.
+//
+// NOT A DENY-LIST, and this is load-bearing: `preference` and `fact` are seed types the
+// memory tier needs as chunk types, and the consolidator writes its STATEMENT node as
+// type "fact". Denying them here would break the pipeline this RFC exists to protect.
+// Whether a seed type is being misused as a SUBJECT's type is a distinction only the
+// writer knows, so that check stays where it already works.
+//
+// FAILS OPEN. No SQL Memory, no ontology document, an unreadable one: the write proceeds.
+// A verification feature that refuses writes when it cannot verify is an outage.
+func (d *Document) gateEntityType(ctx context.Context, in docInput) *tools.Result {
+	typ := strings.TrimSpace(in.Type)
+	if typ == "" || strings.TrimSpace(in.Subject) == "" {
+		return nil // not an entity assertion — nothing the ontology governs
+	}
+	tenantTerms, confirmed, hasOntology := d.tenantOntologyState(ctx)
+	// FAILS OPEN, keyed on the DOCUMENT rather than on the term list. The seed is
+	// compiled in, so an empty tenant layer still yields seven types — a gate reading
+	// only that would enforce a vocabulary nobody chose, and every deployment that never
+	// opened the ontology would start refusing writes it accepts today.
+	if !hasOntology {
+		return nil
+	}
+	effective := memrank.EffectiveOntology(tenantTerms, confirmed)
+	if len(effective) == 0 {
+		return nil
+	}
+	declared := make([]string, 0, len(effective))
+	for _, t := range effective {
+		if strings.EqualFold(t.Name, typ) {
+			return nil
+		}
+		declared = append(declared, t.Name)
+	}
+	sort.Strings(declared)
+	return refusal("upsert_chunk: " + strconv.Quote(typ) + " is not an entity type this tenant " +
+		"declares, so an assertion typed with it becomes a node nobody can find. Declared: " +
+		strings.Join(declared, ", ") + ". Use one of those, drop the type/subject pair to store " +
+		"the claim without an entity node, or propose the type with op=propose_entity and let an " +
+		"operator accept it.")
 }


### PR DESCRIPTION
## Why

A subject existed only inside a natural key and a title — `location:user` with title "user" — so nothing could read it as data. Two consequences, both observed on your deployment:

- **A mistyped subject was invisible.** `location:user`, asserting the user is a location, was findable only by parsing keys.
- **The tool could not tell an entity assertion from a document write**, because `type` carries a document's own structural vocabulary (`rfc`, `section`, `image`) in the same column.

## What

`subject` is now first-class: on the tool input, persisted on `chunk_memory_meta`, **preserved across an edit**, surfaced on `get_chunk`/`list_facts`, and queryable as a column.

That makes the gate possible. The ontology now refuses an entity assertion typed as something it doesn't declare — in the **tool**, so every writer is held to it. The consolidator's existing deny-list reaches exactly one writer; an agent calling `upsert_chunk`, an MCP session, or a curator had no check at all.

## Three things the tests decided, not me

**Gated on the pair.** My first version keyed on "natural_key present ⇒ fact" and the existing suite refused it in one run: `TestDocumentTags_UpsertPath` upserts a *document* with `type: "rfc"` and a natural key. On your store that gate would have blocked the documentation writes. A document carries no subject and never will, so the pair separates the populations by construction. That regression now has its own test covering `rfc`/`section`/`publication`/`image`.

**Not a deny-list.** `preference` and `fact` are seed types the memory tier needs, and the consolidator writes its **statement** node as `type: "fact"` — denying them here would break the pipeline this work protects. Whether a seed type is being misused *as a subject's type* is a distinction only the writer knows, so that check stays where it already works.

**Fails open on the document, not the term list.** The seed is compiled in, so an empty tenant layer still yields seven types — a gate reading only the terms would enforce a vocabulary nobody chose, and every deployment that never opened the ontology would start refusing writes it accepts today. My code comment claimed that behaviour before the code did it; `TestEntityGate_FailsOpenWithNoOntology` caught the gap.

## Tested

`go test ./...` clean.

- `TestEntityGate_RefusesATypeTheOntologyDoesNotDeclare` — **fail-before verified**; also asserts a seed type and the tenant's own confirmed subtype (`research`) both pass, since a gate that only knew the seed would refuse the vocabulary you curated.
- `TestEntityGate_LeavesDocumentWritesAlone` — the killed-v1 regression, plus the consolidator's statement node.
- `TestEntityGate_FailsOpenWithNoOntology`, `TestSubject_IsStoredAndSurfaced` (round-trip, preserved-on-edit, queryable).

## Effect on your deployment

Your tenant **has** a confirmed ontology, so the gate is live there. It declares `project → research`, `preference`, `fact` and the seed — so an agent writing `type: "process"` with a subject now gets a refusal naming the declared types and pointing at `propose_entity`. Your 3,148 document chunks are untouched: they carry no subject.

Next in RFC CC is the remaining §3 checks (subject-in-span, numbers-in-span) and then the judge. Worth noting the subject column makes a *new* check cheap that the RFC didn't anticipate: `subject` is now queryable, so "which facts assert that the user is a location" is a query rather than an audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8