### PR TITLE
feat: L2 structured execution state (RFC CR P2 core)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -655,6 +655,33 @@ As with compaction, the **full transcript is always retained** — audit, replay
 
 > **Which one?** `append` (+ `compaction`) stays the default and is right for most runs. Reach for `mode: recap` on a **local / weak model doing long procedural work**, where a growing prompt measurably degrades answers — that is the regime where keeping recent observations verbatim while recapping old reasoning wins on both cost and quality. On a frontier model at short horizons the two are quality-equivalent, so the motivation there is cost alone.
 
+#### `mode: stateful` — structured execution state
+
+The strongest retention mode. Instead of a history (full, recapped, or otherwise), the model is fed only three things each step: the preamble, a **structured state object** it maintains, and the **latest observation**. It responds with a single `emit_state` call carrying a *patch* to the state and the *next action*:
+
+```yaml
+agents:
+  procedural-runner:
+    context:
+      mode: stateful
+      state_schema:              # optional — the shape the state (and every patch) must hold
+        type: object
+        additionalProperties: false
+        properties:
+          discovered: {type: array, items: {type: string}}
+          current_dir: {type: string}
+          done: {type: boolean}
+      on_invalid_patch: retry    # retry (default) | fail
+      max_patch_retries: 2
+```
+
+Each step the runtime: validates the patch against `state_schema` (a subset — object with typed properties + `additionalProperties`; `required` is not enforced per-step since the state accretes), merges it into the state with **JSON merge-patch** semantics (a `null` value deletes a key), records the new state on the transcript (a `context_state` event — a full audit of how the state evolved), then runs the named action to produce the next observation. The agent finishes by omitting the action (or `done: true`) and putting its answer in `final`. Because only the state + one observation is ever fed, the prompt stays **flat** and cost is linear in the horizon — the same O(T) property as recap, but the model carries an explicit, typed working memory instead of prose.
+
+- **Actions, not tool calls.** A stateful agent does not call its tools directly — it *names* one in `action: {tool, input}` and the runtime dispatches it. The agent's tool catalog + the state schema are described to it in the preamble. It can read its own state back mid-run by naming `Context` with `op: state`.
+- **Invalid patches** are rolled back and retried (the model is shown its rejected `emit_state` and the reason) up to `max_patch_retries`; `on_invalid_patch: fail` ends the run instead. `state_schema` is optional — omit it and patches are accepted unvalidated (useful before a schema is settled).
+- **When to use it:** long-horizon procedural work whose progress is a well-defined *state* (files discovered, hypotheses tested, a working directory) rather than a conversation. On loomcycle's benchmark it was the top arm at long horizon on a weak local model. It is **not** for open-ended conversation — the state must be a sufficient summary of the task, which a chat is not. It is opt-in per agent, like every other retention mode.
+- **Scope note:** stateful runs are autonomous; interactive steering, pause/park, and cross-instance resume of a mid-flight stateful run are not wired yet (a step re-derives cheaply from the state) — they compose on top later. The design rationale lives in the RFC in the doc store.
+
 ### Interactive local agents
 
 For a terminal you steer turn-by-turn:

--- a/internal/agents/loader.go
+++ b/internal/agents/loader.go
@@ -201,11 +201,14 @@ type Compaction struct {
 // content_sha256 — a fork that changes only a context field mints a distinct
 // hash. Pointers so an unset field omits.
 type Context struct {
-	Mode           *string `json:"mode,omitempty"`
-	KeepLastN      *int    `json:"keep_last_n,omitempty"`
-	Reasoning      *string `json:"reasoning,omitempty"`
-	RecapMaxChars  *int    `json:"recap_max_chars,omitempty"`
-	AutoRecapAtPct *int    `json:"autorecap_at_pct,omitempty"`
+	Mode            *string        `json:"mode,omitempty"`
+	KeepLastN       *int           `json:"keep_last_n,omitempty"`
+	Reasoning       *string        `json:"reasoning,omitempty"`
+	RecapMaxChars   *int           `json:"recap_max_chars,omitempty"`
+	AutoRecapAtPct  *int           `json:"autorecap_at_pct,omitempty"`
+	StateSchema     map[string]any `json:"state_schema,omitempty"`
+	OnInvalidPatch  *string        `json:"on_invalid_patch,omitempty"`
+	MaxPatchRetries *int           `json:"max_patch_retries,omitempty"`
 }
 
 // CoreBlock mirrors config.CoreBlock locally so the agents package stays

--- a/internal/agents/sign.go
+++ b/internal/agents/sign.go
@@ -346,7 +346,8 @@ func normalize(c *AgentContent) {
 	// row. An explicit mode:"append" is a non-nil *string and is preserved.
 	if c.Context != nil && c.Context.Mode == nil && c.Context.KeepLastN == nil &&
 		c.Context.Reasoning == nil && c.Context.RecapMaxChars == nil &&
-		c.Context.AutoRecapAtPct == nil {
+		c.Context.AutoRecapAtPct == nil && len(c.Context.StateSchema) == 0 &&
+		c.Context.OnInvalidPatch == nil && c.Context.MaxPatchRetries == nil {
 		c.Context = nil
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
@@ -1742,8 +1743,11 @@ type Context struct {
 	//              evicted assistant REASONING with a running recap note. Choosing
 	//              recap turns auto-recap ON (no separate enable flag). When set,
 	//              recap takes precedence over the `compaction:` auto-trigger.
-	//   "stateful" is reserved for structured execution state (RFC CR L2) and is
-	//              NOT yet available; Validate rejects it for now.
+	//   "stateful" — L2 structured execution state: the loop feeds the model only
+	//              (preamble, the structured state Σ, the latest observation) and it
+	//              emits a state patch + the next action each step. Σ replaces the
+	//              growing history entirely. Needs `state_schema` (optional — a
+	//              patch is validated against it when present).
 	Mode *string `json:"mode,omitempty" yaml:"mode"`
 	// KeepLastN keeps the last N messages verbatim in recap mode, snapped to a
 	// clean user-turn boundary so a tool_use/tool_result pair is never split.
@@ -1763,28 +1767,46 @@ type Context struct {
 	// 50..95; default 80. Only consulted in recap mode when the provider reports a
 	// context window. Mirrors compaction.autocompact_at_pct.
 	AutoRecapAtPct *int `json:"autorecap_at_pct,omitempty" yaml:"autorecap_at_pct"`
+	// StateSchema is the JSON-Schema (a subset — object with typed properties +
+	// required) each Σ patch is validated against in stateful mode. yaml.v3 parses
+	// the nested object as map[string]any (string keys → JSON-marshalable), so it
+	// hashes deterministically. Optional: absent → patches are accepted unvalidated
+	// (permissive, so a stateful run can start before a schema is adopted). Only
+	// consulted in stateful mode.
+	StateSchema map[string]any `json:"state_schema,omitempty" yaml:"state_schema"`
+	// OnInvalidPatch is the stateful-mode policy when a patch fails schema
+	// validation: "retry" (default) re-prompts the model with the error up to
+	// MaxPatchRetries times; "fail" ends the run. Only consulted in stateful mode.
+	OnInvalidPatch *string `json:"on_invalid_patch,omitempty" yaml:"on_invalid_patch"`
+	// MaxPatchRetries bounds the rollback-retry loop on an invalid patch
+	// (on_invalid_patch=retry). Default 2. Only consulted in stateful mode.
+	MaxPatchRetries *int `json:"max_patch_retries,omitempty" yaml:"max_patch_retries"`
 }
 
 // Context mode values.
 const (
-	ContextModeAppend = "append"
-	ContextModeRecap  = "recap"
+	ContextModeAppend   = "append"
+	ContextModeRecap    = "recap"
+	ContextModeStateful = "stateful"
 )
 
 // Context defaults — applied at use-time when a field is unset (never baked into
 // the struct, so an unset field stays nil and the content hash stays byte-stable).
 const (
-	ContextDefaultKeepLastN      = 6
-	ContextDefaultReasoning      = "recap"
-	ContextDefaultRecapMaxChars  = 512
-	ContextDefaultAutoRecapAtPct = 80
+	ContextDefaultKeepLastN       = 6
+	ContextDefaultReasoning       = "recap"
+	ContextDefaultRecapMaxChars   = 512
+	ContextDefaultAutoRecapAtPct  = 80
+	ContextDefaultOnInvalidPatch  = "retry"
+	ContextDefaultMaxPatchRetries = 2
 )
 
 // IsZero reports whether no context field is set (collapse to nil → byte-stable
 // content hashes for agents that don't configure a context block).
 func (c *Context) IsZero() bool {
 	return c == nil || (c.Mode == nil && c.KeepLastN == nil && c.Reasoning == nil &&
-		c.RecapMaxChars == nil && c.AutoRecapAtPct == nil)
+		c.RecapMaxChars == nil && c.AutoRecapAtPct == nil &&
+		len(c.StateSchema) == 0 && c.OnInvalidPatch == nil && c.MaxPatchRetries == nil)
 }
 
 // Clone deep-copies (every field is a pointer) so a merge never aliases an input.
@@ -1812,6 +1834,33 @@ func (c *Context) Clone() *Context {
 	if c.AutoRecapAtPct != nil {
 		v := *c.AutoRecapAtPct
 		out.AutoRecapAtPct = &v
+	}
+	out.StateSchema = cloneAnyMap(c.StateSchema)
+	if c.OnInvalidPatch != nil {
+		v := *c.OnInvalidPatch
+		out.OnInvalidPatch = &v
+	}
+	if c.MaxPatchRetries != nil {
+		v := *c.MaxPatchRetries
+		out.MaxPatchRetries = &v
+	}
+	return out
+}
+
+// cloneAnyMap deep-copies a parsed JSON/YAML object via a JSON round-trip. Used
+// for the Context.StateSchema so a fork/merge never aliases the operator's map.
+// Returns nil for a nil/empty map (keeps IsZero + the content-hash collapse stable).
+func cloneAnyMap(m map[string]any) map[string]any {
+	if len(m) == 0 {
+		return nil
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return nil
+	}
+	var out map[string]any
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil
 	}
 	return out
 }
@@ -1852,6 +1901,18 @@ func MergeContext(base, over *Context) *Context {
 		v := *over.AutoRecapAtPct
 		out.AutoRecapAtPct = &v
 	}
+	// StateSchema replaces wholesale (a schema override is not a per-key merge).
+	if len(over.StateSchema) > 0 {
+		out.StateSchema = cloneAnyMap(over.StateSchema)
+	}
+	if over.OnInvalidPatch != nil {
+		v := *over.OnInvalidPatch
+		out.OnInvalidPatch = &v
+	}
+	if over.MaxPatchRetries != nil {
+		v := *over.MaxPatchRetries
+		out.MaxPatchRetries = &v
+	}
 	return out
 }
 
@@ -1862,12 +1923,10 @@ func (c *Context) Validate() error {
 	}
 	if c.Mode != nil {
 		switch *c.Mode {
-		case ContextModeAppend, ContextModeRecap:
+		case ContextModeAppend, ContextModeRecap, ContextModeStateful:
 			// ok
-		case "stateful":
-			return fmt.Errorf("context.mode %q is not yet available", *c.Mode)
 		default:
-			return fmt.Errorf("context.mode %q invalid (want append|recap)", *c.Mode)
+			return fmt.Errorf("context.mode %q invalid (want append|recap|stateful)", *c.Mode)
 		}
 	}
 	if c.KeepLastN != nil && *c.KeepLastN < 0 {
@@ -1886,6 +1945,31 @@ func (c *Context) Validate() error {
 	}
 	if c.AutoRecapAtPct != nil && (*c.AutoRecapAtPct < 50 || *c.AutoRecapAtPct > 95) {
 		return fmt.Errorf("context.autorecap_at_pct %d out of range [50,95]", *c.AutoRecapAtPct)
+	}
+	if c.OnInvalidPatch != nil {
+		switch *c.OnInvalidPatch {
+		case "retry", "fail":
+			// ok
+		default:
+			return fmt.Errorf("context.on_invalid_patch %q invalid (want retry|fail)", *c.OnInvalidPatch)
+		}
+	}
+	if c.MaxPatchRetries != nil && *c.MaxPatchRetries < 0 {
+		return fmt.Errorf("context.max_patch_retries %d must be >= 0", *c.MaxPatchRetries)
+	}
+	// A state_schema, when given, must be a JSON-Schema object ("type":"object"
+	// with a properties map). The runtime validates patches against the subset the
+	// hand-rolled validator supports; a malformed schema is a config error, not a
+	// silent no-op. Only meaningful in stateful mode, but validated whenever set.
+	if len(c.StateSchema) > 0 {
+		if t, _ := c.StateSchema["type"].(string); t != "" && t != "object" {
+			return fmt.Errorf("context.state_schema type %q unsupported (top level must be object)", t)
+		}
+		if props, ok := c.StateSchema["properties"]; ok {
+			if _, ok := props.(map[string]any); !ok {
+				return fmt.Errorf("context.state_schema properties must be an object")
+			}
+		}
 	}
 	return nil
 }

--- a/internal/config/context_test.go
+++ b/internal/config/context_test.go
@@ -40,23 +40,40 @@ func TestMergeContext_NilInputs(t *testing.T) {
 
 func TestContext_Validate(t *testing.T) {
 	bad := []*Context{
-		{Mode: ptrS("stateful")},       // reserved, not yet available
-		{Mode: ptrS("bogus")},          // unknown
-		{Reasoning: ptrS("summarize")}, // unknown R-policy
-		{KeepLastN: ptrI2(-1)},         // < 0
-		{RecapMaxChars: ptrI2(-1)},     // < 0
-		{AutoRecapAtPct: ptrI2(40)},    // < 50
-		{AutoRecapAtPct: ptrI2(99)},    // > 95
+		{Mode: ptrS("bogus")},                             // unknown
+		{Reasoning: ptrS("summarize")},                    // unknown R-policy
+		{KeepLastN: ptrI2(-1)},                            // < 0
+		{RecapMaxChars: ptrI2(-1)},                        // < 0
+		{AutoRecapAtPct: ptrI2(40)},                       // < 50
+		{AutoRecapAtPct: ptrI2(99)},                       // > 95
+		{OnInvalidPatch: ptrS("ignore")},                  // want retry|fail
+		{MaxPatchRetries: ptrI2(-1)},                      // < 0
+		{StateSchema: map[string]any{"type": "array"}},    // top level must be object
+		{StateSchema: map[string]any{"properties": "no"}}, // properties must be an object
 	}
 	for i, c := range bad {
 		if err := c.Validate(); err == nil {
 			t.Errorf("case %d (%+v): expected a validation error", i, c)
 		}
 	}
-	for _, m := range []string{ContextModeAppend, ContextModeRecap} {
+	for _, m := range []string{ContextModeAppend, ContextModeRecap, ContextModeStateful} {
 		if err := (&Context{Mode: ptrS(m)}).Validate(); err != nil {
 			t.Errorf("mode %q should be valid: %v", m, err)
 		}
+	}
+	// A well-formed stateful config validates.
+	okState := &Context{
+		Mode:            ptrS(ContextModeStateful),
+		OnInvalidPatch:  ptrS("fail"),
+		MaxPatchRetries: ptrI2(3),
+		StateSchema: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{"count": map[string]any{"type": "integer"}},
+			"required":   []any{"count"},
+		},
+	}
+	if err := okState.Validate(); err != nil {
+		t.Errorf("valid stateful context rejected: %v", err)
 	}
 	for _, r := range []string{"recap", "drop", "keep"} {
 		if err := (&Context{Reasoning: ptrS(r)}).Validate(); err != nil {
@@ -70,7 +87,8 @@ func TestContext_Validate(t *testing.T) {
 
 // nonZeroContext sets EVERY field to a non-zero, VALIDATION-PASSING value via
 // reflection, so a newly added field is populated without anyone remembering to
-// update this test. String enum fields get a valid member by name.
+// update this test. String enum fields get a valid member by name; the
+// state_schema map gets a valid minimal object schema.
 func nonZeroContext(t *testing.T) *Context {
 	t.Helper()
 	c := &Context{}
@@ -79,29 +97,49 @@ func nonZeroContext(t *testing.T) *Context {
 	for i := 0; i < v.NumField(); i++ {
 		f := v.Field(i)
 		name := vt.Field(i).Name
-		if f.Kind() != reflect.Ptr {
-			t.Fatalf("Context.%s is not a pointer; this test assumes the all-pointer shape that makes unset distinguishable from zero", name)
-		}
-		elem := reflect.New(f.Type().Elem())
-		switch elem.Elem().Kind() {
-		case reflect.Int:
-			// In-range for autorecap_at_pct (50..95); fine for the others.
-			elem.Elem().SetInt(50)
-		case reflect.String:
-			switch name {
-			case "Mode":
-				elem.Elem().SetString(ContextModeRecap)
-			case "Reasoning":
-				elem.Elem().SetString("recap")
+		switch f.Kind() {
+		case reflect.Ptr:
+			elem := reflect.New(f.Type().Elem())
+			switch elem.Elem().Kind() {
+			case reflect.Int:
+				// In-range for autorecap_at_pct (50..95); fine for the others.
+				elem.Elem().SetInt(50)
+			case reflect.String:
+				switch name {
+				case "Mode":
+					elem.Elem().SetString(ContextModeStateful)
+				case "Reasoning":
+					elem.Elem().SetString("recap")
+				case "OnInvalidPatch":
+					elem.Elem().SetString("retry")
+				default:
+					elem.Elem().SetString("x")
+				}
 			default:
-				elem.Elem().SetString("x")
+				t.Fatalf("Context.%s has unhandled ptr kind %s — extend this helper", name, elem.Elem().Kind())
 			}
+			f.Set(elem)
+		case reflect.Map:
+			// state_schema — a valid minimal object schema.
+			f.Set(reflect.ValueOf(map[string]any{
+				"type":       "object",
+				"properties": map[string]any{"x": map[string]any{"type": "string"}},
+			}))
 		default:
-			t.Fatalf("Context.%s has unhandled kind %s — extend this helper", name, elem.Elem().Kind())
+			t.Fatalf("Context.%s has unhandled kind %s — extend this helper", name, f.Kind())
 		}
-		f.Set(elem)
 	}
 	return c
+}
+
+// derefField returns a field's comparable value, dereferencing a pointer but
+// taking a map (or other reference) as-is — so the reflective drift tests below
+// handle the all-pointer fields AND the state_schema map uniformly.
+func derefField(v reflect.Value) any {
+	if v.Kind() == reflect.Ptr {
+		return v.Elem().Interface()
+	}
+	return v.Interface()
 }
 
 // TestContext_CloneAndMergeCoverEveryField guards sub-struct drift: mergeAgentDef
@@ -123,8 +161,8 @@ func TestContext_CloneAndMergeCoverEveryField(t *testing.T) {
 				t.Errorf("Clone() dropped Context.%s — a fork setting it loses the setting", name)
 				continue
 			}
-			if !reflect.DeepEqual(g.Elem().Interface(), w.Elem().Interface()) {
-				t.Errorf("Clone() Context.%s = %v, want %v", name, g.Elem(), w.Elem())
+			if !reflect.DeepEqual(derefField(g), derefField(w)) {
+				t.Errorf("Clone() Context.%s = %v, want %v", name, derefField(g), derefField(w))
 			}
 			if g.Pointer() == w.Pointer() {
 				t.Errorf("Clone() aliased Context.%s instead of copying it", name)
@@ -142,8 +180,8 @@ func TestContext_CloneAndMergeCoverEveryField(t *testing.T) {
 				t.Errorf("MergeContext() never overlays Context.%s — an override of it is SILENTLY DISCARDED", name)
 				continue
 			}
-			if !reflect.DeepEqual(g.Elem().Interface(), want.Field(i).Elem().Interface()) {
-				t.Errorf("MergeContext() Context.%s = %v, want %v", name, g.Elem(), want.Field(i).Elem())
+			if !reflect.DeepEqual(derefField(g), derefField(want.Field(i))) {
+				t.Errorf("MergeContext() Context.%s = %v, want %v", name, derefField(g), derefField(want.Field(i)))
 			}
 		}
 	})

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -770,6 +770,9 @@ type RunResult struct {
 	FinalText  string // concatenated text from the last assistant turn
 	Iterations int
 	Usage      providers.Usage // sum across iterations
+	// State is the final structured execution state Σ of an L2 stateful run (RFC
+	// CR `context.mode: stateful`); nil for append/recap runs.
+	State map[string]any
 }
 
 // ErrTurnCancelled is the cancel cause the server fires on a run's armed per-turn
@@ -1590,6 +1593,14 @@ func Run(ctx context.Context, opts RunOptions) (RunResult, error) {
 	}
 
 	emit(providers.Event{Type: providers.EventStarted})
+
+	// RFC CR L2: a stateful run is a different loop — it feeds only (P, Σ, O) and
+	// the model emits a patch + action each step. Branch here, after the preamble
+	// P (`system`) and the action-tool catalog are resolved, into the self-
+	// contained stateful loop. The append/recap machinery below does not apply.
+	if contextStatefulMode(opts.Context) {
+		return runStateful(ctx, opts, system, messages, toolSpecs, emit)
+	}
 
 	// Context compaction (v2): a self-request flag the Context op=compact tool
 	// sets (checked at the next iteration boundary), plus the previous iteration's

--- a/internal/loop/stateful.go
+++ b/internal/loop/stateful.go
@@ -1,0 +1,321 @@
+package loop
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/statepatch"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// --- RFC CR L2: structured execution state (the `context.mode: stateful` loop) ---
+//
+// Instead of appending history, the model is fed only (P = the preamble/system,
+// Σ = the structured state object, O = the latest observation) and emits, via one
+// `emit_state` tool call, (reasoning, patch, action). The runtime validates the
+// patch against the state schema, merges it into Σ with null-deletion, discards
+// the reasoning, executes the named action to produce the next observation, and
+// loops. Cost is O(T): the fed prompt never grows. The full event stream (each
+// EventContextState marker) is still persisted for audit.
+//
+// This is a self-contained loop, deliberately separate from the append/recap
+// Run() body so it cannot regress the shipped path. PR1 scope: autonomous runs.
+// Interactive steering, pause/park, and cross-instance resume of a stateful run
+// are not wired here yet (a stateful run is short-horizon-per-step and re-derives
+// cheaply); they compose on top later.
+
+// contextStatefulMode reports whether the resolved policy selects L2 stateful.
+func contextStatefulMode(cx *config.Context) bool {
+	return cx != nil && cx.Mode != nil && *cx.Mode == config.ContextModeStateful
+}
+
+const emitStateToolName = "emit_state"
+
+// emitStateToolSpec is the ONLY tool a stateful step offers: the model must call
+// it, which is how the runtime reliably gets a structured {reasoning, patch,
+// action} object without a provider-specific forced-output primitive.
+func emitStateToolSpec() providers.ToolSpec {
+	return providers.ToolSpec{
+		Name: emitStateToolName,
+		Description: "Advance the task by emitting your state update and next action. Call this EXACTLY ONCE per step. " +
+			"`patch` is a JSON merge-patch applied to the state object (a null value deletes a key) — keep the state the single " +
+			"source of truth for everything you must remember. `action` names the next tool to run; omit it (or set done=true) to " +
+			"finish, putting your answer in `final`.",
+		InputSchema: json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "reasoning": {"type": "string", "description": "your step reasoning; it is discarded after this step, so record durable facts in the patch instead"},
+    "patch": {"type": "object", "description": "a JSON merge-patch applied to the state; a null value deletes a key"},
+    "action": {"type": "object", "properties": {"tool": {"type": "string"}, "input": {"type": "object"}}, "description": "the next tool to run; omit to finish"},
+    "done": {"type": "boolean", "description": "true when the task is complete"},
+    "final": {"type": "string", "description": "the final answer text, when done"}
+  },
+  "required": ["patch"]
+}`),
+	}
+}
+
+type emitStateOut struct {
+	Reasoning string         `json:"reasoning"`
+	Patch     map[string]any `json:"patch"`
+	Action    *stateAction   `json:"action"`
+	Done      bool           `json:"done"`
+	Final     string         `json:"final"`
+}
+
+type stateAction struct {
+	Tool  string          `json:"tool"`
+	Input json.RawMessage `json:"input"`
+}
+
+func parseEmitState(input json.RawMessage) (*emitStateOut, error) {
+	var out emitStateOut
+	if err := json.Unmarshal(input, &out); err != nil {
+		return nil, fmt.Errorf("emit_state was not valid JSON: %w", err)
+	}
+	if out.Patch == nil {
+		out.Patch = map[string]any{} // a step with no state change is legal
+	}
+	return &out, nil
+}
+
+func actionName(es *emitStateOut) string {
+	if es.Action == nil {
+		return ""
+	}
+	return es.Action.Tool
+}
+
+// buildStatefulSystem augments the resolved preamble P with the state protocol
+// instructions, the available action-tool catalog, and the state schema.
+func buildStatefulSystem(base []providers.ContentBlock, toolSpecs []providers.ToolSpec, schema map[string]any) []providers.ContentBlock {
+	var b strings.Builder
+	b.WriteString("\n\n## Structured execution mode\n")
+	b.WriteString("You run in structured-state mode. You do NOT call the task tools directly. Each step you are shown the current state (a JSON object) and the latest observation; respond by calling `emit_state` exactly once:\n")
+	b.WriteString("- `reasoning`: your thinking for this step. It is DISCARDED afterwards, so put anything you must remember into the patch.\n")
+	b.WriteString("- `patch`: a JSON merge-patch applied to the state. Set keys to record progress; a null value deletes a key.\n")
+	b.WriteString("- `action`: the next tool to run, as {\"tool\": <name>, \"input\": {…}}. The runtime executes it and hands you its output as the next observation.\n")
+	b.WriteString("- Finish by omitting `action` (or setting `done: true`) and putting your answer in `final`.\n")
+	if len(toolSpecs) > 0 {
+		b.WriteString("\n### Action tools you may name\n")
+		for _, t := range toolSpecs {
+			fmt.Fprintf(&b, "- `%s`: %s\n", t.Name, oneLineDesc(t.Description))
+		}
+	}
+	if len(schema) > 0 {
+		if sj, err := json.Marshal(schema); err == nil {
+			fmt.Fprintf(&b, "\n### State schema (the state, and every patch, must conform)\n%s\n", string(sj))
+		}
+	}
+	out := append([]providers.ContentBlock(nil), base...)
+	return append(out, providers.ContentBlock{Type: "text", Text: b.String()})
+}
+
+func oneLineDesc(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	if len(s) > 240 {
+		s = s[:240] + "…"
+	}
+	return strings.TrimSpace(s)
+}
+
+// statefulUserMessage renders the fed context for one step: only Σ + O (no
+// history). This is the whole point — the prompt stays flat over the horizon.
+func statefulUserMessage(sigma map[string]any, obs string) providers.Message {
+	sj, _ := json.Marshal(sigma)
+	var b strings.Builder
+	fmt.Fprintf(&b, "Current state:\n%s\n\nLatest observation:\n%s", string(sj), obs)
+	return providers.Message{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: b.String()}}}
+}
+
+// initialObservation renders the run's task (the seed segments) as the first
+// observation O_0.
+func initialObservation(msgs []providers.Message) string {
+	var b strings.Builder
+	for _, m := range msgs {
+		for _, c := range m.Content {
+			if c.Type == "text" && c.Text != "" {
+				b.WriteString(c.Text)
+				b.WriteString("\n")
+			}
+		}
+	}
+	s := strings.TrimSpace(b.String())
+	if s == "" {
+		return "(no task provided)"
+	}
+	return "Task: " + s
+}
+
+// callForEmitState makes one provider call and returns the emit_state tool input,
+// the call's usage, and any error. NO OnEvent hook is set — the returned channel
+// is the event source (mirrors summarizeWith); streaming text is ignored, the
+// tool call is what matters.
+func callForEmitState(ctx context.Context, provider providers.Provider, req providers.Request) (json.RawMessage, *providers.Usage, error) {
+	ch, err := provider.Call(ctx, req)
+	if err != nil {
+		return nil, nil, err
+	}
+	var input json.RawMessage
+	var usage *providers.Usage
+	var streamErr string
+	for ev := range ch {
+		switch ev.Type {
+		case providers.EventToolCall:
+			if ev.ToolUse != nil && ev.ToolUse.Name == emitStateToolName && input == nil {
+				input = ev.ToolUse.Input
+			}
+		case providers.EventDone:
+			usage = ev.Usage
+		case providers.EventError:
+			streamErr = ev.Error
+		}
+	}
+	if streamErr != "" {
+		return nil, usage, errors.New(streamErr)
+	}
+	if len(input) == 0 {
+		return nil, usage, errors.New("model did not call emit_state")
+	}
+	return input, usage, nil
+}
+
+func addUsage(dst *providers.Usage, u *providers.Usage) {
+	if u == nil {
+		return
+	}
+	dst.InputTokens += u.InputTokens
+	dst.OutputTokens += u.OutputTokens
+	dst.CacheCreationTokens += u.CacheCreationTokens
+	dst.CacheReadTokens += u.CacheReadTokens
+	if u.Model != "" {
+		dst.Model = u.Model
+	}
+}
+
+func applyStatefulSampling(req *providers.Request, s *config.Sampling) {
+	if s == nil {
+		return
+	}
+	req.Temperature = s.Temperature
+	req.TopP = s.TopP
+	req.TopK = s.TopK
+	req.FrequencyPenalty = s.FrequencyPenalty
+	req.PresencePenalty = s.PresencePenalty
+	req.Seed = s.Seed
+	req.Stop = s.Stop
+}
+
+// runStateful executes the L2 loop. `system` is the resolved preamble P (already
+// split from opts.Segments); `initial` is the seed conversation (the task);
+// `toolSpecs` is the action-tool catalog; `emit` forwards + persists events.
+func runStateful(ctx context.Context, opts RunOptions, system []providers.ContentBlock, initial []providers.Message, toolSpecs []providers.ToolSpec, emit func(providers.Event)) (RunResult, error) {
+	cx := opts.Context
+	var schema map[string]any
+	onInvalid := config.ContextDefaultOnInvalidPatch
+	maxRetries := config.ContextDefaultMaxPatchRetries
+	if cx != nil {
+		schema = cx.StateSchema
+		if cx.OnInvalidPatch != nil {
+			onInvalid = *cx.OnInvalidPatch
+		}
+		if cx.MaxPatchRetries != nil {
+			maxRetries = *cx.MaxPatchRetries
+		}
+	}
+	maxIter := opts.MaxIterations
+	if maxIter <= 0 {
+		maxIter = 16
+	}
+
+	statefulSystem := buildStatefulSystem(system, toolSpecs, schema)
+	emitTool := []providers.ToolSpec{emitStateToolSpec()}
+
+	sigma := map[string]any{}
+	holder := &tools.ExecStateHolder{Sigma: sigma}
+	dispatchCtx := tools.WithExecutionState(ctx, holder) // the action sees the live Σ (Context op=state)
+
+	obs := initialObservation(initial)
+	var total providers.Usage
+
+	for iter := 0; iter < maxIter; iter++ {
+		if err := ctx.Err(); err != nil {
+			return RunResult{StopReason: "cancelled", Iterations: iter, Usage: total, State: sigma}, err
+		}
+		msgs := []providers.Message{statefulUserMessage(sigma, obs)}
+		var es *emitStateOut
+		for attempt := 0; ; attempt++ {
+			req := providers.Request{Model: opts.Model, System: statefulSystem, Messages: msgs, Tools: emitTool, MaxTokens: opts.MaxTokens, Effort: opts.Effort}
+			applyStatefulSampling(&req, opts.Sampling)
+			input, usage, err := callForEmitState(ctx, opts.Provider, req)
+			addUsage(&total, usage)
+			if err != nil {
+				emit(providers.Event{Type: providers.EventError, Error: "stateful step failed: " + err.Error()})
+				return RunResult{StopReason: "error", Iterations: iter, Usage: total, State: sigma}, err
+			}
+			parsed, perr := parseEmitState(input)
+			var verr error
+			if perr == nil {
+				verr = statepatch.ValidatePatch(schema, parsed.Patch)
+			}
+			if perr != nil || verr != nil {
+				cause := perr
+				if cause == nil {
+					cause = verr
+				}
+				if onInvalid == "fail" || attempt >= maxRetries {
+					msg := fmt.Sprintf("stateful patch rejected after %d attempt(s): %v", attempt+1, cause)
+					emit(providers.Event{Type: providers.EventError, Error: msg})
+					return RunResult{StopReason: "invalid_patch", Iterations: iter, Usage: total, State: sigma}, errors.New(msg)
+				}
+				// Rollback-retry: show the model its rejected emit_state + the reason,
+				// as a proper tool_use/tool_result pair, and ask for a correction.
+				tid := fmt.Sprintf("es-%d-%d", iter, attempt)
+				msgs = append(msgs,
+					providers.Message{Role: "assistant", Content: []providers.ContentBlock{{Type: "tool_use", ToolUseID: tid, ToolName: emitStateToolName, ToolInput: input}}},
+					providers.Message{Role: "user", Content: []providers.ContentBlock{{Type: "tool_result", ToolUseID: tid, Text: "emit_state rejected: " + cause.Error() + ". Emit a corrected emit_state."}}})
+				continue
+			}
+			es = parsed
+			break
+		}
+
+		sigma = statepatch.Merge(sigma, es.Patch)
+		holder.Sigma = sigma
+		emit(providers.Event{Type: providers.EventContextState,
+			ContextState: &providers.ContextStateEventInfo{State: sigma, Patch: es.Patch, Iter: iter, Action: actionName(es), Reasoning: es.Reasoning}})
+
+		// Terminal: done flag, or no action named.
+		if es.Done || es.Action == nil || strings.TrimSpace(es.Action.Tool) == "" {
+			final := es.Final
+			if final == "" {
+				final = es.Reasoning
+			}
+			emit(providers.Event{Type: providers.EventText, Text: final})
+			emit(providers.Event{Type: providers.EventDone, StopReason: "end_turn", Usage: &total})
+			return RunResult{StopReason: "end_turn", FinalText: final, Iterations: iter + 1, Usage: total, State: sigma}, nil
+		}
+
+		// Execute the named action → next observation.
+		if opts.Dispatcher == nil {
+			obs = "ERROR: no tools are available to run action " + es.Action.Tool
+		} else {
+			tid := fmt.Sprintf("es-act-%d", iter)
+			emit(providers.Event{Type: providers.EventToolCall, ToolUse: &providers.ToolUse{ID: tid, Name: es.Action.Tool, Input: es.Action.Input}})
+			res := opts.Dispatcher.Execute(dispatchCtx, es.Action.Tool, es.Action.Input)
+			emit(providers.Event{Type: providers.EventToolResult, ToolUse: &providers.ToolUse{ID: tid, Name: es.Action.Tool, Input: es.Action.Input}, Text: res.Text, IsError: res.IsError})
+			obs = res.Text
+			if res.IsError {
+				obs = "ERROR: " + res.Text
+			}
+		}
+	}
+
+	emit(providers.Event{Type: providers.EventDone, StopReason: "max_iterations", Usage: &total})
+	return RunResult{StopReason: "max_iterations", Iterations: maxIter, Usage: total, State: sigma}, nil
+}

--- a/internal/loop/stateful_test.go
+++ b/internal/loop/stateful_test.go
@@ -1,0 +1,309 @@
+package loop
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// echoTool is a stand-in action tool: it returns a fixed observation and counts
+// its calls (so a test can assert the stateful loop actually dispatched actions).
+type echoTool struct {
+	mu       sync.Mutex
+	calls    int
+	reply    string
+	sawState map[string]any // the live Σ this tool observed on its last call
+}
+
+func (e *echoTool) Name() string                 { return "Echo" }
+func (e *echoTool) Description() string          { return "echoes a fixed observation" }
+func (e *echoTool) InputSchema() json.RawMessage { return json.RawMessage(`{"type":"object"}`) }
+func (e *echoTool) Execute(ctx context.Context, _ json.RawMessage) (tools.Result, error) {
+	e.mu.Lock()
+	e.calls++
+	if h := tools.ExecutionState(ctx); h != nil {
+		e.sawState = h.Sigma // the live Σ (what Context op=state would read)
+	}
+	e.mu.Unlock()
+	return tools.Result{Text: e.reply}, nil
+}
+func (e *echoTool) callCount() int { e.mu.Lock(); defer e.mu.Unlock(); return e.calls }
+
+// statefulScriptProvider returns a scripted emit_state tool_use per Call and
+// records each call's fed Messages, so a test can assert the prompt stays flat.
+type statefulScriptProvider struct {
+	mu       sync.Mutex
+	scripts  []string
+	turn     int
+	requests [][]providers.Message
+}
+
+func (p *statefulScriptProvider) ID() string                                   { return "stateful-script" }
+func (p *statefulScriptProvider) Probe(context.Context) error                  { return nil }
+func (p *statefulScriptProvider) ListModels(context.Context) ([]string, error) { return nil, nil }
+func (p *statefulScriptProvider) Capabilities() providers.Capabilities {
+	return providers.Capabilities{Streaming: true}
+}
+func (p *statefulScriptProvider) Call(_ context.Context, req providers.Request) (<-chan providers.Event, error) {
+	p.mu.Lock()
+	p.requests = append(p.requests, req.Messages)
+	i := p.turn
+	p.turn++
+	p.mu.Unlock()
+	ch := make(chan providers.Event, 2)
+	if i < len(p.scripts) {
+		ch <- providers.Event{Type: providers.EventToolCall,
+			ToolUse: &providers.ToolUse{ID: fmt.Sprintf("t%d", i), Name: emitStateToolName, Input: json.RawMessage(p.scripts[i])}}
+	}
+	ch <- providers.Event{Type: providers.EventDone, StopReason: "tool_use", Usage: &providers.Usage{InputTokens: 10, OutputTokens: 5}}
+	close(ch)
+	return ch, nil
+}
+func (p *statefulScriptProvider) calls() int { p.mu.Lock(); defer p.mu.Unlock(); return p.turn }
+
+func statefulCtx(schema map[string]any) *config.Context {
+	m := config.ContextModeStateful
+	c := &config.Context{Mode: &m}
+	c.StateSchema = schema
+	return c
+}
+
+func statefulTaskSegs() []PromptSegment {
+	return []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "count to 2"}}}}
+}
+
+func TestContextStatefulMode(t *testing.T) {
+	if contextStatefulMode(nil) || contextStatefulMode(&config.Context{}) {
+		t.Error("nil / empty context is not stateful")
+	}
+	if contextStatefulMode(recapMode(-1, "")) {
+		t.Error("recap mode is not stateful")
+	}
+	if !contextStatefulMode(statefulCtx(nil)) {
+		t.Error("mode=stateful should be stateful")
+	}
+}
+
+// The core: a stateful run evolves Σ through patches, dispatches each named
+// action to produce the next observation, finishes on done, and returns the final
+// Σ + answer. Crucially the fed prompt is FLAT — exactly one message (Σ + O) each
+// step, never a growing history.
+func TestRun_Stateful_EvolvesStateAndDispatches(t *testing.T) {
+	prov := &statefulScriptProvider{scripts: []string{
+		`{"reasoning":"begin","patch":{"count":0},"action":{"tool":"Echo","input":{}}}`,
+		`{"patch":{"count":1},"action":{"tool":"Echo","input":{}}}`,
+		`{"patch":{"count":2},"done":true,"final":"count is 2"}`,
+	}}
+	echo := &echoTool{reply: "observed"}
+	var states []map[string]any
+	var finalText string
+	opts := RunOptions{
+		Provider:   prov,
+		Model:      "x",
+		Tools:      []tools.Tool{echo},
+		Dispatcher: tools.NewDispatcher([]tools.Tool{echo}),
+		Segments:   statefulTaskSegs(),
+		Context:    statefulCtx(nil),
+		OnEvent: func(ev providers.Event) {
+			switch ev.Type {
+			case providers.EventContextState:
+				states = append(states, ev.ContextState.State)
+			case providers.EventText:
+				finalText += ev.Text
+			}
+		},
+	}
+	res, err := Run(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.StopReason != "end_turn" {
+		t.Errorf("stop reason = %q, want end_turn", res.StopReason)
+	}
+	if res.FinalText != "count is 2" {
+		t.Errorf("final text = %q, want %q", res.FinalText, "count is 2")
+	}
+	if c, _ := res.State["count"].(float64); c != 2 {
+		t.Errorf("final Σ count = %v, want 2", res.State["count"])
+	}
+	if len(states) != 3 {
+		t.Fatalf("got %d context_state markers, want 3", len(states))
+	}
+	if c, _ := states[0]["count"].(float64); c != 0 {
+		t.Errorf("step 0 Σ count = %v, want 0", states[0]["count"])
+	}
+	if echo.callCount() != 2 {
+		t.Errorf("Echo dispatched %d times, want 2 (steps 0 and 1)", echo.callCount())
+	}
+	// FLAT prompt: every step fed exactly one message (Σ + O), never a history.
+	for i, msgs := range prov.requests {
+		if len(msgs) != 1 {
+			t.Errorf("step %d fed %d messages, want 1 (flat Σ+O)", i, len(msgs))
+		}
+		body := msgs[0].Content[0].Text
+		if !strings.Contains(body, "Current state") || !strings.Contains(body, "observation") {
+			t.Errorf("step %d message is not the Σ+O shape: %q", i, body)
+		}
+	}
+}
+
+// An invalid patch is rolled back and retried: the model is shown its rejected
+// emit_state + the reason and re-emits, within max_patch_retries.
+func TestRun_Stateful_InvalidPatchRetries(t *testing.T) {
+	schema := map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties":           map[string]any{"count": map[string]any{"type": "integer"}},
+	}
+	prov := &statefulScriptProvider{scripts: []string{
+		`{"patch":{"count":"not-an-int"}}`,               // rejected (string for integer)
+		`{"patch":{"count":0},"done":true,"final":"ok"}`, // corrected + done
+	}}
+	cx := statefulCtx(schema)
+	cx.MaxPatchRetries = cptr(1)
+	res, err := Run(context.Background(), RunOptions{
+		Provider: prov, Model: "x",
+		Dispatcher: tools.NewDispatcher(nil),
+		Segments:   statefulTaskSegs(),
+		Context:    cx,
+	})
+	if err != nil {
+		t.Fatalf("Run should have recovered via retry: %v", err)
+	}
+	if res.StopReason != "end_turn" || res.FinalText != "ok" {
+		t.Errorf("after retry: stop=%q final=%q, want end_turn/ok", res.StopReason, res.FinalText)
+	}
+	if prov.calls() != 2 {
+		t.Errorf("provider called %d times, want 2 (reject + corrected)", prov.calls())
+	}
+	if c, _ := res.State["count"].(float64); c != 0 {
+		t.Errorf("Σ count = %v, want the corrected 0", res.State["count"])
+	}
+}
+
+// on_invalid_patch=fail ends the run on the first invalid patch (no retry).
+func TestRun_Stateful_InvalidPatchFail(t *testing.T) {
+	schema := map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties":           map[string]any{"count": map[string]any{"type": "integer"}},
+	}
+	prov := &statefulScriptProvider{scripts: []string{`{"patch":{"count":"bad"}}`}}
+	cx := statefulCtx(schema)
+	fail := "fail"
+	cx.OnInvalidPatch = &fail
+	res, err := Run(context.Background(), RunOptions{
+		Provider: prov, Model: "x",
+		Dispatcher: tools.NewDispatcher(nil),
+		Segments:   statefulTaskSegs(),
+		Context:    cx,
+	})
+	if err == nil {
+		t.Fatal("on_invalid_patch=fail must return an error on an invalid patch")
+	}
+	if res.StopReason != "invalid_patch" {
+		t.Errorf("stop reason = %q, want invalid_patch", res.StopReason)
+	}
+	if prov.calls() != 1 {
+		t.Errorf("provider called %d times, want 1 (no retry on fail)", prov.calls())
+	}
+}
+
+// max_iterations bounds a stateful run that never finishes.
+func TestRun_Stateful_MaxIterations(t *testing.T) {
+	// A script that always emits a valid patch + an action, never done.
+	loopStep := `{"patch":{"n":1},"action":{"tool":"Echo","input":{}}}`
+	scripts := make([]string, 10)
+	for i := range scripts {
+		scripts[i] = loopStep
+	}
+	prov := &statefulScriptProvider{scripts: scripts}
+	echo := &echoTool{reply: "again"}
+	res, err := Run(context.Background(), RunOptions{
+		Provider: prov, Model: "x",
+		Tools:         []tools.Tool{echo},
+		Dispatcher:    tools.NewDispatcher([]tools.Tool{echo}),
+		Segments:      statefulTaskSegs(),
+		Context:       statefulCtx(nil),
+		MaxIterations: 3,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.StopReason != "max_iterations" {
+		t.Errorf("stop reason = %q, want max_iterations", res.StopReason)
+	}
+	if res.Iterations != 3 {
+		t.Errorf("iterations = %d, want 3", res.Iterations)
+	}
+}
+
+func TestParseEmitState(t *testing.T) {
+	es, err := parseEmitState(json.RawMessage(`{"reasoning":"r","patch":{"a":1},"action":{"tool":"Echo","input":{"x":2}}}`))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if es.Reasoning != "r" || es.Action == nil || es.Action.Tool != "Echo" {
+		t.Errorf("parsed wrong: %+v", es)
+	}
+	if v, _ := es.Patch["a"].(float64); v != 1 {
+		t.Errorf("patch a = %v, want 1", es.Patch["a"])
+	}
+	// A missing patch defaults to an empty (non-nil) map — a no-change step is legal.
+	es2, err := parseEmitState(json.RawMessage(`{"done":true,"final":"x"}`))
+	if err != nil || es2.Patch == nil {
+		t.Errorf("missing patch should default to empty map, got %+v err=%v", es2, err)
+	}
+	// Malformed JSON errors.
+	if _, err := parseEmitState(json.RawMessage(`{not json`)); err == nil {
+		t.Error("malformed emit_state should error")
+	}
+}
+
+func TestStatefulUserMessage_OnlySigmaAndObs(t *testing.T) {
+	m := statefulUserMessage(map[string]any{"count": 3}, "the latest thing")
+	if m.Role != "user" || len(m.Content) != 1 {
+		t.Fatalf("want one user content block, got %+v", m)
+	}
+	body := m.Content[0].Text
+	if !strings.Contains(body, `"count":3`) {
+		t.Errorf("Σ not rendered: %q", body)
+	}
+	if !strings.Contains(body, "the latest thing") {
+		t.Errorf("observation not rendered: %q", body)
+	}
+}
+
+// The dispatched action sees the LIVE Σ via ctx (the data path Context op=state
+// relies on): after step 0's patch merges count=5, the Echo action observes
+// Σ={count:5}.
+func TestRun_Stateful_ActionSeesLiveState(t *testing.T) {
+	prov := &statefulScriptProvider{scripts: []string{
+		`{"patch":{"count":5},"action":{"tool":"Echo","input":{}}}`,
+		`{"patch":{},"done":true,"final":"fin"}`,
+	}}
+	echo := &echoTool{reply: "ok"}
+	_, err := Run(context.Background(), RunOptions{
+		Provider: prov, Model: "x",
+		Tools:      []tools.Tool{echo},
+		Dispatcher: tools.NewDispatcher([]tools.Tool{echo}),
+		Segments:   statefulTaskSegs(),
+		Context:    statefulCtx(nil),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	echo.mu.Lock()
+	saw := echo.sawState
+	echo.mu.Unlock()
+	if c, _ := saw["count"].(float64); c != 5 {
+		t.Errorf("action saw Σ count = %v, want the live 5", saw["count"])
+	}
+}

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -535,6 +535,15 @@ const (
 	// retained (non-destructive audit).
 	EventContextRecap EventType = "context_recap"
 
+	// EventContextState marks one step of an L2 structured-execution-state run
+	// (RFC CR `context.mode: stateful`): the model emitted a patch, the runtime
+	// merged it into the state object Σ, and (unless done) will execute the next
+	// action. Sibling of EventContextRecap — it carries the post-merge Σ so the
+	// transcript is a full audit of how the state evolved, and a client can render
+	// the live state. The reasoning is forwarded once here and then discarded (not
+	// fed to the next step).
+	EventContextState EventType = "context_state"
+
 	// EventLimit carries a per-scope token-budget crossing (RFC AW): a soft
 	// crossing (warn, run continues) or a hard crossing (a mid-run notice; the
 	// run still finishes, but the NEXT run for the scope is refused at
@@ -629,6 +638,10 @@ type Event struct {
 	// running reasoning-recap that replaces prior history in L1 recap mode, RFC
 	// CR). Nil otherwise.
 	ContextRecap *ContextRecapEventInfo `json:"context_recap,omitempty"`
+
+	// ContextState carries the structured payload on EventContextState (the
+	// post-merge state Σ + the applied patch, RFC CR L2). Nil otherwise.
+	ContextState *ContextStateEventInfo `json:"context_state,omitempty"`
 
 	// Limit carries the structured payload on EventLimit (a per-scope
 	// token-budget crossing, RFC AW). Nil on all other event types.
@@ -888,6 +901,20 @@ type ContextRecapEventInfo struct {
 	// Reasoning echoes the R-layer policy that produced this ("recap" | "drop").
 	// Informational; replay uses Recap directly.
 	Reasoning string `json:"reasoning,omitempty"`
+}
+
+// ContextStateEventInfo is the structured payload on EventContextState (RFC CR L2
+// structured execution state). State is the post-merge Σ; Patch is the merge-patch
+// the model emitted this step (a null value deleted a key). Iter is the 0-based
+// step index. Action names the tool the step will run next (empty when the run is
+// finishing). Reasoning is the model's discarded step reasoning (carried once for
+// audit, never fed forward).
+type ContextStateEventInfo struct {
+	State     map[string]any `json:"state"`
+	Patch     map[string]any `json:"patch,omitempty"`
+	Iter      int            `json:"iter"`
+	Action    string         `json:"action,omitempty"`
+	Reasoning string         `json:"reasoning,omitempty"`
 }
 
 // MemoryBankedInfo is the outcome of a compaction's memory flush. It is on the

--- a/internal/statepatch/statepatch.go
+++ b/internal/statepatch/statepatch.go
@@ -1,0 +1,168 @@
+// Package statepatch implements the two operations RFC CR L2 (structured
+// execution state) needs on the state object Σ: a JSON Merge Patch (RFC 7386,
+// null-deletes) to apply a model-proposed patch, and a minimal JSON-Schema
+// validator for that patch.
+//
+// It is deliberately small — it supports the flat, typed object schemas the
+// state protocol uses (object / properties / required / additionalProperties,
+// scalar types, and array-of-items), not the full JSON Schema spec (no $ref,
+// no formats, no patternProperties). That subset is what an operator- or
+// model-authored state schema needs; extend it here when a real schema does.
+// No external dependency (the repo vendors no schema validator).
+package statepatch
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+)
+
+// Merge applies an RFC 7386 JSON Merge Patch to base: a null value in `patch`
+// DELETES the key, two objects merge recursively, and any other value (scalar or
+// array) replaces. Neither input is mutated; the result is a fresh top-level map
+// (unpatched nested subtrees are shared by reference — the caller treats Σ as
+// immutable per step, replacing it wholesale, so nothing mutates them in place).
+// A nil base is treated as empty.
+func Merge(base, patch map[string]any) map[string]any {
+	out := make(map[string]any, len(base)+len(patch))
+	for k, v := range base {
+		out[k] = v
+	}
+	for k, pv := range patch {
+		if pv == nil {
+			delete(out, k) // RFC 7386: null deletes
+			continue
+		}
+		if pm, ok := pv.(map[string]any); ok {
+			if bm, ok := out[k].(map[string]any); ok {
+				out[k] = Merge(bm, pm) // both objects → recurse
+				continue
+			}
+		}
+		out[k] = pv // scalar / array / type-mismatch → replace
+	}
+	return out
+}
+
+// ValidatePatch checks a patch against the schema subset: every non-null value
+// must match the declared type of its property, and — when the (nested)
+// additionalProperties is false — no key outside `properties` may appear. Null
+// values (deletions) always pass. An empty/nil schema passes everything
+// (permissive: a stateful run may run before a schema is adopted).
+//
+// `required` is intentionally NOT enforced here. Σ accretes over a run, so a
+// per-step patch legitimately omits fields that are not set yet; completeness is
+// a whole-Σ property, not a patch property. The invariant this enforces is "no
+// patch ever writes a wrong-typed or unknown field into Σ".
+func ValidatePatch(schema, patch map[string]any) error {
+	if len(schema) == 0 {
+		return nil
+	}
+	return validateObject("", schema, patch)
+}
+
+// validateObject checks the keys of `obj` against an object schema's properties +
+// additionalProperties. name is the dotted path prefix for error messages ("" at
+// the root).
+func validateObject(name string, schema, obj map[string]any) error {
+	props, _ := schema["properties"].(map[string]any)
+	additional := true
+	if b, ok := schema["additionalProperties"].(bool); ok {
+		additional = b
+	}
+	for k, v := range obj {
+		if v == nil {
+			continue // deletion / explicit null
+		}
+		ps, ok := props[k].(map[string]any)
+		if !ok {
+			if !additional {
+				return fmt.Errorf("field %q: not permitted by the schema (additionalProperties=false)", qualify(name, k))
+			}
+			continue
+		}
+		if err := checkType(qualify(name, k), ps, v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// checkType verifies v against a property schema's `type` (and recurses for
+// object/array).
+func checkType(name string, schema map[string]any, v any) error {
+	t, _ := schema["type"].(string)
+	switch t {
+	case "", "null":
+		return nil // untyped → accept anything
+	case "string":
+		if _, ok := v.(string); !ok {
+			return typeErr(name, "string", v)
+		}
+	case "boolean":
+		if _, ok := v.(bool); !ok {
+			return typeErr(name, "boolean", v)
+		}
+	case "number":
+		if _, ok := asFloat(v); !ok {
+			return typeErr(name, "number", v)
+		}
+	case "integer":
+		f, ok := asFloat(v)
+		if !ok || f != math.Trunc(f) {
+			return typeErr(name, "integer", v)
+		}
+	case "object":
+		m, ok := v.(map[string]any)
+		if !ok {
+			return typeErr(name, "object", v)
+		}
+		return validateObject(name, schema, m)
+	case "array":
+		arr, ok := v.([]any)
+		if !ok {
+			return typeErr(name, "array", v)
+		}
+		if items, ok := schema["items"].(map[string]any); ok {
+			for i, e := range arr {
+				if err := checkType(fmt.Sprintf("%s[%d]", name, i), items, e); err != nil {
+					return err
+				}
+			}
+		}
+	default:
+		return fmt.Errorf("field %q: unsupported schema type %q", name, t)
+	}
+	return nil
+}
+
+// asFloat coerces a JSON-decoded numeric (float64), a json.Number, or a Go
+// int/int64 to float64. Returns false for a non-number.
+func asFloat(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case float32:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case json.Number:
+		f, err := n.Float64()
+		return f, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func typeErr(name, want string, got any) error {
+	return fmt.Errorf("field %q: want %s, got %T", name, want, got)
+}
+
+func qualify(prefix, key string) string {
+	if prefix == "" {
+		return key
+	}
+	return prefix + "." + key
+}

--- a/internal/statepatch/statepatch_test.go
+++ b/internal/statepatch/statepatch_test.go
@@ -1,0 +1,130 @@
+package statepatch
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+// jsonMap decodes a JSON literal into a map the way a real patch/state arrives
+// (numbers become float64, etc.) so the tests exercise the actual value shapes.
+func jsonMap(t *testing.T, s string) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal([]byte(s), &m); err != nil {
+		t.Fatalf("bad json %q: %v", s, err)
+	}
+	return m
+}
+
+func TestMerge_RFC7386(t *testing.T) {
+	cases := []struct {
+		name              string
+		base, patch, want string
+	}{
+		{"set new key", `{"a":1}`, `{"b":2}`, `{"a":1,"b":2}`},
+		{"replace scalar", `{"a":1}`, `{"a":2}`, `{"a":2}`},
+		{"null deletes", `{"a":1,"b":2}`, `{"a":null}`, `{"b":2}`},
+		{"delete-missing is a no-op", `{"a":1}`, `{"zzz":null}`, `{"a":1}`},
+		{"nested objects merge recursively", `{"o":{"x":1,"y":2}}`, `{"o":{"y":3,"z":4}}`, `{"o":{"x":1,"y":3,"z":4}}`},
+		{"array replaces (not merged)", `{"a":[1,2,3]}`, `{"a":[9]}`, `{"a":[9]}`},
+		{"object replaces a scalar", `{"a":1}`, `{"a":{"x":1}}`, `{"a":{"x":1}}`},
+		{"scalar replaces an object", `{"a":{"x":1}}`, `{"a":5}`, `{"a":5}`},
+		{"nested null deletes a subkey", `{"o":{"x":1,"y":2}}`, `{"o":{"x":null}}`, `{"o":{"y":2}}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			base, patch, want := jsonMap(t, c.base), jsonMap(t, c.patch), jsonMap(t, c.want)
+			got := Merge(base, patch)
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("Merge(%s, %s) = %v, want %v", c.base, c.patch, got, want)
+			}
+			// Inputs must not be mutated.
+			if !reflect.DeepEqual(base, jsonMap(t, c.base)) {
+				t.Errorf("Merge mutated base: %v", base)
+			}
+			if !reflect.DeepEqual(patch, jsonMap(t, c.patch)) {
+				t.Errorf("Merge mutated patch: %v", patch)
+			}
+		})
+	}
+}
+
+func TestMerge_NilBase(t *testing.T) {
+	got := Merge(nil, jsonMap(t, `{"a":1}`))
+	if !reflect.DeepEqual(got, jsonMap(t, `{"a":1}`)) {
+		t.Errorf("Merge(nil, x) = %v", got)
+	}
+}
+
+func schema(t *testing.T, s string) map[string]any { return jsonMap(t, s) }
+
+func TestValidatePatch_TypesAndUnknownKeys(t *testing.T) {
+	sc := schema(t, `{
+		"type":"object",
+		"additionalProperties":false,
+		"properties":{
+			"count":{"type":"integer"},
+			"name":{"type":"string"},
+			"ratio":{"type":"number"},
+			"done":{"type":"boolean"},
+			"tags":{"type":"array","items":{"type":"string"}},
+			"meta":{"type":"object","additionalProperties":false,"properties":{"k":{"type":"string"}}}
+		}
+	}`)
+
+	good := []string{
+		`{"count":3}`,
+		`{"name":"x","done":true}`,
+		`{"ratio":1.5}`,
+		`{"count":5.0}`, // integral float is a valid integer (JSON has no int/float split)
+		`{"tags":["a","b"]}`,
+		`{"meta":{"k":"v"}}`,
+		`{"count":null}`,      // deletion always ok
+		`{"name":null}`,       // deletion of a typed field ok
+		`{"meta":{"k":null}}`, // nested deletion ok
+	}
+	for _, p := range good {
+		if err := ValidatePatch(sc, jsonMap(t, p)); err != nil {
+			t.Errorf("patch %s should be valid: %v", p, err)
+		}
+	}
+
+	bad := []struct{ patch, why string }{
+		{`{"count":"three"}`, "string for integer"},
+		{`{"count":1.5}`, "non-integral for integer"},
+		{`{"name":7}`, "number for string"},
+		{`{"done":"yes"}`, "string for boolean"},
+		{`{"tags":[1,2]}`, "int elements for array-of-string"},
+		{`{"tags":"a"}`, "string for array"},
+		{`{"meta":{"k":9}}`, "number for nested string"},
+		{`{"meta":{"other":"x"}}`, "unknown nested key with additionalProperties=false"},
+		{`{"bogus":1}`, "unknown top-level key with additionalProperties=false"},
+	}
+	for _, c := range bad {
+		if err := ValidatePatch(sc, jsonMap(t, c.patch)); err == nil {
+			t.Errorf("patch %s should be REJECTED (%s)", c.patch, c.why)
+		}
+	}
+}
+
+func TestValidatePatch_AdditionalAllowedByDefault(t *testing.T) {
+	// No additionalProperties → unknown keys pass (permissive default).
+	sc := schema(t, `{"type":"object","properties":{"a":{"type":"integer"}}}`)
+	if err := ValidatePatch(sc, jsonMap(t, `{"a":1,"anything":"goes"}`)); err != nil {
+		t.Errorf("unknown key should pass when additionalProperties is unset: %v", err)
+	}
+	// But a KNOWN key is still type-checked.
+	if err := ValidatePatch(sc, jsonMap(t, `{"a":"nope"}`)); err == nil {
+		t.Error("known key must still be type-checked")
+	}
+}
+
+func TestValidatePatch_EmptySchemaPermissive(t *testing.T) {
+	if err := ValidatePatch(nil, jsonMap(t, `{"a":1,"b":"x"}`)); err != nil {
+		t.Errorf("nil schema must accept everything: %v", err)
+	}
+	if err := ValidatePatch(map[string]any{}, jsonMap(t, `{"a":1}`)); err != nil {
+		t.Errorf("empty schema must accept everything: %v", err)
+	}
+}

--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -1428,11 +1428,14 @@ func signFromMergedDef(name string, def mergedDef) string {
 	// Context is content-identifying, same as Compaction (RFC CR).
 	if cx := def.Context; !cx.IsZero() {
 		c.Context = &agents.Context{
-			Mode:           cx.Mode,
-			KeepLastN:      cx.KeepLastN,
-			Reasoning:      cx.Reasoning,
-			RecapMaxChars:  cx.RecapMaxChars,
-			AutoRecapAtPct: cx.AutoRecapAtPct,
+			Mode:            cx.Mode,
+			KeepLastN:       cx.KeepLastN,
+			Reasoning:       cx.Reasoning,
+			RecapMaxChars:   cx.RecapMaxChars,
+			AutoRecapAtPct:  cx.AutoRecapAtPct,
+			StateSchema:     cx.StateSchema,
+			OnInvalidPatch:  cx.OnInvalidPatch,
+			MaxPatchRetries: cx.MaxPatchRetries,
 		}
 	}
 	return agents.Sign(c)

--- a/internal/tools/builtin/agentdef_sha256_test.go
+++ b/internal/tools/builtin/agentdef_sha256_test.go
@@ -100,6 +100,9 @@ func TestAgentDefTool_ForkInteractiveConfigMovesHash(t *testing.T) {
 		// RFC CR: the context / retention block is behaviour-bearing (it changes how
 		// every run's history is distilled), so a fork setting it must move the hash.
 		"context": `{"op":"fork","name":"researcher","overlay":{"system_prompt":"v1","context":{"mode":"recap"}}}`,
+		// RFC CR L2: the state_schema map is content-identifying too — easy to drop
+		// from the hash since it's a map, not a scalar pointer.
+		"context_state_schema": `{"op":"fork","name":"researcher","overlay":{"system_prompt":"v1","context":{"mode":"stateful","state_schema":{"type":"object","properties":{"count":{"type":"integer"}}}}}}`,
 	}
 	for field, overlay := range cases {
 		res, _ := tool.Execute(ctx, json.RawMessage(overlay))

--- a/internal/tools/builtin/context.go
+++ b/internal/tools/builtin/context.go
@@ -121,7 +121,7 @@ const contextDescription = `Read-only runtime introspection. ` +
 const contextInputSchema = `{
   "type": "object",
   "properties": {
-    "op":              {"type": "string", "enum": ["self","tools","guide","doc","permissions","agents","lineage","evaluations","channels","help","time","compact","capabilities"], "description": "Which introspection op to run."},
+    "op":              {"type": "string", "enum": ["self","tools","guide","doc","permissions","agents","lineage","evaluations","channels","help","time","compact","state","capabilities"], "description": "Which introspection op to run."},
     "name":            {"type": "string", "description": "doc only: the tool name to fetch detailed docs for."},
     "prefix":          {"type": "string", "description": "agents / channels: optional name prefix filter."},
     "def_id":          {"type": "string", "description": "lineage / evaluations: the agent_defs row id to inspect. Use Context.agents to discover def_ids first."},
@@ -186,13 +186,35 @@ func (c *Context) Execute(ctx context.Context, raw json.RawMessage) (tools.Resul
 		return c.execTime(ctx)
 	case "compact":
 		return c.execCompact(ctx)
+	case "state":
+		return c.execState(ctx)
 	case "capabilities":
 		return c.execCapabilities(ctx)
 	case "":
 		return errResult("missing required field: op"), nil
 	default:
-		return errResult(fmt.Sprintf("unknown op %q (must be one of: self, tools, guide, doc, permissions, agents, lineage, evaluations, channels, help, time, compact, capabilities)", in.Op)), nil
+		return errResult(fmt.Sprintf("unknown op %q (must be one of: self, tools, guide, doc, permissions, agents, lineage, evaluations, channels, help, time, compact, state, capabilities)", in.Op)), nil
 	}
+}
+
+// ---- state ----
+
+// execState returns the CURRENT structured execution state Σ of an L2 stateful
+// run (RFC CR `context.mode: stateful`). A stateful agent doesn't call tools
+// directly — it names an action — so this is reachable when it names `Context`
+// (op=state) as its action, to read back what it has recorded so far. Returns an
+// empty state (not an error) on a stateful run that hasn't recorded anything yet,
+// and an error on a non-stateful run where there is no Σ.
+func (c *Context) execState(ctx context.Context) (tools.Result, error) {
+	h := tools.ExecutionState(ctx)
+	if h == nil {
+		return errResult("structured execution state is not available (this run is not in context.mode=stateful)"), nil
+	}
+	state := h.Sigma
+	if state == nil {
+		state = map[string]any{}
+	}
+	return okJSON(map[string]any{"state": state})
 }
 
 // ---- compact ----

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -1010,6 +1010,29 @@ func WithContextPolicy(ctx context.Context, c *config.Context) context.Context {
 	return context.WithValue(ctx, ctxKeyContextPolicy{}, c)
 }
 
+type ctxKeyExecState struct{}
+
+// ExecStateHolder holds the live structured execution state Σ of an L2 stateful
+// run (RFC CR `context.mode: stateful`). The loop re-points Sigma each step
+// before dispatching an action, so a stateful agent that names `Context` as its
+// action (op=state) reads the current state. A pointer holder (not the map
+// directly) so the loop can swap Σ wholesale each step without re-stamping ctx.
+type ExecStateHolder struct{ Sigma map[string]any }
+
+// WithExecutionState attaches the live-Σ holder to ctx. nil is a no-op.
+func WithExecutionState(ctx context.Context, h *ExecStateHolder) context.Context {
+	if h == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, ctxKeyExecState{}, h)
+}
+
+// ExecutionState returns the live-Σ holder, or nil when the run is not stateful.
+func ExecutionState(ctx context.Context) *ExecStateHolder {
+	h, _ := ctx.Value(ctxKeyExecState{}).(*ExecStateHolder)
+	return h
+}
+
 // ContextPolicy returns the inherited layered-context settings (sparse), or nil.
 func ContextPolicy(ctx context.Context) *config.Context {
 	c, _ := ctx.Value(ctxKeyContextPolicy{}).(*config.Context)


### PR DESCRIPTION
Builds on #1117 (P1 L1 reasoning-recap). This is the **L2 core**: `context.mode: stateful` — the structured-execution-state loop, the top-performing arm on the RFC CS benchmark at long horizon on a weak local model.

## Why

L1 recap distils a growing history; L2 removes the history entirely. The model is fed only **(P, Σ, O)** — preamble, a structured state object Σ, the latest observation — and maintains Σ explicitly instead of re-reading prose. Cost is O(T) (flat prompt), and the model carries a typed working memory that doesn't drift the way a summarized transcript does. Author-provided schema first (the paper's proven static-schema config, and RFC CR's own O2 note); the model-proposed→operator-adopted flow is the next PR.

## What

`mode: stateful` makes `Run()` branch into a **self-contained loop** (separate from the append/recap body, so it can't regress the shipped path). Each step:

1. Feed `[P, Σ, O]` — exactly one message (Σ + O); a test asserts the prompt stays flat across steps.
2. The model emits **one `emit_state` call** `{reasoning, patch, action, done, final}` — the single tool offered, so it must call it. This is how we get a reliable structured object with **no provider-specific forced-output primitive** (the confirmed design choice), reusing the existing tool-use parse.
3. Validate the patch against `state_schema`, **merge** it into Σ with JSON-merge-patch (null deletes), emit a `context_state` marker (full Σ on the transcript for audit), discard the reasoning.
4. Dispatch the named **action** via the normal dispatcher → next observation. `done`/no-action finishes with `final`.
5. An invalid patch is **rolled back and retried** (the model sees its rejected `emit_state` + the reason) up to `max_patch_retries`, or ends the run on `on_invalid_patch: fail`.

A stateful agent reads its own Σ mid-run via **`Context op=state`** (it names `Context` as an action); the loop stamps the live-Σ holder on the dispatch ctx. `RunResult.State` carries the final Σ.

### Commits
1. **config** — `mode: stateful` accepted, `state_schema` (map, hashed deterministically) + `on_invalid_patch` + `max_patch_retries` on the `context:` block, full merge/validate/hash/lookup parity (mirrors P1). state_schema is optional (permissive when absent) and content-identifying.
2. **statepatch** — a dependency-free package: RFC 7386 `Merge` (null-deletes, recursive object merge) + a hand-rolled `ValidatePatch` over the schema subset (object/properties/additionalProperties + scalars + array-items; type-checks non-null values + rejects unknown keys; `required` not enforced per-step since Σ accretes).
3. **loop** — the stateful loop + `emit_state` tool + `EventContextState` marker + `Context op=state` + `WithExecutionState`.
4. **docs**.

## Tested
- **statepatch:** RFC 7386 merge (set/replace/null-delete/recursive/array-replace) + validator (types, unknown-keys, nested, permissive-empty).
- **config:** reflective Clone/Merge/IsZero/Validate over all fields incl. the schema map; `state_schema` moves the content hash; stateful mode validates.
- **loop (through `Run()`):** evolve-Σ-and-dispatch happy path, the **flat-prompt** property, invalid-patch **retry** and **fail**, `max_iterations`, `emit_state` parse, and the **live-Σ action** path (an action reads the current Σ).
- `go test ./...` clean. Manual: `loomcycle validate` accepts a `mode: stateful` agent with a nested `state_schema`.

## Deferred (documented)
- Interactive steering / pause / cross-instance resume of a mid-flight stateful run (a step re-derives cheaply from Σ) — composes on top later.
- The model-proposed→operator-adopted `state_schema` flow (ontology-style) — next PR.
- gRPC/MCP/adapter per-run `context` parity — P4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)