### PR TITLE
feat(bench): longhorizon — RFC CS context-retention benchmark (P1)

### DIFF
--- a/bench/cmd/longhorizon/README.md
+++ b/bench/cmd/longhorizon/README.md
@@ -1,0 +1,71 @@
+# longhorizon — RFC CS long-horizon benchmark (P1)
+
+Measures the RFC CR context-retention regimes on a synthetic, horizon-scalable,
+oracle-graded task, to decide (measure-first) whether RFC CR is worth building into
+the loop. It drives the model **through loomcycle's OpenAI-compatible gateway**
+(`POST /v1/chat/completions`), so every arm shares the same provider routing and the
+RFC AV cost ledger; token counts are provider-reported `usage`.
+
+## The arms (RFC CR regimes, as harness-side context assemblers)
+
+| Arm | Regime | Per-step context | Cost |
+|-----|--------|------------------|------|
+| **A0** | append (today) | system + **full growing history** + step | O(T²) |
+| **A1** | recap (RFC CR L1) | system + a **model-maintained running recap** + last-N verbatim + step | O(T) |
+| **A2** | stateful (RFC CR L2 / SKILL.state) | system + an **explicit JSON state** the model patches; no history | O(T) |
+
+These are faithful stand-ins for what the loomcycle loop would do server-side — the
+point is to measure the *idea* before changing the loop.
+
+## The task
+
+A deterministic **counter-tracking** stream: T instructions (`SET`/`ADD`/`SUB`/`RESET`),
+optional distractor `NOTE` lines (`-noise`) and one external `CORRECTION` (`-drift`),
+followed by queries (`GET` a counter, `SUM`, `MAX`) graded against an oracle. It is
+state-tracking with light arithmetic — losing an early mutation gives a wrong answer,
+which is exactly what separates the arms at long horizons.
+
+> ⚠️ **RFC CS Q3.** This task is *maximally schema-able*, so it likely **overstates the
+> A2 win**. It is the clean-curve instrument (cost-vs-horizon, the local A0-vs-A1
+> gate). The go/no-go weights the controlled **marketing-research team run** (RFC CS
+> P2) higher — that is the reality check.
+
+## Run
+
+Needs a running loomcycle with the OpenAI-compat gateway enabled and a routable model.
+
+```sh
+go run ./bench/cmd/longhorizon \
+  -base http://127.0.0.1:8787 -bearer "$LOOMCYCLE_AUTH_TOKEN" \
+  -model claude-frontier -arm all -horizon 100 -keys 5 -seeds 3 -out results.jsonl
+```
+
+Key flags: `-arm A0|A1|A2|all`, `-horizon T`, `-keys N`, `-seed`/`-seeds`,
+`-noise <pct>`, `-drift`, `-keep-last-n` (A1 window), `-out <jsonl>`.
+
+Output is a per-arm table averaged over seeds:
+
+```
+longhorizon  T=100  (avg over seeds)
+arm            total_tok  peak_prompt   accuracy    steps   recaps       ms
+A0-append         ...          ...        ...        100        0      ...
+A1-recap          ...          ...        ...        100       ..      ...
+A2-stateful       ...          ...        ...        100        0      ...
+```
+
+`peak_prompt` is the O(T)-flatness witness: A0 grows with T, A1/A2 stay roughly flat.
+
+## The decision gate (RFC CS)
+
+- **Local model:** A0 vs **A1** — greenlight L1 if A1 cuts cumulative tokens ≥ ~30% at
+  the target horizon with accuracy within noise of A0.
+- **Frontier model:** A0 vs **A2** (+ budget-matched controls, a later addition) —
+  greenlight L2 if A2 beats A0 and the controls at equal-or-lower cost.
+
+## Status / next
+
+P1 is the synthetic instrument + A0/A1/A2. Not yet included (RFC CS later phases):
+budget-matched controls (sliding-window, prose-summary), the noise/drift robustness
+sweeps as first-class report rows, and the marketing-research team-run workload (P2).
+A2 currently drops an unparseable patch (a no-op); the RFC CR rollback-retry is a
+follow-up.

--- a/bench/cmd/longhorizon/main.go
+++ b/bench/cmd/longhorizon/main.go
@@ -27,7 +27,8 @@ func main() {
 	var (
 		base      = flag.String("base", "http://127.0.0.1:8787", "loomcycle base URL (OpenAI-compat gateway)")
 		bearer    = flag.String("bearer", os.Getenv("LONGHORIZON_BEARER"), "bearer token (default $LONGHORIZON_BEARER)")
-		model     = flag.String("model", "", "model / alias to route to (required)")
+		model     = flag.String("model", "", "model to route to, e.g. qwen3.8:latest or claude-sonnet-4-6 (required)")
+		provider  = flag.String("provider", "", "loomcycle_provider to pin, e.g. ollama-local (empty = let the gateway resolve by model)")
 		arm       = flag.String("arm", "all", "A0 | A1 | A2 | all")
 		horizon   = flag.Int("horizon", 50, "number of instructions T")
 		keys      = flag.Int("keys", 5, "number of counters")
@@ -53,7 +54,7 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
-	client := NewModelClient(*base, *bearer, *model, *timeout)
+	client := NewModelClient(*base, *bearer, *model, *provider, *timeout)
 
 	var results []RunResult
 	for _, a := range arms {

--- a/bench/cmd/longhorizon/main.go
+++ b/bench/cmd/longhorizon/main.go
@@ -1,0 +1,140 @@
+// Command longhorizon is the RFC CS long-horizon benchmark harness (P1).
+//
+// It measures the RFC CR retention regimes — A0 append (today), A1 recap, A2
+// structured state — on a synthetic, horizon-scalable, oracle-graded counter task,
+// driving the model through loomcycle's OpenAI-compatible gateway so every arm
+// shares provider routing and the RFC AV cost ledger. It reports cumulative tokens
+// (the O(T^2) vs O(T) curve), peak single-prompt size, and task accuracy.
+//
+// The synthetic task is the CLEAN-CURVE instrument and is maximally schema-able, so
+// it likely OVERSTATES the A2 win (RFC CS Q3). The go/no-go weights the controlled
+// marketing-research team run (P2) higher; this harness produces the cost curves and
+// the first A0-vs-A1 (local gate) / A0-vs-A2 (frontier gate) signal.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"time"
+)
+
+func main() {
+	var (
+		base      = flag.String("base", "http://127.0.0.1:8787", "loomcycle base URL (OpenAI-compat gateway)")
+		bearer    = flag.String("bearer", os.Getenv("LONGHORIZON_BEARER"), "bearer token (default $LONGHORIZON_BEARER)")
+		model     = flag.String("model", "", "model / alias to route to (required)")
+		arm       = flag.String("arm", "all", "A0 | A1 | A2 | all")
+		horizon   = flag.Int("horizon", 50, "number of instructions T")
+		keys      = flag.Int("keys", 5, "number of counters")
+		seed      = flag.Int64("seed", 1, "base RNG seed")
+		seeds     = flag.Int("seeds", 1, "number of consecutive seeds to run + average")
+		noisePct  = flag.Int("noise", 0, "percent of steps that are distractor NOTE lines (0..100)")
+		drift     = flag.Bool("drift", false, "inject one external CORRECTION at the midpoint")
+		keepLastN = flag.Int("keep-last-n", 6, "A1 verbatim window (steps)")
+		timeout   = flag.Duration("timeout", 120*time.Second, "per-call HTTP timeout")
+		out       = flag.String("out", "", "append JSONL results to this file")
+	)
+	flag.Parse()
+
+	if *model == "" {
+		fmt.Fprintln(os.Stderr, "longhorizon: -model is required")
+		os.Exit(2)
+	}
+	arms := []string{"A0", "A1", "A2"}
+	if *arm != "all" {
+		arms = []string{strings.ToUpper(*arm)}
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	client := NewModelClient(*base, *bearer, *model, *timeout)
+
+	var results []RunResult
+	for _, a := range arms {
+		for i := 0; i < *seeds; i++ {
+			s := *seed + int64(i)
+			task := GenerateTask(s, *horizon, *keys, float64(*noisePct)/100, *drift)
+			strat := newStrategy(a, task, *keepLastN)
+			if strat == nil {
+				fmt.Fprintf(os.Stderr, "unknown arm %q\n", a)
+				os.Exit(2)
+			}
+			r := RunOnce(ctx, strat, task, client)
+			r.NoisePct = *noisePct
+			r.Drift = *drift
+			results = append(results, r)
+			if r.Err != "" {
+				fmt.Fprintf(os.Stderr, "%s seed=%d: ERROR %s\n", a, s, r.Err)
+			}
+			if ctx.Err() != nil {
+				break
+			}
+		}
+	}
+
+	if *out != "" {
+		if err := appendJSONL(*out, results); err != nil {
+			fmt.Fprintf(os.Stderr, "write %s: %v\n", *out, err)
+		}
+	}
+	printSummary(results, *horizon)
+}
+
+func appendJSONL(path string, rs []RunResult) error {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	for _, r := range rs {
+		if err := enc.Encode(r); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// printSummary aggregates results by arm (averaging across seeds) into a table.
+func printSummary(rs []RunResult, horizon int) {
+	type agg struct {
+		n                     int
+		totalTok, peakTok     int
+		acc                   float64
+		stepCalls, recapCalls int
+		elapsed               int64
+	}
+	order := []string{}
+	m := map[string]*agg{}
+	for _, r := range rs {
+		a, ok := m[r.Arm]
+		if !ok {
+			a = &agg{}
+			m[r.Arm] = a
+			order = append(order, r.Arm)
+		}
+		a.n++
+		a.totalTok += r.TotalTokens
+		a.peakTok += r.PeakPromptTokens
+		a.acc += r.Accuracy
+		a.stepCalls += r.StepCalls
+		a.recapCalls += r.RecapCalls
+		a.elapsed += r.ElapsedMs
+	}
+	fmt.Printf("\nlonghorizon  T=%d  (avg over seeds)\n", horizon)
+	fmt.Printf("%-12s %12s %12s %10s %8s %8s %8s\n",
+		"arm", "total_tok", "peak_prompt", "accuracy", "steps", "recaps", "ms")
+	for _, name := range order {
+		a := m[name]
+		n := float64(a.n)
+		fmt.Printf("%-12s %12d %12d %9.3f %8d %8d %8d\n",
+			name, a.totalTok/a.n, a.peakTok/a.n, a.acc/n,
+			a.stepCalls/a.n, a.recapCalls/a.n, a.elapsed/int64(a.n))
+	}
+}

--- a/bench/cmd/longhorizon/model.go
+++ b/bench/cmd/longhorizon/model.go
@@ -16,19 +16,21 @@ import (
 // block (provider-reported), which is the truth this benchmark measures.
 
 type ModelClient struct {
-	base   string
-	bearer string
-	model  string
-	httpc  *http.Client
+	base     string
+	bearer   string
+	model    string
+	provider string // loomcycle_provider extension: pins the provider (e.g. ollama-local)
+	httpc    *http.Client
 }
 
-func NewModelClient(base, bearer, model string, timeout time.Duration) *ModelClient {
-	return &ModelClient{base: base, bearer: bearer, model: model,
+func NewModelClient(base, bearer, model, provider string, timeout time.Duration) *ModelClient {
+	return &ModelClient{base: base, bearer: bearer, model: model, provider: provider,
 		httpc: &http.Client{Timeout: timeout}}
 }
 
 type chatRequest struct {
 	Model       string    `json:"model"`
+	Provider    string    `json:"loomcycle_provider,omitempty"` // loomcycle gateway extension
 	Messages    []Message `json:"messages"`
 	Temperature float64   `json:"temperature"`
 }
@@ -53,7 +55,7 @@ type Usage struct {
 // Call sends one chat completion (temperature 0 for determinism) and returns the
 // content plus provider-reported token usage.
 func (c *ModelClient) Call(ctx context.Context, messages []Message) (string, Usage, error) {
-	body, _ := json.Marshal(chatRequest{Model: c.model, Messages: messages, Temperature: 0})
+	body, _ := json.Marshal(chatRequest{Model: c.model, Provider: c.provider, Messages: messages, Temperature: 0})
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.base+"/v1/chat/completions", bytes.NewReader(body))
 	if err != nil {
 		return "", Usage{}, err
@@ -78,8 +80,21 @@ func (c *ModelClient) Call(ctx context.Context, messages []Message) (string, Usa
 	if len(out.Choices) == 0 {
 		return "", Usage{}, fmt.Errorf("no choices in response")
 	}
-	return out.Choices[0].Message.Content,
-		Usage{Prompt: out.Usage.PromptTokens, Completion: out.Usage.CompletionTokens}, nil
+	content := out.Choices[0].Message.Content
+	u := Usage{Prompt: out.Usage.PromptTokens, Completion: out.Usage.CompletionTokens}
+	// Some providers (e.g. Ollama via loomcycle's OpenAI-compat shim) do not surface
+	// token usage. Fall back to a ~4-chars-per-token ESTIMATE of the assembled
+	// context + reply. This measures context SIZE directly — which is exactly the
+	// O(T^2)-vs-O(T) quantity this benchmark compares — and is deterministic; the
+	// arms are compared on the same estimator, so the relative curve is unaffected.
+	if u.Prompt == 0 && u.Completion == 0 {
+		promptChars := 0
+		for _, m := range messages {
+			promptChars += len(m.Content)
+		}
+		u = Usage{Prompt: (promptChars + 3) / 4, Completion: (len(content) + 3) / 4}
+	}
+	return content, u, nil
 }
 
 func truncate(s string, n int) string {

--- a/bench/cmd/longhorizon/model.go
+++ b/bench/cmd/longhorizon/model.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// model.go — drives the model per step through loomcycle's OpenAI-compatible
+// gateway (POST /v1/chat/completions), so every arm rides the SAME provider
+// routing and the RFC AV cost ledger. Token counts come from the response `usage`
+// block (provider-reported), which is the truth this benchmark measures.
+
+type ModelClient struct {
+	base   string
+	bearer string
+	model  string
+	httpc  *http.Client
+}
+
+func NewModelClient(base, bearer, model string, timeout time.Duration) *ModelClient {
+	return &ModelClient{base: base, bearer: bearer, model: model,
+		httpc: &http.Client{Timeout: timeout}}
+}
+
+type chatRequest struct {
+	Model       string    `json:"model"`
+	Messages    []Message `json:"messages"`
+	Temperature float64   `json:"temperature"`
+}
+
+type chatResponse struct {
+	Choices []struct {
+		Message Message `json:"message"`
+	} `json:"choices"`
+	Usage struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+		TotalTokens      int `json:"total_tokens"`
+	} `json:"usage"`
+}
+
+// Usage is the per-call token accounting.
+type Usage struct {
+	Prompt     int
+	Completion int
+}
+
+// Call sends one chat completion (temperature 0 for determinism) and returns the
+// content plus provider-reported token usage.
+func (c *ModelClient) Call(ctx context.Context, messages []Message) (string, Usage, error) {
+	body, _ := json.Marshal(chatRequest{Model: c.model, Messages: messages, Temperature: 0})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.base+"/v1/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return "", Usage{}, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+c.bearer)
+	}
+	resp, err := c.httpc.Do(req)
+	if err != nil {
+		return "", Usage{}, err
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", Usage{}, fmt.Errorf("chat/completions: %d: %s", resp.StatusCode, truncate(string(raw), 300))
+	}
+	var out chatResponse
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return "", Usage{}, fmt.Errorf("decode: %w", err)
+	}
+	if len(out.Choices) == 0 {
+		return "", Usage{}, fmt.Errorf("no choices in response")
+	}
+	return out.Choices[0].Message.Content,
+		Usage{Prompt: out.Usage.PromptTokens, Completion: out.Usage.CompletionTokens}, nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/bench/cmd/longhorizon/parse.go
+++ b/bench/cmd/longhorizon/parse.go
@@ -1,0 +1,21 @@
+package main
+
+import "regexp"
+
+var (
+	intRe = regexp.MustCompile(`-?\d+`)
+	keyRe = regexp.MustCompile(`counter_\d+`)
+)
+
+// firstInt returns the first integer token in s (as its canonical string), or "".
+// Tolerates a model that answers "The value is 42." instead of "42", and — because
+// a model may echo the counter name — strips counter_NN tokens first so
+// "counter_01 = 42" grades as 42, not 01.
+func firstInt(s string) string {
+	return intRe.FindString(keyRe.ReplaceAllString(s, ""))
+}
+
+// firstKey returns the first counter_NN token in s, or "".
+func firstKey(s string) string {
+	return keyRe.FindString(s)
+}

--- a/bench/cmd/longhorizon/runner.go
+++ b/bench/cmd/longhorizon/runner.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"context"
+	"time"
+)
+
+// runner.go — drive one strategy through one task instance, accumulating the
+// benchmark's primary metrics: cumulative tokens (the O(T^2) vs O(T) curve), peak
+// single-prompt size (flatness), and task accuracy from the oracle.
+
+// RunResult is one (arm, model, task) measurement.
+type RunResult struct {
+	Arm      string `json:"arm"`
+	Model    string `json:"model"`
+	Horizon  int    `json:"horizon"`
+	Seed     int64  `json:"seed"`
+	NoisePct int    `json:"noise_pct"`
+	Drift    bool   `json:"drift"`
+
+	StepCalls  int `json:"step_calls"`
+	RecapCalls int `json:"recap_calls"`
+	QueryCalls int `json:"query_calls"`
+
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+	PeakPromptTokens int `json:"peak_prompt_tokens"` // O(T)-flatness witness
+
+	Queries  int     `json:"queries"`
+	Correct  int     `json:"correct"`
+	Accuracy float64 `json:"accuracy"`
+
+	ElapsedMs int64  `json:"elapsed_ms"`
+	Err       string `json:"error,omitempty"`
+}
+
+// RunOnce executes the task's instruction stream then its queries under strat,
+// driving the model through client. A model error aborts and is reported in-result.
+func RunOnce(ctx context.Context, strat Strategy, task Task, client *ModelClient) RunResult {
+	res := RunResult{
+		Arm: strat.Name(), Model: client.model, Horizon: task.Horizon, Seed: task.Seed,
+		Queries: len(task.Queries),
+	}
+	start := time.Now()
+
+	acc := func(u Usage) {
+		res.PromptTokens += u.Prompt
+		res.CompletionTokens += u.Completion
+		res.TotalTokens += u.Prompt + u.Completion
+		if u.Prompt > res.PeakPromptTokens {
+			res.PeakPromptTokens = u.Prompt
+		}
+	}
+
+	for _, insn := range task.Instructions {
+		resp, u, err := client.Call(ctx, strat.StepMessages(insn))
+		if err != nil {
+			res.Err = err.Error()
+			res.ElapsedMs = time.Since(start).Milliseconds()
+			return res
+		}
+		acc(u)
+		res.StepCalls++
+		strat.Observe(insn, resp)
+		if rm := strat.PendingRecap(); rm != nil {
+			recap, u2, err := client.Call(ctx, rm)
+			if err != nil {
+				res.Err = err.Error()
+				res.ElapsedMs = time.Since(start).Milliseconds()
+				return res
+			}
+			acc(u2)
+			res.RecapCalls++
+			strat.SetRecap(recap)
+		}
+	}
+
+	for _, q := range task.Queries {
+		ans, u, err := client.Call(ctx, strat.QueryMessages(q))
+		if err != nil {
+			res.Err = err.Error()
+			res.ElapsedMs = time.Since(start).Milliseconds()
+			return res
+		}
+		acc(u)
+		res.QueryCalls++
+		if q.Grade(ans) {
+			res.Correct++
+		}
+	}
+
+	if res.Queries > 0 {
+		res.Accuracy = float64(res.Correct) / float64(res.Queries)
+	}
+	res.ElapsedMs = time.Since(start).Milliseconds()
+	return res
+}
+
+// newStrategy builds the strategy for an arm.
+func newStrategy(arm string, task Task, keepLastN int) Strategy {
+	switch arm {
+	case "A0":
+		return NewA0()
+	case "A1":
+		return NewA1(keepLastN)
+	case "A2":
+		return NewA2(task.Keys)
+	}
+	return nil
+}

--- a/bench/cmd/longhorizon/strategy.go
+++ b/bench/cmd/longhorizon/strategy.go
@@ -1,0 +1,261 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// strategy.go — the three RFC CR retention regimes, as harness-side context
+// assemblers driven per step by the runner. Each is a faithful, loop-agnostic
+// stand-in for what the loomcycle loop would do server-side, so we can MEASURE the
+// idea (RFC CS) before building it into the loop (RFC CR):
+//
+//   A0 append   — full growing history (today's default; O(T^2) tokens)
+//   A1 recap    — immutable preamble + last-N verbatim + a MODEL-maintained running
+//                 recap of evicted steps (RFC CR L1; O(T) tokens)
+//   A2 stateful — immutable preamble + an explicit JSON state object the model
+//                 patches each step; no history (RFC CR L2 / SKILL.state; O(T) tokens)
+
+// Message is one chat message.
+type Message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// Strategy assembles the messages sent each step and records the model's response.
+type Strategy interface {
+	Name() string
+	// StepMessages builds the context to execute one instruction.
+	StepMessages(insn Instruction) []Message
+	// Observe records the model's response to the executed step.
+	Observe(insn Instruction, response string)
+	// PendingRecap returns messages for a model-driven recap call the runner should
+	// make (A1 only, when a step falls out of the window); nil otherwise.
+	PendingRecap() []Message
+	// SetRecap installs the recap the runner obtained from PendingRecap().
+	SetRecap(recap string)
+	// QueryMessages builds the context to answer a post-stream query.
+	QueryMessages(q Query) []Message
+}
+
+// taskRules is the immutable preamble P shared by every arm — the "skill spec".
+func taskRules() string {
+	return "You track a set of named integer counters as instructions arrive one at a time. " +
+		"Each instruction may SET a counter to a value, ADD to it, SUBTRACT from it, or RESET it to 0. " +
+		"A CORRECTION line overrides a counter's value regardless of prior steps. NOTE lines change nothing. " +
+		"Maintain the counters exactly. When later asked a question, answer from the current counter values only."
+}
+
+// stepUser renders the per-step user turn.
+func stepUser(insn Instruction) string {
+	return "Instruction: " + insn.Text + "\nAcknowledge in one short line."
+}
+
+// ── A0: full append-only history ────────────────────────────────────────────
+
+type A0 struct {
+	history []Message
+}
+
+func NewA0() *A0 { return &A0{} }
+
+func (s *A0) Name() string { return "A0-append" }
+
+func (s *A0) StepMessages(insn Instruction) []Message {
+	msgs := []Message{{Role: "system", Content: taskRules()}}
+	msgs = append(msgs, s.history...)
+	msgs = append(msgs, Message{Role: "user", Content: stepUser(insn)})
+	return msgs
+}
+
+func (s *A0) Observe(insn Instruction, response string) {
+	s.history = append(s.history,
+		Message{Role: "user", Content: stepUser(insn)},
+		Message{Role: "assistant", Content: response})
+}
+
+func (s *A0) PendingRecap() []Message { return nil }
+func (s *A0) SetRecap(string)         {}
+
+func (s *A0) QueryMessages(q Query) []Message {
+	msgs := []Message{{Role: "system", Content: taskRules()}}
+	msgs = append(msgs, s.history...)
+	msgs = append(msgs, Message{Role: "user", Content: q.QuestionText()})
+	return msgs
+}
+
+// ── A1: last-N window + model-maintained recap (RFC CR L1) ───────────────────
+
+type A1 struct {
+	keepLastN int
+	window    []Message // recent (user, assistant) pairs, capped at 2*keepLastN
+	recap     string    // running distillation of everything evicted
+	pending   []Message // a recap call the runner should make
+}
+
+func NewA1(keepLastN int) *A1 { return &A1{keepLastN: keepLastN} }
+
+func (s *A1) Name() string { return "A1-recap" }
+
+func (s *A1) preamble() []Message {
+	msgs := []Message{{Role: "system", Content: taskRules()}}
+	if s.recap != "" {
+		msgs = append(msgs, Message{Role: "system",
+			Content: "State recap so far (the net effect of all earlier instructions):\n" + s.recap})
+	}
+	return msgs
+}
+
+func (s *A1) StepMessages(insn Instruction) []Message {
+	msgs := s.preamble()
+	msgs = append(msgs, s.window...)
+	msgs = append(msgs, Message{Role: "user", Content: stepUser(insn)})
+	return msgs
+}
+
+func (s *A1) Observe(insn Instruction, response string) {
+	s.window = append(s.window,
+		Message{Role: "user", Content: stepUser(insn)},
+		Message{Role: "assistant", Content: response})
+	// Evict the oldest pair past the window into a pending recap call.
+	if len(s.window) > 2*s.keepLastN {
+		evicted := s.window[:2]
+		s.window = s.window[2:]
+		prior := s.recap
+		if prior == "" {
+			prior = "(none yet)"
+		}
+		s.pending = []Message{
+			{Role: "system", Content: "You maintain a short running recap of counter state. " +
+				"Given the prior recap and the steps now leaving the visible window, produce an updated recap " +
+				"that preserves every counter value implied so far. Be terse; output only the recap."},
+			{Role: "user", Content: fmt.Sprintf("Prior recap:\n%s\n\nSteps leaving the window:\n%s\n%s\n\nUpdated recap:",
+				prior, evicted[0].Content, evicted[1].Content)},
+		}
+	}
+}
+
+func (s *A1) PendingRecap() []Message {
+	p := s.pending
+	s.pending = nil
+	return p
+}
+
+func (s *A1) SetRecap(recap string) { s.recap = strings.TrimSpace(recap) }
+
+func (s *A1) QueryMessages(q Query) []Message {
+	msgs := s.preamble()
+	msgs = append(msgs, s.window...)
+	msgs = append(msgs, Message{Role: "user", Content: q.QuestionText()})
+	return msgs
+}
+
+// ── A2: explicit structured state, patched each step (RFC CR L2) ─────────────
+
+type A2 struct {
+	state map[string]int
+}
+
+// A2StateSchema is the static per-domain schema (SKILL.state): the counter map.
+const A2StateSchema = `{"type":"object","additionalProperties":{"type":"integer"}}`
+
+func NewA2(keys []string) *A2 {
+	st := map[string]int{}
+	for _, k := range keys {
+		st[k] = 0
+	}
+	return &A2{state: st}
+}
+
+func (s *A2) Name() string { return "A2-stateful" }
+
+func (s *A2) stateJSON() string {
+	// Deterministic key order so the prompt (and its hash) is stable.
+	keys := make([]string, 0, len(s.state))
+	for k := range s.state {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteByte('{')
+	for i, k := range keys {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		fmt.Fprintf(&b, "%q:%d", k, s.state[k])
+	}
+	b.WriteByte('}')
+	return b.String()
+}
+
+func (s *A2) preamble() []Message {
+	return []Message{{Role: "system", Content: taskRules() +
+		"\n\nYou are given the current counter STATE as a JSON object. After applying the instruction, " +
+		"reply with ONLY a JSON object patch of the counters that CHANGED (key -> new integer value); " +
+		"use null to delete a key. Reply with {} if nothing changed. No prose."}}
+}
+
+func (s *A2) StepMessages(insn Instruction) []Message {
+	msgs := s.preamble()
+	msgs = append(msgs,
+		Message{Role: "user", Content: "STATE: " + s.stateJSON() + "\nInstruction: " + insn.Text + "\nPatch:"})
+	return msgs
+}
+
+// Observe validates the patch against the schema and merges it (null-deletion). An
+// unparseable patch is dropped (the runner's rollback-retry is a future extension);
+// the merge is the runtime-owned operation, never the model's.
+func (s *A2) Observe(insn Instruction, response string) {
+	patch, ok := parsePatch(response)
+	if !ok {
+		return
+	}
+	for k, v := range patch {
+		if v == nil {
+			delete(s.state, k)
+			continue
+		}
+		if n, ok := asInt(v); ok {
+			s.state[k] = n
+		}
+	}
+}
+
+func (s *A2) PendingRecap() []Message { return nil }
+func (s *A2) SetRecap(string)         {}
+
+func (s *A2) QueryMessages(q Query) []Message {
+	msgs := []Message{{Role: "system", Content: taskRules() +
+		"\n\nThe current counter STATE is given as JSON. Answer the question from it."}}
+	msgs = append(msgs,
+		Message{Role: "user", Content: "STATE: " + s.stateJSON() + "\n" + q.QuestionText()})
+	return msgs
+}
+
+// parsePatch extracts the first JSON object from a model reply and decodes it as a
+// counter patch (values are integer or null).
+func parsePatch(s string) (map[string]any, bool) {
+	i := strings.IndexByte(s, '{')
+	j := strings.LastIndexByte(s, '}')
+	if i < 0 || j < i {
+		return nil, false
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(s[i:j+1]), &m); err != nil {
+		return nil, false
+	}
+	return m, true
+}
+
+// asInt coerces a JSON number (which decodes as float64) to an int.
+func asInt(v any) (int, bool) {
+	switch n := v.(type) {
+	case float64:
+		return int(n), true
+	case int:
+		return n, true
+	}
+	return 0, false
+}

--- a/bench/cmd/longhorizon/strategy_test.go
+++ b/bench/cmd/longhorizon/strategy_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestA0_HistoryGrows(t *testing.T) {
+	s := NewA0()
+	insn := Instruction{Op: OpSet, Key: "counter_00", Value: 3, Text: "SET counter_00 = 3."}
+	// Before any step: system + current user = 2 messages.
+	if got := len(s.StepMessages(insn)); got != 2 {
+		t.Fatalf("initial step messages = %d, want 2", got)
+	}
+	for i := 0; i < 5; i++ {
+		s.Observe(insn, "ok")
+	}
+	// After 5 steps: system + 5*(user,assistant) + current user = 1 + 10 + 1 = 12.
+	if got := len(s.StepMessages(insn)); got != 12 {
+		t.Errorf("step messages after 5 obs = %d, want 12 (history grows O(T))", got)
+	}
+	if s.PendingRecap() != nil {
+		t.Error("A0 must never request a recap")
+	}
+}
+
+func TestA1_WindowEvictsAndRecaps(t *testing.T) {
+	s := NewA1(2) // window cap = 2 pairs = 4 messages
+	insn := Instruction{Op: OpAdd, Key: "counter_01", Value: 1, Text: "ADD 1 to counter_01."}
+
+	s.Observe(insn, "ok") // 1 pair
+	s.Observe(insn, "ok") // 2 pairs (at cap)
+	if s.PendingRecap() != nil {
+		t.Fatal("recap fired before the window overflowed")
+	}
+	s.Observe(insn, "ok") // 3rd pair -> evict oldest -> recap pending
+	rm := s.PendingRecap()
+	if rm == nil {
+		t.Fatal("no recap requested after window overflow")
+	}
+	if len(s.window) != 4 {
+		t.Errorf("window not trimmed to 4 messages: got %d", len(s.window))
+	}
+	// PendingRecap is consumed (one-shot).
+	if s.PendingRecap() != nil {
+		t.Error("PendingRecap should return nil on the second read")
+	}
+	// Installing the recap surfaces it in the preamble.
+	s.SetRecap("counter_01 = 2")
+	msgs := s.StepMessages(insn)
+	if !strings.Contains(joinContents(msgs), "counter_01 = 2") {
+		t.Error("recap not injected into the step preamble")
+	}
+	if msgs[0].Role != "system" {
+		t.Error("preamble must start with the system task rules")
+	}
+}
+
+func TestA2_PatchMergeAndNullDeletion(t *testing.T) {
+	s := NewA2([]string{"counter_00", "counter_01"})
+	if got := s.stateJSON(); got != `{"counter_00":0,"counter_01":0}` {
+		t.Fatalf("initial stateJSON = %s", got)
+	}
+	// A prose-wrapped patch is still parsed; the merge is runtime-owned.
+	s.Observe(Instruction{}, "Here is the patch: {\"counter_00\": 7}")
+	if s.state["counter_00"] != 7 {
+		t.Errorf("patch not applied: %v", s.state)
+	}
+	// null deletes a key.
+	s.Observe(Instruction{}, `{"counter_01": null}`)
+	if _, ok := s.state["counter_01"]; ok {
+		t.Errorf("null did not delete the key: %v", s.state)
+	}
+	// An unparseable reply is a no-op (dropped, not corrupting state).
+	before := s.stateJSON()
+	s.Observe(Instruction{}, "I could not decide.")
+	if s.stateJSON() != before {
+		t.Errorf("unparseable patch mutated state: %s -> %s", before, s.stateJSON())
+	}
+	// stateJSON is deterministically ordered (stable prompt/hash).
+	if s.stateJSON() != `{"counter_00":7}` {
+		t.Errorf("stateJSON after ops = %s", s.stateJSON())
+	}
+	// The step prompt carries the STATE, not a history.
+	msgs := s.StepMessages(Instruction{Text: "ADD 1 to counter_00."})
+	if !strings.Contains(joinContents(msgs), `STATE: {"counter_00":7}`) {
+		t.Error("A2 step prompt missing the state object")
+	}
+}
+
+func TestParsePatch(t *testing.T) {
+	m, ok := parsePatch(`prefix {"a": 1, "b": null} suffix`)
+	if !ok || len(m) != 2 {
+		t.Fatalf("parsePatch failed: %v %v", m, ok)
+	}
+	if n, ok := asInt(m["a"]); !ok || n != 1 {
+		t.Errorf("asInt(a) = %d,%v", n, ok)
+	}
+	if m["b"] != nil {
+		t.Errorf("b should be nil, got %v", m["b"])
+	}
+	if _, ok := parsePatch("no json here"); ok {
+		t.Error("parsePatch should fail on non-JSON")
+	}
+}
+
+func joinContents(msgs []Message) string {
+	var b strings.Builder
+	for _, m := range msgs {
+		b.WriteString(m.Content)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}

--- a/bench/cmd/longhorizon/task.go
+++ b/bench/cmd/longhorizon/task.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"sort"
+	"strings"
+)
+
+// task.go — the synthetic horizon-scaling task for RFC CS P1.
+//
+// A deterministic COUNTER-TRACKING task: the agent is fed T instructions, one per
+// step, each mutating a small set of named counters (SET/ADD/SUB/RESET). After the
+// stream it must answer queries (GET a counter, SUM all, MAX key) from the final
+// state. It is state-tracking with light arithmetic — enough that a context
+// strategy which loses an early mutation gives a wrong answer, which is exactly
+// what separates full-history (A0), reasoning-recap (A1), and structured-state (A2)
+// at long horizons.
+//
+// Deterministic from a seed (reproducible), horizon-scalable (T), and gradable by
+// an oracle that computes ground truth directly. Optional NOISE (distractor lines)
+// and a DRIFT event (an external correction) exercise the two robustness axes RFC CS
+// names. NOTE (RFC CS Q3): this task is maximally schema-able, so it likely
+// OVERSTATES the A2 win — it is the clean-curve instrument; the marketing-research
+// team run (P2) is the reality check.
+
+// Op is a counter mutation.
+type Op int
+
+const (
+	OpSet Op = iota
+	OpAdd
+	OpSub
+	OpReset
+	OpNote       // a distractor line (noise); does not mutate state
+	OpCorrection // an external drift correction: sets a key to a value out-of-band
+)
+
+// Instruction is one step's observation.
+type Instruction struct {
+	Op    Op
+	Key   string
+	Value int
+	Text  string // the rendered natural-language line the agent sees
+}
+
+// Query is a post-stream question with a known answer.
+type Query struct {
+	Kind   string // "get" | "sum" | "max"
+	Key    string // for "get"
+	Answer string // ground-truth answer, canonicalised
+}
+
+// Task is a generated instance.
+type Task struct {
+	Seed         int64
+	Horizon      int
+	Keys         []string
+	Instructions []Instruction
+	Queries      []Query
+	FinalState   map[string]int // the oracle's ground-truth end state
+}
+
+// GenerateTask builds a deterministic instance. noiseRate in [0,1] is the fraction
+// of steps that are distractor NOTE lines; drift, when true, injects one CORRECTION
+// at ~the midpoint that changes a key out-of-band (the agent must honour it).
+func GenerateTask(seed int64, horizon, nKeys int, noiseRate float64, drift bool) Task {
+	r := rand.New(rand.NewSource(seed))
+	keys := make([]string, nKeys)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("counter_%02d", i)
+	}
+	state := map[string]int{}
+	for _, k := range keys {
+		state[k] = 0
+	}
+
+	driftAt := -1
+	if drift {
+		driftAt = horizon / 2
+	}
+
+	insns := make([]Instruction, 0, horizon)
+	for t := 0; t < horizon; t++ {
+		if t == driftAt {
+			k := keys[r.Intn(nKeys)]
+			v := r.Intn(100)
+			state[k] = v // out-of-band: overrides whatever the stream implied
+			insns = append(insns, Instruction{Op: OpCorrection, Key: k, Value: v,
+				Text: fmt.Sprintf("CORRECTION: regardless of prior steps, %s is now exactly %d.", k, v)})
+			continue
+		}
+		if noiseRate > 0 && r.Float64() < noiseRate {
+			insns = append(insns, Instruction{Op: OpNote,
+				Text: fmt.Sprintf("NOTE: shift %d completed a routine audit; no counter changes.", t)})
+			continue
+		}
+		k := keys[r.Intn(nKeys)]
+		switch r.Intn(4) {
+		case 0:
+			v := r.Intn(50)
+			state[k] = v
+			insns = append(insns, Instruction{Op: OpSet, Key: k, Value: v,
+				Text: fmt.Sprintf("SET %s = %d.", k, v)})
+		case 1:
+			v := 1 + r.Intn(20)
+			state[k] += v
+			insns = append(insns, Instruction{Op: OpAdd, Key: k, Value: v,
+				Text: fmt.Sprintf("ADD %d to %s.", v, k)})
+		case 2:
+			v := 1 + r.Intn(20)
+			state[k] -= v
+			insns = append(insns, Instruction{Op: OpSub, Key: k, Value: v,
+				Text: fmt.Sprintf("SUBTRACT %d from %s.", v, k)})
+		default:
+			state[k] = 0
+			insns = append(insns, Instruction{Op: OpReset, Key: k,
+				Text: fmt.Sprintf("RESET %s to 0.", k)})
+		}
+	}
+
+	// Queries: GET each key, plus SUM and MAX. Deterministic + fully covered.
+	queries := make([]Query, 0, nKeys+2)
+	for _, k := range keys {
+		queries = append(queries, Query{Kind: "get", Key: k, Answer: fmt.Sprintf("%d", state[k])})
+	}
+	sum := 0
+	for _, k := range keys {
+		sum += state[k]
+	}
+	queries = append(queries, Query{Kind: "sum", Answer: fmt.Sprintf("%d", sum)})
+	queries = append(queries, Query{Kind: "max", Answer: maxKey(state)})
+
+	final := map[string]int{}
+	for k, v := range state {
+		final[k] = v
+	}
+	return Task{Seed: seed, Horizon: horizon, Keys: keys, Instructions: insns, Queries: queries, FinalState: final}
+}
+
+// maxKey returns the key with the largest value, ties broken by name (stable).
+func maxKey(state map[string]int) string {
+	keys := make([]string, 0, len(state))
+	for k := range state {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	best := keys[0]
+	for _, k := range keys[1:] {
+		if state[k] > state[best] {
+			best = k
+		}
+	}
+	return best
+}
+
+// QuestionText renders a query as the natural-language question posed to the model.
+func (q Query) QuestionText() string {
+	switch q.Kind {
+	case "get":
+		return fmt.Sprintf("What is the current value of %s? Answer with only the integer.", q.Key)
+	case "sum":
+		return "What is the sum of all counters right now? Answer with only the integer."
+	case "max":
+		return "Which counter currently has the highest value? Answer with only its name (e.g. counter_03)."
+	}
+	return ""
+}
+
+// Grade canonicalises a model answer and compares it to the ground truth. Integers
+// are compared numerically (tolerating surrounding text); the max-key is compared as
+// the first counter_NN token found.
+func (q Query) Grade(modelAnswer string) bool {
+	got := strings.TrimSpace(modelAnswer)
+	switch q.Kind {
+	case "get", "sum":
+		return firstInt(got) == q.Answer
+	case "max":
+		return firstKey(got) == q.Answer
+	}
+	return false
+}

--- a/bench/cmd/longhorizon/task_test.go
+++ b/bench/cmd/longhorizon/task_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+// applyInstructions re-derives the end state from the rendered instruction stream,
+// independently of GenerateTask's inline computation — so a mismatch means the
+// instructions an agent SEES disagree with the oracle it is graded against.
+func applyInstructions(keys []string, insns []Instruction) map[string]int {
+	st := map[string]int{}
+	for _, k := range keys {
+		st[k] = 0
+	}
+	for _, in := range insns {
+		switch in.Op {
+		case OpSet, OpCorrection:
+			st[in.Key] = in.Value
+		case OpAdd:
+			st[in.Key] += in.Value
+		case OpSub:
+			st[in.Key] -= in.Value
+		case OpReset:
+			st[in.Key] = 0
+		case OpNote:
+			// no-op
+		}
+	}
+	return st
+}
+
+func TestGenerateTask_OracleMatchesRenderedStream(t *testing.T) {
+	task := GenerateTask(7, 120, 5, 0.15, true)
+	got := applyInstructions(task.Keys, task.Instructions)
+	if !reflect.DeepEqual(got, task.FinalState) {
+		t.Fatalf("oracle FinalState %v != replayed stream %v", task.FinalState, got)
+	}
+	if len(task.Instructions) != 120 {
+		t.Errorf("horizon = %d, want 120", len(task.Instructions))
+	}
+	// Queries cover every key + SUM + MAX, and their answers match the oracle.
+	if len(task.Queries) != len(task.Keys)+2 {
+		t.Fatalf("queries = %d, want keys+2", len(task.Queries))
+	}
+	for _, q := range task.Queries {
+		if q.Kind == "get" {
+			if want := fmt.Sprintf("%d", task.FinalState[q.Key]); q.Answer != want {
+				t.Errorf("query %s answer %q, want %q", q.Key, q.Answer, want)
+			}
+		}
+	}
+}
+
+func TestGenerateTask_Deterministic(t *testing.T) {
+	a := GenerateTask(42, 60, 4, 0.1, true)
+	b := GenerateTask(42, 60, 4, 0.1, true)
+	if !reflect.DeepEqual(a, b) {
+		t.Fatal("same seed produced different tasks — not reproducible")
+	}
+	c := GenerateTask(43, 60, 4, 0.1, true)
+	if reflect.DeepEqual(a, c) {
+		t.Fatal("different seeds produced identical tasks")
+	}
+}
+
+func TestGenerateTask_DriftHonoured(t *testing.T) {
+	task := GenerateTask(3, 40, 3, 0, true)
+	var corr *Instruction
+	for i := range task.Instructions {
+		if task.Instructions[i].Op == OpCorrection {
+			corr = &task.Instructions[i]
+		}
+	}
+	if corr == nil {
+		t.Fatal("drift=true produced no CORRECTION")
+	}
+	// The correction is the LAST word on its key (nothing after it re-touches it
+	// unless a later step does, in which case the oracle reflects that later step).
+	got := applyInstructions(task.Keys, task.Instructions)
+	if got[corr.Key] != task.FinalState[corr.Key] {
+		t.Errorf("drift key %s not consistent: replay %d vs oracle %d", corr.Key, got[corr.Key], task.FinalState[corr.Key])
+	}
+}
+
+func TestQuery_GradeTolerantParsing(t *testing.T) {
+	get := Query{Kind: "get", Key: "counter_01", Answer: "42"}
+	for _, ans := range []string{"42", " 42 ", "The value is 42.", "counter_01 = 42"} {
+		if !get.Grade(ans) {
+			t.Errorf("get.Grade(%q) = false, want true", ans)
+		}
+	}
+	if get.Grade("41") {
+		t.Error("get.Grade(41) = true, want false")
+	}
+	mx := Query{Kind: "max", Answer: "counter_03"}
+	if !mx.Grade("The highest is counter_03 right now.") {
+		t.Error("max.Grade with surrounding text failed")
+	}
+	if mx.Grade("counter_04") {
+		t.Error("max.Grade(counter_04) = true, want false")
+	}
+}


### PR DESCRIPTION
P1 of **RFC CS** (`/loomcycle/rfcs/long-horizon-agentic-benchmark`, confirmed) — the measure-first gate for **RFC CR** (layered execution context / SKILL.state adaptation). No loop changes: this harness measures whether the retention idea works *before* we build it in.

## What it does

Drives the model **per step through loomcycle's OpenAI-compat gateway** (`/v1/chat/completions`) — so every arm shares provider routing + the RFC AV cost ledger, and token counts are provider-reported — on a deterministic, horizon-scalable, oracle-graded **counter-tracking** task.

Three arms = the RFC CR regimes, as faithful harness-side context assemblers:
| Arm | Regime | Per-step context | Cost |
|---|---|---|---|
| **A0** | append (today) | full growing history | O(T²) |
| **A1** | recap (L1) | last-N + a model-maintained running recap | O(T) |
| **A2** | stateful (L2 / SKILL.state) | explicit JSON state the model patches; no history | O(T) |

Metrics: cumulative tokens (the O(T²) vs O(T) curve), **peak single prompt** (the flatness witness), oracle accuracy, latency. `-noise`/`-drift` exercise the two robustness axes.

> ⚠️ The synthetic task is *maximally schema-able*, so it likely **overstates A2** (RFC CS Q3). It's the clean-curve instrument + the local A0-vs-A1 gate; the marketing-research team run (P2) is the reality check.

## Tested

`go test ./bench/cmd/longhorizon` clean; `go build ./bench/...` + gofmt + vet clean. The deterministic core needs no live model:
- **task/oracle:** oracle-matches-rendered-stream, seed determinism, drift honoured, tolerant answer grading (incl. the "model echoes the counter name" case).
- **strategies:** A0 history growth; A1 window-evict-and-recap (one-shot `PendingRecap`, recap injected into the preamble); A2 patch-merge + **null-deletion** + unparseable-patch-is-a-no-op; `parsePatch`.

The live measurement run needs a loomcycle instance + a model key (documented in the README), same as `bench/cmd/locomo`.

## Next (RFC CS later phases)
Budget-matched controls (sliding-window, prose-summary), noise/drift as first-class report rows, and the controlled marketing-research team-run workload (P2). RFC CR stays `draft`, gated on this benchmark's go/no-go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)