### PR TITLE
feat(document): bound documents_summary, and measure the pathological directory

### DIFF
--- a/adapters/ts/src/types.ts
+++ b/adapters/ts/src/types.ts
@@ -1644,6 +1644,10 @@ export type DocumentToolInput = {
   under_path?: string;
   /** query_chunks: raw read-only SELECT (escape hatch; validator-gated). */
   sql?: string;
+  /** Row/response bound. On `documents_summary` it defaults to 500 (max 5000) and
+   *  the response reports `truncated: true` when it clips — an `under_path` over a
+   *  subject-homed fact store is as wide as the tenant's entity count, so page the
+   *  directory with `path op=ls` and pass each page's ids as `document_ids`. */
   limit?: number;
   /** define/list_types: the type name. */
   name?: string;

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -85,7 +85,7 @@ const documentInputSchema = `{
 		"path":        {"type": "string", "description": "create_document: name the doc in the Path tree (default /documents/<title> if omitted). set_path: the path to attach to an existing document (by id). get/delete_document: address by path instead of id."},
 		"title":       {"type": "string"},
 		"document_id": {"type": "string"},
-		"document_ids": {"type": "array", "items": {"type": "string"}, "description": "documents_summary: the document ids to summarize (combine with or instead of under_path)."},
+		"document_ids": {"type": "array", "items": {"type": "string"}, "description": "documents_summary: the document ids to summarize (combine with or instead of under_path). The response is bounded (default 500, max 5000) and reports truncated:true when it clips — an under_path over a subject-homed fact store is as large as the tenant's entity count, so page the directory with path op=ls and pass each page's ids here."},
 		"parent":      {"type": "string", "description": "propose_entity: the IN-FORCE entity type this one is a kind of, BY NAME (omit for a new top-level type). Use a name from the entity types listed in your instructions."},
 		"parent_id":   {"type": "string", "description": "create_chunk: parent chunk (omit for a child of the root)."},
 		"new_parent_id": {"type": "string", "description": "move_chunk: the new parent."},
@@ -1787,6 +1787,33 @@ func (d *Document) documentsSummary(ctx context.Context, key sqlmem.ScopeKey, ms
 	if len(uniq) == 0 {
 		return jsonResult(map[string]any{"documents": []any{}})
 	}
+	// BOUND THE RESPONSE (RFC CV OQ2). under_path resolves to EVERY document under
+	// a subtree, and subject-homed facts make `/facts` exactly as large as the
+	// tenant's entity count — so this built a ten-thousand-element IN list and
+	// returned ten thousand rows. Postgres serves that; an agent's context window
+	// does not, which is the same reason `path op=ls` is paged.
+	//
+	// The bound is a DEFAULT rather than a refusal, which is a deliberate deviation
+	// from "requires under_path or a limit": refusing an unbounded call would break
+	// the explorer, which legitimately passes a page of ids it already holds, and
+	// buys nothing — the response is bounded either way. Truncation is REPORTED, so
+	// it is a bound rather than a lie.
+	//
+	// No cursor, and that is not an omission. A caller pages the DIRECTORY through
+	// `path op=ls`, which has one, and asks for metadata a page at a time; a second
+	// cursor here would let it page metadata for a set it never enumerated.
+	limit := in.Limit
+	if limit <= 0 {
+		limit = lsDefaultLimit
+	}
+	if limit > lsMaxLimit {
+		limit = lsMaxLimit
+	}
+	truncated := false
+	if len(uniq) > limit {
+		uniq = uniq[:limit]
+		truncated = true
+	}
 	// Batch: the documents rows.
 	ph, args := inPlaceholders(uniq)
 	dres, err := d.query(ctx, key, `SELECT id, title, root_chunk_id FROM documents WHERE id IN (`+ph+`)`, args...)
@@ -1844,7 +1871,15 @@ func (d *Document) documentsSummary(ctx context.Context, key sqlmem.ScopeKey, ms
 		}
 		out = append(out, entry)
 	}
-	return jsonResult(map[string]any{"documents": out})
+	// truncated is emitted only when it fired: a caller that never hit the bound
+	// should not have to reason about a field that is always false.
+	res := map[string]any{"documents": out}
+	if truncated {
+		res["truncated"] = true
+		res["note"] = "more documents matched than were returned; narrow under_path, " +
+			"or page the directory with `path op=ls` and pass each page's ids as document_ids"
+	}
+	return jsonResult(res)
 }
 
 func (d *Document) deleteDocument(ctx context.Context, key sqlmem.ScopeKey, mscope store.MemoryScope, in docInput) (tools.Result, error) {

--- a/internal/tools/builtin/document_summary_bound_test.go
+++ b/internal/tools/builtin/document_summary_bound_test.go
@@ -1,0 +1,105 @@
+package builtin
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+// documents_summary must bound its response (RFC CV OQ2).
+//
+// under_path resolves to EVERY document under a subtree, and subject-homed facts
+// make /facts exactly as large as the tenant's entity count — so an unbounded call
+// built a ten-thousand-element IN list and returned ten thousand rows. Postgres
+// serves that; an agent's context window does not, which is the same reason
+// `path op=ls` is paged.
+
+// TestDocumentsSummary_BoundsAnUnboundedSubtree.
+func TestDocumentsSummary_BoundsAnUnboundedSubtree(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	const n = 12
+	for i := 0; i < n; i++ {
+		if _, r := docExec(t, d, ctx, fmt.Sprintf(
+			`{"op":"create_document","scope":"user","title":"subject-%02d","path":"/facts/subject-%02d"}`, i, i)); r.IsError {
+			t.Fatalf("create_document %d: %s", i, r.Text)
+		}
+	}
+
+	// Unbounded by default? No — but the default is far above this fixture, so the
+	// bound is exercised with an explicit small limit AND the default is checked to
+	// return everything, which is what says the default did not silently clip.
+	out, r := docExec(t, d, ctx, `{"op":"documents_summary","scope":"user","under_path":"/facts"}`)
+	if r.IsError {
+		t.Fatalf("documents_summary: %s", r.Text)
+	}
+	var all struct {
+		Documents []json.RawMessage `json:"documents"`
+		Truncated bool              `json:"truncated"`
+	}
+	_ = json.Unmarshal([]byte(r.Text), &all)
+	if len(all.Documents) != n {
+		t.Errorf("default returned %d of %d documents — the default bound must be well above "+
+			"an ordinary subtree, or it clips silently; out=%v", len(all.Documents), n, out)
+	}
+	if all.Truncated {
+		t.Errorf("a subtree inside the default bound reported truncated — the flag must mean " +
+			"something was actually clipped")
+	}
+
+	// Now the bound itself.
+	_, r = docExec(t, d, ctx, `{"op":"documents_summary","scope":"user","under_path":"/facts","limit":5}`)
+	if r.IsError {
+		t.Fatalf("documents_summary limited: %s", r.Text)
+	}
+	var clipped struct {
+		Documents []json.RawMessage `json:"documents"`
+		Truncated bool              `json:"truncated"`
+		Note      string            `json:"note"`
+	}
+	_ = json.Unmarshal([]byte(r.Text), &clipped)
+	if len(clipped.Documents) != 5 {
+		t.Errorf("limit=5 returned %d documents", len(clipped.Documents))
+	}
+	// REPORTED, not silent. A bound a caller cannot detect is indistinguishable
+	// from a store that holds less than it does.
+	if !clipped.Truncated {
+		t.Error("the response was clipped without saying so — that is a lie, not a bound")
+	}
+	if clipped.Note == "" {
+		t.Error("truncation carries no note saying how to get the rest")
+	}
+}
+
+// TestDocumentsSummary_ExplicitIdsAreStillHonoured: the explorer passes a page of
+// ids it already holds, and bounding must not break that path — which is why the
+// bound is a default rather than a refusal to answer an unbounded call.
+func TestDocumentsSummary_ExplicitIdsAreStillHonoured(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	var ids []string
+	for i := 0; i < 3; i++ {
+		out, r := docExec(t, d, ctx, fmt.Sprintf(
+			`{"op":"create_document","scope":"user","title":"d-%d","path":"/docs/d-%d"}`, i, i))
+		if r.IsError {
+			t.Fatalf("create_document: %s", r.Text)
+		}
+		ids = append(ids, asStr(out["document_id"]))
+	}
+	body, _ := json.Marshal(map[string]any{
+		"op": "documents_summary", "scope": "user", "document_ids": ids,
+	})
+	_, r := docExec(t, d, ctx, string(body))
+	if r.IsError {
+		t.Fatalf("documents_summary by ids: %s", r.Text)
+	}
+	var got struct {
+		Documents []json.RawMessage `json:"documents"`
+		Truncated bool              `json:"truncated"`
+	}
+	_ = json.Unmarshal([]byte(r.Text), &got)
+	if len(got.Documents) != len(ids) {
+		t.Errorf("asked for %d ids, got %d — bounding must not clip a caller's own page", len(ids), len(got.Documents))
+	}
+	if got.Truncated {
+		t.Error("a caller's own page reported truncated")
+	}
+}

--- a/internal/tools/builtin/pathtool_load_test.go
+++ b/internal/tools/builtin/pathtool_load_test.go
@@ -1,0 +1,98 @@
+package builtin
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// The PATHOLOGICAL directory (RFC CV OQ2).
+//
+// The cardinality question was answered from the schema: per-subject reads scale,
+// because chunks_doc_parent_pos makes a dossier read an index lookup whose cost is
+// independent of how many subjects exist. What was never measured is the one case
+// the schema does not answer — a SINGLE directory with ten thousand children,
+// which is exactly what `/facts` becomes on a ten-thousand-entity tenant once
+// facts are subject-homed.
+//
+// The risk was never the row count. Postgres serves ten thousand dirents; the
+// RESPONSE and the agent's context window do not. So what this measures is that
+// the listing stays bounded at that width, and that a caller can still walk the
+// whole directory — a bound that made the directory un-enumerable would have
+// broken the entity directory that subject-homing exists to provide, which is
+// precisely why a hard cap with a truncation flag was rejected in favour of a
+// cursor.
+func TestPathLs_TenThousandChildrenStayBoundedAndWalkable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("seeds 10k dirents; skipped under -short")
+	}
+	p, ctx, _ := pathFixture(t)
+
+	const n = 10000
+	seeded := time.Now()
+	for i := 0; i < n; i++ {
+		seedAgent(t, p.Store, "/facts/", fmt.Sprintf("subj-%05d", i), "document")
+	}
+	t.Logf("seeded %d dirents in one directory in %s", n, time.Since(seeded).Round(time.Millisecond))
+
+	// 1. A DEFAULT listing is bounded. This is the assertion the whole OQ is about:
+	//    without it the response carries ten thousand entries.
+	start := time.Now()
+	out, r := pathExec(t, p, ctx, `{"op":"ls","scope":"agent","path":"/facts"}`)
+	if r.IsError {
+		t.Fatalf("ls: %s", r.Text)
+	}
+	first, truncated, next := lsNames(t, out)
+	t.Logf("first page: %d entries in %s", len(first), time.Since(start).Round(time.Millisecond))
+	if len(first) > lsDefaultLimit {
+		t.Errorf("a default listing returned %d entries on a %d-child directory — the response "+
+			"is unbounded, which is what the agent's context window cannot take", len(first), n)
+	}
+	if !truncated || next == "" {
+		t.Fatalf("a %d-child directory did not report truncation (truncated=%v next=%q) — a "+
+			"silent bound is indistinguishable from a directory that holds less than it does",
+			n, truncated, next)
+	}
+
+	// 2. The whole directory is still WALKABLE, and every child appears exactly
+	//    once. A cursor that skipped or repeated entries would make the entity
+	//    directory unusable in a way no single page could reveal.
+	seen := make(map[string]int, n)
+	for _, name := range first {
+		seen[name]++
+	}
+	pages, cursor := 1, next
+	walk := time.Now()
+	for cursor != "" {
+		if pages > n/10+10 {
+			t.Fatalf("walk did not terminate after %d pages — a cursor that does not advance "+
+				"turns a bounded listing into an infinite one", pages)
+		}
+		out, r := pathExec(t, p, ctx, fmt.Sprintf(
+			`{"op":"ls","scope":"agent","path":"/facts","cursor":%q}`, cursor))
+		if r.IsError {
+			t.Fatalf("ls page %d: %s", pages+1, r.Text)
+		}
+		names, _, nxt := lsNames(t, out)
+		if len(names) == 0 && nxt != "" {
+			t.Fatalf("page %d returned nothing but offered another cursor", pages+1)
+		}
+		for _, name := range names {
+			seen[name]++
+		}
+		cursor = nxt
+		pages++
+	}
+	t.Logf("walked %d pages in %s", pages, time.Since(walk).Round(time.Millisecond))
+
+	if len(seen) != n {
+		t.Errorf("the walk saw %d distinct children, want %d — a cursor that skips entries "+
+			"hides facts that are really there", len(seen), n)
+	}
+	for name, count := range seen {
+		if count != 1 {
+			t.Errorf("%s appeared %d times — a repeating cursor inflates the directory", name, count)
+			break
+		}
+	}
+}


### PR DESCRIPTION
**RFC CV OQ2**, the part that was still outstanding — and the gate on P3.

OQ2's decision was already made: *"`path op=ls` gains a `limit` plus an opaque cursor, and `documents_summary` requires `under_path` or a limit."* The `ls` half is already on `main`, with a cursor and a full test suite. These are the two things that were not.

## documents_summary was unbounded

`under_path` resolves to **every** document under a subtree, and subject-homed facts make `/facts` exactly as wide as the tenant's entity count — so it built a ten-thousand-element `IN` list and returned ten thousand rows. Postgres serves that; an agent's context window does not, which is the same reason `ls` is paged.

It now takes a `limit` (default 500, max 5000), **reusing `ls`'s constants** rather than inventing a second pair, and reports `truncated` plus how to get the rest.

Two deliberate deviations, both stated in the code:

- **A default, not a refusal.** The RFC says "requires `under_path` or a limit". Refusing an unbounded call would break the explorer, which legitimately passes a page of ids it already holds, and buys nothing — the response is bounded either way.
- **No cursor.** A caller pages the *directory* through `ls`, which has one, and asks for metadata a page at a time. A second cursor here would let it page metadata for a set it never enumerated.

## The case the schema could not answer, measured

The cardinality question was settled from the indexes — a dossier read is an index lookup whose cost is independent of how many subjects exist. What was never measured is a **single directory with ten thousand children**, which is exactly what `/facts` becomes once facts are subject-homed. Synthetic dirents, not a 10k-document corpus, per the RFC:

```
seeded 10000 dirents in one directory   270ms
first page: 500 entries                  18ms
full walk: 20 pages                     328ms, every child exactly once
```

**Both halves matter and the test asserts both.** A listing that stayed unbounded is the defect; a bound that made the directory **un-enumerable** would have broken the entity directory subject-homing exists to provide — which is precisely why a hard cap with a truncation flag was rejected in favour of a cursor. The walk also pins that no child is skipped or repeated, which no single page could reveal.

Verified non-vacuous: with an unbounded default the first page returns 5000 and the test says so.

## Adapter lockstep

Already satisfied for `ls` — `PathToolInput` carries `limit`/`cursor` with the right docs. `DocumentToolInput` already had `limit`; only its doc comment needed the `documents_summary` note.

`go test ./...` clean.

## OQ2 is now closed

With this in, both directory surfaces are bounded and the pathological width is measured rather than reasoned about — which was the stated gate on **P3** (`/facts/<subject>` re-homing, root chunk = entity node).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8