### PR TITLE
feat(teamrun): step a Starter wave with run-scoped breakpoints

### DIFF
--- a/internal/teamrun/breakpoint.go
+++ b/internal/teamrun/breakpoint.go
@@ -1,0 +1,222 @@
+package teamrun
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/teamgraph"
+)
+
+// Debug breakpoints on a Starter (RFC CY, Decision 4 amended).
+//
+// WHY THE BREAKPOINT IS HERE AND NOT ON THE CHANNEL. A breakpoint decides when
+// work starts, and a node kind is the thing that runs — so it belongs on the
+// dispatcher. Two consequences fall out that a channel-level gate could not
+// give: a paused Starter needs no storage mechanism at all (the messages simply
+// stay on the channel, unread, which is what a cursor is for), and it pauses
+// ONE dispatcher rather than stalling a wire for every reader in the tenant.
+//
+// It is also the only place the interesting data exists. The composed prompt
+// for each agent never touches a channel, so no amount of channel inspection
+// would ever show what an agent was actually asked — which is the first thing
+// anyone wants when a fan-out misbehaves.
+
+// BreakpointPhase is where in a wave the walk paused.
+type BreakpointPhase string
+
+const (
+	// BeforeDispatch — the source has been read, binds applied and every prompt
+	// composed, and NOTHING has been spawned. Step into.
+	BeforeDispatch BreakpointPhase = "before_dispatch"
+	// AfterCollection — the wave is complete and NOTHING has been published to
+	// the sink. Step over.
+	AfterCollection BreakpointPhase = "after_collection"
+)
+
+// PromptPreview is one pending run, as the operator sees it at BeforeDispatch:
+// the agent that will run and the exact text it will receive.
+//
+// System and Input are the node's RAW templates — placeholders and ${...}
+// included — because that is what the definition says, and resolving them here
+// would mean resolving them twice. Message is the payload that will fill the
+// data slot, which is the part an operator is usually looking for.
+type PromptPreview struct {
+	Index   int
+	Agent   string
+	System  string
+	Input   string
+	Message string
+}
+
+// Breakpoint is what the walk hands the operator when it pauses.
+type Breakpoint struct {
+	State string
+	Phase BreakpointPhase
+	Wave  string
+	// WaveSize is the whole wave's width, which stays fixed while a staged
+	// release works through it — so "3 of 8" means the same thing at every
+	// pause.
+	WaveSize int
+	// Pending is how many of the wave are still waiting at this phase: still to
+	// dispatch at BeforeDispatch, still to publish at AfterCollection.
+	Pending int
+	// Prompts is set at BeforeDispatch — the pending runs, in wave order.
+	Prompts []PromptPreview
+	// Results is set at AfterCollection — the finished runs whose sink messages
+	// have not been published yet.
+	Results []BreakpointResult
+}
+
+// BreakpointResult is one finished run at AfterCollection. It is a VIEW, not a
+// store: the run itself is durable and carries the transcript, the tokens and
+// the cost. This is the summary that answers "should the next stage see this".
+type BreakpointResult struct {
+	Index  int
+	Agent  string
+	Ok     bool
+	Output string
+	Error  string
+}
+
+// BreakAction is what the operator decided.
+type BreakAction int
+
+const (
+	// BreakAbort terminates the walk. The zero value, so a nil or incomplete
+	// decision fails safe rather than releasing a wave nobody approved.
+	BreakAbort BreakAction = iota
+	// BreakContinue releases everything still pending at this pause.
+	BreakContinue
+	// BreakRelease releases N and pauses again with the rest.
+	BreakRelease
+)
+
+// BreakDecision is the operator's answer.
+type BreakDecision struct {
+	Action BreakAction
+	// N applies to BreakRelease. Below 1 is treated as 1 — "release some" with
+	// no number is a step, not a no-op that would park forever.
+	N int
+}
+
+// BreakpointFunc is asked at each pause. An error aborts the walk: a debugger
+// whose operator cannot be reached must not silently release the wave.
+type BreakpointFunc func(ctx context.Context, bp Breakpoint) (BreakDecision, error)
+
+// stage walks a pending count in operator-sized steps.
+//
+// It is the shared loop behind both pauses, because "release one, look, release
+// three, look, release the rest" is the same gesture whether what is being
+// released is a dispatch or a publish. act is called with the half-open range
+// to release; ask is called before each step.
+func stage(ctx context.Context, total int, ask func(pending int) (BreakDecision, error), act func(from, to int) error) error {
+	for from := 0; from < total; {
+		dec, err := ask(total - from)
+		if err != nil {
+			return err
+		}
+		to := total
+		switch dec.Action {
+		case BreakContinue:
+			// everything remaining
+		case BreakRelease:
+			n := dec.N
+			if n < 1 {
+				n = 1
+			}
+			if from+n < to {
+				to = from + n
+			}
+		default:
+			return fmt.Errorf("aborted at the breakpoint")
+		}
+		if err := act(from, to); err != nil {
+			return err
+		}
+		from = to
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ParseBreakpoint splits one breakpoint argument into a state id and the phase
+// it arms:
+//
+//	"review"                   both phases of state `review`
+//	"review:after_collection"  that phase only
+//
+// Both forms exist because the two pauses answer different questions — "what is
+// about to run" and "what came back" — and a canvas stepping through a wave
+// wants one at a time, while an operator who just wants the walk to stop at a
+// state should not have to know there are two.
+//
+// It reports ok=false for an empty id or an unknown phase, so a typo is REFUSED
+// at the run boundary rather than arming nothing and leaving the operator
+// watching a walk that never pauses.
+func ParseBreakpoint(s string) (id string, phase BreakpointPhase, ok bool) {
+	id = s
+	if i := strings.LastIndex(s, ":"); i >= 0 {
+		id, phase = s[:i], BreakpointPhase(s[i+1:])
+		if phase != BeforeDispatch && phase != AfterCollection {
+			return "", "", false
+		}
+	}
+	if strings.TrimSpace(id) == "" {
+		return "", "", false
+	}
+	return id, phase, true
+}
+
+// ValidateBreakpoints reports the first argument that does not parse, for the
+// run boundary to refuse.
+func ValidateBreakpoints(bps []string) error {
+	for _, b := range bps {
+		if _, _, ok := ParseBreakpoint(b); !ok {
+			return fmt.Errorf("breakpoint %q: expected \"<state>\" or \"<state>:%s\"|\"<state>:%s\"",
+				b, BeforeDispatch, AfterCollection)
+		}
+	}
+	return nil
+}
+
+// armed reports whether this state pauses at this phase. A walk with no
+// breakpoints answers false on the first term and never touches the map, so it
+// takes the same path it took before this existed.
+func (r *agentRunner) armed(st teamgraph.State, phase BreakpointPhase) bool {
+	return r.onBreak != nil && r.breakAt[st.ID][phase]
+}
+
+// previewPrompts renders the pending half of a wave for the BeforeDispatch
+// pause, in wave order.
+func previewPrompts(h teamgraph.Handler, msgs []ChannelMessage, agentFor func(int) string, from, to int) []PromptPreview {
+	out := make([]PromptPreview, 0, to-from)
+	for i := from; i < to; i++ {
+		p := PromptPreview{Index: i, Agent: agentFor(i)}
+		if h.Prompt != nil {
+			p.System, p.Input = h.Prompt.System, h.Prompt.Input
+		}
+		slots := waveSlots(h, msgs, i)
+		if m, ok := slots[StarterMessageSlot]; ok {
+			p.Message = m
+		} else {
+			p.Message = slots[StarterMessagesSlot]
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+// previewResults renders finished runs for the AfterCollection pause.
+func previewResults(rs []agentResult) []BreakpointResult {
+	out := make([]BreakpointResult, 0, len(rs))
+	for _, res := range rs {
+		out = append(out, BreakpointResult{
+			Index: res.Index, Agent: res.Agent, Ok: res.Ok,
+			Output: res.Output, Error: res.Error,
+		})
+	}
+	return out
+}

--- a/internal/teamrun/breakpoint_test.go
+++ b/internal/teamrun/breakpoint_test.go
@@ -29,7 +29,13 @@ type countingSpawn struct {
 	prompts []string
 }
 
-func (c *countingSpawn) fn(_ context.Context, _ string, p Prompt, _ string) (string, error) {
+// fn HONOURS ctx, because that is what a real spawn does — and because a fake
+// that ignores it cannot tell a run that was cancelled from one that ran. The
+// short-circuit test below is only meaningful against a spawner that notices.
+func (c *countingSpawn) fn(ctx context.Context, _ string, p Prompt, _ string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	msg := p.DataSlots[StarterMessageSlot]

--- a/internal/teamrun/breakpoint_test.go
+++ b/internal/teamrun/breakpoint_test.go
@@ -1,0 +1,417 @@
+package teamrun
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/teamgraph"
+)
+
+// threeMessages is the fixture every breakpoint test walks: a wave of three, so
+// "release one, look, release the rest" has something to distinguish it from
+// both "release nothing" and "release everything".
+func threeMessages() *fakeChannels {
+	return &fakeChannels{inbox: []ChannelMessage{
+		{ID: "m1", Payload: json.RawMessage(`{"pr":1}`)},
+		{ID: "m2", Payload: json.RawMessage(`{"pr":2}`)},
+		{ID: "m3", Payload: json.RawMessage(`{"pr":3}`)},
+	}}
+}
+
+// countingSpawn records the order runs were spawned in, safely under fan-out.
+type countingSpawn struct {
+	mu      sync.Mutex
+	prompts []string
+}
+
+func (c *countingSpawn) fn(_ context.Context, _ string, p Prompt, _ string) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	msg := p.DataSlots[StarterMessageSlot]
+	c.prompts = append(c.prompts, msg)
+	return "verdict for " + msg, nil
+}
+
+func (c *countingSpawn) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.prompts)
+}
+
+func breakRunner(t *testing.T, ch *fakeChannels, spawn SpawnFunc, states []string, f BreakpointFunc) *agentRunner {
+	t.Helper()
+	r := starterRunner(ch, spawn)
+	WithBreakpoints(states, f)(r)
+	return r
+}
+
+// TestBreakpoint_BeforeDispatchHoldsEveryRunUntilReleased: the pause happens
+// with the wave composed and NOTHING spawned. This is the property the whole
+// phase exists for — an operator who aborts here has run no agent and spent no
+// tokens.
+func TestBreakpoint_BeforeDispatchHoldsEveryRunUntilReleased(t *testing.T) {
+	ch := threeMessages()
+	spawn := &countingSpawn{}
+	var spawnedAtAsk int
+	r := breakRunner(t, ch, spawn.fn, []string{"wave:before_dispatch"},
+		func(_ context.Context, bp Breakpoint) (BreakDecision, error) {
+			spawnedAtAsk = spawn.count()
+			if bp.Phase != BeforeDispatch {
+				t.Errorf("phase = %q, want before_dispatch", bp.Phase)
+			}
+			return BreakDecision{Action: BreakContinue}, nil
+		})
+
+	if _, err := r.RunHandler(context.Background(), starterState(), &Task{Input: "go", WalkID: "wlk_t"}); err != nil {
+		t.Fatalf("starter: %v", err)
+	}
+	if spawnedAtAsk != 0 {
+		t.Errorf("%d runs had already been spawned when the breakpoint asked — before_dispatch must hold every run", spawnedAtAsk)
+	}
+	if got := spawn.count(); got != 3 {
+		t.Errorf("spawned %d runs after continue, want 3", got)
+	}
+}
+
+// TestBreakpoint_BeforeDispatchReleasesExactlyN: a staged release dispatches
+// only the runs the operator released, and pauses again with the rest.
+func TestBreakpoint_BeforeDispatchReleasesExactlyN(t *testing.T) {
+	ch := threeMessages()
+	spawn := &countingSpawn{}
+	var pendings, spawnedBefore []int
+	r := breakRunner(t, ch, spawn.fn, []string{"wave:before_dispatch"},
+		func(_ context.Context, bp Breakpoint) (BreakDecision, error) {
+			pendings = append(pendings, bp.Pending)
+			spawnedBefore = append(spawnedBefore, spawn.count())
+			if len(pendings) == 1 {
+				return BreakDecision{Action: BreakRelease, N: 1}, nil
+			}
+			return BreakDecision{Action: BreakContinue}, nil
+		})
+
+	if _, err := r.RunHandler(context.Background(), starterState(), &Task{Input: "go", WalkID: "wlk_t"}); err != nil {
+		t.Fatalf("starter: %v", err)
+	}
+	if want := []int{3, 2}; !equalInts(pendings, want) {
+		t.Errorf("pending at each pause = %v, want %v", pendings, want)
+	}
+	// The count at the SECOND ask is the proof the release was bounded: exactly
+	// the one released ran, not the whole wave.
+	if want := []int{0, 1}; !equalInts(spawnedBefore, want) {
+		t.Errorf("runs spawned at each pause = %v, want %v", spawnedBefore, want)
+	}
+	if got := spawn.count(); got != 3 {
+		t.Errorf("spawned %d in total, want 3", got)
+	}
+}
+
+// TestBreakpoint_BeforeDispatchAbortSpawnsNothing: the zero-value decision is
+// abort, so a caller that answers with an empty struct fails safe.
+func TestBreakpoint_BeforeDispatchAbortSpawnsNothing(t *testing.T) {
+	ch := threeMessages()
+	spawn := &countingSpawn{}
+	r := breakRunner(t, ch, spawn.fn, []string{"wave"},
+		func(context.Context, Breakpoint) (BreakDecision, error) {
+			return BreakDecision{}, nil // zero value
+		})
+
+	_, err := r.RunHandler(context.Background(), starterState(), &Task{Input: "go", WalkID: "wlk_t"})
+	if err == nil {
+		t.Fatal("an aborted breakpoint must fail the walk")
+	}
+	if got := spawn.count(); got != 0 {
+		t.Errorf("spawned %d runs after an abort, want 0", got)
+	}
+	if n := len(ch.sinks(t)); n != 0 {
+		t.Errorf("published %d sink messages after an abort, want 0", n)
+	}
+	// Ack is gated on the wave succeeding, so an aborted wave redelivers.
+	if len(ch.acked) != 0 {
+		t.Errorf("acked %v after an abort — the batch must redeliver", ch.acked)
+	}
+}
+
+// TestBreakpoint_PromptPreviewCarriesTheComposedMessage: the pause shows what
+// each agent WILL be asked, which is the thing no channel inspection could ever
+// show — the composed prompt never touches a channel.
+func TestBreakpoint_PromptPreviewCarriesTheComposedMessage(t *testing.T) {
+	ch := threeMessages()
+	spawn := &countingSpawn{}
+	var seen []PromptPreview
+	r := breakRunner(t, ch, spawn.fn, []string{"wave:before_dispatch"},
+		func(_ context.Context, bp Breakpoint) (BreakDecision, error) {
+			seen = bp.Prompts
+			return BreakDecision{Action: BreakContinue}, nil
+		})
+	if _, err := r.RunHandler(context.Background(), starterState(), &Task{Input: "go", WalkID: "wlk_t"}); err != nil {
+		t.Fatalf("starter: %v", err)
+	}
+	if len(seen) != 3 {
+		t.Fatalf("previewed %d prompts, want 3", len(seen))
+	}
+	for i, p := range seen {
+		if p.Index != i {
+			t.Errorf("preview[%d].Index = %d", i, p.Index)
+		}
+		if p.Agent != "reviewer" {
+			t.Errorf("preview[%d].Agent = %q, want reviewer", i, p.Agent)
+		}
+		if want := fmt.Sprintf(`{"pr":%d}`, i+1); p.Message != want {
+			t.Errorf("preview[%d].Message = %q, want %q", i, p.Message, want)
+		}
+		if p.System != "You review." || !strings.Contains(p.Input, StarterMessageSlot) {
+			t.Errorf("preview[%d] lost the node's templates: %+v", i, p)
+		}
+	}
+}
+
+// TestBreakpoint_AfterCollectionWithholdsEverySinkMessage: every run is DONE and
+// the sink is still empty. That is the whole claim of the phase — the next stage
+// must not see a result the operator has not released.
+func TestBreakpoint_AfterCollectionWithholdsEverySinkMessage(t *testing.T) {
+	ch := threeMessages()
+	spawn := &countingSpawn{}
+	var ranAtAsk, publishedAtAsk int
+	var results []BreakpointResult
+	r := breakRunner(t, ch, spawn.fn, []string{"wave:after_collection"},
+		func(_ context.Context, bp Breakpoint) (BreakDecision, error) {
+			ranAtAsk, publishedAtAsk = spawn.count(), len(ch.sinks(t))
+			results = bp.Results
+			return BreakDecision{Action: BreakContinue}, nil
+		})
+
+	if _, err := r.RunHandler(context.Background(), starterState(), &Task{Input: "go", WalkID: "wlk_t"}); err != nil {
+		t.Fatalf("starter: %v", err)
+	}
+	if ranAtAsk != 3 {
+		t.Errorf("%d runs had finished when after_collection asked, want 3", ranAtAsk)
+	}
+	if publishedAtAsk != 0 {
+		t.Errorf("%d sink messages were already published when after_collection asked — the phase must withhold all of them", publishedAtAsk)
+	}
+	if len(results) != 3 || results[0].Output != `verdict for {"pr":1}` {
+		t.Errorf("result preview = %+v, want the three outputs", results)
+	}
+	if n := len(ch.sinks(t)); n != 3 {
+		t.Errorf("published %d sink messages after continue, want 3", n)
+	}
+}
+
+// TestBreakpoint_AfterCollectionReleasesExactlyN: a staged publish moves exactly
+// the released results onto the sink, in wave order.
+func TestBreakpoint_AfterCollectionReleasesExactlyN(t *testing.T) {
+	ch := threeMessages()
+	spawn := &countingSpawn{}
+	var publishedAtAsk []int
+	r := breakRunner(t, ch, spawn.fn, []string{"wave:after_collection"},
+		func(_ context.Context, bp Breakpoint) (BreakDecision, error) {
+			publishedAtAsk = append(publishedAtAsk, len(ch.sinks(t)))
+			if len(publishedAtAsk) == 1 {
+				return BreakDecision{Action: BreakRelease, N: 2}, nil
+			}
+			return BreakDecision{Action: BreakContinue}, nil
+		})
+
+	if _, err := r.RunHandler(context.Background(), starterState(), &Task{Input: "go", WalkID: "wlk_t"}); err != nil {
+		t.Fatalf("starter: %v", err)
+	}
+	if want := []int{0, 2}; !equalInts(publishedAtAsk, want) {
+		t.Errorf("sink depth at each pause = %v, want %v", publishedAtAsk, want)
+	}
+	sinks := ch.sinks(t)
+	if len(sinks) != 3 {
+		t.Fatalf("published %d, want 3", len(sinks))
+	}
+	for i, m := range sinks {
+		if m.Index != i {
+			t.Errorf("sink[%d].Index = %d — a staged release must publish in wave order", i, m.Index)
+		}
+		if m.WaveSize != 3 {
+			t.Errorf("sink[%d].WaveSize = %d, want 3 — the width must not shrink to the released count", i, m.WaveSize)
+		}
+	}
+}
+
+// TestBreakpoint_AfterCollectionAbortWithholdsTheUnreleased: rejecting a wave
+// means the next stage never sees it. A flush-on-abort would make the one thing
+// this breakpoint exists to do untrue.
+func TestBreakpoint_AfterCollectionAbortWithholdsTheUnreleased(t *testing.T) {
+	ch := threeMessages()
+	spawn := &countingSpawn{}
+	asks := 0
+	r := breakRunner(t, ch, spawn.fn, []string{"wave:after_collection"},
+		func(context.Context, Breakpoint) (BreakDecision, error) {
+			asks++
+			if asks == 1 {
+				return BreakDecision{Action: BreakRelease, N: 1}, nil
+			}
+			return BreakDecision{Action: BreakAbort}, nil
+		})
+
+	_, err := r.RunHandler(context.Background(), starterState(), &Task{Input: "go", WalkID: "wlk_t"})
+	if err == nil {
+		t.Fatal("an aborted breakpoint must fail the walk")
+	}
+	// The one the operator released stays published; the two they rejected do
+	// not appear.
+	if n := len(ch.sinks(t)); n != 1 {
+		t.Errorf("published %d sink messages, want 1 — only the released result may reach the sink", n)
+	}
+	if spawn.count() != 3 {
+		t.Errorf("the runs themselves still happened: spawned %d, want 3", spawn.count())
+	}
+}
+
+// TestBreakpoint_PhaseScopedArmingPausesOnlyThatPhase: "state:after_collection"
+// must not stop the walk before dispatch, or the phase suffix means nothing.
+func TestBreakpoint_PhaseScopedArmingPausesOnlyThatPhase(t *testing.T) {
+	for _, tc := range []struct {
+		arg   string
+		phase BreakpointPhase
+		want  []BreakpointPhase
+	}{
+		{"wave:before_dispatch", BeforeDispatch, []BreakpointPhase{BeforeDispatch}},
+		{"wave:after_collection", AfterCollection, []BreakpointPhase{AfterCollection}},
+		{"wave", "", []BreakpointPhase{BeforeDispatch, AfterCollection}},
+	} {
+		t.Run(tc.arg, func(t *testing.T) {
+			ch := threeMessages()
+			spawn := &countingSpawn{}
+			var phases []BreakpointPhase
+			r := breakRunner(t, ch, spawn.fn, []string{tc.arg},
+				func(_ context.Context, bp Breakpoint) (BreakDecision, error) {
+					phases = append(phases, bp.Phase)
+					return BreakDecision{Action: BreakContinue}, nil
+				})
+			if _, err := r.RunHandler(context.Background(), starterState(), &Task{Input: "go", WalkID: "wlk_t"}); err != nil {
+				t.Fatalf("starter: %v", err)
+			}
+			if len(phases) != len(tc.want) {
+				t.Fatalf("paused at %v, want %v", phases, tc.want)
+			}
+			for i := range phases {
+				if phases[i] != tc.want[i] {
+					t.Errorf("pause[%d] = %q, want %q", i, phases[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestBreakpoint_UnarmedStateTakesTheOriginalPath: a walk that arms a different
+// state never asks, and publishes as it goes — the no-breakpoints behaviour.
+func TestBreakpoint_UnarmedStateTakesTheOriginalPath(t *testing.T) {
+	ch := threeMessages()
+	spawn := &countingSpawn{}
+	r := breakRunner(t, ch, spawn.fn, []string{"some-other-state"},
+		func(context.Context, Breakpoint) (BreakDecision, error) {
+			t.Error("an unarmed state must never pause")
+			return BreakDecision{Action: BreakAbort}, nil
+		})
+	if _, err := r.RunHandler(context.Background(), starterState(), &Task{Input: "go", WalkID: "wlk_t"}); err != nil {
+		t.Fatalf("starter: %v", err)
+	}
+	if n := len(ch.sinks(t)); n != 3 {
+		t.Errorf("published %d, want 3", n)
+	}
+}
+
+// TestBreakpoint_AskErrorAbortsTheWalk: a debugger whose operator cannot be
+// reached must not release the wave.
+func TestBreakpoint_AskErrorAbortsTheWalk(t *testing.T) {
+	ch := threeMessages()
+	spawn := &countingSpawn{}
+	sentinel := errors.New("interruption timed out")
+	r := breakRunner(t, ch, spawn.fn, []string{"wave:before_dispatch"},
+		func(context.Context, Breakpoint) (BreakDecision, error) {
+			return BreakDecision{Action: BreakContinue}, sentinel
+		})
+	_, err := r.RunHandler(context.Background(), starterState(), &Task{Input: "go", WalkID: "wlk_t"})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want the ask's error", err)
+	}
+	if spawn.count() != 0 {
+		t.Errorf("spawned %d runs despite an unanswerable breakpoint, want 0", spawn.count())
+	}
+}
+
+// TestBreakpoint_StagedDispatchDoesNotShortCircuit: the wait threshold stops
+// runs nobody is waiting for, but an operator stepping through a wave released
+// each batch DELIBERATELY. Cancelling one because an earlier batch already met
+// the threshold would make the debugger lie about what it ran.
+func TestBreakpoint_StagedDispatchDoesNotShortCircuit(t *testing.T) {
+	ch := threeMessages()
+	spawn := &countingSpawn{}
+	st := starterState()
+	st.Handler.Fanout.Wait = teamgraph.WaitAtLeast + ":1"
+
+	asks := 0
+	r := breakRunner(t, ch, spawn.fn, []string{"wave:before_dispatch"},
+		func(context.Context, Breakpoint) (BreakDecision, error) {
+			asks++
+			return BreakDecision{Action: BreakRelease, N: 1}, nil
+		})
+	if _, err := r.RunHandler(context.Background(), st, &Task{Input: "go", WalkID: "wlk_t"}); err != nil {
+		t.Fatalf("starter: %v", err)
+	}
+	if asks != 3 {
+		t.Errorf("asked %d times, want 3 — every step must be offered", asks)
+	}
+	if got := spawn.count(); got != 3 {
+		t.Errorf("spawned %d runs, want 3 — a released run must actually run even once at_least is met", got)
+	}
+	for i, m := range ch.sinks(t) {
+		if m.Status != SinkOK {
+			t.Errorf("sink[%d] = %q (%s), want ok — a released run must not be cancelled", i, m.Status, m.Error)
+		}
+	}
+}
+
+func TestParseBreakpoint(t *testing.T) {
+	for _, tc := range []struct {
+		in    string
+		id    string
+		phase BreakpointPhase
+		ok    bool
+	}{
+		{"wave", "wave", "", true},
+		{"wave:before_dispatch", "wave", BeforeDispatch, true},
+		{"wave:after_collection", "wave", AfterCollection, true},
+		{"wave:typo", "", "", false},
+		{"", "", "", false},
+		{":before_dispatch", "", "", false},
+		// A state id may itself contain a colon, so only the LAST segment is a
+		// phase candidate — and if it is not a phase, the whole thing is refused
+		// rather than silently read as an id.
+		{"team:wave:after_collection", "team:wave", AfterCollection, true},
+	} {
+		id, phase, ok := ParseBreakpoint(tc.in)
+		if id != tc.id || phase != tc.phase || ok != tc.ok {
+			t.Errorf("ParseBreakpoint(%q) = (%q, %q, %v), want (%q, %q, %v)",
+				tc.in, id, phase, ok, tc.id, tc.phase, tc.ok)
+		}
+	}
+	if err := ValidateBreakpoints([]string{"wave", "wave:typo"}); err == nil {
+		t.Error("ValidateBreakpoints must refuse an unknown phase")
+	}
+	if err := ValidateBreakpoints([]string{"wave", "wave:after_collection"}); err != nil {
+		t.Errorf("ValidateBreakpoints refused a valid pair: %v", err)
+	}
+}
+
+func equalInts(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/teamrun/spawn.go
+++ b/internal/teamrun/spawn.go
@@ -132,6 +132,16 @@ type agentRunner struct {
 	// internal/connector, and teamrun importing that would undo the dependency
 	// contract this package is built on.
 	maxWave int
+	// breakAt is the set of state ids the operator armed, and onBreak is how
+	// they are asked. BOTH come from the RUN, never from the definition: a
+	// `debug: true` in a def would change its content hash, so turning the
+	// debugger on would fork the workflow — and then the thing being debugged
+	// is not the thing that runs in production.
+	//
+	// Empty breakAt means no state ever asks, so a walk without breakpoints
+	// takes byte-identical paths to one from before this existed.
+	breakAt map[string]map[BreakpointPhase]bool
+	onBreak BreakpointFunc
 }
 
 // RunnerOption configures the production runner. Options rather than more
@@ -153,6 +163,40 @@ func WithWaveContext(f func(ctx context.Context, walkID, waveID string, index in
 // WithMaxWave wires the deployment's ceiling on one Starter wave.
 func WithMaxWave(n int) RunnerOption {
 	return func(r *agentRunner) { r.maxWave = n }
+}
+
+// WithBreakpoints arms debug pauses on the named Starter states.
+//
+// A RUN argument by construction: the caller passes the state ids it was given
+// for THIS run, so the same promoted definition runs straight through in
+// production and paused in a canvas.
+func WithBreakpoints(states []string, f BreakpointFunc) RunnerOption {
+	return func(r *agentRunner) {
+		if len(states) == 0 || f == nil {
+			return
+		}
+		r.breakAt = make(map[string]map[BreakpointPhase]bool, len(states))
+		for _, s := range states {
+			id, phase, ok := ParseBreakpoint(s)
+			if !ok {
+				continue // refused at the run boundary; skipped here as belt
+			}
+			if r.breakAt[id] == nil {
+				r.breakAt[id] = map[BreakpointPhase]bool{}
+			}
+			if phase == "" {
+				r.breakAt[id][BeforeDispatch] = true
+				r.breakAt[id][AfterCollection] = true
+				continue
+			}
+			r.breakAt[id][phase] = true
+		}
+		if len(r.breakAt) == 0 {
+			r.breakAt = nil
+			return
+		}
+		r.onBreak = f
+	}
 }
 
 // WithRunnerLogf wires the non-fatal log sink.

--- a/internal/teamrun/starter.go
+++ b/internal/teamrun/starter.go
@@ -211,41 +211,124 @@ func (r *agentRunner) runWave(ctx context.Context, st teamgraph.State, task *Tas
 	defer cancel()
 
 	results := make([]agentResult, dispatches)
+	published := make([]bool, dispatches)
 	sem := make(chan struct{}, parallelConcurrency(dispatches))
-	var wg sync.WaitGroup
-	var mu sync.Mutex
+	var mu sync.Mutex // guards successes and published
 	successes := 0
 
-	for i := 0; i < dispatches; i++ {
-		i := i
-		agent := agentFor(i)
-		slots := waveSlots(h, msgs, i)
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			select {
-			case sem <- struct{}{}:
-				defer func() { <-sem }()
-			case <-runCtx.Done():
-				// Cancelled before it ever ran — still a result, and still a
-				// sink message, because the count is the contract.
-				res := agentResult{Index: i, Agent: agent, Ok: false, Error: runCtx.Err().Error()}
-				results[i] = res
-				r.publishSink(ctx, st, waveID, dispatches, res)
-				return
-			}
-			results[i] = r.dispatchOne(runCtx, st, env, agent, waveID, i, dispatches, slots)
-			if results[i].Ok {
+	// The sink publish is DEFERRED when this state is armed at AfterCollection:
+	// the operator is reviewing the wave, and the next stage must not see a
+	// result they have not released. It is a deferral, never a durable cache —
+	// the runs themselves hold the outputs, and if this process dies while
+	// parked, no sink message arrives: the orchestrator-died-mid-wave case the
+	// design already documents and the downstream wait_ms already backstops.
+	deferPublish := r.armed(st, AfterCollection)
+
+	// A staged dispatch must not short-circuit. The wait threshold exists to
+	// stop runs nobody is waiting for, but an operator stepping through a wave
+	// released each batch deliberately — cancelling one because an earlier batch
+	// already met the threshold would make the debugger lie about what it ran.
+	shortCircuit := !r.armed(st, BeforeDispatch)
+
+	// emit publishes run i's sink message exactly once. The claim is taken under
+	// the lock and the publish made outside it: publishSink is a store write
+	// with its own timeout, and holding the wave's lock across it would
+	// serialize a fan-out that exists to be parallel.
+	emit := func(i int) {
+		mu.Lock()
+		if published[i] {
+			mu.Unlock()
+			return
+		}
+		published[i] = true
+		mu.Unlock()
+		r.publishSink(ctx, st, waveID, dispatches, results[i])
+	}
+
+	dispatch := func(from, to int) error {
+		var wg sync.WaitGroup
+		for i := from; i < to; i++ {
+			i := i
+			agent := agentFor(i)
+			slots := waveSlots(h, msgs, i)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				select {
+				case sem <- struct{}{}:
+					defer func() { <-sem }()
+				case <-runCtx.Done():
+					// Cancelled before it ever ran — still a result, and still
+					// a sink message, because the count is the contract.
+					results[i] = agentResult{Index: i, Agent: agent, Ok: false, Error: runCtx.Err().Error()}
+					if !deferPublish {
+						emit(i)
+					}
+					return
+				}
+				res := r.dispatchOne(runCtx, st, env, agent, waveID, i, slots)
 				mu.Lock()
-				successes++
-				if successes >= need {
-					cancel() // enough succeeded → stop the rest (no-op for wait:all)
+				results[i] = res
+				if res.Ok {
+					successes++
+					if shortCircuit && successes >= need {
+						cancel() // enough succeeded → stop the rest (no-op for wait:all)
+					}
 				}
 				mu.Unlock()
-			}
-		}()
+				if !deferPublish {
+					emit(i)
+				}
+			}()
+		}
+		wg.Wait()
+		return nil
 	}
-	wg.Wait()
+
+	// PAUSE 1 — before_dispatch. Every prompt is composed and nothing has run.
+	if r.armed(st, BeforeDispatch) {
+		err = stage(ctx, dispatches,
+			func(pending int) (BreakDecision, error) {
+				return r.onBreak(ctx, Breakpoint{
+					State: st.ID, Phase: BeforeDispatch, Wave: waveID,
+					WaveSize: dispatches, Pending: pending,
+					Prompts: previewPrompts(h, msgs, agentFor, dispatches-pending, dispatches),
+				})
+			}, dispatch)
+	} else {
+		err = dispatch(0, dispatches)
+	}
+	if err != nil {
+		return results, err
+	}
+
+	// PAUSE 2 — after_collection. The wave is complete and the sink is empty.
+	//
+	// Aborting here publishes NOTHING further, and that is the point: an
+	// operator who rejects a wave is saying the next stage must not see it. A
+	// flush-on-abort would make the one thing this breakpoint exists to do —
+	// withhold a result — untrue. Runs already released in an earlier step stay
+	// published, because the operator released them. Nothing downstream is left
+	// hanging either way: the abort fails the walk, so there is no next stage.
+	if deferPublish {
+		if err := stage(ctx, dispatches,
+			func(pending int) (BreakDecision, error) {
+				from := dispatches - pending
+				return r.onBreak(ctx, Breakpoint{
+					State: st.ID, Phase: AfterCollection, Wave: waveID,
+					WaveSize: dispatches, Pending: pending,
+					Results: previewResults(results[from:]),
+				})
+			},
+			func(from, to int) error {
+				for i := from; i < to; i++ {
+					emit(i)
+				}
+				return nil
+			}); err != nil {
+			return results, err
+		}
+	}
 
 	if successes < need {
 		wait := h.Fanout.Wait
@@ -264,21 +347,22 @@ func (r *agentRunner) runWave(ctx context.Context, st teamgraph.State, task *Tas
 	return results, nil
 }
 
-// dispatchOne spawns one run of the wave and publishes exactly one sink message
-// for it, whatever happens.
+// dispatchOne spawns one run of the wave and ALWAYS returns a result, including
+// for a panic in the spawner.
 //
-// The publish is deferred so it survives a panic in the spawner: a fan-in
-// counting messages cannot tell "still running" from "died", so a wave that can
-// produce fewer messages than runs turns a downstream wait into a hang. The
-// count is the contract.
-func (r *agentRunner) dispatchOne(ctx context.Context, st teamgraph.State, env Env, agent, waveID string, index, waveSize int, slots map[string]string) (res agentResult) {
+// It returns the result rather than publishing it, because whether a result may
+// be published is the caller's question once a breakpoint can withhold one. The
+// guarantee the recover protects is unchanged and still load-bearing: a fan-in
+// counting sink messages cannot tell "still running" from "died", so a wave that
+// produced fewer results than runs would turn a downstream wait into a hang.
+// The count is the contract.
+func (r *agentRunner) dispatchOne(ctx context.Context, st teamgraph.State, env Env, agent, waveID string, index int, slots map[string]string) (res agentResult) {
 	res = agentResult{Index: index, Agent: agent}
 	defer func() {
 		if rec := recover(); rec != nil {
 			res = agentResult{Index: index, Agent: agent, Ok: false,
 				Error: fmt.Sprintf("agent %q panicked: %v", agent, rec)}
 		}
-		r.publishSink(ctx, st, waveID, waveSize, res)
 	}()
 
 	prompt := Prompt{Values: env.Values(), DataSlots: slots}
@@ -296,8 +380,8 @@ func (r *agentRunner) dispatchOne(ctx context.Context, st teamgraph.State, env E
 	return res
 }
 
-// publishSink writes one run's outcome to the sink. Called from dispatchOne's
-// defer, so it runs on every path including a panic.
+// publishSink writes one run's outcome to the sink. Called through the wave's
+// emit, which claims each index once so a staged release cannot double-publish.
 func (r *agentRunner) publishSink(ctx context.Context, st teamgraph.State, waveID string, waveSize int, res agentResult) {
 	if st.Handler.Sink == nil {
 		return

--- a/internal/tools/builtin/teamdef.go
+++ b/internal/tools/builtin/teamdef.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/denn-gubsky/loomcycle/internal/store"
@@ -125,7 +126,9 @@ const teamDefDescription = `Author, fork, promote, retire, and inspect team work
 	`(success to advance, pushback to loop back for rework) — output threads to the next state, until a ` +
 	`terminal state. run may OPTIONALLY bind to a Document chunk board (board_chunk_id) so progress persists ` +
 	`as chunk.status and resumes across runs, and may escalate an iteration cap to a human (interrupt_on_cap) ` +
-	`instead of aborting. retire soft-retires one version; delete ` +
+	`instead of aborting. run may also set breakpoints on starter states to step a fan-out wave: the walk pauses ` +
+	`before dispatching (showing each composed prompt) and/or after collecting (showing each result, before any of ` +
+	`it reaches the sink) and asks a human to release all, release n, or abort. retire soft-retires one version; delete ` +
 	`hard-removes a whole team by name (all versions + active pointer), scoped to your tenant. Operations: ` +
 	`create, fork, get, list, retire, delete, promote, verify, render_diagram, run.`
 
@@ -157,7 +160,8 @@ const teamDefInputSchema = `{
     "input":          {"type": "string", "description": "run: the initial input handed to the entry state's agent (the task/prompt the team works on)."},
     "board_chunk_id": {"type": "string", "description": "run (optional): bind the walk to a Document chunk task board. Each state transition persists chunk.status = the current team state (durable progress), and a later run RESUMES from the persisted status. Omit for an ephemeral run (default)."},
     "board_scope":    {"type": "string", "enum": ["agent","user"], "description": "run (optional): the Document scope of board_chunk_id (default user)."},
-    "interrupt_on_cap": {"type": "boolean", "description": "run (optional): when a state hits its iteration cap, ask a human (Interruption) whether to continue / reroute:<state> / abort instead of returning the iteration_cap outcome. An unanswered/timed-out/declined ask aborts (still terminates). Default false."}
+    "interrupt_on_cap": {"type": "boolean", "description": "run (optional): when a state hits its iteration cap, ask a human (Interruption) whether to continue / reroute:<state> / abort instead of returning the iteration_cap outcome. An unanswered/timed-out/declined ask aborts (still terminates). Default false."},
+    "breakpoints":      {"type": "array", "items": {"type": "string"}, "description": "run (optional): debug mode. Each entry is a starter state id — \"review\" pauses both phases, \"review:before_dispatch\" or \"review:after_collection\" pauses one. At before_dispatch the wave is composed but nothing has run; at after_collection the runs are done but nothing has reached the sink. Each pause asks a human (Interruption) to reply 'continue' (release all), 'release:<n>' (release n and pause again), or 'abort'. An unanswered/declined ask aborts. A run-time argument, never part of the definition: debugging a team must not change what the team IS."}
   },
   "required": ["op"]
 }`
@@ -178,6 +182,7 @@ type teamDefInput struct {
 	BoardChunkID   string          `json:"board_chunk_id,omitempty"`   // run: bind the walk to a Document chunk board
 	BoardScope     string          `json:"board_scope,omitempty"`      // run: board_chunk_id's Document scope (agent|user, default user)
 	InterruptOnCap bool            `json:"interrupt_on_cap,omitempty"` // run: escalate an iteration cap to a human instead of aborting
+	Breakpoints    []string        `json:"breakpoints,omitempty"`      // run: starter states to pause at (debug mode)
 }
 
 // Name implements tools.Tool.
@@ -755,7 +760,54 @@ func (t *TeamDef) execRun(ctx context.Context, in teamDefInput) (tools.Result, e
 		}))
 	}
 
+	// Breakpoints are a RUN argument, deliberately: a `debug: true` in a
+	// definition would change its content hash, so turning the debugger on would
+	// fork the workflow — and the thing being debugged would not be the thing
+	// that runs in production.
+	breaks := 0
+	lastBreak := ""
 	var runnerOpts []teamrun.RunnerOption
+	if len(in.Breakpoints) > 0 {
+		if err := teamrun.ValidateBreakpoints(in.Breakpoints); err != nil {
+			return errResult(fmt.Sprintf("run: %s", err)), nil
+		}
+		// A breakpoint on a state that does not exist — or on one that never
+		// dispatches a wave — would arm nothing, and the operator would sit
+		// watching a walk that runs to completion without ever pausing. Refuse
+		// the typo instead.
+		for _, bp := range in.Breakpoints {
+			id, _, _ := teamrun.ParseBreakpoint(bp)
+			bst, known := teamgraph.StateByID(def, id)
+			if !known {
+				return errResult(fmt.Sprintf("run: breakpoint %q: team %q has no state %q", bp, row.Name, id)), nil
+			}
+			if bst.Handler.Kind != teamgraph.HandlerStarter {
+				return errResult(fmt.Sprintf("run: breakpoint %q: state %q is a %q, and only a starter dispatches a wave to pause on",
+					bp, id, bst.Handler.Kind)), nil
+			}
+		}
+		// REFUSED rather than degraded. interrupt_on_cap may silently fall back
+		// to aborting because the fallback is still safe; a breakpoint's whole
+		// job is to hold work back, so running at full speed because nobody can
+		// be asked is the opposite of what the caller requested.
+		if t.AskHuman == nil {
+			return errResult("run: breakpoints require the Interruption machinery, which is not wired on this server"), nil
+		}
+		runnerOpts = append(runnerOpts, teamrun.WithBreakpoints(in.Breakpoints,
+			func(c context.Context, bp teamrun.Breakpoint) (teamrun.BreakDecision, error) {
+				breaks++
+				answer, aerr := t.AskHuman(c, formatBreakpoint(row.Name, bp))
+				if aerr != nil {
+					// Unavailable / timed out / cancelled / declined → abort.
+					// A debugger nobody can answer must not release the wave.
+					lastBreak = "abort"
+					return teamrun.BreakDecision{Action: teamrun.BreakAbort}, nil
+				}
+				dec := parseBreakAnswer(answer)
+				lastBreak = breakActionLabel(dec)
+				return dec, nil
+			}))
+	}
 	if t.Channels != nil {
 		// Built per run: the executor closes over THIS definition's ACL, which
 		// is what makes the team the ACL subject for its source and sink.
@@ -797,6 +849,12 @@ func (t *TeamDef) execRun(ctx context.Context, in teamDefInput) (tools.Result, e
 			m["interruptions"] = interruptions
 			if lastDecision != "" {
 				m["cap_decision"] = lastDecision
+			}
+		}
+		if len(in.Breakpoints) > 0 {
+			m["breakpoints_hit"] = breaks
+			if lastBreak != "" {
+				m["break_decision"] = lastBreak
 			}
 		}
 		return m
@@ -861,6 +919,99 @@ func capActionLabel(d teamrun.CapDecision) string {
 		return "continue"
 	case teamrun.CapReroute:
 		return "reroute:" + d.Reroute
+	default:
+		return "abort"
+	}
+}
+
+// maxBreakPreview bounds ONE previewed prompt or output in the question text.
+// An agent's output can be a whole document; a human deciding "release this or
+// not" needs enough to recognise it, and an Interruption ask that carries a
+// megabyte helps nobody.
+const maxBreakPreview = 600
+
+// formatBreakpoint renders a pause as the question a human answers.
+//
+// The wave's width is stated on every pause so "3 of 8" means the same thing at
+// each step of a staged release, and each pending entry is listed with its wave
+// index — the index is what the operator matches against the sink messages and
+// the run list afterwards.
+func formatBreakpoint(team string, bp teamrun.Breakpoint) string {
+	var b strings.Builder
+	phase := "BEFORE dispatching"
+	unit := "run"
+	if bp.Phase == teamrun.AfterCollection {
+		phase = "AFTER collecting"
+		unit = "result"
+	}
+	fmt.Fprintf(&b, "Team %q: state %q paused %s wave %s (%d %ss in the wave, %d pending).\n",
+		team, bp.State, phase, bp.Wave, bp.WaveSize, unit, bp.Pending)
+	for _, p := range bp.Prompts {
+		fmt.Fprintf(&b, "[%d] %s ← %s\n", p.Index, p.Agent, truncPreview(p.Message))
+	}
+	for _, res := range bp.Results {
+		status, body := "ok", res.Output
+		if !res.Ok {
+			status, body = "error", res.Error
+		}
+		fmt.Fprintf(&b, "[%d] %s %s: %s\n", res.Index, res.Agent, status, truncPreview(body))
+	}
+	verb := "dispatch"
+	if bp.Phase == teamrun.AfterCollection {
+		verb = "publish"
+	}
+	fmt.Fprintf(&b, "Reply `continue` to %s all %d, `release:<n>` to %s the first n and pause again, or `abort` to stop the walk.",
+		verb, bp.Pending, verb)
+	return b.String()
+}
+
+// truncPreview bounds one previewed body and says so, rather than silently
+// handing a human a prefix they would read as the whole thing.
+func truncPreview(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "(empty)"
+	}
+	if len(s) <= maxBreakPreview {
+		return s
+	}
+	return s[:maxBreakPreview] + fmt.Sprintf("… (+%d bytes)", len(s)-maxBreakPreview)
+}
+
+// parseBreakAnswer maps a human's free-text breakpoint answer to a decision.
+// Mirrors parseCapAnswer: only an explicit continue or release proceeds, and
+// everything else — "abort", empty, an unrecognised reply — stops. A debugger
+// that defaulted to releasing would be a debugger you cannot trust to hold.
+func parseBreakAnswer(answer string) teamrun.BreakDecision {
+	trimmed := strings.TrimSpace(answer)
+	switch {
+	case strings.EqualFold(trimmed, "continue"), strings.EqualFold(trimmed, "all"):
+		return teamrun.BreakDecision{Action: teamrun.BreakContinue}
+	case strings.HasPrefix(strings.ToLower(trimmed), "release"):
+		rest := strings.TrimSpace(trimmed[len("release"):])
+		rest = strings.TrimSpace(strings.TrimPrefix(rest, ":"))
+		if rest == "" {
+			// "release" with no number is one step — the same reading the
+			// runner gives an N below 1.
+			return teamrun.BreakDecision{Action: teamrun.BreakRelease, N: 1}
+		}
+		n, err := strconv.Atoi(rest)
+		if err != nil || n < 1 {
+			return teamrun.BreakDecision{Action: teamrun.BreakAbort}
+		}
+		return teamrun.BreakDecision{Action: teamrun.BreakRelease, N: n}
+	default:
+		return teamrun.BreakDecision{Action: teamrun.BreakAbort}
+	}
+}
+
+// breakActionLabel is the human-readable decision recorded on the run response.
+func breakActionLabel(d teamrun.BreakDecision) string {
+	switch d.Action {
+	case teamrun.BreakContinue:
+		return "continue"
+	case teamrun.BreakRelease:
+		return fmt.Sprintf("release:%d", d.N)
 	default:
 		return "abort"
 	}

--- a/internal/tools/builtin/teamdef_breakpoint_test.go
+++ b/internal/tools/builtin/teamdef_breakpoint_test.go
@@ -1,0 +1,261 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/teamgraph"
+	"github.com/denn-gubsky/loomcycle/internal/teamrun"
+)
+
+// stubChannelIO is a two-message inbox and a recording sink — enough to drive a
+// starter state end-to-end through op=run without a channel store.
+type stubChannelIO struct {
+	mu        sync.Mutex
+	published []json.RawMessage
+}
+
+func (s *stubChannelIO) Read(context.Context, string, int, int, int) ([]teamrun.ChannelMessage, string, error) {
+	return []teamrun.ChannelMessage{
+		{ID: "m1", Payload: json.RawMessage(`{"pr":1}`)},
+		{ID: "m2", Payload: json.RawMessage(`{"pr":2}`)},
+	}, "cur", nil
+}
+
+func (s *stubChannelIO) Ack(context.Context, string, string) error { return nil }
+
+func (s *stubChannelIO) Publish(_ context.Context, _ string, payload json.RawMessage) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.published = append(s.published, payload)
+	return nil
+}
+
+func (s *stubChannelIO) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.published)
+}
+
+// breakFixture wires a runnable starter team: a spawner, a channel executor and
+// the team itself.
+func breakFixture(t *testing.T) (*TeamDef, context.Context, *stubChannelIO, *int, func()) {
+	t.Helper()
+	tool, ctx, done := teamDefFixture(t)
+	io := &stubChannelIO{}
+	spawned := 0
+	var mu sync.Mutex
+	tool.Spawn = func(_ context.Context, _ string, _ teamrun.Prompt, _ string) (string, error) {
+		mu.Lock()
+		spawned++
+		mu.Unlock()
+		return "reviewed", nil
+	}
+	tool.Channels = func(context.Context, teamgraph.Definition) teamrun.ChannelIO { return io }
+	actx := authoringCtx([]string{"verdicts"}, []string{"pr-events"})
+	createTeam(t, tool, actx, "triage",
+		strings.TrimSuffix(starterGraph, "}")+`,"channels":{"publish":["verdicts"],"subscribe":["pr-events"]}}`)
+	_ = ctx
+	return tool, actx, io, &spawned, done
+}
+
+// TestTeamDefTool_Run_BreakpointAsksAtBothPhasesAndReleases: the end-to-end
+// debug path — a breakpoint on a starter pauses twice (before dispatch, after
+// collection), the human's answer releases each, and the run reports what
+// happened.
+func TestTeamDefTool_Run_BreakpointAsksAtBothPhasesAndReleases(t *testing.T) {
+	tool, ctx, io, spawned, done := breakFixture(t)
+	defer done()
+
+	var questions []string
+	var spawnedAtAsk, publishedAtAsk []int
+	tool.AskHuman = func(_ context.Context, q string) (string, error) {
+		questions = append(questions, q)
+		spawnedAtAsk = append(spawnedAtAsk, *spawned)
+		publishedAtAsk = append(publishedAtAsk, io.count())
+		return "continue", nil
+	}
+
+	res, _ := tool.Execute(ctx, json.RawMessage(
+		`{"op":"run","name":"triage","input":"x","breakpoints":["wave"]}`))
+	if res.IsError {
+		t.Fatalf("run: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	if out["status"] != "completed" {
+		t.Fatalf("status = %v, want completed", out["status"])
+	}
+	if len(questions) != 2 {
+		t.Fatalf("asked %d times, want 2 (before_dispatch + after_collection):\n%s",
+			len(questions), strings.Join(questions, "\n---\n"))
+	}
+	// Pause 1 happens with nothing spawned; pause 2 with everything spawned and
+	// nothing published. Those two numbers ARE the feature.
+	if spawnedAtAsk[0] != 0 {
+		t.Errorf("%d runs already spawned at the before_dispatch pause, want 0", spawnedAtAsk[0])
+	}
+	if spawnedAtAsk[1] != 2 || publishedAtAsk[1] != 0 {
+		t.Errorf("at the after_collection pause: spawned=%d published=%d, want 2 and 0",
+			spawnedAtAsk[1], publishedAtAsk[1])
+	}
+	if !strings.Contains(questions[0], "BEFORE dispatching") || !strings.Contains(questions[0], `state "wave"`) {
+		t.Errorf("before_dispatch question does not say what it is:\n%s", questions[0])
+	}
+	if !strings.Contains(questions[0], `{"pr":1}`) {
+		t.Errorf("before_dispatch question omits the composed prompt — the one thing no channel inspection shows:\n%s", questions[0])
+	}
+	if !strings.Contains(questions[1], "AFTER collecting") || !strings.Contains(questions[1], "reviewed") {
+		t.Errorf("after_collection question omits the results:\n%s", questions[1])
+	}
+	if io.count() != 2 {
+		t.Errorf("published %d sink messages, want 2", io.count())
+	}
+	if out["breakpoints_hit"].(float64) != 2 {
+		t.Errorf("breakpoints_hit = %v, want 2", out["breakpoints_hit"])
+	}
+	if out["break_decision"] != "continue" {
+		t.Errorf("break_decision = %v, want continue", out["break_decision"])
+	}
+}
+
+// TestTeamDefTool_Run_BreakpointAbortWithholdsTheSink: an unanswerable or
+// refused ask aborts, and nothing reaches the sink.
+func TestTeamDefTool_Run_BreakpointAbortWithholdsTheSink(t *testing.T) {
+	tool, ctx, io, spawned, done := breakFixture(t)
+	defer done()
+	tool.AskHuman = func(context.Context, string) (string, error) { return "abort", nil }
+
+	res, _ := tool.Execute(ctx, json.RawMessage(
+		`{"op":"run","name":"triage","input":"x","breakpoints":["wave:after_collection"]}`))
+	if !res.IsError {
+		t.Fatalf("an aborted breakpoint must fail the run, got: %s", res.Text)
+	}
+	if *spawned != 2 {
+		t.Errorf("spawned %d, want 2 (after_collection aborts AFTER the runs)", *spawned)
+	}
+	if io.count() != 0 {
+		t.Errorf("published %d sink messages after an abort, want 0 — withholding the result is the point", io.count())
+	}
+}
+
+// TestTeamDefTool_Run_BreakpointRefusals pins every way a breakpoint argument
+// can be wrong. Each is refused rather than armed as nothing — an operator who
+// typed a breakpoint and got a walk that never paused would reasonably conclude
+// the feature is broken.
+func TestTeamDefTool_Run_BreakpointRefusals(t *testing.T) {
+	for _, tc := range []struct {
+		name, bps, want string
+	}{
+		{"unknown state", `["nope"]`, "no state"},
+		{"not a starter", `["done"]`, "only a starter"},
+		{"unknown phase", `["wave:whenever"]`, "breakpoint"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tool, ctx, io, spawned, done := breakFixture(t)
+			defer done()
+			tool.AskHuman = func(context.Context, string) (string, error) { return "continue", nil }
+
+			res, _ := tool.Execute(ctx, json.RawMessage(
+				`{"op":"run","name":"triage","input":"x","breakpoints":`+tc.bps+`}`))
+			if !res.IsError || !strings.Contains(res.Text, tc.want) {
+				t.Fatalf("want a refusal containing %q, got IsError=%v: %s", tc.want, res.IsError, res.Text)
+			}
+			if *spawned != 0 || io.count() != 0 {
+				t.Errorf("a refused run must not walk: spawned=%d published=%d", *spawned, io.count())
+			}
+		})
+	}
+}
+
+// TestTeamDefTool_Run_BreakpointsRequireTheInterruptionMachinery: with no way
+// to ask, the run is REFUSED rather than silently running at full speed.
+// interrupt_on_cap may degrade to aborting because that fallback is still safe;
+// a breakpoint's whole job is to hold work back.
+func TestTeamDefTool_Run_BreakpointsRequireTheInterruptionMachinery(t *testing.T) {
+	tool, ctx, io, spawned, done := breakFixture(t)
+	defer done()
+	tool.AskHuman = nil
+
+	res, _ := tool.Execute(ctx, json.RawMessage(
+		`{"op":"run","name":"triage","input":"x","breakpoints":["wave"]}`))
+	if !res.IsError || !strings.Contains(res.Text, "Interruption") {
+		t.Fatalf("want a refusal naming the missing machinery, got IsError=%v: %s", res.IsError, res.Text)
+	}
+	if *spawned != 0 || io.count() != 0 {
+		t.Errorf("the wave ran anyway: spawned=%d published=%d", *spawned, io.count())
+	}
+}
+
+// TestTeamDefTool_Run_NoBreakpointsNeverAsks pins the additive contract: with
+// AskHuman wired but `breakpoints` absent, the run never pauses and the response
+// carries no debug fields. (Fail-before: arm unconditionally and this breaks.)
+func TestTeamDefTool_Run_NoBreakpointsNeverAsks(t *testing.T) {
+	tool, ctx, io, _, done := breakFixture(t)
+	defer done()
+	asked := 0
+	tool.AskHuman = func(context.Context, string) (string, error) { asked++; return "continue", nil }
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"run","name":"triage","input":"x"}`))
+	if res.IsError {
+		t.Fatalf("run: %s", res.Text)
+	}
+	if asked != 0 {
+		t.Errorf("AskHuman called %d times without breakpoints, want 0", asked)
+	}
+	out := decodeResult(t, res.Text)
+	if _, present := out["breakpoints_hit"]; present {
+		t.Errorf("breakpoints_hit present on a run that set none: %v", out)
+	}
+	if io.count() != 2 {
+		t.Errorf("published %d, want 2", io.count())
+	}
+}
+
+func TestParseBreakAnswer(t *testing.T) {
+	for _, tc := range []struct {
+		in     string
+		action teamrun.BreakAction
+		n      int
+	}{
+		{"continue", teamrun.BreakContinue, 0},
+		{"  CONTINUE ", teamrun.BreakContinue, 0},
+		{"all", teamrun.BreakContinue, 0},
+		{"release:3", teamrun.BreakRelease, 3},
+		{"release 2", teamrun.BreakRelease, 2},
+		{"release", teamrun.BreakRelease, 1},
+		{"release:0", teamrun.BreakAbort, 0},
+		{"release:-1", teamrun.BreakAbort, 0},
+		{"release:many", teamrun.BreakAbort, 0},
+		{"abort", teamrun.BreakAbort, 0},
+		// Anything unrecognised STOPS. A debugger that defaulted to releasing
+		// would be a debugger you cannot trust to hold.
+		{"", teamrun.BreakAbort, 0},
+		{"sure, go ahead", teamrun.BreakAbort, 0},
+	} {
+		got := parseBreakAnswer(tc.in)
+		if got.Action != tc.action || (tc.action == teamrun.BreakRelease && got.N != tc.n) {
+			t.Errorf("parseBreakAnswer(%q) = %+v, want action=%v n=%d", tc.in, got, tc.action, tc.n)
+		}
+	}
+}
+
+// TestFormatBreakpoint_TruncatesAnOversizedPreview: an agent's output can be a
+// whole document; the question a human answers must stay readable and say that
+// it was cut rather than hand over a prefix they would read as the whole thing.
+func TestFormatBreakpoint_TruncatesAnOversizedPreview(t *testing.T) {
+	q := formatBreakpoint("triage", teamrun.Breakpoint{
+		State: "wave", Phase: teamrun.AfterCollection, Wave: "wav_x",
+		WaveSize: 1, Pending: 1,
+		Results: []teamrun.BreakpointResult{{Index: 0, Agent: "reviewer", Ok: true,
+			Output: strings.Repeat("x", maxBreakPreview*3)}},
+	})
+	if len(q) > maxBreakPreview*2 {
+		t.Errorf("question is %d bytes — an oversized output was not bounded", len(q))
+	}
+	if !strings.Contains(q, "bytes)") {
+		t.Errorf("a truncated preview must say so:\n%s", q)
+	}
+}


### PR DESCRIPTION
## Why

A fan-out is the hardest thing in a workflow to watch. By the time anything is observable the whole wave has already run and its results are already on the next channel — and the one artefact you actually want, **what each agent was asked**, never touches a channel at all, so no amount of channel inspection will ever show it.

## What

Two pause points on the `starter` — the node kind that dispatches a wave:

| phase | state of the world |
|---|---|
| `before_dispatch` | every prompt composed, **nothing spawned** |
| `after_collection` | every run finished, **nothing published to the sink** |

At each pause the walk asks a human — through the Interruption machinery already injected for `interrupt_on_cap` — to release everything, release the first *n* and pause again, or abort. `release:n` is the step button: work through a wave one run, then three, then the rest.

```json
{"op":"run","name":"triage","input":"…","breakpoints":["wave"]}
{"op":"run","name":"triage","input":"…","breakpoints":["wave:after_collection"]}
```

**Why the Starter and not the channel.** A breakpoint decides when work starts, and a node kind is the thing that runs. Here, a paused wave needs no storage mechanism — the messages simply stay on the channel, unread, which is what a cursor is for — and it pauses ONE dispatcher instead of stalling a wire for every reader in the tenant. The channel-level `hold` that already ships stays what it is: an operator freezing a wire.

**Why it is a run argument.** A `debug: true` in a definition would change its content hash, so turning the debugger on would fork the workflow — and the thing being debugged would not be the thing that runs in production.

### Decisions worth calling out in review

- **Aborting at `after_collection` publishes nothing further.** A flush-on-abort would make the one thing this breakpoint exists to do — withhold a result from the next stage — untrue. Runs released in an earlier step stay published. Nothing hangs downstream either way: the abort fails the walk, so there is no next stage.
- **A staged dispatch does not short-circuit on the wait threshold.** An operator stepping through released each batch deliberately; cancelling one because an earlier batch already met `at_least` would make the debugger lie about what it ran.
- **Everything unclear aborts.** The zero-value decision, an unanswerable ask, an unrecognised reply. A debugger that defaults to releasing is one you cannot trust to hold.
- **Typos are refused, not armed as nothing.** A breakpoint on a state that does not exist, or on one that is not a starter, is a 4xx — otherwise the operator watches a walk that never pauses and concludes the feature is broken. So is a run asking for breakpoints on a server with no Interruption machinery: `interrupt_on_cap` may degrade to aborting because that fallback is still safe, but running a wave at full speed because nobody can be asked is the opposite of what the caller requested.
- **The sink publish moved out of `dispatchOne` into the wave**, behind a once-per-index claim, because whether a result may be published is now the caller's question. The guarantee the panic recovery protects is unchanged: every spawned run still produces exactly one result, so a downstream fan-in counting messages can never be left short. The claim is taken under the lock and the publish made outside it, so a fan-out that exists to be parallel is not serialized behind a store write.

### Scope, stated rather than assumed

The deferral is **in memory**. If the process dies while parked, no sink message arrives — which is the orchestrator-died-mid-wave case the design already documents and the downstream `wait_ms` already backstops. Surviving a restart while parked needs a persisted walk id and an indexed query over the runs; that is its own change, and I did not want to claim the stronger property by implication.

A run that sets no breakpoints takes the same path it took before this existed, asks nobody, and carries no new response fields.

## Found while verifying this: a bare `*` channel allowlist grants nothing

Running the feature end-to-end surfaced a **pre-existing** defect that blocks it (and blocks the canvas). Three def-authoring planes declare an open channel ACL as `Publish: []string{"*"}` — `internal/api/mcp/context.go:153`, `internal/api/grpc/substrate.go:73`, `internal/api/http/substrate_admin.go:410`, the MCP one carrying the comment *"open ACL (`*` matches every channel name)"*. `channelAllowed` supports an exact match and a trailing `/*` prefix wildcard and nothing else, so a bare `*` matches **no name at all**:

```
channelAllowed("verdicts",       ["*"]) = false
channelAllowed("pr-events",      ["*"]) = false
channelAllowed("findings/alpha", ["*"]) = false
```

Consequence, reproduced live: an MCP session cannot author a TeamDef with a `channels` block (`checkTeamChannelAuthority` refuses every entry), and without that block the Starter refuses its source at run time — so **no Starter team is both authorable and runnable over any non-in-band transport**. It is not this PR's code, but this PR is what surfaced it and its primary consumer is blocked by it. Fixing it at the matcher would silently widen every allowlist in the system that today grants nothing, so it needs an explicit discriminator rather than a wildcard tweak — **a separate PR, opened next**.

## Tested

`go build ./...`, `go vet ./...`, `gofmt -l` clean, **`go test ./...` green (110 packages)**, `go test -race ./internal/teamrun/...` green.

**Fail-before, six claims, each red against its own deliberate break:**

| break | test that reds |
|---|---|
| `deferPublish := false` | `TestBreakpoint_AfterCollectionWithholdsEverySinkMessage` |
| flush on abort at pause 2 | `TestBreakpoint_AfterCollectionAbortWithholdsTheUnreleased` |
| `shortCircuit := true` | `TestBreakpoint_StagedDispatchDoesNotShortCircuit` |
| `stage` ignores `N` | `TestBreakpoint_BeforeDispatchReleasesExactlyN` |
| drop the `AskHuman` requirement | `TestTeamDefTool_Run_BreakpointsRequireTheInterruptionMachinery` |
| drop the state/kind validation | `TestTeamDefTool_Run_BreakpointRefusals` |

The short-circuit one was **vacuous on the first attempt** — it passed against the break because the fake spawner ignored its context, so a cancelled run still returned success. Second commit fixes the fixture; it now reds deterministically across repeats (the select between the semaphore and a done context picks randomly when both are ready, so the assertion has to live on the spawn's result, not on which branch it took).

**Manual, against a throwaway instance on `:8911` over `/v1/_mcp`:**

```
breakpoints:["nope"]           → run: breakpoint "nope": team "triage" has no state "nope"
breakpoints:["done"]           → run: breakpoint "done": state "done" is a "terminal",
                                 and only a starter dispatches a wave to pause on
breakpoints:["wave:whenever"]  → run: breakpoint "wave:whenever": expected "<state>" or
                                 "<state>:before_dispatch"|"<state>:after_collection"
```

New tests: `TestBreakpoint_BeforeDispatchHoldsEveryRunUntilReleased`, `_BeforeDispatchReleasesExactlyN`, `_BeforeDispatchAbortSpawnsNothing`, `_PromptPreviewCarriesTheComposedMessage`, `_AfterCollectionWithholdsEverySinkMessage`, `_AfterCollectionReleasesExactlyN`, `_AfterCollectionAbortWithholdsTheUnreleased`, `_PhaseScopedArmingPausesOnlyThatPhase`, `_UnarmedStateTakesTheOriginalPath`, `_AskErrorAbortsTheWalk`, `_StagedDispatchDoesNotShortCircuit`, `TestParseBreakpoint`; `TestTeamDefTool_Run_BreakpointAsksAtBothPhasesAndReleases`, `_BreakpointAbortWithholdsTheSink`, `_BreakpointRefusals`, `_BreakpointsRequireTheInterruptionMachinery`, `_NoBreakpointsNeverAsks`, `TestParseBreakAnswer`, `TestFormatBreakpoint_TruncatesAnOversizedPreview`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD