### PR TITLE
feat(memory): an undeclared type becomes a candidate, and its subject is kept

### DIFF
--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -517,6 +517,9 @@ agents:
           // canonicalType started contributing to it.
           type_lookup_failed: 0,
           type_lookup_error: "",
+          type_proposed: 0,         // unknown types filed as inert ontology candidates
+          type_fell_back: 0,        // subjects filed under the fallback type instead of being lost
+          proposed_names: {},       // name -> true, so one pass proposes a type once
           entity_nodes: 0,          // distinct subjects given an entity chunk
           entity_facts: 0,          // facts mirrored into the graph
           // The judge's candidates, in WRITE ORDER. An array rather than a map
@@ -1701,6 +1704,57 @@ agents:
       // to guess.
       function entityKey(type, subject) { return type + ":" + slug(normalizeSubject(subject)); }
 
+      // ENTITY_FALLBACK_TYPE is where a subject goes when its proposed type cannot be used.
+      //
+      // MEASURED: on a real corpus the extractor invented `experience`, the tenant had not
+      // declared it, and upsert_chunk refused the write — so the fact landed in k/v with NO
+      // graph presence at all. The gate's own message is that an undeclared-type node
+      // "becomes a node nobody can find", but refusing produces no node, which loses the
+      // subject entirely. A generic-but-findable node keeps the subject reachable and keeps
+      // its facts together, which is what the entity tier is for.
+      //
+      // `object` because it is part of the compiled-in seed (POLE+O), so it is declared in
+      // every tenant that has not deliberately removed it.
+      var ENTITY_FALLBACK_TYPE = "object";
+
+      // proposeOntologyType files an unknown type as an INERT candidate.
+      //
+      // The type is not adopted and changes nothing for any run: propose_entity only ever
+      // writes a proposal, and resolving one is an operator action on a surface this agent
+      // cannot reach. So a type the extractor invented becomes something an operator can
+      // look at and accept, instead of a silently discarded write.
+      //
+      // ONCE PER PASS PER NAME, and best-effort: the op itself refuses a duplicate, a name
+      // already in force, and one an operator already rejected (a tombstone, so this cannot
+      // nag). A failure here never affects the fact.
+      // undeclaredTypeRefusal reports whether the LAST entity write failed because the
+      // tenant does not declare that type — as opposed to any other fault.
+      //
+      // Matched on the refusal's own words rather than a status code, because the tool
+      // returns prose. Narrow on purpose: a store fault must NOT be mistaken for an
+      // undeclared type, or a transient error would quietly re-type a subject.
+      function undeclaredTypeRefusal(st) {
+        return /is not an entity type this tenant declares/.test(String(st.entity_error || ""));
+      }
+
+      function proposeOntologyType(st, name) {
+        if (!name || st.proposed_names[name]) { return; }
+        st.proposed_names[name] = true;
+        try {
+          Document({
+            op: "propose_entity", name: name,
+            body: "Proposed by the memory consolidator: the extractor typed at least one " +
+                  "fact with this kind and the tenant does not declare it, so those facts " +
+                  "were filed under " + ENTITY_FALLBACK_TYPE + " instead. Accept it to give " +
+                  "them their own type, or reject it to keep the fallback."
+          });
+          st.type_proposed++;
+        } catch (e) {
+          // An already-proposed or already-rejected name lands here. Not worth a counter:
+          // the point of the tombstone is that re-filing is a no-op.
+        }
+      }
+
       // canonicalType returns the type this subject is ALREADY filed under, or the
       // extractor's proposal when the subject is new.
       //
@@ -1803,21 +1857,44 @@ agents:
       function mirrorEntity(st, key, fact, scope) {
         if (!fact.type || !fact.subject) { return; } // untyped fact: k/v only (by design)
         scope = scope || CONFIG.scope;
-        // A statement class is not an entity type. Counted rather than silently
-        // skipped: a pass that mirrored nothing because every type was rejected
-        // must not look like a pass with nothing to mirror.
-        if (ENTITY_TYPE_DENY[fact.type] === true) { st.entity_type_refused++; return; }
         var docID = entitiesDoc(st, scope);
         if (!docID) { return; }
 
+        // A statement class is not an entity type — "preference:user" reads as "the entity
+        // of type preference named user". It used to be DROPPED, which lost the subject; the
+        // subject itself ("user") was never the problem, only the kind. Filed under the
+        // fallback instead, so the facts stay reachable. NOT proposed as a candidate: these
+        // names are already declared, they are simply being misused as a kind.
+        var proposed = fact.type;
+        if (ENTITY_TYPE_DENY[proposed] === true) {
+          st.entity_type_refused++;
+          proposed = ENTITY_FALLBACK_TYPE;
+        }
+
         // The type this subject is ALREADY filed under wins over this call's guess, so one
         // subject is one node however many ways the extractor spells its kind.
-        var subjType = canonicalType(st, scope, fact.type, fact.subject);
+        var subjType = canonicalType(st, scope, proposed, fact.subject);
         var subjKey = entityKey(subjType, fact.subject);
         var isNewSubject = !st.entity_ids[scope + "\u0000" + subjKey];
         var subjID = upsertEntityChunk(st, scope, docID, subjKey, {
           title: fact.subject, type: subjType, subject: fact.subject
         });
+        // UNDECLARED TYPE: the write was refused because the tenant does not declare this
+        // kind. File the kind as an inert candidate an operator can accept, then retry under
+        // the fallback — the key has to move with the type, since the type is part of a
+        // subject node's identity.
+        if (!subjID && subjType !== ENTITY_FALLBACK_TYPE && undeclaredTypeRefusal(st)) {
+          proposeOntologyType(st, subjType);
+          st.type_fell_back++;
+          // Remember the fallback for this subject so the rest of the pass agrees with it.
+          st.subject_types[scope + "\u0000" + slug(normalizeSubject(fact.subject))] = ENTITY_FALLBACK_TYPE;
+          subjType = ENTITY_FALLBACK_TYPE;
+          subjKey = entityKey(subjType, fact.subject);
+          isNewSubject = !st.entity_ids[scope + "\u0000" + subjKey];
+          subjID = upsertEntityChunk(st, scope, docID, subjKey, {
+            title: fact.subject, type: subjType, subject: fact.subject
+          });
+        }
         if (!subjID) { return; }
         if (isNewSubject) { st.entity_nodes++; }
 
@@ -2463,6 +2540,13 @@ agents:
             ent += ", " + st.entity_failed + " graph write(s) failed";
             // The reason, because the transcript of an internal agent cannot be read back.
             if (st.entity_error) { ent += " (first: " + String(st.entity_error).slice(0, 220) + ")"; }
+          }
+          if (st.type_fell_back) {
+            ent += ", " + st.type_fell_back + " subject(s) filed under " + ENTITY_FALLBACK_TYPE +
+              " because the tenant declares no such type";
+          }
+          if (st.type_proposed) {
+            ent += ", " + st.type_proposed + " new type(s) proposed for an operator to accept";
           }
           if (st.type_lookup_failed) {
             ent += ", " + st.type_lookup_failed + " subject-type lookup(s) failed";

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -517,6 +517,9 @@ agents:
           // canonicalType started contributing to it.
           type_lookup_failed: 0,
           type_lookup_error: "",
+          type_proposed: 0,         // unknown types filed as inert ontology candidates
+          type_fell_back: 0,        // subjects filed under the fallback type instead of being lost
+          proposed_names: {},       // name -> true, so one pass proposes a type once
           entity_nodes: 0,          // distinct subjects given an entity chunk
           entity_facts: 0,          // facts mirrored into the graph
           // The judge's candidates, in WRITE ORDER. An array rather than a map
@@ -1701,6 +1704,57 @@ agents:
       // to guess.
       function entityKey(type, subject) { return type + ":" + slug(normalizeSubject(subject)); }
 
+      // ENTITY_FALLBACK_TYPE is where a subject goes when its proposed type cannot be used.
+      //
+      // MEASURED: on a real corpus the extractor invented `experience`, the tenant had not
+      // declared it, and upsert_chunk refused the write — so the fact landed in k/v with NO
+      // graph presence at all. The gate's own message is that an undeclared-type node
+      // "becomes a node nobody can find", but refusing produces no node, which loses the
+      // subject entirely. A generic-but-findable node keeps the subject reachable and keeps
+      // its facts together, which is what the entity tier is for.
+      //
+      // `object` because it is part of the compiled-in seed (POLE+O), so it is declared in
+      // every tenant that has not deliberately removed it.
+      var ENTITY_FALLBACK_TYPE = "object";
+
+      // proposeOntologyType files an unknown type as an INERT candidate.
+      //
+      // The type is not adopted and changes nothing for any run: propose_entity only ever
+      // writes a proposal, and resolving one is an operator action on a surface this agent
+      // cannot reach. So a type the extractor invented becomes something an operator can
+      // look at and accept, instead of a silently discarded write.
+      //
+      // ONCE PER PASS PER NAME, and best-effort: the op itself refuses a duplicate, a name
+      // already in force, and one an operator already rejected (a tombstone, so this cannot
+      // nag). A failure here never affects the fact.
+      // undeclaredTypeRefusal reports whether the LAST entity write failed because the
+      // tenant does not declare that type — as opposed to any other fault.
+      //
+      // Matched on the refusal's own words rather than a status code, because the tool
+      // returns prose. Narrow on purpose: a store fault must NOT be mistaken for an
+      // undeclared type, or a transient error would quietly re-type a subject.
+      function undeclaredTypeRefusal(st) {
+        return /is not an entity type this tenant declares/.test(String(st.entity_error || ""));
+      }
+
+      function proposeOntologyType(st, name) {
+        if (!name || st.proposed_names[name]) { return; }
+        st.proposed_names[name] = true;
+        try {
+          Document({
+            op: "propose_entity", name: name,
+            body: "Proposed by the memory consolidator: the extractor typed at least one " +
+                  "fact with this kind and the tenant does not declare it, so those facts " +
+                  "were filed under " + ENTITY_FALLBACK_TYPE + " instead. Accept it to give " +
+                  "them their own type, or reject it to keep the fallback."
+          });
+          st.type_proposed++;
+        } catch (e) {
+          // An already-proposed or already-rejected name lands here. Not worth a counter:
+          // the point of the tombstone is that re-filing is a no-op.
+        }
+      }
+
       // canonicalType returns the type this subject is ALREADY filed under, or the
       // extractor's proposal when the subject is new.
       //
@@ -1803,21 +1857,44 @@ agents:
       function mirrorEntity(st, key, fact, scope) {
         if (!fact.type || !fact.subject) { return; } // untyped fact: k/v only (by design)
         scope = scope || CONFIG.scope;
-        // A statement class is not an entity type. Counted rather than silently
-        // skipped: a pass that mirrored nothing because every type was rejected
-        // must not look like a pass with nothing to mirror.
-        if (ENTITY_TYPE_DENY[fact.type] === true) { st.entity_type_refused++; return; }
         var docID = entitiesDoc(st, scope);
         if (!docID) { return; }
 
+        // A statement class is not an entity type — "preference:user" reads as "the entity
+        // of type preference named user". It used to be DROPPED, which lost the subject; the
+        // subject itself ("user") was never the problem, only the kind. Filed under the
+        // fallback instead, so the facts stay reachable. NOT proposed as a candidate: these
+        // names are already declared, they are simply being misused as a kind.
+        var proposed = fact.type;
+        if (ENTITY_TYPE_DENY[proposed] === true) {
+          st.entity_type_refused++;
+          proposed = ENTITY_FALLBACK_TYPE;
+        }
+
         // The type this subject is ALREADY filed under wins over this call's guess, so one
         // subject is one node however many ways the extractor spells its kind.
-        var subjType = canonicalType(st, scope, fact.type, fact.subject);
+        var subjType = canonicalType(st, scope, proposed, fact.subject);
         var subjKey = entityKey(subjType, fact.subject);
         var isNewSubject = !st.entity_ids[scope + "\u0000" + subjKey];
         var subjID = upsertEntityChunk(st, scope, docID, subjKey, {
           title: fact.subject, type: subjType, subject: fact.subject
         });
+        // UNDECLARED TYPE: the write was refused because the tenant does not declare this
+        // kind. File the kind as an inert candidate an operator can accept, then retry under
+        // the fallback — the key has to move with the type, since the type is part of a
+        // subject node's identity.
+        if (!subjID && subjType !== ENTITY_FALLBACK_TYPE && undeclaredTypeRefusal(st)) {
+          proposeOntologyType(st, subjType);
+          st.type_fell_back++;
+          // Remember the fallback for this subject so the rest of the pass agrees with it.
+          st.subject_types[scope + "\u0000" + slug(normalizeSubject(fact.subject))] = ENTITY_FALLBACK_TYPE;
+          subjType = ENTITY_FALLBACK_TYPE;
+          subjKey = entityKey(subjType, fact.subject);
+          isNewSubject = !st.entity_ids[scope + "\u0000" + subjKey];
+          subjID = upsertEntityChunk(st, scope, docID, subjKey, {
+            title: fact.subject, type: subjType, subject: fact.subject
+          });
+        }
         if (!subjID) { return; }
         if (isNewSubject) { st.entity_nodes++; }
 
@@ -2463,6 +2540,13 @@ agents:
             ent += ", " + st.entity_failed + " graph write(s) failed";
             // The reason, because the transcript of an internal agent cannot be read back.
             if (st.entity_error) { ent += " (first: " + String(st.entity_error).slice(0, 220) + ")"; }
+          }
+          if (st.type_fell_back) {
+            ent += ", " + st.type_fell_back + " subject(s) filed under " + ENTITY_FALLBACK_TYPE +
+              " because the tenant declares no such type";
+          }
+          if (st.type_proposed) {
+            ent += ", " + st.type_proposed + " new type(s) proposed for an operator to accept";
           }
           if (st.type_lookup_failed) {
             ent += ", " + st.type_lookup_failed + " subject-type lookup(s) failed";

--- a/cmd/loomcycle/presets_memory_codejs_test.go
+++ b/cmd/loomcycle/presets_memory_codejs_test.go
@@ -7,6 +7,7 @@ import (
 	meminject "github.com/denn-gubsky/loomcycle/internal/memory"
 	"math"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -59,6 +60,11 @@ type fakeToolset struct {
 	// failTypeLookup makes the canonical-type query error, so a lookup failure can be told
 	// apart from a chunk-write failure in the report.
 	failTypeLookup bool
+	// declaredTypes, when non-empty, makes upsert_chunk refuse an entity type outside the
+	// set with the REAL gate's wording — the refusal the fallback keys off.
+	declaredTypes map[string]bool
+	// proposedTypes records propose_entity calls: name -> true.
+	proposedTypes map[string]bool
 
 	// The entity half, filled by fakeDocument.
 	entitiesDocID string
@@ -158,6 +164,7 @@ func newFakeToolset() *fakeToolset {
 		chunkRows:      map[string]map[string]any{},
 		verdicts:       map[string]string{},
 		failEntityKeys: map[string]bool{},
+		proposedTypes:  map[string]bool{},
 		// Source of truth for this format: formatSubAgentOutput in
 		// internal/api/http/resume.go. Nothing links them — grep that name.
 		subAgentHeader: "[sub-agent agent_id=a_test000000000000]\n",
@@ -295,6 +302,14 @@ func (d *fakeDocument) Execute(_ context.Context, raw json.RawMessage) (tools.Re
 		if d.f.failEntityKeys[key] {
 			return tools.Result{IsError: true, Text: "upsert_chunk: write failed for " + key}, nil
 		}
+		// The ontology gate, in the real gate's own words — the fallback matches on them.
+		if len(d.f.declaredTypes) > 0 {
+			if typ, _ := in["type"].(string); typ != "" && !d.f.declaredTypes[typ] {
+				return tools.Result{IsError: true, Text: "upsert_chunk: " + strconv.Quote(typ) +
+					" is not an entity type this tenant declares, so an assertion typed with it " +
+					"becomes a node nobody can find. Declared: object, person"}, nil
+			}
+		}
 		id, existed := d.f.chunks[key]
 		if !existed {
 			id = fmt.Sprintf("chunk-%d", len(d.f.chunks)+1)
@@ -383,6 +398,13 @@ func (d *fakeDocument) Execute(_ context.Context, raw json.RawMessage) (tools.Re
 		old, _ := in["supersedes_id"].(string)
 		d.f.supersededChunks = append(d.f.supersededChunks, old+" by "+id)
 		return okResult(map[string]any{"ok": true})
+	case "propose_entity":
+		name, _ := in["name"].(string)
+		if d.f.proposedTypes[name] {
+			return tools.Result{IsError: true, Text: "propose_entity: " + name + " is already proposed"}, nil
+		}
+		d.f.proposedTypes[name] = true
+		return okResult(map[string]any{"proposed": name, "chunk_id": "prop-" + name})
 	case "query_chunks":
 		sql, _ := in["sql"].(string)
 		// The canonical-TYPE lookup: "... LIKE '%:<slug>' AND c.type <> 'fact'". Answers
@@ -4632,5 +4654,83 @@ func TestConsolidator_SeparatesATypeLookupFailureFromAWriteFailure(t *testing.T)
 	}
 	if strings.Contains(res.FinalText, "graph write(s) failed") {
 		t.Errorf("a lookup failure must NOT be counted as a write failure: %s", res.FinalText)
+	}
+}
+
+// ---- an undeclared type becomes a candidate, and the subject is kept ----------
+
+// TestConsolidator_UndeclaredTypeIsProposedAndTheSubjectFiledAsObject is the fix for a
+// measured loss. On a real corpus the extractor invented `experience`, the tenant had not
+// declared it, and upsert_chunk refused the write — so the fact landed in key/value with NO
+// graph presence at all. The gate's own message is that an undeclared-type node "becomes a
+// node nobody can find", but refusing produces no node, which loses the subject entirely.
+func TestConsolidator_UndeclaredTypeIsProposedAndTheSubjectFiledAsObject(t *testing.T) {
+	f := newFakeToolset()
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	f.transcript = "user: dave went skydiving\nassistant: wow"
+	f.declaredTypes = map[string]bool{"object": true, "person": true, "fact": true}
+	f.factsJSON = `[{"text":"Dave went skydiving in June.","class":"fact","type":"experience","subject":"Dave"}]`
+
+	res := runConsolidator(t, f)
+
+	// The subject survives, under the fallback type and a key that MOVED with it — the type
+	// is part of a subject node's identity, so a stale key would split it.
+	if _, ok := f.chunks["object:dave"]; !ok {
+		t.Errorf("the subject was not filed under the fallback type; chunks: %v", f.chunks)
+	}
+	if _, ok := f.chunks["experience:dave"]; ok {
+		t.Errorf("a chunk was created under the refused type: %v", f.chunks)
+	}
+	// The unknown kind becomes something an operator can accept, rather than a lost write.
+	if !f.proposedTypes["experience"] {
+		t.Errorf("the undeclared type was not proposed as a candidate: %v", f.proposedTypes)
+	}
+	for _, want := range []string{"filed under object", "type(s) proposed"} {
+		if !strings.Contains(res.FinalText, want) {
+			t.Errorf("the report should say %q: %s", want, res.FinalText)
+		}
+	}
+}
+
+// A statement class misused as a kind is already DECLARED — proposing it would be
+// meaningless — but the subject is still not the problem, so it must not be dropped.
+func TestConsolidator_AStatementClassFallsBackWithoutBeingProposed(t *testing.T) {
+	f := newFakeToolset()
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	f.transcript = "user: I prefer rock\nassistant: ok"
+	f.declaredTypes = map[string]bool{"object": true, "person": true, "fact": true, "preference": true}
+	f.factsJSON = `[{"text":"The user prefers rock music.","class":"preference","type":"preference","subject":"user"}]`
+
+	runConsolidator(t, f)
+
+	if _, ok := f.chunks["object:user"]; !ok {
+		t.Errorf("a statement-class type should fall back, not drop the subject: %v", f.chunks)
+	}
+	if f.proposedTypes["preference"] {
+		t.Error("a declared statement class must NOT be proposed as a new entity type")
+	}
+}
+
+// A refusal that is NOT about an undeclared type must not trigger the fallback: re-typing a
+// subject on a transient store fault would move it for the wrong reason, and the type is
+// part of its identity.
+func TestConsolidator_AnUnrelatedWriteFailureDoesNotRetypeTheSubject(t *testing.T) {
+	f := newFakeToolset()
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	f.transcript = "user: dave is an engineer\nassistant: ok"
+	f.declaredTypes = map[string]bool{"object": true, "person": true, "fact": true}
+	f.failEntityKeys["person:dave"] = true // a plain write failure, not a gate refusal
+	f.factsJSON = `[{"text":"Dave is an automotive engineer.","class":"fact","type":"person","subject":"Dave"}]`
+
+	res := runConsolidator(t, f)
+
+	if _, ok := f.chunks["object:dave"]; ok {
+		t.Errorf("a store fault re-typed the subject to the fallback: %v", f.chunks)
+	}
+	if len(f.proposedTypes) != 0 {
+		t.Errorf("nothing should be proposed for a non-gate failure: %v", f.proposedTypes)
+	}
+	if !strings.Contains(res.FinalText, "graph write(s) failed") {
+		t.Errorf("the failure should still be reported: %s", res.FinalText)
 	}
 }


### PR DESCRIPTION
Measured on a real corpus at v1.68.2: the extractor invented `experience`, the tenant had not
declared it, and `upsert_chunk` refused the write — so the fact landed in key/value with **no
graph presence at all**. Every typed fact in that run was lost to the graph the same way,
which is why the entity tier came back empty and CQ-1 could not be measured.

The gate's own message is that an undeclared-type node *"becomes a node nobody can find"*.
True — but refusing produces **no node**, which loses the subject entirely, and that is
strictly worse than a generic one. The subject was never the problem; only the kind was.

## Two paths, deliberately different

**An undeclared type** is filed as an inert ontology **candidate** via `propose_entity`, and
the subject is written under `object`. The candidate changes nothing for any run until an
operator accepts it — resolving one is an action on a surface this agent cannot reach — so an
invented kind becomes something a person can look at and adopt, instead of a silently
discarded write. Once per pass per name; the op's own tombstone means a rejected name cannot
nag.

**A statement class misused as a kind** — `preference:user` reads as *"the entity of type
preference named user"* — also falls back to `object`, but is **not** proposed: those names
are already declared, they are simply being used for the wrong thing. Previously it was
dropped, losing the subject over a naming mistake.

## Two details that matter

**The key moves with the type.** A subject node's natural key is `type + ":" + slug`, so the
type is part of its identity — re-typing without re-keying would have created a *second* node
rather than rescuing the first. The fallback is also written into the pass's subject-type memo
so the rest of the pass agrees with it.

**The retry is narrow on purpose**, matched against the gate's own wording. A store fault must
never be mistaken for an undeclared type, or a transient error would quietly re-type a
subject — and the type is identity. There's a test for exactly that.

`object` because it is part of the compiled-in POLE+O seed, so it is declared in every tenant
that has not deliberately removed it.

## What was tested

- The undeclared type is proposed **and** the subject lands under the fallback with a key that
  moved with it, with **no** chunk under the refused type.
- A statement class falls back without being proposed.
- An unrelated write failure neither re-types the subject nor proposes anything, and is still
  reported.

**Fail-before verified:** removing the retry fails the first test.
`go test ./...` clean, exit 0. `LOOMCYCLE_PRESETS=base,memory loomcycle agents list` clean.

The fake toolset gained the ontology gate in the real gate's own words, plus a
`propose_entity` recorder — it previously accepted any type, so nothing exercised the refusal.

## Note

This should make the entity tier non-empty on the LoCoMo two-user run, which unblocks the
CQ-1 typing measurement. It does not touch the larger problem in that run: 1,136 turns of
input produced 4 facts, with ~35–39 malformed extractor entries dropped per pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8