### PR TITLE
fix(memory): ask the extractor for the time on the path that has one

### DIFF
--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -1000,29 +1000,43 @@ agents:
         // The date goes BEFORE the transcript and outside its delimiters: it is
         // ours, not the transcript's, and a date inside the data would be one more
         // thing a hostile transcript could try to restate.
-        // The temporal rule lives HERE, in the per-call prompt, and only when a date
-        // actually exists — NOT in the system prompt. Three reasons, all measured:
+        // The temporal rule lives HERE, in the per-call prompt, NOT in the system
+        // prompt. Two reasons, both still current:
         //
         //   1. The system prompt has a 2600-char ceiling that sits deliberately below
-        //      a 3,055-char prompt observed to come back EMPTY. This rule is ~1.2k;
+        //      a 3,055-char prompt observed to come back EMPTY. This rule is ~1.4k;
         //      adding it there would push the extractor past a known breaking point.
         //   2. The recorded extraction baselines are keyed by the SYSTEM prompt's
         //      digest, so editing it ungates every stored score until someone spends
-        //      a live eval re-measuring them. This costs nothing.
-        //   3. A chat with no date cannot use the rule, and half the calls have none
-        //      (the queued-batch path never does). Paying for it there would be tokens
-        //      spent to tell a model about a field it must not fill in.
-        var dateLine = "";
-        if (when) {
-          dateLine =
-            "This conversation took place on " + String(when) + ".\n" +
-            "If a fact is dated RELATIVE to that (\"yesterday\", \"last week\", \"since March\"), " +
-            "resolve it and add \"valid_at\" — plus \"invalid_at\" if it later stopped being " +
-            "true — as full RFC3339 instants (2023-10-03T00:00:00Z). A state still true " +
-            "gets valid_at and no invalid_at. OMIT BOTH when the text gives no such " +
-            "reference: most facts have none, and a guessed date files the fact under a " +
-            "day it did not happen.\n\n";
-        }
+        //      a live eval re-measuring them. Keeping the rule here costs nothing.
+        //
+        // ⚠️ A THIRD REASON USED TO GATE THIS ON `when` BEING PRESENT, AND IT WAS WRONG.
+        // It read: "a chat with no date cannot use the rule, and half the calls have
+        // none (the queued-batch path never does), so paying for it there would be
+        // tokens spent to tell a model about a field it must not fill in." The premise
+        // is false. `when` is the CONVERSATION-level date, and the queued path passes
+        // "" for it — but the turns themselves carry an absolute timestamp in the text
+        // (`[7:56 pm on 7 July, 2023] Dave: …`). So a date was available on exactly the
+        // path the rule was being withheld from, and the extractor was left staring at
+        // a timestamp with no instruction to date the fact. Measured consequence: 0 of
+        // 217 facts across four different extractor models carried ANY temporal field.
+        // The rule is now always emitted, and it names the in-text timestamp as a
+        // source. The omit-when-absent discipline is unchanged — it is what stops a
+        // guessed date, and it is doing the work the removed gate was credited with.
+        var dateLine =
+          "TIMES. Add \"observed_at\" — when the thing was SAID — as a full RFC3339 " +
+          "instant (2023-10-03T19:56:00Z). " +
+          (when
+            ? "This conversation took place on " + String(when) + "; use that unless a " +
+              "turn carries its own timestamp, which always wins over it.\n"
+            : "Read it from the turn's own leading timestamp, e.g. " +
+              "\"[7:56 pm on 7 July, 2023] Dave: …\".\n") +
+          "If a fact is additionally dated RELATIVE to when it was said (\"yesterday\", " +
+          "\"last week\", \"since March\"), resolve it and add \"valid_at\" — when it became " +
+          "true in the world — plus \"invalid_at\" if it later stopped being true. A state " +
+          "still true gets valid_at and no invalid_at.\n" +
+          "OMIT ANY of these you cannot read off the text. Most facts have no valid_at, " +
+          "and a guessed date files the fact under a day it did not happen.\n\n";
         // WHOSE memory this is — BY NAME, or not at all.
         //
         // ⚠️ THE EARLIER VERSION OF THIS WAS WORSE THAN NOTHING, and a live run proved it.
@@ -1101,8 +1115,13 @@ agents:
           var va = tsOrEmpty(f.valid_at), iva = tsOrEmpty(f.invalid_at);
           if (va && iva && iva <= va) { va = ""; iva = ""; st.interval_dropped++; }
           if (!va) { iva = ""; }
+          // observed_at is WHEN IT WAS SAID and is independent of the validity
+          // interval: a fact with no world-time still has an utterance time, which is
+          // what `Memory when=` narrows on. Validated by the same RFC3339-or-nothing
+          // rule and carried separately, so a dropped interval never takes it with it.
+          var oa = tsOrEmpty(f.observed_at);
           out.push({ text: text, cls: cls, type: typ, subject: subj, quote: "",
-                     valid_at: va, invalid_at: iva });
+                     observed_at: oa, valid_at: va, invalid_at: iva });
         }
         return out;
       }
@@ -1653,6 +1672,11 @@ agents:
           args.valid_at = fact.valid_at;
           if (fact.invalid_at) { args.invalid_at = fact.invalid_at; }
         }
+        // WHEN IT WAS SAID. Set independently of valid_at — `Memory set` has taken
+        // observed_at since the temporal tier shipped, and it is what a `when` window
+        // matches against, so a fact that carries only an utterance time is still
+        // findable by time. Omitted when the extractor could not read one.
+        if (fact.observed_at) { args.observed_at = fact.observed_at; }
         // A fact distilled from a QUEUED item relays that item's id so the server
         // resolves its origin + source ids from the pending row. We cannot author
         // origin ourselves — it is server-stamped precisely so an agent cannot

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -1000,29 +1000,43 @@ agents:
         // The date goes BEFORE the transcript and outside its delimiters: it is
         // ours, not the transcript's, and a date inside the data would be one more
         // thing a hostile transcript could try to restate.
-        // The temporal rule lives HERE, in the per-call prompt, and only when a date
-        // actually exists — NOT in the system prompt. Three reasons, all measured:
+        // The temporal rule lives HERE, in the per-call prompt, NOT in the system
+        // prompt. Two reasons, both still current:
         //
         //   1. The system prompt has a 2600-char ceiling that sits deliberately below
-        //      a 3,055-char prompt observed to come back EMPTY. This rule is ~1.2k;
+        //      a 3,055-char prompt observed to come back EMPTY. This rule is ~1.4k;
         //      adding it there would push the extractor past a known breaking point.
         //   2. The recorded extraction baselines are keyed by the SYSTEM prompt's
         //      digest, so editing it ungates every stored score until someone spends
-        //      a live eval re-measuring them. This costs nothing.
-        //   3. A chat with no date cannot use the rule, and half the calls have none
-        //      (the queued-batch path never does). Paying for it there would be tokens
-        //      spent to tell a model about a field it must not fill in.
-        var dateLine = "";
-        if (when) {
-          dateLine =
-            "This conversation took place on " + String(when) + ".\n" +
-            "If a fact is dated RELATIVE to that (\"yesterday\", \"last week\", \"since March\"), " +
-            "resolve it and add \"valid_at\" — plus \"invalid_at\" if it later stopped being " +
-            "true — as full RFC3339 instants (2023-10-03T00:00:00Z). A state still true " +
-            "gets valid_at and no invalid_at. OMIT BOTH when the text gives no such " +
-            "reference: most facts have none, and a guessed date files the fact under a " +
-            "day it did not happen.\n\n";
-        }
+        //      a live eval re-measuring them. Keeping the rule here costs nothing.
+        //
+        // ⚠️ A THIRD REASON USED TO GATE THIS ON `when` BEING PRESENT, AND IT WAS WRONG.
+        // It read: "a chat with no date cannot use the rule, and half the calls have
+        // none (the queued-batch path never does), so paying for it there would be
+        // tokens spent to tell a model about a field it must not fill in." The premise
+        // is false. `when` is the CONVERSATION-level date, and the queued path passes
+        // "" for it — but the turns themselves carry an absolute timestamp in the text
+        // (`[7:56 pm on 7 July, 2023] Dave: …`). So a date was available on exactly the
+        // path the rule was being withheld from, and the extractor was left staring at
+        // a timestamp with no instruction to date the fact. Measured consequence: 0 of
+        // 217 facts across four different extractor models carried ANY temporal field.
+        // The rule is now always emitted, and it names the in-text timestamp as a
+        // source. The omit-when-absent discipline is unchanged — it is what stops a
+        // guessed date, and it is doing the work the removed gate was credited with.
+        var dateLine =
+          "TIMES. Add \"observed_at\" — when the thing was SAID — as a full RFC3339 " +
+          "instant (2023-10-03T19:56:00Z). " +
+          (when
+            ? "This conversation took place on " + String(when) + "; use that unless a " +
+              "turn carries its own timestamp, which always wins over it.\n"
+            : "Read it from the turn's own leading timestamp, e.g. " +
+              "\"[7:56 pm on 7 July, 2023] Dave: …\".\n") +
+          "If a fact is additionally dated RELATIVE to when it was said (\"yesterday\", " +
+          "\"last week\", \"since March\"), resolve it and add \"valid_at\" — when it became " +
+          "true in the world — plus \"invalid_at\" if it later stopped being true. A state " +
+          "still true gets valid_at and no invalid_at.\n" +
+          "OMIT ANY of these you cannot read off the text. Most facts have no valid_at, " +
+          "and a guessed date files the fact under a day it did not happen.\n\n";
         // WHOSE memory this is — BY NAME, or not at all.
         //
         // ⚠️ THE EARLIER VERSION OF THIS WAS WORSE THAN NOTHING, and a live run proved it.
@@ -1101,8 +1115,13 @@ agents:
           var va = tsOrEmpty(f.valid_at), iva = tsOrEmpty(f.invalid_at);
           if (va && iva && iva <= va) { va = ""; iva = ""; st.interval_dropped++; }
           if (!va) { iva = ""; }
+          // observed_at is WHEN IT WAS SAID and is independent of the validity
+          // interval: a fact with no world-time still has an utterance time, which is
+          // what `Memory when=` narrows on. Validated by the same RFC3339-or-nothing
+          // rule and carried separately, so a dropped interval never takes it with it.
+          var oa = tsOrEmpty(f.observed_at);
           out.push({ text: text, cls: cls, type: typ, subject: subj, quote: "",
-                     valid_at: va, invalid_at: iva });
+                     observed_at: oa, valid_at: va, invalid_at: iva });
         }
         return out;
       }
@@ -1653,6 +1672,11 @@ agents:
           args.valid_at = fact.valid_at;
           if (fact.invalid_at) { args.invalid_at = fact.invalid_at; }
         }
+        // WHEN IT WAS SAID. Set independently of valid_at — `Memory set` has taken
+        // observed_at since the temporal tier shipped, and it is what a `when` window
+        // matches against, so a fact that carries only an utterance time is still
+        // findable by time. Omitted when the extractor could not read one.
+        if (fact.observed_at) { args.observed_at = fact.observed_at; }
         // A fact distilled from a QUEUED item relays that item's id so the server
         // resolves its origin + source ids from the pending row. We cannot author
         // origin ourselves — it is server-stamped precisely so an agent cannot

--- a/cmd/loomcycle/presets_memory_temporal_test.go
+++ b/cmd/loomcycle/presets_memory_temporal_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The temporal regressions for RFC CW Probe 1.
+//
+// The bi-temporal columns (`observed_at`, `valid_at`, `invalid_at`) existed and were
+// EMPTY in every stored fact — 0 of 217 across four different extractor models. The
+// cause was not the model and not the schema: the per-call temporal rule that ASKS for
+// those fields was gated on a conversation-level `when`, and the queued path passes "".
+// So on the path that `Memory op=add` feeds — the benchmark's and the product's — the
+// rule was never emitted, while the date sat in the turn text the whole time.
+
+// TestConsolidator_QueuedBatchStillAsksForTheTime is the regression. A queued batch has
+// no conversation-level date, which is exactly when the rule used to be withheld.
+//
+// FAILS on the unfixed bundle: the extractor prompt for the queued batch carries no
+// temporal instruction at all.
+func TestConsolidator_QueuedBatchStillAsksForTheTime(t *testing.T) {
+	f := newFakeToolset()
+	f.sessions = nil // no chats — the queued batch is the only extraction this pass
+	f.pending = []map[string]any{{
+		"id": "pend-1",
+		"payload": map[string]any{"messages": []any{
+			map[string]any{"role": "user", "content": "[7:56 pm on 7 July, 2023] Dave: I moved to Berlin last month."},
+		}},
+	}}
+	f.factsJSON = `[{"text":"Dave moved to Berlin.","class":"fact"}]`
+
+	runConsolidator(t, f)
+
+	spawn := lastCall(t, f, "Agent")
+	prompt, _ := spawn.Input["prompt"].(string)
+	if !strings.Contains(prompt, "observed_at") {
+		t.Errorf("the queued-batch extraction prompt never asks for observed_at, so no fact from "+
+			"`Memory op=add` can ever be dated; prompt = %q", prompt)
+	}
+	if !strings.Contains(prompt, "[7:56 pm on 7 July, 2023]") && !strings.Contains(prompt, "leading timestamp") {
+		t.Errorf("the prompt does not tell the extractor to read the turn's own timestamp, which is "+
+			"the only date available on this path; prompt = %q", prompt)
+	}
+}
+
+// TestConsolidator_ObservedAtReachesTheWrite — the field has to survive the validator
+// and land on the write, or asking for it changes nothing.
+//
+// FAILS on the unfixed bundle: validateFacts builds its output object without
+// observed_at, so the extractor's value is silently dropped before the write.
+func TestConsolidator_ObservedAtReachesTheWrite(t *testing.T) {
+	f := newFakeToolset()
+	f.bands = map[string]any{"merge_threshold": 0.90, "related_threshold": 0.50}
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	f.transcript = "user: I moved to Berlin.\nassistant: ok"
+	f.factsJSON = `[{"text":"Dave moved to Berlin.","class":"fact","observed_at":"2023-07-07T19:56:00Z"}]`
+
+	runConsolidator(t, f)
+
+	set := lastCall(t, f, "Memory.set")
+	got, _ := set.Input["observed_at"].(string)
+	if got != "2023-07-07T19:56:00Z" {
+		t.Errorf("Memory.set observed_at = %q, want the extractor's value to reach the write "+
+			"(input keys: %v)", got, keysOf(set.Input))
+	}
+}
+
+// TestConsolidator_ObservedAtIsIndependentOfTheValidityInterval. A reversed interval is
+// dropped while the FACT is kept — the standing rule. observed_at must not be collateral:
+// "when it was said" is a different claim from "when it was true", and it is what a
+// `Memory when=` window matches on, so losing it would make the fact untimed.
+func TestConsolidator_ObservedAtIsIndependentOfTheValidityInterval(t *testing.T) {
+	f := newFakeToolset()
+	f.bands = map[string]any{"merge_threshold": 0.90, "related_threshold": 0.50}
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	f.transcript = "user: I moved to Berlin.\nassistant: ok"
+	// invalid_at <= valid_at: the interval is refused, the fact survives.
+	f.factsJSON = `[{"text":"Dave moved to Berlin.","class":"fact",` +
+		`"observed_at":"2023-07-07T19:56:00Z",` +
+		`"valid_at":"2023-06-01T00:00:00Z","invalid_at":"2023-05-01T00:00:00Z"}]`
+
+	runConsolidator(t, f)
+
+	set := lastCall(t, f, "Memory.set")
+	if got, _ := set.Input["observed_at"].(string); got != "2023-07-07T19:56:00Z" {
+		t.Errorf("observed_at = %q, want it to survive a refused validity interval", got)
+	}
+	if _, ok := set.Input["valid_at"]; ok {
+		t.Errorf("valid_at was written despite being a reversed interval: %v", set.Input["valid_at"])
+	}
+}
+
+// TestConsolidator_ANonRFC3339TimeIsRefusedNotCoerced. tsOrEmpty accepts only a full
+// instant, and observed_at joins that rule: half a timestamp guessed into a whole one is
+// the wrong-date failure the field exists to avoid.
+func TestConsolidator_ANonRFC3339TimeIsRefusedNotCoerced(t *testing.T) {
+	f := newFakeToolset()
+	f.bands = map[string]any{"merge_threshold": 0.90, "related_threshold": 0.50}
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	f.transcript = "user: I moved to Berlin.\nassistant: ok"
+	f.factsJSON = `[{"text":"Dave moved to Berlin.","class":"fact","observed_at":"July 2023"}]`
+
+	runConsolidator(t, f)
+
+	set := lastCall(t, f, "Memory.set")
+	if v, ok := set.Input["observed_at"]; ok {
+		t.Errorf("observed_at = %v, want the prose date REFUSED and the field omitted entirely", v)
+	}
+	if value, _ := set.Input["value"].(string); value != "Dave moved to Berlin." {
+		t.Errorf("stored value = %q, want the fact kept — a good fact with a bad date is still a good fact", value)
+	}
+}
+
+// keysOf is a failure-message helper: naming the keys that ARE present turns "want
+// observed_at" into a diagnosis of what the write actually carried.
+func keysOf(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
RFC CW **Probe 1**. Revised on 2026-09-07 from "add a temporal rule" to "date plumbing" once the mechanism was actually read — the rule already existed.

## Why

The bi-temporal columns were empty in **every** stored fact — **0 of 217** across four different extractor models (qwen3.6, qwen3.8, mistral-medium-3.5, deepseek-v4-flash). It was neither the model nor the schema.

The per-call rule that *asks* for the temporal fields was gated on a conversation-level `when`, and the queued path passes `""` — `extract(st, pendingText, "", "")`. So on the path `Memory op=add` feeds, which is both the benchmark's and the product's, **the rule was never emitted at all**. Meanwhile the date was in the turn text the whole time: `[7:56 pm on 7 July, 2023] Dave: …`.

The gate's own comment named the reason, and the reason was false: *"a chat with no date cannot use the rule, and half the calls have none (the queued-batch path never does)."* `when` is the **conversation's** date; the **turn's** date is a different thing, and it was present. That comment is now rewritten to record why the gate was wrong, so the next reader doesn't restore it.

The fail-before output shows the whole bug in one string — the unfixed prompt contains the transcript's `[7:56 pm on 7 July, 2023]` with no temporal instruction anywhere.

## What

Three changes, all in the bundle, **no wire change**:

- The temporal rule is **always** emitted; with no conversation date it names the turn's own leading timestamp as the source to read.
- **`observed_at`** (when it was *said*) is requested, distinct from `valid_at` (when it became *true*). It goes in the per-call rule, not the system prompt — that prompt has a 2600-char ceiling below an observed empty-response cliff, and its digest gates the recorded extraction baselines, so editing it would ungate every stored score.
- `observed_at` is carried through `validateFacts` and onto the write. `Memory set` has accepted the field since the temporal tier shipped.

A per-turn timestamp now **wins over** the conversation-level date. That also fixes a latent wrong-anchor bug: the chat path passes `row.completed_at`, loomcycle's *own* session time — for an imported or replayed corpus that's the ingest date, not the conversation's, so relative dates resolved against the wrong day.

The omit-when-absent discipline is untouched. It's what stops a guessed date, and it's doing the work the removed gate was credited with.

## What was tested

4 cases in `cmd/loomcycle/presets_memory_temporal_test.go`:

- **`QueuedBatchStillAsksForTheTime`** — regression; the queued batch is exactly the case the rule was withheld from. Fails unfixed.
- **`ObservedAtReachesTheWrite`** — regression; the field has to survive the validator or asking changes nothing. Fails unfixed (`input keys: [key op provenance scope value embed embed_text]`).
- `ObservedAtIsIndependentOfTheValidityInterval` — a refused interval must not take `observed_at` with it; "when it was said" is a different claim from "when it was true", and it's what a `when` window matches on.
- `ANonRFC3339TimeIsRefusedNotCoerced` — a prose date is refused, the fact kept.

Also: full `go test ./...` clean (99 packages); `loomcycle validate` OK on `base,memory` and `base,local,memory`; embedded bundle copy re-synced (a drift test enforces it).

## Note

This changes what the extractor is *asked* for. Whether it moves the temporal slice is Probe 1's measurement, not this PR's claim — and per the RFC, if temporal does **not** move now that the rule reaches the model with a date in hand, the premise behind ~25 of the 50 points is wrong and needs re-arguing. The three-model result already rules out "the model can't do it".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8