### PR TITLE
feat: change-subscription push — HMAC-signed outbound delivery (RFC CD Part C)

### DIFF
--- a/cmd/loomcycle/embedded/loomcycle.example.yaml
+++ b/cmd/loomcycle/embedded/loomcycle.example.yaml
@@ -446,6 +446,51 @@ hooks:
     # bare owner = shared tenant ""; "tenant:owner" = that tenant only.
     owners: []                    # e.g. ["jobember:jobs-search-web"] — empty default-denies for all
 
+# ─── Memory backends (RFC CD Part B) ──────────────────────────────────
+# Named memory backends an agent selects with `memory_backend: <name>`. With no
+# entry (or kind: inprocess) an agent uses loomcycle's own store — the default.
+#
+# kind: remote proxies an agent's memory to ANOTHER loomcycle instance's
+# /v1/_memory/* — one loomcycle uses another's memory as a backend. The peer
+# embeds server-side (this instance needs no embedder for it); get/set/list/
+# search/stats all round-trip. Auth is api_key_env: a credential-allowlisted
+# env-var NAME (LOOMCYCLE_*-prefixed or a known third-party key — never one of
+# loomcycle's own infra secrets), resolved at use time. The peer host is dialed
+# through an SSRF guard; a private-network peer (sibling replica / tailnet) is
+# reached because the operator declared its base_url. See docs/MEMORY-BACKENDS.md.
+memory_backends: {}
+  # peer:
+  #   kind: remote
+  #   config:
+  #     base_url: "https://peer.example:8787"    # the peer loomcycle instance
+  #     api_key_env: LOOMCYCLE_PEER_MEMORY_KEY   # env NAME of the peer bearer (allowlisted)
+  #   fallback_on_error: inprocess               # degrade to LOCAL memory when the peer is unreachable
+  #   tenancy_strategy:                          # optional; "" = one shared credential
+  #     kind: key_per_tenant                     # a distinct peer credential per local tenant
+  #     env_pattern: LOOMCYCLE_PEER_{tenant_id}_KEY
+  #   # (shared_key_with_prefix is NOT supported for kind: remote — the peer
+  #   #  search API has no key-prefix param, so a namespaced search can't be
+  #   #  tenant-scoped; use key_per_tenant.)
+
+# ─── Change subscriptions — push memory/document change events (RFC CD Part C) ─
+# Deliver value-free change events (the coordinate of WHAT changed, never the
+# value) to an HTTP callback, HMAC-signed. REQUIRES the change feed to be on:
+# LOOMCYCLE_MEMORY_CHANGES_ENABLED=1 (see docs/CONFIGURATION.md). Delivery is
+# at-least-once — a persisted per-subscription cursor resumes across restarts,
+# and the subscriber dedupes on the monotonic seq. The signature is
+# X-Loomcycle-Signature = hex(hmac-sha256(secret, body)), the same scheme
+# loomcycle's inbound webhook verifier checks. (The SSE pull feed —
+# GET /v1/_memory/changes — needs no subscription; see docs/EXTERNAL_API.md.)
+change_subscriptions: {}
+  # my-consumer:
+  #   callback_url: "https://consumer.example/loomcycle-changes"
+  #   secret_env: LOOMCYCLE_CHANGE_SUB_SECRET    # env NAME of the HMAC key (allowlisted); omit = unsigned
+  #   tenant_id: ""                              # which tenant's feed ("" = shared/default)
+  #   scope: user                                # optional filter: agent | user | tenant
+  #   kinds: [memory, document.chunk.updated]    # optional; family "memory"/"document" or exact types
+  #   allow_private_host: false                  # true to deliver to a private-network callback (SSRF opt-in)
+  #   disabled: false
+
 # ─── Default routing for agents that don't specify their own ──────────
 # Used by agents that declare neither `tier:` nor an explicit
 # `provider:`+`model:` pin. v0.6.x back-compat path; tier-based agents

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -75,6 +76,8 @@ import (
 	// Deterministic stub embedder for runtime tests; its init() registers the
 	// "stub" provider ONLY when LOOMCYCLE_EMBEDDER_STUB=1, so it is invisible
 	// to a production binary that never sets the flag.
+	"github.com/denn-gubsky/loomcycle/internal/changesub"
+	"github.com/denn-gubsky/loomcycle/internal/netguard"
 	_ "github.com/denn-gubsky/loomcycle/internal/providers/stubembedder"
 	"github.com/denn-gubsky/loomcycle/internal/resolve"
 	"github.com/denn-gubsky/loomcycle/internal/retention"
@@ -159,6 +162,65 @@ func memoryChangesRetention() time.Duration {
 		}
 	}
 	return 24 * time.Hour
+}
+
+// changeSubDeliveryTimeout bounds each outbound change-subscription POST.
+const changeSubDeliveryTimeout = 30 * time.Second
+
+// resolveChangeSubSecret resolves a subscription's secret_env NAME to its value,
+// gated by the same credential allowlist config-load validation uses — so a
+// callback signing key can never be one of loomcycle's own infra secrets.
+// Returns only the env-var NAME in errors, never the value.
+func resolveChangeSubSecret(name string) (string, error) {
+	if !config.EnvNameCredentialSafe(name) {
+		return "", fmt.Errorf("secret_env %q is not an allowed credential env var", name)
+	}
+	v := os.Getenv(name)
+	if v == "" {
+		return "", fmt.Errorf("secret_env %q is not set", name)
+	}
+	return v, nil
+}
+
+// changeSubDeliveryInterval is how often the RFC CD Part C push engine tails the
+// feed. Default 5s; override with LOOMCYCLE_CHANGE_SUB_INTERVAL_MS.
+func changeSubDeliveryInterval() time.Duration {
+	if s := os.Getenv("LOOMCYCLE_CHANGE_SUB_INTERVAL_MS"); s != "" {
+		if n, err := strconv.Atoi(s); err == nil && n > 0 {
+			return time.Duration(n) * time.Millisecond
+		}
+	}
+	return 5 * time.Second
+}
+
+// resolveChangeSubscriptions turns the static change_subscriptions config into
+// deliverable subscriptions, each with its OWN SSRF-guarded client — the
+// callback host is private-allowlisted only when allow_private_host is set, so
+// one subscription's opt-in never widens another's dial reach. Disabled entries
+// are skipped.
+func resolveChangeSubscriptions(cfg *config.Config) []changesub.Subscription {
+	var out []changesub.Subscription
+	for name, sub := range cfg.ChangeSubscriptions {
+		if sub.Disabled {
+			continue
+		}
+		var allow []string
+		if sub.AllowPrivateHost {
+			if u, err := url.Parse(sub.CallbackURL); err == nil && u.Hostname() != "" {
+				allow = []string{u.Hostname()}
+			}
+		}
+		out = append(out, changesub.Subscription{
+			Name:        name,
+			CallbackURL: sub.CallbackURL,
+			TenantID:    sub.TenantID,
+			Scope:       sub.Scope,
+			Kinds:       sub.Kinds,
+			SecretEnv:   sub.SecretEnv,
+			Client:      netguard.NewGuardedClient(changeSubDeliveryTimeout, allow),
+		})
+	}
+	return out
 }
 
 // asPostgresStore unwraps any store decorators (the CDC wrapper) and returns
@@ -2615,6 +2677,22 @@ func main() {
 				}
 			})
 		log.Printf("memory: change-feed retention sweeper interval=1h window=%s", window)
+	}
+
+	// RFC CD Part C (push) — deliver change events to operator-declared HTTP
+	// callbacks. Only when the feed is enabled AND subscriptions are declared;
+	// advisory-gated so ONE replica delivers per tick (the persisted cursor is
+	// shared). Each subscription's callback is dialed through its own
+	// SSRF-guarded client (private hosts blocked unless allow_private_host).
+	if memoryChangesEnabled() && storeIface != nil && len(cfg.ChangeSubscriptions) > 0 {
+		subs := resolveChangeSubscriptions(cfg)
+		if len(subs) > 0 {
+			deliverer := changesub.New(storeIface, resolveChangeSubSecret, log.Printf)
+			interval := changeSubDeliveryInterval()
+			go runAdvisoryGatedSweeper(bgCtx, interval, advisoryLock, coord.LockKeyChangeSubDelivery, "change_subscriptions",
+				func(ctx context.Context) { deliverer.RunOnce(ctx, subs) })
+			log.Printf("memory: change-subscription push engine — %d subscription(s), interval=%s", len(subs), interval)
+		}
 	}
 
 	// Dead-link reconciliation: the only layer that actually COLLECTS chunk

--- a/docs/EXTERNAL_API.md
+++ b/docs/EXTERNAL_API.md
@@ -72,3 +72,36 @@ generated client covers the whole surface below.
   with a diagnostic `code`.
 - The spec is kept honest by a drift test that fails if a `Document` / `Path`
   tool op is added or removed without updating the contract.
+
+## Change feed — react to changes instead of polling
+
+When the change-data-capture feed is enabled (`LOOMCYCLE_MEMORY_CHANGES_ENABLED=1`), loomcycle emits a **value-free** change event on every memory/document write — the coordinate of *what* changed (`{seq, type, tenant, scope, scope_id, key|chunk_id, at}`), not the value. A consumer reads the current value via the data API above. Off by default: when off there is zero overhead and no table growth.
+
+**Subscribe (pull, SSE).** `GET /v1/_memory/changes?since=<seq>` and `GET /v1/_document/changes?since=<seq>` stream events as they happen; `seq` is a monotonic cursor to resume from. `substrate:tenant` scope; each stream is your own tenant's changes only (not member-accessible — the feed is operator observability).
+
+**Push (webhook).** Declare a `change_subscriptions:` entry in operator yaml and loomcycle POSTs signed batches to your callback:
+
+```yaml
+change_subscriptions:
+  my-consumer:
+    callback_url: "https://consumer.example/loomcycle-changes"
+    secret_env: LOOMCYCLE_CHANGE_SUB_SECRET   # env NAME of the HMAC key (allowlisted)
+    tenant_id: ""                             # which tenant's feed ("" = shared/default)
+    kinds: [memory, document.chunk.updated]   # optional (scope, kinds) filter
+    # allow_private_host: true                # to deliver to a private-network callback
+```
+
+Each POST carries `X-Loomcycle-Signature: hex(hmac-sha256(secret, body))` — verify it with the secret to authenticate the sender. Delivery is **at-least-once** (a persisted cursor resumes across restarts); dedupe on the `seq`.
+
+**Environment flags:**
+
+- `LOOMCYCLE_MEMORY_CHANGES_ENABLED=1` — turn the feed on.
+- `LOOMCYCLE_MEMORY_CHANGES_RETENTION_HOURS` — how long change rows are kept (default 24).
+- `LOOMCYCLE_CHANGE_SUB_INTERVAL_MS` — push delivery poll interval (default 5000).
+
+## loomcycle → loomcycle, and the gRPC/Python twin
+
+Two more ways to consume the same memory surface:
+
+- **A peer as a memory backend.** A `kind: remote` memory backend proxies an agent's memory to *another* loomcycle instance's `/v1/_memory/*` — one loomcycle uses another's memory as a backend (the peer embeds server-side). See [MEMORY-BACKENDS.md](MEMORY-BACKENDS.md).
+- **gRPC / Python.** The memory surface is also a gRPC RPC (`Memory`), so the Python client reaches it the same way it reaches documents and paths: `await client.memory({"op": "get", "scope": "user", "key": "tone"})`. The TypeScript client uses the HTTP surface above.

--- a/docs/MEMORY-BACKENDS.md
+++ b/docs/MEMORY-BACKENDS.md
@@ -40,11 +40,18 @@ named backend; absent, the agent uses the operator-default (in-process).
 The backend NAME is operator-resolved and stamped onto the run — it is
 **never** model/tool input (same trust posture as the memory scope).
 
-One backend kind ships today:
+Two backend kinds ship today:
 
 | kind        | where state lives                        | when to use |
 |-------------|------------------------------------------|-------------|
 | `inprocess` | loomcycle's own store + embedder (default) | single binary, no external dependency, lowest latency |
+| `remote`    | **another loomcycle instance's** `/v1/_memory/*` (RFC CD Part B) | share or centralize memory across instances; the peer embeds server-side |
+
+A `remote` backend proxies an agent's memory to a peer loomcycle. Unlike the
+external LLM-extract memory *products* the earlier `mem9` slot targeted, a peer
+loomcycle is a **faithful** flat KV+vector store — synchronous `set`→`get`, real
+`stats`, real vector `search` — so it plugs in behind the same six-method
+`memory.Backend` with no paradigm mismatch. See **`kind: remote`** below.
 
 An external REST backend (`mem9`) shipped between v0.15.0 and the removal
 below. It was retired once the in-process backend became a native memory
@@ -67,16 +74,12 @@ memory_backends:
     kind: inprocess
 ```
 
-That is the whole live surface. The persisted definition shape also carries
-`config` (`base_url` / `api_version` / `api_key_env`), `tenancy_strategy`,
-`fallback_on_error`, and `health_check_interval_seconds`. **No shipped kind
-reads any of them** — they are retained because the shape is content-addressed
-and mirrored three ways (operator yaml, the substrate write shape, the
-substrate read shape), so removing them is a storage change rather than a
-docs change. Treat them as **reserved**: set them and nothing happens.
-
-Two are still *validated* at authoring time, deliberately, so the persisted
-shape can never hold a state a future external kind would act on unsafely:
+For `inprocess` that is the whole surface. The definition also carries `config`
+(`base_url` / `api_version` / `api_key_env`), `tenancy_strategy`,
+`fallback_on_error`, and `health_check_interval_seconds` — **inert for
+`inprocess`** (set them and nothing happens) but **consumed by `kind: remote`**
+(below). They are validated at authoring time regardless of kind, so the
+persisted shape can never hold a state a backend would act on unsafely:
 
 - `tenancy_strategy.kind: shared_key_with_prefix` requires a
   `prefix_pattern` containing `{tenant_id}`. An empty or token-less prefix
@@ -86,6 +89,47 @@ shape can never hold a state a future external kind would act on unsafely:
   to contain `{tenant_id}`.
 
 `api_key_env` is an env-var **name**, never a plaintext key.
+
+## `kind: remote` — a peer loomcycle (RFC CD Part B)
+
+A `remote` backend HTTP-proxies the six memory ops to another loomcycle
+instance's `/v1/_memory/*`. The peer embeds server-side, so this instance needs
+no embedder for it; `get`/`set`/`delete`/`list`/`search`/`stats` all round-trip.
+
+```yaml
+memory_backends:
+  peer:
+    kind: remote
+    config:
+      base_url: "https://peer.example:8787"    # the peer loomcycle instance
+      api_key_env: LOOMCYCLE_PEER_MEMORY_KEY    # env NAME of the peer bearer
+    fallback_on_error: inprocess                # degrade to LOCAL memory if the peer is down
+    tenancy_strategy:                           # optional; omit = one shared credential
+      kind: key_per_tenant
+      env_pattern: LOOMCYCLE_PEER_{tenant_id}_KEY
+```
+
+- **`config.base_url`** (required) — the peer's origin. Dialed through an SSRF
+  guard; a private-network peer (a sibling replica, a tailnet host) is reached
+  because the operator declared it, while a redirect to any *other* private
+  address is still refused.
+- **`config.api_key_env`** — the env-var **name** of the bearer minted on the
+  *peer* (a `substrate:tenant` or non-isolated member token). Credential-
+  allowlisted (`LOOMCYCLE_*`-prefixed or a known third-party key) and resolved
+  at use time, so it can never be pointed at one of loomcycle's own infra
+  secrets. Sent as `Authorization: Bearer`; never logged.
+- **`fallback_on_error: inprocess`** — wrap the remote so an unreachable peer
+  **degrades to local memory per-op** instead of failing the run. A genuine
+  "key absent" from the peer is a valid answer and does *not* fall back (it
+  would mask a remote deletion).
+- **`tenancy_strategy`** — `key_per_tenant` maps each local tenant to its own
+  peer credential (env name from `env_pattern`). `shared_key_with_prefix` is
+  **not supported** for `kind: remote`: the peer search API has no key-prefix
+  parameter, so a namespaced search could not be tenant-scoped. Use
+  `key_per_tenant`, or one shared credential (no strategy).
+
+The peer's `/v1/_memory/*` is the same surface published in the OpenAPI contract
+(`GET /v1/openapi.json`, `/v1/docs`) — see [EXTERNAL_API.md](EXTERNAL_API.md).
 
 ## Memory layer: add / recall
 

--- a/internal/changesub/changesub.go
+++ b/internal/changesub/changesub.go
@@ -1,0 +1,220 @@
+// Package changesub delivers value-free memory/document change events to
+// operator-declared HTTP callbacks (RFC CD Part C — push). It is the outbound
+// twin of the SSE change feed: an engine tails the change feed per subscription,
+// filters by (scope, kinds), and POSTs HMAC-signed batches to a callback.
+//
+// Delivery is AT-LEAST-ONCE: a persisted per-subscription cursor (advanced only
+// after a successful POST) resumes across restarts, and the subscriber dedupes
+// on the monotonic seq. The signature is X-Loomcycle-Signature =
+// hex(hmac-sha256(secret, body)) — the same scheme loomcycle's inbound webhook
+// verifier checks, so a peer can verify it and any consumer can with the
+// documented scheme.
+//
+// The engine only runs when LOOMCYCLE_MEMORY_CHANGES_ENABLED (the feed exists)
+// and at least one subscription is declared. The SSRF-guarded HTTP client and
+// the secret-env allowlist are injected by the caller (main.go), so this
+// package stays testable against an httptest receiver.
+package changesub
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// Subscription is a resolved change subscription (config.ChangeSubscription +
+// its name + the SSRF-guarded client the caller built for its host).
+type Subscription struct {
+	Name        string
+	CallbackURL string
+	TenantID    string
+	Scope       string   // "" = any scope
+	Kinds       []string // "" = all; exact types or the "memory"/"document" family
+	SecretEnv   string   // "" = unsigned
+	Client      *http.Client
+}
+
+// Store is the subset of store.Store the deliverer needs.
+type Store interface {
+	GetMemoryChangesSince(ctx context.Context, tenantID string, afterSeq int64, limit int) ([]store.MemoryChange, error)
+	GetChangeSubscriptionCursor(ctx context.Context, name string) (int64, error)
+	SetChangeSubscriptionCursor(ctx context.Context, name string, seq int64) error
+}
+
+// Deliverer delivers pending change events to subscriptions.
+type Deliverer struct {
+	store      Store
+	secretFor  func(envName string) (string, error) // allowlist-gated env resolve
+	logf       func(string, ...any)
+	batchLimit int
+	maxRetries int
+}
+
+// New builds a Deliverer. secretFor resolves an env-var NAME to its value
+// (allowlist-gated); logf may be nil.
+func New(s Store, secretFor func(string) (string, error), logf func(string, ...any)) *Deliverer {
+	return &Deliverer{store: s, secretFor: secretFor, logf: logf, batchLimit: 200, maxRetries: 3}
+}
+
+// RunOnce delivers pending changes for every subscription, draining each
+// subscription's backlog. Called on a ticker (advisory-gated in cluster mode).
+func (d *Deliverer) RunOnce(ctx context.Context, subs []Subscription) {
+	for _, sub := range subs {
+		for {
+			fetched, err := d.deliverOnce(ctx, sub)
+			if err != nil {
+				if d.logf != nil {
+					d.logf("change_subscriptions.%s: delivery failed (will retry): %v", sub.Name, err)
+				}
+				break
+			}
+			if fetched < d.batchLimit || ctx.Err() != nil {
+				break // drained (or cancelled)
+			}
+		}
+	}
+}
+
+// deliverOnce processes one batch for a subscription. It fetches the next window
+// of changes past the cursor, POSTs the ones matching the filter, and — only on
+// a successful POST — advances + persists the cursor over the WHOLE fetched
+// window (filtered-out rows are skipped, not re-scanned). Returns how many rows
+// were fetched (== batchLimit means more may remain). On a POST failure the
+// cursor is left untouched so the next tick re-attempts (at-least-once).
+func (d *Deliverer) deliverOnce(ctx context.Context, sub Subscription) (int, error) {
+	cursor, err := d.store.GetChangeSubscriptionCursor(ctx, sub.Name)
+	if err != nil {
+		return 0, fmt.Errorf("read cursor: %w", err)
+	}
+	changes, err := d.store.GetMemoryChangesSince(ctx, sub.TenantID, cursor, d.batchLimit)
+	if err != nil {
+		return 0, fmt.Errorf("read changes: %w", err)
+	}
+	if len(changes) == 0 {
+		return 0, nil
+	}
+	maxSeq := changes[len(changes)-1].Seq
+
+	matched := make([]store.MemoryChange, 0, len(changes))
+	for _, ch := range changes {
+		if matches(ch, sub) {
+			matched = append(matched, ch)
+		}
+	}
+	if len(matched) > 0 {
+		body, mErr := json.Marshal(deliveryBatch{Subscription: sub.Name, Changes: matched})
+		if mErr != nil {
+			return 0, mErr
+		}
+		if pErr := d.post(ctx, sub, body); pErr != nil {
+			return 0, pErr // leave the cursor — retry next tick
+		}
+	}
+	if err := d.store.SetChangeSubscriptionCursor(ctx, sub.Name, maxSeq); err != nil {
+		return 0, fmt.Errorf("advance cursor: %w", err)
+	}
+	return len(changes), nil
+}
+
+// deliveryBatch is the POST body — value-free (each MemoryChange is a coordinate,
+// not a value).
+type deliveryBatch struct {
+	Subscription string               `json:"subscription"`
+	Changes      []store.MemoryChange `json:"changes"`
+}
+
+func matches(ch store.MemoryChange, sub Subscription) bool {
+	if sub.Scope != "" && string(ch.Scope) != sub.Scope {
+		return false
+	}
+	if len(sub.Kinds) == 0 {
+		return true
+	}
+	t := string(ch.Type)
+	for _, k := range sub.Kinds {
+		switch {
+		case k == t:
+			return true
+		case k == "memory" && strings.HasPrefix(t, "memory."):
+			return true
+		case k == "document" && strings.HasPrefix(t, "document."):
+			return true
+		}
+	}
+	return false
+}
+
+// post signs + POSTs the body, retrying with bounded backoff on a transport
+// error or non-2xx. A secret-resolution failure (config error) is NOT retried.
+// The body carries no secret; errors carry only the env-var name.
+func (d *Deliverer) post(ctx context.Context, sub Subscription, body []byte) error {
+	var sig string
+	if sub.SecretEnv != "" {
+		secret, err := d.secretFor(sub.SecretEnv)
+		if err != nil {
+			return fmt.Errorf("signing key: %w", err) // config error — don't retry
+		}
+		sig = sign(secret, body)
+	}
+	var lastErr error
+	for attempt := 0; attempt <= d.maxRetries; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(backoff(attempt)):
+			}
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, sub.CallbackURL, bytes.NewReader(body))
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("User-Agent", "loomcycle-change-subscription")
+		req.Header.Set("X-Loomcycle-Subscription", sub.Name)
+		if sig != "" {
+			req.Header.Set("X-Loomcycle-Signature", sig)
+		}
+		resp, err := sub.Client.Do(req)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+		_ = resp.Body.Close()
+		if resp.StatusCode/100 == 2 {
+			return nil
+		}
+		lastErr = fmt.Errorf("callback %s returned %d", sub.CallbackURL, resp.StatusCode)
+	}
+	return lastErr
+}
+
+// sign returns hex(hmac-sha256(secret, body)) — symmetric with loomcycle's
+// inbound webhook verifier (internal/api/webhook/signature.go compareHMAC).
+func sign(secret string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func backoff(attempt int) time.Duration {
+	d := 100 * time.Millisecond
+	for i := 1; i < attempt; i++ {
+		d *= 4
+	}
+	if d > 5*time.Second {
+		d = 5 * time.Second
+	}
+	return d
+}

--- a/internal/changesub/changesub_test.go
+++ b/internal/changesub/changesub_test.go
@@ -1,0 +1,159 @@
+package changesub
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+type fakeStore struct {
+	changes []store.MemoryChange
+	cursors map[string]int64
+}
+
+func (f *fakeStore) GetMemoryChangesSince(_ context.Context, tenantID string, afterSeq int64, limit int) ([]store.MemoryChange, error) {
+	var out []store.MemoryChange
+	for _, ch := range f.changes {
+		if ch.TenantID == tenantID && ch.Seq > afterSeq {
+			out = append(out, ch)
+			if len(out) == limit {
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeStore) GetChangeSubscriptionCursor(_ context.Context, name string) (int64, error) {
+	return f.cursors[name], nil
+}
+
+func (f *fakeStore) SetChangeSubscriptionCursor(_ context.Context, name string, seq int64) error {
+	f.cursors[name] = seq
+	return nil
+}
+
+func seeded() *fakeStore {
+	return &fakeStore{
+		cursors: map[string]int64{},
+		changes: []store.MemoryChange{
+			{Seq: 1, TenantID: "acme", Type: store.MemoryChangeSet, Scope: store.MemoryScopeAgent, ScopeID: "a1", Key: "k1"},
+			{Seq: 2, TenantID: "acme", Type: store.DocumentChangeUpdated, Scope: store.MemoryScopeAgent, ScopeID: "a1", ChunkID: "CID"},
+			{Seq: 3, TenantID: "globex", Type: store.MemoryChangeSet, Scope: store.MemoryScopeUser, ScopeID: "u1", Key: "z"},
+		},
+	}
+}
+
+const testSecret = "s3cr3t"
+
+func testSecretFor(string) (string, error) { return testSecret, nil }
+
+func TestDeliver_SignsBatchAndAdvancesCursor(t *testing.T) {
+	fs := seeded()
+	var gotSig string
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		gotSig = r.Header.Get("X-Loomcycle-Signature")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	d := New(fs, testSecretFor, nil)
+	sub := Subscription{Name: "s1", CallbackURL: srv.URL, TenantID: "acme", SecretEnv: "SECRET", Client: srv.Client()}
+	d.RunOnce(context.Background(), []Subscription{sub})
+
+	// acme has seqs 1,2 (globex's 3 is another tenant) → cursor advances to 2.
+	if fs.cursors["s1"] != 2 {
+		t.Errorf("cursor = %d, want 2", fs.cursors["s1"])
+	}
+	// The signature verifies against the body with the shared secret.
+	if want := sign(testSecret, gotBody); want != gotSig {
+		t.Errorf("signature = %q, want %q", gotSig, want)
+	}
+	// The body is the value-free batch (both acme changes, no value field).
+	var batch deliveryBatch
+	if err := json.Unmarshal(gotBody, &batch); err != nil {
+		t.Fatalf("batch: %v", err)
+	}
+	if batch.Subscription != "s1" || len(batch.Changes) != 2 {
+		t.Errorf("batch = %+v", batch)
+	}
+	if batch.Changes[0].Key != "k1" || batch.Changes[1].ChunkID != "CID" {
+		t.Errorf("batch changes = %+v", batch.Changes)
+	}
+}
+
+func TestDeliver_FiltersButStillAdvancesCursor(t *testing.T) {
+	fs := seeded()
+	var count int
+	var delivered []store.MemoryChange
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var b deliveryBatch
+		_ = json.NewDecoder(r.Body).Decode(&b)
+		delivered = append(delivered, b.Changes...)
+		count++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	d := New(fs, testSecretFor, nil)
+	// Only memory.* changes → the document change (seq 2) is skipped, but the
+	// cursor still advances over it (no re-scan).
+	sub := Subscription{Name: "s1", CallbackURL: srv.URL, TenantID: "acme", Kinds: []string{"memory"}, Client: srv.Client()}
+	d.RunOnce(context.Background(), []Subscription{sub})
+
+	if len(delivered) != 1 || delivered[0].Type != store.MemoryChangeSet {
+		t.Errorf("delivered = %+v, want only the memory.set", delivered)
+	}
+	if fs.cursors["s1"] != 2 {
+		t.Errorf("cursor = %d, want 2 (advanced past the skipped document change)", fs.cursors["s1"])
+	}
+}
+
+func TestDeliver_RetriesThenAdvances(t *testing.T) {
+	fs := seeded()
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&hits, 1) == 1 {
+			w.WriteHeader(http.StatusBadGateway) // fail the first attempt
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	d := New(fs, testSecretFor, nil)
+	sub := Subscription{Name: "s1", CallbackURL: srv.URL, TenantID: "acme", Client: srv.Client()}
+	d.RunOnce(context.Background(), []Subscription{sub})
+
+	if atomic.LoadInt32(&hits) < 2 {
+		t.Errorf("expected a retry (hits=%d)", hits)
+	}
+	if fs.cursors["s1"] != 2 {
+		t.Errorf("cursor = %d, want 2 after the retry succeeded", fs.cursors["s1"])
+	}
+}
+
+func TestDeliver_FailureLeavesCursor(t *testing.T) {
+	fs := seeded()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError) // always fail
+	}))
+	defer srv.Close()
+
+	d := New(fs, testSecretFor, nil)
+	sub := Subscription{Name: "s1", CallbackURL: srv.URL, TenantID: "acme", Client: srv.Client()}
+	d.RunOnce(context.Background(), []Subscription{sub})
+
+	// At-least-once: a failed delivery must NOT advance the cursor.
+	if fs.cursors["s1"] != 0 {
+		t.Errorf("cursor = %d, want 0 (delivery failed, must retry next tick)", fs.cursors["s1"])
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -187,6 +187,13 @@ type Config struct {
 	// factory land in MR-3b.
 	MemoryBackends map[string]MemoryBackend `yaml:"memory_backends"`
 
+	// ChangeSubscriptions is the RFC CD Part C (push) registry of outbound
+	// change-feed subscriptions — where to POST value-free memory/document
+	// change events (HMAC-signed), and the (scope, kinds) filter. Delivered by
+	// the change-subscription engine only when LOOMCYCLE_MEMORY_CHANGES_ENABLED.
+	// Empty / nil = no push delivery (the SSE feed still works).
+	ChangeSubscriptions map[string]ChangeSubscription `yaml:"change_subscriptions"`
+
 	// Volumes is the RFC AH registry of named filesystem volumes — the
 	// universe of ro/rw roots an AgentDef may bind to (the filesystem
 	// analog of "registered tools" for tools). Each entry's `path`
@@ -2071,6 +2078,38 @@ type A2AExpectedSkill struct {
 // A 3-way drift test (yaml ↔ lookup.SubstrateWebhookDef ↔ json) pins
 // parity. on_complete reuses ScheduledRunHook — the same hook shape
 // ScheduleDef uses — rather than a parallel type.
+// ChangeSubscription declares one outbound memory/document change-feed
+// subscription (RFC CD Part C push). The engine tails the tenant's change feed,
+// filters by (scope, kinds), and POSTs value-free batches to CallbackURL,
+// HMAC-signed with the key named by SecretEnv. Delivery is at-least-once (a
+// persisted per-subscription cursor resumes across restarts; the subscriber
+// dedupes on the monotonic seq).
+type ChangeSubscription struct {
+	// CallbackURL is the HTTP(S) endpoint that receives the signed batch POST.
+	CallbackURL string `json:"callback_url,omitempty" yaml:"callback_url"`
+	// SecretEnv is the env-var NAME of the HMAC signing key (allowlist-gated,
+	// like a credential env). The value is sent to no one — it signs the body,
+	// carried as X-Loomcycle-Signature = hex(hmac-sha256(secret, body)), the
+	// same scheme loomcycle's inbound webhook verifier checks. Empty = unsigned.
+	SecretEnv string `json:"secret_env,omitempty" yaml:"secret_env"`
+	// TenantID is WHICH tenant's change feed to deliver. "" = the shared/default
+	// tenant. A subscription only ever sees its own tenant's changes.
+	TenantID string `json:"tenant_id,omitempty" yaml:"tenant_id"`
+	// Scope, when set, filters to changes in that memory scope (agent/user/tenant).
+	Scope string `json:"scope,omitempty" yaml:"scope"`
+	// Kinds, when non-empty, filters to these change types. Accepts exact types
+	// (memory.set, document.chunk.updated, …) OR the family shorthands "memory"
+	// / "document". Empty = all changes.
+	Kinds []string `json:"kinds,omitempty" yaml:"kinds"`
+	// AllowPrivateHost opts this subscription's callback in to a private-network
+	// address (a sibling service on the same host/tailnet). Off by default: the
+	// delivery client blocks private/loopback/metadata dials (SSRF) unless the
+	// operator vouches for the host here.
+	AllowPrivateHost bool `json:"allow_private_host,omitempty" yaml:"allow_private_host"`
+	// Disabled turns the subscription off without removing it.
+	Disabled bool `json:"disabled,omitempty" yaml:"disabled"`
+}
+
 type Webhook struct {
 	Enabled  bool   `json:"enabled,omitempty" yaml:"enabled"`
 	Delivery string `json:"delivery,omitempty" yaml:"delivery"`
@@ -5809,6 +5848,38 @@ func validate(c *Config) error {
 			}
 			if mb.TenancyStrategy.Kind == "shared_key_with_prefix" {
 				return fmt.Errorf("memory_backends.%s: kind=remote does not support tenancy_strategy=shared_key_with_prefix (use key_per_tenant)", bname)
+			}
+		}
+	}
+	// Static change subscriptions (RFC CD Part C push): a misconfigured callback
+	// can never deliver, so fail fast at load.
+	changeKindValid := map[string]bool{
+		"memory": true, "document": true,
+		"memory.set": true, "memory.delete": true, "memory.scope_deleted": true,
+		"document.chunk.updated": true, "document.chunk.deleted": true,
+	}
+	for sname, sub := range c.ChangeSubscriptions {
+		if sub.Disabled {
+			continue
+		}
+		if sub.CallbackURL == "" {
+			return fmt.Errorf("change_subscriptions.%s: callback_url is required", sname)
+		}
+		if u, uerr := url.Parse(sub.CallbackURL); uerr != nil || (u.Scheme != "http" && u.Scheme != "https") {
+			return fmt.Errorf("change_subscriptions.%s: callback_url %q must be an http(s) URL", sname, sub.CallbackURL)
+		}
+		if sub.SecretEnv != "" && !EnvNameCredentialSafe(sub.SecretEnv) {
+			return fmt.Errorf("change_subscriptions.%s: secret_env %q is not an allowed credential env var "+
+				"(must be LOOMCYCLE_-prefixed or a known third-party key, and not an infra secret)", sname, sub.SecretEnv)
+		}
+		switch sub.Scope {
+		case "", "agent", "user", "tenant":
+		default:
+			return fmt.Errorf("change_subscriptions.%s: scope %q must be agent, user, or tenant", sname, sub.Scope)
+		}
+		for _, k := range sub.Kinds {
+			if !changeKindValid[k] {
+				return fmt.Errorf("change_subscriptions.%s: unknown kind %q (want a change type or the family \"memory\"/\"document\")", sname, k)
 			}
 		}
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -141,6 +141,40 @@ mcp_servers:
 	}
 }
 
+// RFC CD Part C (push) — change_subscriptions validation.
+func TestChangeSubscriptionsValidation(t *testing.T) {
+	const base = "defaults: { provider: anthropic, model: x }\n"
+	cases := []struct {
+		name    string
+		yaml    string
+		wantErr bool
+	}{
+		{"valid", "change_subscriptions:\n  s1: { callback_url: \"https://example.com/hook\", secret_env: LOOMCYCLE_SUB_SECRET, scope: user, kinds: [memory, document.chunk.updated] }", false},
+		{"missing callback_url", "change_subscriptions:\n  s1: { secret_env: LOOMCYCLE_SUB_SECRET }", true},
+		{"non-http callback", "change_subscriptions:\n  s1: { callback_url: \"ftp://example.com\" }", true},
+		{"bad secret_env (not allowlisted)", "change_subscriptions:\n  s1: { callback_url: \"https://example.com\", secret_env: SOME_RANDOM_SECRET }", true},
+		{"bad scope", "change_subscriptions:\n  s1: { callback_url: \"https://example.com\", scope: cluster }", true},
+		{"unknown kind", "change_subscriptions:\n  s1: { callback_url: \"https://example.com\", kinds: [bogus] }", true},
+		{"disabled skips validation", "change_subscriptions:\n  s1: { disabled: true }", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			p := filepath.Join(tmp, "c.yaml")
+			if err := os.WriteFile(p, []byte(base+c.yaml+"\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			_, err := Load(p)
+			if c.wantErr && err == nil {
+				t.Errorf("expected a validation error, got nil")
+			}
+			if !c.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 // v0.8.6 system-channels validation rules.
 
 func TestValidationRejectsPeriodWithoutPublisherSystem(t *testing.T) {

--- a/internal/coord/advisory_lock.go
+++ b/internal/coord/advisory_lock.go
@@ -118,8 +118,12 @@ var (
 	// LockKeyMemoryChangesSweeper gates the RFC CD Part C change-feed retention
 	// prune so one replica per cluster prunes per tick.
 	LockKeyMemoryChangesSweeper int64
-	LockKeyDynamicAgentSweeper  int64
-	LockKeyReplicasSweeper      int64
+	// LockKeyChangeSubDelivery gates the RFC CD Part C (push) outbound
+	// change-subscription delivery so ONE replica delivers per tick — the
+	// persisted cursor is shared, so N replicas would double-deliver and race.
+	LockKeyChangeSubDelivery   int64
+	LockKeyDynamicAgentSweeper int64
+	LockKeyReplicasSweeper     int64
 	// LockKeyResumePausedRuns gates the one-shot boot-time re-dispatch of
 	// pause_state='paused' runs (F42 / RFC X Phase 2) so exactly ONE replica
 	// resurrects each paused run's loop in a cluster — not a periodic sweep.
@@ -185,6 +189,7 @@ func init() {
 	LockKeyInterruptsSweeper = fnvKey("interrupts_sweeper")
 	LockKeyMetricsSweeper = fnvKey("metrics_sweeper")
 	LockKeyMemoryChangesSweeper = fnvKey("memory_changes_sweeper")
+	LockKeyChangeSubDelivery = fnvKey("change_sub_delivery")
 	LockKeyDynamicAgentSweeper = fnvKey("dynamic_agent_sweeper")
 	LockKeyReplicasSweeper = fnvKey("replicas_sweeper")
 	LockKeyResumePausedRuns = fnvKey("resume_paused_runs")

--- a/internal/store/postgres/memory_changes.go
+++ b/internal/store/postgres/memory_changes.go
@@ -2,7 +2,10 @@ package postgres
 
 import (
 	"context"
+	"errors"
 	"time"
+
+	"github.com/jackc/pgx/v5"
 
 	"github.com/denn-gubsky/loomcycle/internal/store"
 )
@@ -60,4 +63,22 @@ func (s *Store) PruneMemoryChanges(ctx context.Context, olderThan time.Time) (in
 		return 0, err
 	}
 	return int(tag.RowsAffected()), nil
+}
+
+func (s *Store) GetChangeSubscriptionCursor(ctx context.Context, name string) (int64, error) {
+	var seq int64
+	err := s.pool.QueryRow(ctx, `SELECT last_seq FROM change_subscription_cursors WHERE name = $1`, name).Scan(&seq)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return 0, nil
+	}
+	return seq, err
+}
+
+func (s *Store) SetChangeSubscriptionCursor(ctx context.Context, name string, seq int64) error {
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO change_subscription_cursors(name, last_seq, updated_at) VALUES ($1, $2, now())
+		 ON CONFLICT(name) DO UPDATE SET last_seq = EXCLUDED.last_seq, updated_at = now()`,
+		name, seq,
+	)
+	return err
 }

--- a/internal/store/postgres/migrations/0071_change_subscription_cursors.down.sql
+++ b/internal/store/postgres/migrations/0071_change_subscription_cursors.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS change_subscription_cursors;

--- a/internal/store/postgres/migrations/0071_change_subscription_cursors.up.sql
+++ b/internal/store/postgres/migrations/0071_change_subscription_cursors.up.sql
@@ -1,0 +1,10 @@
+-- RFC CD Part C (push): the persisted per-subscription delivery cursor. The
+-- outbound change-subscription engine advances last_seq after a successful
+-- signed delivery, so push resumes at-least-once across a restart (the
+-- subscriber dedupes on the monotonic seq). Keyed by the operator-declared
+-- subscription name (change_subscriptions.<name>).
+CREATE TABLE IF NOT EXISTS change_subscription_cursors (
+	name       TEXT PRIMARY KEY,
+	last_seq   BIGINT NOT NULL DEFAULT 0,
+	updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/internal/store/sqlite/memory_changes.go
+++ b/internal/store/sqlite/memory_changes.go
@@ -2,6 +2,8 @@ package sqlite
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/store"
@@ -61,4 +63,22 @@ func (s *Store) PruneMemoryChanges(ctx context.Context, olderThan time.Time) (in
 	}
 	n, _ := res.RowsAffected()
 	return int(n), nil
+}
+
+func (s *Store) GetChangeSubscriptionCursor(ctx context.Context, name string) (int64, error) {
+	var seq int64
+	err := s.db.QueryRowContext(ctx, `SELECT last_seq FROM change_subscription_cursors WHERE name = ?`, name).Scan(&seq)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
+	return seq, err
+}
+
+func (s *Store) SetChangeSubscriptionCursor(ctx context.Context, name string, seq int64) error {
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO change_subscription_cursors(name, last_seq, updated_at) VALUES (?, ?, ?)
+		 ON CONFLICT(name) DO UPDATE SET last_seq = excluded.last_seq, updated_at = excluded.updated_at`,
+		name, seq, time.Now().UnixNano(),
+	)
+	return err
 }

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -213,6 +213,14 @@ func (s *Store) migrate(ctx context.Context) error {
 		)`,
 		`CREATE INDEX IF NOT EXISTS memory_changes_by_tenant ON memory_changes(tenant_id, seq)`,
 		`CREATE INDEX IF NOT EXISTS memory_changes_by_at ON memory_changes(at)`,
+		// RFC CD Part C (push): the persisted per-subscription delivery cursor,
+		// so outbound change delivery resumes at-least-once across a restart.
+		// Mirrors postgres migration 0071.
+		`CREATE TABLE IF NOT EXISTS change_subscription_cursors (
+			name       TEXT PRIMARY KEY,
+			last_seq   INTEGER NOT NULL DEFAULT 0,
+			updated_at INTEGER NOT NULL  -- unix nano
+		)`,
 		// v0.8.21 audit view — cross-session queries by ts (descending)
 		// and ts-with-type-equality. Mirrors the postgres
 		// 0014_events_audit_index migration; both stores need the

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1752,6 +1752,16 @@ type Store interface {
 	// returns the count removed — keeps the opt-in feed table bounded.
 	PruneMemoryChanges(ctx context.Context, olderThan time.Time) (int, error)
 
+	// GetChangeSubscriptionCursor returns the last seq delivered to a
+	// change-subscription (RFC CD Part C push), or 0 if it has never delivered.
+	// The persisted cursor makes push delivery resume at-least-once across a
+	// restart (the subscriber dedupes on the monotonic seq).
+	GetChangeSubscriptionCursor(ctx context.Context, name string) (int64, error)
+
+	// SetChangeSubscriptionCursor upserts the last delivered seq for a
+	// change-subscription.
+	SetChangeSubscriptionCursor(ctx context.Context, name string, seq int64) error
+
 	// MemoryAtomicUpdate runs `reducer` as an atomic read-modify-write
 	// against (scope, scopeID, key). The reducer receives the current
 	// value (empty json.RawMessage when the row doesn't exist) and

--- a/internal/store/storetest/memory_changes.go
+++ b/internal/store/storetest/memory_changes.go
@@ -72,4 +72,27 @@ func testMemoryChangesFeed(t *testing.T, s store.Store) {
 	if left, _ := s.GetMemoryChangesSince(ctx, "acme", 0, 100); len(left) != 0 {
 		t.Errorf("after prune acme has %d rows, want 0", len(left))
 	}
+
+	// RFC CD Part C push — the persisted delivery cursor: 0 before any delivery,
+	// then upserts.
+	cur, err := s.GetChangeSubscriptionCursor(ctx, "sub-a")
+	if err != nil || cur != 0 {
+		t.Fatalf("initial cursor = %d (err %v), want 0", cur, err)
+	}
+	if err := s.SetChangeSubscriptionCursor(ctx, "sub-a", 42); err != nil {
+		t.Fatalf("SetChangeSubscriptionCursor: %v", err)
+	}
+	if cur, err = s.GetChangeSubscriptionCursor(ctx, "sub-a"); err != nil || cur != 42 {
+		t.Errorf("cursor after set = %d (err %v), want 42", cur, err)
+	}
+	if err := s.SetChangeSubscriptionCursor(ctx, "sub-a", 99); err != nil {
+		t.Fatalf("SetChangeSubscriptionCursor(update): %v", err)
+	}
+	if cur, _ = s.GetChangeSubscriptionCursor(ctx, "sub-a"); cur != 99 {
+		t.Errorf("cursor after update = %d, want 99", cur)
+	}
+	// A different subscription is independent.
+	if cur, _ = s.GetChangeSubscriptionCursor(ctx, "sub-b"); cur != 0 {
+		t.Errorf("independent sub-b cursor = %d, want 0", cur)
+	}
 }


### PR DESCRIPTION
## Why

The SSE change feed (merged, #1008) lets a consumer **subscribe**, but a consumer that wants events **pushed to its own endpoint** still had to hold an SSE connection. **RFC CD Part C's push mode** delivers value-free change events to an operator-declared HTTP callback — completing Part C. (You approved this scope: config-declared registration + a persisted cursor.)

## What

**Registration — config-declared `change_subscriptions:`** (mirrors the static `webhooks:` map): `callback_url`, `secret_env` (HMAC key, credential-allowlisted), `tenant_id`, an optional `(scope, kinds)` filter, `allow_private_host`, `disabled`. Validated at config-load (fail fast on a bad callback / unsafe `secret_env` / unknown `scope`|`kind`). Runtime substrate authoring stays a follow-on if ever needed.

**Persisted cursor — at-least-once.** A `change_subscription_cursors` table (sqlite + **postgres migration 0071**) + `Get`/`SetChangeSubscriptionCursor`, so push resumes across a restart; the subscriber dedupes on the monotonic `seq`.

**Delivery engine — `internal/changesub`.** Tails `GetMemoryChangesSince` per subscription, filters by `(scope, kinds)`, and POSTs a **value-free** batch signed `X-Loomcycle-Signature = hex(hmac-sha256(secret, body))` — the **same scheme loomcycle's inbound webhook verifier checks**, so a peer (or any consumer) can verify it. The cursor advances over the whole fetched window (skipped rows aren't re-scanned) **only after a successful POST**; a failure leaves it for the next tick. Bounded retry/backoff. The SSRF-guarded client + secret resolver are injected, so the package is testable against an httptest receiver.

**Wiring (cmd/loomcycle).** When `LOOMCYCLE_MEMORY_CHANGES_ENABLED` and subscriptions are declared: each is resolved to a deliverable with its **own** netguard client (the callback host is private-allowlisted only when `allow_private_host` is set, so one subscription's opt-in never widens another's dial reach), and the engine runs **advisory-gated** (a new coord lock key) so one replica delivers per tick — the shared cursor means N replicas would double-deliver and race. `resolveChangeSubSecret` gates `secret_env` through the same credential allowlist config uses.

## Tested

- `internal/changesub`: HMAC signing + cursor advance; `(scope, kinds)` filtering with cursor-skip; retry-then-advance; **failure-leaves-cursor** (at-least-once).
- Config: the valid case + five rejections.
- Store contract test (`MemoryChangesFeed`) gains cursor round-trip — verified on **both** sqlite and a **real local Postgres** (migration 0071).
- **Manual (live server):** feed enabled + a subscription pointed at a local receiver → a `PUT` to `/v1/_memory` delivered a value-free `memory.set` batch whose `X-Loomcycle-Signature` the receiver verified (`sig_ok=true`) via an independent `hmac-sha256`; delivery reached a private `127.0.0.1` callback because `allow_private_host` was set.
- Full suite: `go test ./...` → **0 failures, 90 packages**; gofmt + vet clean.

## RFC CD status

This completes **RFC CD** end to end: A (OpenAPI + Swagger UI), B (remote memory backend), C (SSE feed + this push mode), D (Python gRPC memory parity). Next up is **RFC CE** (remote document backend + sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD