### PR TITLE
fix(memory): reembed honours ?tenant=, and an admin who names none is refused

### DIFF
--- a/internal/api/http/memory_admin.go
+++ b/internal/api/http/memory_admin.go
@@ -3,6 +3,7 @@ package http
 import (
 	"encoding/json"
 	"errors"
+	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"net/http"
 	"strconv"
 	"strings"
@@ -215,9 +216,37 @@ func (s *Server) handleMemoryReembed(w http.ResponseWriter, r *http.Request) {
 			limit = n
 		}
 	}
-	// RFC BL: tenant from the authenticated principal, reused for the read +
-	// the write-back below so the reembed stays within one tenant partition.
-	tenantID := tenantFromCtx(r.Context())
+	// ?tenant= IS HONOURED FOR AN ADMIN, and an admin who names none is REFUSED.
+	//
+	// This route took the tenant from the caller's principal alone, which is the same
+	// defect already fixed in embed_stats and guarded in purge_stale_embeddings — and
+	// it was the worst of the three places to have it. An operator migrating another
+	// tenant's scope after an embedder change swept their OWN partition, found nothing
+	// to re-embed, and got `rows_total: 0` — indistinguishable from "already migrated".
+	// The store then keeps serving that tenant's rows to a vector search that silently
+	// excludes them, because nothing errors once any row of the new dimension exists.
+	//
+	// Refused rather than defaulted, like purge: a reembed WRITES (and spends one
+	// embedder call per row), so sweeping a partition the operator never named is not
+	// merely a misleading count. Has() distinguishes an explicit `?tenant=` — the
+	// default partition, i.e. the whole deployment on a single-tenant install — from an
+	// omitted one, so a single-tenant admin can still ask.
+	tenantID, all := s.principalTenantScope(r.Context(), r.URL.Query().Get("tenant"))
+	// Scoped to an AUTHENTICATED ADMIN, deliberately narrower than the sibling guard on
+	// backfill_embeddings. principalTenantScope reports all=true for a request with NO
+	// principal at all, which is every request on an open-mode deployment — and an
+	// open-mode install has no tenants, so demanding one there is friction with no
+	// safety to buy. The hazard is specifically a multi-tenant admin sweeping a
+	// partition they did not name.
+	pr, authed := auth.PrincipalFromContext(r.Context())
+	adminMustName := authed && auth.HasScope(pr.Scopes, auth.ScopeAdmin)
+	if all && adminMustName && !r.URL.Query().Has("tenant") {
+		writeJSONError(w, http.StatusBadRequest, "tenant_required",
+			"an admin token must name the tenant: memory rows are keyed on it, and this "+
+				"operation re-embeds them at one model call per row. Pass ?tenant=<id>, or "+
+				"?tenant= for the default tenant.")
+		return
+	}
 	// tenant scope reembeds the single tenant-wide keyspace (store scope_id "");
 	// the placeholder is dropped. Reused for the read + write-back below.
 	storeScopeID := adminMemoryStoreScopeID(scope, scopeID)

--- a/internal/api/http/memory_admin_test.go
+++ b/internal/api/http/memory_admin_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/cancel"
 	"github.com/denn-gubsky/loomcycle/internal/concurrency"
 	"github.com/denn-gubsky/loomcycle/internal/config"
@@ -43,34 +44,34 @@ func newVectorAdminStore(s store.Store, supports bool) *vectorAdminStore {
 
 func (v *vectorAdminStore) SupportsVectors() bool { return v.supports }
 
-func (v *vectorAdminStore) MemoryEmbedSet(ctx context.Context, _ string, scope store.MemoryScope, scopeID, key string, e store.MemoryEmbedding) error {
+func (v *vectorAdminStore) MemoryEmbedSet(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string, e store.MemoryEmbedding) error {
 	if !v.supports {
 		return store.ErrVectorUnsupported
 	}
 	v.mu.Lock()
 	defer v.mu.Unlock()
-	v.embeds[string(scope)+"|"+scopeID+"|"+key] = e
+	v.embeds[embedKey(tenantID, scope, scopeID, key)] = e
 	return nil
 }
 
-func (v *vectorAdminStore) MemoryEmbedGet(ctx context.Context, _ string, scope store.MemoryScope, scopeID, key string) (store.MemoryEmbedding, error) {
+func (v *vectorAdminStore) MemoryEmbedGet(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string) (store.MemoryEmbedding, error) {
 	v.mu.Lock()
 	defer v.mu.Unlock()
-	e, ok := v.embeds[string(scope)+"|"+scopeID+"|"+key]
+	e, ok := v.embeds[embedKey(tenantID, scope, scopeID, key)]
 	if !ok {
 		return store.MemoryEmbedding{}, &store.ErrNotFound{Kind: "memory_embedding", ID: key}
 	}
 	return e, nil
 }
 
-func (v *vectorAdminStore) MemoryEmbedListByModel(ctx context.Context, _ string, scope store.MemoryScope, scopeID, currentProvider, currentModel string, limit int) ([]store.MemoryEntry, error) {
+func (v *vectorAdminStore) MemoryEmbedListByModel(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, currentProvider, currentModel string, limit int) ([]store.MemoryEntry, error) {
 	if !v.supports {
 		return nil, store.ErrVectorUnsupported
 	}
 	v.mu.Lock()
 	defer v.mu.Unlock()
 	out := []store.MemoryEntry{}
-	prefix := string(scope) + "|" + scopeID + "|"
+	prefix := embedKey(tenantID, scope, scopeID, "")
 	for k, e := range v.embeds {
 		if !strings.HasPrefix(k, prefix) {
 			continue
@@ -79,7 +80,7 @@ func (v *vectorAdminStore) MemoryEmbedListByModel(ctx context.Context, _ string,
 			continue
 		}
 		key := strings.TrimPrefix(k, prefix)
-		entry, err := v.Store.MemoryGet(ctx, "", scope, scopeID, key)
+		entry, err := v.Store.MemoryGet(ctx, tenantID, scope, scopeID, key)
 		if err != nil {
 			continue
 		}
@@ -95,7 +96,7 @@ func (v *vectorAdminStore) MemoryEmbedSearch(ctx context.Context, _ string, scop
 	return nil, errors.New("MemoryEmbedSearch not implemented in admin fake")
 }
 
-func (v *vectorAdminStore) MemoryEmbedStats(ctx context.Context, _ string, scope store.MemoryScope) (store.MemoryEmbedStats, error) {
+func (v *vectorAdminStore) MemoryEmbedStats(ctx context.Context, tenantID string, scope store.MemoryScope) (store.MemoryEmbedStats, error) {
 	if !v.supports {
 		return store.MemoryEmbedStats{}, store.ErrVectorUnsupported
 	}
@@ -106,7 +107,7 @@ func (v *vectorAdminStore) MemoryEmbedStats(ctx context.Context, _ string, scope
 	defer v.mu.Unlock()
 	counts := map[string]int{}
 	dims := map[string]int{}
-	prefix := string(scope) + "|"
+	prefix := tenantID + "|" + string(scope) + "|"
 	var totalBytes int64
 	for k, e := range v.embeds {
 		if !strings.HasPrefix(k, prefix) {
@@ -186,6 +187,15 @@ func vectorAdminFixture(t *testing.T, supportsVectors bool) (*Server, *adminFake
 	return srv, emb, vs
 }
 
+// embedKey is the fake store's row address. IT INCLUDES THE TENANT, and that is the
+// point: this double previously dropped the tenant argument (`_ string`) and keyed on
+// scope|scope_id alone, so every tenant's rows shared one address. A double blind to the
+// tenant cannot fail a tenant bug — which is exactly how the reembed handler shipped
+// resolving the tenant from the caller's principal instead of ?tenant=.
+func embedKey(tenantID string, scope store.MemoryScope, scopeID, key string) string {
+	return tenantID + "|" + string(scope) + "|" + scopeID + "|" + key
+}
+
 // Pre-load: write k/v rows + matching embeddings under (user, alice).
 // Two rows are on the OLD embedder (provider+model differ from
 // current); one row is on the CURRENT embedder.
@@ -203,9 +213,131 @@ func preloadReembedFixture(t *testing.T, srv *Server, vs *vectorAdminStore) {
 	// (we want explicit control).
 	old := store.MemoryEmbedding{Provider: "openai", Model: "text-embedding-3-small", Dimension: 4, Vector: []float32{1, 0, 0, 0}, EmbedText: "x", CreatedAt: time.Now().UTC()}
 	current := store.MemoryEmbedding{Provider: "openai", Model: "text-embedding-3-large", Dimension: 4, Vector: []float32{0, 1, 0, 0}, EmbedText: "x", CreatedAt: time.Now().UTC()}
-	vs.embeds["user|alice|old1"] = old
-	vs.embeds["user|alice|old2"] = old
-	vs.embeds["user|alice|current"] = current
+	vs.embeds[embedKey("", store.MemoryScopeUser, "alice", "old1")] = old
+	vs.embeds[embedKey("", store.MemoryScopeUser, "alice", "old2")] = old
+	vs.embeds[embedKey("", store.MemoryScopeUser, "alice", "current")] = current
+}
+
+// preloadReembedFixtureForTenant is preloadReembedFixture keyed on a NAMED tenant, so a
+// test can prove which partition a sweep actually read.
+func preloadReembedFixtureForTenant(t *testing.T, srv *Server, vs *vectorAdminStore, tenant string) {
+	t.Helper()
+	ctx := context.Background()
+	for _, k := range []string{"old1", "old2"} {
+		if err := srv.store.MemorySet(ctx, tenant, store.MemoryScopeUser, "alice", k, []byte(`"x"`), 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+	old := store.MemoryEmbedding{Provider: "openai", Model: "text-embedding-3-small", Dimension: 4,
+		Vector: []float32{1, 0, 0, 0}, EmbedText: "x", CreatedAt: time.Now().UTC()}
+	vs.embeds[embedKey(tenant, store.MemoryScopeUser, "alice", "old1")] = old
+	vs.embeds[embedKey(tenant, store.MemoryScopeUser, "alice", "old2")] = old
+}
+
+// TestReembed_AdminMustNameATenant.
+//
+// Memory rows are keyed on the tenant, and this route took it from the caller's
+// principal ALONE — so an admin migrating another tenant's scope after an embedder
+// change swept their OWN partition and got `rows_total: 0`, indistinguishable from
+// "already migrated". Observed on a live three-tenant deployment: an operator ran the
+// sweep for a tenant holding thousands of stale embeddings and was told there was
+// nothing to do, while vector search kept silently excluding those rows.
+//
+// The same defect was already fixed in embed_stats and guarded in backfill_embeddings,
+// purge_stale_embeddings, erasure, directory and orphan-repair. This route was the one
+// sibling that got neither treatment.
+func TestReembed_AdminMustNameATenant(t *testing.T) {
+	srv, _, vs := vectorAdminFixture(t, true)
+	preloadReembedFixture(t, srv, vs)
+
+	adminReq := func(qs string) *httptest.ResponseRecorder {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/v1/_memory/reembed?scope=user&scope_id=alice"+qs, nil).
+			WithContext(auth.WithPrincipal(context.Background(), auth.Principal{
+				Subject: "root", Scopes: []string{auth.ScopeAdmin},
+			}))
+		srv.handleMemoryReembed(rec, req)
+		return rec
+	}
+
+	rec := adminReq("")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 when an authenticated admin names no tenant; body: %s",
+			rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "tenant_required") {
+		t.Errorf("body = %s, want code tenant_required", rec.Body.String())
+	}
+
+	// An EXPLICIT empty tenant is a legitimate target — the default partition, i.e. the
+	// whole deployment on a single-tenant install. Refusing it would make that partition
+	// unsweepable.
+	if rec2 := adminReq("&tenant="); rec2.Code != http.StatusOK {
+		t.Errorf("explicit ?tenant= (the default partition) got %d, want 200; body: %s",
+			rec2.Code, rec2.Body.String())
+	}
+}
+
+// TestReembed_OpenModeNeedsNoTenant.
+//
+// The refusal above is scoped to an AUTHENTICATED ADMIN on purpose.
+// principalTenantScope reports all=true for a request with NO principal, which is every
+// request on an open-mode deployment — and an open-mode install has no tenants, so
+// demanding one there would break a route that has worked since v0.9.0 to buy no safety.
+func TestReembed_OpenModeNeedsNoTenant(t *testing.T) {
+	srv, _, vs := vectorAdminFixture(t, true)
+	preloadReembedFixture(t, srv, vs)
+
+	rec := httptest.NewRecorder()
+	// No principal in context at all.
+	req := httptest.NewRequest("POST", "/v1/_memory/reembed?scope=user&scope_id=alice", nil)
+	srv.handleMemoryReembed(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("open mode got %d, want 200 — the guard must not fire without a principal; body: %s",
+			rec.Code, rec.Body.String())
+	}
+}
+
+// TestReembed_HonoursTheNamedTenant.
+//
+// The refusal is only half the fix; this is the half that was actually blocking a
+// migration. `?tenant=` has to REACH the store read, or an admin can name the right
+// tenant and still sweep the wrong partition — a confident zero, which is the failure
+// mode being removed.
+//
+// Two tenants hold stale rows under the same (scope, scope_id). Naming one must find
+// exactly its own.
+func TestReembed_HonoursTheNamedTenant(t *testing.T) {
+	srv, _, vs := vectorAdminFixture(t, true)
+	preloadReembedFixtureForTenant(t, srv, vs, "acme")
+
+	plan := func(tenant string) memoryReembedDryRunResponse {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("POST",
+			"/v1/_memory/reembed?scope=user&scope_id=alice&tenant="+tenant, nil).
+			WithContext(auth.WithPrincipal(context.Background(), auth.Principal{
+				Subject: "root", Scopes: []string{auth.ScopeAdmin},
+			}))
+		srv.handleMemoryReembed(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("tenant %q: status=%d body=%s", tenant, rec.Code, rec.Body.String())
+		}
+		var resp memoryReembedDryRunResponse
+		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+			t.Fatal(err)
+		}
+		return resp
+	}
+
+	if got := plan("acme").RowsToReembed; got != 2 {
+		t.Errorf("tenant=acme found %d stale rows, want 2 — ?tenant= did not reach the store read, "+
+			"so an admin naming the right tenant still sweeps the wrong partition", got)
+	}
+	// A tenant that holds nothing must report zero — otherwise the first assertion
+	// could pass by reading every tenant at once.
+	if got := plan("other").RowsToReembed; got != 0 {
+		t.Errorf("tenant=other found %d stale rows, want 0 — the sweep is not tenant-scoped", got)
+	}
 }
 
 // ---- /v1/_memory/embed_stats tests ----

--- a/internal/api/http/memory_embed_dimension_test.go
+++ b/internal/api/http/memory_embed_dimension_test.go
@@ -3,6 +3,7 @@ package http
 import (
 	"context"
 	"encoding/json"
+	"github.com/denn-gubsky/loomcycle/internal/store"
 	"testing"
 )
 
@@ -45,7 +46,10 @@ func TestMemoryEmbed_StoresObservedWidthWhenEmbedderReportsZero(t *testing.T) {
 		t.Fatalf("embedMemoryEntry: %v", err)
 	}
 
-	got, ok := vs.embeds["user|alice|k"]
+	// Addressed through embedKey, not a hand-written literal: the fake's row address
+	// includes the tenant, and a string typed out here silently stops matching the
+	// moment that changes.
+	got, ok := vs.embeds[embedKey("", store.MemoryScopeUser, "alice", "k")]
 	if !ok {
 		t.Fatal("no embedding row was written")
 	}


### PR DESCRIPTION
`/v1/_memory/reembed` took the tenant from the caller's principal **alone** and ignored `?tenant=` entirely. So an operator migrating another tenant's scope after an embedder change swept their **own** partition, found nothing, and got `rows_total: 0` — indistinguishable from "already migrated".

## Observed live, on the deployment that prompted this

A tenant `loomcycle-dev` install switched `embeddinggemma` (768d) → `bge-m3` (1024d). A legacy admin token carries no tenant, so every reembed call resolved to the **default** partition:

```
POST /v1/_memory/reembed?scope=user&scope_id=<real id>
{"rows_total":0,"rows_to_reembed":0,"current_embedder":{"model":"bge-m3:latest","dimension":1024}}
```

…while thousands of stale rows sat in `loomcycle-dev`, unreachable by semantic search. The console's own "reembed plan" reported the same `0` for the same reason, and I initially misdiagnosed it as an empty tenant scope.

The store then keeps serving those rows to a vector search that silently excludes them, because **nothing errors once any row of the new dimension exists** — the dimension pre-check samples one row. Search stops failing loudly and starts returning only the post-switch slice, with plausible scores.

## This is the third variant of one defect

| surface | state before this PR |
|---|---|
| `embed_stats` | already fixed — *"an admin inspecting another tenant's scope measured their OWN and got zeros — indistinguishable from an unembedded scope"* |
| `backfill_embeddings`, `purge_stale_embeddings`, erasure, directory, orphan-repair | already guard the unnamed-tenant case |
| **`reembed`** | **neither** |

Now `principalTenantScope` resolves it, so `?tenant=` reaches both the read and the write-back, and an authenticated admin who names none is refused rather than defaulted — a reembed **writes**, and spends one embedder call per row, so sweeping an unnamed partition is not merely a misleading count.

**The refusal is narrower than its siblings, deliberately.** `principalTenantScope` reports `all=true` for a request with *no* principal, which is every request on an open-mode deployment — and an open-mode install has no tenants, so demanding one there would break a route that has worked since v0.9.0 to buy no safety. The guard fires only for an authenticated admin, and all five pre-existing reembed tests pass unchanged.

## The test double was blind to the tenant in three places

Which is how this shipped. `vectorAdminStore`:

1. dropped the tenant argument (`_ string`) on `MemoryEmbedSet` / `MemoryEmbedGet` / `MemoryEmbedListByModel`, keying rows on `scope|scope_id` alone — every tenant shared one address;
2. joined the k/v row inside its list method with a **hardcoded empty tenant** (`MemoryGet(ctx, "", …)`);
3. prefixed `MemoryEmbedStats` without one.

A double that ignores the dimension under test cannot fail a bug in it. All three now carry the tenant through a shared `embedKey` helper, and the one sibling test that hand-wrote a key literal (`vs.embeds["user|alice|k"]`) now uses the helper — a typed-out address silently stops matching the moment the scheme changes.

## Tests

- **`TestReembed_HonoursTheNamedTenant`** — two tenants hold stale rows under the same `(scope, scope_id)`; naming one finds exactly its own, and naming an empty tenant finds **zero**, so the first assertion cannot pass by reading every tenant at once. Fails on the shipped code with *"?tenant= did not reach the store read"*.
- **`TestReembed_AdminMustNameATenant`** — 400 `tenant_required`, while an *explicit* `?tenant=` (the default partition) stays accepted or that partition becomes unsweepable. On the shipped code this returns **200 with `rows_total: 2` from a tenant nobody named**.
- **`TestReembed_OpenModeNeedsNoTenant`** — pins the narrower scoping.

`go test ./...` clean (91 packages). Both new behaviours verified to fail on the pre-fix handler, with the probe confirmed to compile first.

## Delivery note

The fix is in the Go binary, so it needs a runtime image. A `vX.Y.Z` patch tag builds only the browser sidecar — so a v1.57.1 release wants `force_full=true` on the release workflow, or it will ship nothing that carries this.

## Workaround on the current build

`embed_stats`, `backfill_embeddings` and `purge_stale_embeddings` already honour `?tenant=`, so inspection and the purge sweep work today. Only `reembed` needs either this fix or an admin token whose **principal tenant** is the target — `tenantFromCtx` returns `p.TenantID`, so a token minted in `loomcycle-dev` sweeps the right partition on the shipped binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8
