### PR TITLE
feat(ui): semantic search over memory, as the front door to the facts panel

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1118,6 +1118,52 @@ export function getVerificationStats(
   return substratePost("/v1/_document", { op: "verification_stats", scope }, browse);
 }
 
+// MemorySearchHit is one hit from POST /v1/_memory/search.
+//
+// `kind` is the server's own classification — "fact" (a consolidator distilled it),
+// "note" (an agent wrote it directly) or "document" (a Document chunk body) — and a
+// document hit carries the chunk_id its entity block hangs off. The console does not
+// re-derive any of that from the key.
+export interface MemorySearchHit {
+  key: string;
+  value?: unknown;
+  score: number;
+  rank_score: number;
+  kind: string;
+  chunk_id?: string;
+}
+
+export interface MemorySearchResponse {
+  scope: string;
+  scope_id: string;
+  entries: MemorySearchHit[];
+  truncated?: boolean;
+}
+
+// searchMemory runs a semantic search across a scope's remembered things.
+//
+// `scopeId` is a REQUEST FIELD here, not the ?scope_id= browse override the substrate
+// endpoints take — this is a different endpoint with its own shape, and the tenant is
+// still stamped server-side from the authenticated principal.
+export function searchMemory(
+  query: string,
+  scope: "agent" | "user" | "tenant",
+  scopeId: string,
+  opts?: { sources?: string[]; topK?: number },
+): Promise<MemorySearchResponse> {
+  return jsonFetch<MemorySearchResponse>("/v1/_memory/search", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      query,
+      scope,
+      scope_id: scopeId,
+      ...(opts?.sources ? { sources: opts.sources } : {}),
+      ...(opts?.topK ? { top_k: opts.topK } : {}),
+    }),
+  });
+}
+
 // FactRow is one row of `Document op=list_facts`.
 //
 // `title` is the claim, TRUNCATED by the writer at 80 characters — the consolidator

--- a/web/src/components/MemorySearchPanel.tsx
+++ b/web/src/components/MemorySearchPanel.tsx
@@ -1,0 +1,145 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { documentGetChunk, searchMemory, type BrowseScope, type MemorySearchHit } from "../api";
+import { factVerdict, type FactEntity } from "../lib/factVerdict";
+import { hitText, judgeable, SEARCH_SOURCES, sourcesParam } from "../lib/memorySearch";
+
+// Semantic search over a scope's memory — the front door to the facts below it.
+//
+// WHY IT EARNS ITS PLACE next to a list that already shows every fact: the list is
+// ordered by recency and capped, so "what do we know about X" is answerable by scrolling
+// only while a store is small. Search is also how an operator finds the ONE fact they
+// came here to correct, which is the panel's whole reason for existing.
+//
+// A hit's verification state is fetched per document hit, not for every row: only a
+// document-chunk hit can carry a verdict at all, and the k/v plane has no entity block
+// to read.
+export default function MemorySearchPanel({
+  scopeId,
+  browse,
+}: {
+  scopeId: string;
+  browse?: BrowseScope;
+}) {
+  const [query, setQuery] = useState("");
+  const [hits, setHits] = useState<MemorySearchHit[] | null>(null);
+  const [entities, setEntities] = useState<Record<string, FactEntity>>({});
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [err, setErr] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const all = SEARCH_SOURCES.map((s) => s.id as string);
+
+  const run = async () => {
+    if (!query.trim()) return;
+    setBusy(true);
+    try {
+      const r = await searchMemory(query, "user", scopeId, {
+        sources: sourcesParam(selected, all),
+        topK: 20,
+      });
+      const entries = r.entries ?? [];
+      setHits(entries);
+      setErr(null);
+      // Verification state for the hits that can have one. Bounded by top_k, and only
+      // the document hits — a handful of reads, not one per row.
+      const next: Record<string, FactEntity> = {};
+      await Promise.all(
+        entries.filter(judgeable).map(async (h) => {
+          try {
+            const c = await documentGetChunk(h.chunk_id!, "user", browse);
+            const e = (c as { entity?: FactEntity }).entity;
+            if (e) next[h.chunk_id!] = e;
+          } catch {
+            // A hit whose entity will not load still shows its text and score; it
+            // simply cannot show a verdict.
+          }
+        }),
+      );
+      setEntities(next);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+      setHits(null);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const toggle = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  return (
+    <div className="memory-search">
+      <div className="settings-row">
+        <input
+          value={query}
+          placeholder="what do we know about…"
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") void run();
+          }}
+        />
+        <button type="button" onClick={() => void run()} disabled={busy || !query.trim()}>
+          {busy ? "searching…" : "Search"}
+        </button>
+      </div>
+
+      <div className="settings-row search-sources">
+        {SEARCH_SOURCES.map((s) => (
+          <label key={s.id} title={s.hint}>
+            <input
+              type="checkbox"
+              checked={selected.size === 0 || selected.has(s.id)}
+              onChange={() => toggle(s.id)}
+            />
+            {s.label}
+          </label>
+        ))}
+        <span className="settings-muted">
+          {selected.size === 0 || selected.size === all.length
+            ? "searching everything remembered"
+            : "narrowed"}
+        </span>
+      </div>
+
+      {err && <div className="settings-error">{err}</div>}
+      {hits && hits.length === 0 && (
+        <div className="settings-muted">Nothing matched.</div>
+      )}
+
+      {hits?.map((h) => {
+        const entity = h.chunk_id ? entities[h.chunk_id] : undefined;
+        const v = factVerdict(entity);
+        return (
+          <div key={h.key} className="search-hit">
+            <div className="search-hit-head">
+              <span className={"fact-badge search-kind-" + h.kind}>{h.kind}</span>
+              {/* The score, because a weak top hit and a strong one look identical in a
+                  list — and this floor is not calibrated for anyone's embedder. */}
+              <span className="settings-muted">{h.rank_score.toFixed(2)}</span>
+              {entity && <span className={"fact-badge fact-badge-" + v.state}>{v.state}</span>}
+              {judgeable(h) && (
+                <Link
+                  className="settings-action-link"
+                  to={`/documents/${encodeURIComponent(h.chunk_id ?? "")}?scope=user`}
+                >
+                  open →
+                </Link>
+              )}
+            </div>
+            <div className="search-hit-text">{hitText(h.value)}</div>
+            {entity?.source_quote && (
+              <blockquote className="fact-span">{entity.source_quote}</blockquote>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/lib/memorySearch.test.ts
+++ b/web/src/lib/memorySearch.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { hitText, judgeable, SEARCH_SOURCES, sourcesParam } from "./memorySearch";
+
+describe("judgeable", () => {
+  it("only a document-chunk hit can carry a verdict", () => {
+    // Verification state lives on the entity tier. A k/v row has nowhere to hold a
+    // verdict and no span to check one against, so offering the controls there would
+    // produce a button that fails.
+    expect(judgeable({ key: "doc.chunk:abc", score: 1, rank_score: 1, kind: "document", chunk_id: "abc" })).toBe(true);
+    expect(judgeable({ key: "memory/fact/x", score: 1, rank_score: 1, kind: "fact" })).toBe(false);
+    expect(judgeable({ key: "notes/y", score: 1, rank_score: 1, kind: "note" })).toBe(false);
+  });
+
+  it("refuses a document hit with no chunk id rather than guessing one from the key", () => {
+    // The server supplies chunk_id; parsing it out of the key would be a second decoder
+    // for a format the server already decoded.
+    expect(judgeable({ key: "doc.chunk:abc", score: 1, rank_score: 1, kind: "document" })).toBe(false);
+  });
+});
+
+describe("hitText", () => {
+  it("renders a string value as itself", () => {
+    expect(hitText("The user lives in Cluj-Napoca.")).toBe("The user lives in Cluj-Napoca.");
+  });
+
+  it("renders a non-string value as JSON rather than [object Object]", () => {
+    expect(hitText({ a: 1 })).toBe('{"a":1}');
+    expect(hitText(["x"])).toBe('["x"]');
+  });
+
+  it("renders nothing for an absent value", () => {
+    expect(hitText(null)).toBe("");
+    expect(hitText(undefined)).toBe("");
+  });
+});
+
+describe("sourcesParam", () => {
+  const all = SEARCH_SOURCES.map((s) => s.id);
+
+  it("sends nothing when everything is selected", () => {
+    // The endpoint reads an empty list as "every source". Enumerating today's three
+    // would mean the same thing now and silently exclude a fourth added later.
+    expect(sourcesParam(new Set(all), all)).toBeUndefined();
+    expect(sourcesParam(new Set(), all)).toBeUndefined();
+  });
+
+  it("sends the selection when it is a subset", () => {
+    expect(sourcesParam(new Set(["facts"]), all)).toEqual(["facts"]);
+    expect(sourcesParam(new Set(["facts", "documents"]), all)).toEqual(["facts", "documents"]);
+  });
+
+  it("keeps the server's order rather than the click order", () => {
+    // Selection is a set; the request should be stable so two identical selections
+    // produce identical requests (and identical cache keys downstream).
+    expect(sourcesParam(new Set(["documents", "facts"]), all)).toEqual(["facts", "documents"]);
+  });
+});

--- a/web/src/lib/memorySearch.ts
+++ b/web/src/lib/memorySearch.ts
@@ -1,0 +1,59 @@
+// Reading a memory search result.
+//
+// The endpoint classifies each hit itself — `kind` is "fact" (a consolidator distilled
+// it), "note" (an agent wrote it directly with `set`) or "document" (a Document chunk
+// body), and a document hit carries the `chunk_id` its entity block hangs off. So this
+// module does not parse keys; it decides what the console can DO with each kind.
+// The KIND a hit comes back as, and the SOURCE name used to ask for it, are different
+// vocabularies — singular on the result, plural on the request. Both are the server's;
+// keeping them as separate types is what stops one being sent where the other is meant.
+export type HitKind = "fact" | "note" | "document";
+export type SearchSource = "facts" | "notes" | "documents";
+
+export const SEARCH_SOURCES: { id: SearchSource; label: string; hint: string }[] = [
+  { id: "facts", label: "facts", hint: "distilled by a consolidation pass" },
+  { id: "notes", label: "notes", hint: "written directly by an agent" },
+  { id: "documents", label: "documents", hint: "prose in a document" },
+];
+
+export interface SearchHit {
+  key: string;
+  value?: unknown;
+  score: number;
+  rank_score: number;
+  kind: string;
+  chunk_id?: string;
+}
+
+// judgeable reports whether a hit can carry a verdict.
+//
+// ONLY A DOCUMENT-CHUNK HIT CAN. Verification state lives on the entity tier, so a k/v
+// row — the "fact" and "note" kinds — has nowhere to hold a verdict and no span to check
+// one against. Offering the controls on those rows would produce a button that 404s,
+// and hiding the distinction would suggest the k/v plane is verified when it is not.
+export function judgeable(hit: SearchHit): boolean {
+  return hit.kind === "document" && !!hit.chunk_id;
+}
+
+// hitText renders a hit's stored value for display.
+//
+// A k/v value arrives as raw JSON, which is usually a bare string but is not required to
+// be one. Rendering `[object Object]` at an operator is worse than rendering the JSON,
+// so anything that is not a string is shown as its JSON form rather than coerced.
+export function hitText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === null || value === undefined) return "";
+  return JSON.stringify(value);
+}
+
+// sourcesParam turns the panel's checkbox state into the wire's `sources`.
+//
+// ALL-SELECTED SENDS NOTHING, deliberately. The endpoint treats an empty list as "every
+// source", and sending all three explicitly would mean the same thing by a longer route —
+// but it would also freeze today's vocabulary into every request, so a fourth source
+// added server-side would be silently excluded by a client that thinks it asked for
+// everything.
+export function sourcesParam(selected: Set<string>, all: string[]): string[] | undefined {
+  if (selected.size === 0 || selected.size === all.length) return undefined;
+  return all.filter((s) => selected.has(s));
+}

--- a/web/src/pages/SettingsView.tsx
+++ b/web/src/pages/SettingsView.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState, type FormEvent } from "react";
 import { Link } from "react-router-dom";
 import FactsPanel from "../components/FactsPanel";
+import MemorySearchPanel from "../components/MemorySearchPanel";
 import {
   canSee,
   hasTenantScope as principalHasTenantScope,
@@ -1114,6 +1115,20 @@ function MemorySection() {
           than on their own tab because the coverage figures are unreadable without the
           rows they summarise, and the rows are unjudgeable without knowing how much of
           the store is verified at all. */}
+      {/* Search sits ABOVE the list: an operator who came here to fix one fact should
+          not have to scroll a store to find it, and the list below is capped and ordered
+          by recency rather than relevance. */}
+      <h3 className="settings-subhead">Search</h3>
+      <p className="settings-help settings-muted">
+        Across everything {who} has remembered — facts a pass distilled, notes an agent
+        wrote directly, and prose inside documents. Only a document hit can carry a
+        verdict; the key/value plane has nowhere to hold one.
+      </p>
+      <MemorySearchPanel
+        scopeId={pickedUser}
+        browse={pickedUser ? { scopeId: pickedUser } : undefined}
+      />
+
       <h3 className="settings-subhead">Facts</h3>
       <p className="settings-help settings-muted">
         What {who} has stored, with the evidence each fact was drawn from. A verdict here

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5814,6 +5814,49 @@ button.primary:disabled {
   color: var(--lc-running);
 }
 
+/* Memory search (Settings → Memory). Hits are looser than facts — a note has no span
+   and no verdict — so the row is lighter than a fact card and does not pretend to the
+   same structure. */
+.memory-search {
+  display: flex;
+  flex-direction: column;
+  gap: var(--lc-space-1);
+  margin: var(--lc-space-2) 0;
+}
+.memory-search > .settings-row input {
+  flex: 1;
+  min-width: 14rem;
+}
+.search-sources {
+  gap: var(--lc-space-2);
+  font-size: var(--lc-text-sm);
+}
+.search-sources label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.search-hit {
+  border: 1px solid var(--lc-rule);
+  border-radius: var(--lc-radius-sm);
+  padding: var(--lc-space-2);
+  background: var(--lc-surface-2);
+}
+.search-hit-head {
+  display: flex;
+  align-items: baseline;
+  gap: var(--lc-space-1);
+}
+.search-hit-head .fact-badge {
+  margin-left: 0;
+}
+.search-hit-head .settings-action-link {
+  margin-left: auto;
+}
+.search-hit-text {
+  margin-top: 4px;
+}
+
 /* The facts list (Settings → Memory). Rows rather than a table: each fact is a claim,
    its evidence and its verdict — three things of very different lengths, which a table
    would either truncate or stretch. The state drives the left border so a scan down the


### PR DESCRIPTION
RFC CF phase 3. Rebased onto main now that #1024 has landed.

## Why

The facts list is ordered by recency and capped, so *"what do we know about X"* is answerable by scrolling only while a store is small — and finding the **one** fact an operator came to correct is the panel's whole reason for existing. `POST /v1/_memory/search` has existed for a while with no UI at all.

## What the server already decides

Each hit carries its own `kind` — **fact** (a consolidator distilled it), **note** (an agent wrote it directly, no provenance) or **document** (a chunk body) — and a document hit carries the `chunk_id` its entity block hangs off. This client does no key parsing; the server decoded that already.

## Only a document hit can carry a verdict — and the panel says so

Verification state lives on the entity tier, so a k/v row has nowhere to hold a verdict and no span to check one against. Offering the controls there would produce a button that fails; hiding the distinction would imply the k/v plane is verified when it is not.

Verification state is fetched only for the hits that can have one — bounded by `top_k` and filtered to document hits, so a search costs a handful of reads rather than one per row.

## Selecting every source sends no sources

The endpoint reads an empty list as "everything". Enumerating today's three would mean the same thing now, while silently excluding a fourth added later.

The score is shown, including on weak hits: a poor top match and a strong one look identical in a list, and this ranking is not calibrated for anyone's particular embedder.

## Tested

8 lib tests (77 total): only a document hit *with a chunk id* is judgeable; a non-string value renders as JSON rather than `[object Object]`; an all-selected filter sends nothing; the source list keeps the server's order so identical selections produce identical requests.

`tsc --noEmit` clean, `make build-ui` clean, `go test ./...` clean.

## ⚠️ One thing I could not verify

**Whether one stored fact appears twice** — once as its k/v row, once as its entity chunk, since the consolidator writes both.

I set up Postgres + pgvector to check (the sqlite build has no vector support at all, so search cannot run there). The probe did **not** settle it: my off-run document write landed under the operator's own `scope_id` rather than the target user's, so the two planes never shared a partition. That is a flaw in the probe, not evidence of absence.

The panel renders either case sanely — each hit shows its kind — but **if a real consolidation pass produces pairs, this wants dedup.** Flagged here and in the commit message rather than assumed away.

Incidentally confirmed: classification is provenance-driven — a hand-written k/v row comes back as `kind=note`, matching the server's own definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)