### PR TITLE
feat(memory): a subject is its own document, and its facts are its children

### DIFF
--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -679,6 +679,7 @@ agents:
           // Next pass will try again; within a pass, once is enough.
           judge_attempted: {},
           entity_failed: 0,         // entity writes that failed (k/v still landed)
+          subject_docs: {},        // scope+slug -> {doc, root} for /facts/<slug>
           fact_no_subject: 0,       // facts chunked with no subject node (extractor named none)
           type_absent: 0,           // subjects filed under the fallback because no type was given
           entity_type_refused: 0,   // typed facts whose type was a statement class
@@ -2476,6 +2477,59 @@ agents:
         return "";
       }
 
+      // subjectDoc resolves — creating on first sight — the DOCUMENT that IS a
+      // subject: `/facts/<subject-slug>`, whose root chunk is the entity node
+      //. Returns {doc, root}, or null when it cannot be had.
+      //
+      // WHY A DOCUMENT PER SUBJECT rather than one shared entity document: it makes
+      // "what do we know about X" a single get_document instead of a search or a
+      // traversal, and `path op=ls /facts` a real entity directory. The facts are
+      // the document's children, so the answer is a read of one tree.
+      //
+      // THE PATH CARRIES IDENTITY ONLY — `/facts/denn`, never `/facts/person/denn`
+      //. Type is MUTABLE: on one measured run the extractor proposed a
+      // different kind for an already-filed subject 91 times. With the type in the
+      // path every re-type would be a document MOVE, and the type would live in two
+      // places that can disagree. It stays a chunk field, where canonicalType
+      // already arbitrates it.
+      //
+      // The memo is keyed on the slug alone for the same reason: one subject is one
+      // document however its kind is spelled this pass.
+      function subjectDoc(st, scope, subjType, subjName) {
+        var slug8 = slug(normalizeSubject(subjName));
+        if (!slug8) { return null; }
+        var memo = scope + "\u0000" + slug8;
+        if (st.subject_docs[memo] !== undefined) { return st.subject_docs[memo]; }
+        var path = "/facts/" + slug8;
+        var out = null;
+        try {
+          var got = JSON.parse(Document({ op: "get_document", scope: scope, path: path }));
+          if (got && got.document_id && got.root_chunk_id) {
+            out = { doc: got.document_id, root: got.root_chunk_id };
+          }
+        } catch (e) { /* not there yet — created below */ }
+        if (!out) {
+          try {
+            var made = JSON.parse(Document({
+              op: "create_document", scope: scope, title: subjName, path: path,
+              // The pair PLUS the key is what makes the root the entity itself
+              // rather than a container holding one.
+              type: subjType, subject: subjName,
+              natural_key: entityKey(subjType, subjName)
+            }));
+            if (made && made.document_id && made.root_chunk_id) {
+              out = { doc: made.document_id, root: made.root_chunk_id };
+              st.entity_nodes++;
+            }
+          } catch (e2) {
+            st.entity_failed++;
+            if (!st.entity_error) { st.entity_error = errText(e2); }
+          }
+        }
+        st.subject_docs[memo] = out;
+        return out;
+      }
+
       // nonEmpty reports a USABLE string field — present, a string, and not merely
       // whitespace. The extractor omits a key, sends null, and sends "" for the same
       // "I do not know", so all three have to read the same way.
@@ -2538,6 +2592,11 @@ agents:
         var docID = entitiesDoc(st, scope);
         if (!docID) { return false; }
 
+        // homeDoc is the document the fact is filed in: its SUBJECT's, when it has
+        // one. A fact naming nobody keeps the shared entity document — it has no
+        // subject to be homed under, and inventing one is the thing mirrorEntity
+        // refuses to do.
+        var homeDoc = docID;
         var subjID = "";
         if (nonEmpty(fact.subject)) {
           // A statement class is not an entity type — "preference:user" reads as "the entity
@@ -2561,10 +2620,8 @@ agents:
           // subject is one node however many ways the extractor spells its kind.
           var subjType = canonicalType(st, scope, proposed, fact.subject);
           var subjKey = entityKey(subjType, fact.subject);
-          var isNewSubject = !st.entity_ids[scope + "\u0000" + subjKey];
-          subjID = upsertEntityChunk(st, scope, docID, subjKey, {
-            title: fact.subject, type: subjType, subject: fact.subject
-          });
+          var home = subjectDoc(st, scope, subjType, fact.subject);
+          if (home) { homeDoc = home.doc; subjID = home.root; }
           // UNDECLARED TYPE: the write was refused because the tenant does not declare this
           // kind. File the kind as an inert candidate an operator can accept, then retry under
           // the fallback — the key has to move with the type, since the type is part of a
@@ -2576,16 +2633,17 @@ agents:
             st.subject_types[scope + "\u0000" + slug(normalizeSubject(fact.subject))] = ENTITY_FALLBACK_TYPE;
             subjType = ENTITY_FALLBACK_TYPE;
             subjKey = entityKey(subjType, fact.subject);
-            isNewSubject = !st.entity_ids[scope + "\u0000" + subjKey];
-            subjID = upsertEntityChunk(st, scope, docID, subjKey, {
-              title: fact.subject, type: subjType, subject: fact.subject
-            });
+            // The identity PATH does not move — only the kind changes — so this
+            // retries the same /facts/<slug> document under a type the tenant
+            // declares. The memo is dropped so the retry is actually attempted.
+            delete st.subject_docs[scope + "\u0000" + slug(normalizeSubject(fact.subject))];
+            var retry = subjectDoc(st, scope, subjType, fact.subject);
+            if (retry) { homeDoc = retry.doc; subjID = retry.root; }
           }
           // A REFUSED subject write no longer costs the fact its chunk either. The
           // existing safety property is that a graph failure degrades to "no edge" and
           // never to "no fact"; once the chunk is the fact's home, that property has to
           // cover the chunk and not just the k/v row.
-          if (subjID && isNewSubject) { st.entity_nodes++; }
         } else {
           st.fact_no_subject++;
         }
@@ -2627,7 +2685,10 @@ agents:
         // erasure report keys on it — without it a placed fact cannot be surfaced as
         // residue for the subject who produced it.
         if (sourceID) { factArgs.source_session_id = sourceID; }
-        var factID = upsertEntityChunk(st, scope, docID, key, factArgs);
+        // FILED UNDER ITS SUBJECT. No parent_id: create_chunk makes a chunk with
+        // none a child of the document's root, which IS the entity — so the fact
+        // becomes a child of the thing it is about, and the dossier is one read.
+        var factID = upsertEntityChunk(st, scope, homeDoc, key, factArgs);
         if (!factID) { return false; }
         st.entity_facts++;
 

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -679,6 +679,7 @@ agents:
           // Next pass will try again; within a pass, once is enough.
           judge_attempted: {},
           entity_failed: 0,         // entity writes that failed (k/v still landed)
+          subject_docs: {},        // scope+slug -> {doc, root} for /facts/<slug>
           fact_no_subject: 0,       // facts chunked with no subject node (extractor named none)
           type_absent: 0,           // subjects filed under the fallback because no type was given
           entity_type_refused: 0,   // typed facts whose type was a statement class
@@ -2476,6 +2477,59 @@ agents:
         return "";
       }
 
+      // subjectDoc resolves — creating on first sight — the DOCUMENT that IS a
+      // subject: `/facts/<subject-slug>`, whose root chunk is the entity node
+      //. Returns {doc, root}, or null when it cannot be had.
+      //
+      // WHY A DOCUMENT PER SUBJECT rather than one shared entity document: it makes
+      // "what do we know about X" a single get_document instead of a search or a
+      // traversal, and `path op=ls /facts` a real entity directory. The facts are
+      // the document's children, so the answer is a read of one tree.
+      //
+      // THE PATH CARRIES IDENTITY ONLY — `/facts/denn`, never `/facts/person/denn`
+      //. Type is MUTABLE: on one measured run the extractor proposed a
+      // different kind for an already-filed subject 91 times. With the type in the
+      // path every re-type would be a document MOVE, and the type would live in two
+      // places that can disagree. It stays a chunk field, where canonicalType
+      // already arbitrates it.
+      //
+      // The memo is keyed on the slug alone for the same reason: one subject is one
+      // document however its kind is spelled this pass.
+      function subjectDoc(st, scope, subjType, subjName) {
+        var slug8 = slug(normalizeSubject(subjName));
+        if (!slug8) { return null; }
+        var memo = scope + "\u0000" + slug8;
+        if (st.subject_docs[memo] !== undefined) { return st.subject_docs[memo]; }
+        var path = "/facts/" + slug8;
+        var out = null;
+        try {
+          var got = JSON.parse(Document({ op: "get_document", scope: scope, path: path }));
+          if (got && got.document_id && got.root_chunk_id) {
+            out = { doc: got.document_id, root: got.root_chunk_id };
+          }
+        } catch (e) { /* not there yet — created below */ }
+        if (!out) {
+          try {
+            var made = JSON.parse(Document({
+              op: "create_document", scope: scope, title: subjName, path: path,
+              // The pair PLUS the key is what makes the root the entity itself
+              // rather than a container holding one.
+              type: subjType, subject: subjName,
+              natural_key: entityKey(subjType, subjName)
+            }));
+            if (made && made.document_id && made.root_chunk_id) {
+              out = { doc: made.document_id, root: made.root_chunk_id };
+              st.entity_nodes++;
+            }
+          } catch (e2) {
+            st.entity_failed++;
+            if (!st.entity_error) { st.entity_error = errText(e2); }
+          }
+        }
+        st.subject_docs[memo] = out;
+        return out;
+      }
+
       // nonEmpty reports a USABLE string field — present, a string, and not merely
       // whitespace. The extractor omits a key, sends null, and sends "" for the same
       // "I do not know", so all three have to read the same way.
@@ -2538,6 +2592,11 @@ agents:
         var docID = entitiesDoc(st, scope);
         if (!docID) { return false; }
 
+        // homeDoc is the document the fact is filed in: its SUBJECT's, when it has
+        // one. A fact naming nobody keeps the shared entity document — it has no
+        // subject to be homed under, and inventing one is the thing mirrorEntity
+        // refuses to do.
+        var homeDoc = docID;
         var subjID = "";
         if (nonEmpty(fact.subject)) {
           // A statement class is not an entity type — "preference:user" reads as "the entity
@@ -2561,10 +2620,8 @@ agents:
           // subject is one node however many ways the extractor spells its kind.
           var subjType = canonicalType(st, scope, proposed, fact.subject);
           var subjKey = entityKey(subjType, fact.subject);
-          var isNewSubject = !st.entity_ids[scope + "\u0000" + subjKey];
-          subjID = upsertEntityChunk(st, scope, docID, subjKey, {
-            title: fact.subject, type: subjType, subject: fact.subject
-          });
+          var home = subjectDoc(st, scope, subjType, fact.subject);
+          if (home) { homeDoc = home.doc; subjID = home.root; }
           // UNDECLARED TYPE: the write was refused because the tenant does not declare this
           // kind. File the kind as an inert candidate an operator can accept, then retry under
           // the fallback — the key has to move with the type, since the type is part of a
@@ -2576,16 +2633,17 @@ agents:
             st.subject_types[scope + "\u0000" + slug(normalizeSubject(fact.subject))] = ENTITY_FALLBACK_TYPE;
             subjType = ENTITY_FALLBACK_TYPE;
             subjKey = entityKey(subjType, fact.subject);
-            isNewSubject = !st.entity_ids[scope + "\u0000" + subjKey];
-            subjID = upsertEntityChunk(st, scope, docID, subjKey, {
-              title: fact.subject, type: subjType, subject: fact.subject
-            });
+            // The identity PATH does not move — only the kind changes — so this
+            // retries the same /facts/<slug> document under a type the tenant
+            // declares. The memo is dropped so the retry is actually attempted.
+            delete st.subject_docs[scope + "\u0000" + slug(normalizeSubject(fact.subject))];
+            var retry = subjectDoc(st, scope, subjType, fact.subject);
+            if (retry) { homeDoc = retry.doc; subjID = retry.root; }
           }
           // A REFUSED subject write no longer costs the fact its chunk either. The
           // existing safety property is that a graph failure degrades to "no edge" and
           // never to "no fact"; once the chunk is the fact's home, that property has to
           // cover the chunk and not just the k/v row.
-          if (subjID && isNewSubject) { st.entity_nodes++; }
         } else {
           st.fact_no_subject++;
         }
@@ -2627,7 +2685,10 @@ agents:
         // erasure report keys on it — without it a placed fact cannot be surfaced as
         // residue for the subject who produced it.
         if (sourceID) { factArgs.source_session_id = sourceID; }
-        var factID = upsertEntityChunk(st, scope, docID, key, factArgs);
+        // FILED UNDER ITS SUBJECT. No parent_id: create_chunk makes a chunk with
+        // none a child of the document's root, which IS the entity — so the fact
+        // becomes a child of the thing it is about, and the dossier is one read.
+        var factID = upsertEntityChunk(st, scope, homeDoc, key, factArgs);
         if (!factID) { return false; }
         st.entity_facts++;
 

