### PR TITLE
fix(config): code-review fixes for the section-per-file split (RFC CK)

### DIFF
--- a/cmd/loomcycle/autodiscover.go
+++ b/cmd/loomcycle/autodiscover.go
@@ -78,38 +78,6 @@ func userOverrodeConfigFlag() bool {
 	return overrode
 }
 
-// siblingSectionFiles returns the loomcycle.<section>.yaml (/.yml) files sitting
-// NEXT TO the resolved base loomcycle.yaml, sorted lexically, excluding the base
-// itself. This is the RFC CK section-per-file split: an operator can move
-// `providers:` into loomcycle.providers.yaml and `memory:` into
-// loomcycle.memory.yaml beside loomcycle.yaml, and they auto-layer (deep-merged,
-// after the base, so a section file overrides the base for that section) with no
-// LOOMCYCLE_CONFIG_DIR / LOOMCYCLE_CONFIG_FILES plumbing. Only the auto-discovery
-// path picks these up; an explicit --config stays literal (list them or use a dir).
-func siblingSectionFiles(basePath string) []string {
-	return sectionFilesIn(filepath.Dir(basePath), basePath)
-}
-
-// sectionFilesIn globs loomcycle.*.yaml / loomcycle.*.yml directly in dir
-// (sorted, deduped, excluding `exclude`). loomcycle.yaml itself does not match
-// loomcycle.*.yaml (no middle segment), but `exclude` guards it regardless.
-func sectionFilesIn(dir, exclude string) []string {
-	seen := map[string]bool{}
-	var files []string
-	for _, pat := range []string{"loomcycle.*.yaml", "loomcycle.*.yml"} {
-		matches, _ := filepath.Glob(filepath.Join(dir, pat))
-		for _, f := range matches {
-			if f == exclude || seen[f] {
-				continue
-			}
-			seen[f] = true
-			files = append(files, f)
-		}
-	}
-	sort.Strings(files)
-	return files
-}
-
 // configDirLayers returns the *.yaml / *.yml files directly under dir, sorted
 // lexically — the LOOMCYCLE_CONFIG_DIR layer group (RFC AQ §4). The directory
 // must exist and be readable (a set-but-missing dir is the operator's typo →

--- a/cmd/loomcycle/autodiscover_test.go
+++ b/cmd/loomcycle/autodiscover_test.go
@@ -62,36 +62,3 @@ func TestConfigDirLayers_EmptyAndMissing(t *testing.T) {
 		t.Errorf("a missing LOOMCYCLE_CONFIG_DIR should error (caller exits)")
 	}
 }
-
-// TestSiblingSectionFiles: the RFC CK section-per-file split discovers
-// loomcycle.*.yaml siblings beside the base loomcycle.yaml, sorted, excluding the
-// base and unrelated files.
-func TestSiblingSectionFiles(t *testing.T) {
-	dir := t.TempDir()
-	for _, n := range []string{
-		"loomcycle.yaml",           // the base — excluded
-		"loomcycle.providers.yaml", // section
-		"loomcycle.memory.yaml",    // section
-		"loomcycle.agents.yml",     // section (.yml)
-		"notloomcycle.yaml",        // unrelated
-		"loomcycle.yml",            // base-ish, no middle segment → not a section
-	} {
-		if err := os.WriteFile(filepath.Join(dir, n), []byte("provider_priority: [mock]\n"), 0o644); err != nil {
-			t.Fatal(err)
-		}
-	}
-	got := siblingSectionFiles(filepath.Join(dir, "loomcycle.yaml"))
-	want := []string{
-		filepath.Join(dir, "loomcycle.agents.yml"),
-		filepath.Join(dir, "loomcycle.memory.yaml"),
-		filepath.Join(dir, "loomcycle.providers.yaml"),
-	}
-	if len(got) != len(want) {
-		t.Fatalf("siblingSectionFiles = %v, want %v", got, want)
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Errorf("sibling[%d] = %s, want %s", i, got[i], want[i])
-		}
-	}
-}

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -723,13 +723,7 @@ func main() {
 		resolvedCfg, found := resolveConfigPath("loomcycle.yaml")
 		switch {
 		case found:
-			// RFC CK section-per-file: the base loomcycle.yaml + any loomcycle.*.yaml
-			// section siblings beside it (e.g. loomcycle.providers.yaml), deep-merged.
-			cfgFiles = append([]string{resolvedCfg}, siblingSectionFiles(resolvedCfg)...)
-			if len(cfgFiles) > 1 {
-				log.Printf("config: + %d section file(s) beside %s: %s",
-					len(cfgFiles)-1, resolvedCfg, strings.Join(cfgFiles[1:], ", "))
-			}
+			cfgFiles = []string{resolvedCfg}
 		case len(presetLayers) > 0:
 			// Presets-only: the embedded base IS the config (RFC AQ §2.2).
 			log.Printf("config: no operator config file — running from embedded presets only")
@@ -752,6 +746,27 @@ func main() {
 				os.Exit(1)
 			}
 		}
+	}
+
+	// RFC CK section-per-file: a loomcycle.yaml base (auto-discovered OR passed via
+	// --config / CONFIG_FILES) brings its loomcycle.*.yaml section siblings, which
+	// deep-merge after it. Shared with loadLayeredConfig so validate/doctor resolve
+	// the identical set (lockstep). CONFIG_DIR is untouched — it already globs the
+	// whole dir. Only the sibling FILES existing on disk are added, so no new
+	// existence check is needed.
+	if expanded := cli.WithSectionSiblings(cfgFiles); len(expanded) > len(cfgFiles) {
+		orig := make(map[string]bool, len(cfgFiles))
+		for _, f := range cfgFiles {
+			orig[f] = true
+		}
+		var added []string
+		for _, f := range expanded {
+			if !orig[f] {
+				added = append(added, f)
+			}
+		}
+		log.Printf("config: + %d section file(s): %s", len(added), strings.Join(added, ", "))
+		cfgFiles = expanded
 	}
 
 	// The ordered disk-file layers: CONFIG_DIR first, then CONFIG_FILES/--config.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1224,13 +1224,23 @@ loomcycle.channels.yaml   # channels:
 
 Because it's the same deep-merge, a section file simply *owns* its section (put
 `providers:` in `loomcycle.providers.yaml` and leave it out of `loomcycle.yaml`).
-This pairs with runtime reload: edit one section file and `POST /v1/_config/reload`
-picks it up (a section file present at boot is re-read on reload; adding a *new*
-section file still needs a restart). Notes: a base `loomcycle.yaml` must exist
-(it may be minimal); this applies to **auto-discovery only** — an explicit
-`--config` stays literal (list the files or use `LOOMCYCLE_CONFIG_DIR`); and any
-`loomcycle.*.yaml` in the directory is loaded, so don't keep `loomcycle.example.yaml`
-beside a live config.
+
+**A `loomcycle.yaml` base brings its siblings however it's reached** — by
+auto-discovery, by `--config loomcycle.yaml`, or in `LOOMCYCLE_CONFIG_FILES` — so
+`loomcycle validate loomcycle.yaml` / `doctor` see the *same* split config the
+server runs (no lockstep drift). `LOOMCYCLE_CONFIG_DIR` is unaffected: it already
+layers every `*.yaml` in the directory.
+
+This pairs with runtime reload: edit a section file present at boot and
+`POST /v1/_config/reload` picks it up. **Adding or removing** a section file after
+boot needs a restart — the reload re-reads the file set captured at boot, so a new
+file is not seen and a removed file makes the reload fail (`422`, the running
+config is kept, never corrupted) until it's restored or the process restarts.
+
+Notes: a base `loomcycle.yaml` must exist (it may be minimal); `*.example.yaml`
+siblings are ignored (so the shipped `loomcycle.example.yaml` left beside a live
+config can't silently override it), but any *other* `loomcycle.*.yaml` in the
+directory is loaded — mind dated backups like `loomcycle.2026-08.yaml`.
 
 **The merge rule (one rule, all sections).** Files are merged at the YAML-tree
 level *before* typed unmarshal, so a key's presence is explicit:

--- a/internal/cli/discover.go
+++ b/internal/cli/discover.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// discover.go — RFC CK section-per-file config split.
+//
+// A loomcycle.yaml base "brings" its loomcycle.<section>.yaml siblings: they
+// deep-merge (RFC AN) after the base. This lives in internal/cli — the shared
+// config-assembly home — so BOTH the server boot path (cmd/loomcycle/main.go)
+// and loadLayeredConfig (validate / doctor / agents list) discover the same
+// section files. Server-only discovery was the #602/v1.8.1 lockstep-drift bug
+// class; keeping one helper is what prevents it here.
+
+// SectionSiblings returns the loomcycle.<section>.yaml (/.yml) section files that
+// sit beside basePath, sorted lexically. It excludes:
+//   - the base itself;
+//   - any *.example.yaml / *.example.yml — the repo ships loomcycle.example.yaml
+//     and the cp-and-edit workflow leaves it beside a live config; a template
+//     must never silently deep-merge OVER the operator's values (last wins);
+//   - any non-regular file (a directory, broken symlink, or fifo matching the
+//     glob), which would otherwise reach config.LoadLayers → os.ReadFile and
+//     abort boot — mirroring configDirLayers' IsDir guard.
+//
+// filepath.Glob's only error is ErrBadPattern, impossible for these constant
+// patterns, so it is discarded deliberately.
+func SectionSiblings(basePath string) []string {
+	dir := filepath.Dir(basePath)
+	var files []string
+	for _, pat := range []string{"loomcycle.*.yaml", "loomcycle.*.yml"} {
+		matches, _ := filepath.Glob(filepath.Join(dir, pat))
+		for _, m := range matches {
+			if m == basePath ||
+				strings.HasSuffix(m, ".example.yaml") || strings.HasSuffix(m, ".example.yml") {
+				continue
+			}
+			// os.Stat follows symlinks: a symlink to a regular file loads; a
+			// directory, broken symlink, or fifo is skipped.
+			if fi, err := os.Stat(m); err != nil || !fi.Mode().IsRegular() {
+				continue
+			}
+			files = append(files, m)
+		}
+	}
+	// A file matches at most one of the two suffix patterns, so no dedup is needed
+	// within this call; ordering across the two globs is restored by the sort.
+	sort.Strings(files)
+	return files
+}
+
+// WithSectionSiblings expands a list of operator config files so each
+// loomcycle.yaml is immediately followed by its SectionSiblings (deep-merged
+// after it). Non-base files pass through unchanged. The result preserves order
+// and is deduped, so a base listed twice — or two bases sharing a directory —
+// never double-layers a sibling. Applied wherever loomcycle.yaml files are
+// layered explicitly (LOOMCYCLE_CONFIG_FILES / --config) or by auto-discovery;
+// NOT to LOOMCYCLE_CONFIG_DIR, which already globs every *.yaml in the dir.
+func WithSectionSiblings(files []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	add := func(f string) {
+		if !seen[f] {
+			seen[f] = true
+			out = append(out, f)
+		}
+	}
+	for _, f := range files {
+		add(f)
+		if filepath.Base(f) == "loomcycle.yaml" {
+			for _, s := range SectionSiblings(f) {
+				add(s)
+			}
+		}
+	}
+	return out
+}

--- a/internal/cli/discover_test.go
+++ b/internal/cli/discover_test.go
@@ -1,0 +1,95 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func writeFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("provider_priority: [mock]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestSectionSiblings covers the RFC CK section discovery: loomcycle.*.yaml /
+// .yml beside the base, sorted, excluding the base, *.example.yaml, unrelated
+// files, and non-regular matches (a directory).
+func TestSectionSiblings(t *testing.T) {
+	dir := t.TempDir()
+	for _, n := range []string{
+		"loomcycle.yaml",              // base — excluded
+		"loomcycle.providers.yaml",    // section
+		"loomcycle.memory.yaml",       // section
+		"loomcycle.agents.yml",        // section (.yml)
+		"loomcycle.example.yaml",      // shipped template — MUST be excluded (footgun)
+		"loomcycle.local.example.yml", // *.example.yml — excluded
+		"notloomcycle.yaml",           // unrelated
+		"loomcycle.yml",               // no middle segment → not a section
+	} {
+		writeFile(t, filepath.Join(dir, n))
+	}
+	// A directory that matches the glob must be skipped, not sent to LoadLayers.
+	if err := os.Mkdir(filepath.Join(dir, "loomcycle.d.yaml"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := SectionSiblings(filepath.Join(dir, "loomcycle.yaml"))
+	want := []string{
+		filepath.Join(dir, "loomcycle.agents.yml"),
+		filepath.Join(dir, "loomcycle.memory.yaml"),
+		filepath.Join(dir, "loomcycle.providers.yaml"),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("SectionSiblings = %v, want %v", got, want)
+	}
+}
+
+// TestSectionSiblings_SkipsBrokenSymlink: a dangling symlink matching the glob is
+// skipped (os.Stat errors), not passed to the loader.
+func TestSectionSiblings_SkipsBrokenSymlink(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "loomcycle.yaml"))
+	writeFile(t, filepath.Join(dir, "loomcycle.real.yaml"))
+	if err := os.Symlink(filepath.Join(dir, "gone.yaml"), filepath.Join(dir, "loomcycle.dead.yaml")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	got := SectionSiblings(filepath.Join(dir, "loomcycle.yaml"))
+	want := []string{filepath.Join(dir, "loomcycle.real.yaml")}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("SectionSiblings = %v, want %v (dangling symlink skipped)", got, want)
+	}
+}
+
+// TestWithSectionSiblings: each loomcycle.yaml is followed by its siblings;
+// non-base files pass through; the result is deduped (a base listed twice, or two
+// bases sharing a dir, does not double-layer a sibling) with order preserved.
+func TestWithSectionSiblings(t *testing.T) {
+	dir := t.TempDir()
+	base := filepath.Join(dir, "loomcycle.yaml")
+	sib := filepath.Join(dir, "loomcycle.providers.yaml")
+	other := filepath.Join(dir, "override.yaml")
+	for _, f := range []string{base, sib, other} {
+		writeFile(t, f)
+	}
+
+	// base brings its sibling, then the unrelated override passes through.
+	got := WithSectionSiblings([]string{base, other})
+	if want := []string{base, sib, other}; !reflect.DeepEqual(got, want) {
+		t.Errorf("WithSectionSiblings = %v, want %v", got, want)
+	}
+
+	// base listed twice → sibling added once (dedup).
+	got = WithSectionSiblings([]string{base, base})
+	if want := []string{base, sib}; !reflect.DeepEqual(got, want) {
+		t.Errorf("dedup: WithSectionSiblings = %v, want %v", got, want)
+	}
+
+	// a non-base file alone → passthrough, no discovery.
+	got = WithSectionSiblings([]string{other})
+	if want := []string{other}; !reflect.DeepEqual(got, want) {
+		t.Errorf("passthrough: WithSectionSiblings = %v, want %v", got, want)
+	}
+}

--- a/internal/cli/loadcfg.go
+++ b/internal/cli/loadcfg.go
@@ -70,22 +70,33 @@ func loadLayeredConfig(explicitPath string) (*config.Config, error) {
 		}
 	}
 
-	// LOOMCYCLE_CONFIG_FILES — colon-separated.
+	// LOOMCYCLE_CONFIG_FILES — colon-separated. Collected (not yet layered) so the
+	// RFC CK section-sibling expansion below runs over the whole operator file set.
+	var opFiles []string
 	for _, f := range strings.Split(os.Getenv("LOOMCYCLE_CONFIG_FILES"), ":") {
 		if f = strings.TrimSpace(f); f != "" {
-			layers = append(layers, config.Layer{Name: f})
+			opFiles = append(opFiles, f)
 		}
 	}
 
 	// The explicit --config path (highest precedence). When it's absent from
 	// disk but the presets/env layers already provide a config, skip it (a
-	// presets-only stack, RFC AQ); when there are no other operator layers, keep
-	// it so LoadLayers surfaces the same file-not-found error the CLI produced
+	// presets-only stack, RFC AQ); when there is no other operator config at all,
+	// keep it so LoadLayers surfaces the same file-not-found error the CLI produced
 	// before (baseLayers excludes the always-on default-providers layer).
 	if explicitPath = strings.TrimSpace(explicitPath); explicitPath != "" {
-		if _, err := os.Stat(explicitPath); err == nil || len(layers) == baseLayers {
-			layers = append(layers, config.Layer{Name: explicitPath})
+		if _, err := os.Stat(explicitPath); err == nil || (len(layers) == baseLayers && len(opFiles) == 0) {
+			opFiles = append(opFiles, explicitPath)
 		}
+	}
+
+	// RFC CK section-per-file: a loomcycle.yaml among the operator files brings its
+	// loomcycle.*.yaml section siblings, deep-merged after it — the SAME helper the
+	// server boot path uses, so validate/doctor/agents resolve the identical split
+	// config the running server does (lockstep). LOOMCYCLE_CONFIG_DIR is excluded:
+	// it already globs every *.yaml in its directory.
+	for _, f := range WithSectionSiblings(opFiles) {
+		layers = append(layers, config.Layer{Name: f})
 	}
 
 	return config.LoadLayers(layers...)


### PR DESCRIPTION
Follow-up to #1083 (merged). A self-review after that PR merged surfaced a lockstep gap plus a few rough edges in the `loomcycle.*.yaml` section-split; #1083 merged at the head *before* these fixes landed, so this carries them to `main`.

## Fixes

- **Lockstep (high):** `validate`/`doctor`/`agents` (via `loadLayeredConfig`) did **not** discover the section siblings the server auto-layers, so they'd falsely report "no provider resolved" on a split config — the #602/v1.8.1 drift class. Discovery is now a **shared `internal/cli` helper** (`SectionSiblings` + `WithSectionSiblings`) that both the server boot path and `loadLayeredConfig` call. **Semantics:** a `loomcycle.yaml` base brings its siblings *however it's reached* — auto-discovery, `--config`, or `LOOMCYCLE_CONFIG_FILES` — so server and CLI resolve the identical set. `LOOMCYCLE_CONFIG_DIR` is untouched (it already globs the dir).
- **`loomcycle.example.yaml` footgun (high):** the glob now **excludes `*.example.yaml`/`.yml`**, so the shipped template left beside a live config can't silently deep-merge over it.
- **Boot-abort on a matching non-file (medium):** added the `IsDir`/regular-file guard `configDirLayers` already has — a directory / broken symlink / fifo named `loomcycle.x.yaml` is skipped instead of aborting startup.
- **Reload after add/remove (medium):** documented accurately — adding *or* removing a section file needs a restart; a removed file makes reload `422` (running config kept, never corrupted) until restored. The deeper fix (re-glob on reload) is a follow-up in the reload-robustness line.
- **Cleanup + coverage:** dropped the dead dedup (it now lives, and earns its keep, in the list-based `WithSectionSiblings`); added tests for example-exclusion, a matching directory, a dangling symlink, expansion, dedup, and passthrough.

## Tested

`go test ./...` clean (95 ok); `gofmt`/`vet` clean. Live: `loomcycle validate <split-base>/loomcycle.yaml` now passes (sibling loaded, agent resolves) while a stray `loomcycle.example.yaml` is ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)