### PR TITLE
fix(memory): the ontologist named its own tool in lowercase and never ran

### DIFF
--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -2761,25 +2761,27 @@ agents:
 
       ## What to do
 
-      Every call needs an `op`. You have about eight calls; spend them like this.
+      Every call needs an `op`, and the tool is named `Document` with a capital D —
+      tool dispatch is an exact-match lookup, so `document` is not found at all.
+      You have about eight calls; spend them like this.
 
       1. Find which types the FACTS carry. Only the join matters — the `type`
          column is shared with ordinary document chunks, and those are not
          entity types:
-         `document` op=query_chunks scope=user
+         `Document` op=query_chunks scope=user
          sql: SELECT coalesce(c.type,'(none)') AS t, count(*) AS n FROM chunks c
               JOIN chunk_memory_meta m ON m.chunk_id = c.id
               GROUP BY 1 ORDER BY 2 DESC LIMIT 50
       2. If that returns a handful of rows, there is little to curate — say so
          and stop. Otherwise read a sample of ONE type worth looking into
          (at most two of these):
-         `document` op=query_chunks scope=user
+         `Document` op=query_chunks scope=user
          sql: SELECT c.title FROM chunks c JOIN chunk_memory_meta m ON m.chunk_id = c.id
               WHERE c.type = 'event' LIMIT 30
          (`title` and `type` are the readable columns. There is no `fields` or
          `body` column — a chunk's text is not in this table.)
       3. File at most THREE suggestions, best first, with
-         `document` op=propose_entity — name, optional parent, body.
+         `Document` op=propose_entity — name, optional parent, body.
 
       ## What makes a good suggestion
 

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -2761,25 +2761,27 @@ agents:
 
       ## What to do
 
-      Every call needs an `op`. You have about eight calls; spend them like this.
+      Every call needs an `op`, and the tool is named `Document` with a capital D —
+      tool dispatch is an exact-match lookup, so `document` is not found at all.
+      You have about eight calls; spend them like this.
 
       1. Find which types the FACTS carry. Only the join matters — the `type`
          column is shared with ordinary document chunks, and those are not
          entity types:
-         `document` op=query_chunks scope=user
+         `Document` op=query_chunks scope=user
          sql: SELECT coalesce(c.type,'(none)') AS t, count(*) AS n FROM chunks c
               JOIN chunk_memory_meta m ON m.chunk_id = c.id
               GROUP BY 1 ORDER BY 2 DESC LIMIT 50
       2. If that returns a handful of rows, there is little to curate — say so
          and stop. Otherwise read a sample of ONE type worth looking into
          (at most two of these):
-         `document` op=query_chunks scope=user
+         `Document` op=query_chunks scope=user
          sql: SELECT c.title FROM chunks c JOIN chunk_memory_meta m ON m.chunk_id = c.id
               WHERE c.type = 'event' LIMIT 30
          (`title` and `type` are the readable columns. There is no `fields` or
          `body` column — a chunk's text is not in this table.)
       3. File at most THREE suggestions, best first, with
-         `document` op=propose_entity — name, optional parent, body.
+         `Document` op=propose_entity — name, optional parent, body.
 
       ## What makes a good suggestion
 

--- a/cmd/loomcycle/presets_tool_names_test.go
+++ b/cmd/loomcycle/presets_tool_names_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestBundlePrompts_NameToolsExactly.
+//
+// Tool dispatch is an exact-match map lookup (tools.Dispatcher.Execute does
+// `d.tools[name]`), so a system prompt that instructs a model to call `document`
+// when the registered tool is `Document` does not degrade — it fails outright with
+// "tool not found: document" on the FIRST call, and the model then spends its whole
+// budget reasoning about which tools it has.
+//
+// That is exactly what memory/ontologist did on a live deployment: three lowercase
+// `document` op=… instructions, a failed first call, and 1,937 output tokens of the
+// model concluding its tools were missing. The def granted the tool correctly; only
+// the prompt's spelling was wrong, which is why nothing caught it — the ACL is
+// checked, the prose is not.
+//
+// So: any bundle prompt that writes `name` op=… must spell a name some agent in that
+// bundle is actually granted. Scoped to that backticked-name-plus-op shape rather
+// than every mention of a word, because "ordinary document chunks" is legitimate
+// prose in the same paragraph.
+func TestBundlePrompts_NameToolsExactly(t *testing.T) {
+	// The backticked call form the bundles use to teach a tool call.
+	callForm := regexp.MustCompile("`([A-Za-z_][A-Za-z0-9_]*)` op=")
+
+	roots := []string{filepath.Join("..", "..", "bundles"), filepath.Join("embedded", "bundles")}
+	checked := 0
+	for _, root := range roots {
+		_ = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+			if err != nil || info.IsDir() || !strings.HasSuffix(path, ".yaml") {
+				return nil
+			}
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+			var doc struct {
+				Agents map[string]struct {
+					Tools        []string `yaml:"tools"`
+					SystemPrompt string   `yaml:"system_prompt"`
+				} `yaml:"agents"`
+			}
+			if err := yaml.Unmarshal(raw, &doc); err != nil {
+				return nil // not an agent bundle
+			}
+			for name, def := range doc.Agents {
+				if def.SystemPrompt == "" {
+					continue
+				}
+				granted := map[string]bool{}
+				for _, tl := range def.Tools {
+					granted[tl] = true
+				}
+				for _, m := range callForm.FindAllStringSubmatch(def.SystemPrompt, -1) {
+					checked++
+					if !granted[m[1]] {
+						t.Errorf("%s: agent %q instructs `%s` op=… but its tools are %v — dispatch is "+
+							"exact-match, so that call returns \"tool not found: %s\" and the agent "+
+							"never gets started",
+							filepath.Base(path), name, m[1], def.Tools, m[1])
+					}
+				}
+			}
+			return nil
+		})
+	}
+	// Guard the guard: if the call form ever stops matching, this test would pass by
+	// examining nothing at all.
+	if checked == 0 {
+		t.Fatal("no `name` op=… instructions found in any bundle prompt — the pattern no longer matches, so this test asserts nothing")
+	}
+	t.Logf("checked %d tool-call instructions across the bundles", checked)
+}


### PR DESCRIPTION
## What was happening

`memory/ontologist` failed its **first** tool call on every run, then spent the rest of its budget reasoning about which tools it had. From a live pass:

```
tool_call    document lc-0-0 {"op":"query_chunks",...}
tool_result  tool not found: document
text         (1,937 output tokens concluding the Document tool was missing,
              and hallucinating `generate_tool_suggestion` / `search`)
```

**The def is fine.** It grants `tools: [Document]`. The *prompt* told the model to call `` `document` `` — lowercase, three times — and tool dispatch is an exact-match map lookup (`tools.Dispatcher.Execute` does `d.tools[name]`), so the call never reached the tool and never could.

Nothing caught it because the two halves are checked by different things and neither checks the pair: the ACL is validated at config load, the prose isn't validated at all. The agent looked correctly configured in every listing, and the only symptom was a curator that produced confident nonsense.

## The fix

Spell the registered name, and say *why* in the prompt's own one-line reminder so a later edit doesn't quietly undo it.

## Regression guard

`TestBundlePrompts_NameToolsExactly` scans every bundle agent's system prompt for the backticked `` `name` op=… `` form the bundles use to teach a tool call, and asserts the name is one that agent is actually granted.

Two deliberate details:

- **Scoped to that call form**, not to every mention of a word — "ordinary document chunks" is legitimate prose in the very same paragraph.
- **It fails when the pattern matches nothing**, so it can't pass by examining zero instructions. It currently checks 6.

Verified by restoring the lowercase name; the test reports the live failure verbatim:

```
agent "memory/ontologist" instructs `document` op=… but its tools are [Document]
— dispatch is exact-match, so that call returns "tool not found: document"
```

## Tested

`go test ./...` clean. Both bundle copies byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8