### PR TITLE
test(teamrun): pin that a variable crosses a state boundary, via Walk

### DIFF
--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -5763,12 +5763,6 @@ type subRunPrep struct {
 	cleanup   func()
 }
 
-// prepareSubRun does all sub-run setup shared by the synchronous spawn path and
-// the resident interactive path. fwd is the recording emit's forward sink (the
-// sync path passes a no-op; the interactive path passes a turn-capturer).
-// interactive=true means: pass a nil provider slot to fallbackForRun (a parked
-// resident child, like a top-level interactive run, must not swap/hold the
-// provider gate across turns) — everything else is identical.
 // composeSubRunSegments builds a sub-run's input segments: the agent's own
 // system_prompt (with cache_control), then an optional caller-supplied system
 // segment, then the prompt as the first user message. Mirrors the shape of
@@ -5823,6 +5817,12 @@ func composeSubRunSegments(agentSystemPrompt, systemExtra, prompt string) []loop
 	})
 }
 
+// prepareSubRun does all sub-run setup shared by the synchronous spawn path and
+// the resident interactive path. fwd is the recording emit's forward sink (the
+// sync path passes a no-op; the interactive path passes a turn-capturer).
+// interactive=true means: pass a nil provider slot to fallbackForRun (a parked
+// resident child, like a top-level interactive run, must not swap/hold the
+// provider gate across turns) — everything else is identical.
 func (s *Server) prepareSubRun(ctx context.Context, name, systemExtra, prompt, defID string, interactive bool, fwd func(providers.Event)) (*subRunPrep, error) {
 	return s.prepareSubRunValues(ctx, name, systemExtra, prompt, defID, interactive, fwd, nil)
 }

--- a/internal/teamgraph/graph.go
+++ b/internal/teamgraph/graph.go
@@ -76,7 +76,7 @@ type State struct {
 
 // Handler is the "who acts" for a state.
 type Handler struct {
-	Kind string `json:"kind"` // agent | parallel | consolidator | terminal
+	Kind string `json:"kind"` // agent | parallel | consolidator | terminal | vars | input
 	// Agent — for kind=agent and kind=consolidator: the AgentDef name to run.
 	Agent string `json:"agent,omitempty"`
 	// Agents — for kind=parallel: the AgentDef names fanned out concurrently.

--- a/internal/teamrun/vars_test.go
+++ b/internal/teamrun/vars_test.go
@@ -200,3 +200,58 @@ func TestEnvFor_NowIsStableWithinAState(t *testing.T) {
 		t.Errorf("two ${now.unix} in one state disagreed: %q vs %q", task.Vars["a"], task.Vars["b"])
 	}
 }
+
+// The same assertion as TestVarsState_BoundValueTravelsToALaterStatesPrompt,
+// but through WALK rather than two direct RunHandler calls.
+//
+// Why both: the unit version proves the handler carries a variable between
+// invocations; this one proves the WALK hands every state the same *Task. If a
+// future edit made the walk copy or rebuild the task per state — an easy thing
+// to do while adding per-state bookkeeping — the unit test would still pass and
+// every variable would silently stop crossing a state boundary, which is the
+// whole point of the primitive.
+func TestWalk_VarsBoundInOneStateReachALaterStatesPrompt(t *testing.T) {
+	var got Prompt
+	r := varsRunner(func(_ context.Context, _ string, p Prompt, _ string) (string, error) {
+		got = p
+		return "reviewed", nil
+	})
+
+	review := agentState("reviewer")
+	review.ID = "review"
+	review.Handler.InputTemplate = "Review PR ${var.pr}."
+
+	d := teamgraph.Definition{
+		Entry: "stamp",
+		States: []teamgraph.State{
+			varsState(map[string]string{"pr": "42"}),
+			review,
+			{ID: "done", Handler: teamgraph.Handler{Kind: teamgraph.HandlerTerminal}},
+		},
+		Transitions: []teamgraph.Transition{
+			{From: "stamp", To: "review", On: teamgraph.OnSuccess},
+			{From: "review", To: "done", On: teamgraph.OnSuccess},
+		},
+	}
+	if err := teamgraph.Validate(d); err != nil {
+		t.Fatalf("the fixture graph must be valid: %v", err)
+	}
+
+	task := &Task{Input: "start", State: "stamp"}
+	trace, err := Walk(context.Background(), d, task, r)
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	if len(trace) != 2 {
+		t.Fatalf("trace = %d steps, want 2 (stamp, review)", len(trace))
+	}
+	if got.Values["var.pr"] != "42" {
+		t.Errorf("values[var.pr] = %q, want 42 — the variable did not cross the state boundary", got.Values["var.pr"])
+	}
+	if got.Input != "Review PR ${var.pr}." {
+		t.Errorf("input = %q, want the RAW template (expansion happens at prompt assembly)", got.Input)
+	}
+	if task.Vars["pr"] != "42" {
+		t.Errorf("task.Vars[pr] = %q after the walk, want 42", task.Vars["pr"])
+	}
+}


### PR DESCRIPTION
Three small findings from the RFC CY review pass — the leftovers after the one real defect (#1182).

1. **The cross-state guarantee was tested one level too low.** A variable bound in one state reaching a later state's prompt is *the whole point* of the primitive, and the existing test proves it by calling `RunHandler` twice on one `Task` — which shows the **handler** carries it, not that the **walk** hands every state the same `*Task`. A future edit that copied or rebuilt the task per state (easy to do while adding per-state bookkeeping) would leave that test green while every variable silently stopped crossing a boundary. Now walked end to end: `vars → agent → terminal`, asserting both the spawned prompt's `Values` and the task's own `Vars`.

2. **`prepareSubRun`'s doc comment was orphaned.** Extracting `composeSubRunSegments` inserted it between `prepareSubRun`'s comment and its body, so godoc attached the whole block to `composeSubRunSegments` — and `prepareSubRun`, the function that actually needs explaining because of the interactive/provider-slot subtlety, was left undocumented.

3. **`Handler.Kind`'s enum comment lost `vars | input`** when L2 added them. The validator's error message lists them; the field a reader looks at first did not.

`go test ./...` clean (100 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD