### PR TITLE
feat(document): a document's root can be the entity itself

### DIFF
--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -107,7 +107,7 @@ const documentInputSchema = `{
 		"reason":       {"type": "string", "description": "judge_fact: one sentence on WHY, quoted back to the operator. A verdict nobody can act on is a verdict nobody trusts."},
 		"subject":      {"type": "string", "description": "upsert_chunk: the thing this entity assertion is ABOUT, paired with type — emit both or neither. type says what kind of thing it is, subject names it. A plain document chunk has no subject; passing the pair is what marks a write as an entity the ontology governs."},
 		"source_quote": {"type": "string", "description": "upsert_chunk: the EXACT text this fact was derived from, copied verbatim from the source you read — not a paraphrase. It is what a later pass checks the claim against, and what an operator sees when they ask why the store believes this. Omit only when there is no source text (material you are recording as evidence in its own right)."},
-		"natural_key": {"type": "string", "description": "upsert_chunk: the stable identity of this entity or fact. Upserting twice with the same key updates ONE chunk instead of adding a second — use a derived form such as person:ada-lovelace, or subject|predicate|object for a fact. Unique within the scope."},
+		"natural_key": {"type": "string", "description": "create_document: pair it with type+subject to make the new document's ROOT the entity node itself, so /facts/<subject> IS the subject and its facts are its children. upsert_chunk: the stable identity of this entity or fact. Upserting twice with the same key updates ONE chunk instead of adding a second — use a derived form such as person:ada-lovelace, or subject|predicate|object for a fact. Unique within the scope."},
 		"supersedes_id": {"type": "string", "description": "supersede_chunk: the id of the chunk being RETIRED by this one. The retired chunk is not deleted — it stays queryable so that questions about an earlier point in time still have an answer."},
 		"valid_at":   {"type": "integer", "description": "When the fact became true IN THE WORLD (unix nanos). Omit when unknown — an undated fact is honest and still matches an as_of question; a guessed instant is not. Distinct from when it was recorded."},
 		"from_pending": {"type": "string", "description": "upsert_chunk: the id of a pending item you drained, so this fact records what produced it. The server fills in the origin and the source ids from that row — you cannot set those yourself. Unknown or unowned ids are ignored and the write still succeeds."},
@@ -1494,6 +1494,25 @@ func (d *Document) createDocument(ctx context.Context, key sqlmem.ScopeKey, msco
 	}
 	if err := d.writeBody(ctx, mscope, key, rootID, "", "", nil); err != nil {
 		return errResult("create_document: root body: " + err.Error()), nil
+	}
+	// A DOCUMENT'S ROOT CAN BE THE ENTITY ITSELF (RFC CV decision 1). When the
+	// caller names the entity pair AND a natural key, the root chunk gets the
+	// sidecar that makes it an entity node — so the subject node and the document
+	// root are ONE object rather than a container holding a node that repeats it.
+	//
+	// That collapse is the whole point of subject-homing: `/facts/<subject>` is the
+	// subject, its facts are its children, and "what do we know about X" is one
+	// get_document rather than a search or a traversal. Two objects would mean two
+	// titles, two types and two places to correct either.
+	//
+	// Absent the pair this is a no-op, so every existing create_document is
+	// unchanged — an ordinary document's root is not an entity and must not
+	// acquire a sidecar row that the fact surfaces would then list.
+	if strings.TrimSpace(in.Subject) != "" && strings.TrimSpace(in.NaturalKey) != "" {
+		if err := d.writeChunkMeta(ctx, key, rootID, in); err != nil {
+			return errResult("create_document: the root was created but its entity metadata " +
+				"failed, so the document exists and is not the subject it claims to be: " + err.Error()), nil
+		}
 	}
 	// A document's tags are its own (independent of the root chunk's tags).
 	if len(in.Tags) > 0 {

--- a/internal/tools/builtin/document_root_entity_test.go
+++ b/internal/tools/builtin/document_root_entity_test.go
@@ -1,0 +1,108 @@
+package builtin
+
+import (
+	"testing"
+)
+
+// A document's ROOT can be the entity itself (RFC CV decision 1, the P3 primitive).
+//
+// Subject-homing collapses the subject node and the document root into ONE object:
+// `/facts/<subject>` IS the subject, and its facts are its children. Two objects
+// would mean two titles, two types, and two places to correct either — and "what
+// do we know about X" would go back to being a traversal rather than one read.
+
+// TestCreateDocument_RootBecomesTheEntityWhenNamed.
+func TestCreateDocument_RootBecomesTheEntityWhenNamed(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+
+	out, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Denn",
+		"path":"/facts/denn","type":"person","subject":"Denn","natural_key":"person:denn"}`)
+	if r.IsError {
+		t.Fatalf("create_document: %s", r.Text)
+	}
+	root := asStr(out["root_chunk_id"])
+	if root == "" {
+		t.Fatal("no root_chunk_id returned")
+	}
+
+	// The sidecar is what makes a chunk an entity — without it the root is an
+	// ordinary container and the fact surfaces cannot see it.
+	res, err := d.SqlMem.Query(ctx, sidecarScope(t, d, ctx),
+		d.SqlMem.Rebind(`SELECT coalesce(natural_key,''), coalesce(subject,''), coalesce(origin,'')
+		                   FROM chunk_memory_meta WHERE chunk_id = ?`), []any{root})
+	if err != nil {
+		t.Fatalf("sidecar read: %v", err)
+	}
+	if len(res.Rows) == 0 {
+		t.Fatal("the root carries no entity sidecar, so the document is a container and not the subject")
+	}
+	if got := asStr(res.Rows[0][0]); got != "person:denn" {
+		t.Errorf("root natural_key = %q, want person:denn", got)
+	}
+	if got := asStr(res.Rows[0][1]); got != "Denn" {
+		t.Errorf("root subject = %q, want Denn", got)
+	}
+	if asStr(res.Rows[0][2]) == "" {
+		t.Error("the root entity carries no origin — it is a write like any other and must say who made it")
+	}
+
+	// And it reads back as an entity through the ordinary surface.
+	got, r := docExec(t, d, ctx, `{"op":"get_chunk","scope":"user","id":"`+root+`"}`)
+	if r.IsError {
+		t.Fatalf("get_chunk: %s", r.Text)
+	}
+	ent, _ := got["entity"].(map[string]any)
+	if ent == nil {
+		t.Fatalf("get_chunk on the root returned no entity block: %v", got)
+	}
+	if ent["natural_key"] != "person:denn" {
+		t.Errorf("entity block natural_key = %v", ent["natural_key"])
+	}
+}
+
+// TestCreateDocument_AnOrdinaryRootIsNotAnEntity is the other half, and the one
+// that keeps every existing caller unchanged: a document created without the pair
+// must NOT acquire a sidecar, or every ordinary document's root would start
+// appearing in the fact surfaces.
+func TestCreateDocument_AnOrdinaryRootIsNotAnEntity(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+
+	out, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Notes","path":"/docs/notes"}`)
+	if r.IsError {
+		t.Fatalf("create_document: %s", r.Text)
+	}
+	res, err := d.SqlMem.Query(ctx, sidecarScope(t, d, ctx),
+		d.SqlMem.Rebind(`SELECT count(*) FROM chunk_memory_meta WHERE chunk_id = ?`),
+		[]any{asStr(out["root_chunk_id"])})
+	if err != nil {
+		t.Fatalf("sidecar count: %v", err)
+	}
+	if scanCount(res.Rows) != 0 {
+		t.Error("an ordinary document's root became an entity — every document would then " +
+			"list as a fact")
+	}
+}
+
+// TestCreateDocument_HalfThePairIsNotAnEntity. type+subject is what marks an
+// entity; a natural_key alone is what document SYNC uses to reconcile ordinary
+// chunks, so treating it as an entity marker would turn every synced document's
+// root into a subject.
+func TestCreateDocument_HalfThePairIsNotAnEntity(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+
+	out, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Synced",
+		"path":"/docs/synced","natural_key":"doc:synced"}`)
+	if r.IsError {
+		t.Fatalf("create_document: %s", r.Text)
+	}
+	res, err := d.SqlMem.Query(ctx, sidecarScope(t, d, ctx),
+		d.SqlMem.Rebind(`SELECT count(*) FROM chunk_memory_meta WHERE chunk_id = ?`),
+		[]any{asStr(out["root_chunk_id"])})
+	if err != nil {
+		t.Fatalf("sidecar count: %v", err)
+	}
+	if scanCount(res.Rows) != 0 {
+		t.Error("a natural_key alone made the root an entity — document sync keys ordinary " +
+			"chunks that way, so every synced document would become a subject")
+	}
+}


### PR DESCRIPTION
**RFC CV P3's enabling primitive** — the first half of decision 1: *"its root chunk IS the entity node — subject node and document root collapse into one object."*

Both of P3's gates are now met: **OQ2** closed in #1200 (directory surfaces bounded, the 10k-child case measured) and **OQ1** resolved (`natural_key` frozen as identity, path re-homed only by explicit operator `mv`).

## Why

`create_document` already applied `type` to the root chunk but wrote no entity sidecar, so a root could **contain** an entity but never **be** one.

Subject-homing needs the collapse. `/facts/<subject>` *is* the subject, its facts are its children, and "what do we know about X" becomes one `get_document` rather than a search or a traversal. Two objects would mean two titles, two types, and two places to correct either.

## What

When the caller names the entity **pair** *and* a natural key, the root chunk gets the sidecar that makes it an entity node.

- **Absent the pair it is a no-op**, which keeps every existing `create_document` unchanged — an ordinary document's root must not acquire a sidecar row that the fact surfaces would then list.
- **The pair is required, not just the key.** Document *sync* reconciles ordinary chunks **by** `natural_key`, so treating a lone key as an entity marker would turn every synced document's root into a subject.
- A failed sidecar write reports what it is — *"the document exists and is not the subject it claims to be"* — rather than as a create failure, because the document is real either way and an operator retrying blind would get a second one.

## What was tested

All three directions, which is what says the marker is the **pair** rather than any one field:

| | |
|---|---|
| named pair + key | root carries the sidecar **and** reads back through `get_chunk`'s entity block |
| ordinary document | root acquires no sidecar |
| `natural_key` alone | root acquires no sidecar |

Fail-before: *"the root carries no entity sidecar, so the document is a container and not the subject"*. `go test ./...` clean.

## What is still ahead in P3

This is the primitive, not the phase. Still to come, and each is its own change:

1. the consolidator writing to `/facts/<subject-slug>` per subject instead of one `/memory/entities` document
2. the **reader contract** — a relation-fact reachable from *every* subject it references, which is a test rather than a note
3. migrating the facts already homed in `/memory/entities`

Worth flagging on (2): decision 7 wants N subject references "from the first phase", but the extractor still emits a single `subject` — widening it is CW Probe 3, which is unstarted and currently gate-blocked. So the reader contract can be built and tested against a hand-made reference, but it will not have real multi-subject facts to carry until CW lands. I would rather say that now than have the inbound half look exercised when nothing produces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8