### PR TITLE
ci: raise the race-test deadline, which main is already failing on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,14 +47,30 @@ jobs:
         # Per-package timeout. `-race` instrumentation runs several-fold slower,
         # and `go test ./...` runs package binaries concurrently, so on a
         # CPU-constrained CI runner the largest suites contend for cores. This
-        # was bumped 120s→300s once already as the codebase grew; the two
-        # largest suites have since crept up again — measured locally under
-        # -race on an idle box, internal/tools/builtin ~176s and
-        # internal/api/http ~161s (both PASS, no deadlock), but under CI
-        # contention they crossed the 300s deadline. 900s gives generous
-        # headroom under load while still catching a genuine deadlock (a hung
-        # test still fails, just later). No package should approach it.
-        run: go test -race -timeout 900s ./...
+        # was bumped 120s→300s→900s as the codebase grew, each time after the
+        # largest suite crossed the previous deadline under CI contention.
+        #
+        # 900s→1800s for the same reason, and the note above that "no package
+        # should approach it" had already stopped being true: on main,
+        # internal/tools/builtin measured 676s → 850s → 875s → 877s over
+        # successive runs and then timed out twice, at 96% of budget before it
+        # finally crossed. A deadline that a suite sits against does not fail
+        # honestly — it fails on whichever run the runner happened to be busy.
+        #
+        # IT IS NOT ONE SLOW TEST. Measured locally under -race: the package is
+        # 496s across 1010 test functions, the slowest single test is 4.1s, and
+        # the top twenty account for 29s — 6% of the total. It is a thousand
+        # tests that each provision a real store, so there is nothing to
+        # optimise short of restructuring the package, and a deadline is the
+        # wrong tool for that conversation.
+        #
+        # A timeout here is also WORSE than an ordinary failure, which is the
+        # real argument for headroom: the deadline kills tests mid-flight, so
+        # `FAIL ... 900.043s` arrives with ZERO `--- FAIL` lines and reads like
+        # a hung test rather than an exhausted budget. (The postgres store step
+        # below carries the same note, having learned it first.) A genuinely
+        # hung test still fails, just later.
+        run: go test -race -timeout 1800s ./...
 
       - name: gofmt check
         run: |


### PR DESCRIPTION
## Why

**`main` is currently red on this**, intermittently. `internal/tools/builtin` has been sitting against the 900s per-package deadline and has now crossed it twice:

| run | `internal/tools/builtin` |
|---|---|
| 31816446518 | ok **676s** |
| 31869341135 | ok 850s |
| 31871407519 | ok 875s |
| 31871468851 | **FAIL 900.048s** |
| 31871483633 | **FAIL 900.046s** |
| 31871506476 | ok 877s |

A suite at 96% of its budget does not fail honestly — it fails on whichever run the runner happened to be busy. The comment on this step claiming "no package should approach it" had already stopped being true.

The failure is also maximally confusing, which is the real argument for headroom rather than a tighter watch: the deadline kills tests mid-flight, so `FAIL ... 900.043s` arrives with **zero `--- FAIL` lines** and reads like a hung test rather than an exhausted budget. The postgres store step below carries the same note, having learned it first.

## It is not one slow test

I checked before reaching for the number. Measured locally under `-race`:

- the package is **496s across 1010 test functions**
- the slowest single test is **4.1s** (`TestMemoryBackendDefTool_RefusesUnsafeAPIKeyEnv`)
- the **top twenty account for 29s — 6%** of the total

It is a thousand tests that each provision a real store, so there is nothing to optimise short of restructuring the package, and a deadline is the wrong tool for that conversation. If the package should be split, that is worth doing on its own terms rather than under the pressure of a red build.

## What

`-timeout 900s` → `1800s`, matching what the postgres store step already uses, with the measurement recorded in the comment so the next person facing this has the numbers rather than the guess. A genuinely hung test still fails, just later.

Found while getting #1011 green — that PR touches only the memory bundle and its tests, and failed on this instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)