### PR TITLE
feat(memory): parse observed_at from the turn instead of asking the model

### DIFF
--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -796,6 +796,7 @@ agents:
           // text the extractor actually saw, or a fact could be handed evidence from a
           // section that was never in front of the model.
           deriveSpans(facts, parts[i]);
+          stampObservedAt(facts, parts[i]);
           all = all.concat(facts);
           readable++;
         }
@@ -1182,6 +1183,7 @@ agents:
           // wrong one would date every fact in the batch to the same wrong day.
           var facts = extract(st, pendingText, "", "");
           deriveSpans(facts, pendingText);
+          stampObservedAt(facts, pendingText);
           // Unreadable is not empty: the call FAILED rather than answered, so stop
           // spending on this queue and leave the rest for the next pass. Retrying
           // inside one pass would multiply an outage by the call budget.
@@ -1478,6 +1480,107 @@ agents:
       // No match above the floor means NO span, which reads as unverified rather than
       // as refuted. A fact whose support cannot be located is exactly the fact a
       // verifier should be told nothing about.
+      // stampObservedAt fills `observed_at` from the TURN'S OWN TIMESTAMP, by
+      // PARSING it — no model call, no model cooperation.
+      //
+      // WHY THIS IS NOT A PROMPT PROBLEM. The prompt was changed to ask for
+      // `observed_at` and the extractor simply did not emit it: measured across
+      // three full runs, 0 of ~240 facts carried the field, while the very same
+      // change lifted the temporal slice from 2 to 8-10 correct answers purely by
+      // making the model keep dates in the fact PROSE. So asking works, partly, for
+      // the wrong reason — and the structured field stays empty however the request
+      // is worded. Asking an LLM to echo a date it was just handed is the wrong
+      // shape for the job. The timestamp is already machine-readable in the turn
+      // text, so the pass reads it directly: mechanism, not judgement, which is the
+      // same reason this consolidator is code-js rather than an LLM.
+      //
+      // ATTRIBUTION. A batch spans several turns with different timestamps, so a
+      // single date for the batch would file facts under a day they did not happen.
+      // deriveSpans has already matched each fact to its own source line, and that
+      // line carries the bracketed stamp — so the fact's own quote is the attribution
+      // path. Only when a fact has no usable quote does it fall back, and then ONLY
+      // if the whole text carries exactly ONE distinct timestamp; two candidates is
+      // an ambiguity, and the omit-when-unknown rule applies to the parser exactly as
+      // it applies to the model.
+      function stampObservedAt(facts, sourceText) {
+        if (!facts || !facts.length) { return facts; }
+        var all = collectStamps(sourceText);
+        var only = "";
+        for (var k = 0; k < all.length; k++) {
+          if (!only) { only = all[k]; }
+          else if (only !== all[k]) { only = ""; break; }
+        }
+        for (var i = 0; i < facts.length; i++) {
+          if (facts[i].observed_at) { continue; }   // the model DID emit one: leave it
+          var own = facts[i].quote ? collectStamps(facts[i].quote) : [];
+          if (own.length === 1) { facts[i].observed_at = own[0]; continue; }
+          if (own.length > 1) { continue; }         // ambiguous within one span
+          if (only) { facts[i].observed_at = only; }
+        }
+        return facts;
+      }
+
+      // collectStamps returns every bracketed timestamp in the text as an RFC3339
+      // instant, in order. Unparseable brackets are SKIPPED rather than guessed:
+      // half a timestamp coerced into a whole one is the wrong-date failure the
+      // field exists to avoid, and a wrong date is worse than no date because it
+      // hides the fact from the window it truly belongs in.
+      function collectStamps(text) {
+        var out = [];
+        if (typeof text !== "string" || !text) { return out; }
+        var re = /\[([^\]]{4,64})\]/g, m;
+        while ((m = re.exec(text)) !== null) {
+          var ts = parseStamp(m[1]);
+          if (ts) { out.push(ts); }
+        }
+        return out;
+      }
+
+      var MONTHS = {
+        january: "01", february: "02", march: "03", april: "04", may: "05",
+        june: "06", july: "07", august: "08", september: "09", october: "10",
+        november: "11", december: "12"
+      };
+
+      // parseStamp recognises the shapes real corpora actually use and refuses
+      // everything else. Deliberately NOT Date.parse: that accepts nearly anything
+      // and resolves ambiguity by guessing, which is the one behaviour this field
+      // must not have. Built as a string, so there is no local-timezone shift
+      // between the transcript and the stored instant.
+      function parseStamp(raw) {
+        var s = String(raw).replace(/\s+/g, " ").trim();
+        // 2023-07-07T19:56:00Z  /  2023-07-07 19:56[:00]
+        var m = /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?/.exec(s);
+        if (m) { return m[1] + "-" + m[2] + "-" + m[3] + "T" + m[4] + ":" + m[5] + ":" + (m[6] || "00") + "Z"; }
+        // 2023-07-07  (date only → midnight)
+        m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s);
+        if (m) { return m[1] + "-" + m[2] + "-" + m[3] + "T00:00:00Z"; }
+        // 7:56 pm on 7 July, 2023   (the LoCoMo shape)
+        m = /^(\d{1,2}):(\d{2}) ?(am|pm) on (\d{1,2}) ([A-Za-z]+),? (\d{4})$/i.exec(s);
+        if (m) {
+          var mon = MONTHS[m[5].toLowerCase()];
+          if (!mon) { return ""; }
+          var h = parseInt(m[1], 10);
+          if (h < 1 || h > 12) { return ""; }
+          if (/pm/i.test(m[3]) && h !== 12) { h += 12; }
+          if (/am/i.test(m[3]) && h === 12) { h = 0; }
+          return m[6] + "-" + mon + "-" + pad2(m[4]) + "T" + pad2(String(h)) + ":" + m[2] + ":00Z";
+        }
+        // 7 July, 2023  (date only)
+        m = /^(\d{1,2}) ([A-Za-z]+),? (\d{4})$/.exec(s);
+        if (m) {
+          var mo = MONTHS[m[2].toLowerCase()];
+          if (!mo) { return ""; }
+          return m[3] + "-" + mo + "-" + pad2(m[1]) + "T00:00:00Z";
+        }
+        return "";
+      }
+
+      function pad2(v) {
+        var t = String(v);
+        return t.length === 1 ? "0" + t : t;
+      }
+
       function deriveSpans(facts, sourceText) {
         if (!facts || !facts.length || !sourceText) { return facts; }
         var sentences = splitSentences(sourceText);

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -796,6 +796,7 @@ agents:
           // text the extractor actually saw, or a fact could be handed evidence from a
           // section that was never in front of the model.
           deriveSpans(facts, parts[i]);
+          stampObservedAt(facts, parts[i]);
           all = all.concat(facts);
           readable++;
         }
@@ -1182,6 +1183,7 @@ agents:
           // wrong one would date every fact in the batch to the same wrong day.
           var facts = extract(st, pendingText, "", "");
           deriveSpans(facts, pendingText);
+          stampObservedAt(facts, pendingText);
           // Unreadable is not empty: the call FAILED rather than answered, so stop
           // spending on this queue and leave the rest for the next pass. Retrying
           // inside one pass would multiply an outage by the call budget.
@@ -1478,6 +1480,107 @@ agents:
       // No match above the floor means NO span, which reads as unverified rather than
       // as refuted. A fact whose support cannot be located is exactly the fact a
       // verifier should be told nothing about.
+      // stampObservedAt fills `observed_at` from the TURN'S OWN TIMESTAMP, by
+      // PARSING it — no model call, no model cooperation.
+      //
+      // WHY THIS IS NOT A PROMPT PROBLEM. The prompt was changed to ask for
+      // `observed_at` and the extractor simply did not emit it: measured across
+      // three full runs, 0 of ~240 facts carried the field, while the very same
+      // change lifted the temporal slice from 2 to 8-10 correct answers purely by
+      // making the model keep dates in the fact PROSE. So asking works, partly, for
+      // the wrong reason — and the structured field stays empty however the request
+      // is worded. Asking an LLM to echo a date it was just handed is the wrong
+      // shape for the job. The timestamp is already machine-readable in the turn
+      // text, so the pass reads it directly: mechanism, not judgement, which is the
+      // same reason this consolidator is code-js rather than an LLM.
+      //
+      // ATTRIBUTION. A batch spans several turns with different timestamps, so a
+      // single date for the batch would file facts under a day they did not happen.
+      // deriveSpans has already matched each fact to its own source line, and that
+      // line carries the bracketed stamp — so the fact's own quote is the attribution
+      // path. Only when a fact has no usable quote does it fall back, and then ONLY
+      // if the whole text carries exactly ONE distinct timestamp; two candidates is
+      // an ambiguity, and the omit-when-unknown rule applies to the parser exactly as
+      // it applies to the model.
+      function stampObservedAt(facts, sourceText) {
+        if (!facts || !facts.length) { return facts; }
+        var all = collectStamps(sourceText);
+        var only = "";
+        for (var k = 0; k < all.length; k++) {
+          if (!only) { only = all[k]; }
+          else if (only !== all[k]) { only = ""; break; }
+        }
+        for (var i = 0; i < facts.length; i++) {
+          if (facts[i].observed_at) { continue; }   // the model DID emit one: leave it
+          var own = facts[i].quote ? collectStamps(facts[i].quote) : [];
+          if (own.length === 1) { facts[i].observed_at = own[0]; continue; }
+          if (own.length > 1) { continue; }         // ambiguous within one span
+          if (only) { facts[i].observed_at = only; }
+        }
+        return facts;
+      }
+
+      // collectStamps returns every bracketed timestamp in the text as an RFC3339
+      // instant, in order. Unparseable brackets are SKIPPED rather than guessed:
+      // half a timestamp coerced into a whole one is the wrong-date failure the
+      // field exists to avoid, and a wrong date is worse than no date because it
+      // hides the fact from the window it truly belongs in.
+      function collectStamps(text) {
+        var out = [];
+        if (typeof text !== "string" || !text) { return out; }
+        var re = /\[([^\]]{4,64})\]/g, m;
+        while ((m = re.exec(text)) !== null) {
+          var ts = parseStamp(m[1]);
+          if (ts) { out.push(ts); }
+        }
+        return out;
+      }
+
+      var MONTHS = {
+        january: "01", february: "02", march: "03", april: "04", may: "05",
+        june: "06", july: "07", august: "08", september: "09", october: "10",
+        november: "11", december: "12"
+      };
+
+      // parseStamp recognises the shapes real corpora actually use and refuses
+      // everything else. Deliberately NOT Date.parse: that accepts nearly anything
+      // and resolves ambiguity by guessing, which is the one behaviour this field
+      // must not have. Built as a string, so there is no local-timezone shift
+      // between the transcript and the stored instant.
+      function parseStamp(raw) {
+        var s = String(raw).replace(/\s+/g, " ").trim();
+        // 2023-07-07T19:56:00Z  /  2023-07-07 19:56[:00]
+        var m = /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?/.exec(s);
+        if (m) { return m[1] + "-" + m[2] + "-" + m[3] + "T" + m[4] + ":" + m[5] + ":" + (m[6] || "00") + "Z"; }
+        // 2023-07-07  (date only → midnight)
+        m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s);
+        if (m) { return m[1] + "-" + m[2] + "-" + m[3] + "T00:00:00Z"; }
+        // 7:56 pm on 7 July, 2023   (the LoCoMo shape)
+        m = /^(\d{1,2}):(\d{2}) ?(am|pm) on (\d{1,2}) ([A-Za-z]+),? (\d{4})$/i.exec(s);
+        if (m) {
+          var mon = MONTHS[m[5].toLowerCase()];
+          if (!mon) { return ""; }
+          var h = parseInt(m[1], 10);
+          if (h < 1 || h > 12) { return ""; }
+          if (/pm/i.test(m[3]) && h !== 12) { h += 12; }
+          if (/am/i.test(m[3]) && h === 12) { h = 0; }
+          return m[6] + "-" + mon + "-" + pad2(m[4]) + "T" + pad2(String(h)) + ":" + m[2] + ":00Z";
+        }
+        // 7 July, 2023  (date only)
+        m = /^(\d{1,2}) ([A-Za-z]+),? (\d{4})$/.exec(s);
+        if (m) {
+          var mo = MONTHS[m[2].toLowerCase()];
+          if (!mo) { return ""; }
+          return m[3] + "-" + mo + "-" + pad2(m[1]) + "T00:00:00Z";
+        }
+        return "";
+      }
+
+      function pad2(v) {
+        var t = String(v);
+        return t.length === 1 ? "0" + t : t;
+      }
+
       function deriveSpans(facts, sourceText) {
         if (!facts || !facts.length || !sourceText) { return facts; }
         var sentences = splitSentences(sourceText);

--- a/cmd/loomcycle/presets_memory_stamp_test.go
+++ b/cmd/loomcycle/presets_memory_stamp_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"testing"
+)
+
+// RFC CW Probe 1b — observed_at is PARSED from the turn, not requested from the
+// model.
+//
+// Probe 1 asked the extractor for `observed_at` and measured the answer across
+// three full runs: 0 of ~240 facts carried it. The same prompt change did lift
+// the temporal slice from 2 to 8-10 correct — but by making the model keep dates
+// in the fact PROSE, not by filling the field. So the field stays empty however
+// the request is worded, and the value of having it has never been collected.
+//
+// The timestamp is already machine-readable in the turn text, so the pass reads
+// it. Mechanism, not judgement.
+
+// TestConsolidator_ObservedAtIsParsedFromTheTurnWithoutTheModel is the
+// regression. The extractor emits NO temporal field — exactly as the live model
+// behaves — and the fact must still land dated.
+//
+// FAILS on the unfixed bundle: nothing parses the turn, so observed_at is absent.
+func TestConsolidator_ObservedAtIsParsedFromTheTurnWithoutTheModel(t *testing.T) {
+	f := newFakeToolset()
+	f.bands = map[string]any{"merge_threshold": 0.90, "related_threshold": 0.50}
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	f.transcript = "user: [7:56 pm on 7 July, 2023] Dave: I moved to Berlin for a new job.\nassistant: ok"
+	// No observed_at, no valid_at — what qwen3.8 actually returns.
+	f.factsJSON = `[{"text":"Dave moved to Berlin for a new job.","class":"fact"}]`
+
+	runConsolidator(t, f)
+
+	set := lastCall(t, f, "Memory.set")
+	got, _ := set.Input["observed_at"].(string)
+	if got != "2023-07-07T19:56:00Z" {
+		t.Errorf("observed_at = %q, want 2023-07-07T19:56:00Z parsed from the turn's own "+
+			"bracketed stamp — the model emits nothing, so asking it cannot be the mechanism "+
+			"(write keys: %v)", got, keysOf(set.Input))
+	}
+}
+
+// TestConsolidator_AModelSuppliedTimeIsNotOverwritten. If a capable extractor DOES
+// emit the field, the parser must not clobber it: the model saw the sentence and
+// may have resolved a relative date ("last month") the parser cannot.
+func TestConsolidator_AModelSuppliedTimeIsNotOverwritten(t *testing.T) {
+	f := newFakeToolset()
+	f.bands = map[string]any{"merge_threshold": 0.90, "related_threshold": 0.50}
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	f.transcript = "user: [7:56 pm on 7 July, 2023] Dave: I moved to Berlin.\nassistant: ok"
+	f.factsJSON = `[{"text":"Dave moved to Berlin.","class":"fact","observed_at":"2023-06-01T09:00:00Z"}]`
+
+	runConsolidator(t, f)
+
+	set := lastCall(t, f, "Memory.set")
+	if got, _ := set.Input["observed_at"].(string); got != "2023-06-01T09:00:00Z" {
+		t.Errorf("observed_at = %q, want the model's own value kept — the parser fills a gap, "+
+			"it does not override a reading of the sentence", got)
+	}
+}
+
+// TestConsolidator_AnUnparseableStampIsRefusedNotGuessed. The omit-when-unknown
+// rule applies to the parser exactly as it applies to the model: a wrong date is
+// worse than no date, because it hides the fact from the window it belongs in.
+func TestConsolidator_AnUnparseableStampIsRefusedNotGuessed(t *testing.T) {
+	f := newFakeToolset()
+	f.bands = map[string]any{"merge_threshold": 0.90, "related_threshold": 0.50}
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	// "sometime last summer" is not a timestamp. Neither is a 13 o'clock am/pm.
+	f.transcript = "user: [sometime last summer] Dave: I moved to Berlin.\nassistant: ok"
+	f.factsJSON = `[{"text":"Dave moved to Berlin.","class":"fact"}]`
+
+	runConsolidator(t, f)
+
+	set := lastCall(t, f, "Memory.set")
+	if v, ok := set.Input["observed_at"]; ok {
+		t.Errorf("observed_at = %v, want the field OMITTED — a guessed date files the fact "+
+			"under a day it did not happen", v)
+	}
+	if value, _ := set.Input["value"].(string); value != "Dave moved to Berlin." {
+		t.Errorf("stored value = %q, want the fact kept regardless", value)
+	}
+}
+
+// TestConsolidator_TwoDifferentStampsInOneBatchAreNotCollapsed. A queued batch
+// spans several turns with different dates. Stamping every fact with one batch
+// date would file facts under a day they did not happen, so attribution runs
+// through each fact's own derived span; where that is ambiguous the field is
+// omitted rather than assumed.
+func TestConsolidator_TwoDifferentStampsInOneBatchAreNotCollapsed(t *testing.T) {
+	f := newFakeToolset()
+	f.bands = map[string]any{"merge_threshold": 0.90, "related_threshold": 0.50}
+	f.sessions = nil
+	f.pending = []map[string]any{{
+		"id": "pend-1",
+		"payload": map[string]any{"messages": []any{
+			map[string]any{"role": "user", "content": "[7:56 pm on 7 July, 2023] Dave: I moved to Berlin for a new job."},
+			map[string]any{"role": "user", "content": "[9:15 am on 20 August, 2023] Dave: I adopted a cat named Mochi."},
+		}},
+	}}
+	f.factsJSON = `[{"text":"Dave adopted a cat named Mochi.","class":"fact"}]`
+
+	runConsolidator(t, f)
+
+	set := lastCall(t, f, "Memory.set")
+	got, _ := set.Input["observed_at"].(string)
+	// The cat fact belongs to the SECOND turn. The first turn's date would be wrong.
+	if got != "2023-08-20T09:15:00Z" {
+		t.Errorf("observed_at = %q, want the August turn's stamp (2023-08-20T09:15:00Z) — "+
+			"attribution is per fact via its own span, not one date for the whole batch", got)
+	}
+}
+
+// TestConsolidator_RFC3339AndISOStampsAreAccepted. LongMemEval carries
+// `haystack_dates` like "2023-07-07 19:56"; the LoCoMo shape is prose. Both reach
+// the turn text through the same bracket, so both must parse.
+func TestConsolidator_RFC3339AndISOStampsAreAccepted(t *testing.T) {
+	for _, tc := range []struct{ stamp, want string }{
+		{"2023-07-07 19:56", "2023-07-07T19:56:00Z"},
+		{"2023-07-07T19:56:00Z", "2023-07-07T19:56:00Z"},
+		{"2023-07-07", "2023-07-07T00:00:00Z"},
+		{"7 July, 2023", "2023-07-07T00:00:00Z"},
+	} {
+		f := newFakeToolset()
+		f.bands = map[string]any{"merge_threshold": 0.90, "related_threshold": 0.50}
+		f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+		f.transcript = "user: [" + tc.stamp + "] Dave: I moved to Berlin.\nassistant: ok"
+		f.factsJSON = `[{"text":"Dave moved to Berlin.","class":"fact"}]`
+
+		runConsolidator(t, f)
+
+		set := lastCall(t, f, "Memory.set")
+		if got, _ := set.Input["observed_at"].(string); got != tc.want {
+			t.Errorf("stamp %q -> observed_at %q, want %q", tc.stamp, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
RFC CW **Probe 1b**, and the direct consequence of Probe 1's measurement.

## What Probe 1 measured

Probe 1 (#1139) asked the extractor for `observed_at`. Across three full runs: **0 of ~240 facts carried it.**

The same prompt change *did* lift the pre-registered temporal slice from **2 → 8–10 correct**, against a same-binary variance yardstick of 6/8 (p=0.79) — but by making the model keep dates in the fact **prose**, not by filling the field. Verified directly: given `[7:56 pm on 7 July, 2023] Dave: I moved to Berlin last month`, qwen3.8 returns

```json
[{"text": "Dave moved to Berlin for a new job.", "class": "fact", "type": "event", "subject": "Dave"}]
```

No temporal field, and "last month" dropped too.

So the field stays empty however the request is worded, and **none of its value has been collected.** Asking an LLM to echo a date it was just handed is the wrong shape for the job — the timestamp is already machine-readable in the turn text, so the pass reads it. *Mechanism, not judgement*, the same reason this consolidator is code-js rather than an LLM.

## Design decisions worth reviewing

**Attribution is per fact, not per batch.** A queued batch spans several turns with different dates; one date for the batch would file facts under a day they didn't happen. `deriveSpans` has already matched each fact to its source line and that line carries the stamp, so the fact's own quote is the attribution path. A fact with no usable quote falls back **only** when the whole text carries exactly one distinct timestamp — two candidates is an ambiguity, and the field is omitted.

**Deliberately not `Date.parse`.** It accepts nearly anything and resolves ambiguity by guessing, which is the one behaviour this field must not have. A strict recogniser handles the shapes real corpora use — RFC3339, `2023-07-07 19:56`, date-only, and LoCoMo's `7:56 pm on 7 July, 2023` — and refuses everything else. Instants are built as strings, so there's no local-timezone shift between transcript and store.

**A model-supplied value is never overwritten.** The model saw the sentence and may have resolved a relative date the parser cannot. The parser fills a gap; it doesn't override a reading.

## What was tested

5 cases in `cmd/loomcycle/presets_memory_stamp_test.go`. The regression feeds the fake extractor **exactly what the live model returns** — no temporal field at all — and asserts the fact still lands dated. Fails on the unfixed bundle with `observed_at = ""`.

The others pin the discipline: an unparseable stamp is omitted not guessed (and the fact is still kept), a model value is preserved, two stamps in one batch are attributed separately rather than collapsed, and all four accepted shapes parse.

Full `go test ./...` clean (99 packages); `validate` OK on `base,memory` and `base,local,memory`; embedded bundle re-synced.

## On how Probe 1 was verified badly

Its unit tests **injected** `observed_at` into the fake extractor's JSON. They correctly proved the write path *carries* the field and proved nothing about whether a real model *emits* one — a stub that always cooperates cannot test compliance. That's why this change is tested against the model's actual output shape, and why RFC CW now requires a live call asserting the model produces the shape any probe depends on.

## Expected effect

Additive on top of Probe 1's measured temporal gain, since the structured field's value is entirely uncollected so far. It needs measuring the same way — paired, **with a same-binary replicate**, because variance on that slice is worth ±2 correct answers and would otherwise manufacture a result on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8