### PR TITLE
fix(memory): scan a chat WHOLE; bound a pass by chats, not by trimming one

### DIFF
--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -148,7 +148,7 @@
 # THE COST IS MODEL CALLS. A 21,635-char transcript is now three or four
 # extractor runs instead of one, so a pass takes correspondingly longer in wall
 # clock. That matters to an operator running a tight cadence; see the
-# max_parts_per_chat note in the body for the worst-case arithmetic.
+# max_parts_per_pass note in the body for the worst-case arithmetic.
 #
 # Two fan-out caps are operator-tunable via env:
 #   LOOMCYCLE_MAX_CONSOLIDATION_TARGETS      (default 32) targets per tick
@@ -307,7 +307,7 @@ agents:
         // N=4..6 the short sliding window, with max_part_chars still a hard
         // ceiling above it.
         //
-        // ⚠️ IT INTERACTS WITH max_parts_per_chat, WHICH WILL SILENTLY EAT THE
+        // ⚠️ IT INTERACTS WITH max_parts_per_pass, WHICH BOUNDS A PASS'S TOTAL
         // SWEEP IF LEFT AT 4. A 22-turn chat at N=1 is 22 parts; the cap keeps the
         // LATEST 4 and discards eighteen messages, so the arm would measure a
         // truncated conversation while reporting a finer window. Raise both
@@ -327,11 +327,22 @@ agents:
         // The report names the chat and how many parts went unread.
         //
         // WALL CLOCK, which an operator on a tight cadence needs: the worst case
-        // is scan_limit × this = 40 extractor calls in one pass against a 1500 s
-        // budget, about 37 s per call. A deployment whose extractor is slower
-        // than that should lower scan_limit — the budget itself cannot rise
-        // much, since it has to stay under the lease TTL.
-        max_parts_per_chat: 4,
+        // is this many extractor calls in one pass against run_timeout_seconds.
+        //
+        // ⚠️ THIS USED TO BE A PER-CHAT CAP THAT DISCARDED DATA. A chat splitting
+        // past 4 parts had its EARLIEST parts dropped (parts.slice) and the
+        // watermark advanced past the chat anyway, so that content was gone for
+        // good — a long chat was silently extracted only from its tail. The
+        // budget is now per PASS and bounds how many CHATS a pass starts, never
+        // how much of a chat it reads: a chat is the unit the watermark tracks,
+        // so deferring a WHOLE unread chat costs nothing and the next pass takes
+        // it. Trading wall clock for silent data loss was the wrong way round.
+        //
+        // A single chat larger than the whole budget is still read IN FULL, for
+        // the same reason takePending always accepts its first item: otherwise an
+        // oversized chat is never extracted and never advanced past, wedging the
+        // watermark permanently.
+        max_parts_per_pass: 40,
         max_fact_chars: 400,
         // A span may run longer than the one-sentence fact it supports, but it must
         // not become a way to copy the transcript into the store. Over-long spans are
@@ -410,7 +421,7 @@ agents:
         // rather than acts — a candidate left for the next pass costs nothing at all.
         max_conflict_calls: 4,
         // Bounds the judge calls one pass can make, for the same wall-clock reason
-        // max_parts_per_chat bounds the extractor's. When it bites, the facts past
+        // max_parts_per_pass bounds the extractor's. When it bites, the facts past
         // the cap stay UNJUDGED and recallable, and the report says how many.
         max_judge_calls: 6,
         // How many of the most recent facts a BACKFILL scan looks at. Bounded because
@@ -519,7 +530,8 @@ agents:
           queued_stepped: 0,        // items examined ALONE that yielded nothing durable; left queued, stepped over
           extractions: 0,           // extractor calls, which is now PARTS and not chats
           split_chats: 0,           // chats that needed more than one extractor call
-          parts_capped: 0,          // parts dropped by the per-chat cap
+          parts_spent: 0,           // extractor parts this pass has committed to
+          chats_deferred: 0,        // chats left UNREAD for the next pass (budget spent)
           turns_truncated: 0,       // single messages larger than the whole budget
           seen: {},                 // session_id -> true; the re-read guard
           merge_refused_subject: 0, // above the band, but about a different subject
@@ -672,6 +684,13 @@ agents:
           var row = sessions[i];
           var sid = (row && typeof row.session_id === "string") ? row.session_id : "";
           if (!sid || st.seen[sid] === true) { continue; }
+          // Out of budget: leave this chat and the rest of the page UNREAD so the
+          // watermark stays behind them and the next pass takes them whole. This
+          // is the deferral that replaced discarding parts.
+          if (!hasPartBudget(st)) {
+            st.chats_deferred = sessions.length - i;
+            break;
+          }
           st.seen[sid] = true;
 
           var text = readTranscript(st, sid);
@@ -847,18 +866,23 @@ agents:
       // began mid-word.
       function chatParts(st, text, sid) {
         var parts = packParts(st, splitTurns(text), sid);
-        if (parts.length > CONFIG.max_parts_per_chat) {
-          var dropped = parts.length - CONFIG.max_parts_per_chat;
-          // Keep the LATEST parts: durable content accumulates at the end of a
-          // conversation. Said out loud, because stopping at the cap in silence
-          // is indistinguishable from a chat that simply had less to give.
-          parts = parts.slice(dropped);
-          st.parts_capped += dropped;
-          note(st, sid + ": split past the " + CONFIG.max_parts_per_chat +
-            "-part cap, its earliest " + dropped + " part(s) were not extracted");
-        }
+        // NO PER-CHAT CAP. Every part of a chat that this pass starts is
+        // extracted; the pass's budget is spent by not STARTING further chats
+        // (see hasPartBudget), which loses nothing because an unread chat leaves
+        // the watermark behind it and the next pass reads it whole.
         if (parts.length > 1) { st.split_chats++; }
+        st.parts_spent += parts.length;
         return parts;
+      }
+
+      // hasPartBudget reports whether the pass may START another chat.
+      //
+      // Checked BEFORE reading a chat, never in the middle of one: stopping
+      // mid-chat is what discarded data before. The first chat of a pass always
+      // proceeds however large it is, mirroring takePending's first-item rule —
+      // without that an oversized chat is never extracted and never passed over.
+      function hasPartBudget(st) {
+        return st.parts_spent === 0 || st.parts_spent < CONFIG.max_parts_per_pass;
       }
 
       // splitTurns cuts the transcript at message boundaries, keeping every byte
@@ -2899,9 +2923,12 @@ agents:
             " (cut on message boundaries, each part extracted, results merged; " +
             st.extractions + " extractor calls this pass)");
         }
