### PR TITLE
test(coord): build test replica ids that pass ValidateReplicaID

### DIFF
--- a/internal/coord/cancel_coordinator_test.go
+++ b/internal/coord/cancel_coordinator_test.go
@@ -66,7 +66,7 @@ func TestCancelCoordinator_NotFound_ReturnsMiss(t *testing.T) {
 	dsn := pgDSNFromEnv(t)
 	pool := freshUserQuotasPool(t, dsn)
 	bp, err := NewPostgresBackplane(PostgresBackplaneConfig{
-		Pool: pool, DSN: dsn, ReplicaID: "test-cc-nf-" + time.Now().Format("150405.000"),
+		Pool: pool, DSN: dsn, ReplicaID: testReplicaID(t, "test-cc-nf-"),
 	})
 	if err != nil {
 		t.Fatalf("backplane: %v", err)
@@ -149,7 +149,7 @@ func TestCancelCoordinator_DeadOwner_MarksRunFailed(t *testing.T) {
 	rs := NewReplicaStore(pool)
 	// Seed a backdated heartbeat row for dead-replica so IsReplicaAlive
 	// returns false.
-	deadID := "dead-replica-" + time.Now().Format("150405.000")
+	deadID := testReplicaID(t, "dead-replica-")
 	stub.runs["a_dead"] = store.Run{ID: "r2", Status: store.RunRunning, ReplicaID: deadID}
 	_, _ = pool.Exec(context.Background(),
 		`INSERT INTO replicas (id, hostname, started_at, last_heartbeat_at, version)
@@ -195,7 +195,7 @@ func TestCancelCoordinator_Timeout_ReturnsOwnerUnreachable(t *testing.T) {
 	// Owner row: a fake replica with a fresh heartbeat (so the alive
 	// check passes and we proceed to broadcast). No subscriber will
 	// respond, so we hit timeout.
-	freshOwner := "fresh-fake-owner-" + time.Now().Format("150405.000")
+	freshOwner := testReplicaID(t, "fresh-fake-owner-")
 	_, _ = pool.Exec(context.Background(),
 		`INSERT INTO replicas (id, hostname, started_at, last_heartbeat_at, version)
 		 VALUES ($1, 'h', now(), now(), 'v')

--- a/internal/coord/postgres_backplane_test.go
+++ b/internal/coord/postgres_backplane_test.go
@@ -52,14 +52,14 @@ func TestPostgresBackplane_PublishSubscribeRoundtrip(t *testing.T) {
 
 	// Two backplanes simulating two replicas sharing one Postgres.
 	bpA, err := NewPostgresBackplane(PostgresBackplaneConfig{
-		Pool: pool, DSN: dsn, ReplicaID: "test-A-" + time.Now().Format("150405.000"),
+		Pool: pool, DSN: dsn, ReplicaID: testReplicaID(t, "test-A-"),
 	})
 	if err != nil {
 		t.Fatalf("backplane A: %v", err)
 	}
 	defer bpA.Close()
 	bpB, err := NewPostgresBackplane(PostgresBackplaneConfig{
-		Pool: pool, DSN: dsn, ReplicaID: "test-B-" + time.Now().Format("150405.000"),
+		Pool: pool, DSN: dsn, ReplicaID: testReplicaID(t, "test-B-"),
 	})
 	if err != nil {
 		t.Fatalf("backplane B: %v", err)
@@ -108,7 +108,7 @@ func TestPostgresBackplane_SelfMessageFiltered(t *testing.T) {
 	}
 	defer pool.Close()
 	bp, err := NewPostgresBackplane(PostgresBackplaneConfig{
-		Pool: pool, DSN: dsn, ReplicaID: "test-self-" + time.Now().Format("150405.000"),
+		Pool: pool, DSN: dsn, ReplicaID: testReplicaID(t, "test-self-"),
 	})
 	if err != nil {
 		t.Fatalf("backplane: %v", err)
@@ -147,7 +147,7 @@ func TestPostgresBackplane_PayloadTooLarge(t *testing.T) {
 	}
 	defer pool.Close()
 	bp, err := NewPostgresBackplane(PostgresBackplaneConfig{
-		Pool: pool, DSN: dsn, ReplicaID: "test-large-" + time.Now().Format("150405.000"),
+		Pool: pool, DSN: dsn, ReplicaID: testReplicaID(t, "test-large-"),
 	})
 	if err != nil {
 		t.Fatalf("backplane: %v", err)
@@ -169,7 +169,7 @@ func TestPostgresBackplane_PublishAfterClose(t *testing.T) {
 	}
 	defer pool.Close()
 	bp, err := NewPostgresBackplane(PostgresBackplaneConfig{
-		Pool: pool, DSN: dsn, ReplicaID: "test-closed-" + time.Now().Format("150405.000"),
+		Pool: pool, DSN: dsn, ReplicaID: testReplicaID(t, "test-closed-"),
 	})
 	if err != nil {
 		t.Fatalf("backplane: %v", err)
@@ -191,7 +191,7 @@ func TestPostgresBackplane_InvalidTopic(t *testing.T) {
 	}
 	defer pool.Close()
 	bp, err := NewPostgresBackplane(PostgresBackplaneConfig{
-		Pool: pool, DSN: dsn, ReplicaID: "test-topic-" + time.Now().Format("150405.000"),
+		Pool: pool, DSN: dsn, ReplicaID: testReplicaID(t, "test-topic-"),
 	})
 	if err != nil {
 		t.Fatalf("backplane: %v", err)

--- a/internal/coord/replica_store_test.go
+++ b/internal/coord/replica_store_test.go
@@ -128,10 +128,38 @@ func freshReplicasTable(t *testing.T, dsn string) *pgxpool.Pool {
 	return pool
 }
 
+// testReplicaID builds a unique, VALID replica id for a test fixture.
+//
+// The obvious idiom — prefix + time.Now().Format("150405.000") — embeds a '.',
+// which ValidateReplicaID rejects ([A-Za-z0-9][A-Za-z0-9_-]{0,63}). Six tests
+// were written that way and every one of them died in its backplane
+// constructor instead of asserting the thing it was about, while the fixtures
+// in the other coord tests were seeding `replicas` rows with an id production
+// would refuse to boot with.
+//
+// It sat on main because this family is INVISIBLE TO CI: the Go job runs
+// without LOOMCYCLE_TEST_PG_DSN, so every PG-gated coord test skips there and
+// nothing went red.
+//
+// The id is checked through ValidateReplicaID ITSELF rather than against a
+// copy of the pattern — if the production format ever narrows, each fixture
+// fails right here with a clear message instead of somewhere downstream.
+func testReplicaID(t *testing.T, prefix string) string {
+	t.Helper()
+	// Format then strip the separator: Go's fractional-second layout requires
+	// a '.' or ',' after the seconds, so the substitution is what keeps
+	// microsecond uniqueness AND a legal id.
+	id := prefix + strings.ReplaceAll(time.Now().Format("150405.000000"), ".", "-")
+	if err := ValidateReplicaID(id); err != nil {
+		t.Fatalf("test fixture built an invalid replica id: %v", err)
+	}
+	return id
+}
+
 func TestReplicaStore_UpsertListDelete(t *testing.T) {
 	pool := freshReplicasTable(t, pgDSNFromEnv(t))
 	store := NewReplicaStore(pool)
-	id := "test-rs-" + time.Now().Format("150405.000")
+	id := testReplicaID(t, "test-rs-")
 	ctx := context.Background()
 	if err := store.UpsertReplica(ctx, id, "host-a", "v0.12.0-test"); err != nil {
 		t.Fatalf("upsert: %v", err)
@@ -183,7 +211,7 @@ func TestReplicaStore_UpsertListDelete(t *testing.T) {
 func TestReplicaStore_UpsertUpdatesHeartbeat(t *testing.T) {
 	pool := freshReplicasTable(t, pgDSNFromEnv(t))
 	store := NewReplicaStore(pool)
-	id := "test-hb-" + time.Now().Format("150405.000")
+	id := testReplicaID(t, "test-hb-")
 	ctx := context.Background()
 	if err := store.UpsertReplica(ctx, id, "host-b", "v0.12.0-test"); err != nil {
 		t.Fatalf("first upsert: %v", err)
@@ -223,7 +251,7 @@ func TestReplicaStore_UpsertUpdatesHeartbeat(t *testing.T) {
 func TestHeartbeat_RunExitsOnContextDone(t *testing.T) {
 	pool := freshReplicasTable(t, pgDSNFromEnv(t))
 	store := NewReplicaStore(pool)
-	id := "test-run-" + time.Now().Format("150405.000")
+	id := testReplicaID(t, "test-run-")
 	hb := NewHeartbeat(store, HeartbeatConfig{
 		ReplicaID:       id,
 		Hostname:        "host-c",

--- a/internal/coord/replicas_sweeper_test.go
+++ b/internal/coord/replicas_sweeper_test.go
@@ -75,7 +75,7 @@ func TestReplicasSweeper_ReapsStaleReplica(t *testing.T) {
 	pool := freshUserQuotasPool(t, pgDSNFromEnv(t))
 	sessionID := seedSession(t, pool)
 
-	replicaID := "test-rs-stale-" + time.Now().Format("150405.000000")
+	replicaID := testReplicaID(t, "test-rs-stale-")
 	userID := "u-" + time.Now().Format("150405.000000")
 	runID := "r-" + time.Now().Format("150405.000000")
 
@@ -126,7 +126,7 @@ func TestReplicasSweeper_ReapsStaleReplica(t *testing.T) {
 
 func TestReplicasSweeper_SkipsFreshReplica(t *testing.T) {
 	pool := freshUserQuotasPool(t, pgDSNFromEnv(t))
-	replicaID := "test-rs-fresh-" + time.Now().Format("150405.000000")
+	replicaID := testReplicaID(t, "test-rs-fresh-")
 	// Fresh heartbeat.
 	_, _ = pool.Exec(context.Background(), `
 		INSERT INTO replicas (id, hostname, started_at, last_heartbeat_at, version)
@@ -150,7 +150,7 @@ func TestReplicasSweeper_SkipsFreshReplica(t *testing.T) {
 func TestReplicasSweeper_GreatestZeroClampOnQuota(t *testing.T) {
 	pool := freshUserQuotasPool(t, pgDSNFromEnv(t))
 	sessionID := seedSession(t, pool)
-	replicaID := "test-rs-clamp-" + time.Now().Format("150405.000000")
+	replicaID := testReplicaID(t, "test-rs-clamp-")
 	userID := "u-" + time.Now().Format("150405.000000")
 	runID := "r-" + time.Now().Format("150405.000000")
 


### PR DESCRIPTION
## Why

Six PG-gated `internal/coord` tests fail on `main` today:

```
replica id "test-A-071135.641": must match [A-Za-z0-9][A-Za-z0-9_-]{0,63}
```

The fixtures built ids as `prefix + time.Now().Format("150405.000")`. Go's fractional-second layout **requires** a `.` or `,` after the seconds, so every such id carried a character `ValidateReplicaID` rejects. The tests died in their backplane constructor instead of asserting what they were about: cancel-coordinator miss handling, publish/subscribe round trip, self-message filtering, the payload cap, publish-after-close, and topic validation.

**Why it sat on `main`.** This family is invisible to CI. The `Go` job runs `go test ./...` with no `LOOMCYCLE_TEST_PG_DSN`, so every PG-gated coord test *skips* there and nothing goes red. The pg-tier job that does have a DSN runs only `./internal/store/...`, so it never reaches this package. Dev-must-verify-locally — and it drifted.

## What

One helper, `testReplicaID(t, prefix)`, applied at all **15** replica-id fixtures across four files. Two properties beyond just swapping the separator:

**It validates through `ValidateReplicaID` itself**, not a copy of the pattern. If the production format ever narrows, each fixture fails at construction naming itself as the culprit rather than surfacing deep inside a constructor:

```
replica_store_test.go:162: test fixture built an invalid replica id:
  replica id "test-rs-071332.609513": must match [A-Za-z0-9][A-Za-z0-9_-]{0,63}
```

**It fixes nine fixtures that were not failing yet.** Those seed `replicas` rows directly, bypassing the validator, with an id production would refuse to boot with — a fixture that cannot occur in production, waiting to break the day that path gains validation.

### Deliberately not changed

The dotted idiom stays for **topics** (`validateTopic` explicitly allows `.`, and dotted namespaces are the point) and for **session / user / run ids**, which carry no such constraint. Only replica ids moved. After the change, the only remaining `Format("150405.` uses are those legitimate ones plus the helper itself.

## What was tested

Fail-before is the bug report: the six failures above are the state of `main`, reproduced locally before the change.

- **`./internal/coord/...` passes** against local PostgreSQL 17 (`public` schema pre-migrated, which this package requires).
- **`-count=3`** — confirms microsecond resolution gives unique ids with no collisions across repeats.
- **`-race`** — these are concurrency tests, so worth stating: clean.
- **The self-check has teeth** — verified by reintroducing the `.` in the helper and watching it fire with the message above, rather than trusting that the guard works.

Note this PR cannot go green *in* CI in the sense that matters, because CI never runs these tests — that is the finding, not an oversight. The verification above is local and is the only place it can happen today. Widening the pg-tier job's package list to include `./internal/coord/...` would close the blind spot; that is a CI-config change with its own runtime cost, so it is not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8
