### PR TITLE
bench(locomo): -answer-only grades the store as it stands

### DIFF
--- a/bench/cmd/locomo/answer.go
+++ b/bench/cmd/locomo/answer.go
@@ -650,60 +650,83 @@ func doAnswerAxis(ctx context.Context, convs []Conversation, defects *Defects, o
 			return err
 		}
 		fmt.Fprintf(stdout, "%s:\n", conv.ScopeID())
-		// FLUSH before purging, not after, and DISCARD rather than consolidate.
-		// purgeLayer removes k/v rows; it cannot reach the pending consolidation
-		// queue, so anything left queued from an earlier conversation (or an
-		// interrupted run) would otherwise be consolidated into THIS
-		// conversation's facts after the purge had already run, silently mixing
-		// two conversations in one partition.
+		// ANSWER-ONLY: grade what the store already holds.
 		//
-		// This used to call consolidateDrain — the same function that does the
-		// real work — for up to consolidatePasses passes. Leftovers only need to
-		// be GONE, and extracting from them cost the full extractor spend on data
-		// about to be thrown away: measured at ~70 minutes on one run before it
-		// reached its own conversation. A flush is drain + ack, no model calls.
-		if n, err := flushPendingQueue(ctx, mc, stdout); err != nil {
-			return fmt.Errorf("pre-ingest flush: %w", err)
-		} else if n > 0 {
-			fmt.Fprintf(stdout, "  flushed %d leftover queued item(s) without extracting\n", n)
-		}
-		if _, err := purgeLayer(ctx, rest, "user", userID, stdout); err != nil {
-			return err
-		}
-		// OPTIONALLY put the raw turns where the answerer can actually read them.
+		// A retrieval-side change has to be measured with the corpus FIXED.
+		// Rebuilding it per arm puts extraction non-determinism back into the
+		// comparison, and that noise is not small: two identical runs of one
+		// binary scored 10 and 8 on the temporal slice, balanced 6/8 discordant.
+		// An arm pair could then differ because their stores differ rather than
+		// because of the projection under test. With this on, the store is a
+		// constant and a repeat run isolates ANSWERER variance.
 		//
-		// WHY THIS EXISTS. The answerer is an in-band agent, so its scope_id is
-		// server-derived from the run identity: `memory_scopes: [user]` resolves to
-		// user/<subject> and `[agent]` would resolve to agent/<the agent's own
-		// name>. The retrieval corpus lives at agent/<conversation-id>, a scope_id
-		// no in-band agent can address — so no agent config can point the answerer
-		// at it. The only way to let it answer from conversation content is to write
-		// that content into the partition it already reads.
-		//
-		// This is also what makes the number comparable: the published systems
-		// answer from retrieved conversation turns, not from a distilled fact store.
-		// Measured without it, the answerer had 29 facts distilled from 419 turns,
-		// abstained on 72% of questions and scored 0.1389; with it, 0.7353.
-		if opts.seedTurns {
-			n, err := seedTurnRows(ctx, rest, userID, conv, opts, stdout)
-			if err != nil {
-				return fmt.Errorf("seed turns: %w", err)
+		// The empty-store guard below is deliberately NOT skipped — answering an
+		// empty store is exactly the vacuous run it exists to refuse.
+		// Declared out here because the guards below read them: in answer-only
+		// mode they stay 0, which the diversion guard already tolerates
+		// (factsDiverted requires factsWritten > 0) while the empty-store guard
+		// keys off the row count and so still applies.
+		var facts, passes, sessions int
+		if opts.answerOnly {
+			fmt.Fprintf(stdout, "  answer-only: grading the existing store (no purge/ingest/consolidate)\n")
+		} else {
+			// FLUSH before purging, not after, and DISCARD rather than consolidate.
+			// purgeLayer removes k/v rows; it cannot reach the pending consolidation
+			// queue, so anything left queued from an earlier conversation (or an
+			// interrupted run) would otherwise be consolidated into THIS
+			// conversation's facts after the purge had already run, silently mixing
+			// two conversations in one partition.
+			//
+			// This used to call consolidateDrain — the same function that does the
+			// real work — for up to consolidatePasses passes. Leftovers only need to
+			// be GONE, and extracting from them cost the full extractor spend on data
+			// about to be thrown away: measured at ~70 minutes on one run before it
+			// reached its own conversation. A flush is drain + ack, no model calls.
+			if n, err := flushPendingQueue(ctx, mc, stdout); err != nil {
+				return fmt.Errorf("pre-ingest flush: %w", err)
+			} else if n > 0 {
+				fmt.Fprintf(stdout, "  flushed %d leftover queued item(s) without extracting\n", n)
 			}
-			rep.SeededTurns += n
-		}
-		sessions, err := ingestLayer(ctx, mc, conv, stdout)
-		if err != nil {
-			return err
-		}
-		rep.Sessions += sessions
-		rep.Turns += len(conv.Turns)
+			if _, err := purgeLayer(ctx, rest, "user", userID, stdout); err != nil {
+				return err
+			}
+			// OPTIONALLY put the raw turns where the answerer can actually read them.
+			//
+			// WHY THIS EXISTS. The answerer is an in-band agent, so its scope_id is
+			// server-derived from the run identity: `memory_scopes: [user]` resolves to
+			// user/<subject> and `[agent]` would resolve to agent/<the agent's own
+			// name>. The retrieval corpus lives at agent/<conversation-id>, a scope_id
+			// no in-band agent can address — so no agent config can point the answerer
+			// at it. The only way to let it answer from conversation content is to write
+			// that content into the partition it already reads.
+			//
+			// This is also what makes the number comparable: the published systems
+			// answer from retrieved conversation turns, not from a distilled fact store.
+			// Measured without it, the answerer had 29 facts distilled from 419 turns,
+			// abstained on 72% of questions and scored 0.1389; with it, 0.7353.
+			if opts.seedTurns {
+				n, err := seedTurnRows(ctx, rest, userID, conv, opts, stdout)
+				if err != nil {
+					return fmt.Errorf("seed turns: %w", err)
+				}
+				rep.SeededTurns += n
+			}
+			ingested, err := ingestLayer(ctx, mc, conv, stdout)
+			if err != nil {
+				return err
+			}
+			sessions = ingested
+			rep.Sessions += sessions
+			rep.Turns += len(conv.Turns)
 
-		facts, passes, err := consolidateDrain(ctx, mc, userID, opts.consolidatePasses, stdout)
-		if err != nil {
-			return err
+			gotFacts, gotPasses, err := consolidateDrain(ctx, mc, userID, opts.consolidatePasses, stdout)
+			if err != nil {
+				return err
+			}
+			facts, passes = gotFacts, gotPasses
+			rep.FactsWritten += facts
+			fmt.Fprintf(stdout, "  consolidated in %d pass(es), %d facts written\n", passes, facts)
 		}
-		rep.FactsWritten += facts
-		fmt.Fprintf(stdout, "  consolidated in %d pass(es), %d facts written\n", passes, facts)
 
 		// REFUSE to grade an empty store. With no rows, every recall comes back
 		// empty, the answerer abstains on everything, and the report reads

--- a/bench/cmd/locomo/main.go
+++ b/bench/cmd/locomo/main.go
@@ -73,7 +73,15 @@ type options struct {
 	sampleQuestions   int
 	consolidatePasses int
 	seedTurns         bool
-	runTimeout        time.Duration
+	// answerOnly grades the store AS IT STANDS: no flush, purge, seed, ingest
+	// or consolidation. It exists because a RETRIEVAL-side change must be
+	// measured with the store held constant — rebuilding it per arm reintroduces
+	// extraction non-determinism, which on the temporal slice is large enough to
+	// manufacture a significant result by itself (two identical runs scored 10
+	// and 8). With the corpus fixed, the only variable left is the projection
+	// under test, and a repeat run measures ANSWERER variance alone.
+	answerOnly bool
+	runTimeout time.Duration
 }
 
 func run(args []string, stdout, stderr io.Writer) error {
@@ -102,6 +110,7 @@ func run(args []string, stdout, stderr io.Writer) error {
 		judge       = fs.String("judge", "locomo/judge", "agent that grades an answer against gold (answer axis)")
 		sampleQ     = fs.Int("sample-questions", 0, "answer axis: grade only N questions, stratified by category (0 = all)")
 		consPasses  = fs.Int("consolidate-passes", 12, "answer axis: max consolidation passes per conversation (0 = skip consolidation entirely)")
+		answerOnly  = fs.Bool("answer-only", false, "answer axis: grade the EXISTING store — skip flush/purge/seed/ingest/consolidate. For measuring a retrieval-side change with the corpus held constant; the empty-store guard still applies")
 		seedTurns   = fs.Bool("seed-turns", false, "answer axis: also write one embedded row per TURN into the partition the answerer reads, so it answers from conversation content rather than only from distilled facts (this is what the published systems do)")
 		runTimeout  = fs.Duration("run-timeout", 10*time.Minute, "answer axis: per-run timeout (agent runs are slower than REST calls)")
 	)
@@ -123,6 +132,7 @@ func run(args []string, stdout, stderr io.Writer) error {
 		allowSharedTenant: *allowShared, timeout: *timeout,
 		answerer: *answerer, judge: *judge, sampleQuestions: *sampleQ,
 		consolidatePasses: *consPasses, runTimeout: *runTimeout, seedTurns: *seedTurns,
+		answerOnly: *answerOnly,
 	}
 	if opts.concurrency < 1 {
 		opts.concurrency = 1


### PR DESCRIPTION
## Why

A **retrieval-side** change has to be measured with the corpus held constant, and the harness had no way to do that: `-mode answer` always flushed, purged, ingested and consolidated before grading, so every arm built its own store.

That reintroduces the dominant noise term for no reason. Extraction is non-deterministic, and not mildly — two identical runs of one binary scored **10 and 8** on the temporal slice, 14 discordant pairs balanced 6/8 (p=0.79). An arm pair built that way can differ because their *stores* differ rather than because of the thing under test.

That is exactly the confound the RFC CV P1 reach-through measurement had to avoid, since its entire change is on the read path. With `-answer-only` the store is a constant, the only variable left is the projection, and a repeat run measures **answerer** variance alone.

## What

One flag. When set, the per-conversation loop skips flush / purge / seed-turns / ingest / consolidate and grades whatever the store already holds.

Two guards deliberately preserved:

- **The empty-store guard still applies.** Grading an empty store is precisely the vacuous run it exists to refuse — with no rows every recall returns nothing, the answerer abstains on everything, and the report reads `accuracy 0.0000`: a number about the plumbing wearing the costume of a result about memory.
- **The diversion guard needs no change.** `factsDiverted` already requires `factsWritten > 0`, so it cannot fire when this mode reports 0 written.

`facts` / `passes` / `sessions` are hoisted out of the branch because the guards below read them; in this mode they stay 0, which both guards tolerate as above.

## What was tested

Used for real, immediately: it ran five arms of the P1 reach-through measurement against one fixed 85-fact corpus.

- **The store is provably untouched.** Row counts read `85 memory/ facts, 173 total` before the first arm and identically after each one.
- **The mode is visible in the log** rather than silent: `answer-only: grading the existing store (no purge/ingest/consolidate)`, followed by `grading 150 of 150 questions`.
- **It measured the thing it was built for.** Same-binary replicate discordance came out at 4/128 — a floor that only exists because extraction was held out of the comparison. With the old behaviour that floor would have been dominated by extraction variance instead.

`go build ./bench/...` and `go vet ./bench/cmd/locomo/` clean.

## Note

This is bench tooling only — no runtime code, no wire change. Its value outlives the P1 probe: any future retrieval-side change (projection, ranking, fusion, reach-through) needs the store held constant to be measurable at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8
