### PR TITLE
feat(erasure): refuse to erase a subject without a durable record of who asked

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -2015,6 +2015,18 @@ func main() {
 		tokenAudit = fs
 		log.Printf("audit: OperatorTokenDef mutations → %s", cfg.Env.AuditLogPath)
 	}
+	// Subject erasure shares the same sink — but NOT the same posture: with no audit
+	// path configured, erasure REFUSES rather than proceeding unrecorded. It is the one
+	// operation nothing can undo, so "we cannot say who did this" is a reason not to do
+	// it. Wiring the sink even when it is a NopSink would defeat that, so this passes
+	// nil when there is no file to write to.
+	if cfg.Env.AuditLogPath != "" {
+		srv.SetEraseAudit(tokenAudit)
+		log.Printf("audit: subject erasures → %s", cfg.Env.AuditLogPath)
+	} else {
+		log.Printf("audit: no LOOMCYCLE_AUDIT_LOG_PATH — subject erasure is DISABLED " +
+			"(it will not delete without a durable record of who asked)")
+	}
 	graceSecs := 0
 	if v := os.Getenv("LOOMCYCLE_OPERATOR_TOKEN_ROTATION_GRACE_SECONDS"); v != "" {
 		if n, perr := strconv.Atoi(v); perr == nil && n >= 0 {

--- a/internal/api/http/erasure_audit_test.go
+++ b/internal/api/http/erasure_audit_test.go
@@ -1,0 +1,148 @@
+package http
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/audit"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+)
+
+// errDiskFull stands in for whatever stops a sink writing — a full disk, a read-only
+// mount, a path the process cannot open.
+var errDiskFull = errors.New("no space left on device")
+
+func memStoreForTest(t *testing.T) store.Store {
+	t.Helper()
+	st, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return st
+}
+
+// failingSink refuses every record, standing in for a full disk, a read-only mount, or a
+// path the process cannot write.
+type failingSink struct{ err error }
+
+func (f failingSink) Record(audit.Event) error { return f.err }
+
+// recordingSink keeps what was written, in order.
+type recordingSink struct{ events []audit.Event }
+
+func (r *recordingSink) Record(ev audit.Event) error {
+	r.events = append(r.events, ev)
+	return nil
+}
+
+// TestErasure_RefusesWithoutAnAuditSink.
+//
+// Every other consumer of the audit sink treats recording as best-effort — audit is
+// observability, not a transaction participant. Erasure is the deliberate exception: it
+// is the one operation nothing can undo, so a deployment that cannot record WHO erased
+// WHICH subject does not get to perform the deletion.
+//
+// Refusing is recoverable (configure the sink, retry). An unrecorded erasure is not.
+func TestErasure_RefusesWithoutAnAuditSink(t *testing.T) {
+	s := &Server{store: memStoreForTest(t)}
+	// No SetEraseAudit call at all — the shape a deployment with no audit path has.
+
+	rec := httptest.NewRecorder()
+	body := `{"subject":"alice","dry_run":false,"confirm":"alice"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/_erasure?tenant=t1", strings.NewReader(body))
+	s.handleErasureExecute(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 — an erasure with nowhere to record it must refuse", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "audit") {
+		t.Errorf("the refusal does not say why: %s", rec.Body.String())
+	}
+}
+
+// TestErasure_RefusesWhenTheRecordCannotBeWritten. A configured sink that fails is the
+// same situation as none: the deletion must not happen unrecorded.
+func TestErasure_RefusesWhenTheRecordCannotBeWritten(t *testing.T) {
+	s := &Server{store: memStoreForTest(t)}
+	s.SetEraseAudit(failingSink{err: errDiskFull})
+
+	rec := httptest.NewRecorder()
+	body := `{"subject":"alice","dry_run":false,"confirm":"alice"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/_erasure?tenant=t1", strings.NewReader(body))
+	s.handleErasureExecute(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+}
+
+// TestErasure_RecordsIntentBeforeDeletingAndOutcomeAfter.
+//
+// The ORDER is the point. An intent record written first means a crash mid-erasure still
+// leaves evidence that one was attempted, by whom, against which subject — which a single
+// after-the-fact record cannot promise for an operation nothing can undo.
+func TestErasure_RecordsIntentBeforeDeletingAndOutcomeAfter(t *testing.T) {
+	sink := &recordingSink{}
+	s := &Server{store: memStoreForTest(t)}
+	s.SetEraseAudit(sink)
+
+	rec := httptest.NewRecorder()
+	body := `{"subject":"alice","dry_run":false,"confirm":"alice"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/_erasure?tenant=t1", strings.NewReader(body))
+	s.handleErasureExecute(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", rec.Code, rec.Body.String())
+	}
+	if len(sink.events) != 2 {
+		t.Fatalf("wrote %d records, want intent + result: %+v", len(sink.events), sink.events)
+	}
+	if sink.events[0].Action != "erase_intent" {
+		t.Errorf("first record is %q — the intent must be written BEFORE the deletion",
+			sink.events[0].Action)
+	}
+	if sink.events[1].Action != "erase_result" {
+		t.Errorf("second record is %q, want erase_result", sink.events[1].Action)
+	}
+	for i, ev := range sink.events {
+		if ev.TargetSubject != "alice" || ev.TargetTenant != "t1" {
+			t.Errorf("record %d does not identify the subject/tenant: %+v", i, ev)
+		}
+	}
+	// The outcome carries what went, including what was deliberately kept — a record
+	// listing only deletions would read as complete when it is not.
+	if sink.events[1].ErasePlanes == nil && sink.events[1].EraseRetained == nil {
+		t.Errorf("the result record carries neither planes nor retentions: %+v", sink.events[1])
+	}
+}
+
+// TestErasure_DryRunWritesNoRecord. A preview removes nothing, and an audit log full of
+// previews is one an auditor stops reading.
+func TestErasure_DryRunWritesNoRecord(t *testing.T) {
+	sink := &recordingSink{}
+	s := &Server{store: memStoreForTest(t)}
+	s.SetEraseAudit(sink)
+
+	rec := httptest.NewRecorder()
+	body := `{"subject":"alice","dry_run":true,"confirm":"alice"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/_erasure?tenant=t1", strings.NewReader(body))
+	s.handleErasureExecute(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", rec.Code, rec.Body.String())
+	}
+	if len(sink.events) != 0 {
+		t.Errorf("a dry run wrote %d audit record(s): %+v", len(sink.events), sink.events)
+	}
+	var res map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &res)
+	if dry, _ := res["dry_run"].(bool); !dry {
+		t.Errorf("the response does not report itself as a dry run: %v", res)
+	}
+}

--- a/internal/api/http/erasure_execute.go
+++ b/internal/api/http/erasure_execute.go
@@ -14,8 +14,12 @@ package http
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"log"
 	"net/http"
 
+	"github.com/denn-gubsky/loomcycle/internal/audit"
+	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/erasure"
 )
 
@@ -44,9 +48,49 @@ func (s *Server) handleErasureExecute(w http.ResponseWriter, r *http.Request) {
 	if req.DryRun != nil {
 		dryRun = *req.DryRun
 	}
-	res, err := s.erasureService().Execute(r.Context(), erasure.ExecuteRequest{
+
+	// VALIDATE FIRST, so a request that was going to be rejected never writes an audit
+	// record. A log of intents that never happened is noise in the one log an auditor
+	// needs to trust — and reporting "audit unavailable" for a mistyped confirmation
+	// would name the wrong problem.
+	svc := s.erasureService()
+	execReq := erasure.ExecuteRequest{
 		Tenant: tenant, Subject: req.Subject, DryRun: dryRun, Confirm: req.Confirm,
-	})
+	}
+	if verr := svc.Validate(execReq); verr != nil {
+		switch {
+		case errors.Is(verr, erasure.ErrNoSubject):
+			writeJSONError(w, http.StatusBadRequest, "missing_subject", "subject is required")
+		case errors.Is(verr, erasure.ErrConfirmMismatch):
+			writeJSONError(w, http.StatusBadRequest, "confirm_mismatch", verr.Error())
+		default:
+			writeJSONError(w, http.StatusBadRequest, "invalid_request", verr.Error())
+		}
+		return
+	}
+
+	// AUDIT BEFORE DELETING, and refuse if the record will not write.
+	//
+	// Every other consumer of this sink treats recording as best-effort — audit is
+	// observability, not a transaction participant. Erasure is the exception, and
+	// deliberately so: it is the one operation in this API that nothing can undo, so a
+	// deployment that cannot say WHO erased WHICH subject does not get to perform the
+	// deletion. Refusing is recoverable (configure the sink and retry); an unrecorded
+	// erasure is not.
+	//
+	// A dry run writes no record: it removes nothing, and an audit log full of previews
+	// is one an auditor stops reading.
+	if !dryRun {
+		if err := s.recordEraseIntent(r, tenant, req.Subject); err != nil {
+			writeJSONError(w, http.StatusServiceUnavailable, "audit_unavailable",
+				"refusing to erase without an audit record: "+err.Error()+
+					". Erasure cannot be undone, so it is not performed unless who did it "+
+					"can be recorded — set LOOMCYCLE_AUDIT_LOG_PATH and retry.")
+			return
+		}
+	}
+
+	res, err := svc.Execute(r.Context(), execReq)
 	switch {
 	case errors.Is(err, erasure.ErrNoSubject):
 		writeJSONError(w, http.StatusBadRequest, "missing_subject", "subject is required")
@@ -58,5 +102,49 @@ func (s *Server) handleErasureExecute(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusInternalServerError, "erasure_failed", err.Error())
 		return
 	}
+	// The outcome record is BEST-EFFORT, unlike the intent above. The deletion has
+	// already happened; refusing now would report a failure for work that was done, and
+	// the intent record already answers "who erased which subject, when". This one only
+	// enriches it with what went.
+	if !dryRun {
+		s.recordEraseResult(r, tenant, req.Subject, res)
+	}
 	writeJSON(w, http.StatusOK, res)
+}
+
+// recordEraseIntent writes the record that must exist before anything is deleted.
+func (s *Server) recordEraseIntent(r *http.Request, tenant, subject string) error {
+	if s.eraseAudit == nil {
+		return fmt.Errorf("no audit sink configured")
+	}
+	ev := audit.Event{Action: "erase_intent", TargetTenant: tenant, TargetSubject: subject}
+	s.stampEraseActor(r, &ev)
+	return s.eraseAudit.Record(ev)
+}
+
+// recordEraseResult appends what the erasure actually did.
+func (s *Server) recordEraseResult(r *http.Request, tenant, subject string, res erasure.Result) {
+	if s.eraseAudit == nil {
+		return
+	}
+	ev := audit.Event{
+		Action: "erase_result", TargetTenant: tenant, TargetSubject: subject,
+		ErasePlanes: res.Deleted, EraseRetained: res.Retained, EraseErrors: res.Errors,
+	}
+	s.stampEraseActor(r, &ev)
+	if err := s.eraseAudit.Record(ev); err != nil {
+		// Logged, not returned: the rows are gone either way, and the intent record
+		// already carries who and what.
+		log.Printf("audit: erase_result record failed (subject=%s tenant=%s): %v", subject, tenant, err)
+	}
+}
+
+// stampEraseActor fills WHO from the authenticated principal — never from the body.
+func (s *Server) stampEraseActor(r *http.Request, ev *audit.Event) {
+	if p, ok := auth.PrincipalFromContext(r.Context()); ok {
+		ev.ActorTenant = p.TenantID
+		ev.ActorSubject = p.Subject
+		ev.ActorTokenSuffix = p.TokenSuffix
+	}
+	ev.SourceAddr = r.RemoteAddr
 }

--- a/internal/api/http/erasure_execute_test.go
+++ b/internal/api/http/erasure_execute_test.go
@@ -126,6 +126,9 @@ func TestErasureExecute_LiveRunRequiresMatchingConfirm(t *testing.T) {
 // orphan, and must not delete it.
 func TestErasureExecute_ReportsResidueItIsAboutToMakeUnfindable(t *testing.T) {
 	srv, _ := makeServer(t, completingProvider(), makeBaseConfig())
+	// A LIVE erasure refuses without somewhere to record who asked for it, so every
+	// test that performs one has to supply a sink (see erasure_audit_test.go).
+	srv.SetEraseAudit(&recordingSink{})
 	ctx := context.Background()
 	const tenant, subject = "acme", "alice"
 	seedSubject(t, srv, tenant, subject)
@@ -179,6 +182,7 @@ func TestErasureExecute_ReportsResidueItIsAboutToMakeUnfindable(t *testing.T) {
 // result, and says the number is undeterminable instead.
 func TestErasureExecute_ResidueBecomesUnfindableAfterwards(t *testing.T) {
 	srv, _ := makeServer(t, completingProvider(), makeBaseConfig())
+	srv.SetEraseAudit(&recordingSink{})
 	ctx := context.Background()
 	const tenant, subject = "acme", "alice"
 	seedSubject(t, srv, tenant, subject)

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/audit"
 	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/cancel"
 	"github.com/denn-gubsky/loomcycle/internal/channels"
@@ -77,6 +78,10 @@ type Server struct {
 	// are nil-safe). Wired at boot via SetProviderGates.
 	providerGates *concurrency.ProviderGates
 	store         store.Store // optional; nil means "don't persist"
+	// eraseAudit records subject erasures. Unlike every other audit consumer, a nil or
+	// failing sink here REFUSES the operation rather than proceeding unrecorded — see
+	// SetEraseAudit.
+	eraseAudit audit.Sink
 
 	// sqlMem is the RFC AA SQL Memory manager (per-scope sqlite databases
 	// backing the Memory tool's sql_query/sql_exec). Nil when the subsystem
@@ -957,6 +962,16 @@ func (s *Server) SetDocumentSourceDefTool(t tools.Tool) {
 // with "not configured".
 func (s *Server) SetOperatorTokenDefTool(t tools.Tool) {
 	s.operatorTokenDefTool = t
+}
+
+// SetEraseAudit wires the sink subject erasure records to.
+//
+// NIL IS NOT "no audit" HERE — it is "erasure is unavailable". Every other consumer of
+// this sink treats recording as best-effort observability, which is right for them;
+// erasure is the one operation nothing can undo, so a deployment that cannot write the
+// record does not get to perform the deletion. handleErasureExecute enforces that.
+func (s *Server) SetEraseAudit(sink audit.Sink) {
+	s.eraseAudit = sink
 }
 
 // SetSqlMem wires the RFC AA SQL Memory manager so the server can drop a

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -42,6 +42,25 @@ type Event struct {
 	SqlRows       int64  `json:"sql_rows,omitempty"`      // rows returned (query) or affected (exec)
 	SqlDurationMs int64  `json:"sql_duration_ms,omitempty"`
 	SqlError      string `json:"sql_error,omitempty"`
+
+	// --- RFC CF §7 subject erasure (Action = "erase_intent" | "erase_result") ---
+	//
+	// TWO RECORDS, and the pair is the point. `erase_intent` is written BEFORE any
+	// deletion and its failure REFUSES the erasure; `erase_result` is written after and
+	// carries what actually went. A crash between them still leaves evidence that an
+	// erasure was attempted, by whom, against which subject — which a single
+	// after-the-fact record cannot promise for an operation nothing can undo.
+	//
+	// The subject and tenant travel in TargetSubject / TargetTenant above; these add
+	// only what is specific to an erasure.
+	EraseDryRun bool `json:"erase_dry_run,omitempty"`
+	// ErasePlanes is plane → rows removed. Recorded rather than a total because
+	// "which planes were touched" is the question an auditor actually has.
+	ErasePlanes map[string]int `json:"erase_planes,omitempty"`
+	// EraseRetained is plane → why it was kept. An erasure record listing only its
+	// deletions would read as complete when it is not.
+	EraseRetained map[string]string `json:"erase_retained,omitempty"`
+	EraseErrors   []string          `json:"erase_errors,omitempty"`
 }
 
 // Sink records audit events. Record must be safe for concurrent use and

--- a/internal/erasure/erasure.go
+++ b/internal/erasure/erasure.go
@@ -285,16 +285,32 @@ func (s *Service) Report(ctx context.Context, tenant, subject string) (Report, e
 // should leave them standing. The residue is measured FIRST, from session ids
 // captured up front — see Result.Notes for why that number can never be
 // recovered afterwards.
-func (s *Service) Execute(ctx context.Context, req ExecuteRequest) (Result, error) {
+// Validate applies the guards that decide whether an erasure may proceed, WITHOUT
+// touching anything.
+//
+// Extracted from Execute so a caller can ask "would this be accepted?" before doing
+// something irreversible on the strength of it — the HTTP layer writes an audit record
+// between the two, and a record written for a request that was about to be rejected
+// would be noise in the one log an auditor needs to trust. Execute still calls this, so
+// the rule has one home and every transport inherits it.
+func (s *Service) Validate(req ExecuteRequest) error {
 	subject := strings.TrimSpace(req.Subject)
 	if subject == "" {
-		return Result{}, ErrNoSubject
+		return ErrNoSubject
 	}
-	// Enforced HERE so every transport inherits it. A subject id matching nothing
-	// is harmless; one matching the wrong person is irreversible.
+	// A subject id matching nothing is harmless; one matching the wrong person is
+	// irreversible.
 	if !req.DryRun && req.Confirm != subject {
-		return Result{}, ErrConfirmMismatch
+		return ErrConfirmMismatch
 	}
+	return nil
+}
+
+func (s *Service) Execute(ctx context.Context, req ExecuteRequest) (Result, error) {
+	if err := s.Validate(req); err != nil {
+		return Result{}, err
+	}
+	subject := strings.TrimSpace(req.Subject)
 	tenant := req.Tenant
 	res := Result{
 		Tenant: tenant, Subject: subject, DryRun: req.DryRun,


### PR DESCRIPTION
RFC CF §7, and your §12.4 decision: erasure gets its own audit record — **as a precondition, not a side effect**.

This is the server half. The console surface follows once this posture is settled, since what the UI may offer depends on it.

## Why this sink

The existing append-only JSONL audit already carries *who did what to which principal*, and it lives **outside the store** — so it is not subject to the retention sweeps that #1032's report describes. That was the objection to using the event log, and it doesn't apply here.

## The posture is a deliberate exception

The sink's own contract says recording *"must never block the caller's primary operation — audit is best-effort observability, not a transaction participant."* That is right for every other consumer and **wrong for this one**.

Erasure is the single operation in this API that nothing can undo. A deployment that cannot say who erased which subject does not get to perform the deletion. **Refusing is recoverable** — configure the sink and retry. An unrecorded erasure is not.

So a nil sink means *"erasure unavailable"*, not *"erasure unaudited"*, and boot says so out loud when no audit path is configured.

## Two records, and the order is the point

| record | when | on failure |
|---|---|---|
| `erase_intent` | **before** any deletion | refuses the erasure |
| `erase_result` | after, with planes deleted + retained | logged only |

A crash between them still leaves evidence that an erasure was attempted, by whom, against which subject — which a single after-the-fact record cannot promise. The result record is best-effort because the rows are already gone; blocking then would report a failure for work that was done.

**A dry run writes nothing.** It removes nothing, and an audit log full of previews is one an auditor stops reading.

## A bug in my own first draft

The audit gate initially ran **before** validation. So a mistyped confirmation came back `audit_unavailable` — naming the wrong problem — and would have written an intent record for a request about to be rejected. A log of intents that never happened is noise in the one log an auditor needs to trust.

`erasure.Validate` is extracted for it, and `Execute` still calls it, so the rule keeps one home and every transport inherits it.

## Already there

The typed confirmation the RFC asked for **already exists**: `ErrConfirmMismatch` requires `confirm` to equal the subject for a live run, enforced in the service rather than at the edge. The UI will surface it rather than reinvent it.

## Tested

Four guarantees, each verified fail-before: refusal with no sink; refusal when the sink errors; intent-before-result ordering with subject and tenant on both records; and a dry run writing none.

Two existing tests that performed live erasures now wire a sink — the contract genuinely changed for them, and that change is the feature.

`go test ./...` clean, gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)