### PR TITLE
fix: the consolidator can reach a declared scope; a capability-only override no longer hits the code cap

### DIFF
--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -201,13 +201,32 @@ agents:
     # surfaces (the chat listing, a second consolidator's scan), and a schedule
     # pointed at a differently-named agent would not exclude it at all.
     internal: true
-    memory_scopes: [agent, user]  # user = the fan-out target; agent = its own bookkeeping
-    # NO sql_scopes, deliberately, even though the entity half writes chunk
-    # STRUCTURE into SQL Memory. The Document tool issues its own trusted SQL and
-    # checks `sql_scopes` only for TENANT scope — agent and user are ungated — so
-    # granting it here would buy nothing and hand an injected instruction the raw
-    # `Memory sql_exec` surface. The absence is what keeps the consolidator unable
-    # to write the tenant-shared store at all, whatever a transcript asks for.
+    # user = the fan-out target; agent = its own bookkeeping; tenant = the shared
+    # plane a type may DECLARE its facts belong in (`@memory_scope` in the tenant's
+    # ontology document). A fact lands in tenant scope only when the ontology says
+    # so AND the subject survives every placement guard — a fact about the profile
+    # owner, or about a subject typed two different ways, stays with the user.
+    memory_scopes: [agent, user, tenant]
+    # tenant, and ONLY tenant. A fact is stored twice — a k/v row (what `recall`
+    # searches) and a typed chunk (what a graph walk reaches) — and the chunk half
+    # is what this gate governs: the Document tool issues its own trusted SQL and
+    # checks `sql_scopes` for TENANT scope alone, leaving agent/user ungated. So
+    # without this the two halves of a placed fact could not land in the same
+    # scope, and placement would be unreachable in a default deployment.
+    #
+    # This grant WAS deliberately absent, on the argument that an unused grant is
+    # the capability an injected instruction reaches for. That argument is written
+    # for a PROMPT-driven agent: it holds only where model output steers the
+    # control flow. This agent is `provider: code-js` — a deterministic body,
+    # shipped by the operator, in which model output is data that gets written and
+    # never code that gets run. `Memory sql_exec` is reachable only from the body,
+    # so the grant widens what THIS code can do, not what a transcript can talk it
+    # into. What actually bounds the tenant write is the server-side placement
+    # resolver, which fails closed on every uncertainty.
+    #
+    # It is also INERT on its own: no shipped ontology type declares a scope, so a
+    # default deployment places nothing until an operator declares one per tenant.
+    sql_scopes: [tenant]
     memory_consolidation: true    # the cursor / supersede / pending-queue control ops
     history_scope: [user]         # narrowest scope that can read the target user's chats
     # ⚠️ MUST STAY BELOW the LEASE_TTL_MS literal in the body below. A pass that

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -201,13 +201,32 @@ agents:
     # surfaces (the chat listing, a second consolidator's scan), and a schedule
     # pointed at a differently-named agent would not exclude it at all.
     internal: true
-    memory_scopes: [agent, user]  # user = the fan-out target; agent = its own bookkeeping
-    # NO sql_scopes, deliberately, even though the entity half writes chunk
-    # STRUCTURE into SQL Memory. The Document tool issues its own trusted SQL and
-    # checks `sql_scopes` only for TENANT scope — agent and user are ungated — so
-    # granting it here would buy nothing and hand an injected instruction the raw
-    # `Memory sql_exec` surface. The absence is what keeps the consolidator unable
-    # to write the tenant-shared store at all, whatever a transcript asks for.
+    # user = the fan-out target; agent = its own bookkeeping; tenant = the shared
+    # plane a type may DECLARE its facts belong in (`@memory_scope` in the tenant's
+    # ontology document). A fact lands in tenant scope only when the ontology says
+    # so AND the subject survives every placement guard — a fact about the profile
+    # owner, or about a subject typed two different ways, stays with the user.
+    memory_scopes: [agent, user, tenant]
+    # tenant, and ONLY tenant. A fact is stored twice — a k/v row (what `recall`
+    # searches) and a typed chunk (what a graph walk reaches) — and the chunk half
+    # is what this gate governs: the Document tool issues its own trusted SQL and
+    # checks `sql_scopes` for TENANT scope alone, leaving agent/user ungated. So
+    # without this the two halves of a placed fact could not land in the same
+    # scope, and placement would be unreachable in a default deployment.
+    #
+    # This grant WAS deliberately absent, on the argument that an unused grant is
+    # the capability an injected instruction reaches for. That argument is written
+    # for a PROMPT-driven agent: it holds only where model output steers the
+    # control flow. This agent is `provider: code-js` — a deterministic body,
+    # shipped by the operator, in which model output is data that gets written and
+    # never code that gets run. `Memory sql_exec` is reachable only from the body,
+    # so the grant widens what THIS code can do, not what a transcript can talk it
+    # into. What actually bounds the tenant write is the server-side placement
+    # resolver, which fails closed on every uncertainty.
+    #
+    # It is also INERT on its own: no shipped ontology type declares a scope, so a
+    # default deployment places nothing until an operator declares one per tenant.
+    sql_scopes: [tenant]
     memory_consolidation: true    # the cursor / supersede / pending-queue control ops
     history_scope: [user]         # narrowest scope that can read the target user's chats
     # ⚠️ MUST STAY BELOW the LEASE_TTL_MS literal in the body below. A pass that

--- a/cmd/loomcycle/presets_agent_override_test.go
+++ b/cmd/loomcycle/presets_agent_override_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+)
+
+// TestAgentOverride_ReDeclaringABundleAgentKeepsItsBody is the operator story that broke a
+// live deployment: an operator adds a few fields to a BUNDLED agent — the documented way to
+// grant it a scope — and the agent must keep everything the bundle gave it.
+//
+// The consolidator is the worst case and the one that failed: it is a code-js agent whose
+// whole behaviour IS its code_body (~139 KB), so silently losing that yields an agent with a
+// provider and nothing to run.
+func TestAgentOverride_ReDeclaringABundleAgentKeepsItsBody(t *testing.T) {
+	dir := t.TempDir()
+	overlay := filepath.Join(dir, "grant.yaml")
+	if err := os.WriteFile(overlay, []byte(
+		"agents:\n  memory/consolidator:\n    memory_scopes: [agent, user, tenant]\n    sql_scopes: [tenant]\n",
+	), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	base, err := config.LoadLayers(layersFor(t, "base", "memory")...)
+	if err != nil {
+		t.Fatalf("baseline load: %v", err)
+	}
+	bAgent, ok := base.Agents["memory/consolidator"]
+	if !ok {
+		t.Fatal("baseline: the bundle declares no memory/consolidator")
+	}
+	if len(bAgent.Code) == 0 {
+		t.Fatal("baseline: the bundled consolidator has no code_body — fixture is wrong")
+	}
+
+	layers := append(layersFor(t, "base", "memory"), config.Layer{Name: "operator-overlay", Data: mustRead(t, overlay)})
+	got, err := config.LoadLayers(layers...)
+	if err != nil {
+		t.Fatalf("load with the operator overlay: %v", err)
+	}
+	a, ok := got.Agents["memory/consolidator"]
+	if !ok {
+		t.Fatal("the overlay removed the agent entirely")
+	}
+
+	// The grants the operator asked for.
+	if len(a.MemoryScopes) != 3 || a.MemoryScopes[2] != "tenant" {
+		t.Errorf("memory_scopes = %v, want the overlay's three", a.MemoryScopes)
+	}
+	if len(a.SqlScopes) != 1 || a.SqlScopes[0] != "tenant" {
+		t.Errorf("sql_scopes = %v, want [tenant]", a.SqlScopes)
+	}
+
+	// Everything the bundle gave it must survive. code_body FIRST: it is the whole agent.
+	if len(a.Code) != len(bAgent.Code) {
+		t.Errorf("code_body went from %d bytes to %d — an operator adding a grant must not "+
+			"erase the agent's behaviour", len(bAgent.Code), len(a.Code))
+	}
+	if a.Provider != bAgent.Provider {
+		t.Errorf("provider %q -> %q", bAgent.Provider, a.Provider)
+	}
+	if len(a.Tools) != len(bAgent.Tools) {
+		t.Errorf("tools %v -> %v", bAgent.Tools, a.Tools)
+	}
+	if a.MemoryConsolidation != bAgent.MemoryConsolidation {
+		t.Errorf("memory_consolidation %v -> %v — the consolidation ops would refuse",
+			bAgent.MemoryConsolidation, a.MemoryConsolidation)
+	}
+	if a.HistoryScope == nil && bAgent.HistoryScope != nil {
+		t.Errorf("history_scope %v -> nil", bAgent.HistoryScope)
+	}
+}
+
+// The same overlay, layered onto a stack WITHOUT the bundle it means to widen. The merge
+// cannot know the difference, so it builds a half agent — capability grants and nothing to
+// run — and config validation refuses it. What the refusal must do is point at the missing
+// bundle, because the reader's eye goes to the overlay they just wrote.
+func TestAgentOverride_OverlayWithoutItsBundleNamesTheMissingLayer(t *testing.T) {
+	dir := t.TempDir()
+	overlay := filepath.Join(dir, "grant.yaml")
+	if err := os.WriteFile(overlay, []byte(
+		"agents:\n  memory/consolidator:\n    memory_scopes: [agent, user, tenant]\n    sql_scopes: [tenant]\n",
+	), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// "base" only — the memory bundle, which defines the agent, is absent.
+	layers := append(layersFor(t, "base"), config.Layer{Name: "operator-overlay", Data: mustRead(t, overlay)})
+	_, err := config.LoadLayers(layers...)
+	if err == nil {
+		t.Fatal("an agent with grants but no provider/model/tier must be refused")
+	}
+	for _, want := range []string{"LOOMCYCLE_PRESETS", "memory/consolidator", "capability grants"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("refusal should mention %q so the reader looks at the layer stack; got: %v", want, err)
+		}
+	}
+}
+
+func mustRead(t *testing.T, path string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return b
+}

--- a/cmd/loomcycle/presets_memory_test.go
+++ b/cmd/loomcycle/presets_memory_test.go
@@ -92,8 +92,11 @@ func TestConsolidatorBundle_Validates(t *testing.T) {
 	if !extractor.Internal {
 		t.Error("memory/extractor must set internal: true — its sessions are the bulk of the self-consumption loop (one per chat read, every pass, each containing the chat it just extracted)")
 	}
-	// user = the fan-out target's scope; agent = the consolidator's own bookkeeping.
-	for _, want := range []string{"agent", "user"} {
+	// user = the fan-out target's scope; agent = the consolidator's own
+	// bookkeeping; tenant = the shared plane an ontology type may declare its
+	// facts belong in. Without tenant on BOTH grants, placement is unreachable
+	// in a stock deployment and an operator has to override the agent to try it.
+	for _, want := range []string{"agent", "user", "tenant"} {
 		if !containsString(agent.MemoryScopes, want) {
 			t.Errorf("memory_scopes should include %q; got %v", want, agent.MemoryScopes)
 		}
@@ -102,14 +105,24 @@ func TestConsolidatorBundle_Validates(t *testing.T) {
 	if !containsString(agent.HistoryScope, "user") {
 		t.Errorf("history_scope should include user (the narrowest scope that reads the target's chats); got %v", agent.HistoryScope)
 	}
-	// sql_scopes stays GONE even though the entity half writes chunk structure into
-	// SQL Memory. The Document tool issues its own trusted SQL and checks
-	// `sql_scopes` only for TENANT scope — agent and user are ungated — so the
-	// grant would buy nothing while handing an injected instruction the raw
-	// `Memory sql_exec` surface. Its absence is also what makes a tenant-scope
-	// Document write impossible here, whatever a transcript asks for.
-	if len(agent.SqlScopes) != 0 {
-		t.Errorf("memory/consolidator still grants sql_scopes=%v — the code body issues no SQL op, and an unused grant is the capability an injection reaches for", agent.SqlScopes)
+	// sql_scopes is tenant, and ONLY tenant. A placed fact is stored twice — a
+	// k/v row and a typed chunk — and this grant is what lets the chunk half
+	// reach the same scope as the k/v half: the Document tool issues its own
+	// trusted SQL and consults `sql_scopes` for TENANT alone, leaving agent and
+	// user ungated. Anything wider than tenant here is unused, and an unused
+	// grant is the capability an injection reaches for.
+	if strings.Join(agent.SqlScopes, ",") != "tenant" {
+		t.Errorf("sql_scopes should be exactly [tenant] (the chunk half of a placed fact, nothing wider); got %v", agent.SqlScopes)
+	}
+	// What BOUNDS that grant: a code-js body in which model output is data that
+	// gets written and never code that gets run. The grant also opens the raw
+	// `Memory sql_exec` surface, and this body reaching for it is the change
+	// that would turn a bounded widening into an unbounded one — so it must stay
+	// unexercised. If a SQL op is ever added here, re-argue the grant first.
+	for _, op := range []string{"sql_exec", "sql_query", "sql_schema"} {
+		if strings.Contains(agent.Code, op) {
+			t.Errorf("the consolidator body now issues %q — the tenant sql_scopes grant was argued on the body never touching the raw SQL surface", op)
+		}
 	}
 	// The procedure lives in the code body, so neither the old skill nor the old
 	// system prompt may survive as a second, drifting copy that nothing runs.

--- a/docs/SQL_MEMORY.md
+++ b/docs/SQL_MEMORY.md
@@ -69,7 +69,7 @@ storage:
 agents:
   research-bot:
     tools: [Memory, Read, Grep]
-    sql_scopes: [agent, run]      # closed enum {agent,user,run}; empty => every SQL op refuses
+    sql_scopes: [agent, run]      # closed enum {agent,user,run,tenant}; empty => every SQL op refuses
     sql_quota_bytes: 52428800     # optional per-agent override of the global quota
 ```
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5734,6 +5734,28 @@ var validSqlScopes = map[string]bool{
 	"tenant": true, // shared-write across the tenant — see validMemoryScopes
 }
 
+// looksLikeAnOverrideOnly reports whether an agent declaration carries nothing
+// but capability grants — the shape of an operator overlay that was meant to
+// widen an existing agent, not to define a new one.
+func looksLikeAnOverrideOnly(a AgentDef) bool {
+	if a.Code != "" || strings.TrimSpace(a.SystemPrompt) != "" {
+		return false
+	}
+	return len(a.MemoryScopes) > 0 || len(a.SqlScopes) > 0 || len(a.HistoryScope) > 0 ||
+		len(a.Volumes) > 0 || len(a.EvaluationScopes) > 0
+}
+
+// sqlScopeNames renders validSqlScopes for an error message. Derived from the
+// set rather than restated, so the message cannot fall behind the enum.
+func sqlScopeNames() string {
+	names := make([]string, 0, len(validSqlScopes))
+	for k := range validSqlScopes {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}
+
 // validChannelScopes is the closed set of Channel tool scope names
 // accepted on a top-level `channels:` entry. agent + user mirror
 // Memory's vocabulary; global is the cross-tenant fan-out shape.
@@ -6340,6 +6362,17 @@ func validate(c *Config) error {
 			// Back-compat path: agents without either fall back
 			// to defaults.model — same as v0.5.x behaviour.
 			if c.Defaults.Model == "" {
+				// An agent that declares ONLY capability grants is almost
+				// never a new agent — it is an operator overlay meant to
+				// widen a bundled one, layered onto a stack that does not
+				// contain the bundle. Merging then produces this half-built
+				// agent, and the bare size/model complaint sends the reader
+				// looking at their overlay instead of at LOOMCYCLE_PRESETS.
+				if looksLikeAnOverrideOnly(agent) {
+					return fmt.Errorf("agent %q: no model, no tier, and no defaults.model — this declares only capability grants, "+
+						"so it reads as an override of an agent that no earlier config layer defines. Check that the bundle providing "+
+						"%q is in LOOMCYCLE_PRESETS / LOOMCYCLE_CONFIG_DIR, and that the layer carrying the override comes after it", name, name)
+				}
 				return fmt.Errorf("agent %q: no model, no tier, and no defaults.model", name)
 			}
 		}
@@ -6450,10 +6483,12 @@ func validate(c *Config) error {
 		}
 		// RFC AA SQL Memory: validate sql_scopes are known scope strings.
 		// Empty = no SQL access (default-deny, enforced at runtime, not here).
-		// Non-empty must be a subset of {agent, user, run}.
+		// Non-empty must be a subset of validSqlScopes. Keep the message
+		// generated FROM that set: it read "agent, user, run" long after
+		// `tenant` was added, so a correct config looked rejected.
 		for i, sc := range agent.SqlScopes {
 			if !validSqlScopes[sc] {
-				return fmt.Errorf("agent %q: sql_scopes[%d]: unknown scope %q (want one of: agent, user, run)", name, i, sc)
+				return fmt.Errorf("agent %q: sql_scopes[%d]: unknown scope %q (want one of: %s)", name, i, sc, sqlScopeNames())
 			}
 		}
 		// RFC AH Phase 1: a per-agent `volumes` binding must reference a

--- a/internal/memory/templates/ontology.md
+++ b/internal/memory/templates/ontology.md
@@ -49,9 +49,11 @@ Three things it will NOT do, so you can declare one safely:
 - It never places a fact whose subject is typed **inconsistently** — one thing recorded
   as two different types is a thing the store cannot identify, and it is left alone
   with a note rather than filed under a guess.
-- It does nothing at all until the agent that writes memory is granted the scope, on
-  **both** `memory_scopes` and `sql_scopes`. Declaring a scope is not the same as
-  opening one.
+- It does nothing at all unless the agent that writes memory is granted the scope, on
+  **both** `memory_scopes` and `sql_scopes` — a fact is stored twice, and both halves
+  have to be able to land in the same place. The bundled memory agents hold those
+  grants already, so on a stock deployment this declaration is the only switch; a
+  consolidator you configured yourself needs them added.
 
 ## project
 

--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -248,8 +248,10 @@ func (a *AgentDef) execCreate(ctx context.Context, policy tools.AgentDefPolicyVa
 	if err != nil {
 		return errResult(fmt.Sprintf("create: marshal: %s", err)), nil
 	}
-	if a.MaxDefinitionBytes > 0 && len(defJSON) > a.MaxDefinitionBytes {
-		return errResult(fmt.Sprintf("create: definition (%d bytes) exceeds max %d", len(defJSON), a.MaxDefinitionBytes)), nil
+	if n, err := definitionSizeForCap(def, defJSON); err != nil {
+		return errResult(fmt.Sprintf("create: measure: %s", err)), nil
+	} else if a.MaxDefinitionBytes > 0 && n > a.MaxDefinitionBytes {
+		return errResult(fmt.Sprintf("create: definition (%d bytes, excluding code_body) exceeds max %d", n, a.MaxDefinitionBytes)), nil
 	}
 	if a.MaxDescriptionBytes > 0 && len(in.Description) > a.MaxDescriptionBytes {
 		return errResult(fmt.Sprintf("create: description (%d bytes) exceeds max %d", len(in.Description), a.MaxDescriptionBytes)), nil
@@ -451,8 +453,10 @@ func (a *AgentDef) execFork(ctx context.Context, policy tools.AgentDefPolicyValu
 	if err != nil {
 		return errResult(fmt.Sprintf("fork: marshal: %s", err)), nil
 	}
-	if a.MaxDefinitionBytes > 0 && len(defJSON) > a.MaxDefinitionBytes {
-		return errResult(fmt.Sprintf("fork: definition (%d bytes) exceeds max %d", len(defJSON), a.MaxDefinitionBytes)), nil
+	if n, err := definitionSizeForCap(def, defJSON); err != nil {
+		return errResult(fmt.Sprintf("fork: measure: %s", err)), nil
+	} else if a.MaxDefinitionBytes > 0 && n > a.MaxDefinitionBytes {
+		return errResult(fmt.Sprintf("fork: definition (%d bytes, excluding code_body) exceeds max %d", n, a.MaxDefinitionBytes)), nil
 	}
 	if a.MaxDescriptionBytes > 0 && len(in.Description) > a.MaxDescriptionBytes {
 		return errResult(fmt.Sprintf("fork: description (%d bytes) exceeds max %d", len(in.Description), a.MaxDescriptionBytes)), nil
@@ -1452,6 +1456,30 @@ func signFromMergedDef(name string, def mergedDef) string {
 //   - PARSE: compile via the shared codejs.Validate so a syntax error
 //     is rejected at authorship — mirrors boot validateCodeAgents,
 //     using the provider's exact compile flags (single source of truth).
+//
+// definitionSizeForCap measures the definition JSON that MaxDefinitionBytes
+// governs — everything except the inline code body, which has its own dedicated
+// and deliberately larger cap (MaxCodeBytes, checked in validateInlineCode).
+//
+// Counting the body in both made the dedicated cap unreachable: the defaults are
+// 128 KiB for the whole definition and 256 KiB for code, so any body between the
+// two passed the cap written for it and was then refused by the smaller one. The
+// shipped memory/consolidator (~139 KB of code-js) sits in that dead zone, which
+// made it impossible to fork the agent to flip a single capability grant — the
+// error blamed the definition size for a body the overlay never touched.
+func definitionSizeForCap(def mergedDef, defJSON []byte) (int, error) {
+	if def.Code == "" {
+		return len(defJSON), nil
+	}
+	bare := def
+	bare.Code = ""
+	b, err := json.Marshal(bare)
+	if err != nil {
+		return 0, err
+	}
+	return len(b), nil
+}
+
 func (a *AgentDef) validateInlineCode(op string, def mergedDef) error {
 	if def.Code == "" {
 		return nil

--- a/internal/tools/builtin/agentdef_override_cap_test.go
+++ b/internal/tools/builtin/agentdef_override_cap_test.go
@@ -1,0 +1,139 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// largeCodeBody returns compilable code-js source of roughly n bytes, sized to
+// land between the shipped MaxDefinitionBytes (128 KiB) and MaxCodeBytes
+// (256 KiB) defaults — the dead zone the shipped memory/consolidator occupies.
+func largeCodeBody(n int) string {
+	return "// " + strings.Repeat("x", n) + "\nfunction run() { return {}; }\n"
+}
+
+// codeAgentFixture mirrors agentDefFixture but the operator-blessed root is a
+// code-js agent with a body larger than MaxDefinitionBytes, as the shipped
+// memory bundle's consolidator is.
+func codeAgentFixture(t *testing.T) (*AgentDef, context.Context, func()) {
+	t.Helper()
+	s, err := sqlite.Open(t.TempDir() + "/t.db")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	cfg := &config.Config{
+		Agents: map[string]config.AgentDef{
+			"memory/consolidator": {
+				Provider:     "code-js",
+				Model:        "memory/consolidator",
+				Code:         largeCodeBody(140_000),
+				Tools:        []string{"Memory", "Document", "AgentDef"},
+				MemoryScopes: []string{"agent", "user"},
+			},
+		},
+	}
+	cfg.Env.CodeAgentsEnabled = true
+	tool := &AgentDef{
+		Store:               s,
+		Cfg:                 cfg,
+		MaxDefinitionBytes:  131072,
+		MaxDescriptionBytes: 8192,
+		MaxCodeBytes:        262144,
+	}
+	ctx := tools.WithAgentName(context.Background(), "memory/consolidator")
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a_test"})
+	ctx = tools.WithAgentDefPolicy(ctx, tools.AgentDefPolicyValue{
+		Scopes:   []string{"any"},
+		SelfName: "memory/consolidator",
+	})
+	return tool, ctx, func() { _ = s.Close() }
+}
+
+// A capability-only overlay on a large code-js agent must be accepted. The
+// inherited body is governed by MaxCodeBytes, which is deliberately larger;
+// charging it to MaxDefinitionBytes too made overriding such an agent
+// impossible, whatever the overlay actually changed.
+func TestAgentDefTool_ForkOverridesGrantsOnALargeCodeAgent(t *testing.T) {
+	tool, ctx, cleanup := codeAgentFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(
+		`{"op":"fork","name":"memory/consolidator","overlay":{"memory_scopes":["agent","user","tenant"],"sql_scopes":["tenant"]},"description":"grant tenant placement"}`))
+	if res.IsError {
+		t.Fatalf("capability-only fork of a large code agent must be accepted; got %s", res.Text)
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal([]byte(res.Text), &out); err != nil {
+		t.Fatalf("unmarshal fork result: %v (%s)", err, res.Text)
+	}
+	defID, _ := out["def_id"].(string)
+	if defID == "" {
+		t.Fatalf("fork returned no def_id: %s", res.Text)
+	}
+
+	// The body must survive the override intact — it is the whole agent.
+	got, _ := tool.Execute(ctx, json.RawMessage(`{"op":"get","def_id":"`+defID+`"}`))
+	if got.IsError {
+		t.Fatalf("get after fork: %s", got.Text)
+	}
+	if !strings.Contains(got.Text, "memory_scopes") || !strings.Contains(got.Text, "tenant") {
+		t.Fatalf("fork did not record the new grants: %s", got.Text)
+	}
+	var gotDef struct {
+		Definition struct {
+			Code         string   `json:"code_body"`
+			MemoryScopes []string `json:"memory_scopes"`
+			SqlScopes    []string `json:"sql_scopes"`
+		} `json:"definition"`
+	}
+	if err := json.Unmarshal([]byte(got.Text), &gotDef); err != nil {
+		t.Fatalf("unmarshal get result: %v", err)
+	}
+	if len(gotDef.Definition.Code) < 140_000 {
+		t.Fatalf("inherited code body truncated: %d bytes", len(gotDef.Definition.Code))
+	}
+	if strings.Join(gotDef.Definition.SqlScopes, ",") != "tenant" {
+		t.Fatalf("sql_scopes = %v, want [tenant]", gotDef.Definition.SqlScopes)
+	}
+}
+
+// The dedicated code cap must still bite: excluding the body from the
+// definition cap must not leave it ungoverned.
+func TestAgentDefTool_ForkStillRefusesCodeOverItsOwnCap(t *testing.T) {
+	tool, ctx, cleanup := codeAgentFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(
+		`{"op":"fork","name":"memory/consolidator","overlay":{"code_body":`+
+			mustJSON(largeCodeBody(300_000))+`}}`))
+	if !res.IsError {
+		t.Fatalf("a body over MaxCodeBytes must be refused; got accepted")
+	}
+	if !strings.Contains(res.Text, "code_body") {
+		t.Fatalf("refusal should name code_body, got: %s", res.Text)
+	}
+}
+
+// A non-code definition is still measured whole — the exclusion is scoped to
+// the body, not a general relaxation of the cap.
+func TestAgentDefTool_ForkStillRefusesAnOversizedNonCodeDefinition(t *testing.T) {
+	tool, ctx, cleanup := codeAgentFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(
+		`{"op":"fork","name":"memory/consolidator","overlay":{"system_prompt":`+
+			mustJSON(strings.Repeat("p", 200_000))+`}}`))
+	if !res.IsError {
+		t.Fatalf("an oversized non-code definition must still be refused; got accepted")
+	}
+	if !strings.Contains(res.Text, "definition") {
+		t.Fatalf("refusal should name the definition cap, got: %s", res.Text)
+	}
+}


### PR DESCRIPTION
## Why

Three defects that together made ontology-declared memory placement unreachable, and cost a down instance to discover.

**The feature was inert in every stock deployment.** An ontology type can declare that facts about it belong in the tenant plane, but the agent that writes memory could not put one there — the shipped consolidator held `memory_scopes: [agent, user]` and no `sql_scopes`. A placed fact is stored **twice** (a k/v row, which `recall` searches; a typed chunk, which a graph walk reaches), so both grants must include tenant or the two halves cannot land in the same scope.

**The documented workaround was broken.** Forking the consolidator to flip one grant returned `fork: definition (139169 bytes) exceeds max 131072` — for a body the overlay never touched.

**And the config route's failure was misdiagnosable.** Layering the grants onto a stack without the bundle produces `no model, no tier, and no defaults.model`: accurate, but it points at the overlay rather than at `LOOMCYCLE_PRESETS`, and boot is fatal.

## What

**1. The bundle grants tenant on both axes** (`memory_scopes: [agent, user, tenant]`, `sql_scopes: [tenant]`).

The absence of `sql_scopes` was deliberate, on the argument that an unused grant is the capability an injected instruction reaches for. That argument is written for a **prompt-driven** agent, where model output steers control flow. This one is `provider: code-js` — a deterministic body, shipped by the operator, in which model output is data that gets written and never code that gets run. The grant widens what *this code* can do, not what a transcript can talk it into. What bounds the tenant write is the server-side placement resolver, which fails closed on every uncertainty: an unknown or inconsistently-typed subject, or a fact about the profile owner, stays with the user.

It is **inert on its own** — no shipped ontology type declares a scope, so a default deployment places nothing until an operator declares one per tenant. The declaration is now the only switch left, and the ontology template's note that said otherwise is corrected.

**2. `MaxDefinitionBytes` no longer counts the inline code body.** The two caps are meant to be independent — `MaxCodeBytes` exists, as its own comment says, so executable source is not judged by the whole-definition cap — but the check measured the JSON with the code inside it. With defaults of 128 KiB (definition) and 256 KiB (code), any body between them passed the cap written for it and was refused by the smaller one, making the dedicated cap unreachable. The consolidator (~133 KB) sits in that dead zone. The stored definition is unchanged; no wire or schema change, and anything accepted before is still accepted.

**3. The refusal names the layer stack** when a declaration carries nothing but capability grants — the shape of an override, never of a new agent. Also stops two statements of the `sql_scopes` enum from lying: the validation error listed `agent, user, run` long after `tenant` was added, so a *correct* config read as rejected. The message is now rendered from the set.

## What was tested

`go test ./...` clean — 98 packages, exit 0.

Each fix has a regression test verified to **fail on the unfixed code**:

- `TestAgentDefTool_ForkOverridesGrantsOnALargeCodeAgent` — fails with the exact production error; also asserts the inherited body survives the override intact. Two guards keep the exclusion narrow: `TestAgentDefTool_ForkStillRefusesCodeOverItsOwnCap` and `..._ForkStillRefusesAnOversizedNonCodeDefinition`.
- `TestAgentOverride_OverlayWithoutItsBundleNamesTheMissingLayer` — fails on the unfixed code, which mentions neither the grants nor the presets. `TestAgentOverride_ReDeclaringABundleAgentKeepsItsBody` pins the working case, `code_body` first because it is the whole agent.
- `TestConsolidatorBundle_Validates` — updated: `sql_scopes` is exactly `[tenant]` (nothing wider is used) and, as the executable form of the argument above, the body still issues no `sql_exec` / `sql_query` / `sql_schema` op. If one is ever added there, the grant has to be re-argued rather than silently inherited.

Manual: `validate` clean on `base`, `base,memory`, `base,memory,chat`, `base,memory,document-agent`; `agents list` confirms the grants land on the shipped agent.

## Assumption stated

Granting tenant SQL scope opens the raw `Memory sql_exec` surface on the tenant keyspace as well as the Document tenant-chunk path this change needs — the gate shares one list, so there is no narrower grant available today. The consolidator body issues no SQL op, and a test now keeps it that way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8