### PR TITLE
fix(ui): Settings tabs get the three-tier role class the nav already had

### DIFF
--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,3 +1,8 @@
+import {
+  canSee,
+  hasTenantScope as principalHasTenantScope,
+  type Visibility,
+} from "../lib/visibility";
 import { useEffect, useState } from "react";
 import { Link, NavLink, Outlet, useOutletContext } from "react-router-dom";
 import {
@@ -54,7 +59,8 @@ const SIDEBAR_KEY = "loomcycle.sidebar.collapsed";
 // handlers source the tenant from the principal (list filters by tenant; the
 // cross-tenant `global` scope stays admin-only to create), and the routes were
 // re-gated to ScopeTenant — closing the earlier admin-only carve-out.
-type Visibility = "all" | "tenant" | "admin";
+// The type and the predicate live in ../lib/visibility — the Settings tabs use the
+// same two, and a second copy is how the two surfaces drifted apart in the first place.
 interface NavItem {
   to: string;
   label: string;
@@ -92,17 +98,6 @@ const NAV_ITEMS: NavItem[] = [
   // now the primary surface — see SettingsView's routing/limits tabs).
 ];
 
-// canSeeNav gates a nav item by the principal's role (RFC AS §4).
-function canSeeNav(vis: Visibility, isAdmin: boolean, hasTenantScope: boolean): boolean {
-  switch (vis) {
-    case "all":
-      return true;
-    case "tenant":
-      return isAdmin || hasTenantScope;
-    case "admin":
-      return isAdmin;
-  }
-}
 // Refresh the user picker every 30 s. Activity stats (running counts)
 // drift fast on busy deployments; the dropdown is rendered with the
 // most recent counts each time it opens.
@@ -131,9 +126,9 @@ export default function Layout() {
   const isAdmin = principal?.is_admin === true;
   // RFC AS §4: a substrate:tenant operator additionally sees the tenant-scoped
   // surfaces. Admin, legacy, and open-mode principals all report is_admin:true
-  // (handleWhoami), so they already see every item via canSeeNav's admin branch
+  // (handleWhoami), so they already see every item via canSee's admin branch
   // — no open-mode special case needed here.
-  const hasTenantScope = principal?.scopes?.includes("substrate:tenant") === true;
+  const hasTenantScope = principalHasTenantScope(principal?.scopes);
 
   // Super-admin tenant-focus (?tenant=): "" = all tenants (admin's default
   // global view). A tenant principal can't set this — the backend forces
@@ -247,10 +242,10 @@ export default function Layout() {
       <aside className={"sidebar" + (navCollapsed ? " sidebar-collapsed" : "")}>
         {/* Per-surface visibility (RFC AS §4): run/runs for every role; the
             tenant-scoped surfaces for admin OR a substrate:tenant operator;
-            the operator-plane surfaces for admin only. canSeeNav encodes the
+            the operator-plane surfaces for admin only. canSee encodes the
             class → role gate; the server still enforces it (defence in depth). */}
         <nav className="sidebar-nav">
-          {NAV_ITEMS.filter((it) => canSeeNav(it.vis, isAdmin, hasTenantScope)).map(({ to, label, Icon }) => (
+          {NAV_ITEMS.filter((it) => canSee(it.vis, isAdmin, hasTenantScope)).map(({ to, label, Icon }) => (
             <NavLink key={to} to={to} title={label}>
               <Icon size={18} className="sidebar-icon" />
               <span className="sidebar-label">{label}</span>

--- a/web/src/lib/visibility.test.ts
+++ b/web/src/lib/visibility.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { canSee, hasTenantScope, TENANT_SCOPE } from "./visibility";
+
+describe("canSee", () => {
+  it("shows an `all` surface to every role, including a delegated user", () => {
+    expect(canSee("all", false, false)).toBe(true);
+  });
+
+  it("shows a `tenant` surface to an operator and to admin, not to a delegated user", () => {
+    // The delegated-user case is the one that matters: substrate:user holds none of
+    // the tenant scopes, so every call behind a `tenant` surface 403s for them.
+    expect(canSee("tenant", false, false)).toBe(false);
+    expect(canSee("tenant", false, true)).toBe(true);
+    expect(canSee("tenant", true, false)).toBe(true);
+  });
+
+  it("admin satisfies tenant, because the server's HasScope says so", () => {
+    // If this ever stopped being true in the UI, an admin would lose surfaces the
+    // API would happily serve them.
+    expect(canSee("tenant", true, false)).toBe(true);
+  });
+
+  it("keeps an `admin` surface away from a tenant operator", () => {
+    expect(canSee("admin", false, true)).toBe(false);
+    expect(canSee("admin", true, true)).toBe(true);
+  });
+});
+
+describe("hasTenantScope", () => {
+  it("reads the operator role off the scope list", () => {
+    expect(hasTenantScope([TENANT_SCOPE])).toBe(true);
+    expect(hasTenantScope(["runs:read", TENANT_SCOPE])).toBe(true);
+  });
+
+  it("is false for a delegated user and for a missing list", () => {
+    expect(hasTenantScope(["substrate:user", "runs:read"])).toBe(false);
+    expect(hasTenantScope([])).toBe(false);
+    expect(hasTenantScope(undefined)).toBe(false);
+  });
+
+  it("does not match a scope that merely contains the name", () => {
+    // An exact-membership check, not a substring one — "substrate:tenant-readonly"
+    // is not the operator scope, and a startsWith/includes bug would grant it.
+    expect(hasTenantScope(["substrate:tenant-readonly"])).toBe(false);
+  });
+});

--- a/web/src/lib/visibility.ts
+++ b/web/src/lib/visibility.ts
@@ -1,0 +1,45 @@
+// Per-surface visibility class, shared by the left nav and the Settings tabs.
+//
+//   "all"    — every authenticated role, including a delegated user.
+//   "tenant" — admin OR a substrate:tenant operator. The surface's reads are
+//              tenant-scoped server-side and its writes are reachable by
+//              substrate:tenant, so it lights up once visible.
+//   "admin"  — super-admin only (operator plane, no per-tenant axis).
+//
+// ONE DEFINITION, because there were two. The nav has classified surfaces this way
+// since the tenant-operator UI landed; the Settings tabs kept a binary `admin`
+// boolean, which cannot express the middle tier. The result was a delegated user
+// reaching /settings directly and being shown five tabs whose every call 403s —
+// visible only by direct URL, since the nav's gear is already gated, but visible.
+//
+// ⚠️ THE RULE THAT MAKES THIS SAFE: a surface is marked "tenant" ONLY where the
+// backing route gate actually admits substrate:tenant (requiredScopeFor →
+// ScopeTenant, or a tenant-implied scope). Marking a surface "tenant" does not
+// grant anything — the server decides — so a wrong label here does not open a
+// hole; it produces a control that 403s, which is the exact failure this replaces.
+export type Visibility = "all" | "tenant" | "admin";
+
+// canSee gates one surface by the principal's role.
+export function canSee(vis: Visibility, isAdmin: boolean, hasTenantScope: boolean): boolean {
+  switch (vis) {
+    case "all":
+      return true;
+    case "tenant":
+      return isAdmin || hasTenantScope;
+    case "admin":
+      return isAdmin;
+  }
+}
+
+// TENANT_SCOPE is the scope string that marks a tenant operator. Named because it
+// appears in the principal's scope list verbatim and a typo would silently demote
+// every tenant operator to a delegated user.
+export const TENANT_SCOPE = "substrate:tenant";
+
+// hasTenantScope reads the role off a principal's scope list.
+//
+// Takes the list rather than the principal so it cannot accidentally depend on any
+// other field: role here is a function of scopes and nothing else.
+export function hasTenantScope(scopes: string[] | undefined): boolean {
+  return scopes?.includes(TENANT_SCOPE) === true;
+}

--- a/web/src/pages/SettingsView.tsx
+++ b/web/src/pages/SettingsView.tsx
@@ -1,5 +1,10 @@
 import { useCallback, useEffect, useState, type FormEvent } from "react";
 import { Link } from "react-router-dom";
+import {
+  canSee,
+  hasTenantScope as principalHasTenantScope,
+  type Visibility,
+} from "../lib/visibility";
 import { verificationSummary } from "../lib/verificationSummary";
 import {
   consolidationRunHref,
@@ -67,30 +72,40 @@ type Section =
 interface SectionDef {
   id: Section;
   label: string;
-  admin: boolean; // true = super-admin only
+  // Which roles may reach this tab, using the same three-tier class the left nav
+  // uses. It replaces a binary `admin` boolean, which could not express the middle
+  // tier: a substrate:tenant operator is not an admin, but is not a delegated user
+  // either, and every tab below is at least tenant-gated on the server.
+  //
+  // ⚠️ ASSIGNED FROM THE ROUTE GATE, never from taste. A tab is "tenant" only where
+  // requiredScopeFor on its backing endpoint returns ScopeTenant. Mislabelling one
+  // grants nothing — the server still refuses — but it produces a control that
+  // 403s, which is exactly the defect this replaces.
+  vis: Visibility;
 }
 
 const SECTIONS: SectionDef[] = [
-  { id: "credentials", label: "Credentials", admin: false },
-  { id: "limits", label: "Limits", admin: false },
-  { id: "routing", label: "Routing", admin: false },
-  // Tenant-visible: the ontology is per-tenant config, and the operator who owns
-  // the vocabulary is the one who should activate it. GET/POST /v1/_ontology are
-  // ScopeTenant and derive the tenant from the principal, so a tenant operator
-  // reaches only its own.
-  { id: "ontology", label: "Ontology", admin: false },
-  // Tenant-visible for the same reason: the coverage read goes through
-  // POST /v1/_document (ScopeTenant, subject resolved from the principal), and
-  // starting a pass is staged in the run terminal rather than done here.
-  { id: "memory", label: "Memory", admin: false },
-  { id: "tokens", label: "Tokens", admin: true },
-  { id: "presets", label: "Presets", admin: true },
-  { id: "runtime", label: "Runtime", admin: true },
-  // Admin-only: the repair rewrites rows across every scope in one statement,
-  // which is not a tenant operator's authority even over its own tenant. The
-  // route enforces this too (defence in depth).
-  { id: "maintenance", label: "Maintenance", admin: true },
-  { id: "health", label: "Health", admin: true },
+  // Every tab here is at least tenant-gated: there is no "all" settings surface,
+  // because a delegated user administers nothing. The nav's gear is already gated on
+  // (admin || tenant), so this list is what protects the direct-URL path.
+  //
+  // ScopeTenant on the server: /v1/_credentialdef (isTenantConfinedDefPath),
+  // /v1/_limits, /v1/_routing, /v1/_ontology, and the memory tab's /v1/_document +
+  // /v1/_memory/* family.
+  { id: "credentials", label: "Credentials", vis: "tenant" },
+  { id: "limits", label: "Limits", vis: "tenant" },
+  { id: "routing", label: "Routing", vis: "tenant" },
+  { id: "ontology", label: "Ontology", vis: "tenant" },
+  { id: "memory", label: "Memory", vis: "tenant" },
+  // ScopeAdmin: token minting has no tenant axis and is deliberately excluded from
+  // the tenant-confined def set; presets/runtime/health fall through to the /v1/_*
+  // catch-all; and repair-tenant is explicitly admin because it rewrites rows across
+  // every scope in one statement.
+  { id: "tokens", label: "Tokens", vis: "admin" },
+  { id: "presets", label: "Presets", vis: "admin" },
+  { id: "runtime", label: "Runtime", vis: "admin" },
+  { id: "maintenance", label: "Maintenance", vis: "admin" },
+  { id: "health", label: "Health", vis: "admin" },
 ];
 
 export default function SettingsView() {
@@ -99,12 +114,35 @@ export default function SettingsView() {
   // handleWhoami's open-mode synthetic admin). Layout only renders this view
   // once the principal has resolved, so this reflects the real role.
   const isAdmin = !principal || principal.is_admin;
-  const visible = SECTIONS.filter((s) => isAdmin || !s.admin);
-  // Default to the first tab the principal can see: tokens for an admin,
-  // credentials for a tenant operator.
-  const [section, setSection] = useState<Section>(
-    isAdmin ? "tokens" : "credentials",
-  );
+  const hasTenantScope = principalHasTenantScope(principal?.scopes);
+  const visible = SECTIONS.filter((s) => canSee(s.vis, isAdmin, hasTenantScope));
+  // Default to the first tab the principal can actually see, rather than to a
+  // hardcoded one. The old default was "credentials" for anyone non-admin, which a
+  // delegated user could reach by typing /settings — rendering a panel whose every
+  // call 403s.
+  const [section, setSection] = useState<Section>(visible[0]?.id ?? "credentials");
+  // And re-derive on every render rather than trusting the stored value: the role
+  // resolves asynchronously, and a section selected before it lands (or left over
+  // from a previous principal) must not render just because state remembers it.
+  // Selection is a preference; visibility is a rule.
+  const active = visible.some((s) => s.id === section) ? section : visible[0]?.id;
+
+  if (visible.length === 0) {
+    // Reachable by direct URL only — the nav's gear is gated on (admin || tenant) —
+    // but "no tabs at all" renders as a blank page, which reads as broken rather
+    // than as forbidden. Say which it is.
+    return (
+      <div className="settings-view">
+        <div className="settings-panel">
+          <h2>Settings</h2>
+          <p className="settings-help">
+            Nothing here is available to your access level. Settings administers a
+            tenant or the operator plane; your token holds neither.
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="settings-view">
@@ -113,7 +151,7 @@ export default function SettingsView() {
           <button
             key={s.id}
             type="button"
-            className={"settings-tab" + (section === s.id ? " active" : "")}
+            className={"settings-tab" + (active === s.id ? " active" : "")}
             onClick={() => setSection(s.id)}
           >
             {s.label}
@@ -121,16 +159,16 @@ export default function SettingsView() {
         ))}
       </nav>
       <div className="settings-body">
-        {section === "credentials" && <CredentialsSection />}
-        {section === "limits" && <LimitsView />}
-        {section === "routing" && <RoutingView />}
-        {section === "ontology" && <OntologySection />}
-        {section === "memory" && <MemorySection />}
-        {section === "tokens" && <TokenManager />}
-        {section === "presets" && <PresetsSection />}
-        {section === "runtime" && <RuntimeSection />}
-        {section === "maintenance" && <MaintenanceSection />}
-        {section === "health" && <HealthSection />}
+        {active === "credentials" && <CredentialsSection />}
+        {active === "limits" && <LimitsView />}
+        {active === "routing" && <RoutingView />}
+        {active === "ontology" && <OntologySection />}
+        {active === "memory" && <MemorySection />}
+        {active === "tokens" && <TokenManager />}
+        {active === "presets" && <PresetsSection />}
+        {active === "runtime" && <RuntimeSection />}
+        {active === "maintenance" && <MaintenanceSection />}
+        {active === "health" && <HealthSection />}
       </div>
     </div>
   );


### PR DESCRIPTION
RFC CF phase 1 — the prerequisite for the memory operations, and a live fix on its own.

## The defect

The Settings tabs classified themselves with a binary `admin` boolean and showed every non-admin tab to every non-admin principal. The authorization model has **three** tiers — admin, tenant operator, delegated user — and a boolean cannot express the middle one.

A delegated user holding `substrate:user` who typed `/settings` was shown five tabs whose every call 403s. Not reachable through the UI (the nav's gear is already gated on `admin || tenant`), but reachable — and it renders as a *broken* console rather than a forbidden one.

Adding the memory operations to that tab set would have made it worse: every one of them is at least tenant-gated.

## One definition, not a second copy

The left nav has classified surfaces as `all`/`tenant`/`admin` since the tenant-operator UI landed. Rather than reproduce that model, both surfaces now import one — a second copy is how the two drifted apart to begin with.

## Labels derived from the route gate, not chosen

Each tab is `"tenant"` only where `requiredScopeFor` on its backing endpoint returns `ScopeTenant`. Verified one at a time:

| tab | gate |
|---|---|
| Credentials | `/v1/_credentialdef` — **is** in the tenant-confined def set (second list) |
| Limits, Routing, Ontology | explicit `ScopeTenant` cases |
| Memory | `/v1/_document` + the `/v1/_memory/*` family |
| Tokens | token minting has no tenant axis, deliberately excluded from that set |
| Presets, Runtime, Health | fall through to the `/v1/_*` catch-all |
| Maintenance | `repair-tenant` is explicitly `ScopeAdmin` — it "rewrites rows across every scope in one statement" |

Mislabelling a tab grants nothing — the server still refuses — but it produces a control that 403s, which is precisely the defect being fixed. So the labels are derived rather than picked.

## Two smaller things the same bug implied

- **The default tab was hardcoded per role** (`"credentials"` for anyone non-admin), so it could select a tab the principal cannot see. It now defaults to the first *visible* tab.
- **The rendered tab is re-derived every render** instead of trusted from state. The role resolves asynchronously, and a selection made before it lands must not render just because state remembers it. *Selection is a preference; visibility is a rule.*

A principal who can see nothing now gets a sentence saying so, instead of an empty tab bar over a blank page.

## Tested

7 tests on the shared predicate, each verified fail-before:

- a delegated user is refused a `tenant` surface
- **admin satisfies tenant** — if this stopped holding in the UI, an admin would lose surfaces the API serves them
- a tenant operator is refused an `admin` surface
- the scope check is **exact membership**, not a prefix — `substrate:tenant-readonly` must not pass

58 web tests green, `tsc --noEmit` clean, `make build-ui` clean, `go test ./...` clean.

## Note on the RFC

RFC CF §2.1 says the exposure is "live today"; researching this narrowed it — the nav gear is already gated, so it is direct-URL only. I have corrected the RFC rather than leaving it overstated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)