### PR TITLE
feat(auth): user credential self-service — scope=user, HTTP (RFC CN P1)

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -73,7 +73,16 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 			// budget-write / erasure / hooks) are excluded by
 			// tenantMemberAccessible; and every such handler still confines a
 			// member to its own tenant via principalTenantScope / tenantFromCtx.
-			if !(tenantMemberAccessible(r.Method, r.URL.Path) && !auth.IsIsolated(p, ok)) {
+			memberOK := tenantMemberAccessible(r.Method, r.URL.Path) && !auth.IsIsolated(p, ok)
+			// RFC CN: the credential self-service surface admits ANY authenticated
+			// principal that carries a subject — INCLUDING an isolated substrate:user
+			// user, who is otherwise held at the tenant-member isolation floor — so a
+			// user can store their OWN scope=user API tokens (a personal Slack/Telegram
+			// bot token, a per-user webhook secret). handleSubstrateCredentialDef then
+			// confines a non-tenant caller to scope=user on its own subject before the
+			// tool runs; tenant/agent scope still requires substrate:tenant.
+			selfOK := credentialSelfServiceAccessible(r.Method, r.URL.Path) && p.Subject != ""
+			if !(memberOK || selfOK) {
 				// Scope names are public; token state is not.
 				w.Header().Set("WWW-Authenticate", `Bearer scope="`+required+`"`)
 				http.Error(w, "insufficient scope", http.StatusForbidden)
@@ -872,6 +881,18 @@ func tenantMemberAccessible(method, path string) bool {
 		return false
 	}
 	return !memberCarveOut(method, path)
+}
+
+// credentialSelfServiceAccessible marks the credential-store surface that RFC CN
+// opens for user SELF-SERVICE of scope=user credentials. It is an ADDITIONAL
+// admission path in authMiddleware — the route stays nominally ScopeTenant, so a
+// tenant operator's full tenant/agent authoring is unchanged, and members reach it
+// via the RFC CB member path — but it also admits an isolated substrate:user user
+// (who otherwise 403s at the isolation floor). handleSubstrateCredentialDef
+// confines such a caller to scope=user on its own subject before dispatch, so the
+// widened admission grants nothing beyond a user's own personal tokens.
+func credentialSelfServiceAccessible(method, path string) bool {
+	return method == http.MethodPost && path == "/v1/_credentialdef"
 }
 
 // memberCarveOut lists the ScopeTenant routes that STAY operator-only (require a

--- a/internal/api/http/auth_principal_test.go
+++ b/internal/api/http/auth_principal_test.go
@@ -498,9 +498,18 @@ func TestAuthMiddleware_RFCCBMember(t *testing.T) {
 		}
 	}
 
-	// The isolation floor: an isolated token is refused on every member surface.
+	// The isolation floor: an isolated token is refused on every member surface —
+	// EXCEPT the RFC CN credential self-service route (POST /v1/_credentialdef),
+	// where an isolated substrate:user user IS admitted so it can manage its OWN
+	// scope=user tokens; the handler then confines it to scope=user.
 	for _, c := range admitted {
 		reached, code := runMW(t, s, c.method, c.path, "lct_isolated")
+		if c.method == "POST" && c.path == "/v1/_credentialdef" {
+			if !reached || code == http.StatusForbidden {
+				t.Errorf("isolated on %s %s: code=%d reached=%v, want ADMITTED (RFC CN self-service)", c.method, c.path, code, reached)
+			}
+			continue
+		}
 		if code != http.StatusForbidden || reached {
 			t.Errorf("isolated on %s %s: code=%d reached=%v, want 403 (floor)", c.method, c.path, code, reached)
 		}

--- a/internal/api/http/credential_selfservice_test.go
+++ b/internal/api/http/credential_selfservice_test.go
@@ -1,0 +1,93 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/connector"
+)
+
+// TestConstrainToUserScope pins the RFC CN isolated-user rule: an isolated
+// substrate:user caller's CredentialDef input is confined to scope=user — an
+// omitted scope defaults to user (never the tool's tenant default), an explicit
+// scope=user passes, and scope=tenant/agent is refused with credential_scope_forbidden.
+func TestConstrainToUserScope(t *testing.T) {
+	// Omitted scope → rewritten to user (must not fall through to the tool's tenant default).
+	out, gerr := constrainToUserScope([]byte(`{"op":"list"}`))
+	if gerr != nil {
+		t.Fatalf("omitted scope: unexpected refusal %+v", gerr)
+	}
+	if !strings.Contains(string(out), `"scope":"user"`) {
+		t.Errorf("omitted scope not defaulted to user: %s", out)
+	}
+
+	// Explicit scope=user → allowed, stays user.
+	out, gerr = constrainToUserScope([]byte(`{"op":"create","name":"telegram","scope":"user","value":"x"}`))
+	if gerr != nil || !strings.Contains(string(out), `"scope":"user"`) {
+		t.Errorf("scope=user: out=%s gerr=%+v", out, gerr)
+	}
+	// The secret value survives the rewrite (the guard must not drop fields).
+	if !strings.Contains(string(out), `"value":"x"`) {
+		t.Errorf("scope=user rewrite dropped a field: %s", out)
+	}
+
+	// scope=tenant → refused.
+	if _, gerr = constrainToUserScope([]byte(`{"op":"create","name":"t","scope":"tenant","value":"x"}`)); gerr == nil ||
+		gerr.status != http.StatusForbidden || gerr.code != "credential_scope_forbidden" {
+		t.Errorf("scope=tenant: want 403 credential_scope_forbidden, got %+v", gerr)
+	}
+
+	// scope=agent → refused.
+	if _, gerr = constrainToUserScope([]byte(`{"op":"list","scope":"agent"}`)); gerr == nil {
+		t.Error("scope=agent: want a guardError, got nil")
+	}
+
+	// A non-object body (array/scalar) passes through so the tool rejects it with
+	// its own message rather than the guard masking it as a scope error.
+	if _, gerr = constrainToUserScope([]byte(`[1,2,3]`)); gerr != nil {
+		t.Errorf("non-object body should pass through, got %+v", gerr)
+	}
+}
+
+// TestDispatchSubstrateCtxGuarded_AppliesGuard drives the guarded dispatch through
+// an HTTP request with a capturing fake connector, proving the RFC CN plumbing:
+// the guard's rewritten body is what reaches the tool, and a guard refusal 403s
+// before the tool is ever called.
+func TestDispatchSubstrateCtxGuarded_AppliesGuard(t *testing.T) {
+	s, _ := tokenAuthServer(t, "legacy")
+	guard := func(_ context.Context, body []byte) ([]byte, *guardError) { return constrainToUserScope(body) }
+
+	call := func(inBody string) (status int, forwarded string, called bool) {
+		fake := func(_ context.Context, input json.RawMessage) (connector.ToolResult, error) {
+			forwarded = string(input)
+			called = true
+			return connector.ToolResult{Text: `{"ok":true}`}, nil
+		}
+		req := httptest.NewRequest("POST", "/v1/_credentialdef", strings.NewReader(inBody))
+		rec := httptest.NewRecorder()
+		s.dispatchSubstrateCtxGuarded(rec, req, "CredentialDef", fake, substrateAdminUserCtx, guard)
+		return rec.Code, forwarded, called
+	}
+
+	// Omitted scope: the tool receives scope=user, 200.
+	code, fwd, called := call(`{"op":"create","name":"telegram","value":"x"}`)
+	if code != http.StatusOK || !called {
+		t.Fatalf("omitted scope: code=%d called=%v, want 200 + tool called", code, called)
+	}
+	if !strings.Contains(fwd, `"scope":"user"`) {
+		t.Errorf("omitted scope not rewritten to user before the tool: %s", fwd)
+	}
+
+	// scope=tenant: refused 403, the tool is never called.
+	code, _, called = call(`{"op":"create","name":"telegram","scope":"tenant","value":"x"}`)
+	if code != http.StatusForbidden {
+		t.Errorf("scope=tenant: code=%d, want 403", code)
+	}
+	if called {
+		t.Error("scope=tenant reached the tool; the guard should refuse before dispatch")
+	}
+}

--- a/internal/api/http/substrate_admin.go
+++ b/internal/api/http/substrate_admin.go
@@ -199,7 +199,68 @@ func (s *Server) handleSubstrateHistory(w http.ResponseWriter, r *http.Request) 
 // plaintext `value`; this handler adds NO logging of the body or value (the tool
 // masks the value from the transcript and never echoes it in get/list output).
 func (s *Server) handleSubstrateCredentialDef(w http.ResponseWriter, r *http.Request) {
-	s.dispatchSubstrateCtx(w, r, "CredentialDef", s.CredentialDef, substrateAdminUserCtx)
+	// RFC CN — user credential self-service. An ISOLATED substrate:user caller
+	// (admitted by credentialSelfServiceAccessible) may only manage scope=user
+	// credentials keyed on its OWN subject: its omitted scope defaults to user and
+	// an explicit scope=tenant/agent is refused. Members / tenant operators / admin
+	// are unconstrained (their tenant-plane authority is unchanged). The scope_id is
+	// still derived from identity by the tool's resolveScope — this guard only bounds
+	// which scopes an isolated caller may REQUEST.
+	p, ok := auth.PrincipalFromContext(r.Context())
+	isolated := auth.IsIsolated(p, ok)
+	guard := func(_ context.Context, body []byte) ([]byte, *guardError) {
+		if !isolated {
+			return body, nil
+		}
+		return constrainToUserScope(body)
+	}
+	s.dispatchSubstrateCtxGuarded(w, r, "CredentialDef", s.CredentialDef, substrateAdminUserCtx, guard)
+}
+
+// guardError is a pre-dispatch refusal produced by a dispatchSubstrateCtxGuarded
+// guard — an authorization decision taken once the validated body is in hand,
+// written as a canonical JSON error at the guard's chosen status.
+type guardError struct {
+	status int
+	code   string
+	msg    string
+}
+
+// constrainToUserScope enforces the RFC CN isolated-user rule on a CredentialDef
+// input: the effective scope must be user. An omitted scope defaults to user (the
+// tool's own default is tenant, which is wrong for a self-service caller and would
+// leak into the tenant bucket), and the body is rewritten so the tool resolves
+// scope=user on the caller's own subject. An explicit scope=tenant/agent is refused.
+func constrainToUserScope(body []byte) ([]byte, *guardError) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(body, &fields); err != nil {
+		// dispatchSubstrateCtxGuarded already checked json.Valid, so this is a
+		// non-object body (array / scalar). Leave it for the tool to reject with
+		// its own message rather than masking it as a scope error.
+		return body, nil
+	}
+	scope := ""
+	if raw, present := fields["scope"]; present {
+		_ = json.Unmarshal(raw, &scope) // a non-string value stays "" → defaulted below
+	}
+	if scope == "" {
+		scope = "user"
+	}
+	if scope != "user" {
+		return nil, &guardError{
+			status: http.StatusForbidden,
+			code:   "credential_scope_forbidden",
+			msg:    "an isolated user token may only manage scope=user credentials (its own); scope=tenant and scope=agent require substrate:tenant",
+		}
+	}
+	// Pin scope=user in the body so an omitted scope cannot fall through to the
+	// tool's tenant default.
+	fields["scope"] = json.RawMessage(`"user"`)
+	out, err := json.Marshal(fields)
+	if err != nil {
+		return body, nil // unreachable (re-marshalling validated fields); keep the original
+	}
+	return out, nil
 }
 
 // dispatchSubstrate is the shared body of the substrate-def handlers.
@@ -220,6 +281,21 @@ func (s *Server) dispatchSubstrateCtx(
 	w http.ResponseWriter, r *http.Request, toolName string,
 	connectorFn func(ctx context.Context, input json.RawMessage) (connector.ToolResult, error),
 	ctxFn func(context.Context) context.Context,
+) {
+	s.dispatchSubstrateCtxGuarded(w, r, toolName, connectorFn, ctxFn, nil)
+}
+
+// dispatchSubstrateCtxGuarded is dispatchSubstrateCtx with an optional guard that
+// runs after the body is read + JSON-validated and after ctxFn builds the
+// operator-trust ctx, but BEFORE the tool. A guard makes a body-aware
+// authorization decision (RFC CN: confine an isolated user to scope=user): it may
+// return a rewritten body to forward, or a *guardError to refuse with a canonical
+// JSON error. A nil guard is the plain dispatch.
+func (s *Server) dispatchSubstrateCtxGuarded(
+	w http.ResponseWriter, r *http.Request, toolName string,
+	connectorFn func(ctx context.Context, input json.RawMessage) (connector.ToolResult, error),
+	ctxFn func(context.Context) context.Context,
+	guard func(context.Context, []byte) ([]byte, *guardError),
 ) {
 	// Operator-authed substrate ops; the cap (default 8 MiB, RFC BO) admits a
 	// set_asset base64 image payload + a large import_md document — the historical
@@ -242,6 +318,14 @@ func (s *Server) dispatchSubstrateCtx(
 	}
 
 	ctx := ctxFn(r.Context())
+	if guard != nil {
+		newBody, gerr := guard(ctx, body)
+		if gerr != nil {
+			writeJSONError(w, gerr.status, gerr.code, gerr.msg)
+			return
+		}
+		body = newBody
+	}
 	result, err := connectorFn(ctx, body)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "internal", err.Error())


### PR DESCRIPTION
First phase of **RFC CN — Per-user credential self-service** (`/loomcycle/rfcs/user-scope-credential-self-service`, confirmed). Lets a logged-in user store their **own** API tokens — a personal Slack/Telegram bot token, a per-user webhook secret — over **HTTP**, for both **isolated `substrate:user`** and **non-isolated member** logins.

## Why

Every credential was tenant-operator-authored: `POST /v1/_credentialdef` is `ScopeTenant` (`isTenantConfinedDefPath`), so an isolated `substrate:user` user was 403'd at the tenant-member isolation floor. But the **consumer side already binds per-user credentials** — `$cred:<name>` resolves **agent > user > tenant** and `Substitute` binds it per run — so an operator can author one webhook→agent→Slack flow with `$cred:telegram` and each user's own token wins. The only missing piece was letting the user *put their token in*.

## What (Phase 1, HTTP)

- **`authMiddleware`** admits an isolated `substrate:user` token to `POST /v1/_credentialdef` via a new `credentialSelfServiceAccessible` path. The route stays *nominally* `ScopeTenant`, so tenant/admin authoring and the RFC CB member path are **unchanged** — this is a purely additive admission.
- **`handleSubstrateCredentialDef`** then confines such a caller: an isolated user may manage **only `scope=user`** credentials on its **own subject** — an omitted scope defaults to `user` (not the tool's tenant default), and an explicit `scope=tenant`/`agent` is refused **403 `credential_scope_forbidden`**. Members / tenant operators / admin are **unconstrained** (no regression to RFC CB tenant-plane writes).
- `scope_id` is still derived from identity by the tool's `resolveScope` — the guard only bounds which scopes an isolated caller may *request*, never widens what it can address.
- **Mechanism:** a new `dispatchSubstrateCtxGuarded` runs a body-aware guard after JSON-validation and ctx-build, before the tool; the guard may rewrite the body (pin `scope=user`) or refuse. `dispatchSubstrateCtx` delegates to it with a nil guard, so every other def handler is byte-identical.

## Tested

`go test ./internal/api/http` clean (full package); `go build ./...` + gofmt + vet clean.
- **New** `TestConstrainToUserScope` — omitted→user; user passes; tenant/agent→403; non-object passes through to the tool.
- **New** `TestDispatchSubstrateCtxGuarded_AppliesGuard` — the rewritten body reaches the tool; a refusal 403s *before* dispatch.
- **Updated** `TestAuthMiddleware_RFCCBMember` — the isolation floor now documents `POST /v1/_credentialdef` as the RFC CN self-service exception (isolated admitted, not 403).
- Both new behaviors verified fail-before (neutering the admission or the guard fails the tests).

## Follow-up phases (separate PRs)

P2 — MCP parity (permit `credentialdef` in a per-principal user/tenant session, same constraint). P3 — a Web UI "My Credentials" page (scope=user only). P4 — gRPC/adapter parity if exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)