### PR TITLE
fix(auth): a super-admin may focus a tenant on the memory browse routes

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -475,6 +475,25 @@ func (s *Server) serverCapabilities() map[string]any {
 	}
 }
 
+// THREE HELPERS RESOLVE A TENANT, AND THEY DISAGREE ON PURPOSE.
+//
+// The disagreement is irreducible, so it is written down here once instead of
+// being rediscovered from three call sites:
+//
+//   - principalTenantScope — a LIST read, which can mean "every tenant". An
+//     admin naming none gets all=true and sees the whole deployment.
+//   - adminFocusedTenant — a SINGLE-TUPLE read or write, which must name exactly
+//     one tenant. "All" is not expressible, so an admin naming none keeps its
+//     own tenant, and only an explicit ?tenant= widens.
+//   - substrateBrowseCtxFn — the same single-tuple case for the Path/Document
+//     data plane, which additionally carries a subject (?scope_id=).
+//
+// What they must NEVER disagree on, and do not: a non-admin's wire value is
+// ignored rather than honoured-then-checked, so no tenant can widen its own
+// scope on any of the three. TestTenantResolution_AdminDefaultsAreDeliberate
+// pins every cell of that table, so a future change to one has to state whether
+// it meant to change the family.
+//
 // principalTenantScope resolves the tenant a list read should be scoped
 // to, mirroring applyPrincipal's posture (multi-tenant UI authz):
 //   - super-admin (substrate:admin) → (wireTenant, all = wireTenant=="") so the
@@ -515,6 +534,40 @@ func tenantFromCtx(ctx context.Context) string {
 		return p.TenantID
 	}
 	return tools.RunIdentity(ctx).TenantID
+}
+
+// adminFocusedTenant resolves the tenant for an operator console request that
+// addresses ONE tenant's data, honouring a super-admin's explicit `?tenant=`
+// focus and ignoring it for everyone else.
+//
+// It exists because admin was, on these surfaces, strictly LESS capable than a
+// tenant operator. The memory browse handlers pinned the tenant with
+// tenantFromCtx and took nothing from the URL, so a substrate:tenant token read
+// its own tenant's memory while a substrate:admin token — which satisfies every
+// scope gate — could only ever see its own, usually empty, tenant and had no way
+// to name another. The sibling maintenance routes on the same store (embed
+// stats, reembed, backfill, purge) had accepted `?tenant=` via
+// principalTenantScope all along, so the inconsistency was inside one file.
+//
+// Only an EXPLICIT focus widens: with no `?tenant=` this returns exactly what
+// tenantFromCtx returned, so every existing caller is byte-identical and the
+// change adds a capability rather than moving a default. A non-admin's wire
+// value is ignored, not honoured-then-checked, which is the same posture
+// principalTenantScope takes — a tenant cannot widen its own scope.
+func (s *Server) adminFocusedTenant(ctx context.Context, wireTenant string) string {
+	wireTenant = strings.TrimSpace(wireTenant)
+	if wireTenant == "" {
+		return tenantFromCtx(ctx)
+	}
+	p, ok := auth.PrincipalFromContext(ctx)
+	// Open mode and legacy are is_admin-equivalent, matching principalTenantScope.
+	if !ok || p.Legacy || auth.HasScope(p.Scopes, auth.ScopeAdmin) {
+		return wireTenant
+	}
+	if wireTenant != p.TenantID {
+		log.Printf("auth: tenant_focus_ignored wire=%q principal=%q token_def=%q", wireTenant, p.TenantID, p.TokenDefID)
+	}
+	return tenantFromCtx(ctx)
 }
 
 // tenantVisible reports whether the caller may read a row belonging to

--- a/internal/api/http/auth_principal_tenant_family_test.go
+++ b/internal/api/http/auth_principal_tenant_family_test.go
@@ -1,0 +1,73 @@
+package http
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// The three tenant-resolution helpers disagree on what an admin gets when it
+// names no tenant, and that disagreement is deliberate: a LIST read can mean
+// "every tenant" while a single-tuple read must name exactly one. Nothing
+// asserted it, so the difference read as an accident — and on the memory browse
+// routes it WAS one, leaving a super-admin unable to see data its own tenant
+// operator could.
+//
+// This pins every cell. A change to one helper now has to state whether it meant
+// to change the family.
+func TestTenantResolution_AdminDefaultsAreDeliberate(t *testing.T) {
+	s := &Server{}
+	adminCtx := auth.WithPrincipal(t.Context(), auth.Principal{
+		TenantID: "acme", Subject: "root", Scopes: []string{auth.ScopeAdmin},
+	})
+	opCtx := auth.WithPrincipal(t.Context(), auth.Principal{
+		TenantID: "acme", Subject: "op", Scopes: []string{auth.ScopeTenant},
+	})
+
+	t.Run("list read: admin naming none sees every tenant", func(t *testing.T) {
+		tenant, all := s.principalTenantScope(adminCtx, "")
+		if !all || tenant != "" {
+			t.Errorf("principalTenantScope(admin, \"\") = (%q, %v), want (\"\", true) — a list read is where \"all tenants\" is expressible", tenant, all)
+		}
+	})
+	t.Run("single-tuple read: admin naming none keeps its own", func(t *testing.T) {
+		if got := s.adminFocusedTenant(adminCtx, ""); got != "acme" {
+			t.Errorf("adminFocusedTenant(admin, \"\") = %q, want acme — widening the default here would move behaviour for every existing caller instead of adding a capability", got)
+		}
+	})
+	t.Run("both honour an explicit admin focus", func(t *testing.T) {
+		if tenant, all := s.principalTenantScope(adminCtx, "other"); tenant != "other" || all {
+			t.Errorf("principalTenantScope(admin, other) = (%q, %v), want (other, false)", tenant, all)
+		}
+		if got := s.adminFocusedTenant(adminCtx, "other"); got != "other" {
+			t.Errorf("adminFocusedTenant(admin, other) = %q, want other", got)
+		}
+	})
+	t.Run("neither lets a tenant operator widen", func(t *testing.T) {
+		if tenant, all := s.principalTenantScope(opCtx, "other"); tenant != "acme" || all {
+			t.Errorf("principalTenantScope(operator, other) = (%q, %v), want (acme, false) — a tenant must not widen its own scope", tenant, all)
+		}
+		if got := s.adminFocusedTenant(opCtx, "other"); got != "acme" {
+			t.Errorf("adminFocusedTenant(operator, other) = %q, want acme — a tenant must not widen its own scope", got)
+		}
+	})
+	t.Run("browse ctx: operator keeps its tenant, admin takes the focus", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/x?tenant=other&scope_id=carol", nil)
+		if got := tenantOfBrowseCtx(s, opCtx, req); got != "acme" {
+			t.Errorf("substrateBrowseCtxFn(operator) tenant = %q, want acme", got)
+		}
+		if got := tenantOfBrowseCtx(s, adminCtx, req); got != "other" {
+			t.Errorf("substrateBrowseCtxFn(admin) tenant = %q, want other", got)
+		}
+	})
+}
+
+// tenantOfBrowseCtx runs substrateBrowseCtxFn and reads back the tenant it
+// stamped, so the browse path can be asserted next to its two siblings.
+func tenantOfBrowseCtx(s *Server, ctx context.Context, r *http.Request) string {
+	return tools.RunIdentity(s.substrateBrowseCtxFn(r)(ctx)).TenantID
+}

--- a/internal/api/http/memory.go
+++ b/internal/api/http/memory.go
@@ -105,10 +105,12 @@ func (s *Server) handleListMemoryScopeIDs(w http.ResponseWriter, r *http.Request
 			"scope must be one of: agent, user, tenant")
 		return
 	}
-	// RFC BL: scope the admin browse to the authenticated principal's tenant
-	// (server-sourced via tenantFromCtx — never from the URL/body). Open mode /
-	// legacy resolve to "" so single-tenant deployments are unchanged.
-	rows, err := s.store.MemoryListScopeIDs(r.Context(), tenantFromCtx(r.Context()), store.MemoryScope(scope))
+	// The tenant is the authenticated principal's, except that a SUPER-ADMIN may
+	// focus another with `?tenant=` — adminFocusedTenant ignores the wire value for
+	// everyone else, so a tenant operator still cannot widen its own scope. Without
+	// the param this is exactly tenantFromCtx, so single-tenant deployments and
+	// every existing caller are unchanged.
+	rows, err := s.store.MemoryListScopeIDs(r.Context(), s.adminFocusedTenant(r.Context(), r.URL.Query().Get("tenant")), store.MemoryScope(scope))
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "internal", err.Error())
 		return
@@ -151,9 +153,9 @@ func (s *Server) handleListMemoryEntries(w http.ResponseWriter, r *http.Request)
 	if limit > 1000 {
 		limit = 1000
 	}
-	// RFC BL: tenant from the authenticated principal (server-sourced), one
+	// Tenant from the authenticated principal, or a super-admin's `?tenant=` focus, one
 	// lookup reused by the entries list + the per-key embedding-metadata probe.
-	tenantID := tenantFromCtx(r.Context())
+	tenantID := s.adminFocusedTenant(r.Context(), r.URL.Query().Get("tenant"))
 	// tenant scope reads the single tenant-wide keyspace (store scope_id ""); the
 	// path placeholder is dropped. agent/user keep their scope_id.
 	storeScopeID := adminMemoryStoreScopeID(scope, scopeID)
@@ -216,7 +218,7 @@ func (s *Server) handleGetMemoryEntry(w http.ResponseWriter, r *http.Request) {
 			"scope_id and key are required")
 		return
 	}
-	entry, err := s.store.MemoryGet(r.Context(), tenantFromCtx(r.Context()), store.MemoryScope(scope), adminMemoryStoreScopeID(scope, scopeID), key)
+	entry, err := s.store.MemoryGet(r.Context(), s.adminFocusedTenant(r.Context(), r.URL.Query().Get("tenant")), store.MemoryScope(scope), adminMemoryStoreScopeID(scope, scopeID), key)
 	if err != nil {
 		var nf *store.ErrNotFound
 		if errors.As(err, &nf) {
@@ -390,7 +392,7 @@ func (s *Server) handlePutMemoryEntry(w http.ResponseWriter, r *http.Request) {
 			"invalid_at must be after valid_at — the interval is half-open [valid_at, invalid_at)")
 		return
 	}
-	if err := s.store.MemorySetTimed(r.Context(), tenantFromCtx(r.Context()), store.MemoryScope(scope), storeScopeID, key, body.Value, ttl, store.MemoryProvenance{}, times); err != nil {
+	if err := s.store.MemorySetTimed(r.Context(), s.adminFocusedTenant(r.Context(), r.URL.Query().Get("tenant")), store.MemoryScope(scope), storeScopeID, key, body.Value, ttl, store.MemoryProvenance{}, times); err != nil {
 		if errors.Is(err, store.ErrMemoryQuotaExceeded) {
 			writeJSONError(w, http.StatusRequestEntityTooLarge, "memory_quota_exceeded", err.Error())
 			return
@@ -440,7 +442,7 @@ func (s *Server) handleDeleteMemoryEntry(w http.ResponseWriter, r *http.Request)
 			"scope_id and key are required")
 		return
 	}
-	if _, err := s.store.MemoryDelete(r.Context(), tenantFromCtx(r.Context()), store.MemoryScope(scope), adminMemoryStoreScopeID(scope, scopeID), key); err != nil {
+	if _, err := s.store.MemoryDelete(r.Context(), s.adminFocusedTenant(r.Context(), r.URL.Query().Get("tenant")), store.MemoryScope(scope), adminMemoryStoreScopeID(scope, scopeID), key); err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "internal", err.Error())
 		return
 	}

--- a/internal/api/http/memory_test.go
+++ b/internal/api/http/memory_test.go
@@ -145,6 +145,60 @@ func TestHandleMemory_TenantOperatorConfined(t *testing.T) {
 	}
 }
 
+// A super-admin was strictly LESS capable than a tenant operator here, which is
+// backwards: it satisfies every scope gate and then could not read the data the
+// gate admits. The browse handlers pinned the tenant to the principal's own and
+// took nothing from the URL, so an admin whose own tenant is empty saw an empty
+// console while that tenant's own operator saw its rows — and had no parameter
+// available to look. Its siblings on the same store (embed stats, reembed,
+// backfill, purge) had accepted ?tenant= all along.
+//
+// The confinement half of this is TestHandleMemory_TenantOperatorConfined, which
+// sends the same ?tenant= as a tenant operator and must keep seeing nothing: the
+// focus widens for admin only, and is ignored rather than honoured-then-checked.
+func TestHandleMemory_AdminMayFocusAnotherTenant(t *testing.T) {
+	s := memoryAdminFixture(t)
+	ctx := t.Context()
+	// Same address under two tenants, so a wrong resolution shows the wrong value
+	// rather than nothing.
+	if err := s.store.MemorySet(ctx, "acme", store.MemoryScopeUser, "carol", "voice", []byte(`"acme-voice"`), 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.store.MemorySet(ctx, "other", store.MemoryScopeUser, "carol", "voice", []byte(`"other-voice"`), 0); err != nil {
+		t.Fatal(err)
+	}
+	// A super-admin whose OWN tenant is "acme".
+	admin := func(r *http.Request) *http.Request {
+		return r.WithContext(auth.WithPrincipal(r.Context(), auth.Principal{
+			TenantID: "acme", Subject: "root", Scopes: []string{auth.ScopeAdmin},
+		}))
+	}
+	list := func(query string) string {
+		req := httptest.NewRequest("GET", "/v1/_memory/scopes/user/carol/keys"+query, nil)
+		req.SetPathValue("scope", "user")
+		req.SetPathValue("scope_id", "carol")
+		rec := httptest.NewRecorder()
+		s.handleListMemoryEntries(rec, admin(req))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+		}
+		return rec.Body.String()
+	}
+
+	// With an explicit focus the admin reaches the other tenant.
+	if body := list("?tenant=other"); !strings.Contains(body, "other-voice") {
+		t.Errorf("admin could not focus tenant \"other\" — a super-admin cannot read data its own tenant operator can: %s", body)
+	}
+	// With NO focus it is byte-identical to the old behaviour: its own tenant.
+	body := list("")
+	if !strings.Contains(body, "acme-voice") {
+		t.Errorf("admin with no ?tenant= should see its OWN tenant: %s", body)
+	}
+	if strings.Contains(body, "other-voice") {
+		t.Errorf("admin with no ?tenant= must not silently widen — that would move a default, not add a capability: %s", body)
+	}
+}
+
 // TestHandleMemory_TenantScope: the tenant scope addresses a single tenant-wide
 // keyspace whose store scope_id is EMPTY (the tenant_id column partitions it, per
 // the Memory tool's resolveScope). The admin handlers therefore accept


### PR DESCRIPTION
## Why

An admin was **strictly less capable than a tenant operator** on the Memory console, which is backwards: `substrate:admin` satisfies every scope gate and then couldn't read the data the gate admits.

Reproduced against a live deployment, same route the Web UI uses:

| caller | resolves to | rows |
|---|---|---|
| `substrate:tenant` (locomo-bench) | own tenant | **5** |
| `substrate:admin`, no `?tenant=` | own tenant `default` | **0** |
| `substrate:admin` + `?tenant=locomo-bench` | *param was ignored* | **0** |

The five memory browse handlers resolved the tenant with `tenantFromCtx` — *"server-sourced, never from the URL/body"* — so an admin had **no parameter available** to look elsewhere. From the console it looks like a permissions failure.

The inconsistency was **inside one file**: the sibling maintenance routes on the same store — embed stats, reembed, backfill, purge — had accepted `?tenant=` via `principalTenantScope` all along. Only the reads and writes an operator actually browses with were pinned.

## What

`adminFocusedTenant` resolves those five (list scope-ids, list entries, get, put, delete).

**Only an explicit focus widens.** With no `?tenant=` it returns exactly what `tenantFromCtx` returned, so every existing caller is byte-identical — this adds a capability rather than moving a default. A non-admin's wire value is **ignored** rather than honoured-then-checked, the same posture `principalTenantScope` takes, so no tenant can widen its own scope.

The isolation guard was already written: the pre-existing `TestHandleMemory_TenantOperatorConfined` sends exactly this `?tenant=other` as a tenant operator and must keep seeing nothing. It passed before (param ignored) and passes now (ignored for non-admins).

## The helper family, reconciled

Three helpers resolve a tenant and they disagree on the admin default. That disagreement is **irreducible** — a LIST read can mean "every tenant"; a single-tuple read must name exactly one, so "all" isn't expressible:

| helper | case | admin, no `?tenant=` |
|---|---|---|
| `principalTenantScope` | list read | **all tenants** |
| `adminFocusedTenant` | single tuple | **own tenant** |
| `substrateBrowseCtxFn` | single tuple + subject | **own tenant** |

What made it a defect is that **nothing asserted it**, so the difference read as an accident — and on these routes it was one. It's now written down once, at `principalTenantScope`, naming all three and the one thing they must never disagree on (a non-admin never widens). `TestTenantResolution_AdminDefaultsAreDeliberate` pins every cell, so a change to one helper has to state whether it meant to change the family.

## What was tested

`go test ./...` clean — 98 packages, exit 0.

- `TestHandleMemory_AdminMayFocusAnotherTenant` — verified to **fail on the unfixed code**: the admin's `?tenant=other` returns its own tenant's row. Also pins that an admin naming none does *not* silently widen.
- `TestTenantResolution_AdminDefaultsAreDeliberate` — 5 subtests covering the family, including the isolation cell.
- `TestHandleMemory_TenantOperatorConfined` (pre-existing) — the confinement guard, still green.

## Not in this change

The Memory console still sends no `?tenant=`, so the UI half of this needs `@loomcycle/client` → `@loomcycle/memory-view` → `web` threading, all three version-gated for publish. The API is correct now; the console wiring is its own change. Every other browse surface (Documents, Paths, Agents, Users) already consumes `useFocusTenant()` — Memory is the one that never did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8