### PR TITLE
feat: re-glob config layers on reload — add/remove a config file without a restart (RFC CK)

### DIFF
--- a/cmd/loomcycle/autodiscover.go
+++ b/cmd/loomcycle/autodiscover.go
@@ -1,11 +1,18 @@
 package main
 
 import (
+	"errors"
 	"flag"
+	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/denn-gubsky/loomcycle/cmd/loomcycle/embedded"
+	"github.com/denn-gubsky/loomcycle/internal/cli"
+	"github.com/denn-gubsky/loomcycle/internal/config"
 )
 
 // autodiscover.go — v0.11.1 config auto-discovery.
@@ -99,4 +106,144 @@ func configDirLayers(dir string) ([]string, error) {
 	}
 	sort.Strings(files)
 	return files, nil
+}
+
+// assembleConfigLayers builds the ordered config-layer list from the embedded
+// preset selection + the operator's config files, exactly the way boot does.
+// It is shared by boot AND the RFC CK runtime reload: because it RE-runs the
+// preset resolution, CONFIG_DIR glob, and loomcycle.*.yaml section-sibling
+// discovery every call, a reload picks up config or section files that were
+// added or removed since boot without a restart (the "re-glob on reload"
+// follow-up). Precedence, base → top, last wins:
+//
+//	providers.default → embedded presets → LOOMCYCLE_CONFIG_DIR/*.yaml
+//	→ LOOMCYCLE_CONFIG_FILES → --config (+ each base's loomcycle.*.yaml siblings)
+//
+// It returns an error (never os.Exit) so a reload can reject a now-broken
+// assembly and keep the running config; boot wraps the error as fatal. verbose
+// gates the boot-time info logs — the reload path passes false so it does not
+// re-log the whole layering on every reload (auth.env is set-if-unset, so its
+// re-run at reload is a silent no-op regardless).
+func assembleConfigLayers(presetFlags, cfgPaths []string, verbose bool) ([]config.Layer, error) {
+	logf := func(format string, args ...any) {
+		if verbose {
+			log.Printf(format, args...)
+		}
+	}
+
+	// Embedded presets (RFC AQ) — the base of the stack, opt-in.
+	presetNames := selectPresetNames(presetFlags, os.Getenv("LOOMCYCLE_PRESETS"))
+	var presetLayers []config.Layer
+	if len(presetNames) > 0 {
+		units, err := embedded.ResolveUnits(presetNames)
+		if err != nil {
+			return nil, err
+		}
+		for _, u := range units {
+			presetLayers = append(presetLayers, config.Layer{Name: u.Name, Data: u.Data})
+		}
+		logf("config: layering %d embedded preset(s)/bundle(s) as base: %s", len(presetNames), strings.Join(presetNames, ", "))
+	}
+
+	// LOOMCYCLE_CONFIG_DIR (RFC AQ §4) — a directory of *.yaml/*.yml layered as a
+	// group, lexically, between the presets and CONFIG_FILES. Unset → skipped.
+	var configDirFiles []string
+	if dir := strings.TrimSpace(os.Getenv("LOOMCYCLE_CONFIG_DIR")); dir != "" {
+		files, err := configDirLayers(dir)
+		if err != nil {
+			return nil, fmt.Errorf("LOOMCYCLE_CONFIG_DIR: %w", err)
+		}
+		configDirFiles = files
+		if len(files) > 0 {
+			logf("config: layering %d file(s) from LOOMCYCLE_CONFIG_DIR=%s (lexical order)", len(files), dir)
+		}
+	}
+
+	// LOOMCYCLE_CONFIG_FILES + --config.
+	var cfgFiles []string
+	for _, f := range strings.Split(os.Getenv("LOOMCYCLE_CONFIG_FILES"), ":") {
+		if f = strings.TrimSpace(f); f != "" {
+			cfgFiles = append(cfgFiles, f)
+		}
+	}
+	cfgFiles = append(cfgFiles, cfgPaths...)
+
+	if len(cfgFiles) == 0 && len(configDirFiles) == 0 {
+		// No explicit operator config → XDG auto-discovery (lockstep with doctor).
+		resolvedCfg, found := resolveConfigPath("loomcycle.yaml")
+		switch {
+		case found:
+			cfgFiles = []string{resolvedCfg}
+		case len(presetLayers) > 0:
+			// Presets-only: the embedded base IS the config (RFC AQ §2.2).
+			logf("config: no operator config file — running from embedded presets only")
+		default:
+			var b strings.Builder
+			b.WriteString("no config found at any of:\n")
+			for _, p := range configAutoDiscoveryPaths() {
+				fmt.Fprintf(&b, "    %s\n", p)
+			}
+			b.WriteString("\nRun `loomcycle init` to create one, pass --config <path>, set LOOMCYCLE_CONFIG_DIR, or select an embedded base with LOOMCYCLE_PRESETS=base.")
+			return nil, errors.New(b.String())
+		}
+	} else {
+		// Explicit --config / CONFIG_FILES layers must each exist (no per-file XDG
+		// fallback). CONFIG_DIR files were already validated by configDirLayers.
+		for _, f := range cfgFiles {
+			if _, err := os.Stat(f); err != nil {
+				return nil, fmt.Errorf("config file not found: %s", f)
+			}
+		}
+	}
+
+	// RFC CK section-per-file: a loomcycle.yaml base brings its loomcycle.*.yaml
+	// section siblings, deep-merged after it. Re-globbed every call so an
+	// added/removed section file is seen on reload. Shared with loadLayeredConfig
+	// (validate/doctor lockstep). Only files existing on disk are added.
+	if expanded := cli.WithSectionSiblings(cfgFiles); len(expanded) > len(cfgFiles) {
+		orig := make(map[string]bool, len(cfgFiles))
+		for _, f := range cfgFiles {
+			orig[f] = true
+		}
+		var added []string
+		for _, f := range expanded {
+			if !orig[f] {
+				added = append(added, f)
+			}
+		}
+		logf("config: + %d section file(s): %s", len(added), strings.Join(added, ", "))
+		cfgFiles = expanded
+	}
+
+	// Ordered disk-file layers: CONFIG_DIR first, then CONFIG_FILES/--config.
+	diskFiles := append(append([]string{}, configDirFiles...), cfgFiles...)
+	if len(diskFiles) > 1 {
+		logf("config: layering %d files (last wins): %s", len(diskFiles), strings.Join(diskFiles, " ◁ "))
+	}
+	// Auto-load <configdir>/auth.env BEFORE config.Load reads os.Getenv, keyed on
+	// the LAST (authoritative) disk-file layer. Set-if-unset (real env wins), so a
+	// reload re-run sets nothing (n=0) and stays silent. A presets-only stack has
+	// no file to load from.
+	if len(diskFiles) > 0 {
+		if authEnvPath, n, err := cli.LoadAuthEnv(diskFiles[len(diskFiles)-1]); err != nil {
+			logf("auth.env: %v (continuing without it)", err)
+		} else if n > 0 {
+			logf("auth.env: loaded %d var(s) from %s (a shell export overrides them)", n, authEnvPath)
+		}
+	}
+
+	// Build the full ordered layer list. RFC BF P2a: the embedded default-providers
+	// layer is the UNCONDITIONAL base (before opt-in presets); LOOMCYCLE_NO_DEFAULT_PROVIDERS=1
+	// drops it. Kept OUT of presetLayers so the "no config found" error still fires
+	// on a bare run. Order, base→top (last wins):
+	//   providers.default → opt-in presets → CONFIG_DIR → CONFIG_FILES/--config
+	layers := make([]config.Layer, 0, 1+len(presetLayers)+len(diskFiles))
+	if os.Getenv("LOOMCYCLE_NO_DEFAULT_PROVIDERS") != "1" {
+		layers = append(layers, config.Layer{Name: "providers.default", Data: embedded.DefaultProviders()})
+	}
+	layers = append(layers, presetLayers...)
+	for _, f := range diskFiles {
+		layers = append(layers, config.Layer{Name: f})
+	}
+	return layers, nil
 }

--- a/cmd/loomcycle/autodiscover_test.go
+++ b/cmd/loomcycle/autodiscover_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
 )
 
 // TestConfigDirLayers: LOOMCYCLE_CONFIG_DIR enumerates *.yaml/*.yml directly
@@ -60,5 +62,89 @@ func TestConfigDirLayers_EmptyAndMissing(t *testing.T) {
 
 	if _, err := configDirLayers(filepath.Join(empty, "does-not-exist")); err == nil {
 		t.Errorf("a missing LOOMCYCLE_CONFIG_DIR should error (caller exits)")
+	}
+}
+
+// layerNamesOf collects the Name of each layer in order.
+func layerNamesOf(layers []config.Layer) []string {
+	out := make([]string, len(layers))
+	for i, l := range layers {
+		out[i] = l.Name
+	}
+	return out
+}
+
+func layersContain(names []string, want string) bool {
+	for _, n := range names {
+		if n == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestAssembleConfigLayers_ReGlobsSectionSiblings proves the RFC CK reload
+// follow-up: assembleConfigLayers re-globs a base's loomcycle.*.yaml siblings on
+// every call, so a section file added (or removed) after boot is picked up by a
+// runtime reload with no restart. NO_DEFAULT_PROVIDERS=1 drops the constant
+// providers.default layer so the layer count is exactly the disk files.
+func TestAssembleConfigLayers_ReGlobsSectionSiblings(t *testing.T) {
+	dir := t.TempDir()
+	base := filepath.Join(dir, "loomcycle.yaml")
+	if err := os.WriteFile(base, []byte("provider_priority: [mock]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LOOMCYCLE_PRESETS", "")
+	t.Setenv("LOOMCYCLE_CONFIG_DIR", "")
+	t.Setenv("LOOMCYCLE_CONFIG_FILES", "")
+	t.Setenv("LOOMCYCLE_NO_DEFAULT_PROVIDERS", "1")
+
+	sib := filepath.Join(dir, "loomcycle.memory.yaml")
+
+	before, err := assembleConfigLayers(nil, []string{base}, false)
+	if err != nil {
+		t.Fatalf("assemble before: %v", err)
+	}
+	if names := layerNamesOf(before); layersContain(names, sib) {
+		t.Fatalf("sibling %s present before it was created: %v", sib, names)
+	}
+
+	// Add a section sibling and RE-assemble: the re-glob sees it, no restart.
+	if err := os.WriteFile(sib, []byte("provider_priority: [mock]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	after, err := assembleConfigLayers(nil, []string{base}, false)
+	if err != nil {
+		t.Fatalf("assemble after: %v", err)
+	}
+	if names := layerNamesOf(after); !layersContain(names, sib) {
+		t.Fatalf("re-glob did not pick up added sibling %s: %v", sib, names)
+	}
+	if len(after) != len(before)+1 {
+		t.Fatalf("adding one sibling should add exactly one layer: before=%d after=%d", len(before), len(after))
+	}
+
+	// Remove the sibling and RE-assemble: it drops back out.
+	if err := os.Remove(sib); err != nil {
+		t.Fatal(err)
+	}
+	gone, err := assembleConfigLayers(nil, []string{base}, false)
+	if err != nil {
+		t.Fatalf("assemble gone: %v", err)
+	}
+	if names := layerNamesOf(gone); layersContain(names, sib) {
+		t.Fatalf("removed sibling %s still present after re-glob: %v", sib, names)
+	}
+}
+
+// TestAssembleConfigLayers_MissingExplicitFile: an explicit config file that does
+// not exist yields an ERROR, not an os.Exit — the property the runtime reload
+// relies on to reject a now-broken assembly and keep the running config.
+func TestAssembleConfigLayers_MissingExplicitFile(t *testing.T) {
+	t.Setenv("LOOMCYCLE_PRESETS", "")
+	t.Setenv("LOOMCYCLE_CONFIG_DIR", "")
+	t.Setenv("LOOMCYCLE_CONFIG_FILES", "")
+	if _, err := assembleConfigLayers(nil, []string{filepath.Join(t.TempDir(), "nope.yaml")}, false); err == nil {
+		t.Fatal("expected an error for a missing explicit config file, got nil")
 	}
 }

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -35,7 +35,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/denn-gubsky/loomcycle/cmd/loomcycle/embedded"
 	"github.com/denn-gubsky/loomcycle/internal/agents"
 	a2aapi "github.com/denn-gubsky/loomcycle/internal/api/a2a"
 	lchttp "github.com/denn-gubsky/loomcycle/internal/api/http"
@@ -668,141 +667,15 @@ func main() {
 		return
 	}
 
-	// RFC AQ — resolve the embedded-preset selection (base of the config stack).
-	// --preset flags, if any, override the LOOMCYCLE_PRESETS env list; OPT-IN by
-	// default (neither set → no presets → exactly today's behaviour). A bad name
-	// is fatal (typo protection) and lists the available units.
-	presetNames := selectPresetNames(presetFlags, os.Getenv("LOOMCYCLE_PRESETS"))
-	var presetLayers []config.Layer
-	if len(presetNames) > 0 {
-		units, err := embedded.ResolveUnits(presetNames)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "loomcycle: %v\n", err)
-			os.Exit(1)
-		}
-		for _, u := range units {
-			presetLayers = append(presetLayers, config.Layer{Name: u.Name, Data: u.Data})
-		}
-		log.Printf("config: layering %d embedded preset(s)/bundle(s) as base: %s", len(presetNames), strings.Join(presetNames, ", "))
-	}
-
-	// Assemble the operator's config-FILE layers (RFC AN/AQ). The precedence
-	// chain, base → top, last wins:
-	//   embedded presets → LOOMCYCLE_CONFIG_DIR/*.yaml → LOOMCYCLE_CONFIG_FILES → --config
-	// With none of these, fall back to the lone XDG-discovered default (today's
-	// behavior) — unless embedded presets are active, in which case a presets-only
-	// stack (no operator file) is allowed (RFC AQ bare-start).
-
-	// LOOMCYCLE_CONFIG_DIR (RFC AQ §4) — a directory whose *.yaml/*.yml files layer
-	// as a group, lexically, between the presets and CONFIG_FILES. For a mounted
-	// overlay dir or an image-baked drop-in set. Unset → skipped.
-	var configDirFiles []string
-	if dir := strings.TrimSpace(os.Getenv("LOOMCYCLE_CONFIG_DIR")); dir != "" {
-		files, err := configDirLayers(dir)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "loomcycle: LOOMCYCLE_CONFIG_DIR: %v\n", err)
-			os.Exit(1)
-		}
-		configDirFiles = files
-		if len(files) > 0 {
-			log.Printf("config: layering %d file(s) from LOOMCYCLE_CONFIG_DIR=%s (lexical order)", len(files), dir)
-		}
-	}
-
-	var cfgFiles []string
-	for _, f := range strings.Split(os.Getenv("LOOMCYCLE_CONFIG_FILES"), ":") {
-		if f = strings.TrimSpace(f); f != "" {
-			cfgFiles = append(cfgFiles, f)
-		}
-	}
-	cfgFiles = append(cfgFiles, cfgPaths...)
-
-	if len(cfgFiles) == 0 && len(configDirFiles) == 0 {
-		// No explicit operator config (dir or files) → v0.11.1 XDG auto-discovery.
-		// The search list is the same one `loomcycle doctor` uses (lockstep).
-		resolvedCfg, found := resolveConfigPath("loomcycle.yaml")
-		switch {
-		case found:
-			cfgFiles = []string{resolvedCfg}
-		case len(presetLayers) > 0:
-			// Presets-only: the embedded base IS the config (RFC AQ §2.2).
-			log.Printf("config: no operator config file — running from embedded presets only")
-		default:
-			fmt.Fprintln(os.Stderr, "loomcycle: no config found at any of:")
-			for _, p := range configAutoDiscoveryPaths() {
-				fmt.Fprintf(os.Stderr, "    %s\n", p)
-			}
-			fmt.Fprintln(os.Stderr)
-			fmt.Fprintln(os.Stderr, "Run `loomcycle init` to create one, pass --config <path>, set LOOMCYCLE_CONFIG_DIR, or select an embedded base with LOOMCYCLE_PRESETS=base.")
-			os.Exit(1)
-		}
-	} else {
-		// Explicit --config / CONFIG_FILES layers must each exist (no per-file XDG
-		// fallback — explicit means literal). The CONFIG_DIR files were already
-		// validated by configDirLayers. Fail fast with the offending path.
-		for _, f := range cfgFiles {
-			if _, err := os.Stat(f); err != nil {
-				fmt.Fprintf(os.Stderr, "loomcycle: config file not found: %s\n", f)
-				os.Exit(1)
-			}
-		}
-	}
-
-	// RFC CK section-per-file: a loomcycle.yaml base (auto-discovered OR passed via
-	// --config / CONFIG_FILES) brings its loomcycle.*.yaml section siblings, which
-	// deep-merge after it. Shared with loadLayeredConfig so validate/doctor resolve
-	// the identical set (lockstep). CONFIG_DIR is untouched — it already globs the
-	// whole dir. Only the sibling FILES existing on disk are added, so no new
-	// existence check is needed.
-	if expanded := cli.WithSectionSiblings(cfgFiles); len(expanded) > len(cfgFiles) {
-		orig := make(map[string]bool, len(cfgFiles))
-		for _, f := range cfgFiles {
-			orig[f] = true
-		}
-		var added []string
-		for _, f := range expanded {
-			if !orig[f] {
-				added = append(added, f)
-			}
-		}
-		log.Printf("config: + %d section file(s): %s", len(added), strings.Join(added, ", "))
-		cfgFiles = expanded
-	}
-
-	// The ordered disk-file layers: CONFIG_DIR first, then CONFIG_FILES/--config.
-	diskFiles := append(append([]string{}, configDirFiles...), cfgFiles...)
-	if len(diskFiles) > 1 {
-		log.Printf("config: layering %d files (last wins): %s", len(diskFiles), strings.Join(diskFiles, " ◁ "))
-	}
-	// Auto-load <configdir>/auth.env (companion to `loomcycle init
-	// --with-token`) BEFORE config.Load reads os.Getenv, so a persisted
-	// LOOMCYCLE_AUTH_TOKEN is in scope without a shell-rc edit. Set-if-unset
-	// (real env wins), so an explicit shell export still overrides it. Keyed on
-	// the LAST (authoritative) disk-file layer — that's where an init-written
-	// auth.env lives. A presets-only stack has no file, so there's nothing to load.
-	if len(diskFiles) > 0 {
-		if authEnvPath, n, err := cli.LoadAuthEnv(diskFiles[len(diskFiles)-1]); err != nil {
-			log.Printf("auth.env: %v (continuing without it)", err)
-		} else if n > 0 {
-			log.Printf("auth.env: loaded %d var(s) from %s (a shell export overrides them)", n, authEnvPath)
-		}
-	}
-	// Build the full ordered layer list. RFC BF P2a: the embedded default-providers
-	// layer is the UNCONDITIONAL base (before opt-in presets) so a config with no
-	// `providers:` block resolves providers identically to pre-P2a; operator
-	// `providers:` entries deep-merge over it. LOOMCYCLE_NO_DEFAULT_PROVIDERS=1 drops
-	// it (then only explicitly-declared providers exist). It is kept OUT of
-	// presetLayers so the "no config found" error above still fires on a bare run
-	// (a lone default-providers layer is not, on its own, a usable config). Order,
-	// base→top (last wins):
-	//   providers.default → opt-in presets → CONFIG_DIR → CONFIG_FILES/--config
-	layers := make([]config.Layer, 0, 1+len(presetLayers)+len(diskFiles))
-	if os.Getenv("LOOMCYCLE_NO_DEFAULT_PROVIDERS") != "1" {
-		layers = append(layers, config.Layer{Name: "providers.default", Data: embedded.DefaultProviders()})
-	}
-	layers = append(layers, presetLayers...)
-	for _, f := range diskFiles {
-		layers = append(layers, config.Layer{Name: f})
+	// Assemble the ordered config-layer stack (embedded presets → CONFIG_DIR →
+	// CONFIG_FILES/--config + loomcycle.*.yaml section siblings). Factored into a
+	// shared, error-returning helper (autodiscover.go) so the RFC CK runtime
+	// reload can RE-run the same assembly — re-globbing siblings and re-reading
+	// CONFIG_DIR — and thus pick up added/removed config files without a restart.
+	layers, err := assembleConfigLayers(presetFlags, cfgPaths, true)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "loomcycle: %s\n", err)
+		os.Exit(1)
 	}
 	cfg, err := config.LoadLayers(layers...)
 	if err != nil {
@@ -3302,7 +3175,17 @@ func main() {
 			},
 		})
 	}
-	srv.SetConfigReloader(func() (*config.Config, error) { return config.LoadLayers(layers...) }, reloaders...)
+	// The reload LOADER re-runs the full boot assembly (re-glob siblings, re-read
+	// CONFIG_DIR/CONFIG_FILES) rather than replaying the captured boot `layers`, so
+	// a config or section file added/removed since boot takes effect on reload
+	// without a restart. verbose=false: don't re-log the layering on every reload.
+	srv.SetConfigReloader(func() (*config.Config, error) {
+		reloadLayers, err := assembleConfigLayers(presetFlags, cfgPaths, false)
+		if err != nil {
+			return nil, err
+		}
+		return config.LoadLayers(reloadLayers...)
+	}, reloaders...)
 
 	go func() {
 		log.Printf("loomcycle listening on %s", cfg.Env.ListenAddr)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -922,7 +922,7 @@ The same operation is available through every transport that consumes the Connec
 
 ### At runtime — reload changed config (`POST /v1/_config/reload`)
 
-Edited a config file and want it live without a restart (which drops in-flight runs)? `POST /v1/_config/reload` re-loads the **same layered stack** the server booted with (presets → `LOOMCYCLE_CONFIG_DIR` → `LOOMCYCLE_CONFIG_FILES` → `--config`; disk-file layers are re-read fresh), validates it, and applies the sections it can apply live — reporting the rest.
+Edited a config file and want it live without a restart (which drops in-flight runs)? `POST /v1/_config/reload` **re-assembles** the layered stack the server booted with (presets → `LOOMCYCLE_CONFIG_DIR` → `LOOMCYCLE_CONFIG_FILES` → `--config`), re-globbing the `loomcycle.*.yaml` section siblings and re-reading `LOOMCYCLE_CONFIG_DIR` fresh — so a config or section file **added or removed** since boot is picked up too — validates it, and applies the sections it can apply live — reporting the rest.
 
 ```sh
 # Preview the diff without applying:
@@ -1235,9 +1235,11 @@ layers every `*.yaml` in the directory.
 
 This pairs with runtime reload: edit a section file present at boot and
 `POST /v1/_config/reload` picks it up. **Adding or removing** a section file after
-boot needs a restart — the reload re-reads the file set captured at boot, so a new
-file is not seen and a removed file makes the reload fail (`422`, the running
-config is kept, never corrupted) until it's restored or the process restarts.
+boot is also picked up on reload — the reload re-globs the `loomcycle.*.yaml`
+siblings (and re-reads `LOOMCYCLE_CONFIG_DIR`) fresh each time, so a newly-dropped
+section file takes effect and a removed one is dropped, with no restart. (If a
+removal leaves the candidate invalid, the reload fails `422` and the running
+config is kept, never corrupted.)
 
 Notes: a base `loomcycle.yaml` must exist (it may be minimal); `*.example.yaml`
 siblings are ignored (so the shipped `loomcycle.example.yaml` left beside a live


### PR DESCRIPTION
The second of the three RFC CK reload follow-ups: **re-glob on reload**.

## Problem

`POST /v1/_config/reload` replayed the layer list captured at boot, so a config or section file **added or removed** after boot was never seen — an operator dropping a new `loomcycle.memory.yaml` beside the base had to restart (dropping in-flight runs). The docs even told them so. That defeats the point of section-per-file config.

## Change

Factor the boot config-assembly — preset resolution, `LOOMCYCLE_CONFIG_DIR` glob, `loomcycle.*.yaml` sibling discovery, `auth.env`, the ordered layer build — out of `main()` into a shared, **error-returning** helper `assembleConfigLayers(presetFlags, cfgPaths, verbose)` in `autodiscover.go`.

- **Boot** calls it with `verbose=true` and keeps the `os.Exit`-on-error behavior (a boot with a broken config still dies loudly).
- **The reload loader** now calls it too (`verbose=false`) instead of replaying the captured boot `layers` slice — so every reload **re-globs the section siblings and re-reads `CONFIG_DIR` fresh**, picking up added/removed files.
- Because it returns an error rather than `os.Exit`, a now-broken assembly (e.g. a removed base) makes the reload fail **422 with the running config kept** — the validate-before-apply contract already in place.

`auth.env` is set-if-unset, so its re-run on reload sets nothing (`n=0`) and stays silent; `verbose` gates the boot-time layering logs so a reload doesn't re-log the whole stack. Net `main()` change is a −146-line extraction; no behavior change at boot.

## Tested

`go test ./...` clean (95 ok); `gofmt`/`vet` clean.

- **Unit** (`autodiscover_test.go`): \`TestAssembleConfigLayers_ReGlobsSectionSiblings\` — a sibling added between two calls appears in the second assembly and is dropped when removed; \`TestAssembleConfigLayers_MissingExplicitFile\` — a missing explicit file returns an *error*, not an `os.Exit` (the property reload relies on).
- **Live**: booted with a base-only `loomcycle.yaml`; baseline reload → \`applied:[]\` (no-op); dropped a NEW \`loomcycle.tiers.yaml\` **post-boot** → reload → \`applied:[tiers]\`, and the \`high\` tier appeared under \`user_tier default\` in \`/v1/_routing\`; removed the file → reload → \`applied:[tiers]\`, tier gone. No restart at any point.

## Docs

`CONFIGURATION.md` reload + section-per-file notes updated: adding/removing a section file is now reload-live, no longer restart-required.

## Follow-up

Last of the three: **Connector/gRPC/MCP parity** for the reload endpoint (lift `ReloadConfig` to the `Connector` interface + a gRPC RPC + an MCP tool + TS/Python adapters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)