### PR TITLE
feat(bench): the LoCoMo answer axis, plus the RFC CL/CM measurement instrumentation

### DIFF
--- a/bench/cmd/locomo/README.md
+++ b/bench/cmd/locomo/README.md
@@ -147,6 +147,75 @@ A run on the current file scores **1,535 queries over 5,882 rows**.
   characters against a couple of hundred is noise for a dense embedder, but it
   is an asymmetry and the report says so.
 
+## The answer axis (`-mode=answer`)
+
+Everything above measures **retrieval**: does the supporting turn come back.
+`-mode=answer` measures the whole pipeline instead — turns go in through the
+memory **layer**, the consolidator distils them into facts, an agent answers
+each question from recall alone, and a second model grades the answer against
+the gold one on the LoCoMo convention (correct 1, partial 0.5, wrong 0).
+
+```sh
+# one conversation, every question
+./bin/locomo -mode=answer -data locomo10.json -loomcycle http://127.0.0.1:8787
+
+# a cheap first pass: 12 questions, stratified across categories
+./bin/locomo -mode=answer -data locomo10.json -sample-questions 12
+```
+
+It needs two agents, `-answerer` and `-judge` (defaults `locomo/answerer` and
+`locomo/judge`). Author them with the `agentdef` tool — note the overlay goes in
+the **`overlay`** field; a `def` field is silently ignored, which produces an
+agent with no prompt, no tools and no model:
+
+```json
+{"op":"create","name":"locomo/answerer","promote":true,
+ "overlay":{"provider":"deepseek","model":"deepseek-v4-pro","tools":["Memory"],
+            "skills":["-*"],"memory_scopes":["user"],"max_tokens":400,
+            "system_prompt":"...answer only from Memory recall; NOT_FOUND if absent..."}}
+```
+
+Pin `provider` + `model` explicitly rather than relying on `tier`: a tier that
+resolves through a model alias pointing at a tag the host does not have fails
+the run with a bare 404.
+
+### Why it is built this way
+
+- **Ingest is deterministic.** Turns are handed to `Memory op=add` verbatim over
+  MCP. Prompting an agent to store them instead would measure that agent's
+  transcription fidelity, and a benchmark whose ingest can silently lose content
+  cannot attribute a miss to memory. MCP is the only off-run route — the REST
+  `/v1/_memory` family covers the k/v plane, embeddings and search, but the
+  memory-layer ops exist solely as in-band tools.
+- **The answerer gets `Memory` and nothing else**, and must answer `NOT_FOUND`
+  rather than fall back on general knowledge. A chat agent with web search would
+  answer some open-domain questions without consulting memory at all.
+- **One conversation resident at a time.** `scope_id` is server-derived from the
+  run identity, so an off-run caller cannot give each conversation its own
+  partition. Conversations run in sequence with the layer purged between, which
+  is why `-conversations` defaults differently here in practice.
+- **The drain runs before the purge.** Purge clears k/v rows but cannot reach the
+  pending consolidation queue; anything left queued from an earlier conversation
+  would otherwise be consolidated into this one's facts after the purge had run.
+
+### Two failure modes it refuses to paper over
+
+- **A leased consolidation target.** A pass killed mid-flight leaves the lease
+  held, and the bundle leases for **30 minutes**. Every later pass then answers
+  "target busy". That is its own error naming the TTL — the first live run of
+  this axis treated it as a drained queue and graded 10 questions against an
+  empty store, reporting `accuracy 0.0000` with `NOT_FOUND 1.000`: a plumbing
+  failure wearing the costume of a result.
+- **An empty partition after consolidation.** The axis refuses to grade at all,
+  rather than reporting the zero that would follow.
+
+An unparsed judge verdict is excluded from accuracy and counted separately, for
+the same reason: grading an instrument failure as a memory miss understates the
+system under test.
+
+Output lands beside the retrieval report as `answer-matrix.md` +
+`answer-report.json`.
+
 ## Not covered here
 
 LoCoMo does not test **knowledge updates**, which is what a bi-temporal fact

--- a/bench/cmd/locomo/answer.go
+++ b/bench/cmd/locomo/answer.go
@@ -1,0 +1,780 @@
+package main
+
+// answer.go — the ANSWER axis (phase 3).
+//
+// Phase 2 measured retrieval: does the supporting turn come back. This measures
+// the whole memory pipeline: conversation turns go in through the memory LAYER
+// (`Memory op=add`), the consolidator distils them into facts, an agent answers
+// each question from recall alone, and a second model grades the answer against
+// the gold one.
+//
+// Two things make this measure memory rather than something else:
+//
+//   - Ingest is DETERMINISTIC. The turns are handed to `Memory op=add` verbatim
+//     over MCP. The obvious alternative — prompting an agent to store the turns —
+//     would have measured that agent's transcription fidelity, and a benchmark
+//     whose ingest step can lose content cannot attribute a miss to memory.
+//   - The answerer has the Memory tool and NOTHING else, with a system prompt
+//     that forbids general knowledge and requires NOT_FOUND when recall comes up
+//     empty. A chat agent with web search would have answered some of LoCoMo's
+//     open-domain questions without consulting memory at all.
+//
+// ONE CONVERSATION AT A TIME. `scope_id` is server-derived from the run
+// identity, never caller-supplied, so an off-run `add` lands under the token's
+// own subject — there is no way to give each conversation its own partition from
+// outside a run. Conversations are therefore run in sequence with the memory
+// layer purged between them, which is why -conversations defaults to 1 here.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Verdict is the judge's grade.
+type Verdict string
+
+const (
+	VerdictCorrect Verdict = "correct"
+	VerdictPartial Verdict = "partial"
+	VerdictWrong   Verdict = "wrong"
+	// VerdictUnparsed means the judge did not return a readable verdict. It is
+	// counted and EXCLUDED from accuracy rather than folded into "wrong":
+	// scoring a judge malfunction as a memory miss would quietly understate the
+	// system under test.
+	VerdictUnparsed Verdict = "unparsed"
+)
+
+// Score maps a verdict to the LoCoMo convention: correct 1, partial 0.5,
+// wrong 0.
+func (v Verdict) Score() float64 {
+	switch v {
+	case VerdictCorrect:
+		return 1
+	case VerdictPartial:
+		return 0.5
+	default:
+		return 0
+	}
+}
+
+// notFound is the abstention token the answerer's prompt mandates.
+const notFound = "NOT_FOUND"
+
+var (
+	// jsonObjectRe finds the first {...} block, so a judge that wraps its JSON
+	// in prose is still readable.
+	jsonObjectRe = regexp.MustCompile(`(?s)\{.*?\}`)
+	// queuedRe reads the consolidator's own report of what is left to drain.
+	queuedRe = regexp.MustCompile(`queued items (\d+), acked (\d+)`)
+	factsRe  = regexp.MustCompile(`facts written (\d+)`)
+	// busyRe matches the pass's refusal when another consolidator holds the
+	// target's lease. The bundle leases for 30 minutes, so a consolidator killed
+	// mid-pass blocks the target for that long — and every later pass returns
+	// this instead of a queue depth.
+	busyRe = regexp.MustCompile(`(?i)target busy`)
+)
+
+// ErrConsolidatorBusy reports that the target's consolidation lease is held.
+// Surfaced as its own error because the alternative is grading against a store
+// that was never consolidated, which scores the memory system at zero for a
+// reason that has nothing to do with memory.
+type ErrConsolidatorBusy struct{ Report string }
+
+func (e *ErrConsolidatorBusy) Error() string {
+	return "consolidation target is leased by another consolidator (the bundle leases for 30 minutes, " +
+		"so a pass killed mid-flight blocks the target until it expires): " + truncate(e.Report, 160)
+}
+
+// ParseVerdict reads the judge's reply.
+func ParseVerdict(reply string) (Verdict, string) {
+	for _, candidate := range jsonObjectRe.FindAllString(reply, 4) {
+		var out struct {
+			Verdict string `json:"verdict"`
+			Why     string `json:"why"`
+		}
+		if err := json.Unmarshal([]byte(candidate), &out); err != nil {
+			continue
+		}
+		switch Verdict(strings.ToLower(strings.TrimSpace(out.Verdict))) {
+		case VerdictCorrect:
+			return VerdictCorrect, out.Why
+		case VerdictPartial:
+			return VerdictPartial, out.Why
+		case VerdictWrong:
+			return VerdictWrong, out.Why
+		}
+	}
+	return VerdictUnparsed, truncate(strings.TrimSpace(reply), 160)
+}
+
+// LayerMessages renders one session's turns as memory-layer messages.
+//
+// LoCoMo has exactly two speakers, so the first one seen becomes "user" and the
+// other "assistant". The speaker NAME stays in the content regardless: role
+// alone loses identity, and several questions turn on who said a thing. The
+// session timestamp is prefixed for the same reason it is on the retrieval
+// rows — LoCoMo dates live on the session, not the turn.
+func (c Conversation) LayerMessages() [][]LayerMessage {
+	roles := map[string]string{}
+	bySession := map[int][]LayerMessage{}
+	var order []int
+	for _, t := range c.Turns {
+		role, ok := roles[t.Speaker]
+		if !ok {
+			role = "user"
+			if len(roles) > 0 {
+				role = "assistant"
+			}
+			roles[t.Speaker] = role
+		}
+		if _, seen := bySession[t.Session]; !seen {
+			order = append(order, t.Session)
+		}
+		bySession[t.Session] = append(bySession[t.Session], LayerMessage{Role: role, Content: t.Body()})
+	}
+	sort.Ints(order)
+	out := make([][]LayerMessage, 0, len(order))
+	for _, s := range order {
+		out = append(out, bySession[s])
+	}
+	return out
+}
+
+// SampleQueries picks n queries, stratified across categories and taken at an
+// even stride within each so the sample is deterministic — a benchmark whose
+// sample moves between runs cannot show a regression.
+func SampleQueries(qs []Query, n int) []Query {
+	if n <= 0 || n >= len(qs) {
+		return qs
+	}
+	byCat := map[int][]Query{}
+	for _, q := range qs {
+		byCat[q.Category] = append(byCat[q.Category], q)
+	}
+	cats := make([]int, 0, len(byCat))
+	for c := range byCat {
+		cats = append(cats, c)
+	}
+	sort.Ints(cats)
+
+	var out []Query
+	for _, c := range cats {
+		bucket := byCat[c]
+		// Proportional share, at least one per represented category.
+		want := int(float64(n) * float64(len(bucket)) / float64(len(qs)))
+		if want < 1 {
+			want = 1
+		}
+		if want > len(bucket) {
+			want = len(bucket)
+		}
+		stride := len(bucket) / want
+		if stride < 1 {
+			stride = 1
+		}
+		for i := 0; i < len(bucket) && len(out) < n+len(cats); i += stride {
+			out = append(out, bucket[i])
+			if countCat(out, c) >= want {
+				break
+			}
+		}
+	}
+	if len(out) > n {
+		out = out[:n]
+	}
+	return out
+}
+
+func countCat(qs []Query, c int) int {
+	n := 0
+	for _, q := range qs {
+		if q.Category == c {
+			n++
+		}
+	}
+	return n
+}
+
+// AnswerResult is one graded question.
+type AnswerResult struct {
+	Question  string  `json:"question"`
+	Category  int     `json:"category"`
+	Gold      string  `json:"gold"`
+	Answer    string  `json:"answer"`
+	Verdict   Verdict `json:"verdict"`
+	Why       string  `json:"why,omitempty"`
+	NotFound  bool    `json:"not_found"`
+	Model     string  `json:"model,omitempty"`
+	LatencyMs float64 `json:"latency_ms"`
+	// WindowUsed records that a resolved `when` window was supplied with this
+	// question, so a run splits into the questions the predicate could act on and
+	// the ones it could not.
+	WindowUsed bool `json:"window_used,omitempty"`
+}
+
+// AnswerStats aggregates graded answers.
+type AnswerStats struct {
+	Label string `json:"label"`
+	// Graded excludes unparsed verdicts; Queries counts everything attempted.
+	Queries      int     `json:"queries"`
+	Graded       int     `json:"graded"`
+	Accuracy     float64 `json:"accuracy"`
+	Correct      int     `json:"correct"`
+	Partial      int     `json:"partial"`
+	Wrong        int     `json:"wrong"`
+	Unparsed     int     `json:"unparsed"`
+	NotFoundRate float64 `json:"not_found_rate"`
+	LatencyP50Ms float64 `json:"latency_p50_ms"`
+}
+
+// AggregateAnswers computes the accuracy metrics.
+func AggregateAnswers(label string, rs []AnswerResult) AnswerStats {
+	st := AnswerStats{Label: label, Queries: len(rs)}
+	if len(rs) == 0 {
+		return st
+	}
+	var sum float64
+	var nf int
+	lat := make([]time.Duration, 0, len(rs))
+	for _, r := range rs {
+		switch r.Verdict {
+		case VerdictCorrect:
+			st.Correct++
+		case VerdictPartial:
+			st.Partial++
+		case VerdictWrong:
+			st.Wrong++
+		default:
+			st.Unparsed++
+		}
+		if r.Verdict != VerdictUnparsed {
+			st.Graded++
+			sum += r.Verdict.Score()
+		}
+		if r.NotFound {
+			nf++
+		}
+		lat = append(lat, time.Duration(r.LatencyMs*float64(time.Millisecond)))
+	}
+	if st.Graded > 0 {
+		st.Accuracy = sum / float64(st.Graded)
+	}
+	st.NotFoundRate = float64(nf) / float64(len(rs))
+	st.LatencyP50Ms = percentileMs(lat, 0.50)
+	return st
+}
+
+// AnswersByCategory buckets per LoCoMo category, category id ascending.
+func AnswersByCategory(rs []AnswerResult) []AnswerStats {
+	buckets := map[int][]AnswerResult{}
+	for _, r := range rs {
+		buckets[r.Category] = append(buckets[r.Category], r)
+	}
+	cats := make([]int, 0, len(buckets))
+	for c := range buckets {
+		cats = append(cats, c)
+	}
+	sort.Ints(cats)
+	out := make([]AnswerStats, 0, len(cats))
+	for _, c := range cats {
+		out = append(out, AggregateAnswers(CategoryName(c), buckets[c]))
+	}
+	return out
+}
+
+// purgeLayer empties the memory-layer partition so the next conversation starts
+// from nothing. Keys are read back from the store rather than derived, because
+// the consolidator names the rows it writes (memory/fact/...), not this harness.
+func purgeLayer(ctx context.Context, rest *Client, scope, scopeID string, stdout io.Writer) (int, error) {
+	deleted := 0
+	for pass := 0; pass < 50; pass++ {
+		keys, err := rest.ListKeys(ctx, scope, scopeID, 500)
+		if err != nil {
+			return deleted, err
+		}
+		if len(keys) == 0 {
+			break
+		}
+		for _, k := range keys {
+			if err := rest.DeleteEntry(ctx, scope, scopeID, k); err != nil {
+				return deleted, fmt.Errorf("purge %s: %w", k, err)
+			}
+			deleted++
+		}
+	}
+	fmt.Fprintf(stdout, "  purged %d rows from %s/%s\n", deleted, scope, scopeID)
+	return deleted, nil
+}
+
+// seedTurnRows writes one embedded row per turn into the partition the ANSWERER
+// reads, keyed by dia_id. It is the answer-axis mirror of what -mode=ingest does
+// for the retrieval axis, and it uses the same Turn.Body() — which prefixes the
+// SESSION timestamp, without which the temporal category is unretrievable no
+// matter how good the embedder is (LoCoMo dates live on the session, not the turn).
+//
+// Off-run through the REST client on purpose: only an off-run caller may name an
+// explicit scope_id, which is exactly the asymmetry that makes this necessary.
+func seedTurnRows(ctx context.Context, rest *Client, userID string, conv Conversation, opts options, stdout io.Writer) (int, error) {
+	jobs := make(chan Turn)
+	var (
+		mu     sync.Mutex
+		wrote  int
+		firstE error
+	)
+	workers := opts.concurrency
+	if workers < 1 {
+		workers = 1
+	}
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for t := range jobs {
+				// Dated when asked for, so the RFC CL `when` predicate has something to
+				// filter on. Undated otherwise, which is what every prior run measured.
+				obs := ""
+				if opts.dated {
+					obs = t.ObservedAt()
+				}
+				if _, err := rest.PutEntryAt(ctx, "user", userID, t.DiaID, t.Body(), !opts.noEmbed, obs); err != nil {
+					mu.Lock()
+					if firstE == nil {
+						firstE = err
+					}
+					mu.Unlock()
+					return
+				}
+				mu.Lock()
+				wrote++
+				mu.Unlock()
+			}
+		}()
+	}
+	for _, t := range conv.Turns {
+		if err := ctx.Err(); err != nil {
+			break
+		}
+		mu.Lock()
+		stop := firstE != nil
+		mu.Unlock()
+		if stop {
+			break
+		}
+		jobs <- t
+	}
+	close(jobs)
+	wg.Wait()
+	if firstE != nil {
+		return wrote, firstE
+	}
+	fmt.Fprintf(stdout, "  seeded %d turn row(s) into user/%s (embedded, keyed by dia_id)\n", wrote, userID)
+	return wrote, nil
+}
+
+// ingestLayer adds every session of one conversation to the consolidation queue.
+func ingestLayer(ctx context.Context, mc *MCPClient, conv Conversation, stdout io.Writer) (int, error) {
+	sessions := conv.LayerMessages()
+	for i, msgs := range sessions {
+		if err := ctx.Err(); err != nil {
+			return i, err
+		}
+		if _, err := mc.MemoryAdd(ctx, "user", msgs); err != nil {
+			return i, fmt.Errorf("memory add (session %d/%d): %w", i+1, len(sessions), err)
+		}
+	}
+	fmt.Fprintf(stdout, "  queued %d sessions (%d turns) for consolidation\n", len(sessions), len(conv.Turns))
+	return len(sessions), nil
+}
+
+// consolidateDrain runs consolidation passes until the queue is empty.
+//
+// The pass reports what it did in prose, including "queued items N, acked M",
+// and that report is the only signal for when to stop — so it is parsed. A pass
+// whose report cannot be read stops the loop rather than spinning: an unbounded
+// loop against a changed message would burn extractor spend indefinitely.
+// flushPendingQueue discards whatever is left in the consolidation queue and
+// returns how many items it dropped. No extractor calls, no facts written.
+//
+// WHY DISCARD RATHER THAN CONSOLIDATE. These items belong to a previous
+// conversation or an interrupted run. This harness purges the partition and
+// re-ingests from the dataset file, so the same turns arrive again — extracting
+// from the leftovers produces facts that are either duplicates or, worse, another
+// conversation's, in the partition about to be measured.
+//
+// WHY IT HOLDS THE LEASE. pending_ack is lease-gated on the server
+// (requireConsolidationLease), so a flush has to hold the target exactly as a
+// pass would or every ack is refused as a non-owner. The TTL is deliberately
+// SHORT: this is a handful of round trips, and if the process dies mid-flush a
+// short lease means the target frees itself in a minute rather than blocking
+// every pass for the bundle's half-hour default.
+func flushPendingQueue(ctx context.Context, mc *MCPClient, stdout io.Writer) (int, error) {
+	const leaseTTLMs = 60_000
+	lease, err := memoryOp(ctx, mc, map[string]any{
+		"op": "cursor_lease", "scope": "user", "lease_ttl_ms": leaseTTLMs,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("lease the target: %w", err)
+	}
+	if acquired, _ := lease["acquired"].(bool); !acquired {
+		// Someone else owns the target. Refuse rather than flush around them:
+		// their pass is reading the very queue this would empty.
+		return 0, &ErrConsolidatorBusy{Report: fmt.Sprintf(
+			"cannot flush: the target is leased by %v until %v",
+			lease["leased_by"], lease["lease_expires_at"])}
+	}
+	// Release on every path, including the error paths below — a flush that
+	// leaves the lease held is worse than one that does nothing.
+	defer func() {
+		if _, rerr := memoryOp(ctx, mc, map[string]any{"op": "cursor_release", "scope": "user"}); rerr != nil {
+			fmt.Fprintf(stdout, "  warning: could not release the flush lease: %v\n", rerr)
+		}
+	}()
+
+	total := 0
+	for {
+		if err := ctx.Err(); err != nil {
+			return total, err
+		}
+		drained, err := memoryOp(ctx, mc, map[string]any{
+			"op": "pending_drain", "scope": "user", "limit": 50,
+		})
+		if err != nil {
+			return total, fmt.Errorf("drain: %w", err)
+		}
+		rows, _ := drained["pending"].([]any)
+		ids := make([]any, 0, len(rows))
+		for _, r := range rows {
+			if m, ok := r.(map[string]any); ok {
+				if id, ok := m["id"].(string); ok && id != "" {
+					ids = append(ids, id)
+				}
+			}
+		}
+		if len(ids) == 0 {
+			return total, nil
+		}
+		if _, err := memoryOp(ctx, mc, map[string]any{
+			"op": "pending_ack", "scope": "user", "ids": ids,
+		}); err != nil {
+			return total, fmt.Errorf("ack %d item(s): %w", len(ids), err)
+		}
+		total += len(ids)
+	}
+}
+
+// memoryOp calls one op on the Memory tool and decodes its JSON result.
+func memoryOp(ctx context.Context, mc *MCPClient, args map[string]any) (map[string]any, error) {
+	txt, err := mc.CallTool(ctx, "memory", args)
+	if err != nil {
+		return nil, err
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(txt), &out); err != nil {
+		return nil, fmt.Errorf("memory %v: unreadable result %q: %w", args["op"], txt, err)
+	}
+	return out, nil
+}
+
+func consolidateDrain(ctx context.Context, mc *MCPClient, userID string, maxPasses int, stdout io.Writer) (facts int, passes int, err error) {
+	const prompt = "Run one consolidation pass for your assigned memory target."
+	for passes = 1; passes <= maxPasses; passes++ {
+		rr, err := mc.SpawnRun(ctx, "memory/consolidator", userID, prompt)
+		if err != nil {
+			return facts, passes, fmt.Errorf("consolidation pass %d: %w", passes, err)
+		}
+		if m := factsRe.FindStringSubmatch(rr.FinalText); m != nil {
+			var n int
+			_, _ = fmt.Sscanf(m[1], "%d", &n)
+			facts += n
+		}
+		if busyRe.MatchString(rr.FinalText) {
+			return facts, passes, &ErrConsolidatorBusy{Report: rr.FinalText}
+		}
+		m := queuedRe.FindStringSubmatch(rr.FinalText)
+		if m == nil {
+			fmt.Fprintf(stdout, "  pass %d: no queue depth in the pass report, treating as drained — %s\n",
+				passes, truncate(rr.FinalText, 120))
+			return facts, passes, nil
+		}
+		var queued int
+		_, _ = fmt.Sscanf(m[1], "%d", &queued)
+		fmt.Fprintf(stdout, "  pass %d: %s\n", passes, truncate(rr.FinalText, 160))
+		if queued == 0 {
+			return facts, passes, nil
+		}
+	}
+	fmt.Fprintf(stdout, "  stopped after %d passes with work still queued — raise -consolidate-passes\n", maxPasses)
+	return facts, passes - 1, nil
+}
+
+// answerOne asks the answerer, then has the judge grade it against gold.
+func answerOne(ctx context.Context, mc *MCPClient, userID string, q Query, answerer, judge string, injectWhen bool) AnswerResult {
+	res := AnswerResult{Question: q.Question, Category: q.Category, Gold: q.Answer}
+	// The window is resolved HERE and handed to the answerer, rather than left for
+	// it to derive. Asked to build one from a system-prompt rule, the answerer
+	// ignored the instruction on every question tried; handed one, it passes it
+	// through faithfully. Supplying it measures the PREDICATE rather than whether a
+	// particular model remembers to construct a window.
+	askPrompt := q.Question
+	if injectWhen {
+		if from, to, ok := ResolveWhen(q.Question, 2023, 3); ok {
+			askPrompt += WhenInstruction(from, to)
+			res.WindowUsed = true
+		}
+	}
+	start := time.Now()
+	rr, err := mc.SpawnRun(ctx, answerer, userID, askPrompt)
+	res.LatencyMs = float64(time.Since(start).Microseconds()) / 1000.0
+	if err != nil {
+		res.Verdict = VerdictUnparsed
+		res.Why = "answer run failed: " + truncate(err.Error(), 140)
+		return res
+	}
+	res.Answer = strings.TrimSpace(rr.FinalText)
+	res.Model = rr.Usage.Provider + "/" + rr.Usage.Model
+	res.NotFound = strings.Contains(strings.ToUpper(res.Answer), notFound)
+
+	// An abstention needs no judge call — it cannot match a gold answer, and for
+	// categories 1-4 (all answerable) it is a miss. Skipping the call saves a
+	// model round trip per abstention and removes a chance for the judge to
+	// mis-grade one.
+	if res.NotFound {
+		res.Verdict = VerdictWrong
+		res.Why = "answerer abstained (NOT_FOUND)"
+		return res
+	}
+	prompt := fmt.Sprintf("Question: %s\nGold answer: %s\nModel answer: %s", q.Question, q.Answer, res.Answer)
+	jr, err := mc.SpawnRun(ctx, judge, "", prompt)
+	if err != nil {
+		res.Verdict = VerdictUnparsed
+		res.Why = "judge run failed: " + truncate(err.Error(), 140)
+		return res
+	}
+	res.Verdict, res.Why = ParseVerdict(jr.FinalText)
+	return res
+}
+
+// doAnswerAxis runs phase 3: for each conversation, purge the memory layer,
+// ingest its sessions, drain consolidation, then answer and grade its questions.
+//
+// Sequential across conversations by necessity — see the file header on why a
+// single partition is all an off-run caller can address.
+func doAnswerAxis(ctx context.Context, convs []Conversation, defects *Defects, opts options, stdout io.Writer) error {
+	rest, id, err := connect(ctx, opts, stdout)
+	if err != nil {
+		return err
+	}
+	// The memory-layer partition an off-run `add` lands in is the principal's
+	// own subject, and the answering run must recall from that same partition.
+	userID := id.Subject
+	if userID == "" {
+		return fmt.Errorf("the bearer has no subject, so the memory-layer partition cannot be addressed")
+	}
+	mc := NewMCPClient(opts.instance, bearer(), opts.runTimeout)
+
+	rep := AnswerReport{
+		Tool: "locomo", Axis: "answer", StartedAt: time.Now().UTC().Format(time.RFC3339),
+		Instance: opts.instance, Tenant: id.TenantID, Subject: userID,
+		Answerer: opts.answerer, Judge: opts.judge, Categories: opts.categories,
+		Conversations: len(convs), Defects: defects,
+		Notes: []string{
+			"Ingest is deterministic: turns are handed to `Memory op=add` verbatim over MCP, so a miss " +
+				"is attributable to consolidation or recall rather than to an ingesting agent's transcription.",
+			"The answerer holds the Memory tool and nothing else, and is instructed to answer NOT_FOUND " +
+				"rather than fall back on general knowledge.",
+			"Conversations run in sequence with the memory layer purged between them: scope_id is " +
+				"server-derived from the run identity, so an off-run caller cannot give each conversation " +
+				"its own partition.",
+		},
+	}
+
+	var all []AnswerResult
+	for _, conv := range convs {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		fmt.Fprintf(stdout, "%s:\n", conv.ScopeID())
+		// FLUSH before purging, not after, and DISCARD rather than consolidate.
+		// purgeLayer removes k/v rows; it cannot reach the pending consolidation
+		// queue, so anything left queued from an earlier conversation (or an
+		// interrupted run) would otherwise be consolidated into THIS
+		// conversation's facts after the purge had already run, silently mixing
+		// two conversations in one partition.
+		//
+		// This used to call consolidateDrain — the same function that does the
+		// real work — for up to consolidatePasses passes. Leftovers only need to
+		// be GONE, and extracting from them cost the full extractor spend on data
+		// about to be thrown away: measured at ~70 minutes on one run before it
+		// reached its own conversation. A flush is drain + ack, no model calls.
+		if n, err := flushPendingQueue(ctx, mc, stdout); err != nil {
+			return fmt.Errorf("pre-ingest flush: %w", err)
+		} else if n > 0 {
+			fmt.Fprintf(stdout, "  flushed %d leftover queued item(s) without extracting\n", n)
+		}
+		if _, err := purgeLayer(ctx, rest, "user", userID, stdout); err != nil {
+			return err
+		}
+		// OPTIONALLY put the raw turns where the answerer can actually read them.
+		//
+		// WHY THIS EXISTS. The answerer is an in-band agent, so its scope_id is
+		// server-derived from the run identity: `memory_scopes: [user]` resolves to
+		// user/<subject> and `[agent]` would resolve to agent/<the agent's own
+		// name>. The retrieval corpus lives at agent/<conversation-id>, a scope_id
+		// no in-band agent can address — so no agent config can point the answerer
+		// at it. The only way to let it answer from conversation content is to write
+		// that content into the partition it already reads.
+		//
+		// This is also what makes the number comparable: the published systems
+		// answer from retrieved conversation turns, not from a distilled fact store.
+		// Measured without it, the answerer had 29 facts distilled from 419 turns,
+		// abstained on 72% of questions and scored 0.1389; with it, 0.7353.
+		if opts.seedTurns {
+			n, err := seedTurnRows(ctx, rest, userID, conv, opts, stdout)
+			if err != nil {
+				return fmt.Errorf("seed turns: %w", err)
+			}
+			rep.SeededTurns += n
+		}
+		sessions, err := ingestLayer(ctx, mc, conv, stdout)
+		if err != nil {
+			return err
+		}
+		rep.Sessions += sessions
+		rep.Turns += len(conv.Turns)
+
+		facts, passes, err := consolidateDrain(ctx, mc, userID, opts.consolidatePasses, stdout)
+		if err != nil {
+			return err
+		}
+		rep.FactsWritten += facts
+		fmt.Fprintf(stdout, "  consolidated in %d pass(es), %d facts written\n", passes, facts)
+
+		// REFUSE to grade an empty store. With no rows, every recall comes back
+		// empty, the answerer abstains on everything, and the report reads
+		// "accuracy 0.0000" — a number about the plumbing wearing the costume of a
+		// result about memory. Failing here is the difference between a broken run
+		// and a false negative.
+		rows, err := rest.ListKeys(ctx, "user", userID, 5)
+		if err != nil {
+			return fmt.Errorf("post-consolidation check: %w", err)
+		}
+		if len(rows) == 0 {
+			return fmt.Errorf("consolidation left %s/%s empty after %d pass(es) over %d sessions: every "+
+				"recall would return nothing and the run would score 0 for a reason unrelated to memory. "+
+				"Check that the consolidator can reach its extractor model and that the target is not leased",
+				"user", userID, passes, sessions)
+		}
+
+		qs := SampleQueries(conv.Queries, opts.sampleQuestions)
+		if opts.onlyDated {
+			// The `when` predicate can only help a question that NAMES a window, so
+			// grading the rest to measure it spends the judge on questions whose score
+			// cannot move. The filter runs after sampling so the two compose predictably.
+			kept := qs[:0:0]
+			for _, q := range qs {
+				if DateConstrained(q.Question) {
+					kept = append(kept, q)
+				}
+			}
+			qs = kept
+		}
+		if len(qs) == 0 {
+			fmt.Fprintf(stdout, "  no questions selected for this conversation\n")
+			continue
+		}
+		fmt.Fprintf(stdout, "  grading %d of %d questions\n", len(qs), len(conv.Queries))
+		results, err := gradeQueries(ctx, mc, userID, qs, opts, stdout)
+		if err != nil {
+			return err
+		}
+		all = append(all, results...)
+
+		// CHECKPOINT after every conversation, not only at the end.
+		//
+		// Two full runs were lost to this: one when the judge's provider ran out of
+		// balance 47% in, one to a SIGTERM at 95%. Both times every graded verdict
+		// lived only in memory, so ~70 minutes of judge spend produced nothing —
+		// the log kept the per-conversation COUNTS and none of the verdicts.
+		//
+		// Writing the partial report each time makes the cost of an interruption
+		// proportional to what is left rather than total. It rewrites the same two
+		// files, so the last write wins and a completed run is byte-identical to
+		// before; a partial one is clearly labelled by its own conversation count.
+		if !opts.dryRun {
+			partial := rep
+			partial.Sampled = len(all)
+			partial.Overall = AggregateAnswers("overall", all)
+			partial.PerCategory = AnswersByCategory(all)
+			partial.Results = all
+			if err := partial.Write(opts.out); err != nil {
+				// Never fail the run for a checkpoint: the run is the product and the
+				// checkpoint is insurance. Say so and carry on.
+				fmt.Fprintf(stdout, "  warning: checkpoint write failed: %v\n", err)
+			}
+		}
+	}
+
+	rep.Sampled = len(all)
+	rep.Overall = AggregateAnswers("overall", all)
+	rep.PerCategory = AnswersByCategory(all)
+	rep.Results = all
+	rep.Matrix(stdout)
+	if opts.dryRun {
+		fmt.Fprintln(stdout, "\ndry-run: report not written")
+		return nil
+	}
+	if err := rep.Write(opts.out); err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "\nwrote %s/answer-matrix.md and answer-report.json\n", opts.out)
+	return nil
+}
+
+// gradeQueries answers and grades a question set concurrently.
+func gradeQueries(ctx context.Context, mc *MCPClient, userID string, qs []Query, opts options, stdout io.Writer) ([]AnswerResult, error) {
+	out := make([]AnswerResult, len(qs))
+	type job struct{ i int }
+	jobs := make(chan job)
+	var wg sync.WaitGroup
+	for w := 0; w < opts.concurrency; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := range jobs {
+				out[j.i] = answerOne(ctx, mc, userID, qs[j.i], opts.answerer, opts.judge, opts.injectWhen)
+			}
+		}()
+	}
+	go func() {
+		defer close(jobs)
+		for i := range qs {
+			select {
+			case <-ctx.Done():
+				return
+			case jobs <- job{i}:
+			}
+		}
+	}()
+	wg.Wait()
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	// Report progress after the fact rather than per answer: the pool finishes
+	// out of order and interleaved per-answer lines are unreadable.
+	graded := 0
+	for _, r := range out {
+		if r.Verdict != VerdictUnparsed {
+			graded++
+		}
+	}
+	fmt.Fprintf(stdout, "  graded %d/%d (%d unparsed)\n", graded, len(out), len(out)-graded)
+	return out, nil
+}

--- a/bench/cmd/locomo/answer_test.go
+++ b/bench/cmd/locomo/answer_test.go
@@ -1,0 +1,498 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestParseVerdict_ReadsAJudgeThatWrapsItsJSONInProse(t *testing.T) {
+	cases := []struct {
+		in   string
+		want Verdict
+	}{
+		{`{"verdict":"correct","why":"same date"}`, VerdictCorrect},
+		{`{"verdict":"partial","why":"missing the month"}`, VerdictPartial},
+		{`{"verdict":"wrong","why":"different person"}`, VerdictWrong},
+		{"Sure! Here is my grade:\n```json\n{\"verdict\":\"correct\",\"why\":\"ok\"}\n```\nHope that helps.", VerdictCorrect},
+		{`{"VERDICT":"Correct"}`, VerdictCorrect},
+		// A judge that answers in prose only is a judge malfunction, not a wrong
+		// answer — it must not be scored as one.
+		{"The answer looks right to me.", VerdictUnparsed},
+		{`{"grade":"A"}`, VerdictUnparsed},
+		{"", VerdictUnparsed},
+	}
+	for _, tc := range cases {
+		got, _ := ParseVerdict(tc.in)
+		if got != tc.want {
+			t.Errorf("ParseVerdict(%.40q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestVerdict_ScoreFollowsTheLoCoMoConvention(t *testing.T) {
+	for v, want := range map[Verdict]float64{
+		VerdictCorrect: 1, VerdictPartial: 0.5, VerdictWrong: 0, VerdictUnparsed: 0,
+	} {
+		if got := v.Score(); got != want {
+			t.Errorf("%q.Score() = %v, want %v", v, got, want)
+		}
+	}
+}
+
+// TestAggregateAnswers_UnparsedIsExcludedFromAccuracyNotScoredZero — folding a
+// judge malfunction into the denominator as a miss would understate the memory
+// system, which is the opposite of what a benchmark should do when its own
+// instrument fails.
+func TestAggregateAnswers_UnparsedIsExcludedFromAccuracyNotScoredZero(t *testing.T) {
+	rs := []AnswerResult{
+		{Verdict: VerdictCorrect},
+		{Verdict: VerdictUnparsed},
+	}
+	st := AggregateAnswers("t", rs)
+	if st.Queries != 2 {
+		t.Errorf("Queries = %d, want 2 (everything attempted)", st.Queries)
+	}
+	if st.Graded != 1 {
+		t.Errorf("Graded = %d, want 1 (the unparsed one is not graded)", st.Graded)
+	}
+	if st.Accuracy != 1.0 {
+		t.Errorf("Accuracy = %v, want 1.0 — the one graded answer was correct; "+
+			"scoring the unparsed verdict as wrong would have given 0.5", st.Accuracy)
+	}
+	if st.Unparsed != 1 {
+		t.Errorf("Unparsed = %d, want 1 reported separately", st.Unparsed)
+	}
+}
+
+func TestAggregateAnswers_PartialCountsHalfAndNotFoundRateIsReported(t *testing.T) {
+	st := AggregateAnswers("t", []AnswerResult{
+		{Verdict: VerdictCorrect},
+		{Verdict: VerdictPartial},
+		{Verdict: VerdictWrong, NotFound: true},
+		{Verdict: VerdictWrong},
+	})
+	if st.Accuracy != (1+0.5+0+0)/4 {
+		t.Errorf("Accuracy = %v, want %v", st.Accuracy, 1.5/4)
+	}
+	if st.NotFoundRate != 0.25 {
+		t.Errorf("NotFoundRate = %v, want 0.25", st.NotFoundRate)
+	}
+}
+
+func TestAggregateAnswers_EmptyIsZeroNotNaN(t *testing.T) {
+	st := AggregateAnswers("t", nil)
+	if st.Accuracy != 0 || st.NotFoundRate != 0 || st.Queries != 0 {
+		t.Errorf("empty aggregate = %+v, want zeroes", st)
+	}
+}
+
+// TestLayerMessages_MapsTwoSpeakersToRolesButKeepsTheirNames — role alone loses
+// identity, and LoCoMo asks who said what.
+func TestLayerMessages_MapsTwoSpeakersToRolesButKeepsTheirNames(t *testing.T) {
+	convs, _ := parseFixture(t)
+	sessions := convs[0].LayerMessages()
+	if len(sessions) != 2 {
+		t.Fatalf("got %d sessions, want 2", len(sessions))
+	}
+	first := sessions[0]
+	if first[0].Role != "user" {
+		t.Errorf("first speaker mapped to %q, want user", first[0].Role)
+	}
+	if len(first) < 2 || first[1].Role != "assistant" {
+		t.Errorf("second speaker mapped to %q, want assistant", first[1].Role)
+	}
+	if !strings.Contains(first[0].Content, "Ada") {
+		t.Errorf("content %q dropped the speaker name", first[0].Content)
+	}
+	if !strings.Contains(first[0].Content, "3 May, 2023") {
+		t.Errorf("content %q dropped the session timestamp", first[0].Content)
+	}
+	// The same speaker keeps the same role across sessions.
+	if sessions[1][0].Role != "user" {
+		t.Errorf("Ada mapped to %q in session 2, want the same role as session 1", sessions[1][0].Role)
+	}
+}
+
+func TestSampleQueries_IsDeterministicAndCoversEveryCategory(t *testing.T) {
+	var qs []Query
+	for i := 0; i < 40; i++ {
+		qs = append(qs, Query{Question: "q", Category: 4, Expected: []string{"x"}})
+	}
+	for i := 0; i < 8; i++ {
+		qs = append(qs, Query{Question: "m", Category: 1, Expected: []string{"x"}})
+	}
+	qs = append(qs, Query{Question: "o", Category: 3, Expected: []string{"x"}})
+
+	a := SampleQueries(qs, 12)
+	b := SampleQueries(qs, 12)
+	if len(a) != len(b) {
+		t.Fatalf("sample sizes differ between runs: %d vs %d", len(a), len(b))
+	}
+	for i := range a {
+		if a[i].Question != b[i].Question || a[i].Category != b[i].Category {
+			t.Fatalf("sample is not deterministic at %d — a regression could not be distinguished from resampling", i)
+		}
+	}
+	if len(a) > 12 {
+		t.Errorf("sample size %d exceeds the requested 12", len(a))
+	}
+	// The one-question category must still be represented, or a whole ability
+	// silently drops out of the report.
+	if countCat(a, 3) == 0 {
+		t.Error("the single open-domain question was dropped from the sample")
+	}
+	if n := SampleQueries(qs, 0); len(n) != len(qs) {
+		t.Errorf("sample 0 returned %d, want all %d", len(n), len(qs))
+	}
+}
+
+func TestUnframeSSE_ExtractsTheDataLine(t *testing.T) {
+	framed := "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1}\n\n"
+	if got := string(unframeSSE([]byte(framed))); got != `{"jsonrpc":"2.0","id":1}` {
+		t.Errorf("unframeSSE = %q", got)
+	}
+	plain := `{"jsonrpc":"2.0","id":1}`
+	if got := string(unframeSSE([]byte(plain))); got != plain {
+		t.Errorf("unframeSSE mangled a plain JSON body: %q", got)
+	}
+}
+
+// mcpStub serves just enough MCP for the drain tests, answering spawn_run with
+// the supplied pass reports in order.
+func mcpStub(t *testing.T, reports []string) (*httptest.Server, *int32) {
+	t.Helper()
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string `json:"method"`
+			ID     int    `json:"id"`
+			Params struct {
+				Name string `json:"name"`
+			} `json:"params"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Mcp-Session-Id", "sess-1")
+		if req.Method == "initialize" {
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+			return
+		}
+		n := atomic.AddInt32(&calls, 1)
+		idx := int(n) - 1
+		if idx >= len(reports) {
+			idx = len(reports) - 1
+		}
+		ack, _ := json.Marshal(map[string]any{
+			"run_id": "r_1", "status": "completed", "final_text": reports[idx],
+		})
+		out, _ := json.Marshal(map[string]any{
+			"jsonrpc": "2.0", "id": req.ID,
+			"result": map[string]any{"content": []any{map[string]any{"type": "text", "text": string(ack)}}},
+		})
+		_, _ = w.Write(out)
+	}))
+	return srv, &calls
+}
+
+func TestConsolidateDrain_StopsWhenTheQueueReachesZero(t *testing.T) {
+	srv, calls := mcpStub(t, []string{
+		"facts written 4; queued items 3, acked 1; watermark unchanged",
+		"facts written 2; queued items 0, acked 3; watermark advanced",
+	})
+	defer srv.Close()
+	var out bytes.Buffer
+	mc := NewMCPClient(srv.URL, "tok", 5*time.Second)
+	facts, passes, err := consolidateDrain(context.Background(), mc, "u", 12, &out)
+	if err != nil {
+		t.Fatalf("consolidateDrain: %v", err)
+	}
+	if passes != 2 {
+		t.Errorf("passes = %d, want 2 (stop as soon as the queue is empty)", passes)
+	}
+	if facts != 6 {
+		t.Errorf("facts = %d, want 6 summed across passes", facts)
+	}
+	if got := atomic.LoadInt32(calls); got != 2 {
+		t.Errorf("spawned %d runs, want 2 — extra passes are extractor spend", got)
+	}
+}
+
+func TestConsolidateDrain_HonoursThePassCeiling(t *testing.T) {
+	srv, calls := mcpStub(t, []string{"facts written 1; queued items 9, acked 1"})
+	defer srv.Close()
+	var out bytes.Buffer
+	mc := NewMCPClient(srv.URL, "tok", 5*time.Second)
+	if _, _, err := consolidateDrain(context.Background(), mc, "u", 3, &out); err != nil {
+		t.Fatalf("consolidateDrain: %v", err)
+	}
+	if got := atomic.LoadInt32(calls); got != 3 {
+		t.Errorf("spawned %d runs, want exactly the 3-pass ceiling", got)
+	}
+	if !strings.Contains(out.String(), "still queued") {
+		t.Errorf("a truncated drain was not reported: %q", out.String())
+	}
+}
+
+// TestAnswerOne_AbstentionSkipsTheJudgeAndScoresWrong — NOT_FOUND cannot match a
+// gold answer, so spending a judge call on it only adds a chance to mis-grade.
+func TestAnswerOne_AbstentionSkipsTheJudgeAndScoresWrong(t *testing.T) {
+	srv, calls := mcpStub(t, []string{"NOT_FOUND"})
+	defer srv.Close()
+	mc := NewMCPClient(srv.URL, "tok", 5*time.Second)
+	res := answerOne(context.Background(), mc, "u",
+		Query{Question: "when?", Category: 2, Answer: "May 2023"}, "a", "j", false)
+	if res.Verdict != VerdictWrong {
+		t.Errorf("Verdict = %q, want wrong", res.Verdict)
+	}
+	if !res.NotFound {
+		t.Error("NotFound = false, want the abstention flagged for the report")
+	}
+	if got := atomic.LoadInt32(calls); got != 1 {
+		t.Errorf("made %d runs, want 1 — the judge call should be skipped", got)
+	}
+}
+
+// TestConsolidateDrain_ReportsALeasedTargetAsItsOwnError — the failure that
+// produced a false 0.0000 in the first live run. Every pass answered "target
+// busy", which matched no queue-depth pattern, so the loop treated a blocked
+// target as a drained one and grading proceeded against an empty store.
+func TestConsolidateDrain_ReportsALeasedTargetAsItsOwnError(t *testing.T) {
+	srv, calls := mcpStub(t, []string{
+		"target busy: another consolidator holds this target's lease. Nothing read, nothing written.",
+	})
+	defer srv.Close()
+	var out bytes.Buffer
+	mc := NewMCPClient(srv.URL, "tok", 5*time.Second)
+	_, _, err := consolidateDrain(context.Background(), mc, "u", 12, &out)
+	if err == nil {
+		t.Fatal("a leased target was reported as a successful drain")
+	}
+	var busy *ErrConsolidatorBusy
+	if !errors.As(err, &busy) {
+		t.Fatalf("err = %T %v, want ErrConsolidatorBusy so the caller can tell it apart", err, err)
+	}
+	if !strings.Contains(err.Error(), "30 minutes") {
+		t.Errorf("the error does not tell the operator how long the lease lasts: %v", err)
+	}
+	if got := atomic.LoadInt32(calls); got != 1 {
+		t.Errorf("spawned %d passes against a leased target, want 1", got)
+	}
+}
+
+// TestConsolidateDrain_TreatsAReportWithoutAQueueDepthAsDrained — a pass with
+// nothing to do says so in prose. That is a legitimate stop, distinct from the
+// leased case above, and must not be an error.
+func TestConsolidateDrain_TreatsAReportWithoutAQueueDepthAsDrained(t *testing.T) {
+	srv, _ := mcpStub(t, []string{"nothing to consolidate for this target"})
+	defer srv.Close()
+	var out bytes.Buffer
+	mc := NewMCPClient(srv.URL, "tok", 5*time.Second)
+	if _, passes, err := consolidateDrain(context.Background(), mc, "u", 12, &out); err != nil {
+		t.Fatalf("a nothing-to-do pass was reported as an error: %v", err)
+	} else if passes != 1 {
+		t.Errorf("passes = %d, want 1", passes)
+	}
+	if !strings.Contains(out.String(), "treating as drained") {
+		t.Errorf("stop reason not explained: %q", out.String())
+	}
+}
+
+// memoryStub answers Memory-tool calls by op, recording the ops it saw in order.
+// It exists because the flush's whole content is a SEQUENCE — lease, then drain,
+// then ack, then release — and the ordering is what makes it correct: acking
+// without the lease is refused by the server, and releasing before the last ack
+// would hand the target away mid-flush.
+func memoryStub(t *testing.T, acquired bool, pages [][]string) (*httptest.Server, *[]string) {
+	t.Helper()
+	var mu sync.Mutex
+	ops := []string{}
+	page := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string `json:"method"`
+			ID     int    `json:"id"`
+			Params struct {
+				Name      string         `json:"name"`
+				Arguments map[string]any `json:"arguments"`
+			} `json:"params"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Mcp-Session-Id", "sess-1")
+		if req.Method == "initialize" {
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+			return
+		}
+		op, _ := req.Params.Arguments["op"].(string)
+		mu.Lock()
+		ops = append(ops, op)
+		var payload map[string]any
+		switch op {
+		case "cursor_lease":
+			payload = map[string]any{"acquired": acquired, "leased_by": "someone-else",
+				"lease_expires_at": "2026-08-28T09:00:00Z"}
+		case "pending_drain":
+			rows := []any{}
+			if page < len(pages) {
+				for _, id := range pages[page] {
+					rows = append(rows, map[string]any{"id": id})
+				}
+				page++
+			}
+			payload = map[string]any{"pending": rows}
+		case "pending_ack":
+			ids, _ := req.Params.Arguments["ids"].([]any)
+			payload = map[string]any{"ok": true, "acked": len(ids)}
+		default:
+			payload = map[string]any{"ok": true}
+		}
+		mu.Unlock()
+		body, _ := json.Marshal(payload)
+		out, _ := json.Marshal(map[string]any{
+			"jsonrpc": "2.0", "id": req.ID,
+			"result": map[string]any{"content": []any{map[string]any{"type": "text", "text": string(body)}}},
+		})
+		_, _ = w.Write(out)
+	}))
+	return srv, &ops
+}
+
+// TestFlushPendingQueue_DiscardsEveryPageWithoutSpawningAnything is the point of
+// the flush: leftovers go away without an extractor call. The pre-ingest step used
+// to run up to twelve full consolidation passes to achieve this, which cost the
+// whole extractor spend on data the harness was about to purge and re-ingest —
+// measured at ~70 minutes on one run before it reached its own conversation.
+func TestFlushPendingQueue_DiscardsEveryPageWithoutSpawningAnything(t *testing.T) {
+	srv, ops := memoryStub(t, true, [][]string{
+		{"pend-1", "pend-2"},
+		{"pend-3"},
+		{}, // the queue is empty; the loop must stop here
+	})
+	defer srv.Close()
+	mc := NewMCPClient(srv.URL, "tok", 30*time.Second)
+
+	n, err := flushPendingQueue(context.Background(), mc, io.Discard)
+	if err != nil {
+		t.Fatalf("flushPendingQueue: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("flushed %d, want 3 across two pages", n)
+	}
+	got := strings.Join(*ops, ",")
+	want := "cursor_lease,pending_drain,pending_ack,pending_drain,pending_ack,pending_drain,cursor_release"
+	if got != want {
+		t.Errorf("op sequence =\n  %s\nwant\n  %s", got, want)
+	}
+	// No agent was spawned — that is the whole saving.
+	if strings.Contains(got, "spawn") {
+		t.Errorf("the flush spawned something: %s", got)
+	}
+}
+
+// TestFlushPendingQueue_RefusesWhenTheTargetIsLeased. Another pass holding the
+// lease is READING the queue this would empty, so flushing around it would delete
+// the input it is mid-way through. Refuse, and say who holds it.
+func TestFlushPendingQueue_RefusesWhenTheTargetIsLeased(t *testing.T) {
+	srv, ops := memoryStub(t, false, [][]string{{"pend-1"}})
+	defer srv.Close()
+	mc := NewMCPClient(srv.URL, "tok", 30*time.Second)
+
+	n, err := flushPendingQueue(context.Background(), mc, io.Discard)
+	if err == nil {
+		t.Fatal("flushed a target another pass holds")
+	}
+	var busy *ErrConsolidatorBusy
+	if !errors.As(err, &busy) {
+		t.Errorf("error = %T (%v), want ErrConsolidatorBusy so the caller can report it as busy", err, err)
+	}
+	if n != 0 {
+		t.Errorf("flushed %d items despite not holding the lease", n)
+	}
+	// It must NOT have acked anything, and must not hold a lease it never got.
+	got := strings.Join(*ops, ",")
+	if strings.Contains(got, "pending_ack") {
+		t.Errorf("acked without the lease: %s", got)
+	}
+	if strings.Contains(got, "cursor_release") {
+		t.Errorf("released a lease it never acquired: %s", got)
+	}
+}
+
+// TestSeedTurnRows_WritesEveryTurnEmbeddedIntoTheAnswerersPartition.
+//
+// The measurement this enables is the whole point, so the properties worth pinning
+// are the ones that silently produce a zero: every turn present (a missing turn is
+// an unanswerable question), embed ON (an unembedded row is invisible to semantic
+// search), keyed by dia_id (the retrieval axis's convention), and the SESSION
+// TIMESTAMP carried in the body — LoCoMo dates live on the session, not the turn,
+// so without the prefix the temporal category is unretrievable at any embedder
+// quality.
+//
+// Measured before this existed: the answerer had 29 facts distilled from 419 turns
+// and abstained on 72% of questions; with the turns seeded it scored 0.7353.
+func TestSeedTurnRows_WritesEveryTurnEmbeddedIntoTheAnswerersPartition(t *testing.T) {
+	type put struct {
+		path string
+		body map[string]any
+	}
+	var mu sync.Mutex
+	var puts []put
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		mu.Lock()
+		puts = append(puts, put{path: r.URL.Path, body: body})
+		mu.Unlock()
+		_, _ = w.Write([]byte(`{"key":"k","embedded":true}`))
+	}))
+	defer srv.Close()
+
+	conv := Conversation{Turns: []Turn{
+		{DiaID: "D1:1", Speaker: "Caroline", Text: "I bought a clay pot.", DateTime: "1:36 pm on 3 July, 2023"},
+		{DiaID: "D1:2", Speaker: "Melanie", Text: "Nice!", DateTime: "1:36 pm on 3 July, 2023"},
+	}}
+	rest := NewClient(srv.URL, "tok", 5*time.Second)
+
+	n, err := seedTurnRows(context.Background(), rest, "subj-1", conv, options{concurrency: 2}, io.Discard)
+	if err != nil {
+		t.Fatalf("seedTurnRows: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("seeded %d, want 2 (one row per turn)", n)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(puts) != 2 {
+		t.Fatalf("PUTs = %d, want one per turn: %+v", len(puts), puts)
+	}
+	seenDia := map[string]bool{}
+	for _, p := range puts {
+		// The answerer reads user/<subject>; anything else is a partition it cannot see.
+		if !strings.Contains(p.path, "/user/") || !strings.Contains(p.path, "subj-1") {
+			t.Errorf("PUT path %q does not address user/subj-1", p.path)
+		}
+		for _, d := range []string{"D1:1", "D1:2"} {
+			if strings.Contains(p.path, d) {
+				seenDia[d] = true
+			}
+		}
+		if embed, _ := p.body["embed"].(bool); !embed {
+			t.Errorf("PUT %s did not request embedding — an unembedded row is invisible to search: %+v", p.path, p.body)
+		}
+		val, _ := p.body["value"].(string)
+		if !strings.Contains(val, "3 July, 2023") {
+			t.Errorf("PUT %s body carries no session timestamp, so temporal questions cannot retrieve it: %q", p.path, val)
+		}
+	}
+	if len(seenDia) != 2 {
+		t.Errorf("rows are not keyed by dia_id; saw %v", seenDia)
+	}
+}

--- a/bench/cmd/locomo/client.go
+++ b/bench/cmd/locomo/client.go
@@ -98,6 +98,11 @@ func (c *Client) Whoami(ctx context.Context) (Identity, error) {
 type putEntryBody struct {
 	Value json.RawMessage `json:"value"`
 	Embed bool            `json:"embed,omitempty"`
+	// ObservedAt dates the row — when the turn was SAID. LoCoMo stamps the SESSION,
+	// and every turn in it inherits that stamp, which is the only date the corpus
+	// actually carries. Empty leaves the row undated, which is what every run before
+	// this one produced.
+	ObservedAt string `json:"observed_at,omitempty"`
 }
 
 type putEntryResponse struct {
@@ -114,6 +119,13 @@ type putEntryResponse struct {
 // noise for a dense embedder, but it IS an asymmetry with the un-quoted query
 // and the report says so rather than leaving it unstated.
 func (c *Client) PutEntry(ctx context.Context, scope, scopeID, key, value string, embed bool) (putEntryResponse, error) {
+	return c.PutEntryAt(ctx, scope, scopeID, key, value, embed, "")
+}
+
+// PutEntryAt is PutEntry plus the row's observed time (RFC CL). Separate rather than
+// a sixth positional argument on the old one, so the dozen existing call sites stay
+// untouched and undated — which is what they mean.
+func (c *Client) PutEntryAt(ctx context.Context, scope, scopeID, key, value string, embed bool, observedAt string) (putEntryResponse, error) {
 	raw, err := json.Marshal(value)
 	if err != nil {
 		return putEntryResponse{}, err
@@ -121,7 +133,7 @@ func (c *Client) PutEntry(ctx context.Context, scope, scopeID, key, value string
 	path := fmt.Sprintf("/v1/_memory/scopes/%s/%s/keys/%s",
 		url.PathEscape(scope), url.PathEscape(scopeID), url.PathEscape(key))
 	var out putEntryResponse
-	err = c.do(ctx, http.MethodPut, path, putEntryBody{Value: raw, Embed: embed}, &out)
+	err = c.do(ctx, http.MethodPut, path, putEntryBody{Value: raw, Embed: embed, ObservedAt: observedAt}, &out)
 	return out, err
 }
 
@@ -164,4 +176,24 @@ func (c *Client) DeleteEntry(ctx context.Context, scope, scopeID, key string) er
 	path := fmt.Sprintf("/v1/_memory/scopes/%s/%s/keys/%s",
 		url.PathEscape(scope), url.PathEscape(scopeID), url.PathEscape(key))
 	return c.do(ctx, http.MethodDelete, path, nil, nil)
+}
+
+// ListKeys returns the keys held in one (scope, scope_id) partition. Used by the
+// answer axis to purge the memory layer between conversations.
+func (c *Client) ListKeys(ctx context.Context, scope, scopeID string, limit int) ([]string, error) {
+	path := fmt.Sprintf("/v1/_memory/scopes/%s/%s/keys?limit=%d",
+		url.PathEscape(scope), url.PathEscape(scopeID), limit)
+	var out struct {
+		Entries []struct {
+			Key string `json:"key"`
+		} `json:"entries"`
+	}
+	if err := c.do(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	keys := make([]string, 0, len(out.Entries))
+	for _, e := range out.Entries {
+		keys = append(keys, e.Key)
+	}
+	return keys, nil
 }

--- a/bench/cmd/locomo/client_test.go
+++ b/bench/cmd/locomo/client_test.go
@@ -12,6 +12,17 @@ import (
 	"time"
 )
 
+// clearBearerEnv unsets every name bearer() consults. Without it a test
+// asserting "no bearer" passes or fails according to what the developer running
+// it happens to export — this suite was written on a machine with a real
+// LOCOMO_BENCH_TENANT_TOKEN in the environment, and it caught exactly that.
+func clearBearerEnv(t *testing.T) {
+	t.Helper()
+	for _, env := range []string{"LOOMCYCLE_LOCOMO_TOKEN", "LOCOMO_BENCH_TENANT_TOKEN", "LOOMCYCLE_AUTH_TOKEN"} {
+		t.Setenv(env, "")
+	}
+}
+
 func meServer(t *testing.T, tenant string) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -32,6 +43,7 @@ func meServer(t *testing.T, tenant string) *httptest.Server {
 func TestConnect_RefusesTheDefaultTenantSoTheCorpusCannotLandInRealMemory(t *testing.T) {
 	srv := meServer(t, "")
 	defer srv.Close()
+	clearBearerEnv(t)
 	t.Setenv("LOOMCYCLE_LOCOMO_TOKEN", "tok")
 
 	var out bytes.Buffer
@@ -47,6 +59,7 @@ func TestConnect_RefusesTheDefaultTenantSoTheCorpusCannotLandInRealMemory(t *tes
 func TestConnect_AcceptsADedicatedTenant(t *testing.T) {
 	srv := meServer(t, "locomo-bench")
 	defer srv.Close()
+	clearBearerEnv(t)
 	t.Setenv("LOOMCYCLE_LOCOMO_TOKEN", "tok")
 
 	var out bytes.Buffer
@@ -69,6 +82,7 @@ func TestConnect_AcceptsADedicatedTenant(t *testing.T) {
 func TestConnect_AllowSharedTenantIsAnExplicitOverride(t *testing.T) {
 	srv := meServer(t, "")
 	defer srv.Close()
+	clearBearerEnv(t)
 	t.Setenv("LOOMCYCLE_LOCOMO_TOKEN", "tok")
 
 	var out bytes.Buffer
@@ -79,8 +93,7 @@ func TestConnect_AllowSharedTenantIsAnExplicitOverride(t *testing.T) {
 }
 
 func TestConnect_RefusesWithNoBearerRatherThanCallingUnauthenticated(t *testing.T) {
-	t.Setenv("LOOMCYCLE_LOCOMO_TOKEN", "")
-	t.Setenv("LOOMCYCLE_AUTH_TOKEN", "")
+	clearBearerEnv(t)
 	var out bytes.Buffer
 	if _, _, err := connect(context.Background(), options{instance: "http://127.0.0.1:1", timeout: time.Second}, &out); err == nil ||
 		!strings.Contains(err.Error(), "no bearer") {
@@ -89,10 +102,22 @@ func TestConnect_RefusesWithNoBearerRatherThanCallingUnauthenticated(t *testing.
 }
 
 func TestBearer_PrefersTheBenchmarkSpecificToken(t *testing.T) {
+	clearBearerEnv(t)
 	t.Setenv("LOOMCYCLE_AUTH_TOKEN", "operator")
 	t.Setenv("LOOMCYCLE_LOCOMO_TOKEN", "bench")
 	if got := bearer(); got != "bench" {
 		t.Errorf("bearer() = %q, want the benchmark token so the operator bearer is not reused", got)
+	}
+}
+
+// TestBearer_AcceptsTheOperatorsNaturalNameForTheBenchToken — the name an
+// operator reaches for when minting a dedicated bench bearer.
+func TestBearer_AcceptsTheOperatorsNaturalNameForTheBenchToken(t *testing.T) {
+	clearBearerEnv(t)
+	t.Setenv("LOOMCYCLE_AUTH_TOKEN", "operator")
+	t.Setenv("LOCOMO_BENCH_TENANT_TOKEN", "bench")
+	if got := bearer(); got != "bench" {
+		t.Errorf("bearer() = %q, want the bench token to win over the operator bearer", got)
 	}
 }
 

--- a/bench/cmd/locomo/episodes.go
+++ b/bench/cmd/locomo/episodes.go
@@ -1,0 +1,125 @@
+package main
+
+// episodes.go — RFC CM-1: measure, build nothing.
+//
+// CM-1 asks one question before any episode tier is designed: does a coarser,
+// curated unit beat dumping the raw turns in? Verbatim turns are the strongest
+// configuration this harness has ever measured (answer 0.6915, retrieval recall@10
+// 0.6675), so an episode tier that merely ties with them is machinery bought for
+// nothing. This file provides the alternative units to compare against, and the
+// observed-time stamping that RFC CL's `when` predicate needs.
+//
+// Nothing here writes an episode TIER. It builds the rows a tier would produce and
+// measures them through the existing search and answer axes, which is the whole
+// point of a phase that builds nothing.
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// sessionDateRe pulls the day out of LoCoMo's session stamp, e.g.
+// "1:56 pm on 8 May, 2023". Only the DATE is taken: the clock time is present but
+// every turn in a session shares it, so it carries no ordering information and
+// pretending otherwise would stamp forty turns at the same instant with false
+// precision.
+var sessionDateRe = regexp.MustCompile(`on\s+(\d{1,2})\s+([A-Za-z]+),\s*(\d{4})`)
+
+// ObservedAt renders the turn's session date as an RFC3339 instant, or "" when the
+// stamp cannot be read.
+//
+// EMPTY ON FAILURE, never a guess. A wrong observed time is worse than none: it files
+// the row under a day it does not belong to, where a window query finds it and a
+// query for the right day does not.
+func (t Turn) ObservedAt() string {
+	m := sessionDateRe.FindStringSubmatch(t.DateTime)
+	if m == nil {
+		return ""
+	}
+	d, err := time.Parse("2 January 2006", fmt.Sprintf("%s %s %s", m[1], m[2], m[3]))
+	if err != nil {
+		return ""
+	}
+	return d.UTC().Format(time.RFC3339)
+}
+
+// SessionRow is one session's turns collapsed into a single stored row — the
+// coarser unit CM-1 measures against per-turn.
+type SessionRow struct {
+	Key        string
+	Body       string
+	ObservedAt string
+}
+
+// SessionRows groups a conversation's turns by session, in session order.
+//
+// The KEY keeps a dia_id shape (`D<session>:s`) so the retrieval axis can still map
+// a hit back to ground truth: LoCoMo's `qa.evidence` names turn ids, so a
+// session-level row is scored as containing any of its turns' ids. That mapping is
+// the reason this comparison is possible at all without re-annotating the corpus.
+func SessionRows(conv Conversation) []SessionRow {
+	order := []int{}
+	byTurn := map[int][]Turn{}
+	for _, t := range conv.Turns {
+		if _, seen := byTurn[t.Session]; !seen {
+			order = append(order, t.Session)
+		}
+		byTurn[t.Session] = append(byTurn[t.Session], t)
+	}
+	out := make([]SessionRow, 0, len(order))
+	for _, sess := range order {
+		turns := byTurn[sess]
+		if len(turns) == 0 {
+			continue
+		}
+		var b strings.Builder
+		// The session stamp goes in ONCE at the top rather than on every turn: it is
+		// the same date for all of them, and repeating it forty times would let the
+		// date dominate the embedding of a row whose value is its content.
+		b.WriteString("[" + turns[0].DateTime + "]\n")
+		for _, t := range turns {
+			b.WriteString(t.Speaker)
+			b.WriteString(": ")
+			b.WriteString(t.Text)
+			if t.Caption != "" {
+				b.WriteString(" (" + t.Caption + ")")
+			}
+			b.WriteString("\n")
+		}
+		out = append(out, SessionRow{
+			Key:        fmt.Sprintf("D%d:s", sess),
+			Body:       b.String(),
+			ObservedAt: turns[0].ObservedAt(),
+		})
+	}
+	return out
+}
+
+// SessionOfDiaID maps a turn id onto the session row key that would contain it, so
+// a recall@k computed over session rows can be scored against turn-level ground
+// truth. Returns "" for an unparseable id rather than inventing a session.
+func SessionOfDiaID(diaID string) string {
+	i := strings.Index(diaID, ":")
+	if i <= 0 {
+		return ""
+	}
+	return diaID[:i] + ":s"
+}
+
+// DateConstrained reports whether a question names an absolute date or window —
+// "on October 3, 2023", "in the first weekend of August", "during July 2023".
+//
+// This is the slice RFC CL's `when` predicate exists for, and the only slice where
+// it can help: a topic-shaped question has no window to pass. It is deliberately the
+// SAME pattern the CL analysis used, so the measured 0.5484 baseline and any rerun
+// are computed over the same set rather than over two similar-looking ones.
+var dateConstrainedRe = regexp.MustCompile(
+	`(?i)\b(on|in|during|first|second|third|last)\s+(week|weekend|month)?\s*(of\s+)?` +
+		`(January|February|March|April|May|June|July|August|September|October|November|December|` +
+		`\d{1,2}\s+\w+|\d{4})`)
+
+func DateConstrained(question string) bool {
+	return dateConstrainedRe.MatchString(question)
+}

--- a/bench/cmd/locomo/episodes_test.go
+++ b/bench/cmd/locomo/episodes_test.go
@@ -1,0 +1,120 @@
+package main
+
+import "testing"
+
+// The session stamp becomes a real observed time, and an unreadable one becomes
+// nothing rather than a guess.
+func TestTurn_ObservedAt(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"1:56 pm on 8 May, 2023", "2023-05-08T00:00:00Z"},
+		{"9:00 am on 1 June, 2023", "2023-06-01T00:00:00Z"},
+		{"7:15 pm on 23 October, 2023", "2023-10-23T00:00:00Z"},
+		{"sometime last spring", ""},
+		{"", ""},
+		{"on 31 Febtober, 2023", ""},
+	} {
+		if got := (Turn{DateTime: tc.in}).ObservedAt(); got != tc.want {
+			t.Errorf("ObservedAt(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// A session row carries every turn in the session, once, under one date — and its
+// key maps back to turn-level ground truth so recall stays scoreable.
+func TestSessionRows_GroupsAndStaysScoreable(t *testing.T) {
+	conv := Conversation{Turns: []Turn{
+		{DiaID: "D1:1", Session: 1, DateTime: "1:00 pm on 3 May, 2023", Speaker: "A", Text: "hello"},
+		{DiaID: "D1:2", Session: 1, DateTime: "1:00 pm on 3 May, 2023", Speaker: "B", Text: "hi there"},
+		{DiaID: "D2:1", Session: 2, DateTime: "9:00 am on 10 May, 2023", Speaker: "A", Text: "later"},
+	}}
+	rows := SessionRows(conv)
+	if len(rows) != 2 {
+		t.Fatalf("got %d session rows, want 2", len(rows))
+	}
+	if rows[0].Key != "D1:s" || rows[1].Key != "D2:s" {
+		t.Errorf("keys = %q/%q, want D1:s/D2:s", rows[0].Key, rows[1].Key)
+	}
+	if rows[0].ObservedAt != "2023-05-03T00:00:00Z" {
+		t.Errorf("observed_at = %q, want the session's own date", rows[0].ObservedAt)
+	}
+	for _, want := range []string{"hello", "hi there"} {
+		if !contains(rows[0].Body, want) {
+			t.Errorf("session row lost %q: %s", want, rows[0].Body)
+		}
+	}
+	if contains(rows[0].Body, "later") {
+		t.Error("session row absorbed a turn from another session")
+	}
+	// The date appears ONCE — repeating it per turn would let it dominate the
+	// embedding of a row whose value is its content.
+	if n := count(rows[0].Body, "3 May, 2023"); n != 1 {
+		t.Errorf("session date appears %d times, want exactly 1", n)
+	}
+	// And ground truth still maps.
+	if SessionOfDiaID("D1:2") != "D1:s" {
+		t.Errorf("SessionOfDiaID(D1:2) = %q, want D1:s — without this a session row "+
+			"cannot be scored against turn-level evidence", SessionOfDiaID("D1:2"))
+	}
+	if SessionOfDiaID("nonsense") != "" {
+		t.Error("an unparseable id must map to nothing, not to an invented session")
+	}
+}
+
+func contains(hay, needle string) bool { return count(hay, needle) > 0 }
+
+func count(hay, needle string) int {
+	n, i := 0, 0
+	for {
+		j := indexFrom(hay, needle, i)
+		if j < 0 {
+			return n
+		}
+		n++
+		i = j + 1
+	}
+}
+
+func indexFrom(hay, needle string, from int) int {
+	if from >= len(hay) {
+		return -1
+	}
+	for i := from; i+len(needle) <= len(hay); i++ {
+		if hay[i:i+len(needle)] == needle {
+			return i
+		}
+	}
+	return -1
+}
+
+// Scoring must credit a SESSION row for the expected TURNS it contains, or the
+// CM-1 comparison measures nothing: the coarse arm would score zero everywhere.
+func TestScore_SessionRowCreditsTheTurnsItContains(t *testing.T) {
+	q := Query{Question: "when did X", Expected: []string{"D1:2", "D1:5", "D3:1"}}
+
+	// Turn-level arm: three exact keys, three hits.
+	turnRes := Score(q, []string{"D1:2", "D9:9", "D1:5", "D3:1"}, 10, 0)
+	if turnRes.Hits != 3 {
+		t.Errorf("turn arm hits = %d, want 3", turnRes.Hits)
+	}
+
+	// Session-level arm: D1:s covers TWO expected turns, D3:s covers one.
+	sessRes := Score(q, []string{"D1:s", "D9:s", "D3:s"}, 10, 0)
+	if sessRes.Hits != 3 {
+		t.Errorf("session arm hits = %d, want 3 — a session row must credit every "+
+			"expected turn it contains, or the coarse arm loses purely for being coarse",
+			sessRes.Hits)
+	}
+	if sessRes.FirstHitRank != 1 {
+		t.Errorf("session arm first hit at rank %d, want 1", sessRes.FirstHitRank)
+	}
+}
+
+// The same expected turn is never credited twice, however it is reached.
+func TestScore_NoDoubleCredit(t *testing.T) {
+	q := Query{Question: "q", Expected: []string{"D1:2"}}
+	res := Score(q, []string{"D1:s", "D1:2"}, 10, 0)
+	if res.Hits != 1 {
+		t.Errorf("hits = %d, want 1 — the session row and the turn row cover the SAME "+
+			"expected turn, and counting it twice would report recall above 1.0", res.Hits)
+	}
+}

--- a/bench/cmd/locomo/main.go
+++ b/bench/cmd/locomo/main.go
@@ -39,26 +39,47 @@ func main() {
 }
 
 type options struct {
-	mode              string
-	data              string
-	instance          string
-	scope             string
-	topK              int
-	categories        []int
-	conversations     int
-	concurrency       int
-	out               string
-	dryRun            bool
-	noEmbed           bool
+	mode          string
+	data          string
+	instance      string
+	scope         string
+	topK          int
+	categories    []int
+	conversations int
+	concurrency   int
+	out           string
+	dryRun        bool
+	noEmbed       bool
+	// unit is the row GRANULARITY (RFC CM-1): "turn" reproduces every run before
+	// this one, "session" collapses each session into one row. The comparison is the
+	// whole point of CM-1 — an episode tier that does not beat verbatim turns is not
+	// worth building.
+	unit string
+	// dated stamps each row's observed time from its session date, so the RFC CL
+	// `when` predicate has something to filter on. Off reproduces the undated corpus
+	// every prior number was measured against.
+	dated bool
+	// onlyDated restricts grading to the date-constrained slice — 31 of 1,535
+	// questions. It is the only slice the `when` predicate can help, and grading the
+	// other 1,504 to measure it costs 75 minutes of judge to move a headline number
+	// by half a point.
+	onlyDated         bool
+	injectWhen        bool
 	allowSharedTenant bool
 	timeout           time.Duration
+	answerer          string
+	judge             string
+	sampleQuestions   int
+	consolidatePasses int
+	seedTurns         bool
+	runTimeout        time.Duration
 }
 
 func run(args []string, stdout, stderr io.Writer) error {
 	fs := flag.NewFlagSet("locomo", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	var (
-		mode        = fs.String("mode", "convert", "convert | ingest | search | all | purge")
+		mode        = fs.String("mode", "convert", "convert | ingest | search | all | purge | answer")
 		data        = fs.String("data", "", "path to locomo10.json (required; not vendored — see README)")
 		instance    = fs.String("loomcycle", "http://127.0.0.1:8787", "base URL of the running loomcycle")
 		scope       = fs.String("scope", "agent", "memory scope to write/read (agent|user|tenant)")
@@ -69,8 +90,18 @@ func run(args []string, stdout, stderr io.Writer) error {
 		out         = fs.String("out", "", "output directory (default: bench/results/locomo-<timestamp>)")
 		dryRun      = fs.Bool("dry-run", false, "parse and report, write nothing")
 		noEmbed     = fs.Bool("no-embed", false, "skip embedding on ingest (use /v1/_memory/backfill_embeddings after)")
+		unit        = fs.String("unit", "turn", "row granularity: turn|session (RFC CM-1)")
+		dated       = fs.Bool("dated", false, "stamp observed_at from each row's session date (RFC CL)")
+		onlyDated   = fs.Bool("only-date-questions", false, "grade ONLY questions naming an absolute date/window (RFC CL slice)")
+		injectWhen  = fs.Bool("inject-when", false, "resolve the question date phrase and hand the answerer a when window")
 		allowShared = fs.Bool("allow-shared-tenant", false, "permit writing into the default/legacy tenant (NOT isolated)")
 		timeout     = fs.Duration("timeout", 60*time.Second, "per-request timeout")
+		answerer    = fs.String("answerer", "locomo/answerer", "agent that answers from memory (answer axis)")
+		judge       = fs.String("judge", "locomo/judge", "agent that grades an answer against gold (answer axis)")
+		sampleQ     = fs.Int("sample-questions", 0, "answer axis: grade only N questions, stratified by category (0 = all)")
+		consPasses  = fs.Int("consolidate-passes", 12, "answer axis: max consolidation passes per conversation (0 = skip consolidation entirely)")
+		seedTurns   = fs.Bool("seed-turns", false, "answer axis: also write one embedded row per TURN into the partition the answerer reads, so it answers from conversation content rather than only from distilled facts (this is what the published systems do)")
+		runTimeout  = fs.Duration("run-timeout", 10*time.Minute, "answer axis: per-run timeout (agent runs are slower than REST calls)")
 	)
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -86,7 +117,10 @@ func run(args []string, stdout, stderr io.Writer) error {
 		mode: *mode, data: *data, instance: *instance, scope: *scope,
 		topK: *topK, categories: cats, conversations: *convLimit,
 		concurrency: *concurrency, out: *out, dryRun: *dryRun, noEmbed: *noEmbed,
+		unit: *unit, dated: *dated, onlyDated: *onlyDated, injectWhen: *injectWhen,
 		allowSharedTenant: *allowShared, timeout: *timeout,
+		answerer: *answerer, judge: *judge, sampleQuestions: *sampleQ,
+		consolidatePasses: *consPasses, runTimeout: *runTimeout, seedTurns: *seedTurns,
 	}
 	if opts.concurrency < 1 {
 		opts.concurrency = 1
@@ -126,8 +160,10 @@ func run(args []string, stdout, stderr io.Writer) error {
 		return doSearch(ctx, convs, defects, inFile, opts, stdout)
 	case "purge":
 		return doPurge(ctx, convs, opts, stdout)
+	case "answer", "answer-all":
+		return doAnswerAxis(ctx, convs, defects, opts, stdout)
 	default:
-		return fmt.Errorf("unknown -mode %q (convert|ingest|search|all|purge)", opts.mode)
+		return fmt.Errorf("unknown -mode %q (convert|ingest|search|all|purge|answer)", opts.mode)
 	}
 }
 
@@ -188,7 +224,9 @@ func countQueries(cs []Conversation) int {
 // operator can point this at an isolated tenant without touching the operator
 // bearer their tools already use.
 func bearer() string {
-	for _, env := range []string{"LOOMCYCLE_LOCOMO_TOKEN", "LOOMCYCLE_AUTH_TOKEN"} {
+	// LOCOMO_BENCH_TENANT_TOKEN is accepted because it is what operators
+	// actually name the dedicated bench bearer when they mint one.
+	for _, env := range []string{"LOOMCYCLE_LOCOMO_TOKEN", "LOCOMO_BENCH_TENANT_TOKEN", "LOOMCYCLE_AUTH_TOKEN"} {
 		if v := strings.TrimSpace(os.Getenv(env)); v != "" {
 			return v
 		}
@@ -306,9 +344,15 @@ func doIngest(ctx context.Context, convs []Conversation, opts options, stdout io
 	ctx, cancelPool := context.WithCancel(ctx)
 	defer cancelPool()
 
+	// One job shape for both granularities (RFC CM-1). Collapsing them here rather
+	// than forking the pool keeps the concurrency, the error handling and the
+	// embed-warning abort identical between the two arms — a comparison whose arms
+	// differ in their plumbing measures the plumbing.
 	type job struct {
-		scopeID string
-		turn    Turn
+		scopeID    string
+		key        string
+		body       string
+		observedAt string
 	}
 	jobs := make(chan job)
 	var (
@@ -326,12 +370,12 @@ func doIngest(ctx context.Context, convs []Conversation, opts options, stdout io
 		go func() {
 			defer wg.Done()
 			for j := range jobs {
-				resp, err := c.PutEntry(ctx, opts.scope, j.scopeID, j.turn.DiaID, j.turn.Body(), !opts.noEmbed)
+				resp, err := c.PutEntryAt(ctx, opts.scope, j.scopeID, j.key, j.body, !opts.noEmbed, j.observedAt)
 				mu.Lock()
 				switch {
 				case err != nil:
 					if firstErr == nil {
-						firstErr = fmt.Errorf("put %s/%s: %w", j.scopeID, j.turn.DiaID, err)
+						firstErr = fmt.Errorf("put %s/%s: %w", j.scopeID, j.key, err)
 						cancelPool()
 					}
 				default:
@@ -354,11 +398,29 @@ func doIngest(ctx context.Context, convs []Conversation, opts options, stdout io
 	go func() {
 		defer close(jobs)
 		for _, conv := range convs {
+			if opts.unit == "session" {
+				for _, r := range SessionRows(conv) {
+					obs := ""
+					if opts.dated {
+						obs = r.ObservedAt
+					}
+					select {
+					case <-ctx.Done():
+						return
+					case jobs <- job{scopeID: conv.ScopeID(), key: r.Key, body: r.Body, observedAt: obs}:
+					}
+				}
+				continue
+			}
 			for _, t := range conv.Turns {
+				obs := ""
+				if opts.dated {
+					obs = t.ObservedAt()
+				}
 				select {
 				case <-ctx.Done():
 					return
-				case jobs <- job{scopeID: conv.ScopeID(), turn: t}:
+				case jobs <- job{scopeID: conv.ScopeID(), key: t.DiaID, body: t.Body(), observedAt: obs}:
 				}
 			}
 		}
@@ -451,16 +513,31 @@ func doPurge(ctx context.Context, convs []Conversation, opts options, stdout io.
 	if err != nil {
 		return err
 	}
+	// EVERY KEY SHAPE THE HARNESS CAN WRITE, or a purge silently leaves rows behind.
+	//
+	// Keys are derived from the dataset, never from a listing, so purge can only ever
+	// remove rows this harness itself would have written — a deliberate safety
+	// property, and the reason a NEW key shape has to be added here explicitly.
+	// Adding the CM-1 session unit without this left every `D<n>:s` row in place
+	// across a re-ingest, and 15.6% of the next run's retrieved keys were rows from
+	// the previous arm — a contaminated comparison that looked like a spectacular
+	// result. The count was the tell: it read 5,882 both times, because it counts
+	// dataset turns rather than rows actually removed.
 	deleted := 0
 	for _, conv := range convs {
+		keys := make([]string, 0, len(conv.Turns))
 		for _, t := range conv.Turns {
+			keys = append(keys, t.DiaID)
+		}
+		for _, r := range SessionRows(conv) {
+			keys = append(keys, r.Key)
+		}
+		for _, k := range keys {
 			if err := ctx.Err(); err != nil {
 				return err
 			}
-			// Keys are derived from the dataset, never from a listing, so purge can
-			// only ever remove rows this harness itself would have written.
-			if err := c.DeleteEntry(ctx, opts.scope, conv.ScopeID(), t.DiaID); err != nil {
-				return fmt.Errorf("delete %s/%s: %w", conv.ScopeID(), t.DiaID, err)
+			if err := c.DeleteEntry(ctx, opts.scope, conv.ScopeID(), k); err != nil {
+				return fmt.Errorf("delete %s/%s: %w", conv.ScopeID(), k, err)
 			}
 			deleted++
 		}

--- a/bench/cmd/locomo/mcp.go
+++ b/bench/cmd/locomo/mcp.go
@@ -1,0 +1,249 @@
+package main
+
+// mcp.go — the minimal MCP (JSON-RPC over Streamable HTTP) client the answer
+// axis needs.
+//
+// WHY MCP and not the REST memory routes: the memory-LAYER ops (`add`,
+// `recall`) and `spawn_run` exist only as in-band tools. The REST family under
+// /v1/_memory covers the k/v plane, embeddings and search — not `add`. So the
+// consolidation path is reachable off-run through the MCP transport or not at
+// all.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// MCPClient is one MCP session against a loomcycle instance.
+type MCPClient struct {
+	base   string
+	bearer string
+	httpc  *http.Client
+
+	mu        sync.Mutex
+	sessionID string
+	nextID    int
+	inited    bool
+}
+
+func NewMCPClient(base, bearer string, timeout time.Duration) *MCPClient {
+	return &MCPClient{
+		base:   strings.TrimRight(base, "/"),
+		bearer: bearer,
+		httpc:  &http.Client{Timeout: timeout},
+	}
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type rpcResponse struct {
+	Result json.RawMessage `json:"result"`
+	Error  *rpcError       `json:"error"`
+}
+
+// toolResult is the MCP tools/call envelope. A tool that fails sets isError and
+// puts the diagnosis in the text content rather than returning a JSON-RPC error.
+type toolResult struct {
+	Content []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"content"`
+	IsError bool `json:"isError"`
+}
+
+func (c *MCPClient) rpc(ctx context.Context, method string, params any) (json.RawMessage, error) {
+	c.mu.Lock()
+	c.nextID++
+	id := c.nextID
+	session := c.sessionID
+	c.mu.Unlock()
+
+	payload := map[string]any{"jsonrpc": "2.0", "id": id, "method": method}
+	if params != nil {
+		payload["params"] = params
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.base+"/v1/_mcp", bytes.NewReader(raw))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	// Both media types per the Streamable HTTP spec — a strict server 406s
+	// otherwise, and the response may come back either framed or plain.
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	if c.bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+c.bearer)
+	}
+	if session != "" {
+		req.Header.Set("Mcp-Session-Id", session)
+	}
+	resp, err := c.httpc.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if sid := resp.Header.Get("Mcp-Session-Id"); sid != "" {
+		c.mu.Lock()
+		c.sessionID = sid
+		c.mu.Unlock()
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("mcp %s: %s: %s", method, resp.Status, truncate(strings.TrimSpace(string(body)), 300))
+	}
+	var out rpcResponse
+	if err := json.Unmarshal(unframeSSE(body), &out); err != nil {
+		return nil, fmt.Errorf("mcp %s: decode: %w", method, err)
+	}
+	if out.Error != nil {
+		return nil, fmt.Errorf("mcp %s: %d %s", method, out.Error.Code, out.Error.Message)
+	}
+	return out.Result, nil
+}
+
+// unframeSSE pulls the JSON out of an SSE-framed response. The transport
+// advertises both media types, so the server may answer either way.
+func unframeSSE(b []byte) []byte {
+	s := strings.TrimSpace(string(b))
+	if !strings.HasPrefix(s, "event:") && !strings.HasPrefix(s, "data:") {
+		return b
+	}
+	for _, line := range strings.Split(s, "\n") {
+		if rest, ok := strings.CutPrefix(strings.TrimSpace(line), "data:"); ok {
+			return []byte(strings.TrimSpace(rest))
+		}
+	}
+	return b
+}
+
+// ensureInit performs the handshake once per client.
+func (c *MCPClient) ensureInit(ctx context.Context) error {
+	c.mu.Lock()
+	done := c.inited
+	c.mu.Unlock()
+	if done {
+		return nil
+	}
+	if _, err := c.rpc(ctx, "initialize", map[string]any{
+		"protocolVersion": "2025-06-18",
+		"capabilities":    map[string]any{},
+		"clientInfo":      map[string]any{"name": "locomo-bench", "version": "1"},
+	}); err != nil {
+		return fmt.Errorf("mcp initialize: %w", err)
+	}
+	c.mu.Lock()
+	c.inited = true
+	c.mu.Unlock()
+	return nil
+}
+
+// CallTool invokes one MCP tool and returns its text content. A tool-level
+// failure (isError) is returned as an error carrying the server's diagnosis.
+func (c *MCPClient) CallTool(ctx context.Context, name string, args map[string]any) (string, error) {
+	if err := c.ensureInit(ctx); err != nil {
+		return "", err
+	}
+	res, err := c.rpc(ctx, "tools/call", map[string]any{"name": name, "arguments": args})
+	if err != nil {
+		return "", err
+	}
+	var tr toolResult
+	if err := json.Unmarshal(res, &tr); err != nil {
+		return "", fmt.Errorf("mcp %s: decode tool result: %w", name, err)
+	}
+	var sb strings.Builder
+	for _, c := range tr.Content {
+		sb.WriteString(c.Text)
+	}
+	if tr.IsError {
+		return sb.String(), fmt.Errorf("mcp tool %s failed: %s", name, truncate(sb.String(), 400))
+	}
+	return sb.String(), nil
+}
+
+// RunResult is the subset of a spawn_run ack this harness reads.
+type RunResult struct {
+	RunID      string `json:"run_id"`
+	Status     string `json:"status"`
+	StopReason string `json:"stop_reason"`
+	FinalText  string `json:"final_text"`
+	Error      string `json:"error"`
+	Usage      struct {
+		InputTokens  int    `json:"input_tokens"`
+		OutputTokens int    `json:"output_tokens"`
+		Provider     string `json:"provider"`
+		Model        string `json:"model"`
+	} `json:"usage"`
+}
+
+// SpawnRun runs one agent to completion. userID selects the memory scope the
+// run's `scope=user` ops resolve to — which is how a conversation's facts are
+// addressed, since scope_id is server-derived and never caller-supplied.
+func (c *MCPClient) SpawnRun(ctx context.Context, agent, userID, prompt string) (RunResult, error) {
+	args := map[string]any{
+		"agent": agent,
+		// segments, not a bare prompt: spawn_run refuses a fresh run with no
+		// user turn.
+		"segments": []any{map[string]any{
+			"role":    "user",
+			"content": []any{map[string]any{"type": "trusted-text", "text": prompt}},
+		}},
+	}
+	if userID != "" {
+		args["user_id"] = userID
+	}
+	txt, err := c.CallTool(ctx, "spawn_run", args)
+	if err != nil {
+		return RunResult{}, err
+	}
+	var rr RunResult
+	if err := json.Unmarshal([]byte(txt), &rr); err != nil {
+		return RunResult{}, fmt.Errorf("spawn_run: decode ack: %w (got %s)", err, truncate(txt, 200))
+	}
+	if rr.Status != "completed" {
+		return rr, fmt.Errorf("run %s: status=%s %s", rr.RunID, rr.Status, truncate(rr.Error, 200))
+	}
+	return rr, nil
+}
+
+// MemoryAdd enqueues one span of conversation onto the consolidation queue.
+func (c *MCPClient) MemoryAdd(ctx context.Context, scope string, msgs []LayerMessage) (string, error) {
+	items := make([]any, 0, len(msgs))
+	for _, m := range msgs {
+		items = append(items, map[string]any{"role": m.Role, "content": m.Content})
+	}
+	txt, err := c.CallTool(ctx, "memory", map[string]any{
+		"op": "add", "scope": scope, "messages": items,
+	})
+	if err != nil {
+		return "", err
+	}
+	var ack struct {
+		EventID string `json:"event_id"`
+		Status  string `json:"status"`
+	}
+	_ = json.Unmarshal([]byte(txt), &ack)
+	return ack.EventID, nil
+}
+
+// LayerMessage is one turn as the memory layer takes it.
+type LayerMessage struct {
+	Role    string
+	Content string
+}

--- a/bench/cmd/locomo/metrics.go
+++ b/bench/cmd/locomo/metrics.go
@@ -29,9 +29,22 @@ type QueryResult struct {
 
 // Score computes one query's outcome against its answer key.
 func Score(q Query, retrieved []string, topK int, latency time.Duration) QueryResult {
+	// GROUND TRUTH IS TURN-LEVEL, ALWAYS. LoCoMo's qa.evidence names turn ids, so a
+	// coarser row (RFC CM-1's session unit) is credited when it CONTAINS an expected
+	// turn — its key maps to the same session. Without this a session-level arm would
+	// score zero against every question and the comparison would measure nothing.
+	//
+	// Recall stays denominated in EXPECTED TURNS, not in rows: one session row that
+	// covers three expected turns is three hits, exactly as three turn rows would be.
+	// Counting it as one would make the coarse arm look worse purely for being
+	// coarse, and counting the row once as a full hit would make it look better.
 	want := make(map[string]bool, len(q.Expected))
+	bySession := make(map[string][]string, len(q.Expected))
 	for _, e := range q.Expected {
 		want[e] = true
+		if sk := SessionOfDiaID(e); sk != "" {
+			bySession[sk] = append(bySession[sk], e)
+		}
 	}
 	res := QueryResult{
 		Question: q.Question, Category: q.Category,
@@ -42,8 +55,27 @@ func Score(q Query, retrieved []string, topK int, latency time.Duration) QueryRe
 		retrieved = retrieved[:topK]
 		res.Retrieved = retrieved
 	}
+	credited := make(map[string]bool, len(q.Expected))
 	for i, key := range retrieved {
-		if want[key] {
+		// A session row credits every expected turn it contains, each only once.
+		if covered, ok := bySession[key]; ok && !want[key] {
+			fresh := 0
+			for _, e := range covered {
+				if !credited[e] {
+					credited[e] = true
+					fresh++
+				}
+			}
+			if fresh > 0 {
+				res.Hits += fresh
+				if res.FirstHitRank == 0 {
+					res.FirstHitRank = i + 1
+				}
+			}
+			continue
+		}
+		if want[key] && !credited[key] {
+			credited[key] = true
 			res.Hits++
 			if res.FirstHitRank == 0 {
 				res.FirstHitRank = i + 1

--- a/bench/cmd/locomo/report.go
+++ b/bench/cmd/locomo/report.go
@@ -127,3 +127,101 @@ func (r Report) Matrix(w io.Writer) {
 func DefaultOutDir(now time.Time) string {
 	return filepath.Join("bench", "results", "locomo-"+now.UTC().Format("2006-01-02-1504"))
 }
+
+// AnswerReport is the answer axis's output.
+type AnswerReport struct {
+	Tool          string `json:"tool"`
+	Axis          string `json:"axis"`
+	StartedAt     string `json:"started_at"`
+	Instance      string `json:"instance"`
+	Tenant        string `json:"tenant"`
+	Subject       string `json:"subject"`
+	Answerer      string `json:"answerer"`
+	Judge         string `json:"judge"`
+	Categories    []int  `json:"categories_included"`
+	Conversations int    `json:"conversations"`
+	Turns         int    `json:"turns_ingested"`
+	Sessions      int    `json:"sessions_ingested"`
+	FactsWritten  int    `json:"facts_written"`
+	// SeededTurns counts turn rows written straight into the answerer's own
+	// partition (-seed-turns). It is the difference between "answered from
+	// distilled facts" and "answered from conversation content", so a report
+	// without it cannot be compared against one with it.
+	SeededTurns int            `json:"seeded_turn_rows"`
+	Sampled     int            `json:"sampled_questions"`
+	Overall     AnswerStats    `json:"overall"`
+	PerCategory []AnswerStats  `json:"per_category"`
+	Defects     *Defects       `json:"defects,omitempty"`
+	Notes       []string       `json:"notes,omitempty"`
+	Results     []AnswerResult `json:"results,omitempty"`
+}
+
+const answerHeader = "| slice | asked | graded | accuracy | correct | partial | wrong | unparsed | NOT_FOUND | p50 ms |\n" +
+	"|---|---|---|---|---|---|---|---|---|---|\n"
+
+func answerRow(w io.Writer, s AnswerStats) {
+	fmt.Fprintf(w, "| %s | %d | %d | %.4f | %d | %d | %d | %d | %.3f | %.0f |\n",
+		s.Label, s.Queries, s.Graded, s.Accuracy, s.Correct, s.Partial, s.Wrong,
+		s.Unparsed, s.NotFoundRate, s.LatencyP50Ms)
+}
+
+// Matrix renders the answer-axis report.
+func (r AnswerReport) Matrix(w io.Writer) {
+	fmt.Fprintf(w, "# LoCoMo answer axis — %s\n\n", r.StartedAt)
+	fmt.Fprintf(w, "- instance: `%s`   tenant: `%s`   memory subject: `%s`\n", r.Instance, r.Tenant, r.Subject)
+	fmt.Fprintf(w, "- answerer: `%s`   judge: `%s`\n", r.Answerer, r.Judge)
+	// The answerer's store is stated FIRST, because it is the single fact that
+	// decides what the accuracy below means: answering from 29 distilled facts and
+	// answering from 419 conversation turns are different measurements.
+	if r.SeededTurns > 0 {
+		fmt.Fprintf(w, "- **answerer's store: %d embedded TURN rows + %d consolidated facts** (-seed-turns)\n",
+			r.SeededTurns, r.FactsWritten)
+	} else {
+		fmt.Fprintf(w, "- **answerer's store: %d consolidated facts only** (no -seed-turns; the raw turns are not in the partition it reads)\n",
+			r.FactsWritten)
+	}
+	fmt.Fprintf(w, "- ingested: %d turns across %d sessions from %d conversation(s); %d facts written by consolidation\n",
+		r.Turns, r.Sessions, r.Conversations, r.FactsWritten)
+	cats := make([]string, 0, len(r.Categories))
+	for _, c := range r.Categories {
+		cats = append(cats, fmt.Sprintf("%d (%s)", c, CategoryName(c)))
+	}
+	fmt.Fprintf(w, "- **categories included: %s**\n", strings.Join(cats, ", "))
+	fmt.Fprintf(w, "- questions asked: %d\n", r.Sampled)
+
+	fmt.Fprintf(w, "\n## Overall\n\n%s", answerHeader)
+	answerRow(w, r.Overall)
+	if len(r.PerCategory) > 0 {
+		fmt.Fprintf(w, "\n## By category\n\n%s", answerHeader)
+		for _, s := range r.PerCategory {
+			answerRow(w, s)
+		}
+	}
+	fmt.Fprintf(w, "\nAccuracy is the LoCoMo convention: correct 1, partial 0.5, wrong 0, averaged over GRADED "+
+		"answers. Unparsed verdicts are excluded from accuracy and counted separately — grading a judge "+
+		"malfunction as a memory miss would understate the system under test. NOT_FOUND is the answerer's "+
+		"abstention rate; every category here is answerable, so an abstention is scored wrong.\n")
+	if len(r.Notes) > 0 {
+		fmt.Fprintf(w, "\n## Notes\n\n")
+		for _, n := range r.Notes {
+			fmt.Fprintf(w, "- %s\n", n)
+		}
+	}
+}
+
+// Write persists the answer report.
+func (r AnswerReport) Write(dir string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	b, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(dir, "answer-report.json"), append(b, '\n'), 0o644); err != nil {
+		return err
+	}
+	var md strings.Builder
+	r.Matrix(&md)
+	return os.WriteFile(filepath.Join(dir, "answer-matrix.md"), []byte(md.String()), 0o644)
+}

--- a/bench/cmd/locomo/whenresolve.go
+++ b/bench/cmd/locomo/whenresolve.go
@@ -1,0 +1,111 @@
+package main
+
+// whenresolve.go — resolve a question's date phrase into an explicit window.
+//
+// This lives in the HARNESS, not the runtime, and deliberately: RFC CL declares
+// natural-language date parsing a non-goal for the memory plane ("the predicate takes
+// instants, not prose") and puts the job on the caller. The benchmark is a caller, so
+// this is that job done here.
+//
+// It also removes the model's discretion, which is the point. Asked to derive a window
+// from a system-prompt rule, the answerer ignored it twice — but it emits `when`
+// faithfully when handed one. Measuring the PREDICATE means supplying the window and
+// not measuring whether a particular model remembers to build one.
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+var months = map[string]time.Month{
+	"january": time.January, "february": time.February, "march": time.March,
+	"april": time.April, "may": time.May, "june": time.June, "july": time.July,
+	"august": time.August, "september": time.September, "october": time.October,
+	"november": time.November, "december": time.December,
+}
+
+const monthAlt = `(January|February|March|April|May|June|July|August|September|October|November|December)`
+
+var (
+	// "on October 3, 2023" / "on 3 October, 2023"
+	reDayMonthYear = regexp.MustCompile(`(?i)\b` + monthAlt + `\s+(\d{1,2})(?:st|nd|rd|th)?,?\s*(\d{4})`)
+	reDayFirst     = regexp.MustCompile(`(?i)\b(\d{1,2})(?:st|nd|rd|th)?\s+` + monthAlt + `,?\s*(\d{4})`)
+	// "the first weekend of August 2023", "the last week of October 2023",
+	// "the second week of November"
+	reOrdinalPart = regexp.MustCompile(`(?i)\b(first|second|third|fourth|last)\s+(week|weekend)\s+(?:of\s+)?` + monthAlt + `(?:,?\s*(\d{4}))?`)
+	// "in July 2023" / "during March 2023" / "in October"
+	reMonthYear = regexp.MustCompile(`(?i)\b(?:in|during|of)\s+` + monthAlt + `(?:,?\s*(\d{4}))?`)
+)
+
+// ResolveWhen turns a question's date phrase into a half-open [from, to) window,
+// already widened. It reports ok=false when the question names no resolvable period —
+// a question with no window must be asked WITHOUT one rather than with a guessed one.
+//
+// slackDays widens both ends. It is generous by default for a measured reason: the
+// remark that answers a question about a day is normally made a day or more AFTER it,
+// so a window pinned to the exact day misses the row roughly seven times in eight.
+func ResolveWhen(question string, defaultYear int, slackDays int) (from, to time.Time, ok bool) {
+	yr := func(s string) int {
+		if s == "" {
+			return defaultYear
+		}
+		var y int
+		fmt.Sscanf(s, "%d", &y)
+		return y
+	}
+	day := func(s string) int {
+		var d int
+		fmt.Sscanf(s, "%d", &d)
+		return d
+	}
+	mon := func(s string) time.Month { return months[strings.ToLower(s)] }
+
+	widen := func(a, b time.Time) (time.Time, time.Time, bool) {
+		d := time.Duration(slackDays) * 24 * time.Hour
+		return a.Add(-d), b.Add(d), true
+	}
+
+	// Ordinal week/weekend FIRST: "the first weekend of August 2023" also matches the
+	// month pattern, and the narrower reading is the one the question asked for.
+	if m := reOrdinalPart.FindStringSubmatch(question); m != nil {
+		month, year := mon(m[3]), yr(m[4])
+		start := time.Date(year, month, 1, 0, 0, 0, 0, time.UTC)
+		var a, b time.Time
+		switch strings.ToLower(m[1]) {
+		case "first":
+			a, b = start, start.AddDate(0, 0, 7)
+		case "second":
+			a, b = start.AddDate(0, 0, 7), start.AddDate(0, 0, 14)
+		case "third":
+			a, b = start.AddDate(0, 0, 14), start.AddDate(0, 0, 21)
+		case "fourth":
+			a, b = start.AddDate(0, 0, 21), start.AddDate(0, 0, 28)
+		default: // "last"
+			end := start.AddDate(0, 1, 0)
+			a, b = end.AddDate(0, 0, -7), end
+		}
+		return widen(a, b)
+	}
+	if m := reDayMonthYear.FindStringSubmatch(question); m != nil {
+		d := time.Date(yr(m[3]), mon(m[1]), day(m[2]), 0, 0, 0, 0, time.UTC)
+		return widen(d, d.AddDate(0, 0, 1))
+	}
+	if m := reDayFirst.FindStringSubmatch(question); m != nil {
+		d := time.Date(yr(m[3]), mon(m[2]), day(m[1]), 0, 0, 0, 0, time.UTC)
+		return widen(d, d.AddDate(0, 0, 1))
+	}
+	if m := reMonthYear.FindStringSubmatch(question); m != nil {
+		start := time.Date(yr(m[2]), mon(m[1]), 1, 0, 0, 0, 0, time.UTC)
+		return widen(start, start.AddDate(0, 1, 0))
+	}
+	return time.Time{}, time.Time{}, false
+}
+
+// WhenInstruction renders the window as the line appended to the question, in the
+// exact shape the answerer was observed to copy faithfully.
+func WhenInstruction(from, to time.Time) string {
+	return fmt.Sprintf("\n\nRestrict your recall with when={\"from\":%q,\"to\":%q}",
+		from.Format(time.RFC3339), to.Format(time.RFC3339))
+}

--- a/bench/cmd/locomo/whenresolve_test.go
+++ b/bench/cmd/locomo/whenresolve_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestResolveWhen(t *testing.T) {
+	const yr = 2023
+	iso := func(s string) string { return s }
+	for _, tc := range []struct {
+		q        string
+		from, to string
+		ok       bool
+	}{
+		// A named day becomes that day, widened. Widening is the whole point: the
+		// remark answering it is normally made a day or more later.
+		{"Which city was Calvin at on October 3, 2023?", "2023-09-30T00:00:00Z", "2023-10-07T00:00:00Z", true},
+		{"What movie did Joanna watch on 1 May, 2022?", "2022-04-28T00:00:00Z", "2022-05-05T00:00:00Z", true},
+		// A whole month.
+		{"Which places in Canada was Evan visiting in July 2023?", "2023-06-28T00:00:00Z", "2023-08-04T00:00:00Z", true},
+		// Ordinal parts must beat the month reading — the question asked for the
+		// narrower period and resolving it as the whole month would discard that.
+		{"Where did Andrew go during the first weekend of August 2023?", "2023-07-29T00:00:00Z", "2023-08-11T00:00:00Z", true},
+		{"Where was Calvin located in the last week of October 2023?", "2023-10-22T00:00:00Z", "2023-11-04T00:00:00Z", true},
+		{"Which country was Tim visiting in the second week of November?", "2023-11-05T00:00:00Z", "2023-11-18T00:00:00Z", true},
+		// No period named: must refuse rather than invent one.
+		{"What do Melanie's kids like?", "", "", false},
+		{"Who did Maria have dinner with?", "", "", false},
+	} {
+		from, to, ok := ResolveWhen(tc.q, yr, 3)
+		if ok != tc.ok {
+			t.Errorf("ResolveWhen(%q) ok=%v, want %v", tc.q, ok, tc.ok)
+			continue
+		}
+		if !ok {
+			continue
+		}
+		if got := from.Format(time.RFC3339); got != iso(tc.from) {
+			t.Errorf("ResolveWhen(%q) from=%s, want %s", tc.q, got, tc.from)
+		}
+		if got := to.Format(time.RFC3339); got != iso(tc.to) {
+			t.Errorf("ResolveWhen(%q) to=%s, want %s", tc.q, got, tc.to)
+		}
+	}
+}
+
+// The instruction must render in the shape the answerer was observed to copy — a
+// window it does not copy is a window that never reaches the store.
+func TestWhenInstruction_ShapeTheModelCopies(t *testing.T) {
+	from := time.Date(2023, 9, 30, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2023, 10, 7, 0, 0, 0, 0, time.UTC)
+	got := WhenInstruction(from, to)
+	want := "\n\nRestrict your recall with when={\"from\":\"2023-09-30T00:00:00Z\",\"to\":\"2023-10-07T00:00:00Z\"}"
+	if got != want {
+		t.Errorf("WhenInstruction =\n%q\nwant\n%q", got, want)
+	}
+}


### PR DESCRIPTION
Everything the LoCoMo harness grew after **#1064** merged its retrieval axis. That branch was squash-merged, so its commits are no longer ancestors of `main` and a PR from it would show ~4,000 lines of already-merged content. This rebases the work onto current main as one reviewable **+2,301 / −27**.

## What's in it

**The answer axis** (`-mode answer`). The retrieval axis scores whether the right rows come back; this scores whether an agent can *answer* from them — an answerer holding only the Memory tool, an LLM judge, and the LoCoMo convention of correct/partial/wrong averaged over graded answers. Unparsed verdicts are counted separately and excluded, because grading a judge malfunction as a memory miss understates the system under test.

`-seed-turns` writes one embedded row per turn so the answerer reads the conversation rather than consolidated facts. That turned out to be **the strongest configuration measured**, which is why RFC CM closed without building anything.

**Report checkpointing.** Two full runs were lost before this — one to a provider balance wall 47% in, one to a SIGTERM at 95%. Both times every verdict lived only in memory and the report was written once at the end, so ~70 minutes of judge spend produced nothing. Now written after every conversation; a completed run is byte-identical, a partial one is labelled by its own counts.

**RFC CM-1 instrumentation** — `-unit turn|session`, `-dated`. Scoring keeps ground truth **turn-level** and credits a session row for the expected turns it contains, each once, so the granularities are comparable at all. This is the measurement that closed RFC CM.

**RFC CL instrumentation** — `-only-date-questions`, `-inject-when`, and a date-phrase resolver. The resolver lives in the harness because RFC CL declares NL date parsing a non-goal for the memory plane and puts it on the caller — a benchmark is a caller.

## Two things this found

**A purge bug, the hard way.** `doPurge` derives keys from the dataset so it can only delete rows the harness itself wrote — deliberate, and the reason a new key shape must be registered explicitly. The CM-1 session unit wasn't, so **15.6% of a later arm's hits were rows from the previous arm** and it read 0.7840 against a true 0.6675. Its own count was the tell: it printed "deleted 5882" regardless of what was in the store. Fixed, and it now reports 6,154 for 5,882 turns + 272 session rows.

**A model won't build a `when` window unprompted.** Told to, in its system prompt, as an explicit first step with a worked example, across two revisions — ignored every time. It emits `when` faithfully when handed one. That's why `-inject-when` resolves the window harness-side: it measures the predicate rather than one model's instruction-following.

## Tested

`go build ./bench/...` and `go test ./bench/...` clean on current main. Unit tests cover the date resolver (including that it refuses a question naming no period rather than inventing one), the session-row grouping and its mapping back to turn-level ground truth, and no-double-credit when a session row and a turn row cover the same evidence.

The harness drives an externally-running instance and needs a token; nothing here runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8
