### PR TITLE
feat: L1 reasoning-recap context retention (RFC CR P1)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -631,6 +631,30 @@ Reading the outcome: the `context_compaction` transcript event gains a `memory_b
 
 Once consolidated, a fact records where it came from. `Memory op=get` with `include_provenance: true` returns `origin: compaction` plus the originating run/session and an `origin_available` flag — `false` once retention has deleted that chat. The fact itself is never pruned for having a dead origin; see [§ retention](#9b-multi-tenant-authentication-rfc-l) for the chat clocks.
 
+### `context:` — reasoning-recap retention (a lighter-weight alternative to compaction)
+
+Compaction summarizes the *whole* span it drops — including tool results — into one prose blob at a threshold. On a **long-horizon** run against a **weak or local** model that is exactly where quality suffers: a bloated append-only history poisons the model, and a lossy prose summary throws away the structured facts (which value, which file, which result) the next step needs. The `context:` block offers a different retention strategy tuned for that regime — it keeps the recent structured turns *verbatim* and distils only the older, verbose reasoning into a running note:
+
+```yaml
+agents:
+  long-runner:
+    context:
+      mode: recap          # "append" (default, unchanged) | "recap"
+      keep_last_n: 6        # recent tool_use/tool_result pairs kept VERBATIM
+      reasoning: recap      # recap (default) | drop | keep
+      recap_max_chars: 512  # bound on the running recap note
+      autorecap_at_pct: 80  # recap when used/window crosses this % (50..95)
+```
+
+In `mode: recap` the loop, at an iteration boundary once the footprint crosses `autorecap_at_pct`, rebuilds what it FEEDS the model as: the pinned task + a bounded **running progress recap** + the last `keep_last_n` `tool_use`/`tool_result` pairs verbatim. The recap folds forward incrementally each time (the prior recap is rolled into the next), so the fed prompt stays flat — cost grows with the horizon linearly, not quadratically. Choosing `recap` mode turns auto-recap on; it takes precedence over the `compaction:` auto-trigger (the two are mutually exclusive per run). `Context op=compact` (and the manual compact control) trigger a recap instead of a compaction while in this mode.
+
+- `reasoning: drop` — the cheapest policy: drop the evicted span with **no** recap call (keeps only the preamble + the last-N tail). No extra model round-trip.
+- `reasoning: keep` — a no-op control (distils nothing); useful only to A/B the recap's contribution.
+
+As with compaction, the **full transcript is always retained** — audit, replay, resume, and memory facts-extraction see the complete trajectory; only the fed window is distilled. The block is content-identifying (a fork that sets it mints a distinct hash), it is a per-run override on `POST /v1/runs` (`context`), and it flows down the spawn tree (a sub-agent inherits the parent's mode; its own def fills any gaps). An agent reads the resolved policy for its run via `Context op=self` (`context_policy`).
+
+> **Which one?** `append` (+ `compaction`) stays the default and is right for most runs. Reach for `mode: recap` on a **local / weak model doing long procedural work**, where a growing prompt measurably degrades answers — that is the regime where keeping recent observations verbatim while recapping old reasoning wins on both cost and quality. On a frontier model at short horizons the two are quality-equivalent, so the motivation there is cost alone.
+
 ### Interactive local agents
 
 For a terminal you steer turn-by-turn:

--- a/internal/agents/loader.go
+++ b/internal/agents/loader.go
@@ -196,6 +196,18 @@ type Compaction struct {
 	MemoryFlush *bool `json:"memory_flush,omitempty"`
 }
 
+// Context mirrors config.Context locally (the agents package stays config-free).
+// json: tags mirror the persisted snake_case and are LOAD-BEARING for
+// content_sha256 — a fork that changes only a context field mints a distinct
+// hash. Pointers so an unset field omits.
+type Context struct {
+	Mode           *string `json:"mode,omitempty"`
+	KeepLastN      *int    `json:"keep_last_n,omitempty"`
+	Reasoning      *string `json:"reasoning,omitempty"`
+	RecapMaxChars  *int    `json:"recap_max_chars,omitempty"`
+	AutoRecapAtPct *int    `json:"autorecap_at_pct,omitempty"`
+}
+
 // CoreBlock mirrors config.CoreBlock locally so the agents package stays
 // config-free. json: tags mirror the persisted snake_case and are LOAD-BEARING
 // for content_sha256 (RFC BL P1 — a fork that changes a core block's

--- a/internal/agents/sign.go
+++ b/internal/agents/sign.go
@@ -111,6 +111,13 @@ type AgentContent struct {
 	// agent omits the key and hashes byte-identical to pre-feature rows. Tag
 	// "compaction" sorts between code_body and description.
 	Compaction *Compaction `json:"compaction,omitempty"`
+	// Context is the per-agent layered-context / retention block (mirrors
+	// config.Context; RFC CR). Content-identifying — a fork that only changes a
+	// context field (e.g. append→recap) mints a distinct content_sha256. Pointer
+	// + omitempty + normalize-collapse so an append-mode/no-context agent omits
+	// the key and hashes byte-identical to pre-feature rows. Tag "context" sorts
+	// between compaction and core_blocks.
+	Context *Context `json:"context,omitempty"`
 	// CoreBlocks is the RFC BL P1 core-memory-block attachment list. Content-
 	// identifying: a fork that changes an attached block's scope/limit/read-only
 	// (or adds/removes a block) mints a distinct content_sha256. omitempty +
@@ -333,6 +340,14 @@ func normalize(c *AgentContent) {
 		c.Compaction.AutoCompactAtPct == nil && c.Compaction.Model == nil &&
 		c.Compaction.MemoryFlush == nil {
 		c.Compaction = nil
+	}
+	// Same all-nil collapse for context (a substrate read of an append-mode/
+	// no-context def yields `"context":{}`) → hashes identically to a pre-feature
+	// row. An explicit mode:"append" is a non-nil *string and is preserved.
+	if c.Context != nil && c.Context.Mode == nil && c.Context.KeepLastN == nil &&
+		c.Context.Reasoning == nil && c.Context.RecapMaxChars == nil &&
+		c.Context.AutoRecapAtPct == nil {
+		c.Context = nil
 	}
 
 	// Trim + normalise the system_prompt to insulate the hash from

--- a/internal/api/http/context_recap_replay_test.go
+++ b/internal/api/http/context_recap_replay_test.go
@@ -1,0 +1,87 @@
+package http
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// A context_recap marker (RFC CR L1) must replay like context_compaction: the
+// span before the kept tail collapses to the task + the running recap + the last-N
+// verbatim, so a rebuild (resume / crash recovery / transcript view) reconstructs
+// the SAME distilled fed history the live loop produced — not the full transcript.
+//
+// Fail-before: replayTranscript had no context_recap case, so a resumed recap-mode
+// run replayed the entire history (the distillation was lost on resume).
+func TestReplayTranscript_ContextRecapMarker(t *testing.T) {
+	srv, _ := replayFixture(t)
+	ctx := context.Background()
+	sess, err := srv.store.CreateSession(ctx, "", "chat/src", "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := srv.store.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a", UserID: "alice", Model: "stub-model"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	uinput := func(text string) []map[string]any {
+		return []map[string]any{{"role": "user", "content": []map[string]any{{"type": "trusted-text", "text": text}}}}
+	}
+	// Three turns accumulate: [user(the task), asst(answer1), user(q2), asst(answer2),
+	// user(q3), asst(answer3)].
+	appendResumeEvent(t, srv, run.ID, "user_input", uinput("the task"))
+	appendResumeEvent(t, srv, run.ID, "text", providers.Event{Type: providers.EventText, Text: "answer1"})
+	appendResumeEvent(t, srv, run.ID, "done", providers.Event{Type: providers.EventDone, StopReason: "end_turn"})
+	appendResumeEvent(t, srv, run.ID, "user_input", uinput("q2"))
+	appendResumeEvent(t, srv, run.ID, "text", providers.Event{Type: providers.EventText, Text: "answer2"})
+	appendResumeEvent(t, srv, run.ID, "done", providers.Event{Type: providers.EventDone, StopReason: "end_turn"})
+	appendResumeEvent(t, srv, run.ID, "user_input", uinput("q3"))
+	appendResumeEvent(t, srv, run.ID, "text", providers.Event{Type: providers.EventText, Text: "answer3"})
+	appendResumeEvent(t, srv, run.ID, "done", providers.Event{Type: providers.EventDone, StopReason: "end_turn"})
+
+	// The recap marker: keep the task (pinned) + the last 2 accumulated messages,
+	// replace the middle with the running recap.
+	appendResumeEvent(t, srv, run.ID, string(providers.EventContextRecap), providers.Event{
+		Type: providers.EventContextRecap,
+		ContextRecap: &providers.ContextRecapEventInfo{
+			Recap: "THE RUNNING RECAP", KeepN: 2, KeepFirst: true, Trigger: "auto", Reasoning: "recap",
+		},
+	})
+
+	events, err := srv.store.GetTranscript(ctx, sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	msgs := replayTranscript(events)
+	if len(msgs) == 0 {
+		t.Fatal("replay produced no messages")
+	}
+	// First turn is the raw pinned task (its own user turn).
+	if msgs[0].Role != "user" || strings.TrimSpace(firstText(msgs[0])) != "the task" {
+		t.Errorf("msg[0] should be the pinned task, got %q (%s)", firstText(msgs[0]), msgs[0].Role)
+	}
+	// The recap is present as an assistant turn.
+	joined := ""
+	sawRecap := false
+	for _, m := range msgs {
+		joined += firstText(m)
+		if m.Role == "assistant" && strings.Contains(firstText(m), "THE RUNNING RECAP") {
+			sawRecap = true
+		}
+	}
+	if !sawRecap {
+		t.Errorf("the running recap did not replay as an assistant turn: %q", joined)
+	}
+	// The recapped-away early turn is gone from the fed history (kept only in the
+	// retained transcript, not fed).
+	if strings.Contains(joined, "answer1") {
+		t.Errorf("recapped-away turn 'answer1' leaked into the replayed fed history: %q", joined)
+	}
+	// The kept tail survived.
+	if !strings.Contains(joined, "answer3") {
+		t.Errorf("kept tail 'answer3' missing from the replayed history: %q", joined)
+	}
+}

--- a/internal/api/http/resume.go
+++ b/internal/api/http/resume.go
@@ -358,6 +358,7 @@ func (s *Server) resumePausedRun(ctx context.Context, run store.Run) error {
 		Interactive:         run.Interactive,
 		Sampling:            agentDef.Sampling,   // per-run override not snapshotted
 		Compaction:          agentDef.Compaction, // per-run override not snapshotted
+		Context:             agentDef.Context,    // per-run override not snapshotted (RFC CR)
 		// BankCompactedSpan is deliberately ABSENT (RFC BL P3). A resumed run
 		// replays a compaction that already happened, and its span was banked when
 		// it first ran — wiring it here would re-bank the same conversation on

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2563,6 +2563,10 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	// inherits the parent's effective policy (its def fills any gaps the parent
 	// left unset), overridable per-spawn by the Agent tool.
 	loopCtx = tools.WithCompactionPolicy(loopCtx, config.MergeCompaction(agentDef.Compaction, in.Compaction))
+	// RFC CR: the resolved layered-context policy flows down the spawn tree the
+	// same way — a sub-agent inherits the parent's effective mode; its def fills
+	// gaps the parent left unset.
+	loopCtx = tools.WithContextPolicy(loopCtx, config.MergeContext(agentDef.Context, in.Context))
 	// RFC AH: the run's filesystem-volume bindings. Unbound agents get an
 	// empty policy (the file tools fall back to the legacy jail Root);
 	// sub-agents inherit + narrow this via runSubAgent.
@@ -2631,6 +2635,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 		Interactive:         in.Interactive,
 		Sampling:            config.MergeSampling(agentDef.Sampling, in.Sampling),       // per-run wins per field
 		Compaction:          config.MergeCompaction(agentDef.Compaction, in.Compaction), // per-run wins per field
+		Context:             config.MergeContext(agentDef.Context, in.Context),          // per-run wins per field (RFC CR)
 		// RFC BL P3: nil unless the agent set compaction.memory_flush, so an
 		// unopted agent's compaction path is byte-identical.
 		BankCompactedSpan:      s.bankCompactedSpanFn(agentDef, rid.TenantID, effectiveUserID, in.Agent, runID, sessionID),
@@ -3615,6 +3620,11 @@ type runRequest struct {
 	// inherit). nil = inherit the agent's entirely.
 	Compaction *config.Compaction `json:"compaction,omitempty"`
 
+	// Context is an optional per-RUN layered-context / retention override (RFC CR)
+	// — merged PER FIELD over the agent's own `context:` block (this wins; unset
+	// fields inherit). nil = inherit the agent's entirely.
+	Context *config.Context `json:"context,omitempty"`
+
 	// MaxContextTokens is an optional per-RUN context-WINDOW override (RFC CJ) —
 	// wins over the agent's own max_context_tokens when > 0, else inherits it
 	// (and 0 there falls through to the provider/driver default). Distinct from
@@ -4181,6 +4191,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		QuotaBytes:    agentDef.SqlQuotaBytes,
 	})
 	loopCtx = tools.WithCompactionPolicy(loopCtx, config.MergeCompaction(agentDef.Compaction, req.Compaction))
+	loopCtx = tools.WithContextPolicy(loopCtx, config.MergeContext(agentDef.Context, req.Context)) // RFC CR
 	// RFC AH: the run's filesystem-volume bindings. Unbound agents get an
 	// empty policy (the file tools fall back to the legacy jail Root);
 	// sub-agents inherit + narrow this via runSubAgent.
@@ -4243,6 +4254,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		Interactive:         req.Interactive,
 		Sampling:            config.MergeSampling(agentDef.Sampling, req.Sampling),       // per-run wins per field
 		Compaction:          config.MergeCompaction(agentDef.Compaction, req.Compaction), // per-run wins per field
+		Context:             config.MergeContext(agentDef.Context, req.Context),          // per-run wins per field (RFC CR)
 		// RFC BL P3: nil unless the agent set compaction.memory_flush.
 		BankCompactedSpan:      s.bankCompactedSpanFn(agentDef, rid.TenantID, req.UserID, req.Agent, runID, sessionID),
 		ContextPlugins:         s.contextPlugins, // RFC Z runtime-wide chain (code-js exempt in the loop)
@@ -4389,6 +4401,10 @@ type messagesRequest struct {
 	// Compaction: per-RUN context-compaction override for this continuation,
 	// merged per field over the agent's. Same semantics as runRequest.Compaction.
 	Compaction *config.Compaction `json:"compaction,omitempty"`
+
+	// Context: per-RUN layered-context override for this continuation, merged per
+	// field over the agent's. Same semantics as runRequest.Context (RFC CR).
+	Context *config.Context `json:"context,omitempty"`
 
 	// MaxContextTokens: per-RUN context-WINDOW override for this continuation
 	// turn (RFC CJ). Same semantics as runRequest.MaxContextTokens.
@@ -4771,6 +4787,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		QuotaBytes:    agentDef.SqlQuotaBytes,
 	})
 	loopCtx = tools.WithCompactionPolicy(loopCtx, config.MergeCompaction(agentDef.Compaction, body.Compaction))
+	loopCtx = tools.WithContextPolicy(loopCtx, config.MergeContext(agentDef.Context, body.Context)) // RFC CR
 	// RFC AH: the run's filesystem-volume bindings. Unbound agents get an
 	// empty policy (the file tools fall back to the legacy jail Root);
 	// sub-agents inherit + narrow this via runSubAgent.
@@ -4830,6 +4847,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		ArmTurnCancel:          s.armTurnCancelIf(body.Interactive, run.ID),                  // RFC BH: turn-cancellable when interactive
 		Sampling:               config.MergeSampling(agentDef.Sampling, body.Sampling),       // per-run wins per field
 		Compaction:             config.MergeCompaction(agentDef.Compaction, body.Compaction), // per-run wins per field
+		Context:                config.MergeContext(agentDef.Context, body.Context),          // per-run wins per field (RFC CR)
 		ContextPlugins:         s.contextPlugins,                                             // RFC Z runtime-wide chain (code-js exempt in the loop)
 		UserTier:               body.UserTier,
 		FallbackPolicy:         fbPolicy,
@@ -5015,6 +5033,41 @@ func replayTranscript(events []store.Event) []providers.Message {
 					}
 				}
 				messages = loop.CompactionMessages(pinned, cc.Summary, tail)
+			}
+			asstText.Reset()
+			asstTools = nil
+			pendingToolResults = nil
+			asstReasoning = ""
+			asstReasoningSignature = ""
+		case "context_recap":
+			// L1 reasoning-recap (RFC CR): the span before the kept tail collapses
+			// to a running recap. RESET accumulated state and seed the same
+			// task + recap + kept-tail form the live loop swapped in, so a rebuild
+			// reconstructs the recapped fed history, not the full transcript. Events
+			// AFTER the marker replay normally on top. The full transcript is
+			// retained (non-destructive audit).
+			flushAssistant()
+			flushPendingTools()
+			var pe providers.Event
+			if err := json.Unmarshal(ev.Payload, &pe); err == nil && pe.ContextRecap != nil {
+				cr := pe.ContextRecap
+				keepN := cr.KeepN
+				if keepN < 0 {
+					keepN = 0
+				}
+				if keepN > len(messages) {
+					keepN = len(messages)
+				}
+				tail := append([]providers.Message(nil), messages[len(messages)-keepN:]...)
+				pinned := ""
+				if cr.KeepFirst && len(messages) > 0 {
+					for _, c := range messages[0].Content {
+						if c.Type == "text" {
+							pinned += c.Text
+						}
+					}
+				}
+				messages = loop.RecapMessages(pinned, cr.Recap, tail)
 			}
 			asstText.Reset()
 			asstTools = nil
@@ -6013,6 +6066,12 @@ func (s *Server) prepareSubRun(ctx context.Context, name, prompt, defID string, 
 	subCompaction := config.MergeCompaction(def.Compaction, tools.CompactionPolicy(ctx))
 	subCompaction = config.MergeCompaction(subCompaction, tools.CompactionOverride(ctx))
 	subCtx = tools.WithCompactionPolicy(subCtx, subCompaction)
+	// RFC CR: the layered-context policy inherits the same way — the parent's
+	// effective policy fills the gaps the child def leaves unset (parent-set fields
+	// win). No per-spawn override knob yet (P4). Stamped on subCtx so grandchildren
+	// inherit recursively, and passed to the sub-loop's RunOptions.
+	subContext := config.MergeContext(def.Context, tools.ContextPolicy(ctx))
+	subCtx = tools.WithContextPolicy(subCtx, subContext)
 	// RFC AH §4 — the load-bearing spawn invariant: a child's volume set is
 	// the NARROW-ONLY intersection of (child-declared) ∩ (parent's active
 	// bindings). A sub-agent can never gain a volume its parent lacks, and
@@ -6111,6 +6170,7 @@ func (s *Server) prepareSubRun(ctx context.Context, name, prompt, defID string, 
 		// a breeder varies temperature by FORKING a def, then spawning it).
 		Sampling:               def.Sampling,
 		Compaction:             subCompaction,
+		Context:                subContext,       // RFC CR: inherited layered-context policy
 		ContextPlugins:         s.contextPlugins, // RFC Z runtime-wide chain (sub-agents included; code-js exempt in the loop)
 		UserTier:               parentTier,
 		FallbackPolicy:         fbPolicy,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1074,6 +1074,14 @@ type AgentDef struct {
 	// child def fills gaps), overridable per-spawn via the Agent tool.
 	Compaction *Compaction `yaml:"compaction,omitempty"`
 
+	// Context is the per-agent layered-context / retention block (yaml/JSON
+	// `context:`, RFC CR). Selects the feed-side distillation strategy —
+	// `mode: append` (default, byte-identical) or `mode: recap` (L1 reasoning
+	// distillation). nil = append. Inherited down the spawn tree (parent-set
+	// fields win; a child def fills gaps), overridable per-spawn via the Agent
+	// tool — the same precedence as Compaction.
+	Context *Context `yaml:"context,omitempty"`
+
 	// Volumes is the RFC AH Phase 1 filesystem-volume binding list — the
 	// names of top-level `volumes:` entries the agent's file/exec tools
 	// (Read/Write/Edit/Glob/Grep/Bash/NotebookEdit) may resolve paths
@@ -1710,6 +1718,174 @@ func (c *Compaction) Validate() error {
 	}
 	if c.AutoCompactAtPct != nil && (*c.AutoCompactAtPct < 50 || *c.AutoCompactAtPct > 95) {
 		return fmt.Errorf("compaction.autocompact_at_pct %d out of range [50,95]", *c.AutoCompactAtPct)
+	}
+	return nil
+}
+
+// Context is the per-agent layered-context / retention block (the yaml/JSON
+// `context:` object, RFC CR). It selects the FEED-SIDE distillation strategy for
+// a run's growing history — how the model's per-step input is assembled from the
+// full (still-retained) transcript. The store side is untouched: the complete
+// transcript is always persisted for audit, replay, and facts-extraction; this
+// block changes only what is FED to the model.
+//
+// Every field is a pointer so "unset" (nil) is distinct from a meaningful value,
+// and so the per-field merge (parent/child/per-run/per-spawn) can tell "inherit"
+// from "explicitly set". nil = "append": today's behavior, byte-identical to
+// pre-feature (the separate `compaction:` block still governs L0 summarization).
+type Context struct {
+	// Mode selects the retention strategy:
+	//   "append" — the default. Full history is fed; the `compaction:` block may
+	//              still summarize at its threshold. Byte-identical to pre-feature.
+	//   "recap"  — L1 reasoning distillation: keep the re-derived preamble + the
+	//              last-N tool_use/tool_result pairs verbatim, and replace the
+	//              evicted assistant REASONING with a running recap note. Choosing
+	//              recap turns auto-recap ON (no separate enable flag). When set,
+	//              recap takes precedence over the `compaction:` auto-trigger.
+	//   "stateful" is reserved for structured execution state (RFC CR L2) and is
+	//              NOT yet available; Validate rejects it for now.
+	Mode *string `json:"mode,omitempty" yaml:"mode"`
+	// KeepLastN keeps the last N messages verbatim in recap mode, snapped to a
+	// clean user-turn boundary so a tool_use/tool_result pair is never split.
+	// Default 6. 0 = keep none. Mirrors compaction.keep_last_n.
+	KeepLastN *int `json:"keep_last_n,omitempty" yaml:"keep_last_n"`
+	// Reasoning is the R-layer policy in recap mode:
+	//   "recap" — the default: replace evicted assistant reasoning with a running
+	//             short recap ("what has been tried / concluded so far").
+	//   "drop"  — discard evicted reasoning with no recap (cheapest; no extra call).
+	//   "keep"  — leave evicted reasoning verbatim (recap is a no-op; the A/B
+	//             control that isolates the recap's contribution).
+	// Ignored in append mode.
+	Reasoning *string `json:"reasoning,omitempty" yaml:"reasoning"`
+	// RecapMaxChars bounds the running reasoning-recap note. Default 512.
+	RecapMaxChars *int `json:"recap_max_chars,omitempty" yaml:"recap_max_chars"`
+	// AutoRecapAtPct is the recap trigger: recap when used/window >= N%. Range
+	// 50..95; default 80. Only consulted in recap mode when the provider reports a
+	// context window. Mirrors compaction.autocompact_at_pct.
+	AutoRecapAtPct *int `json:"autorecap_at_pct,omitempty" yaml:"autorecap_at_pct"`
+}
+
+// Context mode values.
+const (
+	ContextModeAppend = "append"
+	ContextModeRecap  = "recap"
+)
+
+// Context defaults — applied at use-time when a field is unset (never baked into
+// the struct, so an unset field stays nil and the content hash stays byte-stable).
+const (
+	ContextDefaultKeepLastN      = 6
+	ContextDefaultReasoning      = "recap"
+	ContextDefaultRecapMaxChars  = 512
+	ContextDefaultAutoRecapAtPct = 80
+)
+
+// IsZero reports whether no context field is set (collapse to nil → byte-stable
+// content hashes for agents that don't configure a context block).
+func (c *Context) IsZero() bool {
+	return c == nil || (c.Mode == nil && c.KeepLastN == nil && c.Reasoning == nil &&
+		c.RecapMaxChars == nil && c.AutoRecapAtPct == nil)
+}
+
+// Clone deep-copies (every field is a pointer) so a merge never aliases an input.
+func (c *Context) Clone() *Context {
+	if c == nil {
+		return nil
+	}
+	out := &Context{}
+	if c.Mode != nil {
+		v := *c.Mode
+		out.Mode = &v
+	}
+	if c.KeepLastN != nil {
+		v := *c.KeepLastN
+		out.KeepLastN = &v
+	}
+	if c.Reasoning != nil {
+		v := *c.Reasoning
+		out.Reasoning = &v
+	}
+	if c.RecapMaxChars != nil {
+		v := *c.RecapMaxChars
+		out.RecapMaxChars = &v
+	}
+	if c.AutoRecapAtPct != nil {
+		v := *c.AutoRecapAtPct
+		out.AutoRecapAtPct = &v
+	}
+	return out
+}
+
+// MergeContext overlays `over` onto `base` PER FIELD — a field set in `over`
+// wins, an unset field keeps `base`'s value. Drives the AgentDef fork overlay,
+// the per-run override, AND the spawn precedence blend (a child fills the gaps
+// its parent left unset: MergeContext(childDef, parentSparse)). Returns nil only
+// when both inputs are empty; never aliases either input.
+func MergeContext(base, over *Context) *Context {
+	if base.IsZero() && over.IsZero() {
+		return nil
+	}
+	out := base.Clone()
+	if out == nil {
+		out = &Context{}
+	}
+	if over == nil {
+		return out
+	}
+	if over.Mode != nil {
+		v := *over.Mode
+		out.Mode = &v
+	}
+	if over.KeepLastN != nil {
+		v := *over.KeepLastN
+		out.KeepLastN = &v
+	}
+	if over.Reasoning != nil {
+		v := *over.Reasoning
+		out.Reasoning = &v
+	}
+	if over.RecapMaxChars != nil {
+		v := *over.RecapMaxChars
+		out.RecapMaxChars = &v
+	}
+	if over.AutoRecapAtPct != nil {
+		v := *over.AutoRecapAtPct
+		out.AutoRecapAtPct = &v
+	}
+	return out
+}
+
+// Validate checks per-field bounds. Returns a descriptive error naming the field.
+func (c *Context) Validate() error {
+	if c == nil {
+		return nil
+	}
+	if c.Mode != nil {
+		switch *c.Mode {
+		case ContextModeAppend, ContextModeRecap:
+			// ok
+		case "stateful":
+			return fmt.Errorf("context.mode %q is not yet available", *c.Mode)
+		default:
+			return fmt.Errorf("context.mode %q invalid (want append|recap)", *c.Mode)
+		}
+	}
+	if c.KeepLastN != nil && *c.KeepLastN < 0 {
+		return fmt.Errorf("context.keep_last_n %d must be >= 0", *c.KeepLastN)
+	}
+	if c.Reasoning != nil {
+		switch *c.Reasoning {
+		case "recap", "drop", "keep":
+			// ok
+		default:
+			return fmt.Errorf("context.reasoning %q invalid (want recap|drop|keep)", *c.Reasoning)
+		}
+	}
+	if c.RecapMaxChars != nil && *c.RecapMaxChars < 0 {
+		return fmt.Errorf("context.recap_max_chars %d must be >= 0", *c.RecapMaxChars)
+	}
+	if c.AutoRecapAtPct != nil && (*c.AutoRecapAtPct < 50 || *c.AutoRecapAtPct > 95) {
+		return fmt.Errorf("context.autorecap_at_pct %d out of range [50,95]", *c.AutoRecapAtPct)
 	}
 	return nil
 }
@@ -5149,6 +5325,9 @@ func mergeAgentDef(base, override AgentDef) AgentDef {
 	if !override.Compaction.IsZero() {
 		out.Compaction = MergeCompaction(out.Compaction, override.Compaction)
 	}
+	if !override.Context.IsZero() {
+		out.Context = MergeContext(out.Context, override.Context)
+	}
 	if override.Providers != nil {
 		out.Providers = override.Providers
 	}
@@ -6082,6 +6261,9 @@ func validate(c *Config) error {
 			return fmt.Errorf("agent %q: %w", name, err)
 		}
 		if err := agent.Compaction.Validate(); err != nil {
+			return fmt.Errorf("agent %q: %w", name, err)
+		}
+		if err := agent.Context.Validate(); err != nil {
 			return fmt.Errorf("agent %q: %w", name, err)
 		}
 		if hasTier && !validTierNames[agent.Tier] {

--- a/internal/config/context_test.go
+++ b/internal/config/context_test.go
@@ -1,0 +1,170 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+// MergeContext overlays `over` onto `base` per field — the building block for the
+// spawn precedence blend (per-spawn > parent-inherited > child def), same as
+// MergeCompaction.
+func TestMergeContext_PerFieldAndPrecedence(t *testing.T) {
+	childDef := &Context{KeepLastN: ptrI2(8), RecapMaxChars: ptrI2(256), Reasoning: ptrS("drop")}
+	parent := &Context{Mode: ptrS(ContextModeRecap), KeepLastN: ptrI2(4)} // parent sets mode + keep_last_n
+	override := &Context{RecapMaxChars: ptrI2(512)}                       // per-spawn changes the budget
+
+	eff := MergeContext(MergeContext(childDef, parent), override)
+	if eff.Mode == nil || *eff.Mode != ContextModeRecap {
+		t.Errorf("mode: parent-set should win, got %v", eff.Mode)
+	}
+	if eff.KeepLastN == nil || *eff.KeepLastN != 4 {
+		t.Errorf("keep_last_n: parent-set (4) should win over child (8), got %v", eff.KeepLastN)
+	}
+	if eff.Reasoning == nil || *eff.Reasoning != "drop" {
+		t.Errorf("reasoning: parent unset → child def (drop) fills the gap, got %v", eff.Reasoning)
+	}
+	if eff.RecapMaxChars == nil || *eff.RecapMaxChars != 512 {
+		t.Errorf("recap_max_chars: per-spawn override (512) should win, got %v", eff.RecapMaxChars)
+	}
+}
+
+func TestMergeContext_NilInputs(t *testing.T) {
+	if MergeContext(nil, nil) != nil {
+		t.Error("merge(nil,nil) should be nil")
+	}
+	out := MergeContext(nil, &Context{KeepLastN: ptrI2(3)})
+	if out == nil || out.KeepLastN == nil || *out.KeepLastN != 3 {
+		t.Errorf("merge(nil, x) should be x: %+v", out)
+	}
+}
+
+func TestContext_Validate(t *testing.T) {
+	bad := []*Context{
+		{Mode: ptrS("stateful")},       // reserved, not yet available
+		{Mode: ptrS("bogus")},          // unknown
+		{Reasoning: ptrS("summarize")}, // unknown R-policy
+		{KeepLastN: ptrI2(-1)},         // < 0
+		{RecapMaxChars: ptrI2(-1)},     // < 0
+		{AutoRecapAtPct: ptrI2(40)},    // < 50
+		{AutoRecapAtPct: ptrI2(99)},    // > 95
+	}
+	for i, c := range bad {
+		if err := c.Validate(); err == nil {
+			t.Errorf("case %d (%+v): expected a validation error", i, c)
+		}
+	}
+	for _, m := range []string{ContextModeAppend, ContextModeRecap} {
+		if err := (&Context{Mode: ptrS(m)}).Validate(); err != nil {
+			t.Errorf("mode %q should be valid: %v", m, err)
+		}
+	}
+	for _, r := range []string{"recap", "drop", "keep"} {
+		if err := (&Context{Reasoning: ptrS(r)}).Validate(); err != nil {
+			t.Errorf("reasoning %q should be valid: %v", r, err)
+		}
+	}
+	if (*Context)(nil).Validate() != nil {
+		t.Error("nil context should validate")
+	}
+}
+
+// nonZeroContext sets EVERY field to a non-zero, VALIDATION-PASSING value via
+// reflection, so a newly added field is populated without anyone remembering to
+// update this test. String enum fields get a valid member by name.
+func nonZeroContext(t *testing.T) *Context {
+	t.Helper()
+	c := &Context{}
+	v := reflect.ValueOf(c).Elem()
+	vt := v.Type()
+	for i := 0; i < v.NumField(); i++ {
+		f := v.Field(i)
+		name := vt.Field(i).Name
+		if f.Kind() != reflect.Ptr {
+			t.Fatalf("Context.%s is not a pointer; this test assumes the all-pointer shape that makes unset distinguishable from zero", name)
+		}
+		elem := reflect.New(f.Type().Elem())
+		switch elem.Elem().Kind() {
+		case reflect.Int:
+			// In-range for autorecap_at_pct (50..95); fine for the others.
+			elem.Elem().SetInt(50)
+		case reflect.String:
+			switch name {
+			case "Mode":
+				elem.Elem().SetString(ContextModeRecap)
+			case "Reasoning":
+				elem.Elem().SetString("recap")
+			default:
+				elem.Elem().SetString("x")
+			}
+		default:
+			t.Fatalf("Context.%s has unhandled kind %s — extend this helper", name, elem.Elem().Kind())
+		}
+		f.Set(elem)
+	}
+	return c
+}
+
+// TestContext_CloneAndMergeCoverEveryField guards sub-struct drift: mergeAgentDef
+// and lookup.SubstrateAgentDef both carry *Context WHOLESALE, so a field added to
+// the struct but forgotten in Clone / MergeContext / IsZero is silently dropped on
+// every fork and spawn-inherited override — with no compile error. Reflective on
+// purpose: it fails for a field nobody remembered to add.
+func TestContext_CloneAndMergeCoverEveryField(t *testing.T) {
+	full := nonZeroContext(t)
+	ft := reflect.TypeOf(Context{})
+
+	t.Run("Clone", func(t *testing.T) {
+		got := reflect.ValueOf(full.Clone()).Elem()
+		want := reflect.ValueOf(full).Elem()
+		for i := 0; i < ft.NumField(); i++ {
+			name := ft.Field(i).Name
+			g, w := got.Field(i), want.Field(i)
+			if g.IsNil() {
+				t.Errorf("Clone() dropped Context.%s — a fork setting it loses the setting", name)
+				continue
+			}
+			if !reflect.DeepEqual(g.Elem().Interface(), w.Elem().Interface()) {
+				t.Errorf("Clone() Context.%s = %v, want %v", name, g.Elem(), w.Elem())
+			}
+			if g.Pointer() == w.Pointer() {
+				t.Errorf("Clone() aliased Context.%s instead of copying it", name)
+			}
+		}
+	})
+
+	t.Run("MergeContext", func(t *testing.T) {
+		got := reflect.ValueOf(MergeContext(&Context{}, full)).Elem()
+		want := reflect.ValueOf(full).Elem()
+		for i := 0; i < ft.NumField(); i++ {
+			name := ft.Field(i).Name
+			g := got.Field(i)
+			if g.IsNil() {
+				t.Errorf("MergeContext() never overlays Context.%s — an override of it is SILENTLY DISCARDED", name)
+				continue
+			}
+			if !reflect.DeepEqual(g.Elem().Interface(), want.Field(i).Elem().Interface()) {
+				t.Errorf("MergeContext() Context.%s = %v, want %v", name, g.Elem(), want.Field(i).Elem())
+			}
+		}
+	})
+
+	t.Run("IsZero", func(t *testing.T) {
+		fv := reflect.ValueOf(full).Elem()
+		for i := 0; i < ft.NumField(); i++ {
+			only := &Context{}
+			reflect.ValueOf(only).Elem().Field(i).Set(fv.Field(i))
+			if only.IsZero() {
+				t.Errorf("IsZero() ignores Context.%s — a def setting only that field collapses to nil", ft.Field(i).Name)
+			}
+		}
+		if !(&Context{}).IsZero() || !(*Context)(nil).IsZero() {
+			t.Error("an all-unset / nil Context must be zero, or every pre-feature agent re-hashes")
+		}
+	})
+
+	t.Run("Validate accepts the all-set form", func(t *testing.T) {
+		if err := full.Validate(); err != nil {
+			t.Errorf("the all-fields-set Context failed Validate: %v", err)
+		}
+	})
+}

--- a/internal/lookup/agent.go
+++ b/internal/lookup/agent.go
@@ -188,10 +188,13 @@ type SubstrateAgentDef struct {
 	Sampling *config.Sampling `json:"sampling,omitempty"`
 	// Compaction: per-agent context-compaction settings (mirrors config.Compaction
 	// / mergedDef).
-	Compaction       *config.Compaction `json:"compaction,omitempty"`
-	MaxTokens        int                `json:"max_tokens,omitempty"`
-	MaxContextTokens int                `json:"max_context_tokens,omitempty"` // RFC CJ; content-identifying
-	MaxIterations    int                `json:"max_iterations,omitempty"`
+	Compaction *config.Compaction `json:"compaction,omitempty"`
+	// Context: per-agent layered-context / retention block (mirrors config.Context
+	// / mergedDef; RFC CR).
+	Context          *config.Context `json:"context,omitempty"`
+	MaxTokens        int             `json:"max_tokens,omitempty"`
+	MaxContextTokens int             `json:"max_context_tokens,omitempty"` // RFC CJ; content-identifying
+	MaxIterations    int             `json:"max_iterations,omitempty"`
 	// UnboundedIterations lifts the MaxIterations soft-cap for an LLM agent
 	// (interactive runs). Mirrors mergedDef; the drift test pins parity.
 	UnboundedIterations bool `json:"unbounded_iterations,omitempty"`
@@ -285,6 +288,7 @@ func (s SubstrateAgentDef) ToConfigDef() config.AgentDef {
 		Effort:                s.Effort,
 		Sampling:              s.Sampling,
 		Compaction:            s.Compaction,
+		Context:               s.Context,
 		MaxTokens:             s.MaxTokens,
 		MaxContextTokens:      s.MaxContextTokens,
 		MaxIterations:         s.MaxIterations,

--- a/internal/lookup/agent_test.go
+++ b/internal/lookup/agent_test.go
@@ -285,6 +285,7 @@ func TestAgent_DriftDetection(t *testing.T) {
 		"effort":                  true,
 		"sampling":                true, // per-agent LLM sampling params (temperature, top_p, …)
 		"compaction":              true, // per-agent context-compaction settings
+		"context":                 true, // RFC CR — per-agent layered-context / retention block (content-identifying; mirror mergedDef)
 		"max_tokens":              true,
 		"max_context_tokens":      true, // RFC CJ — per-agent context window (content-identifying; mirror mergedDef)
 		"max_iterations":          true,

--- a/internal/loop/context_recap_test.go
+++ b/internal/loop/context_recap_test.go
@@ -1,0 +1,339 @@
+package loop
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/steer"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// recapMode builds a resolved context policy in recap mode with the given tuning.
+func recapMode(keepLastN int, reasoning string) *config.Context {
+	m := config.ContextModeRecap
+	c := &config.Context{Mode: &m}
+	if keepLastN >= 0 {
+		c.KeepLastN = &keepLastN
+	}
+	if reasoning != "" {
+		c.Reasoning = &reasoning
+	}
+	return c
+}
+
+func TestContextRecapMode(t *testing.T) {
+	if contextRecapMode(nil) {
+		t.Error("nil context is append, not recap")
+	}
+	if contextRecapMode(&config.Context{}) {
+		t.Error("no mode is append, not recap")
+	}
+	appendM := config.ContextModeAppend
+	if contextRecapMode(&config.Context{Mode: &appendM}) {
+		t.Error("mode=append is not recap")
+	}
+	if !contextRecapMode(recapMode(-1, "")) {
+		t.Error("mode=recap should be recap")
+	}
+}
+
+// shouldAutoRecap mirrors shouldAutoCompact: fires at the threshold, is
+// self-enabling (mode=recap needs no separate flag), honors the window guard +
+// the one-iteration debounce, and never fires outside recap mode.
+func TestShouldAutoRecap(t *testing.T) {
+	on := recapMode(6, "recap")
+	on.AutoRecapAtPct = cptr(80)
+	if !shouldAutoRecap(on, 850, 1000, 5, -2) {
+		t.Error("85% should fire")
+	}
+	if shouldAutoRecap(on, 700, 1000, 5, -2) {
+		t.Error("70% should not fire")
+	}
+	if shouldAutoRecap(on, 900, 0, 5, -2) {
+		t.Error("unknown window (0) should not fire")
+	}
+	if shouldAutoRecap(on, 900, 1000, 3, 2) {
+		t.Error("one-iteration debounce should suppress")
+	}
+	// append mode never auto-recaps, even over threshold.
+	appendM := config.ContextModeAppend
+	if shouldAutoRecap(&config.Context{Mode: &appendM, AutoRecapAtPct: cptr(80)}, 900, 1000, 5, -2) {
+		t.Error("append mode must not auto-recap")
+	}
+	if shouldAutoRecap(nil, 900, 1000, 5, -2) {
+		t.Error("nil context must not auto-recap")
+	}
+	// Default threshold (80%) applies when AutoRecapAtPct is unset.
+	if !shouldAutoRecap(recapMode(6, "recap"), 810, 1000, 5, -2) {
+		t.Error("81% should fire at the default 80% threshold")
+	}
+}
+
+// RecapReasoning must use the RUNNING-recap prompt (bounded note), NOT the
+// compaction prompt's proportional target, bound its token cap to the char
+// budget, flatten the whole span, and offer no tools.
+func TestRecapReasoning_UsesBoundedRunningRecapPrompt(t *testing.T) {
+	p := &recapProbeProvider{reply: "counter=5; two SET ops applied."}
+	_, err := RecapReasoning(context.Background(), p, "m",
+		[]providers.Message{userMsg("SET counter 3"), asstMsg("ok"), userMsg("ADD 2")}, 512)
+	if err != nil {
+		t.Fatalf("RecapReasoning: %v", err)
+	}
+	sys := p.req.System[0].Text
+	if !strings.Contains(sys, "running RECAP") {
+		t.Errorf("recap prompt should ask for a running recap, got %q", sys)
+	}
+	if !strings.Contains(sys, strconv.Itoa(512)) {
+		t.Errorf("recap prompt should carry the %d-char budget, got %q", 512, sys)
+	}
+	if strings.Contains(sys, "% of the original length") {
+		t.Errorf("recap must not reuse the compaction proportional target: %q", sys)
+	}
+	// Token cap is bounded and leaves headroom over the char budget.
+	if p.req.MaxTokens == 0 || p.req.MaxTokens*4 <= 512 {
+		t.Errorf("MaxTokens=%d, want a bound with headroom over 512 chars", p.req.MaxTokens)
+	}
+	// Whole span flattened into one user message; no tools.
+	if len(p.req.Messages) != 1 || p.req.Messages[0].Role != "user" {
+		t.Fatalf("want one flattened user message, got %+v", p.req.Messages)
+	}
+	body := p.req.Messages[0].Content[0].Text
+	for _, w := range []string{"SET counter 3", "ADD 2"} {
+		if !strings.Contains(body, w) {
+			t.Errorf("flattened span missing %q: %q", w, body)
+		}
+	}
+	if len(p.req.Tools) != 0 {
+		t.Errorf("recap call must offer no tools, got %d", len(p.req.Tools))
+	}
+}
+
+// RecapMessages: the task is a user turn ON ITS OWN (no header to nest), the
+// recap is a SEPARATE assistant turn, and the kept tail is appended verbatim. An
+// empty recap (drop policy) omits the recap turn entirely.
+func TestRecapMessages_Shape(t *testing.T) {
+	tail := []providers.Message{userMsg("recent q"), asstMsg("recent a")}
+	msgs := RecapMessages("THE TASK", "THE RECAP", tail)
+	if len(msgs) != 4 {
+		t.Fatalf("got %d messages, want 4 (task + recap + 2 tail): %+v", len(msgs), msgs)
+	}
+	if msgs[0].Role != "user" || msgs[0].Content[0].Text != "THE TASK" {
+		t.Errorf("msg[0] must be the RAW task user turn (no header), got %q", msgs[0].Content[0].Text)
+	}
+	if msgs[1].Role != "assistant" || !strings.Contains(msgs[1].Content[0].Text, "THE RECAP") {
+		t.Errorf("msg[1] must be the recap assistant turn, got %+v", msgs[1])
+	}
+	if msgs[2].Content[0].Text != "recent q" || msgs[3].Content[0].Text != "recent a" {
+		t.Errorf("kept tail not appended verbatim: %+v", msgs[2:])
+	}
+	// drop policy: empty recap → no recap turn.
+	drop := RecapMessages("THE TASK", "", tail)
+	if len(drop) != 3 || drop[0].Content[0].Text != "THE TASK" || drop[1].Content[0].Text != "recent q" {
+		t.Errorf("empty recap must omit the recap turn: %+v", drop)
+	}
+}
+
+// maybeRecap folds the middle into a recap assistant turn, keeps the last-N tail
+// verbatim, and pins the task as its own user turn.
+func TestMaybeRecap_RecapsAndKeepsTail(t *testing.T) {
+	msgs := []providers.Message{userMsg("the task"), asstMsg("a1"), userMsg("q2"), asstMsg("a2"), userMsg("q3"), asstMsg("a3")}
+	opts := RunOptions{Provider: &steerProvider{}, Model: "x", Context: recapMode(2, "recap")}
+	out, did := maybeRecap(context.Background(), opts, msgs, 0, func(providers.Event) {}, "auto")
+	if !did {
+		t.Fatal("expected a recap distillation")
+	}
+	// [user(task), assistant(recap "ok"), q3, a3]
+	if len(out) != 4 {
+		t.Fatalf("got %d messages, want 4: %+v", len(out), out)
+	}
+	if out[0].Role != "user" || out[0].Content[0].Text != "the task" {
+		t.Errorf("task must be pinned raw as its own turn: %q", out[0].Content[0].Text)
+	}
+	if out[1].Role != "assistant" || !strings.Contains(out[1].Content[0].Text, "Progress recap") {
+		t.Errorf("recap must be a separate assistant turn: %+v", out[1])
+	}
+	if out[2].Content[0].Text != "q3" || out[3].Content[0].Text != "a3" {
+		t.Errorf("last-2 tail not kept verbatim: %+v", out[2:])
+	}
+}
+
+// THE load-bearing property: recap-mode keeps the fed prompt FLAT across repeated
+// distillations. After two recaps the pinned task turn is byte-identical (no
+// nesting), and the SECOND recap call is fed the FIRST recap turn (fold-forward),
+// so the recap accumulates without a separate running-state to thread or restore.
+func TestMaybeRecap_FlatAndFoldsForward(t *testing.T) {
+	p := &recapProbeProvider{reply: "RECAP-CONTENT"}
+	opts := RunOptions{Provider: p, Model: "x", Context: recapMode(2, "recap")}
+
+	msgs := []providers.Message{userMsg("the task"), asstMsg("a1"), userMsg("q2"), asstMsg("a2"), userMsg("q3"), asstMsg("a3")}
+	out1, did := maybeRecap(context.Background(), opts, msgs, 0, func(providers.Event) {}, "auto")
+	if !did {
+		t.Fatal("first recap did not fire")
+	}
+	task1 := out1[0].Content[0].Text
+
+	// New turns arrive, then a second recap.
+	out1 = append(out1, userMsg("q4"), asstMsg("a4"), userMsg("q5"), asstMsg("a5"))
+	out2, did := maybeRecap(context.Background(), opts, out1, 0, func(providers.Event) {}, "auto")
+	if !did {
+		t.Fatal("second recap did not fire")
+	}
+	task2 := out2[0].Content[0].Text
+
+	// Flat: the pinned task turn is byte-identical, not re-wrapped/nested.
+	if task1 != "the task" || task2 != "the task" {
+		t.Errorf("pinned task not flat across recaps: %q then %q (want %q both)", task1, task2, "the task")
+	}
+	// Fold-forward: the second recap call was fed the first recap's turn.
+	body := p.req.Messages[0].Content[0].Text
+	if !strings.Contains(body, "Progress recap") {
+		t.Errorf("second recap was not fed the prior recap turn (no fold-forward): %q", body)
+	}
+}
+
+// reasoning=drop makes NO provider call and drops the evicted span with no recap
+// turn — the cheapest policy.
+func TestMaybeRecap_DropMode(t *testing.T) {
+	p := &recapProbeProvider{reply: "SHOULD-NOT-BE-CALLED"}
+	opts := RunOptions{Provider: p, Model: "x", Context: recapMode(2, "drop")}
+	msgs := []providers.Message{userMsg("the task"), asstMsg("a1"), userMsg("q2"), asstMsg("a2"), userMsg("q3"), asstMsg("a3")}
+	out, did := maybeRecap(context.Background(), opts, msgs, 0, func(providers.Event) {}, "auto")
+	if !did {
+		t.Fatal("drop mode should still distil (drop the evicted span)")
+	}
+	if p.calls != 0 {
+		t.Errorf("drop mode must make NO recap call, got %d", p.calls)
+	}
+	// [user(task), q3, a3] — no recap turn.
+	if len(out) != 3 || out[0].Content[0].Text != "the task" || out[1].Content[0].Text != "q3" {
+		t.Errorf("drop mode shape wrong: %+v", out)
+	}
+}
+
+// reasoning=keep is a no-op: recap mode with keep distils nothing.
+func TestMaybeRecap_KeepMode(t *testing.T) {
+	p := &recapProbeProvider{reply: "x"}
+	opts := RunOptions{Provider: p, Model: "x", Context: recapMode(2, "keep")}
+	msgs := []providers.Message{userMsg("the task"), asstMsg("a1"), userMsg("q2"), asstMsg("a2"), userMsg("q3"), asstMsg("a3")}
+	out, did := maybeRecap(context.Background(), opts, msgs, 0, func(providers.Event) {}, "auto")
+	if did {
+		t.Error("keep mode must not distil")
+	}
+	if p.calls != 0 {
+		t.Errorf("keep mode must make no call, got %d", p.calls)
+	}
+	if len(out) != len(msgs) {
+		t.Errorf("keep mode must leave messages unchanged: %d != %d", len(out), len(msgs))
+	}
+}
+
+// A failed recap call changes nothing (the run keeps its history) and names the
+// failure via emit — the same fail-open invariant as compaction.
+func TestMaybeRecap_SurvivesRecapFailure(t *testing.T) {
+	opts := RunOptions{Provider: &errProvider{}, Model: "x", Context: recapMode(2, "recap")}
+	msgs := []providers.Message{userMsg("the task"), asstMsg("a1"), userMsg("q2"), asstMsg("a2"), userMsg("q3"), asstMsg("a3")}
+	var gotErr bool
+	out, did := maybeRecap(context.Background(), opts, msgs, 0, func(ev providers.Event) {
+		if ev.Type == providers.EventError {
+			gotErr = true
+		}
+	}, "auto")
+	if did {
+		t.Error("a failed recap must not distil")
+	}
+	if !gotErr {
+		t.Error("a failed recap must emit an error event")
+	}
+	if len(out) != len(msgs) {
+		t.Errorf("a failed recap must leave the history unchanged: %d != %d", len(out), len(msgs))
+	}
+}
+
+// errProvider always returns an error frame from Call.
+type errProvider struct{}
+
+func (p *errProvider) ID() string                                   { return "err-test" }
+func (p *errProvider) Probe(context.Context) error                  { return nil }
+func (p *errProvider) ListModels(context.Context) ([]string, error) { return nil, nil }
+func (p *errProvider) Capabilities() providers.Capabilities {
+	return providers.Capabilities{Streaming: true}
+}
+func (p *errProvider) Call(context.Context, providers.Request) (<-chan providers.Event, error) {
+	ch := make(chan providers.Event, 1)
+	ch <- providers.Event{Type: providers.EventError, Error: "boom"}
+	close(ch)
+	return ch, nil
+}
+
+// Full-loop integration: in recap mode the trigger gate routes to maybeRecap (not
+// compaction) when the previous turn's footprint crosses the threshold, emits
+// EventContextRecap, and the next request runs on the shrunk history. This is the
+// one seam the unit tests above don't cover — that Run() actually wires recapMode
+// to the gate. keep_last_n=0 forces a distil on the short interactive history.
+func TestRun_RecapMode_AutoRecapsAndShrinks(t *testing.T) {
+	q := make(chan steer.Message, 4)
+	parked := make(chan struct{}, 8)
+	recapped := make(chan struct{}, 8)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	prov := &ctxUsageProvider{firstIn: 164000, maxCtx: 200000} // turn 0 → 82% footprint
+	m := config.ContextModeRecap
+	done := make(chan struct{})
+	go func() {
+		_, _ = Run(ctx, RunOptions{
+			Provider:    prov,
+			Model:       "x",
+			Tools:       []tools.Tool{noopTool{}},
+			Dispatcher:  tools.NewDispatcher([]tools.Tool{noopTool{}}),
+			Segments:    steerSegs(),
+			SteerQueue:  q,
+			Interactive: true,
+			Context:     &config.Context{Mode: &m, KeepLastN: cptr(0), AutoRecapAtPct: cptr(50)},
+			OnEvent: func(ev providers.Event) {
+				switch ev.Type {
+				case providers.EventAwaitingInput:
+					parked <- struct{}{}
+				case providers.EventContextRecap:
+					recapped <- struct{}{}
+				case providers.EventContextCompaction:
+					t.Errorf("recap mode must NOT emit a compaction marker")
+				}
+			},
+		})
+		close(done)
+	}()
+	waitOn := func(ch <-chan struct{}, what string) {
+		t.Helper()
+		select {
+		case <-ch:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("%s: timed out", what)
+		}
+	}
+	waitOn(parked, "initial end_turn park")
+	q <- steer.Message{Text: "continue"} // a real turn → the recap gate fires at its top
+	waitOn(recapped, "auto-recap fired")
+	waitOn(parked, "re-park after the recapped turn")
+
+	prov.mu.Lock()
+	seen := append([]int(nil), prov.seenUsed...)
+	prov.mu.Unlock()
+	if len(seen) < 2 {
+		t.Fatalf("want >=2 provider calls, got %d (%v)", len(seen), seen)
+	}
+	if post := seen[len(seen)-1]; post >= prov.firstIn {
+		t.Errorf("post-recap Context op=self footprint = %d; want the small recapped size, not the pre-recap %d", post, prov.firstIn)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("run did not terminate after cancel")
+	}
+}

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -188,6 +188,15 @@ type RunOptions struct {
 	// applied at use-time (see config.CompactionDefault*).
 	Compaction *config.Compaction
 
+	// Context carries the resolved per-agent layered-context / retention settings
+	// (already merged: per-run > parent-inherited > child def; RFC CR). When
+	// Mode=="recap" and the provider reports a context window, the loop distils the
+	// fed history by reasoning-recap at a top-of-iteration boundary once used/window
+	// crosses AutoRecapAtPct — replacing the append+compaction path for the run.
+	// nil / Mode=="append" = today's behavior. Defaults applied at use-time (see
+	// config.ContextDefault*).
+	Context *config.Context
+
 	// ContextPlugins is the runtime-wide context-transform chain (RFC Z / F43):
 	// fast, built-in transforms applied to a COPY of the outbound request each
 	// turn (e.g. secret redaction), in order. nil/empty = no chain. Built once
@@ -1306,6 +1315,167 @@ func bankDiscardedSpan(ctx context.Context, opts RunOptions, dropped []providers
 	return &providers.MemoryBankedInfo{PendingID: id, Messages: len(dropped)}
 }
 
+// --- RFC CR L1: reasoning-recap distillation ---
+//
+// Recap mode is a sibling of compaction on the retention spectrum. It reuses the
+// same boundary-snapping (CompactionSplit) and window safety cap so the kept tail
+// never orphans a tool_use/tool_result pair, but differs in two ways: the middle
+// span becomes a bounded RUNNING recap (folded incrementally into the prior recap
+// — O(1) per step, not a fresh proportional summary each time), and the recent
+// tool_use/tool_result pairs are kept VERBATIM rather than summarized. The store
+// side is untouched — the full transcript is always retained.
+
+// contextRecapMode reports whether the resolved context policy selects L1 recap.
+func contextRecapMode(cx *config.Context) bool {
+	return cx != nil && cx.Mode != nil && *cx.Mode == config.ContextModeRecap
+}
+
+// RecapMessages builds the replacement conversation for a recap distillation:
+//
+//	[user(pinnedTask)?] ++ [assistant("[Progress recap]…" + recap)?] ++ keptTail
+//
+// The task is a user turn ON ITS OWN (never fused with the recap), so it stays a
+// fixed size across distillations and the fed prompt stays FLAT — the O(T) property
+// the benchmark proved. The recap is a separate ASSISTANT turn (the agent's own
+// progress note): on the NEXT distillation it falls INTO the evicted span and is
+// folded forward by the recap call, so the recap accumulates correctly with no
+// separate running-state to thread or restore on resume. keptTail is snapped to a
+// clean user-turn boundary (CompactionSplit) so nothing orphans a tool cycle; when
+// there is something to distil it is non-empty and the sequence ends on a real turn.
+func RecapMessages(pinnedTask, recap string, keptTail []providers.Message) []providers.Message {
+	var out []providers.Message
+	if strings.TrimSpace(pinnedTask) != "" {
+		// The task is emitted RAW (no wrapping header). It is its own turn, so it
+		// reads as the original task without one — and, crucially, re-pinning it
+		// next cycle via messageText(messages[0]) then yields the SAME text, so the
+		// pinned turn stays a fixed size. A header would nest on every distillation.
+		out = append(out, providers.Message{Role: "user",
+			Content: []providers.ContentBlock{{Type: "text", Text: pinnedTask}}})
+	}
+	if strings.TrimSpace(recap) != "" {
+		out = append(out, providers.Message{Role: "assistant",
+			Content: []providers.ContentBlock{{Type: "text",
+				Text: "[Progress recap — what I have done and concluded so far; established context for everything before the recent steps below:]\n\n" + recap}}})
+	}
+	return append(out, keptTail...)
+}
+
+// recapReasoningPrompt builds the system prompt for a RUNNING progress recap
+// bounded to maxChars. Unlike compactionPrompt (a proportional N% summary) it asks
+// for a fixed-size running note. The newly-evicted span it is fed already CONTAINS
+// the prior recap (as the assistant turn RecapMessages emitted last time), so the
+// call is incremental — it folds the small prior note plus the new steps into an
+// updated note, never re-reading the whole history. That, plus the flat pinned
+// task, is what keeps recap-mode cost O(T).
+func recapReasoningPrompt(maxChars int) string {
+	if maxChars <= 0 {
+		maxChars = config.ContextDefaultRecapMaxChars
+	}
+	return fmt.Sprintf("You maintain a running RECAP of an agent's progress on a task, carried forward as its working context. "+
+		"The input may include an earlier '[Progress recap …]' note plus the NEW steps taken since. Produce an UPDATED recap, at most %d characters, "+
+		"that folds the new steps into the old: preserve the goal, decisions, established facts and values, tool results that still "+
+		"matter, and the current state; drop verbose reasoning and superseded attempts. Write durable prose the agent can rely on to "+
+		"continue. Output ONLY the recap — no preamble.", maxChars)
+}
+
+// RecapReasoning makes ONE provider call to fold the newly-evicted span (which
+// already contains the prior recap turn) into an updated recap bounded near
+// maxChars. Reuses summarizeWith (NO tools offered → can't re-enter the loop).
+//
+// It is fed the whole evicted span (reasoning + tool_use/tool_result), not only
+// the assistant's prose: on a procedural task the progress IS in the tool results
+// (the counter values, the fetched facts), so recapping prose alone would lose
+// exactly what the next step needs. The recap OUTPUT is what replaces the verbose
+// reasoning — that is the "reasoning distillation".
+func RecapReasoning(ctx context.Context, provider providers.Provider, model string, evicted []providers.Message, maxChars int) (string, error) {
+	maxTok := 0
+	if maxChars > 0 {
+		maxTok = maxChars/4 + 64 // chars→tokens, generous so a compliant model finishes its sentence
+	}
+	return summarizeWith(ctx, provider, model, evicted, recapReasoningPrompt(maxChars), "Progress to recap:", maxTok)
+}
+
+// shouldAutoRecap mirrors shouldAutoCompact for recap mode: the mode is recap,
+// the provider reports a window, the previous turn's footprint crossed the
+// trigger percentage, and we didn't just distil (one-iteration debounce). Recap
+// mode is self-enabling — choosing the mode turns auto-recap on (no separate
+// Enabled flag, unlike compaction).
+func shouldAutoRecap(cx *config.Context, used, window, iter, lastIter int) bool {
+	if !contextRecapMode(cx) {
+		return false
+	}
+	if window <= 0 || used <= 0 || iter <= lastIter+1 {
+		return false
+	}
+	at := config.ContextDefaultAutoRecapAtPct
+	if cx.AutoRecapAtPct != nil {
+		at = *cx.AutoRecapAtPct
+	}
+	return used*100 >= window*at
+}
+
+// maybeRecap runs an INLINE recap distillation (RFC CR L1): fold the evicted span
+// into a fresh running recap, keep the last-N tail verbatim, and replace
+// `messages`. Returns the (possibly unchanged) slice and whether it distilled. A
+// failed recap call changes nothing (logged via emit). The first user turn (the
+// task) is always pinned — the preamble the paper under-counts. No running-state
+// is threaded: the prior recap lives in the evicted span (see RecapMessages) and
+// is folded forward by the recap call, so replay/resume rebuild identically.
+func maybeRecap(ctx context.Context, opts RunOptions, messages []providers.Message, window int, emit func(providers.Event), trigger string) ([]providers.Message, bool) {
+	cx := opts.Context
+	keepLastN := config.ContextDefaultKeepLastN
+	reasoning := config.ContextDefaultReasoning
+	maxChars := config.ContextDefaultRecapMaxChars
+	keepFirst := config.CompactionDefaultKeepFirst // pin the task verbatim, like compaction
+	model := opts.Model
+	if cx != nil {
+		if cx.KeepLastN != nil {
+			keepLastN = *cx.KeepLastN
+		}
+		if cx.Reasoning != nil {
+			reasoning = *cx.Reasoning
+		}
+		if cx.RecapMaxChars != nil {
+			maxChars = *cx.RecapMaxChars
+		}
+	}
+	if reasoning == "keep" {
+		return messages, false // no distillation in keep mode
+	}
+	firstIdx, cut, ok := CompactionSplit(messages, keepLastN, keepFirst)
+	if !ok {
+		return messages, false
+	}
+	if window > 0 {
+		cut = capKeptTailToWindow(messages, cut, window*compactionKeptTailBudgetPct/100)
+	}
+	newRecap := ""
+	if reasoning == "recap" {
+		r, err := RecapReasoning(ctx, opts.Provider, model, messages[firstIdx:cut], maxChars)
+		if err != nil || strings.TrimSpace(r) == "" {
+			if err != nil {
+				emit(providers.Event{Type: providers.EventError, Error: "context recap failed (" + trigger + "): " + err.Error()})
+			}
+			return messages, false
+		}
+		newRecap = strings.TrimSpace(r)
+	}
+	// reasoning=="drop": no recap call; the evicted span is dropped with no note.
+	before := estimateMessageTokens(messages)
+	pinned := ""
+	if firstIdx > 0 {
+		pinned = messageText(messages[0])
+	}
+	out := RecapMessages(pinned, newRecap, messages[cut:])
+	after := estimateMessageTokens(out)
+	emit(providers.Event{Type: providers.EventContextRecap,
+		ContextRecap: &providers.ContextRecapEventInfo{
+			Recap: newRecap, KeepN: len(messages) - cut, KeepFirst: firstIdx > 0,
+			BeforeTokens: before, AfterTokens: after, Trigger: trigger, Reasoning: reasoning}})
+	lcotel.RecordCompactionCtx(ctx, "recap:"+trigger, before, after)
+	return out, true
+}
+
 func Run(ctx context.Context, opts RunOptions) (RunResult, error) {
 	// An interactive run is operator-driven and Cancel-bounded: each operator
 	// turn (and each end_turn park awaiting input) consumes a loop iteration,
@@ -1429,6 +1599,11 @@ func Run(ctx context.Context, opts RunOptions) (RunResult, error) {
 	ctx = tools.WithCompactRequest(ctx, &compactRequested)
 	var lastCtxTokens, lastWindow int
 	lastCompactIter := -2
+	// L1 recap (RFC CR) reuses lastCompactIter to debounce — the two distillation
+	// modes are mutually exclusive per run. No running-recap state is threaded: the
+	// prior recap rides the transcript (see RecapMessages), so replay/resume are
+	// byte-identical without restoring loop state.
+	recapMode := contextRecapMode(opts.Context)
 
 	var totalUsage providers.Usage
 	var finalText string
@@ -1586,18 +1761,32 @@ outerLoop:
 			}
 		}
 
-		// Auto / self-requested compaction — also a clean boundary (drainSteer
-		// ran; no tool cycle is mid-flight). Fires when the agent asked
-		// (Context op=compact) OR the PREVIOUS iteration's context footprint
-		// crossed the configured threshold. The loop summarizes inline and
-		// replaces the history; the smaller next request self-debounces the
-		// threshold. Applies to ALL runs (interactive + autonomous).
-		if selfReq := compactRequested.Swap(false); selfReq || shouldAutoCompact(opts.Compaction, lastCtxTokens, lastWindow, iter, lastCompactIter) {
+		// Auto / self-requested context distillation — also a clean boundary
+		// (drainSteer ran; no tool cycle is mid-flight). Fires when the agent asked
+		// (Context op=compact) OR the PREVIOUS iteration's footprint crossed the
+		// configured threshold. In recap mode (RFC CR L1) the loop recaps inline;
+		// otherwise it compacts (L0). The two are mutually exclusive per run —
+		// choosing recap bypasses the compaction auto-trigger. The smaller next
+		// request self-debounces. Applies to ALL runs (interactive + autonomous).
+		selfReq := compactRequested.Swap(false)
+		var distill bool
+		if recapMode {
+			distill = selfReq || shouldAutoRecap(opts.Context, lastCtxTokens, lastWindow, iter, lastCompactIter)
+		} else {
+			distill = selfReq || shouldAutoCompact(opts.Compaction, lastCtxTokens, lastWindow, iter, lastCompactIter)
+		}
+		if distill {
 			trigger := "auto"
 			if selfReq {
 				trigger = "self"
 			}
-			if newMsgs, did := maybeAutoCompact(iterCtx, opts, messages, lastWindow, emit, trigger); did {
+			if recapMode {
+				if newMsgs, did := maybeRecap(iterCtx, opts, messages, lastWindow, emit, trigger); did {
+					messages = newMsgs
+					lastCompactIter = iter
+					lastCtxTokens = estimateMessageTokens(messages)
+				}
+			} else if newMsgs, did := maybeAutoCompact(iterCtx, opts, messages, lastWindow, emit, trigger); did {
 				messages = newMsgs
 				lastCompactIter = iter
 				// Compaction shrank the history; refresh the footprint so op=self

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -525,6 +525,16 @@ const (
 	// full history. The full transcript is retained (non-destructive audit).
 	EventContextCompaction EventType = "context_compaction"
 
+	// EventContextRecap marks where a run's fed history was distilled by L1
+	// reasoning-recap (RFC CR `context.mode: recap`): the span before the kept
+	// tail is replaced by a running progress recap, and the recent tool_use/
+	// tool_result pairs are kept verbatim. Sibling of EventContextCompaction — the
+	// loop emits it (persisted + forwarded) when it recaps at an iteration
+	// boundary; replayTranscript RESETS to the recap form on replay so a resume
+	// rebuild reconstructs the identical fed history. The full transcript is
+	// retained (non-destructive audit).
+	EventContextRecap EventType = "context_recap"
+
 	// EventLimit carries a per-scope token-budget crossing (RFC AW): a soft
 	// crossing (warn, run continues) or a hard crossing (a mid-run notice; the
 	// run still finishes, but the NEXT run for the scope is refused at
@@ -614,6 +624,11 @@ type Event struct {
 	// ContextCompaction carries the structured payload on EventContextCompaction
 	// (the conversation summary that replaces prior history). Nil otherwise.
 	ContextCompaction *ContextCompactionEventInfo `json:"context_compaction,omitempty"`
+
+	// ContextRecap carries the structured payload on EventContextRecap (the
+	// running reasoning-recap that replaces prior history in L1 recap mode, RFC
+	// CR). Nil otherwise.
+	ContextRecap *ContextRecapEventInfo `json:"context_recap,omitempty"`
 
 	// Limit carries the structured payload on EventLimit (a per-scope
 	// token-budget crossing, RFC AW). Nil on all other event types.
@@ -849,6 +864,30 @@ type ContextCompactionEventInfo struct {
 	// in, which is the default. Additive and ignored by replay — banking already
 	// happened when the compaction first ran, so a rebuild must not repeat it.
 	MemoryBanked *MemoryBankedInfo `json:"memory_banked,omitempty"`
+}
+
+// ContextRecapEventInfo is the structured payload on EventContextRecap (RFC CR
+// L1 reasoning-recap). Recap is the running progress note that replaces the span
+// before the kept tail; Before/AfterTokens are the rough footprint before vs
+// after, for the operator-facing "context recapped (N→M)" line. replayTranscript
+// reads Recap + KeepN/KeepFirst to reconstruct the identical fed form.
+type ContextRecapEventInfo struct {
+	// Recap is the running progress recap that seeds the rebuilt history. On
+	// replay it is restored verbatim AND becomes the loop's running-recap state,
+	// so the NEXT recap folds into it (the cumulative O(1)-per-step property).
+	Recap        string `json:"recap"`
+	BeforeTokens int    `json:"before_tokens,omitempty"`
+	AfterTokens  int    `json:"after_tokens,omitempty"`
+	// KeepN / KeepFirst record how much recent history was kept verbatim and
+	// whether the first user turn (the task) was pinned — replayTranscript reads
+	// these to reconstruct the identical recapped form.
+	KeepN     int  `json:"keep_n,omitempty"`
+	KeepFirst bool `json:"keep_first,omitempty"`
+	// Trigger is "auto" | "self" — which path fired the recap. Metrics/UI only.
+	Trigger string `json:"trigger,omitempty"`
+	// Reasoning echoes the R-layer policy that produced this ("recap" | "drop").
+	// Informational; replay uses Recap directly.
+	Reasoning string `json:"reasoning,omitempty"`
 }
 
 // MemoryBankedInfo is the outcome of a compaction's memory flush. It is on the

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -274,6 +274,11 @@ type RunInput struct {
 	// FIELD over the agent's own Compaction. nil = inherit the agent's entirely.
 	Compaction *config.Compaction
 
+	// Context is an optional per-RUN layered-context / retention override (RFC CR),
+	// merged PER FIELD over the agent's own Context. nil = inherit the agent's
+	// entirely.
+	Context *config.Context
+
 	// MaxContextTokens is an optional per-RUN context-WINDOW override (RFC CJ).
 	// > 0 wins over the agent's own max_context_tokens; 0 inherits it. The server
 	// resolves the merge (config.MergeMaxContextTokens) and passes the winner to

--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -867,6 +867,10 @@ type mergedDef struct {
 	// Compaction: per-agent context-compaction settings. Same PER-FIELD overlay +
 	// content-identifying treatment as Sampling.
 	Compaction *config.Compaction `json:"compaction,omitempty"`
+	// Context: per-agent layered-context / retention block (RFC CR). Same
+	// PER-FIELD overlay + content-identifying treatment as Compaction; also
+	// inherited down the spawn tree.
+	Context *config.Context `json:"context,omitempty"`
 	// MaxIterations caps the loop at N provider calls before
 	// terminating with stop_reason="max_iterations". 0 = use the
 	// loop default (16). Set higher for discovery-style forks
@@ -1001,6 +1005,10 @@ func (d *mergedDef) applyOverlay(ov mergedDef) {
 	// Compaction merges PER FIELD, same as Sampling.
 	if !ov.Compaction.IsZero() {
 		d.Compaction = config.MergeCompaction(d.Compaction, ov.Compaction)
+	}
+	// Context merges PER FIELD, same as Compaction.
+	if !ov.Context.IsZero() {
+		d.Context = config.MergeContext(d.Context, ov.Context)
 	}
 	if ov.MaxTokens != 0 {
 		d.MaxTokens = ov.MaxTokens
@@ -1226,6 +1234,7 @@ func staticToMergedDef(s config.AgentDef) mergedDef {
 		Effort:                s.Effort,
 		Sampling:              s.Sampling.Clone(),
 		Compaction:            s.Compaction.Clone(),
+		Context:               s.Context.Clone(),
 		MaxTokens:             s.MaxTokens,
 		MaxContextTokens:      s.MaxContextTokens,
 		MaxIterations:         s.MaxIterations,
@@ -1414,6 +1423,16 @@ func signFromMergedDef(name string, def mergedDef) string {
 			AutoCompactAtPct: cp.AutoCompactAtPct,
 			Model:            cp.Model,
 			MemoryFlush:      cp.MemoryFlush,
+		}
+	}
+	// Context is content-identifying, same as Compaction (RFC CR).
+	if cx := def.Context; !cx.IsZero() {
+		c.Context = &agents.Context{
+			Mode:           cx.Mode,
+			KeepLastN:      cx.KeepLastN,
+			Reasoning:      cx.Reasoning,
+			RecapMaxChars:  cx.RecapMaxChars,
+			AutoRecapAtPct: cx.AutoRecapAtPct,
 		}
 	}
 	return agents.Sign(c)

--- a/internal/tools/builtin/agentdef_sha256_test.go
+++ b/internal/tools/builtin/agentdef_sha256_test.go
@@ -97,6 +97,9 @@ func TestAgentDefTool_ForkInteractiveConfigMovesHash(t *testing.T) {
 		// def is told), so a fork that flips it must mint a distinct content hash.
 		"inject_tool_guide":  `{"op":"fork","name":"researcher","overlay":{"system_prompt":"v1","inject_tool_guide":true}}`,
 		"max_context_tokens": `{"op":"fork","name":"researcher","overlay":{"system_prompt":"v1","max_context_tokens":65536}}`,
+		// RFC CR: the context / retention block is behaviour-bearing (it changes how
+		// every run's history is distilled), so a fork setting it must move the hash.
+		"context": `{"op":"fork","name":"researcher","overlay":{"system_prompt":"v1","context":{"mode":"recap"}}}`,
 	}
 	for field, overlay := range cases {
 		res, _ := tool.Execute(ctx, json.RawMessage(overlay))

--- a/internal/tools/builtin/context.go
+++ b/internal/tools/builtin/context.go
@@ -262,6 +262,15 @@ func (c *Context) execSelf(ctx context.Context) (tools.Result, error) {
 	if cp := tools.CompactionPolicy(ctx); !cp.IsZero() {
 		out["compaction"] = cp
 	}
+	// context_policy: the resolved layered-context / retention settings in effect
+	// for this run (RFC CR) — mode (append|recap) + its knobs, inherited down the
+	// spawn tree. DISTINCT from `context` below, which reports how full the window
+	// is: this reports HOW the history is distilled. In recap mode an agent's older
+	// reasoning is folded into a running recap; op=compact triggers a recap rather
+	// than a compaction. Omitted when no context block is configured (append).
+	if cx := tools.ContextPolicy(ctx); !cx.IsZero() {
+		out["context_policy"] = cx
+	}
 	// context: how full the window is as of the last completed turn (used =
 	// input + cache tokens; max = the model's window, 0/absent when unknown e.g.
 	// Ollama). Paired with `compaction` above, this is what an agent needs to

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -996,6 +996,26 @@ func CompactionPolicy(ctx context.Context) *config.Compaction {
 	return c
 }
 
+type ctxKeyContextPolicy struct{}
+
+// WithContextPolicy attaches the run's RESOLVED-but-sparse layered-context
+// settings to ctx (per-run > parent-inherited > child def, defaults applied at
+// use-time; RFC CR). A sub-agent inherits this; the spawn path blends the child
+// def over it (parent-set fields win). Read by Context op=self to report the
+// active mode. nil/IsZero is a no-op.
+func WithContextPolicy(ctx context.Context, c *config.Context) context.Context {
+	if c.IsZero() {
+		return ctx
+	}
+	return context.WithValue(ctx, ctxKeyContextPolicy{}, c)
+}
+
+// ContextPolicy returns the inherited layered-context settings (sparse), or nil.
+func ContextPolicy(ctx context.Context) *config.Context {
+	c, _ := ctx.Value(ctxKeyContextPolicy{}).(*config.Context)
+	return c
+}
+
 type ctxKeyCompactionOverride struct{}
 
 // WithCompactionOverride carries a per-spawn compaction override (the Agent


### PR DESCRIPTION
## Why

A long-horizon run on a **weak or local** model degrades as its append-only history grows and poisons the prompt, and today's compaction is lossy in the worst way — a prose summary of the whole span discards the structured tool results (which value, which file) the next step needs. The RFC CS benchmark proved a **reasoning-recap** distillation recovers cost in *every* regime and accuracy in loomcycle's target regime (long horizon + weak/local model): append **0.686** vs recap **0.857** vs stateful 0.971 @ T=200 on a weak local model, Welch p≈0.003/0.033 — statistically significant, where earlier context ideas (RFC CL/CM) were not. Go/no-go on RFC CR is **GO**; this PR lands **P1 = L1 reasoning-recap**, the schema-free universal floor of the retention spectrum.

## What

A new per-agent `context:` block, a sibling of `compaction:` that it mirrors field-for-field:

```yaml
context:
  mode: recap          # append (default, byte-identical) | recap
  keep_last_n: 6        # recent tool_use/tool_result pairs kept VERBATIM
  reasoning: recap      # recap (default) | drop | keep
  recap_max_chars: 512
  autorecap_at_pct: 80  # 50..95
```

In `mode: recap` the loop, at an iteration boundary once the footprint crosses the threshold, rebuilds what it **feeds** the model as `pinned task + running progress recap + last-N tool pairs verbatim`. The recap folds forward incrementally, and the task is pinned as its own raw turn, so **the fed prompt stays flat** — cost is O(T), not O(T²). recap replaces the compaction auto-trigger (mutually exclusive per run). `reasoning: drop` skips the recap call; `keep` is an A/B no-op.

- **Store side untouched:** the full transcript is always persisted — audit, replay, resume, and memory facts-extraction see the complete trajectory; only the fed window shrinks.
- **Durable:** a `context_recap` transcript marker (sibling of `context_compaction`) makes `replayTranscript` rebuild the identical distilled form on resume/crash-recovery — no separate running-state to restore (the prior recap rides the transcript and folds forward).
- **Content-identifying** (a fork setting it mints a distinct hash; an append/no-context agent hashes byte-identical to a pre-feature row via the all-nil collapse), a **per-run override** on `POST /v1/runs`, and it **flows down the spawn tree** (parent wins, child fills gaps) — the same three planes as `compaction:`, with three-way mirror parity.
- `Context op=self` reports the active `context_policy`.

**Deferred (documented):** gRPC/MCP/adapter *per-run* `context` parity is P4 (the per-agent block already flows on every transport via the resolved def). Structured state (L2, `mode: stateful`) is P2 — the value is reserved and rejected by `validate` for now.

## Tested

- **Unit (loop):** recap primitives; the **flat-and-folds-forward** property (pinned task byte-identical across two recaps + the 2nd recap is fed the 1st recap turn); drop/keep/fail-open modes; `shouldAutoRecap` threshold/debounce/self-enabling.
- **Integration (loop):** a full `Run()` in recap mode auto-recaps at the threshold, emits `EventContextRecap` (not a compaction marker), and shrinks the next request.
- **Replay (http):** a `context_recap` marker round-trips through `replayTranscript` to the identical distilled history (recapped-away turn gone from the fed history, recap + tail preserved).
- **Config:** reflective Clone/Merge/IsZero/Validate coverage (sub-struct-drift guard); the lookup three-way drift want-map + the sha256 hash-move test gain the conscious `context` entry.
- `go test ./...` clean. Manual: `loomcycle validate` accepts a `context: {mode: recap, …}` agent and rejects `mode: stateful` with a clear message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)