### PR TITLE
fix(channels): a bad release count is 400, not 500

### DIFF
--- a/internal/api/http/channels_admin.go
+++ b/internal/api/http/channels_admin.go
@@ -28,6 +28,7 @@ package http
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/denn-gubsky/loomcycle/internal/connector"
@@ -211,6 +212,20 @@ func (s *Server) handleChannelRelease(w http.ResponseWriter, r *http.Request) {
 			writeJSONError(w, http.StatusBadRequest, "invalid_body", "invalid request body: "+err.Error())
 			return
 		}
+	}
+	// A bad `count` is the CALLER's mistake, so answer 400 — writeChannelError's
+	// default arm is 500, which tells a caller the server broke and pages
+	// whoever watches 5xx. The Connector keeps its own guard for any future
+	// non-HTTP caller; this one exists to get the status right.
+	if body.Count < 0 {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request",
+			fmt.Sprintf("release: count must be >= 0 (0 means 1), got %d", body.Count))
+		return
+	}
+	if body.Count > maxChannelReleaseCount {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request",
+			fmt.Sprintf("release: count %d exceeds max %d", body.Count, maxChannelReleaseCount))
+		return
 	}
 	body.Channel = name // the path is authoritative, not the body
 	out, err := s.ReleaseChannel(r.Context(), body)

--- a/internal/api/http/channels_hold_test.go
+++ b/internal/api/http/channels_hold_test.go
@@ -281,14 +281,25 @@ func TestChannelRelease_WireAndToolCapsAgree(t *testing.T) {
 }
 
 // Over-cap is refused rather than silently clamped: a caller asking to release
-// a million is asking for something the hold was there to prevent, and
-// quietly doing a thousand of them is not the answer they wanted.
-func TestChannelHold_ReleaseOverCapIsRefused(t *testing.T) {
+// a million is asking for something the hold was there to prevent, and quietly
+// doing a thousand of them is not the answer they wanted.
+//
+// It is a 400, not a 500. Found by running the endpoint rather than testing it:
+// the refusal reached writeChannelError's default arm, which reports 500 — so a
+// caller's own typo read as "the server broke" and would page whoever watches
+// 5xx. A negative count is refused the same way; 0 keeps meaning "one".
+func TestChannelHold_ReleaseBadCountIs400(t *testing.T) {
 	srv, _, cleanup := channelHoldFixture(t)
 	defer cleanup()
-	rec := postJSON(t, srv, "/v1/_channels/gate/release", `{"count":100000}`)
-	if rec.Code == http.StatusOK {
-		t.Errorf("an over-cap release succeeded: %s", rec.Body.String())
+	for _, body := range []string{`{"count":100000}`, `{"count":-5}`} {
+		rec := postJSON(t, srv, "/v1/_channels/gate/release", body)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("release %s: status %d, want 400 (%s)", body, rec.Code, rec.Body.String())
+		}
+	}
+	// 0 is not a bad count — it is the default, and still releases one.
+	if rec := postJSON(t, srv, "/v1/_channels/gate/release", `{"count":0}`); rec.Code != http.StatusOK {
+		t.Errorf("release count:0 → status %d, want 200 (%s)", rec.Code, rec.Body.String())
 	}
 }
 


### PR DESCRIPTION
**Follow-up to #1180 — this commit missed its merge window.** I pushed it to `feature-cy-channel-hold` while the PR was being squashed, so the squash took the head as it stood (three commits) and this fourth one never reached `main`. Same shape as the #1171 → #1172 carry-over; the code is unchanged from what was on that branch.

## The defect

Found by **running** the endpoint rather than testing it. An over-cap `count` on `POST /v1/_channels/{name}/release` fell through to `writeChannelError`'s default arm, which answers **500** — so a caller's own typo read as "the server broke" and would page whoever watches 5xx.

The handler now answers **400** for a count above the cap or below zero, with the bound in the message. `0` still means one: it is the omitted-field default, not a bad value. The Connector keeps its own guard for any future non-HTTP caller; this check exists to get the status right on the surface that has one.

## Verified live

On a throwaway instance with a yaml-declared `hold: true` channel:

```
over-cap 400 · negative 400 · zero 200 · undeclared 404
```

`go test ./...` clean on current `main` (100 packages, full output grepped for `FAIL`), plus the regression test that pins all three cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD