### PR TITLE
feat: recall-augmented distillation — Recall tool over evicted context spans (RFC CT P1)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -894,6 +894,16 @@ func main() {
 	}
 	allTools = append(allTools, memoryTool)
 
+	// Recall tool — the read side of recall-augmented distillation
+	// (context.recall). Searches the run-scoped index of spans the loop's
+	// distillation evicted, with a silent fallback to the agent's durable memory
+	// via the Memory tool (held by pointer, so its late-bound Backend is resolved
+	// at call time). Registered unconditionally like Memory: the run-scoped index
+	// is only built when an agent set context.recall, but the persistent-memory
+	// free-text search is useful for any agent that grants the tool.
+	recallTool := &builtin.Recall{Memory: memoryTool}
+	allTools = append(allTools, recallTool)
+
 	// Channel tool (v0.8.4) — persistent inter-agent message bus.
 	// One Bus instance per process so in-process subscribers waiting
 	// in long-poll mode get sub-millisecond notification. Same

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -699,6 +699,28 @@ A **local** backend (`ollama-local`, `vllm`, `llamacpp`) resolves to **recap** �
 
 The per-run `context` override is available on `POST /v1/runs` and on the MCP `spawn_run` (and fan-out `spawn_runs`); the per-agent block reaches every transport via the resolved def.
 
+#### `recall` — fetch back a detail a distillation dropped
+
+Every retention mode above is **lossy**: compaction summarizes the span it drops, recap keeps only a running note, stateful feeds only the state + the latest observation. That is the point — it keeps a long run affordable — but it means a specific value mentioned early (a token, a file path, a number, a decision) can be gone from what the model sees by the time it needs it. Growing the fed context back is the thing these modes exist to avoid.
+
+`recall: true` closes that gap without regrowing the prompt. As a run distils, each evicted span is embedded into a small **run-scoped index**; the agent gains a `Recall` tool that takes a **free-text** question and returns the most similar *original* spans verbatim:
+
+```yaml
+agents:
+  long-runner:
+    context:
+      mode: recap
+      recall: true          # off by default; harvest evicted spans + grant the Recall tool
+```
+
+So distillation now *shrinks* the fed context while *growing* a searchable index of what it dropped — a needle buried past a distillation boundary stays reachable by asking for it. The query is free text (not an id or exact wording) on purpose: models query fluently in plain language but barely reproduce identifiers, which also makes the tool far likelier to actually be used. `Recall` also transparently searches the agent's **durable memory**, so a fact learned in an earlier session may surface through the same call — the model needn't know where a fact lives.
+
+Notes:
+- **Needs an embedder.** The index keys and queries on embeddings, so `memory.embedder` must be configured; without one the run-index degrades to a no-op (the durable-memory search still applies for any agent that grants the `Recall` tool).
+- **Works in every mode** (`append` + `compaction`, `recap`, `stateful`) — it hooks the same distillation boundary each uses.
+- **Off is byte-identical.** `recall` unset/false changes nothing; a resumed run does not re-index (it replays its past distillations).
+- Available per-agent and as a per-run `context.recall` override on the same surfaces as the rest of the block.
+
 ### Interactive local agents
 
 For a terminal you steer turn-by-turn:

--- a/internal/agents/loader.go
+++ b/internal/agents/loader.go
@@ -209,6 +209,7 @@ type Context struct {
 	StateSchema     map[string]any `json:"state_schema,omitempty"`
 	OnInvalidPatch  *string        `json:"on_invalid_patch,omitempty"`
 	MaxPatchRetries *int           `json:"max_patch_retries,omitempty"`
+	Recall          *bool          `json:"recall,omitempty"`
 }
 
 // CoreBlock mirrors config.CoreBlock locally so the agents package stays

--- a/internal/agents/sign.go
+++ b/internal/agents/sign.go
@@ -347,7 +347,8 @@ func normalize(c *AgentContent) {
 	if c.Context != nil && c.Context.Mode == nil && c.Context.KeepLastN == nil &&
 		c.Context.Reasoning == nil && c.Context.RecapMaxChars == nil &&
 		c.Context.AutoRecapAtPct == nil && len(c.Context.StateSchema) == 0 &&
-		c.Context.OnInvalidPatch == nil && c.Context.MaxPatchRetries == nil {
+		c.Context.OnInvalidPatch == nil && c.Context.MaxPatchRetries == nil &&
+		c.Context.Recall == nil {
 		c.Context = nil
 	}
 

--- a/internal/agents/sign_test.go
+++ b/internal/agents/sign_test.go
@@ -405,6 +405,34 @@ func TestFromOverlay_ChannelsConvergeWithWritePath(t *testing.T) {
 	}
 }
 
+func TestFromOverlay_ContextRecallIsContentIdentifying(t *testing.T) {
+	// The substrate read path (FromOverlay) hashes the context block; context.recall
+	// must be content-identifying (a fork that flips it mints a distinct hash) while
+	// an empty context still collapses to the bare hash — mirroring every sibling
+	// context field, so a recall fork is not silently deduped as identical content.
+	bareHash := Sign(FromYAMLAgent(&Agent{Name: "x"}))
+
+	empty, err := FromOverlay(json.RawMessage(`{"name":"x","context":{}}`))
+	if err != nil {
+		t.Fatalf("FromOverlay(empty context): %v", err)
+	}
+	if Sign(empty) != bareHash {
+		t.Error("persisted empty context did not collapse to the bare hash — backfill/verify would diverge from create")
+	}
+
+	on, err := FromOverlay(json.RawMessage(`{"name":"x","context":{"recall":true}}`))
+	if err != nil {
+		t.Fatalf("FromOverlay(recall): %v", err)
+	}
+	if Sign(on) == bareHash {
+		t.Error("context.recall:true did not change the content hash — a recall fork must mint a distinct hash")
+	}
+	on2, _ := FromOverlay(json.RawMessage(`{"name":"x","context":{"recall":true}}`))
+	if Sign(on) != Sign(on2) {
+		t.Error("context.recall hash is not stable across identical reads")
+	}
+}
+
 func TestFromOverlay_ParsesValidJSON(t *testing.T) {
 	overlay := json.RawMessage(`{"name":"x","system_prompt":"hi","tools":["Read"]}`)
 	c, err := FromOverlay(overlay)

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -37,6 +37,7 @@ import (
 	lcotel "github.com/denn-gubsky/loomcycle/internal/otel"
 	"github.com/denn-gubsky/loomcycle/internal/pause"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/recall"
 	"github.com/denn-gubsky/loomcycle/internal/redact"
 	"github.com/denn-gubsky/loomcycle/internal/resolve"
 	"github.com/denn-gubsky/loomcycle/internal/runner"
@@ -2204,6 +2205,20 @@ func convertConfigCandidates(in map[string][]config.TierCandidate, models map[st
 // the same change as gRPC's Run/Continue would touch ~500 LOC of
 // HTTP code in a PR whose primary purpose is gRPC streaming;
 // keeping them separate makes both PRs reviewable.
+// recallIndexForRun builds the run-scoped recall index (RFC CT) for a fresh run,
+// or nil to leave recall off. It is built only when the merged context policy sets
+// recall AND an embedder is configured: without an embedder the index cannot key
+// or query anything, so it degrades to a no-op rather than a half-wired feature.
+// nil flows into loop.RunOptions.RecallIndex, whose harvest/stamp are nil-safe, so
+// the default path stays byte-identical. Deliberately NOT called on the resume
+// path (a resumed run replays past distillations without harvesting).
+func (s *Server) recallIndexForRun(cx *config.Context) *recall.Index {
+	if cx == nil || cx.Recall == nil || !*cx.Recall || s.embedder == nil {
+		return nil
+	}
+	return recall.NewIndex(s.embedder, 0)
+}
+
 func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunCallbacks) error {
 	// ---- Validation phase ----
 	if in.UserID != "" && !validIdent(in.UserID) {
@@ -2639,6 +2654,9 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 		Sampling:            config.MergeSampling(agentDef.Sampling, in.Sampling),       // per-run wins per field
 		Compaction:          config.MergeCompaction(agentDef.Compaction, in.Compaction), // per-run wins per field
 		Context:             config.MergeContext(agentDef.Context, in.Context),          // per-run wins per field (RFC CR)
+		// Recall-augmented distillation: nil unless the agent set context.recall AND
+		// an embedder is configured, so an unopted run is byte-identical (RFC CT).
+		RecallIndex: s.recallIndexForRun(config.MergeContext(agentDef.Context, in.Context)),
 		// RFC BL P3: nil unless the agent set compaction.memory_flush, so an
 		// unopted agent's compaction path is byte-identical.
 		BankCompactedSpan:      s.bankCompactedSpanFn(agentDef, rid.TenantID, effectiveUserID, in.Agent, runID, sessionID),
@@ -4258,6 +4276,9 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		Sampling:            config.MergeSampling(agentDef.Sampling, req.Sampling),       // per-run wins per field
 		Compaction:          config.MergeCompaction(agentDef.Compaction, req.Compaction), // per-run wins per field
 		Context:             config.MergeContext(agentDef.Context, req.Context),          // per-run wins per field (RFC CR)
+		// Recall-augmented distillation: nil unless context.recall is set AND an
+		// embedder is configured, so an unopted run is byte-identical (RFC CT).
+		RecallIndex: s.recallIndexForRun(config.MergeContext(agentDef.Context, req.Context)),
 		// RFC BL P3: nil unless the agent set compaction.memory_flush.
 		BankCompactedSpan:      s.bankCompactedSpanFn(agentDef, rid.TenantID, req.UserID, req.Agent, runID, sessionID),
 		ContextPlugins:         s.contextPlugins, // RFC Z runtime-wide chain (code-js exempt in the loop)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1781,6 +1781,18 @@ type Context struct {
 	// MaxPatchRetries bounds the rollback-retry loop on an invalid patch
 	// (on_invalid_patch=retry). Default 2. Only consulted in stateful mode.
 	MaxPatchRetries *int `json:"max_patch_retries,omitempty" yaml:"max_patch_retries"`
+	// Recall opts the run into recall-augmented distillation: every span the
+	// context distillation (compaction / recap / stateful) evicts is embedded into
+	// a run-scoped index, and the agent gains a `Recall` tool that fetches the most
+	// similar ORIGINAL spans by free-text query — with a silent fallback to the
+	// agent's durable memory. Distillation shrinks the fed context while GROWING a
+	// searchable index of what it dropped, so a needle buried past a distillation
+	// boundary stays reachable. Off (nil/false) = today's behavior, byte-identical.
+	// Needs an embedder (memory.embedder); a deployment without one degrades the
+	// run-index leg to a no-op (the persistent fallback still applies). Applies in
+	// every retention mode. Content-identifying — a fork that flips it mints a
+	// distinct hash.
+	Recall *bool `json:"recall,omitempty" yaml:"recall"`
 }
 
 // Context mode values.
@@ -1811,7 +1823,8 @@ const (
 func (c *Context) IsZero() bool {
 	return c == nil || (c.Mode == nil && c.KeepLastN == nil && c.Reasoning == nil &&
 		c.RecapMaxChars == nil && c.AutoRecapAtPct == nil &&
-		len(c.StateSchema) == 0 && c.OnInvalidPatch == nil && c.MaxPatchRetries == nil)
+		len(c.StateSchema) == 0 && c.OnInvalidPatch == nil && c.MaxPatchRetries == nil &&
+		c.Recall == nil)
 }
 
 // Clone deep-copies (every field is a pointer) so a merge never aliases an input.
@@ -1848,6 +1861,10 @@ func (c *Context) Clone() *Context {
 	if c.MaxPatchRetries != nil {
 		v := *c.MaxPatchRetries
 		out.MaxPatchRetries = &v
+	}
+	if c.Recall != nil {
+		v := *c.Recall
+		out.Recall = &v
 	}
 	return out
 }
@@ -1917,6 +1934,10 @@ func MergeContext(base, over *Context) *Context {
 	if over.MaxPatchRetries != nil {
 		v := *over.MaxPatchRetries
 		out.MaxPatchRetries = &v
+	}
+	if over.Recall != nil {
+		v := *over.Recall
+		out.Recall = &v
 	}
 	return out
 }

--- a/internal/config/context_test.go
+++ b/internal/config/context_test.go
@@ -104,6 +104,9 @@ func nonZeroContext(t *testing.T) *Context {
 			case reflect.Int:
 				// In-range for autorecap_at_pct (50..95); fine for the others.
 				elem.Elem().SetInt(50)
+			case reflect.Bool:
+				// recall — a plain opt-in flag.
+				elem.Elem().SetBool(true)
 			case reflect.String:
 				switch name {
 				case "Mode":

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -23,6 +23,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/hooks"
 	lcotel "github.com/denn-gubsky/loomcycle/internal/otel"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/recall"
 	"github.com/denn-gubsky/loomcycle/internal/steer"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
@@ -196,6 +197,18 @@ type RunOptions struct {
 	// nil / Mode=="append" = today's behavior. Defaults applied at use-time (see
 	// config.ContextDefault*).
 	Context *config.Context
+
+	// RecallIndex is the run-scoped index recall-augmented distillation harvests
+	// into. When non-nil (the server builds it only when context.recall is set AND
+	// an embedder is configured), each distillation — compaction, recap, stateful
+	// — embeds the span it evicts into this index, and the loop stamps it on ctx so
+	// the Recall builtin can query it. nil = recall off (byte-identical to before).
+	//
+	// Deliberately NOT set on the resume path: a resumed run replays its past
+	// distillations through applyCompactSummary, which never harvests, so leaving
+	// this nil there avoids double-indexing. Like BankCompactedSpan, a callback-free
+	// handle the loop only ever reads.
+	RecallIndex *recall.Index
 
 	// ContextPlugins is the runtime-wide context-transform chain (RFC Z / F43):
 	// fast, built-in transforms applied to a COPY of the outbound request each
@@ -1295,6 +1308,10 @@ func maybeAutoCompact(ctx context.Context, opts RunOptions, messages []providers
 	// this is the last moment the discarded turns exist. Never fatal — see
 	// RunOptions.BankCompactedSpan.
 	info.MemoryBanked = bankDiscardedSpan(ctx, opts, messages[firstIdx:cut])
+	// Recall harvest: embed the span this compaction is dropping into the run-
+	// scoped index so a later Recall(query) can fetch it back. Same "last moment
+	// the discarded turns exist" rationale as banking; nil-safe when recall is off.
+	opts.RecallIndex.Harvest(ctx, messages[firstIdx:cut])
 	emit(providers.Event{Type: providers.EventContextCompaction, ContextCompaction: info})
 	lcotel.RecordCompactionCtx(ctx, trigger, before, after) // per-run-shape metric via OTEL span event
 	return out, true
@@ -1469,6 +1486,10 @@ func maybeRecap(ctx context.Context, opts RunOptions, messages []providers.Messa
 		newRecap = strings.TrimSpace(r)
 	}
 	// reasoning=="drop": no recap call; the evicted span is dropped with no note.
+	// Recall harvest: embed the evicted span before it is dropped, so a later
+	// Recall(query) can fetch it back — most valuable exactly here, where recap
+	// (or drop) loses the detail. nil-safe when recall is off.
+	opts.RecallIndex.Harvest(ctx, messages[firstIdx:cut])
 	before := estimateMessageTokens(messages)
 	pinned := ""
 	if firstIdx > 0 {
@@ -1608,6 +1629,11 @@ func Run(ctx context.Context, opts RunOptions) (RunResult, error) {
 	if contextAutoMode(opts.Context) {
 		opts.Context = resolveAutoContextMode(opts.Context, opts.Provider.Capabilities().Local, opts.Interactive)
 	}
+
+	// Recall-augmented distillation: stamp the run-scoped index on ctx (before the
+	// stateful branch, so both loop paths and their dispatched tools reach it via
+	// recall.FromContext). No-op when opts.RecallIndex is nil (recall off).
+	ctx = recall.NewContext(ctx, opts.RecallIndex)
 
 	// RFC CR L2: a stateful run is a different loop — it feeds only (P, Σ, O) and
 	// the model emits a patch + action each step. Branch here, after the preamble

--- a/internal/loop/recall_harvest_test.go
+++ b/internal/loop/recall_harvest_test.go
@@ -1,0 +1,111 @@
+package loop
+
+import (
+	"context"
+	"hash/fnv"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/recall"
+)
+
+// recallTestEmbedder is a deterministic bag-of-words embedder so a query sharing
+// the needle's tokens retrieves it — enough to prove the harvest wired the evicted
+// span into the index, without a real embedding model.
+type recallTestEmbedder struct{ dim int }
+
+func (e recallTestEmbedder) Embed(_ context.Context, texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i, t := range texts {
+		v := make([]float32, e.dim)
+		for _, tok := range strings.Fields(strings.ToLower(t)) {
+			h := fnv.New32a()
+			_, _ = h.Write([]byte(tok))
+			v[h.Sum32()%uint32(e.dim)]++
+		}
+		out[i] = v
+	}
+	return out, nil
+}
+
+func (e recallTestEmbedder) Model() string    { return "bag" }
+func (e recallTestEmbedder) Provider() string { return "test" }
+func (e recallTestEmbedder) Dimension() int   { return e.dim }
+
+// TestMaybeAutoCompact_HarvestsEvictedSpanToRecallIndex: recall-augmented
+// distillation must embed the exact span a compaction drops into the run-scoped
+// index, so a later free-text Recall recovers a needle buried past the boundary.
+func TestMaybeAutoCompact_HarvestsEvictedSpanToRecallIndex(t *testing.T) {
+	msgs := []providers.Message{
+		userMsg("the task"), asstMsg("the secret token is orchid-88 keep it"),
+		userMsg("q2"), asstMsg("a2"), userMsg("q3"), asstMsg("a3"),
+	}
+	ix := recall.NewIndex(recallTestEmbedder{dim: 256}, 0)
+	opts := RunOptions{
+		Provider:    &steerProvider{}, // Call returns "ok" → summary succeeds
+		Model:       "x",
+		Compaction:  &config.Compaction{KeepLastN: cptr(2), KeepFirst: cptr(true), TargetPercentage: cptr(10)},
+		RecallIndex: ix,
+	}
+	_, did := maybeAutoCompact(context.Background(), opts, msgs, 0, func(providers.Event) {}, "auto")
+	if !did {
+		t.Fatal("expected compaction to happen")
+	}
+	// Evicted = the span between the pinned first turn and the kept last-2 tail:
+	// a1, q2, a2 — three messages, indexed per-message.
+	if ix.Len() != 3 {
+		t.Fatalf("index Len = %d, want 3 evicted spans harvested", ix.Len())
+	}
+	hits, err := ix.Search(context.Background(), "what is the secret token", 3)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(hits) == 0 || !strings.Contains(hits[0].Text, "orchid-88") {
+		t.Fatalf("recall did not recover the evicted needle: %+v", hits)
+	}
+}
+
+// TestMaybeAutoCompact_NilRecallIndexNoOp: with recall off (nil index),
+// compaction proceeds unchanged and the nil-receiver Harvest never panics.
+func TestMaybeAutoCompact_NilRecallIndexNoOp(t *testing.T) {
+	msgs := []providers.Message{userMsg("the task"), asstMsg("a1"), userMsg("q2"), asstMsg("a2"), userMsg("q3"), asstMsg("a3")}
+	opts := RunOptions{
+		Provider:   &steerProvider{},
+		Model:      "x",
+		Compaction: &config.Compaction{KeepLastN: cptr(2), KeepFirst: cptr(true), TargetPercentage: cptr(10)},
+	}
+	if _, did := maybeAutoCompact(context.Background(), opts, msgs, 0, func(providers.Event) {}, "auto"); !did {
+		t.Fatal("compaction should still happen with recall off")
+	}
+}
+
+// TestMaybeRecap_HarvestsEvictedSpan: the recap path drops the evicted reasoning
+// (or, in drop mode, everything) — exactly where recall is most valuable — so it
+// must harvest the span too, not only the compaction path.
+func TestMaybeRecap_HarvestsEvictedSpan(t *testing.T) {
+	msgs := []providers.Message{
+		userMsg("the task"), asstMsg("the api key rotates to violet-31 tomorrow"),
+		userMsg("q2"), asstMsg("a2"), userMsg("q3"), asstMsg("a3"),
+	}
+	ix := recall.NewIndex(recallTestEmbedder{dim: 256}, 0)
+	opts := RunOptions{
+		Provider: &steerProvider{},
+		Model:    "x",
+		// reasoning=drop: no recap call, pure eviction — the harsh case.
+		Context:     &config.Context{Mode: cptr(config.ContextModeRecap), KeepLastN: cptr(2), Reasoning: cptr("drop")},
+		RecallIndex: ix,
+	}
+	_, did := maybeRecap(context.Background(), opts, msgs, 0, func(providers.Event) {}, "auto")
+	if !did {
+		t.Fatal("expected recap distillation to happen")
+	}
+	if ix.Len() == 0 {
+		t.Fatal("recap dropped the span without harvesting it into the recall index")
+	}
+	hits, _ := ix.Search(context.Background(), "when does the api key rotate", 3)
+	if len(hits) == 0 || !strings.Contains(hits[0].Text, "violet-31") {
+		t.Fatalf("recall did not recover the evicted needle from the recap path: %+v", hits)
+	}
+}

--- a/internal/loop/stateful.go
+++ b/internal/loop/stateful.go
@@ -323,6 +323,15 @@ func runStateful(ctx context.Context, opts RunOptions, system []providers.Conten
 		emit(providers.Event{Type: providers.EventContextState,
 			ContextState: &providers.ContextStateEventInfo{State: sigma, Patch: es.Patch, Iter: iter, Action: actionName(es), Reasoning: es.Reasoning, ProposedSchema: proposed}})
 
+		// Recall harvest (RFC CT): stateful is the most lossy mode — only Σ and the
+		// latest observation are fed, so each step's reasoning + observation are
+		// otherwise discarded. Embed them into the run-scoped index so a later
+		// Recall(query) can fetch the original detail back. nil-safe when recall off.
+		opts.RecallIndex.Harvest(ctx, []providers.Message{
+			{Role: "assistant", Reasoning: es.Reasoning,
+				Content: []providers.ContentBlock{{Type: "text", Text: obs}}},
+		})
+
 		// Terminal: done flag, or no action named.
 		if es.Done || es.Action == nil || strings.TrimSpace(es.Action.Tool) == "" {
 			final := es.Final

--- a/internal/recall/context.go
+++ b/internal/recall/context.go
@@ -1,0 +1,22 @@
+package recall
+
+import "context"
+
+type ctxKey struct{}
+
+// NewContext stamps the run-scoped index on ctx so the loop's harvest hook and
+// the Recall tool both reach it. A nil index is a no-op (recall disabled) — the
+// Recall tool then finds no run-index and falls back to durable memory only.
+func NewContext(ctx context.Context, ix *Index) context.Context {
+	if ix == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, ctxKey{}, ix)
+}
+
+// FromContext returns the run-scoped index, or nil when recall is not enabled for
+// this run.
+func FromContext(ctx context.Context) *Index {
+	ix, _ := ctx.Value(ctxKey{}).(*Index)
+	return ix
+}

--- a/internal/recall/index.go
+++ b/internal/recall/index.go
@@ -1,0 +1,233 @@
+// Package recall implements a run-scoped, embedding-keyed index of the
+// conversation spans a run's context distillation evicts, plus the free-text
+// lookup the Recall tool uses to fetch them back.
+//
+// The invariant it rests on: context distillation (compaction / recap / stateful)
+// is lossy and one-way, but the ORIGINAL turns are already retained on the
+// transcript and the embedding machinery already exists. So as the loop distils a
+// span, this package embeds each evicted message and keeps the vector in memory
+// for the rest of the run; a later Recall(query) embeds the query and returns the
+// most similar original spans. Distillation therefore SHRINKS the fed context
+// while GROWING a searchable index of what it dropped — a needle buried past a
+// distillation boundary stays reachable by a free-text question.
+//
+// A run-scoped in-memory index (rather than the persistent vector store) is
+// deliberate: the persistent store is per-scope and durable, so indexing every
+// evicted turn there would pollute the agent's memory and add store writes on the
+// distillation hot path. The durable half — curating facts worth keeping across
+// runs — is the consolidator (compaction.memory_flush) and the Recall tool's
+// silent fallback to the agent's memory; this index is the immediate, within-run
+// half.
+package recall
+
+import (
+	"context"
+	"math"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// DefaultMaxEntries caps a run-scoped index. A long run evicts many spans; past
+// the cap the oldest entries are dropped (FIFO) so memory stays bounded. The cap
+// is generous — recall targets recently-evicted facts — and each entry is only a
+// vector plus a bounded text snippet.
+const DefaultMaxEntries = 4096
+
+// DefaultTopK is the fetch size when a Recall query does not name one. The
+// needle-recall probe found k=3 recovers a buried fact reliably without diluting
+// the answer with near-duplicates.
+const DefaultTopK = 3
+
+// MaxTopK bounds a caller-supplied k.
+const MaxTopK = 10
+
+// maxEntryChars bounds the text embedded per evicted message, so one giant tool
+// result cannot blow the embedder's token budget. The head of a span carries the
+// identifying fact; the tail is usually boilerplate.
+const maxEntryChars = 4000
+
+// Index is a run-scoped, in-memory, embedding-keyed store of the spans a run's
+// context distillation evicted. One Index per run, discarded when the run ends.
+// Safe for concurrent Harvest/Search: the loop harvests at a distillation
+// boundary while a tool call may be searching.
+type Index struct {
+	embedder   providers.Embedder
+	maxEntries int
+
+	mu      sync.Mutex
+	entries []entry
+}
+
+type entry struct {
+	vec  []float32
+	text string
+}
+
+// Hit is one recall result: an original span and its cosine similarity to the
+// query. Source names where it came from ("run" = this run's evicted spans,
+// "memory" = the agent's durable memory) so a caller can tell them apart.
+type Hit struct {
+	Text   string
+	Score  float64
+	Source string
+}
+
+// NewIndex builds a run-scoped index. embedder may be nil — Harvest and Search
+// then no-op — so a caller need not special-case a no-embedder deployment.
+// maxEntries <= 0 uses DefaultMaxEntries.
+func NewIndex(embedder providers.Embedder, maxEntries int) *Index {
+	if maxEntries <= 0 {
+		maxEntries = DefaultMaxEntries
+	}
+	return &Index{embedder: embedder, maxEntries: maxEntries}
+}
+
+// Harvest embeds each evicted message that carries text and appends it as its OWN
+// entry — the probe found a per-message granularity beats a per-block one (a
+// coarse block dilutes the discriminating fact). One batch Embed call covers the
+// whole span.
+//
+// Never fatal: harvest exists to help a later recall, and an embed failure (local
+// model down, a timeout) must not break a live run — the batch is dropped and the
+// run continues. A nil embedder or empty span is a no-op.
+func (ix *Index) Harvest(ctx context.Context, evicted []providers.Message) {
+	if ix == nil || ix.embedder == nil || len(evicted) == 0 {
+		return
+	}
+	texts := make([]string, 0, len(evicted))
+	for _, m := range evicted {
+		if t := renderMessage(m); t != "" {
+			texts = append(texts, t)
+		}
+	}
+	if len(texts) == 0 {
+		return
+	}
+	vecs, err := ix.embedder.Embed(ctx, texts)
+	if err != nil || len(vecs) != len(texts) {
+		return // swallowed — see the doc comment
+	}
+	ix.mu.Lock()
+	defer ix.mu.Unlock()
+	for i, v := range vecs {
+		ix.entries = append(ix.entries, entry{vec: v, text: texts[i]})
+	}
+	// FIFO trim to the cap: keep the most recently harvested spans.
+	if len(ix.entries) > ix.maxEntries {
+		ix.entries = ix.entries[len(ix.entries)-ix.maxEntries:]
+	}
+}
+
+// Search embeds the query and returns up to k entries by descending cosine
+// similarity, tagged Source="run". Returns (nil, nil) when the index is empty,
+// the embedder is unset, or the query is blank. k <= 0 uses DefaultTopK; k is
+// clamped to MaxTopK.
+func (ix *Index) Search(ctx context.Context, query string, k int) ([]Hit, error) {
+	if ix == nil || ix.embedder == nil {
+		return nil, nil
+	}
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return nil, nil
+	}
+	if k <= 0 {
+		k = DefaultTopK
+	}
+	if k > MaxTopK {
+		k = MaxTopK
+	}
+	ix.mu.Lock()
+	snapshot := make([]entry, len(ix.entries))
+	copy(snapshot, ix.entries)
+	ix.mu.Unlock()
+	if len(snapshot) == 0 {
+		return nil, nil
+	}
+	vecs, err := ix.embedder.Embed(ctx, []string{query})
+	if err != nil || len(vecs) == 0 {
+		return nil, err
+	}
+	q := vecs[0]
+	hits := make([]Hit, 0, len(snapshot))
+	for _, e := range snapshot {
+		hits = append(hits, Hit{Text: e.text, Score: cosine(q, e.vec), Source: "run"})
+	}
+	sort.SliceStable(hits, func(i, j int) bool { return hits[i].Score > hits[j].Score })
+	if len(hits) > k {
+		hits = hits[:k]
+	}
+	return hits, nil
+}
+
+// Len reports the number of indexed spans (for tests / diagnostics).
+func (ix *Index) Len() int {
+	if ix == nil {
+		return 0
+	}
+	ix.mu.Lock()
+	defer ix.mu.Unlock()
+	return len(ix.entries)
+}
+
+// renderMessage flattens a message to the text worth embedding: its role, the
+// text of each content block (tool results included — they carry the facts a
+// distillation drops), any tool_use tool name (so an action is still findable),
+// and the assistant reasoning trace when present. Returns "" when there is
+// nothing textual to index. Capped at maxEntryChars so a giant tool result does
+// not dominate the embedder's input.
+func renderMessage(m providers.Message) string {
+	var b strings.Builder
+	add := func(s string) {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return
+		}
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(s)
+	}
+	for _, c := range m.Content {
+		switch c.Type {
+		case "text", "tool_result":
+			add(c.Text)
+		case "tool_use":
+			add(c.ToolName)
+		}
+	}
+	add(m.Reasoning)
+	body := strings.TrimSpace(b.String())
+	if body == "" {
+		return ""
+	}
+	if m.Role != "" {
+		body = m.Role + ": " + body
+	}
+	if len(body) > maxEntryChars {
+		body = body[:maxEntryChars]
+	}
+	return body
+}
+
+// cosine is the standard cosine similarity of two equal-length vectors, 0 for a
+// length mismatch or a zero vector. Kept local so the package depends only on
+// providers (the memory package has its own copy for the same reason).
+func cosine(a, b []float32) float64 {
+	if len(a) != len(b) || len(a) == 0 {
+		return 0
+	}
+	var dot, na, nb float64
+	for i := range a {
+		af, bf := float64(a[i]), float64(b[i])
+		dot += af * bf
+		na += af * af
+		nb += bf * bf
+	}
+	if na == 0 || nb == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(na) * math.Sqrt(nb))
+}

--- a/internal/recall/index_test.go
+++ b/internal/recall/index_test.go
@@ -1,0 +1,181 @@
+package recall
+
+import (
+	"context"
+	"errors"
+	"hash/fnv"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// bagEmbedder is a deterministic bag-of-words embedder: each token bumps one
+// dimension chosen by its hash. Two texts that share distinctive tokens land near
+// each other in cosine space, so a query sharing the needle's words retrieves it.
+// Good enough to exercise Harvest/Search ranking without a real embedding model.
+type bagEmbedder struct {
+	dim  int
+	fail bool
+}
+
+func (b bagEmbedder) Embed(_ context.Context, texts []string) ([][]float32, error) {
+	if b.fail {
+		return nil, errors.New("embed unavailable")
+	}
+	out := make([][]float32, len(texts))
+	for i, t := range texts {
+		v := make([]float32, b.dim)
+		for _, tok := range strings.Fields(strings.ToLower(t)) {
+			h := fnv.New32a()
+			_, _ = h.Write([]byte(tok))
+			v[h.Sum32()%uint32(b.dim)]++
+		}
+		out[i] = v
+	}
+	return out, nil
+}
+
+func (b bagEmbedder) Model() string    { return "bag" }
+func (b bagEmbedder) Provider() string { return "test" }
+func (b bagEmbedder) Dimension() int   { return b.dim }
+
+func userMsg(text string) providers.Message {
+	return providers.Message{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: text}}}
+}
+
+func TestIndex_HarvestThenSearchFindsNeedle(t *testing.T) {
+	ix := NewIndex(bagEmbedder{dim: 256}, 0)
+	ix.Harvest(context.Background(), []providers.Message{
+		userMsg("the weather in paris was mild that afternoon"),
+		userMsg("the deployment token is zephyr-quartz-42 keep it safe"),
+		userMsg("lunch was a sandwich and some coffee"),
+		userMsg("the meeting is scheduled for next tuesday morning"),
+	})
+	if ix.Len() != 4 {
+		t.Fatalf("Len = %d, want 4", ix.Len())
+	}
+	hits, err := ix.Search(context.Background(), "what is the deployment token", 3)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(hits) == 0 {
+		t.Fatal("no hits")
+	}
+	if !strings.Contains(hits[0].Text, "zephyr-quartz-42") {
+		t.Fatalf("top hit did not recover the needle: %q", hits[0].Text)
+	}
+	if hits[0].Source != "run" {
+		t.Fatalf("Source = %q, want run", hits[0].Source)
+	}
+}
+
+func TestIndex_NilEmbedderIsNoOp(t *testing.T) {
+	ix := NewIndex(nil, 0)
+	ix.Harvest(context.Background(), []providers.Message{userMsg("anything")})
+	if ix.Len() != 0 {
+		t.Fatalf("Len = %d, want 0 with nil embedder", ix.Len())
+	}
+	hits, err := ix.Search(context.Background(), "anything", 3)
+	if err != nil || hits != nil {
+		t.Fatalf("Search on nil-embedder index = (%v, %v), want (nil, nil)", hits, err)
+	}
+}
+
+func TestIndex_CapEvictsOldest(t *testing.T) {
+	ix := NewIndex(bagEmbedder{dim: 64}, 3)
+	for _, s := range []string{"alpha one", "bravo two", "charlie three", "delta four", "echo five"} {
+		ix.Harvest(context.Background(), []providers.Message{userMsg(s)})
+	}
+	if ix.Len() != 3 {
+		t.Fatalf("Len = %d, want 3 after cap", ix.Len())
+	}
+	// The two oldest ("alpha", "bravo") must be gone; the newest kept.
+	hits, _ := ix.Search(context.Background(), "echo five", MaxTopK)
+	for _, h := range hits {
+		if strings.Contains(h.Text, "alpha") || strings.Contains(h.Text, "bravo") {
+			t.Fatalf("evicted entry still present: %q", h.Text)
+		}
+	}
+}
+
+func TestIndex_HarvestEmbedFailureSwallowed(t *testing.T) {
+	// A harvest whose embed call fails must not break the run: the batch is
+	// dropped, the index stays empty, and a later Search is a clean no-op.
+	ix := NewIndex(bagEmbedder{dim: 64, fail: true}, 0)
+	ix.Harvest(context.Background(), []providers.Message{userMsg("dropped on embed error")})
+	if ix.Len() != 0 {
+		t.Fatalf("Len = %d, want 0 when the embed call fails", ix.Len())
+	}
+	if hits, err := ix.Search(context.Background(), "x", 3); err != nil || hits != nil {
+		t.Fatalf("Search after failed harvest = (%v, %v), want (nil, nil)", hits, err)
+	}
+}
+
+func TestIndex_SearchEmbedFailureSurfaces(t *testing.T) {
+	// With entries present but the query-embed failing, Search surfaces the error
+	// rather than silently returning no hits (the caller should know recall broke,
+	// not mistake it for "nothing relevant").
+	ix := &Index{embedder: bagEmbedder{dim: 64}, maxEntries: DefaultMaxEntries}
+	ix.Harvest(context.Background(), []providers.Message{userMsg("indexed while embedder healthy")})
+	if ix.Len() != 1 {
+		t.Fatalf("Len = %d, want 1", ix.Len())
+	}
+	ix.embedder = bagEmbedder{dim: 64, fail: true} // query-time failure only
+	if _, err := ix.Search(context.Background(), "x", 3); err == nil {
+		t.Fatal("Search should surface the query-embed error when the index is non-empty")
+	}
+}
+
+func TestIndex_EmptyQueryAndEmptyIndex(t *testing.T) {
+	ix := NewIndex(bagEmbedder{dim: 64}, 0)
+	if hits, err := ix.Search(context.Background(), "q", 3); err != nil || hits != nil {
+		t.Fatalf("empty index Search = (%v, %v), want (nil, nil)", hits, err)
+	}
+	ix.Harvest(context.Background(), []providers.Message{userMsg("something")})
+	if hits, err := ix.Search(context.Background(), "   ", 3); err != nil || hits != nil {
+		t.Fatalf("blank query Search = (%v, %v), want (nil, nil)", hits, err)
+	}
+}
+
+func TestIndex_HarvestSkipsEmptyMessages(t *testing.T) {
+	ix := NewIndex(bagEmbedder{dim: 64}, 0)
+	ix.Harvest(context.Background(), []providers.Message{
+		{Role: "assistant", Content: []providers.ContentBlock{{Type: "image", Data: "abc"}}}, // no text
+		userMsg("real content here"),
+	})
+	if ix.Len() != 1 {
+		t.Fatalf("Len = %d, want 1 (empty message skipped)", ix.Len())
+	}
+}
+
+func TestIndex_ToolResultAndReasoningIndexed(t *testing.T) {
+	ix := NewIndex(bagEmbedder{dim: 256}, 0)
+	ix.Harvest(context.Background(), []providers.Message{
+		{Role: "user", Content: []providers.ContentBlock{{Type: "tool_result", Text: "quarterly revenue was 4.2 million dollars"}}},
+		{Role: "assistant", Reasoning: "the client prefers vanadium alloy fittings", Content: []providers.ContentBlock{{Type: "text", Text: "ok"}}},
+	})
+	rev, _ := ix.Search(context.Background(), "revenue", 1)
+	if len(rev) == 0 || !strings.Contains(rev[0].Text, "4.2 million") {
+		t.Fatalf("tool_result not recalled: %+v", rev)
+	}
+	al, _ := ix.Search(context.Background(), "vanadium alloy fittings preference", 1)
+	if len(al) == 0 || !strings.Contains(al[0].Text, "vanadium") {
+		t.Fatalf("reasoning not recalled: %+v", al)
+	}
+}
+
+func TestContext_RoundTripAndNil(t *testing.T) {
+	if FromContext(context.Background()) != nil {
+		t.Fatal("FromContext on a bare ctx should be nil")
+	}
+	// A nil index leaves ctx unchanged.
+	if got := NewContext(context.Background(), nil); FromContext(got) != nil {
+		t.Fatal("NewContext(nil) should not stamp an index")
+	}
+	ix := NewIndex(bagEmbedder{dim: 8}, 0)
+	ctx := NewContext(context.Background(), ix)
+	if FromContext(ctx) != ix {
+		t.Fatal("FromContext did not round-trip the index")
+	}
+}

--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -1729,6 +1729,52 @@ func (m *Memory) execRecall(ctx context.Context, scope store.MemoryScope, scopeI
 	return okJSON(out)
 }
 
+// RecallFallback is the persistent-memory leg of the Recall tool's silent
+// fallback: a free-text recall over the agent's durable memory, so a single
+// Recall(query) transparently searches both the run-scoped index of evicted spans
+// and the facts the agent has actually learned. It searches the agent's permitted
+// scopes in the order user → agent → tenant (user first because that is where the
+// consolidator's cross-run facts and compaction-banked spans land), deduplicates
+// by (scope, text), and returns the union — the caller sorts and trims.
+//
+// It NEVER surfaces an error: the fallback must only ADD hits when it can. A
+// missing store/embedder, an agent with no memory_scopes, or a per-scope failure
+// all yield fewer (or zero) hits, never a failed Recall. A blank query or topK<=0
+// returns nil / uses a small default.
+func (m *Memory) RecallFallback(ctx context.Context, query string, topK int) []memrank.RecallFact {
+	if m == nil || strings.TrimSpace(query) == "" {
+		return nil
+	}
+	layer, ok := m.memoryLayer(ctx)
+	if !ok {
+		return nil
+	}
+	if topK <= 0 {
+		topK = 3
+	}
+	seen := map[string]bool{}
+	var out []memrank.RecallFact
+	for _, scope := range []string{"user", "agent", "tenant"} {
+		s, sid, err := m.resolveScope(ctx, scope)
+		if err != nil {
+			continue // scope not permitted / not resolvable on this run — skip silently
+		}
+		res, err := layer.Recall(ctx, s, sid, memrank.RecallQuery{Query: query, TopK: topK})
+		if err != nil {
+			continue
+		}
+		for _, f := range res.Facts {
+			key := string(s) + "|" + f.Memory
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
 // --- RFC BL P2 consolidation control ops ---
 //
 // Every op below is gated by BOTH resolveScope (the memory_scopes ACL, already

--- a/internal/tools/builtin/recall.go
+++ b/internal/tools/builtin/recall.go
@@ -1,0 +1,116 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/recall"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// Recall is the read side of recall-augmented distillation: a free-text query
+// over the conversation spans this run's context distillation evicted (the
+// run-scoped index the loop harvested), with a silent fallback to the agent's
+// durable memory. ONE tool searches both, so the model need not know where a fact
+// lives — it just asks for what it needs.
+//
+// The design choice that makes it work is free text, not identifiers: models
+// barely reproduce fixed ids or exact prior wording but query fluently in plain
+// language, which also makes the tool far more likely to actually be invoked. The
+// query is embedded and matched against the (per-message) evicted spans + the
+// agent's memory facts; the top few originals come back verbatim.
+type Recall struct {
+	// Memory backs the silent persistent-memory fallback. When nil, Recall
+	// searches only the run-scoped index (still useful — recall of this run's own
+	// evicted spans). When the run has no index either (recall disabled), the tool
+	// degrades to a durable-memory free-text search.
+	Memory *Memory
+}
+
+func (r *Recall) Name() string { return "Recall" }
+
+func (r *Recall) Description() string {
+	return strings.TrimSpace(`
+Fetch details from earlier in this conversation that have since been summarized away.
+
+As a conversation grows, older turns are distilled into a short summary and their
+specifics — exact values, names, numbers, IDs, file paths, quoted lines — are dropped
+from what you can currently see. Recall searches the ORIGINAL turns by meaning and
+returns the most relevant ones verbatim.
+
+Use it whenever you are about to state or rely on a specific detail from earlier that
+you are not certain is still in front of you. Ask in plain language for what you need
+(for example "the deployment token the user gave" or "the revenue figure from the Q2
+report") — you do not need to remember the exact wording. It also transparently
+searches your durable memory, so a fact learned in an earlier session may surface too.
+Prefer recalling a specific value over guessing it.`)
+}
+
+// UsageHint surfaces via Context op=guide for the agent's highest-error tools.
+func (r *Recall) UsageHint() string {
+	return "Unsure of an exact value, name, or number from earlier in the conversation? Recall it in plain language instead of guessing."
+}
+
+func (r *Recall) InputSchema() json.RawMessage {
+	return json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "query": {"type": "string", "description": "Plain-language description of the detail you need from earlier in the conversation."},
+    "top_k": {"type": "integer", "description": "How many original spans to return (default 3, max 10)."}
+  },
+  "required": ["query"],
+  "additionalProperties": false
+}`)
+}
+
+type recallInput struct {
+	Query string `json:"query"`
+	TopK  int    `json:"top_k,omitempty"`
+}
+
+func (r *Recall) Execute(ctx context.Context, input json.RawMessage) (tools.Result, error) {
+	var in recallInput
+	if err := json.Unmarshal(input, &in); err != nil {
+		return errResult("Recall: invalid input: " + err.Error()), nil
+	}
+	if strings.TrimSpace(in.Query) == "" {
+		return errResult("Recall: missing required field: query"), nil
+	}
+	k := in.TopK
+	if k <= 0 {
+		k = recall.DefaultTopK
+	}
+	if k > recall.MaxTopK {
+		k = recall.MaxTopK
+	}
+
+	var hits []recall.Hit
+	// Run-scoped index leg: this run's own evicted spans (nil when recall is off
+	// for the run or no embedder is configured — Search returns nothing).
+	if ix := recall.FromContext(ctx); ix != nil {
+		if found, err := ix.Search(ctx, in.Query, k); err == nil {
+			hits = append(hits, found...)
+		}
+	}
+	// Silent persistent-memory fallback: the agent's durable facts. Never errors.
+	if r.Memory != nil {
+		for _, f := range r.Memory.RecallFallback(ctx, in.Query, k) {
+			hits = append(hits, recall.Hit{Text: f.Memory, Score: f.Score, Source: "memory"})
+		}
+	}
+	if len(hits) == 0 {
+		return tools.Result{Text: "No earlier details matched that query."}, nil
+	}
+	sort.SliceStable(hits, func(i, j int) bool { return hits[i].Score > hits[j].Score })
+	if len(hits) > k {
+		hits = hits[:k]
+	}
+
+	recalled := make([]map[string]any, 0, len(hits))
+	for _, h := range hits {
+		recalled = append(recalled, map[string]any{"text": h.Text, "score": h.Score, "source": h.Source})
+	}
+	return okJSON(map[string]any{"recalled": recalled})
+}

--- a/internal/tools/builtin/recall_test.go
+++ b/internal/tools/builtin/recall_test.go
@@ -1,0 +1,106 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"hash/fnv"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/recall"
+)
+
+type recallBagEmbedder struct{ dim int }
+
+func (e recallBagEmbedder) Embed(_ context.Context, texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i, t := range texts {
+		v := make([]float32, e.dim)
+		for _, tok := range strings.Fields(strings.ToLower(t)) {
+			h := fnv.New32a()
+			_, _ = h.Write([]byte(tok))
+			v[h.Sum32()%uint32(e.dim)]++
+		}
+		out[i] = v
+	}
+	return out, nil
+}
+
+func (e recallBagEmbedder) Model() string    { return "bag" }
+func (e recallBagEmbedder) Provider() string { return "test" }
+func (e recallBagEmbedder) Dimension() int   { return e.dim }
+
+func TestRecall_SearchesRunIndex(t *testing.T) {
+	ix := recall.NewIndex(recallBagEmbedder{dim: 256}, 0)
+	ix.Harvest(context.Background(), []providers.Message{
+		{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "the license key is maple-7731 do not lose it"}}},
+		{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "the weather was nice all afternoon"}}},
+	})
+	ctx := recall.NewContext(context.Background(), ix)
+
+	tool := &Recall{} // no Memory — run-index only
+	res, err := tool.Execute(ctx, json.RawMessage(`{"query":"what is the license key"}`))
+	if err != nil || res.IsError {
+		t.Fatalf("Execute: err=%v res=%+v", err, res)
+	}
+	if !strings.Contains(res.Text, "maple-7731") {
+		t.Fatalf("recalled text missing the needle: %s", res.Text)
+	}
+	if !strings.Contains(res.Text, `"source":"run"`) {
+		t.Fatalf("run-index hit not tagged source=run: %s", res.Text)
+	}
+}
+
+func TestRecall_TopKClampAndDefault(t *testing.T) {
+	ix := recall.NewIndex(recallBagEmbedder{dim: 128}, 0)
+	for _, s := range []string{"alpha term", "beta term", "gamma term", "delta term", "epsilon term"} {
+		ix.Harvest(context.Background(), []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: s}}}})
+	}
+	ctx := recall.NewContext(context.Background(), ix)
+	tool := &Recall{}
+
+	// Default top_k = 3.
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"query":"term"}`))
+	var got map[string][]map[string]any
+	if err := json.Unmarshal([]byte(res.Text), &got); err != nil {
+		t.Fatalf("unmarshal: %v (%s)", err, res.Text)
+	}
+	if n := len(got["recalled"]); n != 3 {
+		t.Fatalf("default returned %d hits, want 3", n)
+	}
+}
+
+func TestRecall_EmptyWhenNothingAvailable(t *testing.T) {
+	// No run index on ctx and no Memory backing: a clean, non-error "nothing".
+	tool := &Recall{}
+	res, err := tool.Execute(context.Background(), json.RawMessage(`{"query":"anything"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("empty recall should not be an error: %+v", res)
+	}
+	if !strings.Contains(res.Text, "No earlier details") {
+		t.Fatalf("unexpected empty-recall text: %s", res.Text)
+	}
+}
+
+func TestRecall_MissingQuery(t *testing.T) {
+	tool := &Recall{}
+	res, err := tool.Execute(context.Background(), json.RawMessage(`{"query":"  "}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("a blank query should be a tool error")
+	}
+}
+
+func TestRecall_InvalidInput(t *testing.T) {
+	tool := &Recall{}
+	res, _ := tool.Execute(context.Background(), json.RawMessage(`{not json`))
+	if !res.IsError {
+		t.Fatal("invalid JSON input should be a tool error")
+	}
+}


### PR DESCRIPTION
## Why

Every context-retention mode is **lossy**: compaction summarizes the span it drops, recap keeps only a running note, stateful feeds only the state + the latest observation. That is the point — it keeps a long run affordable — but a specific value mentioned early (a token, a file path, a number, a decision) can be gone from what the model sees by the time it needs it, and regrowing the fed context is the thing these modes exist to avoid.

A throwaway needle-recall probe (against real Ollama embeddings, 5 seeds × two models incl. a deliberately weak one) settled the design decisively: with a free-text recall tool over the evicted spans, a needle buried past a distillation boundary is recovered **1.00** vs **0.00** without it — and even the weak model **invokes** the tool unprompted (the failure mode that sank id-based recall). Two follow-on probes fixed the details this PR bakes in: index the **raw span / specific fact**, not a model recap of it (raw 0.80 vs recap 0.40–0.60 retrieval-hit), and at **per-message** granularity (a coarse block dilutes the needle).

## What

Adds an opt-in `context.recall` that makes distillation *net-additive* — it shrinks the fed context while **growing a searchable index of what it dropped**:

- **`context.recall` config gate** — per-agent + per-run bool, off by default, threaded through the same content-identifying plumbing as the rest of the `context` block (Merge/Clone/IsZero + the agents-package hash mirror + collapse).
- **`internal/recall`** — a run-scoped, in-memory, embedding-keyed index. `Harvest` embeds each evicted message (per-message); `Search` answers a free-text query by cosine topK. Run-scoped on purpose: indexing every evicted turn in the persistent store would pollute durable memory and add store writes on the distillation hot path. Harvest is never fatal; a nil embedder makes it a clean no-op.
- **Loop harvest hooks** — compaction, recap (recap *and* drop), and stateful each harvest the span they evict. Stamped on ctx before the stateful branch; the resume path is deliberately unwired (a resumed run replays past distillations without harvesting, so it never double-indexes).
- **`Recall` builtin** — one free-text `Recall(query)` tool searching the run index **and** the agent's durable memory (silent fallback via `Memory.RecallFallback`), so the model needn't know where a fact lives. Free text, not identifiers, because models query fluently in plain language but barely reproduce ids — which also makes the tool far likelier to be invoked. The description carries the weak-model nudge (recall a value rather than guess it).
- Server wiring at both fresh-run builders (`RunOnce`, which every non-HTTP trigger routes through, and HTTP `handleRuns`); the index is built only when recall is set **and** an embedder is configured.

This is P1 of the recall-augmented-distillation line (the RFC lives in the doc store). Persistent-memory *harvest* on the write side and inline fact-markers are later phases; this ships the validated read/write core.

## What was tested

- `go test ./...` — clean across 109 packages.
- `internal/recall`: harvest→search recovers a needle, nil-embedder no-op, FIFO cap eviction, embed-failure swallowed on harvest / surfaced on query, tool_result + reasoning indexed, ctx round-trip.
- `internal/loop`: `TestMaybeAutoCompact_HarvestsEvictedSpanToRecallIndex`, `TestMaybeRecap_HarvestsEvictedSpan` (drop mode — pure eviction), `TestMaybeAutoCompact_NilRecallIndexNoOp`.
- `internal/tools/builtin`: run-index search, top_k default/clamp, empty/no-backing, blank-query + invalid-input errors.
- Drift guards extended: the reflective Clone/Merge/IsZero cover-every-field test (a `*bool` case) and a substrate read-path regression that `context.recall` is content-identifying while an empty context still collapses to the bare hash.
- Manual: `bin/loomcycle validate` on a config with `context.recall: true` → OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD
