### PR TITLE
test: de-flake deferred-channel contract windows under -race

### DIFF
--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -5844,7 +5844,12 @@ func testChannelReplayFromCursorZero(t *testing.T, s store.Store) {
 
 func testChannelDeferredHiddenUntilVisible(t *testing.T, s store.Store) {
 	ctx := context.Background()
-	deferTo := time.Now().Add(150 * time.Millisecond)
+	// The window must be wide enough that the "hidden now" assertion
+	// below reliably runs BEFORE visible_at elapses even on a loaded
+	// -race CI runner, where a scheduler stall of a few hundred ms
+	// between publish and the immediate subscribe is normal. A 150ms
+	// window flaked (got 1, want 0); 2s leaves ample margin.
+	deferTo := time.Now().Add(2 * time.Second)
 	_, _, err := s.ChannelPublish(ctx, store.ChannelMessage{
 		Channel: "ch", Scope: store.MemoryScopeAgent, ScopeID: "x",
 		Payload:   json.RawMessage(`{"k":"v"}`),
@@ -5861,7 +5866,7 @@ func testChannelDeferredHiddenUntilVisible(t *testing.T, s store.Store) {
 		t.Fatalf("deferred message visible too early: got %d, want 0", len(msgs))
 	}
 	// Wait past visible_at, then verify it shows up.
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(2200 * time.Millisecond)
 	msgs, _, err = s.ChannelSubscribe(ctx, "", "ch", store.MemoryScopeAgent, "x", "", 10)
 	if err != nil {
 		t.Fatalf("post-visible subscribe: %v", err)
@@ -5883,7 +5888,10 @@ func testChannelDeferredDeliversAfterProgressedCursor(t *testing.T, s store.Stor
 		Payload: json.RawMessage(`"A"`),
 	}, 0)
 	time.Sleep(time.Microsecond)
-	deferTo := time.Now().Add(150 * time.Millisecond)
+	// Wide window so the page1 assertion (B still hidden) reliably runs
+	// before visible_at on a loaded -race CI runner — see the sibling
+	// testChannelDeferredHiddenUntilVisible for why 150ms flaked.
+	deferTo := time.Now().Add(2 * time.Second)
 	_, _, _ = s.ChannelPublish(ctx, store.ChannelMessage{
 		Channel: "ch", Scope: store.MemoryScopeAgent, ScopeID: "x",
 		Payload:   json.RawMessage(`"B"`),
@@ -5910,7 +5918,7 @@ func testChannelDeferredDeliversAfterProgressedCursor(t *testing.T, s store.Stor
 		t.Fatal(err)
 	}
 	// Wait past visible_at for B.
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(2200 * time.Millisecond)
 	// Now subscribe again — B should be delivered even though its
 	// msg_id is < C's. This is the (visible_at, id) tuple-ordering
 	// invariant that prevents silent skip-on-progress for deferred


### PR DESCRIPTION
## Why

CI's `Go 1.26.x` job intermittently fails on `TestStoreContract/ChannelDeferredHiddenUntilVisible`:

```
deferred message visible too early: got 1, want 0
```

Two deferred-channel store-contract subtests assert that a message is **hidden** before its `visible_at`, using a **150ms** deferral window. On a loaded `-race` CI runner the scheduler can stall a few hundred ms between the `ChannelPublish` and the immediate `ChannelSubscribe`, so `visible_at` has already elapsed by the time the "hidden now" assertion runs — a pure timing flake, not a store-logic bug. It surfaced as a spurious red on unrelated PRs (e.g. #1065).

## What

Widen the deferral window to **2s** (and the matching post-visible sleep to **2.2s**) in the two immediate-hidden-assert subtests:

- `testChannelDeferredHiddenUntilVisible`
- `testChannelDeferredDeliversAfterProgressedCursor`

The sibling subtests that only ever wait **past** the window are robust in that direction and are left unchanged (`TTLCountsFromPublished`, `PastDeliverAtTreatedAsNow`, `AckCommitsTupleCursor`, `MaxMessagesTrimPreservesDeferred`).

## Tested

`go test -race -run 'TestStoreContract/(ChannelDeferred*|ChannelMaxMessagesTrimPreservesDeferred)' ./internal/store/sqlite/ -count=3` → `ok` (all deferred-channel subtests, 3× under `-race`). No production code touched — test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)