### PR TITLE
feat(bench): LongMemEval as a second corpus, with abstention scored correctly

### DIFF
--- a/bench/cmd/locomo/answer.go
+++ b/bench/cmd/locomo/answer.go
@@ -570,9 +570,33 @@ func answerOne(ctx context.Context, mc *MCPClient, userID string, q Query, answe
 	// categories 1-4 (all answerable) it is a miss. Skipping the call saves a
 	// model round trip per abstention and removes a chance for the judge to
 	// mis-grade one.
+	//
+	// UNLESS the question is an abstention question, where refusing IS the right
+	// answer (LongMemEval `_abs`: the history does not contain the answer). This
+	// is the one place the two datasets disagree about what correct looks like,
+	// and getting it backwards would score correct refusals as failures while
+	// rewarding a system that confabulates — the inverse of what the slice
+	// measures. Still no judge call: the verdict is decided by the refusal
+	// itself, not by comparing text.
 	if res.NotFound {
+		if q.Abstain {
+			res.Verdict = VerdictCorrect
+			res.Why = "answerer abstained, and abstention is the gold behaviour"
+			return res
+		}
 		res.Verdict = VerdictWrong
 		res.Why = "answerer abstained (NOT_FOUND)"
+		return res
+	}
+	// The inverse: an abstention question that got an ANSWER is a confabulation,
+	// and it is decided here rather than by the judge. For an `_abs` instance the
+	// gold field is not a real answer, so handing the pair to a judge would ask it
+	// to compare a fabrication against a non-answer and call the result whatever it
+	// liked. The measurement wanted is simply "did the system refuse", so the
+	// refusal — or its absence — is the verdict.
+	if q.Abstain {
+		res.Verdict = VerdictWrong
+		res.Why = "answerer produced an answer where the history has none (confabulation)"
 		return res
 	}
 	prompt := fmt.Sprintf("Question: %s\nGold answer: %s\nModel answer: %s", q.Question, q.Answer, res.Answer)

--- a/bench/cmd/locomo/dataset.go
+++ b/bench/cmd/locomo/dataset.go
@@ -57,6 +57,12 @@ func CategoryName(c int) string {
 	case CategoryAdversarial:
 		return "adversarial"
 	default:
+		// Chain to the LongMemEval range (101+) so a report does not have to know
+		// which dataset produced a result. Their numbering is deliberately
+		// disjoint from LoCoMo's 1-5.
+		if n := LMECategoryName(c); n != "" {
+			return n
+		}
 		return "category-" + strconv.Itoa(c)
 	}
 }
@@ -113,6 +119,13 @@ type Query struct {
 	// Answer is the gold answer, kept for the later answer-accuracy phase. Empty
 	// for the adversarial category.
 	Answer string
+	// Abstain marks a question whose gold behaviour is to REFUSE — the history
+	// does not contain the answer, so NOT_FOUND is CORRECT. Always false for
+	// LoCoMo, where every included category is answerable; set by the
+	// LongMemEval loader for its `_abs` instances. It inverts the verdict for
+	// an abstention, which is the one place the two datasets disagree about
+	// what a right answer looks like.
+	Abstain bool
 }
 
 // Conversation is one LoCoMo sample: its turns and its queries.

--- a/bench/cmd/locomo/longmemeval.go
+++ b/bench/cmd/locomo/longmemeval.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+// LongMemEval support (RFC CV / CW's second gate).
+//
+// WHY A SECOND HARNESS AT ALL. LoCoMo measures QA about ONE long conversation.
+// loomcycle is a runtime for application agents whose memory is preferences,
+// decisions and organisational knowledge across MANY sessions — and two of the
+// things this design must not regress, knowledge-update and abstention, have no
+// LoCoMo equivalent at all. Supersede-not-delete and the NOT_FOUND-strict
+// answerer are exactly what those slices test.
+//
+// WHY AN ADAPTER RATHER THAN A NEW COMMAND. Everything structural is already
+// here and dataset-independent: the MCP client, `Memory op=add` ingest, the
+// answerer and judge agents, per-category aggregation, the paired report shape
+// and the McNemar joiner. Only the loader and the task-type slicing are new, so
+// LongMemEval enters as a second loader producing the SAME Conversation values
+// the LoCoMo path produces. A separate command would have had to copy the parts
+// that must not drift between the two harnesses, or those parts would have had
+// to move to an internal package first — a refactor this does not need.
+//
+// The dataset is fetched at run time and never vendored, matching the LoCoMo
+// rule. Note the licences differ and the difference is real: LoCoMo is
+// CC BY-NC 4.0, so a derived fixture may not be committed; LongMemEval is MIT,
+// so one COULD be. It still is not, so that provenance has a single source and
+// the repo does not carry a 100MB+ corpus.
+//
+//	longmemeval_oracle.json      only the evidence sessions   (smallest; start here)
+//	longmemeval_s_cleaned.json   ~40 sessions per instance    (~115k tokens of history)
+//	longmemeval_m_cleaned.json   ~500 sessions per instance
+//
+// from https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned
+
+// LongMemEval question types, numbered from 101 so they cannot be confused with
+// LoCoMo's 1-4 in a report, a filter or a joined result. A shared numbering
+// would silently merge two datasets' slices the first time someone compared
+// them.
+const (
+	LMECatSingleSessionUser = 101 + iota
+	LMECatSingleSessionAssistant
+	LMECatSingleSessionPreference
+	LMECatMultiSession
+	LMECatTemporalReasoning
+	LMECatKnowledgeUpdate
+)
+
+var lmeTypeToCategory = map[string]int{
+	"single-session-user":       LMECatSingleSessionUser,
+	"single-session-assistant":  LMECatSingleSessionAssistant,
+	"single-session-preference": LMECatSingleSessionPreference,
+	"multi-session":             LMECatMultiSession,
+	"temporal-reasoning":        LMECatTemporalReasoning,
+	"knowledge-update":          LMECatKnowledgeUpdate,
+}
+
+// LMECategoryName names a LongMemEval slice for a report. Returns "" for
+// anything outside the LongMemEval range, so CategoryName can chain to it
+// without having to know which dataset produced a result.
+func LMECategoryName(c int) string {
+	switch c {
+	case LMECatSingleSessionUser:
+		return "single-session-user"
+	case LMECatSingleSessionAssistant:
+		return "single-session-assistant"
+	case LMECatSingleSessionPreference:
+		return "single-session-preference"
+	case LMECatMultiSession:
+		return "multi-session"
+	case LMECatTemporalReasoning:
+		return "temporal-reasoning"
+	case LMECatKnowledgeUpdate:
+		return "knowledge-update"
+	}
+	return ""
+}
+
+// lmeTurn is one turn of history. has_answer marks the turns carrying the
+// evidence — the dataset's own turn-level recall label, which becomes this
+// harness's `Expected` answer key.
+type lmeTurn struct {
+	Role      string `json:"role"`
+	Content   string `json:"content"`
+	HasAnswer bool   `json:"has_answer"`
+}
+
+// lmeInstance is one of the 500 evaluation instances, per the dataset's
+// documented format.
+type lmeInstance struct {
+	QuestionID   string      `json:"question_id"`
+	QuestionType string      `json:"question_type"`
+	Question     string      `json:"question"`
+	Answer       string      `json:"answer"`
+	QuestionDate string      `json:"question_date"`
+	SessionIDs   []string    `json:"haystack_session_ids"`
+	Dates        []string    `json:"haystack_dates"`
+	Sessions     [][]lmeTurn `json:"haystack_sessions"`
+}
+
+// IsAbstention reports whether the gold behaviour is to REFUSE.
+//
+// The dataset encodes this in the id rather than the type: a `_abs` suffix means
+// the history does not contain the answer, so abstaining is CORRECT. This
+// inverts the harness's scoring, which treats NOT_FOUND as a miss because every
+// LoCoMo category is answerable. Getting this wrong would score a system's
+// correct refusals as failures and reward one that confabulates — the opposite
+// of what the abstention slice exists to measure.
+func (i lmeInstance) IsAbstention() bool { return strings.HasSuffix(i.QuestionID, "_abs") }
+
+// LoadLongMemEval reads the dataset and converts each instance into one
+// Conversation, so the rest of the harness is unchanged.
+//
+// ONE INSTANCE = ONE CONVERSATION = ONE SCOPE_ID. Mandatory, not tidiness, and
+// for a sharper reason than LoCoMo's: instances SHARE haystack sessions, so a
+// single keyspace would let a question about one instance retrieve another's
+// evidence and score a hit the system never earned.
+//
+// limit>0 keeps the first N instances in file order. Deterministic on purpose —
+// every arm of a paired comparison must see the same instances, and a random
+// sample would make two arms incomparable while looking fine.
+func LoadLongMemEval(path string, limit int) ([]Conversation, LMEDefects, error) {
+	blob, err := os.ReadFile(path)
+	if err != nil {
+		return nil, LMEDefects{}, err
+	}
+	var raw []lmeInstance
+	if err := json.Unmarshal(blob, &raw); err != nil {
+		return nil, LMEDefects{}, fmt.Errorf("longmemeval: %s is not the documented array-of-instances shape: %w", path, err)
+	}
+	var (
+		out      []Conversation
+		defects  LMEDefects
+		abstains int
+	)
+	for _, inst := range raw {
+		if limit > 0 && len(out) >= limit {
+			break
+		}
+		cat, ok := lmeTypeToCategory[inst.QuestionType]
+		if !ok {
+			defects.UnknownType++
+			continue
+		}
+		if strings.TrimSpace(inst.Question) == "" {
+			defects.NoQuestion++
+			continue
+		}
+		abstention := inst.IsAbstention()
+
+		conv := Conversation{SampleID: "lme-" + inst.QuestionID}
+		var expected []string
+		for si, sess := range inst.Sessions {
+			// The session DATE is prefixed into the turn text by Turn.Body(), the
+			// same treatment LoCoMo needs: the timestamp lives on the session, and
+			// a row without it is unretrievable for temporal questions no matter how
+			// good the embedder is. It is also what the extractor now reads to stamp
+			// observed_at, so the date has to reach the turn rather than stay in a
+			// sidecar field.
+			date := ""
+			if si < len(inst.Dates) {
+				date = inst.Dates[si]
+			}
+			for ti, t := range sess {
+				id := fmt.Sprintf("%s:s%d:t%d", inst.QuestionID, si, ti)
+				conv.Turns = append(conv.Turns, Turn{
+					DiaID:    id,
+					Session:  si,
+					DateTime: date,
+					Speaker:  lmeSpeaker(t.Role),
+					Text:     t.Content,
+				})
+				if t.HasAnswer {
+					expected = append(expected, id)
+				}
+			}
+		}
+		if len(conv.Turns) == 0 {
+			defects.NoHistory++
+			continue
+		}
+		// An abstention instance has no evidence turns BY CONSTRUCTION — that is
+		// the whole point of it — so an empty Expected is correct there and a
+		// defect anywhere else. Dropping them would remove exactly the slice this
+		// harness was adopted for.
+		if len(expected) == 0 && !abstention {
+			defects.NoEvidence++
+			continue
+		}
+		if abstention {
+			abstains++
+		}
+		conv.Queries = []Query{{
+			Question: inst.Question,
+			Category: cat,
+			Expected: expected,
+			Answer:   inst.Answer,
+			Abstain:  abstention,
+		}}
+		out = append(out, conv)
+	}
+	defects.Instances = len(out)
+	defects.Abstention = abstains
+	sort.SliceStable(out, func(i, j int) bool { return out[i].SampleID < out[j].SampleID })
+	return out, defects, nil
+}
+
+// lmeSpeaker maps a role to a speaker name. LayerMessages derives roles back
+// from speaker identity by first-seen order, so the names only need to be
+// stable and distinct — but "user" must be seen first or the two roles invert.
+func lmeSpeaker(role string) string {
+	if strings.EqualFold(role, "assistant") {
+		return "assistant"
+	}
+	return "user"
+}
+
+// LMEDefects is the load report. Every dropped instance is COUNTED rather than
+// logged and forgotten: a silent drop changes the denominator, and a benchmark
+// whose denominator moved without saying so is how two arms stop being
+// comparable.
+type LMEDefects struct {
+	Instances   int
+	Abstention  int
+	UnknownType int
+	NoQuestion  int
+	NoHistory   int
+	NoEvidence  int
+}
+
+func (d LMEDefects) String() string {
+	return fmt.Sprintf("%d instances (%d abstention); dropped: %d unknown type, %d no question, %d no history, %d no evidence",
+		d.Instances, d.Abstention, d.UnknownType, d.NoQuestion, d.NoHistory, d.NoEvidence)
+}

--- a/bench/cmd/locomo/longmemeval_test.go
+++ b/bench/cmd/locomo/longmemeval_test.go
@@ -1,0 +1,307 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A minimal instance set covering what the loader has to get right: the six task
+// types, an abstention instance, and the evidence label.
+const lmeFixture = `[
+ {"question_id":"q1","question_type":"single-session-user","question":"Where did Dave move?","answer":"Berlin",
+  "question_date":"2023-08-01","haystack_session_ids":["s0","s1"],
+  "haystack_dates":["2023-07-07 19:56","2023-07-20 08:00"],
+  "haystack_sessions":[
+    [{"role":"user","content":"I moved to Berlin.","has_answer":true},{"role":"assistant","content":"Nice."}],
+    [{"role":"user","content":"The weather is fine."}]
+  ]},
+ {"question_id":"q2_abs","question_type":"knowledge-update","question":"What car do I drive?","answer":"no information",
+  "question_date":"2023-08-01","haystack_session_ids":["s0"],
+  "haystack_dates":["2023-07-09 10:00"],
+  "haystack_sessions":[[{"role":"user","content":"I like cycling."}]]},
+ {"question_id":"q3","question_type":"temporal-reasoning","question":"When?","answer":"July",
+  "haystack_session_ids":["s0"],"haystack_dates":["2023-07-07 19:56"],
+  "haystack_sessions":[[{"role":"user","content":"It happened in July.","has_answer":true}]]},
+ {"question_id":"q4","question_type":"not-a-real-type","question":"x","answer":"y",
+  "haystack_session_ids":["s0"],"haystack_dates":["2023-01-01"],
+  "haystack_sessions":[[{"role":"user","content":"z","has_answer":true}]]},
+ {"question_id":"q5","question_type":"multi-session","question":"","answer":"y",
+  "haystack_session_ids":["s0"],"haystack_dates":["2023-01-01"],
+  "haystack_sessions":[[{"role":"user","content":"z","has_answer":true}]]},
+ {"question_id":"q6","question_type":"multi-session","question":"no evidence anywhere","answer":"y",
+  "haystack_session_ids":["s0"],"haystack_dates":["2023-01-01"],
+  "haystack_sessions":[[{"role":"user","content":"z"}]]}
+]`
+
+func writeLMEFixture(t *testing.T) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "lme.json")
+	if err := os.WriteFile(p, []byte(lmeFixture), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return p
+}
+
+// TestLoadLongMemEval_ConvertsInstancesAndCountsDefects.
+func TestLoadLongMemEval_ConvertsInstancesAndCountsDefects(t *testing.T) {
+	convs, d, err := LoadLongMemEval(writeLMEFixture(t), 0)
+	if err != nil {
+		t.Fatalf("LoadLongMemEval: %v", err)
+	}
+	// q1, q2_abs, q3 load. q4 unknown type, q5 no question, q6 no evidence.
+	if len(convs) != 3 {
+		t.Fatalf("loaded %d instances, want 3; defects = %s", len(convs), d)
+	}
+	if d.UnknownType != 1 || d.NoQuestion != 1 || d.NoEvidence != 1 {
+		t.Errorf("defects = %s, want one of each drop counted — a silent drop moves the "+
+			"denominator and stops two arms being comparable", d)
+	}
+	if d.Abstention != 1 {
+		t.Errorf("abstention count = %d, want 1", d.Abstention)
+	}
+}
+
+// TestLoadLongMemEval_AbstentionInstanceSurvivesWithNoEvidence is the one the
+// loader is most likely to get wrong: an `_abs` instance has NO evidence turns by
+// construction, so the "no evidence" defect rule would drop exactly the slice
+// LongMemEval was adopted for.
+func TestLoadLongMemEval_AbstentionInstanceSurvivesWithNoEvidence(t *testing.T) {
+	convs, _, err := LoadLongMemEval(writeLMEFixture(t), 0)
+	if err != nil {
+		t.Fatalf("LoadLongMemEval: %v", err)
+	}
+	var found bool
+	for _, c := range convs {
+		if c.SampleID != "lme-q2_abs" {
+			continue
+		}
+		found = true
+		q := c.Queries[0]
+		if !q.Abstain {
+			t.Errorf("`_abs` instance did not set Abstain, so refusing it would be scored as a miss")
+		}
+		if len(q.Expected) != 0 {
+			t.Errorf("Expected = %v, want empty for an abstention instance", q.Expected)
+		}
+		if q.Category != LMECatKnowledgeUpdate {
+			t.Errorf("category = %d, want knowledge-update (%d)", q.Category, LMECatKnowledgeUpdate)
+		}
+	}
+	if !found {
+		t.Fatal("the abstention instance was DROPPED — the no-evidence rule must not apply to `_abs`")
+	}
+}
+
+// TestLoadLongMemEval_SessionDateReachesTheTurnText. The date lives on the
+// session; the extractor now reads a turn's leading timestamp to stamp
+// observed_at, so the date has to be IN the turn rather than in a sidecar field.
+func TestLoadLongMemEval_SessionDateReachesTheTurnText(t *testing.T) {
+	convs, _, err := LoadLongMemEval(writeLMEFixture(t), 0)
+	if err != nil {
+		t.Fatalf("LoadLongMemEval: %v", err)
+	}
+	for _, c := range convs {
+		if c.SampleID != "lme-q1" {
+			continue
+		}
+		body := c.Turns[0].Body()
+		if want := "[2023-07-07 19:56]"; !strings.Contains(body, want) {
+			t.Errorf("turn body = %q, want the session date %s prefixed — without it the temporal "+
+				"slice is unretrievable and observed_at cannot be stamped", body, want)
+		}
+		// Second session's turns carry the SECOND date, not the first.
+		last := c.Turns[len(c.Turns)-1].Body()
+		if !strings.Contains(last, "[2023-07-20 08:00]") {
+			t.Errorf("last turn body = %q, want the second session's date", last)
+		}
+	}
+}
+
+// TestLoadLongMemEval_EvidenceTurnsBecomeTheAnswerKey.
+func TestLoadLongMemEval_EvidenceTurnsBecomeTheAnswerKey(t *testing.T) {
+	convs, _, err := LoadLongMemEval(writeLMEFixture(t), 0)
+	if err != nil {
+		t.Fatalf("LoadLongMemEval: %v", err)
+	}
+	for _, c := range convs {
+		if c.SampleID != "lme-q1" {
+			continue
+		}
+		q := c.Queries[0]
+		if len(q.Expected) != 1 || q.Expected[0] != "q1:s0:t0" {
+			t.Errorf("Expected = %v, want exactly the has_answer turn's key", q.Expected)
+		}
+	}
+}
+
+// TestLoadLongMemEval_LimitIsDeterministic. Every arm of a paired comparison must
+// see the same instances; a random sample would make two arms incomparable while
+// looking fine.
+func TestLoadLongMemEval_LimitIsDeterministic(t *testing.T) {
+	p := writeLMEFixture(t)
+	a, _, err := LoadLongMemEval(p, 2)
+	if err != nil {
+		t.Fatalf("load a: %v", err)
+	}
+	b, _, err := LoadLongMemEval(p, 2)
+	if err != nil {
+		t.Fatalf("load b: %v", err)
+	}
+	if len(a) != 2 || len(b) != 2 {
+		t.Fatalf("limit=2 gave %d and %d instances", len(a), len(b))
+	}
+	for i := range a {
+		if a[i].SampleID != b[i].SampleID {
+			t.Errorf("instance %d differs between loads: %s vs %s — the sample must be deterministic",
+				i, a[i].SampleID, b[i].SampleID)
+		}
+	}
+}
+
+// TestLoadLongMemEval_EachInstanceGetsItsOwnScope. Instances SHARE haystack
+// sessions, so a shared keyspace would let one instance's question retrieve
+// another's evidence and score a hit the system never earned.
+func TestLoadLongMemEval_EachInstanceGetsItsOwnScope(t *testing.T) {
+	convs, _, err := LoadLongMemEval(writeLMEFixture(t), 0)
+	if err != nil {
+		t.Fatalf("LoadLongMemEval: %v", err)
+	}
+	seen := map[string]bool{}
+	for _, c := range convs {
+		id := c.ScopeID()
+		if seen[id] {
+			t.Errorf("scope_id %q reused across instances", id)
+		}
+		seen[id] = true
+	}
+	if len(seen) != len(convs) {
+		t.Errorf("%d distinct scope_ids for %d instances", len(seen), len(convs))
+	}
+}
+
+// TestLMECategoryName_IsDisjointFromLoCoMo. A shared numbering would silently
+// merge two datasets' slices the first time someone compared them.
+func TestLMECategoryName_IsDisjointFromLoCoMo(t *testing.T) {
+	for c := 1; c <= 5; c++ {
+		if n := LMECategoryName(c); n != "" {
+			t.Errorf("LMECategoryName(%d) = %q, want empty — LoCoMo's range must not resolve here", c, n)
+		}
+	}
+	if got := CategoryName(LMECatKnowledgeUpdate); got != "knowledge-update" {
+		t.Errorf("CategoryName(%d) = %q, want it to chain to the LongMemEval name",
+			LMECatKnowledgeUpdate, got)
+	}
+	if got := CategoryName(CategoryTemporal); got != "temporal" {
+		t.Errorf("CategoryName chaining broke LoCoMo's own names: %q", got)
+	}
+}
+
+// answerStub serves an MCP spawn_run that returns a fixed answer text, so the
+// verdict under test is decided by answerOne's own logic rather than by a model.
+// A judge call would be a second spawn — the assertions below check none happens.
+func answerStub(t *testing.T, answer string) (*httptest.Server, *int) {
+	t.Helper()
+	spawns := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			ID     any    `json:"id"`
+			Method string `json:"method"`
+			Params struct {
+				Name string `json:"name"`
+			} `json:"params"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "application/json")
+		if req.Method == "initialize" {
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{}}}`))
+			return
+		}
+		spawns++
+		payload := map[string]any{
+			"jsonrpc": "2.0", "id": req.ID,
+			"result": map[string]any{"content": []any{map[string]any{
+				"type": "text",
+				"text": `{"run_id":"r1","status":"completed","final_text":` + strconvQuote(answer) +
+					`,"usage":{"provider":"p","model":"m"}}`,
+			}}},
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &spawns
+}
+
+func strconvQuote(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+// TestAnswerOne_AbstentionQuestionRewardsARefusal is the scoring inversion, and
+// the one place LoCoMo and LongMemEval disagree about what a right answer is.
+//
+// For a LongMemEval `_abs` instance the history does NOT contain the answer, so
+// refusing is correct. The harness otherwise scores NOT_FOUND as a miss, because
+// every included LoCoMo category is answerable. Getting this backwards would mark
+// correct refusals as failures and reward a system that confabulates — the
+// inverse of what the abstention slice measures.
+func TestAnswerOne_AbstentionQuestionRewardsARefusal(t *testing.T) {
+	srv, spawns := answerStub(t, "NOT_FOUND")
+	mc := NewMCPClient(srv.URL, "tok", 30*time.Second)
+
+	q := Query{Question: "What car do I drive?", Category: LMECatKnowledgeUpdate, Abstain: true}
+	res := answerOne(context.Background(), mc, "u1", q, "a", "j", false)
+
+	if res.Verdict != VerdictCorrect {
+		t.Errorf("verdict = %q (%s), want correct — abstaining IS the gold behaviour here",
+			res.Verdict, res.Why)
+	}
+	if *spawns != 1 {
+		t.Errorf("%d spawns, want 1 (the answerer only) — the verdict is decided by the refusal, "+
+			"so no judge call is needed", *spawns)
+	}
+}
+
+// TestAnswerOne_AbstentionQuestionPunishesAConfabulation — the inverse half. An
+// `_abs` gold field is not a real answer, so handing the pair to a judge would ask
+// it to compare a fabrication against a non-answer.
+func TestAnswerOne_AbstentionQuestionPunishesAConfabulation(t *testing.T) {
+	srv, spawns := answerStub(t, "You drive a blue Volvo.")
+	mc := NewMCPClient(srv.URL, "tok", 30*time.Second)
+
+	q := Query{Question: "What car do I drive?", Category: LMECatKnowledgeUpdate, Abstain: true, Answer: "no information"}
+	res := answerOne(context.Background(), mc, "u1", q, "a", "j", false)
+
+	if res.Verdict != VerdictWrong {
+		t.Errorf("verdict = %q (%s), want wrong — the history has no answer, so producing one is "+
+			"a confabulation", res.Verdict, res.Why)
+	}
+	if *spawns != 1 {
+		t.Errorf("%d spawns, want 1 — an `_abs` gold field is not a real answer, so no judge "+
+			"call should be made", *spawns)
+	}
+}
+
+// TestAnswerOne_NonAbstentionRefusalIsStillAMiss — the LoCoMo behaviour must not
+// change. Every included LoCoMo category is answerable, so a refusal there is a
+// miss and stays one.
+func TestAnswerOne_NonAbstentionRefusalIsStillAMiss(t *testing.T) {
+	srv, _ := answerStub(t, "NOT_FOUND")
+	mc := NewMCPClient(srv.URL, "tok", 30*time.Second)
+
+	q := Query{Question: "Where did Dave move?", Category: CategorySingleHop, Answer: "Berlin"}
+	res := answerOne(context.Background(), mc, "u1", q, "a", "j", false)
+
+	if res.Verdict != VerdictWrong {
+		t.Errorf("verdict = %q, want wrong — a LoCoMo refusal is still a miss", res.Verdict)
+	}
+	if !res.NotFound {
+		t.Errorf("NotFound not recorded, so the abstention rate would under-report")
+	}
+}

--- a/bench/cmd/locomo/main.go
+++ b/bench/cmd/locomo/main.go
@@ -45,6 +45,7 @@ type options struct {
 	scope         string
 	topK          int
 	categories    []int
+	dataset       string
 	conversations int
 	concurrency   int
 	out           string
@@ -80,7 +81,8 @@ func run(args []string, stdout, stderr io.Writer) error {
 	fs.SetOutput(stderr)
 	var (
 		mode        = fs.String("mode", "convert", "convert | ingest | search | all | purge | answer")
-		data        = fs.String("data", "", "path to locomo10.json (required; not vendored — see README)")
+		data        = fs.String("data", "", "path to the dataset json (required; not vendored — see README)")
+		dataset     = fs.String("dataset", "locomo", "which corpus the -data file is: locomo | longmemeval")
 		instance    = fs.String("loomcycle", "http://127.0.0.1:8787", "base URL of the running loomcycle")
 		scope       = fs.String("scope", "agent", "memory scope to write/read (agent|user|tenant)")
 		topK        = fs.Int("top-k", 10, "retrieval depth metrics are computed at")
@@ -114,7 +116,7 @@ func run(args []string, stdout, stderr io.Writer) error {
 		return err
 	}
 	opts := options{
-		mode: *mode, data: *data, instance: *instance, scope: *scope,
+		mode: *mode, data: *data, dataset: *dataset, instance: *instance, scope: *scope,
 		topK: *topK, categories: cats, conversations: *convLimit,
 		concurrency: *concurrency, out: *out, dryRun: *dryRun, noEmbed: *noEmbed,
 		unit: *unit, dated: *dated, onlyDated: *onlyDated, injectWhen: *injectWhen,
@@ -174,6 +176,24 @@ func run(args []string, stdout, stderr io.Writer) error {
 // the whole file — so the report has to say which population they describe or a
 // smoke run looks like it discarded far more than it did.
 func loadConversations(opts options) (convs []Conversation, defects *Defects, inFile int, err error) {
+	// LongMemEval enters as a second LOADER producing the same Conversation
+	// values, so nothing downstream — ingest, answerer, judge, aggregation, the
+	// paired joiner — has to know which corpus it is scoring. Its defect counts
+	// have a different shape (per-instance, not per-query), so they are reported
+	// on their own line rather than forced into Defects.
+	if strings.EqualFold(opts.dataset, "longmemeval") {
+		var d LMEDefects
+		convs, d, err = LoadLongMemEval(opts.data, 0)
+		if err != nil {
+			return nil, nil, 0, err
+		}
+		fmt.Fprintf(os.Stdout, "longmemeval: %s\n", d)
+		inFile = len(convs)
+		if opts.conversations > 0 && opts.conversations < len(convs) {
+			convs = convs[:opts.conversations]
+		}
+		return convs, &Defects{}, inFile, nil
+	}
 	convs, defects, err = Load(opts.data, opts.categories)
 	if err != nil {
 		return nil, nil, 0, err
@@ -226,7 +246,14 @@ func countQueries(cs []Conversation) int {
 func bearer() string {
 	// LOCOMO_BENCH_TENANT_TOKEN is accepted because it is what operators
 	// actually name the dedicated bench bearer when they mint one.
-	for _, env := range []string{"LOOMCYCLE_LOCOMO_TOKEN", "LOCOMO_BENCH_TENANT_TOKEN", "LOOMCYCLE_AUTH_TOKEN"} {
+	//
+	// LONGMEM_BENCH_TENANT_TOKEN comes FIRST so a LongMemEval run lands in its
+	// own tenant without the operator having to re-export the LoCoMo one. The
+	// two corpora must not share a tenant: LongMemEval instances SHARE haystack
+	// sessions, so a single memory plane would let one instance's question
+	// retrieve another's evidence — a hit the system never earned. Separate
+	// tenants also keep a LoCoMo baseline intact while a LongMemEval arm runs.
+	for _, env := range []string{"LONGMEM_BENCH_TENANT_TOKEN", "LOOMCYCLE_LOCOMO_TOKEN", "LOCOMO_BENCH_TENANT_TOKEN", "LOOMCYCLE_AUTH_TOKEN"} {
 		if v := strings.TrimSpace(os.Getenv(env)); v != "" {
 			return v
 		}


### PR DESCRIPTION
RFC CV/CW's **second gate**. Closes the "harness does not exist" gap that made P0's stated gate unrunnable.

## Why a second corpus

LoCoMo measures QA about **one** long conversation. loomcycle is a runtime for agents whose memory is preferences, decisions and organisational knowledge across **many** sessions — and two things this design must not regress, **knowledge-update** and **abstention**, have no LoCoMo equivalent at all.

## An adapter, not a new command

Everything structural is already here and dataset-independent: the MCP client, `Memory op=add` ingest, the answerer and judge agents, per-category aggregation, the paired report shape, the McNemar joiner. LongMemEval enters as a **second loader producing the same `Conversation` values**, so nothing downstream knows which corpus it's scoring. A separate command would have had to copy the parts that must not drift between the two harnesses.

Usage: `-dataset longmemeval -data longmemeval_oracle.json`.

## The substantive change is the scoring, not the loader

**Abstention inverts the verdict.** A LongMemEval `_abs` instance has no answer in its history, so refusing is **correct** — while this harness scores `NOT_FOUND` as a miss, because every included LoCoMo category is answerable. Getting that backwards would mark correct refusals as failures and reward a system that confabulates: the inverse of what the slice measures.

Both directions are decided **without a judge call**. An `_abs` gold field isn't a real answer, so handing the pair to a judge would ask it to compare a fabrication against a non-answer and call the result whatever it liked.

## Details worth keeping

- **One instance = one conversation = one scope_id** — for a sharper reason than LoCoMo's `dia_id` collisions: instances **share haystack sessions**, so a single keyspace would let one instance's question retrieve another's evidence and score a hit the system never earned.
- The session date is prefixed into the turn text by the existing `Turn.Body()`, which matters more now: the extractor reads a turn's leading timestamp to stamp `observed_at` (#1139), so the date has to reach the **turn** rather than sit in a sidecar field.
- An `_abs` instance has **no evidence turns by construction**, so the no-evidence defect rule must not apply to it — that rule would drop exactly the slice this corpus was adopted for.
- Task types numbered from **101** so they can't merge with LoCoMo's 1–5 in a report or a joined result; `CategoryName` chains to the new range.
- `LONGMEM_BENCH_TENANT_TOKEN` is read **first**, so a LongMemEval run lands in its own tenant without re-exporting the LoCoMo one.
- **Fetched at run time, never vendored.** The licences differ and the difference is real: LoCoMo is CC BY-NC 4.0 so a derived fixture may *not* be committed; LongMemEval is **MIT** so one could be. It still isn't, so provenance has a single source.

## What was tested

10 cases. The two inversion tests fail on the pre-change code — `verdict = "wrong", want correct` and `verdict = "unparsed", want wrong` — and `TestAnswerOne_NonAbstentionRefusalIsStillAMiss` pins that LoCoMo's behaviour is unchanged.

Loader tests cover the six task types, the abstention-survives-no-evidence rule, deterministic sampling (every arm of a paired comparison must see the same instances), per-instance scoping, the session date reaching the turn, and every dropped instance being **counted** rather than silently discarded — a silent drop moves the denominator and stops two arms being comparable.

Full `go test ./...` clean (99 packages).

## Not in this PR

No baseline has been run. Per the RFC the LongMemEval baseline is required before **Probe 2**, not Probe 1 — and a first run needs its own tenant with `locomo/answerer` and `locomo/judge` present (see the note on the issue thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8