### PR TITLE
fix(bench): LongMemEval answers are not all strings

### DIFF
--- a/bench/cmd/locomo/longmemeval.go
+++ b/bench/cmd/locomo/longmemeval.go
@@ -93,14 +93,25 @@ type lmeTurn struct {
 // lmeInstance is one of the 500 evaluation instances, per the dataset's
 // documented format.
 type lmeInstance struct {
-	QuestionID   string      `json:"question_id"`
-	QuestionType string      `json:"question_type"`
-	Question     string      `json:"question"`
-	Answer       string      `json:"answer"`
-	QuestionDate string      `json:"question_date"`
-	SessionIDs   []string    `json:"haystack_session_ids"`
-	Dates        []string    `json:"haystack_dates"`
-	Sessions     [][]lmeTurn `json:"haystack_sessions"`
+	QuestionID   string `json:"question_id"`
+	QuestionType string `json:"question_type"`
+	Question     string `json:"question"`
+	// Answer is json.RawMessage because the DATASET IS NOT UNIFORMLY TYPED: 468
+	// of the 500 oracle answers are strings and 32 are bare NUMBERS — "3" for
+	// "How many items of clothing do I need to pick up", and so on. Declaring it
+	// `string` made encoding/json reject the whole file with
+	// "cannot unmarshal number into Go struct field lmeInstance.answer", so the
+	// adapter could not read the corpus it was written for at all.
+	//
+	// This shipped that way because the loader's tests used hand-written
+	// fixtures, and every fixture answer was a string. A fixture that always
+	// cooperates cannot discover the shape the real data takes; the download is
+	// what found it.
+	Answer       json.RawMessage `json:"answer"`
+	QuestionDate string          `json:"question_date"`
+	SessionIDs   []string        `json:"haystack_session_ids"`
+	Dates        []string        `json:"haystack_dates"`
+	Sessions     [][]lmeTurn     `json:"haystack_sessions"`
 }
 
 // IsAbstention reports whether the gold behaviour is to REFUSE.
@@ -112,6 +123,26 @@ type lmeInstance struct {
 // correct refusals as failures and reward one that confabulates — the opposite
 // of what the abstention slice exists to measure.
 func (i lmeInstance) IsAbstention() bool { return strings.HasSuffix(i.QuestionID, "_abs") }
+
+// lmeAnswerString renders a gold answer as the text the judge compares against,
+// accepting either JSON shape the dataset uses.
+//
+// A quoted string unquotes; anything else (a number) is passed through as its
+// literal source text, which is exactly what "3" should be. Unparseable input
+// yields "" rather than an error: a gold answer that cannot be read makes the
+// instance ungradeable, and the loader's defect counters already report
+// instances it had to drop — failing the whole file over one malformed answer
+// would lose the other 499.
+func lmeAnswerString(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	return strings.TrimSpace(string(raw))
+}
 
 // LoadLongMemEval reads the dataset and converts each instance into one
 // Conversation, so the rest of the harness is unchanged.
@@ -199,7 +230,7 @@ func LoadLongMemEval(path string, limit int) ([]Conversation, LMEDefects, error)
 			Question: inst.Question,
 			Category: cat,
 			Expected: expected,
-			Answer:   inst.Answer,
+			Answer:   lmeAnswerString(inst.Answer),
 			Abstain:  abstention,
 		}}
 		out = append(out, conv)


### PR DESCRIPTION
## Why

The adapter could not read the dataset it was written for. Pointed at the real `longmemeval_oracle.json` it failed the **whole file**:

```
longmemeval: ... is not the documented array-of-instances shape:
json: cannot unmarshal number into Go struct field lmeInstance.answer of type string
```

**468 of the 500 oracle answers are strings; 32 are bare numbers** — `3` for *"How many items of clothing do I need to pick up or return from a store"*, and so on.

## Why it shipped broken

The lesson is the reusable part: the loader's tests used hand-written fixtures, and every fixture answer was a string. **A fixture that always cooperates cannot discover the shape the real data takes.** It's the same failure already recorded for the extractor probe, where a stub that always emitted `observed_at` proved the write path and nothing about whether a model emits it.

The dataset was never downloaded until it was needed — and downloading it found the bug in one command.

## What

`Answer` becomes `json.RawMessage`, rendered by `lmeAnswerString`: a quoted string unquotes, anything else passes through as its literal source text (which is what `3` should be). Unreadable input yields `""` rather than failing the load, because one malformed gold answer must not cost the other 499 — the loader's defect counters already report what it dropped.

## What was tested

Verified against the real corpus, which is the only test that could have caught this:

```
longmemeval: 500 instances (30 abstention); dropped: 0 unknown type,
             0 no question, 0 no history, 0 no evidence
loaded 500 conversations, 10960 turns, 500 scoreable queries
```

All six question types present (temporal-reasoning 133, multi-session 133, knowledge-update 78, single-session-user 70, single-session-assistant 56, single-session-preference 30), and the 30 `_abs` abstention instances are detected.

Bench-only; no runtime code. This unblocks the granularity probe, whose gate requires a LongMemEval baseline before the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8
