### PR TITLE
fix(webui): web pinned an old @loomcycle/client, so the console sweep buttons threw

### DIFF
--- a/internal/api/http/memory_purge.go
+++ b/internal/api/http/memory_purge.go
@@ -30,6 +30,7 @@ import (
 	"context"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
@@ -75,8 +76,14 @@ func (s *Server) handleMemoryPurgeStaleEmbeddings(w http.ResponseWriter, r *http
 		return
 	}
 	scopeID := r.URL.Query().Get("scope_id")
-	if scopeID == "" {
-		writeJSONError(w, http.StatusBadRequest, "missing_scope_id", "scope_id is required")
+	// The tenant keyspace is ONE tenant-wide partition with an empty store scope_id,
+	// so a tenant-scope call legitimately has none — which is what
+	// adminMemoryScopeIDRequired exists to express, and what reembed and
+	// backfill_embeddings both use. Demanding it unconditionally here made this route
+	// advertise `tenant` in its own validator above and then refuse it.
+	if adminMemoryScopeIDRequired(scope) && strings.TrimSpace(scopeID) == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing_scope_id",
+			"scope_id is required for scope="+scope+" (tenant is a single keyspace and needs none)")
 		return
 	}
 	// dry_run defaults TRUE. This one DELETES, so the default matters more than on the

--- a/internal/webui/deduped_peer_test.go
+++ b/internal/webui/deduped_peer_test.go
@@ -1,0 +1,210 @@
+package webui
+
+// deduped_peer_test.go — the web app's dependency on a DEDUPED package must satisfy
+// the peer range of every package consumed from source.
+//
+// WHY THIS TEST EXISTS, from a bug that reached a release. @loomcycle/memory-view is
+// compiled from SOURCE through a Vite alias, and web/vite.config.ts lists
+// @loomcycle/client in `resolve.dedupe`. Dedupe makes web/node_modules' copy the one
+// that ends up in the BUNDLE — so web's version, not the package's own, is what runs
+// in the browser.
+//
+// Nothing caught the mismatch, and the two obvious candidates each cannot:
+//
+//   - `tsc --noEmit` (which web's build DOES run) resolves @loomcycle/client from the
+//     memory-view SOURCE file, i.e. packages/memory-view/node_modules — the correct,
+//     newer copy. It typechecks clean against a version the bundle will not contain.
+//   - `vite build` strips types with esbuild and performs no such check.
+//
+// So web pinned ^1.49.0 while memory-view declared peer ^1.55.0, the build was green,
+// and the console threw `e.backfillEmbeddings is not a function` at an operator —
+// two methods that landed in the client at 1.55.0 were simply absent from the bundle.
+//
+// A Go test rather than a lint rule because `go test ./...` is the gate everybody
+// already runs, including CI, and this needs no node_modules to be installed.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// sourceConsumedPackages are the packages web compiles from source via a Vite alias.
+// Extend this when another one is added — the same trap applies to each.
+var sourceConsumedPackages = []string{
+	"../../packages/memory-view/package.json",
+	"../../packages/library/package.json",
+	"../../packages/explorer/package.json",
+}
+
+type pkgJSON struct {
+	Name             string            `json:"name"`
+	Version          string            `json:"version"`
+	Dependencies     map[string]string `json:"dependencies"`
+	PeerDependencies map[string]string `json:"peerDependencies"`
+}
+
+func readPkg(t *testing.T, path string) pkgJSON {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Skipf("%s not present: %v", path, err)
+	}
+	var p pkgJSON
+	if err := json.Unmarshal(b, &p); err != nil {
+		t.Fatalf("%s: %v", path, err)
+	}
+	return p
+}
+
+// minVersion extracts the lower bound of a simple npm range ("^1.56.0", "~1.2.3",
+// ">=1.2.3", "1.2.3"). Ranges this does not understand return ok=false and are
+// SKIPPED rather than guessed at — a wrong comparison would be worse than none.
+func minVersion(rng string) (maj, min, patch int, ok bool) {
+	s := strings.TrimSpace(rng)
+	// A disjunction ("^18.0.0 || ^19.0.0") is satisfied by any branch, so its lower
+	// bound is the LOWEST branch. Taking that keeps react/react-dom guarded instead of
+	// skipped. It means the check only catches web being too OLD, never too new — which
+	// is the direction that removes methods from the bundle.
+	if i := strings.Index(s, "||"); i >= 0 {
+		s = strings.TrimSpace(s[:i])
+	}
+	for _, p := range []string{"^", "~", ">=", ">", "=", "v"} {
+		s = strings.TrimPrefix(s, p)
+	}
+	parts := strings.SplitN(s, ".", 3)
+	if len(parts) != 3 {
+		return 0, 0, 0, false
+	}
+	nums := make([]int, 3)
+	for i, p := range parts {
+		// Drop any prerelease/build suffix.
+		if idx := strings.IndexAny(p, "-+"); idx >= 0 {
+			p = p[:idx]
+		}
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return 0, 0, 0, false
+		}
+		nums[i] = n
+	}
+	return nums[0], nums[1], nums[2], true
+}
+
+func TestWebDedupedDeps_SatisfySourcePackagePeers(t *testing.T) {
+	web := readPkg(t, "../../web/package.json")
+	deduped := dedupedFromViteConfig(t)
+	if len(deduped) == 0 {
+		t.Fatal("parsed no dedupe list from web/vite.config.ts — the guard would pass vacuously")
+	}
+
+	for _, path := range sourceConsumedPackages {
+		pkg := readPkg(t, path)
+		for dep, peerRange := range pkg.PeerDependencies {
+			if !deduped[dep] {
+				// Not deduped: the package's own copy is bundled, so web's version
+				// does not govern. Nothing to check.
+				continue
+			}
+			webRange, present := web.Dependencies[dep]
+			if !present {
+				t.Errorf("%s peers on deduped %q but web/package.json does not depend on it — "+
+					"dedupe would resolve it from web/node_modules, which has no copy",
+					pkg.Name, dep)
+				continue
+			}
+			pMaj, pMin, pPatch, okP := minVersion(peerRange)
+			wMaj, wMin, wPatch, okW := minVersion(webRange)
+			if !okP || !okW {
+				t.Logf("skipping %s %s: unparsed range (peer %q, web %q)", pkg.Name, dep, peerRange, webRange)
+				continue
+			}
+			peer := [3]int{pMaj, pMin, pPatch}
+			have := [3]int{wMaj, wMin, wPatch}
+			if less(have, peer) {
+				t.Errorf("web/package.json has %s %q but %s peers on %q.\n"+
+					"  %s is DEDUPED in web/vite.config.ts, so web's copy is what lands in the\n"+
+					"  bundle — the older methods are simply absent at runtime, and neither\n"+
+					"  `tsc --noEmit` (resolves the package's own newer copy) nor `vite build`\n"+
+					"  (no typecheck) will tell you. Bump web to at least %q.",
+					dep, webRange, pkg.Name, peerRange, dep, peerRange)
+			}
+		}
+	}
+}
+
+func less(a, b [3]int) bool {
+	for i := 0; i < 3; i++ {
+		if a[i] != b[i] {
+			return a[i] < b[i]
+		}
+	}
+	return false
+}
+
+// dedupedFromViteConfig reads the resolve.dedupe list out of web/vite.config.ts.
+// Parsed from the real config rather than duplicated here, so removing a name from
+// the dedupe list correctly relaxes this test instead of leaving it asserting a rule
+// the build no longer follows.
+func dedupedFromViteConfig(t *testing.T) map[string]bool {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("..", "..", "web", "vite.config.ts"))
+	if err != nil {
+		t.Skipf("web/vite.config.ts unreadable: %v", err)
+	}
+	src := string(b)
+	i := strings.Index(src, "dedupe:")
+	if i < 0 {
+		return nil
+	}
+	open := strings.Index(src[i:], "[")
+	close := strings.Index(src[i:], "]")
+	if open < 0 || close < 0 || close < open {
+		return nil
+	}
+	out := map[string]bool{}
+	for _, raw := range strings.Split(src[i+open+1:i+close], ",") {
+		s := strings.TrimSpace(strings.Trim(strings.TrimSpace(raw), `"'`))
+		if s != "" && !strings.HasPrefix(s, "//") {
+			out[s] = true
+		}
+	}
+	return out
+}
+
+// TestWebDedupedDeps_GuardActuallyCompares proves the comparison is not vacuous —
+// an older web range against a newer peer must be reported.
+func TestWebDedupedDeps_GuardActuallyCompares(t *testing.T) {
+	cases := []struct {
+		web, peer string
+		wantLess  bool
+	}{
+		{"^1.49.0", "^1.55.0", true}, // the bug that shipped
+		{"^1.56.0", "^1.55.0", false},
+		{"^1.55.0", "^1.55.0", false},
+		{"^1.55.0", "^1.55.1", true},
+		{"^2.0.0", "^1.55.0", false},
+	}
+	for _, c := range cases {
+		wM, wm, wp, ok1 := minVersion(c.web)
+		pM, pm, pp, ok2 := minVersion(c.peer)
+		if !ok1 || !ok2 {
+			t.Fatalf("failed to parse %q / %q", c.web, c.peer)
+		}
+		got := less([3]int{wM, wm, wp}, [3]int{pM, pm, pp})
+		if got != c.wantLess {
+			t.Errorf("web %s vs peer %s: less=%v, want %v", c.web, c.peer, got, c.wantLess)
+		}
+	}
+	if _, _, _, ok := minVersion("workspace:*"); ok {
+		t.Error("an unparseable range must report ok=false rather than a guessed number")
+	}
+	// A disjunction resolves to its lowest branch, so react's real peer is covered
+	// rather than skipped.
+	if maj, _, _, ok := minVersion("^18.0.0 || ^19.0.0"); !ok || maj != 18 {
+		t.Errorf("disjunction should resolve to its lowest branch, got maj=%d ok=%v", maj, ok)
+	}
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,7 +11,7 @@
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
         "@fontsource-variable/outfit": "^5.2.8",
-        "@loomcycle/client": "^1.49.0",
+        "@loomcycle/client": "^1.56.0",
         "js-yaml": "^4.2.0",
         "lucide-react": "^0.460.0",
         "mermaid": "^11.16.0",
@@ -876,9 +876,9 @@
       }
     },
     "node_modules/@loomcycle/client": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/@loomcycle/client/-/client-1.49.0.tgz",
-      "integrity": "sha512-qiK9jgktJANI9WKOEBABjxSq1nEKIRnUNrjacDBd3Wz7//o6vTcLbpPVsYzvS4bO/fUCsKg+dW1dYg0X+zS3Kw==",
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@loomcycle/client/-/client-1.56.0.tgz",
+      "integrity": "sha512-HR8jLmWyjzQwOkqYAKe8uec3bJ07O8pbSKUEKOFaZDRY+vFw1ZO6ba6wciFUlheut792tLYSU6q+Fq1yqHFf0Q==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"

--- a/web/package.json
+++ b/web/package.json
@@ -15,7 +15,7 @@
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@fontsource-variable/outfit": "^5.2.8",
-    "@loomcycle/client": "^1.49.0",
+    "@loomcycle/client": "^1.56.0",
     "js-yaml": "^4.2.0",
     "lucide-react": "^0.460.0",
     "mermaid": "^11.16.0",


### PR DESCRIPTION
An operator pressing **Backfill** or **Purge** in the Memory console got `e.backfillEmbeddings is not a function`. Both methods landed in `@loomcycle/client` at **1.55.0**; `web/package.json` depended on **`^1.49.0`**.

## Why nothing caught it

This is the part worth fixing. `@loomcycle/memory-view` is compiled from **source** through a Vite alias, and `web/vite.config.ts` lists `@loomcycle/client` in `resolve.dedupe` — added, per its own comment, *"for good measure — a duplicate is wasteful even if not fatal."*

Dedupe makes **web's** copy the one that lands in the bundle, which quietly turned a wasteful duplicate into a **version downgrade**. And the two checks that should have caught it each structurally cannot:

| check | why it passes anyway |
|---|---|
| `tsc --noEmit` (web's build **does** run it) | resolves `@loomcycle/client` from the memory-view *source file* → `packages/memory-view/node_modules`, the correct 1.55.0 copy. It typechecks clean against a version the bundle will not contain. |
| `vite build` | strips types with esbuild; no such check. |

So the build was green in CI *and* in `make build-ui`, and the failure appeared only in a browser at the moment a button was pressed.

`reembed` kept working because `reembedMemory` has existed since 1.49.0 — which is why three buttons failed in two different ways and looked like three unrelated bugs:

| method | 1.49.0 | 1.56.0 | symptom |
|---|---|---|---|
| `reembedMemory` | present | present | worked (returned a real 0) |
| `backfillEmbeddings` | **missing** | present | `is not a function` |
| `purgeStaleEmbeddings` | **missing** | present | `is not a function` |

## Fixes

**1. `web/package.json` → `^1.56.0`** (+ lockfile). Verified in the built bundle rather than by inference — `backfillEmbeddings`, `purgeStaleEmbeddings`, `reembedMemory` and all three endpoint paths are now present in `internal/webui/dist`.

**2. A guard: `TestWebDedupedDeps_SatisfySourcePackagePeers`.** For every package web consumes from source, any peer dependency that is *also* in vite's dedupe list must be satisfied by web's own dependency range.

- A **Go** test, because `go test ./...` is the gate everyone already runs and it needs no `node_modules` installed.
- The dedupe list is **parsed from the real `vite.config.ts`**, so removing a name there correctly relaxes the test rather than leaving it asserting a rule the build no longer follows.
- Verified to **fail on the pre-fix tree**, with the diagnosis in the failure message.
- A `||` peer range resolves to its **lowest** branch, so `react`/`react-dom` are covered rather than skipped. The check is deliberately one-directional: too *old* is what removes methods from a bundle.

**3. `purge_stale_embeddings` honours the tenant carve-out.** Its validator advertises `agent, user, tenant` and then demanded `scope_id` unconditionally, so a tenant-scope call was refused with `missing_scope_id` — while `reembed` and `backfill` both use `adminMemoryScopeIDRequired` for exactly that case (the tenant keyspace is one partition with an empty store scope_id).

**Latent, and explicitly not what was reported** — the client never had the method, so that request never reached the server. I had this as my leading theory until the version comparison showed both missing methods, which is a reminder that a plausible server-side bug and the actual client-side one can produce the same button.

## What was tested

`go test ./...` clean (91 packages). `make build-ui` clean, with the bundle contents asserted afterwards.

## Delivery

The Web UI is embedded in the binary, so this needs a **patch release** to reach a deployment — the fix is inert until the runtime is rebuilt.

Found while migrating a live deployment from `embeddinggemma` (768d) to `bge-m3` (1024d), where the console's sweeps are exactly the tool an operator reaches for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8
