### PR TITLE
fix(memory): a body rewrite must not erase a fact's provenance

### DIFF
--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -996,12 +996,38 @@ func (d *Document) writeBodyAs(ctx context.Context, mscope store.MemoryScope, ke
 	// structure never drift across the tenant axis.
 	tenant := direntTenant(ctx)
 	bodyKey := chunkBodyKey(chunkID)
-	if origin == "" {
+	// A BODY REWRITE NEVER ERASES PROVENANCE. MemorySet delegates to
+	// MemorySetProvenance with the extra arguments zeroed, so a plain set over an
+	// existing row CLEARS its origin — verified, not assumed. That matters because
+	// the origin on a body row is now what distinguishes a fact from prose: without
+	// this, an operator editing a fact through update_chunk (which writes the body
+	// with no origin of its own) would strip the column and silently reclassify the
+	// fact as a document. The text would still be right; the fact would just stop
+	// being a fact.
+	//
+	// This is the same rule writeChunkMeta already applies to the sidecar — "an
+	// operator correcting a fact's wording must not strip the span it was derived
+	// from" — applied to the other half of the same fact. A caller that supplies an
+	// origin still wins; absence means "I have nothing to say about provenance",
+	// never "erase it".
+	//
+	// The whole provenance struct is carried, not just the origin, so a re-set does
+	// not clear class or the source ids either. The extra point read costs nothing
+	// next to the embedding call this function already makes.
+	prov := store.MemoryProvenance{Origin: origin}
+	if prev, perr := d.Store.MemoryProvenanceGet(ctx, tenant, mscope, scopeID, bodyKey); perr == nil {
+		if prov.Origin == "" {
+			prov.Origin = prev.Origin
+		}
+		prov.Class = prev.Class
+		prov.SourceSessionID = prev.SourceSessionID
+		prov.SourceRunID = prev.SourceRunID
+	}
+	if prov.Origin == "" && prov.Class == "" && prov.SourceSessionID == "" && prov.SourceRunID == "" {
 		if err := d.Store.MemorySet(ctx, tenant, mscope, scopeID, bodyKey, v, 0); err != nil {
 			return err
 		}
-	} else if err := d.Store.MemorySetProvenance(ctx, tenant, mscope, scopeID, bodyKey, v, 0,
-		store.MemoryProvenance{Origin: origin}); err != nil {
+	} else if err := d.Store.MemorySetProvenance(ctx, tenant, mscope, scopeID, bodyKey, v, 0, prov); err != nil {
 		return err
 	}
 	// The body is durable at this point. Embedding is a SEPARATE, best-effort

--- a/internal/tools/builtin/document_body_provenance_test.go
+++ b/internal/tools/builtin/document_body_provenance_test.go
@@ -1,6 +1,7 @@
 package builtin
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/denn-gubsky/loomcycle/internal/store"
@@ -70,5 +71,59 @@ func TestChunkBody_AFactCarriesItsOriginAndProseDoesNot(t *testing.T) {
 	}
 	if got := store.ClassifyMemoryRow("doc.chunk:"+proseID, proseProv.Origin, "doc.chunk:"); got != store.MemoryRowDocument {
 		t.Errorf("ordinary prose classifies as %q, want document", got)
+	}
+}
+
+// TestChunkBody_EditingAFactDoesNotStripItsProvenance is the defect a review pass
+// caught in the change above.
+//
+// update_chunk rewrites a body through the origin-less path, and a plain MemorySet
+// delegates to MemorySetProvenance with the extra arguments zeroed — so it CLEARS
+// the column. Once that column is what tells a fact from prose, an operator merely
+// correcting a fact's wording would silently reclassify it as a document, and
+// nothing would report it: the text would still be right, the fact would just stop
+// being a fact.
+func TestChunkBody_EditingAFactDoesNotStripItsProvenance(t *testing.T) {
+	d, ctx, st := documentFixture(t)
+	doc := newEntityDoc(t, d, ctx)
+
+	out, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+doc+`",
+		"natural_key":"memory/fact/denn-prefers-go","title":"Denn prefers Go",
+		"body":"Denn prefers Go for backend services.","type":"fact","subject":"Denn"}`)
+	if r.IsError {
+		t.Fatalf("upsert_chunk: %s", r.Text)
+	}
+	id := asStr(out["id"])
+	sk := sidecarScope(t, d, ctx)
+	tenant := direntTenant(ctx)
+
+	before, err := st.MemoryProvenanceGet(ctx, tenant, store.MemoryScopeUser, sk.ScopeID, "doc.chunk:"+id)
+	if err != nil || before.Origin == "" {
+		t.Fatalf("fixture: the fact's body row should carry an origin, got %+v (%v)", before, err)
+	}
+
+	// An ORDINARY EDIT, through the op an operator would actually use. update_chunk
+	// is optimistically concurrent, so it needs the current revision.
+	cur, r := docExec(t, d, ctx, `{"op":"get_chunk","scope":"user","id":"`+id+`"}`)
+	if r.IsError {
+		t.Fatalf("get_chunk: %s", r.Text)
+	}
+	rev, _ := cur["revision"].(float64)
+	if _, r := docExec(t, d, ctx, fmt.Sprintf(`{"op":"update_chunk","scope":"user","id":%q,
+		"revision":%d,"body":"Denn prefers Go for backend services, and Rust for tooling."}`,
+		id, int(rev))); r.IsError {
+		t.Fatalf("update_chunk: %s", r.Text)
+	}
+
+	after, err := st.MemoryProvenanceGet(ctx, tenant, store.MemoryScopeUser, sk.ScopeID, "doc.chunk:"+id)
+	if err != nil {
+		t.Fatalf("read back after the edit: %v", err)
+	}
+	if after.Origin != before.Origin {
+		t.Errorf("editing the fact changed its origin %q -> %q — a wording correction must not "+
+			"turn a fact into prose", before.Origin, after.Origin)
+	}
+	if got := store.ClassifyMemoryRow("doc.chunk:"+id, after.Origin, "doc.chunk:"); got != store.MemoryRowFact {
+		t.Errorf("after an ordinary edit the fact classifies as %q, want fact", got)
 	}
 }


### PR DESCRIPTION
**This is a bug currently live on `main`**, introduced by #1177 and found by the self-review pass on it. Split out of #1179 so it can land without waiting on that PR's merge ordering.

## Why

#1177 made a chunk-body row's `origin` load-bearing: it is now what distinguishes a distilled fact from document prose. Giving an existing column a new meaning is not an additive change — **every writer that does not supply it becomes a writer that destroys it.**

`update_chunk` rewrites a chunk body through the origin-less path, and `MemorySet` delegates to `MemorySetProvenance` with the extra arguments zeroed, so a plain set over an existing row **clears** the column. Verified against the store rather than assumed: origin after a plain set over a provenanced row reads `""`.

So an operator merely correcting a fact's wording silently reclassified it as prose. The text would still be right; the fact would just stop being a fact — dropping out of `sources=facts`, answering as a document, with nothing logged and no error.

## What

`writeBodyAs` preserves what it is not told. A caller that supplies an origin still wins; absence means "I have nothing to say about provenance", never "erase it".

This is the same rule `writeChunkMeta` already applies to the sidecar — *"an operator correcting a fact's wording must not strip the span it was derived from"* — applied to the other half of the same fact. The **whole** provenance struct is carried, not just the origin, so a re-set does not clear `class` or the source ids either. The extra point read costs nothing next to the embedding call the function already makes.

## What was tested

`TestChunkBody_EditingAFactDoesNotStripItsProvenance` edits through the op an operator would actually use (`update_chunk`, with its required revision), not through the internal helper.

Fail-before run against **current `main`'s** `document.go` rather than a synthetic revert, which is what establishes the bug is live and not hypothetical:

```
editing the fact changed its origin "operator" -> "" — a wording correction must not turn a fact into prose
after an ordinary edit the fact classifies as "document", want fact
```

`go test ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8