### PR TITLE
ci: gate the coordination tier on the Postgres job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,15 @@ jobs:
       # Migrated with loomcycle's OWN migrator rather than a psql loop over
       # migrations/*.up.sql, so the ordering cannot drift from the real one and
       # schema_migrations is stamped as in production.
+      #
+      # !cancelled() so a red store contract does not SKIP this gate. That is
+      # not hypothetical: on this step's first CI run the store contract
+      # exhausted its 1800s budget and both coord steps were skipped, which
+      # would have silently restored the very blind spot they exist to close.
+      # The two surfaces share only the service container, so coord's result is
+      # independent and worth having even when the contract is red.
       - name: Provision the coordination-tier DB
+        if: ${{ !cancelled() }}
         env:
           PGPASSWORD: loomcycle
         run: |
@@ -203,6 +211,7 @@ jobs:
       # live replicas); a data race here is the bug class that matters, and the
       # suite is fast enough (~3s locally) to afford the detector.
       - name: Coordination tier (Postgres)
+        if: ${{ !cancelled() }}
         env:
           LOOMCYCLE_TEST_PG_DSN: postgres://loomcycle:loomcycle@127.0.0.1:5432/coord_test?sslmode=disable
         run: go test -count=1 -race -timeout 600s ./internal/coord/...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,12 @@ jobs:
           fi
 
   go-postgres:
-    name: Go (Postgres store contract)
+    # Named for the TIERS it gates, not just the store contract: this job now
+    # owns three PG-only surfaces (store contract, coordination tier, SQL
+    # Memory), and a red check named "store contract" sends the next person
+    # debugging a coord or sqlmem regression to the wrong package. The job KEY
+    # stays go-postgres.
+    name: Go (Postgres tiers)
     runs-on: ubuntu-latest
     # Runs the shared storetest contract against a REAL Postgres so
     # backend-parity bugs are caught in CI, not only on SQLite. The contract
@@ -156,6 +161,51 @@ jobs:
         # fail, it poisons the database for the following run in a way that looks
         # like an unrelated bug.
         run: go test -count=1 -timeout 1800s ./internal/store/...
+
+      # COORDINATION TIER (multi-replica): cancel/steer coordinators, the
+      # Postgres backplane, the replica store + heartbeat, the replicas sweeper
+      # and user quotas. Every test here is PG-gated, and until now nothing ran
+      # them: the `Go` job invokes `go test ./...` with no LOOMCYCLE_TEST_PG_DSN
+      # so they all skip, and this job's store step covers only
+      # ./internal/store/... . The whole package was structurally invisible, and
+      # it drifted — six tests sat broken on main because their fixtures built
+      # replica ids containing a '.' (Go's fractional-second layout forces the
+      # separator) which ValidateReplicaID rejects. Nothing could go red.
+      #
+      # A SEPARATE DATABASE, not the store contract's, and not a convenient
+      # ordering. These tests need a MIGRATED `public` schema (the store
+      # contract creates a per-test schema and deliberately leaves `public`
+      # empty), but two store tests need `public` LEFT un-migrated:
+      # TestOpen_ExtensionPresentButTableMissingDisablesVectorSupport and
+      # TestMigrate0062_RepairedTableMatchesFromScratchShape both fail against a
+      # pre-migrated one ("0062 did not create memory_embeddings"). The two
+      # requirements are mutually exclusive in one database, so sharing
+      # loomcycle_test would work only while the steps happen to run in this
+      # order — and would break on a reorder or a re-run with a failure that
+      # looks like a migration bug. Same reasoning as the sqlmem aux DB below.
+      #
+      # Migrated with loomcycle's OWN migrator rather than a psql loop over
+      # migrations/*.up.sql, so the ordering cannot drift from the real one and
+      # schema_migrations is stamped as in production.
+      - name: Provision the coordination-tier DB
+        env:
+          PGPASSWORD: loomcycle
+        run: |
+          psql -h 127.0.0.1 -U loomcycle -d loomcycle_test -v ON_ERROR_STOP=1 \
+            -c "CREATE DATABASE coord_test OWNER loomcycle;"
+          psql -h 127.0.0.1 -U loomcycle -d coord_test -v ON_ERROR_STOP=1 \
+            -c "CREATE EXTENSION IF NOT EXISTS vector;"
+          go run ./cmd/loomcycle migrate up \
+            --dsn "postgres://loomcycle:loomcycle@127.0.0.1:5432/coord_test?sslmode=disable"
+
+      # -race because this package is entirely about concurrency (a backplane
+      # fanning out to subscribers, a heartbeat goroutine, a sweeper racing
+      # live replicas); a data race here is the bug class that matters, and the
+      # suite is fast enough (~3s locally) to afford the detector.
+      - name: Coordination tier (Postgres)
+        env:
+          LOOMCYCLE_TEST_PG_DSN: postgres://loomcycle:loomcycle@127.0.0.1:5432/coord_test?sslmode=disable
+        run: go test -count=1 -race -timeout 600s ./internal/coord/...
 
       # RFC AA SQL Memory postgres tier: provision a SEPARATE aux DB reached by a
       # NON-superuser CREATEROLE admin (exactly the production provisioning), so


### PR DESCRIPTION
Closes the CI blind spot named in #1150.

## Why

Every test in `./internal/coord/...` is PG-gated, and **nothing ran them**:

- the `Go` job invokes `go test ./...` with no `LOOMCYCLE_TEST_PG_DSN`, so they all skip
- this job's store step covers only `./internal/store/...`

So the cancel/steer coordinators, the Postgres backplane, the replica store + heartbeat, the replicas sweeper and user quotas were structurally invisible to CI. And it drifted, as invisible things do: six tests sat broken on `main` (fixed in #1150) because their fixtures built replica ids containing a `.`, which `ValidateReplicaID` rejects. Nothing could go red.

## What

Two steps on the existing `go-postgres` job.

**A separate database — not the store contract's, and not a convenient ordering.** This is the part worth reviewing. The coord tests need a **migrated** `public` schema (the store contract creates a per-test schema and deliberately leaves `public` empty). But two store tests need `public` **left un-migrated**:

- `TestOpen_ExtensionPresentButTableMissingDisablesVectorSupport`
- `TestMigrate0062_RepairedTableMatchesFromScratchShape` — fails `0062 did not create memory_embeddings`

The two requirements are mutually exclusive in one database. Sharing `loomcycle_test` would work only while the steps happen to run in this order, and would break on a reorder or a re-run — with a failure that reads like a migration bug rather than a CI-config problem. Same reasoning as the `sqlmem_aux` DB already in this job.

**Migrated with loomcycle's own migrator** (`migrate up --dsn`) rather than a psql loop over `migrations/*.up.sql`, so the ordering cannot drift from the real one and `schema_migrations` is stamped as in production.

**`-race`**, because this package is entirely about concurrency — a backplane fanning out to subscribers, a heartbeat goroutine, a sweeper racing live replicas. That's the bug class that matters here, and the suite is fast enough (~3 s) to afford the detector.

**Job renamed to "Go (Postgres tiers)"** — it gates three PG-only surfaces now, and a red check named "store contract" would send the next person debugging a coord or sqlmem regression to the wrong package. The job key stays `go-postgres`; `main` has no branch protection, so no required-check name breaks.

## What was tested

A CI-config change is only as good as the evidence it actually runs, so I ran both steps **verbatim** against local PostgreSQL 17 — as the `loomcycle` role, exactly as CI does, not as a superuser:

```
### Provision the coordination-tier DB ###
CREATE DATABASE
CREATE EXTENSION
migrate up: OK (version=74 dirty=false)
### Coordination tier (Postgres) ###
ok  github.com/denn-gubsky/loomcycle/internal/coord  3.134s
```

**The gate is not decoration.** Reintroducing the `.` that #1150 removed turns the new step red:

```
--- FAIL: TestCancelCoordinator_NotFound_ReturnsMiss
--- FAIL: TestCancelCoordinator_DeadOwner_MarksRunFailed
--- FAIL: TestCancelCoordinator_Timeout_ReturnsOwnerUnreachable
--- FAIL: TestPostgresBackplane_PublishSubscribeRoundtrip
--- FAIL: TestPostgresBackplane_SelfMessageFiltered
```

**No interference.** The store contract's two repair tests still pass against their own un-migrated database, confirming the separate DB leaves them alone.

YAML parses (`yaml.safe_load`) and the step order is valid — `psql` is installed by an earlier step in the same job.

## Note on runtime

This adds ~3 s of tests plus a `go run` of the migrator and two `psql` calls to a job that already runs ~10 min. `-race` on this package is cheap; I did not add it to the store contract, which is the slow step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8
