### PR TITLE
feat(retention): snapshot a fact's source span before archiving the chat

### DIFF
--- a/internal/retention/mem_content_test.go
+++ b/internal/retention/mem_content_test.go
@@ -27,13 +27,41 @@ func (f *fakePruner) PruneRetiredChunks(_ context.Context, key sqlmem.ScopeKey, 
 }
 
 // fakeSQLMem lists a fixed scope set.
-type fakeSQLMem struct{ scopes []sqlmem.ScopeKey }
+type fakeSQLMem struct {
+	scopes []sqlmem.ScopeKey
+	// execs records every statement the sweeper ran, so a test can assert on the
+	// archival span snapshot without a live SQL Memory.
+	execs   []fakeExec
+	execErr error
+	// affected is what Exec reports as RowsAffected.
+	affected int64
+	// onExec runs inside Exec, so a test can observe the world AT THE MOMENT the
+	// snapshot writes — which is how the snapshot-before-delete ordering is
+	// asserted rather than assumed.
+	onExec func()
+}
+
+type fakeExec struct {
+	Key       sqlmem.ScopeKey
+	Statement string
+	Args      []any
+}
 
 func (f *fakeSQLMem) ListScopes(context.Context) ([]sqlmem.ScopeKey, error) { return f.scopes, nil }
 func (f *fakeSQLMem) ExportScope(context.Context, sqlmem.ScopeKey) (*sqlmem.ScopeDump, error) {
 	return &sqlmem.ScopeDump{}, nil
 }
 func (f *fakeSQLMem) DropScope(context.Context, sqlmem.ScopeKey) (bool, error) { return false, nil }
+func (f *fakeSQLMem) Exec(_ context.Context, key sqlmem.ScopeKey, stmt string, args []any, _ int) (*sqlmem.ExecResult, error) {
+	f.execs = append(f.execs, fakeExec{Key: key, Statement: stmt, Args: args})
+	if f.onExec != nil {
+		f.onExec()
+	}
+	if f.execErr != nil {
+		return nil, f.execErr
+	}
+	return &sqlmem.ExecResult{RowsAffected: f.affected}, nil
+}
 
 // TestMemContent_OffByDefault: every destructive retention family is opt-in, and
 // this one deletes content out of LIVE scopes rather than reclaiming dead ones — so

--- a/internal/retention/snapshot_span.go
+++ b/internal/retention/snapshot_span.go
@@ -1,0 +1,186 @@
+package retention
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// snapshotSpanMaxChars caps a snapshotted span. A span is EVIDENCE, not an
+// archive: it exists so an operator can see why the store believes a fact, and
+// the export already keeps the full transcript for anyone who needs all of it.
+const snapshotSpanMaxChars = 4000
+
+// snapshotSpansBeforeArchive copies each fact's source span onto the fact
+// itself, for facts derived from a session that is about to be deleted.
+//
+// WHY IT EXISTS. A fact keeps a live reference to the turn it was distilled
+// from, and retrieval can hand that turn back verbatim — for exactly as long as
+// the turn exists. When the chats sweeper archives the session, that reference
+// becomes dangling (the cascade deletes runs and events with it), and a fact
+// whose reference dangles and whose source_quote is empty can no longer answer
+// "why does the store believe this" at all. So the span is copied onto the fact
+// AS THE SOURCE LEAVES.
+//
+// This is not the duplication the one-chunk-store work removes. For the whole
+// life of the source there is ONE copy, in the transcript, reached by the
+// reference; the copy onto the fact is made only when the source is going away.
+// At every moment the span exists exactly once.
+//
+// ⚠️ ORDERING IS THE POINT, not an implementation detail. Snapshot BEFORE
+// archive, so a crash between the two steps leaves a live source and a fact
+// that can be snapshotted again next tick. The other order leaves a fact with
+// neither the reference nor the span, which is unrecoverable.
+//
+// KEYED ON run_id, NOT session_id, and that is a measurement rather than a
+// preference: across 1,096 fact-provenance rows on a live store, run_id was
+// 100% populated and session_id 0%. The queue enqueues with the ingesting run's
+// id and no session (there is no session-id helper on the tools context), so
+// run_id is the pointer that actually carries provenance, and runs.session_id is
+// one hop from it. RunsForSession is already called here for the export, so the
+// run set costs nothing extra.
+func (s *Sweeper) snapshotSpansBeforeArchive(ctx context.Context, sessionID string) {
+	if s.sqlMem == nil {
+		return // no SQL Memory: no chunk provenance to snapshot
+	}
+	runs, err := s.store.RunsForSession(ctx, sessionID)
+	if err != nil || len(runs) == 0 {
+		if err != nil {
+			s.logf("retention: snapshot spans: runs for session %s: %v", sessionID, err)
+		}
+		return
+	}
+	runIDs := make([]string, 0, len(runs))
+	for _, r := range runs {
+		if r.ID != "" {
+			runIDs = append(runIDs, r.ID)
+		}
+	}
+	if len(runIDs) == 0 {
+		return
+	}
+
+	events, err := s.store.GetTranscript(ctx, sessionID)
+	if err != nil {
+		s.logf("retention: snapshot spans: transcript for session %s: %v", sessionID, err)
+		return
+	}
+	// The whole conversation, rendered once. A fact points at a RUN rather than
+	// a turn (event_seq is unpopulated on the queue path), so the honest span is
+	// the conversation the fact was distilled from — trimmed to the same cap the
+	// write path applies, because a span is evidence and not an archive.
+	span := renderTranscriptSpan(events)
+	if span == "" {
+		return
+	}
+
+	scopes, err := s.sqlMem.ListScopes(ctx)
+	if err != nil {
+		s.logf("retention: snapshot spans: list scopes: %v", err)
+		return
+	}
+	filled := 0
+	for _, key := range scopes {
+		n, err := s.fillEmptySpans(ctx, key, runIDs, span)
+		if err != nil {
+			// A scope that has no chunk_memory_meta table is the common case, not
+			// a fault: only scopes carrying entity-tier content have one. Logged at
+			// debug volume would drown the tick, so an error here is skipped
+			// silently and the NEXT scope still gets its chance.
+			continue
+		}
+		filled += n
+	}
+	if filled > 0 {
+		s.logf("retention: snapshot spans: session %s leaving, %d fact(s) kept their source span", sessionID, filled)
+	}
+}
+
+// fillEmptySpans writes the span onto facts in one scope that came from these
+// runs and carry no span yet.
+//
+// ONLY THE EMPTY ONES. A fact that already has a source_quote got it at write
+// time from the text the extractor actually saw, which is a tighter span than a
+// whole conversation — overwriting it would trade precise evidence for coarse.
+func (s *Sweeper) fillEmptySpans(ctx context.Context, key sqlmem.ScopeKey, runIDs []string, span string) (int, error) {
+	ph := make([]string, len(runIDs))
+	args := make([]any, 0, len(runIDs)+1)
+	args = append(args, span)
+	for i := range runIDs {
+		ph[i] = "?"
+		args = append(args, runIDs[i])
+	}
+	stmt := "UPDATE chunk_memory_meta SET source_quote = ? WHERE run_id IN (" +
+		strings.Join(ph, ",") + ") AND (source_quote IS NULL OR source_quote = '')"
+	res, err := s.sqlMem.Exec(ctx, key, stmt, args, 0)
+	if err != nil {
+		return 0, err
+	}
+	return int(res.RowsAffected), nil
+}
+
+// renderTranscriptSpan turns a session's events into the text a fact can carry
+// as its evidence, capped.
+//
+// Reuses the shape the extractor was shown — "### role" sections — so a span
+// snapshotted at archival reads like the spans written at extraction time
+// rather than like a different format that happens to live in the same column.
+func renderTranscriptSpan(events []store.Event) string {
+	var b strings.Builder
+	for _, ev := range events {
+		var text string
+		switch ev.Type {
+		case "user_input":
+			text = firstUserText(ev.Payload)
+		case "text":
+			var pe struct {
+				Text string `json:"text"`
+			}
+			if json.Unmarshal(ev.Payload, &pe) == nil {
+				text = pe.Text
+			}
+		default:
+			continue
+		}
+		if text = strings.TrimSpace(text); text == "" {
+			continue
+		}
+		if b.Len()+len(text) > snapshotSpanMaxChars {
+			break
+		}
+		fmt.Fprintf(&b, "%s\n\n", text)
+	}
+	return strings.TrimSpace(b.String())
+}
+
+// firstUserText pulls the human words out of a persisted user_input payload
+// (a []PromptSegment), dropping system framing and image bytes.
+func firstUserText(payload []byte) string {
+	var segs []struct {
+		Role    string `json:"role"`
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if json.Unmarshal(payload, &segs) != nil {
+		return ""
+	}
+	var parts []string
+	for _, seg := range segs {
+		if seg.Role != "user" {
+			continue
+		}
+		for _, c := range seg.Content {
+			if c.Type == "image" || strings.TrimSpace(c.Text) == "" {
+				continue
+			}
+			parts = append(parts, c.Text)
+		}
+	}
+	return strings.Join(parts, "\n")
+}

--- a/internal/retention/snapshot_span_test.go
+++ b/internal/retention/snapshot_span_test.go
@@ -1,0 +1,206 @@
+package retention
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+)
+
+// TestSnapshot_SpanIsCopiedOntoFactsBEFORETheSessionIsDeleted.
+//
+// A fact keeps a live reference to the turn it was distilled from, and
+// retrieval can hand that turn back verbatim — for exactly as long as the turn
+// exists. The chats sweeper deletes an aged session with its runs and events,
+// so that reference dangles, and a fact with a dangling reference and no
+// source_quote can no longer answer "why does the store believe this" at all.
+//
+// FOUR PROPERTIES, and the ordering is the one that cannot be recovered if it
+// is wrong:
+//
+//  1. ORDERING — the snapshot must run while the source is still alive. A crash
+//     between snapshot and delete leaves a live source and a fact that can be
+//     snapshotted again next tick; the other order leaves a fact with neither
+//     the reference nor the span. Asserted by having the snapshot's own Exec
+//     look the transcript back up: if the delete had already run it would come
+//     back empty.
+//  2. KEYED ON run_id — measured on a live store: across 1,096 fact-provenance
+//     rows, run_id was 100% populated and session_id 0%, because the queue
+//     enqueues with the ingesting run's id and there is no session-id helper on
+//     the tools context. Keying on session_id would match nothing.
+//  3. NEVER OVERWRITES a span that already exists. One written at extraction
+//     time came from the text the extractor actually saw, which is tighter than
+//     a whole conversation; replacing it would trade precise evidence for
+//     coarse.
+//  4. The span carries the conversation's own words.
+func TestSnapshot_SpanIsCopiedOntoFactsBEFORETheSessionIsDeleted(t *testing.T) {
+	ctx := context.Background()
+	st, err := sqlite.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+
+	sess, err := st.CreateSession(ctx, "acme", "chat", "u1")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	run, err := st.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_chat"})
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	seg, _ := json.Marshal([]map[string]any{{
+		"role":    "user",
+		"content": []map[string]any{{"type": "text", "text": "I moved to Berlin in July for a new job."}},
+	}})
+	if err := st.AppendEvent(ctx, run.ID, "user_input", seg); err != nil {
+		t.Fatalf("append event: %v", err)
+	}
+
+	// The snapshot's Exec re-reads the transcript, which is the ordering proof:
+	// a non-empty transcript at that moment means the session had not yet been
+	// deleted.
+	var sourceAliveAtSnapshot bool
+	fake := &fakeSQLMem{
+		scopes:   []sqlmem.ScopeKey{{Tenant: "acme", Scope: "user", ScopeID: "u1"}},
+		affected: 2,
+	}
+	sw := New(st, Config{SQLMem: fake, Logger: quietLogger, Now: futureHour})
+	fake.onExec = func() {
+		ev, err := st.GetTranscript(context.Background(), sess.ID)
+		sourceAliveAtSnapshot = err == nil && len(ev) > 0
+	}
+
+	sw.snapshotSpansBeforeArchive(ctx, sess.ID)
+
+	if len(fake.execs) != 1 {
+		t.Fatalf("snapshot ran %d statement(s), want 1 (one per scope carrying entity content)", len(fake.execs))
+	}
+	if !sourceAliveAtSnapshot {
+		t.Error("the snapshot ran with the transcript already gone — snapshot must precede the " +
+			"delete, or a crash between them leaves a fact with neither its reference nor its span")
+	}
+
+	got := fake.execs[0]
+	if !strings.Contains(got.Statement, "chunk_memory_meta") || !strings.Contains(got.Statement, "source_quote") {
+		t.Errorf("statement does not write a fact's span: %q", got.Statement)
+	}
+	if !strings.Contains(got.Statement, "run_id IN") {
+		t.Errorf("statement is not keyed on run_id: %q — session_id is 0%% populated on a live "+
+			"store, so keying on it would match nothing", got.Statement)
+	}
+	if !strings.Contains(got.Statement, "source_quote IS NULL OR source_quote = ''") {
+		t.Errorf("statement lacks the never-overwrite guard: %q — a span written at extraction "+
+			"time is tighter than a whole conversation and must survive", got.Statement)
+	}
+	// args[0] is the span; the rest are the run ids.
+	if len(got.Args) < 2 {
+		t.Fatalf("args = %v, want the span plus at least one run id", got.Args)
+	}
+	span, _ := got.Args[0].(string)
+	if !strings.Contains(span, "I moved to Berlin in July") {
+		t.Errorf("span does not carry the conversation's own words: %q", span)
+	}
+	var sawRun bool
+	for _, a := range got.Args[1:] {
+		if s, _ := a.(string); s == run.ID {
+			sawRun = true
+		}
+	}
+	if !sawRun {
+		t.Errorf("the session's run %q is not among the keyed args %v", run.ID, got.Args[1:])
+	}
+}
+
+// TestSnapshot_NoSQLMemoryIsANoOp — a deployment without SQL Memory has no
+// chunk provenance to snapshot, and must not fail the sweep over it.
+func TestSnapshot_NoSQLMemoryIsANoOp(t *testing.T) {
+	ctx := context.Background()
+	st, err := sqlite.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+	sw := New(st, Config{Logger: quietLogger, Now: futureHour})
+	sw.snapshotSpansBeforeArchive(ctx, "s-missing") // must not panic
+}
+
+// TestSnapshot_TheSWEEPERSnapshotsBeforeItDeletes.
+//
+// The test above drives snapshotSpansBeforeArchive directly, so it proves the
+// function reads a live source — but it CANNOT catch the sweeper calling it in
+// the wrong place. Moving the call after DeleteSessionCascade leaves that test
+// green while destroying the property, which makes this second test the one
+// that actually pins the ordering.
+//
+// It runs the real chats sweep against a real store and asserts, from inside
+// the snapshot's own write, that the session's transcript is still readable. If
+// the delete had already run, the cascade would have taken the events with it.
+func TestSnapshot_TheSWEEPERSnapshotsBeforeItDeletes(t *testing.T) {
+	ctx := context.Background()
+	st, err := sqlite.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+
+	sess, err := st.CreateSession(ctx, "acme", "chat", "u1")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	run, err := st.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_chat"})
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	seg, _ := json.Marshal([]map[string]any{{
+		"role":    "user",
+		"content": []map[string]any{{"type": "text", "text": "We celebrated ten years in June."}},
+	}})
+	if err := st.AppendEvent(ctx, run.ID, "user_input", seg); err != nil {
+		t.Fatalf("append event: %v", err)
+	}
+	// Terminal, so the session is prunable at all.
+	if err := st.FinishRun(ctx, run.ID, store.RunCompleted, "end_turn", store.Usage{}, ""); err != nil {
+		t.Fatalf("finish run: %v", err)
+	}
+
+	var transcriptAliveAtWrite, sawWrite bool
+	fake := &fakeSQLMem{
+		scopes:   []sqlmem.ScopeKey{{Tenant: "acme", Scope: "user", ScopeID: "u1"}},
+		affected: 1,
+	}
+	fake.onExec = func() {
+		sawWrite = true
+		ev, err := st.GetTranscript(context.Background(), sess.ID)
+		transcriptAliveAtWrite = err == nil && len(ev) > 0
+	}
+
+	// A future clock makes the just-created session "aged" without sleeping.
+	sw := New(st, Config{
+		ChatsMode: "prune", ChatsMaxAge: time.Minute,
+		SQLMem: fake, Logger: quietLogger, Now: futureHour,
+	})
+	if _, _, err := sw.sweepChatsOnce(ctx); err != nil {
+		t.Fatalf("sweepChatsOnce: %v", err)
+	}
+
+	if !sawWrite {
+		t.Fatalf("the sweep deleted a session without snapshotting any span — a fact derived from " +
+			"it keeps a dangling reference and no evidence")
+	}
+	if !transcriptAliveAtWrite {
+		t.Error("the sweeper snapshotted AFTER deleting the session: the span was written from an " +
+			"already-empty transcript, so the fact ends up with neither its reference nor its span")
+	}
+	// And the session really is gone afterwards — otherwise the ordering claim is
+	// vacuous because nothing was archived at all.
+	if ev, err := st.GetTranscript(ctx, sess.ID); err == nil && len(ev) > 0 {
+		t.Errorf("the session was not pruned, so this test did not exercise archival (%d events left)", len(ev))
+	}
+}

--- a/internal/retention/sweeper.go
+++ b/internal/retention/sweeper.go
@@ -76,6 +76,11 @@ type SQLMemory interface {
 	ExportScope(ctx context.Context, key sqlmem.ScopeKey) (*sqlmem.ScopeDump, error)
 	// DropScope drops one durable scope. removed reports whether it existed.
 	DropScope(ctx context.Context, key sqlmem.ScopeKey) (bool, error)
+	// Exec runs one statement in a scope. Used by the archival span snapshot to
+	// fill a fact's empty source_quote before its source session is deleted —
+	// the one write this sweeper makes rather than a delete, and the reason it
+	// is a write at all is that the alternative is losing the evidence.
+	Exec(ctx context.Context, key sqlmem.ScopeKey, statement string, args []any, quotaOverride int) (*sqlmem.ExecResult, error)
 }
 
 // Config carries the sweeper's tuning knobs. Zero/missing values fall back to
@@ -747,6 +752,16 @@ func (s *Sweeper) pruneSessionBatch(ctx context.Context, cutoff time.Time, match
 			pruned++
 			continue
 		}
+		// SNAPSHOT BEFORE ARCHIVE. A fact's reference to this session's turns is
+		// about to dangle, so the span is copied onto the fact first. Ordered this
+		// way deliberately: a crash here leaves a live source and a fact that can
+		// be snapshotted again next tick, where the other order leaves a fact with
+		// neither the reference nor the span.
+		//
+		// Never fatal to the delete. The session is aged out either way, and a
+		// snapshot that could not run is a fact with coarser provenance — not a
+		// reason to keep every aged chat forever.
+		s.snapshotSpansBeforeArchive(ctx, sid)
 		if err := s.store.DeleteSessionCascade(ctx, sid); err != nil {
 			s.logf("retention: delete chat session %s failed: %v", sid, err)
 			continue

--- a/internal/retention/sweeper_test.go
+++ b/internal/retention/sweeper_test.go
@@ -962,6 +962,9 @@ type errSQLMem struct {
 }
 
 func (e *errSQLMem) ListScopes(context.Context) ([]sqlmem.ScopeKey, error) { return e.scopes, nil }
+func (e *errSQLMem) Exec(context.Context, sqlmem.ScopeKey, string, []any, int) (*sqlmem.ExecResult, error) {
+	return &sqlmem.ExecResult{}, nil
+}
 func (e *errSQLMem) ExportScope(context.Context, sqlmem.ScopeKey) (*sqlmem.ScopeDump, error) {
 	return nil, errExportBoom
 }


### PR DESCRIPTION
Implements RFC CV decision 8 / OQ7 — the archival half of the fact→source relation (CX-4).

## Why

A fact keeps a live reference to the turn it was distilled from, and retrieval can hand that turn back verbatim — **for exactly as long as the turn exists.** The chats sweeper deletes an aged session with its runs and events, so the reference dangles, and a fact whose reference dangles *and* whose `source_quote` is empty can no longer answer "why does the store believe this" at all.

So the span is copied onto the fact **as the source leaves**.

This is *not* the duplication the one-chunk-store work removes. For the whole life of the source there is **one** copy — in the transcript, reached by the reference. The copy onto the fact is made only when the source is going away, so at every moment the span exists exactly once.

## Keyed on `run_id`, not `session_id` — measured, not preferred

Across 1,096 fact-provenance rows on a live store:

| field | populated | whose |
|---|---|---|
| `run_id` | **1096/1096 (100%)** | the **ingesting** run |
| `session_id` | **0/1096** | — no session-id helper on the tools ctx |
| `source_quote` | 893/1096 (82%) | |

The enqueue site says so outright: *"SourceRunID is enough to correlate the enqueue back to the run that produced it."* So `run_id` is the pointer that actually carries provenance, and `runs.session_id` is one hop from it.

**Keying on `session_id` would have produced a step that runs, reports success, and protects zero facts** — the inert-mechanism failure this line of work has already hit three times. `RunsForSession` and `GetTranscript` are *already called here* for the export, so the run set and the span cost nothing extra.

## Ordering is the point, not an implementation detail

Snapshot **before** the cascade, so a crash between the two leaves a live source and a fact that can be snapshotted again next tick. The other order leaves a fact with **neither** the reference nor the span — unrecoverable.

Never fatal to the delete: the session ages out either way, and a snapshot that could not run is a fact with coarser provenance, not a reason to keep every aged chat forever.

**Only empty spans are filled.** One written at extraction time came from the text the extractor actually saw, which is tighter than a whole conversation; overwriting it would trade precise evidence for coarse.

## What was tested — and why there are two tests

- **`SpanIsCopiedOntoFactsBEFORETheSessionIsDeleted`** drives the function and pins the statement shape: writes `chunk_memory_meta.source_quote`, keys on `run_id IN (...)`, carries the `source_quote IS NULL OR source_quote = ''` guard, and passes the conversation's own words plus the session's run id.

- **`TheSWEEPERSnapshotsBeforeItDeletes`** runs the **real** chats sweep — because the first test *cannot* catch the call being in the wrong place. Moving it after `DeleteSessionCascade` leaves that test green while destroying the property. This one asserts, from inside the snapshot's own write, that the transcript is still readable; and afterwards that the session really *was* pruned, so the ordering claim cannot pass vacuously on a sweep that archived nothing.

Fail-before, with the call moved after the delete:

```
--- FAIL: TestSnapshot_TheSWEEPERSnapshotsBeforeItDeletes
    the sweep deleted a session without snapshotting any span — a fact derived
    from it keeps a dangling reference and no evidence
```

Plus `NoSQLMemoryIsANoOp`: a deployment without SQL Memory has no chunk provenance and must not fail the sweep over it.

`./internal/retention`, `./internal/sqlmem` and `./internal/store/...` green.

## Note on the interface change

`SQLMemory` gains `Exec` — the one **write** this sweeper makes rather than a delete. It is a write because the alternative is losing the evidence.

## Follow-up, not blocking

`session_id` being 0% populated is worth fixing for directness (the enqueue path has no session-id ctx helper), but it is **not** a blocker: run_id carries the provenance today. Recorded for RFC CV rather than done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8
