### PR TITLE
feat(bench): bulk Wikidata fact-corpus builder and importer

### DIFF
--- a/bench/wikidata/README.md
+++ b/bench/wikidata/README.md
@@ -23,6 +23,9 @@ not, and cannot be — that corpus is CC BY-NC.
     build_types.py      -> fixtures/types.json      entities by P31 class (CO-3)
     build_xlingual.py   -> fixtures/xlingual.json   multi-language labels (CO-4)
 
+    build_facts.py      -> a bulk fact corpus (NOT committed — see below)
+    import_facts.py        bulk-load that corpus into a loomcycle memory scope
+
     run_co1.py   knowledge updates: does a superseded fact stop being returned
     run_co3.py   ontology typing:   does an entity get the right base type
     run_co4.py   cross-lingual:     English corpus, non-English query
@@ -55,6 +58,54 @@ which reads as a memory failure and is not one.
 **Read an AgentDef back after authoring it.** The mutable field set goes under
 `overlay`; any other key (`def`, say) is accepted with a 200, a def_id, and an empty
 definition. A run against that agent measures nothing and says so in no way at all.
+
+## Bulk fact corpus, for testing models against a store that holds something
+
+`build_facts.py` renders twelve Wikidata properties into self-contained English
+sentences — *"Marie Curie was born on 1867-11-07"*, not triples, because the sentence
+is what gets embedded and what a model reads back. `import_facts.py` loads them.
+
+    python3 build_facts.py facts.json 1000        # ~8.5k facts, a few minutes
+    python3 import_facts.py facts.json            # writes + embeds
+
+**The corpus itself is NOT committed.** At ~1.3 MB it is an order of magnitude past the
+other fixtures, and it is regenerable. Keep your own copy if you need a specific run to
+be reproducible — see the caveat below.
+
+### Two things this got wrong first, so you do not have to
+
+**Sample across the index, or the corpus is degenerate.** QLever returns rows in index
+order, grouped by object, so a single `LIMIT 1000` query grabs one contiguous block. A
+first build produced **809 of 1000 "is located in Gabon"** and **810 of 996
+"headquartered in Boston"**. That corpus is useless for retrieval testing — most queries
+would have hundreds of equally good answers, and a model would score well or badly for
+reasons having nothing to do with memory. `OFFSETS` spreads the sampling geometrically
+and short-circuits on an empty chunk, because these properties differ in size by orders
+of magnitude. Top-object share after the fix: 0.3%–17.6%.
+
+**Bulk does not go through `Memory op=add`.** That is one LLM call per span and a
+five-figure token bill at this size. Bulk is the off-run PUT with `embed: false`, then
+`/v1/_memory/backfill_embeddings`, which **bounds by work DONE rather than rows seen**
+— so it is driven in a loop until it reports nothing left. A single call silently leaves
+most of the corpus unembedded, and an unembedded row is invisible to recall, which later
+looks exactly like a memory failure. That endpoint also takes **query params, not a JSON
+body**, and `dry_run` defaults to **true**.
+
+### Caveat: regenerable, not byte-stable
+
+A rebuild will not reproduce the same corpus. The builder is deterministic in its
+property list and offsets, but QLever's index order shifts as Wikidata changes, so the
+rows behind a given offset drift. If a number has to be comparable across time, keep the
+`facts.json` that produced it.
+
+Reference figures from the first build (2026-08-29): **8,541 facts**, 22s to write,
+8,541 embedded over 19 backfill rounds with `bge-m3` (1024-dim, ~35 MB of vectors).
+
+Expect genuine obscurity in the long tail — *"S is headquartered in Tokyo"* is a real
+row. For memory testing that is arguably a feature: a model cannot answer from training
+data, so a correct answer is attributable to retrieval. RFC CO-1's control arm exists
+because the opposite case — famous facts the model already knows — silently inflates a
+memory score.
 
 ## Results on v1.66.0 (RFC CO)
 

--- a/bench/wikidata/build_facts.py
+++ b/bench/wikidata/build_facts.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Build a Wikidata fact corpus for loomcycle memory (5k-15k rows).
+
+Facts are rendered as ONE self-contained English sentence each, because that is what
+gets embedded and what a model reads back. "Marie Curie was born on 1867-11-07", not a
+triple — a bag of QIDs embeds badly and reads worse.
+
+Deterministic from the property list + LIMIT, so a rebuild produces the same corpus and
+a later score is comparable. CC0.
+"""
+import json, re, sys, time, urllib.parse, urllib.request
+
+UA = "loomcycle-memory-benchmark/1.0 (fact corpus; research)"
+QLEVER = "https://qlever.dev/api/wikidata"
+
+# (property, object-is-literal, sentence template). Chosen because each renders into a
+# natural sentence without a subordinate clause — a template that needs one produces
+# text no human would write, and the embedding then measures the template.
+PROPS = [
+    ("P569", True,  "{s} was born on {o}."),
+    ("P570", True,  "{s} died on {o}."),
+    ("P571", True,  "{s} was founded on {o}."),
+    ("P27",  False, "{s} is a citizen of {o}."),
+    ("P106", False, "{s} works as a {o}."),
+    ("P19",  False, "{s} was born in {o}."),
+    ("P17",  False, "{s} is located in {o}."),
+    ("P36",  False, "The capital of {s} is {o}."),
+    ("P112", False, "{s} was founded by {o}."),
+    ("P159", False, "{s} is headquartered in {o}."),
+    ("P50",  False, "{s} was written by {o}."),
+    ("P495", False, "{s} originates from {o}."),
+]
+PREFIXES = ("PREFIX wdt: <http://www.wikidata.org/prop/direct/> "
+            "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> ")
+
+def get(url):
+    req = urllib.request.Request(url, headers={
+        "User-Agent": UA, "Accept": "application/sparql-results+json"})
+    for a in range(4):
+        try:
+            return json.loads(urllib.request.urlopen(req, timeout=180).read())
+        except Exception as e:
+            if a == 3:
+                raise
+            time.sleep(2 ** a)
+
+# Offsets spread across the index. A single LIMIT-N query returns one CONTIGUOUS block,
+# and QLever's index order is grouped by object — a first attempt produced 809 of 1000
+# "is located in Gabon" and 810 of 996 "headquartered in Boston". That corpus would make
+# any retrieval test meaningless, because most queries would have hundreds of equally
+# good answers.
+#
+# Geometric rather than uniform, and short-circuiting on an empty chunk, because the
+# properties differ in size by orders of magnitude: P17 has millions of triples, P112
+# far fewer, and a fixed large offset returns nothing for the small ones.
+OFFSETS = [0, 3000, 12000, 40000, 90000, 180000, 320000, 550000, 900000,
+           1400000, 2100000, 3000000, 4200000, 5800000, 7800000]
+
+def query(prop, literal, limit, offset):
+    if literal:
+        q = (PREFIXES + f"SELECT ?s ?sl ?o WHERE {{ ?s wdt:{prop} ?o ; rdfs:label ?sl . "
+             f"FILTER(LANG(?sl)='en') }} LIMIT {limit} OFFSET {offset}")
+    else:
+        q = (PREFIXES + f"SELECT ?s ?sl ?ol WHERE {{ ?s wdt:{prop} ?o ; rdfs:label ?sl . "
+             f"?o rdfs:label ?ol . FILTER(LANG(?sl)='en') FILTER(LANG(?ol)='en') }} "
+             f"LIMIT {limit} OFFSET {offset}")
+    return get(QLEVER + "?" + urllib.parse.urlencode({"query": q}))
+
+def clean_date(v):
+    """A Wikidata time literal is an xsd:dateTime; the day is the useful part. A
+    year-only value arrives as -01-01 and is rendered as the year alone rather than
+    asserting a January 1st that the source never claimed."""
+    m = re.match(r"^([+-]?\d{4})-(\d{2})-(\d{2})", v)
+    if not m:
+        return None
+    y, mo, d = m.groups()
+    if y.startswith("-"):
+        return None                      # BCE: the sentence templates read wrong
+    y = y.lstrip("+")
+    return y if (mo, d) == ("01", "01") else f"{y}-{mo}-{d}"
+
+def main():
+    per = int(sys.argv[2]) if len(sys.argv) > 2 else 1000
+    facts, seen = [], set()
+    for prop, literal, tmpl in PROPS:
+        kept = 0
+        chunk = max(20, per // len(OFFSETS))
+        for off in OFFSETS:
+            if kept >= per:
+                break
+            try:
+                res = query(prop, literal, chunk, off)
+            except Exception as e:
+                print(f"  {prop}@{off}: FAILED {e}", file=sys.stderr)
+                continue
+            rows = res.get("results", {}).get("bindings", [])
+            if not rows:
+                break                      # past the end of this property
+            for b in rows:
+                qid = b["s"]["value"].rsplit("/", 1)[-1]
+                key = f"wiki:{qid}:{prop}"
+                if key in seen:            # one value per (entity, property)
+                    continue
+                subj = (b.get("sl") or {}).get("value", "")
+                if not subj or subj.startswith("Q"):
+                    continue
+                if literal:
+                    obj = clean_date((b.get("o") or {}).get("value", ""))
+                else:
+                    obj = (b.get("ol") or {}).get("value", "")
+                    if obj.startswith("Q"):
+                        obj = ""
+                if not obj:
+                    continue
+                seen.add(key)
+                facts.append({"key": key, "qid": qid, "property": prop,
+                              "text": tmpl.format(s=subj, o=obj)})
+                kept += 1
+            time.sleep(0.4)                # polite; QLever is a shared service
+        print(f"  {prop}: {kept} facts", file=sys.stderr)
+    json.dump({"facts": facts}, open(sys.argv[1], "w"), indent=1)
+    print(f"\nwrote {len(facts)} facts", file=sys.stderr)
+
+main()

--- a/bench/wikidata/import_facts.py
+++ b/bench/wikidata/import_facts.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Bulk-import a Wikidata fact corpus into loomcycle memory.
+
+NOT through `Memory op=add`: that is one LLM call per span and a five-figure token bill
+at this size. Bulk goes through the off-run PUT with embed=false, then
+/v1/_memory/backfill_embeddings vectorizes in batches.
+
+The backfill bounds by work DONE, not rows seen, so it is driven in a loop until it
+reports nothing left — a single call silently leaves most of the corpus unembedded, and
+an unembedded row is invisible to recall.
+"""
+import json, os, sys, time, urllib.parse, urllib.request
+from concurrent.futures import ThreadPoolExecutor
+
+BASE = "http://truenas.local:8787"
+TOK  = os.environ["WIKI_BENCH_TENANT_TOKEN"]
+
+def api(method, path, body=None, timeout=300):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(BASE + path, data=data, method=method,
+        headers={"Authorization": "Bearer " + TOK, "Content-Type": "application/json"})
+    return urllib.request.urlopen(req, timeout=timeout).read()
+
+def main():
+    facts = json.load(open(sys.argv[1]))["facts"]
+    scope = json.loads(api("GET", "/v1/_me"))["subject"]
+    print(f"scope: user/{scope}   facts: {len(facts)}", flush=True)
+
+    # Write unembedded and fast. Concurrency is fine here — this is our own server,
+    # not a public API — but kept modest so the box stays responsive.
+    done = [0]
+    def put(f):
+        api("PUT", f"/v1/_memory/scopes/user/{scope}/keys/{urllib.parse.quote(f['key'], safe='')}",
+            {"value": f["text"], "embed": False})
+        done[0] += 1
+        if done[0] % 500 == 0:
+            print(f"  written {done[0]}/{len(facts)}", flush=True)
+
+    t0 = time.time()
+    with ThreadPoolExecutor(max_workers=8) as ex:
+        list(ex.map(put, facts))
+    print(f"wrote {done[0]} rows in {time.time()-t0:.0f}s\n", flush=True)
+
+    # Vectorize. dry_run defaults TRUE on this endpoint, so it must be said explicitly
+    # or the loop spins forever reporting work it never does.
+    total, rounds = 0, 0
+    while True:
+        rounds += 1
+        q = urllib.parse.urlencode({"scope": "user", "scope_id": scope,
+                                    "dry_run": "false", "limit": 500})
+        out = json.loads(api("POST", "/v1/_memory/backfill_embeddings?" + q, {}, timeout=900))
+        n = out.get("embedded") or out.get("updated") or 0
+        total += n
+        print(f"  round {rounds:3}: embedded {n:4}  stop_reason={out.get('stop_reason')}  total={total}",
+              flush=True)
+        if n == 0:
+            break
+        if rounds > 200:
+            print("  ABORT: too many rounds, something is not converging", flush=True)
+            break
+    print(f"\nembedded {total} rows over {rounds} rounds")
+
+main()


### PR DESCRIPTION
Adds the bulk fact-corpus tooling to `bench/wikidata/` (merged in #1099): a builder that renders Wikidata into sentences, and an importer that loads them into a loomcycle memory scope — so a model can be tested against a store that actually holds something.

Twelve properties rendered as **self-contained English sentences** — *"Marie Curie was born on 1867-11-07"*, not triples, because the sentence is what gets embedded and what a model reads back.

## Sampling spread is the whole trick, and my first attempt got it wrong

QLever returns rows in index order grouped by object, so a single `LIMIT 1000` query grabs one contiguous block:

| property | first attempt | after the fix |
|---|---|---|
| P17 | **809/1000 "located in Gabon"** | 11.4% "United Kingdom" |
| P159 | **810/996 "headquartered in Boston"** | 13.3% "Tokyo" |
| P106 | 378 "federal judge" | 17.6% "painter" |

A corpus like that is useless for retrieval testing — most queries would have hundreds of equally good answers, and a model would score well or badly for reasons having nothing to do with memory. `OFFSETS` spreads the sampling geometrically and short-circuits on an empty chunk, since these properties differ in size by orders of magnitude.

Cost: 11,572 facts → 8,541. Worth it several times over.

## Bulk does not go through `Memory op=add`

That's one LLM call per span and a five-figure token bill at this size. It's the off-run PUT with `embed: false`, then `backfill_embeddings` — which **bounds by work done rather than rows seen**, so it's driven in a loop until it reports nothing left. A single call silently leaves most of the corpus unembedded, and an unembedded row is invisible to recall, which later looks exactly like a memory failure. That endpoint also takes **query params rather than a JSON body**, and `dry_run` defaults to **true**.

## Reference run

8,541 facts, 22s to write, 8,541 embedded over 19 rounds with `bge-m3` (1024-dim, ~35 MB of vectors). Paraphrase queries retrieve correctly — *"who was born in Berlin"* → *"Renee Goddard was born in Berlin."* (0.631), none of them literal matches.

## What is deliberately not committed

**The corpus.** At ~1.3 MB it's an order of magnitude past the other fixtures here, and it's regenerable.

But the README states the caveat plainly: **a rebuild is not byte-stable.** The builder is deterministic in its property list and offsets, yet QLever's index order shifts as Wikidata changes, so the rows behind a given offset drift. Anyone needing a number comparable across time must keep the `facts.json` that produced it.

Also noted: the long tail is genuinely obscure — *"S is headquartered in Tokyo"* is a real row. For memory testing that's arguably a feature, since a model can't answer it from training data and a correct answer is therefore attributable to retrieval. RFC CO-1's control arm exists because the opposite case — famous facts the model already knows — silently inflates a memory score.

`go build ./bench/...` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8
