### PR TITLE
bench(locomo): a barren conversation skips, it does not kill the run

### DIFF
--- a/bench/cmd/locomo/answer.go
+++ b/bench/cmd/locomo/answer.go
@@ -738,10 +738,32 @@ func doAnswerAxis(ctx context.Context, convs []Conversation, defects *Defects, o
 			return fmt.Errorf("post-consolidation check: %w", err)
 		}
 		if len(rows) == 0 {
-			return fmt.Errorf("consolidation left %s/%s empty after %d pass(es) over %d sessions: every "+
-				"recall would return nothing and the run would score 0 for a reason unrelated to memory. "+
-				"Check that the consolidator can reach its extractor model and that the target is not leased",
-				"user", userID, passes, sessions)
+			// ONE barren conversation is not a broken pipeline, and on a
+			// many-instance corpus it is expected. This guard was written for
+			// LoCoMo, where a run is one or two large conversations and an empty
+			// store can only mean the plumbing failed. LongMemEval is 72 small
+			// instances and some genuinely hold nothing durable — the abstention
+			// instances are built that way on purpose, their history deliberately
+			// lacking the answer. Measured: a 72-instance baseline died at
+			// instance 18 of 72 after 17 consecutive instances yielded 8..29
+			// facts each. Aborting there threw away a run that was working.
+			//
+			// So the check moves from per-instance-fatal to per-instance-SKIP
+			// plus a RUN-LEVEL threshold, which is what actually distinguishes
+			// the two cases: a plumbing failure starves EVERY instance, while a
+			// barren conversation starves one. The threshold still fails loudly,
+			// just on the evidence that can tell them apart.
+			rep.EmptyInstances++
+			fmt.Fprintf(stdout, "  SKIPPED: consolidation produced no rows for this conversation "+
+				"(%d of %d so far); not graded\n", rep.EmptyInstances, len(all)+1)
+			if rep.EmptyInstances > 1 && rep.EmptyInstances*2 > len(convs) {
+				return fmt.Errorf("consolidation left %s/%s empty for %d of %d conversation(s): that is "+
+					"most of the corpus, so this is the pipeline and not the data. Every recall would "+
+					"return nothing and the run would score 0 for a reason unrelated to memory. Check "+
+					"that the consolidator can reach its extractor model and that the target is not leased",
+					"user", userID, rep.EmptyInstances, len(convs))
+			}
+			continue
 		}
 
 		// AND refuse when the facts went somewhere the answerer cannot read.

--- a/bench/cmd/locomo/report.go
+++ b/bench/cmd/locomo/report.go
@@ -143,6 +143,11 @@ type AnswerReport struct {
 	Turns         int    `json:"turns_ingested"`
 	Sessions      int    `json:"sessions_ingested"`
 	FactsWritten  int    `json:"facts_written"`
+	// EmptyInstances counts conversations whose consolidation produced no rows
+	// and were therefore not graded. Reported rather than silent: a baseline
+	// with a handful of barren instances is a different claim from one where
+	// every instance yielded facts, and the reader has to be able to tell.
+	EmptyInstances int `json:"empty_instances,omitempty"`
 	// SeededTurns counts turn rows written straight into the answerer's own
 	// partition (-seed-turns). It is the difference between "answered from
 	// distilled facts" and "answered from conversation content", so a report


### PR DESCRIPTION
## Why

The empty-store guard **aborted a 72-instance LongMemEval baseline at instance 18**, after seventeen consecutive instances had yielded 8–29 facts each. The run was working; one conversation held nothing durable and the guard treated that as a broken pipeline.

Its premise is sound for the corpus it was written against. LoCoMo is one or two **large** conversations, so an empty store there can only mean the plumbing failed. LongMemEval is 72 small instances and some genuinely hold nothing durable — **the abstention instances are built that way on purpose**, their history deliberately lacking the answer. On that shape a per-instance abort throws away the whole run over expected data.

## What

The check moves from per-instance-**fatal** to per-instance-**skip** plus a **run-level threshold**, which is what actually separates the two cases:

> a plumbing failure starves **every** instance; a barren conversation starves one.

It still fails loudly — just on the evidence that can tell them apart (more than half the corpus empty, and more than one).

A skipped instance is **counted and reported** (`empty_instances`), not silent. A baseline with a handful of barren instances is a different claim from one where every instance yielded facts, and the reader has to be able to tell which they are holding.

## What was tested

Used immediately, and the threshold did its job in both directions:

- With the fix, the baseline completed **72/72 instances with 5 skipped** — well under the threshold.
- On a later arm the same guard **correctly aborted** at *37 of 72* empty, which was a genuine pipeline problem (a window fragmenting short sources below the size at which the extractor finds anything). That abort is what led to the `min_turns_to_window` fix.

So the threshold tolerated real data and still caught a real fault. `go test ./bench/...` green; bench-only, no runtime code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8
