### PR TITLE
fix(memory): an operator may vouch for a fact that has no span

### DIFF
--- a/internal/tools/builtin/document_verdict.go
+++ b/internal/tools/builtin/document_verdict.go
@@ -118,19 +118,39 @@ func (d *Document) judgeFact(ctx context.Context, key sqlmem.ScopeKey, in docInp
 		// check it against.
 		return errResult("judge_fact: that chunk is not a fact (it carries no entity metadata)"), nil
 	}
-	// A fact with NO span cannot be judged against anything. Refusing is the honest
-	// answer: a verdict reached without evidence is the failure this RFC exists to stop,
-	// and it would be indistinguishable from one that was checked.
-	if prev.SourceQuote == "" && verdict != "unclear" {
+	// A fact with no span cannot be CHECKED against anything — but a person can still
+	// vouch for it, and that is a different act with a different authority.
+	//
+	// THIS RULE USED TO REFUSE EVERYONE, and its stated reason was that such a verdict
+	// "would be indistinguishable from one that was checked". That justification stopped
+	// being true when `judged_by` landed: the store now records whether a machine or a
+	// human reached a verdict, so an operator's evidence-free affirmation is no longer
+	// mistakable for an entailment check. The refusal outlived its own argument, and in
+	// the meantime it made a legitimate operator action impossible — confirming a fact
+	// stored before spans existed, which is most of what an older store holds.
+	//
+	// AN AGENT IS STILL REFUSED. It cannot vouch: its "I checked this" is exactly the
+	// claim the span exists to substantiate, and letting a run affirm what it cannot
+	// check is the laundering this line is built against. An operator supplying no span
+	// is not making that claim — they are putting their own name to it, which the reason
+	// and `judged_by` record.
+	// `mistyped` is excluded from that relaxation, by anyone. It is not a claim about
+	// whether the fact is TRUE — it says the span carries the claim but the filing is
+	// wrong — so without a span there is nothing for it to be about. An operator who
+	// wants to correct a filing retypes the fact, which is an edit, not a verdict.
+	judgedBy := judgedByForVerdict(ctx)
+	mayVouch := judgedBy == "operator" && verdict != "mistyped"
+	if prev.SourceQuote == "" && verdict != "unclear" && !mayVouch {
 		return errResult("judge_fact: that fact records no source span, so there is nothing to " +
-			"check it against. Leave it unjudged (which reads as unverified) rather than " +
-			"recording a verdict with no evidence"), nil
+			"check it against. An operator may still vouch for it from the console — a run " +
+			"may not, because affirming what you cannot check is the failure a span exists " +
+			"to prevent. Leave it unjudged, which reads as unverified"), nil
 	}
 
 	now := time.Now().UnixNano()
 	if err := d.exec(ctx, key,
 		`UPDATE chunk_memory_meta SET confidence = ?, judged_at = ?, judge_reason = ?, judged_by = ? WHERE chunk_id = ?`,
-		confidence, now, in.Reason, judgedByForVerdict(ctx), chunkID); err != nil {
+		confidence, now, in.Reason, judgedBy, chunkID); err != nil {
 		return errResult("judge_fact: " + err.Error()), nil
 	}
 	return jsonResult(map[string]any{

--- a/internal/tools/builtin/document_verdict_test.go
+++ b/internal/tools/builtin/document_verdict_test.go
@@ -136,8 +136,8 @@ func TestVerdict_SupportedAndUnclearStayVisible(t *testing.T) {
 func TestVerdict_RefusesWhatItCannotCheck(t *testing.T) {
 	d, ctx, withSpan, noSpan := verdictFixture(t)
 	cases := []struct{ name, req, want string }{
-		{"no span to check against",
-			`{"op":"judge_fact","scope":"user","id":"` + noSpan + `","verdict":"supported","reason":"r"}`,
+		{"a span-less fact judged MISTYPED — a claim about a span that does not exist",
+			`{"op":"judge_fact","scope":"user","id":"` + noSpan + `","verdict":"mistyped","reason":"r"}`,
 			"no source span"},
 		{"a number instead of a verdict",
 			`{"op":"judge_fact","scope":"user","id":"` + withSpan + `","verdict":"0.9","reason":"r"}`,
@@ -584,5 +584,70 @@ func TestVerdict_MigratesAScopeThatPredatesJudgedBy(t *testing.T) {
 	entity, _ := got["entity"].(map[string]any)
 	if entity["judged_by"] != "operator" {
 		t.Errorf("judged_by not recorded after the migration: %v", entity)
+	}
+}
+
+// TestVerdict_AnOperatorMayVouchForASpanlessFact.
+//
+// The reported bug: an operator opened a fact stored before spans existed, wrote "User
+// confirmed", and was refused — the console offered a control the server would never
+// accept, and BOTH controls failed, since only `unclear` was allowed without a span.
+//
+// The rule's own justification had expired. It refused because such a verdict "would be
+// indistinguishable from one that was checked" — which stopped being true once
+// `judged_by` recorded whether a machine or a human reached it. A person putting their
+// name to a fact is not claiming to have checked it against a source; they are supplying
+// their own authority, and the store now says which happened.
+func TestVerdict_AnOperatorMayVouchForASpanlessFact(t *testing.T) {
+	d, ctx, _, noSpan := verdictFixture(t)
+
+	out, r := docExec(t, d, ctx, `{"op":"judge_fact","scope":"user","id":"`+noSpan+
+		`","verdict":"supported","reason":"User confirmed"}`)
+	if r.IsError {
+		t.Fatalf("an operator was refused a verdict on a span-less fact: %s", r.Text)
+	}
+	if w, _ := out["withheld"].(bool); w {
+		t.Error("vouching for a fact withheld it")
+	}
+
+	got, _ := docExec(t, d, ctx, `{"op":"get_chunk","scope":"user","id":"`+noSpan+`"}`)
+	entity, _ := got["entity"].(map[string]any)
+	if entity["judged_by"] != "operator" {
+		t.Errorf("judged_by = %v, want operator — the record of WHOSE authority this is "+
+			"is what makes an evidence-free verdict honest", entity["judged_by"])
+	}
+	if entity["judge_reason"] != "User confirmed" {
+		t.Errorf("the operator's stated ground was not kept: %v", entity["judge_reason"])
+	}
+	// The fact still has no span, and nothing pretends otherwise. Vouching is not
+	// fabricating evidence.
+	if q, _ := entity["source_quote"].(string); q != "" {
+		t.Errorf("vouching invented a source span: %q", q)
+	}
+}
+
+// TestVerdict_AnAgentStillCannotVouch.
+//
+// The laundering guard, unchanged. A run affirming what it cannot check is exactly the
+// claim a span exists to substantiate — and an agent that could do it would turn "no
+// evidence" into "verified" by asserting it.
+func TestVerdict_AnAgentStillCannotVouch(t *testing.T) {
+	d, ctx, _, noSpan := verdictFixture(t)
+	runCtx := tools.WithRunID(ctx, "r_1")
+	runCtx = tools.WithAgentName(runCtx, "memory/judge")
+
+	_, r := docExec(t, d, runCtx, `{"op":"judge_fact","scope":"user","id":"`+noSpan+
+		`","verdict":"supported","reason":"looks right to me"}`)
+	if !r.IsError {
+		t.Fatal("an agent affirmed a fact it had no evidence for")
+	}
+	if !strings.Contains(r.Text, "operator may still vouch") {
+		t.Errorf("the refusal does not distinguish who may: %s", r.Text)
+	}
+
+	// And `unclear` remains open to anyone — it asserts nothing.
+	if _, r := docExec(t, d, runCtx, `{"op":"judge_fact","scope":"user","id":"`+noSpan+
+		`","verdict":"unclear","reason":"cannot tell"}`); r.IsError {
+		t.Errorf("an agent was refused `unclear` on a span-less fact: %s", r.Text)
 	}
 }

--- a/packages/memory-view/src/components/ChunkDetailPanel.tsx
+++ b/packages/memory-view/src/components/ChunkDetailPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import type { ChunkDetail, DocEdge, FactEntity, MemoryScope } from "../types";
 import { useMemoryData } from "../lib/dataLayer";
-import { factActions, factVerdict } from "../lib/factVerdict";
+import { factActions, factVerdict, vouchNotice } from "../lib/factVerdict";
 
 // ChunkDetailPanel — the fact/chunk inspector shared by the FactViewer and the
 // SearchPanel (a document hit opens the same detail). Given a (scope, chunkId)
@@ -293,6 +293,9 @@ function VerdictBlock({
           </button>
         )}
       </div>
+      {arming && vouchNotice(entity) && (
+        <div className="fact-verdict-vouch">{vouchNotice(entity)}</div>
+      )}
       {arming && (
         <div className="fact-verdict-form">
           <input

--- a/packages/memory-view/src/components/CoverageBar.tsx
+++ b/packages/memory-view/src/components/CoverageBar.tsx
@@ -73,7 +73,7 @@ export default function CoverageBar({
         </span>
       )}
       {(stats.unverifiable_no_span ?? 0) > 0 && (
-        <span title="no source span — these can never be verified by anyone, not merely not yet">
+        <span title="no source span — nothing can check these against a source; only a person can vouch for them">
           <strong>{stats.unverifiable_no_span}</strong> unverifiable
         </span>
       )}

--- a/packages/memory-view/src/lib/factVerdict.test.ts
+++ b/packages/memory-view/src/lib/factVerdict.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { factActions, factVerdict, OPERATOR } from "./factVerdict";
+import { factActions, factVerdict, OPERATOR, vouchNotice } from "./factVerdict";
 import type { FactEntity } from "../types";
 
 // ent fills the one field every entity carries so a case can state only what it is
@@ -93,5 +93,20 @@ describe("factActions", () => {
     const a = factActions(factVerdict(ent()));
     expect(a.canMarkWrong).toBe(true);
     expect(a.canMarkGood).toBe(true);
+  });
+});
+
+describe("vouchNotice", () => {
+  it("warns when there is no span to check against", () => {
+    // Confirming a fact against a recorded quote is CHECKING; confirming one with no
+    // quote is VOUCHING. An operator should know which they just did — their name goes
+    // on it either way.
+    const n = vouchNotice(ent());
+    expect(n).toContain("vouch");
+    expect(n).toContain("YOU");
+  });
+
+  it("says nothing when the fact carries its evidence", () => {
+    expect(vouchNotice(ent({ source_quote: "I live in Cluj-Napoca" }))).toBe("");
   });
 });

--- a/packages/memory-view/src/lib/factVerdict.ts
+++ b/packages/memory-view/src/lib/factVerdict.ts
@@ -49,6 +49,22 @@ export function factVerdict(entity: FactEntity | undefined): FactVerdict {
 // Both directions are available on a judged fact, deliberately: the reason this surface
 // exists is to correct a verdict the judge got WRONG, and a panel that only offered
 // "mark wrong" would let an operator withhold but never restore.
+//
+// A SPAN-LESS FACT STILL OFFERS BOTH. An operator may vouch for a fact with no recorded
+// evidence — their name on it IS the authority, and the store records that it was a
+// person rather than a machine. What they are asserting is different, though, so the
+// form says so; see vouchNotice.
 export function factActions(v: FactVerdict): { canMarkWrong: boolean; canMarkGood: boolean } {
   return { canMarkWrong: v.state !== "withheld", canMarkGood: v.state !== "checked" };
+}
+
+// vouchNotice is what to tell an operator about to judge a fact that has no span.
+//
+// Without it the two cases look identical, and they are not: confirming a fact against a
+// recorded quote is checking, while confirming one with no quote is vouching. An operator
+// should know which they just did — it is their name that ends up on it.
+export function vouchNotice(entity: FactEntity | undefined): string {
+  if (entity?.source_quote) return "";
+  return "This fact records no source span, so there is nothing to check it against — " +
+    "your verdict records that YOU vouch for it, under your own name.";
 }

--- a/packages/memory-view/src/styles.css
+++ b/packages/memory-view/src/styles.css
@@ -1292,3 +1292,13 @@
   font-size: 12px;
   color: var(--accent);
 }
+
+/* Shown when the fact being judged has no span: the operator is vouching, not checking,
+   and the two should not look identical at the moment their name goes on it. */
+.loomcycle-memory-view .fact-verdict-vouch {
+  font-size: 12px;
+  margin-top: 6px;
+  padding: 6px 8px;
+  border-left: 2px solid var(--running);
+  opacity: 0.9;
+}


### PR DESCRIPTION
Reported from the console: opening a fact stored before spans existed, writing *"User confirmed"*, and being refused.

**Both controls failed there** — only `unclear` was allowed without a span — so the panel offered two buttons the server would never accept. That's the bug you hit.

## The rule's own justification had expired

It refused because a verdict without evidence *"would be indistinguishable from one that was checked"*.

That stopped being true when **`judged_by`** landed a week later. The store now records whether a machine or a human reached a verdict — so an operator putting their name to a fact is no longer mistakable for an entailment check. The refusal outlived its own argument, and in the meantime it made a legitimate action impossible: confirming a fact stored before spans existed, which is most of what an older store holds.

**An operator may now record `supported` or `unsupported` on a span-less fact.** Nothing is fabricated — no span is invented, the fact still counts as span-less in coverage, and the reason plus `judged_by` carry whose word it is.

**An agent still cannot.** A run affirming what it cannot check is exactly the claim a span exists to substantiate; letting one do it would turn "no evidence" into "verified" by assertion. That guard is untouched.

## One thing an existing test caught

**`mistyped` is excluded from the relaxation for anyone.** It is not a claim about whether the fact is *true* — it says the span carries the claim but the filing is wrong — so with no span there is nothing for it to be about. Correcting a filing is an edit, not a verdict.

I'd have relaxed it along with the others; the test that asserted `mistyped` needs a span is what stopped me.

## Two copy fixes fall out

- **The console now says what you are asserting** when the fact has no span. Confirming against a recorded quote is *checking*; confirming with no quote is *vouching*. The two should not look identical at the moment your name goes on it.
- **The coverage strip called span-less facts "can never be verified by anyone"** — already an overstatement, now simply wrong. They cannot be checked against a source; a person can still vouch.

## Tested

Four branches, each verified fail-before: an operator's verdict on a span-less fact is accepted and records `judged_by=operator` with the reason while inventing no span; an agent is still refused and told who may; `unclear` remains open to both; `mistyped` without a span is refused whoever asks.

`go test ./...`, package `tsc`/`vitest` (41), `make build-ui` — all clean.

## Note

This is a runtime behaviour change, so it wants a release to reach your deployment — it will not arrive by reloading the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)