### PR TITLE
fix(memory): a placed fact stays reachable from its subject

### DIFF
--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -1978,7 +1978,10 @@ agents:
         if (st.bands.judge) {
           if (fact.quote) {
             st.judge_candidates.push({
-              id: factID, text: fact.text, quote: fact.quote,
+              // The SCOPE travels too, for the same reason the edge needs it: a
+              // placed fact is not in CONFIG.scope, and a verdict written to the
+              // wrong scope finds nothing to mark.
+              id: factID, text: fact.text, quote: fact.quote, scope: scope,
               // The TYPE and SUBJECT travel together, because that pair is what a
               // mistyping verdict is about: `location` + `user` is the observed
               // failure, and neither half alone shows it.
@@ -1990,10 +1993,19 @@ agents:
         }
 
         try {
-          Document({ op: "link_chunks", scope: CONFIG.scope,
+          // `scope`, NOT CONFIG.scope. Every other write in this function already
+          // threads the placed scope; this one did not, so a fact the ontology sent
+          // to the tenant plane got its subject node and its fact node there and
+          // then tried to join them in the caller's scope, where neither exists.
+          // The two nodes were stored and the edge silently was not — leaving a
+          // placed fact unreachable from the person it is about, which is the whole
+          // reason the entity tier exists. Measured live: 3 facts placed, 3 edges
+          // lost, 0 inbound edges on the subject.
+          Document({ op: "link_chunks", scope: scope,
                      from_id: factID, to_id: subjID, kind: "about" });
         } catch (e) {
           st.entity_failed++; // the nodes exist; only the edge is missing
+          if (!st.entity_error) { st.entity_error = errText(e); }
         }
       }
 
@@ -2287,7 +2299,7 @@ agents:
         if (reason.length > CONFIG.max_fact_chars) { reason = reason.slice(0, CONFIG.max_fact_chars); }
 
         try {
-          Document({ op: "judge_fact", scope: CONFIG.scope,
+          Document({ op: "judge_fact", scope: batch[idx - 1].scope || CONFIG.scope,
                      id: batch[idx - 1].id, verdict: verdict, reason: reason });
         } catch (e) {
           st.judge_failed++;
@@ -2345,6 +2357,7 @@ agents:
                      id: newID, supersedes_id: oldID });
         } catch (e) {
           st.entity_failed++;
+          if (!st.entity_error) { st.entity_error = errText(e); }
         }
       }
 

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -1978,7 +1978,10 @@ agents:
         if (st.bands.judge) {
           if (fact.quote) {
             st.judge_candidates.push({
-              id: factID, text: fact.text, quote: fact.quote,
+              // The SCOPE travels too, for the same reason the edge needs it: a
+              // placed fact is not in CONFIG.scope, and a verdict written to the
+              // wrong scope finds nothing to mark.
+              id: factID, text: fact.text, quote: fact.quote, scope: scope,
               // The TYPE and SUBJECT travel together, because that pair is what a
               // mistyping verdict is about: `location` + `user` is the observed
               // failure, and neither half alone shows it.
@@ -1990,10 +1993,19 @@ agents:
         }
 
         try {
-          Document({ op: "link_chunks", scope: CONFIG.scope,
+          // `scope`, NOT CONFIG.scope. Every other write in this function already
+          // threads the placed scope; this one did not, so a fact the ontology sent
+          // to the tenant plane got its subject node and its fact node there and
+          // then tried to join them in the caller's scope, where neither exists.
+          // The two nodes were stored and the edge silently was not — leaving a
+          // placed fact unreachable from the person it is about, which is the whole
+          // reason the entity tier exists. Measured live: 3 facts placed, 3 edges
+          // lost, 0 inbound edges on the subject.
+          Document({ op: "link_chunks", scope: scope,
                      from_id: factID, to_id: subjID, kind: "about" });
         } catch (e) {
           st.entity_failed++; // the nodes exist; only the edge is missing
+          if (!st.entity_error) { st.entity_error = errText(e); }
         }
       }
 
@@ -2287,7 +2299,7 @@ agents:
         if (reason.length > CONFIG.max_fact_chars) { reason = reason.slice(0, CONFIG.max_fact_chars); }
 
         try {
-          Document({ op: "judge_fact", scope: CONFIG.scope,
+          Document({ op: "judge_fact", scope: batch[idx - 1].scope || CONFIG.scope,
                      id: batch[idx - 1].id, verdict: verdict, reason: reason });
         } catch (e) {
           st.judge_failed++;
@@ -2345,6 +2357,7 @@ agents:
                      id: newID, supersedes_id: oldID });
         } catch (e) {
           st.entity_failed++;
+          if (!st.entity_error) { st.entity_error = errText(e); }
         }
       }
 

--- a/cmd/loomcycle/presets_memory_codejs_test.go
+++ b/cmd/loomcycle/presets_memory_codejs_test.go
@@ -72,8 +72,13 @@ type fakeToolset struct {
 	// The entity half, filled by fakeDocument.
 	entitiesDocID string
 	chunks        map[string]string // natural_key -> chunk id
-	chunkTypes    map[string]string // natural_key -> type
-	chunkSpans    map[string]string // natural_key -> source_quote (RFC CC)
+	// chunkScopes maps chunk id -> the scope it was written into. The double used to be
+	// scope-BLIND, which is why it could not see the placed-fact edge bug: the feature
+	// under test is entirely about which scope a write lands in, and the fake answered
+	// every scope identically. A double has to model the dimension the feature varies.
+	chunkScopes map[string]string
+	chunkTypes  map[string]string // natural_key -> type
+	chunkSpans  map[string]string // natural_key -> source_quote (RFC CC)
 	// chunkRows is what a READ of a chunk returns: id -> the fields upsert_chunk was
 	// given, plus any verdict since written. The backfill sweep reads facts back
 	// (list_facts to find them, get_chunk for the body the listing truncates), so the
@@ -162,6 +167,7 @@ func newFakeToolset() *fakeToolset {
 		bands:          map[string]any{"merge_threshold": 0.9, "related_threshold": 0.5},
 		failSetKeys:    map[string]bool{},
 		chunks:         map[string]string{},
+		chunkScopes:    map[string]string{},
 		chunkTypes:     map[string]string{},
 		chunkSpans:     map[string]string{},
 		chunkRows:      map[string]map[string]any{},
@@ -317,6 +323,8 @@ func (d *fakeDocument) Execute(_ context.Context, raw json.RawMessage) (tools.Re
 		if !existed {
 			id = fmt.Sprintf("chunk-%d", len(d.f.chunks)+1)
 			d.f.chunks[key] = id
+			wscope, _ := in["scope"].(string)
+			d.f.chunkScopes[id] = wscope
 		}
 		if typ, ok := in["type"].(string); ok && typ != "" {
 			d.f.chunkTypes[key] = typ
@@ -394,6 +402,17 @@ func (d *fakeDocument) Execute(_ context.Context, raw json.RawMessage) (tools.Re
 		from, _ := in["from_id"].(string)
 		to, _ := in["to_id"].(string)
 		kind, _ := in["kind"].(string)
+		// A chunk is addressable only in the scope it was written into, so a link
+		// naming a scope neither endpoint lives in cannot resolve them. The live
+		// store fails exactly here, and the fake used to accept it — which is how a
+		// placed fact came to be stored with its edge silently dropped.
+		lscope, _ := in["scope"].(string)
+		for _, end := range []string{from, to} {
+			if got, ok := d.f.chunkScopes[end]; ok && got != lscope {
+				return tools.Result{IsError: true, Text: "link_chunks: chunk " + end +
+					" is in scope " + strconv.Quote(got) + ", not " + strconv.Quote(lscope)}, nil
+			}
+		}
 		d.f.edges = append(d.f.edges, from+"-"+kind+"->"+to)
 		return okResult(map[string]any{"ok": true})
 	case "supersede_chunk":
@@ -4353,6 +4372,39 @@ func TestConsolidator_PlacementRoutesBOTHHALVESToTheDeclaredScope(t *testing.T) 
 				t.Errorf("resolved the entities document in %q, want tenant", got)
 			}
 		}
+	}
+}
+
+// A placed fact must stay REACHABLE FROM ITS SUBJECT. The two nodes going to the
+// declared scope is not enough: the `about` edge that joins them has to be written
+// there too, and it was written in the caller's scope instead — so both nodes landed
+// in the tenant plane and the edge joining them was silently dropped, leaving the
+// facts stored but unreachable from the person they are about. That is the one
+// property the entity tier exists to provide, and the sibling test above passed
+// throughout because it never looked at the link.
+func TestConsolidator_APlacedFactIsLinkedToItsSubjectInThePlacedScope(t *testing.T) {
+	const fact = "The checkout-api service requires two approvals to release."
+	f := placementFixtureToolset(fact)
+	f.placements = map[string]string{"service\x00checkout-api": "tenant"}
+
+	rep := runConsolidator(t, f)
+
+	links := callsWithOp(f, "Document.link_chunks")
+	if len(links) == 0 {
+		t.Fatal("a typed, placed fact must be joined to its subject — no link_chunks call")
+	}
+	for _, c := range links {
+		if got, _ := c.Input["scope"].(string); got != "tenant" {
+			t.Errorf("the about-edge was written in %q while both endpoints are in tenant — "+
+				"the edge cannot resolve either node and the fact is orphaned: %v", got, c.Input)
+		}
+	}
+	if len(f.edges) != len(links) {
+		t.Errorf("%d link_chunks calls but %d edges recorded — a link was refused", len(links), len(f.edges))
+	}
+	// And the pass must not be reporting a silent failure.
+	if strings.Contains(rep.FinalText, "graph write(s) failed") {
+		t.Errorf("the pass reported a failed graph write for a placed fact: %s", rep.FinalText)
 	}
 }
 


### PR DESCRIPTION
## Why

Found by running the placement test on the live store, which is the first time anything exercised it end to end.

Placement works: the k/v row and the fact chunk and the subject node all reach the tenant plane. Then the `about` edge that joins the fact to its subject is written in the **caller's** scope, where neither endpoint exists. The link fails, a counter increments, and the pass carries on.

Measured live: **3 facts placed, 3 edges lost, 0 inbound edges on the subject node.** The facts sit in the shared plane and a graph walk from the person's name reaches none of them — which is the one property the entity tier exists to provide. "What else do we know about her" returns nothing for exactly the facts placement was supposed to make shareable.

## What

**The edge (`bundles/memory/loomcycle.yaml`).** `mirrorEntity` already threads the placed scope into every write it makes — the entities document, the canonical-type lookup, the subject node, the fact node. Only `link_chunks` used `CONFIG.scope`. One word.

**The judge, same defect one function over.** A judge candidate carried its id but not the scope it was written in, so `judge_fact` looked for a placed fact in `CONFIG.scope` and could only fail. The scope now travels with the candidate. (Opt-in via `verify_writes`, so it was not firing live — but it is the same bug and fixing one without the other leaves it in place.)

**Two silent failure sites now record the reason,** matching the two that already did. This is why the live diagnosis needed a code read: the deployed build said `3 graph write(s) failed` and nothing more, while the mechanism for saying *why* was already there and simply not wired at these sites.

## Why no test caught it

**The double was scope-blind.** Its chunk store was `natural_key -> id` with no record of where a chunk was written, so every scope answered identically. The sibling test `TestConsolidator_PlacementRoutesBOTHHALVESToTheDeclaredScope` asserts the row, the chunks *and* the entities document all reach the declared scope — and passed throughout, because it never looked at the link. A double has to model the dimension the feature varies.

The fake now records each chunk's write scope and refuses a link naming a scope neither endpoint lives in, as the real store does. It reproduces the production report verbatim:

```
entities 1 fact(s) across 1 subject(s), 1 graph write(s) failed
  (first: link_chunks: chunk chunk-2 is in scope "tenant", not "user")
```

## What was tested

`go test ./...` clean — 98 packages, exit 0.

`TestConsolidator_APlacedFactIsLinkedToItsSubjectInThePlacedScope` — verified to **fail on the unfixed bundle** with all three symptoms: the edge written in `user`, the link refused, and the pass reporting a failed graph write. It asserts the edge's scope, that no link was refused, and that the pass reports no graph failure.

Live verification of the diagnosis before the fix: `list_facts scope=tenant` shows the 3 fact chunks and the `person` subject node all present; `backlinks` on that subject returns **0 inbound edges**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8