### PR TITLE
fix(memory): one fact must not be returned twice while it is dual-written

### DIFF
--- a/internal/memory/backend.go
+++ b/internal/memory/backend.go
@@ -217,12 +217,13 @@ func (q SearchQuery) Filter() (store.MemorySearchFilter, error) {
 		// makes this selector mean prose.
 		f.Provenance = store.ProvenanceAbsent
 	case facts && !notes:
-		// FACTS ARE WHEREVER PROVENANCE IS, with no namespace constraint. This used
-		// to exclude the chunk namespace, which was right only while a fact's home
-		// was its own k/v row and the chunk body was a duplicate of it. A fact homed
-		// in a chunk lives at that prefix, so the exclusion would now hide exactly
-		// what was asked for.
 		f.Provenance = store.ProvenanceRequired
+		if !FactsAreChunkHomed {
+			// Still dual-written: the SAME fact exists as its k/v row and as its
+			// chunk body, and since both carry an origin, provenance alone matches
+			// both. Excluding the chunk namespace picks exactly one of the pair.
+			f.ExcludeKeyPrefix = DocumentChunkKeyPrefix
+		}
 	case notes && !facts:
 		// A note is what an agent wrote down ITSELF: no provenance, and not a chunk
 		// body. Both halves are load-bearing — prose has no provenance either, so
@@ -231,14 +232,36 @@ func (q SearchQuery) Filter() (store.MemorySearchFilter, error) {
 		f.Provenance = store.ProvenanceAbsent
 	case memory && !docs:
 		// facts + notes — everything EXCEPT prose, and the default for recall.
-		// No longer expressible by excluding the chunk namespace, because the facts
-		// half now lives inside it; this excludes the document CLASS, which is the
-		// only thing being ruled out.
-		f.ExcludeDocumentPrefix = DocumentChunkKeyPrefix
+		if FactsAreChunkHomed {
+			// Not expressible by excluding the chunk namespace once the facts half
+			// lives inside it; what is ruled out is the document CLASS.
+			f.ExcludeDocumentPrefix = DocumentChunkKeyPrefix
+		} else {
+			// While a fact is dual-written, excluding the namespace rules out prose
+			// AND the duplicate half of every fact, which is what this needs.
+			f.ExcludeKeyPrefix = DocumentChunkKeyPrefix
+		}
 	}
 	// docs && facts && notes → everything; the zero filter already says that.
 	return f, nil
 }
+
+// FactsAreChunkHomed reports whether a fact's HOME has moved to the chunk plane.
+//
+// It is false while a fact is written to BOTH planes — its k/v
+// `memory/<class>/<slug>` row and its `doc.chunk:<hex>` body — which is the state
+// until the collapse deletes the k/v row. Both carry an origin, so a
+// provenance-only predicate matches both and one fact comes back TWICE. Measured
+// against real Postgres: `sources=facts` and the `facts+notes` recall default each
+// returned 2 hits for a single fact, which halves the effective top_k.
+//
+// It is a constant rather than a config knob deliberately. Which plane holds a
+// fact is a property of the deployed schema, not an operator preference, and an
+// operator who set it early would silently lose every fact that had not been
+// mirrored yet. Flipping it is a one-line change that belongs in the same commit as
+// the migration that deletes the k/v rows, and the selectors above are written so
+// that flip is all it takes.
+const FactsAreChunkHomed = false
 
 // Class labels a result row so a caller can tell what it got (RFC BW §4b).
 func Class(e store.MemorySearchEntry) store.MemoryRowClass {

--- a/internal/memory/sources_test.go
+++ b/internal/memory/sources_test.go
@@ -45,9 +45,12 @@ func TestSearchQueryFilter_SourcesMapToPredicate(t *testing.T) {
 				"(exclude AND require the same prefix), which would return nothing",
 		},
 		{
-			name: "facts are wherever provenance is, in EITHER namespace",
+			name: "facts require provenance, and exclude the twin while dual-written",
 			q:    SearchQuery{Sources: []Source{SourceFacts}},
-			want: store.MemorySearchFilter{Provenance: store.ProvenanceRequired},
+			want: store.MemorySearchFilter{
+				Provenance:       store.ProvenanceRequired,
+				ExcludeKeyPrefix: DocumentChunkKeyPrefix,
+			},
 			comment: "origin is server-stamped, so it is the unforgeable discriminator " +
 				"(RFC BW §9 Q1) — class is model-supplied and would let an agent promote " +
 				"its own note to a fact. No namespace constraint: excluding the chunk " +
@@ -63,9 +66,9 @@ func TestSearchQueryFilter_SourcesMapToPredicate(t *testing.T) {
 			},
 		},
 		{
-			name: "facts+notes excludes the document CLASS, not the namespace",
+			name: "facts+notes excludes the chunk namespace while facts are dual-written",
 			q:    SearchQuery{Sources: []Source{SourceFacts, SourceNotes}},
-			want: store.MemorySearchFilter{ExcludeDocumentPrefix: DocumentChunkKeyPrefix},
+			want: store.MemorySearchFilter{ExcludeKeyPrefix: DocumentChunkKeyPrefix},
 			comment: "the recall default: everything the agent remembers, prose " +
 				"excluded. Excluding the namespace no longer expresses that, because " +
 				"the facts half now lives inside it — so what is ruled out is the " +
@@ -74,7 +77,7 @@ func TestSearchQueryFilter_SourcesMapToPredicate(t *testing.T) {
 		{
 			name: "an explicit prefix survives a source selector",
 			q:    SearchQuery{Prefix: "proj/", Sources: []Source{SourceFacts, SourceNotes}},
-			want: store.MemorySearchFilter{KeyPrefix: "proj/", ExcludeDocumentPrefix: DocumentChunkKeyPrefix},
+			want: store.MemorySearchFilter{KeyPrefix: "proj/", ExcludeKeyPrefix: DocumentChunkKeyPrefix},
 		},
 		{
 			name: "an explicit prefix WINS over documents-only",
@@ -178,6 +181,43 @@ func TestClass_LabelsRowsFromTheirOwnColumns(t *testing.T) {
 		})
 		if got != tc.want {
 			t.Errorf("Class(key=%q origin=%q) = %q, want %q", tc.key, tc.origin, got, tc.want)
+		}
+	}
+}
+
+// TestSearchQueryFilter_DualWriteNeverSelectsAFactTwice is the invariant the
+// FactsAreChunkHomed constant exists for.
+//
+// While a fact is written to both planes, its k/v row and its chunk body BOTH
+// carry an origin, so a provenance-only predicate matches both and one fact comes
+// back twice — measured against real Postgres as 2 hits for a single fact, on
+// `sources=facts` and on the `facts+notes` recall default. Duplicates halve the
+// effective top_k, which is an accuracy effect, so this is a correctness invariant
+// rather than a retrieval-quality preference.
+//
+// The assertion is written against the CONSTANT rather than against today's value,
+// so it keeps meaning after the collapse flips it: before, exactly one plane is
+// selected; after, the namespace is no longer excluded because there is no twin
+// left to exclude.
+func TestSearchQueryFilter_DualWriteNeverSelectsAFactTwice(t *testing.T) {
+	for _, srcs := range [][]Source{
+		{SourceFacts},
+		{SourceFacts, SourceNotes},
+	} {
+		f, err := (SearchQuery{Sources: srcs}).Filter()
+		if err != nil {
+			t.Fatalf("Filter(%v): %v", srcs, err)
+		}
+		if FactsAreChunkHomed {
+			if f.ExcludeKeyPrefix == DocumentChunkKeyPrefix {
+				t.Errorf("%v still excludes the chunk namespace after the collapse — that is "+
+					"where the facts live now, so this selects nothing", srcs)
+			}
+			continue
+		}
+		if f.ExcludeKeyPrefix != DocumentChunkKeyPrefix {
+			t.Errorf("%v selects BOTH planes while a fact is dual-written, so every fact "+
+				"comes back twice and the effective top_k halves; got %+v", srcs, f)
 		}
 	}
 }


### PR DESCRIPTION
**Live on `main` since #1179.** I flagged this as a merge-ordering constraint on that PR; it merged without P2f, so the regression is now real. Measured against real Postgres rather than reasoned:

```
sources=[facts]        -> 2 hit(s) for ONE fact: [doc.chunk:abc123 memory/fact/denn-prefers-go]
sources=[facts notes]  -> 2 hit(s) for ONE fact: [doc.chunk:abc123 memory/fact/denn-prefers-go]
```

`facts+notes` is the **recall default**, so this affects ordinary recall, not just an explicit selector.

## Why

#1179 redefined `sources=facts` as *"provenance present, any namespace"* — correct for the end state, wrong for now. A fact is currently written to **both** planes (its `memory/<class>/<slug>` row and its `doc.chunk:<hex>` body), and since #1177 both carry an origin, so a provenance-only predicate matches both. Duplicates halve the effective top-k, which is an accuracy effect in a phase whose gate explicitly forbids one.

## What

The mechanism #1179 added is right and **stays** — the class-based encoding, the `ExcludeDocumentPrefix` predicate, the `IsZero` fix. Only the **timing** was wrong: facts are not chunk-homed until the k/v row is deleted.

That assumption is now named rather than implicit. `FactsAreChunkHomed` is false while both rows exist, and the selectors are written so the collapse is a **one-line flip**:

| | `facts` | `facts+notes` |
|---|---|---|
| `false` (now) | provenance + exclude the chunk namespace — picks exactly one of the pair | exclude the chunk namespace — rules out prose *and* the duplicate half |
| `true` (after P2f) | provenance, any namespace | exclude the document **class** |

A constant rather than a config knob, deliberately: which plane holds a fact is a property of the deployed schema, not an operator preference, and an operator who set it early would silently lose every fact not yet mirrored.

## Alternatives rejected

- **Dedupe the two hits in the projection.** Needs the planes to agree on a value, and they do not — the k/v row stores the fact text, the chunk body stores a `{"body":…}` envelope. The identity test would be guesswork.
- **Revert #1179.** Takes the mechanism with it, including the `IsZero` fix, which is an unrelated latent bug.

## What was tested

`TestSearchQueryFilter_DualWriteNeverSelectsAFactTwice` asserts against the **constant** rather than today's value, so it keeps meaning after the flip: before, exactly one plane is selected; after, the namespace is not excluded because there is no twin left to exclude.

Verified end-to-end on real Postgres with pgvector — the same probe that returned 2 hits now returns **1**. `go test ./...` clean.

## Note on P2f

This is the guard, not the resolution. The collapse (deleting the k/v fact row, after backfilling any unmirrored fact and copying `access_count` onto the body row — see #1178) is what actually moves the home, and it flips this constant in the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8