### PR TITLE
feat(mcp): user credential self-service over MCP (RFC CN P2)

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -74,14 +74,15 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 			// tenantMemberAccessible; and every such handler still confines a
 			// member to its own tenant via principalTenantScope / tenantFromCtx.
 			memberOK := tenantMemberAccessible(r.Method, r.URL.Path) && !auth.IsIsolated(p, ok)
-			// RFC CN: the credential self-service surface admits ANY authenticated
-			// principal that carries a subject — INCLUDING an isolated substrate:user
-			// user, who is otherwise held at the tenant-member isolation floor — so a
-			// user can store their OWN scope=user API tokens (a personal Slack/Telegram
-			// bot token, a per-user webhook secret). handleSubstrateCredentialDef then
-			// confines a non-tenant caller to scope=user on its own subject before the
-			// tool runs; tenant/agent scope still requires substrate:tenant.
-			selfOK := credentialSelfServiceAccessible(r.Method, r.URL.Path) && p.Subject != ""
+			// RFC CN: the user self-service surfaces (the credential store + the MCP
+			// transport) admit ANY authenticated principal that carries a subject —
+			// INCLUDING an isolated substrate:user user, who is otherwise held at the
+			// tenant-member isolation floor — so a user can store its OWN scope=user
+			// API tokens (a personal Slack/Telegram bot token, a per-user webhook
+			// secret). The handler / MCP per-tool gate then confine a non-tenant caller
+			// to scope=user on its own subject; tenant/agent scope still requires
+			// substrate:tenant.
+			selfOK := userSelfServiceRoute(r.Method, r.URL.Path) && p.Subject != ""
 			if !(memberOK || selfOK) {
 				// Scope names are public; token state is not.
 				w.Header().Set("WWW-Authenticate", `Bearer scope="`+required+`"`)
@@ -883,16 +884,30 @@ func tenantMemberAccessible(method, path string) bool {
 	return !memberCarveOut(method, path)
 }
 
-// credentialSelfServiceAccessible marks the credential-store surface that RFC CN
-// opens for user SELF-SERVICE of scope=user credentials. It is an ADDITIONAL
-// admission path in authMiddleware — the route stays nominally ScopeTenant, so a
-// tenant operator's full tenant/agent authoring is unchanged, and members reach it
-// via the RFC CB member path — but it also admits an isolated substrate:user user
-// (who otherwise 403s at the isolation floor). handleSubstrateCredentialDef
-// confines such a caller to scope=user on its own subject before dispatch, so the
-// widened admission grants nothing beyond a user's own personal tokens.
-func credentialSelfServiceAccessible(method, path string) bool {
-	return method == http.MethodPost && path == "/v1/_credentialdef"
+// userSelfServiceRoute marks the HTTP routes RFC CN opens for user SELF-SERVICE of
+// scope=user credentials, as an ADDITIONAL authMiddleware admission path that also
+// lets an isolated substrate:user user through (it otherwise 403s at the tenant-
+// member isolation floor):
+//
+//   - POST /v1/_credentialdef — the credential store; handleSubstrateCredentialDef
+//     confines an isolated caller to scope=user on its own subject (P1).
+//   - POST + DELETE /v1/_mcp — the loomcycle-as-MCP-server transport, so the same
+//     user can manage its tokens from the `loomcycle mcp --upstream` thin client.
+//     The MCP per-tool gate (principalMayCallTool) restricts an isolated session to
+//     ONLY the credentialdef meta-tool, and that dispatch applies the same scope=user
+//     constraint — so admitting the session grants nothing beyond a user's own tokens.
+//
+// The routes stay nominally ScopeTenant, so a tenant operator's full tenant/agent
+// authoring is unchanged and members reach them via the RFC CB member path; this is
+// purely additive for isolated users.
+func userSelfServiceRoute(method, path string) bool {
+	switch path {
+	case "/v1/_credentialdef":
+		return method == http.MethodPost
+	case "/v1/_mcp":
+		return method == http.MethodPost || method == http.MethodDelete
+	}
+	return false
 }
 
 // memberCarveOut lists the ScopeTenant routes that STAY operator-only (require a

--- a/internal/api/http/auth_principal_test.go
+++ b/internal/api/http/auth_principal_test.go
@@ -499,12 +499,16 @@ func TestAuthMiddleware_RFCCBMember(t *testing.T) {
 	}
 
 	// The isolation floor: an isolated token is refused on every member surface —
-	// EXCEPT the RFC CN credential self-service route (POST /v1/_credentialdef),
-	// where an isolated substrate:user user IS admitted so it can manage its OWN
-	// scope=user tokens; the handler then confines it to scope=user.
+	// EXCEPT the RFC CN user self-service routes, where an isolated substrate:user
+	// user IS admitted so it can manage its OWN scope=user tokens: POST
+	// /v1/_credentialdef (the handler confines it to scope=user) and POST /v1/_mcp
+	// (the per-tool gate confines the session to the credentialdef meta-tool).
+	rfcCNSelfService := func(method, path string) bool {
+		return method == "POST" && (path == "/v1/_credentialdef" || path == "/v1/_mcp")
+	}
 	for _, c := range admitted {
 		reached, code := runMW(t, s, c.method, c.path, "lct_isolated")
-		if c.method == "POST" && c.path == "/v1/_credentialdef" {
+		if rfcCNSelfService(c.method, c.path) {
 			if !reached || code == http.StatusForbidden {
 				t.Errorf("isolated on %s %s: code=%d reached=%v, want ADMITTED (RFC CN self-service)", c.method, c.path, code, reached)
 			}

--- a/internal/api/http/substrate_admin.go
+++ b/internal/api/http/substrate_admin.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/connector"
+	"github.com/denn-gubsky/loomcycle/internal/credential"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
 )
@@ -227,38 +228,17 @@ type guardError struct {
 }
 
 // constrainToUserScope enforces the RFC CN isolated-user rule on a CredentialDef
-// input: the effective scope must be user. An omitted scope defaults to user (the
-// tool's own default is tenant, which is wrong for a self-service caller and would
-// leak into the tenant bucket), and the body is rewritten so the tool resolves
-// scope=user on the caller's own subject. An explicit scope=tenant/agent is refused.
+// input via the transport-neutral credential.ConstrainToUserScope (shared with the
+// MCP dispatch so the rule cannot drift): the effective scope must be user, an
+// omitted scope defaults to user, and scope=tenant/agent is refused 403.
 func constrainToUserScope(body []byte) ([]byte, *guardError) {
-	var fields map[string]json.RawMessage
-	if err := json.Unmarshal(body, &fields); err != nil {
-		// dispatchSubstrateCtxGuarded already checked json.Valid, so this is a
-		// non-object body (array / scalar). Leave it for the tool to reject with
-		// its own message rather than masking it as a scope error.
-		return body, nil
-	}
-	scope := ""
-	if raw, present := fields["scope"]; present {
-		_ = json.Unmarshal(raw, &scope) // a non-string value stays "" → defaulted below
-	}
-	if scope == "" {
-		scope = "user"
-	}
-	if scope != "user" {
+	out, refused := credential.ConstrainToUserScope(body)
+	if refused {
 		return nil, &guardError{
 			status: http.StatusForbidden,
 			code:   "credential_scope_forbidden",
 			msg:    "an isolated user token may only manage scope=user credentials (its own); scope=tenant and scope=agent require substrate:tenant",
 		}
-	}
-	// Pin scope=user in the body so an omitted scope cannot fall through to the
-	// tool's tenant default.
-	fields["scope"] = json.RawMessage(`"user"`)
-	out, err := json.Marshal(fields)
-	if err != nil {
-		return body, nil // unreachable (re-marshalling validated fields); keep the original
 	}
 	return out, nil
 }

--- a/internal/api/mcp/credential_selfservice_test.go
+++ b/internal/api/mcp/credential_selfservice_test.go
@@ -1,0 +1,103 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/connector"
+)
+
+// TestUserSelfServiceTools_SubsetOfTenantConfinable pins the RFC CN invariant that
+// an isolated user's allowlist is a strict subset of a tenant session's surface —
+// every entry must also be tenant-confinable and dispatchable, so the isolated
+// tier can never reach a tool a tenant session cannot.
+func TestUserSelfServiceTools_SubsetOfTenantConfinable(t *testing.T) {
+	for name := range userSelfServiceTools {
+		if !tenantConfinableTools[name] {
+			t.Errorf("userSelfServiceTools has %q which is not tenant-confinable (must be a subset)", name)
+		}
+		if _, ok := handlersByName[name]; !ok {
+			t.Errorf("userSelfServiceTools has %q which is not dispatchable (stale entry)", name)
+		}
+	}
+}
+
+// TestPrincipalMayCallTool_IsolatedUser: an isolated substrate:user session may
+// call ONLY the RFC CN self-service tools (credentialdef) — not the other
+// tenant-confinable tools (document/agentdef/memory/spawn_run) and not admin tools.
+func TestPrincipalMayCallTool_IsolatedUser(t *testing.T) {
+	ctx := auth.WithPrincipal(context.Background(),
+		auth.Principal{TenantID: "acme", Subject: "alice", Scopes: []string{auth.ScopeUser}})
+
+	if !principalMayCallTool(ctx, "credentialdef") {
+		t.Error("isolated user must be allowed credentialdef (RFC CN self-service)")
+	}
+	denied := []string{"document", "agentdef", "memory", "spawn_run", "channel", "path", "operatortokendef", "restore_snapshot"}
+	for _, name := range denied {
+		if principalMayCallTool(ctx, name) {
+			t.Errorf("isolated user must NOT be allowed %q (only self-service tools)", name)
+		}
+	}
+}
+
+// credCapturingConnector records the CredentialDef input actually forwarded to the
+// tool, embedding mockConnector for every other Connector method.
+type credCapturingConnector struct {
+	*mockConnector
+	lastInput string
+	called    bool
+}
+
+func (c *credCapturingConnector) CredentialDef(_ context.Context, in json.RawMessage) (connector.ToolResult, error) {
+	c.lastInput = string(in)
+	c.called = true
+	return connector.ToolResult{Text: `{"stored":true}`}, nil
+}
+
+// TestHandleCredentialDef_ConfinesIsolatedToUserScope drives handleCredentialDef
+// through the two principal classes: an isolated user's omitted scope reaches the
+// tool as scope=user and its scope=tenant is refused before the tool; a tenant
+// principal is unconstrained (scope=tenant passes through untouched).
+func TestHandleCredentialDef_ConfinesIsolatedToUserScope(t *testing.T) {
+	call := func(scopes []string, body string) (fwd string, called, isErr bool) {
+		cc := &credCapturingConnector{mockConnector: &mockConnector{}}
+		env := &handlerEnv{connector: cc}
+		ctx := auth.WithPrincipal(context.Background(),
+			auth.Principal{TenantID: "acme", Subject: "alice", Scopes: scopes})
+		res, err := handleCredentialDef(ctx, env, json.RawMessage(body))
+		if err != nil {
+			t.Fatalf("handleCredentialDef returned a Go error: %v", err)
+		}
+		return cc.lastInput, cc.called, res.IsError
+	}
+
+	// Isolated user, omitted scope → the tool receives scope=user.
+	fwd, called, isErr := call([]string{auth.ScopeUser}, `{"op":"create","name":"telegram","value":"x"}`)
+	if !called || isErr {
+		t.Fatalf("isolated omitted: called=%v isErr=%v, want tool called ok", called, isErr)
+	}
+	if !strings.Contains(fwd, `"scope":"user"`) {
+		t.Errorf("isolated omitted scope not pinned to user before the tool: %s", fwd)
+	}
+
+	// Isolated user, scope=tenant → refused (tool-error), tool NOT called.
+	fwd, called, isErr = call([]string{auth.ScopeUser}, `{"op":"create","name":"t","scope":"tenant","value":"x"}`)
+	if !isErr {
+		t.Error("isolated scope=tenant: want an IsError tool result")
+	}
+	if called {
+		t.Error("isolated scope=tenant reached the tool; the guard should refuse first")
+	}
+
+	// Tenant principal, scope=tenant → unconstrained (forwarded untouched).
+	fwd, called, isErr = call([]string{auth.ScopeTenant}, `{"op":"create","name":"shared","scope":"tenant","value":"x"}`)
+	if !called || isErr {
+		t.Fatalf("tenant scope=tenant: called=%v isErr=%v, want tool called ok", called, isErr)
+	}
+	if !strings.Contains(fwd, `"scope":"tenant"`) {
+		t.Errorf("tenant principal's scope=tenant was altered: %s", fwd)
+	}
+}

--- a/internal/api/mcp/handlers.go
+++ b/internal/api/mcp/handlers.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/connector"
+	"github.com/denn-gubsky/loomcycle/internal/credential"
 	"github.com/denn-gubsky/loomcycle/internal/erasure"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/runner"
@@ -135,10 +136,9 @@ var handlersByName = map[string]toolHandler{
 	}),
 	// RFC AR — secure per-tenant credential store. Tenant/user identity from the
 	// principal ctx (RFC AG mcpPrincipalCtx), never the wire; get/list metadata
-	// only. ops: create/get/list/delete.
-	"credentialdef": wrapBuiltin("credentialdef", func(c connector.Connector, ctx context.Context, in json.RawMessage) (connector.ToolResult, error) {
-		return c.CredentialDef(ctx, in)
-	}),
+	// only. ops: create/get/list/delete. RFC CN confines an isolated substrate:user
+	// session to scope=user — see handleCredentialDef.
+	"credentialdef": handleCredentialDef,
 	"evaluation": wrapBuiltin("evaluation", func(c connector.Connector, ctx context.Context, in json.RawMessage) (connector.ToolResult, error) {
 		return c.Evaluation(ctx, in)
 	}),
@@ -659,6 +659,34 @@ func handleListAgents(ctx context.Context, env *handlerEnv, args json.RawMessage
 // the policies are missing from a bare bgCtx. mcpPrincipalCtx keys identity
 // (UserID/TenantID) off the authenticated principal so user-scoped tools
 // align with the off-run HTTP path; see internal/api/mcp/context.go.
+// handleCredentialDef dispatches the RFC AR credential store over MCP. RFC CN: an
+// ISOLATED substrate:user session (admitted to /v1/_mcp only for self-service, and
+// gated by userSelfServiceTools to this tool alone) is confined to scope=user on
+// its OWN subject, mirroring the HTTP handler via the shared
+// credential.ConstrainToUserScope so the rule cannot drift between transports.
+// Members / tenant operators / admin are unconstrained. The tenant/user/agent
+// identity is stamped from the principal ctx (mcpPrincipalCtx), never the wire.
+func handleCredentialDef(ctx context.Context, env *handlerEnv, args json.RawMessage) (*loommcp.CallToolResult, error) {
+	if env.connector == nil {
+		return nil, fmt.Errorf("credentialdef: no connector wired")
+	}
+	if p, ok := auth.PrincipalFromContext(ctx); auth.IsIsolated(p, ok) {
+		out, refused := credential.ConstrainToUserScope(args)
+		if refused {
+			return toolErr("credentialdef: an isolated user token may only manage scope=user credentials (its own); scope=tenant and scope=agent require substrate:tenant"), nil
+		}
+		args = out
+	}
+	res, err := env.connector.CredentialDef(mcpPrincipalCtx(ctx), args)
+	if err != nil {
+		return toolErr("credentialdef: " + err.Error()), nil
+	}
+	return &loommcp.CallToolResult{
+		Content: []loommcp.ContentBlock{{Type: "text", Text: res.Text}},
+		IsError: res.IsError,
+	}, nil
+}
+
 func wrapBuiltin(toolName string, call func(connector.Connector, context.Context, json.RawMessage) (connector.ToolResult, error)) toolHandler {
 	return func(ctx context.Context, env *handlerEnv, args json.RawMessage) (*loommcp.CallToolResult, error) {
 		if env.connector == nil {

--- a/internal/api/mcp/toolauthz.go
+++ b/internal/api/mcp/toolauthz.go
@@ -134,14 +134,29 @@ var adminOnlyTools = map[string]bool{
 	"list_channels": true,
 }
 
+// userSelfServiceTools is the RFC CN allowlist for an ISOLATED substrate:user
+// session: the ONLY meta-tools an isolated user may list + call over /v1/_mcp. An
+// isolated user is admitted to open a session solely to self-serve its OWN
+// scope=user credentials from the `loomcycle mcp` thin client; the credentialdef
+// dispatch applies the scope=user constraint (credential.ConstrainToUserScope), so
+// this session grants nothing beyond the user's own tokens. Every entry MUST also
+// be in tenantConfinableTools (an isolated user is a strict subset of a tenant
+// session's surface); the drift test asserts that.
+var userSelfServiceTools = map[string]bool{
+	"credentialdef": true, // RFC CN — a user's own scope=user credential store.
+}
+
 // principalMayCallTool reports whether the principal on ctx may list/invoke
 // toolName over the /v1/_mcp transport (RFC AG §3.3):
 //
 //   - No principal (stdio / open mode): process-local operator-trust → every tool.
 //   - Admin principal (substrate:admin, incl. the legacy token): every tool.
-//   - Non-admin (substrate:tenant) principal: only the tenant-confinable
-//     allowlist; everything else — including an unclassified new tool — is
-//     admin-only (deny-by-default).
+//   - Isolated substrate:user principal (RFC CN): only the user self-service
+//     allowlist — everything else, including the tenant-confinable tools, stays
+//     closed.
+//   - Non-admin, non-isolated (substrate:tenant / RFC CB member) principal: the
+//     tenant-confinable allowlist; everything else — including an unclassified new
+//     tool — is admin-only (deny-by-default).
 func principalMayCallTool(ctx context.Context, toolName string) bool {
 	p, ok := auth.PrincipalFromContext(ctx)
 	if !ok {
@@ -149,6 +164,9 @@ func principalMayCallTool(ctx context.Context, toolName string) bool {
 	}
 	if auth.HasScope(p.Scopes, auth.ScopeAdmin) {
 		return true
+	}
+	if auth.IsIsolated(p, ok) {
+		return userSelfServiceTools[toolName]
 	}
 	return tenantConfinableTools[toolName]
 }

--- a/internal/credential/selfservice.go
+++ b/internal/credential/selfservice.go
@@ -1,0 +1,46 @@
+package credential
+
+import "encoding/json"
+
+// ConstrainToUserScope enforces the RFC CN isolated-user rule on a CredentialDef
+// tool input: the effective scope must be user. It is transport-neutral — the HTTP
+// handler and the MCP dispatch both call it and map its refusal onto their own wire
+// error (a 403 / an MCP tool-error), so the rule cannot drift between the two.
+//
+// Behaviour:
+//   - An omitted scope defaults to user and the body is rewritten to pin it. The
+//     tool's own default is tenant, which is wrong for a self-service caller and
+//     would leak the secret into the tenant-shared bucket.
+//   - An explicit scope=user passes through (with scope pinned to user).
+//   - An explicit scope=tenant/agent is refused (refused=true, out nil) — those
+//     require substrate:tenant.
+//   - A non-object body (array / scalar) is passed through unchanged so the tool
+//     rejects it with its own message rather than this masking it as a scope error.
+//
+// The caller must apply this ONLY to an isolated substrate:user principal; members,
+// tenant operators, and admin keep their existing (unconstrained) authority.
+func ConstrainToUserScope(body []byte) (out []byte, refused bool) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(body, &fields); err != nil {
+		// Non-object body — leave it for the tool to reject.
+		return body, false
+	}
+	scope := ""
+	if raw, present := fields["scope"]; present {
+		_ = json.Unmarshal(raw, &scope) // a non-string value stays "" → defaulted below
+	}
+	if scope == "" {
+		scope = "user"
+	}
+	if scope != "user" {
+		return nil, true
+	}
+	// Pin scope=user so an omitted scope cannot fall through to the tool's tenant
+	// default.
+	fields["scope"] = json.RawMessage(`"user"`)
+	rewritten, err := json.Marshal(fields)
+	if err != nil {
+		return body, false // unreachable (re-marshalling validated fields); keep the original
+	}
+	return rewritten, false
+}

--- a/internal/credential/selfservice_test.go
+++ b/internal/credential/selfservice_test.go
@@ -1,0 +1,39 @@
+package credential
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestConstrainToUserScope pins the RFC CN transport-neutral rule shared by the
+// HTTP handler and the MCP dispatch: an isolated caller's CredentialDef input is
+// confined to scope=user — omitted defaults to user, user passes, tenant/agent is
+// refused, and a non-object body passes through for the tool to reject.
+func TestConstrainToUserScope(t *testing.T) {
+	// Omitted scope → rewritten to user (never the tool's tenant default).
+	out, refused := ConstrainToUserScope([]byte(`{"op":"list"}`))
+	if refused {
+		t.Fatal("omitted scope was refused, want defaulted to user")
+	}
+	if !strings.Contains(string(out), `"scope":"user"`) {
+		t.Errorf("omitted scope not defaulted to user: %s", out)
+	}
+
+	// Explicit scope=user → allowed, other fields preserved.
+	out, refused = ConstrainToUserScope([]byte(`{"op":"create","name":"telegram","scope":"user","value":"x"}`))
+	if refused || !strings.Contains(string(out), `"scope":"user"`) || !strings.Contains(string(out), `"value":"x"`) {
+		t.Errorf("scope=user: out=%s refused=%v", out, refused)
+	}
+
+	// scope=tenant and scope=agent → refused.
+	for _, s := range []string{"tenant", "agent"} {
+		if _, refused := ConstrainToUserScope([]byte(`{"op":"create","name":"t","scope":"` + s + `","value":"x"}`)); !refused {
+			t.Errorf("scope=%s: want refused", s)
+		}
+	}
+
+	// Non-object body → passthrough (tool rejects it).
+	if _, refused := ConstrainToUserScope([]byte(`[1,2,3]`)); refused {
+		t.Error("non-object body should pass through, not be refused")
+	}
+}


### PR DESCRIPTION
Phase 2 of **RFC CN — Per-user credential self-service**. Brings the MCP transport (`loomcycle mcp --upstream` thin client) to parity with the HTTP surface from P1 (#1093): an isolated `substrate:user` user can now manage its **own** `scope=user` credentials from the CLI.

## Why

`/v1/_mcp` is `substrate:tenant`-gated, so an isolated user couldn't open a session at all — it could set its tokens over HTTP (P1) but not from the thin client.

## What (Phase 2, MCP)

- **`authMiddleware`** admits an isolated `substrate:user` token to `POST` + `DELETE /v1/_mcp` (via `userSelfServiceRoute`, renamed/generalized from P1's `credentialSelfServiceAccessible`). The route stays nominally `ScopeTenant` — tenant/admin and the RFC CB member path are unchanged.
- **`principalMayCallTool`** gains an **isolated tier**: an isolated session is restricted to `userSelfServiceTools` — **only `credentialdef`**. Every other tool, including the tenant-confinable ones, stays closed, so opening the session grants nothing beyond the user's own tokens.
- **`handleCredentialDef`** (new dedicated MCP handler) confines an isolated session to `scope=user` on its own subject (omitted→user, `scope=tenant`/`agent`→tool-error). Members / tenant / admin are unconstrained.

## Shared rule — no drift

The scope constraint moves into a transport-neutral **`credential.ConstrainToUserScope`**, called by **both** the HTTP guard and the MCP dispatch (the HTTP `constrainToUserScope` now delegates to it). `userSelfServiceTools ⊆ tenantConfinableTools` is asserted by a drift test, so the isolated tier can never reach a tool a tenant session cannot.

## Tested

`go test ./...` clean (95 ok); `go build ./...` + gofmt + vet clean. All three new behaviors verified **fail-before**.
- `credential.TestConstrainToUserScope` — the shared rule.
- `mcp.TestPrincipalMayCallTool_IsolatedUser` — isolated → only `credentialdef`, not `document`/`agentdef`/`memory`/admin.
- `mcp.TestHandleCredentialDef_ConfinesIsolatedToUserScope` — isolated omitted→user reaches the tool; `scope=tenant` refused before it; a tenant principal is untouched.
- `mcp.TestUserSelfServiceTools_SubsetOfTenantConfinable`.
- Updated `http.TestAuthMiddleware_RFCCBMember` — `POST /v1/_mcp` joins `POST /v1/_credentialdef` as an isolation-floor self-service exception.

## Follow-up

P3 — a Web UI "My Credentials" page (scope=user). P4 — gRPC/adapter parity if exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)