### PR TITLE
feat(ui): author remote document sources in Integrations (RFC CE)

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1683,6 +1683,10 @@ export function listMemoryBackendDefNames(): Promise<DefNamesResponse> {
   return jsonFetch<DefNamesResponse>("/v1/_memorybackenddef/names");
 }
 
+export function listDocumentSourceDefNames(): Promise<DefNamesResponse> {
+  return jsonFetch<DefNamesResponse>("/v1/_documentsourcedef/names");
+}
+
 // ---- Teams (RFC AP / BD) ----
 //
 // TeamDefs are the agent-team workflow graphs. The Teams view lists them
@@ -1838,6 +1842,9 @@ export type SubstrateKind =
   | "a2aservercarddef"
   | "a2aagentdef"
   | "memorybackenddef"
+  // RFC CE remote-document-source substrate — create/fork/promote/retire, like
+  // memorybackenddef.
+  | "documentsourcedef"
   // RFC AH dynamic volume substrate. Flat (no versioning): the only ops are
   | "volumedef"; // create / delete / purge — not the create/fork/promote/retire lifecycle.
 

--- a/web/src/components/IntegrationEditModal.test.ts
+++ b/web/src/components/IntegrationEditModal.test.ts
@@ -106,3 +106,75 @@ describe("validateMemoryBackend", () => {
     ).toMatch(/env_pattern/);
   });
 });
+
+// RFC CE — the DocumentSourceDef surface in Integrations.
+import {
+  buildDocumentSourceOverlay,
+  initDocumentSource,
+  validateDocumentSource,
+  type DocumentSourceFormState,
+} from "./IntegrationEditModal";
+
+const docState = (over: Partial<DocumentSourceFormState> = {}): DocumentSourceFormState => ({
+  baseUrl: "https://peer.example:8787",
+  apiVersion: "",
+  apiKeyEnv: "LOOMCYCLE_PEER_DOC_KEY",
+  tenancyKind: "",
+  envPattern: "",
+  ...over,
+});
+
+describe("initDocumentSource", () => {
+  it("reads a def's config + tenancy", () => {
+    const s = initDocumentSource({
+      config: { base_url: "https://peer:8787", api_version: "v1", api_key_env: "LOOMCYCLE_PEER_DOC_KEY" },
+      tenancy_strategy: { kind: "key_per_tenant", env_pattern: "LOOMCYCLE_{tenant_id}_KEY" },
+    });
+    expect(s.baseUrl).toBe("https://peer:8787");
+    expect(s.apiVersion).toBe("v1");
+    expect(s.apiKeyEnv).toBe("LOOMCYCLE_PEER_DOC_KEY");
+    expect(s.tenancyKind).toBe("key_per_tenant");
+    expect(s.envPattern).toBe("LOOMCYCLE_{tenant_id}_KEY");
+  });
+});
+
+describe("buildDocumentSourceOverlay", () => {
+  it("always emits config.base_url and omits blank optionals", () => {
+    const ov = buildDocumentSourceOverlay(docState({ apiVersion: "" }), "peer docs");
+    expect(ov.config).toEqual({
+      base_url: "https://peer.example:8787",
+      api_key_env: "LOOMCYCLE_PEER_DOC_KEY",
+    });
+    expect(ov.description).toBe("peer docs");
+    expect(ov.tenancy_strategy).toBeUndefined();
+  });
+  it("emits tenancy_strategy when set", () => {
+    const ov = buildDocumentSourceOverlay(
+      docState({ tenancyKind: "key_per_tenant", envPattern: "LOOMCYCLE_{tenant_id}_KEY" }),
+      "",
+    );
+    expect(ov.tenancy_strategy).toEqual({
+      kind: "key_per_tenant",
+      env_pattern: "LOOMCYCLE_{tenant_id}_KEY",
+    });
+  });
+});
+
+describe("validateDocumentSource", () => {
+  it("requires a valid http(s) base_url with a host", () => {
+    expect(validateDocumentSource(docState({ baseUrl: "" }))).toMatch(/base_url/);
+    expect(validateDocumentSource(docState({ baseUrl: "ftp://peer" }))).toMatch(/http/);
+    expect(validateDocumentSource(docState({ baseUrl: "http://" }))).toMatch(/host/);
+  });
+  it("requires {tenant_id} in a key_per_tenant env_pattern", () => {
+    expect(
+      validateDocumentSource(docState({ tenancyKind: "key_per_tenant", envPattern: "no-token" })),
+    ).toMatch(/env_pattern/);
+  });
+  it("accepts a well-formed source", () => {
+    expect(validateDocumentSource(docState())).toBeNull();
+    expect(
+      validateDocumentSource(docState({ tenancyKind: "key_per_tenant", envPattern: "K_{tenant_id}" })),
+    ).toBeNull();
+  });
+});

--- a/web/src/components/IntegrationEditModal.tsx
+++ b/web/src/components/IntegrationEditModal.tsx
@@ -22,7 +22,8 @@ export type IntegrationKind =
   | "webhook"
   | "a2a-server-card"
   | "a2a-agent"
-  | "memory-backend";
+  | "memory-backend"
+  | "document-source";
 export type ModalMode = "create" | "fork";
 
 export interface IntegrationEditModalProps {
@@ -108,6 +109,18 @@ export interface MemoryBackendFormState {
   healthCheckIntervalSeconds: string;
 }
 
+// RFC CE — a remote document source (peer loomcycle). Simpler than a memory
+// backend: no kind (a source is always a remote peer), no fallback/health-check;
+// tenancy is "" or key_per_tenant (no shared_key_with_prefix — the document
+// proxy has no key-prefix semantics).
+export interface DocumentSourceFormState {
+  baseUrl: string;
+  apiVersion: string;
+  apiKeyEnv: string;
+  tenancyKind: "" | "key_per_tenant";
+  envPattern: string;
+}
+
 export default function IntegrationEditModal({
   kind,
   mode,
@@ -145,6 +158,11 @@ export default function IntegrationEditModal({
       kind === "memory-backend" ? forkSource?.definition : undefined,
     ),
   );
+  const [docSource, setDocSource] = useState<DocumentSourceFormState>(() =>
+    initDocumentSource(
+      kind === "document-source" ? forkSource?.definition : undefined,
+    ),
+  );
 
   const titlePrefix = mode === "create" ? "Create" : "Edit (fork)";
   const titleLabel = INTEGRATION_LABEL[kind];
@@ -178,6 +196,8 @@ export default function IntegrationEditModal({
         return validateA2AAgent(a2aAgent);
       case "memory-backend":
         return validateMemoryBackend(memBackend);
+      case "document-source":
+        return validateDocumentSource(docSource);
     }
   };
 
@@ -191,6 +211,8 @@ export default function IntegrationEditModal({
         return buildA2AAgentOverlay(a2aAgent, description);
       case "memory-backend":
         return buildMemoryBackendOverlay(memBackend, description);
+      case "document-source":
+        return buildDocumentSourceOverlay(docSource, description);
     }
   };
 
@@ -287,6 +309,13 @@ export default function IntegrationEditModal({
           <MemoryBackendFields
             state={memBackend}
             set={setMemBackend}
+            submitting={submitting}
+          />
+        )}
+        {kind === "document-source" && (
+          <DocumentSourceFields
+            state={docSource}
+            set={setDocSource}
             submitting={submitting}
           />
         )}
@@ -1542,6 +1571,148 @@ export function buildMemoryBackendOverlay(
   return ov;
 }
 
+// ===================== Document Source (RFC CE) =====================
+
+function DocumentSourceFields(props: {
+  state: DocumentSourceFormState;
+  set: (v: DocumentSourceFormState) => void;
+  submitting: boolean;
+}) {
+  const { state: s, set, submitting } = props;
+  const patch = (p: Partial<DocumentSourceFormState>) => set({ ...s, ...p });
+  return (
+    <>
+      <div className="library-form-row">
+        <label htmlFor="int-ds-baseurl">config.base_url</label>
+        <input
+          id="int-ds-baseurl"
+          type="text"
+          value={s.baseUrl}
+          onChange={(e) => patch({ baseUrl: e.target.value })}
+          disabled={submitting}
+          placeholder="https://peer.example:8787"
+        />
+      </div>
+      <div className="library-form-row">
+        <label htmlFor="int-ds-apikeyenv">
+          config.api_key_env
+          <span className="library-modal-field-hint">
+            {" "}
+            — env-var NAME of the peer bearer (LOOMCYCLE_-prefixed or a known key;
+            never a secret value)
+          </span>
+        </label>
+        <input
+          id="int-ds-apikeyenv"
+          type="text"
+          value={s.apiKeyEnv}
+          onChange={(e) => patch({ apiKeyEnv: e.target.value })}
+          disabled={submitting}
+          placeholder="LOOMCYCLE_PEER_DOC_KEY"
+        />
+      </div>
+      <div className="library-form-row">
+        <label htmlFor="int-ds-apiversion">config.api_version</label>
+        <input
+          id="int-ds-apiversion"
+          type="text"
+          value={s.apiVersion}
+          onChange={(e) => patch({ apiVersion: e.target.value })}
+          disabled={submitting}
+          placeholder="(optional)"
+        />
+      </div>
+      <div className="library-form-row">
+        <label htmlFor="int-ds-tenancy">tenancy_strategy.kind</label>
+        <select
+          id="int-ds-tenancy"
+          value={s.tenancyKind}
+          onChange={(e) =>
+            patch({
+              tenancyKind: e.target
+                .value as DocumentSourceFormState["tenancyKind"],
+            })
+          }
+          disabled={submitting}
+        >
+          <option value="">(default)</option>
+          <option value="key_per_tenant">key_per_tenant</option>
+        </select>
+      </div>
+      {s.tenancyKind === "key_per_tenant" && (
+        <div className="library-form-row">
+          <label htmlFor="int-ds-envpat">
+            tenancy_strategy.env_pattern
+            <span className="library-modal-field-hint">
+              {" "}
+              — must contain {"{tenant_id}"} if set
+            </span>
+          </label>
+          <input
+            id="int-ds-envpat"
+            type="text"
+            value={s.envPattern}
+            onChange={(e) => patch({ envPattern: e.target.value })}
+            disabled={submitting}
+            placeholder="LOOMCYCLE_PEER_{tenant_id}_KEY"
+          />
+        </div>
+      )}
+    </>
+  );
+}
+
+export function initDocumentSource(def: unknown): DocumentSourceFormState {
+  const config = pickObject(def, "config");
+  const tenancy = pickObject(def, "tenancy_strategy");
+  return {
+    baseUrl: pickString(config, "base_url"),
+    apiVersion: pickString(config, "api_version"),
+    apiKeyEnv: pickString(config, "api_key_env"),
+    tenancyKind:
+      pickString(tenancy, "kind") === "key_per_tenant" ? "key_per_tenant" : "",
+    envPattern: pickString(tenancy, "env_pattern"),
+  };
+}
+
+export function validateDocumentSource(s: DocumentSourceFormState): string | null {
+  const url = s.baseUrl.trim();
+  if (!url) return "config.base_url is required (the peer loomcycle).";
+  let u: URL;
+  try {
+    u = new URL(url);
+  } catch {
+    return "config.base_url must be a valid http(s) URL with a host.";
+  }
+  if ((u.protocol !== "http:" && u.protocol !== "https:") || !u.host)
+    return "config.base_url must be an http(s) URL with a host.";
+  if (
+    s.tenancyKind === "key_per_tenant" &&
+    s.envPattern.trim() &&
+    !s.envPattern.includes("{tenant_id}")
+  )
+    return "tenancy_strategy.env_pattern must contain {tenant_id}.";
+  return null;
+}
+
+export function buildDocumentSourceOverlay(
+  s: DocumentSourceFormState,
+  description: string,
+): Record<string, unknown> {
+  const ov: Record<string, unknown> = {};
+  if (description.trim()) ov.description = description.trim();
+  const config: Record<string, unknown> = { base_url: s.baseUrl.trim() };
+  if (s.apiVersion.trim()) config.api_version = s.apiVersion.trim();
+  if (s.apiKeyEnv.trim()) config.api_key_env = s.apiKeyEnv.trim();
+  ov.config = config;
+  if (s.tenancyKind) {
+    const ten: Record<string, unknown> = { kind: s.tenancyKind };
+    if (s.envPattern.trim()) ten.env_pattern = s.envPattern.trim();
+    ov.tenancy_strategy = ten;
+  }
+  return ov;
+}
+
 // ===================== shared KV-rows editor =====================
 
 function KVRows(props: {
@@ -1613,6 +1784,7 @@ const INTEGRATION_LABEL: Record<IntegrationKind, string> = {
   "a2a-server-card": "A2A server card",
   "a2a-agent": "A2A agent",
   "memory-backend": "memory backend",
+  "document-source": "document source",
 };
 
 const INTEGRATION_NAME_PLACEHOLDER: Record<IntegrationKind, string> = {
@@ -1620,6 +1792,7 @@ const INTEGRATION_NAME_PLACEHOLDER: Record<IntegrationKind, string> = {
   "a2a-server-card": "my-card",
   "a2a-agent": "peer-researcher",
   "memory-backend": "team-memory",
+  "document-source": "peer-docs",
 };
 
 const KIND_TO_SUBSTRATE: Record<IntegrationKind, SubstrateKind> = {
@@ -1627,6 +1800,7 @@ const KIND_TO_SUBSTRATE: Record<IntegrationKind, SubstrateKind> = {
   "a2a-server-card": "a2aservercarddef",
   "a2a-agent": "a2aagentdef",
   "memory-backend": "memorybackenddef",
+  "document-source": "documentsourcedef",
 };
 
 function pickString(def: unknown, key: string): string {

--- a/web/src/components/LineagePanel.tsx
+++ b/web/src/components/LineagePanel.tsx
@@ -276,6 +276,7 @@ function newCtaLabel(kind: SubstrateKind): string {
     case "a2aservercarddef": return "A2A Server Card";
     case "a2aagentdef": return "A2A Agent";
     case "memorybackenddef": return "Memory Backend";
+    case "documentsourcedef": return "Document Source";
     // VolumeDef is FLAT (no lineage); the Volumes tab uses its own flat table,
     // not LineagePanel, so this label is never rendered for it. The arm keeps
     // the switch exhaustive over SubstrateKind.

--- a/web/src/pages/IntegrationsView.tsx
+++ b/web/src/pages/IntegrationsView.tsx
@@ -7,6 +7,7 @@ import {
   type SubstrateKind,
   listA2AAgentDefNames,
   listA2AServerCardDefNames,
+  listDocumentSourceDefNames,
   listMemoryBackendDefNames,
   listWebhookDefNames,
   retireDef,
@@ -17,7 +18,7 @@ import IntegrationEditModal, {
   type ModalMode,
 } from "../components/IntegrationEditModal";
 
-// IntegrationsView — v0.24.0 manual-management surface for the four
+// IntegrationsView — v0.24.0 manual-management surface for the five
 // substrate families that connect loomcycle to the outside world:
 // inbound Webhooks, A2A Server Cards (what we expose), A2A Agents (peers
 // we call), and pluggable Memory Backends. Sibling of LibraryView, same
@@ -36,13 +37,19 @@ import IntegrationEditModal, {
 
 const REFRESH_MS = 10_000;
 
-type SubKey = "webhooks" | "a2a-server-cards" | "a2a-agents" | "memory-backends";
+type SubKey =
+  | "webhooks"
+  | "a2a-server-cards"
+  | "a2a-agents"
+  | "memory-backends"
+  | "document-sources";
 
 export default function IntegrationsView() {
   const [webhooks, setWebhooks] = useState<LibraryEntry[]>([]);
   const [serverCards, setServerCards] = useState<LibraryEntry[]>([]);
   const [a2aAgents, setA2AAgents] = useState<LibraryEntry[]>([]);
   const [memBackends, setMemBackends] = useState<LibraryEntry[]>([]);
+  const [docSources, setDocSources] = useState<LibraryEntry[]>([]);
   const [err, setErr] = useState<string | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
   const refreshNow = useCallback(() => setRefreshKey((k) => k + 1), []);
@@ -57,17 +64,19 @@ export default function IntegrationsView() {
     let cancelled = false;
     const fetchAll = async () => {
       try {
-        const [wh, sc, ag, mb] = await Promise.all([
+        const [wh, sc, ag, mb, ds] = await Promise.all([
           listWebhookDefNames(),
           listA2AServerCardDefNames(),
           listA2AAgentDefNames(),
           listMemoryBackendDefNames(),
+          listDocumentSourceDefNames(),
         ]);
         if (cancelled) return;
         setWebhooks(toEntries(wh.names));
         setServerCards(toEntries(sc.names));
         setA2AAgents(toEntries(ag.names));
         setMemBackends(toEntries(mb.names));
+        setDocSources(toEntries(ds.names));
         setErr(null);
       } catch (e) {
         if (!cancelled) setErr(e instanceof Error ? e.message : String(e));
@@ -89,7 +98,9 @@ export default function IntegrationsView() {
       ? "a2a-agents"
       : path.startsWith("/integrations/memory-backends")
         ? "memory-backends"
-        : "webhooks";
+        : path.startsWith("/integrations/document-sources")
+          ? "document-sources"
+          : "webhooks";
 
   const cfg = TAB_CONFIG[sub];
   const tabEntries =
@@ -99,7 +110,9 @@ export default function IntegrationsView() {
         ? a2aAgents
         : sub === "memory-backends"
           ? memBackends
-          : webhooks;
+          : sub === "document-sources"
+            ? docSources
+            : webhooks;
 
   const handleCreate = () => setModal({ kind: cfg.kind, mode: "create" });
   const handleEdit = (row: DefRow) =>
@@ -138,6 +151,10 @@ export default function IntegrationsView() {
         <NavLink to="/integrations/memory-backends" end className={subtabClass}>
           Memory Backends{" "}
           <span className="library-subtab-count">{memBackends.length}</span>
+        </NavLink>
+        <NavLink to="/integrations/document-sources" end className={subtabClass}>
+          Document Sources{" "}
+          <span className="library-subtab-count">{docSources.length}</span>
         </NavLink>
       </div>
       {err && (
@@ -223,6 +240,12 @@ const TAB_CONFIG: Record<SubKey, TabCfg> = {
     substrate: "memorybackenddef",
     label: "memory backends",
     render: renderMemoryBackend,
+  },
+  "document-sources": {
+    kind: "document-source",
+    substrate: "documentsourcedef",
+    label: "document sources",
+    render: renderDocumentSource,
   },
 };
 
@@ -348,6 +371,26 @@ function renderMemoryBackend(row: DefRow) {
           ["tenancy_strategy.prefix_pattern", str(tenancy.prefix_pattern)],
           ["fallback_on_error", str(d.fallback_on_error)],
           ["health_check_interval_seconds", numStr(d.health_check_interval_seconds)],
+        ]}
+      />
+    </div>
+  );
+}
+
+function renderDocumentSource(row: DefRow) {
+  const d = (row.definition as Record<string, unknown>) ?? {};
+  const config = obj(d.config);
+  const tenancy = obj(d.tenancy_strategy);
+  return (
+    <div className="def-body">
+      {str(d.description) && <Field label="description" value={str(d.description)} />}
+      <MetaRow
+        items={[
+          ["config.base_url", str(config.base_url)],
+          ["config.api_version", str(config.api_version)],
+          ["config.api_key_env", str(config.api_key_env)],
+          ["tenancy_strategy.kind", str(tenancy.kind)],
+          ["tenancy_strategy.env_pattern", str(tenancy.env_pattern)],
         ]}
       />
     </div>


### PR DESCRIPTION
Adds a fifth **Integrations** family — **Document Sources** — so an operator can author, fork, and retire a peer-loomcycle `DocumentSourceDef` (RFC CE) from the Web UI, matching the memory-backend surface (#1031). Before this the substrate existed only via yaml, the substrate API, or MCP/adapters.

## What
- **`api.ts`** — `listDocumentSourceDefNames()` + `"documentsourcedef"` in `SubstrateKind`.
- **IntegrationsView** — a **Document Sources** subtab with list + create/edit/retire, through the same `LineagePanel`/`createDef`/`forkDef` flow; a row renderer showing `config.base_url` / `api_version` / `api_key_env` + tenancy.
- **IntegrationEditModal** — a `document-source` kind: `config.base_url`, `config.api_key_env` (an env-var *name*, never a secret), optional `config.api_version`, and `tenancy_strategy` (`""` | `key_per_tenant` + `env_pattern`). Posts the same `POST /v1/_documentsourcedef` overlay the API uses.
- **LineagePanel** — the "Create New" CTA label gains a `documentsourcedef` case (the compiler caught the newly non-exhaustive switch over `SubstrateKind`).

Client validation (server-authoritative): `base_url` must parse as http(s) with a host; a `key_per_tenant` `env_pattern` must contain `{tenant_id}`. `shared_key_with_prefix` isn't offered (a document source has no key-prefix semantics).

## Tested
- **`IntegrationEditModal.test.ts`** gains 6 document-source cases (init reads config+tenancy; build always emits `config.base_url` and omits blanks + emits tenancy when set; validate covers base_url/http(s)/host + env_pattern + happy path) — **16 modal cases** total.
- `tsc` clean; full web suite green; `make build-all` embeds the UI + builds the binary.

With #1031 (remote memory backends), both RFC CD Part B and RFC CE peer sources are now UI-authorable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD