### PR TITLE
feat(path): paginate op=ls with a limit and an opaque cursor

### DIFF
--- a/adapters/ts/src/types.ts
+++ b/adapters/ts/src/types.ts
@@ -1466,6 +1466,12 @@ export type PathToolInput = {
   recursive?: boolean;
   /** ls: only entries of this kind (document/volume_mount/memory_entry/directory). */
   kind_filter?: string;
+  /** ls: maximum entries to return (default 500, max 5000). A truncated listing
+   *  reports `truncated: true` and a `next_cursor`; pass that back as `cursor`. */
+  limit?: number;
+  /** ls: continue a truncated listing with the previous response's `next_cursor`.
+   *  Opaque — its encoding is not part of the contract, so do not construct one. */
+  cursor?: string;
   /** rm: also delete the backing resource (NOT supported in v1). */
   resource_too?: boolean;
   [extra: string]: unknown;

--- a/internal/tools/builtin/pathtool.go
+++ b/internal/tools/builtin/pathtool.go
@@ -2,6 +2,7 @@ package builtin
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -49,6 +50,8 @@ const pathInputSchema = `{
 		"scope":         {"type": "string", "enum": ["agent","user","tenant"], "description": "Which tree (default agent). user requires a user_id on the run; tenant is shared across the tenant."},
 		"recursive":     {"type": "boolean", "description": "ls: list all descendants. rm: required to remove a path that has descendants."},
 		"kind_filter":   {"type": "string", "description": "ls: only entries of this kind (document/volume_mount/memory_entry/directory)."},
+		"limit":         {"type": "integer", "minimum": 1, "description": "ls: maximum entries to return (default 500, max 5000). A truncated listing reports truncated:true and a next_cursor — pass that back as the cursor field to continue. Subject-homed facts make a directory as large as the tenant's entity count, so a listing has to be pageable rather than whole."},
+		"cursor":        {"type": "string", "description": "ls: continue a truncated listing — pass the next_cursor from the previous response. Opaque: its encoding is not part of the contract, so do not construct one."},
 		"resource_too":  {"type": "boolean", "description": "rm: also delete the backing resource. NOT supported in v1 (dirent-only removal)."}
 	},
 	"required": ["op"]
@@ -64,6 +67,8 @@ type pathInput struct {
 	Recursive   bool   `json:"recursive"`
 	KindFilter  string `json:"kind_filter"`
 	ResourceToo bool   `json:"resource_too"`
+	Limit       int    `json:"limit"`
+	Cursor      string `json:"cursor"`
 }
 
 func (p *Path) Execute(ctx context.Context, raw json.RawMessage) (tools.Result, error) {
@@ -180,7 +185,11 @@ func (p *Path) ls(ctx context.Context, tenantID, scope, scopeID string, in pathI
 			}
 			entries = append(entries, pathEntry{Name: r.Name, Kind: r.Kind, FullPath: r.ParentPath + r.Name, ResourceRef: r.ResourceRef})
 		}
-		return jsonResult(map[string]any{"path": canonical, "entries": entries})
+		// A recursive listing is flat, so FULL PATH is its identity — names repeat
+		// across directories. Sorting here is not cosmetic: it is what makes the
+		// cursor a stable position rather than a bet on the store's row order.
+		sort.Slice(entries, func(i, j int) bool { return entries[i].FullPath < entries[j].FullPath })
+		return lsPage(canonical, entries, in, func(e pathEntry) string { return e.FullPath })
 	}
 
 	// One-level ls. Directories are IMPLICIT (S3-style, RFC AL): a document at
@@ -230,7 +239,71 @@ func (p *Path) ls(ctx context.Context, tenantID, scope, scopeID string, in pathI
 		}
 	}
 	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
-	return jsonResult(map[string]any{"path": canonical, "entries": entries})
+	return lsPage(canonical, entries, in, func(e pathEntry) string { return e.Name })
+}
+
+// lsDefaultLimit / lsMaxLimit bound a listing's RESPONSE.
+//
+// WHY A DEFAULT AT ALL, given it changes what an existing caller receives: a
+// subject-homed fact store makes a directory exactly as large as the tenant's
+// entity count, so `ls /facts` on a ten-thousand-subject tenant returned ten
+// thousand entries in one response. Postgres serves that; an agent's context
+// window does not. The truncation is REPORTED (truncated + next_cursor) rather
+// than silent, which is the difference between a bound and a lie.
+const (
+	lsDefaultLimit = 500
+	lsMaxLimit     = 5000
+)
+
+// lsPage applies the cursor and the limit to an ALREADY-SORTED slice, and reports
+// how to continue. keyOf names the ordering key — the same value the sort used, or
+// the cursor would point into a different order than the one it was issued from.
+//
+// The cursor is the last emitted key, base64url-encoded to keep it opaque: the
+// encoding is deliberately not part of the contract so it can become a composite
+// (or move into the store as a keyset predicate) without a wire change. It is a
+// POSITION, not an offset, so entries created before it do not shift the page.
+func lsPage(canonical string, entries []pathEntry, in pathInput, keyOf func(pathEntry) string) (tools.Result, error) {
+	if in.Cursor != "" {
+		after, err := decodeLsCursor(in.Cursor)
+		if err != nil {
+			return errResult("ls: " + err.Error()), nil
+		}
+		i := sort.Search(len(entries), func(i int) bool { return keyOf(entries[i]) > after })
+		entries = entries[i:]
+	}
+	limit := in.Limit
+	if limit <= 0 {
+		limit = lsDefaultLimit
+	}
+	if limit > lsMaxLimit {
+		limit = lsMaxLimit
+	}
+	out := map[string]any{"path": canonical}
+	if len(entries) > limit {
+		page := entries[:limit]
+		out["entries"] = page
+		out["truncated"] = true
+		out["next_cursor"] = encodeLsCursor(keyOf(page[len(page)-1]))
+		return jsonResult(out)
+	}
+	out["entries"] = entries
+	return jsonResult(out)
+}
+
+func encodeLsCursor(key string) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(key))
+}
+
+func decodeLsCursor(cursor string) (string, error) {
+	b, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil {
+		// Named as the caller's mistake rather than echoed back: a hand-built
+		// cursor is the one way to get here, and the fix is to pass the
+		// next_cursor from the previous response verbatim.
+		return "", errors.New("cursor is not a value this tool issued — pass back the next_cursor from the previous response")
+	}
+	return string(b), nil
 }
 
 func (p *Path) stat(ctx context.Context, tenantID, scope, scopeID string, in pathInput) (tools.Result, error) {

--- a/internal/tools/builtin/pathtool_pagination_test.go
+++ b/internal/tools/builtin/pathtool_pagination_test.go
@@ -1,0 +1,202 @@
+package builtin
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// Pagination for `path op=ls` (RFC CV OQ2).
+//
+// A subject-homed fact store makes a directory exactly as large as the tenant's
+// entity count, so `ls /facts` on a ten-thousand-subject tenant returned ten
+// thousand entries in ONE response. The op accepted no limit and no cursor at
+// all, so a caller had no way to ask for less. Postgres serves that listing; an
+// agent's context window does not.
+
+// seedSubjects creates n document dirents directly under one parent, in the
+// fixture's agent scope. Zero-padded names so lexical order is numeric order —
+// these tests are about page boundaries, not sort surprises.
+func seedSubjects(t *testing.T, p *Path, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		seedAgent(t, p.Store, "/facts/", fmt.Sprintf("subj-%04d", i), "document")
+	}
+}
+
+func lsNames(t *testing.T, out map[string]any) (names []string, truncated bool, next string) {
+	t.Helper()
+	if e, ok := out["error"].(string); ok && e != "" {
+		t.Fatalf("ls refused: %s", e)
+	}
+	ents, _ := out["entries"].([]any)
+	for _, e := range ents {
+		m, _ := e.(map[string]any)
+		n, _ := m["name"].(string)
+		names = append(names, n)
+	}
+	truncated, _ = out["truncated"].(bool)
+	next, _ = out["next_cursor"].(string)
+	return names, truncated, next
+}
+
+// TestPathLs_DefaultLimitBoundsTheResponseAndSaysSo is the regression: an
+// unbounded listing is what the RFC found. FAILS on the unfixed tool, which
+// returns all 600 entries and reports no truncation.
+func TestPathLs_DefaultLimitBoundsTheResponseAndSaysSo(t *testing.T) {
+	p, ctx, _ := pathFixture(t)
+	seedSubjects(t, p, 600)
+
+	out, _ := pathExec(t, p, ctx, `{"op":"ls","path":"/facts"}`)
+	names, truncated, next := lsNames(t, out)
+
+	// The default cap is spelled as a literal here, not as lsDefaultLimit, so this
+	// test COMPILES against the pre-pagination tool and fails on its behaviour
+	// (600 entries, no truncation) rather than on a missing identifier. A
+	// fail-before that is really a build error demonstrates nothing.
+	const wantDefaultCap = 500
+	if len(names) != wantDefaultCap {
+		t.Errorf("ls returned %d entries, want the %d default cap — an unbounded listing is what "+
+			"blows the caller's context", len(names), wantDefaultCap)
+	}
+	if !truncated {
+		t.Errorf("truncated flag not set; a bound the caller cannot see is a lie rather than a bound")
+	}
+	if next == "" {
+		t.Errorf("no next_cursor on a truncated listing, so the caller can never reach the rest")
+	}
+}
+
+// TestPathLs_CursorWalksEveryEntryExactlyOnce — the property that makes the
+// directory usable rather than merely bounded.
+func TestPathLs_CursorWalksEveryEntryExactlyOnce(t *testing.T) {
+	p, ctx, _ := pathFixture(t)
+	const total = 250
+	seedSubjects(t, p, total)
+
+	seen := map[string]int{}
+	cursor := ""
+	for pages := 0; ; pages++ {
+		if pages > 20 {
+			t.Fatalf("cursor did not terminate after %d pages — a non-advancing cursor loops forever", pages)
+		}
+		body := `{"op":"ls","path":"/facts","limit":40}`
+		if cursor != "" {
+			body = `{"op":"ls","path":"/facts","limit":40,"cursor":"` + cursor + `"}`
+		}
+		out, _ := pathExec(t, p, ctx, body)
+		names, truncated, next := lsNames(t, out)
+		for _, n := range names {
+			seen[n]++
+		}
+		if !truncated {
+			break
+		}
+		cursor = next
+	}
+	if len(seen) != total {
+		t.Errorf("walked %d distinct entries, want %d — the cursor skipped or lost some", len(seen), total)
+	}
+	for n, c := range seen {
+		if c != 1 {
+			t.Errorf("entry %s returned %d times, want exactly once — a page boundary that repeats "+
+				"an entry makes the walk non-terminating in the caller's eyes", n, c)
+		}
+	}
+}
+
+// TestPathLs_ExplicitLimitIsHonouredAndCapped.
+func TestPathLs_ExplicitLimitIsHonouredAndCapped(t *testing.T) {
+	p, ctx, _ := pathFixture(t)
+	seedSubjects(t, p, 30)
+
+	out, _ := pathExec(t, p, ctx, `{"op":"ls","path":"/facts","limit":10}`)
+	names, truncated, _ := lsNames(t, out)
+	if len(names) != 10 || !truncated {
+		t.Errorf("limit=10 gave %d entries (truncated=%v), want 10 and truncated", len(names), truncated)
+	}
+
+	// Over the max: clamped, not refused — a caller asking for too much gets the
+	// most the tool will give rather than an error it has to special-case.
+	out, _ = pathExec(t, p, ctx, `{"op":"ls","path":"/facts","limit":99999}`)
+	names, truncated, _ = lsNames(t, out)
+	if len(names) != 30 || truncated {
+		t.Errorf("limit over the cap gave %d entries (truncated=%v), want all 30 and no truncation",
+			len(names), truncated)
+	}
+}
+
+// TestPathLs_SmallDirectoryIsUnchanged — the compatibility floor. Below the
+// default cap a listing must look exactly as it did: no truncated flag, no
+// cursor, same entries.
+func TestPathLs_SmallDirectoryIsUnchanged(t *testing.T) {
+	p, ctx, _ := pathFixture(t)
+	seedSubjects(t, p, 3)
+
+	out, _ := pathExec(t, p, ctx, `{"op":"ls","path":"/facts"}`)
+	names, truncated, next := lsNames(t, out)
+	if len(names) != 3 || truncated || next != "" {
+		t.Errorf("small listing = %v truncated=%v next=%q, want the pre-pagination shape exactly",
+			names, truncated, next)
+	}
+}
+
+// TestPathLs_RecursiveListingPaginatesOnFullPath. A recursive listing is flat, so
+// names repeat across directories and only the full path is a stable key. Before
+// this change the recursive branch did not sort at all, so any cursor over it
+// would have been a bet on the store's row order.
+func TestPathLs_RecursiveListingPaginatesOnFullPath(t *testing.T) {
+	p, ctx, _ := pathFixture(t)
+	// The same NAME under two parents — indistinguishable by name alone.
+	for i := 0; i < 40; i++ {
+		seedAgent(t, p.Store, "/facts/a/", fmt.Sprintf("subj-%04d", i), "document")
+		seedAgent(t, p.Store, "/facts/b/", fmt.Sprintf("subj-%04d", i), "document")
+	}
+
+	seen := map[string]int{}
+	cursor := ""
+	for pages := 0; ; pages++ {
+		if pages > 20 {
+			t.Fatalf("recursive cursor did not terminate after %d pages", pages)
+		}
+		body := `{"op":"ls","path":"/facts","recursive":true,"limit":15}`
+		if cursor != "" {
+			body = `{"op":"ls","path":"/facts","recursive":true,"limit":15,"cursor":"` + cursor + `"}`
+		}
+		out, _ := pathExec(t, p, ctx, body)
+		if e, ok := out["error"].(string); ok && e != "" {
+			t.Fatalf("recursive ls refused: %s", e)
+		}
+		ents, _ := out["entries"].([]any)
+		for _, e := range ents {
+			m, _ := e.(map[string]any)
+			fp, _ := m["full_path"].(string)
+			seen[fp]++
+		}
+		truncated, _ := out["truncated"].(bool)
+		if !truncated {
+			break
+		}
+		cursor, _ = out["next_cursor"].(string)
+	}
+	if len(seen) != 80 {
+		t.Errorf("walked %d distinct full paths, want 80 — paginating a flat listing on NAME would "+
+			"collapse the two directories' identical names", len(seen))
+	}
+}
+
+// TestPathLs_AHandBuiltCursorIsRefused. The cursor is opaque so its encoding can
+// change (or move into the store as a keyset predicate) without a wire change —
+// which only holds if a caller cannot successfully invent one.
+func TestPathLs_AHandBuiltCursorIsRefused(t *testing.T) {
+	p, ctx, _ := pathFixture(t)
+	seedSubjects(t, p, 5)
+
+	_, res := pathExec(t, p, ctx, `{"op":"ls","path":"/facts","cursor":"subj-0002"}`)
+	if !res.IsError {
+		t.Fatalf("a hand-built cursor was ACCEPTED; the cursor is only opaque if one cannot be invented")
+	}
+	if !strings.Contains(res.Text, "not a value this tool issued") {
+		t.Errorf("refusal = %q, want it to name the fix (pass back next_cursor verbatim)", res.Text)
+	}
+}


### PR DESCRIPTION
RFC CV **OQ2**, decided 2026-09-08.

## Why

`path op=ls` accepted **no limit and no cursor** — a caller had no way to ask for less than the whole directory. That's fine today and stops being fine under CV's subject-homed facts, which make a directory exactly as large as the tenant's entity count: `ls /facts` on a ten-thousand-subject tenant returns ten thousand entries in one response. Postgres serves that listing; an agent's context window does not.

## What

- **`limit`** (default 500, max 5000) bounds the response, and truncation is **reported** — `truncated: true` plus a `next_cursor`. That's the difference between a bound and a lie. A default was chosen over unbounded-unless-asked because the failure mode is a context blow-up in a caller that didn't know to ask; below the default a listing is byte-identical to before, which `TestPathLs_SmallDirectoryIsUnchanged` pins.
- **`cursor`** is the last emitted key, base64url-encoded to keep it **opaque**. The encoding is deliberately outside the contract so it can later become a composite — or move into the store as a keyset predicate — without a wire change. It's a *position*, not an offset, so entries added before it don't shift the page.
- **The recursive branch now sorts**, by full path. It didn't sort at all before, so any cursor over it would have been a bet on the store's row order — and a recursive listing is flat, where names repeat across directories and only the full path is a stable key.

## Deliberately not addressed

One-level `ls` still reads the whole subtree (`DirentListUnder`), because implicit directories are synthesized from descendants' parent paths. This change bounds the **response**, which is the harm the RFC identified. Pushing the limit into the store is a separate change, gated on the pathological-case load test (one directory, 10k children) that RFC CV still calls for.

## Lockstep

| surface | change |
|---|---|
| MCP | none needed — sources `pathInputSchema` verbatim |
| TS `PathToolInput` | two fields added |
| Python `path()` | none needed — pass-through `Mapping` |

⚠️ **At release the TS adapter version must equal the tag**, or the npm publish skips clean and the type change never ships. It's currently 1.72.0 against a 1.75.1 runtime.

## What was tested

6 cases in `internal/tools/builtin/pathtool_pagination_test.go`:

- **`DefaultLimitBoundsTheResponseAndSaysSo`** — the regression. Fails on the unfixed tool with `ls returned 600 entries, want the 500 default cap`, plus no truncation flag and no cursor.
- **`CursorWalksEveryEntryExactlyOnce`** — the property that makes a bounded directory *usable* rather than merely bounded: every entry exactly once, with a page-count guard so a non-advancing cursor fails loudly instead of looping.
- `RecursiveListingPaginatesOnFullPath` — same name under two parents; paginating a flat listing on *name* would collapse them.
- `ExplicitLimitIsHonouredAndCapped` — over-max clamps rather than refusing.
- `SmallDirectoryIsUnchanged` — the compatibility floor.
- `AHandBuiltCursorIsRefused` — the opacity guarantee only holds if one can't be invented.

One note on method: my first version of the regression referenced the new `lsDefaultLimit` constant, so the "fail-before" was a *build* error rather than a behavioural one — which demonstrates nothing. The expectation is now a literal so the test compiles against the pre-pagination tool and fails on its actual behaviour.

Full `go test ./...` clean (99 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8