### PR TITLE
feat(scheduler): a schedule can deliver to a channel instead of a run

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -2930,7 +2930,20 @@ func main() {
 		// Resolve on_complete: channel.publish to the channel's DECLARED scope
 		// (F37 / RFC T) so a hook on a scope:global channel lands at global,
 		// not under the run's user scope. Must be set before Start.
-		sched.SetChannelScope(srv.ResolveChannelScope)
+		// Adapt the server's channel def to the scheduler's DeclaredChannel:
+		// the two packages meet here rather than importing each other for the
+		// sake of one struct.
+		sched.SetChannelScope(func(ctx context.Context, name string) (scheduler.DeclaredChannel, bool) {
+			def, ok := srv.ResolveChannelScope(ctx, name)
+			if !ok {
+				return scheduler.DeclaredChannel{}, false
+			}
+			return scheduler.DeclaredChannel{
+				Scope:       def.Scope,
+				DefaultTTL:  def.DefaultTTL,
+				MaxMessages: def.MaxMessages,
+			}, true
+		})
 		// RFC BL P2 consolidation fan-out: the provider resolver decides
 		// parallel-vs-serial dispatch (a local model runtime is serialized), and
 		// the advisory lock makes exactly one replica per tick enumerate the

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -581,9 +581,11 @@ Operators declare run templates under the yaml `scheduled_runs:` map (`config.Sc
 
 The `ScheduleDef` built-in (`internal/tools/builtin/scheduledef.go`) is a 7-op tool — the five core ops `create` / `fork` / `get` / `list` / `retire` plus `add_hook` / `remove_hook` (each hook edit persists a new lineage version). Static yaml entries remain immutable ground truth; the tool authors *new* names only.
 
+A schedule's **delivery** decides what a tick does. The default (`delivery: run`, or the field omitted) invokes the agent, which is every schedule that existed before RFC CY. `delivery: channel` publishes a cadence message to `channel:` and starts **no run** — the time-side twin of the `delivery: channel` a `webhooks:` entry already has, and the way a channel-driven workflow gets a clock without burning a model call on an agent whose only job is to publish. The tick carries `{schedule_name, fired_at, delivery, payload}`, where the payload is the def's operator-authored `metadata:`, and lands at the channel's **declared** scope. A channel tick is a fire like any other — `next_run_at` advances, `max_fires` counts, a publish failure is recorded as `failed` — and the run-shaped fields (`agent`, `prompt`, `on_complete`, credentials) are **refused** on it at config-load and at substrate write, because a prompt nothing sends is a setting the operator believes they made.
+
 A fired schedule's `on_complete` hooks deliver results through one of three kinds (`internal/scheduler/dispatch.go`): `channel.publish`, `memory.set`, or `mcp.call`. Schedules resolve MCP-tool bearers via `user_credentials_from_env` against the operator's `EnvAllowlist` — the same RFC F credential mechanism, not a parallel one. Persisted in the `schedule_defs` table (migration `0029`).
 
-References: `internal/scheduler/scheduler.go` (sweeper, `tick`, `fireOne`), `internal/scheduler/dispatch.go` (`on_complete` kinds), `internal/tools/builtin/scheduledef.go`, `internal/config/config.go` (`ScheduledRun`).
+References: `internal/scheduler/scheduler.go` (sweeper, `tick`, `fireOne`, `fireChannelDelivery`), `internal/scheduler/dispatch.go` (`on_complete` kinds), `internal/tools/builtin/scheduledef.go`, `internal/config/config.go` (`ScheduledRun`).
 
 ## Multi-replica HA (v0.12.0→v0.12.6)
 

--- a/internal/api/http/channel_scope_resolve_test.go
+++ b/internal/api/http/channel_scope_resolve_test.go
@@ -54,10 +54,10 @@ func TestResolveChannelScope_StaticRuntimeAndPrecedence(t *testing.T) {
 		{"undeclared", "", false},
 	}
 	for _, tc := range cases {
-		gotScope, gotOK := srv.ResolveChannelScope(ctx, tc.channel)
-		if gotScope != tc.wantScope || gotOK != tc.wantOK {
+		gotDef, gotOK := srv.ResolveChannelScope(ctx, tc.channel)
+		if gotDef.Scope != tc.wantScope || gotOK != tc.wantOK {
 			t.Errorf("ResolveChannelScope(%q) = (%q, %v), want (%q, %v)",
-				tc.channel, gotScope, gotOK, tc.wantScope, tc.wantOK)
+				tc.channel, gotDef.Scope, gotOK, tc.wantScope, tc.wantOK)
 		}
 	}
 }

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2088,22 +2088,21 @@ func (s *Server) channelPolicyForAgent(ctx context.Context, agentDef config.Agen
 	}
 }
 
-// ResolveChannelScope returns the declared scope ("global" | "user" |
-// "agent") of a channel by name, consulting static yaml + runtime substrate
-// (the same merge the Channel tool uses). ok=false when the channel is
-// declared nowhere.
+// ResolveChannelScope returns the DECLARED channel def by name, consulting
+// static yaml + runtime substrate (the same merge the Channel tool uses).
+// ok=false when the channel is declared nowhere.
 //
-// Injected into the scheduler so its on_complete: channel.publish hook lands
-// at the channel's DECLARED scope — a hook publishing to a scope:global
-// channel writes under global, not under the run's user scope where a global
-// reader (admin peek, Channel.await/subscribe resolving global) can't see it
-// (F37 / RFC T).
-func (s *Server) ResolveChannelScope(ctx context.Context, channel string) (string, bool) {
+// Injected into the scheduler so a scheduler publish lands at the channel's
+// DECLARED scope — a hook publishing to a scope:global channel writes under
+// global, not under the run's user scope where a global reader (admin peek,
+// Channel.await/subscribe resolving global) can't see it (F37 / RFC T) — and
+// so it honours the channel's declared default_ttl / max_messages, which a
+// cadence writer needs and previously never received. main.go adapts the def
+// to the scheduler's own DeclaredChannel — the two packages share a wiring
+// point, not a type.
+func (s *Server) ResolveChannelScope(ctx context.Context, channel string) (tools.ChannelDef, bool) {
 	def, ok := s.mergedChannelDefs(ctx, true)[channel]
-	if !ok {
-		return "", false
-	}
-	return def.Scope, true
+	return def, ok
 }
 
 // fallbackForRun builds the v0.8.2 PR-2 runtime-fallback policy +

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2250,8 +2250,29 @@ type AgentChannelACL struct {
 //
 // See rfcs/scheduled-agent-runs.md and `Context.help scheduled-runs`.
 type ScheduledRun struct {
+	// Delivery is WHAT a tick does. "" / "run" (the default) invokes the
+	// agent, which is every schedule that existed before this field. "channel"
+	// publishes to Channel and starts NO run — a cadence signal, symmetric
+	// with the `delivery: channel` a Webhook already has.
+	//
+	// Why a tick without a run: a workflow driven off a channel needs a clock,
+	// and today reaching a channel on a cron means burning an agent run whose
+	// only job is to publish. That costs a model call and a run row for a
+	// message the scheduler could write itself.
+	//
+	// A channel tick carries the schedule name, the fire time, and this def's
+	// Metadata as its payload — Metadata being the operator-authored non-secret
+	// structured data already on the def, and the only thing there is to say
+	// when no agent ran.
+	Delivery string `yaml:"delivery"`
+
+	// Channel is the publish target for delivery=channel. Required there,
+	// forbidden otherwise. Resolved at the channel's DECLARED scope, the same
+	// as an on_complete channel.publish hook.
+	Channel string `yaml:"channel"`
+
 	// Agent is the agent name to invoke. Must resolve via lookup.Agent
-	// (static cfg.Agents or substrate). Required.
+	// (static cfg.Agents or substrate). Required for delivery=run.
 	Agent string `yaml:"agent"`
 
 	// Prompt is the input segments. Operators typically use
@@ -6040,6 +6061,46 @@ func sqlMemConfigWarnings(name string, a AgentDef, sqlMemEnabled bool) []string 
 	return nil
 }
 
+// validateScheduleDelivery checks a schedule's delivery target (RFC CY),
+// mirroring validateStaticWebhook below: a mismatched target means the
+// schedule can never do anything useful, and failing loud at boot beats a
+// per-fire error nobody reads.
+//
+// delivery=channel FORBIDS the run-shaped fields rather than ignoring them. A
+// prompt that is never sent or an on_complete that never fires — there being
+// no run to complete — is a setting the operator believes they made, which is
+// the failure this codebase has paid for before.
+func validateScheduleDelivery(name string, sr ScheduledRun) error {
+	switch sr.Delivery {
+	case "", "run":
+		if sr.Agent == "" {
+			return fmt.Errorf("scheduled_runs.%s: agent is required (delivery=run)", name)
+		}
+		if sr.Channel != "" {
+			return fmt.Errorf("scheduled_runs.%s: delivery=run forbids `channel` (set delivery: channel to publish instead of running)", name)
+		}
+	case "channel":
+		if sr.Channel == "" {
+			return fmt.Errorf("scheduled_runs.%s: delivery=channel requires `channel`", name)
+		}
+		if sr.Agent != "" {
+			return fmt.Errorf("scheduled_runs.%s: delivery=channel forbids `agent` (a channel tick starts no run)", name)
+		}
+		if len(sr.Prompt) > 0 {
+			return fmt.Errorf("scheduled_runs.%s: delivery=channel forbids `prompt` (nothing reads it — put the tick's content in `metadata`)", name)
+		}
+		if len(sr.OnComplete) > 0 {
+			return fmt.Errorf("scheduled_runs.%s: delivery=channel forbids `on_complete` (there is no run to complete — the publish IS the delivery)", name)
+		}
+		if len(sr.RequiredCredentials) > 0 || len(sr.UserCredentialsFromEnv) > 0 {
+			return fmt.Errorf("scheduled_runs.%s: delivery=channel forbids credentials (they exist to authorize a run, and no run fires)", name)
+		}
+	default:
+		return fmt.Errorf("scheduled_runs.%s: unknown delivery %q (want run or channel)", name, sr.Delivery)
+	}
+	return nil
+}
+
 // validateStaticWebhook checks a static `webhooks:` entry's delivery target +
 // auth.kind at config-load (F24). A mismatched delivery target (spawn with no
 // agent, channel with no channel) means the webhook can NEVER fire — failing
@@ -6720,11 +6781,13 @@ func validate(c *Config) error {
 		if name == "" {
 			return fmt.Errorf("scheduled_runs: empty schedule name")
 		}
-		if sr.Agent == "" {
-			return fmt.Errorf("scheduled_runs.%s: agent is required", name)
+		if err := validateScheduleDelivery(name, sr); err != nil {
+			return err
 		}
-		if _, ok := c.Agents[sr.Agent]; !ok {
-			return fmt.Errorf("scheduled_runs.%s: agent %q not declared in cfg.Agents (substrate-only agents are resolved at runtime; declare a yaml stub if you want compile-time validation)", name, sr.Agent)
+		if sr.Agent != "" {
+			if _, ok := c.Agents[sr.Agent]; !ok {
+				return fmt.Errorf("scheduled_runs.%s: agent %q not declared in cfg.Agents (substrate-only agents are resolved at runtime; declare a yaml stub if you want compile-time validation)", name, sr.Agent)
+			}
 		}
 		// Mutual exclusion: standalone-schedule vs template-with-tier-defaults.
 		if sr.Schedule != "" && len(sr.UserTierSchedules) > 0 {

--- a/internal/config/schedule_delivery_test.go
+++ b/internal/config/schedule_delivery_test.go
@@ -1,0 +1,128 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// loadScheduleYAML writes a config with the given scheduled_runs block and
+// returns the load error (nil on success).
+func loadScheduleYAML(t *testing.T, scheduledRuns string) (*Config, error) {
+	t.Helper()
+	yamlPath := filepath.Join(t.TempDir(), "c.yaml")
+	body := `
+defaults: { provider: anthropic, model: x }
+agents:
+  worker:
+    provider: anthropic
+    model: x
+channels:
+  wave-in:
+    scope: global
+scheduled_runs:
+` + scheduledRuns
+	if err := os.WriteFile(yamlPath, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return Load(yamlPath)
+}
+
+// The happy path: a cadence tick needs a channel and nothing else.
+func TestScheduleDelivery_ChannelTickNeedsNoAgent(t *testing.T) {
+	cfg, err := loadScheduleYAML(t, `
+  nightly-tick:
+    delivery: channel
+    channel: wave-in
+    schedule: "0 3 * * *"
+    metadata: { batch: nightly }
+    enabled: true
+`)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	got := cfg.ScheduledRuns["nightly-tick"]
+	if got.Delivery != "channel" || got.Channel != "wave-in" {
+		t.Errorf("delivery/channel did not load: %+v", got)
+	}
+	if got.Agent != "" {
+		t.Errorf("agent = %q, want empty", got.Agent)
+	}
+}
+
+// The run-shaped fields are REFUSED on a channel tick, not ignored. Each case
+// is a setting an operator would otherwise believe they had made.
+func TestScheduleDelivery_ChannelTickRefusesRunShapedFields(t *testing.T) {
+	cases := []struct {
+		name  string
+		extra string
+		want  string
+	}{
+		{"agent", "    agent: worker\n", "forbids `agent`"},
+		{"prompt", "    prompt: [{role: user, content: [{type: trusted-text, text: go}]}]\n", "forbids `prompt`"},
+		{"on_complete", "    on_complete: [{kind: memory.set, scope: agent, key: k}]\n", "forbids `on_complete`"},
+		{"required_credentials", "    required_credentials: [jobs]\n", "forbids credentials"},
+		{"user_credentials_from_env", "    user_credentials_from_env: {jobs: LOOMCYCLE_JOBS_TOKEN}\n", "forbids credentials"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := loadScheduleYAML(t, "  tick:\n    delivery: channel\n    channel: wave-in\n    schedule: \"0 3 * * *\"\n"+c.extra)
+			if err == nil {
+				t.Fatalf("delivery=channel with %s loaded; want a refusal", c.name)
+			}
+			if !strings.Contains(err.Error(), c.want) {
+				t.Errorf("error = %v, want it to mention %q", err, c.want)
+			}
+		})
+	}
+}
+
+// A channel tick with no channel can never do anything — fail at boot, where
+// the operator is looking, not at 3am on the first fire.
+func TestScheduleDelivery_ChannelTickRequiresAChannel(t *testing.T) {
+	_, err := loadScheduleYAML(t, `
+  tick:
+    delivery: channel
+    schedule: "0 3 * * *"
+`)
+	if err == nil || !strings.Contains(err.Error(), "requires `channel`") {
+		t.Fatalf("err = %v, want a refusal naming channel", err)
+	}
+}
+
+// The default delivery is unchanged: an agent is still required, and a channel
+// on a run schedule is a mix-up worth naming.
+func TestScheduleDelivery_RunIsTheDefaultAndStillNeedsAnAgent(t *testing.T) {
+	_, err := loadScheduleYAML(t, `
+  tick:
+    schedule: "0 3 * * *"
+    prompt: [{role: user, content: [{type: trusted-text, text: go}]}]
+`)
+	if err == nil || !strings.Contains(err.Error(), "agent is required") {
+		t.Fatalf("err = %v, want an agent-required refusal", err)
+	}
+
+	_, err = loadScheduleYAML(t, `
+  tick:
+    agent: worker
+    channel: wave-in
+    schedule: "0 3 * * *"
+    prompt: [{role: user, content: [{type: trusted-text, text: go}]}]
+`)
+	if err == nil || !strings.Contains(err.Error(), "forbids `channel`") {
+		t.Fatalf("err = %v, want a channel-forbidden refusal", err)
+	}
+}
+
+func TestScheduleDelivery_UnknownDeliveryIsRefused(t *testing.T) {
+	_, err := loadScheduleYAML(t, `
+  tick:
+    delivery: carrier-pigeon
+    channel: wave-in
+    schedule: "0 3 * * *"
+`)
+	if err == nil || !strings.Contains(err.Error(), "unknown delivery") {
+		t.Fatalf("err = %v, want an unknown-delivery refusal", err)
+	}
+}

--- a/internal/lookup/schedule.go
+++ b/internal/lookup/schedule.go
@@ -86,6 +86,10 @@ func resolveScheduleSubstrate(ctx context.Context, s ScheduleStore, tenantID, na
 // in the builtin package pins the field set so a future field added
 // to either side without the matching addition here fails CI.
 type SubstrateScheduleDef struct {
+	// Delivery / Channel are the RFC CY tick target: "" / "run" invokes the
+	// agent, "channel" publishes to Channel and starts no run.
+	Delivery            string                   `json:"delivery,omitempty"`
+	Channel             string                   `json:"channel,omitempty"`
 	Agent               string                   `json:"agent,omitempty"`
 	Prompt              []SubstratePromptSegment `json:"prompt,omitempty"`
 	Schedule            string                   `json:"schedule,omitempty"`
@@ -168,6 +172,8 @@ func (s SubstrateScheduleDef) ToConfigDef() config.ScheduledRun {
 		enabled = *s.Enabled
 	}
 	out := config.ScheduledRun{
+		Delivery:               s.Delivery,
+		Channel:                s.Channel,
 		Agent:                  s.Agent,
 		Schedule:               s.Schedule,
 		UserTierSchedules:      s.UserTierSchedules,

--- a/internal/lookup/schedule_test.go
+++ b/internal/lookup/schedule_test.go
@@ -184,6 +184,11 @@ func TestSchedule_NormalizesTimezone(t *testing.T) {
 // once that ships in the follow-up tool PR.
 func TestSchedule_DriftDetection(t *testing.T) {
 	want := map[string]bool{
+		// RFC CY: the tick target. "" / "run" invokes the agent (every
+		// schedule that existed before); "channel" publishes to `channel`
+		// and starts no run. Both mirror onto config.ScheduledRun.
+		"delivery":                  true,
+		"channel":                   true,
 		"agent":                     true,
 		"prompt":                    true,
 		"schedule":                  true,

--- a/internal/scheduler/channel_delivery_test.go
+++ b/internal/scheduler/channel_delivery_test.go
@@ -1,0 +1,156 @@
+package scheduler
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// A `delivery: channel` schedule publishes a tick and starts NO run — the
+// whole point of the mode. The RunOnce count is the assertion that matters:
+// the old way to reach a channel on a cron was to burn an agent run.
+func TestScheduler_ChannelDeliveryPublishesWithoutARun(t *testing.T) {
+	enabled := true
+	def := scheduleDef{
+		Delivery: "channel",
+		Channel:  "wave-in",
+		Schedule: "0 * * * *",
+		Enabled:  &enabled,
+		Metadata: map[string]any{"batch": "nightly"},
+	}
+	sched, fr, _, defID, st := schedulerFixture(t, def, time.Now().Add(-1*time.Minute))
+	// Declare the channel at global scope, the way the server's resolver does.
+	sched.SetChannelScope(func(context.Context, string) (string, bool) { return "global", true })
+
+	fireT(t, sched)
+
+	if got := len(fr.Calls()); got != 0 {
+		t.Fatalf("RunOnce calls = %d, want 0 — a channel tick starts no run", got)
+	}
+	msgs, _, err := st.ChannelSubscribe(context.Background(), "", "wave-in", store.MemoryScopeGlobal, "", "", 10)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("published %d messages, want 1", len(msgs))
+	}
+	var got map[string]any
+	if err := json.Unmarshal(msgs[0].Payload, &got); err != nil {
+		t.Fatalf("decode tick: %v", err)
+	}
+	if got["schedule_name"] != "sched-test" {
+		t.Errorf("schedule_name = %v, want sched-test", got["schedule_name"])
+	}
+	if got["delivery"] != "channel" {
+		t.Errorf("delivery = %v, want channel", got["delivery"])
+	}
+	if _, ok := got["fired_at"].(string); !ok {
+		t.Errorf("tick carries no fired_at: %s", msgs[0].Payload)
+	}
+	payload, _ := got["payload"].(map[string]any)
+	if payload["batch"] != "nightly" {
+		t.Errorf("metadata did not reach the tick payload: %s", msgs[0].Payload)
+	}
+
+	// A tick is a fire: the state advances and records like any other, or the
+	// row re-presents on the next tick and max_fires never retires it.
+	state, err := st.ScheduleRunStateGet(context.Background(), defID)
+	if err != nil {
+		t.Fatalf("state: %v", err)
+	}
+	if state.LastStatus != "completed" {
+		t.Errorf("last_status = %q, want completed", state.LastStatus)
+	}
+	if state.NextRunAt.Before(time.Now()) {
+		t.Errorf("next_run_at = %v, expected the future", state.NextRunAt)
+	}
+	if state.FireCount != 1 {
+		t.Errorf("fire_count = %d, want 1", state.FireCount)
+	}
+}
+
+// A tick to a channel nobody declared FAILS the fire rather than silently
+// publishing nowhere — and still advances, so a broken schedule reports its
+// breakage every cycle instead of spinning the sweeper.
+func TestScheduler_ChannelDeliveryUndeclaredChannelIsARecordedFailure(t *testing.T) {
+	enabled := true
+	def := scheduleDef{
+		Delivery: "channel",
+		Channel:  "ghost",
+		Schedule: "0 * * * *",
+		Enabled:  &enabled,
+	}
+	sched, fr, _, defID, st := schedulerFixture(t, def, time.Now().Add(-1*time.Minute))
+	sched.SetChannelScope(func(context.Context, string) (string, bool) { return "", false })
+
+	fireT(t, sched)
+
+	if got := len(fr.Calls()); got != 0 {
+		t.Fatalf("RunOnce calls = %d, want 0", got)
+	}
+	state, err := st.ScheduleRunStateGet(context.Background(), defID)
+	if err != nil {
+		t.Fatalf("state: %v", err)
+	}
+	if state.LastStatus != "failed" {
+		t.Errorf("last_status = %q, want failed", state.LastStatus)
+	}
+	if state.LastError == "" {
+		t.Errorf("a failed tick recorded no error")
+	}
+	if state.NextRunAt.Before(time.Now()) {
+		t.Errorf("a failed tick did not advance next_run_at: %v", state.NextRunAt)
+	}
+}
+
+// max_fires bounds a channel tick exactly as it bounds a run — a one-shot
+// cadence signal is a real use (fire once at T, then retire).
+func TestScheduler_ChannelDeliveryRetiresAtMaxFires(t *testing.T) {
+	enabled := true
+	def := scheduleDef{
+		Delivery: "channel",
+		Channel:  "wave-in",
+		Schedule: "* * * * *",
+		Enabled:  &enabled,
+		MaxFires: 1,
+	}
+	sched, _, _, defID, st := schedulerFixture(t, def, time.Now().Add(-1*time.Minute))
+	sched.SetChannelScope(func(context.Context, string) (string, bool) { return "global", true })
+
+	fireT(t, sched)
+
+	row, err := st.ScheduleDefGet(context.Background(), defID)
+	if err != nil {
+		t.Fatalf("def get: %v", err)
+	}
+	if !row.Retired {
+		t.Errorf("max_fires=1 did not retire the def after its first tick")
+	}
+}
+
+// A disabled channel schedule publishes nothing — the kill switch has to work
+// on both delivery modes, and the branch order is what decides that.
+func TestScheduler_ChannelDeliveryRespectsDisabled(t *testing.T) {
+	disabled := false
+	def := scheduleDef{
+		Delivery: "channel",
+		Channel:  "wave-in",
+		Schedule: "0 * * * *",
+		Enabled:  &disabled,
+	}
+	sched, _, _, _, st := schedulerFixture(t, def, time.Now().Add(-1*time.Minute))
+	sched.SetChannelScope(func(context.Context, string) (string, bool) { return "global", true })
+
+	fireT(t, sched)
+
+	msgs, _, err := st.ChannelSubscribe(context.Background(), "", "wave-in", store.MemoryScopeGlobal, "", "", 10)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Errorf("a disabled schedule published %d ticks, want 0", len(msgs))
+	}
+}

--- a/internal/scheduler/channel_delivery_test.go
+++ b/internal/scheduler/channel_delivery_test.go
@@ -23,7 +23,7 @@ func TestScheduler_ChannelDeliveryPublishesWithoutARun(t *testing.T) {
 	}
 	sched, fr, _, defID, st := schedulerFixture(t, def, time.Now().Add(-1*time.Minute))
 	// Declare the channel at global scope, the way the server's resolver does.
-	sched.SetChannelScope(func(context.Context, string) (string, bool) { return "global", true })
+	sched.SetChannelScope(func(context.Context, string) (DeclaredChannel, bool) { return DeclaredChannel{Scope: "global"}, true })
 
 	fireT(t, sched)
 
@@ -84,7 +84,7 @@ func TestScheduler_ChannelDeliveryUndeclaredChannelIsARecordedFailure(t *testing
 		Enabled:  &enabled,
 	}
 	sched, fr, _, defID, st := schedulerFixture(t, def, time.Now().Add(-1*time.Minute))
-	sched.SetChannelScope(func(context.Context, string) (string, bool) { return "", false })
+	sched.SetChannelScope(func(context.Context, string) (DeclaredChannel, bool) { return DeclaredChannel{}, false })
 
 	fireT(t, sched)
 
@@ -118,7 +118,7 @@ func TestScheduler_ChannelDeliveryRetiresAtMaxFires(t *testing.T) {
 		MaxFires: 1,
 	}
 	sched, _, _, defID, st := schedulerFixture(t, def, time.Now().Add(-1*time.Minute))
-	sched.SetChannelScope(func(context.Context, string) (string, bool) { return "global", true })
+	sched.SetChannelScope(func(context.Context, string) (DeclaredChannel, bool) { return DeclaredChannel{Scope: "global"}, true })
 
 	fireT(t, sched)
 
@@ -142,7 +142,7 @@ func TestScheduler_ChannelDeliveryRespectsDisabled(t *testing.T) {
 		Enabled:  &disabled,
 	}
 	sched, _, _, _, st := schedulerFixture(t, def, time.Now().Add(-1*time.Minute))
-	sched.SetChannelScope(func(context.Context, string) (string, bool) { return "global", true })
+	sched.SetChannelScope(func(context.Context, string) (DeclaredChannel, bool) { return DeclaredChannel{Scope: "global"}, true })
 
 	fireT(t, sched)
 
@@ -152,5 +152,63 @@ func TestScheduler_ChannelDeliveryRespectsDisabled(t *testing.T) {
 	}
 	if len(msgs) != 0 {
 		t.Errorf("a disabled schedule published %d ticks, want 0", len(msgs))
+	}
+}
+
+// A cadence writer must honour the channel's declared retention. A tick every
+// minute with neither a TTL nor a bounded-queue cap is half a million rows a
+// year on a channel whose operator DID set limits — they just never reached
+// the writer.
+func TestScheduler_ChannelDeliveryHonoursDeclaredRetention(t *testing.T) {
+	enabled := true
+	def := scheduleDef{
+		Delivery: "channel",
+		Channel:  "wave-in",
+		Schedule: "0 * * * *",
+		Enabled:  &enabled,
+	}
+	sched, _, _, _, st := schedulerFixture(t, def, time.Now().Add(-1*time.Minute))
+	sched.SetChannelScope(func(context.Context, string) (DeclaredChannel, bool) {
+		return DeclaredChannel{Scope: "global", DefaultTTL: 3600, MaxMessages: 5}, true
+	})
+
+	fireT(t, sched)
+
+	msgs, _, err := st.ChannelSubscribe(context.Background(), "", "wave-in", store.MemoryScopeGlobal, "", "", 10)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("published %d, want 1", len(msgs))
+	}
+	if msgs[0].ExpiresAt.IsZero() {
+		t.Errorf("the tick carries no expiry — the channel's default_ttl never reached the writer")
+	}
+}
+
+// An unknown delivery is refused at decode rather than falling through to the
+// run path: firing an agent because of a value nobody could interpret is the
+// loudest possible wrong answer.
+func TestScheduler_UnknownDeliveryDoesNotFallThroughToARun(t *testing.T) {
+	enabled := true
+	def := scheduleDef{
+		Delivery: "smoke-signal",
+		Agent:    "researcher",
+		Schedule: "0 * * * *",
+		Enabled:  &enabled,
+	}
+	sched, fr, _, defID, st := schedulerFixture(t, def, time.Now().Add(-1*time.Minute))
+
+	fireT(t, sched)
+
+	if got := len(fr.Calls()); got != 0 {
+		t.Errorf("an unknown delivery fired the agent %d time(s)", got)
+	}
+	state, err := st.ScheduleRunStateGet(context.Background(), defID)
+	if err != nil {
+		t.Fatalf("state: %v", err)
+	}
+	if state.LastStatus != "decode_def" {
+		t.Errorf("last_status = %q, want decode_def", state.LastStatus)
 	}
 }

--- a/internal/scheduler/dispatch.go
+++ b/internal/scheduler/dispatch.go
@@ -68,32 +68,37 @@ func (s *Scheduler) dispatchChannelPublish(ctx context.Context, scheduleName, us
 	if err != nil {
 		return fmt.Errorf("marshal payload: %w", err)
 	}
-	scope, scopeID, err := s.resolvePublishScope(ctx, h.Channel, userID, agentName)
+	target, err := s.resolvePublishTarget(ctx, h.Channel, userID, agentName)
 	if err != nil {
 		return err
 	}
+	now := time.Now()
 	msg := store.ChannelMessage{
 		Channel: h.Channel,
 		// RFC N: the owning tenant comes from the schedule def (def.TenantID),
 		// threaded down from dispatchHooks — never from the hook payload.
 		TenantID:          tenantID,
-		Scope:             scope,
-		ScopeID:           scopeID,
+		Scope:             target.Scope,
+		ScopeID:           target.ScopeID,
 		Payload:           payload,
-		PublishedAt:       time.Now(),
+		PublishedAt:       now,
 		PublishedByUserID: userID,
 	}
-	// maxMessages = 0 means use the store's default cap. The scheduler
-	// doesn't manage per-channel sizing — that's an operator concern
-	// configured via cfg.Channels.<name>.max_messages, which the
-	// channel publish path itself doesn't know about. v1.1 will surface
-	// a sweeper-side cap if operators report unbounded growth.
-	_, _, err = s.store.ChannelPublish(ctx, msg, 0)
+	// The channel's DECLARED retention applies. This used to pass 0/0 with a
+	// note that per-channel sizing was an operator concern the publish path
+	// could not see — it can see it now that the resolver carries it, and
+	// "the operator configured a cap that never reached the writer" is not a
+	// division of concerns, it is a leak.
+	if target.DefaultTTL > 0 {
+		msg.ExpiresAt = now.Add(time.Duration(target.DefaultTTL) * time.Second)
+	}
+	_, _, err = s.store.ChannelPublish(ctx, msg, target.MaxMessages)
 	return err
 }
 
-// resolvePublishScope returns the (scope, scopeID) an on_complete:
-// channel.publish hook should write under.
+// resolvePublishTarget returns where a scheduler channel write lands — the
+// (scope, scopeID) an on_complete: channel.publish hook or an RFC CY channel
+// tick should write under, plus the channel's declared retention.
 //
 // With a resolver wired (the normal path), it honors the channel's DECLARED
 // scope (F37 / RFC T): a `scope: global` channel publishes at global/"" so a
@@ -106,33 +111,49 @@ func (s *Scheduler) dispatchChannelPublish(ctx context.Context, scheduleName, us
 // With no resolver (nil — small embeds / tests that don't wire one), it
 // falls back to the legacy behavior: user scope when the schedule has a
 // user_id, else global.
-func (s *Scheduler) resolvePublishScope(ctx context.Context, channel, userID, agentName string) (store.MemoryScope, string, error) {
+func (s *Scheduler) resolvePublishTarget(ctx context.Context, channel, userID, agentName string) (publishTarget, error) {
 	if s.chScope == nil {
 		if userID != "" {
-			return store.MemoryScopeUser, userID, nil
+			return publishTarget{Scope: store.MemoryScopeUser, ScopeID: userID}, nil
 		}
-		return store.MemoryScopeGlobal, "", nil
+		return publishTarget{Scope: store.MemoryScopeGlobal}, nil
 	}
 	declared, ok := s.chScope(ctx, channel)
 	if !ok {
-		return "", "", fmt.Errorf("channel.publish: channel %q is not declared (static yaml or runtime substrate)", channel)
+		return publishTarget{}, fmt.Errorf("channel.publish: channel %q is not declared (static yaml or runtime substrate)", channel)
 	}
-	switch declared {
+	out := publishTarget{DefaultTTL: declared.DefaultTTL, MaxMessages: declared.MaxMessages}
+	switch declared.Scope {
 	case "global":
-		return store.MemoryScopeGlobal, "", nil
+		out.Scope = store.MemoryScopeGlobal
 	case "user":
 		if userID == "" {
-			return "", "", fmt.Errorf("channel.publish: channel %q has scope=user but schedule has no user_id", channel)
+			return publishTarget{}, fmt.Errorf("channel.publish: channel %q has scope=user but schedule has no user_id", channel)
 		}
-		return store.MemoryScopeUser, userID, nil
+		out.Scope, out.ScopeID = store.MemoryScopeUser, userID
 	case "agent":
 		if agentName == "" {
-			return "", "", fmt.Errorf("channel.publish: channel %q has scope=agent but schedule has no agent", channel)
+			return publishTarget{}, fmt.Errorf("channel.publish: channel %q has scope=agent but schedule has no agent", channel)
 		}
-		return store.MemoryScopeAgent, agentName, nil
+		out.Scope, out.ScopeID = store.MemoryScopeAgent, agentName
 	default:
-		return "", "", fmt.Errorf("channel.publish: channel %q has unknown scope %q", channel, declared)
+		return publishTarget{}, fmt.Errorf("channel.publish: channel %q has unknown scope %q", channel, declared.Scope)
 	}
+	return out, nil
+}
+
+// publishTarget is where one scheduler channel write lands and how long it may
+// stay — the resolved form of the channel's declaration.
+//
+// Retention travels WITH the address because the two are answered by the same
+// lookup and forgetting the second half is invisible: the write succeeds, the
+// operator's declared `default_ttl` and `max_messages` simply never apply, and
+// the table grows at cron cadence until someone goes looking.
+type publishTarget struct {
+	Scope       store.MemoryScope
+	ScopeID     string
+	DefaultTTL  int
+	MaxMessages int
 }
 
 func (s *Scheduler) dispatchMemorySet(ctx context.Context, scheduleName, userID, tenantID string, h scheduleHook) error {

--- a/internal/scheduler/dispatch_test.go
+++ b/internal/scheduler/dispatch_test.go
@@ -45,7 +45,7 @@ func channelHookDef(channel string) scheduleDef {
 func TestScheduler_OnCompleteHookUsesSurvivalCtx(t *testing.T) {
 	def := channelHookDef("ctx-survival")
 	sched, _, _, defID, st := schedulerFixture(t, def, time.Now().Add(-1*time.Minute))
-	sched.SetChannelScope(func(context.Context, string) (string, bool) { return "global", true })
+	sched.SetChannelScope(func(context.Context, string) (DeclaredChannel, bool) { return DeclaredChannel{Scope: "global"}, true })
 
 	// Parent ctx already cancelled — the run still "completes" (the fake
 	// runner ignores ctx), so status=="completed" and the survival ctx kicks
@@ -73,7 +73,7 @@ func TestScheduler_OnCompleteHookUsesSurvivalCtx(t *testing.T) {
 // global peek returns 0 and the user peek returns 1 (both assertions flip).
 func TestScheduler_OnCompleteChannelPublish_HonorsGlobalScope(t *testing.T) {
 	sched, _, _, _, st := schedulerFixture(t, channelHookDef("exp5-pings"), time.Now().Add(-1*time.Minute))
-	sched.SetChannelScope(func(context.Context, string) (string, bool) { return "global", true })
+	sched.SetChannelScope(func(context.Context, string) (DeclaredChannel, bool) { return DeclaredChannel{Scope: "global"}, true })
 
 	fireT(t, sched)
 
@@ -89,7 +89,7 @@ func TestScheduler_OnCompleteChannelPublish_HonorsGlobalScope(t *testing.T) {
 // still publishes under user/<user_id> (unchanged from pre-fix).
 func TestScheduler_OnCompleteChannelPublish_UserScope(t *testing.T) {
 	sched, _, _, _, st := schedulerFixture(t, channelHookDef("results-alice"), time.Now().Add(-1*time.Minute))
-	sched.SetChannelScope(func(context.Context, string) (string, bool) { return "user", true })
+	sched.SetChannelScope(func(context.Context, string) (DeclaredChannel, bool) { return DeclaredChannel{Scope: "user"}, true })
 
 	fireT(t, sched)
 
@@ -105,7 +105,7 @@ func TestScheduler_OnCompleteChannelPublish_UserScope(t *testing.T) {
 // publishes under agent/<agent name> (the schedule's def.Agent).
 func TestScheduler_OnCompleteChannelPublish_AgentScope(t *testing.T) {
 	sched, _, _, _, st := schedulerFixture(t, channelHookDef("agent-bus"), time.Now().Add(-1*time.Minute))
-	sched.SetChannelScope(func(context.Context, string) (string, bool) { return "agent", true })
+	sched.SetChannelScope(func(context.Context, string) (DeclaredChannel, bool) { return DeclaredChannel{Scope: "agent"}, true })
 
 	fireT(t, sched)
 
@@ -119,7 +119,7 @@ func TestScheduler_OnCompleteChannelPublish_AgentScope(t *testing.T) {
 // mis-scoping — nothing is published.
 func TestScheduler_OnCompleteChannelPublish_UndeclaredFails(t *testing.T) {
 	sched, _, _, _, st := schedulerFixture(t, channelHookDef("ghost"), time.Now().Add(-1*time.Minute))
-	sched.SetChannelScope(func(context.Context, string) (string, bool) { return "", false })
+	sched.SetChannelScope(func(context.Context, string) (DeclaredChannel, bool) { return DeclaredChannel{}, false })
 
 	fireT(t, sched)
 

--- a/internal/scheduler/runinput.go
+++ b/internal/scheduler/runinput.go
@@ -23,6 +23,10 @@ import (
 // would require a new shared package; the duplication is small
 // enough that locking it with the drift test is cheaper.
 type scheduleDef struct {
+	// Delivery / Channel are the RFC CY tick target: "" / "run" invokes the
+	// agent, "channel" publishes and starts no run.
+	Delivery               string              `json:"delivery,omitempty"`
+	Channel                string              `json:"channel,omitempty"`
 	Agent                  string              `json:"agent,omitempty"`
 	Prompt                 []schedulePromptSeg `json:"prompt,omitempty"`
 	Schedule               string              `json:"schedule,omitempty"`
@@ -80,8 +84,20 @@ func unmarshalDef(body []byte) (scheduleDef, error) {
 	if err := json.Unmarshal(body, &def); err != nil {
 		return scheduleDef{}, fmt.Errorf("decode schedule definition: %w", err)
 	}
-	if def.Agent == "" {
-		return def, fmt.Errorf("schedule definition missing required `agent` field")
+	// RFC CY: a channel tick has no agent BY DESIGN — the requirement is
+	// per-delivery, not universal. Keeping the check here (rather than
+	// dropping it) means a run-delivery def with no agent still fails at
+	// decode, where the sweeper records it as a def problem instead of
+	// discovering it inside the runner.
+	switch def.Delivery {
+	case "channel":
+		if def.Channel == "" {
+			return def, fmt.Errorf("schedule definition has delivery=channel but no `channel` field")
+		}
+	default:
+		if def.Agent == "" {
+			return def, fmt.Errorf("schedule definition missing required `agent` field")
+		}
 	}
 	return def, nil
 }

--- a/internal/scheduler/runinput.go
+++ b/internal/scheduler/runinput.go
@@ -94,10 +94,17 @@ func unmarshalDef(body []byte) (scheduleDef, error) {
 		if def.Channel == "" {
 			return def, fmt.Errorf("schedule definition has delivery=channel but no `channel` field")
 		}
-	default:
+	case "", "run":
 		if def.Agent == "" {
 			return def, fmt.Errorf("schedule definition missing required `agent` field")
 		}
+	default:
+		// Both write paths refuse an unknown delivery, so a row carrying one
+		// should not exist. Refusing it HERE anyway is the fail-closed
+		// direction: with a default-run fallthrough, a delivery this sweeper
+		// does not understand would quietly fire the agent — the loudest
+		// possible action taken because of a value nobody could interpret.
+		return def, fmt.Errorf("schedule definition has unknown delivery %q (want run or channel)", def.Delivery)
 	}
 	return def, nil
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -145,14 +145,27 @@ type Scheduler struct {
 	inFlight sync.Map
 }
 
-// ChannelScopeResolver returns the declared scope ("global" | "user" |
-// "agent") of a channel by name. ok=false when the channel is declared
-// nowhere (static yaml + runtime substrate). Injected so the on_complete:
-// channel.publish hook publishes at the channel's declared scope instead of
-// blindly under the run's user scope (F37 / RFC T). Satisfied by
+// DeclaredChannel is what the scheduler needs to know about a channel it is
+// about to write to: where the message goes, and how long it may stay.
+//
+// Retention is here because a scheduler write is a CADENCE write. A tick every
+// minute that carries neither a TTL nor a bounded-queue cap accumulates half a
+// million rows a year on a channel the operator did declare limits for — the
+// limits simply never reached the writer.
+type DeclaredChannel struct {
+	Scope       string // "global" | "user" | "agent"
+	DefaultTTL  int    // seconds; 0 = no TTL
+	MaxMessages int    // 0 = unbounded
+}
+
+// ChannelScopeResolver returns the DECLARED shape of a channel by name.
+// ok=false when the channel is declared nowhere (static yaml + runtime
+// substrate). Injected so a scheduler publish lands at the channel's declared
+// scope instead of blindly under the run's user scope (F37 / RFC T), and
+// honours the channel's declared retention. Satisfied by
 // (*http.Server).ResolveChannelScope; nil leaves the legacy user-scope
 // behavior untouched.
-type ChannelScopeResolver func(ctx context.Context, channel string) (scope string, ok bool)
+type ChannelScopeResolver func(ctx context.Context, channel string) (DeclaredChannel, bool)
 
 // SetChannelScope wires the channel-scope resolver. Must be called before
 // Start (the sweeper reads chScope when dispatching on_complete hooks). A
@@ -333,20 +346,25 @@ func (s *Scheduler) fireOne(ctx context.Context, row store.ScheduleDueRow, now t
 		return
 	}
 
+	// RFC CY: a channel tick is a fire with no run. Everything below — the
+	// consolidation fan-out, RunInput, the runner, the fire timeout,
+	// on_complete — presumes an agent, so delivery is decided FIRST.
+	//
+	// Order matters against the fan-out check in particular: that one keys off
+	// a metadata flag, and on a channel tick `metadata` is opaque payload
+	// rather than configuration. Deciding delivery first is what makes that
+	// sentence true.
+	if def.Delivery == "channel" {
+		s.fireChannelDelivery(ctx, row, def, now)
+		return
+	}
+
 	// RFC BL P2: a consolidation schedule dispatches one run per memory TARGET
 	// with new work rather than one blanket run — the pass operates on exactly
 	// one target, so "consolidate everything" is N runs. See consolidator.go;
 	// it does its own result bookkeeping.
 	if isConsolidationFanout(def) {
 		s.fireConsolidationFanout(ctx, row, def, now)
-		return
-	}
-
-	// RFC CY: a channel tick is a fire with no run. Everything downstream of
-	// here — RunInput, the runner, the fire timeout, on_complete — presumes an
-	// agent, so the branch is taken before any of it is built.
-	if def.Delivery == "channel" {
-		s.fireChannelDelivery(ctx, row, def, now)
 		return
 	}
 
@@ -483,21 +501,25 @@ func (s *Scheduler) publishTick(ctx context.Context, scheduleName string, def sc
 	if err != nil {
 		return fmt.Errorf("marshal tick: %w", err)
 	}
-	scope, scopeID, err := s.resolvePublishScope(ctx, def.Channel, def.UserID, def.Agent)
+	target, err := s.resolvePublishTarget(ctx, def.Channel, def.UserID, def.Agent)
 	if err != nil {
 		return err
 	}
-	_, _, err = s.store.ChannelPublish(ctx, store.ChannelMessage{
+	msg := store.ChannelMessage{
 		Channel: def.Channel,
 		// RFC N: the owning tenant comes from the def, never from anywhere a
 		// caller could influence.
 		TenantID:          def.TenantID,
-		Scope:             scope,
-		ScopeID:           scopeID,
+		Scope:             target.Scope,
+		ScopeID:           target.ScopeID,
 		Payload:           payload,
 		PublishedAt:       now,
 		PublishedByUserID: def.UserID,
-	}, 0)
+	}
+	if target.DefaultTTL > 0 {
+		msg.ExpiresAt = now.Add(time.Duration(target.DefaultTTL) * time.Second)
+	}
+	_, _, err = s.store.ChannelPublish(ctx, msg, target.MaxMessages)
 	return err
 }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -2,7 +2,9 @@ package scheduler
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"runtime"
 	"sync"
 	"time"
@@ -340,6 +342,14 @@ func (s *Scheduler) fireOne(ctx context.Context, row store.ScheduleDueRow, now t
 		return
 	}
 
+	// RFC CY: a channel tick is a fire with no run. Everything downstream of
+	// here — RunInput, the runner, the fire timeout, on_complete — presumes an
+	// agent, so the branch is taken before any of it is built.
+	if def.Delivery == "channel" {
+		s.fireChannelDelivery(ctx, row, def, now)
+		return
+	}
+
 	in := buildRunInput(def, s.cfg.EnvAllowlist, s.logf)
 
 	// Cap the per-fire run time. The runner's ctx-cancellation cascades
@@ -418,6 +428,77 @@ func (s *Scheduler) fireOne(ctx context.Context, row store.ScheduleDueRow, now t
 	if status == "completed" {
 		s.dispatchHooks(recordCtx, row.Name, def, registeredRunID, registeredAgentID)
 	}
+}
+
+// fireChannelDelivery is the RFC CY tick that publishes instead of running.
+//
+// WHY IT EXISTS. A workflow driven off a channel needs a clock. Reaching a
+// channel on a cron used to mean burning an agent run whose only job was to
+// publish — a model call, a run row, and a provider bill for a message the
+// scheduler can write itself. This is the symmetric twin of the
+// `delivery: channel` a Webhook already has: one is an external event landing
+// on a channel, this one is time landing on a channel.
+//
+// The message carries what there is to say when no agent ran: which schedule
+// fired, when, and the def's operator-authored metadata as the payload. A
+// downstream reader keys off schedule_name the same way it keys off an
+// on_complete hook's.
+//
+// Bookkeeping is the SAME as a run fire — next_run_at advances, max_fires
+// counts, a failure is recorded as failed — because from the schedule's side a
+// tick is a fire whatever it delivered. A publish failure counts too: the tick
+// happened, and a channel that is undeclared or unreachable will fail the same
+// way next time, so hiding it from the cap would let a broken schedule run
+// forever.
+func (s *Scheduler) fireChannelDelivery(ctx context.Context, row store.ScheduleDueRow, def scheduleDef, now time.Time) {
+	status := "completed"
+	errStr := ""
+	if err := s.publishTick(ctx, row.Name, def, now); err != nil {
+		status = "failed"
+		errStr = err.Error()
+		s.logf("scheduler: schedule %q channel delivery to %q failed: %v", row.Name, def.Channel, err)
+	}
+	_, done := s.recordFireOutcome(ctx, row, def, now, fireOutcome{
+		Status:      status,
+		Err:         errStr,
+		CountAsFire: true,
+	})
+	done()
+}
+
+// publishTick writes one cadence message to the def's channel, at the
+// channel's DECLARED scope (the same resolution an on_complete channel.publish
+// hook uses, so a global channel's tick is visible to a global reader instead
+// of buried under a user scope).
+func (s *Scheduler) publishTick(ctx context.Context, scheduleName string, def scheduleDef, now time.Time) error {
+	if def.Channel == "" {
+		return fmt.Errorf("delivery=channel missing `channel`")
+	}
+	payload, err := json.Marshal(map[string]any{
+		"schedule_name": scheduleName,
+		"fired_at":      now.UTC().Format(time.RFC3339Nano),
+		"delivery":      "channel",
+		"payload":       def.Metadata,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal tick: %w", err)
+	}
+	scope, scopeID, err := s.resolvePublishScope(ctx, def.Channel, def.UserID, def.Agent)
+	if err != nil {
+		return err
+	}
+	_, _, err = s.store.ChannelPublish(ctx, store.ChannelMessage{
+		Channel: def.Channel,
+		// RFC N: the owning tenant comes from the def, never from anywhere a
+		// caller could influence.
+		TenantID:          def.TenantID,
+		Scope:             scope,
+		ScopeID:           scopeID,
+		Payload:           payload,
+		PublishedAt:       now,
+		PublishedByUserID: def.UserID,
+	}, 0)
+	return err
 }
 
 // fireOutcome is what one fire produced, whatever kind of fire it was. It

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -401,7 +401,46 @@ func (s *Scheduler) fireOne(ctx context.Context, row store.ScheduleDueRow, now t
 		}
 	}
 
-	// Advance next_run_at + record outcome atomically (single UPDATE).
+	recordCtx, done := s.recordFireOutcome(ctx, row, def, now, fireOutcome{
+		RunID:       registeredRunID,
+		Status:      status,
+		Err:         errStr,
+		CountAsFire: countAsFire,
+	})
+	defer done()
+
+	// Dispatch hooks only on success — RFC E says on_complete fires on
+	// "successful runs." Failed/skipped runs don't notify. Use recordCtx (the
+	// survival ctx) not the parent: a run that completes just as shutdown
+	// begins still recorded its result above, so its on_complete hooks
+	// (channel publish / memory set / mcp.call) must fire too rather than be
+	// dropped on a cancelled parent ctx.
+	if status == "completed" {
+		s.dispatchHooks(recordCtx, row.Name, def, registeredRunID, registeredAgentID)
+	}
+}
+
+// fireOutcome is what one fire produced, whatever kind of fire it was. It
+// exists so the bookkeeping below is written once: every fire has to advance
+// next_run_at and count against max_fires, and a fire that skips either one
+// re-presents on the next tick or never retires.
+type fireOutcome struct {
+	RunID       string
+	Status      string
+	Err         string
+	CountAsFire bool
+}
+
+// recordFireOutcome advances next_run_at, records the result, and applies the
+// max_fires lifetime cap.
+//
+// Returns the ctx it used plus a cleanup func. The ctx is a SURVIVAL ctx when
+// the parent is already cancelled (mid-shutdown): without it the store write
+// fails silently, next_run_at stays in the past, and the schedule re-fires
+// immediately on the next startup. Callers with follow-on work — on_complete
+// hooks — dispatch on the same ctx for the same reason, and must call the
+// cleanup func when they are done with it.
+func (s *Scheduler) recordFireOutcome(ctx context.Context, row store.ScheduleDueRow, def scheduleDef, now time.Time, out fireOutcome) (context.Context, func()) {
 	next, nextErr := s.computeNext(def, now)
 	if nextErr != nil {
 		// Without a valid next_run_at, the sweeper would re-fire this
@@ -410,29 +449,26 @@ func (s *Scheduler) fireOne(ctx context.Context, row store.ScheduleDueRow, now t
 		s.logf("scheduler: schedule %q cron-resolve failed: %v — parking 1h", row.Name, nextErr)
 		next = now.Add(1 * time.Hour)
 	}
-	// Use a survival ctx for RecordResult when the parent is already
-	// cancelled (e.g. mid-shutdown). Without this, the store write
-	// fails silently, next_run_at stays in the past, and the schedule
-	// re-fires immediately on the next startup. Bounded 5s timeout
-	// prevents the survival path from hanging shutdown indefinitely.
 	recordCtx := ctx
+	done := func() {}
 	if ctx.Err() != nil {
 		var cancel context.CancelFunc
+		// Bounded 5s so the survival path can't hang shutdown.
 		recordCtx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
+		done = cancel
 	}
 	if err := s.store.ScheduleRunStateRecordResult(recordCtx, store.ScheduleRunResult{
 		DefID:      row.DefID,
-		LastRunID:  registeredRunID,
-		LastStatus: status,
-		LastError:  errStr,
+		LastRunID:  out.RunID,
+		LastStatus: out.Status,
+		LastError:  out.Err,
 		LastRunAt:  now,
 		NextRunAt:  next,
 		// RFC S / F36: this IS a fire (any status counts toward the cap, so
 		// a wedged/always-failing schedule still retires). The disabled-skip
 		// advance (advanceOnly) leaves this false; F38 leaves it false for an
-		// unresolved-agent config error (see countAsFire above).
-		CountAsFire: countAsFire,
+		// unresolved-agent config error.
+		CountAsFire: out.CountAsFire,
 	}); err != nil {
 		s.logf("scheduler: record result for %q: %v", row.Name, err)
 	}
@@ -455,16 +491,7 @@ func (s *Scheduler) fireOne(ctx context.Context, row store.ScheduleDueRow, now t
 			}
 		}
 	}
-
-	// Dispatch hooks only on success — RFC E says on_complete fires on
-	// "successful runs." Failed/skipped runs don't notify. Use recordCtx (the
-	// survival ctx) not the parent: a run that completes just as shutdown
-	// begins still recorded its result above, so its on_complete hooks
-	// (channel publish / memory set / mcp.call) must fire too rather than be
-	// dropped on a cancelled parent ctx.
-	if status == "completed" {
-		s.dispatchHooks(recordCtx, row.Name, def, registeredRunID, registeredAgentID)
-	}
+	return recordCtx, done
 }
 
 // advanceOnly is the disabled-schedule path: bump next_run_at without

--- a/internal/tools/builtin/scheduledef.go
+++ b/internal/tools/builtin/scheduledef.go
@@ -84,7 +84,7 @@ const scheduleDefInputSchema = `{
     "parent_def_id": {"type": "string", "description": "Fork parent (optional for fork — when absent, forks the active def of the name, or bootstraps from a yaml template)."},
     "overlay": {
       "type": "object",
-      "description": "Mutable subset of ScheduledRun for create/fork (agent, prompt, schedule/user_tier_schedules, timezone, enabled, catch_up_max, max_fires, user_id, user_tier, user_credentials, user_credentials_from_env, on_complete, metadata, tenant_id). max_fires N>0 auto-retires the def after its Nth fire (1 = one-shot; 0 = unbounded). Immutable / server-set fields are silently ignored if supplied.",
+      "description": "Mutable subset of ScheduledRun for create/fork (delivery, channel, agent, prompt, schedule/user_tier_schedules, timezone, enabled, catch_up_max, max_fires, user_id, user_tier, user_credentials, user_credentials_from_env, on_complete, metadata, tenant_id). delivery is run (default — invoke the agent) or channel (publish a cadence tick to the named channel and start NO run; forbids agent/prompt/on_complete/credentials, and carries metadata as the message payload). max_fires N>0 auto-retires the def after its Nth fire (1 = one-shot; 0 = unbounded). Immutable / server-set fields are silently ignored if supplied.",
       "additionalProperties": true
     },
     "description":   {"type": "string", "description": "Free-text rationale for create/fork."},
@@ -884,8 +884,37 @@ func computeInitialNextRunAt(def mergedScheduleDef, now time.Time) time.Time {
 // runtime-supplied overlays that would otherwise produce broken
 // schedule rows the sweeper can't fire.
 func validateScheduleDef(def mergedScheduleDef) error {
-	if def.Agent == "" {
-		return fmt.Errorf("agent: required")
+	// RFC CY delivery target. Same rule as the yaml validator
+	// (config.validateScheduleDelivery): the run-shaped fields are REFUSED on
+	// a channel tick rather than ignored, because a prompt that is never sent
+	// or an on_complete that never fires is a setting the author believes they
+	// made.
+	switch def.Delivery {
+	case "", "run":
+		if def.Agent == "" {
+			return fmt.Errorf("agent: required")
+		}
+		if def.Channel != "" {
+			return fmt.Errorf("delivery=run forbids channel (set delivery: channel to publish instead of running)")
+		}
+	case "channel":
+		if def.Channel == "" {
+			return fmt.Errorf("delivery=channel requires channel")
+		}
+		if def.Agent != "" {
+			return fmt.Errorf("delivery=channel forbids agent (a channel tick starts no run)")
+		}
+		if len(def.Prompt) > 0 {
+			return fmt.Errorf("delivery=channel forbids prompt (nothing reads it — put the tick's content in metadata)")
+		}
+		if len(def.OnComplete) > 0 {
+			return fmt.Errorf("delivery=channel forbids on_complete (there is no run to complete — the publish IS the delivery)")
+		}
+		if len(def.RequiredCredentials) > 0 || len(def.UserCredentials) > 0 || len(def.UserCredentialsFromEnv) > 0 {
+			return fmt.Errorf("delivery=channel forbids credentials (they exist to authorize a run, and no run fires)")
+		}
+	default:
+		return fmt.Errorf("unknown delivery %q (want run or channel)", def.Delivery)
 	}
 	if def.Schedule != "" && len(def.UserTierSchedules) > 0 {
 		return fmt.Errorf("cannot set both schedule and user_tier_schedules (pick one)")
@@ -978,6 +1007,10 @@ func scheduleRowResponseMap(row store.ScheduleDefRow) map[string]any {
 // counterpart to RFC F's RunInput.UserCredentials at the wire). The
 // scheduler reads this when building RunInput from the schedule row.
 type mergedScheduleDef struct {
+	// Delivery / Channel are the RFC CY tick target: "" / "run" invokes the
+	// agent, "channel" publishes to Channel and starts no run.
+	Delivery            string                    `json:"delivery,omitempty"`
+	Channel             string                    `json:"channel,omitempty"`
 	Agent               string                    `json:"agent,omitempty"`
 	Prompt              []mergedSchedulePromptSeg `json:"prompt,omitempty"`
 	Schedule            string                    `json:"schedule,omitempty"`
@@ -1130,11 +1163,19 @@ func (d *mergedScheduleDef) applyOverlay(ov mergedScheduleDef) {
 	if ov.TenantID != "" {
 		d.TenantID = ov.TenantID
 	}
+	if ov.Delivery != "" {
+		d.Delivery = ov.Delivery
+	}
+	if ov.Channel != "" {
+		d.Channel = ov.Channel
+	}
 }
 
 func staticToMergedScheduleDef(sr config.ScheduledRun) mergedScheduleDef {
 	enabled := sr.Enabled
 	out := mergedScheduleDef{
+		Delivery:               sr.Delivery,
+		Channel:                sr.Channel,
 		Agent:                  sr.Agent,
 		Schedule:               sr.Schedule,
 		UserTierSchedules:      sr.UserTierSchedules,

--- a/internal/tools/builtin/scheduledef_channel_test.go
+++ b/internal/tools/builtin/scheduledef_channel_test.go
@@ -1,0 +1,74 @@
+package builtin
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// A runtime-authored cadence tick: no agent, no prompt, just a channel. This
+// is the shape a canvas writes when it wires a clock into a workflow, so it
+// has to survive create → definition JSON → the sweeper's read shape.
+func TestScheduleDefTool_CreateChannelDelivery(t *testing.T) {
+	tool, ctx, cleanup := scheduleDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(
+		`{"op":"create","name":"wave-tick","overlay":{"delivery":"channel","channel":"wave-in","schedule":"0 * * * *","metadata":{"batch":"nightly"}}}`))
+	if res.IsError {
+		t.Fatalf("create: %s", res.Text)
+	}
+
+	created := decodeResult(t, res.Text)
+	defID, _ := created["def_id"].(string)
+	if defID == "" {
+		t.Fatalf("create returned no def_id: %s", res.Text)
+	}
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"get","def_id":"`+defID+`"}`))
+	if res.IsError {
+		t.Fatalf("get: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	def, ok := out["definition"].(map[string]any)
+	if !ok {
+		t.Fatalf("no definition in %s", res.Text)
+	}
+	if def["delivery"] != "channel" || def["channel"] != "wave-in" {
+		t.Errorf("delivery/channel did not round-trip: %v", def)
+	}
+	if _, present := def["agent"]; present {
+		t.Errorf("a channel tick stored an agent: %v", def)
+	}
+}
+
+// The substrate refuses the same mixes the yaml validator does — an agent
+// authoring a def must not be able to create the shape the operator can't.
+func TestScheduleDefTool_ChannelDeliveryRefusesRunShapedFields(t *testing.T) {
+	cases := []struct {
+		name    string
+		overlay string
+		want    string
+	}{
+		{"agent", `{"delivery":"channel","channel":"c","schedule":"0 * * * *","agent":"job-search-batch"}`, "forbids agent"},
+		{"prompt", `{"delivery":"channel","channel":"c","schedule":"0 * * * *","prompt":[{"role":"user","content":[{"type":"trusted-text","text":"go"}]}]}`, "forbids prompt"},
+		{"on_complete", `{"delivery":"channel","channel":"c","schedule":"0 * * * *","on_complete":[{"kind":"memory.set","scope":"agent","key":"k"}]}`, "forbids on_complete"},
+		{"credentials", `{"delivery":"channel","channel":"c","schedule":"0 * * * *","user_credentials":{"jobs":"t"}}`, "forbids credentials"},
+		{"no channel", `{"delivery":"channel","schedule":"0 * * * *"}`, "requires channel"},
+		{"unknown delivery", `{"delivery":"smoke-signal","schedule":"0 * * * *"}`, "unknown delivery"},
+		{"channel on a run", `{"agent":"job-search-batch","channel":"c","schedule":"0 * * * *"}`, "forbids channel"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tool, ctx, cleanup := scheduleDefFixture(t)
+			defer cleanup()
+			res, _ := tool.Execute(ctx, json.RawMessage(
+				`{"op":"create","name":"bad-tick","overlay":`+c.overlay+`}`))
+			if !res.IsError {
+				t.Fatalf("create with %s succeeded; want a refusal", c.name)
+			}
+			if !strings.Contains(res.Text, c.want) {
+				t.Errorf("refusal = %q, want it to mention %q", res.Text, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**RFC CY item 11 (phase L6)** — the time-side twin of the `delivery: channel` a webhook already has.

## Why

A workflow driven off channels needs a clock, and today reaching a channel on a cron means **burning an agent run whose only job is to publish** — a model call, a run row, and a provider bill for a message the scheduler can write itself. Webhooks solved the same problem already: `delivery: channel` relays an inbound event straight onto a channel with no run. This is that, with **time** as the event.

```yaml
scheduled_runs:
  nightly-wave:
    delivery: channel
    channel: wave-in
    schedule: "0 3 * * *"
    metadata: { batch: nightly }
```

The tick carries `{schedule_name, fired_at, delivery, payload}` and lands at the channel's **declared** scope — the same resolution an `on_complete: channel.publish` hook uses, because a global channel's tick has to be visible to a global reader, not buried under the schedule's user scope. The payload is the def's `metadata:`, the operator-authored non-secret structured data already on the def and the only thing there is to say when no agent ran, so this needs no new field.

## A tick is a fire

`next_run_at` advances, `max_fires` counts, a publish failure is recorded as `failed` with its error. **A failure counts toward the cap on purpose:** the tick happened, and a channel that is undeclared or unreachable will fail identically next time, so exempting it would let a broken schedule run forever.

## The run-shaped fields are refused, not ignored

`agent`, `prompt`, `on_complete` and credentials are **rejected** on a channel tick — at config-load *and* at substrate write. A prompt nothing sends, or an `on_complete` that can never fire because no run completes, is a setting the author believes they made; this codebase has paid for that class of bug before. Running the same rule on both write paths means an agent authoring a def cannot create a shape the operator's yaml would refuse.

`unmarshalDef`'s agent requirement becomes **per-delivery** rather than universal: a channel def legitimately has no agent, while a run def with no agent still fails at decode, where the sweeper records it as a def problem instead of discovering it inside the runner.

Carried across all three JSON mirrors — `mergedScheduleDef` (write), `lookup.SubstrateScheduleDef` (read), `scheduler.scheduleDef` (fire) — plus `config.ScheduledRun`, `ToConfigDef`, `staticToMergedScheduleDef`, the fork overlay, and the `scheduledef` tool schema. **The lookup drift guard caught the missing `want` entries**, which is what it is for.

## Two commits

1. **`refactor(scheduler)`** — pure extraction, no behaviour change: `fireOne`'s tail (advance `next_run_at`, record the result, apply `max_fires`) becomes `recordFireOutcome`. A fire that skips either half re-presents on the next tick or never retires, so the new fire kind must not reimplement it.
2. **`feat(scheduler)`** — the delivery itself.

## Tested

`go test ./...` clean (**100 packages**, full output grepped for `FAIL`).

- **scheduler** — a due channel def publishes a tick and `RunOnce` is called **zero** times (the count is the assertion: the old way to reach a channel on a cron was to burn a run); the tick's shape, scope and metadata payload are checked; an undeclared channel is a recorded failure that still advances; `max_fires: 1` retires after one tick; a disabled channel schedule publishes nothing;
- **config** — a channel tick loads with no agent, and each run-shaped field is refused by name; a missing channel is refused; `delivery: run` still requires an agent and now refuses a stray channel; an unknown delivery is refused;
- **substrate** — a channel def round-trips through create → definition JSON, and the tool refuses the same seven mixes the yaml validator does.

**Verified fail-before:** disabling the fire branch fails the scheduler tests with `RunOnce calls = 1, want 0`; deleting one validator arm fails exactly its subtest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD