### PR TITLE
test(memory): gate the dual-write planes against drift, and correct a premise

### DIFF
--- a/cmd/loomcycle/presets_memory_codejs_test.go
+++ b/cmd/loomcycle/presets_memory_codejs_test.go
@@ -2956,6 +2956,98 @@ func TestConsolidator_MirrorsTypedFactsIntoAGraph(t *testing.T) {
 	}
 }
 
+// TestConsolidator_TheTwoPlanesAgreeOnEveryTemporalField is the DRIFT GATE for
+// the dual-write window (RFC CV P2c).
+//
+// A fact is written twice today — a k/v row and a chunk — and the collapse deletes
+// the k/v row. Anything the k/v write carries and the chunk write does not is
+// therefore data that disappears at the collapse, silently, with no error and no
+// failing test. That is not hypothetical: the temporal fields were exactly this
+// gap. The k/v write carried observed_at/valid_at/invalid_at and the mirror carried
+// none, so 103 of 103 facts had an utterance time in one plane and no column for it
+// in the other, and nothing noticed until the planes were compared by hand.
+//
+// So this asserts FIELD BY FIELD that the chunk write carries what the k/v write
+// carries, and it fails when someone adds a field to one plane and forgets the
+// other. It deliberately does NOT compare `class`: the two planes both have a
+// column of that name and they mean different things — the k/v one is the statement
+// class (preference | decision | …) and the sidecar's is the retention class
+// (derived | evidential) — so asserting parity there would be asserting a
+// coincidence of naming.
+func TestConsolidator_TheTwoPlanesAgreeOnEveryTemporalField(t *testing.T) {
+	f := newFakeToolset()
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	f.transcript = "### user\n\nI moved to Berlin last week."
+	// Every temporal field populated at once, so a plane that drops one is visible.
+	f.factsJSON = "```json\n" + `[
+		{"text":"Denn lives in Berlin.","class":"fact","type":"person","subject":"Denn",
+		 "observed_at":"2023-07-07T19:56:00Z","valid_at":"2023-06-30T00:00:00Z",
+		 "invalid_at":"2024-01-01T00:00:00Z"}
+	]` + "\n```"
+
+	runConsolidator(t, f)
+
+	sets := callsWithOp(f, "Memory.set")
+	upserts := callsWithOp(f, "Document.upsert_chunk")
+	if len(sets) != 1 {
+		t.Fatalf("k/v writes = %d, want 1; ops=%v", len(sets), f.ops())
+	}
+	// The subject node is also an upsert; the FACT chunk is the one carrying a body.
+	var factArgs map[string]any
+	for _, c := range upserts {
+		if _, ok := c.Input["body"]; ok {
+			factArgs = c.Input
+		}
+	}
+	if factArgs == nil {
+		t.Fatalf("no fact chunk written; upserts=%d ops=%v", len(upserts), f.ops())
+	}
+	kv := sets[0].Input
+
+	// nanosOf mirrors the bundle's own RFC3339 → unix-nanos conversion, so the
+	// comparison is of INSTANTS rather than of spellings: the two planes
+	// deliberately store the same moment in different units.
+	nanosOf := func(v any) int64 {
+		s, _ := v.(string)
+		ts, err := time.Parse(time.RFC3339, s)
+		if err != nil {
+			return 0
+		}
+		return ts.UnixNano()
+	}
+	for _, field := range []string{"observed_at", "valid_at", "invalid_at"} {
+		want, inKV := kv[field]
+		if !inKV {
+			t.Errorf("the k/v write carried no %s — the fixture no longer exercises this field", field)
+			continue
+		}
+		got, inChunk := factArgs[field]
+		if !inChunk {
+			t.Errorf("%s reaches the k/v plane but NOT the chunk plane — it would be lost at the collapse", field)
+			continue
+		}
+		gotN := int64(0)
+		switch v := got.(type) {
+		case float64:
+			gotN = int64(v)
+		case int64:
+			gotN = v
+		}
+		if gotN != nanosOf(want) {
+			t.Errorf("%s: chunk plane has %d, k/v plane has %v (%d nanos) — the planes disagree on the instant",
+				field, gotN, want, nanosOf(want))
+		}
+	}
+
+	// And the claim itself, which is the one field whose loss would be obvious but
+	// whose absence from this list would make the test look complete when it was not.
+	body, _ := factArgs["body"].(string)
+	value, _ := kv["value"].(string)
+	if body != value {
+		t.Errorf("the chunk body %q is not the stored value %q", body, value)
+	}
+}
+
 // TestConsolidator_AFactWithNoSubjectStillGetsItsChunk. A fact naming no single thing
 // used to be mirrored NOWHERE — measured at 249 of 1,225 facts, 20.3% — which is
 // affordable only while the k/v row is the fact's home. It gets its own chunk now, so

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -768,10 +768,22 @@ func (d *Document) migrateDocumentFacets(ctx context.Context, key sqlmem.ScopeKe
 // this table's writer defaulted it to now: three quarters of those instants were
 // write timestamps wearing world-time's column.
 //
-// access_count / last_accessed_at come along now rather than later because
-// access_count feeds the recall ranker's frequency term. They have no writer in
-// the chunk plane yet; the columns exist so that when a fact's home moves there
-// is somewhere for them to land, and ranking does not silently change.
+// access_count / last_accessed_at are here and are NOT the mechanism they were
+// added for. The reasoning that put them here was that access_count feeds the
+// recall ranker's frequency term and would have nowhere to live once a fact's home
+// moved. That premise was wrong, and checking it is what showed why: the counter is
+// maintained per (tenant, scope, scope_id, KEY) on the k/v row itself, and the row
+// a collapsed fact lives in is its `doc.chunk:<hex>` BODY row — a k/v row, which
+// already has these columns and which the access tracker already bumps for any
+// returned hit, key-agnostically. So the telemetry follows the fact for free.
+//
+// They are left in place rather than dropped because a DROP COLUMN migration on
+// every provisioned scope is a worse trade than two nullable unused columns, and
+// this comment is the record so the next reader does not build on them. The real
+// requirement they were standing in for belongs to the collapse: when the k/v fact
+// row is deleted its accumulated access_count must be COPIED onto the body row, or
+// every existing fact's frequency term silently resets to zero — measured at 696
+// accesses across 84 facts on one corpus against 0 on their bodies.
 //
 // ALTER on every scope, new and old alike, and NOT declared in docSchemaDDL — a
 // CREATE TABLE IF NOT EXISTS leaves an existing table untouched, so the DDL alone


### PR DESCRIPTION
RFC CV **P2c**. The dual-write window's safety net, plus a correction to something I got wrong in P2a.

## Why a gate rather than a verifier

A fact is written twice today — a k/v row and a chunk — and the collapse deletes the k/v row. Anything the k/v write carries that the chunk write does not is therefore **data that disappears at the collapse**: silently, with no error and no failing test.

That is not hypothetical. It is exactly what the temporal fields were: the k/v write carried `observed_at`/`valid_at`/`invalid_at` and the mirror carried none, so **103 of 103 facts** had an utterance time in one plane and no column for it in the other, and nothing noticed until the planes were compared by hand.

I first went looking for a place to put an operator-facing parity CLI and concluded a shipped verifier nobody runs is weaker than a CI-enforced test. The dual-write is done by the bundle, and the fake toolset records each call's full argument map, so the drift is assertable exactly where it happens.

## What

`TestConsolidator_TheTwoPlanesAgreeOnEveryTemporalField` asserts **field by field** that the chunk write carries what the k/v write carries, comparing **instants rather than spellings** — the planes deliberately store the same moment in different units (RFC3339 vs unix nanos). It fails when a field is added to one plane and forgotten in the other.

Verified non-vacuous by dropping `observed_at` from the bundle's chunk write: the test reports *"reaches the k/v plane but NOT the chunk plane — it would be lost at the collapse"*, which is the defect it exists for.

It deliberately does **not** compare `class`. Both planes have a column of that name and they mean different things — the k/v one is the statement class (`preference` | `decision` | …), the sidecar's is the retention class (`derived` | `evidential`) — so asserting parity there would be asserting a coincidence of naming.

## A premise I got wrong in P2a

P2a added `chunk_memory_meta.access_count` / `last_accessed_at` on the reasoning that `access_count` feeds the recall ranker's frequency term and would have nowhere to live once a fact's home moved. **That premise was wrong**, and checking it is what showed why: the counter is maintained per `(tenant, scope, scope_id, KEY)` on the k/v row itself, and a collapsed fact's home is its `doc.chunk:<hex>` **body row** — a k/v row that already has those columns and that the access tracker already bumps for any returned hit, key-agnostically. The telemetry follows the fact for free.

The columns stay: a `DROP COLUMN` migration across every provisioned scope is a worse trade than two nullable unused columns, and the comment is now the record so nobody builds on them.

**But the requirement they were standing in for is real, and it belongs to P2d:** when the k/v fact row is deleted, its accumulated `access_count` must be **copied onto the body row**, or every existing fact's frequency term resets to zero. Measured: **696 accesses across 84 facts, against 0 on their body rows** — because `sources=facts` excludes body rows today, so they have never been returned to be bumped. Left unhandled that is a silent ranking shift in a phase whose gate forbids accuracy changes.

`go test ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8