### PR TITLE
feat(bench): wikidata harnesses for knowledge updates, ontology typing, cross-lingual

### DIFF
--- a/bench/wikidata/README.md
+++ b/bench/wikidata/README.md
@@ -1,0 +1,95 @@
+# wikidata bench — knowledge updates, ontology typing, cross-lingual recall
+
+Three small harnesses that drive an externally-running loomcycle instance and score
+memory subsystems against **Wikidata** as ground truth. Companion to `bench/cmd/locomo`,
+which scores conversational retrieval; this scores the axes LoCoMo cannot reach.
+
+Written for RFC CO. The results below are what it produced on v1.66.0 — including one
+phase whose result was "do not build this", which is why the harness exists.
+
+## Why Wikidata
+
+Ground truth is free and machine-checkable. `P580` / `P582` (start/end time) map 1:1
+onto `valid_at` / `invalid_at`; `P31` (instance-of) is a published type hierarchy; and
+one item carries labels for the SAME identity in hundreds of languages, so a
+cross-lingual test needs no translation and no answer-string matching.
+
+It is **CC0**, which is why the fixtures under `fixtures/` are committed. LoCoMo's are
+not, and cannot be — that corpus is CC BY-NC.
+
+## Layout
+
+    build_fixture.py    -> fixtures/chains.json     officeholder chains (CO-1)
+    build_types.py      -> fixtures/types.json      entities by P31 class (CO-3)
+    build_xlingual.py   -> fixtures/xlingual.json   multi-language labels (CO-4)
+
+    run_co1.py   knowledge updates: does a superseded fact stop being returned
+    run_co3.py   ontology typing:   does an entity get the right base type
+    run_co4.py   cross-lingual:     English corpus, non-English query
+
+    answerer_prompt.txt / typer_prompt.txt   the agent prompts the runs install
+
+Run outputs are NOT committed — `bench/results/` is gitignored and these follow the
+same rule. Fixtures are inputs, like `bench/cases/*.yaml`.
+
+## Running
+
+Needs a tenant token in the environment and an instance to talk to:
+
+    export WIKI_BENCH_TENANT_TOKEN=...          # a substrate:tenant token
+    python3 run_co3.py fixtures/types.json     co3.json
+    python3 run_co4.py fixtures/xlingual.json  co4.json
+    python3 run_co1.py fixtures/chains.json 20 co1.json
+
+Rebuild a fixture only when you want fresh data — they are deterministic from a fixed
+class list and committed so a re-run scores the same corpus.
+
+### Two things that will bite you
+
+**The memory scope must be the token's SUBJECT.** In-band `scope=user` is resolved
+server-side from the run identity, never from the wire, so a row written to any other
+`scope_id` is invisible to the agent. `run_co1.py` reads it from `/v1/_me` rather than
+choosing one — an earlier version chose `wiki-co1`, and every arm reported NOT_FOUND,
+which reads as a memory failure and is not one.
+
+**Read an AgentDef back after authoring it.** The mutable field set goes under
+`overlay`; any other key (`def`, say) is accepted with a 200, a def_id, and an empty
+definition. A run against that agent measures nothing and says so in no way at all.
+
+## Results on v1.66.0 (RFC CO)
+
+| phase | result |
+|---|---|
+| CO-1 knowledge updates | **stale-answer rate 0/20**; naive corpus 20/20 — the gate closed CO-2 |
+| CO-3 ontology typing | **63/64 = 0.9844** |
+| CO-4 cross-lingual | **0.976–1.000** recall@10 across en/de/fr/uk/ru/ja/ar |
+
+**Read the caveats before quoting these.**
+
+CO-1's control arm answered **14 of 20 from training alone**, on an empty scope. Only
+the six the model did not know are attributable to memory. Any run of this harness must
+keep the control, or it reports the model's own knowledge as a retrieval score.
+
+CO-3 and CO-4 are measured on the **easy region** of their tasks by construction: CO-3
+uses only `P31` values whose base type is unambiguous, CO-4 queries entity labels rather
+than prose. They establish that the subsystems are not broken on clear cases; they do
+not establish general accuracy.
+
+## Wikidata access notes
+
+- **QLever, not WDQS**, for any set-selection query. `qlever.cs.uni-freiburg.de`
+  308-redirects to **`qlever.dev`**; it wants `Accept: application/sparql-results+json`,
+  has no `wikibase:label` service (use `rdfs:label` + a `LANG` filter), and combining
+  `wikibase:sitelinks` with `rdfs:label` and `schema:description` in one pattern returns
+  zero rows.
+- **WDQS will cut you off.** It began returning `429 Aggressively rate-limiting to
+  1 req / min — active wdqs outage` after ~345 queries for one fixture. The Action API
+  stayed up throughout and is the right tool for id-keyed lookups (50 ids per call).
+- **Be polite**: contactable `User-Agent`, serial requests, exponential backoff. These
+  builders do all three.
+- **The data is dirty.** "Free ground truth" is true of the schema, not the data. A raw
+  officeholder pull contained vandalism ("Phil Baker, President of the United States"),
+  the same person repeated from re-election statements, and a generic `president` item
+  holding unrelated people. `build_fixture.py`'s structural filter is not optional, and
+  it rejects most offices: twenty hand-picked QIDs yielded two usable chains, while
+  candidates discovered from `P1313`/`P1906` yielded 241 of 345.

--- a/bench/wikidata/answerer_prompt.txt
+++ b/bench/wikidata/answerer_prompt.txt
@@ -1,0 +1,23 @@
+You answer one question about who currently holds a public office.
+
+Procedure, in this order, every time:
+
+1. FIRST call Memory with op=recall, scope=user, top_k=10, and a query built from the
+   office name. Do this before you think about the answer.
+2. Answer from what recall returned. If several results name different holders, prefer
+   the one the stored text presents as current.
+3. THEN, separately, say what you would have answered from your own knowledge alone,
+   without the memory results.
+
+Your ENTIRE reply is exactly three lines, nothing else:
+
+MEMORY: <the name recall supports, or NOT_FOUND>
+OWN: <the name you would give from your own knowledge, or UNKNOWN>
+BASIS: <one short clause: what in the results decided it>
+
+Rules:
+- MEMORY must reflect the recall results, not your own knowledge. If recall returned
+  nothing usable, MEMORY is NOT_FOUND even when you are confident of the answer.
+- OWN must be your own knowledge, stated even when it contradicts MEMORY. If you do
+  not know, OWN is UNKNOWN. Do not simply copy MEMORY into OWN.
+- A name only. No titles, no dates, no explanation outside BASIS.

--- a/bench/wikidata/build_fixture.py
+++ b/bench/wikidata/build_fixture.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""RFC CO-1 fixture builder: Wikidata officeholder chains.
+
+Deterministic from a fixed office list so the corpus hashes stably. CC0, committable.
+Ground truth is a QID, never a name string.
+
+WIKIDATA IS NOT CLEAN and this file is mostly the cleaning. A first pass produced
+"Phil Baker, President of the United States (2018-)", the same person three times from
+separate re-election statements, and a generic `president` item holding unrelated
+people. A benchmark built on that measures the corpus, not the store.
+"""
+import json, re, sys, time, urllib.parse, urllib.request
+
+UA = "loomcycle-memory-benchmark/1.0 (RFC CO; research; https://github.com/denn-gubsky/loomcycle)"
+
+def candidate_offices():
+    """Discover office items rather than guessing QIDs.
+
+    Hand-picking twenty QIDs produced seven chains, several of them wrong items (a
+    generic `president` holding unrelated people). Sovereign states declare their
+    head-of-government and head-of-state offices as properties, so the candidate set
+    can be derived instead of recalled — and the per-office cleaner then rejects the
+    messy ones on structure rather than on my memory of what a QID means.
+    """
+    q = ("SELECT DISTINCT ?office WHERE { ?c wdt:P31 wd:Q3624078 . "
+         "{ ?c wdt:P1313 ?office } UNION { ?c wdt:P1906 ?office } }")
+    return [b["office"]["value"].rsplit("/", 1)[-1]
+            for b in sparql(q)["results"]["bindings"]]
+
+
+def get(url):
+    req = urllib.request.Request(url, headers={"User-Agent": UA, "Accept": "application/json"})
+    for a in range(4):
+        try:
+            return json.loads(urllib.request.urlopen(req, timeout=60).read())
+        except Exception:
+            if a == 3:
+                raise
+            time.sleep(2 ** a)          # serial + backoff, per API etiquette
+
+def sparql(q):
+    return get("https://query.wikidata.org/sparql?" + urllib.parse.urlencode({"query": q, "format": "json"}))
+
+def holders(office):
+    q = ("SELECT ?holder ?start ?end WHERE { ?holder p:P39 ?st . "
+         f"?st ps:P39 wd:{office} ; pq:P580 ?start . "
+         "OPTIONAL { ?st pq:P582 ?end } } ORDER BY ?start")
+    out = []
+    for b in sparql(q)["results"]["bindings"]:
+        out.append({"qid": b["holder"]["value"].rsplit("/", 1)[-1],
+                    "start": b["start"]["value"][:10],
+                    "end": b["end"]["value"][:10] if "end" in b else None})
+    return out
+
+def labels(qids):
+    out = {}
+    for i in range(0, len(qids), 50):
+        d = get("https://www.wikidata.org/w/api.php?" + urllib.parse.urlencode({
+            "action": "wbgetentities", "ids": "|".join(qids[i:i+50]),
+            "props": "labels", "languages": "en", "format": "json"}))
+        for qid, ent in (d.get("entities") or {}).items():
+            v = (ent.get("labels") or {}).get("en", {}).get("value")
+            if v:
+                out[qid] = v
+        time.sleep(0.4)
+    return out
+
+def clean(rows):
+    """Reduce a raw statement list to the one transition CO-1 needs: the CURRENT holder
+    and the one immediately before.
+
+    A first attempt validated the whole succession and rejected all 18 offices. Real
+    Wikidata has interim holders, concurrent statements and historical terms with no
+    end date — a chain that is clean end-to-end is the exception. But the benchmark
+    only needs ONE change to be a knowledge-update case, so validating the rest was
+    strictness bought at the cost of having any data at all.
+    """
+    rows = [r for r in rows if r["start"] >= "1990-01-01"]
+    rows.sort(key=lambda r: r["start"])
+    merged = []
+    for r in rows:
+        if merged and merged[-1]["qid"] == r["qid"]:   # re-election, not a change
+            merged[-1]["end"] = r["end"]
+            continue
+        merged.append(dict(r))
+    if len(merged) < 2:
+        return None, "fewer than two distinct holders since 1990"
+    # Exactly one open-ended term, and it must be the LAST one. More than one means the
+    # office is not single-holder here (or the data is wrong), and either way "who
+    # holds it now" has no single answer to grade against.
+    open_terms = [i for i, r in enumerate(merged) if r["end"] is None]
+    if open_terms != [len(merged) - 1]:
+        return None, f"{len(open_terms)} open-ended terms, current holder ambiguous"
+    prev, cur = merged[-2], merged[-1]
+    if prev["end"] is None or prev["end"] > cur["start"]:
+        return None, "previous term does not close before the current one begins"
+    return [prev, cur], None
+
+def main():
+    chains, need, rejected = [], set(), []
+    offices = candidate_offices()
+    print(f'discovered {len(offices)} candidate offices', file=sys.stderr)
+    for off in offices:
+        try:
+            raw = holders(off)
+        except Exception as e:
+            rejected.append((off, f"query failed: {e}")); continue
+        rows, why = clean(raw)
+        if rows is None or len(rows) < 2:
+            rejected.append((off, why or f"only {len(rows or [])} states")); continue
+        chains.append({"office": off, "holders": rows})
+        need.add(off); need.update(r["qid"] for r in rows)
+        time.sleep(0.5)
+    lab = labels(sorted(need))
+    kept = []
+    for c in chains:
+        # A chain with an unresolved label cannot be graded by name in the report, and
+        # more importantly signals an item that is not what we think it is.
+        if c["office"] not in lab or any(h["qid"] not in lab for h in c["holders"]):
+            rejected.append((c["office"], "unresolved label")); continue
+        c["office_label"] = lab[c["office"]]
+        for h in c["holders"]:
+            h["label"] = lab[h["qid"]]
+        kept.append(c)
+    json.dump({"chains": kept}, open(sys.argv[1], "w"), indent=1)
+    from collections import Counter
+    for why, n in Counter(w for _, w in rejected).most_common():
+        print(f"  rejected {n:4}: {why}", file=sys.stderr)
+    print(f"\nkept {len(kept)} chains, rejected {len(rejected)}", file=sys.stderr)
+
+main()

--- a/bench/wikidata/build_types.py
+++ b/bench/wikidata/build_types.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""RFC CO-3 fixture: entities whose Wikidata P31 maps unambiguously onto one of
+loomcycle's base ontology types.
+
+Only UNAMBIGUOUS mappings are used. A film is arguably an `object` and arguably not;
+scoring the store on a call a careful human would hesitate over measures the mapping,
+not the ontology. So the set is restricted to P31 values where the base type is not in
+question, and the ambiguous middle is left out rather than guessed at.
+"""
+import json, sys, time, urllib.parse, urllib.request
+
+UA = "loomcycle-memory-benchmark/1.0 (RFC CO-3; research)"
+
+# Wikidata class -> loomcycle base type. Each entry is a case where the base ontology
+# has exactly one defensible answer.
+CLASSES = [
+    ("Q5",       "person",       "human"),
+    ("Q3624078", "location",     "sovereign state"),
+    ("Q515",     "location",     "city"),
+    ("Q3918",    "organization", "university"),
+    ("Q4830453", "organization", "business"),
+    ("Q7278",    "organization", "political party"),
+    ("Q198",     "event",        "war"),
+    ("Q1656682", "event",        "event"),
+]
+PER_CLASS = 8
+
+def get(url):
+    req = urllib.request.Request(url, headers={"User-Agent": UA, "Accept": "application/sparql-results+json"})
+    for a in range(4):
+        try:
+            return json.loads(urllib.request.urlopen(req, timeout=60).read())
+        except Exception:
+            if a == 3:
+                raise
+            time.sleep(2 ** a)
+
+def sparql(q):
+    """QLever, not WDQS.
+
+    WDQS began returning 429 "aggressively rate-limiting to 1 req / min - this rule was
+    created during active wdqs outage" partway through this work. The research doc
+    already recommended QLever for set-selection queries precisely because WDQS is
+    unreliable at this shape; this is that recommendation taken.
+    """
+    # NOTE: qlever.cs.uni-freiburg.de now 308-redirects to qlever.dev. The research
+    # doc still cites the old host; this is the live one.
+    return get("https://qlever.dev/api/wikidata?" + urllib.parse.urlencode({"query": q}))
+
+def sample(cls, n):
+    """Entities of one Wikidata class, with an English label and description.
+
+    No popularity ordering: combining wikibase:sitelinks with label and description in
+    one pattern returned zero rows on QLever, and ranking by fame is a nicety here —
+    what the fixture needs is entities that HAVE a description to build a sentence
+    from, which the FILTERs already guarantee.
+    """
+    q = ("PREFIX wdt: <http://www.wikidata.org/prop/direct/> "
+         "PREFIX wd: <http://www.wikidata.org/entity/> "
+         "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> "
+         "PREFIX schema: <http://schema.org/> "
+         f"SELECT ?e ?eLabel ?d WHERE {{ ?e wdt:P31 wd:{cls} ; rdfs:label ?eLabel ; "
+         "schema:description ?d . FILTER(LANG(?eLabel)='en') FILTER(LANG(?d)='en') } "
+         f"LIMIT {n}")
+    out = []
+    for b in sparql(q).get("results", {}).get("bindings", []):
+        qid = b["e"]["value"].rsplit("/", 1)[-1]
+        label = (b.get("eLabel") or {}).get("value", "")
+        desc = (b.get("d") or {}).get("value", "")
+        if not label or label == qid or not desc:
+            continue
+        out.append({"qid": qid, "label": label, "description": desc})
+    return out
+
+def main():
+    items = []
+    for cls, base, human in CLASSES:
+        try:
+            rows = sample(cls, PER_CLASS)
+        except Exception as e:
+            print(f"  {human}: FAILED {e}", file=sys.stderr); continue
+        for r in rows:
+            r["expected_type"] = base
+            r["wikidata_class"] = human
+        items.extend(rows)
+        print(f"  {human:16} -> {base:13} {len(rows)} items", file=sys.stderr)
+        time.sleep(0.5)
+    json.dump({"items": items}, open(sys.argv[1], "w"), indent=1)
+    print(f"\nwrote {len(items)} items", file=sys.stderr)
+
+main()

--- a/bench/wikidata/build_xlingual.py
+++ b/bench/wikidata/build_xlingual.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""RFC CO-4 fixture: the same entity's label in several languages.
+
+The cross-lingual test Wikidata makes free: one item carries labels for the SAME
+identity in many languages, so a fact written in one language and queried in another
+has a known-correct answer with no translation work and no answer-string matching —
+the expected key is the row we wrote.
+
+Languages: en, uk, ru, de, fr, ja, ar — the research doc's proposal, chosen for script
+diversity (Latin / Cyrillic / CJK / Arabic) plus the ones actually in use here.
+"""
+import json, sys, time, urllib.parse, urllib.request
+
+UA = "loomcycle-memory-benchmark/1.0 (RFC CO-4; research)"
+LANGS = ["en", "uk", "ru", "de", "fr", "ja", "ar"]
+
+def get(url):
+    req = urllib.request.Request(url, headers={"User-Agent": UA, "Accept": "application/json"})
+    for a in range(4):
+        try:
+            return json.loads(urllib.request.urlopen(req, timeout=60).read())
+        except Exception:
+            if a == 3:
+                raise
+            time.sleep(2 ** a)
+
+def main():
+    # Reuse the CO-3 entities: already filtered to well-described items, and reusing
+    # them keeps the two phases talking about the same corpus.
+    items = json.load(open(sys.argv[1]))["items"]
+    qids = [it["qid"] for it in items]
+    out = []
+    for i in range(0, len(qids), 50):          # 50 ids per call, the documented cap
+        d = get("https://www.wikidata.org/w/api.php?" + urllib.parse.urlencode({
+            "action": "wbgetentities", "ids": "|".join(qids[i:i+50]),
+            "props": "labels|descriptions", "languages": "|".join(LANGS),
+            "format": "json"}))
+        for qid, ent in (d.get("entities") or {}).items():
+            labs = {l: v["value"] for l, v in (ent.get("labels") or {}).items() if l in LANGS}
+            desc = (ent.get("descriptions") or {}).get("en", {}).get("value", "")
+            # An item missing the English label cannot seed the corpus row, and one
+            # with only English has nothing to query cross-lingually. Both are dropped
+            # rather than half-measured.
+            if "en" not in labs or len(labs) < 3:
+                continue
+            out.append({"qid": qid, "labels": labs, "description": desc})
+        time.sleep(0.4)
+    json.dump({"items": out}, open(sys.argv[2], "w"), indent=1)
+    covered = {l: sum(1 for r in out if l in r["labels"]) for l in LANGS}
+    print(f"entities with >=3 languages: {len(out)}", file=sys.stderr)
+    print(f"per-language coverage: {covered}", file=sys.stderr)
+
+main()

--- a/bench/wikidata/fixtures/chains.json
+++ b/bench/wikidata/fixtures/chains.json
@@ -1,0 +1,4342 @@
+{
+ "chains": [
+  {
+   "office": "Q152814",
+   "holders": [
+    {
+     "qid": "Q938224",
+     "start": "2013-03-09",
+     "end": "2020-01-13",
+     "label": "Joseph Muscat"
+    },
+    {
+     "qid": "Q37860840",
+     "start": "2020-01-13",
+     "end": null,
+     "label": "Robert Abela"
+    }
+   ],
+   "office_label": "Prime Minister of Malta"
+  },
+  {
+   "office": "Q182762",
+   "holders": [
+    {
+     "qid": "Q109784588",
+     "start": "2023-11-11",
+     "end": "2025-08-28",
+     "label": "Nadir al-Arbawi"
+    },
+    {
+     "qid": "Q133540883",
+     "start": "2025-08-28",
+     "end": null,
+     "label": "Sifi Ghrieb"
+    }
+   ],
+   "office_label": "Prime Minister of Algeria"
+  },
+  {
+   "office": "Q191827",
+   "holders": [
+    {
+     "qid": "Q7518922",
+     "start": "2024-04-09",
+     "end": "2025-01-23",
+     "label": "Simon Harris"
+    },
+    {
+     "qid": "Q920403",
+     "start": "2025-01-23",
+     "end": null,
+     "label": "Miche\u00e1l Martin"
+    }
+   ],
+   "office_label": "Taoiseach"
+  },
+  {
+   "office": "Q213107",
+   "holders": [
+    {
+     "qid": "Q476596",
+     "start": "2020-10-01",
+     "end": "2025-02-03",
+     "label": "Alexander De Croo"
+    },
+    {
+     "qid": "Q336599",
+     "start": "2025-02-03",
+     "end": null,
+     "label": "Bart De Wever"
+    }
+   ],
+   "office_label": "Prime Minister of Belgium"
+  },
+  {
+   "office": "Q273884",
+   "holders": [
+    {
+     "qid": "Q57282",
+     "start": "2009-05-09",
+     "end": "2018-02-14",
+     "label": "Jacob Zuma"
+    },
+    {
+     "qid": "Q1148669",
+     "start": "2018-02-15",
+     "end": null,
+     "label": "Cyril Ramaphosa"
+    }
+   ],
+   "office_label": "President of South Africa"
+  },
+  {
+   "office": "Q274948",
+   "holders": [
+    {
+     "qid": "Q1335527",
+     "start": "2024-10-01",
+     "end": "2025-10-21",
+     "label": "Shigeru Ishiba"
+    },
+    {
+     "qid": "Q1705028",
+     "start": "2025-10-21",
+     "end": null,
+     "label": "Sanae Takaichi"
+    }
+   ],
+   "office_label": "Prime Minister of Japan"
+  },
+  {
+   "office": "Q319145",
+   "holders": [
+    {
+     "qid": "Q7436908",
+     "start": "2018-08-24",
+     "end": "2022-05-23",
+     "label": "Scott Morrison"
+    },
+    {
+     "qid": "Q335697",
+     "start": "2022-05-23",
+     "end": null,
+     "label": "Anthony Albanese"
+    }
+   ],
+   "office_label": "Prime Minister of Australia"
+  },
+  {
+   "office": "Q369500",
+   "holders": [
+    {
+     "qid": "Q61121565",
+     "start": "2023-09-15",
+     "end": "2026-05-14",
+     "label": "Evika Sili\u0146a"
+    },
+    {
+     "qid": "Q115604300",
+     "start": "2026-05-28",
+     "end": null,
+     "label": "Andris Kulbergs"
+    }
+   ],
+   "office_label": "Prime Minister of Latvia"
+  },
+  {
+   "office": "Q373548",
+   "holders": [
+    {
+     "qid": "Q16149892",
+     "start": "2020-11-08",
+     "end": "2025-11-08",
+     "label": "Luis Arce"
+    },
+    {
+     "qid": "Q110520817",
+     "start": "2025-11-08",
+     "end": null,
+     "label": "Rodrigo Paz"
+    }
+   ],
+   "office_label": "president of Bolivia"
+  },
+  {
+   "office": "Q376006",
+   "holders": [
+    {
+     "qid": "Q6915896",
+     "start": "2015-05-20",
+     "end": "2020-08-02",
+     "label": "Moses Nagamootoo"
+    },
+    {
+     "qid": "Q98053664",
+     "start": "2020-08-03",
+     "end": null,
+     "label": "Mark Phillips"
+    }
+   ],
+   "office_label": "Prime Minister of Guyana"
+  },
+  {
+   "office": "Q466956",
+   "holders": [
+    {
+     "qid": "Q16297876",
+     "start": "2022-03-11",
+     "end": "2026-03-11",
+     "label": "Gabriel Boric"
+    },
+    {
+     "qid": "Q5937916",
+     "start": "2026-03-11",
+     "end": null,
+     "label": "Jos\u00e9 Antonio Kast"
+    }
+   ],
+   "office_label": "President of Chile"
+  },
+  {
+   "office": "Q628102",
+   "holders": [
+    {
+     "qid": "Q109781648",
+     "start": "2022-09-29",
+     "end": "2023-10-30",
+     "label": "Russ J Kun"
+    },
+    {
+     "qid": "Q58096",
+     "start": "2023-10-30",
+     "end": null,
+     "label": "David Adeang"
+    }
+   ],
+   "office_label": "President of Nauru"
+  },
+  {
+   "office": "Q634322",
+   "holders": [
+    {
+     "qid": "Q24801",
+     "start": "2011-05-12",
+     "end": "2019-05-16",
+     "label": "Antoni Mart\u00ed"
+    },
+    {
+     "qid": "Q21001195",
+     "start": "2019-05-16",
+     "end": null,
+     "label": "Xavier Espot Zamora"
+    }
+   ],
+   "office_label": "Prime Minister of Andorra"
+  },
+  {
+   "office": "Q687075",
+   "holders": [
+    {
+     "qid": "Q4935873",
+     "start": "2021-11-30",
+     "end": "2022-10-18",
+     "label": "Magdalena Andersson"
+    },
+    {
+     "qid": "Q1780398",
+     "start": "2022-10-18",
+     "end": null,
+     "label": "Ulf Kristersson"
+    }
+   ],
+   "office_label": "Prime Minister of Sweden"
+  },
+  {
+   "office": "Q688230",
+   "holders": [
+    {
+     "qid": "Q115881",
+     "start": "2025-01-01",
+     "end": "2025-12-31",
+     "label": "Karin Keller-Sutter"
+    },
+    {
+     "qid": "Q121160",
+     "start": "2026-01-01",
+     "end": null,
+     "label": "Guy Parmelin"
+    }
+   ],
+   "office_label": "President of the Swiss Confederation"
+  },
+  {
+   "office": "Q732562",
+   "holders": [
+    {
+     "qid": "Q4414537",
+     "start": "2021-05-24",
+     "end": "2023-11-23",
+     "label": "Guillermo Lasso"
+    },
+    {
+     "qid": "Q112075625",
+     "start": "2023-11-23",
+     "end": null,
+     "label": "Daniel Noboa"
+    }
+   ],
+   "office_label": "President of Ecuador"
+  },
+  {
+   "office": "Q737115",
+   "holders": [
+    {
+     "qid": "Q11869065",
+     "start": "2021-01-26",
+     "end": "2024-07-22",
+     "label": "Kaja Kallas"
+    },
+    {
+     "qid": "Q1789192",
+     "start": "2024-07-22",
+     "end": null,
+     "label": "Kristen Michal"
+    }
+   ],
+   "office_label": "Prime Minister of Estonia"
+  },
+  {
+   "office": "Q738695",
+   "holders": [
+    {
+     "qid": "Q16986436",
+     "start": "2019-12-10",
+     "end": "2023-06-20",
+     "label": "Sanna Marin"
+    },
+    {
+     "qid": "Q6029546",
+     "start": "2023-06-20",
+     "end": null,
+     "label": "Petteri Orpo"
+    }
+   ],
+   "office_label": "Prime Minister of Finland"
+  },
+  {
+   "office": "Q796897",
+   "holders": [
+    {
+     "qid": "Q294460",
+     "start": "2021-02-13",
+     "end": "2022-10-22",
+     "label": "Mario Draghi"
+    },
+    {
+     "qid": "Q451791",
+     "start": "2022-10-22",
+     "end": null,
+     "label": "Giorgia Meloni"
+    }
+   ],
+   "office_label": "Prime Minister of Italy"
+  },
+  {
+   "office": "Q839078",
+   "holders": [
+    {
+     "qid": "Q3099714",
+     "start": "2015-11-04",
+     "end": "2025-03-14",
+     "label": "Justin Trudeau"
+    },
+    {
+     "qid": "Q192533",
+     "start": "2025-03-14",
+     "end": null,
+     "label": "Mark Carney"
+    }
+   ],
+   "office_label": "Prime Minister of Canada"
+  },
+  {
+   "office": "Q841760",
+   "holders": [
+    {
+     "qid": "Q2112764",
+     "start": "2013-02-28",
+     "end": "2023-02-28",
+     "label": "Nikos Anastasiades"
+    },
+    {
+     "qid": "Q48905549",
+     "start": "2023-02-28",
+     "end": null,
+     "label": "Nicos Christodoulides"
+    }
+   ],
+   "office_label": "President of Cyprus"
+  },
+  {
+   "office": "Q844587",
+   "holders": [
+    {
+     "qid": "Q10819",
+     "start": "2011-12-20",
+     "end": "2018-06-01",
+     "label": "Mariano Rajoy"
+    },
+    {
+     "qid": "Q6070218",
+     "start": "2018-06-02",
+     "end": null,
+     "label": "Pedro S\u00e1nchez"
+    }
+   ],
+   "office_label": "Prime Minister of Spain"
+  },
+  {
+   "office": "Q845439",
+   "holders": [
+    {
+     "qid": "Q124516173",
+     "start": "2025-08-26",
+     "end": "2026-07-01",
+     "label": "Inga Ruginien\u0117"
+    },
+    {
+     "qid": "Q1936326",
+     "start": "2026-07-07",
+     "end": null,
+     "label": "Mindaugas Sinkevi\u010dius"
+    }
+   ],
+   "office_label": "Prime Minister of Lithuania"
+  },
+  {
+   "office": "Q853475",
+   "holders": [
+    {
+     "qid": "Q704022",
+     "start": "2022-08-07",
+     "end": "2026-08-07",
+     "label": "Gustavo Petro"
+    },
+    {
+     "qid": "Q137204778",
+     "start": "2026-08-07",
+     "end": null,
+     "label": "Abelardo de la Espriella"
+    }
+   ],
+   "office_label": "President of Colombia"
+  },
+  {
+   "office": "Q862638",
+   "holders": [
+    {
+     "qid": "Q57701",
+     "start": "2008-02-08",
+     "end": "2020-11-12",
+     "label": "Dean Barrow"
+    },
+    {
+     "qid": "Q6266369",
+     "start": "2020-11-12",
+     "end": null,
+     "label": "Johnny Brice\u00f1o"
+    }
+   ],
+   "office_label": "Prime Minister of Belize"
+  },
+  {
+   "office": "Q866756",
+   "holders": [
+    {
+     "qid": "Q57643",
+     "start": "2004-08-12",
+     "end": "2024-05-15",
+     "label": "Lee Hsien Loong"
+    },
+    {
+     "qid": "Q6504758",
+     "start": "2024-05-15",
+     "end": null,
+     "label": "Lawrence Wong"
+    }
+   ],
+   "office_label": "Prime Minister of Singapore"
+  },
+  {
+   "office": "Q878250",
+   "holders": [
+    {
+     "qid": "Q57456",
+     "start": "2003-07-10",
+     "end": "2016-03-11",
+     "label": "Anote Tong"
+    },
+    {
+     "qid": "Q23034482",
+     "start": "2016-03-11",
+     "end": null,
+     "label": "Taneti Maamau"
+    }
+   ],
+   "office_label": "President of Kiribati"
+  },
+  {
+   "office": "Q878254",
+   "holders": [
+    {
+     "qid": "Q333135",
+     "start": "2020-07-16",
+     "end": "2025-07-06",
+     "label": "Chan Santokhi"
+    },
+    {
+     "qid": "Q440403",
+     "start": "2025-07-06",
+     "end": null,
+     "label": "Jennifer Geerlings-Simons"
+    }
+   ],
+   "office_label": "President of Suriname"
+  },
+  {
+   "office": "Q878329",
+   "holders": [
+    {
+     "qid": "Q336285",
+     "start": "2013-01-17",
+     "end": "2021-01-21",
+     "label": "Thomas Remengesau Jr."
+    },
+    {
+     "qid": "Q26703072",
+     "start": "2021-01-21",
+     "end": null,
+     "label": "Surangel Whipps Jr."
+    }
+   ],
+   "office_label": "President of Palau"
+  },
+  {
+   "office": "Q903751",
+   "holders": [
+    {
+     "qid": "Q4142905",
+     "start": "2025-06-13",
+     "end": "2026-03-30",
+     "label": "Gombojavyn Zandanshatar"
+    },
+    {
+     "qid": "Q110962738",
+     "start": "2026-03-30",
+     "end": null,
+     "label": "Uchral Nyam-Osor"
+    }
+   ],
+   "office_label": "Prime Minister of Mongolia"
+  },
+  {
+   "office": "Q915636",
+   "holders": [
+    {
+     "qid": "Q8083950",
+     "start": "2025-01-22",
+     "end": "2025-12-18",
+     "label": "\u02bbAisake Eke"
+    },
+    {
+     "qid": "Q5437258",
+     "start": "2025-12-18",
+     "end": null,
+     "label": "Fatafehi Fakaf\u0101nua, 8th Lord Fakaf\u0101nua"
+    }
+   ],
+   "office_label": "Prime Minister of Tonga"
+  },
+  {
+   "office": "Q946064",
+   "holders": [
+    {
+     "qid": "Q7065106",
+     "start": "2018-04-21",
+     "end": "2019-10-08",
+     "label": "Novruz Mammadov"
+    },
+    {
+     "qid": "Q12850075",
+     "start": "2019-10-08",
+     "end": null,
+     "label": "Ali Asadov"
+    }
+   ],
+   "office_label": "Prime Minister of Azerbaijan"
+  },
+  {
+   "office": "Q978708",
+   "holders": [
+    {
+     "qid": "Q57519",
+     "start": "2018-06-22",
+     "end": "2023-07-01",
+     "label": "Taur Matan Ruak"
+    },
+    {
+     "qid": "Q11509",
+     "start": "2023-07-01",
+     "end": null,
+     "label": "Xanana Gusm\u00e3o"
+    }
+   ],
+   "office_label": "Prime Minister of East Timor"
+  },
+  {
+   "office": "Q1006398",
+   "holders": [
+    {
+     "qid": "Q64168538",
+     "start": "2025-01-10",
+     "end": "2025-03-03",
+     "label": "Alexander Schallenberg"
+    },
+    {
+     "qid": "Q64576653",
+     "start": "2025-03-03",
+     "end": null,
+     "label": "Christian Stocker"
+    }
+   ],
+   "office_label": "Federal Chancellor of Austria"
+  },
+  {
+   "office": "Q1071117",
+   "holders": [
+    {
+     "qid": "Q5106890",
+     "start": "2023-01-25",
+     "end": "2023-11-27",
+     "label": "Chris Hipkins"
+    },
+    {
+     "qid": "Q74370310",
+     "start": "2023-11-27",
+     "end": null,
+     "label": "Christopher Luxon"
+    }
+   ],
+   "office_label": "Prime Minister of New Zealand"
+  },
+  {
+   "office": "Q1074656",
+   "holders": [
+    {
+     "qid": "Q57892",
+     "start": "2011-08-02",
+     "end": "2019-05-29",
+     "label": "Peter O'Neill"
+    },
+    {
+     "qid": "Q6138903",
+     "start": "2019-05-30",
+     "end": null,
+     "label": "James Marape"
+    }
+   ],
+   "office_label": "Prime Minister of Papua New Guinea"
+  },
+  {
+   "office": "Q1123764",
+   "holders": [
+    {
+     "qid": "Q1979923",
+     "start": "2018-04-23",
+     "end": "2018-05-08",
+     "label": "Karen Karapetyan"
+    },
+    {
+     "qid": "Q7035479",
+     "start": "2018-05-08",
+     "end": null,
+     "label": "Nikol Pashinyan"
+    }
+   ],
+   "office_label": "Prime Minister of Armenia"
+  },
+  {
+   "office": "Q1145714",
+   "holders": [
+    {
+     "qid": "Q61112536",
+     "start": "2025-07-17",
+     "end": "2026-07-16",
+     "label": "Yulia Svyrydenko"
+    },
+    {
+     "qid": "Q124101558",
+     "start": "2026-07-16",
+     "end": null,
+     "label": "Serhii Koretskyi"
+    }
+   ],
+   "office_label": "Prime Minister of Ukraine"
+  },
+  {
+   "office": "Q1195270",
+   "holders": [
+    {
+     "qid": "Q21821359",
+     "start": "2016-01-22",
+     "end": "2016-10-19",
+     "label": "Tihomir Ore\u0161kovi\u0107"
+    },
+    {
+     "qid": "Q11685764",
+     "start": "2016-10-19",
+     "end": null,
+     "label": "Andrej Plenkovi\u0107"
+    }
+   ],
+   "office_label": "Prime Minister of Croatia"
+  },
+  {
+   "office": "Q1277355",
+   "holders": [
+    {
+     "qid": "Q5446290",
+     "start": "2021-05-24",
+     "end": "2025-09-16",
+     "label": "Fiam\u0113 Naomi Mata\u02bbafa"
+    },
+    {
+     "qid": "Q16734600",
+     "start": "2025-09-16",
+     "end": null,
+     "label": "La\u02bbauli Leuatea Schmidt"
+    }
+   ],
+   "office_label": "Prime Minister of Samoa"
+  },
+  {
+   "office": "Q1344632",
+   "holders": [
+    {
+     "qid": "Q561213",
+     "start": "2013-12-05",
+     "end": "2023-11-17",
+     "label": "Xavier Bettel"
+    },
+    {
+     "qid": "Q592101",
+     "start": "2023-11-17",
+     "end": null,
+     "label": "Luc Frieden"
+    }
+   ],
+   "office_label": "Prime Minister of Luxembourg"
+  },
+  {
+   "office": "Q1348717",
+   "holders": [
+    {
+     "qid": "Q57808",
+     "start": "2003-12-12",
+     "end": "2016-12-14",
+     "label": "Shavkat Mirziyoyev"
+    },
+    {
+     "qid": "Q28002959",
+     "start": "2016-12-14",
+     "end": null,
+     "label": "Abdulla Aripov"
+    }
+   ],
+   "office_label": "Prime Minister of Uzbekistan"
+  },
+  {
+   "office": "Q1425954",
+   "holders": [
+    {
+     "qid": "Q6180897",
+     "start": "2024-05-02",
+     "end": "2026-05-15",
+     "label": "Jeremiah Manele"
+    },
+    {
+     "qid": "Q6791373",
+     "start": "2026-05-15",
+     "end": null,
+     "label": "Matthew Wale"
+    }
+   ],
+   "office_label": "Prime Minister of the Solomon Islands"
+  },
+  {
+   "office": "Q1469153",
+   "holders": [
+    {
+     "qid": "Q57830",
+     "start": "2007-01-05",
+     "end": "2022-12-24",
+     "label": "Frank Bainimarama"
+    },
+    {
+     "qid": "Q981549",
+     "start": "2022-12-24",
+     "end": null,
+     "label": "Sitiveni Rabuka"
+    }
+   ],
+   "office_label": "Prime Minister of Fiji"
+  },
+  {
+   "office": "Q1571396",
+   "holders": [
+    {
+     "qid": "Q16250142",
+     "start": "2015-09-19",
+     "end": "2018-06-05",
+     "label": "Sherif Ismail"
+    },
+    {
+     "qid": "Q54901515",
+     "start": "2018-06-14",
+     "end": null,
+     "label": "Mostafa Madbouly"
+    }
+   ],
+   "office_label": "Prime Minister of Egypt"
+  },
+  {
+   "office": "Q1587677",
+   "holders": [
+    {
+     "qid": "Q12963",
+     "start": "2024-12-13",
+     "end": "2025-09-09",
+     "label": "Fran\u00e7ois Bayrou"
+    },
+    {
+     "qid": "Q20089181",
+     "start": "2025-09-09",
+     "end": null,
+     "label": "S\u00e9bastien Lecornu"
+    }
+   ],
+   "office_label": "Prime Minister of France"
+  },
+  {
+   "office": "Q1769526",
+   "holders": [
+    {
+     "qid": "Q136687355",
+     "start": "2026-07-08",
+     "end": "2026-07-22",
+     "label": "Eugen Osmochescu"
+    },
+    {
+     "qid": "Q140480413",
+     "start": "2026-07-22",
+     "end": null,
+     "label": "Vasile Tofan"
+    }
+   ],
+   "office_label": "Prime Minister of Moldova"
+  },
+  {
+   "office": "Q1776220",
+   "holders": [
+    {
+     "qid": "Q5860953",
+     "start": "2024-01-28",
+     "end": "2024-06-23",
+     "label": "Talat Xhaferi"
+    },
+    {
+     "qid": "Q46675558",
+     "start": "2024-06-23",
+     "end": null,
+     "label": "Hristijan Mickoski"
+    }
+   ],
+   "office_label": "Prime Minister of North Macedonia"
+  },
+  {
+   "office": "Q1922067",
+   "holders": [
+    {
+     "qid": "Q42852",
+     "start": "2007-08-28",
+     "end": "2014-08-28",
+     "label": "Abdullah G\u00fcl"
+    },
+    {
+     "qid": "Q39259",
+     "start": "2014-08-28",
+     "end": null,
+     "label": "Recep Tayyip Erdo\u011fan"
+    }
+   ],
+   "office_label": "President of Turkey"
+  },
+  {
+   "office": "Q1975365",
+   "holders": [
+    {
+     "qid": "Q6066533",
+     "start": "2021-02-22",
+     "end": "2024-01-29",
+     "label": "Irakli Garibashvili"
+    },
+    {
+     "qid": "Q27885302",
+     "start": "2024-02-08",
+     "end": null,
+     "label": "Irakli Kobakhidze"
+    }
+   ],
+   "office_label": "Prime Minister of Georgia"
+  },
+  {
+   "office": "Q1999325",
+   "holders": [
+    {
+     "qid": "Q57788",
+     "start": "1998-11-30",
+     "end": "2023-08-07",
+     "label": "Hun Sen"
+    },
+    {
+     "qid": "Q13024351",
+     "start": "2023-08-22",
+     "end": null,
+     "label": "Hun Manet"
+    }
+   ],
+   "office_label": "Prime Minister of Cambodia"
+  },
+  {
+   "office": "Q2334076",
+   "holders": [
+    {
+     "qid": "Q291644",
+     "start": "2013-10-16",
+     "end": "2021-10-14",
+     "label": "Erna Solberg"
+    },
+    {
+     "qid": "Q467948",
+     "start": "2021-10-14",
+     "end": null,
+     "label": "Jonas Gahr St\u00f8re"
+    }
+   ],
+   "office_label": "Prime Minister of Norway"
+  },
+  {
+   "office": "Q2353252",
+   "holders": [
+    {
+     "qid": "Q16353146",
+     "start": "2022-04-28",
+     "end": "2023-10-31",
+     "label": "Dritan Abazovi\u0107"
+    },
+    {
+     "qid": "Q101225458",
+     "start": "2023-10-31",
+     "end": null,
+     "label": "Milojko Spaji\u0107"
+    }
+   ],
+   "office_label": "Prime Minister of Montenegro"
+  },
+  {
+   "office": "Q2387238",
+   "holders": [
+    {
+     "qid": "Q543260",
+     "start": "2011-10-01",
+     "end": "2021-10-01",
+     "label": "Giuseppe Bertello"
+    },
+    {
+     "qid": "Q109385659",
+     "start": "2025-03-01",
+     "end": null,
+     "label": "Raffaella Petrini"
+    }
+   ],
+   "office_label": "President of the Pontifical Commission for the Vatican City State"
+  },
+  {
+   "office": "Q2416315",
+   "holders": [
+    {
+     "qid": "Q56825894",
+     "start": "2022-01-05",
+     "end": "2024-02-05",
+     "label": "\u00c4lihan Smaiylov"
+    },
+    {
+     "qid": "Q124436646",
+     "start": "2024-02-06",
+     "end": null,
+     "label": "Olzhas Bektenov"
+    }
+   ],
+   "office_label": "Prime Minister of Kazakhstan"
+  },
+  {
+   "office": "Q2672728",
+   "holders": [
+    {
+     "qid": "Q718601",
+     "start": "2017-01-07",
+     "end": "2025-01-07",
+     "label": "Nana Akufo-Addo"
+    },
+    {
+     "qid": "Q50678",
+     "start": "2025-01-07",
+     "end": null,
+     "label": "John Mahama"
+    }
+   ],
+   "office_label": "President of Ghana"
+  },
+  {
+   "office": "Q3259469",
+   "holders": [
+    {
+     "qid": "Q11771436",
+     "start": "2017-12-11",
+     "end": "2023-12-13",
+     "label": "Mateusz Morawiecki"
+    },
+    {
+     "qid": "Q946",
+     "start": "2023-12-13",
+     "end": null,
+     "label": "Donald Tusk"
+    }
+   ],
+   "office_label": "Prime Minister of Poland"
+  },
+  {
+   "office": "Q3736673",
+   "holders": [
+    {
+     "qid": "Q20658229",
+     "start": "2020-01-13",
+     "end": "2024-01-03",
+     "label": "David Kabua"
+    },
+    {
+     "qid": "Q20090884",
+     "start": "2024-01-04",
+     "end": null,
+     "label": "Hilda Heine"
+    }
+   ],
+   "office_label": "President of the Marshall Islands"
+  },
+  {
+   "office": "Q4122271",
+   "holders": [
+    {
+     "qid": "Q18111",
+     "start": "2013-03-15",
+     "end": "2023-03-11",
+     "label": "Li Keqiang"
+    },
+    {
+     "qid": "Q4414390",
+     "start": "2023-03-11",
+     "end": null,
+     "label": "Li Qiang"
+    }
+   ],
+   "office_label": "Premier of the People's Republic of China"
+  },
+  {
+   "office": "Q4377230",
+   "holders": [
+    {
+     "qid": "Q118402778",
+     "start": "2023-05-25",
+     "end": "2023-06-26",
+     "label": "Ioannis Sarmas"
+    },
+    {
+     "qid": "Q552751",
+     "start": "2023-06-26",
+     "end": null,
+     "label": "Kyriakos Mitsotakis"
+    }
+   ],
+   "office_label": "Prime Minister of Greece"
+  },
+  {
+   "office": "Q4404583",
+   "holders": [
+    {
+     "qid": "Q110313525",
+     "start": "2026-02-19",
+     "end": "2026-05-08",
+     "label": "Andrey Gurov"
+    },
+    {
+     "qid": "Q26257557",
+     "start": "2026-05-08",
+     "end": null,
+     "label": "Rumen Radev"
+    }
+   ],
+   "office_label": "Prime Minister of Bulgaria"
+  },
+  {
+   "office": "Q4524807",
+   "holders": [
+    {
+     "qid": "Q6800406",
+     "start": "2020-03-01",
+     "end": "2025-03-01",
+     "label": "Luis Lacalle Pou"
+    },
+    {
+     "qid": "Q19946921",
+     "start": "2025-03-01",
+     "end": null,
+     "label": "Yamand\u00fa Orsi"
+    }
+   ],
+   "office_label": "President of Uruguay"
+  },
+  {
+   "office": "Q4970706",
+   "holders": [
+    {
+     "qid": "Q61053",
+     "start": "2021-12-08",
+     "end": "2025-05-06",
+     "label": "Olaf Scholz"
+    },
+    {
+     "qid": "Q566257",
+     "start": "2025-05-06",
+     "end": null,
+     "label": "Friedrich Merz"
+    }
+   ],
+   "office_label": "Federal Chancellor of Germany"
+  },
+  {
+   "office": "Q5176750",
+   "holders": [
+    {
+     "qid": "Q10304982",
+     "start": "2019-01-01",
+     "end": "2022-12-31",
+     "label": "Jair Bolsonaro"
+    },
+    {
+     "qid": "Q37181",
+     "start": "2023-01-01",
+     "end": null,
+     "label": "Luiz In\u00e1cio Lula da Silva"
+    }
+   ],
+   "office_label": "President of Brazil"
+  },
+  {
+   "office": "Q6502015",
+   "holders": [
+    {
+     "qid": "Q1932603",
+     "start": "2018-04-19",
+     "end": "2019-12-21",
+     "label": "Miguel D\u00edaz-Canel"
+    },
+    {
+     "qid": "Q79358625",
+     "start": "2019-12-21",
+     "end": null,
+     "label": "Manuel Marrero Cruz"
+    }
+   ],
+   "office_label": "Prime Minister of Cuba"
+  },
+  {
+   "office": "Q7240364",
+   "holders": [
+    {
+     "qid": "Q56818689",
+     "start": "2019-04-11",
+     "end": "2020-08-13",
+     "label": "Kim Jae-ryong"
+    },
+    {
+     "qid": "Q25035961",
+     "start": "2020-08-13",
+     "end": null,
+     "label": "Kim Tok-hun"
+    }
+   ],
+   "office_label": "Premier of North Korea"
+  },
+  {
+   "office": "Q11755916",
+   "holders": [
+    {
+     "qid": "Q3318231",
+     "start": "2014-10-20",
+     "end": "2024-10-20",
+     "label": "Joko Widodo"
+    },
+    {
+     "qid": "Q2107268",
+     "start": "2024-10-20",
+     "end": null,
+     "label": "Prabowo Subianto"
+    }
+   ],
+   "office_label": "President of Indonesia"
+  },
+  {
+   "office": "Q11942698",
+   "holders": [
+    {
+     "qid": "Q58833335",
+     "start": "2019-01-23",
+     "end": "2023-01-05",
+     "label": "Juan Guaid\u00f3"
+    },
+    {
+     "qid": "Q15081116",
+     "start": "2026-01-05",
+     "end": null,
+     "label": "Delcy Rodriguez"
+    }
+   ],
+   "office_label": "President of Venezuela"
+  },
+  {
+   "office": "Q12379704",
+   "holders": [
+    {
+     "qid": "Q27043179",
+     "start": "2020-06-04",
+     "end": "2025-03-10",
+     "label": "Raman Halowchanka"
+    },
+    {
+     "qid": "Q56235580",
+     "start": "2025-03-10",
+     "end": null,
+     "label": "Alexander Turchyn"
+    }
+   ],
+   "office_label": "Prime Minister of Belarus"
+  },
+  {
+   "office": "Q12969145",
+   "holders": [
+    {
+     "qid": "Q2642828",
+     "start": "2019-12-10",
+     "end": "2023-12-10",
+     "label": "Alberto Fern\u00e1ndez"
+    },
+    {
+     "qid": "Q52395487",
+     "start": "2023-12-10",
+     "end": null,
+     "label": "Javier Milei"
+    }
+   ],
+   "office_label": "President of Argentina"
+  },
+  {
+   "office": "Q14784066",
+   "holders": [
+    {
+     "qid": "Q196070",
+     "start": "2013-04-09",
+     "end": "2022-09-13",
+     "label": "Uhuru Kenyatta"
+    },
+    {
+     "qid": "Q195725",
+     "start": "2022-09-13",
+     "end": null,
+     "label": "William Ruto"
+    }
+   ],
+   "office_label": "President of Kenya"
+  },
+  {
+   "office": "Q15304810",
+   "holders": [
+    {
+     "qid": "Q1151156",
+     "start": "2025-05-06",
+     "end": "2025-06-23",
+     "label": "C\u0103t\u0103lin Predoiu"
+    },
+    {
+     "qid": "Q18538164",
+     "start": "2025-06-23",
+     "end": null,
+     "label": "Ilie Bolojan"
+    }
+   ],
+   "office_label": "Prime Minister of Romania"
+  },
+  {
+   "office": "Q15921525",
+   "holders": [
+    {
+     "qid": "Q57709",
+     "start": "2010-10-23",
+     "end": "2018-05-25",
+     "label": "Freundel Stuart"
+    },
+    {
+     "qid": "Q6827147",
+     "start": "2018-05-25",
+     "end": null,
+     "label": "Mia Mottley"
+    }
+   ],
+   "office_label": "Prime Minister of Barbados"
+  },
+  {
+   "office": "Q16009376",
+   "holders": [
+    {
+     "qid": "Q57625",
+     "start": "2005-09-11",
+     "end": "2013-09-15",
+     "label": "Sali Berisha"
+    },
+    {
+     "qid": "Q316901",
+     "start": "2013-09-15",
+     "end": null,
+     "label": "Edi Rama"
+    }
+   ],
+   "office_label": "Prime Minister of Albania"
+  },
+  {
+   "office": "Q16020744",
+   "holders": [
+    {
+     "qid": "Q12752078",
+     "start": "2019-12-23",
+     "end": "2023-01-25",
+     "label": "Zoran Tegeltija"
+    },
+    {
+     "qid": "Q387491",
+     "start": "2023-01-25",
+     "end": null,
+     "label": "Borjana Kri\u0161to"
+    }
+   ],
+   "office_label": "Chairman of the Council of Ministers of Bosnia and Herzegovina"
+  },
+  {
+   "office": "Q19190022",
+   "holders": [
+    {
+     "qid": "Q879376",
+     "start": "2024-04-09",
+     "end": "2024-12-21",
+     "label": "Bjarni Benediktsson"
+    },
+    {
+     "qid": "Q108856371",
+     "start": "2024-12-21",
+     "end": null,
+     "label": "Kristr\u00fan Mj\u00f6ll Frostad\u00f3ttir"
+    }
+   ],
+   "office_label": "Prime Minister of Iceland"
+  },
+  {
+   "office": "Q28003132",
+   "holders": [
+    {
+     "qid": "Q57350",
+     "start": "1990-12-02",
+     "end": "2021-04-20",
+     "label": "Idriss D\u00e9by"
+    },
+    {
+     "qid": "Q16206405",
+     "start": "2021-04-20",
+     "end": null,
+     "label": "Mahamat D\u00e9by"
+    }
+   ],
+   "office_label": "President of Chad"
+  },
+  {
+   "office": "Q30101326",
+   "holders": [
+    {
+     "qid": "Q107504646",
+     "start": "2025-03-17",
+     "end": "2025-05-01",
+     "label": "Stuart Young"
+    },
+    {
+     "qid": "Q57712",
+     "start": "2025-05-01",
+     "end": null,
+     "label": "Kamla Persad-Bissessar"
+    }
+   ],
+   "office_label": "Prime Minister of Trinidad and Tobago"
+  },
+  {
+   "office": "Q30133416",
+   "holders": [
+    {
+     "qid": "Q63872093",
+     "start": "2019-05-11",
+     "end": "2023-05-11",
+     "label": "David W. Panuelo"
+    },
+    {
+     "qid": "Q7984081",
+     "start": "2023-05-11",
+     "end": null,
+     "label": "Wesley Simina"
+    }
+   ],
+   "office_label": "President of the Federated States of Micronesia"
+  },
+  {
+   "office": "Q45369",
+   "holders": [
+    {
+     "qid": "Q96747230",
+     "start": "2023-05-15",
+     "end": "2023-10-25",
+     "label": "\u013dudov\u00edt \u00d3dor"
+    },
+    {
+     "qid": "Q57606",
+     "start": "2023-10-25",
+     "end": null,
+     "label": "Robert Fico"
+    }
+   ],
+   "office_label": "Prime Minister of Slovakia"
+  },
+  {
+   "office": "Q45758",
+   "holders": [
+    {
+     "qid": "Q18645045",
+     "start": "2022-05-25",
+     "end": "2026-05-22",
+     "label": "Robert Golob"
+    },
+    {
+     "qid": "Q57627",
+     "start": "2026-05-22",
+     "end": null,
+     "label": "Janez Jan\u0161a"
+    }
+   ],
+   "office_label": "Prime Minister of Slovenia"
+  },
+  {
+   "office": "Q213702",
+   "holders": [
+    {
+     "qid": "Q57276",
+     "start": "2011-11-11",
+     "end": "2025-11-10",
+     "label": "Michael D. Higgins"
+    },
+    {
+     "qid": "Q5052598",
+     "start": "2025-11-11",
+     "end": null,
+     "label": "Catherine Connolly"
+    }
+   ],
+   "office_label": "president of Ireland"
+  },
+  {
+   "office": "Q218014",
+   "holders": [
+    {
+     "qid": "Q348043",
+     "start": "2019-07-08",
+     "end": "2023-07-08",
+     "label": "Egils Levits"
+    },
+    {
+     "qid": "Q3047551",
+     "start": "2023-07-08",
+     "end": null,
+     "label": "Edgars Rink\u0113vi\u010ds"
+    }
+   ],
+   "office_label": "President of Latvia"
+  },
+  {
+   "office": "Q218295",
+   "holders": [
+    {
+     "qid": "Q23530",
+     "start": "2008-05-07",
+     "end": "2012-05-07",
+     "label": "Dmitry Medvedev"
+    },
+    {
+     "qid": "Q7747",
+     "start": "2012-05-07",
+     "end": null,
+     "label": "Vladimir Putin"
+    }
+   ],
+   "office_label": "President of Russia"
+  },
+  {
+   "office": "Q268984",
+   "holders": [
+    {
+     "qid": "Q3176299",
+     "start": "2015-02-18",
+     "end": "2020-02-18",
+     "label": "Kolinda Grabar-Kitarovi\u0107"
+    },
+    {
+     "qid": "Q57687",
+     "start": "2020-02-19",
+     "end": null,
+     "label": "Zoran Milanovi\u0107"
+    }
+   ],
+   "office_label": "President of Croatia"
+  },
+  {
+   "office": "Q312271",
+   "holders": [
+    {
+     "qid": "Q4164146",
+     "start": "2016-12-23",
+     "end": "2020-12-24",
+     "label": "Igor Dodon"
+    },
+    {
+     "qid": "Q15071069",
+     "start": "2020-12-24",
+     "end": null,
+     "label": "Maia Sandu"
+    }
+   ],
+   "office_label": "President of Moldova"
+  },
+  {
+   "office": "Q313383",
+   "holders": [
+    {
+     "qid": "Q16845347",
+     "start": "2017-07-25",
+     "end": "2022-07-25",
+     "label": "Ram Nath Kovind"
+    },
+    {
+     "qid": "Q19901232",
+     "start": "2022-07-25",
+     "end": null,
+     "label": "Droupadi Murmu"
+    }
+   ],
+   "office_label": "President of India"
+  },
+  {
+   "office": "Q322459",
+   "holders": [
+    {
+     "qid": "Q6756617",
+     "start": "2016-03-09",
+     "end": "2026-03-09",
+     "label": "Marcelo Rebelo de Sousa"
+    },
+    {
+     "qid": "Q1580316",
+     "start": "2026-03-09",
+     "end": null,
+     "label": "Ant\u00f3nio Jos\u00e9 Seguro"
+    }
+   ],
+   "office_label": "President of Portugal"
+  },
+  {
+   "office": "Q332711",
+   "holders": [
+    {
+     "qid": "Q1220",
+     "start": "2006-05-15",
+     "end": "2015-01-14",
+     "label": "Giorgio Napolitano"
+    },
+    {
+     "qid": "Q3956186",
+     "start": "2015-02-03",
+     "end": null,
+     "label": "Sergio Mattarella"
+    }
+   ],
+   "office_label": "President of Italy"
+  },
+  {
+   "office": "Q475658",
+   "holders": [
+    {
+     "qid": "Q11753",
+     "start": "2004-07-08",
+     "end": "2016-07-08",
+     "label": "Heinz Fischer"
+    },
+    {
+     "qid": "Q78869",
+     "start": "2017-01-26",
+     "end": null,
+     "label": "Alexander Van der Bellen"
+    }
+   ],
+   "office_label": "President of Austria"
+  },
+  {
+   "office": "Q495877",
+   "holders": [
+    {
+     "qid": "Q206471",
+     "start": "2012-12-23",
+     "end": "2022-12-22",
+     "label": "Borut Pahor"
+    },
+    {
+     "qid": "Q12797332",
+     "start": "2022-12-22",
+     "end": null,
+     "label": "Nata\u0161a Pirc Musar"
+    }
+   ],
+   "office_label": "President of Slovenia"
+  },
+  {
+   "office": "Q579677",
+   "holders": [
+    {
+     "qid": "Q58077",
+     "start": "2014-06-07",
+     "end": "2019-05-20",
+     "label": "Petro Poroshenko"
+    },
+    {
+     "qid": "Q3874799",
+     "start": "2019-05-20",
+     "end": null,
+     "label": "Volodymyr Zelenskyy"
+    }
+   ],
+   "office_label": "President of Ukraine"
+  },
+  {
+   "office": "Q655407",
+   "holders": [
+    {
+     "qid": "Q15029",
+     "start": "2003-03-15",
+     "end": "2013-03-14",
+     "label": "Hu Jintao"
+    },
+    {
+     "qid": "Q15031",
+     "start": "2013-03-14",
+     "end": null,
+     "label": "Xi Jinping"
+    }
+   ],
+   "office_label": "President of the People's Republic of China"
+  },
+  {
+   "office": "Q678492",
+   "holders": [
+    {
+     "qid": "Q15967423",
+     "start": "2019-05-12",
+     "end": "2024-05-12",
+     "label": "Stevo Pendarovski"
+    },
+    {
+     "qid": "Q12277168",
+     "start": "2024-05-12",
+     "end": null,
+     "label": "Gordana Siljanovska-Davkova"
+    }
+   ],
+   "office_label": "President of North Macedonia"
+  },
+  {
+   "office": "Q685925",
+   "holders": [
+    {
+     "qid": "Q5230470",
+     "start": "2015-05-16",
+     "end": "2020-08-02",
+     "label": "David A. Granger"
+    },
+    {
+     "qid": "Q64840184",
+     "start": "2020-08-02",
+     "end": null,
+     "label": "Irfaan Ali"
+    }
+   ],
+   "office_label": "President of Guyana"
+  },
+  {
+   "office": "Q756265",
+   "holders": [
+    {
+     "qid": "Q9122260",
+     "start": "2017-07-10",
+     "end": "2021-06-25",
+     "label": "Khaltmaagiin Battulga"
+    },
+    {
+     "qid": "Q27058418",
+     "start": "2021-07-10",
+     "end": null,
+     "label": "Khurelsukh Ukhnaa"
+    }
+   ],
+   "office_label": "President of Mongolia"
+  },
+  {
+   "office": "Q796593",
+   "holders": [
+    {
+     "qid": "Q1508402",
+     "start": "2019-04-04",
+     "end": "2024-04-04",
+     "label": "George William Vella"
+    },
+    {
+     "qid": "Q1647394",
+     "start": "2024-04-04",
+     "end": null,
+     "label": "Myriam Spiteri Debono"
+    }
+   ],
+   "office_label": "President of Malta"
+  },
+  {
+   "office": "Q839139",
+   "holders": [
+    {
+     "qid": "Q18538164",
+     "start": "2025-02-12",
+     "end": "2025-05-26",
+     "label": "Ilie Bolojan"
+    },
+    {
+     "qid": "Q11163124",
+     "start": "2025-05-26",
+     "end": null,
+     "label": "Nicu\u0219or Dan"
+    }
+   ],
+   "office_label": "president of Romania"
+  },
+  {
+   "office": "Q843405",
+   "holders": [
+    {
+     "qid": "Q272416",
+     "start": "2018-12-16",
+     "end": "2024-12-29",
+     "label": "Salome Zourabichvili"
+    },
+    {
+     "qid": "Q711893",
+     "start": "2024-12-29",
+     "end": null,
+     "label": "Mikheil Kavelashvili"
+    }
+   ],
+   "office_label": "President of Georgia"
+  },
+  {
+   "office": "Q878217",
+   "holders": [
+    {
+     "qid": "Q55863225",
+     "start": "2022-07-06",
+     "end": "2022-07-23",
+     "label": "Seoule Simeon"
+    },
+    {
+     "qid": "Q113239716",
+     "start": "2022-07-23",
+     "end": null,
+     "label": "Nikenike Vurobaravu"
+    }
+   ],
+   "office_label": "President of Vanuatu"
+  },
+  {
+   "office": "Q878222",
+   "holders": [
+    {
+     "qid": "Q57379",
+     "start": "2009-07-12",
+     "end": "2019-07-12",
+     "label": "Dalia Grybauskait\u0117"
+    },
+    {
+     "qid": "Q9268379",
+     "start": "2019-07-12",
+     "end": null,
+     "label": "Gitanas Naus\u0117da"
+    }
+   ],
+   "office_label": "President of the Republic of Lithuania"
+  },
+  {
+   "office": "Q889830",
+   "holders": [
+    {
+     "qid": "Q57431",
+     "start": "2012-05-31",
+     "end": "2017-05-31",
+     "label": "Tomislav Nikoli\u0107"
+    },
+    {
+     "qid": "Q222031",
+     "start": "2017-05-31",
+     "end": null,
+     "label": "Aleksandar Vu\u010di\u0107"
+    }
+   ],
+   "office_label": "President of Serbia"
+  },
+  {
+   "office": "Q890005",
+   "holders": [
+    {
+     "qid": "Q12366816",
+     "start": "2016-10-10",
+     "end": "2021-10-11",
+     "label": "Kersti Kaljulaid"
+    },
+    {
+     "qid": "Q12358575",
+     "start": "2021-10-11",
+     "end": null,
+     "label": "Alar Karis"
+    }
+   ],
+   "office_label": "President of Estonia"
+  },
+  {
+   "office": "Q1054799",
+   "holders": [
+    {
+     "qid": "Q9151911",
+     "start": "2015-08-06",
+     "end": "2025-08-06",
+     "label": "Andrzej Duda"
+    },
+    {
+     "qid": "Q17704749",
+     "start": "2025-08-06",
+     "end": null,
+     "label": "Karol Nawrocki"
+    }
+   ],
+   "office_label": "President of the Republic of Poland"
+  },
+  {
+   "office": "Q1149153",
+   "holders": [
+    {
+     "qid": "Q200305",
+     "start": "2018-05-20",
+     "end": "2023-05-20",
+     "label": "Milo \u0110ukanovi\u0107"
+    },
+    {
+     "qid": "Q104417661",
+     "start": "2023-05-20",
+     "end": null,
+     "label": "Jakov Milatovi\u0107"
+    }
+   ],
+   "office_label": "President of Montenegro"
+  },
+  {
+   "office": "Q1258128",
+   "holders": [
+    {
+     "qid": "Q57523",
+     "start": "2007-06-20",
+     "end": "2017-07-21",
+     "label": "Tufuga Efi"
+    },
+    {
+     "qid": "Q32014514",
+     "start": "2017-07-21",
+     "end": null,
+     "label": "Va'aletoa Sualauvi II"
+    }
+   ],
+   "office_label": "O le Ao o le Malo"
+  },
+  {
+   "office": "Q1294765",
+   "holders": [
+    {
+     "qid": "Q57287",
+     "start": "1991-01-17",
+     "end": "2026-08-28",
+     "label": "Harald V of Norway"
+    },
+    {
+     "qid": "Q165241",
+     "start": "2026-08-28",
+     "end": null,
+     "label": "Haakon VIII"
+    }
+   ],
+   "office_label": "Monarch of Norway"
+  },
+  {
+   "office": "Q1370482",
+   "holders": [
+    {
+     "qid": "Q46809",
+     "start": "2006-07-31",
+     "end": "2018-04-19",
+     "label": "Ra\u00fal Castro"
+    },
+    {
+     "qid": "Q1932603",
+     "start": "2018-04-19",
+     "end": null,
+     "label": "Miguel D\u00edaz-Canel"
+    }
+   ],
+   "office_label": "President of Cuba"
+  },
+  {
+   "office": "Q1625960",
+   "holders": [
+    {
+     "qid": "Q727132",
+     "start": "2017-07-24",
+     "end": "2022-07-24",
+     "label": "Ilir Meta"
+    },
+    {
+     "qid": "Q107422711",
+     "start": "2022-07-24",
+     "end": null,
+     "label": "Bajram Begaj"
+    }
+   ],
+   "office_label": "President of Albania"
+  },
+  {
+   "office": "Q1819381",
+   "holders": [
+    {
+     "qid": "Q29032",
+     "start": "2013-03-08",
+     "end": "2023-03-08",
+     "label": "Milo\u0161 Zeman"
+    },
+    {
+     "qid": "Q2080040",
+     "start": "2023-03-09",
+     "end": null,
+     "label": "Petr Pavel"
+    }
+   ],
+   "office_label": "President of the Czech Republic"
+  },
+  {
+   "office": "Q2914452",
+   "holders": [
+    {
+     "qid": "Q2821079",
+     "start": "2019-04-09",
+     "end": "2019-12-19",
+     "label": "Abd al-Qadir ibn Saleh"
+    },
+    {
+     "qid": "Q2821166",
+     "start": "2019-12-19",
+     "end": null,
+     "label": "Abdelmadjid Tebboune"
+    }
+   ],
+   "office_label": "President of Algeria"
+  },
+  {
+   "office": "Q3409186",
+   "holders": [
+    {
+     "qid": "Q7399685",
+     "start": "2018-10-25",
+     "end": "2024-10-07",
+     "label": "Sahle-Work Zewde"
+    },
+    {
+     "qid": "Q124831090",
+     "start": "2024-10-07",
+     "end": null,
+     "label": "Taye Atske Selassie"
+    }
+   ],
+   "office_label": "President of Ethiopia"
+  },
+  {
+   "office": "Q3409203",
+   "holders": [
+    {
+     "qid": "Q57415743",
+     "start": "2020-03-13",
+     "end": "2025-03-13",
+     "label": "Katerina Sakellaropoulou"
+    },
+    {
+     "qid": "Q20995518",
+     "start": "2025-03-13",
+     "end": null,
+     "label": "Konstantinos Tasoulas"
+    }
+   ],
+   "office_label": "President of Greece"
+  },
+  {
+   "office": "Q4283840",
+   "holders": [
+    {
+     "qid": "Q20513503",
+     "start": "2022-02-01",
+     "end": "2022-03-13",
+     "label": "Alen Simonyan"
+    },
+    {
+     "qid": "Q3553274",
+     "start": "2022-03-13",
+     "end": null,
+     "label": "Vahagn Khachatryan"
+    }
+   ],
+   "office_label": "President of Armenia"
+  },
+  {
+   "office": "Q5256775",
+   "holders": [
+    {
+     "qid": "Q57394",
+     "start": "1991-12-16",
+     "end": "2019-03-20",
+     "label": "N\u016brs\u016bltan Nazarbaev"
+    },
+    {
+     "qid": "Q200881",
+     "start": "2019-03-20",
+     "end": null,
+     "label": "Qasym-Zhomart Toqaev"
+    }
+   ],
+   "office_label": "President of Kazakhstan"
+  },
+  {
+   "office": "Q6468838",
+   "holders": [
+    {
+     "qid": "Q26273268",
+     "start": "2019-06-15",
+     "end": "2024-06-15",
+     "label": "Zuzana \u010caputov\u00e1"
+    },
+    {
+     "qid": "Q17330556",
+     "start": "2024-06-15",
+     "end": null,
+     "label": "Peter Pellegrini"
+    }
+   ],
+   "office_label": "President of Slovakia"
+  },
+  {
+   "office": "Q7466263",
+   "holders": [
+    {
+     "qid": "Q20533811",
+     "start": "2016-09-02",
+     "end": "2016-09-08",
+     "label": "Nigmatilla Yuldashev"
+    },
+    {
+     "qid": "Q57808",
+     "start": "2016-09-08",
+     "end": null,
+     "label": "Shavkat Mirziyoyev"
+    }
+   ],
+   "office_label": "President of Uzbekistan"
+  },
+  {
+   "office": "Q13592862",
+   "holders": [
+    {
+     "qid": "Q3911",
+     "start": "1993-08-09",
+     "end": "2013-07-21",
+     "label": "Albert II of Belgium"
+    },
+    {
+     "qid": "Q155004",
+     "start": "2013-07-21",
+     "end": null,
+     "label": "Philippe of Belgium"
+    }
+   ],
+   "office_label": "King of the Belgians"
+  },
+  {
+   "office": "Q14946265",
+   "holders": [
+    {
+     "qid": "Q26257557",
+     "start": "2017-01-22",
+     "end": "2026-01-23",
+     "label": "Rumen Radev"
+    },
+    {
+     "qid": "Q433338",
+     "start": "2026-01-23",
+     "end": null,
+     "label": "Iliana Iotova"
+    }
+   ],
+   "office_label": "President of Bulgaria"
+  },
+  {
+   "office": "Q15618993",
+   "holders": [
+    {
+     "qid": "Q13593432",
+     "start": "2013-07-03",
+     "end": "2014-06-08",
+     "label": "Adly Mansour"
+    },
+    {
+     "qid": "Q307871",
+     "start": "2014-06-08",
+     "end": null,
+     "label": "Abdel Fattah el-Sisi"
+    }
+   ],
+   "office_label": "President of Egypt"
+  },
+  {
+   "office": "Q19188924",
+   "holders": [
+    {
+     "qid": "Q24045706",
+     "start": "2016-08-01",
+     "end": "2024-07-31",
+     "label": "Gu\u00f0ni J\u00f3hannesson"
+    },
+    {
+     "qid": "Q24494577",
+     "start": "2024-08-01",
+     "end": null,
+     "label": "Halla T\u00f3masd\u00f3ttir"
+    }
+   ],
+   "office_label": "President of Iceland"
+  },
+  {
+   "office": "Q19808790",
+   "holders": [
+    {
+     "qid": "Q57473",
+     "start": "2003-05-12",
+     "end": "2025-05-31",
+     "label": "Joan Enric Vives Sic\u00edlia"
+    },
+    {
+     "qid": "Q93244592",
+     "start": "2025-05-31",
+     "end": null,
+     "label": "Josep-Llu\u00eds Serrano Pentinat"
+    }
+   ],
+   "office_label": "Episcopal Co-Prince"
+  },
+  {
+   "office": "Q42298576",
+   "holders": [
+    {
+     "qid": "Q227716",
+     "start": "2006-09-11",
+     "end": "2012-03-18",
+     "label": "George Tupou V of Tonga"
+    },
+    {
+     "qid": "Q208497",
+     "start": "2012-03-18",
+     "end": null,
+     "label": "Tupou VI of Tonga"
+    }
+   ],
+   "office_label": "Monarch of Tonga"
+  },
+  {
+   "office": "Q56876342",
+   "holders": [
+    {
+     "qid": "Q10665",
+     "start": "1994-07-08",
+     "end": "2011-12-17",
+     "label": "Kim Jong-il"
+    },
+    {
+     "qid": "Q56226",
+     "start": "2011-12-17",
+     "end": null,
+     "label": "Kim Jong-un"
+    }
+   ],
+   "office_label": "Supreme Leader of North Korea"
+  },
+  {
+   "office": "Q76292543",
+   "holders": [
+    {
+     "qid": "Q109012733",
+     "start": "2021-11-12",
+     "end": "2024-11-12",
+     "label": "Wiliame Katonivere"
+    },
+    {
+     "qid": "Q6959729",
+     "start": "2024-11-12",
+     "end": null,
+     "label": "Naiqama Lalabalavu"
+    }
+   ],
+   "office_label": "President of Fiji"
+  },
+  {
+   "office": "Q108857904",
+   "holders": [
+    {
+     "qid": "Q9333540",
+     "start": "2021-11-30",
+     "end": "2025-11-30",
+     "label": "Sandra Mason"
+    },
+    {
+     "qid": "Q107718230",
+     "start": "2025-11-30",
+     "end": null,
+     "label": "Jeffrey Bostic"
+    }
+   ],
+   "office_label": "President of Barbados"
+  },
+  {
+   "office": "Q19546",
+   "holders": [
+    {
+     "qid": "Q450675",
+     "start": "2013-03-13",
+     "end": "2025-04-21",
+     "label": "Pope Francis"
+    },
+    {
+     "qid": "Q6109517",
+     "start": "2025-05-08",
+     "end": null,
+     "label": "Leo XIV"
+    }
+   ],
+   "office_label": "Pope"
+  },
+  {
+   "office": "Q25223",
+   "holders": [
+    {
+     "qid": "Q2538",
+     "start": "2012-03-18",
+     "end": "2017-03-18",
+     "label": "Joachim Gauck"
+    },
+    {
+     "qid": "Q76658",
+     "start": "2017-03-19",
+     "end": null,
+     "label": "Frank-Walter Steinmeier"
+    }
+   ],
+   "office_label": "president of Germany"
+  },
+  {
+   "office": "Q29558",
+   "holders": [
+    {
+     "qid": "Q29207",
+     "start": "2012-03-01",
+     "end": "2024-03-01",
+     "label": "Sauli Niinist\u00f6"
+    },
+    {
+     "qid": "Q503143",
+     "start": "2024-03-01",
+     "end": null,
+     "label": "Alexander Stubb"
+    }
+   ],
+   "office_label": "President of Finland"
+  },
+  {
+   "office": "Q39021",
+   "holders": [
+    {
+     "qid": "Q5642345",
+     "start": "2017-09-14",
+     "end": "2023-09-13",
+     "label": "Halimah Yacob"
+    },
+    {
+     "qid": "Q983752",
+     "start": "2023-09-14",
+     "end": null,
+     "label": "Tharman Shanmugaratnam"
+    }
+   ],
+   "office_label": "President of Singapore"
+  },
+  {
+   "office": "Q153756",
+   "holders": [
+    {
+     "qid": "Q16193958",
+     "start": "2015-10-29",
+     "end": "2023-03-12",
+     "label": "Bidya Devi Bhandari"
+    },
+    {
+     "qid": "Q3183124",
+     "start": "2023-03-13",
+     "end": null,
+     "label": "Ram Chandra Poudel"
+    }
+   ],
+   "office_label": "President of Nepal"
+  },
+  {
+   "office": "Q174156",
+   "holders": [
+    {
+     "qid": "Q15467111",
+     "start": "2019-01-31",
+     "end": "2024-01-30",
+     "label": "Abdullah of Pahang"
+    },
+    {
+     "qid": "Q2657043",
+     "start": "2024-01-31",
+     "end": null,
+     "label": "Ibrahim Iskandar of Johor"
+    }
+   ],
+   "office_label": "Yang di-Pertuan Agong"
+  },
+  {
+   "office": "Q473984",
+   "holders": [
+    {
+     "qid": "Q4790529",
+     "start": "2018-09-09",
+     "end": "2024-03-10",
+     "label": "Arif Alvi"
+    },
+    {
+     "qid": "Q57373",
+     "start": "2024-03-10",
+     "end": null,
+     "label": "Asif Ali Zardari"
+    }
+   ],
+   "office_label": "President of Pakistan"
+  },
+  {
+   "office": "Q500282",
+   "holders": [
+    {
+     "qid": "Q361567",
+     "start": "2015-05-29",
+     "end": "2023-05-29",
+     "label": "Muhammadu Buhari"
+    },
+    {
+     "qid": "Q3510872",
+     "start": "2023-05-29",
+     "end": null,
+     "label": "Bola Tinubu"
+    }
+   ],
+   "office_label": "President of Nigeria"
+  },
+  {
+   "office": "Q602280",
+   "holders": [
+    {
+     "qid": "Q232610",
+     "start": "2007-07-17",
+     "end": "2014-08-13",
+     "label": "Louise Lake-Tack"
+    },
+    {
+     "qid": "Q17566330",
+     "start": "2014-08-14",
+     "end": null,
+     "label": "Rodney Williams"
+    }
+   ],
+   "office_label": "Governor-General of Antigua and Barbuda"
+  },
+  {
+   "office": "Q607982",
+   "holders": [
+    {
+     "qid": "Q57429",
+     "start": "2012-08-16",
+     "end": "2020-08-16",
+     "label": "Danilo Medina"
+    },
+    {
+     "qid": "Q16594097",
+     "start": "2020-08-16",
+     "end": null,
+     "label": "Luis Abinader"
+    }
+   ],
+   "office_label": "President of the Dominican Republic"
+  },
+  {
+   "office": "Q647198",
+   "holders": [
+    {
+     "qid": "Q287100",
+     "start": "2024-02-04",
+     "end": "2025-03-21",
+     "label": "Nangolo Mbumba"
+    },
+    {
+     "qid": "Q527020",
+     "start": "2025-03-21",
+     "end": null,
+     "label": "Netumbo Nandi-Ndaitwah"
+    }
+   ],
+   "office_label": "President of the Republic of Namibia"
+  },
+  {
+   "office": "Q648464",
+   "holders": [
+    {
+     "qid": "Q44329",
+     "start": "2000-07-17",
+     "end": "2024-12-08",
+     "label": "Bashar al-Assad"
+    },
+    {
+     "qid": "Q7934206",
+     "start": "2025-01-29",
+     "end": null,
+     "label": "Ahmed al-Sharaa"
+    }
+   ],
+   "office_label": "President of Syria"
+  },
+  {
+   "office": "Q838380",
+   "holders": [
+    {
+     "qid": "Q5703610",
+     "start": "2024-05-19",
+     "end": "2024-07-28",
+     "label": "Mohammad Mokhber"
+    },
+    {
+     "qid": "Q5933752",
+     "start": "2024-07-28",
+     "end": null,
+     "label": "Masoud Pezeshkian"
+    }
+   ],
+   "office_label": "President of Iran"
+  },
+  {
+   "office": "Q850168",
+   "holders": [
+    {
+     "qid": "Q57298",
+     "start": "2005-08-01",
+     "end": "2015-01-23",
+     "label": "Abdullah of Saudi Arabia"
+    },
+    {
+     "qid": "Q367825",
+     "start": "2015-01-23",
+     "end": null,
+     "label": "Salman bin Abdulaziz Al Saud"
+    }
+   ],
+   "office_label": "King of Saudi Arabia"
+  },
+  {
+   "office": "Q853036",
+   "holders": [
+    {
+     "qid": "Q25597831",
+     "start": "2020-11-14",
+     "end": "2021-01-27",
+     "label": "Talant Mamytov"
+    },
+    {
+     "qid": "Q25597826",
+     "start": "2021-01-28",
+     "end": null,
+     "label": "Sadyr Japarov"
+    }
+   ],
+   "office_label": "President of Kyrgyzstan"
+  },
+  {
+   "office": "Q866680",
+   "holders": [
+    {
+     "qid": "Q10831196",
+     "start": "2024-05-22",
+     "end": "2024-10-21",
+     "label": "T\u00f4 L\u00e2m"
+    },
+    {
+     "qid": "Q18459548",
+     "start": "2024-10-21",
+     "end": null,
+     "label": "L\u01b0\u01a1ng C\u01b0\u1eddng"
+    }
+   ],
+   "office_label": "President of Vietnam"
+  },
+  {
+   "office": "Q878151",
+   "holders": [
+    {
+     "qid": "Q936831",
+     "start": "2014-06-01",
+     "end": "2019-06-01",
+     "label": "Salvador S\u00e1nchez Cer\u00e9n"
+    },
+    {
+     "qid": "Q17712353",
+     "start": "2019-06-01",
+     "end": null,
+     "label": "Nayib buke"
+    }
+   ],
+   "office_label": "President of El Salvador"
+  },
+  {
+   "office": "Q878256",
+   "holders": [
+    {
+     "qid": "Q57480",
+     "start": "2012-02-27",
+     "end": "2022-04-07",
+     "label": "Abdrabbuh Mansour Hadi"
+    },
+    {
+     "qid": "Q12213376",
+     "start": "2022-04-07",
+     "end": null,
+     "label": "Rashad al-Alimi"
+    }
+   ],
+   "office_label": "President of Yemen"
+  },
+  {
+   "office": "Q886947",
+   "holders": [
+    {
+     "qid": "Q5567306",
+     "start": "2021-03-22",
+     "end": "2021-04-04",
+     "label": "Glauk Konjufca"
+    },
+    {
+     "qid": "Q13047644",
+     "start": "2021-04-04",
+     "end": null,
+     "label": "Vjosa Osmani"
+    }
+   ],
+   "office_label": "President of Kosovo"
+  },
+  {
+   "office": "Q886965",
+   "holders": [
+    {
+     "qid": "Q28122455",
+     "start": "2019-07-01",
+     "end": "2024-07-01",
+     "label": "Laurentino Cortizo"
+    },
+    {
+     "qid": "Q108454869",
+     "start": "2024-07-01",
+     "end": null,
+     "label": "Jos\u00e9 Ra\u00fal Mulino"
+    }
+   ],
+   "office_label": "President of Panama"
+  },
+  {
+   "office": "Q887003",
+   "holders": [
+    {
+     "qid": "Q233984",
+     "start": "2016-05-20",
+     "end": "2024-05-19",
+     "label": "Tsai Ing-wen"
+    },
+    {
+     "qid": "Q3847080",
+     "start": "2024-05-20",
+     "end": null,
+     "label": "Lai Ching-te"
+    }
+   ],
+   "office_label": "President of the Republic of China"
+  },
+  {
+   "office": "Q889817",
+   "holders": [
+    {
+     "qid": "Q6496078",
+     "start": "2022-10-13",
+     "end": "2026-04-11",
+     "label": "Abdul Latif Rashid"
+    },
+    {
+     "qid": "Q115579547",
+     "start": "2026-04-12",
+     "end": null,
+     "label": "Nizar Amidi"
+    }
+   ],
+   "office_label": "President of Iraq"
+  },
+  {
+   "office": "Q890010",
+   "holders": [
+    {
+     "qid": "Q57460",
+     "start": "2007-09-17",
+     "end": "2018-04-04",
+     "label": "Ernest Bai Koroma"
+    },
+    {
+     "qid": "Q283829",
+     "start": "2018-04-04",
+     "end": null,
+     "label": "Julius Maada Bio"
+    }
+   ],
+   "office_label": "President of Sierra Leone"
+  },
+  {
+   "office": "Q904139",
+   "holders": [
+    {
+     "qid": "Q470024",
+     "start": "2016-04-20",
+     "end": "2021-03-22",
+     "label": "Bounnhang Vorachit"
+    },
+    {
+     "qid": "Q58323",
+     "start": "2021-03-22",
+     "end": null,
+     "label": "Thongloun Sisoulith"
+    }
+   ],
+   "office_label": "President of Laos"
+  },
+  {
+   "office": "Q955006",
+   "holders": [
+    {
+     "qid": "Q57655",
+     "start": "2022-05-13",
+     "end": "2022-05-14",
+     "label": "Mohammed bin Rashid Al Maktoum"
+    },
+    {
+     "qid": "Q1951896",
+     "start": "2022-05-14",
+     "end": null,
+     "label": "Mohammed Bin Zayed Al Nahyan"
+    }
+   ],
+   "office_label": "President of the United Arab Emirates"
+  },
+  {
+   "office": "Q1044136",
+   "holders": [
+    {
+     "qid": "Q2828958",
+     "start": "1992-09-07",
+     "end": "1992-11-20",
+     "label": "Akbarsho Iskandrov"
+    },
+    {
+     "qid": "Q57366",
+     "start": "1994-11-19",
+     "end": null,
+     "label": "Emomali Rahmon"
+    }
+   ],
+   "office_label": "president of Tajikistan"
+  },
+  {
+   "office": "Q1064606",
+   "holders": [
+    {
+     "qid": "Q55614252",
+     "start": "2018-11-17",
+     "end": "2023-11-17",
+     "label": "Ibrahim Mohamed Solih"
+    },
+    {
+     "qid": "Q116293030",
+     "start": "2023-11-17",
+     "end": null,
+     "label": "Mohamed Muizzu"
+    }
+   ],
+   "office_label": "President of the Maldives"
+  },
+  {
+   "office": "Q1155759",
+   "holders": [
+    {
+     "qid": "Q57530",
+     "start": "2006-12-21",
+     "end": "2022-03-19",
+     "label": "Gurbanguly Berdimuhamedow"
+    },
+    {
+     "qid": "Q51874548",
+     "start": "2022-03-19",
+     "end": null,
+     "label": "Serdar Berdimuhamedow"
+    }
+   ],
+   "office_label": "President of Turkmenistan"
+  },
+  {
+   "office": "Q1209571",
+   "holders": [
+    {
+     "qid": "Q457786",
+     "start": "2016-06-30",
+     "end": "2022-06-30",
+     "label": "Rodrigo Duterte"
+    },
+    {
+     "qid": "Q983324",
+     "start": "2022-06-30",
+     "end": null,
+     "label": "Bongbong Marcos"
+    }
+   ],
+   "office_label": "President of the Philippines"
+  },
+  {
+   "office": "Q1472951",
+   "holders": [
+    {
+     "qid": "Q548609",
+     "start": "2006-02-15",
+     "end": "2009-02-26",
+     "label": "Kenneth O. Hall"
+    },
+    {
+     "qid": "Q109147",
+     "start": "2009-02-26",
+     "end": null,
+     "label": "Patrick Allen"
+    }
+   ],
+   "office_label": "Governor-General of Jamaica"
+  },
+  {
+   "office": "Q2407810",
+   "holders": [
+    {
+     "qid": "Q16669148",
+     "start": "2016-04-06",
+     "end": "2026-05-24",
+     "label": "Patrice Talon"
+    },
+    {
+     "qid": "Q24951128",
+     "start": "2026-05-24",
+     "end": null,
+     "label": "Romuald Wadagni"
+    }
+   ],
+   "office_label": "President of the Republic of Benin"
+  },
+  {
+   "office": "Q2914380",
+   "holders": [
+    {
+     "qid": "Q983402",
+     "start": "2022-07-15",
+     "end": "2024-09-23",
+     "label": "Ranil Wickremesinghe"
+    },
+    {
+     "qid": "Q4777855",
+     "start": "2024-09-23",
+     "end": null,
+     "label": "Anura Kurankan Dissanayake"
+    }
+   ],
+   "office_label": "President of Sri Lanka"
+  },
+  {
+   "office": "Q3286988",
+   "holders": [
+    {
+     "qid": "Q77311543",
+     "start": "2019-12-02",
+     "end": "2024-12-06",
+     "label": "Prithvirajsing Roopun"
+    },
+    {
+     "qid": "Q131403499",
+     "start": "2024-12-07",
+     "end": null,
+     "label": "Dharam Gokhool"
+    }
+   ],
+   "office_label": "President of Mauritius"
+  },
+  {
+   "office": "Q3409199",
+   "holders": [
+    {
+     "qid": "Q57416",
+     "start": "2001-01-26",
+     "end": "2019-01-25",
+     "label": "Joseph Kabila"
+    },
+    {
+     "qid": "Q29032770",
+     "start": "2019-01-25",
+     "end": null,
+     "label": "F\u00e9lix Tshisekedi"
+    }
+   ],
+   "office_label": "President of the Democratic Republic of the Congo"
+  },
+  {
+   "office": "Q6085537",
+   "holders": [
+    {
+     "qid": "Q2134696",
+     "start": "2020-01-14",
+     "end": "2024-01-14",
+     "label": "Alejandro Giammattei"
+    },
+    {
+     "qid": "Q107254030",
+     "start": "2024-01-15",
+     "end": null,
+     "label": "Bernardo Ar\u00e9valo de Le\u00f3n"
+    }
+   ],
+   "office_label": "president of Guatemala"
+  },
+  {
+   "office": "Q6296418",
+   "holders": [
+    {
+     "qid": "Q16090635",
+     "start": "2022-05-10",
+     "end": "2025-04-04",
+     "label": "Yoon Suk Yeol"
+    },
+    {
+     "qid": "Q12612463",
+     "start": "2025-06-04",
+     "end": null,
+     "label": "Lee Jae Myung"
+    }
+   ],
+   "office_label": "President of South Korea"
+  },
+  {
+   "office": "Q7241291",
+   "holders": [
+    {
+     "qid": "Q5018756",
+     "start": "2015-11-05",
+     "end": "2021-03-17",
+     "label": "John Magufuli"
+    },
+    {
+     "qid": "Q16193885",
+     "start": "2021-03-19",
+     "end": null,
+     "label": "Samia Suluhu Hassan"
+    }
+   ],
+   "office_label": "President of Tanzania"
+  },
+  {
+   "office": "Q10353660",
+   "holders": [
+    {
+     "qid": "Q379725",
+     "start": "1992-08-31",
+     "end": "1997-10-25",
+     "label": "Pascal Lissouba"
+    },
+    {
+     "qid": "Q57418",
+     "start": "1997-10-25",
+     "end": null,
+     "label": "Denis Sassou-Nguesso"
+    }
+   ],
+   "office_label": "President of the Republic of the Congo"
+  },
+  {
+   "office": "Q13341442",
+   "holders": [
+    {
+     "qid": "Q8044708",
+     "start": "2022-01-27",
+     "end": "2026-01-27",
+     "label": "Xiomara Castro"
+    },
+    {
+     "qid": "Q16146159",
+     "start": "2026-01-27",
+     "end": null,
+     "label": "Nasry Asfura"
+    }
+   ],
+   "office_label": "President of Honduras"
+  },
+  {
+   "office": "Q14911897",
+   "holders": [
+    {
+     "qid": "Q3318530",
+     "start": "2019-07-25",
+     "end": "2019-10-23",
+     "label": "Mohamed Ennaceur"
+    },
+    {
+     "qid": "Q16120878",
+     "start": "2019-10-23",
+     "end": null,
+     "label": "Kais Saied"
+    }
+   ],
+   "office_label": "President of Tunisia"
+  },
+  {
+   "office": "Q15710848",
+   "holders": [
+    {
+     "qid": "Q15633683",
+     "start": "2014-01-23",
+     "end": "2016-03-30",
+     "label": "Catherine Samba-Panza"
+    },
+    {
+     "qid": "Q57758",
+     "start": "2016-03-30",
+     "end": null,
+     "label": "Faustin-Archange Touad\u00e9ra"
+    }
+   ],
+   "office_label": "President of the Central African Republic"
+  },
+  {
+   "office": "Q15921518",
+   "holders": [
+    {
+     "qid": "Q57356",
+     "start": "1996-09-29",
+     "end": "2017-01-19",
+     "label": "Yahya Jammeh"
+    },
+    {
+     "qid": "Q27917049",
+     "start": "2017-01-19",
+     "end": null,
+     "label": "Adama Barrow"
+    }
+   ],
+   "office_label": "President of the Gambia"
+  },
+  {
+   "office": "Q15921529",
+   "holders": [
+    {
+     "qid": "Q16202782",
+     "start": "2020-06-28",
+     "end": "2025-10-04",
+     "label": "Lazarus Chakwera"
+    },
+    {
+     "qid": "Q7176020",
+     "start": "2025-10-04",
+     "end": null,
+     "label": "Peter Mutharika"
+    }
+   ],
+   "office_label": "President of Malawi"
+  },
+  {
+   "office": "Q18565665",
+   "holders": [
+    {
+     "qid": "Q5448556",
+     "start": "2015-01-15",
+     "end": "2025-01-15",
+     "label": "Filipe Nyusi"
+    },
+    {
+     "qid": "Q97058466",
+     "start": "2025-01-15",
+     "end": null,
+     "label": "Daniel Chapo"
+    }
+   ],
+   "office_label": "President of Mozambique"
+  },
+  {
+   "office": "Q18985034",
+   "holders": [
+    {
+     "qid": "Q18352991",
+     "start": "2015-01-25",
+     "end": "2021-08-24",
+     "label": "Edgar Lungu"
+    },
+    {
+     "qid": "Q717185",
+     "start": "2021-08-24",
+     "end": null,
+     "label": "Hakainde Hichilema"
+    }
+   ],
+   "office_label": "President of Zambia"
+  },
+  {
+   "office": "Q19056184",
+   "holders": [
+    {
+     "qid": "Q7181212",
+     "start": "2017-11-21",
+     "end": "2017-11-24",
+     "label": "Phelekezela Mphoko"
+    },
+    {
+     "qid": "Q510523",
+     "start": "2017-11-24",
+     "end": null,
+     "label": "Emmerson Mnangagwa"
+    }
+   ],
+   "office_label": "President of Zimbabwe"
+  },
+  {
+   "office": "Q19057726",
+   "holders": [
+    {
+     "qid": "Q471882",
+     "start": "1994-07-19",
+     "end": "2000-03-23",
+     "label": "Pasteur Bizimungu"
+    },
+    {
+     "qid": "Q1231345",
+     "start": "2000-04-22",
+     "end": null,
+     "label": "Paul Kagame"
+    }
+   ],
+   "office_label": "President of Rwanda"
+  },
+  {
+   "office": "Q19057827",
+   "holders": [
+    {
+     "qid": "Q16873213",
+     "start": "2020-06-08",
+     "end": "2020-06-18",
+     "label": "Pascal Nyabenda"
+    },
+    {
+     "qid": "Q27329764",
+     "start": "2020-06-18",
+     "end": null,
+     "label": "\u00c9variste Ndayishimiye"
+    }
+   ],
+   "office_label": "President of Burundi"
+  },
+  {
+   "office": "Q19058289",
+   "holders": [
+    {
+     "qid": "Q709734",
+     "start": "2016-09-03",
+     "end": "2021-10-02",
+     "label": "Evaristo Carvalho"
+    },
+    {
+     "qid": "Q27982047",
+     "start": "2021-10-02",
+     "end": null,
+     "label": "Carlos Vila Nova"
+    }
+   ],
+   "office_label": "President of S\u00e3o Tom\u00e9 and Pr\u00edncipe"
+  },
+  {
+   "office": "Q19058382",
+   "holders": [
+    {
+     "qid": "Q57517",
+     "start": "2011-09-09",
+     "end": "2021-11-09",
+     "label": "Jorge Carlos Fonseca"
+    },
+    {
+     "qid": "Q57649",
+     "start": "2021-11-09",
+     "end": null,
+     "label": "Jos\u00e9 Maria Neves"
+    }
+   ],
+   "office_label": "President of Cape Verde"
+  },
+  {
+   "office": "Q19109718",
+   "holders": [
+    {
+     "qid": "Q57521",
+     "start": "2009-10-16",
+     "end": "2023-08-30",
+     "label": "Ali Bongo Ondimba"
+    },
+    {
+     "qid": "Q122067521",
+     "start": "2023-08-30",
+     "end": null,
+     "label": "Brice Clotaire Oligui Nguema"
+    }
+   ],
+   "office_label": "President of Gabon"
+  },
+  {
+   "office": "Q19116034",
+   "holders": [
+    {
+     "qid": "Q57438",
+     "start": "2012-04-02",
+     "end": "2024-04-02",
+     "label": "Macky Sall"
+    },
+    {
+     "qid": "Q124382437",
+     "start": "2024-04-02",
+     "end": null,
+     "label": "Bassirou Diomaye Faye"
+    }
+   ],
+   "office_label": "President of Senegal"
+  },
+  {
+   "office": "Q19161338",
+   "holders": [
+    {
+     "qid": "Q57363",
+     "start": "2019-01-19",
+     "end": "2025-10-14",
+     "label": "Andry Rajoelina"
+    },
+    {
+     "qid": "Q136500275",
+     "start": "2025-10-14",
+     "end": null,
+     "label": "Michael Randrianirina"
+    }
+   ],
+   "office_label": "President of Madagascar"
+  },
+  {
+   "office": "Q19161825",
+   "holders": [
+    {
+     "qid": "Q173139",
+     "start": "2018-01-22",
+     "end": "2024-01-22",
+     "label": "George Weah"
+    },
+    {
+     "qid": "Q2630483",
+     "start": "2024-01-22",
+     "end": null,
+     "label": "Joseph Boakai"
+    }
+   ],
+   "office_label": "President of Liberia"
+  },
+  {
+   "office": "Q20087535",
+   "holders": [
+    {
+     "qid": "Q2960197",
+     "start": "2013-10-02",
+     "end": "2023-10-02",
+     "label": "Charles Savarin"
+    },
+    {
+     "qid": "Q122208779",
+     "start": "2023-10-02",
+     "end": null,
+     "label": "Sylvanie Burton"
+    }
+   ],
+   "office_label": "president of Dominica"
+  },
+  {
+   "office": "Q20995488",
+   "holders": [
+    {
+     "qid": "Q110666454",
+     "start": "2022-01-24",
+     "end": "2022-09-30",
+     "label": "Paul-Henri Sandaogo Damiba"
+    },
+    {
+     "qid": "Q114341246",
+     "start": "2022-09-30",
+     "end": null,
+     "label": "Ibrahim Traor\u00e9"
+    }
+   ],
+   "office_label": "President of Burkina Faso"
+  },
+  {
+   "office": "Q22001564",
+   "holders": [
+    {
+     "qid": "Q363392",
+     "start": "2016-10-31",
+     "end": "2022-10-30",
+     "label": "Michel Aoun"
+    },
+    {
+     "qid": "Q29033962",
+     "start": "2025-01-09",
+     "end": null,
+     "label": "Joseph Aoun"
+    }
+   ],
+   "office_label": "President of Lebanon"
+  },
+  {
+   "office": "Q25711499",
+   "holders": [
+    {
+     "qid": "Q57360",
+     "start": "1995-06-26",
+     "end": "2013-06-25",
+     "label": "Hamad bin Khalifa Al Thani"
+    },
+    {
+     "qid": "Q1855372",
+     "start": "2013-06-25",
+     "end": null,
+     "label": "Tamim bin Hamad Al Thani"
+    }
+   ],
+   "office_label": "Emir of the State of Qatar"
+  },
+  {
+   "office": "Q28002551",
+   "holders": [
+    {
+     "qid": "Q294969",
+     "start": "2009-08-05",
+     "end": "2019-08-01",
+     "label": "Mohamed Ould Abdel Aziz"
+    },
+    {
+     "qid": "Q12241106",
+     "start": "2019-08-01",
+     "end": null,
+     "label": "Mohamed Ould Ghazouani"
+    }
+   ],
+   "office_label": "President of Mauritania"
+  },
+  {
+   "office": "Q28015452",
+   "holders": [
+    {
+     "qid": "Q28370112",
+     "start": "2019-02-13",
+     "end": "2019-04-03",
+     "label": "Moustadroine Abdou"
+    },
+    {
+     "qid": "Q515602",
+     "start": "2019-05-26",
+     "end": null,
+     "label": "Azali Assoumani"
+    }
+   ],
+   "office_label": "President of Comoros"
+  },
+  {
+   "office": "Q28015461",
+   "holders": [
+    {
+     "qid": "Q16855164",
+     "start": "2020-01-03",
+     "end": "2025-11-26",
+     "label": "Umaro Sissoco Embal\u00f3"
+    },
+    {
+     "qid": "Q137049690",
+     "start": "2025-11-27",
+     "end": null,
+     "label": "Horta Inta-A Na Man"
+    }
+   ],
+   "office_label": "President of Guinea-Bissau"
+  },
+  {
+   "office": "Q28015471",
+   "holders": [
+    {
+     "qid": "Q4414",
+     "start": "2005-05-04",
+     "end": "2025-05-03",
+     "label": "Faure Essozimna Gnassingb\u00e9"
+    },
+    {
+     "qid": "Q6169516",
+     "start": "2025-05-03",
+     "end": null,
+     "label": "Jean-Lucien Savi de Tov\u00e9"
+    }
+   ],
+   "office_label": "President of Togo"
+  },
+  {
+   "office": "Q28015517",
+   "holders": [
+    {
+     "qid": "Q4413",
+     "start": "2010-12-21",
+     "end": "2021-09-05",
+     "label": "Alpha Cond\u00e9"
+    },
+    {
+     "qid": "Q108418519",
+     "start": "2021-10-01",
+     "end": null,
+     "label": "Mamady Doumbouya"
+    }
+   ],
+   "office_label": "President of Guinea"
+  },
+  {
+   "office": "Q47006779",
+   "holders": [
+    {
+     "qid": "Q99522144",
+     "start": "2020-09-25",
+     "end": "2021-05-24",
+     "label": "Bah Ndaw"
+    },
+    {
+     "qid": "Q98497406",
+     "start": "2021-05-24",
+     "end": null,
+     "label": "Assimi Go\u00efta"
+    }
+   ],
+   "office_label": "President of Mali"
+  },
+  {
+   "office": "Q100877419",
+   "holders": [
+    {
+     "qid": "Q641805",
+     "start": "2020-09-29",
+     "end": "2023-12-16",
+     "label": "Nawaf Al-Ahmad Al-Jaber Al-Sabah"
+    },
+    {
+     "qid": "Q12243161",
+     "start": "2023-12-16",
+     "end": null,
+     "label": "Mishal Al-Ahmad Al-Jaber Al-Sabah"
+    }
+   ],
+   "office_label": "emir of Kuwait"
+  },
+  {
+   "office": "Q102181806",
+   "holders": [
+    {
+     "qid": "Q21089561",
+     "start": "2016-03-30",
+     "end": "2021-03-15",
+     "label": "Fayez al-Sarraj"
+    },
+    {
+     "qid": "Q105319610",
+     "start": "2021-03-15",
+     "end": null,
+     "label": "Mohamed al-Menfi"
+    }
+   ],
+   "office_label": "Chairman of the Presidential Council"
+  },
+  {
+   "office": "Q108130107",
+   "holders": [
+    {
+     "qid": "Q2829007",
+     "start": "2015-07-29",
+     "end": "2016-05-21",
+     "label": "Akhtar Mansour"
+    },
+    {
+     "qid": "Q24237654",
+     "start": "2021-08-15",
+     "end": null,
+     "label": "Hibatullah Akhundzada"
+    }
+   ],
+   "office_label": "Supreme Leader of Afghanistan"
+  },
+  {
+   "office": "Q116102",
+   "holders": [
+    {
+     "qid": "Q30323682",
+     "start": "2020-06-03",
+     "end": "2021-03-22",
+     "label": "Avdullah Hoti"
+    },
+    {
+     "qid": "Q441633",
+     "start": "2021-03-22",
+     "end": null,
+     "label": "Albin Kurti"
+    }
+   ],
+   "office_label": "Prime Minister of Kosovo"
+  },
+  {
+   "office": "Q208487",
+   "holders": [
+    {
+     "qid": "Q1396120",
+     "start": "2022-07-01",
+     "end": "2022-12-29",
+     "label": "Yair Lapid"
+    },
+    {
+     "qid": "Q43723",
+     "start": "2022-12-29",
+     "end": null,
+     "label": "Benjamin Netanyahu"
+    }
+   ],
+   "office_label": "Prime Minister of Israel"
+  },
+  {
+   "office": "Q532240",
+   "holders": [
+    {
+     "qid": "Q4665452",
+     "start": "2023-05-17",
+     "end": "2023-07-17",
+     "label": "Abdul Kabir"
+    },
+    {
+     "qid": "Q108444479",
+     "start": "2023-07-17",
+     "end": null,
+     "label": "Mohammad Hasan Akhund"
+    }
+   ],
+   "office_label": "Prime Minister of Afghanistan"
+  },
+  {
+   "office": "Q565424",
+   "holders": [
+    {
+     "qid": "Q16732648",
+     "start": "2017-05-11",
+     "end": "2021-09-17",
+     "label": "Hubert Minnis"
+    },
+    {
+     "qid": "Q7183082",
+     "start": "2021-09-17",
+     "end": null,
+     "label": "Philip \"Brave\" Davis"
+    }
+   ],
+   "office_label": "Prime Minister of the Bahamas"
+  },
+  {
+   "office": "Q663871",
+   "holders": [
+    {
+     "qid": "Q57313851",
+     "start": "2018-11-07",
+     "end": "2023-11-01",
+     "label": "Lotay Tshering"
+    },
+    {
+     "qid": "Q7849613",
+     "start": "2024-01-28",
+     "end": null,
+     "label": "Tshering Tobgay"
+    }
+   ],
+   "office_label": "Prime Minister of Bhutan"
+  },
+  {
+   "office": "Q735575",
+   "holders": [
+    {
+     "qid": "Q155164",
+     "start": "2018-08-18",
+     "end": "2022-04-10",
+     "label": "Imran Khan"
+    },
+    {
+     "qid": "Q2096387",
+     "start": "2022-04-11",
+     "end": null,
+     "label": "Shehbaz Sharif"
+    }
+   ],
+   "office_label": "Prime Minister of Pakistan"
+  },
+  {
+   "office": "Q778651",
+   "holders": [
+    {
+     "qid": "Q7180477",
+     "start": "2021-03-22",
+     "end": "2022-12-30",
+     "label": "Phankham Viphavanh"
+    },
+    {
+     "qid": "Q104914585",
+     "start": "2022-12-30",
+     "end": null,
+     "label": "Sonexay Siphandone"
+    }
+   ],
+   "office_label": "Prime Minister of Laos"
+  },
+  {
+   "office": "Q795477",
+   "holders": [
+    {
+     "qid": "Q182397",
+     "start": "2015-06-28",
+     "end": "2019-06-27",
+     "label": "Lars L\u00f8kke Rasmussen"
+    },
+    {
+     "qid": "Q5015",
+     "start": "2019-06-27",
+     "end": null,
+     "label": "Mette Frederiksen"
+    }
+   ],
+   "office_label": "Prime Minister of Denmark"
+  },
+  {
+   "office": "Q862559",
+   "holders": [
+    {
+     "qid": "Q6084858",
+     "start": "2021-08-21",
+     "end": "2022-11-24",
+     "label": "Ismail Sabri Yaakob"
+    },
+    {
+     "qid": "Q299574",
+     "start": "2022-11-24",
+     "end": null,
+     "label": "Anwar Ibrahim"
+    }
+   ],
+   "office_label": "Prime Minister of Malaysia"
+  },
+  {
+   "office": "Q1064106",
+   "holders": [
+    {
+     "qid": "Q128723414",
+     "start": "2024-08-08",
+     "end": "2025-03-21",
+     "label": "Kamel Madouri"
+    },
+    {
+     "qid": "Q108892374",
+     "start": "2025-03-21",
+     "end": null,
+     "label": "Sarra Zaafrani"
+    }
+   ],
+   "office_label": "Prime Minister of Tunisia"
+  },
+  {
+   "office": "Q1064589",
+   "holders": [
+    {
+     "qid": "Q114735638",
+     "start": "2024-02-25",
+     "end": "2024-04-30",
+     "label": "Michel Patrick Boisvert"
+    },
+    {
+     "qid": "Q131140314",
+     "start": "2024-11-11",
+     "end": null,
+     "label": "Alix Didier Fils-Aim\u00e9"
+    }
+   ],
+   "office_label": "Prime Minister of Haiti"
+  },
+  {
+   "office": "Q1153839",
+   "holders": [
+    {
+     "qid": "Q367825",
+     "start": "2015-01-23",
+     "end": "2022-09-27",
+     "label": "Salman bin Abdulaziz Al Saud"
+    },
+    {
+     "qid": "Q6892571",
+     "start": "2022-09-27",
+     "end": null,
+     "label": "Mohammed bin Salman Al Saud"
+    }
+   ],
+   "office_label": "Prime Minister of Saudi Arabia"
+  },
+  {
+   "office": "Q1192903",
+   "holders": [
+    {
+     "qid": "Q68837007",
+     "start": "2025-05-03",
+     "end": "2026-01-15",
+     "label": "Salem Saleh bin Braik"
+    },
+    {
+     "qid": "Q7460973",
+     "start": "2026-02-06",
+     "end": null,
+     "label": "Shaea al-Zindani"
+    }
+   ],
+   "office_label": "Prime Minister of Yemen"
+  },
+  {
+   "office": "Q1333976",
+   "holders": [
+    {
+     "qid": "Q7395683",
+     "start": "2015-03-21",
+     "end": "2025-03-21",
+     "label": "Saara Kuugongelwa"
+    },
+    {
+     "qid": "Q5360975",
+     "start": "2025-03-21",
+     "end": null,
+     "label": "Elijah Ngurare"
+    }
+   ],
+   "office_label": "Prime Minister of the Republic of Namibia"
+  },
+  {
+   "office": "Q1335939",
+   "holders": [
+    {
+     "qid": "Q99605101",
+     "start": "2020-09-23",
+     "end": "2022-06-26",
+     "label": "Mohamed Hussein Roble"
+    },
+    {
+     "qid": "Q112598575",
+     "start": "2022-06-26",
+     "end": null,
+     "label": "Hamza Abdi Barre"
+    }
+   ],
+   "office_label": "Prime Minister of Somalia"
+  },
+  {
+   "office": "Q1430943",
+   "holders": [
+    {
+     "qid": "Q57597",
+     "start": "2012-01-05",
+     "end": "2016-03-03",
+     "label": "Portia Simpson-Miller"
+    },
+    {
+     "qid": "Q505200",
+     "start": "2016-03-03",
+     "end": null,
+     "label": "Andrew Holness"
+    }
+   ],
+   "office_label": "Prime Minister of Jamaica"
+  },
+  {
+   "office": "Q2462330",
+   "holders": [
+    {
+     "qid": "Q1740843",
+     "start": "2014-09-18",
+     "end": "2021-06-21",
+     "label": "Ruhakana Rugunda"
+    },
+    {
+     "qid": "Q62481397",
+     "start": "2021-06-21",
+     "end": null,
+     "label": "Nabbanja Robinah"
+    }
+   ],
+   "office_label": "Prime Minister of Uganda"
+  },
+  {
+   "office": "Q2590706",
+   "holders": [
+    {
+     "qid": "Q38188115",
+     "start": "2017-08-30",
+     "end": "2025-07-25",
+     "label": "\u00c9douard Ngirente"
+    },
+    {
+     "qid": "Q135454730",
+     "start": "2025-07-25",
+     "end": null,
+     "label": "Justin Nsengiyumva"
+    }
+   ],
+   "office_label": "Prime Minister of Rwanda"
+  },
+  {
+   "office": "Q2734978",
+   "holders": [
+    {
+     "qid": "Q57754",
+     "start": "1999-12-20",
+     "end": "2013-11-23",
+     "label": "Oqil Oqilov"
+    },
+    {
+     "qid": "Q15222839",
+     "start": "2013-11-23",
+     "end": null,
+     "label": "Kokhir Rasulzoda"
+    }
+   ],
+   "office_label": "Prime Minister of Tajikistan"
+  },
+  {
+   "office": "Q3058109",
+   "holders": [
+    {
+     "qid": "Q22338116",
+     "start": "2024-07-02",
+     "end": "2026-02-23",
+     "label": "Dick Schoof"
+    },
+    {
+     "qid": "Q28860866",
+     "start": "2026-02-23",
+     "end": null,
+     "label": "Rob Jetten"
+    }
+   ],
+   "office_label": "Prime Minister of the Netherlands"
+  },
+  {
+   "office": "Q3401753",
+   "holders": [
+    {
+     "qid": "Q105523479",
+     "start": "2021-04-26",
+     "end": "2024-06-12",
+     "label": "Jean-Michel Sama Lukonde Kyenge"
+    },
+    {
+     "qid": "Q117472023",
+     "start": "2024-06-12",
+     "end": null,
+     "label": "Judith Suminwa"
+    }
+   ],
+   "office_label": "Prime Minister of the Democratic Republic of the Congo"
+  },
+  {
+   "office": "Q3401763",
+   "holders": [
+    {
+     "qid": "Q3369176",
+     "start": "2021-03-08",
+     "end": "2023-10-06",
+     "label": "Patrick Achi"
+    },
+    {
+     "qid": "Q3434569",
+     "start": "2023-10-16",
+     "end": null,
+     "label": "Robert Beugr\u00e9 Mamb\u00e9"
+    }
+   ],
+   "office_label": "Prime Minister of Ivory Coast"
+  },
+  {
+   "office": "Q7243300",
+   "holders": [
+    {
+     "qid": "Q63441935",
+     "start": "2020-10-07",
+     "end": "2024-09-15",
+     "label": "Bisher Al-Khasawneh"
+    },
+    {
+     "qid": "Q97011032",
+     "start": "2024-09-18",
+     "end": null,
+     "label": "Jafar Hassan"
+    }
+   ],
+   "office_label": "Prime Minister of Jordan"
+  },
+  {
+   "office": "Q12376089",
+   "holders": [
+    {
+     "qid": "Q13018661",
+     "start": "2025-07-03",
+     "end": "2025-09-07",
+     "label": "Phumtham Wechayachai"
+    },
+    {
+     "qid": "Q16139757",
+     "start": "2025-09-07",
+     "end": null,
+     "label": "Anutin Charnvirakul"
+    }
+   ],
+   "office_label": "Prime Minister of Thailand"
+  },
+  {
+   "office": "Q14565638",
+   "holders": [
+    {
+     "qid": "Q52183",
+     "start": "2009-01-06",
+     "end": "2024-08-05",
+     "label": "Sheikh Hasina"
+    },
+    {
+     "qid": "Q7686199",
+     "start": "2026-02-17",
+     "end": null,
+     "label": "Tarique Rahman"
+    }
+   ],
+   "office_label": "Prime Minister of Bangladesh"
+  },
+  {
+   "office": "Q14915225",
+   "holders": [
+    {
+     "qid": "Q318493",
+     "start": "2021-09-10",
+     "end": "2025-02-08",
+     "label": "Mohamed Agha"
+    },
+    {
+     "qid": "Q638463",
+     "start": "2025-02-08",
+     "end": null,
+     "label": "Nawaf Salam"
+    }
+   ],
+   "office_label": "Prime Minister of Lebanon"
+  },
+  {
+   "office": "Q14917303",
+   "holders": [
+    {
+     "qid": "Q109296984",
+     "start": "2022-08-20",
+     "end": "2024-02-19",
+     "label": "Bernard Goumou"
+    },
+    {
+     "qid": "Q22209348",
+     "start": "2024-02-27",
+     "end": null,
+     "label": "Bah Oury"
+    }
+   ],
+   "office_label": "Prime Minister of Guinea"
+  },
+  {
+   "office": "Q17051823",
+   "holders": [
+    {
+     "qid": "Q57840",
+     "start": "2009-06-30",
+     "end": "2019-01-04",
+     "label": "Phil\u00e9mon Yang"
+    },
+    {
+     "qid": "Q60441515",
+     "start": "2019-01-04",
+     "end": null,
+     "label": "Joseph Ngute"
+    }
+   ],
+   "office_label": "Prime Minister of Cameroon"
+  },
+  {
+   "office": "Q19842743",
+   "holders": [
+    {
+     "qid": "Q2033385",
+     "start": "2017-04-05",
+     "end": "2021-10-07",
+     "label": "Saadeddine Othmani"
+    },
+    {
+     "qid": "Q1638114",
+     "start": "2021-10-07",
+     "end": null,
+     "label": "Aziz Akhannouch"
+    }
+   ],
+   "office_label": "Prime Minister of Morocco"
+  },
+  {
+   "office": "Q20682527",
+   "holders": [
+    {
+     "qid": "Q57602",
+     "start": "2004-03-24",
+     "end": "2014-06-13",
+     "label": "Baldwin Spencer"
+    },
+    {
+     "qid": "Q17177542",
+     "start": "2014-06-13",
+     "end": null,
+     "label": "Gaston Browne"
+    }
+   ],
+   "office_label": "Prime Minister of Antigua and Barbuda"
+  },
+  {
+   "office": "Q23782691",
+   "holders": [
+    {
+     "qid": "Q136448305",
+     "start": "2025-10-06",
+     "end": "2025-10-20",
+     "label": "Ruphin Zafisambo"
+    },
+    {
+     "qid": "Q136542212",
+     "start": "2025-10-20",
+     "end": null,
+     "label": "Herintsalama Rajaonarivelo"
+    }
+   ],
+   "office_label": "Prime Minister of Madagascar"
+  },
+  {
+   "office": "Q28133105",
+   "holders": [
+    {
+     "qid": "Q114835874",
+     "start": "2022-10-21",
+     "end": "2024-12-06",
+     "label": "Apollinaire Joachim Ky\u00e9lem de Tamb\u00e8la"
+    },
+    {
+     "qid": "Q116056730",
+     "start": "2024-12-07",
+     "end": null,
+     "label": "Jean Emmanuel Ou\u00e9draogo"
+    }
+   ],
+   "office_label": "Prime Minister of Burkina Faso"
+  },
+  {
+   "office": "Q30100568",
+   "holders": [
+    {
+     "qid": "Q23899522",
+     "start": "2016-04-22",
+     "end": "2026-06-19",
+     "label": "Ulisses Correia e Silva"
+    },
+    {
+     "qid": "Q139594211",
+     "start": "2026-06-19",
+     "end": null,
+     "label": "Francisco Carvalho"
+    }
+   ],
+   "office_label": "Prime Minister of Cabo Verde"
+  },
+  {
+   "office": "Q30100591",
+   "holders": [
+    {
+     "qid": "Q57683",
+     "start": "2001-03-07",
+     "end": "2013-04-01",
+     "label": "Dileita Mohamed Dileita"
+    },
+    {
+     "qid": "Q10522744",
+     "start": "2013-04-01",
+     "end": null,
+     "label": "Abdoulkader Kamil Mohamed"
+    }
+   ],
+   "office_label": "Prime Minister of Djibouti"
+  },
+  {
+   "office": "Q30100607",
+   "holders": [
+    {
+     "qid": "Q98841301",
+     "start": "2023-01-09",
+     "end": "2023-08-30",
+     "label": "Alain Claude Bilie-By-Nze"
+    },
+    {
+     "qid": "Q57856",
+     "start": "2023-09-08",
+     "end": null,
+     "label": "Raymond Ndong Sima"
+    }
+   ],
+   "office_label": "Prime Minister of Gabon"
+  },
+  {
+   "office": "Q30100613",
+   "holders": [
+    {
+     "qid": "Q370110",
+     "start": "2013-02-20",
+     "end": "2022-06-24",
+     "label": "Keith Mitchell"
+    },
+    {
+     "qid": "Q112679881",
+     "start": "2022-06-24",
+     "end": null,
+     "label": "Dickon Mitchell"
+    }
+   ],
+   "office_label": "Prime Minister of Grenada"
+  },
+  {
+   "office": "Q30100626",
+   "holders": [
+    {
+     "qid": "Q23842116",
+     "start": "2025-09-12",
+     "end": "2026-03-27",
+     "label": "Sushila Karki"
+    },
+    {
+     "qid": "Q111772343",
+     "start": "2026-03-27",
+     "end": null,
+     "label": "Balendra Shah"
+    }
+   ],
+   "office_label": "Prime Minister of Nepal"
+  },
+  {
+   "office": "Q30100634",
+   "holders": [
+    {
+     "qid": "Q7110324",
+     "start": "2021-04-03",
+     "end": "2023-07-26",
+     "label": "Ouhoumoudou Mahamadou"
+    },
+    {
+     "qid": "Q2646711",
+     "start": "2023-08-08",
+     "end": null,
+     "label": "Ali Lamine Zeine"
+    }
+   ],
+   "office_label": "Prime Minister of Niger"
+  },
+  {
+   "office": "Q30100647",
+   "holders": [
+    {
+     "qid": "Q83849153",
+     "start": "2020-01-28",
+     "end": "2023-03-07",
+     "label": "Khalid bin Khalifa bin Abdul Aziz Al Thani"
+    },
+    {
+     "qid": "Q23020336",
+     "start": "2023-03-07",
+     "end": null,
+     "label": "Mohammed bin Abdulrahman Al Thani"
+    }
+   ],
+   "office_label": "Prime Minister of Qatar"
+  },
+  {
+   "office": "Q30100649",
+   "holders": [
+    {
+     "qid": "Q3327520",
+     "start": "2024-01-17",
+     "end": "2024-05-15",
+     "label": "Mohammad Sabah Al-Salem Al-Sabah"
+    },
+    {
+     "qid": "Q16151955",
+     "start": "2024-05-15",
+     "end": null,
+     "label": "Ahmad Al Abdullah Al Sabah"
+    }
+   ],
+   "office_label": "Prime Minister of Kuwait"
+  },
+  {
+   "office": "Q30100661",
+   "holders": [
+    {
+     "qid": "Q16682496",
+     "start": "2020-09-28",
+     "end": "2025-05-03",
+     "label": "Victoire Dogb\u00e9 Tomegah"
+    },
+    {
+     "qid": "Q4414",
+     "start": "2025-05-03",
+     "end": null,
+     "label": "Faure Essozimna Gnassingb\u00e9"
+    }
+   ],
+   "office_label": "President of the Council of Ministers of Togo"
+  },
+  {
+   "office": "Q30101336",
+   "holders": [
+    {
+     "qid": "Q3529064",
+     "start": "2015-02-18",
+     "end": "2022-08-06",
+     "label": "Timothy Harris"
+    },
+    {
+     "qid": "Q113443525",
+     "start": "2022-08-06",
+     "end": null,
+     "label": "Terrance Drew"
+    }
+   ],
+   "office_label": "Prime Minister of St Kitts and Nevis"
+  },
+  {
+   "office": "Q30101433",
+   "holders": [
+    {
+     "qid": "Q16203640",
+     "start": "2016-06-07",
+     "end": "2021-07-26",
+     "label": "Allen Chastanet"
+    },
+    {
+     "qid": "Q7184214",
+     "start": "2021-07-28",
+     "end": null,
+     "label": "Philip J. Pierre"
+    }
+   ],
+   "office_label": "Prime Minister of Saint Lucia"
+  },
+  {
+   "office": "Q30101440",
+   "holders": [
+    {
+     "qid": "Q107600891",
+     "start": "2021-07-16",
+     "end": "2023-09-28",
+     "label": "Cleopas Dlamini"
+    },
+    {
+     "qid": "Q123342092",
+     "start": "2023-11-04",
+     "end": null,
+     "label": "Edeupa Yerimin"
+    }
+   ],
+   "office_label": "Prime Minister of Eswatini"
+  },
+  {
+   "office": "Q30101454",
+   "holders": [
+    {
+     "qid": "Q91621859",
+     "start": "2020-05-20",
+     "end": "2022-10-28",
+     "label": "Moeketsi Majoro"
+    },
+    {
+     "qid": "Q114588964",
+     "start": "2022-10-28",
+     "end": null,
+     "label": "Sam Matekane"
+    }
+   ],
+   "office_label": "Prime Minister of Lesotho"
+  },
+  {
+   "office": "Q30101458",
+   "holders": [
+    {
+     "qid": "Q86715481",
+     "start": "2020-02-28",
+     "end": "2023-08-07",
+     "label": "Nuno Nabiam"
+    },
+    {
+     "qid": "Q627337",
+     "start": "2023-12-21",
+     "end": null,
+     "label": "Rui Duarte de Barros"
+    }
+   ],
+   "office_label": "Prime Minister of Guinea-Bissau"
+  },
+  {
+   "office": "Q30101469",
+   "holders": [
+    {
+     "qid": "Q98137599",
+     "start": "2020-08-06",
+     "end": "2024-08-02",
+     "label": "Mohamed Ould Bilal"
+    },
+    {
+     "qid": "Q66793577",
+     "start": "2024-08-02",
+     "end": null,
+     "label": "Moctar Ould Djay"
+    }
+   ],
+   "office_label": "Prime Minister of Mauritania"
+  },
+  {
+   "office": "Q30101519",
+   "holders": [
+    {
+     "qid": "Q215477",
+     "start": "1990-10-07",
+     "end": "2006-01-04",
+     "label": "Maktoum bin Rashid Al Maktoum"
+    },
+    {
+     "qid": "Q57655",
+     "start": "2006-02-11",
+     "end": null,
+     "label": "Mohammed bin Rashid Al Maktoum"
+    }
+   ],
+   "office_label": "Prime Minister of the United Arab Emirates"
+  }
+ ]
+}

--- a/bench/wikidata/fixtures/types.json
+++ b/bench/wikidata/fixtures/types.json
@@ -1,0 +1,452 @@
+{
+ "items": [
+  {
+   "qid": "Q10000001",
+   "label": "Tatyana Kolotilshchikova",
+   "description": "Soviet ballet dancer and teacher (1937\u20132016)",
+   "expected_type": "person",
+   "wikidata_class": "human"
+  },
+  {
+   "qid": "Q1000002",
+   "label": "Claus Hammel",
+   "description": "East German playwright (1932-1990)",
+   "expected_type": "person",
+   "wikidata_class": "human"
+  },
+  {
+   "qid": "Q10000029",
+   "label": "Nikolai Yuryev",
+   "description": "Russian general",
+   "expected_type": "person",
+   "wikidata_class": "human"
+  },
+  {
+   "qid": "Q1000005",
+   "label": "Karel Mat\u011bj \u010capek-Chod",
+   "description": "Czech writer and journalist (1860\u20131927)",
+   "expected_type": "person",
+   "wikidata_class": "human"
+  },
+  {
+   "qid": "Q1000006",
+   "label": "Florian Eichinger",
+   "description": "German film producer and screenwriter",
+   "expected_type": "person",
+   "wikidata_class": "human"
+  },
+  {
+   "qid": "Q100000811",
+   "label": "Paul Mohr",
+   "description": "physician",
+   "expected_type": "person",
+   "wikidata_class": "human"
+  },
+  {
+   "qid": "Q100000831",
+   "label": "Otto Kramer",
+   "description": "classical philologist",
+   "expected_type": "person",
+   "wikidata_class": "human"
+  },
+  {
+   "qid": "Q100000832",
+   "label": "Marie Madeleine Lebreton",
+   "description": "translator, medievalist, latinist (-1978)",
+   "expected_type": "person",
+   "wikidata_class": "human"
+  },
+  {
+   "qid": "Q1000",
+   "label": "Gabon",
+   "description": "country on the Atlantic coast of Central Africa",
+   "expected_type": "location",
+   "wikidata_class": "sovereign state"
+  },
+  {
+   "qid": "Q1005",
+   "label": "The Gambia",
+   "description": "sovereign state in West Africa",
+   "expected_type": "location",
+   "wikidata_class": "sovereign state"
+  },
+  {
+   "qid": "Q1006",
+   "label": "Guinea",
+   "description": "sovereign state in West Africa",
+   "expected_type": "location",
+   "wikidata_class": "sovereign state"
+  },
+  {
+   "qid": "Q1007",
+   "label": "Guinea-Bissau",
+   "description": "sovereign state in Western Africa",
+   "expected_type": "location",
+   "wikidata_class": "sovereign state"
+  },
+  {
+   "qid": "Q1008",
+   "label": "Ivory Coast",
+   "description": "sovereign state in West Africa",
+   "expected_type": "location",
+   "wikidata_class": "sovereign state"
+  },
+  {
+   "qid": "Q1009",
+   "label": "Cameroon",
+   "description": "sovereign state in West-Central Africa",
+   "expected_type": "location",
+   "wikidata_class": "sovereign state"
+  },
+  {
+   "qid": "Q1011",
+   "label": "Cape Verde",
+   "description": "sovereign state comprising ten islands off the Western coast of Africa",
+   "expected_type": "location",
+   "wikidata_class": "sovereign state"
+  },
+  {
+   "qid": "Q1013",
+   "label": "Lesotho",
+   "description": "sovereign state in southern Africa",
+   "expected_type": "location",
+   "wikidata_class": "sovereign state"
+  },
+  {
+   "qid": "Q1000143",
+   "label": "G\u00fcig\u00fce",
+   "description": "Parroquia",
+   "expected_type": "location",
+   "wikidata_class": "city"
+  },
+  {
+   "qid": "Q1000333",
+   "label": "Huancavelica",
+   "description": "capital city of Huancavelica, Peru",
+   "expected_type": "location",
+   "wikidata_class": "city"
+  },
+  {
+   "qid": "Q1000341",
+   "label": "Ilo",
+   "description": "city in Peru",
+   "expected_type": "location",
+   "wikidata_class": "city"
+  },
+  {
+   "qid": "Q1000346",
+   "label": "Moquegua",
+   "description": "city of Peru, capital of Moquegua region",
+   "expected_type": "location",
+   "wikidata_class": "city"
+  },
+  {
+   "qid": "Q1000373",
+   "label": "Mandalgovi",
+   "description": "city in Dundgovi, Mongolia",
+   "expected_type": "location",
+   "wikidata_class": "city"
+  },
+  {
+   "qid": "Q1000438",
+   "label": "Szczawnica",
+   "description": "city of Poland",
+   "expected_type": "location",
+   "wikidata_class": "city"
+  },
+  {
+   "qid": "Q1000495",
+   "label": "Rewa",
+   "description": "city in the state of Madhya Pradesh in India",
+   "expected_type": "location",
+   "wikidata_class": "city"
+  },
+  {
+   "qid": "Q10006",
+   "label": "Hengelo",
+   "description": "city and municipality in Overijssel, the Netherlands",
+   "expected_type": "location",
+   "wikidata_class": "city"
+  },
+  {
+   "qid": "Q100258387",
+   "label": "University Center Nour Bashir (El-Bayadh)",
+   "description": "University in Algeria",
+   "expected_type": "organization",
+   "wikidata_class": "university"
+  },
+  {
+   "qid": "Q100258391",
+   "label": "Universit\u00e9 Chadli Bendjedid d'El Tarf",
+   "description": "university in Algeria",
+   "expected_type": "organization",
+   "wikidata_class": "university"
+  },
+  {
+   "qid": "Q100260373",
+   "label": "Manara University",
+   "description": "Private university in Latakia, Syria",
+   "expected_type": "organization",
+   "wikidata_class": "university"
+  },
+  {
+   "qid": "Q100261338",
+   "label": "Universit\u00e9 Internationale d'Agadir",
+   "description": "university in Morocco",
+   "expected_type": "organization",
+   "wikidata_class": "university"
+  },
+  {
+   "qid": "Q1003463",
+   "label": "Bulacan State University",
+   "description": "state-funded institution of higher learning in Bulacan province, Philippines",
+   "expected_type": "organization",
+   "wikidata_class": "university"
+  },
+  {
+   "qid": "Q100351283",
+   "label": "Zamfara State University",
+   "description": "Public university in Zamfara State, Nigeria",
+   "expected_type": "organization",
+   "wikidata_class": "university"
+  },
+  {
+   "qid": "Q100418692",
+   "label": "Dhammaduta Chekinda University",
+   "description": "Buddhist missionary university in Auk War Nat Chaung village, Myanmar",
+   "expected_type": "organization",
+   "wikidata_class": "university"
+  },
+  {
+   "qid": "Q100452193",
+   "label": "Universit\u00e9 de Ouahigouya",
+   "description": "public university in Burkina Faso",
+   "expected_type": "organization",
+   "wikidata_class": "university"
+  },
+  {
+   "qid": "Q1000076",
+   "label": "Custom Coasters International",
+   "description": "American wooden roller coaster manufacturer",
+   "expected_type": "organization",
+   "wikidata_class": "business"
+  },
+  {
+   "qid": "Q1000212",
+   "label": "Montreal Light, Heat & Power",
+   "description": "Canadian utility company",
+   "expected_type": "organization",
+   "wikidata_class": "business"
+  },
+  {
+   "qid": "Q100032157",
+   "label": "Svatek a spol.",
+   "description": "former Czech company",
+   "expected_type": "organization",
+   "wikidata_class": "business"
+  },
+  {
+   "qid": "Q1000369",
+   "label": "Buco",
+   "description": "business",
+   "expected_type": "organization",
+   "wikidata_class": "business"
+  },
+  {
+   "qid": "Q1000428",
+   "label": "MySQL AB",
+   "description": "Swedish company",
+   "expected_type": "organization",
+   "wikidata_class": "business"
+  },
+  {
+   "qid": "Q1000531",
+   "label": "Sogo Hong Kong",
+   "description": "company",
+   "expected_type": "organization",
+   "wikidata_class": "business"
+  },
+  {
+   "qid": "Q1000533",
+   "label": "Union Betriebs-Gesellschaft mit beschr\u00e4nkter Haftung",
+   "description": "business",
+   "expected_type": "organization",
+   "wikidata_class": "business"
+  },
+  {
+   "qid": "Q1000725",
+   "label": "Julius Pintsch AG",
+   "description": "business",
+   "expected_type": "organization",
+   "wikidata_class": "business"
+  },
+  {
+   "qid": "Q1000840",
+   "label": "Chart Pattana Party",
+   "description": "Thai political party",
+   "expected_type": "organization",
+   "wikidata_class": "political party"
+  },
+  {
+   "qid": "Q1001115",
+   "label": "Heimatwehr",
+   "description": "Swiss political party",
+   "expected_type": "organization",
+   "wikidata_class": "political party"
+  },
+  {
+   "qid": "Q100136486",
+   "label": "Unity",
+   "description": "Kyrgyz political party",
+   "expected_type": "organization",
+   "wikidata_class": "political party"
+  },
+  {
+   "qid": "Q100144514",
+   "label": "Unidad Constituyente",
+   "description": "Chilean political coalition",
+   "expected_type": "organization",
+   "wikidata_class": "political party"
+  },
+  {
+   "qid": "Q100148859",
+   "label": "Nez\u00e1visl\u00e1 iniciativa (NEI)",
+   "description": "Czech political party",
+   "expected_type": "organization",
+   "wikidata_class": "political party"
+  },
+  {
+   "qid": "Q100186288",
+   "label": "Volba pro kraj",
+   "description": "Czech political movement",
+   "expected_type": "organization",
+   "wikidata_class": "political party"
+  },
+  {
+   "qid": "Q1002594",
+   "label": "People's Progressive Party",
+   "description": "political party in Malaysia",
+   "expected_type": "organization",
+   "wikidata_class": "political party"
+  },
+  {
+   "qid": "Q100261034",
+   "label": "Islamic National Salvation Party",
+   "description": "Palestinian political party",
+   "expected_type": "organization",
+   "wikidata_class": "political party"
+  },
+  {
+   "qid": "Q1006077",
+   "label": "Social War of 220-217 BCE",
+   "description": "ancient Greek war from 220 to 217 BC",
+   "expected_type": "event",
+   "wikidata_class": "war"
+  },
+  {
+   "qid": "Q1014253",
+   "label": "Mongol conquest of the Jin dynasty",
+   "description": "1211\u20131234 campaign in northern China",
+   "expected_type": "event",
+   "wikidata_class": "war"
+  },
+  {
+   "qid": "Q1014825",
+   "label": "Burgdorferkrieg",
+   "description": "event",
+   "expected_type": "event",
+   "wikidata_class": "war"
+  },
+  {
+   "qid": "Q1016077",
+   "label": "Burgundy War",
+   "description": "war",
+   "expected_type": "event",
+   "wikidata_class": "war"
+  },
+  {
+   "qid": "Q1032343",
+   "label": "Ottoman\u2013Habsburg War of 1540\u20131547",
+   "description": "1540\u20131547 war between Ottoman Empire and the Habsburg Monarchy",
+   "expected_type": "event",
+   "wikidata_class": "war"
+  },
+  {
+   "qid": "Q103829968",
+   "label": "War of 1863",
+   "description": "war in Central America",
+   "expected_type": "event",
+   "wikidata_class": "war"
+  },
+  {
+   "qid": "Q1044829",
+   "label": "Polish\u2013Muscovite War",
+   "description": "1605\u20131618 sequence of military conflicts and eastward invasions",
+   "expected_type": "event",
+   "wikidata_class": "war"
+  },
+  {
+   "qid": "Q10484164",
+   "label": "English Wars",
+   "description": "1296-1453 part of the Wars of Scottish Independence",
+   "expected_type": "event",
+   "wikidata_class": "war"
+  },
+  {
+   "qid": "Q100233726",
+   "label": "Women's Suffrage Day",
+   "description": "event on May 2",
+   "expected_type": "event",
+   "wikidata_class": "event"
+  },
+  {
+   "qid": "Q100235488",
+   "label": "Wikipedia 20",
+   "description": "20th birthday of Wikipedia",
+   "expected_type": "event",
+   "wikidata_class": "event"
+  },
+  {
+   "qid": "Q100923916",
+   "label": "Cunningham Lectures",
+   "description": "annual social sciences lecture",
+   "expected_type": "event",
+   "wikidata_class": "event"
+  },
+  {
+   "qid": "Q1012810",
+   "label": "Steve Bartman incident",
+   "description": "controversial play in a 2003 baseball game",
+   "expected_type": "event",
+   "wikidata_class": "event"
+  },
+  {
+   "qid": "Q101421918",
+   "label": "Parlamentary Group Constitution",
+   "description": "event linked to the electoral process, where elected parties joint into chamber parliamentary groups.",
+   "expected_type": "event",
+   "wikidata_class": "event"
+  },
+  {
+   "qid": "Q102104861",
+   "label": "First baptism and rope exchange from Capoeira Ginga Ativa",
+   "description": "Event happened where the first baptism and rope exchange that takes place together with a maculel\u00ea workshop and Angola wheel",
+   "expected_type": "event",
+   "wikidata_class": "event"
+  },
+  {
+   "qid": "Q102119426",
+   "label": "Brereton Report",
+   "description": "Australian war crimes investigation and report",
+   "expected_type": "event",
+   "wikidata_class": "event"
+  },
+  {
+   "qid": "Q1022208",
+   "label": "NORAD Tracks Santa",
+   "description": "annual program around Christmas",
+   "expected_type": "event",
+   "wikidata_class": "event"
+  }
+ ]
+}

--- a/bench/wikidata/fixtures/xlingual.json
+++ b/bench/wikidata/fixtures/xlingual.json
@@ -1,0 +1,557 @@
+{
+ "items": [
+  {
+   "qid": "Q10000001",
+   "labels": {
+    "en": "Tatyana Kolotilshchikova",
+    "ru": "\u0422\u0430\u0442\u044c\u044f\u043d\u0430 \u041a\u043e\u043b\u043e\u0442\u0438\u043b\u044c\u0449\u0438\u043a\u043e\u0432\u0430",
+    "fr": "Tatyana Kolotilshchikova",
+    "ja": "\u30bf\u30c6\u30a3\u30a2\u30ca\u30fb\u30b3\u30ed\u30c6\u30a3\u30eb\u30b7\u30c1\u30b3\u30ef"
+   },
+   "description": "Soviet ballet dancer and teacher (1937\u20132016)"
+  },
+  {
+   "qid": "Q1000002",
+   "labels": {
+    "de": "Claus Hammel",
+    "en": "Claus Hammel",
+    "fr": "Claus Hammel"
+   },
+   "description": "East German playwright (1932-1990)"
+  },
+  {
+   "qid": "Q10000029",
+   "labels": {
+    "ru": "\u041d\u0438\u043a\u043e\u043b\u0430\u0439 \u041f\u0435\u0442\u0440\u043e\u0432\u0438\u0447 \u042e\u0440\u044c\u0435\u0432",
+    "en": "Nikolai Yuryev",
+    "de": "Nikolaj Petrowitsch Jurjew"
+   },
+   "description": "Russian general"
+  },
+  {
+   "qid": "Q1000005",
+   "labels": {
+    "de": "Karel Mat\u011bj \u010capek-Chod",
+    "en": "Karel Mat\u011bj \u010capek-Chod",
+    "fr": "Karel Mat\u011bj \u010capek-Chod",
+    "ru": "\u041a\u0430\u0440\u0435\u043b \u041c\u0430\u0442\u0435\u0439 \u0427\u0430\u043f\u0435\u043a-\u0425\u043e\u0434"
+   },
+   "description": "Czech writer and journalist (1860\u20131927)"
+  },
+  {
+   "qid": "Q1000006",
+   "labels": {
+    "de": "Florian Eichinger",
+    "fr": "Florian Eichinger",
+    "en": "Florian Eichinger",
+    "ru": "\u0424\u043b\u043e\u0440\u0438\u0430\u043d \u042d\u0439\u0447\u0438\u043d\u0433\u0435\u0440"
+   },
+   "description": "German film producer and screenwriter"
+  },
+  {
+   "qid": "Q100000811",
+   "labels": {
+    "en": "Paul Mohr",
+    "de": "Paul Mohr",
+    "fr": "Paul Mohr"
+   },
+   "description": "physician"
+  },
+  {
+   "qid": "Q100000831",
+   "labels": {
+    "en": "Otto Kramer",
+    "de": "Otto Kramer",
+    "fr": "Otto Kramer"
+   },
+   "description": "classical philologist"
+  },
+  {
+   "qid": "Q100000832",
+   "labels": {
+    "en": "Marie Madeleine Lebreton",
+    "de": "Marie Madeleine Lebreton",
+    "fr": "Marie Madeleine Lebreton"
+   },
+   "description": "translator, medievalist, latinist (-1978)"
+  },
+  {
+   "qid": "Q1000",
+   "labels": {
+    "en": "Gabon",
+    "de": "Gabun",
+    "fr": "Gabon",
+    "ru": "\u0413\u0430\u0431\u043e\u043d",
+    "ar": "\u0627\u0644\u063a\u0627\u0628\u0648\u0646",
+    "ja": "\u30ac\u30dc\u30f3",
+    "uk": "\u0413\u0430\u0431\u043e\u043d"
+   },
+   "description": "country on the Atlantic coast of Central Africa"
+  },
+  {
+   "qid": "Q1005",
+   "labels": {
+    "en": "The Gambia",
+    "fr": "Gambie",
+    "de": "Gambia",
+    "ar": "\u063a\u0627\u0645\u0628\u064a\u0627",
+    "ja": "\u30ac\u30f3\u30d3\u30a2",
+    "ru": "\u0413\u0430\u043c\u0431\u0438\u044f",
+    "uk": "\u0413\u0430\u043c\u0431\u0456\u044f"
+   },
+   "description": "sovereign state in West Africa"
+  },
+  {
+   "qid": "Q1006",
+   "labels": {
+    "en": "Guinea",
+    "de": "Guinea",
+    "fr": "Guin\u00e9e",
+    "ar": "\u063a\u064a\u0646\u064a\u0627",
+    "ja": "\u30ae\u30cb\u30a2",
+    "ru": "\u0413\u0432\u0438\u043d\u0435\u044f",
+    "uk": "\u0413\u0432\u0456\u043d\u0435\u044f"
+   },
+   "description": "sovereign state in West Africa"
+  },
+  {
+   "qid": "Q1007",
+   "labels": {
+    "en": "Guinea-Bissau",
+    "fr": "Guin\u00e9e-Bissau",
+    "de": "Guinea-Bissau",
+    "ar": "\u063a\u064a\u0646\u064a\u0627 \u0628\u064a\u0633\u0627\u0648",
+    "ja": "\u30ae\u30cb\u30a2\u30d3\u30b5\u30a6\u5171\u548c\u56fd",
+    "ru": "\u0413\u0432\u0438\u043d\u0435\u044f-\u0411\u0438\u0441\u0430\u0443",
+    "uk": "\u0413\u0432\u0456\u043d\u0435\u044f-\u0411\u0456\u0441\u0430\u0443"
+   },
+   "description": "sovereign state in Western Africa"
+  },
+  {
+   "qid": "Q1008",
+   "labels": {
+    "de": "Elfenbeink\u00fcste",
+    "en": "Ivory Coast",
+    "fr": "C\u00f4te d'Ivoire",
+    "ja": "\u30b3\u30fc\u30c8\u30b8\u30dc\u30ef\u30fc\u30eb",
+    "ru": "\u041a\u043e\u0442-\u0434\u2019\u0418\u0432\u0443\u0430\u0440",
+    "uk": "\u041a\u043e\u0442-\u0434'\u0406\u0432\u0443\u0430\u0440",
+    "ar": "\u0633\u0627\u062d\u0644 \u0627\u0644\u0639\u0627\u062c"
+   },
+   "description": "sovereign state in West Africa"
+  },
+  {
+   "qid": "Q1009",
+   "labels": {
+    "en": "Cameroon",
+    "ru": "\u041a\u0430\u043c\u0435\u0440\u0443\u043d",
+    "fr": "Cameroun",
+    "de": "Kamerun",
+    "ar": "\u0627\u0644\u0643\u0627\u0645\u064a\u0631\u0648\u0646",
+    "ja": "\u30ab\u30e1\u30eb\u30fc\u30f3",
+    "uk": "\u041a\u0430\u043c\u0435\u0440\u0443\u043d"
+   },
+   "description": "sovereign state in West-Central Africa"
+  },
+  {
+   "qid": "Q1011",
+   "labels": {
+    "en": "Cape Verde",
+    "fr": "Cap-Vert",
+    "de": "Kap Verde",
+    "ar": "\u0627\u0644\u0631\u0623\u0633 \u0627\u0644\u0623\u062e\u0636\u0631",
+    "ja": "\u30ab\u30fc\u30dc\u30d9\u30eb\u30c7",
+    "ru": "\u041a\u0430\u0431\u043e-\u0412\u0435\u0440\u0434\u0435",
+    "uk": "\u041a\u0430\u0431\u043e-\u0412\u0435\u0440\u0434\u0435"
+   },
+   "description": "sovereign state comprising ten islands off the Western coast of Africa"
+  },
+  {
+   "qid": "Q1013",
+   "labels": {
+    "en": "Lesotho",
+    "ru": "\u041b\u0435\u0441\u043e\u0442\u043e",
+    "fr": "Lesotho",
+    "de": "Lesotho",
+    "ar": "\u0644\u064a\u0633\u0648\u062a\u0648",
+    "ja": "\u30ec\u30bd\u30c8",
+    "uk": "\u041b\u0435\u0441\u043e\u0442\u043e"
+   },
+   "description": "sovereign state in southern Africa"
+  },
+  {
+   "qid": "Q1000143",
+   "labels": {
+    "de": "G\u00fcig\u00fce",
+    "fr": "G\u00fcig\u00fce",
+    "en": "G\u00fcig\u00fce",
+    "ja": "\u30b0\u30a4\u30b0\u30a8",
+    "ru": "\u0413\u0438\u0433\u0435",
+    "ar": "\u063a\u0648\u064a\u063a\u0648\u064a",
+    "uk": "\u0413\u0432\u0456\u0433\u0432\u0435"
+   },
+   "description": "Parroquia"
+  },
+  {
+   "qid": "Q1000333",
+   "labels": {
+    "fr": "Huancavelica",
+    "ru": "\u0423\u0430\u043d\u043a\u0430\u0432\u0435\u043b\u0438\u043a\u0430",
+    "en": "Huancavelica",
+    "de": "Huancavelica",
+    "uk": "\u0423\u0430\u043d\u043a\u0430\u0432\u0435\u043b\u0456\u043a\u0430",
+    "ja": "\u30a6\u30a2\u30f3\u30ab\u30d9\u30ea\u30ab",
+    "ar": "\u0647\u0648\u0627\u0646\u0643\u0627\u0641\u0644\u064a\u0643\u0627"
+   },
+   "description": "capital city of Huancavelica, Peru"
+  },
+  {
+   "qid": "Q1000341",
+   "labels": {
+    "ru": "\u0418\u043b\u043e",
+    "fr": "Ilo",
+    "en": "Ilo",
+    "de": "Ilo",
+    "uk": "\u0406\u043b\u043e",
+    "ja": "\u30a4\u30ed",
+    "ar": "\u0645\u064a\u0646\u0627\u0621 \u0625\u064a\u0644\u0648"
+   },
+   "description": "city in Peru"
+  },
+  {
+   "qid": "Q1000346",
+   "labels": {
+    "fr": "Moquegua",
+    "en": "Moquegua",
+    "de": "Moquegua",
+    "ru": "\u041c\u043e\u043a\u0435\u0433\u0443\u0430",
+    "uk": "\u041c\u043e\u043a\u0435\u0491\u0443\u0430",
+    "ja": "\u30e2\u30b1\u30b0\u30a2",
+    "ar": "\u0645\u0648\u0643\u064a\u063a\u0648\u0627"
+   },
+   "description": "city of Peru, capital of Moquegua region"
+  },
+  {
+   "qid": "Q1000373",
+   "labels": {
+    "ru": "\u041c\u0430\u043d\u0434\u0430\u043b\u0433\u043e\u0432\u044c",
+    "en": "Mandalgovi",
+    "de": "Mandalgobi",
+    "ja": "\u30de\u30f3\u30c0\u30eb\u30b4\u30d3",
+    "uk": "\u041c\u0430\u043d\u0434\u0430\u043b\u0433\u043e\u0432\u044c",
+    "fr": "Mandalgov\u012d",
+    "ar": "\u0645\u0627\u0646\u062f\u0627\u0644\u063a\u0648\u0641\u064a"
+   },
+   "description": "city in Dundgovi, Mongolia"
+  },
+  {
+   "qid": "Q1000438",
+   "labels": {
+    "ru": "\u0429\u0430\u0432\u043d\u0438\u0446\u0430",
+    "en": "Szczawnica",
+    "uk": "\u0429\u0430\u0432\u043d\u0438\u0446\u044f",
+    "de": "Szczawnica",
+    "fr": "Szczawnica",
+    "ja": "\u30b7\u30e5\u30c1\u30e3\u30f4\u30cb\u30c4\u30a1"
+   },
+   "description": "city of Poland"
+  },
+  {
+   "qid": "Q1000495",
+   "labels": {
+    "ru": "\u0420\u0435\u0432\u0430",
+    "en": "Rewa",
+    "de": "Rewa",
+    "fr": "Rewa",
+    "ja": "\u30ea\u30fc\u30ef\u30fc",
+    "ar": "\u0631\u064a\u0648\u0627",
+    "uk": "\u0420\u0435\u0432\u0430"
+   },
+   "description": "city in the state of Madhya Pradesh in India"
+  },
+  {
+   "qid": "Q10006",
+   "labels": {
+    "en": "Hengelo",
+    "de": "Hengelo",
+    "fr": "Hengelo",
+    "ja": "\u30d8\u30f3\u30b2\u30ed\u30fc",
+    "ru": "\u0425\u0435\u043d\u0433\u0435\u043b\u043e",
+    "ar": "\u0647\u064a\u0646\u062c\u064a\u0644\u0648",
+    "uk": "\u0413\u0435\u043d\u0491\u0435\u043b\u043e"
+   },
+   "description": "city and municipality in Overijssel, the Netherlands"
+  },
+  {
+   "qid": "Q100258387",
+   "labels": {
+    "ar": "\u0627\u0644\u0645\u0631\u0643\u0632 \u0627\u0644\u062c\u0627\u0645\u0639\u064a \u0646\u0648\u0631 \u0627\u0644\u0628\u0634\u064a\u0631 \u0627\u0644\u0628\u064a\u0636",
+    "en": "University Center Nour Bashir (El-Bayadh)",
+    "fr": "Centre Universitaire Nour Bachir El-Bayadh"
+   },
+   "description": "University in Algeria"
+  },
+  {
+   "qid": "Q100258391",
+   "labels": {
+    "ar": "\u062c\u0627\u0645\u0639\u0629 \u0627\u0644\u0634\u0627\u0630\u0644\u064a \u0628\u0646 \u062c\u062f\u064a\u062f -\u0627\u0644\u0637\u0627\u0631\u0641",
+    "en": "Universit\u00e9 Chadli Bendjedid d'El Tarf",
+    "fr": "universit\u00e9 Chadli-Bendjedid"
+   },
+   "description": "university in Algeria"
+  },
+  {
+   "qid": "Q100260373",
+   "labels": {
+    "ar": "\u062c\u0627\u0645\u0639\u0629 \u0627\u0644\u0645\u0646\u0627\u0631\u0629",
+    "en": "Manara University",
+    "fr": "universit\u00e9 Manara"
+   },
+   "description": "Private university in Latakia, Syria"
+  },
+  {
+   "qid": "Q100261338",
+   "labels": {
+    "ar": "\u0627\u0644\u062c\u0627\u0645\u0639\u0629 \u0627\u0644\u062f\u0648\u0644\u064a\u0629 \u0644\u0623\u0643\u0627\u062f\u064a\u0631",
+    "fr": "universit\u00e9 internationale d'Agadir",
+    "en": "Universit\u00e9 Internationale d'Agadir"
+   },
+   "description": "university in Morocco"
+  },
+  {
+   "qid": "Q1003463",
+   "labels": {
+    "en": "Bulacan State University",
+    "de": "Bulacan State University",
+    "fr": "universit\u00e9 de Bulacain"
+   },
+   "description": "state-funded institution of higher learning in Bulacan province, Philippines"
+  },
+  {
+   "qid": "Q100418692",
+   "labels": {
+    "en": "Dhammaduta Chekinda University",
+    "de": "Dhammaduta Chekinda University",
+    "fr": "Dhammaduta Chekinda University"
+   },
+   "description": "Buddhist missionary university in Auk War Nat Chaung village, Myanmar"
+  },
+  {
+   "qid": "Q1000076",
+   "labels": {
+    "de": "Custom Coasters International",
+    "en": "Custom Coasters International",
+    "fr": "Custom Coasters International",
+    "ar": "\u0643\u0627\u0633\u062a\u0645 \u0643\u0648\u0633\u062a\u0631\u0632 \u0625\u0646\u062a\u0631\u0646\u0627\u0634\u0648\u0646\u0627\u0644"
+   },
+   "description": "American wooden roller coaster manufacturer"
+  },
+  {
+   "qid": "Q1000212",
+   "labels": {
+    "de": "Montreal Light, Heat and Power",
+    "en": "Montreal Light, Heat & Power",
+    "fr": "Montreal Light, Heat and Power",
+    "ja": "\u30e2\u30f3\u30c8\u30ea\u30aa\u30fc\u30eb\u30fb\u30e9\u30a4\u30c8\u30fb\u30d2\u30fc\u30c8\u30fb\u30a2\u30f3\u30c9\u30fb\u30d1\u30ef\u30fc"
+   },
+   "description": "Canadian utility company"
+  },
+  {
+   "qid": "Q1000369",
+   "labels": {
+    "de": "Buco",
+    "en": "Buco",
+    "fr": "Buco"
+   },
+   "description": "business"
+  },
+  {
+   "qid": "Q1000428",
+   "labels": {
+    "de": "MySQL AB",
+    "en": "MySQL AB",
+    "fr": "MySQL AB",
+    "ja": "MySQL AB",
+    "ru": "MySQL AB",
+    "uk": "MySQL AB",
+    "ar": "\u0645\u0627\u064a \u0625\u0633 \u0643\u064a\u0648 \u0625\u0644 \u0625\u064a\u0647 \u0628\u064a"
+   },
+   "description": "Swedish company"
+  },
+  {
+   "qid": "Q1000531",
+   "labels": {
+    "ja": "\u9999\u6e2f\u305d\u3054\u3046",
+    "en": "Sogo Hong Kong",
+    "fr": "Sogo Hong Kong"
+   },
+   "description": "company"
+  },
+  {
+   "qid": "Q1000533",
+   "labels": {
+    "de": "Union Betriebs-Gesellschaft mit beschr\u00e4nkter Haftung",
+    "fr": "Union Betriebs-Gesellschaft mit beschr\u00e4nkter Haftung",
+    "en": "Union Betriebs-Gesellschaft mit beschr\u00e4nkter Haftung"
+   },
+   "description": "business"
+  },
+  {
+   "qid": "Q1000725",
+   "labels": {
+    "de": "Julius Pintsch AG",
+    "fr": "Julius Pintsch AG",
+    "en": "Julius Pintsch AG"
+   },
+   "description": "business"
+  },
+  {
+   "qid": "Q1000840",
+   "labels": {
+    "ja": "\u30bf\u30a4\u56e3\u7d50\u56fd\u5bb6\u958b\u767a\u515a",
+    "en": "Chart Pattana Party",
+    "de": "Chart-Pattana-Partei",
+    "ru": "\u041f\u0430\u0440\u0442\u0438\u044f \u043d\u0430\u0446\u0438\u043e\u043d\u0430\u043b\u044c\u043d\u043e\u0433\u043e \u0440\u0430\u0437\u0432\u0438\u0442\u0438\u044f",
+    "fr": "Parti national du d\u00e9veloppement audacieux"
+   },
+   "description": "Thai political party"
+  },
+  {
+   "qid": "Q1001115",
+   "labels": {
+    "de": "Heimatwehr",
+    "en": "Heimatwehr",
+    "fr": "Heimatwehr"
+   },
+   "description": "Swiss political party"
+  },
+  {
+   "qid": "Q100136486",
+   "labels": {
+    "en": "Unity",
+    "uk": "\u0411\u0438\u0440\u0438\u043c\u0434\u0438\u043a",
+    "fr": "Birimdik",
+    "de": "Birimdik",
+    "ru": "\u0411\u0438\u0440\u0438\u043c\u0434\u0438\u043a",
+    "ja": "\u7d71\u4e00"
+   },
+   "description": "Kyrgyz political party"
+  },
+  {
+   "qid": "Q100144514",
+   "labels": {
+    "en": "Unidad Constituyente",
+    "fr": "Unit\u00e9 constituante",
+    "de": "Unidad Constituyente"
+   },
+   "description": "Chilean political coalition"
+  },
+  {
+   "qid": "Q1006077",
+   "labels": {
+    "ru": "\u0421\u043e\u044e\u0437\u043d\u0438\u0447\u0435\u0441\u043a\u0430\u044f \u0432\u043e\u0439\u043d\u0430 (220\u2014217 \u0434\u043e \u043d. \u044d.)",
+    "fr": "guerre des Alli\u00e9s",
+    "en": "Social War of 220-217 BCE",
+    "de": "Bundesgenossenkrieg (Hellenismus)",
+    "ja": "\u540c\u76df\u5e02\u6226\u4e89 (\u7d00\u5143\u524d220\u5e74-\u7d00\u5143\u524d217\u5e74)",
+    "uk": "\u0421\u043e\u044e\u0437\u043d\u0438\u0446\u044c\u043a\u0430 \u0432\u0456\u0439\u043d\u0430 (220-217 \u0434\u043e \u043d.\u0435.)"
+   },
+   "description": "ancient Greek war from 220 to 217 BC"
+  },
+  {
+   "qid": "Q1014253",
+   "labels": {
+    "ru": "\u041c\u043e\u043d\u0433\u043e\u043b\u044c\u0441\u043a\u043e-\u0446\u0437\u0438\u043d\u044c\u0441\u043a\u0430\u044f \u0432\u043e\u0439\u043d\u0430",
+    "en": "Mongol conquest of the Jin dynasty",
+    "uk": "\u041c\u043e\u043d\u0433\u043e\u043b\u044c\u0441\u044c\u043a\u043e-\u0446\u0437\u0456\u043d\u044c\u0441\u044c\u043a\u0430 \u0432\u0456\u0439\u043d\u0430",
+    "ja": "\u30e2\u30f3\u30b4\u30eb\u30fb\u91d1\u6226\u4e89",
+    "fr": "invasion mongole de la dynastie Jin",
+    "ar": "\u063a\u0632\u0648 \u0627\u0644\u0645\u063a\u0648\u0644 \u0644\u0633\u0644\u0627\u0644\u0629 \u062c\u064a\u0646 \u0627\u0644\u0635\u064a\u0646\u064a\u0629"
+   },
+   "description": "1211\u20131234 campaign in northern China"
+  },
+  {
+   "qid": "Q1014825",
+   "labels": {
+    "de": "Burgdorferkrieg",
+    "en": "Burgdorferkrieg",
+    "fr": "guerre de Berthoud"
+   },
+   "description": "event"
+  },
+  {
+   "qid": "Q1016077",
+   "labels": {
+    "fr": "guerre de Burgondie",
+    "de": "Burgundenkrieg",
+    "ru": "\u0411\u0443\u0440\u0433\u0443\u043d\u0434\u043e-\u0444\u0440\u0430\u043d\u043a\u0441\u043a\u0430\u044f \u0432\u043e\u0439\u043d\u0430",
+    "en": "Burgundy War",
+    "ja": "\u30d6\u30eb\u30b4\u30fc\u30cb\u30e5\u6226\u4e89"
+   },
+   "description": "war"
+  },
+  {
+   "qid": "Q1032343",
+   "labels": {
+    "ru": "\u0410\u0432\u0441\u0442\u0440\u043e-\u0442\u0443\u0440\u0435\u0446\u043a\u0430\u044f \u0432\u043e\u0439\u043d\u0430",
+    "en": "Ottoman\u2013Habsburg War of 1540\u20131547",
+    "uk": "\u0413\u0430\u0431\u0441\u0431\u0443\u0440\u0437\u044c\u043a\u043e-\u043e\u0441\u043c\u0430\u043d\u0441\u044c\u043a\u0430 \u0432\u0456\u0439\u043d\u0430 1540\u20131547",
+    "fr": "guerre ottomano-habsbourgeoise de 1540\u20131547"
+   },
+   "description": "1540\u20131547 war between Ottoman Empire and the Habsburg Monarchy"
+  },
+  {
+   "qid": "Q1044829",
+   "labels": {
+    "fr": "guerre polono-russe",
+    "ru": "\u0420\u0443\u0441\u0441\u043a\u043e-\u043f\u043e\u043b\u044c\u0441\u043a\u0430\u044f \u0432\u043e\u0439\u043d\u0430 1605\u20141618 \u0433\u043e\u0434\u043e\u0432",
+    "en": "Polish\u2013Muscovite War",
+    "uk": "\u041c\u043e\u0441\u043a\u043e\u0432\u0441\u044c\u043a\u043e-\u043f\u043e\u043b\u044c\u0441\u044c\u043a\u0430 \u0432\u0456\u0439\u043d\u0430 1605\u20141618",
+    "de": "Polnisch-Russischer Krieg 1609\u20131618",
+    "ja": "\u30ed\u30b7\u30a2\u30fb\u30dd\u30fc\u30e9\u30f3\u30c9\u6226\u4e89",
+    "ar": "\u0627\u0644\u062d\u0631\u0628 \u0627\u0644\u0628\u0648\u0644\u0646\u062f\u064a\u0629 \u0627\u0644\u0645\u0648\u0633\u0643\u064a\u0629"
+   },
+   "description": "1605\u20131618 sequence of military conflicts and eastward invasions"
+  },
+  {
+   "qid": "Q100235488",
+   "labels": {
+    "ru": "20-\u043b\u0435\u0442\u0438\u0435 \u0412\u0438\u043a\u0438\u043f\u0435\u0434\u0438\u0438",
+    "en": "Wikipedia 20",
+    "fr": "20 ans de Wikip\u00e9dia",
+    "ar": "\u0648\u064a\u0643\u064a\u0628\u064a\u062f\u064a\u0627 20",
+    "de": "Wikipedia 20"
+   },
+   "description": "20th birthday of Wikipedia"
+  },
+  {
+   "qid": "Q1012810",
+   "labels": {
+    "ja": "\u30b9\u30c6\u30a3\u30fc\u30d6\u30fb\u30d0\u30fc\u30c8\u30de\u30f3\u4e8b\u4ef6",
+    "fr": "incident de Steve Bartman",
+    "en": "Steve Bartman incident"
+   },
+   "description": "controversial play in a 2003 baseball game"
+  },
+  {
+   "qid": "Q102119426",
+   "labels": {
+    "en": "Brereton Report",
+    "ar": "\u062a\u0642\u0631\u064a\u0631 \u0628\u0631\u064a\u0631\u064a\u062a\u0648\u0646",
+    "ja": "\u30d6\u30ec\u30ec\u30c8\u30f3\u5831\u544a\u66f8"
+   },
+   "description": "Australian war crimes investigation and report"
+  },
+  {
+   "qid": "Q1022208",
+   "labels": {
+    "en": "NORAD Tracks Santa",
+    "fr": "NORAD Tracks Santa",
+    "ru": "NORAD Tracks Santa",
+    "ja": "NORAD\u306e\u30b5\u30f3\u30bf\u8ffd\u8de1",
+    "de": "NORAD Tracks Santa"
+   },
+   "description": "annual program around Christmas"
+  }
+ ]
+}

--- a/bench/wikidata/run_co1.py
+++ b/bench/wikidata/run_co1.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""RFC CO-1 — the gate. Builds nothing; loads rows and asks questions.
+
+Three arms over the same questions:
+
+  control   empty scope, no retrieval  -> what the model already knows (parametric floor)
+  static    whole chain loaded, dated  -> does the fact's own text suffice
+  sequential  old fact stored, asked, new fact stored, asked -> STALENESS
+
+The sequential arm is the benchmark. The other two exist so its number can be read:
+without the control, a score measures training data; without static, a staleness
+result cannot be told apart from "the store never had it".
+"""
+import json, os, re, sys, time, urllib.request
+
+BASE = "http://truenas.local:8787"
+TOK  = os.environ["WIKI_BENCH_TENANT_TOKEN"]
+AGENT = "wiki/answerer"
+
+def api(method, path, body=None, timeout=300):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(BASE + path, data=data, method=method,
+        headers={"Authorization": "Bearer " + TOK, "Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        raw = r.read()
+    return raw
+
+def put_row(scope_id, key, value, observed_at=None):
+    b = {"value": value, "embed": True}
+    if observed_at:
+        b["observed_at"] = observed_at
+    out = json.loads(api("PUT", f"/v1/_memory/scopes/user/{scope_id}/keys/{key}", b))
+    if not out.get("embedded"):
+        # An unembedded row is invisible to recall, so a run that ignored this would
+        # score an empty store and call it a memory failure.
+        raise SystemExit(f"row {key} did not embed: {out.get('embed_warning')}")
+
+def purge(scope_id, keys):
+    for k in keys:
+        try:
+            api("DELETE", f"/v1/_memory/scopes/user/{scope_id}/keys/{k}")
+        except Exception:
+            pass
+
+def scope_rows(scope_id):
+    out = json.loads(api("GET", f"/v1/_memory/scopes/user/{scope_id}/keys?limit=5000"))
+    return [e["key"] for e in (out.get("entries") or [])]
+
+TRIPLE = re.compile(r"MEMORY:\s*(.*?)\s*\n\s*OWN:\s*(.*?)\s*\n", re.I | re.S)
+
+def ask(scope_id, question):
+    """Returns (memory_answer, own_answer, retrieved_bool, raw)."""
+    body = {"agent": AGENT, "prompt": question, "user_id": scope_id, "max_iterations": 4}
+    raw = api("POST", "/v1/runs", body).decode("utf-8", "replace")
+    text, retrieved = "", False
+    for line in raw.splitlines():
+        if not line.startswith("data: "):
+            continue
+        try:
+            ev = json.loads(line[6:])
+        except Exception:
+            continue
+        if ev.get("type") == "text":
+            text += ev.get("text", "")
+        # Verify the retrieval ACTUALLY happened rather than trusting the instruction —
+        # an RFC CL answerer ignored exactly this kind of rule on every question.
+        tu = ev.get("tool_use") or {}
+        if tu.get("name") == "Memory" and (tu.get("input") or {}).get("op") in ("recall", "search"):
+            retrieved = True
+    m = TRIPLE.search(text + "\n")
+    if not m:
+        return None, None, retrieved, text.strip()[:160]
+    return m.group(1).strip(), m.group(2).strip(), retrieved, text.strip()[:160]
+
+def norm(s):
+    return re.sub(r"[^a-z ]", "", (s or "").lower()).strip()
+
+def match(answer, label):
+    """Grade on surname containment: the fixture's ground truth is a QID and the label
+    is its English name, so a reply of "Merz" or "Friedrich Merz" is the same answer."""
+    a, l = norm(answer), norm(label)
+    if not a or not l:
+        return False
+    return l in a or a in l or (l.split()[-1] and l.split()[-1] in a)
+
+def main():
+    chains = json.load(open(sys.argv[1]))["chains"]
+    limit = int(sys.argv[2]) if len(sys.argv) > 2 else 20
+    chains = chains[:limit]
+    # THE SCOPE MUST BE THE TOKEN'S SUBJECT. In-band `scope=user` is resolved
+    # server-side from the run identity, never from the wire, so a row written to any
+    # other scope_id is invisible to the agent — it recalls an empty partition and
+    # every arm reports NOT_FOUND, which reads as a memory failure and is not one.
+    scope = json.loads(api("GET", "/v1/_me"))["subject"]
+    print(f"scope (token subject): {scope}", flush=True)
+    results = []
+
+    print(f"CO-1 over {len(chains)} chains\n", flush=True)
+    for c in chains:
+        office, prev, cur = c["office_label"], c["holders"][0], c["holders"][1]
+        q = f"Who is the {office}?"
+        keys = [f"co1:{c['office']}:prev", f"co1:{c['office']}:cur"]
+        purge(scope, keys)
+
+        # ---- control: empty scope. No rows, so recall can only return nothing.
+        left = scope_rows(scope)
+        if left:
+            raise SystemExit(f"scope not empty before control: {len(left)} rows — "
+                             "a contaminated control invalidates every arm")
+        c_mem, c_own, c_ret, _ = ask(scope, q)
+
+        # ---- sequential: the old fact arrives first, unqualified.
+        put_row(scope, keys[0], f"{prev['label']} is the {office}.", prev["start"] + "T00:00:00Z")
+        s1_mem, s1_own, s1_ret, _ = ask(scope, q)
+        # ...then the new one arrives, exactly as a knowledge update does.
+        put_row(scope, keys[1], f"{cur['label']} is the {office}.", cur["start"] + "T00:00:00Z")
+        s2_mem, s2_own, s2_ret, s2_raw = ask(scope, q)
+
+        # ---- static: both facts, each carrying its own dates in the text.
+        purge(scope, keys)
+        put_row(scope, keys[0],
+                f"{prev['label']} was the {office} from {prev['start']} to {prev['end']}.",
+                prev["start"] + "T00:00:00Z")
+        put_row(scope, keys[1],
+                f"{cur['label']} has been the {office} since {cur['start']}.",
+                cur["start"] + "T00:00:00Z")
+        st_mem, st_own, st_ret, _ = ask(scope, q)
+        purge(scope, keys)
+
+        row = {
+            "office": office, "office_qid": c["office"],
+            "prev": prev["label"], "prev_qid": prev["qid"],
+            "cur": cur["label"], "cur_qid": cur["qid"],
+            "control_own": c_own, "control_mem": c_mem, "control_retrieved": c_ret,
+            "seq_before": s1_mem, "seq_after": s2_mem, "seq_own": s2_own,
+            "seq_retrieved": s2_ret, "seq_raw": s2_raw,
+            "static_mem": st_mem, "static_own": st_own, "static_retrieved": st_ret,
+        }
+        row["control_knew"] = match(c_own, cur["label"])
+        row["seq_current"]  = match(s2_mem, cur["label"])
+        row["seq_stale"]    = match(s2_mem, prev["label"]) and not row["seq_current"]
+        row["static_current"] = match(st_mem, cur["label"])
+        results.append(row)
+        print(f"  {office[:34]:36} control_own={str(row['control_knew'])[:5]:5} "
+              f"seq={'CURRENT' if row['seq_current'] else ('STALE' if row['seq_stale'] else 'other'):7} "
+              f"static={'ok' if row['static_current'] else 'no':3} retrieved={s2_ret}", flush=True)
+        json.dump(results, open(sys.argv[3] if len(sys.argv) > 3 else "co1.json", "w"), indent=1)
+    print(f"\nwrote {len(results)} rows")
+
+main()

--- a/bench/wikidata/run_co3.py
+++ b/bench/wikidata/run_co3.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""RFC CO-3 — ontology type-assignment accuracy against Wikidata P31.
+
+The RFC BZ/CA type hierarchy has no external ground truth of any kind. Wikidata's
+instance-of IS a published one, so this is the first scored number that subsystem has.
+
+Scored per Wikidata class as well as overall: an ontology can be right about people and
+wrong about organizations, and one aggregate would hide that.
+"""
+import json, os, re, sys, urllib.request
+from collections import defaultdict
+
+BASE = "http://truenas.local:8787"
+TOK  = os.environ["WIKI_BENCH_TENANT_TOKEN"]
+
+def ask(question):
+    body = {"agent": "wiki/typer", "prompt": question, "user_id": "co3", "max_iterations": 2}
+    req = urllib.request.Request(BASE + "/v1/runs", data=json.dumps(body).encode(), method="POST",
+        headers={"Authorization": "Bearer " + TOK, "Content-Type": "application/json"})
+    raw = urllib.request.urlopen(req, timeout=300).read().decode("utf-8", "replace")
+    text = ""
+    for line in raw.splitlines():
+        if not line.startswith("data: "):
+            continue
+        try:
+            ev = json.loads(line[6:])
+        except Exception:
+            continue
+        if ev.get("type") == "text":
+            text += ev.get("text", "")
+    m = re.search(r"TYPE:\s*([a-zA-Z]+)", text)
+    return (m.group(1).lower() if m else None), text.strip()[:120]
+
+def main():
+    items = json.load(open(sys.argv[1]))["items"]
+    out, by_class = [], defaultdict(lambda: [0, 0])
+    for i, it in enumerate(items, 1):
+        q = f"Entity: {it['label']}\nDescription: {it['description']}"
+        got, raw = ask(q)
+        ok = (got == it["expected_type"])
+        by_class[it["wikidata_class"]][1] += 1
+        if ok:
+            by_class[it["wikidata_class"]][0] += 1
+        out.append({**it, "assigned": got, "correct": ok, "raw": raw})
+        print(f"  {i:3}/{len(items)} {it['label'][:26]:28} want={it['expected_type']:13} "
+              f"got={str(got):13} {'ok' if ok else 'MISS'}", flush=True)
+        json.dump(out, open(sys.argv[2], "w"), indent=1)
+
+    n = len(out); c = sum(1 for r in out if r["correct"])
+    print(f"\noverall type accuracy: {c}/{n} = {c/n:.4f}\n")
+    print(f"{'wikidata class':18}{'expected':14}{'accuracy':>10}")
+    for cls, (good, tot) in sorted(by_class.items()):
+        exp = next(r["expected_type"] for r in out if r["wikidata_class"] == cls)
+        print(f"{cls:18}{exp:14}{good}/{tot}")
+    # Under-typing: refused rather than mis-assigned. Different failure, different fix.
+    none = sum(1 for r in out if r["assigned"] in (None, "none"))
+    print(f"\nunder-typed (none/unparsed): {none}/{n}")
+
+main()

--- a/bench/wikidata/run_co4.py
+++ b/bench/wikidata/run_co4.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""RFC CO-4 — cross-lingual retrieval.
+
+Write one row per entity in ENGLISH, keyed by its QID. Then query with the SAME
+entity's label in another language and check whether that row comes back.
+
+No LLM anywhere: the expected key is the row we wrote, so this scores the EMBEDDER and
+the ranker directly. That is the point — a judge here would measure the judge.
+
+bge-m3 claims 100+ languages and has never been verified on this stack.
+"""
+import json, os, sys, urllib.request
+from collections import defaultdict
+
+BASE = "http://truenas.local:8787"
+TOK  = os.environ["WIKI_BENCH_TENANT_TOKEN"]
+TOP_K = 10
+
+def api(method, path, body=None):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(BASE + path, data=data, method=method,
+        headers={"Authorization": "Bearer " + TOK, "Content-Type": "application/json"})
+    return urllib.request.urlopen(req, timeout=180).read()
+
+def main():
+    items = json.load(open(sys.argv[1]))["items"]
+    scope = json.loads(api("GET", "/v1/_me"))["subject"]
+    print(f"scope: {scope}   entities: {len(items)}", flush=True)
+
+    keys = [f"co4:{it['qid']}" for it in items]
+    for k in keys:                                    # start from a known-empty corpus
+        try: api("DELETE", f"/v1/_memory/scopes/user/{scope}/keys/{k}")
+        except Exception: pass
+
+    # Seed in ENGLISH only.
+    for it in items:
+        body = {"value": f"{it['labels']['en']} — {it['description']}", "embed": True}
+        out = json.loads(api("PUT", f"/v1/_memory/scopes/user/{scope}/keys/co4:{it['qid']}", body))
+        if not out.get("embedded"):
+            raise SystemExit(f"{it['qid']} did not embed: {out.get('embed_warning')}")
+    print(f"seeded {len(items)} english rows", flush=True)
+
+    hits = defaultdict(lambda: [0, 0])
+    rows = []
+    for it in items:
+        want = f"co4:{it['qid']}"
+        for lang, label in it["labels"].items():
+            res = json.loads(api("POST", "/v1/_memory/search", {
+                "query": label, "scope": "user", "scope_id": scope, "top_k": TOP_K}))
+            got = [e["key"] for e in (res.get("entries") or [])]
+            ok = want in got
+            rank = got.index(want) + 1 if ok else 0
+            hits[lang][1] += 1
+            if ok: hits[lang][0] += 1
+            rows.append({"qid": it["qid"], "lang": lang, "query": label,
+                         "hit": ok, "rank": rank})
+        json.dump(rows, open(sys.argv[2], "w"), indent=1)
+
+    print(f"\nEnglish corpus, query language varied — recall@{TOP_K}\n")
+    print(f"{'query lang':12}{'hit@10':>10}{'rate':>9}{'MRR':>8}")
+    for lang in ["en", "de", "fr", "uk", "ru", "ja", "ar"]:
+        good, tot = hits[lang]
+        if not tot: continue
+        mrr = sum(1.0/r["rank"] for r in rows if r["lang"] == lang and r["rank"]) / tot
+        star = "  <- same language as the corpus" if lang == "en" else ""
+        print(f"{lang:12}{good}/{tot:<8}{good/tot:>8.3f}{mrr:>8.3f}{star}")
+
+main()

--- a/bench/wikidata/typer_prompt.txt
+++ b/bench/wikidata/typer_prompt.txt
@@ -1,0 +1,20 @@
+You classify one entity into the memory ontology.
+
+# Entity types
+
+Use exactly one of these type names:
+
+- person        — a human being
+- organization  — a company, institution, party, agency or other body of people
+- location      — a place: a country, city, region or site
+- event         — something that happened over a period of time
+- object        — a physical thing that is none of the above
+
+You are given an entity's name and a one-line description. Reply with EXACTLY two
+lines and nothing else:
+
+TYPE: <one type name from the list, lowercase>
+WHY: <one short clause>
+
+If none of the types fits, answer TYPE: none rather than forcing a fit. A wrong type
+is worse than no type: it files the entity where nothing will look for it.


### PR DESCRIPTION
Three small harnesses that score the memory axes **LoCoMo structurally cannot reach**, against Wikidata as ground truth. Companion to `bench/cmd/locomo`. Written for RFC CO.

## Why Wikidata

The ground truth is free and machine-checkable: `P580`/`P582` map 1:1 onto `valid_at`/`invalid_at`, `P31` is a published type hierarchy, and one item carries labels for the **same identity** in hundreds of languages — so the cross-lingual test needs no translation and no answer-string matching. It's also **CC0**, which is why these fixtures are committed and LoCoMo's cannot be.

## What it measured on v1.66.0

| phase | result |
|---|---|
| CO-1 knowledge updates | **stale-answer rate 0/20**; naive corpus 20/20 |
| CO-3 ontology typing | **63/64 = 0.9844** — the tier's first external number |
| CO-4 cross-lingual | **0.976–1.000** recall@10 over en/de/fr/uk/ru/ja/ar |

**CO-1's result closed its own phase.** A naive corpus of unqualified rows already answered every knowledge-update question, so the bi-temporal tier had no headroom to demonstrate anything and CO-2 was not built. The harness is committed anyway — a measurement that says *"do not build this"* is worth being able to re-run, and it's the only place the control arm exists.

## The control arm is the part not to drop

It answered **14 of 20 questions from training alone**, against an empty scope. Only the six the model *didn't* know are attributable to memory. Without it, the same run reads as "20/20, memory works" — and 70% of that is the model's own knowledge, not retrieval.

CO-3 and CO-4 are measured on the **easy region** of their tasks by construction: CO-3 uses only `P31` values whose base type is unambiguous, CO-4 queries entity labels rather than prose. The README says so where someone about to quote them will read it.

## Two traps documented because both cost a run here

**The memory scope must be the token's subject.** In-band `scope=user` is resolved server-side from the run identity, never from the wire — rows written to any other `scope_id` are invisible to the agent, and every arm reports `NOT_FOUND`, which reads as a memory failure and isn't one. `run_co1.py` now reads it from `/v1/_me` rather than choosing.

**Read an AgentDef back after authoring it.** The mutable fields go under `overlay`; any other key is accepted with a **200, a def_id, and an empty definition**. A run against that agent measures nothing and signals nothing.

## Conventions followed

- Run outputs are **not** committed, matching the gitignored `bench/results/`. Fixtures are inputs, like `bench/cases/*.yaml`.
- `go build ./bench/...` and `go test ./bench/...` unaffected — 9 packages still ok.
- Builders are polite to Wikimedia: contactable `User-Agent`, serial requests, exponential backoff.

Also recorded in the README: QLever moved to **`qlever.dev`**, WDQS rate-limits to 1 req/min under load, and Wikidata's officeholder data contains vandalism, re-election duplicates and generic office items — so `build_fixture.py`'s structural filter is mandatory, and candidates must be **discovered** from `P1313`/`P1906` rather than recalled (20 hand-picked QIDs gave 2 chains; discovery gave 241 of 345).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8
