### PR TITLE
feat(memory): recall reaches through to the span a fact was distilled from

### DIFF
--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -308,6 +308,7 @@ const memoryInputSchema = `{
     "ids":           {"type": "array", "description": "pending_ack: the pending-row ids to mark drained (as returned by pending_drain).", "items": {"type": "string"}},
     "provenance":    {"type": "object", "description": "set-only: where this fact came from, recorded alongside the row. class is a short label for the kind of fact (e.g. preference, fact, decision, correction); source_session_id / source_run_id name the chat and run it was distilled from (relay them from pending_drain or the transcript you read). Descriptive only — it never changes what the write can reach. The writer identity is stamped server-side.", "properties": {"class": {"type": "string"}, "source_session_id": {"type": "string"}, "source_run_id": {"type": "string"}}, "additionalProperties": false},
     "from_pending":  {"type": "string", "description": "set-only: the id of a pending item you drained, so this fact records what produced it. Pass the id and the server fills in the origin and source ids from that row — you cannot set those yourself. Unknown or unowned ids are ignored and the write still succeeds. Prefer this over filling source_session_id / source_run_id by hand when the fact came from a drained item."},
+    "include_source": {"type": "boolean", "description": "recall-only: include the verbatim source span each fact was distilled from, when one was recorded (default TRUE). The span carries the original wording and its own leading timestamp, so a fact whose summary dropped \"last week\" is still datable through it. Pass false for a smaller payload."},
     "include_provenance": {"type": "boolean", "description": "get-only: also return where the fact came from, and whether that origin is still readable (origin_available). A false origin_available means the chat has since been deleted — the fact is still valid, you just cannot go re-read its source."}
   },
   "required": ["op","scope"],
@@ -420,6 +421,12 @@ type memoryInput struct {
 	// whether that origin is still inspectable (RFC BL P3). Opt-in: it costs a
 	// second read, and the default output stays byte-identical.
 	IncludeProvenance bool `json:"include_provenance,omitempty"`
+
+	// IncludeSource is a POINTER so absent and false are distinguishable: absent
+	// means "default", which is ON, and an explicit false is a caller opting out of
+	// the payload. A plain bool would make every caller that never heard of the
+	// field opt out silently.
+	IncludeSource *bool `json:"include_source,omitempty"`
 }
 
 // memoryProvenanceInput is the model-supplied half of store.MemoryProvenance.
@@ -1674,12 +1681,40 @@ func (m *Memory) execRecall(ctx context.Context, scope store.MemoryScope, scopeI
 	if err != nil {
 		return errResult(fmt.Sprintf("recall: %s", err)), nil
 	}
+	// RFC CV P1 — REACH THROUGH TO THE SOURCE. A recalled fact now carries the
+	// verbatim span it was distilled from, when one was recorded.
+	//
+	// DEFAULT-ON, deliberately, and not behind a flag the caller must remember.
+	// RFC CL measured the alternative: asked to construct a `when` window from a
+	// system-prompt rule, the answerer ignored the instruction on EVERY question
+	// tried; handed one, it passed it through faithfully. A provenance field that
+	// only appears when an agent thinks to ask for it is a field that mostly does
+	// not appear. `include_source: false` suppresses it for a caller that wants the
+	// smaller payload.
+	//
+	// The span is already capped at write time (the consolidator's
+	// max_quote_chars), so this adds roughly one sentence per hit.
+	var spans map[string]string
+	if in.IncludeSource == nil || *in.IncludeSource {
+		ids := make([]string, 0, len(res.Facts))
+		for _, f := range res.Facts {
+			ids = append(ids, f.ID)
+		}
+		spans = SourceSpansFor(ctx, m.SqlMem, tools.RunIdentity(ctx).TenantID, scope, scopeID, ids)
+	}
 	memories := make([]map[string]any, 0, len(res.Facts))
 	for _, f := range res.Facts {
 		mem := map[string]any{
 			"id":     f.ID, // server-assigned; opaque to loomcycle, NOT a caller key
 			"memory": f.Memory,
 			"score":  f.Score,
+		}
+		// "source" is the ORIGINAL WORDING, not a second opinion: it carries the
+		// turn's own leading timestamp and whatever relative phrasing distillation
+		// dropped, which is exactly what a "when did X happen" question needs and a
+		// summarised sentence cannot supply.
+		if sp := spans[f.ID]; sp != "" {
+			mem["source"] = sp
 		}
 		// Omitted when the backend could not classify the row — see RecallFact.Kind.
 		// An absent kind means "unknown", which is why this is not defaulted.

--- a/internal/tools/builtin/memory_source_span.go
+++ b/internal/tools/builtin/memory_source_span.go
@@ -1,0 +1,90 @@
+package builtin
+
+import (
+	"context"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// maxSourceSpanLookup bounds the IN list. recall itself caps at 50 hits, so this
+// is headroom rather than a policy — it exists so a future caller raising the cap
+// cannot turn one recall into an unbounded query.
+const maxSourceSpanLookup = 64
+
+// SourceSpansFor returns the verbatim source span recorded for each recalled
+// fact, keyed by the fact's id.
+//
+// WHY THIS EXISTS (RFC CV P1). Every system that scores well on long-conversation
+// QA keeps the episode reachable from the fact: Graphiti's facts point at their
+// source episode, MemGPT's recall memory IS the transcript. loomcycle's own
+// numbers say the same thing louder than any of them — the raw-turns arm answers
+// temporal questions at 0.873 while the distilled-facts arm answers them at 0.18.
+// The information exists; distillation discards it.
+//
+// ⚠️ RFC CV P1 SAYS THE POINTER IS `session_id` / `event_seq` AND THAT IS NOT WHAT
+// IS POPULATED. Measured on a live rig, 87 rows of chunk_memory_meta: session_id 0,
+// event_seq 0, run_id 87 — and `source_quote` 76 (87%). So the plan's stated
+// reach-through (resolve a session event through History) has no data behind it,
+// while the span it wanted to reach is ALREADY STORED on the fact. This reads what
+// exists instead of resolving what does not, which makes P1's first slice a
+// projection rather than a new lookup path.
+//
+// The span is what the temporal case needs, because it is stored with its own
+// leading timestamp — e.g. `user: [1:56 pm on 8 May, 2023] Caroline: …`. A
+// distilled sentence that dropped "last week" is undatable; its span is not.
+//
+// A fact's id from recall IS the k/v key, and a fact chunk's `natural_key` is that
+// key verbatim — the bundle keeps one key space for both stores precisely so they
+// cannot drift. That is the join, and it needs no new column.
+//
+// Returns nil on any failure. A missing span must degrade to "no span" rather than
+// failing the recall: the distilled fact is still a valid answer, and an error here
+// would trade a working retrieval for a provenance nicety.
+func SourceSpansFor(ctx context.Context, sm *sqlmem.Manager, tenantID string,
+	scope store.MemoryScope, scopeID string, factIDs []string) map[string]string {
+	if sm == nil || len(factIDs) == 0 {
+		return nil
+	}
+	key, ok := docScopeKeyFor(tenantID, scope, scopeID)
+	if !ok {
+		return nil
+	}
+	keys := make([]any, 0, len(factIDs))
+	seen := make(map[string]bool, len(factIDs))
+	for _, id := range factIDs {
+		// Only k/v-keyed facts can join: a document-chunk hit's id is a chunk id,
+		// which is not a natural_key and would match nothing.
+		if id == "" || seen[id] || !strings.HasPrefix(id, "memory/") {
+			continue
+		}
+		seen[id] = true
+		keys = append(keys, id)
+		if len(keys) >= maxSourceSpanLookup {
+			break
+		}
+	}
+	if len(keys) == 0 {
+		return nil
+	}
+	stmt := `SELECT natural_key, source_quote FROM chunk_memory_meta ` +
+		`WHERE source_quote IS NOT NULL AND source_quote <> '' AND natural_key IN (` +
+		strings.TrimSuffix(strings.Repeat("?,", len(keys)), ",") + `)`
+	res, err := sm.Query(ctx, key, sm.Rebind(stmt), keys)
+	if err != nil || res == nil {
+		return nil
+	}
+	out := make(map[string]string, len(res.Rows))
+	for _, row := range res.Rows {
+		if len(row) < 2 {
+			continue
+		}
+		nk, span := asStr(row[0]), asStr(row[1])
+		if nk == "" || span == "" {
+			continue
+		}
+		out[nk] = span
+	}
+	return out
+}

--- a/internal/tools/builtin/memory_source_span_test.go
+++ b/internal/tools/builtin/memory_source_span_test.go
@@ -1,0 +1,101 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	memrank "github.com/denn-gubsky/loomcycle/internal/memory"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// RFC CV P1 — a recalled fact reaches through to the span it came from.
+//
+// The case for it is the project's own strongest number: the raw-turns arm answers
+// temporal questions at 0.873 while the distilled-facts arm answers them at 0.18.
+// The information exists and distillation discards it — and an existing test in
+// this package already records that recall's gap against `search` "was
+// concentrated in temporal questions, where the model reported the timestamp of
+// the utterance as the date of the event".
+//
+// The span is stored (measured: 76 of 87 chunk_memory_meta rows carry
+// source_quote) and carries its own leading timestamp, so it is precisely what a
+// "when did X happen" question needs from a sentence that dropped "last week".
+
+// TestMemoryTool_Recall_SourceIsAbsentWithoutSQLMemory — degrade, never fail. A
+// missing span must cost the provenance nicety and not the retrieval: the
+// distilled fact is still a valid answer.
+func TestMemoryTool_Recall_SourceIsAbsentWithoutSQLMemory(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t)
+	defer cleanup()
+	tool.SqlMem = nil // SQL Memory disabled on this server
+	tool.Backend = &fakeLayerBackend{recallOut: []memrank.RecallFact{
+		{ID: "memory/fact/dave-berlin", Memory: "Dave moved to Berlin.", Score: 0.9},
+	}}
+
+	res, err := tool.Execute(ctx, json.RawMessage(`{"op":"recall","scope":"user","query":"dave"}`))
+	if err != nil || res.IsError {
+		t.Fatalf("recall failed with SQL Memory off: err=%v res=%+v", err, res)
+	}
+	if strings.Contains(res.Text, `"source"`) {
+		t.Errorf("a source field appeared with no SQL Memory to read it from: %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "Dave moved to Berlin.") {
+		t.Errorf("the fact itself went missing: %s", res.Text)
+	}
+}
+
+// TestMemoryTool_Recall_IncludeSourceFalseSuppressesTheLookup. Default-on is
+// deliberate — RFC CL measured an answerer ignoring a system-prompt instruction on
+// every question tried — but a caller that wants the smaller payload can say so.
+func TestMemoryTool_Recall_IncludeSourceFalseSuppressesTheLookup(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t)
+	defer cleanup()
+	tool.Backend = &fakeLayerBackend{recallOut: []memrank.RecallFact{
+		{ID: "memory/fact/dave-berlin", Memory: "Dave moved to Berlin.", Score: 0.9},
+	}}
+
+	res, err := tool.Execute(ctx, json.RawMessage(
+		`{"op":"recall","scope":"user","query":"dave","include_source":false}`))
+	if err != nil || res.IsError {
+		t.Fatalf("recall failed: err=%v res=%+v", err, res)
+	}
+	if strings.Contains(res.Text, `"source"`) {
+		t.Errorf("include_source:false still returned a source: %s", res.Text)
+	}
+}
+
+// TestSourceSpansFor_OnlyJoinsKvKeyedFacts. The join is fact-id == natural_key,
+// which holds because the bundle keeps ONE key space for both stores. A document
+// chunk's id is a chunk uuid, not a natural key, so including it would widen the
+// IN list to match nothing.
+func TestSourceSpansFor_OnlyJoinsKvKeyedFacts(t *testing.T) {
+	// A nil manager exercises the guard without needing a database: the function
+	// must refuse before building any statement.
+	got := SourceSpansFor(context.Background(), nil, "tnt", store.MemoryScopeUser, "u1",
+		[]string{"memory/fact/a", "doc.chunk:deadbeef", ""})
+	if got != nil {
+		t.Errorf("SourceSpansFor with no manager = %v, want nil", got)
+	}
+}
+
+// TestMemoryTool_Recall_SourceSurvivesAnUnclassifiedRow. `kind` is omitted when the
+// backend cannot classify a row; the source span is independent of that and must
+// not be dropped along with it.
+func TestMemoryTool_Recall_SourceSurvivesAnUnclassifiedRow(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t)
+	defer cleanup()
+	tool.SqlMem = nil
+	tool.Backend = &fakeLayerBackend{recallOut: []memrank.RecallFact{
+		{ID: "memory/fact/a", Memory: "a fact", Score: 0.9}, // no Kind set
+	}}
+
+	res, err := tool.Execute(ctx, json.RawMessage(`{"op":"recall","scope":"user","query":"a"}`))
+	if err != nil || res.IsError {
+		t.Fatalf("recall failed: err=%v res=%+v", err, res)
+	}
+	if strings.Contains(res.Text, `"kind"`) {
+		t.Errorf("an unclassified row asserted a kind: %s", res.Text)
+	}
+}


### PR DESCRIPTION
RFC CV **P1**, first slice. `recall` returned `{id, memory, score, kind}` and dropped provenance the store already holds — the plan's own "the pointer is written, but nothing at retrieval follows it."

## Why

The project's strongest number: the **raw-turns arm answers temporal questions at 0.873 while distilled facts answer at 0.18**. An existing test in this package already records recall's gap against `search` as *"concentrated in temporal questions, where the model reported the timestamp of the utterance as the date of the event."* The information exists; distillation discards it.

## P1's stated pointer isn't the one that's populated

RFC CV says the relation is `session_id` / `event_seq` in `chunk_memory_meta`. Measured on a live rig, 87 rows:

| column | populated |
|---|---|
| `session_id` | **0** |
| `event_seq` | **0** |
| `run_id` | 87 |
| **`source_quote`** | **76 (87%)** |

So the planned reach-through — resolve a session event through History — has **no data behind it**, while the span it wanted is already stored on the fact. This reads what exists, which makes the first slice a **projection** rather than a new lookup path.

The join is `fact-id == natural_key`, which holds because the bundle keeps one key space for both stores precisely so they can't drift. No new column, no schema change.

## Default-on, deliberately

Not behind a flag the caller must remember. RFC CL measured the alternative: asked to construct a `when` window from a system-prompt rule, the answerer **ignored it on every question tried**; handed one, it passed it through faithfully. A provenance field that appears only when an agent thinks to ask is a field that mostly doesn't appear.

`include_source: false` opts out, and the field is a **pointer** so absent (default on) stays distinguishable from an explicit false — a plain bool would silently opt out every caller that never heard of it.

Degrades rather than fails: no SQL Memory, no span, or an unjoinable id costs the provenance and never the retrieval.

## ⚠️ Span quality is the open question, not the wiring

Verified live, and this is the part worth reviewing. A real recall now carries `source` — but:

```
memory: Caroline is planning to attend a transgender conference this month
source: I'm going to a transgender conference this month.              ← good

memory: Caroline attended an LGBTQ conference two days before 12 July
source: user: [4:33 pm on 12 July, 2023] Caroline: Wow!               ← the span is "Wow!"
```

`deriveSpans` matches on **subject overlap** and often lands on a short, uninformative sentence. So this is a **weak proxy** for reaching the turn that actually held the information, ~13% of facts have no span at all, and **the accuracy benefit is unmeasured**.

RFC CV's original design — a real `(session_id, event_seq)` reference resolved through History — is the stronger form and remains unimplemented. This slice is a prerequisite and a cheap test of the hypothesis, not the finished feature.

## Tested

4 cases here plus the existing recall-projection tests; full `go test ./...` clean (99 packages). The accuracy effect needs the paired-plus-replicate protocol before any claim — variance on the temporal slice is worth ±2 correct answers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8