### PR TITLE
feat(teamdef): make a team walk debuggable — a walk is a run, armed live

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -890,6 +890,13 @@ func requiredScopeFor(method, path string) string {
 	// default empty arm, letting a read-only bearer steer a run.)
 	case method == http.MethodPost && strings.HasPrefix(path, "/v1/runs/") && strings.HasSuffix(path, "/input"):
 		return auth.ScopeRunsCreate
+	// Arming a team walk's breakpoints holds work back and releases it — a
+	// run-state mutation, same scope as steer/cancel/compact. Without this case
+	// the PUT falls through to the default-deny admin arm, which would lock a
+	// tenant operator out of debugging their own run. (The GET is covered by
+	// the runs-read case below.)
+	case method == http.MethodPut && strings.HasPrefix(path, "/v1/runs/") && strings.HasSuffix(path, "/breakpoints"):
+		return auth.ScopeRunsCreate
 	case method == http.MethodGet && strings.HasPrefix(path, "/v1/runs/"):
 		return auth.ScopeRunsRead
 	// Run / agent / session / user reads.

--- a/internal/api/http/breakpoints_handler.go
+++ b/internal/api/http/breakpoints_handler.go
@@ -1,0 +1,131 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/denn-gubsky/loomcycle/internal/breakpoints"
+	"github.com/denn-gubsky/loomcycle/internal/teamrun"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// Live breakpoint arming for a team walk — GET/PUT /v1/runs/{run_id}/breakpoints.
+//
+// The run argument on `TeamDef op=run` covers the case where you already know
+// the workflow is broken. It cannot cover the common one: you start a run
+// expecting it to work, watch a wave go wrong, and want to stop before the next
+// one. There is nothing to pass at that moment, so the arming has to be
+// something the walk keeps re-reading and this endpoint can write to.
+//
+// Addressed by run_id, the same handle every other live-run surface uses
+// (cancel, steer, interrupts) and the one the loomboard canvas already holds.
+
+type breakpointsRequest struct {
+	// Breakpoints is the WHOLE desired set, not a delta. The caller holds the
+	// configuration and pushes it, so two operators cannot interleave a
+	// read-modify-write, and "turn Debug off" is the empty list rather than a
+	// second verb.
+	Breakpoints []string `json:"breakpoints"`
+}
+
+type breakpointsResponse struct {
+	RunID string `json:"run_id"`
+	// Armed is canonical — always phase-qualified and sorted — so a caller
+	// reading back its own arming sees what the walk will actually do rather
+	// than an echo of its own shorthand.
+	Armed []string `json:"armed"`
+}
+
+// handleGetRunBreakpoints serves GET /v1/runs/{run_id}/breakpoints.
+func (s *Server) handleGetRunBreakpoints(w http.ResponseWriter, r *http.Request) {
+	set, runID, ok := s.liveBreakpointSet(w, r)
+	if !ok {
+		return
+	}
+	writeJSON(w, http.StatusOK, breakpointsResponse{RunID: runID, Armed: set.List()})
+}
+
+// handlePutRunBreakpoints serves PUT /v1/runs/{run_id}/breakpoints — replace
+// the armed set of the team walk running under this run.
+//
+// It takes effect at the NEXT pause point the walk reaches: the before_dispatch
+// of a wave that has not started, or the after_collection of one whose results
+// have not gone out yet. It cannot un-publish a result the next stage has
+// already seen, and does not pretend to.
+func (s *Server) handlePutRunBreakpoints(w http.ResponseWriter, r *http.Request) {
+	set, runID, ok := s.liveBreakpointSet(w, r)
+	if !ok {
+		return
+	}
+	var req breakpointsRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_body", "invalid JSON body")
+		return
+	}
+	// Replace validates before it mutates, so a rejected call leaves the
+	// previous arming exactly as it was — an operator fixing a typo must not
+	// discover they have also disarmed everything that was working.
+	if err := set.Replace(req.Breakpoints); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_breakpoint", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, breakpointsResponse{RunID: runID, Armed: set.List()})
+}
+
+// liveBreakpointSet resolves the armed set for a run, or writes the refusal.
+//
+// A run the caller's tenant cannot see and a run with no walk in flight both
+// fold into the SAME 404: run_ids are not secret (they are returned to callers
+// and shown in the UI), so the gate must not become an existence oracle.
+func (s *Server) liveBreakpointSet(w http.ResponseWriter, r *http.Request) (*breakpoints.Set, string, bool) {
+	if s.breakpointReg == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "team breakpoints are not enabled on this server")
+		return nil, "", false
+	}
+	runID := r.PathValue("run_id")
+	if !validIdent(runID) {
+		writeJSONError(w, http.StatusBadRequest, "invalid_run_id", "run_id must match [A-Za-z0-9_-]{1,128}")
+		return nil, "", false
+	}
+	if _, err := s.tenantStore(r.Context()).GetRun(r.Context(), runID); err != nil {
+		writeJSONError(w, http.StatusNotFound, "no_live_walk", "no live team walk for that run_id")
+		return nil, "", false
+	}
+	set, ok := s.breakpointReg.Get(runID)
+	if !ok {
+		// Single-process today: a walk on ANOTHER replica is not reachable from
+		// here and reports the same miss. Loudly, never silently — an arming
+		// that appeared to succeed and then never paused anything would be the
+		// worst possible outcome for a debugger. Cross-replica owner-routing is
+		// the same follow-on cancel and steer each took.
+		writeJSONError(w, http.StatusNotFound, "no_live_walk",
+			"no live team walk for that run_id on this replica")
+		return nil, "", false
+	}
+	return set, runID, true
+}
+
+// openTeamBreakpoints is what TeamDef op=run calls to get its armed set. The
+// run id comes from ctx, never from tool input — a caller must not be able to
+// register its walk under someone else's run.
+func (s *Server) openTeamBreakpoints(ctx context.Context, seed []string) (teamrun.BreakpointSource, func(), error) {
+	set, release, err := s.breakpointReg.Open(tools.RunID(ctx), seed)
+	if err != nil {
+		return nil, nil, err
+	}
+	return liveBreakpoints{set}, release, nil
+}
+
+// liveBreakpoints adapts the registry's Set to what the walk asks.
+//
+// The adapter exists so internal/breakpoints stays a leaf: the walk's phase is
+// a named string type in teamrun, and importing it into the registry would put
+// the graph-walker inside the HTTP layer's dependency set for the sake of one
+// conversion. The two phase spellings are pinned against each other by
+// TestBreakpointPhases_MatchTheRegistrys.
+type liveBreakpoints struct{ set *breakpoints.Set }
+
+func (l liveBreakpoints) Armed(state string, phase teamrun.BreakpointPhase) bool {
+	return l.set.Armed(state, string(phase))
+}

--- a/internal/api/http/breakpoints_handler_test.go
+++ b/internal/api/http/breakpoints_handler_test.go
@@ -1,0 +1,175 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/breakpoints"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/teamrun"
+)
+
+// seedRun creates a session + run the tenant gate will accept.
+func seedRun(t *testing.T, srv *Server) string {
+	t.Helper()
+	ctx := context.Background()
+	sess, err := srv.store.CreateSession(ctx, "", "agent-x", "alice")
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	run, err := srv.store.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "agent-x", UserID: "alice"})
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	return run.ID
+}
+
+func armedFrom(t *testing.T, body string) []string {
+	t.Helper()
+	var out struct {
+		RunID string   `json:"run_id"`
+		Armed []string `json:"armed"`
+	}
+	if err := json.Unmarshal([]byte(body), &out); err != nil {
+		t.Fatalf("decode %q: %v", body, err)
+	}
+	return out.Armed
+}
+
+// TestHandleBreakpoints_ArmsAWalkThatIsAlreadyRunning is the whole point: the
+// walk registered with no breakpoints, and an operator arms one afterwards.
+func TestHandleBreakpoints_ArmsAWalkThatIsAlreadyRunning(t *testing.T) {
+	srv, cleanup := channelFanFixture(t)
+	defer cleanup()
+	runID := seedRun(t, srv)
+
+	// A walk starts with NOTHING armed — the ordinary case.
+	set, release, err := srv.breakpointReg.Open(runID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+	if set.Armed("wave", breakpoints.BeforeDispatch) {
+		t.Fatal("a walk with no run argument started armed")
+	}
+
+	rec := doJSON(t, srv, "PUT", "/v1/runs/"+runID+"/breakpoints", `{"breakpoints":["wave:before_dispatch"]}`)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := armedFrom(t, rec.Body.String()); len(got) != 1 || got[0] != "wave:before_dispatch" {
+		t.Errorf("armed = %v", got)
+	}
+	// The LIVE set the walk is consulting changed — not a copy.
+	if !set.Armed("wave", breakpoints.BeforeDispatch) {
+		t.Error("the walk's own set did not see the arming")
+	}
+	if set.Armed("wave", breakpoints.AfterCollection) {
+		t.Error("a phase-qualified spec armed the other phase too")
+	}
+}
+
+// TestHandleBreakpoints_GetReadsBackCanonically: a caller sees what the walk
+// will do, not an echo of its shorthand.
+func TestHandleBreakpoints_GetReadsBackCanonically(t *testing.T) {
+	srv, cleanup := channelFanFixture(t)
+	defer cleanup()
+	runID := seedRun(t, srv)
+	_, release, _ := srv.breakpointReg.Open(runID, []string{"wave"})
+	defer release()
+
+	rec := doJSON(t, srv, "GET", "/v1/runs/"+runID+"/breakpoints", "")
+	if rec.Code != 200 {
+		t.Fatalf("status = %d; body=%s", rec.Code, rec.Body.String())
+	}
+	got := armedFrom(t, rec.Body.String())
+	if len(got) != 2 || got[0] != "wave:after_collection" || got[1] != "wave:before_dispatch" {
+		t.Errorf("armed = %v, want both phases, canonical and sorted", got)
+	}
+}
+
+// TestHandleBreakpoints_EmptyListTurnsDebugOff — the canvas's off switch.
+func TestHandleBreakpoints_EmptyListTurnsDebugOff(t *testing.T) {
+	srv, cleanup := channelFanFixture(t)
+	defer cleanup()
+	runID := seedRun(t, srv)
+	set, release, _ := srv.breakpointReg.Open(runID, []string{"wave"})
+	defer release()
+
+	rec := doJSON(t, srv, "PUT", "/v1/runs/"+runID+"/breakpoints", `{"breakpoints":[]}`)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d; body=%s", rec.Code, rec.Body.String())
+	}
+	if len(armedFrom(t, rec.Body.String())) != 0 || set.Armed("wave", breakpoints.BeforeDispatch) {
+		t.Error("the empty list did not disarm")
+	}
+}
+
+// TestHandleBreakpoints_RejectedPutKeepsThePreviousArming: an operator fixing a
+// typo must not discover they have also disarmed what was working.
+func TestHandleBreakpoints_RejectedPutKeepsThePreviousArming(t *testing.T) {
+	srv, cleanup := channelFanFixture(t)
+	defer cleanup()
+	runID := seedRun(t, srv)
+	set, release, _ := srv.breakpointReg.Open(runID, []string{"wave:before_dispatch"})
+	defer release()
+
+	rec := doJSON(t, srv, "PUT", "/v1/runs/"+runID+"/breakpoints", `{"breakpoints":["review","wave:typo"]}`)
+	if rec.Code != 400 {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	if !set.Armed("wave", breakpoints.BeforeDispatch) {
+		t.Error("a rejected PUT disarmed the previous set")
+	}
+	if set.Armed("review", breakpoints.BeforeDispatch) {
+		t.Error("a rejected PUT partially applied")
+	}
+}
+
+// TestHandleBreakpoints_NoLiveWalkIs404: an arming that appeared to succeed and
+// then never paused anything is the worst outcome for a debugger, so a run with
+// no walk in flight fails loudly. A cross-tenant run folds into the SAME 404 —
+// run_ids are not secret, so the gate must not become an existence oracle.
+func TestHandleBreakpoints_NoLiveWalkIs404(t *testing.T) {
+	srv, cleanup := channelFanFixture(t)
+	defer cleanup()
+	runID := seedRun(t, srv) // a real run, but no walk registered
+
+	for _, method := range []string{"GET", "PUT"} {
+		rec := doJSON(t, srv, method, "/v1/runs/"+runID+"/breakpoints", `{"breakpoints":["wave"]}`)
+		if rec.Code != 404 {
+			t.Errorf("%s with no live walk = %d, want 404; body=%s", method, rec.Code, rec.Body.String())
+		}
+	}
+	// An unknown run id is the same 404, not a different code that would say
+	// "this run does not exist".
+	rec := doJSON(t, srv, "GET", "/v1/runs/run-nope/breakpoints", "")
+	if rec.Code != 404 {
+		t.Errorf("unknown run = %d, want the same opaque 404", rec.Code)
+	}
+}
+
+// TestBreakpointPhases_MatchTheRegistrys pins the two spellings of the phase
+// against each other. The registry is a leaf and cannot import teamrun, so the
+// constants are declared twice; if they ever diverge, every arming would
+// silently stop matching and no other test would notice.
+func TestBreakpointPhases_MatchTheRegistrys(t *testing.T) {
+	if string(teamrun.BeforeDispatch) != breakpoints.BeforeDispatch {
+		t.Errorf("before_dispatch spelled %q in teamrun and %q in breakpoints",
+			teamrun.BeforeDispatch, breakpoints.BeforeDispatch)
+	}
+	if string(teamrun.AfterCollection) != breakpoints.AfterCollection {
+		t.Errorf("after_collection spelled %q in teamrun and %q in breakpoints",
+			teamrun.AfterCollection, breakpoints.AfterCollection)
+	}
+	// And the adapter actually bridges them.
+	set, _ := breakpoints.NewSet([]string{"wave:after_collection"})
+	var src teamrun.BreakpointSource = liveBreakpoints{set}
+	if !src.Armed("wave", teamrun.AfterCollection) {
+		t.Error("the adapter did not translate the phase")
+	}
+	if src.Armed("wave", teamrun.BeforeDispatch) {
+		t.Error("the adapter armed the wrong phase")
+	}
+}

--- a/internal/api/http/channels_fan_test.go
+++ b/internal/api/http/channels_fan_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/breakpoints"
 	"github.com/denn-gubsky/loomcycle/internal/cancel"
 	"github.com/denn-gubsky/loomcycle/internal/channels"
 	"github.com/denn-gubsky/loomcycle/internal/concurrency"
@@ -49,6 +50,7 @@ func channelFanFixture(t *testing.T) (*Server, func()) {
 		hookRegistry:   hookReg,
 		hookDispatcher: hooks.NewDispatcher(hookReg, nil),
 		sem:            concurrency.New(8, 16, 30000),
+		breakpointReg:  breakpoints.NewRegistry(),
 	}
 	srv.SetSystemPublisher(&channels.StorePublisher{Store: s, Bus: bus, Scheduler: sched})
 	srv.SetChannelBus(bus)

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/denn-gubsky/loomcycle/internal/audit"
 	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/breakpoints"
 	"github.com/denn-gubsky/loomcycle/internal/cancel"
 	"github.com/denn-gubsky/loomcycle/internal/channels"
 	"github.com/denn-gubsky/loomcycle/internal/clienttools"
@@ -151,6 +152,13 @@ type Server struct {
 	// parks it at awaiting_input (vs the whole-run cancel registry, which
 	// terminates). Always non-nil after New(); armed only for interactive runs.
 	turnCancelReg *turncancel.Registry
+
+	// breakpointReg maps a live run_id → the armed breakpoint set of the team
+	// walk running under it, so an operator can arm a Starter state while the
+	// walk is already going. Always non-nil (a debugger that silently is not
+	// there is worse than one that refuses), and entries live only as long as
+	// the walk.
+	breakpointReg *breakpoints.Registry
 
 	// residentReg maps a resident interactive sub-agent's run_id → its live
 	// handle (RFC BK). In-process (P1 single-replica). Non-nil after New();
@@ -511,6 +519,9 @@ func New(cfg *config.Config, pr ProviderResolver, builtinTools []tools.Tool, sem
 	// way to mutate the trust boundary is a restart with new yaml.
 	hookReg := hooks.NewRegistryWithPermissions(cfg.Hooks.PermitHostWiden.Owners)
 	s := &Server{
+		// Always present: an operator hitting Debug on a run must get either an
+		// arming or a clear refusal, never a silent no-op.
+		breakpointReg:  breakpoints.NewRegistry(),
 		cfgHolder:      config.NewHolder(cfg),
 		providers:      pr,
 		tools:          builtinTools,
@@ -923,6 +934,14 @@ func (s *Server) SetTeamDefTool(t tools.Tool) {
 				}
 				return nil
 			}
+		}
+		if td.LiveBreakpoints == nil {
+			// Ad-hoc Run → Debug: the walk reads its arming from a set this
+			// server can still write to, so a state can be armed after the run
+			// started. Without this the run argument is the only way in, and
+			// the case an operator is actually in — watching a wave go wrong —
+			// has nothing to write to.
+			td.LiveBreakpoints = s.openTeamBreakpoints
 		}
 		if td.ChannelCatalog == nil {
 			// The same merged set the per-agent channel policy is built from, so
@@ -3311,6 +3330,8 @@ func (s *Server) Mux() http.Handler {
 	// PR 2 / interactive terminal: inject an operator "steering" instruction
 	// into an in-flight run (appended to the live conversation mid-turn).
 	mux.Handle("POST /v1/runs/{run_id}/input", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleRunInput))))
+	mux.Handle("GET /v1/runs/{run_id}/breakpoints", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleGetRunBreakpoints))))
+	mux.Handle("PUT /v1/runs/{run_id}/breakpoints", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handlePutRunBreakpoints))))
 	mux.Handle("POST /v1/runs/{run_id}/cancel", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleCancelTurn))))
 	mux.Handle("POST /v1/runs/{run_id}/compact", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleCompactRun))))
 	// Re-attach to a running (or finished) run's event stream — the operator

--- a/internal/breakpoints/registry.go
+++ b/internal/breakpoints/registry.go
@@ -1,0 +1,233 @@
+// Package breakpoints implements the in-memory per-run debug arming for a team
+// walk. It mirrors internal/turncancel's run-keyed shape: a map (run_id → the
+// live armed set) that vanishes when the process exits.
+//
+// WHY IT IS MUTABLE AND NOT A RUN ARGUMENT. Breakpoints arrived as an argument
+// fixed at dispatch, which serves the case where you already know the workflow
+// is broken. It does not serve the common one: you start a run expecting it to
+// work, watch a wave go wrong, and want to stop before the next one. There is
+// nothing to pass at that point — the run is already going — so the armed set
+// has to be something the walk RE-READS rather than something it captured.
+//
+// That is the whole design: the walk consults a Set at every pause point, and
+// an operator can change what that Set says while the walk is running.
+//
+// WHY IT IS NOT PERSISTED. The arming is live debugger state, meaningful only
+// while a particular walk is in flight. Persisting it would create a worse
+// problem than it solves — a breakpoint surviving into a later run of the same
+// team, pausing a workflow nobody is watching, with the ask timing out and
+// aborting the walk. The set dies with the walk, deliberately.
+package breakpoints
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// Phase mirrors teamrun.BreakpointPhase. It is duplicated as a string constant
+// rather than imported because this package must stay a leaf — teamrun consumes
+// it through an interface, and an import in the other direction would put the
+// HTTP registry inside the graph-walker's dependency set.
+//
+// ParseSpec below is the single parser both sides use, so the two spellings
+// cannot drift into accepting different arguments.
+const (
+	BeforeDispatch  = "before_dispatch"
+	AfterCollection = "after_collection"
+)
+
+// Set is one run's armed breakpoints: state id → the phases armed on it.
+//
+// Safe for concurrent use by the walk goroutine (Armed, at every pause) and an
+// API goroutine (Replace, when an operator changes the arming mid-run).
+type Set struct {
+	mu sync.RWMutex
+	at map[string]map[string]bool
+}
+
+// NewSet builds a Set from breakpoint specs, refusing the whole list if any
+// entry is malformed — a partially-applied arming is how an operator ends up
+// watching a walk that never pauses at the state they typed.
+func NewSet(specs []string) (*Set, error) {
+	s := &Set{at: map[string]map[string]bool{}}
+	if err := s.Replace(specs); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// Armed reports whether this state pauses at this phase. Called by the walk at
+// every pause point, so it is the read that makes mid-run arming work.
+func (s *Set) Armed(state, phase string) bool {
+	if s == nil {
+		return false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.at[state][phase]
+}
+
+// Replace swaps the whole armed set atomically.
+//
+// A whole-set replace rather than arm/disarm deltas: the caller holds the
+// desired configuration and pushes it, so there is no read-modify-write race
+// between two operators and no ordering question about which delta won.
+// Disarming everything is the empty list, which is also how a canvas turns
+// Debug off.
+//
+// It VALIDATES BEFORE it mutates, so a rejected call leaves the previous arming
+// exactly as it was — an operator fixing a typo must not discover they have
+// also disarmed everything that was working.
+func (s *Set) Replace(specs []string) error {
+	next := make(map[string]map[string]bool, len(specs))
+	for _, spec := range specs {
+		state, phase, err := ParseSpec(spec)
+		if err != nil {
+			return err
+		}
+		if next[state] == nil {
+			next[state] = map[string]bool{}
+		}
+		if phase == "" {
+			next[state][BeforeDispatch] = true
+			next[state][AfterCollection] = true
+			continue
+		}
+		next[state][phase] = true
+	}
+	s.mu.Lock()
+	s.at = next
+	s.mu.Unlock()
+	return nil
+}
+
+// List renders the armed set back as canonical specs, sorted, always
+// phase-qualified. Canonical rather than echoing what was sent: a caller
+// reading back its own arming should see exactly what the walk will do, not its
+// own shorthand.
+func (s *Set) List() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var out []string
+	for state, phases := range s.at {
+		for phase, on := range phases {
+			if on {
+				out = append(out, state+":"+phase)
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ParseSpec splits one breakpoint spec into a state id and an optional phase.
+//
+//	"review"                   both phases
+//	"review:after_collection"  that phase only
+//
+// A state id may itself contain a colon, so only the LAST segment is a phase
+// candidate; if it is not a phase, the whole spec is refused rather than
+// silently read as a state id that does not exist.
+func ParseSpec(spec string) (state, phase string, err error) {
+	state = spec
+	if i := strings.LastIndex(spec, ":"); i >= 0 {
+		state, phase = spec[:i], spec[i+1:]
+		if phase != BeforeDispatch && phase != AfterCollection {
+			return "", "", fmt.Errorf("breakpoint %q: expected \"<state>\" or \"<state>:%s\" or \"<state>:%s\"",
+				spec, BeforeDispatch, AfterCollection)
+		}
+	}
+	if strings.TrimSpace(state) == "" {
+		return "", "", fmt.Errorf("breakpoint %q: missing the state id", spec)
+	}
+	return state, phase, nil
+}
+
+// Registry maps a live run_id → the armed set of the team walk running under
+// it. An entry exists only while a walk is in flight.
+//
+// Keyed by RUN, not by walk: "debug this run" is what an operator means when
+// they hit the button, and the run id is the handle every other run-scoped
+// surface already uses (cancel, steer, interrupts). A single run driving two
+// walks concurrently shares one set — the state ids come from different
+// definitions, so they do not collide in practice, and one arming for one run
+// is the behaviour an operator expects either way.
+type Registry struct {
+	mu   sync.Mutex
+	sets map[string]*entry
+}
+
+type entry struct {
+	set *Set
+	// refs counts the walks sharing this run's set, so the second walk to
+	// finish does not delete a set the first is still consulting.
+	refs int
+}
+
+func NewRegistry() *Registry {
+	return &Registry{sets: map[string]*entry{}}
+}
+
+// Open registers a walk's armed set under runID, seeded with the run argument,
+// and returns it plus the release to call when the walk ends.
+//
+// An empty runID gets a detached Set: the arming still works for whatever was
+// passed at dispatch, but nothing can reach it to change it. That is the honest
+// outcome for a walk started outside a run (there is no handle to address), and
+// it fails by being un-armable rather than by refusing to run.
+func (r *Registry) Open(runID string, seed []string) (*Set, func(), error) {
+	set, err := NewSet(seed)
+	if err != nil {
+		return nil, nil, err
+	}
+	// A nil registry (a Server assembled without one) degrades to a detached
+	// set: the dispatch-time arming still works and nothing can reach it. That
+	// is the documented fallback, and it must not be a panic inside a live walk.
+	if r == nil || runID == "" {
+		return set, func() {}, nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if e, ok := r.sets[runID]; ok {
+		// A second walk under the same run joins the existing set rather than
+		// replacing it, so an operator's arming is not silently dropped by a
+		// walk that started later.
+		e.refs++
+		return e.set, func() { r.release(runID) }, nil
+	}
+	r.sets[runID] = &entry{set: set, refs: 1}
+	return set, func() { r.release(runID) }, nil
+}
+
+func (r *Registry) release(runID string) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	e, ok := r.sets[runID]
+	if !ok {
+		return
+	}
+	e.refs--
+	if e.refs <= 0 {
+		delete(r.sets, runID)
+	}
+}
+
+// Get returns the live set for a run, or false when no walk is in flight under
+// it on this replica.
+func (r *Registry) Get(runID string) (*Set, bool) {
+	if r == nil {
+		return nil, false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	e, ok := r.sets[runID]
+	if !ok {
+		return nil, false
+	}
+	return e.set, true
+}

--- a/internal/breakpoints/registry_test.go
+++ b/internal/breakpoints/registry_test.go
@@ -1,0 +1,201 @@
+package breakpoints
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestParseSpec(t *testing.T) {
+	for _, tc := range []struct {
+		in, state, phase string
+		ok               bool
+	}{
+		{"wave", "wave", "", true},
+		{"wave:before_dispatch", "wave", BeforeDispatch, true},
+		{"wave:after_collection", "wave", AfterCollection, true},
+		// A state id may itself contain a colon, so only the LAST segment is a
+		// phase candidate.
+		{"team:wave:after_collection", "team:wave", AfterCollection, true},
+		{"wave:typo", "", "", false},
+		{"", "", "", false},
+		{":before_dispatch", "", "", false},
+	} {
+		state, phase, err := ParseSpec(tc.in)
+		if (err == nil) != tc.ok || state != tc.state || phase != tc.phase {
+			t.Errorf("ParseSpec(%q) = (%q,%q,err=%v), want (%q,%q,ok=%v)",
+				tc.in, state, phase, err, tc.state, tc.phase, tc.ok)
+		}
+	}
+}
+
+// TestSet_BareStateArmsBothPhases: "wave" means "stop at this state", which is
+// what an operator means when they click one node.
+func TestSet_BareStateArmsBothPhases(t *testing.T) {
+	s, err := NewSet([]string{"wave"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range []string{BeforeDispatch, AfterCollection} {
+		if !s.Armed("wave", p) {
+			t.Errorf("a bare state did not arm %s", p)
+		}
+	}
+	if s.Armed("other", BeforeDispatch) {
+		t.Error("armed a state nobody named")
+	}
+}
+
+// TestSet_ReplaceIsAtomicAndValidatesFirst: a rejected replace must leave the
+// previous arming exactly as it was. An operator fixing a typo must not
+// discover they have also disarmed everything that was working.
+func TestSet_ReplaceIsAtomicAndValidatesFirst(t *testing.T) {
+	s, err := NewSet([]string{"wave:before_dispatch"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Replace([]string{"review", "wave:typo"}); err == nil {
+		t.Fatal("a malformed entry must refuse the whole list")
+	}
+	if !s.Armed("wave", BeforeDispatch) {
+		t.Error("a REJECTED replace disarmed the previous set")
+	}
+	if s.Armed("review", BeforeDispatch) {
+		t.Error("a REJECTED replace partially applied")
+	}
+	// And a good one does swap wholesale — this is a replace, not a merge.
+	if err := s.Replace([]string{"review"}); err != nil {
+		t.Fatal(err)
+	}
+	if s.Armed("wave", BeforeDispatch) {
+		t.Error("Replace merged instead of replacing")
+	}
+	if !s.Armed("review", AfterCollection) {
+		t.Error("Replace did not apply the new set")
+	}
+	// Disarming everything is the empty list — how a canvas turns Debug off.
+	if err := s.Replace(nil); err != nil {
+		t.Fatal(err)
+	}
+	if s.Armed("review", AfterCollection) || len(s.List()) != 0 {
+		t.Errorf("the empty list must disarm everything, got %v", s.List())
+	}
+}
+
+// TestSet_ListIsCanonical: a caller reading back its own arming should see what
+// the walk will do, not an echo of its shorthand.
+func TestSet_ListIsCanonical(t *testing.T) {
+	s, _ := NewSet([]string{"zeta", "alpha:after_collection"})
+	got := strings.Join(s.List(), " ")
+	want := "alpha:after_collection zeta:after_collection zeta:before_dispatch"
+	if got != want {
+		t.Errorf("List() = %q, want %q", got, want)
+	}
+}
+
+// TestSet_NilIsNotArmed: the walk holds a source that may be nil on paths where
+// nothing was opened; it must answer false rather than panic.
+func TestSet_NilIsNotArmed(t *testing.T) {
+	var s *Set
+	if s.Armed("wave", BeforeDispatch) {
+		t.Error("a nil Set claimed to be armed")
+	}
+}
+
+func TestRegistry_OpenGetRelease(t *testing.T) {
+	r := NewRegistry()
+	set, release, err := r.Open("run_1", []string{"wave"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok := r.Get("run_1")
+	if !ok || got != set {
+		t.Fatal("Open did not register the set under its run")
+	}
+	release()
+	if _, ok := r.Get("run_1"); ok {
+		t.Error("the set outlived the walk — a breakpoint surviving into a later run would pause a workflow nobody is watching")
+	}
+}
+
+// TestRegistry_TwoWalksShareOneRunsSet: the second walk to finish must not
+// delete a set the first is still consulting, and a walk starting later must
+// not silently drop an operator's arming.
+func TestRegistry_TwoWalksShareOneRunsSet(t *testing.T) {
+	r := NewRegistry()
+	first, releaseFirst, _ := r.Open("run_1", []string{"wave"})
+	second, releaseSecond, _ := r.Open("run_1", nil)
+	if first != second {
+		t.Fatal("two walks under one run must share the set")
+	}
+	if !second.Armed("wave", BeforeDispatch) {
+		t.Error("the later walk replaced the arming instead of joining it")
+	}
+	releaseFirst()
+	if _, ok := r.Get("run_1"); !ok {
+		t.Fatal("releasing one walk removed a set the other is still using")
+	}
+	releaseSecond()
+	if _, ok := r.Get("run_1"); ok {
+		t.Error("the set outlived the last walk")
+	}
+}
+
+// TestRegistry_NoRunIDIsDetached: a walk started outside a run has no handle to
+// address, so it gets a working-but-unreachable set rather than a refusal.
+func TestRegistry_NoRunIDIsDetached(t *testing.T) {
+	r := NewRegistry()
+	set, release, err := r.Open("", []string{"wave"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+	if !set.Armed("wave", BeforeDispatch) {
+		t.Error("the dispatch-time arming must still work with no run id")
+	}
+	if _, ok := r.Get(""); ok {
+		t.Error("a detached set must not be registered under the empty run id")
+	}
+}
+
+// TestRegistry_OpenRefusesABadSeed: the run argument goes through the same
+// parser as a mid-run arm, so a typo cannot enter by the other door.
+func TestRegistry_OpenRefusesABadSeed(t *testing.T) {
+	r := NewRegistry()
+	if _, _, err := r.Open("run_1", []string{"wave:typo"}); err == nil {
+		t.Fatal("a malformed seed was accepted")
+	}
+	if _, ok := r.Get("run_1"); ok {
+		t.Error("a refused Open left an entry behind")
+	}
+}
+
+// TestSet_ConcurrentArmAndReplace is the property the whole design rests on:
+// the walk reads while an operator writes. Run with -race.
+func TestSet_ConcurrentArmAndReplace(t *testing.T) {
+	s, _ := NewSet(nil)
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	wg.Add(1)
+	go func() { // the walk
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = s.Armed("wave", BeforeDispatch)
+			}
+		}
+	}()
+	for i := 0; i < 200; i++ { // the operator
+		if err := s.Replace([]string{"wave", "review:after_collection"}); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.Replace(nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+	close(stop)
+	wg.Wait()
+}

--- a/internal/teamrun/breakpoint.go
+++ b/internal/teamrun/breakpoint.go
@@ -104,42 +104,107 @@ type BreakDecision struct {
 // whose operator cannot be reached must not silently release the wave.
 type BreakpointFunc func(ctx context.Context, bp Breakpoint) (BreakDecision, error)
 
-// stage walks a pending count in operator-sized steps.
+// BreakpointSource is what the walk asks whether a state is armed. It is
+// CONSULTED AT EVERY PAUSE POINT, never captured at dispatch — that is the
+// whole interface.
+//
+// Breakpoints began as an argument fixed when the run started, which serves the
+// case where you already know the workflow is broken. It does not serve the
+// common one: you start a run expecting it to work, watch a wave go wrong, and
+// want to stop before the next one. There is nothing to pass at that moment, so
+// "is this armed" has to be a question the walk keeps asking rather than an
+// answer it wrote down.
+//
+// An implementation may therefore change its answers concurrently with the
+// walk, and must be safe for concurrent use.
+type BreakpointSource interface {
+	Armed(state string, phase BreakpointPhase) bool
+}
+
+// StaticBreakpoints is a fixed armed set — the dispatch-time argument, and the
+// behaviour of a walk nobody is watching live.
+type StaticBreakpoints map[string]map[BreakpointPhase]bool
+
+// Armed implements BreakpointSource.
+func (s StaticBreakpoints) Armed(state string, phase BreakpointPhase) bool {
+	return s[state][phase]
+}
+
+// NewStaticBreakpoints builds a fixed source from breakpoint specs, refusing
+// the whole list if any entry is malformed.
+func NewStaticBreakpoints(specs []string) (StaticBreakpoints, error) {
+	if err := ValidateBreakpoints(specs); err != nil {
+		return nil, err
+	}
+	out := StaticBreakpoints{}
+	for _, spec := range specs {
+		id, phase, _ := ParseBreakpoint(spec)
+		if out[id] == nil {
+			out[id] = map[BreakpointPhase]bool{}
+		}
+		if phase == "" {
+			out[id][BeforeDispatch] = true
+			out[id][AfterCollection] = true
+			continue
+		}
+		out[id][phase] = true
+	}
+	return out, nil
+}
+
+// stage walks a shrinking set of pending items in operator-sized steps.
 //
 // It is the shared loop behind both pauses, because "release one, look, release
 // three, look, release the rest" is the same gesture whether what is being
-// released is a dispatch or a publish. act is called with the half-open range
-// to release; ask is called before each step.
-func stage(ctx context.Context, total int, ask func(pending int) (BreakDecision, error), act func(from, to int) error) error {
-	for from := 0; from < total; {
-		dec, err := ask(total - from)
+// released is a dispatch or a publish.
+//
+// pending is RE-READ each round rather than tracked as a range, because the set
+// is not always a suffix: a state armed part-way through a wave holds only the
+// results that had not been published yet, and those are whatever indices
+// happened to still be running.
+func stage(ctx context.Context, pending func() []int, ask func([]int) (BreakDecision, error), act func([]int) error) error {
+	for last := -1; ; {
+		p := pending()
+		if len(p) == 0 {
+			return nil
+		}
+		// act must shrink the pending set; if it ever does not, this would spin
+		// forever asking a human the same question. Fail loudly instead — a
+		// wedged walk is far harder to diagnose than an error naming the bug.
+		if last >= 0 && len(p) >= last {
+			return fmt.Errorf("breakpoint staging made no progress at %d pending — releasing did not retire anything", len(p))
+		}
+		last = len(p)
+
+		dec, err := ask(p)
 		if err != nil {
 			return err
 		}
-		to := total
+		var release []int
 		switch dec.Action {
 		case BreakContinue:
-			// everything remaining
+			release = p
 		case BreakRelease:
 			n := dec.N
 			if n < 1 {
+				// "release some" with no number is a step, not a no-op that
+				// would park forever.
 				n = 1
 			}
-			if from+n < to {
-				to = from + n
+			if n > len(p) {
+				n = len(p)
 			}
+			release = p[:n]
 		default:
 			return fmt.Errorf("aborted at the breakpoint")
 		}
-		if err := act(from, to); err != nil {
+		if err := act(release); err != nil {
 			return err
 		}
-		from = to
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 	}
-	return nil
 }
 
 // ParseBreakpoint splits one breakpoint argument into a state id and the phase
@@ -182,18 +247,21 @@ func ValidateBreakpoints(bps []string) error {
 	return nil
 }
 
-// armed reports whether this state pauses at this phase. A walk with no
-// breakpoints answers false on the first term and never touches the map, so it
-// takes the same path it took before this existed.
+// armed asks the SOURCE, every time — never a value captured when the walk
+// started. That is what lets an operator arm a state while the walk is running.
+//
+// A walk with no breakpoints answers false on the first term and never reaches
+// the source, so it takes the same path it took before any of this existed.
 func (r *agentRunner) armed(st teamgraph.State, phase BreakpointPhase) bool {
-	return r.onBreak != nil && r.breakAt[st.ID][phase]
+	return r.onBreak != nil && r.breakAt != nil && r.breakAt.Armed(st.ID, phase)
 }
 
-// previewPrompts renders the pending half of a wave for the BeforeDispatch
-// pause, in wave order.
-func previewPrompts(h teamgraph.Handler, msgs []ChannelMessage, agentFor func(int) string, from, to int) []PromptPreview {
-	out := make([]PromptPreview, 0, to-from)
-	for i := from; i < to; i++ {
+// previewPrompts renders the pending runs for the BeforeDispatch pause, in wave
+// order. It takes the indices rather than a range because the pending set is
+// not always a suffix.
+func previewPrompts(h teamgraph.Handler, msgs []ChannelMessage, agentFor func(int) string, idx []int) []PromptPreview {
+	out := make([]PromptPreview, 0, len(idx))
+	for _, i := range idx {
 		p := PromptPreview{Index: i, Agent: agentFor(i)}
 		if h.Prompt != nil {
 			p.System, p.Input = h.Prompt.System, h.Prompt.Input
@@ -209,10 +277,11 @@ func previewPrompts(h teamgraph.Handler, msgs []ChannelMessage, agentFor func(in
 	return out
 }
 
-// previewResults renders finished runs for the AfterCollection pause.
-func previewResults(rs []agentResult) []BreakpointResult {
-	out := make([]BreakpointResult, 0, len(rs))
-	for _, res := range rs {
+// previewResults renders the finished runs still awaiting publication.
+func previewResults(all []agentResult, idx []int) []BreakpointResult {
+	out := make([]BreakpointResult, 0, len(idx))
+	for _, i := range idx {
+		res := all[i]
 		out = append(out, BreakpointResult{
 			Index: res.Index, Agent: res.Agent, Ok: res.Ok,
 			Output: res.Output, Error: res.Error,

--- a/internal/teamrun/breakpoint_live_test.go
+++ b/internal/teamrun/breakpoint_live_test.go
@@ -48,10 +48,15 @@ func TestBreakpoint_ArmingMidWalkPausesTheNextWave(t *testing.T) {
 		return BreakDecision{Action: BreakContinue}, nil
 	}
 
-	// Wave 1: nobody has armed anything. It must run straight through.
+	// ONE runner across both waves — the way Walk actually drives a graph that
+	// loops back to its Starter. A test that built a fresh runner for wave 2
+	// would pass even if the source were read once and cached, which is exactly
+	// the bug this is about.
 	ch := threeMessages()
 	r := starterRunner(ch, spawn.fn)
 	WithBreakpoints(src, ask)(r)
+
+	// Wave 1: nobody has armed anything. It must run straight through.
 	if _, err := r.RunHandler(context.Background(), starterState(), &Task{Input: "go", WalkID: "wlk_t"}); err != nil {
 		t.Fatalf("wave 1: %v", err)
 	}
@@ -65,15 +70,12 @@ func TestBreakpoint_ArmingMidWalkPausesTheNextWave(t *testing.T) {
 	// The operator watches that wave, does not like it, and hits Debug.
 	src.arm("wave", BeforeDispatch)
 
-	// Wave 2 — the SAME runner, already constructed — must now pause.
-	ch2 := threeMessages()
-	r2 := starterRunner(ch2, spawn.fn)
-	WithBreakpoints(src, ask)(r2)
-	if _, err := r2.RunHandler(context.Background(), starterState(), &Task{Input: "go", WalkID: "wlk_t"}); err != nil {
+	// Wave 2 on the SAME runner must now pause.
+	if _, err := r.RunHandler(context.Background(), starterState(), &Task{Input: "go", WalkID: "wlk_t"}); err != nil {
 		t.Fatalf("wave 2: %v", err)
 	}
 	if len(pauses) != 1 || pauses[0] != BeforeDispatch {
-		t.Errorf("wave 2 paused %v, want one before_dispatch — arming after dispatch had no effect", pauses)
+		t.Errorf("wave 2 paused %v, want one before_dispatch — the runner cached its arming instead of re-reading it", pauses)
 	}
 }
 

--- a/internal/teamrun/breakpoint_live_test.go
+++ b/internal/teamrun/breakpoint_live_test.go
@@ -1,0 +1,209 @@
+package teamrun
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+)
+
+// mutableSource is a BreakpointSource an operator can change while the walk is
+// running — the in-test stand-in for the run-scoped registry.
+type mutableSource struct {
+	mu sync.RWMutex
+	at map[string]map[BreakpointPhase]bool
+}
+
+func newMutableSource() *mutableSource {
+	return &mutableSource{at: map[string]map[BreakpointPhase]bool{}}
+}
+
+func (m *mutableSource) Armed(state string, phase BreakpointPhase) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.at[state][phase]
+}
+
+func (m *mutableSource) arm(state string, phases ...BreakpointPhase) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.at[state] == nil {
+		m.at[state] = map[BreakpointPhase]bool{}
+	}
+	for _, p := range phases {
+		m.at[state][p] = true
+	}
+}
+
+// TestBreakpoint_ArmingMidWalkPausesTheNextWave is the requirement the
+// dispatch-time argument could not meet: you start a run expecting it to work,
+// watch a wave go wrong, and stop before the next one. Nothing can be passed at
+// that moment, so the walk has to re-read its arming.
+func TestBreakpoint_ArmingMidWalkPausesTheNextWave(t *testing.T) {
+	src := newMutableSource()
+	spawn := &countingSpawn{}
+	var pauses []BreakpointPhase
+	ask := func(_ context.Context, bp Breakpoint) (BreakDecision, error) {
+		pauses = append(pauses, bp.Phase)
+		return BreakDecision{Action: BreakContinue}, nil
+	}
+
+	// Wave 1: nobody has armed anything. It must run straight through.
+	ch := threeMessages()
+	r := starterRunner(ch, spawn.fn)
+	WithBreakpoints(src, ask)(r)
+	if _, err := r.RunHandler(context.Background(), starterState(), &Task{Input: "go", WalkID: "wlk_t"}); err != nil {
+		t.Fatalf("wave 1: %v", err)
+	}
+	if len(pauses) != 0 {
+		t.Fatalf("wave 1 paused %v with nothing armed", pauses)
+	}
+	if got := len(ch.sinks(t)); got != 3 {
+		t.Fatalf("wave 1 published %d sink messages, want 3", got)
+	}
+
+	// The operator watches that wave, does not like it, and hits Debug.
+	src.arm("wave", BeforeDispatch)
+
+	// Wave 2 — the SAME runner, already constructed — must now pause.
+	ch2 := threeMessages()
+	r2 := starterRunner(ch2, spawn.fn)
+	WithBreakpoints(src, ask)(r2)
+	if _, err := r2.RunHandler(context.Background(), starterState(), &Task{Input: "go", WalkID: "wlk_t"}); err != nil {
+		t.Fatalf("wave 2: %v", err)
+	}
+	if len(pauses) != 1 || pauses[0] != BeforeDispatch {
+		t.Errorf("wave 2 paused %v, want one before_dispatch — arming after dispatch had no effect", pauses)
+	}
+}
+
+// TestBreakpoint_ArmingMidWaveHoldsWhatHasNotPublished: arming while a wave is
+// in flight holds the results that have not reached the sink yet. What already
+// went out stays out — the next stage has seen it, and a debugger that claimed
+// otherwise would be lying.
+func TestBreakpoint_ArmingMidWaveHoldsWhatHasNotPublished(t *testing.T) {
+	src := newMutableSource()
+	ch := threeMessages()
+
+	firstDone := make(chan struct{}) // run 0 has returned
+	release := make(chan struct{})   // runs 1+2 may proceed
+	var once sync.Once
+	spawn := func(ctx context.Context, _ string, p Prompt, _ string) (string, error) {
+		if p.DataSlots[StarterMessageSlot] == `{"pr":1}` {
+			once.Do(func() { close(firstDone) })
+			return "first", nil
+		}
+		<-release
+		return "later", nil
+	}
+
+	var seen []BreakpointResult
+	r := starterRunner(ch, spawn)
+	WithBreakpoints(src, func(_ context.Context, bp Breakpoint) (BreakDecision, error) {
+		seen = bp.Results
+		return BreakDecision{Action: BreakContinue}, nil
+	})(r)
+
+	go func() {
+		<-firstDone
+		// Run 0's sink message is already out; arm, then let the rest finish.
+		for len(ch.sinks(t)) == 0 {
+		}
+		src.arm("wave", AfterCollection)
+		close(release)
+	}()
+
+	if _, err := r.RunHandler(context.Background(), starterState(), &Task{Input: "go", WalkID: "wlk_t"}); err != nil {
+		t.Fatalf("starter: %v", err)
+	}
+	// The pause saw only what was still held — never the one already published.
+	if len(seen) != 2 {
+		t.Fatalf("the pause offered %d results, want the 2 that had not published: %+v", len(seen), seen)
+	}
+	for _, res := range seen {
+		if res.Index == 0 {
+			t.Errorf("the pause offered a result that had already reached the sink: %+v", res)
+		}
+	}
+	// And every run still produced exactly one sink message — the count is the
+	// contract, whatever the arming did.
+	if got := len(ch.sinks(t)); got != 3 {
+		t.Errorf("published %d sink messages, want 3", got)
+	}
+}
+
+// TestBreakpoint_DisarmingMidWalkStopsPausing: Debug goes off as well as on.
+func TestBreakpoint_DisarmingMidWalkStopsPausing(t *testing.T) {
+	src := newMutableSource()
+	src.arm("wave", BeforeDispatch)
+	spawn := &countingSpawn{}
+	asks := 0
+
+	ch := threeMessages()
+	r := starterRunner(ch, spawn.fn)
+	WithBreakpoints(src, func(context.Context, Breakpoint) (BreakDecision, error) {
+		asks++
+		// Turn Debug off from inside the pause, the way an operator would.
+		src.mu.Lock()
+		src.at = map[string]map[BreakpointPhase]bool{}
+		src.mu.Unlock()
+		return BreakDecision{Action: BreakRelease, N: 1}, nil
+	})(r)
+	if _, err := r.RunHandler(context.Background(), starterState(), &Task{Input: "go", WalkID: "wlk_t"}); err != nil {
+		t.Fatalf("starter: %v", err)
+	}
+	// It asked once; with the state disarmed, the remaining two dispatched
+	// without another pause.
+	if asks != 1 {
+		t.Errorf("asked %d times, want 1 — disarming mid-pause must stop the staging", asks)
+	}
+	if spawn.count() != 3 {
+		t.Errorf("spawned %d, want 3 — disarming must release the rest, not strand them", spawn.count())
+	}
+}
+
+// TestStage_RefusesToSpinWhenNothingRetires: a release that does not shrink the
+// pending set would ask a human the same question forever. A wedged walk is far
+// harder to diagnose than an error naming the bug.
+func TestStage_RefusesToSpinWhenNothingRetires(t *testing.T) {
+	pending := func() []int { return []int{0, 1} } // never shrinks
+	err := stage(context.Background(), pending,
+		func([]int) (BreakDecision, error) { return BreakDecision{Action: BreakRelease, N: 1}, nil },
+		func([]int) error { return nil })
+	if err == nil {
+		t.Fatal("stage looped on a pending set that never shrank instead of failing")
+	}
+}
+
+// TestStage_ReleasesNonContiguousIndices: the pending set is not always a
+// suffix — a mid-wave arm holds whichever runs happened to still be going.
+func TestStage_ReleasesNonContiguousIndices(t *testing.T) {
+	done := map[int]bool{}
+	pending := func() []int {
+		var out []int
+		for _, i := range []int{1, 4, 7} {
+			if !done[i] {
+				out = append(out, i)
+			}
+		}
+		return out
+	}
+	var released []int
+	err := stage(context.Background(), pending,
+		func([]int) (BreakDecision, error) { return BreakDecision{Action: BreakRelease, N: 2}, nil },
+		func(idx []int) error {
+			released = append(released, idx...)
+			for _, i := range idx {
+				done[i] = true
+			}
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("stage: %v", err)
+	}
+	if len(released) != 3 || released[0] != 1 || released[1] != 4 || released[2] != 7 {
+		t.Errorf("released %v, want [1 4 7] in order", released)
+	}
+}
+
+var _ = json.Marshal

--- a/internal/teamrun/breakpoint_test.go
+++ b/internal/teamrun/breakpoint_test.go
@@ -51,8 +51,12 @@ func (c *countingSpawn) count() int {
 
 func breakRunner(t *testing.T, ch *fakeChannels, spawn SpawnFunc, states []string, f BreakpointFunc) *agentRunner {
 	t.Helper()
+	src, err := NewStaticBreakpoints(states)
+	if err != nil {
+		t.Fatalf("NewStaticBreakpoints(%v): %v", states, err)
+	}
 	r := starterRunner(ch, spawn)
-	WithBreakpoints(states, f)(r)
+	WithBreakpoints(src, f)(r)
 	return r
 }
 

--- a/internal/teamrun/spawn.go
+++ b/internal/teamrun/spawn.go
@@ -132,15 +132,18 @@ type agentRunner struct {
 	// internal/connector, and teamrun importing that would undo the dependency
 	// contract this package is built on.
 	maxWave int
-	// breakAt is the set of state ids the operator armed, and onBreak is how
-	// they are asked. BOTH come from the RUN, never from the definition: a
-	// `debug: true` in a def would change its content hash, so turning the
-	// debugger on would fork the workflow — and then the thing being debugged
-	// is not the thing that runs in production.
+	// breakAt is where the operator's arming is READ FROM — consulted at every
+	// pause, never captured at dispatch, so a state can be armed while the walk
+	// is already running. onBreak is how the pause is asked.
 	//
-	// Empty breakAt means no state ever asks, so a walk without breakpoints
-	// takes byte-identical paths to one from before this existed.
-	breakAt map[string]map[BreakpointPhase]bool
+	// BOTH come from the RUN, never from the definition: a `debug: true` in a
+	// def would change its content hash, so turning the debugger on would fork
+	// the workflow — and then the thing being debugged is not the thing that
+	// runs in production.
+	//
+	// A nil source means no state ever asks, so a walk without breakpoints takes
+	// byte-identical paths to one from before this existed.
+	breakAt BreakpointSource
 	onBreak BreakpointFunc
 }
 
@@ -165,36 +168,19 @@ func WithMaxWave(n int) RunnerOption {
 	return func(r *agentRunner) { r.maxWave = n }
 }
 
-// WithBreakpoints arms debug pauses on the named Starter states.
+// WithBreakpoints wires the debug pauses: where the arming is read from, and
+// how a pause is asked.
 //
-// A RUN argument by construction: the caller passes the state ids it was given
-// for THIS run, so the same promoted definition runs straight through in
-// production and paused in a canvas.
-func WithBreakpoints(states []string, f BreakpointFunc) RunnerOption {
+// A RUN argument by construction — the caller supplies both for THIS run, so
+// the same promoted definition runs straight through in production and paused
+// in a canvas. The source is consulted at every pause rather than read once, so
+// a caller holding a live set can arm a state after the walk has started.
+func WithBreakpoints(src BreakpointSource, f BreakpointFunc) RunnerOption {
 	return func(r *agentRunner) {
-		if len(states) == 0 || f == nil {
+		if src == nil || f == nil {
 			return
 		}
-		r.breakAt = make(map[string]map[BreakpointPhase]bool, len(states))
-		for _, s := range states {
-			id, phase, ok := ParseBreakpoint(s)
-			if !ok {
-				continue // refused at the run boundary; skipped here as belt
-			}
-			if r.breakAt[id] == nil {
-				r.breakAt[id] = map[BreakpointPhase]bool{}
-			}
-			if phase == "" {
-				r.breakAt[id][BeforeDispatch] = true
-				r.breakAt[id][AfterCollection] = true
-				continue
-			}
-			r.breakAt[id][phase] = true
-		}
-		if len(r.breakAt) == 0 {
-			r.breakAt = nil
-			return
-		}
+		r.breakAt = src
 		r.onBreak = f
 	}
 }

--- a/internal/teamrun/starter.go
+++ b/internal/teamrun/starter.go
@@ -216,13 +216,21 @@ func (r *agentRunner) runWave(ctx context.Context, st teamgraph.State, task *Tas
 	var mu sync.Mutex // guards successes and published
 	successes := 0
 
-	// The sink publish is DEFERRED when this state is armed at AfterCollection:
-	// the operator is reviewing the wave, and the next stage must not see a
-	// result they have not released. It is a deferral, never a durable cache —
-	// the runs themselves hold the outputs, and if this process dies while
-	// parked, no sink message arrives: the orchestrator-died-mid-wave case the
-	// design already documents and the downstream wait_ms already backstops.
-	deferPublish := r.armed(st, AfterCollection)
+	// Whether a result may reach the sink is asked LIVE, at the moment it would
+	// be published — not latched when the wave started. A state armed part-way
+	// through a wave therefore holds whatever has not gone out yet, which is the
+	// case an operator is in when they watch a wave go wrong and hit Debug.
+	//
+	// What has already been published stays published: the next stage has seen
+	// it, and pretending otherwise would be a debugger that lies. So arming
+	// mid-wave holds a SUFFIX of the wave in the general case, and the whole
+	// wave when it was armed before dispatch.
+	//
+	// It is a deferral either way, never a durable cache — the runs themselves
+	// hold the outputs, and if this process dies while parked, no sink message
+	// arrives: the orchestrator-died-mid-wave case the design already documents
+	// and the downstream wait_ms already backstops.
+	holdSink := func() bool { return r.armed(st, AfterCollection) }
 
 	// A staged dispatch must not short-circuit. The wait threshold exists to
 	// stop runs nobody is waiting for, but an operator stepping through a wave
@@ -244,10 +252,25 @@ func (r *agentRunner) runWave(ctx context.Context, st teamgraph.State, task *Tas
 		mu.Unlock()
 		r.publishSink(ctx, st, waveID, dispatches, results[i])
 	}
+	// unpublished is the pending set for the AfterCollection pause. Recomputed
+	// rather than tracked, because which indices are still held depends on when
+	// the operator armed the state.
+	unpublished := func() []int {
+		mu.Lock()
+		defer mu.Unlock()
+		var out []int
+		for i := range published {
+			if !published[i] {
+				out = append(out, i)
+			}
+		}
+		return out
+	}
 
-	dispatch := func(from, to int) error {
+	dispatched := 0
+	dispatch := func(idx []int) error {
 		var wg sync.WaitGroup
-		for i := from; i < to; i++ {
+		for _, i := range idx {
 			i := i
 			agent := agentFor(i)
 			slots := waveSlots(h, msgs, i)
@@ -261,7 +284,7 @@ func (r *agentRunner) runWave(ctx context.Context, st teamgraph.State, task *Tas
 					// Cancelled before it ever ran — still a result, and still
 					// a sink message, because the count is the contract.
 					results[i] = agentResult{Index: i, Agent: agent, Ok: false, Error: runCtx.Err().Error()}
-					if !deferPublish {
+					if !holdSink() {
 						emit(i)
 					}
 					return
@@ -276,52 +299,73 @@ func (r *agentRunner) runWave(ctx context.Context, st teamgraph.State, task *Tas
 					}
 				}
 				mu.Unlock()
-				if !deferPublish {
+				if !holdSink() {
 					emit(i)
 				}
 			}()
 		}
 		wg.Wait()
+		dispatched += len(idx)
 		return nil
+	}
+	pendingDispatch := func() []int {
+		out := make([]int, 0, dispatches-dispatched)
+		for i := dispatched; i < dispatches; i++ {
+			out = append(out, i)
+		}
+		return out
 	}
 
 	// PAUSE 1 — before_dispatch. Every prompt is composed and nothing has run.
 	if r.armed(st, BeforeDispatch) {
-		err = stage(ctx, dispatches,
-			func(pending int) (BreakDecision, error) {
+		err = stage(ctx, pendingDispatch,
+			func(idx []int) (BreakDecision, error) {
+				// Disarmed while parked — the operator turned Debug off. That
+				// means RELEASE the rest, never abandon it: the runs still owe
+				// the sink a message each, and a wave that silently came up
+				// short would hang a downstream fan-in.
+				if !r.armed(st, BeforeDispatch) {
+					return BreakDecision{Action: BreakContinue}, nil
+				}
 				return r.onBreak(ctx, Breakpoint{
 					State: st.ID, Phase: BeforeDispatch, Wave: waveID,
-					WaveSize: dispatches, Pending: pending,
-					Prompts: previewPrompts(h, msgs, agentFor, dispatches-pending, dispatches),
+					WaveSize: dispatches, Pending: len(idx),
+					Prompts: previewPrompts(h, msgs, agentFor, idx),
 				})
 			}, dispatch)
 	} else {
-		err = dispatch(0, dispatches)
+		err = dispatch(pendingDispatch())
 	}
 	if err != nil {
 		return results, err
 	}
 
-	// PAUSE 2 — after_collection. The wave is complete and the sink is empty.
+	// PAUSE 2 — after_collection. The wave is complete; whatever the live check
+	// held back is still off the sink.
 	//
 	// Aborting here publishes NOTHING further, and that is the point: an
 	// operator who rejects a wave is saying the next stage must not see it. A
 	// flush-on-abort would make the one thing this breakpoint exists to do —
-	// withhold a result — untrue. Runs already released in an earlier step stay
-	// published, because the operator released them. Nothing downstream is left
-	// hanging either way: the abort fails the walk, so there is no next stage.
-	if deferPublish {
-		if err := stage(ctx, dispatches,
-			func(pending int) (BreakDecision, error) {
-				from := dispatches - pending
+	// withhold a result — untrue. Runs already released stay published, because
+	// the operator released them (or the state was not yet armed when they
+	// went out). Nothing downstream is left hanging either way: the abort fails
+	// the walk, so there is no next stage.
+	if r.armed(st, AfterCollection) {
+		if err := stage(ctx, unpublished,
+			func(idx []int) (BreakDecision, error) {
+				// Same rule as the dispatch pause: disarming publishes the rest
+				// rather than withholding it forever.
+				if !r.armed(st, AfterCollection) {
+					return BreakDecision{Action: BreakContinue}, nil
+				}
 				return r.onBreak(ctx, Breakpoint{
 					State: st.ID, Phase: AfterCollection, Wave: waveID,
-					WaveSize: dispatches, Pending: pending,
-					Results: previewResults(results[from:]),
+					WaveSize: dispatches, Pending: len(idx),
+					Results: previewResults(results, idx),
 				})
 			},
-			func(from, to int) error {
-				for i := from; i < to; i++ {
+			func(idx []int) error {
+				for _, i := range idx {
 					emit(i)
 				}
 				return nil

--- a/internal/tools/builtin/teamdef.go
+++ b/internal/tools/builtin/teamdef.go
@@ -113,6 +113,21 @@ type TeamDef struct {
 	// is omitted from the report rather than reported as failing.
 	AgentExists func(ctx context.Context, name string) bool
 
+	// LiveBreakpoints, if set, opens the MUTABLE armed set for this run's walk,
+	// seeded with the run argument, and returns it plus the release to call when
+	// the walk ends.
+	//
+	// It is what makes ad-hoc debugging possible. A breakpoint set captured at
+	// dispatch only serves an operator who already knows the workflow is broken;
+	// the common case is starting a run that you expect to work, watching a wave
+	// go wrong, and wanting to stop before the next one. There is nothing to
+	// pass at that moment, so the walk has to read an armed set something else
+	// can still write to.
+	//
+	// nil = breakpoints are dispatch-time only (the run argument still works,
+	// and nothing can arm a state once the walk has started).
+	LiveBreakpoints func(ctx context.Context, seed []string) (teamrun.BreakpointSource, func(), error)
+
 	// AskHuman, if set, escalates an iteration-cap overflow to a human instead of
 	// aborting: when the caller passes interrupt_on_cap, a capped state raises an
 	// Interruption `ask` (this closure blocks until answered/timed-out/cancelled)
@@ -892,7 +907,21 @@ func (t *TeamDef) execRun(ctx context.Context, in teamDefInput) (tools.Result, e
 		if t.AskHuman == nil {
 			return errResult("run: breakpoints require the Interruption machinery, which is not wired on this server"), nil
 		}
-		runnerOpts = append(runnerOpts, teamrun.WithBreakpoints(in.Breakpoints,
+	}
+	// The armed set is opened for EVERY run that could be asked, not only one
+	// that passed `breakpoints`. A run that starts with none is exactly the run
+	// an operator later wants to debug, and if the set only existed when it was
+	// seeded there would be nothing for them to arm.
+	//
+	// An empty set answers false for every state, so a walk nobody arms takes
+	// the same path it took before any of this existed.
+	if t.AskHuman != nil {
+		src, release, serr := t.openBreakpoints(ctx, in.Breakpoints)
+		if serr != nil {
+			return errResult(fmt.Sprintf("run: %s", serr)), nil
+		}
+		defer release()
+		runnerOpts = append(runnerOpts, teamrun.WithBreakpoints(src,
 			func(c context.Context, bp teamrun.Breakpoint) (teamrun.BreakDecision, error) {
 				breaks++
 				answer, aerr := t.AskHuman(c, formatBreakpoint(row.Name, bp))
@@ -950,7 +979,10 @@ func (t *TeamDef) execRun(ctx context.Context, in teamDefInput) (tools.Result, e
 				m["cap_decision"] = lastDecision
 			}
 		}
-		if len(in.Breakpoints) > 0 {
+		// Reported when the walk actually paused — not when `breakpoints` was
+		// passed. A walk armed mid-run passed nothing and still paused, and a
+		// walk that was armed but never reached the state paused nothing.
+		if breaks > 0 {
 			m["breakpoints_hit"] = breaks
 			if lastBreak != "" {
 				m["break_decision"] = lastBreak
@@ -1021,6 +1053,24 @@ func capActionLabel(d teamrun.CapDecision) string {
 	default:
 		return "abort"
 	}
+}
+
+// openBreakpoints returns the armed set the walk will consult, plus the release
+// to call when it ends.
+//
+// With LiveBreakpoints wired the set is MUTABLE and addressable while the walk
+// runs; without it the run argument still works exactly as before, fixed at
+// dispatch. Degrading rather than refusing is right here — the dispatch-time
+// behaviour is the feature this replaces, not a broken half of it.
+func (t *TeamDef) openBreakpoints(ctx context.Context, seed []string) (teamrun.BreakpointSource, func(), error) {
+	if t.LiveBreakpoints != nil {
+		return t.LiveBreakpoints(ctx, seed)
+	}
+	src, err := teamrun.NewStaticBreakpoints(seed)
+	if err != nil {
+		return nil, nil, err
+	}
+	return src, func() {}, nil
 }
 
 // maxBreakPreview bounds ONE previewed prompt or output in the question text.

--- a/internal/tools/builtin/teamdef_breakpoint_test.go
+++ b/internal/tools/builtin/teamdef_breakpoint_test.go
@@ -259,3 +259,41 @@ func TestFormatBreakpoint_TruncatesAnOversizedPreview(t *testing.T) {
 		t.Errorf("a truncated preview must say so:\n%s", q)
 	}
 }
+
+// TestTeamDefTool_Run_OpensALiveSetEvenWithNoBreakpoints: the run that an
+// operator later wants to debug is precisely the run that passed no
+// breakpoints. If the armed set only existed when it was seeded, ad-hoc
+// Run → Debug would have nothing to write to.
+func TestTeamDefTool_Run_OpensALiveSetEvenWithNoBreakpoints(t *testing.T) {
+	tool, ctx, io, _, done := breakFixture(t)
+	defer done()
+	tool.AskHuman = func(context.Context, string) (string, error) { return "continue", nil }
+
+	opened, released := 0, 0
+	var seenSeed []string
+	tool.LiveBreakpoints = func(_ context.Context, seed []string) (teamrun.BreakpointSource, func(), error) {
+		opened++
+		seenSeed = seed
+		src, err := teamrun.NewStaticBreakpoints(seed)
+		return src, func() { released++ }, err
+	}
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"run","name":"triage","input":"x"}`))
+	if res.IsError {
+		t.Fatalf("run: %s", res.Text)
+	}
+	if opened != 1 {
+		t.Fatalf("a run that armed nothing opened %d live sets, want 1 — there would be nothing to arm mid-run", opened)
+	}
+	if len(seenSeed) != 0 {
+		t.Errorf("seed = %v, want empty", seenSeed)
+	}
+	// And it is released when the walk ends — a set outliving its walk would
+	// pause a later run nobody is watching.
+	if released != 1 {
+		t.Errorf("released %d times, want 1", released)
+	}
+	if io.count() != 2 {
+		t.Errorf("published %d sink messages, want 2 — an unarmed run must be unaffected", io.count())
+	}
+}


### PR DESCRIPTION
## Why

Breakpoints shipped in #1197 as an argument fixed at dispatch. The loomboard team flagged that as blocking the canvas: you start a run expecting it to work, watch a wave go wrong, and want to stop before the next one — and there is nothing to pass at that moment.

Fixing that surfaced a second, worse problem. **loomboard drives loomcycle through the TS adapter over HTTP**, and on that path the feature was not merely unreachable — arming a breakpoint **killed the walk**:

```
POST /v1/_teamdef {"op":"run","name":"triage","breakpoints":["wave"]}
→ "run: teamrun: state \"wave\" … wave: aborted at the breakpoint"
```

`POST /v1/_teamdef` dispatches under `substrateAdminCtx` — no run id, no Interruption policy. The pause asks through `Interruption op=ask`, which needs both, so the ask errored, and by design an unanswerable pause fails safe to abort.

And underneath *that*: `op=run` over HTTP is **synchronous**. The caller learns nothing until the walk is over, so it never holds a handle for a walk that is still running. No endpoint fixes that.

## What

**1 — the armed set is re-read, not captured.** The walk holds a `BreakpointSource` it asks at every pause; a run-scoped registry (`internal/breakpoints`, mirroring `internal/turncancel`) holds the live set, and `PUT/GET /v1/runs/{run_id}/breakpoints` mutates it mid-walk. The set is opened for **every** run, not only one that passed `breakpoints` — a run that starts with Debug off is exactly the one you later want to debug.

**2 — a team walk is a RUN.** `op=run` opens a session and a `runs` row (filed `team:<name>`), stamps the run id on the walk ctx, grants the Interruption policy the pause needs, and finishes the row with the walk's status and error.

Everything that makes a walk observable or controllable is addressed by run id — the breakpoint set, the ask, cancel, the event stream. A walk that had no run had no handle, so none of them could reach it. That was never a gap in any one of them; it was the walk not being a first-class unit of work. It is also the handle L7 live status needs next.

**3 — `mode: "detach"`** returns `{run_id, status:"running"}` immediately and continues the walk behind the caller, detached with `context.WithoutCancel` so it keeps the request's values without dying when the handler returns. Omitting `mode` keeps the synchronous behaviour *and* still returns `run_id`.

### Semantics worth reviewing

| | |
|---|---|
| **When an arm takes effect** | the next pause the walk reaches |
| **Arming mid-wave** | holds whatever has **not published yet** — the hold is asked live |
| **Already-published results** | stay published; the next stage has seen them |
| **Disarming** | **releases** everything pending, never abandons it |
| **PUT, not deltas** | no read-modify-write race; `[]` is the off switch; validated **before** the mutation |

`stage` now walks a shrinking pending **set** rather than a suffix range, because which runs are held depends on when the operator armed.

### Things that needed care

- **The breakpoint release is not deferred.** A detached walk outlives `Execute`; releasing on return would unregister the armed set the moment the caller got its run id — leaving a running walk nobody could arm.
- **`mode=detach` with no run tracking is refused**, not run inline: a caller that asked for a handle and got a finished walk cannot notice.
- **Disarming mid-pause kept asking** in the first draft — a real bug, caught by its own test.
- The registry is **nil-safe**, so a `Server` assembled without one degrades to dispatch-time arming instead of panicking inside a live walk.

### Limits, deliberate and stated

Single-replica (another replica → a loud `404 no_live_walk`); nothing persisted; **no resume-after-restart** — which also corrects RFC CY, whose earlier text promised a parked walk would reconstruct its wave from the runs. That was a design sketch, never built.

## Verified over the canvas's own transport

```
POST /v1/_teamdef {"op":"run","mode":"detach","breakpoints":["wave"]}
→ {"run_id":"r_d4c3fb…","status":"running"}          ← immediately
GET  /v1/runs/r_d4c3fb…/breakpoints
→ {"armed":["wave:after_collection","wave:before_dispatch"]}
GET  /v1/runs/r_d4c3fb…/interrupts
→ pending question: 'paused BEFORE dispatching wave wav_3ebf17… (2 runs, 2 pending)
   [0] reviewer ← {"pr":1}   [1] reviewer ← {"pr":2}'
POST …/interrupts/{id}/resolve {"answer":"release:1"}
→ dispatches ONE, parks again reporting "1 pending"
```

The run row lands as `team:triage` / `failed` with the walk's error. Refusals also checked: `404 no_live_walk` for an unknown run (same code as a cross-tenant one — no existence oracle), `400` on a bad run id, `401` unauthenticated.

## Tested

`go build ./...`, `go vet ./...`, `gofmt -l` clean, **`go test ./...` green (111 packages)**, `-race` on `teamrun` + `breakpoints`. All twelve breakpoint tests from #1197 pass unchanged.

**Fail-before — twelve claims across the two halves, each red against its own break.** Live arming: the runner caching its arming · the sink hold latched at wave start · disarming that keeps asking · `Replace` mutating before validating · the live set opened only when seeded · diverging phase spellings. Walk-is-a-run: no Interruption grant · no run id on the walk ctx · detach not detaching the ctx · detach running inline · a deferred breakpoint release · detach silently degrading.

**Four were vacuous on the first attempt**, all because the test did not model the real path — e.g. the mid-walk test built a *fresh* runner for the second wave, so a runner that cached its arming still looked correct. Fixed in follow-up commits.

## RFCs updated

- **CY**: *"Decision 4 amended (2) — breakpoints are armed LIVE"* and *"(3) — a team walk is a RUN"*, the latter naming the false assumption both earlier amendments rested on (that `op=run` always happens inside a run).
- **CZ**: the verified contract, with each line marked as executed. My first note said "dependency cleared" and was wrong on their transport; it has been corrected in place.

**Follow-up, as agreed:** the TS adapter surface (`runTeam` gaining `mode`/`breakpoints`, plus the arming calls) is a separate PR, with the `@loomcycle/client` version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD