### PR TITLE
chore(library): 0.4.0 for the capability-gates renderer

### DIFF
--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@loomcycle/library",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
-  "description": "Embeddable React Library component for the loomcycle agentic runtime — the Agents / Skills / MCP-Servers substrate browser (lineage, create/fork/promote/retire, Claude Code import) as a standalone, themeable package.",
+  "description": "Embeddable React Library component for the loomcycle agentic runtime \u2014 the Agents / Skills / MCP-Servers substrate browser (lineage, create/fork/promote/retire, Claude Code import) as a standalone, themeable package.",
   "license": "Apache-2.0",
   "author": "Dennis Gubsky",
   "repository": {


### PR DESCRIPTION
## Why

The agent definition view gained the capability gates in loomcycle v1.72.0 (#1126) — each non-empty scope gate as a pill row, the boolean grants as flags, quotas and context window in the meta row. It previously rendered **no gate at all**, not even `memory_scopes`, so an agent granted the tenant plane looked identical to one confined to its own scope.

That reached the embedded Web UI, which consumes this package from **source**. It did not reach npm: the package sat at 0.3.0 and **npm already holds 0.3.0**, so the publish had nothing to do. External consumers of `@loomcycle/library` have been rendering the old view since.

## What

Version only, 0.3.0 → 0.4.0.

The `@loomcycle/client` peer stays at `^1.7.0` — the renderer reads fields off an opaque `definition` object and calls no new client API, so there is no floor to raise. (Contrast `@loomcycle/memory-view` 0.5.0, whose peer *did* move to `^1.72.0` because it calls the new `tenant` option.)

Publishes when tagged `library-v0.4.0`.

## What was tested

`npm run typecheck` clean, 7 tests pass. No source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8