### PR TITLE
docs(memory): document verified writes, and close the adapter gap

### DIFF
--- a/adapters/ts/src/types.ts
+++ b/adapters/ts/src/types.ts
@@ -1447,7 +1447,18 @@ export type DocumentToolInput = {
     | "get_version"
     | "diff"
     | "export_canvas"
-    | "import_canvas";
+    | "import_canvas"
+    // The fact tier (RFC CC). upsert_chunk/supersede_chunk/graph_recall are above;
+    // these are the rest of it.
+    | "list_facts"
+    | "judge_fact"
+    | "verbatim_answer"
+    | "verification_stats"
+    | "propose_entity"
+    | "search"
+    // Remote document sources (RFC CE).
+    | "set_remote"
+    | "sync";
   scope?: "agent" | "user" | "tenant";
   /** Document id (get/delete_document) or chunk id (get/update/delete/move_chunk). */
   id?: string;
@@ -1493,6 +1504,36 @@ export type DocumentToolInput = {
   /** export_md: embed round-trippable chunk metadata + edges as HTML comments
    *  (default true server-side). false = clean human-facing Markdown. */
   include_metadata?: boolean;
+  /** search / graph_recall: free text. search matches it semantically against
+   *  chunk BODIES; graph_recall uses it to find starting chunks by title.
+   *  verbatim_answer: the lookup question to answer. */
+  query?: string;
+  /** upsert_chunk: the stable identity of this fact — upserting twice with the
+   *  same key updates ONE chunk. judge_fact: name the fact by key instead of id. */
+  natural_key?: string;
+  /** The entity this fact is about, paired with `type` (RFC CC). Documents
+   *  carry neither, which is what lets the ontology gate tell them apart. */
+  subject?: string;
+  /** upsert_chunk: the span of source text this fact was drawn from — the
+   *  evidence a judge checks the claim against. */
+  source_quote?: string;
+  /** judge_fact: whether the fact's recorded span supports it. The confidence
+   *  each maps to is set by the SERVER, so a caller cannot invent a scale.
+   *  `mistyped` = the span does support the claim, but it is filed as the wrong
+   *  kind of thing; the fix is a retype, so it stays visible. */
+  verdict?: "supported" | "unclear" | "unsupported" | "mistyped";
+  /** judge_fact: why. Required — a withheld fact whose ground is not stated is
+   *  indistinguishable from a bug. */
+  reason?: string;
+  /** list_facts / graph_recall: also return facts a judge marked unsupported.
+   *  They are withheld by default and never deleted, so this is how to read what
+   *  was refused, and why. */
+  include_refuted?: boolean;
+  /** verbatim_answer: how close a match must be before it can be quoted as an
+   *  answer (default 0.6 server-side). Cosine scale is a property of the
+   *  EMBEDDING MODEL, so tune this against your own — the response reports the
+   *  actual score even when it declines to answer. */
+  min_score?: number;
   /** import_md: an export_md-shaped Markdown document (headings = hierarchy;
    *  `<!-- loom: ... -->` metadata; `<!-- loom-edges: ... -->` trailer). Omit
    *  document_id to create a new document; pass it (+ optional parent_id) to

--- a/cmd/loomcycle/embedded/loomcycle.example.yaml
+++ b/cmd/loomcycle/embedded/loomcycle.example.yaml
@@ -472,6 +472,33 @@ memory_backends: {}
   #   #  search API has no key-prefix param, so a namespaced search can't be
   #   #  tenant-scoped; use key_per_tenant.)
 
+# ─── Memory: consolidation + verified writes ────────────────────────────────
+# The background consolidation pass distils chats into durable facts. Both
+# blocks below are OPTIONAL and both default to the values shown.
+memory:
+  consolidation:
+    # DUPLICATE-DETECTION BANDS. These are a property of your EMBEDDING MODEL,
+    # not of the procedure — the same paraphrase pair measured 0.7675 on one
+    # embedder and 0.9005 on another. Do not carry numbers between models;
+    # measure yours with `loomcycle memory-calibrate`.
+    merge_threshold: 0.95     # >= this ⇒ the same fact reworded — merge in place
+    related_threshold: 0.85   # this..merge ⇒ same subject, different claim — add
+
+    # VERIFIED WRITES (off by default). Every fact already carries the span of
+    # source text it came from; turning this on adds a judge that checks the
+    # claim against that span, and withholds — never deletes — one that fails.
+    #
+    # Costs about one model call per 8 facts written, on a cheaper tier than the
+    # extractor, plus up to 6 calls per pass working through older unjudged
+    # facts. The judge runs AFTER the watermark advances, so nothing it does can
+    # cost a fact, block a pass, or make a chat be re-read.
+    #
+    # A fact with no verdict stays fully visible, so a judge outage degrades
+    # verification rather than emptying memory. Read your coverage with
+    # `Document op=verification_stats`; measure the judge itself with
+    # `loomcycle memory-eval-judge`. See docs/VERIFIED-WRITES.md.
+    verify_writes: false
+
 # ─── Change subscriptions — push memory/document change events (RFC CD Part C) ─
 # Deliver value-free change events (the coordinate of WHAT changed, never the
 # value) to an HTTP callback, HMAC-signed. REQUIRES the change feed to be on:

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -613,6 +613,24 @@ It prints each class's `n / min / p05 / median / p95 / max`, the two class gaps,
 
 **Exit codes.** `0` — the duplicate and related classes separate, so a merge threshold exists. `1` — they overlap (no threshold both merges every duplicate and spares every distinct fact: either the model cannot tell these facts apart or a probe is mislabelled), or `--check` found the configured bands inert/destructive. `2` — invocation error.
 
+##### Verified writes — spans, a judge, and verbatim answers
+
+Every fact the pass stores also carries **the span of source text it was drawn from**, and a judge can be asked whether that span actually carries the claim. A fact that fails stops being returned by the fact surfaces without being deleted.
+
+```yaml
+memory:
+  consolidation:
+    verify_writes: true   # off by default; costs ~1 model call per 8 facts written
+```
+
+Read at runtime from `Context op=capabilities` → `consolidation`, exactly like the bands above, so it takes effect on the next pass. Unset, false, or an older runtime that does not report it all mean **off**, and a deployment that never enables it behaves as it did before.
+
+The verdict sets the fact's `confidence` (`supported` 0.9 / `unclear` 0.5 / `mistyped` 0.4 / `unsupported` 0.0); anything below **0.25** is withheld from `list_facts` and `graph_recall` and readable again with `include_refuted: true`. A fact with **no** verdict has a NULL confidence and stays visible — which is what makes a judge outage degrade verification rather than empty memory.
+
+`Document op=verification_stats` reports how much of a scope is verified; `Document op=verbatim_answer` answers a lookup question with a stored fact quoted next to its span, and refuses — with a reason — whenever the best match is unverified, below the similarity floor, or tied with another fact. `loomcycle memory-eval-judge` scores the judge against a corpus that measures false refusals and false admissions in both directions.
+
+**→ [docs/VERIFIED-WRITES.md](VERIFIED-WRITES.md)** covers the whole line: what each verdict means, where verification is and is not visible (`Memory.recall` deliberately still returns a refuted claim's text), how to measure your own judge, and the known limits.
+
 **What it measured on `embeddinggemma`.** 768-dim, served by `ollama-local`; the bundled corpus of 12 facts and 24 labelled probes, reading raw cosine (`Memory op=search`'s `score` is raw cosine — an exact self-match returns 1.0):
 
 | class | n | min | p05 | median | p95 | max |

--- a/docs/VERIFIED-WRITES.md
+++ b/docs/VERIFIED-WRITES.md
@@ -1,0 +1,144 @@
+# Verified writes (RFC CC)
+
+Every fact loomcycle stores carries **the span of source text it was drawn from**. A judge checks the claim against that span, and a fact that fails stops being returned — without being deleted. On top of that, a lookup question can be answered with the stored claim quoted verbatim next to its citation, with no generated text in the answer path at all.
+
+It is **off by default**. A deployment that never enables it behaves exactly as it did before.
+
+## The failure this exists for
+
+A memory pipeline writes what a model tells it to. Three things observed on a live store in one week:
+
+- a curator proposed entity types whose counts and example titles were copied out of its own prompt,
+- the extractor typed `location:user` as the subject of "the user resides in Cluj-Napoca",
+- a fact recorded an outage duration and an affected-user count that appear in no transcript.
+
+None of these look wrong. They are fluent, on-topic, and confidently stated, which is exactly why a better prompt does not fix them: **the component that fabricates is the component you would be asking not to.** Prompting was tried twice on the curator before this line was built.
+
+So the check moved out of the prompt and into the store: a claim must carry the text it came from, and something other than its author must be able to compare the two.
+
+## How it fits together
+
+| stage | what it does | model? |
+|---|---|---|
+| **span** | the consolidator derives each fact's supporting sentence from the transcript | no |
+| **deterministic gate** | rejects what word overlap alone can reject, at zero cost | no |
+| **judge** | asks whether the quote actually carries the claim | yes, batched |
+| **backfill** | sweeps facts stored before verification was on | yes, batched |
+| **verbatim answers** | quotes a verified fact instead of generating one | no |
+
+The span is **derived, not requested**. Asking the extractor for a `quote` field was measured and made it worse — it cost rule-following on a small local model, against a recorded baseline the unchanged prompt still hits. A derived span also cannot be fabricated: it is selected *from* the source, so it is in the source by construction.
+
+## Turning it on
+
+```yaml
+memory:
+  consolidation:
+    verify_writes: true
+```
+
+The consolidation pass reads this at runtime through its capabilities report, the same way it reads the similarity bands — so it takes effect on the next pass with no restart and no change to the bundled agent.
+
+**What it costs.** One model call per eight facts written, plus up to six calls per pass working through the backlog. The judge runs on a cheaper tier than the extractor, and it runs *after* the watermark advances, so nothing it does can cost a fact, block a pass, or make a chat be re-read.
+
+## What a verdict means
+
+The judge answers one question per fact in four words. The server owns what each is worth, so no caller can invent a scale:
+
+| verdict | confidence | effect |
+|---|---|---|
+| `supported` | 0.9 | the quote carries the claim |
+| `unclear` | 0.5 | it carries part of it, or cannot be told |
+| `mistyped` | 0.4 | the claim is true but filed as the wrong kind of thing |
+| `unsupported` | 0.0 | the quote does not carry the claim — **withheld** |
+
+Facts below **0.25** are withheld. Only `unsupported` falls below it: a judge that is unsure is not evidence against a claim, and a fact withheld on a maybe is a fact nobody will notice is gone.
+
+**Withheld is not deleted.** The claim stays in the store and stays readable with `include_refuted: true`, which returns it with the judge's stated reason. A wrong verdict is always recoverable by re-judging, never by restoring content something overwrote.
+
+**Never assessed is not refuted.** A fact with no verdict has a NULL confidence and stays fully visible. That is what makes a judge outage degrade *verification* rather than emptying memory: no judge configured, unreachable, timed out, or answering in a shape the caller cannot read all leave facts exactly where they were.
+
+## Where verification is visible — and where it is not
+
+The fact surfaces withhold: `list_facts`, both `graph_recall` paths.
+
+**`Memory.recall` does not.** Verification state lives on the entity tier, and nothing in the recall path reads it — making recall respect a verdict would mean either a second copy of one truth behind a store migration or a cross-tier join on every recall. The line is drawn where the state already is: the k/v tier records what was *said*, the entity tier is the curated view of what is *believed*.
+
+The consequence, stated so it is not discovered later: **a plain `Memory.recall` still returns a refuted claim's text.**
+
+## Measuring the judge — `loomcycle memory-eval-judge`
+
+A judge is a classifier in the write path, and its two error directions are not symmetric. A **false refusal** withholds a true fact and the loss is invisible; a **false admission** keeps a fabrication, which is where the store already is. So the gate is on false refusals, and the fabrication cases are measured without blocking.
+
+```bash
+loomcycle memory-eval-judge --provider ollama-local --model gemma4:latest
+```
+
+| flag | effect |
+|---|---|
+| `--provider` / `--model` | required; a score is only meaningful against a named triple |
+| `--effort` | defaults to the judge agent's configured effort |
+| `--baseline <file>` | compare against a committed baseline and gate on regressions |
+| `--update-baseline <file>` | record this run (refuses an incomplete or violation-bearing run) |
+| `--batch <n>` | candidates per call; defaults to what the consolidator ships |
+| `--no-gate` | report only |
+
+The corpus measures **both directions** — known-good facts that must be admitted, the fabrications actually observed, ambiguous cases that must come back `unclear`, and mistyping in both directions. A corpus of nothing but fabrications is scored perfectly by a judge that refuses everything, so the harness refuses a one-directional corpus outright.
+
+### What the measurement showed
+
+Same prompt, same corpus, effort low:
+
+| model | entailment | fabrication | partial | mistyping | false refusals |
+|---|---|---|---|---|---|
+| gemma4 (low tier — what ships) | 1.00 | 1.00 | 0.50 | 0.50 | **0** |
+| qwen3.6 (the extractor's tier) | 1.00 | 1.00 | 0.00 | 0.00 | **1** |
+
+The cheaper tier is not merely adequate here, it is **better on the axis that gates**. Both admit every plainly-supported claim and catch every fabrication. The difference is at the margin: the stronger model read "works on loomcycle and deploys it on TrueNAS" against a quote covering only the first half and answered `unsupported` — defensible as strictness, and a withheld true fact all the same.
+
+Entailment against a supplied span rewards a literal reader, and a stronger model brings inference to a task that does not want any. If your own numbers are bad, change the tier in your **tier policy** — never by pinning a provider or model on the agent.
+
+## Reading your coverage
+
+```json
+{"op": "verification_stats", "scope": "user"}
+```
+
+```json
+{"facts": 412, "with_span": 380, "judged": 210, "supported": 190,
+ "withheld": 12, "unverifiable_no_span": 32, "awaiting_judge": 170,
+ "verified_share": 0.46}
+```
+
+The two unverified populations are counted separately because they mean different things: a fact with **no span** can never be verified by anyone — the transcript it came from may be gone — while one merely **awaiting a judge** can. `verified_share` is the number to quote when deciding whether to trust the verbatim path.
+
+## Answering verbatim
+
+```json
+{"op": "verbatim_answer", "scope": "user", "query": "what is my github username"}
+```
+
+Returns the stored claim and the span it was verified against, with no generated text:
+
+```json
+{"answered": true, "answer": "The user's github username is denn.",
+ "source": "my github username is denn", "confidence": 0.9, "score": 0.94}
+```
+
+**The error direction is inverted from the judge's.** Here the dangerous failure is the confident *wrong* answer, because verbatim delivery reads as authority — a synthesised sentence invites the doubt a quotation suppresses. So every ambiguity resolves to no answer, and each refusal says which:
+
+- the best-matching fact is unverified, or was checked and not affirmed
+- it does not clear the similarity floor
+- a second fact matches about equally well
+
+The top-ranked fact must itself be the verified one. Quoting a worse-matching fact because it happens to be verified would answer with something known not to be the closest thing in the store.
+
+**`min_score` is not calibrated for your embedder.** Cosine scale is a property of the embedding model — the same pair measures 0.7675 on one and 0.9005 on another, which is why the consolidation bands are calibrated per deployment. The default is deliberately conservative, it is overridable per call, and the actual score is reported on every response including refusals so you can see what your embedder does before trusting it.
+
+It only works for lookup. "What is my GitHub username" has a verbatim answer; "how should I structure this migration" does not. This is an opportunistic fast path, never the whole answer path.
+
+## Known limits
+
+- **`mistyped` is not reliable** on the local models measured. One misses the filing error; the other gets it backwards in both directions, calling a correctly filed fact mistyped. It only ever reduces confidence and never withholds, so it costs precision rather than data — but an absence of mistyping verdicts is not evidence of an absence of mistyped facts.
+- **`Memory.recall` still returns refuted text**, as above.
+- **The verbatim similarity floor is uncalibrated.** There is no `memory-calibrate` equivalent for it yet.
+- **Facts stored before this shipped mostly have no span** and can only be counted, never verified. The backfill reports how many.

--- a/internal/tools/builtin/document_adapter_parity_test.go
+++ b/internal/tools/builtin/document_adapter_parity_test.go
@@ -1,0 +1,75 @@
+package builtin
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+)
+
+// TestDocumentOps_TypeScriptAdapterIsInParity.
+//
+// The TS adapter types `op` as a closed union, so an op missing from it is one a
+// TypeScript consumer cannot call without a compile error — the runtime would accept it
+// happily. Nothing linked the two lists, and they had drifted by eight ops before this
+// test existed: three from the fact tier, `search` and `propose_entity` from before that,
+// and two from remote document sources.
+//
+// The failure mode is what makes it worth a test rather than a habit. It is invisible
+// from the Go side (every server test passes), invisible from the adapter side (the type
+// is internally consistent), and only shows up as a consumer discovering their client
+// cannot express something the server has supported for months.
+func TestDocumentOps_TypeScriptAdapterIsInParity(t *testing.T) {
+	var schema struct {
+		Properties struct {
+			Op struct {
+				Enum []string `json:"enum"`
+			} `json:"op"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal([]byte(documentInputSchema), &schema); err != nil {
+		t.Fatalf("parse the document input schema: %v", err)
+	}
+	if len(schema.Properties.Op.Enum) == 0 {
+		t.Fatal("no ops in the schema — the test is reading the wrong thing")
+	}
+
+	path := filepath.Join("..", "..", "..", "adapters", "ts", "src", "types.ts")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read the TS adapter types: %v", err)
+	}
+	// The union runs from the first op to the `scope?:` field that follows it. Scoped
+	// that way rather than searching the whole file so an op name appearing in some
+	// unrelated comment cannot make this pass.
+	src := string(b)
+	start := indexOrFail(t, src, `| "create_document"`)
+	end := indexOrFail(t, src[start:], "scope?:") + start
+	union := src[start:end]
+	quoted := regexp.MustCompile(`"([a-z_]+)"`)
+	inTS := map[string]bool{}
+	for _, m := range quoted.FindAllStringSubmatch(union, -1) {
+		inTS[m[1]] = true
+	}
+
+	for _, op := range schema.Properties.Op.Enum {
+		if !inTS[op] {
+			t.Errorf("Document op %q is served by the runtime but MISSING from the TS adapter's "+
+				"op union — a TypeScript caller cannot express it. Add it to DocumentInput's `op` "+
+				"in adapters/ts/src/types.ts", op)
+		}
+	}
+}
+
+func indexOrFail(t *testing.T, haystack, needle string) int {
+	t.Helper()
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return i
+		}
+	}
+	t.Fatalf("could not find %q in the TS adapter types — the file's shape changed, so this "+
+		"parity test is no longer reading the op union", needle)
+	return 0
+}


### PR DESCRIPTION
Closes the discoverability gaps from the audit. No runtime behaviour changes.

## The feature line shipped undiscoverable

Nothing in `docs/` or the README mentioned `verify_writes`, `judge_fact`, `verbatim_answer` or `memory-eval-judge`. The config key appeared in exactly **two** places in the repo — both comments inside a code body. An operator could not learn it existed, let alone turn it on.

**`docs/VERIFIED-WRITES.md`** is the operator guide: what spans and verdicts mean, how to enable it and what it costs, where verification is visible and where it deliberately is **not** (`Memory.recall` still returns a refuted claim's text — a decision, not an oversight), how to measure your own judge, and the known limits, including that `mistyped` is unreliable on the local models measured and that the verbatim floor is uncalibrated. It is exported from the loomcycle document store, where the primary copy lives at `/loomcycle/docs/verified-writes`.

**`docs/TOOLS.md`** gains the config keys next to the consolidation bands — where someone reading about memory config already is — and links onward.

**`loomcycle.example.yaml` had no `memory:` block at all**, so neither the similarity bands nor the new key had a worked example. It has one now, with the cost and the fail-open behaviour stated where an operator will actually read them.

## The TS adapter was eight ops behind — only three of them mine

`op` is a closed union there, so a missing op is one a TypeScript consumer **cannot call** without a compile error while the runtime accepts it happily. Invisible from both sides: every Go test passes, the adapter's types are internally consistent, and it surfaces only when someone discovers their client cannot express something the server has supported for months.

| missing | since |
|---|---|
| `list_facts`, `search`, `propose_entity` | before this line |
| `judge_fact`, `verbatim_answer`, `verification_stats` | this line |
| `set_remote`, `sync` | remote document sources (#1015) |

All eight added, plus the input fields for the verified-writes ops (`source_quote`, `subject`, `verdict`, `reason`, `include_refuted`, `min_score`, `query`, `natural_key`) with the caveats documented in-editor — notably that `min_score` is not calibrated for your embedder.

**The real fix is the drift test**, not the careful edit: it reads the runtime's own op enum and fails naming any op the adapter cannot express. Same shape as the MCP description test, which is what caught `judge_fact` missing from the tool surface earlier in this line.

## Verified

- `tsc --noEmit` clean on the adapter.
- The parity test fails-before when an op is removed from the union.
- The example config parses and is covered by the existing config tests.
- `go test ./...` clean.

## Depends on #1014

The guide documents `verbatim_answer` and `verification_stats`, which land there. If this merges first, those two sections describe ops that do not exist yet for as long as #1014 is open.

**The Claude Code plugin is updated separately** in claude-code-plugin-loomcycle#27, which also carries the ontology-hierarchy docs that branch was already holding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)