### PR TITLE
fix(snapshot): a memory snapshot round trip keeps the temporal columns

### DIFF
--- a/internal/retention/mem_export_chunkbody_test.go
+++ b/internal/retention/mem_export_chunkbody_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
@@ -97,5 +98,101 @@ func TestSweeper_MemExportIncludesChunkBodyRows(t *testing.T) {
 	}
 	if len(entries) != 0 {
 		t.Errorf("base memory survived export+prune: %d rows remain", len(entries))
+	}
+}
+
+// TestSweeper_MemExportCarriesTemporalColumns — the reclamation export must
+// carry a fact's dates, not just its text.
+//
+// Unlike the snapshot path, this one needed no fix: exportBaseMemory marshals
+// store.MemoryEntry straight out of MemoryList, so it inherited the three
+// columns when MemoryList started reading them. That makes the property
+// INCIDENTAL in the same way the chunk-body coverage above is incidental — it
+// holds because of a decision made in a different file. An export is the last
+// copy of an agent's memory before the rows are pruned, so a silently undated
+// export is unrecoverable; this test is what turns a future regression in the
+// projection into a red build instead of a quiet loss.
+func TestSweeper_MemExportCarriesTemporalColumns(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	st, err := sqlite.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+	sm := newTestSqlMem(t)
+
+	seedRetiredAgent(t, st, "acme", "dead", 1)
+	seedAgentSQLScope(t, sm, "acme", "dead")
+	seedAgentDirent(t, st, "acme", "dead")
+
+	observed := time.Date(2023, 7, 7, 19, 56, 0, 0, time.UTC)
+	body, _ := json.Marshal(map[string]string{"body": "Dave moved to Berlin in July 2023."})
+	if err := st.MemorySetTimed(ctx, "", store.MemoryScopeAgent, "dead",
+		"doc.chunk:9f2c1b7e4a", json.RawMessage(body), 0, store.MemoryProvenance{},
+		store.MemoryTimes{ObservedAt: observed}); err != nil {
+		t.Fatalf("seed dated chunk body row: %v", err)
+	}
+
+	sw := New(st, Config{MemMode: "export+prune", ExportDir: dir, SQLMem: sm, Logger: quietLogger, Now: futureHour})
+	if _, err := sw.sweepOnce(ctx); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	var blob string
+	_ = filepath.WalkDir(dir, func(p string, d fs.DirEntry, _ error) error {
+		if d == nil || d.IsDir() || filepath.Base(filepath.Dir(p)) != "agent-memory" {
+			return nil
+		}
+		b, err := os.ReadFile(p)
+		if err == nil {
+			blob = string(b)
+		}
+		return nil
+	})
+	if blob == "" {
+		t.Fatalf("no agent-memory export file was written under %s", dir)
+	}
+	// Asserted on the parsed INSTANT, not on a literal string: the export
+	// marshals time.Time in the host's local zone (e.g. "+03:00"), so a
+	// string match on a "Z" form passes or fails by machine timezone rather
+	// than by whether the date survived.
+	var exported []struct {
+		Key        string    `json:"key"`
+		ObservedAt time.Time `json:"observed_at"`
+	}
+	if err := json.Unmarshal([]byte(blob), &exported); err != nil {
+		t.Fatalf("unmarshal export: %v\n\n%s", err, blob)
+	}
+	var found bool
+	for _, e := range exported {
+		if e.Key != "doc.chunk:9f2c1b7e4a" {
+			continue
+		}
+		found = true
+		if !e.ObservedAt.UTC().Equal(observed) {
+			t.Errorf("exported observed_at = %v, want %v.\n\nAn export is the LAST copy of "+
+				"these rows before the prune deletes them, so a date missing here is gone for "+
+				"good. The field rides along only because exportBaseMemory marshals "+
+				"store.MemoryEntry from MemoryList — if that projection stops reading the "+
+				"column, this is where it costs data.\n\nexport:\n%s",
+				e.ObservedAt.UTC(), observed, blob)
+		}
+	}
+	if !found {
+		t.Fatalf("the seeded row is not in the export:\n%s", blob)
+	}
+
+	// PRE-EXISTING WART, recorded here rather than fixed: `omitempty` on a
+	// time.Time does nothing (encoding/json does not treat a zero struct as
+	// empty), so an UNDATED row exports as "valid_at": "0001-01-01T00:00:00Z"
+	// — a wrong date where the honest answer is no date, in the one file an
+	// operator reads after the rows are gone. Fixing it means pointer fields
+	// on store.MemoryEntry, which changes every API response that marshals
+	// it, so it wants its own change. The snapshot archive type does use
+	// *time.Time + omitempty and correctly omits the key.
+	if !strings.Contains(blob, `"valid_at": "0001-01-01T00:00:00Z"`) {
+		t.Log("note: the year-1 serialisation of an undated valid_at is gone — if that was " +
+			"deliberate, drop this assertion and the comment above it")
 	}
 }

--- a/internal/snapshot/restore.go
+++ b/internal/snapshot/restore.go
@@ -374,6 +374,18 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 			if e.ExpiresAt != nil {
 				expires = *e.ExpiresAt
 			}
+			// A snapshot written before these fields existed decodes them as
+			// nil, which leaves the zero instant — undated, the honest answer.
+			var observed, validAt, invalidAt time.Time
+			if e.ObservedAt != nil {
+				observed = *e.ObservedAt
+			}
+			if e.ValidAt != nil {
+				validAt = *e.ValidAt
+			}
+			if e.InvalidAt != nil {
+				invalidAt = *e.InvalidAt
+			}
 			entry := store.MemorySnapshotEntry{
 				// RFC BL: restore into the row's tenant partition. An older
 				// snapshot with no tenant_id decodes e.TenantID as "" (the
@@ -382,11 +394,14 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 				Scope:    store.MemoryScope(e.Scope),
 				ScopeID:  e.ScopeID,
 				MemoryEntry: store.MemoryEntry{
-					Key:       e.Key,
-					Value:     e.Value,
-					ExpiresAt: expires,
-					CreatedAt: e.CreatedAt,
-					UpdatedAt: e.UpdatedAt,
+					Key:        e.Key,
+					Value:      e.Value,
+					ExpiresAt:  expires,
+					CreatedAt:  e.CreatedAt,
+					UpdatedAt:  e.UpdatedAt,
+					ObservedAt: observed,
+					ValidAt:    validAt,
+					InvalidAt:  invalidAt,
 				},
 			}
 			inserted, err := s.SnapshotRestoreMemory(ctx, entry)

--- a/internal/snapshot/restore_test.go
+++ b/internal/snapshot/restore_test.go
@@ -1015,3 +1015,160 @@ func TestRestore_LegacySnapshotWithoutChecksumStillRestores(t *testing.T) {
 		t.Errorf("AgentDefsRestored = %d, want 1", res.AgentDefsRestored)
 	}
 }
+
+// TestSnapshotRestore_MemoryTemporalSurvivesRoundTrip — a fact's dates must
+// survive capture → JSON → restore onto a different instance.
+//
+// This is the end-to-end form of the store-contract round trip, and it is the
+// one that matches how the loss actually happened: an operator snapshots one
+// instance and restores onto another. Before the fix, every leg dropped the
+// three columns, so the destination held a corpus in which nothing was dated —
+// and because zero means "undated", which is the honest state for most rows,
+// nothing about the restored store looked wrong.
+func TestSnapshotRestore_MemoryTemporalSurvivesRoundTrip(t *testing.T) {
+	src, cleanupSrc := newTestStore(t)
+	defer cleanupSrc()
+	ctx := context.Background()
+
+	observed := mustParseTime(t, "2023-07-07T19:56:00Z")
+	validAt := mustParseTime(t, "2023-06-01T00:00:00Z")
+	invalidAt := mustParseTime(t, "2023-08-01T00:00:00Z")
+
+	if err := src.MemorySetTimed(ctx, "", store.MemoryScopeUser, "u1", "memory/fact/dated",
+		json.RawMessage(`{"text":"dated"}`), 0, store.MemoryProvenance{},
+		store.MemoryTimes{ObservedAt: observed, ValidAt: validAt, InvalidAt: invalidAt}); err != nil {
+		t.Fatalf("MemorySetTimed dated: %v", err)
+	}
+	if err := src.MemorySetTimed(ctx, "", store.MemoryScopeUser, "u1", "memory/fact/undated",
+		json.RawMessage(`{"text":"undated"}`), 0, store.MemoryProvenance{},
+		store.MemoryTimes{}); err != nil {
+		t.Fatalf("MemorySetTimed undated: %v", err)
+	}
+
+	_, raw, err := Capture(ctx, src, CaptureOptions{})
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+
+	// The archive itself must carry the dates, and must OMIT them for the
+	// undated row — the omitempty half of the contract, which is what keeps an
+	// undated snapshot byte-identical to a pre-change one.
+	var env Envelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	byKey := map[string]MemoryEntry{}
+	for _, e := range env.Sections.Memory.Entries {
+		byKey[e.Key] = e
+	}
+	dated, ok := byKey["memory/fact/dated"]
+	if !ok {
+		t.Fatalf("dated row missing from the archive (%d entries)", len(env.Sections.Memory.Entries))
+	}
+	if dated.ObservedAt == nil || !dated.ObservedAt.UTC().Equal(observed) {
+		t.Errorf("archive observed_at = %v, want %v", dated.ObservedAt, observed)
+	}
+	if dated.ValidAt == nil || !dated.ValidAt.UTC().Equal(validAt) {
+		t.Errorf("archive valid_at = %v, want %v", dated.ValidAt, validAt)
+	}
+	if dated.InvalidAt == nil || !dated.InvalidAt.UTC().Equal(invalidAt) {
+		t.Errorf("archive invalid_at = %v, want %v", dated.InvalidAt, invalidAt)
+	}
+	undated, ok := byKey["memory/fact/undated"]
+	if !ok {
+		t.Fatalf("undated row missing from the archive")
+	}
+	if undated.ObservedAt != nil || undated.ValidAt != nil || undated.InvalidAt != nil {
+		t.Errorf("archive dated an UNDATED row: observed=%v valid=%v invalid=%v, want all absent",
+			undated.ObservedAt, undated.ValidAt, undated.InvalidAt)
+	}
+	if strings.Contains(string(raw), `"observed_at":"0001-01-01`) {
+		t.Error("archive serialised the ZERO instant as an observed_at — undated must be an " +
+			"absent field, not year 1")
+	}
+
+	// Restore onto a fresh instance and read the dates back.
+	dst, cleanupDst := newTestStore(t)
+	defer cleanupDst()
+	if _, err := Restore(ctx, dst, raw, RestoreOptions{}); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+
+	got, err := dst.MemoryGet(ctx, "", store.MemoryScopeUser, "u1", "memory/fact/dated")
+	if err != nil {
+		t.Fatalf("MemoryGet on the restored store: %v", err)
+	}
+	if !got.ObservedAt.UTC().Equal(observed) {
+		t.Errorf("restored ObservedAt = %v, want %v", got.ObservedAt.UTC(), observed)
+	}
+	if !got.ValidAt.UTC().Equal(validAt) {
+		t.Errorf("restored ValidAt = %v, want %v", got.ValidAt.UTC(), validAt)
+	}
+	if !got.InvalidAt.UTC().Equal(invalidAt) {
+		t.Errorf("restored InvalidAt = %v, want %v", got.InvalidAt.UTC(), invalidAt)
+	}
+	gotUndated, err := dst.MemoryGet(ctx, "", store.MemoryScopeUser, "u1", "memory/fact/undated")
+	if err != nil {
+		t.Fatalf("MemoryGet undated on the restored store: %v", err)
+	}
+	if !gotUndated.ObservedAt.IsZero() || !gotUndated.ValidAt.IsZero() || !gotUndated.InvalidAt.IsZero() {
+		t.Errorf("restored undated row reports observed=%v valid=%v invalid=%v, want all ZERO",
+			gotUndated.ObservedAt, gotUndated.ValidAt, gotUndated.InvalidAt)
+	}
+}
+
+// TestSnapshotRestore_MemoryWithoutTemporalFieldsRestoresUndated — an archive
+// written BEFORE the temporal fields existed must still restore.
+//
+// The fields were added without a section-version bump precisely so this keeps
+// working: a bump would make an older reader reject the memory section outright
+// (ErrSnapshotVersionTooNew), so the cross-version path is carried by
+// omitempty + the nil→zero decode instead. This test is that path — the JSON
+// below is a v1.0 memory section with no observed_at/valid_at/invalid_at keys,
+// and the row must come back undated rather than failing or landing on year 1.
+func TestSnapshotRestore_MemoryWithoutTemporalFieldsRestoresUndated(t *testing.T) {
+	dst, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	raw := []byte(`{
+	  "schema_version": 1,
+	  "created_at": "2023-01-01T00:00:00Z",
+	  "sections": {
+	    "memory": {
+	      "version": "1.0",
+	      "entries": [
+	        {
+	          "scope": "user",
+	          "scope_id": "legacy",
+	          "key": "memory/fact/old",
+	          "value": {"text":"from an older loomcycle"},
+	          "created_at": "2023-01-01T00:00:00Z",
+	          "updated_at": "2023-01-01T00:00:00Z",
+	          "embedding": null
+	        }
+	      ]
+	    }
+	  }
+	}`)
+
+	res, err := Restore(ctx, dst, raw, RestoreOptions{})
+	if err != nil {
+		t.Fatalf("Restore of a pre-temporal archive: %v", err)
+	}
+	if res.MemoryRestored != 1 {
+		t.Fatalf("MemoryRestored = %d, want 1 (warnings: %v)", res.MemoryRestored, res.Warnings)
+	}
+	got, err := dst.MemoryGet(ctx, "", store.MemoryScopeUser, "legacy", "memory/fact/old")
+	if err != nil {
+		t.Fatalf("MemoryGet: %v", err)
+	}
+	if !got.ObservedAt.IsZero() || !got.ValidAt.IsZero() || !got.InvalidAt.IsZero() {
+		t.Errorf("a pre-temporal archive restored to observed=%v valid=%v invalid=%v, want all "+
+			"ZERO — absent must decode to undated, never to a fabricated date",
+			got.ObservedAt, got.ValidAt, got.InvalidAt)
+	}
+	if !got.CreatedAt.UTC().Equal(mustParseTime(t, "2023-01-01T00:00:00Z")) {
+		t.Errorf("CreatedAt = %v, want the archive's value", got.CreatedAt.UTC())
+	}
+}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -431,6 +431,20 @@ func captureMemory(ctx context.Context, s store.Store, out *MemorySection) error
 			t := r.ExpiresAt
 			entry.ExpiresAt = &t
 		}
+		// Zero stays nil rather than becoming a pointer to the zero instant:
+		// undated must serialise as an absent field, not as year 1.
+		if !r.ObservedAt.IsZero() {
+			t := r.ObservedAt
+			entry.ObservedAt = &t
+		}
+		if !r.ValidAt.IsZero() {
+			t := r.ValidAt
+			entry.ValidAt = &t
+		}
+		if !r.InvalidAt.IsZero() {
+			t := r.InvalidAt
+			entry.InvalidAt = &t
+		}
 		out.Entries = append(out.Entries, entry)
 	}
 	return nil

--- a/internal/snapshot/types.go
+++ b/internal/snapshot/types.go
@@ -280,15 +280,34 @@ type MemoryEntry struct {
 	// single-tenant snapshot stays byte-identical to a pre-RFC-BL one, and a
 	// snapshot written before the column existed decodes to "" (the legacy
 	// tenant) on restore — the graceful cross-version path.
-	TenantID  string                   `json:"tenant_id,omitempty"`
-	Scope     string                   `json:"scope"`
-	ScopeID   string                   `json:"scope_id"`
-	Key       string                   `json:"key"`
-	Value     json.RawMessage          `json:"value"`
-	ExpiresAt *time.Time               `json:"expires_at,omitempty"`
-	CreatedAt time.Time                `json:"created_at"`
-	UpdatedAt time.Time                `json:"updated_at"`
-	Embedding *MemoryEmbeddingSnapshot `json:"embedding"` // explicit null when nil; see memory_embedding.go
+	TenantID  string          `json:"tenant_id,omitempty"`
+	Scope     string          `json:"scope"`
+	ScopeID   string          `json:"scope_id"`
+	Key       string          `json:"key"`
+	Value     json.RawMessage `json:"value"`
+	ExpiresAt *time.Time      `json:"expires_at,omitempty"`
+	CreatedAt time.Time       `json:"created_at"`
+	UpdatedAt time.Time       `json:"updated_at"`
+	// The bi-temporal columns: when the remembered thing was SAID
+	// (ObservedAt) and when it became / stopped being true in the world
+	// (ValidAt / InvalidAt). Carried so a snapshot round trip does not
+	// silently undate every fact — before these existed here, capture read
+	// them from nothing and restore inserted nothing, so a restored corpus
+	// answered "undated" for rows that were correctly dated at the source.
+	//
+	// Pointers with omitempty, matching ExpiresAt and following the
+	// tenant_id/embedding precedent: an undated row adds no bytes (a
+	// single-tenant undated snapshot stays byte-identical to a pre-change
+	// one), and a snapshot written before the fields existed decodes them as
+	// nil → the zero instant → undated, which is the honest answer. Deliberately
+	// NOT a section-version bump: bumping would make an older reader reject
+	// the whole memory section with ErrSnapshotVersionTooNew, trading a
+	// graceful degrade (older reader drops the unknown fields, exactly as it
+	// does today) for a hard restore failure.
+	ObservedAt *time.Time               `json:"observed_at,omitempty"`
+	ValidAt    *time.Time               `json:"valid_at,omitempty"`
+	InvalidAt  *time.Time               `json:"invalid_at,omitempty"`
+	Embedding  *MemoryEmbeddingSnapshot `json:"embedding"` // explicit null when nil; see memory_embedding.go
 }
 
 // ChannelsSection wraps channels config + messages + cursors. Channel

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -2339,7 +2339,13 @@ func (s *Store) SnapshotReadMCPServerDefActive(ctx context.Context) ([]store.MCP
 func (s *Store) SnapshotReadMemory(ctx context.Context) ([]store.MemorySnapshotEntry, error) {
 	now := time.Now().UTC()
 	rows, err := s.pool.Query(ctx,
-		`SELECT COALESCE(tenant_id, ''), scope, scope_id, key, value::text, expires_at, created_at, updated_at
+		// The three temporal columns are part of the row's content, so a
+		// capture that omits them writes an archive that silently undates
+		// every fact — and a restore from it cannot recover what was never
+		// written. Losing them here is worse than a misreporting projection:
+		// it is permanent.
+		`SELECT COALESCE(tenant_id, ''), scope, scope_id, key, value::text, expires_at, created_at, updated_at,
+		        observed_at, valid_at, invalid_at
 		 FROM memory
 		 WHERE expires_at IS NULL OR expires_at > $1
 		 ORDER BY scope ASC, scope_id ASC, key ASC`, now)
@@ -2350,18 +2356,32 @@ func (s *Store) SnapshotReadMemory(ctx context.Context) ([]store.MemorySnapshotE
 	var out []store.MemorySnapshotEntry
 	for rows.Next() {
 		var (
-			e         store.MemorySnapshotEntry
-			scopeStr  string
-			value     string
-			expiresAt *time.Time
+			e          store.MemorySnapshotEntry
+			scopeStr   string
+			value      string
+			expiresAt  *time.Time
+			observedAt *time.Time
+			validAt    *time.Time
+			invalidAt  *time.Time
 		)
-		if err := rows.Scan(&e.TenantID, &scopeStr, &e.ScopeID, &e.Key, &value, &expiresAt, &e.CreatedAt, &e.UpdatedAt); err != nil {
+		if err := rows.Scan(&e.TenantID, &scopeStr, &e.ScopeID, &e.Key, &value, &expiresAt, &e.CreatedAt, &e.UpdatedAt,
+			&observedAt, &validAt, &invalidAt); err != nil {
 			return nil, fmt.Errorf("scan memory: %w", err)
 		}
 		e.Scope = store.MemoryScope(scopeStr)
 		e.Value = json.RawMessage(value)
 		if expiresAt != nil {
 			e.ExpiresAt = *expiresAt
+		}
+		// NULL leaves the field zero — undated. Never Unix(0, 0), which is 1970.
+		if observedAt != nil {
+			e.ObservedAt = *observedAt
+		}
+		if validAt != nil {
+			e.ValidAt = *validAt
+		}
+		if invalidAt != nil {
+			e.InvalidAt = *invalidAt
 		}
 		out = append(out, e)
 	}
@@ -2820,12 +2840,22 @@ func (s *Store) SnapshotRestoreMemory(ctx context.Context, e store.MemorySnapsho
 		t := e.ExpiresAt
 		expiresAt = &t
 	}
+	// A zero instant restores as NULL, not as year 1: an undated row must come
+	// back undated, and writing the zero time would date it to 0001-01-01.
+	nilIfZero := func(t time.Time) *time.Time {
+		if t.IsZero() {
+			return nil
+		}
+		return &t
+	}
 	tag, err := s.pool.Exec(ctx,
-		`INSERT INTO memory(tenant_id, scope, scope_id, key, value, expires_at, created_at, updated_at)
-		 VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8)
+		`INSERT INTO memory(tenant_id, scope, scope_id, key, value, expires_at, created_at, updated_at,
+		                    observed_at, valid_at, invalid_at)
+		 VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10, $11)
 		 ON CONFLICT (tenant_id, scope, scope_id, key) DO NOTHING`,
 		e.TenantID, string(e.Scope), e.ScopeID, e.Key, string(e.Value),
 		expiresAt, createdAt, updatedAt,
+		nilIfZero(e.ObservedAt), nilIfZero(e.ValidAt), nilIfZero(e.InvalidAt),
 	)
 	if err != nil {
 		return false, fmt.Errorf("snapshot restore memory: %w", err)

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -3535,7 +3535,10 @@ func (s *Store) SnapshotReadMCPServerDefActive(ctx context.Context) ([]store.MCP
 func (s *Store) SnapshotReadMemory(ctx context.Context) ([]store.MemorySnapshotEntry, error) {
 	now := time.Now().UnixNano()
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT COALESCE(tenant_id, ''), scope, scope_id, key, value, expires_at, created_at, updated_at
+		// See the Postgres sibling: omitting the temporal columns here writes
+		// an archive that has permanently undated every fact.
+		`SELECT COALESCE(tenant_id, ''), scope, scope_id, key, value, expires_at, created_at, updated_at,
+		        observed_at, valid_at, invalid_at
 		 FROM memory
 		 WHERE expires_at IS NULL OR expires_at > ?
 		 ORDER BY scope ASC, scope_id ASC, key ASC`, now)
@@ -3546,16 +3549,20 @@ func (s *Store) SnapshotReadMemory(ctx context.Context) ([]store.MemorySnapshotE
 	var out []store.MemorySnapshotEntry
 	for rows.Next() {
 		var (
-			e         store.MemorySnapshotEntry
-			scopeStr  string
-			value     string
-			expiresNs sql.NullInt64
-			createdNs int64
-			updatedNs int64
+			e          store.MemorySnapshotEntry
+			scopeStr   string
+			value      string
+			expiresNs  sql.NullInt64
+			createdNs  int64
+			updatedNs  int64
+			observedNs sql.NullInt64
+			validNs    sql.NullInt64
+			invalidNs  sql.NullInt64
 		)
 		if err := rows.Scan(
 			&e.TenantID, &scopeStr, &e.ScopeID, &e.Key, &value,
 			&expiresNs, &createdNs, &updatedNs,
+			&observedNs, &validNs, &invalidNs,
 		); err != nil {
 			return nil, fmt.Errorf("scan memory: %w", err)
 		}
@@ -3566,6 +3573,16 @@ func (s *Store) SnapshotReadMemory(ctx context.Context) ([]store.MemorySnapshotE
 		}
 		e.CreatedAt = time.Unix(0, createdNs)
 		e.UpdatedAt = time.Unix(0, updatedNs)
+		// NULL leaves the field zero — undated. Never time.Unix(0, 0) = 1970.
+		if observedNs.Valid {
+			e.ObservedAt = time.Unix(0, observedNs.Int64)
+		}
+		if validNs.Valid {
+			e.ValidAt = time.Unix(0, validNs.Int64)
+		}
+		if invalidNs.Valid {
+			e.InvalidAt = time.Unix(0, invalidNs.Int64)
+		}
 		out = append(out, e)
 	}
 	return out, rows.Err()
@@ -4027,8 +4044,8 @@ func (s *Store) SnapshotRestoreMCPServerDefActive(ctx context.Context, e store.M
 }
 
 // SnapshotRestoreMemory implements store.Store. Preserves CreatedAt /
-// UpdatedAt / ExpiresAt / Value. INSERT OR IGNORE on (scope, scope_id,
-// key) PK → idempotent.
+// UpdatedAt / ExpiresAt / Value and the bi-temporal ObservedAt / ValidAt /
+// InvalidAt. INSERT OR IGNORE on (scope, scope_id, key) PK → idempotent.
 func (s *Store) SnapshotRestoreMemory(ctx context.Context, e store.MemorySnapshotEntry) (bool, error) {
 	if e.Scope == "" || e.Key == "" {
 		return false, fmt.Errorf("snapshot restore memory: scope and key required")
@@ -4045,10 +4062,20 @@ func (s *Store) SnapshotRestoreMemory(ctx context.Context, e store.MemorySnapsho
 	if !e.ExpiresAt.IsZero() {
 		expiresNs = e.ExpiresAt.UnixNano()
 	}
+	// A zero instant restores as NULL, not as 1970: an undated row must come
+	// back undated. `any` left nil binds SQL NULL.
+	nsOrNil := func(t time.Time) any {
+		if t.IsZero() {
+			return nil
+		}
+		return t.UnixNano()
+	}
 	res, err := s.db.ExecContext(ctx,
-		`INSERT OR IGNORE INTO memory(tenant_id, scope, scope_id, key, value, expires_at, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT OR IGNORE INTO memory(tenant_id, scope, scope_id, key, value, expires_at, created_at, updated_at,
+		                              observed_at, valid_at, invalid_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		e.TenantID, string(e.Scope), e.ScopeID, e.Key, string(e.Value), expiresNs, createdNs, updatedNs,
+		nsOrNil(e.ObservedAt), nsOrNil(e.ValidAt), nsOrNil(e.InvalidAt),
 	)
 	if err != nil {
 		return false, fmt.Errorf("snapshot restore memory: %w", err)

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -141,6 +141,7 @@ func Run(t *testing.T, factory Factory) {
 		{"SnapshotReadMemoryEmpty", testSnapshotReadMemoryEmpty},
 		{"SnapshotReadMemoryFiltersExpired", testSnapshotReadMemoryFiltersExpired},
 		{"SnapshotReadMemoryOrdered", testSnapshotReadMemoryOrdered},
+		{"SnapshotMemoryTemporalRoundTrip", testSnapshotMemoryTemporalRoundTrip},
 		{"SnapshotReadChannelMessagesEmpty", testSnapshotReadChannelMessagesEmpty},
 		{"SnapshotReadChannelCursorsEmpty", testSnapshotReadChannelCursorsEmpty},
 		{"SnapshotReadEvaluationsEmpty", testSnapshotReadEvaluationsEmpty},
@@ -12191,5 +12192,115 @@ func testMemoryGetReturnsTemporalColumns(t *testing.T, s store.Store) {
 		t.Errorf("undated row reports observed=%v valid=%v invalid=%v, want all ZERO — mapping "+
 			"NULL onto Unix(0,0) would date every undated row to 1970, which is worse than "+
 			"reporting nothing", undated.ObservedAt, undated.ValidAt, undated.InvalidAt)
+	}
+}
+
+// testSnapshotMemoryTemporalRoundTrip — a snapshot capture-then-restore must
+// preserve the times a row carries.
+//
+// WHY THIS ONE MATTERS MORE THAN THE READ PROJECTIONS. The misreporting bug in
+// MemoryList/MemoryGet was recoverable: the columns were still in the table, so
+// fixing the query recovered the truth. Here BOTH legs dropped them —
+// SnapshotReadMemory did not select them and SnapshotRestoreMemory did not
+// insert them — so a snapshot silently undated the whole corpus and a restore
+// from that archive could not recover what was never written. Permanent loss,
+// and invisible, because "undated" is the plausible state for most rows.
+//
+// Exercises both legs in one test: read the seeded rows out through the capture
+// projection, then restore them under a FRESH scope_id (the restore is
+// idempotent on the PK, so restoring onto the seeds would no-op and prove
+// nothing) and read them back. An undated row rides along throughout: a fix
+// that wrote the zero instant instead of NULL would date every undated row to
+// year 1 (or 1970 on the nanosecond tiers) and still pass a dated-only test.
+func testSnapshotMemoryTemporalRoundTrip(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	const srcScopeID = "snap-temporal-src"
+	const dstScopeID = "snap-temporal-dst"
+	observed := time.Date(2023, 7, 7, 19, 56, 0, 0, time.UTC)
+	validAt := time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC)
+	invalidAt := time.Date(2023, 8, 1, 0, 0, 0, 0, time.UTC)
+
+	if err := s.MemorySetTimed(ctx, "", store.MemoryScopeUser, srcScopeID, "dated",
+		json.RawMessage(`{"text":"dated"}`), 0, store.MemoryProvenance{},
+		store.MemoryTimes{ObservedAt: observed, ValidAt: validAt, InvalidAt: invalidAt}); err != nil {
+		t.Fatalf("MemorySetTimed dated: %v", err)
+	}
+	if err := s.MemorySetTimed(ctx, "", store.MemoryScopeUser, srcScopeID, "undated",
+		json.RawMessage(`{"text":"undated"}`), 0, store.MemoryProvenance{},
+		store.MemoryTimes{}); err != nil {
+		t.Fatalf("MemorySetTimed undated: %v", err)
+	}
+
+	// --- capture leg ---
+	rows, err := s.SnapshotReadMemory(ctx)
+	if err != nil {
+		t.Fatalf("SnapshotReadMemory: %v", err)
+	}
+	captured := map[string]store.MemorySnapshotEntry{}
+	for _, r := range rows {
+		if r.ScopeID == srcScopeID {
+			captured[r.Key] = r
+		}
+	}
+	dated, ok := captured["dated"]
+	if !ok {
+		t.Fatalf("dated row missing from capture (%d rows total)", len(rows))
+	}
+	if !dated.ObservedAt.UTC().Equal(observed) {
+		t.Errorf("captured ObservedAt = %v, want %v — a capture that drops the column writes "+
+			"an archive in which every fact is undated, and a restore cannot recover what was "+
+			"never written", dated.ObservedAt.UTC(), observed)
+	}
+	if !dated.ValidAt.UTC().Equal(validAt) {
+		t.Errorf("captured ValidAt = %v, want %v", dated.ValidAt.UTC(), validAt)
+	}
+	if !dated.InvalidAt.UTC().Equal(invalidAt) {
+		t.Errorf("captured InvalidAt = %v, want %v", dated.InvalidAt.UTC(), invalidAt)
+	}
+	capturedUndated, ok := captured["undated"]
+	if !ok {
+		t.Fatalf("undated row missing from capture")
+	}
+	if !capturedUndated.ObservedAt.IsZero() || !capturedUndated.ValidAt.IsZero() || !capturedUndated.InvalidAt.IsZero() {
+		t.Errorf("captured undated row reports observed=%v valid=%v invalid=%v, want all ZERO",
+			capturedUndated.ObservedAt, capturedUndated.ValidAt, capturedUndated.InvalidAt)
+	}
+
+	// --- restore leg, into a fresh scope so the PK conflict cannot mask it ---
+	for _, key := range []string{"dated", "undated"} {
+		e := captured[key]
+		e.ScopeID = dstScopeID
+		inserted, err := s.SnapshotRestoreMemory(ctx, e)
+		if err != nil {
+			t.Fatalf("SnapshotRestoreMemory %s: %v", key, err)
+		}
+		if !inserted {
+			t.Fatalf("SnapshotRestoreMemory %s reported no insert into a fresh scope", key)
+		}
+	}
+
+	restored, err := s.MemoryGet(ctx, "", store.MemoryScopeUser, dstScopeID, "dated")
+	if err != nil {
+		t.Fatalf("MemoryGet restored dated: %v", err)
+	}
+	if !restored.ObservedAt.UTC().Equal(observed) {
+		t.Errorf("restored ObservedAt = %v, want %v — the restore INSERT dropped the column, "+
+			"so the archive's dates died at the write leg", restored.ObservedAt.UTC(), observed)
+	}
+	if !restored.ValidAt.UTC().Equal(validAt) {
+		t.Errorf("restored ValidAt = %v, want %v", restored.ValidAt.UTC(), validAt)
+	}
+	if !restored.InvalidAt.UTC().Equal(invalidAt) {
+		t.Errorf("restored InvalidAt = %v, want %v", restored.InvalidAt.UTC(), invalidAt)
+	}
+
+	restoredUndated, err := s.MemoryGet(ctx, "", store.MemoryScopeUser, dstScopeID, "undated")
+	if err != nil {
+		t.Fatalf("MemoryGet restored undated: %v", err)
+	}
+	if !restoredUndated.ObservedAt.IsZero() || !restoredUndated.ValidAt.IsZero() || !restoredUndated.InvalidAt.IsZero() {
+		t.Errorf("restored undated row reports observed=%v valid=%v invalid=%v, want all ZERO — "+
+			"binding the zero instant instead of NULL dates every undated row to year 1",
+			restoredUndated.ObservedAt, restoredUndated.ValidAt, restoredUndated.InvalidAt)
 	}
 }


### PR DESCRIPTION
Closes the snapshot half of the temporal gap flagged in #1148.

## Why

A snapshot capture-then-restore **silently undated every fact**. All three legs dropped the columns, in both backends:

- `SnapshotReadMemory` didn't `SELECT` `observed_at` / `valid_at` / `invalid_at`
- the archive type had no field to hold them
- `SnapshotRestoreMemory`'s `INSERT` didn't write them

So an operator who snapshotted one instance and restored onto another landed a corpus in which nothing was dated.

**This is worse than the bugs #1148 fixed.** Those were misreporting: the columns were still in the table, so fixing the query recovered the truth. Here the data is *gone* — a restore cannot recover what the capture never wrote. And it's invisible, because zero means "undated" and undated is the honest state for most rows, so nothing about the restored store looks wrong.

## What

| site | change |
|---|---|
| `postgres` + `sqlite` `SnapshotReadMemory` | `SELECT` + scan the three columns |
| `snapshot.MemoryEntry` | three `*time.Time` `omitempty` fields |
| `captureMemory` | zero stays `nil`, so undated serialises as an **absent** field, not year 1 |
| `restore.go` | `nil` decodes to the zero instant (undated) |
| `postgres` + `sqlite` `SnapshotRestoreMemory` | bind `NULL` for a zero instant rather than writing `0001-01-01` / `1970` |

**No section-version bump, deliberately.** Bumping `memory` to `1.1` would make an older reader reject the whole section with `ErrSnapshotVersionTooNew` — trading today's graceful degrade (an older reader drops the unknown fields, exactly as it does now) for a hard restore failure. The cross-version path is carried by `omitempty` plus the `nil`→zero decode instead, which is the precedent already set by `tenant_id` and `embedding`. An undated single-tenant snapshot stays byte-identical to a pre-change one.

## What was tested

Four tests. Each carries an **undated row alongside the dated one**: binding the zero instant instead of `NULL` would date every undated row and still pass a dated-only test.

- **`SnapshotMemoryTemporalRoundTrip`** (store contract, both backends) — capture leg and restore leg in one test, restoring into a *fresh* `scope_id`, because the restore is idempotent on the PK and restoring onto the seeds would no-op and prove nothing.
- **`TestSnapshotRestore_MemoryTemporalSurvivesRoundTrip`** — end-to-end `Capture` → JSON → `Restore` onto a second instance. Also asserts the archive *omits* the keys for an undated row, and that no `"observed_at":"0001-01-01` string appears anywhere in it.
- **`TestSnapshotRestore_MemoryWithoutTemporalFieldsRestoresUndated`** — a hand-written pre-temporal v1.0 archive still restores, undated. This one **passes on the unfixed code too**, by design: it guards the cross-version path against a future regression (someone bumping the section version), it isn't a fail-before target.
- **`TestSweeper_MemExportCarriesTemporalColumns`** (second commit) — see below.

### Fail-before

Verified against local PostgreSQL 17 + pgvector 0.8.6. I reverted the four **plumbing** files and deliberately kept `types.go`: reverting the struct field would make the archive test fail to *compile*, which demonstrates nothing. The revert compiles, and fails on both legs, both backends:

```
--- FAIL: TestSnapshotRestore_MemoryTemporalSurvivesRoundTrip
    archive observed_at = <nil>, want 2023-07-07 19:56:00 +0000 UTC
    restored ObservedAt = 0001-01-01 00:00:00 +0000 UTC, want 2023-07-07 19:56:00 +0000 UTC
--- FAIL: TestStoreContract/SnapshotMemoryTemporalRoundTrip            (sqlite + postgres)
--- FAIL: TestStoreContractWithPgvector/SnapshotMemoryTemporalRoundTrip
    captured ObservedAt = 0001-01-01 ... — a capture that drops the column writes an
      archive in which every fact is undated, and a restore cannot recover it
    restored ObservedAt = 0001-01-01 ... — the restore INSERT dropped the column
```

### A claim I made and then had to check

The first commit says the RFC BM retention export already inherited these fields from #1144. I'd verified that by *reading* the call path, not by running anything, so the second commit makes it executable — and that was worth doing twice over:

- The claim is **true**. `exportBaseMemory` → `MemoryList` → `MarshalIndent` does carry `observed_at`.
- My first assertion **still failed**, because the export marshals `time.Time` in the *host's local zone* (`+03:00`), not `Z`. A string match on the UTC form would have passed or failed by the machine's timezone rather than by whether the date survived. The test now compares parsed instants. Fail-before confirmed by neutering `MemoryList`'s temporal population: `exported observed_at = 0001-01-01, want 2023-07-07`.

## Found, deliberately not fixed

`omitempty` on a `time.Time` **does nothing** — `encoding/json` doesn't treat a zero struct as empty. So an undated row exports as `"valid_at": "0001-01-01T00:00:00Z"`: a wrong date where the honest answer is no date, in the one file an operator reads *after* the rows are pruned. Fixing it means pointer fields on `store.MemoryEntry`, which changes every API response that marshals it — its own change, with a wire-shape decision attached. Recorded in a comment at the assertion site so it's found again. (The snapshot archive type added here does use `*time.Time` + `omitempty` and correctly omits the key.)

## Suites

All green with `LOOMCYCLE_TEST_PG_DSN` + `LOOMCYCLE_TEST_PG_VECTOR=1` set — a green run without the DSN means *skipped*, not *passed*:

```
ok  internal/store/postgres    247.390s
ok  internal/store/sqlite       24.410s
ok  internal/snapshot            6.428s
ok  internal/snapshot/migrations 0.215s
ok  internal/retention           3.357s
ok  internal/store/cdc           0.455s
```

`go build ./...` clean, `gofmt` clean, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8
