### PR TITLE
feat(ui): the erasure console — report first, type the id, and no undo

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1111,6 +1111,69 @@ export interface RetentionReport {
   sqlmem_gc?: Record<string, unknown>;
 }
 
+// ErasureReport is GET /v1/_erasure — what the deployment holds about one subject,
+// in three tiers.
+//
+// The tiers are not degrees of confidence, they are degrees of REACH: tier 1 is what an
+// erasure deletes, tier 2 is subject-keyed data nothing deletes yet, and tier 3 is what
+// a subject-keyed delete cannot reach at all. A UI that summed them would report a
+// deletion far larger than the one it performs.
+export interface ErasureTier {
+  counts: Record<string, number>;
+  total: number;
+}
+
+export interface ErasureReportResponse {
+  tenant: string;
+  subject: string;
+  tier1_covered: ErasureTier;
+  tier2_uncovered: ErasureTier;
+  tier3_residue: {
+    rows: number;
+    scopes?: string[];
+    sessions_examined: number;
+    truncated?: boolean;
+  };
+  notes?: string[];
+  errors?: string[];
+}
+
+export interface ErasureResult {
+  tenant: string;
+  subject: string;
+  dry_run: boolean;
+  deleted: Record<string, number>;
+  retained: Record<string, string>;
+  residue?: ErasureReportResponse["tier3_residue"];
+  errors?: string[];
+  notes?: string[];
+}
+
+export function getErasureReport(subject: string, tenant?: string): Promise<ErasureReportResponse> {
+  const q = new URLSearchParams({ subject });
+  // An ADMIN token must name the tenant: a subject id is only meaningful within one, and
+  // the same string in two tenants is two different people. The server refuses rather
+  // than defaulting, so this forwards an explicitly empty value when asked to.
+  if (tenant !== undefined) q.set("tenant", tenant);
+  return jsonFetch<ErasureReportResponse>(`/v1/_erasure?${q.toString()}`);
+}
+
+// executeErasure runs (or previews) the deletion. `confirm` must equal the subject for a
+// live run — enforced by the server, mirrored by the console.
+export function executeErasure(
+  subject: string,
+  opts: { dryRun: boolean; confirm?: string; tenant?: string },
+): Promise<ErasureResult> {
+  const q = new URLSearchParams();
+  if (opts.tenant !== undefined) q.set("tenant", opts.tenant);
+  const qs = q.toString();
+  return jsonFetch<ErasureResult>(`/v1/_erasure${qs ? "?" + qs : ""}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ subject, dry_run: opts.dryRun, confirm: opts.confirm ?? "" }),
+  });
+}
+
 export function getRetentionReport(): Promise<RetentionReport> {
   return jsonFetch<RetentionReport>("/v1/_retention");
 }

--- a/web/src/lib/erasure.test.ts
+++ b/web/src/lib/erasure.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { erasureGate, residueMeaning } from "./erasure";
+
+describe("erasureGate", () => {
+  const ready = { subject: "alice", reportedSubject: "alice", confirm: "alice" };
+
+  it("allows an erasure only when the report, the subject and the confirmation agree", () => {
+    expect(erasureGate(ready)).toEqual({ canExecute: true, reason: "ready" });
+  });
+
+  it("refuses when the report is for a DIFFERENT subject", () => {
+    // The failure this exists for: report on alice, read what would go, edit the field
+    // to alicia, click erase — confirming against a preview of someone else's data.
+    const g = erasureGate({ subject: "alicia", reportedSubject: "alice", confirm: "alicia" });
+    expect(g.canExecute).toBe(false);
+    expect(g.reason).toBe("report-is-for-another-subject");
+  });
+
+  it("refuses before any report has been run", () => {
+    expect(erasureGate({ ...ready, reportedSubject: "" }).reason).toBe("no-report");
+  });
+
+  it("requires the confirmation to match the subject EXACTLY", () => {
+    expect(erasureGate({ ...ready, confirm: "" }).reason).toBe("confirm-does-not-match");
+    expect(erasureGate({ ...ready, confirm: "Alice" }).reason).toBe("confirm-does-not-match");
+    // Not trimmed: the server compares exactly, so trimming here would enable a button
+    // the server then refuses.
+    expect(erasureGate({ ...ready, confirm: "alice " }).reason).toBe("confirm-does-not-match");
+  });
+
+  it("refuses an empty subject before anything else", () => {
+    expect(erasureGate({ subject: "  ", reportedSubject: "", confirm: "" }).reason).toBe("no-subject");
+  });
+});
+
+describe("residueMeaning", () => {
+  it("says UNKNOWN when no sessions were examined", () => {
+    // The most reassuring possible lie on a screen whose whole job is to say what
+    // erasure cannot reach: reporting "0 rows" as "nothing left behind" when in fact
+    // there was nothing to trace from.
+    const m = residueMeaning({ rows: 0, sessions_examined: 0 });
+    expect(m).toContain("unknown");
+    expect(m).not.toContain("none found");
+  });
+
+  it("says none only when sessions WERE examined", () => {
+    expect(residueMeaning({ rows: 0, sessions_examined: 4 })).toContain("none found");
+  });
+
+  it("reports a truncated scan as a floor, not a total", () => {
+    const m = residueMeaning({ rows: 12, sessions_examined: 4, truncated: true });
+    expect(m).toContain("at least 12");
+  });
+
+  it("reports an exact count when the scan was complete", () => {
+    const m = residueMeaning({ rows: 12, sessions_examined: 4 });
+    expect(m).toContain("12 row(s)");
+    expect(m).not.toContain("at least");
+  });
+});

--- a/web/src/lib/erasure.ts
+++ b/web/src/lib/erasure.ts
@@ -1,0 +1,72 @@
+// The rules the erasure console enforces before it will offer to delete anything.
+//
+// These live here rather than inline because each one is a guard against a specific way
+// an operator could destroy the wrong data, and a guard nobody can test is a guard
+// nobody should trust.
+
+export interface ErasureResidue {
+  rows: number;
+  scopes?: string[];
+  sessions_examined: number;
+  truncated?: boolean;
+}
+
+export interface ErasureGateState {
+  /** The subject typed into the field right now. */
+  subject: string;
+  /** The subject the CURRENTLY DISPLAYED report was run for, or "" if none. */
+  reportedSubject: string;
+  /** What the operator typed into the confirmation box. */
+  confirm: string;
+}
+
+export type GateReason =
+  | "ready"
+  | "no-subject"
+  | "no-report"
+  | "report-is-for-another-subject"
+  | "confirm-does-not-match";
+
+// erasureGate decides whether the execute control may fire, and why not when it may not.
+//
+// THE STALE-REPORT RULE IS THE IMPORTANT ONE. An operator reports on `alice`, reads what
+// would go, then edits the field to `alicia` and clicks erase — without this, they would
+// be confirming against a preview of somebody else's data. So changing the subject
+// invalidates the report, and the report must be re-run for the subject actually being
+// erased.
+//
+// The typed confirmation is an EXACT match on the subject id, not a yes/no. A modal with
+// a red button is dismissed by reflex; typing the identifier is the smallest gesture
+// that cannot be made absent-mindedly — and the identifier is what matters, because the
+// failure mode is erasing the WRONG subject rather than erasing accidentally.
+export function erasureGate(s: ErasureGateState): { canExecute: boolean; reason: GateReason } {
+  const subject = s.subject.trim();
+  if (!subject) return { canExecute: false, reason: "no-subject" };
+  if (!s.reportedSubject) return { canExecute: false, reason: "no-report" };
+  if (s.reportedSubject !== subject) {
+    return { canExecute: false, reason: "report-is-for-another-subject" };
+  }
+  // Untrimmed on purpose: the server compares `confirm` to the subject exactly, and a UI
+  // that trimmed here would enable a button the server then refuses.
+  if (s.confirm !== subject) return { canExecute: false, reason: "confirm-does-not-match" };
+  return { canExecute: true, reason: "ready" };
+}
+
+// residueMeaning renders what the residue count actually tells you.
+//
+// A ZERO ACROSS ZERO SESSIONS IS UNKNOWN, NOT NONE. The residue is found by tracing what
+// derives from the subject's sessions; with no sessions examined there was nothing to
+// trace FROM, so "0 rows" means the question could not be asked — and reporting that as
+// "nothing left behind" would be the most reassuring possible lie on a screen whose
+// whole job is to say what erasure cannot reach.
+export function residueMeaning(r: ErasureResidue | undefined): string {
+  if (!r) return "";
+  if (r.sessions_examined === 0) {
+    return "unknown — no sessions were examined, so there was nothing to trace derived data from";
+  }
+  const scope = r.truncated ? "at least " : "";
+  if (r.rows === 0) {
+    return `none found across ${r.sessions_examined} session(s)`;
+  }
+  return `${scope}${r.rows} row(s) derived from this subject's sessions, which a subject-keyed delete does not reach`;
+}

--- a/web/src/pages/SettingsView.tsx
+++ b/web/src/pages/SettingsView.tsx
@@ -6,6 +6,7 @@ import {
   type Visibility,
 } from "../lib/visibility";
 import { ontologistRunHref, ontologyEditHref } from "../lib/ontologyEditHref";
+import { erasureGate, residueMeaning } from "../lib/erasure";
 import { countMeaning, exportMisconfigured, familyEffect } from "../lib/retention";
 import {
   CredentialMeta,
@@ -22,6 +23,8 @@ import {
   getEnvTemplate,
   getHealth,
   getOntology,
+  executeErasure,
+  getErasureReport,
   getRetentionReport,
   getRuntimeState,
   listCredentials,
@@ -33,6 +36,8 @@ import {
   setOntologyStatus,
   showPreset,
   OntologyTerm,
+  ErasureReportResponse,
+  ErasureResult,
   RetentionReport,
 } from "../api";
 import { usePrincipal, useUserId } from "../components/Layout";
@@ -59,6 +64,7 @@ type Section =
   | "routing"
   | "ontology"
   | "retention"
+  | "erasure"
   | "tokens"
   | "presets"
   | "runtime"
@@ -93,6 +99,7 @@ const SECTIONS: SectionDef[] = [
   { id: "routing", label: "Routing", vis: "tenant" },
   { id: "ontology", label: "Ontology", vis: "tenant" },
   { id: "retention", label: "Retention", vis: "tenant" },
+  { id: "erasure", label: "Erasure", vis: "tenant" },
   // ScopeAdmin: token minting has no tenant axis and is deliberately excluded from
   // the tenant-confined def set; presets/runtime/health fall through to the /v1/_*
   // catch-all; and repair-tenant is explicitly admin because it rewrites rows across
@@ -160,6 +167,7 @@ export default function SettingsView() {
         {active === "routing" && <RoutingView />}
         {active === "ontology" && <OntologySection />}
         {active === "retention" && <RetentionSection />}
+        {active === "erasure" && <ErasureSection />}
         {active === "tokens" && <TokenManager />}
         {active === "presets" && <PresetsSection />}
         {active === "runtime" && <RuntimeSection />}
@@ -1071,6 +1079,206 @@ function RetentionSection() {
       )}
     </div>
   );
+}
+
+// ─── Erasure ─────────────────────────────────────────────────────────────────
+//
+// The most consequential control in this console, and the only one nothing can undo.
+//
+// REPORT BEFORE EXECUTE, ALWAYS. The execute path does not exist until a report has been
+// shown for the SAME subject: changing the field invalidates it, because otherwise an
+// operator could read what would go for one person and confirm the deletion of another.
+//
+// TYPED CONFIRMATION, NOT A DIALOG. A modal with a red button is dismissed by reflex;
+// typing the identifier is the smallest gesture that cannot be made absent-mindedly —
+// and the identifier is what matters, since the failure mode is erasing the WRONG
+// subject rather than erasing accidentally. The server enforces the same rule.
+function ErasureSection() {
+  const [subject, setSubject] = useState("");
+  const [tenant, setTenant] = useState("");
+  const [report, setReport] = useState<ErasureReportResponse | null>(null);
+  const [reportedSubject, setReportedSubject] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [result, setResult] = useState<ErasureResult | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const gate = erasureGate({ subject, reportedSubject, confirm });
+
+  const runReport = async () => {
+    setBusy(true);
+    setResult(null);
+    try {
+      const rep = await getErasureReport(subject.trim(), tenant);
+      setReport(rep);
+      setReportedSubject(subject.trim());
+      setErr(null);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+      setReport(null);
+      setReportedSubject("");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const runErase = async () => {
+    if (!gate.canExecute) return;
+    setBusy(true);
+    try {
+      const res = await executeErasure(subject.trim(), {
+        dryRun: false,
+        confirm,
+        tenant,
+      });
+      setResult(res);
+      // The report described a state that no longer exists. Clearing it forces a fresh
+      // one before anything else can be erased.
+      setReport(null);
+      setReportedSubject("");
+      setConfirm("");
+      setErr(null);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="settings-panel">
+      <h2>Erasure</h2>
+      <p className="settings-help">
+        Report what this deployment holds about one subject, and — after reading it —
+        delete what can be deleted. <strong>An erasure cannot be undone.</strong> Nothing
+        else in this console is irreversible; this is.
+      </p>
+
+      <div className="settings-row">
+        <label>
+          Subject
+          <input
+            value={subject}
+            placeholder="user id"
+            onChange={(e) => setSubject(e.target.value)}
+          />
+        </label>
+        <label>
+          Tenant
+          <input value={tenant} placeholder="(admin: required)" onChange={(e) => setTenant(e.target.value)} />
+        </label>
+        <button type="button" onClick={() => void runReport()} disabled={busy || !subject.trim()}>
+          {busy ? "reading…" : "Report"}
+        </button>
+      </div>
+      <p className="settings-help settings-muted">
+        A subject id is only meaningful inside a tenant — the same string in two tenants
+        is two different people — so an admin token must name one. A tenant operator&rsquo;s
+        own tenant is used when this is blank.
+      </p>
+
+      {err && <div className="settings-error">{err}</div>}
+
+      {report && (
+        <>
+          <h3 className="settings-subhead">
+            What is held about <code>{report.subject}</code>
+          </h3>
+          {/* The three tiers are degrees of REACH, not of confidence, and they are never
+              summed: a total would announce a deletion far larger than the one that
+              happens. */}
+          <dl className="settings-stats">
+            <div>
+              <dt>will be deleted</dt>
+              <dd>{report.tier1_covered.total}</dd>
+              <dd className="settings-muted">
+                {Object.entries(report.tier1_covered.counts)
+                  .filter(([, n]) => n > 0)
+                  .map(([k, n]) => `${k} ${n}`)
+                  .join(" · ") || "nothing"}
+              </dd>
+            </div>
+            <div>
+              <dt>held, but NOT deleted</dt>
+              <dd>{report.tier2_uncovered.total}</dd>
+              <dd className="settings-muted">
+                subject-keyed data no primitive removes yet — it stays after an erasure
+              </dd>
+            </div>
+            <div>
+              <dt>cannot be reached</dt>
+              <dd>{report.tier3_residue.rows}</dd>
+              <dd className="settings-muted">{residueMeaning(report.tier3_residue)}</dd>
+            </div>
+          </dl>
+          {report.errors && report.errors.length > 0 && (
+            <div className="settings-error">
+              some planes could not be read, so this report is incomplete:{" "}
+              {report.errors.join("; ")}
+            </div>
+          )}
+
+          <div className="settings-row">
+            <label>
+              Type <code>{report.subject}</code> to confirm
+              <input value={confirm} onChange={(e) => setConfirm(e.target.value)} />
+            </label>
+            <button
+              type="button"
+              className="danger-btn"
+              disabled={busy || !gate.canExecute}
+              title={gate.canExecute ? undefined : gateHint(gate.reason)}
+              onClick={() => void runErase()}
+            >
+              Erase permanently
+            </button>
+          </div>
+        </>
+      )}
+
+      {/* A report for a DIFFERENT subject than the one in the field is stale, and saying
+          so is more useful than silently disabling the button. */}
+      {reportedSubject && reportedSubject !== subject.trim() && (
+        <div className="settings-muted">
+          the report above is for <code>{reportedSubject}</code>; report again for{" "}
+          <code>{subject.trim() || "…"}</code> before erasing
+        </div>
+      )}
+
+      {result && (
+        <>
+          <h3 className="settings-subhead">Erased</h3>
+          <div className="settings-flash">
+            {Object.entries(result.deleted)
+              .map(([k, n]) => `${k} ${n}`)
+              .join(" · ")}
+          </div>
+          {Object.keys(result.retained).length > 0 && (
+            <div className="settings-muted">
+              kept: {Object.entries(result.retained).map(([k, why]) => `${k} (${why})`).join("; ")}
+            </div>
+          )}
+          {result.errors && result.errors.length > 0 && (
+            <div className="settings-error">{result.errors.join("; ")}</div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+// gateHint explains a disabled erase button. Silence would read as a broken control.
+function gateHint(reason: string): string {
+  switch (reason) {
+    case "no-subject":
+      return "name a subject first";
+    case "no-report":
+      return "run the report first — nothing is erased from this console unsighted";
+    case "report-is-for-another-subject":
+      return "the report shown is for a different subject; report again";
+    default:
+      return "type the subject id exactly to confirm";
+  }
 }
 
 function MaintenanceSection() {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5814,6 +5814,20 @@ button.primary:disabled {
   color: var(--lc-running);
 }
 
+/* The one irreversible control in the console. Weighted so it cannot be mistaken for
+   the ordinary buttons beside it, and DISABLED by default — it only lifts once a report
+   for this exact subject has been read and the identifier typed back. */
+.danger-btn {
+  background: var(--lc-danger);
+  border-color: var(--lc-danger);
+  color: #fff;
+}
+.danger-btn:disabled {
+  background: transparent;
+  border-color: var(--lc-rule);
+  color: var(--lc-text-faint);
+}
+
 /* Memory search (Settings → Memory). Hits are looser than facts — a note has no span
    and no verdict — so the row is lighter than a fact card and does not pretend to the
    same structure. */


### PR DESCRIPTION
RFC CF §7's console surface, built on the server posture #1033 settled.

## Report before execute — enforced, not encouraged

The erase control does not lift until a report has been shown **for the same subject**. Editing the field invalidates it.

That guard exists for a specific mistake: report on `alice`, read what would go, edit the field to `alicia`, click erase. No confirmation dialog catches that — the dialog would be telling you the truth about the wrong subject.

## Typed confirmation, not a dialog

A modal with a red button is dismissed by reflex. Typing the identifier is the smallest gesture that cannot be made absent-mindedly — and **the identifier is what matters**, since the failure mode is erasing the *wrong* subject rather than erasing accidentally.

Compared **untrimmed**, because the server compares exactly; a console that trimmed would enable a button the server then refuses.

## The three tiers are never summed

They are degrees of **reach**, not of confidence, so each is labelled by what it does:

| tier | label in the UI |
|---|---|
| 1 | **will be deleted** |
| 2 | **held, but NOT deleted** — subject-keyed data no primitive removes yet; it survives the erasure |
| 3 | **cannot be reached** — what a subject-keyed delete never touches |

A total would announce a deletion far larger than the one that happens.

## A residue of zero across zero sessions is *unknown*, not *none*

The residue is found by tracing what derives from the subject's sessions. With none examined there was nothing to trace from — and rendering that as "nothing left behind" would be the most reassuring possible lie on the one screen whose job is to say what erasure **cannot** reach.

Likewise a report that could not read every plane says so: a plane that *failed* is not a plane that is *empty*, and an incomplete report must not read as a clean one.

After a successful erasure the report is cleared — it describes a state that no longer exists, so a second erasure needs a fresh one.

## Tested

9 lib tests, each verified fail-before: the stale-report rule, the exact-match confirmation (including that a trailing space is refused), the report-required gate, and the unknown-vs-none residue distinction.

`tsc --noEmit` clean, 84 web tests passing, `make build-ui` clean, `go test ./...` clean.

## Note

The tenant field is required for an admin token and blank for a tenant operator — a subject id is only meaningful inside a tenant, and the same string in two tenants is two different people. The server refuses rather than defaulting; the console explains why rather than hiding the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)