### PR TITLE
feat(memory): the consolidator places facts in the scope the ontology declares

### DIFF
--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -488,8 +488,18 @@ agents:
           supersede_queue: [],      // neighbour keys judged duplicates of a kept row
           supersede_keeper: {},     // retired key -> the key that survived it (entity half)
           written_keys: {},         // never retire a row this pass just wrote
-          entities_doc: null,       // the /memory/entities document id, resolved once
-          entity_ids: {},           // natural_key -> chunk id, for this pass
+          entities_doc: {},         // scope -> /memory/entities document id, resolved once each
+          entity_ids: {},           // scope + "\u0000" + natural_key -> chunk id, for this pass
+          // scope PLACEMENT (ontology-declared). type|subject -> target scope, for the
+          // pairs the server said belong somewhere other than CONFIG.scope. Absent key
+          // means "leave it where it was", which is every fact on a deployment whose
+          // ontology declares nothing — i.e. the default.
+          placement: {},
+          placed: 0,                // facts written to a declared scope
+          placement_displaced: 0,   // stale same-key twins retired after a move
+          placement_displace_failed: 0,
+          placement_moved_keys: {}, // key -> target scope, for the displaced-twin retire
+          placement_error: "",
           entity_nodes: 0,          // distinct subjects given an entity chunk
           entity_facts: 0,          // facts mirrored into the graph
           // The judge's candidates, in WRITE ORDER. An array rather than a map
@@ -1144,6 +1154,7 @@ agents:
       // applyFacts returns true only when every write it attempted landed.
       function applyFacts(st, facts, sourceID, pendingID) {
         var ok = true;
+        resolvePlacements(st, facts);
         for (var i = 0; i < facts.length; i++) {
           if (!applyOne(st, facts[i], sourceID, pendingID)) { ok = false; }
         }
@@ -1211,6 +1222,32 @@ agents:
             st.supersede_keeper[dupes[d].id] = dupes[0].id;
           }
           if (!write(st, primary.id, fact, sourceID, pendingID)) { return false; }
+          // SUPERSEDE-WITH-POINTER. The rewrite above went to the scope the ontology
+          // declares, which may not be the scope the old row is in — that happens when a
+          // fact has lived here for a while and the operator has since declared its type
+          // shared. Leave the old row live and the same fact is readable in two places,
+          // with two places to correct it, which is the duplication this feature exists
+          // to remove. So retire it.
+          //
+          // The POINTER is exact without a new column: the row was rewritten under the
+          // SAME key, so the live copy is (this key, the target scope), and the new row's
+          // provenance carries promoted_from. A retired row is a soft archive — the audit
+          // trail survives and nothing is deleted.
+          //
+          // Not routed through supersede_queue: that queue's cap exists to stop a steered
+          // "everything you know is obsolete" driving an unbounded sweep, and this is
+          // driven by the operator's ontology rather than by anything in a transcript. It
+          // is one supersede per displaced fact, bounded by the batch.
+          if (st.placement_moved_keys[primary.id]) {
+            try {
+              Memory.supersede({ scope: CONFIG.scope, key: primary.id });
+              st.placement_displaced++;
+            } catch (e) {
+              // The fact is safely stored in its declared scope; the stale twin is a
+              // duplicate, not a loss. Counted so a pass that cannot retire says so.
+              st.placement_displace_failed++;
+            }
+          }
           st.updated++;
           return true;
         }
@@ -1423,15 +1460,81 @@ agents:
       // stored ones silently moves every fact off that calibration and the
       // deduplication above quietly stops firing. A test asserts the two are
       // byte-identical on every write.
+      // resolvePlacements asks the server, ONCE for the whole batch, which scope each
+      // typed fact belongs in.
+      //
+      // ONE CALL, and that is the design rather than an optimization. A fact is stored
+      // twice — the k/v row recall searches and the chunk mirror the graph walks — and
+      // both halves must land in the SAME scope or recall finds the fact in one place and
+      // graph_recall in another. Deciding once, before either write, is what guarantees
+      // that; deciding per write site would be two decisions agreeing by luck.
+      //
+      // Only typed facts are asked about: the ontology routes by the subject's entity
+      // type, so an untyped fact has nothing to route on and is also the set that gets no
+      // mirror. That alignment is load-bearing — a placed fact ALWAYS has a mirror, so the
+      // two halves always move together.
+      //
+      // BEST-EFFORT. A failure leaves the memo empty, every fact stays in CONFIG.scope,
+      // and the pass proceeds exactly as it did before placement existed. The report names
+      // it. Nothing here is allowed to cost a fact.
+      function resolvePlacements(st, facts) {
+        var items = [], seen = {};
+        for (var i = 0; i < facts.length; i++) {
+          var f = facts[i];
+          if (!f || !f.type || !f.subject) { continue; }
+          var k = f.type + "\u0000" + f.subject;
+          if (seen[k]) { continue; }
+          seen[k] = true;
+          items.push({ type: f.type, subject: f.subject });
+        }
+        if (!items.length) { return; }
+        try {
+          // TWO conventions, and getting either wrong is silent. Memory is a META-TOOL:
+          // it is namespaced by op (Memory.set, Memory.recall — never Memory({op:...}),
+          // which throws before any call is made), and the bridge hands back an ALREADY
+          // PARSED object. Document and History take an `op` field and return a STRING
+          // that has to be JSON.parse'd. Wrapping this one in JSON.parse stringifies the
+          // object and fails, which reads as a server refusal.
+          var res = Memory.placement({ scope: CONFIG.scope, items: items });
+          var rows = (res && res.placements) ? res.placements : [];
+          for (var r = 0; r < rows.length; r++) {
+            var row = rows[r];
+            if (row && row.moved && row.scope) {
+              st.placement[row.type + "\u0000" + row.subject] = row.scope;
+            }
+          }
+        } catch (e) {
+          st.placement_error = errText(e);
+        }
+      }
+
+      // placementFor is the ONLY place a write learns its scope. CONFIG.scope stays the
+      // answer for everything the ontology does not place, which is the default.
+      function placementFor(st, fact) {
+        if (!fact || !fact.type || !fact.subject) { return CONFIG.scope; }
+        var got = st.placement[fact.type + "\u0000" + fact.subject];
+        return got ? got : CONFIG.scope;
+      }
+
       function write(st, key, fact, sourceID, pendingID) {
+        // The scope the ontology declares for this fact's subject, or CONFIG.scope.
+        var scope = placementFor(st, fact);
+        var prov = sourceID ? { "class": fact.cls, source_session_id: sourceID }
+                            : { "class": fact.cls };
+        // WHERE IT CAME FROM, on a placed fact only. An operator looking at a row in the
+        // shared plane must be able to answer "why is this here" without guessing, and
+        // source_session_id alone does not say that the row was MOVED. It also keeps the
+        // erasure report honest: a placed fact still carries the session it came from, so
+        // it shows up as residue for the subject who produced it even though a user
+        // erasure correctly leaves it alone.
+        if (scope !== CONFIG.scope) { prov.promoted_from = CONFIG.scope; }
         var args = {
-          scope: CONFIG.scope,
+          scope: scope,
           key: key,
           value: fact.text,
           embed: true,
           embed_text: fact.text,
-          provenance: sourceID ? { "class": fact.cls, source_session_id: sourceID }
-                               : { "class": fact.cls }
+          provenance: prov
         };
         // WHEN the fact was true, when the extractor could tell. Omitted entirely
         // otherwise — an undated fact is the common and correct case, and a
@@ -1454,9 +1557,14 @@ agents:
           return false;
         }
         st.written_keys[key] = true;
