### PR TITLE
feat(memory): the change feed reports what the embedder is actually doing

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -977,6 +977,15 @@ func main() {
 	}
 	if embedder != nil {
 		log.Printf("embedder: %s/%s (dim=%d)", embedder.Provider(), embedder.Model(), embedder.Dimension())
+		// Wrapped ONCE, here, before any consumer takes a reference: the Memory
+		// tool, the Document tool and the HTTP server all share this instance, so
+		// the observed health covers every embedding the process performs rather
+		// than one subsystem's slice of them. ObserveEmbedder(nil) returns nil, so
+		// the `if Embedder == nil` checks downstream keep working.
+		//
+		// Only reachable when an embedder is configured — an unconfigured
+		// deployment stays byte-identical, holding a nil embedder as before.
+		embedder = providers.ObserveEmbedder(embedder)
 	}
 
 	memoryTool := &builtin.Memory{

--- a/internal/api/http/memory_changes.go
+++ b/internal/api/http/memory_changes.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+
 	"github.com/denn-gubsky/loomcycle/internal/store"
 )
 
@@ -32,6 +34,48 @@ type changeFeedCapturer interface{ CapturesChanges() bool }
 func (s *Server) changeFeedEnabled() bool {
 	c, ok := s.store.(changeFeedCapturer)
 	return ok && c.CapturesChanges()
+}
+
+// embedderHealthReporter is implemented by providers.ObservedEmbedder.
+type embedderHealthReporter interface {
+	Health() providers.EmbedderHealth
+}
+
+// embedderHealth reports what the embedder has actually been doing, for the
+// opening frame.
+//
+// WHY THE CHANGE FEED CARRIES THIS. An embedding failure on a content write is
+// deliberately not fatal — the body is stored and the embedding skipped with a log
+// line, because losing an author's text to an unreachable embedder is worse than
+// losing its searchability. So an embedder outage produces no error anywhere a
+// caller can see: writes succeed, change frames keep arriving, and search quietly
+// stops finding everything written during the outage. A reader watching this feed
+// to answer "is the memory pipeline healthy" would see a perfectly busy feed and
+// conclude yes.
+//
+// `state: failing` plus a failure COUNT is what makes it actionable: the count is
+// how many rows need `backfill_embeddings`, which is the remedy that already
+// exists.
+//
+// A deployment with no embedder reports `absent` rather than nothing at all — the
+// difference between "not configured" and "configured and broken" is the whole
+// point, and an omitted field would collapse them.
+func (s *Server) embedderHealth() providers.EmbedderHealth {
+	if s.embedder == nil {
+		return providers.EmbedderHealth{State: providers.EmbedderAbsent}
+	}
+	if r, ok := s.embedder.(embedderHealthReporter); ok {
+		return r.Health()
+	}
+	// An embedder that is configured but not wrapped (a test fixture, or a future
+	// call site that forgets ObserveEmbedder). Report what is knowable and do NOT
+	// claim health: `untried` says "configured, nothing observed", which is exactly
+	// true here.
+	return providers.EmbedderHealth{
+		State:    providers.EmbedderUntried,
+		Provider: s.embedder.Provider(),
+		Model:    s.embedder.Model(),
+	}
 }
 
 func (s *Server) handleMemoryChanges(w http.ResponseWriter, r *http.Request) {
@@ -84,6 +128,10 @@ func (s *Server) streamMemoryChanges(w http.ResponseWriter, r *http.Request, doc
 	stream.sendRaw("feed", map[string]any{
 		"enabled": s.changeFeedEnabled(),
 		"since":   cursor,
+		// Reported alongside `enabled`, never folded into it: capture being on and
+		// the embedder working are independent failures, and a single boolean would
+		// make "capturing but unsearchable" indistinguishable from healthy.
+		"embedder": s.embedderHealth(),
 	})
 
 	stream.startKeepalive(r.Context(), s.cfg.Env.SSEKeepaliveInterval)

--- a/internal/api/http/memory_changes_test.go
+++ b/internal/api/http/memory_changes_test.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	"github.com/denn-gubsky/loomcycle/internal/store/cdc"
 	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
@@ -144,3 +146,76 @@ func TestMemoryChanges_OpeningFrameEchoesTheCursor(t *testing.T) {
 		t.Errorf("a rejected cursor must report the cursor in force (0):\n%s", body)
 	}
 }
+
+// TestMemoryChanges_OpeningFrameReportsEmbedderHealth.
+//
+// The reason this rides the change feed rather than a health endpoint: an
+// embedding failure on a content write is deliberately not fatal (the body is
+// stored, the embedding is skipped with a log line), so an embedder outage produces
+// a perfectly busy change feed over a store whose new rows are unsearchable. A
+// reader watching the feed to answer "is the memory pipeline healthy" would
+// otherwise conclude yes.
+//
+// `absent` and `untried` are asserted as distinct because collapsing them is the
+// mistake: one means nothing will ever be embedded, the other means nothing has been
+// yet.
+func TestMemoryChanges_OpeningFrameReportsEmbedderHealth(t *testing.T) {
+	raw, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer raw.Close()
+
+	t.Run("no embedder configured", func(t *testing.T) {
+		srv := &Server{store: cdc.Wrap(raw, nil), cfg: &config.Config{}}
+		body := runSSEOnce(t, srv.handleMemoryChanges, "/v1/_memory/changes")
+		if !strings.Contains(body, `"state":"absent"`) {
+			t.Errorf("want embedder state absent:\n%s", body)
+		}
+	})
+
+	t.Run("configured and observed", func(t *testing.T) {
+		obs := providers.ObserveEmbedder(&stubEmbedder{})
+		if _, e := obs.Embed(context.Background(), []string{"x"}); e != nil {
+			t.Fatal(e)
+		}
+		srv := &Server{store: cdc.Wrap(raw, nil), cfg: &config.Config{}}
+		srv.SetEmbedder(obs)
+		body := runSSEOnce(t, srv.handleMemoryChanges, "/v1/_memory/changes")
+		for _, want := range []string{`"state":"ok"`, `"provider":"stub"`, `"calls":1`} {
+			if !strings.Contains(body, want) {
+				t.Errorf("opening frame missing %s:\n%s", want, body)
+			}
+		}
+	})
+
+	t.Run("failing is visible and counted", func(t *testing.T) {
+		obs := providers.ObserveEmbedder(&stubEmbedder{err: errors.New("boom")})
+		for i := 0; i < 2; i++ {
+			_, _ = obs.Embed(context.Background(), []string{"x"})
+		}
+		srv := &Server{store: cdc.Wrap(raw, nil), cfg: &config.Config{}}
+		srv.SetEmbedder(obs)
+		body := runSSEOnce(t, srv.handleDocumentChanges, "/v1/_document/changes")
+		// The count is the actionable part: it is how many rows need re-embedding.
+		if !strings.Contains(body, `"state":"failing"`) || !strings.Contains(body, `"failures":2`) {
+			t.Errorf("want failing with a count:\n%s", body)
+		}
+		// And the raw error must not travel — only a classified kind.
+		if strings.Contains(body, "boom") {
+			t.Errorf("the frame leaked the driver's error text:\n%s", body)
+		}
+	})
+}
+
+type stubEmbedder struct{ err error }
+
+func (s *stubEmbedder) Embed(context.Context, []string) ([][]float32, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return [][]float32{{1}}, nil
+}
+func (s *stubEmbedder) Model() string    { return "stub-model" }
+func (s *stubEmbedder) Provider() string { return "stub" }
+func (s *stubEmbedder) Dimension() int   { return 1 }

--- a/internal/providers/embedder_observed.go
+++ b/internal/providers/embedder_observed.go
@@ -1,0 +1,180 @@
+package providers
+
+// embedder_observed.go — an Embedder decorator that records what happened, so a
+// reader can be TOLD the embedder is failing rather than inferring it from
+// results that look fine.
+//
+// WHY THIS IS NEEDED AT ALL, and it is not the obvious reason. An embedding
+// failure on a content write is deliberately NOT fatal: the chunk body is stored
+// and the embedding is skipped with one log line, because losing an author's text
+// to an unreachable embedder would be far worse than losing its searchability
+// (see internal/tools/builtin/document.go writeBody, and the admin re-embed
+// surface that exists to recover such a scope). The consequence is that an
+// embedder outage is INVISIBLE at the call site: every write succeeds, search
+// quietly stops finding the rows written during the outage, and the only trace is
+// a server log line an operator is not watching.
+//
+// So the thing worth reporting is not "can I reach the embedder" — a probe would
+// cost a model call per reader and still only describe one instant. It is what
+// the embedder ACTUALLY DID for the traffic that already went through it. Asking
+// the decorator is free at read time and cannot disagree with reality, the same
+// argument as cdc.Store.CapturesChanges().
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+// EmbedderState is the coarse answer a reader acts on.
+type EmbedderState string
+
+const (
+	// EmbedderAbsent — no embedder is configured. Nothing will ever be embedded,
+	// and no amount of waiting changes that.
+	EmbedderAbsent EmbedderState = "absent"
+	// EmbedderUntried — configured, but nothing has been embedded since boot. We
+	// genuinely do not know whether it works. Reported as its own state rather
+	// than folded into "ok", because claiming health we have not observed is the
+	// same class of lie as a disabled change feed reading as a quiet one.
+	EmbedderUntried EmbedderState = "untried"
+	// EmbedderOK — the most recent call succeeded.
+	EmbedderOK EmbedderState = "ok"
+	// EmbedderFailing — the most recent call failed. Rows written since then are
+	// stored but unsearchable; `backfill_embeddings` is the recovery.
+	EmbedderFailing EmbedderState = "failing"
+)
+
+// EmbedderHealth is what an observed embedder reports. Counts are SINCE BOOT and
+// process-local — this is an operator hint, not an SLO.
+//
+// Provider and Model are included because the capabilities report already
+// discloses exactly those (provider/model/dimension, "none of the three is a
+// secret or an address"). The base URL is NOT here and must not be added: it maps
+// the operator's network. Neither is the error TEXT — a dial error carries an
+// address — so failures are reported as a classified kind.
+type EmbedderHealth struct {
+	State        EmbedderState `json:"state"`
+	Provider     string        `json:"provider,omitempty"`
+	Model        string        `json:"model,omitempty"`
+	Calls        uint64        `json:"calls"`
+	Failures     uint64        `json:"failures"`
+	LastFailKind string        `json:"last_failure_kind,omitempty"`
+	// LastOKUnix / LastFailUnix are seconds, 0 when never. A reader shows "failing
+	// for 20 minutes" from these; an absolute stamp travels better than an age
+	// computed against the server's clock.
+	LastOKUnix   int64 `json:"last_ok_unix,omitempty"`
+	LastFailUnix int64 `json:"last_failure_unix,omitempty"`
+}
+
+// ObservedEmbedder wraps an Embedder and records each call's outcome.
+type ObservedEmbedder struct {
+	inner Embedder
+
+	mu       sync.Mutex
+	calls    uint64
+	failures uint64
+	// lastFailed is the OUTCOME OF THE MOST RECENT CALL, recorded rather than
+	// derived. Deriving it from `lastFail.After(lastOK)` looks equivalent and is
+	// not: two calls inside one clock tick make the comparison false, so a failure
+	// immediately after a success reports as ok — which is precisely the unchecked
+	// claim this type exists to prevent. It showed up as a test that passed alone
+	// and failed in the full suite, i.e. as flake, which is how a clock-derived
+	// state usually announces itself.
+	lastFailed   bool
+	lastOK       time.Time
+	lastFail     time.Time
+	lastFailKind string
+}
+
+var _ Embedder = (*ObservedEmbedder)(nil)
+
+// ObserveEmbedder decorates e. A nil embedder returns nil so the caller's
+// "no embedder configured" checks (`if d.Embedder == nil`) keep working — wrapping
+// nil into a non-nil interface holding a nil pointer is exactly how that check
+// silently stops firing.
+func ObserveEmbedder(e Embedder) *ObservedEmbedder {
+	if e == nil {
+		return nil
+	}
+	return &ObservedEmbedder{inner: e}
+}
+
+func (o *ObservedEmbedder) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+	vecs, err := o.inner.Embed(ctx, texts)
+	o.mu.Lock()
+	o.calls++
+	if err != nil {
+		o.failures++
+		o.lastFailed = true
+		o.lastFail = time.Now().UTC()
+		o.lastFailKind = classifyEmbedError(err)
+	} else {
+		o.lastFailed = false
+		o.lastOK = time.Now().UTC()
+	}
+	o.mu.Unlock()
+	return vecs, err
+}
+
+func (o *ObservedEmbedder) Model() string    { return o.inner.Model() }
+func (o *ObservedEmbedder) Provider() string { return o.inner.Provider() }
+func (o *ObservedEmbedder) Dimension() int   { return o.inner.Dimension() }
+
+// Unwrap exposes the underlying embedder for a call site that type-asserts a
+// concrete driver. Mirrors cdc.Store.Unwrap.
+func (o *ObservedEmbedder) Unwrap() Embedder { return o.inner }
+
+// Health reports the observed state.
+func (o *ObservedEmbedder) Health() EmbedderHealth {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	h := EmbedderHealth{
+		Provider:     o.inner.Provider(),
+		Model:        o.inner.Model(),
+		Calls:        o.calls,
+		Failures:     o.failures,
+		LastFailKind: o.lastFailKind,
+	}
+	if !o.lastOK.IsZero() {
+		h.LastOKUnix = o.lastOK.Unix()
+	}
+	if !o.lastFail.IsZero() {
+		h.LastFailUnix = o.lastFail.Unix()
+	}
+	switch {
+	case o.calls == 0:
+		h.State = EmbedderUntried
+	case o.lastFailed:
+		h.State = EmbedderFailing
+	default:
+		h.State = EmbedderOK
+	}
+	return h
+}
+
+// classifyEmbedError buckets a failure WITHOUT quoting it. The error text is the
+// one thing that cannot be forwarded: a transport failure reads like
+// `dial tcp 192.168.0.77:11434: connect: connection refused`, which is a map of
+// the operator's network — the same reason the capabilities report withholds the
+// base URL.
+//
+// Classified by ERRORS.IS where a sentinel exists, and left as "other" where one
+// does not, rather than sniffing substrings. A wrong bucket derived from string
+// matching would be a confident wrong answer, and "other" is an honest one. The
+// store's ErrEmbedderNotImplemented is deliberately NOT special-cased: it lives in
+// internal/store, this package must not depend on it, and an embedder that cannot
+// embed fails every call and therefore already reports as failing.
+func classifyEmbedError(err error) string {
+	switch {
+	case err == nil:
+		return ""
+	case errors.Is(err, context.DeadlineExceeded):
+		return "timeout"
+	case errors.Is(err, context.Canceled):
+		return "canceled"
+	default:
+		return "other"
+	}
+}

--- a/internal/providers/embedder_observed_test.go
+++ b/internal/providers/embedder_observed_test.go
@@ -1,0 +1,143 @@
+package providers
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type fakeEmbedder struct {
+	err   error
+	calls int
+}
+
+func (f *fakeEmbedder) Embed(context.Context, []string) ([][]float32, error) {
+	f.calls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return [][]float32{{0.1}}, nil
+}
+func (f *fakeEmbedder) Model() string    { return "embeddinggemma:latest" }
+func (f *fakeEmbedder) Provider() string { return "ollama-local" }
+func (f *fakeEmbedder) Dimension() int   { return 1 }
+
+// TestObserveEmbedder_UntriedIsNotHealthy.
+//
+// A configured-but-never-called embedder must NOT report ok. Claiming health that
+// has not been observed is the same class of lie as a disabled change feed reading
+// as a quiet one — and it is the state a freshly booted deployment is in, so it is
+// the state a reader sees most often.
+func TestObserveEmbedder_UntriedIsNotHealthy(t *testing.T) {
+	o := ObserveEmbedder(&fakeEmbedder{})
+	h := o.Health()
+	if h.State != EmbedderUntried {
+		t.Errorf("state = %q, want %q", h.State, EmbedderUntried)
+	}
+	if h.Calls != 0 || h.Failures != 0 {
+		t.Errorf("counts should be zero before any call, got %d/%d", h.Calls, h.Failures)
+	}
+	// Provider/model are knowable without a call and are what capabilities already
+	// discloses, so they belong even in the untried state.
+	if h.Provider != "ollama-local" || h.Model != "embeddinggemma:latest" {
+		t.Errorf("provider/model missing: %+v", h)
+	}
+}
+
+// TestObserveEmbedder_TracksOutcomesAndRecovers.
+//
+// The count is the actionable part — it is how many rows need re-embedding — and
+// recovery must flip the state back, or an operator who fixed the embedder still
+// sees "failing" and re-embeds forever.
+func TestObserveEmbedder_TracksOutcomesAndRecovers(t *testing.T) {
+	f := &fakeEmbedder{}
+	o := ObserveEmbedder(f)
+	ctx := context.Background()
+
+	if _, err := o.Embed(ctx, []string{"a"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := o.Health().State; got != EmbedderOK {
+		t.Errorf("after a success, state = %q, want ok", got)
+	}
+
+	f.err = context.DeadlineExceeded
+	for i := 0; i < 3; i++ {
+		if _, err := o.Embed(ctx, []string{"a"}); err == nil {
+			t.Fatal("expected the injected failure")
+		}
+	}
+	h := o.Health()
+	if h.State != EmbedderFailing {
+		t.Errorf("state = %q, want failing", h.State)
+	}
+	if h.Failures != 3 || h.Calls != 4 {
+		t.Errorf("calls/failures = %d/%d, want 4/3", h.Calls, h.Failures)
+	}
+	if h.LastFailKind != "timeout" {
+		t.Errorf("last_failure_kind = %q, want timeout", h.LastFailKind)
+	}
+
+	f.err = nil
+	if _, err := o.Embed(ctx, []string{"a"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := o.Health().State; got != EmbedderOK {
+		t.Errorf("after recovery, state = %q, want ok — a stuck `failing` sends an "+
+			"operator re-embedding a scope that is already fine", got)
+	}
+}
+
+// TestObserveEmbedder_NeverLeaksTheErrorText.
+//
+// The error text is the one thing that cannot be forwarded: a transport failure
+// reads `dial tcp 192.168.0.77:11434: connect: connection refused`, which is a map
+// of the operator's network — the same reason the capabilities report withholds the
+// embedder's base URL. Only a classified kind may escape.
+func TestObserveEmbedder_NeverLeaksTheErrorText(t *testing.T) {
+	secret := "dial tcp 192.168.0.77:11434: connect: connection refused"
+	o := ObserveEmbedder(&fakeEmbedder{err: errors.New(secret)})
+	if _, err := o.Embed(context.Background(), []string{"a"}); err == nil {
+		t.Fatal("expected the injected failure")
+	}
+	h := o.Health()
+	if h.LastFailKind != "other" {
+		t.Errorf("kind = %q, want other (no sentinel matched)", h.LastFailKind)
+	}
+	for _, needle := range []string{"192.168", "11434", "dial", "refused"} {
+		if strings.Contains(h.LastFailKind, needle) {
+			t.Errorf("health leaked %q from the error text: %+v", needle, h)
+		}
+	}
+}
+
+// TestObserveEmbedder_NilStaysNil.
+//
+// Every consumer gates on `if Embedder == nil`. Wrapping nil into a non-nil
+// interface holding a nil pointer is exactly how that check silently stops firing,
+// and the symptom would be a nil dereference on the first write of a deployment
+// that configured no embedder at all.
+func TestObserveEmbedder_NilStaysNil(t *testing.T) {
+	if o := ObserveEmbedder(nil); o != nil {
+		t.Fatalf("ObserveEmbedder(nil) = %v, want nil", o)
+	}
+	var e Embedder = ObserveEmbedder(nil)
+	_ = e // documents the hazard: this assignment is why the nil check above exists
+}
+
+// TestObserveEmbedder_PassesThroughTheDriverIdentity.
+//
+// Dimension in particular is load-bearing: the Memory tool refuses a search whose
+// dimension does not match the stored rows, so a decorator that reported its own
+// zero would break every vector search on a wrapped deployment.
+func TestObserveEmbedder_PassesThroughTheDriverIdentity(t *testing.T) {
+	o := ObserveEmbedder(&fakeEmbedder{})
+	if o.Dimension() != 1 || o.Provider() != "ollama-local" || o.Model() != "embeddinggemma:latest" {
+		t.Errorf("identity not passed through: dim=%d provider=%q model=%q",
+			o.Dimension(), o.Provider(), o.Model())
+	}
+	if _, ok := o.Unwrap().(*fakeEmbedder); !ok {
+		t.Error("Unwrap should return the wrapped driver")
+	}
+}

--- a/packages/memory-view/package-lock.json
+++ b/packages/memory-view/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@loomcycle/memory-view",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@loomcycle/memory-view",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@loomcycle/client": "^1.55.0",

--- a/packages/memory-view/package.json
+++ b/packages/memory-view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loomcycle/memory-view",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "description": "Embeddable React memory browser for the loomcycle agentic runtime (RFC BV) \u2014 a themeable, standalone k/v Vector Memory console (with a fact viewer + unified semantic search).",
   "license": "Apache-2.0",

--- a/packages/memory-view/src/components/ChangeFeedPanel.tsx
+++ b/packages/memory-view/src/components/ChangeFeedPanel.tsx
@@ -8,9 +8,11 @@ import {
   matchesFilter,
   CHANGE_BUFFER_CAP,
   CHANGE_FEED_ENV,
+  embedderNotice,
   type ChangeBuffer,
   type ChangeFamily,
   type ChangeFilter,
+  type EmbedderHealth,
   type MemoryChangeRow,
 } from "../lib/changeFeed";
 
@@ -60,6 +62,10 @@ export default function ChangeFeedPanel({ scopeId }: ChangeFeedPanelProps) {
   );
   const [err, setErr] = useState<string>("");
   const [paused, setPaused] = useState(false);
+  // Held separately from `state`: capture being on and the embedder working are
+  // independent failures, and a store can be busily capturing rows that nothing
+  // can find.
+  const [embedder, setEmbedder] = useState<EmbedderHealth | undefined>();
 
   const [filter, setFilter] = useState<ChangeFilter>({
     family: "",
@@ -86,6 +92,7 @@ export default function ChangeFeedPanel({ scopeId }: ChangeFeedPanelProps) {
         if (cancelled) return;
         if (frame.kind === "status") {
           setState(frame.status.enabled ? "live" : "disabled");
+          if (frame.status.embedder) setEmbedder(frame.status.embedder);
           continue;
         }
         setBuf((b) => appendChange(b, frame.change));
@@ -187,6 +194,8 @@ export default function ChangeFeedPanel({ scopeId }: ChangeFeedPanelProps) {
       )}
       {state === "error" && <div className="err">{err}</div>}
 
+      <EmbedderNote health={embedder} />
+
       <Counters buf={buf} shown={visible.length} state={state} />
 
       {visible.length === 0 ? (
@@ -242,6 +251,31 @@ function ChangeRow({ row }: { row: MemoryChangeRow }) {
       </td>
       <td className="change-feed-coord">{describeChange(row)}</td>
     </tr>
+  );
+}
+
+// EmbedderNote surfaces a failing or absent embedder. Silent when the embedder is
+// fine OR when the runtime did not report one at all — an older runtime cannot say,
+// and inventing "healthy" for it would be the same unchecked claim this panel exists
+// to avoid.
+function EmbedderNote({ health }: { health?: EmbedderHealth }) {
+  const notice = embedderNotice(health);
+  if (!notice) return null;
+  return (
+    <div
+      className={
+        "change-feed-note" +
+        (health?.state === "failing" ? " change-feed-note-warn" : "")
+      }
+    >
+      {notice}
+      {health?.provider && health?.model ? (
+        <span className="change-feed-embedder-id">
+          {" "}
+          ({health.provider}/{health.model})
+        </span>
+      ) : null}
+    </div>
   );
 }
 

--- a/packages/memory-view/src/lib/changeFeed.test.ts
+++ b/packages/memory-view/src/lib/changeFeed.test.ts
@@ -7,6 +7,8 @@ import {
   matchesFilter,
   describeChange,
   tailChanges,
+  embedderNotice,
+  type EmbedderHealth,
   type MemoryChangeRow,
 } from "./changeFeed";
 
@@ -230,5 +232,78 @@ describe("tailChanges (transport)", () => {
     ))
       void _;
     expect(seen.Authorization).toBeUndefined();
+  });
+});
+
+describe("embedderNotice", () => {
+  const h = (o: Partial<EmbedderHealth>): EmbedderHealth => ({
+    state: "ok",
+    calls: 10,
+    failures: 0,
+    ...o,
+  });
+
+  // The count is the actionable part — it is roughly how many rows need a backfill
+  // to become searchable again — so a notice without it is not worth showing.
+  it("names the failure count and the remedy when failing", () => {
+    const n = embedderNotice(
+      h({
+        state: "failing",
+        failures: 47,
+        calls: 312,
+        last_failure_kind: "timeout",
+      }),
+    );
+    expect(n).toContain("47");
+    expect(n).toContain("312");
+    expect(n).toContain("timeout");
+    expect(n.toLowerCase()).toContain("backfill");
+    // The distinction that matters: writes are FINE, searchability is not.
+    expect(n.toLowerCase()).toContain("not searchable");
+  });
+
+  it("says so when no embedder is configured", () => {
+    expect(embedderNotice(h({ state: "absent" })).toLowerCase()).toContain(
+      "no embedder",
+    );
+  });
+
+  // `untried` is the normal state of a freshly booted runtime. Warning about it
+  // would train an operator to ignore this line, which is the only thing that would
+  // be showing when it matters.
+  it("is silent for untried and ok", () => {
+    expect(embedderNotice(h({ state: "untried", calls: 0 }))).toBe("");
+    expect(embedderNotice(h({ state: "ok" }))).toBe("");
+  });
+
+  // An older runtime does not send the field at all. Inventing "healthy" for it
+  // would be the same unchecked claim the opening frame exists to prevent.
+  it("is silent when the runtime reported nothing", () => {
+    expect(embedderNotice(undefined)).toBe("");
+  });
+});
+
+describe("classifyFrame — embedder health rides the status frame", () => {
+  it("carries the embedder block through", () => {
+    const f = classifyFrame(
+      "feed",
+      '{"enabled":true,"since":0,"embedder":{"state":"failing","calls":5,"failures":5,"provider":"ollama-local","model":"embeddinggemma:latest"}}',
+    );
+    expect(f).toEqual({
+      kind: "status",
+      status: expect.objectContaining({
+        enabled: true,
+        embedder: expect.objectContaining({ state: "failing", failures: 5 }),
+      }),
+    });
+  });
+
+  // A runtime that predates the field still yields a usable status frame.
+  it("still reads a status frame with no embedder block", () => {
+    const f = classifyFrame("feed", '{"enabled":true,"since":0}');
+    expect(f?.kind).toBe("status");
+    expect(
+      (f as { status: { embedder?: unknown } }).status.embedder,
+    ).toBeUndefined();
   });
 });

--- a/packages/memory-view/src/lib/changeFeed.ts
+++ b/packages/memory-view/src/lib/changeFeed.ts
@@ -36,6 +36,58 @@ export interface MemoryChangeRow {
 export interface ChangeFeedStatus {
   enabled: boolean;
   since: number;
+  /** What the embedder has actually been doing. Absent on a runtime older than the
+   *  field — which reads as "this build cannot say", not as healthy. */
+  embedder?: EmbedderHealth;
+}
+
+/** The embedder's observed state, as the runtime reports it.
+ *
+ *  Why this is on a CHANGE feed: an embedding failure on a content write is not
+ *  fatal in loomcycle — the body is stored and the embedding skipped — so an
+ *  embedder outage produces a perfectly busy feed over a store whose new rows are
+ *  unsearchable. Without this, a reader watching the feed to decide "is memory
+ *  healthy" sees activity and concludes yes.
+ *
+ *  `untried` is its own state on purpose: a freshly booted runtime has embedded
+ *  nothing, and reporting that as healthy would be a claim nobody checked. */
+export interface EmbedderHealth {
+  state: "absent" | "untried" | "ok" | "failing";
+  provider?: string;
+  model?: string;
+  calls: number;
+  /** How many embeddings failed since boot. This is the actionable number: it is
+   *  roughly how many rows need `backfill_embeddings` to become searchable. */
+  failures: number;
+  last_failure_kind?: string;
+  last_ok_unix?: number;
+  last_failure_unix?: number;
+}
+
+/** embedderNotice renders the one sentence worth showing for a non-ok embedder, or
+ *  "" when there is nothing to say.
+ *
+ *  Kept as a pure function so the wording is testable and lives in one place — the
+ *  same reason factVerdict exists rather than the components each deciding what a
+ *  confidence means. */
+export function embedderNotice(e: EmbedderHealth | undefined): string {
+  if (!e) return "";
+  switch (e.state) {
+    case "failing":
+      return (
+        `The embedder is failing (${e.failures} of ${e.calls} calls` +
+        (e.last_failure_kind ? `, last: ${e.last_failure_kind}` : "") +
+        `). Content is still being stored, but anything written now is NOT searchable — ` +
+        `run a backfill once it recovers.`
+      );
+    case "absent":
+      return "No embedder is configured, so nothing written is semantically searchable.";
+    case "untried":
+      // NOT a warning. Normal for a runtime that has not embedded yet.
+      return "";
+    default:
+      return "";
+  }
 }
 
 export type ChangeFeedFrame =
@@ -81,10 +133,25 @@ export function classifyFrame(
     // enabled: the whole point of the frame is to stop a disabled feed reading as
     // a quiet one, and a permissive default reinstates exactly that.
     if (typeof p.enabled !== "boolean") return null;
-    return {
-      kind: "status",
-      status: { enabled: p.enabled, since: Number(p.since) || 0 },
+    const status: ChangeFeedStatus = {
+      enabled: p.enabled,
+      since: Number(p.since) || 0,
     };
+    // Carried through rather than rebuilt field by field. `state` is checked because
+    // everything downstream switches on it; the rest is passed as sent, so a newer
+    // runtime adding a field is not silently dropped here. This projection is written
+    // by hand, which is exactly how an added field goes missing — the test beside this
+    // one asserts the block survives, and it caught precisely that mistake.
+    const e = (parsed as { embedder?: Partial<EmbedderHealth> }).embedder;
+    if (e && typeof e.state === "string") {
+      status.embedder = {
+        ...e,
+        state: e.state,
+        calls: Number(e.calls) || 0,
+        failures: Number(e.failures) || 0,
+      } as EmbedderHealth;
+    }
+    return { kind: "status", status };
   }
   if (event === "change") {
     const p = parsed as Partial<MemoryChangeRow>;

--- a/packages/memory-view/src/styles.css
+++ b/packages/memory-view/src/styles.css
@@ -1397,3 +1397,13 @@
 .loomcycle-memory-view .change-feed-type-delete {
   color: var(--danger);
 }
+
+/* A failing embedder is a warning, not an error: writes are still succeeding. */
+.loomcycle-memory-view .change-feed-note-warn {
+  border-color: var(--danger);
+  color: var(--fg);
+}
+.loomcycle-memory-view .change-feed-embedder-id {
+  color: var(--fg-soft);
+  font-family: var(--lc-font-mono);
+}


### PR DESCRIPTION
An embedder outage is **invisible at every call site**, by design — and that makes the Activity tab from #1046 misleading in exactly the case it was built for.

A failed embedding on a content write is deliberately not fatal:

```go
// One log line, not a returned error — see writeBody. The admin re-embed
// surface is how an operator recovers a scope that was written while the
// embedder was down.
log.Printf("document: embed body failed for chunk %s: %v", chunkID, err)
```

That is the right trade (losing an author's text to an unreachable embedder is far worse than losing its searchability), but the consequence is that writes succeed, change frames keep arriving, and search quietly stops finding anything written during the outage. A reader watching the feed to answer *"is the memory pipeline healthy"* sees a busy feed and concludes yes.

## What

The opening `feed` frame gains an `embedder` block beside `enabled`:

```json
{"enabled": true, "since": 0,
 "embedder": {"state": "failing", "provider": "ollama-local", "model": "embeddinggemma:latest",
              "calls": 312, "failures": 47, "last_failure_kind": "timeout",
              "last_ok_unix": 1787040000, "last_failure_unix": 1787041200}}
```

**Not a probe.** Probing on connect would cost a model call per reader and still describe one instant. A new `providers.ObservedEmbedder` decorator records the outcome of traffic that already went through it — free at read time, and it cannot disagree with what the embedder actually did. Same argument as `cdc.Store.CapturesChanges()`.

Four decisions with a plausible wrong answer, each pinned by a test:

| decision | why the alternative is wrong |
|---|---|
| **`untried` is its own state** | a configured-but-never-called embedder must not report `ok` — that is the state a freshly booted deployment is in, so it is what a reader sees most often |
| **the failure *count*, not a boolean** | it is roughly how many rows need `backfill_embeddings` to become searchable, which connects the signal to the remedy that already exists |
| **no error text escapes** | `dial tcp 192.168.0.77:11434: connect: connection refused` is a map of the operator's network — the same reason capabilities withholds the base URL. Classified by `errors.Is`, left as `other` where no sentinel exists, never sniffed from substrings |
| **separate from `enabled`** | capture being on and the embedder working are independent failures; one boolean makes "capturing but unsearchable" look healthy |

`ObserveEmbedder(nil)` returns nil so the `if Embedder == nil` gates downstream keep firing, and the wrap happens **once in main before any consumer takes a reference** — so the health covers every embedding the process performs, not one subsystem's slice. An unconfigured deployment is byte-identical.

The console shows one sentence for a failing or absent embedder and stays **silent** for `untried`, `ok`, and a runtime too old to send the field. Warning about the normal boot state would train an operator to ignore the only line that matters when it fires. `@loomcycle/memory-view` → **0.3.1**.

## Two bugs caught during the build

**The state was derived from two clocks.** First version computed `lastFail.After(lastOK)`. Two calls inside one clock tick make that false, so a failure immediately after a success reported as **ok** — precisely the unchecked claim this type exists to prevent. It passed in isolation and failed in the full suite, which is how a clock-derived state announces itself: as flake. The outcome is now *recorded* at the moment it happens rather than inferred.

**`classifyFrame` silently dropped the new block.** The status projection is built by hand, so an added field goes missing exactly as it did in the `list_facts` projection twice before in this line of work. The test asserting the block survives caught it before it shipped.

## Verification

`go test ./...` clean (91 packages); `-race -count=5` clean on the new package (it holds a mutex over counters read from an SSE handler); `tsc --noEmit` clean; 63 package tests; `build:lib` and `make build-ui` clean.

New tests: `TestObserveEmbedder_{UntriedIsNotHealthy, TracksOutcomesAndRecovers, NeverLeaksTheErrorText, NilStaysNil, PassesThroughTheDriverIdentity}` — the recovery case asserts `failing` flips back to `ok`, or an operator who fixed the embedder re-embeds forever; `TestMemoryChanges_OpeningFrameReportsEmbedderHealth` across absent/observed/failing on both endpoints; plus the `embedderNotice` and `classifyFrame` cases.

## A correction to the reasoning that prompted this

I originally attributed yesterday's failed `import_md` to the embedder, on the strength of a probe table showing embedding-dependent writes failing while reads succeeded. That inference was wrong: the healthy probes ran *after* recovery rather than during the outage, and — as this PR documents — an embedder failure **cannot** fail a `create_chunk` at all. It was the runtime reloading, as reported. The feature stands on its own merits; the diagnosis that motivated it did not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8
