### PR TITLE
fix(document): RFC CE review — all eight findings

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -964,6 +964,13 @@ func isTenantConfinedDefPath(path string) bool {
 	for _, fam := range []string{
 		"/v1/_agentdef", "/v1/_skilldef", "/v1/_teamdef", "/v1/_mcpserverdef", "/v1/_scheduledef",
 		"/v1/_webhookdef", "/v1/_memorybackenddef", "/v1/_a2aagentdef", "/v1/_a2aservercarddef",
+		// RFC CE — the DocumentSourceDef substrate write-stamps the caller's
+		// tenant + opaque-404s cross-tenant, exactly like _memorybackenddef, so
+		// it joins the ScopeTenant set. Without this it fell through to the
+		// /v1/_* ScopeAdmin catch-all, making the HTTP transport stricter than
+		// the gRPC/MCP ones (both grant ScopeTenant) and leaving the
+		// tenant-scoping in handleListDocumentSourceDefNames dead for tenant tokens.
+		"/v1/_documentsourcedef",
 		// RFC AH Phase 2a — the dynamic-volume substrate is tenant-confined
 		// (write-stamps the caller's tenant + opaque-404s cross-tenant), so
 		// it joins the ScopeTenant set. No /names sub-path: the list op

--- a/internal/api/http/auth_principal_test.go
+++ b/internal/api/http/auth_principal_test.go
@@ -243,6 +243,7 @@ func TestRequiredScopeFor(t *testing.T) {
 		{"POST", "/v1/_scheduledef", auth.ScopeTenant},
 		{"POST", "/v1/_webhookdef", auth.ScopeTenant},
 		{"POST", "/v1/_memorybackenddef", auth.ScopeTenant},
+		{"POST", "/v1/_documentsourcedef", auth.ScopeTenant},
 		{"POST", "/v1/_a2aagentdef", auth.ScopeTenant},
 		{"POST", "/v1/_a2aservercarddef", auth.ScopeTenant},
 		{"GET", "/v1/_a2aservercarddef/names", auth.ScopeTenant},
@@ -307,6 +308,11 @@ func TestRequiredScopeFor(t *testing.T) {
 		// NOT via the /v1/_memory/ prefix (no slash after "memory").
 		{"POST", "/v1/_memorybackenddef", auth.ScopeTenant},
 		{"GET", "/v1/_memorybackenddef/names", auth.ScopeTenant},
+		// RFC CE: the DocumentSourceDef def family is ScopeTenant via
+		// isTenantConfinedDefPath (mirrors _memorybackenddef) — gRPC/MCP already
+		// grant ScopeTenant, so the HTTP route must not be stricter.
+		{"POST", "/v1/_documentsourcedef", auth.ScopeTenant},
+		{"GET", "/v1/_documentsourcedef/names", auth.ScopeTenant},
 		// RFC AF: hooks are tenant-confined now that the registry is
 		// tenant-isolated (stamp on register, tenant-filtered Match, scoped
 		// List/Delete). substrate:admin still satisfies.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5918,8 +5918,12 @@ func validate(c *Config) error {
 		if ds.Config.BaseURL == "" {
 			return fmt.Errorf("document_sources.%s: config.base_url is required", dname)
 		}
-		if u, uerr := url.Parse(ds.Config.BaseURL); uerr != nil || (u.Scheme != "http" && u.Scheme != "https") {
-			return fmt.Errorf("document_sources.%s: config.base_url %q must be an http(s) URL", dname, ds.Config.BaseURL)
+		// Require scheme AND host — an empty host (e.g. "http:///v1") is a
+		// non-dialable URL. This matches the DocumentSourceDef overlay validator
+		// (requireHTTPURL), so a value accepted at boot is also accepted for a
+		// runtime fork and vice-versa.
+		if u, uerr := url.Parse(ds.Config.BaseURL); uerr != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+			return fmt.Errorf("document_sources.%s: config.base_url %q must be an http(s) URL with a host", dname, ds.Config.BaseURL)
 		}
 		if ds.Config.APIKeyEnv != "" && !EnvNameCredentialSafe(ds.Config.APIKeyEnv) {
 			return fmt.Errorf("document_sources.%s: config.api_key_env %q is not an allowed credential env var "+

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -187,6 +187,7 @@ func TestDocumentSourcesValidation(t *testing.T) {
 		{"valid key_per_tenant", "document_sources:\n  peerA: { config: { base_url: \"https://peer.example.com\", api_key_env: LOOMCYCLE_PEERA_KEY }, tenancy_strategy: { kind: key_per_tenant, env_pattern: \"LOOMCYCLE_PEERA_{tenant_id}_KEY\" } }", false},
 		{"missing base_url", "document_sources:\n  peerA: { config: {} }", true},
 		{"non-http base_url", "document_sources:\n  peerA: { config: { base_url: \"ftp://peer\" } }", true},
+		{"empty-host base_url", "document_sources:\n  peerA: { config: { base_url: \"http:///v1\" } }", true},
 		{"infra-secret api_key_env", "document_sources:\n  peerA: { config: { base_url: \"https://peer\", api_key_env: LOOMCYCLE_AUTH_TOKEN } }", true},
 		{"unlisted api_key_env", "document_sources:\n  peerA: { config: { base_url: \"https://peer\", api_key_env: RANDOM_SECRET } }", true},
 		{"bad tenancy kind", "document_sources:\n  peerA: { config: { base_url: \"https://peer\" }, tenancy_strategy: { kind: shared_key } }", true},

--- a/internal/lookup/document_source.go
+++ b/internal/lookup/document_source.go
@@ -60,6 +60,14 @@ func resolveDocumentSourceSubstrate(ctx context.Context, s DocumentSourceStore, 
 	if err != nil {
 		return config.DocumentSource{}, false
 	}
+	// A retired def that is still the active pointer must NOT resolve — retiring
+	// the active source deactivates it (set_remote/sync then report "unknown
+	// source" until a live version is promoted), rather than silently dialing a
+	// peer the operator retired. (The store keeps the pointer for lineage; the
+	// resolver is where "retired means unusable" is enforced.)
+	if activeRow.Retired {
+		return config.DocumentSource{}, false
+	}
 	var sd SubstrateDocumentSourceDef
 	if uerr := json.Unmarshal(activeRow.Definition, &sd); uerr != nil {
 		return config.DocumentSource{}, false

--- a/internal/lookup/document_source_test.go
+++ b/internal/lookup/document_source_test.go
@@ -76,6 +76,27 @@ func TestDocumentSource_EquivalenceYamlVsSubstrate(t *testing.T) {
 	}
 }
 
+func TestDocumentSource_RetiredActiveDoesNotResolve(t *testing.T) {
+	ss := &stubDocumentSourceStore{
+		defs: map[string]store.DocumentSourceDefRow{
+			"peer": {DefID: "ds_v1", Name: "peer", Retired: true, Definition: json.RawMessage(`{"config":{"base_url":"https://retired.example.com"}}`)},
+		},
+	}
+	// A retired def that is still the active pointer must NOT resolve — retiring
+	// the active source deactivates it.
+	if _, ok := lookup.DocumentSource(context.Background(), ss, &config.Config{}, "", "peer"); ok {
+		t.Errorf("a retired active def must not resolve")
+	}
+	// Static yaml still wins even when a retired substrate pointer exists.
+	cfg := &config.Config{DocumentSources: map[string]config.DocumentSource{
+		"peer": {Config: config.DocumentSourceConfig{BaseURL: "https://static.example.com"}},
+	}}
+	got, ok := lookup.DocumentSource(context.Background(), ss, cfg, "", "peer")
+	if !ok || got.Config.BaseURL != "https://static.example.com" {
+		t.Errorf("static should resolve past a retired substrate pointer, got ok=%v %q", ok, got.Config.BaseURL)
+	}
+}
+
 func TestDocumentSource_StaticBeforeSubstrate(t *testing.T) {
 	cfg := &config.Config{
 		DocumentSources: map[string]config.DocumentSource{

--- a/internal/tools/builtin/document_sync.go
+++ b/internal/tools/builtin/document_sync.go
@@ -386,7 +386,11 @@ func (d *Document) loadRemoteSnapshot(ctx context.Context, client *docremote.Cli
 // direction-agnostic applyReconcile resolves natural_keys to ids.
 type sideWriter interface {
 	createKeyed(ctx context.Context, sc syncChunk) (id string, err error)
-	updateKeyed(ctx context.Context, id string, sc syncChunk, revision int) error
+	// updateKeyed updates a keyed chunk's content. includeBody=false omits the
+	// body from the write so an update that only touches title/type/status/tags
+	// does NOT record a duplicate-body entry in the chunk's revision history
+	// (update_chunk snapshots history only when the body field is present).
+	updateKeyed(ctx context.Context, id string, sc syncChunk, revision int, includeBody bool) error
 	move(ctx context.Context, id, parentID string, position int) error
 	ensureEdge(ctx context.Context, fromID, toID, kind string) error
 }
@@ -416,12 +420,16 @@ func (w localWriter) createKeyed(ctx context.Context, sc syncChunk) (string, err
 	return out.ID, nil
 }
 
-func (w localWriter) updateKeyed(ctx context.Context, id string, sc syncChunk, revision int) error {
-	raw, _ := json.Marshal(map[string]any{"id": id, "revision": revision, "body": sc.body, "title": sc.title, "type": sc.ctype, "status": sc.status, "tags": nonNilTags(sc.tags)})
+func (w localWriter) updateKeyed(ctx context.Context, id string, sc syncChunk, revision int, includeBody bool) error {
 	rev := revision
-	res, err := w.d.updateChunk(ctx, w.key, w.mscope, docInput{
-		ID: id, Revision: &rev, Body: sc.body, Title: sc.title, Type: sc.ctype, Status: sc.status, Tags: nonNilTags(sc.tags),
-	}, raw)
+	payload := map[string]any{"id": id, "revision": revision, "title": sc.title, "type": sc.ctype, "status": sc.status, "tags": nonNilTags(sc.tags)}
+	in := docInput{ID: id, Revision: &rev, Title: sc.title, Type: sc.ctype, Status: sc.status, Tags: nonNilTags(sc.tags)}
+	if includeBody {
+		payload["body"] = sc.body
+		in.Body = sc.body
+	}
+	raw, _ := json.Marshal(payload)
+	res, err := w.d.updateChunk(ctx, w.key, w.mscope, in, raw)
 	if err != nil {
 		return err
 	}
@@ -476,11 +484,15 @@ func (w remoteWriter) createKeyed(ctx context.Context, sc syncChunk) (string, er
 	return out.ID, nil
 }
 
-func (w remoteWriter) updateKeyed(ctx context.Context, id string, sc syncChunk, revision int) error {
-	_, err := w.client.Do(ctx, map[string]any{
+func (w remoteWriter) updateKeyed(ctx context.Context, id string, sc syncChunk, revision int, includeBody bool) error {
+	payload := map[string]any{
 		"op": "update_chunk", "id": id, "revision": revision, "scope": w.scope,
-		"body": sc.body, "title": sc.title, "type": sc.ctype, "status": sc.status, "tags": nonNilTags(sc.tags),
-	})
+		"title": sc.title, "type": sc.ctype, "status": sc.status, "tags": nonNilTags(sc.tags),
+	}
+	if includeBody {
+		payload["body"] = sc.body
+	}
+	_, err := w.client.Do(ctx, payload)
 	return err
 }
 
@@ -534,7 +546,7 @@ func applyReconcile(ctx context.Context, w sideWriter, source, target *sideSnaps
 			idByNK[nk] = id
 			c.created++
 		} else if contentDiffers(sc, tc) {
-			if err := w.updateKeyed(ctx, tc.id, sc, tc.revision); err != nil {
+			if err := w.updateKeyed(ctx, tc.id, sc, tc.revision, sc.body != tc.body); err != nil {
 				return c, fmt.Errorf("update %s: %w", nk, err)
 			}
 			c.updated++
@@ -709,9 +721,12 @@ func (d *Document) diffRemote(ctx context.Context, key sqlmem.ScopeKey, mscope s
 		if !sameTags(lc.tags, rc.tags) {
 			retagged = append(retagged, diffEntry{NaturalKey: nk, Title: lc.title})
 		}
-		// Effective parent on each side (a parent absent on the other side is a
-		// hole that resolves to the root), plus sibling position.
-		if effectiveParentNK(lc, remote) != effectiveParentNK(rc, local) || lc.position != rc.position {
+		// Report a reparent if a sync in EITHER direction would move the chunk —
+		// exactly the check applyReconcile pass 2 runs (wanted parent = the
+		// source's parent if it is keyed on the target, else the root; plus
+		// position). The earlier symmetric effective-parent comparison missed a
+		// move when the parent was keyed on only one side.
+		if wouldReparent(rc, lc, local.chunks) || wouldReparent(lc, rc, remote.chunks) {
 			reparented = append(reparented, diffEntry{NaturalKey: nk, Title: lc.title})
 		}
 	}
@@ -755,17 +770,19 @@ func (d *Document) diffRemote(ctx context.Context, key sqlmem.ScopeKey, mscope s
 	})
 }
 
-// effectiveParentNK is a chunk's parent natural_key AS IT WOULD RESOLVE against
-// `other` — a parent that isn't keyed on the other side is a hole that resolves
-// to the root (""), so the two sides are compared on the same footing.
-func effectiveParentNK(sc syncChunk, other *sideSnapshot) string {
-	if sc.parentNK == "" {
-		return ""
+// wouldReparent reports whether reconciling `src` INTO the side holding
+// `tgtChunks` (where `tgt` is src's current counterpart there) would move it —
+// the exact rule applyReconcile pass 2 uses: the wanted parent is src's parent
+// if that parent is keyed on the target (else the root), and a position change
+// also counts. Used by diff_remote to predict a move for either sync direction.
+func wouldReparent(src, tgt syncChunk, tgtChunks map[string]syncChunk) bool {
+	wantParentNK := ""
+	if src.parentNK != "" {
+		if _, ok := tgtChunks[src.parentNK]; ok {
+			wantParentNK = src.parentNK
+		}
 	}
-	if _, ok := other.chunks[sc.parentNK]; ok {
-		return sc.parentNK
-	}
-	return ""
+	return wantParentNK != tgt.parentNK || src.position != tgt.position
 }
 
 // ---- helpers ----

--- a/internal/tools/builtin/document_sync.go
+++ b/internal/tools/builtin/document_sync.go
@@ -212,6 +212,12 @@ type syncChunk struct {
 	position int
 	revision int
 	tags     []string // sorted
+	// withheld is true when this keyed chunk is a REFUTED fact (confidence below
+	// the withhold floor). It stays in the snapshot for EXISTENCE (so the
+	// reconcile never spuriously "creates" a chunk that already exists and would
+	// churn its revision every run), but a withheld SOURCE chunk is not
+	// propagated — the reconcile skips it, mirroring list_facts' withhold floor.
+	withheld bool
 }
 
 // edgeKey identifies a manual cross-reference edge portably (both endpoints by
@@ -258,6 +264,7 @@ func (d *Document) loadLocalSnapshot(ctx context.Context, key sqlmem.ScopeKey, m
 		snap.chunks[kc.NaturalKey] = syncChunk{
 			id: kc.ID, nk: kc.NaturalKey, title: kc.Title, ctype: kc.Type, status: kc.Status,
 			body: cb.Body, parentNK: idToNK[row.ParentID], position: row.Position, revision: row.Revision, tags: tags,
+			withheld: kc.Withheld,
 		}
 	}
 	rows, err := d.query(ctx, key, `SELECT from_id, to_id, kind, auto FROM chunk_edges
@@ -288,7 +295,11 @@ func (d *Document) loadLocalSnapshot(ctx context.Context, key sqlmem.ScopeKey, m
 
 // loadRemoteSnapshot reads the peer document's keyed structure over the client.
 func (d *Document) loadRemoteSnapshot(ctx context.Context, client *docremote.Client, docID, rootID, scope string) (*sideSnapshot, error) {
-	rawFacts, err := client.Do(ctx, map[string]any{"op": "list_facts", "document_id": docID, "scope": scope, "limit": 10000})
+	// include_refuted:true so the snapshot carries EVERY keyed chunk for
+	// existence — a refuted remote chunk that matches a local key must be seen as
+	// "exists" (else the reconcile churns it). Refuted chunks are skipped as a
+	// propagation SOURCE by applyReconcile, keyed on the per-fact `withheld` flag.
+	rawFacts, err := client.Do(ctx, map[string]any{"op": "list_facts", "document_id": docID, "scope": scope, "include_refuted": true, "limit": 10000})
 	if err != nil {
 		return nil, fmt.Errorf("list remote facts: %w", err)
 	}
@@ -324,6 +335,7 @@ func (d *Document) loadRemoteSnapshot(ctx context.Context, client *docremote.Cli
 		snap.chunks[nk] = syncChunk{
 			id: f.ID, nk: nk, title: f.Title, ctype: f.Type, status: f.Status,
 			body: rc.Body, parentNK: idToNK[rc.ParentID], position: rc.Position, revision: rc.Revision, tags: rc.Tags,
+			withheld: f.Entity.Withheld,
 		}
 	}
 	rawEdges, err := client.Do(ctx, map[string]any{"op": "get_edges", "document_id": docID, "scope": scope})
@@ -485,7 +497,7 @@ func (w remoteWriter) ensureEdge(ctx context.Context, fromID, toID, kind string)
 // ---- the direction-agnostic reconcile ----
 
 type reconcileCounts struct {
-	created, updated, unchanged, reparented, edgesAdded int
+	created, updated, unchanged, reparented, edgesAdded, excludedWithheld int
 }
 
 // applyReconcile reconciles `source` INTO the writer's side, using `target` as
@@ -502,9 +514,17 @@ func applyReconcile(ctx context.Context, w sideWriter, source, target *sideSnaps
 		idByNK[nk] = tc.id
 	}
 
-	// Pass 1 — content + tags.
+	// Pass 1 — content (body, title, type, status) + tags.
 	for _, nk := range sortedChunkKeys(source.chunks) {
 		sc := source.chunks[nk]
+		if sc.withheld {
+			// A refuted SOURCE fact is not propagated (it exists in the snapshot
+			// only so the target's copy isn't spuriously re-created). Skipping it
+			// here — rather than filtering it out of the snapshot — is what keeps
+			// sync convergent when the same key is refuted on one side.
+			c.excludedWithheld++
+			continue
+		}
 		tc, exists := target.chunks[nk]
 		if !exists {
 			id, err := w.createKeyed(ctx, sc)
@@ -513,7 +533,7 @@ func applyReconcile(ctx context.Context, w sideWriter, source, target *sideSnaps
 			}
 			idByNK[nk] = id
 			c.created++
-		} else if sc.body != tc.body || !sameTags(sc.tags, tc.tags) {
+		} else if contentDiffers(sc, tc) {
 			if err := w.updateKeyed(ctx, tc.id, sc, tc.revision); err != nil {
 				return c, fmt.Errorf("update %s: %w", nk, err)
 			}
@@ -531,6 +551,9 @@ func applyReconcile(ctx context.Context, w sideWriter, source, target *sideSnaps
 	// pass (and stay idempotent) rather than drift on the next run.
 	for _, nk := range sortedChunkKeys(source.chunks) {
 		sc := source.chunks[nk]
+		if sc.withheld {
+			continue // not propagated (see pass 1)
+		}
 		wantParentNK := ""
 		if sc.parentNK != "" {
 			if _, ok := idByNK[sc.parentNK]; ok {
@@ -620,7 +643,20 @@ func reconcileReport(direction string, b *remoteBinding, excludedUnkeyed int, c 
 		"reparented":         c.reparented,
 		"edges_added":        c.edgesAdded,
 		"excluded_unkeyed":   excludedUnkeyed,
+		"excluded_withheld":  c.excludedWithheld,
 	}
+}
+
+// contentDiffers reports whether a source keyed chunk's content — body, title,
+// type, status, or tags — differs from the target's. Title/type/status are
+// included so a rename or a status change on the source actually propagates (and
+// diff_remote reports it), not only a body/tag edit.
+func contentDiffers(sc, tc syncChunk) bool {
+	return sc.body != tc.body ||
+		sc.title != tc.title ||
+		sc.ctype != tc.ctype ||
+		sc.status != tc.status ||
+		!sameTags(sc.tags, tc.tags)
 }
 
 // ---- diff_remote: dry-run change set between the local document and its peer ----
@@ -656,12 +692,16 @@ func (d *Document) diffRemote(ctx context.Context, key sqlmem.ScopeKey, mscope s
 	same := 0
 	for _, nk := range sortedChunkKeys(local.chunks) {
 		lc := local.chunks[nk]
+		if lc.withheld {
+			continue // refuted local fact — sync won't propagate it, so it's not in the diff
+		}
 		rc, ok := remote.chunks[nk]
-		if !ok {
+		if !ok || rc.withheld { // a refuted remote fact reads as "not present" for the diff
 			onlyLocal = append(onlyLocal, diffEntry{NaturalKey: nk, Title: lc.title})
 			continue
 		}
-		if lc.body == rc.body {
+		// diverged = body/title/type/status differs; same = all of those identical.
+		if lc.body == rc.body && lc.title == rc.title && lc.ctype == rc.ctype && lc.status == rc.status {
 			same++
 		} else {
 			diverged = append(diverged, diffEntry{NaturalKey: nk, Title: lc.title})
@@ -676,8 +716,12 @@ func (d *Document) diffRemote(ctx context.Context, key sqlmem.ScopeKey, mscope s
 		}
 	}
 	for _, nk := range sortedChunkKeys(remote.chunks) {
-		if _, ok := local.chunks[nk]; !ok {
-			onlyRemote = append(onlyRemote, diffEntry{NaturalKey: nk, Title: remote.chunks[nk].title})
+		rc := remote.chunks[nk]
+		if rc.withheld {
+			continue
+		}
+		if lc, ok := local.chunks[nk]; !ok || lc.withheld {
+			onlyRemote = append(onlyRemote, diffEntry{NaturalKey: nk, Title: rc.title})
 		}
 	}
 
@@ -766,6 +810,7 @@ type remoteFact struct {
 	Status string `json:"status"`
 	Entity struct {
 		NaturalKey string `json:"natural_key"`
+		Withheld   bool   `json:"withheld"`
 	} `json:"entity"`
 }
 
@@ -782,21 +827,21 @@ func decodeRemoteFacts(raw json.RawMessage) ([]remoteFact, error) {
 // keyedChunk is one local entity-tier chunk the snapshot loader reads from.
 type keyedChunk struct {
 	ID, NaturalKey, Title, Type, Status string
+	Withheld                            bool
 }
 
-// localKeyedChunks returns the document's entity-tier chunks (those with a
-// natural_key), excluding refuted ones — the same withhold floor list_facts
-// applies, so sync propagates only the facts the local store itself surfaces.
+// localKeyedChunks returns ALL of the document's entity-tier chunks (those with
+// a natural_key), each flagged `Withheld` when it is a refuted fact (confidence
+// below the withhold floor). It deliberately does NOT filter refuted chunks out:
+// the snapshot needs every keyed chunk for EXISTENCE (chunkIDByNaturalKey sees
+// refuted rows, so filtering them here made the reconcile "create" an existing
+// chunk on every run and churn its revision). A refuted SOURCE chunk is instead
+// skipped by the reconcile itself, so it is still not propagated.
 func (d *Document) localKeyedChunks(ctx context.Context, key sqlmem.ScopeKey, docID string) ([]keyedChunk, error) {
-	where := "c.document_id = ?"
-	args := []any{docID}
-	if wc := withholdClause("m.confidence", false); wc != "" {
-		where += " AND " + wc
-	}
-	stmt := `SELECT c.id, coalesce(c.title,''), coalesce(c.type,''), coalesce(c.status,''), m.natural_key
+	stmt := `SELECT c.id, coalesce(c.title,''), coalesce(c.type,''), coalesce(c.status,''), m.natural_key, m.confidence
 	           FROM chunks c JOIN chunk_memory_meta m ON m.chunk_id = c.id
-	          WHERE ` + where
-	res, err := d.query(ctx, key, stmt, args...)
+	          WHERE c.document_id = ?`
+	res, err := d.query(ctx, key, stmt, docID)
 	if err != nil {
 		return nil, err
 	}
@@ -805,6 +850,9 @@ func (d *Document) localKeyedChunks(ctx context.Context, key sqlmem.ScopeKey, do
 		kc := keyedChunk{ID: asStr(r[0]), Title: asStr(r[1]), Type: asStr(r[2]), Status: asStr(r[3]), NaturalKey: asStr(r[4])}
 		if kc.NaturalKey == "" {
 			continue
+		}
+		if conf := asFloat64Ptr(r[5]); conf != nil && *conf < withholdBelowConfidence {
+			kc.Withheld = true
 		}
 		out = append(out, kc)
 	}

--- a/internal/tools/builtin/document_sync_test.go
+++ b/internal/tools/builtin/document_sync_test.go
@@ -621,3 +621,123 @@ func TestDocumentSync_PropagatesTitleChange(t *testing.T) {
 		t.Errorf("local title = %v, want RemoteTitle (title change must land)", got["title"])
 	}
 }
+
+// TestDocumentSync_TagsOnlyNoBodyRevision is the #6 regression: a tags-only sync
+// must NOT record a duplicate-body entry in the chunk's revision history
+// (update_chunk snapshots history whenever the body field is present, so the
+// reconcile must omit the body when it is unchanged).
+func TestDocumentSync_TagsOnlyNoBodyRevision(t *testing.T) {
+	// Peer nk1: same body, but an extra tag.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var in struct {
+			Op string `json:"op"`
+			ID string `json:"id"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&in)
+		w.Header().Set("Content-Type", "application/json")
+		switch in.Op {
+		case "get_document":
+			_ = json.NewEncoder(w).Encode(map[string]any{"document_id": "remoteDoc", "root_chunk_id": "r"})
+		case "list_facts":
+			_ = json.NewEncoder(w).Encode(map[string]any{"facts": []map[string]any{
+				{"id": "c1", "title": "One", "type": "note", "entity": map[string]any{"natural_key": "nk1"}},
+			}})
+		case "get_chunk":
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": in.ID, "body": "same-body", "tags": []string{"a", "b"}})
+		case "query_chunks":
+			_ = json.NewEncoder(w).Encode(map[string]any{"chunks": []map[string]any{{"id": "r"}, {"id": "c1"}}})
+		case "get_edges":
+			_ = json.NewEncoder(w).Encode(map[string]any{"edges": []any{}})
+		}
+	}))
+	t.Cleanup(srv.Close)
+	d, ctx, _ := documentFixture(t)
+	d.Cfg = &config.Config{DocumentSources: map[string]config.DocumentSource{"peerA": {Config: config.DocumentSourceConfig{BaseURL: srv.URL}}}}
+	out, _ := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Local"}`)
+	docID := out["document_id"].(string)
+	// Local nk1: same body, tag [a] only.
+	docExec(t, d, ctx, fmt.Sprintf(`{"op":"upsert_chunk","scope":"user","document_id":%q,"natural_key":"nk1","title":"One","type":"note","body":"same-body","tags":["a"]}`, docID))
+	docExec(t, d, ctx, fmt.Sprintf(`{"op":"set_remote","scope":"user","id":%q,"source":"peerA","remote_ref":"/docs/x"}`, docID))
+
+	key, _, _ := d.resolveScope(ctx, "user")
+	localID, _ := d.chunkIDByNaturalKey(ctx, key, "nk1")
+	before, _ := docExec(t, d, ctx, fmt.Sprintf(`{"op":"history","scope":"user","id":%q}`, localID))
+	nBefore := len(before["revisions"].([]any))
+
+	s, r := docExec(t, d, ctx, fmt.Sprintf(`{"op":"sync","scope":"user","id":%q}`, docID))
+	if r.IsError {
+		t.Fatalf("sync: %s", r.Text)
+	}
+	if s["updated"].(float64) != 1 {
+		t.Fatalf("expected the tag change to update (updated=1), got %+v", s)
+	}
+	after, _ := docExec(t, d, ctx, fmt.Sprintf(`{"op":"history","scope":"user","id":%q}`, localID))
+	nAfter := len(after["revisions"].([]any))
+	if nAfter != nBefore {
+		t.Errorf("body revision history grew from %d to %d on a TAGS-ONLY sync (spurious body revision)", nBefore, nAfter)
+	}
+	// The tags did land.
+	got, _ := docExec(t, d, ctx, fmt.Sprintf(`{"op":"get_chunk","scope":"user","id":%q}`, localID))
+	tj, _ := json.Marshal(got["tags"])
+	if string(tj) != `["a","b"]` {
+		t.Errorf("tags = %s, want [a b]", tj)
+	}
+}
+
+// TestDocumentDiffRemote_ReparentAcrossHole is the #4 regression: diff_remote
+// must report a reparent even when the parent is keyed on only ONE side (a real
+// sync WOULD move the chunk). Before the fix the symmetric effective-parent
+// comparison collapsed both sides to "root" and reported nothing.
+func TestDocumentDiffRemote_ReparentAcrossHole(t *testing.T) {
+	// Peer has nkX at the ROOT (and no nkP).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var in struct {
+			Op string `json:"op"`
+			ID string `json:"id"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&in)
+		w.Header().Set("Content-Type", "application/json")
+		switch in.Op {
+		case "get_document":
+			_ = json.NewEncoder(w).Encode(map[string]any{"document_id": "remoteDoc", "root_chunk_id": "r"})
+		case "list_facts":
+			_ = json.NewEncoder(w).Encode(map[string]any{"facts": []map[string]any{
+				{"id": "cx", "title": "X", "type": "note", "entity": map[string]any{"natural_key": "nkX"}},
+			}})
+		case "get_chunk":
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": in.ID, "body": "bx", "position": 0})
+		case "query_chunks":
+			_ = json.NewEncoder(w).Encode(map[string]any{"chunks": []map[string]any{{"id": "r"}, {"id": "cx"}}})
+		case "get_edges":
+			_ = json.NewEncoder(w).Encode(map[string]any{"edges": []any{}})
+		}
+	}))
+	t.Cleanup(srv.Close)
+	d, ctx, _ := documentFixture(t)
+	d.Cfg = &config.Config{DocumentSources: map[string]config.DocumentSource{"peerA": {Config: config.DocumentSourceConfig{BaseURL: srv.URL}}}}
+	out, _ := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Local"}`)
+	docID := out["document_id"].(string)
+	// Local: nkP (keyed, local-only) and nkX UNDER nkP with the same body as the peer.
+	docExec(t, d, ctx, fmt.Sprintf(`{"op":"upsert_chunk","scope":"user","document_id":%q,"natural_key":"nkP","title":"P","type":"note","body":"bp"}`, docID))
+	docExec(t, d, ctx, fmt.Sprintf(`{"op":"upsert_chunk","scope":"user","document_id":%q,"natural_key":"nkX","title":"X","type":"note","body":"bx"}`, docID))
+	key, _, _ := d.resolveScope(ctx, "user")
+	pID, _ := d.chunkIDByNaturalKey(ctx, key, "nkP")
+	xID, _ := d.chunkIDByNaturalKey(ctx, key, "nkX")
+	docExec(t, d, ctx, fmt.Sprintf(`{"op":"move_chunk","scope":"user","id":%q,"new_parent_id":%q,"position":0}`, xID, pID))
+	docExec(t, d, ctx, fmt.Sprintf(`{"op":"set_remote","scope":"user","id":%q,"source":"peerA","remote_ref":"/docs/x"}`, docID))
+
+	diff, _ := docExec(t, d, ctx, fmt.Sprintf(`{"op":"diff_remote","scope":"user","id":%q}`, docID))
+	var reparented []string
+	for _, e := range diff["reparented"].([]any) {
+		reparented = append(reparented, e.(map[string]any)["natural_key"].(string))
+	}
+	found := false
+	for _, nk := range reparented {
+		if nk == "nkX" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("diff reparented = %v, want it to include nkX (a pull would move it from nkP to root)", reparented)
+	}
+}

--- a/internal/tools/builtin/document_sync_test.go
+++ b/internal/tools/builtin/document_sync_test.go
@@ -519,3 +519,105 @@ func TestDocumentSyncPull_ReconcilesHierarchyTagsEdges(t *testing.T) {
 		t.Errorf("second pull = %+v, want created=0 reparented=0 edges_added=0 unchanged=3", s2)
 	}
 }
+
+// oneFactStubPeer serves a remote document with a single visible keyed chunk
+// (nk1) whose title + body are configurable — used by the convergence (#1) and
+// title-propagation (#3) regression tests.
+func oneFactStubPeer(title, body string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var in struct {
+			Op string `json:"op"`
+			ID string `json:"id"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&in)
+		w.Header().Set("Content-Type", "application/json")
+		switch in.Op {
+		case "get_document":
+			_ = json.NewEncoder(w).Encode(map[string]any{"document_id": "remoteDoc", "root_chunk_id": "r"})
+		case "list_facts":
+			_ = json.NewEncoder(w).Encode(map[string]any{"facts": []map[string]any{
+				{"id": "c1", "title": title, "type": "note", "entity": map[string]any{"natural_key": "nk1", "withheld": false}},
+			}})
+		case "get_chunk":
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": in.ID, "body": body})
+		case "query_chunks":
+			_ = json.NewEncoder(w).Encode(map[string]any{"chunks": []map[string]any{{"id": "r"}, {"id": "c1"}}})
+		case "get_edges":
+			_ = json.NewEncoder(w).Encode(map[string]any{"edges": []any{}})
+		default:
+			w.WriteHeader(422)
+			_ = json.NewEncoder(w).Encode(map[string]any{"code": "tool_refused", "error": "unknown op"})
+		}
+	})
+}
+
+// TestDocumentSync_ConvergesOnWithheldLocalChunk is the #1 regression: a keyed
+// chunk that is REFUTED locally (confidence below the withhold floor) but
+// visible on the peer must NOT be re-"created" on every pull. Before the fix,
+// localKeyedChunks excluded the refuted chunk from the target snapshot, so pass
+// 1 took the create branch every run and churned the chunk's revision.
+func TestDocumentSync_ConvergesOnWithheldLocalChunk(t *testing.T) {
+	srv := httptest.NewServer(oneFactStubPeer("One", "shared-body"))
+	t.Cleanup(srv.Close)
+	d, ctx, _ := documentFixture(t)
+	d.Cfg = &config.Config{DocumentSources: map[string]config.DocumentSource{
+		"peerA": {Config: config.DocumentSourceConfig{BaseURL: srv.URL}},
+	}}
+	out, _ := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Local"}`)
+	docID := out["document_id"].(string)
+	// nk1 exists locally but is REFUTED (confidence 0.1 < 0.25 floor) → withheld.
+	docExec(t, d, ctx, fmt.Sprintf(`{"op":"upsert_chunk","scope":"user","document_id":%q,"natural_key":"nk1","title":"One","type":"note","body":"shared-body","confidence":0.1}`, docID))
+	docExec(t, d, ctx, fmt.Sprintf(`{"op":"set_remote","scope":"user","id":%q,"source":"peerA","remote_ref":"/docs/x"}`, docID))
+
+	s1, r1 := docExec(t, d, ctx, fmt.Sprintf(`{"op":"sync","scope":"user","id":%q}`, docID))
+	if r1.IsError {
+		t.Fatalf("sync: %s", r1.Text)
+	}
+	// The refuted local chunk EXISTS, so the pull must NOT create it (the churn bug).
+	if s1["created"].(float64) != 0 {
+		t.Errorf("first pull created = %v, want 0 (the withheld local chunk already exists — must not be re-created)", s1["created"])
+	}
+	// Second pull is idempotent (the churn bug re-created every run).
+	s2, _ := docExec(t, d, ctx, fmt.Sprintf(`{"op":"sync","scope":"user","id":%q}`, docID))
+	if s2["created"].(float64) != 0 {
+		t.Errorf("second pull created = %v, want 0 (sync must converge on a withheld chunk)", s2["created"])
+	}
+}
+
+// TestDocumentSync_PropagatesTitleChange is the #3 regression: a source chunk
+// whose ONLY difference is title (body + tags identical) must still propagate,
+// and diff_remote must report it as diverged. Before the fix, pass 1's change
+// detection was body/tags only, so a rename was silently dropped.
+func TestDocumentSync_PropagatesTitleChange(t *testing.T) {
+	srv := httptest.NewServer(oneFactStubPeer("RemoteTitle", "same-body"))
+	t.Cleanup(srv.Close)
+	d, ctx, _ := documentFixture(t)
+	d.Cfg = &config.Config{DocumentSources: map[string]config.DocumentSource{
+		"peerA": {Config: config.DocumentSourceConfig{BaseURL: srv.URL}},
+	}}
+	out, _ := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Local"}`)
+	docID := out["document_id"].(string)
+	// nk1 locally: same body as the peer, but a DIFFERENT title.
+	docExec(t, d, ctx, fmt.Sprintf(`{"op":"upsert_chunk","scope":"user","document_id":%q,"natural_key":"nk1","title":"LocalTitle","type":"note","body":"same-body"}`, docID))
+	docExec(t, d, ctx, fmt.Sprintf(`{"op":"set_remote","scope":"user","id":%q,"source":"peerA","remote_ref":"/docs/x"}`, docID))
+
+	// diff_remote must SEE the title divergence (not report "same").
+	diff, _ := docExec(t, d, ctx, fmt.Sprintf(`{"op":"diff_remote","scope":"user","id":%q}`, docID))
+	if n := len(diff["diverged"].([]any)); n != 1 {
+		t.Errorf("diff diverged = %d, want 1 (a title-only change must show as diverged)", n)
+	}
+
+	s, r := docExec(t, d, ctx, fmt.Sprintf(`{"op":"sync","scope":"user","id":%q}`, docID))
+	if r.IsError {
+		t.Fatalf("sync: %s", r.Text)
+	}
+	if s["updated"].(float64) != 1 {
+		t.Errorf("pull updated = %v, want 1 (a title-only change must propagate)", s["updated"])
+	}
+	key, _, _ := d.resolveScope(ctx, "user")
+	localID, _ := d.chunkIDByNaturalKey(ctx, key, "nk1")
+	got, _ := docExec(t, d, ctx, fmt.Sprintf(`{"op":"get_chunk","scope":"user","id":%q}`, localID))
+	if got["title"] != "RemoteTitle" {
+		t.Errorf("local title = %v, want RemoteTitle (title change must land)", got["title"])
+	}
+}


### PR DESCRIPTION
Addresses **all eight findings** from the RFC CE code-review pass (all on merged code), each with a fail-before/pass-after regression test.

## Confirmed correctness/authz (commit 1)
- **#2 (High)** — HTTP `/v1/_documentsourcedef` was ScopeAdmin while gRPC/MCP were ScopeTenant (missing from `isTenantConfinedDefPath`). Fixed → the def family is ScopeTenant on every transport; the tenant-scoping in the names handler is no longer dead code.
- **#1 (High)** — sync was non-convergent on a **refuted** keyed chunk that also exists on the peer (create-churn, unbounded revision growth). The snapshot now carries every keyed chunk with a `withheld` flag; the reconcile skips a withheld *source* (still not propagated) but recognizes a withheld *target* (never re-created). Also fixes **#7** (`excluded_unkeyed` no longer miscounts refuted chunks).
- **#3 (Med)** — title/type/status-only edits now propagate (`contentDiffers`) and show in `diff_remote`.

## Review follow-ups (commit 2)
- **#5** — `retire` now deactivates a source: `lookup.DocumentSource` skips a retired active def, so `set_remote`/`sync` report "unknown source" rather than silently dialing a retired peer. (Scoped to DocumentSource; MemoryBackend has the same latent behavior — a substrate-wide decision.)
- **#4** — `diff_remote` reparent prediction now matches what a sync actually does (`wouldReparent` mirrors `applyReconcile` pass 2, checking both directions); the old symmetric comparison missed a move when the parent was keyed on only one side.
- **#6** — a tags/title/type/status-only sync no longer writes a duplicate-body entry to chunk history (`updateKeyed` omits the body when unchanged).
- **#8** — the static `document_sources` validator now also rejects an empty host, matching the overlay validator.

## Tests
Nine regression tests across `config`, `lookup`, `builtin`, and `api/http`, all verified **fail-before / pass-after**. Existing sync/tree/diff/DocumentSourceDef unit tests + the three **live two-instance e2es** (tree pull+push, DocumentSourceDef authoring) re-run green; `go test ./...` exit 0 (91 ok); `go vet` + `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD