### PR TITLE
fix(memory): a fact keeps its identity when its home moves to a chunk

### DIFF
--- a/internal/tools/builtin/document_labels.go
+++ b/internal/tools/builtin/document_labels.go
@@ -28,6 +28,17 @@ import (
 type ChunkLabel struct {
 	Document string // the document's title
 	Title    string // the chunk's own title (its heading)
+	// NaturalKey is the fact's STABLE IDENTITY — `memory/<class>/<slug>`, the same
+	// string its k/v row is keyed on, by deliberate design ("one key space for both
+	// stores is what stops them drifting").
+	//
+	// It is carried here so a chunk-homed fact can be addressed by the name it has
+	// always had. A chunk's row key is `doc.chunk:<hex>`, which is an opaque
+	// server-assigned address; handing that back as a fact's id would change every
+	// fact's identity the moment its home moved, and the consolidator's merge path
+	// writes a neighbour back UNDER ITS OWN KEY. Empty for an ordinary prose chunk,
+	// which has no sidecar row.
+	NaturalKey string
 }
 
 // maxChunkLabelLookup bounds the IN list. Both search surfaces cap top_k at 50
@@ -71,8 +82,11 @@ func ChunkLabelsFor(ctx context.Context, sm *sqlmem.Manager, tenantID string,
 	}
 
 	// LEFT JOIN: a chunk whose document row is missing still yields its own title.
-	stmt := `SELECT c.id, c.title, d.title FROM chunks c ` +
-		`LEFT JOIN documents d ON d.id = c.document_id WHERE c.id IN (` +
+	// The sidecar joins the same way and for the same reason — an ordinary prose
+	// chunk has no row there, and must still yield its label.
+	stmt := `SELECT c.id, c.title, d.title, coalesce(m.natural_key, '') FROM chunks c ` +
+		`LEFT JOIN documents d ON d.id = c.document_id ` +
+		`LEFT JOIN chunk_memory_meta m ON m.chunk_id = c.id WHERE c.id IN (` +
 		strings.TrimSuffix(strings.Repeat("?,", len(ids)), ",") + `)`
 	res, err := sm.Query(ctx, key, sm.Rebind(stmt), ids)
 	if err != nil || res == nil {
@@ -87,7 +101,11 @@ func ChunkLabelsFor(ctx context.Context, sm *sqlmem.Manager, tenantID string,
 		if id == "" {
 			continue
 		}
-		out[id] = ChunkLabel{Document: asStr(row[2]), Title: asStr(row[1])}
+		lb := ChunkLabel{Document: asStr(row[2]), Title: asStr(row[1])}
+		if len(row) > 3 {
+			lb.NaturalKey = asStr(row[3])
+		}
+		out[id] = lb
 	}
 	return out
 }

--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -1708,10 +1708,65 @@ func (m *Memory) execRecall(ctx context.Context, scope store.MemoryScope, scopeI
 		}
 		spans = SourceSpansFor(ctx, m.SqlMem, tools.RunIdentity(ctx).TenantID, scope, scopeID, ids)
 	}
+
+	// A FACT'S IDENTITY IS ITS NATURAL KEY, wherever the fact is stored.
+	//
+	// The backend reports a row's own key, which for a chunk-homed fact is the
+	// opaque `doc.chunk:<hex>` address rather than the `memory/<class>/<slug>` name
+	// the fact has always had. Handing that back would change every fact's identity
+	// the moment its home moved — and the consolidator's merge path writes a
+	// recalled neighbour back UNDER ITS OWN KEY, so it would write a fact under an
+	// address instead of a name. SourceSpansFor keys on the natural key too, so the
+	// source span and its run id would quietly stop resolving.
+	//
+	// Resolved in ONE batched query, and only for rows that need it. A chunk whose
+	// sidecar has no natural key (ordinary prose) keeps its own key, so nothing is
+	// invented for a row that has no other name.
+	naturalKeys := map[string]string{}
+	if m.SqlMem != nil {
+		var chunkIDs []string
+		for _, f := range res.Facts {
+			if strings.HasPrefix(f.ID, memrank.DocumentChunkKeyPrefix) {
+				chunkIDs = append(chunkIDs, strings.TrimPrefix(f.ID, memrank.DocumentChunkKeyPrefix))
+			}
+		}
+		if len(chunkIDs) > 0 {
+			for cid, lb := range ChunkLabelsFor(ctx, m.SqlMem, tools.RunIdentity(ctx).TenantID, scope, scopeID, chunkIDs) {
+				if lb.NaturalKey != "" {
+					naturalKeys[memrank.DocumentChunkKeyPrefix+cid] = lb.NaturalKey
+				}
+			}
+		}
+		// The spans are keyed by natural key, so re-resolve them once the names are
+		// known — otherwise a chunk-homed fact loses the source reference P1 built.
+		if len(naturalKeys) > 0 {
+			var named []string
+			for _, f := range res.Facts {
+				if nk, ok := naturalKeys[f.ID]; ok {
+					named = append(named, nk)
+				}
+			}
+			if extra := SourceSpansFor(ctx, m.SqlMem, tools.RunIdentity(ctx).TenantID, scope, scopeID, named); len(extra) > 0 {
+				if spans == nil {
+					// SourceSpansFor returns nil on a miss or a fault, and the first
+					// call above may well have missed: it looked the facts up under
+					// keys they no longer have.
+					spans = make(map[string]FactSource, len(extra))
+				}
+				for k, v := range extra {
+					spans[k] = v
+				}
+			}
+		}
+	}
 	memories := make([]map[string]any, 0, len(res.Facts))
 	for _, f := range res.Facts {
+		id := f.ID
+		if nk, ok := naturalKeys[id]; ok {
+			id = nk
+		}
 		mem := map[string]any{
-			"id":     f.ID, // server-assigned; opaque to loomcycle, NOT a caller key
+			"id":     id, // the fact's stable natural key, wherever it is stored
 			"memory": f.Memory,
 			"score":  f.Score,
 		}
@@ -1719,7 +1774,7 @@ func (m *Memory) execRecall(ctx context.Context, scope store.MemoryScope, scopeI
 		// turn's own leading timestamp and whatever relative phrasing distillation
 		// dropped, which is exactly what a "when did X happen" question needs and a
 		// summarised sentence cannot supply.
-		if sp, ok := spans[f.ID]; ok {
+		if sp, ok := spans[id]; ok {
 			if sp.Span != "" {
 				mem["source"] = sp.Span
 			}

--- a/internal/tools/builtin/memory_fact_identity_test.go
+++ b/internal/tools/builtin/memory_fact_identity_test.go
@@ -1,0 +1,95 @@
+package builtin
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// A FACT'S IDENTITY IS ITS NATURAL KEY, wherever the fact is stored
+// (RFC CV, P2f prerequisite).
+//
+// The backend reports a row's own key. For a chunk-homed fact that is the opaque
+// `doc.chunk:<hex>` address rather than the `memory/<class>/<slug>` name the fact
+// has always had — and the two stores share one key space deliberately, because
+// "one key space for both stores is what stops them drifting".
+//
+// Two things break if recall hands back the address. The consolidator's merge path
+// writes a recalled neighbour back UNDER ITS OWN KEY, so it would file a fact under
+// an address instead of a name. And SourceSpansFor keys on the natural key, so the
+// source span and its run id — the reach-through P1 exists for — quietly stop
+// resolving.
+
+// TestChunkLabelsFor_CarriesTheNaturalKey pins the lookup half. The label query is
+// already batched for titles, so the identity rides along on it rather than costing
+// a second round trip.
+func TestChunkLabelsFor_CarriesTheNaturalKey(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	doc := newEntityDoc(t, d, ctx)
+
+	out, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+doc+`",
+		"natural_key":"memory/fact/denn-prefers-go","title":"Denn prefers Go",
+		"body":"Denn prefers Go for backend services.","type":"fact","subject":"Denn"}`)
+	if r.IsError {
+		t.Fatalf("upsert_chunk: %s", r.Text)
+	}
+	factID := asStr(out["id"])
+
+	// Ordinary prose in the same document: it has no sidecar row, so it must carry
+	// NO natural key. Inventing one would give a fact-shaped identity to a chunk
+	// that has no other name.
+	out, r = docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+doc+`",
+		"title":"A section","body":"Ordinary prose."}`)
+	if r.IsError {
+		t.Fatalf("create_chunk: %s", r.Text)
+	}
+	proseID := asStr(out["id"])
+
+	sk := sidecarScope(t, d, ctx)
+	labels := ChunkLabelsFor(ctx, d.SqlMem, direntTenant(ctx), store.MemoryScopeUser, sk.ScopeID,
+		[]string{factID, proseID})
+	if labels == nil {
+		t.Fatal("no labels resolved")
+	}
+	if got := labels[factID].NaturalKey; got != "memory/fact/denn-prefers-go" {
+		t.Errorf("fact chunk natural_key = %q, want memory/fact/denn-prefers-go — without it a "+
+			"chunk-homed fact can only be addressed by its opaque row key", got)
+	}
+	if got := labels[proseID].NaturalKey; got != "" {
+		t.Errorf("ordinary prose carries natural_key %q — a chunk with no sidecar has no other name", got)
+	}
+	// The titles must still resolve: the identity rides the SAME query.
+	if labels[factID].Title == "" || labels[proseID].Title == "" {
+		t.Errorf("adding the identity column cost a title: %+v / %+v", labels[factID], labels[proseID])
+	}
+}
+
+// TestChunkLabelsFor_ToleratesAChunkWithNoSidecar guards the join. chunk_memory_meta
+// is LEFT JOINed for the same reason the documents table is: most chunks have no row
+// there, and an inner join would drop every ordinary chunk from the label lookup —
+// a regression that would show as missing titles, not as an error.
+func TestChunkLabelsFor_ToleratesAChunkWithNoSidecar(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	doc := newEntityDoc(t, d, ctx)
+	var ids []string
+	for _, title := range []string{"one", "two", "three"} {
+		out, r := docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+doc+`",
+			"title":"`+title+`","body":"Prose."}`)
+		if r.IsError {
+			t.Fatalf("create_chunk %s: %s", title, r.Text)
+		}
+		ids = append(ids, asStr(out["id"]))
+	}
+	sk := sidecarScope(t, d, ctx)
+	labels := ChunkLabelsFor(ctx, d.SqlMem, direntTenant(ctx), store.MemoryScopeUser, sk.ScopeID, ids)
+	if len(labels) != len(ids) {
+		t.Errorf("resolved %d of %d sidecar-less chunks — an inner join would drop every ordinary chunk",
+			len(labels), len(ids))
+	}
+	for _, id := range ids {
+		if strings.TrimSpace(labels[id].Title) == "" {
+			t.Errorf("chunk %s lost its title", id)
+		}
+	}
+}


### PR DESCRIPTION
The last prerequisite the collapse needs — and the one that would have broken things **quietly** rather than loudly.

## Why

The backend reports a row's own key. For a chunk-homed fact that is the opaque `doc.chunk:<hex>` address, not the `memory/<class>/<slug>` name the fact has always had. The two stores share **one key space** by deliberate design — *"one key space for both stores is what stops them drifting"* — and a fact chunk's `natural_key` **is** its k/v key, verbatim.

Hand back the address instead and two things break with no error:

- **The merge path files facts under addresses.** The consolidator writes a recalled neighbour back *under its own key* (its comment: *"a merge REWRITES the neighbour in place, under ITS OWN key"*). It would write a fact keyed on `doc.chunk:<hex>`, and every later pass would see a new fact rather than the existing one — so merging would stop collapsing duplicates and start manufacturing them.
- **The source reference stops resolving.** `SourceSpansFor` keys on the natural key, so a recalled fact's span and run id — the reach-through P1 exists for — silently vanish. A missing span renders as a fact without one, indistinguishable from a fact that never had one.

## What

Recall resolves a chunk-homed fact back to its natural key and reports that as the `id`. The lookup rides the **existing batched label query** — one more column on a join that already runs — rather than costing a second round trip. The spans are then re-resolved once the names are known, because the first lookup necessarily missed: it asked for the facts under keys they no longer have.

A chunk whose sidecar has no natural key keeps its own key. Ordinary prose has no other name, and inventing one would give a fact-shaped identity to a chunk that is not a fact.

`chunk_memory_meta` is **LEFT** JOINed for the same reason the documents table already is: most chunks have no row there, and an inner join would drop every ordinary chunk from the label lookup — a regression that shows as missing titles rather than as an error.

## What was tested

- `TestChunkLabelsFor_CarriesTheNaturalKey` — both directions: a fact carries its key, prose carries none, and the titles still resolve (the identity rides the same query, so a broken join would cost both).
- `TestChunkLabelsFor_ToleratesAChunkWithNoSidecar` — the join must not drop sidecar-less chunks.

Fail-before reports `natural_key = ""`. `go test ./...` clean.

Also guards a **nil-map write** I introduced: `SourceSpansFor` returns nil on a miss, and the first call here is *expected* to miss.

## Where P2f stands

Stacked prerequisites, each independently shippable, all now open or merged:

| | |
|---|---|
| #1190 | the chunk plane answers "who wrote this" as the k/v plane does |
| this | a fact keeps its identity when its home moves |
| next | backfill + copy `access_count`, stop the k/v write, flip `FactsAreChunkHomed`, delete |

Every one of these was found by asking what the destructive step would lose, rather than by writing the migration first. With both in, the chunk plane carries the fact's text, embedding, temporal fields, provenance, source reference **and** identity — which is the actual precondition for deleting the k/v row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8