### PR TITLE
feat(memory): let the ontology declare which scope a type's facts belong in

### DIFF
--- a/internal/memory/ontology.go
+++ b/internal/memory/ontology.go
@@ -82,6 +82,40 @@ type OntologyTerm struct {
 	// beneath, so subclassing a standard type means overriding it as a root chunk and
 	// nesting under your own copy (RFC BZ §10.1).
 	Parent string `json:"parent,omitempty"`
+	// MemoryScope is the memory partition that facts ABOUT this kind of thing belong
+	// in — "user" or "tenant" — as declared on this type, or "" when it declares
+	// nothing.
+	//
+	// WHY IT LIVES HERE. Organisation knowledge ("releases need two approvals") has
+	// nowhere good to live: written to one user's scope it is invisible to everyone
+	// else, and copied to each of them it has N places to be corrected. Deciding
+	// per-FACT means a model judgement in front of every write, thousands of chances
+	// to put a personal fact in front of the whole tenant. Deciding per-TYPE makes it
+	// operator config instead: a handful of declarations, authored once, versioned in
+	// the ontology document, and reviewable on one screen.
+	//
+	// EMPTY IS THE DEFAULT AND MEANS "DO NOT ROUTE". A type that declares nothing
+	// leaves its facts exactly where they are written today. Nothing is promoted
+	// because a type was left alone, so an ontology nobody edits behaves as it always
+	// did — and the same is true of the seed terms, which deliberately declare none.
+	MemoryScope string `json:"memory_scope,omitempty"`
+	// MemoryScopeInherited is the scope resolved from the nearest ancestor that
+	// declares one, or "" when no ancestor does.
+	//
+	// SEPARATE from MemoryScope for the same reason Inherited is separate from Fields:
+	// the operator panel has to be able to say which type actually declared it. A
+	// subclass showing an inherited scope as its own would make the panel claim a
+	// declaration nobody wrote. Consumers want EffectiveMemoryScope.
+	MemoryScopeInherited string `json:"memory_scope_inherited,omitempty"`
+	// MemoryScopeIssue is an operator-facing advisory when the declared value is not
+	// one this can route to.
+	//
+	// The type stays fully in force and its scope stays UNSET — an unusable value must
+	// never be guessed into a real one, because the wrong guess is "tenant" and its
+	// blast radius is every user. Advisory rather than fatal, matching the rest of this
+	// parser: an ontology that dropped a type over a typo'd directive would be worse
+	// than one that ignores the directive and says so.
+	MemoryScopeIssue string `json:"memory_scope_issue,omitempty"`
 }
 
 // BaseSeedOntology is the ontology every tenant starts with: POLE+O — person,
@@ -343,9 +377,41 @@ func ResolveInheritance(terms []OntologyTerm) []OntologyTerm {
 		memo[name] = out
 		return out
 	}
+	// Scope inherits by the same rule as fields — declared beats inherited, nearest
+	// ancestor wins — so an operator declares `organization → tenant` once and every
+	// kind of organization follows. Resolved into its own field rather than folded into
+	// MemoryScope so the panel can still name the type that declared it.
+	//
+	// An INVALID declaration does not block inheritance: the type's own scope is unset
+	// (with an advisory), so it falls through to its ancestor's, which is the same thing
+	// that happens when it declares nothing. Honouring a broken directive by routing
+	// nowhere would be a silent third behaviour.
+	scopeMemo := make(map[string]string, len(terms))
+	var resolveScope func(name string, seen map[string]bool) string
+	resolveScope = func(name string, seen map[string]bool) string {
+		if got, ok := scopeMemo[name]; ok {
+			return got
+		}
+		t, ok := byName[name]
+		if !ok || t.Parent == "" || seen[name] {
+			return ""
+		}
+		seen[name] = true
+		parent, ok := byName[t.Parent]
+		if !ok {
+			return ""
+		}
+		got := parent.MemoryScope
+		if got == "" {
+			got = resolveScope(t.Parent, seen)
+		}
+		scopeMemo[name] = got
+		return got
+	}
 	res := make([]OntologyTerm, 0, len(terms))
 	for _, t := range terms {
 		t.Inherited = resolve(t.Name, map[string]bool{})
+		t.MemoryScopeInherited = resolveScope(t.Name, map[string]bool{})
 		res = append(res, t)
 	}
 	return res
@@ -536,11 +602,106 @@ func ParseOntologyFields(body string) []string {
 		if !strings.HasPrefix(t, "- ") {
 			continue
 		}
-		if f := firstBackticked(t); f != "" {
+		// A reserved `@directive` is not a field. Without this skip, a type that
+		// declared its scope would grow a phantom field named "@memory_scope" — one
+		// the prompt would then instruct a model to fill in.
+		if f := firstBackticked(t); f != "" && !strings.HasPrefix(f, "@") {
 			out = append(out, f)
 		}
 	}
 	return out
+}
+
+// OntologyScopeDirective is the reserved bullet that declares a type's memory scope:
+//
+//	## service
+//	- `@memory_scope` tenant — everybody in the org depends on these
+//	- `name` — what people call it
+//
+// A BULLET rather than a prose line, so it lives inside the grammar the parser and the
+// operator already share, and one code path handles both the whole-document Markdown and
+// a single type's chunk body. The `@` sigil is what keeps it out of the field list: a
+// field is the first backticked token on a bullet, and `@`-prefixed tokens are reserved
+// for directives and skipped (see ParseOntologyFields). Without the sigil this
+// declaration would silently become a field named "memory_scope" on every type that used
+// it.
+const OntologyScopeDirective = "@memory_scope"
+
+// OntologyScopeValues are the scopes a type may declare.
+//
+// `user` and `tenant` only. `agent` is one agent's private keyspace, so it cannot express
+// "facts about this kind of thing belong to X"; `run` is dropped when the run ends. Both
+// would be silently useless here, and a narrow vocabulary is what lets an unrecognised
+// value be reported instead of half-honoured.
+func OntologyScopeValues() []string { return []string{"user", "tenant"} }
+
+// ParseOntologyScope reads the scope directive out of one type's body.
+//
+// Returns the declared scope and an advisory. They are mutually exclusive: a value this
+// cannot route to yields ("", advisory), never a guess. The LAST directive wins, matching
+// how a repeated field would behave, and a body with no directive yields ("", "").
+func ParseOntologyScope(body string) (scope, issue string) {
+	for _, line := range strings.Split(body, "\n") {
+		t := strings.TrimSpace(line)
+		if !strings.HasPrefix(t, "- ") {
+			continue
+		}
+		if firstBackticked(t) != OntologyScopeDirective {
+			continue
+		}
+		raw := directiveValue(t)
+		if raw == "" {
+			scope, issue = "", "`"+OntologyScopeDirective+"` names no scope — write "+
+				"`- `"+OntologyScopeDirective+"` tenant` (or `user`)"
+			continue
+		}
+		valid := false
+		for _, v := range OntologyScopeValues() {
+			if raw == v {
+				valid = true
+				break
+			}
+		}
+		if !valid {
+			scope, issue = "", "`"+OntologyScopeDirective+"` says "+raw+", which is not a "+
+				"scope facts can be placed in (want "+joinComma(OntologyScopeValues())+
+				"); this type is in force but places nothing"
+			continue
+		}
+		scope, issue = raw, ""
+	}
+	return scope, issue
+}
+
+// directiveValue returns the first word after a directive's closing backtick.
+//
+// Prose after the value is the operator's own note and is ignored, exactly as it is on a
+// field bullet — "- `@memory_scope` tenant — everyone sees these" declares `tenant`.
+func directiveValue(line string) string {
+	i := strings.Index(line, "`")
+	if i < 0 {
+		return ""
+	}
+	rest := line[i+1:]
+	j := strings.Index(rest, "`")
+	if j < 0 {
+		return ""
+	}
+	tail := strings.TrimSpace(rest[j+1:])
+	// An em-dash note may follow with no space before it.
+	if k := strings.IndexAny(tail, " \t—:"); k > 0 {
+		tail = tail[:k]
+	}
+	return strings.ToLower(strings.Trim(tail, "`.,;—- \t"))
+}
+
+// EffectiveMemoryScope is a term's scope as a consumer should see it: what it declared,
+// else what it inherits, else "" for "do not route".
+func EffectiveMemoryScope(t OntologyTerm) string {
+	if t.MemoryScope != "" {
+		return t.MemoryScope
+	}
+	return t.MemoryScopeInherited
 }
 
 // ParseOntologyMarkdown extracts terms from the ontology document's Markdown.
@@ -583,7 +744,18 @@ func ParseOntologyMarkdown(md string) []OntologyTerm {
 			// The document title, not a term.
 			flush()
 		case cur != nil && strings.HasPrefix(t, "- "):
-			if f := firstBackticked(t); f != "" {
+			f := firstBackticked(t)
+			switch {
+			case f == OntologyScopeDirective:
+				// Parsed off the single line rather than by re-scanning the body,
+				// because this walker never assembles one.
+				if sc, iss := ParseOntologyScope(t); iss != "" {
+					cur.MemoryScopeIssue = iss
+					cur.MemoryScope = ""
+				} else if sc != "" {
+					cur.MemoryScope, cur.MemoryScopeIssue = sc, ""
+				}
+			case f != "" && !strings.HasPrefix(f, "@"):
 				cur.Fields = append(cur.Fields, f)
 			}
 		}

--- a/internal/memory/ontology.go
+++ b/internal/memory/ontology.go
@@ -651,8 +651,8 @@ func ParseOntologyScope(body string) (scope, issue string) {
 		}
 		raw := directiveValue(t)
 		if raw == "" {
-			scope, issue = "", "`"+OntologyScopeDirective+"` names no scope — write "+
-				"`- `"+OntologyScopeDirective+"` tenant` (or `user`)"
+			scope, issue = "", OntologyScopeDirective+" names no scope — give it one of: "+
+				joinComma(OntologyScopeValues())
 			continue
 		}
 		valid := false
@@ -663,7 +663,7 @@ func ParseOntologyScope(body string) (scope, issue string) {
 			}
 		}
 		if !valid {
-			scope, issue = "", "`"+OntologyScopeDirective+"` says "+raw+", which is not a "+
+			scope, issue = "", OntologyScopeDirective+" says \""+raw+"\", which is not a "+
 				"scope facts can be placed in (want "+joinComma(OntologyScopeValues())+
 				"); this type is in force but places nothing"
 			continue
@@ -688,11 +688,16 @@ func directiveValue(line string) string {
 		return ""
 	}
 	tail := strings.TrimSpace(rest[j+1:])
-	// An em-dash note may follow with no space before it.
-	if k := strings.IndexAny(tail, " \t—:"); k > 0 {
+	// An operator reasonably writes any of `@memory_scope tenant`,
+	// `@memory_scope: tenant` or `@memory_scope = tenant`. Punctuation between the
+	// directive and its value is separator, not value — reading ": tenant" as the scope
+	// would reject a spelling nobody would think to doubt.
+	tail = strings.TrimLeft(tail, ":=—- \t")
+	// A trailing note may follow, with or without a space before its dash.
+	if k := strings.IndexAny(tail, " \t—"); k > 0 {
 		tail = tail[:k]
 	}
-	return strings.ToLower(strings.Trim(tail, "`.,;—- \t"))
+	return strings.ToLower(strings.Trim(tail, "`.,;:—- \t"))
 }
 
 // EffectiveMemoryScope is a term's scope as a consumer should see it: what it declared,

--- a/internal/memory/ontology_scope_test.go
+++ b/internal/memory/ontology_scope_test.go
@@ -1,0 +1,198 @@
+package memory
+
+import (
+	"strings"
+	"testing"
+)
+
+// Organisation knowledge is placed by DECLARATION on the entity type, not by a
+// per-fact model judgement. These tests pin the properties that make that safe: the
+// default routes nothing, an unusable value is never guessed into a real one, and the
+// declaration never reaches the agent-facing prompt.
+
+func TestOntologyScope_DirectiveParsesAndIgnoresTrailingProse(t *testing.T) {
+	for _, tc := range []struct {
+		name, body, want string
+	}{
+		{"bare", "- `@memory_scope` tenant", "tenant"},
+		{"em-dash note", "- `@memory_scope` tenant — everyone in the org depends on these", "tenant"},
+		{"no space before the dash", "- `@memory_scope` user—private to one person", "user"},
+		{"mixed case", "- `@memory_scope` Tenant", "tenant"},
+		{"among fields", "- `name` — what people call it\n- `@memory_scope` tenant\n- `owner` — accountable", "tenant"},
+		{"absent", "- `name` — what people call it", ""},
+		{"last wins", "- `@memory_scope` user\n- `@memory_scope` tenant", "tenant"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, issue := ParseOntologyScope(tc.body)
+			if got != tc.want {
+				t.Errorf("scope = %q, want %q (issue %q)", got, tc.want, issue)
+			}
+			if tc.want != "" && issue != "" {
+				t.Errorf("a valid declaration must carry no advisory, got %q", issue)
+			}
+		})
+	}
+}
+
+// TestOntologyScope_UnusableValueIsReportedNotGuessed is the safety property. The wrong
+// guess here is "tenant", and its blast radius is every user in the tenant — so an
+// unrecognised value must leave the type placing NOTHING and say why.
+func TestOntologyScope_UnusableValueIsReportedNotGuessed(t *testing.T) {
+	for _, body := range []string{
+		"- `@memory_scope` global",
+		"- `@memory_scope` agent",   // a real memory scope, but not one facts can be placed in
+		"- `@memory_scope` run",     // ditto, and ephemeral
+		"- `@memory_scope` TENANTS", // near-miss on a valid value
+		"- `@memory_scope`",         // names nothing at all
+	} {
+		got, issue := ParseOntologyScope(body)
+		if got != "" {
+			t.Errorf("%q: declared scope %q — an unusable value must not resolve to a real scope", body, got)
+		}
+		if issue == "" {
+			t.Errorf("%q: silently ignored; an operator who typo'd this needs to be told", body)
+		}
+	}
+}
+
+// TestOntologyScope_DirectiveIsNotAField guards the reason the `@` sigil exists. Without
+// the skip, every type declaring a scope grows a phantom field the prompt then tells a
+// model to fill in.
+func TestOntologyScope_DirectiveIsNotAField(t *testing.T) {
+	body := "- `name` — what people call it\n- `@memory_scope` tenant\n- `owner` — accountable"
+	for _, f := range ParseOntologyFields(body) {
+		if strings.HasPrefix(f, "@") {
+			t.Errorf("ParseOntologyFields returned the directive %q as a field", f)
+		}
+	}
+	if got := ParseOntologyFields(body); len(got) != 2 {
+		t.Errorf("want exactly the two real fields, got %v", got)
+	}
+
+	// Same guarantee on the whole-document parser, which is a separate code path.
+	terms := ParseOntologyMarkdown("# Tenant Ontology\n\n## service\n" + body + "\n")
+	if len(terms) != 1 {
+		t.Fatalf("want 1 term, got %d", len(terms))
+	}
+	if terms[0].MemoryScope != "tenant" {
+		t.Errorf("markdown parser did not read the directive: %+v", terms[0])
+	}
+	for _, f := range terms[0].Fields {
+		if strings.HasPrefix(f, "@") {
+			t.Errorf("markdown parser kept the directive as a field %q", f)
+		}
+	}
+}
+
+func TestOntologyScope_InheritsFromNearestDeclaringAncestor(t *testing.T) {
+	terms := ResolveInheritance([]OntologyTerm{
+		{Name: "organization", MemoryScope: "tenant"},
+		{Name: "team", Parent: "organization"},                         // inherits tenant
+		{Name: "squad", Parent: "team"},                                // inherits through team
+		{Name: "contact", Parent: "organization", MemoryScope: "user"}, // declared beats inherited
+		{Name: "loose"}, // no ancestor, no declaration
+	})
+	want := map[string]string{
+		"organization": "tenant",
+		"team":         "tenant",
+		"squad":        "tenant",
+		"contact":      "user",
+		"loose":        "",
+	}
+	for _, tm := range terms {
+		if got := EffectiveMemoryScope(tm); got != want[tm.Name] {
+			t.Errorf("%s: effective scope %q, want %q", tm.Name, got, want[tm.Name])
+		}
+	}
+	// The declaring type must still be identifiable: a subclass showing an inherited
+	// scope as its own would make the operator panel claim a declaration nobody wrote.
+	for _, tm := range terms {
+		if tm.Name == "team" && tm.MemoryScope != "" {
+			t.Errorf("team declared nothing, but MemoryScope = %q", tm.MemoryScope)
+		}
+	}
+}
+
+// An invalid declaration must behave exactly like no declaration — falling through to
+// the ancestor — rather than becoming a silent third state that routes nowhere.
+func TestOntologyScope_InvalidDeclarationFallsThroughToTheAncestor(t *testing.T) {
+	_, issue := ParseOntologyScope("- `@memory_scope` nonsense")
+	if issue == "" {
+		t.Fatal("precondition: the value must be reported as unusable")
+	}
+	terms := ResolveInheritance([]OntologyTerm{
+		{Name: "organization", MemoryScope: "tenant"},
+		{Name: "team", Parent: "organization", MemoryScopeIssue: issue},
+	})
+	for _, tm := range terms {
+		if tm.Name == "team" && EffectiveMemoryScope(tm) != "tenant" {
+			t.Errorf("team should inherit tenant despite its own broken directive, got %q",
+				EffectiveMemoryScope(tm))
+		}
+	}
+}
+
+// TestOntologyScope_SeedDeclaresNothing keeps the default inert. A deployment that never
+// edits its ontology must place facts exactly where it does today.
+func TestOntologyScope_SeedDeclaresNothing(t *testing.T) {
+	for _, tm := range BaseSeedOntology() {
+		if tm.MemoryScope != "" {
+			t.Errorf("seed type %q declares scope %q — the seed must route nothing", tm.Name, tm.MemoryScope)
+		}
+	}
+	for _, tm := range EffectiveOntology(nil, false) {
+		if EffectiveMemoryScope(tm) != "" {
+			t.Errorf("unedited ontology places %q in %q", tm.Name, EffectiveMemoryScope(tm))
+		}
+	}
+}
+
+// A draft ontology steers nothing, and that has to include its scope declarations —
+// otherwise a half-written document would start moving facts between partitions before
+// the operator confirmed it.
+func TestOntologyScope_DraftOntologyDeclarationsAreDiscarded(t *testing.T) {
+	tenant := []OntologyTerm{{Name: "service", MemoryScope: "tenant"}}
+
+	for _, tm := range EffectiveOntology(tenant, false) {
+		if tm.Name == "service" {
+			t.Errorf("a DRAFT ontology contributed the type %q at all", tm.Name)
+		}
+	}
+	found := false
+	for _, tm := range EffectiveOntology(tenant, true) {
+		if tm.Name == "service" {
+			found = true
+			if EffectiveMemoryScope(tm) != "tenant" {
+				t.Errorf("confirmed ontology lost the declaration: %+v", tm)
+			}
+		}
+	}
+	if !found {
+		t.Error("a CONFIRMED ontology must contribute the tenant's type")
+	}
+}
+
+// TestOntologyScope_NotRenderedIntoTheAgentPrompt is the one that matters most.
+//
+// The extractor is the weakest link in the memory pipeline — its own bundle calls the
+// prompt "a mitigation, not a guarantee" and caps it in a test because "size is a
+// feature". Placement is deliberately NOT its judgement to make: it emits a type, and an
+// operator's declaration turns that into a partition. Rendering the scope here would hand
+// it the decision this whole design exists to keep away from it.
+func TestOntologyScope_NotRenderedIntoTheAgentPrompt(t *testing.T) {
+	terms := ResolveInheritance([]OntologyTerm{
+		{Name: "organization", Fields: []string{"name"}, MemoryScope: "tenant"},
+		{Name: "team", Parent: "organization", Fields: []string{"lead"}},
+	})
+	rendered := RenderOntology(terms, true)
+	for _, leak := range []string{"memory_scope", OntologyScopeDirective, "tenant scope"} {
+		if strings.Contains(strings.ToLower(rendered), strings.ToLower(leak)) {
+			t.Errorf("the agent-facing ontology prompt mentions %q:\n%s", leak, rendered)
+		}
+	}
+	// It must still render the types themselves — a prompt that lost them would pass
+	// the check above for the wrong reason.
+	if !strings.Contains(rendered, "organization") || !strings.Contains(rendered, "team") {
+		t.Errorf("the prompt lost its types:\n%s", rendered)
+	}
+}

--- a/internal/memory/ontology_scope_test.go
+++ b/internal/memory/ontology_scope_test.go
@@ -21,6 +21,11 @@ func TestOntologyScope_DirectiveParsesAndIgnoresTrailingProse(t *testing.T) {
 		{"among fields", "- `name` — what people call it\n- `@memory_scope` tenant\n- `owner` — accountable", "tenant"},
 		{"absent", "- `name` — what people call it", ""},
 		{"last wins", "- `@memory_scope` user\n- `@memory_scope` tenant", "tenant"},
+		// Separator spellings an operator would not think to doubt.
+		{"colon", "- `@memory_scope`: tenant", "tenant"},
+		{"colon inside prose", "- `@memory_scope`: tenant — shared", "tenant"},
+		{"equals", "- `@memory_scope` = user", "user"},
+		{"value backticked", "- `@memory_scope` `tenant`", "tenant"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			got, issue := ParseOntologyScope(tc.body)
@@ -51,6 +56,16 @@ func TestOntologyScope_UnusableValueIsReportedNotGuessed(t *testing.T) {
 		}
 		if issue == "" {
 			t.Errorf("%q: silently ignored; an operator who typo'd this needs to be told", body)
+			continue
+		}
+		// The advisory is read by a person in a panel. Nested backticks from building it
+		// out of markdown fragments render as garbage, so it must name the directive and
+		// the values plainly.
+		if strings.Contains(issue, "``") {
+			t.Errorf("%q: advisory has collapsed backticks and will render wrong: %s", body, issue)
+		}
+		if !strings.Contains(issue, OntologyScopeDirective) {
+			t.Errorf("%q: advisory does not name the directive: %s", body, issue)
 		}
 	}
 }

--- a/internal/tools/builtin/document_ontology.go
+++ b/internal/tools/builtin/document_ontology.go
@@ -181,11 +181,19 @@ func (d *Document) ontologyForKey(ctx context.Context, key sqlmem.ScopeKey, msco
 				continue
 			}
 			body, _ := d.readBody(ctx, mscope, key.ScopeID, c.id)
+			// The scope directive is read on THIS path too, not only from the
+			// whole-document Markdown. This is the reader the live ontology actually
+			// goes through — one chunk per type — so a declaration parsed in only one
+			// of the two places would work in the template and do nothing in
+			// production.
+			mscopeDecl, mscopeIssue := memrank.ParseOntologyScope(body.Body)
 			out = append(out, memrank.OntologyTerm{
-				Name:   name,
-				Fields: memrank.ParseOntologyFields(body.Body),
-				Source: "tenant",
-				Parent: parentName,
+				Name:             name,
+				Fields:           memrank.ParseOntologyFields(body.Body),
+				Source:           "tenant",
+				Parent:           parentName,
+				MemoryScope:      mscopeDecl,
+				MemoryScopeIssue: mscopeIssue,
 			})
 			// AT the cap, this node's children are reported with this node's OWN
 			// parent — so a would-be level-5 type lands at level 4 as a sibling, and

--- a/internal/tools/builtin/document_ontology_test.go
+++ b/internal/tools/builtin/document_ontology_test.go
@@ -942,3 +942,77 @@ func TestProposeEntity_NeedsNoTenantGrant(t *testing.T) {
 		}
 	}
 }
+
+// TestOntologyTree_ReadsTheScopeDirectiveFromTheChunkBody covers the reader the LIVE
+// ontology actually goes through — one chunk per type — rather than the whole-document
+// Markdown form. A declaration parsed in only one of the two places would work in the
+// template and silently do nothing in production, which is the failure this asserts
+// against.
+func TestOntologyTree_ReadsTheScopeDirectiveFromTheChunkBody(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	path := ontologyDocFixture(t, d, ctx, strings.Join([]string{
+		"# Tenant Ontology",
+		"",
+		"## organization",
+		"",
+		"- `@memory_scope` tenant — everybody in the org depends on these",
+		"- `name` — what people call it",
+		"",
+		"### team",
+		"",
+		"- `lead` — accountable",
+		"",
+		"## preference",
+		"",
+		"- `@memory_scope` user",
+		"- `statement` — the preference itself",
+		"",
+		"## incident",
+		"",
+		"- `@memory_scope` nowhere",
+		"- `cause` — what was responsible",
+		"",
+	}, "\n"))
+
+	got, err := d.OntologyTermsFromTree(ctx, "user", path)
+	if err != nil {
+		t.Fatalf("OntologyTermsFromTree: %v", err)
+	}
+	byName := map[string]memrank.OntologyTerm{}
+	for _, tm := range memrank.ResolveInheritance(got.Terms) {
+		byName[tm.Name] = tm
+	}
+
+	if s := byName["organization"].MemoryScope; s != "tenant" {
+		t.Errorf("organization declared tenant, reader saw %q", s)
+	}
+	if s := byName["preference"].MemoryScope; s != "user" {
+		t.Errorf("preference declared user, reader saw %q", s)
+	}
+	// Inherited down the chunk hierarchy, so `organization → tenant` is declared once.
+	if s := memrank.EffectiveMemoryScope(byName["team"]); s != "tenant" {
+		t.Errorf("team should inherit tenant from organization, got %q", s)
+	}
+	if byName["team"].MemoryScope != "" {
+		t.Errorf("team declared nothing; its own MemoryScope must stay empty, got %q",
+			byName["team"].MemoryScope)
+	}
+	// An unusable value places NOTHING and says so, rather than being guessed into a
+	// real scope — the wrong guess is "tenant" and every user sees it.
+	inc := byName["incident"]
+	if inc.MemoryScope != "" {
+		t.Errorf("incident's bad directive resolved to %q", inc.MemoryScope)
+	}
+	if inc.MemoryScopeIssue == "" {
+		t.Error("incident's bad directive was ignored silently")
+	}
+
+	// And the directive never becomes a field the prompt tells a model to fill in.
+	for name, tm := range byName {
+		for _, f := range append(append([]string{}, tm.Fields...), tm.Inherited...) {
+			if strings.HasPrefix(f, "@") {
+				t.Errorf("%s carries the directive %q as a field", name, f)
+			}
+		}
+	}
+}


### PR DESCRIPTION
RFC CQ, the declaration half. Second PR on that RFC; #1101 (reachability) is the first
and this does not depend on it landing.

## Why

Organisation knowledge has nowhere good to live. *"Releases need two approvals"* written
into one user's scope is invisible to everyone else; copied into each of them it has N
places to be corrected.

The obvious fix is to decide **per fact** — and that is the wrong shape. It puts a model
judgement in front of every write, thousands of independent chances to place a personal
fact in front of the whole tenant, and it lands on the extractor, whose own bundle calls
its prompt *"a mitigation, not a guarantee"* and caps it in a test because *"size is a
feature"*.

Deciding **per type** makes it operator config instead:

```
## service
- `@memory_scope` tenant — everybody in the org depends on these
- `name` — what people call it
```

A handful of declarations, authored once, versioned in the ontology document, reviewable
on one screen. No new model call anywhere — the type is already assigned at extraction
time, so this rides on work that already happens.

## What — and what it does NOT do

**Nothing routes yet.** The value is parsed, inherited and reported; no writer consults
it. That is deliberate: routing lands with its guards, and a store's typing readiness has
to be measured first (see below).

Properties that are the point rather than incidental, each with a test:

- **Empty is the default and routes nothing.** The seed types declare none, so a
  deployment that never edits its ontology behaves exactly as it does today.
