### PR TITLE
fix(store): MemoryList returns the temporal columns it was silently dropping

### DIFF
--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -3749,7 +3749,18 @@ func (s *Store) MemoryList(ctx context.Context, tenantID string, scope store.Mem
 	}
 	pattern := escapeLikePrefix(prefix) + "%"
 	rows, err := s.pool.Query(ctx,
-		`SELECT key, value::text, expires_at, created_at, updated_at
+		// observed_at / valid_at / invalid_at are SELECTED here, and their absence
+		// was a real defect rather than an omission with no consequence:
+		// MemoryEntry carries the three fields, so a listing that did not read
+		// them serialised the ZERO instant for every row — reporting "undated" for
+		// rows that were correctly dated in the table. Zero is a MEANINGFUL value
+		// on this column ("undated is the honest state for most rows"), so nothing
+		// downstream could tell the difference between absent and unread. It cost
+		// four wrong conclusions in one benchmarking session, including a written-up
+		// finding that the extractor never filled the fields, when the rows in
+		// Postgres carried real timestamps the whole time.
+		`SELECT key, value::text, expires_at, created_at, updated_at,
+		        observed_at, valid_at, invalid_at
 		 FROM memory
 		 WHERE tenant_id = $1 AND scope = $2 AND scope_id = $3 AND key LIKE $4 ESCAPE '\'
 		   AND (expires_at IS NULL OR expires_at > NOW())
@@ -3765,13 +3776,17 @@ func (s *Store) MemoryList(ctx context.Context, tenantID string, scope store.Mem
 	var out []store.MemoryEntry
 	for rows.Next() {
 		var (
-			key       string
-			valueText []byte
-			expiresAt *time.Time
-			createdAt time.Time
-			updatedAt time.Time
+			key        string
+			valueText  []byte
+			expiresAt  *time.Time
+			createdAt  time.Time
+			updatedAt  time.Time
+			observedAt *time.Time
+			validAt    *time.Time
+			invalidAt  *time.Time
 		)
-		if err := rows.Scan(&key, &valueText, &expiresAt, &createdAt, &updatedAt); err != nil {
+		if err := rows.Scan(&key, &valueText, &expiresAt, &createdAt, &updatedAt,
+			&observedAt, &validAt, &invalidAt); err != nil {
 			return nil, false, fmt.Errorf("memory list scan: %w", err)
 		}
 		entry := store.MemoryEntry{
@@ -3782,6 +3797,18 @@ func (s *Store) MemoryList(ctx context.Context, tenantID string, scope store.Mem
 		}
 		if expiresAt != nil {
 			entry.ExpiresAt = *expiresAt
+		}
+		// Scanned as pointers because the columns are NULLABLE and NULL is the
+		// undated case: a zero time.Time is what an undated row must present, so
+		// leaving the field untouched is exactly right.
+		if observedAt != nil {
+			entry.ObservedAt = *observedAt
+		}
+		if validAt != nil {
+			entry.ValidAt = *validAt
+		}
+		if invalidAt != nil {
+			entry.InvalidAt = *invalidAt
 		}
 		out = append(out, entry)
 	}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -4373,7 +4373,12 @@ func (s *Store) MemoryList(ctx context.Context, tenantID string, scope store.Mem
 	nowNs := time.Now().UnixNano()
 	// Fetch limit+1 to detect truncation without a separate COUNT(*).
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT key, value, expires_at, created_at, updated_at
+		// observed_at / valid_at / invalid_at are SELECTED here — see the note on
+		// the postgres twin. Omitting them made a listing report the ZERO instant
+		// for correctly-dated rows, and zero is a meaningful value on this column
+		// ("undated"), so absent and unread were indistinguishable downstream.
+		`SELECT key, value, expires_at, created_at, updated_at,
+		        observed_at, valid_at, invalid_at
 		 FROM memory
 		 WHERE tenant_id = ? AND scope = ? AND scope_id = ? AND key LIKE ? ESCAPE '\'
 		   AND (expires_at IS NULL OR expires_at > ?)
@@ -4389,13 +4394,17 @@ func (s *Store) MemoryList(ctx context.Context, tenantID string, scope store.Mem
 	var out []store.MemoryEntry
 	for rows.Next() {
 		var (
-			key       string
-			valueText string
-			expiresAt sql.NullInt64
-			createdAt int64
-			updatedAt int64
+			key        string
+			valueText  string
+			expiresAt  sql.NullInt64
+			createdAt  int64
+			updatedAt  int64
+			observedAt sql.NullInt64
+			validAt    sql.NullInt64
+			invalidAt  sql.NullInt64
 		)
-		if err := rows.Scan(&key, &valueText, &expiresAt, &createdAt, &updatedAt); err != nil {
+		if err := rows.Scan(&key, &valueText, &expiresAt, &createdAt, &updatedAt,
+			&observedAt, &validAt, &invalidAt); err != nil {
 			return nil, false, err
 		}
 		entry := store.MemoryEntry{
@@ -4406,6 +4415,18 @@ func (s *Store) MemoryList(ctx context.Context, tenantID string, scope store.Mem
 		}
 		if expiresAt.Valid {
 			entry.ExpiresAt = time.Unix(0, expiresAt.Int64)
+		}
+		// NULL is the undated case, and a zero time.Time is what undated must
+		// present — so an invalid Null* leaves the field alone rather than
+		// writing time.Unix(0,0), which is 1970 and would be a WRONG date.
+		if observedAt.Valid {
+			entry.ObservedAt = time.Unix(0, observedAt.Int64)
+		}
+		if validAt.Valid {
+			entry.ValidAt = time.Unix(0, validAt.Int64)
+		}
+		if invalidAt.Valid {
+			entry.InvalidAt = time.Unix(0, invalidAt.Int64)
 		}
 		out = append(out, entry)
 	}

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -81,6 +81,7 @@ func Run(t *testing.T, factory Factory) {
 		// (append / tenant-scoped since-cursor / prune). sqlite always;
 		// Postgres when a DSN is set.
 		{"MemoryChangesFeed", testMemoryChangesFeed},
+		{"MemoryListReturnsTemporalColumns", testMemoryListReturnsTemporalColumns},
 		{"CreateSessionUserIDRoundTrip", testCreateSessionUserIDRoundTrip},
 		{"CreateRunIdentityRoundTrip", testCreateRunIdentityRoundTrip},
 		{"CreateRunParentContextRoundTrip", testCreateRunParentContextRoundTrip},
@@ -11995,5 +11996,75 @@ func testMemoryCursorReleaseByOwner(t *testing.T, s store.Store) {
 		t.Fatal(err)
 	} else if ok {
 		t.Error("an empty-owner release freed a live lease")
+	}
+}
+
+// testMemoryListReturnsTemporalColumns — a listing must report the times the row
+// actually carries.
+//
+// WHY THIS IS A CONTRACT TEST AND NOT A BACKEND ONE. Both backends had the same
+// defect independently: MemoryList selected key/value/expires/created/updated and
+// nothing else, while MemoryEntry carries ObservedAt/ValidAt/InvalidAt. So every
+// listed row serialised the ZERO instant regardless of what was stored. Zero is a
+// MEANINGFUL value on these columns — "undated is the honest state for most rows"
+// — so no caller could distinguish "this row has no observed time" from "the query
+// forgot to ask". It went unnoticed through a whole benchmarking session and
+// produced four wrong conclusions, including a written-up finding that the
+// extractor never populated the fields while Postgres held real timestamps.
+//
+// The assertion is deliberately on a NON-ZERO round trip plus an undated row in
+// the same listing: reading the columns is only half the contract, and a fix that
+// mapped NULL onto Unix(0,0) — 1970, a wrong date — would pass a
+// non-zero-only test while corrupting every undated row.
+func testMemoryListReturnsTemporalColumns(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	const scopeID = "temporal-list"
+	observed := time.Date(2023, 7, 7, 19, 56, 0, 0, time.UTC)
+	validAt := time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC)
+	invalidAt := time.Date(2023, 8, 1, 0, 0, 0, 0, time.UTC)
+
+	if err := s.MemorySetTimed(ctx, "", store.MemoryScopeUser, scopeID, "memory/fact/dated",
+		json.RawMessage(`{"text":"dated"}`), 0, store.MemoryProvenance{},
+		store.MemoryTimes{ObservedAt: observed, ValidAt: validAt, InvalidAt: invalidAt}); err != nil {
+		t.Fatalf("MemorySetTimed dated: %v", err)
+	}
+	// An UNDATED row in the same listing — the other half of the contract.
+	if err := s.MemorySetTimed(ctx, "", store.MemoryScopeUser, scopeID, "memory/fact/undated",
+		json.RawMessage(`{"text":"undated"}`), 0, store.MemoryProvenance{},
+		store.MemoryTimes{}); err != nil {
+		t.Fatalf("MemorySetTimed undated: %v", err)
+	}
+
+	entries, _, err := s.MemoryList(ctx, "", store.MemoryScopeUser, scopeID, "memory/", 100)
+	if err != nil {
+		t.Fatalf("MemoryList: %v", err)
+	}
+	got := map[string]store.MemoryEntry{}
+	for _, e := range entries {
+		got[e.Key] = e
+	}
+	dated, ok := got["memory/fact/dated"]
+	if !ok {
+		t.Fatalf("dated row missing from listing (%d entries)", len(entries))
+	}
+	if !dated.ObservedAt.UTC().Equal(observed) {
+		t.Errorf("ObservedAt = %v, want %v — a listing that drops the column reports every "+
+			"row as undated, and zero is a meaningful value here so nothing downstream can tell",
+			dated.ObservedAt.UTC(), observed)
+	}
+	if !dated.ValidAt.UTC().Equal(validAt) {
+		t.Errorf("ValidAt = %v, want %v", dated.ValidAt.UTC(), validAt)
+	}
+	if !dated.InvalidAt.UTC().Equal(invalidAt) {
+		t.Errorf("InvalidAt = %v, want %v", dated.InvalidAt.UTC(), invalidAt)
+	}
+	undated, ok := got["memory/fact/undated"]
+	if !ok {
+		t.Fatalf("undated row missing from listing")
+	}
+	if !undated.ObservedAt.IsZero() || !undated.ValidAt.IsZero() || !undated.InvalidAt.IsZero() {
+		t.Errorf("undated row reports observed=%v valid=%v invalid=%v, want all ZERO — mapping "+
+			"NULL onto Unix(0,0) would date every undated row to 1970, which is worse than "+
+			"reporting nothing", undated.ObservedAt, undated.ValidAt, undated.InvalidAt)
 	}
 }


### PR DESCRIPTION
## The bug

`MemoryList` selected `key, value, expires_at, created_at, updated_at` and nothing else — **in both backends** — while `store.MemoryEntry` carries `ObservedAt` / `ValidAt` / `InvalidAt`. Every listed row therefore serialised the **zero instant** no matter what the table held.

Zero is a **meaningful** value on these columns. The field docs say so: *"ZERO MEANS UNDATED, and undated is the honest state for most rows."* That is precisely why this survived — no caller could distinguish "this row has no observed time" from "the query forgot to ask", so the endpoint returned a plausible answer rather than an obviously broken one.

## How it was found

Disagreement with ground truth. For one key:

```
GET /v1/_memory/scopes/user/<id>/keys  →  observed_at 0001-01-01T00:00:00Z
psql                                   →  observed_at 2023-10-13 13:31:00+03
```

## What it cost

Four wrong conclusions in a single benchmarking session, all built on the listing as a measurement instrument:

1. A recorded finding that **0 of 217 facts** carried any temporal field — written into RFC CV as OQ9.
2. A Probe 1 conclusion that the extractor **never fills** the fields.
3. The follow-on inference that Probe 1's measured temporal gain must have come from date-bearing *prose* rather than the designed mechanism.
4. A Probe 1b smoke test read as a **failure** when the parser was in fact stamping **114 of 114** facts.

The rows were dated the whole time. Those RFC claims are being corrected separately.

## The fix, and the test

Both backends had the defect **independently**, so this is a **store-contract** test rather than a backend one.

It asserts a non-zero round trip **and an undated row in the same listing**. Reading the columns is only half the contract: a fix that mapped `NULL` onto `Unix(0, 0)` — 1970, a wrong date — would pass a non-zero-only test while corrupting every undated row. Hence pointer / `sql.NullInt64` scans that leave the field untouched when NULL, and an explicit assertion that the undated row still reports zero.

Fails on the unfixed backends with:

```
ObservedAt = 0001-01-01 00:00:00 +0000 UTC, want 2023-07-07 19:56:00 +0000 UTC
```

## Verification

- Store contract green on **sqlite** and on the **Postgres tier** (`LOOMCYCLE_TEST_PG_DSN`, 119s).
- Full `go test ./...` clean (99 packages).

## Note

`MemoryEntry`'s temporal fields are still not populated by any *other* read path — `ObservedAt:` is assigned nowhere else in either backend. This PR fixes the listing that had a caller depending on it; whether `MemoryGet` and the search projections should also return them is a separate question worth answering deliberately rather than by extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8