### PR TITLE
fix(memory): classify a chunk-homed fact by its provenance, not its namespace

### DIFF
--- a/internal/memory/backend.go
+++ b/internal/memory/backend.go
@@ -210,6 +210,12 @@ func (q SearchQuery) Filter() (store.MemorySearchFilter, error) {
 		if f.KeyPrefix == "" {
 			f.KeyPrefix = DocumentChunkKeyPrefix
 		}
+		// AND provenance-free. The prefix alone selects every chunk body, facts
+		// included, so "documents" used to return distilled facts — and the label
+		// agreed with the filter only because both were wrong in the same way. A
+		// fact's body row now carries an origin, so excluding provenance is what
+		// makes this selector mean prose.
+		f.Provenance = store.ProvenanceAbsent
 	case memory && !docs:
 		f.ExcludeKeyPrefix = DocumentChunkKeyPrefix
 		if facts && !notes {

--- a/internal/memory/sources_test.go
+++ b/internal/memory/sources_test.go
@@ -29,9 +29,13 @@ func TestSearchQueryFilter_SourcesMapToPredicate(t *testing.T) {
 		},
 
 		{
-			name: "documents restricts to it",
+			name: "documents restricts to prose — the namespace AND no provenance",
 			q:    SearchQuery{Sources: []Source{SourceDocuments}},
-			want: store.MemorySearchFilter{KeyPrefix: DocumentChunkKeyPrefix},
+			want: store.MemorySearchFilter{KeyPrefix: DocumentChunkKeyPrefix, Provenance: store.ProvenanceAbsent},
+			comment: "the prefix alone selects every chunk body, facts included, so " +
+				"asking for documents used to return distilled facts; a fact's body " +
+				"row carries an origin, so excluding provenance is what makes this " +
+				"selector mean prose",
 		},
 		{
 			name: "all three is the same as neither",
@@ -74,7 +78,7 @@ func TestSearchQueryFilter_SourcesMapToPredicate(t *testing.T) {
 		{
 			name: "an explicit prefix WINS over documents-only",
 			q:    SearchQuery{Prefix: "doc.chunk:abc", Sources: []Source{SourceDocuments}},
-			want: store.MemorySearchFilter{KeyPrefix: "doc.chunk:abc"},
+			want: store.MemorySearchFilter{KeyPrefix: "doc.chunk:abc", Provenance: store.ProvenanceAbsent},
 			comment: "narrowing to one chunk must not be widened back to the whole " +
 				"namespace by the selector",
 		},
@@ -155,7 +159,13 @@ func TestClass_LabelsRowsFromTheirOwnColumns(t *testing.T) {
 		want        store.MemoryRowClass
 	}{
 		{"doc.chunk:abc", "", store.MemoryRowDocument},
-		{"doc.chunk:abc", "consolidator", store.MemoryRowDocument}, // namespace wins
+		// PROVENANCE wins, not the namespace. The prefix says "this row is a chunk
+		// body"; it does not say what kind of thing the chunk holds, and facts and
+		// prose are both chunk bodies. Namespace-first therefore labelled every
+		// chunk-homed fact a document — which is why `sources=documents` returned
+		// facts — and the filter agreed with the label only because both were wrong
+		// in the same way. A body row carries an origin iff a distiller wrote it.
+		{"doc.chunk:abc", "consolidator", store.MemoryRowFact},
 		{"memory/fact/x", "consolidator", store.MemoryRowFact},
 		{"memory/fact/x", "", store.MemoryRowNote}, // no writer stamped
 		{"scratch/todo", "", store.MemoryRowNote},

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -3222,11 +3222,21 @@ const (
 // documentKeyPrefix is passed rather than hardcoded: the namespace belongs to the
 // Document tool, and storage should not know its spelling.
 func ClassifyMemoryRow(key, origin, documentKeyPrefix string) MemoryRowClass {
-	if documentKeyPrefix != "" && strings.HasPrefix(key, documentKeyPrefix) {
-		return MemoryRowDocument
-	}
+	// PROVENANCE IS TESTED FIRST, and the order is the whole fix. The key prefix
+	// says "this row is a chunk body"; it does not say what KIND of thing the chunk
+	// is. Facts and document prose are both chunk bodies, so a prefix-first test
+	// classified every fact that had a chunk as a document — which is why
+	// `sources=documents` returned facts.
+	//
+	// origin is the right discriminator because it is server-stamped and
+	// unforgeable: it is deliberately absent from the `Memory set` input schema
+	// precisely because it names the writer. A distilled fact carries one; prose an
+	// author typed does not.
 	if strings.TrimSpace(origin) != "" {
 		return MemoryRowFact
+	}
+	if documentKeyPrefix != "" && strings.HasPrefix(key, documentKeyPrefix) {
+		return MemoryRowDocument
 	}
 	return MemoryRowNote
 }

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -238,7 +238,12 @@ type docInput struct {
 	// chunk plane had no column for it at all — so a fact mirrored into the graph
 	// silently lost the one temporal field that is actually populated (measured
 	// 103/103 on a real corpus, against 27/103 for valid_at).
-	ObservedAt *int64   `json:"observed_at"`
+	ObservedAt *int64 `json:"observed_at"`
+	// bodyOrigin is the origin to stamp on this chunk's BODY row, threaded from
+	// the fact-tier write path. UNEXPORTED on purpose: origin names the writer, so
+	// a caller must not be able to claim one — an exported field would be settable
+	// from the tool's JSON input and the column would stop being trustworthy.
+	bodyOrigin string
 	Confidence *float64 `json:"confidence"`
 	// Class is 'derived' | 'evidential' — the retention-exemption signal.
 	Class string `json:"class"`
@@ -950,6 +955,28 @@ type chunkBody struct {
 }
 
 func (d *Document) writeBody(ctx context.Context, mscope store.MemoryScope, key sqlmem.ScopeKey, chunkID, chunkType, body string, fields json.RawMessage) error {
+	return d.writeBodyAs(ctx, mscope, key, chunkID, chunkType, body, fields, "")
+}
+
+// writeBodyAs is writeBody with the row's ORIGIN — who produced this content.
+//
+// An ordinary document chunk passes "" and the row stays provenance-free, which is
+// what marks it as prose. An ENTITY write passes the same origin its sidecar
+// records, and that is the whole point: a fact's body row was previously
+// indistinguishable from a document's, because both are `doc.chunk:<hex>` keys with
+// an empty origin. Retrieval therefore had only the key prefix to go on, and the
+// key prefix says "chunk body", not "fact" — so `sources=documents` returned facts
+// and labelled them documents.
+//
+// It has to be ORIGIN rather than a new column. origin is already server-stamped
+// and deliberately absent from the `Memory set` input schema BECAUSE it names the
+// writer, so a caller cannot claim one; a fresh `row_class` column would add a
+// writer-forgot-to-set failure mode, which is the class of bug a derived
+// discriminator exists to avoid. And it cannot be a lookup: chunk_memory_meta lives
+// in SQL Memory — a DIFFERENT database from the k/v plane — so consulting it per
+// candidate would be a cross-database round trip from each of the four call sites
+// that label a row.
+func (d *Document) writeBodyAs(ctx context.Context, mscope store.MemoryScope, key sqlmem.ScopeKey, chunkID, chunkType, body string, fields json.RawMessage, origin string) error {
 	scopeID := key.ScopeID
 	v, _ := json.Marshal(chunkBody{Body: body, Fields: fields})
 	// RFC BL: key chunk bodies on the same tenant the document's dirent + SQL
@@ -957,7 +984,12 @@ func (d *Document) writeBody(ctx context.Context, mscope store.MemoryScope, key 
 	// structure never drift across the tenant axis.
 	tenant := direntTenant(ctx)
 	bodyKey := chunkBodyKey(chunkID)
-	if err := d.Store.MemorySet(ctx, tenant, mscope, scopeID, bodyKey, v, 0); err != nil {
+	if origin == "" {
+		if err := d.Store.MemorySet(ctx, tenant, mscope, scopeID, bodyKey, v, 0); err != nil {
+			return err
+		}
+	} else if err := d.Store.MemorySetProvenance(ctx, tenant, mscope, scopeID, bodyKey, v, 0,
+		store.MemoryProvenance{Origin: origin}); err != nil {
 		return err
 	}
 	// The body is durable at this point. Embedding is a SEPARATE, best-effort
@@ -1954,7 +1986,7 @@ func (d *Document) createChunk(ctx context.Context, key sqlmem.ScopeKey, mscope 
 	if insErr != nil {
 		return errResult("create_chunk: " + insErr.Error()), nil
 	}
-	if err := d.writeBody(ctx, mscope, key, id, in.Type, in.Body, in.Fields); err != nil {
+	if err := d.writeBodyAs(ctx, mscope, key, id, in.Type, in.Body, in.Fields, in.bodyOrigin); err != nil {
 		return errResult("create_chunk: body: " + err.Error()), nil
 	}
 	// Seed the body-change log at revision 1 (RFC BS Phase 3a) — the chunk's body

--- a/internal/tools/builtin/document_body_provenance_test.go
+++ b/internal/tools/builtin/document_body_provenance_test.go
@@ -1,0 +1,74 @@
+package builtin
+
+import (
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// A chunk body's ORIGIN is what tells a fact from prose (RFC CV P2b / OQ3).
+//
+// Both are `doc.chunk:<hex>` rows in the k/v plane, so the key namespace cannot
+// distinguish them — and while it was the only signal, `sources=documents`
+// selected every chunk body and labelled the distilled facts among them
+// "document". origin is the right discriminator because it is server-stamped and
+// deliberately absent from the `Memory set` input schema BECAUSE it names the
+// writer, so a caller cannot claim one.
+//
+// It could not be a lookup instead: chunk_memory_meta lives in SQL Memory, a
+// DIFFERENT database from the k/v plane, so consulting it per candidate would be a
+// cross-database round trip from each of the four sites that label a row.
+
+// TestChunkBody_AFactCarriesItsOriginAndProseDoesNot pins both directions. The
+// negative half matters as much as the positive one: if ordinary prose were
+// stamped too, provenance would stop meaning "a distiller wrote this" and the
+// discriminator would be worthless in the other direction.
+func TestChunkBody_AFactCarriesItsOriginAndProseDoesNot(t *testing.T) {
+	d, ctx, st := documentFixture(t)
+	doc := newEntityDoc(t, d, ctx)
+
+	// A FACT: the entity pair is what marks a write as one the ontology governs.
+	out, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+doc+`",
+		"natural_key":"memory/fact/denn-prefers-go","title":"Denn prefers Go",
+		"body":"Denn prefers Go for backend services.","type":"fact","subject":"Denn"}`)
+	if r.IsError {
+		t.Fatalf("upsert_chunk: %s", r.Text)
+	}
+	factID := asStr(out["id"])
+
+	// ORDINARY PROSE in the same document, written the ordinary way.
+	out, r = docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+doc+`",
+		"title":"A section","body":"Some ordinary prose that nobody distilled."}`)
+	if r.IsError {
+		t.Fatalf("create_chunk: %s", r.Text)
+	}
+	proseID := asStr(out["id"])
+
+	// The scope id and tenant come from the tool's OWN resolution, so the test
+	// reads exactly the row the tool wrote rather than a guessed address.
+	sk := sidecarScope(t, d, ctx)
+	tenant := direntTenant(ctx)
+	factProv, err := st.MemoryProvenanceGet(ctx, tenant, store.MemoryScopeUser, sk.ScopeID, "doc.chunk:"+factID)
+	if err != nil {
+		t.Fatalf("read fact body provenance: %v", err)
+	}
+	proseProv, err := st.MemoryProvenanceGet(ctx, tenant, store.MemoryScopeUser, sk.ScopeID, "doc.chunk:"+proseID)
+	if err != nil {
+		t.Fatalf("read prose body provenance: %v", err)
+	}
+
+	if factProv.Origin == "" {
+		t.Errorf("the fact's body row carries no origin — once the chunk is the fact's only home it is indistinguishable from prose")
+	}
+	if proseProv.Origin != "" {
+		t.Errorf("ordinary prose was stamped origin=%q — provenance would stop meaning 'a distiller wrote this'", proseProv.Origin)
+	}
+
+	// And the LABEL must follow the column, not the namespace.
+	if got := store.ClassifyMemoryRow("doc.chunk:"+factID, factProv.Origin, "doc.chunk:"); got != store.MemoryRowFact {
+		t.Errorf("a chunk-homed fact classifies as %q, want fact", got)
+	}
+	if got := store.ClassifyMemoryRow("doc.chunk:"+proseID, proseProv.Origin, "doc.chunk:"); got != store.MemoryRowDocument {
+		t.Errorf("ordinary prose classifies as %q, want document", got)
+	}
+}

--- a/internal/tools/builtin/document_entity.go
+++ b/internal/tools/builtin/document_entity.go
@@ -68,6 +68,14 @@ func (d *Document) upsertChunk(ctx context.Context, key sqlmem.ScopeKey, mscope 
 		return errResult("upsert_chunk: lookup: " + err.Error()), nil
 	}
 
+	// upsert_chunk IS the fact-tier write op — every write through it gets a
+	// sidecar row — so it is the right place to decide that this chunk's body row
+	// carries provenance. Set once, before either branch, because a fact reaches
+	// the k/v plane through create_chunk when it is new and through the entity body
+	// writer when it already exists; stamping only one of those would leave the
+	// discriminator depending on whether a fact had been seen before.
+	in.bodyOrigin = originForEntityWrite(ctx)
+
 	if existing == "" {
 		// Delegate the INSERT to create_chunk rather than writing a second insert
 		// path. It owns the parent/position/document-exists validation, and a
@@ -155,7 +163,10 @@ func (d *Document) updateChunkForUpsert(ctx context.Context, key sqlmem.ScopeKey
 				fields = cur.Fields
 			}
 		}
-		return d.writeBody(ctx, mscope, key, chunkID, "", body, fields)
+		// The SAME origin the sidecar records, so the body row carries the one
+		// signal that distinguishes a fact from prose. Without it a collapsed fact
+		// — whose body row becomes its only home — reads as a document.
+		return d.writeBodyAs(ctx, mscope, key, chunkID, "", body, fields, in.bodyOrigin)
 	}
 	return nil
 }

--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -1501,9 +1501,15 @@ func (m *Memory) execSearch(ctx context.Context, scope store.MemoryScope, scopeI
 
 	// Collect the document hits' chunk ids up front so their readable labels
 	// resolve in ONE batched query instead of one per row.
+	// Collected by KEY SHAPE, not by class. A readable label is a property of
+	// being a chunk body — the label lives on the chunk — and has nothing to do
+	// with whether that chunk is prose or a distilled fact. Keying this on
+	// MemoryRowDocument meant a fact whose home is a chunk came back addressed only
+	// by its opaque `doc.chunk:<hex>` key, which is the very thing ChunkLabelsFor
+	// exists to prevent.
 	var docChunkIDs []string
 	for _, r := range res.Entries {
-		if memrank.Class(r) == store.MemoryRowDocument {
+		if strings.HasPrefix(r.Key, memrank.DocumentChunkKeyPrefix) {
 			docChunkIDs = append(docChunkIDs, strings.TrimPrefix(r.Key, memrank.DocumentChunkKeyPrefix))
 		}
 	}


### PR DESCRIPTION
RFC CV **P2b** (OQ3). Asking for documents returned facts.

## Why

`sources=documents` selected every `doc.chunk:` row, and the label agreed with it — so a distilled fact that had a chunk came back as prose. Both halves were wrong in the same way, which is why nothing caught it: the key namespace says "this row is a chunk **body**", and it does not say what kind of thing the chunk holds. Facts and prose are both chunk bodies.

Survivable while a fact's home is its `memory/<class>/<slug>` row and the chunk body is a duplicate. Not survivable once the chunk is the fact's only home, because then **every fact in the store reads as a document** — exactly what OQ3 predicted.

## What

`origin` becomes the discriminator, tested **before** the namespace:

- **Unforgeable.** It is deliberately absent from the `Memory set` input schema *because* it names the writer, so a caller cannot claim one. A distilled fact carries one; prose an author typed does not.
- **No lookup.** `chunk_memory_meta` lives in SQL Memory — a *different database* from the k/v plane — so OQ3's "one meta lookup per candidate, very likely free" would in fact be a cross-database round trip from each of the **four** sites that label a row. This is the one place I deviated from the RFC's stated design, and the reason is recorded in the code.
- **Not the rejected `row_class` column.** That would add a writer-forgot-to-set failure mode — the class of bug a derived discriminator exists to avoid.

For that to mean anything, a fact's body row has to carry it. `upsert_chunk` — the fact-tier write op, every write through which gets a sidecar row — now stamps the same origin the sidecar records. Set **once, before both branches**: a fact reaches the k/v plane through `create_chunk` when it is new and through the entity body writer when it already exists, so stamping only one would leave the discriminator depending on whether the fact had been seen before. The carrier is an **unexported** `docInput` field, so the tool's JSON input can never set it.

The **filter moves with the label**, per the single-definition rule the classifier was written for: `sources=documents` is now the namespace *and* no provenance. Reordering the label alone would have left `kind` a claim the filter did not back.

Also: chunk labels are now resolved by **key shape** rather than by class. A readable label is a property of being a chunk body and has nothing to do with whether the chunk holds prose or a fact, so keying it on `MemoryRowDocument` meant a chunk-homed fact came back addressed only by its opaque `doc.chunk:<hex>` key — the thing `ChunkLabelsFor` exists to prevent.

## What was tested

`TestChunkBody_AFactCarriesItsOriginAndProseDoesNot` asserts **both directions** — a stamp on prose too would make provenance stop meaning "a distiller wrote this" and break the discriminator the other way.

`TestClass_LabelsRowsFromTheirOwnColumns` keeps its principle (the label must derive from what the filter selects on) and flips the single row whose comment said `// namespace wins`.

Fail-before was decomposed, because the two halves can each mask the other:
- revert the **stamp** only → no origin on the fact body row *and* misclassified
- revert the **label reorder** only, stamp intact → still misclassified

Both fail independently. `go test ./...` clean.

## Interim state, stated rather than smoothed over

During dual-write a fact still has two embedded rows, so an unfiltered search can match both. That duplication predates this change — it was one fact plus one mislabelled document, and is now two facts — and it is what **P2d** removes by deleting the k/v row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8