### PR TITLE
feat: retention report + the two embedding-maintenance client methods

### DIFF
--- a/adapters/ts/src/client.ts
+++ b/adapters/ts/src/client.ts
@@ -108,6 +108,8 @@ import type {
   MemoryEmbedStatsResponse,
   MemoryEntriesResponse,
   MemoryEntryResponse,
+  MemoryBackfillResponse,
+  MemoryPurgeResponse,
   MemoryReembedResponse,
   MemoryScopeIDsResponse,
   MemoryScopesResponse,
@@ -1146,6 +1148,55 @@ export class LoomcycleClient {
    *  rows processed per call (server default 1000). The response is a
    *  discriminated union on `dry_run` — narrow before reading its
    *  arm-specific fields. */
+  // backfillEmbeddings embeds rows that carry none — what an embedder added AFTER the
+  // rows were written leaves behind.
+  //
+  // dry_run defaults TRUE server-side and this only ever sends `false` to commit, the
+  // same posture as reembedMemory: an omitted flag cannot accidentally spend thousands
+  // of embedder calls.
+  async backfillEmbeddings(
+    scope: string,
+    scopeId: string,
+    opts?: { dryRun?: boolean; limit?: number; prefix?: string; tenant?: string; signal?: AbortSignal },
+  ): Promise<MemoryBackfillResponse> {
+    const query: Record<string, string> = { scope, scope_id: scopeId };
+    if (opts?.dryRun === false) query.dry_run = "false";
+    if (opts?.limit !== undefined && opts.limit > 0) query.limit = String(opts.limit);
+    if (opts?.prefix) query.prefix = opts.prefix;
+    // An ADMIN token must name the tenant: memory rows are keyed on it, so omitting it
+    // silently targets the default tenant and reports a truthful-looking zero.
+    if (opts?.tenant !== undefined) query.tenant = opts.tenant;
+    return postJSON<MemoryBackfillResponse>(
+      this.ctx,
+      "/v1/_memory/backfill_embeddings",
+      undefined,
+      { query, signal: opts?.signal },
+    );
+  }
+
+  // purgeStaleEmbeddings drops embeddings from rows that have no indexable text.
+  //
+  // THIS ONE DELETES, so the dry-run default matters more than on its siblings — and a
+  // zero `stale` with `truncated: true` means the scan was cut short, not that the scope
+  // is clean.
+  async purgeStaleEmbeddings(
+    scope: string,
+    scopeId: string,
+    opts?: { dryRun?: boolean; limit?: number; prefix?: string; tenant?: string; signal?: AbortSignal },
+  ): Promise<MemoryPurgeResponse> {
+    const query: Record<string, string> = { scope, scope_id: scopeId };
+    if (opts?.dryRun === false) query.dry_run = "false";
+    if (opts?.limit !== undefined && opts.limit > 0) query.limit = String(opts.limit);
+    if (opts?.prefix) query.prefix = opts.prefix;
+    if (opts?.tenant !== undefined) query.tenant = opts.tenant;
+    return postJSON<MemoryPurgeResponse>(
+      this.ctx,
+      "/v1/_memory/purge_stale_embeddings",
+      undefined,
+      { query, signal: opts?.signal },
+    );
+  }
+
   async reembedMemory(
     scope: string,
     scopeId: string,

--- a/adapters/ts/src/index.ts
+++ b/adapters/ts/src/index.ts
@@ -50,6 +50,8 @@
  *     memorySearch(input): Promise<MemorySearchResponse>          // unified k/v + document-chunk search
  *     memoryEmbedStats(scope): Promise<MemoryEmbedStatsResponse>
  *     reembedMemory(scope, scopeId, opts?): Promise<MemoryReembedResponse>  // dry_run defaults true
+ *     backfillEmbeddings(scope, scopeId, opts?): Promise<MemoryBackfillResponse>   // embeds rows that have none
+ *     purgeStaleEmbeddings(scope, scopeId, opts?): Promise<MemoryPurgeResponse>    // DELETES; dry_run defaults true
  *
  *     // Interruption (v0.8.16; decline RFC BH)
  *     listUserInterrupts(userId, opts?): Promise<InterruptListResponse>

--- a/adapters/ts/src/types.ts
+++ b/adapters/ts/src/types.ts
@@ -2675,3 +2675,47 @@ export interface SetTokenLimitRequest {
   soft_limit?: number;
   hard_limit?: number;
 }
+
+// MemoryBackfillResponse — POST /v1/_memory/backfill_embeddings.
+//
+// `skipped_empty` is reported rather than folded into a failure count because those rows
+// have NO text to embed (a document root, a section heading) and therefore remain
+// candidates permanently. Without it an operator watches `candidates` stop falling with
+// `embedded` at 0 and no stated reason.
+export interface MemoryBackfillResponse {
+  scope: string;
+  scope_id: string;
+  prefix?: string;
+  dry_run: boolean;
+  /** Unembedded rows this call SAW, bounded by limit. */
+  candidates: number;
+  embedded?: number;
+  failed?: number;
+  skipped_empty?: number;
+  /** The limit was reached with candidates outstanding — another call has work. */
+  more?: boolean;
+  failed_keys?: string[];
+  sample_keys?: string[];
+  notes?: string[];
+}
+
+// MemoryPurgeResponse — POST /v1/_memory/purge_stale_embeddings.
+//
+// `truncated` means the scan stopped at the limit, so a zero `stale` does NOT mean the
+// scope is clean — a distinction worth keeping because this op deletes.
+export interface MemoryPurgeResponse {
+  scope: string;
+  scope_id: string;
+  prefix?: string;
+  dry_run: boolean;
+  scanned: number;
+  /** Rows with no indexable text that nonetheless carry an embedding. */
+  stale: number;
+  purged: number;
+  failed?: number;
+  truncated: boolean;
+  sample_keys?: string[];
+  failed_keys?: string[];
+  first_failure?: string;
+  notes?: string[];
+}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1087,6 +1087,34 @@ export function documentQueryChunks(
   );
 }
 
+// RetentionReport is GET /v1/_retention — what the sweeper is configured to do, and
+// (for an admin) how much the current settings would match right now.
+//
+// A tenant operator sees the configuration without the `purgeable` preview; the handler
+// strips it. Absent counts therefore mean "not shown to you", never "zero".
+export interface RetentionReport {
+  admin: boolean;
+  enabled: boolean;
+  interval_ms: number;
+  defs_mode: string;
+  defs_max_age_ms: number;
+  defs_keep_last_n: number;
+  chats_mode: string;
+  chats_max_age_ms: number;
+  chats_internal_max_age_ms: number;
+  mem_mode: string;
+  mem_max_age_ms: number;
+  mem_content_mode: string;
+  mem_content_max_age_ms: number;
+  export_dir?: string;
+  purgeable?: Record<string, number>;
+  sqlmem_gc?: Record<string, unknown>;
+}
+
+export function getRetentionReport(): Promise<RetentionReport> {
+  return jsonFetch<RetentionReport>("/v1/_retention");
+}
+
 export function documentGetChunk(id: string, scope: DocScope, browse?: BrowseScope): Promise<ChunkDetail> {
   return substratePost("/v1/_document", { op: "get_chunk", id, scope }, browse);
 }

--- a/web/src/lib/retention.test.ts
+++ b/web/src/lib/retention.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { countMeaning, exportMisconfigured, familyEffect } from "./retention";
+
+describe("familyEffect", () => {
+  it("names what each mode does", () => {
+    expect(familyEffect("off")).toBe("inert");
+    expect(familyEffect("prune")).toBe("deletes");
+    expect(familyEffect("export+prune")).toBe("exports-then-deletes");
+  });
+
+  it("treats an unknown mode as inert rather than as deleting", () => {
+    // A mode this UI does not know must not be announced as destroying data. The safe
+    // reading of an unknown is that we cannot say it deletes.
+    expect(familyEffect("something-new")).toBe("inert");
+    expect(familyEffect("")).toBe("inert");
+  });
+});
+
+describe("countMeaning", () => {
+  it("does not imply a deletion that will never happen", () => {
+    // `purgeable` is computed regardless of mode. Shown beside an `off` family, a bare
+    // count reads as a countdown to deletion.
+    expect(countMeaning("off", 38)).toContain("this family is off");
+    expect(countMeaning("off", 38)).not.toContain("will be removed");
+  });
+
+  it("says plainly when data IS about to go", () => {
+    expect(countMeaning("prune", 38)).toContain("will be removed");
+    expect(countMeaning("export+prune", 38)).toContain("will be removed");
+  });
+
+  it("distinguishes zero from absent", () => {
+    // Zero means the age matched nothing; absent means the caller may not see counts at
+    // all (a tenant operator), and inventing "0" for them would assert something the
+    // server did not say.
+    expect(countMeaning("prune", 0)).toBe("nothing matches the current age");
+    expect(countMeaning("prune", undefined)).toBe("");
+  });
+});
+
+describe("exportMisconfigured", () => {
+  it("catches the combination that silently does nothing", () => {
+    // export+prune with no export dir: the sweeper refuses the family, so the data is
+    // neither exported nor pruned — and this report is the only place that shows.
+    expect(exportMisconfigured("export+prune", "")).toBe(true);
+    expect(exportMisconfigured("export+prune", undefined)).toBe(true);
+    expect(exportMisconfigured("export+prune", "/var/exports")).toBe(false);
+  });
+
+  it("is not raised for families that do not export", () => {
+    expect(exportMisconfigured("prune", "")).toBe(false);
+    expect(exportMisconfigured("off", "")).toBe(false);
+  });
+});

--- a/web/src/lib/retention.ts
+++ b/web/src/lib/retention.ts
@@ -1,0 +1,56 @@
+// Reading the retention report.
+//
+// THE MISLEADING NUMBER THIS EXISTS TO PREVENT. `purgeable` is a preview computed
+// REGARDLESS OF MODE — it answers "how much would the current age settings match", not
+// "how much is about to be deleted". A family set to `off` deletes nothing, and showing
+// "38 purgeable" beside it reads as a countdown. The inverse is worse: a family set to
+// `prune` with rows matching IS deleting data on the next sweep, and that deserves to
+// look different from a preview.
+//
+// So a count is only ever rendered together with what its family's mode will actually do
+// with it.
+export type RetentionMode = "off" | "prune" | "export+prune" | string;
+
+export interface RetentionFamily {
+  key: string;
+  label: string;
+  mode: RetentionMode;
+  maxAgeMs: number;
+  /** Preview count, when the caller is allowed to see one. */
+  purgeable?: number;
+}
+
+export type FamilyEffect = "inert" | "deletes" | "exports-then-deletes";
+
+// familyEffect says what this family's mode DOES, in the terms an operator cares about.
+export function familyEffect(mode: RetentionMode): FamilyEffect {
+  switch (mode) {
+    case "prune":
+      return "deletes";
+    case "export+prune":
+      return "exports-then-deletes";
+    default:
+      // Anything unrecognised is treated as inert. A future mode this UI does not know
+      // must not be announced as deleting data — the safe reading of an unknown is that
+      // we cannot say it deletes, and the raw mode string is shown alongside anyway.
+      return "inert";
+  }
+}
+
+// countMeaning is what a purgeable count means for THIS family. The count alone is
+// ambiguous; paired with the mode it is not.
+export function countMeaning(mode: RetentionMode, purgeable?: number): string {
+  if (purgeable === undefined) return "";
+  if (purgeable === 0) return "nothing matches the current age";
+  return familyEffect(mode) === "inert"
+    ? `${purgeable} would match — but this family is off, so nothing is deleted`
+    : `${purgeable} will be removed on the next sweep`;
+}
+
+// exportMisconfigured reports the one combination that silently does nothing: a family
+// set to export-then-delete with no export directory configured. The sweeper refuses to
+// run it, so the operator's data is neither exported nor pruned — and the report is the
+// only place that is visible.
+export function exportMisconfigured(mode: RetentionMode, exportDir: string | undefined): boolean {
+  return familyEffect(mode) === "exports-then-deletes" && !exportDir;
+}

--- a/web/src/pages/SettingsView.tsx
+++ b/web/src/pages/SettingsView.tsx
@@ -6,6 +6,7 @@ import {
   type Visibility,
 } from "../lib/visibility";
 import { ontologistRunHref, ontologyEditHref } from "../lib/ontologyEditHref";
+import { countMeaning, exportMisconfigured, familyEffect } from "../lib/retention";
 import {
   CredentialMeta,
   CredentialScope,
@@ -21,6 +22,7 @@ import {
   getEnvTemplate,
   getHealth,
   getOntology,
+  getRetentionReport,
   getRuntimeState,
   listCredentials,
   listPresets,
@@ -31,6 +33,7 @@ import {
   setOntologyStatus,
   showPreset,
   OntologyTerm,
+  RetentionReport,
 } from "../api";
 import { usePrincipal, useUserId } from "../components/Layout";
 import LimitsView from "./LimitsView";
@@ -55,6 +58,7 @@ type Section =
   | "limits"
   | "routing"
   | "ontology"
+  | "retention"
   | "tokens"
   | "presets"
   | "runtime"
@@ -88,6 +92,7 @@ const SECTIONS: SectionDef[] = [
   { id: "limits", label: "Limits", vis: "tenant" },
   { id: "routing", label: "Routing", vis: "tenant" },
   { id: "ontology", label: "Ontology", vis: "tenant" },
+  { id: "retention", label: "Retention", vis: "tenant" },
   // ScopeAdmin: token minting has no tenant axis and is deliberately excluded from
   // the tenant-confined def set; presets/runtime/health fall through to the /v1/_*
   // catch-all; and repair-tenant is explicitly admin because it rewrites rows across
@@ -154,6 +159,7 @@ export default function SettingsView() {
         {active === "limits" && <LimitsView />}
         {active === "routing" && <RoutingView />}
         {active === "ontology" && <OntologySection />}
+        {active === "retention" && <RetentionSection />}
         {active === "tokens" && <TokenManager />}
         {active === "presets" && <PresetsSection />}
         {active === "runtime" && <RuntimeSection />}
@@ -959,6 +965,108 @@ function OntologySection() {
               </tbody>
             </table>
           </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ─── Retention ───────────────────────────────────────────────────────────────
+//
+// What the sweeper is configured to delete, and — for an admin — how much the current
+// settings would match right now.
+//
+// READ-ONLY BY DESIGN. Retention is config: changing it here would mean an operator
+// deleting data through a form whose effect they cannot preview, and the preview IS this
+// page. The report is the instrument; the yaml is the control.
+function RetentionSection() {
+  const [rep, setRep] = useState<RetentionReport | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    getRetentionReport()
+      .then((r) => {
+        setRep(r);
+        setErr(null);
+      })
+      .catch((e) => setErr(e instanceof Error ? e.message : String(e)));
+  }, []);
+
+  const days = (ms: number) => (ms > 0 ? `${Math.round(ms / 86_400_000)}d` : "—");
+
+  const families = rep
+    ? [
+        { key: "defs", label: "definition versions", mode: rep.defs_mode, age: rep.defs_max_age_ms },
+        { key: "chats", label: "chats", mode: rep.chats_mode, age: rep.chats_max_age_ms },
+        {
+          key: "chats_internal",
+          label: "chats (internal agents)",
+          mode: rep.chats_mode,
+          age: rep.chats_internal_max_age_ms,
+        },
+        { key: "mem", label: "retired agents' memory", mode: rep.mem_mode, age: rep.mem_max_age_ms },
+        {
+          key: "mem_content",
+          label: "superseded memory content",
+          mode: rep.mem_content_mode,
+          age: rep.mem_content_max_age_ms,
+        },
+      ]
+    : [];
+
+  return (
+    <div className="settings-panel">
+      <h2>Retention</h2>
+      <p className="settings-help">
+        What the background sweeper is configured to remove, and when. This page reports;
+        the settings themselves live in the operator&rsquo;s yaml — a form that deleted
+        data without a preview would be the wrong control, and this is the preview.
+      </p>
+      {err && <div className="settings-error">{err}</div>}
+      {rep && (
+        <>
+          <div className="settings-muted">
+            {rep.enabled
+              ? `sweeper on, every ${Math.round(rep.interval_ms / 60_000)} min`
+              : "sweeper OFF — nothing is removed on any schedule, whatever the families below say"}
+          </div>
+          <dl className="settings-stats">
+            {families.map((f) => {
+              const effect = familyEffect(f.mode);
+              const count = rep.purgeable?.[f.key];
+              return (
+                <div key={f.key}>
+                  <dt>{f.label}</dt>
+                  <dd>
+                    <code>{f.mode}</code>
+                    {effect !== "inert" && <> · older than {days(f.age)}</>}
+                  </dd>
+                  {/* The count NEVER stands alone — see lib/retention for why a bare
+                      number beside an `off` family reads as a countdown. */}
+                  {count !== undefined && (
+                    <dd className="settings-muted">{countMeaning(f.mode, count)}</dd>
+                  )}
+                  {exportMisconfigured(f.mode, rep.export_dir) && (
+                    <dd className="settings-error">
+                      exports nowhere — no export directory is configured, so the sweeper
+                      refuses this family and nothing is removed
+                    </dd>
+                  )}
+                </div>
+              );
+            })}
+          </dl>
+          {!rep.admin && (
+            <div className="settings-muted">
+              Counts are admin-only, so this shows the configuration without them — an
+              absent number here means &ldquo;not shown to you&rdquo;, never zero.
+            </div>
+          )}
+          {rep.export_dir && (
+            <div className="settings-muted">
+              exports to <code>{rep.export_dir}</code>
+            </div>
+          )}
         </>
       )}
     </div>


### PR DESCRIPTION
RFC CF phase 5 — and it **splits**: one half ships here, one half cannot yet.

## What ships: the retention report

Settings → Retention. What the sweeper is configured to remove and when, per family, with the sweeper's own on/off state stated **first** — a family set to `prune` removes nothing while the sweeper is off, and reading the families without that is reading a plan nobody executes.

**Read-only by design.** Retention is config, and a form that deleted data without a preview would be the wrong control — this page *is* the preview. The yaml stays the control.

### The misleading number this is shaped against

`purgeable` is computed **regardless of mode**. It answers *"how much would the current age match"*, not *"how much is about to go"*. A bare count beside an `off` family reads as a countdown to a deletion that will never happen; the same count beside `prune` means data goes on the next sweep.

So a count is **never rendered alone** — it always carries what its family's mode will actually do with it.

Two smaller honesty points, both tested:

- **An unknown mode reads as inert.** A mode this UI doesn't recognise must not be announced as destroying data; the raw string is shown regardless.
- **An absent count means "not shown to you"**, never zero — a tenant operator sees the configuration without the admin-only preview, and inventing a `0` would assert something the server didn't say.
- **`export+prune` with no export directory is called out.** The sweeper refuses that family outright, so the data is neither exported nor pruned — and this report is the only place that shows.

## What cannot ship yet, and why it isn't hacked around

`backfill_embeddings` and `purge_stale_embeddings` belong in the shared package beside the reembed flow — both are per-scope, which is what settled §12.5 in your favour.

But **the package typechecks against the published `@loomcycle/client`**, a peer dependency pinned at `^1.49.0`. It cannot call client methods that exist only in this tree.

So the two methods are added to the **adapter** here. They publish on the next release, and the package's buttons follow immediately after. The alternative — a second call path inside the package, bypassing its client — is exactly the duplication #1029 was spent removing.

## Tested

7 lib tests on the report's reading rules, each verified fail-before: an `off` family's count doesn't read as a countdown, an unknown mode is inert, an absent count isn't zero, and the export-misconfiguration is caught.

Adapter and app typecheck clean; `vitest` 59 passing; `go test ./...` clean.

## Sequencing note

Phase 5 is therefore complete only after the next `@loomcycle/client` release. Phase 6 (erasure) is unblocked — §12.4 is decided: **it gets its own durable audit record**, since the event log is session-scoped and subject to the same retention sweeps this very page describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)