### PR TITLE
feat: persistent-memory harvest across distillation modes (RFC CT P2)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -721,6 +721,29 @@ Notes:
 - **Off is byte-identical.** `recall` unset/false changes nothing; a resumed run does not re-index (it replays its past distillations).
 - Available per-agent and as a per-run `context.recall` override on the same surfaces as the rest of the block.
 
+#### `harvest_to_memory` — keep an evicted span's facts across runs
+
+`recall` (above) keeps an evicted span reachable *within the run*. `harvest_to_memory` is its cross-run sibling: as any distillation mode evicts a span, that span is **banked for the memory consolidator**, which extracts its durable facts into the agent's long-term memory — so a fact the agent learned mid-run survives into future runs:
+
+```yaml
+agents:
+  long-runner:
+    memory_scopes: [user]     # required — consolidation drains user scopes
+    context:
+      mode: recap
+      harvest_to_memory: true # off by default
+```
+
+It **generalizes `compaction.memory_flush`** (which banks only on L0 compaction) to every distillation mode — `recap` and `stateful` evict spans that `memory_flush` never saw, and a long-lived session that never terminates is one the background consolidator's session scan would otherwise skip entirely; banking its evicted spans gets them consolidated regardless.
+
+Why banking (deferred) rather than extracting inline at each boundary: a measurement (the fact-harvest-quality probe) showed that extracting facts from each distillation span *in isolation* loses the coreference-dependent ones — a fact whose subject was named two spans earlier ("my project *Streaky*" … later "*it* hit 500 users") can't be named from the later span alone, so a per-span extractor drops it while the consolidator's whole-transcript extraction keeps it. Banking hands the consolidator that broader context, so no facts are lost to fragmentation, and it adds no model call to the run's own hot path.
+
+Notes:
+- **Needs `user` in `memory_scopes` and a `user_id` on the run** — same prerequisite as `memory_flush` (the consolidator only drains user scopes). A misconfigured agent surfaces a non-fatal error rather than silently never harvesting.
+- **Deferred, not immediate.** Facts appear after the consolidator's next pass, not mid-run — which is what cross-run harvest wants (within-run immediacy is `recall`'s job).
+- **Off is byte-identical**; a resumed run does not re-bank (it replays its past distillations).
+- Available per-agent and as a per-run `context.harvest_to_memory` override.
+
 ### Interactive local agents
 
 For a terminal you steer turn-by-turn:

--- a/internal/agents/loader.go
+++ b/internal/agents/loader.go
@@ -210,6 +210,7 @@ type Context struct {
 	OnInvalidPatch  *string        `json:"on_invalid_patch,omitempty"`
 	MaxPatchRetries *int           `json:"max_patch_retries,omitempty"`
 	Recall          *bool          `json:"recall,omitempty"`
+	HarvestToMemory *bool          `json:"harvest_to_memory,omitempty"`
 }
 
 // CoreBlock mirrors config.CoreBlock locally so the agents package stays

--- a/internal/agents/sign.go
+++ b/internal/agents/sign.go
@@ -348,7 +348,7 @@ func normalize(c *AgentContent) {
 		c.Context.Reasoning == nil && c.Context.RecapMaxChars == nil &&
 		c.Context.AutoRecapAtPct == nil && len(c.Context.StateSchema) == 0 &&
 		c.Context.OnInvalidPatch == nil && c.Context.MaxPatchRetries == nil &&
-		c.Context.Recall == nil {
+		c.Context.Recall == nil && c.Context.HarvestToMemory == nil {
 		c.Context = nil
 	}
 

--- a/internal/agents/sign_test.go
+++ b/internal/agents/sign_test.go
@@ -433,6 +433,25 @@ func TestFromOverlay_ContextRecallIsContentIdentifying(t *testing.T) {
 	}
 }
 
+func TestFromOverlay_ContextHarvestToMemoryIsContentIdentifying(t *testing.T) {
+	// RFC CT P2: context.harvest_to_memory is content-identifying like every sibling
+	// context field — a fork that flips it mints a distinct hash — while an empty
+	// context still collapses to the bare hash.
+	bareHash := Sign(FromYAMLAgent(&Agent{Name: "x"}))
+
+	on, err := FromOverlay(json.RawMessage(`{"name":"x","context":{"harvest_to_memory":true}}`))
+	if err != nil {
+		t.Fatalf("FromOverlay(harvest_to_memory): %v", err)
+	}
+	if Sign(on) == bareHash {
+		t.Error("context.harvest_to_memory:true did not change the content hash — a fork must mint a distinct hash")
+	}
+	on2, _ := FromOverlay(json.RawMessage(`{"name":"x","context":{"harvest_to_memory":true}}`))
+	if Sign(on) != Sign(on2) {
+		t.Error("context.harvest_to_memory hash is not stable across identical reads")
+	}
+}
+
 func TestFromOverlay_ParsesValidJSON(t *testing.T) {
 	overlay := json.RawMessage(`{"name":"x","system_prompt":"hi","tools":["Read"]}`)
 	c, err := FromOverlay(overlay)

--- a/internal/api/http/bank_compaction.go
+++ b/internal/api/http/bank_compaction.go
@@ -21,23 +21,27 @@ import (
 // anything. Banked and silently forgotten is worse than not banked, so this
 // refuses instead, by name.
 //
-// The callback is installed whenever `memory_flush` is set, even when it cannot
-// bank. Returning nil for a misconfigured agent would make the misconfiguration
-// invisible; an error in the compaction marker on every pass is noisy in exactly
-// the way an operator needs.
-func (s *Server) bankCompactedSpanFn(agentDef config.AgentDef, tenantID, userID, agentName, runID, sessionID string) func(context.Context, []providers.Message) (string, error) {
-	if agentDef.Compaction == nil || agentDef.Compaction.MemoryFlush == nil || !*agentDef.Compaction.MemoryFlush {
+// The callback is installed whenever `memory_flush` OR the context block's
+// `harvest_to_memory` (RFC CT P2) is set — the latter generalizes the L0-only
+// flush to every distillation mode (recap / stateful too), banking evicted spans
+// for the same consolidator. It is installed even when it cannot bank: returning
+// nil for a misconfigured agent would make the misconfiguration invisible; an error
+// in the distillation marker on every pass is noisy in exactly the way an operator
+// needs. `harvestToMemory` is the resolved (per-run > per-agent) context flag.
+func (s *Server) bankCompactedSpanFn(agentDef config.AgentDef, harvestToMemory bool, tenantID, userID, agentName, runID, sessionID string) func(context.Context, []providers.Message) (string, error) {
+	memoryFlush := agentDef.Compaction != nil && agentDef.Compaction.MemoryFlush != nil && *agentDef.Compaction.MemoryFlush
+	if !memoryFlush && !harvestToMemory {
 		return nil
 	}
 	return func(ctx context.Context, dropped []providers.Message) (string, error) {
 		if s.store == nil {
-			return "", fmt.Errorf("memory_flush: no persistent store on this instance")
+			return "", fmt.Errorf("memory harvest: no persistent store on this instance")
 		}
 		if !containsString(agentDef.MemoryScopes, "user") {
-			return "", fmt.Errorf("memory_flush is set but agent %q has no `user` in memory_scopes; consolidation only drains user scopes, so a banked span would never be consolidated", agentName)
+			return "", fmt.Errorf("memory harvest is enabled but agent %q has no `user` in memory_scopes; consolidation only drains user scopes, so a banked span would never be consolidated", agentName)
 		}
 		if userID == "" {
-			return "", fmt.Errorf("memory_flush is set but this run carries no user_id, so there is no user scope to bank into")
+			return "", fmt.Errorf("memory harvest is enabled but this run carries no user_id, so there is no user scope to bank into")
 		}
 		msgs := memrank.ConversationFromMessages(dropped)
 		return memrank.BankSpan(ctx, s.store, memrank.BankSpanRequest{
@@ -49,8 +53,9 @@ func (s *Server) bankCompactedSpanFn(agentDef config.AgentDef, tenantID, userID,
 			Messages:  msgs,
 			// Metadata rides into the payload the consolidator reads. `source`
 			// tells a pass (and an operator reading a queue row) that these turns
-			// were rescued from a compaction rather than volunteered by an agent.
-			Metadata: map[string]string{"source": "compaction", "agent": agentName},
+			// were rescued from a context distillation rather than volunteered by an
+			// agent (covers compaction, recap, and stateful alike).
+			Metadata: map[string]string{"source": "distillation", "agent": agentName},
 		})
 	}
 }

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2584,7 +2584,8 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	// RFC CR: the resolved layered-context policy flows down the spawn tree the
 	// same way — a sub-agent inherits the parent's effective mode; its def fills
 	// gaps the parent left unset.
-	loopCtx = tools.WithContextPolicy(loopCtx, config.MergeContext(agentDef.Context, in.Context))
+	mergedContext := config.MergeContext(agentDef.Context, in.Context) // per-run > per-agent (RFC CR); resolved once
+	loopCtx = tools.WithContextPolicy(loopCtx, mergedContext)
 	// RFC AH: the run's filesystem-volume bindings. Unbound agents get an
 	// empty policy (the file tools fall back to the legacy jail Root);
 	// sub-agents inherit + narrow this via runSubAgent.
@@ -2653,13 +2654,13 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 		Interactive:         in.Interactive,
 		Sampling:            config.MergeSampling(agentDef.Sampling, in.Sampling),       // per-run wins per field
 		Compaction:          config.MergeCompaction(agentDef.Compaction, in.Compaction), // per-run wins per field
-		Context:             config.MergeContext(agentDef.Context, in.Context),          // per-run wins per field (RFC CR)
+		Context:             mergedContext,                                              // per-run wins per field (RFC CR)
 		// Recall-augmented distillation: nil unless the agent set context.recall AND
 		// an embedder is configured, so an unopted run is byte-identical (RFC CT).
-		RecallIndex: s.recallIndexForRun(config.MergeContext(agentDef.Context, in.Context)),
-		// RFC BL P3: nil unless the agent set compaction.memory_flush, so an
-		// unopted agent's compaction path is byte-identical.
-		BankCompactedSpan:      s.bankCompactedSpanFn(agentDef, rid.TenantID, effectiveUserID, in.Agent, runID, sessionID),
+		RecallIndex: s.recallIndexForRun(mergedContext),
+		// RFC BL P3 + RFC CT P2: installed when compaction.memory_flush OR
+		// context.harvest_to_memory is set, else nil (unopted path byte-identical).
+		BankCompactedSpan:      s.bankCompactedSpanFn(agentDef, config.HarvestToMemoryEnabled(mergedContext), rid.TenantID, effectiveUserID, in.Agent, runID, sessionID),
 		ContextPlugins:         s.contextPlugins, // RFC Z runtime-wide chain (code-js exempt in the loop)
 		UserTier:               in.UserTier,
 		FallbackPolicy:         fbPolicy,
@@ -4212,7 +4213,8 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		QuotaBytes:    agentDef.SqlQuotaBytes,
 	})
 	loopCtx = tools.WithCompactionPolicy(loopCtx, config.MergeCompaction(agentDef.Compaction, req.Compaction))
-	loopCtx = tools.WithContextPolicy(loopCtx, config.MergeContext(agentDef.Context, req.Context)) // RFC CR
+	mergedContext := config.MergeContext(agentDef.Context, req.Context) // per-run > per-agent (RFC CR); resolved once
+	loopCtx = tools.WithContextPolicy(loopCtx, mergedContext)           // RFC CR
 	// RFC AH: the run's filesystem-volume bindings. Unbound agents get an
 	// empty policy (the file tools fall back to the legacy jail Root);
 	// sub-agents inherit + narrow this via runSubAgent.
@@ -4275,12 +4277,13 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		Interactive:         req.Interactive,
 		Sampling:            config.MergeSampling(agentDef.Sampling, req.Sampling),       // per-run wins per field
 		Compaction:          config.MergeCompaction(agentDef.Compaction, req.Compaction), // per-run wins per field
-		Context:             config.MergeContext(agentDef.Context, req.Context),          // per-run wins per field (RFC CR)
+		Context:             mergedContext,                                               // per-run wins per field (RFC CR)
 		// Recall-augmented distillation: nil unless context.recall is set AND an
 		// embedder is configured, so an unopted run is byte-identical (RFC CT).
-		RecallIndex: s.recallIndexForRun(config.MergeContext(agentDef.Context, req.Context)),
-		// RFC BL P3: nil unless the agent set compaction.memory_flush.
-		BankCompactedSpan:      s.bankCompactedSpanFn(agentDef, rid.TenantID, req.UserID, req.Agent, runID, sessionID),
+		RecallIndex: s.recallIndexForRun(mergedContext),
+		// RFC BL P3 + RFC CT P2: installed when compaction.memory_flush OR
+		// context.harvest_to_memory is set, else nil (unopted path byte-identical).
+		BankCompactedSpan:      s.bankCompactedSpanFn(agentDef, config.HarvestToMemoryEnabled(mergedContext), rid.TenantID, req.UserID, req.Agent, runID, sessionID),
 		ContextPlugins:         s.contextPlugins, // RFC Z runtime-wide chain (code-js exempt in the loop)
 		UserTier:               req.UserTier,
 		FallbackPolicy:         fbPolicy,
@@ -6994,7 +6997,7 @@ func (s *Server) compactRunWithSource(ctx context.Context, runID, source string)
 	//
 	// Best-effort exactly like the auto path: a compact must not fail because a
 	// queue write did.
-	if bank := s.bankCompactedSpanFn(agentDef, run.TenantID, run.UserID, run.Agent, runID, run.SessionID); bank != nil {
+	if bank := s.bankCompactedSpanFn(agentDef, config.HarvestToMemoryEnabled(agentDef.Context), run.TenantID, run.UserID, run.Agent, runID, run.SessionID); bank != nil {
 		if _, berr := bank(summCtx, msgs[firstIdx:cut]); berr != nil {
 			log.Printf("compact %s: memory_flush did not bank: %v", runID, berr)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1793,6 +1793,19 @@ type Context struct {
 	// every retention mode. Content-identifying — a fork that flips it mints a
 	// distinct hash.
 	Recall *bool `json:"recall,omitempty" yaml:"recall"`
+	// HarvestToMemory opts the run into persistent-memory harvest: as the context
+	// distillation (compaction / recap / stateful) evicts a span, that span is
+	// BANKED onto the consolidation queue so the memory consolidator extracts its
+	// durable facts into the agent's long-term memory later. It generalizes the
+	// L0-only compaction.memory_flush to every distillation mode, and needs the same
+	// prerequisite — the agent must have `user` in memory_scopes and the run must
+	// carry a user_id (the consolidator drains user scopes). It is DEFERRED, not
+	// inline: banking hands raw spans to the existing consolidator rather than
+	// extracting inline — a measurement (RFC CU Probe 2) showed per-span isolated
+	// extraction loses coreference-dependent facts a span named earlier, which the
+	// consolidator's whole/batched extraction retains. Off (nil/false) = today's
+	// behavior. Content-identifying — a fork that flips it mints a distinct hash.
+	HarvestToMemory *bool `json:"harvest_to_memory,omitempty" yaml:"harvest_to_memory"`
 }
 
 // Context mode values.
@@ -1824,7 +1837,7 @@ func (c *Context) IsZero() bool {
 	return c == nil || (c.Mode == nil && c.KeepLastN == nil && c.Reasoning == nil &&
 		c.RecapMaxChars == nil && c.AutoRecapAtPct == nil &&
 		len(c.StateSchema) == 0 && c.OnInvalidPatch == nil && c.MaxPatchRetries == nil &&
-		c.Recall == nil)
+		c.Recall == nil && c.HarvestToMemory == nil)
 }
 
 // Clone deep-copies (every field is a pointer) so a merge never aliases an input.
@@ -1865,6 +1878,10 @@ func (c *Context) Clone() *Context {
 	if c.Recall != nil {
 		v := *c.Recall
 		out.Recall = &v
+	}
+	if c.HarvestToMemory != nil {
+		v := *c.HarvestToMemory
+		out.HarvestToMemory = &v
 	}
 	return out
 }
@@ -1939,7 +1956,18 @@ func MergeContext(base, over *Context) *Context {
 		v := *over.Recall
 		out.Recall = &v
 	}
+	if over.HarvestToMemory != nil {
+		v := *over.HarvestToMemory
+		out.HarvestToMemory = &v
+	}
 	return out
+}
+
+// HarvestToMemoryEnabled reports whether the resolved context policy opts into
+// persistent-memory harvest (banking evicted spans for the consolidator). nil
+// context / unset field = off, so the default distillation path is unchanged.
+func HarvestToMemoryEnabled(c *Context) bool {
+	return c != nil && c.HarvestToMemory != nil && *c.HarvestToMemory
 }
 
 // Validate checks per-field bounds. Returns a descriptive error naming the field.

--- a/internal/loop/harvest_to_memory_test.go
+++ b/internal/loop/harvest_to_memory_test.go
@@ -1,0 +1,125 @@
+package loop
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// RFC CT P2: context.harvest_to_memory extends the L0-only compaction banking to
+// the recap and stateful distillation modes, so the consolidator harvests their
+// evicted spans' durable facts too. These tests pin that the recap and stateful
+// paths bank the evicted span when opted in, do NOT when off, and never fail the
+// run when banking errors.
+
+func TestMaybeRecap_BanksToMemoryWhenOptedIn(t *testing.T) {
+	msgs := []providers.Message{userMsg("the task"), asstMsg("a1"), userMsg("q2"), asstMsg("a2"), userMsg("q3"), asstMsg("a3")}
+	var banked [][]providers.Message
+	opts := RunOptions{
+		Provider: &steerProvider{},
+		Model:    "x",
+		// drop mode: pure eviction, no recap call — the harsh case for harvest.
+		Context: &config.Context{Mode: cptr(config.ContextModeRecap), KeepLastN: cptr(2), Reasoning: cptr("drop"), HarvestToMemory: cptr(true)},
+		BankCompactedSpan: func(_ context.Context, dropped []providers.Message) (string, error) {
+			banked = append(banked, dropped)
+			return "mp_1", nil
+		},
+	}
+	_, did := maybeRecap(context.Background(), opts, msgs, 0, func(providers.Event) {}, "auto")
+	if !did {
+		t.Fatal("expected recap distillation to happen")
+	}
+	if len(banked) != 1 {
+		t.Fatalf("banked %d spans, want exactly 1 (the evicted middle)", len(banked))
+	}
+	// The evicted span is everything between the pinned first turn and the kept
+	// last-2 tail: a1, q2, a2.
+	if len(banked[0]) != 3 {
+		t.Fatalf("banked span = %d msgs, want 3 (a1, q2, a2)", len(banked[0]))
+	}
+}
+
+func TestMaybeRecap_NoBankWhenHarvestOff(t *testing.T) {
+	msgs := []providers.Message{userMsg("the task"), asstMsg("a1"), userMsg("q2"), asstMsg("a2"), userMsg("q3"), asstMsg("a3")}
+	banked := 0
+	opts := RunOptions{
+		Provider: &steerProvider{},
+		Model:    "x",
+		// harvest_to_memory OFF. Even with a callback installed (e.g. because the
+		// agent also set compaction.memory_flush, which is compaction-semantics), a
+		// recap distillation must NOT bank — only harvest_to_memory enables recap
+		// banking.
+		Context: &config.Context{Mode: cptr(config.ContextModeRecap), KeepLastN: cptr(2), Reasoning: cptr("drop")},
+		BankCompactedSpan: func(_ context.Context, _ []providers.Message) (string, error) {
+			banked++
+			return "x", nil
+		},
+	}
+	if _, did := maybeRecap(context.Background(), opts, msgs, 0, func(providers.Event) {}, "auto"); !did {
+		t.Fatal("expected recap distillation")
+	}
+	if banked != 0 {
+		t.Fatalf("recap banked %d times with harvest_to_memory off — memory_flush must not trigger recap banking", banked)
+	}
+}
+
+func TestHarvestToMemory_BankingErrorIsNonFatal(t *testing.T) {
+	msgs := []providers.Message{userMsg("the task"), asstMsg("a1"), userMsg("q2"), asstMsg("a2"), userMsg("q3"), asstMsg("a3")}
+	errs := 0
+	opts := RunOptions{
+		Provider: &steerProvider{},
+		Model:    "x",
+		Context:  &config.Context{Mode: cptr(config.ContextModeRecap), KeepLastN: cptr(2), Reasoning: cptr("drop"), HarvestToMemory: cptr(true)},
+		BankCompactedSpan: func(_ context.Context, _ []providers.Message) (string, error) {
+			return "", errors.New("agent has no user in memory_scopes")
+		},
+	}
+	_, did := maybeRecap(context.Background(), opts, msgs, 0, func(ev providers.Event) {
+		if ev.Type == providers.EventError {
+			errs++
+		}
+	}, "auto")
+	if !did {
+		t.Fatal("recap must complete despite a banking failure — banking is secondary to keeping the run alive")
+	}
+	if errs == 0 {
+		t.Fatal("a banking misconfiguration should surface as a non-fatal EventError, not be silently dropped")
+	}
+}
+
+func TestRun_Stateful_HarvestsToMemoryWhenOptedIn(t *testing.T) {
+	prov := &statefulScriptProvider{scripts: []string{
+		`{"reasoning":"begin","patch":{"count":0},"action":{"tool":"Echo","input":{}}}`,
+		`{"patch":{"count":1},"action":{"tool":"Echo","input":{}}}`,
+		`{"patch":{"count":2},"done":true,"final":"count is 2"}`,
+	}}
+	echo := &echoTool{reply: "observed"}
+	sc := statefulCtx(nil)
+	sc.HarvestToMemory = cptr(true)
+	banked := 0
+	opts := RunOptions{
+		Provider:   prov,
+		Model:      "x",
+		Tools:      []tools.Tool{echo},
+		Dispatcher: tools.NewDispatcher([]tools.Tool{echo}),
+		Segments:   statefulTaskSegs(),
+		Context:    sc,
+		OnEvent:    func(providers.Event) {},
+		BankCompactedSpan: func(_ context.Context, _ []providers.Message) (string, error) {
+			banked++
+			return "mp", nil
+		},
+	}
+	if _, err := Run(context.Background(), opts); err != nil {
+		t.Fatalf("stateful run: %v", err)
+	}
+	// A stateful run harvests each step's (reasoning + observation) span; the
+	// scripted run has multiple steps, so several banks fire.
+	if banked < 2 {
+		t.Fatalf("stateful harvest banked %d times, want >= 2 (one per step)", banked)
+	}
+}

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -1340,6 +1340,25 @@ func bankDiscardedSpan(ctx context.Context, opts RunOptions, dropped []providers
 	return &providers.MemoryBankedInfo{PendingID: id, Messages: len(dropped)}
 }
 
+// harvestToMemory banks an evicted span to the consolidation queue at a recap or
+// stateful distillation boundary when the agent set context.harvest_to_memory
+// (RFC CT P2) — extending the L0-only compaction banking to those modes so the
+// consolidator harvests their durable facts too. The compaction path already banks
+// via bankDiscardedSpan (its marker), so this covers only the other two modes.
+//
+// Never fatal, like all banking: a genuine failure (no store, misconfigured scope,
+// no user_id) surfaces as a non-fatal EventError so a misconfiguration is visible
+// rather than silently dropping every span; a span with nothing conversational to
+// bank (id == "") is a benign no-op and stays silent.
+func harvestToMemory(ctx context.Context, opts RunOptions, emit func(providers.Event), evicted []providers.Message) {
+	if !config.HarvestToMemoryEnabled(opts.Context) || opts.BankCompactedSpan == nil || len(evicted) == 0 {
+		return
+	}
+	if _, err := opts.BankCompactedSpan(ctx, evicted); err != nil {
+		emit(providers.Event{Type: providers.EventError, Error: "memory harvest: " + err.Error()})
+	}
+}
+
 // --- RFC CR L1: reasoning-recap distillation ---
 //
 // Recap mode is a sibling of compaction on the retention spectrum. It reuses the
@@ -1490,6 +1509,9 @@ func maybeRecap(ctx context.Context, opts RunOptions, messages []providers.Messa
 	// Recall(query) can fetch it back — most valuable exactly here, where recap
 	// (or drop) loses the detail. nil-safe when recall is off.
 	opts.RecallIndex.Harvest(ctx, messages[firstIdx:cut])
+	// Persistent-memory harvest (RFC CT P2): bank the same evicted span for the
+	// consolidator when the agent opted in. No-op unless context.harvest_to_memory.
+	harvestToMemory(ctx, opts, emit, messages[firstIdx:cut])
 	before := estimateMessageTokens(messages)
 	pinned := ""
 	if firstIdx > 0 {

--- a/internal/loop/stateful.go
+++ b/internal/loop/stateful.go
@@ -327,10 +327,14 @@ func runStateful(ctx context.Context, opts RunOptions, system []providers.Conten
 		// latest observation are fed, so each step's reasoning + observation are
 		// otherwise discarded. Embed them into the run-scoped index so a later
 		// Recall(query) can fetch the original detail back. nil-safe when recall off.
-		opts.RecallIndex.Harvest(ctx, []providers.Message{
+		stepSpan := []providers.Message{
 			{Role: "assistant", Reasoning: es.Reasoning,
 				Content: []providers.ContentBlock{{Type: "text", Text: obs}}},
-		})
+		}
+		opts.RecallIndex.Harvest(ctx, stepSpan)
+		// Persistent-memory harvest (RFC CT P2): bank the same evicted step for the
+		// consolidator when the agent opted in. No-op unless context.harvest_to_memory.
+		harvestToMemory(ctx, opts, emit, stepSpan)
 
 		// Terminal: done flag, or no action named.
 		if es.Done || es.Action == nil || strings.TrimSpace(es.Action.Tool) == "" {


### PR DESCRIPTION
## Why

`context.recall` (P1) keeps an evicted span reachable *within a run*. Its cross-run sibling was missing: durable facts a long agentic run accumulates (an entity named early, referenced throughout) should survive into future runs. Today only L0 compaction banks its dropped span for the consolidator (`compaction.memory_flush`); `recap` and `stateful` evict spans nothing harvests, and a long-lived session that never terminates is one the daemon's session-scan skips entirely.

## Measure first (the decision this PR encodes)

The open design fork was **inline per-span extraction** vs **bank-and-defer**. A map of the machinery found extraction isn't a cheap Go call — it's a spawned tool-less LLM sub-agent (`memory/extractor`). So I ran **RFC CU Probe 2** before building: extract facts from each distillation-sized span *in isolation* vs from the *whole* transcript, on hand-authored chats that plant self-contained (`local`) and coreference-dependent (`cross`) facts, using the real extractor prompt and an entailment judge.

Result (qwen3.8 extractor + judge, 12 chats):

| arm | local | xparty (3rd-party coref) | xproj (project coref) |
|---|---|---|---|
| whole | 0.67 | 0.31 | **0.75** |
| span  | 0.78 | 0.00 | **0.00** |

- Per-span isolation captured **zero** coreference-dependent facts (McNemar cross **b=11, c=0, p=0.0010**, one-directional) while matching whole on self-contained facts. The extractor's "name the subject explicitly" rule can't be met when the subject was named in a now-absent earlier span.
- Cross-model: with a strict qwen judge, laguna-s-2.1's per-span extraction also captured **0/8** cross facts — its apparent per-span "hits" when self-judging were weak-judge leniency over *fabricated* subjects (a distinct, also-bad failure of inline extraction on weak models).

Verdict: **bank-and-defer**, not inline — banking hands the consolidator whole/batched context (no coreference loss) and adds no model call to the run's hot path. (Throwaway harness, not shipped.)

## What

Adds an opt-in `context.harvest_to_memory` that **generalizes `compaction.memory_flush` to every distillation mode**:

- **Config gate** — per-agent + per-run `context.harvest_to_memory` bool, off by default, threaded through the same content-identifying plumbing as the rest of the context block (+ a `HarvestToMemoryEnabled` resolver).
- **Banking across modes** — the bank callback is installed when `memory_flush` OR `harvest_to_memory` is set; the loop now banks the evicted span at the **recap** and **stateful** boundaries too (compaction already did), gated on the resolved flag, mirroring exactly where P1's recall index harvests. Deferred to the existing consolidator; no daemon-exclusion needed (nothing self-extracts). Deliberately absent on resume.
- Banking stays **never-fatal**: a misconfiguration (no store / no `user` scope / no `user_id`) surfaces as a non-fatal `EventError` rather than silently never harvesting. The banked metadata source is generalized `compaction`→`distillation` (no consumer branches on it).
- The server resolves the merged context once per run (removing three redundant `MergeContext` recomputes).

## What was tested

- `go test ./...` — clean across 99 packages.
- `internal/loop`: recap banks the evicted span when opted in; does **not** when off (memory_flush must not trigger recap banking); a banking error is a non-fatal `EventError` and the run completes; a stateful run banks each step.
- Drift guards: the reflective Clone/Merge/IsZero cover-every-field test auto-covers the new `*bool`; a substrate read-path regression pins `context.harvest_to_memory` content-identifying.
- Manual: `go build ./...` clean; the config validates.

This is P2 of the recall-augmented-distillation line (RFC lives in the doc store). P3 (inline fact markers, gated on Probe 2's mimicry check) remains a later phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD
