### PR TITLE
fix: qwen-on-ollama tool-call regression (recover wrapped calls + stop defaulting inject_tool_guide)

### DIFF
--- a/REVISIONS.md
+++ b/REVISIONS.md
@@ -4,6 +4,36 @@ Per-version release notes from v0.4.0 onward. The current and immediately previo
 
 For the **public roadmap** (planned v0.8.16 through v1.0 work — Question tool, Pause / Resume / Snapshot, distribution, operator postures), see [`docs/PLAN.md`](docs/PLAN.md).
 
+## What's in v1.56.1
+
+**A tool-call regression on qwen-via-Ollama, and the v1.56.0 bundle change that caused
+it.** Patch — one runtime fix and one config revert; no wire, schema, or adapter change.
+
+### qwen on Ollama stopped calling tools
+
+A `chat/medium` run on a local qwen3.6 model wanted to search but emitted its call as
+TEXT, copying the framing of loomcycle's own injected `{{tool:Context.*}}` reference
+blocks — `<tool_result> {"type":"function","function":{"name":"WebSearch", …}} </tool_result>`.
+Ollama's extractor expects `<tool_call>`, so it recovered nothing, and the existing
+text-recovery parser only understood a flat `{name, arguments}` object. The wrapped,
+OpenAI-nested shape fell through, and the run ended with the un-executed block as its
+"answer" — no search ran.
+
+- The Ollama driver's `tryParseToolCallsFromText` now peels one wrapper tag
+  (`<tool_call>` / `<tool_result>` / `<function_call>`, hyphen or underscore, with or
+  without attributes) and accepts the OpenAI-nested `{"function":{name,arguments}}`
+  envelope, with arguments as an object or a JSON-encoded string. Same strict,
+  tools-gated contract — prose and non-tool JSON still recover nothing.
+
+### inject_tool_guide is no longer a bundle default
+
+Making `inject_tool_guide` a bundle default in v1.56.0 was premature: its target is
+small local models, and that is exactly where the three injected `<tool-result>`-framed
+blocks both bloat the prompt and get copied by the model as its tool-call format. The
+flag is removed from every bundled agent; the mechanism — `Context op=guide`, the
+`HintedTool` hints, the injectable refs, and the per-agent flag — stays intact for
+explicit opt-in on a strong-model agent.
+
 ## What's in v1.56.0
 
 **Agents that know how to call their tools, a live view of the memory pipeline, and

--- a/bundles/agent-teams/loomcycle.yaml
+++ b/bundles/agent-teams/loomcycle.yaml
@@ -59,7 +59,6 @@ channels:
 
 agents:
   agent/assistant:
-    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     tier: middle
     max_iterations: 24
     max_tokens: 8192
@@ -100,7 +99,6 @@ agents:
       workflow.
 
   team/assistant:
-    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     tier: middle
     max_iterations: 32
     max_tokens: 8192
@@ -147,7 +145,6 @@ agents:
       state what you'd run to test it.
 
   team/orchestrator:
-    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     # Run this agent INTERACTIVELY (the operator starts it with interactive:true
     # from the /run terminal) so it parks for human input between turns — that's a
     # per-run flag, not an agent field. unbounded_iterations lifts the loop cap so a

--- a/bundles/chat/loomcycle.yaml
+++ b/bundles/chat/loomcycle.yaml
@@ -27,10 +27,6 @@ agents:
   chat/medium:
     tier: middle
     effort: medium
-    # Auto-inject the deployment capabilities + a per-tool call digest (op enum +
-    # required args + usage hints) so the agent knows what it can do and how to
-    # call its tools without the operator hand-pointing it at help topics.
-    inject_tool_guide: true
     # max_tokens intentionally OMITTED — each provider applies its own default
     # (Anthropic defaults to 8192; ollama generates until the context fills).
     # Pinning a value would only IMPOSE a per-reply cap, not add headroom.
@@ -102,9 +98,6 @@ agents:
   chat/local:
     model: local-medium                     # → ollama-local; local-only, no cloud fallback
     effort: medium
-    # Local models under-attend to the tool schemas the loop already sends, so the
-    # runtime-knowledge injection matters most here — see chat/medium above.
-    inject_tool_guide: true
     # max_tokens OMITTED — ollama-local generates until the context window fills
     # (set the window via LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX, e.g. 131072 for 128K).
     unbounded_iterations: true
@@ -158,9 +151,6 @@ agents:
   chat/local-small:
     model: local-small                     # → ollama-local; local-only, no cloud fallback
     effort: medium
-    # A small local model needs the runtime-knowledge injection most — see
-    # chat/medium above.
-    inject_tool_guide: true
     # max_tokens OMITTED — ollama-local generates until the context window fills
     # (set the window via LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX, e.g. 131072 for 128K).
     unbounded_iterations: true

--- a/bundles/document-agent/loomcycle.yaml
+++ b/bundles/document-agent/loomcycle.yaml
@@ -29,10 +29,6 @@ agents:
     memory_scopes: [user]
     sql_scopes: [user]
     skills: [doc/*]
-    # Auto-inject the deployment capabilities + a per-tool call digest (op enum +
-    # required args + usage hints) so the manager picks the right Document op and
-    # required fields instead of learning them from refusals.
-    inject_tool_guide: true
     system_prompt: |
       You are DOC-MANAGER, a co-author of chunked-graph Documents (see Context op=help topic=document). You
       turn an operator's plain-text instructions into Document tool calls — the

--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -2325,7 +2325,6 @@ agents:
       cannot judge rather than guessing at it.
 
   memory/ontologist:
-    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     # An ONTOLOGY CURATOR: it reads the entity types in force, looks at what types
     # the stored facts actually carry, and FILES SUGGESTIONS. It cannot change the
     # type system — the propose op only ever writes an inert entity, and resolving

--- a/bundles/team-examples/loomcycle.yaml
+++ b/bundles/team-examples/loomcycle.yaml
@@ -31,7 +31,6 @@
 agents:
   # ---- software (SDLC) handlers — operate the shared ephemeral `work` volume ----
   sdlc/architect:
-    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     tier: middle
     max_tokens: 8192
     effort: high
@@ -44,7 +43,6 @@ agents:
       one-line "ready to implement?" so the orchestrator can gate on approval.
 
   sdlc/coder:
-    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     tier: middle
     max_tokens: 16384
     effort: medium
@@ -58,7 +56,6 @@ agents:
       commit or push; the orchestrator opens the PR.
 
   sdlc/reviewer:
-    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     tier: middle
     max_tokens: 8192
     effort: high
@@ -72,7 +69,6 @@ agents:
 
   # ---- marketing handlers — Documents only, no volume/repo ----
   marketing/writer:
-    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     tier: middle
     max_tokens: 8192
     effort: medium
@@ -87,7 +83,6 @@ agents:
       and no PR; the Document is the deliverable.
 
   marketing/editor:
-    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     tier: middle
     max_tokens: 8192
     effort: high

--- a/cmd/loomcycle/embedded/bundles/agent-teams.yaml
+++ b/cmd/loomcycle/embedded/bundles/agent-teams.yaml
@@ -59,7 +59,6 @@ channels:
 
 agents:
   agent/assistant:
-    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     tier: middle
     max_iterations: 24
     max_tokens: 8192
@@ -100,7 +99,6 @@ agents:
       workflow.
 
   team/assistant:
-    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     tier: middle
     max_iterations: 32
     max_tokens: 8192
@@ -147,7 +145,6 @@ agents:
       state what you'd run to test it.
 
   team/orchestrator:
-    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     # Run this agent INTERACTIVELY (the operator starts it with interactive:true
     # from the /run terminal) so it parks for human input between turns — that's a
     # per-run flag, not an agent field. unbounded_iterations lifts the loop cap so a

--- a/cmd/loomcycle/embedded/bundles/chat.yaml
+++ b/cmd/loomcycle/embedded/bundles/chat.yaml
@@ -27,10 +27,6 @@ agents:
   chat/medium:
     tier: middle
     effort: medium
-    # Auto-inject the deployment capabilities + a per-tool call digest (op enum +
-    # required args + usage hints) so the agent knows what it can do and how to
-    # call its tools without the operator hand-pointing it at help topics.
-    inject_tool_guide: true
     # max_tokens intentionally OMITTED — each provider applies its own default
     # (Anthropic defaults to 8192; ollama generates until the context fills).
     # Pinning a value would only IMPOSE a per-reply cap, not add headroom.
@@ -102,9 +98,6 @@ agents:
   chat/local:
     model: local-medium                     # → ollama-local; local-only, no cloud fallback
     effort: medium
-    # Local models under-attend to the tool schemas the loop already sends, so the
-    # runtime-knowledge injection matters most here — see chat/medium above.
-    inject_tool_guide: true
     # max_tokens OMITTED — ollama-local generates until the context window fills
     # (set the window via LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX, e.g. 131072 for 128K).
     unbounded_iterations: true
@@ -158,9 +151,6 @@ agents:
   chat/local-small:
     model: local-small                     # → ollama-local; local-only, no cloud fallback
     effort: medium
-    # A small local model needs the runtime-knowledge injection most — see
-    # chat/medium above.
-    inject_tool_guide: true
     # max_tokens OMITTED — ollama-local generates until the context window fills
     # (set the window via LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX, e.g. 131072 for 128K).
     unbounded_iterations: true

--- a/cmd/loomcycle/embedded/bundles/document-agent.yaml
+++ b/cmd/loomcycle/embedded/bundles/document-agent.yaml
@@ -29,10 +29,6 @@ agents:
     memory_scopes: [user]
     sql_scopes: [user]
     skills: [doc/*]
-    # Auto-inject the deployment capabilities + a per-tool call digest (op enum +
-    # required args + usage hints) so the manager picks the right Document op and
-    # required fields instead of learning them from refusals.
-    inject_tool_guide: true
     system_prompt: |
       You are DOC-MANAGER, a co-author of chunked-graph Documents (see Context op=help topic=document). You
       turn an operator's plain-text instructions into Document tool calls — the

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -2325,7 +2325,6 @@ agents:
       cannot judge rather than guessing at it.
 
   memory/ontologist:
-    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     # An ONTOLOGY CURATOR: it reads the entity types in force, looks at what types
     # the stored facts actually carry, and FILES SUGGESTIONS. It cannot change the
     # type system — the propose op only ever writes an inert entity, and resolving

--- a/cmd/loomcycle/embedded/bundles/team-examples.yaml
+++ b/cmd/loomcycle/embedded/bundles/team-examples.yaml
@@ -31,7 +31,6 @@
 agents:
   # ---- software (SDLC) handlers — operate the shared ephemeral `work` volume ----
   sdlc/architect:
-    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     tier: middle
     max_tokens: 8192
     effort: high
@@ -44,7 +43,6 @@ agents:
       one-line "ready to implement?" so the orchestrator can gate on approval.
 
   sdlc/coder:
-    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     tier: middle
     max_tokens: 16384
     effort: medium
@@ -58,7 +56,6 @@ agents:
       commit or push; the orchestrator opens the PR.
 
   sdlc/reviewer:
-    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     tier: middle
     max_tokens: 8192
     effort: high
@@ -72,7 +69,6 @@ agents:
 
   # ---- marketing handlers — Documents only, no volume/repo ----
   marketing/writer:
-    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     tier: middle
     max_tokens: 8192
     effort: medium
@@ -87,7 +83,6 @@ agents:
       and no PR; the Document is the deliverable.
 
   marketing/editor:
-    inject_tool_guide: true   # auto-inject tool call-digest + runtime capabilities
     tier: middle
     max_tokens: 8192
     effort: high

--- a/internal/providers/ollama/driver.go
+++ b/internal/providers/ollama/driver.go
@@ -964,29 +964,43 @@ func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.
 }
 
 // tryParseToolCallsFromText attempts to parse the raw text content as
-// one or more Ollama-shaped tool-call objects. Two shapes covered:
+// one or more Ollama-shaped tool-call objects. Shapes covered:
 //
 //  1. JSON-shape (PR #26):
 //     {"name":"...","arguments":{...}}
 //     or an array of such objects, optionally wrapped in a ```json fence.
 //
-//  2. Markdown-bracket shape (this function's fallback path, v0.7.x):
-//     [tool_use: <name>]\n{"...": ...}
-//     [tool_use: <name> {"...": ...}]
-//     [tool_use: <name>]
-//     Some chat templates produce this form instead of structured
-//     tool_calls — observed on a few hermes / mistral fine-tunes.
+//  2. OpenAI-nested envelope:
+//     {"type":"function","function":{"name":"...","arguments":{...}}}
+//     (arguments may be an object OR a JSON-encoded string). Small local
+//     models copy this envelope from their training when they emit a call as
+//     text instead of via native tool_calls.
 //
-// Returns the parsed ToolUse list when either shape matches, nil
-// otherwise. Strict matching prevents false positives from text that
-// happens to look JSON-ish or contains the literal phrase "tool_use" in
-// prose: we require the ENTIRE trimmed content to deserialise into the
+//  3. Any of the above wrapped in a single <tool_call>/<tool_result>/
+//     <function_call> tag. qwen3 on Ollama copies whatever call/result FRAMING
+//     it sees in the system prompt — including loomcycle's own injected
+//     <tool-result …> reference blocks — and emits its call inside that tag
+//     rather than as structured tool_calls. Ollama's extractor expects
+//     <tool_call>, so it recovers nothing; without this, the run silently ends
+//     with the call sitting in the text as an un-executed <tool_result> block.
+//
+//  4. Markdown-bracket shape (v0.7.x fallback):
+//     [tool_use: <name>]\n{"...": ...} / [tool_use: <name> {...}] / [tool_use: <name>]
+//     Observed on a few hermes / mistral fine-tunes.
+//
+// Returns the parsed ToolUse list when a shape matches, nil otherwise. Strict
+// matching prevents false positives from text that happens to look JSON-ish or
+// contains the literal phrase "tool_use" in prose: we require the ENTIRE trimmed
+// content (after peeling one wrapper tag / fence) to deserialise into a
 // tool-call shape.
 func tryParseToolCallsFromText(text string) []*providers.ToolUse {
 	s := strings.TrimSpace(text)
 	if s == "" {
 		return nil
 	}
+	// Peel ONE tool-call wrapper tag before anything else, so a fenced or bare
+	// JSON body inside <tool_result>…</tool_result> is reached (shape 3).
+	s = stripToolWrapperTag(s)
 	// Strip a single markdown fence pair if present. qwen3's chat
 	// template sometimes wraps tool-call output in ```json ... ```.
 	if strings.HasPrefix(s, "```") {
@@ -1000,25 +1014,17 @@ func tryParseToolCallsFromText(text string) []*providers.ToolUse {
 		s = strings.TrimSpace(s)
 	}
 
-	type rawCall struct {
-		Name      string          `json:"name"`
-		Arguments json.RawMessage `json:"arguments"`
-	}
-
 	// Try array first — qwen3 occasionally batches multiple calls.
 	if strings.HasPrefix(s, "[") && !strings.HasPrefix(s, "[tool_use:") {
-		var arr []rawCall
+		var arr []rawToolCall
 		if err := json.Unmarshal([]byte(s), &arr); err == nil && len(arr) > 0 {
 			out := make([]*providers.ToolUse, 0, len(arr))
 			for _, r := range arr {
-				if r.Name == "" {
+				tu := r.toToolUse()
+				if tu == nil {
 					return nil // any malformed entry → bail; treat as prose
 				}
-				args := r.Arguments
-				if len(args) == 0 {
-					args = json.RawMessage("{}")
-				}
-				out = append(out, &providers.ToolUse{Name: r.Name, Input: args})
+				out = append(out, tu)
 			}
 			return out
 		}
@@ -1036,19 +1042,97 @@ func tryParseToolCallsFromText(text string) []*providers.ToolUse {
 		return nil
 	}
 
-	// Try single JSON object.
-	var r rawCall
+	// Try single JSON object (flat or OpenAI-nested).
+	var r rawToolCall
 	if err := json.Unmarshal([]byte(s), &r); err != nil {
 		return nil
 	}
-	if r.Name == "" {
+	if tu := r.toToolUse(); tu != nil {
+		return []*providers.ToolUse{tu}
+	}
+	return nil
+}
+
+// rawToolCall is the union of the flat and OpenAI-nested tool-call shapes a
+// text-emitting model produces. toToolUse normalises whichever is present.
+type rawToolCall struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+	// OpenAI-style nesting: {"type":"function","function":{"name":…,"arguments":…}}.
+	Function *struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	} `json:"function"`
+}
+
+// toToolUse normalises a rawToolCall to a ToolUse, preferring the nested
+// `function` envelope when present. Returns nil when no name is set (the caller
+// treats nil as "this isn't a tool call, leave it as text").
+func (r rawToolCall) toToolUse() *providers.ToolUse {
+	name, args := r.Name, r.Arguments
+	if r.Function != nil && r.Function.Name != "" {
+		name, args = r.Function.Name, r.Function.Arguments
+	}
+	if name == "" {
 		return nil
 	}
-	args := r.Arguments
-	if len(args) == 0 {
-		args = json.RawMessage("{}")
+	return &providers.ToolUse{Name: name, Input: normalizeToolArgs(args)}
+}
+
+// normalizeToolArgs returns a JSON object for a call's arguments. Absent → "{}".
+// A JSON-STRING (the OpenAI wire form often double-encodes arguments, e.g.
+// "{\"q\":\"x\"}") is unquoted to the object it encodes so the dispatcher sees an
+// object either way; anything else passes through untouched.
+func normalizeToolArgs(args json.RawMessage) json.RawMessage {
+	a := bytes.TrimSpace(args)
+	if len(a) == 0 {
+		return json.RawMessage("{}")
 	}
-	return []*providers.ToolUse{{Name: r.Name, Input: args}}
+	if a[0] == '"' {
+		var str string
+		if err := json.Unmarshal(a, &str); err == nil {
+			if t := strings.TrimSpace(str); t != "" {
+				return json.RawMessage(t)
+			}
+			return json.RawMessage("{}")
+		}
+	}
+	return a
+}
+
+// toolWrapperTags are the call/result framing tags a text-emitting model may put
+// around its call. Underscore and hyphen spellings both occur; loomcycle's own
+// injected reference blocks use <tool-result …>.
+var toolWrapperTags = []string{"tool_call", "tool-call", "tool_result", "tool-result", "function_call", "function-call"}
+
+// stripToolWrapperTag removes ONE surrounding wrapper tag (with or without
+// attributes) and returns the trimmed inner text; returns s unchanged when it is
+// not wrapped. The plural <tool_calls> is deliberately NOT matched (the attribute
+// guard rejects the trailing "s"), so a genuine tool_calls container is left for
+// the JSON parser rather than mis-peeled.
+func stripToolWrapperTag(s string) string {
+	lower := strings.ToLower(s)
+	for _, tag := range toolWrapperTags {
+		if !strings.HasPrefix(lower, "<"+tag) {
+			continue
+		}
+		gt := strings.IndexByte(s, '>')
+		if gt < 0 {
+			continue
+		}
+		// Between the tag name and '>' must be nothing, a self-close, or an
+		// attribute run (leading space) — otherwise "<tool_calls>" would match
+		// the "tool_call" tag.
+		if after := s[len("<"+tag):gt]; after != "" && after != "/" && !strings.HasPrefix(after, " ") {
+			continue
+		}
+		inner := s[gt+1:]
+		if li := strings.LastIndex(strings.ToLower(inner), "</"+tag+">"); li >= 0 {
+			inner = inner[:li]
+		}
+		return strings.TrimSpace(inner)
+	}
+	return s
 }
 
 // parseMarkdownToolCall recognises the bracketed-markdown tool-call

--- a/internal/providers/ollama/tool_text_recovery_test.go
+++ b/internal/providers/ollama/tool_text_recovery_test.go
@@ -275,3 +275,103 @@ func TestTryParseToolCallsFromText_DefaultsEmptyArguments(t *testing.T) {
 		t.Errorf("default arguments = %q, want {}", string(calls[0].Input))
 	}
 }
+
+// ---- Wrapper-tag + OpenAI-nested envelope recovery (the 2026-08-17 regression) ----
+
+func TestTryParseToolCallsFromText_ToolResultWrapperFunctionEnvelope(t *testing.T) {
+	// The exact live shape: chat/medium on qwen3.6 copied loomcycle's injected
+	// <tool-result …> framing and emitted its call as text inside <tool_result>,
+	// using the OpenAI-nested {"function":{…}} envelope.
+	calls := tryParseToolCallsFromText(
+		`<tool_result> {"type": "function", "function": {"name": "WebSearch", "arguments": {"query": "agentic memory architectures LLMs survey 2023 2024"}}} </tool_result>`)
+	if len(calls) != 1 || calls[0].Name != "WebSearch" {
+		t.Fatalf("parse = %+v, want one call name=WebSearch", calls)
+	}
+	if !strings.Contains(string(calls[0].Input), `"query"`) {
+		t.Errorf("arguments lost: %s", calls[0].Input)
+	}
+}
+
+func TestTryParseToolCallsFromText_ToolCallWrapperWithAttributes(t *testing.T) {
+	// Attribute-bearing open tag — the exact form loomcycle injects
+	// (<tool-result tool="Context" op="tools">) and a small model may copy.
+	calls := tryParseToolCallsFromText(
+		`<tool-result tool="Context" op="tools">{"name":"foo","arguments":{"x":1}}</tool-result>`)
+	if len(calls) != 1 || calls[0].Name != "foo" {
+		t.Errorf("parse = %+v, want one call name=foo", calls)
+	}
+}
+
+func TestTryParseToolCallsFromText_FunctionEnvelopeUnwrapped(t *testing.T) {
+	calls := tryParseToolCallsFromText(`{"type":"function","function":{"name":"foo","arguments":{"x":1}}}`)
+	if len(calls) != 1 || calls[0].Name != "foo" {
+		t.Fatalf("parse = %+v, want one call name=foo", calls)
+	}
+}
+
+func TestTryParseToolCallsFromText_FunctionEnvelopeStringArgs(t *testing.T) {
+	// The OpenAI wire form double-encodes arguments as a JSON STRING — normalise
+	// back to an object so the dispatcher sees {"x":1}, not a quoted string.
+	calls := tryParseToolCallsFromText(`{"type":"function","function":{"name":"foo","arguments":"{\"x\":1}"}}`)
+	if len(calls) != 1 || calls[0].Name != "foo" {
+		t.Fatalf("parse = %+v, want one call name=foo", calls)
+	}
+	var args map[string]any
+	if err := json.Unmarshal(calls[0].Input, &args); err != nil {
+		t.Fatalf("arguments not an object: %s (%v)", calls[0].Input, err)
+	}
+	if args["x"] != float64(1) {
+		t.Errorf("arguments = %v, want x=1", args)
+	}
+}
+
+func TestTryParseToolCallsFromText_WrapperDoesNotRescueProse(t *testing.T) {
+	// A wrapper around non-tool-call text must still yield nil — the tag alone
+	// is not license to recover; the inner content must be a tool-call shape.
+	if got := tryParseToolCallsFromText(`<tool_result>the answer is 42</tool_result>`); got != nil {
+		t.Errorf("parse = %v, want nil (inner isn't a tool call)", got)
+	}
+}
+
+func TestToolTextRecovery_RecoversToolResultWrappedFunctionEnvelope(t *testing.T) {
+	// End-to-end through Call(): the live regression must now synthesise a real
+	// EventToolCall and remap the stop reason so the loop iterates instead of
+	// ending with the un-executed <tool_result> block as the "answer".
+	content := `<tool_result> {"type": "function", "function": {"name": "WebSearch", "arguments": {"query": "agentic memory architectures LLMs survey 2023 2024"}}} </tool_result>`
+	fb, _ := json.Marshal(map[string]any{
+		"model":       "qwen3.6:latest",
+		"message":     map[string]any{"role": "assistant", "content": content},
+		"done":        true,
+		"done_reason": "stop",
+	})
+	srv := fakeStream(t, []string{string(fb) + "\n"})
+	defer srv.Close()
+
+	d := New("", "", srv.URL, streamhttp.Options{}, nil)
+	ch, _ := d.Call(context.Background(), providers.Request{
+		Model:    "qwen3.6:latest",
+		Tools:    []providers.ToolSpec{{Name: "WebSearch", InputSchema: json.RawMessage(`{}`)}},
+		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "digest agentic memory"}}}},
+	})
+	var got *providers.ToolUse
+	var done providers.Event
+	for ev := range ch {
+		if ev.Type == providers.EventToolCall && ev.ToolUse != nil {
+			got = ev.ToolUse
+		}
+		if ev.Type == providers.EventDone {
+			done = ev
+		}
+	}
+	if got == nil || got.Name != "WebSearch" {
+		t.Fatalf("recovered tool_use = %+v, want name=WebSearch", got)
+	}
+	var args map[string]any
+	_ = json.Unmarshal(got.Input, &args)
+	if q, _ := args["query"].(string); !strings.Contains(q, "agentic memory") {
+		t.Errorf("recovered arguments = %v, want query containing 'agentic memory'", args)
+	}
+	if done.StopReason != "tool_use" {
+		t.Errorf("done.StopReason = %q, want tool_use (recovery remaps)", done.StopReason)
+	}
+}


### PR DESCRIPTION
## The incident

A `chat/medium` run (on **qwen3.6 via ollama-local**) stopped calling tools. From the transcript, the model *wanted* to search but emitted its call as **text**, copying the framing of loomcycle's own injected `{{tool:Context.*}}` reference blocks:

```
<tool_result> {"type":"function","function":{"name":"WebSearch",
  "arguments":{"query":"agentic memory architectures LLMs survey 2023 2024"}}} </tool_result>
```

Ollama's extractor expects `<tool_call>` → recovered nothing. loomcycle's existing text-recovery parser only understood a **flat** `{name,arguments}` object → the wrapped, OpenAI-nested shape fell through → the run ended with the un-executed block as the "answer". No search ran, three times, through user corrections.

Root cause: injecting three `<tool-result>`-framed blocks (`Context.tools` + the `Context.capabilities`/`Context.guide` I added in #1042/#1043) taught the small local model to *mimic that framing* as its tool-call format — a format neither Ollama nor loomcycle parsed.

## Fix (two commits)

**1. Harden the Ollama text-recovery parser** (`tryParseToolCallsFromText`):
- peel one wrapper tag — `<tool_call>` / `<tool_result>` / `<function_call>`, hyphen or underscore, with or without attributes (the plural `<tool_calls>` container is deliberately not mis-peeled);
- accept the OpenAI-nested `{"type":"function","function":{name,arguments}}` envelope (flat still works), with `arguments` as an object **or** a JSON-encoded string (normalised to an object).
- Same strict-match, `wantTools`-gated contract — prose and non-tool JSON still return `nil`.

**2. Stop defaulting `inject_tool_guide` on bundled agents.** Making it a bundle default was premature: the target (small/local models) is exactly where the `<tool-result>` framing backfires, and the chat agents already carry a hand-written tools section. Removed from all bundled agents (chat/\*, doc/manager, agent/assistant, team/\*, sdlc/\*, marketing/\*, memory/ontologist). **The mechanism stays intact** — `Context op=guide`, the `HintedTool` hints, the injectable refs, and the per-agent flag — so it can still be opted into for a specific strong-model agent.

## Tested

- `internal/providers/ollama`: 6 new cases incl. the exact live string end-to-end through `Call()` (synthesises `EventToolCall`, remaps stop→`tool_use`). **Fail-before verified** — the 4 new shape tests fail on the pre-fix driver.
- `go test ./...` clean (91 packages); bundle source==embedded sync tests pass; `LOOMCYCLE_PRESETS=base,chat,document-agent,agent-teams,team-examples,memory loomcycle validate` resolves clean with no `inject_tool_guide` remaining.
- Unrelated memory-bundle changes on `main` left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)