### PR TITLE
fix(memory): the pass report says WHY a graph write failed

### DIFF
--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -503,6 +503,20 @@ agents:
           placement_asked: {},      // type|subject already asked about, so batches don't re-ask
           subject_types: {},        // scope + slug -> the type this subject is ALREADY filed under
           type_stabilised: 0,       // times the extractor's guess was overridden by the existing type
+          // WHY a graph write failed, not just how many. The counter alone is unactionable:
+          // this agent is `internal: true`, so its runs are kept out of the run and history
+          // surfaces and its transcript CANNOT be read back — the pass report is the only
+          // channel it has. A live investigation stalled on exactly that: "2 graph write(s)
+          // failed" with the reason discarded, and no way to recover it afterwards.
+          //
+          // FIRST message only, and truncated. A per-failure list would put unbounded
+          // model-adjacent text in the report; the first one is what a person acts on.
+          entity_error: "",
+          // The type LOOKUP is a different failure from the chunk WRITE and must not share a
+          // counter. Conflating them is what made the live signal uninterpretable once
+          // canonicalType started contributing to it.
+          type_lookup_failed: 0,
+          type_lookup_error: "",
           entity_nodes: 0,          // distinct subjects given an entity chunk
           entity_facts: 0,          // facts mirrored into the graph
           // The judge's candidates, in WRITE ORDER. An array rather than a map
@@ -1740,7 +1754,12 @@ agents:
         } catch (e) {
           // Best-effort: an unreadable store leaves the proposal in place, which is exactly
           // the behaviour before this existed. Never costs a fact.
-          st.entity_failed++;
+          //
+          // Counted SEPARATELY from a chunk write: a failed lookup means the type may drift,
+          // a failed write means the fact is missing from the graph entirely. One counter for
+          // both told an operator neither.
+          st.type_lookup_failed++;
+          if (!st.type_lookup_error) { st.type_lookup_error = errText(e); }
         }
         // MEMOISE THE TYPE ACTUALLY CHOSEN, not the lookup result. Caching "" for a subject
         // nobody has filed yet means the next fact about it in THIS pass falls back to its
@@ -1767,8 +1786,14 @@ agents:
           args.natural_key = naturalKey;
           var res = JSON.parse(Document(args));
           if (res && res.id) { st.entity_ids[memo] = res.id; return res.id; }
+          // Parsed but no id: a refusal that did not throw. It used to return "" silently
+          // and increment NOTHING, so a pass could lose every entity write and report a
+          // clean sheet.
+          st.entity_failed++;
+          if (!st.entity_error) { st.entity_error = "no id in reply: " + String(res && res.error ? res.error : "").slice(0, 200); }
         } catch (e) {
           st.entity_failed++;
+          if (!st.entity_error) { st.entity_error = errText(e); }
         }
         return "";
       }
@@ -2434,7 +2459,15 @@ agents:
         // call failed, and those need different fixes.
         if (st.entity_facts || st.entity_nodes || st.entity_failed || st.entity_type_refused) {
           var ent = "entities " + st.entity_facts + " fact(s) across " + st.entity_nodes + " subject(s)";
-          if (st.entity_failed) { ent += ", " + st.entity_failed + " graph write(s) failed"; }
+          if (st.entity_failed) {
+            ent += ", " + st.entity_failed + " graph write(s) failed";
+            // The reason, because the transcript of an internal agent cannot be read back.
+            if (st.entity_error) { ent += " (first: " + String(st.entity_error).slice(0, 220) + ")"; }
+          }
+          if (st.type_lookup_failed) {
+            ent += ", " + st.type_lookup_failed + " subject-type lookup(s) failed";
+            if (st.type_lookup_error) { ent += " (first: " + String(st.type_lookup_error).slice(0, 220) + ")"; }
+          }
           if (st.entity_type_refused) {
             ent += ", " + st.entity_type_refused + " refused (a statement class is not an entity type)";
           }

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -503,6 +503,20 @@ agents:
           placement_asked: {},      // type|subject already asked about, so batches don't re-ask
           subject_types: {},        // scope + slug -> the type this subject is ALREADY filed under
           type_stabilised: 0,       // times the extractor's guess was overridden by the existing type
+          // WHY a graph write failed, not just how many. The counter alone is unactionable:
+          // this agent is `internal: true`, so its runs are kept out of the run and history
+          // surfaces and its transcript CANNOT be read back — the pass report is the only
+          // channel it has. A live investigation stalled on exactly that: "2 graph write(s)
+          // failed" with the reason discarded, and no way to recover it afterwards.
+          //
+          // FIRST message only, and truncated. A per-failure list would put unbounded
+          // model-adjacent text in the report; the first one is what a person acts on.
+          entity_error: "",
+          // The type LOOKUP is a different failure from the chunk WRITE and must not share a
+          // counter. Conflating them is what made the live signal uninterpretable once
+          // canonicalType started contributing to it.
+          type_lookup_failed: 0,
+          type_lookup_error: "",
           entity_nodes: 0,          // distinct subjects given an entity chunk
           entity_facts: 0,          // facts mirrored into the graph
           // The judge's candidates, in WRITE ORDER. An array rather than a map
@@ -1740,7 +1754,12 @@ agents:
         } catch (e) {
           // Best-effort: an unreadable store leaves the proposal in place, which is exactly
           // the behaviour before this existed. Never costs a fact.
-          st.entity_failed++;
+          //
+          // Counted SEPARATELY from a chunk write: a failed lookup means the type may drift,
+          // a failed write means the fact is missing from the graph entirely. One counter for
+          // both told an operator neither.
+          st.type_lookup_failed++;
+          if (!st.type_lookup_error) { st.type_lookup_error = errText(e); }
         }
         // MEMOISE THE TYPE ACTUALLY CHOSEN, not the lookup result. Caching "" for a subject
         // nobody has filed yet means the next fact about it in THIS pass falls back to its
@@ -1767,8 +1786,14 @@ agents:
           args.natural_key = naturalKey;
           var res = JSON.parse(Document(args));
           if (res && res.id) { st.entity_ids[memo] = res.id; return res.id; }
+          // Parsed but no id: a refusal that did not throw. It used to return "" silently
+          // and increment NOTHING, so a pass could lose every entity write and report a
+          // clean sheet.
+          st.entity_failed++;
+          if (!st.entity_error) { st.entity_error = "no id in reply: " + String(res && res.error ? res.error : "").slice(0, 200); }
         } catch (e) {
           st.entity_failed++;
+          if (!st.entity_error) { st.entity_error = errText(e); }
         }
         return "";
       }
@@ -2434,7 +2459,15 @@ agents:
         // call failed, and those need different fixes.
         if (st.entity_facts || st.entity_nodes || st.entity_failed || st.entity_type_refused) {
           var ent = "entities " + st.entity_facts + " fact(s) across " + st.entity_nodes + " subject(s)";
-          if (st.entity_failed) { ent += ", " + st.entity_failed + " graph write(s) failed"; }
+          if (st.entity_failed) {
+            ent += ", " + st.entity_failed + " graph write(s) failed";
+            // The reason, because the transcript of an internal agent cannot be read back.
+            if (st.entity_error) { ent += " (first: " + String(st.entity_error).slice(0, 220) + ")"; }
+          }
+          if (st.type_lookup_failed) {
+            ent += ", " + st.type_lookup_failed + " subject-type lookup(s) failed";
+            if (st.type_lookup_error) { ent += " (first: " + String(st.type_lookup_error).slice(0, 220) + ")"; }
+          }
           if (st.entity_type_refused) {
             ent += ", " + st.entity_type_refused + " refused (a statement class is not an entity type)";
           }

--- a/cmd/loomcycle/presets_memory_codejs_test.go
+++ b/cmd/loomcycle/presets_memory_codejs_test.go
@@ -56,6 +56,9 @@ type fakeToolset struct {
 	// is what a deployment without SQL Memory or with an unreadable ontology looks like.
 	placements     map[string]string
 	placementFails bool
+	// failTypeLookup makes the canonical-type query error, so a lookup failure can be told
+	// apart from a chunk-write failure in the report.
+	failTypeLookup bool
 
 	// The entity half, filled by fakeDocument.
 	entitiesDocID string
@@ -387,6 +390,9 @@ func (d *fakeDocument) Execute(_ context.Context, raw json.RawMessage) (tools.Re
 		// is visible to a later one. Keys are sorted for a deterministic winner (the real
 		// query orders by created_at; a Go map does not iterate in order).
 		if strings.Contains(sql, "SELECT c.type") && strings.Contains(sql, "LIKE '%:") {
+			if d.f.failTypeLookup {
+				return tools.Result{IsError: true, Text: "query_chunks: subject-type lookup unavailable"}, nil
+			}
 			suffix := sql[strings.Index(sql, "LIKE '%:")+len("LIKE '%"):]
 			if q := strings.Index(suffix, "'"); q >= 0 {
 				suffix = suffix[:q]
@@ -4573,5 +4579,58 @@ func TestConsolidator_ExtractionPromptSaysWhoseMemoryItIs(t *testing.T) {
 	// The rule goes BEFORE the transcript delimiters — it is ours, not the transcript's.
 	if strings.Index(prompt, "belongs to ONE person") > strings.Index(prompt, "BEGIN TRANSCRIPT") {
 		t.Error("the owner rule must precede the transcript, like the date line")
+	}
+}
+
+// TestConsolidator_ReportsWhyAGraphWriteFailed: the counter alone is unactionable. This
+// agent is `internal: true`, so its runs are kept out of the run and history surfaces and
+// its transcript cannot be read back — the pass report is the ONLY channel it has. A live
+// investigation stalled on exactly that: "2 graph write(s) failed" with the reason
+// discarded and no way to recover it after the fact.
+func TestConsolidator_ReportsWhyAGraphWriteFailed(t *testing.T) {
+	f := newFakeToolset()
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	f.transcript = "user: dave likes rock\nassistant: ok"
+	f.factsJSON = `[{"text":"Dave listens to classic rock.","class":"preference","type":"person","subject":"Dave"}]`
+	// The entity write is refused; the k/v write is untouched.
+	f.failEntityKeys["person:dave"] = true
+
+	res := runConsolidator(t, f)
+
+	if !strings.Contains(res.FinalText, "graph write(s) failed") {
+		t.Fatalf("the failure was not reported at all: %s", res.FinalText)
+	}
+	if !strings.Contains(res.FinalText, "first:") {
+		t.Errorf("the report counts the failure but not its REASON — which is all an operator "+
+			"has, since an internal agent's transcript cannot be read back: %s", res.FinalText)
+	}
+	// The reason has to be the store's own words, not a generic label.
+	if !strings.Contains(res.FinalText, "person:dave") {
+		t.Errorf("the reported reason should carry the underlying error text: %s", res.FinalText)
+	}
+	// And the fact itself still landed — a graph failure never costs a fact.
+	if !strings.Contains(res.FinalText, "facts written 1") {
+		t.Errorf("the k/v write should be unaffected: %s", res.FinalText)
+	}
+}
+
+// A failed subject-type LOOKUP is a different failure from a failed chunk WRITE and must not
+// share a counter: a bad lookup means the type may drift, a bad write means the fact is
+// missing from the graph entirely. Conflating them is what made the live signal
+// uninterpretable once canonicalType started contributing to it.
+func TestConsolidator_SeparatesATypeLookupFailureFromAWriteFailure(t *testing.T) {
+	f := newFakeToolset()
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	f.transcript = "user: dave likes rock\nassistant: ok"
+	f.factsJSON = `[{"text":"Dave listens to classic rock.","class":"preference","type":"person","subject":"Dave"}]`
+	f.failTypeLookup = true
+
+	res := runConsolidator(t, f)
+
+	if !strings.Contains(res.FinalText, "subject-type lookup(s) failed") {
+		t.Errorf("a failed lookup must be reported on its own line: %s", res.FinalText)
+	}
+	if strings.Contains(res.FinalText, "graph write(s) failed") {
+		t.Errorf("a lookup failure must NOT be counted as a write failure: %s", res.FinalText)
 	}
 }


### PR DESCRIPTION
A live two-user run on a real corpus stalled on an unactionable report:

```
entities 0 fact(s) across 0 subject(s), 2 graph write(s) failed
```

Every entity write failed and **the reason was discarded** — `catch (e) { st.entity_failed++; }`.

There is no second channel. This agent is `internal: true`, so its runs are deliberately kept
out of the run and history surfaces and **its transcript cannot be read back** — I confirmed
that with a 404 from both `/v1/runs/{id}` and its events. The pass report is the only thing
the consolidator ever gets to say, so a swallowed message is a message lost for good.

## Three changes

- **The first error text is kept and reported**, truncated. First only: a per-failure list
  would put unbounded model-adjacent text in the report, and the first is what a person acts
  on.
- **A failed subject-type lookup gets its own counter and message.** It is a different failure
  from a failed chunk write — a bad lookup means the type may *drift*, a bad write means the
  fact is *missing from the graph entirely*. Sharing one counter is what made the live signal
  uninterpretable as soon as `canonicalType` started contributing to it, which was my own
  doing in #1112.
- **A reply that parses but carries no id is now counted.** It used to return `""` and
  increment nothing, so a pass could lose every entity write and still report a clean sheet.

Nothing about what gets stored changes. What changes is what a failing pass can tell the
operator — which, on an internal agent, is everything.

## What was tested

`TestConsolidator_ReportsWhyAGraphWriteFailed` asserts the report carries the store's **own
words** rather than a generic label, and that the k/v write is unaffected (a graph failure
never costs a fact). `TestConsolidator_SeparatesATypeLookupFailureFromAWriteFailure` asserts a
lookup failure is not counted as a write failure.

**Fail-before verified:** removing the reason line fails the first test.
`go test ./...` clean, exit 0.

## Context

This unblocks the two-user LoCoMo measurement. That run is otherwise set up and working — both
users loaded, consolidated per user, and #1112 verified live ("subject types held stable 2",
the extractor proposing a different kind for a subject already on file). The entity tier came
back empty and I could not find out why, which is exactly the gap this closes.

Needs a deploy before the re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8