### PR TITLE
feat(teamdef): tag board-bound op=run handler runs with the task key (RFC BT P4)

### DIFF
--- a/adapters/ts/src/client.ts
+++ b/adapters/ts/src/client.ts
@@ -1706,13 +1706,27 @@ export class LoomcycleClient {
    *  task handed to the entry state's agent. The walk runs under the same
    *  admission a normal run gets (token budget / operator-key / depth). */
   async runTeam(
-    target: { name?: string; defId?: string; input?: string },
+    target: {
+      name?: string;
+      defId?: string;
+      input?: string;
+      /** Bind the walk to a Document chunk task board (RFC BT P4): each state
+       *  transition persists `chunk.status` = the current team state, and every
+       *  handler run this walk spawns carries the task key on its
+       *  `parent_context` (so a board client can pin the live agent to the
+       *  card). Omit for an ephemeral run. */
+      boardChunkId?: string;
+      /** The Document scope of `boardChunkId` (agent | user, default user). */
+      boardScope?: "agent" | "user";
+    },
     opts?: { signal?: AbortSignal },
   ): Promise<TeamRunResult> {
     const body: Record<string, unknown> = { op: "run" };
     if (target.name !== undefined) body.name = target.name;
     if (target.defId !== undefined) body.def_id = target.defId;
     if (target.input !== undefined) body.input = target.input;
+    if (target.boardChunkId !== undefined) body.board_chunk_id = target.boardChunkId;
+    if (target.boardScope !== undefined) body.board_scope = target.boardScope;
     return postJSON<TeamRunResult>(this.ctx, "/v1/_teamdef", body, opts);
   }
 

--- a/adapters/ts/src/types.ts
+++ b/adapters/ts/src/types.ts
@@ -339,6 +339,13 @@ export interface ParentContext {
   /** The consumer's tier marker captured at root-run time (distinct from
    *  `userTier`, which is loomcycle's resolver policy). */
   tier_at_run?: string;
+  /** Workflow-board correlation (loomboard, RFC BT P4). A board-bound
+   *  `TeamDef op=run` stamps these onto each handler run it spawns, so a client
+   *  folding the run-state stream (RunStateEvent.parent_context) can pin the
+   *  live agent to its kanban card. Absent for non-board runs. */
+  board_scope?: string;
+  board_chunk_id?: string;
+  board_document_id?: string;
 }
 
 export interface ContinueOptions {

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -5686,6 +5686,18 @@ func (s *Server) prepareSubRun(ctx context.Context, name, prompt, defID string, 
 		// cannot escape by spawning. Persisted so a resumed sub-run keeps it.
 		Isolated: parentIdentity.Isolated,
 	}
+	// RFC BT P4: a board-bound `TeamDef op=run` puts the task key on ctx; stamp it
+	// onto this handler run's ParentContext so a client folding the run-state
+	// stream can pin the live agent to its kanban card. Cleared from subRunCtx
+	// below, so only the DIRECT handler is tagged (not its own sub-agents).
+	if bt, ok := store.BoardTaskFromContext(ctx); ok {
+		if subIdentity.ParentContext == nil {
+			subIdentity.ParentContext = &store.ParentContext{}
+		}
+		subIdentity.ParentContext.BoardScope = bt.Scope
+		subIdentity.ParentContext.BoardChunkID = bt.ChunkID
+		subIdentity.ParentContext.BoardDocumentID = bt.DocumentID
+	}
 	subSessionID, subRunID, err := s.openOrCreateSessionAndRun(ctx, "", name, parentIdentity.TenantID, parentIdentity.UserID, subIdentity)
 	if err != nil {
 		return nil, fmt.Errorf("create sub-session for %q: %w", name, err)
@@ -5722,6 +5734,9 @@ func (s *Server) prepareSubRun(ctx context.Context, name, prompt, defID string, 
 	// the registry entry lets the cascade walk in Cancel() find this
 	// sub explicitly (belt-and-braces against grandchild races).
 	subRunCtx, subCancelFn := context.WithCancelCause(ctx)
+	// Board task tags only the DIRECT handler run; clear it on the handler's own
+	// execution ctx so its sub-agents aren't also pinned onto the card (RFC BT P4).
+	subRunCtx = store.WithBoardTask(subRunCtx, store.BoardTask{})
 	defer func() {
 		if !prepOK {
 			subCancelFn(nil)
@@ -5778,7 +5793,10 @@ func (s *Server) prepareSubRun(ctx context.Context, name, prompt, defID string, 
 		TenantID:      parentIdentity.TenantID, // sub-agent inherits the parent run's tenant
 		ParentAgentID: parentIdentity.AgentID,
 		otelSpan:      subRunSpan,
-		ParentContext: parentIdentity.ParentContext, // v0.12.x: sub-agent's run-state events carry the root's lineage
+		// v0.12.x root lineage + RFC BT P4 board task (subIdentity's is the clone
+		// of the parent's plus any board stamp above), echoed on this sub-run's
+		// run-state events so a board client can pin it to its card.
+		ParentContext: subIdentity.ParentContext,
 	}
 	s.publishRunState(subMeta, "running", "", "")
 

--- a/internal/store/board_task_test.go
+++ b/internal/store/board_task_test.go
@@ -1,0 +1,52 @@
+package store
+
+import (
+	"context"
+	"testing"
+)
+
+func TestBoardTaskContextRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	if _, ok := BoardTaskFromContext(ctx); ok {
+		t.Fatal("empty ctx should carry no board task")
+	}
+
+	bt := BoardTask{Scope: "user", ChunkID: "c1", DocumentID: "d1"}
+	ctx = WithBoardTask(ctx, bt)
+	got, ok := BoardTaskFromContext(ctx)
+	if !ok || got != bt {
+		t.Fatalf("round-trip: got %+v ok=%v, want %+v", got, ok, bt)
+	}
+
+	// A zero task CLEARS it (so a handler's sub-agents aren't tagged).
+	ctx = WithBoardTask(ctx, BoardTask{})
+	if _, ok := BoardTaskFromContext(ctx); ok {
+		t.Fatal("a zero board task should clear it")
+	}
+}
+
+func TestParentContextBoardFields(t *testing.T) {
+	var p *ParentContext
+	if !p.IsZero() {
+		t.Fatal("nil ParentContext is zero")
+	}
+	p = &ParentContext{BoardChunkID: "c1"}
+	if p.IsZero() {
+		t.Fatal("a board chunk id makes ParentContext non-zero")
+	}
+	cp := p.Clone()
+	if cp == p {
+		t.Fatal("clone must not alias")
+	}
+	if cp.BoardChunkID != "c1" {
+		t.Fatalf("clone must copy board fields: %+v", cp)
+	}
+	// Board fields survive the JSON round-trip persisted in runs.parent_context.
+	enc, ok, err := EncodeParentContext(&ParentContext{BoardScope: "user", BoardChunkID: "c1", BoardDocumentID: "d1"})
+	if err != nil || !ok {
+		t.Fatalf("encode: ok=%v err=%v", ok, err)
+	}
+	if enc == "" {
+		t.Fatal("encoded board ParentContext should not be empty")
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -810,13 +810,22 @@ type ParentContext struct {
 	// Distinct from UserTier (loomcycle's resolver policy) — this is the
 	// consumer's own snapshot, carried verbatim.
 	TierAtRun string `json:"tier_at_run,omitempty"`
+	// Board{Scope,ChunkID,DocumentID} correlate a run to a workflow-board task
+	// (a Document chunk) for loomboard (RFC BT P4). A board-bound `TeamDef
+	// op=run` stamps these onto each handler run it spawns, so a client folding
+	// the run-state stream can pin a live agent to its kanban card. Empty for
+	// non-board runs. Not secret — safe to persist and emit like the rest.
+	BoardScope      string `json:"board_scope,omitempty"`
+	BoardChunkID    string `json:"board_chunk_id,omitempty"`
+	BoardDocumentID string `json:"board_document_id,omitempty"`
 }
 
 // IsZero reports whether every field is empty (no meaningful tracking
 // context). Wire entry points normalise a zero struct to nil so
 // back-compat decode paths stay clean.
 func (p *ParentContext) IsZero() bool {
-	return p == nil || (p.RootAgentRunID == "" && p.FunctionKey == "" && p.TierAtRun == "")
+	return p == nil || (p.RootAgentRunID == "" && p.FunctionKey == "" && p.TierAtRun == "" &&
+		p.BoardScope == "" && p.BoardChunkID == "" && p.BoardDocumentID == "")
 }
 
 // Clone returns a deep copy (nil-safe) so a parent's ParentContext can
@@ -827,6 +836,34 @@ func (p *ParentContext) Clone() *ParentContext {
 	}
 	cp := *p
 	return &cp
+}
+
+// BoardTask identifies the workflow-board task (a Document chunk) a board-bound
+// `TeamDef op=run` is driving. It rides the walk context so each handler spawn
+// stamps it onto the child run's ParentContext (see the sub-agent spawn path).
+type BoardTask struct {
+	Scope      string
+	ChunkID    string
+	DocumentID string
+}
+
+type boardTaskCtxKey struct{}
+
+// WithBoardTask returns a context carrying the board task. A zero task (empty
+// ChunkID) CLEARS it — used to stop propagation past the direct handler run so
+// a handler's own sub-agents aren't also pinned onto the card.
+func WithBoardTask(ctx context.Context, t BoardTask) context.Context {
+	return context.WithValue(ctx, boardTaskCtxKey{}, t)
+}
+
+// BoardTaskFromContext returns the board task on ctx. ok=false for a missing or
+// cleared (zero) task.
+func BoardTaskFromContext(ctx context.Context) (BoardTask, bool) {
+	t, _ := ctx.Value(boardTaskCtxKey{}).(BoardTask)
+	if t.ChunkID == "" {
+		return BoardTask{}, false
+	}
+	return t, true
 }
 
 // EncodeParentContext returns the JSON to persist in the runs.parent_context

--- a/internal/tools/builtin/teamdef.go
+++ b/internal/tools/builtin/teamdef.go
@@ -674,6 +674,11 @@ func (t *TeamDef) execRun(ctx context.Context, in teamDefInput) (tools.Result, e
 	var opts []teamrun.Option
 	resumedFrom := ""
 	if boardBound {
+		// Tag every handler run this walk spawns with the board task, so a client
+		// folding the run-state stream can pin the live agent to this chunk's card
+		// (RFC BT P4). Only the DIRECT handler run is tagged — the sub-agent spawn
+		// path clears it so a handler's own sub-agents aren't pinned onto the card.
+		walkCtx = store.WithBoardTask(walkCtx, store.BoardTask{Scope: boardScope, ChunkID: in.BoardChunkID})
 		// Resume: continue from the chunk's persisted status when it names a state
 		// still in the current graph (a graph edit that dropped that state falls
 		// back to the entry — start over rather than resume into a hole).


### PR DESCRIPTION
## Why
The loomboard workflow board (RFC BT P4) shows agent **miniatures pinned to task cards** — but nothing shipped links a live run to the chunk it's working. A board-bound `TeamDef op=run` (`board_chunk_id`) persists `chunk.status`, yet never records **which run** is handling the chunk, and neither the run-state stream nor the Channel events carry a chunk id. This is the minimal enabler for that correlation.

## What
Threads the board task key through the existing **ParentContext** lineage (already echoed on `RunStateEvent`), so a client folding `streamUserRunStates` can map run → chunk with no extra reads.

- **`store.ParentContext`** gains `Board{Scope,ChunkID,DocumentID}` (json omitempty; `IsZero`/`Clone` updated). New `BoardTask` + `WithBoardTask`/`BoardTaskFromContext` context carrier.
- **`op=run`** seeds `walkCtx` with the board task when board-bound.
- **`runSubAgent`** stamps the task key onto each handler run's `ParentContext` and echoes the child's context on its run-state events. The key is **cleared on the handler's own execution ctx**, so only the DIRECT handler is pinned to the card — not its sub-agents.
- **TS:** `ParentContext` gains `board_scope`/`board_chunk_id`/`board_document_id` (read side); `runTeam` accepts `boardChunkId`/`boardScope` so a client can launch a board-bound autopilot (the wire op already accepted them; the helper didn't surface them).

## Scope / safety
- Additive + backward-compatible: non-board runs are byte-identical (a zero board task is `IsZero` → nil → SQL NULL). The `subMeta.ParentContext` echo switched from the parent's to the child's clone, which carries the **same** root lineage plus (only for board runs) the task key.
- Not secret — board fields ride the existing "safe to persist/log/emit" ParentContext.

## Tested
- `go build ./...` clean; `go test ./internal/store ./internal/teamrun ./internal/tools/builtin` pass (new store test: ctx round-trip, `IsZero`/`Clone`/encode with board fields).
- TS `tsc --noEmit` clean.
- **Not exercised end-to-end here** (the run-state echo is integration-level): validated via the loomboard board (RFC BT P4 M2) consuming `parent_context.board_chunk_id` off the run-state stream — a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)