### PR TITLE
feat(memory): record WHO judged a fact, in a column the caller cannot set

### DIFF
--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -303,7 +303,7 @@ var docSchemaDDL = []string{
 		class TEXT, origin TEXT, confidence DOUBLE PRECISION,
 		session_id TEXT, run_id TEXT, event_seq BIGINT,
 		natural_key TEXT, source_quote TEXT, subject TEXT,
-		judged_at BIGINT, judge_reason TEXT)`,
+		judged_at BIGINT, judge_reason TEXT, judged_by TEXT)`,
 	// UNIQUE per SCOPE, not per document: each scope owns its own database (a
 	// sqlite file / a postgres schema), so a bare UNIQUE index on the column IS
 	// scope-wide — one entity per tenant regardless of which document holds it.
@@ -628,7 +628,10 @@ func (d *Document) ensureSchema(ctx context.Context, key sqlmem.ScopeKey) error 
 	if err := d.migrateSubject(ctx, key); err != nil {
 		return err
 	}
-	return d.migrateVerdict(ctx, key)
+	if err := d.migrateVerdict(ctx, key); err != nil {
+		return err
+	}
+	return d.migrateJudgedBy(ctx, key)
 }
 
 // migrateConfidencePrecision widens chunk_memory_meta.confidence from postgres
@@ -828,6 +831,19 @@ func (d *Document) migrateVerdict(ctx context.Context, key sqlmem.ScopeKey) erro
 		return nil
 	}
 	return d.exec(ctx, key, `ALTER TABLE chunk_memory_meta ADD COLUMN judge_reason TEXT`)
+}
+
+// migrateJudgedBy adds the column recording WHO reached a verdict.
+//
+// Probe-then-ALTER like its siblings. An existing row keeps a NULL, which reads as
+// "unknown" rather than as either party — a verdict recorded before this column existed
+// was reached by the judge or by an operator and the store genuinely cannot say which,
+// so it must not claim one.
+func (d *Document) migrateJudgedBy(ctx context.Context, key sqlmem.ScopeKey) error {
+	if _, err := d.query(ctx, key, `SELECT judged_by FROM chunk_memory_meta WHERE 1=0`); err == nil {
+		return nil
+	}
+	return d.exec(ctx, key, `ALTER TABLE chunk_memory_meta ADD COLUMN judged_by TEXT`)
 }
 
 func (d *Document) migrateSubject(ctx context.Context, key sqlmem.ScopeKey) error {

--- a/internal/tools/builtin/document_entity.go
+++ b/internal/tools/builtin/document_entity.go
@@ -187,12 +187,16 @@ type chunkMetaRow struct {
 	// state from judged-and-refuted and the one withholding depends on.
 	JudgedAt    *int64
 	JudgeReason string
+	// JudgedBy is "operator" or the agent's name — server-stamped, never supplied by
+	// the caller. NULL on a verdict recorded before the column existed, which reads as
+	// unknown rather than as either party.
+	JudgedBy string
 }
 
 // readChunkMeta returns the chunk's sidecar row, or found=false when it has none.
 func (d *Document) readChunkMeta(ctx context.Context, key sqlmem.ScopeKey, chunkID string) (row chunkMetaRow, found bool, err error) {
 	res, err := d.query(ctx, key,
-		`SELECT valid_at, invalid_at, created_at, expired_at, class, origin, confidence, session_id, run_id, event_seq, natural_key, coalesce(source_quote, ''), coalesce(subject, ''), judged_at, coalesce(judge_reason, '')
+		`SELECT valid_at, invalid_at, created_at, expired_at, class, origin, confidence, session_id, run_id, event_seq, natural_key, coalesce(source_quote, ''), coalesce(subject, ''), judged_at, coalesce(judge_reason, ''), coalesce(judged_by, '')
 		   FROM chunk_memory_meta WHERE chunk_id = ?`, chunkID)
 	if err != nil || len(res.Rows) == 0 {
 		return chunkMetaRow{}, false, err
@@ -204,7 +208,7 @@ func (d *Document) readChunkMeta(ctx context.Context, key sqlmem.ScopeKey, chunk
 		Class: asStr(r[4]), Origin: asStr(r[5]), Confidence: asFloat64Ptr(r[6]),
 		SessionID: asStr(r[7]), RunID: asStr(r[8]), EventSeq: asInt64Ptr(r[9]),
 		NaturalKey: asStr(r[10]), SourceQuote: asStr(r[11]), Subject: asStr(r[12]),
-		JudgedAt: asInt64Ptr(r[13]), JudgeReason: asStr(r[14]),
+		JudgedAt: asInt64Ptr(r[13]), JudgeReason: asStr(r[14]), JudgedBy: asStr(r[15]),
 	}, true, nil
 }
 
@@ -268,6 +272,9 @@ func chunkMetaToJSON(m chunkMetaRow) map[string]any {
 	if m.JudgeReason != "" {
 		out["judge_reason"] = m.JudgeReason
 	}
+	if m.JudgedBy != "" {
+		out["judged_by"] = m.JudgedBy
+	}
 	return out
 }
 
@@ -325,7 +332,7 @@ func (d *Document) listFacts(ctx context.Context, key sqlmem.ScopeKey, in docInp
 	stmt := `SELECT c.id, c.document_id, c.parent_id, c.position, c.title, c.type, c.status, c.revision,
 	                m.valid_at, m.invalid_at, m.created_at, m.expired_at, m.class, m.origin, m.confidence,
 	                m.session_id, m.run_id, m.event_seq, m.natural_key, coalesce(m.source_quote, ''), coalesce(m.subject, ''),
-	                m.judged_at, coalesce(m.judge_reason, '')
+	                m.judged_at, coalesce(m.judge_reason, ''), coalesce(m.judged_by, '')
 	           FROM chunks c JOIN chunk_memory_meta m ON m.chunk_id = c.id`
 	if len(where) > 0 {
 		stmt += " WHERE " + strings.Join(where, " AND ")
@@ -354,7 +361,7 @@ func (d *Document) listFacts(ctx context.Context, key sqlmem.ScopeKey, in docInp
 			Class: asStr(r[12]), Origin: asStr(r[13]), Confidence: asFloat64Ptr(r[14]),
 			SessionID: asStr(r[15]), RunID: asStr(r[16]), EventSeq: asInt64Ptr(r[17]),
 			NaturalKey: asStr(r[18]), SourceQuote: asStr(r[19]), Subject: asStr(r[20]),
-			JudgedAt: asInt64Ptr(r[21]), JudgeReason: asStr(r[22]),
+			JudgedAt: asInt64Ptr(r[21]), JudgeReason: asStr(r[22]), JudgedBy: asStr(r[23]),
 		}
 		fact := map[string]any{
 			"id":          asStr(r[0]),
@@ -499,14 +506,15 @@ func (d *Document) writeChunkMeta(ctx context.Context, key sqlmem.ScopeKey, chun
 	// operator the verdict may be stale.
 	judgedAt := int64Arg(prev.JudgedAt)
 	judgeReason := prev.JudgeReason
+	judgedBy := prev.JudgedBy
 
 	if err := d.exec(ctx, key, `DELETE FROM chunk_memory_meta WHERE chunk_id = ?`, chunkID); err != nil {
 		return err
 	}
 	return d.exec(ctx, key,
 		`INSERT INTO chunk_memory_meta
-		   (chunk_id, valid_at, invalid_at, created_at, expired_at, class, origin, confidence, session_id, run_id, event_seq, natural_key, source_quote, subject, judged_at, judge_reason)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		   (chunk_id, valid_at, invalid_at, created_at, expired_at, class, origin, confidence, session_id, run_id, event_seq, natural_key, source_quote, subject, judged_at, judge_reason, judged_by)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		chunkID, validAt, invalidAt, createdAt, expiredAt, class,
 		originForEntityWrite(ctx), confidence,
 		// session_id has no writer yet: it is not on the run ctx, only the run id is.
@@ -514,7 +522,7 @@ func (d *Document) writeChunkMeta(ctx context.Context, key sqlmem.ScopeKey, chun
 		// when it relays a drained pending row — does not lose it to the next upsert.
 		nullIfEmpty(prev.SessionID), nullIfEmpty(runID), int64Arg(prev.EventSeq),
 		nullIfEmpty(naturalKey), nullIfEmpty(sourceQuote), nullIfEmpty(subject),
-		judgedAt, nullIfEmpty(judgeReason))
+		judgedAt, nullIfEmpty(judgeReason), nullIfEmpty(judgedBy))
 }
 
 // int64Arg / float64Arg turn a nullable read back into a bind arg that round-trips

--- a/internal/tools/builtin/document_verdict.go
+++ b/internal/tools/builtin/document_verdict.go
@@ -129,8 +129,8 @@ func (d *Document) judgeFact(ctx context.Context, key sqlmem.ScopeKey, in docInp
 
 	now := time.Now().UnixNano()
 	if err := d.exec(ctx, key,
-		`UPDATE chunk_memory_meta SET confidence = ?, judged_at = ?, judge_reason = ? WHERE chunk_id = ?`,
-		confidence, now, in.Reason, chunkID); err != nil {
+		`UPDATE chunk_memory_meta SET confidence = ?, judged_at = ?, judge_reason = ?, judged_by = ? WHERE chunk_id = ?`,
+		confidence, now, in.Reason, judgedByForVerdict(ctx), chunkID); err != nil {
 		return errResult("judge_fact: " + err.Error()), nil
 	}
 	return jsonResult(map[string]any{
@@ -140,6 +140,30 @@ func (d *Document) judgeFact(ctx context.Context, key sqlmem.ScopeKey, in docInp
 		"judged_at":  now,
 		"withheld":   confidence < withholdBelowConfidence,
 	})
+}
+
+// judgedByForVerdict records WHO reached a verdict, derived from the context rather than
+// accepted from the caller.
+//
+// SERVER-STAMPED FOR THE REASON `origin` IS: a writer must not get to label its own
+// provenance. An agent asked to record "an operator decided this" would be one prompt
+// injection away from laundering a machine's verdict into a human's, and the whole value
+// of the distinction is that an operator reading a refusal months later can tell which
+// it was.
+//
+// The presence of a run id is the discriminator, exactly as originForEntityWrite uses it:
+// no run means the call came from the off-run console, which only an authenticated
+// operator can reach. An agent's verdict records the AGENT'S NAME rather than a generic
+// marker — "memory/judge" and some other agent that happened to hold the Document tool
+// are different claims, and the second is worth being able to see.
+func judgedByForVerdict(ctx context.Context) string {
+	if tools.RunID(ctx) == "" {
+		return "operator"
+	}
+	if name := tools.AgentName(ctx); name != "" {
+		return name
+	}
+	return "agent"
 }
 
 // withholdClause is the SQL the fact surfaces apply, plus whether it applies at all.

--- a/internal/tools/builtin/document_verdict_test.go
+++ b/internal/tools/builtin/document_verdict_test.go
@@ -501,3 +501,88 @@ func TestVerdict_PostgresTierMigratesAndWithholds(t *testing.T) {
 		t.Errorf("postgres: an unjudged fact must stay visible, got count %v", facts["count"])
 	}
 }
+
+// TestVerdict_JudgedByIsServerStampedFromTheContext.
+//
+// A writer must not label its own provenance. An agent able to record "an operator
+// decided this" would be one injected instruction away from laundering a machine's
+// verdict into a human's — and the entire value of the distinction is that someone
+// reading a refusal months later can tell which it was.
+//
+// The presence of a run id is the discriminator, exactly as `origin` uses it: no run
+// means the call arrived through the off-run console, which only an authenticated
+// operator reaches.
+func TestVerdict_JudgedByIsServerStampedFromTheContext(t *testing.T) {
+	d, ctx, withSpan, _ := verdictFixture(t)
+
+	// The fixture's ctx carries no run id → the console.
+	if _, r := docExec(t, d, ctx, `{"op":"judge_fact","scope":"user","id":"`+withSpan+
+		`","verdict":"unsupported","reason":"an operator said so"}`); r.IsError {
+		t.Fatalf("judge: %s", r.Text)
+	}
+	got, _ := docExec(t, d, ctx, `{"op":"get_chunk","scope":"user","id":"`+withSpan+`"}`)
+	entity, _ := got["entity"].(map[string]any)
+	if entity["judged_by"] != "operator" {
+		t.Errorf("judged_by = %v, want \"operator\" for an off-run call", entity["judged_by"])
+	}
+
+	// Now the same op from inside a run: it records the AGENT, and cannot claim to be
+	// the operator however it asks.
+	runCtx := tools.WithRunID(ctx, "r_1")
+	runCtx = tools.WithAgentName(runCtx, "memory/judge")
+	if _, r := docExec(t, d, runCtx, `{"op":"judge_fact","scope":"user","id":"`+withSpan+
+		`","verdict":"supported","reason":"the span carries it","judged_by":"operator"}`); r.IsError {
+		t.Fatalf("judge(run): %s", r.Text)
+	}
+	got, _ = docExec(t, d, ctx, `{"op":"get_chunk","scope":"user","id":"`+withSpan+`"}`)
+	entity, _ = got["entity"].(map[string]any)
+	if entity["judged_by"] != "memory/judge" {
+		t.Errorf("judged_by = %v, want the agent's name — a run must not be able to "+
+			"record itself as the operator", entity["judged_by"])
+	}
+}
+
+// TestVerdict_JudgedBySurvivesAnEditOfTheClaim, like the rest of the verdict. Editing a
+// fact's text must not silently reattribute who judged it.
+func TestVerdict_JudgedBySurvivesAnEditOfTheClaim(t *testing.T) {
+	d, ctx, withSpan, _ := verdictFixture(t)
+	if _, r := docExec(t, d, ctx, `{"op":"judge_fact","scope":"user","id":"`+withSpan+
+		`","verdict":"unsupported","reason":"r"}`); r.IsError {
+		t.Fatalf("judge: %s", r.Text)
+	}
+	if _, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","natural_key":"f:spanned",`+
+		`"title":"The user lives somewhere else now."}`); r.IsError {
+		t.Fatalf("edit: %s", r.Text)
+	}
+	got, _ := docExec(t, d, ctx, `{"op":"get_chunk","scope":"user","id":"`+withSpan+`"}`)
+	entity, _ := got["entity"].(map[string]any)
+	if entity["judged_by"] != "operator" {
+		t.Errorf("judged_by was lost by an edit: %v", entity)
+	}
+}
+
+// TestVerdict_MigratesAScopeThatPredatesJudgedBy. Same argument as the other verdict
+// columns: CREATE TABLE IF NOT EXISTS leaves an existing table alone, so a store
+// provisioned before this column would never gain it and every verdict write would fail.
+func TestVerdict_MigratesAScopeThatPredatesJudgedBy(t *testing.T) {
+	d, ctx, withSpan, _ := verdictFixture(t)
+	key, _, err := d.resolveScope(ctx, "user")
+	if err != nil {
+		t.Fatalf("resolveScope: %v", err)
+	}
+	if derr := d.exec(ctx, key, `ALTER TABLE chunk_memory_meta DROP COLUMN judged_by`); derr != nil {
+		t.Skipf("this tier cannot drop a column: %v", derr)
+	}
+	if d.tableHasColumn(ctx, key, "chunk_memory_meta", "judged_by") {
+		t.Fatal("the column survived the drop — the test cannot reach the state it is for")
+	}
+	if _, r := docExec(t, d, ctx, `{"op":"judge_fact","scope":"user","id":"`+withSpan+
+		`","verdict":"unsupported","reason":"after the migration"}`); r.IsError {
+		t.Fatalf("the migration did not run: %s", r.Text)
+	}
+	got, _ := docExec(t, d, ctx, `{"op":"get_chunk","scope":"user","id":"`+withSpan+`"}`)
+	entity, _ := got["entity"].(map[string]any)
+	if entity["judged_by"] != "operator" {
+		t.Errorf("judged_by not recorded after the migration: %v", entity)
+	}
+}

--- a/web/src/components/FactsPanel.tsx
+++ b/web/src/components/FactsPanel.tsx
@@ -7,7 +7,7 @@ import {
   type BrowseScope,
   type FactRow,
 } from "../api";
-import { factActions, factVerdict, operatorReason } from "../lib/factVerdict";
+import { factActions, factVerdict } from "../lib/factVerdict";
 
 // The facts a scope holds, with the evidence each was drawn from and whatever verdict it
 // carries — and the two controls that let a person overrule the judge.
@@ -56,9 +56,9 @@ export default function FactsPanel({ browse }: { browse?: BrowseScope }) {
     if (!reason.trim()) return;
     setBusy(true);
     try {
-      // The operator marker travels in the reason (see the lib module for why it is a
-      // prefix and not a column).
-      await judgeFact(id, good ? "supported" : "unsupported", operatorReason(reason), "user", browse);
+      // No marker in the reason: the server stamps who judged from the call's own
+      // context, so an off-run call like this one records "operator" without asking.
+      await judgeFact(id, good ? "supported" : "unsupported", reason, "user", browse);
       setArming(null);
       setReason("");
       await load();
@@ -136,7 +136,8 @@ export default function FactsPanel({ browse }: { browse?: BrowseScope }) {
 
             {v.reason && (
               <div className="settings-muted fact-reason">
-                {v.byOperator ? "an operator said" : "the judge said"}: {v.reason}
+                {v.byOperator ? "an operator" : v.judgedBy || "an earlier verdict"} said:{" "}
+                {v.reason}
               </div>
             )}
 

--- a/web/src/lib/factVerdict.test.ts
+++ b/web/src/lib/factVerdict.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { factActions, factVerdict, operatorReason, OPERATOR_REASON_PREFIX } from "./factVerdict";
+import { factActions, factVerdict, OPERATOR } from "./factVerdict";
 
 describe("factVerdict", () => {
   it("a fact with no verdict is unverified, not refuted", () => {
@@ -25,17 +25,41 @@ describe("factVerdict", () => {
     expect(factVerdict({ judged_at: 1, confidence: 0.1 }).state).toBe("checked");
   });
 
-  it("separates an operator's verdict from the judge's, and strips the marker", () => {
-    const v = factVerdict({ judged_at: 1, judge_reason: operatorReason("this is out of date") });
+  it("reads who judged from the server's column, not from the reason text", () => {
+    // The reason is free text a judge writes. Inferring provenance from it would let a
+    // model that happens to start its reason with the marker word be rendered as a human.
+    const v = factVerdict({
+      judged_at: 1,
+      judged_by: OPERATOR,
+      judge_reason: "this is out of date",
+    });
     expect(v.byOperator).toBe(true);
     expect(v.reason).toBe("this is out of date");
-    expect(v.reason.startsWith(OPERATOR_REASON_PREFIX)).toBe(false);
   });
 
-  it("treats a judge's reason as the judge's", () => {
-    const v = factVerdict({ judged_at: 1, judge_reason: "the quote gives no duration" });
+  it("does not read a reason that merely mentions the operator as an operator verdict", () => {
+    const v = factVerdict({
+      judged_at: 1,
+      judged_by: "memory/judge",
+      judge_reason: "operator: the quote gives no duration",
+    });
     expect(v.byOperator).toBe(false);
-    expect(v.reason).toBe("the quote gives no duration");
+    expect(v.judgedBy).toBe("memory/judge");
+  });
+
+  it("names the agent that judged", () => {
+    const v = factVerdict({ judged_at: 1, judged_by: "memory/judge", judge_reason: "no city" });
+    expect(v.byOperator).toBe(false);
+    expect(v.judgedBy).toBe("memory/judge");
+    expect(v.reason).toBe("no city");
+  });
+
+  it("says nothing about who when the store does not know", () => {
+    // A verdict recorded before the column existed. Claiming either party would be a
+    // guess presented as a record.
+    const v = factVerdict({ judged_at: 1, judge_reason: "an older verdict" });
+    expect(v.byOperator).toBe(false);
+    expect(v.judgedBy).toBe("");
   });
 
   it("reports no reason for an unverified fact even if one is somehow stored", () => {

--- a/web/src/lib/factVerdict.ts
+++ b/web/src/lib/factVerdict.ts
@@ -17,43 +17,42 @@ export interface FactEntity {
   subject?: string;
   judged_at?: number;
   judge_reason?: string;
+  /** Who reached the verdict: "operator", or the agent's name. Server-stamped — a
+   *  writer does not get to label its own provenance. Absent on a verdict recorded
+   *  before the column existed, which reads as unknown rather than as either party. */
+  judged_by?: string;
   withheld?: boolean;
   confidence?: number;
   origin?: string;
   natural_key?: string;
 }
 
-// OPERATOR_REASON_PREFIX marks a verdict a human recorded.
-//
-// A prefix rather than a column: nothing BRANCHES on who judged, it only changes how the
-// reason renders, and a display distinction is not worth a migration. If anything ever
-// needs to act on it — a judge that must not overwrite a human's decision, say — this
-// becomes a real field and this constant is the thing to grep for.
-export const OPERATOR_REASON_PREFIX = "operator: ";
-
-export function operatorReason(text: string): string {
-  return OPERATOR_REASON_PREFIX + text.trim();
-}
+// OPERATOR marks a verdict a human recorded. It is the value the SERVER stamps for an
+// off-run call, not something this client sends — the column is provenance, and a writer
+// that could set it could launder a machine's verdict into a human's.
+export const OPERATOR = "operator";
 
 export interface FactVerdict {
   state: FactState;
-  /** True when a person recorded this verdict rather than the judge. */
+  /** True when a person recorded this verdict rather than an agent. */
   byOperator: boolean;
-  /** The reason with any operator marker removed — the marker is rendered separately. */
+  /** Who judged, for display: "an operator", the agent's name, or "" when the store
+   *  does not know (a verdict predating the column). */
+  judgedBy: string;
   reason: string;
 }
 
 export function factVerdict(entity: FactEntity | undefined): FactVerdict {
-  const reasonRaw = entity?.judge_reason ?? "";
-  const byOperator = reasonRaw.startsWith(OPERATOR_REASON_PREFIX);
-  const reason = byOperator ? reasonRaw.slice(OPERATOR_REASON_PREFIX.length) : reasonRaw;
+  const reason = entity?.judge_reason ?? "";
+  const judgedBy = entity?.judged_by ?? "";
+  const byOperator = judgedBy === OPERATOR;
   // `judged_at` is the discriminator, NOT the confidence. A fact can legitimately carry
   // a confidence with no verdict (an extractor could supply one), and reading that as
   // "checked" would report a machine's guess as a decision.
   if (!entity?.judged_at) {
-    return { state: "unverified", byOperator: false, reason: "" };
+    return { state: "unverified", byOperator: false, judgedBy: "", reason: "" };
   }
-  return { state: entity.withheld ? "withheld" : "checked", byOperator, reason };
+  return { state: entity.withheld ? "withheld" : "checked", byOperator, judgedBy, reason };
 }
 
 // factActions decides which controls a row offers.


### PR DESCRIPTION
RFC CF §12.2, decided as **a column**. Replaces the reason-prefix that shipped in #1023.

## Why the prefix was the weaker half

It made provenance a property of **free text a judge writes**. A model whose reason happened to begin with the marker word would render as a human decision, and anything that ever needed to *act* on who judged would be parsing prose.

## The column

`chunk_memory_meta.judged_by`, **server-stamped from the call's own context** — exactly as `origin` already is, and for the same reason: a writer must not get to label its own provenance. An agent able to record "an operator decided this" is one injected instruction away from laundering a machine's verdict into a human's, and the entire value of the distinction is that someone reading a refusal months later can tell which it was.

There is no wire field to set it with. Adding one would be the thing to argue about.

- **The discriminator is the presence of a run id** (`originForEntityWrite`'s rule): no run means the call arrived through the off-run console, which only an authenticated operator reaches.
- **An agent's verdict records the agent's name**, not a generic marker — `memory/judge` and some other agent that happened to hold the Document tool are different claims, and the second is worth being able to see.
- **A verdict predating the column reads as unknown**, not as either party. The store genuinely cannot say which it was, so it must not claim one; the UI renders "an earlier verdict" rather than picking a side.

## Wired through every read site in one change

The row struct, `readChunkMeta`, the `list_facts` projection, the shared formatter, and the preserve path in `writeChunkMeta`. That projection has silently dropped three added fields before now — the drift test added with the first of them is what makes this a checklist rather than a memory exercise, and it passes.

## Tested

Server, each verified fail-before:

- the stamp for both call shapes — an off-run call records `operator`; a run records its agent name **and cannot record itself as the operator**
- survival through an edit of the claim (editing text must not silently reattribute who judged it)
- the migration of a scope that predates the column

UI: 69 tests green, including that provenance is read from the column and **not** from a reason that merely mentions the operator.

`go test ./...`, `tsc --noEmit`, `make build-ui`, gofmt — all clean.

## Also in this branch

RFC §12 updated with both of your decisions, plus §12.1 which implementation answered on its own: `list_facts` already returns the full span, so the facts panel needed neither an `include_bodies` flag nor an eager N+1 — the body loads only for a row that gets expanded.

§12.3 (instruction writes to **user** scope) is recorded and applies to phase 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)