### PR TITLE
feat(memory): ontology-declared placement — the decision, and an op to ask it

### DIFF
--- a/internal/api/mcp/tools.go
+++ b/internal/api/mcp/tools.go
@@ -236,7 +236,7 @@ func toolDescriptors() []loommcp.ToolDescriptor {
 		// can't drift from the validation the agent loop applies.
 		{
 			Name:        "memory",
-			Description: "Memory tool ops. Families: key/value (get/set/delete/list/incr/merge/append_dedupe/bounded_list/search); memory-layer (add/recall — add enqueues for background consolidation, recall needs an embedder + vector store); SQL (sql_query/sql_exec/sql_begin/sql_commit/sql_rollback — a per-scope SQL database, gated separately by sql_scopes). Pass-through to the underlying Memory builtin; see the inputSchema's op enum.",
+			Description: "Memory tool ops. Families: key/value (get/set/delete/list/incr/merge/append_dedupe/bounded_list/search); memory-layer (add/recall — add enqueues for background consolidation, recall needs an embedder + vector store); SQL (sql_query/sql_exec/sql_begin/sql_commit/sql_rollback — a per-scope SQL database, gated separately by sql_scopes); placement (which scope a batch of {type, subject} facts belongs in, from the operator's per-type declaration on the tenant ontology — it DECIDES and never writes, so a caller that stores a fact in more than one place can ask once and put both halves together). Pass-through to the underlying Memory builtin; see the inputSchema's op enum.",
 			InputSchema: builtinSchema("memory"),
 		},
 		{

--- a/internal/memory/placement.go
+++ b/internal/memory/placement.go
@@ -46,6 +46,22 @@ type PlacementInput struct {
 	// Isolated is the run's server-derived isolation bit. An isolated member has no
 	// tenant plane at all.
 	Isolated bool
+	// GrantedScopes is the calling agent's own memory_scopes.
+	//
+	// THIS IS THE ENABLE SWITCH, and deliberately not a separate flag. Placement writes
+	// to a plane every user in the tenant reads, so it must be something an operator
+	// turned on rather than a side effect of editing a taxonomy. The grant is that act:
+	// an agent without `tenant` in its memory_scopes places nothing there, and a
+	// declaration alone changes nothing until the operator also grants the writer.
+	//
+	// Deciding it HERE rather than letting the write fail at the gate is what makes the
+	// fallback graceful. The alternative is a consolidator that resolves `tenant`,
+	// attempts the write, and errors on a pass that would otherwise have stored the fact
+	// perfectly well in the user's own scope.
+	//
+	// Empty means "not supplied" and is treated as granting nothing, so a caller that
+	// forgets to pass it places nothing rather than everything.
+	GrantedScopes []string
 }
 
 // PlacementDecision is where the fact goes and why.
@@ -113,6 +129,10 @@ func ResolvePlacement(in PlacementInput) PlacementDecision {
 		}
 	}
 
+	if !grants(in.GrantedScopes, target) {
+		return stay("this agent is not granted " + target + " scope, so nothing is placed there")
+	}
+
 	if target == MemoryScopeTenantName && in.Isolated {
 		// The tenant plane is refused to an isolated member at the tool gate anyway.
 		// Deciding it here means the write succeeds in the caller's own scope instead of
@@ -135,6 +155,16 @@ const (
 	MemoryScopeUserName   = "user"
 	MemoryScopeTenantName = "tenant"
 )
+
+// grants reports whether the caller may write the target scope at all.
+func grants(scopes []string, target string) bool {
+	for _, s := range scopes {
+		if strings.EqualFold(strings.TrimSpace(s), target) {
+			return true
+		}
+	}
+	return false
+}
 
 type scopedType struct{ typeName, scope string }
 

--- a/internal/memory/placement.go
+++ b/internal/memory/placement.go
@@ -1,0 +1,201 @@
+package memory
+
+import "strings"
+
+// Placement decides which memory partition a fact belongs in, from the entity type its
+// subject carries and the scope an operator declared on that type.
+//
+// WHY A SEPARATE UNIT. The decision has to be identical wherever it is made, and there is
+// more than one writer: a fact is stored twice — a key/value row that semantic recall
+// searches, and a chunk mirror that the graph walks. Two writers reaching the decision
+// independently is how they drift, and a fact whose halves land in different partitions is
+// worse than one that never moved: recall finds it in one scope and the graph in another.
+//
+// EVERY UNCERTAINTY RESOLVES TO "LEAVE IT WHERE THE CALLER PUT IT". That asymmetry is the
+// whole design. Declining to move a fact costs what the system already costs today — the
+// fact stays in one user's scope. Moving one wrongly puts a person's private sentence in
+// front of everybody in the tenant, and there is no un-publishing it. So this function
+// refuses on: no type, an unknown type, a type nobody declared, a subject that names the
+// run's own user, a subject typed inconsistently, and an isolated member. It commits only
+// when the operator's declaration is unambiguous.
+
+// PlacementInput is everything the decision may read. Assembled by the caller so this
+// stays a pure function — it is the piece under test, and a version that queried a store
+// could not be tested without one.
+type PlacementInput struct {
+	// DeclaredType is the entity type the writer is recording the subject under, e.g.
+	// "service". Empty means the writer named no type, which is the common case on a
+	// small local model and is not an error.
+	DeclaredType string
+	// Subject is the thing the fact is about, as the writer spelled it.
+	Subject string
+	// Terms is the EFFECTIVE ontology — layered, pinned and inheritance-resolved. Pass
+	// what a run would be told, not the raw tenant document, or a subclass inheriting
+	// its scope from an ancestor will read as undeclared.
+	Terms []OntologyTerm
+	// CallerScope is where the writer asked to put it, and the answer whenever this
+	// declines to move it.
+	CallerScope string
+	// UserID identifies the end-user the run belongs to, for the self-subject guard.
+	UserID string
+	// SubjectTypes are the entity types this subject ALREADY carries in the store,
+	// including DeclaredType if it is already recorded. One subject spelled under two
+	// types is the failure mode that makes routing unsafe, so the caller supplies what
+	// it knows and this refuses when they disagree.
+	SubjectTypes []string
+	// Isolated is the run's server-derived isolation bit. An isolated member has no
+	// tenant plane at all.
+	Isolated bool
+}
+
+// PlacementDecision is where the fact goes and why.
+//
+// Reason is populated on every decision, including the refusals, because "why did this
+// fact not move" is the question an operator asks first and the one a silent policy cannot
+// answer.
+type PlacementDecision struct {
+	// Scope is the partition to write to. Always set: a refusal returns CallerScope
+	// rather than "", so no caller has to remember which is which.
+	Scope string
+	// Moved reports whether Scope differs from the caller's own.
+	Moved bool
+	// Reason is a short operator-facing explanation, always set.
+	Reason string
+	// Advisory is set when the store's own data blocked a declared placement — a subject
+	// typed two ways. Distinct from Reason because this one is a data problem an operator
+	// can go and fix, not a normal outcome.
+	Advisory string
+}
+
+// ResolvePlacement is the whole decision.
+func ResolvePlacement(in PlacementInput) PlacementDecision {
+	stay := func(reason string) PlacementDecision {
+		return PlacementDecision{Scope: in.CallerScope, Moved: false, Reason: reason}
+	}
+
+	typ := TrimOntologyName(in.DeclaredType)
+	if typ == "" {
+		return stay("the write names no entity type, so no declaration applies")
+	}
+	if strings.TrimSpace(in.Subject) == "" {
+		// type and subject travel together by the extractor's own contract; a type with
+		// no subject is a malformed write and not something to route on.
+		return stay("the write names a type but no subject")
+	}
+
+	term, ok := findTerm(in.Terms, typ)
+	if !ok {
+		return stay("no type named " + typ + " is in force, so nothing declares where it belongs")
+	}
+	target := EffectiveMemoryScope(term)
+	if target == "" {
+		return stay(typ + " declares no memory scope")
+	}
+
+	// THE SELF GUARD, and it is deliberately placed before the declaration is honoured.
+	// A fact about the person whose run this is belongs to them whatever their ontology
+	// says, because the cost of being wrong here is the one cost this design cannot
+	// accept.
+	if target != MemoryScopeUserName && IsSelfSubject(in.Subject, in.UserID) {
+		return stay("the subject is the run's own user, which is never placed outside their scope")
+	}
+
+	// A subject spelled under two types is the store telling us it does not know what
+	// this thing is. Placing the fact would pick one of the two arbitrarily, and the
+	// arbitrary pick is visible to everybody when it lands in the tenant.
+	if other, conflict := conflictingScope(in, typ, target); conflict {
+		return PlacementDecision{
+			Scope: in.CallerScope, Moved: false,
+			Reason: "left in " + in.CallerScope + " scope: this subject is typed inconsistently",
+			Advisory: "subject " + strings.TrimSpace(in.Subject) + " is recorded as both " + typ +
+				" (→ " + target + ") and " + other.typeName + " (→ " + other.scope + "). " +
+				"Give it ONE type before facts about it can be placed automatically.",
+		}
+	}
+
+	if target == MemoryScopeTenantName && in.Isolated {
+		// The tenant plane is refused to an isolated member at the tool gate anyway.
+		// Deciding it here means the write succeeds in the caller's own scope instead of
+		// failing, which is what an agent written once and run by both kinds of user
+		// needs.
+		return stay("this member is isolated from the tenant plane")
+	}
+
+	if target == in.CallerScope {
+		return PlacementDecision{Scope: target, Moved: false,
+			Reason: typ + " declares " + target + " scope, which is where this was already going"}
+	}
+	return PlacementDecision{Scope: target, Moved: true,
+		Reason: typ + " declares " + target + " scope"}
+}
+
+// Scope names this package decides between. Spelled here rather than imported from the
+// store package to keep this unit free of it — the two must agree, and a test asserts it.
+const (
+	MemoryScopeUserName   = "user"
+	MemoryScopeTenantName = "tenant"
+)
+
+type scopedType struct{ typeName, scope string }
+
+// conflictingScope reports whether the subject's OTHER recorded types would place it
+// somewhere else.
+//
+// Only a disagreement about the SCOPE counts. A subject typed both `service` and
+// `internal-service` is not a problem when both resolve to the tenant — the ontology is
+// imprecise but the placement is not in doubt.
+func conflictingScope(in PlacementInput, typ, target string) (scopedType, bool) {
+	for _, other := range in.SubjectTypes {
+		o := TrimOntologyName(other)
+		if o == "" || strings.EqualFold(o, typ) {
+			continue
+		}
+		term, ok := findTerm(in.Terms, o)
+		if !ok {
+			// An unknown type declares nothing, so it cannot contradict a declaration.
+			continue
+		}
+		got := EffectiveMemoryScope(term)
+		if got == "" || got == target {
+			continue
+		}
+		return scopedType{typeName: o, scope: got}, true
+	}
+	return scopedType{}, false
+}
+
+func findTerm(terms []OntologyTerm, name string) (OntologyTerm, bool) {
+	for _, t := range terms {
+		if strings.EqualFold(t.Name, name) {
+			return t, true
+		}
+	}
+	return OntologyTerm{}, false
+}
+
+// IsSelfSubject reports whether a subject names the end-user of the run rather than some
+// third party.
+//
+// ⚠️ THIS GUARD IS INCOMPLETE AND CANNOT BE COMPLETED HERE. It catches the way the
+// extractor actually spells a self-reference — a live store has entities literally named
+// "user" carrying facts like "The user resides in Cluj-Napoca, Romania" — and the run's
+// own user id. It CANNOT catch a fact recorded about the same person under their own
+// name: "Denn prefers Go" is indistinguishable from "Maria owns the release process"
+// without knowing who Denn is, and this function is not told.
+//
+// So it narrows the exposure and does not close it. That is the argument for an operator
+// seeing a placement before it goes live, and it is why this returns a REFUSAL to move
+// rather than a licence to move whatever it does not recognise.
+func IsSelfSubject(subject, userID string) bool {
+	s := strings.ToLower(strings.TrimSpace(subject))
+	s = strings.TrimPrefix(s, "the ")
+	if s == "" {
+		return false
+	}
+	for _, self := range []string{"user", "me", "i", "myself", "operator", "current user"} {
+		if s == self {
+			return true
+		}
+	}
+	return userID != "" && strings.EqualFold(s, strings.TrimSpace(userID))
+}

--- a/internal/memory/placement_test.go
+++ b/internal/memory/placement_test.go
@@ -30,6 +30,11 @@ func base(in PlacementInput) PlacementInput {
 	if in.UserID == "" {
 		in.UserID = "u_alice"
 	}
+	// The fixture grants both, so each test exercises the guard it is about rather than
+	// the grant. TestResolvePlacement_AnUngrantedScopeIsNeverPlaced covers the grant.
+	if in.GrantedScopes == nil {
+		in.GrantedScopes = []string{"agent", "user", "tenant"}
+	}
 	return in
 }
 
@@ -195,5 +200,39 @@ func TestResolvePlacement_ScopeNamesMatchTheStore(t *testing.T) {
 	}
 	if MemoryScopeTenantName != string(store.MemoryScopeTenant) {
 		t.Errorf("tenant scope name drifted: %q vs %q", MemoryScopeTenantName, store.MemoryScopeTenant)
+	}
+}
+
+// TestResolvePlacement_AnUngrantedScopeIsNeverPlaced is the enable switch. A declaration
+// on its own must change nothing until the operator also grants the writer — otherwise
+// editing a taxonomy would start publishing to the shared plane as a side effect.
+func TestResolvePlacement_AnUngrantedScopeIsNeverPlaced(t *testing.T) {
+	for _, granted := range [][]string{
+		nil,               // not supplied at all: grants nothing
+		{},                // explicitly empty
+		{"agent", "user"}, // the shipped consolidator's grant today
+	} {
+		// Constructed WITHOUT base(), which fills a nil grant and would defeat the
+		// first case — the one that matters most, since a caller that forgets the
+		// field must place nothing rather than everything.
+		got := ResolvePlacement(PlacementInput{
+			DeclaredType: "service", Subject: "checkout-api", GrantedScopes: granted,
+			Terms: placementOntology(), CallerScope: "user", UserID: "u_alice",
+		})
+		if got.Moved || got.Scope != "user" {
+			t.Errorf("granted %v: placed in %q — an ungranted scope must never be written: %s",
+				granted, got.Scope, got.Reason)
+		}
+		if !strings.Contains(got.Reason, "not granted") {
+			t.Errorf("granted %v: the reason should name the missing grant, got %q", granted, got.Reason)
+		}
+	}
+	// And with the grant, the same fact is placed — or the guard would be a blanket veto.
+	got := ResolvePlacement(base(PlacementInput{
+		DeclaredType: "service", Subject: "checkout-api",
+		GrantedScopes: []string{"user", "tenant"},
+	}))
+	if !got.Moved || got.Scope != "tenant" {
+		t.Errorf("with the grant the fact should be placed, got %+v", got)
 	}
 }

--- a/internal/memory/placement_test.go
+++ b/internal/memory/placement_test.go
@@ -1,0 +1,199 @@
+package memory
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// placementOntology is a small confirmed ontology with the two declarations that matter
+// and one subclass, resolved the way a run would see it.
+func placementOntology() []OntologyTerm {
+	return ResolveInheritance([]OntologyTerm{
+		{Name: "service", MemoryScope: "tenant"},
+		{Name: "internal-service", Parent: "service"}, // inherits tenant
+		{Name: "policy", MemoryScope: "tenant"},
+		{Name: "person", MemoryScope: "user"},
+		{Name: "location"}, // in force, declares nothing
+		{Name: "incident"}, // ditto
+	})
+}
+
+func base(in PlacementInput) PlacementInput {
+	if in.Terms == nil {
+		in.Terms = placementOntology()
+	}
+	if in.CallerScope == "" {
+		in.CallerScope = "user"
+	}
+	if in.UserID == "" {
+		in.UserID = "u_alice"
+	}
+	return in
+}
+
+func TestResolvePlacement_HonoursTheDeclarationIncludingThroughInheritance(t *testing.T) {
+	for _, tc := range []struct{ name, typ, subject, want string }{
+		{"declared tenant", "service", "checkout-api", "tenant"},
+		{"inherited tenant", "internal-service", "billing-worker", "tenant"},
+		{"declared tenant, another type", "policy", "release approvals", "tenant"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ResolvePlacement(base(PlacementInput{DeclaredType: tc.typ, Subject: tc.subject}))
+			if got.Scope != tc.want {
+				t.Errorf("scope = %q, want %q (%s)", got.Scope, tc.want, got.Reason)
+			}
+			if !got.Moved {
+				t.Errorf("want a move away from the caller's scope, got %+v", got)
+			}
+			if got.Reason == "" {
+				t.Error("every decision must carry a reason")
+			}
+		})
+	}
+}
+
+// Each of these is a reason to leave the fact alone. Together they are the design: an
+// uncertain placement is not a placement.
+func TestResolvePlacement_EveryUncertaintyLeavesTheFactWhereItWas(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   PlacementInput
+	}{
+		{"no type named", PlacementInput{Subject: "checkout-api"}},
+		{"type but no subject", PlacementInput{DeclaredType: "service"}},
+		{"type not in force", PlacementInput{DeclaredType: "spacecraft", Subject: "voyager"}},
+		{"type declares nothing", PlacementInput{DeclaredType: "location", Subject: "Cluj-Napoca"}},
+		{"isolated member", PlacementInput{DeclaredType: "service", Subject: "checkout-api", Isolated: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			in := base(tc.in)
+			got := ResolvePlacement(in)
+			if got.Scope != in.CallerScope {
+				t.Errorf("scope = %q, want the caller's %q", got.Scope, in.CallerScope)
+			}
+			if got.Moved {
+				t.Errorf("must not report a move: %+v", got)
+			}
+			if got.Reason == "" {
+				t.Error("a refusal has to say why — it is the first thing an operator asks")
+			}
+		})
+	}
+}
+
+// TestResolvePlacement_NeverPlacesTheRunsOwnUserOutsideTheirScope is the safety guard,
+// and it must beat the declaration rather than defer to it.
+func TestResolvePlacement_NeverPlacesTheRunsOwnUserOutsideTheirScope(t *testing.T) {
+	// A live store types the end-user's own entity as `person` AND as `location` — the
+	// second is what carries "The user resides in Cluj-Napoca, Romania". An operator
+	// declaring location→tenant is being entirely reasonable, and it must not publish a
+	// home city.
+	terms := ResolveInheritance([]OntologyTerm{
+		{Name: "location", MemoryScope: "tenant"},
+		{Name: "person", MemoryScope: "tenant"}, // even declared tenant, the user is exempt
+	})
+	for _, subject := range []string{"user", "the user", "User", "me", "u_alice", " user "} {
+		got := ResolvePlacement(base(PlacementInput{
+			DeclaredType: "location", Subject: subject, Terms: terms,
+		}))
+		if got.Moved || got.Scope != "user" {
+			t.Errorf("subject %q was placed in %q — a fact about the run's own user must stay put: %s",
+				subject, got.Scope, got.Reason)
+		}
+	}
+	// A third party under the same type is placed, or the guard would be a blanket veto.
+	got := ResolvePlacement(base(PlacementInput{
+		DeclaredType: "location", Subject: "Cluj-Napoca office", Terms: terms,
+	}))
+	if !got.Moved || got.Scope != "tenant" {
+		t.Errorf("a genuine location should be placed in tenant, got %+v", got)
+	}
+}
+
+// TestResolvePlacement_SelfGuardCannotCatchTheUsersOwnName documents the hole rather than
+// pretending it is closed. A fact about the end-user recorded under their own name is
+// indistinguishable from a fact about a colleague, so automatic placement WILL sometimes
+// publish a personal fact.
+//
+// Asserted so the limitation is visible in the suite and cannot be forgotten when someone
+// reasons about how safe automatic placement is.
+func TestResolvePlacement_SelfGuardCannotCatchTheUsersOwnName(t *testing.T) {
+	terms := ResolveInheritance([]OntologyTerm{{Name: "person", MemoryScope: "tenant"}})
+	got := ResolvePlacement(base(PlacementInput{
+		DeclaredType: "person", Subject: "Denn", Terms: terms, UserID: "u_alice",
+	}))
+	if !got.Moved {
+		t.Skip("the guard has been widened to catch a named self-reference — update this test and the comment on IsSelfSubject")
+	}
+	if got.Scope != "tenant" {
+		t.Fatalf("unexpected scope %q", got.Scope)
+	}
+	t.Log("KNOWN AND UNCLOSED: a fact about the end-user under their own name is placed " +
+		"like a fact about anyone else. This is why an operator should see a placement " +
+		"before it goes live.")
+}
+
+// TestResolvePlacement_InconsistentlyTypedSubjectIsRefusedWithSomethingActionable is the
+// guard for the defect a real store already has.
+func TestResolvePlacement_InconsistentlyTypedSubjectIsRefusedWithSomethingActionable(t *testing.T) {
+	got := ResolvePlacement(base(PlacementInput{
+		DeclaredType: "service",
+		Subject:      "loomboard",
+		SubjectTypes: []string{"service", "person"}, // person → user, service → tenant
+	}))
+	if got.Moved {
+		t.Errorf("a subject typed two ways must not be placed: %+v", got)
+	}
+	if got.Advisory == "" {
+		t.Fatal("this is a data problem an operator can fix, so it must produce an advisory")
+	}
+	for _, want := range []string{"loomboard", "service", "person", "tenant", "user"} {
+		if !strings.Contains(got.Advisory, want) {
+			t.Errorf("the advisory must name %q so the operator can act on it: %s", want, got.Advisory)
+		}
+	}
+}
+
+// Types that disagree about the NAME but agree about the SCOPE are not a conflict. The
+// ontology is imprecise; the placement is not in doubt.
+func TestResolvePlacement_TypesAgreeingOnScopeAreNotAConflict(t *testing.T) {
+	got := ResolvePlacement(base(PlacementInput{
+		DeclaredType: "service",
+		Subject:      "checkout-api",
+		SubjectTypes: []string{"service", "internal-service", "spacecraft"}, // both tenant; one unknown
+	}))
+	if !got.Moved || got.Scope != "tenant" {
+		t.Errorf("agreeing types should still place: %+v (advisory %q)", got, got.Advisory)
+	}
+	if got.Advisory != "" {
+		t.Errorf("no conflict, so no advisory: %q", got.Advisory)
+	}
+}
+
+// A declaration that matches where the write was already going is honoured without being
+// reported as a move — a caller logging every move would otherwise log every user-scope
+// write on a store that declares person→user.
+func TestResolvePlacement_DeclaringTheCallersOwnScopeIsNotAMove(t *testing.T) {
+	got := ResolvePlacement(base(PlacementInput{
+		DeclaredType: "person", Subject: "Maria", CallerScope: "user",
+	}))
+	if got.Scope != "user" {
+		t.Errorf("scope = %q, want user", got.Scope)
+	}
+	if got.Moved {
+		t.Errorf("same scope is not a move: %+v", got)
+	}
+}
+
+// The scope names in this package must be the store's own, or a decision made here would
+// name a partition the writer cannot resolve.
+func TestResolvePlacement_ScopeNamesMatchTheStore(t *testing.T) {
+	if MemoryScopeUserName != string(store.MemoryScopeUser) {
+		t.Errorf("user scope name drifted: %q vs %q", MemoryScopeUserName, store.MemoryScopeUser)
+	}
+	if MemoryScopeTenantName != string(store.MemoryScopeTenant) {
+		t.Errorf("tenant scope name drifted: %q vs %q", MemoryScopeTenantName, store.MemoryScopeTenant)
+	}
+}

