### PR TITLE
fix(sqlmem): one tenant mapping; refuse a benchmark whose facts were diverted

### DIFF
--- a/bench/cmd/locomo/answer.go
+++ b/bench/cmd/locomo/answer.go
@@ -289,6 +289,30 @@ func AnswersByCategory(rs []AnswerResult) []AnswerStats {
 	return out
 }
 
+// factsDiverted reports how many written facts are reachable in the partition the
+// answerer recalls from, and whether the shortfall is large enough to invalidate a
+// grading run.
+//
+// Exported from the guard rather than inlined so the THRESHOLD is pinned by a test
+// against the real numbers from both a contaminated run and a healthy one — a
+// guard whose arithmetic only exists inside the function it protects is a guard
+// nobody can check.
+//
+// `doc.chunk:` rows are chunk BODIES, not recallable facts. Counting them is
+// precisely what made a diverted partition look populated: 16 rows present, ~7 of
+// them actual facts, and the empty-store check waved it through.
+func factsDiverted(factsWritten int, keys []string) (reachable int, diverted bool) {
+	for _, k := range keys {
+		if strings.HasPrefix(k, "memory/") {
+			reachable++
+		}
+	}
+	// Half is the tolerance: supersede/retire legitimately removes a few, but a
+	// diversion loses most or all of them (76 written, 7 reachable on the run this
+	// exists for).
+	return reachable, factsWritten > 0 && reachable*2 < factsWritten
+}
+
 // purgeLayer empties the memory-layer partition so the next conversation starts
 // from nothing. Keys are read back from the store rather than derived, because
 // the consolidator names the rows it writes (memory/fact/...), not this harness.
@@ -662,7 +686,7 @@ func doAnswerAxis(ctx context.Context, convs []Conversation, defects *Defects, o
 		// "accuracy 0.0000" — a number about the plumbing wearing the costume of a
 		// result about memory. Failing here is the difference between a broken run
 		// and a false negative.
-		rows, err := rest.ListKeys(ctx, "user", userID, 5)
+		rows, err := rest.ListKeys(ctx, "user", userID, 2*facts+500)
 		if err != nil {
 			return fmt.Errorf("post-consolidation check: %w", err)
 		}
@@ -671,6 +695,31 @@ func doAnswerAxis(ctx context.Context, convs []Conversation, defects *Defects, o
 				"recall would return nothing and the run would score 0 for a reason unrelated to memory. "+
 				"Check that the consolidator can reach its extractor model and that the target is not leased",
 				"user", userID, passes, sessions)
+		}
+
+		// AND refuse when the facts went somewhere the answerer cannot read.
+		//
+		// The empty check above is not enough, and a live run proved it: with an
+		// ontology declaring `@memory_scope: tenant` for the corpus's own entity
+		// types, the consolidator PLACED most facts into the tenant scope while the
+		// answerer — memory_scopes:[user] — recalls from user/<subject> only. The
+		// partition held a handful of rows, so the guard passed, and the run scored
+		// 0.0216 with 95% abstention: a number about the wrong partition wearing the
+		// costume of a result about consolidation. Three plausible mechanisms were
+		// then reasoned on top of it before anyone compared the counter to the store.
+		//
+		// So compare them. The pass report says how many facts it wrote; this counts
+		// how many are reachable where the answerer looks. A large shortfall means
+		// diversion, whatever the cause — placement, a mis-scoped consolidator, a
+		// fan-out target that is not this subject.
+		reachable, diverted := factsDiverted(facts, rows)
+		if diverted {
+			return fmt.Errorf("consolidation reported %d fact(s) written but only %d are reachable in %s/%s "+
+				"(the partition the answerer recalls from): the facts were written to a scope this run cannot read, "+
+				"so grading would measure the wrong partition. The usual cause is ontology-declared placement — "+
+				"check for a live `@memory_scope` declaration in the tenant's /memory/ontology document and remove it "+
+				"for benchmarking, then purge every scope and verify each is empty BY LISTING it",
+				facts, reachable, "user", userID)
 		}
 
 		qs := SampleQueries(conv.Queries, opts.sampleQuestions)

