### PR TITLE
fix(memory): recall told the model every row was a fact, and carried no kind

### DIFF
--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -2015,7 +2015,13 @@ agents:
           st.recall_unavailable = true;
           return [];
         }
-        return (res && res.facts) ? res.facts : [];
+        // `memories` is the current key; `facts` is what recall emitted before the
+        // rename. Both are read because a code-js body REPLAYS against tool results
+        // recorded earlier in the same run, so a pass that survives a version change
+        // would otherwise read undefined and silently recall nothing — and a
+        // consolidator that recalls nothing writes a duplicate instead of merging.
+        var rows = res ? (res.memories || res.facts) : null;
+        return rows ? rows : [];
       }
 
       // --------------------------------------------------------------- report

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -2015,7 +2015,13 @@ agents:
           st.recall_unavailable = true;
           return [];
         }
-        return (res && res.facts) ? res.facts : [];
+        // `memories` is the current key; `facts` is what recall emitted before the
+        // rename. Both are read because a code-js body REPLAYS against tool results
+        // recorded earlier in the same run, so a pass that survives a version change
+        // would otherwise read undefined and silently recall nothing — and a
+        // consolidator that recalls nothing writes a duplicate instead of merging.
+        var rows = res ? (res.memories || res.facts) : null;
+        return rows ? rows : [];
       }
 
       // --------------------------------------------------------------- report

--- a/docs/MEMORY-BACKENDS.md
+++ b/docs/MEMORY-BACKENDS.md
@@ -150,7 +150,10 @@ may instead extract facts server-side with its own LLM.
 
 // recall stored memories by meaning
 {"op": "recall", "scope": "user", "query": "ui preferences", "top_k": 5}
-// → {"facts": [{"id": "mem_ab12…", "memory": "user prefers dark mode", "score": 0.91}]}
+// → {"memories": [{"id": "mem_ab12…", "memory": "user prefers dark mode",
+//                  "score": 0.91, "kind": "fact"}]}
+// kind is "fact" (a consolidator distilled it), "note" (an agent wrote it
+// directly) or absent when the backend cannot classify its own rows.
 ```
 
 `recall` needs the vector stack (an embedder + a vector-capable store);

--- a/internal/memory/backends/inprocess/inprocess.go
+++ b/internal/memory/backends/inprocess/inprocess.go
@@ -523,6 +523,9 @@ func (b *Backend) Recall(ctx context.Context, scope store.MemoryScope, scopeID s
 			ID:     e.Key,
 			Memory: recallText(e.Value),
 			Score:  e.Score,
+			// Classified by the SAME function the source selector filtered on, so the
+			// rendered kind cannot disagree with what `sources` admitted.
+			Kind: memory.Class(e),
 		})
 	}
 	if len(facts) > topK {

--- a/internal/memory/backends/inprocess/inprocess_test.go
+++ b/internal/memory/backends/inprocess/inprocess_test.go
@@ -862,3 +862,47 @@ func TestInprocess_Recall_DefaultIncludesNotes(t *testing.T) {
 		t.Error("recall with an explicit sources=[notes] returned nothing")
 	}
 }
+
+// TestInprocess_Recall_ClassifiesEachRow pins the class onto every recalled row.
+//
+// The Memory tool's input schema has always promised that "each result carries a
+// matching kind". `search` delivered it; recall returned {id, memory, score} and
+// nothing else, so a caller had no way to tell a consolidator-distilled fact from a
+// remark an agent had jotted down — while the array wrapping them was called
+// "facts". The class is already computed to APPLY the source selector, so the only
+// thing missing was carrying it out to the caller.
+func TestInprocess_Recall_ClassifiesEachRow(t *testing.T) {
+	b, st, emb, cleanup := vectorFixture(t)
+	defer cleanup()
+	ctx := context.Background()
+	scope, id := store.MemoryScopeUser, "u1"
+
+	// A NOTE (no origin) and a FACT (origin present) that both match the query, so
+	// one recall returns both classes and a constant would be visible as wrong.
+	seedEmbeddedNote(t, st, emb, scope, id, "turn-1", "alice bought a clay pot")
+	seedEmbeddedNote(t, st, emb, scope, id, "fact-1", "alice collects clay pottery")
+	st.origins[vsKey(scope, id, "fact-1")] = "consolidator"
+
+	res, err := b.Recall(ctx, scope, id, memory.RecallQuery{Query: "clay pot", TopK: 5})
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	if len(res.Facts) != 2 {
+		t.Fatalf("recalled %d rows, want the note and the fact: %+v", len(res.Facts), res.Facts)
+	}
+	got := map[string]store.MemoryRowClass{}
+	for _, f := range res.Facts {
+		if f.Kind == "" {
+			t.Errorf("row %q carries no kind — the schema promises one on every result", f.ID)
+		}
+		got[f.ID] = f.Kind
+	}
+	if got["turn-1"] != store.MemoryRowNote {
+		t.Errorf("turn-1 kind = %q, want %q: a row with no provenance is a note",
+			got["turn-1"], store.MemoryRowNote)
+	}
+	if got["fact-1"] != store.MemoryRowFact {
+		t.Errorf("fact-1 kind = %q, want %q: a row a consolidator wrote is a fact",
+			got["fact-1"], store.MemoryRowFact)
+	}
+}

--- a/internal/memory/layer.go
+++ b/internal/memory/layer.go
@@ -157,9 +157,23 @@ type RecallQuery struct {
 // (a UUID, NOT a caller key) — it is opaque to loomcycle and only meaningful
 // to the backend.
 type RecallFact struct {
-	ID       string            `json:"id"`
-	Memory   string            `json:"memory"`
-	Score    float64           `json:"score"`
+	ID     string  `json:"id"`
+	Memory string  `json:"memory"`
+	Score  float64 `json:"score"`
+
+	// Kind is the row's class — "fact" (a consolidator distilled it), "note" (an
+	// agent wrote it directly) or "document" (Document chunk prose). The Memory
+	// tool's own input schema has always promised that "each result carries a
+	// matching kind", and for `search` it does; recall rendered no kind at all, so
+	// a caller could not tell a distilled fact from a raw note it had jotted down
+	// — while the surrounding array called every one of them a fact.
+	//
+	// EMPTY MEANS UNKNOWN, NOT "fact". Only a backend that classifies its own rows
+	// can fill this in; a remote memory layer returning opaque server-side ids
+	// cannot, and the tool omits the field rather than assert a class it does not
+	// know. Guessing here would recreate the exact defect this closes.
+	Kind store.MemoryRowClass `json:"kind,omitempty"`
+
 	Metadata map[string]string `json:"metadata,omitempty"`
 }
 

--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -268,7 +268,7 @@ const memoryDescription = `Persistent key/value storage scoped to this agent or 
 	`Values are JSON. Optional TTL is in seconds. ` +
 	`v0.9.0: pass embed=true with embed_text on set to enable semantic search; use op=search with query to find rows by similarity. ` +
 	`v0.12.x: merge / append_dedupe / bounded_list are atomic reducers — use them instead of get-modify-set when concurrent updates are possible. ` +
-	`add / recall: add ingests conversation messages for durable memory — on the default backend it enqueues them for background consolidation and returns status "pending" (a scheduled consolidator later distils durable facts); recall is a natural-language semantic search over stored memories and needs an embedder + a vector-capable store (otherwise it returns vector_unsupported / embedder_not_configured). A backend that is not memory-layer-capable returns capability_unsupported. Unlike set/get, add does not store value-at-key and is async — do not assume read-after-write. ` +
+	`add / recall: add ingests conversation messages for durable memory — on the default backend it enqueues them for background consolidation and returns status "pending" (a scheduled consolidator later distils durable facts); recall is a natural-language semantic search over stored memories and needs an embedder + a vector-capable store (otherwise it returns vector_unsupported / embedder_not_configured). A backend that is not memory-layer-capable returns capability_unsupported. Unlike set/get, add does not store value-at-key and is async — do not assume read-after-write. recall returns {"memories": [{id, memory, score, kind}]}: each item is something REMEMBERED, not something established — a "note" is a remark an agent recorded, only a "fact" has been distilled and reconciled by a consolidator. A remembered remark often carries the time it was SAID (e.g. a leading timestamp); when it refers to "yesterday" or "last week", the event happened relative to that time and is not the timestamp itself. ` +
 	`SQL Memory (a DISTINCT capability of this tool, gated separately by the agent's sql_scopes — having Memory alone does NOT grant it): sql_query runs a read-only SELECT and sql_exec runs a single DDL/DML statement (CREATE/INSERT/UPDATE/DELETE) against a per-scope SQL database SEPARATE from the key/value memory above. Pass statement (one statement, no ATTACH/PRAGMA/load_extension/multiple statements) and optional positional args for ? placeholders. scope selects the database: agent (this agent, durable), user (this end-user, durable), or run (ephemeral, dropped when the run ends). For atomic multi-step writes, sql_begin opens a transaction for the scope, subsequent sql_exec/sql_query run on it, and sql_commit / sql_rollback finish it (it auto-rolls-back if the run ends or it is abandoned). A second sql_begin while one is open NESTS a savepoint — sql_commit/sql_rollback then affect the innermost level (the outer transaction continues on rollback); each result reports the current depth (0 = closed). Requires sql_scopes on the agent AND the server-side subsystem enabled.`
 
 const memoryInputSchema = `{
@@ -1586,19 +1586,40 @@ func (m *Memory) execRecall(ctx context.Context, scope store.MemoryScope, scopeI
 	if err != nil {
 		return errResult(fmt.Sprintf("recall: %s", err)), nil
 	}
-	facts := make([]map[string]any, 0, len(res.Facts))
+	memories := make([]map[string]any, 0, len(res.Facts))
 	for _, f := range res.Facts {
-		fact := map[string]any{
+		mem := map[string]any{
 			"id":     f.ID, // server-assigned; opaque to loomcycle, NOT a caller key
 			"memory": f.Memory,
 			"score":  f.Score,
 		}
-		if len(f.Metadata) > 0 {
-			fact["metadata"] = f.Metadata
+		// Omitted when the backend could not classify the row — see RecallFact.Kind.
+		// An absent kind means "unknown", which is why this is not defaulted.
+		if f.Kind != "" {
+			mem["kind"] = string(f.Kind)
 		}
-		facts = append(facts, fact)
+		if len(f.Metadata) > 0 {
+			mem["metadata"] = f.Metadata
+		}
+		memories = append(memories, mem)
 	}
-	out := map[string]any{"facts": facts}
+	// THE ARRAY IS "memories", NOT "facts" (it used to be "facts").
+	//
+	// Recall's default admits notes as well as distilled facts, and on a corpus of
+	// raw ingested turns EVERY row is a note — so the old key asserted, of every
+	// result, a status most of them did not have. That is not cosmetic: measured on
+	// the LoCoMo answer axis, an answerer reading the identical retrieved rows scored
+	// 0.6692 through this projection against 0.6906 through `search`'s, and the loss
+	// was concentrated in temporal questions (-8.6pp), where the model reported the
+	// TIMESTAMP OF THE UTTERANCE as the date of the event — reading a dated remark
+	// as a standing fact is exactly what "facts" invites. Retrieval was identical
+	// between the two: same keys, same order, same scores.
+	//
+	// No compatibility alias. Nothing parses this key programmatically (it is
+	// model-visible tool output, and the in-repo consumers are prose), and emitting
+	// both names would leave the misleading one in front of the model, which is the
+	// whole thing being fixed.
+	out := map[string]any{"memories": memories}
 	// A BACKEND THAT IGNORED THE SELECTOR MUST NOT LOOK LIKE ONE THAT HONOURED IT
 	// (RFC BW §6). Recall's default EXCLUDES document prose, so a backend that dropped
 	// the selector returns exactly what the default exists to keep out — and the caller
@@ -1607,7 +1628,7 @@ func (m *Memory) execRecall(ctx context.Context, scope store.MemoryScope, scopeI
 	if !res.SourcesApplied {
 		out["sources_applied"] = false
 		out["note"] = "this memory backend did not apply the source selector, so these " +
-			"results may include document prose rather than only remembered facts"
+			"results may include document prose rather than only your own remembered facts and notes"
 	}
 	return okJSON(out)
 }

--- a/internal/tools/builtin/memory_layer_test.go
+++ b/internal/tools/builtin/memory_layer_test.go
@@ -223,3 +223,82 @@ func TestMemoryTool_Add_RejectsEmptyMessages(t *testing.T) {
 		t.Errorf("empty messages should be refused with a messages error; got %s", res.Text)
 	}
 }
+
+// TestMemoryTool_Recall_RendersMemoriesNotFacts pins the projection the model reads.
+//
+// Recall's default admits notes as well as distilled facts, so on a corpus of raw
+// ingested turns EVERY row is a note — and the array was called "facts", asserting
+// of each result a status most of them did not have. Measured on the LoCoMo answer
+// axis, an answerer reading the IDENTICAL retrieved rows scored 0.6692 through this
+// projection against 0.6906 through `search`'s (same keys, same order, same scores),
+// and the gap was concentrated in temporal questions, where the model reported the
+// timestamp of the utterance as the date of the event.
+//
+// So this test guards two things at once: the honest container name, and a per-row
+// kind for the classes the backend can distinguish.
+func TestMemoryTool_Recall_RendersMemoriesNotFacts(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t)
+	defer cleanup()
+	tool.Backend = &fakeLayerBackend{recallOut: []memrank.RecallFact{
+		{ID: "turn-1", Memory: "[8 May 2023] I went yesterday", Score: 0.91, Kind: store.MemoryRowNote},
+		{ID: "f-1", Memory: "user prefers dark mode", Score: 0.77, Kind: store.MemoryRowFact},
+	}}
+
+	res, err := tool.Execute(ctx, json.RawMessage(
+		`{"op":"recall","scope":"user","query":"anything"}`))
+	if err != nil || res.IsError {
+		t.Fatalf("recall failed: err=%v res=%+v", err, res)
+	}
+	var out struct {
+		Memories []struct {
+			ID   string `json:"id"`
+			Kind string `json:"kind"`
+		} `json:"memories"`
+		Facts []json.RawMessage `json:"facts"`
+	}
+	if err := json.Unmarshal([]byte(res.Text), &out); err != nil {
+		t.Fatalf("recall output is not JSON: %v\n%s", err, res.Text)
+	}
+	if len(out.Facts) != 0 {
+		t.Errorf("recall still renders a \"facts\" array; the key is \"memories\": %s", res.Text)
+	}
+	if len(out.Memories) != 2 {
+		t.Fatalf("got %d memories, want 2: %s", len(out.Memories), res.Text)
+	}
+	byID := map[string]string{}
+	for _, m := range out.Memories {
+		byID[m.ID] = m.Kind
+	}
+	if byID["turn-1"] != string(store.MemoryRowNote) || byID["f-1"] != string(store.MemoryRowFact) {
+		t.Errorf("per-row kind not rendered (turn-1=%q f-1=%q): %s",
+			byID["turn-1"], byID["f-1"], res.Text)
+	}
+}
+
+// A backend that cannot classify its own rows — a remote memory layer handing back
+// opaque server-side ids — must yield NO kind rather than a guessed one. Defaulting
+// to "fact" here would recreate the defect the field exists to close.
+func TestMemoryTool_Recall_OmitsKindWhenBackendCannotClassify(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t)
+	defer cleanup()
+	tool.Backend = &fakeLayerBackend{recallOut: []memrank.RecallFact{
+		{ID: "mem_ab12", Memory: "user prefers dark mode", Score: 0.91}, // no Kind
+	}}
+
+	res, err := tool.Execute(ctx, json.RawMessage(`{"op":"recall","scope":"user","query":"x"}`))
+	if err != nil || res.IsError {
+		t.Fatalf("recall failed: err=%v res=%+v", err, res)
+	}
+	var out struct {
+		Memories []map[string]any `json:"memories"`
+	}
+	if err := json.Unmarshal([]byte(res.Text), &out); err != nil {
+		t.Fatalf("recall output is not JSON: %v\n%s", err, res.Text)
+	}
+	if len(out.Memories) != 1 {
+		t.Fatalf("got %d memories, want 1: %s", len(out.Memories), res.Text)
+	}
+	if k, present := out.Memories[0]["kind"]; present {
+		t.Errorf("kind = %v, but an unclassified row must omit the field entirely: %s", k, res.Text)
+	}
+}


### PR DESCRIPTION
## Why

Two defects in one projection — the JSON `Memory op=recall` puts in front of the model.

**It promised a `kind` and never sent one.** The Memory tool's input schema has always
said of `sources` that *"each result carries a matching kind"*. For `search` that is
true. For `recall` it was not: the projection rendered `{id, memory, score}` and
nothing else, so a caller could not tell a consolidator-distilled fact from a remark
an agent had jotted down from document prose. This is the same defect class as #1075,
which added `kind` to `search` and left `recall` alone.

**And it called them all facts anyway.** Recall's default admits notes as well as
facts, and on a corpus of raw ingested turns *every* row is a note — so the array name
asserted, of every result, a status most of them did not have.

That second one is not cosmetic. Running the LoCoMo answer axis twice over one corpus
(1,535 questions, same judge, same answerer model, 1,524 graded by both), changing
only which op the answerer called:

| slice | `op=search` | `op=recall` | delta |
|---|---|---|---|
| **overall** | **0.6906** | **0.6692** | **−0.0214** |
| single-hop | 0.7873 | 0.7873 | ±0.0000 |
| multi-hop | 0.5344 | 0.5283 | −0.0060 |
| temporal | 0.6589 | 0.5727 | **−0.0862** |
| open-domain | 0.3571 | 0.3258 | −0.0313 |

**Retrieval was identical between the two.** Probed in-band with the same query, both
ops returned the same ten keys, in the same order, with the same scores — expected
here, because with no consolidation pass every row is a note, so recall's facts+notes
default and search's unfiltered scan select the same set (`facts_written=0` in both
runs; every row classifies `note`). The entire gap is the projection.

It concentrates in temporal questions, and the failure has one shape: of 43 temporal
answers that went correct → wrong, 29 reported the timestamp of the **utterance** as
the date of the **event**.

> *"When did Caroline go to the LGBTQ support group?"* — gold **7 May 2023**
> through `search`: "7 May 2023 (she went 'yesterday' on 8 May)" ✓
> through `recall`: "8 May 2023" ✗

Reading a dated remark as a standing fact is exactly what "facts" invites. The other
14 were abstentions (NOT_FOUND 0.134 → 0.167).

## What

- `RecallFact` grows a `Kind`; the in-process backend fills it from the same `Class()`
  the source selector filters on, so the rendered kind cannot disagree with what
  `sources` admitted.
- **An empty kind stays empty.** A remote memory layer handing back opaque
  server-side ids cannot classify its own rows, and defaulting those to `"fact"` would
  recreate the defect this closes. The field is omitted instead.
- The array is `memories`, not `facts`. Each item carries its `kind`.
- The op description now says what a remembered remark *is*: something recorded, not
  something established, often stamped with the time it was **said** rather than the
  time it happened.
- **No compatibility alias on the wire.** Nothing parses this key programmatically —
  it is model-visible tool output — and emitting both names would leave the misleading
  one in front of the model, which is the whole point.
- The one real consumer, the code-js consolidator's `recall()`, reads
  `memories || facts`: a code-js body replays against results recorded earlier in the
  *same run*, so a pass straddling the upgrade would otherwise read undefined, recall
  nothing, and write a duplicate instead of merging. Removable after a release.
- `Document op=list_facts` is untouched and still returns `facts` — those are facts.
- The Go field `RecallResult.Facts` keeps its name deliberately: renaming internal
  identifiers would put a refactor in a behaviour-change commit.

## What was tested

Three regression tests, each verified to **fail on the unfixed code** by reverting
each half in turn rather than by assuming:

- `TestInprocess_Recall_ClassifiesEachRow` — a note and a fact in one recall, so a
  constant would be visible as wrong. Fails before with `kind = ""` on both rows.
- `TestMemoryTool_Recall_RendersMemoriesNotFacts` — container name and per-row kind.
- `TestMemoryTool_Recall_OmitsKindWhenBackendCannotClassify` — an unclassified row
  must omit the field, not guess.

`go test ./...` clean (exit 0, no FAIL in the full output — not a tail).

Preset stacks validate, including the edited memory bundle:
`base,memory` · `base,memory,chat,document-agent` · and the full nine-bundle stack.
Both bundle copies verified byte-identical.

**End-to-end**, against real Postgres 17 + pgvector 0.8.6, a real `bge-m3` embedder,
and real tool dispatch — driven by a zero-token `code-js` agent so no LLM sits between
the tool and the assertion:

```json
{"memories": [
  {"id": "fact-1", "kind": "fact",
   "memory": "Caroline attends an LGBTQ support group",              "score": 0.4088},
  {"id": "turn-1", "kind": "note",
   "memory": "[8 May 2023] Caroline: I went to the support group yesterday", "score": 0.3699}
]}
```

The origin-stamped row comes back `fact`, the raw turn `note`.

## What is NOT verified

The accuracy claim is a **diagnosis, not yet a demonstration**. The −0.0214 is measured
on the old projection; that the new one recovers it is the hypothesis this change rests
on. The check is to re-run the answer axis with `op=recall` after deploy and compare
against 0.6692 / 0.5727 temporal. Worth saying plainly: the retrieval-identity finding
overturned my first hypothesis (that recall's dedup was collapsing near-duplicate dated
rows), so this one deserves the same measurement before it is believed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8
