### PR TITLE
feat(teamdef): refuse an unrunnable team at create, and sweep for rot at verify

### DIFF
--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -924,6 +924,24 @@ func (s *Server) SetTeamDefTool(t tools.Tool) {
 				return nil
 			}
 		}
+		if td.ChannelCatalog == nil {
+			// The same merged set the per-agent channel policy is built from, so
+			// "declared" means one thing everywhere. Read through the server
+			// rather than the ctx policy, which makes the preflight behave
+			// identically on every transport — including the def-authoring
+			// planes that carry no channel catalog on the policy at all.
+			td.ChannelCatalog = func(ctx context.Context) map[string]tools.ChannelDef {
+				return s.mergedChannelDefs(ctx, true)
+			}
+		}
+		if td.AgentExists == nil {
+			// The same lookup op=run resolves a member through, so verify cannot
+			// call a team runnable that run would refuse.
+			td.AgentExists = func(ctx context.Context, name string) bool {
+				_, ok := s.lookupAgent(ctx, tenantFromCtx(ctx), name)
+				return ok
+			}
+		}
 		if td.MaxWave == 0 {
 			// The same ceiling the external fan-out surface uses. One number for
 			// "how many runs may one call start", so an operator who tunes it

--- a/internal/teamgraph/refs.go
+++ b/internal/teamgraph/refs.go
@@ -1,0 +1,120 @@
+package teamgraph
+
+// refs.go — what a definition NAMES but does not contain.
+//
+// A team graph is self-contained except for two kinds of reference: the
+// channels it reads and writes, and the agents it runs. Both are resolved
+// elsewhere and both can rot — a channel is deleted from the operator's
+// config, an agent is retired — leaving a definition that validates perfectly
+// and fails at the first state that needs it.
+//
+// Enumerating them HERE, once, is the point. The preflight at create, the
+// sweep at verify and anything that comes later all walk the same list, so a
+// new channel-bearing or agent-bearing field cannot be checked in one place
+// and forgotten in another. Adding such a field to Handler without adding it
+// here is the bug this file exists to make loud: TestChannelRefs_CoversEvery
+// ChannelBearingField pins it.
+
+// ChannelSide is which half of an ACL a reference needs. The values match the
+// `channels:` yaml keys so a refusal can name the exact line to add.
+type ChannelSide string
+
+const (
+	SidePublish   ChannelSide = "publish"
+	SideSubscribe ChannelSide = "subscribe"
+)
+
+// ChannelRef is one channel a definition names, and why.
+type ChannelRef struct {
+	// Channel is the name as written.
+	Channel string
+	// Side is the grant this use requires.
+	Side ChannelSide
+	// State is the node that names it, and Field which of its fields — both
+	// carried so a refusal points at the line the author wrote rather than at
+	// the graph in general.
+	State string
+	Field string
+}
+
+// ChannelRefs returns every channel the definition names, in state order, with
+// duplicates kept: the same channel used as a source in one state and a sink in
+// another needs BOTH grants, and collapsing them would hide one.
+func ChannelRefs(d Definition) []ChannelRef {
+	var out []ChannelRef
+	for _, s := range d.States {
+		h := s.Handler
+		if h.Source != nil && h.Source.Channel != "" {
+			out = append(out, ChannelRef{h.Source.Channel, SideSubscribe, s.ID, "source"})
+		}
+		if h.Sink != nil && h.Sink.Channel != "" {
+			out = append(out, ChannelRef{h.Sink.Channel, SidePublish, s.ID, "sink"})
+		}
+		if h.Channel != "" {
+			out = append(out, ChannelRef{h.Channel, SidePublish, s.ID, "channel"})
+		}
+	}
+	return out
+}
+
+// AgentRef is one agent name a definition runs, and the field that names it.
+type AgentRef struct {
+	Agent string
+	State string
+	Field string
+}
+
+// AgentRefs returns every agent name the definition runs, in state order.
+//
+// Duplicates are kept for the same reason ChannelRefs keeps them: a report that
+// collapsed them could not say WHICH node is broken, which is the only thing
+// the reader can act on.
+func AgentRefs(d Definition) []AgentRef {
+	var out []AgentRef
+	for _, s := range d.States {
+		h := s.Handler
+		if h.Agent != "" {
+			out = append(out, AgentRef{h.Agent, s.ID, "agent"})
+		}
+		for _, a := range h.Agents {
+			if a != "" {
+				out = append(out, AgentRef{a, s.ID, "agents"})
+			}
+		}
+		if h.Consolidator != "" {
+			out = append(out, AgentRef{h.Consolidator, s.ID, "consolidator"})
+		}
+		if h.Fanout != nil {
+			if h.Fanout.Agent != "" {
+				out = append(out, AgentRef{h.Fanout.Agent, s.ID, "fanout.agent"})
+			}
+			for _, a := range h.Fanout.Agents {
+				if a != "" {
+					out = append(out, AgentRef{a, s.ID, "fanout.agents"})
+				}
+			}
+		}
+	}
+	return out
+}
+
+// GrantList returns the team's own allowlist for one side of a reference. A nil
+// Channels block yields nothing — which is correct and is the case that bites:
+// a definition with a Starter and no `channels` block parses, validates, and
+// then refuses its own source the first time it runs.
+//
+// It returns the LIST rather than a verdict on purpose. Matching a name against
+// an allowlist is the runtime's rule, and there must be exactly one
+// implementation of it — a second one here could drift into a preflight that
+// accepts what the runtime refuses, which is worse than no preflight. teamgraph
+// is a leaf package and cannot import the matcher, so it hands the caller the
+// list and the caller applies the one true matcher.
+func (d Definition) GrantList(side ChannelSide) []string {
+	if d.Channels == nil {
+		return nil
+	}
+	if side == SideSubscribe {
+		return d.Channels.Subscribe
+	}
+	return d.Channels.Publish
+}

--- a/internal/teamgraph/refs_test.go
+++ b/internal/teamgraph/refs_test.go
@@ -1,0 +1,165 @@
+package teamgraph
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestChannelRefs_CoversEveryChannelBearingField is the guard on the whole
+// preflight: every check downstream walks ChannelRefs, so a channel-bearing
+// field added to Handler without a line in ChannelRefs silently stops being
+// checked — the definition would validate, save, and fail at run time, which
+// is the exact failure this phase exists to remove.
+//
+// It reads Handler's own FIELDS rather than a hand-written list, so adding one
+// reds this test instead of quietly widening the hole.
+func TestChannelRefs_CoversEveryChannelBearingField(t *testing.T) {
+	// The fields of Handler (and its nested starter structs) that name a
+	// channel. Derived from the struct, so a new one appears here on its own.
+	var bearing []string
+	ht := reflect.TypeOf(Handler{})
+	for i := 0; i < ht.NumField(); i++ {
+		f := ht.Field(i)
+		switch f.Type.Kind() {
+		case reflect.String:
+			if strings.Contains(strings.ToLower(f.Name), "channel") {
+				bearing = append(bearing, f.Name)
+			}
+		case reflect.Ptr:
+			// A starter sub-struct carrying a Channel field is a channel site.
+			st := f.Type.Elem()
+			if st.Kind() != reflect.Struct {
+				continue
+			}
+			if _, ok := st.FieldByName("Channel"); ok {
+				bearing = append(bearing, f.Name)
+			}
+		}
+	}
+	if len(bearing) == 0 {
+		t.Fatal("found no channel-bearing fields on Handler — the derivation broke, not the code")
+	}
+
+	// One state per bearing field, each naming a distinct channel, so a missed
+	// field shows up as a missing name rather than as a count that happens to
+	// match.
+	def := Definition{Entry: "s0", States: []State{
+		{ID: "src", Handler: Handler{Kind: HandlerStarter,
+			Source: &StarterSource{Channel: "ch-source"},
+			Sink:   &StarterSink{Channel: "ch-sink"}}},
+		{ID: "pub", Handler: Handler{Kind: HandlerChannel, Channel: "ch-channel"}},
+	}}
+	got := map[string]bool{}
+	for _, r := range ChannelRefs(def) {
+		got[r.Channel] = true
+	}
+	for name, want := range map[string]string{
+		"Source": "ch-source", "Sink": "ch-sink", "Channel": "ch-channel",
+	} {
+		if !got[want] {
+			t.Errorf("Handler.%s names a channel that ChannelRefs does not report (%q) — "+
+				"add it to ChannelRefs or the preflight silently stops checking it", name, want)
+		}
+	}
+	for _, f := range bearing {
+		if _, covered := map[string]bool{"Source": true, "Sink": true, "Channel": true}[f]; !covered {
+			t.Errorf("Handler.%s is a NEW channel-bearing field with no case in ChannelRefs "+
+				"(and no coverage in this test) — every channel a definition names must be enumerated", f)
+		}
+	}
+}
+
+// TestChannelRefs_CarriesSideStateAndField: a refusal is only actionable if it
+// says which node, which field, and which grant.
+func TestChannelRefs_CarriesSideStateAndField(t *testing.T) {
+	def := Definition{States: []State{
+		{ID: "wave", Handler: Handler{Kind: HandlerStarter,
+			Source: &StarterSource{Channel: "in"}, Sink: &StarterSink{Channel: "out"}}},
+		{ID: "notify", Handler: Handler{Kind: HandlerChannel, Channel: "out"}},
+	}}
+	want := []ChannelRef{
+		{"in", SideSubscribe, "wave", "source"},
+		{"out", SidePublish, "wave", "sink"},
+		{"out", SidePublish, "notify", "channel"},
+	}
+	got := ChannelRefs(def)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ChannelRefs =\n  %+v\nwant\n  %+v", got, want)
+	}
+}
+
+// TestChannelRefs_KeepsDuplicates: one channel used as a source in one state
+// and a sink in another needs BOTH grants; collapsing by name would hide one.
+func TestChannelRefs_KeepsDuplicates(t *testing.T) {
+	def := Definition{States: []State{
+		{ID: "a", Handler: Handler{Kind: HandlerStarter, Source: &StarterSource{Channel: "loop"}}},
+		{ID: "b", Handler: Handler{Kind: HandlerChannel, Channel: "loop"}},
+	}}
+	refs := ChannelRefs(def)
+	if len(refs) != 2 || refs[0].Side == refs[1].Side {
+		t.Fatalf("both uses of one channel must survive with their own side: %+v", refs)
+	}
+}
+
+func TestAgentRefs_CoversEveryAgentBearingField(t *testing.T) {
+	def := Definition{States: []State{
+		{ID: "one", Handler: Handler{Kind: HandlerAgent, Agent: "a1", Consolidator: "c1"}},
+		{ID: "par", Handler: Handler{Kind: HandlerParallel, Agents: []string{"a2", "a3"}}},
+		{ID: "wave", Handler: Handler{Kind: HandlerStarter,
+			Fanout: &StarterFanout{Agent: "a4", Agents: []string{"a5"}}}},
+	}}
+	got := map[string]string{}
+	for _, r := range AgentRefs(def) {
+		got[r.Agent] = r.Field
+	}
+	for agent, field := range map[string]string{
+		"a1": "agent", "c1": "consolidator", "a2": "agents", "a3": "agents",
+		"a4": "fanout.agent", "a5": "fanout.agents",
+	} {
+		if got[agent] != field {
+			t.Errorf("AgentRefs missed %q (want field %q, got %q)", agent, field, got[agent])
+		}
+	}
+}
+
+// TestGrantList_NilChannelsGrantsNothing pins the case that strands workflows:
+// a definition with a Starter and NO channels block parses, validates, and then
+// refuses its own source the first time it runs.
+func TestGrantList_NilChannelsGrantsNothing(t *testing.T) {
+	var def Definition
+	if got := def.GrantList(SidePublish); got != nil {
+		t.Errorf("GrantList on a nil Channels block = %v, want nil", got)
+	}
+	if got := def.GrantList(SideSubscribe); got != nil {
+		t.Errorf("GrantList on a nil Channels block = %v, want nil", got)
+	}
+	def.Channels = &TeamChannels{Publish: []string{"p"}, Subscribe: []string{"s"}}
+	if got := def.GrantList(SidePublish); len(got) != 1 || got[0] != "p" {
+		t.Errorf("GrantList(publish) = %v", got)
+	}
+	if got := def.GrantList(SideSubscribe); len(got) != 1 || got[0] != "s" {
+		t.Errorf("GrantList(subscribe) = %v", got)
+	}
+}
+
+// TestChannelRefs_SurvivesJSONRoundTrip: the sweep reads a STORED definition,
+// so the refs must come out of parsed JSON, not only out of a Go literal.
+func TestChannelRefs_SurvivesJSONRoundTrip(t *testing.T) {
+	raw := `{"entry":"wave","states":[
+	  {"state":"wave","handler":{"kind":"starter","source":{"channel":"in"},
+	    "fanout":{"agent":"r","per":"message","max":2},"sink":{"channel":"out"}}},
+	  {"state":"done","handler":{"kind":"terminal"}}],
+	  "transitions":[{"from":"wave","to":"done","on":"success"}]}`
+	var def Definition
+	if err := json.Unmarshal([]byte(raw), &def); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := len(ChannelRefs(def)); got != 2 {
+		t.Errorf("ChannelRefs over parsed JSON = %d refs, want 2", got)
+	}
+	if got := len(AgentRefs(def)); got != 1 {
+		t.Errorf("AgentRefs over parsed JSON = %d refs, want 1", got)
+	}
+}

--- a/internal/tools/builtin/teamdef.go
+++ b/internal/tools/builtin/teamdef.go
@@ -96,6 +96,23 @@ type TeamDef struct {
 	// unavailable (board_chunk_id is then refused). Wired by SetTeamDefTool.
 	Board teamBoard
 
+	// ChannelCatalog, if set, reads the operator's DECLARED channel set so
+	// create/fork can refuse a definition naming a channel that does not exist,
+	// and verify can report one deleted after the def was written.
+	//
+	// It reads the config + runtime channel rows directly rather than the ctx
+	// channel POLICY, deliberately: the policy is the caller's grant, and the
+	// question here is whether the channel exists at all. Reading the grant
+	// would make the preflight refuse different definitions on different
+	// transports. nil = the declared-set check is SKIPPED (never failed) — a
+	// tool with no catalog cannot tell "undeclared" from "I have no list".
+	ChannelCatalog func(ctx context.Context) map[string]tools.ChannelDef
+
+	// AgentExists, if set, reports whether an agent name resolves, so verify can
+	// report a member retired after the def was written. nil = the agent sweep
+	// is omitted from the report rather than reported as failing.
+	AgentExists func(ctx context.Context, name string) bool
+
 	// AskHuman, if set, escalates an iteration-cap overflow to a human instead of
 	// aborting: when the caller passes interrupt_on_cap, a capped state raises an
 	// Interruption `ask` (this closure blocks until answered/timed-out/cancelled)
@@ -126,7 +143,11 @@ const teamDefDescription = `Author, fork, promote, retire, and inspect team work
 	`(success to advance, pushback to loop back for rework) — output threads to the next state, until a ` +
 	`terminal state. run may OPTIONALLY bind to a Document chunk board (board_chunk_id) so progress persists ` +
 	`as chunk.status and resumes across runs, and may escalate an iteration cap to a human (interrupt_on_cap) ` +
-	`instead of aborting. run may also set breakpoints on starter states to step a fan-out wave: the walk pauses ` +
+	`instead of aborting. create and fork PREFLIGHT a definition's channel references — a channel the team's own ACL ` +
+	`does not grant, or one that is not declared at all, is refused with the exact block to add, rather than ` +
+	`failing later at the state that needed it. verify reports the content hash AND sweeps what the stored ` +
+	`definition references but does not contain (channels deleted, ACL gaps, members retired) as issues[] with ` +
+	`a runnable flag. run may also set breakpoints on starter states to step a fan-out wave: the walk pauses ` +
 	`before dispatching (showing each composed prompt) and/or after collecting (showing each result, before any of ` +
 	`it reaches the sink) and asks a human to release all, release n, or abort. retire soft-retires one version; delete ` +
 	`hard-removes a whole team by name (all versions + active pointer), scoped to your tenant. Operations: ` +
@@ -154,7 +175,7 @@ const teamDefInputSchema = `{
     "description":    {"type": "string", "description": "Free-text rationale for create/fork."},
     "promote":        {"type": "boolean", "description": "create defaults true, fork defaults false."},
     "retired":        {"type": "boolean", "description": "Required for retire — set true to retire, false to un-retire."},
-    "content_sha256": {"type": "string", "description": "Input for op=verify — the local content hash to compare against the active row."},
+    "content_sha256": {"type": "string", "description": "Input for op=verify — the local content hash to compare against the active row. verify also returns runnable + issues[]: what the stored definition references but does not contain (an undeclared channel, a team-ACL gap, a retired member). Optional — verify reports the sweep with or without it."},
     "format":         {"type": "string", "enum": ["mermaid","d2"], "description": "render_diagram output format (default mermaid; d2 is deferred)."},
     "highlight_state": {"type": "string", "description": "render_diagram: optionally mark this state (e.g. a chunk's current state) with a bold outline."},
     "input":          {"type": "string", "description": "run: the initial input handed to the entry state's agent (the task/prompt the team works on)."},
@@ -251,6 +272,12 @@ func (t *TeamDef) execCreate(ctx context.Context, in teamDefInput) (tools.Result
 		return errResult(fmt.Sprintf("create: %s", err)), nil
 	}
 	if err := checkTeamChannelAuthority(ctx, def); err != nil {
+		return errResult(fmt.Sprintf("create: %s", err)), nil
+	}
+	// Preflight AFTER the authority check: "you may not grant this" is a
+	// harder refusal than "this will not work", and reporting the softer one
+	// first would send the author to fix a def they are not allowed to write.
+	if err := t.preflightChannels(ctx, def); err != nil {
 		return errResult(fmt.Sprintf("create: %s", err)), nil
 	}
 	if err := t.checkSizeCaps(defJSON, in.Description); err != nil {
@@ -364,6 +391,9 @@ func (t *TeamDef) execFork(ctx context.Context, in teamDefInput) (tools.Result, 
 		return errResult(fmt.Sprintf("fork: %s", err)), nil
 	}
 	if err := checkTeamChannelAuthority(ctx, def); err != nil {
+		return errResult(fmt.Sprintf("fork: %s", err)), nil
+	}
+	if err := t.preflightChannels(ctx, def); err != nil {
 		return errResult(fmt.Sprintf("fork: %s", err)), nil
 	}
 	if err := t.checkSizeCaps(defJSON, in.Description); err != nil {
@@ -534,14 +564,83 @@ func (t *TeamDef) execVerify(ctx context.Context, in teamDefInput) (tools.Result
 		}
 		return errResult(fmt.Sprintf("verify: %s", err)), nil
 	}
-	return okJSON(map[string]any{
+	out := map[string]any{
 		"matches":        in.ContentSHA256 != "" && in.ContentSHA256 == row.ContentSHA256,
 		"current_sha256": row.ContentSHA256,
 		"current_def_id": row.DefID,
 		"version":        row.Version,
 		"name":           row.Name,
 		"deployed":       true,
-	})
+	}
+	// The hash answers "is this the def I wrote". It cannot answer "will it
+	// still run" — a matching def whose channel was deleted or whose member was
+	// retired is byte-identical and broken. So verify also sweeps what the def
+	// REFERENCES but does not contain.
+	//
+	// The sweep NEVER turns verify into an error: the op's contract is a report,
+	// and a caller comparing hashes across deployments must not start failing
+	// because the far side is missing a channel. Findings ride the response.
+	if def, perr := teamgraph.Parse(row.Definition); perr == nil {
+		issues := t.sweepReferences(ctx, def)
+		// `runnable` is reported either way — present-and-true is an answer,
+		// where an absent field would be indistinguishable from a sweep that
+		// did not run. `issues` appears only when there are some, so a healthy
+		// team's response stays the shape callers already parse.
+		out["runnable"] = len(issues) == 0
+		if len(issues) > 0 {
+			out["issues"] = issues
+		}
+	}
+	return okJSON(out)
+}
+
+// sweepReferences reports what a stored definition names that no longer
+// resolves. Each issue is a map so a canvas can render it and a human can read
+// it, and each carries the state that names the thing — the only part anyone
+// can act on.
+func (t *TeamDef) sweepReferences(ctx context.Context, def teamgraph.Definition) []map[string]any {
+	var issues []map[string]any
+	catalog := t.channelCatalog(ctx)
+	for _, ref := range teamgraph.ChannelRefs(def) {
+		// The team ACL is def-internal, so this is checkable on every plane and
+		// is the failure that actually strands workflows: a def promoted before
+		// the ACL existed still validates.
+		if !channelAllowed(ref.Channel, def.GrantList(ref.Side)) {
+			issues = append(issues, map[string]any{
+				"kind": "acl_missing", "state": ref.State, "field": ref.Field,
+				"channel": ref.Channel, "side": string(ref.Side),
+				"detail": fmt.Sprintf("the team's ACL does not grant %s on %q", ref.Side, ref.Channel),
+			})
+		}
+		// Skipped, not reported as broken, when no catalog is wired — the same
+		// reason the preflight skips it.
+		if catalog == nil {
+			continue
+		}
+		if _, ok := catalog[ref.Channel]; !ok {
+			issues = append(issues, map[string]any{
+				"kind": "channel_undeclared", "state": ref.State, "field": ref.Field,
+				"channel": ref.Channel,
+				"detail":  fmt.Sprintf("channel %q is no longer declared", ref.Channel),
+			})
+		}
+	}
+	if t.AgentExists != nil {
+		seen := map[string]bool{}
+		for _, ref := range teamgraph.AgentRefs(def) {
+			if seen[ref.Agent] || t.AgentExists(ctx, ref.Agent) {
+				seen[ref.Agent] = true
+				continue
+			}
+			seen[ref.Agent] = true
+			issues = append(issues, map[string]any{
+				"kind": "agent_missing", "state": ref.State, "field": ref.Field,
+				"agent":  ref.Agent,
+				"detail": fmt.Sprintf("agent %q does not resolve in this tenant", ref.Agent),
+			})
+		}
+	}
+	return issues
 }
 
 // execRenderDiagram generates a diagram for a team — by def_id (a specific

--- a/internal/tools/builtin/teamdef_channels_test.go
+++ b/internal/tools/builtin/teamdef_channels_test.go
@@ -116,8 +116,12 @@ func TestTeamDef_ForkCannotWidenTheChannelACL(t *testing.T) {
 	tool, _, cleanup := teamDefFixture(t)
 	defer cleanup()
 	broad := authoringCtx([]string{"verdicts"}, []string{"pr-events"})
+	// The parent declares BOTH sides. It used to declare only subscribe, which
+	// the create-time preflight now refuses — the graph's sink had no publish
+	// grant, so the team could never have run. The widening rule this test is
+	// about is unchanged; the fixture just stopped being an unrunnable def.
 	createTeam(t, tool, broad, "triage",
-		strings.TrimSuffix(starterGraph, "}")+`,"channels":{"subscribe":["pr-events"]}}`)
+		strings.TrimSuffix(starterGraph, "}")+`,"channels":{"publish":["verdicts"],"subscribe":["pr-events"]}}`)
 
 	res, _ := tool.Execute(broad, json.RawMessage(
 		`{"op":"fork","name":"triage","overlay":{"channels":{"subscribe":["pr-events","secrets"]}}}`))

--- a/internal/tools/builtin/teamdef_preflight.go
+++ b/internal/tools/builtin/teamdef_preflight.go
@@ -1,0 +1,134 @@
+package builtin
+
+// teamdef_preflight.go — catch at CREATE what would otherwise fail at RUN.
+//
+// A team graph can be perfectly valid and still be unrunnable, because the two
+// things it references live outside it: the channels it reads and writes, and
+// the agents it runs. Both failures used to surface the same way — you author a
+// workflow, it saves, you run it, and a state deep in the graph says it cannot
+// reach its own source. By then the def is promoted and something may already
+// have consumed it.
+//
+// The refusals here are written to be ACTED ON, not merely understood: each one
+// carries the exact yaml or overlay line to add. A preflight that says "channel
+// not declared" and leaves the author to work out the fix has moved the
+// discovery earlier without making it cheaper.
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/teamgraph"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// preflightChannels refuses a definition whose channel references cannot work.
+//
+// Two independent checks, because they fail for different reasons and have
+// different fixes:
+//
+//  1. THE TEAM ACL — does the definition grant itself the side it uses? This is
+//     purely internal to the def, so it always runs. It is the check that would
+//     have caught the commonest shape of broken workflow: a Starter with no
+//     `channels` block at all.
+//  2. THE OPERATOR'S DECLARED SET — does the channel exist? This needs the
+//     catalog, and when none is wired the check is SKIPPED rather than failed.
+//     A tool that cannot see the declarations cannot tell "undeclared" from "I
+//     have no list", and refusing on the second would break every create on a
+//     plane that simply never wired a catalog.
+func (t *TeamDef) preflightChannels(ctx context.Context, def teamgraph.Definition) error {
+	refs := teamgraph.ChannelRefs(def)
+	if len(refs) == 0 {
+		return nil
+	}
+
+	// The ACL check, against the ONE runtime matcher — never a second copy of
+	// its rules. A preflight that accepted what the runtime refuses would be
+	// worse than none: it would certify a def that cannot run.
+	for _, ref := range refs {
+		if channelAllowed(ref.Channel, def.GrantList(ref.Side)) {
+			continue
+		}
+		return fmt.Errorf("state %q uses channel %q as its %s, but the team's own ACL does not grant %s on it — "+
+			"a Starter resolves its channels under the TEAM's authority, so add it to the definition:\n%s",
+			ref.State, ref.Channel, ref.Field, ref.Side, aclFixFor(def, refs))
+	}
+
+	catalog := t.channelCatalog(ctx)
+	if catalog == nil {
+		return nil
+	}
+	for _, ref := range refs {
+		if _, ok := catalog[ref.Channel]; !ok {
+			return fmt.Errorf("state %q names channel %q, which is not declared — "+
+				"declare it in the operator config:\n%s\nor at runtime with "+
+				"`ChannelDef op=create name=%s overlay={\"scope\":\"user\"}`",
+				ref.State, ref.Channel, channelYAMLFor(ref.Channel), ref.Channel)
+		}
+	}
+	return nil
+}
+
+// channelCatalog reads the declared channel set, or nil when none is wired.
+func (t *TeamDef) channelCatalog(ctx context.Context) map[string]tools.ChannelDef {
+	if t.ChannelCatalog == nil {
+		return nil
+	}
+	return t.ChannelCatalog(ctx)
+}
+
+// aclFixFor renders the `channels` block this definition needs — the WHOLE
+// block, not just the missing line.
+//
+// The whole block, because an author who is missing one grant is usually
+// missing the block, and a fragment they have to splice is a second chance to
+// get it wrong. It is sorted so the same graph always produces the same text.
+func aclFixFor(def teamgraph.Definition, refs []teamgraph.ChannelRef) string {
+	pub, sub := map[string]bool{}, map[string]bool{}
+	for _, ref := range refs {
+		if ref.Side == teamgraph.SideSubscribe {
+			sub[ref.Channel] = true
+			continue
+		}
+		pub[ref.Channel] = true
+	}
+	var b strings.Builder
+	b.WriteString("  \"channels\": {")
+	first := true
+	for _, side := range []struct {
+		key string
+		set map[string]bool
+	}{{"publish", pub}, {"subscribe", sub}} {
+		if len(side.set) == 0 {
+			continue
+		}
+		if !first {
+			b.WriteString(",")
+		}
+		first = false
+		fmt.Fprintf(&b, "\n    %q: [%s]", side.key, quotedList(side.set))
+	}
+	b.WriteString("\n  }")
+	return b.String()
+}
+
+// channelYAMLFor renders the operator-config stanza for a missing channel.
+//
+// scope=user is the suggestion because it is the one a workflow almost always
+// wants — per-end-user isolation — and because suggesting `global` would hand
+// an author a cross-tenant channel they did not ask for. The comment says the
+// alternatives rather than the value silently deciding for them.
+func channelYAMLFor(name string) string {
+	return "  channels:\n    " + name + ":\n      scope: user   # agent | user | global"
+}
+
+func quotedList(set map[string]bool) string {
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, fmt.Sprintf("%q", k))
+	}
+	sort.Strings(out)
+	return strings.Join(out, ", ")
+}

--- a/internal/tools/builtin/teamdef_preflight_test.go
+++ b/internal/tools/builtin/teamdef_preflight_test.go
@@ -152,14 +152,22 @@ func TestTeamDefPreflight_RunsOnFork(t *testing.T) {
 func TestTeamDefPreflight_AuthorityRefusalWinsOverPreflight(t *testing.T) {
 	tool, _, cleanup := teamDefFixture(t)
 	defer cleanup()
-	narrow := authoringCtx(nil, []string{"pr-events"}) // holds no publish grant
+	// The def must fail BOTH checks, or the test cannot tell which ran first:
+	// its ACL claims a subscribe grant the author does not hold (authority), AND
+	// leaves the sink with no publish grant (preflight).
+	narrow := authoringCtx(nil, nil) // holds nothing
 
-	res, _ := tool.Execute(narrow, json.RawMessage(`{"op":"create","name":"triage","overlay":`+fullACL()+`}`))
+	res, _ := tool.Execute(narrow, json.RawMessage(
+		`{"op":"create","name":"triage","overlay":`+
+			strings.TrimSuffix(starterGraph, "}")+`,"channels":{"subscribe":["pr-events"]}}}`))
 	if !res.IsError {
 		t.Fatal("expected a refusal")
 	}
 	if !strings.Contains(res.Text, "never widen it") {
 		t.Errorf("the AUTHORITY refusal must come first, got:\n%s", res.Text)
+	}
+	if strings.Contains(res.Text, "does not grant publish") {
+		t.Errorf("the preflight refusal preempted the authority one:\n%s", res.Text)
 	}
 }
 

--- a/internal/tools/builtin/teamdef_preflight_test.go
+++ b/internal/tools/builtin/teamdef_preflight_test.go
@@ -1,0 +1,308 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/teamgraph"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// fullACL is the graph plus the ACL a runnable Starter needs.
+func fullACL() string {
+	return strings.TrimSuffix(starterGraph, "}") + `,"channels":{"publish":["verdicts"],"subscribe":["pr-events"]}}`
+}
+
+func declared(names ...string) func(context.Context) map[string]tools.ChannelDef {
+	m := map[string]tools.ChannelDef{}
+	for _, n := range names {
+		m[n] = tools.ChannelDef{Name: n, Scope: "user"}
+	}
+	return func(context.Context) map[string]tools.ChannelDef { return m }
+}
+
+// TestTeamDefPreflight_RefusesAStarterWithNoACL is the shape that actually
+// stranded a workflow: the def parses, validates, saves, promotes — and then
+// the first run says it cannot reach its own source. Now it never gets stored.
+func TestTeamDefPreflight_RefusesAStarterWithNoACL(t *testing.T) {
+	tool, _, cleanup := teamDefFixture(t)
+	defer cleanup()
+	ctx := authoringCtx([]string{"verdicts"}, []string{"pr-events"})
+
+	res, _ := tool.Execute(ctx, json.RawMessage(
+		`{"op":"create","name":"triage","overlay":`+starterGraph+`}`))
+	if !res.IsError {
+		t.Fatal("a Starter with no channels block was accepted — it could never have run")
+	}
+	// The refusal must be ACTIONABLE: which state, which field, and the exact
+	// block to paste. A preflight that only moves the discovery earlier without
+	// making the fix cheaper has done half a job.
+	for _, want := range []string{`state "wave"`, "source", `"channels"`, `"publish": ["verdicts"]`, `"subscribe": ["pr-events"]`} {
+		if !strings.Contains(res.Text, want) {
+			t.Errorf("refusal is missing %q:\n%s", want, res.Text)
+		}
+	}
+	// And nothing was stored — a refusal that persisted a broken def would be
+	// worse than no refusal, because the row would then be forkable.
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"list","name":"triage"}`))
+	versions, _ := decodeResult(t, res.Text)["versions"].([]any)
+	if len(versions) != 0 {
+		t.Errorf("a refused create left %d version(s) behind: %s", len(versions), res.Text)
+	}
+}
+
+// TestTeamDefPreflight_RefusesAHalfACL: the sink side is checked as
+// independently as the source side.
+func TestTeamDefPreflight_RefusesAHalfACL(t *testing.T) {
+	tool, _, cleanup := teamDefFixture(t)
+	defer cleanup()
+	ctx := authoringCtx([]string{"verdicts"}, []string{"pr-events"})
+
+	res, _ := tool.Execute(ctx, json.RawMessage(
+		`{"op":"create","name":"triage","overlay":`+
+			strings.TrimSuffix(starterGraph, "}")+`,"channels":{"subscribe":["pr-events"]}}}`))
+	if !res.IsError || !strings.Contains(res.Text, "does not grant publish") {
+		t.Fatalf("a sink with no publish grant was accepted: IsError=%v %s", res.IsError, res.Text)
+	}
+}
+
+// TestTeamDefPreflight_RefusesAnUndeclaredChannel — with a catalog wired, a
+// channel that does not exist is refused with the yaml to declare it.
+func TestTeamDefPreflight_RefusesAnUndeclaredChannel(t *testing.T) {
+	tool, _, cleanup := teamDefFixture(t)
+	defer cleanup()
+	tool.ChannelCatalog = declared("pr-events") // "verdicts" is missing
+	ctx := authoringCtx([]string{"verdicts"}, []string{"pr-events"})
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"triage","overlay":`+fullACL()+`}`))
+	if !res.IsError {
+		t.Fatal("a def naming an undeclared channel was accepted")
+	}
+	for _, want := range []string{`channel "verdicts"`, "not declared", "channels:", "scope: user", "ChannelDef op=create"} {
+		if !strings.Contains(res.Text, want) {
+			t.Errorf("refusal is missing %q:\n%s", want, res.Text)
+		}
+	}
+}
+
+// TestTeamDefPreflight_SkipsTheDeclaredCheckWithNoCatalog: a tool that cannot
+// see the declarations must not refuse — it cannot tell "undeclared" from "I
+// have no list", and refusing on the second breaks every create on a plane
+// that wired no catalog.
+func TestTeamDefPreflight_SkipsTheDeclaredCheckWithNoCatalog(t *testing.T) {
+	tool, _, cleanup := teamDefFixture(t)
+	defer cleanup()
+	tool.ChannelCatalog = nil
+	ctx := authoringCtx([]string{"verdicts"}, []string{"pr-events"})
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"triage","overlay":`+fullACL()+`}`))
+	if res.IsError {
+		t.Fatalf("no catalog wired must SKIP the declared-set check, not fail it: %s", res.Text)
+	}
+	// The ACL half still runs — it needs no catalog.
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"other","overlay":`+starterGraph+`}`))
+	if !res.IsError || !strings.Contains(res.Text, "does not grant") {
+		t.Errorf("the ACL check must run with no catalog: IsError=%v %s", res.IsError, res.Text)
+	}
+}
+
+// TestTeamDefPreflight_AcceptsAWellFormedDef — the preflight must not become a
+// reason a correct workflow cannot be written.
+func TestTeamDefPreflight_AcceptsAWellFormedDef(t *testing.T) {
+	tool, _, cleanup := teamDefFixture(t)
+	defer cleanup()
+	tool.ChannelCatalog = declared("pr-events", "verdicts")
+	ctx := authoringCtx([]string{"verdicts"}, []string{"pr-events"})
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"triage","overlay":`+fullACL()+`}`))
+	if res.IsError {
+		t.Fatalf("a correct def was refused: %s", res.Text)
+	}
+	// And a graph with no channels at all is untouched by any of this.
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"plain","overlay":`+linearBoardTeam+`}`))
+	if res.IsError {
+		t.Fatalf("a channel-free team was refused: %s", res.Text)
+	}
+}
+
+// TestTeamDefPreflight_RunsOnFork: a fork is an authoring act too, and an
+// overlay replaces `channels` wholesale — so a fork is exactly how a good def
+// becomes a broken one.
+func TestTeamDefPreflight_RunsOnFork(t *testing.T) {
+	tool, _, cleanup := teamDefFixture(t)
+	defer cleanup()
+	tool.ChannelCatalog = declared("pr-events", "verdicts")
+	ctx := authoringCtx([]string{"verdicts"}, []string{"pr-events"})
+	createTeam(t, tool, ctx, "triage", fullACL())
+
+	res, _ := tool.Execute(ctx, json.RawMessage(
+		`{"op":"fork","name":"triage","overlay":{"channels":{"subscribe":["pr-events"]}}}`))
+	if !res.IsError || !strings.Contains(res.Text, "does not grant publish") {
+		t.Fatalf("a fork that dropped the publish grant was accepted: IsError=%v %s", res.IsError, res.Text)
+	}
+}
+
+// TestTeamDefPreflight_AuthorityRefusalWinsOverPreflight pins the ordering:
+// "you may not grant this" is a harder refusal than "this will not work", and
+// reporting the softer one first would send the author to fix a def they are
+// not allowed to write at all.
+func TestTeamDefPreflight_AuthorityRefusalWinsOverPreflight(t *testing.T) {
+	tool, _, cleanup := teamDefFixture(t)
+	defer cleanup()
+	narrow := authoringCtx(nil, []string{"pr-events"}) // holds no publish grant
+
+	res, _ := tool.Execute(narrow, json.RawMessage(`{"op":"create","name":"triage","overlay":`+fullACL()+`}`))
+	if !res.IsError {
+		t.Fatal("expected a refusal")
+	}
+	if !strings.Contains(res.Text, "never widen it") {
+		t.Errorf("the AUTHORITY refusal must come first, got:\n%s", res.Text)
+	}
+}
+
+// ---- the verify sweep ----
+
+// storeBrokenTeam writes a definition straight to the store, bypassing create.
+// That is how a def written BEFORE the preflight existed reaches the sweep —
+// and it is the only population the sweep is really for.
+func storeBrokenTeam(t *testing.T, tool *TeamDef, ctx context.Context, name, defJSON string) {
+	t.Helper()
+	def, err := teamgraph.Parse([]byte(defJSON))
+	if err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	row, err := tool.Store.TeamDefCreate(ctx, store.TeamDefRow{
+		DefID: mintTeamDefID(), Name: name, Definition: json.RawMessage(defJSON),
+		ContentSHA256: teamgraph.Sign(name, def),
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := tool.Store.TeamDefSetActive(ctx, "", name, row.DefID, "a_test"); err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+}
+
+// TestTeamDefVerify_ReportsAChannelDeletedAfterTheDefWasWritten: the hash still
+// matches and the team is broken. That gap is the whole reason verify sweeps.
+func TestTeamDefVerify_ReportsAChannelDeletedAfterTheDefWasWritten(t *testing.T) {
+	tool, ctx, cleanup := teamDefFixture(t)
+	defer cleanup()
+	tool.ChannelCatalog = declared("pr-events", "verdicts")
+	actx := authoringCtx([]string{"verdicts"}, []string{"pr-events"})
+	created := createTeam(t, tool, actx, "triage", fullACL())
+	sha, _ := created["content_sha256"].(string)
+
+	// The operator deletes the channel.
+	tool.ChannelCatalog = declared("pr-events")
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"verify","name":"triage","content_sha256":"`+sha+`"}`))
+	if res.IsError {
+		t.Fatalf("the sweep must never turn verify into an error: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	if out["matches"] != true {
+		t.Errorf("matches = %v — the def is unchanged, so the hash must still match", out["matches"])
+	}
+	if out["runnable"] != false {
+		t.Errorf("runnable = %v, want false", out["runnable"])
+	}
+	issues, _ := out["issues"].([]any)
+	if len(issues) != 1 {
+		t.Fatalf("issues = %v, want one", out["issues"])
+	}
+	got, _ := issues[0].(map[string]any)
+	if got["kind"] != "channel_undeclared" || got["channel"] != "verdicts" || got["state"] != "wave" {
+		t.Errorf("issue = %v, want channel_undeclared on state wave / channel verdicts", got)
+	}
+}
+
+// TestTeamDefVerify_ReportsAnACLGap covers the def written before the preflight
+// existed — the population that is already stored and cannot be fixed by
+// refusing new writes.
+func TestTeamDefVerify_ReportsAnACLGap(t *testing.T) {
+	tool, ctx, cleanup := teamDefFixture(t)
+	defer cleanup()
+	tool.ChannelCatalog = declared("pr-events", "verdicts")
+	storeBrokenTeam(t, tool, ctx, "legacy", starterGraph) // no channels block at all
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"verify","name":"legacy"}`))
+	if res.IsError {
+		t.Fatalf("verify: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	if out["runnable"] != false {
+		t.Fatalf("runnable = %v, want false", out["runnable"])
+	}
+	kinds := map[string]bool{}
+	for _, raw := range out["issues"].([]any) {
+		kinds[raw.(map[string]any)["kind"].(string)] = true
+	}
+	if !kinds["acl_missing"] {
+		t.Errorf("issues = %v, want an acl_missing", out["issues"])
+	}
+}
+
+// TestTeamDefVerify_ReportsARetiredMember: a def can also rot because a member
+// stopped resolving.
+func TestTeamDefVerify_ReportsARetiredMember(t *testing.T) {
+	tool, ctx, cleanup := teamDefFixture(t)
+	defer cleanup()
+	tool.ChannelCatalog = declared("pr-events", "verdicts")
+	tool.AgentExists = func(_ context.Context, name string) bool { return name != "reviewer" }
+	actx := authoringCtx([]string{"verdicts"}, []string{"pr-events"})
+	createTeam(t, tool, actx, "triage", fullACL())
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"verify","name":"triage"}`))
+	out := decodeResult(t, res.Text)
+	if out["runnable"] != false {
+		t.Fatalf("runnable = %v, want false; issues=%v", out["runnable"], out["issues"])
+	}
+	got := out["issues"].([]any)[0].(map[string]any)
+	if got["kind"] != "agent_missing" || got["agent"] != "reviewer" {
+		t.Errorf("issue = %v, want agent_missing for reviewer", got)
+	}
+}
+
+// TestTeamDefVerify_HealthyTeamKeepsTheOldShape: `issues` appears only when
+// there are some, so an existing caller parsing the response sees no change;
+// `runnable` is reported either way, because an absent field could not be told
+// apart from a sweep that did not run.
+func TestTeamDefVerify_HealthyTeamKeepsTheOldShape(t *testing.T) {
+	tool, ctx, cleanup := teamDefFixture(t)
+	defer cleanup()
+	tool.ChannelCatalog = declared("pr-events", "verdicts")
+	tool.AgentExists = func(context.Context, string) bool { return true }
+	actx := authoringCtx([]string{"verdicts"}, []string{"pr-events"})
+	created := createTeam(t, tool, actx, "triage", fullACL())
+	sha, _ := created["content_sha256"].(string)
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"verify","name":"triage","content_sha256":"`+sha+`"}`))
+	out := decodeResult(t, res.Text)
+	if _, present := out["issues"]; present {
+		t.Errorf("a healthy team reported issues: %v", out["issues"])
+	}
+	if out["runnable"] != true || out["matches"] != true || out["deployed"] != true {
+		t.Errorf("healthy verify = %v", out)
+	}
+}
+
+// TestTeamDefVerify_UndeployedTeamIsUnchanged: the not-found branch returns
+// before any sweep, so it keeps its exact shape.
+func TestTeamDefVerify_UndeployedTeamIsUnchanged(t *testing.T) {
+	tool, ctx, cleanup := teamDefFixture(t)
+	defer cleanup()
+	tool.ChannelCatalog = declared("pr-events")
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"verify","name":"nope"}`))
+	out := decodeResult(t, res.Text)
+	if out["deployed"] != false {
+		t.Fatalf("deployed = %v, want false", out["deployed"])
+	}
+	if _, present := out["runnable"]; present {
+		t.Errorf("an undeployed team must not claim a runnable verdict: %v", out)
+	}
+}


### PR DESCRIPTION
## Why

A team graph can be perfectly valid and still be unrunnable, because the two things it references live outside it: the **channels** it reads and writes, and the **agents** it runs. Both failed the same way — you author a workflow, it validates, it saves, it promotes, and then the first run says a state deep in the graph cannot reach its own source. By then the def is live and something may already have forked it.

I hit exactly this while verifying the Starter end to end in #1198: a definition with a `starter` and no `channels` block parses and validates, then refuses its own source at run time.

## What

### create and fork now preflight

Two independent checks, because they fail for different reasons and have different fixes:

1. **The team ACL** — does the definition grant itself the side it uses? Purely internal to the def, so it always runs, on every transport. This catches the commonest broken workflow.
2. **The operator's declared set** — does the channel exist at all? Needs a catalog; when none is wired the check is **skipped, never failed**. A tool that cannot see the declarations cannot tell "undeclared" from "I have no list", and refusing on the second would break every create on a plane that wired no catalog.

The refusals are written to be **acted on** — each names the state, the field and the side, and carries the exact block to paste:

```
create: state "wave" uses channel "pr-events" as its source, but the team's own ACL
does not grant subscribe on it — a Starter resolves its channels under the TEAM's
authority, so add it to the definition:
  "channels": {
    "publish": ["verdicts"],
    "subscribe": ["pr-events"]
  }
