### PR TITLE
fix(memory): carry observed_at into the chunk plane, stop inventing valid_at

### DIFF
--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -2461,6 +2461,31 @@ agents:
       // "I do not know", so all three have to read the same way.
       function nonEmpty(v) { return typeof v === "string" && v.trim() !== ""; }
 
+      // nanosOfStamp turns one of this bundle's RFC3339 strings into the unix-nanos
+      // integer the Document tool takes. The two planes spell the same instant
+      // differently — `Memory set` takes RFC3339, `upsert_chunk` takes nanos — so a
+      // fact crossing into the chunk plane has to be converted rather than dropped,
+      // which is what used to happen.
+      //
+      // Date.parse IS used here, and that does not contradict parseStamp's refusal to
+      // use it: parseStamp reads UNTRUSTED transcript text, where Date.parse's habit
+      // of guessing at ambiguity is the defect. Here the input has already passed
+      // tsOrEmpty's strict RFC3339 test, so there is nothing left to guess — the
+      // offset is explicit in the string.
+      //
+      // Exactness: a double holds integers exactly only to 2^53, and 2023 in nanos is
+      // ~1.7e18, so representable values there are multiples of 256. Every stamp this
+      // bundle produces is second-granularity, hence a multiple of 1e9 = 2^9·1953125,
+      // hence a multiple of 512 — so the conversion is exact for the values it
+      // actually sees. Sub-microsecond precision would not be, and none is available
+      // from a transcript anyway.
+      function nanosOfStamp(s) {
+        if (typeof s !== "string" || s === "") { return null; }
+        var ms = Date.parse(s);
+        if (isNaN(ms)) { return null; }
+        return ms * 1000000;
+      }
+
       // mirrorEntity writes the fact node and — when the fact actually names something
       // — a subject node plus the edge between them. Called after the k/v write has
       // already succeeded.
@@ -2555,6 +2580,22 @@ agents:
         // claim — there is nothing about "Denn" for a quote to support, and attaching
         // one there would make the evidence look like it backed the wrong thing.
         if (fact.quote) { factArgs.source_quote = fact.quote; }
+        // THE TEMPORAL FIELDS TRAVEL WITH THE FACT. They used not to: the k/v write
+        // above carried observed_at/valid_at/invalid_at and this one carried none, so
+        // the mirrored fact arrived undated and the sidecar's own writer stamped
+        // valid_at = now. Measured on a real corpus: 103/103 facts had observed_at in
+        // the k/v plane, 0 could have it in the chunk plane, and 117 of 120 sidecar
+        // rows held a valid_at that was really a write time. Once the chunk is the
+        // fact's only home that is not a cosmetic gap — it is the whole temporal
+        // tier, and `when` narrows on observed_at.
+        var oaN = nanosOfStamp(fact.observed_at);
+        if (oaN !== null) { factArgs.observed_at = oaN; }
+        var vaN = nanosOfStamp(fact.valid_at);
+        if (vaN !== null) {
+          factArgs.valid_at = vaN;
+          var ivaN = nanosOfStamp(fact.invalid_at);
+          if (ivaN !== null) { factArgs.invalid_at = ivaN; }
+        }
         var factID = upsertEntityChunk(st, scope, docID, key, factArgs);
         if (!factID) { return; }
         st.entity_facts++;

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -2461,6 +2461,31 @@ agents:
       // "I do not know", so all three have to read the same way.
       function nonEmpty(v) { return typeof v === "string" && v.trim() !== ""; }
 
+      // nanosOfStamp turns one of this bundle's RFC3339 strings into the unix-nanos
+      // integer the Document tool takes. The two planes spell the same instant
+      // differently — `Memory set` takes RFC3339, `upsert_chunk` takes nanos — so a
+      // fact crossing into the chunk plane has to be converted rather than dropped,
+      // which is what used to happen.
+      //
+      // Date.parse IS used here, and that does not contradict parseStamp's refusal to
+      // use it: parseStamp reads UNTRUSTED transcript text, where Date.parse's habit
+      // of guessing at ambiguity is the defect. Here the input has already passed
+      // tsOrEmpty's strict RFC3339 test, so there is nothing left to guess — the
+      // offset is explicit in the string.
+      //
+      // Exactness: a double holds integers exactly only to 2^53, and 2023 in nanos is
+      // ~1.7e18, so representable values there are multiples of 256. Every stamp this
+      // bundle produces is second-granularity, hence a multiple of 1e9 = 2^9·1953125,
+      // hence a multiple of 512 — so the conversion is exact for the values it
+      // actually sees. Sub-microsecond precision would not be, and none is available
+      // from a transcript anyway.
+      function nanosOfStamp(s) {
+        if (typeof s !== "string" || s === "") { return null; }
+        var ms = Date.parse(s);
+        if (isNaN(ms)) { return null; }
+        return ms * 1000000;
+      }
+
       // mirrorEntity writes the fact node and — when the fact actually names something
       // — a subject node plus the edge between them. Called after the k/v write has
       // already succeeded.
@@ -2555,6 +2580,22 @@ agents:
         // claim — there is nothing about "Denn" for a quote to support, and attaching
         // one there would make the evidence look like it backed the wrong thing.
         if (fact.quote) { factArgs.source_quote = fact.quote; }
+        // THE TEMPORAL FIELDS TRAVEL WITH THE FACT. They used not to: the k/v write
+        // above carried observed_at/valid_at/invalid_at and this one carried none, so
+        // the mirrored fact arrived undated and the sidecar's own writer stamped
+        // valid_at = now. Measured on a real corpus: 103/103 facts had observed_at in
+        // the k/v plane, 0 could have it in the chunk plane, and 117 of 120 sidecar
+        // rows held a valid_at that was really a write time. Once the chunk is the
+        // fact's only home that is not a cosmetic gap — it is the whole temporal
+        // tier, and `when` narrows on observed_at.
+        var oaN = nanosOfStamp(fact.observed_at);
+        if (oaN !== null) { factArgs.observed_at = oaN; }
+        var vaN = nanosOfStamp(fact.valid_at);
+        if (vaN !== null) {
+          factArgs.valid_at = vaN;
+          var ivaN = nanosOfStamp(fact.invalid_at);
+          if (ivaN !== null) { factArgs.invalid_at = ivaN; }
+        }
         var factID = upsertEntityChunk(st, scope, docID, key, factArgs);
         if (!factID) { return; }
         st.entity_facts++;

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -109,7 +109,8 @@ const documentInputSchema = `{
 		"source_quote": {"type": "string", "description": "upsert_chunk: the EXACT text this fact was derived from, copied verbatim from the source you read — not a paraphrase. It is what a later pass checks the claim against, and what an operator sees when they ask why the store believes this. Omit only when there is no source text (material you are recording as evidence in its own right)."},
 		"natural_key": {"type": "string", "description": "upsert_chunk: the stable identity of this entity or fact. Upserting twice with the same key updates ONE chunk instead of adding a second — use a derived form such as person:ada-lovelace, or subject|predicate|object for a fact. Unique within the scope."},
 		"supersedes_id": {"type": "string", "description": "supersede_chunk: the id of the chunk being RETIRED by this one. The retired chunk is not deleted — it stays queryable so that questions about an earlier point in time still have an answer."},
-		"valid_at":   {"type": "integer", "description": "When the fact became true IN THE WORLD (unix nanos). Defaults to now. Distinct from when it was recorded."},
+		"valid_at":   {"type": "integer", "description": "When the fact became true IN THE WORLD (unix nanos). Omit when unknown — an undated fact is honest and still matches an as_of question; a guessed instant is not. Distinct from when it was recorded."},
+		"observed_at": {"type": "integer", "description": "When the thing was SAID or written (unix nanos), as distinct from when it became true. \"Yesterday I met them in Boston\", said on the 4th, is observed_at the 4th and valid_at the 3rd. Omit when unknown."},
 		"invalid_at": {"type": "integer", "description": "When the fact STOPPED being true in the world (unix nanos). Leave unset for something still true."},
 		"class":      {"type": "string", "enum": ["derived","evidential"], "description": "derived = distilled from something else (the default). evidential = source material, exempt from age-based pruning. list_facts: filter to facts of this class."},
 		"confidence": {"type": "number", "description": "0..1, how sure you are of this fact."},
@@ -230,8 +231,14 @@ type docInput struct {
 	SupersedesID string `json:"supersedes_id"`
 	// Pointers so "unset" is distinguishable from zero — valid_at=0 is a real
 	// instant (the unix epoch), not a missing value.
-	ValidAt    *int64   `json:"valid_at"`
-	InvalidAt  *int64   `json:"invalid_at"`
+	ValidAt   *int64 `json:"valid_at"`
+	InvalidAt *int64 `json:"invalid_at"`
+	// ObservedAt is WHEN THE THING WAS SAID, which is a different timeline from
+	// when it was true. The k/v memory plane has carried it since RFC CL and the
+	// chunk plane had no column for it at all — so a fact mirrored into the graph
+	// silently lost the one temporal field that is actually populated (measured
+	// 103/103 on a real corpus, against 27/103 for valid_at).
+	ObservedAt *int64   `json:"observed_at"`
 	Confidence *float64 `json:"confidence"`
 	// Class is 'derived' | 'evidential' — the retention-exemption signal.
 	Class string `json:"class"`
@@ -642,6 +649,9 @@ func (d *Document) ensureSchema(ctx context.Context, key sqlmem.ScopeKey) error 
 	if err := d.migrateAssetDescription(ctx, key); err != nil {
 		return err
 	}
+	if err := d.migrateFactObservation(ctx, key); err != nil {
+		return err
+	}
 	if err := d.migrateEdgeAuto(ctx, key); err != nil {
 		return err
 	}
@@ -743,6 +753,48 @@ func (d *Document) migrateDocumentFacets(ctx context.Context, key sqlmem.ScopeKe
 	}
 	return d.exec(ctx, key,
 		`UPDATE documents SET status = (SELECT status FROM chunks WHERE chunks.id = documents.root_chunk_id) WHERE status IS NULL`)
+}
+
+// migrateFactObservation adds chunk_memory_meta.observed_at, access_count and
+// last_accessed_at to a scope provisioned before the chunk plane had to carry
+// them.
+//
+// MEASURED, and it is why this exists: on one real corpus every one of 103 facts
+// carried observed_at in the k/v memory row and the chunk sidecar had NO COLUMN
+// FOR IT. observed_at is not a spare field — it is the predicate `when` narrows
+// on (RFC CL) and the only temporal value that is fully populated, so mirroring a
+// fact into the graph dropped the one date it actually had. valid_at, by
+// contrast, was 100% populated in the chunk plane and 26% in the k/v one, because
+// this table's writer defaulted it to now: three quarters of those instants were
+// write timestamps wearing world-time's column.
+//
+// access_count / last_accessed_at come along now rather than later because
+// access_count feeds the recall ranker's frequency term. They have no writer in
+// the chunk plane yet; the columns exist so that when a fact's home moves there
+// is somewhere for them to land, and ranking does not silently change.
+//
+// ALTER on every scope, new and old alike, and NOT declared in docSchemaDDL — a
+// CREATE TABLE IF NOT EXISTS leaves an existing table untouched, so the DDL alone
+// would reach only fresh scopes. Same shape as migrateAssetDescription: a
+// leading-SELECT fast path, then per-column probes so a crash between two ALTERs
+// does not become a duplicate-column error on the next run.
+func (d *Document) migrateFactObservation(ctx context.Context, key sqlmem.ScopeKey) error {
+	// Fast path: all three present → nothing to do (the common case).
+	if _, err := d.query(ctx, key, `SELECT observed_at, access_count, last_accessed_at FROM chunk_memory_meta WHERE 1=0`); err == nil {
+		return nil
+	}
+	for _, col := range []string{"observed_at", "access_count", "last_accessed_at"} {
+		if d.tableHasColumn(ctx, key, "chunk_memory_meta", col) {
+			continue
+		}
+		// BIGINT and NULLABLE for all three. Nullable matters: a zero access_count
+		// is a real count and a zero instant is 1970, so "never set" has to stay
+		// distinguishable from "set to nothing" — the same argument int64Arg makes.
+		if err := d.exec(ctx, key, `ALTER TABLE chunk_memory_meta ADD COLUMN `+col+` BIGINT`); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // migrateAssetDescription adds chunk_assets.description + described_at (RFC BU

--- a/internal/tools/builtin/document_entity.go
+++ b/internal/tools/builtin/document_entity.go
@@ -191,12 +191,22 @@ type chunkMetaRow struct {
 	// the caller. NULL on a verdict recorded before the column existed, which reads as
 	// unknown rather than as either party.
 	JudgedBy string
+	// ObservedAt is WHEN THE CLAIM WAS SAID — a third timeline, independent of both
+	// pairs above. A fact can be undated in the world (no valid_at) and still have a
+	// precise utterance time, which is what `when` narrows on; conflating the two
+	// loses the only date most facts actually carry.
+	ObservedAt *int64
+	// AccessCount / LastAccessedAt are RETRIEVAL telemetry, not content: access_count
+	// feeds the recall ranker's frequency term. Nil means never recorded, which is a
+	// different state from a count of zero.
+	AccessCount    *int64
+	LastAccessedAt *int64
 }
 
 // readChunkMeta returns the chunk's sidecar row, or found=false when it has none.
 func (d *Document) readChunkMeta(ctx context.Context, key sqlmem.ScopeKey, chunkID string) (row chunkMetaRow, found bool, err error) {
 	res, err := d.query(ctx, key,
-		`SELECT valid_at, invalid_at, created_at, expired_at, class, origin, confidence, session_id, run_id, event_seq, natural_key, coalesce(source_quote, ''), coalesce(subject, ''), judged_at, coalesce(judge_reason, ''), coalesce(judged_by, '')
+		`SELECT valid_at, invalid_at, created_at, expired_at, class, origin, confidence, session_id, run_id, event_seq, natural_key, coalesce(source_quote, ''), coalesce(subject, ''), judged_at, coalesce(judge_reason, ''), coalesce(judged_by, ''), observed_at, access_count, last_accessed_at
 		   FROM chunk_memory_meta WHERE chunk_id = ?`, chunkID)
 	if err != nil || len(res.Rows) == 0 {
 		return chunkMetaRow{}, false, err
@@ -209,6 +219,8 @@ func (d *Document) readChunkMeta(ctx context.Context, key sqlmem.ScopeKey, chunk
 		SessionID: asStr(r[7]), RunID: asStr(r[8]), EventSeq: asInt64Ptr(r[9]),
 		NaturalKey: asStr(r[10]), SourceQuote: asStr(r[11]), Subject: asStr(r[12]),
 		JudgedAt: asInt64Ptr(r[13]), JudgeReason: asStr(r[14]), JudgedBy: asStr(r[15]),
+		ObservedAt:  asInt64Ptr(r[16]),
+		AccessCount: asInt64Ptr(r[17]), LastAccessedAt: asInt64Ptr(r[18]),
 	}, true, nil
 }
 
@@ -229,6 +241,12 @@ func chunkMetaToJSON(m chunkMetaRow) map[string]any {
 	}
 	if m.InvalidAt != nil {
 		out["invalid_at"] = *m.InvalidAt
+	}
+	// observed_at is emitted beside the two intervals because it answers a
+	// different question from either: not when the claim was true, but when it was
+	// made. A reader that only sees valid_at cannot date an undated fact at all.
+	if m.ObservedAt != nil {
+		out["observed_at"] = *m.ObservedAt
 	}
 	if m.CreatedAt != nil {
 		out["created_at"] = *m.CreatedAt
@@ -486,13 +504,31 @@ func (d *Document) writeChunkMeta(ctx context.Context, key sqlmem.ScopeKey, chun
 		return err
 	}
 
-	// valid_at — caller, else what was already believed, else now.
-	validAt := now
+	// valid_at — caller, else what was already believed, else UNSET.
+	//
+	// It used to default to `now`, and that was a fabrication: world-time is not
+	// write-time, and on a measured corpus 117 of 120 sidecar rows carried a
+	// valid_at that was simply when the row was written, while the same facts were
+	// honestly undated in the k/v plane. An instant nobody asserted is worse than
+	// no instant, because a reader cannot tell it from one that was.
+	//
+	// Leaving it NULL is safe by construction, not by luck: the as-of predicate is
+	// already `(m.valid_at IS NULL OR m.valid_at <= ?)`, so an undated fact still
+	// answers "what was true then" — it is only excluded from a window it never
+	// claimed to be in.
+	var validAt *int64
 	if hadPrev && prev.ValidAt != nil {
-		validAt = *prev.ValidAt
+		validAt = prev.ValidAt
 	}
 	if in.ValidAt != nil {
-		validAt = *in.ValidAt
+		validAt = in.ValidAt
+	}
+	// observed_at — caller, else preserved. Preserved for the same reason as the
+	// provenance triple: an operator rewording a fact is not withdrawing the claim
+	// about when it was said.
+	observedAt := prev.ObservedAt
+	if in.ObservedAt != nil {
+		observedAt = in.ObservedAt
 	}
 	// invalid_at — caller, else preserved. Preserving is what keeps a retirement
 	// retired across a re-observation.
@@ -558,16 +594,21 @@ func (d *Document) writeChunkMeta(ctx context.Context, key sqlmem.ScopeKey, chun
 	}
 	return d.exec(ctx, key,
 		`INSERT INTO chunk_memory_meta
-		   (chunk_id, valid_at, invalid_at, created_at, expired_at, class, origin, confidence, session_id, run_id, event_seq, natural_key, source_quote, subject, judged_at, judge_reason, judged_by)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		chunkID, validAt, invalidAt, createdAt, expiredAt, class,
+		   (chunk_id, valid_at, invalid_at, created_at, expired_at, class, origin, confidence, session_id, run_id, event_seq, natural_key, source_quote, subject, judged_at, judge_reason, judged_by, observed_at, access_count, last_accessed_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		chunkID, int64Arg(validAt), invalidAt, createdAt, expiredAt, class,
 		originForEntityWrite(ctx), confidence,
 		// session_id has no writer yet: it is not on the run ctx, only the run id is.
 		// Preserved rather than nulled so the consolidation path — which CAN fill it
 		// when it relays a drained pending row — does not lose it to the next upsert.
 		nullIfEmpty(prev.SessionID), nullIfEmpty(runID), int64Arg(prev.EventSeq),
 		nullIfEmpty(naturalKey), nullIfEmpty(sourceQuote), nullIfEmpty(subject),
-		judgedAt, nullIfEmpty(judgeReason), nullIfEmpty(judgedBy))
+		judgedAt, nullIfEmpty(judgeReason), nullIfEmpty(judgedBy),
+		int64Arg(observedAt),
+		// PRESERVED, never stamped here. Nothing in the chunk plane counts a read
+		// yet — the k/v row still owns retrieval telemetry — so an upsert must not
+		// reset a count it cannot produce.
+		int64Arg(prev.AccessCount), int64Arg(prev.LastAccessedAt))
 }
 
 // int64Arg / float64Arg turn a nullable read back into a bind arg that round-trips

--- a/internal/tools/builtin/document_entity_preserve_test.go
+++ b/internal/tools/builtin/document_entity_preserve_test.go
@@ -84,10 +84,14 @@ func TestUpsert_ReObservationKeepsTheFirstBeliefTime(t *testing.T) {
 	d, ctx, _ := documentFixture(t)
 	docID := newEntityDoc(t, d, ctx)
 
-	id := upsert(t, d, ctx, docID, "rotation", "rotation", "Weekly, on Mondays.", "")
+	// valid_at is supplied EXPLICITLY. It used to arrive by default — the writer
+	// stamped `now` — so this test preserved a fabricated instant and would have
+	// passed with nil on both sides once that default went away. A caller-asserted
+	// world-time is the only kind whose preservation means anything.
+	id := upsertAt(t, d, ctx, docID, "rotation", "rotation", "Weekly, on Mondays.", "", 1688759760000000000)
 	first := metaOf(t, d, ctx, id)
 	if first.CreatedAt == nil || first.ValidAt == nil {
-		t.Fatalf("fixture: a fresh row should carry both start-timestamps, got %+v", first)
+		t.Fatalf("fixture: created_at is stamped and valid_at was supplied, got %+v", first)
 	}
 
 	upsert(t, d, ctx, docID, "rotation", "", "Weekly, on Mondays at 10:00 UTC.", "")
@@ -240,8 +244,17 @@ func TestUpsert_CreateIsUnchanged(t *testing.T) {
 	if got.Class != "derived" {
 		t.Errorf("a fresh row defaults to derived, got %q", got.Class)
 	}
-	if got.ValidAt == nil || got.CreatedAt == nil {
-		t.Errorf("a fresh row stamps both start-timestamps, got %+v", got)
+	// created_at IS stamped — the system always knows when it began believing
+	// something. valid_at is NOT: world-time is not write-time, and a fresh row
+	// whose caller named no instant is UNDATED. It used to default to `now`, which
+	// made three quarters of a measured corpus claim a world-time nobody supplied,
+	// indistinguishable from one that was asserted. An undated fact still answers
+	// as_of (`valid_at IS NULL OR valid_at <= ?`), so nothing is lost by saying so.
+	if got.CreatedAt == nil {
+		t.Errorf("a fresh row stamps created_at, got %+v", got)
+	}
+	if got.ValidAt != nil {
+		t.Errorf("a fresh row invented valid_at=%d — a write timestamp is not a world time", *got.ValidAt)
 	}
 	if got.InvalidAt != nil || got.ExpiredAt != nil {
 		t.Errorf("a fresh row is not retired, got invalid_at=%d expired_at=%d",
@@ -273,6 +286,34 @@ func newEntityDoc(t *testing.T, d *Document, ctx context.Context) string {
 
 // upsert returns the chunk id. A blank title is omitted entirely, which is how a
 // re-observation that only carries a body reaches the tool.
+// upsertAt is upsert with an explicit world-time. Separate rather than a variadic
+// so every existing caller keeps reading as "no valid_at supplied", which is now a
+// meaningful statement about the row rather than a gap the writer fills in.
+func upsertAt(t *testing.T, d *Document, ctx context.Context, docID, key, title, body, class string, validAt int64) string {
+	t.Helper()
+	in := map[string]any{
+		"op": "upsert_chunk", "scope": "user", "document_id": docID,
+		"natural_key": key, "body": body, "valid_at": validAt,
+	}
+	if title != "" {
+		in["title"] = title
+	}
+	if class != "" {
+		in["class"] = class
+	}
+	res, err := d.Execute(ctx, entityJSON(in))
+	if err != nil || res.IsError {
+		t.Fatalf("upsert_chunk %q: %v %s", key, err, res.Text)
+	}
+	var out struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(res.Text), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return out.ID
+}
+
 func upsert(t *testing.T, d *Document, ctx context.Context, docID, key, title, body, class string) string {
 	t.Helper()
 	in := map[string]any{

--- a/internal/tools/builtin/document_fact_observation_test.go
+++ b/internal/tools/builtin/document_fact_observation_test.go
@@ -1,0 +1,152 @@
+package builtin
+
+import (
+	"context"
+	"testing"
+)
+
+// The chunk plane's third timeline (RFC CV P2a).
+//
+// A fact carries three independent instants: when it was SAID (observed_at), when
+// it became true (valid_at) and when the system learned it (created_at). The
+// sidecar had columns for the last two pairs and none for the first, so a fact
+// mirrored from the k/v plane into the graph arrived with its only populated date
+// missing — measured at 103/103 facts on a real corpus — while the sidecar's own
+// writer stamped valid_at = now, making 117 of 120 rows claim a world-time they
+// had never been told.
+
+// sidecarInstants reads the three temporal columns for a chunk, as nil-able
+// values, so "unset" stays distinguishable from "set to the epoch".
+func sidecarInstants(t *testing.T, d *Document, ctx context.Context, chunkID string) (observed, valid *int64) {
+	t.Helper()
+	res, err := d.SqlMem.Query(ctx, sidecarScope(t, d, ctx),
+		d.SqlMem.Rebind(`SELECT observed_at, valid_at FROM chunk_memory_meta WHERE chunk_id = ?`),
+		[]any{chunkID})
+	if err != nil {
+		t.Fatalf("read sidecar instants: %v", err)
+	}
+	if len(res.Rows) == 0 {
+		t.Fatalf("no sidecar row for %s", chunkID)
+	}
+	return asInt64Ptr(res.Rows[0][0]), asInt64Ptr(res.Rows[0][1])
+}
+
+// TestUpsertChunk_ObservedAtReachesTheSidecarAndReadsBack. The write path and the
+// read path have to agree, and the round trip through get_chunk is the half a
+// column addition usually forgets: a value that lands in SQL but is not emitted is
+// invisible to every consumer, which is exactly how the k/v plane's temporal
+// columns went unread for a whole session (#1144).
+func TestUpsertChunk_ObservedAtReachesTheSidecarAndReadsBack(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	doc := newEntityDoc(t, d, ctx)
+	const said = int64(1688759760000000000) // 2023-07-07T19:56:00Z, the LoCoMo shape
+
+	out, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+doc+`","natural_key":"memory/fact/denn-prefers-go",
+		"title":"Denn prefers Go","body":"Denn prefers Go for backend services.",
+		"type":"fact","subject":"Denn","observed_at":1688759760000000000}`)
+	if r.IsError {
+		t.Fatalf("upsert_chunk: %s", r.Text)
+	}
+	id := asStr(out["id"])
+
+	if observed, _ := sidecarInstants(t, d, ctx, id); observed == nil || *observed != said {
+		t.Errorf("sidecar observed_at = %v, want %d — the fact's utterance time did not survive the write", observed, said)
+	}
+
+	// And it must come back out: `when` narrows on this field, so a value the read
+	// surface drops is a value no retrieval can use.
+	got, r := docExec(t, d, ctx, `{"op":"get_chunk","scope":"user","id":"`+id+`"}`)
+	if r.IsError {
+		t.Fatalf("get_chunk: %s", r.Text)
+	}
+	ent, _ := got["entity"].(map[string]any)
+	if ent == nil {
+		t.Fatalf("get_chunk returned no entity block: %v", got)
+	}
+	if v, ok := ent["observed_at"]; !ok {
+		t.Errorf("get_chunk omitted observed_at; entity block = %v", ent)
+	} else if int64(v.(float64)) != said {
+		t.Errorf("get_chunk observed_at = %v, want %d", v, said)
+	}
+}
+
+// TestUpsertChunk_AnUndatedFactGetsNoFabricatedValidAt is the correction half.
+//
+// valid_at defaulted to now, which asserts a world-time nobody supplied. It is not
+// a harmless default: a reader cannot tell a fabricated instant from a real one, so
+// every undated fact silently claimed to have become true at the moment it was
+// written. Leaving it NULL is safe by construction rather than by luck — the as-of
+// predicate is already `(valid_at IS NULL OR valid_at <= ?)`, which the companion
+// test below exercises.
+func TestUpsertChunk_AnUndatedFactGetsNoFabricatedValidAt(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	doc := newEntityDoc(t, d, ctx)
+
+	out, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+doc+`","natural_key":"memory/fact/undated",
+		"title":"Releases are never cut on a Friday","body":"Releases are never cut on a Friday.",
+		"type":"fact","subject":"the team"}`)
+	if r.IsError {
+		t.Fatalf("upsert_chunk: %s", r.Text)
+	}
+	id := asStr(out["id"])
+
+	if _, valid := sidecarInstants(t, d, ctx, id); valid != nil {
+		t.Errorf("valid_at = %d for a fact whose caller supplied none — a write timestamp is not a world time", *valid)
+	}
+}
+
+// TestUpsertChunk_AnUndatedFactStillAnswersAsOf proves the NULL is not a
+// regression. This is the property that makes dropping the default safe, so it is
+// asserted rather than assumed: an undated fact is not excluded from a temporal
+// question, it is only absent from a window it never claimed to be in.
+func TestUpsertChunk_AnUndatedFactStillAnswersAsOf(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	doc := newEntityDoc(t, d, ctx)
+	if _, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+doc+`","natural_key":"memory/fact/undated-recall",
+		"title":"Ada owns the ledger service","body":"Ada owns the ledger service.",
+		"type":"person","subject":"Ada"}`); r.IsError {
+		t.Fatalf("upsert_chunk: %s", r.Text)
+	}
+	// as_of well BEFORE the write: an undated fact has no start to fall outside of.
+	out, r := docExec(t, d, ctx, `{"op":"list_facts","scope":"user","as_of":1000000000000000000}`)
+	if r.IsError {
+		t.Fatalf("list_facts as_of: %s", r.Text)
+	}
+	rows, _ := out["facts"].([]any)
+	if len(rows) == 0 {
+		t.Errorf("an undated fact vanished from an as_of query — dropping the valid_at default would be a retrieval regression; got %v", out)
+	}
+}
+
+// TestMigrateFactObservation_ReachesAnExistingScope. A `CREATE TABLE IF NOT
+// EXISTS` leaves a provisioned table alone, so a fresh-database test cannot see
+// whether an UPGRADE works — the columns would appear on new scopes and never on
+// the ones that already hold data. The old shape is reconstructed here by dropping
+// the columns from a live scope and re-running ensureSchema.
+func TestMigrateFactObservation_ReachesAnExistingScope(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	// Provision the scope the ordinary way.
+	if _, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"seed"}`); r.IsError {
+		t.Fatalf("create_document: %s", r.Text)
+	}
+	key := sidecarScope(t, d, ctx)
+
+	// Rewind to the pre-migration shape.
+	for _, col := range []string{"observed_at", "access_count", "last_accessed_at"} {
+		if _, err := d.SqlMem.Exec(ctx, key, `ALTER TABLE chunk_memory_meta DROP COLUMN `+col, nil, 0); err != nil {
+			t.Fatalf("rewind %s: %v", col, err)
+		}
+	}
+	if d.tableHasColumn(ctx, key, "chunk_memory_meta", "observed_at") {
+		t.Fatal("rewind did not take — the test would pass against the unmigrated code")
+	}
+
+	if err := d.ensureSchema(ctx, key); err != nil {
+		t.Fatalf("ensureSchema: %v", err)
+	}
+	for _, col := range []string{"observed_at", "access_count", "last_accessed_at"} {
+		if !d.tableHasColumn(ctx, key, "chunk_memory_meta", col) {
+			t.Errorf("%s absent after ensureSchema — an existing scope never gains the column", col)
+		}
+	}
+}


### PR DESCRIPTION
RFC CV **P2a** — the prerequisite for the P2 collapse. The chunk plane could not hold the one temporal field that is actually populated, and invented the one that mostly is not.

## Why

Measured on a real LoCoMo corpus, the **same 103 facts** in both planes:

| field | k/v memory row | `chunk_memory_meta` |
|---|---|---|
| `observed_at` | **103/103 populated** | **no such column** |
| `valid_at` | 27/103 (NULL = undated) | 103/103 — of which **117 write-stamped** |

`observed_at` is not a spare field. It is the predicate `when` narrows on (RFC CL) and the only fully-populated temporal value in the store, so a fact mirrored into the graph arrived with its only date missing. That is survivable while the k/v row is the fact's home. It stops being survivable when the chunk becomes the *only* home — the temporal tier would simply be gone, on the axis RFC CV names as one of three mechanisms behind the ~50-point gap.

`valid_at` was the mirror-image defect. `writeChunkMeta` defaulted it to `now`, so a fact whose caller named no world-time claimed to have become true at the moment it was written — indistinguishable, to any reader, from one that really was.

## What

- `chunk_memory_meta` gains `observed_at`, `access_count`, `last_accessed_at`. By **ALTER on every scope, new and old alike**, not in `docSchemaDDL`: a `CREATE TABLE IF NOT EXISTS` leaves a provisioned table untouched, so the DDL alone would reach only fresh scopes.
- `upsert_chunk` accepts and persists `observed_at`, and `get_chunk` emits it.
- `valid_at` stops defaulting. Leaving it NULL is safe **by construction, not by luck**: the as-of predicate is already `(valid_at IS NULL OR valid_at <= ?)`, so an undated fact still answers "what was true then" and is only absent from a window it never claimed to be in. A test asserts that rather than assuming it.
- The bundle was the other half — the k/v write carried the three fields and the mirror carried none, which is *why* the sidecar held write times. It now converts this bundle's RFC3339 strings to the unix nanos the Document tool takes.
- `access_count` / `last_accessed_at` arrive with **no writer yet**. `access_count` feeds the recall ranker's frequency term, so the columns exist before the collapse needs them and ranking cannot change silently underneath it.

`Date.parse` is used in the bundle helper and that does not contradict `parseStamp`'s refusal to use it: `parseStamp` reads untrusted transcript text, where guessing at ambiguity is the defect; here the input has already passed a strict RFC3339 test, so there is nothing left to guess.

## Two existing tests changed, neither guarding this

- `TestUpsert_ReObservationKeepsTheFirstBeliefTime` used `valid_at` as fixture, not subject. It now supplies an **explicit** world-time, so its preservation claim is about a caller-asserted instant instead of a fabricated one — it would otherwise have passed vacuously with nil on both sides.
- `TestUpsert_CreateIsUnchanged` flips to assert that a fresh row stamps `created_at` and leaves `valid_at` unset, with the reason recorded.

## What was tested

`TestUpsertChunk_ObservedAtReachesTheSidecarAndReadsBack` (the SQL column **and** the `get_chunk` round trip — a value that lands but is not emitted is invisible, which is exactly how #1144 happened), `TestUpsertChunk_AnUndatedFactGetsNoFabricatedValidAt`, `TestUpsertChunk_AnUndatedFactStillAnswersAsOf`, and `TestMigrateFactObservation_ReachesAnExistingScope`, which **rewinds a live scope to the pre-migration shape** because a fresh-database test cannot see whether an upgrade works.

Fail-before was verified in two parts, because the first was the wrong shape: reverting everything makes all three new tests die on `no such column`, which proves the column is new and nothing about behaviour. Reverting **only** the `valid_at` default, with the migration left in place, fails both undated tests on a real fabricated instant (`valid_at=1789064200117264000`).

## Live gate

Fresh corpus pass on a rig built from this branch (served commit asserted against the binary), 84 facts:

| plane | facts | `observed_at` | `valid_at` |
|---|---|---|---|
| k/v | 84 | **78** | 2 |
| chunk (fact chunks only) | 84 | **78** | 1 |

Coverage is identical and the **instants are byte-identical** on the same natural keys, not merely the counts. Subject nodes are excluded from the chunk side deliberately: a subject is an identity, not a claim, and has no utterance time.

**One residual, stated rather than smoothed over:** `valid_at` is 1 vs 2. The missing row went through the merge/update-in-place path, where the k/v write preserves a `valid_at` from an earlier write of that key while the chunk's `prev` for that natural key had none — a preserve-rule difference between the two planes. It is a one-row gap of a real value replacing a 117-row fabrication, and it becomes moot at P2d when the k/v row goes away. Not fixed here.

`go test ./...` clean. Both bundle copies byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8