### PR TITLE
ci(release): mirror every image to ghcr.io so a rate-limited operator has a fallback

### DIFF
--- a/.github/workflows/publish-sandbox-images.yml
+++ b/.github/workflows/publish-sandbox-images.yml
@@ -21,6 +21,13 @@ name: Publish sandbox images
 # on the repo VARIABLE `DOCKER_PUBLISH_ENABLED == 'true'` and logs in with the
 # `DOCKER_USERNAME` / `DOCKER_PASSWORD` secrets. When the operator hasn't enabled
 # docker publishing the job is SKIPPED cleanly (no failure).
+#
+# Registries: every image goes to Docker Hub AND to the ghcr.io/denn-gubsky
+# mirror, from one build (see .goreleaser.yaml's `dockers:` comment for why, and
+# for the one-time "make the GHCR package public" step). The var name still says
+# DOCKER_PUBLISH_ENABLED but now gates BOTH registries — it is deliberately not
+# renamed, since that would silently disable publishing until the operator
+# created a new repo variable.
 
 on:
   push:
@@ -38,6 +45,7 @@ env:
 
 permissions:
   contents: read
+  packages: write  # push the GHCR mirror with the built-in GITHUB_TOKEN
 
 jobs:
   # FULL vs LEAN, mirroring release.yml: the sandbox images are FULL-build-only.
@@ -114,6 +122,14 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      # GHCR mirror — no new secret (GITHUB_TOKEN + packages:write above).
+      # Rationale in .goreleaser.yaml's dockers: comment.
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # ── Builder sidecar — rootless podman base (deploy/builder/Dockerfile) ──
       - name: Build + push loomcycle-builder (rootless)
@@ -125,9 +141,13 @@ jobs:
           push: true
           build-args: |
             VERSION=${{ steps.ver.outputs.version }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/denn-gubsky/loomcycle
           tags: |
             denngubsky/loomcycle-builder:${{ steps.ver.outputs.version }}
             denngubsky/loomcycle-builder:latest
+            ghcr.io/denn-gubsky/loomcycle-builder:${{ steps.ver.outputs.version }}
+            ghcr.io/denn-gubsky/loomcycle-builder:latest
 
       # ── Builder sidecar — host-Docker-socket base (deploy/builder/Dockerfile.docker) ──
       - name: Build + push loomcycle-builder-docker (docker socket)
@@ -139,9 +159,13 @@ jobs:
           push: true
           build-args: |
             VERSION=${{ steps.ver.outputs.version }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/denn-gubsky/loomcycle
           tags: |
             denngubsky/loomcycle-builder-docker:${{ steps.ver.outputs.version }}
             denngubsky/loomcycle-builder-docker:latest
+            ghcr.io/denn-gubsky/loomcycle-builder-docker:${{ steps.ver.outputs.version }}
+            ghcr.io/denn-gubsky/loomcycle-builder-docker:latest
 
       # ── Session toolchain image (deploy/builder/session/Dockerfile) ──
       # NOTE: the arm64 build runs apt + Go/Rust/gh downloads under QEMU emulation
@@ -156,6 +180,10 @@ jobs:
           file: deploy/builder/session/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          labels: |
+            org.opencontainers.image.source=https://github.com/denn-gubsky/loomcycle
           tags: |
             denngubsky/loomcycle-sandbox-session:${{ steps.ver.outputs.version }}
             denngubsky/loomcycle-sandbox-session:latest
+            ghcr.io/denn-gubsky/loomcycle-sandbox-session:${{ steps.ver.outputs.version }}
+            ghcr.io/denn-gubsky/loomcycle-sandbox-session:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,7 @@ env:
 
 permissions:
   contents: write  # needed for goreleaser to upload release assets
+  packages: write  # push the GHCR mirror with the built-in GITHUB_TOKEN
 
 jobs:
   # Decide FULL vs LEAN from the tag shape (the release-cadence rule):
@@ -165,6 +166,19 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      # GHCR mirror (see .goreleaser.yaml's dockers: comment for WHY —
+      # Docker Hub meters anonymous pulls per source IP / IPv6 /64).
+      # No new secret: GITHUB_TOKEN + the job's packages:write permission.
+      # Gated on the SAME var as Docker Hub because goreleaser tags one
+      # built image with both registries — it cannot push half of them, so
+      # a login failure on either registry fails the whole dockers stage.
+      - name: Log in to GHCR
+        if: vars.DOCKER_PUBLISH_ENABLED == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pre-create GitHub release with annotated tag body
         # Why this step exists: goreleaser's `release.mode: keep-existing`
@@ -263,7 +277,10 @@ jobs:
     if: needs.classify.outputs.full == 'false'
     runs-on: ubuntu-latest
     permissions:
+      # A job-level block REPLACES the workflow-level one, so packages:write
+      # has to be restated here — otherwise the GHCR push 403s on a patch tag.
       contents: write # pre-create the GitHub release from the annotated tag
+      packages: write # push the GHCR mirror of loomcycle-browser
     steps:
       - uses: actions/checkout@v5
         with:
@@ -341,7 +358,18 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Log in to GHCR
+        if: vars.DOCKER_PUBLISH_ENABLED == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Pushed to BOTH registries from one build — buildx uploads the same
+      # image twice, so the digests match and an operator can switch the
+      # registry prefix without a version change. The source label is what
+      # links the GHCR package to this repo in the UI.
       - name: Build + push loomcycle-browser (linux/amd64)
         if: vars.DOCKER_PUBLISH_ENABLED == 'true'
         uses: docker/build-push-action@v6
@@ -350,6 +378,10 @@ jobs:
           file: Dockerfile.browser
           platforms: linux/amd64
           push: true
+          labels: |
+            org.opencontainers.image.source=https://github.com/denn-gubsky/loomcycle
           tags: |
             denngubsky/loomcycle-browser:${{ needs.classify.outputs.version }}
             denngubsky/loomcycle-browser:latest
+            ghcr.io/denn-gubsky/loomcycle-browser:${{ needs.classify.outputs.version }}
+            ghcr.io/denn-gubsky/loomcycle-browser:latest

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -132,7 +132,24 @@ brews:
 # further config changes.
 #
 # Note on registry naming: Docker Hub strips hyphens from usernames.
-# `denn-gubsky` on GitHub becomes `denngubsky` on Docker Hub.
+# `denn-gubsky` on GitHub becomes `denngubsky` on Docker Hub. GHCR keeps
+# the hyphen, so the two namespaces are spelled DIFFERENTLY:
+#   docker.io/denngubsky/loomcycle   ·   ghcr.io/denn-gubsky/loomcycle
+#
+# Every image is published to BOTH registries. Docker Hub stays the
+# documented default (existing installs pin it); GHCR is a byte-identical
+# mirror that exists because Docker Hub meters anonymous pulls per source
+# IP — and for IPv6 that bucket is keyed on the whole /64, so one home
+# network or NAT egress shares a single quota across every host behind it.
+# An operator who hits `toomanyrequests` swaps the registry prefix and is
+# unblocked. Same manifest digests, no rebuild: goreleaser tags one built
+# image with both names, so the mirror costs an extra push, not a build.
+#
+# ⚠️ First publish only: GHCR creates each package PRIVATE. Flip each to
+# public once at github.com/users/denn-gubsky/packages → <package> →
+# Package settings → Change visibility. There is no REST endpoint for it,
+# so it cannot be automated here. Until then anonymous pulls 401 and the
+# mirror is useless — verify with `docker pull` from a logged-out client.
 #
 # Uses Dockerfile.release (the goreleaser-specific variant that copies
 # the already-built binary in instead of running the multi-stage build
@@ -144,7 +161,9 @@ dockers:
       - loomcycle
     image_templates:
       - "denngubsky/loomcycle:{{ .Version }}-amd64"
+      - "ghcr.io/denn-gubsky/loomcycle:{{ .Version }}-amd64"
       - "denngubsky/loomcycle:latest-amd64"
+      - "ghcr.io/denn-gubsky/loomcycle:latest-amd64"
     dockerfile: Dockerfile.release
     use: buildx
     build_flag_templates:
@@ -162,7 +181,9 @@ dockers:
       - loomcycle
     image_templates:
       - "denngubsky/loomcycle:{{ .Version }}-arm64"
+      - "ghcr.io/denn-gubsky/loomcycle:{{ .Version }}-arm64"
       - "denngubsky/loomcycle:latest-arm64"
+      - "ghcr.io/denn-gubsky/loomcycle:latest-arm64"
     dockerfile: Dockerfile.release
     use: buildx
     build_flag_templates:
@@ -193,7 +214,9 @@ dockers:
       - loomcycle
     image_templates:
       - "denngubsky/loomcycle-toolbox:{{ .Version }}-amd64"
+      - "ghcr.io/denn-gubsky/loomcycle-toolbox:{{ .Version }}-amd64"
       - "denngubsky/loomcycle-toolbox:latest-amd64"
+      - "ghcr.io/denn-gubsky/loomcycle-toolbox:latest-amd64"
     dockerfile: Dockerfile.toolbox
     use: buildx
     build_flag_templates:
@@ -211,7 +234,9 @@ dockers:
       - loomcycle
     image_templates:
       - "denngubsky/loomcycle-toolbox:{{ .Version }}-arm64"
+      - "ghcr.io/denn-gubsky/loomcycle-toolbox:{{ .Version }}-arm64"
       - "denngubsky/loomcycle-toolbox:latest-arm64"
+      - "ghcr.io/denn-gubsky/loomcycle-toolbox:latest-arm64"
     dockerfile: Dockerfile.toolbox
     use: buildx
     build_flag_templates:
@@ -236,7 +261,9 @@ dockers:
       - loomcycle
     image_templates:
       - "denngubsky/loomcycle-browser:{{ .Version }}-amd64"
+      - "ghcr.io/denn-gubsky/loomcycle-browser:{{ .Version }}-amd64"
       - "denngubsky/loomcycle-browser:latest-amd64"
+      - "ghcr.io/denn-gubsky/loomcycle-browser:latest-amd64"
     dockerfile: Dockerfile.browser
     use: buildx
     build_flag_templates:
@@ -254,7 +281,9 @@ dockers:
       - loomcycle
     image_templates:
       - "denngubsky/loomcycle-browser:{{ .Version }}-arm64"
+      - "ghcr.io/denn-gubsky/loomcycle-browser:{{ .Version }}-arm64"
       - "denngubsky/loomcycle-browser:latest-arm64"
+      - "ghcr.io/denn-gubsky/loomcycle-browser:latest-arm64"
     dockerfile: Dockerfile.browser
     use: buildx
     build_flag_templates:
@@ -271,6 +300,11 @@ dockers:
 # docker_manifests joins per-arch images into one multi-arch manifest
 # the operator pulls with `docker pull denngubsky/loomcycle:vX.Y.Z`
 # regardless of their host arch.
+#
+# A manifest list is registry-local — it can only reference per-arch
+# images in its OWN registry — so the GHCR mirror needs its own six
+# entries rather than a second name on the Docker Hub ones. The per-arch
+# images they join are the same builds, pushed twice (see `dockers:`).
 docker_manifests:
   - name_template: "denngubsky/loomcycle:{{ .Version }}"
     image_templates:
@@ -296,3 +330,29 @@ docker_manifests:
     image_templates:
       - "denngubsky/loomcycle-browser:latest-amd64"
       - "denngubsky/loomcycle-browser:latest-arm64"
+
+  # ── GHCR mirror ──
+  - name_template: "ghcr.io/denn-gubsky/loomcycle:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/denn-gubsky/loomcycle:{{ .Version }}-amd64"
+      - "ghcr.io/denn-gubsky/loomcycle:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/denn-gubsky/loomcycle:latest"
+    image_templates:
+      - "ghcr.io/denn-gubsky/loomcycle:latest-amd64"
+      - "ghcr.io/denn-gubsky/loomcycle:latest-arm64"
+  - name_template: "ghcr.io/denn-gubsky/loomcycle-toolbox:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/denn-gubsky/loomcycle-toolbox:{{ .Version }}-amd64"
+      - "ghcr.io/denn-gubsky/loomcycle-toolbox:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/denn-gubsky/loomcycle-toolbox:latest"
+    image_templates:
+      - "ghcr.io/denn-gubsky/loomcycle-toolbox:latest-amd64"
+      - "ghcr.io/denn-gubsky/loomcycle-toolbox:latest-arm64"
+  - name_template: "ghcr.io/denn-gubsky/loomcycle-browser:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/denn-gubsky/loomcycle-browser:{{ .Version }}-amd64"
+      - "ghcr.io/denn-gubsky/loomcycle-browser:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/denn-gubsky/loomcycle-browser:latest"
+    image_templates:
+      - "ghcr.io/denn-gubsky/loomcycle-browser:latest-amd64"
+      - "ghcr.io/denn-gubsky/loomcycle-browser:latest-arm64"

--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ brew install denn-gubsky/loomcycle/loomcycle
 # Docker (v0.11.2+; pull works on amd64 + arm64 including Apple Silicon)
 docker pull denngubsky/loomcycle:latest
 
+# …or the same image from GHCR, if Docker Hub rate-limits your pulls.
+# Byte-identical, published by the same release job. Docker Hub meters
+# anonymous pulls per source IP — and for IPv6 per /64, so every host on
+# one network shares a quota. Swap the prefix on any loomcycle image.
+docker pull ghcr.io/denn-gubsky/loomcycle:latest
+
 # go install from source (skips Web UI embedding — for dev only)
 go install github.com/denn-gubsky/loomcycle/cmd/loomcycle@latest
 

--- a/deploy/truenas/INSTALL.md
+++ b/deploy/truenas/INSTALL.md
@@ -22,6 +22,13 @@ never in the YAML you paste into the TrueNAS UI.**
 > ([`../../docs/SANDBOX.md`](../../docs/SANDBOX.md)). Either way pin **≥ v1.6.0** — the
 > first release with the embedded presets (RFC AQ) this app's `LOOMCYCLE_PRESETS`
 > relies on; older tags fail to boot with `no config found`.
+>
+> **Registry.** Every loomcycle image is published to Docker Hub *and* to
+> `ghcr.io/denn-gubsky/…` (same build, same digest). If a pull fails with
+> `toomanyrequests`, swap the prefix — `ghcr.io/denn-gubsky/loomcycle-toolbox:1.23.1`
+> — everywhere in the YAML below. See "Docker Hub rate limits" in Troubleshooting;
+> TrueNAS is unusually exposed to this because it re-checks every installed app for
+> image updates on a timer, and each check spends from the same anonymous quota.
 
 ---
 
@@ -334,3 +341,34 @@ Verify end-to-end: spawn `dev/exec` with `{"expose":"devsrv","commands":["nohup 
 | Documents fail with `sqlmem: provision scope: ... permission denied to create role` | The SQL-Memory DSN's role lacks `CREATEROLE` (it provisions a per-scope login role). Grant it: `ALTER ROLE loomcycle CREATEROLE;` (Phase 1 now creates the role with it). |
 | `doc/manager` idle | Needs `LOOMCYCLE_SQLMEM_ENABLED=1` + the `loomcycle_sqlmem` DSN + a `middle` tier (base provides one). |
 | An agent has no file access | Its bound volume isn't mapped — check the overlay `volumes:` `path` equals the in-container mount path (Phase 3 ↔ Phase 5). |
+| `toomanyrequests: You have reached your pull rate limit` | Docker Hub anonymous quota exhausted — see below. |
+
+### Docker Hub rate limits
+
+Docker Hub meters **anonymous** pulls per source IP, and over IPv6 the bucket is
+keyed on the whole **/64 prefix** — so your TrueNAS box, your laptop and everything
+else behind one connection drain a single shared quota. TrueNAS also re-checks every
+installed app for image updates on a timer, and each check spends from it. Check
+what's left, from the box:
+
+```sh
+TOKEN=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
+curl -sI -H "Authorization: Bearer $TOKEN" \
+  https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep -i ratelimit
+```
+
+Three fixes, in order of how well they hold:
+
+1. **Pull from GHCR instead.** Every loomcycle image is mirrored to
+   `ghcr.io/denn-gubsky/…` from the same build, so swapping the registry prefix
+   changes nothing but where the bytes come from. Not metered like Docker Hub.
+   Third-party images (`pinchtab/pinchtab`) still come from Docker Hub.
+2. **Authenticate.** `sudo -i` then `docker login -u <user>` on the TrueNAS host, with
+   a read-only access token — *not* `sudo docker login`, which can write the
+   credential to the calling user's `~/.docker/config.json` while the app middleware
+   reads root's. Authenticated pulls are metered per account, not per source IP.
+   Verify: `cat /root/.docker/config.json` shows an `auths` entry.
+3. **Pull less.** Add `pull_policy: missing` to each service so a restart reuses the
+   image already on disk instead of re-fetching its manifest. Pinning by digest
+   (`image: denngubsky/loomcycle-toolbox@sha256:…`) also halves the requests a
+   multi-arch tag costs, since it skips the manifest-list lookup.

--- a/deploy/truenas/docker-compose.browser.yaml
+++ b/deploy/truenas/docker-compose.browser.yaml
@@ -22,6 +22,11 @@
 #   • The config overlay adds an mcp_servers.browser block — copy
 #     loomcycle.overlay.browser.example.yaml (NOT the plain overlay example).
 #
+# Registry: every loomcycle image below is also on GHCR — prefix it with
+# `ghcr.io/denn-gubsky/` (same build, same digest) if a Docker Hub pull fails with
+# `toomanyrequests`. `pinchtab/pinchtab` is third-party and Docker-Hub-only.
+# INSTALL.md → "Docker Hub rate limits".
+#
 # ── BEFORE YOU INSTALL (see INSTALL.md "Browser + sandbox variant") ───────────
 #   Replace `tank` with your pool throughout, then:
 #   1. Datasets (the distroless runtime is uid 65532; PINCHTAB runs as uid 1000):

--- a/deploy/truenas/docker-compose.yaml
+++ b/deploy/truenas/docker-compose.yaml
@@ -31,6 +31,10 @@
 #     a locked-down / multi-tenant deploy, switch BOTH images to this and DELETE the
 #     "code execution" env block below. For ISOLATED untrusted code execution, keep
 #     distroless and add the builder sidecar (docs/SANDBOX.md).
+#
+#   Registry: whichever you pick is also on GHCR — prefix it with
+#   `ghcr.io/denn-gubsky/` (same build, same digest) if a Docker Hub pull fails
+#   with `toomanyrequests`. INSTALL.md → "Docker Hub rate limits".
 
 name: loomcycle
 

--- a/docs/TRUENAS.md
+++ b/docs/TRUENAS.md
@@ -143,6 +143,12 @@ can't run scripts or compile code. To let them, switch both services to the
 bakes in python / go / rust / c++ / node + git/gh/curl/jq/rsync/wget/unzip/sqlite3)
 and enable a shell tool, then grant it to an agent via its `tools:`:
 
+> Either image is also on GHCR as `ghcr.io/denn-gubsky/…` — same build, same digest.
+> Reach for it when a Docker Hub pull fails with `toomanyrequests`: the anonymous
+> quota is per source IP (per /64 on IPv6), so a whole network shares one, and
+> TrueNAS's periodic per-app update checks spend from it.
+> [`deploy/truenas/INSTALL.md`](../deploy/truenas/INSTALL.md) has the full recipe.
+
 - **`LOOMCYCLE_BASH_ENABLED=1`** — the raw `Bash` tool (unsandboxed: the whole
   toolchain, and it can run a compiled `./binary`). Simplest for a trusted box.
 - **`LOOMCYCLE_BASHBOX_ENABLED=1`** + `LOOMCYCLE_BASHBOX_FALLBACK_COMMANDS=<drivers>`


### PR DESCRIPTION
## Why

An operator running loomcycle on TrueNAS SCALE hit Docker Hub's pull rate limit and could not update or start containers. Confirmed against the registry from that network:

```
HTTP/2 429
docker-ratelimit-source: 2a02:2f0e:3a16:2000::
ratelimit-limit:     100;w=3600
ratelimit-remaining:   0;w=3600
```

Two things make this worse than it looks. The quota is keyed on the **IPv6 /64**, not the host — so every machine behind one connection shares a single bucket, and one box's pulls block another's. And TrueNAS re-checks every installed app for image updates on a timer, so a box can exhaust the quota with nobody pulling anything by hand.

There was no fallback: despite the plan recorded when the Docker Hub namespace was reserved, **every publish path targeted `docker.io` only** — goreleaser, the patch-tag browser job, and the sandbox-images workflow.

## What

Publish all six images to GHCR as well, from the same builds:

| Image | Built by | Now also pushed as |
|---|---|---|
| `loomcycle` | goreleaser `dockers:` | `ghcr.io/denn-gubsky/loomcycle` |
| `loomcycle-toolbox` | goreleaser `dockers:` | `ghcr.io/denn-gubsky/loomcycle-toolbox` |
| `loomcycle-browser` | goreleaser + `browser-patch` | `ghcr.io/denn-gubsky/loomcycle-browser` |
| `loomcycle-builder` | publish-sandbox-images | `ghcr.io/denn-gubsky/loomcycle-builder` |
| `loomcycle-builder-docker` | publish-sandbox-images | `ghcr.io/denn-gubsky/loomcycle-builder-docker` |
| `loomcycle-sandbox-session` | publish-sandbox-images | `ghcr.io/denn-gubsky/loomcycle-sandbox-session` |

No rebuild and no new secret — one built image is tagged twice, and GHCR auth is the built-in `GITHUB_TOKEN` plus `packages: write`.

Three things worth a reviewer's attention:

- **`docker_manifests` needed six *new* entries, not extra names.** A manifest list can only reference per-arch images in its own registry, so the mirror gets its own manifests joining the ghcr per-arch tags.
- **`packages: write` is restated on `browser-patch`.** A job-level `permissions:` block *replaces* the workflow-level one instead of merging, so without it the patch-tag path would 403.
- **`DOCKER_PUBLISH_ENABLED` now gates both registries** and is deliberately not renamed — renaming would silently disable publishing until the operator created a new repo variable. Both registries share one gate because goreleaser tags one image with both names and cannot push half of them.

Docker Hub stays the documented default so existing installs are untouched; GHCR is an escape hatch reached by swapping the registry prefix. Docs put that swap where an operator staring at `toomanyrequests` will look: the README install block, both TrueNAS paste-composes, the TrueNAS runbook, and a new Troubleshooting section that also covers the two fixes the mirror doesn't give you (authenticating, and pulling less via `pull_policy: missing` / digest pins).

## ⚠️ One manual step after the first tag

GHCR creates each package **private**, and no REST endpoint can change that. Each must be flipped to public once at github.com/users/denn-gubsky/packages → package → Package settings → Change visibility, or anonymous pulls will 401. Worth verifying with a logged-out `docker pull` before telling anyone the mirror works.

## Tested

- `goreleaser check` — config valid. Its non-zero exit is the pre-existing `dockers`/`docker_manifests`/`brews` deprecation warnings; verified identical on `origin/main`, so not introduced here.
- `actionlint` clean on both workflows.
- Structural assertion over the parsed `.goreleaser.yaml`: 24 image templates (12 ghcr), 12 manifests (6 ghcr), every manifest child is an image a `dockers:` block actually pushes, and no manifest mixes registries.
- Both TrueNAS composes still parse as YAML.
- `go test ./cmd/loomcycle/... ./internal/cli/... ./internal/skills/... ./internal/claudeimport/...` — the packages whose tests reference the touched docs. Pass.

**Not verified, and unverifiable pre-merge:** the actual push. Whether GHCR accepts these manifests only shows at the next `v*` tag. The blast radius if something is wrong is the release job failing after the Docker Hub push has already succeeded — the mirror is additive, so a failure can't corrupt the Docker Hub images, but it would leave a red release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)