### PR TITLE
feat(memory): provision the identity Documents when a principal is established

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -2567,6 +2567,14 @@ func main() {
 		log.Printf("limits: seed failed (budgets start empty until next write): %v", err)
 	}
 
+	// Identity Documents for config-declared principals. They exist because an operator
+	// wrote them into the yaml, so they are established before anybody authenticates —
+	// which makes them the case lazy provisioning serves worst, since their templates
+	// should be waiting rather than appearing on some later run. Backgrounded: a hand-
+	// written principal list is small, but it is one store round-trip each and boot
+	// should not wait on a convenience. Best-effort inside.
+	go srv.ProvisionDeclaredPrincipalDocs(bgCtx)
+
 	// Memory tool TTL sweeper. Cheap periodic DELETE of expired rows.
 	// The store also filters expired entries at read time, so this
 	// goroutine only matters for keeping the table small over the

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -470,6 +470,7 @@ agents:
 | `LOOMCYCLE_MEMORY_MAX_VALUE_BYTES` | `65536` | Per-write cap on the `value` payload. 0 disables. |
 | `LOOMCYCLE_MEMORY_MAX_SCOPE_BYTES` | `1048576` | Default per-(scope, scope_id) cap. 0 disables. |
 | `LOOMCYCLE_MEMORY_SWEEP_MS` | `900000` (15 min) | TTL reaper goroutine cadence. 0 disables. |
+| `LOOMCYCLE_MEMORY_PROVISION_IDENTITY_DOCS` | `1` | Create the tenant-root and user-root Documents when a principal is **established** — at token mint, and at boot for config-declared principals — instead of only on the first run that references them. They are templates a person fills in (the user-root `## Identity` section is what lets memory placement tell a fact about the user from a fact about a colleague), so arriving on first reference is too late. `0` keeps the older lazy-only behaviour. |
 
 ### Atomic increment
 

--- a/internal/api/http/connector_impl.go
+++ b/internal/api/http/connector_impl.go
@@ -672,7 +672,52 @@ func (s *Server) OperatorTokenDef(ctx context.Context, input json.RawMessage) (c
 	if !res.IsError && isMutatingTokenOp(input) {
 		s.invalidateTokenCache(ctx)
 	}
+	// A successful CREATE is the moment a (tenant, subject) comes into existence, so it
+	// is where the identity Documents get provisioned — the templates a person fills in
+	// should be waiting when they arrive, not appear on whatever run first happens to
+	// reference them.
+	//
+	// Read off the RESPONSE, not the request: `subject` is optional on the wire and
+	// defaults to a derived per-token id, so the request does not always carry the
+	// subject that was actually created.
+	//
+	// Best-effort and after the fact — minting the token is the operation that must
+	// succeed, and this never affects its result.
+	if !res.IsError && isTokenCreateOp(input) {
+		if tenant, subject, ok := createdTokenPrincipal(res.Text); ok {
+			s.ProvisionIdentityDocs(ctx, tenant, subject)
+		}
+	}
 	return connector.ToolResult{Text: res.Text, IsError: res.IsError}, nil
+}
+
+// isTokenCreateOp is narrower than isMutatingTokenOp: rotate and retire act on a
+// principal that already exists, so only create establishes one.
+func isTokenCreateOp(input json.RawMessage) bool {
+	var p struct {
+		Op string `json:"op"`
+	}
+	if err := json.Unmarshal(input, &p); err != nil {
+		return false // unknown shape → provision nothing (unlike cache invalidation,
+		// there is no safe-by-default action here, and the lazy path still covers it)
+	}
+	return p.Op == "create"
+}
+
+// createdTokenPrincipal reads the authoritative (tenant, subject) out of a create
+// response.
+func createdTokenPrincipal(body string) (tenant, subject string, ok bool) {
+	var r struct {
+		TenantID string `json:"tenant_id"`
+		Subject  string `json:"subject"`
+	}
+	if err := json.Unmarshal([]byte(body), &r); err != nil {
+		return "", "", false
+	}
+	if r.TenantID == "" {
+		return "", "", false
+	}
+	return r.TenantID, r.Subject, true
 }
 
 // isMutatingTokenOp reports whether an OperatorTokenDef input is a

