### PR TITLE
fix(history): make op=recap write a short summary, not a compaction

### DIFF
--- a/internal/api/http/history_recap_test.go
+++ b/internal/api/http/history_recap_test.go
@@ -2,7 +2,11 @@ package http
 
 import (
 	"context"
+	"strings"
 	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/loop"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
 )
 
 // TestRecapSession_ProducesSummary: the server-injected History op=recap
@@ -34,5 +38,57 @@ func TestRecapSession_EmptyTranscriptErrors(t *testing.T) {
 	}
 	if _, err := srv.RecapSession(ctx, sess.ID); err == nil {
 		t.Fatal("recap of a chat with no transcript must return an error")
+	}
+}
+
+// promptCapturingProvider answers like compactFixture's scripted provider but
+// keeps the system prompt, so a test can assert WHICH summarization prompt the
+// recap path sent.
+type promptCapturingProvider struct {
+	sys string
+}
+
+func (p *promptCapturingProvider) ID() string                                   { return "scripted" }
+func (p *promptCapturingProvider) Probe(context.Context) error                  { return nil }
+func (p *promptCapturingProvider) ListModels(context.Context) ([]string, error) { return nil, nil }
+func (p *promptCapturingProvider) Capabilities() providers.Capabilities {
+	return providers.Capabilities{Streaming: true}
+}
+func (p *promptCapturingProvider) Call(_ context.Context, req providers.Request) (<-chan providers.Event, error) {
+	if len(req.System) > 0 {
+		p.sys = req.System[0].Text
+	}
+	ch := make(chan providers.Event, 2)
+	ch <- providers.Event{Type: providers.EventText, Text: "Short recap."}
+	ch <- providers.Event{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{}}
+	close(ch)
+	return ch, nil
+}
+
+// TestRecapSession_UsesTheShortRecapPrompt: op=recap must summarize for a chat
+// LIST — two sentences — not reuse compactionPrompt's "N% of the original
+// length", which is sized to free a context window and yields the paragraphs
+// that made stored recaps unusable as a title subtitle.
+func TestRecapSession_UsesTheShortRecapPrompt(t *testing.T) {
+	srv, _ := compactFixture(t)
+	sessID, _ := seedConversation(t, srv, true)
+
+	// Swap the fixture's scripted provider for one that keeps the system prompt.
+	// Same-package test, so the unexported resolver field is reachable directly —
+	// compactFixture hard-wires its own provider and takes no injection point.
+	prov := &promptCapturingProvider{}
+	srv.providers = &stubResolver{p: prov}
+
+	if _, err := srv.RecapSession(context.Background(), sessID); err != nil {
+		t.Fatalf("RecapSession: %v", err)
+	}
+	if !strings.Contains(prov.sys, "two sentences") {
+		t.Errorf("recap should ask for two sentences, sent: %q", prov.sys)
+	}
+	if strings.Contains(prov.sys, "% of the original length") {
+		t.Errorf("recap must not send the compaction prompt, sent: %q", prov.sys)
+	}
+	if !strings.Contains(prov.sys, "256") {
+		t.Errorf("recap prompt should name the %d-char budget, sent: %q", loop.RecapMaxChars, prov.sys)
 	}
 }

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -6962,13 +6962,16 @@ func (s *Server) compactRunWithSource(ctx context.Context, runID, source string)
 	return connector.CompactResult{RunID: runID, Compacted: true, BeforeTokens: before, AfterTokens: after, Applied: applied}, nil
 }
 
-// RecapSession produces a fresh LLM summary of a whole chat (session) for the
-// History tool's op=recap. It is the off-loop, session-scoped twin of
-// compactRunWithSource's summarize step: a chat spans EVERY run, so it replays
-// the full session transcript (like resume) rather than a single run's, and it
-// does NOT mutate the loop or persist a compaction marker — the History tool
-// stores the returned text to sessions.summary. The tool has ALREADY enforced
-// the scope fold on sessionID before calling this, so the lookup here trusts it.
+// RecapSession produces a fresh SHORT summary of a whole chat (session) for the
+// History tool's op=recap. It shares compactRunWithSource's summarize plumbing
+// but not its prompt: a chat spans EVERY run, so it replays the full session
+// transcript (like resume) rather than a single run's, it does NOT mutate the
+// loop or persist a compaction marker — the History tool stores the returned
+// text to sessions.summary — and it asks loop.Recap for the two-sentence gist
+// that belongs beside a title in a chat list, not the long durable-context
+// summary a compaction produces for an assistant to resume from. The tool has
+// ALREADY enforced the scope fold on sessionID before calling this, so the
+// lookup here trusts it.
 //
 // Wired onto History.Recap in main.go. Returns a clean error on every failure
 // path (surfaced by the tool as an errResult) — never a panic.
@@ -7020,14 +7023,12 @@ func (s *Server) RecapSession(ctx context.Context, sessionID string) (string, er
 		return "", fmt.Errorf("provider unavailable: %w", err)
 	}
 
-	// Prefer the agent's cheaper compaction model + target when configured — a
-	// recap is exactly a compaction summary that we persist instead of applying.
-	targetPct := config.CompactionDefaultTargetPct
+	// Prefer the agent's cheaper compaction model when configured — a recap is a
+	// summarization call like compaction's, so the same cheap model suits it. Its
+	// target_percentage is deliberately NOT read: that sizes a compaction summary
+	// against the context window, while a recap is bounded by loop.RecapMaxChars.
 	summaryModel := model
 	if c := agentDef.Compaction; c != nil {
-		if c.TargetPercentage != nil {
-			targetPct = *c.TargetPercentage
-		}
 		if c.Model != nil && *c.Model != "" {
 			summaryModel = *c.Model
 		}
@@ -7041,7 +7042,7 @@ func (s *Server) RecapSession(ctx context.Context, sessionID string) (string, er
 	summCtx = providers.WithOperatorKeyAllowed(summCtx, !restricted)
 	summCtx = tools.WithRunIdentity(summCtx, tools.RunIdentityValue{TenantID: sess.TenantID, UserID: userID})
 	summCtx = tools.WithAgentName(summCtx, sess.Agent)
-	summary, err := loop.Summarize(summCtx, provider, summaryModel, msgs, targetPct)
+	summary, err := loop.Recap(summCtx, provider, summaryModel, msgs)
 	if err != nil {
 		return "", fmt.Errorf("summarize: %w", err)
 	}

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -1044,13 +1044,51 @@ func compactionPrompt(targetPct int) string {
 		"context the assistant can rely on to continue. Output ONLY the summary prose — no preamble.", targetPct)
 }
 
-// Summarize makes ONE provider call to compact msgs into a summary string. The
-// conversation is flattened into a single user message (role-tagged) so the call
-// is valid regardless of how msgs alternates, and the model clearly sees
-// "summarize this". NO tools are offered → the summary call cannot re-enter the
-// tool / compaction machinery. Shared by the loop (auto + self-compact) and the
-// server (manual + terminal compaction). model may be a cheaper same-provider model.
+// RecapMaxChars bounds the History op=recap summary. A recap is a chat-list
+// subtitle a human skims — a couple of lines beside the chat's title — so the
+// length has to be a property of the TEXT, not something each surface clips off
+// whatever came back.
+const RecapMaxChars = 256
+
+// recapMaxTokens caps the recap call so a model that ignores the length
+// instruction still can't bill (or return) a paragraph. Generous next to
+// RecapMaxChars (~64 tokens at 4 chars/token) so a compliant model finishes its
+// sentence well inside the cap rather than being cut off mid-word.
+const recapMaxTokens = 160
+
+// recapPrompt is the op=recap counterpart to compactionPrompt. A recap is NOT a
+// compaction: nothing is being freed and no assistant has to resume from it, so
+// compactionPrompt's "roughly N% of the original length" — which on a long chat
+// means several paragraphs of durable context — is the wrong target entirely.
+// Ask for the two-sentence gist a human reads in a list.
+func recapPrompt() string {
+	return fmt.Sprintf("Summarize this conversation in at most two sentences, under %d characters, "+
+		"to label it in a list of chats: what the user is working on and where it stands. "+
+		"Write plain prose — no preamble, no bullet points, no markdown, no heading. "+
+		"Output ONLY the summary.", RecapMaxChars)
+}
+
+// Summarize makes ONE provider call to compact msgs into a summary string.
+// Shared by the loop (auto + self-compact) and the server (manual + terminal
+// compaction). model may be a cheaper same-provider model.
 func Summarize(ctx context.Context, provider providers.Provider, model string, msgs []providers.Message, targetPct int) (string, error) {
+	return summarizeWith(ctx, provider, model, msgs, compactionPrompt(targetPct), "Conversation to compact:", 0)
+}
+
+// Recap makes ONE provider call to produce the SHORT chat summary behind History
+// op=recap, which the server persists to sessions.summary for the chat list.
+// Same mechanics as Summarize, different prompt and a token cap — see
+// recapPrompt for why a recap can't just reuse the compaction summary.
+func Recap(ctx context.Context, provider providers.Provider, model string, msgs []providers.Message) (string, error) {
+	return summarizeWith(ctx, provider, model, msgs, recapPrompt(), "Conversation to summarize:", recapMaxTokens)
+}
+
+// summarizeWith is the shared body of Summarize and Recap. The conversation is
+// flattened into a single user message (role-tagged) so the call is valid
+// regardless of how msgs alternates, and the model clearly sees "summarize
+// this". NO tools are offered → the summary call cannot re-enter the tool /
+// compaction machinery. maxTokens 0 leaves the provider default.
+func summarizeWith(ctx context.Context, provider providers.Provider, model string, msgs []providers.Message, system, lead string, maxTokens int) (string, error) {
 	var convo strings.Builder
 	for _, m := range msgs {
 		for _, c := range m.Content {
@@ -1067,11 +1105,12 @@ func Summarize(ctx context.Context, provider providers.Provider, model string, m
 		}
 	}
 	ch, err := provider.Call(ctx, providers.Request{
-		Model:  model,
-		System: []providers.ContentBlock{{Type: "text", Text: compactionPrompt(targetPct)}},
+		Model:     model,
+		System:    []providers.ContentBlock{{Type: "text", Text: system}},
+		MaxTokens: maxTokens,
 		Messages: []providers.Message{{
 			Role:    "user",
-			Content: []providers.ContentBlock{{Type: "text", Text: "Conversation to compact:\n\n" + convo.String()}},
+			Content: []providers.ContentBlock{{Type: "text", Text: lead + "\n\n" + convo.String()}},
 		}},
 	})
 	if err != nil {

--- a/internal/loop/recap_test.go
+++ b/internal/loop/recap_test.go
@@ -1,0 +1,141 @@
+package loop
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// recapProbeProvider records the last Request it was called with — including the
+// token cap, which the package's other capturingProvider does not keep — and
+// replies with scripted text, so a test can assert on what the summarize path
+// actually sends AND on what it returns.
+type recapProbeProvider struct {
+	req   providers.Request
+	calls int
+	reply string
+}
+
+func (p *recapProbeProvider) ID() string                                   { return "capturing" }
+func (p *recapProbeProvider) Probe(context.Context) error                  { return nil }
+func (p *recapProbeProvider) ListModels(context.Context) ([]string, error) { return nil, nil }
+func (p *recapProbeProvider) Capabilities() providers.Capabilities {
+	return providers.Capabilities{Streaming: true}
+}
+func (p *recapProbeProvider) Call(_ context.Context, req providers.Request) (<-chan providers.Event, error) {
+	p.req = req
+	p.calls++
+	ch := make(chan providers.Event, 2)
+	ch <- providers.Event{Type: providers.EventText, Text: p.reply}
+	ch <- providers.Event{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{}}
+	close(ch)
+	return ch, nil
+}
+
+func recapConvo() []providers.Message {
+	return []providers.Message{userMsg("port the board to SSE"), asstMsg("done, here is the diff")}
+}
+
+// TestRecap_AsksForATwoSentenceSummary: the recap prompt must ask for the short
+// chat-list gist — NOT compactionPrompt's "roughly N% of the original length",
+// which is what made stored recaps run to paragraphs.
+func TestRecap_AsksForATwoSentenceSummary(t *testing.T) {
+	p := &recapProbeProvider{reply: "Ported the board to SSE. The diff is under review."}
+	if _, err := Recap(context.Background(), p, "m", recapConvo()); err != nil {
+		t.Fatalf("Recap: %v", err)
+	}
+	if len(p.req.System) != 1 {
+		t.Fatalf("want exactly one system block, got %d", len(p.req.System))
+	}
+	sys := p.req.System[0].Text
+	if !strings.Contains(sys, "two sentences") {
+		t.Errorf("recap prompt should ask for at most two sentences, got %q", sys)
+	}
+	if !strings.Contains(sys, strconv.Itoa(RecapMaxChars)) {
+		t.Errorf("recap prompt should name the %d-char budget, got %q", RecapMaxChars, sys)
+	}
+	if strings.Contains(sys, "% of the original length") {
+		t.Errorf("recap must not reuse the compaction prompt's length target: %q", sys)
+	}
+	if strings.Contains(sys, "context window") {
+		t.Errorf("recap is not a compaction; prompt should not talk about the context window: %q", sys)
+	}
+}
+
+// TestRecap_CapsMaxTokens: the prompt is an instruction a model may ignore, so
+// the request also carries a hard token cap — with headroom over RecapMaxChars
+// (~4 chars/token) so a compliant reply is never cut off mid-sentence.
+func TestRecap_CapsMaxTokens(t *testing.T) {
+	p := &recapProbeProvider{reply: "Short."}
+	if _, err := Recap(context.Background(), p, "m", recapConvo()); err != nil {
+		t.Fatalf("Recap: %v", err)
+	}
+	if p.req.MaxTokens != recapMaxTokens {
+		t.Errorf("MaxTokens = %d, want %d", p.req.MaxTokens, recapMaxTokens)
+	}
+	if p.req.MaxTokens*4 <= RecapMaxChars {
+		t.Errorf("token cap %d leaves no headroom over the %d-char budget", p.req.MaxTokens, RecapMaxChars)
+	}
+}
+
+// TestRecap_SendsTheWholeConversationAndNoTools: same flattening contract as
+// Summarize — every turn reaches the model in one user message, and no tools are
+// offered, so the summarize call can never re-enter the tool machinery.
+func TestRecap_SendsTheWholeConversationAndNoTools(t *testing.T) {
+	p := &recapProbeProvider{reply: "ok"}
+	if _, err := Recap(context.Background(), p, "m", recapConvo()); err != nil {
+		t.Fatalf("Recap: %v", err)
+	}
+	if len(p.req.Messages) != 1 || p.req.Messages[0].Role != "user" {
+		t.Fatalf("want one user message, got %+v", p.req.Messages)
+	}
+	body := p.req.Messages[0].Content[0].Text
+	for _, want := range []string{"port the board to SSE", "done, here is the diff"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("flattened conversation is missing %q: %q", want, body)
+		}
+	}
+	if len(p.req.Tools) != 0 {
+		t.Errorf("the recap call must offer no tools, got %d", len(p.req.Tools))
+	}
+}
+
+// TestRecap_ReturnsTheModelText: the recap is stored verbatim — no server-side
+// clipping — so whatever the model writes is what the chat list shows.
+func TestRecap_ReturnsTheModelText(t *testing.T) {
+	p := &recapProbeProvider{reply: "Ported the board to SSE; the diff is under review."}
+	got, err := Recap(context.Background(), p, "m", recapConvo())
+	if err != nil {
+		t.Fatalf("Recap: %v", err)
+	}
+	if got != p.reply {
+		t.Errorf("got %q, want the model text %q", got, p.reply)
+	}
+}
+
+// TestSummarize_StillUsesTheCompactionPrompt: extracting summarizeWith must not
+// have changed the compaction path — it keeps the percentage-target prompt and
+// leaves MaxTokens at the provider default (a compaction summary is long).
+func TestSummarize_StillUsesTheCompactionPrompt(t *testing.T) {
+	p := &recapProbeProvider{reply: "SUMMARY"}
+	if _, err := Summarize(context.Background(), p, "m", recapConvo(), 25); err != nil {
+		t.Fatalf("Summarize: %v", err)
+	}
+	sys := p.req.System[0].Text
+	if !strings.Contains(sys, fmt.Sprintf("roughly %d%%", 25)) {
+		t.Errorf("compaction prompt should carry the percentage target, got %q", sys)
+	}
+	if !strings.Contains(sys, "context window") {
+		t.Errorf("compaction prompt should still frame this as freeing context, got %q", sys)
+	}
+	if p.req.MaxTokens != 0 {
+		t.Errorf("MaxTokens = %d, want 0 (provider default) for a compaction summary", p.req.MaxTokens)
+	}
+	if !strings.Contains(p.req.Messages[0].Content[0].Text, "Conversation to compact:") {
+		t.Errorf("compaction lead-in changed: %q", p.req.Messages[0].Content[0].Text)
+	}
+}

--- a/internal/tools/builtin/history.go
+++ b/internal/tools/builtin/history.go
@@ -82,7 +82,7 @@ func (h *History) Description() string {
 		"get (one chat's metadata + full transcript; format:markdown renders the whole event log for a human, " +
 		"format:conversation renders only the user/assistant turns for a model), rename (set title), " +
 		"annotate (set description and/or tags), pin (float to the top), archive (reversible soft-hide), " +
-		"recap (refresh the stored LLM summary of the chat — idempotent, safe on a live/parked chat), " +
+		"recap (refresh the chat's stored one-or-two-sentence summary — idempotent, safe on a live/parked chat), " +
 		"resume (return a handle for continuing the chat in a new run), " +
 		"related (find chats similar in meaning to a given chat (session_id) or a free-text query — needs an embedder). " +
 		"scope selects whose chats: self = this agent's, user = this end-user's, tenant = this tenant's, " +


### PR DESCRIPTION
Recovered work: this commit was authored on a since-abandoned local branch (`feature-cli-tier-only-agent-resolution`, never pushed) and would have been lost. Every other commit on that branch was already superseded by work merged separately (RFC CG `op=guide`/`inject_tool_guide` → #1042/#1043, the identity-node verify fix → #1044/#1045, the tier-only CLI fix landed on its own). **This one alone was a genuine, unmerged improvement**, so it's recovered here verbatim (original authorship preserved) and cherry-picked cleanly onto current `main`.

## The problem

`RecapSession` (History `op=recap`) reused `loop.Summarize`, whose prompt asks for *"roughly N% of the original length"* — the right target for **compaction** (it's freeing a context window) but wrong for a **recap**, which is a chat-list subtitle a human skims beside the title. On a long chat the stored `sessions.summary` came back as several paragraphs, and every surface showing it had to clip it — a length contract no consumer can rely on.

## The fix

Give recap its own prompt: at most two sentences, under `RecapMaxChars` (256), plain prose. Since a prompt is only an instruction a model may ignore, the request also carries `MaxTokens=160` (headroom over the ~64 tokens 256 chars need) so a compliant reply finishes its sentence rather than being cut mid-word, while a runaway one can't bill for a paragraph. Nothing truncates the text — what the model writes is what's stored and shown.

`Summarize` and the new `Recap` share `summarizeWith` (the flatten + provider call, extracted verbatim); `Summarize`'s behaviour is unchanged. `RecapSession` no longer reads the agent's compaction `target_percentage` (meaningless for a recap) but still prefers the agent's cheaper compaction model.

## Tested

`go build ./...` clean; `go test ./...` clean (verified `./internal/loop` + `./internal/api/http` recap/summarize suites here). The three behaviour tests were confirmed red on the original branch by pointing `RecapSession` back at `loop.Summarize`: `TestRecap_AsksForATwoSentenceSummary`, `TestRecap_CapsMaxTokens`, `TestRecap_SendsTheWholeConversationAndNoTools`, plus `TestSummarize_StillUsesTheCompactionPrompt` (guards the extraction) and `TestRecapSession_UsesTheShortRecapPrompt` end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)