--- a/bench/cmd/locomo/diversion_guard_check_test.go
+++ b/bench/cmd/locomo/diversion_guard_check_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+// The contaminated run this guard exists for, and the healthy run it must not
+// block. Both are real numbers from the same corpus on the same day: the first
+// scored 0.0216 and looked like a result about consolidation, the second is what
+// consolidation actually does.
+func TestDiversionGuard_CatchesTheContaminatedRunAndPassesTheHealthyOne(t *testing.T) {
+	keys := func(facts, chunks int) []string {
+		var out []string
+		for i := 0; i < facts; i++ {
+			out = append(out, fmt.Sprintf("memory/fact/f-%d", i))
+		}
+		for i := 0; i < chunks; i++ {
+			// doc.chunk rows are chunk BODIES, not recallable facts — counting them
+			// as facts is what let the partition look populated when it was not.
+			out = append(out, fmt.Sprintf("doc.chunk:%032x", i))
+		}
+		return out
+	}
+	for _, tc := range []struct {
+		name       string
+		written    int
+		facts      int
+		chunks     int
+		wantRefuse bool
+	}{
+		{"the contaminated run: placement diverted them to tenant scope", 76, 7, 9, true},
+		{"the healthy run: 59 written, 58 reachable", 59, 58, 55, false},
+		{"the healthy run, second conversation", 41, 41, 38, false},
+		{"a few retired is fine, not a diversion", 40, 36, 0, false},
+		{"total diversion", 40, 0, 12, true},
+		{"the turns arm writes no facts — guard must stay silent", 0, 0, 419, false},
+		{"exactly half is a shortfall we tolerate", 40, 20, 0, false},
+		{"just under half refuses", 40, 19, 0, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reachable, refuse := factsDiverted(tc.written, keys(tc.facts, tc.chunks))
+			if reachable != tc.facts {
+				t.Errorf("counted %d reachable, want %d — doc.chunk rows must not count as facts", reachable, tc.facts)
+			}
+			if refuse != tc.wantRefuse {
+				t.Errorf("refuse = %v, want %v (written=%d reachable=%d)", refuse, tc.wantRefuse, tc.written, reachable)
+			}
+		})
+	}
+}