--- a/internal/api/http/identitydocs.go
+++ b/internal/api/http/identitydocs.go
@@ -1,0 +1,95 @@
+// identitydocs.go — provisioning the per-user and per-tenant identity Documents at the
+// moment a principal is ESTABLISHED, rather than on the first run that happens to
+// reference them.
+package http
+
+import (
+	"context"
+	"log"
+)
+
+// ProvisionIdentityDocs creates the tenant-root and user-root Documents for a principal
+// if they do not exist yet.
+//
+// WHY EAGER, WHEN LAZY ALREADY WORKS. Both documents are seeded from a template the
+// person is expected to fill in — the user-root Document's Identity section is what lets
+// placement tell a fact about the user from a fact about a colleague, and it can only do
+// that if somebody wrote their name in it. Lazily provisioning on the first run that
+// references {{memory:user_info}} means the document does not exist until an agent asks
+// for it, so a person who has not run anything yet has nothing to fill in and no way to
+// discover there is something to fill in. The template is useless if it arrives after the
+// moment it was needed.
+//
+// So it is created when the principal is established: at token mint, and at boot for
+// config-declared principals. Those are the two moments a (tenant, subject) comes into
+// existence, and both are rare — which is the other half of the reason. The underlying
+// ensure* helpers note that their exists-check is cheap "dwarfed by the per-run LLM call
+// that gates this path"; hanging them off something frequent, like authentication, would
+// put an indexed read on the hot path for every request. Mint and boot happen once per
+// principal.
+//
+// BEST-EFFORT, ALWAYS. A failure here must never fail the thing that triggered it: minting
+// a token is a security operation and booting is a liveness one, while this is a
+// convenience. Both ensure* helpers are already idempotent, singleflighted in-process and
+// advisory-locked across replicas, so a skipped or failed pass is recovered by the next
+// mint, the next boot, or the original lazy path on first reference.
+//
+// Empty subject provisions the tenant document alone — a tenant-scoped token with no
+// distinct subject establishes the tenant but no person.
+func (s *Server) ProvisionIdentityDocs(ctx context.Context, tenant, subject string) {
+	if s.store == nil || s.sqlMem == nil {
+		return // no SQL Memory: Documents are unavailable, and that is not an error here
+	}
+	// Read through the accessor, not a captured field, so a runtime config reload is
+	// honoured on the next mint rather than needing a restart.
+	//
+	// NIL-SAFE, and nil means DO NOTHING. New() always installs the holder, so a nil
+	// config is a Server assembled without one — a test, or a degraded construction.
+	// Provisioning is a side effect on the operator's data, and doing it without knowing
+	// whether the operator wants it is worse than skipping it: the lazy path still
+	// creates the document on first reference either way.
+	cfg := s.cfg()
+	if cfg == nil || !cfg.Env.ProvisionIdentityDocs {
+		return
+	}
+	mi := memInject{Tenant: tenant, UserID: subject}
+	s.ensureTenantRootDoc(ctx, mi)
+	if subject != "" {
+		s.ensureUserRootDoc(ctx, mi)
+	}
+}
+
+// ProvisionDeclaredPrincipalDocs provisions the identity Documents for every
+// config-declared principal, at boot.
+//
+// Declared principals are the case lazy provisioning serves worst: they exist because an
+// operator wrote them into the config, so they are established before anybody has
+// authenticated, let alone started a run. Their documents should be waiting.
+//
+// Runs to completion synchronously against however many principals the config declares —
+// a hand-written list, so tens at most. The caller decides whether to background it.
+func (s *Server) ProvisionDeclaredPrincipalDocs(ctx context.Context) {
+	if s.store == nil || s.sqlMem == nil {
+		return
+	}
+	cfg := s.cfg()
+	if cfg == nil || !cfg.Env.ProvisionIdentityDocs {
+		return
+	}
+	seen := map[string]bool{}
+	n := 0
+	for _, dp := range cfg.ResolvedPrincipals {
+		t, sub := dp.Principal.TenantID, dp.Principal.Subject
+		// Dedup so two tokens for one person do not each pay the exists-check.
+		k := t + "\x00" + sub
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		s.ProvisionIdentityDocs(ctx, t, sub)
+		n++
+	}
+	if n > 0 {
+		log.Printf("memory: provisioned identity documents for %d declared principal(s)", n)
+	}
+}

--- a/internal/api/http/identitydocs_test.go
+++ b/internal/api/http/identitydocs_test.go
@@ -1,0 +1,284 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	meminject "github.com/denn-gubsky/loomcycle/internal/memory"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
+)
+
+// identityDocsFixture is the ontology fixture plus a config holder, since provisioning
+// reads the operator's setting and a Server with no config deliberately does nothing.
+func identityDocsFixture(t *testing.T, enabled bool) (*Server, memInject) {
+	t.Helper()
+	s, mi := ontologyFixture(t)
+	cfg := &config.Config{}
+	cfg.Env.ProvisionIdentityDocs = enabled
+	s.cfgHolder = config.NewHolder(cfg)
+	return s, mi
+}
+
+// docExistsAt reports whether a document is present at path in scope, WITHOUT
+// provisioning it — a probe that provisioned would make every assertion below vacuous.
+func (s *Server) docExistsAt(t *testing.T, mi memInject, scope, path string) bool {
+	t.Helper()
+	doc := &builtin.Document{Store: s.store, SqlMem: s.sqlMem}
+	dctx := s.docToolCtx(context.Background(), mi)
+	dctx = tools.WithMemoryPolicy(dctx, tools.MemoryPolicyValue{AllowedScopes: []string{"tenant", "user"}})
+	dctx = tools.WithSqlMemPolicy(dctx, tools.SqlMemPolicyValue{AllowedScopes: []string{"tenant", "user"}})
+	req, _ := json.Marshal(map[string]any{"op": "get_document", "scope": scope, "path": path})
+	res, _ := doc.Execute(dctx, req)
+	return !res.IsError
+}
+
+func TestProvisionIdentityDocs_CreatesBothForAPrincipal(t *testing.T) {
+	s, mi := identityDocsFixture(t, true)
+	if s.docExistsAt(t, mi, "user", meminject.UserRootPath) {
+		t.Fatal("fixture: the user-root document should not exist yet")
+	}
+
+	s.ProvisionIdentityDocs(context.Background(), mi.Tenant, mi.UserID)
+
+	if !s.docExistsAt(t, mi, "user", meminject.UserRootPath) {
+		t.Error("the user-root document was not provisioned")
+	}
+	if !s.docExistsAt(t, mi, "tenant", meminject.TenantRootPath) {
+		t.Error("the tenant-root document was not provisioned")
+	}
+}
+
+// The point of provisioning eagerly is that the person has a TEMPLATE to fill in, so the
+// document has to arrive with the template in it — including the Identity section that
+// memory placement depends on.
+func TestProvisionIdentityDocs_TheUserDocArrivesWithTheIdentityTemplate(t *testing.T) {
+	s, mi := identityDocsFixture(t, true)
+	s.ProvisionIdentityDocs(context.Background(), mi.Tenant, mi.UserID)
+
+	md := s.readUserRootMarkdown(context.Background(), mi)
+	if md == "" {
+		t.Fatal("the provisioned document is empty")
+	}
+	if !strings.Contains(md, "Identity") || !strings.Contains(md, meminject.SelfNameDirective) {
+		t.Errorf("the provisioned document lacks the Identity section a person is meant to fill in:\n%s", md)
+	}
+	// And it must declare NOBODY until edited — the template's example is indented for
+	// exactly this reason.
+	if names := meminject.ParseSelfNames(md); len(names) != 0 {
+		t.Errorf("a freshly provisioned profile already declares %v", names)
+	}
+}
+
+// An empty subject establishes a tenant but no person, so only the tenant document is
+// created — a user-root document keyed on nobody would be unreachable litter.
+func TestProvisionIdentityDocs_EmptySubjectProvisionsOnlyTheTenantDoc(t *testing.T) {
+	s, mi := identityDocsFixture(t, true)
+	s.ProvisionIdentityDocs(context.Background(), mi.Tenant, "")
+
+	if !s.docExistsAt(t, mi, "tenant", meminject.TenantRootPath) {
+		t.Error("the tenant-root document should still be provisioned")
+	}
+	if s.docExistsAt(t, mi, "user", meminject.UserRootPath) {
+		t.Error("a user-root document was created for an empty subject")
+	}
+}
+
+func TestProvisionIdentityDocs_DisabledCreatesNothing(t *testing.T) {
+	s, mi := identityDocsFixture(t, false)
+	s.ProvisionIdentityDocs(context.Background(), mi.Tenant, mi.UserID)
+	if s.docExistsAt(t, mi, "user", meminject.UserRootPath) {
+		t.Error("provisioning is disabled but the user-root document was created")
+	}
+	if s.docExistsAt(t, mi, "tenant", meminject.TenantRootPath) {
+		t.Error("provisioning is disabled but the tenant-root document was created")
+	}
+}
+
+// A Server with no config must not provision, and must not panic reaching for one.
+func TestProvisionIdentityDocs_NoConfigDoesNothingAndDoesNotPanic(t *testing.T) {
+	s, mi := ontologyFixture(t) // no cfgHolder
+	s.ProvisionIdentityDocs(context.Background(), mi.Tenant, mi.UserID)
+	if s.docExistsAt(t, mi, "user", meminject.UserRootPath) {
+		t.Error("a Server with no config provisioned a document")
+	}
+}
+
+// Twice is once. The provisioners are idempotent, and this asserts it through the eager
+// path — a second mint for the same principal must not leave a duplicate document.
+func TestProvisionIdentityDocs_IsIdempotent(t *testing.T) {
+	s, mi := identityDocsFixture(t, true)
+	s.ProvisionIdentityDocs(context.Background(), mi.Tenant, mi.UserID)
+	first := s.readUserRootMarkdown(context.Background(), mi)
+	s.ProvisionIdentityDocs(context.Background(), mi.Tenant, mi.UserID)
+	second := s.readUserRootMarkdown(context.Background(), mi)
+	if first != second || first == "" {
+		t.Errorf("a second provision changed the document.\nfirst:  %q\nsecond: %q", first, second)
+	}
+}
+
+func TestProvisionDeclaredPrincipalDocs_ProvisionsEachOnceAtBoot(t *testing.T) {
+	s, _ := identityDocsFixture(t, true)
+	cfg := s.cfg()
+	cfg.ResolvedPrincipals = []auth.DeclaredPrincipal{
+		{Principal: auth.Principal{TenantID: "acme", Subject: "alice"}},
+		{Principal: auth.Principal{TenantID: "acme", Subject: "bob"}},
+		// Two tokens for one person: deduped, so the exists-check is not paid twice.
+		{Principal: auth.Principal{TenantID: "acme", Subject: "alice"}},
+		{Principal: auth.Principal{TenantID: "other", Subject: "carol"}},
+	}
+
+	s.ProvisionDeclaredPrincipalDocs(context.Background())
+
+	for _, want := range []memInject{
+		{Tenant: "acme", UserID: "alice"},
+		{Tenant: "acme", UserID: "bob"},
+		{Tenant: "other", UserID: "carol"},
+	} {
+		if !s.docExistsAt(t, want, "user", meminject.UserRootPath) {
+			t.Errorf("no user-root document for declared principal %s/%s", want.Tenant, want.UserID)
+		}
+		if !s.docExistsAt(t, want, "tenant", meminject.TenantRootPath) {
+			t.Errorf("no tenant-root document for tenant %s", want.Tenant)
+		}
+	}
+	// A principal in another tenant must not have reached this one's user scope.
+	if s.docExistsAt(t, memInject{Tenant: "acme", UserID: "carol"}, "user", meminject.UserRootPath) {
+		t.Error("a declared principal's document leaked into the wrong tenant")
+	}
+}
+
+// Only `create` establishes a principal. rotate and retire act on one that already
+// exists, and retire in particular must not resurrect a document for a principal being
+// taken away.
+func TestIsTokenCreateOp_OnlyCreateEstablishesAPrincipal(t *testing.T) {
+	for body, want := range map[string]bool{
+		`{"op":"create","name":"n"}`: true,
+		`{"op":"rotate","name":"n"}`: false,
+		`{"op":"retire","name":"n"}`: false,
+		`{"op":"get","name":"n"}`:    false,
+		`{"op":"list"}`:              false,
+		`not json`:                   false,
+	} {
+		if got := isTokenCreateOp(json.RawMessage(body)); got != want {
+			t.Errorf("isTokenCreateOp(%s) = %v, want %v", body, got, want)
+		}
+	}
+}
+
+// The subject is read off the RESPONSE because it is optional on the wire and defaults to
+// a derived per-token id — taking it from the request would provision nothing for every
+// token minted without an explicit subject.
+func TestCreatedTokenPrincipal_ReadsTheResolvedSubjectFromTheResponse(t *testing.T) {
+	tenant, subject, ok := createdTokenPrincipal(`{"tenant_id":"acme","subject":"tok-ci-runner","name":"ci-runner"}`)
+	if !ok || tenant != "acme" || subject != "tok-ci-runner" {
+		t.Errorf("got (%q, %q, %v)", tenant, subject, ok)
+	}
+	// A tenant-scoped token with no distinct subject still establishes the tenant.
+	if tenant, subject, ok := createdTokenPrincipal(`{"tenant_id":"acme","subject":""}`); !ok || tenant != "acme" || subject != "" {
+		t.Errorf("empty subject: got (%q, %q, %v)", tenant, subject, ok)
+	}
+	// No tenant means nothing to provision against.
+	if _, _, ok := createdTokenPrincipal(`{"subject":"alice"}`); ok {
+		t.Error("a response with no tenant_id must not be provisioned against")
+	}
+	if _, _, ok := createdTokenPrincipal(`nonsense`); ok {
+		t.Error("an unparseable response must not be provisioned against")
+	}
+}
+
+// TestOperatorTokenDef_MintProvisionsTheIdentityDocs closes the wiring gap: the pieces
+// above are each tested, but nothing asserted that a real mint actually reaches them.
+// The composition is three lines and exactly the kind that is silently wrong.
+func TestOperatorTokenDef_MintProvisionsTheIdentityDocs(t *testing.T) {
+	s, _ := identityDocsFixture(t, true)
+	s.SetOperatorTokenDefTool(&builtin.OperatorTokenDef{Store: s.store})
+
+	mi := memInject{Tenant: "acme", UserID: "alice"}
+	if s.docExistsAt(t, mi, "user", meminject.UserRootPath) {
+		t.Fatal("fixture: nothing should exist yet")
+	}
+
+	req, _ := json.Marshal(map[string]any{
+		"op": "create", "name": "alice-cli", "tenant_id": "acme", "subject": "alice",
+		"scopes": []string{"runs:create"},
+	})
+	res, err := s.OperatorTokenDef(tokenAdminCtx(), req)
+	if err != nil {
+		t.Fatalf("OperatorTokenDef: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("create failed: %s", res.Text)
+	}
+
+	if !s.docExistsAt(t, mi, "user", meminject.UserRootPath) {
+		t.Error("minting a token did not provision the user-root document")
+	}
+	if !s.docExistsAt(t, mi, "tenant", meminject.TenantRootPath) {
+		t.Error("minting a token did not provision the tenant-root document")
+	}
+}
+
+// A mint with no explicit subject still establishes a principal — the derived `tok-<name>`
+// id — so it must still get a profile. Taking the subject from the REQUEST would provision
+// nothing here, which is why it is read off the response.
+func TestOperatorTokenDef_MintWithoutAnExplicitSubjectStillProvisions(t *testing.T) {
+	s, _ := identityDocsFixture(t, true)
+	s.SetOperatorTokenDefTool(&builtin.OperatorTokenDef{Store: s.store})
+
+	req, _ := json.Marshal(map[string]any{
+		"op": "create", "name": "ci-runner", "tenant_id": "acme",
+		"scopes": []string{"runs:create"},
+	})
+	res, err := s.OperatorTokenDef(tokenAdminCtx(), req)
+	if err != nil || res.IsError {
+		t.Fatalf("create failed: %v %s", err, res.Text)
+	}
+	var got struct {
+		Subject string `json:"subject"`
+	}
+	if err := json.Unmarshal([]byte(res.Text), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Subject == "" {
+		t.Fatal("precondition: create should derive a subject when none is given")
+	}
+	if !s.docExistsAt(t, memInject{Tenant: "acme", UserID: got.Subject}, "user", meminject.UserRootPath) {
+		t.Errorf("no profile provisioned for the derived subject %q", got.Subject)
+	}
+}
+
+// Retiring a principal must not provision anything. A document appearing as a token is
+// taken away would be the opposite of the intent.
+func TestOperatorTokenDef_RetireProvisionsNothing(t *testing.T) {
+	s, _ := identityDocsFixture(t, true)
+	s.SetOperatorTokenDefTool(&builtin.OperatorTokenDef{Store: s.store})
+
+	mk, _ := json.Marshal(map[string]any{
+		"op": "create", "name": "temp", "tenant_id": "acme", "subject": "bob",
+		"scopes": []string{"runs:create"},
+	})
+	if res, err := s.OperatorTokenDef(tokenAdminCtx(), mk); err != nil || res.IsError {
+		t.Fatalf("seed create: %v %s", err, res.Text)
+	}
+	// Provisioning for a DIFFERENT principal, so the retire below has a clean target.
+	mi := memInject{Tenant: "acme", UserID: "carol"}
+	rt, _ := json.Marshal(map[string]any{"op": "retire", "name": "temp", "tenant_id": "acme"})
+	if res, err := s.OperatorTokenDef(tokenAdminCtx(), rt); err != nil {
+		t.Fatalf("retire: %v (%s)", err, res.Text)
+	}
+	if s.docExistsAt(t, mi, "user", meminject.UserRootPath) {
+		t.Error("a retire provisioned a document")
+	}
+}
+
+// adminCtx grants the operator-admin policy the mint tool requires, which the real HTTP
+// route stamps after its bearer check.
+func tokenAdminCtx() context.Context {
+	return tools.WithOperatorTokenDefPolicy(context.Background(),
+		tools.OperatorTokenDefPolicyValue{Admin: true})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3100,6 +3100,23 @@ type Env struct {
 	// Env: LOOMCYCLE_DEADLINK_GC_DRY_RUN=1.
 	DeadLinkGCDryRun bool
 
+	// ProvisionIdentityDocs creates the tenant-root and user-root Documents when a
+	// principal is ESTABLISHED — at token mint, and at boot for config-declared
+	// principals — instead of only on the first run that references them.
+	//
+	// Default TRUE. Both documents are templates a person fills in, and the user-root
+	// one's Identity section is what lets memory placement tell a fact about the user
+	// from a fact about a colleague. Arriving on first reference is too late to be
+	// filled in beforehand, and a person with no runs yet cannot discover there is
+	// anything to fill.
+	//
+	// Set LOOMCYCLE_MEMORY_PROVISION_IDENTITY_DOCS=0 to keep the older lazy-only
+	// behaviour — an operator who does not want a document per principal appearing
+	// without being asked for.
+	//
+	// Env: LOOMCYCLE_MEMORY_PROVISION_IDENTITY_DOCS (default 1).
+	ProvisionIdentityDocs bool
+
 	// MemorySweepInterval is how often the TTL reaper goroutine
 	// runs MemorySweep on the store. Default 15 minutes. Set to 0
 	// to disable (operators with an external reaper, or tests that
@@ -3566,6 +3583,7 @@ func LoadLayers(layers ...Layer) (*Config, error) {
 		HTTPHostAllowlist:           splitCSV(os.Getenv("LOOMCYCLE_HTTP_HOST_ALLOWLIST")),
 		HTTPPrivateHostAllowlist:    splitCSV(os.Getenv("LOOMCYCLE_HTTP_PRIVATE_HOST_ALLOWLIST")),
 		MCPAllowPrivateIPs:          getenvBool("LOOMCYCLE_MCP_ALLOW_PRIVATE_IPS", true),
+		ProvisionIdentityDocs:       getenvBool("LOOMCYCLE_MEMORY_PROVISION_IDENTITY_DOCS", true),
 		HTTPCallerAuthoritative:     os.Getenv("LOOMCYCLE_HTTP_CALLER_AUTHORITATIVE") == "1",
 		ResumeFanout:                os.Getenv("LOOMCYCLE_RESUME_FANOUT") == "1",
 		MaxInteractiveChildren:      getenvInt("LOOMCYCLE_MAX_INTERACTIVE_CHILDREN", 0),


### PR DESCRIPTION
RFC CQ follow-up. Fifth PR on the line (#1101, #1102, #1103, #1104).

## Why

The user-root and tenant-root Documents are templates a person is meant to fill in, and
the user-root one's `## Identity` section (added in #1104) is what lets memory placement
tell a fact about the user from a fact about a colleague.

Both were provisioned **lazily** — on the first run that referenced
`{{memory:user_info}}`. So the document did not exist until an agent asked for it, and a
person who had not run anything yet had nothing to fill in and no way to discover there
was anything to fill. `memory_roots: force` did not help: it is a **per-agent** setting
that still needs a run to happen.

**A template that arrives after the moment it was needed is not a template.**

## What

Provisioned when the principal comes into existence:

- **at token mint**, hooked off a successful `OperatorTokenDef` create in the connector
  method that both the Web UI route and the substrate transports go through — one hook
  covers every mint path;
- **at boot for config-declared principals**, which lazy provisioning serves worst: they
  exist because an operator wrote them into the yaml, so they are established before
  anybody authenticates.

**Why not on authentication**, which would also cover every path: the `ensure*` helpers
note their exists-check is cheap because it is *"dwarfed by the per-run LLM call that gates
this path"*. Hanging them off something per-request would put an indexed read on the hot
path for every call. Mint and boot happen once per principal.

## Details worth reviewing

- **The subject is read off the RESPONSE, not the request.** `subject` is optional on the
  wire and create derives `tok-<name>` when omitted, so taking it from the request would
  provision nothing for every token minted without an explicit subject. There is a test
  for exactly that.
- **Only `create` provisions.** rotate and retire act on a principal that already exists,
  and a document appearing as a token is taken away would be the opposite of the intent.
- **Best-effort, always, and after the fact.** Minting is a security operation and booting
  a liveness one; this is a convenience and never affects either result. The `ensure*`
  helpers are already idempotent, singleflighted and advisory-locked across replicas.
- **The config read is nil-safe and nil means do nothing.** `New()` always installs the
  holder, so a nil config is a Server built without one; acting on the operator's data
  without knowing their setting is worse than skipping.
- Read through `s.cfg()` rather than a captured field, so a runtime config reload is
  honoured on the next mint.

Default **on**; `LOOMCYCLE_MEMORY_PROVISION_IDENTITY_DOCS=0` restores lazy-only, for an
operator who does not want a document per principal appearing unasked. Documented in
`docs/TOOLS.md`'s Memory env table.

## What was tested

`identitydocs_test.go`: both documents created; the template arriving **with** the Identity
section and declaring nobody until edited; an empty subject provisioning only the tenant
doc; the disabled knob; a Server with no config not panicking; idempotency; declared
principals deduped at boot with no cross-tenant leak; the op and response parsers.

Three tests drive the **real connector method** end to end — mint provisions, a mint with
no explicit subject still provisions, retire provisions nothing — because the three-line
composition is exactly the kind that is silently wrong while its parts each pass.
**Fail-before verified:** removing the hook fails both mint tests.

`go test ./...` clean, exit 0, no failures in the complete output.

**Live run**, clean data dir, `LOOMCYCLE_PRESETS=base` plus two declared principals:

```
memory: provisioned identity documents for 2 declared principal(s)
```

and in the store — one tenant-root document for `acme`, one user-root document each for
`alice` and `bob`, both carrying the Identity chunk and the `@name` directive, with no
duplicate tenant document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8