### PR TITLE
fix(memory): a search pattern is not evidence for a fact

### DIFF
--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -298,6 +298,19 @@ agents:
         // and every fact loses its evidence; too low and a fact gets handed an
         // unrelated sentence, which is worse than none because it looks like proof.
         min_span_overlap: 0.25,
+        // The share of ASCII punctuation above which a candidate span is CODE rather than
+        // a sentence, so it cannot be evidence. Like merge_min_subject_overlap and unlike
+        // the cosine bands, this is a property of prose rather than of a deployment's
+        // embedder, so it is a shipped constant and not a `memory.consolidation.*` key.
+        //
+        // 0.20 is MEASURED, on the spans of one live store: real prose ran 0.009 to 0.150
+        // (the top is a markdown bold heading, legitimate evidence), while the two
+        // pattern lines that each cost a true fact measured 0.259 and 0.382. Biased toward
+        // the LOW end of that window because the errors are not symmetric — too high
+        // admits a regex as evidence and the judge then withholds a TRUE fact, which loses
+        // data; too low leaves a fact with no span, which reads as unverified and stays
+        // fully visible.
+        max_span_punctuation: 0.20,
         // The SECOND signal an in-place rewrite has to clear, alongside the
         // similarity band — see mergeRefusal for why one number is not enough
         // authority to destroy a fact. It is the Dice overlap between the two
@@ -1194,9 +1207,56 @@ agents:
         var out = [];
         for (var i = 0; i < raw.length; i++) {
           var t = raw[i].trim();
-          if (t.length >= 12) { out.push(t); }
+          if (t.length >= 12 && !notProse(t)) { out.push(t); }
         }
         return out;