+        if (scope !== CONFIG.scope) {
+          st.placed++;
+          st.placement_moved_keys[key] = scope;
+        }
         // The entity graph mirrors the fact AFTER the authoritative write lands, so
-        // a graph failure can never cost a fact.
-        mirrorEntity(st, key, fact);
+        // a graph failure can never cost a fact. SAME scope as the row above — the two
+        // halves of one fact never split.
+        mirrorEntity(st, key, fact, scope);
         return true;
       }
 
@@ -1484,24 +1592,28 @@ agents:
       // /memory/entities document. Provisioned here rather than server-side
       // because nothing on the server has a reason to touch it — the consolidator
       // is its only writer.
-      function entitiesDoc(st) {
-        if (st.entities_doc !== null) { return st.entities_doc; }
+      function entitiesDoc(st, scope) {
+        scope = scope || CONFIG.scope;
+        // PER SCOPE: /memory/entities is a path within a scope, so a placed fact's graph
+        // belongs to the target scope's own document. One memo entry per scope, resolved
+        // at most once each per pass.
+        if (st.entities_doc[scope] !== undefined) { return st.entities_doc[scope]; }
         var path = "/memory/entities";
         try {
-          var got = JSON.parse(Document({ op: "get_document", scope: CONFIG.scope, path: path }));
-          st.entities_doc = got.document_id || "";
+          var got = JSON.parse(Document({ op: "get_document", scope: scope, path: path }));
+          st.entities_doc[scope] = got.document_id || "";
         } catch (e) {
           try {
             var made = JSON.parse(Document({
-              op: "create_document", scope: CONFIG.scope,
+              op: "create_document", scope: scope,
               title: "Entities", path: path
             }));
-            st.entities_doc = made.document_id || "";
+            st.entities_doc[scope] = made.document_id || "";
           } catch (e2) {
-            st.entities_doc = ""; // give up for this pass; k/v is unaffected
+            st.entities_doc[scope] = ""; // give up for this pass; k/v is unaffected
           }
         }
-        return st.entities_doc;
+        return st.entities_doc[scope];
       }
 
       // ENTITY_TYPE_DENY are ontology terms that are STATEMENT CLASSES, not things a
@@ -1542,15 +1654,19 @@ agents:
       function entityKey(type, subject) { return type + ":" + slug(normalizeSubject(subject)); }
 
       // upsertEntityChunk writes one chunk and returns its id, or "" on failure.
-      function upsertEntityChunk(st, docID, naturalKey, args) {
-        if (st.entity_ids[naturalKey]) { return st.entity_ids[naturalKey]; }
+      function upsertEntityChunk(st, scope, docID, naturalKey, args) {
+        // MEMOISED PER SCOPE. The same natural key exists independently in each scope, so
+        // a scope-blind memo would hand back a user-scope chunk id for a tenant write and
+        // silently attach the edge to the wrong document.
+        var memo = scope + "\u0000" + naturalKey;
+        if (st.entity_ids[memo]) { return st.entity_ids[memo]; }
         try {
           args.op = "upsert_chunk";
-          args.scope = CONFIG.scope;
+          args.scope = scope;
           args.document_id = docID;
           args.natural_key = naturalKey;
           var res = JSON.parse(Document(args));
-          if (res && res.id) { st.entity_ids[naturalKey] = res.id; return res.id; }
+          if (res && res.id) { st.entity_ids[memo] = res.id; return res.id; }
         } catch (e) {
           st.entity_failed++;
         }
@@ -1559,18 +1675,19 @@ agents:
 
       // mirrorEntity writes the subject node, the fact node and the edge between
       // them. Called after the k/v write has already succeeded.
-      function mirrorEntity(st, key, fact) {
+      function mirrorEntity(st, key, fact, scope) {
         if (!fact.type || !fact.subject) { return; } // untyped fact: k/v only (by design)
+        scope = scope || CONFIG.scope;
         // A statement class is not an entity type. Counted rather than silently
         // skipped: a pass that mirrored nothing because every type was rejected
         // must not look like a pass with nothing to mirror.
         if (ENTITY_TYPE_DENY[fact.type] === true) { st.entity_type_refused++; return; }
-        var docID = entitiesDoc(st);
+        var docID = entitiesDoc(st, scope);
         if (!docID) { return; }
 
         var subjKey = entityKey(fact.type, fact.subject);
-        var isNewSubject = !st.entity_ids[subjKey];
-        var subjID = upsertEntityChunk(st, docID, subjKey, {
+        var isNewSubject = !st.entity_ids[scope + "\u0000" + subjKey];
+        var subjID = upsertEntityChunk(st, scope, docID, subjKey, {
           title: fact.subject, type: fact.type, subject: fact.subject
         });
         if (!subjID) { return; }
@@ -1586,7 +1703,7 @@ agents:
         // claim — there is nothing about "Denn" for a quote to support, and attaching
         // one there would make the evidence look like it backed the wrong thing.
         if (fact.quote) { factArgs.source_quote = fact.quote; }
-        var factID = upsertEntityChunk(st, docID, key, factArgs);
+        var factID = upsertEntityChunk(st, scope, docID, key, factArgs);
         if (!factID) { return; }
         st.entity_facts++;
 
@@ -1953,7 +2070,9 @@ agents:
       function retireEntity(st, retiredKey) {
         var keeperKey = st.supersede_keeper[retiredKey];
         if (!keeperKey) { return; }
-        var docID = entitiesDoc(st);
+        // CONFIG.scope explicitly: duplicate collapse is a within-scope operation, and
+        // both the retired row and its survivor are in the scope this pass owns.
+        var docID = entitiesDoc(st, CONFIG.scope);
         if (!docID) { return; }
         var oldID = entityIDByKey(st, retiredKey), newID = entityIDByKey(st, keeperKey);
         if (!oldID || !newID) { return; } // neither was ever mirrored — nothing to retire
@@ -1974,7 +2093,10 @@ agents:
       // [a-z0-9:-] by construction, so no quote can occur. Do not extend this to a
       // key from anywhere else.
       function entityIDByKey(st, naturalKey) {
-        if (st.entity_ids[naturalKey]) { return st.entity_ids[naturalKey]; }
+        // CONFIG.scope's memo, because that is the scope this queries. The memo is keyed
+        // by scope since placement made the same natural key exist in more than one.
+        var memo = CONFIG.scope + "\u0000" + naturalKey;
+        if (st.entity_ids[memo]) { return st.entity_ids[memo]; }
         if (!/^[a-z0-9:_/-]+$/.test(naturalKey)) { return ""; }
         try {
           var res = JSON.parse(Document({
@@ -1982,8 +2104,8 @@ agents:
             sql: "SELECT chunk_id FROM chunk_memory_meta WHERE natural_key = '" + naturalKey + "'"
           }));
           if (res && res.rows && res.rows.length && res.rows[0].length) {
-            st.entity_ids[naturalKey] = String(res.rows[0][0]);
-            return st.entity_ids[naturalKey];
+            st.entity_ids[memo] = String(res.rows[0][0]);
+            return st.entity_ids[memo];
           }
         } catch (e) {
           st.entity_failed++;
@@ -2097,6 +2219,26 @@ agents:
         parts.push("facts written " + st.written);
         parts.push("updated in place " + st.updated);
         parts.push("retired " + st.superseded);
+        // PLACEMENT is silent when nothing is declared, which is the default and the
+        // common case — a line saying "placed 0" on every pass of every deployment that
+        // has no declarations would be noise. When it DOES fire the operator needs to see
+        // it: these rows left this user's scope for a plane everyone reads.
+        if (st.placed > 0) {
+          parts.push("placed in a declared scope " + st.placed);
+        }
+        if (st.placement_displaced > 0) {
+          parts.push("stale same-key twins retired after placement " + st.placement_displaced);
+        }
+        if (st.placement_displace_failed > 0) {
+          parts.push("twins that could NOT be retired " + st.placement_displace_failed +
+            " (the fact is stored in its declared scope; a duplicate remains here)");
+        }
+        // Said out loud rather than swallowed: the pass stored everything in this scope,
+        // which is correct behaviour but NOT the behaviour a declaring operator expects.
+        if (st.placement_error) {
+          parts.push("scope placement unavailable (" + st.placement_error +
+            ") — everything stayed in " + CONFIG.scope + " scope");
+        }
         if (st.supersede_capped > 0) {
           parts.push("retirement capped at " + CONFIG.max_supersedes + " (" + st.supersede_capped + " left for the next pass)");
         }

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -488,8 +488,18 @@ agents:
           supersede_queue: [],      // neighbour keys judged duplicates of a kept row
           supersede_keeper: {},     // retired key -> the key that survived it (entity half)
           written_keys: {},         // never retire a row this pass just wrote
-          entities_doc: null,       // the /memory/entities document id, resolved once
-          entity_ids: {},           // natural_key -> chunk id, for this pass
+          entities_doc: {},         // scope -> /memory/entities document id, resolved once each
+          entity_ids: {},           // scope + "\u0000" + natural_key -> chunk id, for this pass
+          // scope PLACEMENT (ontology-declared). type|subject -> target scope, for the
+          // pairs the server said belong somewhere other than CONFIG.scope. Absent key
+          // means "leave it where it was", which is every fact on a deployment whose
+          // ontology declares nothing — i.e. the default.
+          placement: {},
+          placed: 0,                // facts written to a declared scope
+          placement_displaced: 0,   // stale same-key twins retired after a move
+          placement_displace_failed: 0,
+          placement_moved_keys: {}, // key -> target scope, for the displaced-twin retire
+          placement_error: "",
           entity_nodes: 0,          // distinct subjects given an entity chunk
           entity_facts: 0,          // facts mirrored into the graph
           // The judge's candidates, in WRITE ORDER. An array rather than a map
@@ -1144,6 +1154,7 @@ agents:
       // applyFacts returns true only when every write it attempted landed.
       function applyFacts(st, facts, sourceID, pendingID) {
         var ok = true;
+        resolvePlacements(st, facts);
         for (var i = 0; i < facts.length; i++) {
           if (!applyOne(st, facts[i], sourceID, pendingID)) { ok = false; }
         }
@@ -1211,6 +1222,32 @@ agents:
             st.supersede_keeper[dupes[d].id] = dupes[0].id;
           }
           if (!write(st, primary.id, fact, sourceID, pendingID)) { return false; }
+          // SUPERSEDE-WITH-POINTER. The rewrite above went to the scope the ontology
+          // declares, which may not be the scope the old row is in — that happens when a
+          // fact has lived here for a while and the operator has since declared its type
+          // shared. Leave the old row live and the same fact is readable in two places,
+          // with two places to correct it, which is the duplication this feature exists
+          // to remove. So retire it.
+          //
+          // The POINTER is exact without a new column: the row was rewritten under the
+          // SAME key, so the live copy is (this key, the target scope), and the new row's
+          // provenance carries promoted_from. A retired row is a soft archive — the audit
+          // trail survives and nothing is deleted.
+          //
+          // Not routed through supersede_queue: that queue's cap exists to stop a steered
+          // "everything you know is obsolete" driving an unbounded sweep, and this is
+          // driven by the operator's ontology rather than by anything in a transcript. It
+          // is one supersede per displaced fact, bounded by the batch.
+          if (st.placement_moved_keys[primary.id]) {
+            try {
+              Memory.supersede({ scope: CONFIG.scope, key: primary.id });
+              st.placement_displaced++;
+            } catch (e) {
+              // The fact is safely stored in its declared scope; the stale twin is a
+              // duplicate, not a loss. Counted so a pass that cannot retire says so.
+              st.placement_displace_failed++;
+            }
+          }
           st.updated++;
           return true;
         }
@@ -1423,15 +1460,81 @@ agents:
       // stored ones silently moves every fact off that calibration and the
       // deduplication above quietly stops firing. A test asserts the two are
       // byte-identical on every write.
+      // resolvePlacements asks the server, ONCE for the whole batch, which scope each
+      // typed fact belongs in.
+      //
+      // ONE CALL, and that is the design rather than an optimization. A fact is stored
+      // twice — the k/v row recall searches and the chunk mirror the graph walks — and
+      // both halves must land in the SAME scope or recall finds the fact in one place and
+      // graph_recall in another. Deciding once, before either write, is what guarantees
+      // that; deciding per write site would be two decisions agreeing by luck.
+      //
+      // Only typed facts are asked about: the ontology routes by the subject's entity
+      // type, so an untyped fact has nothing to route on and is also the set that gets no
+      // mirror. That alignment is load-bearing — a placed fact ALWAYS has a mirror, so the
+      // two halves always move together.
+      //
+      // BEST-EFFORT. A failure leaves the memo empty, every fact stays in CONFIG.scope,
+      // and the pass proceeds exactly as it did before placement existed. The report names
+      // it. Nothing here is allowed to cost a fact.
+      function resolvePlacements(st, facts) {
+        var items = [], seen = {};
+        for (var i = 0; i < facts.length; i++) {
+          var f = facts[i];
+          if (!f || !f.type || !f.subject) { continue; }
+          var k = f.type + "\u0000" + f.subject;
+          if (seen[k]) { continue; }
+          seen[k] = true;
+          items.push({ type: f.type, subject: f.subject });
+        }
+        if (!items.length) { return; }
+        try {
+          // TWO conventions, and getting either wrong is silent. Memory is a META-TOOL:
+          // it is namespaced by op (Memory.set, Memory.recall — never Memory({op:...}),
+          // which throws before any call is made), and the bridge hands back an ALREADY
+          // PARSED object. Document and History take an `op` field and return a STRING
+          // that has to be JSON.parse'd. Wrapping this one in JSON.parse stringifies the
+          // object and fails, which reads as a server refusal.
+          var res = Memory.placement({ scope: CONFIG.scope, items: items });
+          var rows = (res && res.placements) ? res.placements : [];
+          for (var r = 0; r < rows.length; r++) {
+            var row = rows[r];
+            if (row && row.moved && row.scope) {
+              st.placement[row.type + "\u0000" + row.subject] = row.scope;
+            }
+          }
+        } catch (e) {
+          st.placement_error = errText(e);
+        }
+      }
+
+      // placementFor is the ONLY place a write learns its scope. CONFIG.scope stays the
+      // answer for everything the ontology does not place, which is the default.
+      function placementFor(st, fact) {
+        if (!fact || !fact.type || !fact.subject) { return CONFIG.scope; }
+        var got = st.placement[fact.type + "\u0000" + fact.subject];
+        return got ? got : CONFIG.scope;
+      }
+
       function write(st, key, fact, sourceID, pendingID) {
+        // The scope the ontology declares for this fact's subject, or CONFIG.scope.
+        var scope = placementFor(st, fact);
+        var prov = sourceID ? { "class": fact.cls, source_session_id: sourceID }
+                            : { "class": fact.cls };
+        // WHERE IT CAME FROM, on a placed fact only. An operator looking at a row in the
+        // shared plane must be able to answer "why is this here" without guessing, and
+        // source_session_id alone does not say that the row was MOVED. It also keeps the
+        // erasure report honest: a placed fact still carries the session it came from, so
+        // it shows up as residue for the subject who produced it even though a user
+        // erasure correctly leaves it alone.
+        if (scope !== CONFIG.scope) { prov.promoted_from = CONFIG.scope; }
         var args = {
-          scope: CONFIG.scope,
+          scope: scope,
           key: key,
           value: fact.text,
           embed: true,
           embed_text: fact.text,
-          provenance: sourceID ? { "class": fact.cls, source_session_id: sourceID }
-                               : { "class": fact.cls }
+          provenance: prov
         };
         // WHEN the fact was true, when the extractor could tell. Omitted entirely
         // otherwise — an undated fact is the common and correct case, and a
@@ -1454,9 +1557,14 @@ agents:
           return false;
         }
         st.written_keys[key] = true;
+        if (scope !== CONFIG.scope) {
+          st.placed++;
+          st.placement_moved_keys[key] = scope;
+        }
         // The entity graph mirrors the fact AFTER the authoritative write lands, so
-        // a graph failure can never cost a fact.
-        mirrorEntity(st, key, fact);
+        // a graph failure can never cost a fact. SAME scope as the row above — the two
+        // halves of one fact never split.
+        mirrorEntity(st, key, fact, scope);
         return true;
       }
 
@@ -1484,24 +1592,28 @@ agents:
       // /memory/entities document. Provisioned here rather than server-side
       // because nothing on the server has a reason to touch it — the consolidator
       // is its only writer.
-      function entitiesDoc(st) {
-        if (st.entities_doc !== null) { return st.entities_doc; }
+      function entitiesDoc(st, scope) {
+        scope = scope || CONFIG.scope;
+        // PER SCOPE: /memory/entities is a path within a scope, so a placed fact's graph
+        // belongs to the target scope's own document. One memo entry per scope, resolved
+        // at most once each per pass.
+        if (st.entities_doc[scope] !== undefined) { return st.entities_doc[scope]; }
         var path = "/memory/entities";
         try {
-          var got = JSON.parse(Document({ op: "get_document", scope: CONFIG.scope, path: path }));
-          st.entities_doc = got.document_id || "";
+          var got = JSON.parse(Document({ op: "get_document", scope: scope, path: path }));
+          st.entities_doc[scope] = got.document_id || "";
         } catch (e) {
           try {
             var made = JSON.parse(Document({
-              op: "create_document", scope: CONFIG.scope,
+              op: "create_document", scope: scope,
               title: "Entities", path: path
             }));
-            st.entities_doc = made.document_id || "";
+            st.entities_doc[scope] = made.document_id || "";
           } catch (e2) {
-            st.entities_doc = ""; // give up for this pass; k/v is unaffected
+            st.entities_doc[scope] = ""; // give up for this pass; k/v is unaffected
           }
         }
-        return st.entities_doc;
+        return st.entities_doc[scope];
       }
 
       // ENTITY_TYPE_DENY are ontology terms that are STATEMENT CLASSES, not things a
@@ -1542,15 +1654,19 @@ agents:
       function entityKey(type, subject) { return type + ":" + slug(normalizeSubject(subject)); }
 
       // upsertEntityChunk writes one chunk and returns its id, or "" on failure.
-      function upsertEntityChunk(st, docID, naturalKey, args) {
-        if (st.entity_ids[naturalKey]) { return st.entity_ids[naturalKey]; }
+      function upsertEntityChunk(st, scope, docID, naturalKey, args) {
+        // MEMOISED PER SCOPE. The same natural key exists independently in each scope, so
+        // a scope-blind memo would hand back a user-scope chunk id for a tenant write and
+        // silently attach the edge to the wrong document.
+        var memo = scope + "\u0000" + naturalKey;
+        if (st.entity_ids[memo]) { return st.entity_ids[memo]; }
         try {
           args.op = "upsert_chunk";
-          args.scope = CONFIG.scope;
+          args.scope = scope;
           args.document_id = docID;
           args.natural_key = naturalKey;
           var res = JSON.parse(Document(args));
-          if (res && res.id) { st.entity_ids[naturalKey] = res.id; return res.id; }
+          if (res && res.id) { st.entity_ids[memo] = res.id; return res.id; }
         } catch (e) {
           st.entity_failed++;
         }
@@ -1559,18 +1675,19 @@ agents:
 
       // mirrorEntity writes the subject node, the fact node and the edge between
       // them. Called after the k/v write has already succeeded.
-      function mirrorEntity(st, key, fact) {
+      function mirrorEntity(st, key, fact, scope) {
         if (!fact.type || !fact.subject) { return; } // untyped fact: k/v only (by design)
+        scope = scope || CONFIG.scope;
         // A statement class is not an entity type. Counted rather than silently
         // skipped: a pass that mirrored nothing because every type was rejected
         // must not look like a pass with nothing to mirror.
         if (ENTITY_TYPE_DENY[fact.type] === true) { st.entity_type_refused++; return; }
-        var docID = entitiesDoc(st);
+        var docID = entitiesDoc(st, scope);
         if (!docID) { return; }
 
         var subjKey = entityKey(fact.type, fact.subject);
-        var isNewSubject = !st.entity_ids[subjKey];
-        var subjID = upsertEntityChunk(st, docID, subjKey, {
+        var isNewSubject = !st.entity_ids[scope + "\u0000" + subjKey];
+        var subjID = upsertEntityChunk(st, scope, docID, subjKey, {
           title: fact.subject, type: fact.type, subject: fact.subject
         });
         if (!subjID) { return; }
@@ -1586,7 +1703,7 @@ agents:
         // claim — there is nothing about "Denn" for a quote to support, and attaching
         // one there would make the evidence look like it backed the wrong thing.
         if (fact.quote) { factArgs.source_quote = fact.quote; }
-        var factID = upsertEntityChunk(st, docID, key, factArgs);
+        var factID = upsertEntityChunk(st, scope, docID, key, factArgs);
         if (!factID) { return; }
         st.entity_facts++;
 
@@ -1953,7 +2070,9 @@ agents:
       function retireEntity(st, retiredKey) {
         var keeperKey = st.supersede_keeper[retiredKey];
         if (!keeperKey) { return; }
-        var docID = entitiesDoc(st);
+        // CONFIG.scope explicitly: duplicate collapse is a within-scope operation, and
+        // both the retired row and its survivor are in the scope this pass owns.
+        var docID = entitiesDoc(st, CONFIG.scope);
         if (!docID) { return; }
         var oldID = entityIDByKey(st, retiredKey), newID = entityIDByKey(st, keeperKey);
         if (!oldID || !newID) { return; } // neither was ever mirrored — nothing to retire
@@ -1974,7 +2093,10 @@ agents:
       // [a-z0-9:-] by construction, so no quote can occur. Do not extend this to a
       // key from anywhere else.
       function entityIDByKey(st, naturalKey) {
-        if (st.entity_ids[naturalKey]) { return st.entity_ids[naturalKey]; }
+        // CONFIG.scope's memo, because that is the scope this queries. The memo is keyed
+        // by scope since placement made the same natural key exist in more than one.
+        var memo = CONFIG.scope + "\u0000" + naturalKey;
+        if (st.entity_ids[memo]) { return st.entity_ids[memo]; }
         if (!/^[a-z0-9:_/-]+$/.test(naturalKey)) { return ""; }
         try {
           var res = JSON.parse(Document({
@@ -1982,8 +2104,8 @@ agents:
             sql: "SELECT chunk_id FROM chunk_memory_meta WHERE natural_key = '" + naturalKey + "'"
           }));
           if (res && res.rows && res.rows.length && res.rows[0].length) {
-            st.entity_ids[naturalKey] = String(res.rows[0][0]);
-            return st.entity_ids[naturalKey];
+            st.entity_ids[memo] = String(res.rows[0][0]);
+            return st.entity_ids[memo];
           }
         } catch (e) {
           st.entity_failed++;
@@ -2097,6 +2219,26 @@ agents:
         parts.push("facts written " + st.written);
         parts.push("updated in place " + st.updated);
         parts.push("retired " + st.superseded);
+        // PLACEMENT is silent when nothing is declared, which is the default and the
+        // common case — a line saying "placed 0" on every pass of every deployment that
+        // has no declarations would be noise. When it DOES fire the operator needs to see
+        // it: these rows left this user's scope for a plane everyone reads.
+        if (st.placed > 0) {
+          parts.push("placed in a declared scope " + st.placed);
+        }
+        if (st.placement_displaced > 0) {
+          parts.push("stale same-key twins retired after placement " + st.placement_displaced);
+        }
+        if (st.placement_displace_failed > 0) {
+          parts.push("twins that could NOT be retired " + st.placement_displace_failed +
+            " (the fact is stored in its declared scope; a duplicate remains here)");
+        }
+        // Said out loud rather than swallowed: the pass stored everything in this scope,
+        // which is correct behaviour but NOT the behaviour a declaring operator expects.
+        if (st.placement_error) {
+          parts.push("scope placement unavailable (" + st.placement_error +
+            ") — everything stayed in " + CONFIG.scope + " scope");
+        }
         if (st.supersede_capped > 0) {
           parts.push("retirement capped at " + CONFIG.max_supersedes + " (" + st.supersede_capped + " left for the next pass)");
         }

--- a/cmd/loomcycle/presets_memory_codejs_test.go
+++ b/cmd/loomcycle/presets_memory_codejs_test.go
@@ -50,6 +50,13 @@ type recordedCall struct {
 type fakeToolset struct {
 	calls []recordedCall
 
+	// placements maps "type\x00subject" -> the scope the server says that fact belongs
+	// in. Empty (the default, and the real default) means the ontology declares nothing
+	// and every fact stays in the caller's scope. placementFails makes the op error, which
+	// is what a deployment without SQL Memory or with an unreadable ontology looks like.
+	placements     map[string]string
+	placementFails bool
+
 	// The entity half, filled by fakeDocument.
 	entitiesDocID string
 	chunks        map[string]string // natural_key -> chunk id
@@ -226,6 +233,30 @@ func (m *fakeMemory) Execute(_ context.Context, raw json.RawMessage) (tools.Resu
 			m.f.vectors[key] = embed
 		}
 		return okResult(map[string]any{"ok": true})
+	case "placement":
+		if m.f.placementFails {
+			return tools.Result{IsError: true, Text: "placement: SQL Memory is not enabled"}, nil
+		}
+		items, _ := in["items"].([]any)
+		caller, _ := in["scope"].(string)
+		rows := make([]map[string]any, 0, len(items))
+		moved := 0
+		for _, it := range items {
+			m2, _ := it.(map[string]any)
+			typ, _ := m2["type"].(string)
+			subj, _ := m2["subject"].(string)
+			target := caller
+			if got, ok := m.f.placements[typ+"\x00"+subj]; ok {
+				target = got
+			}
+			row := map[string]any{"type": typ, "subject": subj, "scope": target,
+				"moved": target != caller, "reason": "test"}
+			if target != caller {
+				moved++
+			}
+			rows = append(rows, row)
+		}
+		return okResult(map[string]any{"placements": rows, "moved": moved, "caller_scope": caller})
 	case "supersede", "pending_ack", "cursor_advance", "cursor_release":
 		return okResult(map[string]any{"ok": true})
 	}
@@ -4198,5 +4229,194 @@ func TestConsolidator_BadIntervalIsStrippedButTheFactSurvives(t *testing.T) {
 				t.Errorf("a %s interval reached the store via invalid_at", tc.name)
 			}
 		})
+	}
+}
+
+// ---- ontology-declared scope placement -------------------------------------
+
+// callsWithOp returns every recorded call matching "Tool.op".
+func callsWithOp(f *fakeToolset, want string) []recordedCall {
+	var out []recordedCall
+	seq := f.ops()
+	for i := range seq {
+		if seq[i] == want {
+			out = append(out, f.calls[i])
+		}
+	}
+	return out
+}
+
+func placementFixtureToolset(fact string) *fakeToolset {
+	f := newFakeToolset()
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	f.transcript = "user: the checkout api needs two approvals\nassistant: noted"
+	f.factsJSON = `[{"text":"` + fact + `","class":"fact","type":"service","subject":"checkout-api"}]`
+	return f
+}
+
+// TestConsolidator_PlacementRoutesBOTHHALVESToTheDeclaredScope is the property the whole
+// one-decision design exists for.
+//
+// A fact is stored twice: the k/v row semantic recall searches, and a chunk mirror the
+// graph walks. If those land in different scopes the fact is findable by recall in one
+// place and by graph_recall in another, which is worse than never moving it. So the
+// assertion is not "the row moved" but "everything about this fact moved together".
+func TestConsolidator_PlacementRoutesBOTHHALVESToTheDeclaredScope(t *testing.T) {
+	const fact = "The checkout-api service requires two approvals to release."
+	f := placementFixtureToolset(fact)
+	f.placements = map[string]string{"service\x00checkout-api": "tenant"}
+
+	runConsolidator(t, f)
+
+	set := lastCall(t, f, "Memory.set")
+	if got, _ := set.Input["scope"].(string); got != "tenant" {
+		t.Errorf("the fact row went to %q, want tenant", got)
+	}
+	// Provenance says it was moved. source_session_id alone does not, and an operator
+	// looking at a row in the shared plane has to be able to answer "why is this here".
+	prov, _ := set.Input["provenance"].(map[string]any)
+	if from, _ := prov["promoted_from"].(string); from != "user" {
+		t.Errorf("provenance.promoted_from = %q, want user: %v", from, prov)
+	}
+
+	upserts := callsWithOp(f, "Document.upsert_chunk")
+	if len(upserts) == 0 {
+		t.Fatal("the fact was typed, so it must have been mirrored into the graph")
+	}
+	for _, c := range upserts {
+		if got, _ := c.Input["scope"].(string); got != "tenant" {
+			t.Errorf("a chunk went to %q while the row went to tenant — the two halves of "+
+				"one fact split across scopes: %v", got, c.Input)
+		}
+	}
+	// The entity document itself must be the TARGET scope's, not the caller's.
+	for _, c := range callsWithOp(f, "Document.get_document") {
+		if p, _ := c.Input["path"].(string); p == "/memory/entities" {
+			if got, _ := c.Input["scope"].(string); got != "tenant" {
+				t.Errorf("resolved the entities document in %q, want tenant", got)
+			}
+		}
+	}
+}
+
+// The default has to be inert: a deployment whose ontology declares nothing must behave
+// exactly as it did before placement existed.
+func TestConsolidator_NoDeclarationLeavesEveryFactInTheCallersScope(t *testing.T) {
+	f := placementFixtureToolset("The checkout-api service requires two approvals to release.")
+	// No placements configured — the server answers "stay" for everything.
+
+	runConsolidator(t, f)
+
+	for _, name := range []string{"Memory.set", "Document.upsert_chunk"} {
+		for _, c := range callsWithOp(f, name) {
+			if got, _ := c.Input["scope"].(string); got != "user" {
+				t.Errorf("%s went to %q with nothing declared, want user: %v", name, got, c.Input)
+			}
+		}
+	}
+	set := lastCall(t, f, "Memory.set")
+	prov, _ := set.Input["provenance"].(map[string]any)
+	if _, ok := prov["promoted_from"]; ok {
+		t.Errorf("an unplaced fact must not claim it was promoted: %v", prov)
+	}
+}
+
+// TestConsolidator_PlacementIsAskedOncePerPass: the op is a batch for a reason. Asking per
+// fact would put a tool call in front of every write.
+func TestConsolidator_PlacementIsAskedOncePerPass(t *testing.T) {
+	f := newFakeToolset()
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	f.transcript = "user: several things\nassistant: ok"
+	f.factsJSON = `[
+		{"text":"The checkout-api service requires two approvals.","class":"fact","type":"service","subject":"checkout-api"},
+		{"text":"The ledger service is owned by the payments team.","class":"fact","type":"service","subject":"ledger"},
+		{"text":"The checkout-api service runs in eu-west-1.","class":"fact","type":"service","subject":"checkout-api"},
+		{"text":"Denn prefers Go.","class":"preference"}
+	]`
+	f.placements = map[string]string{"service\x00checkout-api": "tenant"}
+
+	runConsolidator(t, f)
+
+	if n := len(callsWithOp(f, "Memory.placement")); n != 1 {
+		t.Errorf("asked for placement %d times, want exactly 1 per pass", n)
+	}
+	// The untyped fact has nothing to route on and must not have been asked about.
+	call := lastCall(t, f, "Memory.placement")
+	items, _ := call.Input["items"].([]any)
+	if len(items) != 2 {
+		t.Errorf("asked about %d items, want the 2 DISTINCT typed subjects: %v", len(items), items)
+	}
+}
+
+// A placement failure must cost nothing. Everything stays in the caller's scope — which is
+// what the system did before this feature — and the report says so rather than leaving an
+// operator who declared a scope wondering why nothing moved.
+func TestConsolidator_PlacementFailureKeepsEverythingInTheCallersScopeAndSaysSo(t *testing.T) {
+	f := placementFixtureToolset("The checkout-api service requires two approvals to release.")
+	f.placements = map[string]string{"service\x00checkout-api": "tenant"}
+	f.placementFails = true
+
+	res := runConsolidator(t, f)
+
+	for _, c := range callsWithOp(f, "Memory.set") {
+		if got, _ := c.Input["scope"].(string); got != "user" {
+			t.Errorf("a write went to %q after placement failed, want the caller's own user scope", got)
+		}
+	}
+	if !strings.Contains(res.FinalText, "placement unavailable") {
+		t.Errorf("the report must name the failure, got: %s", res.FinalText)
+	}
+	// The call must have been ATTEMPTED. Without this the test passes when the pass
+	// never asks at all — which is how a client-side typo in the call form (Memory is
+	// namespaced by op, not called with one) looked exactly like a server refusal.
+	if n := len(callsWithOp(f, "Memory.placement")); n != 1 {
+		t.Errorf("placement was attempted %d times, want 1 — a report that names a failure "+
+			"nobody asked for is not evidence of anything", n)
+	}
+	// And the pass still stored the fact — a placement fault is not a fact lost.
+	if len(callsWithOp(f, "Memory.set")) == 0 {
+		t.Error("no fact was written at all")
+	}
+}
+
+// TestConsolidator_DisplacedTwinIsRetiredInTheOldScope is supersede-with-pointer.
+//
+// A fact that already lived in the caller's scope, whose type the operator has since
+// declared shared, is rewritten into the declared scope. Leaving the old row live would
+// mean the same fact readable in two places with two places to correct it — the exact
+// duplication this feature removes. The old row is retired (a soft archive, so the audit
+// trail survives), and the pointer is exact without a new column: same key, target scope,
+// plus promoted_from on the new row.
+func TestConsolidator_DisplacedTwinIsRetiredInTheOldScope(t *testing.T) {
+	const fact = "The checkout-api service requires two approvals to release."
+	f := placementFixtureToolset(fact)
+	f.placements = map[string]string{"service\x00checkout-api": "tenant"}
+	// An existing row for this same fact, well inside the merge band, so the pass
+	// rewrites it in place under ITS key rather than writing a new one.
+	f.recallFacts = []map[string]any{{
+		"id":     "memory/fact/checkout-api-two-approvals",
+		"memory": fact,
+		"score":  0.99,
+	}}
+
+	runConsolidator(t, f)
+
+	set := lastCall(t, f, "Memory.set")
+	if got, _ := set.Input["scope"].(string); got != "tenant" {
+		t.Fatalf("precondition: the rewrite should have gone to tenant, got %q", got)
+	}
+	key, _ := set.Input["key"].(string)
+
+	var found bool
+	for _, c := range callsWithOp(f, "Memory.supersede") {
+		sc, _ := c.Input["scope"].(string)
+		k, _ := c.Input["key"].(string)
+		if sc == "user" && k == key {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("the stale twin at key %q was not retired in the user scope; calls: %v",
+			key, f.ops())
 	}
 }

--- a/internal/memory/templates/ontology.md
+++ b/internal/memory/templates/ontology.md
@@ -27,6 +27,32 @@ top-level. You may nest your types *under* them, but nesting them under one of
 yours is ignored. Names work best lowercase, as `a-z0-9-_` — a name with spaces
 still works, it just reads as prose inside a prompt.
 
+### Where a type's facts are stored
+
+A type may declare which memory scope facts about that kind of thing belong in:
+
+    ## service
+    - `@memory_scope` tenant
+    - `name` — what people call it
+
+`tenant` means facts about a service are written to the plane **every user in this
+tenant reads**, instead of into the scope of whoever happened to mention it. `user`
+means they stay with the person. Declaring nothing — the default, and what every type
+below does — leaves facts exactly where they are written today.
+
+A subtype inherits the declaration, so `organization → tenant` is written once.
+
+Three things it will NOT do, so you can declare one safely:
+
+- It never places a fact about **you**. Add your names to the Identity section of your
+  own profile document and facts about you stay yours whatever their type says.
+- It never places a fact whose subject is typed **inconsistently** — one thing recorded
+  as two different types is a thing the store cannot identify, and it is left alone
+  with a note rather than filed under a guess.
+- It does nothing at all until the agent that writes memory is granted the scope, on
+  **both** `memory_scopes` and `sql_scopes`. Declaring a scope is not the same as
+  opening one.
+
 ## project
 
 A body of work with a lifecycle of its own. Worth its own type when memory


### PR DESCRIPTION
The last piece of RFC CQ. Until now **nothing consulted the placement op**, so the whole
subsystem was inert. Independent of #1107 (both branch off main); land either order.

## What

The consolidator asks once per pass which scope each typed fact belongs in, and writes it
there.

**One call for the batch, and that is the design rather than an optimization.** A fact is
stored twice — the k/v row `recall` searches and the chunk mirror the graph walks — and both
halves must land in the **same** scope, or `recall` finds the fact in one place and
`graph_recall` in another, which is worse than never moving it. Deciding once, before either
write, is what guarantees it; deciding at each write site would be two decisions agreeing by
luck.

Only typed facts are asked about, and the alignment is load-bearing: the ontology routes by
the subject's entity type, so an untyped fact has nothing to route on — and it is also
exactly the set that gets no mirror. **A placed fact therefore always has a mirror, so the
halves always move together.**

## Supersede-with-pointer

When an operator declares a type shared *after* the fact, the rewrite goes to the declared
scope and the stale twin is retired in the old one — otherwise the same fact is readable in
two places with two places to correct it, the duplication this feature exists to remove.

The pointer needs no new column: the row is rewritten under the **same key**, so the live
copy is (that key, the target scope), and the new row's provenance carries `promoted_from`.
Retirement is a soft archive, so the audit trail survives.

Deliberately not routed through `supersede_queue` — that cap exists to stop a steered
"everything you know is obsolete" driving an unbounded sweep, and this is driven by the
operator's ontology, not by anything in a transcript.

## The entity half needed more than a scope swap

`/memory/entities` is a path **within** a scope, so a placed fact's graph belongs to the
target scope's own document. `entitiesDoc` and the chunk-id memo are now per scope; a
scope-blind memo would hand back a user-scope chunk id for a tenant write and attach the edge
to the wrong document.

## Still inert by default

Nothing is declared out of the box, the consolidator's grants are untouched, and a deployment
that edits nothing behaves exactly as before. The report stays silent unless something was
actually placed — and says so loudly when placement was **unavailable**, because "everything
stayed in user scope" is correct behaviour and *not* what an operator who declared a scope
expects.

The operator template now documents the directive, since it finally does something —
including the three things it will not do: never place a fact about you, never place an
inconsistently typed subject, and nothing at all until the writer is granted the scope on
both `memory_scopes` and `sql_scopes`.

## Two bugs the tests found, both silent, both the same shape

A mistake in the calling convention is **indistinguishable from the server refusing**:

- `Memory` is a **meta-tool**, namespaced by op. `Memory({op:"placement"})` throws before any
  call is made.
- A meta-tool's result arrives **already parsed**; only `Document` and `History` return a
  string to `JSON.parse`. Wrapping this one stringified the object.

Either produced "everything stayed in user scope" plus a plausible error in the report — a
feature that looks switched off. The failure-path test now asserts the call was **attempted**,
so it can no longer pass while the pass never asks.

## What was tested

Five tests in `presets_memory_codejs_test.go`, driving the shipped code-js body:

1. Both halves to the declared scope, including the entity *document* and `promoted_from`.
2. The default leaves everything alone and claims no promotion.
3. Exactly one call per pass, asking only about distinct typed subjects.
4. A failure keeps every write local, reports it, and still stores the fact.
5. The displaced twin is retired in the old scope, under the same key.

The fake toolset gained a placement knob — it previously **errored** on the op, which is why
every existing test silently took the failure path.

**Fail-before verified:** pinning `write()` back to `CONFIG.scope` fails (1) on the row, both
chunks, and the entity document. `go test ./...` clean, exit 0. `LOOMCYCLE_PRESETS=base,memory
loomcycle agents list` loads clean.

## Note

The wiring commit briefly landed on #1107's branch and was pushed; I moved it here and
force-pushed that branch back to its single intended commit. #1107 is unchanged in content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8