### PR TITLE
feat(memory): the user declares their own names, closing the named-self gap

### DIFF
--- a/internal/memory/placement.go
+++ b/internal/memory/placement.go
@@ -46,6 +46,10 @@ type PlacementInput struct {
 	// Isolated is the run's server-derived isolation bit. An isolated member has no
 	// tenant plane at all.
 	Isolated bool
+	// SelfNames are the names the user declared for themselves in their user-root
+	// Document's Identity section. Empty is normal — most profiles are unedited — and
+	// means the self guard falls back to catching literal self-reference only.
+	SelfNames []string
 	// GrantedScopes is the calling agent's own memory_scopes.
 	//
 	// THIS IS THE ENABLE SWITCH, and deliberately not a separate flag. Placement writes
@@ -112,7 +116,7 @@ func ResolvePlacement(in PlacementInput) PlacementDecision {
 	// A fact about the person whose run this is belongs to them whatever their ontology
 	// says, because the cost of being wrong here is the one cost this design cannot
 	// accept.
-	if target != MemoryScopeUserName && IsSelfSubject(in.Subject, in.UserID) {
+	if target != MemoryScopeUserName && IsSelfSubject(in.Subject, in.UserID, in.SelfNames) {
 		return stay("the subject is the run's own user, which is never placed outside their scope")
 	}
 
@@ -206,17 +210,23 @@ func findTerm(terms []OntologyTerm, name string) (OntologyTerm, bool) {
 // IsSelfSubject reports whether a subject names the end-user of the run rather than some
 // third party.
 //
-// ⚠️ THIS GUARD IS INCOMPLETE AND CANNOT BE COMPLETED HERE. It catches the way the
-// extractor actually spells a self-reference — a live store has entities literally named
-// "user" carrying facts like "The user resides in Cluj-Napoca, Romania" — and the run's
-// own user id. It CANNOT catch a fact recorded about the same person under their own
-// name: "Denn prefers Go" is indistinguishable from "Maria owns the release process"
-// without knowing who Denn is, and this function is not told.
+// Three ways it can know, in order of how much they cover:
 //
-// So it narrows the exposure and does not close it. That is the argument for an operator
-// seeing a placement before it goes live, and it is why this returns a REFUSAL to move
-// rather than a licence to move whatever it does not recognise.
-func IsSelfSubject(subject, userID string) bool {
+//   - selfNames — what the user wrote in their user-root Document's Identity section.
+//     This is the one that closes the case the other two cannot: a fact recorded under
+//     the user's own name. "Ada prefers Go" and "Maria owns the release process" are
+//     the same shape, and only a declared name separates them.
+//   - the literal self-reference the extractor actually emits. A live store holds
+//     entities titled "user" carrying facts like "The user resides in Cluj-Napoca,
+//     Romania".
+//   - the run's own user id, which some writers use as the subject.
+//
+// ⚠️ STILL NOT COMPLETE, and the residue is now a KNOWN and LOCATABLE gap rather than a
+// structural one: a user who has not filled in their Identity section is in exactly the
+// position everybody was before — their name means nothing here. That is visible (the
+// profile is empty), fixable by the person it affects, and it fails toward refusing to
+// place rather than toward placing wrongly.
+func IsSelfSubject(subject, userID string, selfNames []string) bool {
 	s := strings.ToLower(strings.TrimSpace(subject))
 	s = strings.TrimPrefix(s, "the ")
 	if s == "" {
@@ -224,6 +234,12 @@ func IsSelfSubject(subject, userID string) bool {
 	}
 	for _, self := range []string{"user", "me", "i", "myself", "operator", "current user"} {
 		if s == self {
+			return true
+		}
+	}
+	for _, n := range selfNames {
+		n = strings.ToLower(strings.TrimSpace(n))
+		if n != "" && s == n {
 			return true
 		}
 	}

--- a/internal/memory/placement_test.go
+++ b/internal/memory/placement_test.go
@@ -117,27 +117,52 @@ func TestResolvePlacement_NeverPlacesTheRunsOwnUserOutsideTheirScope(t *testing.
 	}
 }
 
-// TestResolvePlacement_SelfGuardCannotCatchTheUsersOwnName documents the hole rather than
-// pretending it is closed. A fact about the end-user recorded under their own name is
-// indistinguishable from a fact about a colleague, so automatic placement WILL sometimes
-// publish a personal fact.
+// TestResolvePlacement_ADeclaredNameClosesTheNamedSelfReference is the gap that used to be
+// structural. A fact recorded about the user under their OWN NAME is the same shape as a
+// fact about a colleague — "Ada prefers Go" against "Maria owns the release process" — so
+// nothing in the type system could separate them. A name the user declared can.
+func TestResolvePlacement_ADeclaredNameClosesTheNamedSelfReference(t *testing.T) {
+	terms := ResolveInheritance([]OntologyTerm{{Name: "person", MemoryScope: "tenant"}})
+
+	// Declared: the user's own fact stays in their scope even though person→tenant.
+	got := ResolvePlacement(base(PlacementInput{
+		DeclaredType: "person", Subject: "Ada Lovelace", Terms: terms,
+		SelfNames: []string{"Ada Lovelace", "Ada"},
+	}))
+	if got.Moved || got.Scope != "user" {
+		t.Errorf("a fact about the user under their declared name was placed in %q: %s",
+			got.Scope, got.Reason)
+	}
+
+	// A colleague under the same type is still placed, or the guard would be a veto on
+	// every person fact and the declaration would be pointless.
+	got = ResolvePlacement(base(PlacementInput{
+		DeclaredType: "person", Subject: "Maria", Terms: terms,
+		SelfNames: []string{"Ada Lovelace", "Ada"},
+	}))
+	if !got.Moved || got.Scope != "tenant" {
+		t.Errorf("a colleague should still be placed in tenant, got %+v", got)
+	}
+}
+
+// TestResolvePlacement_AnUndeclaredNameIsStillIndistinguishable keeps the residue honest.
 //
-// Asserted so the limitation is visible in the suite and cannot be forgotten when someone
-// reasons about how safe automatic placement is.
-func TestResolvePlacement_SelfGuardCannotCatchTheUsersOwnName(t *testing.T) {
+// A user who has not filled in their Identity section is exactly where everybody was
+// before: their name means nothing here, and a fact about them under it is placed like a
+// fact about anyone else. That is now a LOCATABLE gap — the profile is visibly empty and
+// the person it affects can close it — rather than a structural one, but it is not zero
+// and the suite should say so out loud.
+func TestResolvePlacement_AnUndeclaredNameIsStillIndistinguishable(t *testing.T) {
 	terms := ResolveInheritance([]OntologyTerm{{Name: "person", MemoryScope: "tenant"}})
 	got := ResolvePlacement(base(PlacementInput{
-		DeclaredType: "person", Subject: "Denn", Terms: terms, UserID: "u_alice",
+		DeclaredType: "person", Subject: "Ada Lovelace", Terms: terms, SelfNames: nil,
 	}))
 	if !got.Moved {
-		t.Skip("the guard has been widened to catch a named self-reference — update this test and the comment on IsSelfSubject")
+		t.Skip("the guard now catches an undeclared name — update this test and IsSelfSubject's comment")
 	}
-	if got.Scope != "tenant" {
-		t.Fatalf("unexpected scope %q", got.Scope)
-	}
-	t.Log("KNOWN AND UNCLOSED: a fact about the end-user under their own name is placed " +
-		"like a fact about anyone else. This is why an operator should see a placement " +
-		"before it goes live.")
+	t.Log("KNOWN, and narrowed rather than closed: with no Identity section declared, a " +
+		"fact about the user under their own name is placed like a fact about a colleague. " +
+		"Filling in the user-root Document's Identity section closes it.")
 }
 
 // TestResolvePlacement_InconsistentlyTypedSubjectIsRefusedWithSomethingActionable is the

--- a/internal/memory/selfnames.go
+++ b/internal/memory/selfnames.go
@@ -1,0 +1,100 @@
+package memory
+
+import "strings"
+
+// The identity half of placement: which names mean "the person whose run this is".
+//
+// WHY IT HAS TO BE DECLARED. Placement can route a fact by the entity type its subject
+// carries, but it cannot tell whose fact it is. "Ada prefers Go" and "Maria owns the
+// release process" are the same shape, and only one of them belongs to the person running
+// the agent. Without knowing the user's own names the guard catches literal self-reference
+// ("the user", "me") and nothing else — so a fact recorded about the user under their own
+// name was placed like a fact about a colleague.
+//
+// A DOCUMENT rather than a config field, because the user is who knows the answer: the
+// names people actually use for them in conversation are not something an operator can
+// enumerate from a directory, and they change. The user-root Document already exists, is
+// already per-user, and is already the place a person writes durable context about
+// themselves.
+
+// Directives read out of the user-root Document's Identity section.
+const (
+	SelfNameDirective  = "@name"
+	SelfAliasDirective = "@alias"
+)
+
+// selfNamesMax bounds what one document can declare. A name list is a handful of spellings;
+// a hundred of them is a mistake or an attempt to make the guard refuse everything.
+const selfNamesMax = 24
+
+// selfNameMinLen rejects a one-character "name". A single letter matches too much to be
+// used as identity, and a stray bullet is more likely than a person called "A".
+const selfNameMinLen = 2
+
+// ParseSelfNames extracts the user's declared names from the user-root Document's Markdown.
+//
+// ⚠️ A BULLET MUST START AT COLUMN 0. That is the whole defence against the shipped
+// template arming itself: the template shows the form as an INDENTED code sample, so an
+// unedited profile declares nobody. Trimming leading whitespace first — which every other
+// bullet parser in this package does — would read "Ada Lovelace" out of the example and
+// silently claim the user is called that.
+// TestSelfNames_TheShippedTemplateNamesNobody is the test that matters here.
+//
+// Deliberately lenient about everything else: an unknown directive is skipped, a bullet
+// with no value is skipped, and duplicates and case variants collapse. The result is a
+// set of names to compare against, so a bad entry costs a wasted comparison rather than a
+// failed read.
+func ParseSelfNames(md string) []string {
+	var out []string
+	seen := map[string]bool{}
+	for _, line := range strings.Split(md, "\n") {
+		// NO TrimSpace: see the warning above.
+		if !strings.HasPrefix(line, "- ") {
+			continue
+		}
+		switch firstBackticked(line) {
+		case SelfNameDirective, SelfAliasDirective:
+		default:
+			continue
+		}
+		name := selfNameValue(line)
+		if len(name) < selfNameMinLen {
+			continue
+		}
+		k := strings.ToLower(name)
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		out = append(out, name)
+		if len(out) >= selfNamesMax {
+			break
+		}
+	}
+	return out
+}
+
+// selfNameValue takes the whole remainder after the directive, not the first word — a name
+// is "Ada Lovelace", and cutting at the first space would claim the user is called "Ada".
+//
+// A trailing note is still allowed, set off by a spaced dash the way the rest of these
+// templates write one, so "- `@name` Ada Lovelace — the boss" declares "Ada Lovelace".
+func selfNameValue(line string) string {
+	i := strings.Index(line, "`")
+	if i < 0 {
+		return ""
+	}
+	rest := line[i+1:]
+	j := strings.Index(rest, "`")
+	if j < 0 {
+		return ""
+	}
+	v := strings.TrimSpace(rest[j+1:])
+	v = strings.TrimLeft(v, ":=—- \t")
+	for _, cut := range []string{" — ", " -- ", " – "} {
+		if k := strings.Index(v, cut); k >= 0 {
+			v = v[:k]
+		}
+	}
+	return strings.Trim(v, "`\"'.,;: \t")
+}

--- a/internal/memory/selfnames_test.go
+++ b/internal/memory/selfnames_test.go
@@ -1,0 +1,99 @@
+package memory
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSelfNames_TheShippedTemplateNamesNobody is the test this feature lives or dies by.
+//
+// The template teaches the form by SHOWING it, and a parser that read its own example
+// would claim every unedited profile belongs to "Ada Lovelace" — then refuse to place any
+// fact about a real person of that name, and, far worse, quietly convince a reader that
+// the identity guard was working when it was matching a sample.
+//
+// The defence is that the example is indented, so it is a code sample, and the parser
+// requires a bullet at column 0.
+func TestSelfNames_TheShippedTemplateNamesNobody(t *testing.T) {
+	got := ParseSelfNames(UserRootTemplate())
+	if len(got) != 0 {
+		t.Fatalf("the unedited template declared %v — an untouched profile must name nobody", got)
+	}
+	// And the template really does contain the directives, or this would pass because the
+	// section is missing rather than because the indent works.
+	if !strings.Contains(UserRootTemplate(), SelfNameDirective) {
+		t.Errorf("the template no longer shows %s — the test above is now vacuous", SelfNameDirective)
+	}
+}
+
+func TestSelfNames_ReadsWhatTheUserWrote(t *testing.T) {
+	md := strings.Join([]string{
+		"# User Profile",
+		"",
+		"## Identity",
+		"",
+		"- `@name` Ada Lovelace",
+		"- `@alias` Ada",
+		"- `@alias` ada-lovelace — the git handle",
+		"- `@alias`: Countess Lovelace",
+		"",
+		"## Role and context",
+		"",
+		"- `name` not a directive, just a field bullet",
+		"",
+	}, "\n")
+	got := ParseSelfNames(md)
+	want := []string{"Ada Lovelace", "Ada", "ada-lovelace", "Countess Lovelace"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("name %d = %q, want %q (all: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestSelfNames_SkipsWhatCannotBeAName(t *testing.T) {
+	md := strings.Join([]string{
+		"- `@name`",            // no value
+		"- `@alias` ",          // whitespace only
+		"- `@name` A",          // one character matches too much to be identity
+		"- `@unknown` Ada",     // not a directive this reads
+		"  - `@name` Indented", // a code sample or a nested bullet, never identity
+		"- `@alias` Ada",       // the only real one
+		"- `@alias` ada",       // a case variant of the same name
+	}, "\n")
+	got := ParseSelfNames(md)
+	if len(got) != 1 || got[0] != "Ada" {
+		t.Errorf("got %v, want exactly [Ada]", got)
+	}
+}
+
+func TestSelfNames_BoundsWhatOneDocumentCanDeclare(t *testing.T) {
+	var b strings.Builder
+	for i := 0; i < selfNamesMax*3; i++ {
+		b.WriteString("- `@alias` name")
+		b.WriteString(strings.Repeat("x", i%5+2))
+		b.WriteString("\n")
+	}
+	if got := ParseSelfNames(b.String()); len(got) > selfNamesMax {
+		t.Errorf("declared %d names, over the %d bound", len(got), selfNamesMax)
+	}
+}
+
+// The names are compared case- and whitespace-insensitively, because the extractor spells
+// a subject however the conversation did.
+func TestSelfNames_MatchIgnoresCaseAndSurroundingSpace(t *testing.T) {
+	names := []string{"Ada Lovelace", "Ada"}
+	for _, subject := range []string{"Ada Lovelace", "ada lovelace", "  ADA  ", "the Ada"} {
+		if !IsSelfSubject(subject, "u_1", names) {
+			t.Errorf("subject %q should match a declared name", subject)
+		}
+	}
+	for _, subject := range []string{"Maria", "Ada Byron", "Lovelace"} {
+		if IsSelfSubject(subject, "u_1", names) {
+			t.Errorf("subject %q is not a declared name and must not match", subject)
+		}
+	}
+}

--- a/internal/memory/templates/user_root.md
+++ b/internal/memory/templates/user_root.md
@@ -4,6 +4,24 @@ Operator-authored durable facts about this user. Edit this document to give the
 agent stable, high-signal context. Keep it short — a few lines per section. This
 is reference data the agent reads, not instructions it must obey.
 
+## Identity
+
+The names the agent should understand as **you**. This is the one section the
+runtime reads mechanically, and it is what keeps a fact about you from being
+filed as a fact about a colleague.
+
+Add one bullet per name, starting at the left margin — `@name` for what you are
+called, and `@alias` for each short form, handle or spelling that turns up in
+conversation:
+
+    - `@name` Ada Lovelace
+    - `@alias` Ada
+    - `@alias` ada-lovelace
+
+The example above is indented, so it is a code sample and names nobody. Until
+you add real bullets of your own the runtime knows no names for you, and a fact
+recorded about you under your own name is treated like a fact about anyone else.
+
 ## Role and context
 
 Who is this user and what do they do? (for example: "Staff backend engineer on

--- a/internal/tools/builtin/memory_placement.go
+++ b/internal/tools/builtin/memory_placement.go
@@ -2,6 +2,7 @@ package builtin
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -59,6 +60,10 @@ func (m *Memory) execPlacement(ctx context.Context, callerScope store.MemoryScop
 	}
 
 	effective := memrank.EffectiveOntology(terms, confirmed)
+	// Read ONCE per call. The names come from the user's own profile document, which the
+	// self guard needs to tell a fact about them from a fact about a colleague; a
+	// per-item read would repeat the same export for every fact in the pass.
+	selfNames := m.selfNames(ctx)
 	out := make([]map[string]any, 0, len(in.Items))
 	moved := 0
 	subjectTypes := map[string][]string{}
@@ -89,6 +94,7 @@ func (m *Memory) execPlacement(ctx context.Context, callerScope store.MemoryScop
 			CallerScope:   string(callerScope),
 			UserID:        ident.UserID,
 			SubjectTypes:  subjectTypes[subj],
+			SelfNames:     selfNames,
 			Isolated:      ident.Isolated,
 			GrantedScopes: policy.AllowedScopes,
 		})
@@ -170,4 +176,44 @@ func (m *Memory) typesForSubject(ctx context.Context, subject string) []string {
 		}
 	}
 	return out
+}
+
+// selfNames reads the names the user declared for themselves in their user-root Document.
+//
+// READ-ONLY, and deliberately does NOT provision the document. Prompt rendering
+// provisions it on first reference, which is the right place for a side effect a person
+// then sees and edits; a consolidation pass creating an empty profile behind their back
+// would put a document nobody asked for in their Path tree and still declare no names.
+//
+// Best-effort in the direction of caution: no document, an unreadable one, or an unedited
+// one all yield no names, and no names means the guard falls back to catching literal
+// self-reference. It never yields a WRONG name, which is the only failure that would
+// matter — a wrong name refuses to place facts about a real person of that name.
+func (m *Memory) selfNames(ctx context.Context) []string {
+	if m.Store == nil || m.SqlMem == nil {
+		return nil
+	}
+	ident := tools.RunIdentity(ctx)
+	if ident.UserID == "" {
+		return nil
+	}
+	d := &Document{Store: m.Store, SqlMem: m.SqlMem}
+	req, err := json.Marshal(map[string]any{
+		"op": "export_md", "scope": "user", "path": memrank.UserRootPath,
+		"include_metadata": false,
+	})
+	if err != nil {
+		return nil
+	}
+	res, execErr := d.Execute(ctx, req)
+	if execErr != nil || res.IsError {
+		return nil
+	}
+	var out struct {
+		Markdown string `json:"markdown"`
+	}
+	if json.Unmarshal([]byte(res.Text), &out) != nil {
+		return nil
+	}
+	return memrank.ParseSelfNames(out.Markdown)
 }

--- a/internal/tools/builtin/memory_placement_test.go
+++ b/internal/tools/builtin/memory_placement_test.go
@@ -189,3 +189,89 @@ func TestMemoryPlacement_NeverPlacesTheRunsOwnUser(t *testing.T) {
 		}
 	}
 }
+
+// authorUserProfile writes a user-root Document declaring the given identity bullets, at
+// the well-known path the reader looks at.
+func authorUserProfile(t *testing.T, m *Memory, ctx context.Context, identity string) {
+	t.Helper()
+	d := &Document{Store: m.Store, SqlMem: m.SqlMem}
+	md := "# User Profile\n\n## Identity\n\n" + identity + "\n"
+	mj, _ := json.Marshal(md)
+	out, r := docExec(t, d, ctx, `{"op":"import_md","scope":"user","markdown":`+string(mj)+`}`)
+	if r.IsError {
+		t.Fatalf("import_md user profile: %s", r.Text)
+	}
+	id, _ := out["document_id"].(string)
+	pj, _ := json.Marshal(memrank.UserRootPath)
+	if _, r := docExec(t, d, ctx,
+		`{"op":"set_path","scope":"user","id":"`+id+`","path":`+string(pj)+`}`); r.IsError {
+		t.Fatalf("set_path user profile: %s", r.Text)
+	}
+}
+
+// TestMemoryPlacement_ADeclaredNameKeepsTheUsersOwnFactsInTheirScope closes, end to end,
+// the gap the placement resolver shipped with: a fact about the user under their own name
+// used to be placed like a fact about a colleague.
+func TestMemoryPlacement_ADeclaredNameKeepsTheUsersOwnFactsInTheirScope(t *testing.T) {
+	m, ctx := placementFixture(t, true)
+
+	// BEFORE the profile is filled in, the user's own name means nothing here.
+	got := placements(t, m, ctx, `{"op":"placement","scope":"user","items":[{"type":"service","subject":"Ada Lovelace"}]}`)
+	if got[0]["moved"] != true {
+		t.Fatalf("precondition: with no profile the name should be treated like any other subject: %v", got[0])
+	}
+
+	authorUserProfile(t, m, ctx, "- `@name` Ada Lovelace\n- `@alias` Ada")
+
+	// AFTER: the user's own facts stay put, under either declared spelling.
+	got = placements(t, m, ctx, `{"op":"placement","scope":"user","items":[
+		{"type":"service","subject":"Ada Lovelace"},
+		{"type":"service","subject":"ada"},
+		{"type":"service","subject":"checkout-api"}]}`)
+	if got[0]["moved"] == true {
+		t.Errorf("the declared name was still placed outside the user's scope: %v", got[0])
+	}
+	if got[1]["moved"] == true {
+		t.Errorf("a declared alias was still placed outside the user's scope: %v", got[1])
+	}
+	// And a genuine third-party subject is still placed, or the profile would have turned
+	// the whole feature off.
+	if got[2]["moved"] != true || got[2]["scope"] != "tenant" {
+		t.Errorf("an unrelated subject should still be placed in tenant: %v", got[2])
+	}
+}
+
+// An unedited profile must declare nobody. This is the shipped-template guard again, but
+// through the real document and the real reader rather than the parser alone.
+func TestMemoryPlacement_AnUneditedProfileDeclaresNobody(t *testing.T) {
+	m, ctx := placementFixture(t, true)
+	d := &Document{Store: m.Store, SqlMem: m.SqlMem}
+	mj, _ := json.Marshal(memrank.UserRootTemplate())
+	out, r := docExec(t, d, ctx, `{"op":"import_md","scope":"user","markdown":`+string(mj)+`}`)
+	if r.IsError {
+		t.Fatalf("import_md template: %s", r.Text)
+	}
+	id, _ := out["document_id"].(string)
+	pj, _ := json.Marshal(memrank.UserRootPath)
+	if _, r := docExec(t, d, ctx,
+		`{"op":"set_path","scope":"user","id":"`+id+`","path":`+string(pj)+`}`); r.IsError {
+		t.Fatalf("set_path: %s", r.Text)
+	}
+	if names := m.selfNames(ctx); len(names) != 0 {
+		t.Errorf("the shipped template, stored and read back, declared %v", names)
+	}
+}
+
+// The reader must not create the profile. Provisioning is a side effect a person then sees
+// and edits, and prompt rendering already owns it; a consolidation pass leaving an empty
+// document in someone's Path tree is litter that still declares no names.
+func TestMemoryPlacement_ReadingNamesDoesNotProvisionTheProfile(t *testing.T) {
+	m, ctx := placementFixture(t, true)
+	if names := m.selfNames(ctx); len(names) != 0 {
+		t.Fatalf("precondition: no profile exists yet, got %v", names)
+	}
+	d := &Document{Store: m.Store, SqlMem: m.SqlMem}
+	if _, r := docExec(t, d, ctx, `{"op":"get_document","scope":"user","path":"`+memrank.UserRootPath+`"}`); !r.IsError {
+		t.Error("reading self names provisioned the user-root document; it must stay read-only")
+	}
+}


### PR DESCRIPTION
RFC CQ, the identity half. Fourth PR (#1101 reachability, #1102 declaration, #1103 the
placement decision).

## Why

#1103 shipped with a hole I flagged and could not close from inside it: **a fact recorded
about the end-user under their own name is the same shape as a fact about a colleague.**
*"Ada prefers Go"* and *"Maria owns the release process"* are indistinguishable, so a
`person → tenant` declaration would publish the user's own facts to the whole tenant. The
guard caught only literal self-reference — "the user", "me", the run's user id.

The missing input is *who the user is*, and the user is the one who knows.

## What

Both identity documents already existed — `{{memory:user_info}}` over a per-user user-root
Document, and `{{memory:tenant_info}}` over a tenant-root one — each seeded from a
template. The user-root Document is already where a person writes durable context about
themselves. It just never asked for a name. Now it does:

```
## Identity
- `@name` Ada Lovelace
- `@alias` Ada
```

`ParseSelfNames` reads those bullets, the placement guard compares the subject against
them, and a declared name keeps the user's own facts in their own scope while a colleague
under the same type is still placed.

## ⚠️ The one thing worth reviewing carefully

**The parser must not read the template's own example.** A template teaches the form by
showing it, so a parser matching its own sample would claim every unedited profile belongs
to "Ada Lovelace" — refusing to place facts about any real person of that name and, far
worse, convincing a reader the identity guard worked when it was matching a code sample.

The defence is that the example is **indented** and the parser requires a bullet at
**column 0** — deliberately *not* the `TrimSpace` every other bullet parser in this package
uses.

**Fail-before verified, and it is not subtle:** switching to the obvious `TrimSpace`
version makes the unedited template declare `[Ada Lovelace, Ada, ada-lovelace]`, caught at
both the parser level and end-to-end through the stored document.
`TestSelfNames_TheShippedTemplateNamesNobody` also asserts the template still *contains*
the directives, so it cannot start passing because the section went missing.

## Read-only on purpose

The reader does not provision the document. Prompt rendering already provisions it on first
reference, which is the right place for a side effect a person then sees and edits; a
consolidation pass leaving an empty profile in someone's Path tree is litter that still
declares no names. It never yields a *wrong* name, which is the only failure that would
matter.

## ⚠️ Narrowed, not closed — and the suite says so

A user who has not filled in their Identity section is exactly where everybody was before:
their name means nothing here. `TestResolvePlacement_AnUndeclaredNameIsStillIndistinguishable`
asserts that residue rather than letting it be assumed away.

What changed is the *character* of the gap: it is now visible to the person it affects and
fixable by them, rather than structural.

## Not in this PR: provisioning at establishment

Worth stating because it is the other half of the idea. Provisioning today is **lazy** — the
document appears on the first run that references `{{memory:user_info}}` — and `force` is a
**per-agent** setting (`agentDef.MemoryRoots == "force"`) that still needs a run to happen.
So a user who has never had a run has no profile, and never learns there is one to fill in.

Provisioning at the moment a user or tenant is *established* (token mint / declared
principal) is a separate change in a security-sensitive path, so it is not mixed in here.
Until then the practical path is: the profile appears on first use, and the Identity section
is the first thing in it.

## What was tested

- `internal/memory/selfnames_test.go` — the shipped template names nobody, what is read,
  what is skipped (no value, one character, unknown directive, indented, case duplicates),
  the count bound, case- and space-insensitive matching.
- `placement_test.go` — split into the declared case (closed) and the undeclared case
  (still open, asserted).
- `internal/tools/builtin/memory_placement_test.go` — end to end through a real stored
  profile, the unedited template read back through the real reader, and that reading does
  not provision.
- `go test ./...` clean, exit 0, no failures in the complete output. `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8