```
```
create: state "wave" names channel "nowhere", which is not declared — declare it in
the operator config:
  channels:
    nowhere:
      scope: user   # agent | user | global
or at runtime with `ChannelDef op=create name=nowhere overlay={"scope":"user"}`
```

The **whole** `channels` block, not just the missing line: an author missing one grant is usually missing the block, and a fragment to splice is a second chance to get it wrong.

**Ordering is deliberate — the authority check runs first.** "You may not grant this" is a harder refusal than "this will not work", and reporting the softer one first sends the author to fix a def they are not allowed to write.

### verify now sweeps

The content hash answers *"is this the def I wrote"*. It cannot answer *"will it still run"* — a def whose channel was deleted or whose member was retired is byte-identical and broken. `verify` now reports `runnable` plus an `issues[]` of what the **stored** definition references but no longer resolves (`channel_undeclared`, `acl_missing`, `agent_missing`), each carrying the state that names it. That covers the population refusing new writes cannot: the defs already stored.

**The sweep never turns verify into an error.** The op's contract is a report, and a caller comparing hashes across deployments must not start failing because the far side is missing a channel. `issues` appears only when there are some, so a healthy team's response keeps the shape callers parse; `runnable` is reported either way, because an absent field could not be told apart from a sweep that did not run.

### one enumeration, not several

`teamgraph.ChannelRefs` / `AgentRefs` list what a definition names; the preflight, the sweep and anything later all walk them — so a new channel-bearing field cannot be checked in one place and forgotten in another. `TestChannelRefs_CoversEveryChannelBearingField` **derives** the expected set from `Handler`'s own fields, so adding one reds the test instead of quietly widening the hole.

`teamgraph` hands out the ACL list and does **not** match against it. My first draft duplicated the matcher there; a second implementation could drift into a preflight that accepts what the runtime refuses — worse than no preflight. One matcher, in the tool layer; the leaf package returns the list for it to apply.

## Tested

`go build ./...`, `go vet ./...`, `gofmt -l` clean, **`go test ./...` green (110 packages)**.

**Fail-before, six claims, each red against its own deliberate break:**

| break | test that reds |
|---|---|
| add a new channel-bearing field to `Handler` | `TestChannelRefs_CoversEveryChannelBearingField` |
| drop the ACL half of the preflight | `TestTeamDefPreflight_RefusesAStarterWithNoACL` |
| a missing catalog fails instead of skipping | `TestTeamDefPreflight_SkipsTheDeclaredCheckWithNoCatalog` |
| run the preflight before the authority check | `TestTeamDefPreflight_AuthorityRefusalWinsOverPreflight` |
| drop the verify sweep | `TestTeamDefVerify_ReportsAChannelDeletedAfterTheDefWasWritten` |
| drop the sweep's ACL half | `TestTeamDefVerify_ReportsAnACLGap` |

The ordering one was **vacuous on the first attempt** — its fixture failed only the authority check, so the preflight passed either way and the test could not see the order. Second commit makes the def fail both.

**Manual, throwaway instance on `:8913` over `/v1/_mcp`.** Authored a team, then restarted with the `verdicts` channel deleted and the `reviewer` agent removed from the config — the stored def untouched:

```
matches  : True   <- the def is byte-identical
runnable : False
issue    : channel_undeclared  state=wave  channel "verdicts" is no longer declared
issue    : agent_missing       state=wave  agent "reviewer" does not resolve in this tenant
```

That is the gap the sweep exists for: the hash says "unchanged" and says nothing about whether it works.

**One existing fixture changed.** `TestTeamDef_ForkCannotWidenTheChannelACL` built its parent with a subscribe grant and no publish, which the preflight now refuses — the graph's sink had no grant, so that team could never have run. The widening rule it tests is unchanged; the fixture just stopped being an unrunnable def.

New tests: `TestChannelRefs_CoversEveryChannelBearingField`, `_CarriesSideStateAndField`, `_KeepsDuplicates`, `_SurvivesJSONRoundTrip`, `TestAgentRefs_CoversEveryAgentBearingField`, `TestGrantList_NilChannelsGrantsNothing`; `TestTeamDefPreflight_RefusesAStarterWithNoACL`, `_RefusesAHalfACL`, `_RefusesAnUndeclaredChannel`, `_SkipsTheDeclaredCheckWithNoCatalog`, `_AcceptsAWellFormedDef`, `_RunsOnFork`, `_AuthorityRefusalWinsOverPreflight`; `TestTeamDefVerify_ReportsAChannelDeletedAfterTheDefWasWritten`, `_ReportsAnACLGap`, `_ReportsARetiredMember`, `_HealthyTeamKeepsTheOldShape`, `_UndeployedTeamIsUnchanged`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD