### PR TITLE
fix(memory): a killed consolidation pass no longer strands its lease

### DIFF
--- a/internal/api/http/consolidation_eval_test.go
+++ b/internal/api/http/consolidation_eval_test.go
@@ -351,9 +351,8 @@ func TestConsolidationEval_WatermarkAdvancesAndLeaseExcludesASecondPass(t *testi
 	f := seedEvalFixture(t, env)
 	ctx := context.Background()
 
-	// Pass A: a full pass that leases, advances, and then DOES NOT release — the
-	// shape of a pass still in flight (or one whose process died holding the
-	// lease, which is why the lease has a TTL at all).
+	// Pass A: a full pass that leases, advances, and then DOES NOT release its
+	// lease — the shape of a pass that was killed rather than one that finished.
 	scriptsA := f.evalPassScript(nil, f.fullPassWrites()...)
 	// Drop the release leg (second-to-last, before the report).
 	scriptsA = append(scriptsA[:len(scriptsA)-2], scriptsA[len(scriptsA)-1])
@@ -370,8 +369,23 @@ func TestConsolidationEval_WatermarkAdvancesAndLeaseExcludesASecondPass(t *testi
 	if !afterA.WatermarkCompletedAt.Equal(f.last.SettledAt) {
 		t.Fatalf("watermark completed_at = %v, want the chat's settled instant %v", afterA.WatermarkCompletedAt, f.last.SettledAt)
 	}
+	// THE CONCURRENT HOLDER HAS TO BE A LIVE RUN. Pass A's run has reached
+	// terminal, and a terminal run no longer holds a lease: finishRunWithCancel
+	// reclaims it, precisely because a pass killed mid-flight cannot release its
+	// own and used to strand the target for the rest of the TTL. So "a pass that
+	// skipped its release" is no longer a way to simulate a live competitor —
+	// grant the lease to a third-party owner directly instead. That is also the
+	// truer fixture: what this test is about is a NON-OWNER being refused, and the
+	// owner it is compared against should be unambiguously alive.
+	if _, ok, err := env.store.MemoryCursorLease(ctx, "", store.MemoryScopeUser, evalUserID,
+		"r_concurrent_pass", time.Now().UTC(), time.Hour); err != nil || !ok {
+		t.Fatalf("grant the concurrent pass's lease: acquired=%v err=%v", ok, err)
+	}
+	if afterA, err = env.store.MemoryCursorGet(ctx, "", store.MemoryScopeUser, evalUserID); err != nil {
+		t.Fatalf("MemoryCursorGet after granting the concurrent lease: %v", err)
+	}
 	if afterA.LeasedBy == "" {
-		t.Fatal("pass A left no lease held; the exclusion assertion below would be vacuous")
+		t.Fatal("no lease held; the exclusion assertion below would be vacuous")
 	}
 	liveAfterA := len(liveEntries(t, env))
 

--- a/internal/api/http/consolidation_lease_test.go
+++ b/internal/api/http/consolidation_lease_test.go
@@ -1,0 +1,60 @@
+package http
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+)
+
+// TestReleaseConsolidationLease covers the server-side half of the fix: the hook
+// the terminal-run path defers.
+//
+// Why it matters that this runs on a REAL store rather than a double: the whole
+// point is the SQL predicate (release by owner alone, across targets), and a
+// double that records the call would pass whatever the predicate did.
+func TestReleaseConsolidationLease(t *testing.T) {
+	base, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = base.Close() })
+	s := &Server{store: base}
+	ctx := context.Background()
+
+	// A pass takes a long lease and then its run dies without releasing.
+	if _, ok, err := base.MemoryCursorLease(ctx, "", store.MemoryScopeUser, "alice", "r_dead", time.Now().UTC(), time.Hour); err != nil || !ok {
+		t.Fatalf("lease: acquired=%v err=%v", ok, err)
+	}
+	s.releaseConsolidationLease("r_dead")
+
+	// The next pass must start immediately, not in an hour. Before this hook
+	// existed the only thing that freed the target was the TTL, so every pass in
+	// between refused with "target busy".
+	row, ok, err := base.MemoryCursorLease(ctx, "", store.MemoryScopeUser, "alice", "r_next", time.Now().UTC(), time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || row.LeasedBy != "r_next" {
+		t.Errorf("after the dead run's lease was released: acquired=%v leasedBy=%q, want true/r_next", ok, row.LeasedBy)
+	}
+
+	// A LIVE run's lease is not collateral damage: releasing on behalf of one run
+	// must not touch another's, or a sub-agent finishing would free its parent's.
+	if _, ok, err := base.MemoryCursorLease(ctx, "", store.MemoryScopeUser, "bob", "r_live", time.Now().UTC(), time.Hour); err != nil || !ok {
+		t.Fatalf("lease bob: acquired=%v err=%v", ok, err)
+	}
+	s.releaseConsolidationLease("r_someone_else")
+	if _, ok, err := base.MemoryCursorLease(ctx, "", store.MemoryScopeUser, "bob", "r_thief", time.Now().UTC(), time.Hour); err != nil {
+		t.Fatal(err)
+	} else if ok {
+		t.Error("releasing for an unrelated run freed a live lease")
+	}
+
+	// The two no-ops. Both matter: nearly every run that reaches the terminal path
+	// holds no lease at all, and this hook is deferred on all of them.
+	s.releaseConsolidationLease("")            // no run id
+	(&Server{}).releaseConsolidationLease("x") // no store configured
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -7249,6 +7249,23 @@ func (s *Server) finishRunWithCancel(ctx context.Context, runCtx context.Context
 	if meta.IsTopLevel {
 		defer s.purgeEphemeralVolumesForRun(meta.RootRunID)
 	}
+	// Free any consolidation lease this run still holds. The pass releases its
+	// own lease in a `finally`, which covers every path the JS can take — but not
+	// the run being KILLED out from under it. A pass stopped by its wall-clock
+	// budget, a cancel, or a crash therefore left the target leased until the TTL
+	// elapsed, and every pass that fired in between refused to start with "target
+	// busy". Measured on a benchmark deployment: one pass wedged on a sub-agent
+	// call that never returned, was killed at its 25-minute budget, and its lease
+	// then blocked ten further passes over the remaining five minutes.
+	//
+	// NOT gated on IsTopLevel, unlike the volume purge above: a lease belongs to
+	// whichever run acquired it, and nothing stops a consolidator from running as
+	// a sub-agent. Keyed on this run's own id for the same reason.
+	//
+	// Best-effort and deferred: it must fire on every terminal branch below, and a
+	// fault here must never fail the run — the TTL is still the backstop it always
+	// was. A run holding no lease frees 0 rows, which is the ordinary case.
+	defer s.releaseConsolidationLease(runID)
 	// RFC BK: close any resident interactive sub-agents this run opened — the
 	// backstop for a parent that completes/errors without closing them itself. A
 	// parent CANCEL already cascades to them (they register with ParentAgentID);
@@ -7374,6 +7391,31 @@ func (s *Server) finishRunCancelled(_ context.Context, runID string, res loop.Ru
 		log.Printf("store: FinishRun(cancelled) failed (run=%s): %v", runID, err)
 	}
 	s.publishRunState(meta, "cancelled", reason, "")
+}
+
+// releaseConsolidationLease frees the memory-cursor lease owned by runID, if it
+// holds one. See the call site in finishRunWithCancel for why this exists.
+//
+// Logged only when it actually freed something: a line per run would be noise on
+// a deployment where no run consolidates, while a freed lease is worth knowing
+// about because it means a pass did not finish on its own terms.
+func (s *Server) releaseConsolidationLease(runID string) {
+	if s.store == nil || runID == "" {
+		return
+	}
+	// Its own short deadline: the run's context is already cancelled by the time
+	// a killed run reaches here, so inheriting it would guarantee the release is
+	// skipped in exactly the case it exists for.
+	bg, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	n, err := s.store.MemoryCursorReleaseByOwner(bg, runID)
+	if err != nil {
+		log.Printf("consolidation lease release (run=%s): %v", runID, err)
+		return
+	}
+	if n > 0 {
+		log.Printf("consolidation lease released on run end (run=%s targets=%d) — the pass did not release it itself", runID, n)
+	}
 }
 
 // purgeEphemeralVolumesForRun tears down a TOP-LEVEL run tree's ephemeral

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -4530,6 +4530,22 @@ func (s *Store) MemoryCursorRelease(ctx context.Context, tenantID string, scope 
 	return nil
 }
 
+// MemoryCursorReleaseByOwner is the Postgres mirror. See the interface doc.
+func (s *Store) MemoryCursorReleaseByOwner(ctx context.Context, owner string) (int, error) {
+	if owner == "" {
+		return 0, nil
+	}
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE memory_cursors SET leased_by = '', lease_expires_at = NULL, updated_at = $1
+		 WHERE leased_by = $2`,
+		time.Now().UTC(), owner,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("memory cursor release by owner: %w", err)
+	}
+	return int(tag.RowsAffected()), nil
+}
+
 // ---- v0.8.4 Channel tool ----
 //
 // Postgres mirror of the SQLite implementation. Reads filter expired

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -5238,6 +5238,31 @@ func (s *Store) MemoryCursorRelease(ctx context.Context, tenantID string, scope 
 	return err
 }
 
+// MemoryCursorReleaseByOwner frees every lease this owner holds. See the
+// interface doc for why it takes no tenant: a run id is globally unique, so
+// matching on it alone cannot reach another run's lease.
+func (s *Store) MemoryCursorReleaseByOwner(ctx context.Context, owner string) (int, error) {
+	// An empty owner would match every unleased row (leased_by = '') and
+	// "release" them all, which is a no-op in effect but a lie in the count —
+	// and it would mask a caller that lost track of its run id.
+	if owner == "" {
+		return 0, nil
+	}
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE memory_cursors SET leased_by = '', lease_expires_at = NULL, updated_at = ?
+		 WHERE leased_by = ?`,
+		time.Now().UnixNano(), owner,
+	)
+	if err != nil {
+		return 0, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return int(n), nil
+}
+
 // ---- v0.8.4 Channel tool ----
 //
 // All five methods are single-table operations against

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2022,6 +2022,21 @@ type Store interface {
 	// clean no-op. The watermark is untouched.
 	MemoryCursorRelease(ctx context.Context, tenantID string, scope MemoryScope, scopeID, owner string) error
 
+	// MemoryCursorReleaseByOwner clears every lease held by owner, whatever
+	// target it is on, and reports how many it freed. Called when a run reaches
+	// a terminal state, because the consolidation pass releases its own lease in
+	// a `finally` that a KILLED run never reaches — a pass stopped by its
+	// wall-clock budget, a cancel, or a crash therefore stranded the target
+	// until the lease TTL elapsed, and every pass in between refused to start.
+	//
+	// Owner-only, with no tenant argument, deliberately: a lease owner is a run
+	// id, which is globally unique, so it can match nothing but that run's own
+	// lease. Requiring the tenant would mean the caller had to know which target
+	// the run had leased, which is exactly the thing a dead run cannot tell it.
+	//
+	// Idempotent, and 0 is the ordinary answer: almost no run holds a lease.
+	MemoryCursorReleaseByOwner(ctx context.Context, owner string) (int, error)
+
 	// SupportsVectors reports whether this backend instance can serve
 	// the MemoryEmbed* family. Backends without a vector index loaded
 	// return false; the Memory tool's `search` op + `embed: true`

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -176,6 +176,7 @@ func Run(t *testing.T, factory Factory) {
 		{"MemoryCursorGetDefault", testMemoryCursorGetDefault},
 		{"MemoryCursorLeaseCAS", testMemoryCursorLeaseCAS},
 		{"MemoryCursorAdvanceMonotonicAndOwner", testMemoryCursorAdvanceMonotonicAndOwner},
+		{"MemoryCursorReleaseByOwner", testMemoryCursorReleaseByOwner},
 		{"MemoryDeleteScopeCleansConsolidationRows", testMemoryDeleteScopeCleansConsolidationRows},
 		{"MemoryOrphanScanSkipsGlobal", testMemoryOrphanScanSkipsGlobal},
 		{"MemoryOrphanRepairMovesAndIsIdempotent", testMemoryOrphanRepairMovesAndIsIdempotent},
@@ -11917,5 +11918,82 @@ func testMemoryEmbedListMissing(t *testing.T, s store.Store) {
 	} else if len(wide) != 2 {
 		t.Errorf("limit=5000 returned %d rows, want 2 — a limit over the cap must clamp "+
 			"to the cap, not fall back to the default page size", len(wide))
+	}
+}
+
+// testMemoryCursorReleaseByOwner: a run that dies without releasing its own lease
+// must not strand the target for the rest of the TTL.
+//
+// The consolidation pass releases its lease in a `finally`, which covers every
+// path its code can take — and none of the paths where the RUN is killed out from
+// under it. Freeing by owner alone is what the terminal-run hook can do, because
+// a dead run cannot say which target it had leased.
+func testMemoryCursorReleaseByOwner(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	// One owner, TWO targets, plus a third target held by somebody else — so this
+	// asserts both halves: everything the owner holds is freed, and nothing that
+	// belongs to another owner is touched.
+	for _, scopeID := range []string{"rbo-one", "rbo-two"} {
+		if _, ok, err := s.MemoryCursorLease(ctx, "", store.MemoryScopeAgent, scopeID, "run-dead", now, time.Hour); err != nil || !ok {
+			t.Fatalf("lease %s: acquired=%v err=%v", scopeID, ok, err)
+		}
+	}
+	if _, ok, err := s.MemoryCursorLease(ctx, "", store.MemoryScopeAgent, "rbo-other", "run-alive", now, time.Hour); err != nil || !ok {
+		t.Fatalf("lease rbo-other: acquired=%v err=%v", ok, err)
+	}
+
+	freed, err := s.MemoryCursorReleaseByOwner(ctx, "run-dead")
+	if err != nil {
+		t.Fatalf("MemoryCursorReleaseByOwner: %v", err)
+	}
+	if freed != 2 {
+		t.Errorf("freed = %d, want 2 (both of the dead run's targets)", freed)
+	}
+
+	// Both of its targets are now acquirable by a fresh run, WITHOUT waiting out
+	// the hour-long TTL. This is the property the fix exists for.
+	for _, scopeID := range []string{"rbo-one", "rbo-two"} {
+		row, ok, err := s.MemoryCursorLease(ctx, "", store.MemoryScopeAgent, scopeID, "run-next", time.Now().UTC(), time.Hour)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ok || row.LeasedBy != "run-next" {
+			t.Errorf("%s after release: acquired=%v leasedBy=%q, want true/run-next", scopeID, ok, row.LeasedBy)
+		}
+	}
+
+	// The other owner's lease survived untouched — releasing by owner must not be
+	// a way to steal a live lease.
+	if _, ok, err := s.MemoryCursorLease(ctx, "", store.MemoryScopeAgent, "rbo-other", "run-thief", time.Now().UTC(), time.Hour); err != nil {
+		t.Fatal(err)
+	} else if ok {
+		t.Error("another owner's live lease was released too")
+	}
+
+	// Idempotent, and an empty owner is a no-op rather than a mass release: '' is
+	// what an UNLEASED row stores in leased_by, so a naive WHERE would match all
+	// of them.
+	if freed, err := s.MemoryCursorReleaseByOwner(ctx, "run-dead"); err != nil || freed != 0 {
+		t.Errorf("second release: freed=%d err=%v, want 0/nil", freed, err)
+	}
+	// For the empty-owner check to mean anything there must BE an unleased row for
+	// a naive `WHERE leased_by = ''` to match — otherwise the assertion passes
+	// against the unguarded query too. Plant one by leasing and releasing properly.
+	if _, ok, err := s.MemoryCursorLease(ctx, "", store.MemoryScopeAgent, "rbo-idle", "run-tidy", time.Now().UTC(), time.Hour); err != nil || !ok {
+		t.Fatalf("lease rbo-idle: acquired=%v err=%v", ok, err)
+	}
+	if err := s.MemoryCursorRelease(ctx, "", store.MemoryScopeAgent, "rbo-idle", "run-tidy"); err != nil {
+		t.Fatalf("release rbo-idle: %v", err)
+	}
+	if freed, err := s.MemoryCursorReleaseByOwner(ctx, ""); err != nil || freed != 0 {
+		t.Errorf("empty owner: freed=%d err=%v, want 0/nil — '' is what an UNLEASED row stores, so a naive WHERE matches every one of them", freed, err)
+	}
+	// And the empty-owner call did not disturb the live lease either.
+	if _, ok, err := s.MemoryCursorLease(ctx, "", store.MemoryScopeAgent, "rbo-other", "run-thief2", time.Now().UTC(), time.Hour); err != nil {
+		t.Fatal(err)
+	} else if ok {
+		t.Error("an empty-owner release freed a live lease")
 	}
 }


### PR DESCRIPTION
## Why

The consolidation pass releases its lease in a `finally`, which covers every path its own code can take — and none of the paths where the **run** is killed out from under it. The owner of a lease is the run id and `cursor_release` is ownership-scoped, so a dead run can never hand its lease back and nothing else is permitted to. The target stayed leased until the TTL elapsed, and every pass that fired in between refused to start.

**Measured on the LoCoMo benchmark deployment**, from the event log:

```
14:21:46  pass r_72753d takes the lease, spawns extractor r_47ed1f
          → neither run emits a `done` event in the next two hours
~14:46:46 parent exhausts run_timeout_seconds (1500s), killed —
          the `finally` never runs
14:51:46  its 30-minute lease finally expires on its own

14:22:18 … 14:50:19   TEN passes bail "target busy, nothing read, nothing
                      written" — a harness poll every 3 minutes across a
                      window where nothing was actually running
```

Note the shape: `run_timeout_seconds` is deliberately *below* `lease_ttl_ms` so a live pass can never be stolen from — which means a killed pass is guaranteed to leave a stranded lease, every time.

## What

`MemoryCursorReleaseByOwner(owner)` frees every lease a run holds, called from `finishRunWithCancel` — the terminal path for every run — as a deferred, best-effort hook that logs only when it actually freed something. A run holding no lease frees 0 rows, which is nearly every run.

Three deliberate choices:

- **Owner-only, no tenant argument.** A lease owner is a run id and therefore globally unique, so matching on it alone cannot reach another run's lease. Requiring the tenant would mean the caller had to know which target the run had leased — exactly what a dead run cannot tell it.
- **Not gated on `IsTopLevel`**, unlike the ephemeral-volume purge beside it. A lease belongs to whichever run acquired it, and nothing stops a consolidator running as a sub-agent.
- **An empty owner is a no-op**, because `''` is what an *unleased* row stores in `leased_by` — a naive predicate would "release" every one of them.

This doesn't remove the TTL's job; it remains the backstop for a process that dies without reaching any Go cleanup. It removes the case where the runtime **knew** the run was over and let the lease sit anyway.

## One existing test changed its fixture — and that's the point

`TestConsolidationEval_WatermarkAdvancesAndLeaseExcludesASecondPass` simulated a concurrent holder by running a pass whose script skipped the release leg — its comment: *"the shape of a pass still in flight (or one whose process died holding the lease)"*. That is no longer a way to hold a lease: the run reaches terminal and the new hook reclaims it.

Its own anti-vacuity guard caught this (`pass A left no lease held; the exclusion assertion below would be vacuous`) rather than the exclusion assertions silently passing — worth noting as the guard earning its keep. The lease is now granted to a **live third-party owner** directly, which is also the truer fixture: the test is about a *non-owner* being refused, so the owner it compares against should be unambiguously alive. Every downstream assertion is unchanged.

## Tested

`go test ./...` clean — 92 packages, zero failures in the full unpiped output.

A store-contract case (runs against **both** backends) asserts three properties, each verified to fail on a matching revert:

| reverted | observed failure |
|---|---|
| release becomes a no-op | `freed = 0, want 2` + `rbo-one after release: acquired=false leasedBy="run-dead"` |
| drop the empty-owner guard | `empty owner: freed=1, want 0` |

That second one **was vacuous on the first attempt** — at that point in the test no row had `leased_by = ''` for the unguarded query to match, so it passed against the broken code. It now plants an unleased row first (lease, then release properly) so the assertion has something to observe. Same failure mode as the dedup assertion in #1062: the layer below already provided the property.

A server-side test exercises the hook against a **real store** rather than a double, because the entire content of the fix is the SQL predicate — a double that recorded the call would pass whatever the predicate did.

## Not in this PR

The other half of the root cause: **a spawned LLM child has no wall-clock bound.** `run_timeout_seconds` is documented as "Ignored by LLM agents", and `Agent.spawn` blocks until the child parks with no timeout parameter (only the resident `send`/`poll` ops take one). So one wedged extractor consumes the parent's entire budget — `ollama-local`'s 600s idle timeout doesn't help, because a response that trickles tokens never goes idle. That needs its own change and probably its own discussion about spawn semantics on timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8