### PR TITLE
fix(memory): the embedder resolves its endpoint from providers: yaml

### DIFF
--- a/cmd/loomcycle/embedded/presets/local.yaml
+++ b/cmd/loomcycle/embedded/presets/local.yaml
@@ -20,6 +20,11 @@ providers:
   # _*_TIMEOUT_MS. To move that off env and into YAML, uncomment and edit — these
   # OVERRIDE the env vars (and loomcycle.yaml overrides these in turn):
   #
+  # base_url here moves CHAT AND THE MEMORY EMBEDDER together: memory.embedder
+  # resolves its endpoint through this same entry, so a new Ollama host is one
+  # edit. Restate it under memory.embedder.base_url only to send embeddings
+  # somewhere else on purpose.
+  #
   # ollama-local:
   #   base_url: http://truenas.local:11434   # else OLLAMA_BASE_URL (default localhost)
   #   options:

--- a/cmd/loomcycle/embedder_provider_yaml_test.go
+++ b/cmd/loomcycle/embedder_provider_yaml_test.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/memory/embedders"
+)
+
+// embedSrv is an Ollama-shaped /api/embed stub that counts what reached it.
+// The endpoint is unexported on every driver, so which server receives the
+// request IS the assertion — the same technique as embedder_endpoint_test.go.
+func embedSrv(t *testing.T, hits *int) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*hits++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"model":"bge-m3","embeddings":[[1,2,3]]}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestEmbedderConfig_OllamaLocalResolvesTheProvidersMapBaseURL — the regression.
+//
+// An operator repoints ollama-local at a new host the documented way, in
+// `providers:` yaml. Chat followed (providerbuild prefers pc.BaseURL) but the
+// embedder read cfg.Env.OllamaBaseURL ONLY, so it kept dialing the stale
+// default. Nothing surfaced it: a k/v memory write returns 200 whether or not
+// the embedding lands, so memory silently degraded to non-semantic.
+//
+// FAILS on the unfixed code — the request lands on the env server.
+func TestEmbedderConfig_OllamaLocalResolvesTheProvidersMapBaseURL(t *testing.T) {
+	var envHits, yamlHits int
+	envSrv := embedSrv(t, &envHits)   // the stale host the env var still names
+	yamlSrv := embedSrv(t, &yamlHits) // the new host declared in yaml
+
+	cfg := &config.Config{}
+	cfg.Env.OllamaBaseURL = envSrv.URL
+	cfg.Providers = map[string]config.ProviderConfig{
+		"ollama-local": {Driver: "ollama", BaseURL: yamlSrv.URL},
+	}
+	cfg.Memory.Embedder = config.EmbedderConfig{Provider: "ollama-local", Model: "bge-m3"}
+
+	e, err := embedders.Build(cfg)
+	if err != nil {
+		t.Fatalf("embedders.Build: %v", err)
+	}
+	if _, err := e.Embed(context.Background(), []string{"x"}); err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if yamlHits != 1 || envHits != 0 {
+		t.Errorf("providers: yaml base_url got %d requests and the env default got %d; want 1 and 0 "+
+			"(the embedder ignored the yaml the chat driver honours)", yamlHits, envHits)
+	}
+}
+
+// TestEmbedderConfig_EmbedderYamlBeatsTheProvidersMap — the embedder's own block
+// stays the top of the precedence chain, so an operator can point embeddings at
+// a dedicated host while chat keeps the shared one.
+func TestEmbedderConfig_EmbedderYamlBeatsTheProvidersMap(t *testing.T) {
+	var providerHits, embedderHits int
+	providerSrv := embedSrv(t, &providerHits)
+	embedderSrv := embedSrv(t, &embedderHits)
+
+	cfg := &config.Config{}
+	cfg.Providers = map[string]config.ProviderConfig{
+		"ollama-local": {Driver: "ollama", BaseURL: providerSrv.URL},
+	}
+	cfg.Memory.Embedder = config.EmbedderConfig{
+		Provider: "ollama-local", Model: "bge-m3", BaseURL: embedderSrv.URL,
+	}
+
+	e, err := embedders.Build(cfg)
+	if err != nil {
+		t.Fatalf("embedders.Build: %v", err)
+	}
+	if _, err := e.Embed(context.Background(), []string{"x"}); err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if embedderHits != 1 || providerHits != 0 {
+		t.Errorf("memory.embedder.base_url got %d and providers: got %d; want 1 and 0",
+			embedderHits, providerHits)
+	}
+}
+
+// TestEmbedderConfig_ProvidersMapApiKeyEnvIsHonoured — api_key_env is a NAME, and
+// the embedder must resolve the one the operator declared rather than assuming
+// the vendor default. Guards the RFC AR renamed-credential case.
+func TestEmbedderConfig_ProvidersMapApiKeyEnvIsHonoured(t *testing.T) {
+	var seenAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"model":"m","data":[{"index":0,"embedding":[1,2]}]}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("LOOMCYCLE_TEST_DECLARED_KEY", "declared-key-placeholder")
+
+	cfg := &config.Config{}
+	cfg.Env.OpenAIAPIKey = "vendor-default-must-lose"
+	cfg.Providers = map[string]config.ProviderConfig{
+		"openai": {Driver: "openai", BaseURL: srv.URL, APIKeyEnv: "LOOMCYCLE_TEST_DECLARED_KEY"},
+	}
+	cfg.Memory.Embedder = config.EmbedderConfig{Provider: "openai", Model: "m"}
+
+	e, err := embedders.Build(cfg)
+	if err != nil {
+		t.Fatalf("embedders.Build: %v", err)
+	}
+	if _, err := e.Embed(context.Background(), []string{"x"}); err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if seenAuth != "Bearer declared-key-placeholder" {
+		t.Errorf("Authorization did not come from the declared api_key_env (got the vendor default)")
+	}
+}
+
+// TestEmbedderConfig_NoProvidersBlockStillUsesTheEnvKey — a deployment running
+// with LOOMCYCLE_NO_DEFAULT_PROVIDERS=1 and no `providers:` block declares no
+// api_key_env at all. The per-id env key must remain the last resort: the openai
+// embedder accepts an empty key at construction and only fails later at 401, so
+// dropping this fallback would turn a working embedder into a runtime auth error.
+func TestEmbedderConfig_NoProvidersBlockStillUsesTheEnvKey(t *testing.T) {
+	var seenAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"model":"m","data":[{"index":0,"embedding":[1,2]}]}`))
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{} // no cfg.Providers at all
+	cfg.Env.OpenAIAPIKey = "env-key-placeholder"
+	cfg.Memory.Embedder = config.EmbedderConfig{Provider: "openai", Model: "m", BaseURL: srv.URL}
+
+	e, err := embedders.Build(cfg)
+	if err != nil {
+		t.Fatalf("embedders.Build: %v", err)
+	}
+	if _, err := e.Embed(context.Background(), []string{"x"}); err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if seenAuth != "Bearer env-key-placeholder" {
+		t.Errorf("Authorization = %q, want the per-id env key fallback", seenAuth)
+	}
+}
+
+// TestEmbedderConfig_AnthropicDoesNotInheritTheChatProviderEntry — the one
+// provider that must NOT share its chat account. The `anthropic` embedder slot is
+// a Voyage AI proxy, a different vendor, so inheriting the anthropic entry would
+// POST Voyage requests at an Anthropic proxy and send ANTHROPIC_API_KEY to
+// Voyage. Both halves must be ignored.
+func TestEmbedderConfig_AnthropicDoesNotInheritTheChatProviderEntry(t *testing.T) {
+	var anthropicHits int
+	anthropicSrv := embedSrv(t, &anthropicHits)
+
+	t.Setenv("LOOMCYCLE_TEST_ANTHROPIC_KEY", "anthropic-key-must-not-reach-voyage")
+
+	cfg := &config.Config{}
+	cfg.Env.VoyageAPIKey = "voyage-key-placeholder"
+	cfg.Providers = map[string]config.ProviderConfig{
+		"anthropic": {
+			Driver:    "anthropic",
+			BaseURL:   anthropicSrv.URL,
+			APIKeyEnv: "LOOMCYCLE_TEST_ANTHROPIC_KEY",
+		},
+	}
+	cfg.Memory.Embedder = config.EmbedderConfig{Provider: "anthropic", Model: "voyage-3"}
+
+	e, err := embedders.Build(cfg)
+	if err != nil {
+		t.Fatalf("embedders.Build: %v", err)
+	}
+	// Not asserting on a successful Embed: the point is that the Voyage driver
+	// never adopted the Anthropic endpoint, so the anthropic stub sees nothing.
+	_, _ = e.Embed(context.Background(), []string{"x"})
+	if anthropicHits != 0 {
+		t.Errorf("the Voyage embedder sent %d requests to the anthropic chat base_url, want 0", anthropicHits)
+	}
+}

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -607,12 +607,21 @@ memory:
   embedder:
     provider: ollama-local
     model: embeddinggemma:latest
-    # base_url inherits OLLAMA_BASE_URL; set it explicitly to override
+    # base_url inherits `providers: ollama-local: base_url:`;
+    # set it here only to point embeddings at a DIFFERENT host than chat
 ```
 
 - **You must pull an embedding model first — this is required, not optional.** A stock Ollama ships none, and every call 404s until you run `ollama pull embeddinggemma` (or `nomic-embed-text`, `qwen3-embedding`, …) on the Ollama host. The error names the model and the pull command.
 - `base_url` must be reachable **from inside the loomcycle container**. In a container `localhost` is the container itself, not the host running Ollama — use the host's LAN address or a compose service name. loomcycle logs the endpoint it defaulted to at boot for exactly this reason.
-- **Precedence:** explicit yaml `base_url` > `OLLAMA_BASE_URL` (the same var the chat provider reads, so one setting serves both) > `http://localhost:11434`. `OLLAMA_BASE_URL=disabled` is the chat side's opt-out marker and is treated as unset here.
+- **Precedence:** `memory.embedder.base_url` > `providers.ollama-local.base_url` > `OLLAMA_BASE_URL` > `http://localhost:11434`. The middle level is what makes YAML the config home: repointing `providers: ollama-local: base_url:` at a new Ollama host moves **chat and embeddings together**, so one setting serves both without restating it. Set `memory.embedder.base_url` only to make them diverge on purpose (a dedicated embedding host). `OLLAMA_BASE_URL=disabled` is the chat side's opt-out marker and is treated as unset here.
+- ⚠️ **An embed failure warns but does not fail the write.** By design: the k/v row is kept and the response carries `embedded: false` plus an `embed_warning` (the `Memory` tool logs it and returns the same field). So the corpus silently accumulates unembedded rows for any caller that ignores that field — `recall` stops matching and search 500s while every write still reports 200. **After changing the Ollama host, write one row with `?embed=true` and READ the response** — `embed_warning` names the endpoint AND the error, which is the whole diagnosis in one call:
+
+  ```
+  PUT /v1/_memory/scopes/user/<id>/keys/probe?embed=true
+  → {"embedded":false,"embed_warning":"ollama /api/embed: Post \"http://<host>:11434/api/embed\": dial tcp: lookup <host>: no such host"}
+  ```
+
+  A name the loomcycle **container** cannot resolve is the common one — Tailscale MagicDNS names do not resolve against Docker's embedded DNS (127.0.0.11), so prefer the tailnet IP or a compose service name. Corroborate with `GET /v1/_memory/embed_stats` (the row count must move after a successful embed) and note that a `POST /v1/_memory/backfill_embeddings?...&dry_run=false` reporting `failed` within milliseconds never dialled anything at all.
 - `provider: ollama` is the hosted ollama.com sibling: `OLLAMA_CLOUD_BASE_URL` + `OLLAMA_API_KEY`. Prefer `ollama-local` for a self-hosted box — the `-local` suffix is also how the consolidation dispatcher recognises a runtime on your own hardware and throttles fan-out accordingly.
 
 **Any OpenAI-compatible server.** `provider: openai` with a `base_url` reaches vLLM, LocalAI, Text Embeddings Inference, Infinity, an Azure OpenAI deployment, or Ollama's own OpenAI-compat layer — no new driver needed:

--- a/internal/memory/embedders/embedders.go
+++ b/internal/memory/embedders/embedders.go
@@ -20,13 +20,29 @@ import (
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/providerbuild"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 )
 
 // Build turns cfg.Memory.Embedder into a constructed providers.Embedder,
-// sourcing the API key + base URL from the same env vars the chat-completion
-// drivers use. Returns (nil, nil) when no embedder is configured — the Memory
-// tool refuses vector ops with embedder_not_configured in that case.
+// resolving the endpoint + credential through the SAME path the chat-completion
+// drivers use (providerbuild.ProviderEndpoint). Returns (nil, nil) when no
+// embedder is configured — the Memory tool refuses vector ops with
+// embedder_not_configured in that case.
+//
+// base_url precedence, highest first:
+//
+//	memory.embedder.base_url  >  providers.<id>.base_url  >  the per-id env default
+//
+// The middle level is the fix for a real outage: the embedder used to read
+// cfg.Env.OllamaBaseURL ONLY, so an operator who repointed
+// `providers: ollama-local: base_url:` at a new Ollama host moved chat and left
+// the embedder on the env var. An embed failure warns rather than failing the
+// write (the row is kept, with embedded:false + embed_warning), so a caller that
+// does not read that field accumulates unembedded rows: memory stopped being
+// semantic (108 fact rows, ~0 embeddings) while every write still reported 200,
+// and the benchmark that surfaced it read as a bad extractor. YAML is now the
+// config home for both.
 //
 // Per-embedder yaml knobs (timeout_ms, batch_size) override the env-var
 // defaults when set; the env-var fallback gives operators a single-place
@@ -37,51 +53,62 @@ func Build(cfg *config.Config) (providers.Embedder, error) {
 		return nil, nil
 	}
 
-	// Reuse the chat-completion driver's auth + base URL. Embedders
-	// hit the same provider account, so a separate set of env vars
-	// would be operator friction without benefit.
-	//
-	// EXCEPTION: the `anthropic` embedder slot is a Voyage AI proxy
-	// (v0.10.2) — Anthropic has no native embeddings API and points
-	// users at Voyage. The operator yaml stays `provider: anthropic`
-	// for ergonomics, but the underlying auth is the separate
-	// VOYAGE_API_KEY env var routed to cfg.Env.VoyageAPIKey.
-	//
-	// Providers with no case here (`stub`) fall through with both empty:
-	// the driver's own default endpoint, keyless.
 	var apiKey, baseURL string
-	switch provider {
-	case "openai":
-		apiKey, baseURL = cfg.Env.OpenAIAPIKey, ""
-	case "gemini":
-		apiKey, baseURL = cfg.Env.GeminiAPIKey, cfg.Env.GeminiBaseURL
-	case "anthropic":
-		apiKey, baseURL = cfg.Env.VoyageAPIKey, ""
+
+	if provider == "anthropic" {
+		// EXCEPTION — the only provider that does NOT share its chat account.
+		// The `anthropic` embedder slot is a Voyage AI proxy (v0.10.2):
+		// Anthropic has no native embeddings API and points users at Voyage.
+		// The operator yaml stays `provider: anthropic` for ergonomics, but the
+		// service is a different vendor, so it must inherit NEITHER half of the
+		// `providers: anthropic:` entry — an Anthropic proxy base_url would
+		// receive Voyage requests, and ANTHROPIC_API_KEY would be sent to
+		// Voyage. Auth is the separate VOYAGE_API_KEY.
+		apiKey = cfg.Env.VoyageAPIKey
 		if apiKey == "" {
 			log.Printf("memory.embedder: provider=anthropic uses Voyage AI; set VOYAGE_API_KEY or Embed() calls will fail at 401")
 		}
-	case "ollama-local":
-		// Inherits the SAME OLLAMA_BASE_URL the chat driver uses, so one
-		// setting serves both. "disabled" is the chat side's opt-out
-		// sentinel (providerEnabled), not an endpoint — treat it as unset
-		// so the embedder falls back to the driver default rather than
-		// trying to dial a host literally named "disabled". Keyless.
-		if cfg.Env.OllamaBaseURL != "disabled" {
-			baseURL = cfg.Env.OllamaBaseURL
+	} else {
+		// Every other embedder hits the same account and endpoint as its chat
+		// twin, so it resolves through the chat path's own resolver rather than
+		// a second copy of the switch that drifted from it once already.
+		var keyEnvName string
+		baseURL, apiKey, keyEnvName = providerbuild.ProviderEndpoint(cfg, provider)
+
+		// "disabled" is the chat side's opt-out sentinel (providerEnabled), not
+		// an endpoint — treat it as unset so the embedder falls back to the
+		// driver default rather than dialing a host literally named "disabled".
+		if baseURL == "disabled" {
+			baseURL = ""
 		}
-	case "ollama":
-		// Hosted ollama.com — same pair the chat provider reads.
-		apiKey, baseURL = cfg.Env.OllamaAPIKey, cfg.Env.OllamaCloudBaseURL
+
+		// The per-id env key stays the LAST resort, for a deployment that runs
+		// with no `providers:` block (LOOMCYCLE_NO_DEFAULT_PROVIDERS=1) and so
+		// declares no api_key_env. It cannot be dropped as dead code: the openai
+		// embedder accepts an empty key at construction and only fails later at
+		// 401, so losing this fallback would trade a working embedder for a
+		// runtime auth error rather than a startup one.
+		if apiKey == "" && keyEnvName == "" {
+			switch provider {
+			case "openai":
+				apiKey = cfg.Env.OpenAIAPIKey
+			case "gemini":
+				apiKey = cfg.Env.GeminiAPIKey
+			case "ollama":
+				apiKey = cfg.Env.OllamaAPIKey
+			}
+		}
 	}
 
-	// The operator's explicit yaml WINS over the per-provider defaults
-	// above — that is the whole point of the two knobs. base_url points
-	// any driver at a self-hosted endpoint (Ollama, vLLM, LocalAI, an
-	// OpenAI-compatible gateway); api_key_env re-points the credential
-	// at the operator's own env var, mirroring the `providers:` map
-	// convention (a NAME, resolved here; the value never appears in
-	// yaml). An empty-valued var is not a silent fallback to the host
-	// key: naming it is an explicit choice, so it wins either way.
+	// The embedder's OWN yaml block wins over everything resolved above —
+	// that is the whole point of the two knobs, and it is what lets the
+	// embedder diverge from its chat twin on purpose (a dedicated embedding
+	// host, or a different key on the same vendor). base_url points any driver
+	// at a self-hosted endpoint (Ollama, vLLM, LocalAI, an OpenAI-compatible
+	// gateway); api_key_env names the operator's own env var (a NAME, resolved
+	// here; the value never appears in yaml). An empty-valued var is not a
+	// silent fallback to the provider key: naming it is an explicit choice, so
+	// it wins either way.
 	if cfg.Memory.Embedder.BaseURL != "" {
 		baseURL = cfg.Memory.Embedder.BaseURL
 	}

--- a/internal/providerbuild/providerbuild.go
+++ b/internal/providerbuild/providerbuild.go
@@ -65,7 +65,7 @@ func Provider(cfg *config.Config, id string) (providers.Provider, error) {
 // KeyEnvName come from api_key_env (RFC AR per-tenant override). StreamOpts +
 // Options carry the per-provider timeouts and ollama num_ctx/num_gpu.
 func DriverOptions(id string, pc config.ProviderConfig, cfg *config.Config) providers.DriverOptions {
-	baseURL := pc.BaseURL
+	baseURL := resolveBaseURL(id, pc, cfg)
 	stream := streamhttp.Options{
 		HeaderTimeout: cfg.Env.ProviderHeaderTimeout,
 		IdleTimeout:   cfg.Env.ProviderIdleTimeout,
@@ -73,16 +73,10 @@ func DriverOptions(id string, pc config.ProviderConfig, cfg *config.Config) prov
 	opts := map[string]any{}
 	switch id {
 	case "ollama": // hosted ollama.com
-		if baseURL == "" {
-			baseURL = cfg.Env.OllamaCloudBaseURL
-		}
 		if cfg.Env.OllamaNumCtx > 0 {
 			opts["num_ctx"] = cfg.Env.OllamaNumCtx
 		}
 	case "ollama-local":
-		if baseURL == "" {
-			baseURL = cfg.Env.OllamaBaseURL
-		}
 		// Local Ollama is slow on first-token (cold model load + large-context
 		// eval), so it gets its own, more generous timeout pair.
 		stream = streamhttp.Options{
@@ -94,14 +88,6 @@ func DriverOptions(id string, pc config.ProviderConfig, cfg *config.Config) prov
 		}
 		if cfg.Env.OllamaLocalNumGpu > 0 {
 			opts["num_gpu"] = cfg.Env.OllamaLocalNumGpu
-		}
-	case "deepseek":
-		if baseURL == "" {
-			baseURL = cfg.Env.DeepSeekBaseURL
-		}
-	case "gemini":
-		if baseURL == "" {
-			baseURL = cfg.Env.GeminiBaseURL
 		}
 	case "code-js":
 		// RFC BF P2a regression fix (b8d3f42d line): the code-js driver factory
@@ -196,4 +182,47 @@ func CapabilityPatch(o *config.CapabilityOverride) *providers.CapabilityPatch {
 		ParallelToolCalls: o.ParallelToolCalls,
 		MaxContextTokens:  o.MaxContextTokens,
 	}
+}
+
+// resolveBaseURL is the ONE place a provider id's endpoint is decided: the
+// operator's `providers:` entry wins, and the per-id env default fills in only
+// when that entry leaves base_url empty.
+//
+// It is a named function rather than inline switch arms because the memory
+// EMBEDDER resolves the same endpoint for the same provider account, and the two
+// copies drifted: the chat side preferred pc.BaseURL while the embedder read
+// cfg.Env.OllamaBaseURL ONLY. Observed live — chat reached a newly-installed
+// Ollama host through `providers: ollama-local: base_url:` while the embedder
+// stayed on the env var pointing at a name the container could not resolve, so
+// memory kept accepting writes and quietly stopped being semantic (108 fact
+// rows, ~0 embeddings; the benchmark that surfaced it read as a bad extractor).
+// Both callers now share this function.
+func resolveBaseURL(id string, pc config.ProviderConfig, cfg *config.Config) string {
+	if pc.BaseURL != "" {
+		return pc.BaseURL
+	}
+	switch id {
+	case "ollama": // hosted ollama.com
+		return cfg.Env.OllamaCloudBaseURL
+	case "ollama-local":
+		return cfg.Env.OllamaBaseURL
+	case "deepseek":
+		return cfg.Env.DeepSeekBaseURL
+	case "gemini":
+		return cfg.Env.GeminiBaseURL
+	}
+	return ""
+}
+
+// ProviderEndpoint resolves the base URL and credential for provider id with the
+// SAME precedence the chat drivers use, for a non-chat consumer that hits the
+// same provider account (today: the memory embedder).
+//
+// keyEnvName is returned alongside apiKey so a caller can report WHICH env var it
+// resolved without echoing the secret. An id absent from cfg.Providers is not an
+// error: it yields the zero ProviderConfig, so the per-id env defaults still
+// apply and a config with no `providers:` block behaves as it did before.
+func ProviderEndpoint(cfg *config.Config, id string) (baseURL, apiKey, keyEnvName string) {
+	pc := cfg.Providers[id]
+	return resolveBaseURL(id, pc, cfg), os.Getenv(pc.APIKeyEnv), pc.APIKeyEnv
 }


### PR DESCRIPTION
## Why

Repointing `ollama-local` at a new Ollama host the documented way — `providers: ollama-local: base_url:` in `loomcycle.yaml` — moved **chat** but not the **embedder**. `providerbuild` prefers the map entry; the embedder read `cfg.Env.OllamaBaseURL` *only*. So the two halves of one provider account resolved to different endpoints.

Observed live on the TrueNAS instance: chat reached a newly-installed box and billed 50 calls, while every embed failed with

```
ollama /api/embed: Post "http://<host>:11434/api/embed": dial tcp:
lookup <host> on 127.0.0.11:53: no such host
```

The env var named a Tailscale MagicDNS host, which does not resolve against Docker's embedded DNS inside the container.

An embed failure **warns but does not fail the write** — by design: the k/v row is kept and the response carries `embedded:false` + `embed_warning`. A caller that ignores that field simply accumulates unembedded rows. A live scope reached **108 fact rows with ~0 embeddings**, `/v1/_memory/search` 500'd, and the LoCoMo arm that surfaced it read as a bad extractor rather than a dead embedder. The tell was that `backfill_embeddings` failed in **25 ms** — too fast to have dialled anything.

## What

The two copies of the per-provider base-URL switch are now **one function**, `resolveBaseURL`, shared by `DriverOptions` and a new `ProviderEndpoint` that the embedder calls. Precedence, highest first:

```
memory.embedder.base_url  >  providers.<id>.base_url  >  the per-id env default
```

YAML is the config home; the env var is only the floor. **Chat resolution is unchanged** — byte-identical inputs to every driver factory (`TestToDriverOptions_PortsEnvBaseURLsAndTimeouts` still passes).

Two deliberate carve-outs, both covered by tests:

- **`anthropic` inherits neither half of its chat entry.** That embedder slot is a Voyage AI proxy, so an Anthropic proxy `base_url` would receive Voyage requests and `ANTHROPIC_API_KEY` would be sent to Voyage.
- **The per-id env KEY stays the last resort**, for a deployment with no `providers:` block (`LOOMCYCLE_NO_DEFAULT_PROVIDERS=1`). Not dead code: the openai embedder accepts an empty key at construction and only fails later at 401, so dropping it would trade a working embedder for a runtime auth error.

Docs: `docs/TOOLS.md` gets the corrected precedence chain plus the one-call diagnosis (`PUT …?embed=true` and read `embed_warning` — it names the endpoint *and* the error); the `local` preset notes that one `base_url` now moves chat and embeddings together.

## What was tested

- **`TestEmbedderConfig_OllamaLocalResolvesTheProvidersMapBaseURL`** — the regression. Verified failing on the unfixed code: the request lands on the env server and the declared yaml host gets zero (`providers: yaml base_url got 0 requests and the env default got 1`).
- `TestEmbedderConfig_EmbedderYamlBeatsTheProvidersMap` — the embedder's own block stays top of the chain, so embeddings can diverge from chat on purpose.
- `TestEmbedderConfig_ProvidersMapApiKeyEnvIsHonoured` — a renamed credential (RFC AR) is honoured; also fails on the unfixed code.
- `TestEmbedderConfig_NoProvidersBlockStillUsesTheEnvKey` — the last-resort key fallback.
- `TestEmbedderConfig_AnthropicDoesNotInheritTheChatProviderEntry` — the Voyage carve-out.

Asserted end-to-end (config → `Build` → driver → wire) because the endpoint is unexported on every driver, so *which stub receives the request* is the only observable.

Also: full `go test ./...` clean (99 packages, 0 failures); `loomcycle validate` OK across the `base`, `base,local` and `base,local,memory` preset stacks.

## Note for the operator

If the embedder endpoint is set via `memory.embedder.base_url` rather than the env var, that still wins by design — remove it to inherit the `providers:` entry. Either way the address must be one the **container** can resolve: prefer the tailnet IP or a compose service name over a MagicDNS name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8