### PR TITLE
feat: POST /v1/_config/reload — runtime config reload, in place (RFC CK, Part B phase 2)

### DIFF
--- a/cmd/loomcycle/config_reload_test.go
+++ b/cmd/loomcycle/config_reload_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+)
+
+// TestProviderResolver_Reload is the RFC CK provider-set reload: Reload rebuilds
+// byID from a new config (changed base_url, added provider) and swaps it in place
+// so Get returns the new set; currentCfg tracks the new config. A subsequent bad
+// config is rejected and the previous set is kept.
+func TestProviderResolver_Reload(t *testing.T) {
+	pr, err := newProviderResolver(&config.Config{
+		Providers: map[string]config.ProviderConfig{
+			"vllm-local": {Driver: "vllm", BaseURL: "http://a:8000/v1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("newProviderResolver: %v", err)
+	}
+	if _, err := pr.Get("vllm-local"); err != nil {
+		t.Fatalf("vllm-local not resolvable pre-reload: %v", err)
+	}
+	if _, err := pr.Get("llamacpp-local"); err == nil {
+		t.Fatal("llamacpp-local resolvable before it was declared")
+	}
+
+	// Reload: change vllm-local's base_url and ADD llamacpp-local.
+	next := &config.Config{
+		Providers: map[string]config.ProviderConfig{
+			"vllm-local":     {Driver: "vllm", BaseURL: "http://b:8000/v1"},
+			"llamacpp-local": {Driver: "llamacpp", BaseURL: "http://c:8080/v1"},
+		},
+	}
+	if err := pr.Reload(next); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	for _, id := range []string{"vllm-local", "llamacpp-local"} {
+		if _, err := pr.Get(id); err != nil {
+			t.Errorf("%s not resolvable post-reload: %v", id, err)
+		}
+	}
+	if pr.currentCfg() != next {
+		t.Error("currentCfg did not advance to the reloaded config")
+	}
+
+	// A bad config (unconstructable — unknown driver) is rejected; the previous
+	// set is kept intact.
+	badErr := pr.Reload(&config.Config{
+		Providers: map[string]config.ProviderConfig{"nope": {Driver: "does-not-exist"}},
+	})
+	if badErr == nil {
+		t.Error("Reload with an unknown driver should error")
+	}
+	if _, err := pr.Get("vllm-local"); err != nil {
+		t.Errorf("previous provider set lost after a rejected reload: %v", err)
+	}
+}
+
+// TestProviderResolver_ReloadRaceWithGet runs concurrent Get against Reload —
+// under -race this fails if the byID swap is not synchronized.
+func TestProviderResolver_ReloadRaceWithGet(t *testing.T) {
+	pr, err := newProviderResolver(&config.Config{
+		Providers: map[string]config.ProviderConfig{"vllm-local": {Driver: "vllm", BaseURL: "http://a:8000/v1"}},
+	})
+	if err != nil {
+		t.Fatalf("newProviderResolver: %v", err)
+	}
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 2000; i++ {
+			_, _ = pr.Get("vllm-local")
+			_ = pr.currentCfg()
+		}
+		close(done)
+	}()
+	for i := 0; i < 2000; i++ {
+		_ = pr.Reload(&config.Config{
+			Providers: map[string]config.ProviderConfig{"vllm-local": {Driver: "vllm", BaseURL: "http://b:8000/v1"}},
+		})
+	}
+	<-done
+}

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -3239,6 +3239,27 @@ func main() {
 	go runResolveProbeLoop(bgCtx, resolver, pr, cfg, probeInterval)
 	log.Printf("resolve probe: interval=%s", probeInterval)
 
+	// RFC CK — wire the runtime config-reload hooks now that the resolver, provider
+	// set, and background ctx exist. load re-runs LoadLayers over the SAME captured
+	// layer stack (disk-file layers re-read fresh, embedded layers static), which
+	// re-validates; apply rebuilds the provider set + resolver policy in place and
+	// probes the new set immediately. POST /v1/_config/reload drives it. In-place
+	// mutation means the Server's resolver/provider pointers never change, so the
+	// probe loop + all readers keep working without a swap.
+	srv.SetConfigReloader(
+		func() (*config.Config, error) { return config.LoadLayers(layers...) },
+		func(newCfg *config.Config) error {
+			if err := pr.Reload(newCfg); err != nil {
+				return err
+			}
+			resolver.ReloadPolicy(newCfg.ProviderPriority, convertTiers(newCfg.Tiers, newCfg.Models))
+			// runResolveProbeOnce reads pr.currentCfg() (now the reloaded config),
+			// so this immediately probes the possibly-changed provider set.
+			runResolveProbeOnce(bgCtx, resolver, pr, newCfg)
+			return nil
+		},
+	)
+
 	go func() {
 		log.Printf("loomcycle listening on %s", cfg.Env.ListenAddr)
 		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
@@ -3455,6 +3476,9 @@ func openStore(cfg *config.Config) (store.Store, func(), error) {
 // supplies the built-ins. A provider whose enabling env is absent is simply not
 // in byID; Get reproduces the pre-P2a "not configured" error for it.
 type providerResolver struct {
+	// mu guards byID + cfg so a runtime config reload (RFC CK) can swap the
+	// constructed provider set under Reload while Get reads it concurrently.
+	mu   sync.RWMutex
 	byID map[string]providers.Provider
 	// cfg is retained so Get can tell a declared-but-disabled provider (a
 	// bespoke "not configured" error) apart from a truly unknown id.
@@ -3466,15 +3490,14 @@ type providerResolver struct {
 	anthropicOAuthRefresher *anthropic_oauth_dev.Refresher
 }
 
-// newProviderResolver builds every enabled provider from cfg.Providers via the
-// RFC BF driver registry (config-driven flip of the pre-P2a hardcoded per-provider
-// construction). It is byte-identical when no operator `providers:` block is
-// declared, because the embedded default-providers layer supplies the built-ins
-// and providerbuild.DriverOptions/providerEnabled port the exact env behaviour. An
-// unconstructable provider (bad driver/dialect/base_url) is a boot error.
-func newProviderResolver(cfg *config.Config) (*providerResolver, error) {
-	pr := &providerResolver{byID: map[string]providers.Provider{}, cfg: cfg}
-
+// buildProviderMap constructs every ENABLED provider from cfg.Providers via the
+// RFC BF driver registry, returning the id→Provider map. Factored out of
+// newProviderResolver so a runtime reload (providerResolver.Reload) rebuilds the
+// exact same set WITHOUT re-running the one-time boot side effects
+// (anthropic-oauth-dev refresher Start, the mock/code-js diagnostic logs). An
+// unconstructable provider is an error (the reload is rejected, old set kept).
+func buildProviderMap(cfg *config.Config) (map[string]providers.Provider, error) {
+	byID := map[string]providers.Provider{}
 	for id, pc := range cfg.Providers {
 		if !providerEnabled(id, pc, cfg) {
 			continue
@@ -3483,8 +3506,23 @@ func newProviderResolver(cfg *config.Config) (*providerResolver, error) {
 		if err != nil {
 			return nil, fmt.Errorf("provider %q: %w", id, err)
 		}
-		pr.byID[id] = p
+		byID[id] = p
 	}
+	return byID, nil
+}
+
+// newProviderResolver builds every enabled provider from cfg.Providers via the
+// RFC BF driver registry (config-driven flip of the pre-P2a hardcoded per-provider
+// construction). It is byte-identical when no operator `providers:` block is
+// declared, because the embedded default-providers layer supplies the built-ins
+// and providerbuild.DriverOptions/providerEnabled port the exact env behaviour. An
+// unconstructable provider (bad driver/dialect/base_url) is a boot error.
+func newProviderResolver(cfg *config.Config) (*providerResolver, error) {
+	byID, err := buildProviderMap(cfg)
+	if err != nil {
+		return nil, err
+	}
+	pr := &providerResolver{byID: byID, cfg: cfg}
 
 	// Residual per-provider boot diagnostics (operator-facing knob echoes, NOT
 	// resolution logic) — kept id-keyed so the boot log is unchanged from pre-P2a
@@ -3732,16 +3770,52 @@ func countCodeAgents(cfg *config.Config) int {
 // — gets its bespoke "not configured" message; a truly unknown id gets the
 // "unknown provider" error.
 func (p *providerResolver) Get(id string) (providers.Provider, error) {
-	if prov, ok := p.byID[id]; ok {
+	p.mu.RLock()
+	prov, ok := p.byID[id]
+	cfg := p.cfg
+	p.mu.RUnlock()
+	if ok {
 		return prov, nil
 	}
 	if id == "anthropic-oauth-dev" {
-		return nil, notConfiguredError(id, p.cfg)
+		return nil, notConfiguredError(id, cfg)
 	}
-	if _, declared := p.cfg.Providers[id]; declared {
-		return nil, notConfiguredError(id, p.cfg)
+	if _, declared := cfg.Providers[id]; declared {
+		return nil, notConfiguredError(id, cfg)
 	}
 	return nil, fmt.Errorf("unknown provider %q", id)
+}
+
+// Reload rebuilds the constructed provider set from a freshly-loaded config
+// (RFC CK config reload) and swaps it in under the write lock, so a changed
+// base_url / options / timeout / added-or-removed provider takes effect on the
+// next run without a restart. In-flight runs keep the provider they already
+// resolved. The residual anthropic-oauth-dev provider (a main-owned refresher
+// lifecycle, not declared in cfg.Providers) is carried over from the old set
+// rather than reconstructed — its background token refresher keeps running.
+// currentCfg returns the config the provider set was last built from (updated in
+// place by Reload), read under the lock. The resolve-probe path reads this so a
+// reloaded provider set (added/removed ids) is tracked without rewiring the
+// periodic loop, which captured the boot cfg by value.
+func (p *providerResolver) currentCfg() *config.Config {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.cfg
+}
+
+func (p *providerResolver) Reload(cfg *config.Config) error {
+	next, err := buildProviderMap(cfg)
+	if err != nil {
+		return err
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if oauth, ok := p.byID["anthropic-oauth-dev"]; ok {
+		next["anthropic-oauth-dev"] = oauth
+	}
+	p.byID = next
+	p.cfg = cfg
+	return nil
 }
 
 // buildResolver constructs the model-resolution matrix
@@ -3781,6 +3855,11 @@ func buildResolver(cfg *config.Config, pr *providerResolver) *resolve.Resolver {
 // caller's ctx (typically bgCtx for the periodic loop, or
 // context.Background for startup) bounds the total wait.
 func runResolveProbeOnce(ctx context.Context, r *resolve.Resolver, pr *providerResolver, cfg *config.Config) {
+	// RFC CK: probe the CURRENT provider set. pr.Reload updates pr.cfg in place, so
+	// reading it here means the periodic loop + force-probe track a reloaded set
+	// (added/removed provider ids) without rewiring — the loop captured the boot
+	// cfg by value. At boot pr.cfg == the passed cfg, so this is a no-op then.
+	cfg = pr.currentCfg()
 	type probeJob struct {
 		id         string             // provider id
 		excluded   bool               // operator opted out

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -920,7 +920,24 @@ Returns the **post-probe** matrix in the same shape as `GET /v1/_resolver`. A pr
 
 The same operation is available through every transport that consumes the Connector: gRPC `ResolveProbe`, the MCP meta-tool `resolve_probe`, and the TypeScript client's `client.resolveProbe()`.
 
-### At runtime — confirm the resolved (provider, model)
+### At runtime — reload changed config (`POST /v1/_config/reload`)
+
+Edited a config file and want it live without a restart (which drops in-flight runs)? `POST /v1/_config/reload` re-loads the **same layered stack** the server booted with (presets → `LOOMCYCLE_CONFIG_DIR` → `LOOMCYCLE_CONFIG_FILES` → `--config`; disk-file layers are re-read fresh), validates it, and applies the sections it can apply live — reporting the rest.
+
+```sh
+# Preview the diff without applying:
+curl -s -X POST -H "Authorization: Bearer $LOOMCYCLE_AUTH_TOKEN" \
+  'http://localhost:8787/v1/_config/reload?dry_run=1' | jq .
+# Apply:
+curl -s -X POST -H "Authorization: Bearer $LOOMCYCLE_AUTH_TOKEN" \
+  http://localhost:8787/v1/_config/reload | jq .
+# → { "dry_run": false, "applied": ["providers"], "restart_required": [] }
+```
+
+- **Validate-before-apply.** A candidate that fails to load or validate (a YAML typo, a bad driver) is rejected whole — `422 config_invalid` with the parse/validation error, and the **running config is left untouched** (the server keeps serving). A reload never crashes a live server.
+- **Applied live (this build):** `providers`, `models`, `tiers`, `provider_priority`. A changed provider `base_url` / `options` (num_ctx, timeouts) / added-or-removed provider takes effect on the **next** run — the provider set + resolver policy are rebuilt in place, so in-flight runs keep the provider they already resolved. The primary use is retuning a local backend (Ollama/vLLM/llama.cpp) without a restart.
+- **`restart_required`:** any other changed section (e.g. `user_tiers`, `defaults`, `agents`, `memory`, `concurrency`, the listen address, the store DSN) is reported here, not applied — a restart picks it up. Later releases move more of these to `applied`.
+- Admin-token-gated. The response's `applied` / `restart_required` are the top-level config sections that changed since the last successful reload (or boot).
 
 Every run's SSE stream includes an early event carrying the resolved pair. Smoke run:
 

--- a/internal/api/http/config_reload.go
+++ b/internal/api/http/config_reload.go
@@ -1,0 +1,158 @@
+// Package http — RFC CK runtime config reload.
+//
+// POST /v1/_config/reload re-loads the layered YAML config at runtime and applies
+// the changes that CAN be applied without a restart, reporting the rest. It is
+// modeled on the resolve-probe escape hatch (resolver.go): an admin endpoint that
+// mutates a long-lived subsystem in place so an operator never has to restart
+// (which would drop in-flight runs) to pick up a config edit.
+//
+// Phase 2 scope (this file): the mechanism + the provider/resolver reloader. A
+// changed `providers` / `models` / `tiers` / `provider_priority` section takes
+// effect on the NEXT run (in-place provider-set rebuild + resolver-policy swap);
+// every other changed section is reported as restart-required. Later phases move
+// more sections from restart-required to applied (they need the s.cfg holder
+// migration — user_tiers, auth, memory, scheduler, skills, concurrency, …).
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+)
+
+// reloadableSections are the top-level config sections a reload APPLIES in the
+// current build (Phase 2). A changed section outside this set is reported under
+// restart_required. user_tiers is deliberately absent: it is read live off
+// s.cfg at run admission, so it needs the config-holder migration a later phase
+// adds, not the resolver-policy swap.
+var reloadableSections = map[string]bool{
+	"providers":         true,
+	"models":            true,
+	"tiers":             true,
+	"provider_priority": true,
+}
+
+// ReloadResult is the POST /v1/_config/reload response (and dry-run diff).
+type ReloadResult struct {
+	// DryRun is true when the caller asked only for the diff (?dry_run=1); no
+	// change was applied.
+	DryRun bool `json:"dry_run"`
+	// Applied lists the changed sections this build reloaded in place (took effect
+	// on the next run). Empty when nothing reloadable changed.
+	Applied []string `json:"applied"`
+	// RestartRequired lists changed sections this build cannot apply live; a
+	// restart is needed to pick them up.
+	RestartRequired []string `json:"restart_required"`
+	// Warnings surfaces the candidate config's load-time warnings (cross-layer
+	// overrides, etc.), the same ones logged at boot.
+	Warnings []string `json:"warnings,omitempty"`
+}
+
+// errReloadUnavailable is returned when no reloader was wired (a Server built
+// without SetConfigReloader — tests / embedded); the handler maps it to 503.
+var errReloadUnavailable = errors.New("config reload not wired on this server")
+
+// SetConfigReloader injects the two hooks the reload engine needs, and seeds the
+// diff baseline with the boot config. load re-assembles + re-loads the layered
+// config (config.LoadLayers, which validates — a bad candidate returns an error
+// and the running config is kept); apply rebuilds the reloadable subsystems
+// (provider set + resolver policy) in place from a validated candidate. Called
+// once by cmd/loomcycle after the Server + resolver are wired.
+func (s *Server) SetConfigReloader(load func() (*config.Config, error), apply func(*config.Config) error) {
+	s.reloadLoad = load
+	s.reloadApply = apply
+	if s.reloadBaseline.Load() == nil {
+		s.reloadBaseline.Store(s.cfg)
+	}
+}
+
+// ReloadConfig re-loads the layered config and, unless dryRun, applies the
+// reloadable subset. It is the canonical implementation behind
+// POST /v1/_config/reload. Validate-before-apply: a candidate that fails to load
+// or validate is rejected whole (error returned, running config untouched). The
+// applied/restart-required split is computed by diffing the candidate against the
+// last-applied baseline. Concurrent calls are serialized so two reloads can't
+// interleave a diff with an apply.
+func (s *Server) ReloadConfig(ctx context.Context, dryRun bool) (ReloadResult, error) {
+	if s.reloadLoad == nil || s.reloadApply == nil {
+		return ReloadResult{}, errReloadUnavailable
+	}
+	s.reloadMu.Lock()
+	defer s.reloadMu.Unlock()
+
+	// (1) Load + validate the candidate. LoadLayers IS the validation gate; a bad
+	// edit returns an error here and nothing is touched.
+	candidate, err := s.reloadLoad()
+	if err != nil {
+		return ReloadResult{}, fmt.Errorf("%w: %v", config.ErrReloadInvalid, err)
+	}
+
+	// (2) Diff against the last-applied baseline to classify the changes.
+	baseline := s.reloadBaseline.Load()
+	changed, err := config.ChangedSections(baseline, candidate)
+	if err != nil {
+		return ReloadResult{}, fmt.Errorf("%w: diffing config: %v", config.ErrReloadInvalid, err)
+	}
+	res := ReloadResult{DryRun: dryRun, Applied: []string{}, RestartRequired: []string{}, Warnings: candidate.Warnings}
+	for _, sec := range changed {
+		if reloadableSections[sec] {
+			res.Applied = append(res.Applied, sec)
+		} else {
+			res.RestartRequired = append(res.RestartRequired, sec)
+		}
+	}
+
+	// (3) Dry run stops here — report the diff, apply nothing.
+	if dryRun {
+		return res, nil
+	}
+
+	// (4) Apply the reloadable subsystems only when a reloadable section actually
+	// changed (an apply rebuilds the provider set + re-probes, so skip it when
+	// only restart-required sections moved — no churn). On apply failure the
+	// baseline is NOT advanced, so the running subsystems keep the old config.
+	if len(res.Applied) > 0 {
+		if err := s.reloadApply(candidate); err != nil {
+			return ReloadResult{}, fmt.Errorf("%w: %v", config.ErrReloadApply, err)
+		}
+	}
+	// Advance the baseline to the candidate regardless of whether a reloadable
+	// section changed: a subsequent reload should diff against what the operator
+	// most recently loaded, so an unchanged-then-changed sequence is detected.
+	s.reloadBaseline.Store(candidate)
+	return res, nil
+}
+
+// handleConfigReload is POST /v1/_config/reload (admin-gated by the /v1/_ route
+// prefix). ?dry_run=1 returns the section diff without applying. Mirrors
+// handleResolveProbe's shape: delegate to the canonical method, map typed errors
+// to status codes, encode the result.
+func (s *Server) handleConfigReload(w http.ResponseWriter, r *http.Request) {
+	dryRun := r.URL.Query().Get("dry_run") == "1" || r.URL.Query().Get("dry_run") == "true"
+	res, err := s.ReloadConfig(r.Context(), dryRun)
+	if err != nil {
+		switch {
+		case errors.Is(err, errReloadUnavailable):
+			writeJSONError(w, http.StatusServiceUnavailable, "reload_unavailable",
+				"runtime config reload is not enabled on this server")
+		case errors.Is(err, config.ErrReloadInvalid):
+			// The candidate failed to load/validate — the running config is
+			// unchanged. 422 (not 500): the operator's edit is at fault.
+			writeJSONError(w, http.StatusUnprocessableEntity, "config_invalid", err.Error())
+		case errors.Is(err, config.ErrReloadApply):
+			writeJSONError(w, http.StatusInternalServerError, "reload_apply_failed", err.Error())
+		default:
+			writeJSONError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		}
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(res)
+}

--- a/internal/api/http/config_reload_test.go
+++ b/internal/api/http/config_reload_test.go
@@ -1,0 +1,216 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+func baselineCfg() *config.Config {
+	return &config.Config{
+		Providers:        map[string]config.ProviderConfig{"ollama-local": {Driver: "ollama", BaseURL: "http://a:11434"}},
+		ProviderPriority: []string{"ollama-local"},
+	}
+}
+
+// providersChangedCfg is baselineCfg with the ollama-local base_url edited — a
+// change in the reloadable `providers` section.
+func providersChangedCfg() *config.Config {
+	c := baselineCfg()
+	c.Providers = map[string]config.ProviderConfig{"ollama-local": {Driver: "ollama", BaseURL: "http://b:11434"}}
+	return c
+}
+
+func TestReloadConfig_Unwired(t *testing.T) {
+	s := &Server{}
+	if _, err := s.ReloadConfig(context.Background(), false); !errors.Is(err, errReloadUnavailable) {
+		t.Fatalf("err = %v, want errReloadUnavailable", err)
+	}
+}
+
+// TestReloadConfig_DryRunReportsButDoesNotApply: dry-run classifies the diff and
+// applies nothing (apply hook untouched, baseline unchanged).
+func TestReloadConfig_DryRunReportsButDoesNotApply(t *testing.T) {
+	s := &Server{cfg: baselineCfg()}
+	applied := 0
+	s.SetConfigReloader(
+		func() (*config.Config, error) { return providersChangedCfg(), nil },
+		func(*config.Config) error { applied++; return nil },
+	)
+	res, err := s.ReloadConfig(context.Background(), true)
+	if err != nil {
+		t.Fatalf("ReloadConfig: %v", err)
+	}
+	if !res.DryRun || len(res.Applied) != 1 || res.Applied[0] != "providers" {
+		t.Errorf("dry-run result = %+v, want DryRun + Applied=[providers]", res)
+	}
+	if applied != 0 {
+		t.Errorf("apply called %d times on dry-run, want 0", applied)
+	}
+}
+
+// TestReloadConfig_AppliesReloadableSection: a changed reloadable section calls
+// the apply hook once and advances the baseline (a second reload sees no change).
+func TestReloadConfig_AppliesReloadableSection(t *testing.T) {
+	s := &Server{cfg: baselineCfg()}
+	applied := 0
+	loaded := providersChangedCfg()
+	s.SetConfigReloader(
+		func() (*config.Config, error) { return loaded, nil },
+		func(*config.Config) error { applied++; return nil },
+	)
+	res, err := s.ReloadConfig(context.Background(), false)
+	if err != nil {
+		t.Fatalf("ReloadConfig: %v", err)
+	}
+	if len(res.Applied) != 1 || res.Applied[0] != "providers" || applied != 1 {
+		t.Errorf("result=%+v applied=%d, want Applied=[providers] applied=1", res, applied)
+	}
+	// Baseline advanced: reloading the same config again is a no-op (no apply).
+	res2, err := s.ReloadConfig(context.Background(), false)
+	if err != nil {
+		t.Fatalf("second ReloadConfig: %v", err)
+	}
+	if len(res2.Applied) != 0 || applied != 1 {
+		t.Errorf("second reload result=%+v applied=%d, want no change (baseline advanced)", res2, applied)
+	}
+}
+
+// TestReloadConfig_InvalidRejectedNotApplied: a candidate that fails to load is
+// rejected whole (ErrReloadInvalid) and the apply hook is never called.
+func TestReloadConfig_InvalidRejectedNotApplied(t *testing.T) {
+	s := &Server{cfg: baselineCfg()}
+	applied := 0
+	s.SetConfigReloader(
+		func() (*config.Config, error) { return nil, errors.New("bad yaml at line 7") },
+		func(*config.Config) error { applied++; return nil },
+	)
+	_, err := s.ReloadConfig(context.Background(), false)
+	if !errors.Is(err, config.ErrReloadInvalid) {
+		t.Fatalf("err = %v, want ErrReloadInvalid", err)
+	}
+	if applied != 0 {
+		t.Errorf("apply called %d times for an invalid candidate, want 0", applied)
+	}
+}
+
+// TestReloadConfig_NonReloadableSectionRestartRequired: a changed section outside
+// the reloadable set is reported under restart_required and the apply hook is
+// NOT called (nothing reloadable changed).
+func TestReloadConfig_NonReloadableSectionRestartRequired(t *testing.T) {
+	s := &Server{cfg: baselineCfg()}
+	applied := 0
+	changed := baselineCfg()
+	changed.Defaults = config.Defaults{Provider: "anthropic", Model: "claude"} // a non-reloadable section
+	s.SetConfigReloader(
+		func() (*config.Config, error) { return changed, nil },
+		func(*config.Config) error { applied++; return nil },
+	)
+	res, err := s.ReloadConfig(context.Background(), false)
+	if err != nil {
+		t.Fatalf("ReloadConfig: %v", err)
+	}
+	if len(res.Applied) != 0 {
+		t.Errorf("Applied = %v, want none (defaults is not reloadable)", res.Applied)
+	}
+	if len(res.RestartRequired) != 1 || res.RestartRequired[0] != "defaults" {
+		t.Errorf("RestartRequired = %v, want [defaults]", res.RestartRequired)
+	}
+	if applied != 0 {
+		t.Errorf("apply called %d times when only a restart-required section changed, want 0", applied)
+	}
+}
+
+// TestHandleConfigReload_EndToEnd exercises the real POST /v1/_config/reload
+// route: auth (open mode), ?dry_run parsing, the handler → ReloadConfig →
+// JSON-encode path, and the 422 rejection of an invalid candidate.
+func TestHandleConfigReload_EndToEnd(t *testing.T) {
+	cfg := &config.Config{
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+	}
+	cfg.Env.AuthToken = "" // open mode
+	cfg.Providers = map[string]config.ProviderConfig{"ollama-local": {Driver: "ollama", BaseURL: "http://a:11434"}}
+	sem := concurrency.New(4, 4, 100*time.Millisecond)
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "reload.db"))
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	srv := New(cfg, &stubResolver{}, []tools.Tool{}, sem, st)
+
+	valid := true
+	applied := 0
+	srv.SetConfigReloader(
+		func() (*config.Config, error) {
+			if !valid {
+				return nil, errors.New("providers[0]: unknown driver \"bogus\"")
+			}
+			c := &config.Config{Providers: map[string]config.ProviderConfig{"ollama-local": {Driver: "ollama", BaseURL: "http://b:11434"}}}
+			return c, nil
+		},
+		func(*config.Config) error { applied++; return nil },
+	)
+	ts := httptest.NewServer(srv.Mux())
+	t.Cleanup(ts.Close)
+
+	// (1) dry-run: reports providers changed, applies nothing.
+	body := doReload(t, ts.URL+"/v1/_config/reload?dry_run=1", http.StatusOK)
+	if !body.DryRun || len(body.Applied) != 1 || body.Applied[0] != "providers" || applied != 0 {
+		t.Errorf("dry-run body=%+v applied=%d, want DryRun Applied=[providers] applied=0", body, applied)
+	}
+
+	// (2) real apply: providers applied, hook called.
+	body = doReload(t, ts.URL+"/v1/_config/reload", http.StatusOK)
+	if body.DryRun || len(body.Applied) != 1 || applied != 1 {
+		t.Errorf("apply body=%+v applied=%d, want Applied=[providers] applied=1", body, applied)
+	}
+
+	// (3) invalid candidate → 422, hook not called again.
+	valid = false
+	doReloadStatus(t, ts.URL+"/v1/_config/reload", http.StatusUnprocessableEntity)
+	if applied != 1 {
+		t.Errorf("apply called %d times total, want 1 (invalid candidate must not apply)", applied)
+	}
+}
+
+func doReload(t *testing.T, url string, wantStatus int) ReloadResult {
+	t.Helper()
+	resp, err := http.Post(url, "application/json", nil)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != wantStatus {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want %d (%s)", resp.StatusCode, wantStatus, b)
+	}
+	var out ReloadResult
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return out
+}
+
+func doReloadStatus(t *testing.T, url string, wantStatus int) {
+	t.Helper()
+	resp, err := http.Post(url, "application/json", nil)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.ReadAll(resp.Body)
+	if resp.StatusCode != wantStatus {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, wantStatus)
+	}
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/audit"
@@ -70,6 +71,18 @@ type Server struct {
 	providers ProviderResolver
 	tools     []tools.Tool
 	sem       *concurrency.Semaphore
+
+	// --- RFC CK runtime config reload (POST /v1/_config/reload) ---
+	// reloadLoad re-assembles + re-loads the layered config the same way boot did
+	// (config.LoadLayers, which validates); reloadApply rebuilds the reloadable
+	// subsystems (provider set + resolver policy) in place. Both are injected by
+	// cmd/loomcycle via SetConfigReloader; nil on a Server built without them
+	// (tests / embedded) → the endpoint 503s. reloadBaseline is the last applied
+	// config, the diff baseline; reloadMu serializes concurrent reload calls.
+	reloadLoad     func() (*config.Config, error)
+	reloadApply    func(*config.Config) error
+	reloadBaseline atomic.Pointer[config.Config]
+	reloadMu       sync.Mutex
 	// providerGates caps in-flight runs PER provider id (RFC BF P2b,
 	// providers.<id>.max_concurrent). Acquired at admission BEFORE the global
 	// sem so a run blocked on a full per-provider cap doesn't hold a global slot
@@ -2789,6 +2802,10 @@ func (s *Server) Mux() http.Handler {
 	// availability matrix after a transient outage without a restart,
 	// instead of waiting up to a full probe interval for the next tick.
 	mux.Handle("POST /v1/_resolve/probe", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleResolveProbe))))
+	// RFC CK — runtime config reload. Re-loads the layered YAML and applies the
+	// reloadable sections (providers/models/tiers/provider_priority) in place;
+	// ?dry_run=1 returns the section diff. Admin-gated by the /v1/_ prefix.
+	mux.Handle("POST /v1/_config/reload", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleConfigReload))))
 	// v0.12.x live provider introspection. Complements /v1/_resolver
 	// (cached matrix) by doing a fresh ListModels round-trip — useful
 	// after adding a model to the upstream console without waiting

--- a/internal/config/reload.go
+++ b/internal/config/reload.go
@@ -1,0 +1,78 @@
+package config
+
+import (
+	"errors"
+	"sort"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ErrReloadInvalid classifies a runtime config reload (RFC CK) that was rejected
+// because the candidate config failed to load or validate — the running config is
+// left untouched. The HTTP layer maps it to 422.
+var ErrReloadInvalid = errors.New("config reload: candidate invalid")
+
+// ErrReloadApply classifies a reload whose candidate validated but whose
+// subsystem apply failed (e.g. a provider driver that would not construct). The
+// running subsystems keep the previous config. Mapped to 500.
+var ErrReloadApply = errors.New("config reload: apply failed")
+
+// ChangedSections reports which top-level config sections differ between two
+// loaded configs (RFC CK runtime reload). It marshals each config to YAML and
+// compares the serialized value of every top-level key, returning the changed
+// keys sorted. This is a whole-config diff by section name (providers / models /
+// tiers / agents / memory / concurrency / …) that a reload engine uses to decide
+// what to apply vs report as restart-required, without enumerating every field.
+//
+// Both configs are produced by the SAME process env (env changes need a restart),
+// so env-derived fields serialize identically and are not flagged — only sections
+// an operator actually edited in the YAML surface as changed. A marshal error on
+// either side yields ("", err); callers treat that as "cannot diff" and refuse.
+func ChangedSections(oldCfg, newCfg *Config) ([]string, error) {
+	oldSecs, err := sectionBytes(oldCfg)
+	if err != nil {
+		return nil, err
+	}
+	newSecs, err := sectionBytes(newCfg)
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string]struct{}{}
+	for k := range oldSecs {
+		seen[k] = struct{}{}
+	}
+	for k := range newSecs {
+		seen[k] = struct{}{}
+	}
+	var changed []string
+	for k := range seen {
+		if oldSecs[k] != newSecs[k] {
+			changed = append(changed, k)
+		}
+	}
+	sort.Strings(changed)
+	return changed, nil
+}
+
+// sectionBytes marshals a config to YAML and returns each top-level key mapped to
+// its re-marshaled (canonical) value bytes, so two values compare equal iff they
+// serialize identically regardless of map ordering.
+func sectionBytes(c *Config) (map[string]string, error) {
+	raw, err := yaml.Marshal(c)
+	if err != nil {
+		return nil, err
+	}
+	var top map[string]yaml.Node
+	if err := yaml.Unmarshal(raw, &top); err != nil {
+		return nil, err
+	}
+	out := make(map[string]string, len(top))
+	for k, node := range top {
+		vb, err := yaml.Marshal(&node)
+		if err != nil {
+			return nil, err
+		}
+		out[k] = string(vb)
+	}
+	return out, nil
+}

--- a/internal/config/reload_test.go
+++ b/internal/config/reload_test.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestChangedSections is the RFC CK section-diff: two configs are compared by
+// top-level YAML section, and only the sections that actually differ are
+// reported (sorted). Env-derived fields are identical between two loads of the
+// same process env, so they never surface.
+func TestChangedSections(t *testing.T) {
+	base := &Config{
+		Providers:        map[string]ProviderConfig{"ollama-local": {Driver: "ollama", BaseURL: "http://a:11434"}},
+		ProviderPriority: []string{"ollama-local"},
+		Tiers:            map[string][]TierCandidate{"low": {{Provider: "ollama-local", Model: "m1"}}},
+	}
+
+	// (1) identical → no changes.
+	same := &Config{
+		Providers:        map[string]ProviderConfig{"ollama-local": {Driver: "ollama", BaseURL: "http://a:11434"}},
+		ProviderPriority: []string{"ollama-local"},
+		Tiers:            map[string][]TierCandidate{"low": {{Provider: "ollama-local", Model: "m1"}}},
+	}
+	got, err := ChangedSections(base, same)
+	if err != nil {
+		t.Fatalf("ChangedSections: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("identical configs reported changed sections %v, want none", got)
+	}
+
+	// (2) one section (providers.base_url) changed → only "providers".
+	newBase := &Config{
+		Providers:        map[string]ProviderConfig{"ollama-local": {Driver: "ollama", BaseURL: "http://b:11434"}},
+		ProviderPriority: []string{"ollama-local"},
+		Tiers:            map[string][]TierCandidate{"low": {{Provider: "ollama-local", Model: "m1"}}},
+	}
+	got, err = ChangedSections(base, newBase)
+	if err != nil {
+		t.Fatalf("ChangedSections: %v", err)
+	}
+	if !reflect.DeepEqual(got, []string{"providers"}) {
+		t.Errorf("changed sections = %v, want [providers]", got)
+	}
+
+	// (3) two sections changed → both, sorted.
+	twoChanged := &Config{
+		Providers:        map[string]ProviderConfig{"ollama-local": {Driver: "ollama", BaseURL: "http://b:11434"}},
+		ProviderPriority: []string{"ollama-local", "openai"},
+		Tiers:            map[string][]TierCandidate{"low": {{Provider: "ollama-local", Model: "m1"}}},
+	}
+	got, err = ChangedSections(base, twoChanged)
+	if err != nil {
+		t.Fatalf("ChangedSections: %v", err)
+	}
+	if !reflect.DeepEqual(got, []string{"provider_priority", "providers"}) {
+		t.Errorf("changed sections = %v, want [provider_priority providers]", got)
+	}
+}

--- a/internal/resolve/matrix.go
+++ b/internal/resolve/matrix.go
@@ -676,7 +676,28 @@ func (r *Resolver) priorityFor(req AgentRequest) (order []string, refused bool) 
 	case req.UserTier != nil && len(req.UserTier.ProviderPriority) > 0:
 		return req.UserTier.ProviderPriority, false
 	}
+	// Library fallback — read under the lock so a concurrent ReloadPolicy
+	// (RFC CK config reload) can swap it safely. Mirrors candidatesFor's
+	// libraryTiers read above; the earlier return paths touch only req fields.
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	return r.libraryPriority, false
+}
+
+// ReloadPolicy atomically replaces the library-wide provider priority + tier
+// candidates (RFC CK config reload) WITHOUT disturbing the availability matrix
+// or the probe wiring — reachability persists across a policy reload, and the
+// forceProbe hook the probe loop installed stays intact. The next Resolve sees
+// the new policy; an in-flight resolution already past candidatesFor/priorityFor
+// is unaffected. Empty priority falls back to the default, matching NewResolver.
+func (r *Resolver) ReloadPolicy(libraryPriority []string, libraryTiers map[string][]Candidate) {
+	if len(libraryPriority) == 0 {
+		libraryPriority = defaultLibraryPriority
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.libraryPriority = libraryPriority
+	r.libraryTiers = libraryTiers
 }
 
 // isAvailableLocked checks whether a (provider, model) is currently

--- a/internal/resolve/reload_test.go
+++ b/internal/resolve/reload_test.go
@@ -1,0 +1,70 @@
+package resolve
+
+import "testing"
+
+// TestReloadPolicy is the RFC CK config reload: ReloadPolicy replaces the
+// library tier candidates + provider priority in place (the next resolution
+// sees them) WITHOUT disturbing the availability matrix (a prior probe result
+// survives) or the forceProbe wiring.
+func TestReloadPolicy(t *testing.T) {
+	r := NewResolver([]string{"p1"}, map[string][]Candidate{"low": {{Provider: "p1", Model: "m1"}}})
+
+	// A probe result on p1 before the reload must survive it.
+	r.SetReachable("p1", true, []string{"m1"}, "")
+
+	// Before: library policy resolves to p1/m1.
+	if cands := r.candidatesFor(AgentRequest{Tier: "low"}); len(cands) != 1 || cands[0].Model != "m1" {
+		t.Fatalf("pre-reload candidatesFor = %+v, want [{p1 m1}]", cands)
+	}
+	if order, _ := r.priorityFor(AgentRequest{}); len(order) != 1 || order[0] != "p1" {
+		t.Fatalf("pre-reload priorityFor = %v, want [p1]", order)
+	}
+
+	// Reload the policy: new tier candidate + new priority.
+	r.ReloadPolicy([]string{"p2"}, map[string][]Candidate{"low": {{Provider: "p2", Model: "m2"}}})
+
+	// After: the next resolution sees the new policy.
+	if cands := r.candidatesFor(AgentRequest{Tier: "low"}); len(cands) != 1 || cands[0].Model != "m2" {
+		t.Errorf("post-reload candidatesFor = %+v, want [{p2 m2}]", cands)
+	}
+	if order, _ := r.priorityFor(AgentRequest{}); len(order) != 1 || order[0] != "p2" {
+		t.Errorf("post-reload priorityFor = %v, want [p2]", order)
+	}
+
+	// The availability matrix is untouched: p1's reachability persists across the
+	// policy reload (reachability is a live probe fact, not config).
+	snap := r.Snapshot()
+	if av, ok := snap["p1"]; !ok || !av.Reachable {
+		t.Errorf("p1 reachability lost across ReloadPolicy: %+v", snap["p1"])
+	}
+}
+
+// TestReloadPolicy_EmptyPriorityFallsBackToDefault mirrors NewResolver's
+// empty-priority handling.
+func TestReloadPolicy_EmptyPriorityFallsBackToDefault(t *testing.T) {
+	r := NewResolver([]string{"p1"}, nil)
+	r.ReloadPolicy(nil, nil)
+	order, _ := r.priorityFor(AgentRequest{})
+	if len(order) == 0 {
+		t.Error("empty priority should fall back to the default library priority, got none")
+	}
+}
+
+// TestReloadPolicy_RaceWithReads runs concurrent policy reads (candidatesFor /
+// priorityFor, the resolver's hot path) against ReloadPolicy — under -race this
+// fails if the in-place swap is not synchronized.
+func TestReloadPolicy_RaceWithReads(t *testing.T) {
+	r := NewResolver([]string{"p1"}, map[string][]Candidate{"low": {{Provider: "p1", Model: "m1"}}})
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 2000; i++ {
+			_ = r.candidatesFor(AgentRequest{Tier: "low"})
+			_, _ = r.priorityFor(AgentRequest{})
+		}
+		close(done)
+	}()
+	for i := 0; i < 2000; i++ {
+		r.ReloadPolicy([]string{"p2"}, map[string][]Candidate{"low": {{Provider: "p2", Model: "m2"}}})
+	}
+	<-done
+}


### PR DESCRIPTION
Part B of [RFC CK](/loomcycle/rfcs/local-provider-bundle-and-config-reload): reload changed YAML config **without a restart** (which drops in-flight runs). This is **phase 2** — the mechanism + the provider/resolver reloader (the motivating "retune a local provider live" case). Later phases move more sections from restart-required to applied.

## What

`POST /v1/_config/reload` (+ `?dry_run=1`), admin-gated, modeled on the existing `POST /v1/_resolve/probe` escape hatch — an endpoint that mutates a long-lived subsystem **in place** so an operator never restarts to pick up a config edit.

- **Validate-before-apply.** It re-runs `config.LoadLayers` over the *same* captured layer stack (disk-file layers re-read fresh — this is the validate gate). A candidate that fails to load/validate is rejected whole → `422 config_invalid`, and the **running config is left untouched**. A reload never crashes a live server.
- **Applied live this phase:** `providers`, `models`, `tiers`, `provider_priority`. A changed provider `base_url` / `options` (num_ctx, timeouts) / added-or-removed provider takes effect on the **next** run.
- **`restart_required`:** every other changed section (`user_tiers`, `defaults`, `agents`, `memory`, `concurrency`, listen addr, store DSN) is *reported*, not applied — they're read live off `s.cfg`, which needs the config-holder migration a later phase adds.

## How (the key design choice)

**In-place mutation, not pointer-swap.** Rather than migrate the ~151 `s.cfg` read-sites (and ~50 resolver/provider sites) to atomic accessors, the two subsystems became internally reloadable:
- `resolve.Resolver.ReloadPolicy(...)` — swaps the tier/priority/model policy under its existing RWMutex; the availability matrix + probe wiring are untouched.
- `providerResolver.Reload(cfg)` — rebuilds `byID` under a new RWMutex (factored `buildProviderMap`), carrying over the main-owned `anthropic-oauth-dev` provider so its refresher isn't leaked/restarted.

So the Server's `resolver`/`provider` **pointers never change** — the probe loop and every reader keep working without a swap, and in-flight runs keep the provider/policy they already resolved. `runResolveProbeOnce` now reads `pr.currentCfg()`, so the periodic probe tracks a reloaded provider set with no rewiring. HTTP-only for now (a direct `Server` method, not the `Connector` interface — zero blast radius on gRPC/MCP impls); a later phase lifts it for transport parity.

## Tested

- `go test ./...` clean (95 ok); `gofmt`/`vet` clean; **`-race`** on concurrent Get-vs-Reload and reads-vs-ReloadPolicy (in-place reload is race-safe).
- Unit: `ChangedSections` classification; provider-set `Reload` (change base_url + add provider; bad driver rejected → old set kept); the engine (unwired 503, dry-run applies nothing, reloadable applied + baseline advance, invalid → not applied, non-reloadable → restart_required); an end-to-end handler test (route/auth/`dry_run`/JSON + 422).
- **Live** (built binary): edit `base_url` → `applied:[providers]`; add a model + tier → `applied:[models,tiers]`; introduce a YAML syntax error → `422` and the server keeps serving.

Follow-up (later phase): the `config.Holder` (`s.cfg`) migration for live-field/`user_tiers`/auth reload + the remaining section reloaders (memory, scheduler, skills, concurrency, host-allowlists) + the per-section audit policy + Connector/gRPC/MCP parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)