### PR TITLE
feat(channels): a held channel stores without delivering, until released

### DIFF
--- a/adapters/ts/src/client.ts
+++ b/adapters/ts/src/client.ts
@@ -79,11 +79,13 @@ import type {
   ChannelPeekResult,
   ChannelPublishResult,
   ChannelPurgeResult,
+  ChannelReleaseResult,
   ChannelSubscribeResult,
   CreateChannelOptions,
   ListChannelsResponse,
   PeekChannelOptions,
   PublishChannelOptions,
+  ReleaseChannelOptions,
   SetMemoryEntryOptions,
   SetMemoryEntryResponse,
   SubscribeChannelOptions,
@@ -2390,6 +2392,7 @@ export class LoomcycleClient {
     if (opts.max_messages !== undefined) body.max_messages = opts.max_messages;
     if (opts.publisher !== undefined) body.publisher = opts.publisher;
     if (opts.period !== undefined) body.period = opts.period;
+    if (opts.hold !== undefined) body.hold = opts.hold;
     return postJSON<ChannelDescriptor>(this.ctx, "/v1/_channels", body, {
       signal: opts.signal,
     });
@@ -2407,6 +2410,7 @@ export class LoomcycleClient {
     if (opts.default_ttl !== undefined) body.default_ttl = opts.default_ttl;
     if (opts.max_messages !== undefined) body.max_messages = opts.max_messages;
     if (opts.semantic !== undefined) body.semantic = opts.semantic;
+    if (opts.hold !== undefined) body.hold = opts.hold;
     return patchJSON<ChannelDescriptor>(
       this.ctx,
       `/v1/_channels/${encodeURIComponent(name)}`,
@@ -2444,6 +2448,27 @@ export class LoomcycleClient {
       this.ctx,
       `/v1/_channels/${encodeURIComponent(name)}/purge`,
       {},
+      { signal: opts?.signal },
+    );
+  }
+
+  /** Hand the oldest `count` (default 1) messages held on a `hold:`
+   *  channel to its subscribers. Allowed on yaml-declared channels —
+   *  releasing moves messages, it does not mutate the definition.
+   *  Releasing a channel with nothing held reports zero rather than
+   *  failing. */
+  async releaseChannel(
+    name: string,
+    opts?: ReleaseChannelOptions,
+  ): Promise<ChannelReleaseResult> {
+    const body: Record<string, unknown> = {};
+    if (opts?.count !== undefined) body.count = opts.count;
+    if (opts?.scope !== undefined) body.scope = opts.scope;
+    if (opts?.scope_id !== undefined) body.scope_id = opts.scope_id;
+    return postJSON<ChannelReleaseResult>(
+      this.ctx,
+      `/v1/_channels/${encodeURIComponent(name)}/release`,
+      body,
       { signal: opts?.signal },
     );
   }

--- a/adapters/ts/src/index.ts
+++ b/adapters/ts/src/index.ts
@@ -286,6 +286,7 @@ export type {
   ChannelPeekResult,
   ChannelPublishResult,
   ChannelPurgeResult,
+  ChannelReleaseResult,
   ChannelScope,
   ChannelSubscribeResult,
   PeekChannelOptions,
@@ -301,6 +302,7 @@ export type {
   ChannelBroadcastResult,
   // Channel admin CRUD (v0.11.5)
   CreateChannelOptions,
+  ReleaseChannelOptions,
   UpdateChannelOptions,
   // Memory entry admin CRUD (v0.11.5)
   SetMemoryEntryOptions,

--- a/adapters/ts/src/types.ts
+++ b/adapters/ts/src/types.ts
@@ -1773,6 +1773,8 @@ export interface ChannelDescriptor {
   period?: string;
   default_ttl?: number;
   max_messages?: number;
+  /** Breakpoint: publishes are stored but never delivered until released. */
+  hold?: boolean;
   message_count: number;
   /** RFC3339 — empty when count == 0. */
   oldest_visible_at?: string;
@@ -1988,6 +1990,9 @@ export interface CreateChannelOptions {
   publisher?: string;
   /** Free-form retention hint; not enforced by the substrate. */
   period?: string;
+  /** Breakpoint: publishes are stored but never delivered until
+   *  {@link LoomcycleClient.releaseChannel} hands them over. */
+  hold?: boolean;
   signal?: AbortSignal;
 }
 
@@ -1999,7 +2004,30 @@ export interface UpdateChannelOptions {
   max_messages?: number;
   /** "queue" | "topic" */
   semantic?: string;
+  /** Turn the breakpoint on or off. Messages already held stay held
+   *  until released — turning it off does not flush the queue. */
+  hold?: boolean;
   signal?: AbortSignal;
+}
+
+/** Options for {@link LoomcycleClient.releaseChannel}. */
+export interface ReleaseChannelOptions {
+  /** How many held messages to hand over, oldest first. Default 1. */
+  count?: number;
+  /** "global" (default) | "user" | "tenant". */
+  scope?: string;
+  /** Required when scope is "user". */
+  scope_id?: string;
+  signal?: AbortSignal;
+}
+
+/** Result of {@link LoomcycleClient.releaseChannel}. `released` is the
+ *  ids handed over, in delivery order; `still_held` is what is left. */
+export interface ChannelReleaseResult {
+  channel: string;
+  released: string[];
+  released_count: number;
+  still_held: number;
 }
 
 // ---- v0.11.5 Memory entry admin CRUD types ----

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -2058,6 +2058,9 @@ func main() {
 		Store:     storeIface,
 		Bus:       channelBus,
 		Scheduler: channelScheduler,
+		// RFC CY: one wiring point makes every internal publish path
+		// honour a `hold:` channel — see StorePublisher.HoldFn.
+		HoldFn: srv.ChannelHeld,
 	}
 	srv.SetSystemPublisher(sysPublisher)
 	// Wire the SystemPublisher onto the Interruption tool too — same

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -797,6 +797,11 @@ channels:
     default_ttl: 3600
     max_messages: 1000
     semantic: broadcast
+
+  review-queue:
+    scope: global
+    max_messages: 100
+    hold: true                # breakpoint: store, deliver only on release
 ```
 
 Per-agent ACL via the agent yaml:
@@ -831,6 +836,11 @@ Wildcards are anchored at the end (`findings/*` matches `findings/alpha` but NOT
 
 // Peek — non-consuming read (debugging or at-least-once consumer pattern):
 { "op": "peek", "channel": "findings", "from_cursor": "cur_0", "max_messages": 10 }
+
+// Release — hand the oldest N messages held on a `hold:` channel to
+// subscribers. Needs the PUBLISH allowlist (it completes a publish):
+{ "op": "release", "channel": "review-queue", "count": 1 }
+//   → { "channel": "review-queue", "released": ["msg_..."], "released_count": 1, "still_held": 2 }
 
 // List — informational, reports this agent's allowlists:
 { "op": "list_channels" }
@@ -868,6 +878,25 @@ It long-polls up to `wait_ms` (clamped to the operator's `LOOMCYCLE_CHANNELS_LON
 **`await` is non-committing (detection only).** It returns each fired channel's `next_cursor` but never advances the committed cursor — auto-committing across N channels on a partial/`any`/timeout result would silently consume messages on channels the agent didn't act on. After `await` returns, the agent `subscribe`/`ack`s exactly what it processes. Each channel is resolved through the agent's **subscribe** allowlist, so `await` can't read a channel it couldn't `subscribe` to. Max 32 channels per call.
 
 > **`await` vs `Agent.parallel_spawn`:** both are barriers, but over different things. `parallel_spawn` joins the **sub-agents this agent spawned** (`wg.Wait()`). `await` joins **independent producers** — scheduler-fired runs, inbound webhooks, separately-spawned agents — that `parallel_spawn` can't reach. A scheduler-driven fan-out (N collectors) → consolidator pipeline uses `await`; an in-agent fan-out uses `parallel_spawn`. (`on_complete: channel.publish` on a `ScheduledRun` stamps `schedule_name` per fire — the distinct-producer key an `at_least`/`all` consolidator counts.)
+
+### Breakpoints (`hold` + `release`)
+
+A channel declared `hold: true` **stores a publish without delivering it**. Nothing is handed to a subscriber and no long-poll wakes; the message waits until someone releases it — `Channel op=release` for an agent, `POST /v1/_channels/{name}/release` for an operator, the **Release** control on the channel page in the Web UI. `count` defaults to 1, oldest first, so a workflow wired through the channel can be **single-stepped**: the wave upstream runs, its results queue, and nothing downstream starts until a human says go.
+
+```
+POST /v1/_channels/review-queue/release   { "count": 1 }
+  → { "channel": "review-queue", "released": ["msg_..."], "released_count": 1, "still_held": 2 }
+```
+
+What a hold does **not** change:
+
+- **TTL still counts from publish time.** An expired held message is never released and never delivered — holding is not a way to outlive the retention its publisher declared.
+- **Overflow still trims the oldest**, reporting `dropped_oldest`, exactly as on any other channel. A hold buffers; it does not make the buffer unbounded.
+- **The hold wins over `deliver_at`.** A held message waits for a release, not for a clock, so a caller cannot schedule its way past the breakpoint. The publish result says `"held": true` instead of a `visible_at`.
+
+`release` is gated by the **publish** allowlist rather than subscribe: releasing is the act of making a message deliverable — the half of a publish the hold deferred — so the question is whether the agent may put messages on this channel, not whether it may read them. `_system/` channels are released through the admin endpoint, like every other write to one.
+
+Releasing a channel with nothing held reports zero rather than failing, and a channel switched back to `hold: false` can still release what it holds — turning the breakpoint off does not flush the queue.
 
 ### Delivery semantics
 

--- a/internal/api/grpc/server_test.go
+++ b/internal/api/grpc/server_test.go
@@ -937,6 +937,9 @@ func (m *mockConnector) DeleteChannel(context.Context, string) error {
 func (m *mockConnector) PurgeChannel(context.Context, string) (connector.ChannelPurgeResult, error) {
 	return connector.ChannelPurgeResult{}, nil
 }
+func (m *mockConnector) ReleaseChannel(context.Context, connector.ChannelReleaseRequest) (connector.ChannelReleaseResult, error) {
+	return connector.ChannelReleaseResult{}, nil
+}
 func (m *mockConnector) Config(context.Context) ([]byte, error) {
 	return nil, errors.New("not implemented")
 }

--- a/internal/api/http/channels_admin.go
+++ b/internal/api/http/channels_admin.go
@@ -64,6 +64,12 @@ type channelAckBody struct {
 	Cursor string `json:"cursor"`
 }
 
+// channelReleaseBody is the (optional) body of a release — how many held
+// messages to hand over. An empty body means one.
+type channelReleaseBody struct {
+	Count int `json:"count,omitempty"`
+}
+
 // ---- error mapping ----------------------------------------------
 
 // writeChannelError maps the typed Connector errors to HTTP status +
@@ -178,6 +184,42 @@ func (s *Server) handleChannelPurge(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(res)
+}
+
+// handleChannelRelease serves POST /v1/_channels/{name}/release — the
+// operator half of the RFC CY hold breakpoint: hand the oldest `count`
+// (default 1) held messages to subscribers.
+//
+// Allowed on yaml channels, like purge and unlike DELETE: releasing moves
+// messages, it does not mutate the definition — and a yaml-declared hold: is
+// exactly the channel an operator most wants to single-step.
+//
+// scope/scope_id come from the body (default global) so the same route reaches
+// a user- or tenant-scoped hold queue without a second route family.
+func (s *Server) handleChannelRelease(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	if name == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing_name", "missing channel name in URL path")
+		return
+	}
+	var body connector.ChannelReleaseRequest
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+	// An empty body is the common case ("release one") — only a malformed
+	// non-empty body is an error, mirroring subscribe.
+	if r.ContentLength != 0 {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeJSONError(w, http.StatusBadRequest, "invalid_body", "invalid request body: "+err.Error())
+			return
+		}
+	}
+	body.Channel = name // the path is authoritative, not the body
+	out, err := s.ReleaseChannel(r.Context(), body)
+	if err != nil {
+		writeChannelError(w, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(out)
 }
 
 // ---- admin handlers (scope=global) ------------------------------

--- a/internal/api/http/channels_hold_test.go
+++ b/internal/api/http/channels_hold_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/runner"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
 )
 
 // channelHoldFixture is channelCRUDFixture with one held channel and one
@@ -266,5 +267,96 @@ func TestChannelHold_InternalPublisherIsHeldWithoutResolvingTheDef(t *testing.T)
 	}
 	if n := peekCount(t, srv, "gate"); n != 1 {
 		t.Errorf("after release, %d readable, want 1", n)
+	}
+}
+
+// The wire cap and the in-band tool cap are the same number. Two caps that
+// drift mean the same release is accepted on one surface and refused on the
+// other, which an operator discovers by having it work in the terminal and
+// fail from an agent.
+func TestChannelRelease_WireAndToolCapsAgree(t *testing.T) {
+	if maxChannelReleaseCount != builtin.MaxReleaseCountForDrift {
+		t.Errorf("wire cap %d != tool cap %d", maxChannelReleaseCount, builtin.MaxReleaseCountForDrift)
+	}
+}
+
+// Over-cap is refused rather than silently clamped: a caller asking to release
+// a million is asking for something the hold was there to prevent, and
+// quietly doing a thousand of them is not the answer they wanted.
+func TestChannelHold_ReleaseOverCapIsRefused(t *testing.T) {
+	srv, _, cleanup := channelHoldFixture(t)
+	defer cleanup()
+	rec := postJSON(t, srv, "/v1/_channels/gate/release", `{"count":100000}`)
+	if rec.Code == http.StatusOK {
+		t.Errorf("an over-cap release succeeded: %s", rec.Body.String())
+	}
+}
+
+// ChannelHeld resolves yaml first (operator-global, so every tenant sees it)
+// and then the runtime row IN THE CALLER'S TENANT. Pinned because it decides
+// what an internal publisher sees: one whose ctx carries no tenant — the
+// inbound webhook relay is the live example — honours a yaml-declared hold but
+// cannot see another tenant's runtime-declared one.
+func TestChannelHeld_YamlIsTenantWideRuntimeRowIsNot(t *testing.T) {
+	srv, st, cleanup := channelHoldFixture(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// yaml: visible with no tenant on the ctx.
+	if !srv.ChannelHeld(ctx, "gate") {
+		t.Errorf("a yaml-declared hold was not seen without a tenant on the ctx")
+	}
+	// runtime row owned by another tenant: not visible.
+	if err := st.ChannelsCreate(ctx, store.ChannelRow{
+		Name: "t1-only", TenantID: "t1", Scope: "global", Semantic: "queue", Hold: true,
+	}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if srv.ChannelHeld(ctx, "t1-only") {
+		t.Errorf("another tenant's runtime hold leaked into a tenant-less ctx")
+	}
+	// runtime row in the shared tenant: visible.
+	if err := st.ChannelsCreate(ctx, store.ChannelRow{
+		Name: "shared", TenantID: "", Scope: "global", Semantic: "queue", Hold: true,
+	}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if !srv.ChannelHeld(ctx, "shared") {
+		t.Errorf("a shared-tenant runtime hold was not seen")
+	}
+}
+
+// The channel listing must not print the reserved held instant as a delivery
+// time: "newest_visible_at: 2200-01-01" reads as a bug, not as "this channel
+// is holding". The `hold` flag is what says that.
+func TestChannelHold_ListingHidesTheReservedInstant(t *testing.T) {
+	srv, _, cleanup := channelHoldFixture(t)
+	defer cleanup()
+
+	if rec := postJSON(t, srv, "/v1/_channels/gate/publish", `{"payload":{"n":1}}`); rec.Code != http.StatusOK {
+		t.Fatalf("publish: status %d (%s)", rec.Code, rec.Body.String())
+	}
+	resp, err := srv.ListChannels(context.Background())
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	var gate *connector.ChannelDescriptor
+	for i := range resp.Channels {
+		if resp.Channels[i].Name == "gate" {
+			gate = &resp.Channels[i]
+		}
+	}
+	if gate == nil {
+		t.Fatalf("gate missing from the listing")
+	}
+	if !gate.Hold {
+		t.Errorf("the listing does not report the channel as held: %+v", gate)
+	}
+	if gate.MessageCount != 1 {
+		t.Errorf("message_count = %d, want 1 — a held message is still stored", gate.MessageCount)
+	}
+	if gate.OldestVisibleAt != "" || gate.NewestVisibleAt != "" {
+		t.Errorf("the reserved held instant leaked into the listing: oldest=%q newest=%q",
+			gate.OldestVisibleAt, gate.NewestVisibleAt)
 	}
 }

--- a/internal/api/http/channels_hold_test.go
+++ b/internal/api/http/channels_hold_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -226,6 +227,44 @@ func TestChannelHold_RuntimeDeclaredChannelHoldsAndReleases(t *testing.T) {
 		t.Fatalf("release: status %d (%s)", rec.Code, rec.Body.String())
 	}
 	if n := peekCount(t, srv, "wave-in"); n != 1 {
+		t.Errorf("after release, %d readable, want 1", n)
+	}
+}
+
+// An INTERNAL publisher — one that never resolves a channel definition, the
+// shape heartbeats, interrupts and the webhook relay use — is held too. This
+// is the HoldFn seam: the hold is enforced inside StorePublisher, so a caller
+// that knows nothing about the definition cannot walk past the breakpoint.
+//
+// Without this the hold would only be as good as the call sites that remember
+// to ask, which is the failure mode the seam exists to prevent.
+func TestChannelHold_InternalPublisherIsHeldWithoutResolvingTheDef(t *testing.T) {
+	srv, _, cleanup := channelHoldFixture(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	if _, err := srv.systemPublisher.PublishNow(ctx, "gate", "", store.MemoryScopeGlobal, "",
+		json.RawMessage(`{"beat":1}`), channels.SystemPublisherUserID, 0, 0); err != nil {
+		t.Fatalf("internal publish: %v", err)
+	}
+	if n := peekCount(t, srv, "gate"); n != 0 {
+		t.Errorf("an internal publish walked past the hold: %d delivered, want 0", n)
+	}
+
+	// Control: the same internal publish on a channel with no hold arrives.
+	if _, err := srv.systemPublisher.PublishNow(ctx, "open", "", store.MemoryScopeGlobal, "",
+		json.RawMessage(`{"beat":1}`), channels.SystemPublisherUserID, 0, 0); err != nil {
+		t.Fatalf("control publish: %v", err)
+	}
+	if n := peekCount(t, srv, "open"); n != 1 {
+		t.Errorf("control channel delivered %d, want 1", n)
+	}
+
+	// And the held one is released like any other.
+	if rec := postJSON(t, srv, "/v1/_channels/gate/release", ""); rec.Code != http.StatusOK {
+		t.Fatalf("release: status %d (%s)", rec.Code, rec.Body.String())
+	}
+	if n := peekCount(t, srv, "gate"); n != 1 {
 		t.Errorf("after release, %d readable, want 1", n)
 	}
 }

--- a/internal/api/http/channels_hold_test.go
+++ b/internal/api/http/channels_hold_test.go
@@ -1,0 +1,231 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/cancel"
+	"github.com/denn-gubsky/loomcycle/internal/channels"
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/connector"
+	"github.com/denn-gubsky/loomcycle/internal/hooks"
+	"github.com/denn-gubsky/loomcycle/internal/runner"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+)
+
+// channelHoldFixture is channelCRUDFixture with one held channel and one
+// ordinary one, and — importantly — the SystemPublisher wired the way main.go
+// wires it, HoldFn included. Without that wiring the hold is a setting nothing
+// reads, which is precisely the regression these tests guard.
+func channelHoldFixture(t *testing.T) (*Server, store.Store, func()) {
+	t.Helper()
+	s, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	cfg := &config.Config{
+		Channels: map[string]config.Channel{
+			"gate": {Scope: "global", Semantic: "queue", MaxMessages: 100, Hold: true},
+			"open": {Scope: "global", Semantic: "queue", MaxMessages: 100},
+		},
+		Env: config.Env{
+			AuthToken:             "test-token",
+			ChannelsMaxValueBytes: 64 * 1024,
+			ChannelsLongPollCapMS: 1000,
+		},
+	}
+	hookReg := hooks.NewRegistry()
+	bus := channels.NewBus()
+	sched := channels.NewScheduler(bus, 100)
+	srv := &Server{
+		cfgHolder:      config.NewHolder(cfg),
+		store:          s,
+		cancelReg:      cancel.NewRegistry(),
+		sessionLocks:   runner.NewSessionLockMap(),
+		hookRegistry:   hookReg,
+		hookDispatcher: hooks.NewDispatcher(hookReg, nil),
+		sem:            concurrency.New(8, 16, 30000),
+	}
+	srv.SetSystemPublisher(&channels.StorePublisher{
+		Store: s, Bus: bus, Scheduler: sched, HoldFn: srv.ChannelHeld,
+	})
+	srv.SetChannelBus(bus)
+	return srv, s, func() { _ = s.Close() }
+}
+
+func postJSON(t *testing.T, srv *Server, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	var r *http.Request
+	if body == "" {
+		r = authedRequest("POST", path, nil)
+	} else {
+		r = authedRequest("POST", path, strings.NewReader(body))
+	}
+	rec := httptest.NewRecorder()
+	srv.Mux().ServeHTTP(rec, r)
+	return rec
+}
+
+func peekCount(t *testing.T, srv *Server, channel string) int {
+	t.Helper()
+	req := authedRequest("GET", "/v1/_channels/"+channel+"/peek?max_messages=50", nil)
+	rec := httptest.NewRecorder()
+	srv.Mux().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("peek %s: status %d (%s)", channel, rec.Code, rec.Body.String())
+	}
+	var out connector.ChannelPeekResult
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("peek decode: %v", err)
+	}
+	return len(out.Messages)
+}
+
+// The admin publish route honours a yaml `hold:` — stored, reported as held,
+// not delivered. The control channel in the same fixture proves the route
+// otherwise delivers.
+func TestChannelHold_AdminPublishIsHeldNotDelivered(t *testing.T) {
+	srv, _, cleanup := channelHoldFixture(t)
+	defer cleanup()
+
+	rec := postJSON(t, srv, "/v1/_channels/gate/publish", `{"payload":{"n":1}}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("publish: status %d (%s)", rec.Code, rec.Body.String())
+	}
+	var pub connector.ChannelPublishResult
+	if err := json.Unmarshal(rec.Body.Bytes(), &pub); err != nil {
+		t.Fatalf("decode publish: %v", err)
+	}
+	if !pub.Held {
+		t.Errorf("publish to a hold: channel must report held:true, got %+v", pub)
+	}
+	if pub.VisibleAt != "" {
+		t.Errorf("a held publish must not promise a visible_at, got %q", pub.VisibleAt)
+	}
+	if n := peekCount(t, srv, "gate"); n != 0 {
+		t.Errorf("held message readable: %d, want 0", n)
+	}
+
+	if rec := postJSON(t, srv, "/v1/_channels/open/publish", `{"payload":{"n":1}}`); rec.Code != http.StatusOK {
+		t.Fatalf("control publish: status %d (%s)", rec.Code, rec.Body.String())
+	}
+	if n := peekCount(t, srv, "open"); n != 1 {
+		t.Errorf("control channel delivered %d, want 1", n)
+	}
+}
+
+// POST /v1/_channels/{name}/release hands over the oldest N and says what is
+// left. Allowed on a yaml channel — releasing moves messages, it does not
+// mutate the definition.
+func TestChannelHold_ReleaseEndpointDeliversOldestFirst(t *testing.T) {
+	srv, _, cleanup := channelHoldFixture(t)
+	defer cleanup()
+
+	for _, n := range []string{"1", "2", "3"} {
+		if rec := postJSON(t, srv, "/v1/_channels/gate/publish", `{"payload":{"n":`+n+`}}`); rec.Code != http.StatusOK {
+			t.Fatalf("publish %s: status %d (%s)", n, rec.Code, rec.Body.String())
+		}
+	}
+
+	// Empty body = release one.
+	rec := postJSON(t, srv, "/v1/_channels/gate/release", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("release: status %d (%s)", rec.Code, rec.Body.String())
+	}
+	var out connector.ChannelReleaseResult
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode release: %v", err)
+	}
+	if out.ReleasedCount != 1 || out.StillHeld != 2 {
+		t.Fatalf("released %d leaving %d, want 1 leaving 2", out.ReleasedCount, out.StillHeld)
+	}
+	if n := peekCount(t, srv, "gate"); n != 1 {
+		t.Errorf("after one release, %d readable, want 1", n)
+	}
+
+	rec = postJSON(t, srv, "/v1/_channels/gate/release", `{"count":10}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("release rest: status %d (%s)", rec.Code, rec.Body.String())
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &out)
+	if out.ReleasedCount != 2 || out.StillHeld != 0 {
+		t.Errorf("drain released %d leaving %d, want 2 leaving 0", out.ReleasedCount, out.StillHeld)
+	}
+	if n := peekCount(t, srv, "gate"); n != 3 {
+		t.Errorf("after draining, %d readable, want 3", n)
+	}
+}
+
+// An undeclared channel 404s rather than silently releasing nothing — the same
+// answer publish/subscribe give, so a typo is a typo everywhere.
+func TestChannelHold_ReleaseUndeclaredChannelIs404(t *testing.T) {
+	srv, _, cleanup := channelHoldFixture(t)
+	defer cleanup()
+	rec := postJSON(t, srv, "/v1/_channels/ghost/release", "")
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("release on an undeclared channel: status %d, want 404 (%s)", rec.Code, rec.Body.String())
+	}
+}
+
+// The hold is a property of the CHANNEL, so a deliver_at cannot escape it: a
+// caller asking for delivery in two seconds still waits for a release.
+func TestChannelHold_DeliverAtDoesNotEscapeTheHold(t *testing.T) {
+	srv, _, cleanup := channelHoldFixture(t)
+	defer cleanup()
+
+	rec := postJSON(t, srv, "/v1/_channels/gate/publish",
+		`{"payload":{"n":1},"deliver_at":"2000-01-01T00:00:00Z"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("publish: status %d (%s)", rec.Code, rec.Body.String())
+	}
+	var pub connector.ChannelPublishResult
+	_ = json.Unmarshal(rec.Body.Bytes(), &pub)
+	if !pub.Held {
+		t.Errorf("a past deliver_at escaped the hold: %+v", pub)
+	}
+	if n := peekCount(t, srv, "gate"); n != 0 {
+		t.Errorf("held message with a past deliver_at was delivered: %d", n)
+	}
+}
+
+// A RUNTIME-declared channel holds too. This is the path the canvas uses —
+// a workflow declares its own channels through the substrate, not through
+// operator yaml — so the hold has to survive create → ChannelGet → publish,
+// not just the yaml map.
+func TestChannelHold_RuntimeDeclaredChannelHoldsAndReleases(t *testing.T) {
+	srv, _, cleanup := channelHoldFixture(t)
+	defer cleanup()
+
+	rec := postJSON(t, srv, "/v1/_channels",
+		`{"name":"wave-in","scope":"global","semantic":"queue","hold":true}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create: status %d (%s)", rec.Code, rec.Body.String())
+	}
+	var desc connector.ChannelDescriptor
+	if err := json.Unmarshal(rec.Body.Bytes(), &desc); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+	if !desc.Hold {
+		t.Errorf("create response dropped hold: %+v", desc)
+	}
+
+	if rec := postJSON(t, srv, "/v1/_channels/wave-in/publish", `{"payload":{"n":1}}`); rec.Code != http.StatusOK {
+		t.Fatalf("publish: status %d (%s)", rec.Code, rec.Body.String())
+	}
+	if n := peekCount(t, srv, "wave-in"); n != 0 {
+		t.Errorf("runtime hold channel delivered %d, want 0", n)
+	}
+
+	rec = postJSON(t, srv, "/v1/_channels/wave-in/release", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("release: status %d (%s)", rec.Code, rec.Body.String())
+	}
+	if n := peekCount(t, srv, "wave-in"); n != 1 {
+		t.Errorf("after release, %d readable, want 1", n)
+	}
+}

--- a/internal/api/http/connector_impl_channels.go
+++ b/internal/api/http/connector_impl_channels.go
@@ -27,8 +27,10 @@ import (
 const channelFanCap = 32
 
 // maxChannelReleaseCount bounds one release — the wire twin of the in-band
-// tool's maxReleaseCount, kept in step by the drift test in
-// connector_impl_channels_test.go.
+// tool's builtin.maxReleaseCount. Kept in step by
+// TestChannelRelease_WireAndToolCapsAgree in channels_hold_test.go: two caps
+// that drift mean the same request is accepted on one surface and refused on
+// the other.
 const maxChannelReleaseCount = 1000
 
 // resolveChannelScope maps the wire-string `scope` to the store enum

--- a/internal/api/http/connector_impl_channels.go
+++ b/internal/api/http/connector_impl_channels.go
@@ -26,6 +26,11 @@ import (
 // the wire surface — same cap as the in-band Channel tool's maxFanChannels.
 const channelFanCap = 32
 
+// maxChannelReleaseCount bounds one release — the wire twin of the in-band
+// tool's maxReleaseCount, kept in step by the drift test in
+// connector_impl_channels_test.go.
+const maxChannelReleaseCount = 1000
+
 // resolveChannelScope maps the wire-string `scope` to the store enum
 // and validates `scope_id` shape. Channel CRUD only supports global +
 // user; agent scope isn't reachable from an HTTP boundary (the agent
@@ -61,6 +66,7 @@ func (s *Server) requireChannelDeclared(ctx context.Context, name string) (chann
 		return channelDef{
 			MaxMessages: def.MaxMessages,
 			DefaultTTL:  def.DefaultTTL,
+			Hold:        def.Hold,
 		}, nil
 	}
 	if s.store != nil {
@@ -74,6 +80,7 @@ func (s *Server) requireChannelDeclared(ctx context.Context, name string) (chann
 			return channelDef{
 				MaxMessages: row.MaxMessages,
 				DefaultTTL:  row.DefaultTTL,
+				Hold:        row.Hold,
 			}, nil
 		case isNotFound(err):
 			// fall through to the not-declared signal below
@@ -89,6 +96,7 @@ func (s *Server) requireChannelDeclared(ctx context.Context, name string) (chann
 type channelDef struct {
 	MaxMessages int
 	DefaultTTL  int
+	Hold        bool
 }
 
 // PublishChannel publishes a message to a declared channel. Delegates
@@ -130,6 +138,12 @@ func (s *Server) PublishChannel(ctx context.Context, req connector.ChannelPublis
 		}
 		deliverAt = parsed
 	}
+	// A hold overrides deliver_at: the message waits for a release, not for
+	// a clock. Passed as the reserved instant so the publisher's own HoldFn
+	// short-circuits instead of resolving the definition a second time.
+	if def.Hold {
+		deliverAt = store.ChannelHeldVisibleAt()
+	}
 
 	// Audit attribution: "_admin" for global-scope (operator), the
 	// user_id for user-scope (per-end-user). The bearer's identity
@@ -154,10 +168,62 @@ func (s *Server) PublishChannel(ctx context.Context, req connector.ChannelPublis
 		Channel:   req.Channel,
 		CreatedAt: msg.PublishedAt.UTC().Format(time.RFC3339Nano),
 	}
-	if !msg.VisibleAt.IsZero() && !msg.VisibleAt.Equal(msg.PublishedAt) {
+	if def.Hold {
+		// Report the hold instead of a visible_at in the year 2200 — the
+		// reserved instant is an implementation marker, not a promise about
+		// when this message is coming.
+		out.Held = true
+	} else if !msg.VisibleAt.IsZero() && !msg.VisibleAt.Equal(msg.PublishedAt) {
 		out.VisibleAt = msg.VisibleAt.UTC().Format(time.RFC3339Nano)
 	}
 	return out, nil
+}
+
+// ReleaseChannel implements the operator half of the hold breakpoint: hand
+// the oldest Count held messages to subscribers and wake the long-poll bus,
+// exactly as the publish would have done had the channel not been held.
+//
+// Deliberately NOT gated on the channel being declared hold: — a channel
+// switched back to delivering can still have messages held from before, and
+// refusing to release them would strand the queue with no way out but a
+// purge.
+func (s *Server) ReleaseChannel(ctx context.Context, req connector.ChannelReleaseRequest) (connector.ChannelReleaseResult, error) {
+	if req.Channel == "" {
+		return connector.ChannelReleaseResult{}, fmt.Errorf("release: missing required field: channel")
+	}
+	if req.Count > maxChannelReleaseCount {
+		return connector.ChannelReleaseResult{}, fmt.Errorf("release: count %d exceeds max %d", req.Count, maxChannelReleaseCount)
+	}
+	if _, err := s.requireChannelDeclared(ctx, req.Channel); err != nil {
+		return connector.ChannelReleaseResult{}, err
+	}
+	scope, scopeID, err := resolveChannelScope(req.Scope, req.ScopeID)
+	if err != nil {
+		return connector.ChannelReleaseResult{}, err
+	}
+	if s.store == nil {
+		return connector.ChannelReleaseResult{}, fmt.Errorf("release: no store configured")
+	}
+	count := req.Count
+	if count <= 0 {
+		count = 1
+	}
+	released, stillHeld, err := s.store.ChannelRelease(ctx, tenantFromCtx(ctx), req.Channel, scope, scopeID, count)
+	if err != nil {
+		return connector.ChannelReleaseResult{}, fmt.Errorf("release: %w", err)
+	}
+	if released == nil {
+		released = []string{}
+	}
+	if len(released) > 0 && s.channelBus != nil {
+		s.channelBus.Notify(req.Channel)
+	}
+	return connector.ChannelReleaseResult{
+		Channel:       req.Channel,
+		Released:      released,
+		ReleasedCount: len(released),
+		StillHeld:     stillHeld,
+	}, nil
 }
 
 // SubscribeChannel reads the next batch of messages, optionally waiting

--- a/internal/api/http/connector_impl_channels_crud.go
+++ b/internal/api/http/connector_impl_channels_crud.go
@@ -51,6 +51,7 @@ func rowToBareDescriptor(row store.ChannelRow) connector.ChannelDescriptor {
 		Period:      row.Period,
 		DefaultTTL:  row.DefaultTTL,
 		MaxMessages: row.MaxMessages,
+		Hold:        row.Hold,
 		Source:      "runtime",
 	}
 }
@@ -129,6 +130,7 @@ func (s *Server) CreateChannel(ctx context.Context, req connector.ChannelCreateR
 		MaxMessages: req.MaxMessages,
 		Publisher:   req.Publisher,
 		Period:      req.Period,
+		Hold:        req.Hold,
 		CreatedAt:   time.Now().UTC(),
 	}
 	if err := s.store.ChannelsCreate(ctx, row); err != nil {
@@ -172,6 +174,7 @@ func (s *Server) UpdateChannel(ctx context.Context, name string, req connector.C
 		DefaultTTL:  req.DefaultTTL,
 		MaxMessages: req.MaxMessages,
 		Semantic:    req.Semantic,
+		Hold:        req.Hold,
 	}
 	if err := s.store.ChannelsUpdate(ctx, tenantFromCtx(ctx), name, patch); err != nil {
 		var notFound *store.ErrNotFound

--- a/internal/api/http/connector_impl_n8n.go
+++ b/internal/api/http/connector_impl_n8n.go
@@ -12,12 +12,28 @@ import (
 
 	"github.com/denn-gubsky/loomcycle/internal/connector"
 	"github.com/denn-gubsky/loomcycle/internal/runstate"
+	"github.com/denn-gubsky/loomcycle/internal/store"
 )
 
 // ListChannels returns the operator-declared channels joined with
 // runtime stats (count + oldest/newest visible_at). Mirrors what
 // handleListChannels writes to the HTTP wire — same code path
 // minus the JSON-encoder framing.
+// formatVisibleAt renders a message's visible_at for the channel listing,
+// returning "" for anything that is not a real delivery time.
+//
+// A HELD message carries the reserved sentinel instant (RFC CY), and printing
+// "2200-01-01" in an operator's channel list reads as a bug rather than as
+// "this channel is holding". The `hold` flag on the descriptor is what says
+// that; the timestamp says nothing, which is the truth — a held message has no
+// scheduled arrival.
+func formatVisibleAt(t time.Time) string {
+	if t.IsZero() || store.IsChannelHeld(t) {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
+}
+
 func (s *Server) ListChannels(ctx context.Context) (connector.ListChannelsResponse, error) {
 	stats, err := s.store.ChannelStats(ctx)
 	if err != nil {
@@ -52,12 +68,8 @@ func (s *Server) ListChannels(ctx context.Context) (connector.ListChannelsRespon
 		}
 		if st, ok := statsByName[name]; ok {
 			desc.MessageCount = st.Count
-			if !st.OldestVisibleAt.IsZero() {
-				desc.OldestVisibleAt = st.OldestVisibleAt.UTC().Format(time.RFC3339)
-			}
-			if !st.NewestVisibleAt.IsZero() {
-				desc.NewestVisibleAt = st.NewestVisibleAt.UTC().Format(time.RFC3339)
-			}
+			desc.OldestVisibleAt = formatVisibleAt(st.OldestVisibleAt)
+			desc.NewestVisibleAt = formatVisibleAt(st.NewestVisibleAt)
 		}
 		out = append(out, desc)
 	}
@@ -93,12 +105,8 @@ func (s *Server) ListChannels(ctx context.Context) (connector.ListChannelsRespon
 		}
 		if st, ok := statsByName[r.Name]; ok {
 			desc.MessageCount = st.Count
-			if !st.OldestVisibleAt.IsZero() {
-				desc.OldestVisibleAt = st.OldestVisibleAt.UTC().Format(time.RFC3339)
-			}
-			if !st.NewestVisibleAt.IsZero() {
-				desc.NewestVisibleAt = st.NewestVisibleAt.UTC().Format(time.RFC3339)
-			}
+			desc.OldestVisibleAt = formatVisibleAt(st.OldestVisibleAt)
+			desc.NewestVisibleAt = formatVisibleAt(st.NewestVisibleAt)
 		}
 		out = append(out, desc)
 	}
@@ -117,12 +125,8 @@ func (s *Server) ListChannels(ctx context.Context) (connector.ListChannelsRespon
 			continue
 		}
 		desc := connector.ChannelDescriptor{Name: name, MessageCount: st.Count, Source: "orphan"}
-		if !st.OldestVisibleAt.IsZero() {
-			desc.OldestVisibleAt = st.OldestVisibleAt.UTC().Format(time.RFC3339)
-		}
-		if !st.NewestVisibleAt.IsZero() {
-			desc.NewestVisibleAt = st.NewestVisibleAt.UTC().Format(time.RFC3339)
-		}
+		desc.OldestVisibleAt = formatVisibleAt(st.OldestVisibleAt)
+		desc.NewestVisibleAt = formatVisibleAt(st.NewestVisibleAt)
 		out = append(out, desc)
 	}
 	// Deterministic order — easier on transports that snapshot the

--- a/internal/api/http/connector_impl_n8n.go
+++ b/internal/api/http/connector_impl_n8n.go
@@ -47,6 +47,7 @@ func (s *Server) ListChannels(ctx context.Context) (connector.ListChannelsRespon
 			Period:      ch.Period,
 			DefaultTTL:  ch.DefaultTTL,
 			MaxMessages: ch.MaxMessages,
+			Hold:        ch.Hold,
 			Source:      "yaml",
 		}
 		if st, ok := statsByName[name]; ok {
@@ -87,6 +88,7 @@ func (s *Server) ListChannels(ctx context.Context) (connector.ListChannelsRespon
 			Period:      r.Period,
 			DefaultTTL:  r.DefaultTTL,
 			MaxMessages: r.MaxMessages,
+			Hold:        r.Hold,
 			Source:      "runtime",
 		}
 		if st, ok := statsByName[r.Name]; ok {

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2042,6 +2042,7 @@ func (s *Server) mergedChannelDefs(ctx context.Context, includeRuntime bool) map
 			MaxMessages: ch.MaxMessages,
 			Semantic:    ch.Semantic,
 			Publisher:   ch.Publisher, // v0.8.6: agent publish refusal when "system"
+			Hold:        ch.Hold,      // RFC CY: store-without-delivering breakpoint
 		}
 	}
 	if includeRuntime && s.store != nil {
@@ -2064,6 +2065,7 @@ func (s *Server) mergedChannelDefs(ctx context.Context, includeRuntime bool) map
 					MaxMessages: r.MaxMessages,
 					Semantic:    r.Semantic,
 					Publisher:   r.Publisher,
+					Hold:        r.Hold,
 				}
 			}
 		}
@@ -2104,6 +2106,31 @@ func (s *Server) ResolveChannelScope(ctx context.Context, channel string) (strin
 		return "", false
 	}
 	return def.Scope, true
+}
+
+// ChannelHeld reports whether a channel is declared `hold:` (RFC CY) —
+// publishes are stored but never delivered until a release. Wired into the
+// SystemPublisher so every internal publish path (heartbeats, the webhook
+// relay, interrupts, the admin endpoint) honours the hold without each one
+// resolving the definition itself.
+//
+// A POINT lookup, not the mergedChannelDefs scan ResolveChannelScope uses:
+// this runs on every system publish, including the webhook relay's hot path.
+// Static yaml wins over a runtime row, matching the merge order everywhere
+// else. A store fault answers false — an unreachable definition plane must
+// not silently start holding a channel that isn't declared held.
+func (s *Server) ChannelHeld(ctx context.Context, channel string) bool {
+	if def, ok := s.cfg().Channels[channel]; ok {
+		return def.Hold
+	}
+	if s.store == nil {
+		return false
+	}
+	row, err := s.store.ChannelGet(ctx, tenantFromCtx(ctx), channel)
+	if err != nil {
+		return false
+	}
+	return row.Hold
 }
 
 // fallbackForRun builds the v0.8.2 PR-2 runtime-fallback policy +
@@ -2958,6 +2985,10 @@ func (s *Server) Mux() http.Handler {
 	mux.Handle("GET /v1/_channels/{name}/peek", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleAdminChannelPeek))))
 	mux.Handle("POST /v1/_channels/{name}/ack", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleAdminChannelAck))))
 	mux.Handle("POST /v1/_channels/{name}/purge", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleChannelPurge))))
+	// RFC CY: release held messages on a `hold:` channel. Allowed on yaml
+	// channels for the same reason purge is — it moves messages, it does not
+	// mutate the definition.
+	mux.Handle("POST /v1/_channels/{name}/release", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleChannelRelease))))
 	// RFC S client twins — multi-channel fan-in / fan-out. The reserved
 	// `_await` / `_broadcast` literals are strictly more specific than the
 	// `{name...}` system-publish catch-all, so Go 1.22+ mux routes them here.

--- a/internal/api/mcp/http_transport_test.go
+++ b/internal/api/mcp/http_transport_test.go
@@ -234,6 +234,9 @@ func (m *httpMockConnector) DeleteChannel(context.Context, string) error {
 func (m *httpMockConnector) PurgeChannel(context.Context, string) (connector.ChannelPurgeResult, error) {
 	return connector.ChannelPurgeResult{}, errors.New("not implemented")
 }
+func (m *httpMockConnector) ReleaseChannel(context.Context, connector.ChannelReleaseRequest) (connector.ChannelReleaseResult, error) {
+	return connector.ChannelReleaseResult{}, errors.New("not implemented")
+}
 func (m *httpMockConnector) Config(context.Context) ([]byte, error) {
 	return nil, errors.New("not implemented")
 }

--- a/internal/api/mcp/server_test.go
+++ b/internal/api/mcp/server_test.go
@@ -340,6 +340,9 @@ func (m *mockConnector) PurgeChannel(context.Context, string) (connector.Channel
 	m.chanDefCalls.Add(1)
 	return connector.ChannelPurgeResult{}, nil
 }
+func (m *mockConnector) ReleaseChannel(context.Context, connector.ChannelReleaseRequest) (connector.ChannelReleaseResult, error) {
+	return connector.ChannelReleaseResult{}, nil
+}
 func (m *mockConnector) Config(context.Context) ([]byte, error) {
 	return nil, errors.New("not implemented")
 }

--- a/internal/api/mcp/tools.go
+++ b/internal/api/mcp/tools.go
@@ -242,7 +242,7 @@ func toolDescriptors() []loommcp.ToolDescriptor {
 		},
 		{
 			Name:        "channel",
-			Description: "Channel tool ops (publish/subscribe/ack/peek/list_channels/await/broadcast). await = multi-channel fan-in barrier (any/all/at_least N or timeout; non-committing); broadcast = symmetric fan-out (one payload → N channels, atomic ACL pre-flight). Pass-through.",
+			Description: "Channel tool ops (publish/subscribe/ack/peek/release/list_channels/await/broadcast). await = multi-channel fan-in barrier (any/all/at_least N or timeout; non-committing); broadcast = symmetric fan-out (one payload → N channels, atomic ACL pre-flight); release = hand over the oldest count (default 1) messages held on a hold: channel. Pass-through.",
 			InputSchema: builtinSchema("channel"),
 		},
 		{
@@ -259,6 +259,7 @@ func toolDescriptors() []loommcp.ToolDescriptor {
 					"semantic":     {"type": "string", "enum": ["queue", "topic"], "description": "Default queue."},
 					"default_ttl":  {"type": "integer", "description": "Per-message TTL seconds. 0 = no TTL."},
 					"max_messages": {"type": "integer", "description": "Bounded-queue cap. 0 = unbounded."},
+					"hold":         {"type": "boolean", "description": "Breakpoint: publishes are stored but never delivered until released (POST /v1/_channels/{name}/release, or Channel op=release)."},
 					"publisher":    {"type": "string", "description": "create only. Free-form attribution."}
 				}
 			}`),

--- a/internal/channels/system.go
+++ b/internal/channels/system.go
@@ -52,6 +52,21 @@ type StorePublisher struct {
 	Store     store.Store
 	Bus       *Bus       // nil disables in-process notification
 	Scheduler *Scheduler // nil disables deferred-publish wake-up scheduling
+
+	// HoldFn reports whether a channel is declared `hold:` — stored but not
+	// delivered until released (RFC CY).
+	//
+	// The CHECK LIVES HERE, not at the call sites, and that is the point: a
+	// hold is a promise that nothing reaches a subscriber, and a promise
+	// enforced at five call sites is a promise the sixth one breaks. Every
+	// internal publisher — heartbeats, webhook relay, interrupts, the admin
+	// endpoint — goes through this one method, so wiring the resolver once
+	// holds all of them.
+	//
+	// Injected rather than resolved here because the channel definition
+	// plane (static yaml merged with the runtime substrate, tenant-scoped)
+	// lives in the server. nil = nothing is held.
+	HoldFn func(ctx context.Context, channel string) bool
 }
 
 // SystemPublisherUserID is the audit-trail sentinel for internal Go
@@ -82,6 +97,19 @@ func (p *StorePublisher) Publish(ctx context.Context, channel, tenantID string, 
 		deferred = true
 	}
 
+	// A held channel overrides any deliver_at: the message waits for a
+	// release, not for a clock. Callers that already resolved the def pass
+	// the reserved instant as deliverAt (the store.IsChannelHeld arm);
+	// everyone else is caught by HoldFn.
+	held := store.IsChannelHeld(deliverAt)
+	if !held && p.HoldFn != nil {
+		held = p.HoldFn(ctx, channel)
+	}
+	if held {
+		visibleAt = store.ChannelHeldVisibleAt()
+		deferred = false
+	}
+
 	msg := store.ChannelMessage{
 		Channel:           channel,
 		TenantID:          tenantID,
@@ -103,10 +131,15 @@ func (p *StorePublisher) Publish(ctx context.Context, channel, tenantID string, 
 
 	// Wake subscribers. Deferred publishes go through the scheduler
 	// (wakes at visible_at); immediate publishes notify the bus
-	// directly (same path as the agent tool's execPublish).
-	if deferred && p.Scheduler != nil {
+	// directly (same path as the agent tool's execPublish). A HELD
+	// message wakes nobody — that is what holding means, and arming a
+	// timer for the reserved instant would be a timer for the year 2200.
+	switch {
+	case held:
+		// no notification, no timer
+	case deferred && p.Scheduler != nil:
 		p.Scheduler.Schedule(channel, id, visibleAt)
-	} else if p.Bus != nil {
+	case p.Bus != nil:
 		p.Bus.Notify(channel)
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2216,6 +2216,22 @@ type Channel struct {
 	// ACL allows) but may not publish regardless of Publisher value.
 	Publisher string `yaml:"publisher"`
 	Period    string `yaml:"period"`
+
+	// Hold turns the channel into a BREAKPOINT: a publish is stored but
+	// never delivered and never wakes a subscriber, until an operator (or
+	// an agent with publish rights) releases it — `Channel op=release`, or
+	// POST /v1/_channels/{name}/release.
+	//
+	// A held message keeps its TTL, so a hold never becomes a way to keep a
+	// message past the retention its publisher declared, and overflow trims
+	// the oldest exactly as on any other channel.
+	//
+	// Why an operator wants this: a workflow whose stages are wired through
+	// channels can be single-stepped by holding one of them — the wave
+	// upstream runs, its results queue, and nothing downstream starts until
+	// a human says go. Default false: every existing channel delivers as
+	// before.
+	Hold bool `yaml:"hold"`
 }
 
 // PeriodDuration parses Period as a Go time.Duration. Returns 0 + nil

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -553,6 +553,16 @@ type Connector interface {
 	// the name is neither yaml-declared nor in the runtime table.
 	PurgeChannel(ctx context.Context, name string) (ChannelPurgeResult, error)
 
+	// ReleaseChannel hands the oldest Count held messages on a `hold:`
+	// channel to its subscribers — the operator half of the breakpoint the
+	// in-band Channel op=release gives agents. Releasing on a channel with
+	// nothing held reports zero rather than failing: "advance the queue" is
+	// a reasonable request even when the queue is empty.
+	//
+	// Typed errors: ErrChannelNotDeclared (NotFound), ErrChannelScopeInvalid
+	// (InvalidArgument).
+	ReleaseChannel(ctx context.Context, req ChannelReleaseRequest) (ChannelReleaseResult, error)
+
 	// --- Instance configuration ---
 
 	// Config returns the instance-configuration report — what this deployment is

--- a/internal/connector/types.go
+++ b/internal/connector/types.go
@@ -471,6 +471,7 @@ type ChannelDescriptor struct {
 	Period          string `json:"period,omitempty"`
 	DefaultTTL      int    `json:"default_ttl,omitempty"`
 	MaxMessages     int    `json:"max_messages,omitempty"`
+	Hold            bool   `json:"hold,omitempty"` // stores without delivering until released
 	MessageCount    int64  `json:"message_count"`
 	OldestVisibleAt string `json:"oldest_visible_at,omitempty"` // RFC3339; empty when count=0
 	NewestVisibleAt string `json:"newest_visible_at,omitempty"`
@@ -510,6 +511,10 @@ type ChannelPublishResult struct {
 	Channel   string `json:"channel"`
 	CreatedAt string `json:"created_at"`           // RFC3339Nano
 	VisibleAt string `json:"visible_at,omitempty"` // RFC3339Nano; omitted when not deferred
+	// Held reports that the channel is declared hold: — the message is
+	// stored but was NOT delivered and woke no subscriber. Said out loud
+	// because a msg_id with no further word reads as "delivered".
+	Held bool `json:"held,omitempty"`
 }
 
 // ChannelSubscribeRequest is the input to Connector.SubscribeChannel.
@@ -664,6 +669,7 @@ type ChannelCreateRequest struct {
 	MaxMessages int    `json:"max_messages,omitempty"` // bounded queue; 0 = unbounded
 	Publisher   string `json:"publisher,omitempty"`    // free-form attribution; not enforced
 	Period      string `json:"period,omitempty"`       // free-form retention hint; not enforced
+	Hold        bool   `json:"hold,omitempty"`         // store publishes without delivering until released
 }
 
 // ChannelUpdateRequest is the input to Connector.UpdateChannel. Nil
@@ -674,6 +680,26 @@ type ChannelUpdateRequest struct {
 	DefaultTTL  *int    `json:"default_ttl,omitempty"`
 	MaxMessages *int    `json:"max_messages,omitempty"`
 	Semantic    *string `json:"semantic,omitempty"`
+	Hold        *bool   `json:"hold,omitempty"`
+}
+
+// ChannelReleaseRequest is the input to Connector.ReleaseChannel — hand the
+// oldest Count held messages on a hold: channel to its subscribers. Count 0
+// means 1: a release is a single step unless the caller says otherwise.
+type ChannelReleaseRequest struct {
+	Channel string `json:"channel"`
+	Scope   string `json:"scope,omitempty"`
+	ScopeID string `json:"scope_id,omitempty"`
+	Count   int    `json:"count,omitempty"`
+}
+
+// ChannelReleaseResult reports what a release handed over and what is left.
+// Released is [] (never null) so a consumer can index it unconditionally.
+type ChannelReleaseResult struct {
+	Channel       string   `json:"channel"`
+	Released      []string `json:"released"`
+	ReleasedCount int      `json:"released_count"`
+	StillHeld     int      `json:"still_held"`
 }
 
 // ChannelPurgeResult is the output of Connector.PurgeChannel — the

--- a/internal/providers/codejs/codejs_test.go
+++ b/internal/providers/codejs/codejs_test.go
@@ -431,7 +431,7 @@ func TestCodeJS_ReplayDivergence_FailsLoud(t *testing.T) {
 // canary that catches a regression to a hardcoded subset OR an op whose name
 // collides with a reserved JS property).
 var memoryOpsMirror = []string{"get", "set", "delete", "list", "incr", "search", "merge", "append_dedupe", "bounded_list", "add", "recall"}
-var channelOpsMirror = []string{"publish", "subscribe", "ack", "peek", "list_channels"}
+var channelOpsMirror = []string{"publish", "subscribe", "ack", "peek", "release", "list_channels"}
 
 // Meta-tool op drift: every op the Memory/Channel tools accept must be
 // reachable from code-js as Memory.<op>(...) / Channel.<op>(...), and none may

--- a/internal/store/postgres/channels.go
+++ b/internal/store/postgres/channels.go
@@ -23,7 +23,7 @@ import (
 func (s *Store) ChannelsList(ctx context.Context) ([]store.ChannelRow, error) {
 	rows, err := s.pool.Query(ctx, `
 		SELECT name, tenant_id, description, scope, semantic,
-		       default_ttl, max_messages, publisher, period, created_at
+		       default_ttl, max_messages, publisher, period, hold, created_at
 		FROM channels
 		ORDER BY tenant_id, name
 	`)
@@ -38,7 +38,7 @@ func (s *Store) ChannelsList(ctx context.Context) ([]store.ChannelRow, error) {
 		if err := rows.Scan(
 			&r.Name, &r.TenantID, &r.Description, &r.Scope, &r.Semantic,
 			&r.DefaultTTL, &r.MaxMessages, &r.Publisher, &r.Period,
-			&createdAt,
+			&r.Hold, &createdAt,
 		); err != nil {
 			return nil, fmt.Errorf("channels list scan: %w", err)
 		}
@@ -58,13 +58,13 @@ func (s *Store) ChannelGet(ctx context.Context, tenantID, name string) (store.Ch
 	var createdAt time.Time
 	err := s.pool.QueryRow(ctx, `
 		SELECT name, tenant_id, description, scope, semantic,
-		       default_ttl, max_messages, publisher, period, created_at
+		       default_ttl, max_messages, publisher, period, hold, created_at
 		FROM channels
 		WHERE tenant_id = $1 AND name = $2
 	`, tenantID, name).Scan(
 		&r.Name, &r.TenantID, &r.Description, &r.Scope, &r.Semantic,
 		&r.DefaultTTL, &r.MaxMessages, &r.Publisher, &r.Period,
-		&createdAt,
+		&r.Hold, &createdAt,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return store.ChannelRow{}, &store.ErrNotFound{Kind: "channel", ID: name}
@@ -87,11 +87,11 @@ func (s *Store) ChannelsCreate(ctx context.Context, row store.ChannelRow) error 
 	_, err := s.pool.Exec(ctx, `
 		INSERT INTO channels (
 			name, description, scope, semantic,
-			default_ttl, max_messages, publisher, period, created_at, tenant_id
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+			default_ttl, max_messages, publisher, period, hold, created_at, tenant_id
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 	`,
 		row.Name, row.Description, row.Scope, row.Semantic,
-		row.DefaultTTL, row.MaxMessages, row.Publisher, row.Period, createdAt, row.TenantID,
+		row.DefaultTTL, row.MaxMessages, row.Publisher, row.Period, row.Hold, createdAt, row.TenantID,
 	)
 	if err != nil {
 		var pgErr *pgconn.PgError
@@ -129,6 +129,11 @@ func (s *Store) ChannelsUpdate(ctx context.Context, tenantID, name string, patch
 	if patch.Semantic != nil {
 		sets = append(sets, fmt.Sprintf("semantic = $%d", idx))
 		args = append(args, *patch.Semantic)
+		idx++
+	}
+	if patch.Hold != nil {
+		sets = append(sets, fmt.Sprintf("hold = $%d", idx))
+		args = append(args, *patch.Hold)
 		idx++
 	}
 	if len(sets) == 0 {

--- a/internal/store/postgres/migrations/0075_channels_hold.down.sql
+++ b/internal/store/postgres/migrations/0075_channels_hold.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE channels DROP COLUMN IF EXISTS hold;

--- a/internal/store/postgres/migrations/0075_channels_hold.up.sql
+++ b/internal/store/postgres/migrations/0075_channels_hold.up.sql
@@ -1,0 +1,14 @@
+-- 0075_channels_hold.up.sql — RFC CY: the hold breakpoint.
+--
+-- A held channel STORES a publish without delivering or notifying; a release
+-- hands the oldest N messages to subscribers. The flag lives on the channel
+-- definition (not the message) because holding is a property of the wire, not
+-- of one payload: an operator single-stepping a wave holds the channel, runs
+-- the workflow, and releases one message at a time.
+--
+-- Held MESSAGES are marked in channel_messages by a reserved visible_at
+-- instant (store.ChannelHeldVisibleAt), which needs no column of its own —
+-- every read already filters visible_at <= now.
+--
+-- Default FALSE: every existing channel keeps delivering exactly as before.
+ALTER TABLE channels ADD COLUMN IF NOT EXISTS hold BOOLEAN NOT NULL DEFAULT FALSE;

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -4772,6 +4772,82 @@ func (s *Store) ChannelPeek(ctx context.Context, tenantID, channel string, scope
 	return msgs, err
 }
 
+// ChannelRelease makes the `count` oldest held messages deliverable now.
+//
+// SELECT ... FOR UPDATE, then UPDATE, in one transaction: under READ COMMITTED
+// two concurrent releases would otherwise pick the same rows and each report
+// them as its own. FOR UPDATE makes the second wait, and when it proceeds the
+// re-checked predicate no longer matches the rows the first took, so it moves
+// on to the next held messages instead of double-releasing.
+//
+// The UPDATE re-states the held predicate for the same reason.
+func (s *Store) ChannelRelease(ctx context.Context, tenantID, channel string, scope store.MemoryScope, scopeID string, count int) ([]string, int, error) {
+	tenantID = store.ChannelScopeTenant(tenantID, scope) // global => "" (cross-tenant keyspace)
+	if count <= 0 {
+		count = 1
+	}
+	held := store.ChannelHeldVisibleAt()
+
+	var tx pgx.Tx
+	if err := retryOnTransientConn(ctx, func() error {
+		var beginErr error
+		tx, beginErr = s.pool.Begin(ctx)
+		return beginErr
+	}); err != nil {
+		return nil, 0, fmt.Errorf("channel release begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	rows, err := tx.Query(ctx,
+		`SELECT id FROM channel_messages
+		  WHERE tenant_id = $1 AND channel = $2 AND scope = $3 AND scope_id = $4
+		    AND visible_at = $5
+		    AND (expires_at IS NULL OR expires_at > NOW())
+		  ORDER BY id ASC
+		  LIMIT $6
+		  FOR UPDATE`,
+		tenantID, channel, string(scope), scopeID, held, count)
+	if err != nil {
+		return nil, 0, fmt.Errorf("channel release select: %w", err)
+	}
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return nil, 0, err
+		}
+		ids = append(ids, id)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, 0, err
+	}
+
+	for _, id := range ids {
+		if _, err := tx.Exec(ctx,
+			`UPDATE channel_messages SET visible_at = NOW() WHERE id = $1 AND visible_at = $2`,
+			id, held); err != nil {
+			return nil, 0, fmt.Errorf("channel release update: %w", err)
+		}
+	}
+
+	var stillHeld int
+	if err := tx.QueryRow(ctx,
+		`SELECT COUNT(*) FROM channel_messages
+		  WHERE tenant_id = $1 AND channel = $2 AND scope = $3 AND scope_id = $4
+		    AND visible_at = $5
+		    AND (expires_at IS NULL OR expires_at > NOW())`,
+		tenantID, channel, string(scope), scopeID, held).Scan(&stillHeld); err != nil {
+		return nil, 0, fmt.Errorf("channel release remaining: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, 0, fmt.Errorf("channel release commit: %w", err)
+	}
+	return ids, stillHeld, nil
+}
+
 func (s *Store) ChannelStats(ctx context.Context) ([]store.ChannelStats, error) {
 	rows, err := s.pool.Query(ctx, `
 		SELECT tenant_id, channel, COUNT(*), MIN(visible_at), MAX(visible_at)

--- a/internal/store/sqlite/channels.go
+++ b/internal/store/sqlite/channels.go
@@ -20,7 +20,7 @@ import (
 func (s *Store) ChannelsList(ctx context.Context) ([]store.ChannelRow, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT name, tenant_id, description, scope, semantic,
-		       default_ttl, max_messages, publisher, period, created_at
+		       default_ttl, max_messages, publisher, period, hold, created_at
 		FROM channels
 		ORDER BY tenant_id, name
 	`)
@@ -35,7 +35,7 @@ func (s *Store) ChannelsList(ctx context.Context) ([]store.ChannelRow, error) {
 		if err := rows.Scan(
 			&r.Name, &r.TenantID, &r.Description, &r.Scope, &r.Semantic,
 			&r.DefaultTTL, &r.MaxMessages, &r.Publisher, &r.Period,
-			&createdNano,
+			&r.Hold, &createdNano,
 		); err != nil {
 			return nil, fmt.Errorf("channels list scan: %w", err)
 		}
@@ -55,13 +55,13 @@ func (s *Store) ChannelGet(ctx context.Context, tenantID, name string) (store.Ch
 	var createdNano int64
 	err := s.db.QueryRowContext(ctx, `
 		SELECT name, tenant_id, description, scope, semantic,
-		       default_ttl, max_messages, publisher, period, created_at
+		       default_ttl, max_messages, publisher, period, hold, created_at
 		FROM channels
 		WHERE tenant_id = ? AND name = ?
 	`, tenantID, name).Scan(
 		&r.Name, &r.TenantID, &r.Description, &r.Scope, &r.Semantic,
 		&r.DefaultTTL, &r.MaxMessages, &r.Publisher, &r.Period,
-		&createdNano,
+		&r.Hold, &createdNano,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return store.ChannelRow{}, &store.ErrNotFound{Kind: "channel", ID: name}
@@ -84,12 +84,12 @@ func (s *Store) ChannelsCreate(ctx context.Context, row store.ChannelRow) error 
 	_, err := s.db.ExecContext(ctx, `
 		INSERT INTO channels (
 			name, description, scope, semantic,
-			default_ttl, max_messages, publisher, period, created_at, tenant_id
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			default_ttl, max_messages, publisher, period, hold, created_at, tenant_id
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		row.Name, row.Description, row.Scope, row.Semantic,
 		row.DefaultTTL, row.MaxMessages, row.Publisher, row.Period,
-		row.CreatedAt.UnixNano(), row.TenantID,
+		row.Hold, row.CreatedAt.UnixNano(), row.TenantID,
 	)
 	if err != nil {
 		// modernc.org/sqlite surfaces UNIQUE-constraint failures
@@ -128,6 +128,10 @@ func (s *Store) ChannelsUpdate(ctx context.Context, tenantID, name string, patch
 	if patch.Semantic != nil {
 		sets = append(sets, "semantic = ?")
 		args = append(args, *patch.Semantic)
+	}
+	if patch.Hold != nil {
+		sets = append(sets, "hold = ?")
+		args = append(args, *patch.Hold)
 	}
 	if len(sets) == 0 {
 		// Nothing to update — verify existence and return.

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -393,6 +393,7 @@ func (s *Store) migrate(ctx context.Context) error {
 			max_messages INTEGER NOT NULL DEFAULT 0,
 			publisher    TEXT    NOT NULL DEFAULT '',
 			period       TEXT    NOT NULL DEFAULT '',
+			hold         INTEGER NOT NULL DEFAULT 0,
 			created_at   INTEGER NOT NULL,
 			tenant_id    TEXT    NOT NULL DEFAULT '',
 			PRIMARY KEY (tenant_id, name)
@@ -1060,6 +1061,10 @@ func (s *Store) migrate(ctx context.Context) error {
 		`ALTER TABLE channel_messages ADD COLUMN tenant_id TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE channel_cursors ADD COLUMN tenant_id TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE channels ADD COLUMN tenant_id TEXT NOT NULL DEFAULT ''`,
+		// RFC CY: a held channel stores without delivering until a
+		// release. Mirrors postgres migration 0075. Idempotent ALTER for
+		// existing DBs; the CREATE TABLE above already declares it.
+		`ALTER TABLE channels ADD COLUMN hold INTEGER NOT NULL DEFAULT 0`,
 		// v0.9.x content_sha256 — see internal/store/postgres/migrations/
 		// 0018_agent_defs_content_sha256.up.sql for the rationale. NULL
 		// until the boot-time backfill walks pre-migration rows.
@@ -5499,6 +5504,92 @@ func (s *Store) ChannelSubscribe(ctx context.Context, tenantID, channel string, 
 func (s *Store) ChannelPeek(ctx context.Context, tenantID, channel string, scope store.MemoryScope, scopeID, fromCursor string, limit int) ([]store.ChannelMessage, error) {
 	msgs, _, err := s.channelRead(ctx, tenantID, channel, scope, scopeID, fromCursor, limit)
 	return msgs, err
+}
+
+// ChannelRelease makes the `count` oldest held messages deliverable now.
+//
+// BEGIN IMMEDIATE, not a deferred transaction: this reads the held set and
+// then writes it, and a deferred txn takes the write lock only at the UPDATE
+// — two concurrent releases would both read the same ids and the second's
+// upgrade could fail busy. Same pattern, and the same reason, as
+// MemoryIncrement.
+//
+// The UPDATE re-states the held predicate so a row another releaser already
+// took can never be released twice, whatever the isolation level does.
+func (s *Store) ChannelRelease(ctx context.Context, tenantID, channel string, scope store.MemoryScope, scopeID string, count int) ([]string, int, error) {
+	tenantID = store.ChannelScopeTenant(tenantID, scope) // global => "" (cross-tenant keyspace)
+	if count <= 0 {
+		count = 1
+	}
+	now := time.Now()
+	nowNs := now.UnixNano()
+	heldNs := store.ChannelHeldVisibleAt().UnixNano()
+
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer conn.Close()
+
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return nil, 0, fmt.Errorf("channel release begin: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.Background(), "ROLLBACK")
+		}
+	}()
+
+	rows, err := conn.QueryContext(ctx,
+		`SELECT id FROM channel_messages
+		  WHERE tenant_id = ? AND channel = ? AND scope = ? AND scope_id = ?
+		    AND visible_at = ?
+		    AND (expires_at IS NULL OR expires_at > ?)
+		  ORDER BY id ASC
+		  LIMIT ?`,
+		tenantID, channel, string(scope), scopeID, heldNs, nowNs, count)
+	if err != nil {
+		return nil, 0, fmt.Errorf("channel release select: %w", err)
+	}
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return nil, 0, err
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return nil, 0, err
+	}
+	rows.Close()
+
+	for _, id := range ids {
+		if _, err := conn.ExecContext(ctx,
+			`UPDATE channel_messages SET visible_at = ? WHERE id = ? AND visible_at = ?`,
+			nowNs, id, heldNs); err != nil {
+			return nil, 0, fmt.Errorf("channel release update: %w", err)
+		}
+	}
+
+	var stillHeld int
+	if err := conn.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM channel_messages
+		  WHERE tenant_id = ? AND channel = ? AND scope = ? AND scope_id = ?
+		    AND visible_at = ?
+		    AND (expires_at IS NULL OR expires_at > ?)`,
+		tenantID, channel, string(scope), scopeID, heldNs, nowNs).Scan(&stillHeld); err != nil {
+		return nil, 0, fmt.Errorf("channel release remaining: %w", err)
+	}
+
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return nil, 0, fmt.Errorf("channel release commit: %w", err)
+	}
+	committed = true
+	return ids, stillHeld, nil
 }
 
 func (s *Store) ChannelStats(ctx context.Context) ([]store.ChannelStats, error) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -52,6 +52,35 @@ func MintChannelMessageID(t time.Time) string {
 	return fmt.Sprintf("msg_%016x%s", uint64(t.UnixNano()), hex.EncodeToString(buf[:]))
 }
 
+// ChannelHeldVisibleAt is the reserved `visible_at` instant a message on a
+// HELD channel carries — the storage marker for "stored, but not deliverable
+// until someone releases it".
+//
+// WHY A RESERVED INSTANT RATHER THAN A `held` COLUMN. Every channel read
+// already filters `visible_at <= now`, so a held row is withheld by machinery
+// that exists — subscribe, peek, await and any read path added later, without
+// each one having to remember. A boolean column would need its own predicate
+// on every one of those queries, and a query that FORGETS it delivers a
+// message that was supposed to be stopped. The two designs fail in opposite
+// directions and only one of them is safe: a missed sentinel keeps a message
+// hidden, a missed column releases it.
+//
+// The instant is far enough out that no real deferred publish reaches it, and
+// short of 2262 so UnixNano does not overflow int64 (the same bound
+// MintChannelMessageID's lex-order invariant depends on). It is RESERVED: a
+// caller that names this exact instant as a deliver_at gets hold semantics,
+// which is the documented behaviour, not an accident.
+func ChannelHeldVisibleAt() time.Time {
+	return time.Date(2200, 1, 1, 0, 0, 0, 0, time.UTC)
+}
+
+// IsChannelHeld reports whether a visible_at marks a held message. Exact
+// equality on the reserved instant — a deferred publish one nanosecond off is
+// an ordinary deferred publish and delivers on its own.
+func IsChannelHeld(visibleAt time.Time) bool {
+	return visibleAt.Equal(ChannelHeldVisibleAt())
+}
+
 // EncodeChannelCursor renders a (visible_at, msg_id) tuple as the
 // opaque cursor token agents receive. Format:
 //
@@ -2236,6 +2265,22 @@ type Store interface {
 	// from cur_0 without disturbing the consumer's position.
 	ChannelPeek(ctx context.Context, tenantID, channel string, scope MemoryScope, scopeID, fromCursor string, limit int) ([]ChannelMessage, error)
 
+	// ChannelRelease makes the `count` oldest HELD messages on one
+	// (channel, scope, scope_id) deliverable now — the read half of the
+	// hold breakpoint (see ChannelHeldVisibleAt). Released messages take a
+	// visible_at of the release instant, so they sort AFTER everything
+	// already delivered and a subscriber's cursor never has to rewind.
+	//
+	// Returns the released ids in delivery order plus how many stay held.
+	// Releasing more than are held releases what there is; releasing on a
+	// channel with nothing held is a no-op, not an error — a release is a
+	// request to advance, and "nothing to advance" is an answer.
+	//
+	// Expired rows are skipped: a held message still honours its TTL, so a
+	// hold is not a way to keep a message past the retention its publisher
+	// declared.
+	ChannelRelease(ctx context.Context, tenantID, channel string, scope MemoryScope, scopeID string, count int) (released []string, stillHeld int, err error)
+
 	// ChannelStats returns one row per channel that has at least one
 	// non-expired message, with the aggregate count + oldest/newest
 	// visible_at timestamps. Channels declared in operator yaml but
@@ -3040,7 +3085,10 @@ type ChannelRow struct {
 	MaxMessages int
 	Publisher   string
 	Period      string
-	CreatedAt   time.Time
+	// Hold makes the channel a breakpoint: a publish is stored but never
+	// delivered or notified until a release. See ChannelHeldVisibleAt.
+	Hold      bool
+	CreatedAt time.Time
 }
 
 // ChannelPatch carries the subset of fields ChannelsUpdate can
@@ -3052,6 +3100,7 @@ type ChannelPatch struct {
 	DefaultTTL  *int
 	MaxMessages *int
 	Semantic    *string
+	Hold        *bool
 }
 
 // MemoryScope is the addressing axis for a Memory or Channel row.

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -229,6 +229,10 @@ func Run(t *testing.T, factory Factory) {
 		{"ChannelStatsAggregatesNonExpired", testChannelStatsAggregatesNonExpired},
 		{"ChannelStatsEmptyOnNoMessages", testChannelStatsEmptyOnNoMessages},
 		{"ChannelGetPointLookup", testChannelGetPointLookup},
+		// RFC CY hold breakpoint
+		{"ChannelHoldRoundTripsOnTheDefinition", testChannelHoldRoundTripsOnTheDefinition},
+		{"ChannelReleaseHandsOverOldestFirst", testChannelReleaseHandsOverOldestFirst},
+		{"ChannelReleaseSkipsExpiredHeld", testChannelReleaseSkipsExpiredHeld},
 		// v0.8.6 deferred publish (PR 1)
 		{"ChannelDeferredHiddenUntilVisible", testChannelDeferredHiddenUntilVisible},
 		{"ChannelDeferredDeliversAfterProgressedCursor", testChannelDeferredDeliversAfterProgressedCursor},
@@ -5882,6 +5886,156 @@ func testChannelGetPointLookup(t *testing.T, s store.Store) {
 	var nf *store.ErrNotFound
 	if !errors.As(err, &nf) {
 		t.Errorf("ChannelGet(missing): got %v (%T), want *store.ErrNotFound", err, err)
+	}
+}
+
+// testChannelHoldRoundTripsOnTheDefinition pins hold as a persisted channel
+// attribute: settable at create, readable back, and patchable both ways. A
+// definition field that does not survive the round-trip is a setting the
+// operator believes they made.
+func testChannelHoldRoundTripsOnTheDefinition(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	if err := s.ChannelsCreate(ctx, store.ChannelRow{
+		Name: "ch-hold", Scope: "global", Semantic: "queue", Hold: true,
+	}); err != nil {
+		t.Fatalf("ChannelsCreate: %v", err)
+	}
+	got, err := s.ChannelGet(ctx, "", "ch-hold")
+	if err != nil {
+		t.Fatalf("ChannelGet: %v", err)
+	}
+	if !got.Hold {
+		t.Errorf("hold did not survive create: %+v", got)
+	}
+	rows, err := s.ChannelsList(ctx)
+	if err != nil {
+		t.Fatalf("ChannelsList: %v", err)
+	}
+	var listed bool
+	for _, r := range rows {
+		if r.Name == "ch-hold" {
+			listed = r.Hold
+		}
+	}
+	if !listed {
+		t.Errorf("hold missing from the listing")
+	}
+
+	off := false
+	if err := s.ChannelsUpdate(ctx, "", "ch-hold", store.ChannelPatch{Hold: &off}); err != nil {
+		t.Fatalf("ChannelsUpdate(hold=false): %v", err)
+	}
+	got, err = s.ChannelGet(ctx, "", "ch-hold")
+	if err != nil {
+		t.Fatalf("ChannelGet after patch: %v", err)
+	}
+	if got.Hold {
+		t.Errorf("patch did not clear hold: %+v", got)
+	}
+	// A patch that does not mention hold must leave it alone (the nil-means-
+	// unchanged contract every other field on ChannelPatch keeps).
+	on := true
+	if err := s.ChannelsUpdate(ctx, "", "ch-hold", store.ChannelPatch{Hold: &on}); err != nil {
+		t.Fatalf("ChannelsUpdate(hold=true): %v", err)
+	}
+	desc := "unrelated"
+	if err := s.ChannelsUpdate(ctx, "", "ch-hold", store.ChannelPatch{Description: &desc}); err != nil {
+		t.Fatalf("ChannelsUpdate(description): %v", err)
+	}
+	got, _ = s.ChannelGet(ctx, "", "ch-hold")
+	if !got.Hold {
+		t.Errorf("an unrelated patch cleared hold: %+v", got)
+	}
+}
+
+// testChannelReleaseHandsOverOldestFirst pins the release contract: a message
+// stored at the reserved held instant is invisible to a read, becomes visible
+// in publish order as it is released, and the report says how many are left.
+func testChannelReleaseHandsOverOldestFirst(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	for _, body := range []string{`"A"`, `"B"`, `"C"`} {
+		if _, _, err := s.ChannelPublish(ctx, store.ChannelMessage{
+			Channel: "ch-rel", Scope: store.MemoryScopeAgent, ScopeID: "x",
+			Payload:   json.RawMessage(body),
+			VisibleAt: store.ChannelHeldVisibleAt(),
+		}, 0); err != nil {
+			t.Fatalf("publish held: %v", err)
+		}
+		time.Sleep(time.Millisecond)
+	}
+	msgs, _, err := s.ChannelSubscribe(ctx, "", "ch-rel", store.MemoryScopeAgent, "x", "", 10)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Fatalf("held messages delivered: got %d, want 0", len(msgs))
+	}
+
+	released, stillHeld, err := s.ChannelRelease(ctx, "", "ch-rel", store.MemoryScopeAgent, "x", 2)
+	if err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	if len(released) != 2 {
+		t.Fatalf("released %d, want 2", len(released))
+	}
+	if stillHeld != 1 {
+		t.Errorf("still held = %d, want 1", stillHeld)
+	}
+	msgs, _, err = s.ChannelSubscribe(ctx, "", "ch-rel", store.MemoryScopeAgent, "x", "", 10)
+	if err != nil {
+		t.Fatalf("subscribe after release: %v", err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("after releasing 2, delivered %d", len(msgs))
+	}
+	if string(msgs[0].Payload) != `"A"` || string(msgs[1].Payload) != `"B"` {
+		t.Errorf("released out of publish order: %s, %s", msgs[0].Payload, msgs[1].Payload)
+	}
+
+	// Releasing more than remain releases what there is.
+	released, stillHeld, err = s.ChannelRelease(ctx, "", "ch-rel", store.MemoryScopeAgent, "x", 10)
+	if err != nil {
+		t.Fatalf("release rest: %v", err)
+	}
+	if len(released) != 1 || stillHeld != 0 {
+		t.Errorf("drain released %d leaving %d, want 1 leaving 0", len(released), stillHeld)
+	}
+	// And a release with nothing held is a no-op, not an error.
+	released, stillHeld, err = s.ChannelRelease(ctx, "", "ch-rel", store.MemoryScopeAgent, "x", 1)
+	if err != nil {
+		t.Fatalf("release on drained queue: %v", err)
+	}
+	if len(released) != 0 || stillHeld != 0 {
+		t.Errorf("release on a drained queue reported %d/%d, want 0/0", len(released), stillHeld)
+	}
+}
+
+// testChannelReleaseSkipsExpiredHeld pins the TTL floor: a held message that
+// outlived its TTL is never released and never counted as held, so a hold is
+// not a way to keep a message past the retention its publisher declared.
+func testChannelReleaseSkipsExpiredHeld(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	if _, _, err := s.ChannelPublish(ctx, store.ChannelMessage{
+		Channel: "ch-rel-exp", Scope: store.MemoryScopeAgent, ScopeID: "x",
+		Payload:   json.RawMessage(`"gone"`),
+		VisibleAt: store.ChannelHeldVisibleAt(),
+		ExpiresAt: time.Now().Add(-time.Minute),
+	}, 0); err != nil {
+		t.Fatalf("publish expired-held: %v", err)
+	}
+	released, stillHeld, err := s.ChannelRelease(ctx, "", "ch-rel-exp", store.MemoryScopeAgent, "x", 10)
+	if err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	if len(released) != 0 || stillHeld != 0 {
+		t.Errorf("expired held message released/counted: %d/%d, want 0/0", len(released), stillHeld)
+	}
+	msgs, _, err := s.ChannelSubscribe(ctx, "", "ch-rel-exp", store.MemoryScopeAgent, "x", "", 10)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Errorf("expired held message delivered: %d", len(msgs))
 	}
 }
 

--- a/internal/tools/builtin/channel.go
+++ b/internal/tools/builtin/channel.go
@@ -451,6 +451,11 @@ func (c *Channel) storeAndNotify(ctx context.Context, channel string, def tools.
 // was there to prevent, and the bound keeps one call's transaction small.
 const maxReleaseCount = 1000
 
+// MaxReleaseCountForDrift exports the cap for the wire-surface drift test in
+// internal/api/http — the two caps are one rule, and a test is the only thing
+// that keeps them one.
+const MaxReleaseCountForDrift = maxReleaseCount
+
 // execRelease hands the oldest `count` HELD messages on a channel to its
 // subscribers (RFC CY). Default 1: a release is a single step unless the
 // caller says otherwise.

--- a/internal/tools/builtin/channel.go
+++ b/internal/tools/builtin/channel.go
@@ -25,6 +25,7 @@ import (
 //	subscribe      — drain up to N new messages; auto-commits the previous batch's cursor
 //	ack            — explicitly commit a cursor (crash-safety: commit BEFORE next read)
 //	peek           — non-consuming read; never advances cursor
+//	release        — hand the oldest N HELD messages to subscribers (hold: channels)
 //	list_channels  — informational; reports the agent's publish/subscribe allowlists
 //
 // scope_id is RESOLVED SERVER-SIDE based on the agent's run context
@@ -99,19 +100,21 @@ func (c *Channel) shouldWarnTruncation(channel string) bool {
 
 const channelDescription = `Persistent inter-agent message bus. ` +
 	`Publish JSON payloads to a named channel; subscribe to drain new messages with cursor-based at-least-once delivery. ` +
-	`Operations: publish, subscribe, ack, peek, list_channels, await, broadcast. ` +
+	`Operations: publish, subscribe, ack, peek, release, list_channels, await, broadcast. ` +
 	`Channel ACLs are operator-configured; the tool refuses ops on channels not in this agent's publish/subscribe allowlists. ` +
 	`Scope (agent / user / global) is set by the operator per channel; cursor isolation matches that scope. ` +
 	`await is a fan-in barrier across MULTIPLE channels (wait for any / all / at_least N messages, or a timeout) — the complement to ` +
 	`Agent.parallel_spawn (which joins sub-agents); use await to join independent producers (scheduler / webhook / separately-spawned agents). ` +
 	`await is non-committing (detection only) — it never advances cursors, so subscribe/ack exactly what you process. ` +
 	`broadcast is the symmetric fan-OUT: publish one payload to MULTIPLE channels in a single call (e.g. ping N workers to start). ` +
-	`Both await and broadcast cap at 32 channels and refuse the whole op if any channel fails its ACL (no partial broadcast).`
+	`Both await and broadcast cap at 32 channels and refuse the whole op if any channel fails its ACL (no partial broadcast). ` +
+	`A channel the operator declared hold: stores publishes without delivering them; release hands over the oldest count (default 1) ` +
+	`so a workflow wired through that channel can be single-stepped. release needs the PUBLISH allowlist — it completes a publish.`
 
 const channelInputSchema = `{
   "type": "object",
   "properties": {
-    "op":           {"type": "string", "enum": ["publish","subscribe","ack","peek","list_channels","await","broadcast"], "description": "Which operation to perform."},
+    "op":           {"type": "string", "enum": ["publish","subscribe","ack","peek","release","list_channels","await","broadcast"], "description": "Which operation to perform."},
     "channel":      {"type": "string", "description": "The channel name (required for publish/subscribe/ack/peek)."},
     "channels":     {"type": "array", "items": {"type": "string"}, "description": "await + broadcast (max 32 channels). await resolves each under the SUBSCRIBE allowlist (fan-in); broadcast under the PUBLISH allowlist (fan-out)."},
     "mode":         {"type": "string", "enum": ["any","all","at_least"], "description": "Await only: any = ≥1 channel has a message; all = every channel has ≥1; at_least = total messages across channels ≥ n. Default any."},
@@ -122,7 +125,8 @@ const channelInputSchema = `{
     "from_cursor":  {"type": "string", "description": "Subscribe/peek only: read starting after this cursor. Absent = since last ack. \"cur_0\" = replay from oldest."},
     "max_messages": {"type": "integer", "description": "Subscribe/peek only: max messages to return (default 10, cap 100)."},
     "wait_ms":      {"type": "integer", "description": "Subscribe only: long-poll budget in ms. 0 = return immediately. Capped by operator config."},
-    "cursor":       {"type": "string", "description": "Ack only: the cursor to commit (must be >= currently committed)."}
+    "cursor":       {"type": "string", "description": "Ack only: the cursor to commit (must be >= currently committed)."},
+    "count":        {"type": "integer", "description": "Release only: how many held messages to hand over, oldest first. Default 1."}
   },
   "required": ["op"],
   "additionalProperties": false
@@ -141,6 +145,7 @@ type channelInput struct {
 	MaxMessages int             `json:"max_messages,omitempty"`
 	WaitMS      int             `json:"wait_ms,omitempty"`
 	Cursor      string          `json:"cursor,omitempty"`
+	Count       int             `json:"count,omitempty"` // release: how many held messages to hand over
 }
 
 // Name implements tools.Tool.
@@ -178,6 +183,8 @@ func (c *Channel) Execute(ctx context.Context, raw json.RawMessage) (tools.Resul
 		return c.execAck(ctx, policy, in)
 	case "peek":
 		return c.execPeek(ctx, policy, in)
+	case "release":
+		return c.execRelease(ctx, policy, in)
 	case "list_channels":
 		return c.execListChannels(policy)
 	case "await":
@@ -187,7 +194,7 @@ func (c *Channel) Execute(ctx context.Context, raw json.RawMessage) (tools.Resul
 	case "":
 		return errResult("missing required field: op"), nil
 	default:
-		return errResult(fmt.Sprintf("unknown op %q (must be one of: publish, subscribe, ack, peek, list_channels, await, broadcast)", in.Op)), nil
+		return errResult(fmt.Sprintf("unknown op %q (must be one of: publish, subscribe, ack, peek, release, list_channels, await, broadcast)", in.Op)), nil
 	}
 }
 
@@ -360,7 +367,7 @@ func parsePublishDeliverAt(deliverAt string, now time.Time) (visibleAt time.Time
 // subscribers (or arms the deferred-visibility timer), and emits the typed
 // audit event — the side-effecting half of a publish, shared by publish +
 // broadcast. Returns the per-channel result map (message_id / channel /
-// dropped_oldest, + visible_at when deferred).
+// dropped_oldest, + visible_at when deferred, + held when the channel holds).
 func (c *Channel) storeAndNotify(ctx context.Context, channel string, def tools.ChannelDef, scope store.MemoryScope, scopeID string, value json.RawMessage, ttl int64, visibleAt time.Time, deferred bool, now time.Time) (map[string]any, error) {
 	// TTL precedence: per-message > channel default > none. TTL counts
 	// from publish time, not deliver_at — a deferred message never
@@ -372,6 +379,16 @@ func (c *Channel) storeAndNotify(ctx context.Context, channel string, def tools.
 	var expiresAt time.Time
 	if ttlSecs > 0 {
 		expiresAt = now.Add(time.Duration(ttlSecs) * time.Second)
+	}
+
+	// A held channel stores the message at the reserved visible_at and wakes
+	// nobody — it waits for a release, not for a clock, so an operator-set
+	// hold overrides a caller's deliver_at rather than racing it. The TTL
+	// still counts from publish time: holding is not a way to outlive the
+	// retention the publisher declared.
+	if def.Hold {
+		visibleAt = store.ChannelHeldVisibleAt()
+		deferred = false
 	}
 
 	id, dropped, err := c.Store.ChannelPublish(ctx, store.ChannelMessage{
@@ -388,10 +405,14 @@ func (c *Channel) storeAndNotify(ctx context.Context, channel string, def tools.
 		return nil, err
 	}
 	// Deferred publishes go via the scheduler so long-poll subscribers
-	// wake at visible_at. Immediate publishes notify the bus directly.
-	if deferred && c.Scheduler != nil {
+	// wake at visible_at. Immediate publishes notify the bus directly. A
+	// held publish notifies nobody — that is what holding means.
+	switch {
+	case def.Hold:
+		// no notification, no timer
+	case deferred && c.Scheduler != nil:
 		c.Scheduler.Schedule(channel, id, visibleAt)
-	} else if c.Bus != nil {
+	case c.Bus != nil:
 		c.Bus.Notify(channel)
 	}
 	// Typed audit event (v0.8.4 polish): a separate event type so SSE
@@ -417,7 +438,69 @@ func (c *Channel) storeAndNotify(ctx context.Context, channel string, def tools.
 	if deferred {
 		result["visible_at"] = visibleAt.UTC().Format(time.RFC3339Nano)
 	}
+	if def.Hold {
+		// Say so in the result: a publisher that gets back a message_id and
+		// no further word would reasonably assume the message was delivered.
+		result["held"] = true
+	}
 	return result, nil
+}
+
+// maxReleaseCount bounds one release. A release is a breakpoint step, not a
+// drain — an operator asking for a million is asking for something the hold
+// was there to prevent, and the bound keeps one call's transaction small.
+const maxReleaseCount = 1000
+
+// execRelease hands the oldest `count` HELD messages on a channel to its
+// subscribers (RFC CY). Default 1: a release is a single step unless the
+// caller says otherwise.
+//
+// Gated by the PUBLISH allowlist, not subscribe: releasing is the act of
+// making a message deliverable — the second half of a publish that the hold
+// deferred — so the right question is "may this agent put messages on this
+// channel", not "may it read them". The system-channel refusals apply for the
+// same reason (a held _system channel is released through the admin endpoint,
+// as with every other write to one).
+//
+// Releasing on a channel with nothing held is a no-op reporting zero, not an
+// error: "advance the queue" is a reasonable request even when the queue is
+// empty, and a workflow driver should not have to poll before stepping.
+func (c *Channel) execRelease(ctx context.Context, policy tools.ChannelPolicyValue, in channelInput) (tools.Result, error) {
+	def, scope, scopeID, refusal := c.checkPublishACL(ctx, policy, in.Channel)
+	if refusal != "" {
+		return errResult(refusal), nil
+	}
+	count := in.Count
+	if count <= 0 {
+		count = 1
+	}
+	if count > maxReleaseCount {
+		return errResult(fmt.Sprintf("release: count %d exceeds max %d", count, maxReleaseCount)), nil
+	}
+	released, stillHeld, err := c.Store.ChannelRelease(ctx, tools.RunIdentity(ctx).TenantID, in.Channel, scope, scopeID, count)
+	if err != nil {
+		return errResult(fmt.Sprintf("release: %s", err)), nil
+	}
+	// Wake long-poll subscribers exactly as a publish would — from their side
+	// a release IS the publish arriving.
+	if len(released) > 0 && c.Bus != nil {
+		c.Bus.Notify(in.Channel)
+	}
+	if released == nil {
+		released = []string{} // JSON [] not null — a consumer indexes this
+	}
+	out := map[string]any{
+		"channel":        in.Channel,
+		"released":       released,
+		"released_count": len(released),
+		"still_held":     stillHeld,
+	}
+	if !def.Hold {
+		// The channel is not declared hold:, so nothing new will be held.
+		// Say it rather than let a zero look like a timing problem.
+		out["note"] = "channel is not declared hold: — nothing new is held on it"
+	}
+	return okJSON(out)
 }
 
 // execBroadcast is the symmetric fan-OUT to await's fan-in (RFC S shape):

--- a/internal/tools/builtin/channel_hold_test.go
+++ b/internal/tools/builtin/channel_hold_test.go
@@ -1,0 +1,216 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/channels"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// holdFixture is channelFixture's twin with ONE difference that is the whole
+// point: `gate` is declared hold. `open` is the control — same shape, no hold —
+// so every assertion below can be read as "held, unlike this".
+func holdFixture(t *testing.T) (*Channel, context.Context, func()) {
+	t.Helper()
+	s, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	tool := &Channel{
+		Store:         s,
+		Bus:           channels.NewBus(),
+		MaxValueBytes: 65536,
+		LongPollCapMS: 30000,
+	}
+	ctx := tools.WithAgentName(context.Background(), "researcher")
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{UserID: "alice", AgentID: "a_test"})
+	ctx = tools.WithChannelPolicy(ctx, tools.ChannelPolicyValue{
+		Publish:   []string{"gate", "open"},
+		Subscribe: []string{"gate", "open"},
+		Channels: map[string]tools.ChannelDef{
+			"gate": {Name: "gate", Scope: "agent", Semantic: "queue", Hold: true},
+			"open": {Name: "open", Scope: "agent", Semantic: "queue"},
+		},
+	})
+	return tool, ctx, func() { _ = s.Close() }
+}
+
+func publishTo(t *testing.T, tool *Channel, ctx context.Context, channel string, i int) map[string]any {
+	t.Helper()
+	res, _ := tool.Execute(ctx, json.RawMessage(
+		`{"op":"publish","channel":"`+channel+`","value":{"i":`+intToStr(i)+`}}`))
+	if res.IsError {
+		t.Fatalf("publish to %s: %s", channel, res.Text)
+	}
+	// Distinct message ids are minted from the clock; keep them ordered.
+	time.Sleep(time.Microsecond)
+	return decodeResult(t, res.Text)
+}
+
+func subscribeCount(t *testing.T, tool *Channel, ctx context.Context, channel string) int {
+	t.Helper()
+	res, _ := tool.Execute(ctx, json.RawMessage(
+		`{"op":"subscribe","channel":"`+channel+`","max_messages":50}`))
+	if res.IsError {
+		t.Fatalf("subscribe %s: %s", channel, res.Text)
+	}
+	got := decodeResult(t, res.Text)
+	msgs, _ := got["messages"].([]any)
+	return len(msgs)
+}
+
+// A publish to a held channel is STORED and REPORTED, but not delivered — the
+// whole contract in one test. The control channel proves the fixture would
+// otherwise deliver.
+func TestChannelHold_PublishStoresButDoesNotDeliver(t *testing.T) {
+	tool, ctx, cleanup := holdFixture(t)
+	defer cleanup()
+
+	got := publishTo(t, tool, ctx, "gate", 1)
+	if got["message_id"] == "" {
+		t.Errorf("held publish should still report a message_id: %v", got)
+	}
+	if held, _ := got["held"].(bool); !held {
+		t.Errorf("held publish must report held:true, got %v", got)
+	}
+	if _, ok := got["visible_at"]; ok {
+		t.Errorf("a held publish must not promise a visible_at: %v", got)
+	}
+	if n := subscribeCount(t, tool, ctx, "gate"); n != 0 {
+		t.Errorf("held channel delivered %d messages, want 0", n)
+	}
+
+	// Control: the identical publish on a channel with no hold arrives.
+	publishTo(t, tool, ctx, "open", 1)
+	if n := subscribeCount(t, tool, ctx, "open"); n != 1 {
+		t.Errorf("control channel delivered %d messages, want 1", n)
+	}
+}
+
+// Release hands over the OLDEST first, one at a time by default, and reports
+// what is left — the single-step property the hold exists for.
+func TestChannelHold_ReleaseHandsOverOldestFirst(t *testing.T) {
+	tool, ctx, cleanup := holdFixture(t)
+	defer cleanup()
+
+	for i := 0; i < 3; i++ {
+		publishTo(t, tool, ctx, "gate", i)
+	}
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"release","channel":"gate"}`))
+	if res.IsError {
+		t.Fatalf("release: %s", res.Text)
+	}
+	got := decodeResult(t, res.Text)
+	if n, _ := got["released_count"].(float64); n != 1 {
+		t.Errorf("default release count = %v, want 1", got["released_count"])
+	}
+	if n, _ := got["still_held"].(float64); n != 2 {
+		t.Errorf("still_held = %v, want 2", got["still_held"])
+	}
+
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"subscribe","channel":"gate","max_messages":50}`))
+	if res.IsError {
+		t.Fatalf("subscribe: %s", res.Text)
+	}
+	sub := decodeResult(t, res.Text)
+	msgs, _ := sub["messages"].([]any)
+	if len(msgs) != 1 {
+		t.Fatalf("after one release, delivered %d messages, want 1", len(msgs))
+	}
+	first, _ := msgs[0].(map[string]any)
+	val, _ := first["value"].(map[string]any)
+	if i, _ := val["i"].(float64); i != 0 {
+		t.Errorf("released message carries i=%v, want the OLDEST (0)", val["i"])
+	}
+
+	// Releasing the rest drains the queue.
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"release","channel":"gate","count":5}`))
+	if res.IsError {
+		t.Fatalf("release rest: %s", res.Text)
+	}
+	got = decodeResult(t, res.Text)
+	if n, _ := got["released_count"].(float64); n != 2 {
+		t.Errorf("released %v, want the 2 remaining", got["released_count"])
+	}
+	if n, _ := got["still_held"].(float64); n != 0 {
+		t.Errorf("still_held = %v, want 0", got["still_held"])
+	}
+	if n := subscribeCount(t, tool, ctx, "gate"); n != 2 {
+		t.Errorf("delivered %d messages after draining, want the 2 released", n)
+	}
+}
+
+// Release is gated by the PUBLISH allowlist: it completes a publish, so a
+// subscribe-only agent may not make a held message arrive.
+func TestChannelHold_ReleaseNeedsPublishNotSubscribe(t *testing.T) {
+	tool, ctx, cleanup := holdFixture(t)
+	defer cleanup()
+	publishTo(t, tool, ctx, "gate", 1)
+
+	readOnly := tools.WithChannelPolicy(ctx, tools.ChannelPolicyValue{
+		Publish:   []string{"open"},
+		Subscribe: []string{"gate"},
+		Channels: map[string]tools.ChannelDef{
+			"gate": {Name: "gate", Scope: "agent", Hold: true},
+			"open": {Name: "open", Scope: "agent"},
+		},
+	})
+	res, _ := tool.Execute(readOnly, json.RawMessage(`{"op":"release","channel":"gate"}`))
+	if !res.IsError {
+		t.Fatalf("release with subscribe-only ACL should be refused; got %s", res.Text)
+	}
+	if n := subscribeCount(t, tool, ctx, "gate"); n != 0 {
+		t.Errorf("refused release still delivered %d messages", n)
+	}
+}
+
+// Releasing a channel with nothing held is an answer, not an error.
+func TestChannelHold_ReleaseOnEmptyQueueReportsZero(t *testing.T) {
+	tool, ctx, cleanup := holdFixture(t)
+	defer cleanup()
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"release","channel":"gate","count":3}`))
+	if res.IsError {
+		t.Fatalf("release on an empty hold queue should not error: %s", res.Text)
+	}
+	got := decodeResult(t, res.Text)
+	if n, _ := got["released_count"].(float64); n != 0 {
+		t.Errorf("released_count = %v, want 0", got["released_count"])
+	}
+	if _, ok := got["released"].([]any); !ok {
+		t.Errorf("released must be [] not null: %s", res.Text)
+	}
+}
+
+// A held message still honours its TTL: holding is not a way to outlive the
+// retention the publisher declared. The one test here that sleeps — the TTL
+// floor is one second, and faking it would fake the very filter under test.
+func TestChannelHold_ExpiredHeldMessageIsNeverReleased(t *testing.T) {
+	tool, ctx, cleanup := holdFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"publish","channel":"gate","ttl":1,"value":{"i":0}}`))
+	if res.IsError {
+		t.Fatalf("publish: %s", res.Text)
+	}
+	time.Sleep(1100 * time.Millisecond)
+
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"release","channel":"gate","count":10}`))
+	if res.IsError {
+		t.Fatalf("release: %s", res.Text)
+	}
+	got := decodeResult(t, res.Text)
+	if n, _ := got["released_count"].(float64); n != 0 {
+		t.Errorf("released %v expired held message(s), want 0", got["released_count"])
+	}
+	if n, _ := got["still_held"].(float64); n != 0 {
+		t.Errorf("still_held counts an expired message: %v", got["still_held"])
+	}
+	if n := subscribeCount(t, tool, ctx, "gate"); n != 0 {
+		t.Errorf("expired held message was delivered (%d)", n)
+	}
+}

--- a/internal/tools/builtin/context.go
+++ b/internal/tools/builtin/context.go
@@ -835,6 +835,7 @@ func (c *Context) execChannels(ctx context.Context, in contextInput) (tools.Resu
 		DefaultTTL  int    `json:"default_ttl,omitempty"`
 		MaxMessages int    `json:"max_messages,omitempty"`
 		Publisher   string `json:"publisher,omitempty"`
+		Hold        bool   `json:"hold,omitempty"`
 		Publish     bool   `json:"publish"`
 		Subscribe   bool   `json:"subscribe"`
 	}
@@ -867,6 +868,7 @@ func (c *Context) execChannels(ctx context.Context, in contextInput) (tools.Resu
 			DefaultTTL:  def.DefaultTTL,
 			MaxMessages: def.MaxMessages,
 			Publisher:   def.Publisher,
+			Hold:        def.Hold,
 			Publish:     publishSet[name],
 			Subscribe:   subscribeSet[name],
 		})

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -744,6 +744,10 @@ type ChannelDef struct {
 	// internal Go publisher and the admin endpoint may write. Empty =
 	// agents may publish (ACL permitting).
 	Publisher string
+	// Hold makes the channel a breakpoint: a publish is stored but not
+	// delivered or notified until a release. See store.ChannelHeldVisibleAt
+	// for how a held message is marked.
+	Hold bool
 }
 
 // WithChannelPolicy attaches the agent's resolved Channel policy to ctx.

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1427,6 +1427,8 @@ export interface ChannelDescriptor {
   period?: string;
   default_ttl?: number;
   max_messages?: number;
+  // Breakpoint: publishes are stored but never delivered until released.
+  hold?: boolean;
   message_count: number;
   oldest_visible_at?: string;
   newest_visible_at?: string;
@@ -2220,6 +2222,7 @@ export interface ChannelCreateRequest {
   max_messages?: number;
   publisher?: string;
   period?: string;
+  hold?: boolean;
 }
 
 export interface ChannelUpdateRequest {
@@ -2227,6 +2230,30 @@ export interface ChannelUpdateRequest {
   default_ttl?: number;
   max_messages?: number;
   semantic?: string;
+  hold?: boolean;
+}
+
+export interface ChannelReleaseResult {
+  channel: string;
+  released: string[];
+  released_count: number;
+  still_held: number;
+}
+
+// releaseChannel hands the oldest `count` (default 1) messages held on a
+// hold: channel to its subscribers — the operator's breakpoint step.
+export function releaseChannel(
+  name: string,
+  count?: number,
+): Promise<ChannelReleaseResult> {
+  return jsonFetch<ChannelReleaseResult>(
+    `/v1/_channels/${encodeURIComponent(name)}/release`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(count && count > 0 ? { count } : {}),
+    },
+  );
 }
 
 export function createChannel(body: ChannelCreateRequest): Promise<ChannelDescriptor> {

--- a/web/src/components/ChannelEditModal.tsx
+++ b/web/src/components/ChannelEditModal.tsx
@@ -44,6 +44,7 @@ export default function ChannelEditModal({
   const [maxMessages, setMaxMessages] = useState<string>(
     existing?.max_messages !== undefined ? String(existing.max_messages) : "0",
   );
+  const [hold, setHold] = useState<boolean>(existing?.hold ?? false);
   const [submitting, setSubmitting] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
@@ -62,6 +63,7 @@ export default function ChannelEditModal({
           semantic,
           default_ttl: ttl,
           max_messages: max,
+          hold,
         };
         saved = await createChannel(req);
       } else {
@@ -71,6 +73,7 @@ export default function ChannelEditModal({
           default_ttl: ttl,
           max_messages: max,
           semantic,
+          hold,
         };
         saved = await updateChannel(existing.name, patch);
       }
@@ -157,6 +160,21 @@ export default function ChannelEditModal({
               />
             </label>
           </div>
+
+          <label className="library-modal-field">
+            <span>
+              <input
+                type="checkbox"
+                checked={hold}
+                onChange={(e) => setHold(e.target.checked)}
+              />{" "}
+              Hold (breakpoint)
+            </span>
+            <small>
+              Publishes are stored but never delivered until you release
+              them — one at a time from the channel page.
+            </small>
+          </label>
         </div>
 
         {err && <div className="error-banner">{err}</div>}

--- a/web/src/pages/ChannelsView.tsx
+++ b/web/src/pages/ChannelsView.tsx
@@ -10,6 +10,7 @@ import {
   listChannels,
   peekChannel,
   publishChannel,
+  releaseChannel,
 } from "../api";
 import Splitter from "../components/Splitter";
 import ChannelEditModal from "../components/ChannelEditModal";
@@ -355,8 +356,16 @@ function ChannelDetail({ channel }: { channel: ChannelDescriptor }) {
           {channel.max_messages !== undefined && channel.max_messages > 0 && (
             <span>max={channel.max_messages}</span>
           )}
+          {channel.hold && <span className="channel-hold">hold</span>}
         </div>
       </div>
+
+      {channel.hold && (
+        <ReleaseForm
+          channelName={channel.name}
+          onReleased={() => setReloadKey((k) => k + 1)}
+        />
+      )}
 
       <PublishForm
         channelName={channel.name}
@@ -401,6 +410,69 @@ function ChannelDetail({ channel }: { channel: ChannelDescriptor }) {
           </ul>
         )}
       </div>
+    </div>
+  );
+}
+
+// ReleaseForm is the operator's breakpoint step on a hold: channel: hand the
+// oldest N held messages to whatever is subscribed. Rendered only when the
+// channel is declared hold — on any other channel there is nothing to release.
+function ReleaseForm({
+  channelName,
+  onReleased,
+}: {
+  channelName: string;
+  onReleased: () => void;
+}) {
+  const [count, setCount] = useState("1");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [result, setResult] = useState<{ released: number; held: number } | null>(
+    null,
+  );
+
+  const submit = async () => {
+    setErr(null);
+    setResult(null);
+    const n = parseInt(count.trim() || "1", 10);
+    if (!Number.isInteger(n) || n <= 0) {
+      setErr("count must be a positive integer.");
+      return;
+    }
+    setBusy(true);
+    try {
+      const r = await releaseChannel(channelName, n);
+      setResult({ released: r.released_count, held: r.still_held });
+      onReleased();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="channel-detail-section">
+      <h4>Release (held)</h4>
+      <label className="modal-field">
+        <span>count</span>
+        <input
+          type="number"
+          min="1"
+          value={count}
+          onChange={(e) => setCount(e.target.value)}
+        />
+      </label>
+      <button type="button" onClick={submit} disabled={busy}>
+        {busy ? "Releasing…" : "Release"}
+      </button>
+      {err && <div className="error-banner">{err}</div>}
+      {result && (
+        <div className="flash-ok">
+          Released {result.released} message{result.released === 1 ? "" : "s"};{" "}
+          {result.held} still held.
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3258,6 +3258,18 @@ button.primary:disabled {
   color: var(--danger, #d33);
   border-color: var(--danger, #d33);
 }
+/* RFC CY — a held channel is a breakpoint; the chip says so at a glance
+   because "nothing is arriving" otherwise looks like a broken workflow. */
+.channel-hold {
+  font-family: var(--mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 1px 6px;
+  border-radius: 8px;
+  color: var(--warn, #b8860b);
+  border: 1px solid var(--warn, #b8860b);
+}
 .channel-row {
   display: flex;
   align-items: center;


### PR DESCRIPTION
**RFC CY item 9 (phase L5)** — the breakpoint a workflow needs.

## Why

A workflow wired through channels has **no pause**. Once a stage publishes, the next stage's subscriber wakes and the wave is gone — there is nowhere to stand between "the results are in" and "the next wave starts". An operator who wants to look before the run continues has only bad options today: stop the whole runtime, or let it go and read the transcript afterwards.

`hold: true` on a channel definition makes it a **breakpoint**. A publish is stored and reported, but delivered to nobody and waking nobody, until someone releases it — `Channel op=release` for an agent, `POST /v1/_channels/{name}/release` for an operator, a **Release** control on the channel page for a human. `count` defaults to 1, oldest first, so a workflow can be **single-stepped**: the wave upstream runs, its results queue, and nothing downstream starts until someone says go.

```
POST /v1/_channels/review-queue/release   { "count": 1 }
  → { "channel": "review-queue", "released": ["msg_…"], "released_count": 1, "still_held": 2 }
```

## A reserved `visible_at`, not a `held` column

Every channel read already filters `visible_at <= now`. Marking a held message with a reserved far-future instant (`store.ChannelHeldVisibleAt`, 2200-01-01 — inside int64 nanos, which run out in 2262) withholds it through machinery that **already exists**: subscribe, peek, await, and any read path added later, without each one having to remember.

A boolean column would need its own predicate on every one of those queries, and the query that *forgets* it delivers the message the hold was supposed to stop. **The two designs fail in opposite directions and only one of them is safe.** It also costs no schema change on `channel_messages`, and the existing overflow trim already orders by `(visible_at, id)`.

## The check lives in the publisher

`StorePublisher.HoldFn` — wired once in `main.go`, resolving through a point lookup — means every internal publish path (heartbeats, the webhook relay, interrupts, the admin endpoint) honours a hold without each call site remembering to ask. *A promise enforced at five call sites is a promise the sixth one breaks.* The in-band tool checks the def it already resolved; the connector passes the reserved instant so the publisher short-circuits rather than resolving twice.

## Release is gated by publish, not subscribe

Releasing is the act of making a message deliverable — the half of a publish the hold deferred — so the question is whether the agent may *put messages on* this channel, not whether it may read them. The `_system/` refusals apply for the same reason.

## What a hold does not change

- **TTL still counts from publish time.** An expired held message is never released and never delivered — holding is not a way to outlive the retention its publisher declared.
- **Overflow still trims the oldest**, reporting `dropped_oldest`. A hold buffers; it does not make the buffer unbounded.
- **The hold wins over `deliver_at`** — a held message waits for a release, not for a clock — so the publish result says `"held": true` rather than promising a `visible_at` in the year 2200.

Releasing a channel with nothing held reports **zero rather than failing**, and a channel switched back to `hold: false` can still release what it holds — turning the breakpoint off must not strand the queue with no way out but a purge.

## The definition plane, end to end

`hold` is carried by operator yaml, the `channels` table (sqlite ALTER + postgres **migration 0075**, default false so every existing channel delivers exactly as before), `ChannelPatch`, the substrate CRUD, the MCP `channeldef` schema, `Context op=channels`, the TS adapter (`createChannel`/`updateChannel`/`releaseChannel`), and the Web UI (a hold checkbox, a hold chip, a Release control that appears only on a held channel). *A def field that survives only half the plane is a setting the operator believes they made.*

## Tested

`go test ./...` clean (**100 packages**, full output grepped for `FAIL`) plus the **postgres tier** against a local Postgres 14 (`TestStoreContract`, 128 s — migration 0075 and the `FOR UPDATE` release path both exercised on the real backend).

- **store contract, both backends** — hold round-trips through create/list/patch and an unrelated patch does not clear it; release hands over oldest first, reports what is left, drains, and is a no-op on an empty queue; an expired held message is neither released nor counted;
- **the tool** — a held publish is stored, reports `held:true`, and is *not* delivered, with a control channel in the same fixture proving the fixture otherwise delivers; release is refused with a subscribe-only ACL and the message stays held; TTL expiry survives the hold;
- **the wire** — the admin publish route holds, the release endpoint steps oldest first, an undeclared channel 404s, a `deliver_at` cannot escape the hold, and a **runtime-declared (substrate)** channel holds and releases — the path the canvas will use, which the yaml map alone would not cover;
- **the seam** — a publisher that never resolves a definition (`SystemPublisher.PublishNow`, the heartbeat/webhook/interrupt shape) is held anyway.

**The fail-before pass found a hole in its own tests** and the second commit closes it: with the `HoldFn` consultation removed, every HTTP hold test still passed, because they only exercised the connector's own def-aware check. The seam test now fails on exactly that deletion (`an internal publish walked past the hold: 1 delivered, want 0`). Reverting the tool's hold arm fails three tool tests; reversing the release ordering fails the store contract.

## Known gaps, deliberate

- The **webhook channel relay** does not resolve a channel def at all today (it passes `0/0` for `max_messages` and `default_ttl` too), so a hold does not apply there yet — it arrives with the L4 trigger work.
- **gRPC's `ListChannels`** descriptor does not carry `hold`: gRPC has no channel CRUD, and regenerating the pb for one read-only field is not worth it in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD