### PR TITLE
fix(memory): a merge must reach the chunk, not just the k/v row

### DIFF
--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -2436,7 +2436,20 @@ agents:
         // a scope-blind memo would hand back a user-scope chunk id for a tenant write and
         // silently attach the edge to the wrong document.
         var memo = scope + "\u0000" + naturalKey;
-        if (st.entity_ids[memo]) { return st.entity_ids[memo]; }
+        // THE MEMO SKIPS A REPEAT WRITE, SO IT MUST NOT SKIP A CHANGED ONE.
+        //
+        // It exists for the SUBJECT node, which recurs across every fact about the same
+        // thing and carries only an identity — re-writing it says nothing new. A FACT
+        // node carries a body, and a body can change within a single pass: the merge
+        // path rewrites a neighbour in place under its own key, which is the mechanism
+        // that collapses duplicates.
+        //
+        // MEASURED on a real corpus: of 4 facts merged in a pass, 3 ended with different
+        // TEXT in the two planes — the k/v row held the merged wording and the chunk
+        // still held the original, revision 1, never rewritten. Harmless only while the
+        // k/v row is the fact's home. Once the chunk is the only home, every merge is
+        // silently discarded and the duplicates it exists to collapse come back.
+        if (st.entity_ids[memo] && !nonEmpty(args.body)) { return st.entity_ids[memo]; }
         try {
           args.op = "upsert_chunk";
           args.scope = scope;

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -2436,7 +2436,20 @@ agents:
         // a scope-blind memo would hand back a user-scope chunk id for a tenant write and
         // silently attach the edge to the wrong document.
         var memo = scope + "\u0000" + naturalKey;
-        if (st.entity_ids[memo]) { return st.entity_ids[memo]; }
+        // THE MEMO SKIPS A REPEAT WRITE, SO IT MUST NOT SKIP A CHANGED ONE.
+        //
+        // It exists for the SUBJECT node, which recurs across every fact about the same
+        // thing and carries only an identity — re-writing it says nothing new. A FACT
+        // node carries a body, and a body can change within a single pass: the merge
+        // path rewrites a neighbour in place under its own key, which is the mechanism
+        // that collapses duplicates.
+        //
+        // MEASURED on a real corpus: of 4 facts merged in a pass, 3 ended with different
+        // TEXT in the two planes — the k/v row held the merged wording and the chunk
+        // still held the original, revision 1, never rewritten. Harmless only while the
+        // k/v row is the fact's home. Once the chunk is the only home, every merge is
+        // silently discarded and the duplicates it exists to collapse come back.
+        if (st.entity_ids[memo] && !nonEmpty(args.body)) { return st.entity_ids[memo]; }
         try {
           args.op = "upsert_chunk";
           args.scope = scope;

--- a/cmd/loomcycle/presets_memory_codejs_test.go
+++ b/cmd/loomcycle/presets_memory_codejs_test.go
@@ -2956,6 +2956,78 @@ func TestConsolidator_MirrorsTypedFactsIntoAGraph(t *testing.T) {
 	}
 }
 
+// TestConsolidator_AMergeReachesTheChunkToo.
+//
+// The merge path rewrites a recalled neighbour IN PLACE under its own key — that is
+// the mechanism that collapses duplicates. upsertEntityChunk memoised per natural
+// key and returned the cached id without calling the tool again, so the merged
+// wording never reached the chunk: the k/v row held it and the chunk still held the
+// original, revision 1.
+//
+// MEASURED on a real corpus before this fix: of 4 facts merged in a pass, 3 ended
+// with different TEXT in the two planes. Invisible while the k/v row is the fact's
+// home; once the chunk is the only home, every merge is silently discarded and the
+// duplicates it exists to collapse come back.
+//
+// The fixture is the one the in-place merge test already uses, because the bug only
+// appears when the SAME natural key is written twice in one pass — two facts that
+// merely resemble each other slug to two different keys and would pass either way.
+func TestConsolidator_AMergeReachesTheChunkToo(t *testing.T) {
+	const (
+		first  = "Denn prefers Go over Python for backend services."
+		second = "Denn prefers Go rather than Python for backend services."
+	)
+	f := newFakeToolset()
+	f.bands = map[string]any{"merge_threshold": 0.75, "related_threshold": 0.40}
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	f.transcript = "user: I prefer Go over Python.\nassistant: ok"
+	// type+subject so the fact is mirrored into the graph at all.
+	f.factsJSON = `[{"text":"` + first + `","class":"preference","type":"person","subject":"Denn"},
+	                {"text":"` + second + `","class":"preference","type":"person","subject":"Denn"}]`
+	// One pre-existing row in the RELATED band, exactly as the in-place merge test
+	// sets it up — the scripted similarity is what makes the second wording recall
+	// the first and merge onto its key.
+	f.vectors = map[string]string{
+		"memory/fact/denn-works-mostly-backend-services": "Denn works mostly on backend services.",
+	}
+
+	res := runConsolidator(t, f)
+	if !strings.Contains(res.FinalText, "updated in place 1") {
+		t.Fatalf("fixture: the paraphrase did not merge, so the same natural key is never "+
+			"written twice and this test proves nothing; report = %q", res.FinalText)
+	}
+
+	// Both writes must have REACHED the tool. Under the old memo the second was
+	// answered from the cache and never issued, so the chunk kept the first wording.
+	var bodies []string
+	for _, c := range callsWithOp(f, "Document.upsert_chunk") {
+		if b, ok := c.Input["body"].(string); ok && b != "" {
+			bodies = append(bodies, b)
+		}
+	}
+	if len(bodies) < 2 {
+		t.Errorf("only %d content-bearing chunk write(s) reached the tool (%v) — the rewrite "+
+			"under an existing natural key was answered from the memo, so the chunk keeps the "+
+			"stale wording while the k/v row has the merged one", len(bodies), bodies)
+	}
+	if len(bodies) > 0 && bodies[len(bodies)-1] != second {
+		t.Errorf("the last chunk write carried %q, want the merged wording %q", bodies[len(bodies)-1], second)
+	}
+
+	// And the SUBJECT node must still be memoised: both facts are about Denn, and
+	// re-writing an identity that cannot change is the cost the memo exists to avoid.
+	subjectWrites := 0
+	for _, c := range callsWithOp(f, "Document.upsert_chunk") {
+		if b, _ := c.Input["body"].(string); b == "" {
+			subjectWrites++
+		}
+	}
+	if subjectWrites > 1 {
+		t.Errorf("the subject node was written %d times for one subject — the memo must still "+
+			"short-circuit a write that carries no content", subjectWrites)
+	}
+}
+
 // TestConsolidator_TheTwoPlanesAgreeOnEveryTemporalField is the DRIFT GATE for
 // the dual-write window (RFC CV P2c).
 //


### PR DESCRIPTION
Found by measuring both planes **before** the collapse — which is the whole reason to measure first. This is a live data-correctness bug today, and the collapse would have made it permanent and silent.

## The measurement

Fresh LoCoMo corpus pass on a rig built from `main` (served commit asserted), **91 facts**, both planes compared field by field:

| | |
|---|---|
| **reachability** | **91/91** — every k/v fact has its chunk, none orphaned either way |
| valid_at, session_id, embedding | agree on all 91 |
| run_id | chunk has it on 91/91, k/v on **0** — the chunk plane is strictly better |
| access_count | 74/91 differ (known, and P2f's job) |
| **text** | **3 of the 4 MERGED facts differ**; all 87 written-once facts agree |

```
memory/identity/caroline-identifies-transgender   (chunk revision = 1)
  k/v   "Caroline identifies as trans."          <- the merged wording
  chunk "Caroline identifies as transgender."    <- the original
```

Chunk revision is **1** on every one of them: the body was never rewritten.

## Why

`upsertEntityChunk` memoises the chunk id per `(scope, natural key)` and returned the cached id **without calling the tool again**.

The memo is right for a **subject** node — it recurs across every fact about the same thing and carries only an identity, so re-writing it says nothing new. It is wrong for a **fact** node, because a fact's body can change within a single pass: the merge path rewrites a recalled neighbour in place under its own key, and that is the mechanism that collapses duplicates.

So the k/v row holds the merged wording and the chunk still holds the first one. Invisible while the k/v row is the fact's home. **Once the chunk is the only home, every merge is silently discarded** — the duplicates merging exists to collapse come straight back, and nothing reports it.

The fix is one condition: the memo short-circuits only a write that carries **no content**.

## What was tested

`TestConsolidator_AMergeReachesTheChunkToo` — both halves: every content-bearing write reaches the tool and carries the merged wording, **and** the subject node is still written once (removing the memo outright would re-write one identity node per fact, which is the cost it exists to avoid).

**My first version of this test was vacuous and passed against the unfixed code.** Two facts that merely resemble each other slug to two different keys, so the same natural key was never written twice. It now uses the fixture the in-place merge test already uses, and asserts `updated in place 1` as an explicit **fixture guard**, so a fixture that stops exercising the merge fails loudly instead of quietly proving nothing.

Fail-before: `only 1 content-bearing chunk write(s) reached the tool … the chunk keeps the stale wording while the k/v row has the merged one`.

`go test ./...` clean; both bundle copies byte-identical.

## What this means for P2f

Reachability being 91/91 means **no backfill is needed** — the collapse's "create a chunk for any unmirrored fact" step has nothing to do on a corpus written by current code. What remains for the delete is narrower than planned: copy `access_count`, flip `FactsAreChunkHomed`, stop the k/v write, delete.

Two smaller residues the measurement also surfaced, neither blocking, both worth recording: `invalid_at` differs on 2 superseded facts because the planes express retirement differently (`superseded_at` vs `invalid_at`+`expired_at`), and `origin` differs on 2 rewritten facts in **both** directions — the same dual-write staleness this PR fixes, seen through a different column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8