### PR TITLE
feat(teamdef): per-node prompts, and layout that doesn't fork a definition

### DIFF
--- a/internal/api/http/resident.go
+++ b/internal/api/http/resident.go
@@ -257,7 +257,9 @@ func (s *Server) openResidentChild(ctx context.Context, name, prompt, defID stri
 	// The child must SURVIVE this tool call returning → detach its ctx from the
 	// parent request's cancellation (keep values) before prepareSubRun wraps it
 	// in its own cancel scope (fired by close / idle-reap / parent teardown).
-	prep, err := s.prepareSubRun(context.WithoutCancel(ctx), name, prompt, defID, true, fwd)
+	// No extra system segment: a resident sub-agent is opened by the Agent tool,
+	// not by a team state, so only the AgentDef's own prompt applies.
+	prep, err := s.prepareSubRun(context.WithoutCancel(ctx), name, "", prompt, defID, true, fwd)
 	if err != nil {
 		return "", "", "", err
 	}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -48,6 +48,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
 	"github.com/denn-gubsky/loomcycle/internal/steer"
 	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/teamrun"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
 	"github.com/denn-gubsky/loomcycle/internal/tools/policy"
@@ -552,10 +553,16 @@ func New(cfg *config.Config, pr ProviderResolver, builtinTools []tools.Tool, sem
 		// keeps it for the parallel_spawn ledger (RFC X Phase 3). Both drive
 		// the same runSubAgent.
 		Run: func(ctx context.Context, name, prompt, defID string) (string, error) {
-			out, _, _, err := s.runSubAgent(ctx, name, prompt, defID)
+			out, _, _, err := s.runSubAgent(ctx, name, "", prompt, defID)
 			return out, err
 		},
-		RunDetailed: s.runSubAgent,
+		// A closure rather than a bare method value: runSubAgent gained a
+		// systemExtra param that only a TEAM STATE supplies, and the Agent tool's
+		// SubAgentRunnerDetailed deliberately has no way to set it — a spawning
+		// agent must not be able to prepend text to its child's system prompt.
+		RunDetailed: func(ctx context.Context, name, prompt, defID string) (string, map[string]any, string, error) {
+			return s.runSubAgent(ctx, name, "", prompt, defID)
+		},
 		// RFC BK resident sub-agents: open/send/poll/cancel/close drive a
 		// persistent interactive child (the interactive fork of runSubAgent).
 		OpenChild:   s.openResidentChild,
@@ -890,11 +897,15 @@ func (s *Server) SetTeamDefTool(t tools.Tool) {
 	//
 	if td, ok := t.(*builtin.TeamDef); ok {
 		if td.Spawn == nil {
-			td.Spawn = func(ctx context.Context, name, prompt, defID string) (string, error) {
+			td.Spawn = func(ctx context.Context, name string, p teamrun.Prompt, defID string) (string, error) {
+				// p.System is the STATE's role, appended to the agent's own system
+				// prompt rather than replacing it (see runSubAgent's systemExtra).
+				// This is what makes a fan-out of N roles one AgentDef and N states.
+				//
 				// Team members thread results as strings today; a stateful member's
 				// Σ hand-off is a separate follow-on (teamrun is string-only
 				// end-to-end). Drop state here — the Agent-tool fan-out carries it.
-				out, _, _, err := s.runSubAgent(ctx, name, prompt, defID)
+				out, _, _, err := s.runSubAgent(ctx, name, p.System, p.Input, defID)
 				return out, err
 			}
 		}
@@ -5690,8 +5701,12 @@ func secretEnvValues(environ []string) map[string]string {
 // child's run row id (RFC X Phase 3) — "" when the run was never created (an
 // early resolution/provider error), otherwise the sub-run's id even on failure
 // so the parent's spawn ledger can re-find it. (Wired to AgentTool.Run.)
-func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, defID string) (string, map[string]any, string, error) {
-	prep, err := s.prepareSubRun(ctx, name, prompt, defID, false, func(providers.Event) {})
+// systemExtra is an EXTRA system segment appended after the agent's own system
+// prompt (empty for every caller but a team state — see teamgraph.Handler.
+// SystemPrompt). It never replaces the agent's prompt, so an agent's identity
+// cannot be overridden by whoever spawns it.
+func (s *Server) runSubAgent(ctx context.Context, name string, systemExtra string, prompt string, defID string) (string, map[string]any, string, error) {
+	prep, err := s.prepareSubRun(ctx, name, systemExtra, prompt, defID, false, func(providers.Event) {})
 	if err != nil {
 		return "", nil, "", err
 	}
@@ -5747,7 +5762,61 @@ type subRunPrep struct {
 // interactive=true means: pass a nil provider slot to fallbackForRun (a parked
 // resident child, like a top-level interactive run, must not swap/hold the
 // provider gate across turns) — everything else is identical.
-func (s *Server) prepareSubRun(ctx context.Context, name, prompt, defID string, interactive bool, fwd func(providers.Event)) (*subRunPrep, error) {
+// composeSubRunSegments builds a sub-run's input segments: the agent's own
+// system_prompt (with cache_control), then an optional caller-supplied system
+// segment, then the prompt as the first user message. Mirrors the shape of
+// /v1/runs.
+//
+// systemExtra APPENDS rather than replaces. A team state uses it to say what
+// this node's agent is doing HERE while the AgentDef keeps saying what it IS,
+// which is what lets one AgentDef serve N differently-roled states without a
+// clone per role — and it means a spawning caller can never override the
+// identity of the agent it spawns.
+//
+// The extra segment is deliberately NOT Cacheable. The agent's base prompt
+// above keeps its cache_control, so N states sharing an agent still hit ONE
+// cached prefix; marking this varying segment cacheable would move the cache
+// breakpoint past per-node text and defeat that. The prompt-cache saving is the
+// second half of the argument for not cloning an agent per role, so it is a
+// property worth pinning rather than a detail.
+//
+// Both system segments are trusted-text: each is operator-authored, the
+// AgentDef's prompt and the team definition's alike. Interpolating untrusted
+// content INTO either is a separate concern handled where that content enters,
+// not here.
+//
+// Pure, so the segment shape is unit-testable without a server.
+func composeSubRunSegments(agentSystemPrompt, systemExtra, prompt string) []loop.PromptSegment {
+	var segs []loop.PromptSegment
+	if agentSystemPrompt != "" {
+		segs = append(segs, loop.PromptSegment{
+			Role: "system",
+			Content: []loop.PromptContentBlock{{
+				Type:      "trusted-text",
+				Text:      agentSystemPrompt,
+				Cacheable: true,
+			}},
+		})
+	}
+	if systemExtra != "" {
+		segs = append(segs, loop.PromptSegment{
+			Role: "system",
+			Content: []loop.PromptContentBlock{{
+				Type: "trusted-text",
+				Text: systemExtra,
+			}},
+		})
+	}
+	return append(segs, loop.PromptSegment{
+		Role: "user",
+		Content: []loop.PromptContentBlock{{
+			Type: "trusted-text",
+			Text: prompt,
+		}},
+	})
+}
+
+func (s *Server) prepareSubRun(ctx context.Context, name, systemExtra, prompt, defID string, interactive bool, fwd func(providers.Event)) (*subRunPrep, error) {
 	// RFC N: a parent in tenant T resolves the sub-agent name within T's
 	// view (parent tenant flows via ctx RunIdentity, inherited by every
 	// sub-agent). Confirms RFC N's open-question on cross-boundary spawn:
@@ -6007,27 +6076,7 @@ func (s *Server) prepareSubRun(ctx context.Context, name, prompt, defID string, 
 		Tenant: parentIdentity.TenantID, UserID: parentIdentity.UserID, AgentName: name,
 		InitialInput: prompt, Tools: subTools,
 	})
-	// Build segments: agent's system_prompt (with cache_control) + the
-	// caller-supplied prompt as the first user message. Mirrors the
-	// shape of /v1/runs.
-	var segs []loop.PromptSegment
-	if def.SystemPrompt != "" {
-		segs = append(segs, loop.PromptSegment{
-			Role: "system",
-			Content: []loop.PromptContentBlock{{
-				Type:      "trusted-text",
-				Text:      def.SystemPrompt,
-				Cacheable: true,
-			}},
-		})
-	}
-	segs = append(segs, loop.PromptSegment{
-		Role: "user",
-		Content: []loop.PromptContentBlock{{
-			Type: "trusted-text",
-			Text: prompt,
-		}},
-	})
+	segs := composeSubRunSegments(def.SystemPrompt, systemExtra, prompt)
 
 	// Inherit the parent's caller-authoritative host policy. Without
 	// this, sub-agents fall back to the operator's static

--- a/internal/api/http/subrun_segments_test.go
+++ b/internal/api/http/subrun_segments_test.go
@@ -1,0 +1,88 @@
+package http
+
+import (
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/loop"
+)
+
+// composeSubRunSegments carries the property Decision 3 of the team-workflow
+// design rests on: a per-state system prompt is an EXTRA segment, so one
+// AgentDef serves N differently-roled states without a clone per role AND
+// without losing the prompt cache on its base prompt.
+
+func roles(segs []loop.PromptSegment) []string {
+	out := make([]string, 0, len(segs))
+	for _, s := range segs {
+		out = append(out, s.Role)
+	}
+	return out
+}
+
+func TestComposeSubRunSegments_ExtraSystemAppendsAfterTheAgentsOwn(t *testing.T) {
+	segs := composeSubRunSegments("You are a code reviewer.", "Judge only exploitability.", "the diff")
+
+	if got := roles(segs); len(got) != 3 || got[0] != "system" || got[1] != "system" || got[2] != "user" {
+		t.Fatalf("roles = %v, want [system system user]", got)
+	}
+	if segs[0].Content[0].Text != "You are a code reviewer." {
+		t.Errorf("the agent's own prompt must come FIRST; got %q", segs[0].Content[0].Text)
+	}
+	if segs[1].Content[0].Text != "Judge only exploitability." {
+		t.Errorf("the state's role must come SECOND; got %q", segs[1].Content[0].Text)
+	}
+	if segs[2].Content[0].Text != "the diff" {
+		t.Errorf("user segment = %q, want the prompt", segs[2].Content[0].Text)
+	}
+}
+
+// The load-bearing one. If the varying per-state segment were marked cacheable
+// it would push the cache breakpoint past per-node text, so N states sharing an
+// agent would each miss the cache — which is half the reason the design stores
+// prompts on the node instead of cloning the agent.
+func TestComposeSubRunSegments_OnlyTheAgentsBasePromptIsCacheable(t *testing.T) {
+	segs := composeSubRunSegments("base", "per-node role", "input")
+
+	if !segs[0].Content[0].Cacheable {
+		t.Error("the agent's base system prompt lost its cache_control — every state sharing this agent now pays full prompt cost")
+	}
+	if segs[1].Content[0].Cacheable {
+		t.Error("the per-state system segment is cacheable; it VARIES per state, so caching it moves the breakpoint past per-node text and defeats the shared prefix")
+	}
+}
+
+// A caller must not be able to replace the identity of the agent it spawns, only
+// add to it. Every non-team caller passes "" and must be unaffected.
+func TestComposeSubRunSegments_NoExtraLeavesTheShapeUnchanged(t *testing.T) {
+	segs := composeSubRunSegments("You are a code reviewer.", "", "the diff")
+
+	if got := roles(segs); len(got) != 2 || got[0] != "system" || got[1] != "user" {
+		t.Fatalf("roles = %v, want [system user] — an empty extra must add nothing", got)
+	}
+	if !segs[0].Content[0].Cacheable {
+		t.Error("base prompt should still be cacheable")
+	}
+}
+
+func TestComposeSubRunSegments_AgentWithNoPromptOfItsOwnStillGetsTheStatesRole(t *testing.T) {
+	segs := composeSubRunSegments("", "Judge only exploitability.", "the diff")
+
+	if got := roles(segs); len(got) != 2 || got[0] != "system" || got[1] != "user" {
+		t.Fatalf("roles = %v, want [system user]", got)
+	}
+	if segs[0].Content[0].Text != "Judge only exploitability." {
+		t.Errorf("system segment = %q, want the state's role", segs[0].Content[0].Text)
+	}
+	if segs[0].Content[0].Cacheable {
+		t.Error("a per-state role must not become cacheable just because the agent has no prompt of its own")
+	}
+}
+
+func TestComposeSubRunSegments_BothSystemSegmentsAreTrustedText(t *testing.T) {
+	segs := composeSubRunSegments("base", "per-node role", "input")
+	for i, seg := range segs {
+		if got := seg.Content[0].Type; got != "trusted-text" {
+			t.Errorf("segment %d type = %q, want trusted-text", i, got)
+		}
+	}
+}

--- a/internal/teamgraph/graph.go
+++ b/internal/teamgraph/graph.go
@@ -55,9 +55,15 @@ type Definition struct {
 	States        []State      `json:"states"`
 	Transitions   []Transition `json:"transitions"`
 	// Colors is presentation only (unsaturated state fills, saturated transition
-	// edges). It is EXCLUDED from the content hash (see internal/agents/teamsign)
-	// so recolouring a workflow doesn't fork its identity.
+	// edges). It is EXCLUDED from the content hash (see sign.go) so recolouring a
+	// workflow doesn't fork its identity.
 	Colors *Colors `json:"colors,omitempty"`
+	// Layout is presentation only: where a canvas draws each node. EXCLUDED from
+	// the content hash for exactly Colors' reason — dragging a node to tidy a
+	// diagram must not mint a new version, or the version history stops meaning
+	// anything. Exclusion is by omission: teamContent in sign.go is a whitelist,
+	// so a field is out of the hash unless it is listed there.
+	Layout *Layout `json:"layout,omitempty"`
 }
 
 // State is one node: an id + the handler that runs when a task is in it.
@@ -79,9 +85,41 @@ type Handler struct {
 	// picks the outgoing transition. REQUIRED for kind=parallel; OPTIONAL for
 	// kind=agent ("re-evaluate after one agent").
 	Consolidator string `json:"consolidator,omitempty"`
-	// InputTemplate / TimeoutMS — optional per-handler run config.
+	// SystemPrompt is this NODE's role, APPENDED to the agent's own system
+	// prompt as a second system segment rather than replacing it: the AgentDef
+	// says what the agent IS, the node says what it is doing here.
+	//
+	// It is why a fan-out of N reviewers is ONE AgentDef and N states. Cloning an
+	// agent per node would fork a def per role, and — because the agent's base
+	// prompt is sent with cache_control — would also lose prompt caching across
+	// nodes that share an agent. The composed segments keep the base cacheable
+	// and add this one uncached, so N nodes still hit one cached prefix.
+	//
+	// Content-identifying: Handler rides States, which teamContent hashes, so
+	// editing a node's role forks the definition. Existing defs omit the field
+	// and hash byte-identically (omitempty).
+	SystemPrompt string `json:"system_prompt,omitempty"`
+	// InputTemplate is this node's user prompt. When set it REPLACES the input
+	// threaded from the previous state; when empty the threaded input is used.
+	// Declared by RFC AP and read for the first time here.
 	InputTemplate string `json:"input_template,omitempty"`
 	TimeoutMS     int    `json:"timeout_ms,omitempty"`
+}
+
+// Layout is the optional canvas geometry: where each node sits. Presentation
+// only, and excluded from the content hash (see Definition.Layout).
+type Layout struct {
+	// Nodes maps a state id to its position. A state with no entry is
+	// auto-placed by the client.
+	Nodes map[string]NodePos `json:"nodes,omitempty"`
+}
+
+// NodePos is one node's canvas position (and optional size).
+type NodePos struct {
+	X int `json:"x"`
+	Y int `json:"y"`
+	W int `json:"w,omitempty"`
+	H int `json:"h,omitempty"`
 }
 
 // Transition is one edge: from-state → to-state, gated by an `on` label.

--- a/internal/teamgraph/sign.go
+++ b/internal/teamgraph/sign.go
@@ -7,10 +7,19 @@ import (
 )
 
 // teamContent is the closed set of content-identifying fields hashed into a
-// TeamDef's content_sha256. The COLOR scheme (presentation) and identity/tenant
-// (operational) are deliberately EXCLUDED — mirroring how `skills:` and
-// tenant_id are excluded from AgentDef's hash — so two tenants forking the same
-// workflow share a hash and recolouring never changes a def's identity.
+// TeamDef's content_sha256. It is a WHITELIST: a Definition field is out of the
+// hash unless it is listed here, which is what keeps presentation out for free.
+// Excluded deliberately: the COLOR scheme and the canvas LAYOUT (presentation —
+// recolouring or dragging a node must not fork a def's identity) and
+// identity/tenant (operational), mirroring how `skills:` and tenant_id are
+// excluded from AgentDef's hash, so two tenants forking the same workflow share
+// a hash.
+//
+// Handler fields ride States and ARE hashed — including SystemPrompt and
+// InputTemplate, so editing a node's role or its prompt forks the definition,
+// which is the intended behaviour. Both carry omitempty, so a definition that
+// omits them marshals byte-identically to one written before they existed and
+// every recorded content_sha256 stays valid.
 //
 // DO NOT reorder these fields: json.Marshal emits them in declaration order and
 // the resulting bytes are the hash input, so reordering would break every

--- a/internal/teamgraph/sign_presentation_test.go
+++ b/internal/teamgraph/sign_presentation_test.go
@@ -1,0 +1,86 @@
+package teamgraph
+
+import "testing"
+
+// The presentation fields — Colors and Layout — must never reach the content
+// hash. teamContent is a whitelist, so this holds by omission; these tests exist
+// because the property is load-bearing (dragging a node on a canvas must not
+// fork a definition) and a future edit to that struct could silently break it.
+
+func baseDef() Definition {
+	return Definition{
+		Entry: "review",
+		States: []State{
+			{ID: "review", Handler: Handler{Kind: HandlerAgent, Agent: "reviewer"}},
+			{ID: "done", Handler: Handler{Kind: HandlerTerminal}},
+		},
+		Transitions: []Transition{{From: "review", To: "done", On: OnSuccess}},
+	}
+}
+
+func TestSign_LayoutIsExcludedFromTheContentHash(t *testing.T) {
+	plain := baseDef()
+	positioned := baseDef()
+	positioned.Layout = &Layout{Nodes: map[string]NodePos{
+		"review": {X: 120, Y: 40, W: 220, H: 90},
+		"done":   {X: 480, Y: 40},
+	}}
+
+	if got, want := Sign("sdlc", positioned), Sign("sdlc", plain); got != want {
+		t.Errorf("laying out a graph changed its identity:\n  with layout: %s\n  without:     %s\n"+
+			"Dragging a node must not mint a new version — add nothing to teamContent that is presentation.", got, want)
+	}
+}
+
+func TestSign_ColorsRemainExcluded(t *testing.T) {
+	plain := baseDef()
+	coloured := baseDef()
+	coloured.Colors = &Colors{States: map[string]string{"review": "#8ecae6"}}
+
+	if Sign("sdlc", coloured) != Sign("sdlc", plain) {
+		t.Error("recolouring changed the content hash; Colors must stay out of teamContent")
+	}
+}
+
+// The complement: a node's prompts ARE content. Editing what a state tells its
+// agent to do is a change to the workflow and must fork the definition — that is
+// what makes one AgentDef safely serve N differently-roled states.
+
+func TestSign_NodePromptsAreContentIdentifying(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		apply func(*Handler)
+	}{
+		{"system_prompt", func(h *Handler) { h.SystemPrompt = "You are a security reviewer." }},
+		{"input_template", func(h *Handler) { h.InputTemplate = "Review the diff." }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			plain := baseDef()
+			edited := baseDef()
+			tc.apply(&edited.States[0].Handler)
+
+			if Sign("sdlc", edited) == Sign("sdlc", plain) {
+				t.Errorf("%s did not change the content hash; a node's prompt is content and must fork the def", tc.name)
+			}
+		})
+	}
+}
+
+// Byte stability: a definition that sets NEITHER new field must hash to exactly
+// what it hashed to before they were added. Both carry omitempty, so they
+// marshal to nothing — but the hash input is raw json.Marshal output in
+// declaration order, so a missing omitempty (or a reorder) would silently
+// invalidate every content_sha256 already recorded against a stored TeamDef.
+//
+// The literal below was produced by the code as it stood BEFORE SystemPrompt and
+// Layout existed. Do not regenerate it to make this test pass — a diff here
+// means stored hashes just became wrong.
+func TestSign_ByteStableForDefinitionsWithoutTheNewFields(t *testing.T) {
+	d := Definition{Entry: "a", States: []State{{ID: "a", Handler: Handler{Kind: HandlerTerminal}}}}
+
+	const before = "sha256:4db3ad92f133dda9bd89bcf2d6dc59daa1039e8de15ed16e2d4e60924506a0a0"
+	if got := Sign("t", d); got != before {
+		t.Errorf("content hash of an unchanged definition moved:\n  now:    %s\n  before: %s\n"+
+			"Every stored TeamDef's content_sha256 just stopped matching.", got, before)
+	}
+}

--- a/internal/teamrun/nodeprompt_test.go
+++ b/internal/teamrun/nodeprompt_test.go
@@ -1,0 +1,162 @@
+package teamrun
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/teamgraph"
+)
+
+// capturingSpawn records the full Prompt each agent was handed, so these tests
+// assert what actually reached the agent rather than only what came back.
+func capturingSpawn(mu *sync.Mutex, got map[string]Prompt) SpawnFunc {
+	return func(_ context.Context, agent string, p Prompt, _ string) (string, error) {
+		mu.Lock()
+		got[agent] = p
+		mu.Unlock()
+		return agent + ":ok", nil
+	}
+}
+
+// The point of per-node prompts: ONE AgentDef, two states, different roles, no
+// clone. This is the test that would fail if a node's SystemPrompt were dropped
+// on the way to the spawn — which is exactly what the old bare-string SpawnFunc
+// made unavoidable.
+func TestRunHandler_OneAgentTwoStatesGetTheirOwnSystemPrompts(t *testing.T) {
+	var mu sync.Mutex
+	got := map[string]Prompt{}
+	r := NewAgentRunner(func(_ context.Context, agent string, p Prompt, _ string) (string, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		got[p.System] = p // key by role: same agent, two roles
+		return "ok", nil
+	})
+
+	sec := teamgraph.State{ID: "sec", Handler: teamgraph.Handler{
+		Kind: teamgraph.HandlerAgent, Agent: "reviewer",
+		SystemPrompt: "You are a security reviewer.",
+	}}
+	style := teamgraph.State{ID: "style", Handler: teamgraph.Handler{
+		Kind: teamgraph.HandlerAgent, Agent: "reviewer",
+		SystemPrompt: "You are a style reviewer.",
+	}}
+
+	if _, err := r.RunHandler(context.Background(), sec, "the diff"); err != nil {
+		t.Fatalf("sec: %v", err)
+	}
+	if _, err := r.RunHandler(context.Background(), style, "the diff"); err != nil {
+		t.Fatalf("style: %v", err)
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("one AgentDef ran two roles but %d distinct system prompts reached it: %v", len(got), got)
+	}
+	for role, p := range got {
+		if p.Input != "the diff" {
+			t.Errorf("role %q got input %q, want the threaded input", role, p.Input)
+		}
+	}
+}
+
+func TestNodePrompt_InputTemplateReplacesTheThreadedInput(t *testing.T) {
+	h := teamgraph.Handler{Kind: teamgraph.HandlerAgent, InputTemplate: "Summarise the release notes."}
+	if got := nodePrompt(h, "previous state output"); got.Input != "Summarise the release notes." {
+		t.Errorf("input = %q, want the template", got.Input)
+	}
+}
+
+func TestNodePrompt_EmptyTemplateFallsBackToTheThreadedInput(t *testing.T) {
+	h := teamgraph.Handler{Kind: teamgraph.HandlerAgent}
+	if got := nodePrompt(h, "previous state output"); got.Input != "previous state output" {
+		t.Errorf("input = %q, want the threaded input", got.Input)
+	}
+}
+
+// A fan-out is one node with one role, so every member is handed the same
+// prompt. States whose members need different roles are separate `agent` states
+// — the shape per-node prompts exist to make cheap.
+func TestRunHandler_ParallelMembersShareTheNodesPrompt(t *testing.T) {
+	var mu sync.Mutex
+	got := map[string]Prompt{}
+	r := NewAgentRunner(func(_ context.Context, agent string, p Prompt, _ string) (string, error) {
+		mu.Lock()
+		got[agent] = p
+		mu.Unlock()
+		if agent == "judge" {
+			return "signal: success", nil
+		}
+		return agent + ":ok", nil
+	})
+
+	st := teamgraph.State{ID: "fan", Handler: teamgraph.Handler{
+		Kind: teamgraph.HandlerParallel, Agents: []string{"a", "b"},
+		Consolidator:  "judge",
+		SystemPrompt:  "Review only what you are qualified to review.",
+		InputTemplate: "Look at PR 42.",
+	}}
+	if _, err := r.RunHandler(context.Background(), st, "threaded"); err != nil {
+		t.Fatalf("RunHandler: %v", err)
+	}
+
+	for _, name := range []string{"a", "b"} {
+		if got[name].System != st.Handler.SystemPrompt {
+			t.Errorf("%s system = %q, want the node's", name, got[name].System)
+		}
+		if got[name].Input != "Look at PR 42." {
+			t.Errorf("%s input = %q, want the node's template", name, got[name].Input)
+		}
+	}
+}
+
+// A consolidator that FOLLOWS a handler is a different agent doing a different
+// job, so the node's system prompt (which describes the state's own agent) must
+// not leak onto it. It receives the results envelope and nothing else.
+func TestRunHandler_ConsolidatorDoesNotInheritTheNodesSystemPrompt(t *testing.T) {
+	var mu sync.Mutex
+	got := map[string]Prompt{}
+	r := NewAgentRunner(func(_ context.Context, agent string, p Prompt, _ string) (string, error) {
+		mu.Lock()
+		got[agent] = p
+		mu.Unlock()
+		if agent == "judge" {
+			return "signal: success", nil
+		}
+		return "work product", nil
+	})
+
+	st := teamgraph.State{ID: "review", Handler: teamgraph.Handler{
+		Kind: teamgraph.HandlerAgent, Agent: "reviewer", Consolidator: "judge",
+		SystemPrompt: "You are a security reviewer.",
+	}}
+	if _, err := r.RunHandler(context.Background(), st, "the diff"); err != nil {
+		t.Fatalf("RunHandler: %v", err)
+	}
+
+	if got["reviewer"].System != st.Handler.SystemPrompt {
+		t.Errorf("the state's own agent lost its role: %q", got["reviewer"].System)
+	}
+	if got["judge"].System != "" {
+		t.Errorf("consolidator inherited the reviewer's role %q — it is a different agent doing a different job", got["judge"].System)
+	}
+}
+
+// A STANDALONE consolidator state IS the consolidator, so the node's prompt does
+// apply to it. The mirror of the test above, and the reason the two cases are
+// wired differently.
+func TestRunHandler_StandaloneConsolidatorStateUsesItsOwnSystemPrompt(t *testing.T) {
+	var mu sync.Mutex
+	got := map[string]Prompt{}
+	r := NewAgentRunner(capturingSpawn(&mu, got))
+
+	st := teamgraph.State{ID: "judge", Handler: teamgraph.Handler{
+		Kind: teamgraph.HandlerConsolidator, Agent: "judge",
+		SystemPrompt: "Weigh the reviews and decide.",
+	}}
+	if _, err := r.RunHandler(context.Background(), st, "the reviews"); err != nil {
+		t.Fatalf("RunHandler: %v", err)
+	}
+	if got["judge"].System != st.Handler.SystemPrompt {
+		t.Errorf("standalone consolidator system = %q, want the node's", got["judge"].System)
+	}
+}

--- a/internal/teamrun/spawn.go
+++ b/internal/teamrun/spawn.go
@@ -11,11 +11,37 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/teamgraph"
 )
 
-// SpawnFunc runs one named agent with an input prompt and returns its final text
-// output. It mirrors builtin.SubAgentRunner exactly, so the orchestrator reuses
-// the existing sub-agent machinery (tenant/identity inheritance, the recursion
-// depth cap, the cancel registry) rather than re-implementing run dispatch.
-type SpawnFunc func(ctx context.Context, agent, input, defID string) (string, error)
+// Prompt is what a state hands its agent: the node's own role plus the text to
+// work on. It replaces the bare `input string` SpawnFunc used to take, which
+// could not carry a per-node system prompt at all.
+//
+// WHY A STRUCT AND NOT []loop.PromptSegment: this package's contract is that it
+// is a pure graph-walker with no runtime dependencies — importing internal/loop
+// takes teamrun from 2 internal dependencies to 21, for a type whose only use
+// here is "a system string and a user string". The server closure that
+// implements SpawnFunc already lives where the loop types are and composes the
+// segments there. If a team node ever needs multimodal input, adding a field
+// here is additive and breaks nobody.
+type Prompt struct {
+	// System is the NODE's role. The server APPENDS it to the agent's own system
+	// prompt as a second system segment rather than replacing it — see
+	// teamgraph.Handler.SystemPrompt for why that is what makes one AgentDef
+	// serve N differently-roled states.
+	System string
+	// Input is the user segment: the node's InputTemplate when it has one, else
+	// the output threaded from the previous state.
+	Input string
+}
+
+// SpawnFunc runs one named agent with a prompt and returns its final text
+// output. It mirrors builtin.SubAgentRunner, so the orchestrator reuses the
+// existing sub-agent machinery (tenant/identity inheritance, the recursion depth
+// cap, the cancel registry) rather than re-implementing run dispatch.
+//
+// The Prompt parameter replaced a bare `input string`. Widening rather than
+// adding a sibling was deliberate: it breaks every implementor at compile time,
+// and none should be silently missed.
+type SpawnFunc func(ctx context.Context, agent string, p Prompt, defID string) (string, error)
 
 // maxParallelConcurrency bounds how many of a parallel state's agents run at
 // once. It mirrors builtin.DefaultMaxConcurrentChildren (4): high enough to
@@ -53,7 +79,7 @@ type agentRunner struct {
 func (r *agentRunner) RunHandler(ctx context.Context, st teamgraph.State, input string) (Outcome, error) {
 	switch st.Handler.Kind {
 	case teamgraph.HandlerAgent:
-		out, err := r.spawn(ctx, st.Handler.Agent, input, "")
+		out, err := r.spawn(ctx, st.Handler.Agent, nodePrompt(st.Handler, input), "")
 		if err != nil {
 			return Outcome{}, err
 		}
@@ -88,8 +114,9 @@ func (r *agentRunner) RunHandler(ctx context.Context, st teamgraph.State, input 
 		// A standalone judging state: run the agent on the threaded input; its
 		// output selects the edge. Unlike a Consolidator that follows a fan-out,
 		// it reads the raw work product (not a results envelope) — it judges the
-		// previous state's output directly.
-		out, err := r.spawn(ctx, st.Handler.Agent, input, "")
+		// previous state's output directly. This state IS the consolidator, so
+		// the node's own system prompt applies to it.
+		out, err := r.spawn(ctx, st.Handler.Agent, nodePrompt(st.Handler, input), "")
 		if err != nil {
 			return Outcome{}, err
 		}
@@ -99,6 +126,23 @@ func (r *agentRunner) RunHandler(ctx context.Context, st teamgraph.State, input 
 		// terminal is handled by the walk; anything else is a validation gap.
 		return Outcome{}, fmt.Errorf("unexpected handler kind %q", st.Handler.Kind)
 	}
+}
+
+// nodePrompt composes what a state hands its agent: the node's system prompt,
+// and its InputTemplate when set — otherwise the input threaded from the
+// previous state.
+//
+// A template REPLACES the threaded input rather than being prepended to it. That
+// is the RFC AP field's declared meaning, and it keeps the rule simple: a state
+// either works on what it was handed, or it states its own task. Referring to
+// the threaded input from inside a template needs the variable expander, which
+// is the next phase; until then a template is used verbatim.
+func nodePrompt(h teamgraph.Handler, threaded string) Prompt {
+	in := threaded
+	if h.InputTemplate != "" {
+		in = h.InputTemplate
+	}
+	return Prompt{System: h.SystemPrompt, Input: in}
 }
 
 // runParallel fans a parallel state's agents out concurrently with bounded
@@ -118,6 +162,10 @@ func (r *agentRunner) RunHandler(ctx context.Context, st teamgraph.State, input 
 // so wait:all awaits every agent as documented.
 func (r *agentRunner) runParallel(ctx context.Context, st teamgraph.State, input string) ([]agentResult, error) {
 	agents := st.Handler.Agents
+	// One node, one role: every member of a fan-out shares this state's system
+	// prompt and input. States whose members need DIFFERENT roles are separate
+	// `agent` states, which is the shape per-node prompts exist to make cheap.
+	prompt := nodePrompt(st.Handler, input)
 	n := len(agents)
 	need, err := requiredSuccesses(st.Handler.Wait, n)
 	if err != nil {
@@ -147,7 +195,7 @@ func (r *agentRunner) runParallel(ctx context.Context, st teamgraph.State, input
 				results[i] = agentResult{Index: i, Agent: name, Ok: false, Error: runCtx.Err().Error()}
 				return
 			}
-			out, spawnErr := r.spawn(runCtx, name, input, "")
+			out, spawnErr := r.spawn(runCtx, name, prompt, "")
 			if spawnErr != nil {
 				results[i] = agentResult{Index: i, Agent: name, Ok: false, Error: spawnErr.Error()}
 				return
@@ -182,8 +230,11 @@ func (r *agentRunner) runParallel(ctx context.Context, st teamgraph.State, input
 
 // runConsolidator runs the consolidator agent on the results envelope and maps
 // its output to an Outcome via the signal convention.
+// The consolidator is a DIFFERENT agent from the state's own, so the node's
+// system prompt (which describes that agent's role) is deliberately not applied
+// to it; it receives only the envelope.
 func (r *agentRunner) runConsolidator(ctx context.Context, consolidator, envelope string) (Outcome, error) {
-	out, err := r.spawn(ctx, consolidator, envelope, "")
+	out, err := r.spawn(ctx, consolidator, Prompt{Input: envelope}, "")
 	if err != nil {
 		return Outcome{}, err
 	}

--- a/internal/teamrun/spawn_test.go
+++ b/internal/teamrun/spawn_test.go
@@ -12,7 +12,9 @@ import (
 // under mu, then delegates to fn. calls/inputs are safe to read after Walk
 // returns (Walk joins all goroutines before returning).
 func recordingSpawn(mu *sync.Mutex, calls *[]string, inputs map[string]string, fn func(ctx context.Context, agent, input string) (string, error)) SpawnFunc {
-	return func(ctx context.Context, agent, input, defID string) (string, error) {
+	return func(ctx context.Context, agent string, p Prompt, defID string) (string, error) {
+		input := p.Input
+
 		mu.Lock()
 		*calls = append(*calls, agent)
 		if inputs != nil {
@@ -29,7 +31,9 @@ func TestAgentRunner_WalksLinearTeamViaSpawn(t *testing.T) {
 	// Fake spawn: echoes which agent ran + the input, so we can assert the
 	// output threads state to state.
 	var spawned []string
-	spawn := func(_ context.Context, agent, input, defID string) (string, error) {
+	spawn := func(_ context.Context, agent string, p Prompt, defID string) (string, error) {
+		input := p.Input
+
 		spawned = append(spawned, agent)
 		return fmt.Sprintf("%s(%s)", agent, input), nil
 	}
@@ -53,7 +57,8 @@ func TestAgentRunner_WalksLinearTeamViaSpawn(t *testing.T) {
 
 func TestAgentRunner_SpawnErrorStopsWalk(t *testing.T) {
 	d := mustParse(t, linearJSON)
-	spawn := func(_ context.Context, agent, input, defID string) (string, error) {
+	spawn := func(_ context.Context, agent string, p Prompt, defID string) (string, error) {
+
 		if agent == "agent-b" {
 			return "", fmt.Errorf("boom")
 		}
@@ -204,7 +209,8 @@ func TestAgentRunner_ParallelWaitAtLeastCancelsOnceThresholdMet(t *testing.T) {
 func TestAgentRunner_ParallelWaitAllAgentErrorAborts(t *testing.T) {
 	d := mustParse(t, parallelJSON)
 	consolidatorCalled := false
-	spawn := func(_ context.Context, agent, input, defID string) (string, error) {
+	spawn := func(_ context.Context, agent string, p Prompt, defID string) (string, error) {
+
 		switch agent {
 		case "a":
 			return "A-out", nil
@@ -286,7 +292,8 @@ func TestAgentRunner_PushbackCycleHitsIterationCap(t *testing.T) {
 	// A judge that ALWAYS pushes back never converges; the per-state cap must
 	// bound the loop rather than spin forever.
 	d := mustParse(t, pushbackJSON) // max_iterations:3
-	spawn := func(_ context.Context, agent, input, defID string) (string, error) {
+	spawn := func(_ context.Context, agent string, p Prompt, defID string) (string, error) {
+
 		switch agent {
 		case "coder":
 			return "code", nil

--- a/internal/tools/builtin/teamdef.go
+++ b/internal/tools/builtin/teamdef.go
@@ -878,6 +878,13 @@ func applyTeamOverlay(base *teamgraph.Definition, ov teamgraph.Definition) {
 	if ov.Colors != nil {
 		base.Colors = ov.Colors
 	}
+	// Layout is how a canvas persists node positions, so a missing case here is
+	// not a cosmetic gap: the fork succeeds and every position is silently gone.
+	// Presentation, like Colors — and like Colors it is excluded from the content
+	// hash, so a layout-only fork keeps the parent's identity.
+	if ov.Layout != nil {
+		base.Layout = ov.Layout
+	}
 }
 
 func (t *TeamDef) checkSizeCaps(defJSON []byte, description string) error {

--- a/internal/tools/builtin/teamdef_layout_test.go
+++ b/internal/tools/builtin/teamdef_layout_test.go
@@ -1,0 +1,81 @@
+package builtin
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// A canvas persists node positions by forking with a `layout`. applyTeamOverlay
+// merges the definition PER TOP-LEVEL FIELD, so a field it does not name is
+// silently dropped — the save appears to succeed and the positions are gone.
+// Colors had this handled; Layout is its exact sibling and needs the same case.
+func TestTeamDefTool_Fork_PersistsLayout(t *testing.T) {
+	tool, ctx, done := teamDefFixture(t)
+	defer done()
+
+	createTeam(t, tool, ctx, "layout-team", `{
+	  "entry":"review",
+	  "states":[
+	    {"state":"review","handler":{"kind":"agent","agent":"reviewer"}},
+	    {"state":"done","handler":{"kind":"terminal"}}
+	  ],
+	  "transitions":[{"from":"review","to":"done","on":"success"}]
+	}`)
+
+	res, _ := tool.Execute(ctx, json.RawMessage(
+		`{"op":"fork","name":"layout-team","overlay":{"layout":{"nodes":{"review":{"x":120,"y":40,"w":220,"h":90},"done":{"x":480,"y":40}}}}}`))
+	if res.IsError {
+		t.Fatalf("fork: %s", res.Text)
+	}
+	forked := decodeResult(t, res.Text)
+
+	defJSON, _ := json.Marshal(forked["definition"])
+	if !strings.Contains(string(defJSON), `"layout"`) {
+		t.Fatalf("the fork dropped `layout` — a canvas save would silently lose every node position.\nstored definition: %s", defJSON)
+	}
+
+	var got struct {
+		Layout struct {
+			Nodes map[string]struct{ X, Y, W, H int } `json:"nodes"`
+		} `json:"layout"`
+		States []json.RawMessage `json:"states"`
+	}
+	if err := json.Unmarshal(defJSON, &got); err != nil {
+		t.Fatalf("unmarshal stored definition: %v", err)
+	}
+	if n := got.Layout.Nodes["review"]; n.X != 120 || n.Y != 40 || n.W != 220 || n.H != 90 {
+		t.Errorf("review position = %+v, want {120 40 220 90}", n)
+	}
+	// A layout-only fork must not disturb the graph it is laying out.
+	if len(got.States) != 2 {
+		t.Errorf("states = %d, want 2 — a layout overlay must not replace the graph", len(got.States))
+	}
+}
+
+// The complement, and the reason Layout is worth carrying: laying a graph out
+// must not change its identity, so a layout-only fork keeps the parent's hash.
+func TestTeamDefTool_Fork_LayoutDoesNotChangeContentHash(t *testing.T) {
+	tool, ctx, done := teamDefFixture(t)
+	defer done()
+
+	created := createTeam(t, tool, ctx, "hash-team", `{
+	  "entry":"review",
+	  "states":[
+	    {"state":"review","handler":{"kind":"agent","agent":"reviewer"}},
+	    {"state":"done","handler":{"kind":"terminal"}}
+	  ],
+	  "transitions":[{"from":"review","to":"done","on":"success"}]
+	}`)
+
+	res, _ := tool.Execute(ctx, json.RawMessage(
+		`{"op":"fork","name":"hash-team","overlay":{"layout":{"nodes":{"review":{"x":999,"y":777}}}}}`))
+	if res.IsError {
+		t.Fatalf("fork: %s", res.Text)
+	}
+	forked := decodeResult(t, res.Text)
+
+	if got, want := forked["content_sha256"], created["content_sha256"]; got != want {
+		t.Errorf("laying out the graph changed its identity:\n  forked: %v\n  parent: %v", got, want)
+	}
+}

--- a/internal/tools/builtin/teamdef_test.go
+++ b/internal/tools/builtin/teamdef_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/teamrun"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
 
@@ -59,7 +60,9 @@ func TestTeamDefTool_Run_LinearTeam(t *testing.T) {
 	defer done()
 
 	var spawned []string
-	tool.Spawn = func(_ context.Context, agent, input, defID string) (string, error) {
+	tool.Spawn = func(_ context.Context, agent string, p teamrun.Prompt, defID string) (string, error) {
+		input := p.Input
+
 		spawned = append(spawned, agent)
 		return agent + "(" + input + ")", nil
 	}
@@ -103,7 +106,8 @@ func TestTeamDefTool_Run_AdmitRefusalAbortsBeforeSpawn(t *testing.T) {
 	defer done()
 
 	spawnCalled := false
-	tool.Spawn = func(_ context.Context, agent, input, defID string) (string, error) {
+	tool.Spawn = func(_ context.Context, agent string, p teamrun.Prompt, defID string) (string, error) {
+
 		spawnCalled = true
 		return "ok", nil
 	}
@@ -140,7 +144,8 @@ func TestTeamDefTool_Run_AdmittedCtxFlowsToSpawn(t *testing.T) {
 		return context.WithValue(c, admitMarkerKey{}, "admitted"), nil
 	}
 	sawMarker := false
-	tool.Spawn = func(c context.Context, agent, input, defID string) (string, error) {
+	tool.Spawn = func(c context.Context, agent string, p teamrun.Prompt, defID string) (string, error) {
+
 		if c.Value(admitMarkerKey{}) == "admitted" {
 			sawMarker = true
 		}
@@ -178,7 +183,9 @@ func TestTeamDefTool_Run_NotConfigured(t *testing.T) {
 func TestTeamDefTool_Run_IterationCap(t *testing.T) {
 	tool, ctx, done := teamDefFixture(t)
 	defer done()
-	tool.Spawn = func(_ context.Context, agent, input, defID string) (string, error) { return "ok", nil }
+	tool.Spawn = func(_ context.Context, agent string, p teamrun.Prompt, defID string) (string, error) {
+		return "ok", nil
+	}
 
 	// a ⇄ b ping-pong on success (no terminal reachable) → the walk never
 	// converges and the per-state cap must fire.
@@ -210,7 +217,9 @@ func TestTeamDefTool_Run_IterationCap(t *testing.T) {
 func TestTeamDefTool_Run_UnknownTeam(t *testing.T) {
 	tool, ctx, done := teamDefFixture(t)
 	defer done()
-	tool.Spawn = func(_ context.Context, agent, input, defID string) (string, error) { return "", nil }
+	tool.Spawn = func(_ context.Context, agent string, p teamrun.Prompt, defID string) (string, error) {
+		return "", nil
+	}
 	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"run","name":"ghost","input":"x"}`))
 	if !res.IsError || !strings.Contains(res.Text, "not found") {
 		t.Fatalf("unknown team should be not-found; got %q (isErr=%v)", res.Text, res.IsError)
@@ -222,7 +231,8 @@ func TestTeamDefTool_Run_ParallelFanOutConsolidates(t *testing.T) {
 	defer done()
 	// x/y fan out concurrently; the consolidator c reads their results and
 	// selects the success edge via the signal convention.
-	tool.Spawn = func(_ context.Context, agent, input, defID string) (string, error) {
+	tool.Spawn = func(_ context.Context, agent string, p teamrun.Prompt, defID string) (string, error) {
+
 		if agent == "c" {
 			return "signal: success", nil
 		}
@@ -608,7 +618,9 @@ const pingPongTeam = `{
 func TestTeamDefTool_Run_BoardPersistsStatusAcrossTransitions(t *testing.T) {
 	tool, ctx, done := teamDefFixture(t)
 	defer done()
-	tool.Spawn = func(_ context.Context, agent, input, defID string) (string, error) { return agent + "!", nil }
+	tool.Spawn = func(_ context.Context, agent string, p teamrun.Prompt, defID string) (string, error) {
+		return agent + "!", nil
+	}
 	board := &fakeBoard{exists: true}
 	tool.Board = board
 	createTeam(t, tool, ctx, "board-linear", linearBoardTeam)
@@ -636,7 +648,8 @@ func TestTeamDefTool_Run_BoardResumesFromPersistedState(t *testing.T) {
 	tool, ctx, done := teamDefFixture(t)
 	defer done()
 	var spawned []string
-	tool.Spawn = func(_ context.Context, agent, input, defID string) (string, error) {
+	tool.Spawn = func(_ context.Context, agent string, p teamrun.Prompt, defID string) (string, error) {
+
 		spawned = append(spawned, agent)
 		return agent + "!", nil
 	}
@@ -669,7 +682,9 @@ func TestTeamDefTool_Run_BoardResumesFromPersistedState(t *testing.T) {
 func TestTeamDefTool_Run_InterruptOnCapContinuesThenAborts(t *testing.T) {
 	tool, ctx, done := teamDefFixture(t)
 	defer done()
-	tool.Spawn = func(_ context.Context, agent, input, defID string) (string, error) { return "ok", nil }
+	tool.Spawn = func(_ context.Context, agent string, p teamrun.Prompt, defID string) (string, error) {
+		return "ok", nil
+	}
 	asked := 0
 	tool.AskHuman = func(_ context.Context, _ string) (string, error) {
 		asked++
@@ -704,7 +719,9 @@ func TestTeamDefTool_Run_InterruptOnCapContinuesThenAborts(t *testing.T) {
 func TestTeamDefTool_Run_InterruptOnCapReroutesToTerminal(t *testing.T) {
 	tool, ctx, done := teamDefFixture(t)
 	defer done()
-	tool.Spawn = func(_ context.Context, agent, input, defID string) (string, error) { return "ok", nil }
+	tool.Spawn = func(_ context.Context, agent string, p teamrun.Prompt, defID string) (string, error) {
+		return "ok", nil
+	}
 	tool.AskHuman = func(_ context.Context, _ string) (string, error) { return "reroute:done", nil }
 	createTeam(t, tool, ctx, "intr-reroute", `{
 	  "entry":"a","max_iterations":2,
@@ -743,7 +760,9 @@ func TestTeamDefTool_Run_InterruptOnCapReroutesToTerminal(t *testing.T) {
 func TestTeamDefTool_Run_DefaultPathIgnoresBoardAndInterrupt(t *testing.T) {
 	tool, ctx, done := teamDefFixture(t)
 	defer done()
-	tool.Spawn = func(_ context.Context, agent, input, defID string) (string, error) { return "ok", nil }
+	tool.Spawn = func(_ context.Context, agent string, p teamrun.Prompt, defID string) (string, error) {
+		return "ok", nil
+	}
 	board := &fakeBoard{exists: true}
 	tool.Board = board
 	asked := 0
@@ -780,7 +799,9 @@ func TestTeamDefTool_Run_DefaultPathIgnoresBoardAndInterrupt(t *testing.T) {
 func TestTeamDefTool_Run_BoardChunkIDWithoutBoardWiredErrors(t *testing.T) {
 	tool, ctx, done := teamDefFixture(t)
 	defer done()
-	tool.Spawn = func(_ context.Context, agent, input, defID string) (string, error) { return "ok", nil }
+	tool.Spawn = func(_ context.Context, agent string, p teamrun.Prompt, defID string) (string, error) {
+		return "ok", nil
+	}
 	// tool.Board left nil.
 	createTeam(t, tool, ctx, "board-missing", linearBoardTeam)
 	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"run","name":"board-missing","input":"x","board_chunk_id":"c1"}`))


### PR DESCRIPTION
**RFC CY phase L1** — the keystone that unblocks the workflow canvas (RFC CZ). Substrate only: no client changes, no wire break, no schema migration.

## Why

A team node named an AgentDef and nothing else, so two states using one agent for two different roles were **not expressible**. The only workaround was a **clone per role**, which forks a definition per node, sprays the Library with near-identical agents, and — because an agent's own system prompt is sent with `cache_control` — makes every clone **miss the prompt cache** the original was warming. A canvas makes that worse by turning node creation into a gesture.

## What

**1. `teamgraph.Handler.SystemPrompt`** — the *node's* role. The server **appends** it to the agent's own system prompt as a second system segment rather than replacing it: the AgentDef says what the agent **is**, the node says what it is doing **here**. A fan-out of N reviewers becomes **one AgentDef and N states**.

**2. `Handler.InputTemplate` is finally read.** It was declared by RFC AP and used **nowhere** in the repo — verified across Go, TS and docs. Set → replaces the input threaded from the previous state; empty → the threaded input is used. Referring to the threaded input *from inside* a template needs the variable expander (L2); until then a template is verbatim.

**3. `teamrun.SpawnFunc` widened** from a bare `input string` to `Prompt{System, Input}`. Widening rather than adding a sibling was deliberate — it breaks every implementor at compile time, and it did: **one production call site and 17 test closures**, none silently missed.

> **Deviation from the RFC, with its reason.** The RFC wrote this as `[]loop.PromptSegment`. `teamrun`'s stated contract is that it is a pure graph-walker with no runtime dependencies, and importing `internal/loop` takes it from **2 internal dependencies to 21** — measured — for a type whose only use here is *"a system string and a user string"*. The server closure implementing `SpawnFunc` already lives where the loop types are and composes segments there. Adding a field later is additive and breaks nobody.

**4. `Definition.Layout`** — canvas geometry, **excluded from `content_sha256`** for exactly `Colors`' reason: dragging a node to tidy a diagram must not mint a new version, or version history stops meaning anything. Exclusion is by omission (`teamContent` is a whitelist), which is *why* it now has a test.

**5. `composeSubRunSegments` extracted** as a pure function, so the segment shape is unit-testable without standing up a server.

### Two deliberate asymmetries, both tested

- A consolidator that **follows** a handler does **not** inherit the node's system prompt — it is a different agent doing a different job — while a **standalone** consolidator state **does**, because that state *is* the consolidator.
- The per-state segment is **not** `Cacheable`. The agent's base prompt keeps its `cache_control`, so N states sharing an agent still hit **one** cached prefix; marking the varying segment cacheable would move the breakpoint past per-node text and defeat it. That saving is the second half of the argument against cloning, so it is pinned rather than assumed.

`Walk` is untouched, per RFC AP's invariant. The Agent tool **cannot** set the extra segment — `RunDetailed` became a closure passing `""` specifically so a spawning agent can never prepend text to its child's system prompt.

## The second commit: a bug my own change introduced

`applyTeamOverlay` merges a fork's overlay **per top-level field**, so a field it doesn't name is dropped. Adding `Definition.Layout` without adding its case meant a fork would return 200, mint a version, and **silently lose every node position** — the silent-config-discard shape, in the worst possible place, since saving positions is the most frequent write a canvas makes.

Found in the **self-review pass**, not by a failing test. Fixed in its own commit with a fail-before-verified regression test.

## What was tested

**18 new unit tests**; `go test ./...` clean (**99 packages**, full output grepped for `FAIL` rather than tailed).

- **teamgraph** — `Layout` and `Colors` excluded from the hash; `SystemPrompt` and `InputTemplate` **are** content-identifying; and **byte stability**: a definition setting neither new field hashes to the literal it hashed to *before they existed*, so no stored `content_sha256` moved.
- **teamrun** — one AgentDef across two states receives two distinct roles; template replaces / empty falls back; parallel members share the node's prompt; both consolidator cases.
- **api/http** — the extra segment appends after the agent's own, only the base is cacheable, an empty extra leaves the shape unchanged, both system segments are `trusted-text`.
- **builtin** — a fork persists `layout` without replacing the graph, and a layout-only fork keeps the parent's hash.

**Three invariants verified fail-before** by breaking them one at a time: adding `Layout` to `teamContent` (hash test fails), marking the per-state segment cacheable (cache test fails), and dropping `SystemPrompt` from `nodePrompt` (two roles collapse to one). Plus the layout-fork test above.

**End-to-end against a local instance** (mock provider), reading the **persisted `user_input` events** — the authoritative record of what was actually sent:

| | sub-run 1 (`sec`) | sub-run 2 (`style`) |
|---|---|---|
| `[0]` system, `cacheable=true` | `"You are a careful reviewer."` | **same** — one shared cached prefix |
| `[1]` system, `cacheable=false` | `"You are a SECURITY reviewer…"` | `"You are a STYLE reviewer…"` |
| `[2]` user | `"Review PR 42 for security."` ← template replaced | previous state's output ← fell back |

One AgentDef, two roles, no clone; and a layout-only fork returned a byte-identical `content_sha256`.

## Next

L2 (the `${var.*}` expander) and L3 (the `{{…}}` binding families, which carry the security weight). RFC CZ's P0 needs none of them, so the canvas work proceeds in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD