### PR TITLE
feat(memory): Activity — a live tail of the change feed (RFC CF phase 7)

### DIFF
--- a/internal/api/http/memory_changes.go
+++ b/internal/api/http/memory_changes.go
@@ -21,6 +21,19 @@ import (
 
 const memoryChangesPollInterval = 250 * time.Millisecond
 
+// changeFeedCapturer is implemented by the CDC store decorator, which is in the
+// write path exactly when LOOMCYCLE_MEMORY_CHANGES_ENABLED. Asking the store is
+// what makes the answer below true by construction rather than by a second
+// reading of the env var — the two could disagree, and the one that matters is
+// whether writes are actually being captured.
+type changeFeedCapturer interface{ CapturesChanges() bool }
+
+// changeFeedEnabled reports whether writes to this store land in the feed.
+func (s *Server) changeFeedEnabled() bool {
+	c, ok := s.store.(changeFeedCapturer)
+	return ok && c.CapturesChanges()
+}
+
 func (s *Server) handleMemoryChanges(w http.ResponseWriter, r *http.Request) {
 	s.streamMemoryChanges(w, r, false)
 }
@@ -53,6 +66,26 @@ func (s *Server) streamMemoryChanges(w http.ResponseWriter, r *http.Request, doc
 		return
 	}
 	stream.start()
+
+	// THE OPENING FRAME SAYS WHETHER THE FEED IS ON, and it is here because of what
+	// this stream does otherwise. With LOOMCYCLE_MEMORY_CHANGES_ENABLED unset the
+	// table is never written, so the connection succeeds, keepalives flow, and no
+	// change frame ever arrives — which is indistinguishable from a healthy feed over
+	// a quiet store. A reader watching for "is the pass doing anything" would wait
+	// forever on a misconfiguration and conclude nothing is happening.
+	//
+	// Sent on the channel that would otherwise idle rather than added to a separate
+	// report, so a client cannot hold a stale answer while connected, and so the
+	// statement comes from the code that would be doing the capturing.
+	//
+	// Additive: an existing subscriber switches on the change TYPE and ignores an
+	// event name it does not know (the payload deliberately carries no `type`, so a
+	// client that backfills from the event name sees `feed`).
+	stream.sendRaw("feed", map[string]any{
+		"enabled": s.changeFeedEnabled(),
+		"since":   cursor,
+	})
+
 	stream.startKeepalive(r.Context(), s.cfg.Env.SSEKeepaliveInterval)
 
 	ticker := time.NewTicker(memoryChangesPollInterval)

--- a/internal/api/http/memory_changes_test.go
+++ b/internal/api/http/memory_changes_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/cdc"
 	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
 )
 
@@ -72,4 +73,74 @@ func runSSEOnce(t *testing.T, h http.HandlerFunc, path string) string {
 	rec := httptest.NewRecorder()
 	h(rec, req)
 	return rec.Body.String()
+}
+
+// TestMemoryChanges_OpeningFrameSaysWhetherTheFeedIsOn.
+//
+// With LOOMCYCLE_MEMORY_CHANGES_ENABLED unset, nothing writes the change table, so
+// the stream connects, keepalives flow, and no change frame ever arrives — which
+// looks exactly like a healthy feed over a quiet store. A reader watching for "is
+// the pass doing anything" would wait forever on a misconfiguration and conclude
+// the answer was no.
+//
+// The answer comes from the STORE, not from re-reading the env var: the CDC
+// decorator is in the write path exactly when the feed is on, so its presence
+// cannot disagree with whether writes are actually captured.
+func TestMemoryChanges_OpeningFrameSaysWhetherTheFeedIsOn(t *testing.T) {
+	raw, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer raw.Close()
+
+	for _, tc := range []struct {
+		name  string
+		store store.Store
+		want  string
+	}{
+		// A plain store does not implement CapturesChanges at all.
+		{"feed off", raw, `"enabled":false`},
+		{"feed on", cdc.Wrap(raw, nil), `"enabled":true`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := &Server{store: tc.store, cfg: &config.Config{}}
+			for path, h := range map[string]http.HandlerFunc{
+				"/v1/_memory/changes":   srv.handleMemoryChanges,
+				"/v1/_document/changes": srv.handleDocumentChanges,
+			} {
+				body := runSSEOnce(t, h, path)
+				if !strings.Contains(body, "event: feed") {
+					t.Errorf("%s: no opening feed frame — a reader cannot tell a disabled feed "+
+						"from a quiet one:\n%s", path, body)
+				}
+				if !strings.Contains(body, tc.want) {
+					t.Errorf("%s: opening frame missing %s:\n%s", path, tc.want, body)
+				}
+			}
+		})
+	}
+}
+
+// TestMemoryChanges_OpeningFrameEchoesTheCursor.
+//
+// A reader resuming with ?since=N needs to know the server accepted that cursor.
+// Without it, a `since` the server silently ignored (unparseable, negative) looks
+// like a feed with nothing new, and the reader re-reads from 0 or waits forever
+// depending on which way it guessed.
+func TestMemoryChanges_OpeningFrameEchoesTheCursor(t *testing.T) {
+	raw, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer raw.Close()
+	srv := &Server{store: cdc.Wrap(raw, nil), cfg: &config.Config{}}
+
+	if body := runSSEOnce(t, srv.handleMemoryChanges, "/v1/_memory/changes?since=42"); !strings.Contains(body, `"since":42`) {
+		t.Errorf("opening frame did not echo the accepted cursor:\n%s", body)
+	}
+	// A cursor the server REFUSED must report as the value actually in use, not as
+	// the one that was asked for.
+	if body := runSSEOnce(t, srv.handleMemoryChanges, "/v1/_memory/changes?since=-7"); !strings.Contains(body, `"since":0`) {
+		t.Errorf("a rejected cursor must report the cursor in force (0):\n%s", body)
+	}
 }

--- a/internal/store/cdc/cdc.go
+++ b/internal/store/cdc/cdc.go
@@ -42,6 +42,17 @@ func Wrap(base store.Store, logf func(format string, args ...any)) *Store {
 
 var _ store.Store = (*Store)(nil)
 
+// CapturesChanges reports that writes through this store land in the change
+// feed. It exists so a reader of the feed can be TOLD the feed is on, rather
+// than inferring it from an empty stream.
+//
+// Asked of the store rather than re-read from LOOMCYCLE_MEMORY_CHANGES_ENABLED,
+// because this decorator IS the mechanism: it is in the path exactly when the
+// feed is on, so its presence cannot disagree with reality the way a second
+// reading of an env var can. A plain store answers false by not implementing
+// the method at all.
+func (c *Store) CapturesChanges() bool { return true }
+
 // Unwrap returns the wrapped store. Call sites that need a CONCRETE backend
 // (e.g. the postgres cluster-coordination wiring type-asserts *postgres.Store)
 // must unwrap through this — see cmd/loomcycle's asPostgresStore.

--- a/packages/memory-view/package-lock.json
+++ b/packages/memory-view/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@loomcycle/memory-view",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@loomcycle/memory-view",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@loomcycle/client": "^1.55.0",

--- a/packages/memory-view/package.json
+++ b/packages/memory-view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loomcycle/memory-view",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "type": "module",
   "description": "Embeddable React memory browser for the loomcycle agentic runtime (RFC BV) \u2014 a themeable, standalone k/v Vector Memory console (with a fact viewer + unified semantic search).",
   "license": "Apache-2.0",

--- a/packages/memory-view/src/MemoryView.tsx
+++ b/packages/memory-view/src/MemoryView.tsx
@@ -7,16 +7,18 @@ import {
 import MemoryConsole from "./components/MemoryConsole";
 import FactViewer from "./components/FactViewer";
 import SearchPanel from "./components/SearchPanel";
+import ChangeFeedPanel from "./components/ChangeFeedPanel";
 
 // MemoryView is the standalone, self-styling root for the Memory view. It hosts
 // three tabs over one injected data layer:
 //   - Entries : the k/v Vector Memory console (scope/scope_id/key browser + editor).
 //   - Facts   : the entity-tier fact browser (bi-temporal, supersession chain).
 //   - Search  : off-run unified semantic search across k/v + document chunks.
+//   - Activity: a live tail of the value-free change feed — coordinates only.
 // Mount it on its own page; it resolves its own data layer + wraps in the
 // themeable `.loomcycle-memory-view` root. Styles ship separately:
 // `import "@loomcycle/memory-view/styles.css"`.
-export type MemoryTab = "entries" | "facts" | "search";
+export type MemoryTab = "entries" | "facts" | "search" | "activity";
 
 export interface MemoryViewProps extends MemoryDataSource {
   /** Theming. Set → the root carries data-theme; omit → inherit an ancestor's
@@ -69,11 +71,15 @@ function MemoryTabs({
         <TabButton tab="search" active={tab} onSelect={setTab}>
           Search
         </TabButton>
+        <TabButton tab="activity" active={tab} onSelect={setTab}>
+          Activity
+        </TabButton>
       </div>
       <div className="memory-view-tabpanel">
         {tab === "entries" && <MemoryConsole />}
         {tab === "facts" && <FactViewer onRunConsolidation={onRunConsolidation} />}
         {tab === "search" && <SearchPanel />}
+        {tab === "activity" && <ChangeFeedPanel />}
       </div>
     </>
   );

--- a/packages/memory-view/src/components/ChangeFeedPanel.tsx
+++ b/packages/memory-view/src/components/ChangeFeedPanel.tsx
@@ -1,0 +1,294 @@
+import { useEffect, useMemo, useState } from "react";
+import { useMemoryData } from "../lib/dataLayer";
+import {
+  appendChange,
+  describeChange,
+  emptyBuffer,
+  isDocumentChange,
+  matchesFilter,
+  CHANGE_BUFFER_CAP,
+  CHANGE_FEED_ENV,
+  type ChangeBuffer,
+  type ChangeFamily,
+  type ChangeFilter,
+  type MemoryChangeRow,
+} from "../lib/changeFeed";
+
+// ChangeFeedPanel — a live tail of the value-free change feed (RFC CF §9).
+//
+// It answers one question an operator otherwise cannot: IS ANYTHING HAPPENING. A
+// consolidation pass takes minutes and reports only at the end, so between starting
+// it and reading its summary there is nothing to look at. This is that.
+//
+// It shows COORDINATES, never values, because that is all the feed carries — a
+// deliberate privacy property of the endpoint. There is no "value" column here to
+// leave conspicuously empty.
+//
+// THREE STATES, KEPT DISTINCT, and this is the part that earns the component:
+//
+//   unsupported  the data layer has no streamChanges (a host-supplied layer, or a
+//                bare `client` with no base URL for SSE). Nothing will ever arrive
+//                and the runtime is not the reason.
+//   disabled     the runtime answered `enabled: false` — the feed exists but
+//                LOOMCYCLE_MEMORY_CHANGES_ENABLED is unset, so no write is being
+//                captured. Nothing will ever arrive and the fix is one env var.
+//   live         connected and capturing. An empty list here genuinely means
+//                nothing has changed.
+//
+// Collapsing those into "no rows yet" is the failure this panel is written against:
+// all three look identical, and two of them are misconfigurations that a reader
+// would instead take as "the pass is doing nothing".
+
+const FAMILIES: ChangeFamily[] = ["memory", "documents"];
+
+type FeedState = "connecting" | "live" | "disabled" | "unsupported" | "error";
+
+export interface ChangeFeedPanelProps {
+  /** Pre-narrow the tail to one scope_id (the console's current selection). The feed
+   *  is TENANT-WIDE, so on a shared deployment an unfiltered tail is every user's
+   *  activity at once. */
+  scopeId?: string;
+}
+
+export default function ChangeFeedPanel({ scopeId }: ChangeFeedPanelProps) {
+  const data = useMemoryData();
+  const supported = typeof data.streamChanges === "function";
+
+  const [buf, setBuf] = useState<ChangeBuffer>(emptyBuffer);
+  const [state, setState] = useState<FeedState>(
+    supported ? "connecting" : "unsupported",
+  );
+  const [err, setErr] = useState<string>("");
+  const [paused, setPaused] = useState(false);
+
+  const [filter, setFilter] = useState<ChangeFilter>({
+    family: "",
+    scope: "",
+    scopeId: scopeId ?? "",
+    type: "",
+  });
+
+  // The effect below depends on `paused` and NOT on the filter: filtering is a VIEW
+  // over what has already arrived, so re-opening the stream on a filter change would
+  // silently discard rows the operator had seen and reset the counters they were
+  // reading.
+  useEffect(() => {
+    if (!supported || paused) return;
+    const ac = new AbortController();
+    let cancelled = false;
+    // Each family is its own endpoint, so both are tailed and merged here. A single
+    // status is enough: the two share the flag, and reporting per-family would
+    // invite a UI that shows one half live and the other silent for no real reason.
+    const pumps = FAMILIES.map(async (family) => {
+      for await (const frame of data.streamChanges!(family, {
+        signal: ac.signal,
+      })) {
+        if (cancelled) return;
+        if (frame.kind === "status") {
+          setState(frame.status.enabled ? "live" : "disabled");
+          continue;
+        }
+        setBuf((b) => appendChange(b, frame.change));
+      }
+    });
+    Promise.all(pumps).catch((e: unknown) => {
+      if (cancelled || ac.signal.aborted) return;
+      setState("error");
+      setErr(e instanceof Error ? e.message : String(e));
+    });
+    return () => {
+      cancelled = true;
+      ac.abort();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [supported, paused, data]);
+
+  const visible = useMemo(
+    () => buf.rows.filter((r) => matchesFilter(r, filter)),
+    [buf, filter],
+  );
+
+  return (
+    <div className="change-feed">
+      <div className="change-feed-head">
+        <FeedBadge state={state} />
+        <div className="change-feed-filters">
+          <select
+            value={filter.family}
+            onChange={(e) =>
+              setFilter((f) => ({
+                ...f,
+                family: e.target.value as ChangeFilter["family"],
+              }))
+            }
+            aria-label="family"
+          >
+            <option value="">both families</option>
+            <option value="memory">memory</option>
+            <option value="documents">documents</option>
+          </select>
+          <select
+            value={filter.scope}
+            onChange={(e) =>
+              setFilter((f) => ({
+                ...f,
+                scope: e.target.value as ChangeFilter["scope"],
+              }))
+            }
+            aria-label="scope"
+          >
+            <option value="">any scope</option>
+            <option value="agent">agent</option>
+            <option value="user">user</option>
+            <option value="tenant">tenant</option>
+          </select>
+          <input
+            className="change-feed-scopeid"
+            placeholder="scope_id contains…"
+            value={filter.scopeId}
+            onChange={(e) =>
+              setFilter((f) => ({ ...f, scopeId: e.target.value }))
+            }
+            aria-label="scope_id filter"
+          />
+          <button
+            type="button"
+            className="change-feed-btn"
+            onClick={() => setPaused((p) => !p)}
+            disabled={!supported || state === "disabled"}
+          >
+            {paused ? "resume" : "pause"}
+          </button>
+          <button
+            type="button"
+            className="change-feed-btn"
+            onClick={() => setBuf(emptyBuffer)}
+            disabled={!buf.rows.length}
+          >
+            clear
+          </button>
+        </div>
+      </div>
+
+      {state === "unsupported" && (
+        <div className="change-feed-note">
+          This build cannot tail the change feed — it needs a{" "}
+          <code>connection</code> (base URL + fetch), which a prebuilt client or
+          a custom data layer does not expose. Nothing will arrive here; the
+          runtime is not the reason.
+        </div>
+      )}
+      {state === "disabled" && (
+        <div className="change-feed-note">
+          The change feed is <strong>off</strong> in this runtime, so no write
+          is being recorded and nothing will ever arrive here. Set{" "}
+          <code>{CHANGE_FEED_ENV}=1</code> and restart to turn it on.
+        </div>
+      )}
+      {state === "error" && <div className="err">{err}</div>}
+
+      <Counters buf={buf} shown={visible.length} state={state} />
+
+      {visible.length === 0 ? (
+        <div className="empty">
+          {state === "live"
+            ? buf.rows.length
+              ? "No change matches these filters."
+              : "Connected. Nothing has changed yet."
+            : "—"}
+        </div>
+      ) : (
+        <table className="change-feed-table">
+          <thead>
+            <tr>
+              <th>seq</th>
+              <th>when</th>
+              <th>type</th>
+              <th>scope</th>
+              <th>coordinate</th>
+            </tr>
+          </thead>
+          <tbody>
+            {visible.map((r) => (
+              <ChangeRow key={`${r.type}:${r.seq}`} row={r} />
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+function ChangeRow({ row }: { row: MemoryChangeRow }) {
+  const deleted = row.type.endsWith(".delete") || row.type.endsWith(".deleted");
+  return (
+    <tr>
+      <td className="change-feed-seq">{row.seq}</td>
+      <td className="change-feed-at">{formatAt(row.at)}</td>
+      <td>
+        <span
+          className={
+            "change-feed-type" +
+            (deleted ? " change-feed-type-delete" : "") +
+            (isDocumentChange(row.type) ? " change-feed-type-doc" : "")
+          }
+        >
+          {row.type}
+        </span>
+      </td>
+      <td className="change-feed-scope">
+        {row.scope}
+        {row.scope_id ? `/${row.scope_id}` : ""}
+      </td>
+      <td className="change-feed-coord">{describeChange(row)}</td>
+    </tr>
+  );
+}
+
+function FeedBadge({ state }: { state: FeedState }) {
+  const label: Record<FeedState, string> = {
+    connecting: "connecting…",
+    live: "live",
+    disabled: "feed off",
+    unsupported: "unavailable",
+    error: "error",
+  };
+  return (
+    <span className={`change-feed-badge change-feed-badge-${state}`}>
+      {label[state]}
+    </span>
+  );
+}
+
+// Counters states what is on screen against what arrived, and names the bound when
+// it bit. A tail that quietly forgets makes "showing 200" read as "200 things
+// happened" — the same silent-truncation trap as a capped scan reporting a clean
+// zero.
+function Counters({
+  buf,
+  shown,
+  state,
+}: {
+  buf: ChangeBuffer;
+  shown: number;
+  state: FeedState;
+}) {
+  if (state !== "live" && buf.seen === 0) return null;
+  const parts = [`${shown} shown`];
+  if (buf.seen !== shown) parts.push(`${buf.seen} received`);
+  if (buf.dropped > 0) {
+    parts.push(
+      `${buf.dropped} older dropped (this view keeps the latest ${CHANGE_BUFFER_CAP})`,
+    );
+  }
+  return <div className="change-feed-counters">{parts.join(" · ")}</div>;
+}
+
+// formatAt shows the wall-clock time only. A change feed is read for ordering and
+// recency, and a full RFC3339 stamp per row crowds out the coordinate that matters.
+// An unparseable value is shown verbatim rather than as "Invalid Date".
+function formatAt(at: string): string {
+  const d = new Date(at);
+  if (Number.isNaN(d.getTime())) return at;
+  return d.toLocaleTimeString();
+}

--- a/packages/memory-view/src/components/MemoryViewRoot.tsx
+++ b/packages/memory-view/src/components/MemoryViewRoot.tsx
@@ -4,6 +4,7 @@ import { createLoomcycleClient, type Connection } from "../lib/createClient";
 import {
   MemoryDataProvider,
   dataLayerFromClient,
+  dataLayerFromConnection,
   type MemoryDataLayer,
 } from "../lib/dataLayer";
 
@@ -28,7 +29,9 @@ export function useResolvedDataLayer(src: MemoryDataSource): MemoryDataLayer | n
   return useMemo<MemoryDataLayer | null>(() => {
     if (dataLayer) return dataLayer;
     if (client) return dataLayerFromClient(client);
-    if (connection) return dataLayerFromClient(createLoomcycleClient(connection));
+    // The connection path gets the change-feed tail too — it is the only path
+    // holding the base URL + fetch that SSE needs (see dataLayerFromConnection).
+    if (connection) return dataLayerFromConnection(connection, createLoomcycleClient(connection));
     return null;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dataLayer, client, connection?.baseUrl, connection?.token, connection?.fetch]);

--- a/packages/memory-view/src/index.ts
+++ b/packages/memory-view/src/index.ts
@@ -16,6 +16,32 @@ export { default as SearchPanel } from "./components/SearchPanel";
 export type { SearchPanelProps } from "./components/SearchPanel";
 export { default as ChunkDetailPanel } from "./components/ChunkDetailPanel";
 export type { ChunkDetailPanelProps } from "./components/ChunkDetailPanel";
+export { default as ChangeFeedPanel } from "./components/ChangeFeedPanel";
+export type { ChangeFeedPanelProps } from "./components/ChangeFeedPanel";
+
+// The change-feed tail's transport + pure helpers, exported because a host with its
+// own layout still wants the framing rules (a status frame that cannot be read is NOT
+// enabled; a bounded buffer reports what it dropped) rather than a looser second copy.
+export {
+  tailChanges,
+  classifyFrame,
+  appendChange,
+  matchesFilter,
+  describeChange,
+  emptyBuffer,
+  isDocumentChange,
+  CHANGE_BUFFER_CAP,
+  CHANGE_FEED_ENV,
+  CHANGE_FEED_PATHS,
+} from "./lib/changeFeed";
+export type {
+  ChangeFamily,
+  ChangeFeedFrame,
+  ChangeFeedStatus,
+  ChangeFilter,
+  ChangeBuffer,
+  MemoryChangeRow,
+} from "./lib/changeFeed";
 
 // Public data types (the shapes the console renders / the data layer produces).
 export type {
@@ -53,7 +79,7 @@ export type { Connection } from "./lib/createClient";
 
 // The data-layer seam: inject a custom implementation, or build one from a
 // @loomcycle/client instance.
-export { dataLayerFromClient } from "./lib/dataLayer";
+export { dataLayerFromClient, dataLayerFromConnection } from "./lib/dataLayer";
 export type { MemoryDataLayer, FactListOptions } from "./lib/dataLayer";
 
 // The shared data-source contract (connection | client | dataLayer), for hosts

--- a/packages/memory-view/src/lib/changeFeed.test.ts
+++ b/packages/memory-view/src/lib/changeFeed.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyFrame,
+  readSSE,
+  appendChange,
+  emptyBuffer,
+  matchesFilter,
+  describeChange,
+  tailChanges,
+  type MemoryChangeRow,
+} from "./changeFeed";
+
+const row = (o: Partial<MemoryChangeRow> = {}): MemoryChangeRow => ({
+  seq: 1,
+  type: "memory.set",
+  scope: "user",
+  scope_id: "alice",
+  key: "memory/fact/x",
+  at: "2026-08-17T12:00:00Z",
+  ...o,
+});
+
+describe("classifyFrame", () => {
+  it("reads the opening status frame", () => {
+    expect(classifyFrame("feed", '{"enabled":true,"since":42}')).toEqual({
+      kind: "status",
+      status: { enabled: true, since: 42 },
+    });
+    expect(classifyFrame("feed", '{"enabled":false,"since":0}')).toEqual({
+      kind: "status",
+      status: { enabled: false, since: 0 },
+    });
+  });
+
+  // A status frame that cannot be read must NOT be treated as enabled. Defaulting
+  // permissively would reinstate the exact ambiguity the frame exists to remove: a
+  // disabled feed reading as a quiet one.
+  it("refuses a status frame with no readable `enabled`", () => {
+    expect(classifyFrame("feed", "{}")).toBeNull();
+    expect(classifyFrame("feed", '{"enabled":"yes"}')).toBeNull();
+    expect(classifyFrame("feed", "not json")).toBeNull();
+  });
+
+  it("reads a change coordinate and ignores unknown event names", () => {
+    const f = classifyFrame("change", JSON.stringify(row({ seq: 7 })));
+    expect(f).toEqual({
+      kind: "change",
+      change: expect.objectContaining({ seq: 7 }),
+    });
+    expect(classifyFrame("something-else", "{}")).toBeNull();
+  });
+
+  // The status payload deliberately carries no `type`, so a parser that
+  // discriminated on the BODY would have to guess. The event name is authoritative.
+  it("discriminates on the event name, not the payload shape", () => {
+    expect(classifyFrame("feed", '{"enabled":true}')?.kind).toBe("status");
+    expect(classifyFrame("change", JSON.stringify(row()))?.kind).toBe("change");
+  });
+});
+
+describe("readSSE", () => {
+  const streamOf = (text: string): ReadableStream<Uint8Array> => {
+    const bytes = new TextEncoder().encode(text);
+    return new ReadableStream({
+      start(c) {
+        // Deliberately split mid-frame: a real stream arrives in arbitrary chunks,
+        // and a parser that only works on whole frames passes a naive test and
+        // loses data in the browser.
+        c.enqueue(bytes.slice(0, Math.floor(bytes.length / 2)));
+        c.enqueue(bytes.slice(Math.floor(bytes.length / 2)));
+        c.close();
+      },
+    });
+  };
+
+  it("yields event/data pairs across chunk boundaries and skips keepalives", async () => {
+    const text =
+      'event: feed\ndata: {"enabled":true}\n\n' +
+      ": keepalive\n\n" +
+      'event: change\ndata: {"seq":1}\n\n';
+    const got: { event: string; data: string }[] = [];
+    for await (const f of readSSE(streamOf(text))) got.push(f);
+    expect(got).toEqual([
+      { event: "feed", data: '{"enabled":true}' },
+      { event: "change", data: '{"seq":1}' },
+    ]);
+  });
+});
+
+describe("appendChange", () => {
+  it("keeps newest first, bounds the list, and COUNTS what it dropped", () => {
+    let buf = emptyBuffer;
+    for (let i = 1; i <= 5; i++) buf = appendChange(buf, row({ seq: i }), 3);
+    expect(buf.rows.map((r) => r.seq)).toEqual([5, 4, 3]);
+    // seen is every row that arrived; dropped is what the cap cost. Without both,
+    // "showing 3" reads as "3 things happened".
+    expect(buf.seen).toBe(5);
+    expect(buf.dropped).toBe(2);
+  });
+
+  it("dedupes on seq so a reconnect does not inflate the count", () => {
+    let buf = appendChange(emptyBuffer, row({ seq: 9 }));
+    buf = appendChange(buf, row({ seq: 9 }));
+    expect(buf.rows).toHaveLength(1);
+    expect(buf.seen).toBe(1);
+  });
+
+  // The two families share a seq space in the runtime's table but arrive on
+  // SEPARATE streams, so the same seq can legitimately appear once per family.
+  it("does not treat two families' rows as duplicates", () => {
+    let buf = appendChange(emptyBuffer, row({ seq: 3, type: "memory.set" }));
+    buf = appendChange(buf, row({ seq: 3, type: "document.chunk.updated" }));
+    expect(buf.rows).toHaveLength(2);
+  });
+});
+
+describe("matchesFilter", () => {
+  it("splits the families", () => {
+    expect(
+      matchesFilter(row({ type: "memory.set" }), { family: "memory" }),
+    ).toBe(true);
+    expect(
+      matchesFilter(row({ type: "memory.set" }), { family: "documents" }),
+    ).toBe(false);
+    expect(
+      matchesFilter(row({ type: "document.chunk.updated" }), {
+        family: "documents",
+      }),
+    ).toBe(true);
+  });
+
+  it("matches scope_id by substring, case-insensitively", () => {
+    expect(matchesFilter(row({ scope_id: "alice" }), { scopeId: "ALI" })).toBe(
+      true,
+    );
+    expect(matchesFilter(row({ scope_id: "alice" }), { scopeId: "bob" })).toBe(
+      false,
+    );
+  });
+
+  it("an empty filter matches everything", () => {
+    expect(matchesFilter(row(), {})).toBe(true);
+    expect(
+      matchesFilter(row(), { family: "", scope: "", scopeId: "", type: "" }),
+    ).toBe(true);
+  });
+});
+
+describe("describeChange", () => {
+  it("names the coordinate, and never implies a value", () => {
+    expect(describeChange(row({ key: "memory/fact/x" }))).toBe("memory/fact/x");
+    expect(
+      describeChange(row({ key: undefined, chunk_id: "abcdef0123456789" })),
+    ).toBe("chunk abcdef012345");
+    expect(
+      describeChange(
+        row({
+          key: undefined,
+          chunk_id: undefined,
+          type: "memory.scope_deleted",
+        }),
+      ),
+    ).toBe("(whole scope)");
+  });
+});
+
+describe("tailChanges (transport)", () => {
+  const sse = (text: string) =>
+    new Response(new Blob([text]).stream(), {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    });
+
+  it("hits the right path per family, threads since, and yields typed frames", async () => {
+    const calls: { url: string; headers: Record<string, string> }[] = [];
+    const fetchImpl = (async (url: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({
+        url: String(url),
+        headers: (init?.headers ?? {}) as Record<string, string>,
+      });
+      return sse('event: feed\ndata: {"enabled":true,"since":5}\n\n');
+    }) as typeof fetch;
+
+    const conn = {
+      baseUrl: "https://rt.example",
+      token: "T",
+      fetch: fetchImpl,
+    };
+    for await (const f of tailChanges(conn, "memory", { since: 5 })) {
+      expect(f).toEqual({
+        kind: "status",
+        status: { enabled: true, since: 5 },
+      });
+    }
+    for await (const _ of tailChanges(conn, "documents")) void _;
+
+    expect(calls[0].url).toBe("https://rt.example/v1/_memory/changes?since=5");
+    // No `since` → no query string at all, rather than `?since=0`: 0 is the server's
+    // own default and an explicit one only invites a reader to think it means something.
+    expect(calls[1].url).toBe("https://rt.example/v1/_document/changes");
+    expect(calls[0].headers.Authorization).toBe("Bearer T");
+    // BOTH media types, or a strict proxy in front of the runtime 406s the request —
+    // the success path is event-stream and the error path is JSON.
+    expect(calls[0].headers.Accept).toBe("text/event-stream, application/json");
+  });
+
+  it("surfaces the runtime's error body, not just the status", async () => {
+    const fetchImpl = (async () =>
+      new Response("change feed requires a persistence backend", {
+        status: 503,
+      })) as typeof fetch;
+    await expect(async () => {
+      for await (const _ of tailChanges(
+        { baseUrl: "", fetch: fetchImpl },
+        "memory",
+      ))
+        void _;
+    }).rejects.toThrow(/503: change feed requires a persistence backend/);
+  });
+
+  it("omits Authorization when there is no token (open mode / cookie auth)", async () => {
+    let seen: Record<string, string> = {};
+    const fetchImpl = (async (_u: RequestInfo | URL, init?: RequestInit) => {
+      seen = (init?.headers ?? {}) as Record<string, string>;
+      return sse("");
+    }) as typeof fetch;
+    for await (const _ of tailChanges(
+      { baseUrl: "", fetch: fetchImpl },
+      "memory",
+    ))
+      void _;
+    expect(seen.Authorization).toBeUndefined();
+  });
+});

--- a/packages/memory-view/src/lib/changeFeed.ts
+++ b/packages/memory-view/src/lib/changeFeed.ts
@@ -1,0 +1,268 @@
+// The change-feed tail (RFC CF §9).
+//
+// `GET /v1/_memory/changes` and `/v1/_document/changes` are SSE feeds of
+// VALUE-FREE change coordinates: each frame names what changed — scope, scope_id,
+// key or chunk_id — and never the value. A reader that wants content pulls it
+// through the data API. That is a privacy property, not an oversight, so nothing
+// here invents a "value" column to fill.
+//
+// WHY THIS LIVES IN THE PACKAGE rather than behind a client method: consuming SSE
+// needs the base URL and the fetch the host configured, which the `connection`
+// data source has and a bare `client` does not. Wiring it here means the shipping
+// console works today; the day @loomcycle/client grows a change-feed method, the
+// data layer built from a client can implement the same optional hook and this
+// file becomes its transport rather than the only one.
+
+/** One change coordinate, exactly as the runtime's store.MemoryChange serialises. */
+export interface MemoryChangeRow {
+  seq: number;
+  tenant?: string;
+  type:
+    | "memory.set"
+    | "memory.delete"
+    | "memory.scope_deleted"
+    | "document.chunk.updated"
+    | "document.chunk.deleted";
+  scope: "agent" | "user" | "tenant";
+  scope_id: string;
+  key?: string;
+  chunk_id?: string;
+  at: string;
+}
+
+/** The opening frame: whether writes are actually being captured, and the cursor
+ *  the server accepted. Both matter — see ChangeFeedPanel for what a missing
+ *  `enabled: false` would cost a reader. */
+export interface ChangeFeedStatus {
+  enabled: boolean;
+  since: number;
+}
+
+export type ChangeFeedFrame =
+  | { kind: "status"; status: ChangeFeedStatus }
+  | { kind: "change"; change: MemoryChangeRow };
+
+/** Which endpoint to tail. The runtime splits the families across two routes, so a
+ *  reader wanting both opens both. */
+export type ChangeFamily = "memory" | "documents";
+
+export const CHANGE_FEED_PATHS: Record<ChangeFamily, string> = {
+  memory: "/v1/_memory/changes",
+  documents: "/v1/_document/changes",
+};
+
+/** The env var an operator sets to turn the feed on. Named in the UI because
+ *  "disabled" without the remedy is a dead end. */
+export const CHANGE_FEED_ENV = "LOOMCYCLE_MEMORY_CHANGES_ENABLED";
+
+// ---------------------------------------------------------------- frame parsing
+
+/** classifyFrame turns one raw SSE frame into a typed frame, or null when it is
+ *  neither (a keepalive comment, an unknown event name, unparseable JSON).
+ *
+ *  DISCRIMINATED ON THE EVENT NAME, not on the payload's shape. The runtime sends
+ *  `event: feed` for the status and `event: change` for a coordinate, and the
+ *  status payload deliberately carries no `type` field — so sniffing the body
+ *  would have to guess, while the name is authoritative. */
+export function classifyFrame(
+  event: string,
+  data: string,
+): ChangeFeedFrame | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(data);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  if (event === "feed") {
+    const p = parsed as Partial<ChangeFeedStatus>;
+    // `enabled` is required. A status frame we cannot read must NOT default to
+    // enabled: the whole point of the frame is to stop a disabled feed reading as
+    // a quiet one, and a permissive default reinstates exactly that.
+    if (typeof p.enabled !== "boolean") return null;
+    return {
+      kind: "status",
+      status: { enabled: p.enabled, since: Number(p.since) || 0 },
+    };
+  }
+  if (event === "change") {
+    const p = parsed as Partial<MemoryChangeRow>;
+    if (typeof p.type !== "string" || typeof p.seq !== "number") return null;
+    return { kind: "change", change: p as MemoryChangeRow };
+  }
+  return null;
+}
+
+/** readSSE yields {event, data} pairs from a byte stream.
+ *
+ *  A local parser rather than the adapter's: @loomcycle/client does not export
+ *  parseSSE, and its version coerces every frame into an AgentEvent — a shape a
+ *  change coordinate is not. Comment lines (`: keepalive`) are skipped, which is
+ *  what keeps a quiet feed from looking like a broken one. */
+export async function* readSSE(
+  stream: ReadableStream<Uint8Array>,
+): AsyncIterable<{ event: string; data: string }> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder("utf-8");
+  let buf = "";
+  let event = "";
+  let data = "";
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      let idx: number;
+      while ((idx = buf.indexOf("\n")) !== -1) {
+        const line = buf.slice(0, idx).replace(/\r$/, "");
+        buf = buf.slice(idx + 1);
+        if (line === "") {
+          if (event && data) yield { event, data };
+          event = "";
+          data = "";
+          continue;
+        }
+        if (line.startsWith(":")) continue; // keepalive comment
+        if (line.startsWith("event:")) event = line.slice(6).trim();
+        else if (line.startsWith("data:")) data = line.slice(5).trim();
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+// ------------------------------------------------------------------ the buffer
+
+/** A bounded, newest-first view of the rows seen, with the count DROPPED because
+ *  of the bound.
+ *
+ *  `seen` and `dropped` are tracked rather than derived from `rows.length` on
+ *  purpose: a tail that silently forgets is a tail that lies about how much
+ *  happened, and "showing the latest 200" reads as "200 things happened" unless
+ *  the total is beside it. */
+export interface ChangeBuffer {
+  rows: MemoryChangeRow[];
+  seen: number;
+  dropped: number;
+}
+
+export const emptyBuffer: ChangeBuffer = { rows: [], seen: 0, dropped: 0 };
+
+/** How many coordinates the panel retains. The feed is a firehose on a busy
+ *  store — one consolidation pass writes a row per fact plus one per chunk — and
+ *  an unbounded list is a memory leak with a scrollbar. */
+export const CHANGE_BUFFER_CAP = 200;
+
+/** appendChange adds one row, newest first, dropping the oldest past the cap.
+ *
+ *  DEDUPED ON seq, because a reconnect resumes from the last cursor and the
+ *  server is inclusive at the boundary in the case where the cursor was never
+ *  advanced — a duplicate row would otherwise inflate `seen` and make a quiet
+ *  feed look busy. */
+export function appendChange(
+  buf: ChangeBuffer,
+  row: MemoryChangeRow,
+  cap = CHANGE_BUFFER_CAP,
+): ChangeBuffer {
+  if (buf.rows.some((r) => r.seq === row.seq && r.type === row.type))
+    return buf;
+  const rows = [row, ...buf.rows];
+  const dropped = buf.dropped + Math.max(0, rows.length - cap);
+  return { rows: rows.slice(0, cap), seen: buf.seen + 1, dropped };
+}
+
+// ------------------------------------------------------------------ filtering
+
+export interface ChangeFilter {
+  /** "" = every family. */
+  family?: ChangeFamily | "";
+  /** "" = every scope. */
+  scope?: MemoryChangeRow["scope"] | "";
+  /** Substring match on scope_id; "" = every scope_id. Substring rather than exact
+   *  because an operator watching one user does not want to type an id exactly, and
+   *  the feed is tenant-wide so SOME narrowing is the difference between readable
+   *  and not. */
+  scopeId?: string;
+  /** "" = every type. */
+  type?: MemoryChangeRow["type"] | "";
+}
+
+export function isDocumentChange(t: MemoryChangeRow["type"]): boolean {
+  return t === "document.chunk.updated" || t === "document.chunk.deleted";
+}
+
+export function matchesFilter(row: MemoryChangeRow, f: ChangeFilter): boolean {
+  if (f.family === "memory" && isDocumentChange(row.type)) return false;
+  if (f.family === "documents" && !isDocumentChange(row.type)) return false;
+  if (f.scope && row.scope !== f.scope) return false;
+  if (f.type && row.type !== f.type) return false;
+  if (
+    f.scopeId &&
+    !row.scope_id.toLowerCase().includes(f.scopeId.toLowerCase())
+  )
+    return false;
+  return true;
+}
+
+/** describeChange renders the coordinate a row names — the key for a memory write,
+ *  the chunk for a document one. Never a value: the feed does not carry one, and a
+ *  UI that showed an empty "value" column would imply it should. */
+export function describeChange(row: MemoryChangeRow): string {
+  if (row.key) return row.key;
+  if (row.chunk_id) return `chunk ${row.chunk_id.slice(0, 12)}`;
+  if (row.type === "memory.scope_deleted") return "(whole scope)";
+  return "—";
+}
+
+// ------------------------------------------------------------------ transport
+
+/** The subset of Connection this transport needs. Declared locally so the tail can
+ *  be handed a plain object in a test without constructing a client. */
+export interface ChangeFeedConnection {
+  baseUrl: string;
+  token?: string;
+  fetch?: typeof fetch;
+}
+
+/** tailChanges opens one family's feed and yields typed frames until the signal
+ *  aborts or the server closes.
+ *
+ *  Accepts BOTH media types, like every other SSE call in this codebase: the
+ *  success path is text/event-stream and the ERROR path is application/json, and a
+ *  strict proxy in front of the runtime 406s a request that only advertises one.
+ *  (Same reason as the MCP HTTP-transport hardening note in CLAUDE.md.) */
+export async function* tailChanges(
+  conn: ChangeFeedConnection,
+  family: ChangeFamily,
+  opts: { since?: number; signal?: AbortSignal } = {},
+): AsyncIterable<ChangeFeedFrame> {
+  const headers: Record<string, string> = {
+    Accept: "text/event-stream, application/json",
+  };
+  if (conn.token) headers.Authorization = `Bearer ${conn.token}`;
+  const qs = opts.since
+    ? `?since=${encodeURIComponent(String(opts.since))}`
+    : "";
+  const doFetch =
+    conn.fetch ?? ((i: RequestInfo | URL, x?: RequestInit) => fetch(i, x));
+  const resp = await doFetch(conn.baseUrl + CHANGE_FEED_PATHS[family] + qs, {
+    method: "GET",
+    headers,
+    signal: opts.signal,
+  });
+  if (!resp.ok) {
+    // The body is the runtime's typed error text; surfaced verbatim because the
+    // panel shows it, and "403" alone does not tell an operator that the feed needs
+    // a tenant-scoped token.
+    throw new Error(
+      `change feed ${resp.status}: ${(await resp.text()).slice(0, 300)}`,
+    );
+  }
+  if (!resp.body) throw new Error("change feed: response has no body");
+  for await (const { event, data } of readSSE(resp.body)) {
+    const frame = classifyFrame(event, data);
+    if (frame) yield frame;
+  }
+}

--- a/packages/memory-view/src/lib/dataLayer.tsx
+++ b/packages/memory-view/src/lib/dataLayer.tsx
@@ -20,6 +20,12 @@ import type {
   MemoryScope,
   VerificationStats,
 } from "../types";
+import {
+  tailChanges,
+  type ChangeFamily,
+  type ChangeFeedConnection,
+  type ChangeFeedFrame,
+} from "./changeFeed";
 
 // The two embedding-maintenance response types are DERIVED from the client's method
 // signatures rather than imported by name.
@@ -162,6 +168,18 @@ export interface MemoryDataLayer {
     text: string,
     opts?: { scopeId?: string; type?: string; subject?: string },
   ): Promise<unknown>;
+  // ---- The change-feed tail (OPTIONAL) ---------------------------------
+  // Tail one family of the value-free change feed. OPTIONAL because only a data
+  // layer holding a raw CONNECTION can implement it: consuming SSE needs the base
+  // URL and the host's fetch, which a bare @loomcycle/client instance does not
+  // expose. A data layer without it makes the Activity tab say so, which is a
+  // DIFFERENT statement from "the feed is disabled" and must not be confused with
+  // it — see ChangeFeedPanel.
+  streamChanges?(
+    family: ChangeFamily,
+    opts?: { since?: number; signal?: AbortSignal },
+  ): AsyncIterable<ChangeFeedFrame>;
+
   // verificationStats reports how much of a scope's fact store carries evidence and a
   // verdict — the number that says whether verification is doing anything at all.
   verificationStats(scope: MemoryScope, opts?: { scopeId?: string }): Promise<VerificationStats>;
@@ -331,4 +349,22 @@ export function useMemoryData(): MemoryDataLayer {
     );
   }
   return v;
+}
+
+// dataLayerFromConnection is dataLayerFromClient PLUS the change-feed tail.
+//
+// The split is not cosmetic. Everything else this console does is a request/response
+// call @loomcycle/client models; the tail is a long-lived SSE GET, which needs the
+// base URL and the host's configured fetch. A connection has those, a prebuilt client
+// does not expose them — so the capability lives on exactly the path that can honestly
+// provide it, rather than being faked everywhere and failing at runtime on two paths
+// out of three.
+export function dataLayerFromConnection(
+  conn: ChangeFeedConnection,
+  client: LoomcycleClient,
+): MemoryDataLayer {
+  return {
+    ...dataLayerFromClient(client),
+    streamChanges: (family, opts) => tailChanges(conn, family, opts),
+  };
 }

--- a/packages/memory-view/src/styles.css
+++ b/packages/memory-view/src/styles.css
@@ -1302,3 +1302,98 @@
   border-left: 2px solid var(--running);
   opacity: 0.9;
 }
+
+/* ---- Activity: the change-feed tail (RFC CF §9) ------------------------- */
+.loomcycle-memory-view .change-feed {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  min-height: 0;
+}
+.loomcycle-memory-view .change-feed-head {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+.loomcycle-memory-view .change-feed-filters {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+.loomcycle-memory-view .change-feed-scopeid {
+  width: 14rem;
+}
+.loomcycle-memory-view .change-feed-btn {
+  padding: 0.2rem 0.6rem;
+}
+/* The badge is the panel's whole point: three non-live states that would
+   otherwise all read as "nothing happening". */
+.loomcycle-memory-view .change-feed-badge {
+  font-size: var(--lc-text-sm);
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  color: var(--fg-muted);
+  white-space: nowrap;
+}
+.loomcycle-memory-view .change-feed-badge-live {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.loomcycle-memory-view .change-feed-badge-disabled,
+.loomcycle-memory-view .change-feed-badge-unsupported {
+  color: var(--fg-soft);
+}
+.loomcycle-memory-view .change-feed-badge-error {
+  color: var(--danger);
+  border-color: var(--danger);
+}
+.loomcycle-memory-view .change-feed-note {
+  border: 1px solid var(--border);
+  background: var(--bg-soft);
+  color: var(--fg-muted);
+  padding: 0.5rem 0.7rem;
+  font-size: var(--lc-text-sm);
+  line-height: 1.45;
+}
+.loomcycle-memory-view .change-feed-counters {
+  font-size: var(--lc-text-sm);
+  color: var(--fg-soft);
+}
+.loomcycle-memory-view .change-feed-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--lc-text-sm);
+}
+.loomcycle-memory-view .change-feed-table th {
+  text-align: left;
+  color: var(--fg-soft);
+  font-weight: 500;
+  border-bottom: 1px solid var(--border);
+  padding: 0.25rem 0.5rem 0.25rem 0;
+}
+.loomcycle-memory-view .change-feed-table td {
+  padding: 0.2rem 0.5rem 0.2rem 0;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+.loomcycle-memory-view .change-feed-seq,
+.loomcycle-memory-view .change-feed-at,
+.loomcycle-memory-view .change-feed-coord {
+  font-family: var(--lc-font-mono);
+}
+.loomcycle-memory-view .change-feed-coord {
+  word-break: break-all;
+}
+.loomcycle-memory-view .change-feed-type {
+  font-family: var(--lc-font-mono);
+  color: var(--fg-muted);
+}
+.loomcycle-memory-view .change-feed-type-doc {
+  color: var(--accent);
+}
+.loomcycle-memory-view .change-feed-type-delete {
+  color: var(--danger);
+}


### PR DESCRIPTION
The last phase of RFC CF, and the one the RFC flagged as *"the only item here that is a substantial build rather than a form over an endpoint"*. A consolidation pass takes minutes and reports only at the end, so between starting one and reading its summary there is nothing to look at. This is that.

The SSE endpoints already existed (RFC CD Part C). What did not exist was any way for a reader to know they were **on**.

## The defect this starts from

The feed is off unless `LOOMCYCLE_MEMORY_CHANGES_ENABLED=1`, and with it off nothing writes the change table — so `GET /v1/_memory/changes` connects, keepalives flow, and **no change frame ever arrives**. That is indistinguishable from a healthy feed over a quiet store. A reader watching for "is the pass doing anything" waits forever on a misconfiguration and concludes the answer is no.

Same shape as the last two things this epic found: a coverage number that counted identity nodes, and a capped scan reporting a clean zero. A state that is wrong in a way that looks fine.

## What

**Server** — each stream opens with an additive `feed` frame carrying `enabled` and the cursor actually in force.

- **The answer comes from the store**, via a new `cdc.Store.CapturesChanges()`. The CDC decorator is in the write path exactly when the feed is on, so asking it cannot disagree with whether writes are being captured — a second reading of the env var could, and the var is not even in the config struct (`main.go` reads it directly to decide whether to wrap the store). A plain store answers false by not implementing the method.
- **It rides the channel that would otherwise idle** rather than joining a separate report, so a client cannot hold a stale answer while connected.
- `since` is echoed because a cursor the server *refused* (unparseable, negative) is otherwise invisible: the reader sees a feed with nothing new and either re-reads from zero or waits, depending on which way it guessed.

**Console** — an Activity tab tailing both families, merged, showing **coordinates and never values** (the feed is value-free by design, so there is no empty "value" column here implying otherwise).

Three non-live states, kept apart, which is what earns the component:

| state | meaning | what the panel says |
|---|---|---|
| `unsupported` | the data layer has no `streamChanges` | nothing will arrive, and the runtime is not the reason |
| `disabled` | the runtime answered `enabled: false` | names the env var — "disabled" without the remedy is a dead end |
| `live` | connected and capturing | an empty list genuinely means nothing changed |

**The tail is a capability of the connection path, not of every path.** Everything else this console does is a request/response call `@loomcycle/client` models; a long-lived SSE GET needs the base URL and the host's configured fetch, which a `connection` has and a prebuilt client does not expose. So `streamChanges` is **optional** on the data layer and implemented by a new `dataLayerFromConnection` — present exactly where it can honestly work, rather than faked on three paths and failing at runtime on two. When the client grows a change-feed method, that path implements the same hook and this transport stops being the only one.

Filtering (family / scope / `scope_id` substring) is a **view** over what arrived, so changing it never re-opens the stream — that would discard rows the operator had seen and reset the counters they were reading. The buffer keeps the latest 200 and **reports what it dropped**, because "showing 200" reads as "200 things happened" unless the total is beside it.

## What was tested

`go test ./...` clean — 91 packages, exit 0, with the Postgres tier enabled. Package: `tsc --noEmit` clean, **57 tests** (15 new), `build:lib` clean, `make build-ui` clean (the web console consumes the package source through a Vite alias).

Server tests: `TestMemoryChanges_OpeningFrameSaysWhetherTheFeedIsOn` (both endpoints × both store states) and `TestMemoryChanges_OpeningFrameEchoesTheCursor` (including a rejected cursor reporting the one in force, not the one asked for). Fail-before: removing `CapturesChanges` makes a wrapped store report disabled and the test fails.

Package tests worth naming, because each pins a decision that has a plausible wrong answer:

- a status frame that cannot be read is **not** enabled — a permissive default would reinstate the exact ambiguity the frame exists to remove
- frames discriminate on the event **name**: the status payload deliberately carries no `type`, so a body-sniffing parser would have to guess
- `readSSE` is fed a stream **split mid-frame** — a parser that only handles whole frames passes a naive test and loses data in a browser
- the buffer dedupes on `seq` **per family**, since the two share a seq space but arrive on separate streams
- a failed request surfaces the runtime's body, not a bare status (403 alone does not tell an operator the feed needs a tenant-scoped token)

**Verified live** against a real runtime, both directions:

```
feed off → event: feed  data: {"enabled":false,"since":0}
feed on  → event: feed  data: {"enabled":true,"since":0}
           event: change data: {"seq":1,...,"type":"document.chunk.updated","scope":"user","scope_id":"denn","chunk_id":"8779e5..."}
```

with the coordinates produced by a real `remember` write.

## Notes

- The first draft appended **bare** CSS selectors; every rule in this package is scoped under `.loomcycle-memory-view`, so that would have leaked styles into any host. Rescoped.
- Prettier reformatted ~15 unrelated lines in `dataLayer.tsx` on the way through. Reverted and the edits re-applied by hand, so the diff is 968/−6 rather than 1046/−27 and reviewable.
- `@loomcycle/memory-view` → **0.3.0** (a new tab and a new data-layer capability); needs a `memory-view-v0.3.0` tag to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8