-        if (st.parts_capped > 0) {
-          parts.push("parts not extracted " + st.parts_capped + " (per-chat cap of " + CONFIG.max_parts_per_chat +
-            " reached; the earliest parts of those chats were passed over)");
+        if (st.chats_deferred > 0) {
+          // DEFERRED, not dropped, and the wording has to say so: the previous
+          // message here reported parts that were gone for good.
+          parts.push("chats left for the next pass " + st.chats_deferred +
+            " (this pass spent its " + CONFIG.max_parts_per_pass +
+            "-part budget; the watermark stays behind them and they are read WHOLE next pass)");
         }
         if (st.turns_truncated > 0) {
           parts.push("oversized messages truncated " + st.turns_truncated +

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -148,7 +148,7 @@
 # THE COST IS MODEL CALLS. A 21,635-char transcript is now three or four
 # extractor runs instead of one, so a pass takes correspondingly longer in wall
 # clock. That matters to an operator running a tight cadence; see the
-# max_parts_per_chat note in the body for the worst-case arithmetic.
+# max_parts_per_pass note in the body for the worst-case arithmetic.
 #
 # Two fan-out caps are operator-tunable via env:
 #   LOOMCYCLE_MAX_CONSOLIDATION_TARGETS      (default 32) targets per tick
@@ -307,7 +307,7 @@ agents:
         // N=4..6 the short sliding window, with max_part_chars still a hard
         // ceiling above it.
         //
-        // ⚠️ IT INTERACTS WITH max_parts_per_chat, WHICH WILL SILENTLY EAT THE
+        // ⚠️ IT INTERACTS WITH max_parts_per_pass, WHICH BOUNDS A PASS'S TOTAL
         // SWEEP IF LEFT AT 4. A 22-turn chat at N=1 is 22 parts; the cap keeps the
         // LATEST 4 and discards eighteen messages, so the arm would measure a
         // truncated conversation while reporting a finer window. Raise both
@@ -327,11 +327,22 @@ agents:
         // The report names the chat and how many parts went unread.
         //
         // WALL CLOCK, which an operator on a tight cadence needs: the worst case
-        // is scan_limit × this = 40 extractor calls in one pass against a 1500 s
-        // budget, about 37 s per call. A deployment whose extractor is slower
-        // than that should lower scan_limit — the budget itself cannot rise
-        // much, since it has to stay under the lease TTL.
-        max_parts_per_chat: 4,
+        // is this many extractor calls in one pass against run_timeout_seconds.
+        //
+        // ⚠️ THIS USED TO BE A PER-CHAT CAP THAT DISCARDED DATA. A chat splitting
+        // past 4 parts had its EARLIEST parts dropped (parts.slice) and the
+        // watermark advanced past the chat anyway, so that content was gone for
+        // good — a long chat was silently extracted only from its tail. The
+        // budget is now per PASS and bounds how many CHATS a pass starts, never
+        // how much of a chat it reads: a chat is the unit the watermark tracks,
+        // so deferring a WHOLE unread chat costs nothing and the next pass takes
+        // it. Trading wall clock for silent data loss was the wrong way round.
+        //
+        // A single chat larger than the whole budget is still read IN FULL, for
+        // the same reason takePending always accepts its first item: otherwise an
+        // oversized chat is never extracted and never advanced past, wedging the
+        // watermark permanently.
+        max_parts_per_pass: 40,
         max_fact_chars: 400,
         // A span may run longer than the one-sentence fact it supports, but it must
         // not become a way to copy the transcript into the store. Over-long spans are
@@ -410,7 +421,7 @@ agents:
         // rather than acts — a candidate left for the next pass costs nothing at all.
         max_conflict_calls: 4,
         // Bounds the judge calls one pass can make, for the same wall-clock reason
-        // max_parts_per_chat bounds the extractor's. When it bites, the facts past
+        // max_parts_per_pass bounds the extractor's. When it bites, the facts past
         // the cap stay UNJUDGED and recallable, and the report says how many.
         max_judge_calls: 6,
         // How many of the most recent facts a BACKFILL scan looks at. Bounded because
@@ -519,7 +530,8 @@ agents:
           queued_stepped: 0,        // items examined ALONE that yielded nothing durable; left queued, stepped over
           extractions: 0,           // extractor calls, which is now PARTS and not chats
           split_chats: 0,           // chats that needed more than one extractor call
-          parts_capped: 0,          // parts dropped by the per-chat cap
+          parts_spent: 0,           // extractor parts this pass has committed to
+          chats_deferred: 0,        // chats left UNREAD for the next pass (budget spent)
           turns_truncated: 0,       // single messages larger than the whole budget
           seen: {},                 // session_id -> true; the re-read guard
           merge_refused_subject: 0, // above the band, but about a different subject
@@ -672,6 +684,13 @@ agents:
           var row = sessions[i];
           var sid = (row && typeof row.session_id === "string") ? row.session_id : "";
           if (!sid || st.seen[sid] === true) { continue; }
+          // Out of budget: leave this chat and the rest of the page UNREAD so the
+          // watermark stays behind them and the next pass takes them whole. This
+          // is the deferral that replaced discarding parts.
+          if (!hasPartBudget(st)) {
+            st.chats_deferred = sessions.length - i;
+            break;
+          }
           st.seen[sid] = true;
 
           var text = readTranscript(st, sid);
@@ -847,18 +866,23 @@ agents:
       // began mid-word.
       function chatParts(st, text, sid) {
         var parts = packParts(st, splitTurns(text), sid);
-        if (parts.length > CONFIG.max_parts_per_chat) {
-          var dropped = parts.length - CONFIG.max_parts_per_chat;
-          // Keep the LATEST parts: durable content accumulates at the end of a
-          // conversation. Said out loud, because stopping at the cap in silence
-          // is indistinguishable from a chat that simply had less to give.
-          parts = parts.slice(dropped);
-          st.parts_capped += dropped;
-          note(st, sid + ": split past the " + CONFIG.max_parts_per_chat +
-            "-part cap, its earliest " + dropped + " part(s) were not extracted");
-        }
+        // NO PER-CHAT CAP. Every part of a chat that this pass starts is
+        // extracted; the pass's budget is spent by not STARTING further chats
+        // (see hasPartBudget), which loses nothing because an unread chat leaves
+        // the watermark behind it and the next pass reads it whole.
         if (parts.length > 1) { st.split_chats++; }
+        st.parts_spent += parts.length;
         return parts;
+      }
+
+      // hasPartBudget reports whether the pass may START another chat.
+      //
+      // Checked BEFORE reading a chat, never in the middle of one: stopping
+      // mid-chat is what discarded data before. The first chat of a pass always
+      // proceeds however large it is, mirroring takePending's first-item rule —
+      // without that an oversized chat is never extracted and never passed over.
+      function hasPartBudget(st) {
+        return st.parts_spent === 0 || st.parts_spent < CONFIG.max_parts_per_pass;
       }
 
       // splitTurns cuts the transcript at message boundaries, keeping every byte
@@ -2899,9 +2923,12 @@ agents:
             " (cut on message boundaries, each part extracted, results merged; " +
             st.extractions + " extractor calls this pass)");
         }
-        if (st.parts_capped > 0) {
-          parts.push("parts not extracted " + st.parts_capped + " (per-chat cap of " + CONFIG.max_parts_per_chat +
-            " reached; the earliest parts of those chats were passed over)");
+        if (st.chats_deferred > 0) {
+          // DEFERRED, not dropped, and the wording has to say so: the previous
+          // message here reported parts that were gone for good.
+          parts.push("chats left for the next pass " + st.chats_deferred +
+            " (this pass spent its " + CONFIG.max_parts_per_pass +
+            "-part budget; the watermark stays behind them and they are read WHOLE next pass)");
         }
         if (st.turns_truncated > 0) {
           parts.push("oversized messages truncated " + st.turns_truncated +

--- a/cmd/loomcycle/presets_memory_codejs_test.go
+++ b/cmd/loomcycle/presets_memory_codejs_test.go
@@ -2312,37 +2312,89 @@ func TestConsolidator_OversizedSingleMessageIsTruncatedAndSaidSo(t *testing.T) {
 	}
 }
 
-// TestConsolidator_PartCapBoundsTheExtractorCallsOneChatCanSpawn. Without a cap
-// a pathological transcript spawns an unbounded number of model calls inside one
-// pass, which is the same class of hazard the retirement cap exists for. When it
-// bites, the EARLIEST parts go: durable content accumulates at the end of a
-// conversation, which is the same reason the old truncation kept the tail.
+// TestConsolidator_ALongChatIsReadWHOLEAndThePassDefersOtherChats.
 //
-// Stopping at the cap in silence would be indistinguishable from a chat that
-// simply had less to say, so the report names the chat and the count.
-func TestConsolidator_PartCapBoundsTheExtractorCallsOneChatCanSpawn(t *testing.T) {
+// REPLACES a test that asserted the opposite, and the reason is a defect not a
+// preference. The per-chat cap bounded a pass by DISCARDING the earliest parts
+// of a long chat (parts.slice) and then advancing the watermark past it anyway,
+// so a chat over ~48k chars was permanently extracted from its tail alone and
+// the rest was gone with nothing left to notice. The old test pinned that: it
+// required exactly 4 extractor calls for a 6-part chat and failed if nothing had
+// been dropped.
+//
+// A pass still has to be bounded — an unbounded number of model calls inside one
+// pass is a real hazard. But the bound now falls on how many CHATS a pass
+// STARTS, never on how much of a chat it reads: a chat is the unit the watermark
+// tracks, so an unread chat leaves the mark behind it and the next pass takes it
+// whole. Wall clock is the thing to spend; data is not.
+func TestConsolidator_ALongChatIsReadWHOLEAndThePassDefersOtherChats(t *testing.T) {
 	f := newFakeToolset()
 	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
-	f.transcript = historyTranscript(60, 1000) // ~62k chars → ~6 parts, cap is 4
+	f.transcript = historyTranscript(60, 1000) // ~62k chars → ~6 parts
 	f.factsJSON = "[]"
 
 	res := runConsolidator(t, f)
 
-	if n := f.countOp("Agent"); n != 4 {
-		t.Errorf("extractor spawned %d times for one chat, want exactly 4 — the per-chat cap is the only bound on it; sequence %v", n, f.ops())
-	}
-	// The parts kept are the LAST ones: the final turn must be in there, the
-	// first must not.
 	parts := extractorParts(t, f)
 	joined := strings.Join(parts, "\n")
+	// BOTH ENDS must be present. The tail alone is what the old cap left, so
+	// asserting only turn59 would pass against the defect.
+	if !strings.Contains(joined, "turn00 ") {
+		t.Errorf("the BEGINNING of the chat never reached the extractor — a long chat is still "+
+			"being read from its tail only, which is the data loss this replaced (%d parts)", len(parts))
+	}
 	if !strings.Contains(joined, "turn59 ") {
-		t.Error("the cap dropped the END of the conversation — durable content accumulates there, so the tail is what must survive")
+		t.Errorf("the END of the chat never reached the extractor (%d parts)", len(parts))
 	}
-	if strings.Contains(joined, "turn00 ") {
-		t.Error("the cap did not actually drop anything; this scenario proves nothing")
+	if n := f.countOp("Agent"); n < 6 {
+		t.Errorf("extractor spawned %d times for a ~6-part chat, want every part extracted; "+
+			"sequence %v", n, f.ops())
 	}
-	if !strings.Contains(res.FinalText, "parts not extracted") || !strings.Contains(res.FinalText, "sess-a") {
-		t.Errorf("report = %q, want the cap and the chat named — stopping at the cap silently reads as a chat with less to say", res.FinalText)
+	if strings.Contains(res.FinalText, "parts not extracted") {
+		t.Errorf("report still speaks of discarded parts: %q", res.FinalText)
+	}
+	if !f.has("Memory.cursor_advance") {
+		t.Errorf("a fully-read chat must advance the watermark; sequence %v", f.ops())
+	}
+}
+
+// TestConsolidator_PassBudgetDefersWholeChatsRatherThanTrimmingOne.
+//
+// The other half of the contract above: the bound still exists. Several long
+// chats in one page must not all be started — the pass spends its part budget,
+// stops STARTING chats, and says so. What must never appear is a chat that was
+// read in part.
+func TestConsolidator_PassBudgetDefersWholeChatsRatherThanTrimmingOne(t *testing.T) {
+	f := newFakeToolset()
+	f.sessions = nil
+	f.transcripts = map[string]string{}
+	// 8 chats x ~6 parts = ~48 parts, comfortably over the 40-part pass budget.
+	for i := 0; i < 8; i++ {
+		sid := fmt.Sprintf("sess-%d", i)
+		f.sessions = append(f.sessions, scanRow(sid, "2026-07-01T10:00:00Z"))
+		f.transcripts[sid] = historyTranscript(60, 1000)
+	}
+	f.factsJSON = "[]"
+
+	res := runConsolidator(t, f)
+
+	if !strings.Contains(res.FinalText, "chats left for the next pass") {
+		t.Errorf("eight ~6-part chats did not exhaust the pass budget, so this scenario cannot "+
+			"show deferral: %q", res.FinalText)
+	}
+	if strings.Contains(res.FinalText, "parts not extracted") {
+		t.Errorf("the pass trimmed a chat instead of deferring one: %q", res.FinalText)
+	}
+	// A chat the pass started must appear in full: its OPENING part has to be
+	// among what the extractor saw. A chat not read at all is fine and expected —
+	// that is what deferral means.
+	joined := strings.Join(extractorParts(t, f), "\n")
+	if !strings.Contains(joined, "turn00 ") {
+		t.Errorf("no chat contributed its opening part; the pass read tails only: %q", res.FinalText)
+	}
+	// And the watermark must still move, or a full queue never drains.
+	if !f.has("Memory.cursor_advance") {
+		t.Errorf("a pass that fully read some chats must advance past them; sequence %v", f.ops())
 	}
 }
 


### PR DESCRIPTION
## A long chat was silently extracted from its tail only

`chatParts` capped a chat at 4 parts, **discarded the earliest ones** with `parts.slice`, and the watermark advanced past the chat anyway. So a transcript over ~48k chars lost its opening permanently, with nothing left anywhere to re-read it.

The old behaviour, from a real pass report over eight long chats:

```
parts not extracted 16 (per-chat cap of 4 reached; the earliest parts of
those chats were passed over) ... watermark advanced to sess-7
```

**~160k characters — about a third of the content — gone, and the mark moved on.** It is also a plausible cause of low fact yield on any corpus with long sessions, since two thirds of each chat is all the extractor ever saw.

## What

A pass still needs a bound — an unbounded number of model calls in one pass is a real hazard. But the bound now falls on how many **chats a pass starts**, never on how much of a chat it reads.

| before | after |
|---|---|
| `max_parts_per_chat: 4` — trims a chat, **discards data** | `max_parts_per_pass: 40` — defers whole chats |
| checked while splitting one chat | `hasPartBudget` checked **before starting** a chat |
| report: "parts not extracted" (gone) | report: "chats left for the next pass … read WHOLE next pass" (queued) |

Same worst-case call count as before (`scan_limit 10 × 4`), so the wall-clock argument the old cap was written for still holds.

**Deferral is free where trimming was not**: a chat is the unit the watermark tracks, so an unread chat leaves the mark behind it and the next pass reads it whole. A chat larger than the entire budget is still read **in full**, for the same reason `takePending` always accepts its first item — otherwise an oversized chat is never extracted and never advanced past, wedging the watermark forever.

The report wording changed because the old one described content that was *gone* and the new one describes work that is *queued*. Those are not the same statement to an operator.

## What was tested

**The old test asserted the defect.** It required exactly 4 extractor calls for a 6-part chat and failed if nothing had been dropped — *"the cap did not actually drop anything; this scenario proves nothing"*. That is how a test and a data-loss bug coexisted. It is **replaced, not weakened**, by two tests pinning both halves of the new contract:

- **`ALongChatIsReadWHOLEAndThePassDefersOtherChats`** — asserts **both ends** of a 6-part chat reach the extractor. Asserting only the tail would pass against the defect, which is exactly the trap the old test fell into.
- **`PassBudgetDefersWholeChatsRatherThanTrimmingOne`** — eight ~6-part chats over the budget: requires deferral, the absence of any trimming, *and* that the watermark still advances. A bound that never advances is a queue that never drains.

Fail-before on the old bundle:

```
--- FAIL: TestConsolidator_ALongChatIsReadWHOLEAndThePassDefersOtherChats
    the BEGINNING of the chat never reached the extractor — a long chat is
    still being read from its tail only
```

`./cmd/loomcycle` and `./internal/memory/...` green; both bundle copies byte-identical.

## Scope note, so this is not over-credited

**This was not the limiter on the current benchmark corpus.** conv-26's 19 sessions average ~3.2k chars — one part each — so the cap never fired there (verified: zero "split past the cap" events), and the w0 control's 0.3732 is unaffected. This is a latent data-loss path that fires on long sessions, found by reasoning about the yield question rather than by the benchmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8