--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -269,18 +269,20 @@ const memoryDescription = `Persistent key/value storage scoped to this agent or 
 	`v0.9.0: pass embed=true with embed_text on set to enable semantic search; use op=search with query to find rows by similarity. ` +
 	`v0.12.x: merge / append_dedupe / bounded_list are atomic reducers — use them instead of get-modify-set when concurrent updates are possible. ` +
 	`add / recall: add ingests conversation messages for durable memory — on the default backend it enqueues them for background consolidation and returns status "pending" (a scheduled consolidator later distils durable facts); recall is a natural-language semantic search over stored memories and needs an embedder + a vector-capable store (otherwise it returns vector_unsupported / embedder_not_configured). A backend that is not memory-layer-capable returns capability_unsupported. Unlike set/get, add does not store value-at-key and is async — do not assume read-after-write. search / recall accept a "when" object to narrow by WHEN something was said (see the schema; give a generous window, because a remark usually follows the event it describes), and set accepts "observed_at" to date a row so "when" can find it. recall returns {"memories": [{id, memory, score, kind}]}: each item is something REMEMBERED, not something established — a "note" is a remark an agent recorded, only a "fact" has been distilled and reconciled by a consolidator. A remembered remark often carries the time it was SAID (e.g. a leading timestamp); when it refers to "yesterday" or "last week", the event happened relative to that time and is not the timestamp itself. ` +
+	`placement: answers WHICH SCOPE a batch of facts belongs in, and writes nothing. Pass items:[{type,subject}] plus the scope you were going to use; each answer carries the scope to write, whether that differs from yours, and why. The scope comes from the operator's per-type declaration on the tenant ontology, never from you — an undeclared type, an unknown one, a subject that names the run's own user, a subject typed inconsistently, or a scope this agent is not granted all answer with the scope you passed in. Ask ONCE per batch before writing: a fact stored in more than one place must have both halves in the same scope. ` +
 	`SQL Memory (a DISTINCT capability of this tool, gated separately by the agent's sql_scopes — having Memory alone does NOT grant it): sql_query runs a read-only SELECT and sql_exec runs a single DDL/DML statement (CREATE/INSERT/UPDATE/DELETE) against a per-scope SQL database SEPARATE from the key/value memory above. Pass statement (one statement, no ATTACH/PRAGMA/load_extension/multiple statements) and optional positional args for ? placeholders. scope selects the database: agent (this agent, durable), user (this end-user, durable), or run (ephemeral, dropped when the run ends). For atomic multi-step writes, sql_begin opens a transaction for the scope, subsequent sql_exec/sql_query run on it, and sql_commit / sql_rollback finish it (it auto-rolls-back if the run ends or it is abandoned). A second sql_begin while one is open NESTS a savepoint — sql_commit/sql_rollback then affect the innermost level (the outer transaction continues on rollback); each result reports the current depth (0 = closed). Requires sql_scopes on the agent AND the server-side subsystem enabled.`
 
 const memoryInputSchema = `{
   "type": "object",
   "properties": {
-    "op":         {"type": "string", "enum": ["get","set","delete","list","incr","search","merge","append_dedupe","bounded_list","add","recall","sql_query","sql_exec","sql_begin","sql_commit","sql_rollback","cursor_get","cursor_scan","cursor_lease","cursor_advance","cursor_release","supersede","pending_drain","pending_ack"], "description": "Which operation to perform. Families: key/value (get,set,delete,list,incr,merge,append_dedupe,bounded_list,search); memory-layer (add,recall — add enqueues for background consolidation, recall needs the vector stack); SQL (sql_query,sql_exec,sql_begin,sql_commit,sql_rollback — a per-scope SQL database, gated separately by sql_scopes); consolidation (cursor_get,cursor_scan,cursor_lease,cursor_advance,cursor_release,supersede,pending_drain,pending_ack — background memory consolidation, gated separately by a dedicated grant)."},
+    "op":         {"type": "string", "enum": ["get","set","delete","list","incr","search","merge","append_dedupe","bounded_list","add","recall","placement","sql_query","sql_exec","sql_begin","sql_commit","sql_rollback","cursor_get","cursor_scan","cursor_lease","cursor_advance","cursor_release","supersede","pending_drain","pending_ack"], "description": "Which operation to perform. Families: key/value (get,set,delete,list,incr,merge,append_dedupe,bounded_list,search); memory-layer (add,recall — add enqueues for background consolidation, recall needs the vector stack); SQL (sql_query,sql_exec,sql_begin,sql_commit,sql_rollback — a per-scope SQL database, gated separately by sql_scopes); consolidation (cursor_get,cursor_scan,cursor_lease,cursor_advance,cursor_release,supersede,pending_drain,pending_ack — background memory consolidation, gated separately by a dedicated grant)."},
     "scope":      {"type": "string", "enum": ["agent","user","tenant","run"], "description": "Which keyspace/database. ONE scope per call, and a call reads ONLY the scope you name: a user-scope search or recall does NOT see tenant knowledge, and a tenant-scope one does not see the user's. To consult both, make TWO calls and merge the results by score — that recovers exactly what one combined query would have returned. agent: this agent's (cross-run, cross-user). user: this end-user's (cross-agent). tenant: knowledge shared across the tenant — the place for what is true of the whole organisation rather than of one person, read by every user and agent, and never included in a user-scope recall. run: ephemeral per-run, dropped at run end — SQL ops only."},
     "key":        {"type": "string", "description": "The entry's key. Required for get / set / delete / incr / merge / append_dedupe / bounded_list."},
     "value":      {"description": "The JSON value. Required for set / merge / append_dedupe / bounded_list. For merge: a JSON object whose fields overlay the existing object. For append_dedupe / bounded_list: the item to append."},
     "delta":      {"type": "integer", "description": "Increment delta for incr (default 1, may be negative)."},
     "ttl":        {"type": "integer", "description": "Optional time-to-live in seconds. Applies to write ops; 0 means no expiry (or keep existing on update)."},
     "prefix":     {"type": "string", "description": "Optional key prefix filter for list / search."},
+    "items":      {"type": "array", "items": {"type": "object", "properties": {"type": {"type": "string"}, "subject": {"type": "string"}}, "required": ["type","subject"]}, "description": "placement: the {type, subject} pairs you are about to store. Ask once for the whole batch — one ontology read serves all of them."},
     "sources":    {"type": "array", "items": {"type": "string", "enum": ["facts","notes","documents"]}, "description": "search / recall: which kinds of remembered thing to return. \"facts\" = memory a consolidator distilled; \"notes\" = memory an agent wrote directly; \"documents\" = Document chunk bodies, which share the memory keyspace. recall defaults to facts+notes (document prose is not something you were told); search defaults to everything. Each result carries a matching \"kind\". Mixing documents with only ONE of facts/notes is refused — use [facts], [notes], [facts,notes], [documents], or all three. Use this instead of guessing key prefixes."},
     "limit":      {"type": "integer", "description": "list: max entries returned (default 100). bounded_list: keep the N most recent items (required, >= 1). cursor_scan: max chats returned in one page (default 10, max 50)."},
     "embed":      {"type": "boolean", "description": "v0.9.0 set-only: when true, also generates and stores an embedding so this row is reachable via op=search."},
@@ -312,6 +314,14 @@ const memoryInputSchema = `{
   "additionalProperties": false
 }`
 
+// memoryPlacementItem is one thing the caller is about to record. Type and subject
+// travel together — a type with no subject names nothing, and the ontology governs
+// subjects, not sentences.
+type memoryPlacementItem struct {
+	Type    string `json:"type"`
+	Subject string `json:"subject"`
+}
+
 type memoryInput struct {
 	Op    string `json:"op"`
 	Scope string `json:"scope"`
@@ -320,11 +330,14 @@ type memoryInput struct {
 	// tree. On `set`, a memory_entry dirent is registered at this path; on
 	// `get`, the path resolves to the entry's key (an alternative to `key`).
 	// Same (scope, scope_id) as the entry; tenant from the run identity.
-	Path   string          `json:"path,omitempty"`
-	Value  json.RawMessage `json:"value,omitempty"`
-	Delta  *int64          `json:"delta,omitempty"`
-	TTL    int64           `json:"ttl,omitempty"`
-	Prefix string          `json:"prefix,omitempty"`
+	Path string `json:"path,omitempty"`
+	// Items is the `placement` batch: the {type, subject} pairs a writer is about to
+	// store, asked about together so one ontology read serves the whole pass.
+	Items  []memoryPlacementItem `json:"items,omitempty"`
+	Value  json.RawMessage       `json:"value,omitempty"`
+	Delta  *int64                `json:"delta,omitempty"`
+	TTL    int64                 `json:"ttl,omitempty"`
+	Prefix string                `json:"prefix,omitempty"`
 	// Sources selects WHICH KINDS of remembered thing search/recall may return
 	// (RFC BW): "facts" (the agent's own memory) and/or "documents" (Document chunk
 	// bodies, which share the memory keyspace). It is the named alternative to making
@@ -567,6 +580,8 @@ func (m *Memory) Execute(ctx context.Context, raw json.RawMessage) (tools.Result
 		return m.execAdd(ctx, scope, scopeID, in)
 	case "recall":
 		return m.execRecall(ctx, scope, scopeID, in)
+	case "placement":
+		return m.execPlacement(ctx, scope, in)
 	case "cursor_get":
 		return m.execCursorGet(ctx, scope, scopeID, in)
 	case "cursor_scan":
@@ -586,7 +601,7 @@ func (m *Memory) Execute(ctx context.Context, raw json.RawMessage) (tools.Result
 	case "":
 		return errResult("missing required field: op"), nil
 	default:
-		return errResult(fmt.Sprintf("unknown op %q (must be one of: get, set, delete, list, incr, search, merge, append_dedupe, bounded_list, add, recall, cursor_get, cursor_scan, cursor_lease, cursor_advance, cursor_release, supersede, pending_drain, pending_ack, sql_query, sql_exec, sql_begin, sql_commit, sql_rollback)", in.Op)), nil
+		return errResult(fmt.Sprintf("unknown op %q (must be one of: get, set, delete, list, incr, search, merge, append_dedupe, bounded_list, add, recall, placement, cursor_get, cursor_scan, cursor_lease, cursor_advance, cursor_release, supersede, pending_drain, pending_ack, sql_query, sql_exec, sql_begin, sql_commit, sql_rollback)", in.Op)), nil
 	}
 }
 

--- a/internal/tools/builtin/memory_placement.go
+++ b/internal/tools/builtin/memory_placement.go
@@ -1,0 +1,173 @@
+package builtin
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	memrank "github.com/denn-gubsky/loomcycle/internal/memory"
+	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// placementBatchMax bounds one call. The caller is a consolidation pass, whose fact
+// count an operator does not control, and each distinct subject costs a query.
+const placementBatchMax = 200
+
+// execPlacement answers "where does a fact about this subject belong" for a batch, and
+// writes nothing.
+//
+// WHY AN OP AND NOT A SERVER-SIDE REDIRECT. A fact is stored twice — a key/value row that
+// semantic recall searches, and a chunk mirror the graph walks — and only the chunk write
+// carries the type and subject the decision needs. Resolving it independently on each path
+// would mean two writers agreeing by luck, and a fact whose halves land in different
+// partitions is worse than one that never moved: recall finds it in one scope and the
+// graph in another.
+//
+// So the decision is made ONCE, by the writer that owns both halves, before either is
+// written. That also keeps the scope gate intact: the caller then writes to the scope it
+// was told, through the ordinary grant check, instead of the server silently redirecting a
+// write to a plane the caller was never granted. An operator reading `memory_scopes` still
+// sees the whole truth about what an agent can reach.
+func (m *Memory) execPlacement(ctx context.Context, callerScope store.MemoryScope, in memoryInput) (tools.Result, error) {
+	if len(in.Items) == 0 {
+		return errResult("placement: items is required — pass [{\"type\":\"service\",\"subject\":\"checkout-api\"}, …] " +
+			"for the facts you are about to write"), nil
+	}
+	if len(in.Items) > placementBatchMax {
+		return errResult(fmt.Sprintf("placement: %d items, over the %d limit — split the batch",
+			len(in.Items), placementBatchMax)), nil
+	}
+
+	policy := tools.MemoryPolicy(ctx)
+	ident := tools.RunIdentity(ctx)
+
+	// FAILS CLOSED, unlike the retrieval-side ontology reads. Those fail open because an
+	// unreadable ontology should still answer the question narrowly; here "I could not
+	// read the declarations" must mean "place nothing", since the alternative is placing
+	// on a guess.
+	terms, confirmed, exists := m.placementOntology(ctx)
+	reasonNoOntology := ""
+	switch {
+	case m.SqlMem == nil:
+		reasonNoOntology = "SQL Memory is not enabled, so no ontology can be read"
+	case !exists:
+		reasonNoOntology = "this tenant has no ontology document, so nothing declares where facts belong"
+	case !confirmed:
+		reasonNoOntology = "this tenant's ontology is a draft, so its declarations are not in force"
+	}
+
+	effective := memrank.EffectiveOntology(terms, confirmed)
+	out := make([]map[string]any, 0, len(in.Items))
+	moved := 0
+	subjectTypes := map[string][]string{}
+
+	for _, it := range in.Items {
+		row := map[string]any{
+			"type":    it.Type,
+			"subject": it.Subject,
+			"scope":   string(callerScope),
+			"moved":   false,
+		}
+		if reasonNoOntology != "" {
+			row["reason"] = reasonNoOntology
+			out = append(out, row)
+			continue
+		}
+		// Looked up lazily and memoised per call: a pass usually writes several facts
+		// about the same handful of subjects, and the query only matters for a subject a
+		// declaration would actually move.
+		subj := strings.ToLower(strings.TrimSpace(it.Subject))
+		if _, seen := subjectTypes[subj]; !seen && subj != "" {
+			subjectTypes[subj] = m.typesForSubject(ctx, it.Subject)
+		}
+		d := memrank.ResolvePlacement(memrank.PlacementInput{
+			DeclaredType:  it.Type,
+			Subject:       it.Subject,
+			Terms:         effective,
+			CallerScope:   string(callerScope),
+			UserID:        ident.UserID,
+			SubjectTypes:  subjectTypes[subj],
+			Isolated:      ident.Isolated,
+			GrantedScopes: policy.AllowedScopes,
+		})
+		row["scope"], row["moved"], row["reason"] = d.Scope, d.Moved, d.Reason
+		if d.Advisory != "" {
+			row["advisory"] = d.Advisory
+		}
+		if d.Moved {
+			moved++
+		}
+		out = append(out, row)
+	}
+
+	return jsonResult(map[string]any{
+		"placements":     out,
+		"moved":          moved,
+		"caller_scope":   string(callerScope),
+		"granted_scopes": policy.AllowedScopes,
+	})
+}
+
+// placementOntology reads the tenant's effective ontology terms.
+//
+// Goes through the Document reader rather than duplicating it: the ontology lives in
+// chunks, and a second reader is a second thing to keep in step with the hierarchy, the
+// pinned roots and the inert-proposal rule.
+func (m *Memory) placementOntology(ctx context.Context) (terms []memrank.OntologyTerm, confirmed, exists bool) {
+	if m.Store == nil || m.SqlMem == nil {
+		return nil, false, false
+	}
+	d := &Document{Store: m.Store, SqlMem: m.SqlMem}
+	return d.tenantOntologyState(ctx)
+}
+
+// typesForSubject returns the entity types this subject is already recorded under, in the
+// run's own user scope.
+//
+// The subject is the identity node's TITLE — a live store holds nodes titled "user",
+// "loomboard", "git configuration" — so this is a title match, not a natural-key parse.
+// Natural keys embed a slug of the subject under each type ("person:user",
+// "location:user"), which is exactly the shape that would make a prefix scan miss.
+//
+// One query per distinct subject rather than one batched IN clause. A pass has few
+// distinct subjects, and a hand-built placeholder list is where this kind of code grows a
+// dialect bug — the count has already been wrong once in this repo on Postgres.
+//
+// Best-effort: a fault returns nothing, which means the conflict guard cannot fire and the
+// declaration is honoured on the type in front of it. That is the one place this subsystem
+// fails toward action rather than inaction, and it is bounded — a subject with no
+// recorded conflict is the normal case, and the caller's own grant still gates the write.
+func (m *Memory) typesForSubject(ctx context.Context, subject string) []string {
+	if m.SqlMem == nil || strings.TrimSpace(subject) == "" {
+		return nil
+	}
+	d := &Document{Store: m.Store, SqlMem: m.SqlMem}
+	ident := tools.RunIdentity(ctx)
+	if ident.UserID == "" {
+		return nil
+	}
+	key := sqlmem.ScopeKey{
+		Tenant:  sqlScopeTenant(ctx),
+		Scope:   string(store.MemoryScopeUser),
+		ScopeID: ident.UserID,
+	}
+	res, err := d.query(ctx, key,
+		`SELECT DISTINCT coalesce(c.type, '') FROM chunks c
+		   JOIN chunk_memory_meta mm ON mm.chunk_id = c.id
+		  WHERE lower(coalesce(c.title, '')) = lower(?)`, subject)
+	if err != nil || res == nil {
+		return nil
+	}
+	out := make([]string, 0, len(res.Rows))
+	for _, r := range res.Rows {
+		if len(r) == 0 {
+			continue
+		}
+		if s := strings.TrimSpace(asStr(r[0])); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/internal/tools/builtin/memory_placement_test.go
+++ b/internal/tools/builtin/memory_placement_test.go
@@ -1,0 +1,191 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	memrank "github.com/denn-gubsky/loomcycle/internal/memory"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// placementFixture builds a Memory tool over a store with SQL Memory, an ontology
+// document authored the way an operator authors one, and the grants named by scopes.
+func placementFixture(t *testing.T, confirmed bool, scopes ...string) (*Memory, context.Context) {
+	t.Helper()
+	d, base, _ := documentFixture(t)
+	// Authoring the ontology is an OPERATOR act and needs tenant grants on both planes.
+	// The agent ctx built below is separate and deliberately narrower — the point of the
+	// op is what an agent gets to know, not what an operator can write.
+	base = tools.WithMemoryPolicy(base, tools.MemoryPolicyValue{AllowedScopes: []string{"tenant"}})
+	base = tools.WithSqlMemPolicy(base, tools.SqlMemPolicyValue{AllowedScopes: []string{"tenant"}})
+	dctx := tools.WithSubstrateOperator(base)
+
+	// The ontology lives in the TENANT scope at a fixed path, which is where the reader
+	// looks — authoring it anywhere else would test nothing.
+	md := strings.Join([]string{
+		"# Tenant Ontology",
+		"",
+		"## service",
+		"- `@memory_scope` tenant",
+		"- `name`",
+		"",
+		"## person",
+		"- `@memory_scope` user",
+		"- `name`",
+		"",
+		"## location",
+		"- `name`",
+		"",
+	}, "\n")
+	mj, _ := json.Marshal(md)
+	out, r := docExec(t, d, dctx, `{"op":"import_md","scope":"tenant","markdown":`+string(mj)+`}`)
+	if r.IsError {
+		t.Fatalf("import_md: %s", r.Text)
+	}
+	docID, _ := out["document_id"].(string)
+	pj, _ := json.Marshal(memrank.OntologyPath)
+	if _, r := docExec(t, d, dctx, `{"op":"set_path","scope":"tenant","id":"`+docID+`","path":`+string(pj)+`}`); r.IsError {
+		t.Fatalf("set_path: %s", r.Text)
+	}
+	if confirmed {
+		root, _ := out["root_chunk_id"].(string)
+		got, r := docExec(t, d, dctx, `{"op":"get_chunk","scope":"tenant","id":"`+root+`"}`)
+		if r.IsError {
+			t.Fatalf("get_chunk: %s", r.Text)
+		}
+		rev := int(got["revision"].(float64))
+		if _, r := docExec(t, d, dctx, fmt.Sprintf(
+			`{"op":"update_chunk","scope":"tenant","id":"%s","revision":%d,"status":"%s"}`,
+			root, rev, memrank.OntologyConfirmedStatus)); r.IsError {
+			t.Fatalf("confirm: %s", r.Text)
+		}
+	}
+
+	if len(scopes) == 0 {
+		scopes = []string{"agent", "user", "tenant"}
+	}
+	ctx := tools.WithAgentName(context.Background(), "consolidator")
+	// SAME TENANT as the fixture that authored the ontology ("tnt"). The reader keys the
+	// ontology on the run's tenant, so a mismatch here would read an empty plane and
+	// every assertion below would pass or fail for the wrong reason.
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a", UserID: "u_alice", TenantID: "tnt"})
+	ctx = tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{AllowedScopes: scopes})
+	return &Memory{Store: d.Store, SqlMem: d.SqlMem}, ctx
+}
+
+func placements(t *testing.T, m *Memory, ctx context.Context, body string) []map[string]any {
+	t.Helper()
+	res := memExecJSON(t, m, ctx, body)
+	if res.IsError {
+		t.Fatalf("placement: %s", res.Text)
+	}
+	var out struct {
+		Placements []map[string]any `json:"placements"`
+	}
+	if err := json.Unmarshal([]byte(res.Text), &out); err != nil {
+		t.Fatalf("decode %q: %v", res.Text, err)
+	}
+	return out.Placements
+}
+
+func TestMemoryPlacement_AnswersFromTheOperatorsDeclaration(t *testing.T) {
+	m, ctx := placementFixture(t, true)
+	got := placements(t, m, ctx, `{"op":"placement","scope":"user","items":[
+		{"type":"service","subject":"checkout-api"},
+		{"type":"person","subject":"Maria"},
+		{"type":"location","subject":"Cluj-Napoca"}]}`)
+	if len(got) != 3 {
+		t.Fatalf("want 3 answers, got %d: %v", len(got), got)
+	}
+	// Declared tenant → moved. Declared user → the caller's own scope, not a move.
+	// Undeclared → left alone.
+	if got[0]["scope"] != "tenant" || got[0]["moved"] != true {
+		t.Errorf("service should move to tenant: %v", got[0])
+	}
+	if got[1]["scope"] != "user" || got[1]["moved"] != false {
+		t.Errorf("person declares user, which is where it was going: %v", got[1])
+	}
+	if got[2]["scope"] != "user" || got[2]["moved"] != false {
+		t.Errorf("an undeclared type must be left alone: %v", got[2])
+	}
+	for i, row := range got {
+		if s, _ := row["reason"].(string); s == "" {
+			t.Errorf("row %d carries no reason", i)
+		}
+	}
+}
+
+// The op DECIDES and must never write. A placement call that created a chunk or a row
+// would make asking about a fact indistinguishable from storing one.
+func TestMemoryPlacement_WritesNothing(t *testing.T) {
+	m, ctx := placementFixture(t, true)
+	before := memExecJSON(t, m, ctx, `{"op":"list","scope":"user"}`)
+	placements(t, m, ctx, `{"op":"placement","scope":"user","items":[{"type":"service","subject":"checkout-api"}]}`)
+	after := memExecJSON(t, m, ctx, `{"op":"list","scope":"user"}`)
+	if before.Text != after.Text {
+		t.Errorf("placement changed the store.\nbefore: %s\nafter:  %s", before.Text, after.Text)
+	}
+}
+
+// TestMemoryPlacement_DraftOntologyPlacesNothing: the confirm gate governs placement like
+// it governs everything else the ontology says. A half-written document must not start
+// moving facts between partitions.
+func TestMemoryPlacement_DraftOntologyPlacesNothing(t *testing.T) {
+	m, ctx := placementFixture(t, false)
+	got := placements(t, m, ctx, `{"op":"placement","scope":"user","items":[{"type":"service","subject":"checkout-api"}]}`)
+	if got[0]["moved"] != false || got[0]["scope"] != "user" {
+		t.Errorf("a draft ontology must place nothing: %v", got[0])
+	}
+	if s, _ := got[0]["reason"].(string); !strings.Contains(s, "draft") {
+		t.Errorf("the reason should name the draft gate, got %q", s)
+	}
+}
+
+// The grant is the enable switch: declaring a scope changes nothing until the operator
+// also grants the writer.
+func TestMemoryPlacement_UngrantedTenantPlacesNothing(t *testing.T) {
+	m, ctx := placementFixture(t, true, "agent", "user")
+	got := placements(t, m, ctx, `{"op":"placement","scope":"user","items":[{"type":"service","subject":"checkout-api"}]}`)
+	if got[0]["moved"] != false || got[0]["scope"] != "user" {
+		t.Errorf("without the tenant grant nothing may be placed there: %v", got[0])
+	}
+	if s, _ := got[0]["reason"].(string); !strings.Contains(s, "not granted") {
+		t.Errorf("the reason should name the missing grant, got %q", s)
+	}
+}
+
+func TestMemoryPlacement_RefusesAnEmptyOrOversizedBatch(t *testing.T) {
+	m, ctx := placementFixture(t, true)
+	if r := memExecJSON(t, m, ctx, `{"op":"placement","scope":"user"}`); !r.IsError {
+		t.Error("an empty batch should be refused with guidance, not answered")
+	}
+	var b strings.Builder
+	b.WriteString(`{"op":"placement","scope":"user","items":[`)
+	for i := 0; i < placementBatchMax+1; i++ {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		b.WriteString(`{"type":"service","subject":"s"}`)
+	}
+	b.WriteString(`]}`)
+	if r := memExecJSON(t, m, ctx, b.String()); !r.IsError {
+		t.Errorf("a batch over %d should be refused", placementBatchMax)
+	}
+}
+
+// The self guard, end to end through the op: a live store types the end-user's own
+// entity as `location`, and that is what carries their home city.
+func TestMemoryPlacement_NeverPlacesTheRunsOwnUser(t *testing.T) {
+	m, ctx := placementFixture(t, true)
+	got := placements(t, m, ctx, `{"op":"placement","scope":"user","items":[
+		{"type":"service","subject":"user"},
+		{"type":"service","subject":"u_alice"}]}`)
+	for i, row := range got {
+		if row["moved"] == true {
+			t.Errorf("row %d placed a fact about the run's own user in %v: %v", i, row["scope"], row)
+		}
+	}
+}


### PR DESCRIPTION
RFC CQ, the routing decision. Third PR on that RFC (#1101 reachability, #1102 the
declaration). Nothing calls the op yet — the consolidator wiring is a separate PR so this
can be reviewed as a surface on its own.

## The finding that shaped the design

**A fact is stored twice**: a key/value row that semantic `recall` searches, and a chunk
mirror the graph walks. Only the chunk write carries the `type`/`subject` the decision
needs.

So a server-side redirect on each write path would mean two writers agreeing by luck — and
**a fact whose halves land in different partitions is worse than one that never moved**,
because `recall` finds it in one scope and `graph_recall` in another.

Hence an op: the writer that owns both halves asks once, before either write, and puts
them in the same place. That also keeps the scope gate intact — the caller writes to the
scope it was told, through the ordinary grant check, instead of the server silently
redirecting a write into a plane the caller was never granted. An operator reading
`memory_scopes` still sees the whole truth about what an agent can reach.

## The grant is the enable switch

Deliberately not a new flag. Placement writes to a plane every user in the tenant reads, so
it must be something an operator **turned on**, not a side effect of editing a taxonomy. An
agent without `tenant` in `memory_scopes` places nothing there.

Decided in the resolver rather than left to fail at the gate: otherwise a pass that would
have stored the fact perfectly well in the user's own scope errors instead.

## Every uncertainty refuses to move

The asymmetry is the design, not caution. Declining costs what the system already costs —
the fact stays in one user's scope. Moving one wrongly puts a private sentence in front of
everybody, and there is no un-publishing it.

Refusals, each returning the caller's own scope **and a reason**: no type, unknown type,
undeclared type, draft ontology, no ontology document, no SQL Memory, a subject naming the
run's own user, a subject typed inconsistently, an isolated member, an ungranted scope.

Two guards worth calling out:

- **The self guard beats the declaration.** A live store types the end-user's own entity as
  both `person` and `location`, and it is `location` that carries *"The user resides in
  Cluj-Napoca, Romania"*. An operator declaring `location → tenant` is being entirely
  reasonable, and it must not publish a home city.
- **An inconsistently typed subject is refused with something actionable** — the advisory
  names the subject, both types and both scopes. Types disagreeing on the *name* but
  agreeing on the *scope* are not a conflict: the ontology is imprecise, the placement is
  not in doubt.

## ⚠️ A hole I could not close, asserted rather than assumed

**A fact about the end-user under their own name is indistinguishable from a fact about a
colleague.** *"Denn prefers Go"* and *"Maria owns the release process"* are the same shape,
and the resolver is not told who the user is by name. So the self guard narrows the
exposure and does not close it.

`TestResolvePlacement_SelfGuardCannotCatchTheUsersOwnName` asserts the hole so it stays
visible in the suite instead of being assumed closed. It is the strongest argument for an
operator seeing a placement before it goes live, and it is why the grant — a conscious
operator act — is the switch rather than the declaration alone.

There is a related residual risk worth stating plainly: the ontology moves the *scope*
choice to the operator, but the **extractor still chooses the type**. So a hostile
conversation cannot pick a partition, but it can produce a fact whose type happens to be
tenant-declared. The declaration plus the grant are two conscious operator acts, which is
the mitigation; it is not a proof.

## Implementation notes

- The ontology read **fails closed** here, unlike the retrieval-side reads that fail open.
  "I could not read the declarations" must mean "place nothing".
- Subject types are matched on the identity node's **title** (a live store holds nodes
  titled `user`, `loomboard`, `git configuration`), one query per distinct subject,
  memoised per call. Not a batched `IN`: a pass has few distinct subjects, and a hand-built
  placeholder list is where this grows a dialect bug — the count has already been wrong
  once in this repo on Postgres.
- Documented in the builtin description **and** the MCP one, which enumerates ops by hand
  with no test covering it and drifts silently.

## What was tested

- `internal/memory/placement_test.go` — the decision: declaration, inheritance, all
  refusals, the grant switch, the self guard, the advisory, the known hole.
- `internal/tools/builtin/memory_placement_test.go` — the op end to end against a real
  authored ontology, including that it **writes nothing**, that a draft places nothing, and
  that an ungranted tenant places nothing.
- `go test ./...` — clean, exit 0, no failures in the complete output. `go vet` clean.

A fixture bug found on the way is worth noting: the agent context initially used a
different tenant from the one that authored the ontology, so the reader saw an empty plane.
It surfaced as failures rather than false passes, but the fixture now pins the shared tenant
with a comment saying why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8