- **An unusable value is reported, never guessed.** `agent`, `run` and typos leave the
  type placing nothing, plus an operator advisory. The wrong guess would be `tenant`,
  whose blast radius is every user.
- **The `@` sigil keeps it out of the field list.** A field is the first backticked token
  on a bullet — without the sigil this becomes a phantom field named `memory_scope` that
  the prompt then instructs a model to fill in. The fail-before showed it also
  *propagates down the hierarchy* via inheritance.
- **Inherited like fields.** Declare `organization → tenant` once and every kind of
  organization follows; declared beats inherited, nearest ancestor wins. Kept in its own
  field so the panel can still name the type that actually declared it.
- **Not rendered into the agent prompt.** Placement is not the extractor's judgement to
  make: it emits a type, and an operator's declaration turns that into a partition.
- **A draft ontology declares nothing**, like every other thing a draft ontology says.

Read on **both** paths — the whole-document Markdown and the chunk-per-type tree. The
tree is the one the live ontology goes through, so parsing it in only one place would
work in the template and silently do nothing in production.

The operator surface comes for free: `GET /v1/_ontology` serialises `OntologyTerm`
directly, so the declaration, what it inherits, and any advisory are already reported.

## Why the template is not documented yet

The knob is inert, and inviting an operator to use a knob that does nothing is worse than
not mentioning it. The template gains the directive in the routing PR, where it will be
true.

## What was tested

- `internal/memory/ontology_scope_test.go` — parsing (trailing prose, mixed case,
  last-wins, and the `:` / `=` / backticked-value spellings an operator actually writes),
  the never-guess property, field-list exclusion, inheritance incl. an invalid
  declaration falling through to its ancestor, the inert seed, draft discard, and that
  the prompt does not mention scope.
- `TestOntologyTree_ReadsTheScopeDirectiveFromTheChunkBody` — the live chunk path end to
  end, including a bad directive.
- **Fail-before verified:** removing the `@`-skip fails both packages.
- `go test ./...` — clean, exit 0, no failures anywhere in the complete output.

## Known gap, stated rather than buried

RFC CQ's gate (CQ-1) measures whether a store's entity typing can carry a scope decision
at all. Its preliminary reading **fails**, on a 9-fact dev scope: linkage is 9/9, but 2 of
5 subjects are multiply typed — `user` is both `person` and `location`, so a perfectly
reasonable `location → tenant` declaration would publish a home city. That is a data
problem rather than a design one, and it is why this PR stops at the declaration and the
routing PR will carry the guards (a multiply-typed subject must refuse to place; never
place a claim whose subject is the run's own user).

## Third commit

Self-review on the cold diff found the empty-value advisory built out of markdown
fragments, rendering as collapsed-backtick garbage in the one place it exists to be read;
and `@memory_scope: tenant` parsing as invalid. Both fixed in `30af042f`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8