### PR TITLE
feat(webui): the Memory console honours the tenant focus

### DIFF
--- a/packages/memory-view/package-lock.json
+++ b/packages/memory-view/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@loomcycle/memory-view",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@loomcycle/memory-view",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@loomcycle/client": "^1.55.0",
+        "@loomcycle/client": "^1.72.0",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -21,7 +21,7 @@
         "vitest": "^3.0.0"
       },
       "peerDependencies": {
-        "@loomcycle/client": "^1.55.0",
+        "@loomcycle/client": "^1.72.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
       }
@@ -751,9 +751,9 @@
       }
     },
     "node_modules/@loomcycle/client": {
-      "version": "1.55.0",
-      "resolved": "https://registry.npmjs.org/@loomcycle/client/-/client-1.55.0.tgz",
-      "integrity": "sha512-v94B4WwdsnpuzuPHn6SUriMMGTcAfsyDMbRN63laZpuoUWi6ag/MUo3iD9hwGAxSzCFqBeTFE+DnTr/meRGFTQ==",
+      "version": "1.72.0",
+      "resolved": "https://registry.npmjs.org/@loomcycle/client/-/client-1.72.0.tgz",
+      "integrity": "sha512-r4euiOZqvzqGglIkHeE8L2EOExm1nYniMrWXcq6atp5OGVikEAI2NS1RjBe4VlCKqqa/Dc7F2x1ieyiiWk3dJw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {

--- a/packages/memory-view/package.json
+++ b/packages/memory-view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loomcycle/memory-view",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "description": "Embeddable React memory browser for the loomcycle agentic runtime (RFC BV) \u2014 a themeable, standalone k/v Vector Memory console (with a fact viewer + unified semantic search).",
   "license": "Apache-2.0",
@@ -48,12 +48,12 @@
     "test:watch": "vitest"
   },
   "peerDependencies": {
-    "@loomcycle/client": "^1.55.0",
+    "@loomcycle/client": "^1.72.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
-    "@loomcycle/client": "^1.55.0",
+    "@loomcycle/client": "^1.72.0",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/packages/memory-view/src/components/MemoryViewRoot.tsx
+++ b/packages/memory-view/src/components/MemoryViewRoot.tsx
@@ -6,6 +6,7 @@ import {
   dataLayerFromClient,
   dataLayerFromConnection,
   type MemoryDataLayer,
+  type MemoryBrowseOptions,
 } from "../lib/dataLayer";
 
 // MemoryDataSource is the data-source contract for the public <MemoryView> root.
@@ -18,6 +19,10 @@ export interface MemoryDataSource {
   client?: LoomcycleClient;
   /** A fully custom data layer (e.g. a cookie-authed same-origin fetcher). */
   dataLayer?: MemoryDataLayer;
+  /** Which workspace to browse — today, a super-admin's tenant focus. Applies to
+   *  the `connection` and `client` paths; a host supplying its own `dataLayer`
+   *  has already decided, so it is ignored there. */
+  browse?: MemoryBrowseOptions;
 }
 
 // useResolvedDataLayer picks the data layer from the source props once per
@@ -25,16 +30,23 @@ export interface MemoryDataSource {
 // object) keeps an inline `connection={{...}}` from rebuilding the client every
 // render.
 export function useResolvedDataLayer(src: MemoryDataSource): MemoryDataLayer | null {
-  const { dataLayer, client, connection } = src;
+  const { dataLayer, client, connection, browse } = src;
+  // Depend on the tenant PRIMITIVE, not the browse object, so an inline
+  // browse={{...}} does not rebuild the layer every render — the same reason the
+  // connection is destructured field-by-field below. Rebuilding on a REAL change
+  // is the point: the layer captures the tenant, so switching must produce a new one.
+  const tenant = browse?.tenant;
   return useMemo<MemoryDataLayer | null>(() => {
     if (dataLayer) return dataLayer;
-    if (client) return dataLayerFromClient(client);
+    if (client) return dataLayerFromClient(client, { tenant });
     // The connection path gets the change-feed tail too — it is the only path
     // holding the base URL + fetch that SSE needs (see dataLayerFromConnection).
-    if (connection) return dataLayerFromConnection(connection, createLoomcycleClient(connection));
+    if (connection) {
+      return dataLayerFromConnection(connection, createLoomcycleClient(connection), { tenant });
+    }
     return null;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dataLayer, client, connection?.baseUrl, connection?.token, connection?.fetch]);
+  }, [dataLayer, client, connection?.baseUrl, connection?.token, connection?.fetch, tenant]);
 }
 
 // MemoryViewRoot renders the themeable `.loomcycle-memory-view` wrapper + provides

--- a/packages/memory-view/src/index.ts
+++ b/packages/memory-view/src/index.ts
@@ -85,3 +85,4 @@ export type { MemoryDataLayer, FactListOptions } from "./lib/dataLayer";
 // The shared data-source contract (connection | client | dataLayer), for hosts
 // typing their own wrappers.
 export type { MemoryDataSource } from "./components/MemoryViewRoot";
+export type { MemoryBrowseOptions } from "./lib/dataLayer";

--- a/packages/memory-view/src/lib/dataLayer.test.ts
+++ b/packages/memory-view/src/lib/dataLayer.test.ts
@@ -91,7 +91,10 @@ describe("dataLayerFromClient — @loomcycle/client → memory wire mapping", ()
   it("listScopeIDs passes the scope", async () => {
     const s = stubClient();
     await dataLayerFromClient(s.client).listScopeIDs("user");
-    expect(s.listMemoryScopeIDs).toHaveBeenCalledWith("user");
+    // The focus object is forwarded on every browse method now; with no tenant
+    // set its field is undefined, which the client drops, so the request is
+    // byte-identical to before it existed.
+    expect(s.listMemoryScopeIDs).toHaveBeenCalledWith("user", { tenant: undefined });
   });
 
   it("listEntries passes scope + scope_id + the prefix/limit opts", async () => {
@@ -103,32 +106,78 @@ describe("dataLayerFromClient — @loomcycle/client → memory wire mapping", ()
     expect(s.listMemoryEntries).toHaveBeenCalledWith("user", "alice", {
       prefix: "policy",
       limit: 200,
+      tenant: undefined,
     });
   });
 
-  it("listEntries forwards an omitted opts as undefined (client applies defaults)", async () => {
+  it("listEntries forwards an omitted opts as the focus alone (client applies defaults)", async () => {
     const s = stubClient();
     await dataLayerFromClient(s.client).listEntries("user", "alice");
-    expect(s.listMemoryEntries).toHaveBeenCalledWith("user", "alice", undefined);
+    expect(s.listMemoryEntries).toHaveBeenCalledWith("user", "alice", { tenant: undefined });
+  });
+
+  it("binds a tenant focus onto every browse method", async () => {
+    // The focus is a property of the CONSOLE SESSION — which tenant's workspace
+    // the operator is looking at — so it binds when the layer is built rather
+    // than travelling through twenty call sites that never vary it.
+    const s = stubClient();
+    const dl = dataLayerFromClient(s.client, { tenant: "acme" });
+    await dl.listScopeIDs("user");
+    await dl.listEntries("user", "alice");
+    await dl.getEntry("user", "alice", "tone");
+    await dl.setEntry("user", "alice", "tone", { value: "warm" });
+    await dl.deleteEntry("user", "alice", "tone");
+    expect(s.listMemoryScopeIDs).toHaveBeenCalledWith("user", { tenant: "acme" });
+    expect(s.listMemoryEntries).toHaveBeenCalledWith("user", "alice", { tenant: "acme" });
+    expect(s.getMemoryEntry).toHaveBeenCalledWith("user", "alice", "tone", { tenant: "acme" });
+    expect(s.setMemoryEntry).toHaveBeenCalledWith("user", "alice", "tone", {
+      value: "warm",
+      tenant: "acme",
+    });
+    expect(s.deleteMemoryEntry).toHaveBeenCalledWith("user", "alice", "tone", { tenant: "acme" });
+  });
+
+  it("never sends a focus on listScopes", async () => {
+    // That route answers "what KINDS of scope exist" — a constant set, not any
+    // tenant's data. Sending a tenant would imply the answer varies by tenant.
+    const s = stubClient();
+    await dataLayerFromClient(s.client, { tenant: "acme" }).listScopes();
+    expect(s.listMemoryScopes).toHaveBeenCalledWith();
+  });
+
+  it("treats a blank focus as no focus", async () => {
+    // The topbar switcher is empty until an admin types a tenant, and empty there
+    // means "my own", not a tenant named "". Normalising here also stops the
+    // layer being rebuilt on every keystroke through useResolvedDataLayer's memo.
+    const s = stubClient();
+    await dataLayerFromClient(s.client, { tenant: "   " }).listScopeIDs("user");
+    expect(s.listMemoryScopeIDs).toHaveBeenCalledWith("user", { tenant: undefined });
   });
 
   it("getEntry passes scope + scope_id + key", async () => {
     const s = stubClient();
     await dataLayerFromClient(s.client).getEntry("agent", "researcher", "note");
-    expect(s.getMemoryEntry).toHaveBeenCalledWith("agent", "researcher", "note");
+    expect(s.getMemoryEntry).toHaveBeenCalledWith("agent", "researcher", "note", {
+      tenant: undefined,
+    });
   });
 
   it("setEntry passes the identifier tuple + the SetMemoryEntryOptions", async () => {
     const s = stubClient();
     const input = { value: { a: 1 }, embed: true, ttl_seconds: 3600 };
     await dataLayerFromClient(s.client).setEntry("user", "alice", "company-policy", input);
-    expect(s.setMemoryEntry).toHaveBeenCalledWith("user", "alice", "company-policy", input);
+    expect(s.setMemoryEntry).toHaveBeenCalledWith("user", "alice", "company-policy", {
+      ...input,
+      tenant: undefined,
+    });
   });
 
   it("deleteEntry passes scope + scope_id + key", async () => {
     const s = stubClient();
     await dataLayerFromClient(s.client).deleteEntry("user", "alice", "stale");
-    expect(s.deleteMemoryEntry).toHaveBeenCalledWith("user", "alice", "stale");
+    expect(s.deleteMemoryEntry).toHaveBeenCalledWith("user", "alice", "stale", {
+      tenant: undefined,
+    });
   });
 
   it("embedStats passes the scope", async () => {

--- a/packages/memory-view/src/lib/dataLayer.tsx
+++ b/packages/memory-view/src/lib/dataLayer.tsx
@@ -76,6 +76,15 @@ export interface FactListOptions {
 // RFC AS browse-by-subject reach — a data-plane selector, never an authority
 // grant (the runtime re-authorizes the principal). search itself takes no
 // override: /v1/_memory/search resolves the caller's own subject.
+// MemoryBrowseOptions narrows WHICH workspace the console reads, as distinct from
+// what it reads. Today that is the tenant focus: a super-admin console can point
+// at one tenant, and the server ignores the value for any caller that cannot
+// widen its own scope, so passing it is safe from every principal.
+export interface MemoryBrowseOptions {
+  /** Super-admin tenant focus. Omitted or blank → the caller's own tenant. */
+  tenant?: string;
+}
+
 export interface MemoryDataLayer {
   // The kinds of scopes the server declares (agent, user, or operator yaml).
   listScopes(): Promise<MemoryScopesResponse>;
@@ -211,17 +220,31 @@ export interface MemoryDataLayer {
 // client owns URL construction + auth transport. `listEntries`'s response is the
 // client's (which omits embedding_metadata) — structurally assignable to the
 // package's wider shape, so no cast is needed.
-export function dataLayerFromClient(client: LoomcycleClient): MemoryDataLayer {
+//
+// BROWSE OPTIONS BIND AT CONSTRUCTION, not per call. A tenant focus is a property
+// of the console session — which tenant's workspace the operator is looking at —
+// so threading it through every method signature would put the same never-varying
+// value in twenty call sites inside the console. `listScopes` deliberately does
+// NOT take it: that route returns the constant set of scope KINDS, not any
+// tenant's data.
+export function dataLayerFromClient(
+  client: LoomcycleClient,
+  browse?: MemoryBrowseOptions,
+): MemoryDataLayer {
+  // Normalise once. An empty switcher means "my own tenant", not a tenant named
+  // "" — the client drops a blank focus too, but a layer that captured "" would
+  // still rebuild itself on every keystroke through the memo in MemoryViewRoot.
+  const tenant = browse?.tenant?.trim() || undefined;
   return {
     listScopes: () => client.listMemoryScopes(),
-    listScopeIDs: (scope) => client.listMemoryScopeIDs(scope),
+    listScopeIDs: (scope) => client.listMemoryScopeIDs(scope, { tenant }),
     listEntries: (scope, scopeId, opts) =>
-      client.listMemoryEntries(scope, scopeId, opts),
-    getEntry: (scope, scopeId, key) => client.getMemoryEntry(scope, scopeId, key),
+      client.listMemoryEntries(scope, scopeId, { ...opts, tenant }),
+    getEntry: (scope, scopeId, key) => client.getMemoryEntry(scope, scopeId, key, { tenant }),
     setEntry: (scope, scopeId, key, input) =>
-      client.setMemoryEntry(scope, scopeId, key, input),
+      client.setMemoryEntry(scope, scopeId, key, { ...input, tenant }),
     deleteEntry: (scope, scopeId, key) =>
-      client.deleteMemoryEntry(scope, scopeId, key),
+      client.deleteMemoryEntry(scope, scopeId, key, { tenant }),
     embedStats: (scope) => client.memoryEmbedStats(scope),
     reembed: (scope, scopeId, opts) => client.reembedMemory(scope, scopeId, opts),
     backfillEmbeddings: (scope, scopeId, opts) => client.backfillEmbeddings(scope, scopeId, opts),
@@ -362,9 +385,10 @@ export function useMemoryData(): MemoryDataLayer {
 export function dataLayerFromConnection(
   conn: ChangeFeedConnection,
   client: LoomcycleClient,
+  browse?: MemoryBrowseOptions,
 ): MemoryDataLayer {
   return {
-    ...dataLayerFromClient(client),
+    ...dataLayerFromClient(client, browse),
     streamChanges: (family, opts) => tailChanges(conn, family, opts),
   };
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,7 +11,7 @@
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
         "@fontsource-variable/outfit": "^5.2.8",
-        "@loomcycle/client": "^1.56.0",
+        "@loomcycle/client": "^1.72.0",
         "js-yaml": "^4.2.0",
         "lucide-react": "^0.460.0",
         "mermaid": "^11.16.0",
@@ -876,9 +876,9 @@
       }
     },
     "node_modules/@loomcycle/client": {
-      "version": "1.56.0",
-      "resolved": "https://registry.npmjs.org/@loomcycle/client/-/client-1.56.0.tgz",
-      "integrity": "sha512-HR8jLmWyjzQwOkqYAKe8uec3bJ07O8pbSKUEKOFaZDRY+vFw1ZO6ba6wciFUlheut792tLYSU6q+Fq1yqHFf0Q==",
+      "version": "1.72.0",
+      "resolved": "https://registry.npmjs.org/@loomcycle/client/-/client-1.72.0.tgz",
+      "integrity": "sha512-r4euiOZqvzqGglIkHeE8L2EOExm1nYniMrWXcq6atp5OGVikEAI2NS1RjBe4VlCKqqa/Dc7F2x1ieyiiWk3dJw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"

--- a/web/package.json
+++ b/web/package.json
@@ -3,7 +3,7 @@
   "version": "0.9.0",
   "private": true,
   "type": "module",
-  "description": "Loomcycle web UI — read-only monitoring view: running agents tree, errors, per-agent transcript log.",
+  "description": "Loomcycle web UI \u2014 read-only monitoring view: running agents tree, errors, per-agent transcript log.",
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
@@ -15,7 +15,7 @@
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@fontsource-variable/outfit": "^5.2.8",
-    "@loomcycle/client": "^1.56.0",
+    "@loomcycle/client": "^1.72.0",
     "js-yaml": "^4.2.0",
     "lucide-react": "^0.460.0",
     "mermaid": "^11.16.0",

--- a/web/src/pages/MemoryView.tsx
+++ b/web/src/pages/MemoryView.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import { MemoryView } from "@loomcycle/memory-view";
+import { useFocusTenant } from "../components/Layout";
 import { consolidationRunHref } from "../lib/ontologyEditHref";
 import "@loomcycle/memory-view/styles.css";
 
@@ -27,9 +28,16 @@ const cookieFetch: typeof fetch = async (input, init) => {
 
 export default function MemoryViewPage() {
   const navigate = useNavigate();
+  // The topbar tenant focus, which every OTHER browse surface (Documents, Paths,
+  // Agents, Users) already consumes and this one did not. Without it a
+  // super-admin console could only ever read its own tenant's memory — usually
+  // the empty one — while that tenant's own operator saw its rows, so admin
+  // looked strictly less capable than the role it supersedes. Blank = own tenant.
+  const focusTenant = useFocusTenant();
   return (
     <MemoryView
       connection={{ baseUrl: "", fetch: cookieFetch }}
+      browse={{ tenant: focusTenant || undefined }}
       // Starting a consolidation pass is the HOST's business: the package cannot know
       // about /run, and an embedder does not have it. This stages the agent and prompt
       // in the terminal rather than starting anything — a click that spends tokens with


### PR DESCRIPTION
## Why

Completes the admin-focus fix. #1127 made the server accept `?tenant=` on the memory browse routes and #1128 gave `@loomcycle/client` the option — both shipped in **v1.72.0**, and the client is now on npm at 1.72.0. This is the last hop: the console asking for it.

Until now a super-admin's Memory page could only read its **own** tenant's memory — usually the empty one — while that tenant's operator saw its rows. Admin looked strictly less capable than the role it supersedes.

Every *other* browse surface — Documents, Paths, Agents, Users — already consumed `useFocusTenant()`. Memory is the one that never did.

## The focus binds at construction, not per call

Which tenant's workspace an operator is looking at is a property of the **console session**. Threading it through `MemoryDataLayer`'s signatures would have put the same never-varying value into twenty call sites and changed a 21-method interface to carry it. A `browse` option on `MemoryDataSource`, captured by `dataLayerFromClient`, reaches every method without any of them knowing about it:

```
web/MemoryView.tsx    browse={{ tenant: useFocusTenant() || undefined }}
  -> MemoryDataSource.browse
  -> dataLayerFromClient(client, { tenant })   // captured here
  -> client.listMemoryEntries(..., { tenant }) // every method, transparently
```

`useResolvedDataLayer` depends on the tenant **primitive** rather than the `browse` object, so an inline `browse={{...}}` doesn't rebuild the layer every render — the same reason the connection is destructured field by field there. Rebuilding on a *real* change is the point, since the layer captures the tenant.

Two deliberate exclusions:

- **`listScopes` never carries it.** That route answers "what *kinds* of scope exist" — a constant set. Sending a tenant would imply the answer varies by tenant.
- **A blank focus is normalised away.** The switcher is empty until an admin types a tenant, and empty means "my own", not a tenant named `""`. The client drops a blank too, but normalising here also stops the layer rebuilding on every keystroke.

## Versions

`@loomcycle/memory-view` **0.4.0 → 0.5.0**, with its client peer + dev dependency at **^1.72.0** — the version that introduced the option, so a consumer resolving an older client gets a dependency error rather than a console that silently sends nothing. `web`'s dependency likewise.

That package publishes on its own `memory-view-v*` tag, so 0.5.0 reaches npm only when tagged. The embedded Web UI consumes it from **source**, so the wiring ships in the binary regardless.

## What was tested

Three new cases in `dataLayer.test.ts`, verified to **fail with the binding removed**: a focus reaches all five browse methods, `listScopes` never carries one, a blank focus is dropped.

The existing delegation assertions now expect the forwarded focus object. With no tenant set its field is `undefined`, which the client drops — so the request is byte-identical to before this existed.

`go test ./...` clean (98 packages); memory-view typecheck + **71 tests**; `make build-ui` builds. (The `css-syntax-error` warning in that build is pre-existing — a parenthesis inside a CSS comment during minify; this branch changes no CSS.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8