### PR TITLE
feat(bundles): opt remaining LLM agents into inject_tool_guide

### DIFF
--- a/bundles/agent-teams/loomcycle.yaml
+++ b/bundles/agent-teams/loomcycle.yaml
@@ -59,6 +59,7 @@ channels:
 
 agents:
   agent/assistant:
+    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     tier: middle
     max_iterations: 24
     max_tokens: 8192
@@ -99,6 +100,7 @@ agents:
       workflow.
 
   team/assistant:
+    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     tier: middle
     max_iterations: 32
     max_tokens: 8192
@@ -145,6 +147,7 @@ agents:
       state what you'd run to test it.
 
   team/orchestrator:
+    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     # Run this agent INTERACTIVELY (the operator starts it with interactive:true
     # from the /run terminal) so it parks for human input between turns — that's a
     # per-run flag, not an agent field. unbounded_iterations lifts the loop cap so a

--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -2257,6 +2257,7 @@ agents:
       cannot judge rather than guessing at it.
 
   memory/ontologist:
+    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     # An ONTOLOGY CURATOR: it reads the entity types in force, looks at what types
     # the stored facts actually carry, and FILES SUGGESTIONS. It cannot change the
     # type system — the propose op only ever writes an inert entity, and resolving

--- a/bundles/team-examples/loomcycle.yaml
+++ b/bundles/team-examples/loomcycle.yaml
@@ -31,6 +31,7 @@
 agents:
   # ---- software (SDLC) handlers — operate the shared ephemeral `work` volume ----
   sdlc/architect:
+    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     tier: middle
     max_tokens: 8192
     effort: high
@@ -43,6 +44,7 @@ agents:
       one-line "ready to implement?" so the orchestrator can gate on approval.
 
   sdlc/coder:
+    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     tier: middle
     max_tokens: 16384
     effort: medium
@@ -56,6 +58,7 @@ agents:
       commit or push; the orchestrator opens the PR.
 
   sdlc/reviewer:
+    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     tier: middle
     max_tokens: 8192
     effort: high
@@ -69,6 +72,7 @@ agents:
 
   # ---- marketing handlers — Documents only, no volume/repo ----
   marketing/writer:
+    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     tier: middle
     max_tokens: 8192
     effort: medium
@@ -83,6 +87,7 @@ agents:
       and no PR; the Document is the deliverable.
 
   marketing/editor:
+    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     tier: middle
     max_tokens: 8192
     effort: high

--- a/cmd/loomcycle/embedded/bundles/agent-teams.yaml
+++ b/cmd/loomcycle/embedded/bundles/agent-teams.yaml
@@ -59,6 +59,7 @@ channels:
 
 agents:
   agent/assistant:
+    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     tier: middle
     max_iterations: 24
     max_tokens: 8192
@@ -99,6 +100,7 @@ agents:
       workflow.
 
   team/assistant:
+    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     tier: middle
     max_iterations: 32
     max_tokens: 8192
@@ -145,6 +147,7 @@ agents:
       state what you'd run to test it.
 
   team/orchestrator:
+    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     # Run this agent INTERACTIVELY (the operator starts it with interactive:true
     # from the /run terminal) so it parks for human input between turns — that's a
     # per-run flag, not an agent field. unbounded_iterations lifts the loop cap so a

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -2257,6 +2257,7 @@ agents:
       cannot judge rather than guessing at it.
 
   memory/ontologist:
+    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     # An ONTOLOGY CURATOR: it reads the entity types in force, looks at what types
     # the stored facts actually carry, and FILES SUGGESTIONS. It cannot change the
     # type system — the propose op only ever writes an inert entity, and resolving

--- a/cmd/loomcycle/embedded/bundles/team-examples.yaml
+++ b/cmd/loomcycle/embedded/bundles/team-examples.yaml
@@ -31,6 +31,7 @@
 agents:
   # ---- software (SDLC) handlers — operate the shared ephemeral `work` volume ----
   sdlc/architect:
+    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     tier: middle
     max_tokens: 8192
     effort: high
@@ -43,6 +44,7 @@ agents:
       one-line "ready to implement?" so the orchestrator can gate on approval.
 
   sdlc/coder:
+    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     tier: middle
     max_tokens: 16384
     effort: medium
@@ -56,6 +58,7 @@ agents:
       commit or push; the orchestrator opens the PR.
 
   sdlc/reviewer:
+    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     tier: middle
     max_tokens: 8192
     effort: high
@@ -69,6 +72,7 @@ agents:
 
   # ---- marketing handlers — Documents only, no volume/repo ----
   marketing/writer:
+    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     tier: middle
     max_tokens: 8192
     effort: medium
@@ -83,6 +87,7 @@ agents:
       and no PR; the Document is the deliverable.
 
   marketing/editor:
+    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     tier: middle
     max_tokens: 8192
     effort: high


### PR DESCRIPTION
## Why

Follow-up to #1042. That PR turned on `inject_tool_guide` for `chat/*` and
`doc/manager`. This extends the auto tool-guide + capabilities injection to the
rest of the bundled **LLM** agents that actually call tools, so they no longer
start "blind" on which op to call and what the deployment supports.

## What

Adds `inject_tool_guide: true` to:

| Bundle | Agents |
|---|---|
| agent-teams | `agent/assistant`, `team/assistant`, `team/orchestrator` |
| team-examples | `sdlc/architect`, `sdlc/coder`, `sdlc/reviewer`, `marketing/writer`, `marketing/editor` |
| memory | `memory/ontologist` |

(`chat/*` and `doc/manager` already have it from #1042.)

## Verified — what was deliberately NOT flagged

Checking each entry's **type and provider** was the point of the request — a
naive "all doc/ and team/ agents" would have hit the wrong things:

- **Skills, not agents** — the `doc/*` and `team/*` "sub-agents"
  (`semantic-chunking`, `edge-linking`, `restructuring`, `md-import`,
  `structure`, `workflow`, `orchestrate`, `repo`, `sqldata`, `docboard`,
  `team/examples`) live under `skills:`, not `agents:`. They are prompt-injected
  **into** the flagged LLM agents (`doc/manager`, `team/orchestrator`), so the
  knowledge already reaches them there; `inject_tool_guide` is an AgentDef field
  with no meaning on a skill.
- **code-js agents** — `memory/consolidator`, `dev/exec`, `doc/colorizer` are
  `provider: code-js` (deterministic replay, no LLM reads a system prompt).
- **tool-less agents** — `memory/extractor`, `memory/judge` hold no tools, so
  the guide renders nothing.

Embedded bundle copies (`cmd/loomcycle/embedded/bundles/*.yaml`) synced with the
sources — the embedded copy is what ships.

## What was tested

- `go test ./...` — clean (91 packages); the `*BundleSourceMatchesEmbedded`
  sync tests pass.
- `LOOMCYCLE_PRESETS=base,chat,document-agent,agent-teams,team-examples,memory
  loomcycle validate` resolves all 16 agents clean with the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)