### PR TITLE
feat(bench): add the LoCoMo memory-retrieval benchmark harness

### DIFF
--- a/bench/cmd/locomo/README.md
+++ b/bench/cmd/locomo/README.md
@@ -1,0 +1,152 @@
+# locomo — LoCoMo long-term conversational memory benchmark
+
+Scores loomcycle's memory **retrieval** against the LoCoMo benchmark, on a
+corpus held in an isolated tenant. It drives an externally-running instance, so
+the numbers come from the real vector store and the real configured embedder —
+not from a harness substitute for either.
+
+## Why retrieval, and why this benchmark
+
+LoCoMo's QA annotations carry an `evidence` field: the `dia_id`s of the
+dialogue turns that support each answer. Ingest every turn as a memory row
+**keyed by its `dia_id`**, and each annotation becomes retrieval ground truth:
+
+```
+question  ->  "When did Caroline go to the LGBTQ support group?"
+expected  ->  ["D1:3"]
+```
+
+So the retrieval axis needs **no LLM judge and no answer-string matching**.
+It is deterministic, cheap and re-runnable, and it measures the ranker and the
+embedder rather than the answering model. That matters because LoCoMo's *answer*
+axis is close to saturated (a plain full-context baseline beats reported memory
+systems) while its retrieval axis is not.
+
+The corpus is also small: ~5,900 turns across 10 conversations, so a full run
+costs ~5,900 embeddings and nothing else.
+
+## The dataset is not in this repo
+
+LoCoMo ships under **CC BY-NC 4.0**. Nothing derived from it is committed here.
+Download your own copy:
+
+```sh
+curl -sSLO https://raw.githubusercontent.com/snap-research/locomo/main/data/locomo10.json
+```
+
+Pass it with `-data`. Keep the file and any generated corpus out of version
+control.
+
+## Isolate the memory first
+
+The memory routes derive the tenant from the **principal** — they honour no
+`?tenant=` override — so the only way to keep ~5,900 synthetic conversational
+rows out of real memory is a dedicated tenant's bearer.
+
+Mint one (admin bearer required), then point the harness at it:
+
+```sh
+# 1. mint an OperatorTokenDef for a tenant of its own
+curl -sS -X POST "$LOOMCYCLE/v1/_operatortokendef" \
+  -H "Authorization: Bearer $LOOMCYCLE_AUTH_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"op":"create","name":"locomo-bench","tenant_id":"locomo-bench",
+       "subject":"bench","scopes":["substrate:tenant"]}'
+
+# 2. give it to the harness (preferred over reusing the operator bearer)
+export LOOMCYCLE_LOCOMO_TOKEN='<the minted token>'
+```
+
+The harness calls `GET /v1/_me` before it writes anything, prints the tenant it
+resolved, and **refuses to run** if that tenant is the default/legacy one.
+`-allow-shared-tenant` overrides this deliberately for single-tenant
+deployments.
+
+Prerequisites on the instance: a vector-capable store
+(`LOOMCYCLE_PGVECTOR_ENABLED=1` on Postgres, or a sqlite-vec build) and a
+configured `memory.embedder`. Without either, ingest aborts on the first embed
+warning rather than writing thousands of un-embedded rows.
+
+## Modes
+
+```sh
+go build -o bin/locomo ./bench/cmd/locomo
+
+# offline: emit one memory-eval dataset per conversation (no instance needed)
+./bin/locomo -mode=convert -data locomo10.json -out /tmp/locomo-datasets
+loomcycle memory-eval --dataset /tmp/locomo-datasets/locomo-conv-26.jsonl
+
+# live: ingest, then score
+./bin/locomo -mode=all -data locomo10.json -loomcycle http://127.0.0.1:8787
+
+# smoke it on one conversation first
+./bin/locomo -mode=all -data locomo10.json -conversations 1
+
+# reclaim the scope
+./bin/locomo -mode=purge -data locomo10.json
+```
+
+`convert` output runs through `loomcycle memory-eval`, but that command embeds
+with a deterministic bag-of-tokens stub — those numbers validate the plumbing,
+not retrieval quality. Use `-mode=all` for a semantic number.
+
+One dataset **per conversation**, never combined: `dia_id`s are numbered per
+conversation and collide heavily across them (5,882 turns, 1,033 distinct ids).
+Each conversation is ingested under its own `scope_id` (`locomo-<sample_id>`)
+for the same reason.
+
+Useful flags: `-top-k` (default 10), `-categories` (default `1,2,3,4`),
+`-conversations N`, `-concurrency`, `-no-embed` (write now, embed later via
+`POST /v1/_memory/backfill_embeddings`), `-dry-run`.
+
+## Output
+
+`bench/results/locomo-<timestamp>/` gets `matrix.md` (overall, per-category and
+per-conversation tables) and `report.json` (the same plus every per-query
+result, so a surprising number can be traced rather than re-run).
+
+Every report prints **which categories it included**, because differing filters
+are precisely why published LoCoMo numbers cannot be compared with one another.
+
+## What the dataset gets wrong
+
+The harness counts and reports what it could not use, rather than quietly
+shrinking the answer key underneath the metric. On the released file:
+
+- **Category 5 (adversarial) is excluded by default.** 444 of its 446 questions
+  have a `null` answer; both Mem0 and Zep dropped it too. Categories 1–4 are the
+  1,540 questions everyone reports.
+- **Evidence strings are dirty.** Alongside clean `"D23:1"` entries the file
+  carries `"D8:6; D9:17"`, `"D9:1 D4:4 D4:6"`, `"D:11:26"` and a bare `"D"`. The
+  parser splits packed entries and repairs the unambiguous transposed colon; it
+  reports anything else instead of guessing.
+- **A few evidence ids name no turn in their own conversation** (3 on the
+  current file) — unretrievable by anyone, so they are dropped rather than
+  charged to the memory stack.
+- **5 questions have no usable evidence** and are dropped: open-domain questions
+  legitimately draw on world knowledge rather than a turn.
+- **16 sessions are declared with a timestamp but no turns.**
+- Documented elsewhere and not correctable here: some questions attribute
+  statements to the wrong speaker, some are ambiguous with several valid
+  answers, some multimodal questions are unanswerable from the BLIP caption, and
+  some gold answers are simply wrong.
+
+A run on the current file scores **1,535 queries over 5,882 rows**.
+
+## Two things the numbers depend on
+
+- **Session timestamps are prefixed onto every row.** LoCoMo dates live on the
+  session, not the turn, so a row without one is unretrievable for the temporal
+  category however good the embedder is.
+- **Rows embed with their JSON quotes.** `PUT /v1/_memory/.../keys/{key}` has no
+  `embed_text` field and embeds the JSON-encoded value, so a stored row's
+  embedded text carries surrounding quotes the query text does not. Two
+  characters against a couple of hundred is noise for a dense embedder, but it
+  is an asymmetry and the report says so.
+
+## Not covered here
+
+LoCoMo does not test **knowledge updates**, which is what a bi-temporal fact
+tier exists for. That axis needs a different corpus — see the research document
+`/loomcycle/docs/factual-corpus-sources-and-memory-benchmarks` in the document
+store.

--- a/bench/cmd/locomo/README.md
+++ b/bench/cmd/locomo/README.md
@@ -62,10 +62,13 @@ resolved, and **refuses to run** if that tenant is the default/legacy one.
 `-allow-shared-tenant` overrides this deliberately for single-tenant
 deployments.
 
-Prerequisites on the instance: a vector-capable store
-(`LOOMCYCLE_PGVECTOR_ENABLED=1` on Postgres, or a sqlite-vec build) and a
-configured `memory.embedder`. Without either, ingest aborts on the first embed
-warning rather than writing thousands of un-embedded rows.
+Prerequisites on the instance: **Postgres with pgvector**
+(`LOOMCYCLE_PGVECTOR_ENABLED=1`) and a configured `memory.embedder`. SQLite is
+not an option here whatever the runtime's 503 message suggests: the
+`sqlite_vec` build loads the extension but its `MemoryEmbed*` methods are still
+stubbed and `SupportsVectors()` returns false, so a SQLite instance has no
+vector search at all. Without both, ingest aborts on the first embed warning
+rather than writing thousands of un-embedded rows.
 
 ## Modes
 

--- a/bench/cmd/locomo/client.go
+++ b/bench/cmd/locomo/client.go
@@ -1,0 +1,167 @@
+package main
+
+// client.go — the thin loomcycle HTTP client this harness needs.
+//
+// It drives an EXTERNALLY-RUNNING loomcycle, the same posture as lc-bench: the
+// point is to measure the real vector store and the real configured embedder,
+// not a harness substitute for them.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Client talks to one loomcycle instance as one principal.
+type Client struct {
+	base   string
+	bearer string
+	httpc  *http.Client
+}
+
+// NewClient builds a client. The bearer determines the tenant every write and
+// read lands in — the memory routes derive the tenant from the PRINCIPAL and
+// honour no ?tenant= override, so a dedicated tenant token is the only way to
+// isolate this corpus from real memory.
+func NewClient(base, bearer string, timeout time.Duration) *Client {
+	return &Client{
+		base:   strings.TrimRight(base, "/"),
+		bearer: bearer,
+		httpc:  &http.Client{Timeout: timeout},
+	}
+}
+
+func (c *Client) do(ctx context.Context, method, path string, body any, out any) error {
+	var rdr io.Reader
+	if body != nil {
+		raw, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshal request: %w", err)
+		}
+		rdr = bytes.NewReader(raw)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.base+path, rdr)
+	if err != nil {
+		return err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if c.bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+c.bearer)
+	}
+	resp, err := c.httpc.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	// Bound the error body: an HTML error page from a proxy in front of
+	// loomcycle would otherwise land whole in a log line.
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("%s %s: %s: %s", method, path, resp.Status, truncate(strings.TrimSpace(string(raw)), 300))
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(raw, out); err != nil {
+		return fmt.Errorf("%s %s: decode response: %w", method, path, err)
+	}
+	return nil
+}
+
+// Identity is the subset of GET /v1/_me this harness checks.
+type Identity struct {
+	TenantID string   `json:"tenant_id"`
+	Subject  string   `json:"subject"`
+	Scopes   []string `json:"scopes"`
+	IsAdmin  bool     `json:"is_admin"`
+}
+
+// Whoami resolves the principal behind the bearer. Called before any write, so
+// the operator sees which tenant is about to receive ~6k rows.
+func (c *Client) Whoami(ctx context.Context) (Identity, error) {
+	var id Identity
+	err := c.do(ctx, http.MethodGet, "/v1/_me", nil, &id)
+	return id, err
+}
+
+type putEntryBody struct {
+	Value json.RawMessage `json:"value"`
+	Embed bool            `json:"embed,omitempty"`
+}
+
+type putEntryResponse struct {
+	Embedded     bool   `json:"embedded"`
+	EmbedWarning string `json:"embed_warning,omitempty"`
+}
+
+// PutEntry upserts one memory row and (when embed is set) embeds it
+// synchronously on the instance's configured embedder.
+//
+// The row's embedded text is the JSON-encoded value — the endpoint has no
+// embed_text field — so a string value embeds with its surrounding quotes.
+// Two quote characters against a couple of hundred characters of turn text is
+// noise for a dense embedder, but it IS an asymmetry with the un-quoted query
+// and the report says so rather than leaving it unstated.
+func (c *Client) PutEntry(ctx context.Context, scope, scopeID, key, value string, embed bool) (putEntryResponse, error) {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return putEntryResponse{}, err
+	}
+	path := fmt.Sprintf("/v1/_memory/scopes/%s/%s/keys/%s",
+		url.PathEscape(scope), url.PathEscape(scopeID), url.PathEscape(key))
+	var out putEntryResponse
+	err = c.do(ctx, http.MethodPut, path, putEntryBody{Value: raw, Embed: embed}, &out)
+	return out, err
+}
+
+type searchRequest struct {
+	Query   string `json:"query"`
+	Scope   string `json:"scope"`
+	ScopeID string `json:"scope_id"`
+	TopK    int    `json:"top_k"`
+}
+
+type searchResponse struct {
+	Entries []struct {
+		Key       string  `json:"key"`
+		Score     float64 `json:"score"`
+		RankScore float64 `json:"rank_score"`
+		Kind      string  `json:"kind"`
+	} `json:"entries"`
+	QueryEmbeddingDim int  `json:"query_embedding_dim"`
+	Truncated         bool `json:"truncated"`
+}
+
+// Search runs one semantic query and returns the retrieved keys in rank order.
+func (c *Client) Search(ctx context.Context, scope, scopeID, query string, topK int) ([]string, int, error) {
+	var out searchResponse
+	err := c.do(ctx, http.MethodPost, "/v1/_memory/search", searchRequest{
+		Query: query, Scope: scope, ScopeID: scopeID, TopK: topK,
+	}, &out)
+	if err != nil {
+		return nil, 0, err
+	}
+	keys := make([]string, 0, len(out.Entries))
+	for _, e := range out.Entries {
+		keys = append(keys, e.Key)
+	}
+	return keys, out.QueryEmbeddingDim, nil
+}
+
+// DeleteEntry removes one row — used by -mode=purge to reclaim a scope.
+func (c *Client) DeleteEntry(ctx context.Context, scope, scopeID, key string) error {
+	path := fmt.Sprintf("/v1/_memory/scopes/%s/%s/keys/%s",
+		url.PathEscape(scope), url.PathEscape(scopeID), url.PathEscape(key))
+	return c.do(ctx, http.MethodDelete, path, nil, nil)
+}

--- a/bench/cmd/locomo/client_test.go
+++ b/bench/cmd/locomo/client_test.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func meServer(t *testing.T, tenant string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/_me" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(Identity{
+			TenantID: tenant, Subject: "bench", Scopes: []string{"substrate:tenant"},
+		})
+	}))
+}
+
+// TestConnect_RefusesTheDefaultTenantSoTheCorpusCannotLandInRealMemory is the
+// isolation guard. ~6,000 synthetic conversational rows written into the tenant
+// an operator actually uses is not a mistake you notice until recall degrades,
+// so the harness asks who it is before it writes anything.
+func TestConnect_RefusesTheDefaultTenantSoTheCorpusCannotLandInRealMemory(t *testing.T) {
+	srv := meServer(t, "")
+	defer srv.Close()
+	t.Setenv("LOOMCYCLE_LOCOMO_TOKEN", "tok")
+
+	var out bytes.Buffer
+	_, _, err := connect(context.Background(), options{instance: srv.URL, timeout: time.Second}, &out)
+	if err == nil {
+		t.Fatal("connect accepted a bearer resolving to the default/legacy tenant")
+	}
+	if !strings.Contains(err.Error(), "dedicated tenant") {
+		t.Errorf("error does not tell the operator how to fix it: %v", err)
+	}
+}
+
+func TestConnect_AcceptsADedicatedTenant(t *testing.T) {
+	srv := meServer(t, "locomo-bench")
+	defer srv.Close()
+	t.Setenv("LOOMCYCLE_LOCOMO_TOKEN", "tok")
+
+	var out bytes.Buffer
+	_, id, err := connect(context.Background(), options{instance: srv.URL, timeout: time.Second}, &out)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if id.TenantID != "locomo-bench" {
+		t.Errorf("TenantID = %q, want locomo-bench", id.TenantID)
+	}
+	// The resolved principal is printed, so a run's output records which tenant
+	// received the corpus.
+	if !strings.Contains(out.String(), "locomo-bench") {
+		t.Errorf("connect did not report the tenant it resolved: %q", out.String())
+	}
+}
+
+// TestConnect_AllowSharedTenantIsAnExplicitOverride — the guard must be
+// escapable, or an operator running single-tenant cannot use the harness at all.
+func TestConnect_AllowSharedTenantIsAnExplicitOverride(t *testing.T) {
+	srv := meServer(t, "")
+	defer srv.Close()
+	t.Setenv("LOOMCYCLE_LOCOMO_TOKEN", "tok")
+
+	var out bytes.Buffer
+	if _, _, err := connect(context.Background(),
+		options{instance: srv.URL, timeout: time.Second, allowSharedTenant: true}, &out); err != nil {
+		t.Fatalf("connect with -allow-shared-tenant: %v", err)
+	}
+}
+
+func TestConnect_RefusesWithNoBearerRatherThanCallingUnauthenticated(t *testing.T) {
+	t.Setenv("LOOMCYCLE_LOCOMO_TOKEN", "")
+	t.Setenv("LOOMCYCLE_AUTH_TOKEN", "")
+	var out bytes.Buffer
+	if _, _, err := connect(context.Background(), options{instance: "http://127.0.0.1:1", timeout: time.Second}, &out); err == nil ||
+		!strings.Contains(err.Error(), "no bearer") {
+		t.Fatalf("err = %v, want a missing-bearer refusal", err)
+	}
+}
+
+func TestBearer_PrefersTheBenchmarkSpecificToken(t *testing.T) {
+	t.Setenv("LOOMCYCLE_AUTH_TOKEN", "operator")
+	t.Setenv("LOOMCYCLE_LOCOMO_TOKEN", "bench")
+	if got := bearer(); got != "bench" {
+		t.Errorf("bearer() = %q, want the benchmark token so the operator bearer is not reused", got)
+	}
+}
+
+// TestPutEntry_EscapesTheColonInADiaIDKeyAndSendsAJSONValue — dia_ids contain a
+// colon ("D1:3") and go into the URL path, and the endpoint requires the value
+// to be valid JSON.
+func TestPutEntry_EscapesTheColonInADiaIDKeyAndSendsAJSONValue(t *testing.T) {
+	var gotPath, gotAuth string
+	var gotBody putEntryBody
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.EscapedPath()
+		gotAuth = r.Header.Get("Authorization")
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		_ = json.NewEncoder(w).Encode(putEntryResponse{Embedded: true})
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "tok", time.Second)
+	resp, err := c.PutEntry(context.Background(), "agent", "locomo-conv-1", "D1:3", "Ada: hello", true)
+	if err != nil {
+		t.Fatalf("PutEntry: %v", err)
+	}
+	if !resp.Embedded {
+		t.Error("Embedded = false, want the server's ack echoed")
+	}
+	if !strings.Contains(gotPath, "locomo-conv-1") || !strings.Contains(gotPath, "D1") {
+		t.Errorf("path = %q, want the scope_id and dia_id in it", gotPath)
+	}
+	if gotAuth != "Bearer tok" {
+		t.Errorf("Authorization = %q", gotAuth)
+	}
+	var value string
+	if err := json.Unmarshal(gotBody.Value, &value); err != nil {
+		t.Fatalf("value is not a JSON string: %v", err)
+	}
+	if value != "Ada: hello" {
+		t.Errorf("value = %q, want the turn body", value)
+	}
+	if !gotBody.Embed {
+		t.Error("embed flag not sent; the row would be stored without a vector")
+	}
+}
+
+func TestSearch_ReturnsKeysInRankOrder(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req searchRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if req.ScopeID != "locomo-conv-1" || req.TopK != 3 {
+			t.Errorf("request = %+v, want scope_id/top_k threaded through", req)
+		}
+		_, _ = w.Write([]byte(`{"entries":[{"key":"D1:2","score":0.9},{"key":"D1:1","score":0.7}],` +
+			`"query_embedding_dim":1024}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "tok", time.Second)
+	keys, dim, err := c.Search(context.Background(), "agent", "locomo-conv-1", "what pet?", 3)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if strings.Join(keys, ",") != "D1:2,D1:1" {
+		t.Errorf("keys = %v, want rank order preserved", keys)
+	}
+	if dim != 1024 {
+		t.Errorf("dim = %d, want 1024", dim)
+	}
+}
+
+func TestClient_SurfacesAnErrorStatusWithItsBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"error":"vector_unsupported","message":"no vector support"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "tok", time.Second)
+	_, _, err := c.Search(context.Background(), "agent", "s", "q", 5)
+	if err == nil || !strings.Contains(err.Error(), "vector_unsupported") {
+		t.Fatalf("err = %v, want the server's diagnosis surfaced", err)
+	}
+}
+
+func TestParseCategories_RejectsGarbageAndRequiresOne(t *testing.T) {
+	if _, err := parseCategories("1,x"); err == nil {
+		t.Error("parseCategories accepted a non-numeric category")
+	}
+	if _, err := parseCategories(" , "); err == nil {
+		t.Error("parseCategories accepted an empty set")
+	}
+	got, err := parseCategories(" 4, 1 ,2")
+	if err != nil {
+		t.Fatalf("parseCategories: %v", err)
+	}
+	if len(got) != 3 || got[0] != 4 {
+		t.Errorf("got %v, want the order preserved as given", got)
+	}
+}

--- a/bench/cmd/locomo/dataset.go
+++ b/bench/cmd/locomo/dataset.go
@@ -1,0 +1,366 @@
+package main
+
+// dataset.go — LoCoMo (locomo10.json) parsing, and its conversion into
+// loomcycle memory rows plus retrieval queries.
+//
+// THE DATASET IS NOT VENDORED. LoCoMo ships under CC BY-NC 4.0, so this
+// harness reads a copy the operator downloaded themselves (--data) and writes
+// nothing derived from it into the repo. See README.md.
+//
+// The load-bearing property is qa[].evidence: the dia_ids of the turns that
+// support each answer. Keying every ingested turn by its dia_id turns each
+// annotation into retrieval ground truth, which is why the retrieval axis
+// needs no LLM judge and no answer-string matching.
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Categories as released.
+//
+// The id -> label mapping is DERIVED from the released category counts, not
+// copied from documentation the file carries (it carries none): the file holds
+// 282/321/96/841 questions for categories 1/2/3/4, matching the published
+// 282 multi-hop, 321 temporal, 96 open-domain and 841 single-hop exactly. If a
+// future release renumbers them, every report is mislabelled — re-check the
+// counts before trusting the labels.
+//
+// 5 is adversarial and 444 of its 446 questions have a null answer, which is
+// why both Mem0 and Zep excluded it; 1-4 are the 1,540 questions everyone
+// else reports on.
+const (
+	CategoryMultiHop    = 1
+	CategoryTemporal    = 2
+	CategoryOpenDomain  = 3
+	CategorySingleHop   = 4
+	CategoryAdversarial = 5
+)
+
+// CategoryName labels a category in reports. Unknown ids render numerically so
+// a future category does not silently print as one of these.
+func CategoryName(c int) string {
+	switch c {
+	case CategoryMultiHop:
+		return "multi-hop"
+	case CategoryTemporal:
+		return "temporal"
+	case CategoryOpenDomain:
+		return "open-domain"
+	case CategorySingleHop:
+		return "single-hop"
+	case CategoryAdversarial:
+		return "adversarial"
+	default:
+		return "category-" + strconv.Itoa(c)
+	}
+}
+
+// DefaultCategories excludes 5 (adversarial): its ground-truth answers are
+// missing, so it can be neither answered nor scored. Every report states the
+// filter it ran under, because differing filters are exactly why published
+// LoCoMo numbers are not comparable to one another.
+var DefaultCategories = []int{CategoryMultiHop, CategoryTemporal, CategoryOpenDomain, CategorySingleHop}
+
+// Turn is one dialogue turn of one session.
+type Turn struct {
+	DiaID    string
+	Session  int
+	DateTime string
+	Speaker  string
+	Text     string
+	Caption  string
+}
+
+// Text renders the turn as the string that is both stored and embedded.
+//
+// The session timestamp is prefixed deliberately: the temporal category asks
+// "when did X happen", and the date lives on the SESSION in LoCoMo, not in the
+// turn text. A row without it is unretrievable for those questions no matter
+// how good the embedder is, which would measure the dataset's shape rather
+// than the memory stack.
+func (t Turn) Body() string {
+	var b strings.Builder
+	if t.DateTime != "" {
+		b.WriteString("[" + t.DateTime + "] ")
+	}
+	if t.Speaker != "" {
+		b.WriteString(t.Speaker + ": ")
+	}
+	b.WriteString(t.Text)
+	// Image turns carry a BLIP caption instead of (or alongside) prose. Keep it
+	// — several questions are answerable only from the caption. That the caption
+	// is sometimes inadequate is a documented dataset defect, not ours to fix.
+	if c := strings.TrimSpace(t.Caption); c != "" && !strings.Contains(t.Text, c) {
+		b.WriteString(" (shared an image: " + c + ")")
+	}
+	return b.String()
+}
+
+// Query is one QA annotation reduced to a retrieval probe.
+type Query struct {
+	Question string
+	Category int
+	// Expected holds the dia_ids of the supporting turns — the answer key for
+	// recall/precision. Always non-empty (queries without resolvable evidence
+	// are dropped and counted as a defect).
+	Expected []string
+	// Answer is the gold answer, kept for the later answer-accuracy phase. Empty
+	// for the adversarial category.
+	Answer string
+}
+
+// Conversation is one LoCoMo sample: its turns and its queries.
+type Conversation struct {
+	SampleID string
+	Turns    []Turn
+	Queries  []Query
+}
+
+// ScopeID is the memory scope_id this conversation is ingested under.
+//
+// One scope_id PER CONVERSATION is mandatory, not tidiness: dia_ids are
+// numbered per conversation and collide heavily across them (the released file
+// has 5,882 turns but only 1,033 distinct dia_ids). A single shared keyspace
+// would both overwrite rows and let a question about one conversation retrieve
+// another's turns.
+func (c Conversation) ScopeID() string { return "locomo-" + c.SampleID }
+
+// Defects counts everything the loader could not use. A benchmark that
+// silently discards part of its answer key reports a number computed against a
+// smaller key than it claims, so these are counted, printed, and carried into
+// the report.
+type Defects struct {
+	MalformedEvidenceFragments   int      `json:"malformed_evidence_fragments"`
+	UnresolvedEvidenceIDs        int      `json:"unresolved_evidence_ids"`
+	QueriesWithoutEvidence       int      `json:"queries_without_evidence"`
+	QueriesFilteredByCategory    int      `json:"queries_filtered_by_category"`
+	SessionsDeclaredWithoutTurns int      `json:"sessions_declared_without_turns"`
+	Examples                     []string `json:"examples,omitempty"`
+}
+
+// maxDefectExamples bounds the examples list so a systematically broken file
+// cannot produce a report larger than the dataset.
+const maxDefectExamples = 12
+
+func (d *Defects) note(format string, args ...any) {
+	if len(d.Examples) < maxDefectExamples {
+		d.Examples = append(d.Examples, fmt.Sprintf(format, args...))
+	}
+}
+
+// Any reports whether anything was discarded.
+func (d Defects) Any() bool {
+	return d.MalformedEvidenceFragments > 0 || d.UnresolvedEvidenceIDs > 0 ||
+		d.QueriesWithoutEvidence > 0 || d.SessionsDeclaredWithoutTurns > 0
+}
+
+var (
+	// diaIDRe is the only well-formed evidence shape.
+	diaIDRe = regexp.MustCompile(`^D\d+:\d+$`)
+	// evidenceSplitRe splits a raw entry that packed several ids into one string.
+	evidenceSplitRe = regexp.MustCompile(`[;,\s]+`)
+	sessionKeyRe    = regexp.MustCompile(`^session_(\d+)$`)
+)
+
+// parseEvidence splits one raw evidence entry into dia_ids, returning the
+// fragments it could not read.
+//
+// LoCoMo's evidence field is dirty. Alongside clean "D23:1" strings the
+// released file carries "D8:6; D9:17" (two ids in one entry), "D9:1 D4:4 D4:6"
+// (space-separated), "D:11:26" (extra colon) and a bare "D". A parser that
+// accepted only the clean form would drop those without a word and shrink the
+// answer key underneath the metric, so this splits permissively and hands back
+// what it rejected for the caller to count.
+func parseEvidence(raw string) (ids []string, malformed []string) {
+	for _, frag := range evidenceSplitRe.Split(strings.TrimSpace(raw), -1) {
+		if frag == "" {
+			continue
+		}
+		if diaIDRe.MatchString(frag) {
+			ids = append(ids, frag)
+			continue
+		}
+		// "D:11:26" is a transposed "D11:26" — the only malformation frequent
+		// enough to be worth repairing, and unambiguous when it repairs to a
+		// well-formed id. Everything else is reported, never guessed at.
+		if repaired := strings.Replace(frag, "D:", "D", 1); repaired != frag && diaIDRe.MatchString(repaired) {
+			ids = append(ids, repaired)
+			continue
+		}
+		malformed = append(malformed, frag)
+	}
+	return ids, malformed
+}
+
+// rawSample mirrors the released schema. answer is json.RawMessage because the
+// field is a string for 1,536 questions, a bare number for 6, and null for the
+// 444 adversarial ones.
+type rawSample struct {
+	SampleID     string                     `json:"sample_id"`
+	Conversation map[string]json.RawMessage `json:"conversation"`
+	QA           []rawQA                    `json:"qa"`
+}
+
+type rawQA struct {
+	Question string          `json:"question"`
+	Answer   json.RawMessage `json:"answer"`
+	Category int             `json:"category"`
+	Evidence []string        `json:"evidence"`
+}
+
+type rawTurn struct {
+	Speaker     string `json:"speaker"`
+	DiaID       string `json:"dia_id"`
+	Text        string `json:"text"`
+	BlipCaption string `json:"blip_caption"`
+}
+
+// goldAnswer renders the answer field's several JSON types as one string.
+func goldAnswer(raw json.RawMessage) string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	var n json.Number
+	if err := json.Unmarshal(raw, &n); err == nil {
+		return n.String()
+	}
+	return strings.TrimSpace(string(raw))
+}
+
+// Load reads locomo10.json and converts it, keeping only the named categories.
+func Load(path string, categories []int) ([]Conversation, *Defects, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read dataset: %w", err)
+	}
+	return Parse(b, categories)
+}
+
+// Parse converts an in-memory locomo10.json.
+func Parse(b []byte, categories []int) ([]Conversation, *Defects, error) {
+	var samples []rawSample
+	if err := json.Unmarshal(b, &samples); err != nil {
+		return nil, nil, fmt.Errorf("parse dataset: %w", err)
+	}
+	if len(samples) == 0 {
+		return nil, nil, fmt.Errorf("parse dataset: no samples")
+	}
+	keep := map[int]bool{}
+	for _, c := range categories {
+		keep[c] = true
+	}
+
+	defects := &Defects{}
+	out := make([]Conversation, 0, len(samples))
+	for _, s := range samples {
+		conv := Conversation{SampleID: s.SampleID}
+		byID := map[string]bool{}
+
+		// Sessions in chronological order. 288 session_N_date_time keys exist
+		// against 272 session_N turn lists in the released file, so a session can
+		// be declared with no content — iterate the turn lists, not the timestamps.
+		nums := make([]int, 0, len(s.Conversation))
+		for k := range s.Conversation {
+			if m := sessionKeyRe.FindStringSubmatch(k); m != nil {
+				n, _ := strconv.Atoi(m[1])
+				nums = append(nums, n)
+			}
+		}
+		sort.Ints(nums)
+		for k := range s.Conversation {
+			if !strings.HasSuffix(k, "_date_time") {
+				continue
+			}
+			base := strings.TrimSuffix(k, "_date_time")
+			if !sessionKeyRe.MatchString(base) {
+				continue
+			}
+			if _, ok := s.Conversation[base]; !ok {
+				defects.SessionsDeclaredWithoutTurns++
+				defects.note("%s: %s has a timestamp but no turns", s.SampleID, base)
+			}
+		}
+
+		for _, n := range nums {
+			key := "session_" + strconv.Itoa(n)
+			var turns []rawTurn
+			if err := json.Unmarshal(s.Conversation[key], &turns); err != nil {
+				return nil, nil, fmt.Errorf("parse %s %s: %w", s.SampleID, key, err)
+			}
+			var when string
+			if raw, ok := s.Conversation[key+"_date_time"]; ok {
+				_ = json.Unmarshal(raw, &when)
+			}
+			for _, t := range turns {
+				if strings.TrimSpace(t.DiaID) == "" {
+					continue
+				}
+				conv.Turns = append(conv.Turns, Turn{
+					DiaID: t.DiaID, Session: n, DateTime: when,
+					Speaker: t.Speaker, Text: t.Text, Caption: t.BlipCaption,
+				})
+				byID[t.DiaID] = true
+			}
+		}
+
+		for _, q := range s.QA {
+			if !keep[q.Category] {
+				defects.QueriesFilteredByCategory++
+				continue
+			}
+			var expected []string
+			seen := map[string]bool{}
+			for _, raw := range q.Evidence {
+				ids, bad := parseEvidence(raw)
+				for _, frag := range bad {
+					defects.MalformedEvidenceFragments++
+					defects.note("%s: unreadable evidence %q on %q", s.SampleID, frag, truncate(q.Question, 60))
+				}
+				for _, id := range ids {
+					// An id naming a turn this conversation does not contain cannot be
+					// retrieved by anyone. Counting it as expected would charge the
+					// memory stack for the dataset's error.
+					if !byID[id] {
+						defects.UnresolvedEvidenceIDs++
+						defects.note("%s: evidence %s names no turn in this conversation", s.SampleID, id)
+						continue
+					}
+					if !seen[id] {
+						seen[id] = true
+						expected = append(expected, id)
+					}
+				}
+			}
+			if len(expected) == 0 {
+				// Open-domain questions draw on world knowledge and legitimately have
+				// no supporting turn; they are unscoreable on a retrieval metric.
+				defects.QueriesWithoutEvidence++
+				defects.note("%s: no usable evidence for %q (category %d)", s.SampleID, truncate(q.Question, 60), q.Category)
+				continue
+			}
+			conv.Queries = append(conv.Queries, Query{
+				Question: q.Question, Category: q.Category,
+				Expected: expected, Answer: goldAnswer(q.Answer),
+			})
+		}
+		out = append(out, conv)
+	}
+	return out, defects, nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/bench/cmd/locomo/dataset_test.go
+++ b/bench/cmd/locomo/dataset_test.go
@@ -1,0 +1,263 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/memory/eval"
+)
+
+// fixture is a HAND-WRITTEN stand-in for locomo10.json, deliberately not an
+// excerpt of it: the real dataset is CC BY-NC 4.0 and nothing derived from it
+// belongs in this repo. It reproduces the SHAPES that matter — including the
+// malformations the released file actually contains.
+const fixture = `[
+ {"sample_id":"conv-1",
+  "conversation":{
+    "speaker_a":"Ada","speaker_b":"Bo",
+    "session_1_date_time":"1:00 pm on 3 May, 2023",
+    "session_1":[
+      {"speaker":"Ada","dia_id":"D1:1","text":"I adopted a greyhound."},
+      {"speaker":"Bo","dia_id":"D1:2","text":"Here she is","blip_caption":"a grey dog on a sofa"}],
+    "session_2_date_time":"9:00 am on 10 May, 2023",
+    "session_2":[
+      {"speaker":"Ada","dia_id":"D2:1","text":"We started agility class."}],
+    "session_9_date_time":"9:00 am on 1 June, 2023"
+  },
+  "qa":[
+    {"question":"What pet did Ada adopt?","answer":"a greyhound","category":4,"evidence":["D1:1"]},
+    {"question":"Two ids in one entry","answer":"x","category":1,"evidence":["D1:1; D2:1"]},
+    {"question":"Space separated ids","answer":"x","category":1,"evidence":["D1:1 D1:2"]},
+    {"question":"Transposed colon","answer":"x","category":2,"evidence":["D:2:1"]},
+    {"question":"Bare marker","answer":"x","category":2,"evidence":["D"]},
+    {"question":"Names a turn that is not here","answer":"x","category":4,"evidence":["D7:9"]},
+    {"question":"No evidence at all","answer":"x","category":3,"evidence":[]},
+    {"question":"Numeric answer","answer":3,"category":4,"evidence":["D2:1"]},
+    {"question":"Adversarial with no answer","answer":null,"category":5,"evidence":["D1:1"]}
+  ]},
+ {"sample_id":"conv-2",
+  "conversation":{
+    "session_1_date_time":"2:00 pm on 4 May, 2023",
+    "session_1":[
+      {"speaker":"Cy","dia_id":"D1:1","text":"A different conversation entirely."}]
+  },
+  "qa":[
+    {"question":"Whose conversation is this?","answer":"Cy","category":4,"evidence":["D1:1"]}
+  ]}
+]`
+
+func parseFixture(t *testing.T, cats ...int) ([]Conversation, *Defects) {
+	t.Helper()
+	if len(cats) == 0 {
+		cats = DefaultCategories
+	}
+	convs, defects, err := Parse([]byte(fixture), cats)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	return convs, defects
+}
+
+func TestParseEvidence_RecoversTheMalformationsTheReleasedFileContains(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantIDs  []string
+		wantBadN int
+	}{
+		{"D23:1", []string{"D23:1"}, 0},
+		// Two ids packed into one entry, semicolon-separated.
+		{"D8:6; D9:17", []string{"D8:6", "D9:17"}, 0},
+		// Space-separated run of ids.
+		{"D9:1 D4:4 D4:6", []string{"D9:1", "D4:4", "D4:6"}, 0},
+		// Transposed colon: unambiguously D11:26.
+		{"D:11:26", []string{"D11:26"}, 0},
+		// A bare marker carries no id and must be REPORTED, not guessed at.
+		{"D", nil, 1},
+		{"", nil, 0},
+	}
+	for _, tc := range cases {
+		ids, bad := parseEvidence(tc.in)
+		if strings.Join(ids, ",") != strings.Join(tc.wantIDs, ",") {
+			t.Errorf("parseEvidence(%q) ids = %v, want %v", tc.in, ids, tc.wantIDs)
+		}
+		if len(bad) != tc.wantBadN {
+			t.Errorf("parseEvidence(%q) malformed = %v, want %d", tc.in, bad, tc.wantBadN)
+		}
+	}
+}
+
+// TestParse_ScopeIDIsPerConversationSoCollidingDiaIDsStaySeparate is the
+// load-bearing isolation test: both fixture conversations contain a turn
+// "D1:1", exactly as the released file's 10 conversations do (5,882 turns,
+// 1,033 distinct dia_ids). A shared keyspace would overwrite one with the
+// other and let a probe retrieve the wrong conversation's turn.
+func TestParse_ScopeIDIsPerConversationSoCollidingDiaIDsStaySeparate(t *testing.T) {
+	convs, _ := parseFixture(t)
+	if len(convs) != 2 {
+		t.Fatalf("got %d conversations, want 2", len(convs))
+	}
+	if convs[0].ScopeID() == convs[1].ScopeID() {
+		t.Fatalf("both conversations share scope_id %q", convs[0].ScopeID())
+	}
+	var a, b bool
+	for _, turn := range convs[0].Turns {
+		a = a || turn.DiaID == "D1:1"
+	}
+	for _, turn := range convs[1].Turns {
+		b = b || turn.DiaID == "D1:1"
+	}
+	if !a || !b {
+		t.Fatal("precondition: both conversations must contain a colliding D1:1 turn")
+	}
+}
+
+func TestParse_EvidenceNamingNoTurnInItsConversationIsDroppedAndCounted(t *testing.T) {
+	convs, defects := parseFixture(t)
+	for _, q := range convs[0].Queries {
+		for _, e := range q.Expected {
+			if e == "D7:9" {
+				t.Fatalf("query %q kept evidence D7:9, which names no turn in conv-1", q.Question)
+			}
+		}
+		if q.Question == "Names a turn that is not here" {
+			t.Fatalf("a query whose only evidence is unresolvable must be dropped, not scored")
+		}
+	}
+	if defects.UnresolvedEvidenceIDs != 1 {
+		t.Errorf("UnresolvedEvidenceIDs = %d, want 1", defects.UnresolvedEvidenceIDs)
+	}
+}
+
+func TestParse_QueryWithoutUsableEvidenceIsDroppedAndCounted(t *testing.T) {
+	convs, defects := parseFixture(t)
+	for _, q := range convs[0].Queries {
+		if len(q.Expected) == 0 {
+			t.Fatalf("query %q has an empty answer key and would score recall against nothing", q.Question)
+		}
+	}
+	// Three: the empty-evidence one, the bare-"D" one, and the unresolvable one.
+	if defects.QueriesWithoutEvidence != 3 {
+		t.Errorf("QueriesWithoutEvidence = %d, want 3", defects.QueriesWithoutEvidence)
+	}
+	if defects.MalformedEvidenceFragments != 1 {
+		t.Errorf("MalformedEvidenceFragments = %d, want 1 (the bare \"D\")", defects.MalformedEvidenceFragments)
+	}
+}
+
+func TestParse_CategoryFilterExcludesAdversarialAndCountsIt(t *testing.T) {
+	convs, defects := parseFixture(t)
+	for _, c := range convs {
+		for _, q := range c.Queries {
+			if q.Category == CategoryAdversarial {
+				t.Fatalf("adversarial query %q survived the default filter", q.Question)
+			}
+		}
+	}
+	if defects.QueriesFilteredByCategory != 1 {
+		t.Errorf("QueriesFilteredByCategory = %d, want 1", defects.QueriesFilteredByCategory)
+	}
+	// Asking for it explicitly must include it — the filter is a choice, not a ban.
+	convs, _ = parseFixture(t, CategoryAdversarial)
+	found := false
+	for _, c := range convs {
+		for _, q := range c.Queries {
+			found = found || q.Category == CategoryAdversarial
+		}
+	}
+	if !found {
+		t.Error("-categories=5 did not include the adversarial query")
+	}
+}
+
+func TestParse_SessionDeclaredWithoutTurnsIsCounted(t *testing.T) {
+	_, defects := parseFixture(t)
+	if defects.SessionsDeclaredWithoutTurns != 1 {
+		t.Errorf("SessionsDeclaredWithoutTurns = %d, want 1 (session_9 has a timestamp and no turns)",
+			defects.SessionsDeclaredWithoutTurns)
+	}
+}
+
+func TestParse_NumericGoldAnswerSurvivesAsText(t *testing.T) {
+	convs, _ := parseFixture(t)
+	for _, q := range convs[0].Queries {
+		if q.Question == "Numeric answer" {
+			if q.Answer != "3" {
+				t.Errorf("Answer = %q, want \"3\" (the released file has 6 bare-number answers)", q.Answer)
+			}
+			return
+		}
+	}
+	t.Fatal("the numeric-answer query was dropped")
+}
+
+// TestTurnBody_CarriesSessionTimestampAndImageCaption — the temporal category
+// asks "when", and in LoCoMo the date is on the SESSION. A row without it
+// cannot be retrieved for those questions however good the embedder is.
+func TestTurnBody_CarriesSessionTimestampAndImageCaption(t *testing.T) {
+	convs, _ := parseFixture(t)
+	var withCaption string
+	for _, turn := range convs[0].Turns {
+		if turn.DiaID == "D1:2" {
+			withCaption = turn.Body()
+		}
+		if turn.DiaID == "D1:1" {
+			if !strings.Contains(turn.Body(), "3 May, 2023") {
+				t.Errorf("turn body %q carries no session timestamp", turn.Body())
+			}
+			if !strings.Contains(turn.Body(), "Ada:") {
+				t.Errorf("turn body %q carries no speaker; speaker-attribution questions need it", turn.Body())
+			}
+		}
+	}
+	if !strings.Contains(withCaption, "a grey dog on a sofa") {
+		t.Errorf("image turn body %q dropped the BLIP caption", withCaption)
+	}
+}
+
+// TestConvert_EmitsADatasetTheRealEvalLoaderAccepts guards the one format this
+// harness does not own: it writes memory-eval's JSONL, so the assertion is that
+// memory-eval's OWN parser reads it back, not that it matches a copy of the
+// schema kept here.
+func TestConvert_EmitsADatasetTheRealEvalLoaderAccepts(t *testing.T) {
+	convs, _ := parseFixture(t)
+	dir := t.TempDir()
+	var out bytes.Buffer
+	if err := doConvert(convs, options{out: dir, topK: 7}, &out); err != nil {
+		t.Fatalf("doConvert: %v", err)
+	}
+	path := filepath.Join(dir, convs[0].ScopeID()+".jsonl")
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open emitted dataset: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	ds, err := eval.LoadJSONL(f)
+	if err != nil {
+		t.Fatalf("memory-eval could not load the emitted dataset: %v", err)
+	}
+	if ds.TopK != 7 {
+		t.Errorf("TopK = %d, want 7", ds.TopK)
+	}
+	if len(ds.Corpus) != len(convs[0].Turns) {
+		t.Errorf("corpus rows = %d, want %d", len(ds.Corpus), len(convs[0].Turns))
+	}
+	if len(ds.Queries) != len(convs[0].Queries) {
+		t.Errorf("queries = %d, want %d", len(ds.Queries), len(convs[0].Queries))
+	}
+	// Every expected key must name a row in the corpus, or the dataset scores
+	// recall against keys that cannot be retrieved.
+	keys := map[string]bool{}
+	for _, it := range ds.Corpus {
+		keys[it.Key] = true
+	}
+	for _, q := range ds.Queries {
+		for _, e := range q.Expected {
+			if !keys[e] {
+				t.Errorf("query %q expects key %q which is not in the corpus", q.Query, e)
+			}
+		}
+	}
+}

--- a/bench/cmd/locomo/main.go
+++ b/bench/cmd/locomo/main.go
@@ -95,7 +95,7 @@ func run(args []string, stdout, stderr io.Writer) error {
 		opts.out = DefaultOutDir(time.Now())
 	}
 
-	convs, defects, err := loadConversations(opts)
+	convs, defects, inFile, err := loadConversations(opts)
 	if err != nil {
 		return err
 	}
@@ -118,12 +118,12 @@ func run(args []string, stdout, stderr io.Writer) error {
 		_, err := doIngest(ctx, convs, opts, stdout)
 		return err
 	case "search":
-		return doSearch(ctx, convs, defects, opts, stdout)
+		return doSearch(ctx, convs, defects, inFile, opts, stdout)
 	case "all":
 		if _, err := doIngest(ctx, convs, opts, stdout); err != nil {
 			return err
 		}
-		return doSearch(ctx, convs, defects, opts, stdout)
+		return doSearch(ctx, convs, defects, inFile, opts, stdout)
 	case "purge":
 		return doPurge(ctx, convs, opts, stdout)
 	default:
@@ -131,16 +131,22 @@ func run(args []string, stdout, stderr io.Writer) error {
 	}
 }
 
-// loadConversations loads and applies the -conversations limit.
-func loadConversations(opts options) ([]Conversation, *Defects, error) {
-	convs, defects, err := Load(opts.data, opts.categories)
+// loadConversations loads and applies the -conversations limit, also returning
+// how many conversations the FILE held.
+//
+// The two differ under -conversations, and the defect counts are computed over
+// the whole file — so the report has to say which population they describe or a
+// smoke run looks like it discarded far more than it did.
+func loadConversations(opts options) (convs []Conversation, defects *Defects, inFile int, err error) {
+	convs, defects, err = Load(opts.data, opts.categories)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
+	inFile = len(convs)
 	if opts.conversations > 0 && opts.conversations < len(convs) {
 		convs = convs[:opts.conversations]
 	}
-	return convs, defects, nil
+	return convs, defects, inFile, nil
 }
 
 func parseCategories(s string) ([]int, error) {
@@ -374,7 +380,7 @@ func doIngest(ctx context.Context, convs []Conversation, opts options, stdout io
 	return st, nil
 }
 
-func doSearch(ctx context.Context, convs []Conversation, defects *Defects, opts options, stdout io.Writer) error {
+func doSearch(ctx context.Context, convs []Conversation, defects *Defects, inFile int, opts options, stdout io.Writer) error {
 	c, id, err := connect(ctx, opts, stdout)
 	if err != nil {
 		return err
@@ -383,7 +389,8 @@ func doSearch(ctx context.Context, convs []Conversation, defects *Defects, opts 
 		Tool: "locomo", StartedAt: time.Now().UTC().Format(time.RFC3339),
 		Instance: opts.instance, Tenant: id.TenantID, Subject: id.Subject,
 		Scope: opts.scope, TopK: opts.topK, Categories: opts.categories,
-		Conversations: len(convs), CorpusRows: countTurns(convs), Defects: defects,
+		Conversations: len(convs), ConversationsInFile: inFile,
+		CorpusRows: countTurns(convs), Defects: defects,
 		Notes: []string{
 			"Rows are embedded from the JSON-encoded value (the PUT endpoint has no embed_text " +
 				"field), so a stored row's embedded text carries surrounding quotes the query text " +

--- a/bench/cmd/locomo/main.go
+++ b/bench/cmd/locomo/main.go
@@ -1,0 +1,463 @@
+// Command locomo runs the LoCoMo long-term-conversational-memory benchmark
+// against an externally-running loomcycle instance.
+//
+// The dataset (CC BY-NC 4.0) is never vendored here — pass a copy you
+// downloaded with -data. See bench/cmd/locomo/README.md.
+//
+// Modes:
+//
+//	convert  locomo10.json  ->  one memory-eval JSONL per conversation (no instance needed)
+//	ingest   write every turn as a memory row keyed by its dia_id, embedded
+//	search   run every QA probe and score retrieval against the evidence key
+//	all      ingest then search
+//	purge    delete the rows ingest wrote (reclaim the scope)
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/memory/eval"
+)
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		fmt.Fprintln(os.Stderr, "locomo:", err)
+		os.Exit(1)
+	}
+}
+
+type options struct {
+	mode              string
+	data              string
+	instance          string
+	scope             string
+	topK              int
+	categories        []int
+	conversations     int
+	concurrency       int
+	out               string
+	dryRun            bool
+	noEmbed           bool
+	allowSharedTenant bool
+	timeout           time.Duration
+}
+
+func run(args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("locomo", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		mode        = fs.String("mode", "convert", "convert | ingest | search | all | purge")
+		data        = fs.String("data", "", "path to locomo10.json (required; not vendored — see README)")
+		instance    = fs.String("loomcycle", "http://127.0.0.1:8787", "base URL of the running loomcycle")
+		scope       = fs.String("scope", "agent", "memory scope to write/read (agent|user|tenant)")
+		topK        = fs.Int("top-k", 10, "retrieval depth metrics are computed at")
+		categories  = fs.String("categories", "1,2,3,4", "LoCoMo categories to score (5 is adversarial and has no ground truth)")
+		convLimit   = fs.Int("conversations", 0, "only the first N conversations (0 = all)")
+		concurrency = fs.Int("concurrency", 4, "parallel requests during ingest")
+		out         = fs.String("out", "", "output directory (default: bench/results/locomo-<timestamp>)")
+		dryRun      = fs.Bool("dry-run", false, "parse and report, write nothing")
+		noEmbed     = fs.Bool("no-embed", false, "skip embedding on ingest (use /v1/_memory/backfill_embeddings after)")
+		allowShared = fs.Bool("allow-shared-tenant", false, "permit writing into the default/legacy tenant (NOT isolated)")
+		timeout     = fs.Duration("timeout", 60*time.Second, "per-request timeout")
+	)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if strings.TrimSpace(*data) == "" {
+		return fmt.Errorf("-data is required (path to locomo10.json)")
+	}
+	cats, err := parseCategories(*categories)
+	if err != nil {
+		return err
+	}
+	opts := options{
+		mode: *mode, data: *data, instance: *instance, scope: *scope,
+		topK: *topK, categories: cats, conversations: *convLimit,
+		concurrency: *concurrency, out: *out, dryRun: *dryRun, noEmbed: *noEmbed,
+		allowSharedTenant: *allowShared, timeout: *timeout,
+	}
+	if opts.concurrency < 1 {
+		opts.concurrency = 1
+	}
+	if opts.out == "" {
+		opts.out = DefaultOutDir(time.Now())
+	}
+
+	convs, defects, err := loadConversations(opts)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "loaded %d conversations, %d turns, %d scoreable queries from %s\n",
+		len(convs), countTurns(convs), countQueries(convs), opts.data)
+	if defects.Any() {
+		fmt.Fprintf(stdout, "dataset defects: %d unreadable evidence fragments, %d unresolvable ids, "+
+			"%d questions without usable evidence, %d sessions without turns\n",
+			defects.MalformedEvidenceFragments, defects.UnresolvedEvidenceIDs,
+			defects.QueriesWithoutEvidence, defects.SessionsDeclaredWithoutTurns)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	switch opts.mode {
+	case "convert":
+		return doConvert(convs, opts, stdout)
+	case "ingest":
+		_, err := doIngest(ctx, convs, opts, stdout)
+		return err
+	case "search":
+		return doSearch(ctx, convs, defects, opts, stdout)
+	case "all":
+		if _, err := doIngest(ctx, convs, opts, stdout); err != nil {
+			return err
+		}
+		return doSearch(ctx, convs, defects, opts, stdout)
+	case "purge":
+		return doPurge(ctx, convs, opts, stdout)
+	default:
+		return fmt.Errorf("unknown -mode %q (convert|ingest|search|all|purge)", opts.mode)
+	}
+}
+
+// loadConversations loads and applies the -conversations limit.
+func loadConversations(opts options) ([]Conversation, *Defects, error) {
+	convs, defects, err := Load(opts.data, opts.categories)
+	if err != nil {
+		return nil, nil, err
+	}
+	if opts.conversations > 0 && opts.conversations < len(convs) {
+		convs = convs[:opts.conversations]
+	}
+	return convs, defects, nil
+}
+
+func parseCategories(s string) ([]int, error) {
+	var out []int
+	for _, part := range strings.Split(s, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		n, err := strconv.Atoi(part)
+		if err != nil {
+			return nil, fmt.Errorf("-categories: %q is not a number", part)
+		}
+		out = append(out, n)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("-categories: at least one category is required")
+	}
+	return out, nil
+}
+
+func countTurns(cs []Conversation) int {
+	n := 0
+	for _, c := range cs {
+		n += len(c.Turns)
+	}
+	return n
+}
+
+func countQueries(cs []Conversation) int {
+	n := 0
+	for _, c := range cs {
+		n += len(c.Queries)
+	}
+	return n
+}
+
+// bearer reads the token. A benchmark-specific variable is preferred so an
+// operator can point this at an isolated tenant without touching the operator
+// bearer their tools already use.
+func bearer() string {
+	for _, env := range []string{"LOOMCYCLE_LOCOMO_TOKEN", "LOOMCYCLE_AUTH_TOKEN"} {
+		if v := strings.TrimSpace(os.Getenv(env)); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// connect builds the client and refuses to proceed if the bearer resolves to a
+// tenant that is not isolated.
+//
+// This check is the whole reason the harness asks who it is before it writes:
+// ~6,000 synthetic conversational rows landing in the tenant an operator
+// actually uses is not something you notice until recall gets worse.
+func connect(ctx context.Context, opts options, stdout io.Writer) (*Client, Identity, error) {
+	tok := bearer()
+	if tok == "" {
+		return nil, Identity{}, fmt.Errorf("no bearer: set LOOMCYCLE_LOCOMO_TOKEN (preferred) or LOOMCYCLE_AUTH_TOKEN")
+	}
+	c := NewClient(opts.instance, tok, opts.timeout)
+	id, err := c.Whoami(ctx)
+	if err != nil {
+		return nil, Identity{}, fmt.Errorf("preflight GET /v1/_me: %w", err)
+	}
+	fmt.Fprintf(stdout, "principal: tenant=%q subject=%q admin=%v scopes=%v\n",
+		id.TenantID, id.Subject, id.IsAdmin, id.Scopes)
+	if strings.TrimSpace(id.TenantID) == "" && !opts.allowSharedTenant {
+		return nil, Identity{}, fmt.Errorf("this bearer resolves to the DEFAULT/legacy tenant, so the corpus " +
+			"would mix with real memory. Mint an OperatorTokenDef for a dedicated tenant (e.g. locomo-bench) " +
+			"with the substrate:tenant scope and set LOOMCYCLE_LOCOMO_TOKEN to it, or pass -allow-shared-tenant " +
+			"to override deliberately")
+	}
+	return c, id, nil
+}
+
+// doConvert writes one memory-eval JSONL per conversation.
+//
+// One file per conversation, not one combined file, because dia_ids collide
+// across conversations — a combined corpus would overwrite rows and let
+// queries retrieve another conversation's turns.
+func doConvert(convs []Conversation, opts options, stdout io.Writer) error {
+	if opts.dryRun {
+		fmt.Fprintf(stdout, "dry-run: would write %d datasets to %s\n", len(convs), opts.out)
+		return nil
+	}
+	if err := os.MkdirAll(opts.out, 0o755); err != nil {
+		return err
+	}
+	for _, conv := range convs {
+		ds := eval.Dataset{
+			Name:   conv.ScopeID(),
+			TopK:   opts.topK,
+			Corpus: make([]eval.CorpusItem, 0, len(conv.Turns)),
+		}
+		for _, t := range conv.Turns {
+			body := t.Body()
+			raw, err := json.Marshal(body)
+			if err != nil {
+				return err
+			}
+			ds.Corpus = append(ds.Corpus, eval.CorpusItem{Key: t.DiaID, Value: raw, EmbedText: body})
+		}
+		var b strings.Builder
+		// The header line carries the corpus; LoadJSONL ignores any queries on it
+		// and reads them from the following lines.
+		hdr := ds
+		hdr.Queries = nil
+		raw, err := json.Marshal(hdr)
+		if err != nil {
+			return err
+		}
+		b.Write(raw)
+		b.WriteString("\n")
+		for _, q := range conv.Queries {
+			raw, err := json.Marshal(eval.Query{Query: q.Question, Expected: q.Expected})
+			if err != nil {
+				return err
+			}
+			b.Write(raw)
+			b.WriteString("\n")
+		}
+		path := filepath.Join(opts.out, conv.ScopeID()+".jsonl")
+		if err := os.WriteFile(path, []byte(b.String()), 0o644); err != nil {
+			return err
+		}
+		fmt.Fprintf(stdout, "wrote %s (%d rows, %d queries)\n", path, len(ds.Corpus), len(conv.Queries))
+	}
+	fmt.Fprintf(stdout, "\nrun one with: loomcycle memory-eval --dataset %s\n",
+		filepath.Join(opts.out, convs[0].ScopeID()+".jsonl"))
+	fmt.Fprintln(stdout, "NOTE: memory-eval embeds with a deterministic bag-of-tokens stub, so those "+
+		"numbers validate the plumbing, not retrieval quality. Use -mode=all against a real "+
+		"instance for a semantic number.")
+	return nil
+}
+
+type ingestStats struct {
+	rows     int
+	embedded int
+	warnings int
+}
+
+func doIngest(ctx context.Context, convs []Conversation, opts options, stdout io.Writer) (ingestStats, error) {
+	var st ingestStats
+	if opts.dryRun {
+		fmt.Fprintf(stdout, "dry-run: would write %d rows across %d scope_ids\n", countTurns(convs), len(convs))
+		return st, nil
+	}
+	c, _, err := connect(ctx, opts, stdout)
+	if err != nil {
+		return st, err
+	}
+
+	// A failure that is not per-row — an expired bearer, a store outage — would
+	// otherwise be re-hit once per remaining turn, so the first error cancels the
+	// pool rather than driving thousands of doomed requests.
+	ctx, cancelPool := context.WithCancel(ctx)
+	defer cancelPool()
+
+	type job struct {
+		scopeID string
+		turn    Turn
+	}
+	jobs := make(chan job)
+	var (
+		mu       sync.Mutex
+		firstErr error
+		// firstEmbedWarning aborts the run rather than writing thousands of
+		// un-embedded rows: an unconfigured embedder or a vector-less store makes
+		// every later search return nothing, and finding that out after 6,000
+		// writes is a wasted run.
+		embedWarn string
+	)
+	var wg sync.WaitGroup
+	for i := 0; i < opts.concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := range jobs {
+				resp, err := c.PutEntry(ctx, opts.scope, j.scopeID, j.turn.DiaID, j.turn.Body(), !opts.noEmbed)
+				mu.Lock()
+				switch {
+				case err != nil:
+					if firstErr == nil {
+						firstErr = fmt.Errorf("put %s/%s: %w", j.scopeID, j.turn.DiaID, err)
+						cancelPool()
+					}
+				default:
+					st.rows++
+					if resp.Embedded {
+						st.embedded++
+					}
+					if resp.EmbedWarning != "" {
+						st.warnings++
+						if embedWarn == "" {
+							embedWarn = resp.EmbedWarning
+						}
+					}
+				}
+				mu.Unlock()
+			}
+		}()
+	}
+
+	go func() {
+		defer close(jobs)
+		for _, conv := range convs {
+			for _, t := range conv.Turns {
+				select {
+				case <-ctx.Done():
+					return
+				case jobs <- job{scopeID: conv.ScopeID(), turn: t}:
+				}
+			}
+		}
+	}()
+	wg.Wait()
+
+	if firstErr != nil {
+		return st, firstErr
+	}
+	if err := ctx.Err(); err != nil {
+		return st, err
+	}
+	fmt.Fprintf(stdout, "ingested %d rows (%d embedded, %d embed warnings)\n", st.rows, st.embedded, st.warnings)
+	if !opts.noEmbed && embedWarn != "" {
+		return st, fmt.Errorf("the instance could not embed %d row(s); first warning: %s "+
+			"(a search over un-embedded rows returns nothing, so this run would score zero for the "+
+			"wrong reason)", st.warnings, embedWarn)
+	}
+	return st, nil
+}
+
+func doSearch(ctx context.Context, convs []Conversation, defects *Defects, opts options, stdout io.Writer) error {
+	c, id, err := connect(ctx, opts, stdout)
+	if err != nil {
+		return err
+	}
+	rep := Report{
+		Tool: "locomo", StartedAt: time.Now().UTC().Format(time.RFC3339),
+		Instance: opts.instance, Tenant: id.TenantID, Subject: id.Subject,
+		Scope: opts.scope, TopK: opts.topK, Categories: opts.categories,
+		Conversations: len(convs), CorpusRows: countTurns(convs), Defects: defects,
+		Notes: []string{
+			"Rows are embedded from the JSON-encoded value (the PUT endpoint has no embed_text " +
+				"field), so a stored row's embedded text carries surrounding quotes the query text " +
+				"does not.",
+			"Each conversation is a separate memory scope_id: dia_ids are per-conversation and " +
+				"collide across them.",
+			"Session timestamps are prefixed onto each row because LoCoMo dates live on the " +
+				"session, not the turn — without them the temporal category is unretrievable.",
+		},
+	}
+
+	var all []QueryResult
+	for _, conv := range convs {
+		var perConv []QueryResult
+		for _, q := range conv.Queries {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			start := time.Now()
+			keys, dim, err := c.Search(ctx, opts.scope, conv.ScopeID(), q.Question, opts.topK)
+			if err != nil {
+				return fmt.Errorf("search %s: %w", conv.ScopeID(), err)
+			}
+			if dim > 0 {
+				rep.EmbeddingDim = dim
+			}
+			res := Score(q, keys, opts.topK, time.Since(start))
+			perConv = append(perConv, res)
+			all = append(all, res)
+		}
+		rep.PerConversation = append(rep.PerConversation, Aggregate(conv.ScopeID(), perConv, opts.topK))
+		fmt.Fprintf(stdout, "  %s: %d queries scored\n", conv.ScopeID(), len(perConv))
+	}
+
+	rep.Queries = len(all)
+	rep.Overall = Aggregate("overall", all, opts.topK)
+	rep.PerCategory = ByCategory(all, opts.topK)
+	rep.Results = all
+
+	rep.Matrix(stdout)
+	if opts.dryRun {
+		fmt.Fprintln(stdout, "\ndry-run: report not written")
+		return nil
+	}
+	if err := rep.Write(opts.out); err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "\nwrote %s/matrix.md and report.json\n", opts.out)
+	return nil
+}
+
+func doPurge(ctx context.Context, convs []Conversation, opts options, stdout io.Writer) error {
+	if opts.dryRun {
+		fmt.Fprintf(stdout, "dry-run: would delete %d rows across %d scope_ids\n", countTurns(convs), len(convs))
+		return nil
+	}
+	c, _, err := connect(ctx, opts, stdout)
+	if err != nil {
+		return err
+	}
+	deleted := 0
+	for _, conv := range convs {
+		for _, t := range conv.Turns {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			// Keys are derived from the dataset, never from a listing, so purge can
+			// only ever remove rows this harness itself would have written.
+			if err := c.DeleteEntry(ctx, opts.scope, conv.ScopeID(), t.DiaID); err != nil {
+				return fmt.Errorf("delete %s/%s: %w", conv.ScopeID(), t.DiaID, err)
+			}
+			deleted++
+		}
+	}
+	fmt.Fprintf(stdout, "deleted %d rows\n", deleted)
+	return nil
+}

--- a/bench/cmd/locomo/metrics.go
+++ b/bench/cmd/locomo/metrics.go
@@ -1,0 +1,136 @@
+package main
+
+// metrics.go — retrieval metrics over the LoCoMo evidence answer key.
+//
+// precision@k and recall@k use the same definitions as the in-tree
+// memory-eval harness (precision = hits/k, recall = hits/|expected|) so the
+// two are directly comparable. mrr and hit-rate are added because they are
+// what a memory system's consumer actually feels: whether the supporting turn
+// came back at all, and how far down.
+
+import (
+	"math"
+	"sort"
+	"time"
+)
+
+// QueryResult is one probe's outcome.
+type QueryResult struct {
+	Question  string   `json:"question"`
+	Category  int      `json:"category"`
+	Expected  []string `json:"expected"`
+	Retrieved []string `json:"retrieved"`
+	Hits      int      `json:"hits"`
+	// FirstHitRank is the 1-based rank of the first expected key, 0 if none.
+	FirstHitRank int           `json:"first_hit_rank"`
+	Latency      time.Duration `json:"-"`
+	LatencyMs    float64       `json:"latency_ms"`
+}
+
+// Score computes one query's outcome against its answer key.
+func Score(q Query, retrieved []string, topK int, latency time.Duration) QueryResult {
+	want := make(map[string]bool, len(q.Expected))
+	for _, e := range q.Expected {
+		want[e] = true
+	}
+	res := QueryResult{
+		Question: q.Question, Category: q.Category,
+		Expected: q.Expected, Retrieved: retrieved,
+		Latency: latency, LatencyMs: float64(latency.Microseconds()) / 1000.0,
+	}
+	if topK > 0 && len(retrieved) > topK {
+		retrieved = retrieved[:topK]
+		res.Retrieved = retrieved
+	}
+	for i, key := range retrieved {
+		if want[key] {
+			res.Hits++
+			if res.FirstHitRank == 0 {
+				res.FirstHitRank = i + 1
+			}
+		}
+	}
+	return res
+}
+
+// Stats aggregates a set of query results.
+type Stats struct {
+	Label        string  `json:"label"`
+	Queries      int     `json:"queries"`
+	RecallAtK    float64 `json:"recall_at_k"`
+	PrecisionAtK float64 `json:"precision_at_k"`
+	MRR          float64 `json:"mrr"`
+	HitRate      float64 `json:"hit_rate"`
+	LatencyP50Ms float64 `json:"latency_p50_ms"`
+	LatencyP99Ms float64 `json:"latency_p99_ms"`
+}
+
+// Aggregate computes the metric set over results at retrieval depth k.
+func Aggregate(label string, results []QueryResult, k int) Stats {
+	st := Stats{Label: label, Queries: len(results)}
+	if len(results) == 0 {
+		return st
+	}
+	var sumRecall, sumPrecision, sumRR float64
+	var hit int
+	lat := make([]time.Duration, 0, len(results))
+	for _, r := range results {
+		if len(r.Expected) > 0 {
+			sumRecall += float64(r.Hits) / float64(len(r.Expected))
+		}
+		if k > 0 {
+			sumPrecision += float64(r.Hits) / float64(k)
+		}
+		if r.FirstHitRank > 0 {
+			sumRR += 1 / float64(r.FirstHitRank)
+			hit++
+		}
+		lat = append(lat, r.Latency)
+	}
+	n := float64(len(results))
+	st.RecallAtK = sumRecall / n
+	st.PrecisionAtK = sumPrecision / n
+	st.MRR = sumRR / n
+	st.HitRate = float64(hit) / n
+	st.LatencyP50Ms = percentileMs(lat, 0.50)
+	st.LatencyP99Ms = percentileMs(lat, 0.99)
+	return st
+}
+
+// ByCategory aggregates per LoCoMo category, ordered by category id so the
+// report is stable run to run.
+func ByCategory(results []QueryResult, k int) []Stats {
+	buckets := map[int][]QueryResult{}
+	for _, r := range results {
+		buckets[r.Category] = append(buckets[r.Category], r)
+	}
+	cats := make([]int, 0, len(buckets))
+	for c := range buckets {
+		cats = append(cats, c)
+	}
+	sort.Ints(cats)
+	out := make([]Stats, 0, len(cats))
+	for _, c := range cats {
+		out = append(out, Aggregate(CategoryName(c), buckets[c], k))
+	}
+	return out
+}
+
+// percentileMs mirrors the memory-eval harness's percentile so latency numbers
+// from the two are read the same way.
+func percentileMs(ds []time.Duration, p float64) float64 {
+	if len(ds) == 0 {
+		return 0
+	}
+	sorted := make([]time.Duration, len(ds))
+	copy(sorted, ds)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	idx := int(math.Ceil(p*float64(len(sorted)))) - 1
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return float64(sorted[idx].Microseconds()) / 1000.0
+}

--- a/bench/cmd/locomo/metrics_test.go
+++ b/bench/cmd/locomo/metrics_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func nearly(t *testing.T, label string, got, want float64) {
+	t.Helper()
+	if math.Abs(got-want) > 1e-9 {
+		t.Errorf("%s = %v, want %v", label, got, want)
+	}
+}
+
+func TestScore_CountsHitsAndTheRankOfTheFirstOne(t *testing.T) {
+	q := Query{Question: "q", Category: 4, Expected: []string{"D1:2", "D1:5"}}
+	res := Score(q, []string{"D1:9", "D1:2", "D1:7", "D1:5"}, 10, 3*time.Millisecond)
+	if res.Hits != 2 {
+		t.Errorf("Hits = %d, want 2", res.Hits)
+	}
+	if res.FirstHitRank != 2 {
+		t.Errorf("FirstHitRank = %d, want 2 (1-based)", res.FirstHitRank)
+	}
+	if res.LatencyMs != 3 {
+		t.Errorf("LatencyMs = %v, want 3", res.LatencyMs)
+	}
+}
+
+// TestScore_IgnoresHitsBelowTopK — a store that returns more than top_k rows
+// must not be credited for the overflow, or the depth the metric claims and the
+// depth it measures diverge.
+func TestScore_IgnoresHitsBelowTopK(t *testing.T) {
+	q := Query{Expected: []string{"D1:5"}}
+	res := Score(q, []string{"a", "b", "c", "D1:5"}, 3, 0)
+	if res.Hits != 0 {
+		t.Errorf("Hits = %d, want 0 — D1:5 sits at rank 4 with top_k=3", res.Hits)
+	}
+	if len(res.Retrieved) != 3 {
+		t.Errorf("Retrieved kept %d rows, want it truncated to 3", len(res.Retrieved))
+	}
+}
+
+func TestScore_MissIsZeroNotAnError(t *testing.T) {
+	res := Score(Query{Expected: []string{"D1:1"}}, []string{"x", "y"}, 5, 0)
+	if res.Hits != 0 || res.FirstHitRank != 0 {
+		t.Errorf("miss scored Hits=%d FirstHitRank=%d, want 0/0", res.Hits, res.FirstHitRank)
+	}
+}
+
+// TestAggregate_RecallDividesByExpectedAndPrecisionByK mirrors the in-tree
+// memory-eval definitions so the two harnesses' numbers mean the same thing.
+func TestAggregate_RecallDividesByExpectedAndPrecisionByK(t *testing.T) {
+	results := []QueryResult{
+		// 1 of 2 expected found, at rank 1.
+		{Category: 4, Expected: []string{"a", "b"}, Retrieved: []string{"a"}, Hits: 1, FirstHitRank: 1},
+		// 0 of 1 found.
+		{Category: 4, Expected: []string{"c"}, Retrieved: []string{"z"}, Hits: 0},
+	}
+	st := Aggregate("t", results, 10)
+	nearly(t, "recall@k", st.RecallAtK, (0.5+0.0)/2)
+	nearly(t, "precision@k", st.PrecisionAtK, (1.0/10+0.0)/2)
+	nearly(t, "mrr", st.MRR, (1.0+0.0)/2)
+	nearly(t, "hit_rate", st.HitRate, 0.5)
+	if st.Queries != 2 {
+		t.Errorf("Queries = %d, want 2", st.Queries)
+	}
+}
+
+func TestAggregate_MRRRewardsTheHigherRank(t *testing.T) {
+	high := Aggregate("high", []QueryResult{{Expected: []string{"a"}, Hits: 1, FirstHitRank: 1}}, 10)
+	low := Aggregate("low", []QueryResult{{Expected: []string{"a"}, Hits: 1, FirstHitRank: 5}}, 10)
+	if !(high.MRR > low.MRR) {
+		t.Errorf("MRR did not reward rank: rank1=%v rank5=%v", high.MRR, low.MRR)
+	}
+	// Both found the row, so hit-rate cannot tell them apart — which is why MRR
+	// is reported alongside it.
+	nearly(t, "hit_rate parity", high.HitRate, low.HitRate)
+}
+
+func TestAggregate_EmptyIsZeroNotNaN(t *testing.T) {
+	st := Aggregate("empty", nil, 10)
+	for label, v := range map[string]float64{
+		"recall": st.RecallAtK, "precision": st.PrecisionAtK, "mrr": st.MRR, "hit": st.HitRate,
+	} {
+		if math.IsNaN(v) || v != 0 {
+			t.Errorf("%s = %v, want 0", label, v)
+		}
+	}
+}
+
+func TestByCategory_OrdersByCategoryIDForAStableReport(t *testing.T) {
+	results := []QueryResult{
+		{Category: 4, Expected: []string{"a"}, Hits: 1, FirstHitRank: 1},
+		{Category: 1, Expected: []string{"a"}, Hits: 1, FirstHitRank: 1},
+		{Category: 2, Expected: []string{"a"}, Hits: 0},
+	}
+	got := ByCategory(results, 10)
+	want := []string{"multi-hop", "temporal", "single-hop"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d buckets, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].Label != want[i] {
+			t.Errorf("bucket %d = %q, want %q", i, got[i].Label, want[i])
+		}
+	}
+}
+
+func TestCategoryName_UnknownRendersNumericallyRatherThanMislabelling(t *testing.T) {
+	if got := CategoryName(9); got != "category-9" {
+		t.Errorf("CategoryName(9) = %q, want %q", got, "category-9")
+	}
+}
+
+func TestPercentileMs_P50AndP99(t *testing.T) {
+	ds := []time.Duration{}
+	for i := 1; i <= 100; i++ {
+		ds = append(ds, time.Duration(i)*time.Millisecond)
+	}
+	nearly(t, "p50", percentileMs(ds, 0.50), 50)
+	nearly(t, "p99", percentileMs(ds, 0.99), 99)
+}

--- a/bench/cmd/locomo/report.go
+++ b/bench/cmd/locomo/report.go
@@ -14,23 +14,24 @@ import (
 
 // Report is the whole run, written as report.json alongside matrix.md.
 type Report struct {
-	Tool            string   `json:"tool"`
-	StartedAt       string   `json:"started_at"`
-	Instance        string   `json:"instance"`
-	Tenant          string   `json:"tenant"`
-	Subject         string   `json:"subject"`
-	Scope           string   `json:"scope"`
-	TopK            int      `json:"top_k"`
-	Categories      []int    `json:"categories_included"`
-	Conversations   int      `json:"conversations"`
-	CorpusRows      int      `json:"corpus_rows"`
-	Queries         int      `json:"queries"`
-	EmbeddingDim    int      `json:"query_embedding_dim"`
-	Overall         Stats    `json:"overall"`
-	PerCategory     []Stats  `json:"per_category"`
-	PerConversation []Stats  `json:"per_conversation"`
-	Defects         *Defects `json:"defects,omitempty"`
-	Notes           []string `json:"notes,omitempty"`
+	Tool                string   `json:"tool"`
+	StartedAt           string   `json:"started_at"`
+	Instance            string   `json:"instance"`
+	Tenant              string   `json:"tenant"`
+	Subject             string   `json:"subject"`
+	Scope               string   `json:"scope"`
+	TopK                int      `json:"top_k"`
+	Categories          []int    `json:"categories_included"`
+	Conversations       int      `json:"conversations"`
+	ConversationsInFile int      `json:"conversations_in_file"`
+	CorpusRows          int      `json:"corpus_rows"`
+	Queries             int      `json:"queries"`
+	EmbeddingDim        int      `json:"query_embedding_dim"`
+	Overall             Stats    `json:"overall"`
+	PerCategory         []Stats  `json:"per_category"`
+	PerConversation     []Stats  `json:"per_conversation"`
+	Defects             *Defects `json:"defects,omitempty"`
+	Notes               []string `json:"notes,omitempty"`
 	// Results is the full per-query detail, so a bad number can be traced to
 	// the query that produced it rather than re-run to find out.
 	Results []QueryResult `json:"results,omitempty"`
@@ -96,7 +97,11 @@ func (r Report) Matrix(w io.Writer) {
 		}
 	}
 	if r.Defects != nil && r.Defects.Any() {
-		fmt.Fprintf(w, "\n## Dataset defects (excluded from the numbers above)\n\n")
+		pop := fmt.Sprintf("all %d conversations in the file", r.ConversationsInFile)
+		if r.ConversationsInFile == 0 || r.ConversationsInFile == r.Conversations {
+			pop = "the conversations scored above"
+		}
+		fmt.Fprintf(w, "\n## Dataset defects (counted across %s; excluded from the numbers above)\n\n", pop)
 		fmt.Fprintf(w, "- unreadable evidence fragments: %d\n", r.Defects.MalformedEvidenceFragments)
 		fmt.Fprintf(w, "- evidence ids naming no turn in their own conversation: %d\n", r.Defects.UnresolvedEvidenceIDs)
 		fmt.Fprintf(w, "- questions dropped for having no usable evidence: %d\n", r.Defects.QueriesWithoutEvidence)

--- a/bench/cmd/locomo/report.go
+++ b/bench/cmd/locomo/report.go
@@ -1,0 +1,124 @@
+package main
+
+// report.go — the run's output: a human-readable matrix and the JSON behind it.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Report is the whole run, written as report.json alongside matrix.md.
+type Report struct {
+	Tool            string   `json:"tool"`
+	StartedAt       string   `json:"started_at"`
+	Instance        string   `json:"instance"`
+	Tenant          string   `json:"tenant"`
+	Subject         string   `json:"subject"`
+	Scope           string   `json:"scope"`
+	TopK            int      `json:"top_k"`
+	Categories      []int    `json:"categories_included"`
+	Conversations   int      `json:"conversations"`
+	CorpusRows      int      `json:"corpus_rows"`
+	Queries         int      `json:"queries"`
+	EmbeddingDim    int      `json:"query_embedding_dim"`
+	Overall         Stats    `json:"overall"`
+	PerCategory     []Stats  `json:"per_category"`
+	PerConversation []Stats  `json:"per_conversation"`
+	Defects         *Defects `json:"defects,omitempty"`
+	Notes           []string `json:"notes,omitempty"`
+	// Results is the full per-query detail, so a bad number can be traced to
+	// the query that produced it rather than re-run to find out.
+	Results []QueryResult `json:"results,omitempty"`
+}
+
+// Write persists report.json + matrix.md into dir.
+func (r Report) Write(dir string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	b, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(dir, "report.json"), append(b, '\n'), 0o644); err != nil {
+		return err
+	}
+	var md strings.Builder
+	r.Matrix(&md)
+	return os.WriteFile(filepath.Join(dir, "matrix.md"), []byte(md.String()), 0o644)
+}
+
+func statsRow(w io.Writer, s Stats) {
+	fmt.Fprintf(w, "| %s | %d | %.4f | %.4f | %.4f | %.4f | %.1f | %.1f |\n",
+		s.Label, s.Queries, s.RecallAtK, s.PrecisionAtK, s.MRR, s.HitRate,
+		s.LatencyP50Ms, s.LatencyP99Ms)
+}
+
+const statsHeader = "| slice | queries | recall@k | precision@k | MRR | hit-rate | p50 ms | p99 ms |\n" +
+	"|---|---|---|---|---|---|---|---|\n"
+
+// Matrix renders the human-readable report.
+func (r Report) Matrix(w io.Writer) {
+	fmt.Fprintf(w, "# LoCoMo memory retrieval — %s\n\n", r.StartedAt)
+	fmt.Fprintf(w, "- instance: `%s`\n", r.Instance)
+	fmt.Fprintf(w, "- tenant: `%s`  subject: `%s`  scope: `%s`\n", r.Tenant, r.Subject, r.Scope)
+	fmt.Fprintf(w, "- conversations: %d (one memory scope_id each)\n", r.Conversations)
+	fmt.Fprintf(w, "- corpus rows: %d   queries scored: %d   top_k: %d\n", r.CorpusRows, r.Queries, r.TopK)
+	if r.EmbeddingDim > 0 {
+		fmt.Fprintf(w, "- query embedding dimension: %d\n", r.EmbeddingDim)
+	}
+	// The filter is printed on every report because differing filters are the
+	// reason published LoCoMo numbers cannot be compared with one another.
+	cats := make([]string, 0, len(r.Categories))
+	for _, c := range r.Categories {
+		cats = append(cats, fmt.Sprintf("%d (%s)", c, CategoryName(c)))
+	}
+	fmt.Fprintf(w, "- **categories included: %s**\n", strings.Join(cats, ", "))
+
+	fmt.Fprintf(w, "\n## Overall\n\n%s", statsHeader)
+	statsRow(w, r.Overall)
+
+	if len(r.PerCategory) > 0 {
+		fmt.Fprintf(w, "\n## By category\n\n%s", statsHeader)
+		for _, s := range r.PerCategory {
+			statsRow(w, s)
+		}
+	}
+	if len(r.PerConversation) > 0 {
+		fmt.Fprintf(w, "\n## By conversation\n\n%s", statsHeader)
+		for _, s := range r.PerConversation {
+			statsRow(w, s)
+		}
+	}
+	if r.Defects != nil && r.Defects.Any() {
+		fmt.Fprintf(w, "\n## Dataset defects (excluded from the numbers above)\n\n")
+		fmt.Fprintf(w, "- unreadable evidence fragments: %d\n", r.Defects.MalformedEvidenceFragments)
+		fmt.Fprintf(w, "- evidence ids naming no turn in their own conversation: %d\n", r.Defects.UnresolvedEvidenceIDs)
+		fmt.Fprintf(w, "- questions dropped for having no usable evidence: %d\n", r.Defects.QueriesWithoutEvidence)
+		fmt.Fprintf(w, "- sessions declared with a timestamp but no turns: %d\n", r.Defects.SessionsDeclaredWithoutTurns)
+		fmt.Fprintf(w, "- questions excluded by the category filter: %d\n", r.Defects.QueriesFilteredByCategory)
+		if len(r.Defects.Examples) > 0 {
+			fmt.Fprintf(w, "\nExamples:\n")
+			for _, e := range r.Defects.Examples {
+				fmt.Fprintf(w, "- %s\n", e)
+			}
+		}
+	}
+	if len(r.Notes) > 0 {
+		fmt.Fprintf(w, "\n## Notes\n\n")
+		for _, n := range r.Notes {
+			fmt.Fprintf(w, "- %s\n", n)
+		}
+	}
+}
+
+// DefaultOutDir names a run directory. The caller supplies the clock so the
+// path is testable.
+func DefaultOutDir(now time.Time) string {
+	return filepath.Join("bench", "results", "locomo-"+now.UTC().Format("2006-01-02-1504"))
+}


### PR DESCRIPTION
## Why

loomcycle's memory has had no retrieval-quality number. `memory-eval` reports precision/recall, but only against a hand-written 20-row seed corpus embedded by a deterministic bag-of-tokens stub — so it validates the metric math and nothing about retrieval. Nobody could answer "how good is recall, and did that change make it worse".

LoCoMo closes that gap cheaply because of one property: its QA annotations carry an `evidence` field naming the `dia_id`s of the turns that support each answer. Keying every ingested turn by its `dia_id` turns each annotation into **retrieval ground truth**, so the retrieval axis needs no LLM judge and no answer-string matching — deterministic, re-runnable, and it measures the ranker and the embedder rather than the answering model.

That is also the axis worth measuring. LoCoMo's *answer* accuracy is near-saturated (a plain full-context baseline beats reported memory systems, ~73 vs ~68 J); its retrieval is not. And the corpus is small — ~5,900 turns, so a full run costs ~5,900 embeddings and nothing else.

## What

`bench/cmd/locomo` drives an externally-running instance, the same posture as `lc-bench`, so numbers come from the real vector store and the real configured embedder. Modes: `convert` (emit one `memory-eval` dataset per conversation, no instance needed), `ingest`, `search`, `all`, `purge`.

Three decisions the numbers depend on, each with a test:

- **One memory `scope_id` per conversation.** `dia_id`s are numbered per conversation and collide heavily across them — the released file has 5,882 turns and only 1,033 distinct ids — so a shared keyspace would overwrite rows *and* let a probe retrieve another conversation's turns.
- **Session timestamps are prefixed onto each row.** LoCoMo dates live on the session, not the turn; without them the temporal category is unretrievable however good the embedder is.
- **The harness resolves `GET /v1/_me` before writing and refuses the default/legacy tenant.** The memory routes derive the tenant from the principal and honour no `?tenant=` override, so a dedicated tenant bearer is the only isolation available. `-allow-shared-tenant` is the deliberate override.

Dataset defects are counted and printed rather than silently absorbed — a benchmark that quietly shrinks its answer key reports a number against a smaller key than it claims. On the current file: 1 unreadable evidence fragment, 3 evidence ids naming no turn in their own conversation, 5 questions with no usable evidence, 16 sessions declared with a timestamp and no turns. Category 5 is excluded by default (444 of its 446 questions have a `null` answer; Mem0 and Zep excluded it too), and **every report states its category filter**, because differing filters are why published LoCoMo numbers cannot be compared with one another.

The dataset is **not vendored** — LoCoMo is CC BY-NC 4.0, so `-data` takes an operator-supplied copy and the test fixture is hand-written rather than excerpted. `bench/results/` was already gitignored.

## What was tested

`go test ./...` clean (92 packages ok, 0 failures). 25 unit tests in the new package:

- `TestParseEvidence_RecoversTheMalformationsTheReleasedFileContains` — the released file's evidence field is dirty: `"D8:6; D9:17"`, `"D9:1 D4:4 D4:6"`, `"D:11:26"`, a bare `"D"`. The parser splits packed entries, repairs the unambiguous transposed colon, and reports the rest instead of guessing.
- `TestParse_ScopeIDIsPerConversationSoCollidingDiaIDsStaySeparate` — the collision guard.
- `TestParse_EvidenceNamingNoTurnInItsConversationIsDroppedAndCounted`, `TestParse_QueryWithoutUsableEvidenceIsDroppedAndCounted`, `TestParse_SessionDeclaredWithoutTurnsIsCounted`, `TestParse_CategoryFilterExcludesAdversarialAndCountsIt`
- `TestConnect_RefusesTheDefaultTenantSoTheCorpusCannotLandInRealMemory` (+ the explicit-override and no-bearer cases)
- `TestPutEntry_EscapesTheColonInADiaIDKeyAndSendsAJSONValue` — `dia_id`s contain a colon and go into the URL path.
- `TestConvert_EmitsADatasetTheRealEvalLoaderAccepts` — asserts `memory-eval`'s **own** parser reads the emitted JSONL, so the format cannot drift.
- Metric math incl. MRR, hit-rate, top-k truncation, empty-is-zero-not-NaN.

Fail-before verified on the three load-bearing ones (naive evidence parser, shared `scope_id`, removed tenant guard) — each fails on the broken code and passes on the fix. The shared-`scope_id` break also showed the hazard concretely: the converted corpus collapsed from 3 rows to 1.

Manual, against the real `locomo10.json`: converts to 10 datasets, **5,882 turns / 1,535 scoreable queries**, and `loomcycle memory-eval --dataset locomo-conv-30.jsonl` runs one (recall@10 0.1615 on the stub embedder — the lexical floor, as expected).

## Not covered

LoCoMo does not test knowledge updates, which is what the bi-temporal fact tier exists for. That axis needs a different corpus — see `/loomcycle/docs/factual-corpus-sources-and-memory-benchmarks` in the document store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)