### PR TITLE
feat(memory): remote memory.Backend (kind: remote) — loomcycle→loomcycle (RFC CD Part B)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -550,6 +550,7 @@ components:
             - update_chunk
             - delete_chunk
             - supersede_chunk
+            - judge_fact
             - graph_recall
             - list_facts
             - move_chunk

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5786,6 +5786,17 @@ func validate(c *Config) error {
 			!strings.Contains(mb.TenancyStrategy.PrefixPattern, "{tenant_id}") {
 			return fmt.Errorf("memory_backends.%s: tenancy_strategy.prefix_pattern %q must contain {tenant_id} for shared_key_with_prefix (an empty or token-less prefix collapses all tenants into one keyspace)", bname, mb.TenancyStrategy.PrefixPattern)
 		}
+		// RFC CD Part B: a static kind:remote backend is dialed at runtime, so
+		// fail fast at load on a missing base_url or the unsupported tenancy
+		// (the api_key_env allowlist is enforced at resolve time).
+		if mb.Kind == "remote" {
+			if mb.Config.BaseURL == "" {
+				return fmt.Errorf("memory_backends.%s: kind=remote requires config.base_url", bname)
+			}
+			if mb.TenancyStrategy.Kind == "shared_key_with_prefix" {
+				return fmt.Errorf("memory_backends.%s: kind=remote does not support tenancy_strategy=shared_key_with_prefix (use key_per_tenant)", bname)
+			}
+		}
 	}
 	// Static webhooks: a misconfigured delivery target can never fire (F24).
 	for wname, wh := range c.Webhooks {

--- a/internal/memory/backends/remote/remote.go
+++ b/internal/memory/backends/remote/remote.go
@@ -1,0 +1,440 @@
+// Package remote implements memory.Backend by HTTP-proxying the six data
+// operations to a PEER loomcycle instance's /v1/_memory/* surface. It is the
+// first faithful external backend for the RFC I seam: unlike an LLM-extract
+// memory *product*, another loomcycle is a faithful flat KV+vector store
+// (synchronous Set->Get, real Stats, real vector Search), so it plugs in behind
+// the same six methods with no paradigm mismatch.
+//
+// "Embeds server-side": the peer owns embedding. This backend never touches a
+// local Embedder — Set forwards embed=true and the peer embeds; Search sends
+// query text and the peer runs the vector search. (RFC CD Part B.)
+//
+// Connection policy (the SSRF-guarded HTTP client, the credential-env
+// allowlist) is INJECTED by the factory (internal/tools/builtin), so this
+// package stays free of config/netguard/os coupling and is unit-testable
+// against an httptest peer.
+package remote
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	memory "github.com/denn-gubsky/loomcycle/internal/memory"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// Options configures a remote backend. The factory fills these from a resolved
+// config.MemoryBackend.
+type Options struct {
+	// BaseURL is the peer's origin, e.g. "https://peer.example:8787". A
+	// trailing slash is tolerated.
+	BaseURL string
+	// APIVersion is reserved; the data API is /v1 today.
+	APIVersion string
+	// DefaultAPIKeyEnv is the env-var NAME whose value is the peer bearer,
+	// used when tenancy is "" (one shared credential).
+	DefaultAPIKeyEnv string
+	// TenancyKind is "" (one shared credential) or "key_per_tenant" (a
+	// distinct credential per local tenant, its env name from EnvPattern).
+	// "shared_key_with_prefix" is refused — see New.
+	TenancyKind string
+	// EnvPattern is the key_per_tenant env-name template containing {tenant_id}.
+	EnvPattern string
+	// KeyResolver maps an env-var NAME to its value, allowlist-gated. The
+	// factory supplies config.EnvNameCredentialSafe + os.Getenv. A nil resolver
+	// (or an empty resolved env name) means "no auth" — an unauthenticated peer.
+	KeyResolver func(envName string) (string, error)
+	// HTTPClient is the SSRF-guarded client the factory built. Required.
+	HTTPClient *http.Client
+}
+
+// Backend is a memory.Backend that proxies to a peer's /v1/_memory/*.
+type Backend struct {
+	base         string
+	defAPIKeyEnv string
+	tenancyKind  string
+	envPattern   string
+	keyResolver  func(string) (string, error)
+	http         *http.Client
+}
+
+var _ memory.Backend = (*Backend)(nil)
+
+// New validates the options and builds the backend.
+func New(o Options) (*Backend, error) {
+	if o.BaseURL == "" {
+		return nil, fmt.Errorf("remote memory backend: base_url is required")
+	}
+	if o.TenancyKind == "shared_key_with_prefix" {
+		// The peer search API (POST /v1/_memory/search) has no key-prefix
+		// parameter, so a namespaced search could not be scoped to one
+		// tenant's prefix — it would leak other tenants' rows into a search
+		// result. Refuse loudly rather than half-honor it. Supported tenancy:
+		// "" (one shared credential) and key_per_tenant (a distinct peer
+		// credential/tenant per local tenant).
+		return nil, fmt.Errorf("remote memory backend: tenancy_strategy=shared_key_with_prefix is not supported (use key_per_tenant)")
+	}
+	if o.HTTPClient == nil {
+		return nil, fmt.Errorf("remote memory backend: HTTPClient is required")
+	}
+	return &Backend{
+		base:         strings.TrimRight(o.BaseURL, "/"),
+		defAPIKeyEnv: o.DefaultAPIKeyEnv,
+		tenancyKind:  o.TenancyKind,
+		envPattern:   o.EnvPattern,
+		keyResolver:  o.KeyResolver,
+		http:         o.HTTPClient,
+	}, nil
+}
+
+// authHeader resolves the peer bearer for this call. For key_per_tenant the
+// env-var name is derived from the LOCAL tenant (run identity), so the mapping
+// happens per-call. Returns "" for an unauthenticated peer.
+func (b *Backend) authHeader(ctx context.Context) (string, error) {
+	envName := b.defAPIKeyEnv
+	if b.tenancyKind == "key_per_tenant" && b.envPattern != "" {
+		envName = strings.ReplaceAll(b.envPattern, "{tenant_id}", tools.RunIdentity(ctx).TenantID)
+	}
+	if envName == "" || b.keyResolver == nil {
+		return "", nil
+	}
+	tok, err := b.keyResolver(envName)
+	if err != nil {
+		return "", err // contains only the env-var NAME, never the value
+	}
+	return "Bearer " + tok, nil
+}
+
+func (b *Backend) Get(ctx context.Context, scope store.MemoryScope, scopeID, key string) (store.MemoryEntry, error) {
+	status, raw, err := b.request(ctx, http.MethodGet, b.keysURL(scope, scopeID, key), nil)
+	if err != nil {
+		return store.MemoryEntry{}, err
+	}
+	switch status {
+	case http.StatusOK:
+		var r struct {
+			Entry store.MemoryEntry `json:"entry"`
+		}
+		if uerr := json.Unmarshal(raw, &r); uerr != nil {
+			return store.MemoryEntry{}, decodeErr(uerr)
+		}
+		return r.Entry, nil
+	case http.StatusNotFound:
+		return store.MemoryEntry{}, &store.ErrNotFound{Kind: "memory", ID: key}
+	default:
+		return store.MemoryEntry{}, statusErr("get", status, raw)
+	}
+}
+
+func (b *Backend) Set(ctx context.Context, scope store.MemoryScope, scopeID, key string, value json.RawMessage, opts memory.SetOptions) (memory.SetResult, error) {
+	// NOTE: opts.Provenance cannot round-trip — the peer PUT body carries no
+	// provenance field. A consolidation write's provenance is therefore dropped
+	// over a remote backend (a documented limitation of the HTTP data API).
+	body := putBody{Value: value, Embed: opts.Embed}
+	if opts.TTL > 0 {
+		body.TTLSeconds = int(opts.TTL / time.Second)
+	}
+	status, raw, err := b.request(ctx, http.MethodPut, b.keysURL(scope, scopeID, key), body)
+	if err != nil {
+		return memory.SetResult{}, err
+	}
+	if status != http.StatusOK {
+		return memory.SetResult{}, statusErr("set", status, raw)
+	}
+	var r struct {
+		Embedded     bool   `json:"embedded"`
+		EmbedWarning string `json:"embed_warning"`
+	}
+	_ = json.Unmarshal(raw, &r)
+	return memory.SetResult{Embedded: r.Embedded, EmbedWarning: r.EmbedWarning}, nil
+}
+
+func (b *Backend) Delete(ctx context.Context, scope store.MemoryScope, scopeID, key string) (bool, error) {
+	status, raw, err := b.request(ctx, http.MethodDelete, b.keysURL(scope, scopeID, key), nil)
+	if err != nil {
+		return false, err
+	}
+	switch status {
+	case http.StatusNoContent, http.StatusOK:
+		// The peer DELETE is idempotent and returns no existence signal, so we
+		// report existed=true on success. A remote backend cannot cheaply know
+		// whether a row was present without a racy pre-read.
+		return true, nil
+	default:
+		return false, statusErr("delete", status, raw)
+	}
+}
+
+func (b *Backend) List(ctx context.Context, scope store.MemoryScope, scopeID, prefix string, limit int) ([]store.MemoryEntry, bool, error) {
+	u := b.keysURL(scope, scopeID, "")
+	q := url.Values{}
+	if prefix != "" {
+		q.Set("prefix", prefix)
+	}
+	if limit > 0 {
+		q.Set("limit", strconv.Itoa(limit))
+	}
+	if len(q) > 0 {
+		u += "?" + q.Encode()
+	}
+	status, raw, err := b.request(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, false, err
+	}
+	if status != http.StatusOK {
+		return nil, false, statusErr("list", status, raw)
+	}
+	var r struct {
+		Entries   []store.MemoryEntry `json:"entries"`
+		Truncated bool                `json:"truncated"`
+	}
+	if uerr := json.Unmarshal(raw, &r); uerr != nil {
+		return nil, false, decodeErr(uerr)
+	}
+	return r.Entries, r.Truncated, nil
+}
+
+func (b *Backend) Search(ctx context.Context, scope store.MemoryScope, scopeID string, q memory.SearchQuery, rank memory.RankConfig, dedup memory.DedupConfig) (memory.SearchResult, error) {
+	req := searchReq{
+		Query:   q.QueryText,
+		Scope:   string(scope),
+		ScopeID: scopeID,
+		TopK:    q.TopK,
+		Rank:    rankPtr(rank),   // omitted when zero so the peer uses its default ranking
+		Dedup:   dedupPtr(dedup), // (a zero config forwarded as-is would degrade the peer's rank)
+	}
+	for _, s := range q.Sources {
+		req.Sources = append(req.Sources, string(s))
+	}
+	status, raw, err := b.request(ctx, http.MethodPost, b.base+"/v1/_memory/search", req)
+	if err != nil {
+		return memory.SearchResult{}, err
+	}
+	if status != http.StatusOK {
+		return memory.SearchResult{}, typedStatusErr("search", status, raw)
+	}
+	var r searchResp
+	if uerr := json.Unmarshal(raw, &r); uerr != nil {
+		return memory.SearchResult{}, decodeErr(uerr)
+	}
+	out := memory.SearchResult{
+		QueryEmbeddingDim: r.QueryEmbeddingDim,
+		Truncated:         r.Truncated,
+		// We forwarded the selector to a loomcycle peer, whose /v1/_memory/search
+		// applies it (same code path). Honest to report applied only when we
+		// actually asked (the "false is the zero value on purpose" contract).
+		SourcesApplied: len(q.Sources) > 0,
+	}
+	for _, e := range r.Entries {
+		var se store.MemorySearchEntry
+		se.Key = e.Key
+		se.Value = e.Value
+		se.Score = e.Score
+		se.EmbeddedWith.Provider = e.EmbeddedWith.Provider
+		se.EmbeddedWith.Model = e.EmbeddedWith.Model
+		// Reconstruct Origin so memory.Class(entry) reproduces the peer's kind:
+		// a "fact" needs a non-empty provenance origin; a "note" has none; a
+		// "document" is classified by its reserved key prefix regardless.
+		if e.Kind == "fact" {
+			se.Origin = "remote"
+		}
+		out.Entries = append(out.Entries, se)
+		out.RankScores = append(out.RankScores, e.RankScore)
+	}
+	return out, nil
+}
+
+func (b *Backend) Stats(ctx context.Context, scope store.MemoryScope) (store.MemoryEmbedStats, error) {
+	u := b.base + "/v1/_memory/embed_stats?scope=" + url.QueryEscape(string(scope))
+	status, raw, err := b.request(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return store.MemoryEmbedStats{}, err
+	}
+	if status != http.StatusOK {
+		return store.MemoryEmbedStats{}, typedStatusErr("stats", status, raw)
+	}
+	var r struct {
+		Models              []store.MemoryEmbedModelStats `json:"models"`
+		TotalEmbeddingBytes int64                         `json:"total_embedding_bytes"`
+	}
+	if uerr := json.Unmarshal(raw, &r); uerr != nil {
+		return store.MemoryEmbedStats{}, decodeErr(uerr)
+	}
+	return store.MemoryEmbedStats{Scope: scope, Models: r.Models, TotalEmbeddingBytes: r.TotalEmbeddingBytes}, nil
+}
+
+// keysURL builds .../v1/_memory/scopes/{scope}/{scope_id}/keys[/{key...}],
+// escaping each segment while PRESERVING the key's slashes (the peer's
+// {key...} route treats them as path separators).
+func (b *Backend) keysURL(scope store.MemoryScope, scopeID, key string) string {
+	sid := scopeID
+	if sid == "" {
+		// tenant scope forces scope_id="" server-side, but the route still
+		// needs a segment; any placeholder works.
+		sid = "_"
+	}
+	var sb strings.Builder
+	sb.WriteString(b.base)
+	sb.WriteString("/v1/_memory/scopes/")
+	sb.WriteString(url.PathEscape(string(scope)))
+	sb.WriteByte('/')
+	sb.WriteString(url.PathEscape(sid))
+	sb.WriteString("/keys")
+	if key != "" {
+		sb.WriteByte('/')
+		sb.WriteString(escapeKeyPath(key))
+	}
+	return sb.String()
+}
+
+func escapeKeyPath(key string) string {
+	parts := strings.Split(key, "/")
+	for i, p := range parts {
+		parts[i] = url.PathEscape(p)
+	}
+	return strings.Join(parts, "/")
+}
+
+// request performs one HTTP call and returns (status, body, transport-error).
+// The Authorization header carries the bearer; the URL never does, so a logged
+// error (which includes method + url) is secret-free.
+func (b *Backend) request(ctx context.Context, method, u string, body any) (int, []byte, error) {
+	var rdr io.Reader
+	if body != nil {
+		buf, err := json.Marshal(body)
+		if err != nil {
+			return 0, nil, fmt.Errorf("remote memory backend: encode request: %w", err)
+		}
+		rdr = bytes.NewReader(buf)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, u, rdr)
+	if err != nil {
+		return 0, nil, err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+	authz, err := b.authHeader(ctx)
+	if err != nil {
+		return 0, nil, err
+	}
+	if authz != "" {
+		req.Header.Set("Authorization", authz)
+	}
+	resp, err := b.http.Do(req)
+	if err != nil {
+		return 0, nil, fmt.Errorf("remote memory backend: %s %s: %w", method, u, err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 16<<20))
+	return resp.StatusCode, raw, nil
+}
+
+// --- wire shapes (mirror the peer's HTTP structs) ---
+
+type putBody struct {
+	Value      json.RawMessage `json:"value"`
+	Embed      bool            `json:"embed,omitempty"`
+	TTLSeconds int             `json:"ttl_seconds,omitempty"`
+}
+
+type searchReq struct {
+	Query   string              `json:"query"`
+	Scope   string              `json:"scope"`
+	ScopeID string              `json:"scope_id,omitempty"`
+	TopK    int                 `json:"top_k,omitempty"`
+	Rank    *memory.RankConfig  `json:"rank,omitempty"`
+	Dedup   *memory.DedupConfig `json:"dedup,omitempty"`
+	Sources []string            `json:"sources,omitempty"`
+}
+
+type searchResp struct {
+	Entries []struct {
+		Key          string          `json:"key"`
+		Value        json.RawMessage `json:"value"`
+		Score        float64         `json:"score"`
+		RankScore    float64         `json:"rank_score"`
+		EmbeddedWith struct {
+			Provider string `json:"provider"`
+			Model    string `json:"model"`
+		} `json:"embedded_with"`
+		Kind    string `json:"kind"`
+		ChunkID string `json:"chunk_id"`
+	} `json:"entries"`
+	QueryEmbeddingDim int  `json:"query_embedding_dim"`
+	Truncated         bool `json:"truncated"`
+}
+
+// --- error helpers ---
+
+func decodeErr(err error) error {
+	return fmt.Errorf("remote memory backend: decode response: %w", err)
+}
+
+// bodyErr extracts a {code,error} envelope from a peer error body.
+func bodyErr(raw []byte) (code, msg string) {
+	var e struct {
+		Code  string `json:"code"`
+		Error string `json:"error"`
+	}
+	if json.Unmarshal(raw, &e) == nil {
+		return e.Code, e.Error
+	}
+	return "", ""
+}
+
+// statusErr renders a generic error for a non-2xx (Get/Set/Delete/List): the
+// fallback wrapper degrades on any of these.
+func statusErr(op string, status int, raw []byte) error {
+	code, msg := bodyErr(raw)
+	if msg != "" {
+		return fmt.Errorf("remote memory backend: %s failed (%d %s): %s", op, status, code, msg)
+	}
+	return fmt.Errorf("remote memory backend: %s failed with status %d", op, status)
+}
+
+// typedStatusErr maps a peer {code} error to a *store.MemoryError so
+// Search/Stats honor the interface contract (vector_unsupported etc. render
+// unchanged when the backend is used without a fallback wrapper).
+func typedStatusErr(op string, status int, raw []byte) error {
+	code, msg := bodyErr(raw)
+	if code != "" {
+		if msg == "" {
+			msg = fmt.Sprintf("remote memory backend: %s: %s", op, code)
+		}
+		return &store.MemoryError{Code: code, Msg: msg}
+	}
+	return statusErr(op, status, raw)
+}
+
+// rankPtr / dedupPtr return nil for a zero config so the request omits it and
+// the peer applies its default ranking (a zero config forwarded verbatim would
+// zero every weight and produce a degenerate order).
+var (
+	zeroRankJSON, _  = json.Marshal(memory.RankConfig{})
+	zeroDedupJSON, _ = json.Marshal(memory.DedupConfig{})
+)
+
+func rankPtr(r memory.RankConfig) *memory.RankConfig {
+	if b, _ := json.Marshal(r); bytes.Equal(b, zeroRankJSON) {
+		return nil
+	}
+	return &r
+}
+
+func dedupPtr(d memory.DedupConfig) *memory.DedupConfig {
+	if b, _ := json.Marshal(d); bytes.Equal(b, zeroDedupJSON) {
+		return nil
+	}
+	return &d
+}

--- a/internal/memory/backends/remote/remote_test.go
+++ b/internal/memory/backends/remote/remote_test.go
@@ -1,0 +1,221 @@
+package remote
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	memory "github.com/denn-gubsky/loomcycle/internal/memory"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// stubPeer is a minimal in-memory loomcycle /v1/_memory/* surface for testing
+// the remote backend end-to-end over real HTTP.
+type stubPeer struct {
+	mux    *http.ServeMux
+	data   map[string]json.RawMessage // "scope/scope_id/key" -> value
+	lastAu string                     // last Authorization header seen
+}
+
+func newStubPeer() *stubPeer {
+	p := &stubPeer{mux: http.NewServeMux(), data: map[string]json.RawMessage{}}
+	key := func(r *http.Request) string {
+		return r.PathValue("scope") + "/" + r.PathValue("scope_id") + "/" + r.PathValue("key")
+	}
+	p.mux.HandleFunc("GET /v1/_memory/scopes/{scope}/{scope_id}/keys/{key...}", func(w http.ResponseWriter, r *http.Request) {
+		p.lastAu = r.Header.Get("Authorization")
+		v, ok := p.data[key(r)]
+		if !ok {
+			writeJSON(w, 404, map[string]string{"code": "not_found", "error": "no such key"})
+			return
+		}
+		writeJSON(w, 200, map[string]any{"scope": r.PathValue("scope"), "scope_id": r.PathValue("scope_id"),
+			"entry": map[string]any{"key": r.PathValue("key"), "value": v, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"}})
+	})
+	p.mux.HandleFunc("PUT /v1/_memory/scopes/{scope}/{scope_id}/keys/{key...}", func(w http.ResponseWriter, r *http.Request) {
+		p.lastAu = r.Header.Get("Authorization")
+		var body struct {
+			Value json.RawMessage `json:"value"`
+			Embed bool            `json:"embed"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		p.data[key(r)] = body.Value
+		writeJSON(w, 200, map[string]any{"scope": r.PathValue("scope"), "scope_id": r.PathValue("scope_id"),
+			"key": r.PathValue("key"), "embedded": body.Embed})
+	})
+	p.mux.HandleFunc("DELETE /v1/_memory/scopes/{scope}/{scope_id}/keys/{key...}", func(w http.ResponseWriter, r *http.Request) {
+		delete(p.data, key(r))
+		w.WriteHeader(204)
+	})
+	p.mux.HandleFunc("GET /v1/_memory/scopes/{scope}/{scope_id}/keys", func(w http.ResponseWriter, r *http.Request) {
+		prefix := r.URL.Query().Get("prefix")
+		base := r.PathValue("scope") + "/" + r.PathValue("scope_id") + "/"
+		entries := []map[string]any{}
+		for k, v := range p.data {
+			if !strings.HasPrefix(k, base) {
+				continue
+			}
+			bare := strings.TrimPrefix(k, base)
+			if prefix != "" && !strings.HasPrefix(bare, prefix) {
+				continue
+			}
+			entries = append(entries, map[string]any{"key": bare, "value": v,
+				"created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"})
+		}
+		writeJSON(w, 200, map[string]any{"scope": r.PathValue("scope"), "scope_id": r.PathValue("scope_id"),
+			"entries": entries, "truncated": false})
+	})
+	p.mux.HandleFunc("POST /v1/_memory/search", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, 200, map[string]any{"scope": "agent", "scope_id": "a1", "query_embedding_dim": 3, "truncated": false,
+			"entries": []map[string]any{{
+				"key": "k/1", "value": json.RawMessage(`{"v":1}`), "score": 0.9, "rank_score": 0.8,
+				"embedded_with": map[string]string{"provider": "p", "model": "m"}, "kind": "fact",
+			}}})
+	})
+	p.mux.HandleFunc("GET /v1/_memory/embed_stats", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, 200, map[string]any{"scope": r.URL.Query().Get("scope"), "tenant": "", "total_embedding_bytes": 123,
+			"models": []map[string]any{{"provider": "p", "model": "m", "dimension": 3, "row_count": 5}}})
+	})
+	return p
+}
+
+func writeJSON(w http.ResponseWriter, code int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func newTestBackend(t *testing.T, srv *httptest.Server, o Options) *Backend {
+	t.Helper()
+	o.BaseURL = srv.URL
+	if o.HTTPClient == nil {
+		o.HTTPClient = srv.Client() // unguarded — hits httptest loopback
+	}
+	b, err := New(o)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return b
+}
+
+func TestRemoteBackend_RoundTrip(t *testing.T) {
+	peer := newStubPeer()
+	srv := httptest.NewServer(peer.mux)
+	defer srv.Close()
+	b := newTestBackend(t, srv, Options{})
+	ctx := context.Background()
+
+	// Set (a multi-segment key exercises the slash-preserving URL escaping).
+	if _, err := b.Set(ctx, store.MemoryScopeAgent, "a1", "k/1", json.RawMessage(`{"v":1}`), memory.SetOptions{}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	// Get round-trips the value.
+	e, err := b.Get(ctx, store.MemoryScopeAgent, "a1", "k/1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(e.Value) != `{"v":1}` {
+		t.Errorf("Get value = %s, want {\"v\":1}", e.Value)
+	}
+	// Get on a missing key yields *store.ErrNotFound.
+	_, err = b.Get(ctx, store.MemoryScopeAgent, "a1", "missing")
+	var nf *store.ErrNotFound
+	if !errors.As(err, &nf) {
+		t.Errorf("Get(missing) err = %v, want *store.ErrNotFound", err)
+	}
+	// List returns the entry with its bare key.
+	entries, trunc, err := b.List(ctx, store.MemoryScopeAgent, "a1", "k/", 10)
+	if err != nil || trunc || len(entries) != 1 || entries[0].Key != "k/1" {
+		t.Fatalf("List = %+v trunc=%v err=%v", entries, trunc, err)
+	}
+	// Delete then Get -> not found.
+	if existed, derr := b.Delete(ctx, store.MemoryScopeAgent, "a1", "k/1"); derr != nil || !existed {
+		t.Fatalf("Delete existed=%v err=%v", existed, derr)
+	}
+	if _, err := b.Get(ctx, store.MemoryScopeAgent, "a1", "k/1"); !errors.As(err, &nf) {
+		t.Errorf("Get after Delete err = %v, want ErrNotFound", err)
+	}
+	// Stats maps the peer's model rows.
+	st, err := b.Stats(ctx, store.MemoryScopeAgent)
+	if err != nil || st.TotalEmbeddingBytes != 123 || len(st.Models) != 1 || st.Models[0].RowCount != 5 {
+		t.Fatalf("Stats = %+v err=%v", st, err)
+	}
+}
+
+func TestRemoteBackend_Search(t *testing.T) {
+	peer := newStubPeer()
+	srv := httptest.NewServer(peer.mux)
+	defer srv.Close()
+	b := newTestBackend(t, srv, Options{})
+
+	res, err := b.Search(context.Background(), store.MemoryScopeAgent, "a1",
+		memory.SearchQuery{QueryText: "q", TopK: 5, Sources: []memory.Source{memory.SourceFacts}},
+		memory.RankConfig{}, memory.DedupConfig{})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(res.Entries) != 1 || res.Entries[0].Key != "k/1" {
+		t.Fatalf("Search entries = %+v", res.Entries)
+	}
+	if res.Entries[0].Score != 0.9 || len(res.RankScores) != 1 || res.RankScores[0] != 0.8 {
+		t.Errorf("Search score/rank = %v / %v", res.Entries[0].Score, res.RankScores)
+	}
+	if res.QueryEmbeddingDim != 3 {
+		t.Errorf("QueryEmbeddingDim = %d, want 3", res.QueryEmbeddingDim)
+	}
+	// We forwarded a non-empty Sources to a loomcycle peer -> SourcesApplied.
+	if !res.SourcesApplied {
+		t.Errorf("SourcesApplied = false, want true (a selector was forwarded)")
+	}
+	// kind=fact reconstructs a non-empty Origin so the tool classifies it as a fact.
+	if res.Entries[0].Origin == "" {
+		t.Errorf("Origin empty; a fact should reconstruct a non-empty origin")
+	}
+}
+
+func TestRemoteBackend_KeyPerTenantAuth(t *testing.T) {
+	peer := newStubPeer()
+	srv := httptest.NewServer(peer.mux)
+	defer srv.Close()
+	var askedFor string
+	b := newTestBackend(t, srv, Options{
+		TenancyKind: "key_per_tenant",
+		EnvPattern:  "LOOMCYCLE_PEER_{tenant_id}_KEY",
+		KeyResolver: func(name string) (string, error) { askedFor = name; return "tok-" + name, nil },
+	})
+	ctx := tools.WithRunIdentity(context.Background(), tools.RunIdentityValue{TenantID: "acme"})
+
+	if _, err := b.Set(ctx, store.MemoryScopeAgent, "a1", "k", json.RawMessage(`1`), memory.SetOptions{}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if askedFor != "LOOMCYCLE_PEER_acme_KEY" {
+		t.Errorf("resolver asked for %q, want LOOMCYCLE_PEER_acme_KEY", askedFor)
+	}
+	if peer.lastAu != "Bearer tok-LOOMCYCLE_PEER_acme_KEY" {
+		t.Errorf("peer saw Authorization %q", peer.lastAu)
+	}
+}
+
+func TestRemoteBackend_DeadPeerErrors(t *testing.T) {
+	// A closed server -> every op returns a transport error (which the fallback
+	// wrapper degrades on). 127.0.0.1:1 is not listening.
+	b, err := New(Options{BaseURL: "http://127.0.0.1:1", HTTPClient: http.DefaultClient})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, gerr := b.Get(context.Background(), store.MemoryScopeAgent, "a1", "k"); gerr == nil {
+		t.Errorf("Get against a dead peer returned nil error")
+	}
+}
+
+func TestRemoteBackend_RejectsSharedPrefix(t *testing.T) {
+	_, err := New(Options{BaseURL: "http://peer", TenancyKind: "shared_key_with_prefix", HTTPClient: http.DefaultClient})
+	if err == nil || !strings.Contains(err.Error(), "shared_key_with_prefix") {
+		t.Errorf("New(shared_key_with_prefix) err = %v, want a refusal", err)
+	}
+}

--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -14,7 +16,10 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/lookup"
 	memrank "github.com/denn-gubsky/loomcycle/internal/memory"
+	"github.com/denn-gubsky/loomcycle/internal/memory/backends/fallback"
 	"github.com/denn-gubsky/loomcycle/internal/memory/backends/inprocess"
+	"github.com/denn-gubsky/loomcycle/internal/memory/backends/remote"
+	"github.com/denn-gubsky/loomcycle/internal/netguard"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/redact"
 	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
@@ -159,10 +164,71 @@ func (m *Memory) backend(ctx context.Context) memrank.Backend {
 	switch def.Kind {
 	case "", "inprocess":
 		return inprocess.New(m.Store, m.Embedder)
+	case "remote":
+		rb, err := m.newRemoteBackend(def)
+		if err != nil {
+			// A misconfigured remote def must not fail the agent's run: log and
+			// serve locally (same degrade posture as the unknown-kind arm).
+			log.Printf("memory: memory_backend %q (kind=remote) is misconfigured: %v — using in-process fallback", name, err)
+			return m.defaultBackend()
+		}
+		// fallback_on_error: inprocess wraps the remote so an unreachable peer
+		// degrades to local memory per-op instead of failing the run.
+		if def.FallbackOnError == "inprocess" {
+			return fallback.New(rb, m.defaultBackend(), log.Printf)
+		}
+		return rb
 	default:
 		log.Printf("memory: memory_backend %q has unknown kind %q — using in-process fallback", name, def.Kind)
 		return m.defaultBackend()
 	}
+}
+
+// remoteBackendTimeout bounds each proxied call to a peer instance.
+const remoteBackendTimeout = 30 * time.Second
+
+// newRemoteBackend builds a remote memory backend from a resolved def. The
+// SSRF-guarded HTTP client and the credential-env allowlist are supplied here
+// (the remote package stays free of config/netguard/os coupling). The peer's
+// own host is added to the guarded client's private-host allowlist — the
+// operator authored this base_url, so reaching it on a private network
+// (sibling replica / tailnet) is an explicit trust decision; redirects to any
+// OTHER private address stay blocked.
+func (m *Memory) newRemoteBackend(def config.MemoryBackend) (memrank.Backend, error) {
+	host := ""
+	if u, err := url.Parse(def.Config.BaseURL); err == nil {
+		host = u.Hostname()
+	}
+	var allowlist []string
+	if host != "" {
+		allowlist = []string{host}
+	}
+	client := netguard.NewGuardedClient(remoteBackendTimeout, allowlist)
+	return remote.New(remote.Options{
+		BaseURL:          def.Config.BaseURL,
+		APIVersion:       def.Config.APIVersion,
+		DefaultAPIKeyEnv: def.Config.APIKeyEnv,
+		TenancyKind:      def.TenancyStrategy.Kind,
+		EnvPattern:       def.TenancyStrategy.EnvPattern,
+		KeyResolver:      resolveCredentialEnv,
+		HTTPClient:       client,
+	})
+}
+
+// resolveCredentialEnv resolves an env-var NAME to its value, gated by the SAME
+// allowlist the def validator uses — so a remote backend can never be pointed
+// at one of loomcycle's own infrastructure secrets (e.g. LOOMCYCLE_AUTH_TOKEN),
+// even if a def author named one. Returns only the env-var NAME in errors,
+// never the value (the fallback wrapper logs these).
+func resolveCredentialEnv(name string) (string, error) {
+	if !config.EnvNameCredentialSafe(name) {
+		return "", fmt.Errorf("api_key_env %q is not an allowed credential env var", name)
+	}
+	v := os.Getenv(name)
+	if v == "" {
+		return "", fmt.Errorf("api_key_env %q is not set", name)
+	}
+	return v, nil
 }
 
 // memoryLayer resolves the MemoryLayer capability for the agent's configured

--- a/internal/tools/builtin/memorybackenddef.go
+++ b/internal/tools/builtin/memorybackenddef.go
@@ -535,8 +535,30 @@ func validateMemoryBackendDef(def mergedMemoryBackendDef) error {
 				"(must be LOOMCYCLE_-prefixed or a known third-party key, and must not be one "+
 				"of loomcycle's own infrastructure secrets)", def.Config.APIKeyEnv)
 		}
+	case "remote":
+		// A remote backend (RFC CD Part B) HTTP-proxies to a peer's
+		// /v1/_memory/*. base_url is required and dialed; api_key_env is
+		// resolved and SENT to it, so both are validated at the door (the same
+		// checks the inprocess arm applies defensively, here load-bearing).
+		if def.Config.BaseURL == "" {
+			return fmt.Errorf("config.base_url is required for kind %q", def.Kind)
+		}
+		if err := requireHTTPURL("config.base_url", def.Config.BaseURL); err != nil {
+			return err
+		}
+		if def.Config.APIKeyEnv != "" && !config.EnvNameCredentialSafe(def.Config.APIKeyEnv) {
+			return fmt.Errorf("config.api_key_env %q is not an allowed credential env var "+
+				"(must be LOOMCYCLE_-prefixed or a known third-party key, and must not be one "+
+				"of loomcycle's own infrastructure secrets)", def.Config.APIKeyEnv)
+		}
+		// The peer search API has no key-prefix parameter, so a namespaced
+		// search cannot be scoped to one tenant — refuse the combination at the
+		// door rather than degrade at runtime.
+		if def.TenancyStrategy.Kind == "shared_key_with_prefix" {
+			return fmt.Errorf("kind=remote does not support tenancy_strategy=shared_key_with_prefix (use key_per_tenant): the peer search API has no key-prefix parameter")
+		}
 	default:
-		return fmt.Errorf("unknown kind %q (must be one of: inprocess)", def.Kind)
+		return fmt.Errorf("unknown kind %q (must be one of: inprocess, remote)", def.Kind)
 	}
 
 	// tenancy_strategy.kind ∈ {"", "key_per_tenant", "shared_key_with_prefix"}.

--- a/internal/tools/builtin/memorybackenddef_test.go
+++ b/internal/tools/builtin/memorybackenddef_test.go
@@ -135,6 +135,42 @@ func TestMemoryBackendDefTool_CreateRefusesUnknownKind(t *testing.T) {
 	}
 }
 
+// TestMemoryBackendDefTool_CreateRemote pins that kind:remote (RFC CD Part B)
+// is now an accepted, authorable backend kind with a base_url + api_key_env.
+func TestMemoryBackendDefTool_CreateRemote(t *testing.T) {
+	tool, ctx, cleanup := memoryBackendDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"peerb","overlay":{"kind":"remote","config":{"base_url":"https://peer.example:8787","api_key_env":"LOOMCYCLE_PEER_KEY"},"fallback_on_error":"inprocess"}}`))
+	if res.IsError {
+		t.Fatalf("create kind=remote should succeed; got %s", res.Text)
+	}
+	def := decodeResult(t, res.Text)["definition"].(map[string]any)
+	if def["kind"] != "remote" {
+		t.Errorf("kind = %v, want remote", def["kind"])
+	}
+}
+
+func TestMemoryBackendDefTool_CreateRemoteRefusesMissingBaseURL(t *testing.T) {
+	tool, ctx, cleanup := memoryBackendDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"peerb","overlay":{"kind":"remote","config":{"api_key_env":"LOOMCYCLE_PEER_KEY"}}}`))
+	if !res.IsError || !strings.Contains(res.Text, "base_url is required") {
+		t.Fatalf("kind=remote without base_url should be refused; got %s", res.Text)
+	}
+}
+
+func TestMemoryBackendDefTool_CreateRemoteRefusesSharedPrefixTenancy(t *testing.T) {
+	tool, ctx, cleanup := memoryBackendDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"peerb","overlay":{"kind":"remote","config":{"base_url":"https://peer.example:8787"},"tenancy_strategy":{"kind":"shared_key_with_prefix","prefix_pattern":"t-{tenant_id}-"}}}`))
+	if !res.IsError || !strings.Contains(res.Text, "shared_key_with_prefix") {
+		t.Fatalf("kind=remote + shared_key_with_prefix should be refused; got %s", res.Text)
+	}
+}
+
 func TestMemoryBackendDefTool_CreateRefusesTenancyPatternWithoutTenantID(t *testing.T) {
 	tool, ctx, cleanup := memoryBackendDefFixture(t)
 	defer cleanup()


### PR DESCRIPTION
## Why

The `MemoryBackend` substrate has been remote-**ready** since RFC I (its config carries `base_url` / `api_key_env` / `tenancy_strategy`) but had **no live implementation** — the only external backend (mem9) was removed, the factory degraded any non-inprocess kind, and the validator refused them. **RFC CD Part B** fills that socket so one loomcycle instance can use *another's* memory as a backend.

The key insight (from RFC K): unlike the LLM-extract memory *products* RFC K surveyed, a **peer loomcycle is a faithful flat KV+vector store** (synchronous `Set→Get`, real `Stats`, real vector `Search`), so it plugs in behind the same six `memory.Backend` methods with **no paradigm mismatch**. This is the honest implementation that seam was designed for.

## What

- **`internal/memory/backends/remote`** — a `memory.Backend` that HTTP-proxies the six ops to a peer's `/v1/_memory/*` (Get/Set/Delete/List → the keys routes, Search → `POST /v1/_memory/search`, Stats → `embed_stats`). The **peer embeds server-side**; this backend never touches a local Embedder. Multi-segment keys are URL-escaped per segment with slashes preserved. Connection policy (the guarded client, the credential resolver) is **injected by the factory**, so the package is free of config/netguard/os coupling and unit-testable against an httptest peer.
- **Factory wiring** (`internal/tools/builtin/memory.go`): `case "remote"` builds an **SSRF-guarded** client (`netguard`) whose private-host allowlist is the **peer's own configured host** (an explicit operator trust decision — reaching a sibling replica / tailnet peer is allowed; redirects to any *other* private address stay blocked); resolves `api_key_env` through the **same credential allowlist the validator uses** (so a def can never be pointed at `LOOMCYCLE_AUTH_TOKEN`); and wraps the remote in the existing (until now **constructor-less**) `fallback` backend when `fallback_on_error: inprocess`, so an unreachable peer degrades to local memory per-op instead of failing the run.
- **Validation**: the def validator + the static-config validator accept `remote` (base_url required + HTTP; api_key_env allowlisted). `shared_key_with_prefix` is **refused for `kind=remote`** — the peer search API has no key-prefix parameter, so a namespaced search couldn't be tenant-scoped and would leak rows; `""` and `key_per_tenant` (the RFC's recommended 1:1 shape) are supported.

## Scope note

This PR's first commit (`fix(api): list judge_fact …`) greens a **pre-existing drift on main**: #1003 added a `judge_fact` Document op after #1004's OpenAPI spec was authored, and the two merged without seeing each other — leaving `TestOpenAPISpec_DocumentOpsMatchTool` red. One-line spec addition, kept as its own commit.

## Tested

- `internal/memory/backends/remote`: round-trips Set/Get/List/Delete/Stats + Search against an httptest peer; verifies `key_per_tenant` env-name selection reaches the peer as a `Bearer`; a dead peer errors (so the fallback wrapper degrades); `New` refuses `shared_key_with_prefix`.
- Three new validator tests: remote accept, missing-base_url refusal, shared-prefix refusal.
- **Manual (live peer):** curled a running loomcycle's `/v1/_memory` — `PUT`/`GET`/`LIST`/`DELETE` response shapes match the client's parse structs, and a multi-segment key (`k/1`) round-trips through the URL escaping.
- Full suite: `go test ./...` → **0 failures, 88 packages ok**. gofmt + vet clean.

## Follow-ons (deferred, noted in the RFC)

`MemoryLayer` (add/recall) proxying (no HTTP route yet); a proactive health-check loop (the per-op fallback already covers unreachability); `shared_key_with_prefix` (needs a search key-prefix param).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD