### PR TITLE
feat: per-agent max_context_tokens — agent-level context window (RFC CJ, phase 1)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -562,6 +562,16 @@ Local models change the economics. A frontier cloud model prefills a 100k-token 
 - **Unset** → the driver asks Ollama what the model is currently loaded with (`/api/ps`) and **sends that back** as `options.num_ctx`, so the window it reports is the window it requested. Echoing the loaded window is a no-op for a model already running at that size.
 - **Unset and the window is unknowable** (model not in VRAM yet, a different model resident, an Ollama too old to report it) → `num_ctx` is omitted, exactly as before, so Ollama still applies the model's Modelfile `num_ctx`; the gauge reports Ollama's documented **4096** default as a floor. One turn later `/api/ps` knows the real window and the case above takes over.
 
+**Per agent — `max_context_tokens`.** The env/provider `num_ctx` above is one window for *every* agent on the registration. Setting `max_context_tokens` on an agent def overrides it for **that agent only** — it is sent as `options.num_ctx` for that agent's runs, winning over both `LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX` and any `providers.<id>.options.num_ctx`. So a fetch-heavy `researcher` can hold 128K while `chat` stays at 16K on the same host without a second provider registration:
+
+```yaml
+agents:
+  researcher: { model: qwen3.6-local, max_context_tokens: 131072 }
+  chat/local: { model: local-medium }   # unset → env/provider window
+```
+
+On a **cloud** model the window is fixed by the model, so there `max_context_tokens` cannot enlarge it — it instead caps the agent's *effective* window (a compaction budget the gauge + `autocompact_at_pct` use), clamped to the model's maximum (it can only lower). It is distinct from `max_tokens` (the OUTPUT cap). Caveat: a bigger window costs KV-cache memory, and Ollama keeps a separate resident copy per `(model, num_ctx)`, so mixing windows for one model on one host means duplicate residency.
+
 > **What changed (and why you may see a different number).** Before this, an unset `NUM_CTX` meant loomcycle *advertised* the `/api/ps` window while sending **no `num_ctx` at all** — it reported a window the request never asked for. That matters beyond the gauge: `autocompact_at_pct` is a percentage **of the advertised window**, so an over-claim both let Ollama truncate the prompt (it drops the overflow silently — no error, just a model answering from a partial view) and kept compaction from firing. The two numbers are now one number.
 
 **When a prompt doesn't fit**, the server log now says so, once per call:
@@ -570,7 +580,7 @@ Local models change the economics. A frontier cloud model prefills a 100k-token 
 ollama: prompt ~7104 tokens exceeds the 4096-token context window (assumed) for model "glm-4.7-flash" on ollama-local — Ollama silently truncates the overflow; raise the window with LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX
 ```
 
-The size is an estimate (bytes/4) and gates nothing. `(assumed)` means the window is the 4096 floor above, `(loaded)` that it came from `/api/ps`, `(pinned)` that you set it. Watch for this after a model pull or a restart: a truncated prompt otherwise looks like a model that has simply gone stupid.
+The size is an estimate (bytes/4) and gates nothing. `(assumed)` means the window is the 4096 floor above, `(loaded)` that it came from `/api/ps`, `(pinned)` that you set it via env/provider, `(request)` that an agent's `max_context_tokens` set it. Watch for this after a model pull or a restart: a truncated prompt otherwise looks like a model that has simply gone stupid.
 
 Pick a value **every** local model you use can handle (it's global), e.g. `131072`. Too low starves long sessions; too high blows up prefill time and VRAM on a slow GPU. ~128K is a sane middle for a 24GB+ card. A model's *training* context (e.g. 256K) is an upper bound, not what you must load — load only what your GPU can prefill in reasonable time.
 
@@ -680,6 +690,7 @@ Parsed at `internal/agents/loader.go:199` (the `frontmatter` struct):
 | `models` | `map[tier][]TierCandidate` | Per-agent tier candidate lists | Full replacement of library `tiers[]` for this agent. |
 | `effort` | string | `low` / `medium` / `high` | Reasoning-effort hint. Anthropic + OpenAI honour it; Ollama ignores. |
 | `max_tokens` | int | Per-iteration assistant output cap | 0 = provider default. |
+| `max_context_tokens` | int | Per-agent context WINDOW | RFC CJ. 0 = unset. Local (Ollama) → `options.num_ctx`, winning over the env/provider window. Cloud → caps the effective window (a compaction budget clamped to the model max — can only lower). Distinct from `max_tokens` (output). Content-identifying. |
 | `sampling` | object | LLM sampling params | `temperature` / `top_p` / `top_k` / `frequency_penalty` / `presence_penalty` / `seed` / `stop`. Each driver applies what its provider supports, drops the rest. `temperature: 0.0` is deterministic (≠ unset). Overridable per-run on `/v1/runs` (`sampling`), merged per field (per-run wins). See `Context op=help topic=sampling`. Anthropic drops temperature/top_p when `effort` engages thinking. |
 | **Tool fields** | | | |
 | `tools` | `[]string` | Tool allowlist (loomcycle form) | Empty list = zero tools. Always wins over `tools:`. |
@@ -784,7 +795,7 @@ Mix of built-in tools (WebSearch, WebFetch) and an MCP tool. Tier-driven resolut
 
 ### Claude-Code compatibility
 
-The same `.md` file works in both Claude Code and loomcycle. **Claude-Code-honoured fields**: `name`, `description`, `tools` (comma-string), `model`. **Loomcycle extensions**: `tier`, `models`, `providers`, `effort`, `max_tokens`, `sampling`, `skills`, `tools` (list form), `system_prompt_file`, `memory_scopes`, `memory_quota_bytes`, `channels`, `agent_def_scopes`, `evaluation_scopes`. Claude Code ignores unknown keys; loomcycle treats the format as a superset. Keep your agents portable by including both `tools:` (Claude Code shape) and `tools:` (loomcycle shape) when you want the same file used in both.
+The same `.md` file works in both Claude Code and loomcycle. **Claude-Code-honoured fields**: `name`, `description`, `tools` (comma-string), `model`. **Loomcycle extensions**: `tier`, `models`, `providers`, `effort`, `max_tokens`, `max_context_tokens`, `sampling`, `skills`, `tools` (list form), `system_prompt_file`, `memory_scopes`, `memory_quota_bytes`, `channels`, `agent_def_scopes`, `evaluation_scopes`. Claude Code ignores unknown keys; loomcycle treats the format as a superset. Keep your agents portable by including both `tools:` (Claude Code shape) and `tools:` (loomcycle shape) when you want the same file used in both.
 
 ### Operator-yaml `agents:` overlay
 

--- a/internal/agents/loader.go
+++ b/internal/agents/loader.go
@@ -66,6 +66,8 @@ type Agent struct {
 	Tier      string
 	Effort    string
 	MaxTokens int
+	// MaxContextTokens is the per-agent context window (RFC CJ); content-identifying.
+	MaxContextTokens int
 	// MaxIterations caps the agent loop at this many provider calls
 	// before terminating with stop_reason="max_iterations". 0 means
 	// use the loop default (16). Set higher for discovery-style
@@ -331,6 +333,7 @@ type frontmatter struct {
 	Tier                  string                     `yaml:"tier"`
 	Effort                string                     `yaml:"effort"`
 	MaxTokens             int                        `yaml:"max_tokens"`
+	MaxContextTokens      int                        `yaml:"max_context_tokens"` // RFC CJ
 	MaxIterations         int                        `yaml:"max_iterations"`
 	MaxConcurrentChildren int                        `yaml:"max_concurrent_children"`
 	Skills                []string                   `yaml:"skills"`
@@ -408,6 +411,7 @@ func parseAgent(raw []byte) (*Agent, error) {
 	a.Tier = fm.Tier
 	a.Effort = fm.Effort
 	a.MaxTokens = fm.MaxTokens
+	a.MaxContextTokens = fm.MaxContextTokens
 	a.MaxIterations = fm.MaxIterations
 	a.MaxConcurrentChildren = fm.MaxConcurrentChildren
 	a.Skills = fm.Skills

--- a/internal/agents/sign.go
+++ b/internal/agents/sign.go
@@ -166,6 +166,7 @@ type AgentContent struct {
 	Internal              bool                  `json:"internal,omitempty"`
 	Interruption          *AgentInterruptionACL `json:"interruption,omitempty"`
 	MaxConcurrentChildren int                   `json:"max_concurrent_children,omitempty"`
+	MaxContextTokens      int                   `json:"max_context_tokens,omitempty"` // RFC CJ — per-agent context window; content-identifying
 	MaxIterations         int                   `json:"max_iterations,omitempty"`
 	MaxTokens             int                   `json:"max_tokens,omitempty"`
 	MemoryBackend         string                `json:"memory_backend,omitempty"`
@@ -373,6 +374,7 @@ func FromYAMLAgent(a *Agent) AgentContent {
 		Tier:                  a.Tier,
 		Effort:                a.Effort,
 		MaxTokens:             a.MaxTokens,
+		MaxContextTokens:      a.MaxContextTokens,
 		MaxIterations:         a.MaxIterations,
 		MaxConcurrentChildren: a.MaxConcurrentChildren,
 		Tools:                 a.Tools,

--- a/internal/agents/sign_test.go
+++ b/internal/agents/sign_test.go
@@ -52,6 +52,19 @@ func TestSign_MemoryConsolidation_IsContentIdentifying(t *testing.T) {
 	}
 }
 
+func TestSign_MaxContextTokens_IsContentIdentifying(t *testing.T) {
+	base := AgentContent{Name: "researcher", SystemPrompt: "be thorough"}
+	withWindow := base
+	withWindow.MaxContextTokens = 131072
+
+	if Sign(base) == Sign(withWindow) {
+		t.Error("MaxContextTokens not content-identifying: setting it did not change the hash")
+	}
+	if got, want := Sign(base), Sign(AgentContent{Name: "researcher", SystemPrompt: "be thorough", MaxContextTokens: 0}); got != want {
+		t.Errorf("unset MaxContextTokens changed the hash (omitempty broken): %s vs %s", got, want)
+	}
+}
+
 func TestSign_DeterministicAcrossCalls(t *testing.T) {
 	c := AgentContent{
 		Name:         "researcher",

--- a/internal/api/http/resume.go
+++ b/internal/api/http/resume.go
@@ -342,6 +342,7 @@ func (s *Server) resumePausedRun(ctx context.Context, run store.Run) error {
 		OnEvent:             emit,
 		OnHeartbeat:         heartbeat,
 		MaxTokens:           agentDef.MaxTokens,
+		MaxContextTokens:    agentDef.MaxContextTokens, // RFC CJ
 		MaxIterations:       agentDef.MaxIterations,
 		UnboundedIterations: agentDef.UnboundedIterations,
 		SteerQueue:          steerQ,

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2584,7 +2584,8 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 		OnEvent:             emit,
 		OnHeartbeat:         heartbeat,
 		MaxTokens:           agentDef.MaxTokens,
-		MaxIterations:       agentDef.MaxIterations, // 0 → loop default (16)
+		MaxContextTokens:    agentDef.MaxContextTokens, // RFC CJ; 0 → provider/driver default
+		MaxIterations:       agentDef.MaxIterations,    // 0 → loop default (16)
 		UnboundedIterations: agentDef.UnboundedIterations,
 		SteerQueue:          steerQ,
 		OnSteer:             onSteer,
@@ -4185,8 +4186,9 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		Segments:            injectMetadataSegments(req.Segments, provider.Capabilities().MetadataViaInput, req.Metadata, nil),
 		OnEvent:             emit,
 		OnHeartbeat:         heartbeat,
-		MaxTokens:           agentDef.MaxTokens,     // 0 → driver default
-		MaxIterations:       agentDef.MaxIterations, // 0 → loop default (16)
+		MaxTokens:           agentDef.MaxTokens,        // 0 → driver default
+		MaxContextTokens:    agentDef.MaxContextTokens, // RFC CJ; 0 → provider/driver default
+		MaxIterations:       agentDef.MaxIterations,    // 0 → loop default (16)
 		UnboundedIterations: agentDef.UnboundedIterations,
 		SteerQueue:          steerQ,
 		OnSteer:             onSteer,
@@ -4766,8 +4768,9 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		PauseGate:              gate,
 		OnEvent:                emit,
 		OnHeartbeat:            heartbeat,
-		MaxTokens:              agentDef.MaxTokens,     // 0 → driver default
-		MaxIterations:          agentDef.MaxIterations, // 0 → loop default (16)
+		MaxTokens:              agentDef.MaxTokens,        // 0 → driver default
+		MaxContextTokens:       agentDef.MaxContextTokens, // RFC CJ; 0 → provider/driver default
+		MaxIterations:          agentDef.MaxIterations,    // 0 → loop default (16)
 		UnboundedIterations:    agentDef.UnboundedIterations,
 		SteerQueue:             steerQ,
 		OnSteer:                onSteer,
@@ -6043,8 +6046,9 @@ func (s *Server) prepareSubRun(ctx context.Context, name, prompt, defID string, 
 		OnEvent:             subEmit,
 		OnHeartbeat:         subHeartbeat,
 		PauseGate:           subGate,
-		MaxTokens:           def.MaxTokens,     // 0 → driver default
-		MaxIterations:       def.MaxIterations, // 0 → loop default (16)
+		MaxTokens:           def.MaxTokens,        // 0 → driver default
+		MaxContextTokens:    def.MaxContextTokens, // RFC CJ; 0 → provider/driver default
+		MaxIterations:       def.MaxIterations,    // 0 → loop default (16)
 		UnboundedIterations: def.UnboundedIterations,
 		Effort:              effort,
 		MarkStalled:         s.markStalledFn(providerID, model),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -988,6 +988,17 @@ type AgentDef struct {
 	// use, 16384+ for batch scoring agents.
 	MaxTokens int `yaml:"max_tokens"`
 
+	// MaxContextTokens sets the context WINDOW this agent uses (RFC CJ) —
+	// distinct from MaxTokens, which is the OUTPUT cap. 0 = unset → today's
+	// behavior exactly. Local (Ollama): sent as options.num_ctx, sizing the real
+	// KV-cache window (Ollama caps it at the model's trained context). Cloud: the
+	// window is fixed by the model, so this caps the agent's EFFECTIVE/advertised
+	// window — a compaction budget clamped to the model's maximum (it can only
+	// LOWER, never enlarge). Behaviour-bearing (a smaller window truncates the
+	// prompt → different output), so content-identifying like sampling; omitempty
+	// keeps every pre-feature agent row byte-stable in content_sha256.
+	MaxContextTokens int `yaml:"max_context_tokens,omitempty"`
+
 	// MaxIterations caps the agent loop at this many provider calls
 	// before terminating with stop_reason="max_iterations". Zero =
 	// use the loop default (16). Set higher for discovery-style

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4966,6 +4966,7 @@ func agentFromDiscovered(d *agents.Agent) AgentDef {
 		Tools:            d.Tools,
 		Skills:           d.Skills,
 		MaxTokens:        d.MaxTokens,
+		MaxContextTokens: d.MaxContextTokens,
 		MaxIterations:    d.MaxIterations,
 		// MaxConcurrentChildren rounds out the loop-budget trio (with
 		// MaxTokens/MaxIterations) — it lives on agents.Agent + the MD
@@ -5081,6 +5082,9 @@ func mergeAgentDef(base, override AgentDef) AgentDef {
 	}
 	if override.MaxTokens != 0 {
 		out.MaxTokens = override.MaxTokens
+	}
+	if override.MaxContextTokens != 0 {
+		out.MaxContextTokens = override.MaxContextTokens
 	}
 	if override.MaxIterations != 0 {
 		out.MaxIterations = override.MaxIterations
@@ -6112,6 +6116,9 @@ func validate(c *Config) error {
 		}
 		if agent.MemoryInjectMaxTokens < 0 {
 			return fmt.Errorf("agent %q: memory_inject_max_tokens must be >= 0", name)
+		}
+		if agent.MaxContextTokens < 0 {
+			return fmt.Errorf("agent %q: max_context_tokens must be >= 0", name)
 		}
 		if agent.MemoryIndexMaxBytes < 0 {
 			return fmt.Errorf("agent %q: memory_index_max_bytes must be >= 0", name)

--- a/internal/config/merge_agentdef_coverage_test.go
+++ b/internal/config/merge_agentdef_coverage_test.go
@@ -81,6 +81,7 @@ func nonZeroAgentDef() AgentDef {
 		Tools:                 []string{"Read"},
 		Skills:                []string{"a/*"},
 		MaxTokens:             111,
+		MaxContextTokens:      65536,
 		MaxIterations:         22,
 		UnboundedIterations:   true,
 		MaxConcurrentChildren: 7,

--- a/internal/lookup/agent.go
+++ b/internal/lookup/agent.go
@@ -188,9 +188,10 @@ type SubstrateAgentDef struct {
 	Sampling *config.Sampling `json:"sampling,omitempty"`
 	// Compaction: per-agent context-compaction settings (mirrors config.Compaction
 	// / mergedDef).
-	Compaction    *config.Compaction `json:"compaction,omitempty"`
-	MaxTokens     int                `json:"max_tokens,omitempty"`
-	MaxIterations int                `json:"max_iterations,omitempty"`
+	Compaction       *config.Compaction `json:"compaction,omitempty"`
+	MaxTokens        int                `json:"max_tokens,omitempty"`
+	MaxContextTokens int                `json:"max_context_tokens,omitempty"` // RFC CJ; content-identifying
+	MaxIterations    int                `json:"max_iterations,omitempty"`
 	// UnboundedIterations lifts the MaxIterations soft-cap for an LLM agent
 	// (interactive runs). Mirrors mergedDef; the drift test pins parity.
 	UnboundedIterations bool `json:"unbounded_iterations,omitempty"`
@@ -285,6 +286,7 @@ func (s SubstrateAgentDef) ToConfigDef() config.AgentDef {
 		Sampling:              s.Sampling,
 		Compaction:            s.Compaction,
 		MaxTokens:             s.MaxTokens,
+		MaxContextTokens:      s.MaxContextTokens,
 		MaxIterations:         s.MaxIterations,
 		UnboundedIterations:   s.UnboundedIterations,
 		MaxConcurrentChildren: s.MaxConcurrentChildren,

--- a/internal/lookup/agent_test.go
+++ b/internal/lookup/agent_test.go
@@ -286,6 +286,7 @@ func TestAgent_DriftDetection(t *testing.T) {
 		"sampling":                true, // per-agent LLM sampling params (temperature, top_p, …)
 		"compaction":              true, // per-agent context-compaction settings
 		"max_tokens":              true,
+		"max_context_tokens":      true, // RFC CJ — per-agent context window (content-identifying; mirror mergedDef)
 		"max_iterations":          true,
 		"unbounded_iterations":    true, // lift the iteration soft-cap for interactive LLM agents
 		"max_concurrent_children": true,

--- a/internal/loop/compact_test.go
+++ b/internal/loop/compact_test.go
@@ -272,6 +272,44 @@ func (p *ctxUsageProvider) Call(ctx context.Context, _ providers.Request) (<-cha
 	return ch, nil
 }
 
+// TestRun_MaxContextTokens_CapsEffectiveWindow pins RFC CJ's budget path: a
+// per-agent MaxContextTokens caps the EFFECTIVE window reported on the usage
+// event (which the auto-compaction threshold + the UI gauge read), clamped to
+// the provider's real max — a budget can only LOWER a fixed window, never
+// enlarge it. (For Ollama the driver reports the per-agent num_ctx directly; on
+// a fixed-window cloud provider this loop clamp is what makes the budget bite.)
+func TestRun_MaxContextTokens_CapsEffectiveWindow(t *testing.T) {
+	reportedWindow := func(budget int) int {
+		prov := &ctxUsageProvider{maxCtx: 128000} // model's fixed window
+		var window int
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_, _ = Run(ctx, RunOptions{
+			Provider:         prov,
+			Model:            "x",
+			Tools:            []tools.Tool{noopTool{}},
+			Dispatcher:       tools.NewDispatcher([]tools.Tool{noopTool{}}),
+			Segments:         steerSegs(),
+			MaxContextTokens: budget,
+			OnEvent: func(ev providers.Event) {
+				if ev.Type == providers.EventUsage && ev.Usage != nil && ev.Usage.MaxContextTokens > 0 {
+					window = ev.Usage.MaxContextTokens
+				}
+			},
+		})
+		return window
+	}
+	if got := reportedWindow(32000); got != 32000 {
+		t.Errorf("budget 32000 below the 128000 model window: reported %d, want 32000 (clamped down)", got)
+	}
+	if got := reportedWindow(0); got != 128000 {
+		t.Errorf("no budget: reported %d, want the model's 128000", got)
+	}
+	if got := reportedWindow(500000); got != 128000 {
+		t.Errorf("budget 500000 above the model window: reported %d, want 128000 (cannot enlarge)", got)
+	}
+}
+
 // A parked interactive run that compacts (steer.KindCompact) must refresh the
 // context footprint so the NEXT operator turn's Context op=self reports the
 // compacted (small) size — not the stale pre-compaction footprint.

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -158,6 +158,13 @@ type RunOptions struct {
 	// from cfg.Agents[X].MaxTokens at request time.
 	MaxTokens int
 
+	// MaxContextTokens is the resolved per-agent context WINDOW (RFC CJ; per-run
+	// > per-agent, merged by the caller), distinct from MaxTokens (output). The
+	// loop passes it to the driver (Ollama → options.num_ctx) AND uses it as the
+	// effective window for the auto-compaction threshold + the gauge, clamped to
+	// the provider's real max (a cloud budget can only lower). 0 = no override.
+	MaxContextTokens int
+
 	// Effort is the reasoning-effort hint plumbed through to the
 	// driver. One of "low" / "medium" / "high" or empty (= no hint).
 	// Per-driver translation lands in PR 3 of the resolve-matrix
@@ -1603,8 +1610,9 @@ outerLoop:
 			System:    reqSystem,
 			Messages:  reqMessages,
 			Tools:     toolSpecs,
-			MaxTokens: opts.MaxTokens, // 0 → driver default
-			Effort:    opts.Effort,    // "" → driver default; PR 3 wires per-driver translation
+			MaxTokens:        opts.MaxTokens,        // 0 → driver default
+			MaxContextTokens: opts.MaxContextTokens, // 0 → driver/provider default (RFC CJ)
+			Effort:           opts.Effort,           // "" → driver default; PR 3 wires per-driver translation
 			// OnEvent lets the driver fire pre-channel events (currently
 			// EventRetry during a 429 sleep) directly to the same caller
 			// hook the loop uses for response events. Without this hop
@@ -1941,6 +1949,16 @@ outerLoop:
 			// that and only fall back to the static capability default.
 			if iterUsage.MaxContextTokens == 0 {
 				iterUsage.MaxContextTokens = opts.Provider.Capabilities().MaxContextTokens
+			}
+			// RFC CJ: a per-agent context budget caps the EFFECTIVE window used by
+			// the auto-compaction threshold + the gauge. Clamp to whatever the
+			// provider reported — a budget can only LOWER a fixed cloud window,
+			// never enlarge it (0 = unknown window → adopt the budget). For Ollama
+			// the driver already reported the per-agent num_ctx here, so this is a
+			// no-op unless the budget is smaller still.
+			if opts.MaxContextTokens > 0 &&
+				(iterUsage.MaxContextTokens == 0 || opts.MaxContextTokens < iterUsage.MaxContextTokens) {
+				iterUsage.MaxContextTokens = opts.MaxContextTokens
 			}
 			// RFC AV: stamp the serving provider onto the per-call usage event
 			// too (not just totalUsage) so the token_usage row records which

--- a/internal/providers/ollama/driver.go
+++ b/internal/providers/ollama/driver.go
@@ -231,11 +231,17 @@ type ctxWindow struct {
 //     keeps today's behaviour and 4096 is a floor we cannot under-deliver on,
 //     so the advertised window is pessimistic but never a lie. One turn later
 //     /api/ps reports the real window and the exact case above takes over.
-func (d *Driver) resolveContext(model string) ctxWindow {
+func (d *Driver) resolveContext(req providers.Request) ctxWindow {
+	// RFC CJ: a per-agent/per-run window resolved by the loop wins over the
+	// construction-time num_ctx (per-provider options / env). Ollama caps it at
+	// the model's trained context, so an over-large value is safe.
+	if req.MaxContextTokens > 0 {
+		return ctxWindow{send: req.MaxContextTokens, advertise: req.MaxContextTokens, source: "request"}
+	}
 	if d.numCtx > 0 {
 		return ctxWindow{send: d.numCtx, advertise: d.numCtx, source: "pinned"}
 	}
-	if n := d.loadedContext(model); n > 0 {
+	if n := d.loadedContext(req.Model); n > 0 {
 		return ctxWindow{send: n, advertise: n, source: "loaded"}
 	}
 	return ctxWindow{send: 0, advertise: defaultNumCtx, source: "assumed"}
@@ -439,7 +445,7 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 	// wire and the usage stamp: resolving twice (e.g. again at the done frame)
 	// would let the cache TTL expire mid-generation and re-open the gap this
 	// closes.
-	window := d.resolveContext(req.Model)
+	window := d.resolveContext(req)
 	d.warnIfPromptOverWindow(req, window)
 
 	body, err := d.buildRequestBody(req, window.send)

--- a/internal/providers/ollama/driver_test.go
+++ b/internal/providers/ollama/driver_test.go
@@ -309,6 +309,44 @@ func TestRequestBody_NumCtxPropagated(t *testing.T) {
 	}
 }
 
+// TestRequestBody_PerRequestMaxContextTokensOverrides pins RFC CJ: a per-agent
+// window resolved by the loop (Request.MaxContextTokens) wins over the driver's
+// construction-time num_ctx (per-provider options / env). So two agents on the
+// same ollama-local registration can run at different windows.
+func TestRequestBody_PerRequestMaxContextTokensOverrides(t *testing.T) {
+	var captured []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/ps" {
+			fmt.Fprint(w, `{"models":[]}`)
+			return
+		}
+		captured, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		fmt.Fprint(w, `{"model":"x","message":{"role":"assistant","content":""},"done":true}`+"\n")
+	}))
+	defer srv.Close()
+
+	// Driver pinned to 8192 (the shared provider/env default); the request asks
+	// for 131072 — the request must win.
+	d := New("", "", srv.URL, streamhttp.Options{}, nil).WithNumCtx(8192)
+	ch, err := d.Call(context.Background(), providers.Request{
+		Model:            "glm-4.7-flash:q4_K_M",
+		MaxContextTokens: 131072,
+		Messages:         []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	for range ch {
+	}
+	if !strings.Contains(string(captured), `"num_ctx":131072`) {
+		t.Errorf("per-request num_ctx=131072 did not override the pinned 8192; body:\n%s", string(captured))
+	}
+	if strings.Contains(string(captured), `"num_ctx":8192`) {
+		t.Errorf("pinned 8192 leaked despite a per-request override; body:\n%s", string(captured))
+	}
+}
+
 // TestRequestBody_NumGpuOmittedByDefault pins that no num_gpu field is sent
 // when the driver was built without WithNumGpu. The omitempty tag is
 // load-bearing: a literal "num_gpu":0 would force Ollama to run CPU-only.

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -160,6 +160,14 @@ type Request struct {
 	Temperature *float64       `json:"temperature,omitempty"`
 	Stream      bool           `json:"stream"`
 
+	// MaxContextTokens is the per-agent context WINDOW the loop resolved for
+	// this run (RFC CJ; per-run > per-agent), distinct from MaxTokens (output).
+	// Translate-or-drop, like Effort: the Ollama driver applies it as
+	// options.num_ctx (preferred over its construction-time num_ctx); every
+	// other driver ignores it — the window there is model-fixed and the loop
+	// handles the advertised-window budget itself. 0 = no per-agent override.
+	MaxContextTokens int `json:"max_context_tokens,omitempty"`
+
 	// Per-agent LLM sampling knobs (config.Sampling, resolved per-run >
 	// per-agent and mapped onto these flat fields by the loop). Each driver
 	// applies the ones its provider supports and DROPS the rest (the same

--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -857,6 +857,9 @@ type mergedDef struct {
 	Tier      string `json:"tier,omitempty"`
 	Effort    string `json:"effort,omitempty"`
 	MaxTokens int    `json:"max_tokens,omitempty"`
+	// MaxContextTokens: per-agent context WINDOW (RFC CJ; distinct from MaxTokens,
+	// the output cap). Content-identifying, plain int (0 = unset).
+	MaxContextTokens int `json:"max_context_tokens,omitempty"`
 	// Sampling: per-agent LLM sampling params. Round-trips as the `sampling`
 	// object; applyOverlay merges it PER FIELD (a fork that sets only
 	// temperature keeps the parent's top_p). Content-identifying (hashed).
@@ -1001,6 +1004,9 @@ func (d *mergedDef) applyOverlay(ov mergedDef) {
 	}
 	if ov.MaxTokens != 0 {
 		d.MaxTokens = ov.MaxTokens
+	}
+	if ov.MaxContextTokens != 0 {
+		d.MaxContextTokens = ov.MaxContextTokens
 	}
 	if ov.MaxIterations != 0 {
 		d.MaxIterations = ov.MaxIterations
@@ -1221,6 +1227,7 @@ func staticToMergedDef(s config.AgentDef) mergedDef {
 		Sampling:              s.Sampling.Clone(),
 		Compaction:            s.Compaction.Clone(),
 		MaxTokens:             s.MaxTokens,
+		MaxContextTokens:      s.MaxContextTokens,
 		MaxIterations:         s.MaxIterations,
 		UnboundedIterations:   s.UnboundedIterations,
 		MaxConcurrentChildren: s.MaxConcurrentChildren,
@@ -1337,6 +1344,7 @@ func signFromMergedDef(name string, def mergedDef) string {
 		Tier:                  def.Tier,
 		Effort:                def.Effort,
 		MaxTokens:             def.MaxTokens,
+		MaxContextTokens:      def.MaxContextTokens,
 		MaxIterations:         def.MaxIterations,
 		UnboundedIterations:   def.UnboundedIterations,
 		MaxConcurrentChildren: def.MaxConcurrentChildren,

--- a/internal/tools/builtin/agentdef_sha256_test.go
+++ b/internal/tools/builtin/agentdef_sha256_test.go
@@ -95,7 +95,8 @@ func TestAgentDefTool_ForkInteractiveConfigMovesHash(t *testing.T) {
 		"interruption":      `{"op":"fork","name":"researcher","overlay":{"system_prompt":"v1","interruption":{"enabled":true,"max_pending":2}}}`,
 		// inject_tool_guide is behaviour-bearing (it changes what every run of the
 		// def is told), so a fork that flips it must mint a distinct content hash.
-		"inject_tool_guide": `{"op":"fork","name":"researcher","overlay":{"system_prompt":"v1","inject_tool_guide":true}}`,
+		"inject_tool_guide":  `{"op":"fork","name":"researcher","overlay":{"system_prompt":"v1","inject_tool_guide":true}}`,
+		"max_context_tokens": `{"op":"fork","name":"researcher","overlay":{"system_prompt":"v1","max_context_tokens":65536}}`,
 	}
 	for field, overlay := range cases {
 		res, _ := tool.Execute(ctx, json.RawMessage(overlay))


### PR DESCRIPTION
Implements **RFC CJ** (`/loomcycle/rfcs/per-agent-context-size`), phase 1: an **agent-level** `max_context_tokens`. Per-run override + gRPC/adapter parity + `Context op=self` visibility are a noted phase-2 follow-up (see below).

## Why

An agent's context window was not agent-settable. For Ollama it's fixed at boot on the driver instance (global `LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX` or per-provider `options.num_ctx`), shared by every agent on that registration — so a fetch-heavy `researcher` that needs 128K forces the larger KV cache + slower prefill on every other local agent, and a too-small shared window timed the researcher out (0 tokens, `context deadline exceeded`).

## What

`config.AgentDef.max_context_tokens` (int, `omitempty`; 0 = unset → byte-identical to today). Distinct from `max_tokens` (the *output* cap). Interpreted per driver through one effective-window seam:

- **Local (Ollama):** sent as `options.num_ctx`, sizing the real window. The driver's `resolveContext` prefers the per-agent value over its construction-time `num_ctx` (precedence: per-agent > per-provider `options.num_ctx` > env > `/api/ps` loaded > 4096). Two agents on one `ollama-local` registration can now run at different windows.
- **Cloud:** the window is model-fixed, so the value caps the agent's **effective** window — a compaction budget the auto-compaction threshold + the UI gauge read, **clamped to the model max** (it can only lower, never enlarge).

**Content-identifying** (hashed like `sampling`): a fork that changes it mints a new `content_sha256`.

Full substrate round-trip (mirrors `sampling`, as a plain hashed int): AgentDef create/fork overlay, lookup adapter, `content_sha256`, `mergeAgentDef`, and — unlike `sampling` — the **MD-frontmatter loader** (operators author local agents via `<name>.md`). Threaded into `loop.Options` → `providers.Request` at the HTTP run / continue / messages / sub-agent / resume sites.

```yaml
agents:
  researcher: { model: qwen3.6-local, max_context_tokens: 131072 }   # 128K window
  chat/local: { model: local-medium }                                # env/provider window
  analyst:    { tier: middle, max_context_tokens: 32768 }            # cloud: compact at 32K, not the model's 128K
```

## Tested

- `go test ./...` — clean (91 packages).
- `internal/providers/ollama` `TestRequestBody_PerRequestMaxContextTokensOverrides` — per-request `num_ctx` overrides the pinned value.
- `internal/loop` `TestRun_MaxContextTokens_CapsEffectiveWindow` — budget below the model window clamps down; unset keeps the max; above-max cannot enlarge.
- Drift/parity enforced: `TestAgent_DriftDetection`, the mergedDef/mergeAgentDef coverage tests, `TestAgentDefTool_ForkInteractiveConfigMovesHash` (a `max_context_tokens` fork moves the hash), new `TestSign_MaxContextTokens_IsContentIdentifying`.
- Docs: `docs/CONFIGURATION.md` (num_ctx section + field table + `.md` field list).

## Phase 2 (follow-up, not in this PR)

Per-run `max_context_tokens` override + cross-transport parity (it flows `runRequest → connector.SpawnRunRequest → runner.RunInput → RunOnce`, so it needs the connector/gRPC/adapter cascade) and `Context op=self` window visibility. Deferred to keep this PR focused on the agent-level path, which is the operator's actual need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)