### PR TITLE
fix(channels): every writer that resolves a channel def honours its hold

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -2945,6 +2945,7 @@ func main() {
 				Scope:       def.Scope,
 				DefaultTTL:  def.DefaultTTL,
 				MaxMessages: def.MaxMessages,
+				Hold:        def.Hold,
 			}, true
 		})
 		// RFC BL P2 consolidation fan-out: the provider resolver decides

--- a/internal/api/webhook/oncomplete.go
+++ b/internal/api/webhook/oncomplete.go
@@ -111,9 +111,14 @@ func (rec *Receiver) dispatchOnCompleteChannelPublish(ctx context.Context, name,
 // (operator-global, so every tenant sees it), then the tenant's runtime row.
 //
 // A store fault answers false: an unreachable definition plane must not start
-// holding a channel nobody declared held. Mirrors (*http.Server).ChannelHeld,
-// which the in-process publishers use; the receiver has its own because it
-// holds a narrow store interface rather than the server.
+// holding channels nobody declared held. The choice is nearly moot in practice
+// — the publish on the next line uses the SAME store, so a fault here means the
+// message is not written either — and "don't invent a hold" is the safer
+// default for a transient error. A yaml-declared hold never touches the store
+// at all.
+//
+// Mirrors (*http.Server).ChannelHeld, which the in-process publishers use; the
+// receiver has its own because it holds a narrow store interface, not a server.
 func (rec *Receiver) channelHeld(ctx context.Context, tenantID, channel string) bool {
 	if rec.cfg != nil {
 		if def, ok := rec.cfg.Channels[channel]; ok {

--- a/internal/api/webhook/oncomplete.go
+++ b/internal/api/webhook/oncomplete.go
@@ -93,11 +93,41 @@ func (rec *Receiver) dispatchOnCompleteChannelPublish(ctx context.Context, name,
 		PublishedAt:       rec.now(),
 		PublishedByUserID: userID,
 	}
-	// maxMessages = 0 means use the store's default cap (operator sizing is a
-	// per-channel cfg concern the publish path doesn't see), mirroring the
-	// scheduler.
+	// A HELD channel stores the hook's message without delivering it, like every
+	// other write to that channel. The rest of the definition — max_messages,
+	// default_ttl, the declared scope — is still not consulted here (this path
+	// has always passed 0 and derived the scope from the user id); widening that
+	// moves where existing messages LAND, which is a separate change. A hold is
+	// not: honouring it can only withhold a message the operator asked to be
+	// withheld.
+	if rec.channelHeld(ctx, tenantID, h.Channel) {
+		msg.VisibleAt = store.ChannelHeldVisibleAt()
+	}
 	_, _, err = rec.store.ChannelPublish(ctx, msg, 0)
 	return err
+}
+
+// channelHeld reports whether a channel is declared `hold:` — yaml first
+// (operator-global, so every tenant sees it), then the tenant's runtime row.
+//
+// A store fault answers false: an unreachable definition plane must not start
+// holding a channel nobody declared held. Mirrors (*http.Server).ChannelHeld,
+// which the in-process publishers use; the receiver has its own because it
+// holds a narrow store interface rather than the server.
+func (rec *Receiver) channelHeld(ctx context.Context, tenantID, channel string) bool {
+	if rec.cfg != nil {
+		if def, ok := rec.cfg.Channels[channel]; ok {
+			return def.Hold
+		}
+	}
+	if rec.store == nil {
+		return false
+	}
+	row, err := rec.store.ChannelGet(ctx, tenantID, channel)
+	if err != nil {
+		return false
+	}
+	return row.Hold
 }
 
 // dispatchOnCompleteMemorySet mirrors scheduler.dispatchMemorySet. agent

--- a/internal/api/webhook/server_test.go
+++ b/internal/api/webhook/server_test.go
@@ -473,6 +473,9 @@ type fakeWebhookStore struct {
 	channelPublishes []store.ChannelMessage
 	memorySets       []memorySetCall
 
+	// heldChannels marks runtime-declared `hold: true` channels for ChannelGet.
+	heldChannels map[string]bool
+
 	// askedTenants records every tenant passed to WebhookDefGetActive (RFC N).
 	// Lets the URL-tenant route test assert the receiver threaded the
 	// URL-derived tenant into the resolver.
@@ -509,6 +512,18 @@ func (f *fakeWebhookStore) ChannelPublish(_ context.Context, msg store.ChannelMe
 	defer f.mu.Unlock()
 	f.channelPublishes = append(f.channelPublishes, msg)
 	return "msg-1", 0, nil
+}
+
+// heldChannels names the RUNTIME-declared channels this fake reports as
+// `hold: true`; anything else is not-found, the same answer a real store gives
+// for a yaml-only or undeclared channel.
+func (f *fakeWebhookStore) ChannelGet(_ context.Context, _, name string) (store.ChannelRow, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.heldChannels[name] {
+		return store.ChannelRow{Name: name, Hold: true}, nil
+	}
+	return store.ChannelRow{}, &store.ErrNotFound{Kind: "channel", ID: name}
 }
 
 func (f *fakeWebhookStore) MemorySet(_ context.Context, _ string, scope store.MemoryScope, scopeID, key string, value json.RawMessage, _ time.Duration) error {
@@ -684,6 +699,10 @@ func (s *raceStore) RunByIdempotencyKey(_ context.Context, key string) (store.Ru
 
 // ChannelPublish + MemorySet satisfy lookup.WebhookStore (WH-5b). The race
 // tests never declare on_complete hooks, so no-ops suffice.
+func (s *raceStore) ChannelGet(_ context.Context, _, name string) (store.ChannelRow, error) {
+	return store.ChannelRow{}, &store.ErrNotFound{Kind: "channel", ID: name}
+}
+
 func (s *raceStore) ChannelPublish(_ context.Context, _ store.ChannelMessage, _ int) (string, int, error) {
 	return "", 0, nil
 }

--- a/internal/api/webhook/wh5b_test.go
+++ b/internal/api/webhook/wh5b_test.go
@@ -350,3 +350,86 @@ func TestReceiver_Test_BadSig_WouldAcceptFalse(t *testing.T) {
 		t.Fatal("dry-run /test must NOT invoke the runner even on bad sig")
 	}
 }
+
+// A webhook's on_complete channel.publish honours a HELD channel: the message
+// is stored at the reserved instant and delivered to nobody until a release.
+//
+// This path resolves the channel definition (now), so it owes the definition
+// the same obedience every other writer does — a breakpoint with one writer
+// that walks past it is not a breakpoint. Both declaration sources are covered:
+// operator yaml here, and a runtime-declared row below.
+func TestReceiver_OnCompleteChannelPublish_HonoursAHold(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		channels map[string]config.Channel
+		held     map[string]bool
+	}{
+		{"yaml-declared", map[string]config.Channel{"results": {Scope: "global", Hold: true}}, nil},
+		{"runtime-declared", nil, map[string]bool{"results": true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			secret := "shhh"
+			now := time.Unix(1_700_000_000, 0)
+			body := []byte(`{"goal":"do it","user":"u-7"}`)
+
+			wh := config.Webhook{
+				Enabled:        true,
+				Delivery:       "spawn",
+				Agent:          "researcher",
+				Auth:           config.WebhookAuth{Kind: "hmac", Header: "X-Hub-Signature-256", SigningSecretEnv: "WH_SECRET"},
+				PayloadMapping: map[string]string{"goal": "$.goal", "user_id": "$.user"},
+				OnComplete: []config.ScheduledRunHook{
+					{Kind: "channel.publish", Channel: "results"},
+				},
+			}
+			fr := &fakeRunner{runID: "run-1", agentID: "agent-1"}
+			st := &fakeWebhookStore{existing: map[string]store.Run{}, heldChannels: tc.held}
+			rec := newTestReceiverWithStore(t, map[string]config.Webhook{"gh": wh}, fr, st,
+				map[string]string{"WH_SECRET": secret}, []string{"WH_SECRET"}, now)
+			rec.cfg.Channels = tc.channels
+
+			h := http.Header{}
+			h.Set("X-Hub-Signature-256", githubSig(secret, body))
+			if w := doPost(rec, "gh", body, h); w.Code != http.StatusAccepted {
+				t.Fatalf("status = %d, want 202; body=%s", w.Code, w.Body.String())
+			}
+
+			cp, _ := waitForHooks(t, st, 1, 0)
+			if !store.IsChannelHeld(cp[0].VisibleAt) {
+				t.Errorf("visible_at = %v, want the reserved held instant — the hook walked past the hold",
+					cp[0].VisibleAt)
+			}
+		})
+	}
+}
+
+// The control: an ordinary channel is unaffected — no held instant, so the
+// message delivers as it always has.
+func TestReceiver_OnCompleteChannelPublish_UnheldChannelIsUnchanged(t *testing.T) {
+	secret := "shhh"
+	now := time.Unix(1_700_000_000, 0)
+	body := []byte(`{"goal":"do it","user":"u-7"}`)
+
+	wh := config.Webhook{
+		Enabled:        true,
+		Delivery:       "spawn",
+		Agent:          "researcher",
+		Auth:           config.WebhookAuth{Kind: "hmac", Header: "X-Hub-Signature-256", SigningSecretEnv: "WH_SECRET"},
+		PayloadMapping: map[string]string{"goal": "$.goal", "user_id": "$.user"},
+		OnComplete:     []config.ScheduledRunHook{{Kind: "channel.publish", Channel: "results"}},
+	}
+	fr := &fakeRunner{runID: "run-1", agentID: "agent-1"}
+	st := &fakeWebhookStore{existing: map[string]store.Run{}}
+	rec := newTestReceiverWithStore(t, map[string]config.Webhook{"gh": wh}, fr, st,
+		map[string]string{"WH_SECRET": secret}, []string{"WH_SECRET"}, now)
+
+	h := http.Header{}
+	h.Set("X-Hub-Signature-256", githubSig(secret, body))
+	if w := doPost(rec, "gh", body, h); w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202", w.Code)
+	}
+	cp, _ := waitForHooks(t, st, 1, 0)
+	if store.IsChannelHeld(cp[0].VisibleAt) {
+		t.Errorf("an undeclared channel was treated as held: %v", cp[0].VisibleAt)
+	}
+}

--- a/internal/lookup/webhook.go
+++ b/internal/lookup/webhook.go
@@ -29,6 +29,13 @@ type WebhookStore interface {
 	// interface unchanged; the webhook receiver only needs these two of
 	// the channel/memory surface.
 	ChannelPublish(ctx context.Context, msg store.ChannelMessage, maxMessages int) (id string, dropped int, err error)
+
+	// ChannelGet resolves a RUNTIME-declared channel so an on_complete
+	// channel.publish hook can honour its `hold:` — a held channel that a
+	// webhook hook wrote straight past would be a breakpoint with a hole in it.
+	// Signature matches store.Store, so store.Store still satisfies this
+	// interface unchanged.
+	ChannelGet(ctx context.Context, tenantID, name string) (store.ChannelRow, error)
 	MemorySet(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string, value json.RawMessage, ttl time.Duration) error
 }
 

--- a/internal/lookup/webhook.go
+++ b/internal/lookup/webhook.go
@@ -23,18 +23,14 @@ type WebhookStore interface {
 	// means no prior run — proceed with the spawn.
 	RunByIdempotencyKey(ctx context.Context, key string) (store.Run, bool, error)
 
-	// ChannelPublish + MemorySet back the WH-5b on_complete hooks (the
-	// receiver MIRRORS the scheduler's dispatch rather than importing it).
+	// ChannelPublish + ChannelGet + MemorySet back the WH-5b on_complete hooks
+	// (the receiver MIRRORS the scheduler's dispatch rather than importing it).
+	// ChannelGet is what lets the channel.publish hook honour a `hold:` — a
+	// held channel one writer walks past is a breakpoint with a hole in it.
 	// Signatures match store.Store exactly so store.Store satisfies this
-	// interface unchanged; the webhook receiver only needs these two of
-	// the channel/memory surface.
+	// interface unchanged; the receiver needs only these three of the
+	// channel/memory surface.
 	ChannelPublish(ctx context.Context, msg store.ChannelMessage, maxMessages int) (id string, dropped int, err error)
-
-	// ChannelGet resolves a RUNTIME-declared channel so an on_complete
-	// channel.publish hook can honour its `hold:` — a held channel that a
-	// webhook hook wrote straight past would be a breakpoint with a hole in it.
-	// Signature matches store.Store, so store.Store still satisfies this
-	// interface unchanged.
 	ChannelGet(ctx context.Context, tenantID, name string) (store.ChannelRow, error)
 	MemorySet(ctx context.Context, tenantID string, scope store.MemoryScope, scopeID, key string, value json.RawMessage, ttl time.Duration) error
 }

--- a/internal/lookup/webhook_test.go
+++ b/internal/lookup/webhook_test.go
@@ -45,6 +45,10 @@ func (s *stubWebhookStore) ChannelPublish(_ context.Context, _ store.ChannelMess
 	return "", 0, nil
 }
 
+func (s *stubWebhookStore) ChannelGet(_ context.Context, _, name string) (store.ChannelRow, error) {
+	return store.ChannelRow{}, &store.ErrNotFound{Kind: "channel", ID: name}
+}
+
 func (s *stubWebhookStore) MemorySet(_ context.Context, _ string, _ store.MemoryScope, _, _ string, _ json.RawMessage, _ time.Duration) error {
 	return nil
 }

--- a/internal/scheduler/channel_delivery_test.go
+++ b/internal/scheduler/channel_delivery_test.go
@@ -212,3 +212,42 @@ func TestScheduler_UnknownDeliveryDoesNotFallThroughToARun(t *testing.T) {
 		t.Errorf("last_status = %q, want decode_def", state.LastStatus)
 	}
 }
+
+// A tick to a HELD channel is stored and NOT delivered. Found by running the
+// two features together: the tick wrote straight through the store, bypassing
+// the publisher where the hold is enforced, so a cron walked past a breakpoint.
+func TestScheduler_ChannelDeliveryHonoursAHold(t *testing.T) {
+	enabled := true
+	def := scheduleDef{
+		Delivery: "channel",
+		Channel:  "wave-in",
+		Schedule: "0 * * * *",
+		Enabled:  &enabled,
+	}
+	sched, _, _, _, st := schedulerFixture(t, def, time.Now().Add(-1*time.Minute))
+	sched.SetChannelScope(func(context.Context, string) (DeclaredChannel, bool) {
+		return DeclaredChannel{Scope: "global", Hold: true}, true
+	})
+
+	fireT(t, sched)
+
+	msgs, _, err := st.ChannelSubscribe(context.Background(), "", "wave-in", store.MemoryScopeGlobal, "", "", 10)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Fatalf("a held channel delivered the tick: %d messages", len(msgs))
+	}
+	// Stored, not lost: releasing hands it over.
+	released, held, err := st.ChannelRelease(context.Background(), "", "wave-in", store.MemoryScopeGlobal, "", 1)
+	if err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	if len(released) != 1 || held != 0 {
+		t.Fatalf("release gave %d leaving %d, want 1 leaving 0 — the tick was not held, it was lost", len(released), held)
+	}
+	msgs, _, _ = st.ChannelSubscribe(context.Background(), "", "wave-in", store.MemoryScopeGlobal, "", "", 10)
+	if len(msgs) != 1 {
+		t.Errorf("after release, %d delivered, want 1", len(msgs))
+	}
+}

--- a/internal/scheduler/dispatch.go
+++ b/internal/scheduler/dispatch.go
@@ -92,6 +92,9 @@ func (s *Scheduler) dispatchChannelPublish(ctx context.Context, scheduleName, us
 	if target.DefaultTTL > 0 {
 		msg.ExpiresAt = now.Add(time.Duration(target.DefaultTTL) * time.Second)
 	}
+	if target.Hold {
+		msg.VisibleAt = store.ChannelHeldVisibleAt()
+	}
 	_, _, err = s.store.ChannelPublish(ctx, msg, target.MaxMessages)
 	return err
 }
@@ -122,7 +125,7 @@ func (s *Scheduler) resolvePublishTarget(ctx context.Context, channel, userID, a
 	if !ok {
 		return publishTarget{}, fmt.Errorf("channel.publish: channel %q is not declared (static yaml or runtime substrate)", channel)
 	}
-	out := publishTarget{DefaultTTL: declared.DefaultTTL, MaxMessages: declared.MaxMessages}
+	out := publishTarget{DefaultTTL: declared.DefaultTTL, MaxMessages: declared.MaxMessages, Hold: declared.Hold}
 	switch declared.Scope {
 	case "global":
 		out.Scope = store.MemoryScopeGlobal
@@ -154,6 +157,7 @@ type publishTarget struct {
 	ScopeID     string
 	DefaultTTL  int
 	MaxMessages int
+	Hold        bool
 }
 
 func (s *Scheduler) dispatchMemorySet(ctx context.Context, scheduleName, userID, tenantID string, h scheduleHook) error {

--- a/internal/scheduler/dispatch_test.go
+++ b/internal/scheduler/dispatch_test.go
@@ -142,3 +142,34 @@ func TestScheduler_OnCompleteChannelPublish_LegacyNilResolver(t *testing.T) {
 		t.Errorf("legacy user/alice message count = %d, want 1", got)
 	}
 }
+
+// An on_complete channel.publish hook honours a hold too — it resolves the
+// channel definition, so it owes the definition the same obedience the tick
+// does. Without this a completed run would walk past the same breakpoint.
+func TestDispatchChannelPublish_HonoursAHold(t *testing.T) {
+	sched, _, _, _, st := schedulerFixture(t, channelHookDef("done"), time.Now().Add(time.Hour))
+	sched.SetChannelScope(func(context.Context, string) (DeclaredChannel, bool) {
+		return DeclaredChannel{Scope: "global", Hold: true}, true
+	})
+
+	err := sched.dispatchOneHook(context.Background(), "sched", "", "researcher", "",
+		scheduleHook{Kind: "channel.publish", Channel: "done"}, "r_1", "a_1")
+	if err != nil {
+		t.Fatalf("hook: %v", err)
+	}
+
+	msgs, _, err := st.ChannelSubscribe(context.Background(), "", "done", store.MemoryScopeGlobal, "", "", 10)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Fatalf("a held channel delivered the hook message: %d", len(msgs))
+	}
+	released, _, err := st.ChannelRelease(context.Background(), "", "done", store.MemoryScopeGlobal, "", 1)
+	if err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	if len(released) != 1 {
+		t.Errorf("released %d, want the held hook message", len(released))
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -156,6 +156,12 @@ type DeclaredChannel struct {
 	Scope       string // "global" | "user" | "agent"
 	DefaultTTL  int    // seconds; 0 = no TTL
 	MaxMessages int    // 0 = unbounded
+	// Hold is the breakpoint: the message is STORED at the reserved instant and
+	// delivered to nobody until someone releases it. A scheduler write has to
+	// honour it for the same reason it honours the scope — it resolved the
+	// definition, and a definition half-honoured is a setting the operator
+	// believes they made.
+	Hold bool
 }
 
 // ChannelScopeResolver returns the DECLARED shape of a channel by name.
@@ -518,6 +524,12 @@ func (s *Scheduler) publishTick(ctx context.Context, scheduleName string, def sc
 	}
 	if target.DefaultTTL > 0 {
 		msg.ExpiresAt = now.Add(time.Duration(target.DefaultTTL) * time.Second)
+	}
+	// A held channel stores the tick without delivering it — the cadence signal
+	// waits for a release. Without this a cron tick would walk straight past a
+	// breakpoint, which is exactly the pairing the two features exist for.
+	if target.Hold {
+		msg.VisibleAt = store.ChannelHeldVisibleAt()
 	}
 	_, _, err = s.store.ChannelPublish(ctx, msg, target.MaxMessages)
 	return err

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -233,6 +233,7 @@ func Run(t *testing.T, factory Factory) {
 		{"ChannelHoldRoundTripsOnTheDefinition", testChannelHoldRoundTripsOnTheDefinition},
 		{"ChannelReleaseHandsOverOldestFirst", testChannelReleaseHandsOverOldestFirst},
 		{"ChannelReleaseSkipsExpiredHeld", testChannelReleaseSkipsExpiredHeld},
+		{"ChannelHoldSurvivesASnapshotRoundTrip", testChannelHoldSurvivesASnapshotRoundTrip},
 		// v0.8.6 deferred publish (PR 1)
 		{"ChannelDeferredHiddenUntilVisible", testChannelDeferredHiddenUntilVisible},
 		{"ChannelDeferredDeliversAfterProgressedCursor", testChannelDeferredDeliversAfterProgressedCursor},
@@ -6007,6 +6008,61 @@ func testChannelReleaseHandsOverOldestFirst(t *testing.T, s store.Store) {
 	}
 	if len(released) != 0 || stillHeld != 0 {
 		t.Errorf("release on a drained queue reported %d/%d, want 0/0", len(released), stillHeld)
+	}
+}
+
+// testChannelHoldSurvivesASnapshotRoundTrip pins the one path that could
+// silently RELEASE every held message: snapshot restore is the only writer
+// that sets visible_at from a caller-supplied value without clamping, so if it
+// ever normalised the instant the way ChannelPublish clamps a past one, an
+// operator restoring a snapshot would find every breakpoint opened.
+//
+// Snapshotting a paused workflow and bringing it up elsewhere is exactly when
+// an operator is relying on the hold still being there.
+func testChannelHoldSurvivesASnapshotRoundTrip(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	if _, _, err := s.ChannelPublish(ctx, store.ChannelMessage{
+		Channel: "ch-snap", Scope: store.MemoryScopeAgent, ScopeID: "x",
+		Payload:   json.RawMessage(`"held"`),
+		VisibleAt: store.ChannelHeldVisibleAt(),
+	}, 0); err != nil {
+		t.Fatalf("publish held: %v", err)
+	}
+	rows, err := s.SnapshotReadChannelMessages(ctx)
+	if err != nil {
+		t.Fatalf("snapshot read: %v", err)
+	}
+	var held store.ChannelMessage
+	for _, r := range rows {
+		if r.Channel == "ch-snap" {
+			held = r
+		}
+	}
+	if held.ID == "" {
+		t.Fatalf("the held message is missing from the snapshot — a hold must not make it unexportable")
+	}
+	if !store.IsChannelHeld(held.VisibleAt) {
+		t.Fatalf("the export lost the held instant: %v", held.VisibleAt)
+	}
+
+	// Restore it under a fresh id, as a restore onto another deployment would.
+	held.ID = "msg_restored0000000000000000"
+	if _, err := s.SnapshotRestoreChannelMessage(ctx, held); err != nil {
+		t.Fatalf("snapshot restore: %v", err)
+	}
+	msgs, _, err := s.ChannelSubscribe(ctx, "", "ch-snap", store.MemoryScopeAgent, "x", "", 10)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Fatalf("restore released %d held message(s) — the breakpoint opened itself", len(msgs))
+	}
+	released, _, err := s.ChannelRelease(ctx, "", "ch-snap", store.MemoryScopeAgent, "x", 10)
+	if err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	if len(released) != 2 {
+		t.Errorf("released %d, want 2 (the original and the restored copy)", len(released))
 	}
 }
 


### PR DESCRIPTION
#1180 shipped the hold with the claim that putting the check in `StorePublisher` makes every internal publish path honour it — *"a promise enforced at five call sites is a promise the sixth one breaks."* Then #1181 added a sixth writer that doesn't go through the publisher, and it broke exactly that way.

## How it was found

By running the two features **together**, which is the pairing they exist for: a cron tick into a `hold: true` channel — cadence arrives, the workflow waits for a human.

```
peek after the tick → {"messages":[ …the tick… ]}     # delivered immediately
release             → {"released":[],"still_held":0}  # nothing was ever held
```

The scheduler writes via `store.ChannelPublish` directly, so `HoldFn` never ran. Neither unit tests nor either PR's own live check could see it: each feature was correct alone.

## The fix

Four writers reach the store without the publisher. **Two resolve the channel definition** and therefore owe it obedience:

- the scheduler's `delivery: channel` tick (the regression), and
- the scheduler's `on_complete: channel.publish` — same gap, older than this line.

Both already learn scope and retention from `ChannelScopeResolver`, so hold rides the same lookup: `DeclaredChannel` gains `Hold`, and a held target writes the reserved `visible_at`.

The **webhook's `on_complete: channel.publish`** is the third. It resolved nothing, so `lookup.WebhookStore` gains `ChannelGet` (`store.Store` already satisfies it) and the receiver gets the yaml-then-runtime resolution `(*http.Server).ChannelHeld` uses.

**The rule, now true: a writer either resolves the channel definition or honours nothing from it.** The webhook hook still doesn't consult `max_messages`, TTL or the declared scope — widening *that* moves where existing messages land, which is a separate change with its own blast radius. A hold is not: honouring it can only withhold a message the operator asked to be withheld.

The fourth writer is Document's change-event ring, which publishes to a **synthetic** name (`documents/<id>/chunks`) no operator can declare. An undeclared channel has no definition to honour, so there's nothing to fix.

## Tested

`go test ./...` clean (**100 packages**, full output grepped for `FAIL`).

- **scheduler** — a tick to a held channel delivers nothing *and is releasable* (stored, not lost); an `on_complete` hook likewise;
- **webhook** — the hook honours a hold from operator yaml **and** from a runtime-declared row, with an unheld channel as the control.

**Verified live**, the same way the bug was found: the cron tick now peeks **empty** after firing, and one release hands over the cadence signal with `still_held: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD