### PR TITLE
docs(memory): correct why the observed_at parser exists — it is a fallback

### DIFF
--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -1483,16 +1483,27 @@ agents:
       // stampObservedAt fills `observed_at` from the TURN'S OWN TIMESTAMP, by
       // PARSING it — no model call, no model cooperation.
       //
-      // WHY THIS IS NOT A PROMPT PROBLEM. The prompt was changed to ask for
-      // `observed_at` and the extractor simply did not emit it: measured across
-      // three full runs, 0 of ~240 facts carried the field, while the very same
-      // change lifted the temporal slice from 2 to 8-10 correct answers purely by
-      // making the model keep dates in the fact PROSE. So asking works, partly, for
-      // the wrong reason — and the structured field stays empty however the request
-      // is worded. Asking an LLM to echo a date it was just handed is the wrong
-      // shape for the job. The timestamp is already machine-readable in the turn
-      // text, so the pass reads it directly: mechanism, not judgement, which is the
-      // same reason this consolidator is code-js rather than an LLM.
+      // ⚠️ WHY THIS IS A FALLBACK AND NOT THE PRIMARY PATH — corrected 2026-09-08.
+      //
+      // This function was added on the belief that the extractor does not emit
+      // `observed_at`: an API listing reported 0 of ~240 facts carrying the field
+      // across three runs. THAT WAS A DEFECT IN THE LISTING, not a fact about the
+      // store — `MemoryList` dropped the temporal columns in both backends and
+      // serialised the zero instant for every row (#1144). Measured afterwards by
+      // direct SQL, the extractor fills `observed_at` on 100% of facts with real
+      // per-turn dates, entirely without this parser.
+      //
+      // So the prompt DOES work and this is not the mechanism that made Probe 1
+      // succeed. What it is: cover for a weaker or non-compliant extractor. The
+      // three-model comparison found that extractor tier does not otherwise matter
+      // (0.2245 / 0.2266 / 0.2665, no pairing significant), so an operator may
+      // reasonably run a small local model — and a model that silently omits the
+      // field would leave every fact undated with nothing to notice it. This keeps
+      // that deployment dated at no token cost.
+      //
+      // It is deliberately GAP-FILLING ONLY: a model-supplied value always wins,
+      // because the model read the sentence and may have resolved a relative date
+      // ("last month") that a timestamp parser cannot.
       //
       // ATTRIBUTION. A batch spans several turns with different timestamps, so a
       // single date for the batch would file facts under a day they did not happen.

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -1483,16 +1483,27 @@ agents:
       // stampObservedAt fills `observed_at` from the TURN'S OWN TIMESTAMP, by
       // PARSING it — no model call, no model cooperation.
       //
-      // WHY THIS IS NOT A PROMPT PROBLEM. The prompt was changed to ask for
-      // `observed_at` and the extractor simply did not emit it: measured across
-      // three full runs, 0 of ~240 facts carried the field, while the very same
-      // change lifted the temporal slice from 2 to 8-10 correct answers purely by
-      // making the model keep dates in the fact PROSE. So asking works, partly, for
-      // the wrong reason — and the structured field stays empty however the request
-      // is worded. Asking an LLM to echo a date it was just handed is the wrong
-      // shape for the job. The timestamp is already machine-readable in the turn
-      // text, so the pass reads it directly: mechanism, not judgement, which is the
-      // same reason this consolidator is code-js rather than an LLM.
+      // ⚠️ WHY THIS IS A FALLBACK AND NOT THE PRIMARY PATH — corrected 2026-09-08.
+      //
+      // This function was added on the belief that the extractor does not emit
+      // `observed_at`: an API listing reported 0 of ~240 facts carrying the field
+      // across three runs. THAT WAS A DEFECT IN THE LISTING, not a fact about the
+      // store — `MemoryList` dropped the temporal columns in both backends and
+      // serialised the zero instant for every row (#1144). Measured afterwards by
+      // direct SQL, the extractor fills `observed_at` on 100% of facts with real
+      // per-turn dates, entirely without this parser.
+      //
+      // So the prompt DOES work and this is not the mechanism that made Probe 1
+      // succeed. What it is: cover for a weaker or non-compliant extractor. The
+      // three-model comparison found that extractor tier does not otherwise matter
+      // (0.2245 / 0.2266 / 0.2665, no pairing significant), so an operator may
+      // reasonably run a small local model — and a model that silently omits the
+      // field would leave every fact undated with nothing to notice it. This keeps
+      // that deployment dated at no token cost.
+      //
+      // It is deliberately GAP-FILLING ONLY: a model-supplied value always wins,
+      // because the model read the sentence and may have resolved a relative date
+      // ("last month") that a timestamp parser cannot.
       //
       // ATTRIBUTION. A batch spans several turns with different timestamps, so a
       // single date for the batch would file facts under a day they did not happen.

--- a/cmd/loomcycle/presets_memory_stamp_test.go
+++ b/cmd/loomcycle/presets_memory_stamp_test.go
@@ -4,21 +4,26 @@ import (
 	"testing"
 )
 
-// RFC CW Probe 1b — observed_at is PARSED from the turn, not requested from the
-// model.
+// RFC CW Probe 1b — observed_at parsed from the turn as a FALLBACK.
 //
-// Probe 1 asked the extractor for `observed_at` and measured the answer across
-// three full runs: 0 of ~240 facts carried it. The same prompt change did lift
-// the temporal slice from 2 to 8-10 correct — but by making the model keep dates
-// in the fact PROSE, not by filling the field. So the field stays empty however
-// the request is worded, and the value of having it has never been collected.
+// ⚠️ Corrected 2026-09-08. These tests were written believing the extractor never
+// emits `observed_at` — an API listing reported 0 of ~240 facts carrying it. That
+// was a defect in the listing, which dropped the temporal columns in both
+// backends (#1144). Direct SQL afterwards showed the extractor fills the field on
+// 100% of facts, with real per-turn dates, without this parser at all.
 //
-// The timestamp is already machine-readable in the turn text, so the pass reads
-// it. Mechanism, not judgement.
+// What the parser is FOR, then: a weaker or non-compliant extractor. Extractor
+// tier was measured not to matter otherwise, so an operator may reasonably run a
+// small local model, and one that silently omits the field would leave every fact
+// undated with nothing to notice it. The tests below still describe the behaviour
+// correctly — they feed an extractor that emits no temporal field, which is
+// exactly the deployment this covers — only the premise about how COMMON that is
+// was wrong.
 
 // TestConsolidator_ObservedAtIsParsedFromTheTurnWithoutTheModel is the
-// regression. The extractor emits NO temporal field — exactly as the live model
-// behaves — and the fact must still land dated.
+// regression. The extractor emits NO temporal field — the non-compliant case this
+// parser exists for, NOT what the measured model does — and the fact must still
+// land dated.
 //
 // FAILS on the unfixed bundle: nothing parses the turn, so observed_at is absent.
 func TestConsolidator_ObservedAtIsParsedFromTheTurnWithoutTheModel(t *testing.T) {


### PR DESCRIPTION
**No behaviour change.** This corrects the stated rationale for #1143, which shipped on a false premise and said so at length in the comments.

## The premise was wrong

#1143 was built on the belief that the extractor never emits `observed_at` — an API listing reported **0 of ~240 facts** carrying the field across three runs.

That was a defect in the listing. `MemoryList` dropped the temporal columns in both backends and serialised the zero instant for every row (#1144). Measured afterwards by direct SQL, on a binary whose **served commit was asserted**, on the **pre-parser** build:

| field | coverage |
|---|---|
| `observed_at` | **86/86 = 100%**, real per-turn 2023 dates, no schema default |
| `valid_at` | 16/86 ≈ 19% |

**Probe 1 worked exactly as designed** — it asked for the fields and the model filled them. The parser was never the mechanism that made it succeed.

## What the parser is actually for

It stays, with its purpose stated correctly: **cover for a weaker or non-compliant extractor.**

That's a real deployment rather than a hypothetical. The three-model comparison found extractor tier doesn't otherwise matter (0.2245 / 0.2266 / 0.2665, no pairing significant), so an operator may reasonably run a small local model — and one that silently omits the field would leave every fact undated with nothing to notice it. This keeps that deployment dated at no token cost.

**Gap-filling only:** a model-supplied value always wins, because the model read the sentence and may have resolved a relative date ("last month") that a timestamp parser cannot.

## Why the tests didn't change

They still describe the behaviour correctly — they feed an extractor that emits no temporal field, which is precisely the case this covers. Only their **header** asserted the wrong thing about how common that case is, and that's corrected.

I'd rather leave a correct explanation of a redundant-looking guard than leave code whose comments argue from a measurement that turned out to be an instrument artifact. RFC CV (OQ9) and RFC CW (Probe 1) carry matching corrections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8