### PR TITLE
fix(memory): non-Latin facts no longer collide on one key (#1047)

### DIFF
--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -1960,7 +1960,45 @@ agents:
         if (!keep.length) { keep = words.slice(0, 6); }
         var out = keep.join("-");
         if (out.length > 60) { out = out.slice(0, 60).replace(/-+$/, ""); }
-        return out || "unnamed";
+        // A TEXT THAT TOKENISES TO NOTHING STILL NEEDS ITS OWN KEY. rawWords is
+        // ASCII-only (/[^a-z0-9]+/), so a fact written in Cyrillic, Greek, Hebrew, or
+        // any CJK script reduces to no words at all — and the old constant "unnamed"
+        // made every one of them the SAME key. factKey is the pass's idempotency
+        // mechanism and write() upserts on it, so the second such fact silently
+        // OVERWROTE the first and a scope's entire non-Latin population collapsed onto
+        // one row. Measured against the real engine: two different Ukrainian facts both
+        // keyed memory/fact/unnamed.
+        //
+        // The suffix is a pure function of the text, which is the property that matters:
+        // factKey must stay deterministic or a re-run of the pass would write a second
+        // row for a fact it already stored. Two independent 32-bit hashes rather than
+        // one, because a single 32-bit space collides at roughly a percent by ten
+        // thousand facts — and a collision here is the very failure being fixed.
+        //
+        // Base36 keeps the result inside [a-z0-9-]: this key is interpolated into SQL
+        // by the lookup path, so the fallback must never introduce a character the slug
+        // rules exclude.
+        //
+        // This does NOT widen the tokeniser. A non-Latin fact still derives no span
+        // (subjectOverlap sees no shared words), so it stores as unverified-and-visible
+        // rather than verified. That is the separate, larger change; this one stops the
+        // data loss.
+        return out || ("unnamed-" + textFingerprint(text));
+      }
+
+      // textFingerprint is a deterministic, replay-pure 64-bit fingerprint rendered in
+      // base36. Two djb2 variants with different seeds are combined; only 32-bit shift
+      // and add are used, because the engine here is ES5.1-era and Math.imul is not
+      // available (and a plain 32-bit multiply loses precision past 2^53).
+      function textFingerprint(text) {
+        var s = String(text);
+        var a = 5381, b = 52711;
+        for (var i = 0; i < s.length; i++) {
+          var c = s.charCodeAt(i);
+          a = ((a << 5) + a + c) | 0;
+          b = ((b << 5) + b + (c ^ 0x5f)) | 0;
+        }
+        return (a >>> 0).toString(36) + (b >>> 0).toString(36);
       }
 
       // rawWords / contentWords are the ONE tokenisation in this file, shared by

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -1960,7 +1960,45 @@ agents:
         if (!keep.length) { keep = words.slice(0, 6); }
         var out = keep.join("-");
         if (out.length > 60) { out = out.slice(0, 60).replace(/-+$/, ""); }
-        return out || "unnamed";
+        // A TEXT THAT TOKENISES TO NOTHING STILL NEEDS ITS OWN KEY. rawWords is
+        // ASCII-only (/[^a-z0-9]+/), so a fact written in Cyrillic, Greek, Hebrew, or
+        // any CJK script reduces to no words at all — and the old constant "unnamed"
+        // made every one of them the SAME key. factKey is the pass's idempotency
+        // mechanism and write() upserts on it, so the second such fact silently
+        // OVERWROTE the first and a scope's entire non-Latin population collapsed onto
+        // one row. Measured against the real engine: two different Ukrainian facts both
+        // keyed memory/fact/unnamed.
+        //
+        // The suffix is a pure function of the text, which is the property that matters:
+        // factKey must stay deterministic or a re-run of the pass would write a second
+        // row for a fact it already stored. Two independent 32-bit hashes rather than
+        // one, because a single 32-bit space collides at roughly a percent by ten
+        // thousand facts — and a collision here is the very failure being fixed.
+        //
+        // Base36 keeps the result inside [a-z0-9-]: this key is interpolated into SQL
+        // by the lookup path, so the fallback must never introduce a character the slug
+        // rules exclude.
+        //
+        // This does NOT widen the tokeniser. A non-Latin fact still derives no span
+        // (subjectOverlap sees no shared words), so it stores as unverified-and-visible
+        // rather than verified. That is the separate, larger change; this one stops the
+        // data loss.
+        return out || ("unnamed-" + textFingerprint(text));
+      }
+
+      // textFingerprint is a deterministic, replay-pure 64-bit fingerprint rendered in
+      // base36. Two djb2 variants with different seeds are combined; only 32-bit shift
+      // and add are used, because the engine here is ES5.1-era and Math.imul is not
+      // available (and a plain 32-bit multiply loses precision past 2^53).
+      function textFingerprint(text) {
+        var s = String(text);
+        var a = 5381, b = 52711;
+        for (var i = 0; i < s.length; i++) {
+          var c = s.charCodeAt(i);
+          a = ((a << 5) + a + c) | 0;
+          b = ((b << 5) + b + (c ^ 0x5f)) | 0;
+        }
+        return (a >>> 0).toString(36) + (b >>> 0).toString(36);
       }
 
       // rawWords / contentWords are the ONE tokenisation in this file, shared by

--- a/cmd/loomcycle/presets_memory_codejs_test.go
+++ b/cmd/loomcycle/presets_memory_codejs_test.go
@@ -3109,6 +3109,131 @@ func TestConsolidator_ARegexInProseIsNotEvidence(t *testing.T) {
 	}
 }
 
+// TestConsolidator_NonLatinFactsGetDistinctKeys (#1047).
+//
+// rawWords tokenises on /[^a-z0-9]+/, so a fact written in a non-Latin script reduces
+// to no words and slug() fell back to the constant "unnamed". factKey is the pass's
+// idempotency mechanism and write() upserts on it, so the SECOND such fact silently
+// overwrote the first: a scope's entire non-Latin population collapsed onto one row.
+// Verified against the real engine before the fix — two different Ukrainian facts both
+// keyed memory/fact/unnamed.
+func TestConsolidator_NonLatinFactsGetDistinctKeys(t *testing.T) {
+	f := newFakeToolset()
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	f.transcript = "### user\n\nКористувач живе у Києві і вимкнув нічні резервні копії.\n\n"
+	f.factsJSON = `[` +
+		`{"text":"Користувач живе у Києві.","class":"fact","type":"location","subject":"Київ"},` +
+		`{"text":"Користувач вимкнув нічні резервні копії.","class":"fact","type":"object","subject":"копії"}` +
+		`]`
+
+	runConsolidator(t, f)
+
+	var keys []string
+	for _, c := range f.calls {
+		if c.Tool == "Memory" && c.Op == "set" {
+			if k, _ := c.Input["key"].(string); k != "" {
+				keys = append(keys, k)
+			}
+		}
+	}
+	if len(keys) != 2 {
+		t.Fatalf("expected two writes, got %d: %v", len(keys), keys)
+	}
+	if keys[0] == keys[1] {
+		t.Errorf("two DIFFERENT facts share one key %q — the second overwrites the first", keys[0])
+	}
+	for _, k := range keys {
+		if strings.HasSuffix(k, "/unnamed") {
+			t.Errorf("key %q still uses the colliding constant", k)
+		}
+		// The key is interpolated into SQL by the lookup path, so the fallback must
+		// introduce nothing outside the slug alphabet.
+		for _, r := range strings.TrimPrefix(k, "memory/") {
+			if !(r == '/' || r == '-' || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')) {
+				t.Errorf("key %q contains %q, outside [a-z0-9-/]", k, r)
+			}
+		}
+	}
+}
+
+// TestConsolidator_NonLatinFactKeyIsStableAcrossPasses.
+//
+// The suffix must be a pure function of the text. If it varied — a counter, a clock, a
+// random — then a re-run of the pass would write a SECOND row for a fact it had already
+// stored, turning a fixed collision bug into an unbounded duplication bug. This is the
+// property that makes the whole pass safe to re-run, so it is asserted directly.
+func TestConsolidator_NonLatinFactKeyIsStableAcrossPasses(t *testing.T) {
+	keyFor := func() string {
+		f := newFakeToolset()
+		f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+		f.transcript = "### user\n\nКористувач живе у Києві.\n\n"
+		f.factsJSON = `[{"text":"Користувач живе у Києві.","class":"fact",` +
+			`"type":"location","subject":"Київ"}]`
+		runConsolidator(t, f)
+		for _, c := range f.calls {
+			if c.Tool == "Memory" && c.Op == "set" {
+				if k, _ := c.Input["key"].(string); k != "" {
+					return k
+				}
+			}
+		}
+		t.Fatal("no write observed")
+		return ""
+	}
+	first, second := keyFor(), keyFor()
+	if first != second {
+		t.Errorf("key is not deterministic: %q then %q — a re-run would duplicate the fact",
+			first, second)
+	}
+	// GOLDEN, and this is the assertion that carries the weight. Comparing two runs
+	// barely tests anything: code-js is replay-pure (no clock, no randomness) so a
+	// varying suffix is already impossible, and each run gets a fresh VM so even a
+	// counter would reset and look stable — verified by probing exactly that.
+	//
+	// The real hazard is someone CHANGING the derivation later. Every non-Latin fact
+	// already stored is addressed by this exact string, so a "better hash" would orphan
+	// all of them and the next pass would rewrite the store under new names. Pinning the
+	// value makes that a failing test rather than a silent migration.
+	const golden = "memory/fact/unnamed-1t8x120hl3n7g"
+	if first != golden {
+		t.Errorf("non-Latin key derivation CHANGED: %q, was %q.\nEvery non-Latin fact in "+
+			"every existing store is addressed by the old string — changing this orphans "+
+			"them. If the change is deliberate, it needs a key migration, not a new golden.",
+			first, golden)
+	}
+}
+
+// TestConsolidator_LatinFactKeysAreUNCHANGED.
+//
+// The fix touches ONLY the empty-slug branch. Any text that already produced a slug must
+// key exactly as before: every fact in every existing store is addressed by these keys,
+// so a changed derivation would orphan the lot and the next pass would rewrite the store
+// under new names. This is the test that makes the fix safe to deploy on live data.
+func TestConsolidator_LatinFactKeysAreUNCHANGED(t *testing.T) {
+	f := newFakeToolset()
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	f.transcript = "### user\n\nI live in Cluj-Napoca and I run loomcycle at home.\n\n"
+	f.factsJSON = `[{"text":"The user lives in Cluj-Napoca.","class":"fact",` +
+		`"type":"location","subject":"Cluj-Napoca"}]`
+
+	runConsolidator(t, f)
+
+	var key string
+	for _, c := range f.calls {
+		if c.Tool == "Memory" && c.Op == "set" {
+			key, _ = c.Input["key"].(string)
+		}
+	}
+	// The exact pre-fix key for this text: memory/<class>/<first 6 content words>.
+	if key != "memory/fact/user-lives-cluj-napoca" {
+		t.Errorf("Latin key changed to %q — every fact in every existing store is addressed "+
+			"by this derivation, so a change orphans them all", key)
+	}
+	if strings.Contains(key, "unnamed") {
+		t.Errorf("key %q took the fallback branch for text that tokenises fine", key)
+	}
+}
+
 // --------------------------------------------------------------- the judge
 //
 // Every scenario below drives the SHIPPED body. The judge is opt-in, so each one


### PR DESCRIPTION
Closes #1047.

`rawWords` tokenises on `/[^a-z0-9]+/`, so a fact written in Cyrillic, Greek, Hebrew or any CJK script reduces to **no words at all**, and `slug()` fell back to the constant `"unnamed"`. `factKey` is the pass's idempotency mechanism and `write()` upserts on it — so the **second** such fact silently overwrote the first, and a scope's entire non-Latin population collapsed onto one row.

Verified against the real engine before the fix:

```
PROBE: 2 Memory.set call(s), keys = [memory/fact/unnamed memory/fact/unnamed]
```

The entity-tier mirror uses the same string as its `natural_key`, so it collided identically. Nothing guarded it: the `merge_min_subject_overlap` refusal protects the *similarity* path, not a deterministic key upsert.

## The fix — the fallback only

An empty slug now appends a fingerprint of the text. Four constraints, each with a reason:

- **A pure function of the text**, because `factKey` must stay deterministic or a re-run of the pass would write a second row for a fact it already stored — turning a bounded collision bug into unbounded duplication.
- **Two 32-bit hashes, not one.** A single 32-bit space collides at roughly a percent by ten thousand facts, and a collision here is the very failure being fixed.
- **Only 32-bit shift and add.** The engine is ES5.1-era: `Math.imul` is absent, and a plain 32-bit multiply loses precision past 2^53.
- **Base36**, so the result stays inside `[a-z0-9-]` — this key is interpolated into SQL by the lookup path, so the fallback must not introduce a character the slug rules exclude.

## What this deliberately does not do

**It does not widen the tokeniser.** A non-Latin fact still derives no span (`subjectOverlap` finds no shared words), so it stores as *unverified-and-visible* rather than verified. That is the larger change from the issue — it redefines what a "word" is and so requires re-measuring the `merge_min_subject_overlap` floor against 18 labelled pairs — and it is not attempted here. This PR stops the **data loss**; verification coverage for non-Latin facts remains open.

## Tests

| test | what it protects |
|---|---|
| `NonLatinFactsGetDistinctKeys` | two Ukrainian facts get two keys, and the key stays inside the slug alphabet. **Fails on the pre-fix tree** with the exact colliding string. |
| `LatinFactKeysAreUNCHANGED` | pins the existing derivation for text that tokenises. Every fact in every existing store is addressed by these keys — this is the test that makes the change safe on live data. |
| `NonLatinFactKeyIsStableAcrossPasses` | carries a **golden**. |

**On that last one — my first version was nearly vacuous and the probe caught it.** It compared two runs, which asserts almost nothing here: code-js is replay-pure, so a varying suffix is already impossible, and each run gets a fresh VM, so even an injected counter resets and looks stable. I probed exactly that (a per-call counter in the fingerprint) and the test **passed**.

So it now pins the value instead. The real hazard isn't randomness — it's someone landing a "better hash" later and orphaning every non-Latin fact already stored. The golden makes that a failing test with an explicit message rather than a silent migration, and a **one-digit seed change trips it**.

`go test ./...` clean (91 packages); both bundle copies byte-identical.

Found while migrating a live deployment to `bge-m3` for multilingual memory — where a 100-language embedder over a keyspace that cannot tell two Ukrainian facts apart is only half a solution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8
