### PR TITLE
feat: split loomcycle.yaml by section — auto-layer loomcycle.*.yaml files (RFC CK)

### DIFF
--- a/cmd/loomcycle/autodiscover.go
+++ b/cmd/loomcycle/autodiscover.go
@@ -78,6 +78,38 @@ func userOverrodeConfigFlag() bool {
 	return overrode
 }
 
+// siblingSectionFiles returns the loomcycle.<section>.yaml (/.yml) files sitting
+// NEXT TO the resolved base loomcycle.yaml, sorted lexically, excluding the base
+// itself. This is the RFC CK section-per-file split: an operator can move
+// `providers:` into loomcycle.providers.yaml and `memory:` into
+// loomcycle.memory.yaml beside loomcycle.yaml, and they auto-layer (deep-merged,
+// after the base, so a section file overrides the base for that section) with no
+// LOOMCYCLE_CONFIG_DIR / LOOMCYCLE_CONFIG_FILES plumbing. Only the auto-discovery
+// path picks these up; an explicit --config stays literal (list them or use a dir).
+func siblingSectionFiles(basePath string) []string {
+	return sectionFilesIn(filepath.Dir(basePath), basePath)
+}
+
+// sectionFilesIn globs loomcycle.*.yaml / loomcycle.*.yml directly in dir
+// (sorted, deduped, excluding `exclude`). loomcycle.yaml itself does not match
+// loomcycle.*.yaml (no middle segment), but `exclude` guards it regardless.
+func sectionFilesIn(dir, exclude string) []string {
+	seen := map[string]bool{}
+	var files []string
+	for _, pat := range []string{"loomcycle.*.yaml", "loomcycle.*.yml"} {
+		matches, _ := filepath.Glob(filepath.Join(dir, pat))
+		for _, f := range matches {
+			if f == exclude || seen[f] {
+				continue
+			}
+			seen[f] = true
+			files = append(files, f)
+		}
+	}
+	sort.Strings(files)
+	return files
+}
+
 // configDirLayers returns the *.yaml / *.yml files directly under dir, sorted
 // lexically — the LOOMCYCLE_CONFIG_DIR layer group (RFC AQ §4). The directory
 // must exist and be readable (a set-but-missing dir is the operator's typo →

--- a/cmd/loomcycle/autodiscover_test.go
+++ b/cmd/loomcycle/autodiscover_test.go
@@ -62,3 +62,36 @@ func TestConfigDirLayers_EmptyAndMissing(t *testing.T) {
 		t.Errorf("a missing LOOMCYCLE_CONFIG_DIR should error (caller exits)")
 	}
 }
+
+// TestSiblingSectionFiles: the RFC CK section-per-file split discovers
+// loomcycle.*.yaml siblings beside the base loomcycle.yaml, sorted, excluding the
+// base and unrelated files.
+func TestSiblingSectionFiles(t *testing.T) {
+	dir := t.TempDir()
+	for _, n := range []string{
+		"loomcycle.yaml",           // the base — excluded
+		"loomcycle.providers.yaml", // section
+		"loomcycle.memory.yaml",    // section
+		"loomcycle.agents.yml",     // section (.yml)
+		"notloomcycle.yaml",        // unrelated
+		"loomcycle.yml",            // base-ish, no middle segment → not a section
+	} {
+		if err := os.WriteFile(filepath.Join(dir, n), []byte("provider_priority: [mock]\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got := siblingSectionFiles(filepath.Join(dir, "loomcycle.yaml"))
+	want := []string{
+		filepath.Join(dir, "loomcycle.agents.yml"),
+		filepath.Join(dir, "loomcycle.memory.yaml"),
+		filepath.Join(dir, "loomcycle.providers.yaml"),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("siblingSectionFiles = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("sibling[%d] = %s, want %s", i, got[i], want[i])
+		}
+	}
+}

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -723,7 +723,13 @@ func main() {
 		resolvedCfg, found := resolveConfigPath("loomcycle.yaml")
 		switch {
 		case found:
-			cfgFiles = []string{resolvedCfg}
+			// RFC CK section-per-file: the base loomcycle.yaml + any loomcycle.*.yaml
+			// section siblings beside it (e.g. loomcycle.providers.yaml), deep-merged.
+			cfgFiles = append([]string{resolvedCfg}, siblingSectionFiles(resolvedCfg)...)
+			if len(cfgFiles) > 1 {
+				log.Printf("config: + %d section file(s) beside %s: %s",
+					len(cfgFiles)-1, resolvedCfg, strings.Join(cfgFiles[1:], ", "))
+			}
 		case len(presetLayers) > 0:
 			// Presets-only: the embedded base IS the config (RFC AQ §2.2).
 			log.Printf("config: no operator config file — running from embedded presets only")

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1209,6 +1209,29 @@ Put your authoritative file **LAST**: the bundle contributes its `agents:` (e.g.
 set, `LOOMCYCLE_CONFIG_FILES` files layer as the **base** and explicit `--config`
 flags layer **after** them (an explicit flag always wins).
 
+**Section-per-file (`loomcycle.*.yaml`).** For a large config, split it by section
+into sibling files next to `loomcycle.yaml` and they auto-layer with **no flags or
+env** — run `loomcycle` (no `--config`) in the directory and it loads the base
+`loomcycle.yaml` **plus every `loomcycle.*.yaml`** beside it, deep-merged in
+lexical order after the base:
+
+```
+loomcycle.yaml            # defaults, agents — the small "main" file
+loomcycle.providers.yaml  # providers: / models: / tiers: / provider_priority:
+loomcycle.memory.yaml     # memory:
+loomcycle.channels.yaml   # channels:
+```
+
+Because it's the same deep-merge, a section file simply *owns* its section (put
+`providers:` in `loomcycle.providers.yaml` and leave it out of `loomcycle.yaml`).
+This pairs with runtime reload: edit one section file and `POST /v1/_config/reload`
+picks it up (a section file present at boot is re-read on reload; adding a *new*
+section file still needs a restart). Notes: a base `loomcycle.yaml` must exist
+(it may be minimal); this applies to **auto-discovery only** — an explicit
+`--config` stays literal (list the files or use `LOOMCYCLE_CONFIG_DIR`); and any
+`loomcycle.*.yaml` in the directory is loaded, so don't keep `loomcycle.example.yaml`
+beside a live config.
+
 **The merge rule (one rule, all sections).** Files are merged at the YAML-tree
 level *before* typed unmarshal, so a key's presence is explicit:
 


### PR DESCRIPTION
Splitting `loomcycle.yaml` into per-section files for manageability (your ask alongside the reload work). This is the config-split piece; the remaining **subsystem reloaders** and **Connector/gRPC/MCP parity** for the reload endpoint follow as separate PRs.

## What

Run `loomcycle` (no `--config`) in a directory and it now loads the base `loomcycle.yaml` **plus every `loomcycle.*.yaml`** sibling, deep-merged in lexical order after the base:

```
loomcycle.yaml            # defaults, agents — the small "main" file
loomcycle.providers.yaml  # providers: / models: / tiers: / provider_priority:
loomcycle.memory.yaml     # memory:
loomcycle.channels.yaml   # channels:
```

It's pure config assembly over the existing RFC AN deep-merge — a section file simply *owns* its section (move `providers:` into `loomcycle.providers.yaml` and drop it from `loomcycle.yaml`). No flags, no env.

**Pairs with runtime reload:** the sibling files join the captured layer stack at boot, so editing one section file and calling `POST /v1/_config/reload` picks it up — edit `loomcycle.memory.yaml`, reload, done. (Adding a *new* section file after boot still needs a restart.)

## Scope / invariants

- **Auto-discovery only.** An explicit `--config` stays literal (list the files or use `LOOMCYCLE_CONFIG_DIR`) — so there's no drift between `--config X` and `loomcycle validate X` (the CLI tools take explicit paths). `resolveConfigPath` is used only by the server assembly.
- A base `loomcycle.yaml` must exist (may be minimal). Any `loomcycle.*.yaml` in the dir is loaded — don't keep `loomcycle.example.yaml` beside a live config.

## Tested

- `go test ./...` clean (95 ok); `gofmt`/`vet` clean.
- Unit: `siblingSectionFiles` discovers `loomcycle.*.yaml`/`.yml` beside the base, sorted, excluding the base + unrelated files.
- **Live**: a dir with `loomcycle.yaml` + `loomcycle.providers.yaml` + `loomcycle.memory.yaml` boots with all three layered (`config: + 2 section file(s) beside loomcycle.yaml`), reload endpoint 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)