### PR TITLE
fix(memory): every fact gets a chunk, without inventing a subject

### DIFF
--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -679,6 +679,8 @@ agents:
           // Next pass will try again; within a pass, once is enough.
           judge_attempted: {},
           entity_failed: 0,         // entity writes that failed (k/v still landed)
+          fact_no_subject: 0,       // facts chunked with no subject node (extractor named none)
+          type_absent: 0,           // subjects filed under the fallback because no type was given
           entity_type_refused: 0,   // typed facts whose type was a statement class
           watermark: null,          // the LAST scan row actually consolidated, by reference
           advanced: null,
@@ -1302,12 +1304,19 @@ agents:
           if (TRANSIENT_ID.test(text)) { st.transient++; continue; }
           // type/subject are the entity half and are OPTIONAL — a fact that names
           // no single thing is still a fact worth keeping, so a missing pair is
-          // carried as "" rather than dropping the row. They travel TOGETHER: one
-          // without the other cannot form an entity identity, and half a pair is
-          // more likely a model slip than a partial truth, so both are cleared.
+          // carried as "" rather than dropping the row.
+          //
+          // They no longer travel TOGETHER, because the two halves are not equally
+          // recoverable. A SUBJECT with no type still forms an identity:
+          // ENTITY_FALLBACK_TYPE supplies the kind, `object:denn` is one findable
+          // node, and two subjects still slug to two keys — so clearing the subject
+          // discarded the half with NO substitute in order to protect the half that
+          // already had a default. A TYPE with no subject is genuinely unusable:
+          // there is nothing to name a node after, and the orphan kind would reach
+          // the judge's mistyping check, which needs the pair to mean anything.
           var typ = (typeof f.type === "string") ? f.type.trim().toLowerCase() : "";
           var subj = (typeof f.subject === "string") ? f.subject.trim() : "";
-          if (!typ || !subj) { typ = ""; subj = ""; }
+          if (!subj) { typ = ""; }
           // The validity interval is OPTIONAL and validated shallowly: an
           // unparseable or reversed interval is dropped while the FACT is kept,
           // because a good fact with a bad date is still a good fact, and
@@ -2447,51 +2456,94 @@ agents:
         return "";
       }
 
-      // mirrorEntity writes the subject node, the fact node and the edge between
-      // them. Called after the k/v write has already succeeded.
+      // nonEmpty reports a USABLE string field — present, a string, and not merely
+      // whitespace. The extractor omits a key, sends null, and sends "" for the same
+      // "I do not know", so all three have to read the same way.
+      function nonEmpty(v) { return typeof v === "string" && v.trim() !== ""; }
+
+      // mirrorEntity writes the fact node and — when the fact actually names something
+      // — a subject node plus the edge between them. Called after the k/v write has
+      // already succeeded.
+      //
+      // EVERY FACT GETS A CHUNK. This used to return early unless the extractor supplied
+      // BOTH a type and a subject, which left the fact in k/v with no graph presence at
+      // all: MEASURED at 249 of 1,225 facts, 20.3%, on a real pass. That was affordable
+      // while the k/v row was the fact's home. It stops being affordable the moment the
+      // chunk becomes the ONLY home, because then a fifth of every corpus vanishes.
+      //
+      // The two halves of that old guard are NOT the same problem, and collapsing them
+      // into one condition is what made the gap so wide:
+      //
+      //   A missing TYPE is a naming problem. The subject is a real thing that WAS
+      //   named; only its kind is unknown. ENTITY_FALLBACK_TYPE already exists for
+      //   exactly this case ("the proposed type cannot be used") and an absent type is a
+      //   special case of it. `object:denn` is one findable node about one real thing,
+      //   and two different subjects still slug to two different keys.
+      //
+      //   A missing SUBJECT is not. There is no thing to make a node for, and inventing
+      //   one is precisely how two different things end up merged onto a single node. A
+      //   shared placeholder would be worse than no edge: it would collect every
+      //   unattributed fact onto one hub, and a traversal would then report the team's
+      //   shipping cadence and the Friday release rule as related. So the fact node is
+      //   written, and the subject node and edge are skipped — the fact keeps its home,
+      //   the graph stays honest, and st.fact_no_subject counts the gap so it reads as
+      //   work still to do instead of a silent default.
       function mirrorEntity(st, key, fact, scope) {
-        if (!fact.type || !fact.subject) { return; } // untyped fact: k/v only (by design)
         scope = scope || CONFIG.scope;
         var docID = entitiesDoc(st, scope);
         if (!docID) { return; }
 
-        // A statement class is not an entity type — "preference:user" reads as "the entity
-        // of type preference named user". It used to be DROPPED, which lost the subject; the
-        // subject itself ("user") was never the problem, only the kind. Filed under the
-        // fallback instead, so the facts stay reachable. NOT proposed as a candidate: these
-        // names are already declared, they are simply being misused as a kind.
-        var proposed = fact.type;
-        if (ENTITY_TYPE_DENY[proposed] === true) {
-          st.entity_type_refused++;
-          proposed = ENTITY_FALLBACK_TYPE;
-        }
+        var subjID = "";
+        if (nonEmpty(fact.subject)) {
+          // A statement class is not an entity type — "preference:user" reads as "the entity
+          // of type preference named user". It used to be DROPPED, which lost the subject; the
+          // subject itself ("user") was never the problem, only the kind. Filed under the
+          // fallback instead, so the facts stay reachable. NOT proposed as a candidate: these
+          // names are already declared, they are simply being misused as a kind.
+          var proposed = fact.type;
+          // An ABSENT type is the same problem as an unusable one: the subject was named,
+          // its kind was not. Filed under the fallback so the subject still gets its node,
+          // rather than the missing kind costing the fact its place in the graph.
+          if (!nonEmpty(proposed)) {
+            st.type_absent++;
+            proposed = ENTITY_FALLBACK_TYPE;
+          } else if (ENTITY_TYPE_DENY[proposed] === true) {
+            st.entity_type_refused++;
+            proposed = ENTITY_FALLBACK_TYPE;
+          }
 
-        // The type this subject is ALREADY filed under wins over this call's guess, so one
-        // subject is one node however many ways the extractor spells its kind.
-        var subjType = canonicalType(st, scope, proposed, fact.subject);
-        var subjKey = entityKey(subjType, fact.subject);
-        var isNewSubject = !st.entity_ids[scope + "\u0000" + subjKey];
-        var subjID = upsertEntityChunk(st, scope, docID, subjKey, {
-          title: fact.subject, type: subjType, subject: fact.subject
-        });
-        // UNDECLARED TYPE: the write was refused because the tenant does not declare this
-        // kind. File the kind as an inert candidate an operator can accept, then retry under
-        // the fallback — the key has to move with the type, since the type is part of a
-        // subject node's identity.
-        if (!subjID && subjType !== ENTITY_FALLBACK_TYPE && undeclaredTypeRefusal(st)) {
-          proposeOntologyType(st, subjType);
-          st.type_fell_back++;
-          // Remember the fallback for this subject so the rest of the pass agrees with it.
-          st.subject_types[scope + "\u0000" + slug(normalizeSubject(fact.subject))] = ENTITY_FALLBACK_TYPE;
-          subjType = ENTITY_FALLBACK_TYPE;
-          subjKey = entityKey(subjType, fact.subject);
-          isNewSubject = !st.entity_ids[scope + "\u0000" + subjKey];
+          // The type this subject is ALREADY filed under wins over this call's guess, so one
+          // subject is one node however many ways the extractor spells its kind.
+          var subjType = canonicalType(st, scope, proposed, fact.subject);
+          var subjKey = entityKey(subjType, fact.subject);
+          var isNewSubject = !st.entity_ids[scope + "\u0000" + subjKey];
           subjID = upsertEntityChunk(st, scope, docID, subjKey, {
             title: fact.subject, type: subjType, subject: fact.subject
           });
+          // UNDECLARED TYPE: the write was refused because the tenant does not declare this
+          // kind. File the kind as an inert candidate an operator can accept, then retry under
+          // the fallback — the key has to move with the type, since the type is part of a
+          // subject node's identity.
+          if (!subjID && subjType !== ENTITY_FALLBACK_TYPE && undeclaredTypeRefusal(st)) {
+            proposeOntologyType(st, subjType);
+            st.type_fell_back++;
+            // Remember the fallback for this subject so the rest of the pass agrees with it.
+            st.subject_types[scope + "\u0000" + slug(normalizeSubject(fact.subject))] = ENTITY_FALLBACK_TYPE;
+            subjType = ENTITY_FALLBACK_TYPE;
+            subjKey = entityKey(subjType, fact.subject);
+            isNewSubject = !st.entity_ids[scope + "\u0000" + subjKey];
+            subjID = upsertEntityChunk(st, scope, docID, subjKey, {
+              title: fact.subject, type: subjType, subject: fact.subject
+            });
+          }
+          // A REFUSED subject write no longer costs the fact its chunk either. The
+          // existing safety property is that a graph failure degrades to "no edge" and
+          // never to "no fact"; once the chunk is the fact's home, that property has to
+          // cover the chunk and not just the k/v row.
+          if (subjID && isNewSubject) { st.entity_nodes++; }
+        } else {
+          st.fact_no_subject++;
         }
-        if (!subjID) { return; }
-        if (isNewSubject) { st.entity_nodes++; }
 
         // The fact node carries the sentence; its title is the sentence too,
         // trimmed, because a chunk with no title is unreadable in the Path browser.
@@ -2528,20 +2580,24 @@ agents:
           }
         }
 
-        try {
-          // `scope`, NOT CONFIG.scope. Every other write in this function already
-          // threads the placed scope; this one did not, so a fact the ontology sent
-          // to the tenant plane got its subject node and its fact node there and
-          // then tried to join them in the caller's scope, where neither exists.
-          // The two nodes were stored and the edge silently was not — leaving a
-          // placed fact unreachable from the person it is about, which is the whole
-          // reason the entity tier exists. Measured live: 3 facts placed, 3 edges
-          // lost, 0 inbound edges on the subject.
-          Document({ op: "link_chunks", scope: scope,
-                     from_id: factID, to_id: subjID, kind: "about" });
-        } catch (e) {
-          st.entity_failed++; // the nodes exist; only the edge is missing
-          if (!st.entity_error) { st.entity_error = errText(e); }
+        // No subject node means there is nothing to point an edge at. The fact is
+        // already stored; it is simply not reachable by traversal.
+        if (subjID) {
+          try {
+            // `scope`, NOT CONFIG.scope. Every other write in this function already
+            // threads the placed scope; this one did not, so a fact the ontology sent
+            // to the tenant plane got its subject node and its fact node there and
+            // then tried to join them in the caller's scope, where neither exists.
+            // The two nodes were stored and the edge silently was not — leaving a
+            // placed fact unreachable from the person it is about, which is the whole
+            // reason the entity tier exists. Measured live: 3 facts placed, 3 edges
+            // lost, 0 inbound edges on the subject.
+            Document({ op: "link_chunks", scope: scope,
+                       from_id: factID, to_id: subjID, kind: "about" });
+          } catch (e) {
+            st.entity_failed++; // the nodes exist; only the edge is missing
+            if (!st.entity_error) { st.entity_error = errText(e); }
+          }
         }
       }
 
@@ -3150,7 +3206,7 @@ agents:
         // The entity half, reported even when zero: a pass that mirrored nothing
         // because no fact was typed looks identical to one where every Document
         // call failed, and those need different fixes.
-        if (st.entity_facts || st.entity_nodes || st.entity_failed || st.entity_type_refused) {
+        if (st.entity_facts || st.entity_nodes || st.entity_failed || st.entity_type_refused || st.fact_no_subject) {
           var ent = "entities " + st.entity_facts + " fact(s) across " + st.entity_nodes + " subject(s)";
           if (st.entity_failed) {
             ent += ", " + st.entity_failed + " graph write(s) failed";
@@ -3163,6 +3219,16 @@ agents:
           }
           if (st.type_proposed) {
             ent += ", " + st.type_proposed + " new type(s) proposed for an operator to accept";
+          }
+          // Reported because it is a YIELD gap, not an error: these facts are stored and
+          // searchable, they are just not reachable by traversal. Left silent it looks
+          // like the graph covers the corpus when it covers only part of it.
+          if (st.fact_no_subject) {
+            ent += ", " + st.fact_no_subject + " fact(s) chunked with no subject named";
+          }
+          if (st.type_absent) {
+            ent += ", " + st.type_absent + " subject(s) filed under " + ENTITY_FALLBACK_TYPE +
+              " because no type was given";
           }
           if (st.type_lookup_failed) {
             ent += ", " + st.type_lookup_failed + " subject-type lookup(s) failed";

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -679,6 +679,8 @@ agents:
           // Next pass will try again; within a pass, once is enough.
           judge_attempted: {},
           entity_failed: 0,         // entity writes that failed (k/v still landed)
+          fact_no_subject: 0,       // facts chunked with no subject node (extractor named none)
+          type_absent: 0,           // subjects filed under the fallback because no type was given
           entity_type_refused: 0,   // typed facts whose type was a statement class
           watermark: null,          // the LAST scan row actually consolidated, by reference
           advanced: null,
@@ -1302,12 +1304,19 @@ agents:
           if (TRANSIENT_ID.test(text)) { st.transient++; continue; }
           // type/subject are the entity half and are OPTIONAL — a fact that names
           // no single thing is still a fact worth keeping, so a missing pair is
-          // carried as "" rather than dropping the row. They travel TOGETHER: one
-          // without the other cannot form an entity identity, and half a pair is
-          // more likely a model slip than a partial truth, so both are cleared.
+          // carried as "" rather than dropping the row.
+          //
+          // They no longer travel TOGETHER, because the two halves are not equally
+          // recoverable. A SUBJECT with no type still forms an identity:
+          // ENTITY_FALLBACK_TYPE supplies the kind, `object:denn` is one findable
+          // node, and two subjects still slug to two keys — so clearing the subject
+          // discarded the half with NO substitute in order to protect the half that
+          // already had a default. A TYPE with no subject is genuinely unusable:
+          // there is nothing to name a node after, and the orphan kind would reach
+          // the judge's mistyping check, which needs the pair to mean anything.
           var typ = (typeof f.type === "string") ? f.type.trim().toLowerCase() : "";
           var subj = (typeof f.subject === "string") ? f.subject.trim() : "";
-          if (!typ || !subj) { typ = ""; subj = ""; }
+          if (!subj) { typ = ""; }
           // The validity interval is OPTIONAL and validated shallowly: an
           // unparseable or reversed interval is dropped while the FACT is kept,
           // because a good fact with a bad date is still a good fact, and
@@ -2447,51 +2456,94 @@ agents:
         return "";
       }
 
-      // mirrorEntity writes the subject node, the fact node and the edge between
-      // them. Called after the k/v write has already succeeded.
+      // nonEmpty reports a USABLE string field — present, a string, and not merely
+      // whitespace. The extractor omits a key, sends null, and sends "" for the same
+      // "I do not know", so all three have to read the same way.
+      function nonEmpty(v) { return typeof v === "string" && v.trim() !== ""; }
+
+      // mirrorEntity writes the fact node and — when the fact actually names something
+      // — a subject node plus the edge between them. Called after the k/v write has
+      // already succeeded.
+      //
+      // EVERY FACT GETS A CHUNK. This used to return early unless the extractor supplied
+      // BOTH a type and a subject, which left the fact in k/v with no graph presence at
+      // all: MEASURED at 249 of 1,225 facts, 20.3%, on a real pass. That was affordable
+      // while the k/v row was the fact's home. It stops being affordable the moment the
+      // chunk becomes the ONLY home, because then a fifth of every corpus vanishes.
+      //
+      // The two halves of that old guard are NOT the same problem, and collapsing them
+      // into one condition is what made the gap so wide:
+      //
+      //   A missing TYPE is a naming problem. The subject is a real thing that WAS
+      //   named; only its kind is unknown. ENTITY_FALLBACK_TYPE already exists for
+      //   exactly this case ("the proposed type cannot be used") and an absent type is a
+      //   special case of it. `object:denn` is one findable node about one real thing,
+      //   and two different subjects still slug to two different keys.
+      //
+      //   A missing SUBJECT is not. There is no thing to make a node for, and inventing
+      //   one is precisely how two different things end up merged onto a single node. A
+      //   shared placeholder would be worse than no edge: it would collect every
+      //   unattributed fact onto one hub, and a traversal would then report the team's
+      //   shipping cadence and the Friday release rule as related. So the fact node is
+      //   written, and the subject node and edge are skipped — the fact keeps its home,
+      //   the graph stays honest, and st.fact_no_subject counts the gap so it reads as
+      //   work still to do instead of a silent default.
       function mirrorEntity(st, key, fact, scope) {
-        if (!fact.type || !fact.subject) { return; } // untyped fact: k/v only (by design)
         scope = scope || CONFIG.scope;
         var docID = entitiesDoc(st, scope);
         if (!docID) { return; }
 
-        // A statement class is not an entity type — "preference:user" reads as "the entity
-        // of type preference named user". It used to be DROPPED, which lost the subject; the
-        // subject itself ("user") was never the problem, only the kind. Filed under the
-        // fallback instead, so the facts stay reachable. NOT proposed as a candidate: these
-        // names are already declared, they are simply being misused as a kind.
-        var proposed = fact.type;
-        if (ENTITY_TYPE_DENY[proposed] === true) {
-          st.entity_type_refused++;
-          proposed = ENTITY_FALLBACK_TYPE;
-        }
+        var subjID = "";
+        if (nonEmpty(fact.subject)) {
+          // A statement class is not an entity type — "preference:user" reads as "the entity
+          // of type preference named user". It used to be DROPPED, which lost the subject; the
+          // subject itself ("user") was never the problem, only the kind. Filed under the
+          // fallback instead, so the facts stay reachable. NOT proposed as a candidate: these
+          // names are already declared, they are simply being misused as a kind.
+          var proposed = fact.type;
+          // An ABSENT type is the same problem as an unusable one: the subject was named,
+          // its kind was not. Filed under the fallback so the subject still gets its node,
+          // rather than the missing kind costing the fact its place in the graph.
+          if (!nonEmpty(proposed)) {
+            st.type_absent++;
+            proposed = ENTITY_FALLBACK_TYPE;
+          } else if (ENTITY_TYPE_DENY[proposed] === true) {
+            st.entity_type_refused++;
+            proposed = ENTITY_FALLBACK_TYPE;
+          }
 
-        // The type this subject is ALREADY filed under wins over this call's guess, so one
-        // subject is one node however many ways the extractor spells its kind.
-        var subjType = canonicalType(st, scope, proposed, fact.subject);
-        var subjKey = entityKey(subjType, fact.subject);
-        var isNewSubject = !st.entity_ids[scope + "\u0000" + subjKey];
-        var subjID = upsertEntityChunk(st, scope, docID, subjKey, {
-          title: fact.subject, type: subjType, subject: fact.subject
-        });
-        // UNDECLARED TYPE: the write was refused because the tenant does not declare this
-        // kind. File the kind as an inert candidate an operator can accept, then retry under
-        // the fallback — the key has to move with the type, since the type is part of a
-        // subject node's identity.
-        if (!subjID && subjType !== ENTITY_FALLBACK_TYPE && undeclaredTypeRefusal(st)) {
-          proposeOntologyType(st, subjType);
-          st.type_fell_back++;
-          // Remember the fallback for this subject so the rest of the pass agrees with it.
-          st.subject_types[scope + "\u0000" + slug(normalizeSubject(fact.subject))] = ENTITY_FALLBACK_TYPE;
-          subjType = ENTITY_FALLBACK_TYPE;
-          subjKey = entityKey(subjType, fact.subject);
-          isNewSubject = !st.entity_ids[scope + "\u0000" + subjKey];
+          // The type this subject is ALREADY filed under wins over this call's guess, so one
+          // subject is one node however many ways the extractor spells its kind.
+          var subjType = canonicalType(st, scope, proposed, fact.subject);
+          var subjKey = entityKey(subjType, fact.subject);
+          var isNewSubject = !st.entity_ids[scope + "\u0000" + subjKey];
           subjID = upsertEntityChunk(st, scope, docID, subjKey, {
             title: fact.subject, type: subjType, subject: fact.subject
           });
+          // UNDECLARED TYPE: the write was refused because the tenant does not declare this
+          // kind. File the kind as an inert candidate an operator can accept, then retry under
+          // the fallback — the key has to move with the type, since the type is part of a
+          // subject node's identity.
+          if (!subjID && subjType !== ENTITY_FALLBACK_TYPE && undeclaredTypeRefusal(st)) {
+            proposeOntologyType(st, subjType);
+            st.type_fell_back++;
+            // Remember the fallback for this subject so the rest of the pass agrees with it.
+            st.subject_types[scope + "\u0000" + slug(normalizeSubject(fact.subject))] = ENTITY_FALLBACK_TYPE;
+            subjType = ENTITY_FALLBACK_TYPE;
+            subjKey = entityKey(subjType, fact.subject);
+            isNewSubject = !st.entity_ids[scope + "\u0000" + subjKey];
+            subjID = upsertEntityChunk(st, scope, docID, subjKey, {
+              title: fact.subject, type: subjType, subject: fact.subject
+            });
+          }
+          // A REFUSED subject write no longer costs the fact its chunk either. The
+          // existing safety property is that a graph failure degrades to "no edge" and
+          // never to "no fact"; once the chunk is the fact's home, that property has to
+          // cover the chunk and not just the k/v row.
+          if (subjID && isNewSubject) { st.entity_nodes++; }
+        } else {
+          st.fact_no_subject++;
         }
-        if (!subjID) { return; }
-        if (isNewSubject) { st.entity_nodes++; }
 
         // The fact node carries the sentence; its title is the sentence too,
         // trimmed, because a chunk with no title is unreadable in the Path browser.
@@ -2528,20 +2580,24 @@ agents:
           }
         }
 
-        try {
-          // `scope`, NOT CONFIG.scope. Every other write in this function already
-          // threads the placed scope; this one did not, so a fact the ontology sent
-          // to the tenant plane got its subject node and its fact node there and
-          // then tried to join them in the caller's scope, where neither exists.
-          // The two nodes were stored and the edge silently was not — leaving a
-          // placed fact unreachable from the person it is about, which is the whole
-          // reason the entity tier exists. Measured live: 3 facts placed, 3 edges
-          // lost, 0 inbound edges on the subject.
-          Document({ op: "link_chunks", scope: scope,
-                     from_id: factID, to_id: subjID, kind: "about" });
-        } catch (e) {
-          st.entity_failed++; // the nodes exist; only the edge is missing
-          if (!st.entity_error) { st.entity_error = errText(e); }
+        // No subject node means there is nothing to point an edge at. The fact is
+        // already stored; it is simply not reachable by traversal.
+        if (subjID) {
+          try {
+            // `scope`, NOT CONFIG.scope. Every other write in this function already
+            // threads the placed scope; this one did not, so a fact the ontology sent
+            // to the tenant plane got its subject node and its fact node there and
+            // then tried to join them in the caller's scope, where neither exists.
+            // The two nodes were stored and the edge silently was not — leaving a
+            // placed fact unreachable from the person it is about, which is the whole
+            // reason the entity tier exists. Measured live: 3 facts placed, 3 edges
+            // lost, 0 inbound edges on the subject.
+            Document({ op: "link_chunks", scope: scope,
+                       from_id: factID, to_id: subjID, kind: "about" });
+          } catch (e) {
+            st.entity_failed++; // the nodes exist; only the edge is missing
+            if (!st.entity_error) { st.entity_error = errText(e); }
+          }
         }
       }
 
@@ -3150,7 +3206,7 @@ agents:
         // The entity half, reported even when zero: a pass that mirrored nothing
         // because no fact was typed looks identical to one where every Document
         // call failed, and those need different fixes.
-        if (st.entity_facts || st.entity_nodes || st.entity_failed || st.entity_type_refused) {
+        if (st.entity_facts || st.entity_nodes || st.entity_failed || st.entity_type_refused || st.fact_no_subject) {
           var ent = "entities " + st.entity_facts + " fact(s) across " + st.entity_nodes + " subject(s)";
           if (st.entity_failed) {
             ent += ", " + st.entity_failed + " graph write(s) failed";
@@ -3163,6 +3219,16 @@ agents:
           }
           if (st.type_proposed) {
             ent += ", " + st.type_proposed + " new type(s) proposed for an operator to accept";
+          }
+          // Reported because it is a YIELD gap, not an error: these facts are stored and
+          // searchable, they are just not reachable by traversal. Left silent it looks
+          // like the graph covers the corpus when it covers only part of it.
+          if (st.fact_no_subject) {
+            ent += ", " + st.fact_no_subject + " fact(s) chunked with no subject named";
+          }
+          if (st.type_absent) {
+            ent += ", " + st.type_absent + " subject(s) filed under " + ENTITY_FALLBACK_TYPE +
+              " because no type was given";
           }
           if (st.type_lookup_failed) {
             ent += ", " + st.type_lookup_failed + " subject-type lookup(s) failed";

--- a/cmd/loomcycle/presets_memory_codejs_test.go
+++ b/cmd/loomcycle/presets_memory_codejs_test.go
@@ -2956,10 +2956,16 @@ func TestConsolidator_MirrorsTypedFactsIntoAGraph(t *testing.T) {
 	}
 }
 
-// TestConsolidator_UntypedFactsStayKeyValueOnly: the entity pair is optional, and a
-// fact naming no single thing must not be forced into the graph. Inventing a subject
-// to make one fit is how two different things end up merged onto one node.
-func TestConsolidator_UntypedFactsStayKeyValueOnly(t *testing.T) {
+// TestConsolidator_AFactWithNoSubjectStillGetsItsChunk. A fact naming no single thing
+// used to be mirrored NOWHERE — measured at 249 of 1,225 facts, 20.3% — which is
+// affordable only while the k/v row is the fact's home. It gets its own chunk now, so
+// that a fifth of the corpus does not vanish when the chunk becomes the only home.
+//
+// The half of the old rule that still stands is that no subject is INVENTED for it:
+// this asserts no placeholder node and no edge, because a shared placeholder would
+// collect every unattributed fact onto one hub and a traversal would then report them
+// all as related — which is worse than having no edge to follow.
+func TestConsolidator_AFactWithNoSubjectStillGetsItsChunk(t *testing.T) {
 	f := newFakeToolset()
 	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
 	f.transcript = "user: hi\nassistant: hello"
@@ -2968,13 +2974,56 @@ func TestConsolidator_UntypedFactsStayKeyValueOnly(t *testing.T) {
 		{"text":"Releases are never cut on a Friday.","class":"constraint"}
 	]` + "\n```"
 
-	runConsolidator(t, f)
+	res := runConsolidator(t, f)
 
 	if n := f.countOp("Memory.set"); n != 2 {
-		t.Errorf("k/v writes = %d, want 2 — an untyped fact is still a fact", n)
+		t.Errorf("k/v writes = %d, want 2 — a subjectless fact is still a fact", n)
 	}
-	if n := f.countOp("Document.upsert_chunk"); n != 0 {
-		t.Errorf("wrote %d chunks for untyped facts, want 0; keys=%v", n, f.chunks)
+	// One chunk per fact, keyed on the k/v key: the fact node needs no subject.
+	for _, key := range []string{
+		"memory/decision/team-ships-tuesdays",
+		"memory/constraint/releases-never-cut-friday",
+	} {
+		if _, ok := f.chunks[key]; !ok {
+			t.Errorf("fact %q got no chunk — it would be lost by a collapse; keys=%v", key, f.chunks)
+		}
+	}
+	if n := len(f.chunks); n != 2 {
+		t.Errorf("wrote %d chunks, want exactly 2 (one per fact, no subject node); keys=%v", n, f.chunks)
+	}
+	if n := len(callsWithOp(f, "Document.link_chunks")); n != 0 {
+		t.Errorf("drew %d edge(s) for facts naming no subject, want 0 — there is nothing to point at", n)
+	}
+	// The gap has to be visible: silent, it reads as a graph that covers the corpus.
+	if !strings.Contains(res.FinalText, "2 fact(s) chunked with no subject named") {
+		t.Errorf("the unattributed count must be reported, not defaulted silently; got %q", res.FinalText)
+	}
+}
+
+// TestConsolidator_ASubjectWithNoTypeIsFiledUnderTheFallbackType. A missing type is a
+// different problem from a missing subject: the thing WAS named, only its kind is
+// unknown, so it still becomes one findable node (two subjects never collide, since the
+// name is part of the key). ENTITY_FALLBACK_TYPE already existed for an unusable type;
+// an absent one is the same case.
+func TestConsolidator_ASubjectWithNoTypeIsFiledUnderTheFallbackType(t *testing.T) {
+	f := newFakeToolset()
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	f.transcript = "user: hi\nassistant: hello"
+	f.factsJSON = "```json\n" + `[
+		{"text":"Denn prefers Go for backend services.","class":"preference","subject":"Denn"},
+		{"text":"Ada owns the ledger service.","class":"fact","subject":"Ada"}
+	]` + "\n```"
+
+	runConsolidator(t, f)
+
+	// Two named things, so two distinct nodes — not one merged placeholder.
+	for _, key := range []string{"object:denn", "object:ada"} {
+		if _, ok := f.chunks[key]; !ok {
+			t.Errorf("subject %q got no node; keys=%v", key, f.chunks)
+		}
+	}
+	if n := len(callsWithOp(f, "Document.link_chunks")); n != 2 {
+		t.Errorf("edges = %d, want 2 — a named subject is reachable even with no type given", n)
 	}
 }
 
@@ -3001,6 +3050,11 @@ func TestConsolidator_AGraphFailureNeverCostsAFact(t *testing.T) {
 	}
 	if !strings.Contains(res.FinalText, "graph write(s) failed") {
 		t.Errorf("a silent graph failure is the worst outcome — it must be reported; got %q", res.FinalText)
+	}
+	// The same property, now that the chunk is becoming the fact's home: a refused
+	// SUBJECT node must degrade to "no edge", never to "no fact chunk".
+	if _, ok := f.chunks["memory/preference/denn-prefers-go-backend-services"]; !ok {
+		t.Errorf("the subject node was refused and the fact lost its chunk too; keys=%v", f.chunks)
 	}
 }
 

--- a/internal/cli/memory_eval_live.go
+++ b/internal/cli/memory_eval_live.go
@@ -265,8 +265,8 @@ func printExtractionReport(w io.Writer, r eval.ExtractionReport, base *eval.Base
 	}
 
 	fmt.Fprintf(w, "\nper-ability\n")
-	fmt.Fprintf(w, "  %-12s %6s %9s %11s %8s %6s %7s\n",
-		"ability", "cases", "recall", "violations", "clean", "typed", "errors")
+	fmt.Fprintf(w, "  %-12s %6s %9s %11s %8s %6s %6s %7s\n",
+		"ability", "cases", "recall", "violations", "clean", "typed", "subj", "errors")
 	for _, s := range r.Abilities {
 		recall := "     n/a"
 		if s.Recall >= 0 {
@@ -287,9 +287,18 @@ func printExtractionReport(w io.Writer, r eval.ExtractionReport, base *eval.Base
 		if tr := s.TypedRate(); tr >= 0 {
 			typed = fmt.Sprintf("%6.2f", tr)
 		}
+		// subj = the SUBJECT rate, which is the reachability number: the consolidator
+		// mirrors on a subject alone and falls an absent type back, so `typed` can sit
+		// flat while this moves. Read them as a pair — typed under subj is the model
+		// naming things without naming their kind, which costs ontology placement and
+		// nothing else.
+		subjected := "   n/a"
+		if sr := s.SubjectRate(); sr >= 0 {
+			subjected = fmt.Sprintf("%6.2f", sr)
+		}
 		answered := s.Cases - s.Errors
-		fmt.Fprintf(w, "  %-12s %6d %9s %11d %5d/%d %s %s%s\n",
-			s.Ability, s.Cases, recall, s.Violations, s.CleanCases, answered, typed, errs, delta)
+		fmt.Fprintf(w, "  %-12s %6d %9s %11d %5d/%d %s %s %s%s\n",
+			s.Ability, s.Cases, recall, s.Violations, s.CleanCases, answered, typed, subjected, errs, delta)
 	}
 	fmt.Fprintf(w, "\n  total violations     %d\n", r.TotalViolations)
 

--- a/internal/memory/eval/extraction.go
+++ b/internal/memory/eval/extraction.go
@@ -73,13 +73,26 @@ type ExtractedFact struct {
 	Subject string `json:"subject,omitempty"`
 }
 
-// HasEntity reports whether the fact carries a COMPLETE entity pair. Half a pair
-// is not a partial identity: a type with no subject names nothing and a subject
-// with no type cannot be placed in the ontology, and the consolidator clears
-// either alone for that reason. Counting a half as typed would overstate the
-// instrument.
+// HasEntity reports whether the fact carries a COMPLETE entity pair — both halves,
+// which is what lets the fact be placed in the ontology by its declared type.
+//
+// The two halves are no longer equally consequential, so HasSubject is reported
+// beside it. The consolidator used to clear either half when the other was missing
+// and mirror only a complete pair; it now keeps a lone SUBJECT and falls the type
+// back, because the subject is the half with no substitute. So the pair rate is the
+// ontology-placement rate, while HasSubject is the GRAPH-REACHABILITY rate — the
+// fraction of facts that get a subject node and an edge at all. Reporting only the
+// pair would show a prompt change as flat when it had actually moved reachability.
 func (f ExtractedFact) HasEntity() bool {
 	return strings.TrimSpace(f.Type) != "" && strings.TrimSpace(f.Subject) != ""
+}
+
+// HasSubject reports whether the fact names the thing it is about, whether or not it
+// also named a kind. This is the half that decides whether the fact is reachable by
+// traversal: a subject with no type still becomes one findable node under the
+// fallback type, while a fact with no subject gets its chunk and no edge.
+func (f ExtractedFact) HasSubject() bool {
+	return strings.TrimSpace(f.Subject) != ""
 }
 
 // CaseResult is one case's outcome.
@@ -165,6 +178,11 @@ type AbilityScore struct {
 	// the fixture set rather than the model.
 	TypedFacts   int `json:"typed_facts"`
 	EmittedFacts int `json:"emitted_facts"`
+	// SubjectedFacts is the same measurement one half further out: facts naming a
+	// subject, with or without a kind. Since the consolidator falls an absent type
+	// back and mirrors on the subject alone, this — not the pair — is the number
+	// that tracks how much of the corpus is reachable in the graph.
+	SubjectedFacts int `json:"subjected_facts"`
 }
 
 // TypedRate is the fraction of emitted facts carrying a complete entity pair, or
@@ -175,6 +193,15 @@ func (a AbilityScore) TypedRate() float64 {
 		return -1
 	}
 	return float64(a.TypedFacts) / float64(a.EmittedFacts)
+}
+
+// SubjectRate is the fraction of emitted facts naming a subject, with the same
+// -1-for-nothing-emitted convention as TypedRate.
+func (a AbilityScore) SubjectRate() float64 {
+	if a.EmittedFacts == 0 {
+		return -1
+	}
+	return float64(a.SubjectedFacts) / float64(a.EmittedFacts)
 }
 
 // ExtractionReport is the whole run.
@@ -537,16 +564,18 @@ func ParseExtractorReply(raw string) ([]ExtractedFact, int, error) {
 			continue
 		}
 		// The entity pair, mirroring production's validateFacts exactly: both
-		// lowercased/trimmed, and CLEARED unless both are present. Half a pair is
-		// not a partial identity, and the harness must model the same rule the
-		// consolidator applies or it would score facts the pipeline will not treat
-		// as typed.
+		// lowercased/trimmed, and the TYPE cleared when no subject was named. The
+		// harness has to model the rule the consolidator applies or it scores facts
+		// the pipeline treats differently — and the rule is no longer symmetric. A
+		// lone SUBJECT survives, because the consolidator falls the absent type back
+		// and still mirrors the fact onto a subject node; a lone TYPE does not,
+		// because there is nothing for it to name.
 		typ, _ := r["type"].(string)
 		subj, _ := r["subject"].(string)
 		typ = strings.ToLower(strings.TrimSpace(typ))
 		subj = strings.TrimSpace(subj)
-		if typ == "" || subj == "" {
-			typ, subj = "", ""
+		if subj == "" {
+			typ = ""
 		}
 		out = append(out, ExtractedFact{Text: text, Class: class, Type: typ, Subject: subj})
 	}
@@ -582,17 +611,27 @@ func scoreCase(res *CaseResult, cs ExtractionCase, facts []ExtractedFact) {
 
 	// Forbidden material.
 	for _, f := range cs.Forbid {
-		// An invented entity pair is not a marker in the text, so it is matched on
-		// the PAIR rather than on the sentence. Any typed fact violates it: the
-		// fixture's claim is that this transcript supports no entity identity at
-		// all, and a subject invented to satisfy the schema is what merges a
-		// statement onto the wrong node.
+		// An invented entity is not a marker in the text, so it is matched on the
+		// EMITTED SUBJECT rather than on the sentence. The fixture's claim is that
+		// this transcript supports no entity identity at all, and a subject invented
+		// to satisfy the schema is what merges a statement onto the wrong node.
+		//
+		// Matched on the SUBJECT ALONE, not on the complete pair. The consolidator
+		// now falls an absent type back and mirrors on the subject, so a lone
+		// invented subject builds `object:<slug>` and corrupts identity exactly as a
+		// full pair would — while a pair-only check would score it clean. That gap
+		// would be worst precisely where it matters: the prompt asks for a subject
+		// on every fact it can, so under-typing is the likely shape of an invention.
 		if f.Kind == ForbiddenInventedEntity {
 			for _, fact := range facts {
-				if fact.HasEntity() {
+				if fact.HasSubject() {
+					filed := fact.Subject
+					if fact.Type != "" {
+						filed = fact.Type + ":" + fact.Subject
+					}
 					res.Violations = append(res.Violations, fmt.Sprintf(
-						"%s fixture: %q typed as %s:%s — %s",
-						f.Kind, truncate(fact.Text, 60), fact.Type, fact.Subject, f.Why))
+						"%s fixture: %q typed as %s — %s",
+						f.Kind, truncate(fact.Text, 60), filed, f.Why))
 					break
 				}
 			}
@@ -711,6 +750,9 @@ func scoreAbilities(cases []CaseResult) []AbilityScore {
 				s.EmittedFacts++
 				if f.HasEntity() {
 					s.TypedFacts++
+				}
+				if f.HasSubject() {
+					s.SubjectedFacts++
 				}
 			}
 			if r.Passed() {

--- a/internal/memory/eval/extraction_test.go
+++ b/internal/memory/eval/extraction_test.go
@@ -1185,7 +1185,11 @@ func TestRunExtraction_ReportsTheEntityPairRate(t *testing.T) {
 	corpus := ExtractionFixture()
 	replies := perfectReplies()
 	// Type the two facts that genuinely name a person, leave the rest bare.
-	replies["stated-preference"] = `[{"text":"Prefers tabs over spaces for editor indentation.","class":"preference","type":"person","subject":"the user"}]`
+	// Two facts: one carrying a complete pair, one naming its subject and NOT its
+	// kind, so the pair rate and the subject rate separate. A fixture where every
+	// subject arrived with a type would pass whether the subject count existed or not.
+	replies["stated-preference"] = `[{"text":"Prefers tabs over spaces for editor indentation.","class":"preference","type":"person","subject":"the user"},` +
+		`{"text":"Works on the loomcycle runtime.","class":"fact","subject":"the user"}]`
 
 	rep, err := RunExtraction(context.Background(), &byCaseCaller{replies: replies, corpus: corpus}, ExtractionInput{
 		Corpus: corpus, SystemPrompt: "x", Provider: "test", Model: "test-model",
@@ -1210,6 +1214,19 @@ func TestRunExtraction_ReportsTheEntityPairRate(t *testing.T) {
 		t.Errorf("typed rate = %v, want strictly between 0 and 1 for a mixed corpus", got)
 	}
 
+	// A LONE SUBJECT counts toward reachability but not toward the pair. This is the
+	// case the pair rate alone cannot see: the consolidator falls an absent type back
+	// and still mirrors the fact onto a subject node, so a prompt that wins subjects
+	// without kinds moves the graph while `typed` sits still.
+	if extraction.SubjectedFacts != extraction.TypedFacts+1 {
+		t.Errorf("subjected facts = %d, want %d (the pair, plus the one naming a subject and no kind)",
+			extraction.SubjectedFacts, extraction.TypedFacts+1)
+	}
+	if extraction.SubjectRate() <= extraction.TypedRate() {
+		t.Errorf("subject rate %v must exceed the pair rate %v when a fact names a subject and no type",
+			extraction.SubjectRate(), extraction.TypedRate())
+	}
+
 	// Abstention emits nothing, so its rate must be n/a (-1) rather than 0.00 — a
 	// zero would read as "the model refused to type", which is the opposite
 	// diagnosis from "there was nothing to type".
@@ -1217,6 +1234,45 @@ func TestRunExtraction_ReportsTheEntityPairRate(t *testing.T) {
 		if s.Ability == AbilityAbstention && s.TypedRate() != -1 {
 			t.Errorf("abstention typed rate = %v, want -1 (n/a): it emitted %d facts", s.TypedRate(), s.EmittedFacts)
 		}
+		if s.Ability == AbilityAbstention && s.SubjectRate() != -1 {
+			t.Errorf("abstention subject rate = %v, want -1 (n/a): it emitted %d facts", s.SubjectRate(), s.EmittedFacts)
+		}
+	}
+}
+
+// TestRunExtraction_AnInventedSubjectAloneIsStillAViolation closes the gap that
+// opened when a lone subject became mirrorable. The consolidator falls an absent
+// type back to the fallback and builds `object:<slug>` from the subject, so an
+// invention with no type corrupts identity exactly as a complete pair does — but a
+// check written against the PAIR scores it clean.
+//
+// It is the likely shape of the failure, not a corner: the prompt asks for a
+// subject on every fact that has one and explicitly permits omitting the kind, so a
+// model that invents to fill the schema will tend to invent the half it was told it
+// could supply alone.
+func TestRunExtraction_AnInventedSubjectAloneIsStillAViolation(t *testing.T) {
+	corpus := ExtractionFixture()
+	replies := perfectReplies()
+	// No "ops team" appears in this transcript, and no type is claimed either.
+	replies["durable-but-nobodys"] = `[{"text":"Releases never go out on a Friday.","class":"constraint","subject":"ops team"}]`
+
+	rep, err := RunExtraction(context.Background(), &byCaseCaller{replies: replies, corpus: corpus}, ExtractionInput{
+		Corpus: corpus, SystemPrompt: "x", Provider: "test", Model: "test-model",
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var found string
+	for _, c := range rep.Cases {
+		if c.Name == "durable-but-nobodys" && len(c.Violations) > 0 {
+			found = c.Violations[0]
+		}
+	}
+	if found == "" {
+		t.Fatal("an invented subject with no type must still be a violation — it builds object:ops-team and merges the fact onto that node")
+	}
+	if !strings.Contains(found, "ops team") {
+		t.Errorf("the violation should name the invented subject; got %q", found)
 	}
 }
 


### PR DESCRIPTION
## Why

A fifth of every corpus had no graph presence at all.

`mirrorEntity` returned early unless the extractor supplied **both** a type and a subject, and `normaliseFacts` cleared the pair when only one half arrived. Measured on a real 1,225-fact pass: **249 facts, 20.3%**, lived in the k/v plane and nowhere else.

That is affordable while the k/v row is a fact's home. It stops being affordable the moment the chunk becomes the *only* home — a fifth of the corpus would disappear at the collapse. This is the prerequisite for that change, not the change itself.

## What

The two halves of that guard are not the same problem, and conflating them is what made the gap so wide:

- **A missing TYPE is a naming problem.** The subject is a real thing that *was* named; only its kind is unknown. `ENTITY_FALLBACK_TYPE` already exists for exactly this ("the proposed type cannot be used") and an absent type is a special case of it. `object:denn` is one findable node about one real thing, and two subjects still slug to two keys. So the subject survives and the kind falls back — where the old rule discarded the half with **no substitute** in order to protect the half that already had a default.

- **A missing SUBJECT is not.** There is nothing to make a node for, and inventing one is how two different things end up merged onto a single node. A shared placeholder would be *worse* than no edge: it would collect every unattributed fact onto one hub, and a traversal would then report the team's shipping cadence and the Friday release rule as related. So the fact node is written and the subject node and edge are skipped.

The same rule turned out to live in **three** places — the `mirrorEntity` guard, `normaliseFacts` upstream (which would have made the type fallback dead code), and the eval harness's own parser. All three now agree.

A refused subject write no longer costs the fact its chunk either. The existing safety property is that a graph failure degrades to "no edge" and never to "no fact"; once the chunk is the fact's home, that has to cover the chunk and not just the k/v row.

Both gaps are counted and reported in the pass summary (`fact_no_subject`, `type_absent`) rather than defaulted silently — left invisible they read as a graph that covers the corpus when it covers only part of it.

### Instrument, second commit

The extraction eval modelled the old both-or-neither rule and went stale with it:

- `typed` counts complete pairs, so it is the ontology-**placement** rate. The new `subj` column is the graph-**reachability** rate. Reporting only the pair would show a prompt change as flat when it had moved reachability.
- the invented-entity violation fired only on a complete pair. A lone invented subject builds `object:<slug>` and merges the fact onto that node just as a pair does, so it now fires on the subject alone.

## What was tested

- `TestConsolidator_AFactWithNoSubjectStillGetsItsChunk` — one chunk per fact, **no** placeholder node, **no** edge, and the gap reported.
- `TestConsolidator_ASubjectWithNoTypeIsFiledUnderTheFallbackType` — two named things become two distinct nodes, both reachable.
- `TestConsolidator_AGraphFailureNeverCostsAFact` — extended to assert the chunk survives a refused subject node.
- `TestRunExtraction_AnInventedSubjectAloneIsStillAViolation` — new; fails on the pair-only predicate.
- `TestRunExtraction_ReportsTheEntityPairRate` — extended so the fixture carries a subject-without-type fact and the two rates must separate.

Fail-before verified by restoring the pre-fix bundles against the new tests: all three consolidator tests fail with `keys=map[]`, i.e. zero chunks written — a behavioural failure, not a build error. `go test ./...` clean. Both bundle copies byte-identical.

## Deliberately not in this PR

The extractor prompt still says type and subject "travel together — emit both or neither", which is now stricter than the code. Changing it is blocked, and the blocker is worth recording: any prompt edit changes the prompt digest, and a clean baseline cannot be recorded because the extractor at its **shipped** config (`qwen3.6:latest`, effort=low) emits an invented-entity violation — `SaveBaselineEntry` correctly refuses to record a run with violations, since `Regressions()` only fires on a rise. Measured 6/6 runs across both prompts, always a complete pair, so it is pre-existing and not an artifact of the widened detector. The strict prompt is the safe direction meanwhile: the code tolerates what the prompt discourages, and the 20.3% of facts naming *neither* half still gain chunks regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8