### PR TITLE
feat(def-fields): a shareable field registry + folded primitive editor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,6 +333,19 @@ jobs:
       - name: Test @loomcycle/memory-view
         working-directory: packages/memory-view
         run: npm run typecheck && npm test
+      # @loomcycle/def-fields is consumed from SOURCE via a Vite alias the same
+      # way — install its deps before the web steps
+      # (packages/def-fields/node_modules is gitignored → absent on checkout).
+      - name: Install @loomcycle/def-fields deps
+        working-directory: packages/def-fields
+        run: npm ci
+      # The registry's own tests include the drift guard that pins
+      # AGENTDEF_OVERLAY_KEYS to builtin.mergedDef's json tags — so adding an
+      # overlay parameter in Go without exposing it in the editor fails HERE,
+      # which is the whole reason the registry exists.
+      - name: Test @loomcycle/def-fields
+        working-directory: packages/def-fields
+        run: npm run typecheck && npm test
       - run: npm ci
       - run: npm run typecheck
       - run: npm run test

--- a/.github/workflows/publish-def-fields.yml
+++ b/.github/workflows/publish-def-fields.yml
@@ -1,0 +1,90 @@
+name: Publish @loomcycle/def-fields to npm
+
+# The @loomcycle/def-fields React components (the declarative field registry +
+# the folded/accordion primitive editor) are versioned INDEPENDENTLY of the Go
+# binary and of the other packages — the loomcycle Web UI and the loomboard
+# canvas each pin their own — so the package publishes on its
+# OWN tag namespace `def-fields-v*` (e.g. `def-fields-v0.1.0`) — mirroring
+# @loomcycle/memory-view's `memory-view-v*` and @loomcycle/library's
+# `library-v*`, NOT the binary's `v*`.
+#
+# Safety: the workflow HARD-FAILS if packages/def-fields/package.json's version
+# doesn't match the tag (a dedicated tag should always match — a mismatch is a
+# mistake, surfaced loudly, npm untouched).
+#
+# Auth: an npm automation token in the `NPM_TOKEN` repo secret. setup-node writes
+# it into ~/.npmrc (via NODE_AUTH_TOKEN below), so `npm publish` authenticates as
+# that token's account. This is the token path chosen for the FIRST publish of
+# this brand-new scoped package (OIDC Trusted Publishing can't bootstrap a package
+# that doesn't exist yet). Once @loomcycle/def-fields exists on npm, the operator
+# MAY switch to OIDC Trusted Publishing (register the publisher on the package's
+# Access tab, drop the secret, add `id-token: write` + `--provenance`) — see the
+# @loomcycle/client publish-ts-adapter.yml workflow for that shape.
+#
+# Inputs reaching `run` steps are limited to GITHUB_REF_NAME (a git tag — git
+# rejects metacharacters in ref names) and constants; the tag is routed through
+# `env:` per the GitHub workflow-injection guidance.
+on:
+  push:
+    tags:
+      - "def-fields-v*"
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish @loomcycle/def-fields
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+          cache: npm
+          cache-dependency-path: packages/def-fields/package-lock.json
+
+      - name: Verify package version matches tag
+        working-directory: packages/def-fields
+        # Strip the `def-fields-v` prefix — npm versions don't carry it. A
+        # dedicated tag should always match the package version; a mismatch is a
+        # mistake.
+        env:
+          TAG_REF: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          PKG_VER=$(node -p "require('./package.json').version")
+          TAG_VER="${TAG_REF#def-fields-v}"
+          if [ "$PKG_VER" != "$TAG_VER" ]; then
+            echo "::error::packages/def-fields/package.json version ($PKG_VER) does not match tag ($TAG_VER). Bump the package.json to $TAG_VER and re-tag, or fix the tag."
+            exit 1
+          fi
+          echo "::notice::Publishing @loomcycle/def-fields@$PKG_VER (tag $TAG_REF)"
+
+      - name: Install
+        working-directory: packages/def-fields
+        run: npm ci
+
+      - name: Build
+        working-directory: packages/def-fields
+        run: npm run build:lib
+
+      - name: Test
+        working-directory: packages/def-fields
+        run: npm test
+
+      - name: Publish
+        working-directory: packages/def-fields
+        # --access public for the scoped package. prepack rebuilds dist from a
+        # clean tree, so the published tarball is fresh regardless. NODE_AUTH_TOKEN
+        # is the NPM_TOKEN secret setup-node wired into ~/.npmrc. (--provenance is
+        # omitted: it requires OIDC/id-token, not token auth; add it if/when this
+        # switches to Trusted Publishing.)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public

--- a/packages/def-fields/.gitignore
+++ b/packages/def-fields/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/packages/def-fields/package-lock.json
+++ b/packages/def-fields/package-lock.json
@@ -1,0 +1,2357 @@
+{
+  "name": "@loomcycle/def-fields",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@loomcycle/def-fields",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "@vitejs/plugin-react": "^5.0.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "typescript": "^5.6.0",
+        "vite": "^7.0.0",
+        "vitest": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.1.tgz",
+      "integrity": "sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.1.tgz",
+      "integrity": "sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.1.tgz",
+      "integrity": "sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.1.tgz",
+      "integrity": "sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.1.tgz",
+      "integrity": "sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.1.tgz",
+      "integrity": "sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.1.tgz",
+      "integrity": "sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.1.tgz",
+      "integrity": "sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.1.tgz",
+      "integrity": "sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.1.tgz",
+      "integrity": "sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.1.tgz",
+      "integrity": "sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.1.tgz",
+      "integrity": "sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.1.tgz",
+      "integrity": "sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.1.tgz",
+      "integrity": "sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.1.tgz",
+      "integrity": "sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.1.tgz",
+      "integrity": "sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.1.tgz",
+      "integrity": "sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.1.tgz",
+      "integrity": "sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.1.tgz",
+      "integrity": "sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.1.tgz",
+      "integrity": "sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.1.tgz",
+      "integrity": "sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.1.tgz",
+      "integrity": "sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.1.tgz",
+      "integrity": "sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.2.tgz",
+      "integrity": "sha512-xlvWf4Vs9n1PEVYwP1n4vvG07M6y8WgvJ2t0vbrWTmijsIHp1cS+uJ2kMIRdY3nHZK0nCYKrPeD171+SzF4/zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.3.0.tgz",
+      "integrity": "sha512-N0rFCuH9YoxG9/m61l9MfpJKfmLOVU0em7ipIz6TRgSSkvReLB9vL85GB+yr8Bs5leqpvg96JSwF4ZS1s4viQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.3.0.tgz",
+      "integrity": "sha512-ZI7bU42mZXXKHn/qNLEw2IrbiINU7X5+vfgdixBHkCNpYWXjKgfQ/P+uyGb5CjOLB9UcnTeg3rylQtV2hym44Q==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.3.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+      "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+      "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.11.20",
+        "caniuse-lite": "^1.0.30001810",
+        "electron-to-chromium": "^1.5.420",
+        "node-releases": "^2.0.54",
+        "update-browserslist-db": "^1.3.2"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.425",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.425.tgz",
+      "integrity": "sha512-QvPtl41EUOnuT1HBvMKgxXRIaHNcagBPs50u7VULzhZXaGfqTbZyE16LQsctZ/RQHlGu+FOWeDTR4mY6YbeF1g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.55",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.55.tgz",
+      "integrity": "sha512-mIrE/Cw9y+9Au6dS5vDKDhQza9YvG6w+ZrS6X+ZzA7yFW/soAeaups4Qzn1bL6g5FVy8WtP79+0j82oPIbqRjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+      "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.18",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.3.0.tgz",
+      "integrity": "sha512-E8LUcbtBWt20bbl2YoHfx4ZDBdxVTfOKtCZn9cDSJ4l6/nuoApcpIBcj47t2wZoVX8g2ZHuMHbiShgCR1T5Sog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.3.0.tgz",
+      "integrity": "sha512-JDk8dgif51OjFoDE70+OT9ICyYr+69HlmihNwp1+Nsfbna3t5sIiCa9ZJktDmQ4/1b/rn26hIAR2uYXDMr5r0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.28.0"
+      },
+      "peerDependencies": {
+        "react": "^19.3.0"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.1.tgz",
+      "integrity": "sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.63.1",
+        "@rollup/rollup-android-arm64": "4.63.1",
+        "@rollup/rollup-darwin-arm64": "4.63.1",
+        "@rollup/rollup-darwin-x64": "4.63.1",
+        "@rollup/rollup-freebsd-arm64": "4.63.1",
+        "@rollup/rollup-freebsd-x64": "4.63.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.63.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.63.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.63.1",
+        "@rollup/rollup-linux-arm64-musl": "4.63.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.63.1",
+        "@rollup/rollup-linux-loong64-musl": "4.63.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.63.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.63.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.63.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.63.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-musl": "4.63.1",
+        "@rollup/rollup-openbsd-x64": "4.63.1",
+        "@rollup/rollup-openharmony-arm64": "4.63.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.63.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.63.1",
+        "@rollup/rollup-win32-x64-gnu": "4.63.1",
+        "@rollup/rollup-win32-x64-msvc": "4.63.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.28.0.tgz",
+      "integrity": "sha512-juorfCmIkIw8tT+p5BXSm6PJjQF/ycEYmKyzURCIt/RaZIhL+PulbQ9Yu2z1HdOJDdqDTlxA1+xKBmHXJsczAw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.6.tgz",
+      "integrity": "sha512-u8KszXvGfU68hVcZpRHKG28T0krMuv2G5nDhiHaMLen/gIuFEgIJhaJuO69qjnXg5paSrbPMFfx3brNuN8eVSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/packages/def-fields/package.json
+++ b/packages/def-fields/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@loomcycle/def-fields",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Shareable React field-registry + folded (accordion) editor for loomcycle substrate primitives — one declarative registry drives both a grouped form and a flat folded list, with per-parameter hints.",
+  "license": "Apache-2.0",
+  "author": "Dennis Gubsky",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/denn-gubsky/loomcycle.git",
+    "directory": "packages/def-fields"
+  },
+  "keywords": ["loomcycle", "substrate", "agentdef", "react", "editor", "form", "component"],
+  "sideEffects": ["**/*.css"],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./styles.css": "./dist/styles.css"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": ["dist"],
+  "publishConfig": { "access": "public" },
+  "scripts": {
+    "build": "npm run build:lib",
+    "build:lib": "vite build --config vite.config.lib.ts && tsc -p tsconfig.lib.json && cp src/styles.css dist/styles.css",
+    "prepack": "npm run build:lib",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests",
+    "test:watch": "vitest"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^5.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "typescript": "^5.6.0",
+    "vite": "^7.0.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/def-fields/src/FoldedFieldList.tsx
+++ b/packages/def-fields/src/FoldedFieldList.tsx
@@ -1,0 +1,186 @@
+import { useMemo, useState } from "react";
+import type { DefRegistry, DefValue, FieldSpec } from "./types";
+import { FieldRow } from "./components/FieldRow";
+import { clearField, countSet, fieldsInGroup, setField, visibleFields } from "./lib/value";
+
+// The folded list: every parameter of a substrate primitive, one row each,
+// folded under collapsible groups.
+//
+// It exists because a def has far more parameters than a form can show at once
+// without becoming a wall. Folding keeps the whole surface REACHABLE (nothing
+// hides behind a free-text JSON box) while keeping it SCANNABLE (a closed group
+// costs one line). The same registry also drives the grouped form, so the two
+// are two arrangements of one truth, not two implementations.
+
+export interface FoldedFieldListProps {
+  registry: DefRegistry;
+  value: DefValue;
+  onChange: (next: DefValue) => void;
+  disabled?: boolean;
+  /** Groups open on first render. Default: those with at least one value set,
+   *  so reopening a def lands on what it actually overrides. */
+  defaultOpenGroups?: readonly string[];
+  /** Hide the search + modified-only toolbar (e.g. a narrow canvas inspector). */
+  hideToolbar?: boolean;
+  /** Parameters the HOST already renders elsewhere (e.g. a shared identity row
+   *  carrying name + description). Omitted rather than removed from the
+   *  registry, so the registry stays the complete description of the primitive
+   *  and each host decides what it has already covered. */
+  omitKeys?: readonly string[];
+  /** Palette. Defaults to the dark tokens; a host that themes an ancestor with
+   *  data-theme="light" gets light without passing this. */
+  theme?: "dark" | "light";
+  /** Extra class on the component root, for host layout. */
+  className?: string;
+}
+
+export function FoldedFieldList({
+  registry, value, onChange, disabled, defaultOpenGroups, hideToolbar, omitKeys, theme, className,
+}: FoldedFieldListProps) {
+  const omitted = useMemo(() => new Set(omitKeys ?? []), [omitKeys]);
+  const [query, setQuery] = useState("");
+  const [modifiedOnly, setModifiedOnly] = useState(false);
+  const [showAdvanced, setShowAdvanced] = useState<Set<string>>(() => new Set());
+  const [open, setOpen] = useState<Set<string>>(() => {
+    if (defaultOpenGroups) return new Set(defaultOpenGroups);
+    // Default-open exactly the groups this def actually overrides: the first
+    // thing an operator wants on reopen is "what did I change here".
+    const seeded = registry.groups
+      .map((g) => g.name)
+      .filter((name) => countSet(value, fieldsInGroup(registry, name)) > 0);
+    return new Set(seeded);
+  });
+
+  const searching = query.trim() !== "" || modifiedOnly;
+
+  const groups = useMemo(
+    () =>
+      registry.groups.map((g) => {
+        const all = fieldsInGroup(registry, g.name).filter((f) => !omitted.has(f.key));
+        const shown = visibleFields(all, value, query, modifiedOnly);
+        // An `advanced` field folds away only while it is UNSET and no filter is
+        // active. A rarely-tuned knob that this def actually overrides is not
+        // rarely-tuned any more, and hiding it would make a set value invisible.
+        const deferred = (f: FieldSpec) =>
+          !!f.advanced && !searching && value[f.key] === undefined;
+        return {
+          spec: g,
+          all,
+          primary: shown.filter((f) => !deferred(f)),
+          advanced: shown.filter(deferred),
+          setCount: countSet(value, all),
+        };
+      }),
+    [registry, value, query, modifiedOnly, searching, omitted],
+  );
+
+  const toggle = (name: string) =>
+    setOpen((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name); else next.add(name);
+      return next;
+    });
+
+  const toggleAdvanced = (name: string) =>
+    setShowAdvanced((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name); else next.add(name);
+      return next;
+    });
+
+  const totalShown = groups.reduce((n, g) => n + g.primary.length + g.advanced.length, 0);
+
+  const rowFor = (f: FieldSpec) => (
+    <FieldRow
+      key={f.key}
+      spec={f}
+      value={value[f.key]}
+      disabled={disabled}
+      compact
+      onChange={(next) =>
+        onChange(next === undefined ? clearField(value, f.key) : setField(value, f.key, next))
+      }
+      onClear={() => onChange(clearField(value, f.key))}
+    />
+  );
+
+  return (
+    <div
+      className={`loomcycle-def-fields${className ? ` ${className}` : ""}`}
+      data-theme={theme}
+      data-kind={registry.kind}
+    >
+      {!hideToolbar && (
+        <div className="lc-df-toolbar">
+          <input
+            className="lc-df-input lc-df-search"
+            type="search"
+            value={query}
+            placeholder="Search parameters…"
+            disabled={disabled}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+          <label className="lc-df-toggle">
+            <input
+              type="checkbox"
+              checked={modifiedOnly}
+              disabled={disabled}
+              onChange={(e) => setModifiedOnly(e.target.checked)}
+            />
+            <span>modified only</span>
+          </label>
+        </div>
+      )}
+
+      {searching && totalShown === 0 && (
+        <p className="lc-df-empty">No parameter matches that filter.</p>
+      )}
+
+      {groups.map(({ spec, all, primary, advanced, setCount }) => {
+        if (primary.length + advanced.length === 0) return null;
+        // While filtering, force groups open — a match the operator cannot see
+        // reads as "no result", which is worse than no search at all.
+        const isOpen = searching || open.has(spec.name);
+        const advOpen = showAdvanced.has(spec.name);
+        const shownCount = primary.length + advanced.length;
+        return (
+          <section className="lc-df-group" key={spec.name}>
+            <button
+              type="button"
+              className="lc-df-group-head"
+              aria-expanded={isOpen}
+              onClick={() => toggle(spec.name)}
+            >
+              <span className="lc-df-caret" aria-hidden="true">{isOpen ? "▾" : "▸"}</span>
+              <span className="lc-df-group-name">{spec.name}</span>
+              <span className="lc-df-group-count">
+                ({searching ? `${shownCount}/${all.length}` : all.length})
+              </span>
+              {setCount > 0 && <span className="lc-df-group-set">{setCount} set</span>}
+            </button>
+
+            {isOpen && (
+              <div className="lc-df-group-body">
+                {spec.hint && <p className="lc-df-group-hint">{spec.hint}</p>}
+                {primary.map(rowFor)}
+                {advanced.length > 0 && (
+                  <>
+                    {advOpen && advanced.map(rowFor)}
+                    <button
+                      type="button"
+                      className="lc-df-more"
+                      aria-expanded={advOpen}
+                      onClick={() => toggleAdvanced(spec.name)}
+                    >
+                      {advOpen ? "− hide" : `+ ${advanced.length} more`} advanced
+                    </button>
+                  </>
+                )}
+              </div>
+            )}
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/def-fields/src/components/FieldControl.tsx
+++ b/packages/def-fields/src/components/FieldControl.tsx
@@ -1,0 +1,297 @@
+import { useState } from "react";
+import type { FieldSpec } from "../types";
+
+// One control per FieldType. Both surfaces (grouped form, folded list) render
+// through this switch, so a field looks and behaves identically wherever it is
+// shown and a new type only has to be implemented once.
+//
+// `value === undefined` means UNSET (inherit). Controls render their neutral
+// empty state for it and only call onChange with a concrete value once the
+// operator actually types — clearing back to inherit is the row's job, not the
+// control's, so a control never has to encode the sparse-overlay semantics.
+
+export interface FieldControlProps {
+  spec: FieldSpec;
+  value: unknown;
+  onChange: (next: unknown) => void;
+  disabled?: boolean;
+  /** Rendered for object / object-array children so nesting reuses the row
+   *  chrome (label + hint + inherit affordance) rather than re-implementing it. */
+  renderChild?: (child: FieldSpec, value: unknown, onChange: (v: unknown) => void) => React.ReactNode;
+}
+
+const asString = (v: unknown): string => (typeof v === "string" ? v : "");
+const asStringList = (v: unknown): string[] => (Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : []);
+const asRecord = (v: unknown): Record<string, string> =>
+  v && typeof v === "object" && !Array.isArray(v)
+    ? Object.fromEntries(Object.entries(v as Record<string, unknown>).map(([k, x]) => [k, typeof x === "string" ? x : String(x ?? "")]))
+    : {};
+const asObjectArray = (v: unknown): Record<string, unknown>[] =>
+  Array.isArray(v) ? v.filter((x): x is Record<string, unknown> => !!x && typeof x === "object" && !Array.isArray(x)) : [];
+
+export function FieldControl({ spec, value, onChange, disabled, renderChild }: FieldControlProps) {
+  switch (spec.type) {
+    case "textarea":
+      return (
+        <textarea
+          className="lc-df-input lc-df-textarea"
+          value={asString(value)}
+          placeholder={spec.placeholder}
+          disabled={disabled}
+          rows={4}
+          onChange={(e) => onChange(e.target.value)}
+        />
+      );
+
+    case "int":
+    case "float":
+      return (
+        <input
+          className="lc-df-input lc-df-int"
+          type="number"
+          step={spec.type === "float" ? "any" : 1}
+          inputMode={spec.type === "float" ? "decimal" : "numeric"}
+          value={typeof value === "number" ? String(value) : ""}
+          placeholder={spec.placeholder}
+          min={spec.min}
+          max={spec.max}
+          disabled={disabled}
+          onChange={(e) => {
+            const raw = e.target.value;
+            // An emptied number box means "unset" — emit undefined so the row
+            // deletes the key rather than persisting a bogus 0.
+            if (raw.trim() === "") return onChange(undefined);
+            const n = Number(raw);
+            onChange(Number.isFinite(n) ? n : undefined);
+          }}
+        />
+      );
+
+    case "bool":
+      return (
+        <label className="lc-df-bool">
+          <input
+            type="checkbox"
+            checked={value === true}
+            disabled={disabled}
+            onChange={(e) => onChange(e.target.checked)}
+          />
+          <span>{value === true ? "on" : "off"}</span>
+        </label>
+      );
+
+    case "enum":
+      return (
+        <select
+          className="lc-df-input"
+          value={asString(value)}
+          disabled={disabled}
+          onChange={(e) => onChange(e.target.value === "" ? undefined : e.target.value)}
+        >
+          <option value="">(inherit)</option>
+          {(spec.options ?? []).map((o) => (
+            <option key={o} value={o}>{o}</option>
+          ))}
+        </select>
+      );
+
+    case "string-list":
+      return <StringListControl value={asStringList(value)} disabled={disabled} placeholder={spec.placeholder} onChange={onChange} />;
+
+    case "kv":
+      return <KeyValueControl value={asRecord(value)} disabled={disabled} onChange={onChange} />;
+
+    case "object":
+      return (
+        <div className="lc-df-nested">
+          {(spec.fields ?? []).map((child) => {
+            const parent = (value && typeof value === "object" && !Array.isArray(value) ? value : {}) as Record<string, unknown>;
+            return renderChild?.(child, parent[child.key], (v) => {
+              const next = { ...parent };
+              if (v === undefined) delete next[child.key];
+              else next[child.key] = v;
+              onChange(Object.keys(next).length === 0 ? undefined : next);
+            });
+          })}
+        </div>
+      );
+
+    case "object-array":
+      return <ObjectArrayControl spec={spec} items={asObjectArray(value)} disabled={disabled} onChange={onChange} renderChild={renderChild} />;
+
+    case "json":
+      return <JsonControl value={value} disabled={disabled} placeholder={spec.placeholder} onChange={onChange} />;
+
+    case "text":
+    default:
+      return (
+        <input
+          className="lc-df-input"
+          type="text"
+          value={asString(value)}
+          placeholder={spec.placeholder}
+          disabled={disabled}
+          onChange={(e) => onChange(e.target.value)}
+        />
+      );
+  }
+}
+
+// StringListControl edits []string as removable chips plus an add box. Chips
+// beat a comma-joined text input because several of these lists hold values
+// that may themselves contain commas (tool patterns, stop sequences).
+function StringListControl({
+  value, onChange, disabled, placeholder,
+}: { value: string[]; onChange: (v: unknown) => void; disabled?: boolean; placeholder?: string }) {
+  const [draft, setDraft] = useState("");
+  const commit = () => {
+    const v = draft.trim();
+    if (v === "") return;
+    onChange([...value, v]);
+    setDraft("");
+  };
+  return (
+    <div className="lc-df-chips">
+      {value.map((item, i) => (
+        <span className="lc-df-chip" key={`${item}-${i}`}>
+          {item}
+          <button
+            type="button"
+            className="lc-df-chip-x"
+            disabled={disabled}
+            aria-label={`Remove ${item}`}
+            onClick={() => {
+              const next = value.filter((_, j) => j !== i);
+              onChange(next.length === 0 ? undefined : next);
+            }}
+          >×</button>
+        </span>
+      ))}
+      <input
+        className="lc-df-input lc-df-chip-add"
+        type="text"
+        value={draft}
+        placeholder={placeholder ?? "add…"}
+        disabled={disabled}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") { e.preventDefault(); commit(); }
+        }}
+      />
+    </div>
+  );
+}
+
+// KeyValueControl edits a string map (env, headers). Rows are keyed by index so
+// renaming a key doesn't remount and steal focus mid-edit.
+function KeyValueControl({
+  value, onChange, disabled,
+}: { value: Record<string, string>; onChange: (v: unknown) => void; disabled?: boolean }) {
+  const entries = Object.entries(value);
+  const emit = (next: [string, string][]) => {
+    const obj: Record<string, string> = {};
+    for (const [k, v] of next) if (k.trim() !== "") obj[k] = v;
+    onChange(Object.keys(obj).length === 0 ? undefined : obj);
+  };
+  return (
+    <div className="lc-df-kv">
+      {entries.map(([k, v], i) => (
+        <div className="lc-df-kv-row" key={i}>
+          <input
+            className="lc-df-input lc-df-kv-key" type="text" value={k} placeholder="key" disabled={disabled}
+            onChange={(e) => { const next = [...entries] as [string, string][]; next[i] = [e.target.value, v]; emit(next); }}
+          />
+          <input
+            className="lc-df-input lc-df-kv-val" type="text" value={v} placeholder="value" disabled={disabled}
+            onChange={(e) => { const next = [...entries] as [string, string][]; next[i] = [k, e.target.value]; emit(next); }}
+          />
+          <button
+            type="button" className="lc-df-row-btn" disabled={disabled} aria-label={`Remove ${k}`}
+            onClick={() => emit(entries.filter((_, j) => j !== i) as [string, string][])}
+          >×</button>
+        </div>
+      ))}
+      <button
+        type="button" className="lc-df-row-btn lc-df-add" disabled={disabled}
+        onClick={() => emit([...(entries as [string, string][]), ["", ""]])}
+      >+ add entry</button>
+    </div>
+  );
+}
+
+// ObjectArrayControl edits []object (core_blocks, exposed_agents…): each item is
+// a small card of the child fields.
+function ObjectArrayControl({
+  spec, items, onChange, disabled, renderChild,
+}: {
+  spec: FieldSpec; items: Record<string, unknown>[]; onChange: (v: unknown) => void; disabled?: boolean;
+  renderChild?: FieldControlProps["renderChild"];
+}) {
+  const emit = (next: Record<string, unknown>[]) => onChange(next.length === 0 ? undefined : next);
+  return (
+    <div className="lc-df-objarray">
+      {items.map((item, i) => (
+        <div className="lc-df-objarray-item" key={i}>
+          <div className="lc-df-objarray-head">
+            <span className="lc-df-objarray-idx">#{i + 1}</span>
+            <button
+              type="button" className="lc-df-row-btn" disabled={disabled} aria-label={`Remove item ${i + 1}`}
+              onClick={() => emit(items.filter((_, j) => j !== i))}
+            >×</button>
+          </div>
+          {(spec.fields ?? []).map((child) =>
+            renderChild?.(child, item[child.key], (v) => {
+              const nextItem = { ...item };
+              if (v === undefined) delete nextItem[child.key];
+              else nextItem[child.key] = v;
+              const next = [...items];
+              next[i] = nextItem;
+              emit(next);
+            }),
+          )}
+        </div>
+      ))}
+      <button
+        type="button" className="lc-df-row-btn lc-df-add" disabled={disabled}
+        onClick={() => emit([...items, {}])}
+      >+ add</button>
+    </div>
+  );
+}
+
+// JsonControl edits one free-form structured value. It keeps the raw text in
+// local state so a half-typed document is not destroyed by a reparse on every
+// keystroke, and only emits when the text actually parses — an invalid draft
+// shows an inline error and leaves the last good value in the overlay.
+function JsonControl({
+  value, onChange, disabled, placeholder,
+}: { value: unknown; onChange: (v: unknown) => void; disabled?: boolean; placeholder?: string }) {
+  const pretty = value === undefined ? "" : JSON.stringify(value, null, 2);
+  const [text, setText] = useState(pretty);
+  const [err, setErr] = useState<string | null>(null);
+  const [dirty, setDirty] = useState(false);
+  // Re-sync from props while the operator is not mid-edit (e.g. a def reload).
+  if (!dirty && text !== pretty) setText(pretty);
+  return (
+    <div className="lc-df-json">
+      <textarea
+        className={`lc-df-input lc-df-textarea${err ? " lc-df-invalid" : ""}`}
+        value={text}
+        rows={6}
+        spellCheck={false}
+        placeholder={placeholder ?? "{ }"}
+        disabled={disabled}
+        onChange={(e) => {
+          const raw = e.target.value;
+          setText(raw); setDirty(true);
+          if (raw.trim() === "") { setErr(null); onChange(undefined); return; }
+          try { onChange(JSON.parse(raw)); setErr(null); }
+          catch (ex) { setErr(ex instanceof Error ? ex.message : "invalid JSON"); }
+        }}
+        onBlur={() => setDirty(false)}
+      />
+      {err && <p className="lc-df-error">{err}</p>}
+    </div>
+  );
+}

--- a/packages/def-fields/src/components/FieldRow.tsx
+++ b/packages/def-fields/src/components/FieldRow.tsx
@@ -1,0 +1,78 @@
+import type { FieldSpec } from "../types";
+import { FieldControl } from "./FieldControl";
+
+// One parameter: label · control · hint · inherit-vs-set state.
+//
+// This row is the unit both surfaces share. The grouped form and the folded list
+// differ only in how rows are ARRANGED, never in how a parameter looks or what
+// it explains — which is what keeps the two surfaces from drifting into two
+// different mental models of the same def.
+
+export interface FieldRowProps {
+  spec: FieldSpec;
+  /** undefined = unset (inherited). */
+  value: unknown;
+  onChange: (next: unknown) => void;
+  /** Remove the key entirely, back to inherit. */
+  onClear: () => void;
+  disabled?: boolean;
+  /** Compact = the folded list's denser one-line-per-parameter rhythm. */
+  compact?: boolean;
+}
+
+export function FieldRow({ spec, value, onChange, onClear, disabled, compact }: FieldRowProps) {
+  const set = value !== undefined;
+  return (
+    <div className={`lc-df-row${compact ? " lc-df-row-compact" : ""}${set ? " lc-df-row-set" : ""}`}>
+      <div className="lc-df-row-head">
+        <label className="lc-df-label" title={spec.key}>
+          {spec.label}
+          <code className="lc-df-key">{spec.key}</code>
+        </label>
+        {set ? (
+          <button
+            type="button"
+            className="lc-df-reset"
+            disabled={disabled}
+            onClick={onClear}
+            // The affordance names what clearing RESTORES, because "unset" on a
+            // forked def does not mean "empty" — it means the parent's value
+            // flows through again.
+            title={spec.unsetMeans ? `Clear — ${spec.unsetMeans}` : "Clear (inherit)"}
+          >
+            clear
+          </button>
+        ) : (
+          <span className="lc-df-inherited" title={spec.unsetMeans ?? "Not set on this def"}>
+            inherited
+          </span>
+        )}
+      </div>
+
+      <div className="lc-df-control">
+        <FieldControl
+          spec={spec}
+          value={value}
+          onChange={onChange}
+          disabled={disabled}
+          renderChild={(child, childValue, childOnChange) => (
+            <FieldRow
+              key={child.key}
+              spec={child}
+              value={childValue}
+              onChange={childOnChange}
+              onClear={() => childOnChange(undefined)}
+              disabled={disabled}
+              compact={compact}
+            />
+          )}
+        />
+      </div>
+
+      {/* The hint is ALWAYS rendered, never a hover-only tooltip: these
+          parameters are the kind an operator meets once a year, and a tooltip
+          they must discover is a hint that does not exist. */}
+      <p className="lc-df-hint">{spec.hint}</p>
+    </div>
+  );
+}

--- a/packages/def-fields/src/index.ts
+++ b/packages/def-fields/src/index.ts
@@ -1,0 +1,46 @@
+// @loomcycle/def-fields — the shareable editor surface for loomcycle substrate
+// primitives.
+//
+// The package is deliberately PRESENTATIONAL: it has no client, no fetch, no
+// knowledge of how a def is persisted. It takes a registry (what the parameters
+// are), a sparse overlay value, and an onChange — so the loomcycle Web UI can
+// wire it to `AgentDef create/fork` while loomboard wires the same components to
+// a canvas node's own store, and neither inherits the other's data layer.
+//
+// Styles are NOT imported here: a consumer opts in with
+// `import "@loomcycle/def-fields/styles.css"`, which keeps a host that supplies
+// its own palette from having to fight ours.
+
+export { FoldedFieldList } from "./FoldedFieldList";
+export type { FoldedFieldListProps } from "./FoldedFieldList";
+
+export { FieldRow } from "./components/FieldRow";
+export type { FieldRowProps } from "./components/FieldRow";
+
+export { FieldControl } from "./components/FieldControl";
+export type { FieldControlProps } from "./components/FieldControl";
+
+export type {
+  DefRegistry,
+  DefValue,
+  FieldGroupSpec,
+  FieldSpec,
+  FieldType,
+} from "./types";
+
+// Overlay helpers. A host that builds its own arrangement of FieldRows still
+// needs the sparse-overlay semantics (absent = inherit, present-zero = a real
+// setting), and re-deriving them per host is exactly how that distinction gets
+// lost.
+export {
+  clearField,
+  countSet,
+  fieldsInGroup,
+  isSet,
+  matchesQuery,
+  setField,
+  visibleFields,
+} from "./lib/value";
+
+// Registries, one per substrate kind.
+export { agentDefRegistry, AGENTDEF_EXCLUDED } from "./registries/agentdef";

--- a/packages/def-fields/src/lib/value.test.ts
+++ b/packages/def-fields/src/lib/value.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import type { FieldSpec } from "../types";
+import {
+  clearField, countSet, isSet, matchesQuery, setField, visibleFields,
+} from "./value";
+
+const f = (key: string, over: Partial<FieldSpec> = {}): FieldSpec => ({
+  key, label: key, group: "G", type: "text", hint: `hint for ${key}`, ...over,
+});
+
+describe("isSet", () => {
+  // The whole sparse-overlay contract in one test: a key present with a FALSY
+  // value is a real setting, not an absent one. `value[key] ?? …` would promote
+  // an explicit `temperature: 0` to "inherit" and silently un-determinise a
+  // pinned agent.
+  it("treats an explicit zero, false and empty string as SET", () => {
+    expect(isSet({ max_tokens: 0 }, "max_tokens")).toBe(true);
+    expect(isSet({ internal: false }, "internal")).toBe(true);
+    expect(isSet({ model: "" }, "model")).toBe(true);
+  });
+
+  it("treats an absent key and an explicit undefined as UNSET", () => {
+    expect(isSet({}, "model")).toBe(false);
+    expect(isSet({ model: undefined }, "model")).toBe(false);
+  });
+});
+
+describe("setField / clearField", () => {
+  it("does not mutate the input overlay", () => {
+    const before = { model: "a" };
+    const after = setField(before, "tier", "middle");
+    expect(before).toEqual({ model: "a" });
+    expect(after).toEqual({ model: "a", tier: "middle" });
+  });
+
+  // Writing null would PERSIST a null into the def; only deleting the key lets
+  // the parent / operator value flow through the merge again.
+  it("clear DELETES the key rather than nulling it", () => {
+    const after = clearField({ model: "a", tier: "middle" }, "tier");
+    expect(Object.prototype.hasOwnProperty.call(after, "tier")).toBe(false);
+    expect(after).toEqual({ model: "a" });
+  });
+
+  it("clearing an already-unset key returns the same object", () => {
+    const before = { model: "a" };
+    expect(clearField(before, "tier")).toBe(before);
+  });
+
+  it("can set a falsy value and read it back as set", () => {
+    const after = setField({}, "unbounded_iterations", false);
+    expect(isSet(after, "unbounded_iterations")).toBe(true);
+  });
+});
+
+describe("countSet", () => {
+  it("counts only keys present in the overlay", () => {
+    const fields = [f("a"), f("b"), f("c")];
+    expect(countSet({ a: 1, c: 0 }, fields)).toBe(2);
+    expect(countSet({}, fields)).toBe(0);
+  });
+
+  it("ignores overlay keys the group does not own", () => {
+    expect(countSet({ z: 1 }, [f("a")])).toBe(0);
+  });
+});
+
+describe("matchesQuery", () => {
+  const spec = f("max_context_tokens", { label: "Context window", hint: "The INPUT window this agent uses." });
+
+  it("matches on key, label and hint, case-insensitively", () => {
+    expect(matchesQuery(spec, "context_tok")).toBe(true);
+    expect(matchesQuery(spec, "Window")).toBe(true);
+    expect(matchesQuery(spec, "input window")).toBe(true);
+  });
+
+  it("an empty or whitespace query matches everything", () => {
+    expect(matchesQuery(spec, "")).toBe(true);
+    expect(matchesQuery(spec, "   ")).toBe(true);
+  });
+
+  it("does not match unrelated text", () => {
+    expect(matchesQuery(spec, "temperature")).toBe(false);
+  });
+});
+
+describe("visibleFields", () => {
+  const fields = [f("model"), f("tier"), f("effort")];
+
+  it("applies search and modified-only together", () => {
+    expect(visibleFields(fields, { tier: "middle" }, "", true).map((x) => x.key)).toEqual(["tier"]);
+    expect(visibleFields(fields, { tier: "middle" }, "e", false).map((x) => x.key)).toEqual(["model", "tier", "effort"]);
+    expect(visibleFields(fields, { tier: "middle" }, "ti", true).map((x) => x.key)).toEqual(["tier"]);
+    expect(visibleFields(fields, { model: "x" }, "ti", true)).toEqual([]);
+  });
+
+  it("modified-only keeps a field whose value is falsy-but-set", () => {
+    expect(visibleFields(fields, { effort: "" }, "", true).map((x) => x.key)).toEqual(["effort"]);
+  });
+
+  it("preserves the given field order", () => {
+    expect(visibleFields(fields, {}, "", false).map((x) => x.key)).toEqual(["model", "tier", "effort"]);
+  });
+});

--- a/packages/def-fields/src/lib/value.ts
+++ b/packages/def-fields/src/lib/value.ts
@@ -1,0 +1,64 @@
+import type { DefRegistry, DefValue, FieldSpec } from "../types";
+
+// isSet reports whether the overlay carries an explicit value for this key.
+//
+// The unset-vs-zero distinction is load-bearing: the substrate stores several
+// knobs as POINTERS precisely so `0` / `false` / `""` are real, inheritable-over
+// settings distinct from "not configured". So presence is decided by key
+// presence, never by truthiness — `value[key] ?? fallback` would silently
+// promote an explicit 0 to "inherit".
+export function isSet(value: DefValue, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key) && value[key] !== undefined;
+}
+
+/** setField returns a new overlay with `key` explicitly set. */
+export function setField(value: DefValue, key: string, next: unknown): DefValue {
+  return { ...value, [key]: next };
+}
+
+/** clearField returns a new overlay with `key` removed — i.e. back to inherit.
+ *  Deleting (not writing null) is what the substrate reads as "unset", so the
+ *  parent/operator value survives the merge. */
+export function clearField(value: DefValue, key: string): DefValue {
+  if (!isSet(value, key)) return value;
+  const next = { ...value };
+  delete next[key];
+  return next;
+}
+
+/** countSet is the "(n)" badge on a folded group header. */
+export function countSet(value: DefValue, fields: readonly FieldSpec[]): number {
+  let n = 0;
+  for (const f of fields) if (isSet(value, f.key)) n++;
+  return n;
+}
+
+/** fieldsInGroup preserves registry order, which is the display order. */
+export function fieldsInGroup(reg: DefRegistry, group: string): FieldSpec[] {
+  return reg.fields.filter((f) => f.group === group);
+}
+
+// matchesQuery powers the list's search box. It matches the KEY, the label and
+// the hint, so an operator who remembers "the thing about burst budget" finds
+// the field without knowing its key.
+export function matchesQuery(f: FieldSpec, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (q === "") return true;
+  return (
+    f.key.toLowerCase().includes(q) ||
+    f.label.toLowerCase().includes(q) ||
+    f.hint.toLowerCase().includes(q)
+  );
+}
+
+/** visibleFields applies the search + modified-only filters together. */
+export function visibleFields(
+  fields: readonly FieldSpec[],
+  value: DefValue,
+  query: string,
+  modifiedOnly: boolean,
+): FieldSpec[] {
+  return fields.filter(
+    (f) => matchesQuery(f, query) && (!modifiedOnly || isSet(value, f.key)),
+  );
+}

--- a/packages/def-fields/src/registries/agentdef.test.ts
+++ b/packages/def-fields/src/registries/agentdef.test.ts
@@ -1,0 +1,155 @@
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import type { DefRegistry, FieldSpec } from "../types";
+import { AGENTDEF_EXCLUDED, agentDefRegistry } from "./agentdef";
+
+// The overlay keys `AgentDef create` / `fork` persists, i.e. the json tags of
+// builtin.mergedDef. Copied here so the assertions below read as a checkable
+// list; the "drift against the Go source" test at the bottom is what keeps the
+// copy honest while this package lives in the loomcycle repo.
+const AGENTDEF_OVERLAY_KEYS = [
+  "a2a_agent_def_scopes", "a2a_server_card_def_scopes", "agent_def_scopes",
+  "channels", "code_body", "compaction", "context", "core_blocks",
+  "description", "effort", "evaluation_scopes", "history_scope",
+  "inherit_core_blocks", "inject_tool_guide", "internal", "interruption",
+  "max_concurrent_children", "max_context_tokens", "max_iterations",
+  "max_tokens", "memory_backend", "memory_consolidation",
+  "memory_index_max_bytes", "memory_inject_max_tokens", "memory_protocol",
+  "memory_quota_bytes", "memory_roots", "memory_scopes", "model", "models",
+  "provider", "providers", "retry_attempts", "run_timeout_seconds", "sampling",
+  "schedule_def_scopes", "search_providers", "skills", "sql_quota_bytes",
+  "sql_scopes", "system_prompt", "system_prompt_base", "tier", "tools",
+  "unbounded_iterations", "volume_def_scopes", "volumes",
+] as const;
+
+const topLevelKeys = (reg: DefRegistry) => reg.fields.map((f) => f.key);
+
+const walk = (fields: readonly FieldSpec[], out: FieldSpec[] = []): FieldSpec[] => {
+  for (const f of fields) {
+    out.push(f);
+    if (f.fields) walk(f.fields, out);
+  }
+  return out;
+};
+
+describe("agentDefRegistry — coverage of the persisted overlay", () => {
+  it("declares each key at most once", () => {
+    const keys = topLevelKeys(agentDefRegistry);
+    expect(keys.length).toBe(new Set(keys).size);
+  });
+
+  // A field the editor renders but the substrate does not persist is worse than
+  // a missing one: the operator sets it, saves, and it silently vanishes.
+  it("renders nothing the overlay cannot store", () => {
+    const overlay = new Set<string>(AGENTDEF_OVERLAY_KEYS);
+    const strays = topLevelKeys(agentDefRegistry).filter((k) => !overlay.has(k));
+    expect(strays).toEqual([]);
+  });
+
+  // The complement: a key the overlay stores but no surface exposes is only
+  // reachable by hand-writing yaml — the gap that motivated the registry. An
+  // omission is allowed ONLY with a recorded reason.
+  it("exposes every overlay key, or names it in AGENTDEF_EXCLUDED with a reason", () => {
+    const covered = new Set(topLevelKeys(agentDefRegistry));
+    const missing = AGENTDEF_OVERLAY_KEYS.filter((k) => !covered.has(k));
+    expect(missing).toEqual(["system_prompt_base"]);
+    for (const k of missing) {
+      expect(AGENTDEF_EXCLUDED[k], `${k} must carry an exclusion reason`).toBeTruthy();
+    }
+  });
+
+  it("every exclusion reason is a real sentence, not a placeholder", () => {
+    for (const [key, reason] of Object.entries(AGENTDEF_EXCLUDED)) {
+      expect(reason.length, `${key}`).toBeGreaterThan(15);
+    }
+  });
+});
+
+describe("agentDefRegistry — shape invariants", () => {
+  const all = walk(agentDefRegistry.fields);
+  const groupNames = new Set(agentDefRegistry.groups.map((g) => g.name));
+
+  it("every top-level field folds under a declared group", () => {
+    for (const f of agentDefRegistry.fields) {
+      expect(groupNames.has(f.group), `${f.key} → ${f.group}`).toBe(true);
+    }
+  });
+
+  it("no group is declared empty", () => {
+    for (const g of agentDefRegistry.groups) {
+      const n = agentDefRegistry.fields.filter((f) => f.group === g.name).length;
+      expect(n, `group ${g.name}`).toBeGreaterThan(0);
+    }
+  });
+
+  // The hint is the deliverable, not decoration: an unexplained parameter in a
+  // list of forty-six is indistinguishable from noise.
+  it("every field and sub-field carries a hint", () => {
+    for (const f of all) {
+      expect(f.hint?.trim().length, `${f.key} hint`).toBeGreaterThan(10);
+      expect(f.label.trim(), `${f.key} label`).not.toBe("");
+    }
+  });
+
+  it("enum fields offer options; non-enum fields do not", () => {
+    for (const f of all) {
+      if (f.type === "enum") expect(f.options?.length, `${f.key}`).toBeGreaterThan(1);
+      else expect(f.options, `${f.key}`).toBeUndefined();
+    }
+  });
+
+  it("object and object-array fields declare children; leaf types do not", () => {
+    for (const f of all) {
+      if (f.type === "object" || f.type === "object-array") {
+        expect(f.fields?.length, `${f.key}`).toBeGreaterThan(0);
+      } else {
+        expect(f.fields, `${f.key}`).toBeUndefined();
+      }
+    }
+  });
+
+  it("numeric bounds are ordered and only on numeric fields", () => {
+    for (const f of all) {
+      if (f.min !== undefined && f.max !== undefined) expect(f.min, `${f.key}`).toBeLessThan(f.max);
+      if (f.min !== undefined || f.max !== undefined) {
+        expect(["int", "float"], `${f.key}`).toContain(f.type);
+      }
+    }
+  });
+
+  it("children of a nested field inherit the parent's group, so the fold is coherent", () => {
+    for (const parent of agentDefRegistry.fields) {
+      for (const child of parent.fields ?? []) {
+        expect(child.group, `${parent.key}.${child.key}`).toBe(parent.group);
+      }
+    }
+  });
+});
+
+// Drift guard. While this package sits in the loomcycle repo, the fixture above
+// is checked against the Go struct that actually defines the overlay, so adding
+// a parameter to the substrate without exposing it here fails HERE rather than
+// shipping an unreachable knob. A published/extracted copy has no Go source, so
+// the check reports itself skipped instead of failing.
+describe("AGENTDEF_OVERLAY_KEYS matches builtin.mergedDef", () => {
+  const goFile = fileURLToPath(
+    new URL("../../../../internal/tools/builtin/agentdef.go", import.meta.url),
+  );
+
+  it("has the same json tags as the Go struct", () => {
+    if (!existsSync(goFile)) {
+      // Standalone checkout: nothing to compare against.
+      expect(AGENTDEF_OVERLAY_KEYS.length).toBeGreaterThan(0);
+      return;
+    }
+    const src = readFileSync(goFile, "utf8");
+    const start = src.indexOf("type mergedDef struct {");
+    expect(start, "mergedDef struct not found — did it move or get renamed?").toBeGreaterThan(-1);
+    const end = src.indexOf("\n}", start);
+    const block = src.slice(start, end);
+    const goKeys = [...block.matchAll(/json:"([a-z0-9_]+)/g)].map((m) => m[1]).sort();
+
+    expect(goKeys).toEqual([...AGENTDEF_OVERLAY_KEYS].sort());
+  });
+});

--- a/packages/def-fields/src/registries/agentdef.ts
+++ b/packages/def-fields/src/registries/agentdef.ts
@@ -1,0 +1,232 @@
+import type { DefRegistry, FieldSpec } from "../types";
+
+// The AgentDef parameter registry — the full operator-settable surface of an
+// agent definition, grouped for the folded list and annotated with a hint per
+// parameter.
+//
+// Hints are written for an operator meeting the knob for the first time: what it
+// controls and what happens if it is left alone. They deliberately do not cite
+// internal RFC letters, which mean nothing at the console.
+
+// Parameters deliberately NOT in the registry, and why. The drift test asserts
+// registry ∪ EXCLUDED == the substrate's overlay shape, so an omission has to be
+// justified here rather than silently forgotten.
+export const AGENTDEF_EXCLUDED: Record<string, string> = {
+  system_prompt_base:
+    "derived — the pre-skill-bake snapshot of system_prompt, written by the server, never operator input",
+  system_prompt_file:
+    "load-time only — reads a file off the operator's disk at config load, so a runtime def cannot honour it",
+  // These two are operator-settable in yaml but do NOT round-trip the substrate
+  // overlay yet (absent from both the write shape and the read adapter), so a
+  // control here would silently drop on save. Removed from this list by the
+  // backend round-trip fix.
+  disable_context: "pending backend round-trip support",
+  skill_def_scopes: "pending backend round-trip support",
+};
+
+const scopeList = (label: string, key: string, hint: string): FieldSpec => ({
+  key, label, group: "Capabilities", type: "string-list", hint,
+  placeholder: "scope…", unsetMeans: "no grant — the capability is denied",
+});
+
+export const agentDefRegistry: DefRegistry = {
+  kind: "agentdef",
+  groups: [
+    { name: "Identity & prompt" },
+    { name: "Routing", hint: "How this agent resolves to a concrete provider and model." },
+    { name: "Tools & access" },
+    { name: "Limits", hint: "Budgets and caps. Unset means the operator/global default applies." },
+    { name: "Sampling", hint: "Decoding parameters. Each driver applies what it supports." },
+    { name: "Context & compaction", hint: "How the run's history is retained, distilled and recalled." },
+    { name: "Memory" },
+    { name: "Capabilities", hint: "Capability gates. An empty grant denies the capability entirely." },
+    { name: "Behaviour" },
+  ],
+  fields: [
+    // ---- Identity & prompt ----
+    { key: "description", label: "Description", group: "Identity & prompt", type: "text",
+      hint: "Human-facing summary of what this agent is for. Shown in the Library.",
+      unsetMeans: "inherits the parent def" },
+    { key: "system_prompt", label: "System prompt", group: "Identity & prompt", type: "textarea",
+      hint: "The agent's instructions, as inline text. Skill bodies are appended to it at prompt assembly.",
+      unsetMeans: "inherits the parent def / operator yaml" },
+    { key: "code_body", label: "Code (code-js)", group: "Identity & prompt", type: "textarea",
+      hint: "Inline code-js orchestrator source. Only for code-js agents; leave empty for an LLM agent.",
+      unsetMeans: "not a code-js agent", advanced: true },
+
+    // ---- Routing ----
+    { key: "provider", label: "Provider", group: "Routing", type: "text",
+      hint: "Pin this agent to one provider instead of letting the tier resolve it.",
+      placeholder: "anthropic", unsetMeans: "resolved from the tier" },
+    { key: "model", label: "Model", group: "Routing", type: "text",
+      hint: "Pin a model id or a configured alias. Prefer an alias so operator overrides still apply.",
+      placeholder: "claude-sonnet-5", unsetMeans: "resolved from the tier" },
+    { key: "tier", label: "Tier", group: "Routing", type: "text",
+      hint: "Which model tier the resolver picks from when no explicit provider+model pin is set.",
+      placeholder: "middle", unsetMeans: "the default tier" },
+    { key: "effort", label: "Reasoning effort", group: "Routing", type: "enum", options: ["low", "medium", "high"],
+      hint: "Reasoning-effort hint passed to models that support it. Errors on a model that does not.",
+      unsetMeans: "no hint sent" },
+    { key: "providers", label: "Provider priority", group: "Routing", type: "string-list",
+      hint: "Per-agent override of the provider fallback order used for tier resolution.",
+      unsetMeans: "the library-wide priority", advanced: true },
+    { key: "models", label: "Tier candidates", group: "Routing", type: "json",
+      hint: "Per-agent override of the tier→candidates map. Replaces the library tiers wholesale, not per key.",
+      unsetMeans: "the library tiers", advanced: true },
+    { key: "search_providers", label: "Search providers", group: "Routing", type: "string-list",
+      hint: "Ordered web-search backends the WebSearch tool tries before giving up.",
+      unsetMeans: "the operator default order", advanced: true },
+
+    // ---- Tools & access ----
+    { key: "tools", label: "Tools", group: "Tools & access", type: "string-list",
+      hint: "Which tools this agent may call. An EMPTY list grants no tools at all; patterns like mcp__server__* are allowed.",
+      placeholder: "Read", unsetMeans: "inherits the parent def" },
+    { key: "skills", label: "Skills", group: "Tools & access", type: "string-list",
+      hint: "Skill names whose bodies are concatenated onto the system prompt. Use -* to drop the auto-added Skill tool.",
+      unsetMeans: "inherits the parent def" },
+    { key: "volumes", label: "Volumes", group: "Tools & access", type: "string-list",
+      hint: "Filesystem volumes this agent's file and exec tools may reach. With none bound, it has no filesystem access.",
+      unsetMeans: "no filesystem access" },
+
+    // ---- Limits ----
+    { key: "max_tokens", label: "Max output tokens", group: "Limits", type: "int", min: 1,
+      hint: "Caps the assistant output of a single iteration. Distinct from the context window.",
+      unsetMeans: "the driver default" },
+    { key: "max_context_tokens", label: "Context window", group: "Limits", type: "int", min: 1,
+      hint: "The INPUT window this agent uses. On local models it sets num_ctx; on cloud models it caps the effective window.",
+      unsetMeans: "the provider default" },
+    { key: "max_iterations", label: "Max iterations", group: "Limits", type: "int", min: 1,
+      hint: "How many provider calls the loop may make before stopping with max_iterations.",
+      unsetMeans: "the loop default (16)" },
+    { key: "unbounded_iterations", label: "Unbounded iterations", group: "Limits", type: "bool",
+      hint: "Lifts the iteration soft-cap for a long-running agent. A hard runaway guard still applies.",
+      unsetMeans: "off", advanced: true },
+    { key: "max_concurrent_children", label: "Max concurrent children", group: "Limits", type: "int", min: 1,
+      hint: "How many sub-agents this agent may run in parallel from one fan-out call.",
+      unsetMeans: "the global default" },
+    { key: "run_timeout_seconds", label: "Run timeout (s)", group: "Limits", type: "int", min: 1,
+      hint: "Wall-clock budget for one code-js run, overriding the global timeout.",
+      unsetMeans: "the global timeout", advanced: true },
+    { key: "retry_attempts", label: "Retry attempts", group: "Limits", type: "int", min: 0,
+      hint: "Same-provider retry budget for this agent, overriding the user tier's.",
+      unsetMeans: "the user tier's budget", advanced: true },
+
+    // ---- Sampling ----
+    { key: "sampling", label: "Sampling", group: "Sampling", type: "object",
+      hint: "Decoding parameters. A value of 0 is a real setting and differs from leaving it unset.",
+      unsetMeans: "provider defaults",
+      fields: [
+        { key: "temperature", label: "Temperature", group: "Sampling", type: "float", min: 0, max: 2, hint: "Randomness. 0 is deterministic; unset lets the provider decide." },
+        { key: "top_p", label: "Top-p", group: "Sampling", type: "float", min: 0, max: 1, hint: "Nucleus sampling mass." },
+        { key: "top_k", label: "Top-k", group: "Sampling", type: "int", hint: "Sample only from the k most likely tokens." },
+        { key: "frequency_penalty", label: "Frequency penalty", group: "Sampling", type: "float", min: -2, max: 2, hint: "Discourages repeating the same tokens." },
+        { key: "presence_penalty", label: "Presence penalty", group: "Sampling", type: "float", min: -2, max: 2, hint: "Discourages reusing tokens already present." },
+        { key: "seed", label: "Seed", group: "Sampling", type: "int", hint: "Fixed seed for reproducible sampling, where the provider supports it." },
+        { key: "stop", label: "Stop sequences", group: "Sampling", type: "string-list", hint: "Generation halts when one of these strings is produced." },
+      ] },
+
+    // ---- Context & compaction ----
+    { key: "context", label: "Context retention", group: "Context & compaction", type: "object",
+      hint: "How the fed history is retained: append, a running recap, or a structured state.",
+      unsetMeans: "append (full history)",
+      fields: [
+        { key: "mode", label: "Mode", group: "Context & compaction", type: "enum", options: ["append", "recap", "stateful", "auto"], hint: "append keeps everything; recap distils older turns; stateful feeds only a state object; auto picks by provider." },
+        { key: "keep_last_n", label: "Keep last N", group: "Context & compaction", type: "int", min: 0, hint: "How many recent turns stay verbatim when distilling." },
+        { key: "reasoning", label: "Reasoning policy", group: "Context & compaction", type: "enum", options: ["recap", "drop", "keep"], hint: "What happens to evicted reasoning: fold into a recap, drop it, or keep it." },
+        { key: "recap_max_chars", label: "Recap max chars", group: "Context & compaction", type: "int", min: 0, hint: "Upper bound on the running recap note." },
+        { key: "autorecap_at_pct", label: "Auto-recap at %", group: "Context & compaction", type: "int", min: 50, max: 95, hint: "Distil once the context footprint crosses this share of the window." },
+        { key: "recall", label: "Recall", group: "Context & compaction", type: "bool", hint: "Index every evicted span so the agent can fetch a dropped detail back by a free-text Recall. Grants the Recall tool automatically." },
+        { key: "harvest_to_memory", label: "Harvest to memory", group: "Context & compaction", type: "bool", hint: "Bank each evicted span for the consolidator, so facts learned mid-run survive into later runs. Needs `user` in memory scopes." },
+        { key: "state_schema", label: "State schema", group: "Context & compaction", type: "json", hint: "JSON Schema each state patch is validated against in stateful mode. Optional." },
+        { key: "on_invalid_patch", label: "On invalid patch", group: "Context & compaction", type: "enum", options: ["retry", "fail"], hint: "Whether a schema-invalid state patch is retried or ends the run." },
+        { key: "max_patch_retries", label: "Max patch retries", group: "Context & compaction", type: "int", min: 0, hint: "How many times an invalid state patch is re-prompted." },
+      ] },
+    { key: "compaction", label: "Compaction", group: "Context & compaction", type: "object",
+      hint: "Summarise older turns once the context fills. Mutually exclusive with recap mode.",
+      unsetMeans: "no auto-compaction",
+      fields: [
+        { key: "enabled", label: "Enabled", group: "Context & compaction", type: "bool", hint: "Turn auto-compaction on for this agent." },
+        { key: "target_percentage", label: "Target %", group: "Context & compaction", type: "int", min: 10, max: 50, hint: "How much of the window the summary should occupy." },
+        { key: "keep_last_n", label: "Keep last N", group: "Context & compaction", type: "int", min: 0, hint: "Recent turns kept verbatim behind the summary." },
+        { key: "keep_first", label: "Keep first turn", group: "Context & compaction", type: "bool", hint: "Pin the opening task turn so the goal is never summarised away." },
+        { key: "autocompact_at_pct", label: "Auto-compact at %", group: "Context & compaction", type: "int", min: 50, max: 95, hint: "Compact once the footprint crosses this share of the window." },
+        { key: "model", label: "Summary model", group: "Context & compaction", type: "text", hint: "A cheaper same-provider model to write the summary." },
+        { key: "memory_flush", label: "Memory flush", group: "Context & compaction", type: "bool", hint: "Bank the discarded span for the consolidator instead of dropping it." },
+      ] },
+
+    // ---- Memory ----
+    { key: "memory_scopes", label: "Memory scopes", group: "Memory", type: "string-list",
+      hint: "Which memory scopes the agent may read and write. With none, the Memory tool refuses every op.",
+      placeholder: "user", unsetMeans: "no memory access" },
+    { key: "memory_quota_bytes", label: "Memory quota (bytes)", group: "Memory", type: "int", min: 0,
+      hint: "Per-scope byte cap for this agent. 0 means unlimited.", unsetMeans: "the global cap" },
+    { key: "memory_backend", label: "Memory backend", group: "Memory", type: "text",
+      hint: "Route this agent's memory ops through a named backend instead of the default.",
+      unsetMeans: "the default in-process backend", advanced: true },
+    { key: "sql_scopes", label: "SQL scopes", group: "Memory", type: "string-list",
+      hint: "Which per-scope SQL databases the agent may query. Empty denies all SQL.",
+      unsetMeans: "no SQL access", advanced: true },
+    { key: "sql_quota_bytes", label: "SQL quota (bytes)", group: "Memory", type: "int", min: 0,
+      hint: "Per-scope SQL database byte cap for this agent.", unsetMeans: "the global cap", advanced: true },
+    { key: "core_blocks", label: "Core blocks", group: "Memory", type: "object-array",
+      hint: "Always-resident memory blocks rendered into the system prompt as reference data.",
+      unsetMeans: "none attached",
+      fields: [
+        { key: "label", label: "Label", group: "Memory", type: "text", hint: "Names the block; the backing memory key is core/<label>." },
+        { key: "scope", label: "Scope", group: "Memory", type: "enum", options: ["agent", "user", "tenant"], hint: "Where the block's value lives." },
+        { key: "limit_bytes", label: "Limit (bytes)", group: "Memory", type: "int", min: 0, hint: "Caps an agent write to this block. 0 means no per-block cap." },
+        { key: "read_only", label: "Read only", group: "Memory", type: "bool", hint: "The agent may read the block but never rewrite it." },
+      ] },
+    { key: "inherit_core_blocks", label: "Inherit core blocks", group: "Memory", type: "bool",
+      hint: "Let a sub-agent also receive the parent run's user/tenant blocks. Agent-scope blocks never cross a spawn.",
+      unsetMeans: "off", advanced: true },
+    { key: "memory_inject_max_tokens", label: "Memory inject cap", group: "Memory", type: "int", min: 0,
+      hint: "Caps how much injected memory content may enter the system prompt.",
+      unsetMeans: "the global cap", advanced: true },
+    { key: "memory_protocol", label: "Memory protocol", group: "Memory", type: "bool",
+      hint: "Adds the memory-usage protocol note telling the agent how to keep its own memory.",
+      unsetMeans: "off", advanced: true },
+    { key: "memory_consolidation", label: "Consolidation ops", group: "Memory", type: "bool",
+      hint: "Grants the consolidation control ops (queue drain, cursors, supersede). For maintenance agents.",
+      unsetMeans: "denied", advanced: true },
+    { key: "memory_index_max_bytes", label: "Memory index cap", group: "Memory", type: "int", min: 0,
+      hint: "Soft size the agent is asked to keep its own memory index document under.",
+      unsetMeans: "the global default", advanced: true },
+    { key: "memory_roots", label: "Memory roots", group: "Memory", type: "text",
+      hint: "Controls provisioning of the operator-authored user-root document composed into the prompt.",
+      unsetMeans: "the global default", advanced: true },
+
+    // ---- Capabilities ----
+    scopeList("Agent defs", "agent_def_scopes", "Lets the agent author or fork other agent definitions."),
+    scopeList("Schedule defs", "schedule_def_scopes", "Lets the agent create or change scheduled runs."),
+    scopeList("A2A server cards", "a2a_server_card_def_scopes", "Lets the agent publish agent-to-agent server cards."),
+    scopeList("A2A agents", "a2a_agent_def_scopes", "Lets the agent register agent-to-agent peers."),
+    scopeList("Volume defs", "volume_def_scopes", "Lets the agent define filesystem volumes."),
+    scopeList("Evaluation", "evaluation_scopes", "Lets the agent submit evaluation scores against runs."),
+    { key: "history_scope", label: "History", group: "Capabilities", type: "string-list",
+      hint: "Which past chats the agent may browse, search and annotate. Empty denies the History tool.",
+      unsetMeans: "denied" },
+    { key: "channels", label: "Channels", group: "Capabilities", type: "object",
+      hint: "Which channels the agent may post to and read from.", unsetMeans: "no channel access",
+      fields: [
+        { key: "publish", label: "Publish to", group: "Capabilities", type: "string-list", hint: "Channels the agent may post messages to." },
+        { key: "subscribe", label: "Subscribe to", group: "Capabilities", type: "string-list", hint: "Channels the agent may read from." },
+      ] },
+    { key: "interruption", label: "Interruption", group: "Capabilities", type: "object",
+      hint: "Whether the agent may raise interruptions that pause it for a human answer.",
+      unsetMeans: "cannot interrupt",
+      fields: [
+        { key: "enabled", label: "Enabled", group: "Capabilities", type: "bool", hint: "Allow this agent to raise interruptions." },
+        { key: "kinds", label: "Kinds", group: "Capabilities", type: "string-list", hint: "Which interruption kinds it may raise." },
+        { key: "max_pending", label: "Max pending", group: "Capabilities", type: "int", min: 0, hint: "How many of its interruptions may await an answer at once." },
+      ] },
+
+    // ---- Behaviour ----
+    { key: "internal", label: "Internal", group: "Behaviour", type: "bool",
+      hint: "Marks the agent as maintenance plumbing: its sessions are kept out of the surfaces people browse.",
+      unsetMeans: "a normal, human-facing agent" },
+    { key: "inject_tool_guide", label: "Inject tool guide", group: "Behaviour", type: "bool",
+      hint: "Appends runtime tool guidance to the prompt. Small local models may copy the framing, so prefer it on capable models.",
+      unsetMeans: "off", advanced: true },
+  ],
+};

--- a/packages/def-fields/src/registries/agentdef.ts
+++ b/packages/def-fields/src/registries/agentdef.ts
@@ -16,12 +16,13 @@ export const AGENTDEF_EXCLUDED: Record<string, string> = {
     "derived — the pre-skill-bake snapshot of system_prompt, written by the server, never operator input",
   system_prompt_file:
     "load-time only — reads a file off the operator's disk at config load, so a runtime def cannot honour it",
-  // These two are operator-settable in yaml but do NOT round-trip the substrate
-  // overlay yet (absent from both the write shape and the read adapter), so a
-  // control here would silently drop on save. Removed from this list by the
-  // backend round-trip fix.
-  disable_context: "pending backend round-trip support",
-  skill_def_scopes: "pending backend round-trip support",
+  // The next two are settable in operator yaml but are PERMANENTLY outside the
+  // overlay, not pending work. internal/lookup/agent.go names both carve-outs
+  // and a round-trip test pins them.
+  disable_context:
+    "load-time only — it suppresses the default-add of the Context tool during config load, baking into Tools before anything resolves; a runtime def has no auto-add to opt out of, so a control here would do nothing",
+  skill_def_scopes:
+    "removed-field tombstone (RFC BA) — skill authoring is governed by the skills: pattern allowlist, and the yaml key survives only so config load can reject a stale one with a migration error",
 };
 
 const scopeList = (label: string, key: string, hint: string): FieldSpec => ({

--- a/packages/def-fields/src/styles.css
+++ b/packages/def-fields/src/styles.css
@@ -1,0 +1,390 @@
+/* @loomcycle/def-fields styles. Everything is scoped under the component's
+   `.loomcycle-def-fields` root so it can't leak into — or be clobbered by — the
+   host app. The palette lives on the root as CSS variables; light mode activates
+   when the root (via the `theme` prop) OR any ancestor carries
+   data-theme="light", so an app that themes <html> gets themed fields for free.
+   Override any --var on `.loomcycle-def-fields` to restyle.
+
+   Same posture as @loomcycle/memory-view: the class names here are the
+   package's own (`lc-df-*`), not the Web UI's globals, so a host that embeds
+   <FoldedFieldList> MUST `import "@loomcycle/def-fields/styles.css"`.
+
+   Token names mirror the loomcycle Web UI aliases (--bg/--fg/--accent/… plus
+   --lc-text-*/--lc-font-mono) and are defined here for both themes, so the
+   package is self-contained — no external tokens.css. */
+
+.loomcycle-def-fields {
+  /* dark palette (default) */
+  --bg: #0f1115;
+  --bg-soft: #161922;
+  --bg-soft-2: #1d2230;
+  --bg-input: #0f1115;
+
+  --fg: #e6e6e6;
+  --fg-soft: #9aa0ad;
+  --fg-muted: #888888;
+
+  --border: #2a2e3a;
+  --accent: #56c596;
+  --err: #ff5d68;
+
+  --lc-font-mono: "JetBrains Mono Variable", "JetBrains Mono", ui-monospace,
+    "SF Mono", Menlo, Consolas, monospace;
+  --mono: var(--lc-font-mono);
+  --font-sans: "Inter Variable", "Inter", system-ui, -apple-system, "Segoe UI",
+    Roboto, sans-serif;
+
+  --lc-text-xs: 12px;
+  --lc-text-sm: 13px;
+  --lc-text-base: 14px;
+
+  color: var(--fg);
+  font-family: var(--font-sans);
+  font-size: var(--lc-text-base);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  color-scheme: dark;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
+/* Light mode: the root opts in via the `theme` prop, or inherits a light
+   ancestor (e.g. an app that sets data-theme on <html>). */
+.loomcycle-def-fields[data-theme="light"],
+[data-theme="light"] .loomcycle-def-fields {
+  --bg: #f5f6f8;
+  --bg-soft: #ffffff;
+  --bg-soft-2: #eef0f4;
+  --bg-input: #ffffff;
+
+  --fg: #1c1e22;
+  --fg-soft: #5b6272;
+  --fg-muted: #7c828f;
+
+  --border: #d8dce4;
+  --accent: #1f8a5f;
+  --err: #c62828;
+
+  color-scheme: light;
+}
+
+/* ---------- toolbar ---------- */
+
+.loomcycle-def-fields .lc-df-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.loomcycle-def-fields .lc-df-search {
+  flex: 1 1 200px;
+  min-width: 0;
+}
+
+.loomcycle-def-fields .lc-df-toggle,
+.loomcycle-def-fields .lc-df-bool {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--lc-text-sm);
+  color: var(--fg-soft);
+  cursor: pointer;
+  user-select: none;
+}
+
+.loomcycle-def-fields .lc-df-toggle input,
+.loomcycle-def-fields .lc-df-bool input {
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+.loomcycle-def-fields .lc-df-empty {
+  margin: 4px 0;
+  font-size: var(--lc-text-sm);
+  color: var(--fg-muted);
+}
+
+/* ---------- groups ---------- */
+
+.loomcycle-def-fields .lc-df-group {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-soft);
+  overflow: hidden;
+}
+
+.loomcycle-def-fields .lc-df-group-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 10px;
+  border: 0;
+  background: var(--bg-soft-2);
+  color: var(--fg);
+  font: inherit;
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+}
+
+.loomcycle-def-fields .lc-df-group-head:hover { background: var(--border); }
+
+.loomcycle-def-fields .lc-df-caret {
+  width: 12px;
+  color: var(--fg-soft);
+  flex: 0 0 auto;
+}
+
+.loomcycle-def-fields .lc-df-group-name { flex: 1 1 auto; min-width: 0; }
+
+.loomcycle-def-fields .lc-df-group-count {
+  font-weight: 400;
+  font-size: var(--lc-text-xs);
+  color: var(--fg-muted);
+}
+
+/* The "n set" badge is the whole point of a folded surface: it says which
+   closed groups this def actually overrides, so nothing hides. */
+.loomcycle-def-fields .lc-df-group-set {
+  flex: 0 0 auto;
+  padding: 1px 6px;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  color: var(--accent);
+  font-size: var(--lc-text-xs);
+  font-weight: 600;
+}
+
+.loomcycle-def-fields .lc-df-group-body {
+  display: flex;
+  flex-direction: column;
+  padding: 4px 10px 10px;
+}
+
+.loomcycle-def-fields .lc-df-group-hint {
+  margin: 6px 0 2px;
+  font-size: var(--lc-text-xs);
+  color: var(--fg-soft);
+}
+
+.loomcycle-def-fields .lc-df-more {
+  align-self: flex-start;
+  margin-top: 6px;
+  padding: 2px 8px;
+  border: 1px dashed var(--border);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--fg-soft);
+  font: inherit;
+  font-size: var(--lc-text-xs);
+  cursor: pointer;
+}
+
+.loomcycle-def-fields .lc-df-more:hover { color: var(--fg); border-color: var(--fg-muted); }
+
+/* ---------- rows ---------- */
+
+.loomcycle-def-fields .lc-df-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px 0;
+  border-top: 1px solid var(--border);
+  min-width: 0;
+}
+
+.loomcycle-def-fields .lc-df-group-body > .lc-df-row:first-of-type { border-top: 0; }
+
+/* A row carrying an explicit value is marked on the left edge, so scanning a
+   long group answers "what does this def override" without reading values. */
+.loomcycle-def-fields .lc-df-row-set {
+  box-shadow: inset 2px 0 0 var(--accent);
+  padding-left: 8px;
+}
+
+.loomcycle-def-fields .lc-df-row-head {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.loomcycle-def-fields .lc-df-label {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: var(--lc-text-sm);
+  font-weight: 600;
+}
+
+/* The overlay key is shown next to every label on purpose: it's what the yaml,
+   the API and the docs call this parameter, and an operator who read a doc must
+   be able to find the control by that name. */
+.loomcycle-def-fields .lc-df-key {
+  font-family: var(--mono);
+  font-size: var(--lc-text-xs);
+  font-weight: 400;
+  color: var(--fg-muted);
+  overflow-wrap: anywhere;
+}
+
+.loomcycle-def-fields .lc-df-reset,
+.loomcycle-def-fields .lc-df-row-btn {
+  flex: 0 0 auto;
+  padding: 1px 7px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--fg-soft);
+  font: inherit;
+  font-size: var(--lc-text-xs);
+  cursor: pointer;
+}
+
+.loomcycle-def-fields .lc-df-reset:hover,
+.loomcycle-def-fields .lc-df-row-btn:hover { color: var(--fg); border-color: var(--fg-muted); }
+
+.loomcycle-def-fields .lc-df-reset:disabled,
+.loomcycle-def-fields .lc-df-row-btn:disabled { opacity: 0.5; cursor: default; }
+
+.loomcycle-def-fields .lc-df-inherited {
+  flex: 0 0 auto;
+  font-size: var(--lc-text-xs);
+  color: var(--fg-muted);
+  font-style: italic;
+}
+
+.loomcycle-def-fields .lc-df-hint {
+  margin: 0;
+  font-size: var(--lc-text-xs);
+  color: var(--fg-soft);
+}
+
+.loomcycle-def-fields .lc-df-control { min-width: 0; }
+
+/* ---------- controls ---------- */
+
+.loomcycle-def-fields .lc-df-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 5px 7px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg-input);
+  color: var(--fg);
+  font: inherit;
+  font-size: var(--lc-text-sm);
+}
+
+.loomcycle-def-fields .lc-df-input:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.loomcycle-def-fields .lc-df-input:disabled { opacity: 0.6; }
+
+.loomcycle-def-fields .lc-df-int { max-width: 160px; }
+
+.loomcycle-def-fields .lc-df-textarea {
+  font-family: var(--mono);
+  resize: vertical;
+  min-height: 60px;
+}
+
+.loomcycle-def-fields .lc-df-invalid { border-color: var(--err); }
+
+.loomcycle-def-fields .lc-df-error {
+  margin: 3px 0 0;
+  font-size: var(--lc-text-xs);
+  color: var(--err);
+}
+
+/* string-list: chips + an add box */
+
+.loomcycle-def-fields .lc-df-chips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 5px;
+}
+
+.loomcycle-def-fields .lc-df-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 4px 1px 7px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-soft-2);
+  font-family: var(--mono);
+  font-size: var(--lc-text-xs);
+  overflow-wrap: anywhere;
+}
+
+.loomcycle-def-fields .lc-df-chip-x {
+  border: 0;
+  background: transparent;
+  color: var(--fg-muted);
+  font: inherit;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 2px;
+}
+
+.loomcycle-def-fields .lc-df-chip-x:hover { color: var(--err); }
+
+.loomcycle-def-fields .lc-df-chip-add { flex: 1 1 120px; min-width: 90px; width: auto; }
+
+/* kv + object-array */
+
+.loomcycle-def-fields .lc-df-kv,
+.loomcycle-def-fields .lc-df-objarray {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.loomcycle-def-fields .lc-df-kv-row {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+}
+
+.loomcycle-def-fields .lc-df-kv-key { flex: 0 1 35%; }
+.loomcycle-def-fields .lc-df-kv-val { flex: 1 1 auto; }
+
+.loomcycle-def-fields .lc-df-add { align-self: flex-start; }
+
+.loomcycle-def-fields .lc-df-objarray-item,
+.loomcycle-def-fields .lc-df-nested {
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  background: var(--bg);
+  padding: 2px 8px 6px;
+}
+
+.loomcycle-def-fields .lc-df-objarray-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: 5px;
+}
+
+.loomcycle-def-fields .lc-df-objarray-idx {
+  font-family: var(--mono);
+  font-size: var(--lc-text-xs);
+  color: var(--fg-muted);
+}
+
+/* A nested row's own left-edge marker would stack with its parent's; the parent
+   box already says the object is set. */
+.loomcycle-def-fields .lc-df-nested .lc-df-row-set,
+.loomcycle-def-fields .lc-df-objarray-item .lc-df-row-set {
+  box-shadow: none;
+  padding-left: 0;
+}

--- a/packages/def-fields/src/types.ts
+++ b/packages/def-fields/src/types.ts
@@ -1,0 +1,79 @@
+// The field registry: ONE declarative description of a substrate primitive's
+// editable parameters, from which every surface is derived — the grouped form,
+// the folded (accordion) list, the per-parameter hints, and the overlay
+// read/write.
+//
+// WHY a registry rather than hand-written controls: the pre-registry editor
+// wrote each field three times (state hook, JSX, overlay builder) plus a
+// hand-maintained "which keys are covered" set. That set drifted — two fields
+// shipped rendered-and-emitted but unregistered, so the advanced-overlay logic
+// misclassified them. With a registry, a field is one entry and "rendered but
+// not saved" is not expressible.
+
+// FieldType selects the editor control. Keep this list small: a new type is a
+// new control to maintain in every surface, so prefer composing `object` /
+// `object-array` over inventing bespoke types.
+export type FieldType =
+  | "text"
+  | "textarea"
+  | "int"
+  // A real number ("temperature: 0.7"). Separate from int only so the control
+  // accepts a fractional step — the browser's default number step is 1, which
+  // marks 0.7 invalid.
+  | "float"
+  | "bool"
+  | "enum"
+  | "string-list"
+  | "kv"
+  | "object"
+  | "object-array"
+  // A single field whose VALUE is genuinely free-form structured data (a JSON
+  // Schema, a tier→candidates map). Deliberately per-field and typed — not the
+  // removed whole-overlay JSON box, which hid every uncovered key behind one
+  // unvalidated textarea.
+  | "json";
+
+export interface FieldSpec {
+  /** The overlay key this field reads and writes. Must match the substrate's
+   *  persisted shape exactly — the drift test asserts the whole set. */
+  key: string;
+  label: string;
+  /** Accordion section this field folds under. Must be one of registry.groups. */
+  group: string;
+  type: FieldType;
+  /** One-sentence operator-facing explanation. Rendered in BOTH the form and the
+   *  folded list, so it is written once here and never duplicated per surface. */
+  hint: string;
+  placeholder?: string;
+  /** enum only: the allowed values. */
+  options?: readonly string[];
+  /** int / float only: inclusive bounds, surfaced to the control and to validation. */
+  min?: number;
+  max?: number;
+  /** What an UNSET field means, e.g. "inherits the parent def / operator yaml".
+   *  Shown on the inherit affordance so an empty box is never ambiguous. */
+  unsetMeans?: string;
+  /** object / object-array: the child fields. */
+  fields?: readonly FieldSpec[];
+  /** Folded away by default even inside its group — rarely-tuned knobs. */
+  advanced?: boolean;
+}
+
+export interface FieldGroupSpec {
+  name: string;
+  /** Section-level context, shown once under the group header. */
+  hint?: string;
+}
+
+export interface DefRegistry {
+  /** Substrate kind: "agentdef" | "mcpserverdef" | … */
+  kind: string;
+  /** Section order for the folded list. Every field.group must appear here. */
+  groups: readonly FieldGroupSpec[];
+  fields: readonly FieldSpec[];
+}
+
+/** A sparse overlay: a key that is ABSENT means "inherit", which is different
+ *  from a key present with a zero value (0 / "" / false are real settings the
+ *  substrate's pointer fields preserve). Every editor honours that distinction. */
+export type DefValue = Record<string, unknown>;

--- a/packages/def-fields/tsconfig.json
+++ b/packages/def-fields/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+    "skipLibCheck": true,
+
+    "types": ["vite/client", "node"]
+  },
+  "include": ["src", "vite.config.lib.ts"]
+}

--- a/packages/def-fields/tsconfig.lib.json
+++ b/packages/def-fields/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/packages/def-fields/vite.config.lib.ts
+++ b/packages/def-fields/vite.config.lib.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { fileURLToPath } from "node:url";
+
+// Library build for the published @loomcycle/def-fields package. Emits ESM + CJS
+// to dist/; declarations come from `tsc -p tsconfig.lib.json` and styles.css is
+// copied in — see the build:lib script. Everything imported by bare specifier
+// (react, react-dom) is externalized so it isn't duplicated
+// into the consumer's bundle; only our own relative source is bundled.
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    lib: {
+      entry: fileURLToPath(new URL("./src/index.ts", import.meta.url)),
+      formats: ["es", "cjs"],
+      fileName: (format) => (format === "es" ? "index.js" : "index.cjs"),
+    },
+    outDir: "dist",
+    sourcemap: true,
+    emptyOutDir: true,
+    rollupOptions: {
+      external: (id) => !id.startsWith(".") && !id.startsWith("/"),
+    },
+  },
+});


### PR DESCRIPTION
## Why

An agent definition has **47 persisted overlay parameters**. The Library editor exposes 19 as structured controls; everything else is reachable only through a collapsible free-text JSON/YAML textarea — unvalidated, unhinted, and (the user's words) *unusable*.

The subset kept lagging for a structural reason, not a diligence one: each parameter was written **three times** — a state hook, its JSX, and the overlay builder — plus a hand-maintained `STRUCTURED_AGENT_KEYS` set recording which keys were covered. Four coordinated edits per knob, and the set silently drifts when it gets fewer: `max_context_tokens` and `internal` are rendered and emitted by the form today but absent from that set, so the advanced box mis-warns about shadowing them.

Two consumers need the same surface:

- the **loomcycle Web UI** Library modal, and
- the **loomboard canvas** node inspectors — today `src/chat/components/AgentConfigPanel.tsx`, a hand-written five-field panel re-implementing the same inherit semantics from scratch.

Neither should own the other's data layer, and neither should have to re-derive what a parameter means.

## What

A new standalone package, **`@loomcycle/def-fields`** (v0.1.0).

**A declarative registry.** One `FieldSpec` per parameter carrying its overlay key, group, control type, bounds, and its operator-facing hint. That single entry drives the control, the hint, and the overlay read/write — so *"rendered but not saved"* stops being expressible, which is the class of bug that motivated the package.

**`FoldedFieldList`** — the whole parameter surface as collapsible groups:

- search over key **+** label **+** hint, so an operator who remembers *"the thing about the context window"* finds `max_context_tokens` without knowing its name;
- a **modified-only** filter and per-group **"n set"** badges, so a closed group still says whether this def overrides anything inside it;
- rarely-tuned knobs folded behind **"+ n more advanced"** — but *never* while they carry a value. Hiding a set value is precisely the failure the JSON box already had;
- groups default-open to exactly those the def overrides, because the first question on reopening a def is "what did I change here".

**`FieldRow` / `FieldControl`** — one row and one control per `FieldType`, shared by every arrangement, so the grouped form and the folded list cannot drift into two mental models of the same def. The hint is **always rendered**, never hover-only: a parameter an operator meets once a year has no discoverable tooltip.

**`agentDefRegistry`** — all **46** operator-settable `AgentDef` parameters across nine groups (Identity & prompt · Routing · Tools & access · Limits · Sampling · Context & compaction · Memory · Capabilities · Behaviour), with hints derived from the Go doc comments rather than invented.

### The detail that carries the risk

Sparse-overlay semantics are honoured by **key presence, never truthiness**: absent = inherit; present `0` / `false` / `""` = a real setting the substrate's pointer fields deliberately preserve. `value[key] ?? fallback` would promote an explicit `temperature: 0` to "inherit" and silently un-determinise a pinned agent. Clearing **deletes** the key rather than writing `null`, so the parent value flows through the merge again — and the affordance names what clearing *restores* instead of saying "unset", because on a forked def "unset" does not mean "empty".

### Coverage is complete

Three `config.AgentDef` fields are deliberately absent, and `AGENTDEF_EXCLUDED` records why for each — all three are carve-outs the runtime already documents at `internal/lookup/agent.go:293` with a round-trip test naming them, not gaps awaiting a backend fix:

| field | why it cannot be a control |
|---|---|
| `system_prompt_base` | derived — the pre-skill-bake snapshot the server writes, never operator input |
| `system_prompt_file` | load-time only — reads a path off the operator's disk at config load, which a runtime def has no filesystem for |
| `disable_context` | load-time only — `addContextToolDefaults` bakes `Context` into `Tools` during `config.Load`; a runtime def has no auto-add to opt out of, so the control would do nothing |
| `skill_def_scopes` | removed-field tombstone (RFC BA) — skill authoring is governed by the `skills:` allowlist; the yaml key survives only so config load can reject a stale one with a migration error |

(The second commit corrects `disable_context` / `skill_def_scopes`, which I had first recorded as "pending backend round-trip support". That was a misreading of two documented carve-outs; no backend change is owed.)

### Packaging

Deliberately **presentational**: peer deps are `react`/`react-dom` only — no `@loomcycle/client` — so loomboard can wire its own persistence without pulling the Library UI. Styles are scoped under `.loomcycle-def-fields` with a dark default and a light override, matching `@loomcycle/memory-view`; a host opts in with `import "@loomcycle/def-fields/styles.css"`.

## What was tested

**26 unit tests** (`packages/def-fields`, vitest):

- `value.test.ts` — the sparse-overlay contract: explicit `0`/`false`/`""` read back as SET; an absent key and an explicit `undefined` read as UNSET; clear **deletes** rather than nulls; clearing an unset key is identity; no input mutation; the search and modified-only filters compose, and modified-only keeps a falsy-but-set field.
- `agentdef.test.ts` — registry invariants: no duplicate keys; **nothing rendered that the overlay cannot store**; every overlay key exposed *or* named in `AGENTDEF_EXCLUDED` with a reason; every field and sub-field hinted; enum options, nested children, and numeric bounds well-formed; nested children inherit the parent's group.

**A drift guard.** `AGENTDEF_OVERLAY_KEYS` is checked against the `json` tags of `builtin.mergedDef`, read from the Go source — so adding an overlay parameter in Go without exposing it in the editor **fails here**, which is the whole reason the registry exists. Verified fail-before by dropping one key from the fixture: the guard failed and named it. Outside the repo (a published tarball has no Go source) it reports itself skipped rather than failing.

`npm run typecheck`, `npm test`, and `npm run build:lib` all clean; the lib build emits ESM + CJS + `.d.ts` + `styles.css`.

**CI/publish:** the `web-ui` job now runs the package's typecheck + tests on every PR (alongside `@loomcycle/memory-view`'s), and `publish-def-fields.yml` publishes on its own `def-fields-v*` tag namespace, mirroring `memory-view-v*` / `library-v*`. Both workflows validated as parseable YAML.

## Not in this PR — and why

- **The Library wiring** (a Form ⇄ List switcher, then removing the JSON/YAML box). `packages/library` builds standalone and emits declarations under `rootDir: src`, so consuming a sibling *source* package breaks its declaration emit (TS6059 — verified, not assumed). The repo's convention for an in-repo package's consumer is the published version (`packages/library` consumes the published `@loomcycle/client`, never `adapters/ts` source), so the wiring lands after `def-fields-v0.1.0` is on npm. The Web UI is unchanged by this PR.
- **Registries for the other substrate kinds** (mcpserverdef, skilldef, volumedef, memorybackenddef, and the auth-sensitive webhookdef + two A2A kinds). One kind per PR keeps each reviewable against its own Go shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD