### PR TITLE
fix(cli): a tier-only agent is not a config error

### DIFF
--- a/internal/cli/agents.go
+++ b/internal/cli/agents.go
@@ -64,14 +64,9 @@ func runAgentsList(args []string, stdout, stderr io.Writer) int {
 	// chatty column we truncate to keep things readable.
 	for _, name := range names {
 		def := cfg.Agents[name]
-		provider, model, pattern, err := cfg.ResolveAgentModel(name)
+		provider, model, err := agentModelForDisplay(cfg, name)
 		if err != nil {
 			return fail(stderr, "agent %q: %v", name, err)
-		}
-		// RFC BG: a model_pattern alias has no concrete model until run time;
-		// show the glob so the operator sees what the alias points at.
-		if pattern != "" {
-			model = pattern
 		}
 		tools := strings.Join(def.Tools, ",")
 		if tools == "" {
@@ -110,18 +105,22 @@ func runAgentsListJSON(stdout, stderr io.Writer, cfg *config.Config, names []str
 	fmt.Fprintln(stdout, "[")
 	for i, name := range names {
 		def := cfg.Agents[name]
-		provider, model, pattern, err := cfg.ResolveAgentModel(name)
+		provider, model, err := agentModelForDisplay(cfg, name)
 		if err != nil {
 			return fail(stderr, "agent %q: %v", name, err)
 		}
-		// RFC BG: surface the glob for a model_pattern alias (resolved at run time).
-		if pattern != "" {
-			model = pattern
+		// The table form prints "(by tier)" for an agent routed at run time; JSON
+		// must NOT, because a consumer reading .provider would take that
+		// placeholder for a provider id. Both fields stay empty and the additive
+		// `tier` field carries the answer.
+		if provider == byTierProvider {
+			provider, model = "", ""
 		}
 		fmt.Fprintln(stdout, "  {")
 		fmt.Fprintf(stdout, "    \"name\": %s,\n", jsonString(name))
 		fmt.Fprintf(stdout, "    \"provider\": %s,\n", jsonString(provider))
 		fmt.Fprintf(stdout, "    \"model\": %s,\n", jsonString(model))
+		fmt.Fprintf(stdout, "    \"tier\": %s,\n", jsonString(def.Tier))
 		fmt.Fprintf(stdout, "    \"max_tokens\": %d,\n", def.MaxTokens)
 		fmt.Fprintf(stdout, "    \"system_prompt_file\": %s,\n", jsonString(def.SystemPromptFile))
 		fmt.Fprintf(stdout, "    \"tools\": %s,\n", jsonStringArray(def.Tools))

--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -85,5 +86,49 @@ func TestRunAgents_NoArgs(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "Usage:") {
 		t.Errorf("stderr missing usage: %q", stderr.String())
+	}
+}
+
+// `agents list --json` must stay PARSEABLE for an agent routed at run time. Before
+// the fix it bailed at the first tier-only agent, having already written that
+// agent's opening brace — so the array was never closed and every consumer got a
+// syntax error rather than a message. The parse below is the assertion; the field
+// checks are what a consumer would then read.
+func TestRunAgentsList_TierOnlyAgent_JSONStaysParseable(t *testing.T) {
+	path := writeTempConfig(t, `
+tiers:
+  middle: [{ provider: anthropic, model: claude-sonnet-4-6 }]
+user_tiers:
+  default:
+    provider_priority: [anthropic]
+agents:
+  extractor:
+    tier: middle
+    system_prompt: "extract"
+    tools: []
+`)
+	var stdout, stderr bytes.Buffer
+	if rc := RunAgents([]string{"list", "--json", "--config", path}, &stdout, &stderr); rc != 0 {
+		t.Fatalf("rc = %d, want 0; stderr = %q", rc, stderr.String())
+	}
+	var got []struct {
+		Name     string `json:"name"`
+		Provider string `json:"provider"`
+		Model    string `json:"model"`
+		Tier     string `json:"tier"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid JSON (%v):\n%s", err, stdout.String())
+	}
+	if len(got) != 1 || got[0].Name != "extractor" {
+		t.Fatalf("unexpected agents: %+v", got)
+	}
+	if got[0].Tier != "middle" {
+		t.Errorf("tier = %q, want \"middle\"", got[0].Tier)
+	}
+	// The placeholder the human table prints must not leak into a machine field.
+	if got[0].Provider != "" || got[0].Model != "" {
+		t.Errorf("provider/model = %q/%q, want both empty for a tier-routed agent",
+			got[0].Provider, got[0].Model)
 	}
 }

--- a/internal/cli/loadcfg.go
+++ b/internal/cli/loadcfg.go
@@ -91,6 +91,53 @@ func loadLayeredConfig(explicitPath string) (*config.Config, error) {
 	return config.LoadLayers(layers...)
 }
 
+// byTierProvider is what the introspection commands print for an agent whose
+// provider is chosen at run time. Not a provider id, and deliberately shaped so
+// it cannot be mistaken for one.
+const byTierProvider = "(by tier)"
+
+// agentModelForDisplay reports how an agent will get its provider and model, for
+// the introspection commands (validate, agents list).
+//
+// THREE outcomes, not two, and collapsing them into two is the bug this exists
+// for. config.ResolveAgentModel answers the PIN path: an agent naming a provider
+// or model (or an alias for one) resolves here and now. An agent naming a `tier:`
+// is resolved at RUN time by the resolver against the live availability matrix,
+// which a CLI process has no access to — so the pin path legitimately finds
+// nothing for it. Reporting that as a config error made `loomcycle validate` exit
+// 2 on every bundled agent preset (chat, memory, document-agent, agent-teams)
+// naming an agent the running server resolves fine. The exit code was the small
+// half: validate returns at the FIRST agent, so MCP servers and everything after
+// went unchecked, and `agents list --json` bailed mid-array leaving output no
+// parser accepts.
+//
+// TIER IS CHECKED FIRST, mirroring the runtime — internal/api/http.resolveAgentDef
+// takes the tier path before it ever looks at a pin or at `defaults:`. Ordering it
+// the other way (pin path first, tier only when that errors) looks equivalent and
+// is not: for a tier agent in a config that also sets `defaults:`, the pin path
+// succeeds and returns the DEFAULTS, so the command would confidently print a
+// provider the server will never use for it.
+//
+// An agent with neither a pin nor a tier still fails, because that one is a real
+// config error — the resolver refuses it too ("has neither pin nor tier").
+func agentModelForDisplay(cfg *config.Config, name string) (provider, model string, err error) {
+	// Config validation rejects pin+tier on one agent, so a non-empty tier here
+	// means the tier path is the ONLY path this agent has.
+	if def, ok := cfg.Agents[name]; ok && def.Tier != "" {
+		return byTierProvider, "tier:" + def.Tier, nil
+	}
+	provider, model, pattern, err := cfg.ResolveAgentModel(name)
+	if err != nil {
+		return "", "", err
+	}
+	// RFC BG: a model_pattern alias resolves against the live catalog at run
+	// time, so show the glob rather than the empty string it resolves to here.
+	if pattern != "" {
+		model = pattern
+	}
+	return provider, model, nil
+}
+
 // configDirYAMLs lists *.yaml/*.yml in dir in lexical order — mirrors
 // cmd/loomcycle.configDirLayers (the server's LOOMCYCLE_CONFIG_DIR reader).
 func configDirYAMLs(dir string) ([]string, error) {

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -77,14 +77,9 @@ func RunValidate(args []string, stdout, stderr io.Writer) int {
 	} else {
 		fmt.Fprintf(stdout, "Agents           : %d\n", len(names))
 		for _, name := range names {
-			provider, model, pattern, err := cfg.ResolveAgentModel(name)
+			provider, model, err := agentModelForDisplay(cfg, name)
 			if err != nil {
 				return fail(stderr, "agent %q: %v", name, err)
-			}
-			// RFC BG: a model_pattern alias resolves to a concrete model only at
-			// run time (against the live catalog), so show the glob here.
-			if pattern != "" {
-				model = pattern
 			}
 			fmt.Fprintf(stdout, "  %-24s provider=%-10s model=%s\n", name, provider, model)
 		}

--- a/internal/cli/validate_test.go
+++ b/internal/cli/validate_test.go
@@ -107,3 +107,93 @@ func TestMaskDSN(t *testing.T) {
 		}
 	}
 }
+
+// A TIER-ONLY agent is not a config error. It is how every bundled agent preset
+// is written (chat, memory, document-agent, agent-teams all name a `tier:` and
+// pin nothing), and before the fix validate exited 2 on all of them — naming an
+// agent the running server resolves without trouble. Because validate returns at
+// the first agent, everything after it (MCP servers, the OK footer) went
+// unreported too, so the assertions below cover the whole output, not just the
+// exit code.
+func TestRunValidate_TierOnlyAgentIsNotAnError(t *testing.T) {
+	path := writeTempConfig(t, `
+tiers:
+  middle: [{ provider: anthropic, model: claude-sonnet-4-6 }]
+user_tiers:
+  default:
+    provider_priority: [anthropic]
+agents:
+  extractor:
+    tier: middle
+    system_prompt: "extract"
+    tools: []
+mcp_servers:
+  peer:
+    transport: http
+    url: https://example.invalid/mcp
+`)
+	var stdout, stderr bytes.Buffer
+	if rc := RunValidate([]string{path}, &stdout, &stderr); rc != 0 {
+		t.Fatalf("rc = %d, want 0; stderr = %q", rc, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"extractor", "tier:middle", "MCP servers", "OK"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// The other half of the same rule: an agent with NEITHER a pin nor a tier has no
+// way to reach a model, and the resolver refuses it at run time too — so validate
+// must keep failing on it. Without this, "stop failing on tier agents" is one
+// sloppy edit away from "stop checking agents".
+func TestRunValidate_AgentWithNeitherPinNorTierStillFails(t *testing.T) {
+	path := writeTempConfig(t, `
+agents:
+  orphan:
+    system_prompt: "nothing routes me"
+    tools: []
+`)
+	var stdout, stderr bytes.Buffer
+	if rc := RunValidate([]string{path}, &stdout, &stderr); rc == 0 {
+		t.Fatalf("rc = 0, want non-zero; stdout = %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "orphan") {
+		t.Errorf("stderr should name the offending agent, got %q", stderr.String())
+	}
+}
+
+// A tier agent in a config that ALSO sets `defaults:` must still report its tier.
+// The runtime takes the tier path before it looks at a pin or at defaults, so
+// resolving the pin path first and treating the tier as a fallback would print a
+// provider the server never uses for this agent — a wrong answer, which is worse
+// than the refusal it replaced.
+func TestRunValidate_TierWinsOverDefaultsInTheReport(t *testing.T) {
+	path := writeTempConfig(t, `
+defaults:
+  provider: anthropic
+  model: claude-sonnet-4-6
+tiers:
+  low: [{ provider: openai, model: gpt-5-mini }]
+user_tiers:
+  default:
+    provider_priority: [openai]
+agents:
+  judge:
+    tier: low
+    system_prompt: "judge"
+    tools: []
+`)
+	var stdout, stderr bytes.Buffer
+	if rc := RunValidate([]string{path}, &stdout, &stderr); rc != 0 {
+		t.Fatalf("rc = %d, want 0; stderr = %q", rc, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "tier:low") {
+		t.Errorf("expected the tier reported for a tier agent, got:\n%s", out)
+	}
+	if strings.Contains(out, "claude-sonnet-4-6") {
+		t.Errorf("reported the defaults model for an agent the server routes by tier:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Why

`loomcycle validate` — the tool the install docs and the project's own workflow point operators at first — exits 2 on **every bundled agent preset**, naming an agent the running server resolves without trouble:

```
$ LOOMCYCLE_PRESETS=base,memory loomcycle validate loomcycle.yaml
loomcycle: error: agent "memory/extractor": no provider resolved
```

Same for `base,chat` (`chat/medium`), `base,document-agent` (`doc/manager`) and `base,agent-teams` (`agent/assistant`). Each of those agents names a `tier:` and pins no provider, which is how the bundles are written.

The exit code is the smaller half of it:

- validate returns at the **first** agent, so MCP servers, the rest of the agent table and the `OK` footer go unreported — a real problem downstream of the first tier agent is invisible.
- `agents list --json` bails mid-array having already written an opening brace, so the output is **unparseable**, not merely incomplete.

## What

`config.ResolveAgentModel` answers the **pin** path only. An agent naming a tier is resolved at run time by the resolver against the live availability matrix, which a CLI process has no access to — so the pin path legitimately finds nothing for it, and the three call sites treated "nothing" as "broken".

This is the sibling of the layering gap fixed in v1.8.1 (#602). That fix made these tools read the *same config* the server does; this one makes them apply the *same resolution rule*.

A shared `agentModelForDisplay` (in `internal/cli/loadcfg.go`, beside the #602 fix it completes) reports:

| agent | reported |
|---|---|
| pins a provider/model, or an alias | the resolved pair (unchanged) |
| names a `tier:` | `provider=(by tier)  model=tier:middle` |
| neither pin nor tier | **still fails** — the resolver refuses it too (`has neither pin nor tier`) |

Two details that are load-bearing:

- **The tier is checked FIRST**, mirroring `resolveAgentDef`, which takes the tier path before it looks at a pin or at `defaults:`. Ordering it the other way — pin path first, tier only when that errors — looks equivalent and is not: for a tier agent in a config that also sets `defaults:`, the pin path *succeeds* and returns the defaults, so the command would confidently print a provider the server never uses for that agent. A wrong answer is worse than the refusal it replaces.
- **The JSON form does not print `(by tier)`.** Provider and model stay empty and an additive `tier` field carries the answer, so a consumer reading `.provider` cannot mistake a display placeholder for a provider id.

## What was tested

`go test ./...` clean (91 packages, exit 0) in a clean worktree off `main`.

New tests, each verified to fail on the unfixed code:

- `TestRunValidate_TierOnlyAgentIsNotAnError` — asserts the **whole** output (the agent, its tier, the MCP section, the `OK` footer), not just the exit code, since truncation was half the bug.
- `TestRunAgentsList_TierOnlyAgent_JSONStaysParseable` — `json.Unmarshal` of the output is the assertion.
- `TestRunValidate_TierWinsOverDefaultsInTheReport` — pins the ordering above.
- `TestRunValidate_AgentWithNeitherPinNorTierStillFails` — the other half of the rule, so "stop failing on tier agents" cannot drift into "stop checking agents".

Fail-before probes (mutations applied to the committed fix, both confirmed to compile first, so neither probe was vacuous):

1. remove the tier branch → the three tier tests fail, the neither-pin-nor-tier test correctly still passes.
2. tier as a *fallback* after the pin path → only `TierWinsOverDefaults` fails, which is why that test exists.

Manual: `validate` now passes on `base`, `base,chat`, `base,memory`, `base,document-agent`, `base,agent-teams`; `agents list --json` parses and reports `tier` per agent; a `code-js` agent still shows its concrete provider.

Found while standing up a live deployment to exercise verified writes on real data — the config would not validate, and the config was fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8