### PR TITLE
fix(memory): a question is not evidence for a fact

### DIFF
--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -1768,6 +1768,18 @@ agents:
       function notProse(s) {
         var text = s.replace(/<[^>]*>/g, "").trim();
         if (text === "") { return true; }
+        // A QUESTION ASSERTS NOTHING, so it cannot be the span a claim is checked
+        // against. MEASURED on a live corpus: 6 of 76 attached spans were
+        // interrogatives — "What type of guitar?" standing as the evidence for a
+        // fact about someone's guitar, "How long have you been married?" for one
+        // about a marriage.
+        //
+        // A question is the WORST case for the overlap score rather than a marginal
+        // one: it repeats the claim's keywords exactly while affirming none of them,
+        // so it scores like a paraphrase. The punctuation rule below cannot catch it
+        // either — one "?" in twenty characters is 0.05, far under any sane density
+        // threshold. It has to be its own rule.
+        if (text.charAt(text.length - 1) === "?") { return true; }
         var punct = text.replace(/[^!-\/:-@\[-`{-~]/g, "").length;
         return punct / text.length > CONFIG.max_span_punctuation;
       }

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -1768,6 +1768,18 @@ agents:
       function notProse(s) {
         var text = s.replace(/<[^>]*>/g, "").trim();
         if (text === "") { return true; }
+        // A QUESTION ASSERTS NOTHING, so it cannot be the span a claim is checked
+        // against. MEASURED on a live corpus: 6 of 76 attached spans were
+        // interrogatives — "What type of guitar?" standing as the evidence for a
+        // fact about someone's guitar, "How long have you been married?" for one
+        // about a marriage.
+        //
+        // A question is the WORST case for the overlap score rather than a marginal
+        // one: it repeats the claim's keywords exactly while affirming none of them,
+        // so it scores like a paraphrase. The punctuation rule below cannot catch it
+        // either — one "?" in twenty characters is 0.05, far under any sane density
+        // threshold. It has to be its own rule.
+        if (text.charAt(text.length - 1) === "?") { return true; }
         var punct = text.replace(/[^!-\/:-@\[-`{-~]/g, "").length;
         return punct / text.length > CONFIG.max_span_punctuation;
       }

--- a/cmd/loomcycle/presets_memory_codejs_test.go
+++ b/cmd/loomcycle/presets_memory_codejs_test.go
@@ -4819,3 +4819,56 @@ func TestConsolidator_AnUnrelatedWriteFailureDoesNotRetypeTheSubject(t *testing.
 		t.Errorf("the failure should still be reported: %s", res.FinalText)
 	}
 }
+
+// TestConsolidator_AQuestionIsNotEvidence — an interrogative cannot be the span a
+// claim is checked against.
+//
+// MEASURED on a live corpus before this existed: 6 of 76 attached spans were
+// questions. "How long have you been married?" stood as the evidence for a fact
+// about a marriage; "What type of guitar?" for one about a guitar.
+//
+// A question is the WORST case for Dice overlap rather than a marginal one. It
+// repeats the claim's keywords while affirming none of them, and because Dice
+// divides by both bag sizes, a six-token question outscores the long utterance
+// that actually says the thing. The numbers for this fixture: the question shares
+// {married} for 2*1/(4+2) = 0.333, the real answer shares {ten, years} for
+// 2*2/(4+10) = 0.286. The question WINS, which is why the declarative here is
+// deliberately long — shortening it makes the filter unnecessary and the test
+// vacuous.
+//
+// Shaped like the real rendering (### speaker on its own line): the "user: " prefix
+// form would hand the sentence a token the claim contains and let it win on a word
+// the fixture invented.
+func TestConsolidator_AQuestionIsNotEvidence(t *testing.T) {
+	f := newFakeToolset()
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	f.transcript = "### user\n\n" +
+		"We celebrated our tenth wedding anniversary in June, and honestly the ten " +
+		"years have gone by so fast that I can hardly believe it.\n\n" +
+		"### assistant\n\n" +
+		"How long have you been married?\n\n"
+	f.factsJSON = `[{"text":"Caroline has been married for ten years.",` +
+		`"class":"fact","type":"event","subject":"Caroline"}]`
+
+	runConsolidator(t, f)
+
+	// NO SPAN is an acceptable outcome and a wrong one is not, which is why this
+	// asserts the absence rather than requiring a replacement. A fact with no
+	// quote is the pre-existing state for anything under the overlap floor; a
+	// fact carrying a question makes the judge refuse a TRUE claim, which is the
+	// direction that loses data. Here the declarative is long enough to sit under
+	// the floor itself, so the filter's honest result is no evidence at all.
+	var span, key string
+	for k, v := range f.chunkSpans {
+		if strings.Contains(k, "fact") && v != "" {
+			span, key = v, k
+		}
+	}
+	if strings.HasSuffix(strings.TrimSpace(span), "?") {
+		t.Errorf("chunk %q was handed a QUESTION as its evidence: %q — an interrogative "+
+			"asserts nothing, so a judge shown it can only refuse a true fact", key, span)
+	}
+	if span != "" && !strings.Contains(f.transcript, span) {
+		t.Errorf("span %q is not in the transcript verbatim", span)
+	}
+}


### PR DESCRIPTION
## Why

**Measured** on a live 76-span corpus: **6 spans (7.9%) were interrogatives.**

| attached span | the fact it was evidence for |
|---|---|
| `How long have you been married?` | a marriage |
| `What type of guitar?` | a guitar |
| `Do you like painting animals?` | painting |

A question is the **worst** case for the span score, not a marginal one. It repeats the claim's keywords while affirming none of them, so Dice overlap ranks it like a paraphrase — and because Dice divides by both bag sizes, a six-token question outscores the long utterance that actually says the thing. The punctuation-density rule could never catch it either: one `?` in twenty characters is 0.05.

**This fails in the direction that loses data.** The span is what the verification pass checks a claim against, so a question attached to a **true** fact gets that fact withheld. That is the same failure already recorded for tool-call lines and regex patterns — which is why `notProse` exists, and why this belongs inside it: its contract is already *"a line that cannot be evidence for a claim, because there is no assertion in it"*, and an interrogative asserts nothing.

## What

Three lines in `notProse` (plus the comment explaining the measurement), in both bundle copies, kept byte-identical.

### Withdrawn from this change, and worth recording

I also wrote a rule rejecting a candidate whose only agreement with the claim is the subject's **name** — aimed at `"Thanks, Caroline!"`, which was attached as the evidence for a fact about Caroline because sharing `{caroline}` scores 0.5 against a two-word claim.

**An existing test killed it.** `TestConsolidator_NonProseLinesAreDroppedButMarkedUpProseIsNot` has the claim *"The user lives in Cluj-Napoca"* with subject **"Cluj-Napoca"**, where the correct evidence *"I live in Cluj-Napoca."* shares **only** subject tokens. When the subject *is* the thing asserted — a location, an object — naming it is the evidence, so no token-identity rule separates the two cases.

I removed my rule rather than weaken the test that caught it. Trading a wrong-span class for a lost-span class is the wrong direction, and the fixture-of-one word-count heuristics that would separate them are not worth shipping unmeasured. **The greeting class stays open.**

## Not an accuracy claim

This is a correctness fix on the **verification** path, and explicitly *not* the fix for RFC CV P1. The reach-through gate measured **0.2823 in both arms** (3/129 discordant, p=1.0000) with a source-aware answerer — repairing 7.9% of spans cannot move that. P1's limiter is upstream: 85 facts for 150 questions, ~76% of them carrying no time information at all. The answerer cannot reach through to a specific that was never captured.

## What was tested

`TestConsolidator_AQuestionIsNotEvidence`.

**Fail-before verified** by reverting only the bundle, test unchanged:

```
--- FAIL: TestConsolidator_AQuestionIsNotEvidence
    chunk "memory/fact/caroline-married-ten-years" was handed a QUESTION as its
    evidence: "How long have you been married?"
```

The fixture is deliberately sized so the question **wins** under the old scoring — it shares `{married}` for 2·1/(4+2) = 0.333 against the real answer's `{ten, years}` for 2·2/(4+10) = 0.286. A shorter declarative would make the filter unnecessary and the test vacuous, which is the trap the sibling grep-pattern test documents.

The assertion is on **absence**, and says why: no span is an acceptable outcome (it is the pre-existing state for anything under the overlap floor) while a *wrong* span makes a judge refuse a true claim. Here the declarative sits under the floor on its own merits, so the filter's honest result is no evidence at all.

Green: `./cmd/loomcycle` (the whole consolidator code-js suite, which is what caught my withdrawn rule), `./internal/memory/...`, `./internal/tools/builtin`. Both bundle copies diff-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8
