### PR TITLE
feat(teamrun): the Starter fans out — dynamic N, bounded twice, counted once

### DIFF
--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -924,6 +924,12 @@ func (s *Server) SetTeamDefTool(t tools.Tool) {
 				return nil
 			}
 		}
+		if td.MaxWave == 0 {
+			// The same ceiling the external fan-out surface uses. One number for
+			// "how many runs may one call start", so an operator who tunes it
+			// tunes both rather than discovering a second one later.
+			td.MaxWave = connector.MaxBatchSpawns
+		}
 		if td.WaveContext == nil {
 			td.WaveContext = func(ctx context.Context, walkID, waveID string, index int) context.Context {
 				return store.WithWaveTask(ctx, store.WaveTask{WalkID: walkID, WaveID: waveID, Index: index})

--- a/internal/teamgraph/starter_validate_test.go
+++ b/internal/teamgraph/starter_validate_test.go
@@ -137,3 +137,22 @@ func TestValidate_StarterBindsAreValidatedLikeCapture(t *testing.T) {
 		t.Errorf("a malformed binds path was accepted")
 	}
 }
+
+// binds project THE source message, so they contradict per=once — which hands
+// the agent the whole batch and has no "the" message to project from. Binding
+// from an arbitrary one of N would be a silent choice the author never made.
+func TestValidate_StarterBindsContradictPerOnce(t *testing.T) {
+	h := okStarter()
+	h.Fanout.Per = FanoutPerOnce
+	h.Fanout.Max = 0
+	h.Binds = map[string]string{"pr": "$.pull_request.number"}
+	err := Validate(starterDef(h))
+	if err == nil || !strings.Contains(err.Error(), "binds project ONE source message") {
+		t.Errorf("err = %v, want a refusal explaining the contradiction", err)
+	}
+	// …and are fine on per=message, which is the default.
+	h.Fanout.Per, h.Fanout.Max = FanoutPerMessage, 4
+	if err := Validate(starterDef(h)); err != nil {
+		t.Errorf("binds with per=message refused: %v", err)
+	}
+}

--- a/internal/teamgraph/validate.go
+++ b/internal/teamgraph/validate.go
@@ -341,6 +341,13 @@ func validateStarter(stateID string, h Handler) error {
 		return err
 	}
 
+	// `binds` project THE source message into ${var.*}. per=once hands the agent
+	// a batch, so there is no "the" message — binding from an arbitrary one of N
+	// would be a silent choice the author never made.
+	if h.Fanout.Per == FanoutPerOnce && len(h.Binds) > 0 {
+		return fmt.Errorf("team definition: state %q starter has `binds` with per=once — "+
+			"binds project ONE source message, and per=once hands the agent the whole batch", stateID)
+	}
 	if h.Sink != nil && strings.TrimSpace(h.Sink.Channel) == "" {
 		return fmt.Errorf("team definition: state %q starter `sink` is present but names no channel", stateID)
 	}

--- a/internal/teamrun/expand.go
+++ b/internal/teamrun/expand.go
@@ -50,6 +50,12 @@ type Env struct {
 	Now       time.Time
 	State     string
 	Iteration int
+	// WalkID identifies the traversal, carried here so a handler that spawns
+	// does not need the Task to correlate what it spawned. NOT a token: it is
+	// deliberately absent from Values, because a walk id in a prompt is a
+	// string an agent could copy into somewhere it does not belong, and nothing
+	// in a prompt needs it.
+	WalkID string
 }
 
 // Values flattens the environment into the map prompt assembly resolves from,

--- a/internal/teamrun/spawn.go
+++ b/internal/teamrun/spawn.go
@@ -123,6 +123,15 @@ type agentRunner struct {
 	// logf reports what a Starter could not do but must not fail for — a sink
 	// publish that errored, an ack that did not land. nil = log.Printf.
 	logf func(format string, args ...any)
+	// maxWave is the DEPLOYMENT's ceiling on one wave's width, distinct from
+	// the definition's own `fanout.max`. Dynamic fan-out is a spawn amplifier,
+	// and the definition is authored by whoever can write a def — the operator
+	// bounds it. 0 disables the check (tests, embeds).
+	//
+	// It is injected rather than imported because the number lives in
+	// internal/connector, and teamrun importing that would undo the dependency
+	// contract this package is built on.
+	maxWave int
 }
 
 // RunnerOption configures the production runner. Options rather than more
@@ -139,6 +148,11 @@ func WithChannels(io ChannelIO) RunnerOption {
 // WithWaveContext wires the seam that carries a wave identity to run creation.
 func WithWaveContext(f func(ctx context.Context, walkID, waveID string, index int) context.Context) RunnerOption {
 	return func(r *agentRunner) { r.wave = f }
+}
+
+// WithMaxWave wires the deployment's ceiling on one Starter wave.
+func WithMaxWave(n int) RunnerOption {
+	return func(r *agentRunner) { r.maxWave = n }
 }
 
 // WithRunnerLogf wires the non-fatal log sink.
@@ -279,6 +293,7 @@ func (r *agentRunner) envFor(st teamgraph.State, task *Task) Env {
 		Now:       now(),
 		State:     st.ID,
 		Iteration: task.IterationCounts[st.ID],
+		WalkID:    task.WalkID,
 	}
 }
 

--- a/internal/teamrun/starter.go
+++ b/internal/teamrun/starter.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/jsonpath"
@@ -74,22 +76,23 @@ const (
 	SinkError = "error"
 )
 
-// runStarter executes one starter state: read, dispatch, publish, ack.
-//
-// This phase dispatches exactly ONE run (the vertical slice). The fan-out —
-// dynamic N, the ceiling, wave-size stamping — is the next phase, and the wave
-// envelope is already shaped for it so that phase adds width, not a rewrite.
+// runStarter executes one starter state: read, dispatch the wave, publish one
+// sink message per run, ack.
 func (r *agentRunner) runStarter(ctx context.Context, st teamgraph.State, task *Task) (Outcome, error) {
 	h := st.Handler
 	if r.channels == nil {
 		return Outcome{}, fmt.Errorf("state %q is a starter but no channel executor is wired", st.ID)
 	}
 
+	width, err := r.waveWidth(st)
+	if err != nil {
+		return Outcome{}, err
+	}
 	want := 1
 	if h.Source.Wait == teamgraph.WaitAtLeast && h.Source.N > want {
 		want = h.Source.N
 	}
-	msgs, cursor, err := r.channels.Read(ctx, h.Source.Channel, want, h.Source.Batch, h.Source.WaitMS)
+	msgs, cursor, err := r.channels.Read(ctx, h.Source.Channel, want, width, h.Source.WaitMS)
 	if err != nil {
 		return Outcome{}, fmt.Errorf("state %q read %q: %w", st.ID, h.Source.Channel, err)
 	}
@@ -100,40 +103,165 @@ func (r *agentRunner) runStarter(ctx context.Context, st teamgraph.State, task *
 		// never a silent proceed".
 		return Outcome{}, fmt.Errorf("state %q: no message on %q within the wait", st.ID, h.Source.Channel)
 	}
-
-	// binds project the SOURCE MESSAGE into ${var.*}. The values are UNTRUSTED
-	// (a channel message may be agent-written or webhook-relayed); they are safe
-	// in a prompt, and trust rules 5b/5c hold them wherever they reach a
-	// placeholder argument.
-	r.bindFromMessage(st, task, msgs[0])
-
-	waveID := mintWaveID()
-	agent := h.Fanout.Agent
-	if agent == "" && len(h.Fanout.Agents) > 0 {
-		agent = h.Fanout.Agents[0]
+	// The read is already bounded by width, but a store that returned more
+	// would otherwise widen the wave past the author's ceiling.
+	if len(msgs) > width {
+		msgs = msgs[:width]
 	}
 
-	out, runErr := r.dispatchOne(ctx, st, task, agent, waveID, 0, len(msgs), msgs[0])
+	results, waveErr := r.runWave(ctx, st, task, msgs)
 
-	// The sink publish is a GUARANTEED path: it has already happened by here,
-	// including when the spawn panicked. See dispatchOne.
-	if runErr != nil {
-		// The wave failed, and the sink says so. The walk still fails — a
-		// Starter is a state, and a state whose only run errored has produced
-		// nothing to thread onward.
-		return Outcome{}, fmt.Errorf("state %q wave: %w", st.ID, runErr)
-	}
-
-	// Ack LAST. after_results is at-least-once by construction: a crash between
-	// the results and this line redelivers the batch, which is the tradeoff the
-	// definition asked for. after_read would have acked before dispatch and
-	// lost the batch instead.
-	if h.Ack != teamgraph.AckAfterRead && cursor != "" {
+	// Ack LAST, and only on success. after_results is at-least-once by
+	// construction: a crash — or a failed wave — between the results and this
+	// line redelivers the batch, which is the tradeoff the definition asked
+	// for. after_read acks on read instead and loses the batch to a crash.
+	if waveErr == nil && h.Ack != teamgraph.AckAfterRead && cursor != "" {
 		if aerr := r.channels.Ack(ctx, h.Source.Channel, cursor); aerr != nil {
 			r.log("teamrun: state %q ack %q: %v", st.ID, h.Source.Channel, aerr)
 		}
 	}
-	return r.captured(st, task, Outcome{Output: out})
+	if waveErr != nil {
+		return Outcome{}, fmt.Errorf("state %q wave: %w", st.ID, waveErr)
+	}
+
+	// The state's output is ALWAYS the results envelope, even for a wave of
+	// one. A Starter's output shape must not depend on how many messages
+	// happened to arrive, or a downstream consolidator works on Tuesday and
+	// breaks on Wednesday. It is the same envelope a parallel handler produces,
+	// so one consolidator agent reads either.
+	envelope, err := resultsEnvelope(results)
+	if err != nil {
+		return Outcome{}, err
+	}
+	return r.captured(st, task, Outcome{Output: envelope})
+}
+
+// waveWidth is how many runs this state may dispatch at once: the author's
+// ceiling, bounded by the deployment's.
+//
+// A definition that asks for more than the deployment allows is REFUSED rather
+// than quietly given less. Silently capping is the shape of bug that has cost
+// this codebase real time — an operator sets a number, the runtime uses a
+// different one, and nothing says so.
+func (r *agentRunner) waveWidth(st teamgraph.State) (int, error) {
+	h := st.Handler
+	if h.Fanout.Per == teamgraph.FanoutPerOnce {
+		// One run holding the whole batch; the read is bounded by `batch` alone.
+		w := h.Source.Batch
+		if w <= 0 {
+			w = defaultStarterBatch
+		}
+		return w, nil
+	}
+	w := h.Fanout.Max
+	if b := h.Source.Batch; b > 0 && b < w {
+		// Reading fewer than the ceiling is legitimate: the ceiling says "never
+		// more than this", the batch says "take this many at a time".
+		w = b
+	}
+	if r.maxWave > 0 && h.Fanout.Max > r.maxWave {
+		return 0, fmt.Errorf("state %q fanout max=%d exceeds this deployment's ceiling of %d — "+
+			"lower the definition's max, or raise the substrate's", st.ID, h.Fanout.Max, r.maxWave)
+	}
+	return w, nil
+}
+
+// defaultStarterBatch is how many messages a per=once wave reads when the
+// definition says nothing. Matches the Channel tool's own subscribe default, so
+// an author who reasons about one reasons about both.
+const defaultStarterBatch = 10
+
+// runWave dispatches the wave and returns one result per spawned run, in index
+// order. Every result has a sink message published for it, whatever happened.
+//
+// Concurrency and the wait threshold mirror runParallel — a Starter wave IS a
+// fan-out, and having two answers for "how many must succeed" would be two
+// places to get it wrong.
+func (r *agentRunner) runWave(ctx context.Context, st teamgraph.State, task *Task, msgs []ChannelMessage) ([]agentResult, error) {
+	h := st.Handler
+	waveID := mintWaveID()
+
+	// per=once is ONE run holding every message; per=message is one run each.
+	dispatches := len(msgs)
+	if h.Fanout.Per == teamgraph.FanoutPerOnce {
+		dispatches = 1
+	}
+	agentFor := func(i int) string {
+		if h.Fanout.Agent != "" {
+			return h.Fanout.Agent
+		}
+		// A list of agents fans the SAME message set across them; with
+		// per=message and more messages than agents it cycles, so `agents` is
+		// "these roles" rather than "this many runs".
+		return h.Fanout.Agents[i%len(h.Fanout.Agents)]
+	}
+
+	// binds project THE source message, so they run only where there is one.
+	if h.Fanout.Per != teamgraph.FanoutPerOnce {
+		r.bindFromMessage(st, task, msgs[0])
+	}
+	env := r.envFor(st, task)
+
+	need, err := requiredSuccesses(h.Fanout.Wait, dispatches)
+	if err != nil {
+		return nil, err
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	results := make([]agentResult, dispatches)
+	sem := make(chan struct{}, parallelConcurrency(dispatches))
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	successes := 0
+
+	for i := 0; i < dispatches; i++ {
+		i := i
+		agent := agentFor(i)
+		slots := waveSlots(h, msgs, i)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-runCtx.Done():
+				// Cancelled before it ever ran — still a result, and still a
+				// sink message, because the count is the contract.
+				res := agentResult{Index: i, Agent: agent, Ok: false, Error: runCtx.Err().Error()}
+				results[i] = res
+				r.publishSink(ctx, st, waveID, dispatches, res)
+				return
+			}
+			results[i] = r.dispatchOne(runCtx, st, env, agent, waveID, i, dispatches, slots)
+			if results[i].Ok {
+				mu.Lock()
+				successes++
+				if successes >= need {
+					cancel() // enough succeeded → stop the rest (no-op for wait:all)
+				}
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if successes < need {
+		wait := h.Fanout.Wait
+		if wait == "" {
+			wait = teamgraph.WaitAll
+		}
+		var fails []string
+		for _, res := range results {
+			if !res.Ok {
+				fails = append(fails, fmt.Sprintf("%s: %s", res.Agent, res.Error))
+			}
+		}
+		return results, fmt.Errorf("%d of %d runs succeeded, need %d (wait=%q): %s",
+			successes, dispatches, need, wait, strings.Join(fails, "; "))
+	}
+	return results, nil
 }
 
 // dispatchOne spawns one run of the wave and publishes exactly one sink message
@@ -143,85 +271,89 @@ func (r *agentRunner) runStarter(ctx context.Context, st teamgraph.State, task *
 // counting messages cannot tell "still running" from "died", so a wave that can
 // produce fewer messages than runs turns a downstream wait into a hang. The
 // count is the contract.
-func (r *agentRunner) dispatchOne(ctx context.Context, st teamgraph.State, task *Task, agent, waveID string, index, waveSize int, msg ChannelMessage) (out string, err error) {
-	published := false
-	publish := func(status, output, errText string) {
-		if published || st.Handler.Sink == nil {
-			return
-		}
-		published = true
-		payload, merr := json.Marshal(SinkMessage{
-			Wave: waveID, WaveSize: waveSize, Index: index, Agent: agent,
-			Status: status, Output: output, Error: errText,
-		})
-		if merr != nil {
-			r.log("teamrun: state %q sink marshal: %v", st.ID, merr)
-			return
-		}
-		// A survival ctx: the wave's result must reach the sink even when the
-		// walk's ctx is already cancelled, for the same reason the scheduler
-		// records a result on one — a cancelled parent must not be able to
-		// make a fan-in wait forever.
-		pctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
-		defer cancel()
-		if perr := r.channels.Publish(pctx, st.Handler.Sink.Channel, payload); perr != nil {
-			r.log("teamrun: state %q sink publish: %v", st.ID, perr)
-		}
-	}
+func (r *agentRunner) dispatchOne(ctx context.Context, st teamgraph.State, env Env, agent, waveID string, index, waveSize int, slots map[string]string) (res agentResult) {
+	res = agentResult{Index: index, Agent: agent}
 	defer func() {
 		if rec := recover(); rec != nil {
-			err = fmt.Errorf("agent %q panicked: %v", agent, rec)
-			publish(SinkError, "", err.Error())
-			return
+			res = agentResult{Index: index, Agent: agent, Ok: false,
+				Error: fmt.Sprintf("agent %q panicked: %v", agent, rec)}
 		}
-		if err != nil {
-			publish(SinkError, "", err.Error())
-			return
-		}
-		publish(SinkOK, out, "")
+		r.publishSink(ctx, st, waveID, waveSize, res)
 	}()
 
-	env := r.envFor(st, task)
-	prompt := composeWavePrompt(st.Handler, msg, env)
+	prompt := Prompt{Values: env.Values(), DataSlots: slots}
+	if st.Handler.Prompt != nil {
+		prompt.System, prompt.Input = st.Handler.Prompt.System, st.Handler.Prompt.Input
+	}
 	// The wave this run belongs to rides ctx to the run-creation seam, which
 	// stamps it on the run's ParentContext. A join, not a copy.
-	spawnCtx := r.withWave(ctx, task, waveID, index)
-	out, err = r.spawn(spawnCtx, agent, prompt, "")
-	return out, err
+	out, err := r.spawn(r.withWave(ctx, env.WalkID, waveID, index), agent, prompt, "")
+	if err != nil {
+		res.Error = err.Error()
+		return res
+	}
+	res.Ok, res.Output = true, out
+	return res
 }
 
-// composeWavePrompt builds a wave run's prompt.
-//
-// THE DATA SLOT IS SUBSTITUTED LAST AND ITS CONTENT IS NEVER SCANNED. The
-// message payload is attacker-influenceable — anyone who can reach the channel
-// can write it — and prompt assembly resolves {{...}} placeholders under the
-// RUNTIME's authority, ungated by the agent's tools or scopes. Splicing the
-// payload in as template text would therefore hand an ungated read primitive to
-// whoever can publish. So the operator's template is what carries placeholders,
-// and the payload arrives after they are all resolved, as data.
-//
-// That is why the slot is not just another ${...}: those resolve inside the one
-// combined pass, and this one must land outside it.
-func composeWavePrompt(h teamgraph.Handler, msg ChannelMessage, env Env) Prompt {
-	var system, input string
-	if h.Prompt != nil {
-		system, input = h.Prompt.System, h.Prompt.Input
+// publishSink writes one run's outcome to the sink. Called from dispatchOne's
+// defer, so it runs on every path including a panic.
+func (r *agentRunner) publishSink(ctx context.Context, st teamgraph.State, waveID string, waveSize int, res agentResult) {
+	if st.Handler.Sink == nil {
+		return
 	}
-	return Prompt{
-		System: system,
-		Input:  input,
-		Values: env.Values(),
-		// DataSlots are substituted by the assembler AFTER expansion completes.
-		DataSlots: map[string]string{
-			StarterMessageSlot: string(msg.Payload),
-		},
+	msg := SinkMessage{
+		Wave: waveID, WaveSize: waveSize, Index: res.Index, Agent: res.Agent,
+		Status: SinkOK, Output: res.Output,
+	}
+	if !res.Ok {
+		msg.Status, msg.Output, msg.Error = SinkError, "", res.Error
+	}
+	payload, err := json.Marshal(msg)
+	if err != nil {
+		r.log("teamrun: state %q sink marshal: %v", st.ID, err)
+		return
+	}
+	// A survival ctx: the wave's result must reach the sink even when the
+	// walk's ctx is already cancelled — by a sibling hitting the wait
+	// threshold, or by the parent run. A cancelled parent must not be able to
+	// make a downstream fan-in wait forever.
+	pctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	if perr := r.channels.Publish(pctx, st.Handler.Sink.Channel, payload); perr != nil {
+		r.log("teamrun: state %q sink publish: %v", st.ID, perr)
 	}
 }
 
-// StarterMessageSlot is the reserved slot a Starter's prompt uses to receive
-// the source message. Reserved: an operator writing it into a non-starter
-// prompt gets nothing, because nothing fills it there.
-const StarterMessageSlot = "{{starter.message}}"
+// waveSlots builds the data slots for one dispatch: the single message for
+// per=message, the whole batch as a JSON array for per=once.
+func waveSlots(h teamgraph.Handler, msgs []ChannelMessage, i int) map[string]string {
+	if h.Fanout.Per == teamgraph.FanoutPerOnce {
+		parts := make([]json.RawMessage, 0, len(msgs))
+		for _, m := range msgs {
+			parts = append(parts, m.Payload)
+		}
+		all, err := json.Marshal(parts)
+		if err != nil {
+			all = []byte("[]")
+		}
+		return map[string]string{StarterMessagesSlot: string(all)}
+	}
+	return map[string]string{StarterMessageSlot: string(msgs[i].Payload)}
+}
+
+// The reserved slots a Starter's prompt receives its payload in. Reserved: an
+// operator writing one into a prompt that fills no slots gets it back
+// unchanged, because nothing fills it there.
+//
+// Two, because the two fan-out shapes hand the agent different things: one
+// message each (per=message), or the whole batch as a JSON array (per=once).
+// Naming them separately means a template says which shape it expects, instead
+// of a singular name quietly holding a list.
+const (
+	StarterMessageSlot  = "{{starter.message}}"
+	StarterMessagesSlot = "{{starter.messages}}"
+)
 
 // logf reports what a Starter could not do but must not fail for.
 func (r *agentRunner) log(format string, args ...any) {
@@ -256,11 +388,11 @@ func (r *agentRunner) bindFromMessage(st teamgraph.State, task *Task, msg Channe
 }
 
 // withWave puts this run's wave identity on ctx for the run-creation seam.
-func (r *agentRunner) withWave(ctx context.Context, task *Task, waveID string, index int) context.Context {
+func (r *agentRunner) withWave(ctx context.Context, walkID, waveID string, index int) context.Context {
 	if r.wave == nil {
 		return ctx
 	}
-	return r.wave(ctx, task.WalkID, waveID, index)
+	return r.wave(ctx, walkID, waveID, index)
 }
 
 // mintWaveID / mintWalkID return fresh correlation ids. Short and opaque: they

--- a/internal/teamrun/starter_test.go
+++ b/internal/teamrun/starter_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -102,8 +104,13 @@ func TestStarter_ReadsDispatchesPublishesAcks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("starter: %v", err)
 	}
-	if out.Output != "looks fine" {
-		t.Errorf("output = %q, want the agent's", out.Output)
+	// ALWAYS the results envelope, even for a wave of one: a Starter's output
+	// shape must not depend on how many messages happened to arrive, or a
+	// downstream consolidator works on Tuesday and breaks on Wednesday. It is
+	// the same envelope a parallel handler produces, so one consolidator agent
+	// reads either.
+	if !strings.Contains(out.Output, `"output":"looks fine"`) || !strings.HasPrefix(out.Output, `{"results":`) {
+		t.Errorf("output = %q, want the results envelope", out.Output)
 	}
 
 	// The payload reaches the agent through the DATA SLOT, not the template.
@@ -249,5 +256,222 @@ func TestChannelKind_PublishesAndThreadsInputThrough(t *testing.T) {
 	}
 	if len(ch.published) != 1 || ch.published[0].Channel != "verdicts" {
 		t.Fatalf("published = %+v", ch.published)
+	}
+}
+
+// ---- P5: fan-out ----
+
+func inbox(n int) []ChannelMessage {
+	out := make([]ChannelMessage, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, ChannelMessage{
+			ID:      "m" + strconv.Itoa(i),
+			Payload: json.RawMessage(`{"i":` + strconv.Itoa(i) + `}`),
+		})
+	}
+	return out
+}
+
+// N messages become N runs and N sink messages, each carrying its index and the
+// wave's SIZE — the number a downstream fan-in counts to, taken from the
+// runtime rather than from a literal the author would have to keep in sync.
+func TestStarterFanout_OneRunAndOneSinkMessagePerMessage(t *testing.T) {
+	ch := &fakeChannels{inbox: inbox(4)}
+	var mu sync.Mutex
+	var seen []string
+	r := starterRunner(ch, func(_ context.Context, _ string, p Prompt, _ string) (string, error) {
+		mu.Lock()
+		seen = append(seen, p.DataSlots[StarterMessageSlot])
+		mu.Unlock()
+		return "done", nil
+	})
+
+	if _, err := r.RunHandler(context.Background(), starterState(), &Task{}); err != nil {
+		t.Fatalf("wave: %v", err)
+	}
+	if len(seen) != 4 {
+		t.Fatalf("spawned %d runs, want 4", len(seen))
+	}
+	sinks := ch.sinks(t)
+	if len(sinks) != 4 {
+		t.Fatalf("published %d sink messages, want 4 — the count IS the fan-in contract", len(sinks))
+	}
+	idx := map[int]bool{}
+	for _, m := range sinks {
+		if m.WaveSize != 4 {
+			t.Errorf("sink wave_size = %d, want 4 (the runtime's count, not a literal)", m.WaveSize)
+		}
+		if m.Wave != sinks[0].Wave {
+			t.Errorf("one wave produced two wave ids")
+		}
+		idx[m.Index] = true
+	}
+	if len(idx) != 4 {
+		t.Errorf("indices = %v, want one per run", idx)
+	}
+	// Each run got ITS message, not a shared one.
+	sort.Strings(seen)
+	if seen[0] != `{"i":0}` || seen[3] != `{"i":3}` {
+		t.Errorf("data slots = %v, want one message each", seen)
+	}
+}
+
+// per=once is ONE run holding the whole batch, in the plural slot. The two
+// shapes have separate slot names so a template says which it expects.
+func TestStarterFanout_PerOnceIsOneRunWithTheBatch(t *testing.T) {
+	ch := &fakeChannels{inbox: inbox(3)}
+	var got Prompt
+	r := starterRunner(ch, func(_ context.Context, _ string, p Prompt, _ string) (string, error) {
+		got = p
+		return "done", nil
+	})
+	st := starterState()
+	st.Handler.Fanout.Per = teamgraph.FanoutPerOnce
+	st.Handler.Fanout.Max = 0
+	st.Handler.Prompt.Input = "All:\n" + StarterMessagesSlot
+
+	if _, err := r.RunHandler(context.Background(), st, &Task{}); err != nil {
+		t.Fatalf("wave: %v", err)
+	}
+	if sinks := ch.sinks(t); len(sinks) != 1 || sinks[0].WaveSize != 1 {
+		t.Fatalf("sinks = %+v, want exactly one", sinks)
+	}
+	all := got.DataSlots[StarterMessagesSlot]
+	if !strings.HasPrefix(all, "[") || !strings.Contains(all, `{"i":2}`) {
+		t.Errorf("messages slot = %q, want a JSON array of every message", all)
+	}
+	if _, singular := got.DataSlots[StarterMessageSlot]; singular {
+		t.Errorf("per=once filled the SINGULAR slot too — a batch is not a message")
+	}
+}
+
+// A definition asking for a wider wave than the deployment allows is REFUSED,
+// not quietly given less. Silently capping is the shape of bug that costs real
+// time: an operator sets a number and the runtime uses a different one.
+func TestStarterFanout_MaxAboveTheDeploymentCeilingIsRefused(t *testing.T) {
+	ch := &fakeChannels{inbox: inbox(2)}
+	spawned := 0
+	r := starterRunner(ch, func(context.Context, string, Prompt, string) (string, error) {
+		spawned++
+		return "", nil
+	})
+	r.maxWave = 2
+	st := starterState()
+	st.Handler.Fanout.Max = 8
+
+	_, err := r.RunHandler(context.Background(), st, &Task{})
+	if err == nil || !strings.Contains(err.Error(), "exceeds this deployment's ceiling") {
+		t.Fatalf("err = %v, want a ceiling refusal naming both numbers", err)
+	}
+	if spawned != 0 {
+		t.Errorf("refused AFTER spawning %d runs — the refusal must come first", spawned)
+	}
+}
+
+// The author's own ceiling bounds the wave even when more messages are waiting;
+// the rest stay on the channel for the next pass, unacked.
+func TestStarterFanout_MaxBoundsTheWaveAndLeavesTheRest(t *testing.T) {
+	ch := &fakeChannels{inbox: inbox(10)}
+	r := starterRunner(ch, func(context.Context, string, Prompt, string) (string, error) {
+		return "done", nil
+	})
+	st := starterState()
+	st.Handler.Fanout.Max = 3
+
+	if _, err := r.RunHandler(context.Background(), st, &Task{}); err != nil {
+		t.Fatalf("wave: %v", err)
+	}
+	if sinks := ch.sinks(t); len(sinks) != 3 {
+		t.Errorf("wave was %d wide, want the authored max of 3", len(sinks))
+	}
+}
+
+// A wave where one run fails still publishes a sink message for EVERY run, so a
+// downstream fan-in is unblocked by the failure instead of hanging on it.
+func TestStarterFanout_AFailedRunStillLeavesTheCountWhole(t *testing.T) {
+	ch := &fakeChannels{inbox: inbox(3)}
+	var mu sync.Mutex
+	n := 0
+	r := starterRunner(ch, func(context.Context, string, Prompt, string) (string, error) {
+		mu.Lock()
+		n++
+		mine := n
+		mu.Unlock()
+		if mine == 2 {
+			return "", errors.New("second one failed")
+		}
+		return "ok", nil
+	})
+
+	_, err := r.RunHandler(context.Background(), starterState(), &Task{})
+	if err == nil {
+		t.Fatalf("wait=all with a failure must fail the state")
+	}
+	sinks := ch.sinks(t)
+	if len(sinks) != 3 {
+		t.Fatalf("published %d sink messages for a 3-wide wave — the count is the contract", len(sinks))
+	}
+	errs := 0
+	for _, m := range sinks {
+		if m.Status == SinkError {
+			errs++
+		}
+	}
+	if errs != 1 {
+		t.Errorf("%d error sinks, want exactly the failed run's", errs)
+	}
+}
+
+// wait=at_least lets a wave succeed with failures, and the state still advances.
+func TestStarterFanout_WaitAtLeastSucceedsBelowFull(t *testing.T) {
+	ch := &fakeChannels{inbox: inbox(3)}
+	var mu sync.Mutex
+	n := 0
+	r := starterRunner(ch, func(context.Context, string, Prompt, string) (string, error) {
+		mu.Lock()
+		n++
+		mine := n
+		mu.Unlock()
+		if mine == 1 {
+			return "", errors.New("one failed")
+		}
+		return "ok", nil
+	})
+	st := starterState()
+	st.Handler.Fanout.Wait = teamgraph.WaitAtLeast + ":2"
+
+	out, err := r.RunHandler(context.Background(), st, &Task{})
+	if err != nil {
+		t.Fatalf("at_least:2 with 2 successes must pass: %v", err)
+	}
+	if !strings.Contains(out.Output, `"ok":false`) {
+		t.Errorf("the envelope hides the failure: %s", out.Output)
+	}
+	if len(ch.acked) != 1 {
+		t.Errorf("a successful wave did not ack: %v", ch.acked)
+	}
+}
+
+// A list of agents spreads the wave across roles, cycling when there are more
+// messages than agents — `agents` is "these roles", not "this many runs".
+func TestStarterFanout_AgentsListCyclesAcrossMessages(t *testing.T) {
+	ch := &fakeChannels{inbox: inbox(4)}
+	var mu sync.Mutex
+	counts := map[string]int{}
+	r := starterRunner(ch, func(_ context.Context, agent string, _ Prompt, _ string) (string, error) {
+		mu.Lock()
+		counts[agent]++
+		mu.Unlock()
+		return "ok", nil
+	})
+	st := starterState()
+	st.Handler.Fanout.Agent = ""
+	st.Handler.Fanout.Agents = []string{"a", "b"}
+
+	if _, err := r.RunHandler(context.Background(), st, &Task{}); err != nil {
+		t.Fatalf("wave: %v", err)
+	}
+	if counts["a"] != 2 || counts["b"] != 2 {
+		t.Errorf("agent spread = %v, want 2 each", counts)
 	}
 }

--- a/internal/tools/builtin/teamdef.go
+++ b/internal/tools/builtin/teamdef.go
@@ -82,6 +82,11 @@ type TeamDef struct {
 	// correlation is not recorded.
 	WaveContext func(ctx context.Context, walkID, waveID string, index int) context.Context
 
+	// MaxWave is the DEPLOYMENT's ceiling on one Starter wave's width — the
+	// operator's bound on a spawn amplifier whose definition anyone with def
+	// authority can author. 0 disables the check.
+	MaxWave int
+
 	// Board, if set, lets an op=run OPTIONALLY bind to a Document task board: when
 	// the caller passes board_chunk_id, the walk persists its position onto that
 	// chunk's status (chunk.status = the current team state) on every transition
@@ -760,6 +765,9 @@ func (t *TeamDef) execRun(ctx context.Context, in teamDefInput) (tools.Result, e
 	}
 	if t.WaveContext != nil {
 		runnerOpts = append(runnerOpts, teamrun.WithWaveContext(t.WaveContext))
+	}
+	if t.MaxWave > 0 {
+		runnerOpts = append(runnerOpts, teamrun.WithMaxWave(t.MaxWave))
 	}
 	trace, walkErr := teamrun.Walk(walkCtx, def, task, teamrun.NewAgentRunner(t.Spawn, runnerOpts...), opts...)
 


### PR DESCRIPTION
**RFC CY phase L4c.** A wave is now as wide as the channel is deep, within two ceilings, and every run in it produces exactly one sink message.

## Dynamic N, bounded twice

`per: message` spawns one run per message read, so the width comes from the **data** rather than the definition. Two ceilings bound it, and they answer different questions: `fanout.max` is what the **author** will allow, the deployment's cap is what the **operator** will.

A definition asking for more than the deployment allows is **refused, naming both numbers, before anything spawns**. Silently giving it less is the shape of bug that has cost this codebase real time — someone sets a number and the runtime uses a different one. The substrate ceiling is the same `connector.MaxBatchSpawns` the external fan-out surface uses (one number an operator tunes, not two), injected rather than imported so `teamrun` keeps its dependency contract.

## The count is the contract, and it survives failure

One sink message per spawned run, published from a `defer` — **including for a run cancelled before it started** because a sibling hit the wait threshold. A fan-in counts messages and can't tell "still running" from "died", so a wave that publishes fewer messages than it spawned turns a downstream wait into a hang.

Each message carries the wave's **size**, which is the number a downstream `at_least` needs and the number an author should never have to keep in sync by hand.

## Two slots, because the two shapes hand the agent different things

`{{starter.message}}` for `per=message`; `{{starter.messages}}` — a JSON array — for `per=once`. Separate names mean a template *says* which shape it expects, instead of a singular name quietly holding a list. `binds` are refused with `per=once` for the same reason: they project **the** source message, and a batch has no "the".

## The output is always the results envelope

This deliberately changes L4b's single-run behaviour. A Starter's output shape must not depend on how many messages happened to arrive, or a downstream consolidator works on Tuesday and breaks on Wednesday. It's the same envelope a `parallel` handler produces, so one consolidator agent reads either — which is what makes `parallel` **the degenerate Starter** rather than a parallel concept. Concurrency and the wait threshold reuse `runParallel`'s for the same reason: two answers to "how many must succeed" would be two places to get it wrong.

## Tested

`go test ./...` clean (**100 packages**), plus `-race -count=2` on `teamrun` for the concurrent wave.

N messages → N runs → N sink messages each carrying its index and the wave size; `per=once` is one run with the batch in the plural slot and the singular slot untouched; a max above the deployment ceiling is refused with **zero** spawns; the author's max bounds the wave and leaves the rest on the channel unacked; a failed run still leaves the sink count whole; `at_least` succeeds below full and still acks; an agents list cycles across messages.

**Fail-before verified:** moving the sink publish out of the `defer` fails the panic test with `sinks = []`; silently capping instead of refusing fails the ceiling test with `err = <nil>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD