### PR TITLE
feat(memory): a document search hit names its document and heading

### DIFF
--- a/adapters/ts/src/types.ts
+++ b/adapters/ts/src/types.ts
@@ -1011,7 +1011,9 @@ export type MemorySource = "facts" | "notes" | "documents";
  *  `kind` is the row's class: `"fact"` (a consolidator distilled it),
  *  `"note"` (an agent wrote it directly) or `"document"` (a Document chunk
  *  body). A document hit also carries `chunk_id` so the viewer can fetch its
- *  entity block via document({ op: "get_chunk" }).
+ *  entity block via document({ op: "get_chunk" }), plus `document` and `title`
+ *  — the document it came from and the heading it sits under — so a page of
+ *  hits can be attributed without one fetch per row.
  *
  *  **Changed in 1.49.0 (RFC BW):** this was `"memory" | "document"`. Code
  *  switching on `"document"` is unaffected; code comparing against
@@ -1029,6 +1031,12 @@ export interface MemorySearchEntry {
   embedded_with: { provider: string; model: string };
   kind: "fact" | "note" | "document";
   chunk_id?: string;
+  /** The document this chunk belongs to, by title. Document hits only, and
+   *  best-effort: the titles live in SQL Memory, a different plane from the
+   *  bodies, so a deployment without it omits the field. */
+  document?: string;
+  /** The chunk's own heading. Same conditions as {@link document}. */
+  title?: string;
 }
 
 export interface MemorySearchResponse {

--- a/internal/api/http/memory_search.go
+++ b/internal/api/http/memory_search.go
@@ -22,6 +22,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/memory/backends/inprocess"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
+	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
 )
 
 // parseMemorySources maps the wire strings onto the typed selector. Unknown values are
@@ -87,6 +88,13 @@ type memorySearchResultEntry struct {
 	// prose read as remembered fact.
 	Kind    string `json:"kind"`
 	ChunkID string `json:"chunk_id,omitempty"`
+	// Document and Title are the hit's READABLE identity — the document title and the
+	// chunk's own heading — for document-kind rows only. Both are best-effort: they
+	// live in SQL Memory, a different plane from the bodies, so a scope with no
+	// document tables or a chunk deleted mid-search simply omits them. ChunkID
+	// remains the address; these annotate it.
+	Document string `json:"document,omitempty"`
+	Title    string `json:"title,omitempty"`
 }
 
 type memorySearchResponse struct {
@@ -181,6 +189,18 @@ func (s *Server) handleMemorySearch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	entries := make([]memorySearchResultEntry, 0, len(res.Entries))
+
+	// Collect the document hits' chunk ids up front so their labels resolve in ONE
+	// batched query rather than one per row.
+	var docChunkIDs []string
+	for _, e := range res.Entries {
+		if memrank.Class(e) == store.MemoryRowDocument {
+			docChunkIDs = append(docChunkIDs, strings.TrimPrefix(e.Key, docChunkKeyPrefix))
+		}
+	}
+	labels := builtin.ChunkLabelsFor(ctx, s.sqlMem, tenantFromCtx(r.Context()),
+		store.MemoryScope(body.Scope), storeScopeID, docChunkIDs)
+
 	for i, e := range res.Entries {
 		entry := memorySearchResultEntry{
 			Key:       e.Key,
@@ -196,11 +216,15 @@ func (s *Server) handleMemorySearch(w http.ResponseWriter, r *http.Request) {
 			Kind: string(memrank.Class(e)),
 		}
 		// A doc.chunk hit may be an entity fact OR a plain document chunk; the
-		// viewer calls get_chunk to see its entity block. No per-hit sidecar
-		// lookup here — the sidecar lives in SQL Memory, a different plane; this
-		// handler stays store-only.
+		// viewer calls get_chunk to see its entity block. The ENTITY sidecar is still
+		// not read here — but the chunk's document + heading are, because a page of
+		// opaque `doc.chunk:<hex>` keys cannot be attributed without a fetch per row.
+		// One batched, best-effort query above; a fault costs the labels, not the hit.
 		if entry.Kind == string(store.MemoryRowDocument) {
 			entry.ChunkID = strings.TrimPrefix(e.Key, docChunkKeyPrefix)
+			if lb, ok := labels[entry.ChunkID]; ok {
+				entry.Document, entry.Title = lb.Document, lb.Title
+			}
 		}
 		entries = append(entries, entry)
 	}

--- a/internal/api/http/memory_search_test.go
+++ b/internal/api/http/memory_search_test.go
@@ -3,6 +3,7 @@ package http
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -11,8 +12,12 @@ import (
 	"testing"
 
 	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/channels"
+	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
 )
 
 // searchVectorStore wraps a real Store with an in-memory embedding map and
@@ -226,5 +231,120 @@ func TestMemorySearch_InvalidScope(t *testing.T) {
 	_ = json.Unmarshal(rec.Body.Bytes(), &e)
 	if e["code"] != "invalid_scope" {
 		t.Errorf("code = %v, want invalid_scope", e["code"])
+	}
+}
+
+// seedDocumentChunk creates a REAL document + child chunk in the SQL Memory scope
+// the handler will read, through the Document tool so the schema is the shipped one
+// rather than a hand-written copy that could drift from it. Returns the child's id.
+func seedDocumentChunk(t *testing.T, vs *searchVectorStore, mgr *sqlmem.Manager,
+	tenant, user, docTitle, chunkTitle string) string {
+	t.Helper()
+	d := &builtin.Document{Store: vs, SqlMem: mgr, Bus: channels.NewBus()}
+	ctx := tools.WithAgentName(context.Background(), "doc-agent")
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{UserID: user, TenantID: tenant})
+
+	exec := func(body string) map[string]any {
+		t.Helper()
+		res, err := d.Execute(ctx, json.RawMessage(body))
+		if err != nil {
+			t.Fatalf("Document.Execute: %v", err)
+		}
+		if res.IsError {
+			t.Fatalf("Document op failed: %s", res.Text)
+		}
+		var out map[string]any
+		if err := json.Unmarshal([]byte(res.Text), &out); err != nil {
+			t.Fatalf("decode Document result: %v", err)
+		}
+		return out
+	}
+	doc := exec(fmt.Sprintf(`{"op":"create_document","scope":"user","title":%q}`, docTitle))
+	child := exec(fmt.Sprintf(`{"op":"create_chunk","scope":"user","document_id":%q,"parent_id":%q,"title":%q,"body":"the strip counts claims, not identities"}`,
+		doc["document_id"], doc["root_chunk_id"], chunkTitle))
+	id, _ := child["id"].(string)
+	if id == "" {
+		t.Fatalf("create_chunk returned no id: %+v", child)
+	}
+	return id
+}
+
+// TestMemorySearch_DocumentHitCarriesItsDocumentAndHeading: a document hit comes
+// back with the document it belongs to and the heading it sits under, not just an
+// opaque `doc.chunk:<hex>` key. Without them a page of six hits cannot be
+// attributed without one get_chunk per row, which is what made a semantic search
+// over the doc store unciteable.
+//
+// The two fixture titles differ deliberately — equal ones would pass against a
+// projection that swapped the fields.
+func TestMemorySearch_DocumentHitCarriesItsDocumentAndHeading(t *testing.T) {
+	s, vs := memorySearchServer(t)
+	mgr, err := sqlmem.New(sqlmem.Config{Root: t.TempDir()})
+	if err != nil {
+		t.Fatalf("sqlmem.New: %v", err)
+	}
+	t.Cleanup(func() { _ = mgr.Close() })
+	s.sqlMem = mgr
+
+	childID := seedDocumentChunk(t, vs, mgr, "A", "alice", "Verified writes", "Reading your coverage")
+	// The body + embedding the search double reads. The chunk already has a body
+	// from create_chunk; this adds the embedding that makes it findable.
+	seedSearchRow(t, vs, "A", "alice", "doc.chunk:"+childID, `{"body":"the strip counts claims","fields":null}`)
+
+	rec := postMemorySearch(s, "A", `{"query":"claims","scope":"user","scope_id":"alice"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp memorySearchResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	var found bool
+	for _, e := range resp.Entries {
+		if e.Kind != "document" {
+			continue
+		}
+		found = true
+		if e.ChunkID != childID {
+			t.Errorf("chunk_id = %q, want %q", e.ChunkID, childID)
+		}
+		if e.Document != "Verified writes" {
+			t.Errorf("document = %q, want the DOCUMENT title %q", e.Document, "Verified writes")
+		}
+		if e.Title != "Reading your coverage" {
+			t.Errorf("title = %q, want the CHUNK heading %q", e.Title, "Reading your coverage")
+		}
+	}
+	if !found {
+		t.Fatalf("no document hit in %+v", resp.Entries)
+	}
+}
+
+// TestMemorySearch_WithoutSqlMemoryTheHitKeepsItsID is the best-effort guarantee.
+// The labels live in SQL Memory, a DIFFERENT plane from the bodies this handler
+// reads, so a deployment without it (or one whose lookup faults) must still return
+// the hit and its address — the label is the only thing that goes missing.
+func TestMemorySearch_WithoutSqlMemoryTheHitKeepsItsID(t *testing.T) {
+	s, vs := memorySearchServer(t) // no s.sqlMem
+	seedSearchRow(t, vs, "A", "alice", "doc.chunk:chunk-1", `{"body":"Ada was a mathematician"}`)
+
+	rec := postMemorySearch(s, "A", `{"query":"ada","scope":"user","scope_id":"alice"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp memorySearchResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Entries) != 1 {
+		t.Fatalf("want 1 entry, got %+v", resp.Entries)
+	}
+	e := resp.Entries[0]
+	if e.ChunkID != "chunk-1" {
+		t.Errorf("chunk_id = %q, want chunk-1 — the address must survive a missing label", e.ChunkID)
+	}
+	if e.Document != "" || e.Title != "" {
+		t.Errorf("labels must be ABSENT, not empty strings on the wire: document=%q title=%q", e.Document, e.Title)
 	}
 }

--- a/internal/tools/builtin/document_labels.go
+++ b/internal/tools/builtin/document_labels.go
@@ -1,0 +1,117 @@
+package builtin
+
+import (
+	"context"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// document_labels.go resolves the READABLE identity of a document chunk, for
+// surfaces that can otherwise only show its id.
+//
+// A semantic search over the Memory plane returns document bodies keyed
+// `doc.chunk:<32 hex>`. The id is the correct address — it is stable, unique, and
+// what get_chunk takes — but a page of six of them tells a reader nothing about
+// WHERE the prose came from, so a caller who wants to cite a hit has to fetch each
+// one just to learn its heading. These labels are the annotation that closes that
+// gap; the key stays the address.
+//
+// Everything here is best-effort. The labels live in SQL Memory, a different plane
+// from the bodies, so a scope with no document tables, a store fault, or a chunk
+// deleted between the search and the lookup must all cost a cosmetic string and
+// never a result.
+
+// ChunkLabel is one chunk's readable identity: the heading it sits under, and the
+// document it belongs to.
+type ChunkLabel struct {
+	Document string // the document's title
+	Title    string // the chunk's own title (its heading)
+}
+
+// maxChunkLabelLookup bounds the IN list. Both search surfaces cap top_k at 50
+// today; the bound is stated here so a future caller with a larger page cannot
+// turn one cosmetic lookup into an unbounded query.
+const maxChunkLabelLookup = 100
+
+// ChunkLabelsFor resolves labels for document-chunk hits in ONE batched query,
+// returned keyed by chunk id. A missing entry means "no label available" — callers
+// omit the fields rather than rendering an empty string.
+//
+// scope/scopeID are the MEMORY plane's coordinates (the ones the search ran on).
+// Mapping them onto SQL Memory's differently-keyed scope happens here so that
+// neither caller restates it: the two planes disagree for scope=tenant, and a
+// restated rule is how the tenant axis drifts.
+func ChunkLabelsFor(ctx context.Context, sm *sqlmem.Manager, tenantID string,
+	scope store.MemoryScope, scopeID string, chunkIDs []string) map[string]ChunkLabel {
+	if sm == nil || len(chunkIDs) == 0 {
+		return nil
+	}
+	key, ok := docScopeKeyFor(tenantID, scope, scopeID)
+	if !ok {
+		return nil
+	}
+	// Distinct ids only: several hits from one document is the common case, and a
+	// repeated id would widen the IN list for nothing.
+	ids := make([]any, 0, len(chunkIDs))
+	seen := make(map[string]bool, len(chunkIDs))
+	for _, id := range chunkIDs {
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		ids = append(ids, id)
+		if len(ids) >= maxChunkLabelLookup {
+			break
+		}
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+
+	// LEFT JOIN: a chunk whose document row is missing still yields its own title.
+	stmt := `SELECT c.id, c.title, d.title FROM chunks c ` +
+		`LEFT JOIN documents d ON d.id = c.document_id WHERE c.id IN (` +
+		strings.TrimSuffix(strings.Repeat("?,", len(ids)), ",") + `)`
+	res, err := sm.Query(ctx, key, sm.Rebind(stmt), ids)
+	if err != nil || res == nil {
+		return nil
+	}
+	out := make(map[string]ChunkLabel, len(res.Rows))
+	for _, row := range res.Rows {
+		if len(row) < 3 {
+			continue
+		}
+		id := asStr(row[0])
+		if id == "" {
+			continue
+		}
+		out[id] = ChunkLabel{Document: asStr(row[2]), Title: asStr(row[1])}
+	}
+	return out
+}
+
+// docScopeKeyFor maps the Memory plane's (tenant, scope, scope_id) onto SQL
+// Memory's ScopeKey, mirroring Document.resolveScope's mapping without its
+// ctx-derived identity or its authorization gates — this is a read of titles the
+// caller has ALREADY been served bodies for, so it adds no reach.
+//
+// ok=false for a scope SQL Memory cannot key, which keeps the miss cosmetic.
+func docScopeKeyFor(tenantID string, scope store.MemoryScope, scopeID string) (sqlmem.ScopeKey, bool) {
+	tenant := sqlScopeTenantValue(tenantID)
+	switch scope {
+	case store.MemoryScopeAgent, store.MemoryScopeUser:
+		if scopeID == "" {
+			return sqlmem.ScopeKey{}, false
+		}
+		return sqlmem.ScopeKey{Tenant: tenant, Scope: string(scope), ScopeID: scopeID}, true
+	case store.MemoryScopeTenant:
+		// The two planes take DIFFERENT ids for this ONE logical scope: Memory keys
+		// it "" (the tenant_id column already carries the identity) while SQL Memory
+		// hashes the tenant into a schema + role name and rejects an empty
+		// component. Documented at Document.resolveScope.
+		return sqlmem.ScopeKey{Tenant: tenant, Scope: string(scope), ScopeID: tenant}, true
+	}
+	return sqlmem.ScopeKey{}, false
+}

--- a/internal/tools/builtin/document_labels_test.go
+++ b/internal/tools/builtin/document_labels_test.go
@@ -1,0 +1,292 @@
+package builtin
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// TestChunkLabels_ResolvesTheDocumentAndTheHeading is the whole feature: a search
+// hit addressed only by `doc.chunk:<hex>` gets back the document it came from and
+// the heading it sits under.
+//
+// The two fixture titles are DELIBERATELY different. A test that reused one title
+// for both would pass against a projection that swapped the columns, which is the
+// likeliest way to get this wrong (the query selects two `title` columns).
+func TestChunkLabels_ResolvesTheDocumentAndTheHeading(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	out, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Verified writes"}`)
+	if r.IsError {
+		t.Fatalf("create_document: %s", r.Text)
+	}
+	docID, root := asStr(out["document_id"]), asStr(out["root_chunk_id"])
+
+	child, r := docExec(t, d, ctx, fmt.Sprintf(
+		`{"op":"create_chunk","scope":"user","document_id":%q,"parent_id":%q,"title":%q,"body":%q}`,
+		docID, root, "Reading your coverage", "the strip counts claims, not identities"))
+	if r.IsError {
+		t.Fatalf("create_chunk: %s", r.Text)
+	}
+	childID := asStr(child["id"])
+
+	// The MEMORY plane's coordinates, as a search would supply them — not SQL
+	// Memory's. Mapping between the two is what docScopeKeyFor owns.
+	labels := ChunkLabelsFor(ctx, d.SqlMem, "tnt", store.MemoryScopeUser, "u1", []string{childID})
+	lb, ok := labels[childID]
+	if !ok {
+		t.Fatalf("no label for %s; got %+v", childID, labels)
+	}
+	if lb.Document != "Verified writes" {
+		t.Errorf("Document = %q, want the DOCUMENT title %q", lb.Document, "Verified writes")
+	}
+	if lb.Title != "Reading your coverage" {
+		t.Errorf("Title = %q, want the CHUNK heading %q", lb.Title, "Reading your coverage")
+	}
+}
+
+// TestChunkLabels_ResolvesManyChunksInOneCall covers the batching contract: every
+// requested id comes back from ONE call, including several chunks of the SAME
+// document — the common case for a search, where a few hits usually share a source.
+func TestChunkLabels_ResolvesManyChunksInOneCall(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	out, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"One doc"}`)
+	if r.IsError {
+		t.Fatalf("create_document: %s", r.Text)
+	}
+	docID, root := asStr(out["document_id"]), asStr(out["root_chunk_id"])
+
+	want := map[string]string{}
+	ids := []string{}
+	for _, title := range []string{"First", "Second", "Third"} {
+		c, r := docExec(t, d, ctx, fmt.Sprintf(
+			`{"op":"create_chunk","scope":"user","document_id":%q,"parent_id":%q,"title":%q,"body":"x"}`,
+			docID, root, title))
+		if r.IsError {
+			t.Fatalf("create_chunk %s: %s", title, r.Text)
+		}
+		id := asStr(c["id"])
+		want[id] = title
+		ids = append(ids, id)
+	}
+
+	labels := ChunkLabelsFor(ctx, d.SqlMem, "tnt", store.MemoryScopeUser, "u1", ids)
+	if len(labels) != len(want) {
+		t.Fatalf("got %d labels for %d distinct chunks: %+v", len(labels), len(want), labels)
+	}
+	for id, title := range want {
+		if labels[id].Title != title {
+			t.Errorf("chunk %s title = %q, want %q", id, labels[id].Title, title)
+		}
+		if labels[id].Document != "One doc" {
+			t.Errorf("chunk %s document = %q, want %q", id, labels[id].Document, "One doc")
+		}
+	}
+}
+
+// TestChunkLabels_ScopeKeyMatchesResolveScope is the DRIFT test. The Memory plane
+// and SQL Memory key the same logical scope differently (tenant most of all), so
+// this label lookup carries a second copy of that mapping. If Document.resolveScope
+// ever changes, a silent divergence here would mean labels resolve against an empty
+// schema and quietly stop appearing — a miss that looks exactly like "no labels
+// available". Compare the two directly instead.
+func TestChunkLabels_ScopeKeyMatchesResolveScope(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	// The fixture's identity: tenant "tnt", user "u1", agent "doc-agent".
+	for _, tc := range []struct {
+		requested string
+		scope     store.MemoryScope
+		scopeID   string // the MEMORY plane's id — "" for tenant, by design
+	}{
+		{"agent", store.MemoryScopeAgent, "doc-agent"},
+		{"user", store.MemoryScopeUser, "u1"},
+		{"tenant", store.MemoryScopeTenant, ""},
+	} {
+		t.Run(tc.requested, func(t *testing.T) {
+			// resolveScope gates scope=tenant on an ACL, so grant it for the comparison;
+			// this test is about the KEY, not the authorization.
+			// The tenant scope is gated on BOTH planes; grant them for the
+			// comparison — this test is about the KEY, not the authorization.
+			gctx := ctx
+			if tc.requested == "tenant" {
+				gctx = tools.WithMemoryPolicy(gctx, tools.MemoryPolicyValue{AllowedScopes: []string{"tenant"}})
+				gctx = tools.WithSqlMemPolicy(gctx, tools.SqlMemPolicyValue{AllowedScopes: []string{"tenant"}})
+			}
+			want, _, err := d.resolveScope(gctx, tc.requested)
+			if err != nil {
+				t.Skipf("resolveScope(%s) unavailable in this fixture: %v", tc.requested, err)
+			}
+			got, ok := docScopeKeyFor("tnt", tc.scope, tc.scopeID)
+			if !ok {
+				t.Fatalf("docScopeKeyFor(%s) refused; resolveScope produced %+v", tc.scope, want)
+			}
+			if got != want {
+				t.Errorf("scope %s: label lookup keys %+v, Document keys %+v — the two planes have drifted",
+					tc.scope, got, want)
+			}
+		})
+	}
+}
+
+// TestChunkLabels_BestEffortWhenLabelsCannotBeRead: every missing piece costs the
+// cosmetic label and nothing else. A search must not fail, and must not report a
+// wrong label, because SQL Memory is absent or a chunk has since gone.
+func TestChunkLabels_BestEffortWhenLabelsCannotBeRead(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+
+	if got := ChunkLabelsFor(ctx, nil, "tnt", store.MemoryScopeUser, "u1", []string{"c1"}); got != nil {
+		t.Errorf("no SQL Memory must yield no labels, got %+v", got)
+	}
+	if got := ChunkLabelsFor(ctx, d.SqlMem, "tnt", store.MemoryScopeUser, "u1", nil); got != nil {
+		t.Errorf("no ids must yield no labels, got %+v", got)
+	}
+	if got := ChunkLabelsFor(ctx, d.SqlMem, "tnt", store.MemoryScopeUser, "", []string{"c1"}); got != nil {
+		t.Errorf("a scope with no id must yield no labels, got %+v", got)
+	}
+	if got := ChunkLabelsFor(ctx, d.SqlMem, "tnt", store.MemoryScope("run"), "r1", []string{"c1"}); got != nil {
+		t.Errorf("a scope SQL Memory cannot key must yield no labels, got %+v", got)
+	}
+	// A scope that exists but holds no document tables yet: a store fault, not a
+	// panic, and no labels.
+	if got := ChunkLabelsFor(ctx, d.SqlMem, "tnt", store.MemoryScopeUser, "never-used", []string{"c1"}); len(got) != 0 {
+		t.Errorf("an empty scope must yield no labels, got %+v", got)
+	}
+	// A real scope, an id that is not in it.
+	if _, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"real"}`); r.IsError {
+		t.Fatalf("create_document: %s", r.Text)
+	}
+	got := ChunkLabelsFor(ctx, d.SqlMem, "tnt", store.MemoryScopeUser, "u1", []string{"no-such-chunk"})
+	if _, present := got["no-such-chunk"]; present {
+		t.Errorf("an unknown chunk must have no entry, got %+v", got)
+	}
+}
+
+// TestChunkLabels_RepeatedIDsDoNotCrowdOutTheCap pins the ORDER of two steps that
+// look independent: ids are deduplicated BEFORE the lookup is capped. A page of
+// hits from one document repeats that document's chunk ids, so capping first would
+// let a repeat consume the budget and silently drop a DIFFERENT chunk's label —
+// the label would just be missing, which is indistinguishable from "no labels
+// available". Sized off the constant so it stays honest if the cap moves.
+func TestChunkLabels_RepeatedIDsDoNotCrowdOutTheCap(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	out, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Crowded"}`)
+	if r.IsError {
+		t.Fatalf("create_document: %s", r.Text)
+	}
+	docID, root := asStr(out["document_id"]), asStr(out["root_chunk_id"])
+
+	mk := func(title string) string {
+		c, r := docExec(t, d, ctx, fmt.Sprintf(
+			`{"op":"create_chunk","scope":"user","document_id":%q,"parent_id":%q,"title":%q,"body":"x"}`,
+			docID, root, title))
+		if r.IsError {
+			t.Fatalf("create_chunk %s: %s", title, r.Text)
+		}
+		return asStr(c["id"])
+	}
+	repeated, last := mk("Repeated"), mk("Last")
+
+	// The repeated id fills the whole budget on its own; the distinct one is asked
+	// for once, at the end.
+	ids := make([]string, 0, maxChunkLabelLookup+1)
+	for i := 0; i < maxChunkLabelLookup; i++ {
+		ids = append(ids, repeated)
+	}
+	ids = append(ids, last)
+
+	labels := ChunkLabelsFor(ctx, d.SqlMem, "tnt", store.MemoryScopeUser, "u1", ids)
+	if labels[repeated].Title != "Repeated" {
+		t.Errorf("repeated chunk lost its label: %+v", labels[repeated])
+	}
+	if labels[last].Title != "Last" {
+		t.Errorf("the distinct chunk was crowded out by %d repeats of another id: %+v",
+			maxChunkLabelLookup, labels)
+	}
+}
+
+// TestMemorySearch_DocumentHitCarriesItsDocumentAndHeading is the IN-BAND twin of
+// the HTTP test: an agent searching its own memory gets the same labels an operator
+// gets from /v1/_memory/search. The two projections are hand-maintained copies —
+// this pair is what catches a field added to one and not the other.
+//
+// It also closes a real gap the labels exposed: the in-band search never carried
+// chunk_id at all, so an agent could not even fetch the chunk it had just been
+// shown prose from.
+func TestMemorySearch_DocumentHitCarriesItsDocumentAndHeading(t *testing.T) {
+	d, ctx, base := documentFixture(t)
+	vs := newVectorStore(base)
+	d.Store = vs
+	// The SAME embedder for both tools: the Document tool embeds the chunk body on
+	// write, and the Memory tool embeds the query — a one-hot vocabulary makes the
+	// cosine match exact.
+	fake := newFakeEmbedder("fake", "stub", "claims", "strip", "counts")
+	d.Embedder = fake
+
+	out, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Verified writes"}`)
+	if r.IsError {
+		t.Fatalf("create_document: %s", r.Text)
+	}
+	child, r := docExec(t, d, ctx, fmt.Sprintf(
+		`{"op":"create_chunk","scope":"user","document_id":%q,"parent_id":%q,"title":%q,"body":%q}`,
+		asStr(out["document_id"]), asStr(out["root_chunk_id"]),
+		"Reading your coverage", "the strip counts claims"))
+	if r.IsError {
+		t.Fatalf("create_chunk: %s", r.Text)
+	}
+	childID := asStr(child["id"])
+
+	m := &Memory{Store: vs, Embedder: fake, SqlMem: d.SqlMem}
+	// The Memory tool gates scopes on the agent's own ACL; the Document tool's
+	// grants above do not carry over.
+	mctx := tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{AllowedScopes: []string{"user"}})
+	res, err := m.Execute(mctx, []byte(`{"op":"search","scope":"user","query":"claims","top_k":5}`))
+	if err != nil {
+		t.Fatalf("Memory.Execute: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("search: %s", res.Text)
+	}
+
+	var got struct {
+		Entries []struct {
+			Key      string `json:"key"`
+			Kind     string `json:"kind"`
+			ChunkID  string `json:"chunk_id"`
+			Document string `json:"document"`
+			Title    string `json:"title"`
+		} `json:"entries"`
+	}
+	if err := json.Unmarshal([]byte(res.Text), &got); err != nil {
+		t.Fatalf("decode search result: %v\n%s", err, res.Text)
+	}
+	// The ROOT chunk is embedded too (its body is empty, so the embed path falls back
+	// to the title), so a search legitimately returns both. Assert on the CHILD — the
+	// one whose heading differs from its document's title, and therefore the only one
+	// that can catch a swapped projection.
+	var childHit *struct {
+		Key      string `json:"key"`
+		Kind     string `json:"kind"`
+		ChunkID  string `json:"chunk_id"`
+		Document string `json:"document"`
+		Title    string `json:"title"`
+	}
+	for i := range got.Entries {
+		if got.Entries[i].Kind == "document" && got.Entries[i].ChunkID == childID {
+			childHit = &got.Entries[i]
+		}
+	}
+	if childHit == nil {
+		t.Fatalf("no document hit for chunk %s; search returned: %s", childID, res.Text)
+	}
+	if childHit.Key != "doc.chunk:"+childID {
+		t.Errorf("key = %q, want the addressable doc.chunk form", childHit.Key)
+	}
+	if childHit.Document != "Verified writes" {
+		t.Errorf("document = %q, want the DOCUMENT title %q", childHit.Document, "Verified writes")
+	}
+	if childHit.Title != "Reading your coverage" {
+		t.Errorf("title = %q, want the CHUNK heading %q", childHit.Title, "Reading your coverage")
+	}
+}

--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -1336,6 +1336,10 @@ func (m *Memory) registerMemoryDirent(ctx context.Context, scope store.MemorySco
 //	{ "entries": [
 //	    { "key": "...", "value": <json>, "score": 0.91,
 //	      "embedded_with": {"provider": "openai", "model": "..."} },
+//	    // a document hit also carries the chunk it is addressed by, plus the
+//	    // document + heading it came from when SQL Memory can supply them:
+//	    { "key": "doc.chunk:8f1e...", "kind": "document", "chunk_id": "8f1e...",
+//	      "document": "Verified writes", "title": "Reading your coverage", ... },
 //	    ...
 //	  ],
 //	  "query_embedding_dim": 1536,
@@ -1400,13 +1404,25 @@ func (m *Memory) execSearch(ctx context.Context, scope store.MemoryScope, scopeI
 	}
 
 	entries := make([]map[string]any, 0, len(res.Entries))
+
+	// Collect the document hits' chunk ids up front so their readable labels
+	// resolve in ONE batched query instead of one per row.
+	var docChunkIDs []string
+	for _, r := range res.Entries {
+		if memrank.Class(r) == store.MemoryRowDocument {
+			docChunkIDs = append(docChunkIDs, strings.TrimPrefix(r.Key, memrank.DocumentChunkKeyPrefix))
+		}
+	}
+	labels := ChunkLabelsFor(ctx, m.SqlMem, tools.RunIdentity(ctx).TenantID, scope, scopeID, docChunkIDs)
+
 	for i, r := range res.Entries {
-		entries = append(entries, map[string]any{
+		kind := memrank.Class(r)
+		entry := map[string]any{
 			"key": r.Key,
 			// kind tells a caller WHAT it got: a document hit is prose written down
 			// somewhere, not something the user said, and weighing them alike is how
 			// a fence marker outranks a medication (RFC BW §4b).
-			"kind":       string(memrank.Class(r)),
+			"kind":       string(kind),
 			"value":      r.Value,
 			"score":      r.Score,           // raw cosine similarity — NEVER touched by hybrid fusion or ranking (stable across searches)
 			"rank_score": res.RankScores[i], // computed rank the result was ordered by: fused-semantic (RRF) + recency + frequency
@@ -1415,7 +1431,26 @@ func (m *Memory) execSearch(ctx context.Context, scope store.MemoryScope, scopeI
 				"model":    r.EmbeddedWith.Model,
 			},
 			"expires_at": expiresAtRFC3339(r.ExpiresAt),
-		})
+		}
+		// A document hit is prose the caller may want to CITE, and until now it came
+		// back addressed only by an opaque `doc.chunk:<hex>` key — so a page of hits
+		// could not be attributed without a get_chunk per row. Carry the chunk id it
+		// is addressed by, plus the document and heading it sits under when SQL Memory
+		// can supply them (absent when it cannot; never an error — the bodies and the
+		// titles live on different planes).
+		if kind == store.MemoryRowDocument {
+			chunkID := strings.TrimPrefix(r.Key, memrank.DocumentChunkKeyPrefix)
+			entry["chunk_id"] = chunkID
+			if lb, ok := labels[chunkID]; ok {
+				if lb.Document != "" {
+					entry["document"] = lb.Document
+				}
+				if lb.Title != "" {
+					entry["title"] = lb.Title
+				}
+			}
+		}
+		entries = append(entries, entry)
 	}
 	out := map[string]any{
 		"entries":             entries,

--- a/packages/memory-view/src/components/SearchPanel.tsx
+++ b/packages/memory-view/src/components/SearchPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { MemorySearchEntry, MemoryScope, MemorySource } from "../types";
 import { useMemoryData } from "../lib/dataLayer";
+import { searchHitLabel } from "../lib/searchLabels";
 import Splitter from "./Splitter";
 import ChunkDetailPanel from "./ChunkDetailPanel";
 
@@ -218,8 +219,14 @@ export default function SearchPanel({ scope: scopeProp = "user", scopeId: scopeI
                       <span className={`search-kind-badge search-kind-${hit.kind}`}>
                         {hit.kind}
                       </span>
-                      <span className="search-hit-key">
-                        {isDoc ? hit.chunk_id ?? hit.key : hit.key}
+                      {/* A document hit is named by its document + heading when the
+                          server could resolve them; the opaque id stays on the
+                          tooltip so it is still readable and copyable. */}
+                      <span
+                        className="search-hit-key"
+                        title={isDoc ? hit.chunk_id ?? hit.key : hit.key}
+                      >
+                        {searchHitLabel(hit)}
                       </span>
                       <span className="search-hit-scores" title="cosine similarity · hybrid rank score">
                         {hit.score.toFixed(3)} · {hit.rank_score.toFixed(3)}

--- a/packages/memory-view/src/lib/searchLabels.test.ts
+++ b/packages/memory-view/src/lib/searchLabels.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { searchHitLabel, type LabelledSearchEntry } from "./searchLabels";
+
+const hit = (over: Partial<LabelledSearchEntry>): LabelledSearchEntry =>
+  ({
+    key: "doc.chunk:8f1eb1e1",
+    value: null,
+    score: 0.7,
+    rank_score: 0.7,
+    embedded_with: { provider: "ollama-local", model: "bge-m3:latest" },
+    kind: "document",
+    chunk_id: "8f1eb1e1",
+    ...over,
+  }) as LabelledSearchEntry;
+
+describe("searchHitLabel", () => {
+  it("names a document hit by its document and heading", () => {
+    expect(
+      searchHitLabel(
+        hit({ document: "Verified writes", title: "Reading your coverage" }),
+      ),
+    ).toBe("Verified writes › Reading your coverage");
+  });
+
+  it("does not repeat the title for a document's root chunk", () => {
+    // The root chunk carries the document's own title, so both fields are equal —
+    // "Verified writes › Verified writes" is noise, not information.
+    expect(
+      searchHitLabel(
+        hit({ document: "Verified writes", title: "Verified writes" }),
+      ),
+    ).toBe("Verified writes");
+  });
+
+  it("falls back through heading, document, chunk id, key", () => {
+    expect(searchHitLabel(hit({ title: "Reading your coverage" }))).toBe(
+      "Reading your coverage",
+    );
+    expect(searchHitLabel(hit({ document: "Verified writes" }))).toBe(
+      "Verified writes",
+    );
+    expect(searchHitLabel(hit({}))).toBe("8f1eb1e1");
+    expect(searchHitLabel(hit({ chunk_id: undefined }))).toBe(
+      "doc.chunk:8f1eb1e1",
+    );
+  });
+
+  it("treats a blank label as absent", () => {
+    // A chunk created with no heading stores "", which must not render as an empty
+    // identity — the row would look nameless rather than unlabelled.
+    expect(searchHitLabel(hit({ document: "   ", title: "\n" }))).toBe(
+      "8f1eb1e1",
+    );
+  });
+
+  it("leaves a fact or note keyed by its key", () => {
+    expect(
+      searchHitLabel(hit({ kind: "fact", key: "voice", chunk_id: undefined })),
+    ).toBe("voice");
+    expect(
+      searchHitLabel(
+        hit({ kind: "note", key: "prefs.tone", chunk_id: undefined }),
+      ),
+    ).toBe("prefs.tone");
+  });
+});

--- a/packages/memory-view/src/lib/searchLabels.ts
+++ b/packages/memory-view/src/lib/searchLabels.ts
@@ -1,0 +1,33 @@
+import type { MemorySearchEntry } from "../types";
+
+// searchLabels — the readable identity of a semantic-search hit.
+//
+// A document hit is addressed by an opaque `doc.chunk:<hex>` id, which tells a
+// reader nothing about where the prose came from: a page of six of them cannot be
+// attributed without opening each one. The server annotates those hits with the
+// document's title and the chunk's own heading — best-effort, because the titles
+// live in SQL Memory rather than beside the bodies — and this renders whichever of
+// them arrived, falling back to the id that was always there.
+
+// The two label fields are declared LOCALLY rather than read off MemorySearchEntry
+// so the viewer keeps typechecking against an older published @loomcycle/client:
+// they are additive on the wire and optional here. Fold this into the imported type
+// once the package's peer floor includes them.
+export type LabelledSearchEntry = MemorySearchEntry & {
+  document?: string;
+  title?: string;
+};
+
+const clean = (s: string | undefined): string => s?.trim() ?? "";
+
+/** The hit's readable identity. Never empty: a document hit degrades to its chunk
+ *  id and then to its key, so a missing label costs legibility and not the row. */
+export function searchHitLabel(hit: LabelledSearchEntry): string {
+  if (hit.kind !== "document") return hit.key;
+  const doc = clean(hit.document);
+  const heading = clean(hit.title);
+  // A document's ROOT chunk carries the document's own title, so showing both
+  // would read "Verified writes › Verified writes".
+  if (doc && heading && doc !== heading) return `${doc} › ${heading}`;
+  return heading || doc || hit.chunk_id || hit.key;
+}


### PR DESCRIPTION
## Why

A semantic search that spans the doc store returns prose addressed only by an opaque `doc.chunk:<32 hex>` key. The id is the right **address** — stable, unique, what `get_chunk` takes — but it is not an *identity*. A live search for "verified writes: the judge withholds a fact whose span does not support it" returned six hits, every one of them keyed like this:

```
doc.chunk:2f51f960973ec940301a4d4aebcf35ff
doc.chunk:f5e7492bc3f2065dad0272c969d8beb0
...
```

All six were the right document. Nothing in the response said so. Anything wanting to cite a result had to fetch each row just to learn its heading.

Keying by title instead was the tempting fix and is wrong: titles are not unique, not stable under a rename, and not addressable. So the key stays, and the hit now carries its readable identity beside it:

```json
{"kind":"document","key":"doc.chunk:8f1eb1e1…","chunk_id":"8f1eb1e1…",
 "document":"Verified writes","title":"Reading your coverage",
 "value":{"body":"…"}}
```

## What

- **`ChunkLabelsFor`** (`internal/tools/builtin/document_labels.go`) resolves the document title + chunk heading for a batch of ids in **one** query, and owns the Memory→SQL Memory scope mapping so neither caller restates it — the two planes key the *tenant* scope differently (`""` vs the tenant), and a restated rule is how that axis drifts. Best-effort throughout: no SQL Memory, an unkeyable scope, a store fault, or a chunk deleted mid-search each cost the label and never the result, because the labels live on a different plane from the bodies. Ids are deduplicated *before* the lookup is capped, so a page of hits from one document cannot crowd out another chunk's label.
- **Both search projections** carry `document` + `title` for document hits — the off-run `POST /v1/_memory/search` and the in-band `Memory op=search`. They are hand-maintained copies, so this closes a live asymmetry too: the in-band one never carried `chunk_id` at all, meaning an agent could be shown prose it had no way to fetch.
- **The viewer** names a document hit `document › heading` instead of printing a 32-hex id, keeping the id on the tooltip. A document's root chunk carries the document's own title, so the two are collapsed rather than rendered as `Verified writes › Verified writes`.
- **`MemorySearchEntry`** in the TS adapter gains both optional fields. The viewer widens the type *locally* so it still compiles against the published `@loomcycle/client`; that widening folds into the imported type once the peer floor includes the fields. The adapter version realigns at the next minor tag, as usual.

No wire break: both fields are additive and `omitempty`, and a reader that ignores them sees today's response.

## Tested

`go test ./...` clean — 91 packages, zero failures in the full (unpiped) output. `memory-view`: 68 tests + typecheck clean against the lockfile's client 1.55.0. TS adapter: 279 tests + typecheck clean.

Each new test was verified to **fail on a revert of the specific thing it covers**:

| test | reverted | observed failure |
|---|---|---|
| `TestChunkLabels_ResolvesTheDocumentAndTheHeading` | swap the two `title` columns | `Document = "Reading your coverage", want "Verified writes"` |
| `TestChunkLabels_ScopeKeyMatchesResolveScope` | key the tenant scope the Memory plane's way | `label lookup keys {ScopeID:}, Document keys {ScopeID:tnt} — the two planes have drifted` |
| `TestChunkLabels_RepeatedIDsDoNotCrowdOutTheCap` | cap before deduplicating | `the distinct chunk was crowded out by 100 repeats` |
| `TestMemorySearch_DocumentHitCarriesItsDocumentAndHeading` (×2, one per surface) | drop that surface's projection | HTTP: `document = "", want "Verified writes"`; in-band: `no document hit for chunk …` |

Two notes on test quality:

- **One assertion was found vacuous** by this process and replaced. The first draft asked for each id twice and checked the label count, claiming "a repeat must not cost a row" — but SQL returns one row per *distinct* id whether or not the caller deduped, so it passed against the unfixed code. The replacement pins an observable consequence instead: dedup runs before the cap, so `maxChunkLabelLookup` repeats of one id cannot displace a different chunk's label.
- The positive tests use **deliberately different** document and chunk titles. Equal ones would pass against a projection that swapped the fields, which is the likeliest way to get this wrong given the query selects two columns both named `title`.

The drift test compares the scope mapping against `Document.resolveScope` directly, because a divergence there resolves against an empty schema and the labels just stop appearing — indistinguishable from "no labels available".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8