+      }
+
+      // notProse reports a candidate line that cannot be evidence for a claim, because
+      // there is no assertion in it: a line that is only TAGS (`<Grep pattern="…"/>`,
+      // `<tool_search>`, `</think>`), or one dense enough in punctuation to be CODE — a
+      // regex, a glob, a pattern — rather than a sentence.
+      //
+      // OBSERVED TWICE, on the first two passes run with verification enabled, and the
+      // second one is why this is not simply a tag check. A local chat model wrote its
+      // tool calls as prose instead of using the tool-use protocol, so the transcript
+      // carried both `<Grep pattern="tier.?test|postgres.*17|postgres.*14"/>` and, in a
+      // later reply, ``Try: `(?i)soak[-_]?suite|threadripper|soak[-_]*log[s]?` ``. Each
+      // became the span of a TRUE fact, and the judge then refused both — "the quote only
+      // shows a grep pattern", "the quote shows a search regex, not confirmation of the
+      // run" — so a true claim was withheld over mis-attached evidence, the direction
+      // that loses data.
+      //
+      // Both won because Dice overlap divides by the sizes of BOTH bags: a long
+      // supporting utterance is penalised while a short candidate whose every token hits
+      // is rewarded, and a pattern is a dense bag of exactly the claim's keywords with
+      // none of its meaning. A 6-token regex beat a 30-token sentence that said the thing
+      // outright.
+      //
+      // TAGS COME OFF FIRST, then density is measured on WHAT IS LEFT. The other order
+      // rejects a SHORT marked-up sentence, where the tags are a large share of the line:
+      // `<b>I live in Cluj-Napoca.</b>` measures 0.241 whole — over the threshold — and
+      // 0.091 stripped. The order is what keeps a real sentence that happens to wear a tag.
+      //
+      // ONLY ASCII PUNCTUATION COUNTS — a letter in any script, a digit and a space all
+      // read as prose. The obvious alternative, "anything that is not an ASCII letter is
+      // punctuation", scores Romanian at 0.42 and Japanese near 1.0, so it would call them
+      // code. This costs nothing and keeps the rule about punctuation rather than alphabet.
+      //
+      // It is not, today, load-bearing: `rawWords` tokenises on /[^a-z0-9]+/, so a
+      // non-Latin sentence yields almost no tokens and can never win a span in the first
+      // place ("Я запускаю loomcycle на TrueNAS" reduces to loomcycle+truenas). Widening
+      // the span pipeline past ASCII is a separate change, and this test is written so it
+      // will not have to be revisited as part of it.
+      //
+      // ⚠️ A prose-shaped COMMAND can still slip through: `$ psql -X -q -d loomcycle …`
+      // measures 0.188. The judge remains the backstop for what this misses, which is
+      // the arrangement everywhere else in this pipeline.
+      function notProse(s) {
+        var text = s.replace(/<[^>]*>/g, "").trim();
+        if (text === "") { return true; }
+        var punct = text.replace(/[^!-\/:-@\[-`{-~]/g, "").length;
+        return punct / text.length > CONFIG.max_span_punctuation;
       }
 
       // wordSet collapses a word list to a presence map. `=== true` on lookup

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -298,6 +298,19 @@ agents:
         // and every fact loses its evidence; too low and a fact gets handed an
         // unrelated sentence, which is worse than none because it looks like proof.
         min_span_overlap: 0.25,
+        // The share of ASCII punctuation above which a candidate span is CODE rather than
+        // a sentence, so it cannot be evidence. Like merge_min_subject_overlap and unlike
+        // the cosine bands, this is a property of prose rather than of a deployment's
+        // embedder, so it is a shipped constant and not a `memory.consolidation.*` key.
+        //
+        // 0.20 is MEASURED, on the spans of one live store: real prose ran 0.009 to 0.150
+        // (the top is a markdown bold heading, legitimate evidence), while the two
+        // pattern lines that each cost a true fact measured 0.259 and 0.382. Biased toward
+        // the LOW end of that window because the errors are not symmetric — too high
+        // admits a regex as evidence and the judge then withholds a TRUE fact, which loses
+        // data; too low leaves a fact with no span, which reads as unverified and stays
+        // fully visible.
+        max_span_punctuation: 0.20,
         // The SECOND signal an in-place rewrite has to clear, alongside the
         // similarity band — see mergeRefusal for why one number is not enough
         // authority to destroy a fact. It is the Dice overlap between the two
@@ -1194,9 +1207,56 @@ agents:
         var out = [];
         for (var i = 0; i < raw.length; i++) {
           var t = raw[i].trim();
-          if (t.length >= 12) { out.push(t); }
+          if (t.length >= 12 && !notProse(t)) { out.push(t); }
         }
         return out;
+      }
+
+      // notProse reports a candidate line that cannot be evidence for a claim, because
+      // there is no assertion in it: a line that is only TAGS (`<Grep pattern="…"/>`,
+      // `<tool_search>`, `</think>`), or one dense enough in punctuation to be CODE — a
+      // regex, a glob, a pattern — rather than a sentence.
+      //
+      // OBSERVED TWICE, on the first two passes run with verification enabled, and the
+      // second one is why this is not simply a tag check. A local chat model wrote its
+      // tool calls as prose instead of using the tool-use protocol, so the transcript
+      // carried both `<Grep pattern="tier.?test|postgres.*17|postgres.*14"/>` and, in a
+      // later reply, ``Try: `(?i)soak[-_]?suite|threadripper|soak[-_]*log[s]?` ``. Each
+      // became the span of a TRUE fact, and the judge then refused both — "the quote only
+      // shows a grep pattern", "the quote shows a search regex, not confirmation of the
+      // run" — so a true claim was withheld over mis-attached evidence, the direction
+      // that loses data.
+      //
+      // Both won because Dice overlap divides by the sizes of BOTH bags: a long
+      // supporting utterance is penalised while a short candidate whose every token hits
+      // is rewarded, and a pattern is a dense bag of exactly the claim's keywords with
+      // none of its meaning. A 6-token regex beat a 30-token sentence that said the thing
+      // outright.
+      //
+      // TAGS COME OFF FIRST, then density is measured on WHAT IS LEFT. The other order
+      // rejects a SHORT marked-up sentence, where the tags are a large share of the line:
+      // `<b>I live in Cluj-Napoca.</b>` measures 0.241 whole — over the threshold — and
+      // 0.091 stripped. The order is what keeps a real sentence that happens to wear a tag.
+      //
+      // ONLY ASCII PUNCTUATION COUNTS — a letter in any script, a digit and a space all
+      // read as prose. The obvious alternative, "anything that is not an ASCII letter is
+      // punctuation", scores Romanian at 0.42 and Japanese near 1.0, so it would call them
+      // code. This costs nothing and keeps the rule about punctuation rather than alphabet.
+      //
+      // It is not, today, load-bearing: `rawWords` tokenises on /[^a-z0-9]+/, so a
+      // non-Latin sentence yields almost no tokens and can never win a span in the first
+      // place ("Я запускаю loomcycle на TrueNAS" reduces to loomcycle+truenas). Widening
+      // the span pipeline past ASCII is a separate change, and this test is written so it
+      // will not have to be revisited as part of it.
+      //
+      // ⚠️ A prose-shaped COMMAND can still slip through: `$ psql -X -q -d loomcycle …`
+      // measures 0.188. The judge remains the backstop for what this misses, which is
+      // the arrangement everywhere else in this pipeline.
+      function notProse(s) {
+        var text = s.replace(/<[^>]*>/g, "").trim();
+        if (text === "") { return true; }
+        var punct = text.replace(/[^!-\/:-@\[-`{-~]/g, "").length;
+        return punct / text.length > CONFIG.max_span_punctuation;
       }
 
       // wordSet collapses a word list to a presence map. `=== true` on lookup

--- a/cmd/loomcycle/presets_memory_codejs_test.go
+++ b/cmd/loomcycle/presets_memory_codejs_test.go
@@ -2966,6 +2966,149 @@ func TestConsolidator_NoSupportingSentenceMeansNoSpan(t *testing.T) {
 	}
 }
 
+// TestConsolidator_APseudoToolCallLineIsNotEvidence.
+//
+// The exact failure observed on the first pass run with verification enabled, reduced to
+// a fixture. A local chat model wrote its tool calls as PROSE rather than using the
+// tool-use protocol, so the transcript legitimately carried
+// `<Grep pattern="tier.?test|postgres.*17|postgres.*14"/>` — and against a claim about
+// Postgres 17 that line BEAT the user's own sentence, because Dice overlap rewards a
+// short candidate where nearly every token hits and a regex pattern is a dense bag of the
+// claim's keywords with none of its meaning.
+//
+// The judge then refused the fact ("the quote only shows a grep pattern"), correctly, so
+// a TRUE claim was withheld over mis-attached evidence — the direction that loses data.
+// The user's sentence is present here and must win; nothing in the assertion depends on
+// the pattern being absent from the transcript.
+func TestConsolidator_APseudoToolCallLineIsNotEvidence(t *testing.T) {
+	f := newFakeToolset()
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	// The user's sentence is the LONG one it really was. That matters: Dice overlap
+	// divides by the sizes of both bags, so a long supporting sentence is penalised
+	// while a short dense one is rewarded — which is precisely how a 6-token regex
+	// pattern beat a 30-token utterance. Shortening this sentence makes the fix
+	// unnecessary and the test vacuous, which is what the first draft of it did.
+	// SHAPED LIKE THE REAL RENDERING (### speaker on its own line), not "user: <text>".
+	// The prefix form is not cosmetic: it hands the user's sentence the token "user",
+	// which this claim contains, so the sentence wins on a word the fixture invented and
+	// the test passes with the filter removed. The real renderer puts the label on its
+	// own line, where it is below the candidate length floor and joins nobody's bag.
+	f.transcript = "### user\n\n" +
+		"One more thing about my setup: I keep the loomcycle test database on Postgres 17 " +
+		"rather than 14, and I always verify the Postgres tier tests locally instead of " +
+		"trusting CI to run them.\n\n" +
+		"### assistant\n\n" +
+		"Looking at your workspace to see how the test database is configured...\n" +
+		"<tool_search>\n" +
+		"<Grep pattern=\"tier.?test|postgres.*17|postgres.*14\"/>\n" +
+		"</tool_search>\n\n"
+	f.factsJSON = `[{"text":"The user keeps the loomcycle test database on Postgres 17.",` +
+		`"class":"fact","type":"object","subject":"test database"}]`
+
+	runConsolidator(t, f)
+
+	var span, key string
+	for k, v := range f.chunkSpans {
+		if strings.Contains(k, "fact") && v != "" {
+			span, key = v, k
+		}
+	}
+	if span == "" {
+		t.Fatalf("no fact node carries a span (spans=%v)", f.chunkSpans)
+	}
+	if strings.Contains(span, "Grep") || strings.Contains(span, "pattern=") {
+		t.Errorf("chunk %q was handed a tool-call line as its evidence: %q — a query asserts "+
+			"nothing, and a judge shown this refuses a true fact", key, span)
+	}
+	if !strings.Contains(span, "Postgres 17") {
+		t.Errorf("span = %q, want the user's own sentence", span)
+	}
+	if !strings.Contains(f.transcript, span) {
+		t.Errorf("span %q is not in the transcript verbatim", span)
+	}
+}
+
+// TestConsolidator_NonProseLinesAreDroppedButMarkedUpProseIsNot.
+//
+// The filter strips tags and then asks whether what is LEFT reads as prose, rather than
+// testing whether the line looks tag-shaped — so a sentence wearing markup stays available
+// as evidence. Asserted because the cheap version of this fix (drop anything starting with
+// `<`) passes the test above while quietly costing spans for any transcript carrying HTML,
+// and because measuring density BEFORE stripping rejects this very sentence: a SHORT
+// marked-up line is mostly tag, so `<b>I live in Cluj-Napoca.</b>` measures 0.241 whole —
+// over the threshold — against 0.091 once the tags come off.
+func TestConsolidator_NonProseLinesAreDroppedButMarkedUpProseIsNot(t *testing.T) {
+	f := newFakeToolset()
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	// The ONLY line supporting the claim wears a tag on both ends.
+	// SHORT on purpose: the tags are a large share of the line, so this is the case that
+	// separates strip-then-measure from measure-then-strip (0.091 against 0.241).
+	f.transcript = "<tool_search>\n" +
+		"<b>I live in Cluj-Napoca.</b>\n" +
+		"</tool_search>"
+	f.factsJSON = `[{"text":"The user lives in Cluj-Napoca.","class":"fact",` +
+		`"type":"location","subject":"Cluj-Napoca"}]`
+
+	runConsolidator(t, f)
+
+	var span string
+	for k, v := range f.chunkSpans {
+		if strings.Contains(k, "fact") && v != "" {
+			span = v
+		}
+	}
+	if span == "" {
+		t.Fatalf("marked-up prose was dropped as if it were markup — the only supporting "+
+			"sentence in the transcript lost its span (spans=%v)", f.chunkSpans)
+	}
+	if !strings.Contains(span, "Cluj-Napoca") {
+		t.Errorf("span = %q, want the marked-up sentence", span)
+	}
+}
+
+// TestConsolidator_ARegexInProseIsNotEvidence.
+//
+// The SECOND live failure, and the reason this filter is not merely a tag check. On a
+// later pass the assistant replied with “Try: `(?i)soak[-_]?suite|threadripper|…` “ —
+// prose plus a regex, so tag-stripping leaves it untouched — and it still beat the user's
+// own sentence, because a dense pattern carrying the claim's keywords is exactly what Dice
+// overlap rewards. The judge refused the fact ("the quote shows a search regex, not
+// confirmation of the run"), withholding a true claim for the second time.
+//
+// The transcript here is the observed one, keeping the user's LONG utterance for the same
+// reason as its sibling above: shorten it and the user's sentence wins unaided.
+func TestConsolidator_ARegexInProseIsNotEvidence(t *testing.T) {
+	f := newFakeToolset()
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	f.transcript = "### user\n\n" +
+		"One more note on my tooling: I run the loomcycle soak suite on a Threadripper box " +
+		"rather than on the laptop, and I always keep the soak logs for a week " +
+		"afterwards.\n\n" +
+		"### assistant\n\n" +
+		"Try: `(?i)soak[-_]?suite|threadripper|soak[-_]*log[s]?`\n\n"
+	f.factsJSON = `[{"text":"The user runs the loomcycle soak suite on a Threadripper box.",` +
+		`"class":"fact","type":"object","subject":"soak suite"}]`
+
+	runConsolidator(t, f)
+
+	var span, key string
+	for k, v := range f.chunkSpans {
+		if strings.Contains(k, "fact") && v != "" {
+			span, key = v, k
+		}
+	}
+	if span == "" {
+		t.Fatalf("no fact node carries a span (spans=%v)", f.chunkSpans)
+	}
+	if strings.Contains(span, "(?i)") || strings.Contains(span, "[-_]") {
+		t.Errorf("chunk %q was handed a regex as its evidence: %q — a search pattern asserts "+
+			"nothing, and a judge shown this refuses a true fact", key, span)
+	}
+	if !strings.Contains(span, "Threadripper") {
+		t.Errorf("span = %q, want the user's own sentence", span)
+	}
+}
+
 // --------------------------------------------------------------- the judge
 //
 // Every scenario below drives the SHIPPED body. The judge is opt-in, so each one


### PR DESCRIPTION
## Why

Two consecutive passes run with verification enabled each withheld a **true** fact, because each had been handed a search pattern as its evidence:

| | first pass | second pass |
|---|---|---|
| **claim** | The user keeps the loomcycle test database on Postgres 17. | The user runs the loomcycle soak suite on a Threadripper box. |
| **span** | `<Grep pattern="tier.?test\|postgres.*17\|postgres.*14"/>` | ``Try: `(?i)soak[-_]?suite\|threadripper\|soak[-_]*log[s]?` `` |
| **judge** | "The quote only shows a grep pattern, not the actual database location." | "The quote shows a search regex, not confirmation of the run." |

The judge was right both times. The bug is upstream of it.

A local chat model wrote its tool calls as **prose** instead of using the tool-use protocol, so the transcript legitimately carried both lines. (History's `format:conversation` excludes real tool events *by type* — this was assistant **text**, which is content, emitted verbatim by design.)

**Why they won** is the part worth stating, and it is what makes the second case different from the first: **Dice overlap divides by the sizes of both bags**, so a long supporting utterance is penalised while a short candidate whose every token hits is rewarded — and a pattern is a dense bag of exactly the claim's keywords with none of its meaning. A 6-token regex beat a 30-token sentence that said the thing outright: **0.429 against 0.370**, measured.

Net effect: a true claim withheld over mis-attached evidence — the direction that loses data — twice on the first two live passes.

## What

`splitSentences` no longer offers a candidate with no assertion in it: one that is **only tags**, or one **dense enough in punctuation to be code** rather than a sentence. A fact left with no other candidate gets **no span** — unverified and fully visible, rather than refuted and hidden. Same trade the overlap floor already makes, for the reason the bundle already gives: *"a fact gets handed an unrelated sentence, which is worse than none because it looks like proof."*

Three decisions inside it, each measured and each with a test that fails if it is reversed:

- **Tags come off first**, then density is measured on what is left — a *short* marked-up sentence is mostly tag: `<b>I live in Cluj-Napoca.</b>` is 0.241 whole and 0.091 stripped.
- **0.20**, from the spans of one live store: real prose ran 0.009–0.150 (the top is a markdown bold heading, legitimate evidence) against 0.259 and 0.382 for the two pattern lines. Biased low — too high admits a pattern and withholds a true fact; too low only leaves a fact unverified and visible.
- **Only ASCII punctuation counts**, so the rule is about punctuation, not alphabet. Documented as *not* load-bearing today: `rawWords` tokenises on `/[^a-z0-9]+/`, so a non-Latin sentence can never win a span anyway. That separate limit is named where someone widening it will see it.

This does **not** re-derive spans already stored. Both facts above stay withheld on the live store until something re-judges them; the fix stops new ones.

## What was tested

`go test ./...` clean — 91 packages, exit 0.

Tests drive the shipped code-js body through the real agent loop. Each probe reverses one decision:

| probe | pseudo-tool-call | regex-in-prose | marked-up prose |
|---|---|---|---|
| no filter (pre-fix) | **FAIL** | **FAIL** | pass |
| drop anything tag-shaped | pass | **FAIL** | **FAIL** |
| density measured before stripping | pass | pass | **FAIL** |
| shipped | pass | pass | pass |

**Two fixture traps the probes caught, both recorded in comments** because tidying either is the obvious next thing someone would do:

1. The fixtures are shaped like the **actual** rendering (`### speaker` on its own line). Written as `"user: <text>"`, the prefix hands the user's sentence the token **"user"** — which one of these claims contains — so the sentence wins on a word the fixture invented and the test passes against unfixed code.
2. Both keep the user's real **long** utterance. Shortening it lets the sentence win on Dice unaided, which is what made my first draft of the primary test vacuous.

A test asserting that non-Latin prose keeps its span was written and then **removed**: it passed against every wrong implementation, because the ASCII tokeniser means there was never a span to keep. Asserting nothing is worse than not asserting.

### Note

The branch was force-pushed once after opening, before any review, to amend the original commit rather than stack a correction on it — the fix widened from "tags only" to the measured density rule once the second live failure appeared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8