### PR TITLE
fix(memory): provision identity docs on every user-creation path, not one

### DIFF
--- a/internal/api/http/identitydocs_test.go
+++ b/internal/api/http/identitydocs_test.go
@@ -3,6 +3,8 @@ package http
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -281,4 +283,93 @@ func TestOperatorTokenDef_RetireProvisionsNothing(t *testing.T) {
 func tokenAdminCtx() context.Context {
 	return tools.WithOperatorTokenDefPolicy(context.Background(),
 		tools.OperatorTokenDefPolicyValue{Admin: true})
+}
+
+// TestProvisionIdentityDocs_EveryUserCreationPathProvisions is the guard for the defect
+// that shipped in v1.68.0.
+//
+// Provisioning was hooked to the OperatorTokenDef substrate tool and nothing else, on the
+// strength of one route dispatching through it. But there are THREE ways a principal comes
+// into existence, and two of them write the row directly:
+//
+//	POST /v1/_users                  -> handleCreateUser     (store.UserCreate)
+//	POST /v1/_users/{s}/tokens       -> handleMintUserToken  (store.OperatorTokenDefCreate)
+//	OperatorTokenDef op=create       -> the substrate tool
+//
+// The Web UI drives the first two, so users created through it got no profile — no Identity
+// section, so nobody could declare their own names, so placement could not tell a fact about
+// them from a fact about a colleague. The feature was inert for exactly the people it was
+// built for.
+//
+// This test enumerates the paths rather than testing one, because the failure was a MISSING
+// call site, and a test per path written at the time would have covered the path that
+// already worked.
+func TestProvisionIdentityDocs_EveryUserCreationPathProvisions(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		subject string
+		run     func(t *testing.T, s *Server, subject string)
+	}{
+		{
+			name:    "POST /v1/_users",
+			subject: "created-user",
+			run: func(t *testing.T, s *Server, subject string) {
+				body, _ := json.Marshal(map[string]string{"subject": subject, "display_name": "Created"})
+				req := identityDocsReq(http.MethodPost, "/v1/_users", string(body))
+				rec := httptest.NewRecorder()
+				s.handleCreateUser(rec, req)
+				if rec.Code != http.StatusCreated {
+					t.Fatalf("create user = %d: %s", rec.Code, rec.Body.String())
+				}
+			},
+		},
+		{
+			name:    "POST /v1/_users/{subject}/tokens",
+			subject: "minted-user",
+			run: func(t *testing.T, s *Server, subject string) {
+				// The user must exist for the mint route to accept it.
+				body, _ := json.Marshal(map[string]string{"subject": subject})
+				cr := identityDocsReq(http.MethodPost, "/v1/_users", string(body))
+				crRec := httptest.NewRecorder()
+				s.handleCreateUser(crRec, cr)
+				if crRec.Code != http.StatusCreated {
+					t.Fatalf("seed user = %d: %s", crRec.Code, crRec.Body.String())
+				}
+				req := identityDocsReq(http.MethodPost, "/v1/_users/"+subject+"/tokens", `{}`)
+				req.SetPathValue("subject", subject)
+				rec := httptest.NewRecorder()
+				s.handleMintUserToken(rec, req)
+				if rec.Code != http.StatusCreated {
+					t.Fatalf("mint = %d: %s", rec.Code, rec.Body.String())
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s, _ := identityDocsFixture(t, true)
+			tc.run(t, s, tc.subject)
+
+			mi := memInject{Tenant: identityDocsTenant, UserID: tc.subject}
+			if !s.docExistsAt(t, mi, "user", meminject.UserRootPath) {
+				t.Errorf("%s created a principal but no user-root profile — the Identity "+
+					"section it carries is what lets placement tell this person's facts "+
+					"from a colleague's", tc.name)
+			}
+		})
+	}
+}
+
+// identityDocsTenant is the tenant the guard test's principal belongs to. A token row
+// requires a non-empty tenant, so the request has to carry a real principal.
+const identityDocsTenant = "acme"
+
+// identityDocsReq builds a request stamped with an admin principal in identityDocsTenant —
+// what authMiddleware would have put there in production.
+func identityDocsReq(method, path, body string) *http.Request {
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	return req.WithContext(auth.WithPrincipal(req.Context(), auth.Principal{
+		TenantID: identityDocsTenant,
+		Subject:  "operator",
+		Scopes:   []string{auth.ScopeAdmin},
+	}))
 }

--- a/internal/api/http/users_crud.go
+++ b/internal/api/http/users_crud.go
@@ -119,6 +119,16 @@ func (s *Server) handleCreateUser(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusInternalServerError, "user_create_failed", err.Error())
 		return
 	}
+	// A USER COMING INTO EXISTENCE IS THE ESTABLISHMENT MOMENT, and this is where it
+	// happens — not at token mint. Provisioning was originally hooked only to the
+	// OperatorTokenDef substrate tool, so a user created through this surface (which is
+	// what the Web UI drives) got no profile at all: the template that the Identity
+	// section lives in never appeared, so nobody could declare their own names, so
+	// placement could not tell a fact about them from a fact about a colleague.
+	//
+	// Best-effort and after the row lands: creating the user is the operation that must
+	// succeed, and a template document is a convenience.
+	s.ProvisionIdentityDocs(r.Context(), row.TenantID, row.Subject)
 	writeJSON(w, http.StatusCreated, toWireUserRecord(row))
 }
 

--- a/internal/api/http/users_tokens.go
+++ b/internal/api/http/users_tokens.go
@@ -240,6 +240,13 @@ func (s *Server) handleMintUserToken(w http.ResponseWriter, r *http.Request) {
 	// replica) so the fresh token authenticates within one backplane round-trip.
 	s.invalidateTokenCache(r.Context())
 
+	// Also here, and not only in handleCreateUser. This route writes the token row
+	// DIRECTLY rather than going through the OperatorTokenDef tool, so it shares no code
+	// with the other mint path — and it is reachable for a user that already existed
+	// before provisioning shipped, which is the case handleCreateUser cannot cover.
+	// Idempotent, so the overlap with a just-created user costs one exists-check.
+	s.ProvisionIdentityDocs(r.Context(), tenant, subject)
+
 	// Non-secret correlation only — NEVER the plaintext. The suffix + def_id are
 	// safe to log; the minting operator is attributed via principalSubject.
 	log.Printf("users: minted token tenant=%q subject=%q def_id=%q suffix=%q scopes=%v by=%q",


### PR DESCRIPTION
Reported from the live deployment: two users minted in a tenant got **no profile documents**.
v1.68.0 was supposed to create them when a principal is established, and for the surface the
Web UI actually drives it never did.

## What I got wrong

I hooked provisioning to the `OperatorTokenDef` substrate tool and wrote *"one hook covers
every mint path"* — on the strength of one route dispatching through it. I didn't look for
the others. There are **three** ways a principal comes into existence, and two write the row
directly, sharing no code with the tool:

```
POST /v1/_users              -> handleCreateUser    (store.UserCreate)          NOT hooked
POST /v1/_users/{s}/tokens   -> handleMintUserToken (store.OperatorTokenDefCreate) NOT hooked
OperatorTokenDef op=create   -> the substrate tool                              hooked
```

The Web UI drives the first two. So a user created there got no user-root document, hence no
`## Identity` section, hence no way to declare their own names — and **placement cannot tell a
fact about that person from a fact about a colleague without them.** The feature was inert for
exactly the people it was built for.

## The fix

Both are now hooked.

`handleCreateUser` is the primary one: **a user coming into existence is the establishment
moment**, and hooking only the token mint missed that a user can exist before any token —
which is precisely the reported case.

`handleMintUserToken` is kept as well rather than treated as redundant: it is the only path
that reaches a user who *already existed* before provisioning shipped, which
`handleCreateUser` cannot retrofit. Provisioning is idempotent, so the overlap costs one
exists-check.

## The test enumerates the paths

`TestProvisionIdentityDocs_EveryUserCreationPathProvisions` walks every creation surface
rather than testing one, because **the failure was a missing call site** — a test written
per-path at the time would have covered the path that already worked. That's the same shape as
the sqlite migration bug earlier in this line: the thing that passes is not the thing that's
broken.

It needs a stamped principal, since a token row requires a non-empty tenant. Worth noting
that's also why the original tests couldn't have caught this even by accident.

**Fail-before verified:** removing both hooks fails both subtests.
`go test ./...` clean, exit 0.

## For the two users already created

They exist without profiles, and `handleCreateUser` can't retroactively fix that. Two options
once this deploys: mint a fresh token for each (the mint hook then provisions), or I create
the documents directly via the Document tool. The second is one call each and doesn't churn
credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8