### PR TITLE
fix(channel): an open ACL says so, instead of putting "*" in the allowlist

### DIFF
--- a/internal/api/grpc/substrate.go
+++ b/internal/api/grpc/substrate.go
@@ -70,9 +70,13 @@ func substrateGRPCCtx(ctx context.Context) context.Context {
 		AllowedScopes: []string{"agent", "user", "global"},
 		Consolidation: true,
 	})
+	// Channel: unrestricted, said with the discriminator rather than a "*" in
+	// the allowlist. The matcher supports an exact name and a trailing "/*"
+	// prefix only, so the old []string{"*"} matched NO channel and this plane
+	// silently held no channel authority at all.
 	ctx = tools.WithChannelPolicy(ctx, tools.ChannelPolicyValue{
-		Publish:   []string{"*"},
-		Subscribe: []string{"*"},
+		AllPublish:   true,
+		AllSubscribe: true,
 	})
 	ctx = tools.WithAgentDefPolicy(ctx, tools.AgentDefPolicyValue{
 		Scopes:   []string{"any"},

--- a/internal/api/grpc/substrate_channelacl_test.go
+++ b/internal/api/grpc/substrate_channelacl_test.go
@@ -1,0 +1,25 @@
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
+)
+
+// TestSubstrateGRPCCtx_ChannelPolicyActuallyGrants: this plane holds every
+// channel, so assert that it ALLOWS one rather than that its allowlist is
+// non-empty. The weaker shape is what let the defect live — the plane declared
+// Publish: []string{"*"} intending "everything", and the matcher (exact name or
+// a trailing "/*" prefix, nothing else) never matched a real channel.
+func TestSubstrateGRPCCtx_ChannelPolicyActuallyGrants(t *testing.T) {
+	cp := tools.ChannelPolicy(substrateGRPCCtx(context.Background()))
+	for _, side := range []string{"publish", "subscribe"} {
+		all, list := cp.GrantsFor(side)
+		if !all && !builtin.ChannelAllowed("any-channel-name", list) {
+			t.Errorf("the gRPC substrate plane grants no %s on an arbitrary channel (all=%v list=%v)",
+				side, all, list)
+		}
+	}
+}

--- a/internal/api/http/substrate_admin.go
+++ b/internal/api/http/substrate_admin.go
@@ -406,10 +406,13 @@ func substrateAdminCtx(ctx context.Context) context.Context {
 	ctx = tools.WithSqlMemPolicy(ctx, tools.SqlMemPolicyValue{
 		AllowedScopes: []string{"agent", "user", "tenant"},
 	})
-	// Channel: "*" wildcard matches every channel name.
+	// Channel: unrestricted, said with the discriminator rather than a "*" in
+	// the allowlist. The matcher supports an exact name and a trailing "/*"
+	// prefix only, so the old []string{"*"} matched NO channel and this plane
+	// silently held no channel authority at all.
 	ctx = tools.WithChannelPolicy(ctx, tools.ChannelPolicyValue{
-		Publish:   []string{"*"},
-		Subscribe: []string{"*"},
+		AllPublish:   true,
+		AllSubscribe: true,
 	})
 	// AgentDef + SkillDef: "any" scope (operator-blessed admin).
 	ctx = tools.WithAgentDefPolicy(ctx, tools.AgentDefPolicyValue{

--- a/internal/api/http/substrate_channelacl_test.go
+++ b/internal/api/http/substrate_channelacl_test.go
@@ -1,0 +1,24 @@
+package http
+
+import (
+	"context"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
+)
+
+// TestSubstrateAdminCtx_ChannelPolicyActuallyGrants: see the gRPC twin. This
+// plane holds every channel, so the assertion has to be that it ALLOWS one —
+// a non-empty allowlist proves nothing when the entry is a name that matches
+// no channel.
+func TestSubstrateAdminCtx_ChannelPolicyActuallyGrants(t *testing.T) {
+	cp := tools.ChannelPolicy(substrateAdminCtx(context.Background()))
+	for _, side := range []string{"publish", "subscribe"} {
+		all, list := cp.GrantsFor(side)
+		if !all && !builtin.ChannelAllowed("any-channel-name", list) {
+			t.Errorf("the HTTP substrate-admin plane grants no %s on an arbitrary channel (all=%v list=%v)",
+				side, all, list)
+		}
+	}
+}

--- a/internal/api/mcp/context.go
+++ b/internal/api/mcp/context.go
@@ -149,10 +149,13 @@ func grantOperatorPolicies(ctx context.Context, agentName string, isAdmin bool) 
 	ctx = tools.WithSqlMemPolicy(ctx, tools.SqlMemPolicyValue{
 		AllowedScopes: []string{"agent", "user", "tenant"},
 	})
-	// Channel: open ACL ("*" matches every channel name).
+	// Channel: unrestricted, said with the discriminator rather than a "*" in
+	// the allowlist. The matcher supports an exact name and a trailing "/*"
+	// prefix only, so the old []string{"*"} matched NO channel and this plane
+	// silently held no channel authority at all.
 	ctx = tools.WithChannelPolicy(ctx, tools.ChannelPolicyValue{
-		Publish:   []string{"*"},
-		Subscribe: []string{"*"},
+		AllPublish:   true,
+		AllSubscribe: true,
 	})
 
 	// Def families: "any" name within the stamped tenant (same for admin +

--- a/internal/api/mcp/context_test.go
+++ b/internal/api/mcp/context_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/skillmatch"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
+	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
 )
 
 // TestOperatorCtx_AttachesAllRequiredPolicies pins the load-bearing
@@ -53,13 +54,21 @@ func TestOperatorCtx_AttachesAllRequiredPolicies(t *testing.T) {
 		}
 	}
 
-	// ChannelPolicy: empty Publish/Subscribe ⇒ all channel ops fail.
+	// ChannelPolicy: this plane holds every channel, so assert that it ALLOWS
+	// one — not merely that the allowlist is non-empty.
+	//
+	// The weaker assertion is what let the bug live: the plane declared
+	// Publish: []string{"*"} intending "everything", the list was non-empty so
+	// this passed, and the matcher (exact name or a trailing "/*" prefix, and
+	// nothing else) never matched a real channel — so the plane silently held
+	// NO channel authority at all.
 	cp := tools.ChannelPolicy(ctx)
-	if len(cp.Publish) == 0 {
-		t.Errorf("ChannelPolicy.Publish empty; publish ops would fail")
-	}
-	if len(cp.Subscribe) == 0 {
-		t.Errorf("ChannelPolicy.Subscribe empty; subscribe/peek/ack would fail")
+	for _, side := range []string{"publish", "subscribe"} {
+		all, list := cp.GrantsFor(side)
+		if !all && !builtin.ChannelAllowed("any-channel-name", list) {
+			t.Errorf("ChannelPolicy grants no %s on an arbitrary channel (all=%v list=%v); %s ops would fail",
+				side, all, list, side)
+		}
 	}
 
 	// AgentDefPolicy: empty Scopes ⇒ every mutation op fails.

--- a/internal/tools/builtin/channel.go
+++ b/internal/tools/builtin/channel.go
@@ -210,14 +210,8 @@ func (c *Channel) resolveChannel(ctx context.Context, policy tools.ChannelPolicy
 	if !ok {
 		return tools.ChannelDef{}, "", "", fmt.Errorf("Channel tool: channel %q is not declared in operator config (channels: block)", name)
 	}
-	var allowed []string
-	switch side {
-	case "publish":
-		allowed = policy.Publish
-	case "subscribe":
-		allowed = policy.Subscribe
-	}
-	if !channelAllowed(name, allowed) {
+	all, allowed := policy.GrantsFor(side)
+	if !all && !channelAllowed(name, allowed) {
 		if len(allowed) == 0 {
 			return tools.ChannelDef{}, "", "", fmt.Errorf("Channel tool: this agent has no %s allowlist — add `channels.%s: [%s]` to the agent yaml", side, side, name)
 		}
@@ -1188,10 +1182,21 @@ func (c *Channel) execPeek(ctx context.Context, policy tools.ChannelPolicyValue,
 }
 
 func (c *Channel) execListChannels(policy tools.ChannelPolicyValue) (tools.Result, error) {
-	return okJSON(map[string]any{
+	out := map[string]any{
 		"publish":   policy.Publish,
 		"subscribe": policy.Subscribe,
-	})
+	}
+	// Reported only when set, so a per-agent policy's response shape is
+	// unchanged. An unrestricted plane would otherwise report two empty lists
+	// and read as "no access" — the same confusion the discriminator exists to
+	// end, one layer up.
+	if policy.AllPublish {
+		out["publish_unrestricted"] = true
+	}
+	if policy.AllSubscribe {
+		out["subscribe_unrestricted"] = true
+	}
+	return okJSON(out)
 }
 
 // truncateForEvent caps payload-preview strings at the configured

--- a/internal/tools/builtin/channel_openacl_test.go
+++ b/internal/tools/builtin/channel_openacl_test.go
@@ -1,0 +1,116 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// TestChannelAllowed_BareStarIsNotAWildcard pins the property that makes the
+// AllPublish/AllSubscribe discriminator necessary at all.
+//
+// The matcher supports an exact name and a trailing "/*" prefix, and nothing
+// else — so a bare "*" is a channel literally CALLED "*", matching no real
+// name. Three operator planes declared open access as []string{"*"} and
+// therefore silently held no channel authority. Anyone tempted to "just make
+// `*` work here" should read the comment on ChannelPolicyValue first: doing it
+// at the matcher would widen every operator-authored allowlist in the system
+// that today grants nothing.
+func TestChannelAllowed_BareStarIsNotAWildcard(t *testing.T) {
+	for _, name := range []string{"verdicts", "pr-events", "findings/alpha", "a"} {
+		if channelAllowed(name, []string{"*"}) {
+			t.Errorf("channelAllowed(%q, [\"*\"]) = true — the bare star became a wildcard; "+
+				"that silently widens every allowlist that contains one", name)
+		}
+	}
+	// The wildcard the matcher DOES support is unchanged.
+	if !channelAllowed("findings/alpha", []string{"findings/*"}) {
+		t.Error(`channelAllowed("findings/alpha", ["findings/*"]) = false — the prefix wildcard regressed`)
+	}
+	if channelAllowed("findings", []string{"findings/*"}) {
+		t.Error(`"findings/*" must not match "findings" itself`)
+	}
+}
+
+func TestChannelPolicy_GrantsFor(t *testing.T) {
+	p := tools.ChannelPolicyValue{Publish: []string{"a"}, Subscribe: []string{"b"}}
+	if all, list := p.GrantsFor("publish"); all || len(list) != 1 || list[0] != "a" {
+		t.Errorf("GrantsFor(publish) = %v %v", all, list)
+	}
+	if all, list := p.GrantsFor("subscribe"); all || len(list) != 1 || list[0] != "b" {
+		t.Errorf("GrantsFor(subscribe) = %v %v", all, list)
+	}
+	// An unknown side grants nothing — the closed default. A typo'd side must
+	// not fall through to "unrestricted".
+	if all, list := p.GrantsFor("peek"); all || list != nil {
+		t.Errorf("GrantsFor(unknown) = %v %v, want false nil", all, list)
+	}
+	open := tools.ChannelPolicyValue{AllPublish: true, AllSubscribe: true}
+	for _, side := range []string{"publish", "subscribe"} {
+		if all, _ := open.GrantsFor(side); !all {
+			t.Errorf("GrantsFor(%s) on an unrestricted policy = false", side)
+		}
+	}
+}
+
+// TestChannel_UnrestrictedPolicyReachesADeclaredChannel: the discriminator is
+// honoured at the agent's own publish/subscribe gate, and the closed-set check
+// (is the channel declared at all?) still runs ahead of it — unrestricted means
+// "every declared channel", never "any string".
+func TestChannel_UnrestrictedPolicyReachesADeclaredChannel(t *testing.T) {
+	c := &Channel{}
+	declared := map[string]tools.ChannelDef{"verdicts": {Name: "verdicts", Scope: "user"}}
+	ctx := tools.WithRunIdentity(context.Background(), tools.RunIdentityValue{UserID: "u1", AgentID: "a1"})
+
+	open := tools.ChannelPolicyValue{AllPublish: true, AllSubscribe: true, Channels: declared}
+	for _, side := range []string{"publish", "subscribe"} {
+		if _, _, _, err := c.resolveChannel(ctx, open, side, "verdicts"); err != nil {
+			t.Errorf("unrestricted policy refused %s on a declared channel: %v", side, err)
+		}
+	}
+	// Still closed over the operator's declared set.
+	if _, _, _, err := c.resolveChannel(ctx, open, "publish", "never-declared"); err == nil {
+		t.Error("unrestricted policy reached an UNDECLARED channel — it lifts the allowlist, not the closed set")
+	}
+	// And the old spelling grants nothing, which is the bug this replaces.
+	star := tools.ChannelPolicyValue{Publish: []string{"*"}, Subscribe: []string{"*"}, Channels: declared}
+	if _, _, _, err := c.resolveChannel(ctx, star, "publish", "verdicts"); err == nil {
+		t.Error(`Publish: ["*"] granted publish — a bare star must stay a literal name, not a wildcard`)
+	}
+}
+
+// TestTeamChannelAuthority_UnrestrictedAuthorMayDeclareAnACL is the gap that
+// blocked the Starter: a team ACL may only NARROW what its author holds, and an
+// author holding everything was computed as holding nothing — so no plane but
+// an in-band agent run could author a runnable Starter team.
+func TestTeamChannelAuthority_UnrestrictedAuthorMayDeclareAnACL(t *testing.T) {
+	tool, _, cleanup := teamDefFixture(t)
+	defer cleanup()
+	ctx := tools.WithChannelPolicy(
+		tools.WithRunIdentity(context.Background(), tools.RunIdentityValue{AgentID: "a_operator"}),
+		tools.ChannelPolicyValue{AllPublish: true, AllSubscribe: true})
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"triage","overlay":`+
+		strings.TrimSuffix(starterGraph, "}")+`,"channels":{"publish":["verdicts"],"subscribe":["pr-events"]}}}`))
+	if res.IsError {
+		t.Fatalf("an unrestricted author could not declare a team ACL: %s", res.Text)
+	}
+
+	// The narrowing rule itself is untouched for a normal, listed author.
+	narrow := tools.WithChannelPolicy(
+		tools.WithRunIdentity(context.Background(), tools.RunIdentityValue{AgentID: "a_agent"}),
+		tools.ChannelPolicyValue{Publish: []string{"verdicts"}, Subscribe: []string{"pr-events"}})
+	res, _ = tool.Execute(narrow, json.RawMessage(`{"op":"create","name":"ok-narrow","overlay":`+
+		strings.TrimSuffix(starterGraph, "}")+`,"channels":{"publish":["verdicts"],"subscribe":["pr-events"]}}}`))
+	if res.IsError {
+		t.Fatalf("a listed author was refused its own grants: %s", res.Text)
+	}
+	res, _ = tool.Execute(narrow, json.RawMessage(`{"op":"create","name":"widen","overlay":`+
+		strings.TrimSuffix(starterGraph, "}")+`,"channels":{"publish":["secrets"],"subscribe":["pr-events"]}}}`))
+	if !res.IsError || !strings.Contains(res.Text, "never widen") {
+		t.Fatalf("a team ACL widened past its author's grants: IsError=%v %s", res.IsError, res.Text)
+	}
+}

--- a/internal/tools/builtin/channel_openacl_test.go
+++ b/internal/tools/builtin/channel_openacl_test.go
@@ -71,9 +71,14 @@ func TestChannel_UnrestrictedPolicyReachesADeclaredChannel(t *testing.T) {
 			t.Errorf("unrestricted policy refused %s on a declared channel: %v", side, err)
 		}
 	}
-	// Still closed over the operator's declared set.
-	if _, _, _, err := c.resolveChannel(ctx, open, "publish", "never-declared"); err == nil {
-		t.Error("unrestricted policy reached an UNDECLARED channel — it lifts the allowlist, not the closed set")
+	// Still closed over the operator's declared set, and refused BY THAT CHECK —
+	// asserting the reason, not merely that something errored. An undeclared
+	// channel falling through to a later guard (an empty scope, say) would also
+	// produce an error while the closed set had in fact been lifted.
+	_, _, _, err := c.resolveChannel(ctx, open, "publish", "never-declared")
+	if err == nil || !strings.Contains(err.Error(), "not declared in operator config") {
+		t.Errorf("unrestricted policy reached an UNDECLARED channel — it lifts the allowlist, "+
+			"not the closed set; err = %v", err)
 	}
 	// And the old spelling grants nothing, which is the bug this replaces.
 	star := tools.ChannelPolicyValue{Publish: []string{"*"}, Subscribe: []string{"*"}, Channels: declared}

--- a/internal/tools/builtin/teamdef.go
+++ b/internal/tools/builtin/teamdef.go
@@ -920,15 +920,18 @@ func checkTeamChannelAuthority(ctx context.Context, def teamgraph.Definition) er
 	}
 	pol := tools.ChannelPolicy(ctx)
 	for _, side := range []struct {
-		name    string
-		want    []string
-		granted []string
+		name string
+		want []string
 	}{
-		{"publish", def.Channels.Publish, pol.Publish},
-		{"subscribe", def.Channels.Subscribe, pol.Subscribe},
+		{"publish", def.Channels.Publish},
+		{"subscribe", def.Channels.Subscribe},
 	} {
+		all, granted := pol.GrantsFor(side.name)
+		if all {
+			continue // the plane holds every channel; there is nothing to narrow from
+		}
 		for _, ch := range side.want {
-			if !channelAllowed(ch, side.granted) {
+			if !channelAllowed(ch, granted) {
 				return fmt.Errorf("channels.%s: %q is not in the authoring principal's own %s allowlist — "+
 					"a team ACL may only narrow what its author holds, never widen it", side.name, ch, side.name)
 			}

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -725,10 +725,42 @@ type ctxKeyChannelPolicy struct{}
 //
 // Empty Publish / Subscribe means "no channel access on that side"
 // — the tool returns a typed refusal with the allowlist enumerated.
+//
+// A NAME IS NOT A PATTERN. The matcher supports an exact name and a trailing
+// "/*" prefix, and nothing else — a bare "*" in an allowlist is just a channel
+// literally called "*", so it matches no real channel at all. An unrestricted
+// plane therefore says so with AllPublish / AllSubscribe rather than with a
+// string, because a string that LOOKS like a wildcard and grants nothing is a
+// capability that silently disappears.
 type ChannelPolicyValue struct {
 	Publish   []string
 	Subscribe []string
 	Channels  map[string]ChannelDef
+
+	// AllPublish / AllSubscribe lift the allowlist entirely for that side.
+	//
+	// Set ONLY by the operator/admin planes that genuinely hold every channel —
+	// the per-tenant MCP session, the gRPC substrate surface, the HTTP
+	// substrate-admin surface. It is an explicit discriminator rather than a
+	// sentinel value in the list precisely so a future reader cannot mistake
+	// one for the other, and so no operator-authored yaml can ever produce it:
+	// the field has no config path.
+	AllPublish   bool
+	AllSubscribe bool
+}
+
+// GrantsFor returns one side's allowlist and whether that side is unrestricted.
+// Callers ask the policy rather than reaching for the field, so the "or the
+// plane holds everything" half can never be forgotten at one of the sites.
+// An unknown side grants nothing — the closed default.
+func (p ChannelPolicyValue) GrantsFor(side string) (all bool, allowlist []string) {
+	switch side {
+	case "publish":
+		return p.AllPublish, p.Publish
+	case "subscribe":
+		return p.AllSubscribe, p.Subscribe
+	}
+	return false, nil
 }
 
 // ChannelDef mirrors config.Channel for the tool layer. Lives here


### PR DESCRIPTION
## Why

Three def-authoring planes declared unrestricted channel access as

```go
tools.ChannelPolicyValue{Publish: []string{"*"}, Subscribe: []string{"*"}}
```

the MCP one carrying the comment *"open ACL (`*` matches every channel name)"*. `channelAllowed` supports an exact name and a trailing `/*` prefix and **nothing else**, so a bare `*` is a channel literally *called* `*`:

```
channelAllowed("verdicts",       ["*"]) = false
channelAllowed("pr-events",      ["*"]) = false
channelAllowed("findings/alpha", ["*"]) = false
```

So the per-tenant MCP session (`internal/api/mcp/context.go`), the gRPC substrate surface (`internal/api/grpc/substrate.go`) and the HTTP substrate-admin surface (`internal/api/http/substrate_admin.go`) all held **no channel authority at all**, while reporting an allowlist that looked maximally permissive.

**The visible consequence**, reproduced against a live instance: a team's `channels` block may only *narrow* what its author holds, and an author holding everything computed as holding nothing — so `checkTeamChannelAuthority` refused every entry, and a definition *without* that block has its Starter refuse its own source at run time. **No Starter team was both authorable and runnable over any transport but an in-band agent run** — which is every transport a canvas or an operator actually uses. Found while verifying #1197.

## What

**The fix is not at the matcher.** Teaching `channelAllowed` that a bare `*` means everything would silently widen every operator-authored allowlist in the system that contains one — a trust boundary moving on upgrade with no operator asking for it.

Instead `ChannelPolicyValue` gains explicit `AllPublish` / `AllSubscribe`, set only by those three planes and reachable from **no config path**, plus a `GrantsFor(side)` accessor the two decision sites ask — so the "or the plane holds everything" half cannot be forgotten at one of them. Operator yaml semantics are untouched: a `*` an operator wrote is still a literal name and still matches nothing.

Unrestricted lifts the **allowlist**, never the **closed set**: an undeclared channel is still refused, because the operator's `channels:` block is what says a channel exists.

`Channel op=list_channels` reports `publish_unrestricted` / `subscribe_unrestricted` only when set, so a per-agent policy's response shape is unchanged.

### Why the existing test didn't catch it

`TestOperatorCtx_AttachesAllRequiredPolicies` asserted `len(cp.Publish) != 0` — the *consequence* of a grant, not the grant. A non-empty list of names that match nothing passes it. It now asserts the policy **allows an arbitrary channel**, and reds against the old declaration. The gRPC and HTTP planes get the same assertion, which they had none of.

## Also found, NOT fixed here

The same three planes set **no `Channels` catalog** on the policy (only `internal/api/http/server.go:2112` does, via `mergedChannelDefs`). So even with the allowlist fixed, the in-band `Channel` tool on those planes refuses every name at the earlier closed-set check — verified live:

```
channel op=publish channel=pr-events
→ Channel tool: channel "pr-events" is not declared in operator config (channels: block)
```

(while `pr-events` *is* declared in the yaml, and the admin `publish_channel` meta-tool — a different, connector path — writes to it fine).

I did not fold that in: wiring the catalog into those three planes crosses three packages and has its own design question (does an MCP plane see runtime channel defs, and under which tenant?). It does **not** block the Starter — its channel I/O goes through `teamChannelIO`, not the agent policy — which is why the end-to-end below gets all the way through a wave. Worth its own issue/PR.

## Tested

`go build ./...`, `go vet ./...`, `gofmt -l` clean, **`go test ./...` green (110 packages)**.

**Fail-before, six claims, each red against its own deliberate break:**

| break | test that reds |
|---|---|
| `resolveChannel` ignores the discriminator | `TestChannel_UnrestrictedPolicyReachesADeclaredChannel` |
| `checkTeamChannelAuthority` ignores it | `TestTeamChannelAuthority_UnrestrictedAuthorMayDeclareAnACL` |
| unrestricted also lifts the closed set | `TestChannel_UnrestrictedPolicyReachesADeclaredChannel` |
| `channelAllowed` learns the bare `*` | `TestChannelAllowed_BareStarIsNotAWildcard` |
| gRPC plane back to `["*"]` | `TestSubstrateGRPCCtx_ChannelPolicyActuallyGrants` |
| HTTP plane back to `["*"]` | `TestSubstrateAdminCtx_ChannelPolicyActuallyGrants` |

The MCP plane's own revert reds the strengthened `TestOperatorCtx_AttachesAllRequiredPolicies` (`grants no publish on an arbitrary channel (all=false list=[*])`).

The closed-set assertion was **vacuous on the first attempt** — it required only *some* error, and the perturbation let the name through to a later guard that refused it for an unrelated reason (an empty scope). Second commit pins the refusal by its reason.

**Manual, throwaway instance on `:8912` over `/v1/_mcp`** — before this change, step 1 was impossible:

1. author a Starter team **with** a `channels` ACL → **created**
2. publish 3 messages to the source, run the team → the Starter **read 3, fanned out a wave of 3**, and the sink carried exactly one message per run:

```
wave=wav_77484a13… size=3 index=0 agent=reviewer status=error
wave=wav_77484a13… size=3 index=1 agent=reviewer status=error
wave=wav_77484a13… size=3 index=2 agent=reviewer status=error
```

one `wave` id, correct `wave_size`, every index present, the failure carried as content — the count-is-the-contract rule holding on the guaranteed path. (The `error` is the throwaway config's mock provider not resolving a model; the wave mechanics are what this verifies.)

3. an undeclared channel is still refused.

New tests: `TestChannelAllowed_BareStarIsNotAWildcard` (pins that the star stays a literal, so nobody "fixes" this at the matcher later), `TestChannelPolicy_GrantsFor` (incl. the closed default for an unknown side), `TestChannel_UnrestrictedPolicyReachesADeclaredChannel`, `TestTeamChannelAuthority_UnrestrictedAuthorMayDeclareAnACL` (narrowing rule for a listed author unchanged in both directions), `TestSubstrateGRPCCtx_ChannelPolicyActuallyGrants`, `TestSubstrateAdminCtx_ChannelPolicyActuallyGrants`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD