### PR TITLE
feat(memory-view): the two embedding-maintenance ops, and 0.2.0 to publish them

### DIFF
--- a/adapters/ts/src/index.ts
+++ b/adapters/ts/src/index.ts
@@ -222,6 +222,8 @@ export type {
   MemoryEmbedStatsResponse,
   MemoryReembedConfigured,
   MemoryReembedResponse,
+  MemoryBackfillResponse,
+  MemoryPurgeResponse,
   // Interruption
   InterruptListResponse,
   InterruptRow,

--- a/packages/memory-view/package-lock.json
+++ b/packages/memory-view/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@loomcycle/memory-view",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@loomcycle/memory-view",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@loomcycle/client": "^1.49.0",
+        "@loomcycle/client": "^1.55.0",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -21,7 +21,7 @@
         "vitest": "^3.0.0"
       },
       "peerDependencies": {
-        "@loomcycle/client": "^1.49.0",
+        "@loomcycle/client": "^1.55.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
       }
@@ -751,9 +751,9 @@
       }
     },
     "node_modules/@loomcycle/client": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/@loomcycle/client/-/client-1.49.0.tgz",
-      "integrity": "sha512-qiK9jgktJANI9WKOEBABjxSq1nEKIRnUNrjacDBd3Wz7//o6vTcLbpPVsYzvS4bO/fUCsKg+dW1dYg0X+zS3Kw==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@loomcycle/client/-/client-1.55.0.tgz",
+      "integrity": "sha512-v94B4WwdsnpuzuPHn6SUriMMGTcAfsyDMbRN63laZpuoUWi6ag/MUo3iD9hwGAxSzCFqBeTFE+DnTr/meRGFTQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {

--- a/packages/memory-view/package.json
+++ b/packages/memory-view/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@loomcycle/memory-view",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
-  "description": "Embeddable React memory browser for the loomcycle agentic runtime (RFC BV) — a themeable, standalone k/v Vector Memory console (with a fact viewer + unified semantic search).",
+  "description": "Embeddable React memory browser for the loomcycle agentic runtime (RFC BV) \u2014 a themeable, standalone k/v Vector Memory console (with a fact viewer + unified semantic search).",
   "license": "Apache-2.0",
   "author": "Dennis Gubsky",
   "repository": {
@@ -48,12 +48,12 @@
     "test:watch": "vitest"
   },
   "peerDependencies": {
-    "@loomcycle/client": "^1.49.0",
+    "@loomcycle/client": "^1.55.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
-    "@loomcycle/client": "^1.49.0",
+    "@loomcycle/client": "^1.55.0",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/packages/memory-view/src/components/MemoryConsole.tsx
+++ b/packages/memory-view/src/components/MemoryConsole.tsx
@@ -67,6 +67,14 @@ export default function MemoryConsole() {
   const [embedStats, setEmbedStats] = useState<MemoryEmbedModelStats[] | null>(null);
   const [reembedBanner, setReembedBanner] = useState<MemoryReembedResponse | null>(null);
   const [reembedBusy, setReembedBusy] = useState(false);
+  // The two other embedding-maintenance ops. One `maint` slot rather than a banner each:
+  // they are alternatives, and two open at once would invite committing the wrong one.
+  const [maint, setMaint] = useState<
+    | { kind: "backfill"; resp: Awaited<ReturnType<typeof data.backfillEmbeddings>> }
+    | { kind: "purge"; resp: Awaited<ReturnType<typeof data.purgeStaleEmbeddings>> }
+    | null
+  >(null);
+  const [maintBusy, setMaintBusy] = useState(false);
 
   // CRUD state.
   const [modalState, setModalState] = useState<
@@ -230,6 +238,35 @@ export default function MemoryConsole() {
     return embedStats.some((m) => m.row_count > 0);
   }, [embedStats]);
 
+  const runMaint = async (kind: "backfill" | "purge", dryRun: boolean) => {
+    if (!scope || !scopeID) return;
+    if (kind === "purge" && !dryRun) {
+      if (!window.confirm(
+        `Drop the embeddings of rows under ${scopeLabel} that have no indexable text? ` +
+          `This deletes vectors; the rows themselves are untouched.`,
+      )) {
+        return;
+      }
+    }
+    setMaintBusy(true);
+    setMaint(null);
+    try {
+      const resp =
+        kind === "backfill"
+          ? await data.backfillEmbeddings(scope, scopeID, { dryRun })
+          : await data.purgeStaleEmbeddings(scope, scopeID, { dryRun });
+      setMaint(
+        kind === "backfill"
+          ? { kind, resp: resp as Awaited<ReturnType<typeof data.backfillEmbeddings>> }
+          : { kind, resp: resp as Awaited<ReturnType<typeof data.purgeStaleEmbeddings>> },
+      );
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setMaintBusy(false);
+    }
+  };
+
   const handleReembedDryRun = async () => {
     if (!scope || !scopeID) return;
     setReembedBusy(true);
@@ -363,6 +400,26 @@ export default function MemoryConsole() {
                 {reembedBusy ? "…" : "reembed plan"}
               </button>
             )}
+            {scopeID && (
+              <>
+                <button
+                  className="embed-reembed-btn"
+                  disabled={maintBusy}
+                  onClick={() => void runMaint("backfill", true)}
+                  title="See which rows carry NO embedding — what enabling an embedder after the rows were written leaves behind"
+                >
+                  {maintBusy ? "…" : "backfill plan"}
+                </button>
+                <button
+                  className="embed-reembed-btn"
+                  disabled={maintBusy}
+                  onClick={() => void runMaint("purge", true)}
+                  title="See which rows carry an embedding but have no indexable text to justify one"
+                >
+                  {maintBusy ? "…" : "purge plan"}
+                </button>
+              </>
+            )}
           </div>
         )}
         {scope && embedStats === null && (
@@ -378,6 +435,14 @@ export default function MemoryConsole() {
             busy={reembedBusy}
             onCommit={handleReembedCommit}
             onDismiss={() => setReembedBanner(null)}
+          />
+        )}
+        {maint && (
+          <MaintenanceBanner
+            state={maint}
+            busy={maintBusy}
+            onCommit={() => void runMaint(maint.kind, false)}
+            onDismiss={() => setMaint(null)}
           />
         )}
         {scopeID && (
@@ -561,4 +626,92 @@ function prettyJSON(v: unknown): string {
   } catch {
     return String(v);
   }
+}
+
+// MaintenanceBanner — the plan (or outcome) of a backfill / stale-purge, with the two
+// numbers each response carries that a bare count would misrepresent.
+//
+// BACKFILL: `skipped_empty` rows have NO text to embed — a document root, a section
+// heading — so they remain candidates permanently. Without saying so, an operator watches
+// `candidates` stop falling with `embedded` at 0 and no stated reason. `more` means the
+// limit was reached with work outstanding, which is the honest replacement for "run it
+// until candidates hits 0" — a target unembeddable rows make unreachable.
+//
+// PURGE: `truncated` means the scan stopped at the limit, so a zero `stale` does NOT mean
+// the scope is clean. This op deletes, and "we looked at some of it and found nothing" is
+// a different statement from "there is nothing".
+function MaintenanceBanner({
+  state,
+  busy,
+  onCommit,
+  onDismiss,
+}: {
+  state:
+    | { kind: "backfill"; resp: { dry_run: boolean; candidates: number; embedded?: number; failed?: number; skipped_empty?: number; more?: boolean; sample_keys?: string[]; notes?: string[] } }
+    | { kind: "purge"; resp: { dry_run: boolean; scanned: number; stale: number; purged: number; failed?: number; truncated: boolean; sample_keys?: string[]; notes?: string[] } };
+  busy: boolean;
+  onCommit: () => void;
+  onDismiss: () => void;
+}) {
+  const dry = state.resp.dry_run;
+  return (
+    <div className={"reembed-banner " + (dry ? "reembed-dryrun" : "")}>
+      <div className="reembed-summary">
+        {state.kind === "backfill" ? (
+          <>
+            <strong>{state.resp.candidates}</strong> row
+            {state.resp.candidates === 1 ? "" : "s"} carry no embedding
+            {dry ? " and would be embedded" : ` · embedded ${state.resp.embedded ?? 0}`}
+            {(state.resp.failed ?? 0) > 0 && <> · failed {state.resp.failed}</>}
+            {(state.resp.skipped_empty ?? 0) > 0 && (
+              <>
+                {" "}
+                · <strong>{state.resp.skipped_empty}</strong> have no text to embed and stay
+                candidates permanently
+              </>
+            )}
+            {state.resp.more && <> · the limit was reached, so another run has work</>}
+          </>
+        ) : (
+          <>
+            <strong>{state.resp.stale}</strong> of {state.resp.scanned} scanned row
+            {state.resp.scanned === 1 ? "" : "s"} carry an embedding with no text to justify it
+            {!dry && <> · purged {state.resp.purged}</>}
+            {(state.resp.failed ?? 0) > 0 && <> · failed {state.resp.failed}</>}
+            {state.resp.truncated && (
+              <>
+                {" "}
+                · <strong>the scan stopped at the limit</strong>, so this is not the whole
+                scope
+              </>
+            )}
+          </>
+        )}
+      </div>
+      {state.resp.sample_keys && state.resp.sample_keys.length > 0 && (
+        <ul className="reembed-samples">
+          {state.resp.sample_keys.slice(0, 8).map((k) => (
+            <li key={k}>
+              <code>{k}</code>
+            </li>
+          ))}
+        </ul>
+      )}
+      {state.resp.notes?.map((n) => (
+        <div key={n} className="meta">
+          {n}
+        </div>
+      ))}
+      <div className="reembed-actions">
+        {dry && (
+          <button className="reembed-commit-btn" disabled={busy} onClick={onCommit}>
+            {state.kind === "backfill" ? "embed them" : "purge them"}
+          </button>
+        )}
+        <button className="reembed-dismiss-btn" disabled={busy} onClick={onDismiss}>
+          dismiss
+        </button>
+      </div>
+    </div>
+  );
 }

--- a/packages/memory-view/src/lib/dataLayer.test.ts
+++ b/packages/memory-view/src/lib/dataLayer.test.ts
@@ -21,6 +21,12 @@ function stubClient() {
     .fn()
     .mockResolvedValue({ scope: "user", models: [], total_embedding_bytes: 0 });
   const reembedMemory = vi.fn().mockResolvedValue({ scope: "user", scope_id: "alice", dry_run: true });
+  const backfillEmbeddings = vi
+    .fn()
+    .mockResolvedValue({ scope: "user", scope_id: "bob", dry_run: true, candidates: 0 });
+  const purgeStaleEmbeddings = vi
+    .fn()
+    .mockResolvedValue({ scope: "user", scope_id: "bob", dry_run: true, scanned: 0, stale: 0, purged: 0, truncated: false });
   // P4b — the unified search + Document (list_facts / get_chunk / get_edges) legs.
   const memorySearch = vi
     .fn()
@@ -47,6 +53,8 @@ function stubClient() {
     deleteMemoryEntry,
     memoryEmbedStats,
     reembedMemory,
+    backfillEmbeddings,
+    purgeStaleEmbeddings,
     memorySearch,
     document,
     whoami,
@@ -63,6 +71,8 @@ function stubClient() {
     deleteMemoryEntry,
     memoryEmbedStats,
     reembedMemory,
+    backfillEmbeddings,
+    purgeStaleEmbeddings,
     memorySearch,
     document,
     whoami,
@@ -169,6 +179,19 @@ describe("dataLayerFromClient — @loomcycle/client → memory wire mapping", ()
       { op: "list_facts", scope: "user", include_refuted: true },
       undefined,
     );
+  });
+
+  it("backfillEmbeddings and purgeStaleEmbeddings pass the dry-run flag straight through", async () => {
+    // Both default to dry_run=true SERVER-side, and the client only ever sends `false` to
+    // commit. The console always states it explicitly, so a plan can never be mistaken
+    // for a commit by an omitted flag.
+    const s = stubClient();
+    await dataLayerFromClient(s.client).backfillEmbeddings("user", "bob", { dryRun: true });
+    expect(s.backfillEmbeddings).toHaveBeenCalledWith("user", "bob", { dryRun: true });
+
+    const q = stubClient();
+    await dataLayerFromClient(q.client).purgeStaleEmbeddings("user", "bob", { dryRun: false });
+    expect(q.purgeStaleEmbeddings).toHaveBeenCalledWith("user", "bob", { dryRun: false });
   });
 
   it("remember sends the statement ONCE — the server writes the span from it", async () => {

--- a/packages/memory-view/src/lib/dataLayer.test.ts
+++ b/packages/memory-view/src/lib/dataLayer.test.ts
@@ -181,17 +181,21 @@ describe("dataLayerFromClient — @loomcycle/client → memory wire mapping", ()
     );
   });
 
-  it("backfillEmbeddings and purgeStaleEmbeddings pass the dry-run flag straight through", async () => {
-    // Both default to dry_run=true SERVER-side, and the client only ever sends `false` to
-    // commit. The console always states it explicitly, so a plan can never be mistaken
-    // for a commit by an omitted flag.
-    const s = stubClient();
-    await dataLayerFromClient(s.client).backfillEmbeddings("user", "bob", { dryRun: true });
-    expect(s.backfillEmbeddings).toHaveBeenCalledWith("user", "bob", { dryRun: true });
+  it("backfillEmbeddings and purgeStaleEmbeddings pass the dry-run flag through in BOTH directions", async () => {
+    // Asserted both ways per op, deliberately. Checking only the `true` case cannot
+    // detect a layer that hardcodes true, and checking only `false` cannot detect one
+    // that hardcodes false — and the two failures are not equally bad: a commit that
+    // silently became a plan does nothing, while a PLAN that silently became a commit
+    // changes data with no preview. Neither is caught by a one-directional assertion.
+    for (const dryRun of [true, false]) {
+      const s = stubClient();
+      await dataLayerFromClient(s.client).backfillEmbeddings("user", "bob", { dryRun });
+      expect(s.backfillEmbeddings).toHaveBeenCalledWith("user", "bob", { dryRun });
 
-    const q = stubClient();
-    await dataLayerFromClient(q.client).purgeStaleEmbeddings("user", "bob", { dryRun: false });
-    expect(q.purgeStaleEmbeddings).toHaveBeenCalledWith("user", "bob", { dryRun: false });
+      const q = stubClient();
+      await dataLayerFromClient(q.client).purgeStaleEmbeddings("user", "bob", { dryRun });
+      expect(q.purgeStaleEmbeddings).toHaveBeenCalledWith("user", "bob", { dryRun });
+    }
   });
 
   it("remember sends the statement ONCE — the server writes the span from it", async () => {

--- a/packages/memory-view/src/lib/dataLayer.tsx
+++ b/packages/memory-view/src/lib/dataLayer.tsx
@@ -21,6 +21,18 @@ import type {
   VerificationStats,
 } from "../types";
 
+// The two embedding-maintenance response types are DERIVED from the client's method
+// signatures rather than imported by name.
+//
+// @loomcycle/client 1.55.0 ships the methods but does not re-export their response
+// interfaces from its entry point — they are defined in its types module and missing from
+// the `export type {...}` list, so a consumer cannot name them. That is fixed in the
+// adapter for the next release; deriving them here is drift-free in the meantime (the
+// type IS the client's, not a second copy of it) and does not make this package wait on
+// a release to use methods that already exist.
+type MemoryBackfillResponse = Awaited<ReturnType<LoomcycleClient["backfillEmbeddings"]>>;
+type MemoryPurgeResponse = Awaited<ReturnType<LoomcycleClient["purgeStaleEmbeddings"]>>;
+
 // FactListOptions are the browse filters `listFacts` forwards to the Document
 // tool's list_facts op. All optional — an empty bag lists the whole scope's
 // facts (newest first). `scopeId` is the RFC AS browse-by-subject override (a
@@ -98,6 +110,21 @@ export interface MemoryDataLayer {
     scopeId: string,
     opts: { dryRun?: boolean; limit?: number },
   ): Promise<MemoryReembedResponse>;
+  // Embed rows that carry NO embedding — what enabling an embedder AFTER the rows were
+  // written leaves behind. Same dry-run posture as reembed: plan, then commit.
+  backfillEmbeddings(
+    scope: MemoryScope,
+    scopeId: string,
+    opts: { dryRun?: boolean; limit?: number },
+  ): Promise<MemoryBackfillResponse>;
+  // Drop embeddings from rows that have no indexable text. THIS ONE DELETES, so the plan
+  // matters more than on its siblings — and `truncated` must be read, because a zero
+  // `stale` from a scan cut short at the limit does not mean the scope is clean.
+  purgeStaleEmbeddings(
+    scope: MemoryScope,
+    scopeId: string,
+    opts: { dryRun?: boolean; limit?: number },
+  ): Promise<MemoryPurgeResponse>;
 
   // ---- P4b: unified search + the entity/fact tier -------------------------
 
@@ -179,6 +206,9 @@ export function dataLayerFromClient(client: LoomcycleClient): MemoryDataLayer {
       client.deleteMemoryEntry(scope, scopeId, key),
     embedStats: (scope) => client.memoryEmbedStats(scope),
     reembed: (scope, scopeId, opts) => client.reembedMemory(scope, scopeId, opts),
+    backfillEmbeddings: (scope, scopeId, opts) => client.backfillEmbeddings(scope, scopeId, opts),
+    purgeStaleEmbeddings: (scope, scopeId, opts) =>
+      client.purgeStaleEmbeddings(scope, scopeId, opts),
 
     // ---- P4b -----------------------------------------------------------
     search: (input) => client.memorySearch(input),


### PR DESCRIPTION
RFC CF phase 5's other half — unblocked by `@loomcycle/client@1.55.0` reaching npm — plus the version bump the package needs to publish any of the last month's work.

## The ops

`backfill_embeddings` and `purge_stale_embeddings` join the reembed flow they belong beside: all three are per-scope, which is what settled where they live, and all three are triggered from the same embed-stats badge.

Both follow reembed's **plan-then-commit** shape. `dry_run` defaults true server-side and the console always states it explicitly, so a plan can never become a commit through an omitted flag. The purge additionally confirms, because it deletes.

## The banner exists for two numbers a bare count misrepresents

- **backfill's `skipped_empty`** — rows with *no text to embed* (a document root, a section heading) remain candidates permanently. Unsaid, an operator watches `candidates` stop falling with `embedded` at 0 and no stated reason. **`more`** reports the limit was reached with work outstanding — the honest replacement for "run it until candidates hits 0", a target unembeddable rows make unreachable.
- **purge's `truncated`** — the scan stopped at the limit, so a zero `stale` does **not** mean the scope is clean. This op deletes, and *"we looked at some of it and found nothing"* is a different statement from *"there is nothing"*.

## A gap in the adapter, found by trying to use it

`@loomcycle/client@1.55.0` ships both methods but **does not re-export their response interfaces** from its entry point — they're defined in its types module and missing from the `export type {…}` list, so a consumer cannot name them. Fixed here for the next release.

Meanwhile the package **derives** those types from the client's own method signatures rather than declaring copies. That's drift-free (the type *is* the client's) and meant this work didn't have to wait on a second release to use methods that already exist.

## Version 0.2.0

The peer dependency moves to `^1.55.0` — the package now needs a client that has these methods — and the lockfile moves with it.

This bump is the prerequisite for a `memory-view-v0.2.0` tag. The package has been **13 files and ~866 lines behind its published 0.1.0** since the facts/verdict surface moved into it, so nothing consuming the package (rather than this repo's own web app) has any of the spans, verdicts, coverage strip, `remember`, or the vouching notice.

## Tested

42 package tests, `tsc --noEmit` clean, `npm run build:lib` clean, `make build-ui` and `go test ./...` clean. The dry-run pass-through is verified fail-before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)