--- a/internal/directory/directory.go
+++ b/internal/directory/directory.go
@@ -234,9 +234,5 @@ func (s *Service) Inspect(ctx context.Context, tenant, subject string) (Inspecti
 // refuses an empty tenant and stores the default one as "default", while the k/v
 // plane keeps the raw "". Same rule as builtin.sqlScopeTenant and the erasure
 // service — getting it wrong here would count another tenant's documents.
-func sqlScopeTenant(tenant string) string {
-	if tenant != "" {
-		return tenant
-	}
-	return "default"
-}
+// sqlScopeTenant delegates to sqlmem.ScopeTenant, which owns this rule.
+func sqlScopeTenant(tenant string) string { return sqlmem.ScopeTenant(tenant) }

--- a/internal/erasure/erasure.go
+++ b/internal/erasure/erasure.go
@@ -134,12 +134,10 @@ const retainedUsageLedger = "retained by design: cost rows are accounting record
 // silently matches nothing, so a single-tenant deployment's erasure would leave
 // the subject's ENTIRE SQL Memory database — documents, entity graph — in place
 // while reporting success.
-func sqlScopeTenant(tenant string) string {
-	if tenant != "" {
-		return tenant
-	}
-	return "default"
-}
+// sqlScopeTenant delegates to sqlmem.ScopeTenant, which owns this rule.
+// Kept as a local shim so the many call sites below read unchanged; the
+// mapping itself is no longer duplicated here.
+func sqlScopeTenant(tenant string) string { return sqlmem.ScopeTenant(tenant) }
 
 // userSQLScopeExists reports whether the subject owns a user-scope SQL Memory
 // database IN THIS TENANT.

--- a/internal/sqlmem/scope_tenant_test.go
+++ b/internal/sqlmem/scope_tenant_test.go
@@ -1,0 +1,53 @@
+package sqlmem
+
+import "testing"
+
+// ScopeTenant is the ONE mapping from a runtime tenant to the tenant a SQL
+// Memory scope key uses. It had four implementations across three packages, each
+// comment naming a different one as authoritative and nothing asserting they
+// agreed — they did, byte for byte, which is the only reason it was a latent risk
+// rather than a live bug.
+//
+// The consequence of divergence is documented at the erasure call site and is not
+// cosmetic: a DropScope built from a raw "" tenant matches nothing, so a
+// single-tenant deployment's subject erasure leaves the whole SQL Memory database
+// in place while reporting success. So the rule is pinned here, including the two
+// cases that matter — the empty tenant becoming the default key, and a tenant
+// LITERALLY NAMED "default" being indistinguishable from it.
+func TestScopeTenant_PinsTheMapping(t *testing.T) {
+	for _, tc := range []struct{ in, want, why string }{
+		{"", "default", "an empty runtime tenant is what pgScopeNames refuses, so it MUST become the default key"},
+		{"acme", "acme", "a named tenant passes through untouched"},
+		{"default", "default", "a tenant literally named default is indistinguishable from the empty one — collapsing them is the accepted cost of using a magic name"},
+		{" ", " ", "NOT trimmed: a whitespace tenant is a distinct (if pathological) tenant, and silently folding it into default would merge two keyspaces"},
+	} {
+		if got := ScopeTenant(tc.in); got != tc.want {
+			t.Errorf("ScopeTenant(%q) = %q, want %q — %s", tc.in, got, tc.want, tc.why)
+		}
+	}
+}
+
+// The mapping's whole purpose is producing a tenant pgScopeNames accepts. If it
+// ever returned "" the derivation would refuse, and every SQL Memory op in a
+// single-tenant deployment would fail — so assert the two are consistent rather
+// than trusting that they stay so.
+func TestScopeTenant_ProducesAKeyTheDerivationAccepts(t *testing.T) {
+	for _, in := range []string{"", "acme", "default"} {
+		key := ScopeKey{Tenant: ScopeTenant(in), Scope: "user", ScopeID: "alice"}
+		schema, role, err := pgScopeNames(key)
+		if err != nil {
+			t.Errorf("pgScopeNames rejected the key ScopeTenant(%q) built: %v", in, err)
+			continue
+		}
+		if !pgIdentRe.MatchString(schema) || !pgIdentRe.MatchString(role) {
+			t.Errorf("ScopeTenant(%q) produced non-conforming identifiers %q/%q", in, schema, role)
+		}
+	}
+	// And distinct tenants must still derive distinct schemas — the mapping must
+	// not collapse anything except the empty case it exists for.
+	a, _, _ := pgScopeNames(ScopeKey{Tenant: ScopeTenant(""), Scope: "user", ScopeID: "alice"})
+	b, _, _ := pgScopeNames(ScopeKey{Tenant: ScopeTenant("acme"), Scope: "user", ScopeID: "alice"})
+	if a == b {
+		t.Errorf("the empty tenant and %q derived the SAME schema %q — that is a cross-tenant leak", "acme", a)
+	}
+}

--- a/internal/sqlmem/sqlmem.go
+++ b/internal/sqlmem/sqlmem.go
@@ -241,6 +241,35 @@ const scopeKeySep = '\x1f'
 // through) cannot forge another tenant's prefix. That safety is an accident of
 // field order, not a design, and a fourth component or a reordering would spend
 // it silently.
+// ScopeTenant maps a runtime tenant id onto the tenant SQL Memory keys by.
+//
+// THIS IS THE ONLY CORRECT WAY to build a ScopeKey.Tenant from a runtime tenant,
+// and it lives here because it exists for THIS package's constraint: pgScopeNames
+// rejects an empty tenant (it has to — the empty string would derive a schema and
+// a LOGIN role shared by every single-tenant deployment), while the k/v Memory
+// plane and the Path tree key on the RAW tenant and leave the default one "".
+// Three planes, three keyings — see the tenant-keying seam.
+//
+// It was implemented FOUR TIMES across three packages (builtin, directory,
+// erasure), each with a comment naming a different one as the source of truth and
+// nothing asserting they agreed. They did agree, byte for byte, which is the only
+// reason this was a latent risk rather than a live bug. The failure mode if one
+// drifts is documented at the erasure call site and is not cosmetic: a DropScope
+// built from a raw "" tenant matches nothing, so a single-tenant deployment's
+// subject erasure leaves the subject's ENTIRE SQL Memory database — documents,
+// entity graph — in place while REPORTING SUCCESS.
+func ScopeTenant(tenant string) string {
+	if tenant != "" {
+		return tenant
+	}
+	return defaultTenantKey
+}
+
+// defaultTenantKey is what an empty runtime tenant becomes in a SQL Memory scope
+// key. Named rather than inlined so the three call sites cannot disagree by
+// typo, and so a change here is a change everywhere.
+const defaultTenantKey = "default"
+
 func (k ScopeKey) validate() error {
 	for _, part := range []struct{ name, val string }{
 		{"tenant", k.Tenant}, {"scope", k.Scope}, {"scope_id", k.ScopeID},

--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -854,12 +854,8 @@ func sqlScopeTenant(ctx context.Context) string {
 // default partition is stored as "default" while the k/v and dirent planes keep the
 // raw "". Both forms must go through here — a restated ""→"default" at a call site
 // is how the tenant axis drifts.
-func sqlScopeTenantValue(tenant string) string {
-	if tenant != "" {
-		return tenant
-	}
-	return "default"
-}
+// sqlScopeTenantValue delegates to sqlmem.ScopeTenant, which owns this rule.
+func sqlScopeTenantValue(tenant string) string { return sqlmem.ScopeTenant(tenant) }
 
 // currentSqlTxnID returns the explicit-transaction registry key for the current
 // run + scope, or "" when there is no run id on the context (then SQL ops


### PR DESCRIPTION
Two fixes from the memory hardening pass, both about a rule living in more places than it should.

## One tenant mapping

The `"" → "default"` mapping that turns a runtime tenant into a SQL Memory scope key had **four implementations across three packages** (`builtin`, `directory`, `erasure`), each with a comment naming a *different* one as the source of truth, and **no test asserting they agreed**. They did agree, byte for byte — which is the only reason this was a latent risk rather than a live bug.

The consequence of divergence is documented at the erasure call site and isn't cosmetic:

> a DropScope built from a raw `""` tenant silently matches nothing, so a single-tenant deployment's erasure would leave the subject's ENTIRE SQL Memory database — documents, entity graph — in place while reporting success.

It now lives in `internal/sqlmem` as `ScopeTenant`, which is where it belongs: it exists for *that* package's constraint — `pgScopeNames` rejects an empty tenant, because `""` would derive a schema and a LOGIN role shared by every single-tenant deployment — while the k/v plane and the Path tree key on the raw value. The three call sites delegate, so their many uses read unchanged.

The test pins the two cases that matter (empty → default; a tenant *literally named* `default` being indistinguishable from it), asserts the mapping still produces a key `pgScopeNames` accepts, and asserts distinct tenants still derive distinct schemas.

## Refuse a diverted benchmark

The answer axis already refused an **empty** store, on the grounds that `accuracy 0.0000` is *"a number about the plumbing wearing the costume of a result about memory."* A live run proved that insufficient.

With the corpus tenant's ontology declaring `@memory_scope: tenant` for its own entity types, the consolidator **placed** most facts into the tenant scope while the answerer — `memory_scopes: [user]` — recalls from `user/<subject>` only. The partition still held a handful of rows, so the guard passed. The run scored **0.0216 with 95% abstention**, and three plausible mechanisms were reasoned on top of that number before anyone compared the counter to the store.

So the guard now compares them: the pass report says how many facts it wrote, and this counts how many are reachable where the answerer looks, refusing on a shortfall of more than half — naming ontology-declared placement as the usual cause, since that's what it was.

`doc.chunk:` rows are chunk **bodies**, not recallable facts, and are deliberately excluded. Counting them is exactly what made a diverted partition look populated (16 rows present, ~7 actual facts).

`factsDiverted` is a named function rather than an inline loop, so the threshold is pinned by a test against the **real numbers from both runs**:

| case | written | reachable | refuses |
|---|---|---|---|
| the contaminated run | 76 | 7 | ✅ |
| the healthy run | 59 | 58 | — |
| healthy, conv 2 | 41 | 41 | — |
| turns arm (no facts) | 0 | 0 | — |
| just under half | 40 | 19 | ✅ |

A guard whose arithmetic only exists inside the function it protects is a guard nobody can check — the same lesson as the scope-blind test double in #1125.

## What was tested

Both regressions **verified by injection**: diverging the mapping fails the pin (`ScopeTenant("") = "" want "default"`), and weakening the threshold fails on the contaminated run's numbers (`refuse = false, want true (written=76 reachable=7)`). `go test ./...` clean — 99 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8