### PR TITLE
feat(memory): read facts from the chunk plane, by class rather than namespace

### DIFF
--- a/internal/memory/backend.go
+++ b/internal/memory/backend.go
@@ -216,13 +216,25 @@ func (q SearchQuery) Filter() (store.MemorySearchFilter, error) {
 		// fact's body row now carries an origin, so excluding provenance is what
 		// makes this selector mean prose.
 		f.Provenance = store.ProvenanceAbsent
-	case memory && !docs:
+	case facts && !notes:
+		// FACTS ARE WHEREVER PROVENANCE IS, with no namespace constraint. This used
+		// to exclude the chunk namespace, which was right only while a fact's home
+		// was its own k/v row and the chunk body was a duplicate of it. A fact homed
+		// in a chunk lives at that prefix, so the exclusion would now hide exactly
+		// what was asked for.
+		f.Provenance = store.ProvenanceRequired
+	case notes && !facts:
+		// A note is what an agent wrote down ITSELF: no provenance, and not a chunk
+		// body. Both halves are load-bearing — prose has no provenance either, so
+		// provenance alone would return document text as notes.
 		f.ExcludeKeyPrefix = DocumentChunkKeyPrefix
-		if facts && !notes {
-			f.Provenance = store.ProvenanceRequired
-		} else if notes && !facts {
-			f.Provenance = store.ProvenanceAbsent
-		}
+		f.Provenance = store.ProvenanceAbsent
+	case memory && !docs:
+		// facts + notes — everything EXCEPT prose, and the default for recall.
+		// No longer expressible by excluding the chunk namespace, because the facts
+		// half now lives inside it; this excludes the document CLASS, which is the
+		// only thing being ruled out.
+		f.ExcludeDocumentPrefix = DocumentChunkKeyPrefix
 	}
 	// docs && facts && notes → everything; the zero filter already says that.
 	return f, nil

--- a/internal/memory/sources_test.go
+++ b/internal/memory/sources_test.go
@@ -45,15 +45,14 @@ func TestSearchQueryFilter_SourcesMapToPredicate(t *testing.T) {
 				"(exclude AND require the same prefix), which would return nothing",
 		},
 		{
-			name: "facts only requires provenance",
+			name: "facts are wherever provenance is, in EITHER namespace",
 			q:    SearchQuery{Sources: []Source{SourceFacts}},
-			want: store.MemorySearchFilter{
-				ExcludeKeyPrefix: DocumentChunkKeyPrefix,
-				Provenance:       store.ProvenanceRequired,
-			},
+			want: store.MemorySearchFilter{Provenance: store.ProvenanceRequired},
 			comment: "origin is server-stamped, so it is the unforgeable discriminator " +
 				"(RFC BW §9 Q1) — class is model-supplied and would let an agent promote " +
-				"its own note to a fact",
+				"its own note to a fact. No namespace constraint: excluding the chunk " +
+				"prefix was right only while a fact's home was its own k/v row and the " +
+				"chunk body was a duplicate, and it would now hide a chunk-homed fact",
 		},
 		{
 			name: "notes only excludes provenance",
@@ -64,16 +63,18 @@ func TestSearchQueryFilter_SourcesMapToPredicate(t *testing.T) {
 			},
 		},
 		{
-			name: "facts+notes is memory with no provenance constraint",
+			name: "facts+notes excludes the document CLASS, not the namespace",
 			q:    SearchQuery{Sources: []Source{SourceFacts, SourceNotes}},
-			want: store.MemorySearchFilter{ExcludeKeyPrefix: DocumentChunkKeyPrefix},
-			comment: "the recall default: everything the agent remembers, documents " +
-				"excluded",
+			want: store.MemorySearchFilter{ExcludeDocumentPrefix: DocumentChunkKeyPrefix},
+			comment: "the recall default: everything the agent remembers, prose " +
+				"excluded. Excluding the namespace no longer expresses that, because " +
+				"the facts half now lives inside it — so what is ruled out is the " +
+				"class (a chunk body with no provenance) rather than the prefix",
 		},
 		{
 			name: "an explicit prefix survives a source selector",
 			q:    SearchQuery{Prefix: "proj/", Sources: []Source{SourceFacts, SourceNotes}},
-			want: store.MemorySearchFilter{KeyPrefix: "proj/", ExcludeKeyPrefix: DocumentChunkKeyPrefix},
+			want: store.MemorySearchFilter{KeyPrefix: "proj/", ExcludeDocumentPrefix: DocumentChunkKeyPrefix},
 		},
 		{
 			name: "an explicit prefix WINS over documents-only",

--- a/internal/store/postgres/memory_embeddings.go
+++ b/internal/store/postgres/memory_embeddings.go
@@ -315,6 +315,13 @@ func (s *Store) MemoryEmbedSearch(ctx context.Context, tenantID string, scope st
 		args = append(args, likePrefixPattern(filter.ExcludeKeyPrefix))
 		prefixCondition += " AND me.key NOT LIKE $" + strconv.Itoa(len(args))
 	}
+	// The document CLASS, not the namespace: a chunk body with no provenance. A
+	// fact homed in a chunk shares the prefix, so excluding the prefix outright
+	// would exclude the facts this query is for.
+	if filter.ExcludeDocumentPrefix != "" {
+		args = append(args, likePrefixPattern(filter.ExcludeDocumentPrefix))
+		prefixCondition += " AND NOT (me.key LIKE $" + strconv.Itoa(len(args)) + " AND coalesce(m.origin, '') = '')"
+	}
 	prefixCondition += provenanceCondition(filter.Provenance)
 	var observedCond string
 	observedCond, args = observedCondition(filter, args)
@@ -439,6 +446,10 @@ func (s *Store) MemoryFullTextSearch(ctx context.Context, tenantID string, scope
 	if filter.ExcludeKeyPrefix != "" {
 		args = append(args, likePrefixPattern(filter.ExcludeKeyPrefix))
 		prefixCondition += " AND me.key NOT LIKE $" + strconv.Itoa(len(args))
+	}
+	if filter.ExcludeDocumentPrefix != "" {
+		args = append(args, likePrefixPattern(filter.ExcludeDocumentPrefix))
+		prefixCondition += " AND NOT (me.key LIKE $" + strconv.Itoa(len(args)) + " AND coalesce(m.origin, '') = '')"
 	}
 	prefixCondition += provenanceCondition(filter.Provenance)
 	var observedCond string

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -3197,6 +3197,20 @@ type MemorySearchFilter struct {
 	// caller is unaffected.
 	Provenance MemoryProvenanceConstraint
 
+	// ExcludeDocumentPrefix drops rows that are chunk bodies WITHOUT provenance —
+	// which is exactly the document class, and nothing else.
+	//
+	// It exists because ExcludeKeyPrefix stopped being able to express "not prose".
+	// That worked only while the chunk namespace held nothing but prose; a fact
+	// homed in a chunk lives at the same prefix, so excluding the namespace now
+	// excludes the facts too. The two fields are therefore not variants of one
+	// idea: ExcludeKeyPrefix drops a NAMESPACE, this drops a CLASS.
+	//
+	// Kept as a prefix rather than a bool because the store owns no knowledge of
+	// what the document namespace is called — the caller supplies it, as it already
+	// does for the other two prefix fields.
+	ExcludeDocumentPrefix string
+
 	// ObservedFrom / ObservedTo bound the row's observed time (RFC CL). Zero on
 	// either side is an open bound; both zero constrains nothing. The bounds are
 	// ALREADY WIDENED by the caller's slack — the store applies what it is given and
@@ -3292,8 +3306,21 @@ func ClassifyMemoryRow(key, origin, documentKeyPrefix string) MemoryRowClass {
 
 // IsZero reports whether the filter constrains nothing — the signal that a backend
 // may take a query path with no predicate at all.
+//
+// EVERY predicate-bearing field has to be listed here, because of what the sentence
+// above licenses: a backend that trusts this drops the predicates it does not see.
+// It previously tested only the two prefix fields, so a provenance-constrained
+// filter reported "constrains nothing" — latent, since no backend consumes it yet,
+// but the contract invites exactly the path that would have silently returned notes
+// alongside facts.
+//
+// The observed-time and as-of bounds are deliberately included on the same
+// reasoning; they are predicates like any other.
 func (f MemorySearchFilter) IsZero() bool {
-	return f.KeyPrefix == "" && f.ExcludeKeyPrefix == ""
+	return f.KeyPrefix == "" && f.ExcludeKeyPrefix == "" && f.ExcludeDocumentPrefix == "" &&
+		f.Provenance == ProvenanceAny &&
+		f.ObservedFrom.IsZero() && f.ObservedTo.IsZero() && !f.RequireObserved &&
+		f.AsOf.IsZero() && !f.RequireValid
 }
 
 // MemoryEntry is one row in the memory table. ExpiresAt is zero when

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -12091,6 +12091,59 @@ func testMemorySearchFilterExcludesPrefix(t *testing.T, s store.Store) {
 			}
 		}
 	}
+
+	// ExcludeDocumentPrefix drops the document CLASS rather than the namespace, which
+	// is what "everything except prose" has to mean once facts are homed in chunks.
+	// The distinguishing row is a chunk body WITH provenance: excluding the namespace
+	// would drop it, and this must keep it.
+	if err := s.MemorySetProvenance(ctx, "", store.MemoryScopeUser, sid, "doc.chunk:factbody", v, 0,
+		store.MemoryProvenance{Origin: "consolidator"}); err != nil {
+		t.Fatalf("MemorySetProvenance chunk-homed fact: %v", err)
+	}
+	if err := s.MemoryEmbedSet(ctx, "", store.MemoryScopeUser, sid, "doc.chunk:factbody", store.MemoryEmbedding{
+		Provider: "test", Model: "m", Dimension: 4,
+		Vector: floats32(1, 0, 0, 0), EmbedText: "distilled", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("MemoryEmbedSet chunk-homed fact: %v", err)
+	}
+
+	notProse, err := s.MemoryEmbedSearch(ctx, "", store.MemoryScopeUser, sid,
+		store.MemorySearchFilter{ExcludeDocumentPrefix: "doc.chunk:"}, q, 10)
+	if err != nil {
+		t.Fatalf("exclude document class: %v", err)
+	}
+	var sawFactBody, sawProse bool
+	for _, r := range notProse {
+		if r.Key == "doc.chunk:factbody" {
+			sawFactBody = true
+		}
+		if strings.HasPrefix(r.Key, "doc.chunk:") && r.Origin == "" {
+			sawProse = true
+		}
+	}
+	if !sawFactBody {
+		t.Errorf("ExcludeDocumentPrefix dropped a chunk body that HAS provenance (%v) — it "+
+			"must exclude the class, not the namespace, or a collapsed fact becomes "+
+			"unreachable by the recall default", keysOf(notProse))
+	}
+	if sawProse {
+		t.Errorf("ExcludeDocumentPrefix returned un-stamped chunk prose (%v) — the whole "+
+			"point of the field is that prose stays out", keysOf(notProse))
+	}
+
+	// Same on the lexical leg, for the RRF reason above.
+	if s.SupportsFullText() {
+		lex, err := s.MemoryFullTextSearch(ctx, "", store.MemoryScopeUser, sid,
+			store.MemorySearchFilter{ExcludeDocumentPrefix: "doc.chunk:"}, "distilled", 10)
+		if err != nil {
+			t.Fatalf("fulltext exclude document class: %v", err)
+		}
+		for _, r := range lex {
+			if strings.HasPrefix(r.Key, "doc.chunk:") && r.Origin == "" {
+				t.Errorf("the full-text leg ignored ExcludeDocumentPrefix and returned prose %s", r.Key)
+			}
+		}
+	}
 }
 
 func testMemoryEmbedListMissing(t *testing.T, s store.Store) {


### PR DESCRIPTION
RFC CV **P2d** — the read move.

> ⚠️ **Stacked on #1177** (P2b). Without the origin stamp on a fact's body row, provenance selects nothing in the chunk plane and this change is merely inert. **Merge #1177 first**; this diff narrows to its own two files once that lands.

## Why

Once a fact's home is a chunk, *"everything except prose"* stops being expressible as *"not the chunk namespace"* — because the facts now live **inside** that namespace.

- `sources=facts` excluded the namespace, and would have hidden exactly what was asked for.
- `sources=facts,notes` — the **recall default** — excluded it too, and would have hidden every fact in the store.

## What

The selectors are now defined by **class**, matching the classifier they have to agree with:

| source | predicate |
|---|---|
| `facts` | provenance present, in **either** namespace |
| `notes` | no provenance **and** not a chunk body |
| `documents` | a chunk body **and** no provenance |
| `facts+notes` | everything except the document **class** |

The last needs a predicate the filter did not have. **`ExcludeDocumentPrefix`** drops rows that are chunk bodies *without* provenance — exactly the document class and nothing else.

It is deliberately **not** a variant of `ExcludeKeyPrefix`: that field drops a *namespace*, this one drops a *class*, and conflating them is what made the old encoding wrong. It stays a prefix rather than a bool because the store owns no knowledge of what the document namespace is called — the caller supplies it, as it already does for the other two prefix fields.

Applied to **both** search legs: the vector and lexical legs are fused by RRF, so a row admitted by either reaches the caller, and filtering one filters nothing.

## A latent bug found on the way

`MemorySearchFilter.IsZero` documents itself as *"the filter constrains nothing — the signal that a backend may take a query path with no predicate at all"* while testing only the two prefix fields. A provenance-constrained filter therefore reported "constrains nothing", and a backend that trusted it would have returned notes alongside facts. Latent because no backend consumes it yet — but the contract invites exactly that path, and adding a third predicate field made it worse. Every predicate-bearing field is now listed.

## What was tested

Against **real Postgres with pgvector**, not skipped — the whole point, since these paths are postgres-only and a sqlite run would have passed vacuously. The store contract gains an `ExcludeDocumentPrefix` case whose distinguishing row is a chunk body **with** provenance: excluding the namespace drops it, the class predicate must keep it. Asserted on both legs.

Verified **non-vacuous** by degrading the predicate to a namespace exclusion, which fails with *"dropped a chunk body that HAS provenance … or a collapsed fact becomes unreachable by the recall default"*.

Full `go test ./...` clean; full pgvector contract suite green (126s).

## Not in this PR

P2d's remaining half — the operator listing going chunk-backed, the Web UI moving with it, and the backfill (including copying `access_count` onto the body row, per #1178) — is a separate change touching the SPA. Splitting it keeps this one reviewable as a store/filter change. The irreversible step (deleting the k/v fact row) is P2f and is not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8