### PR TITLE
feat: opt-in memory/document change feed via SSE (RFC CD Part C — subscribe)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -85,6 +85,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
 	"github.com/denn-gubsky/loomcycle/internal/steer"
 	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/cdc"
 	storepostgres "github.com/denn-gubsky/loomcycle/internal/store/postgres"
 	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
 	"github.com/denn-gubsky/loomcycle/internal/usage"
@@ -139,6 +140,43 @@ var (
 // internal/store/postgres/postgres.go for what gets logged.
 func channelDebugEnabled() bool {
 	return os.Getenv("LOOMCYCLE_CHANNEL_DEBUG") == "1"
+}
+
+// memoryChangesEnabled reports whether the RFC CD Part C change-data-capture
+// feed is on. Default off — when off the store is NOT wrapped by the CDC
+// decorator, so the default deployment is byte-identical and pays nothing.
+func memoryChangesEnabled() bool {
+	return os.Getenv("LOOMCYCLE_MEMORY_CHANGES_ENABLED") == "1"
+}
+
+// memoryChangesRetention is how long change-feed rows are kept before the
+// retention sweeper prunes them. Default 24h; override with
+// LOOMCYCLE_MEMORY_CHANGES_RETENTION_HOURS.
+func memoryChangesRetention() time.Duration {
+	if h := os.Getenv("LOOMCYCLE_MEMORY_CHANGES_RETENTION_HOURS"); h != "" {
+		if n, err := strconv.Atoi(h); err == nil && n > 0 {
+			return time.Duration(n) * time.Hour
+		}
+	}
+	return 24 * time.Hour
+}
+
+// asPostgresStore unwraps any store decorators (the CDC wrapper) and returns
+// the concrete *storepostgres.Store when the backend is Postgres. Cluster
+// coordination needs the concrete type, so the CDC wrapper must be transparent
+// to it.
+func asPostgresStore(s store.Store) (*storepostgres.Store, bool) {
+	for s != nil {
+		if pg, ok := s.(*storepostgres.Store); ok {
+			return pg, true
+		}
+		u, ok := s.(interface{ Unwrap() store.Store })
+		if !ok {
+			return nil, false
+		}
+		s = u.Unwrap()
+	}
+	return nil, false
 }
 
 // backfillAgentDefSignFn computes the v0.9.x content_sha256 for an
@@ -1344,6 +1382,14 @@ func main() {
 		log.Fatalf("store: %v", err)
 	}
 	defer storeCloser()
+	// RFC CD Part C — when the change-data-capture feed is enabled, wrap the
+	// store so every memory/document write emits a value-free change row. Off by
+	// default → the store is unwrapped and the path is byte-identical. Cluster
+	// coord below unwraps via asPostgresStore to reach the concrete backend.
+	if memoryChangesEnabled() && storeIface != nil {
+		storeIface = cdc.Wrap(storeIface, log.Printf)
+		log.Printf("memory: change-data-capture feed ENABLED (LOOMCYCLE_MEMORY_CHANGES_ENABLED=1)")
+	}
 
 	// v0.9.x content_sha256 backfill — populate the new column on
 	// every NULL/empty row left over from a pre-v0.9.x upgrade OR
@@ -1425,7 +1471,7 @@ func main() {
 	// the pool fields and the retry behavior is unchanged. The
 	// PoolStatsFn capture lives inside execSubscribe at the case
 	// <-waker: arm — see internal/tools/builtin/channel.go.
-	if pg, ok := storeIface.(*storepostgres.Store); ok && pg != nil {
+	if pg, ok := asPostgresStore(storeIface); ok && pg != nil {
 		channelTool.PoolStatsFn = func() (total, acquired, idle int32) {
 			st := pg.Pool().Stat()
 			return st.TotalConns(), st.AcquiredConns(), st.IdleConns()
@@ -2236,7 +2282,7 @@ func main() {
 	// (only one replica sweeps per tick). v0.12.4 Phase 5.
 	var advisoryLock *coord.AdvisoryLock
 	if cfg.Env.ReplicaID != "" {
-		pgStore, ok := storeIface.(*storepostgres.Store)
+		pgStore, ok := asPostgresStore(storeIface)
 		if !ok {
 			log.Fatalf("coord: REPLICA_ID set but store is not *storepostgres.Store (openStore guard bypassed?)")
 		}
@@ -2546,6 +2592,25 @@ func main() {
 		log.Printf("memory: sweeper disabled (LOOMCYCLE_MEMORY_SWEEP_MS=0 or no Store)")
 	}
 
+	// RFC CD Part C — prune the change-feed table so the opt-in feed stays
+	// bounded. Only when the feed is enabled; the DELETE is idempotent and
+	// advisory-gated so one replica prunes per tick.
+	if memoryChangesEnabled() && storeIface != nil {
+		window := memoryChangesRetention()
+		go runAdvisoryGatedSweeper(bgCtx, time.Hour, advisoryLock, coord.LockKeyMemoryChangesSweeper, "memory_changes",
+			func(ctx context.Context) {
+				pruned, err := storeIface.PruneMemoryChanges(ctx, time.Now().Add(-window))
+				if err != nil {
+					log.Printf("memory_changes prune: %v", err)
+					return
+				}
+				if pruned > 0 {
+					log.Printf("memory_changes prune: deleted %d row(s) older than %s", pruned, window)
+				}
+			})
+		log.Printf("memory: change-feed retention sweeper interval=1h window=%s", window)
+	}
+
 	// Dead-link reconciliation: the only layer that actually COLLECTS chunk
 	// references nothing can reach.
 	//
@@ -2661,7 +2726,7 @@ func main() {
 		// mode; single-replica mode keeps the v0.11.x in-process path
 		// byte-identical.
 		if cfg.Env.ReplicaID != "" {
-			pgStoreForPause, ok := storeIface.(*storepostgres.Store)
+			pgStoreForPause, ok := asPostgresStore(storeIface)
 			if !ok {
 				log.Fatalf("coord: pause cluster wiring requires Postgres store (REPLICA_ID set + non-Postgres store — should have been caught by openStore)")
 			}

--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -896,6 +896,15 @@ func memberCarveOut(method, path string) bool {
 		return true
 	case strings.HasPrefix(path, "/v1/hooks"):
 		return true
+	// RFC CD Part C — the memory/document CHANGE FEED is substrate:tenant-only,
+	// NOT member-accessible (locked decision): the feed exposes the tenant's
+	// write pattern (a metadata side-channel) and is operator observability, not
+	// member data. Both the /v1/_memory/ prefix (ScopeTenant) and the
+	// /v1/_document/changes route (ScopeTenant via isTenantConfinedDefPath) would
+	// otherwise be member-accessible; carve them out so a non-isolated member is
+	// refused.
+	case path == "/v1/_memory/changes" || path == "/v1/_document/changes":
+		return true
 	}
 	return false
 }
@@ -943,6 +952,13 @@ func isTenantConfinedDefPath(path string) bool {
 	// variable {chunk_id} suffix, so it needs a prefix match (the family list
 	// below is exact-match). Same ScopeTenant posture as /v1/_document itself.
 	if strings.HasPrefix(path, "/v1/_document/asset/") {
+		return true
+	}
+	// RFC CD Part C — the document change feed lives under /v1/_document with a
+	// /changes suffix, so (like the asset GET) it needs a prefix match; the
+	// family list below is exact-match. Same ScopeTenant posture as /v1/_document
+	// (and it is carved out of member access — see memberCarveOut).
+	if strings.HasPrefix(path, "/v1/_document/changes") {
 		return true
 	}
 	for _, fam := range []string{

--- a/internal/api/http/memory_changes.go
+++ b/internal/api/http/memory_changes.go
@@ -1,0 +1,88 @@
+package http
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// memory_changes.go serves the RFC CD Part C change-data-capture feed as SSE.
+//
+// GET /v1/_memory/changes?since=<seq>   — memory.* changes
+// GET /v1/_document/changes?since=<seq> — document.* changes
+//
+// Value-free: each frame names WHAT changed; the subscriber pulls the current
+// value via the data API. Tenant-scoped (the feed is read for the caller's OWN
+// tenant only) and — per the locked decision — substrate:tenant, NOT
+// member-accessible (see memberCarveOut). The table is only ever populated when
+// LOOMCYCLE_MEMORY_CHANGES_ENABLED; with the feed off this stream just idles.
+
+const memoryChangesPollInterval = 250 * time.Millisecond
+
+func (s *Server) handleMemoryChanges(w http.ResponseWriter, r *http.Request) {
+	s.streamMemoryChanges(w, r, false)
+}
+
+func (s *Server) handleDocumentChanges(w http.ResponseWriter, r *http.Request) {
+	s.streamMemoryChanges(w, r, true)
+}
+
+// streamMemoryChanges tails the change feed for the caller's tenant, emitting
+// only the family it was asked for (documents vs memory). The cursor advances
+// over EVERY row so the two families stay consistent; filtering happens on the
+// way out.
+func (s *Server) streamMemoryChanges(w http.ResponseWriter, r *http.Request, documents bool) {
+	if s.store == nil {
+		http.Error(w, "change feed requires a persistence backend", http.StatusServiceUnavailable)
+		return
+	}
+	tenantID := tenantFromCtx(r.Context())
+
+	var cursor int64
+	if q := r.URL.Query().Get("since"); q != "" {
+		if n, err := strconv.ParseInt(q, 10, 64); err == nil && n >= 0 {
+			cursor = n
+		}
+	}
+
+	stream, ok := newSSE(w)
+	if !ok {
+		http.Error(w, "server does not support streaming on this transport", http.StatusInternalServerError)
+		return
+	}
+	stream.start()
+	stream.startKeepalive(r.Context(), s.cfg.Env.SSEKeepaliveInterval)
+
+	ticker := time.NewTicker(memoryChangesPollInterval)
+	defer ticker.Stop()
+	for {
+		// Drain everything past the cursor, then wait for the next tick.
+		for {
+			changes, err := s.store.GetMemoryChangesSince(r.Context(), tenantID, cursor, 500)
+			if err != nil {
+				break
+			}
+			for _, ch := range changes {
+				cursor = ch.Seq
+				if isDocumentChange(ch.Type) != documents {
+					continue
+				}
+				stream.sendRaw("change", ch)
+			}
+			if len(changes) < 500 {
+				break
+			}
+		}
+		select {
+		case <-r.Context().Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+func isDocumentChange(t store.MemoryChangeType) bool {
+	return t == store.DocumentChangeUpdated || t == store.DocumentChangeDeleted
+}

--- a/internal/api/http/memory_changes_test.go
+++ b/internal/api/http/memory_changes_test.go
@@ -1,0 +1,75 @@
+package http
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+)
+
+// TestMemoryChanges_AuthGate pins the locked decision: both change feeds are
+// substrate:tenant AND carved out of member access (not member-accessible).
+func TestMemoryChanges_AuthGate(t *testing.T) {
+	for _, p := range []string{"/v1/_memory/changes", "/v1/_document/changes"} {
+		if got := requiredScopeFor(http.MethodGet, p); got != auth.ScopeTenant {
+			t.Errorf("%s scope = %q, want %s", p, got, auth.ScopeTenant)
+		}
+		if tenantMemberAccessible(http.MethodGet, p) {
+			t.Errorf("%s must NOT be member-accessible (memberCarveOut)", p)
+		}
+	}
+}
+
+// TestMemoryChanges_SSEStreamsAndFilters seeds one memory + one document change
+// and asserts each feed streams only its own family (tenant-scoped).
+func TestMemoryChanges_SSEStreamsAndFilters(t *testing.T) {
+	st, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	ctx := context.Background()
+	if err := st.AppendMemoryChange(ctx, store.MemoryChange{Type: store.MemoryChangeSet, Scope: store.MemoryScopeAgent, ScopeID: "a1", Key: "k1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AppendMemoryChange(ctx, store.MemoryChange{Type: store.DocumentChangeUpdated, Scope: store.MemoryScopeAgent, ScopeID: "a1", ChunkID: "CID"}); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := &Server{store: st, cfg: &config.Config{}}
+
+	mem := runSSEOnce(t, srv.handleMemoryChanges, "/v1/_memory/changes")
+	if !strings.Contains(mem, `"memory.set"`) || !strings.Contains(mem, `"k1"`) {
+		t.Errorf("memory feed missing its change: %s", mem)
+	}
+	if strings.Contains(mem, `"document.chunk.updated"`) {
+		t.Errorf("memory feed leaked a document change: %s", mem)
+	}
+
+	doc := runSSEOnce(t, srv.handleDocumentChanges, "/v1/_document/changes")
+	if !strings.Contains(doc, `"document.chunk.updated"`) || !strings.Contains(doc, `"CID"`) {
+		t.Errorf("document feed missing its change: %s", doc)
+	}
+	if strings.Contains(doc, `"memory.set"`) {
+		t.Errorf("document feed leaked a memory change: %s", doc)
+	}
+}
+
+// runSSEOnce invokes an SSE handler with a short-lived context: it drains the
+// already-present changes on entry, then returns when the context times out.
+func runSSEOnce(t *testing.T, h http.HandlerFunc, path string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 350*time.Millisecond)
+	defer cancel()
+	req := httptest.NewRequest(http.MethodGet, path, nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	h(rec, req)
+	return rec.Body.String()
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -3051,6 +3051,11 @@ func (s *Server) Mux() http.Handler {
 	// AND document-chunk bodies. Admin-only via the /v1/_* catch-all (a later
 	// phase re-gates the /v1/_memory/* family to the tenant axis).
 	mux.Handle("POST /v1/_memory/search", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleMemorySearch))))
+	// RFC CD Part C — the memory/document change-data-capture SSE feed
+	// (substrate:tenant, member-carved-out; only populated when
+	// LOOMCYCLE_MEMORY_CHANGES_ENABLED).
+	mux.Handle("GET /v1/_memory/changes", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleMemoryChanges))))
+	mux.Handle("GET /v1/_document/changes", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleDocumentChanges))))
 	mux.Handle("POST /v1/_memory/backfill_embeddings", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleMemoryBackfillEmbeddings))))
 	// RFC BU phase 4b — generate vision descriptions for image chunks that have
 	// none, then re-embed so they become searchable. Left on the /v1/_* catch-all

--- a/internal/coord/advisory_lock.go
+++ b/internal/coord/advisory_lock.go
@@ -110,13 +110,16 @@ func (l *AdvisoryLock) TryRun(ctx context.Context, lockKey int64, fn func(ctx co
 // the var-block size in init(). Never reuse a key for a different
 // sweeper.
 var (
-	LockKeyHeartbeatSweeper    int64
-	LockKeyMemorySweeper       int64
-	LockKeyChannelsSweeper     int64
-	LockKeyInterruptsSweeper   int64
-	LockKeyMetricsSweeper      int64
-	LockKeyDynamicAgentSweeper int64
-	LockKeyReplicasSweeper     int64
+	LockKeyHeartbeatSweeper  int64
+	LockKeyMemorySweeper     int64
+	LockKeyChannelsSweeper   int64
+	LockKeyInterruptsSweeper int64
+	LockKeyMetricsSweeper    int64
+	// LockKeyMemoryChangesSweeper gates the RFC CD Part C change-feed retention
+	// prune so one replica per cluster prunes per tick.
+	LockKeyMemoryChangesSweeper int64
+	LockKeyDynamicAgentSweeper  int64
+	LockKeyReplicasSweeper      int64
 	// LockKeyResumePausedRuns gates the one-shot boot-time re-dispatch of
 	// pause_state='paused' runs (F42 / RFC X Phase 2) so exactly ONE replica
 	// resurrects each paused run's loop in a cluster — not a periodic sweep.
@@ -181,6 +184,7 @@ func init() {
 	LockKeyChannelsSweeper = fnvKey("channels_sweeper")
 	LockKeyInterruptsSweeper = fnvKey("interrupts_sweeper")
 	LockKeyMetricsSweeper = fnvKey("metrics_sweeper")
+	LockKeyMemoryChangesSweeper = fnvKey("memory_changes_sweeper")
 	LockKeyDynamicAgentSweeper = fnvKey("dynamic_agent_sweeper")
 	LockKeyReplicasSweeper = fnvKey("replicas_sweeper")
 	LockKeyResumePausedRuns = fnvKey("resume_paused_runs")

--- a/internal/store/cdc/cdc.go
+++ b/internal/store/cdc/cdc.go
@@ -1,0 +1,127 @@
+// Package cdc wraps a store.Store to emit a value-free change-data-capture row
+// after each successful memory/document write (RFC CD Part C).
+//
+// It is applied ONLY when LOOMCYCLE_MEMORY_CHANGES_ENABLED. When the feed is
+// off the raw store is used directly and this package is never in the path, so
+// the default deployment pays nothing and is byte-identical to before.
+//
+// The decorator embeds store.Store, so every method it does NOT override is
+// promoted unchanged — it overrides only the content-write methods, delegates
+// to the wrapped store, and on success appends a change row. Emit is
+// BEST-EFFORT: an append failure is logged, never returned, so a lagging feed
+// can never fail the write it describes (the feed is advisory; a subscriber
+// reconciles by re-reading via the data API).
+package cdc
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// docChunkPrefix is the reserved key prefix under which Document chunk bodies
+// live in the memory keyspace. Kept in sync with memory.DocumentChunkKeyPrefix
+// (pinned by TestDocChunkPrefix_MatchesMemory) so this package need not import
+// the whole memory package just for a constant.
+const docChunkPrefix = "doc.chunk:"
+
+// Store decorates a store.Store with CDC emission on writes.
+type Store struct {
+	store.Store
+	logf func(format string, args ...any)
+}
+
+// Wrap returns a CDC-emitting store over base. logf may be nil (append
+// failures then go unlogged — used by tests).
+func Wrap(base store.Store, logf func(format string, args ...any)) *Store {
+	return &Store{Store: base, logf: logf}
+}
+
+var _ store.Store = (*Store)(nil)
+
+// Unwrap returns the wrapped store. Call sites that need a CONCRETE backend
+// (e.g. the postgres cluster-coordination wiring type-asserts *postgres.Store)
+// must unwrap through this — see cmd/loomcycle's asPostgresStore.
+func (c *Store) Unwrap() store.Store { return c.Store }
+
+func (c *Store) MemorySet(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string, value json.RawMessage, ttl time.Duration) error {
+	err := c.Store.MemorySet(ctx, tenantID, scope, scopeID, key, value, ttl)
+	if err == nil {
+		c.emitKey(ctx, tenantID, scope, scopeID, key, false)
+	}
+	return err
+}
+
+func (c *Store) MemorySetProvenance(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string, value json.RawMessage, ttl time.Duration, prov store.MemoryProvenance) error {
+	err := c.Store.MemorySetProvenance(ctx, tenantID, scope, scopeID, key, value, ttl, prov)
+	if err == nil {
+		c.emitKey(ctx, tenantID, scope, scopeID, key, false)
+	}
+	return err
+}
+
+func (c *Store) MemoryIncrement(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string, delta int64, ttl time.Duration) (int64, error) {
+	v, err := c.Store.MemoryIncrement(ctx, tenantID, scope, scopeID, key, delta, ttl)
+	if err == nil {
+		c.emitKey(ctx, tenantID, scope, scopeID, key, false)
+	}
+	return v, err
+}
+
+func (c *Store) MemoryDelete(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string) (bool, error) {
+	existed, err := c.Store.MemoryDelete(ctx, tenantID, scope, scopeID, key)
+	if err == nil && existed {
+		c.emitKey(ctx, tenantID, scope, scopeID, key, true)
+	}
+	return existed, err
+}
+
+func (c *Store) MemoryDeleteScope(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID string) (int, error) {
+	n, err := c.Store.MemoryDeleteScope(ctx, tenantID, scope, scopeID)
+	if err == nil && n > 0 {
+		c.emit(ctx, store.MemoryChange{
+			TenantID: tenantID, Type: store.MemoryChangeScopeDeleted, Scope: scope, ScopeID: scopeID,
+		})
+	}
+	return n, err
+}
+
+func (c *Store) MemoryAtomicUpdate(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string, ttl time.Duration, reducer func(current json.RawMessage) (json.RawMessage, error)) (json.RawMessage, error) {
+	v, err := c.Store.MemoryAtomicUpdate(ctx, tenantID, scope, scopeID, key, ttl, reducer)
+	if err == nil {
+		c.emitKey(ctx, tenantID, scope, scopeID, key, false)
+	}
+	return v, err
+}
+
+// emitKey classifies a keyed write as a document-chunk change (reserved
+// doc.chunk: prefix) or a plain memory change, and appends it.
+func (c *Store) emitKey(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string, isDelete bool) {
+	ch := store.MemoryChange{TenantID: tenantID, Scope: scope, ScopeID: scopeID}
+	if chunkID, ok := strings.CutPrefix(key, docChunkPrefix); ok {
+		ch.ChunkID = chunkID
+		if isDelete {
+			ch.Type = store.DocumentChangeDeleted
+		} else {
+			ch.Type = store.DocumentChangeUpdated
+		}
+	} else {
+		ch.Key = key
+		if isDelete {
+			ch.Type = store.MemoryChangeDelete
+		} else {
+			ch.Type = store.MemoryChangeSet
+		}
+	}
+	c.emit(ctx, ch)
+}
+
+func (c *Store) emit(ctx context.Context, ch store.MemoryChange) {
+	if err := c.Store.AppendMemoryChange(ctx, ch); err != nil && c.logf != nil {
+		// The write already succeeded; a failed append only lags the feed.
+		c.logf("cdc: append %s change failed (feed lag, write succeeded): %v", ch.Type, err)
+	}
+}

--- a/internal/store/cdc/cdc_test.go
+++ b/internal/store/cdc/cdc_test.go
@@ -1,0 +1,117 @@
+package cdc
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/memory"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+)
+
+// TestDocChunkPrefix_MatchesMemory pins the local constant against the
+// canonical one so the classification can't silently drift.
+func TestDocChunkPrefix_MatchesMemory(t *testing.T) {
+	if docChunkPrefix != memory.DocumentChunkKeyPrefix {
+		t.Fatalf("docChunkPrefix %q != memory.DocumentChunkKeyPrefix %q", docChunkPrefix, memory.DocumentChunkKeyPrefix)
+	}
+}
+
+func newCDC(t *testing.T) (*Store, func()) {
+	t.Helper()
+	st, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	return Wrap(st, nil), func() { _ = st.Close() }
+}
+
+func TestCDC_EmitsOnWrites(t *testing.T) {
+	c, cleanup := newCDC(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// A plain memory set + a document-chunk set + a delete.
+	if err := c.MemorySet(ctx, "acme", store.MemoryScopeAgent, "a1", "k1", json.RawMessage(`1`), 0); err != nil {
+		t.Fatalf("MemorySet: %v", err)
+	}
+	if err := c.MemorySet(ctx, "acme", store.MemoryScopeAgent, "a1", "doc.chunk:CID", json.RawMessage(`"body"`), 0); err != nil {
+		t.Fatalf("MemorySet(doc): %v", err)
+	}
+	if _, err := c.MemoryDelete(ctx, "acme", store.MemoryScopeAgent, "a1", "k1"); err != nil {
+		t.Fatalf("MemoryDelete: %v", err)
+	}
+
+	changes, err := c.GetMemoryChangesSince(ctx, "acme", 0, 100)
+	if err != nil {
+		t.Fatalf("GetMemoryChangesSince: %v", err)
+	}
+	if len(changes) != 3 {
+		t.Fatalf("got %d changes, want 3: %+v", len(changes), changes)
+	}
+	// Ordered by seq ascending.
+	if changes[0].Type != store.MemoryChangeSet || changes[0].Key != "k1" || changes[0].ChunkID != "" {
+		t.Errorf("change[0] = %+v, want memory.set key=k1", changes[0])
+	}
+	if changes[1].Type != store.DocumentChangeUpdated || changes[1].ChunkID != "CID" || changes[1].Key != "" {
+		t.Errorf("change[1] = %+v, want document.chunk.updated chunk_id=CID", changes[1])
+	}
+	if changes[2].Type != store.MemoryChangeDelete || changes[2].Key != "k1" {
+		t.Errorf("change[2] = %+v, want memory.delete key=k1", changes[2])
+	}
+	// Seq is monotonic; At is stamped.
+	if !(changes[0].Seq < changes[1].Seq && changes[1].Seq < changes[2].Seq) {
+		t.Errorf("seq not monotonic: %d %d %d", changes[0].Seq, changes[1].Seq, changes[2].Seq)
+	}
+	if changes[0].At.IsZero() {
+		t.Errorf("At not stamped")
+	}
+}
+
+func TestCDC_TenantIsolation(t *testing.T) {
+	c, cleanup := newCDC(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	_ = c.MemorySet(ctx, "acme", store.MemoryScopeAgent, "a1", "k", json.RawMessage(`1`), 0)
+	_ = c.MemorySet(ctx, "globex", store.MemoryScopeAgent, "a1", "k", json.RawMessage(`1`), 0)
+
+	acme, _ := c.GetMemoryChangesSince(ctx, "acme", 0, 100)
+	if len(acme) != 1 || acme[0].TenantID != "acme" {
+		t.Errorf("acme feed = %+v, want exactly its own 1 change", acme)
+	}
+	globex, _ := c.GetMemoryChangesSince(ctx, "globex", 0, 100)
+	if len(globex) != 1 || globex[0].TenantID != "globex" {
+		t.Errorf("globex feed = %+v, want exactly its own 1 change", globex)
+	}
+}
+
+func TestCDC_CursorAndPrune(t *testing.T) {
+	c, cleanup := newCDC(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		_ = c.MemorySet(ctx, "acme", store.MemoryScopeAgent, "a1", "k", json.RawMessage(`1`), 0)
+	}
+	all, _ := c.GetMemoryChangesSince(ctx, "acme", 0, 100)
+	if len(all) != 3 {
+		t.Fatalf("want 3 changes, got %d", len(all))
+	}
+	// Cursor: reading since the first seq returns only the later two.
+	after := all[0].Seq
+	rest, _ := c.GetMemoryChangesSince(ctx, "acme", after, 100)
+	if len(rest) != 2 || rest[0].Seq != all[1].Seq {
+		t.Errorf("since=%d returned %+v, want the last two", after, rest)
+	}
+	// Prune removes rows older than a future cutoff (all of them).
+	n, err := c.PruneMemoryChanges(ctx, time.Now().Add(time.Hour))
+	if err != nil || n != 3 {
+		t.Fatalf("Prune removed %d (err %v), want 3", n, err)
+	}
+	if left, _ := c.GetMemoryChangesSince(ctx, "acme", 0, 100); len(left) != 0 {
+		t.Errorf("after prune %d rows remain, want 0", len(left))
+	}
+}

--- a/internal/store/postgres/memory_changes.go
+++ b/internal/store/postgres/memory_changes.go
@@ -1,0 +1,63 @@
+package postgres
+
+import (
+	"context"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// memory_changes.go implements the RFC CD Part C change-data-capture feed
+// (mirrors the sqlite backend). The at column is stamped by the DB (now()).
+
+func (s *Store) AppendMemoryChange(ctx context.Context, c store.MemoryChange) error {
+	// Like AppendEvent, this is on every write when the feed is enabled, so it
+	// absorbs transient connection-pool errors rather than surfacing a gap.
+	return retryOnTransientConn(ctx, func() error {
+		_, err := s.pool.Exec(ctx,
+			`INSERT INTO memory_changes(tenant_id, change_type, scope, scope_id, key, chunk_id)
+			 VALUES ($1, $2, $3, $4, $5, $6)`,
+			c.TenantID, string(c.Type), string(c.Scope), c.ScopeID, c.Key, c.ChunkID,
+		)
+		return err
+	})
+}
+
+func (s *Store) GetMemoryChangesSince(ctx context.Context, tenantID string, afterSeq int64, limit int) ([]store.MemoryChange, error) {
+	if limit <= 0 {
+		limit = 500
+	}
+	rows, err := s.pool.Query(ctx,
+		`SELECT seq, tenant_id, change_type, scope, scope_id, key, chunk_id, at
+		 FROM memory_changes WHERE tenant_id = $1 AND seq > $2 ORDER BY seq ASC LIMIT $3`,
+		tenantID, afterSeq, limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []store.MemoryChange
+	for rows.Next() {
+		var (
+			c  store.MemoryChange
+			ct string
+			sc string
+		)
+		if err := rows.Scan(&c.Seq, &c.TenantID, &ct, &sc, &c.ScopeID, &c.Key, &c.ChunkID, &c.At); err != nil {
+			return nil, err
+		}
+		c.Type = store.MemoryChangeType(ct)
+		c.Scope = store.MemoryScope(sc)
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) PruneMemoryChanges(ctx context.Context, olderThan time.Time) (int, error) {
+	tag, err := s.pool.Exec(ctx, `DELETE FROM memory_changes WHERE at < $1`, olderThan)
+	if err != nil {
+		return 0, err
+	}
+	return int(tag.RowsAffected()), nil
+}

--- a/internal/store/postgres/migrations/0070_memory_changes.down.sql
+++ b/internal/store/postgres/migrations/0070_memory_changes.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS memory_changes;

--- a/internal/store/postgres/migrations/0070_memory_changes.up.sql
+++ b/internal/store/postgres/migrations/0070_memory_changes.up.sql
@@ -1,0 +1,18 @@
+-- RFC CD Part C: the opt-in memory/document change-data-capture feed.
+-- Populated only when LOOMCYCLE_MEMORY_CHANGES_ENABLED (via the CDC store
+-- decorator), so a default deployment carries an empty table and pays nothing.
+-- Value-free rows: each names WHAT changed (the coordinate), not the value — a
+-- subscriber pulls the current value via the data API. The BIGSERIAL seq is the
+-- SSE cursor (the same model as run events). A retention sweeper prunes by at.
+CREATE TABLE IF NOT EXISTS memory_changes (
+	seq         BIGSERIAL PRIMARY KEY,
+	tenant_id   TEXT NOT NULL,
+	change_type TEXT NOT NULL,
+	scope       TEXT NOT NULL,
+	scope_id    TEXT NOT NULL,
+	key         TEXT NOT NULL DEFAULT '',
+	chunk_id    TEXT NOT NULL DEFAULT '',
+	at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS memory_changes_by_tenant ON memory_changes(tenant_id, seq);
+CREATE INDEX IF NOT EXISTS memory_changes_by_at ON memory_changes(at);

--- a/internal/store/sqlite/memory_changes.go
+++ b/internal/store/sqlite/memory_changes.go
@@ -1,0 +1,64 @@
+package sqlite
+
+import (
+	"context"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// memory_changes.go implements the RFC CD Part C change-data-capture feed.
+// The CDC store decorator calls AppendMemoryChange after each successful
+// memory/document write; subscribers read forward from a monotonic seq via
+// GetMemoryChangesSince; a retention sweeper calls PruneMemoryChanges.
+
+func (s *Store) AppendMemoryChange(ctx context.Context, c store.MemoryChange) error {
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO memory_changes(tenant_id, change_type, scope, scope_id, key, chunk_id, at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		c.TenantID, string(c.Type), string(c.Scope), c.ScopeID, c.Key, c.ChunkID, time.Now().UnixNano(),
+	)
+	return err
+}
+
+func (s *Store) GetMemoryChangesSince(ctx context.Context, tenantID string, afterSeq int64, limit int) ([]store.MemoryChange, error) {
+	if limit <= 0 {
+		limit = 500
+	}
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT seq, tenant_id, change_type, scope, scope_id, key, chunk_id, at
+		 FROM memory_changes WHERE tenant_id = ? AND seq > ? ORDER BY seq ASC LIMIT ?`,
+		tenantID, afterSeq, limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []store.MemoryChange
+	for rows.Next() {
+		var (
+			c  store.MemoryChange
+			ct string
+			sc string
+			at int64
+		)
+		if err := rows.Scan(&c.Seq, &c.TenantID, &ct, &sc, &c.ScopeID, &c.Key, &c.ChunkID, &at); err != nil {
+			return nil, err
+		}
+		c.Type = store.MemoryChangeType(ct)
+		c.Scope = store.MemoryScope(sc)
+		c.At = time.Unix(0, at)
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) PruneMemoryChanges(ctx context.Context, olderThan time.Time) (int, error) {
+	res, err := s.db.ExecContext(ctx, `DELETE FROM memory_changes WHERE at < ?`, olderThan.UnixNano())
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -197,6 +197,22 @@ func (s *Store) migrate(ctx context.Context) error {
 			payload    BLOB NOT NULL
 		)`,
 		`CREATE INDEX IF NOT EXISTS events_by_session ON events(session_id, seq)`,
+		// RFC CD Part C: the opt-in memory/document change-data-capture feed.
+		// Populated only when LOOMCYCLE_MEMORY_CHANGES_ENABLED (via the CDC store
+		// decorator); a monotonic seq is the SSE cursor. Mirrors postgres
+		// migration 0070.
+		`CREATE TABLE IF NOT EXISTS memory_changes (
+			seq         INTEGER PRIMARY KEY AUTOINCREMENT,
+			tenant_id   TEXT NOT NULL,
+			change_type TEXT NOT NULL,
+			scope       TEXT NOT NULL,
+			scope_id    TEXT NOT NULL,
+			key         TEXT NOT NULL DEFAULT '',
+			chunk_id    TEXT NOT NULL DEFAULT '',
+			at          INTEGER NOT NULL  -- unix nano
+		)`,
+		`CREATE INDEX IF NOT EXISTS memory_changes_by_tenant ON memory_changes(tenant_id, seq)`,
+		`CREATE INDEX IF NOT EXISTS memory_changes_by_at ON memory_changes(at)`,
 		// v0.8.21 audit view — cross-session queries by ts (descending)
 		// and ts-with-type-equality. Mirrors the postgres
 		// 0014_events_audit_index migration; both stores need the

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -475,6 +475,36 @@ type Event struct {
 	Payload   []byte    `json:"-"` // raw JSON; emit via custom marshalling at the API edge
 }
 
+// MemoryChangeType names a kind of change in the CDC feed (RFC CD Part C).
+type MemoryChangeType string
+
+const (
+	MemoryChangeSet          MemoryChangeType = "memory.set"
+	MemoryChangeDelete       MemoryChangeType = "memory.delete"
+	MemoryChangeScopeDeleted MemoryChangeType = "memory.scope_deleted"
+	DocumentChangeUpdated    MemoryChangeType = "document.chunk.updated"
+	DocumentChangeDeleted    MemoryChangeType = "document.chunk.deleted"
+)
+
+// MemoryChange is one row in the change-data-capture feed (RFC CD Part C),
+// emitted by the CDC store decorator after a successful memory/document write
+// when LOOMCYCLE_MEMORY_CHANGES_ENABLED. It is VALUE-FREE: it names WHAT
+// changed (the coordinate), not the value — a subscriber pulls the current
+// value via the data API. Seq is a per-store monotonic cursor (the same model
+// as run events / GetRunEventsSince). ChunkID is set for document.* changes
+// (derived from the reserved doc.chunk:<id> key); Key is set for plain memory
+// changes.
+type MemoryChange struct {
+	Seq      int64            `json:"seq"`
+	TenantID string           `json:"tenant,omitempty"`
+	Type     MemoryChangeType `json:"type"`
+	Scope    MemoryScope      `json:"scope"`
+	ScopeID  string           `json:"scope_id"`
+	Key      string           `json:"key,omitempty"`
+	ChunkID  string           `json:"chunk_id,omitempty"`
+	At       time.Time        `json:"at"`
+}
+
 // Usage is one run's aggregated token accounting, computed by the loop and
 // passed to FinishRun.
 type Usage struct {
@@ -1705,6 +1735,22 @@ type Store interface {
 	// resets, on a re-incr) the expiry; ttl <= 0 keeps the existing
 	// expiry untouched (or no expiry on a fresh row).
 	MemoryIncrement(ctx context.Context, tenantID string, scope MemoryScope, scopeID, key string, delta int64, ttl time.Duration) (int64, error)
+
+	// AppendMemoryChange records one change-data-capture row (RFC CD Part C),
+	// emitted by the CDC store decorator after a successful memory/document
+	// write when LOOMCYCLE_MEMORY_CHANGES_ENABLED. Best-effort: a failure must
+	// NOT fail the originating write (the decorator logs and continues). Seq is
+	// store-assigned (monotonic); At is store-stamped.
+	AppendMemoryChange(ctx context.Context, c MemoryChange) error
+
+	// GetMemoryChangesSince returns a tenant's change rows with Seq > afterSeq,
+	// oldest first, capped at limit — the SSE cursor read. Tenant-scoped: a
+	// caller only ever sees its OWN tenant's changes.
+	GetMemoryChangesSince(ctx context.Context, tenantID string, afterSeq int64, limit int) ([]MemoryChange, error)
+
+	// PruneMemoryChanges deletes change rows recorded before olderThan and
+	// returns the count removed — keeps the opt-in feed table bounded.
+	PruneMemoryChanges(ctx context.Context, olderThan time.Time) (int, error)
 
 	// MemoryAtomicUpdate runs `reducer` as an atomic read-modify-write
 	// against (scope, scopeID, key). The reducer receives the current

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -77,6 +77,10 @@ func Run(t *testing.T, factory Factory) {
 		{"FinishRunIdempotent", testFinishRunIdempotent},
 		{"GetTranscriptEmpty", testGetTranscriptEmpty},
 		{"GetRunEventsSince", testGetRunEventsSince},
+		// RFC CD Part C — the memory/document change-data-capture feed
+		// (append / tenant-scoped since-cursor / prune). sqlite always;
+		// Postgres when a DSN is set.
+		{"MemoryChangesFeed", testMemoryChangesFeed},
 		{"CreateSessionUserIDRoundTrip", testCreateSessionUserIDRoundTrip},
 		{"CreateRunIdentityRoundTrip", testCreateRunIdentityRoundTrip},
 		{"CreateRunParentContextRoundTrip", testCreateRunParentContextRoundTrip},

--- a/internal/store/storetest/memory_changes.go
+++ b/internal/store/storetest/memory_changes.go
@@ -1,0 +1,75 @@
+package storetest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// testMemoryChangesFeed is the RFC CD Part C change-feed store contract: append,
+// the tenant-scoped since-cursor read (ordering + isolation), and prune. Runs
+// on both backends via storetest.Run.
+func testMemoryChangesFeed(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	must := func(err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatalf("AppendMemoryChange: %v", err)
+		}
+	}
+	must(s.AppendMemoryChange(ctx, store.MemoryChange{TenantID: "acme", Type: store.MemoryChangeSet, Scope: store.MemoryScopeAgent, ScopeID: "a1", Key: "k1"}))
+	must(s.AppendMemoryChange(ctx, store.MemoryChange{TenantID: "acme", Type: store.DocumentChangeUpdated, Scope: store.MemoryScopeAgent, ScopeID: "a1", ChunkID: "CID"}))
+	must(s.AppendMemoryChange(ctx, store.MemoryChange{TenantID: "globex", Type: store.MemoryChangeSet, Scope: store.MemoryScopeUser, ScopeID: "u1", Key: "z"}))
+
+	acme, err := s.GetMemoryChangesSince(ctx, "acme", 0, 100)
+	if err != nil {
+		t.Fatalf("GetMemoryChangesSince(acme): %v", err)
+	}
+	if len(acme) != 2 {
+		t.Fatalf("acme changes = %d, want 2: %+v", len(acme), acme)
+	}
+	if acme[0].Type != store.MemoryChangeSet || acme[0].Key != "k1" || acme[0].ChunkID != "" {
+		t.Errorf("acme[0] = %+v, want memory.set key=k1", acme[0])
+	}
+	if acme[1].Type != store.DocumentChangeUpdated || acme[1].ChunkID != "CID" || acme[1].Key != "" {
+		t.Errorf("acme[1] = %+v, want document.chunk.updated chunk_id=CID", acme[1])
+	}
+	if !(acme[0].Seq < acme[1].Seq) {
+		t.Errorf("seq not ascending: %d then %d", acme[0].Seq, acme[1].Seq)
+	}
+	if acme[0].At.IsZero() {
+		t.Errorf("At not stamped")
+	}
+
+	// Tenant isolation: a globex reader never sees acme's rows.
+	glob, err := s.GetMemoryChangesSince(ctx, "globex", 0, 100)
+	if err != nil {
+		t.Fatalf("GetMemoryChangesSince(globex): %v", err)
+	}
+	if len(glob) != 1 || glob[0].TenantID != "globex" {
+		t.Errorf("globex feed = %+v, want exactly its own 1 change", glob)
+	}
+
+	// Cursor: reading since the first acme seq returns only the second.
+	rest, err := s.GetMemoryChangesSince(ctx, "acme", acme[0].Seq, 100)
+	if err != nil {
+		t.Fatalf("cursor read: %v", err)
+	}
+	if len(rest) != 1 || rest[0].Seq != acme[1].Seq {
+		t.Errorf("since=%d returned %+v, want only the second row", acme[0].Seq, rest)
+	}
+
+	// Prune removes rows older than a future cutoff (all of them).
+	n, err := s.PruneMemoryChanges(ctx, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("PruneMemoryChanges: %v", err)
+	}
+	if n < 3 {
+		t.Errorf("pruned %d, want >= 3", n)
+	}
+	if left, _ := s.GetMemoryChangesSince(ctx, "acme", 0, 100); len(left) != 0 {
+		t.Errorf("after prune acme has %d rows, want 0", len(left))
+	}
+}


### PR DESCRIPTION
## Why

External consumers of loomcycle's memory + documents must **poll** — there is no change channel. **RFC CD Part C** adds a value-free change-data-capture feed so a consumer can *react* to writes. This PR is the **SSE-subscribe** slice; the webhook-push mode (a `ChangeSubscriptionDef` + outbound HMAC client) is a confirmed follow-up.

## What

**Capture — a store decorator (`internal/store/cdc`).** Rather than editing ~6 write methods × 2 backends, the decorator embeds `store.Store` and overrides only the content-write methods to append a value-free change row after a successful write, then delegates. One policy point captures **every** write — in-run *and* external CRUD — and classifies the reserved `doc.chunk:` prefix as a document change vs a plain memory change. Emit is **best-effort** (logged, never returned) so a lagging feed can't fail the write it describes.

**Opt-in, default-off.** Gated behind `LOOMCYCLE_MEMORY_CHANGES_ENABLED`. When off, the store is **never wrapped** → byte-identical default path, empty table. When on, an advisory-gated **retention sweeper** prunes rows older than `LOOMCYCLE_MEMORY_CHANGES_RETENTION_HOURS` (default 24h). `asPostgresStore()` unwraps the decorator at the cluster-coord type-assertion sites so wrapping stays transparent to Postgres coordination.

**Storage.** `store.MemoryChange` + `AppendMemoryChange` / `GetMemoryChangesSince` (tenant-scoped monotonic-`seq` cursor, the run-events model) / `PruneMemoryChanges`, backed by a `memory_changes` table in both backends (sqlite CREATE + **postgres migration 0070**).

**Subscribe.** `GET /v1/_memory/changes?since=<seq>` and `GET /v1/_document/changes?since=<seq>` — SSE streams reusing `sse.go` + the run-stream poll-tail. Value-free frames (`{seq, type, tenant, scope, scope_id, key|chunk_id, at}`); the subscriber pulls the current value via the Part A data API.

**Auth (locked decision).** Both feeds are `substrate:tenant` **and** on `memberCarveOut` — **not member-accessible**: the feed exposes a tenant's write pattern (a metadata side-channel), so it's operator observability, not member data.

## Tested

- `internal/store/cdc`: emit/classify/tenant-isolation/cursor/prune over sqlite; pins `docChunkPrefix == memory.DocumentChunkKeyPrefix`.
- **Store contract test (both tiers):** `MemoryChangesFeed` runs under `storetest.Run` — verified against a **real local Postgres** (migration 0070 applied) *and* sqlite.
- `TestMemoryChanges_AuthGate` (ScopeTenant + not-member-accessible for both routes); `TestMemoryChanges_SSEStreamsAndFilters` (each feed streams only its own family).
- **Manual (live server, flag on):** two `PUT`s → `/v1/_memory/changes` streamed both `memory.set` events (value-free, correct `seq`/tenant/key); `/v1/_document/changes` correctly excluded them; startup logged the feed + retention sweeper.
- Full suite: `go test ./...` → **0 failures, 89 packages**; gofmt + vet clean.

## Follow-up (RFC CD Part C — push)

The webhook delivery mode: a `ChangeSubscriptionDef` substrate + a composed outbound HMAC-signed/retrying/SSRF-guarded client (none exists today) + subscription CRUD. Separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD