### PR TITLE
docs(channels): hold is an operator gate, not the workflow debugger

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -585,7 +585,9 @@ A schedule's **delivery** decides what a tick does. The default (`delivery: run`
 
 A fired schedule's `on_complete` hooks deliver results through one of three kinds (`internal/scheduler/dispatch.go`): `channel.publish`, `memory.set`, or `mcp.call`. Schedules resolve MCP-tool bearers via `user_credentials_from_env` against the operator's `EnvAllowlist` — the same RFC F credential mechanism, not a parallel one. Persisted in the `schedule_defs` table (migration `0029`).
 
-References: `internal/scheduler/scheduler.go` (sweeper, `tick`, `fireOne`, `fireChannelDelivery`), `internal/scheduler/dispatch.go` (`on_complete` kinds), `internal/tools/builtin/scheduledef.go`, `internal/config/config.go` (`ScheduledRun`).
+Both scheduler writes to a channel — the tick and the `on_complete` hook — resolve the channel's **declaration** through an injected `ChannelScopeResolver` and honour all of it: the declared scope (F37/RFC T), `default_ttl`, `max_messages`, and `hold:`. That matters most at cron cadence, where a write that ignored retention would accumulate half a million rows a year on a channel whose operator did set limits, and where a write that ignored a hold would walk a workflow straight past its breakpoint.
+
+References: `internal/scheduler/scheduler.go` (sweeper, `tick`, `fireOne`, `fireChannelDelivery`, `recordFireOutcome`), `internal/scheduler/dispatch.go` (`on_complete` kinds, `resolvePublishTarget`), `internal/tools/builtin/scheduledef.go`, `internal/config/config.go` (`ScheduledRun`).
 
 ## Multi-replica HA (v0.12.0→v0.12.6)
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -888,6 +888,8 @@ POST /v1/_channels/review-queue/release   { "count": 1 }
   → { "channel": "review-queue", "released": ["msg_..."], "released_count": 1, "still_held": 2 }
 ```
 
+A bad `count` (above the cap of 1000, or negative) is a 400; `0` means one. An undeclared channel is a 404, as on every other channel route.
+
 What a hold does **not** change:
 
 - **TTL still counts from publish time.** An expired held message is never released and never delivered — holding is not a way to outlive the retention its publisher declared.
@@ -897,6 +899,10 @@ What a hold does **not** change:
 `release` is gated by the **publish** allowlist rather than subscribe: releasing is the act of making a message deliverable — the half of a publish the hold deferred — so the question is whether the agent may put messages on this channel, not whether it may read them. `_system/` channels are released through the admin endpoint, like every other write to one.
 
 Releasing a channel with nothing held reports zero rather than failing, and a channel switched back to `hold: false` can still release what it holds — turning the breakpoint off does not flush the queue.
+
+**Every writer that resolves the channel definition honours the hold**, which is more than the in-band tool: the admin/connector publish path, the scheduler's `delivery: channel` tick and its `on_complete: channel.publish` hook, and a webhook's `on_complete` hook. Internal publishers that go through the system publisher (heartbeats, interrupts, the inbound webhook relay) are covered by one check inside it. The rule that decides new cases: *a writer either resolves the channel definition or honours nothing from it.*
+
+A held message is marked by a reserved far-future `visible_at`, so it survives a snapshot round trip still held — restoring a snapshotted workflow does not open its breakpoints. The channel listing reports `hold: true` and suppresses that reserved instant rather than printing it as a delivery time.
 
 ### Delivery semantics
 


### PR DESCRIPTION
Two commits, both docs-only — no behaviour change.

## 1. Carry the corrections back from the store

The doc store is the primary copy and these pages are exports of it, so the store was updated first. This carries back the three paragraphs it gained: the release endpoint's status codes (400 for a bad `count` since #1185, 404 for an undeclared channel), **which writers honour a hold** and the rule that decides the next one (#1186), and that a hold survives a snapshot round trip while the listing suppresses the reserved instant. Plus the scheduler's side in `ARCHITECTURE.md`.

## 2. `hold` is an operator gate on a wire, not the workflow debugger

It shipped described as a breakpoint for single-stepping a workflow. It is not the right tool for that, and saying so in fifteen places invites someone to build the canvas debugger on it.

**Why it's the wrong tool** — it stalls the channel for *every* reader in the tenant, not just the workflow being debugged; it cannot show the **prompt** an agent received, because a prompt never travels on a channel; and a held message is unreadable by design, so releasing is blind.

**What it is good for**, which the docs now lead with: stop a channel *now* — a misbehaving producer, an incident, a consumer to keep away from a backlog while someone looks at it — without deleting anything and without editing the producer. Applying to every reader is the **point**: it's a property of the wire.

Narrowed everywhere it was oversold: the yaml field doc (an operator's first read), the in-band tool `Description` and the MCP schema (both model-visible), the store/connector/handler comments, the TS adapter types, the Web UI checkbox and help text, and both markdown pages. The TOOLS section is retitled from "Breakpoints" to "Holding a channel".

The workflow debugger belongs on the node that *reads* a channel and dispatches work — RFC CY's **Decision 4 amendment** records that design (Starter breakpoints, `before_dispatch` / `after_collection`, breakpoints as a run argument, wave correlation on `ParentContext`). This PR only stops the shipped feature from claiming the job.

### The migration comment

`0075_channels_hold.up.sql`'s header is reworded. Safe, and checked rather than assumed: golang-migrate's version table is `(version bigint primary key, dirty boolean)` — **no checksum column** — and re-running migrations over an already-migrated database with the edited file is clean (verified against a local Postgres 14).

### Not fixed here

`docs/TOOLS.md` is ~18 KB larger than its store document. The section structure matches (three cosmetic heading differences), so the divergence is body text the repo accumulated while the store didn't — a wholesale re-export would delete it. Both edits above are hand-synced deltas; reconciling the two properly is its own job.

## Tested

`go test ./...` clean (100 packages), TS typecheck + 296 adapter tests, `make build-ui` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD