### PR TITLE
perf(memory): reembed embeds in batches, not one call per row

### DIFF
--- a/internal/api/http/memory_admin.go
+++ b/internal/api/http/memory_admin.go
@@ -1,14 +1,15 @@
 package http
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
-	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 )
 
@@ -150,6 +151,36 @@ func (s *Server) handleMemoryEmbedStats(w http.ResponseWriter, r *http.Request) 
 				"another one (admin only).")
 	}
 	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// reembedEmbedBatch is how many rows are handed to the embedder per call.
+//
+// Not "all of them": a single Embed of a whole 1000-row page would make one failure
+// cost the entire page (see the per-row fallback below), and some rows are large
+// document bodies, so one request can carry a lot of tokens. 64 is two orders of
+// magnitude fewer round trips than per-row while keeping a failure's blast radius
+// small. The driver chunks again by its own EmbedderOptions.BatchSize
+// (LOOMCYCLE_MEMORY_EMBED_BATCH_SIZE), so an operator can still tune the wire size
+// underneath this.
+const reembedEmbedBatch = 64
+
+// writeReembeddedRow stores one row's new embedding, reporting success. Shared by the
+// batch path and its per-row fallback so the two cannot drift in what they record —
+// Dimension in particular is the OBSERVED width of the returned vector, never the
+// embedder's advertised one (a driver that cannot know its own dimension answers 0,
+// and a row written with 0 makes every later search in that scope report a spurious
+// dimension mismatch).
+func (s *Server) writeReembeddedRow(ctx context.Context, tenantID, scope, storeScopeID string,
+	row store.MemoryEntry, vec []float32, currentEmbedder memoryReembedConfigured) bool {
+	return s.store.MemoryEmbedSet(ctx, tenantID, store.MemoryScope(scope), storeScopeID, row.Key,
+		store.MemoryEmbedding{
+			Provider:  currentEmbedder.Provider,
+			Model:     currentEmbedder.Model,
+			Dimension: len(vec),
+			Vector:    vec,
+			EmbedText: string(row.Value),
+			CreatedAt: time.Now().UTC(),
+		}) == nil
 }
 
 // handleMemoryReembed serves POST /v1/_memory/reembed.
@@ -299,29 +330,60 @@ func (s *Server) handleMemoryReembed(w http.ResponseWriter, r *http.Request) {
 		failed     int
 		failedKeys []string
 	)
-	for _, row := range rows {
-		texts := []string{string(row.Value)}
+	// EMBEDDED IN BATCHES, one STORE WRITE PER ROW.
+	//
+	// This loop used to call Embed once per row, which on a real migration is the whole
+	// cost: 3,633 document-chunk rows moving from a 768d model to a 1024d one measured
+	// ~12 rows/minute against a local Ollama — about five hours — because every row paid
+	// a fresh HTTP round trip and prefill setup. The Embedder interface has always been
+	// batch-shaped (N texts in, N vectors out, chunked again by the driver's own
+	// BatchSize), so the per-row call was leaving that on the floor.
+	//
+	// The store write stays PER ROW on purpose: it is what makes this operation
+	// resumable. A client timeout or a cancelled context mid-sweep costs only the rows
+	// in the current batch, and the next call picks up whatever is left — which is how
+	// an operator paginates a scope too large for one request.
+	for start := 0; start < len(rows); start += reembedEmbedBatch {
+		end := start + reembedEmbedBatch
+		if end > len(rows) {
+			end = len(rows)
+		}
+		batch := rows[start:end]
+		texts := make([]string, len(batch))
+		for i, row := range batch {
+			texts[i] = string(row.Value)
+		}
 		vecs, err := s.embedder.Embed(r.Context(), texts)
-		if err != nil || len(vecs) != 1 {
-			failed++
-			failedKeys = append(failedKeys, row.Key)
+		if err != nil || len(vecs) != len(batch) {
+			// FALL BACK TO PER ROW rather than failing the batch. One unembeddable row
+			// must not cost its batch-mates: before batching, a bad row was counted and
+			// skipped and the rest still migrated, and that accounting is the thing an
+			// operator reads to decide whether a sweep is done. Retrying singly restores
+			// it exactly, at the cost of one extra call per genuinely bad batch.
+			for _, row := range batch {
+				one, oneErr := s.embedder.Embed(r.Context(), []string{string(row.Value)})
+				if oneErr != nil || len(one) != 1 {
+					failed++
+					failedKeys = append(failedKeys, row.Key)
+					continue
+				}
+				if !s.writeReembeddedRow(r.Context(), tenantID, scope, storeScopeID, row, one[0], currentEmbedder) {
+					failed++
+					failedKeys = append(failedKeys, row.Key)
+					continue
+				}
+				reembedded++
+			}
 			continue
 		}
-		emb := store.MemoryEmbedding{
-			Provider:  currentEmbedder.Provider,
-			Model:     currentEmbedder.Model,
-			Dimension: len(vecs[0]),
-			Vector:    vecs[0],
-			EmbedText: string(row.Value),
-			CreatedAt: time.Now().UTC(),
+		for i, row := range batch {
+			if !s.writeReembeddedRow(r.Context(), tenantID, scope, storeScopeID, row, vecs[i], currentEmbedder) {
+				failed++
+				failedKeys = append(failedKeys, row.Key)
+				continue
+			}
+			reembedded++
 		}
-		if err := s.store.MemoryEmbedSet(r.Context(), tenantID,
-			store.MemoryScope(scope), storeScopeID, row.Key, emb); err != nil {
-			failed++
-			failedKeys = append(failedKeys, row.Key)
-			continue
-		}
-		reembedded++
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(memoryReembedRealResponse{

--- a/internal/api/http/memory_admin_test.go
+++ b/internal/api/http/memory_admin_test.go
@@ -131,17 +131,39 @@ func (v *vectorAdminStore) MemoryEmbedStats(ctx context.Context, tenantID string
 	return stats, nil
 }
 
-// adminFakeEmbedder is a deterministic embedder for the reembed
-// endpoint tests. Returns 4-dim unit vectors derived from input
-// length. failNext=true causes the next Embed() to error.
+// adminFakeEmbedder is a deterministic embedder for the reembed endpoint tests.
+// Returns dim-wide vectors derived from input length.
+//
+//   - failNext: the NEXT Embed() errors, once. A TRANSIENT fault.
+//   - failText: any Embed() whose batch contains this text errors, always. A
+//     PERMANENTLY bad row.
+//
+// The distinction exists because the handler embeds in batches and falls back to
+// per-row on a batch error. A transient fault is therefore RETRIED and recovers, while
+// a permanently bad row fails its retry too and is reported — and only the second is a
+// guarantee worth asserting. `failNext` alone could not tell the two apart, so a test
+// using it was really asserting the handler's call pattern.
+//
+// calls counts Embed invocations, which is how the batching itself is asserted: a
+// per-row loop and a batched one produce identical rows and differ only here.
 type adminFakeEmbedder struct {
 	provider string
 	model    string
 	dim      int
 	failNext bool
+	failText string
+	calls    int
 }
 
 func (e *adminFakeEmbedder) Embed(_ context.Context, texts []string) ([][]float32, error) {
+	e.calls++
+	if e.failText != "" {
+		for _, tx := range texts {
+			if tx == e.failText {
+				return nil, errors.New("fake embedder: permanently bad row in batch")
+			}
+		}
+	}
 	if e.failNext {
 		e.failNext = false
 		return nil, errors.New("fake embedder injected failure")
@@ -526,8 +548,12 @@ func TestReembed_RealRunReembedsRowsAndUpdatesModel(t *testing.T) {
 func TestReembed_PartialFailureCollectsFailedKeys(t *testing.T) {
 	srv, emb, vs := vectorAdminFixture(t, true)
 	preloadReembedFixture(t, srv, vs)
-	// First call will fail; second will succeed.
-	emb.failNext = true
+	// A PERMANENTLY bad row, not "the next call fails". The rows carry the value `"x"`,
+	// so this makes every attempt on them fail — including the per-row retry after the
+	// batch error. Previously this test set failNext, which asserted the handler's
+	// call pattern rather than the guarantee: with batching, a one-shot fault is
+	// retried and recovers, so failNext no longer describes a failed ROW.
+	emb.failText = `"x"`
 
 	req := httptest.NewRequest("POST", "/v1/_memory/reembed?scope=user&scope_id=alice&dry_run=false", nil)
 	rec := httptest.NewRecorder()
@@ -537,12 +563,63 @@ func TestReembed_PartialFailureCollectsFailedKeys(t *testing.T) {
 	}
 	var resp memoryReembedRealResponse
 	_ = json.NewDecoder(rec.Body).Decode(&resp)
-	if resp.RowsReembedded != 1 || resp.RowsFailed != 1 {
-		t.Errorf("counts: reembedded=%d failed=%d, want 1/1: %s",
-			resp.RowsReembedded, resp.RowsFailed, rec.Body.String())
+	// Both stale rows are unembeddable, so both are reported — never silently dropped.
+	if resp.RowsReembedded != 0 || resp.RowsFailed != 2 {
+		t.Errorf("counts: reembedded=%d failed=%d, want 0/2", resp.RowsReembedded, resp.RowsFailed)
 	}
-	if len(resp.FailedKeys) != 1 {
-		t.Errorf("FailedKeys len=%d want 1", len(resp.FailedKeys))
+	if len(resp.FailedKeys) != 2 {
+		t.Errorf("FailedKeys=%v, want both keys named — an operator reads these to decide "+
+			"whether a sweep is done", resp.FailedKeys)
+	}
+}
+
+// TestReembed_TransientEmbedFailureIsRetried.
+//
+// The batch path falls back to per-row on ANY batch error, which means a one-shot fault
+// no longer costs the whole batch its rows. Asserted because the fallback is the only
+// thing standing between "one flaky call" and "63 rows silently left stale" — and a
+// future simplification that drops it would still pass the permanent-failure test above.
+func TestReembed_TransientEmbedFailureIsRetried(t *testing.T) {
+	srv, emb, vs := vectorAdminFixture(t, true)
+	preloadReembedFixture(t, srv, vs)
+	emb.failNext = true // the batch call errors once; the per-row retries succeed
+
+	req := httptest.NewRequest("POST", "/v1/_memory/reembed?scope=user&scope_id=alice&dry_run=false", nil)
+	rec := httptest.NewRecorder()
+	srv.handleMemoryReembed(rec, req)
+
+	var resp memoryReembedRealResponse
+	_ = json.NewDecoder(rec.Body).Decode(&resp)
+	if resp.RowsReembedded != 2 || resp.RowsFailed != 0 {
+		t.Errorf("counts: reembedded=%d failed=%d, want 2/0 — a transient batch error must "+
+			"not cost its batch-mates", resp.RowsReembedded, resp.RowsFailed)
+	}
+}
+
+// TestReembed_EmbedsInBatchesNotOnePerRow.
+//
+// The performance claim, asserted rather than assumed. Per-row calling is what made a
+// real migration take ~12 rows/minute against a local Ollama — 3,633 document chunks,
+// about five hours — because each row paid a fresh round trip and prefill. Rows and
+// vectors are identical either way, so the CALL COUNT is the only observable difference,
+// and without this a revert to the simpler loop would pass every other test here.
+func TestReembed_EmbedsInBatchesNotOnePerRow(t *testing.T) {
+	srv, emb, vs := vectorAdminFixture(t, true)
+	preloadReembedFixture(t, srv, vs) // 2 stale rows
+
+	req := httptest.NewRequest("POST", "/v1/_memory/reembed?scope=user&scope_id=alice&dry_run=false", nil)
+	rec := httptest.NewRecorder()
+	srv.handleMemoryReembed(rec, req)
+
+	var resp memoryReembedRealResponse
+	_ = json.NewDecoder(rec.Body).Decode(&resp)
+	if resp.RowsReembedded != 2 {
+		t.Fatalf("reembedded=%d, want 2", resp.RowsReembedded)
+	}
+	if emb.calls != 1 {
+		t.Errorf("embedder was called %d times for 2 rows, want 1 — the rows are batched "+
+			"(reembedEmbedBatch=%d), and one call per row is the cost this exists to remove",
+			emb.calls, reembedEmbedBatch)
 	}
 }
 


### PR DESCRIPTION
A real embedder migration measured **~12 rows/minute**: 3,633 document-chunk rows moving from a 768d model to a 1024d one, about **five hours**, because the loop called `Embed` once per row and each row paid a fresh HTTP round trip and prefill against a local Ollama.

The `Embedder` interface has always been batch-shaped — N texts in, N vectors out, chunked again by the driver's own `BatchSize` — so the per-row call was leaving that on the floor.

## What changed

Rows go to the embedder in **batches of 64** (two orders of magnitude fewer round trips), while the **store write stays per row**.

That second half is deliberate: per-row commits are what make this operation *resumable*. A client timeout or cancelled context mid-sweep costs only the current batch, and the next call picks up what is left — which is how an operator paginates a scope too large for one request. Batching the writes too would have traded that away for nothing.

**Not "all of them" in one call.** A single `Embed` over a whole 1000-row page would make one failure cost the page, and document bodies can be large, so one request would carry a lot of tokens. `LOOMCYCLE_MEMORY_EMBED_BATCH_SIZE` still chunks the wire underneath.

**A batch error falls back to per row.** One unembeddable row must not cost its batch-mates: before batching, a bad row was counted and skipped while the rest migrated, and that accounting is what an operator reads to decide whether a sweep is done. Retrying singly restores it exactly — and as a side effect a transient one-shot fault now recovers instead of stranding a row.

The store write moved into a shared `writeReembeddedRow` so the batch path and its fallback cannot drift. `Dimension` stays the **observed** width of the returned vector, never the embedder's advertised one — a driver that cannot know its own dimension answers 0, and a row written with 0 makes every later search in that scope report a spurious mismatch.

## The test double was asserting the wrong thing

The existing `TestReembed_PartialFailureCollectsFailedKeys` set `failNext` — *"the next call errors"* — and expected `1 reembedded / 1 failed`. Under batching that describes a **transient** fault which the fallback now retries, so it reported `2 reembedded`.

I did not retune the expectation to match the new code. `failNext` was encoding the handler's *call pattern*, not a guarantee. The stub now distinguishes:

| knob | meaning |
|---|---|
| `failNext` | the next `Embed` errors once — a **transient** fault |
| `failText` | any batch containing this text errors, always — a **permanently bad row** |
| `calls` | `Embed` invocation count |

and the test asserts the contract: an unembeddable row is reported in `failed` + `failedKeys` and never silently dropped. It now passes on **both** the batched and per-row shapes, which is what a contract test should do.

## Tests

| test | fails on a revert to per-row? |
|---|---|
| `PartialFailureCollectsFailedKeys` (rewritten) | no — it's a contract |
| `TransientEmbedFailureIsRetried` | **yes** — 1/1 instead of 2/0 |
| `EmbedsInBatchesNotOnePerRow` | **yes** — "called 2 times for 2 rows, want 1" |

The call-count assertion matters because rows and vectors are *identical* either way — the call count is the only observable difference, so without it a revert to the simpler loop would pass every other test in the file.

`go test ./...` clean (91 packages). Both new tests verified to fail on the per-row revert, with the probe confirmed to compile first.

## Note

This does not speed up a sweep already in flight; it applies to the next one. Reaching a deployment needs a patch release with `force_full=true`, since the change is in the runtime binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8
