### PR TITLE
fix(store): Postgres memory reads carry the temporal columns

### DIFF
--- a/internal/store/postgres/memory_embeddings.go
+++ b/internal/store/postgres/memory_embeddings.go
@@ -569,7 +569,16 @@ func (s *Store) MemoryEmbedListByModel(ctx context.Context, tenantID string, sco
 		limit = 1000
 	}
 	rows, err := s.pool.Query(ctx,
-		`SELECT me.key, m.value, m.expires_at, m.created_at, m.updated_at
+		// The temporal columns are read even though the reembed endpoint — the
+		// only caller — needs just key+value: a read path that returns a
+		// MemoryEntry with these three unread hands back the ZERO instant,
+		// which is indistinguishable from the honest "undated" state. That is
+		// not a hypothetical confusion; the identical omission in MemoryList
+		// was used as an instrument a dozen times and produced four wrong
+		// conclusions. Populating them here keeps every MemoryEntry-returning
+		// projection safe to read as evidence.
+		`SELECT me.key, m.value, m.expires_at, m.created_at, m.updated_at,
+		        m.observed_at, m.valid_at, m.invalid_at
 		 FROM memory_embeddings me
 		 JOIN memory m
 		    ON me.tenant_id = m.tenant_id AND me.scope = m.scope AND me.scope_id = m.scope_id AND me.key = m.key
@@ -592,8 +601,12 @@ func (s *Store) MemoryEmbedListByModel(ctx context.Context, tenantID string, sco
 			valueBytes           []byte
 			expiresAt            *time.Time
 			createdAt, updatedAt time.Time
+			observedAt           *time.Time
+			validAt              *time.Time
+			invalidAt            *time.Time
 		)
-		if err := rows.Scan(&key, &valueBytes, &expiresAt, &createdAt, &updatedAt); err != nil {
+		if err := rows.Scan(&key, &valueBytes, &expiresAt, &createdAt, &updatedAt,
+			&observedAt, &validAt, &invalidAt); err != nil {
 			return nil, fmt.Errorf("MemoryEmbedListByModel scan: %w", err)
 		}
 		e := store.MemoryEntry{
@@ -604,6 +617,17 @@ func (s *Store) MemoryEmbedListByModel(ctx context.Context, tenantID string, sco
 		}
 		if expiresAt != nil {
 			e.ExpiresAt = *expiresAt
+		}
+		// NULL leaves the field zero; mapping it onto Unix(0, 0) would stamp
+		// 1970 on every undated row.
+		if observedAt != nil {
+			e.ObservedAt = *observedAt
+		}
+		if validAt != nil {
+			e.ValidAt = *validAt
+		}
+		if invalidAt != nil {
+			e.InvalidAt = *invalidAt
 		}
 		out = append(out, e)
 	}

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -3655,19 +3655,30 @@ func (s *Store) MemoryProvenanceGet(ctx context.Context, tenantID string, scope 
 // sees a stale value, even if the sweeper is behind).
 func (s *Store) MemoryGet(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string) (store.MemoryEntry, error) {
 	var (
-		valueText []byte
-		expiresAt *time.Time
-		createdAt time.Time
-		updatedAt time.Time
+		valueText  []byte
+		expiresAt  *time.Time
+		createdAt  time.Time
+		updatedAt  time.Time
+		observedAt *time.Time
+		validAt    *time.Time
+		invalidAt  *time.Time
 	)
 	err := s.pool.QueryRow(ctx,
-		`SELECT value::text, expires_at, created_at, updated_at
+		// The three temporal columns are read here for the same reason
+		// MemoryList reads them: MemoryEntry carries the fields, so a
+		// projection that skips them hands back the ZERO instant, which is
+		// indistinguishable from the honest "undated" state most rows are in.
+		// sqlite's MemoryGet has always read them — this was a backend
+		// divergence, not a deliberate omission.
+		`SELECT value::text, expires_at, created_at, updated_at,
+		        observed_at, valid_at, invalid_at
 		 FROM memory
 		 WHERE tenant_id = $1 AND scope = $2 AND scope_id = $3 AND key = $4
 		   AND (expires_at IS NULL OR expires_at > NOW())
 		   AND superseded_at IS NULL`,
 		tenantID, string(scope), scopeID, key,
-	).Scan(&valueText, &expiresAt, &createdAt, &updatedAt)
+	).Scan(&valueText, &expiresAt, &createdAt, &updatedAt,
+		&observedAt, &validAt, &invalidAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return store.MemoryEntry{}, &store.ErrNotFound{Kind: "memory", ID: key}
 	}
@@ -3682,6 +3693,17 @@ func (s *Store) MemoryGet(ctx context.Context, tenantID string, scope store.Memo
 	}
 	if expiresAt != nil {
 		out.ExpiresAt = *expiresAt
+	}
+	// A NULL column leaves the field at its zero value. Mapping NULL onto
+	// Unix(0, 0) would stamp 1970 on every undated row.
+	if observedAt != nil {
+		out.ObservedAt = *observedAt
+	}
+	if validAt != nil {
+		out.ValidAt = *validAt
+	}
+	if invalidAt != nil {
+		out.InvalidAt = *invalidAt
 	}
 	return out, nil
 }

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -82,6 +82,7 @@ func Run(t *testing.T, factory Factory) {
 		// Postgres when a DSN is set.
 		{"MemoryChangesFeed", testMemoryChangesFeed},
 		{"MemoryListReturnsTemporalColumns", testMemoryListReturnsTemporalColumns},
+		{"MemoryGetReturnsTemporalColumns", testMemoryGetReturnsTemporalColumns},
 		{"CreateSessionUserIDRoundTrip", testCreateSessionUserIDRoundTrip},
 		{"CreateRunIdentityRoundTrip", testCreateRunIdentityRoundTrip},
 		{"CreateRunParentContextRoundTrip", testCreateRunParentContextRoundTrip},
@@ -208,6 +209,7 @@ func Run(t *testing.T, factory Factory) {
 		{"MemoryEmbedSearchReturnsVectors", testMemoryEmbedSearchReturnsVectors},
 		{"MemoryDeleteCascadesEmbedding", testMemoryDeleteCascadesEmbedding},
 		{"MemoryEmbedListByModelFiltersCurrent", testMemoryEmbedListByModelFiltersCurrent},
+		{"MemoryEmbedListByModelReturnsTemporalColumns", testMemoryEmbedListByModelReturnsTemporalColumns},
 		{"MemoryEmbedStatsReportsPerModelCount", testMemoryEmbedStatsReportsPerModelCount},
 		{"ChannelPublishSubscribeRoundTrip", testChannelPublishSubscribeRoundTrip},
 		{"ChannelSubscribeEmptyChannel", testChannelSubscribeEmptyChannel},
@@ -5205,6 +5207,73 @@ func testMemoryEmbedListByModelFiltersCurrent(t *testing.T, s store.Store) {
 		if r.Key == "new1" {
 			t.Errorf("ListByModel returned the current-model row %q", r.Key)
 		}
+	}
+}
+
+// testMemoryEmbedListByModelReturnsTemporalColumns — the reembed listing is a
+// MemoryEntry-returning read path, so it owes the same columns.
+//
+// No caller reads them today (the reembed endpoint needs key+value and writes
+// only to memory_embeddings), so this pins a projection rather than fixing an
+// observable bug. It is worth pinning anyway: the identical omission in
+// MemoryList was used as an INSTRUMENT a dozen times before anyone checked it
+// against the table, and it read as "undated" — plausible, and wrong. Any
+// MemoryEntry a backend hands back should be safe to read as evidence.
+func testMemoryEmbedListByModelReturnsTemporalColumns(t *testing.T, s store.Store) {
+	if !vectorRefusalCheck(t, s) {
+		return
+	}
+	ctx := context.Background()
+	const scopeID = "temporal-reembed"
+	observed := time.Date(2023, 7, 7, 19, 56, 0, 0, time.UTC)
+	validAt := time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	// One dated row and one undated row, both on the OLD model so both come
+	// back from the "not on the current model" query.
+	if err := s.MemorySetTimed(ctx, "", store.MemoryScopeAgent, scopeID, "dated",
+		json.RawMessage(`"x"`), 0, store.MemoryProvenance{},
+		store.MemoryTimes{ObservedAt: observed, ValidAt: validAt}); err != nil {
+		t.Fatalf("MemorySetTimed dated: %v", err)
+	}
+	if err := s.MemorySetTimed(ctx, "", store.MemoryScopeAgent, scopeID, "undated",
+		json.RawMessage(`"x"`), 0, store.MemoryProvenance{}, store.MemoryTimes{}); err != nil {
+		t.Fatalf("MemorySetTimed undated: %v", err)
+	}
+	for _, k := range []string{"dated", "undated"} {
+		if err := s.MemoryEmbedSet(ctx, "", store.MemoryScopeAgent, scopeID, k, store.MemoryEmbedding{
+			Provider: "openai", Model: "text-embedding-3-small", Dimension: 4,
+			Vector: floats32(1, 0, 0, 0), EmbedText: k, CreatedAt: time.Now(),
+		}); err != nil {
+			t.Fatalf("MemoryEmbedSet %s: %v", k, err)
+		}
+	}
+
+	rows, err := s.MemoryEmbedListByModel(ctx, "", store.MemoryScopeAgent, scopeID,
+		"openai", "text-embedding-3-large", 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]store.MemoryEntry{}
+	for _, r := range rows {
+		got[r.Key] = r
+	}
+	dated, ok := got["dated"]
+	if !ok {
+		t.Fatalf("dated row missing from reembed listing (%d rows)", len(rows))
+	}
+	if !dated.ObservedAt.UTC().Equal(observed) {
+		t.Errorf("ObservedAt = %v, want %v", dated.ObservedAt.UTC(), observed)
+	}
+	if !dated.ValidAt.UTC().Equal(validAt) {
+		t.Errorf("ValidAt = %v, want %v", dated.ValidAt.UTC(), validAt)
+	}
+	undated, ok := got["undated"]
+	if !ok {
+		t.Fatalf("undated row missing from reembed listing")
+	}
+	if !undated.ObservedAt.IsZero() || !undated.ValidAt.IsZero() || !undated.InvalidAt.IsZero() {
+		t.Errorf("undated row reports observed=%v valid=%v invalid=%v, want all ZERO",
+			undated.ObservedAt, undated.ValidAt, undated.InvalidAt)
 	}
 }
 
@@ -12061,6 +12130,62 @@ func testMemoryListReturnsTemporalColumns(t *testing.T, s store.Store) {
 	undated, ok := got["memory/fact/undated"]
 	if !ok {
 		t.Fatalf("undated row missing from listing")
+	}
+	if !undated.ObservedAt.IsZero() || !undated.ValidAt.IsZero() || !undated.InvalidAt.IsZero() {
+		t.Errorf("undated row reports observed=%v valid=%v invalid=%v, want all ZERO — mapping "+
+			"NULL onto Unix(0,0) would date every undated row to 1970, which is worse than "+
+			"reporting nothing", undated.ObservedAt, undated.ValidAt, undated.InvalidAt)
+	}
+}
+
+// testMemoryGetReturnsTemporalColumns — the single-key read must report the
+// times too.
+//
+// Same defect class as the listing above, one backend behind: sqlite's
+// MemoryGet has always selected the three columns, Postgres' never did. A
+// pure backend divergence, so the same key read through the two tiers
+// answered differently — and the Postgres answer ("undated") is the one that
+// looks plausible, because most rows genuinely are.
+//
+// Asserted the same way for the same reason: a non-zero round trip AND an
+// undated row, so a NULL-to-Unix(0,0) mapping cannot pass.
+func testMemoryGetReturnsTemporalColumns(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	const scopeID = "temporal-get"
+	observed := time.Date(2023, 7, 7, 19, 56, 0, 0, time.UTC)
+	validAt := time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC)
+	invalidAt := time.Date(2023, 8, 1, 0, 0, 0, 0, time.UTC)
+
+	if err := s.MemorySetTimed(ctx, "", store.MemoryScopeUser, scopeID, "memory/fact/dated",
+		json.RawMessage(`{"text":"dated"}`), 0, store.MemoryProvenance{},
+		store.MemoryTimes{ObservedAt: observed, ValidAt: validAt, InvalidAt: invalidAt}); err != nil {
+		t.Fatalf("MemorySetTimed dated: %v", err)
+	}
+	if err := s.MemorySetTimed(ctx, "", store.MemoryScopeUser, scopeID, "memory/fact/undated",
+		json.RawMessage(`{"text":"undated"}`), 0, store.MemoryProvenance{},
+		store.MemoryTimes{}); err != nil {
+		t.Fatalf("MemorySetTimed undated: %v", err)
+	}
+
+	dated, err := s.MemoryGet(ctx, "", store.MemoryScopeUser, scopeID, "memory/fact/dated")
+	if err != nil {
+		t.Fatalf("MemoryGet dated: %v", err)
+	}
+	if !dated.ObservedAt.UTC().Equal(observed) {
+		t.Errorf("ObservedAt = %v, want %v — a point read that drops the column reports the "+
+			"row as undated, and zero is a meaningful value here so nothing downstream can tell",
+			dated.ObservedAt.UTC(), observed)
+	}
+	if !dated.ValidAt.UTC().Equal(validAt) {
+		t.Errorf("ValidAt = %v, want %v", dated.ValidAt.UTC(), validAt)
+	}
+	if !dated.InvalidAt.UTC().Equal(invalidAt) {
+		t.Errorf("InvalidAt = %v, want %v", dated.InvalidAt.UTC(), invalidAt)
+	}
+
+	undated, err := s.MemoryGet(ctx, "", store.MemoryScopeUser, scopeID, "memory/fact/undated")
+	if err != nil {
+		t.Fatalf("MemoryGet undated: %v", err)
 	}
 	if !undated.ObservedAt.IsZero() || !undated.ValidAt.IsZero() || !undated.InvalidAt.IsZero() {
 		t.Errorf("undated row reports observed=%v valid=%v invalid=%v, want all ZERO — mapping "+


### PR DESCRIPTION
## Why

#1144 fixed `MemoryList` because a caller depended on it. I flagged at the time that "the `MemoryEntry` temporal fields are still dropped by `MemoryGet` and the search projections." This closes that loose end.

`MemoryEntry` carries `ObservedAt` / `ValidAt` / `InvalidAt`. A read path that does not `SELECT` them hands back the **zero instant** — and zero is a *meaningful* value on these columns (undated is the honest state for most rows), so no caller can distinguish "this row has no observed time" from "the query forgot to ask."

That is not hypothetical. The identical omission in `MemoryList` was used as a measurement instrument a dozen times before anyone compared it against the table, and it produced four wrong conclusions — including a written-up finding that the extractor never populated the fields, while Postgres held real 2023 timestamps the whole time.

## What

**Fixed — two Postgres read paths:**

| path | before | note |
|---|---|---|
| `postgres.MemoryGet` | columns unread | pure backend divergence — sqlite's `MemoryGet` has always read them, so the same key answered differently per tier, and the Postgres answer ("undated") is the plausible-looking one |
| `postgres.MemoryEmbedListByModel` | columns unread | no caller reads them today; pins the projection rather than fixing an observable bug |

`NULL` leaves the field zero throughout. Mapping `NULL` onto `Unix(0, 0)` would stamp **1970** on every undated row — worse than reporting nothing.

On `MemoryEmbedListByModel` specifically: the reembed endpoint needs `key`+`value` and writes only to `memory_embeddings`, so nothing observable is broken today. It is fixed anyway because it is a `MemoryEntry`-returning read path, and the whole lesson of #1144 is that any `MemoryEntry` a backend hands back should be safe to read as evidence.

**Audited and deliberately left alone** — I enumerated every `MemoryEntry` / `MemorySearchEntry` construction site in both backends rather than grepping by function name:

- `sqlite.MemoryEmbedSearch` (both build variants) — stubs returning `ErrVectorUnsupported` / `errVecImplPending`.
- `sqlite.MemoryFullTextSearch` — documented no-op returning `(nil, nil)`; SQLite ships no tsvector index, and per the degrade posture the in-process backend falls back to pure-vector fusion.

Those three construct no `MemoryEntry`, so there is nothing to populate. My first survey flagged them as gaps purely because a stub trivially "doesn't populate" — worth stating so the next reader doesn't re-open them.

- `postgres.MemoryEmbedSearch` / `postgres.MemoryFullTextSearch` already read all three (`memory_embeddings.go:381`, `:509`).

## Out of scope — a related gap worth its own PR

The **snapshot** path drops the same three columns in both backends, end to end: `SnapshotReadMemory` doesn't select them → `snapshot.MemoryEntry` has no field for them → `SnapshotRestoreMemory`'s `INSERT` omits them. So a snapshot/restore round-trip **permanently loses** every row's dates.

That is a worse consequence than a misreporting projection, but it is a different change: it touches the archive JSON format (additive + `omitempty`, but still a format surface) across six sites. Not bundled here.

## What was tested

Three store-contract tests, each asserting a **non-zero round trip AND an undated row in the same read**. Reading the columns is only half the contract — a `NULL`→`Unix(0,0)` fix would pass a non-zero-only test while corrupting every undated row.

- `MemoryGetReturnsTemporalColumns` (new)
- `MemoryEmbedListByModelReturnsTemporalColumns` (new, vector-gated)
- `MemoryListReturnsTemporalColumns` (pre-existing, unchanged)

**Fail-before verified** against a local PostgreSQL 17 + pgvector 0.8.6. The tests use only pre-existing identifiers, so they compile against the unfixed code — no build-error fail-before:

```
--- FAIL: TestStoreContract/MemoryGetReturnsTemporalColumns
    ObservedAt = 0001-01-01 00:00:00 +0000 UTC, want 2023-07-07 19:56:00 +0000 UTC
    ValidAt    = 0001-01-01 00:00:00 +0000 UTC, want 2023-06-01 00:00:00 +0000 UTC
    InvalidAt  = 0001-01-01 00:00:00 +0000 UTC, want 2023-08-01 00:00:00 +0000 UTC
--- FAIL: TestStoreContractWithPgvector/MemoryEmbedListByModelReturnsTemporalColumns
    ObservedAt = 0001-01-01 00:00:00 +0000 UTC, want 2023-07-07 19:56:00 +0000 UTC
    ValidAt    = 0001-01-01 00:00:00 +0000 UTC, want 2023-06-01 00:00:00 +0000 UTC
```

Note the discrimination: the vector-gated test passes vacuously under `TestStoreContract` (no pgvector → `vectorRefusalCheck` returns early) and fails only under `TestStoreContractWithPgvector`, which is where it has teeth. CI's pg tier sets `LOOMCYCLE_TEST_PG_VECTOR: "1"`, so it runs there.

**Full suites, all green** with `LOOMCYCLE_TEST_PG_DSN` + `LOOMCYCLE_TEST_PG_VECTOR=1` set (a green run with no DSN would mean *skipped*, not *passed*):

```
ok  internal/store            0.358s
ok  internal/store/cdc        0.548s
ok  internal/store/postgres   257.384s
ok  internal/store/sqlite      33.483s
ok  internal/snapshot           5.113s
ok  internal/memory             1.139s
ok  internal/tools/builtin     29.434s
```

`go build ./...` clean, `gofmt` clean, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8
