### PR TITLE
fix(build): make build-ui installs @loomcycle/def-fields deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,12 @@ build-ui:
 	# install its deps (packages/memory-view/node_modules is gitignored) before
 	# the web build.
 	cd packages/memory-view && npm ci --silent
+	# @loomcycle/def-fields is consumed from SOURCE the same way — install its
+	# deps (packages/def-fields/node_modules is gitignored) before the web build.
+	# Missing this failed the v1.76.0 release: CI's web-ui job installs each
+	# package itself and stayed green, while the goreleaser job runs THIS target
+	# and could not resolve the package's react types.
+	cd packages/def-fields && npm ci --silent
 	cd web && npm ci --silent && npm run build
 	touch internal/webui/dist/.gitkeep
 


### PR DESCRIPTION
**The v1.76.0 release failed here.** One line, needed before the tag can be re-cut.

## What broke

`make build-ui` installs `node_modules` for each package the SPA consumes from source — library, explorer, memory-view — because those directories are gitignored and absent on a fresh checkout. `@loomcycle/def-fields` joined that set in #1159/#1160 and was never added, so the web build could not resolve the package's `react` types:

```
../packages/def-fields/src/FoldedFieldList.tsx(1,35): error TS2307:
  Cannot find module 'react' or its corresponding type declarations.
```

## Why CI stayed green

There are **two install lists for one dependency set**, and only one was updated. `ci.yml`'s web-ui job installs each package itself and #1159 added a def-fields step *there*. The release's goreleaser job doesn't — it runs this Makefile target.

My local builds passed for the reason that's easy to miss: the package's `node_modules` was left over from working in it. A release runner has no such leftovers.

## What was tested

`make build-ui` on a **fresh worktree with no `node_modules` under `packages/*` or `web/`** — the release runner's state. It fails identically to the release without this line, and completes cleanly with it, verified in that order on the same tree. The target still leaves the working tree clean, which the goreleaser job requires.

## After merge

The failed `v1.76.0` tag produced no release artifacts, so it is deleted and re-cut at the merge commit — reusing the version rather than moving to `v1.76.1`, which as a patch would get the lean browser-only build instead of the full one a server deploy needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD