### PR TITLE
fix(memory): the chunk plane must answer "who wrote this" as the k/v plane does

### DIFF
--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -2219,7 +2219,7 @@ agents:
         // The entity graph mirrors the fact AFTER the authoritative write lands, so
         // a graph failure can never cost a fact. SAME scope as the row above — the two
         // halves of one fact never split.
-        mirrorEntity(st, key, fact, scope);
+        mirrorEntity(st, key, fact, scope, pendingID);
         return true;
       }
 
@@ -2513,7 +2513,7 @@ agents:
       //   written, and the subject node and edge are skipped — the fact keeps its home,
       //   the graph stays honest, and st.fact_no_subject counts the gap so it reads as
       //   work still to do instead of a silent default.
-      function mirrorEntity(st, key, fact, scope) {
+      function mirrorEntity(st, key, fact, scope, pendingID) {
         scope = scope || CONFIG.scope;
         var docID = entitiesDoc(st, scope);
         if (!docID) { return; }
@@ -2596,6 +2596,12 @@ agents:
           var ivaN = nanosOfStamp(fact.invalid_at);
           if (ivaN !== null) { factArgs.invalid_at = ivaN; }
         }
+        // SAME attribution as the k/v write above. The server resolves origin and the
+        // source ids from the drained row, so a distilled fact says "consolidator"
+        // rather than "agent_explicit" — originForEntityWrite cannot tell a
+        // consolidation pass from any other agent, and once the chunk is the fact's
+        // only home there is no k/v twin left holding the real answer.
+        if (pendingID) { factArgs.from_pending = pendingID; }
         var factID = upsertEntityChunk(st, scope, docID, key, factArgs);
         if (!factID) { return; }
         st.entity_facts++;

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -2219,7 +2219,7 @@ agents:
         // The entity graph mirrors the fact AFTER the authoritative write lands, so
         // a graph failure can never cost a fact. SAME scope as the row above — the two
         // halves of one fact never split.
-        mirrorEntity(st, key, fact, scope);
+        mirrorEntity(st, key, fact, scope, pendingID);
         return true;
       }
 
@@ -2513,7 +2513,7 @@ agents:
       //   written, and the subject node and edge are skipped — the fact keeps its home,
       //   the graph stays honest, and st.fact_no_subject counts the gap so it reads as
       //   work still to do instead of a silent default.
-      function mirrorEntity(st, key, fact, scope) {
+      function mirrorEntity(st, key, fact, scope, pendingID) {
         scope = scope || CONFIG.scope;
         var docID = entitiesDoc(st, scope);
         if (!docID) { return; }
@@ -2596,6 +2596,12 @@ agents:
           var ivaN = nanosOfStamp(fact.invalid_at);
           if (ivaN !== null) { factArgs.invalid_at = ivaN; }
         }
+        // SAME attribution as the k/v write above. The server resolves origin and the
+        // source ids from the drained row, so a distilled fact says "consolidator"
+        // rather than "agent_explicit" — originForEntityWrite cannot tell a
+        // consolidation pass from any other agent, and once the chunk is the fact's
+        // only home there is no k/v twin left holding the real answer.
+        if (pendingID) { factArgs.from_pending = pendingID; }
         var factID = upsertEntityChunk(st, scope, docID, key, factArgs);
         if (!factID) { return; }
         st.entity_facts++;

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -110,6 +110,7 @@ const documentInputSchema = `{
 		"natural_key": {"type": "string", "description": "upsert_chunk: the stable identity of this entity or fact. Upserting twice with the same key updates ONE chunk instead of adding a second — use a derived form such as person:ada-lovelace, or subject|predicate|object for a fact. Unique within the scope."},
 		"supersedes_id": {"type": "string", "description": "supersede_chunk: the id of the chunk being RETIRED by this one. The retired chunk is not deleted — it stays queryable so that questions about an earlier point in time still have an answer."},
 		"valid_at":   {"type": "integer", "description": "When the fact became true IN THE WORLD (unix nanos). Omit when unknown — an undated fact is honest and still matches an as_of question; a guessed instant is not. Distinct from when it was recorded."},
+		"from_pending": {"type": "string", "description": "upsert_chunk: the id of a pending item you drained, so this fact records what produced it. The server fills in the origin and the source ids from that row — you cannot set those yourself. Unknown or unowned ids are ignored and the write still succeeds."},
 		"observed_at": {"type": "integer", "description": "When the thing was SAID or written (unix nanos), as distinct from when it became true. \"Yesterday I met them in Boston\", said on the 4th, is observed_at the 4th and valid_at the 3rd. Omit when unknown."},
 		"invalid_at": {"type": "integer", "description": "When the fact STOPPED being true in the world (unix nanos). Leave unset for something still true."},
 		"class":      {"type": "string", "enum": ["derived","evidential"], "description": "derived = distilled from something else (the default). evidential = source material, exempt from age-based pruning. list_facts: filter to facts of this class."},
@@ -244,7 +245,16 @@ type docInput struct {
 	// a caller must not be able to claim one — an exported field would be settable
 	// from the tool's JSON input and the column would stop being trustworthy.
 	bodyOrigin string
-	Confidence *float64 `json:"confidence"`
+	// FromPending attributes this write to a pending-queue row the caller drained,
+	// so the SERVER stamps the origin and source ids from that row. The id is the
+	// only thing a caller may pass — the fields themselves stay unsettable, which
+	// is what keeps origin an unforgeable statement about who wrote a fact.
+	FromPending string `json:"from_pending,omitempty"`
+	// pendingProv is what the server resolved from that row. UNEXPORTED, like
+	// bodyOrigin, so the tool's JSON input can never supply it — the id is the
+	// caller's to pass, the provenance is the server's to decide.
+	pendingProv *store.MemoryProvenance
+	Confidence  *float64 `json:"confidence"`
 	// Class is 'derived' | 'evidential' — the retention-exemption signal.
 	Class string `json:"class"`
 

--- a/internal/tools/builtin/document_chunk_pending_test.go
+++ b/internal/tools/builtin/document_chunk_pending_test.go
@@ -1,0 +1,184 @@
+package builtin
+
+import (
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// The chunk write must carry the SERVER's answer about who wrote a fact
+// (RFC CV, P2f prerequisite).
+//
+// originForEntityWrite cannot tell a consolidation pass from any other agent — it
+// returns "agent_explicit" for every run — so a machine-distilled fact whose home
+// is a chunk would claim to have been written by hand. That is survivable only
+// while the k/v twin carries the real answer, and the collapse removes the twin.
+//
+// from_pending is the same mechanism Memory set uses, for the same reason: origin
+// names the writer, so a caller may hand over an id but never the value.
+
+// TestUpsertChunk_FromPendingStampsTheServersProvenance.
+func TestUpsertChunk_FromPendingStampsTheServersProvenance(t *testing.T) {
+	d, ctx, st := documentFixture(t)
+	doc := newEntityDoc(t, d, ctx)
+	sk := sidecarScope(t, d, ctx)
+	tenant := direntTenant(ctx)
+
+	// A drained pending row, as a consolidation pass would leave it.
+	// The pending row's own origin is the PRODUCER (agent_explicit | compaction),
+	// never "consolidator" — that is the writer's identity and is stamped
+	// separately. This asserts the producer wins, which is the whole point of
+	// from_pending: a server-recorded producer beats an ambient guess.
+	const pendingID = "p-1"
+	if err := st.MemoryPendingEnqueue(ctx, store.MemoryPendingRow{
+		ID: pendingID, TenantID: tenant, Scope: store.MemoryScopeUser, ScopeID: sk.ScopeID,
+		Payload:         []byte(`{"text":"Denn prefers Go."}`),
+		Origin:          store.PendingOriginCompaction,
+		SourceSessionID: "sess-a", SourceRunID: "run-a",
+	}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	out, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+doc+`",
+		"natural_key":"memory/fact/denn-prefers-go","title":"Denn prefers Go",
+		"body":"Denn prefers Go for backend services.","type":"fact","subject":"Denn",
+		"from_pending":"`+pendingID+`"}`)
+	if r.IsError {
+		t.Fatalf("upsert_chunk: %s", r.Text)
+	}
+	id := asStr(out["id"])
+
+	// The BODY row: the discriminator a collapsed fact is classified by.
+	prov, err := st.MemoryProvenanceGet(ctx, tenant, store.MemoryScopeUser, sk.ScopeID, "doc.chunk:"+id)
+	if err != nil {
+		t.Fatalf("body provenance: %v", err)
+	}
+	if prov.Origin != store.PendingOriginCompaction {
+		t.Errorf("body row origin = %q, want %q — a server-recorded producer must beat the "+
+			"ambient attribution, exactly as it does on the k/v write",
+			prov.Origin, store.PendingOriginCompaction)
+	}
+
+	// The SIDECAR: the two halves of one record must agree, or a fact's provenance
+	// depends on which half a reader consults.
+	res, err := d.SqlMem.Query(ctx, sk,
+		d.SqlMem.Rebind(`SELECT coalesce(origin,''), coalesce(session_id,''), coalesce(run_id,'')
+		                   FROM chunk_memory_meta WHERE chunk_id = ?`), []any{id})
+	if err != nil || len(res.Rows) == 0 {
+		t.Fatalf("sidecar read: %v", err)
+	}
+	gotOrigin, gotSession, gotRun := asStr(res.Rows[0][0]), asStr(res.Rows[0][1]), asStr(res.Rows[0][2])
+	if gotOrigin != store.PendingOriginCompaction {
+		t.Errorf("sidecar origin = %q, want %q — it must agree with the body row, or a fact's "+
+			"provenance depends on which half a reader consults", gotOrigin, store.PendingOriginCompaction)
+	}
+	// session_id had NO writer in this plane at all before this: the run id is on
+	// the context and the session id is not, so every chunk-homed fact was missing
+	// the chat half of its source reference.
+	if gotSession != "sess-a" {
+		t.Errorf("sidecar session_id = %q, want sess-a — the chat half of the source reference", gotSession)
+	}
+	if gotRun != "run-a" {
+		t.Errorf("sidecar run_id = %q, want run-a (the run the fact was distilled FROM, not the "+
+			"run doing the writing)", gotRun)
+	}
+}
+
+// TestUpsertChunk_AnUnknownPendingIdIsSilent: a miss must not cost a fact its
+// write, matching Memory set. An id that is unknown or belongs to someone else
+// simply leaves the ambient attribution in place.
+func TestUpsertChunk_AnUnknownPendingIdIsSilent(t *testing.T) {
+	d, ctx, st := documentFixture(t)
+	doc := newEntityDoc(t, d, ctx)
+	sk := sidecarScope(t, d, ctx)
+	tenant := direntTenant(ctx)
+
+	out, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+doc+`",
+		"natural_key":"memory/fact/x","title":"X","body":"A fact.","type":"fact","subject":"X",
+		"from_pending":"no-such-id"}`)
+	if r.IsError {
+		t.Fatalf("an unknown pending id must not fail the write: %s", r.Text)
+	}
+	id := asStr(out["id"])
+	prov, err := st.MemoryProvenanceGet(ctx, tenant, store.MemoryScopeUser, sk.ScopeID, "doc.chunk:"+id)
+	if err != nil {
+		t.Fatalf("body provenance: %v", err)
+	}
+	if prov.Origin == "" {
+		t.Errorf("the write lost its ambient origin to an unknown pending id — a miss is silent, not destructive")
+	}
+}
+
+// TestUpsertChunk_AConsolidationPassSaysSo is the half that actually mattered.
+//
+// The k/v write stamps `consolidator` when the run holds the Consolidation memory
+// policy — a server-side grant, not a caller assertion. The chunk write checked
+// only that a run existed, so the SAME distillation landed origin=consolidator on
+// its k/v row and agent_explicit on its chunk. Harmless only while the k/v twin
+// held the real answer; once the chunk is the fact's only home, every
+// machine-distilled fact would claim to have been written by hand.
+func TestUpsertChunk_AConsolidationPassSaysSo(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		consolidation bool
+		want          string
+	}{
+		{"a consolidation pass", true, "consolidator"},
+		{"an ordinary agent", false, "agent_explicit"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d, ctx, st := documentFixture(t)
+			// A RUN is required, not just the grant: the operator planes hand out
+			// Consolidation alongside wildcard memory scopes and carry no run id, so
+			// keying on the grant alone would let any authenticated operator session
+			// mint facts claiming a machine distilled them.
+			ctx = tools.WithRunID(ctx, "run-1")
+			ctx = tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{Consolidation: tc.consolidation})
+			doc := newEntityDoc(t, d, ctx)
+			sk := sidecarScope(t, d, ctx)
+
+			out, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+doc+`",
+				"natural_key":"memory/fact/x","title":"X","body":"A distilled fact.",
+				"type":"fact","subject":"X"}`)
+			if r.IsError {
+				t.Fatalf("upsert_chunk: %s", r.Text)
+			}
+			id := asStr(out["id"])
+			prov, err := st.MemoryProvenanceGet(ctx, direntTenant(ctx), store.MemoryScopeUser, sk.ScopeID, "doc.chunk:"+id)
+			if err != nil {
+				t.Fatalf("body provenance: %v", err)
+			}
+			if prov.Origin != tc.want {
+				t.Errorf("origin = %q, want %q — the chunk plane must answer 'who wrote this' the "+
+					"same way the k/v plane does", prov.Origin, tc.want)
+			}
+		})
+	}
+}
+
+// TestUpsertChunk_TheGrantAloneIsNotEnough: the Consolidation policy WITHOUT a run
+// must not mint a consolidator origin. The operator planes carry the grant and no
+// run id, so keying on the grant alone would hollow out the one thing the column is
+// for — a trustworthy filter for facts a machine distilled from a transcript.
+func TestUpsertChunk_TheGrantAloneIsNotEnough(t *testing.T) {
+	d, ctx, st := documentFixture(t)
+	ctx = tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{Consolidation: true}) // no run id
+	doc := newEntityDoc(t, d, ctx)
+	sk := sidecarScope(t, d, ctx)
+
+	out, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+doc+`",
+		"natural_key":"memory/fact/y","title":"Y","body":"A fact.","type":"fact","subject":"Y"}`)
+	if r.IsError {
+		t.Fatalf("upsert_chunk: %s", r.Text)
+	}
+	prov, err := st.MemoryProvenanceGet(ctx, direntTenant(ctx), store.MemoryScopeUser, sk.ScopeID,
+		"doc.chunk:"+asStr(out["id"]))
+	if err != nil {
+		t.Fatalf("body provenance: %v", err)
+	}
+	if prov.Origin == "consolidator" {
+		t.Error("the grant alone minted a consolidator origin with no run — any authenticated " +
+			"operator session could then claim a machine distilled its writes")
+	}
+}

--- a/internal/tools/builtin/document_entity.go
+++ b/internal/tools/builtin/document_entity.go
@@ -74,7 +74,19 @@ func (d *Document) upsertChunk(ctx context.Context, key sqlmem.ScopeKey, mscope 
 	// the k/v plane through create_chunk when it is new and through the entity body
 	// writer when it already exists; stamping only one of those would leave the
 	// discriminator depending on whether a fact had been seen before.
+	//
+	// A drained pending row, when the caller named one, OVERRIDES the ambient
+	// attribution — the same override the k/v path applies, and for the same reason:
+	// a server-recorded producer beats an ambient guess. It also fills session_id,
+	// which had NO writer in this plane at all, because the run id is on the context
+	// and the session id is not.
 	in.bodyOrigin = originForEntityWrite(ctx)
+	if prov, ok := d.resolveChunkPending(ctx, mscope, key.ScopeID, in.FromPending); ok {
+		if prov.Origin != "" {
+			in.bodyOrigin = prov.Origin
+		}
+		in.pendingProv = &prov
+	}
 
 	if existing == "" {
 		// Delegate the INSERT to create_chunk rather than writing a second insert
@@ -575,6 +587,19 @@ func (d *Document) writeChunkMeta(ctx context.Context, key sqlmem.ScopeKey, chun
 	if runID == "" {
 		runID = prev.RunID
 	}
+	// The pending row WINS over the ambient run context when the caller attributed
+	// this write to one: it names the run and session the fact was distilled FROM,
+	// which is the source reference, whereas the ctx run id is merely the run doing
+	// the writing. sessionID has no other writer in this plane at all.
+	sessionID := prev.SessionID
+	if in.pendingProv != nil {
+		if in.pendingProv.SourceRunID != "" {
+			runID = in.pendingProv.SourceRunID
+		}
+		if in.pendingProv.SourceSessionID != "" {
+			sessionID = in.pendingProv.SourceSessionID
+		}
+	}
 	naturalKey := in.NaturalKey
 	if naturalKey == "" {
 		naturalKey = prev.NaturalKey
@@ -608,11 +633,11 @@ func (d *Document) writeChunkMeta(ctx context.Context, key sqlmem.ScopeKey, chun
 		   (chunk_id, valid_at, invalid_at, created_at, expired_at, class, origin, confidence, session_id, run_id, event_seq, natural_key, source_quote, subject, judged_at, judge_reason, judged_by, observed_at, access_count, last_accessed_at)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		chunkID, int64Arg(validAt), invalidAt, createdAt, expiredAt, class,
-		originForEntityWrite(ctx), confidence,
+		originForEntityWriteWith(ctx, in), confidence,
 		// session_id has no writer yet: it is not on the run ctx, only the run id is.
 		// Preserved rather than nulled so the consolidation path — which CAN fill it
 		// when it relays a drained pending row — does not lose it to the next upsert.
-		nullIfEmpty(prev.SessionID), nullIfEmpty(runID), int64Arg(prev.EventSeq),
+		nullIfEmpty(sessionID), nullIfEmpty(runID), int64Arg(prev.EventSeq),
 		nullIfEmpty(naturalKey), nullIfEmpty(sourceQuote), nullIfEmpty(subject),
 		judgedAt, nullIfEmpty(judgeReason), nullIfEmpty(judgedBy),
 		int64Arg(observedAt),
@@ -671,9 +696,65 @@ func asFloat64Ptr(v any) *float64 {
 // originForEntityWrite decides the provenance label from the RUN, never the input.
 // A write arriving with no run id is an operator acting by hand (the MCP/off-run
 // plane); one inside a run is an agent.
+// resolveChunkPending reads the provenance the server recorded on a drained
+// pending row. A miss is SILENT and the write still succeeds, matching Memory set:
+// an unknown or unowned id must not cost a fact its write, and distinguishing "no
+// such row" from "not yours" would leak which ids exist.
+//
+// The cross-scope retry is the one the k/v path already needs, for the same
+// measured reason: a consolidation pass drains the queue in the USER scope and,
+// when the ontology declares the fact's type shared, writes the fact to the TENANT
+// scope — so the primary lookup misses and the placed fact lands with no
+// server-stamped origin and no session id. NOT an authorization widening: the
+// fallback tuple is built from the run's OWN identity, never from caller input.
+func (d *Document) resolveChunkPending(ctx context.Context, scope store.MemoryScope, scopeID, pendingID string) (store.MemoryProvenance, bool) {
+	if pendingID == "" || d.Store == nil {
+		return store.MemoryProvenance{}, false
+	}
+	ident := tools.RunIdentity(ctx)
+	row, err := d.Store.MemoryPendingGet(ctx, ident.TenantID, scope, scopeID, pendingID)
+	if err != nil && ident.UserID != "" && !(scope == store.MemoryScopeUser && scopeID == ident.UserID) {
+		row, err = d.Store.MemoryPendingGet(ctx, ident.TenantID, store.MemoryScopeUser, ident.UserID, pendingID)
+	}
+	if err != nil {
+		return store.MemoryProvenance{}, false
+	}
+	return store.MemoryProvenance{
+		Origin:          row.Origin,
+		SourceSessionID: row.SourceSessionID,
+		SourceRunID:     row.SourceRunID,
+	}, true
+}
+
+// originForEntityWriteWith is originForEntityWrite with the server's resolution of
+// a drained pending row layered on top, so the SIDECAR and the BODY row agree about
+// who wrote the fact. They are two halves of one record; disagreeing would make a
+// fact's provenance depend on which half a reader consulted.
+func originForEntityWriteWith(ctx context.Context, in docInput) string {
+	if in.pendingProv != nil && in.pendingProv.Origin != "" {
+		return in.pendingProv.Origin
+	}
+	return originForEntityWrite(ctx)
+}
+
 func originForEntityWrite(ctx context.Context) string {
 	if tools.RunID(ctx) == "" {
 		return "operator"
+	}
+	// A CONSOLIDATION PASS SAYS SO, exactly as the k/v path does. provenanceForSet
+	// stamps `consolidator` when the run holds the Consolidation memory policy, and
+	// this used to check only that a run existed — so the same distillation landed
+	// origin=consolidator on its k/v row and agent_explicit on its chunk. Harmless
+	// only while the k/v twin held the real answer; once the chunk is the fact's
+	// only home, every machine-distilled fact would claim to have been written by
+	// hand, and origin is the column that exists to say otherwise.
+	//
+	// The RUN requirement is the same safeguard and for the same measured reason:
+	// the operator planes hand out Consolidation alongside wildcard memory scopes
+	// and carry no run id, so keying on the grant alone would let any authenticated
+	// operator session mint facts that claim a machine distilled them.
+	if tools.MemoryPolicy(ctx).Consolidation {
+		return memoryOriginConsolidator
 	}
 	return "agent_explicit"
 }


### PR DESCRIPTION
A **prerequisite for the collapse**, found by checking what the destructive step would lose *before* writing it. The collapse deletes the k/v fact row; anything that row answers better than the chunk does is data that disappears.

## Two planes, two different answers

**Origin.** `provenanceForSet` stamps `consolidator` when the run holds the **Consolidation memory policy** — a server-side grant. `originForEntityWrite` checked only that a run existed and returned `agent_explicit` for every one. So the *same distillation* landed `origin=consolidator` on its k/v row and `agent_explicit` on its chunk.

Harmless only while the k/v twin holds the real answer. Once the chunk is the fact's only home, **every machine-distilled fact claims to have been written by hand** — and origin is the column that exists to say otherwise (RFC BW §9 Q1 calls it the unforgeable discriminator).

The **run requirement** carries over with it, for the reason the k/v side already documents: the operator planes hand out `Consolidation` alongside wildcard memory scopes and carry no run id, so keying on the grant alone would let any authenticated operator session mint facts claiming a machine distilled them.

**The drained row.** `from_pending` now resolves on `upsert_chunk` exactly as on `Memory set` — the caller passes an id, the server reads the row and decides. A server-recorded producer (`agent_explicit` | `compaction`) beats the ambient attribution, and the cross-scope retry comes with it because a *placed* fact is drained from the user scope and written to the tenant one.

It also fills **`session_id`, which had no writer in this plane at all** — the run id is on the context and the session id is not, so every chunk-homed fact was missing the chat half of its source reference (RFC CV decision 8). `run_id` likewise now names the run the fact was distilled **from** rather than the run doing the writing.

The sidecar and the body row take the same answer: they are two halves of one record, and disagreeing would make a fact's provenance depend on which half a reader consulted. The resolved value rides an **unexported** `docInput` field, so the tool's JSON input can never supply it — the id is the caller's to pass, the provenance is the server's to decide.

## A wrong turn worth recording

My first attempt targeted the wrong mechanism: I assumed `from_pending` was what produced `consolidator`. It is not — the pending row's own origin is the **producer** (`agent_explicit` | `compaction`), and the writer's identity is stamped separately. `MemoryPendingRow`'s own doc comment says so outright: *"origin on the `memory` table is stamped from the WRITER's identity, which is `consolidator` either way."* Both changes are worth having, but the origin rule is the one that gates the collapse.

## What was tested

- `TestUpsertChunk_AConsolidationPassSaysSo` — both directions: a pass says `consolidator`, an ordinary agent still says `agent_explicit`.
- `TestUpsertChunk_TheGrantAloneIsNotEnough` — the policy *without* a run must not mint one.
- `TestUpsertChunk_FromPendingStampsTheServersProvenance` — body **and** sidecar agree; `session_id`/`run_id` come from the drained row.
- `TestUpsertChunk_AnUnknownPendingIdIsSilent` — a miss never costs a fact its write.

Fail-before on the origin rule: `origin = "agent_explicit", want "consolidator"`. `go test ./...` clean; both bundle copies byte-identical.

## Still ahead for the collapse

With this in, the chunk plane carries everything the k/v row does. The remaining destructive step (P2f) is: backfill a chunk for any unmirrored fact, copy `access_count` onto the body row (#1178 — 696 accesses across 84 facts vs 0 on their bodies), flip `FactsAreChunkHomed`, stop the k/v write, then delete. I have not written that yet — it deletes user data, and I would rather land this and re-measure the two planes first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8