### PR TITLE
feat(memory): a document ref may carry a variable, resolved inside the match

### DIFF
--- a/internal/memory/docinject.go
+++ b/internal/memory/docinject.go
@@ -92,18 +92,30 @@ func (r DocRef) String() string {
 // documentPlaceholderPattern matches an OPTIONAL leading backslash (the escape)
 // followed by {{document:REF}}.
 //
-// The ref charset is deliberately RESTRICTIVE — path characters, plus `#` for
-// the heading selector — and notably excludes `{`, `}` and `$`. That is not
-// tidiness:
+// The ref is a sequence of PATH CHARACTERS or COMPLETE ${...} tokens, and
+// nothing else. Bare `{` and `}` are excluded, which makes the grammar
+// unambiguous and safe at the same time:
 //
-//   - excluding `{` and `}` means a ref can never contain a nested placeholder,
-//     so the single-pass guarantee cannot be undermined from inside an argument;
-//   - excluding `$` means a ref cannot carry a ${var.*} token today. When a later
-//     phase makes team-node prompts expandable, variables inside a ref must be
-//     resolved INSIDE the matched argument rather than by a pre-pass over the
-//     template — widening this charset without doing that would reintroduce
-//     exactly the injection path the single-pass discipline closes.
-const documentPlaceholderPattern = `(\\?)\{\{\s*document\s*:\s*([A-Za-z0-9_./#: @+-]{1,512}?)\s*\}\}`
+//   - a ref can never contain a nested {{...}}, because `{` is not a unit, so
+//     the single-pass guarantee cannot be undermined from inside an argument;
+//   - `{{document:/a}} text {{document:/b}}` still parses as TWO refs, because
+//     `}` cannot be consumed by the argument and therefore terminates it;
+//   - `{{document:/specs/${var.pr}}}` parses as ONE ref whose argument is
+//     `/specs/${var.pr}`, because a whole variable token IS a unit. A plain
+//     non-greedy charset could not express this — it would stop at
+//     `/specs/${var.pr` and leave a stray brace behind.
+//
+// Variables inside the argument are resolved INSIDE the matched placeholder as
+// part of resolving it (see expandDocumentPlaceholder), never by a pass over the
+// template. That is why widening this charset is safe NOW when it was not
+// before: a resolved value lands in a ref that is used as a PATH, and is never
+// re-read as template text.
+//
+// The repetition is `+` rather than a counted bound because RE2 rejects a
+// counted repeat wrapping an inner one (the product blows its automaton
+// budget). That costs nothing: RE2 is linear-time with no backtracking, and the
+// length bound lives in ParseDocRef where it can produce a real message.
+const documentPlaceholderPattern = `(\\?)\{\{\s*document\s*:\s*((?:[A-Za-z0-9_./#: @+-]|` + varTokenPattern + `)+)\s*\}\}`
 
 var documentPlaceholderRe = regexp.MustCompile(`(?i)` + documentPlaceholderPattern)
 
@@ -121,9 +133,17 @@ func ReadInstruction(ref DocRef) string {
 		"</document-ref>"
 }
 
+// MaxRefBytes bounds one ref. A path is short by nature; a long one means a
+// variable interpolated something that is not a path, and refusing it is a
+// clearer outcome than issuing the read.
+const MaxRefBytes = 512
+
 // ParseDocRef canonicalises a raw ref token. It reports ok=false for a ref with
 // no path, which boot validation surfaces rather than leaving literal.
 func ParseDocRef(raw string) (DocRef, bool) {
+	if len(raw) > MaxRefBytes {
+		return DocRef{}, false
+	}
 	path, heading, _ := strings.Cut(strings.TrimSpace(raw), "#")
 	path = strings.TrimSpace(path)
 	heading = strings.TrimSpace(heading)
@@ -178,7 +198,7 @@ func MalformedDocRefs(s string) []string {
 // renders to NOTHING rather than erroring: prompt assembly runs at every
 // run-entry, sub-agent spawn and resume, and a run must not fail because a
 // document moved. The same posture the {{tool:...}} family takes.
-func expandDocumentPlaceholder(match string, bodies map[DocRef]string, remaining *int) string {
+func expandDocumentPlaceholder(match string, bodies map[DocRef]string, remaining *int, values map[string]string, refused *[]string) string {
 	sub := documentPlaceholderRe.FindStringSubmatch(match)
 	if sub == nil {
 		return match
@@ -186,7 +206,18 @@ func expandDocumentPlaceholder(match string, bodies map[DocRef]string, remaining
 	if sub[1] == `\` {
 		return match[1:] // escaped → literal, backslash stripped
 	}
-	ref, ok := ParseDocRef(sub[2])
+	// Resolve the argument's variables HERE, inside the matched placeholder,
+	// rather than in a pass over the template. A value therefore lands in a ref
+	// that is used as a PATH — it is never re-read as template text, so it
+	// cannot introduce a placeholder for anything to expand. Trust rule 5b's
+	// first mitigation, at the only place it can actually be applied.
+	arg := sub[2]
+	if values != nil {
+		arg = varPlaceholderRe.ReplaceAllStringFunc(arg, func(m string) string {
+			return expandVarPlaceholder(m, values, refused)
+		})
+	}
+	ref, ok := ParseDocRef(arg)
 	if !ok {
 		return ""
 	}

--- a/internal/memory/docinject_test.go
+++ b/internal/memory/docinject_test.go
@@ -82,103 +82,36 @@ func TestDocument_ABodyContainingAPlaceholderIsNotRescanned(t *testing.T) {
 	}
 }
 
-// The complement: a document ref can never CONTAIN a placeholder, because the
-// argument charset excludes the delimiters. Belt to the single pass's braces.
-func TestDocument_RefCharsetExcludesTheDelimitersAndVarSigil(t *testing.T) {
+// A ref may carry a VARIABLE — that is the feature — but never a nested
+// PLACEHOLDER. `{` is not a unit of the argument grammar, so a {{...}} inside a
+// ref cannot be consumed by it and the single-pass guarantee holds from inside
+// an argument as well as from inside a body.
+func TestDocument_RefMayCarryAVariableButNeverANestedPlaceholder(t *testing.T) {
+	if refs := ReferencesDocRefs("{{document:/specs/${var.pr}}}"); len(refs) != 1 || refs[0].Path != "/specs/${var.pr}" {
+		t.Errorf("a ref must be able to carry a variable token, got %+v", refs)
+	}
+	// The nested form must not parse AS A DOCUMENT REF. (The inner {{tool:...}}
+	// is operator-authored text and may still be recognised by its own family;
+	// what must not happen is a document read built from it.)
 	for _, raw := range []string{
-		"{{document:/a{{tool:Bash}}}}",
-		"{{document:${var.x}}}",
+		"{{document:/a{{tool:Context.tools}}}}",
+		"{{document:/a{{document:/b}}}}",
 	} {
-		if refs := ReferencesDocRefs(raw); len(refs) != 0 {
-			t.Errorf("%q parsed as %+v; a ref must not be able to carry a placeholder or a variable", raw, refs)
+		for _, ref := range ReferencesDocRefs(raw) {
+			if strings.Contains(ref.Path, "{{") || strings.Contains(ref.Path, "}}") {
+				t.Errorf("%q produced a ref carrying a placeholder: %+v", raw, ref)
+			}
 		}
 	}
 }
 
-// THE RULE. A whole-document ref renders an INSTRUCTION, not content: it is
-// unbounded, and every way of forcing it into a prompt is worse than pointing at
-// it. Truncating hands the model half a spec it cannot tell from a whole one;
-// outlining spends prompt on a table of contents the agent must act on anyway.
-func TestDocument_WholeDocumentRefRendersAReadInstruction(t *testing.T) {
-	out := docExpand("Spec:\n{{document:/specs/launch}}", nil)
-
-	if !strings.Contains(out, "Document op=export_md path=/specs/launch") {
-		t.Errorf("the instruction must name the tool call and the path verbatim — a vague one makes the model guess an argument:\n%s", out)
-	}
-	if !strings.Contains(out, "NOT included") {
-		t.Errorf("it must say the document is absent, or the agent reads the instruction AS the document:\n%s", out)
-	}
-	if !strings.Contains(out, "{{document:/specs/launch#<section>}}") {
-		t.Errorf("it should name the selector that WOULD inline content, so an operator sees the alternative:\n%s", out)
-	}
-}
-
-// The point of rendering an instruction: it needs NO store read, so it resolves
-// identically with no bodies, no store, and no scope — the failure modes that
-// bite an assembly-time read cannot reach it.
-func TestDocument_WholeDocumentRefNeedsNoBody(t *testing.T) {
-	withBody := docExpand("{{document:/specs/launch}}", map[DocRef]string{
-		{Path: "/specs/launch"}: "a body that must be ignored",
-	})
-	without := docExpand("{{document:/specs/launch}}", nil)
-
-	if withBody != without {
-		t.Error("a whole-document ref must not depend on a resolved body at all")
-	}
-	if strings.Contains(withBody, "must be ignored") {
-		t.Error("a whole-document ref inlined content; it must only ever point at it")
-	}
-}
-
-// The complement, and the reason the rule is a rule rather than a blanket: a
-// PRECISE ref is still resolved content the agent cannot decline to read.
-func TestDocument_PreciseRefsStillInlineContent(t *testing.T) {
-	for name, ref := range map[string]DocRef{
-		"section":  {Path: "/specs/launch", Heading: "Risks"},
-		"chunk id": {Path: "08708222be908a886cd69d2c14deb0ec"},
-	} {
-		out := docExpand("{{document:"+ref.String()+"}}", map[DocRef]string{ref: "the actual content"})
-		if !strings.Contains(out, "the actual content") {
-			t.Errorf("%s: content was not inlined:\n%s", name, out)
-		}
-		if strings.Contains(out, "op=export_md") {
-			t.Errorf("%s: rendered an instruction; a precise ref must inline", name)
-		}
-	}
-}
-
-func TestDocRef_IsWholeDocument(t *testing.T) {
-	cases := map[DocRef]bool{
-		{Path: "/specs/launch"}:                    true,
-		{Path: "/specs/launch", Heading: "Risks"}:  false,
-		{Path: "08708222be908a886cd69d2c14deb0ec"}: false,
-	}
-	for ref, want := range cases {
-		if got := ref.IsWholeDocument(); got != want {
-			t.Errorf("%v.IsWholeDocument() = %v, want %v", ref, got, want)
-		}
-	}
-}
-
-// A chunk id addresses one chunk directly — the most precise form, and the one
-// that makes inlining a whole document unnecessary in the common case.
-func TestDocument_AChunkIDIsARefWithNoPath(t *testing.T) {
-	refs := ReferencesDocRefs("{{document:5b025c6853f5bdbcb033d081113a5b74}}")
-	if len(refs) != 1 {
-		t.Fatalf("refs = %+v", refs)
-	}
-	if !refs[0].IsID() {
-		t.Error("a ref with no leading slash must be treated as an id, not a path")
-	}
-	if refs[0].Heading != "" {
-		t.Errorf("heading = %q, want none", refs[0].Heading)
-	}
-}
-
-func TestDocument_APathIsNotAnID(t *testing.T) {
-	refs := ReferencesDocRefs("{{document:/specs/launch}}")
-	if len(refs) != 1 || refs[0].IsID() {
-		t.Errorf("refs = %+v, want a path ref", refs)
+// Two refs on one line must stay two refs: `}` cannot be consumed by an
+// argument, so it terminates one. A greedy charset without that property would
+// swallow the text between them.
+func TestDocument_TwoRefsOnOneLineStayTwoRefs(t *testing.T) {
+	refs := ReferencesDocRefs("see {{document:/a#S}} and {{document:/b#S}}")
+	if len(refs) != 2 || refs[0].Path != "/a" || refs[1].Path != "/b" {
+		t.Errorf("refs = %+v, want /a and /b", refs)
 	}
 }
 
@@ -195,5 +128,61 @@ func TestReferencesDocRefs_DedupesAndSkipsEscaped(t *testing.T) {
 	refs := ReferencesDocRefs(`{{document:/a}} {{document:/a}} \{{document:/b}}`)
 	if len(refs) != 1 || refs[0].Path != "/a" {
 		t.Errorf("refs = %+v, want only /a (deduped, escaped skipped)", refs)
+	}
+}
+
+// THE RFC's OWN EXAMPLE. A variable inside a ref resolves INSIDE the matched
+// placeholder, so the read targets the path the operator meant.
+func TestDocument_VariableInARefResolvesToThePath(t *testing.T) {
+	out := Expand("Spec:\n{{document:/specs/${var.pr}#Risks}}", ExpandInput{
+		Values:    map[string]string{"var.pr": "42"},
+		Documents: map[DocRef]string{{Path: "/specs/42", Heading: "Risks"}: "the risks"},
+	})
+	if !strings.Contains(out, "the risks") {
+		t.Errorf("the variable did not resolve into the ref:\n%s", out)
+	}
+	if !strings.Contains(out, `src="/specs/42#Risks"`) {
+		t.Errorf("the frame should name the RESOLVED ref:\n%s", out)
+	}
+}
+
+// An untrusted value lands in a REF, which is used as a PATH — never re-read as
+// template text. So a value carrying a placeholder is refused (mitigation 2),
+// and even if it were not, it could not become one (the single pass).
+func TestDocument_AnUntrustedValueInARefCannotSmuggleAPlaceholder(t *testing.T) {
+	out, refused := ExpandWithRefusals("{{document:/specs/${var.evil}#S}}", ExpandInput{
+		Values:    map[string]string{"var.evil": "{{tool:Context.tools}}"},
+		Documents: map[DocRef]string{{Path: "/specs/", Heading: "S"}: "should not be reached"},
+	})
+	if strings.Contains(out, "{{") {
+		t.Errorf("delimiters reached the prompt: %q", out)
+	}
+	if len(refused) != 1 || refused[0] != "var.evil" {
+		t.Errorf("refused = %v, want the drop reported", refused)
+	}
+}
+
+// A traversal attempt cannot address a document outside the scope: the ref is
+// handed to the substrate as a path, and pathnorm rejects ".." outright rather
+// than resolving it. Pinned here so the two layers cannot drift apart silently.
+func TestDocument_ATraversingValueProducesATraversingRefNotAResolvedOne(t *testing.T) {
+	out := Expand("{{document:/specs/${var.p}#S}}", ExpandInput{
+		Values: map[string]string{"var.p": "../../other"},
+		Documents: map[DocRef]string{
+			{Path: "/specs/../../other", Heading: "S"}: "",
+			{Path: "/other", Heading: "S"}:             "SHOULD NOT BE REACHED",
+		},
+	})
+	if strings.Contains(out, "SHOULD NOT BE REACHED") {
+		t.Error("a traversing value was normalised into a different document's path")
+	}
+}
+
+// A ref longer than MaxRefBytes is refused rather than issued: a long path means
+// a variable interpolated something that is not a path.
+func TestDocument_AnOverlongRefIsRefused(t *testing.T) {
+	long := strings.Repeat("a", MaxRefBytes+1)
+	if _, ok := ParseDocRef("/" + long); ok {
+		t.Error("an overlong ref parsed; it should be refused")
 	}
 }

--- a/internal/memory/inject.go
+++ b/internal/memory/inject.go
@@ -296,7 +296,7 @@ func ExpandWithRefusals(prompt string, in ExpandInput) (string, []string) {
 			// they are accumulated content an operator placed, whereas the tool
 			// budget exists for the fixed runtime-knowledge blocks.
 			if documentPlaceholderRe.MatchString(match) {
-				return expandDocumentPlaceholder(match, in.Documents, &remaining)
+				return expandDocumentPlaceholder(match, in.Documents, &remaining, in.Values, &refused)
 			}
 			return expandToolPlaceholder(match, in.ToolResults, &toolRemaining)
 		}

--- a/internal/memory/varinject.go
+++ b/internal/memory/varinject.go
@@ -38,6 +38,11 @@ import (
 // The FALLBACK charset excludes `{` and `}`: operator-authored text that cannot
 // introduce a placeholder delimiter either, so the guarantee holds on both
 // halves of the token.
+// varTokenPattern is varPlaceholderPattern without capture groups, for
+// embedding inside another family's argument (see documentPlaceholderPattern).
+// Kept beside it so the two can never describe different tokens.
+const varTokenPattern = `\$\{(?:var|now|team)\.[a-zA-Z0-9_-]{1,64}(?::-[^{}]*)?\}`
+
 const varPlaceholderPattern = `\$\{((?:var|now|team)\.[a-zA-Z0-9_-]{1,64})(?::-([^{}]*?))?\}`
 
 var varPlaceholderRe = regexp.MustCompile(varPlaceholderPattern)


### PR DESCRIPTION
The remaining half of **RFC CY Decision 5, amendment A**. #1173 covered the **prose** region — a `${var.*}` between placeholders — and left the **argument** region, so the RFC's own worked example still didn't parse:

```jsonc
"input_template": "Review PR ${var.pr}.\n\nSpec:\n{{document:/specs/${var.pr}}}"
```

## The grammar

A ref is now a sequence of **path characters or complete `${…}` tokens**, and nothing else. Bare `{` and `}` remain excluded, which is what makes it unambiguous and safe at once:

- a ref can never contain a nested `{{…}}`, because `{` is not a unit — the single-pass guarantee holds from inside an **argument** as it does from inside a **body**;
- `{{document:/a}} text {{document:/b}}` still parses as **two** refs, because `}` cannot be consumed by an argument and therefore terminates it;
- `{{document:/specs/${var.pr}}}` parses as **one** ref whose argument is `/specs/${var.pr}`, because a whole variable token *is* a unit. A plain non-greedy charset cannot express this — it stops at `/specs/${var.pr` and leaves a stray brace.

## Where the variable resolves

**Inside the matched placeholder**, as part of resolving it — never by a pass over the template. That's trust rule 5b's *first* mitigation, at the only place it can actually be applied, and it's why widening the charset is safe **now** when it wasn't before: a resolved value lands in a **ref**, which is then used as a **path**. It is never re-read as template text, so it cannot introduce a placeholder for anything to expand.

A small RE2 note: the repetition is `+` rather than a counted bound, because RE2 refuses a counted repeat wrapping an inner one (the product blows its automaton budget). That costs nothing — RE2 is linear-time with no backtracking — and the length bound moves to `ParseDocRef` as `MaxRefBytes`, where it can *mean* something: a long path is a variable that interpolated something which isn't a path.

## Tested

`go test ./...` clean (**100 packages**, full output grepped for `FAIL`). **Both halves verified fail-before** — removing the arg-scoped resolution stops variables resolving, and narrowing the grammar back stops the RFC's example parsing at all.

- the RFC's example resolves, and the DATA frame names the **resolved** ref (`src="/specs/42#Risks"`), so a reader sees what was actually read;
- a ref may carry a variable but **never** a nested placeholder;
- two refs on one line stay two refs — the property a greedy charset would lose;
- an untrusted value in a ref is refused for carrying delimiters, and the refusal is reported;
- a **traversing** value produces a traversing ref rather than a resolved one — pinned here so this layer and `pathnorm`'s outright `..` rejection can't drift apart silently;
- an overlong ref is refused rather than issued as a read.

With this, amendment A is complete: both the prose and the argument regions resolve in one pass, and the ordering that made a pre-pass dangerous no longer exists anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD