### PR TITLE
fix(recall): context.recall auto-grants the Recall tool

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -716,7 +716,8 @@ agents:
 So distillation now *shrinks* the fed context while *growing* a searchable index of what it dropped — a needle buried past a distillation boundary stays reachable by asking for it. The query is free text (not an id or exact wording) on purpose: models query fluently in plain language but barely reproduce identifiers, which also makes the tool far likelier to actually be used. `Recall` also transparently searches the agent's **durable memory**, so a fact learned in an earlier session may surface through the same call — the model needn't know where a fact lives.
 
 Notes:
-- **Needs an embedder.** The index keys and queries on embeddings, so `memory.embedder` must be configured; without one the run-index degrades to a no-op (the durable-memory search still applies for any agent that grants the `Recall` tool).
+- **The `Recall` tool is auto-granted.** Setting `recall: true` adds `Recall` to the run's toolset automatically — you do **not** also have to list it in `tools:`. (An agent's `tools:` allowlist is otherwise default-deny: an empty list grants *no* tools, so without this a recall agent would have the index but no way to query it.) Recall is read-only over the run's own evicted spans and the agent's own memory, so the auto-grant widens the allowlist but not the trust boundary. Needs an embedder (below); with `recall` off, nothing is granted.
+- **Needs an embedder.** The index keys and queries on embeddings, so `memory.embedder` must be configured; without one recall is inert — the index is not built and the tool is not granted.
 - **Works in every mode** (`append` + `compaction`, `recap`, `stateful`) — it hooks the same distillation boundary each uses.
 - **Off is byte-identical.** `recall` unset/false changes nothing; a resumed run does not re-index (it replays its past distillations).
 - Available per-agent and as a per-run `context.recall` override on the same surfaces as the rest of the block.

--- a/internal/api/http/recall_autogrant_test.go
+++ b/internal/api/http/recall_autogrant_test.go
@@ -1,0 +1,68 @@
+package http
+
+import (
+	"context"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// grantEmbedder is a no-op embedder just to make s.embedder non-nil (recallActive
+// requires an embedder — without one, recall is inert and Recall is not granted).
+type grantEmbedder struct{}
+
+func (grantEmbedder) Embed(context.Context, []string) ([][]float32, error) { return nil, nil }
+func (grantEmbedder) Model() string                                        { return "stub" }
+func (grantEmbedder) Provider() string                                     { return "stub" }
+func (grantEmbedder) Dimension() int                                       { return 3 }
+
+func recallCtx(on bool) *config.Context { return &config.Context{Recall: &on} }
+
+func countTool(ts []tools.Tool, name string) int {
+	n := 0
+	for _, t := range ts {
+		if t.Name() == name {
+			n++
+		}
+	}
+	return n
+}
+
+// TestGrantRecallTool pins the RFC CT auto-grant: context.recall makes the Recall
+// tool appear in a run's toolset even when the agent's tools: allowlist omits it
+// (an empty allowlist grants NOTHING), so enabling recall "just works" — but only
+// when an embedder is configured, only when recall is on, and never duplicated.
+func TestGrantRecallTool(t *testing.T) {
+	recall := namedTool{name: "Recall"}
+	read := namedTool{name: "Read"}
+	withEmb := &Server{tools: []tools.Tool{read, recall}, embedder: grantEmbedder{}}
+	noEmb := &Server{tools: []tools.Tool{read, recall}}
+
+	// recall ON, Recall not already in the (empty-derived) toolset → appended.
+	got := withEmb.grantRecallTool([]tools.Tool{}, recallCtx(true))
+	if countTool(got, "Recall") != 1 {
+		t.Errorf("recall on: Recall should be auto-granted, got %v", toolNames(got))
+	}
+
+	// recall ON but Recall already granted (agent listed it) → no duplicate.
+	got = withEmb.grantRecallTool([]tools.Tool{read, recall}, recallCtx(true))
+	if countTool(got, "Recall") != 1 {
+		t.Errorf("Recall duplicated: %v", toolNames(got))
+	}
+
+	// recall OFF (explicit false, e.g. a per-run override) → not granted.
+	if got := withEmb.grantRecallTool([]tools.Tool{read}, recallCtx(false)); countTool(got, "Recall") != 0 {
+		t.Errorf("recall off: Recall must not be granted, got %v", toolNames(got))
+	}
+
+	// nil / no context block → default byte-identical, not granted.
+	if got := withEmb.grantRecallTool([]tools.Tool{read}, nil); countTool(got, "Recall") != 0 {
+		t.Errorf("nil context: Recall must not be granted, got %v", toolNames(got))
+	}
+
+	// recall ON but NO embedder → recall is inert, so Recall is not granted.
+	if got := noEmb.grantRecallTool([]tools.Tool{read}, recallCtx(true)); countTool(got, "Recall") != 0 {
+		t.Errorf("no embedder: Recall must not be granted (inert), got %v", toolNames(got))
+	}
+}

--- a/internal/api/http/resume.go
+++ b/internal/api/http/resume.go
@@ -111,6 +111,7 @@ func (s *Server) resumePausedRun(ctx context.Context, run store.Run) error {
 	// was a call-time input, never snapshotted — the operator's static floor
 	// (applied inside the tools) is what remains.
 	allowedTools := filterTools(s.candidateTools(ctx, run.TenantID, agentDef.Tools), agentDef.Tools, nil)
+	allowedTools = s.grantRecallTool(allowedTools, agentDef.Context) // RFC CT: keep Recall on a resumed recall run
 	dispatcher := s.newDispatcher(allowedTools)
 
 	// Re-derive the system prompt (skill bodies baked in) from the current

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2213,10 +2213,43 @@ func convertConfigCandidates(in map[string][]config.TierCandidate, models map[st
 // the default path stays byte-identical. Deliberately NOT called on the resume
 // path (a resumed run replays past distillations without harvesting).
 func (s *Server) recallIndexForRun(cx *config.Context) *recall.Index {
-	if cx == nil || cx.Recall == nil || !*cx.Recall || s.embedder == nil {
+	if !s.recallActive(cx) {
 		return nil
 	}
 	return recall.NewIndex(s.embedder, 0)
+}
+
+// recallActive reports whether recall-augmented distillation is active for a run:
+// the agent opted into context.recall AND an embedder is configured (without one
+// both the run-scoped index and the Recall tool's persistent fallback are inert).
+func (s *Server) recallActive(cx *config.Context) bool {
+	return cx != nil && cx.Recall != nil && *cx.Recall && s.embedder != nil
+}
+
+// grantRecallTool ensures the Recall builtin is in a run's toolset when the agent
+// enabled context.recall — so enabling recall "just works" without ALSO having to
+// list Recall in tools: (an empty tools: grants NO tools, and even a populated one
+// easily omits it). No-op when recall is inactive or Recall is already granted.
+//
+// This intentionally widens the per-agent tools allowlist, but not the trust
+// boundary: Recall is read-only over the run's OWN evicted spans and the agent's
+// OWN memory scope, so granting it on the operator's explicit context.recall opt-in
+// exposes no data the agent could not already reach.
+func (s *Server) grantRecallTool(allowed []tools.Tool, cx *config.Context) []tools.Tool {
+	if !s.recallActive(cx) {
+		return allowed
+	}
+	for _, t := range allowed {
+		if t.Name() == "Recall" {
+			return allowed
+		}
+	}
+	for _, t := range s.tools {
+		if t.Name() == "Recall" {
+			return append(allowed, t)
+		}
+	}
+	return allowed
 }
 
 func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunCallbacks) error {
@@ -2366,6 +2399,9 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	// isn't stamped yet, so for non-HTTP-principal spawn surfaces the ctx
 	// tenant is "" and the run would not see its OWN dynamic MCP tools.
 	allowedTools := filterTools(s.candidateTools(ctx, effectiveTenantID, agentDef.Tools), agentDef.Tools, in.Tools)
+	// RFC CT: context.recall auto-grants the Recall tool so enabling recall works
+	// without also listing Recall in tools:.
+	allowedTools = s.grantRecallTool(allowedTools, config.MergeContext(agentDef.Context, in.Context))
 	var hostPolicy tools.HostPolicyValue
 	if in.AllowedHosts != nil || s.cfg().Env.HTTPCallerAuthoritative {
 		var caller []string
@@ -3927,6 +3963,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	// for an open-mode run. Consistent with the agent existence-check +
 	// resolveAgent on this path.
 	allowedTools := filterTools(s.candidateTools(r.Context(), req.TenantID, agentDef.Tools), agentDef.Tools, req.Tools)
+	allowedTools = s.grantRecallTool(allowedTools, config.MergeContext(agentDef.Context, req.Context)) // RFC CT
 	// Per-run host narrowing for HTTP/WebFetch/WebSearch. Behaviour
 	// depends on LOOMCYCLE_HTTP_CALLER_AUTHORITATIVE — see NarrowHosts
 	// doc comment. In caller-authoritative mode we ALWAYS call so the
@@ -4603,6 +4640,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	// the ctx tenant — the ownership gate above already proved the caller
 	// is entitled to this session.
 	allowedTools := filterTools(s.candidateTools(r.Context(), sess.TenantID, agentDef.Tools), agentDef.Tools, body.Tools)
+	allowedTools = s.grantRecallTool(allowedTools, config.MergeContext(agentDef.Context, body.Context)) // RFC CT
 	var hostPolicy tools.HostPolicyValue
 	if body.AllowedHosts != nil || s.cfg().Env.HTTPCallerAuthoritative {
 		var caller []string
@@ -5961,6 +5999,7 @@ func (s *Server) prepareSubRun(ctx context.Context, name, prompt, defID string, 
 	// renders this list. Safe to hoist: applyMemoryInjection rewrites only
 	// SystemPrompt, so def.Tools is the same value it was below.
 	subTools := filterTools(s.candidateTools(ctx, tenantFromCtx(ctx), def.Tools), def.Tools, nil)
+	subTools = s.grantRecallTool(subTools, def.Context) // RFC CT: recall-enabled sub-agent gets Recall
 	// RFC BL P1: memory injection for the sub-agent. ctx still carries the
 	// PARENT run's core-block policy, so an inherit_core_blocks sub-agent picks
 	// up the parent's user/tenant blocks here (agent-scope never crosses).


### PR DESCRIPTION
## Why

`context.recall: true` (RFC CT P1) built the run-scoped index and harvested into it, but a recall-enabled agent still couldn't **query** it: an agent's `tools:` allowlist is default-deny — an empty list grants *no* tools, and even a populated one easily omits `Recall`. So the agent had the index and no way to reach it. The P1 docs implied a "default-all" toolset that does not exist.

This surfaced during an end-to-end confirmation on a real loomcycle (Postgres+pgvector, ollama qwen3.8 + nomic-embed): with the recap distillation evicting a needle, the agent **confabulated** a value rather than recalling it — because `Recall` was never in its toolset. A driver-level dump of the exact tools sent to the model confirmed it: no `Recall`.

## What

When recall is **active** (`context.recall` set AND an embedder configured), auto-grant the `Recall` builtin to the run's toolset if the agent's allowlist did not already include it. Wired at every toolset-resolution site: `RunOnce` (all non-HTTP triggers), HTTP `handleRuns`, the session-continue path, sub-agent spawn, and resume. A shared `recallActive(cx)` gate now backs both the index build and the tool grant.

- **Not a trust-boundary widening:** `Recall` is read-only over the run's *own* evicted spans and the agent's *own* memory scope, so auto-granting it on the operator's explicit `context.recall` opt-in exposes nothing the agent couldn't already reach.
- **No-op when recall is off** or no embedder is configured (recall is inert without one), and it never duplicates an already-granted `Recall`.
- Docs corrected to state the auto-grant.

## What was tested

- `go test ./...` — clean across 99 packages.
- `TestGrantRecallTool`: recall-on grants Recall, recall-off / nil-context / no-embedder do not, and an already-granted Recall isn't duplicated.
- **End-to-end on a real loomcycle:** a `recall-auto` agent with an empty `tools:` and `recall: true` now shows `tools(…)=[… Recall]` in the exact list sent to the model; the same agent with a per-run `recall: false` shows no `Recall`.

Follow-up (not in this PR): a clean recall-recovery answer-quality A/B is best run on a frontier model — qwen3.8 is unreliable at *invoking* tools even when they're available (the known weak-model adoption gap, RFC CU Probe 1c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD
