### PR TITLE
feat(loomboard): @loomcycle/loomboard P1 — saved views over Documents (RFC BT)

### DIFF
--- a/packages/loomboard/.gitignore
+++ b/packages/loomboard/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/packages/loomboard/package-lock.json
+++ b/packages/loomboard/package-lock.json
@@ -1,0 +1,2369 @@
+{
+  "name": "@loomcycle/loomboard",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@loomcycle/loomboard",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@loomcycle/client": "^1.51.0",
+        "@types/node": "^22.0.0",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "@vitejs/plugin-react": "^5.0.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "typescript": "^5.6.0",
+        "vite": "^7.0.0",
+        "vitest": "^3.0.0"
+      },
+      "peerDependencies": {
+        "@loomcycle/client": "^1.51.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@loomcycle/client": {
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/@loomcycle/client/-/client-1.51.0.tgz",
+      "integrity": "sha512-31pO3zxVtDKD4+TmcUYyW8gNYnNwdpaJyyVkbTQ4gb8HYwfIpTRST0i5xZEFAknCtSE7lIfUZvecAcF94TkciQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.14",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.14.tgz",
+      "integrity": "sha512-JyJ954WzuIR8/FFzX0o5krdSTrBAkcCSRfWSleRsIHSWV+cZe2FI1PKggVkFke1hBldRs+LRxUczzE9iPmgZww==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.406",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.406.tgz",
+      "integrity": "sha512-hWH5ORBi3d0IipnMh7BN5GDTaAmrSSSWmznwt2zltdiRNEWoEQyTwF0FFSBxzHO7hLSRT6loQu3IQGV0wg/Tvg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+      "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/packages/loomboard/package.json
+++ b/packages/loomboard/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@loomcycle/loomboard",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Embeddable React view layer for loomcycle Documents (RFC BT) — saved table / cards / kanban / list views over the Document store.",
+  "license": "Apache-2.0",
+  "author": "Dennis Gubsky",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/denn-gubsky/loomcycle.git",
+    "directory": "packages/loomboard"
+  },
+  "keywords": [
+    "loomcycle",
+    "loomboard",
+    "documents",
+    "kanban",
+    "views",
+    "react",
+    "agent",
+    "ai",
+    "component"
+  ],
+  "sideEffects": [
+    "**/*.css"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./styles.css": "./dist/styles.css"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "npm run build:lib",
+    "build:lib": "vite build --config vite.config.lib.ts && tsc -p tsconfig.lib.json && cp src/styles.css dist/styles.css",
+    "prepack": "npm run build:lib",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests",
+    "test:watch": "vitest"
+  },
+  "peerDependencies": {
+    "@loomcycle/client": "^1.51.0",
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
+  },
+  "devDependencies": {
+    "@loomcycle/client": "^1.51.0",
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^5.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "typescript": "^5.6.0",
+    "vite": "^7.0.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/loomboard/src/Loomboard.tsx
+++ b/packages/loomboard/src/Loomboard.tsx
@@ -1,0 +1,33 @@
+import {
+  LoomboardRoot,
+  useResolvedDataLayer,
+  type LoomboardDataSource,
+} from "./components/LoomboardRoot";
+import LoomboardBody from "./components/LoomboardBody";
+import type { BoardScope } from "./types";
+
+// Loomboard is the standalone, self-styling root for the view layer (RFC BT P1):
+// saved table / cards / kanban / list views over loomcycle Documents. Mount it on
+// its own page; it resolves its own data layer and wraps in the themeable
+// `.loomcycle-loomboard` root. Styles ship separately:
+// `import "@loomcycle/loomboard/styles.css"`.
+export interface LoomboardProps extends LoomboardDataSource {
+  /** Theming. Set → the root carries data-theme; omit → inherit an ancestor's
+   *  data-theme (dark is the default palette). */
+  theme?: "light" | "dark";
+  /** Initial store scope. Default "user" (personal views); "tenant" is shared. */
+  defaultScope?: BoardScope;
+  /** Called on a load / save failure, in addition to the inline banner. NEVER
+   *  redirects on 401 — the host owns the auth flow. */
+  onError?: (e: unknown) => void;
+}
+
+export default function Loomboard(props: LoomboardProps) {
+  const { theme, defaultScope, onError } = props;
+  const resolved = useResolvedDataLayer(props);
+  return (
+    <LoomboardRoot theme={theme} dataLayer={resolved}>
+      <LoomboardBody defaultScope={defaultScope} onError={onError} />
+    </LoomboardRoot>
+  );
+}

--- a/packages/loomboard/src/components/BoardView.tsx
+++ b/packages/loomboard/src/components/BoardView.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useRef, useState } from "react";
+import type { BoardRow, BoardScope, SavedView } from "../types";
+import { useLoomboardData } from "../lib/dataLayer";
+import { docRowToBoardRow, chunkRowToBoardRow } from "../lib/view";
+import { BoardLayout } from "./layouts";
+
+// BoardView materializes a saved view's query (documents or chunks) and renders
+// the chosen layout. Load state / errors are surfaced inline; a runtime refusal
+// (e.g. SQL Memory not enabled) arrives as a 422 message, shown as a soft hint
+// rather than a crash. It also forwards failures to the host's onError.
+export default function BoardView({
+  view,
+  scope,
+  onError,
+}: {
+  view: SavedView;
+  scope: BoardScope;
+  onError?: (e: unknown) => void;
+}) {
+  const data = useLoomboardData();
+  const [rows, setRows] = useState<BoardRow[] | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  // Hold onError in a ref so an inline parent callback doesn't re-run the load.
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
+
+  const sig = JSON.stringify(view.query);
+  useEffect(() => {
+    let cancelled = false;
+    setRows(null);
+    setErr(null);
+    (async () => {
+      try {
+        let out: BoardRow[];
+        if (view.query.source === "chunks") {
+          const r = await data.queryChunks(scope, view.query);
+          out = (r.chunks ?? []).map(chunkRowToBoardRow);
+        } else {
+          const r = await data.queryDocuments(scope, view.query);
+          out = (r.documents ?? []).map(docRowToBoardRow);
+        }
+        if (!cancelled) setRows(out);
+      } catch (e) {
+        if (cancelled) return;
+        setErr(e instanceof Error ? e.message : String(e));
+        onErrorRef.current?.(e);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data, scope, view.rootChunkId, sig]);
+
+  return (
+    <div className="board-view">
+      <div className="board-view-head">
+        <span className="board-view-title">{view.title}</span>
+        <span className="board-view-kind">{view.layout.kind}</span>
+      </div>
+      {err ? (
+        <div className="board-error">{err}</div>
+      ) : rows === null ? (
+        <div className="board-loading">Loading…</div>
+      ) : (
+        <BoardLayout rows={rows} layout={view.layout} />
+      )}
+    </div>
+  );
+}

--- a/packages/loomboard/src/components/LoomboardBody.tsx
+++ b/packages/loomboard/src/components/LoomboardBody.tsx
@@ -1,0 +1,128 @@
+import { useCallback, useState } from "react";
+import type { BoardScope, DocRow, SavedView } from "../types";
+import { useLoomboardData } from "../lib/dataLayer";
+import { parseView } from "../lib/view";
+import Splitter from "./Splitter";
+import SavedViewList from "./SavedViewList";
+import BoardView from "./BoardView";
+import ViewEditor from "./ViewEditor";
+
+type Mode = "empty" | "view" | "editor";
+
+// LoomboardBody is the shell inside <LoomboardRoot>: a scope toggle + a splitter
+// with the saved-view rail on the left and the active board / editor on the
+// right. It owns the selection + edit state; every child reads the injected data
+// layer via useLoomboardData().
+export default function LoomboardBody({
+  defaultScope = "user",
+  onError,
+}: {
+  defaultScope?: BoardScope;
+  onError?: (e: unknown) => void;
+}) {
+  const data = useLoomboardData();
+  const [scope, setScope] = useState<BoardScope>(defaultScope);
+  const [mode, setMode] = useState<Mode>("empty");
+  const [active, setActive] = useState<SavedView | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+  const [err, setErr] = useState<string | null>(null);
+
+  const openView = useCallback(
+    async (row: DocRow) => {
+      setErr(null);
+      try {
+        const root = await data.getChunk(scope, row.root_chunk_id);
+        setActive(parseView(row.document_id, root));
+        setMode("view");
+      } catch (e) {
+        setErr(e instanceof Error ? e.message : String(e));
+        onError?.(e);
+      }
+    },
+    [data, scope, onError],
+  );
+
+  const onDelete = useCallback(async () => {
+    if (!active) return;
+    setErr(null);
+    try {
+      await data.deleteView(scope, active.documentId);
+      setActive(null);
+      setMode("empty");
+      setReloadKey((k) => k + 1);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+      onError?.(e);
+    }
+  }, [data, scope, active, onError]);
+
+  return (
+    <div className="loomboard-body">
+      <div className="loomboard-toolbar">
+        <div className="scope-toggle" role="tablist" aria-label="Scope">
+          {(["user", "tenant"] as const).map((s) => (
+            <button
+              key={s}
+              type="button"
+              role="tab"
+              aria-selected={scope === s}
+              className={scope === s ? "on" : ""}
+              onClick={() => {
+                setScope(s);
+                setActive(null);
+                setMode("empty");
+              }}
+            >
+              {s}
+            </button>
+          ))}
+        </div>
+        {mode === "view" && active && (
+          <div className="loomboard-actions">
+            <button type="button" className="btn-ghost" onClick={() => setMode("editor")}>
+              Edit
+            </button>
+            <button type="button" className="btn-ghost danger" onClick={onDelete}>
+              Delete
+            </button>
+          </div>
+        )}
+      </div>
+
+      {err && <div className="loomboard-error">{err}</div>}
+
+      <Splitter storageKey="loomboard.split" defaultLeftWidth={260} className="loomboard-split">
+        <SavedViewList
+          scope={scope}
+          selectedId={active?.documentId ?? null}
+          onSelect={openView}
+          onNew={() => {
+            setMode("editor");
+          }}
+          reloadKey={reloadKey}
+          onError={onError}
+        />
+        <div className="loomboard-main">
+          {mode === "editor" ? (
+            <ViewEditor
+              scope={scope}
+              existing={active ?? undefined}
+              onSaved={() => {
+                setMode(active ? "view" : "empty");
+                setReloadKey((k) => k + 1);
+              }}
+              onCancel={() => setMode(active ? "view" : "empty")}
+              onError={onError}
+            />
+          ) : active ? (
+            <BoardView view={active} scope={scope} onError={onError} />
+          ) : (
+            <div className="loomboard-placeholder">
+              Select a view, or create one with <strong>+ New</strong>.
+            </div>
+          )}
+        </div>
+      </Splitter>
+    </div>
+  );
+}

--- a/packages/loomboard/src/components/LoomboardRoot.tsx
+++ b/packages/loomboard/src/components/LoomboardRoot.tsx
@@ -1,0 +1,64 @@
+import { useMemo, type ReactNode } from "react";
+import type { LoomcycleClient } from "@loomcycle/client";
+import { createLoomcycleClient, type Connection } from "../lib/createClient";
+import {
+  LoomboardDataProvider,
+  dataLayerFromClient,
+  type LoomboardDataLayer,
+} from "../lib/dataLayer";
+
+// LoomboardDataSource is the data-source contract for the public <Loomboard>
+// root. Provide exactly one; precedence is dataLayer > client > connection. The
+// default path is `connection` → an internal LoomcycleClient.
+export interface LoomboardDataSource {
+  /** A raw connection (baseUrl + optional token + optional fetch override). */
+  connection?: Connection;
+  /** A prebuilt @loomcycle/client instance. */
+  client?: LoomcycleClient;
+  /** A fully custom data layer (e.g. a cookie-authed same-origin fetcher). */
+  dataLayer?: LoomboardDataLayer;
+}
+
+// useResolvedDataLayer picks the data layer from the source props once per
+// connection identity — keyed on the connection's PRIMITIVE fields so an inline
+// `connection={{...}}` doesn't rebuild the client every render.
+export function useResolvedDataLayer(src: LoomboardDataSource): LoomboardDataLayer | null {
+  const { dataLayer, client, connection } = src;
+  return useMemo<LoomboardDataLayer | null>(() => {
+    if (dataLayer) return dataLayer;
+    if (client) return dataLayerFromClient(client);
+    if (connection) return dataLayerFromClient(createLoomcycleClient(connection));
+    return null;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dataLayer, client, connection?.baseUrl, connection?.token, connection?.fetch]);
+}
+
+// LoomboardRoot renders the themeable `.loomcycle-loomboard` wrapper + provides
+// the data layer. With no data source it shows an inline banner (so a misconfig
+// is visible, not silent). It NEVER redirects on 401 — the host owns auth.
+export function LoomboardRoot({
+  theme,
+  dataLayer,
+  children,
+}: {
+  theme?: "light" | "dark";
+  dataLayer: LoomboardDataLayer | null;
+  children: ReactNode;
+}) {
+  const themeAttr = theme ? { "data-theme": theme } : {};
+  if (!dataLayer) {
+    return (
+      <div className="loomcycle-loomboard" {...themeAttr}>
+        <div className="error-banner">
+          @loomcycle/loomboard: provide a <code>connection</code>, <code>client</code>, or{" "}
+          <code>dataLayer</code> prop.
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="loomcycle-loomboard" {...themeAttr}>
+      <LoomboardDataProvider value={dataLayer}>{children}</LoomboardDataProvider>
+    </div>
+  );
+}

--- a/packages/loomboard/src/components/SavedViewList.tsx
+++ b/packages/loomboard/src/components/SavedViewList.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useRef, useState } from "react";
+import type { BoardScope, DocRow } from "../types";
+import { useLoomboardData } from "../lib/dataLayer";
+
+// SavedViewList is the left rail: every `type=view` Document in the scope, plus
+// a "New view" affordance. `reloadKey` bumps to re-list after a save / delete.
+export default function SavedViewList({
+  scope,
+  selectedId,
+  onSelect,
+  onNew,
+  reloadKey,
+  onError,
+}: {
+  scope: BoardScope;
+  selectedId: string | null;
+  onSelect: (row: DocRow) => void;
+  onNew: () => void;
+  reloadKey: number;
+  onError?: (e: unknown) => void;
+}) {
+  const data = useLoomboardData();
+  const [views, setViews] = useState<DocRow[] | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
+
+  useEffect(() => {
+    let cancelled = false;
+    setViews(null);
+    setErr(null);
+    (async () => {
+      try {
+        const r = await data.listViews(scope);
+        if (!cancelled) setViews(r.documents ?? []);
+      } catch (e) {
+        if (cancelled) return;
+        setErr(e instanceof Error ? e.message : String(e));
+        onErrorRef.current?.(e);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [data, scope, reloadKey]);
+
+  return (
+    <div className="view-list">
+      <div className="view-list-head">
+        <span className="view-list-title">Views</span>
+        <button type="button" className="view-new" onClick={onNew} title="New view">
+          + New
+        </button>
+      </div>
+      {err ? (
+        <div className="view-list-error">{err}</div>
+      ) : views === null ? (
+        <div className="view-list-loading">Loading…</div>
+      ) : views.length === 0 ? (
+        <div className="view-list-empty">No saved views yet.</div>
+      ) : (
+        <ul className="view-list-items">
+          {views.map((v) => (
+            <li key={v.document_id}>
+              <button
+                type="button"
+                className={v.document_id === selectedId ? "view-item on" : "view-item"}
+                onClick={() => onSelect(v)}
+              >
+                {v.title || "(untitled view)"}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/packages/loomboard/src/components/Splitter.tsx
+++ b/packages/loomboard/src/components/Splitter.tsx
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+
+// Splitter wraps two children with a draggable vertical handle
+// between them. The left pane's width is owned in state and (when
+// `storageKey` is set) persisted to localStorage so the operator's
+// layout choice survives reloads.
+//
+// Implementation notes:
+//   - CSS Grid with three columns: [left] [handle] [right]. Grid
+//     keeps the right pane on a fluid `1fr` regardless of the
+//     window width, while the left pane snaps to the dragged size.
+//   - Drag uses window-level pointermove + pointerup so the user
+//     can drag PAST the handle bounds without losing tracking
+//     (common UX pitfall when the listener lives on the handle
+//     element). The container ref provides the origin for the
+//     fractional clientX calculation.
+//   - min/max clamps so the user can't drag a pane into oblivion
+//     or off-screen.
+//
+// Self-contained copy (the loomcycle Web UI + @loomcycle/library +
+// @loomcycle/explorer + @loomcycle/memory-view carry the same component); this
+// package deliberately owns its own copy rather than sharing, so it has no
+// cross-package coupling.
+
+export interface SplitterProps {
+  children: [ReactNode, ReactNode];
+  // Initial left-pane width in px. Used until the user drags or a
+  // persisted value is restored from localStorage.
+  defaultLeftWidth?: number;
+  // Lower bound for the left pane in px. Pane content has its own
+  // overflow:auto so it survives squeezing, but a too-narrow pane
+  // is unusable.
+  minLeftWidth?: number;
+  // Upper bound for the left pane in px. Prevents the operator from
+  // dragging the right pane to zero by accident.
+  minRightWidth?: number;
+  // localStorage key for persistence. Omit to make the split
+  // ephemeral (resets on every page mount).
+  storageKey?: string;
+  // Extra class on the outer wrapper (the parent .loomcycle-loomboard
+  // rules expect a specific class; this lets the caller keep those
+  // selectors intact).
+  className?: string;
+}
+
+const HANDLE_WIDTH = 6;
+
+export default function Splitter({
+  children,
+  defaultLeftWidth = 380,
+  minLeftWidth = 180,
+  minRightWidth = 240,
+  storageKey,
+  className,
+}: SplitterProps) {
+  const [leftWidth, setLeftWidth] = useState<number>(() => {
+    if (storageKey) {
+      const stored = localStorage.getItem(storageKey);
+      const n = stored ? parseInt(stored, 10) : NaN;
+      if (Number.isFinite(n) && n >= minLeftWidth) return n;
+    }
+    return defaultLeftWidth;
+  });
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [dragging, setDragging] = useState(false);
+
+  // Persist on every settled width. Debouncing isn't needed — drag
+  // already produces a single final settle via pointerup.
+  useEffect(() => {
+    if (!storageKey || dragging) return;
+    localStorage.setItem(storageKey, String(Math.round(leftWidth)));
+  }, [storageKey, leftWidth, dragging]);
+
+  const onPointerDown = useCallback((e: React.PointerEvent) => {
+    e.preventDefault();
+    setDragging(true);
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+  }, []);
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!dragging || !containerRef.current) return;
+      const rect = containerRef.current.getBoundingClientRect();
+      const raw = e.clientX - rect.left;
+      const maxAllowed = rect.width - minRightWidth - HANDLE_WIDTH;
+      const clamped = Math.max(minLeftWidth, Math.min(raw, maxAllowed));
+      setLeftWidth(clamped);
+    },
+    [dragging, minLeftWidth, minRightWidth],
+  );
+
+  const onPointerUp = useCallback((e: React.PointerEvent) => {
+    setDragging(false);
+    try {
+      (e.target as HTMLElement).releasePointerCapture(e.pointerId);
+    } catch {
+      // Pointer was already released (e.g. capture lost from a
+      // browser-internal gesture). Safe to ignore.
+    }
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      className={`splitter ${className ?? ""} ${dragging ? "dragging" : ""}`}
+      style={{
+        gridTemplateColumns: `${leftWidth}px ${HANDLE_WIDTH}px 1fr`,
+      }}
+    >
+      <div className="splitter-pane splitter-left">{children[0]}</div>
+      <div
+        className="splitter-handle"
+        role="separator"
+        aria-orientation="vertical"
+        aria-valuenow={Math.round(leftWidth)}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerUp}
+      />
+      <div className="splitter-pane splitter-right">{children[1]}</div>
+    </div>
+  );
+}

--- a/packages/loomboard/src/components/ViewEditor.tsx
+++ b/packages/loomboard/src/components/ViewEditor.tsx
@@ -1,0 +1,178 @@
+import { useRef, useState, type FormEvent } from "react";
+import type {
+  BoardScope,
+  GroupAxis,
+  LayoutKind,
+  SavedView,
+  SortField,
+  ViewLayout,
+  ViewQuery,
+} from "../types";
+import { useLoomboardData } from "../lib/dataLayer";
+
+// ViewEditor creates or edits a saved view — the query builder (the RFC BS axes:
+// source / type / status / tag / under_path) + the layout picker. On save it
+// persists a `type=view` Document (create) or patches its fields (edit).
+export default function ViewEditor({
+  scope,
+  existing,
+  onSaved,
+  onCancel,
+  onError,
+}: {
+  scope: BoardScope;
+  existing?: SavedView;
+  onSaved: () => void;
+  onCancel: () => void;
+  onError?: (e: unknown) => void;
+}) {
+  const data = useLoomboardData();
+  const q0 = existing?.query;
+  const l0 = existing?.layout;
+
+  const [title, setTitle] = useState(existing?.title ?? "");
+  const [source, setSource] = useState<"documents" | "chunks">(q0?.source ?? "documents");
+  const [type, setType] = useState(q0?.type ?? "");
+  const [status, setStatus] = useState(q0?.status ?? "");
+  const [tag, setTag] = useState(q0?.tag ?? "");
+  const [underPath, setUnderPath] = useState(q0?.underPath ?? "");
+  const [documentId, setDocumentId] = useState(q0?.documentId ?? "");
+  const [kind, setKind] = useState<LayoutKind>(l0?.kind ?? "table");
+  const [groupBy, setGroupBy] = useState<GroupAxis>(l0?.groupBy ?? "status");
+  const [sortBy, setSortBy] = useState<SortField>(l0?.sortBy ?? "updated");
+
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
+
+  function buildQuery(): ViewQuery {
+    const query: ViewQuery = { source };
+    if (source === "chunks" && documentId.trim()) query.documentId = documentId.trim();
+    if (underPath.trim()) query.underPath = underPath.trim();
+    if (type.trim()) query.type = type.trim();
+    if (status.trim()) query.status = status.trim();
+    if (tag.trim()) query.tag = tag.trim();
+    return query;
+  }
+
+  function buildLayout(): ViewLayout {
+    return { kind, groupBy, sortBy, sortDir: "desc" };
+  }
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (busy) return;
+    if (!title.trim()) {
+      setErr("A view needs a title.");
+      return;
+    }
+    setBusy(true);
+    setErr(null);
+    try {
+      if (existing) {
+        await data.updateView(scope, existing.rootChunkId, existing.revision ?? 1, {
+          query: buildQuery(),
+          layout: buildLayout(),
+        });
+      } else {
+        await data.saveView(scope, { title: title.trim(), query: buildQuery(), layout: buildLayout() });
+      }
+      onSaved();
+    } catch (e2) {
+      setErr(e2 instanceof Error ? e2.message : String(e2));
+      onErrorRef.current?.(e2);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form className="view-editor" onSubmit={onSubmit}>
+      <div className="view-editor-head">{existing ? "Edit view" : "New view"}</div>
+
+      <label className="field">
+        <span>Title</span>
+        <input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="e.g. RFCs by status" />
+      </label>
+
+      <div className="field-row">
+        <label className="field">
+          <span>Source</span>
+          <select value={source} onChange={(e) => setSource(e.target.value as "documents" | "chunks")}>
+            <option value="documents">Documents</option>
+            <option value="chunks">Chunks</option>
+          </select>
+        </label>
+        <label className="field">
+          <span>Layout</span>
+          <select value={kind} onChange={(e) => setKind(e.target.value as LayoutKind)}>
+            <option value="table">Table</option>
+            <option value="cards">Cards</option>
+            <option value="kanban">Kanban</option>
+            <option value="list">List</option>
+          </select>
+        </label>
+      </div>
+
+      <div className="field-row">
+        <label className="field">
+          <span>Type</span>
+          <input value={type} onChange={(e) => setType(e.target.value)} placeholder="e.g. rfc" />
+        </label>
+        <label className="field">
+          <span>Status</span>
+          <input value={status} onChange={(e) => setStatus(e.target.value)} placeholder="e.g. draft" />
+        </label>
+      </div>
+
+      <div className="field-row">
+        <label className="field">
+          <span>Tag</span>
+          <input value={tag} onChange={(e) => setTag(e.target.value)} placeholder="e.g. area/ui" />
+        </label>
+        <label className="field">
+          <span>Under path</span>
+          <input value={underPath} onChange={(e) => setUnderPath(e.target.value)} placeholder="/loomcycle/rfcs" />
+        </label>
+      </div>
+
+      {source === "chunks" && (
+        <label className="field">
+          <span>Document id (chunks source)</span>
+          <input value={documentId} onChange={(e) => setDocumentId(e.target.value)} placeholder="document_id" />
+        </label>
+      )}
+
+      {kind === "kanban" && (
+        <label className="field">
+          <span>Group by</span>
+          <select value={groupBy} onChange={(e) => setGroupBy(e.target.value as GroupAxis)}>
+            <option value="status">Status</option>
+            <option value="type">Type</option>
+          </select>
+        </label>
+      )}
+
+      <label className="field">
+        <span>Sort by</span>
+        <select value={sortBy} onChange={(e) => setSortBy(e.target.value as SortField)}>
+          <option value="updated">Updated</option>
+          <option value="title">Title</option>
+          <option value="position">Position</option>
+        </select>
+      </label>
+
+      {err && <div className="view-editor-error">{err}</div>}
+
+      <div className="view-editor-actions">
+        <button type="button" className="btn-ghost" onClick={onCancel} disabled={busy}>
+          Cancel
+        </button>
+        <button type="submit" className="btn-primary" disabled={busy}>
+          {busy ? "Saving…" : existing ? "Save" : "Create"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/packages/loomboard/src/components/layouts.tsx
+++ b/packages/loomboard/src/components/layouts.tsx
@@ -1,0 +1,116 @@
+import type { BoardRow, ViewLayout } from "../types";
+import { groupRows, sortRows, formatWhen } from "../lib/view";
+
+// The layout renderers. Each takes already-materialized BoardRows (title + the
+// SQL-queryable axes: type / status / updated / position) — no `fields`, so a
+// Documents board renders with no per-row fetch.
+
+export function BoardLayout({ rows, layout }: { rows: BoardRow[]; layout: ViewLayout }) {
+  const sorted = sortRows(rows, layout.sortBy, layout.sortDir);
+  if (sorted.length === 0) {
+    return <div className="board-empty">No rows match this view.</div>;
+  }
+  switch (layout.kind) {
+    case "kanban":
+      return <KanbanLayout rows={sorted} layout={layout} />;
+    case "cards":
+      return <CardsLayout rows={sorted} />;
+    case "list":
+      return <ListLayout rows={sorted} />;
+    case "table":
+    default:
+      return <TableLayout rows={sorted} layout={layout} />;
+  }
+}
+
+function Badge({ kind, value }: { kind: "type" | "status"; value?: string }) {
+  if (!value) return null;
+  return <span className={`badge badge-${kind}`}>{value}</span>;
+}
+
+function TableLayout({ rows, layout }: { rows: BoardRow[]; layout: ViewLayout }) {
+  const cols = layout.columns ?? ["type", "status", "updated"];
+  return (
+    <div className="board-scroll">
+      <table className="board-table">
+        <thead>
+          <tr>
+            <th>Title</th>
+            {cols.includes("type") && <th>Type</th>}
+            {cols.includes("status") && <th>Status</th>}
+            {cols.includes("updated") && <th>Updated</th>}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.id}>
+              <td className="cell-title">{r.title}</td>
+              {cols.includes("type") && <td>{r.type ?? ""}</td>}
+              {cols.includes("status") && <td>{r.status ?? ""}</td>}
+              {cols.includes("updated") && <td className="cell-dim">{formatWhen(r.updatedAt)}</td>}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function RowCard({ row }: { row: BoardRow }) {
+  return (
+    <div className="board-card">
+      <div className="board-card-title">{row.title}</div>
+      <div className="board-card-meta">
+        <Badge kind="type" value={row.type} />
+        <Badge kind="status" value={row.status} />
+        {row.updatedAt ? <span className="cell-dim">{formatWhen(row.updatedAt)}</span> : null}
+      </div>
+    </div>
+  );
+}
+
+function CardsLayout({ rows }: { rows: BoardRow[] }) {
+  return (
+    <div className="board-cards">
+      {rows.map((r) => (
+        <RowCard key={r.id} row={r} />
+      ))}
+    </div>
+  );
+}
+
+function ListLayout({ rows }: { rows: BoardRow[] }) {
+  return (
+    <ul className="board-list">
+      {rows.map((r) => (
+        <li key={r.id} className="board-list-row">
+          <span className="board-list-title">{r.title}</span>
+          <Badge kind="status" value={r.status} />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function KanbanLayout({ rows, layout }: { rows: BoardRow[]; layout: ViewLayout }) {
+  const groups = groupRows(rows, layout.groupBy ?? "status");
+  return (
+    <div className="board-scroll">
+      <div className="board-kanban">
+        {groups.map((g) => (
+          <div key={g.key} className="kanban-col">
+            <div className="kanban-col-head">
+              <span className="kanban-col-name">{g.key}</span>
+              <span className="kanban-col-count">{g.rows.length}</span>
+            </div>
+            <div className="kanban-col-body">
+              {g.rows.map((r) => (
+                <RowCard key={r.id} row={r} />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/loomboard/src/index.ts
+++ b/packages/loomboard/src/index.ts
@@ -1,0 +1,51 @@
+// Public API of @loomcycle/loomboard — the embeddable view layer over loomcycle
+// Documents (RFC BT P1: saved table / cards / kanban / list views). Keep this
+// surface small and intentional; it's the contract consumers depend on.
+//
+// Styles ship separately: `import "@loomcycle/loomboard/styles.css"`.
+
+export { default as Loomboard } from "./Loomboard";
+export type { LoomboardProps } from "./Loomboard";
+
+// Public data types (the shapes the board renders / the data layer produces).
+export type {
+  BoardScope,
+  ViewQuery,
+  ViewLayout,
+  LayoutKind,
+  GroupAxis,
+  SortField,
+  SavedView,
+  BoardRow,
+  DocRow,
+  ChunkRow,
+  ChunkDetail,
+  TypeRow,
+  ListTypesResponse,
+  QueryDocumentsResponse,
+  QueryChunksResponse,
+  CreateDocumentResponse,
+} from "./types";
+
+// Connection → client factory (the default data-source path).
+export { createLoomcycleClient } from "./lib/createClient";
+export type { Connection } from "./lib/createClient";
+
+// The data-layer seam: inject a custom implementation, or build one from a
+// @loomcycle/client instance.
+export { dataLayerFromClient } from "./lib/dataLayer";
+export type { LoomboardDataLayer } from "./lib/dataLayer";
+
+// The shared data-source contract (connection | client | dataLayer), for hosts
+// typing their own wrappers.
+export type { LoomboardDataSource } from "./components/LoomboardRoot";
+
+// Pure view helpers — parse a saved view's fields, normalize / group / sort rows.
+// Exported for hosts composing their own surfaces over the same primitives.
+export {
+  parseView,
+  normalizeQuery,
+  normalizeLayout,
+  groupRows,
+  sortRows,
+} from "./lib/view";

--- a/packages/loomboard/src/lib/createClient.ts
+++ b/packages/loomboard/src/lib/createClient.ts
@@ -1,0 +1,28 @@
+import { LoomcycleClient } from "@loomcycle/client";
+
+// Connection the host hands to <MemoryView>. `fetch` is an optional override so
+// an embedding app can route requests however it needs (proxying, header
+// injection, instrumentation). External consumers just pass baseUrl + token and
+// hit the runtime directly.
+export interface Connection {
+  /** loomcycle base URL. "" means same-origin. */
+  baseUrl: string;
+  /** Bearer token. Omit when the runtime runs in open mode (or when the host
+   *  authenticates via a same-origin cookie through a custom `fetch`). */
+  token?: string;
+  /** Optional fetch override (proxying, header injection, instrumentation). */
+  fetch?: typeof fetch;
+}
+
+/** Build a loomcycle client from a Connection. The fetch is always wrapped: the
+ *  SDK calls its stored fetch as a method (`ctx.fetchImpl(url)`), and the
+ *  browser's native fetch rejects a non-global receiver with "Illegal
+ *  invocation" — so we hand it a plain function that calls global fetch. */
+export function createLoomcycleClient(c: Connection): LoomcycleClient {
+  const impl = c.fetch;
+  return new LoomcycleClient({
+    baseUrl: c.baseUrl,
+    authToken: c.token || undefined,
+    fetch: (input, init) => (impl ? impl(input, init) : fetch(input, init)),
+  });
+}

--- a/packages/loomboard/src/lib/dataLayer.test.ts
+++ b/packages/loomboard/src/lib/dataLayer.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi } from "vitest";
+import type { LoomcycleClient } from "@loomcycle/client";
+import { dataLayerFromClient } from "./dataLayer";
+import type { ViewLayout, ViewQuery } from "../types";
+
+// A recording stub for the single `document` meta-tool the data layer routes
+// through. It returns a superset shape so both the create_document leg (needs
+// root_chunk_id) and the query legs narrow cleanly; we assert only routing +
+// the exact wire body per call.
+function stubClient() {
+  const document = vi.fn().mockResolvedValue({
+    document_id: "doc-1",
+    root_chunk_id: "root-1",
+    title: "t",
+    documents: [],
+    chunks: [],
+    types: [],
+    id: "root-1",
+    revision: 1,
+  });
+  const client = { document } as unknown as LoomcycleClient;
+  return { client, document };
+}
+
+const LAYOUT: ViewLayout = { kind: "kanban", groupBy: "status" };
+
+describe("dataLayerFromClient — @loomcycle/client → Document wire mapping", () => {
+  it("queryDocuments sends only the set axes (camelCase → snake_case)", async () => {
+    const s = stubClient();
+    const q: ViewQuery = { source: "documents", type: "rfc", status: "draft", tag: "area/ui", underPath: "/loomcycle/rfcs", limit: 50 };
+    await dataLayerFromClient(s.client).queryDocuments("user", q);
+    expect(s.document).toHaveBeenCalledWith({
+      op: "query_documents",
+      scope: "user",
+      type: "rfc",
+      status: "draft",
+      tag: "area/ui",
+      under_path: "/loomcycle/rfcs",
+      limit: 50,
+    });
+  });
+
+  it("queryDocuments omits unset axes", async () => {
+    const s = stubClient();
+    await dataLayerFromClient(s.client).queryDocuments("tenant", { source: "documents", type: "task" });
+    expect(s.document).toHaveBeenCalledWith({ op: "query_documents", scope: "tenant", type: "task" });
+  });
+
+  it("queryChunks carries document_id + tag_prefix", async () => {
+    const s = stubClient();
+    const q: ViewQuery = { source: "chunks", documentId: "d9", type: "step", tagPrefix: "area", limit: 100 };
+    await dataLayerFromClient(s.client).queryChunks("user", q);
+    expect(s.document).toHaveBeenCalledWith({
+      op: "query_chunks",
+      scope: "user",
+      document_id: "d9",
+      type: "step",
+      tag_prefix: "area",
+      limit: 100,
+    });
+  });
+
+  it("getChunk addresses by id", async () => {
+    const s = stubClient();
+    await dataLayerFromClient(s.client).getChunk("user", "c1");
+    expect(s.document).toHaveBeenCalledWith({ op: "get_chunk", scope: "user", id: "c1" });
+  });
+
+  it("listTypes passes the scope", async () => {
+    const s = stubClient();
+    await dataLayerFromClient(s.client).listTypes("tenant");
+    expect(s.document).toHaveBeenCalledWith({ op: "list_types", scope: "tenant" });
+  });
+
+  it("listViews filters query_documents to type:view", async () => {
+    const s = stubClient();
+    await dataLayerFromClient(s.client).listViews("user");
+    expect(s.document).toHaveBeenCalledWith({ op: "query_documents", scope: "user", type: "view" });
+  });
+
+  it("saveView creates a type=view Document then seeds root fields at revision 1", async () => {
+    const s = stubClient();
+    const query: ViewQuery = { source: "documents", type: "rfc" };
+    const out = await dataLayerFromClient(s.client).saveView("user", {
+      title: "RFCs by status",
+      path: "/loomcycle/views/rfcs",
+      query,
+      layout: LAYOUT,
+    });
+    expect(s.document).toHaveBeenNthCalledWith(1, {
+      op: "create_document",
+      scope: "user",
+      title: "RFCs by status",
+      type: "view",
+      path: "/loomcycle/views/rfcs",
+    });
+    expect(s.document).toHaveBeenNthCalledWith(2, {
+      op: "update_chunk",
+      scope: "user",
+      id: "root-1",
+      revision: 1,
+      fields: { query, layout: LAYOUT },
+    });
+    expect(out).toEqual({ documentId: "doc-1", rootChunkId: "root-1" });
+  });
+
+  it("updateView patches only the given fields on the root chunk", async () => {
+    const s = stubClient();
+    const query: ViewQuery = { source: "documents", status: "done" };
+    await dataLayerFromClient(s.client).updateView("user", "root-1", 4, { query });
+    expect(s.document).toHaveBeenCalledWith({
+      op: "update_chunk",
+      scope: "user",
+      id: "root-1",
+      revision: 4,
+      fields: { query },
+    });
+  });
+
+  it("deleteView removes the whole view Document", async () => {
+    const s = stubClient();
+    await dataLayerFromClient(s.client).deleteView("tenant", "doc-1");
+    expect(s.document).toHaveBeenCalledWith({ op: "delete_document", scope: "tenant", id: "doc-1" });
+  });
+
+  it("setStatus writes a chunk status at its revision (kanban move)", async () => {
+    const s = stubClient();
+    await dataLayerFromClient(s.client).setStatus("user", "c7", 2, "in-progress");
+    expect(s.document).toHaveBeenCalledWith({
+      op: "update_chunk",
+      scope: "user",
+      id: "c7",
+      revision: 2,
+      status: "in-progress",
+    });
+  });
+});

--- a/packages/loomboard/src/lib/dataLayer.tsx
+++ b/packages/loomboard/src/lib/dataLayer.tsx
@@ -1,0 +1,181 @@
+import { createContext, useContext, type ReactNode } from "react";
+import type { LoomcycleClient, DocumentToolInput } from "@loomcycle/client";
+import type {
+  BoardScope,
+  ChunkDetail,
+  CreateDocumentResponse,
+  ListTypesResponse,
+  QueryChunksResponse,
+  QueryDocumentsResponse,
+  ViewLayout,
+  ViewQuery,
+} from "../types";
+
+// LoomboardDataLayer is the narrow data contract the board needs: the reads that
+// materialize a view and the writes that persist one. Decoupling behind this
+// interface lets a host inject the default client-backed implementation
+// (dataLayerFromClient) or a custom one (e.g. a cookie-authed same-origin
+// fetcher) without any component importing a global api module. Every method
+// routes to the single `document` meta-tool; scope + tenant are resolved
+// server-side from the authenticated principal, never read from the wire.
+
+export interface LoomboardDataLayer {
+  /** Materialize a Documents board — filter by the RFC BS axes (type / status /
+   *  tag / under_path). Response rows carry title/type/status/updated, so a
+   *  Documents board renders without an N+1. */
+  queryDocuments(scope: BoardScope, q: ViewQuery): Promise<QueryDocumentsResponse>;
+  /** Materialize a Chunks board — the chunks of a document (or under a path).
+   *  Response is metadata only (no fields/tags/body); rich chips need getChunk. */
+  queryChunks(scope: BoardScope, q: ViewQuery): Promise<QueryChunksResponse>;
+  /** One chunk's full row — the only shape carrying `fields` (a saved view's
+   *  `{query, layout}`), `tags`, and `body`. */
+  getChunk(scope: BoardScope, id: string): Promise<ChunkDetail>;
+  /** The distinct chunk types declared in the scope — populates the query
+   *  builder's `type` picker. (Advisory; `type` is a free-form column, so a
+   *  board can still filter by a type never passed to define_type.) */
+  listTypes(scope: BoardScope): Promise<ListTypesResponse>;
+
+  // ---- saved views (a view is a `type=view` Document) ----
+
+  /** All saved views in the scope. */
+  listViews(scope: BoardScope): Promise<QueryDocumentsResponse>;
+  /** Create a saved view: a `type=view` Document, then seed its root chunk's
+   *  `fields` with `{query, layout}` (create_document can't carry root fields). */
+  saveView(
+    scope: BoardScope,
+    input: { title: string; path?: string; query: ViewQuery; layout: ViewLayout },
+  ): Promise<{ documentId: string; rootChunkId: string }>;
+  /** Update a saved view's `{query, layout}`. `revision` is the root chunk's
+   *  current revision (optimistic concurrency), read from a prior getChunk. */
+  updateView(
+    scope: BoardScope,
+    rootChunkId: string,
+    revision: number,
+    patch: { query?: ViewQuery; layout?: ViewLayout },
+  ): Promise<void>;
+  /** Delete a saved view (the whole `type=view` Document). */
+  deleteView(scope: BoardScope, documentId: string): Promise<void>;
+
+  /** Move a row on a kanban: set a chunk's `status`. `revision` is the row's
+   *  current revision. (P1.1 — the board renders read-first without it.) */
+  setStatus(
+    scope: BoardScope,
+    id: string,
+    revision: number,
+    status: string,
+  ): Promise<void>;
+}
+
+// dataLayerFromClient maps a @loomcycle/client instance onto the LoomboardDataLayer.
+// Every method builds a minimal Document-tool body (only set fields sent, so the
+// wire stays small and the routing tests assert exact shapes) and narrows the
+// `unknown` response to the package's own type.
+export function dataLayerFromClient(client: LoomcycleClient): LoomboardDataLayer {
+  const doc = <T,>(input: Record<string, unknown>): Promise<T> =>
+    client.document(toDocInput(input)).then((r) => r as T);
+
+  return {
+    queryDocuments: (scope, q) => {
+      const input: Record<string, unknown> = { op: "query_documents", scope };
+      if (q.type) input.type = q.type;
+      if (q.status) input.status = q.status;
+      if (q.tag) input.tag = q.tag;
+      if (q.underPath) input.under_path = q.underPath;
+      if (q.limit !== undefined) input.limit = q.limit;
+      return doc<QueryDocumentsResponse>(input);
+    },
+    queryChunks: (scope, q) => {
+      const input: Record<string, unknown> = { op: "query_chunks", scope };
+      if (q.documentId) input.document_id = q.documentId;
+      if (q.underPath) input.under_path = q.underPath;
+      if (q.type) input.type = q.type;
+      if (q.status) input.status = q.status;
+      if (q.tag) input.tag = q.tag;
+      if (q.tagPrefix) input.tag_prefix = q.tagPrefix;
+      if (q.limit !== undefined) input.limit = q.limit;
+      return doc<QueryChunksResponse>(input);
+    },
+    getChunk: (scope, id) => doc<ChunkDetail>({ op: "get_chunk", scope, id }),
+    listTypes: (scope) => doc<ListTypesResponse>({ op: "list_types", scope }),
+
+    listViews: (scope) =>
+      doc<QueryDocumentsResponse>({ op: "query_documents", scope, type: "view" }),
+
+    saveView: async (scope, input) => {
+      const created = await doc<CreateDocumentResponse>({
+        op: "create_document",
+        scope,
+        title: input.title,
+        type: "view",
+        ...(input.path ? { path: input.path } : {}),
+      });
+      // create_document seeds an empty root at revision 1, so the follow-up seed
+      // write uses revision 1. `{query, layout}` are stored opaquely in `fields`.
+      await doc<unknown>({
+        op: "update_chunk",
+        scope,
+        id: created.root_chunk_id,
+        revision: 1,
+        fields: { query: input.query, layout: input.layout },
+      });
+      return { documentId: created.document_id, rootChunkId: created.root_chunk_id };
+    },
+    updateView: async (scope, rootChunkId, revision, patch) => {
+      const fields: Record<string, unknown> = {};
+      if (patch.query) fields.query = patch.query;
+      if (patch.layout) fields.layout = patch.layout;
+      await doc<unknown>({
+        op: "update_chunk",
+        scope,
+        id: rootChunkId,
+        revision,
+        fields,
+      });
+    },
+    deleteView: async (scope, documentId) => {
+      await doc<unknown>({ op: "delete_document", scope, id: documentId });
+    },
+
+    setStatus: async (scope, id, revision, status) => {
+      await doc<unknown>({ op: "update_chunk", scope, id, revision, status });
+    },
+  };
+}
+
+// toDocInput asserts a plain field bag onto DocumentToolInput. BoardScope is a
+// narrowed string and the pinned client's op union predates some ops we send;
+// the runtime passes op + scope VERBATIM and DocumentToolInput carries a
+// `[extra: string]: unknown` index signature, so a Record is structurally
+// assignable and the assertion is sound, not a cast past a real type error.
+function toDocInput(fields: Record<string, unknown>): DocumentToolInput {
+  return fields as DocumentToolInput;
+}
+
+// The data layer reaches the board through context — no module-global singleton.
+// The root (<Loomboard>) builds it once (useMemo over connection identity) and
+// provides it; every panel reads it with useLoomboardData().
+const LoomboardDataContext = createContext<LoomboardDataLayer | null>(null);
+
+export function LoomboardDataProvider({
+  value,
+  children,
+}: {
+  value: LoomboardDataLayer;
+  children: ReactNode;
+}) {
+  return (
+    <LoomboardDataContext.Provider value={value}>
+      {children}
+    </LoomboardDataContext.Provider>
+  );
+}
+
+export function useLoomboardData(): LoomboardDataLayer {
+  const v = useContext(LoomboardDataContext);
+  if (!v) {
+    throw new Error(
+      "useLoomboardData must be used within <Loomboard> (no LoomboardDataLayer in context)",
+    );
+  }
+  return v;
+}

--- a/packages/loomboard/src/lib/view.test.ts
+++ b/packages/loomboard/src/lib/view.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseView,
+  normalizeQuery,
+  normalizeLayout,
+  docRowToBoardRow,
+  chunkRowToBoardRow,
+  groupRows,
+  sortRows,
+  UNGROUPED,
+} from "./view";
+import type { BoardRow, ChunkDetail } from "../types";
+
+describe("normalizeQuery", () => {
+  it("defaults a missing/garbled query to a documents source", () => {
+    expect(normalizeQuery(undefined)).toEqual({ source: "documents" });
+    expect(normalizeQuery("nope")).toEqual({ source: "documents" });
+  });
+  it("keeps only string axes + a numeric limit", () => {
+    expect(
+      normalizeQuery({ source: "chunks", type: "task", status: "", limit: 50, bogus: 1 }),
+    ).toEqual({ source: "chunks", type: "task", limit: 50 });
+  });
+});
+
+describe("normalizeLayout", () => {
+  it("defaults a garbled layout to a table grouped by status", () => {
+    expect(normalizeLayout(null)).toMatchObject({ kind: "table", groupBy: "status", sortDir: "desc" });
+  });
+  it("clamps an unknown kind/axis and filters columns", () => {
+    const l = normalizeLayout({ kind: "wat", groupBy: "tag", sortBy: "title", sortDir: "asc", columns: ["type", "x", "updated"] });
+    expect(l.kind).toBe("table");
+    expect(l.groupBy).toBe("status");
+    expect(l.sortBy).toBe("title");
+    expect(l.sortDir).toBe("asc");
+    expect(l.columns).toEqual(["type", "updated"]);
+  });
+});
+
+describe("parseView", () => {
+  it("reads {query, layout} from the root chunk's fields", () => {
+    const root = {
+      id: "root-1",
+      title: "RFCs",
+      fields: { query: { source: "documents", type: "rfc" }, layout: { kind: "kanban", groupBy: "status" } },
+    } as unknown as ChunkDetail;
+    const v = parseView("doc-1", root);
+    expect(v).toMatchObject({
+      documentId: "doc-1",
+      rootChunkId: "root-1",
+      title: "RFCs",
+      query: { source: "documents", type: "rfc" },
+      layout: { kind: "kanban", groupBy: "status" },
+    });
+  });
+  it("still opens a view with no fields (safe defaults)", () => {
+    const root = { id: "r", title: "empty" } as unknown as ChunkDetail;
+    expect(parseView("d", root).layout.kind).toBe("table");
+  });
+});
+
+describe("row normalization", () => {
+  it("maps a document row", () => {
+    expect(
+      docRowToBoardRow({ document_id: "d1", title: "T", root_chunk_id: "r", type: "rfc", status: "draft", updated_at: 5 }),
+    ).toEqual({ id: "d1", documentId: "d1", title: "T", type: "rfc", status: "draft", updatedAt: 5 });
+  });
+  it("maps a chunk row (id != document_id)", () => {
+    expect(
+      chunkRowToBoardRow({ id: "c1", document_id: "d1", title: "step", position: 2, revision: 1, status: "todo" }),
+    ).toEqual({ id: "c1", documentId: "d1", title: "step", type: undefined, status: "todo", position: 2 });
+  });
+});
+
+describe("groupRows", () => {
+  it("buckets by status in first-seen order; missing → UNGROUPED", () => {
+    const rows: BoardRow[] = [
+      { id: "1", documentId: "d", title: "a", status: "todo" },
+      { id: "2", documentId: "d", title: "b", status: "done" },
+      { id: "3", documentId: "d", title: "c", status: "todo" },
+      { id: "4", documentId: "d", title: "d" },
+    ];
+    const g = groupRows(rows, "status");
+    expect(g.map((x) => x.key)).toEqual(["todo", "done", UNGROUPED]);
+    expect(g[0].rows.map((r) => r.id)).toEqual(["1", "3"]);
+  });
+});
+
+describe("sortRows", () => {
+  const rows: BoardRow[] = [
+    { id: "1", documentId: "d", title: "banana", updatedAt: 10 },
+    { id: "2", documentId: "d", title: "apple", updatedAt: 30 },
+    { id: "3", documentId: "d", title: "cherry", updatedAt: 20 },
+  ];
+  it("sorts by updated desc by default", () => {
+    expect(sortRows(rows, "updated").map((r) => r.id)).toEqual(["2", "3", "1"]);
+  });
+  it("sorts by title asc", () => {
+    expect(sortRows(rows, "title", "asc").map((r) => r.id)).toEqual(["2", "1", "3"]);
+  });
+  it("is a no-op copy when no sort field", () => {
+    const out = sortRows(rows);
+    expect(out).not.toBe(rows);
+    expect(out.map((r) => r.id)).toEqual(["1", "2", "3"]);
+  });
+});

--- a/packages/loomboard/src/lib/view.ts
+++ b/packages/loomboard/src/lib/view.ts
@@ -1,0 +1,142 @@
+import type {
+  BoardRow,
+  ChunkDetail,
+  ChunkRow,
+  DocRow,
+  GroupAxis,
+  LayoutKind,
+  SavedView,
+  SortField,
+  ViewLayout,
+  ViewQuery,
+} from "../types";
+
+// Pure view logic — DOM-free so it's unit-testable without a renderer. Parses a
+// saved view's opaque `fields` defensively, normalizes document/chunk rows into
+// one BoardRow shape, and groups/sorts for the layouts.
+
+const LAYOUT_KINDS: readonly LayoutKind[] = ["table", "cards", "kanban", "list"];
+const GROUP_AXES: readonly GroupAxis[] = ["status", "type"];
+const SORT_FIELDS: readonly SortField[] = ["title", "updated", "position"];
+
+const DEFAULT_QUERY: ViewQuery = { source: "documents" };
+const DEFAULT_LAYOUT: ViewLayout = {
+  kind: "table",
+  groupBy: "status",
+  sortBy: "updated",
+  sortDir: "desc",
+};
+
+/** The value shown for a row with no value on the grouping axis. */
+export const UNGROUPED = "—";
+
+/** Parse a `type=view` root chunk into a SavedView. `{query, layout}` live in
+ *  the opaque `fields`; anything missing or garbled falls back to a safe default
+ *  so a hand-edited or legacy view still opens instead of throwing. */
+export function parseView(documentId: string, root: ChunkDetail): SavedView {
+  const f = (root.fields ?? {}) as { query?: unknown; layout?: unknown };
+  return {
+    documentId,
+    rootChunkId: root.id,
+    title: root.title,
+    query: normalizeQuery(f.query),
+    layout: normalizeLayout(f.layout),
+    revision: root.revision,
+  };
+}
+
+export function normalizeQuery(q: unknown): ViewQuery {
+  if (!q || typeof q !== "object") return { ...DEFAULT_QUERY };
+  const o = q as Record<string, unknown>;
+  const out: ViewQuery = { source: o.source === "chunks" ? "chunks" : "documents" };
+  for (const k of ["documentId", "underPath", "type", "status", "tag", "tagPrefix"] as const) {
+    if (typeof o[k] === "string" && o[k]) out[k] = o[k] as string;
+  }
+  if (typeof o.limit === "number") out.limit = o.limit;
+  return out;
+}
+
+export function normalizeLayout(l: unknown): ViewLayout {
+  if (!l || typeof l !== "object") return { ...DEFAULT_LAYOUT };
+  const o = l as Record<string, unknown>;
+  const kind = LAYOUT_KINDS.includes(o.kind as LayoutKind) ? (o.kind as LayoutKind) : "table";
+  const out: ViewLayout = { kind };
+  out.groupBy = GROUP_AXES.includes(o.groupBy as GroupAxis) ? (o.groupBy as GroupAxis) : "status";
+  if (SORT_FIELDS.includes(o.sortBy as SortField)) out.sortBy = o.sortBy as SortField;
+  out.sortDir = o.sortDir === "asc" ? "asc" : "desc";
+  if (Array.isArray(o.columns)) {
+    out.columns = o.columns.filter(
+      (c): c is "type" | "status" | "updated" =>
+        c === "type" || c === "status" || c === "updated",
+    );
+  }
+  return out;
+}
+
+export function docRowToBoardRow(d: DocRow): BoardRow {
+  return {
+    id: d.document_id,
+    documentId: d.document_id,
+    title: d.title,
+    type: d.type,
+    status: d.status,
+    updatedAt: d.updated_at,
+  };
+}
+
+export function chunkRowToBoardRow(c: ChunkRow): BoardRow {
+  return {
+    id: c.id,
+    documentId: c.document_id,
+    title: c.title,
+    type: c.type,
+    status: c.status,
+    position: c.position,
+  };
+}
+
+/** A single grouping bucket, preserving first-seen column order. */
+export interface RowGroup {
+  key: string;
+  rows: BoardRow[];
+}
+
+/** Bucket rows by a single-valued axis (status | type). Rows with no value on
+ *  the axis go to the UNGROUPED bucket. Column order is first-seen. */
+export function groupRows(rows: BoardRow[], axis: GroupAxis): RowGroup[] {
+  const order: string[] = [];
+  const byKey = new Map<string, BoardRow[]>();
+  for (const r of rows) {
+    const key = (axis === "status" ? r.status : r.type) || UNGROUPED;
+    let bucket = byKey.get(key);
+    if (!bucket) {
+      bucket = [];
+      byKey.set(key, bucket);
+      order.push(key);
+    }
+    bucket.push(r);
+  }
+  return order.map((key) => ({ key, rows: byKey.get(key)! }));
+}
+
+/** Sort rows in place-safe (returns a new array) by the chosen field. */
+export function sortRows(rows: BoardRow[], by?: SortField, dir: "asc" | "desc" = "desc"): BoardRow[] {
+  const sorted = [...rows];
+  if (!by) return sorted;
+  const sign = dir === "asc" ? 1 : -1;
+  sorted.sort((a, b) => {
+    let cmp: number;
+    if (by === "title") cmp = a.title.localeCompare(b.title);
+    else if (by === "updated") cmp = (a.updatedAt ?? 0) - (b.updatedAt ?? 0);
+    else cmp = (a.position ?? 0) - (b.position ?? 0);
+    return cmp * sign;
+  });
+  return sorted;
+}
+
+/** unix-nanoseconds → a short human "when" (or "" when unset). */
+export function formatWhen(ns?: number): string {
+  if (!ns) return "";
+  const d = new Date(ns / 1e6);
+  return Number.isNaN(d.getTime()) ? "" : d.toLocaleDateString();
+}

--- a/packages/loomboard/src/styles.css
+++ b/packages/loomboard/src/styles.css
@@ -1,0 +1,399 @@
+/* @loomcycle/loomboard — scoped, self-contained styles. Everything lives under
+   .loomcycle-loomboard so a host that imports this sheet gets the board styled
+   without leaking rules. Dark is the default palette; a light override applies
+   when the root carries data-theme="light" OR inherits it from any ancestor
+   (so an app theming <html data-theme="light"> themes the board for free).
+   Import once: `import "@loomcycle/loomboard/styles.css"`. */
+
+.loomcycle-loomboard {
+  --lb-bg: #14161a;
+  --lb-surface: #1b1e24;
+  --lb-surface-2: #22262d;
+  --lb-border: #2c313a;
+  --lb-text: #e7e9ee;
+  --lb-dim: #9aa2af;
+  --lb-accent: #3b82f6;
+  --lb-accent-fg: #ffffff;
+  --lb-danger: #ef4444;
+
+  color-scheme: dark;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  background: var(--lb-bg);
+  color: var(--lb-text);
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.loomcycle-loomboard[data-theme="light"],
+[data-theme="light"] .loomcycle-loomboard {
+  --lb-bg: #ffffff;
+  --lb-surface: #f6f7f9;
+  --lb-surface-2: #eef0f3;
+  --lb-border: #d9dce1;
+  --lb-text: #1a1d23;
+  --lb-dim: #616a76;
+  --lb-accent: #2563eb;
+  --lb-accent-fg: #ffffff;
+  --lb-danger: #dc2626;
+  color-scheme: light;
+}
+
+.loomcycle-loomboard *,
+.loomcycle-loomboard *::before,
+.loomcycle-loomboard *::after {
+  box-sizing: border-box;
+}
+.loomcycle-loomboard button {
+  font: inherit;
+  cursor: pointer;
+}
+
+.loomcycle-loomboard .error-banner {
+  margin: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid var(--lb-danger);
+  border-radius: 8px;
+  color: var(--lb-danger);
+}
+
+/* ---- shell ---- */
+.loomcycle-loomboard .loomboard-body {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+.loomcycle-loomboard .loomboard-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  padding: 0.5rem 0.7rem;
+  border-bottom: 1px solid var(--lb-border);
+}
+.loomcycle-loomboard .scope-toggle {
+  display: inline-flex;
+  border: 1px solid var(--lb-border);
+  border-radius: 7px;
+  overflow: hidden;
+}
+.loomcycle-loomboard .scope-toggle button {
+  padding: 0.25em 0.7em;
+  background: transparent;
+  border: 0;
+  color: var(--lb-dim);
+  text-transform: capitalize;
+}
+.loomcycle-loomboard .scope-toggle button.on {
+  background: var(--lb-accent);
+  color: var(--lb-accent-fg);
+}
+.loomcycle-loomboard .loomboard-actions {
+  display: inline-flex;
+  gap: 0.4rem;
+}
+.loomcycle-loomboard .loomboard-error {
+  margin: 0.6rem 0.7rem 0;
+  color: var(--lb-danger);
+  font-size: 0.85em;
+}
+
+.loomcycle-loomboard .loomboard-split {
+  flex: 1;
+  min-height: 0;
+}
+.loomcycle-loomboard .loomboard-main {
+  height: 100%;
+  min-height: 0;
+  overflow: auto;
+  padding: 0.8rem;
+}
+.loomcycle-loomboard .loomboard-placeholder {
+  color: var(--lb-dim);
+  padding: 2rem 1rem;
+  text-align: center;
+}
+
+/* ---- buttons + fields ---- */
+.loomcycle-loomboard .btn-ghost,
+.loomcycle-loomboard .view-new {
+  padding: 0.3em 0.7em;
+  background: var(--lb-surface-2);
+  border: 1px solid var(--lb-border);
+  border-radius: 6px;
+  color: var(--lb-text);
+}
+.loomcycle-loomboard .btn-ghost.danger {
+  color: var(--lb-danger);
+}
+.loomcycle-loomboard .btn-primary {
+  padding: 0.4em 0.9em;
+  background: var(--lb-accent);
+  border: 1px solid var(--lb-accent);
+  border-radius: 6px;
+  color: var(--lb-accent-fg);
+}
+.loomcycle-loomboard .btn-primary:disabled,
+.loomcycle-loomboard .btn-ghost:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.loomcycle-loomboard .field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25em;
+  margin-bottom: 0.6rem;
+}
+.loomcycle-loomboard .field > span {
+  font-size: 0.75em;
+  color: var(--lb-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.loomcycle-loomboard .field input,
+.loomcycle-loomboard .field select {
+  padding: 0.4em 0.55em;
+  background: var(--lb-bg);
+  border: 1px solid var(--lb-border);
+  border-radius: 6px;
+  color: var(--lb-text);
+}
+.loomcycle-loomboard .field-row {
+  display: flex;
+  gap: 0.6rem;
+}
+.loomcycle-loomboard .field-row .field {
+  flex: 1;
+}
+
+/* ---- saved-view rail ---- */
+.loomcycle-loomboard .view-list {
+  height: 100%;
+  overflow: auto;
+  padding: 0.6rem;
+  border-right: 1px solid var(--lb-border);
+}
+.loomcycle-loomboard .view-list-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+.loomcycle-loomboard .view-list-title {
+  font-weight: 600;
+}
+.loomcycle-loomboard .view-list-items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.loomcycle-loomboard .view-item {
+  width: 100%;
+  text-align: left;
+  padding: 0.4em 0.55em;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  color: var(--lb-text);
+}
+.loomcycle-loomboard .view-item:hover {
+  background: var(--lb-surface-2);
+}
+.loomcycle-loomboard .view-item.on {
+  background: var(--lb-accent);
+  color: var(--lb-accent-fg);
+}
+.loomcycle-loomboard .view-list-empty,
+.loomcycle-loomboard .view-list-loading,
+.loomcycle-loomboard .view-list-error {
+  color: var(--lb-dim);
+  font-size: 0.85em;
+  padding: 0.4rem 0.2rem;
+}
+.loomcycle-loomboard .view-list-error {
+  color: var(--lb-danger);
+}
+
+/* ---- view editor ---- */
+.loomcycle-loomboard .view-editor {
+  max-width: 560px;
+}
+.loomcycle-loomboard .view-editor-head {
+  font-weight: 600;
+  font-size: 1.05em;
+  margin-bottom: 0.8rem;
+}
+.loomcycle-loomboard .view-editor-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 0.4rem;
+}
+.loomcycle-loomboard .view-editor-error {
+  color: var(--lb-danger);
+  font-size: 0.85em;
+  margin-bottom: 0.5rem;
+}
+
+/* ---- board renderers ---- */
+.loomcycle-loomboard .board-view-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  margin-bottom: 0.7rem;
+}
+.loomcycle-loomboard .board-view-title {
+  font-weight: 600;
+  font-size: 1.05em;
+}
+.loomcycle-loomboard .board-view-kind {
+  font-size: 0.75em;
+  color: var(--lb-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.loomcycle-loomboard .board-loading,
+.loomcycle-loomboard .board-empty {
+  color: var(--lb-dim);
+  padding: 1rem 0;
+}
+.loomcycle-loomboard .board-error {
+  color: var(--lb-danger);
+  padding: 0.7rem 0;
+}
+.loomcycle-loomboard .board-scroll {
+  overflow-x: auto;
+}
+
+.loomcycle-loomboard .board-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.loomcycle-loomboard .board-table th,
+.loomcycle-loomboard .board-table td {
+  text-align: left;
+  padding: 0.4em 0.7em;
+  border-bottom: 1px solid var(--lb-border);
+  white-space: nowrap;
+}
+.loomcycle-loomboard .board-table th {
+  color: var(--lb-dim);
+  font-size: 0.78em;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.loomcycle-loomboard .cell-title {
+  white-space: normal;
+}
+.loomcycle-loomboard .cell-dim {
+  color: var(--lb-dim);
+}
+
+.loomcycle-loomboard .board-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 0.6rem;
+}
+.loomcycle-loomboard .board-card {
+  background: var(--lb-surface);
+  border: 1px solid var(--lb-border);
+  border-radius: 8px;
+  padding: 0.6rem 0.7rem;
+}
+.loomcycle-loomboard .board-card-title {
+  font-weight: 500;
+  margin-bottom: 0.4rem;
+}
+.loomcycle-loomboard .board-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.8em;
+}
+
+.loomcycle-loomboard .board-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.loomcycle-loomboard .board-list-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  padding: 0.4em 0.2em;
+  border-bottom: 1px solid var(--lb-border);
+}
+
+.loomcycle-loomboard .board-kanban {
+  display: flex;
+  gap: 0.7rem;
+  align-items: flex-start;
+}
+.loomcycle-loomboard .kanban-col {
+  flex: 0 0 240px;
+  background: var(--lb-surface);
+  border: 1px solid var(--lb-border);
+  border-radius: 8px;
+}
+.loomcycle-loomboard .kanban-col-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.7rem;
+  border-bottom: 1px solid var(--lb-border);
+  font-weight: 600;
+}
+.loomcycle-loomboard .kanban-col-count {
+  color: var(--lb-dim);
+  font-size: 0.85em;
+}
+.loomcycle-loomboard .kanban-col-body {
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.loomcycle-loomboard .kanban-col-body .board-card {
+  background: var(--lb-surface-2);
+}
+
+/* ---- badges ---- */
+.loomcycle-loomboard .badge {
+  display: inline-block;
+  padding: 0.1em 0.5em;
+  border-radius: 999px;
+  font-size: 0.75em;
+  border: 1px solid var(--lb-border);
+  color: var(--lb-dim);
+}
+.loomcycle-loomboard .badge-status {
+  border-color: var(--lb-accent);
+  color: var(--lb-accent);
+}
+
+/* ---- splitter (self-contained copy) ---- */
+.loomcycle-loomboard .splitter {
+  display: grid;
+  height: 100%;
+  min-height: 0;
+}
+.loomcycle-loomboard .splitter-pane {
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+.loomcycle-loomboard .splitter-handle {
+  cursor: col-resize;
+  background: var(--lb-border);
+}
+.loomcycle-loomboard .splitter.dragging {
+  user-select: none;
+}

--- a/packages/loomboard/src/types.ts
+++ b/packages/loomboard/src/types.ts
@@ -1,0 +1,148 @@
+// Public data types for @loomcycle/loomboard. The @loomcycle/client Document tool
+// is typed `DocumentToolResponse = unknown`, so the response shapes below are the
+// package's own contract, transcribed from the runtime's document.go responses
+// (query_documents / query_chunks / get_chunk / create_document). A saved view is
+// itself a `type=view` Document, dogfooding the primitive it renders (RFC BT).
+
+import type { Connection } from "./lib/createClient";
+
+export type { Connection };
+
+/** Which Document store a board reads / writes. "agent" is off-run
+ *  operator-private and not a board scope; boards use "user" (personal) or
+ *  "tenant" (shared across the tenant — RFC CB lets a non-isolated member reach
+ *  it). */
+export type BoardScope = "user" | "tenant";
+
+/** The filter half of a saved view — the RFC BS queryable axes ONLY (type /
+ *  status / tags / path). `fields.*` is deliberately absent: it lives in the
+ *  Memory k/v blob and is not SQL-queryable, so filtering by it is a future core
+ *  change (RFC BS §7 promote-a-field), not a P1 workaround. */
+export interface ViewQuery {
+  /** Board granularity: whole Documents, or the chunks within a document / path. */
+  source: "documents" | "chunks";
+  /** chunks source: restrict to one document's chunks. */
+  documentId?: string;
+  /** Path-tree subtree to query at / under. */
+  underPath?: string;
+  /** Single-valued indexed axes (`type` is subtype-expanded server-side). */
+  type?: string;
+  status?: string;
+  /** Multi-valued tag facet: exact membership, or a slash-nested prefix. */
+  tag?: string;
+  tagPrefix?: string;
+  /** Row cap. The server clamps to 100 (default) / 1000 (max); there is no
+   *  pagination, so a big board must narrow by type / status / tag / path. */
+  limit?: number;
+}
+
+export type LayoutKind = "table" | "cards" | "kanban" | "list";
+
+/** The single-valued axis a kanban buckets by. Tags are multi-valued (a row
+ *  lands in several columns at once), so tag-grouping is a later add. */
+export type GroupAxis = "status" | "type";
+
+export type SortField = "title" | "updated" | "position";
+
+/** The presentation half of a saved view. */
+export interface ViewLayout {
+  kind: LayoutKind;
+  /** kanban: the column axis (default "status"). */
+  groupBy?: GroupAxis;
+  sortBy?: SortField;
+  sortDir?: "asc" | "desc";
+  /** table: extra columns beyond the title, drawn from the row axes. */
+  columns?: Array<"type" | "status" | "updated">;
+}
+
+/** A saved view: a `type=view` Document whose `{query, layout}` live in its root
+ *  chunk's `fields`. */
+export interface SavedView {
+  documentId: string;
+  rootChunkId: string;
+  title: string;
+  query: ViewQuery;
+  layout: ViewLayout;
+  /** The root chunk's revision — passed back to updateView for optimistic
+   *  concurrency when editing. */
+  revision?: number;
+  /** unix nanoseconds. */
+  updatedAt?: number;
+}
+
+/** The normalized row the layouts render — unifies a document row and a chunk
+ *  row so one set of renderers serves both board granularities. */
+export interface BoardRow {
+  /** The chunk id, or (documents board) the document_id. */
+  id: string;
+  documentId: string;
+  title: string;
+  type?: string;
+  status?: string;
+  /** unix nanoseconds (÷1e6 for a JS Date). */
+  updatedAt?: number;
+  position?: number;
+}
+
+// ---- Wire response shapes (document.go; DocumentToolResponse is `unknown`) ----
+
+export interface DocRow {
+  document_id: string;
+  title: string;
+  root_chunk_id: string;
+  type?: string;
+  status?: string;
+  created_at?: number;
+  updated_at?: number;
+}
+export interface QueryDocumentsResponse {
+  documents: DocRow[];
+}
+
+export interface ChunkRow {
+  id: string;
+  document_id: string;
+  title: string;
+  position: number;
+  revision: number;
+  parent_id?: string;
+  type?: string;
+  status?: string;
+}
+export interface QueryChunksResponse {
+  chunks: ChunkRow[];
+  /** Present when a `type` filter widened to include subtypes. */
+  type_expanded_to?: string[];
+}
+
+/** The full chunk row — the only shape carrying `fields` / `tags` / `body`. */
+export interface ChunkDetail {
+  id: string;
+  document_id: string;
+  title: string;
+  body: string;
+  revision: number;
+  position: number;
+  parent_id?: string;
+  type?: string;
+  status?: string;
+  fields?: Record<string, unknown>;
+  tags?: string[];
+}
+
+export interface TypeRow {
+  name: string;
+  document_id: string;
+  fields?: unknown;
+}
+export interface ListTypesResponse {
+  types: TypeRow[];
+}
+
+export interface CreateDocumentResponse {
+  document_id: string;
+  root_chunk_id: string;
+  title: string;
+  path?: string;
+  path_warning?: string;
+}

--- a/packages/loomboard/tsconfig.json
+++ b/packages/loomboard/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+    "skipLibCheck": true,
+
+    "types": ["vite/client", "node"]
+  },
+  "include": ["src", "vite.config.lib.ts"]
+}

--- a/packages/loomboard/tsconfig.lib.json
+++ b/packages/loomboard/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/packages/loomboard/vite.config.lib.ts
+++ b/packages/loomboard/vite.config.lib.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { fileURLToPath } from "node:url";
+
+// Library build for the published @loomcycle/memory-view package. Emits ESM + CJS
+// to dist/; declarations come from `tsc -p tsconfig.lib.json` and styles.css is
+// copied in — see the build:lib script. Everything imported by bare specifier
+// (react, react-dom, @loomcycle/client) is externalized so it isn't duplicated
+// into the consumer's bundle; only our own relative source is bundled.
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    lib: {
+      entry: fileURLToPath(new URL("./src/index.ts", import.meta.url)),
+      formats: ["es", "cjs"],
+      fileName: (format) => (format === "es" ? "index.js" : "index.cjs"),
+    },
+    outDir: "dist",
+    sourcemap: true,
+    emptyOutDir: true,
+    rollupOptions: {
+      external: (id) => !id.startsWith(".") && !id.startsWith("/"),
+    },
+  },
+});


### PR DESCRIPTION
## Why
**RFC BT** (loomboard view surfaces) **P1**. loomboard is the opinionated *view layer* over loomcycle Documents — it adds no storage and no business logic; a saved view is itself a `type=view` Document. This lands the first surface: **saved table / cards / kanban / list views**, as a new reusable React package alongside `@loomcycle/explorer` / `@loomcycle/memory-view`.

Design + phasing are captured in the plan Document at `/loomcycle/docs/plans/loomboard-view-surfaces-p1` (user scope). RFC BS (the primitives this consumes) is already shipped, so P1 has no core dependency.

## What — `@loomcycle/loomboard@0.1.0` (`packages/loomboard`)
Packaging mirrors `@loomcycle/memory-view` exactly (standalone package, no monorepo root): `build:lib` = vite → ESM+CJS, `tsc` → types, `cp` → scoped `styles.css`; `connection | client | dataLayer` seam; themeable `.loomcycle-loomboard` root; `onError` + never-redirect-on-401; **no runtime deps**.

- **Data layer** (`src/lib/dataLayer.tsx`) maps onto the single `document` meta-tool: `query_documents` / `query_chunks` / `get_chunk` / `list_types`, and saved-view CRUD — `create_document` + `update_chunk` for the `type=view` Document, `delete_document`, and a P1.1 `setStatus` (kanban write). Response types are the package's own, since `DocumentToolResponse` is `unknown`.
- **Pure view logic** (`src/lib/view.ts`): defensive parse of a view's opaque `fields`, document/chunk → `BoardRow` normalization, group/sort.
- **UI**: `Loomboard` → `LoomboardRoot` → `LoomboardBody` (scope toggle + a splitter of the saved-view rail and the active board/editor); four layout renderers; a query-builder `ViewEditor`.

### Boundary held (RFC BS §13 / RFC BT §5)
- Query axes are **type / status / tags / under_path only** — `fields.*` is not SQL-queryable, so filtering by it is deliberately absent (RFC BS §7 promote-a-field is a future core change, not a workaround here).
- No new storage: the saved view is a Document; the package owns no tables.
- Tenant scope works for a **non-isolated member** (RFC CB).

## Tested
- `npm run typecheck` — clean.
- `npx vitest run` — **22 pass**: 10 data-layer wire-mapping (each method → the right `document` op + minimal body) + 12 view-logic (parse/normalize/group/sort).
- `npm run build:lib` — clean; `dist/` = `index.js` (ESM) + `index.cjs` (CJS) + `.d.ts` + `styles.css`.

**Not yet exercised live** (stub-routing + pure-logic tests only): the end-to-end query→render round-trip and the `saveView` "seed root fields at revision 1" assumption need a run against a real runtime. That happens when the loomboard app mounts this package (a follow-up, after `0.1.0` publishes) — noted so a reviewer knows the live path is unverified.

## Follow-ups (not in this PR)
Publish `0.1.0` → mount in the loomboard app as a tenant-gated "Boards" nav → then P1.1 kanban status-write, richer chunk-board chips, and later phases (graph / canvas / workflow boards / publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)