### PR TITLE
feat(ui): the facts surface — evidence, verdicts, and a way to overrule the judge

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -3,6 +3,8 @@
 // operator visits `/ui?token=...` — fetch() includes it
 // automatically because we're same-origin. No bearer header needed.
 
+import type { FactEntity } from "./lib/factVerdict";
+
 export interface UserSummary {
   user_id: string;
   running_count: number;
@@ -1114,6 +1116,52 @@ export function getVerificationStats(
   browse?: BrowseScope,
 ): Promise<VerificationStats> {
   return substratePost("/v1/_document", { op: "verification_stats", scope }, browse);
+}
+
+// FactRow is one row of `Document op=list_facts`.
+//
+// `title` is the claim, TRUNCATED by the writer at 80 characters — the consolidator
+// stores the sentence as the chunk body and a shortened form as its title. The span in
+// `entity.source_quote` is NOT truncated, so a row can show full evidence next to a
+// possibly-clipped claim; the body is fetched per row on demand rather than for every
+// row up front.
+export interface FactRow {
+  id: string;
+  document_id: string;
+  title: string;
+  revision: number;
+  entity?: FactEntity;
+}
+
+// listFacts reads a scope's facts, newest first. `includeRefuted` surfaces the ones a
+// judge withheld, each carrying the reason it was refused.
+export function listFacts(
+  scope: DocScope = "user",
+  opts?: { includeRefuted?: boolean; limit?: number },
+  browse?: BrowseScope,
+): Promise<{ facts: FactRow[]; count: number }> {
+  return substratePost(
+    "/v1/_document",
+    {
+      op: "list_facts",
+      scope,
+      ...(opts?.includeRefuted ? { include_refuted: true } : {}),
+      ...(opts?.limit ? { limit: opts.limit } : {}),
+    },
+    browse,
+  );
+}
+
+// judgeFact records a verdict against a fact's stored span. The server maps the word to
+// a confidence and stamps the time; a caller supplies only the word and the reason.
+export function judgeFact(
+  id: string,
+  verdict: "supported" | "unclear" | "unsupported" | "mistyped",
+  reason: string,
+  scope: DocScope = "user",
+  browse?: BrowseScope,
+): Promise<{ chunk_id: string; verdict: string; confidence: number; withheld: boolean }> {
+  return substratePost("/v1/_document", { op: "judge_fact", scope, id, verdict, reason }, browse);
 }
 
 export function documentGetChunk(id: string, scope: DocScope, browse?: BrowseScope): Promise<ChunkDetail> {

--- a/web/src/components/FactsPanel.tsx
+++ b/web/src/components/FactsPanel.tsx
@@ -1,0 +1,183 @@
+import { useCallback, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  documentGetChunk,
+  judgeFact,
+  listFacts,
+  type BrowseScope,
+  type FactRow,
+} from "../api";
+import { factActions, factVerdict, operatorReason } from "../lib/factVerdict";
+
+// The facts a scope holds, with the evidence each was drawn from and whatever verdict it
+// carries — and the two controls that let a person overrule the judge.
+//
+// THE SAFETY VALVE IS THE POINT. Verified writes shipped with "a wrong verdict is always
+// recoverable by re-judging" as its argument for withholding rather than deleting, and
+// that recovery existed only as an API call. A judge that wrongly refuses a true fact had
+// no operator-reachable fix.
+//
+// THE SPAN IS SHOWN, NOT HIDDEN BEHIND A DISCLOSURE. It is the evidence; a surface that
+// tucks it away invites judging a claim on how plausible it reads, which is the failure
+// the whole line exists to prevent.
+export default function FactsPanel({ browse }: { browse?: BrowseScope }) {
+  const [facts, setFacts] = useState<FactRow[] | null>(null);
+  const [includeRefuted, setIncludeRefuted] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  // Which row is asking for a reason, and in which direction. A verdict without a stated
+  // ground is refused by the server, and it should be: an operator reading "withheld"
+  // months from now needs to know why.
+  const [arming, setArming] = useState<{ id: string; good: boolean } | null>(null);
+  const [reason, setReason] = useState("");
+  // Bodies are fetched per opened row. The listing carries a claim truncated at 80
+  // characters, which is the whole sentence for most facts and visibly clipped when not.
+  const [expanded, setExpanded] = useState<Record<string, string>>({});
+
+  const load = useCallback(async () => {
+    setBusy(true);
+    try {
+      const r = await listFacts("user", { includeRefuted, limit: 50 }, browse);
+      setFacts(r.facts ?? []);
+      setErr(null);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+      setFacts(null);
+    } finally {
+      setBusy(false);
+    }
+  }, [browse, includeRefuted]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const apply = async (id: string, good: boolean) => {
+    if (!reason.trim()) return;
+    setBusy(true);
+    try {
+      // The operator marker travels in the reason (see the lib module for why it is a
+      // prefix and not a column).
+      await judgeFact(id, good ? "supported" : "unsupported", operatorReason(reason), "user", browse);
+      setArming(null);
+      setReason("");
+      await load();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+      setBusy(false);
+    }
+  };
+
+  const expand = async (f: FactRow) => {
+    if (expanded[f.id] !== undefined) {
+      setExpanded((prev) => {
+        const next = { ...prev };
+        delete next[f.id];
+        return next;
+      });
+      return;
+    }
+    try {
+      const c = await documentGetChunk(f.id, "user", browse);
+      setExpanded((prev) => ({ ...prev, [f.id]: (c as { body?: string }).body ?? f.title }));
+    } catch {
+      // A body that will not load is not worth an error banner over the whole panel —
+      // the row still shows its claim and its evidence.
+      setExpanded((prev) => ({ ...prev, [f.id]: f.title }));
+    }
+  };
+
+  return (
+    <div className="facts-panel">
+      <div className="settings-row">
+        <label className="facts-toggle">
+          <input
+            type="checkbox"
+            checked={includeRefuted}
+            onChange={(e) => setIncludeRefuted(e.target.checked)}
+          />
+          show refused facts
+        </label>
+        <button type="button" onClick={() => void load()} disabled={busy}>
+          {busy ? "reading…" : "Refresh"}
+        </button>
+      </div>
+
+      {err && <div className="settings-error">{err}</div>}
+
+      {facts && facts.length === 0 && (
+        <div className="settings-muted">
+          {includeRefuted ? "No facts stored." : "No facts currently returned."}
+        </div>
+      )}
+
+      {facts?.map((f) => {
+        const v = factVerdict(f.entity);
+        const a = factActions(v);
+        const armed = arming?.id === f.id;
+        return (
+          <div key={f.id} className="fact-row" data-state={v.state}>
+            <div className="fact-claim">
+              <button type="button" className="fact-expand" onClick={() => void expand(f)}>
+                {expanded[f.id] !== undefined ? "−" : "+"}
+              </button>
+              <span>{expanded[f.id] ?? f.title}</span>
+              <span className={"fact-badge fact-badge-" + v.state}>{v.state}</span>
+            </div>
+
+            {/* The evidence, always visible. */}
+            {f.entity?.source_quote ? (
+              <blockquote className="fact-span">{f.entity.source_quote}</blockquote>
+            ) : (
+              <div className="fact-span fact-span-missing">
+                no source span — this fact cannot be verified by anyone
+              </div>
+            )}
+
+            {v.reason && (
+              <div className="settings-muted fact-reason">
+                {v.byOperator ? "an operator said" : "the judge said"}: {v.reason}
+              </div>
+            )}
+
+            <div className="settings-row-actions">
+              {a.canMarkWrong && (
+                <button type="button" className="ghost-btn" disabled={busy}
+                        onClick={() => { setArming({ id: f.id, good: false }); setReason(""); }}>
+                  mark wrong
+                </button>
+              )}
+              {a.canMarkGood && (
+                <button type="button" disabled={busy}
+                        onClick={() => { setArming({ id: f.id, good: true }); setReason(""); }}>
+                  {v.state === "withheld" ? "restore" : "mark good"}
+                </button>
+              )}
+              <Link className="settings-action-link" to={`/documents/${encodeURIComponent(f.document_id)}?scope=user`}>
+                open →
+              </Link>
+            </div>
+
+            {armed && (
+              <div className="settings-row fact-reason-form">
+                <input
+                  autoFocus
+                  value={reason}
+                  placeholder={arming.good ? "why is this right?" : "why is this wrong?"}
+                  onChange={(e) => setReason(e.target.value)}
+                />
+                <button type="button" disabled={busy || !reason.trim()}
+                        onClick={() => void apply(f.id, arming.good)}>
+                  save verdict
+                </button>
+                <button type="button" className="ghost-btn" onClick={() => setArming(null)}>
+                  cancel
+                </button>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/lib/factVerdict.test.ts
+++ b/web/src/lib/factVerdict.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { factActions, factVerdict, operatorReason, OPERATOR_REASON_PREFIX } from "./factVerdict";
+
+describe("factVerdict", () => {
+  it("a fact with no verdict is unverified, not refuted", () => {
+    // The distinction the whole line rests on: never assessed is not the same as
+    // assessed and rejected, and only the second withholds anything.
+    expect(factVerdict({}).state).toBe("unverified");
+    expect(factVerdict(undefined).state).toBe("unverified");
+  });
+
+  it("does not read a confidence as a verdict", () => {
+    // A confidence can exist without anyone having judged — an extractor could supply
+    // one. Treating that as "checked" would report a machine's guess as a decision.
+    expect(factVerdict({ confidence: 0.9 }).state).toBe("unverified");
+    expect(factVerdict({ confidence: 0.0 }).state).toBe("unverified");
+  });
+
+  it("uses the server's withheld flag rather than re-deriving it from the number", () => {
+    // If this ever compared confidence against a floor copied into the browser, the two
+    // copies would drift the first time the server's floor moved.
+    expect(factVerdict({ judged_at: 1, withheld: true, confidence: 0.0 }).state).toBe("withheld");
+    expect(factVerdict({ judged_at: 1, withheld: false, confidence: 0.4 }).state).toBe("checked");
+    // Deliberately: a low confidence the server did NOT withhold still reads as checked.
+    expect(factVerdict({ judged_at: 1, confidence: 0.1 }).state).toBe("checked");
+  });
+
+  it("separates an operator's verdict from the judge's, and strips the marker", () => {
+    const v = factVerdict({ judged_at: 1, judge_reason: operatorReason("this is out of date") });
+    expect(v.byOperator).toBe(true);
+    expect(v.reason).toBe("this is out of date");
+    expect(v.reason.startsWith(OPERATOR_REASON_PREFIX)).toBe(false);
+  });
+
+  it("treats a judge's reason as the judge's", () => {
+    const v = factVerdict({ judged_at: 1, judge_reason: "the quote gives no duration" });
+    expect(v.byOperator).toBe(false);
+    expect(v.reason).toBe("the quote gives no duration");
+  });
+
+  it("reports no reason for an unverified fact even if one is somehow stored", () => {
+    // Rendering a reason next to "unverified" would imply someone decided something.
+    expect(factVerdict({ judge_reason: "stale leftover" }).reason).toBe("");
+  });
+});
+
+describe("factActions", () => {
+  it("offers restoring a withheld fact — the safety valve", () => {
+    // The reason this panel exists: a judge that wrongly refuses a true fact must be
+    // correctable by a person, and only "mark good" does that.
+    const a = factActions(factVerdict({ judged_at: 1, withheld: true }));
+    expect(a.canMarkGood).toBe(true);
+    expect(a.canMarkWrong).toBe(false);
+  });
+
+  it("offers withholding a fact that is currently returned", () => {
+    const a = factActions(factVerdict({ judged_at: 1, withheld: false }));
+    expect(a.canMarkWrong).toBe(true);
+    expect(a.canMarkGood).toBe(false);
+  });
+
+  it("offers both directions on an unverified fact", () => {
+    const a = factActions(factVerdict({}));
+    expect(a.canMarkWrong).toBe(true);
+    expect(a.canMarkGood).toBe(true);
+  });
+});

--- a/web/src/lib/factVerdict.ts
+++ b/web/src/lib/factVerdict.ts
@@ -1,0 +1,69 @@
+// How a fact's verification state is read and written by the console.
+//
+// THE UI DOES NOT RE-DERIVE THE SERVER'S VERDICT SCALE. The runtime maps a verdict word
+// to a confidence number (supported / unclear / mistyped / unsupported) and owns the
+// floor below which a fact is withheld. Reverse-mapping that number back to a word here
+// would put a second copy of the scale in the browser, and the two would drift the first
+// time a threshold moved — silently, since both would keep rendering something plausible.
+//
+// So the console reads only what the server states outright: whether a verdict exists
+// (`judged_at`), whether it withheld the fact (`withheld`), and what reason was given.
+// The nuance between "supported" and "unclear" lives in the reason text, which is where
+// the judge put it.
+export type FactState = "unverified" | "checked" | "withheld";
+
+export interface FactEntity {
+  source_quote?: string;
+  subject?: string;
+  judged_at?: number;
+  judge_reason?: string;
+  withheld?: boolean;
+  confidence?: number;
+  origin?: string;
+  natural_key?: string;
+}
+
+// OPERATOR_REASON_PREFIX marks a verdict a human recorded.
+//
+// A prefix rather than a column: nothing BRANCHES on who judged, it only changes how the
+// reason renders, and a display distinction is not worth a migration. If anything ever
+// needs to act on it — a judge that must not overwrite a human's decision, say — this
+// becomes a real field and this constant is the thing to grep for.
+export const OPERATOR_REASON_PREFIX = "operator: ";
+
+export function operatorReason(text: string): string {
+  return OPERATOR_REASON_PREFIX + text.trim();
+}
+
+export interface FactVerdict {
+  state: FactState;
+  /** True when a person recorded this verdict rather than the judge. */
+  byOperator: boolean;
+  /** The reason with any operator marker removed — the marker is rendered separately. */
+  reason: string;
+}
+
+export function factVerdict(entity: FactEntity | undefined): FactVerdict {
+  const reasonRaw = entity?.judge_reason ?? "";
+  const byOperator = reasonRaw.startsWith(OPERATOR_REASON_PREFIX);
+  const reason = byOperator ? reasonRaw.slice(OPERATOR_REASON_PREFIX.length) : reasonRaw;
+  // `judged_at` is the discriminator, NOT the confidence. A fact can legitimately carry
+  // a confidence with no verdict (an extractor could supply one), and reading that as
+  // "checked" would report a machine's guess as a decision.
+  if (!entity?.judged_at) {
+    return { state: "unverified", byOperator: false, reason: "" };
+  }
+  return { state: entity.withheld ? "withheld" : "checked", byOperator, reason };
+}
+
+// factActions decides which controls a row offers.
+//
+// Both directions are always available on a judged fact, deliberately: the safety valve
+// this panel exists for is re-judging a fact the judge got WRONG, and a UI that only
+// offered "mark wrong" would let an operator withhold but never restore.
+export function factActions(v: FactVerdict): { canMarkWrong: boolean; canMarkGood: boolean } {
+  return {
+    canMarkWrong: v.state !== "withheld",
+    canMarkGood: v.state !== "checked",
+  };
+}

--- a/web/src/pages/SettingsView.tsx
+++ b/web/src/pages/SettingsView.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState, type FormEvent } from "react";
 import { Link } from "react-router-dom";
+import FactsPanel from "../components/FactsPanel";
 import {
   canSee,
   hasTenantScope as principalHasTenantScope,
@@ -1109,6 +1110,18 @@ function MemorySection() {
           works through older unjudged ones. Nothing runs until you start it there.
         </span>
       </p>
+      {/* The facts themselves, under the numbers that describe them. Placed here rather
+          than on their own tab because the coverage figures are unreadable without the
+          rows they summarise, and the rows are unjudgeable without knowing how much of
+          the store is verified at all. */}
+      <h3 className="settings-subhead">Facts</h3>
+      <p className="settings-help settings-muted">
+        What {who} has stored, with the evidence each fact was drawn from. A verdict here
+        overrides the judge&rsquo;s and is itself reversible — nothing on this panel
+        deletes anything.
+      </p>
+      <FactsPanel browse={pickedUser ? { scopeId: pickedUser } : undefined} />
+
       <p className="settings-help settings-muted">
         Entity types and suggestions live in the <strong>Ontology</strong> tab.
       </p>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5814,6 +5814,77 @@ button.primary:disabled {
   color: var(--lc-running);
 }
 
+/* The facts list (Settings → Memory). Rows rather than a table: each fact is a claim,
+   its evidence and its verdict — three things of very different lengths, which a table
+   would either truncate or stretch. The state drives the left border so a scan down the
+   column reads as a state column without one existing. */
+.facts-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--lc-space-2);
+  margin: var(--lc-space-2) 0;
+}
+.fact-row {
+  border: 1px solid var(--lc-rule);
+  border-left-width: 3px;
+  border-radius: var(--lc-radius-sm);
+  padding: var(--lc-space-2);
+  background: var(--lc-surface-2);
+}
+.fact-row[data-state="withheld"] {
+  border-left-color: var(--lc-danger);
+}
+.fact-row[data-state="checked"] {
+  border-left-color: var(--lc-completed);
+}
+.fact-claim {
+  display: flex;
+  align-items: baseline;
+  gap: var(--lc-space-1);
+}
+.fact-expand {
+  background: none;
+  border: none;
+  color: var(--lc-text-faint);
+  cursor: pointer;
+  font-family: var(--lc-font-mono, monospace);
+  padding: 0;
+}
+.fact-badge {
+  margin-left: auto;
+  font-size: var(--lc-text-sm);
+  color: var(--lc-text-faint);
+  white-space: nowrap;
+}
+/* The span is quoted, and set apart, because it is the thing the claim is checked
+   against — not a note about the claim. */
+.fact-span {
+  margin: var(--lc-space-1) 0 0;
+  padding-left: var(--lc-space-2);
+  border-left: 2px solid var(--lc-rule);
+  color: var(--lc-text-faint);
+  font-size: var(--lc-text-sm);
+}
+.fact-span-missing {
+  font-style: italic;
+}
+.fact-reason {
+  margin-top: var(--lc-space-1);
+}
+.fact-reason-form input {
+  flex: 1;
+  min-width: 12rem;
+}
+.facts-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--lc-space-1);
+  font-size: var(--lc-text-sm);
+}
+.settings-subhead {
+  margin-top: var(--lc-space-3);
+}
+
 /* Verification coverage (Settings → Memory). A definition list rather than a table:
    there is no row/column relationship here, just six labelled counts, and a table would
    make an operator hunt for a header that says nothing. Auto-fit so it reflows from six


### PR DESCRIPTION
RFC CF phase 2. Depends on #1021 (merged).

## The gap this closes

Verified writes shipped with *"a wrong verdict is always recoverable by re-judging"* as its argument for withholding rather than deleting — and that recovery existed only as an API call. **A judge that wrongly refuses a true fact had no operator-reachable fix.** This is that fix.

Each row is a claim, the span it was drawn from, and whatever verdict it carries. `include_refuted` on a toggle, because reading what was refused *and why* is the entire point of withholding rather than deleting.

## Three decisions worth reviewing

**The span is shown, not tucked behind a disclosure.** It is the evidence; a surface that hides it invites judging a claim on how plausible it reads — the failure this whole line exists to prevent. A fact with no span says so in place of the quote, since that fact can never be verified by anyone.

**The UI does not re-derive the server's verdict scale.** The runtime maps a verdict word to a confidence and owns the withholding floor. Reverse-mapping that number back into words in the browser would put a second copy of the scale there, and the two would drift the first time a threshold moved — silently, since both would keep rendering something plausible. The console reads only what the server states outright: whether a verdict exists, whether it withheld the fact, and the reason. The nuance between "supported" and "unclear" stays in the reason text, where the judge put it.

`judged_at` is the discriminator, never the confidence — a fact can carry a confidence with no verdict, and reading that as "checked" would report a machine's guess as a decision.

**Both directions are always offered on a judged fact.** A panel that only offered "mark wrong" would let an operator withhold but never restore, which is the opposite of the safety valve this is meant to be.

An operator's verdict is marked with a reason prefix rather than a column: nothing branches on who judged, it only changes how the reason renders, and a display distinction is not worth a migration. The constant is the thing to grep if that ever stops being true.

## Open question §12.1 — resolved with no server change

`list_facts` already returns the **full span**; only the claim is truncated, at 80 characters by the writer. So the list is one call and a body is fetched only for a row the operator actually expands — better than either option the RFC posed (`include_bodies`, or an eager N+1 per row).

## Verified against a running server

The whole safety valve, end to end:

```
1. judge refuses a true fact      → withheld: true
2. default list                   → count 1   ← the fact is simply gone
3. include_refuted: true          → the fact, its reason, and its span
4. operator marks it good         → withheld: false, visible again,
                                    reason "operator: the quote does say Cluj-Napoca"
```

Step 2 is the invisible loss the panel exists to make visible.

## Tests

9 lib tests (67 total), each verified fail-before: a confidence is not read as a verdict; the withheld flag comes from the server rather than a floor copied into the browser; a withheld fact offers restore; the operator marker is stripped for display; an unverified fact reports no reason.

`tsc --noEmit` clean, `make build-ui` clean, `go test ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)