### PR TITLE
fix(store): sqlite upgrade failed when memory predated the RFC CL columns

### DIFF
--- a/internal/store/sqlite/migrate_index_order_test.go
+++ b/internal/store/sqlite/migrate_index_order_test.go
@@ -1,0 +1,73 @@
+package sqlite
+
+import (
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestMigrate_NoIndexInTheSchemaBlockNamesAnAlterAddedColumn makes an invariant that was
+// only a comment into something that fails.
+//
+// migrate() already says "ALTER must precede the partial indexes that reference the new
+// columns" — and three indexes on `memory` violated it anyway, which broke every sqlite
+// upgrade from before RFC CL. The reason it survived review and the whole test suite is
+// that a FRESH database gets those columns from CREATE TABLE, so nothing that starts from
+// an empty file can see the problem. TestMigrate_OpensADBWhoseMemoryTablePredates... covers
+// the `memory` table concretely; this covers every other table, including ones nobody has
+// written a legacy fixture for.
+//
+// It reads the source, which is unusual and deliberate: the property is about the ORDER of
+// two statement lists, and the cheapest honest way to check it for all tables is to look at
+// them. The alternative — a legacy fixture per table — is a lot of code that still misses
+// the next table someone adds.
+func TestMigrate_NoIndexInTheSchemaBlockNamesAnAlterAddedColumn(t *testing.T) {
+	src, err := os.ReadFile("sqlite.go")
+	if err != nil {
+		t.Fatalf("read sqlite.go: %v", err)
+	}
+	s := string(src)
+
+	// The schema block is everything before its own execution loop; the ALTERs come after.
+	parts := strings.SplitN(s, "for _, q := range stmts", 2)
+	if len(parts) != 2 {
+		t.Fatal("could not find the `stmts` execution loop — migrate()'s shape changed, update this test")
+	}
+	schemaBlock := parts[0]
+
+	// Columns that only an upgraded DB gets from an ALTER, per table.
+	added := map[string]map[string]bool{}
+	for _, m := range regexp.MustCompile(`ALTER TABLE (\w+) ADD COLUMN (\w+)`).FindAllStringSubmatch(s, -1) {
+		if added[m[1]] == nil {
+			added[m[1]] = map[string]bool{}
+		}
+		added[m[1]][m[2]] = true
+	}
+	if len(added) == 0 {
+		t.Fatal("found no ALTER TABLE ... ADD COLUMN statements — this test is now vacuous")
+	}
+
+	idxRe := regexp.MustCompile(`CREATE (?:UNIQUE )?INDEX IF NOT EXISTS (\w+) ON (\w+)\(([^)]*)\)([^` + "`" + `]*)`)
+	wordRe := regexp.MustCompile(`\w+`)
+
+	var offenders []string
+	for _, m := range idxRe.FindAllStringSubmatch(schemaBlock, -1) {
+		name, table, cols, tail := m[1], m[2], m[3], m[4]
+		for _, ref := range wordRe.FindAllString(cols+" "+tail, -1) {
+			if added[table][ref] {
+				offenders = append(offenders,
+					name+" on "+table+" references "+ref+", which is added by ALTER")
+				break
+			}
+		}
+	}
+	sort.Strings(offenders)
+	if len(offenders) > 0 {
+		t.Errorf("these indexes are in the CREATE-TABLE block but name a column an upgraded DB "+
+			"only gets from the ALTER block, so migrate() fails on any database old enough to "+
+			"lack it. Move them into addIndexes, which runs after the ALTERs:\n  %s",
+			strings.Join(offenders, "\n  "))
+	}
+}

--- a/internal/store/sqlite/migrate_legacy_memory_test.go
+++ b/internal/store/sqlite/migrate_legacy_memory_test.go
@@ -1,0 +1,122 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+)
+
+// legacyMemoryDDL is the `memory` table as it was created BEFORE any of the columns that
+// arrive by ALTER — no tenant_id, no source_session_id, no observed_at, no valid_at.
+//
+// This is what a long-lived deployment actually has on disk: CREATE TABLE IF NOT EXISTS is
+// a no-op against an existing table, so the table keeps the shape it was first created
+// with and every later column comes from the ALTER block.
+const legacyMemoryDDL = `CREATE TABLE memory (
+	scope      TEXT NOT NULL,
+	scope_id   TEXT NOT NULL,
+	key        TEXT NOT NULL,
+	value      TEXT NOT NULL,
+	expires_at INTEGER,
+	created_at INTEGER NOT NULL,
+	updated_at INTEGER NOT NULL,
+	PRIMARY KEY (scope, scope_id, key)
+)`
+
+// TestMigrate_OpensADBWhoseMemoryTablePredatesEveryAddedColumn is the regression test for
+// an upgrade that could not start at all.
+//
+// The bug: three partial indexes on `memory` sat in the CREATE-TABLE block, ahead of the
+// ALTERs that add the columns they name. On a fresh DB the columns come from CREATE TABLE,
+// so everything passed — including every test, because every test started from an empty
+// file. On an UPGRADED DB the table already existed without those columns, the index
+// creation failed with "no such column: observed_at", index errors are fatal, and the ALTER
+// that would have added the column was never reached. Any sqlite deployment whose `memory`
+// table predated RFC CL refused to open.
+//
+// Starting from the legacy shape is the whole point: a test that starts empty cannot see
+// this class of bug.
+func TestMigrate_OpensADBWhoseMemoryTablePredatesEveryAddedColumn(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy.db")
+
+	// Lay down the old table with a row in it, then close, so Open() faces a real
+	// pre-existing database rather than one this process is already holding open.
+	seed, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	if _, err := seed.Exec(legacyMemoryDDL); err != nil {
+		t.Fatalf("create legacy memory table: %v", err)
+	}
+	if _, err := seed.Exec(
+		`INSERT INTO memory (scope, scope_id, key, value, created_at, updated_at)
+		 VALUES ('user', 'alice', 'pref/editor', '"vim"', 1, 1)`); err != nil {
+		t.Fatalf("seed row: %v", err)
+	}
+	if err := seed.Close(); err != nil {
+		t.Fatalf("close seed: %v", err)
+	}
+
+	st, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open on a legacy DB must migrate it, got: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+
+	ctx := context.Background()
+
+	// The ALTERs ran: every column the indexes name now exists.
+	cols := map[string]bool{}
+	rows, err := st.db.QueryContext(ctx, `SELECT name FROM pragma_table_info('memory')`)
+	if err != nil {
+		t.Fatalf("table_info: %v", err)
+	}
+	for rows.Next() {
+		var n string
+		if err := rows.Scan(&n); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		cols[n] = true
+	}
+	_ = rows.Close()
+	for _, want := range []string{"tenant_id", "source_session_id", "observed_at", "valid_at", "invalid_at"} {
+		if !cols[want] {
+			t.Errorf("column %q was not added to the legacy table", want)
+		}
+	}
+
+	// And the indexes were actually created, rather than the migration "succeeding" by
+	// skipping them — which would leave the time predicates unindexed and silent.
+	for _, want := range []string{"memory_by_source_session", "memory_by_observed_at", "memory_by_valid_at"} {
+		var name string
+		err := st.db.QueryRowContext(ctx,
+			`SELECT name FROM sqlite_master WHERE type='index' AND name = ?`, want).Scan(&name)
+		if err != nil {
+			t.Errorf("index %q missing after migrate: %v", want, err)
+		}
+	}
+
+	// The pre-existing row survived. A migration that fixed the schema by dropping data
+	// would pass every check above.
+	var value string
+	if err := st.db.QueryRowContext(ctx,
+		`SELECT value FROM memory WHERE scope='user' AND scope_id='alice' AND key='pref/editor'`,
+	).Scan(&value); err != nil {
+		t.Fatalf("the legacy row did not survive the migration: %v", err)
+	}
+	if value != `"vim"` {
+		t.Errorf("legacy row value = %q, want %q", value, `"vim"`)
+	}
+
+	// Idempotent: opening again must be a clean no-op, which is what every boot after
+	// the upgrade does.
+	if err := st.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	st2, err := Open(path)
+	if err != nil {
+		t.Fatalf("second Open on the migrated DB failed: %v", err)
+	}
+	_ = st2.Close()
+}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -292,16 +292,13 @@ func (s *Store) migrate(ctx context.Context) error {
 		// because source_session_id is NULL on every row not distilled from a chat
 		// and indexing those pays for the majority to serve a query that never asks
 		// about them. See MemoryListBySourceSessions for why the direction matters.
-		`CREATE INDEX IF NOT EXISTS memory_by_source_session ON memory(tenant_id, source_session_id) WHERE source_session_id IS NOT NULL`,
+		//
+		// memory_by_source_session, memory_by_observed_at and memory_by_valid_at are NOT
+		// here: every column they name is added by ALTER further down, so on an upgraded
+		// DB this block runs before the column exists. They live in addIndexes, after
+		// the ALTERs. Only expires_at is part of the original CREATE TABLE, so only its
+		// index is safe in this block.
 		`CREATE INDEX IF NOT EXISTS memory_by_expires_at ON memory(expires_at) WHERE expires_at IS NOT NULL`,
-		// RFC CL — the observed-time window predicate. Partial for the same reason as
-		// memory_by_source_session: observed_at is NULL on every row nobody dated, and
-		// on a corpus that was never dated that is all of them. Mirrors postgres
-		// migration 0073.
-		`CREATE INDEX IF NOT EXISTS memory_by_observed_at ON memory(tenant_id, scope, scope_id, observed_at) WHERE observed_at IS NOT NULL`,
-		// RFC CL phase 2a — the validity interval. Partial for the same reason.
-		// Mirrors postgres migration 0074.
-		`CREATE INDEX IF NOT EXISTS memory_by_valid_at ON memory(tenant_id, scope, scope_id, valid_at) WHERE valid_at IS NOT NULL`,
 		// RFC BL P2 — the durable consolidation substrate. Mirrors Postgres
 		// migration 0061. memory_pending is the enqueue queue an Add writes to
 		// and the consolidator drains (drained_at = soft-drain marker for
@@ -1400,6 +1397,28 @@ func (s *Store) migrate(ctx context.Context) error {
 		// it the upserts fail "ON CONFLICT clause does not match ..." even
 		// single-tenant. Mirrors the def-plane indexes above.
 		`CREATE UNIQUE INDEX IF NOT EXISTS uniq_memory_tenant_scope_scope_id_key ON memory(tenant_id, scope, scope_id, key)`,
+		// MOVED HERE FROM THE CREATE-TABLE BLOCK, and the move is the fix for an
+		// upgrade that could not start at all.
+		//
+		// Each of these names a column that an upgraded DB only gets from the ALTER
+		// block above: a `CREATE TABLE IF NOT EXISTS` is a no-op against an existing
+		// table, so `memory` keeps whatever shape it was created with and the column
+		// arrives later or not at all. Creating the index first therefore failed with
+		// "no such column: observed_at" — fatally, since index errors are not
+		// swallowed — and the ALTER that would have added it was never reached. Any
+		// sqlite deployment whose `memory` table predated RFC CL could not open.
+		//
+		// A fresh DB is unaffected either way: it gets the columns from CREATE TABLE
+		// and the indexes here, which is why every test passed while real upgrades
+		// broke.
+		//
+		// Partial for the reason the originals gave: the predicate column is NULL on
+		// every row nobody dated, and on a corpus that was never dated that is all of
+		// them. Mirrors postgres migrations 0065 / 0073 / 0074, which do not have this
+		// problem because each is its own ordered file.
+		`CREATE INDEX IF NOT EXISTS memory_by_source_session ON memory(tenant_id, source_session_id) WHERE source_session_id IS NOT NULL`,
+		`CREATE INDEX IF NOT EXISTS memory_by_observed_at ON memory(tenant_id, scope, scope_id, observed_at) WHERE observed_at IS NOT NULL`,
+		`CREATE INDEX IF NOT EXISTS memory_by_valid_at ON memory(tenant_id, scope, scope_id, valid_at) WHERE valid_at IS NOT NULL`,
 	}
 	for _, q := range addIndexes {
 		// Note the asymmetry vs addColumns above: indexes use


### PR DESCRIPTION
**Upgrade blocker.** Any sqlite deployment whose `memory` table was created before RFC CL
(v1.65.0) cannot start on v1.66+:

```
store: sqlite open: migrate: SQL logic error: no such column: observed_at (1)
```

The store never opens, so the failure is total rather than degraded.

## Cause

Three partial indexes on `memory` — `memory_by_source_session`, `memory_by_observed_at`,
`memory_by_valid_at` — sat in `migrate()`'s CREATE-TABLE block, **ahead of the ALTERs that
add the columns they name**.

On an existing database `CREATE TABLE IF NOT EXISTS` is a no-op, so the table keeps the
shape it was first created with. The index creation then fails on the missing column, index
errors are fatal (deliberately — the loop's own comment warns against swallowing them), and
the `ALTER TABLE memory ADD COLUMN observed_at` further down is never reached.

`migrate()` already documents the rule that was broken:

> Order matters only in that ALTER must precede the partial indexes that reference the new
> columns.

## Fix

Move the three statements into `addIndexes`, which runs after the ALTER block. Postgres is
unaffected — migrations 0065 / 0073 / 0074 are separate ordered files, which is why only
sqlite has this.

`memory_by_expires_at` stays in the schema block: `expires_at` is part of the original
CREATE TABLE, so it is the one that was always safe there.

## Why it passed everything

A **fresh** database gets those columns from CREATE TABLE, so both orderings work — and
every existing test starts from an empty file. The bug was only reachable by opening a
database that already existed, which no test did. That is the actual defect here, so both
new tests are about that gap.

## What was tested

- `TestMigrate_OpensADBWhoseMemoryTablePredatesEveryAddedColumn` — creates the pre-ALTER
  `memory` table with a row in it, then opens it for real. Asserts the columns arrive, the
  indexes are **actually created** (a migration that "succeeded" by skipping them would
  leave the time predicates silently unindexed), the legacy row survives, and a second open
  is a clean no-op.
- `TestMigrate_NoIndexInTheSchemaBlockNamesAnAlterAddedColumn` — turns the comment into a
  failure, for **every** table rather than just this one. It reads the source, which is
  deliberate: the property is about the order of two statement lists, and a legacy fixture
  per table is a lot of code that still misses the next table someone adds.
- **Fail-before verified:** with the indexes back in the wrong block, both fail — the
  legacy-DB test with the production error shape (`no such column`), and the guard naming
  all three offenders.
- `go test ./...` clean, exit 0, no failures in the complete output.

**Live proof on a real pre-RFC-CL database** (a copy of one, so nothing was mutated):

```
before:  133 rows, observed_at ABSENT
after:   store: sqlite at .../legacy/loomcycle.db      <- opens
         columns: observed_at valid_at invalid_at
         indexes: memory_by_expires_at memory_by_source_session
                  memory_by_observed_at memory_by_valid_at
         rows: 133   integrity: ok
```

## How it was found

Pointing a v1.67 binary at a real pre-RFC-CL database while verifying an unrelated change.
No data was at risk: the failing statement is a `CREATE INDEX`, so nothing is written, and
the database came back with `integrity_check` ok and every row intact.

Worth noting for anyone else doing this: there is no `LOOMCYCLE_SQLITE_PATH` — the file is
always `{LOOMCYCLE_DATA_DIR}/loomcycle.db`, default `./data`, so a dev binary run from the
repo root opens the repo's own local database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8