### PR TITLE
feat(teamgraph): the starter kind, the publish-only channel kind, the team ACL

### DIFF
--- a/internal/teamgraph/channels_hash_test.go
+++ b/internal/teamgraph/channels_hash_test.go
@@ -1,0 +1,50 @@
+package teamgraph
+
+import "testing"
+
+// Definition.Channels is AUTHORITY, so unlike Colors and Layout it must be
+// inside the content hash: a verify against a recorded hash that passed while
+// the workflow had quietly gained a channel would be worse than no verify.
+func TestSign_ChannelsAreContent(t *testing.T) {
+	base := Definition{
+		Entry:       "a",
+		States:      []State{{ID: "a", Handler: Handler{Kind: HandlerTerminal}}},
+		Transitions: []Transition{},
+	}
+	bare := Sign("t", base)
+
+	withACL := base
+	withACL.Channels = &TeamChannels{Subscribe: []string{"pr-events"}}
+	if Sign("t", withACL) == bare {
+		t.Errorf("adding a channel ACL did not change the hash — authority must be content")
+	}
+
+	wider := base
+	wider.Channels = &TeamChannels{Subscribe: []string{"pr-events", "secrets"}}
+	if Sign("t", wider) == Sign("t", withACL) {
+		t.Errorf("widening the ACL did not change the hash")
+	}
+
+	// And the presentation fields still do NOT change it.
+	withLayout := base
+	withLayout.Layout = &Layout{Nodes: map[string]NodePos{"a": {X: 1, Y: 2}}}
+	if Sign("t", withLayout) != bare {
+		t.Errorf("layout changed the hash; it is presentation")
+	}
+}
+
+// A definition that omits Channels must hash byte-identically to one written
+// before the field existed, or every recorded content_sha256 in every
+// deployment becomes wrong on upgrade. The field is last and omitempty for
+// exactly this reason; this pins it.
+func TestSign_OmittedChannelsKeepsTheRecordedHash(t *testing.T) {
+	// The SAME definition the pre-Channels byte-stability test pins, so this
+	// fails the moment Channels stops being omitempty-last.
+	d := Definition{Entry: "a", States: []State{{ID: "a", Handler: Handler{Kind: HandlerTerminal}}}}
+
+	const before = "sha256:4db3ad92f133dda9bd89bcf2d6dc59daa1039e8de15ed16e2d4e60924506a0a0"
+	if got := Sign("t", d); got != before {
+		t.Errorf("hash of a Channels-less definition = %s, want the pre-Channels %s — "+
+			"every recorded hash in every deployment depends on this", got, before)
+	}
+}

--- a/internal/teamgraph/graph.go
+++ b/internal/teamgraph/graph.go
@@ -33,6 +33,8 @@ const (
 	HandlerTerminal     = "terminal"     // an end state; no agent, no outbound edges required
 	HandlerVars         = "vars"         // binds ${var.*} from literals, tokens and captures
 	HandlerInput        = "input"        // the start form: a typed schema the client renders
+	HandlerStarter      = "starter"      // reads ONE channel and dispatches a wave of agent runs
+	HandlerChannel      = "channel"      // publishes to a channel; it does NOT read one
 )
 
 // Transition kinds — the `on` label prefix. success is bare; pushback and
@@ -41,6 +43,18 @@ const (
 	OnSuccess     = "success"
 	OnPushback    = "pushback"    // pushback:<reason>
 	OnConditional = "conditional" // conditional:<expr>
+)
+
+// Fan-out shapes for a starter handler.
+const (
+	FanoutPerMessage = "message" // one run per message read — dynamic N
+	FanoutPerOnce    = "once"    // one run holding the whole batch
+)
+
+// When a starter advances its source cursor.
+const (
+	AckAfterResults = "after_results" // at-least-once: a crash mid-wave redelivers
+	AckAfterRead    = "after_read"    // at-most-once: a crash loses the batch
 )
 
 // Wait modes for a parallel handler (mirrors Channel.await).
@@ -66,6 +80,22 @@ type Definition struct {
 	// anything. Exclusion is by omission: teamContent in sign.go is a whitelist,
 	// so a field is out of the hash unless it is listed there.
 	Layout *Layout `json:"layout,omitempty"`
+	// Channels is the TEAM's channel ACL — the Starter is the single ACL subject
+	// for its source and sink, so the authority lives on the workflow rather
+	// than on each agent in a wave.
+	//
+	// Unlike Colors and Layout this IS content and IS hashed: it is authority,
+	// and authority that can change without changing the definition's identity
+	// is not auditable. It is validated at create/fork to only NARROW what the
+	// authoring principal already holds (trust rule 4 — inherit, never widen).
+	Channels *TeamChannels `json:"channels,omitempty"`
+}
+
+// TeamChannels is the workflow's own channel allowlist, same shape as an
+// agent's so an operator reads one grammar in both places.
+type TeamChannels struct {
+	Publish   []string `json:"publish,omitempty"`
+	Subscribe []string `json:"subscribe,omitempty"`
 }
 
 // State is one node: an id + the handler that runs when a task is in it.
@@ -127,6 +157,95 @@ type Handler struct {
 	// so a team is self-describing and a headless caller sees the same contract
 	// the canvas does.
 	Schema json.RawMessage `json:"schema,omitempty"`
+	// Source — kind=starter ONLY: the ONE channel this node reads. A Starter is
+	// the dispatcher: it listens, spawns a wave, and routes the results onward.
+	//
+	// One channel, not a set. That is what makes the cursor correct: a channel
+	// cursor is keyed (tenant, channel, scope, scope_id) with NO subscriber
+	// dimension, so N readers of one channel share one position and compete for
+	// messages. One subscriber per Starter is one cursor, by construction.
+	Source *StarterSource `json:"source,omitempty"`
+	// Fanout — kind=starter ONLY: how many runs the wave is, and of what.
+	Fanout *StarterFanout `json:"fanout,omitempty"`
+	// Prompt — kind=starter ONLY: the wave's prompt templates. A Starter node
+	// carries its own prompt here rather than in SystemPrompt/InputTemplate,
+	// because the payload it dispatches lands in the reserved
+	// {{starter.message}} / {{starter.messages}} data slots and the node needs
+	// somewhere to put the text around them.
+	Prompt *StarterPrompt `json:"prompt,omitempty"`
+	// Sink — kind=starter ONLY: the channel the RUNTIME publishes each spawned
+	// run's result to. Declared, never instructed: an agent told in its prompt
+	// to publish may forget, and a forgotten publish leaves a downstream wait
+	// hanging on a message that never arrives. Declaring it also means an agent
+	// in a wave needs no channel grant in either direction.
+	Sink *StarterSink `json:"sink,omitempty"`
+	// Channel — kind=channel ONLY: the channel this node publishes to. The
+	// publish-only half of the old `channel` kind; reading belongs to a Starter.
+	Channel string `json:"channel,omitempty"`
+	// Binds — kind=starter ONLY: variable name → a strict-subset JSONPath over
+	// the SOURCE MESSAGE, into ${var.*}. Same projector and same grammar as a
+	// webhook's payload_mapping, so there is one JSONPath dialect in the
+	// runtime rather than two.
+	//
+	// A value bound here is UNTRUSTED — a channel message may be agent-written
+	// or webhook-relayed. It is safe in a prompt or a Memory key and is held to
+	// trust rules 5b/5c wherever it reaches a placeholder argument.
+	Binds map[string]string `json:"binds,omitempty"`
+	// Ack — kind=starter ONLY: when the source cursor advances.
+	// "after_results" (the default) acks once the wave's results are in, which
+	// is at-least-once: a crash mid-wave redelivers the batch. "after_read"
+	// acks on read, which is at-most-once and loses a batch to a crash.
+	Ack string `json:"ack,omitempty"`
+}
+
+// StarterSource is the channel a Starter reads, reusing Channel op=subscribe's
+// vocabulary rather than inventing a second one.
+type StarterSource struct {
+	Channel string `json:"channel"`
+	// Wait — any | at_least. NOT "all": await's `all` counts CHANNELS, so over
+	// a single channel it is identical to `any` and returns after the FIRST
+	// message. A Starter reads one channel, so `all` there is always a silent
+	// wrong answer and validation refuses it.
+	Wait string `json:"wait,omitempty"`
+	// N — the threshold for wait=at_least. A floor only: with dynamic fan-out
+	// the effective count comes from the upstream wave's stamp, because an
+	// authored literal is stale the moment the upstream reads one more message.
+	N int `json:"n,omitempty"`
+	// WaitMS — how long to wait for the predicate before the walk errors. 0
+	// means the operator's long-poll cap.
+	WaitMS int `json:"wait_ms,omitempty"`
+	// Batch — how many messages to read at once. 0 means the store default.
+	Batch int `json:"batch,omitempty"`
+}
+
+// StarterFanout is the shape of one wave.
+type StarterFanout struct {
+	// Agent or Agents — what to run. Exactly one of the two.
+	Agent  string   `json:"agent,omitempty"`
+	Agents []string `json:"agents,omitempty"`
+	// Per — "message" spawns one run per message read (DYNAMIC N); "once"
+	// spawns a single run holding all of them. Default "message".
+	Per string `json:"per,omitempty"`
+	// Max is the hard ceiling on one wave's width, REQUIRED for per=message.
+	// Dynamic fan-out is a spawn amplifier: without a ceiling, a channel that
+	// accumulated a thousand messages becomes a thousand agent runs. The
+	// substrate's own spawn cap still applies above this.
+	Max int `json:"max,omitempty"`
+	// Wait — how the walk waits for the wave. Mirrors the parallel handler's.
+	Wait string `json:"wait,omitempty"`
+}
+
+// StarterPrompt is a wave's prompt. Both templates are operator-authored and
+// expanded like any other node's; the message payload is substituted into the
+// reserved data slots AFTER expansion and is never scanned as template text.
+type StarterPrompt struct {
+	System string `json:"system,omitempty"`
+	Input  string `json:"input,omitempty"`
+}
+
+// StarterSink is where a wave's results go. One message per spawned run.
+type StarterSink struct {
+	Channel string `json:"channel"`
 }
 
 // Layout is the optional canvas geometry: where each node sits. Presentation

--- a/internal/teamgraph/sign.go
+++ b/internal/teamgraph/sign.go
@@ -30,6 +30,15 @@ type teamContent struct {
 	MaxIterations int          `json:"max_iterations,omitempty"`
 	States        []State      `json:"states"`
 	Transitions   []Transition `json:"transitions"`
+	// Channels is the team's channel ACL, and it IS content — unlike Colors and
+	// Layout. It is AUTHORITY, and authority that can change without changing
+	// the definition's identity is not auditable: a verify against a recorded
+	// hash would pass while the workflow had quietly gained a channel.
+	//
+	// Added LAST, with omitempty, for the reason the comment above gives: a
+	// definition that omits it marshals byte-identically to one written before
+	// the field existed, so every recorded content_sha256 stays valid.
+	Channels *TeamChannels `json:"channels,omitempty"`
 }
 
 // Sign returns "sha256:" + the lowercase-hex SHA-256 of a TeamDef's canonical
@@ -42,6 +51,7 @@ func Sign(name string, d Definition) string {
 		MaxIterations: d.MaxIterations,
 		States:        d.States,
 		Transitions:   d.Transitions,
+		Channels:      d.Channels,
 	})
 	if err != nil {
 		buf = []byte("{}")

--- a/internal/teamgraph/starter_validate_test.go
+++ b/internal/teamgraph/starter_validate_test.go
@@ -1,0 +1,139 @@
+package teamgraph
+
+import (
+	"strings"
+	"testing"
+)
+
+// starterDef wraps one starter state in the smallest valid graph.
+func starterDef(h Handler) Definition {
+	return Definition{
+		Entry: "wave",
+		States: []State{
+			{ID: "wave", Handler: h},
+			{ID: "done", Handler: Handler{Kind: HandlerTerminal}},
+		},
+		Transitions: []Transition{{From: "wave", To: "done", On: OnSuccess}},
+	}
+}
+
+func okStarter() Handler {
+	return Handler{
+		Kind:   HandlerStarter,
+		Source: &StarterSource{Channel: "pr-events"},
+		Fanout: &StarterFanout{Agent: "reviewer", Per: FanoutPerMessage, Max: 8},
+		Sink:   &StarterSink{Channel: "verdicts"},
+	}
+}
+
+func TestValidate_StarterHappyPath(t *testing.T) {
+	if err := Validate(starterDef(okStarter())); err != nil {
+		t.Fatalf("a minimal starter must validate: %v", err)
+	}
+}
+
+// Each of these is a definition that would otherwise dispatch the wrong number
+// of runs, dispatch them nowhere, or wait for something that cannot arrive.
+func TestValidate_StarterRefusals(t *testing.T) {
+	mut := func(f func(h *Handler)) Handler {
+		h := okStarter()
+		f(&h)
+		return h
+	}
+	cases := []struct {
+		name string
+		h    Handler
+		want string
+	}{
+		{"no source", mut(func(h *Handler) { h.Source = nil }), "requires `source.channel`"},
+		{"empty source channel", mut(func(h *Handler) { h.Source.Channel = "  " }), "requires `source.channel`"},
+		// `all` counts CHANNELS; over the one channel a starter reads it returns
+		// after the FIRST message, so it silently yields one of N.
+		{"wait=all", mut(func(h *Handler) { h.Source.Wait = WaitAll }), "counts CHANNELS"},
+		{"wait=at_least without n", mut(func(h *Handler) { h.Source.Wait = WaitAtLeast }), "requires `n` >= 1"},
+		{"unknown wait", mut(func(h *Handler) { h.Source.Wait = "eventually" }), "invalid wait"},
+		{"no fanout", mut(func(h *Handler) { h.Fanout = nil }), "requires `fanout`"},
+		{"both agent and agents", mut(func(h *Handler) { h.Fanout.Agents = []string{"a"} }), "exactly one of"},
+		{"neither agent nor agents", mut(func(h *Handler) { h.Fanout.Agent = "" }), "exactly one of"},
+		{"empty agent name in agents", mut(func(h *Handler) { h.Fanout.Agent = ""; h.Fanout.Agents = []string{" "} }), "empty agent name"},
+		// Dynamic fan-out is a spawn amplifier — the ceiling is not optional.
+		{"per=message without max", mut(func(h *Handler) { h.Fanout.Max = 0 }), "requires `max` >= 1"},
+		{"per=once with max", mut(func(h *Handler) { h.Fanout.Per = FanoutPerOnce }), "`max` means nothing"},
+		{"unknown per", mut(func(h *Handler) { h.Fanout.Per = "each" }), "invalid per"},
+		{"sink with no channel", mut(func(h *Handler) { h.Sink = &StarterSink{} }), "names no channel"},
+		{"unknown ack", mut(func(h *Handler) { h.Ack = "never" }), "invalid ack"},
+		{"agents on the handler itself", mut(func(h *Handler) { h.Agent = "x" }), "names its agents in `fanout`"},
+		{"negative batch", mut(func(h *Handler) { h.Source.Batch = -1 }), "must be >= 0"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := Validate(starterDef(c.h))
+			if err == nil {
+				t.Fatalf("accepted; want a refusal mentioning %q", c.want)
+			}
+			if !strings.Contains(err.Error(), c.want) {
+				t.Errorf("refused with %q, want it to mention %q", err, c.want)
+			}
+		})
+	}
+}
+
+// A starter's fields on any other kind would read as configured and do nothing
+// — the silent-setting failure `set` and `schema` are already guarded against.
+func TestValidate_StarterFieldsOnAnotherKindAreRefused(t *testing.T) {
+	cases := []struct {
+		name string
+		h    Handler
+		want string
+	}{
+		{"source", Handler{Kind: HandlerAgent, Agent: "a", Source: &StarterSource{Channel: "c"}}, "starter only"},
+		{"fanout", Handler{Kind: HandlerAgent, Agent: "a", Fanout: &StarterFanout{Agent: "b", Max: 1}}, "starter only"},
+		{"sink", Handler{Kind: HandlerAgent, Agent: "a", Sink: &StarterSink{Channel: "c"}}, "starter only"},
+		{"binds", Handler{Kind: HandlerAgent, Agent: "a", Binds: map[string]string{"x": "$.y"}}, "starter only"},
+		{"ack", Handler{Kind: HandlerAgent, Agent: "a", Ack: AckAfterRead}, "starter only"},
+		{"prompt", Handler{Kind: HandlerAgent, Agent: "a", Prompt: &StarterPrompt{Input: "hi"}}, "`system_prompt` + `input_template`"},
+		{"channel on an agent", Handler{Kind: HandlerAgent, Agent: "a", Channel: "c"}, "names its channels in `source`/`sink`"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := Validate(starterDef(c.h))
+			if err == nil || !strings.Contains(err.Error(), c.want) {
+				t.Errorf("err = %v, want a refusal mentioning %q", err, c.want)
+			}
+		})
+	}
+}
+
+// The `channel` kind PUBLISHES. Reading is a starter's job, and a channel node
+// that set a source would be a second reader competing on the same cursor.
+func TestValidate_ChannelKindPublishesOnly(t *testing.T) {
+	if err := Validate(starterDef(Handler{Kind: HandlerChannel, Channel: "verdicts"})); err != nil {
+		t.Fatalf("a publish-only channel node must validate: %v", err)
+	}
+	for _, c := range []struct {
+		name string
+		h    Handler
+		want string
+	}{
+		{"no channel", Handler{Kind: HandlerChannel}, "requires `channel`"},
+		{"with an agent", Handler{Kind: HandlerChannel, Channel: "c", Agent: "a"}, "it publishes, it does not run"},
+		{"with a source", Handler{Kind: HandlerChannel, Channel: "c", Source: &StarterSource{Channel: "x"}}, "is a `starter`, not a `channel`"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			err := Validate(starterDef(c.h))
+			if err == nil || !strings.Contains(err.Error(), c.want) {
+				t.Errorf("err = %v, want a refusal mentioning %q", err, c.want)
+			}
+		})
+	}
+}
+
+// binds share the capture validator, so a malformed JSONPath is refused at
+// authoring rather than binding nothing at run time.
+func TestValidate_StarterBindsAreValidatedLikeCapture(t *testing.T) {
+	h := okStarter()
+	h.Binds = map[string]string{"pr": "not a path"}
+	if err := Validate(starterDef(h)); err == nil {
+		t.Errorf("a malformed binds path was accepted")
+	}
+}

--- a/internal/teamgraph/validate.go
+++ b/internal/teamgraph/validate.go
@@ -164,6 +164,20 @@ func validateHandler(stateID string, h Handler) error {
 		if len(h.Schema) > 0 && !json.Valid(h.Schema) {
 			return fmt.Errorf("team definition: state %q input handler `schema` is not valid JSON", stateID)
 		}
+	case HandlerStarter:
+		if err := validateStarter(stateID, h); err != nil {
+			return err
+		}
+	case HandlerChannel:
+		if strings.TrimSpace(h.Channel) == "" {
+			return fmt.Errorf("team definition: state %q channel handler requires `channel`", stateID)
+		}
+		if h.Agent != "" || len(h.Agents) != 0 || h.Consolidator != "" {
+			return fmt.Errorf("team definition: state %q channel handler must not set agent/agents/consolidator — it publishes, it does not run", stateID)
+		}
+		if h.Source != nil {
+			return fmt.Errorf("team definition: state %q channel handler must not set `source` — reading a channel is a `starter`, not a `channel`", stateID)
+		}
 	case HandlerTerminal:
 		if h.Agent != "" || len(h.Agents) != 0 || h.Consolidator != "" {
 			return fmt.Errorf("team definition: state %q terminal handler must not set agent/agents/consolidator", stateID)
@@ -171,7 +185,29 @@ func validateHandler(stateID string, h Handler) error {
 	case "":
 		return fmt.Errorf("team definition: state %q handler is missing a `kind`", stateID)
 	default:
-		return fmt.Errorf("team definition: state %q has unknown handler kind %q (want agent|parallel|consolidator|terminal|vars|input)", stateID, h.Kind)
+		return fmt.Errorf("team definition: state %q has unknown handler kind %q (want agent|parallel|consolidator|terminal|vars|input|starter|channel)", stateID, h.Kind)
+	}
+	// The Starter's own fields belong to the Starter. Left on another kind they
+	// would read as configured and do nothing — the same silent-setting failure
+	// `set` and `schema` are guarded against above.
+	if h.Kind != HandlerStarter {
+		switch {
+		case h.Source != nil:
+			return fmt.Errorf("team definition: state %q sets `source` but is kind %q (starter only)", stateID, h.Kind)
+		case h.Fanout != nil:
+			return fmt.Errorf("team definition: state %q sets `fanout` but is kind %q (starter only)", stateID, h.Kind)
+		case h.Sink != nil:
+			return fmt.Errorf("team definition: state %q sets `sink` but is kind %q (starter only)", stateID, h.Kind)
+		case len(h.Binds) > 0:
+			return fmt.Errorf("team definition: state %q sets `binds` but is kind %q (starter only)", stateID, h.Kind)
+		case h.Ack != "":
+			return fmt.Errorf("team definition: state %q sets `ack` but is kind %q (starter only)", stateID, h.Kind)
+		case h.Prompt != nil:
+			return fmt.Errorf("team definition: state %q sets `prompt` but is kind %q — another kind's prompts are `system_prompt` + `input_template`", stateID, h.Kind)
+		}
+	}
+	if h.Kind != HandlerChannel && strings.TrimSpace(h.Channel) != "" {
+		return fmt.Errorf("team definition: state %q sets `channel` but is kind %q — a starter names its channels in `source`/`sink`", stateID, h.Kind)
 	}
 	if h.Kind != HandlerVars && len(h.Set) > 0 {
 		return fmt.Errorf("team definition: state %q sets `set` but is kind %q — assignment belongs on a `vars` state, where it is visible", stateID, h.Kind)
@@ -240,6 +276,80 @@ func sortedKeys(m map[string]string) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+// validateStarter checks a starter handler's shape. Every refusal here is a
+// definition that would otherwise dispatch the wrong number of runs, dispatch
+// them to nowhere, or wait for something that can never arrive — each a silent
+// wrong answer rather than an error at run time.
+func validateStarter(stateID string, h Handler) error {
+	if h.Agent != "" || len(h.Agents) != 0 || h.Consolidator != "" {
+		return fmt.Errorf("team definition: state %q starter handler names its agents in `fanout`, not in agent/agents/consolidator", stateID)
+	}
+	if h.Source == nil || strings.TrimSpace(h.Source.Channel) == "" {
+		return fmt.Errorf("team definition: state %q starter handler requires `source.channel` — a starter reads exactly one channel", stateID)
+	}
+	// `all` counts CHANNELS, not messages (Channel op=await's predicate). Over
+	// the single channel a starter reads it is therefore identical to `any` and
+	// returns after the FIRST message, so "wait for all of them" written as
+	// `all` silently yields one of N. It is never what the author meant.
+	switch h.Source.Wait {
+	case "", WaitAny:
+	case WaitAtLeast:
+		if h.Source.N < 1 {
+			return fmt.Errorf("team definition: state %q starter source wait=at_least requires `n` >= 1", stateID)
+		}
+	case WaitAll:
+		return fmt.Errorf("team definition: state %q starter source wait=%q counts CHANNELS, and a starter reads ONE — "+
+			"over one channel it returns after the first message. Use at_least with `n`, or any", stateID, WaitAll)
+	default:
+		return fmt.Errorf("team definition: state %q starter source has invalid wait %q (want any|at_least)", stateID, h.Source.Wait)
+	}
+	if h.Source.WaitMS < 0 || h.Source.Batch < 0 || h.Source.N < 0 {
+		return fmt.Errorf("team definition: state %q starter source wait_ms/batch/n must be >= 0", stateID)
+	}
+
+	if h.Fanout == nil {
+		return fmt.Errorf("team definition: state %q starter handler requires `fanout`", stateID)
+	}
+	hasOne, hasMany := strings.TrimSpace(h.Fanout.Agent) != "", len(h.Fanout.Agents) > 0
+	if hasOne == hasMany {
+		return fmt.Errorf("team definition: state %q starter fanout needs exactly one of `agent` or `agents`", stateID)
+	}
+	for _, a := range h.Fanout.Agents {
+		if strings.TrimSpace(a) == "" {
+			return fmt.Errorf("team definition: state %q starter fanout has an empty agent name", stateID)
+		}
+	}
+	switch h.Fanout.Per {
+	case "", FanoutPerMessage:
+		// Dynamic fan-out is a spawn amplifier: one run per message, and the
+		// message count is whatever accumulated on the channel. An authored
+		// ceiling is the only thing the author controls, so it is required.
+		if h.Fanout.Max < 1 {
+			return fmt.Errorf("team definition: state %q starter fanout per=message requires `max` >= 1 — "+
+				"the wave is as wide as the channel is deep, so the ceiling is not optional", stateID)
+		}
+	case FanoutPerOnce:
+		if h.Fanout.Max != 0 {
+			return fmt.Errorf("team definition: state %q starter fanout per=once spawns one run, so `max` means nothing", stateID)
+		}
+	default:
+		return fmt.Errorf("team definition: state %q starter fanout has invalid per %q (want message|once)", stateID, h.Fanout.Per)
+	}
+	if err := validateWait(stateID, h.Fanout.Wait); err != nil {
+		return err
+	}
+
+	if h.Sink != nil && strings.TrimSpace(h.Sink.Channel) == "" {
+		return fmt.Errorf("team definition: state %q starter `sink` is present but names no channel", stateID)
+	}
+	switch h.Ack {
+	case "", AckAfterResults, AckAfterRead:
+	default:
+		return fmt.Errorf("team definition: state %q starter has invalid ack %q (want after_results|after_read)", stateID, h.Ack)
+	}
+	return validateCapture(stateID, h.Binds)
 }
 
 func validateWait(stateID, wait string) error {

--- a/internal/tools/builtin/teamdef.go
+++ b/internal/tools/builtin/teamdef.go
@@ -227,6 +227,9 @@ func (t *TeamDef) execCreate(ctx context.Context, in teamDefInput) (tools.Result
 	if err := teamgraph.Validate(def); err != nil {
 		return errResult(fmt.Sprintf("create: %s", err)), nil
 	}
+	if err := checkTeamChannelAuthority(ctx, def); err != nil {
+		return errResult(fmt.Sprintf("create: %s", err)), nil
+	}
 	if err := t.checkSizeCaps(defJSON, in.Description); err != nil {
 		return errResult(fmt.Sprintf("create: %s", err)), nil
 	}
@@ -335,6 +338,9 @@ func (t *TeamDef) execFork(ctx context.Context, in teamDefInput) (tools.Result, 
 		return errResult(fmt.Sprintf("fork: %s", err)), nil
 	}
 	if err := teamgraph.Validate(def); err != nil {
+		return errResult(fmt.Sprintf("fork: %s", err)), nil
+	}
+	if err := checkTeamChannelAuthority(ctx, def); err != nil {
 		return errResult(fmt.Sprintf("fork: %s", err)), nil
 	}
 	if err := t.checkSizeCaps(defJSON, in.Description); err != nil {
@@ -862,6 +868,43 @@ func (t *TeamDef) buildDefinition(parentJSON string, overlay json.RawMessage) (j
 // applyTeamOverlay merges ov over base per top-level field. Scalars set-if-set;
 // slices/maps replace wholesale (never element-merged) since the graph is a
 // cohesive unit.
+// checkTeamChannelAuthority enforces trust rule 4 on `Definition.Channels`:
+// the workflow's ACL may only NARROW what the authoring principal already
+// holds. Inherit, never widen.
+//
+// This is the half of the team ACL that matters. The field itself is only data;
+// what makes it authority is that the Starter reads and publishes under it
+// rather than under each agent's own grants, so an author who could write a
+// channel into it that they cannot reach themselves would have escalated by
+// authoring a definition. Checked at create AND fork, because a fork is an
+// authoring act by whoever forks, not by whoever wrote the parent.
+//
+// An author with NO channel policy at all can declare no channels — the same
+// default-deny every other channel surface applies, rather than "no policy
+// means no limit".
+func checkTeamChannelAuthority(ctx context.Context, def teamgraph.Definition) error {
+	if def.Channels == nil {
+		return nil
+	}
+	pol := tools.ChannelPolicy(ctx)
+	for _, side := range []struct {
+		name    string
+		want    []string
+		granted []string
+	}{
+		{"publish", def.Channels.Publish, pol.Publish},
+		{"subscribe", def.Channels.Subscribe, pol.Subscribe},
+	} {
+		for _, ch := range side.want {
+			if !channelAllowed(ch, side.granted) {
+				return fmt.Errorf("channels.%s: %q is not in the authoring principal's own %s allowlist — "+
+					"a team ACL may only narrow what its author holds, never widen it", side.name, ch, side.name)
+			}
+		}
+	}
+	return nil
+}
+
 func applyTeamOverlay(base *teamgraph.Definition, ov teamgraph.Definition) {
 	if ov.Entry != "" {
 		base.Entry = ov.Entry
@@ -884,6 +927,13 @@ func applyTeamOverlay(base *teamgraph.Definition, ov teamgraph.Definition) {
 	// hash, so a layout-only fork keeps the parent's identity.
 	if ov.Layout != nil {
 		base.Layout = ov.Layout
+	}
+	// Every Definition field needs a case here or a fork returns 200, mints a
+	// version and silently drops it — which is exactly what happened to Layout
+	// when it was added. Channels is the ACL, so dropping it would hand a
+	// forked workflow no channel authority and fail at run time instead.
+	if ov.Channels != nil {
+		base.Channels = ov.Channels
 	}
 }
 

--- a/internal/tools/builtin/teamdef_channels_test.go
+++ b/internal/tools/builtin/teamdef_channels_test.go
@@ -1,0 +1,130 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// authoringCtx is a teamdef ctx whose principal holds the given channel grants,
+// so the team-ACL narrowing check has something to narrow FROM.
+func authoringCtx(publish, subscribe []string) context.Context {
+	ctx := tools.WithRunIdentity(context.Background(), tools.RunIdentityValue{AgentID: "a_test"})
+	return tools.WithChannelPolicy(ctx, tools.ChannelPolicyValue{
+		Publish:   publish,
+		Subscribe: subscribe,
+	})
+}
+
+const starterGraph = `{"entry":"wave","states":[` +
+	`{"state":"wave","handler":{"kind":"starter","source":{"channel":"pr-events"},` +
+	`"fanout":{"agent":"reviewer","per":"message","max":4},"sink":{"channel":"verdicts"}}},` +
+	`{"state":"done","handler":{"kind":"terminal"}}],` +
+	`"transitions":[{"from":"wave","to":"done","on":"success"}]}`
+
+// A fork that supplies ONLY channels must keep them. Every Definition field
+// needs its own applyTeamOverlay case; Layout was added without one and a fork
+// returned 200, minted a version and silently dropped every node position.
+// Dropping the ACL instead would hand a forked workflow no channel authority.
+func TestTeamDef_ForkKeepsTheChannelACL(t *testing.T) {
+	tool, _, cleanup := teamDefFixture(t)
+	defer cleanup()
+	ctx := authoringCtx([]string{"verdicts"}, []string{"pr-events"})
+
+	created := createTeam(t, tool, ctx, "triage",
+		strings.TrimSuffix(starterGraph, "}")+`,"channels":{"publish":["verdicts"],"subscribe":["pr-events"]}}`)
+	_ = created
+
+	res, _ := tool.Execute(ctx, json.RawMessage(
+		`{"op":"fork","name":"triage","overlay":{"max_iterations":7}}`))
+	if res.IsError {
+		t.Fatalf("fork: %s", res.Text)
+	}
+	forked := decodeResult(t, res.Text)
+	defID, _ := forked["def_id"].(string)
+
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"get","def_id":"`+defID+`"}`))
+	if res.IsError {
+		t.Fatalf("get: %s", res.Text)
+	}
+	def, ok := decodeResult(t, res.Text)["definition"].(map[string]any)
+	if !ok {
+		t.Fatalf("no definition in the forked def")
+	}
+	chans, ok := def["channels"].(map[string]any)
+	if !ok {
+		t.Fatalf("the fork DROPPED the channel ACL: %v", def)
+	}
+	sub, _ := chans["subscribe"].([]any)
+	if len(sub) != 1 || sub[0] != "pr-events" {
+		t.Errorf("subscribe = %v, want [pr-events]", chans["subscribe"])
+	}
+}
+
+// Trust rule 4: a team ACL may only NARROW what its author holds. The field is
+// only data; what makes it authority is that the Starter reads and publishes
+// under it rather than under each agent's grants, so an author who could name a
+// channel they cannot reach would escalate by authoring a definition.
+func TestTeamDef_ChannelACLCannotWidenTheAuthorsOwn(t *testing.T) {
+	for _, c := range []struct {
+		name    string
+		pub     []string
+		sub     []string
+		acl     string
+		wantErr string
+	}{
+		{"narrower is fine", []string{"verdicts", "other"}, []string{"pr-events", "more"},
+			`{"publish":["verdicts"],"subscribe":["pr-events"]}`, ""},
+		{"equal is fine", []string{"verdicts"}, []string{"pr-events"},
+			`{"publish":["verdicts"],"subscribe":["pr-events"]}`, ""},
+		{"wider subscribe is refused", []string{"verdicts"}, []string{"pr-events"},
+			`{"subscribe":["pr-events","secrets"]}`, "may only narrow"},
+		{"wider publish is refused", []string{"verdicts"}, []string{"pr-events"},
+			`{"publish":["verdicts","payouts"]}`, "may only narrow"},
+		// No policy is default-deny, not "no limit".
+		{"no policy at all cannot declare one", nil, nil,
+			`{"subscribe":["pr-events"]}`, "may only narrow"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			tool, _, cleanup := teamDefFixture(t)
+			defer cleanup()
+			ctx := authoringCtx(c.pub, c.sub)
+			res, _ := tool.Execute(ctx, json.RawMessage(
+				`{"op":"create","name":"t","overlay":`+strings.TrimSuffix(starterGraph, "}")+`,"channels":`+c.acl+`}}`))
+			if c.wantErr == "" {
+				if res.IsError {
+					t.Fatalf("create refused a narrowing ACL: %s", res.Text)
+				}
+				return
+			}
+			if !res.IsError {
+				t.Fatalf("create accepted a widening ACL")
+			}
+			if !strings.Contains(res.Text, c.wantErr) {
+				t.Errorf("refusal = %q, want it to mention %q", res.Text, c.wantErr)
+			}
+		})
+	}
+}
+
+// The same check runs on FORK, because a fork is an authoring act by whoever
+// forks — not by whoever wrote the parent.
+func TestTeamDef_ForkCannotWidenTheChannelACL(t *testing.T) {
+	tool, _, cleanup := teamDefFixture(t)
+	defer cleanup()
+	broad := authoringCtx([]string{"verdicts"}, []string{"pr-events"})
+	createTeam(t, tool, broad, "triage",
+		strings.TrimSuffix(starterGraph, "}")+`,"channels":{"subscribe":["pr-events"]}}`)
+
+	res, _ := tool.Execute(broad, json.RawMessage(
+		`{"op":"fork","name":"triage","overlay":{"channels":{"subscribe":["pr-events","secrets"]}}}`))
+	if !res.IsError {
+		t.Fatalf("a fork widened the team ACL")
+	}
+	if !strings.Contains(res.Text, "may only narrow") {
+		t.Errorf("refusal = %q, want it to mention narrowing", res.Text)
+	}
+}


### PR DESCRIPTION
**RFC CY phase L4a** — the first of five PRs building the Starter, per the [confirmed implementation plan](https://github.com/denn-gubsky/loomcycle). The graph shape only: no runtime behind it yet, and `teamgraph` stays pure stdlib so `config` can keep importing it for boot validation.

## What a Starter is

The dispatcher the design was missing: it reads **one** channel, spawns a wave, and the runtime routes each result onward. One channel is not a simplification — a channel cursor is keyed `(tenant, channel, scope, scope_id)` with **no subscriber dimension**, so N readers of one channel share one position and compete for messages. One subscriber per Starter is one cursor, by construction.

`channel` survives as a **publish-only** kind. Reading belongs to a Starter; a channel node that could also read would be the second reader the cursor can't support.

## Every refusal is a silent wrong answer otherwise

- **`source.wait: all`** counts *channels* (`Channel op=await`'s predicate), so over the one channel a Starter reads it's identical to `any` and returns after the **first** message. "Wait for all the reviewers" written that way yields one of N, with no error anywhere. Refused, naming `at_least`.
- **`per: message` without `max`** — dynamic fan-out is a spawn amplifier and the wave is as wide as the channel is deep, so the ceiling isn't optional.
- **A Starter's fields on any other kind** (`source`, `fanout`, `sink`, `binds`, `ack`, `prompt`) — they'd read as configured and do nothing, the same silent-setting failure `set` and `schema` are already guarded against.

## Two traps this phase exists to not fall into

Both from L1's corrections log:

1. **`applyTeamOverlay` merges per top-level field.** Adding `Definition.Channels` without its case would mean a fork returns 200, mints a version, and silently drops the ACL — which is exactly what happened to `Layout`. The case is here, with a test that forks a def supplying only channels.
2. **`Definition.Channels` is content and *is* hashed**, unlike `Colors` and `Layout`. It's **authority**, and authority that can change without changing the definition's identity isn't auditable: a verify against a recorded hash would pass while the workflow had quietly gained a channel. Added last with `omitempty` so a definition omitting it still hashes byte-identically — the pre-Channels literal is re-pinned in a second test for exactly that.

## Trust rule 4, enforced where the policy exists

The ACL may only **narrow** what the authoring principal holds, checked at create **and fork** — a fork is an authoring act by whoever forks, not by whoever wrote the parent. It lives in the tool rather than `teamgraph.Validate` because narrowing needs the caller's channel policy and `teamgraph` is pure graph shape. An author with no channel policy can declare nothing: default-deny, not "no policy means no limit".

## Tested

`go test ./...` clean (**100 packages**, full output grepped for `FAIL`): 16 starter refusals, 7 field-on-the-wrong-kind refusals, 3 channel-kind rules, the fork-keeps-the-ACL trap, 5 narrowing cases including no-policy, and the hash pinned in both directions.

**Fail-before verified on all three guards** — dropping the overlay case fails with the dropped ACL printed; dropping `Channels` from the hash fails both hash assertions; dropping the `wait=all` refusal fails that subtest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD