### PR TITLE
fix(webui): the Library shows what an agent is allowed to reach

### DIFF
--- a/internal/api/http/library_unified.go
+++ b/internal/api/http/library_unified.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/lookup"
 	"github.com/denn-gubsky/loomcycle/internal/skills"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 )
@@ -308,59 +309,18 @@ func deriveSource(inStatic, inSubstrate bool) string {
 	}
 }
 
-// staticAgentDefJSON mirrors the substrate shape of mergedDef +
-// lookup.SubstrateAgentDef so the same renderer in the UI consumes
-// both static and substrate-derived definitions. config.AgentDef
-// carries yaml-only tags, which is why this shadow struct exists —
-// the same conceptual fix PR #184 applied for the substrate-read
-// path.
-type staticAgentDefJSON struct {
-	Provider              string                            `json:"provider,omitempty"`
-	Model                 string                            `json:"model,omitempty"`
-	Code                  string                            `json:"code_body,omitempty"` // RFC J inline code-js body
-	Tier                  string                            `json:"tier,omitempty"`
-	Effort                string                            `json:"effort,omitempty"`
-	MaxTokens             int                               `json:"max_tokens,omitempty"`
-	MaxIterations         int                               `json:"max_iterations,omitempty"`
-	MaxConcurrentChildren int                               `json:"max_concurrent_children,omitempty"`
-	SystemPrompt          string                            `json:"system_prompt,omitempty"`
-	SystemPromptBase      string                            `json:"system_prompt_base,omitempty"`
-	Tools                 []string                          `json:"tools,omitempty"`
-	Skills                []string                          `json:"skills,omitempty"`
-	Providers             []string                          `json:"providers,omitempty"`
-	SearchProviders       []string                          `json:"search_providers,omitempty"`
-	Models                map[string][]config.TierCandidate `json:"models,omitempty"`
-	MemoryScopes          []string                          `json:"memory_scopes,omitempty"`
-	MemoryQuotaBytes      int                               `json:"memory_quota_bytes,omitempty"`
-	MemoryBackend         string                            `json:"memory_backend,omitempty"`
-	// RFC AH per-agent filesystem volume bindings — the names this agent is
-	// confined to. Surfaced so the Volumes Web UI (Phase 4) can cross-reference
-	// which agents bind each volume (derived client-side from this list).
-	Volumes []string `json:"volumes,omitempty"`
-}
-
+// marshalStaticAgentDef renders an operator's static `agents:` entry in the
+// SAME wire shape as a runtime-authored one, so the UI has one renderer and
+// one contract for both.
+//
+// It used to marshal a hand-maintained shadow struct that had drifted to 19 of
+// the substrate shape's 46 fields: `sql_scopes`, `history_scope`,
+// `memory_consolidation`, `internal` and the rest were absent from the wire,
+// so the Library showed an operator half of what an agent was allowed to do —
+// and showed nothing at all for the grant that gates tenant-scoped writes.
+// Converting through lookup leaves no third shape to fall behind.
 func marshalStaticAgentDef(def config.AgentDef) json.RawMessage {
-	b, err := json.Marshal(staticAgentDefJSON{
-		Provider:              def.Provider,
-		Model:                 def.Model,
-		Code:                  def.Code,
-		Tier:                  def.Tier,
-		Effort:                def.Effort,
-		MaxTokens:             def.MaxTokens,
-		MaxIterations:         def.MaxIterations,
-		MaxConcurrentChildren: def.MaxConcurrentChildren,
-		SystemPrompt:          def.SystemPrompt,
-		SystemPromptBase:      def.SystemPromptBase,
-		Tools:                 def.Tools,
-		Skills:                def.Skills,
-		Providers:             def.Providers,
-		SearchProviders:       def.SearchProviders,
-		Models:                def.Models,
-		MemoryScopes:          def.MemoryScopes,
-		MemoryQuotaBytes:      def.MemoryQuotaBytes,
-		MemoryBackend:         def.MemoryBackend,
-		Volumes:               def.Volumes,
-	})
+	b, err := json.Marshal(lookup.SubstrateAgentDefFromConfig(def))
 	if err != nil {
 		return nil
 	}

--- a/internal/api/http/library_unified_test.go
+++ b/internal/api/http/library_unified_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"testing"
 	"time"
 
@@ -567,4 +568,66 @@ func TestUnifiedLibrary_Skills_InlineCfgSurfaced(t *testing.T) {
 	if len(tenant) != 1 || tenant[0].Name != "semantic-chunking" {
 		t.Fatalf("tenant sees %+v, want [semantic-chunking]", tenant)
 	}
+}
+
+// TestUnifiedLibrary_Agents_StaticShowsEveryCapabilityGate is the operator's
+// question: "what is this agent allowed to do?" The Library is where that gets
+// answered, and for a static agent it was answering with half the truth — the
+// wire shape carried 19 of the substrate shape's 46 fields.
+//
+// `sql_scopes` is the one that cost real time: it gates every tenant-scoped
+// write, so an operator checking why placement was not working saw no
+// sql_scopes at all and read that as the grant being absent, when the grant was
+// present and only the field was missing.
+func TestUnifiedLibrary_Agents_StaticShowsEveryCapabilityGate(t *testing.T) {
+	srv, _, cleanup := libraryUnifiedFixture(t, map[string]config.AgentDef{
+		"consolidator": {
+			Provider:            "code-js",
+			Code:                `function run(){ return {}; }`,
+			Tools:               []string{"Memory", "Document"},
+			MemoryScopes:        []string{"agent", "user", "tenant"},
+			SqlScopes:           []string{"tenant"},
+			SqlQuotaBytes:       4096,
+			HistoryScope:        []string{"user"},
+			MemoryConsolidation: true,
+			Internal:            true,
+			EvaluationScopes:    []string{"user"},
+			AgentDefScopes:      []string{"any"},
+			MaxContextTokens:    131072,
+		},
+	}, nil)
+	defer cleanup()
+
+	rec := httptest.NewRecorder()
+	srv.Mux().ServeHTTP(rec, authedRequest("GET", "/v1/_library/agents", nil))
+	entries := decodeLibraryEntries(t, rec)
+	if len(entries) != 1 {
+		t.Fatalf("entries = %+v, want 1", entries)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(entries[0].StaticDefinition, &got); err != nil {
+		t.Fatal(err)
+	}
+	for _, tag := range []string{
+		"sql_scopes", "sql_quota_bytes", "history_scope", "memory_consolidation",
+		"internal", "evaluation_scopes", "agent_def_scopes", "max_context_tokens",
+	} {
+		if _, ok := got[tag]; !ok {
+			t.Errorf("static_definition omits %q — an operator cannot see this capability in the Library: %v",
+				tag, keysOf(got))
+		}
+	}
+	if s, _ := got["sql_scopes"].([]any); len(s) != 1 || s[0] != "tenant" {
+		t.Errorf("sql_scopes = %v, want [tenant]", got["sql_scopes"])
+	}
+}
+
+func keysOf(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/internal/lookup/agent.go
+++ b/internal/lookup/agent.go
@@ -279,6 +279,73 @@ type SubstrateAgentDef struct {
 // ToConfigDef projects the substrate JSON shape onto config.AgentDef
 // for the runtime to consume. Pure data shuffling; no normalization
 // happens here (NormalizeAgentDef is called afterward by Agent).
+// SubstrateAgentDefFromConfig is the inverse of ToConfigDef: it lifts an
+// operator's static `agents:` entry into the substrate wire shape.
+//
+// It exists so the Library can hand the UI ONE shape for both static and
+// runtime-authored agents. That surface used to carry a hand-maintained third
+// mirror of this struct, which drifted to 19 of 46 fields — `sql_scopes`,
+// `history_scope`, `memory_consolidation`, `internal`, the *_def_scopes gates
+// and eighteen more were simply absent from the wire, so an operator inspecting
+// a static agent could not see half of what it was allowed to do. A converter
+// plus this struct means there is nothing left to drift.
+//
+// Three AgentDef fields are deliberately absent from SubstrateAgentDef and so
+// cannot be carried: SystemPromptFile (a load-time path; a runtime def has no
+// filesystem), DisableContext (load-time — it bakes into Tools before anything
+// resolves), and SkillDefScopes (a removed-field tombstone, RFC BA). The
+// round-trip test names each one.
+func SubstrateAgentDefFromConfig(def config.AgentDef) SubstrateAgentDef {
+	return SubstrateAgentDef{
+		Provider:               def.Provider,
+		Model:                  def.Model,
+		Code:                   def.Code,
+		Tier:                   def.Tier,
+		Effort:                 def.Effort,
+		Sampling:               def.Sampling,
+		Compaction:             def.Compaction,
+		Context:                def.Context,
+		MaxTokens:              def.MaxTokens,
+		MaxContextTokens:       def.MaxContextTokens,
+		MaxIterations:          def.MaxIterations,
+		UnboundedIterations:    def.UnboundedIterations,
+		MaxConcurrentChildren:  def.MaxConcurrentChildren,
+		RunTimeoutSeconds:      def.RunTimeoutSeconds,
+		SystemPrompt:           def.SystemPrompt,
+		SystemPromptBase:       def.SystemPromptBase,
+		Tools:                  def.Tools,
+		Skills:                 def.Skills,
+		Providers:              def.Providers,
+		SearchProviders:        def.SearchProviders,
+		Models:                 def.Models,
+		MemoryScopes:           def.MemoryScopes,
+		MemoryQuotaBytes:       def.MemoryQuotaBytes,
+		SqlScopes:              def.SqlScopes,
+		SqlQuotaBytes:          def.SqlQuotaBytes,
+		HistoryScope:           def.HistoryScope,
+		Volumes:                def.Volumes,
+		MemoryBackend:          def.MemoryBackend,
+		CoreBlocks:             def.CoreBlocks,
+		InheritCoreBlocks:      def.InheritCoreBlocks,
+		MemoryInjectMaxTokens:  def.MemoryInjectMaxTokens,
+		InjectToolGuide:        def.InjectToolGuide,
+		MemoryProtocol:         def.MemoryProtocol,
+		Internal:               def.Internal,
+		MemoryConsolidation:    def.MemoryConsolidation,
+		MemoryIndexMaxBytes:    def.MemoryIndexMaxBytes,
+		MemoryRoots:            def.MemoryRoots,
+		RetryAttempts:          def.RetryAttempts,
+		Channels:               def.Channels,
+		EvaluationScopes:       def.EvaluationScopes,
+		Interruption:           def.Interruption,
+		AgentDefScopes:         def.AgentDefScopes,
+		ScheduleDefScopes:      def.ScheduleDefScopes,
+		A2AServerCardDefScopes: def.A2AServerCardDefScopes,
+		A2AAgentDefScopes:      def.A2AAgentDefScopes,
+		VolumeDefScopes:        def.VolumeDefScopes,
+	}
+}
+
 func (s SubstrateAgentDef) ToConfigDef() config.AgentDef {
 	return config.AgentDef{
 		Provider:              s.Provider,

--- a/internal/lookup/agent_roundtrip_test.go
+++ b/internal/lookup/agent_roundtrip_test.go
@@ -1,0 +1,111 @@
+package lookup
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+)
+
+// The Library hands the UI one shape for static and runtime-authored agents
+// alike, converted by SubstrateAgentDefFromConfig / ToConfigDef. These two
+// assertions are what keep that pair honest, and they catch different faults:
+//
+//   - COVERAGE: populate every config.AgentDef field, convert, and require no
+//     field of the result to be left at its zero value. This is the one that
+//     catches a forgotten assignment — the fault that let the old hand-written
+//     wire shape drift to 19 of 46 fields, hiding `sql_scopes` (and with it the
+//     grant that gates every tenant-scoped write) from the Library entirely.
+//   - ROUND TRIP: convert back and require equality. This catches a field wired
+//     to the WRONG source, which coverage alone cannot see: `SqlScopes:
+//     def.MemoryScopes` leaves nothing zero and is still wrong.
+//
+// A round trip alone would miss a SYMMETRIC omission — a field dropped by both
+// directions survives it untouched — which is why coverage is not redundant.
+func TestSubstrateAgentDef_ConfigRoundTripCoversEveryField(t *testing.T) {
+	// Absent from SubstrateAgentDef by design, so the conversion cannot carry
+	// them. Each is load-time-only or dead; adding to this map is the conscious
+	// decision the test forces.
+	exempt := map[string]string{
+		"SystemPromptFile": "a load-time path read from disk; a runtime-authored def has no filesystem to read",
+		"DisableContext":   "load-time only — it suppresses the default-add of the Context tool and bakes into Tools before anything resolves",
+		"SkillDefScopes":   "removed-field tombstone (RFC BA); skill authoring is governed by the skills: allowlist, and carrying it would resurrect a dead gate",
+	}
+
+	var full config.AgentDef
+	populate(t, reflect.ValueOf(&full).Elem(), "AgentDef")
+
+	sub := SubstrateAgentDefFromConfig(full)
+
+	// COVERAGE — nothing the substrate shape declares may be left behind.
+	sv := reflect.ValueOf(sub)
+	for i := 0; i < sv.NumField(); i++ {
+		name := sv.Type().Field(i).Name
+		if sv.Field(i).IsZero() {
+			t.Errorf("SubstrateAgentDefFromConfig leaves %s at its zero value — the field is declared on the wire and never filled, so the Library renders an agent that looks like it lacks the capability",
+				name)
+		}
+	}
+
+	// ROUND TRIP — and every field must come back as itself.
+	back := sub.ToConfigDef()
+	fv := reflect.ValueOf(full)
+	bv := reflect.ValueOf(back)
+	for i := 0; i < fv.NumField(); i++ {
+		name := fv.Type().Field(i).Name
+		if why, ok := exempt[name]; ok {
+			if !bv.Field(i).IsZero() {
+				t.Errorf("AgentDef.%s is exempt (%s) but came back non-zero — the exemption is stale", name, why)
+			}
+			continue
+		}
+		if !reflect.DeepEqual(fv.Field(i).Interface(), bv.Field(i).Interface()) {
+			t.Errorf("AgentDef.%s does not survive config -> substrate -> config:\n  sent: %#v\n  got:  %#v\nEither wire it through both converters OR add it to exempt with a justification.",
+				name, fv.Field(i).Interface(), bv.Field(i).Interface())
+		}
+	}
+}
+
+// populate fills every field of v with a distinctive non-zero value, so a
+// forgotten or mis-wired assignment shows up as a zero or a mismatch rather
+// than as two empty values that happen to compare equal.
+func populate(t *testing.T, v reflect.Value, path string) {
+	t.Helper()
+	switch v.Kind() {
+	case reflect.String:
+		v.SetString("v-" + path)
+	case reflect.Bool:
+		v.SetBool(true)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		v.SetInt(int64(len(path) + 1))
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		v.SetUint(uint64(len(path) + 1))
+	case reflect.Float32, reflect.Float64:
+		v.SetFloat(float64(len(path)) + 0.5)
+	case reflect.Ptr:
+		p := reflect.New(v.Type().Elem())
+		populate(t, p.Elem(), path)
+		v.Set(p)
+	case reflect.Slice:
+		e := reflect.New(v.Type().Elem()).Elem()
+		populate(t, e, path)
+		v.Set(reflect.Append(v, e))
+	case reflect.Map:
+		k := reflect.New(v.Type().Key()).Elem()
+		populate(t, k, path+"-key")
+		e := reflect.New(v.Type().Elem()).Elem()
+		populate(t, e, path)
+		m := reflect.MakeMap(v.Type())
+		m.SetMapIndex(k, e)
+		v.Set(m)
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			if !v.Field(i).CanSet() {
+				continue // unexported: nothing a converter could carry
+			}
+			populate(t, v.Field(i), path+"."+v.Type().Field(i).Name)
+		}
+	case reflect.Interface:
+		v.Set(reflect.ValueOf("v-" + path))
+	}
+}

--- a/packages/library/src/Library.tsx
+++ b/packages/library/src/Library.tsx
@@ -457,6 +457,29 @@ interface AgentDefBody {
   max_tokens?: number;
   max_iterations?: number;
   skills?: string[];
+  // Capability gates. `tools` says which tools an agent may call; these say what
+  // those tools may REACH, which is a different question and the one an operator
+  // is usually asking. They were absent from this renderer entirely — an agent
+  // granted the tenant plane looked identical to one confined to its own scope.
+  memory_scopes?: string[];
+  sql_scopes?: string[];
+  history_scope?: string[];
+  evaluation_scopes?: string[];
+  volumes?: string[];
+  agent_def_scopes?: string[];
+  schedule_def_scopes?: string[];
+  volume_def_scopes?: string[];
+  a2a_server_card_def_scopes?: string[];
+  a2a_agent_def_scopes?: string[];
+  internal?: boolean;
+  memory_consolidation?: boolean;
+  memory_protocol?: boolean;
+  inject_tool_guide?: boolean;
+  unbounded_iterations?: boolean;
+  max_context_tokens?: number;
+  memory_quota_bytes?: number;
+  sql_quota_bytes?: number;
+  run_timeout_seconds?: number;
 }
 
 function renderAgentDefinition(row: DefRow) {
@@ -501,6 +524,7 @@ function renderAgentDefinition(row: DefRow) {
           </div>
         </div>
       )}
+      <AgentGrants body={body} />
       <DefMetaRow
         items={[
           ["tier", body.tier],
@@ -509,9 +533,65 @@ function renderAgentDefinition(row: DefRow) {
           ["effort", body.effort],
           ["max_tokens", body.max_tokens?.toString()],
           ["max_iterations", body.max_iterations?.toString()],
+          ["max_context_tokens", body.max_context_tokens?.toString()],
+          ["run_timeout_seconds", body.run_timeout_seconds?.toString()],
+          ["memory_quota_bytes", body.memory_quota_bytes?.toString()],
+          ["sql_quota_bytes", body.sql_quota_bytes?.toString()],
         ]}
       />
     </div>
+  );
+}
+
+// AgentGrants answers "what is this agent allowed to reach?" — the question the
+// Library exists for and did not answer. Only non-empty gates render, so an
+// agent with none looks exactly as it did before.
+function AgentGrants({ body }: { body: AgentDefBody }) {
+  const scopeGates: Array<[string, string[] | undefined]> = [
+    ["memory_scopes", body.memory_scopes],
+    ["sql_scopes", body.sql_scopes],
+    ["history_scope", body.history_scope],
+    ["evaluation_scopes", body.evaluation_scopes],
+    ["volumes", body.volumes],
+    ["agent_def_scopes", body.agent_def_scopes],
+    ["schedule_def_scopes", body.schedule_def_scopes],
+    ["volume_def_scopes", body.volume_def_scopes],
+    ["a2a_server_card_def_scopes", body.a2a_server_card_def_scopes],
+    ["a2a_agent_def_scopes", body.a2a_agent_def_scopes],
+  ];
+  const flags: Array<[string, boolean | undefined]> = [
+    ["internal", body.internal],
+    ["memory_consolidation", body.memory_consolidation],
+    ["memory_protocol", body.memory_protocol],
+    ["inject_tool_guide", body.inject_tool_guide],
+    ["unbounded_iterations", body.unbounded_iterations],
+  ];
+  const shownGates = scopeGates.filter(([, v]) => v && v.length > 0);
+  const shownFlags = flags.filter(([, v]) => v === true);
+  if (shownGates.length === 0 && shownFlags.length === 0) return null;
+  return (
+    <>
+      {shownGates.map(([label, values]) => (
+        <div className="def-field" key={label}>
+          <span className="def-field-label">{label}</span>
+          <div className="def-pill-row">
+            {(values ?? []).map((v) => (
+              <span key={v} className="def-pill mono">{v}</span>
+            ))}
+          </div>
+        </div>
+      ))}
+      {shownFlags.length > 0 && (
+        <div className="def-field">
+          <span className="def-field-label">flags</span>
+          <div className="def-pill-row">
+            {shownFlags.map(([label]) => (
+              <span key={label} className="def-pill mono">{label}</span>
+            ))}
+          </div>
+        </div>
+      )}
+    </>
   );
 }
 


### PR DESCRIPTION
## Why

An operator asking *"what is this agent allowed to do?"* was getting half an answer, and it cost real diagnosis time: while checking why memory placement wasn't working, the Library showed **no `sql_scopes` at all**, which reads as the grant being absent. The grant was present. Only the field was missing.

## Two gaps, one symptom

**The wire shape.** `staticAgentDefJSON` was a hand-maintained third mirror of the substrate agent shape — its own comment said mirroring was its purpose. It had drifted to **19 of 46 fields**. Absent from the wire: `sql_scopes`, `sql_quota_bytes`, `history_scope`, `memory_consolidation`, `internal`, `channels`, `evaluation_scopes`, `interruption`, `sampling`, `compaction`, `context`, `max_context_tokens`, `retry_attempts`, `run_timeout_seconds`, the five `*_def_scopes` authoring gates, and eight more.

Rather than add the missing 27, the mirror is **deleted**: a new `lookup.SubstrateAgentDefFromConfig` — the inverse of the `ToConfigDef` already there — makes the authoritative struct the wire shape. There is no third thing left to fall behind.

**The renderer.** Even served, none of it would have shown. The agent definition view rendered description, prompt, code body, tools, skills and a numeric meta row — and no capability gate at all, not even `memory_scopes`. An agent granted the tenant plane looked identical to one confined to its own scope. It now renders each non-empty scope gate as a pill row, the boolean grants as flags, and quotas plus the context window in the meta row. An agent with no grants renders exactly as before.

## The guard, and why it's two assertions

- **Coverage** — populate every `config.AgentDef` field, convert, require no field of the result left at zero. Catches the forgotten assignment, the fault that produced this bug.
- **Round trip** — convert back, require equality. Catches a field wired to the *wrong* source, which coverage cannot see: `SqlScopes: def.MemoryScopes` leaves nothing zero and is still wrong.

A round trip alone would also miss a **symmetric** omission, since a field dropped by both directions survives it untouched. Both faults verified by injection:

| injected fault | coverage | round trip | API test |
|---|---|---|---|
| drop the `SqlScopes` assignment | ✅ fails | ✅ fails | ✅ fails |
| wire `SqlScopes: def.MemoryScopes` | ❌ passes | ✅ fails | ❌ passes |

Three `AgentDef` fields cannot be carried and are named with justifications in the `exempt` map: `SystemPromptFile` (a load-time path — a runtime def has no filesystem), `DisableContext` (load-time; it bakes into `Tools` before anything resolves), and `SkillDefScopes` (a removed-field tombstone whose authority moved to the `skills:` allowlist).

## What was tested

`go test ./...` clean — 98 packages, exit 0. `@loomcycle/library` typecheck + tests pass; `make build-ui` builds.

New: `TestSubstrateAgentDef_ConfigRoundTripCoversEveryField`, `TestUnifiedLibrary_Agents_StaticShowsEveryCapabilityGate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8