### PR TITLE
feat(ui): a "My Credentials" page for user credential self-service (RFC CN P3)

### DIFF
--- a/web/src/components/CredentialsPanel.tsx
+++ b/web/src/components/CredentialsPanel.tsx
@@ -1,0 +1,263 @@
+import { FormEvent, useCallback, useEffect, useState } from "react";
+import {
+  CredentialMeta,
+  CredentialScope,
+  createCredential,
+  deleteCredential,
+  listCredentials,
+} from "../api";
+
+// CredentialsPanel is the shared RFC AR credential UI, used in two places:
+//   - the operator Settings hub (full: tenant + user scopes, a scope selector);
+//   - the standalone "My Credentials" page (userOnly: the caller's own scope=user
+//     tokens, no scope selector), which RFC CN opens to every user login incl.
+//     isolated substrate:user users.
+// Keeping it one component means the operator and user surfaces cannot drift.
+
+// isCredStoreDisabled detects the fail-closed error surfaced when the operator
+// hasn't set LOOMCYCLE_SECRET_KEY (the inline backend is off). The server returns
+// the tool's error text verbatim inside the 422 envelope, so we match its markers.
+function isCredStoreDisabled(msg: string): boolean {
+  return (
+    msg.includes("LOOMCYCLE_SECRET_KEY") ||
+    msg.includes("no credential engine") ||
+    msg.includes("disabled")
+  );
+}
+
+// CredentialRow is a metadata row tagged with the scope it was listed under.
+type CredentialRow = CredentialMeta & { _scope: CredentialScope };
+
+// well-known provider/tool key env-var names (mirror docs/CREDENTIALS.md);
+// free-form custom names (e.g. $cred: labels) are still allowed.
+const KNOWN_KEY_NAMES = [
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "DEEPSEEK_API_KEY",
+  "GEMINI_API_KEY",
+  "OLLAMA_API_KEY",
+  // Web-search providers (RFC BB).
+  "BRAVE_API_KEY",
+  "SERPER_API_KEY",
+  "EXA_API_KEY",
+  "TAVILY_API_KEY",
+];
+
+export function CredentialsPanel({ userOnly = false }: { userOnly?: boolean }) {
+  const [rows, setRows] = useState<CredentialRow[]>([]);
+  const [err, setErr] = useState<string | null>(null);
+  const [disabled, setDisabled] = useState(false);
+  const [flash, setFlash] = useState<string | null>(null);
+  // Create form. `value` is write-only — cleared on submit (success OR failure)
+  // and never re-displayed. userOnly locks the scope to the caller's own subject.
+  const [name, setName] = useState("");
+  const [value, setValue] = useState("");
+  const [scope, setScope] = useState<CredentialScope>(
+    userOnly ? "user" : "tenant",
+  );
+  const [busy, setBusy] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setErr(null);
+    try {
+      if (userOnly) {
+        // Only the caller's own subject — a user login can only address scope=user
+        // (the server confines an isolated caller to it anyway).
+        const u = await listCredentials("user");
+        setRows(
+          (u.credentials ?? []).map((c) => ({ ...c, _scope: "user" as const })),
+        );
+      } else {
+        // List BOTH scopes so the operator table shows tenant-shared + own-user
+        // credentials together. list returns metadata only, never a value.
+        const [t, u] = await Promise.all([
+          listCredentials("tenant"),
+          listCredentials("user"),
+        ]);
+        setRows([
+          ...(t.credentials ?? []).map((c) => ({
+            ...c,
+            _scope: "tenant" as const,
+          })),
+          ...(u.credentials ?? []).map((c) => ({
+            ...c,
+            _scope: "user" as const,
+          })),
+        ]);
+      }
+      setDisabled(false);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      if (isCredStoreDisabled(msg)) setDisabled(true);
+      else setErr(msg);
+    }
+  }, [userOnly]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const onCreate = async (e: FormEvent) => {
+    e.preventDefault();
+    if (busy || !name.trim() || !value) return;
+    setBusy(true);
+    setErr(null);
+    setFlash(null);
+    const created = name.trim();
+    const useScope: CredentialScope = userOnly ? "user" : scope;
+    try {
+      await createCredential({ scope: useScope, name: created, value });
+      setValue(""); // clear the secret immediately
+      setName("");
+      setFlash(`stored ${useScope} credential "${created}"`);
+      setDisabled(false);
+      await refresh();
+    } catch (e2) {
+      setValue(""); // clear the secret even on failure — never retained
+      const msg = e2 instanceof Error ? e2.message : String(e2);
+      if (isCredStoreDisabled(msg)) setDisabled(true);
+      else setErr(msg);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onDelete = async (r: CredentialRow) => {
+    if (
+      !confirm(
+        `Delete the ${r._scope} credential "${r.name}"? Anything referencing $cred:${r.name} will stop resolving.`,
+      )
+    ) {
+      return;
+    }
+    try {
+      await deleteCredential({ scope: r._scope, name: r.name });
+      await refresh();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  return (
+    <div className="settings-panel">
+      <h2>{userOnly ? "My Credentials" : "Credentials"}</h2>
+      <p className="settings-help">
+        {userOnly ? (
+          <>
+            Your own encrypted API tokens (RFC AR). A stored secret is referenced
+            elsewhere as <code>$cred:&lt;name&gt;</code> — e.g. a per-user Slack or
+            Telegram bot token an agent uses to publish to <em>your</em> channel —
+            and the runtime binds it server-side, so the value is never shown again
+            after you save it. These are private to your own subject; no one else,
+            not even a tenant operator, can read them.
+          </>
+        ) : (
+          <>
+            Encrypted API credentials for this tenant (RFC AR). A stored secret is
+            referenced elsewhere as <code>$cred:&lt;name&gt;</code> in an MCP
+            server&apos;s env or headers, and the runtime binds it server-side — the
+            value is never shown again after you save it. Naming one after a provider
+            key env-var (e.g. <code>ANTHROPIC_API_KEY</code>,{" "}
+            <code>BRAVE_API_KEY</code>) overrides the operator&apos;s key for this
+            tenant&apos;s runs (RFC AR / AX). <strong>tenant</strong> scope is shared
+            across the tenant; <strong>user</strong> scope is private to your own
+            subject (per-user tokens, e.g. a personal Telegram bot token).
+          </>
+        )}
+      </p>
+
+      {disabled && (
+        <div className="settings-error">
+          The credential store is disabled. The operator must set{" "}
+          <code>LOOMCYCLE_SECRET_KEY</code> to enable encrypted credential storage.
+        </div>
+      )}
+      {err && <div className="settings-error">{err}</div>}
+      {flash && <div className="settings-flash">{flash}</div>}
+
+      <form className="cred-create" onSubmit={onCreate}>
+        <input
+          type="text"
+          list="cred-key-names"
+          placeholder={
+            userOnly ? "name (e.g. TELEGRAM_BOT_TOKEN)" : "name (e.g. ANTHROPIC_API_KEY)"
+          }
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          autoComplete="off"
+          spellCheck={false}
+        />
+        <datalist id="cred-key-names">
+          {KNOWN_KEY_NAMES.map((n) => (
+            <option key={n} value={n} />
+          ))}
+        </datalist>
+        <input
+          type="password"
+          placeholder="value (secret — write-only)"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          autoComplete="new-password"
+        />
+        {!userOnly && (
+          <select
+            value={scope}
+            onChange={(e) => setScope(e.target.value as CredentialScope)}
+            title="tenant = shared; user = your own subject"
+          >
+            <option value="tenant">tenant</option>
+            <option value="user">user</option>
+          </select>
+        )}
+        <button
+          type="submit"
+          className="primary-btn"
+          disabled={busy || !name.trim() || !value}
+        >
+          {busy ? "storing…" : "store"}
+        </button>
+      </form>
+
+      <table className="settings-table cred-table">
+        <thead>
+          <tr>
+            <th>name</th>
+            {!userOnly && <th>scope</th>}
+            <th>updated</th>
+            <th aria-label="actions" />
+          </tr>
+        </thead>
+        <tbody>
+          {rows.length === 0 ? (
+            <tr>
+              <td colSpan={userOnly ? 3 : 4} className="settings-muted">
+                no credentials stored.
+              </td>
+            </tr>
+          ) : (
+            rows.map((r) => (
+              <tr key={`${r._scope}/${r.name}`}>
+                <td>
+                  <code>{r.name}</code>
+                </td>
+                {!userOnly && <td>{r._scope}</td>}
+                <td>
+                  {r.updated_at ? new Date(r.updated_at).toLocaleString() : "—"}
+                </td>
+                <td>
+                  <button
+                    type="button"
+                    className="ghost-btn danger"
+                    onClick={() => void onDelete(r)}
+                  >
+                    delete
+                  </button>
+                </td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -14,6 +14,7 @@ import {
   Coins,
   FolderTree,
   HardDrive,
+  KeyRound,
   Library,
   ListTree,
   LogOut,
@@ -70,6 +71,10 @@ interface NavItem {
 const NAV_ITEMS: NavItem[] = [
   { to: "/run", label: "run", Icon: Play, vis: "all" },
   { to: "/agents", label: "runs", Icon: ListTree, vis: "all" },
+  // RFC CN — every login (incl. an isolated substrate:user user) can self-serve
+  // its OWN scope=user API tokens here; the operator Settings → Credentials tab
+  // (tenant authoring) stays separate.
+  { to: "/my-credentials", label: "credentials", Icon: KeyRound, vis: "all" },
   { to: "/library/agents", label: "library", Icon: Library, vis: "tenant" },
   { to: "/integrations/webhooks", label: "integrations", Icon: Plug, vis: "tenant" },
   { to: "/volumes/persistent", label: "volumes", Icon: HardDrive, vis: "tenant" },

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -29,6 +29,7 @@ import ChannelsView from "./pages/ChannelsView";
 import SchedulesView from "./pages/SchedulesView";
 import TeamsView from "./pages/TeamsView";
 import SettingsView from "./pages/SettingsView";
+import MyCredentialsView from "./pages/MyCredentialsView";
 import Layout from "./components/Layout";
 import AgentIdRedirect from "./components/AgentIdRedirect";
 import LoginView from "./pages/LoginView";
@@ -50,6 +51,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
         <Route path="/" element={<Layout />}>
           <Route index element={<Navigate to="/agents" replace />} />
           <Route path="run" element={<RunView />} />
+          <Route path="my-credentials" element={<MyCredentialsView />} />
           <Route path="teams" element={<TeamsView />} />
           <Route path="agents" element={<AgentsView />} />
           <Route path="agents/:agentId" element={<AgentIdRedirect />} />

--- a/web/src/pages/MyCredentialsView.tsx
+++ b/web/src/pages/MyCredentialsView.tsx
@@ -1,0 +1,18 @@
+import { CredentialsPanel } from "../components/CredentialsPanel";
+
+// MyCredentialsView is the standalone RFC CN "My Credentials" page: a user's OWN
+// scope=user API tokens (a personal Slack/Telegram bot token, a per-user webhook
+// secret), reachable by ANY authenticated login — including an isolated
+// substrate:user user, who has no access to the operator Settings hub. It renders
+// the shared CredentialsPanel in userOnly mode (scope=user only), so it offers
+// exactly what the server permits a user to self-serve; the operator Settings →
+// Credentials tab (tenant + user authoring) stays separate and unchanged.
+export default function MyCredentialsView() {
+  return (
+    <div className="settings-view">
+      <div className="settings-body">
+        <CredentialsPanel userOnly />
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/SettingsView.tsx
+++ b/web/src/pages/SettingsView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, type FormEvent } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import {
   canSee,
@@ -9,8 +9,6 @@ import { ontologistRunHref, ontologyEditHref } from "../lib/ontologyEditHref";
 import { erasureGate, residueMeaning } from "../lib/erasure";
 import { countMeaning, exportMisconfigured, familyEffect } from "../lib/retention";
 import {
-  CredentialMeta,
-  CredentialScope,
   HealthResponse,
   MemoryOrphanReport,
   OntologyProposal,
@@ -18,8 +16,6 @@ import {
   PresetUnit,
   RuntimeStateResponse,
   adoptOntologyType,
-  createCredential,
-  deleteCredential,
   getEnvTemplate,
   getHealth,
   getOntology,
@@ -27,7 +23,6 @@ import {
   getErasureReport,
   getRetentionReport,
   getRuntimeState,
-  listCredentials,
   listPresets,
   pauseRuntime,
   repairTenantMemory,
@@ -41,6 +36,7 @@ import {
   RetentionReport,
 } from "../api";
 import { usePrincipal, useUserId } from "../components/Layout";
+import { CredentialsPanel } from "../components/CredentialsPanel";
 import LimitsView from "./LimitsView";
 import RoutingView from "./RoutingView";
 import TokenManager from "../components/TokenManager";
@@ -162,7 +158,7 @@ export default function SettingsView() {
         ))}
       </nav>
       <div className="settings-body">
-        {active === "credentials" && <CredentialsSection />}
+        {active === "credentials" && <CredentialsPanel />}
         {active === "limits" && <LimitsView />}
         {active === "routing" && <RoutingView />}
         {active === "ontology" && <OntologySection />}
@@ -178,225 +174,9 @@ export default function SettingsView() {
   );
 }
 
-// ─── Credentials (RFC AR) ────────────────────────────────────────────────────
+// ─── Credentials (RFC AR) — the panel lives in ../components/CredentialsPanel
+// (shared with the standalone My Credentials page, RFC CN). ──────────────────
 
-// isCredStoreDisabled detects the fail-closed error surfaced when the operator
-// hasn't set LOOMCYCLE_SECRET_KEY (the inline backend is off). The server
-// returns the tool's error text verbatim inside the 422 envelope, so we match on
-// its stable markers.
-function isCredStoreDisabled(msg: string): boolean {
-  return (
-    msg.includes("LOOMCYCLE_SECRET_KEY") ||
-    msg.includes("no credential engine") ||
-    msg.includes("disabled")
-  );
-}
-
-// CredentialRow is a metadata row tagged with the scope it was listed under (the
-// API groups by scope; we merge tenant + user into one table).
-type CredentialRow = CredentialMeta & { _scope: CredentialScope };
-
-// well-known provider/tool key env-var names (mirror docs/CREDENTIALS.md);
-// free-form custom names (e.g. $cred: labels) are still allowed.
-const KNOWN_KEY_NAMES = [
-  "ANTHROPIC_API_KEY",
-  "OPENAI_API_KEY",
-  "DEEPSEEK_API_KEY",
-  "GEMINI_API_KEY",
-  "OLLAMA_API_KEY",
-  // Web-search providers (RFC BB).
-  "BRAVE_API_KEY",
-  "SERPER_API_KEY",
-  "EXA_API_KEY",
-  "TAVILY_API_KEY",
-];
-
-function CredentialsSection() {
-  const [rows, setRows] = useState<CredentialRow[]>([]);
-  const [err, setErr] = useState<string | null>(null);
-  const [disabled, setDisabled] = useState(false);
-  const [flash, setFlash] = useState<string | null>(null);
-  // Create form. `value` is write-only — cleared on submit (success OR failure)
-  // and never re-displayed.
-  const [name, setName] = useState("");
-  const [value, setValue] = useState("");
-  const [scope, setScope] = useState<CredentialScope>("tenant");
-  const [busy, setBusy] = useState(false);
-
-  const refresh = useCallback(async () => {
-    setErr(null);
-    try {
-      // List BOTH scopes so the table shows the tenant-shared + own-user
-      // credentials together. list returns metadata only, never a value.
-      const [t, u] = await Promise.all([
-        listCredentials("tenant"),
-        listCredentials("user"),
-      ]);
-      setRows([
-        ...(t.credentials ?? []).map((c) => ({ ...c, _scope: "tenant" as const })),
-        ...(u.credentials ?? []).map((c) => ({ ...c, _scope: "user" as const })),
-      ]);
-      setDisabled(false);
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      if (isCredStoreDisabled(msg)) setDisabled(true);
-      else setErr(msg);
-    }
-  }, []);
-
-  useEffect(() => {
-    void refresh();
-  }, [refresh]);
-
-  const onCreate = async (e: FormEvent) => {
-    e.preventDefault();
-    if (busy || !name.trim() || !value) return;
-    setBusy(true);
-    setErr(null);
-    setFlash(null);
-    const created = name.trim();
-    try {
-      await createCredential({ scope, name: created, value });
-      setValue(""); // clear the secret immediately
-      setName("");
-      setFlash(`stored ${scope} credential "${created}"`);
-      setDisabled(false);
-      await refresh();
-    } catch (e2) {
-      setValue(""); // clear the secret even on failure — never retained
-      const msg = e2 instanceof Error ? e2.message : String(e2);
-      if (isCredStoreDisabled(msg)) setDisabled(true);
-      else setErr(msg);
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  const onDelete = async (r: CredentialRow) => {
-    if (
-      !confirm(
-        `Delete the ${r._scope} credential "${r.name}"? Anything referencing $cred:${r.name} will stop resolving.`,
-      )
-    ) {
-      return;
-    }
-    try {
-      await deleteCredential({ scope: r._scope, name: r.name });
-      await refresh();
-    } catch (e) {
-      setErr(e instanceof Error ? e.message : String(e));
-    }
-  };
-
-  return (
-    <div className="settings-panel">
-      <h2>Credentials</h2>
-      <p className="settings-help">
-        Encrypted API credentials for this tenant (RFC AR). A stored secret is
-        referenced elsewhere as <code>$cred:&lt;name&gt;</code> in an MCP
-        server&apos;s env or headers, and the runtime binds it server-side — the
-        value is never shown again after you save it. Naming one after a provider
-        key env-var (e.g. <code>ANTHROPIC_API_KEY</code>,{" "}
-        <code>BRAVE_API_KEY</code>) overrides the operator&apos;s key for this
-        tenant&apos;s runs (RFC AR / AX). <strong>tenant</strong> scope is shared
-        across the tenant; <strong>user</strong> scope is private to your own
-        subject (per-user tokens, e.g. a personal Telegram bot token).
-      </p>
-
-      {disabled && (
-        <div className="settings-error">
-          The credential store is disabled. The operator must set{" "}
-          <code>LOOMCYCLE_SECRET_KEY</code> to enable encrypted credential
-          storage.
-        </div>
-      )}
-      {err && <div className="settings-error">{err}</div>}
-      {flash && <div className="settings-flash">{flash}</div>}
-
-      <form className="cred-create" onSubmit={onCreate}>
-        <input
-          type="text"
-          list="cred-key-names"
-          placeholder="name (e.g. ANTHROPIC_API_KEY)"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          autoComplete="off"
-          spellCheck={false}
-        />
-        <datalist id="cred-key-names">
-          {KNOWN_KEY_NAMES.map((n) => (
-            <option key={n} value={n} />
-          ))}
-        </datalist>
-        <input
-          type="password"
-          placeholder="value (secret — write-only)"
-          value={value}
-          onChange={(e) => setValue(e.target.value)}
-          autoComplete="new-password"
-        />
-        <select
-          value={scope}
-          onChange={(e) => setScope(e.target.value as CredentialScope)}
-          title="tenant = shared; user = your own subject"
-        >
-          <option value="tenant">tenant</option>
-          <option value="user">user</option>
-        </select>
-        <button
-          type="submit"
-          className="primary-btn"
-          disabled={busy || !name.trim() || !value}
-        >
-          {busy ? "storing…" : "store"}
-        </button>
-      </form>
-
-      <table className="settings-table cred-table">
-        <thead>
-          <tr>
-            <th>name</th>
-            <th>scope</th>
-            <th>updated</th>
-            <th aria-label="actions" />
-          </tr>
-        </thead>
-        <tbody>
-          {rows.length === 0 ? (
-            <tr>
-              <td colSpan={4} className="settings-muted">
-                no credentials stored.
-              </td>
-            </tr>
-          ) : (
-            rows.map((r) => (
-              <tr key={`${r._scope}/${r.name}`}>
-                <td>
-                  <code>{r.name}</code>
-                </td>
-                <td>{r._scope}</td>
-                <td>
-                  {r.updated_at
-                    ? new Date(r.updated_at).toLocaleString()
-                    : "—"}
-                </td>
-                <td>
-                  <button
-                    type="button"
-                    className="ghost-btn danger"
-                    onClick={() => void onDelete(r)}
-                  >
-                    delete
-                  </button>
-                </td>
-              </tr>
-            ))
-          )}
-        </tbody>
-      </table>
-    </div>
-  );
-}
 
 // ─── Presets ─────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Phase 3 of **RFC CN — Per-user credential self-service**: the Web UI surface. Gives every login — including a delegated / isolated `substrate:user` user who has no Settings gear — a place to add its own personal API tokens (a Slack/Telegram bot token, a per-user webhook secret) from the browser.

## Why

P1 (#1093, HTTP) and P2 (#1095, MCP) opened the write surface, but the UI's only credential control was **Settings → Credentials**, gated `vis:"tenant"`. An isolated user can't see the Settings hub at all, so it had no browser path to its own tokens.

## What

- A standalone **"My Credentials"** page — nav item `vis:"all"` (visible to everyone), route `/my-credentials`.
- It offers only the caller's own **scope=user** tokens: list / create / rotate / delete, metadata-only, value write-once (never shown again). That's exactly what the server permits a non-tenant caller.
- The operator **Settings → Credentials** tab (tenant + user authoring) is **unchanged**.

## No drift

The RFC AR credentials panel is **extracted** from `SettingsView` into a shared `components/CredentialsPanel` with a `userOnly` prop:
- Settings renders it **full** — scope selector, tenant+user list.
- My Credentials renders it **`userOnly`** — scope forced to `user`, no selector, own-subject list, a personal help text.

One component → the operator and user surfaces can't drift. Net: `SettingsView` shrinks ~225 lines into the shared component.

## Tested

- **Web typecheck clean** for `web/src` (the `packages/*` errors in an isolated checkout are sibling workspaces whose deps CI installs before the web steps).
- `npm test` — **84/84** pass.
- The isolated-user nav visibility is guarded by the existing `visibility.test.ts` (`canSee("all", false, false) === true`).
- The credential **authorization** itself is enforced + tested **server-side** (P1/P2) — the UI only ever sends `scope: "user"` here.

## Follow-up

P4 — gRPC/adapter parity, only if we decide to expose the credential surface there. With HTTP + MCP + UI shipped, RFC CN's user-facing goal is met; P4 is optional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)