--- a/cmd/loomcycle/presets_memory_codejs_test.go
+++ b/cmd/loomcycle/presets_memory_codejs_test.go
@@ -74,6 +74,9 @@ type fakeToolset struct {
 	// The entity half, filled by fakeDocument.
 	entitiesDocID string
 	chunks        map[string]string // natural_key -> chunk id
+	// subjectDocs maps a subject document's id -> the entity natural_key its ROOT
+	// is, so a test can tell which subject a fact was filed under.
+	subjectDocs map[string]string
 	// chunkScopes maps chunk id -> the scope it was written into. The double used to be
 	// scope-BLIND, which is why it could not see the placed-fact edge bug: the feature
 	// under test is entirely about which scope a write lands in, and the fake answered
@@ -165,6 +168,7 @@ func newFakeToolset() *fakeToolset {
 		leaseAcquired:  true,
 		bands:          map[string]any{"merge_threshold": 0.9, "related_threshold": 0.5},
 		chunks:         map[string]string{},
+		subjectDocs:    map[string]string{},
 		chunkScopes:    map[string]string{},
 		chunkTypes:     map[string]string{},
 		chunkSpans:     map[string]string{},
@@ -299,6 +303,42 @@ func (d *fakeDocument) Execute(_ context.Context, raw json.RawMessage) (tools.Re
 		}
 		return okResult(map[string]any{"document_id": d.f.entitiesDocID})
 	case "create_document":
+		// A SUBJECT-HOMED document: /facts/<slug>, whose ROOT is the entity. The
+		// double has to model two things the tool now does, or the tests stop
+		// exercising them: the ontology gate applies here (an entity can be minted
+		// through create_document, so leaving the gate on upsert_chunk alone would
+		// let a subject of an undeclared kind through), and each subject gets its
+		// OWN document rather than every fact landing in one.
+		subj, _ := in["subject"].(string)
+		nk, _ := in["natural_key"].(string)
+		if subj != "" && nk != "" {
+			// The refusal knob has to reach here too: a subject is created through
+			// this op now, so a double that only refuses upsert_chunk would leave
+			// every entity-write-failure test injecting nothing.
+			if d.f.failEntityKeys[nk] {
+				return tools.Result{IsError: true, Text: "create_document: refused for " + nk}, nil
+			}
+			if len(d.f.declaredTypes) > 0 {
+				if typ, _ := in["type"].(string); typ != "" && !d.f.declaredTypes[typ] {
+					return tools.Result{IsError: true, Text: "create_document: " + strconv.Quote(typ) +
+						" is not an entity type this tenant declares, so an assertion typed with it " +
+						"becomes a node nobody can find. Declared: object, person"}, nil
+				}
+			}
+			id, existed := d.f.chunks[nk]
+			if !existed {
+				id = fmt.Sprintf("chunk-%d", len(d.f.chunks)+1)
+				d.f.chunks[nk] = id
+				wscope, _ := in["scope"].(string)
+				d.f.chunkScopes[id] = wscope
+			}
+			if typ, _ := in["type"].(string); typ != "" {
+				d.f.chunkTypes[nk] = typ
+			}
+			docID := "doc-" + nk
+			d.f.subjectDocs[docID] = nk
+			return okResult(map[string]any{"document_id": docID, "root_chunk_id": id})
+		}
 		d.f.entitiesDocID = "doc-entities"
 		return okResult(map[string]any{"document_id": d.f.entitiesDocID, "root_chunk_id": "root"})
 	case "upsert_chunk":
@@ -2854,6 +2894,32 @@ func factWrites(f *fakeToolset) []factWrite {
 
 func factWriteCount(f *fakeToolset) int { return len(factWrites(f)) }
 
+// subjectWrites returns the calls that put a SUBJECT NODE in the store, whichever
+// op carried it.
+//
+// A subject used to be an upsert_chunk inside one shared entity document. It is now
+// the ROOT of its own `/facts/<slug>` document, so it arrives as a create_document
+// — the node and the document are one object, which is what makes a subject's
+// dossier a single read. Tests care that a subject was written once, under one
+// identity, not which op the write happened to be.
+func subjectWrites(f *fakeToolset) []recordedCall {
+	var out []recordedCall
+	for _, c := range f.calls {
+		if c.Tool != "Document" {
+			continue
+		}
+		if c.Op != "upsert_chunk" && c.Op != "create_document" {
+			continue
+		}
+		subj, _ := c.Input["subject"].(string)
+		nk, _ := c.Input["natural_key"].(string)
+		if subj != "" && nk != "" {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
 func lastFactWrite(t *testing.T, f *fakeToolset) factWrite {
 	t.Helper()
 	w := factWrites(f)
@@ -3165,6 +3231,76 @@ func TestConsolidator_TheFactCarriesEveryTemporalFieldItWasGiven(t *testing.T) {
 	// The chat it came from, which the erasure report keys on.
 	if got, _ := w.Input["source_session_id"].(string); got != "sess-a" {
 		t.Errorf("source_session_id = %q, want sess-a", got)
+	}
+}
+
+// TestConsolidator_AFactIsFiledUnderItsSubject is the P3 claim itself.
+//
+// A subject is its own document at /facts/<slug>, whose ROOT is the entity node,
+// and its facts are that document's children. That is what makes "what do we know
+// about X" one read instead of a search or a traversal, and what makes
+// `path op=ls /facts` an entity directory.
+//
+// The path carries IDENTITY ONLY — /facts/caroline, never /facts/person/caroline.
+// Type is mutable (on a measured run the extractor proposed a different kind for an
+// already-filed subject 91 times), so a type in the path would make every re-type a
+// document move and put the type in two places that can disagree.
+func TestConsolidator_AFactIsFiledUnderItsSubject(t *testing.T) {
+	f := newFakeToolset()
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	f.transcript = "### user\n\nCaroline paints, and Denn writes Go."
+	f.factsJSON = `[
+		{"text":"Caroline paints in watercolour.","class":"fact","type":"person","subject":"Caroline"},
+		{"text":"Caroline organises the art show.","class":"fact","type":"person","subject":"Caroline"},
+		{"text":"Denn prefers Go.","class":"preference","type":"person","subject":"Denn"}
+	]`
+
+	runConsolidator(t, f)
+
+	// One document per SUBJECT, created at the identity path.
+	paths := map[string]string{}
+	for _, c := range subjectWrites(f) {
+		p, _ := c.Input["path"].(string)
+		nk, _ := c.Input["natural_key"].(string)
+		paths[nk] = p
+	}
+	if len(paths) != 2 {
+		t.Fatalf("three facts about two subjects produced %d subject document(s): %v", len(paths), paths)
+	}
+	for nk, p := range paths {
+		want := "/facts/" + strings.TrimPrefix(nk, "person:")
+		if p != want {
+			t.Errorf("subject %s was filed at %q, want %q — the path carries identity only, so a "+
+				"re-type must not move the document", nk, p, want)
+		}
+	}
+
+	// Each fact lands in ITS subject's document, and the two Caroline facts share
+	// one — which is the whole point: her dossier is a single read.
+	byDoc := map[string][]string{}
+	for _, w := range factWrites(f) {
+		doc, _ := w.Input["document_id"].(string)
+		byDoc[doc] = append(byDoc[doc], w.Key)
+	}
+	if len(byDoc) != 2 {
+		t.Fatalf("facts landed in %d documents, want 2 (one per subject): %v", len(byDoc), byDoc)
+	}
+	var sizes []int
+	for _, keys := range byDoc {
+		sizes = append(sizes, len(keys))
+	}
+	sort.Ints(sizes)
+	if sizes[0] != 1 || sizes[1] != 2 {
+		t.Errorf("facts split %v across the two subject documents, want 1 and 2 — both of "+
+			"Caroline's belong in hers", sizes)
+	}
+	// And NOT in the shared entity document, which is now only for facts naming
+	// nobody.
+	for doc := range byDoc {
+		if doc == "doc-entities" {
+			t.Errorf("a subject's fact was filed in the shared entity document — subject-homing " +
+				"is what makes the dossier one read")
+		}
 	}
 }
 
@@ -4909,12 +5045,7 @@ func TestConsolidator_ASubjectKeepsTheTypeItIsAlreadyFiledUnder(t *testing.T) {
 
 	res := runConsolidator(t, f)
 
-	var subjectUpserts []recordedCall
-	for _, c := range callsWithOp(f, "Document.upsert_chunk") {
-		if s, _ := c.Input["subject"].(string); s != "" {
-			subjectUpserts = append(subjectUpserts, c)
-		}
-	}
+	subjectUpserts := subjectWrites(f)
 	if len(subjectUpserts) != 1 {
 		t.Fatalf("want one subject-node upsert, got %d", len(subjectUpserts))
 	}
@@ -4974,10 +5105,7 @@ func TestConsolidator_OneSubjectTypedTwoWaysInOnePassStillMakesOneNode(t *testin
 	runConsolidator(t, f)
 
 	keys := map[string]bool{}
-	for _, c := range callsWithOp(f, "Document.upsert_chunk") {
-		if s, _ := c.Input["subject"].(string); s == "" {
-			continue
-		}
+	for _, c := range subjectWrites(f) {
 		k, _ := c.Input["natural_key"].(string)
 		keys[k] = true
 	}

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -1479,6 +1479,18 @@ func (d *Document) createDocument(ctx context.Context, key sqlmem.ScopeKey, msco
 	}
 	now := time.Now().UnixNano()
 	docID := newDocID()
+	// THE ONTOLOGY GATE APPLIES HERE TOO, now that a root can be an entity. It used
+	// to live on upsert_chunk alone, which was the only way to make one; a
+	// subject-homed store creates its entities through create_document, so leaving
+	// the gate behind would let any caller mint an entity of an undeclared kind
+	// simply by creating a document — curation (RFC CA) bypassed by a different op.
+	//
+	// Gated BEFORE the document exists, so a refusal leaves nothing behind.
+	if strings.TrimSpace(in.Subject) != "" && strings.TrimSpace(in.NaturalKey) != "" {
+		if refused := d.gateEntityType(ctx, in); refused != nil {
+			return *refused, nil
+		}
+	}
 	rootID := newDocID()
 	// type/status are set on the root chunk (the authoritative kind/state) AND
 	// mirrored to the documents row (the denormalized copy query_documents /


### PR DESCRIPTION
**RFC CV P3**, single-subject homing (N-subjects deferred to CW, as agreed). A subject was a chunk inside one shared `/memory/entities`; it is now the **root of its own `/facts/<slug>`**, and the facts about it are that document's children.

That is what makes *"what do we know about X"* a single `get_document` instead of a search or a traversal, and `path op=ls /facts` a real entity directory.

## Decisions worth reading

**The path carries identity only** — `/facts/denn`, never `/facts/person/denn`. Type is *mutable*: on one measured run the extractor proposed a different kind for an already-filed subject **91 times**. With the type in the path every re-type would be a document **move**, and the type would live in two places that can disagree. It stays a chunk field, and the undeclared-type retry now re-files the kind without the document going anywhere.

**The `about` edge stays**, and that is a decision rather than an oversight. `graph_recall` traverses `chunk_edges` and does not look at `parent_id` **at all** — I checked rather than assumed — so dropping the edge in favour of containment would make every subject's facts unreachable by traversal. Containment gives the one-read dossier; the edge keeps the graph walkable. Separate mechanisms, as the RFC says.

**A fact naming nobody keeps the shared document.** It has no subject to be homed under, and inventing one is the thing `mirrorEntity` refuses to do.

## An integrity gap this opened, and closed

`gateEntityType` lived on `upsert_chunk` — which used to be the only way to make an entity. A subject-homed store creates them through `create_document`, so leaving the gate behind would have let any caller **mint an entity of an undeclared kind simply by creating a document**: RFC CA's ontology curation bypassed through a different op.

`create_document` now gates too, **before anything is created**, so a refusal leaves nothing behind. The failing tests are what pointed at this — they were asserting a refusal that had silently stopped happening.

## The test double moved with it

It gates `create_document` the same way and honours the failure-injection knob there. Without that, **every entity-write-failure test would have been injecting nothing and passing for that reason** — the same class of false-green the vector-filing change caused in #1199.

`subjectWrites` joins `factWrite` as an adapter: a subject node now arrives as a `create_document`, and the tests care that one was written once under one identity, not which op carried it.

## What was tested

`TestConsolidator_AFactIsFiledUnderItsSubject` — three facts about two subjects produce two documents at the identity paths, each fact lands in **its** subject's, both of Caroline's share one, and none lands in the shared document.

Fail-before files them all in the shared document: *"facts landed in 1 documents, want 2 (one per subject)"*. `go test ./...` clean; both bundle copies byte-identical.

## Still ahead in P3

1. **the reader contract** — a relation-fact reachable from *every* subject it references. Buildable and testable against a hand-made reference, but nothing produces a multi-subject fact until CW Probe 3 lands, so it stays scaffolding for now.
2. **migrating** the facts already homed in `/memory/entities` — existing stores keep working (reads go through the same surfaces), but their facts stay in the shared document until moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8