### PR TITLE
feat(explorer): copy document + chunk ids from the document viewer (for n8n)

### DIFF
--- a/packages/explorer/src/components/DocumentChunkTree.tsx
+++ b/packages/explorer/src/components/DocumentChunkTree.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import type { ChunkRow } from "../types";
 import { chunkColor, effectiveScheme, tintStyle, type ColorScheme } from "../lib/colorScheme";
+import IdCopy from "./IdCopy";
 
 // DocumentChunkTree renders a document's chunk hierarchy (RFC AK), built from
 // the flat query_chunks list by parent_id + position. Mirrors PathTree: a single
@@ -192,6 +193,10 @@ function ChunkTreeNode({ node, expanded, toggle, selectedId, onSelect, tintSchem
             </span>
           )}
         </button>
+        {/* Per-chunk copy id — a sibling of the tile button (not nested, which
+            would be invalid), so any chunk's id can be grabbed for an external
+            workflow without selecting it first. */}
+        <IdCopy value={node.row.id} compact title={`Copy chunk id: ${node.row.id}`} />
       </div>
       {hasChildren && isOpen && (
         <ul className="children chunk-children">

--- a/packages/explorer/src/components/DocumentViewerBody.tsx
+++ b/packages/explorer/src/components/DocumentViewerBody.tsx
@@ -23,6 +23,7 @@ import DocumentChunkTree, {
 } from "./DocumentChunkTree";
 import ChunkEditorModal from "./ChunkEditorModal";
 import ColorSchemeEditor from "./ColorSchemeEditor";
+import IdCopy from "./IdCopy";
 import Connections from "./Connections";
 import CrossReferences from "./CrossReferences";
 import HistoryModal from "./HistoryModal";
@@ -523,6 +524,10 @@ export default function DocumentViewerBody({
         <strong className="doc-title" title={rootTitle}>
           {rootTitle}
         </strong>
+        {/* The document id — surfaced + copyable so it can be wired into an
+            external workflow (e.g. n8n over the MCP/HTTP API), which the viewer
+            otherwise only uses internally. */}
+        <IdCopy value={documentId} label="doc" />
         <div className="doc-toolbar-actions">
           {canCreate && (
             <>
@@ -631,6 +636,8 @@ export default function DocumentViewerBody({
                       {t}
                     </span>
                   ))}
+                  {/* The selected chunk's id — copyable for external workflows. */}
+                  <IdCopy value={selectedDetail.id} label="chunk" />
                 </div>
                 <div className="doc-content-controls">
                   {/* The chunk/markdown switch is per-selected-chunk: markdown

--- a/packages/explorer/src/components/IdCopy.tsx
+++ b/packages/explorer/src/components/IdCopy.tsx
@@ -1,0 +1,59 @@
+import { useState, type MouseEvent } from "react";
+import { copyToClipboard } from "../lib/clipboard";
+
+export interface IdCopyProps {
+  // value is the exact id copied to the clipboard (a document id or a chunk id).
+  value: string;
+  // label is a short prefix shown before the id in full mode (e.g. "doc", "chunk").
+  label?: string;
+  // compact renders the copy glyph ONLY (no visible id text) for dense rows like
+  // the chunk tree; the id still rides in the button's title/aria-label.
+  compact?: boolean;
+  // title overrides the button tooltip (default: `Copy <label>: <value>`).
+  title?: string;
+}
+
+// IdCopy surfaces an id with a click-to-copy button. It exists so an operator
+// wiring a document or a specific chunk into an external workflow — n8n over the
+// MCP/HTTP API — can grab the EXACT id the API expects, which the viewer
+// otherwise only uses internally as React keys. The clipboard always receives
+// the full id even when the on-screen value is ellipsized.
+export default function IdCopy({ value, label, compact, title }: IdCopyProps) {
+  const [state, setState] = useState<"idle" | "copied" | "error">("idle");
+
+  const copy = async (e: MouseEvent) => {
+    // Never let the copy click bubble to the row/tile's own handler (which would
+    // select the chunk or toggle the tree).
+    e.stopPropagation();
+    e.preventDefault();
+    const ok = await copyToClipboard(value);
+    setState(ok ? "copied" : "error");
+    window.setTimeout(() => setState("idle"), ok ? 1200 : 1500);
+  };
+
+  const glyph = state === "copied" ? "✓" : state === "error" ? "✗" : "⎘";
+  const btnTitle = title ?? `Copy ${label ?? "id"}: ${value}`;
+  const button = (
+    <button
+      type="button"
+      className={`id-copy-btn id-copy-${state}`}
+      onClick={copy}
+      title={btnTitle}
+      aria-label={btnTitle}
+    >
+      {glyph}
+    </button>
+  );
+
+  if (compact) return button;
+
+  return (
+    <span className="id-copy">
+      {label && <span className="id-copy-label">{label}</span>}
+      <code className="id-copy-value" title={value}>
+        {value}
+      </code>
+      {button}
+    </span>
+  );
+}

--- a/packages/explorer/src/lib/clipboard.test.ts
+++ b/packages/explorer/src/lib/clipboard.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { copyToClipboard } from "./clipboard";
+
+// The package runs vitest in the default `node` env, where `navigator` is a
+// read-only global — so stub it via vi.stubGlobal (a direct assignment throws)
+// and unstub after each case.
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("copyToClipboard", () => {
+  it("writes the text and reports success", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    const ok = await copyToClipboard("doc-123");
+    expect(ok).toBe(true);
+    expect(writeText).toHaveBeenCalledWith("doc-123");
+  });
+
+  it("returns false (does not throw) when the write rejects", async () => {
+    vi.stubGlobal("navigator", {
+      clipboard: { writeText: vi.fn().mockRejectedValue(new Error("denied")) },
+    });
+    await expect(copyToClipboard("x")).resolves.toBe(false);
+  });
+
+  it("returns false when the clipboard API is absent (insecure context / no DOM)", async () => {
+    vi.stubGlobal("navigator", {}); // navigator present, clipboard undefined
+    await expect(copyToClipboard("x")).resolves.toBe(false);
+  });
+
+  it("returns false when navigator itself is undefined", async () => {
+    vi.stubGlobal("navigator", undefined);
+    await expect(copyToClipboard("x")).resolves.toBe(false);
+  });
+});

--- a/packages/explorer/src/lib/clipboard.ts
+++ b/packages/explorer/src/lib/clipboard.ts
@@ -1,0 +1,15 @@
+// copyToClipboard writes text to the system clipboard and returns whether it
+// succeeded. It is a standalone helper (not inlined in the button) so the copy
+// affordance's success/failure branch is unit-testable without a DOM — the UI
+// only needs the boolean. It guards a missing clipboard (an insecure context, an
+// old browser, or a non-browser test env) by returning false rather than
+// throwing, so a copy button can never crash the viewer.
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    if (typeof navigator === "undefined" || !navigator.clipboard) return false;
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/explorer/src/styles.css
+++ b/packages/explorer/src/styles.css
@@ -587,6 +587,67 @@
   color: white;
   border-color: var(--accent);
 }
+
+/* Id + copy affordance (IdCopy): the document id in the toolbar, the selected
+   chunk id in the content head, and a compact copy on every chunk-tree row.
+   Lets an operator grab the exact id for an external workflow (n8n over the
+   MCP/HTTP API). */
+.loomcycle-explorer .id-copy {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+}
+.loomcycle-explorer .id-copy-label {
+  font-size: var(--lc-text-xs);
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+.loomcycle-explorer .id-copy-value {
+  font-family: var(--mono);
+  font-size: var(--lc-text-xs);
+  color: var(--fg-soft);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 6px;
+  max-width: 22ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.loomcycle-explorer .id-copy-btn {
+  background: transparent;
+  border: none;
+  color: var(--fg-soft);
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 1;
+  padding: 2px 3px;
+  border-radius: 4px;
+  user-select: none;
+}
+.loomcycle-explorer .id-copy-btn:hover {
+  color: var(--accent);
+}
+.loomcycle-explorer .id-copy-btn.id-copy-copied {
+  color: var(--accent);
+}
+.loomcycle-explorer .id-copy-btn.id-copy-error {
+  color: var(--failed);
+}
+/* On a chunk-tree row the copy sits at the far right and stays faint until the
+   row is hovered/selected, so the tree keeps its clean scan-line. */
+.loomcycle-explorer .node .row .id-copy-btn {
+  margin-left: auto;
+  opacity: 0.4;
+}
+.loomcycle-explorer .node .row:hover .id-copy-btn,
+.loomcycle-explorer .node.selected .row .id-copy-btn,
+.loomcycle-explorer .node .row .id-copy-btn:focus-visible {
+  opacity: 1;
+}
 .loomcycle-explorer .doc-mode-toggle {
   display: inline-flex;
   border: 1px solid var(--border);


### PR DESCRIPTION
## Why

Wiring a document or a specific chunk into an external workflow — **n8n over the MCP/HTTP API** — needs the exact `document_id` / chunk id the API expects. The document viewer used those ids only internally (React keys, data-layer calls) and **never displayed them**, so there was no way to grab one from the UI.

## What

All in `@loomcycle/explorer` (the source the web SPA consumes via a Vite alias — no separate package publish needed for the SPA):

- **New `IdCopy` component** — an id + click-to-copy button (`⎘` → `✓`/`✗` feedback). *Full* mode shows the id monospace + ellipsized; *compact* mode is icon-only for dense rows. The clipboard always receives the **full** id even when the on-screen value is truncated. The copy click `stopPropagation`/`preventDefault`s so it never selects the chunk or toggles the tree.
- **New `copyToClipboard(text)` helper** — a tiny standalone so the success/failure branch is unit-testable without a DOM; guards a missing/insecure-context clipboard by returning `false` instead of throwing (a copy button can never crash the viewer).
- **Surfaced in three places:**
  1. the **document id** in the toolbar (`doc <id> ⎘`),
  2. the **selected chunk id** in the content head (`chunk <id> ⎘`),
  3. a **compact per-row copy** on every chunk-tree tile — faint until the row is hovered/selected, so the tree keeps its clean scan-line.
- Scoped `.id-copy` CSS built from the package's own design tokens (no icon-library dependency — matches the viewer's glyph convention).

`IdCopy` is an internal component (not added to the package's public export surface).

## Tested

- `packages/explorer`: `npm run typecheck` clean; `npm test` — **25 pass** (4 new `copyToClipboard` cases: write-success, rejection, absent clipboard, undefined navigator).
- Web SPA `npm run build` succeeds — the explorer changes integrate and compile into the embedded UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)