### PR TITLE
feat(agentdef): named: scopes match by path segment, not only exactly

### DIFF
--- a/internal/config/agentdef_globscope_test.go
+++ b/internal/config/agentdef_globscope_test.go
@@ -1,6 +1,9 @@
 package config
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // Decision 7's guard rail. A bare wildcard grants every name at that depth,
 // which is so close to `any` that writing it is almost certainly a mistake —
@@ -16,6 +19,36 @@ func TestValidateAgentDefScope_BareWildcardIsRefused(t *testing.T) {
 	for _, sc := range []string{"named:sdlc/*", "named:sdlc/**", "named:sdlc/review/*", "named:coder"} {
 		if err := validateAgentDefScope(sc); err != nil {
 			t.Errorf("%q rejected: %v", sc, err)
+		}
+	}
+}
+
+// A pattern the matcher can never match is refused at authoring time rather
+// than granted-and-silent. Each case below is a grant an operator would
+// reasonably write and then wait forever for.
+func TestValidateAgentDefScope_UnmatchablePatternsAreRefused(t *testing.T) {
+	cases := []struct {
+		scope string
+		want  string
+	}{
+		// `**` means "all remaining segments", so nothing can follow it.
+		{"named:sdlc/**/review", "must be last"},
+		// A wildcard is a whole segment; `sdlc*` reads like a prefix match and
+		// is not one — it would match only an agent literally named `sdlc*`,
+		// which agents.ValidateName forbids.
+		{"named:sdlc*", "whole segment"},
+		{"named:sdlc/rev*", "whole segment"},
+		{"named:*sdlc", "whole segment"},
+		{"named:a/**b/c", "whole segment"},
+	}
+	for _, c := range cases {
+		err := validateAgentDefScope(c.scope)
+		if err == nil {
+			t.Errorf("%q accepted; it can never match a valid agent name", c.scope)
+			continue
+		}
+		if !strings.Contains(err.Error(), c.want) {
+			t.Errorf("%q refused with %q, want it to mention %q", c.scope, err, c.want)
 		}
 	}
 }

--- a/internal/config/agentdef_globscope_test.go
+++ b/internal/config/agentdef_globscope_test.go
@@ -1,0 +1,21 @@
+package config
+
+import "testing"
+
+// Decision 7's guard rail. A bare wildcard grants every name at that depth,
+// which is so close to `any` that writing it is almost certainly a mistake —
+// and an operator who means "everything" should say `any`, where it reads as
+// the grant it is.
+func TestValidateAgentDefScope_BareWildcardIsRefused(t *testing.T) {
+	for _, sc := range []string{"named:*", "named:**"} {
+		if err := validateAgentDefScope(sc); err == nil {
+			t.Errorf("%q accepted; it grants every agent name", sc)
+		}
+	}
+	// A SCOPED pattern is the point of the feature and must stay accepted.
+	for _, sc := range []string{"named:sdlc/*", "named:sdlc/**", "named:sdlc/review/*", "named:coder"} {
+		if err := validateAgentDefScope(sc); err != nil {
+			t.Errorf("%q rejected: %v", sc, err)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5873,6 +5873,55 @@ var validHistoryScopes = map[string]bool{
 	"any":    true, // legacy alias for "global"
 }
 
+// ValidateNamedScopePattern checks the pattern half of a `named:<pattern>`
+// capability grant — the segment-glob matcher lives in the AgentDef tool
+// (matchNamedScope), and this is the shape it will accept.
+//
+// EVERY REFUSAL HERE IS A GRANT THAT WOULD NEVER FIRE, or one that fires far
+// wider than it reads. A pattern the matcher silently never matches is worse
+// than a boot error: the operator believes an authority was granted, and finds
+// out when the agent is refused at 3am.
+//
+// Exported because the substrate write path (an agent authoring another
+// agent's def) has to apply the same rule as operator yaml. A check that runs
+// on only one of the two planes teaches an operator a rule the other plane
+// does not keep.
+func ValidateNamedScopePattern(pattern string) error {
+	if pattern == "" {
+		return fmt.Errorf("agent_def_scopes: \"named:\" requires a non-empty name (e.g. \"named:coder\")")
+	}
+	// A BARE wildcard matches every name at that depth, which is so close to
+	// `any` that writing it is almost certainly a mistake rather than an
+	// intent — and an operator who does mean "everything" should say `any`,
+	// where it reads as the grant it is. Refused rather than warned: a log
+	// line at config load is not seen by the person editing the yaml.
+	if pattern == "*" || pattern == "**" {
+		return fmt.Errorf("agent_def_scopes: \"named:%s\" grants every agent name — write \"any\" if that is the intent, "+
+			"or scope the pattern (e.g. \"named:sdlc/**\")", pattern)
+	}
+	segs := strings.Split(pattern, "/")
+	for i, seg := range segs {
+		if !strings.Contains(seg, "*") {
+			continue
+		}
+		// A segment is either a literal or a whole wildcard. `sdlc*` reads like
+		// a prefix match and is not one — the matcher compares segments, so it
+		// would match only an agent literally named `sdlc*`, which
+		// agents.ValidateName forbids. Dead on arrival, so refuse it.
+		if seg != "*" && seg != "**" {
+			return fmt.Errorf("agent_def_scopes: \"named:%s\" — a wildcard must be a whole segment (%q is neither a literal name nor \"*\"/\"**\"); "+
+				"write \"named:sdlc/*\" for one level or \"named:sdlc/**\" for the subtree", pattern, seg)
+		}
+		// `**` means "all remaining segments", so anything after it can never
+		// be reached. `a/**/b` matches nothing at all today.
+		if seg == "**" && i != len(segs)-1 {
+			return fmt.Errorf("agent_def_scopes: \"named:%s\" — \"**\" matches all remaining segments, so it must be last; "+
+				"a pattern with segments after it can never match", pattern)
+		}
+	}
+	return nil
+}
+
 // validateAgentDefScope checks one entry in an agent's
 // agent_def_scopes list. Closed set:
 //
@@ -5890,19 +5939,7 @@ func validateAgentDefScope(sc string) error {
 		return nil
 	}
 	if ref, ok := strings.CutPrefix(sc, "named:"); ok {
-		if ref == "" {
-			return fmt.Errorf("agent_def_scopes: \"named:\" requires a non-empty name (e.g. \"named:coder\")")
-		}
-		// A BARE wildcard matches every name at that depth, which is so close to
-		// `any` that writing it is almost certainly a mistake rather than an
-		// intent — and an operator who does mean "everything" should say `any`,
-		// where it reads as the grant it is. Refused rather than warned: a log
-		// line at config load is not seen by the person editing the yaml.
-		if ref == "*" || ref == "**" {
-			return fmt.Errorf("agent_def_scopes: %q grants every agent name — write \"any\" if that is the intent, "+
-				"or scope the pattern (e.g. \"named:sdlc/**\")", sc)
-		}
-		return nil
+		return ValidateNamedScopePattern(ref)
 	}
 	return fmt.Errorf("unknown scope %q (want one of: self, descendants, any, or \"named:<name>\")", sc)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5889,10 +5889,18 @@ func validateAgentDefScope(sc string) error {
 	case "self", "descendants", "any":
 		return nil
 	}
-	if strings.HasPrefix(sc, "named:") {
-		ref := strings.TrimPrefix(sc, "named:")
+	if ref, ok := strings.CutPrefix(sc, "named:"); ok {
 		if ref == "" {
 			return fmt.Errorf("agent_def_scopes: \"named:\" requires a non-empty name (e.g. \"named:coder\")")
+		}
+		// A BARE wildcard matches every name at that depth, which is so close to
+		// `any` that writing it is almost certainly a mistake rather than an
+		// intent — and an operator who does mean "everything" should say `any`,
+		// where it reads as the grant it is. Refused rather than warned: a log
+		// line at config load is not seen by the person editing the yaml.
+		if ref == "*" || ref == "**" {
+			return fmt.Errorf("agent_def_scopes: %q grants every agent name — write \"any\" if that is the intent, "+
+				"or scope the pattern (e.g. \"named:sdlc/**\")", sc)
 		}
 		return nil
 	}

--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -677,14 +677,70 @@ func (a *AgentDef) checkScopeForName(policy tools.AgentDefPolicyValue, name, _ s
 			// for the pinned-but-undesired current behaviour.
 			return nil
 		default:
-			if strings.HasPrefix(sc, "named:") {
-				if strings.TrimPrefix(sc, "named:") == name {
+			if pat, ok := strings.CutPrefix(sc, "named:"); ok {
+				if matchNamedScope(pat, name) {
 					return nil
 				}
 			}
 		}
 	}
 	return fmt.Errorf("AgentDef tool: name %q not in this agent's agent_def_scopes (%v)", name, policy.Scopes)
+}
+
+// matchNamedScope matches a `named:<pattern>` grant against an agent name.
+//
+// Agent names are a SEGMENTED path grammar (agents.ValidateName splits on "/"
+// and validates each segment), so a grant should be able to speak in segments
+// too. Exact match still works; the two wildcards are path-style, familiar from
+// gitignore:
+//
+//	named:sdlc          → sdlc                        (exact, unchanged)
+//	named:sdlc/*        → sdlc/review                 but NOT sdlc/review/sec
+//	named:sdlc/**       → sdlc/review AND sdlc/review/sec
+//	named:sdlc/review/* → sdlc/review/sec only
+//
+// WHY IT EXISTS. A team-scoped meta-agent authors clones under a `<team>/`
+// prefix, and those names do not exist when the grant is written — with exact
+// match only, the convention is useless for authority and an operator must
+// either enumerate names that do not exist yet or fall back to `any`.
+//
+// WHY WIDENING THE GATE IS SAFE. A glob only ever expands what an OPERATOR
+// explicitly wrote in a def, so it grants nothing an operator could not grant by
+// enumeration — it removes the requirement to enumerate the unknowable. And
+// ValidateName REFUSES `*` and `?` in a name, so a pattern can never be confused
+// for a literal name and no existing name can accidentally match as a glob.
+// That property is what makes this a safe addition rather than a new surface.
+//
+// `*` matches exactly ONE segment, so an operator can grant one level without
+// granting the subtree — which a flat prefix match cannot express, and which is
+// the whole reason for having two wildcards.
+func matchNamedScope(pattern, name string) bool {
+	if pattern == name {
+		return true
+	}
+	if !strings.Contains(pattern, "*") {
+		return false // exact-only pattern, already compared
+	}
+	pseg := strings.Split(pattern, "/")
+	nseg := strings.Split(name, "/")
+	for i, p := range pseg {
+		if p == "**" {
+			// Matches all REMAINING segments — but at least one, so `sdlc/**`
+			// grants the subtree without granting `sdlc` itself. A grant on the
+			// parent is `named:sdlc`, and conflating the two would hand out an
+			// agent the operator did not name.
+			return i < len(nseg) && i == len(pseg)-1
+		}
+		if i >= len(nseg) {
+			return false
+		}
+		if p != "*" && p != nseg[i] {
+			return false
+		}
+	}
+	// Every pattern segment matched; the name must not have more left over, or
+	// `sdlc/*` would match `sdlc/review/sec` and silently grant the subtree.
+	return len(nseg) == len(pseg)
 }
 
 // buildDefinition takes the base definition (parent's JSON for fork;

--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -772,9 +772,40 @@ func (a *AgentDef) buildDefinition(ctx context.Context, name, parentJSON string,
 		if err := json.Unmarshal(overlay, &ov); err != nil {
 			return mergedDef{}, fmt.Errorf("parse overlay: %w", err)
 		}
+		if err := validateOverlayNamedScopes(ov.AgentDefScopes); err != nil {
+			return mergedDef{}, err
+		}
 		base.applyOverlay(ov)
 	}
 	return base, nil
+}
+
+// validateOverlayNamedScopes applies the operator-yaml rule for
+// `named:<pattern>` grants to the SUBSTRATE write path, where one agent
+// authors another's def.
+//
+// The two planes have to agree. Operator yaml refuses a bare `named:**` (it
+// grants every name at that depth) and a pattern the matcher can never match;
+// without the same check here, an operator who learned the rule from a boot
+// error finds the runtime path quietly keeping a different one.
+//
+// It checks only what the CALLER supplied, never what a parent def already
+// carried: refusing on an inherited value would brick forking a def that
+// predates this rule, and this validates authoring, not history. Scope strings
+// that are not `named:` are left alone — widening validation to the whole
+// closed set would start refusing typos that today round-trip harmlessly as
+// default-deny, which is a separate decision from this one.
+func validateOverlayNamedScopes(scopes []string) error {
+	for _, sc := range scopes {
+		pat, ok := strings.CutPrefix(sc, "named:")
+		if !ok {
+			continue
+		}
+		if err := config.ValidateNamedScopePattern(pat); err != nil {
+			return fmt.Errorf("agent_def_scopes: %w", err)
+		}
+	}
+	return nil
 }
 
 // resolveToolsRoot returns the operator-blessed Tools

--- a/internal/tools/builtin/agentdef_globscope_test.go
+++ b/internal/tools/builtin/agentdef_globscope_test.go
@@ -1,0 +1,84 @@
+package builtin
+
+import (
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// The NEGATIVE cases are the point of this table. A prefix match that let
+// `sdlc/*` reach `sdlc/review/sec-review` would silently grant a subtree the
+// operator named one level of — so the two wildcards must stay distinguishable.
+func TestMatchNamedScope(t *testing.T) {
+	cases := []struct {
+		pattern, name string
+		want          bool
+	}{
+		// exact, unchanged behaviour
+		{"sdlc", "sdlc", true},
+		{"sdlc", "sdlc/review", false},
+		{"sdlc/review", "sdlc/review", true},
+
+		// one segment
+		{"sdlc/*", "sdlc/review", true},
+		{"sdlc/*", "sdlc/review/sec-review", false},
+		{"sdlc/*", "sdlc", false},
+		{"sdlc/review/*", "sdlc/review/sec-review", true},
+		{"sdlc/review/*", "sdlc/review", false},
+
+		// all remaining segments
+		{"sdlc/**", "sdlc/review", true},
+		{"sdlc/**", "sdlc/review/sec-review", true},
+		{"sdlc/**", "sdlc", false},
+
+		// a neighbouring prefix must not match — the classic prefix-match bug
+		{"sdlc/**", "sdlcx/review", false},
+		{"sdlc/*", "sdlcx/review", false},
+
+		// wildcards are positional, not free-floating
+		{"*/review", "sdlc/review", true},
+		{"*/review", "sdlc/design", false},
+		{"*", "sdlc", true},
+		{"*", "sdlc/review", false},
+		{"**", "sdlc", true},
+		{"**", "sdlc/review/sec", true},
+	}
+	for _, c := range cases {
+		if got := matchNamedScope(c.pattern, c.name); got != c.want {
+			t.Errorf("matchNamedScope(%q, %q) = %v, want %v", c.pattern, c.name, got, c.want)
+		}
+	}
+}
+
+// A glob is only reachable through a grant an OPERATOR wrote, and it still
+// refuses everything outside it — the gate stays default-deny and a pattern
+// cannot be widened into `any` by accident.
+func TestCheckScopeForName_GlobGrantsTheSubtreeAndNothingElse(t *testing.T) {
+	a := &AgentDef{}
+	pol := agentDefPolicy("named:sdlc/**")
+
+	for _, name := range []string{"sdlc/review", "sdlc/review/sec-review"} {
+		if err := a.checkScopeForName(pol, name, ""); err != nil {
+			t.Errorf("%s: want granted, got %v", name, err)
+		}
+	}
+	for _, name := range []string{"sdlc", "other/review", "sdlcx/review"} {
+		if err := a.checkScopeForName(pol, name, ""); err == nil {
+			t.Errorf("%s: want refused", name)
+		}
+	}
+}
+
+// Default-deny is unchanged: an agent with no scopes is refused regardless of
+// what the name looks like.
+func TestCheckScopeForName_NoScopesStillDefaultDeny(t *testing.T) {
+	a := &AgentDef{}
+	if err := a.checkScopeForName(agentDefPolicy(), "sdlc/review", ""); err == nil {
+		t.Error("an agent with no agent_def_scopes must be refused")
+	}
+}
+
+// agentDefPolicy builds a policy carrying just the scopes under test.
+func agentDefPolicy(scopes ...string) tools.AgentDefPolicyValue {
+	return tools.AgentDefPolicyValue{Scopes: scopes}
+}

--- a/internal/tools/builtin/agentdef_globscope_test.go
+++ b/internal/tools/builtin/agentdef_globscope_test.go
@@ -82,3 +82,33 @@ func TestCheckScopeForName_NoScopesStillDefaultDeny(t *testing.T) {
 func agentDefPolicy(scopes ...string) tools.AgentDefPolicyValue {
 	return tools.AgentDefPolicyValue{Scopes: scopes}
 }
+
+// The substrate write path applies the SAME named-pattern rule as operator
+// yaml. Without this, an operator who learned the rule from a boot error would
+// find the runtime plane quietly keeping a different one — and the bare
+// wildcard the yaml refuses would be one AgentDef create away.
+func TestAgentDefTool_OverlayNamedScopeValidation(t *testing.T) {
+	refused := []string{
+		"named:*",           // grants every name — say `any` instead
+		"named:**",          //
+		"named:sdlc/**/rev", // ** must be last
+		"named:sdlc*",       // a wildcard is a whole segment
+	}
+	for _, sc := range refused {
+		if err := validateOverlayNamedScopes([]string{sc}); err == nil {
+			t.Errorf("overlay scope %q accepted on the substrate path; yaml refuses it", sc)
+		}
+	}
+	accepted := []string{"named:coder", "named:sdlc/*", "named:sdlc/**", "self", "descendants", "any"}
+	for _, sc := range accepted {
+		if err := validateOverlayNamedScopes([]string{sc}); err != nil {
+			t.Errorf("overlay scope %q refused: %v", sc, err)
+		}
+	}
+	// An unknown non-`named:` string is NOT this function's business — it is
+	// default-deny at the gate, and refusing it here would be a separate
+	// behaviour change that could break defs already in the wild.
+	if err := validateOverlayNamedScopes([]string{"typo-scope"}); err != nil {
+		t.Errorf("a non-named scope should pass through untouched, got %v", err)
+	}
+}


### PR DESCRIPTION
**RFC CY Decision 7** — the last piece of the clone convention Decision 3 established.

## Why

A team-scoped meta-agent authors clones under a `<team>/` prefix, and **those names don't exist when the grant is written**. With exact match only, the convention is useless for *authority*: an operator must either enumerate names that don't exist yet, or fall back to `any` and grant everything.

Agent names are already a segmented path grammar — `agents.ValidateName` splits on `/` and validates each segment — so a grant can speak in segments too:

```
named:sdlc          → sdlc                     (exact, unchanged)
named:sdlc/*        → sdlc/review              but NOT sdlc/review/sec
named:sdlc/**       → sdlc/review AND sdlc/review/sec
named:sdlc/review/* → sdlc/review/sec only
```

**Two wildcards, not one.** `*` matches exactly one segment, so an operator can grant one level *without* granting the subtree — which a flat prefix match can't express, and which is the whole reason for having both.

## Why widening this gate is safe

A glob only ever expands what an **operator** explicitly wrote in a def, so it grants nothing an operator couldn't grant by enumeration — it removes the requirement to enumerate the unknowable. And `ValidateName` **refuses `*` and `?` in a name**, so a pattern can never be confused for a literal name and no existing name can accidentally match as a glob. That property is what makes this an addition rather than a new surface.

`**` deliberately does **not** match its own prefix: `named:sdlc/**` grants the subtree but not `sdlc` itself. Conflating them would hand out an agent the operator didn't name.

## One deviation from the decision

Decision 7 said to **warn** on a bare `named:*` / `named:**`. This **refuses** it at config load instead. A log line at config load isn't seen by the person editing the yaml, and this is a capability gate — an operator who means "everything" should write `any`, where it reads as the grant it is.

## Tested

`go test ./...` clean (**100 packages**, full output grepped for `FAIL`).

- a 20-case table whose **negatives** are the point: `sdlc/*` must not reach `sdlc/review/sec-review`; `sdlc/**` must not match `sdlcx/review` (the classic prefix-match bug) and must not match `sdlc` itself;
- the gate grants the subtree **and nothing else**, and stays default-deny with no scopes;
- a bare wildcard is refused at config load while every scoped pattern is accepted.

**Verified fail-before** by reverting the matcher to exact comparison — the subtree-grant test fails naming both refused names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD