### PR TITLE
feat(ui): a Memory tab — verification coverage, and a pass you can start

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1087,6 +1087,35 @@ export function documentQueryChunks(
   );
 }
 
+// VerificationStats is `Document op=verification_stats` — how much of a scope's fact
+// store carries evidence and a verdict.
+//
+// Every count except `facts` is OPTIONAL because the server omits `verified_share`
+// entirely on an empty store rather than reporting 0/0: a 0.00 share would read as
+// "nothing is verified", which is a different claim from "there is nothing to verify".
+export interface VerificationStats {
+  facts: number;
+  with_span?: number;
+  judged?: number;
+  supported?: number;
+  withheld?: number;
+  /** Facts with no span — they can never be verified by anyone, not merely not yet. */
+  unverifiable_no_span?: number;
+  awaiting_judge?: number;
+  /** supported / facts. Absent when there are no facts at all. */
+  verified_share?: number;
+}
+
+// getVerificationStats reads one scope's coverage. `browse.scopeId` targets another
+// subject, which is how the Settings panel reports on the user picked in the topbar
+// rather than on the operator reading the page.
+export function getVerificationStats(
+  scope: DocScope = "user",
+  browse?: BrowseScope,
+): Promise<VerificationStats> {
+  return substratePost("/v1/_document", { op: "verification_stats", scope }, browse);
+}
+
 export function documentGetChunk(id: string, scope: DocScope, browse?: BrowseScope): Promise<ChunkDetail> {
   return substratePost("/v1/_document", { op: "get_chunk", id, scope }, browse);
 }

--- a/web/src/lib/ontologyEditHref.test.ts
+++ b/web/src/lib/ontologyEditHref.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { ontologistRunHref, ontologyEditHref } from "./ontologyEditHref";
+import { consolidationRunHref, ontologistRunHref, ontologyEditHref } from "./ontologyEditHref";
 
 describe("ontologyEditHref", () => {
   // The regression. Without scope=tenant the viewer opens the tenant document at user
@@ -27,5 +27,26 @@ describe("ontologistRunHref", () => {
 
   it("works without a user, since the run's own scope is the survey scope", () => {
     expect(ontologistRunHref()).toContain("/run?agent=memory%2Fontologist");
+  });
+});
+
+describe("consolidationRunHref", () => {
+  it("stages the consolidator, and names the target in the prompt", () => {
+    const href = consolidationRunHref("alice");
+    expect(href).toContain("/run?agent=memory%2Fconsolidator");
+    expect(decodeURIComponent(href)).toContain("for alice");
+  });
+
+  it("does not invent a target when no user is picked", () => {
+    // The run form falls back to the principal's own subject, so a fabricated user
+    // in the prompt would describe a run that targets someone else.
+    expect(decodeURIComponent(consolidationRunHref())).toContain("your assigned memory target");
+    expect(consolidationRunHref()).not.toContain("undefined");
+  });
+
+  it("stages rather than starts — the href is the run page, not an API call", () => {
+    // The whole point of a link here: a settings click must not spend tokens. If this
+    // ever becomes a POST, this test should be the thing that argues about it.
+    expect(consolidationRunHref("alice").startsWith("/run?")).toBe(true);
   });
 });

--- a/web/src/lib/ontologyEditHref.ts
+++ b/web/src/lib/ontologyEditHref.ts
@@ -25,3 +25,22 @@ export function ontologistRunHref(userId?: string): string {
     : "Review the stored facts in this scope and suggest ontology improvements.";
   return `/run?agent=${encodeURIComponent("memory/ontologist")}&prompt=${encodeURIComponent(prompt)}`;
 }
+
+// consolidationRunHref stages a consolidation pass in the run terminal.
+//
+// A LINK, for the same reason the curation one is: a settings click that spends tokens
+// is a surprise, and a consolidation pass is the most expensive thing this UI can start
+// — one extractor call per chat read, plus the judge's calls when verification is on.
+// The operator should see the agent and the prompt before any of that runs.
+//
+// THE USER ID IS THE SCOPE, not decoration. The pass consolidates whichever user the RUN
+// belongs to (its scope is "user"), and the run form seeds that from the same topbar
+// picker this href reads — so the prompt naming a user and the run targeting one cannot
+// disagree. The prompt still names them, because an operator reviewing a staged run
+// should be able to see the target without inspecting the form.
+export function consolidationRunHref(userId?: string): string {
+  const prompt = userId
+    ? `Run one consolidation pass for ${userId}.`
+    : "Run one consolidation pass for your assigned memory target.";
+  return `/run?agent=${encodeURIComponent("memory/consolidator")}&prompt=${encodeURIComponent(prompt)}`;
+}

--- a/web/src/lib/verificationSummary.test.ts
+++ b/web/src/lib/verificationSummary.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { verificationSummary } from "./verificationSummary";
+
+describe("verificationSummary", () => {
+  it("an empty store reports no share at all, not 0%", () => {
+    // 0% reads as "nothing here is verified". "There is nothing to verify" is a
+    // different statement, and the one an operator would act on differently.
+    const s = verificationSummary({ facts: 0 });
+    expect(s.empty).toBe(true);
+    expect(s.sharePct).toBeNull();
+  });
+
+  it("a null response is treated as empty rather than as zero coverage", () => {
+    expect(verificationSummary(null).empty).toBe(true);
+    expect(verificationSummary(null).sharePct).toBeNull();
+  });
+
+  it("uses the server's share and never recomputes one", () => {
+    // supported/facts would be 0.5 here; the server says 0.25. The server's definition
+    // is what the gate uses, so a second one computed in the browser could disagree
+    // with the number a decision is made on.
+    const s = verificationSummary({ facts: 4, supported: 2, verified_share: 0.25 });
+    expect(s.sharePct).toBe(25);
+  });
+
+  it("omits the share when facts exist but the server sent none", () => {
+    expect(verificationSummary({ facts: 4 }).sharePct).toBeNull();
+  });
+
+  it("explains a zero judged count instead of leaving it looking broken", () => {
+    expect(verificationSummary({ facts: 10, judged: 0 }).showUnjudgedNote).toBe(true);
+    expect(verificationSummary({ facts: 10, judged: 3 }).showUnjudgedNote).toBe(false);
+  });
+
+  it("says withheld means hidden only when something actually is", () => {
+    expect(verificationSummary({ facts: 10, judged: 5, withheld: 2 }).showWithheldNote).toBe(true);
+    expect(verificationSummary({ facts: 10, judged: 5, withheld: 0 }).showWithheldNote).toBe(false);
+    expect(verificationSummary({ facts: 10, judged: 5 }).showWithheldNote).toBe(false);
+  });
+});

--- a/web/src/lib/verificationSummary.ts
+++ b/web/src/lib/verificationSummary.ts
@@ -1,0 +1,37 @@
+import type { VerificationStats } from "../api";
+
+// What the coverage panel should say about a scope, decided in one place.
+//
+// EXTRACTED FOR THE SAME REASON THE ONTOLOGY HREF WAS: the risky part is not the
+// rendering, it is a number that is wrong in a way that looks fine. Two specific ones:
+//
+//   - an EMPTY store must not report "0% verified". The server omits `verified_share`
+//     rather than dividing by zero, and a UI that computed its own would print 0%,
+//     which reads as "nothing here is verified" — a different claim from "there is
+//     nothing to verify", and one an operator would act on.
+//   - "0 judged" must come with its reason. The overwhelmingly likely cause is that
+//     verification was never enabled, and a bare zero reads as broken.
+export interface CoverageSummary {
+  /** No facts at all — show the "nothing stored yet" line and no numbers. */
+  empty: boolean;
+  /** Integer percent, or null when the server reported no share (an empty store). */
+  sharePct: number | null;
+  /** Facts exist but none carry a verdict — say why before someone reads it as a fault. */
+  showUnjudgedNote: boolean;
+  /** Something is withheld — say that withheld means hidden, not deleted. */
+  showWithheldNote: boolean;
+}
+
+export function verificationSummary(stats: VerificationStats | null): CoverageSummary {
+  if (!stats || stats.facts <= 0) {
+    return { empty: true, sharePct: null, showUnjudgedNote: false, showWithheldNote: false };
+  }
+  return {
+    empty: false,
+    // Rendered from the SERVER's share, never recomputed here: two definitions of
+    // "verified" would eventually disagree, and the server's is the one the gate uses.
+    sharePct: stats.verified_share === undefined ? null : Math.round(stats.verified_share * 100),
+    showUnjudgedNote: (stats.judged ?? 0) === 0,
+    showWithheldNote: (stats.withheld ?? 0) > 0,
+  };
+}

--- a/web/src/pages/SettingsView.tsx
+++ b/web/src/pages/SettingsView.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useState, type FormEvent } from "react";
 import { Link } from "react-router-dom";
-import { ontologistRunHref, ontologyEditHref } from "../lib/ontologyEditHref";
+import { verificationSummary } from "../lib/verificationSummary";
+import {
+  consolidationRunHref,
+  ontologistRunHref,
+  ontologyEditHref,
+} from "../lib/ontologyEditHref";
 import {
   CredentialMeta,
   CredentialScope,
@@ -16,6 +21,7 @@ import {
   getEnvTemplate,
   getHealth,
   getOntology,
+  getVerificationStats,
   getRuntimeState,
   listCredentials,
   listPresets,
@@ -26,6 +32,7 @@ import {
   setOntologyStatus,
   showPreset,
   OntologyTerm,
+  VerificationStats,
 } from "../api";
 import { usePrincipal, useUserId } from "../components/Layout";
 import LimitsView from "./LimitsView";
@@ -50,6 +57,7 @@ type Section =
   | "limits"
   | "routing"
   | "ontology"
+  | "memory"
   | "tokens"
   | "presets"
   | "runtime"
@@ -71,6 +79,10 @@ const SECTIONS: SectionDef[] = [
   // ScopeTenant and derive the tenant from the principal, so a tenant operator
   // reaches only its own.
   { id: "ontology", label: "Ontology", admin: false },
+  // Tenant-visible for the same reason: the coverage read goes through
+  // POST /v1/_document (ScopeTenant, subject resolved from the principal), and
+  // starting a pass is staged in the run terminal rather than done here.
+  { id: "memory", label: "Memory", admin: false },
   { id: "tokens", label: "Tokens", admin: true },
   { id: "presets", label: "Presets", admin: true },
   { id: "runtime", label: "Runtime", admin: true },
@@ -113,6 +125,7 @@ export default function SettingsView() {
         {section === "limits" && <LimitsView />}
         {section === "routing" && <RoutingView />}
         {section === "ontology" && <OntologySection />}
+        {section === "memory" && <MemorySection />}
         {section === "tokens" && <TokenManager />}
         {section === "presets" && <PresetsSection />}
         {section === "runtime" && <RuntimeSection />}
@@ -920,6 +933,147 @@ function OntologySection() {
           </div>
         </>
       )}
+    </div>
+  );
+}
+
+// ─── Memory operations ───────────────────────────────────────────────────────
+//
+// TWO THINGS AN OPERATOR CANNOT GET ANYWHERE ELSE: how much of a user's memory is
+// actually verified, and a way to run a pass NOW instead of waiting for the hourly
+// schedule, which ships disabled.
+//
+// The coverage read is what makes the rest legible. Without it, "is verification
+// working" gets answered by impression — and these numbers separate three states that
+// look identical from outside: nothing stored, stored but never judged, and judged and
+// refused.
+function MemorySection() {
+  // The SAME picker the run form seeds its user_id from, so the coverage shown here and
+  // the pass staged below describe one user rather than two.
+  const pickedUser = useUserId();
+  const [stats, setStats] = useState<VerificationStats | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    setBusy(true);
+    try {
+      setStats(
+        await getVerificationStats("user", pickedUser ? { scopeId: pickedUser } : undefined),
+      );
+      setErr(null);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+      setStats(null);
+    } finally {
+      setBusy(false);
+    }
+  }, [pickedUser]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const who = pickedUser ? <code>{pickedUser}</code> : "your own scope";
+  const facts = stats?.facts ?? 0;
+  // Every "what should this say" decision lives in one tested place — see the helper
+  // for which numbers are misleading when rendered naively.
+  const summary = verificationSummary(stats);
+
+  return (
+    <div className="settings-panel">
+      <h2>Memory</h2>
+      <p className="settings-help">
+        Coverage and manual passes for {who}. Pick a different user in the top bar to
+        switch target — the pass staged below runs against whoever is picked there.
+      </p>
+
+      {err && <div className="settings-error">{err}</div>}
+
+      <div className="settings-row">
+        <button type="button" onClick={() => void load()} disabled={busy}>
+          {busy ? "reading…" : "Refresh coverage"}
+        </button>
+      </div>
+
+      {stats && summary.empty && (
+        <div className="settings-muted">
+          No facts stored for {who} yet. A consolidation pass reads that user&rsquo;s
+          chats and distils them.
+        </div>
+      )}
+
+      {stats && !summary.empty && (
+        <>
+          <dl className="settings-stats">
+            <div>
+              <dt>facts</dt>
+              <dd>{facts}</dd>
+            </div>
+            <div>
+              <dt>with a span</dt>
+              <dd>{stats.with_span ?? 0}</dd>
+            </div>
+            <div>
+              <dt>verified</dt>
+              <dd>
+                {stats.supported ?? 0}
+                {summary.sharePct !== null && ` (${summary.sharePct}%)`}
+              </dd>
+            </div>
+            <div>
+              <dt>withheld</dt>
+              <dd>{stats.withheld ?? 0}</dd>
+            </div>
+            <div>
+              <dt>awaiting a judge</dt>
+              <dd>{stats.awaiting_judge ?? 0}</dd>
+            </div>
+            <div>
+              {/* Named for what it is. These can never be verified by ANYONE — the
+                  transcript they came from may be gone — so they are a different
+                  population from the ones merely waiting, and rolling the two together
+                  would make the backlog look like something a pass can fix. */}
+              <dt>no span, unverifiable</dt>
+              <dd>{stats.unverifiable_no_span ?? 0}</dd>
+            </div>
+          </dl>
+          {summary.showUnjudgedNote && (
+            // A zero here reads as "broken" unless the reason is stated, and the most
+            // likely reason is that nobody turned verification on.
+            <div className="settings-muted">
+              Nothing has been judged. Verdicts are only recorded when{" "}
+              <code>memory.consolidation.verify_writes</code> is enabled — until then
+              these facts are stored and fully recallable, just unverified.
+            </div>
+          )}
+          {summary.showWithheldNote && (
+            <div className="settings-muted">
+              Withheld facts are hidden from the fact surfaces, never deleted — an agent
+              reads them back with <code>include_refuted</code>, along with the reason
+              each was refused.
+            </div>
+          )}
+        </>
+      )}
+
+      {/* A LINK, not a button, and deliberately so — the same argument the curation
+          control makes. A consolidation pass is the most expensive thing this UI can
+          start (one extractor call per chat read, plus the judge's), and a settings
+          click that spends tokens with no preview is a surprise. */}
+      <p className="settings-help">
+        <Link className="settings-action-link" to={consolidationRunHref(pickedUser)}>
+          Run consolidation &rarr;
+        </Link>{" "}
+        <span className="settings-muted">
+          stages a pass in the terminal — it reads {who}&rsquo;s unconsolidated chats,
+          distils durable facts, and (when verification is on) judges what it writes and
+          works through older unjudged ones. Nothing runs until you start it there.
+        </span>
+      </p>
+      <p className="settings-help settings-muted">
+        Entity types and suggestions live in the <strong>Ontology</strong> tab.
+      </p>
     </div>
   );
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5814,6 +5814,32 @@ button.primary:disabled {
   color: var(--lc-running);
 }
 
+/* Verification coverage (Settings → Memory). A definition list rather than a table:
+   there is no row/column relationship here, just six labelled counts, and a table would
+   make an operator hunt for a header that says nothing. Auto-fit so it reflows from six
+   across on a wide panel to two on a narrow one without a breakpoint per width. */
+.settings-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+  gap: var(--lc-space-2);
+  margin: var(--lc-space-2) 0;
+}
+.settings-stats > div {
+  background: var(--lc-surface-2);
+  border: 1px solid var(--lc-rule);
+  border-radius: var(--lc-radius-sm);
+  padding: var(--lc-space-2);
+}
+.settings-stats dt {
+  color: var(--lc-text-faint);
+  font-size: var(--lc-text-sm);
+}
+.settings-stats dd {
+  margin: 0;
+  font-size: var(--lc-text-lg);
+  font-variant-numeric: tabular-nums;
+}
+
 .settings-row-actions {
   display: flex;
   gap: var(--lc-space-1);


### PR DESCRIPTION
Two things an operator could not get anywhere: **how much of a user's memory is actually verified**, and **a way to run a consolidation pass now** rather than waiting for the hourly schedule, which ships disabled.

## Coverage is what makes the rest legible

Without it, "is verification working" gets answered by impression. The numbers separate three states that look identical from outside: nothing stored, stored but never judged, and judged and refused.

The two unverified populations stay separate because they mean different things — a fact with **no span** can never be verified by anyone, while one **awaiting a judge** can. Rolling them together would make the backlog look like something a pass can fix.

## Running a pass is a link, not a button

Following the curation control already there, and for its stated reason: a settings click that spends tokens is a surprise. A consolidation pass is the most expensive thing this UI can start — one extractor call per chat read, plus the judge's — so it stages the agent and prompt in the terminal and the operator starts it there.

**The target is the topbar user picker**, which is the same source the run form seeds `user_id` from. That is not a coincidence worth leaving implicit: the pass consolidates whichever user the *run* belongs to, so if the panel read a different picker than the form, the coverage shown and the pass staged would describe two different people.

## The presentation decisions are extracted and tested

Same reason the ontology href was: the risk is a number that is wrong in a way that looks fine.

- **An empty store must not report "0% verified".** The server omits the share rather than dividing by zero; a UI computing its own would print 0%, which reads as *"nothing here is verified"* — a different claim from *"there is nothing to verify"*, and one an operator acts on differently.
- **The share is rendered from the server's number, never recomputed.** Two definitions of "verified" would eventually disagree, and the server's is the one the phase gate uses.
- **"0 judged" comes with its reason.** The likely cause is that `verify_writes` was never enabled, and a bare zero reads as broken.

## Verified

Manually, against a running server — this is the one integration point no test covers (the UI calls a route + op combination end to end):

```
empty scope   → {"facts":0,...}                      ← no verified_share at all
2 facts, 1 judged → {"facts":2,"with_span":1,"judged":1,
                     "supported":1,"unverifiable_no_span":1,
                     "verified_share":0.5,"withheld":0}
```

The empty-scope response confirms the behaviour the helper depends on.

Also: 6 new lib tests (51 total), each verified fail-before; `tsc --noEmit` clean for the app; `make build-ui` clean; `go test ./...` clean.

The tab is tenant-visible like Ontology — the read goes through `POST /v1/_document`, which is `ScopeTenant` and resolves the subject from the principal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)