### PR TITLE
fix(memory): recall could not see notes — the selector was dropped and the default excluded them

### DIFF
--- a/internal/memory/backend.go
+++ b/internal/memory/backend.go
@@ -132,7 +132,10 @@ type SearchQuery struct {
 type Source string
 
 const (
-	// SourceFacts is the agent's own memory: consolidated facts and notes it wrote.
+	// SourceFacts is memory a consolidator DISTILLED — it has provenance, so a
+	// server-known writer stands behind it. It does NOT include notes; that
+	// predates the facts/notes split and reading it that way is what let recall's
+	// default drop every directly-written row.
 	SourceFacts Source = "facts"
 	// SourceNotes is memory an agent wrote directly with `set` — no provenance, so no
 	// server-known writer distilled it.

--- a/internal/memory/backends/inprocess/inprocess.go
+++ b/internal/memory/backends/inprocess/inprocess.go
@@ -496,7 +496,17 @@ func (b *Backend) Recall(ctx context.Context, scope store.MemoryScope, scopeID s
 	// record this" across both planes.
 	sources := q.Sources
 	if len(sources) == 0 {
-		sources = []memory.Source{memory.SourceFacts}
+		// FACTS **AND NOTES** — the agent's own memory, both halves. Documents stay
+		// out, which is the whole point of the paragraph above.
+		//
+		// This used to be facts alone, which contradicted the op's own input schema
+		// ("recall defaults to facts+notes") and silently hid every row an agent had
+		// written with `set`: those carry no provenance, so ClassifyMemoryRow calls
+		// them notes. A scope holding 419 such rows answered a bare recall with
+		// nothing. The facts/notes split arrived after this default was written and
+		// this line was never revisited — before the split, "facts" WAS the whole of
+		// the agent's own memory.
+		sources = []memory.Source{memory.SourceFacts, memory.SourceNotes}
 	}
 	res, err := b.Search(ctx, scope, scopeID,
 		memory.SearchQuery{QueryText: q.Query, TopK: topK, Sources: sources},

--- a/internal/memory/backends/inprocess/inprocess_test.go
+++ b/internal/memory/backends/inprocess/inprocess_test.go
@@ -108,6 +108,11 @@ type vectorStore struct {
 	store.Store
 	mu     sync.Mutex
 	embeds map[string]store.MemoryEmbedding
+	// origins is the row provenance the REAL stores keep in the memory table's
+	// origin column and return on MemorySearchEntry.Origin. MemoryEntry does not
+	// expose it, so a double reading rows back cannot recover it — it has to be
+	// recorded on the way in. Absent = a NOTE, which is what a plain `set` writes.
+	origins map[string]string
 	// extra, when non-nil, is appended to every MemoryEmbedSearch result verbatim
 	// — a hook for the dead-link tests to inject an ORPHAN hit (an embedding row
 	// whose backing k/v body is gone, surfaced as an empty Value) that the real
@@ -116,7 +121,8 @@ type vectorStore struct {
 }
 
 func newVectorStore(s store.Store) *vectorStore {
-	return &vectorStore{Store: s, embeds: map[string]store.MemoryEmbedding{}}
+	return &vectorStore{Store: s, embeds: map[string]store.MemoryEmbedding{},
+		origins: map[string]string{}}
 }
 
 func vsKey(scope store.MemoryScope, id, key string) string {
@@ -165,7 +171,27 @@ func (v *vectorStore) MemoryEmbedSearch(ctx context.Context, _ string, scope sto
 		if err != nil {
 			continue
 		}
+		// HONOUR THE TWO FILTER DIMENSIONS BEYOND KeyPrefix. Without these the
+		// double silently ignores every source selector, so a test could not tell
+		// facts from notes or exclude documents — which is exactly how a
+		// facts-only recall default survived unnoticed while the schema promised
+		// facts+notes. The real stores apply both in SQL.
+		origin := v.origins[vsKey(scope, id, r.key)]
+		switch filter.Provenance {
+		case store.ProvenanceRequired:
+			if strings.TrimSpace(origin) == "" {
+				continue // a note: no known writer distilled it
+			}
+		case store.ProvenanceAbsent:
+			if strings.TrimSpace(origin) != "" {
+				continue // a fact
+			}
+		}
+		if filter.ExcludeKeyPrefix != "" && strings.HasPrefix(r.key, filter.ExcludeKeyPrefix) {
+			continue
+		}
 		se := store.MemorySearchEntry{MemoryEntry: entry, Score: r.s}
+		se.Origin = origin
 		se.EmbeddedWith.Provider = r.emb.Provider
 		se.EmbeddedWith.Model = r.emb.Model
 		// Hand back the stored vector so the in-process backend's MR-5 dedup
@@ -762,5 +788,77 @@ func TestInprocess_Recall_RefusesWithoutVectorStack(t *testing.T) {
 	_, err := b.Recall(context.Background(), store.MemoryScopeUser, "u1", memory.RecallQuery{Query: "x"})
 	if !errors.Is(err, store.ErrVectorUnsupported) {
 		t.Fatalf("Recall on a no-vector store: err = %v, want ErrVectorUnsupported (fail honest, not empty)", err)
+	}
+}
+
+// seedEmbeddedNote writes one row straight to the k/v plane with an embedding and
+// NO origin — which is what makes it a NOTE rather than a fact. Deliberately not
+// via Backend.Add: that path stamps store.PendingOriginAgentExplicit, so a row
+// planted through it classifies as a fact and could not exercise the notes filter
+// at all.
+func seedEmbeddedNote(t *testing.T, st *vectorStore, emb *fakeEmbedder, scope store.MemoryScope, id, key, text string) {
+	t.Helper()
+	ctx := context.Background()
+	raw, err := json.Marshal(text)
+	if err != nil {
+		t.Fatalf("marshal note: %v", err)
+	}
+	if err := st.MemorySet(ctx, "", scope, id, key, raw, 0); err != nil {
+		t.Fatalf("MemorySet(%s): %v", key, err)
+	}
+	vecs, err := emb.Embed(ctx, []string{text})
+	if err != nil || len(vecs) != 1 {
+		t.Fatalf("embed note: %v", err)
+	}
+	if err := st.MemoryEmbedSet(ctx, "", scope, id, key, store.MemoryEmbedding{
+		Provider: emb.Provider(), Model: emb.Model(), Dimension: len(vecs[0]), Vector: vecs[0],
+	}); err != nil {
+		t.Fatalf("MemoryEmbedSet(%s): %v", key, err)
+	}
+}
+
+// TestInprocess_Recall_DefaultIncludesNotes is the bug the LoCoMo answer axis hit:
+// a scope holding 419 directly-written rows answered a bare recall with NOTHING.
+//
+// A row written with `set` carries no provenance, so ClassifyMemoryRow calls it a
+// NOTE. Recall's default source set was facts alone, which excluded every one of
+// them — while the op's own input schema promised "recall defaults to facts+notes".
+// The facts/notes split landed after that default was written and the line was
+// never revisited: before the split, "facts" WAS the whole of the agent's memory.
+//
+// Documents stay excluded, which is the separate and still-correct reason the
+// default exists at all (a horizontal rule outranking the fact holding an answer).
+func TestInprocess_Recall_DefaultIncludesNotes(t *testing.T) {
+	b, st, emb, cleanup := vectorFixture(t)
+	defer cleanup()
+	ctx := context.Background()
+	scope, id := store.MemoryScopeUser, "u1"
+
+	// A NOTE: written straight to the k/v plane with an embedding and no origin,
+	// exactly as an off-run PUT or an agent's own `set` does.
+	seedEmbeddedNote(t, st, emb, scope, id, "turn-1", "alice bought a clay pot")
+
+	res, err := b.Recall(ctx, scope, id, memory.RecallQuery{Query: "clay pot", TopK: 5})
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	if len(res.Facts) == 0 {
+		t.Fatal("a bare recall returned nothing for a scope of notes — this is the defect: " +
+			"the schema promises facts+notes, and a row written with `set` is a note")
+	}
+	if !strings.Contains(res.Facts[0].Memory, "clay pot") {
+		t.Errorf("recalled %q, want the seeded note", res.Facts[0].Memory)
+	}
+
+	// And an EXPLICIT notes selector reaches it too — the other half of the same
+	// bug lived in the tool's parseSources, which dropped "notes" outright.
+	res, err = b.Recall(ctx, scope, id, memory.RecallQuery{
+		Query: "clay pot", TopK: 5, Sources: []memory.Source{memory.SourceNotes},
+	})
+	if err != nil {
+		t.Fatalf("Recall(sources=[notes]): %v", err)
+	}
+	if len(res.Facts) == 0 {
+		t.Error("recall with an explicit sources=[notes] returned nothing")
 	}
 }

--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -1128,6 +1128,17 @@ func parseSources(in []string) []memrank.Source {
 		switch memrank.Source(strings.ToLower(strings.TrimSpace(s))) {
 		case memrank.SourceFacts:
 			out = append(out, memrank.SourceFacts)
+		case memrank.SourceNotes:
+			// WAS MISSING, and the failure was silent in two opposite directions.
+			// "notes" is in this op's own input-schema enum, so a caller had every
+			// reason to pass it — and an unknown value is DROPPED by design (see the
+			// doc above), which turned an explicit selector into no selector. On
+			// `search` that widened the result set to everything and looked like it
+			// worked; on `recall` it fell through to the facts-only default and
+			// returned nothing at all. Measured: a scope holding 419 embedded notes
+			// answered `recall sources=["notes"]` with zero rows while
+			// `search sources=["notes"]` returned three.
+			out = append(out, memrank.SourceNotes)
 		case memrank.SourceDocuments:
 			out = append(out, memrank.SourceDocuments)
 		}

--- a/internal/tools/builtin/memory_sources_test.go
+++ b/internal/tools/builtin/memory_sources_test.go
@@ -1,0 +1,81 @@
+package builtin
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+	"testing"
+
+	memrank "github.com/denn-gubsky/loomcycle/internal/memory"
+)
+
+// TestParseSources_AcceptsEverySourceInItsOwnSchema.
+//
+// The bug this pins: `notes` was in this op's input-schema enum and absent from
+// the parser's switch. Unknown values are DROPPED by design (documented on
+// parseSources, and right — rejecting would break an older runtime against a
+// newer value name), so an explicit `sources:["notes"]` became NO selector, and
+// that failed in two opposite directions from one cause: `search` widened to
+// everything and looked correct, while `recall` fell through to its facts-only
+// default and returned nothing.
+//
+// So the invariant is: the parser must accept every value the schema advertises.
+// Driven off the schema text rather than a hand-written list, because a
+// hand-written list is the same kind of second copy that broke in the first place.
+func TestParseSources_AcceptsEverySourceInItsOwnSchema(t *testing.T) {
+	enum := regexp.MustCompile(`"sources":\s*\{[^}]*"enum":\s*\[([^\]]*)\]`).
+		FindStringSubmatch(memoryInputSchema)
+	if enum == nil {
+		t.Fatal("could not find the sources enum in memoryInputSchema — this test asserts nothing until the pattern matches again")
+	}
+	var advertised []string
+	for _, raw := range strings.Split(enum[1], ",") {
+		if v := strings.Trim(strings.TrimSpace(raw), `"`); v != "" {
+			advertised = append(advertised, v)
+		}
+	}
+	if len(advertised) < 3 {
+		t.Fatalf("expected at least facts/notes/documents in the schema enum, got %v", advertised)
+	}
+	for _, v := range advertised {
+		got := parseSources([]string{v})
+		if len(got) != 1 || string(got[0]) != v {
+			t.Errorf("parseSources([%q]) = %v — the schema advertises %q, so a caller passing it "+
+				"gets it SILENTLY DROPPED, which turns an explicit selector into no selector", v, got, v)
+		}
+	}
+}
+
+// TestParseSources_MatchesTheHTTPParser is the drift guard. Two hand-maintained
+// copies of the same vocabulary exist — this one for the in-band tool and
+// parseMemorySources for POST /v1/_memory/search — and they DID drift: the HTTP
+// one handled notes, this one did not, so the same selector meant different things
+// depending on which surface a caller used. Compared through the shared Source
+// constants so adding a fourth kind fails here until both are updated.
+func TestParseSources_MatchesTheHTTPParser(t *testing.T) {
+	for _, s := range []memrank.Source{memrank.SourceFacts, memrank.SourceNotes, memrank.SourceDocuments} {
+		got := parseSources([]string{string(s)})
+		if len(got) != 1 || got[0] != s {
+			t.Errorf("parseSources([%q]) = %v, want [%q] — the HTTP parser accepts it and this one must too",
+				s, got, s)
+		}
+	}
+	// Casing and padding are normalised, matching the HTTP side.
+	if got := parseSources([]string{"  NOTES  "}); len(got) != 1 || got[0] != memrank.SourceNotes {
+		t.Errorf("parseSources([\"  NOTES  \"]) = %v, want [notes]", got)
+	}
+	// An unknown value is still dropped rather than rejected — deliberate, and the
+	// reason the missing case was invisible. Kept so the fix does not change it.
+	if got := parseSources([]string{"facts", "not-a-source"}); len(got) != 1 || got[0] != memrank.SourceFacts {
+		t.Errorf("parseSources with an unknown value = %v, want just [facts]", got)
+	}
+}
+
+// TestMemoryInputSchema_SourcesEnumIsValidJSON guards the guard above: if the
+// schema stops being parseable the first test fails loudly rather than skipping.
+func TestMemoryInputSchema_SourcesEnumIsValidJSON(t *testing.T) {
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(memoryInputSchema), &doc); err != nil {
+		t.Fatalf("memoryInputSchema is not valid JSON: %v", err)
+	}
+}


### PR DESCRIPTION
`Memory op=recall` returned **nothing** on a scope holding 419 embedded rows, while `op=search` returned three hits for the same query in the same partition:

```
search sources=[notes]        → 3 results (cosine 0.546, 0.539…)
recall sources=[notes]        → 0
recall sources=[facts,notes]  → 0
recall (no sources)           → 0
```

Two independent defects, either of which alone produces that.

## Defect 1 — the in-band parser silently dropped `notes`

`parseSources` in `internal/tools/builtin/memory.go` had cases for `facts` and `documents` and **none for `notes`** — while the op's own input-schema enum advertises `["facts","notes","documents"]`.

Unknown values are dropped by design (rejecting would break an older runtime against a newer value name — that's the right call), so an explicit `sources:["notes"]` became **no selector**. One cause, two opposite symptoms: `search` widened to everything and looked correct; `recall` fell through to its default and returned nothing.

The HTTP parser (`parseMemorySources`) has always handled `notes`, so the same selector meant different things depending on which surface a caller used.

## Defect 2 — recall's default excluded notes, contradicting its own schema

`inprocess.Recall` defaulted to `[]Source{SourceFacts}`. The schema says *"recall defaults to facts+notes"*. A row written with `set` (or an off-run PUT) carries no provenance, so `ClassifyMemoryRow` calls it a **note** — and the default hid every one of them.

The facts/notes split landed *after* that default was written and the line was never revisited: before the split, "facts" was the whole of an agent's own memory. Documents stay excluded, which is the separate and still-correct reason the default exists (a horizontal rule outranking the fact holding an answer).

I also corrected the `SourceFacts` doc comment, which still described facts as including notes — reading it that way is what made defect 2 look intentional.

## How it surfaced

The LoCoMo answer axis. An answerer whose prompt says `op=recall` scored **0.0000** with a **94% abstention rate** over 419 embedded conversation turns. Pointed at `op=search` — which, by accident of defect 1, applied no filter at all — the same store, same embedder, same questions scored **0.7353** with zero abstentions.

## The test double could not have caught this, and that's fixed too

The inprocess fixture's `vectorStore` honoured only `filter.KeyPrefix`. It ignored `filter.Provenance` and `filter.ExcludeKeyPrefix`, and never populated `MemorySearchEntry.Origin`. So **no test in that package could distinguish a fact from a note or exclude a document** — source filtering was structurally untestable there.

The double now records each row's origin on the way in (the real stores keep it in a column `MemoryEntry` doesn't expose, so a double reading rows back can't recover it), applies both filter dimensions, and carries `Origin` through.

## Tested

`go test ./...` clean — 92 packages. Each fix verified to fail on its own revert:

| reverted | observed failure |
|---|---|
| remove the `notes` case | `parseSources(["notes"]) = [] — … gets it SILENTLY DROPPED` (both parser tests) |
| recall default → facts-only | `a bare recall returned nothing for a scope of notes` |

**Worth recording: the second fail-before initially PASSED.** The assertion was vacuous precisely *because* the double ignored the filter — making the double faithful is what turned it into a regression test. Same failure mode I hit twice earlier in this line of work: an assertion that can't observe the thing it names.

The parser tests are driven off the schema enum and off the shared `Source` constants rather than a hand-written list, because a hand-written list is the same kind of second copy that drifted here in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8