### PR TITLE
test(retention): pin that the agent export carries doc.chunk body rows

### DIFF
--- a/internal/retention/mem_export_chunkbody_test.go
+++ b/internal/retention/mem_export_chunkbody_test.go
@@ -1,0 +1,101 @@
+package retention
+
+import (
+	"context"
+	"encoding/json"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+)
+
+// TestSweeper_MemExportIncludesChunkBodyRows is RFC CX-1: a characterisation test
+// pinning a property RFC CV's P2 depends on, BEFORE P2 lands.
+//
+// WHY IT EXISTS. CV's P2 collapses a fact's `memory/<class>/<slug>` row onto its
+// chunk, leaving the fact's text in the k/v plane only as a `doc.chunk:<hex>` row
+// with its structure and provenance in SQL Memory. RFC CX-2 was drafted on the
+// assumption that the retired-agent export would then silently lose the fact text
+// — "a retention subsystem that quietly drops what it is supposed to preserve is
+// the worst failure mode available to it".
+//
+// ⚠️ THAT ASSUMPTION IS WRONG, and this test is the evidence. `exportBaseMemory`
+// lists with an EMPTY key prefix, so it already exports every k/v row in the
+// scope including `doc.chunk:` bodies; and the reclaim separately calls
+// `exportSQLMemScope` before `DropScope`, which carries the chunks and
+// `chunk_memory_meta`. Both halves of a post-P2 fact are already covered, so CX-2
+// needs no code change.
+//
+// The test is still worth having — arguably more so. The property is INCIDENTAL:
+// it holds because a prefix is empty. Narrowing that prefix to `memory/` looks
+// like a harmless optimisation and would silently reinstate CV P2's blocker. This
+// test is what makes that a red build instead of a data-loss incident.
+func TestSweeper_MemExportIncludesChunkBodyRows(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	st, err := sqlite.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+	sm := newTestSqlMem(t)
+
+	const factText = "Dave moved to Berlin in July 2023."
+
+	seedRetiredAgent(t, st, "acme", "dead", 1)
+	seedAgentSQLScope(t, sm, "acme", "dead")
+	seedAgentDirent(t, st, "acme", "dead")
+
+	// The POST-P2 shape of a fact: the body lives only as a doc.chunk: row. No
+	// `memory/<class>/<slug>` companion, which is exactly what P2 removes.
+	body, _ := json.Marshal(map[string]string{"body": factText})
+	if err := st.MemorySet(ctx, "", store.MemoryScopeAgent, "dead",
+		"doc.chunk:9f2c1b7e4a", json.RawMessage(body), 0); err != nil {
+		t.Fatalf("seed chunk body row: %v", err)
+	}
+
+	sw := New(st, Config{MemMode: "export+prune", ExportDir: dir, SQLMem: sm, Logger: quietLogger, Now: futureHour})
+	if _, err := sw.sweepOnce(ctx); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	// The fact TEXT must appear in the agent-memory export. Asserted on content,
+	// not on a row count: a count can be right while the bytes that matter are
+	// missing, and it is the text an operator needs back.
+	var exported []string
+	_ = filepath.WalkDir(dir, func(p string, d fs.DirEntry, _ error) error {
+		if d == nil || d.IsDir() || filepath.Base(filepath.Dir(p)) != "agent-memory" {
+			return nil
+		}
+		b, readErr := os.ReadFile(p)
+		if readErr == nil {
+			exported = append(exported, string(b))
+		}
+		return nil
+	})
+	if len(exported) == 0 {
+		t.Fatalf("no agent-memory export file was written under %s", dir)
+	}
+	joined := strings.Join(exported, "\n")
+	if !strings.Contains(joined, factText) {
+		t.Errorf("the agent-memory export does not contain the fact text %q.\n\n"+
+			"After RFC CV P2 a fact's text lives ONLY as a doc.chunk: row, so an export that "+
+			"skips those rows deletes an agent's memory having preserved none of it. This holds "+
+			"today because exportBaseMemory lists with an EMPTY prefix — if that prefix was "+
+			"narrowed, restore it.\n\nexport contents:\n%s", factText, joined)
+	}
+
+	// And the scope really was dropped afterwards, so this is export-THEN-delete
+	// rather than an export that happened to run beside a survivor.
+	entries, _, err := st.MemoryList(ctx, "", store.MemoryScopeAgent, "dead", "", 100)
+	if err != nil {
+		t.Fatalf("MemoryList after sweep: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("base memory survived export+prune: %d rows remain", len(entries))
+	}
+}


### PR DESCRIPTION
RFC **CX-1**, and the evidence that **CX-2 needs no code change**.

## What CX-2 assumed, and why it was wrong

CX-2 was drafted as CV P2's blocker, on the assumption that after P2 — which collapses a fact's `memory/<class>/<slug>` row onto its chunk, leaving the text in the k/v plane only as a `doc.chunk:<hex>` row — the retired-agent export would silently lose the fact text.

Reading the code says otherwise:

- **`exportBaseMemory` lists with an empty key prefix**, so it already exports every k/v row in the scope, `doc.chunk:` bodies included.
- **The reclaim separately calls `exportSQLMemScope` before `DropScope`** (sweeper.go:931 → 936), which carries the chunks and `chunk_memory_meta`.

Both halves of a post-P2 fact are already covered. **CV's P2 is not blocked on a retention change.** I've recorded that in RFC CX rather than writing code to fix a problem that doesn't exist.

It also turned out the export path is stronger than the RFC credited: a truncated listing returns an **error so the caller skips the delete** — *"export-then-delete must never delete more than it exported"* — and `TestSweeper_MemExportFailureSkipsDrop` already pins that.

## Why the test is still worth having

The property is **incidental**. It holds because a prefix happens to be empty. Narrowing that prefix to `memory/` looks like a harmless optimisation and would silently reinstate the blocker — deleting an agent's memory having preserved none of it.

I verified the test has teeth by making exactly that change: it fails, and the message names the prefix as the thing to restore. Without that check this would be a test that passes for the wrong reason.

## What it asserts

- The fact **text** appears in the `agent-memory` export — on **content**, not a row count, because a count can be right while the bytes that matter are missing, and the text is what an operator needs back.
- The scope really was dropped afterwards, so this is export-**then**-delete rather than an export that happened to run beside a survivor.
- The seeded row is the **post-P2 shape**: a `doc.chunk:` body with no `memory/<class>/<slug>` companion.

Passes on unmodified `main` — CX-1's stated bar, since a characterisation test that needs a code change to pass is describing the wrong thing. Full `go test ./...` clean (99 packages).

## Scope note

This is CX-1 only, for the export property that CV P2 depends on. The rest of CX — CX-3 (whole-scope reclaim through the cascade), CX-4 (archival two-step, sequenced after CV P1), CX-5 (empty-dossier mode) — is separate work and not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8