### PR TITLE
fix(memory): the extraction window must reach the queued path

### DIFF
--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -1053,6 +1053,12 @@ agents:
       // Capped, because a long chat's accumulated facts would otherwise grow the
       // prompt window by window until the call that matters is mostly history.
       function rollingContext(priorFacts) {
+        // GATED ON THE WINDOW, so window=0 is byte-identical to what shipped.
+        // The context exists BECAUSE a narrow window loses the antecedent; with
+        // the whole source in one call there is nothing to carry forward. Leaving
+        // it ungated would have quietly changed the control arm of the sweep and
+        // conflated two variables — window and context — in one comparison.
+        if (CONFIG.extract_window_turns <= 0) { return ""; }
         if (!priorFacts || !priorFacts.length) { return ""; }
         var lines = [], start = priorFacts.length > CONFIG.max_context_facts
           ? priorFacts.length - CONFIG.max_context_facts : 0;
@@ -1243,6 +1249,9 @@ agents:
         if (!pending.length) { return []; }
         var acked = [];
         var queue = pending;
+        // Facts this pass has already pulled off the queue, carried into later
+        // batches as context. Reset per pass, not per batch.
+        if (!st.batch_facts) { st.batch_facts = []; }
         // narrowed: the previous call came back empty, so the next takes the head
         // ALONE to find out whether that one item is the problem.
         var narrowed = false;
@@ -1260,7 +1269,10 @@ agents:
           // No reference date: a batch spans MANY queued items with different
           // arrival times, so there is no single "today" to resolve against and a
           // wrong one would date every fact in the batch to the same wrong day.
-          var facts = extract(st, pendingText, "", "");
+          // The batch carries the rolling context too: a narrow queue window has
+          // the same coreference problem a narrow chat window does, and `acked`
+          // is not the right carrier — what the earlier batches YIELDED is.
+          var facts = extract(st, pendingText, "", "", st.batch_facts);
           deriveSpans(facts, pendingText);
           stampObservedAt(facts, pendingText);
           resolveValidAt(facts);
@@ -1300,6 +1312,9 @@ agents:
           // are only acked after a successful write, and re-draining costs nothing.
           if (!applyFacts(st, facts, "", attributeTo)) { break; }
 
+          for (var i = 0; i < facts.length && st.batch_facts.length < CONFIG.max_context_facts * 4; i++) {
+            st.batch_facts.push(facts[i]);
+          }
           for (var i = 0; i < taken.length; i++) {
             if (taken[i] && typeof taken[i].id === "string") { acked.push(taken[i].id); }
           }
@@ -1315,11 +1330,25 @@ agents:
       // budget. The first item always goes in however large it is — otherwise a
       // single oversized queued item would wedge the queue permanently, never
       // taken and never acked.
+      //
+      // THE GRANULARITY KNOB APPLIES HERE TOO, and it is not a nicety: this is the
+      // path `Memory op=add` takes. A pass that reports "chats read 0" did all its
+      // extraction through this function, so a window implemented only in the chat
+      // splitter is INERT for every enqueued turn — measured, on a 419-turn corpus
+      // where the whole-chat and 5-turn arms produced byte-identical extractor
+      // input (34,710 tokens, 10 calls) because neither ever reached the splitter.
+      //
+      // A queued item is one enqueued payload, so capping the batch at N items is
+      // the queue's equivalent of closing a part after N turns.
       function takePending(pending, budget) {
         var taken = [], used = 0;
+        var windowTurns = CONFIG.extract_window_turns > 0 ? CONFIG.extract_window_turns : 0;
         for (var i = 0; i < pending.length; i++) {
           var size = renderPending([pending[i]]).length;
           if (taken.length && used + size > budget) { break; }
+          // The item cap closes the batch even when the budget has room, exactly
+          // as the turn cap closes a part.
+          if (windowTurns > 0 && taken.length >= windowTurns) { break; }
           taken.push(pending[i]);
           used += size + 1;
         }

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -1053,6 +1053,12 @@ agents:
       // Capped, because a long chat's accumulated facts would otherwise grow the
       // prompt window by window until the call that matters is mostly history.
       function rollingContext(priorFacts) {
+        // GATED ON THE WINDOW, so window=0 is byte-identical to what shipped.
+        // The context exists BECAUSE a narrow window loses the antecedent; with
+        // the whole source in one call there is nothing to carry forward. Leaving
+        // it ungated would have quietly changed the control arm of the sweep and
+        // conflated two variables — window and context — in one comparison.
+        if (CONFIG.extract_window_turns <= 0) { return ""; }
         if (!priorFacts || !priorFacts.length) { return ""; }
         var lines = [], start = priorFacts.length > CONFIG.max_context_facts
           ? priorFacts.length - CONFIG.max_context_facts : 0;
@@ -1243,6 +1249,9 @@ agents:
         if (!pending.length) { return []; }
         var acked = [];
         var queue = pending;
+        // Facts this pass has already pulled off the queue, carried into later
+        // batches as context. Reset per pass, not per batch.
+        if (!st.batch_facts) { st.batch_facts = []; }
         // narrowed: the previous call came back empty, so the next takes the head
         // ALONE to find out whether that one item is the problem.
         var narrowed = false;
@@ -1260,7 +1269,10 @@ agents:
           // No reference date: a batch spans MANY queued items with different
           // arrival times, so there is no single "today" to resolve against and a
           // wrong one would date every fact in the batch to the same wrong day.
-          var facts = extract(st, pendingText, "", "");
+          // The batch carries the rolling context too: a narrow queue window has
+          // the same coreference problem a narrow chat window does, and `acked`
+          // is not the right carrier — what the earlier batches YIELDED is.
+          var facts = extract(st, pendingText, "", "", st.batch_facts);
           deriveSpans(facts, pendingText);
           stampObservedAt(facts, pendingText);
           resolveValidAt(facts);
@@ -1300,6 +1312,9 @@ agents:
           // are only acked after a successful write, and re-draining costs nothing.
           if (!applyFacts(st, facts, "", attributeTo)) { break; }
 
+          for (var i = 0; i < facts.length && st.batch_facts.length < CONFIG.max_context_facts * 4; i++) {
+            st.batch_facts.push(facts[i]);
+          }
           for (var i = 0; i < taken.length; i++) {
             if (taken[i] && typeof taken[i].id === "string") { acked.push(taken[i].id); }
           }
@@ -1315,11 +1330,25 @@ agents:
       // budget. The first item always goes in however large it is — otherwise a
       // single oversized queued item would wedge the queue permanently, never
       // taken and never acked.
+      //
+      // THE GRANULARITY KNOB APPLIES HERE TOO, and it is not a nicety: this is the
+      // path `Memory op=add` takes. A pass that reports "chats read 0" did all its
+      // extraction through this function, so a window implemented only in the chat
+      // splitter is INERT for every enqueued turn — measured, on a 419-turn corpus
+      // where the whole-chat and 5-turn arms produced byte-identical extractor
+      // input (34,710 tokens, 10 calls) because neither ever reached the splitter.
+      //
+      // A queued item is one enqueued payload, so capping the batch at N items is
+      // the queue's equivalent of closing a part after N turns.
       function takePending(pending, budget) {
         var taken = [], used = 0;
+        var windowTurns = CONFIG.extract_window_turns > 0 ? CONFIG.extract_window_turns : 0;
         for (var i = 0; i < pending.length; i++) {
           var size = renderPending([pending[i]]).length;
           if (taken.length && used + size > budget) { break; }
+          // The item cap closes the batch even when the budget has room, exactly
+          // as the turn cap closes a part.
+          if (windowTurns > 0 && taken.length >= windowTurns) { break; }
           taken.push(pending[i]);
           used += size + 1;
         }

--- a/cmd/loomcycle/presets_memory_codejs_test.go
+++ b/cmd/loomcycle/presets_memory_codejs_test.go
@@ -5021,3 +5021,54 @@ func TestConsolidator_LaterWindowsCarryTheEarlierFactsAsContext(t *testing.T) {
 		}
 	}
 }
+
+// TestConsolidator_QueuedPathHonoursTheExtractionWindow — the granularity knob
+// must reach the path `Memory op=add` actually takes.
+//
+// MEASURED, and it is why this test exists: a sweep of the whole-chat and
+// 5-turn windows on a 419-turn corpus produced BYTE-IDENTICAL extractor input
+// (34,710 tokens across 10 calls) in both arms. Every pass reported "chats read
+// 0" — all the work came off the pending queue, which called the extractor
+// directly and never reached the chat splitter where the window lived. The knob
+// was real, the arms were configurationally identical, and the run measured
+// nothing.
+//
+// Asserted on the CALL COUNT, like its chat-path sibling: what must be true is
+// that the extractor saw the queue in N-item batches rather than one.
+func TestConsolidator_QueuedPathHonoursTheExtractionWindow(t *testing.T) {
+	newFixture := func() *fakeToolset {
+		f := newFakeToolset()
+		// No chats to read — exactly the shape the benchmark and `Memory op=add`
+		// produce, and the shape that hid the gap.
+		f.sessions = nil
+		f.pending = []map[string]any{}
+		for i := 0; i < 6; i++ {
+			f.pending = append(f.pending, map[string]any{
+				"id": fmt.Sprintf("q%d", i),
+				"payload": map[string]any{"messages": []map[string]any{
+					{"role": "user", "content": fmt.Sprintf("Queued turn %d: I visited city number %d in July.", i, i)},
+				}},
+			})
+		}
+		f.factsJSON = `[]`
+		return f
+	}
+
+	wide := newFixture()
+	runConsolidator(t, wide)
+	wideCalls := len(extractorPrompts(wide))
+
+	narrow := newFixture()
+	runConsolidatorWindow(t, narrow, 1)
+	narrowCalls := len(extractorPrompts(narrow))
+
+	if wideCalls == 0 || narrowCalls == 0 {
+		t.Fatalf("the queue was never extracted (wide=%d narrow=%d) — the fixture does not "+
+			"exercise the pending path", wideCalls, narrowCalls)
+	}
+	if narrowCalls <= wideCalls {
+		t.Errorf("per-item window made %d extractor call(s) against the default's %d — the "+
+			"window does not reach the queued path, so an arm set on it measures nothing",
+			narrowCalls, wideCalls)
+	}
+}


### PR DESCRIPTION
## The granularity knob shipped inert for the path that matters

It lived only in the chat splitter — and `Memory op=add` does not go through the chat splitter. Enqueued turns are drained by `consolidatePending`, which calls the extractor directly at `extract(st, pendingText, "", "")`.

**Measured, which is how this was found.** A sweep of the whole-chat and 5-turn windows over a 419-turn corpus produced **byte-identical extractor input — 34,710 tokens across 10 calls — in both arms**, with every pass reporting `chats read 0`. The two arms were configurationally identical and the run measured nothing about granularity.

This also means the feature was **inert in production** for any agent writing through `Memory op=add`, not just in the benchmark.

## What

- **`takePending` caps a batch at N queued items** when the knob is set — the queue's equivalent of closing a part after N turns, since one queued item is one enqueued payload.
- **The batch carries rolling context too.** A narrow queue window has the same coreference problem a narrow chat window does. The carrier is what earlier batches *yielded* (`st.batch_facts`), reset per pass.
- **`rollingContext` is now gated on the window being set.** Without that gate the queue path would have gained context at `window=0`, quietly changing the sweep's **control** arm and conflating two variables in one comparison. The gate is principled, not convenient: the context exists *because* a narrow window loses the antecedent, and with the whole source in one call there is nothing to carry.

### ⚠️ `max_pending_calls` is the queue's `max_parts_per_chat`

Same trap, same shape. At 4 calls per pass a 419-item queue needs ~105 passes, so an arm that does not raise it measures a truncated corpus while reporting a finer window. Now stated at both knobs.

## What was tested

`TestConsolidator_QueuedPathHonoursTheExtractionWindow`, with a fixture that has **no chats** — the shape the benchmark and `Memory op=add` both produce, and precisely the shape that hid this gap. Asserted on the call count, like its chat-path sibling.

Fail-before against the merged version:

```
--- FAIL: TestConsolidator_QueuedPathHonoursTheExtractionWindow
    per-item window made 1 extractor call(s) against the default's 1 — the window
    does not reach the queued path, so an arm set on it measures nothing
```

`./cmd/loomcycle` green; both bundle copies byte-identical.

## Byproduct worth keeping

The two identical arms scored **0.3732 and 0.3451** — a **2.8pp spread from extraction/answering nondeterminism alone** on this corpus. That is the rig's noise floor, and any granularity effect has to clear it. It is a more useful number than either arm's accuracy was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8
