### PR TITLE
fix(memory): home existing facts under their subjects, and stop the leak that blocked it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,7 +249,7 @@ jobs:
           # and `go test ./...` cannot run both packages against it concurrently.
           # Add every new postgres-tier test in this package here, or it is
           # decoration rather than a gate.
-          go test -count=1 -run 'TestEmbedDirective|TestEncodePgvector|TestResolveEmbedArgs|TestMemorySQL_EmbedDirective|TestDocument_Postgres|TestDocumentTags_CoreBothTiers|TestDocumentNameLinks_CoreBothTiers|TestDocumentHistory_|TestDocumentBacklinks_|TestDocumentUnlinkedMentions_|TestDocumentCanvas_|TestSidecar_PostgresTierParity|TestUpsert_ReObservation|TestConfidence_|TestVerdict_PostgresTier|TestVerificationStats_PostgresTier' ./internal/tools/builtin/...
+          go test -count=1 -run 'TestEmbedDirective|TestEncodePgvector|TestResolveEmbedArgs|TestMemorySQL_EmbedDirective|TestDocument_Postgres|TestDocumentTags_CoreBothTiers|TestDocumentNameLinks_CoreBothTiers|TestDocumentHistory_|TestDocumentBacklinks_|TestDocumentUnlinkedMentions_|TestDocumentCanvas_|TestSidecar_PostgresTierParity|TestUpsert_ReObservation|TestConfidence_|TestVerdict_PostgresTier|TestVerificationStats_PostgresTier|TestHomeFactsUnderSubjects_PostgresTierParity' ./internal/tools/builtin/...
 
   runtime-codejs:
     name: Runtime suites (code-js)

--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -639,6 +639,7 @@ agents:
           proposed_names: {},       // name -> true, so one pass proposes a type once
           owner_names: null,        // the target's DECLARED names, resolved once per pass
           entity_nodes: 0,          // distinct subjects given an entity chunk
+          subject_doc_unavailable: 0, // subjects filed in the shared document instead of their own
           entity_facts: 0,          // facts mirrored into the graph
           // The judge's candidates, in WRITE ORDER. An array rather than a map
           // because this body re-executes from the top on every turn and must be a
@@ -2530,6 +2531,36 @@ agents:
         return out;
       }
 
+      // homeFor answers "which document does a fact about this subject go in", and
+      // ALWAYS answers if the graph can be written at all.
+      //
+      // The preferred answer is the subject's own document. The fallback is the shared
+      // entity document with the subject as a sibling node — the shape this pass wrote
+      // before subject-homing — and it exists because a scope written in that shape
+      // CANNOT adopt the new one on its own: natural_key is unique per scope, so while
+      // the old node holds `person:denn` the document claiming the same key cannot be
+      // created. Without a fallback every fact about an already-known subject would be
+      // stored with NO `about` edge, which is a fact unreachable from the person it is
+      // about — the one failure the entity tier exists to prevent. The migration
+      // (op home_facts on the memory admin surface) moves those nodes into their own
+      // documents, after which this never fires again.
+      //
+      // Counted separately from entity_failed: a fallback is a store awaiting migration,
+      // not a broken write, and an operator reading "N graph writes failed" would go
+      // looking for the wrong thing.
+      function homeFor(st, scope, sharedDoc, subjType, subjName) {
+        var home = subjectDoc(st, scope, subjType, subjName);
+        if (home) { return home; }
+        var subjKey = entityKey(subjType, subjName);
+        var isNew = !st.entity_ids[scope + "\u0000" + subjKey];
+        var id = upsertEntityChunk(st, scope, sharedDoc, subjKey, {
+          title: subjName, type: subjType, subject: subjName
+        });
+        if (!id) { return null; }
+        if (isNew) { st.entity_nodes++; st.subject_doc_unavailable++; }
+        return { doc: sharedDoc, root: id };
+      }
+
       // nonEmpty reports a USABLE string field — present, a string, and not merely
       // whitespace. The extractor omits a key, sends null, and sends "" for the same
       // "I do not know", so all three have to read the same way.
@@ -2620,7 +2651,7 @@ agents:
           // subject is one node however many ways the extractor spells its kind.
           var subjType = canonicalType(st, scope, proposed, fact.subject);
           var subjKey = entityKey(subjType, fact.subject);
-          var home = subjectDoc(st, scope, subjType, fact.subject);
+          var home = homeFor(st, scope, docID, subjType, fact.subject);
           if (home) { homeDoc = home.doc; subjID = home.root; }
           // UNDECLARED TYPE: the write was refused because the tenant does not declare this
           // kind. File the kind as an inert candidate an operator can accept, then retry under
@@ -2637,7 +2668,7 @@ agents:
             // retries the same /facts/<slug> document under a type the tenant
             // declares. The memo is dropped so the retry is actually attempted.
             delete st.subject_docs[scope + "\u0000" + slug(normalizeSubject(fact.subject))];
-            var retry = subjectDoc(st, scope, subjType, fact.subject);
+            var retry = homeFor(st, scope, docID, subjType, fact.subject);
             if (retry) { homeDoc = retry.doc; subjID = retry.root; }
           }
           // A REFUSED subject write no longer costs the fact its chunk either. The
@@ -3349,6 +3380,11 @@ agents:
             ent += ", " + st.entity_failed + " graph write(s) failed";
             // The reason, because the transcript of an internal agent cannot be read back.
             if (st.entity_error) { ent += " (first: " + String(st.entity_error).slice(0, 220) + ")"; }
+          }
+          if (st.subject_doc_unavailable) {
+            ent += ", " + st.subject_doc_unavailable + " subject(s) still filed in the shared " +
+              "document because their node predates per-subject documents — move them with the " +
+              "home_facts operation on the memory admin surface";
           }
           if (st.type_fell_back) {
             ent += ", " + st.type_fell_back + " subject(s) filed under " + ENTITY_FALLBACK_TYPE +

--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -2523,7 +2523,12 @@ agents:
               st.entity_nodes++;
             }
           } catch (e2) {
-            st.entity_failed++;
+            // RECORDED, NOT COUNTED. The text has to land in st.entity_error because
+            // undeclaredTypeRefusal reads it to decide whether to retry under the
+            // fallback type. But a failure HERE is not yet a failure: homeFor falls
+            // back to the shared entity document, and if that lands then no fact lost
+            // its edge and nothing should read as a broken write. Whoever cannot
+            // recover counts it — upsertEntityChunk does, on the fallback path.
             if (!st.entity_error) { st.entity_error = errText(e2); }
           }
         }
@@ -2545,9 +2550,11 @@ agents:
       // (op home_facts on the memory admin surface) moves those nodes into their own
       // documents, after which this never fires again.
       //
-      // Counted separately from entity_failed: a fallback is a store awaiting migration,
-      // not a broken write, and an operator reading "N graph writes failed" would go
-      // looking for the wrong thing.
+      // A SUCCESSFUL FALLBACK IS NOT A FAILURE. It is counted on its own line, and
+      // st.entity_failed stays where it belongs — on writes that landed nowhere.
+      // An operator reading "N graph writes failed" would go looking for a broken
+      // Document tool; the real answer is a store that has not been migrated yet, and
+      // the two need opposite actions.
       function homeFor(st, scope, sharedDoc, subjType, subjName) {
         var home = subjectDoc(st, scope, subjType, subjName);
         if (home) { return home; }

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -639,6 +639,7 @@ agents:
           proposed_names: {},       // name -> true, so one pass proposes a type once
           owner_names: null,        // the target's DECLARED names, resolved once per pass
           entity_nodes: 0,          // distinct subjects given an entity chunk
+          subject_doc_unavailable: 0, // subjects filed in the shared document instead of their own
           entity_facts: 0,          // facts mirrored into the graph
           // The judge's candidates, in WRITE ORDER. An array rather than a map
           // because this body re-executes from the top on every turn and must be a
@@ -2530,6 +2531,36 @@ agents:
         return out;
       }
 
+      // homeFor answers "which document does a fact about this subject go in", and
+      // ALWAYS answers if the graph can be written at all.
+      //
+      // The preferred answer is the subject's own document. The fallback is the shared
+      // entity document with the subject as a sibling node — the shape this pass wrote
+      // before subject-homing — and it exists because a scope written in that shape
+      // CANNOT adopt the new one on its own: natural_key is unique per scope, so while
+      // the old node holds `person:denn` the document claiming the same key cannot be
+      // created. Without a fallback every fact about an already-known subject would be
+      // stored with NO `about` edge, which is a fact unreachable from the person it is
+      // about — the one failure the entity tier exists to prevent. The migration
+      // (op home_facts on the memory admin surface) moves those nodes into their own
+      // documents, after which this never fires again.
+      //
+      // Counted separately from entity_failed: a fallback is a store awaiting migration,
+      // not a broken write, and an operator reading "N graph writes failed" would go
+      // looking for the wrong thing.
+      function homeFor(st, scope, sharedDoc, subjType, subjName) {
+        var home = subjectDoc(st, scope, subjType, subjName);
+        if (home) { return home; }
+        var subjKey = entityKey(subjType, subjName);
+        var isNew = !st.entity_ids[scope + "\u0000" + subjKey];
+        var id = upsertEntityChunk(st, scope, sharedDoc, subjKey, {
+          title: subjName, type: subjType, subject: subjName
+        });
+        if (!id) { return null; }
+        if (isNew) { st.entity_nodes++; st.subject_doc_unavailable++; }
+        return { doc: sharedDoc, root: id };
+      }
+
       // nonEmpty reports a USABLE string field — present, a string, and not merely
       // whitespace. The extractor omits a key, sends null, and sends "" for the same
       // "I do not know", so all three have to read the same way.
@@ -2620,7 +2651,7 @@ agents:
           // subject is one node however many ways the extractor spells its kind.
           var subjType = canonicalType(st, scope, proposed, fact.subject);
           var subjKey = entityKey(subjType, fact.subject);
-          var home = subjectDoc(st, scope, subjType, fact.subject);
+          var home = homeFor(st, scope, docID, subjType, fact.subject);
           if (home) { homeDoc = home.doc; subjID = home.root; }
           // UNDECLARED TYPE: the write was refused because the tenant does not declare this
           // kind. File the kind as an inert candidate an operator can accept, then retry under
@@ -2637,7 +2668,7 @@ agents:
             // retries the same /facts/<slug> document under a type the tenant
             // declares. The memo is dropped so the retry is actually attempted.
             delete st.subject_docs[scope + "\u0000" + slug(normalizeSubject(fact.subject))];
-            var retry = subjectDoc(st, scope, subjType, fact.subject);
+            var retry = homeFor(st, scope, docID, subjType, fact.subject);
             if (retry) { homeDoc = retry.doc; subjID = retry.root; }
           }
           // A REFUSED subject write no longer costs the fact its chunk either. The
@@ -3349,6 +3380,11 @@ agents:
             ent += ", " + st.entity_failed + " graph write(s) failed";
             // The reason, because the transcript of an internal agent cannot be read back.
             if (st.entity_error) { ent += " (first: " + String(st.entity_error).slice(0, 220) + ")"; }
+          }
+          if (st.subject_doc_unavailable) {
+            ent += ", " + st.subject_doc_unavailable + " subject(s) still filed in the shared " +
+              "document because their node predates per-subject documents — move them with the " +
+              "home_facts operation on the memory admin surface";
           }
           if (st.type_fell_back) {
             ent += ", " + st.type_fell_back + " subject(s) filed under " + ENTITY_FALLBACK_TYPE +

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -2523,7 +2523,12 @@ agents:
               st.entity_nodes++;
             }
           } catch (e2) {
-            st.entity_failed++;
+            // RECORDED, NOT COUNTED. The text has to land in st.entity_error because
+            // undeclaredTypeRefusal reads it to decide whether to retry under the
+            // fallback type. But a failure HERE is not yet a failure: homeFor falls
+            // back to the shared entity document, and if that lands then no fact lost
+            // its edge and nothing should read as a broken write. Whoever cannot
+            // recover counts it — upsertEntityChunk does, on the fallback path.
             if (!st.entity_error) { st.entity_error = errText(e2); }
           }
         }
@@ -2545,9 +2550,11 @@ agents:
       // (op home_facts on the memory admin surface) moves those nodes into their own
       // documents, after which this never fires again.
       //
-      // Counted separately from entity_failed: a fallback is a store awaiting migration,
-      // not a broken write, and an operator reading "N graph writes failed" would go
-      // looking for the wrong thing.
+      // A SUCCESSFUL FALLBACK IS NOT A FAILURE. It is counted on its own line, and
+      // st.entity_failed stays where it belongs — on writes that landed nowhere.
+      // An operator reading "N graph writes failed" would go looking for a broken
+      // Document tool; the real answer is a store that has not been migrated yet, and
+      // the two need opposite actions.
       function homeFor(st, scope, sharedDoc, subjType, subjName) {
         var home = subjectDoc(st, scope, subjType, subjName);
         if (home) { return home; }

--- a/cmd/loomcycle/presets_memory_codejs_test.go
+++ b/cmd/loomcycle/presets_memory_codejs_test.go
@@ -99,6 +99,12 @@ type fakeToolset struct {
 	edges            []string // "from-kind->to"
 	supersededChunks []string // "old by new"
 	failEntityKeys   map[string]bool
+	// failSubjectDocs models the ONE state a pre-subject-homing store is in: the
+	// entity's natural key is already held by a node in the shared document, so
+	// create_document cannot claim it (the column is unique per scope) while
+	// upsert_chunk, which UPDATES the holder, works fine. failEntityKeys cannot
+	// express it — it fails both ops — and the difference is the whole fallback.
+	failSubjectDocs map[string]bool
 
 	leaseAcquired bool
 	sessions      []map[string]any
@@ -165,17 +171,18 @@ type fakeToolset struct {
 
 func newFakeToolset() *fakeToolset {
 	return &fakeToolset{
-		leaseAcquired:  true,
-		bands:          map[string]any{"merge_threshold": 0.9, "related_threshold": 0.5},
-		chunks:         map[string]string{},
-		subjectDocs:    map[string]string{},
-		chunkScopes:    map[string]string{},
-		chunkTypes:     map[string]string{},
-		chunkSpans:     map[string]string{},
-		chunkRows:      map[string]map[string]any{},
-		verdicts:       map[string]string{},
-		failEntityKeys: map[string]bool{},
-		proposedTypes:  map[string]bool{},
+		leaseAcquired:   true,
+		bands:           map[string]any{"merge_threshold": 0.9, "related_threshold": 0.5},
+		chunks:          map[string]string{},
+		subjectDocs:     map[string]string{},
+		chunkScopes:     map[string]string{},
+		chunkTypes:      map[string]string{},
+		chunkSpans:      map[string]string{},
+		chunkRows:       map[string]map[string]any{},
+		verdicts:        map[string]string{},
+		failEntityKeys:  map[string]bool{},
+		failSubjectDocs: map[string]bool{},
+		proposedTypes:   map[string]bool{},
 		// Source of truth for this format: formatSubAgentOutput in
 		// internal/api/http/resume.go. Nothing links them — grep that name.
 		subAgentHeader: "[sub-agent agent_id=a_test000000000000]\n",
@@ -317,6 +324,11 @@ func (d *fakeDocument) Execute(_ context.Context, raw json.RawMessage) (tools.Re
 			// every entity-write-failure test injecting nothing.
 			if d.f.failEntityKeys[nk] {
 				return tools.Result{IsError: true, Text: "create_document: refused for " + nk}, nil
+			}
+			if d.f.failSubjectDocs[nk] {
+				return tools.Result{IsError: true, Text: "create_document: chunk " + d.f.chunks[nk] +
+					" already holds the natural key " + strconv.Quote(nk) + ", and a key names ONE " +
+					"thing per scope."}, nil
 			}
 			if len(d.f.declaredTypes) > 0 {
 				if typ, _ := in["type"].(string); typ != "" && !d.f.declaredTypes[typ] {
@@ -3372,6 +3384,60 @@ func TestConsolidator_ASubjectWithNoTypeIsFiledUnderTheFallbackType(t *testing.T
 	}
 	if n := len(callsWithOp(f, "Document.link_chunks")); n != 2 {
 		t.Errorf("edges = %d, want 2 — a named subject is reachable even with no type given", n)
+	}
+}
+
+// TestConsolidator_AnUnmigratedSubjectStillGetsItsEdge.
+//
+// A scope written before subject-homing CANNOT adopt it on its own: natural_key is
+// unique per scope, so while the old node in the shared document holds `person:denn`,
+// the document claiming that key cannot be created. MEASURED against the real store:
+// create_document fails on the constraint on every pass.
+//
+// Without a fallback the consequence is not a cosmetic one. subjectDoc returns
+// nothing, so no subject node is resolved, so NO `about` EDGE IS WRITTEN — and a fact
+// unreachable from the person it is about is the failure the entity tier exists to
+// prevent. The fact would still be stored, which is why nothing else in the suite
+// catches it.
+//
+// So the fall back is the shape that scope is already in: the subject as a node in the
+// shared document, the fact beside it, the edge joining them. It self-retires — after
+// the home_facts migration moves the node into its own document, the preferred path
+// succeeds and this never fires.
+func TestConsolidator_AnUnmigratedSubjectStillGetsItsEdge(t *testing.T) {
+	f := newFakeToolset()
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	f.transcript = "### user\n\nDenn prefers Go."
+	f.factsJSON = `[{"text":"Denn prefers Go.","class":"preference","type":"person","subject":"Denn"}]`
+	// The pre-subject-homing state: the node exists and holds the key, so its own
+	// document cannot claim it — while upsert_chunk, which updates the holder, works.
+	f.chunks["person:denn"] = "chunk-existing"
+	f.chunkTypes["person:denn"] = "person"
+	f.failSubjectDocs = map[string]bool{"person:denn": true}
+
+	res := runConsolidator(t, f)
+
+	if n := factWriteCount(f); n != 1 {
+		t.Fatalf("the fact must still be stored; fact writes=%d", n)
+	}
+	links := callsWithOp(f, "Document.link_chunks")
+	if len(links) != 1 {
+		t.Fatalf("about edges = %d, want 1 — a subject whose own document cannot be created "+
+			"must still be reachable from its facts", len(links))
+	}
+	if to, _ := links[0].Input["to_id"].(string); to != "chunk-existing" {
+		t.Errorf("edge points at %q, want the existing subject node chunk-existing", to)
+	}
+	// And the fact is filed beside it, in the shared document — the old shape,
+	// entire, rather than a fact homed nowhere.
+	if doc, _ := lastFactWrite(t, f).Input["document_id"].(string); doc != "doc-entities" {
+		t.Errorf("fact filed in %q, want the shared entity document while the subject is "+
+			"still in it", doc)
+	}
+	// The operator is TOLD, and told the remedy — a store in this state is one
+	// migration away from the shape it should be in, and nothing else would say so.
+	if !strings.Contains(res.FinalText, "home_facts") {
+		t.Errorf("the report must name the migration that frees the key, got: %s", res.FinalText)
 	}
 }
 

--- a/cmd/loomcycle/presets_memory_codejs_test.go
+++ b/cmd/loomcycle/presets_memory_codejs_test.go
@@ -3439,6 +3439,11 @@ func TestConsolidator_AnUnmigratedSubjectStillGetsItsEdge(t *testing.T) {
 	if !strings.Contains(res.FinalText, "home_facts") {
 		t.Errorf("the report must name the migration that frees the key, got: %s", res.FinalText)
 	}
+	// And NOT told a write failed, because none did. The two readings send an
+	// operator to opposite places: one to a broken Document tool, one to a migration.
+	if strings.Contains(res.FinalText, "graph write(s) failed") {
+		t.Errorf("a recovered fallback was reported as a failed graph write: %s", res.FinalText)
+	}
 }
 
 // TestConsolidator_AGraphFailureNeverCostsAFact is the safety property. The k/v row

--- a/internal/api/http/memory_home_facts.go
+++ b/internal/api/http/memory_home_facts.go
@@ -1,0 +1,80 @@
+package http
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
+)
+
+// memory_home_facts.go — RFC CV P3: the migration that moves facts already stored in
+// the shared `/memory/entities` document into the document that IS their subject.
+//
+// A store written before subject-homing keeps every fact in one document with the
+// subject as a sibling chunk. A store written after it keeps `/facts/<slug>` per
+// subject, root chunk = the entity. Both READ correctly — the fact surfaces search
+// and the graph walks edges, and neither cares where a chunk is filed — so this is
+// not a repair. It is the step that stops the two shapes disagreeing about IDENTITY:
+// the old subject chunk and the new document root carry the same natural key, and a
+// key resolves scope-wide, so a later write finds whichever the database hands back
+// first. One subject, two nodes, each collecting a different half of what is known.
+//
+// Operator-triggered rather than run-at-boot, and dry_run defaults TRUE, for the
+// reason the collapse gave: a migration that runs itself is a migration nobody reads
+// the report of. The work itself is in builtin, where createDocument and the chunk
+// transaction live — this is the scoping, the authorization and the refusal.
+
+// handleMemoryHomeFacts serves POST
+// /v1/_memory/home_facts?scope=&scope_id=&tenant=&dry_run=
+func (s *Server) handleMemoryHomeFacts(w http.ResponseWriter, r *http.Request) {
+	if s.store == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "store_unavailable",
+			"store not configured; subject homing requires a persistent store")
+		return
+	}
+	if s.sqlMem == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "sqlmem_unavailable",
+			"SQL Memory is not enabled, so there is no chunk plane to home facts in")
+		return
+	}
+	scope := r.URL.Query().Get("scope")
+	if !validAdminMemoryScope(scope) {
+		writeJSONError(w, http.StatusBadRequest, "invalid_scope",
+			"scope must be one of: agent, user, tenant")
+		return
+	}
+	scopeID := r.URL.Query().Get("scope_id")
+	if adminMemoryScopeIDRequired(scope) && strings.TrimSpace(scopeID) == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing_scope_id",
+			"scope_id is required for scope="+scope+" (tenant is a single keyspace and needs none)")
+		return
+	}
+	dryRun := true
+	if v := r.URL.Query().Get("dry_run"); v != "" {
+		dryRun = v != "false" && v != "0"
+	}
+	tenant, all := s.principalTenantScope(r.Context(), r.URL.Query().Get("tenant"))
+	if all && !r.URL.Query().Has("tenant") {
+		// The same refusal the collapse makes, for a weaker but still real reason:
+		// nothing here is deleted but a subject node whose contents have already
+		// moved, yet the documents this CREATES are named in a tenant's Path tree and
+		// an unnamed tenant would silently be the default one.
+		writeJSONError(w, http.StatusBadRequest, "tenant_required",
+			"an admin token must name the tenant: memory rows are keyed on it, and this "+
+				"operation MOVES facts between documents. Pass ?tenant=<id>, or ?tenant= for "+
+				"the default tenant.")
+		return
+	}
+
+	doc := &builtin.Document{Store: s.store, SqlMem: s.sqlMem}
+	rep, err := doc.HomeFactsUnderSubjects(r.Context(), tenant, store.MemoryScope(scope), scopeID, dryRun)
+	if err != nil {
+		// A fault mid-scope leaves the subjects already committed homed and the rest
+		// where they were — both shapes read, so a partial run is a smaller job next
+		// time rather than a broken store. The report says how far it got.
+		writeJSONError(w, http.StatusInternalServerError, "homing_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, rep)
+}

--- a/internal/api/http/memory_home_facts_test.go
+++ b/internal/api/http/memory_home_facts_test.go
@@ -1,0 +1,357 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
+)
+
+// Subject homing moves a fact into the document that IS its subject (RFC CV P3).
+// These pin the move, the things it must NOT move, and the merge — because the
+// migration's whole value is that a fact keeps its identity while changing homes.
+
+// homingFixture is a scope holding the OLD shape: one shared /memory/entities
+// document with subject nodes and fact nodes as siblings, joined by `about` edges.
+type homingFixture struct {
+	t      *testing.T
+	srv    *Server
+	doc    *builtin.Document
+	ctx    context.Context
+	shared string
+}
+
+func newHomingFixture(t *testing.T) *homingFixture {
+	t.Helper()
+	srv, _ := makeServer(t, completingProvider(), makeBaseConfig())
+	withSqlMem(t, srv)
+	f := &homingFixture{
+		t: t, srv: srv,
+		doc: &builtin.Document{Store: srv.store, SqlMem: srv.sqlMem},
+		ctx: tools.WithAgentName(tools.WithRunIdentity(context.Background(),
+			tools.RunIdentityValue{UserID: "alice"}), "consolidator"),
+	}
+	f.shared = f.mkDoc("Entities", "/memory/entities")
+	return f
+}
+
+func (f *homingFixture) exec(body string) tools.Result {
+	f.t.Helper()
+	res, err := f.doc.Execute(f.ctx, json.RawMessage(body))
+	if err != nil {
+		f.t.Fatalf("document: %v", err)
+	}
+	if res.IsError {
+		f.t.Fatalf("document op failed: %s", res.Text)
+	}
+	return res
+}
+
+func (f *homingFixture) mkDoc(title, path string) string {
+	f.t.Helper()
+	res := f.exec(`{"op":"create_document","scope":"user","title":"` + title + `","path":"` + path + `"}`)
+	var out struct {
+		DocumentID string `json:"document_id"`
+	}
+	_ = json.Unmarshal([]byte(res.Text), &out)
+	if out.DocumentID == "" {
+		f.t.Fatalf("create_document %s returned no id: %s", path, res.Text)
+	}
+	return out.DocumentID
+}
+
+// subject writes an OLD-SHAPE subject node: a sibling chunk in the shared document.
+func (f *homingFixture) subject(docID, typ, name, key string) string {
+	f.t.Helper()
+	res := f.exec(`{"op":"upsert_chunk","scope":"user","document_id":"` + docID + `",
+		"natural_key":"` + key + `","title":"` + name + `","type":"` + typ + `","subject":"` + name + `"}`)
+	return chunkIDOf(f.t, res)
+}
+
+// fact writes a fact node and, when subjID is non-empty, the `about` edge that makes
+// it reachable from its subject — the pair the migration reads.
+func (f *homingFixture) fact(docID, key, text, subjID string) string {
+	f.t.Helper()
+	res := f.exec(`{"op":"upsert_chunk","scope":"user","document_id":"` + docID + `",
+		"natural_key":"` + key + `","title":"` + text + `","body":"` + text + `","type":"fact"}`)
+	id := chunkIDOf(f.t, res)
+	if subjID != "" {
+		f.exec(`{"op":"link_chunks","scope":"user","from_id":"` + id + `","to_id":"` + subjID + `","kind":"about"}`)
+	}
+	return id
+}
+
+func (f *homingFixture) rootOf(docID string) string {
+	f.t.Helper()
+	rows := f.sqlRows(`SELECT root_chunk_id FROM documents WHERE id = '` + docID + `'`)
+	if len(rows) != 1 {
+		f.t.Fatalf("document %s: %v", docID, rows)
+	}
+	return asString(rows[0][0])
+}
+
+func chunkIDOf(t *testing.T, res tools.Result) string {
+	t.Helper()
+	var out struct {
+		ID string `json:"id"`
+	}
+	_ = json.Unmarshal([]byte(res.Text), &out)
+	if out.ID == "" {
+		t.Fatalf("no chunk id in reply: %s", res.Text)
+	}
+	return out.ID
+}
+
+// sqlRows runs a read straight against the scope's chunk tables. The migration's
+// postconditions are document_id/parent_id/edge rows, none of which any read op
+// reports — asserting them through the tool surface would assert the surface.
+func (f *homingFixture) sqlRows(query string) [][]any {
+	f.t.Helper()
+	res := f.exec(`{"op":"query_chunks","scope":"user","sql":` + jsonStr(query) + `}`)
+	var out struct {
+		Rows [][]any `json:"rows"`
+	}
+	if err := json.Unmarshal([]byte(res.Text), &out); err != nil {
+		f.t.Fatalf("query_chunks: %v (%s)", err, res.Text)
+	}
+	return out.Rows
+}
+
+func jsonStr(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+func homeReq(t *testing.T, srv *Server, query string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/_memory/home_facts"+query, nil).
+		WithContext(auth.WithPrincipal(context.Background(), auth.Principal{
+			Subject: "root", Scopes: []string{auth.ScopeAdmin},
+		}))
+	srv.handleMemoryHomeFacts(rec, req)
+	return rec
+}
+
+func homeRun(t *testing.T, srv *Server, query string) builtin.FactHomingReport {
+	t.Helper()
+	rec := homeReq(t, srv, query)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var rep builtin.FactHomingReport
+	if err := json.Unmarshal(rec.Body.Bytes(), &rep); err != nil {
+		t.Fatalf("report: %v (%s)", err, rec.Body.String())
+	}
+	return rep
+}
+
+// TestHomeFacts_AFactMovesIntoItsSubjectsDocument is the migration proper.
+//
+// The assertions are the ones that say a MOVE happened rather than a copy: BOTH the
+// fact and its subject keep their chunk ids, so their bodies, embeddings, sidecars,
+// spans, counters and edges follow them for free. The subject BECOMES the new
+// document's root — which is why the `about` edge still points at the same chunk and
+// why nothing ever has to hold the unique natural key twice.
+func TestHomeFacts_AFactMovesIntoItsSubjectsDocument(t *testing.T) {
+	f := newHomingFixture(t)
+	subj := f.subject(f.shared, "person", "Denn", "person:denn")
+	fact := f.fact(f.shared, "memory/fact/denn-writes-go", "Denn writes Go.", subj)
+
+	rep := homeRun(t, f.srv, "?scope=user&scope_id=alice&tenant=&dry_run=false")
+	if rep.FactsMoved != 1 || rep.DocumentsCreated != 1 || rep.SubjectsHomed != 1 {
+		t.Fatalf("report = %+v, want one fact moved into one created document", rep)
+	}
+
+	rows := f.sqlRows(`SELECT c.id, c.document_id, c.parent_id FROM chunks c WHERE c.id = '` + fact + `'`)
+	if len(rows) != 1 {
+		t.Fatalf("the fact chunk is gone — it must MOVE, never be re-created: %v", rows)
+	}
+	docID, parentID := asString(rows[0][1]), asString(rows[0][2])
+
+	newDoc := f.exec(`{"op":"get_document","scope":"user","path":"/facts/denn"}`)
+	var nd struct {
+		DocumentID  string `json:"document_id"`
+		RootChunkID string `json:"root_chunk_id"`
+	}
+	_ = json.Unmarshal([]byte(newDoc.Text), &nd)
+	if docID != nd.DocumentID {
+		t.Errorf("fact is in document %q, want /facts/denn (%q)", docID, nd.DocumentID)
+	}
+	if parentID != nd.RootChunkID {
+		t.Errorf("fact's parent is %q, want the root %q — the subject's facts are its "+
+			"CHILDREN, which is what makes the dossier one read", parentID, nd.RootChunkID)
+	}
+
+	// THE SUBJECT NODE IS THE ROOT. Not a copy of it beside a fresh one: the same
+	// chunk, which is what carries the unique natural key across without ever holding
+	// it twice, and what leaves the `about` edge pointing at the right thing.
+	if nd.RootChunkID != subj {
+		t.Errorf("root of /facts/denn = %q, want the subject node %q itself — re-creating it "+
+			"would need the unique key held by two chunks at once", nd.RootChunkID, subj)
+	}
+	keys := f.sqlRows(`SELECT chunk_id FROM chunk_memory_meta WHERE natural_key = 'person:denn'`)
+	if len(keys) != 1 || asString(keys[0][0]) != subj {
+		t.Errorf("chunks claiming person:denn = %v, want only the moved subject node %q", keys, subj)
+	}
+	// The subject is a root now: no parent, and out of the shared document.
+	sr := f.sqlRows(`SELECT document_id, parent_id FROM chunks WHERE id = '` + subj + `'`)
+	if len(sr) != 1 || asString(sr[0][0]) != nd.DocumentID || sr[0][1] != nil {
+		t.Errorf("subject node sits at %v, want document %q with no parent", sr, nd.DocumentID)
+	}
+	// The edge never moved, because neither endpoint changed id.
+	edges := f.sqlRows(`SELECT to_id FROM chunk_edges WHERE from_id = '` + fact + `' AND kind = 'about'`)
+	if len(edges) != 1 || asString(edges[0][0]) != subj {
+		t.Errorf("about edge = %v, want one pointing at the subject %q — an edge dropped "+
+			"here is a retrieval loss even though the fact survives", edges, subj)
+	}
+}
+
+// TestHomeFacts_AFactAboutNobodyStaysInTheSharedDocument. mirrorEntity refuses to
+// invent a subject for a fact that names none — inventing one is how two different
+// things end up merged onto a single node — so the migration must refuse it too.
+// /memory/entities stays the home for facts about nobody.
+func TestHomeFacts_AFactAboutNobodyStaysInTheSharedDocument(t *testing.T) {
+	f := newHomingFixture(t)
+	subj := f.subject(f.shared, "person", "Denn", "person:denn")
+	homed := f.fact(f.shared, "memory/fact/denn-writes-go", "Denn writes Go.", subj)
+	orphan := f.fact(f.shared, "memory/fact/releases-are-friday", "Releases ship on Friday.", "")
+
+	rep := homeRun(t, f.srv, "?scope=user&scope_id=alice&tenant=&dry_run=false")
+	if rep.FactsMoved != 1 {
+		t.Errorf("moved %d facts, want 1 — only the one with a subject", rep.FactsMoved)
+	}
+	if rep.FactsWithoutSubject != 1 {
+		t.Errorf("facts_without_subject = %d, want 1 — the gap must READ as work still to "+
+			"do rather than vanish into a silent default", rep.FactsWithoutSubject)
+	}
+	rows := f.sqlRows(`SELECT id, document_id FROM chunks WHERE id IN ('` + homed + `','` + orphan + `')`)
+	for _, r := range rows {
+		id, doc := asString(r[0]), asString(r[1])
+		if id == orphan && doc != f.shared {
+			t.Errorf("the subject-less fact moved to %q — it has no subject to be homed under", doc)
+		}
+		if id == homed && doc == f.shared {
+			t.Error("the subjected fact did not move")
+		}
+	}
+}
+
+// TestHomeFacts_AdoptsTheEmptyDocumentAnUnmigratedPassLeftBehind.
+//
+// MEASURED: on a store whose subject node predates subject-homing, create_document
+// inserted the document and its root and only THEN failed on the unique natural key,
+// so every consolidation pass left one more empty, path-less /facts/<slug> behind. The
+// document is now rolled back, but stores that ran the broken version still carry
+// them — and one of them may be the very document at the path this subject needs. It
+// is adopted rather than sidestepped, or the migration would create a second
+// /facts/denn the Path tree cannot name.
+func TestHomeFacts_AdoptsTheEmptyDocumentAnUnmigratedPassLeftBehind(t *testing.T) {
+	f := newHomingFixture(t)
+	stray := f.mkDoc("Denn", "/facts/denn") // no entity fields: exactly what leaked
+	strayRoot := f.rootOf(stray)
+	subj := f.subject(f.shared, "person", "Denn", "person:denn")
+	fact := f.fact(f.shared, "memory/fact/denn-writes-go", "Denn writes Go.", subj)
+
+	rep := homeRun(t, f.srv, "?scope=user&scope_id=alice&tenant=&dry_run=false")
+	if rep.DocumentsAdopted != 1 || rep.DocumentsCreated != 0 {
+		t.Errorf("report = %+v, want the stray /facts/denn ADOPTED, not a second one made", rep)
+	}
+	rows := f.sqlRows(`SELECT document_id, parent_id FROM chunks WHERE id = '` + fact + `'`)
+	if len(rows) != 1 || asString(rows[0][0]) != stray || asString(rows[0][1]) != subj {
+		t.Errorf("fact landed at %v, want the adopted document %q under the subject %q", rows, stray, subj)
+	}
+	if root := f.rootOf(stray); root != subj {
+		t.Errorf("adopted document's root = %q, want the subject node %q", root, subj)
+	}
+	if len(f.sqlRows(`SELECT id FROM chunks WHERE id = '`+strayRoot+`'`)) != 0 {
+		t.Error("the placeholder root survives, so the document has two roots")
+	}
+	// One document at the path, not two — the Path tree names only one of them.
+	if docs := f.sqlRows(`SELECT id FROM documents`); len(docs) != 2 {
+		t.Errorf("%d documents, want 2 (the shared one and /facts/denn)", len(docs))
+	}
+}
+
+// TestHomeFacts_IsIdempotent. A migration that has to be run exactly once is a
+// migration that will be run twice.
+func TestHomeFacts_IsIdempotent(t *testing.T) {
+	f := newHomingFixture(t)
+	subj := f.subject(f.shared, "person", "Denn", "person:denn")
+	f.fact(f.shared, "memory/fact/denn-writes-go", "Denn writes Go.", subj)
+
+	if rep := homeRun(t, f.srv, "?scope=user&scope_id=alice&tenant=&dry_run=false"); rep.FactsMoved != 1 {
+		t.Fatalf("first run moved %d, want 1", rep.FactsMoved)
+	}
+	rep := homeRun(t, f.srv, "?scope=user&scope_id=alice&tenant=&dry_run=false")
+	if rep.FactsMoved != 0 || rep.Subjects != 0 || rep.SubjectsHomed != 0 {
+		t.Errorf("second run = %+v, want nothing left to do", rep)
+	}
+}
+
+// TestHomeFacts_DryRunIsTheDefaultAndMovesNothing. A bare POST must not rewrite a
+// store, and must still report what it WOULD do — that report is the reason this is
+// operator-triggered rather than run at boot.
+func TestHomeFacts_DryRunIsTheDefaultAndMovesNothing(t *testing.T) {
+	f := newHomingFixture(t)
+	subj := f.subject(f.shared, "person", "Denn", "person:denn")
+	fact := f.fact(f.shared, "memory/fact/denn-writes-go", "Denn writes Go.", subj)
+
+	rep := homeRun(t, f.srv, "?scope=user&scope_id=alice&tenant=") // no dry_run param
+	if !rep.DryRun {
+		t.Fatal("dry_run defaulted to FALSE — a bare POST would rewrite the store")
+	}
+	if rep.Subjects != 1 || rep.FactsMoved != 1 {
+		t.Errorf("report = %+v, want it to say one fact WOULD move", rep)
+	}
+	rows := f.sqlRows(`SELECT document_id FROM chunks WHERE id = '` + fact + `'`)
+	if len(rows) != 1 || asString(rows[0][0]) != f.shared {
+		t.Errorf("the fact moved on a DRY RUN: %v", rows)
+	}
+	if len(f.sqlRows(`SELECT id FROM chunks WHERE id = '`+subj+`'`)) != 1 {
+		t.Error("the old subject node was removed on a DRY RUN")
+	}
+}
+
+// TestHomeFacts_AnAdminMustNameTheTenant. Documents are named in a tenant's Path
+// tree, so an admin naming no tenant would silently create /facts/<slug> in the
+// default one — the same refusal the collapse makes.
+func TestHomeFacts_AnAdminMustNameTheTenant(t *testing.T) {
+	srv, _ := makeServer(t, completingProvider(), makeBaseConfig())
+	withSqlMem(t, srv)
+	rec := homeReq(t, srv, "?scope=user&scope_id=alice&dry_run=false") // no ?tenant=
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body: %s", rec.Code, rec.Body.String())
+	}
+	var e map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &e)
+	if e["code"] != "tenant_required" {
+		t.Errorf("error = %v, want tenant_required", e["code"])
+	}
+}
+
+// TestHomeFacts_AScopeWithNoSharedDocumentIsNotAFault. A scope written entirely in
+// the new shape has no /memory/entities at all; "nothing to do" must read as success
+// so an operator sweeping every scope is not told a clean one is broken.
+func TestHomeFacts_AScopeWithNoSharedDocumentIsNotAFault(t *testing.T) {
+	srv, _ := makeServer(t, completingProvider(), makeBaseConfig())
+	withSqlMem(t, srv)
+	rep := homeRun(t, srv, "?scope=user&scope_id=nobody&tenant=&dry_run=false")
+	if rep.Subjects != 0 || rep.FactsMoved != 0 {
+		t.Errorf("report = %+v, want an empty run", rep)
+	}
+	if !strings.Contains(rep.Note, "nothing to home") {
+		t.Errorf("note = %q, want it to say why there was nothing to do", rep.Note)
+	}
+}
+
+func asString(v any) string {
+	s, _ := v.(string)
+	return s
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -3300,6 +3300,7 @@ func (s *Server) Mux() http.Handler {
 	// and unlike them it DELETES, so its dry_run default is load-bearing.
 	mux.Handle("POST /v1/_memory/purge_stale_embeddings", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleMemoryPurgeStaleEmbeddings))))
 	mux.Handle("POST /v1/_memory/collapse_facts", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleMemoryCollapseFacts))))
+	mux.Handle("POST /v1/_memory/home_facts", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleMemoryHomeFacts))))
 	mux.Handle("POST /v1/_document/describe_images", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleDescribeImages))))
 	// v0.8.17 Snapshot capture (PR 2). Bearer-authed; same posture
 	// as /v1/_resolver. The full runtime-state JSON envelope; see

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1490,6 +1491,24 @@ func (d *Document) createDocument(ctx context.Context, key sqlmem.ScopeKey, msco
 		if refused := d.gateEntityType(ctx, in); refused != nil {
 			return *refused, nil
 		}
+		// AND THE KEY MUST BE FREE. chunk_memory_meta.natural_key is UNIQUE per scope,
+		// so a root claiming a key another chunk holds fails — and it used to fail
+		// AFTER the document and its root were inserted, leaving an empty, path-less
+		// document behind every time. Measured on a store whose subject nodes predate
+		// subject-homing: one orphan per subject per consolidation pass, growing
+		// forever, because the caller retries on the next pass and fails identically.
+		//
+		// Refused here, before anything exists, with the holder named — a caller that
+		// hits this is looking at a store whose entities have not been moved into
+		// their own documents yet, and that is what the message has to say.
+		if held, herr := d.chunkIDByNaturalKey(ctx, key, in.NaturalKey); herr != nil {
+			return errResult("create_document: natural key lookup: " + herr.Error()), nil
+		} else if held != "" {
+			return errResult("create_document: chunk " + held + " already holds the natural key " +
+				strconv.Quote(in.NaturalKey) + ", and a key names ONE thing per scope. That entity " +
+				"has not been moved into its own document yet — run the subject-homing migration " +
+				"(POST /v1/_memory/home_facts), which moves the node itself rather than copying it."), nil
+		}
 	}
 	rootID := newDocID()
 	// type/status are set on the root chunk (the authoritative kind/state) AND
@@ -1522,8 +1541,21 @@ func (d *Document) createDocument(ctx context.Context, key sqlmem.ScopeKey, msco
 	// acquire a sidecar row that the fact surfaces would then list.
 	if strings.TrimSpace(in.Subject) != "" && strings.TrimSpace(in.NaturalKey) != "" {
 		if err := d.writeChunkMeta(ctx, key, rootID, in); err != nil {
-			return errResult("create_document: the root was created but its entity metadata " +
-				"failed, so the document exists and is not the subject it claims to be: " + err.Error()), nil
+			// UNWOUND, not left behind. A document that "is not the subject it claims to
+			// be" is precisely what must not survive the call: it is invisible (the
+			// dirent below never runs), it is empty, and the caller retries — so leaving
+			// it turns one failure into an unbounded leak. The guard above catches the
+			// cause that is knowable in advance; this catches the race and anything else,
+			// because the leak is what does the damage, not its reason.
+			//
+			// An unwind rather than a transaction because the body row lives in the
+			// Memory k/v plane, a DIFFERENT database, which cannot join a SQL txn — the
+			// same constraint delete_chunk works under.
+			_ = d.exec(ctx, key, `DELETE FROM chunks WHERE id = ?`, rootID)
+			_ = d.exec(ctx, key, `DELETE FROM documents WHERE id = ?`, docID)
+			_, _ = d.Store.MemoryDelete(ctx, direntTenant(ctx), mscope, key.ScopeID, chunkBodyKey(rootID))
+			return errResult("create_document: the root's entity metadata could not be written, " +
+				"so nothing was created: " + err.Error()), nil
 		}
 	}
 	// A document's tags are its own (independent of the root chunk's tags).

--- a/internal/tools/builtin/document_entity_test.go
+++ b/internal/tools/builtin/document_entity_test.go
@@ -498,3 +498,55 @@ func TestChunkParentage_RefusesAnUnreachableParent(t *testing.T) {
 		t.Errorf("moving to the root level was refused: %s", r.Text)
 	}
 }
+
+// TestCreateDocument_RefusesAHeldNaturalKeyAndLeavesNothingBehind.
+//
+// chunk_memory_meta.natural_key is UNIQUE per scope, so a document root claiming a key
+// another chunk holds cannot be written — and the write used to be attempted AFTER the
+// documents row and the root chunk were inserted. MEASURED on a store whose subject
+// nodes predate subject-homing: the consolidator retries every pass, so each pass left
+// one more empty, path-less document behind (3 passes → 4 documents), and never wrote
+// the `about` edge either.
+//
+// The count is the assertion. A refusal that leaks is not a refusal.
+func TestCreateDocument_RefusesAHeldNaturalKeyAndLeavesNothingBehind(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+
+	out, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Entities","path":"/memory/entities"}`)
+	if r.IsError {
+		t.Fatalf("create shared: %s", r.Text)
+	}
+	shared, _ := out["document_id"].(string)
+	if _, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+shared+
+		`","natural_key":"person:denn","title":"Denn","type":"person","subject":"Denn"}`); r.IsError {
+		t.Fatalf("seed subject node: %s", r.Text)
+	}
+
+	for pass := 1; pass <= 3; pass++ {
+		_, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Denn","path":"/facts/denn",`+
+			`"type":"person","subject":"Denn","natural_key":"person:denn"}`)
+		if !r.IsError {
+			t.Fatalf("pass %d: create_document succeeded with a key another chunk holds", pass)
+		}
+		if !strings.Contains(r.Text, "home_facts") {
+			t.Errorf("pass %d: refusal does not point at the migration that frees the key: %s", pass, r.Text)
+		}
+	}
+
+	key := sidecarScope(t, d, ctx)
+	docs, err := d.query(ctx, key, `SELECT count(*) FROM documents`)
+	if err != nil {
+		t.Fatalf("count documents: %v", err)
+	}
+	if n := asInt(docs.Rows[0][0]); n != 1 {
+		t.Errorf("%d documents after 3 refused creates, want 1 — a refusal that leaves the "+
+			"document behind turns one failure into an unbounded leak", n)
+	}
+	chunks, err := d.query(ctx, key, `SELECT count(*) FROM chunks`)
+	if err != nil {
+		t.Fatalf("count chunks: %v", err)
+	}
+	if n := asInt(chunks.Rows[0][0]); n != 2 {
+		t.Errorf("%d chunks, want 2 (the shared root and the subject node)", n)
+	}
+}

--- a/internal/tools/builtin/document_fact_home.go
+++ b/internal/tools/builtin/document_fact_home.go
@@ -1,0 +1,536 @@
+package builtin
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// document_fact_home.go — RFC CV P3: move a fact into the document that IS its
+// subject, and move the subject with it.
+//
+// A store written before subject-homing keeps every fact in ONE shared document,
+// `/memory/entities`, with the subject as a sibling chunk and an `about` edge joining
+// them. A store written after it keeps `/facts/<subject-slug>` per subject, whose ROOT
+// chunk is the entity and whose children are its facts.
+//
+// THIS IS NOT TIDYING. `chunk_memory_meta.natural_key` is UNIQUE per scope, so while
+// the old subject node holds `person:denn` the consolidator CANNOT create the document
+// that claims the same key — measured: create_document fails on the constraint, so
+// subjectDoc returns nothing, the fact is filed in the shared document AND its `about`
+// edge is never written. A fact unreachable from the person it is about is the whole
+// reason the entity tier exists. Until a scope is migrated it runs on the fallback
+// mirrorEntity keeps for exactly this window; after it, the new shape is available.
+//
+// IT MOVES, IT DOES NOT COPY — the subject node included. A chunk keeps its id, so its
+// body row, its embedding, its bi-temporal sidecar, its span, its access counters and
+// every edge it has follow it for free. The subject node BECOMES the new document's
+// root rather than being re-created beside it, which is why no edge has to be
+// re-pointed and why the unique key is never held twice: there is only ever one chunk
+// claiming `person:denn`, and it changes address.
+//
+// The move is `document_id` + `parent_id`, which is exactly the pair move_chunk refuses
+// to change (a chunk parented across documents is corruption from the other side) — so
+// this cannot be expressed as a sequence of tool calls, and that is why it is
+// server-side.
+//
+// THE UNIT OF REFUSAL IS THE SUBJECT, not the scope. The collapse refused a whole scope
+// because it DELETED rows: a partial run there left the operator with a success and
+// some facts one run away from being dropped. Nothing here is deleted but an empty
+// placeholder root, so a subject that cannot be homed — its type is no longer declared,
+// its slug already names a different entity — is left exactly where it is, reported,
+// and picked up by the next run once the operator has fixed the cause.
+//
+// A FACT WITH NO SUBJECT STAYS PUT, and that is the same refusal mirrorEntity makes
+// when it writes one: there is no thing to file it under, and inventing one is how two
+// different things end up merged onto a single node. `/memory/entities` remains the
+// home for facts about nobody. `remember`-written facts stay too: they carry a subject
+// on the fact chunk itself and have no subject node, so there is no natural key to
+// follow, and deriving one would mean a Go twin of the bundle's slug.
+
+// subjectDocPathPrefix is where a subject's document lives — `/facts/<slug>`, the
+// same path subjectDoc() creates, because the migration must land on the document
+// the next consolidation pass will find rather than a parallel one.
+const subjectDocPathPrefix = "/facts/"
+
+// aboutEdgeKind joins a fact to the subject it is about.
+const aboutEdgeKind = "about"
+
+// FactHomingSkip is one subject the migration did not move, and why. Reported
+// rather than logged: a subject left behind is work the operator still has to do,
+// and a count alone does not say what to fix.
+type FactHomingSkip struct {
+	NaturalKey string `json:"natural_key"`
+	Subject    string `json:"subject,omitempty"`
+	Facts      int    `json:"facts"`
+	Reason     string `json:"reason"`
+}
+
+// FactHomingReport is what one run of the migration did (or, on a dry run, would
+// do) to one scope.
+type FactHomingReport struct {
+	Scope               string           `json:"scope"`
+	ScopeID             string           `json:"scope_id"`
+	Tenant              string           `json:"tenant"`
+	SharedDocument      string           `json:"shared_document,omitempty"`
+	Subjects            int              `json:"subjects"`
+	SubjectsHomed       int              `json:"subjects_homed"`
+	DocumentsCreated    int              `json:"documents_created"`
+	DocumentsAdopted    int              `json:"documents_adopted"`
+	FactsMoved          int              `json:"facts_moved"`
+	FactsWithoutSubject int              `json:"facts_without_subject"`
+	Skipped             []FactHomingSkip `json:"skipped,omitempty"`
+	DryRun              bool             `json:"dry_run"`
+	Note                string           `json:"note,omitempty"`
+}
+
+// homingSubject is one old-shape subject node and the facts pointing at it.
+type homingSubject struct {
+	chunkID    string
+	naturalKey string
+	slug       string
+	typ        string
+	status     string
+	name       string
+	factIDs    []string
+}
+
+// HomeFactsUnderSubjects moves every fact in the scope's shared entity document
+// into its subject's own `/facts/<slug>` document, creating that document when it
+// does not exist yet and removing the now-duplicate subject node from the shared
+// one. It is IDEMPOTENT: a second run finds nothing left to move, and a run
+// interrupted between creating a subject's document and deleting its old node
+// leaves a duplicate that the next run resolves — duplication, never loss, is the
+// failure mode chosen at every step.
+func (d *Document) HomeFactsUnderSubjects(ctx context.Context, tenantID string,
+	scope store.MemoryScope, scopeID string, dryRun bool) (FactHomingReport, error) {
+
+	rep := FactHomingReport{Scope: string(scope), ScopeID: scopeID, Tenant: tenantID, DryRun: dryRun}
+	if d.SqlMem == nil || d.Store == nil {
+		return rep, fmt.Errorf("subject homing requires SQL Memory and a persistent store")
+	}
+	key, ok := docScopeKeyFor(tenantID, scope, scopeID)
+	if !ok {
+		return rep, fmt.Errorf("scope %s/%s is not a document scope", scope, scopeID)
+	}
+	// Every dirent read and every document write below reads the tenant off the
+	// context (direntTenant), so an operator-triggered call has to stamp it — there
+	// is no run identity on an HTTP request, and an unstamped call would resolve
+	// paths in the default tenant's tree while writing SQL in the named one.
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{TenantID: tenantID})
+	mscope := scope
+
+	sharedID, err := d.docIDFromInput(ctx, key, docInput{Path: rememberedFactsPath})
+	if err != nil {
+		// No shared entity document is the state of a scope that was never written
+		// in the old shape, or has already been migrated and had it removed. Nothing
+		// to do is a successful outcome, not a fault.
+		rep.Note = "no " + rememberedFactsPath + " document in this scope — nothing to home"
+		return rep, nil
+	}
+	rep.SharedDocument = sharedID
+
+	subjects, factsNoSubject, err := d.collectHomingSubjects(ctx, key, sharedID)
+	if err != nil {
+		return rep, err
+	}
+	rep.Subjects = len(subjects)
+	rep.FactsWithoutSubject = factsNoSubject
+
+	for i := range subjects {
+		s := subjects[i]
+		if s.slug == "" {
+			rep.Skipped = append(rep.Skipped, FactHomingSkip{
+				NaturalKey: s.naturalKey, Subject: s.name, Facts: len(s.factIDs),
+				Reason: "natural key is not an entity key (want <type>:<slug>), so there is no identity path to home it at",
+			})
+			continue
+		}
+		// The ontology gate, applied HERE because the document is assembled below
+		// rather than through create_document. A type the tenant has stopped declaring
+		// is a subject left where it is, not one filed under a kind nobody can find.
+		if refused := d.gateEntityType(ctx, docInput{Type: s.typ, Subject: s.name}); refused != nil {
+			rep.Skipped = append(rep.Skipped, FactHomingSkip{
+				NaturalKey: s.naturalKey, Subject: s.name, Facts: len(s.factIDs),
+				Reason: strings.TrimSpace(refused.Text),
+			})
+			continue
+		}
+		path := subjectDocPathPrefix + s.slug
+		target, terr := d.subjectHomeTarget(ctx, key, path, s)
+		if terr != nil {
+			rep.Skipped = append(rep.Skipped, FactHomingSkip{
+				NaturalKey: s.naturalKey, Subject: s.name, Facts: len(s.factIDs),
+				Reason: terr.Error(),
+			})
+			continue
+		}
+		rep.SubjectsHomed++
+		if target.adopt {
+			rep.DocumentsAdopted++
+		} else {
+			rep.DocumentsCreated++
+		}
+		rep.FactsMoved += len(s.factIDs)
+		if dryRun {
+			continue
+		}
+		if err := d.homeOneSubject(ctx, key, target, s); err != nil {
+			return rep, fmt.Errorf("homing %s: %w (%d subjects were already homed and are committed)",
+				s.naturalKey, err, rep.SubjectsHomed-1)
+		}
+		// The placeholder root an adopted document came with, after its SQL side is
+		// committed — bodies live in a different database and cannot join that
+		// transaction, and an orphaned body is invisible dead k/v where an orphaned
+		// row would not be.
+		if target.dropRoot != "" {
+			_, _ = d.Store.MemoryDelete(ctx, tenantID, mscope, key.ScopeID, chunkBodyKey(target.dropRoot))
+		}
+		// The Path-tree name LAST, and only for a document this run created: a failure
+		// here leaves the facts correctly homed and merely unnamed, which is the
+		// failure direction create_document already chose (it reports a path_warning
+		// rather than undoing the document).
+		if !target.adopt {
+			if _, perr := d.registerDocDirent(ctx, key, target.docID, path); perr != nil {
+				rep.Skipped = append(rep.Skipped, FactHomingSkip{
+					NaturalKey: s.naturalKey, Subject: s.name,
+					Reason: "the facts were homed but " + path + " could not be registered, so the " +
+						"document is reachable by search and by id and not by path: " + perr.Error(),
+				})
+			}
+		}
+	}
+
+	if dryRun {
+		rep.Note = strings.TrimSpace(rep.Note + " DRY RUN — nothing was created, moved or removed. Re-send with dry_run=false.")
+	}
+	return rep, nil
+}
+
+// collectHomingSubjects reads the shared entity document and pairs each subject
+// node with the facts whose `about` edge points at it.
+//
+// WHY THE EDGE DECIDES, and not the chunk type. A distilled fact's type is the
+// constant "fact", which makes `type = 'fact'` look like the obvious test — but
+// `remember` stamps the CALLER's type, so that filter drops operator-remembered
+// facts, and dropping them here would mean leaving them behind in a document whose
+// subject node has just been deleted. Being the TARGET of an `about` edge is what an
+// identity node structurally is, and being its SOURCE is what a fact is; that is the
+// rule listFacts already applies for the same reason, and it needs no re-stamping so
+// it holds for stores that already exist.
+//
+// The shared document is the ONLY source considered. A criterion like "every entity
+// node that is not a document root" would also sweep up the ontology document's type
+// chunks, which are entities of a different kind entirely — filing `person` under
+// `/facts/person` would make a type into a subject.
+func (d *Document) collectHomingSubjects(ctx context.Context, key sqlmem.ScopeKey, sharedID string) ([]homingSubject, int, error) {
+	rootRes, err := d.query(ctx, key, `SELECT root_chunk_id FROM documents WHERE id = ?`, sharedID)
+	if err != nil {
+		return nil, 0, err
+	}
+	sharedRoot := ""
+	if len(rootRes.Rows) > 0 {
+		sharedRoot = asStr(rootRes.Rows[0][0])
+	}
+
+	res, err := d.query(ctx, key,
+		`SELECT c.id, coalesce(c.title, ''), coalesce(c.type, ''), coalesce(c.status, ''), coalesce(m.natural_key, ''), coalesce(m.subject, '')
+		   FROM chunks c LEFT JOIN chunk_memory_meta m ON m.chunk_id = c.id
+		  WHERE c.document_id = ?`, sharedID)
+	if err != nil {
+		return nil, 0, err
+	}
+	// A TRUNCATED READ IS A FAULT, not a smaller job. Migrating the visible half and
+	// reporting success would leave the rest silently behind, which is the exact
+	// shape of the purge this project already trusted for its own count.
+	if res.Truncated {
+		return nil, 0, fmt.Errorf("the shared entity document has more chunks than one read returns; "+
+			"refusing to home a partial view of it (document %s)", sharedID)
+	}
+
+	type localChunk struct{ title, typ, status, naturalKey, subject string }
+	here := map[string]localChunk{}
+	for _, row := range res.Rows {
+		if len(row) < 6 {
+			continue
+		}
+		id := asStr(row[0])
+		if id == "" || id == sharedRoot {
+			continue
+		}
+		here[id] = localChunk{asStr(row[1]), asStr(row[2]), asStr(row[3]), asStr(row[4]), asStr(row[5])}
+	}
+
+	eres, err := d.query(ctx, key, `SELECT from_id, to_id FROM chunk_edges WHERE kind = ?`, aboutEdgeKind)
+	if err != nil {
+		return nil, 0, err
+	}
+	if eres.Truncated {
+		return nil, 0, fmt.Errorf("the scope has more `about` edges than one read returns; " +
+			"refusing to home facts from a partial view of the graph")
+	}
+
+	byID := map[string]*homingSubject{}
+	isFact := map[string]bool{}
+	type aboutEdge struct{ from, to string }
+	var edges []aboutEdge
+	for _, row := range eres.Rows {
+		if len(row) < 2 {
+			continue
+		}
+		from, to := asStr(row[0]), asStr(row[1])
+		c, inDoc := here[to]
+		if !inDoc {
+			continue // the subject lives elsewhere already — nothing here to home it at
+		}
+		// BELT AND BRACES: the two planes share the `memory/` keyspace verbatim, so a
+		// chunk keyed there is a FACT however the graph is shaped. Treating one as a
+		// subject would file a fact's own key as an identity path.
+		if c.naturalKey != "" && strings.HasPrefix(c.naturalKey, MemoryFactKeyPrefix) {
+			continue
+		}
+		if _, ok := here[from]; !ok {
+			continue // the fact is not in this document; only its subject is
+		}
+		if _, seen := byID[to]; !seen {
+			name := c.subject
+			if name == "" {
+				name = c.title
+			}
+			byID[to] = &homingSubject{
+				chunkID: to, naturalKey: c.naturalKey, slug: entitySlugOfKey(c.naturalKey),
+				typ: c.typ, status: c.status, name: name,
+			}
+		}
+		isFact[from] = true
+		edges = append(edges, aboutEdge{from, to})
+	}
+
+	// ONE HOME, MANY REFERENCES. Containment is single-parent by construction, so a
+	// fact naming several subjects is filed under the first in natural-key order and
+	// stays REACHABLE from the rest through the edges it keeps — which is what the
+	// edge plane is for. Deterministic rather than arbitrary, so a re-run of the
+	// migration reaches the same layout.
+	sort.SliceStable(edges, func(i, j int) bool {
+		ki, kj := byID[edges[i].to].naturalKey, byID[edges[j].to].naturalKey
+		if ki != kj {
+			return ki < kj
+		}
+		return edges[i].from < edges[j].from
+	})
+	homed := map[string]bool{}
+	for _, e := range edges {
+		if homed[e.from] {
+			continue
+		}
+		homed[e.from] = true
+		byID[e.to].factIDs = append(byID[e.to].factIDs, e.from)
+	}
+
+	out := make([]homingSubject, 0, len(byID))
+	for _, s := range byID {
+		sort.Strings(s.factIDs)
+		out = append(out, *s)
+	}
+	// Deterministic across runs AND across the arbitrary order two subject nodes for
+	// one slug come back in: the lower natural key is resolved first, so a merge
+	// lands the same way twice.
+	sort.SliceStable(out, func(i, j int) bool { return out[i].naturalKey < out[j].naturalKey })
+
+	// A chunk here with a sidecar that no `about` edge reaches is a fact with nowhere
+	// to go — one the pass wrote about nobody, or one `remember` wrote with its
+	// subject on the fact itself and no subject node at all. It STAYS, and it is
+	// counted so the gap reads as work still to do rather than a silent default.
+	noSubject := 0
+	for id, c := range here {
+		if isFact[id] || byID[id] != nil || c.naturalKey == "" {
+			continue
+		}
+		noSubject++
+	}
+	return out, noSubject, nil
+}
+
+// entitySlugOfKey takes the identity half of an entity natural key `<type>:<slug>`.
+//
+// The slug is READ from the key rather than recomputed from the name, deliberately:
+// it was produced by the bundle's own slug(), and a Go twin of that function is a
+// second definition of identity that can drift from the one that writes it — the
+// migration would then create `/facts/<other-slug>` beside the document the next
+// consolidation pass resolves.
+func entitySlugOfKey(naturalKey string) string {
+	i := strings.Index(naturalKey, ":")
+	if i < 0 {
+		return ""
+	}
+	slug := strings.TrimSpace(naturalKey[i+1:])
+	// The slug becomes one Path segment. The bundle emits [a-z0-9-], but a key
+	// hand-written through the tool surface need not, and a separator here would
+	// silently re-home the subject somewhere else in the tree.
+	if slug == "" || strings.ContainsAny(slug, "/\\") || slug == "." || slug == ".." {
+		return ""
+	}
+	return slug
+}
+
+// homeTarget is where one subject is going: the document that will hold it, and the
+// placeholder root (if any) it displaces.
+type homeTarget struct {
+	docID    string
+	adopt    bool   // the document already existed at the path
+	dropRoot string // the empty root an adopted document came with, to be removed
+}
+
+// subjectHomeTarget decides where a subject's document is, or that one has to be made.
+//
+// Adoption matters because of the leak this migration also ends: create_document used
+// to insert the document and its root BEFORE the entity-metadata write that fails on
+// the unique key, so an un-migrated scope accumulated one empty, path-less document per
+// subject per pass. Those are exactly the documents to reuse.
+func (d *Document) subjectHomeTarget(ctx context.Context, key sqlmem.ScopeKey, path string, s homingSubject) (homeTarget, error) {
+	existing, derr := d.docIDFromInput(ctx, key, docInput{Path: path})
+	if derr != nil || existing == "" {
+		return homeTarget{docID: newDocID()}, nil
+	}
+	res, qerr := d.query(ctx, key, `SELECT root_chunk_id FROM documents WHERE id = ?`, existing)
+	if qerr != nil {
+		return homeTarget{}, qerr
+	}
+	if len(res.Rows) == 0 {
+		return homeTarget{}, fmt.Errorf("%s names document %s, which does not exist", path, existing)
+	}
+	root := asStr(res.Rows[0][0])
+	kres, kerr := d.query(ctx, key, `SELECT coalesce(natural_key, '') FROM chunk_memory_meta WHERE chunk_id = ?`, root)
+	if kerr != nil {
+		return homeTarget{}, kerr
+	}
+	// A root that is ALREADY an entity is somebody's identity, and the unique key
+	// guarantees it is not this subject's (whose key is still held by the node in the
+	// shared document). Two subjects whose names slug alike is not a collision a
+	// migration may resolve by picking one.
+	if len(kres.Rows) > 0 && asStr(kres.Rows[0][0]) != "" {
+		return homeTarget{}, fmt.Errorf("%s is already the entity %q, so homing %q there would "+
+			"merge two subjects onto one node", path, asStr(kres.Rows[0][0]), s.naturalKey)
+	}
+	// Anything parented under the placeholder root would be orphaned by removing it.
+	cres, cerr := d.query(ctx, key, `SELECT count(*) FROM chunks WHERE parent_id = ?`, root)
+	if cerr != nil {
+		return homeTarget{}, cerr
+	}
+	if len(cres.Rows) > 0 && asInt(cres.Rows[0][0]) > 0 {
+		return homeTarget{}, fmt.Errorf("%s already holds content under a root that is not an "+
+			"entity, so it is somebody else's document", path)
+	}
+	return homeTarget{docID: existing, adopt: true, dropRoot: root}, nil
+}
+
+// homeOneSubject makes the subject node the root of its own document and files its
+// facts beneath it — all in ONE transaction, so a fault leaves the old shape intact
+// rather than a fact filed under a root that is no longer there.
+func (d *Document) homeOneSubject(ctx context.Context, key sqlmem.ScopeKey, target homeTarget, s homingSubject) error {
+	now := time.Now().UnixNano()
+	return d.withSqlTxn(ctx, key, func(txnID string) error {
+		if target.adopt {
+			// The placeholder root goes before the subject takes its place, so the
+			// document never has two roots — and its own cascades run, because an
+			// empty root still owns a revision row and a layout row.
+			if err := d.deletePlaceholderRoot(ctx, txnID, target.dropRoot); err != nil {
+				return err
+			}
+			if err := d.execTxn(ctx, txnID,
+				`UPDATE documents SET root_chunk_id = ?, title = ?, type = ?, status = ?, updated_at = ? WHERE id = ?`,
+				s.chunkID, s.name, nullIfEmpty(s.typ), nullIfEmpty(s.status), now, target.docID); err != nil {
+				return err
+			}
+		} else if err := d.execTxn(ctx, txnID,
+			`INSERT INTO documents (id, title, root_chunk_id, type, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			target.docID, s.name, s.chunkID, nullIfEmpty(s.typ), nullIfEmpty(s.status), now, now); err != nil {
+			return err
+		}
+		// THE SUBJECT ITSELF MOVES. It keeps its chunk id, so its sidecar (the unique
+		// natural key included), its edges and its body come with it — there is no
+		// window in which two chunks claim the key, and nothing to re-point.
+		if err := d.execTxn(ctx, txnID,
+			`UPDATE chunks SET document_id = ?, parent_id = NULL, position = 0, updated_at = ? WHERE id = ?`,
+			target.docID, now, s.chunkID); err != nil {
+			return err
+		}
+		for i, fid := range s.factIDs {
+			if err := d.execTxn(ctx, txnID,
+				`UPDATE chunks SET document_id = ?, parent_id = ?, position = ?, updated_at = ? WHERE id = ?`,
+				target.docID, s.chunkID, i, now, fid); err != nil {
+				return err
+			}
+			// A fact is a leaf today, but a chunk left behind in the old document while
+			// its parent lives in the new one is precisely the cross-document parentage
+			// move_chunk refuses — so the subtree travels with it.
+			if err := d.moveSubtreeDocument(ctx, txnID, fid, target.docID); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// moveSubtreeDocument re-stamps document_id on every descendant of a moved chunk,
+// leaving parent_id alone — the shape inside the subtree is unchanged, only which
+// document owns it.
+func (d *Document) moveSubtreeDocument(ctx context.Context, txnID, chunkID, docID string) error {
+	frontier := []string{chunkID}
+	seen := map[string]bool{chunkID: true}
+	for depth := 0; len(frontier) > 0 && depth <= maxChunkDepth; depth++ {
+		var next []string
+		for _, pid := range frontier {
+			res, err := d.queryTxn(ctx, txnID, `SELECT id FROM chunks WHERE parent_id = ?`, pid)
+			if err != nil {
+				return err
+			}
+			if res.Truncated {
+				return fmt.Errorf("subtree too wide to move safely (a level exceeds the row cap)")
+			}
+			for _, row := range res.Rows {
+				cid := asStr(row[0])
+				if cid == "" || seen[cid] {
+					continue
+				}
+				seen[cid] = true
+				if err := d.execTxn(ctx, txnID, `UPDATE chunks SET document_id = ? WHERE id = ?`, docID, cid); err != nil {
+					return err
+				}
+				next = append(next, cid)
+			}
+		}
+		frontier = next
+	}
+	return nil
+}
+
+// deletePlaceholderRoot removes the empty root an adopted document came with. Every
+// per-chunk cascade delete_chunk performs is repeated, because a revision or layout row
+// reachable only through the chunk that is going is an orphan nothing can see.
+func (d *Document) deletePlaceholderRoot(ctx context.Context, txnID, chunkID string) error {
+	for _, stmt := range []string{
+		`DELETE FROM chunk_edges WHERE from_id = ? OR to_id = ?`,
+		`DELETE FROM chunk_assets WHERE chunk_id = ?`,
+		`DELETE FROM chunk_tags WHERE chunk_id = ?`,
+		`DELETE FROM chunk_memory_meta WHERE chunk_id = ?`,
+		`DELETE FROM chunk_revisions WHERE chunk_id = ?`,
+		`DELETE FROM chunk_layout WHERE chunk_id = ?`,
+		`DELETE FROM chunks WHERE id = ?`,
+	} {
+		args := []any{chunkID}
+		if strings.Contains(stmt, "OR to_id") {
+			args = append(args, chunkID)
+		}
+		if err := d.execTxn(ctx, txnID, stmt, args...); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/tools/builtin/document_fact_home.go
+++ b/internal/tools/builtin/document_fact_home.go
@@ -86,8 +86,13 @@ type FactHomingReport struct {
 	FactsMoved          int              `json:"facts_moved"`
 	FactsWithoutSubject int              `json:"facts_without_subject"`
 	Skipped             []FactHomingSkip `json:"skipped,omitempty"`
-	DryRun              bool             `json:"dry_run"`
-	Note                string           `json:"note,omitempty"`
+	// PathWarnings names subjects that WERE homed but could not be given their
+	// Path-tree name — reachable by search and by id, invisible to a path browse.
+	// Separate from Skipped because the two need opposite actions: a skip is work
+	// still to do, this is work done and mis-filed.
+	PathWarnings []string `json:"path_warnings,omitempty"`
+	DryRun       bool     `json:"dry_run"`
+	Note         string   `json:"note,omitempty"`
 }
 
 // homingSubject is one old-shape subject node and the facts pointing at it.
@@ -124,7 +129,6 @@ func (d *Document) HomeFactsUnderSubjects(ctx context.Context, tenantID string,
 	// is no run identity on an HTTP request, and an unstamped call would resolve
 	// paths in the default tenant's tree while writing SQL in the named one.
 	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{TenantID: tenantID})
-	mscope := scope
 
 	sharedID, err := d.docIDFromInput(ctx, key, docInput{Path: rememberedFactsPath})
 	if err != nil {
@@ -190,7 +194,7 @@ func (d *Document) HomeFactsUnderSubjects(ctx context.Context, tenantID string,
 		// transaction, and an orphaned body is invisible dead k/v where an orphaned
 		// row would not be.
 		if target.dropRoot != "" {
-			_, _ = d.Store.MemoryDelete(ctx, tenantID, mscope, key.ScopeID, chunkBodyKey(target.dropRoot))
+			_, _ = d.Store.MemoryDelete(ctx, tenantID, scope, key.ScopeID, chunkBodyKey(target.dropRoot))
 		}
 		// The Path-tree name LAST, and only for a document this run created: a failure
 		// here leaves the facts correctly homed and merely unnamed, which is the
@@ -198,11 +202,10 @@ func (d *Document) HomeFactsUnderSubjects(ctx context.Context, tenantID string,
 		// rather than undoing the document).
 		if !target.adopt {
 			if _, perr := d.registerDocDirent(ctx, key, target.docID, path); perr != nil {
-				rep.Skipped = append(rep.Skipped, FactHomingSkip{
-					NaturalKey: s.naturalKey, Subject: s.name,
-					Reason: "the facts were homed but " + path + " could not be registered, so the " +
-						"document is reachable by search and by id and not by path: " + perr.Error(),
-				})
+				rep.PathWarnings = append(rep.PathWarnings,
+					s.naturalKey+" was homed in document "+target.docID+" but "+path+
+						" could not be registered, so it is reachable by search and by id "+
+						"and not by path: "+perr.Error())
 			}
 		}
 	}
@@ -349,7 +352,11 @@ func (d *Document) collectHomingSubjects(ctx context.Context, key sqlmem.ScopeKe
 	// counted so the gap reads as work still to do rather than a silent default.
 	noSubject := 0
 	for id, c := range here {
-		if isFact[id] || byID[id] != nil || c.naturalKey == "" {
+		// Keyed in the FACT keyspace is what makes a chunk a fact here — the one
+		// namespace the k/v and chunk planes share verbatim. Testing merely "has a
+		// sidecar" would also count a subject node whose facts happen to live
+		// elsewhere, and report an identity as a fact with nowhere to go.
+		if isFact[id] || !strings.HasPrefix(c.naturalKey, MemoryFactKeyPrefix) {
 			continue
 		}
 		noSubject++
@@ -395,7 +402,18 @@ type homeTarget struct {
 // subject per pass. Those are exactly the documents to reuse.
 func (d *Document) subjectHomeTarget(ctx context.Context, key sqlmem.ScopeKey, path string, s homingSubject) (homeTarget, error) {
 	existing, derr := d.docIDFromInput(ctx, key, docInput{Path: path})
-	if derr != nil || existing == "" {
+	if derr != nil {
+		// ONLY "not there" means "make one". Treating a transient dirent read fault
+		// as absence would create a SECOND document for a subject that already has
+		// one, and the Path tree can name only one of them — a fork no later run
+		// would notice, because the subject is gone from the shared document either
+		// way.
+		if !strings.Contains(derr.Error(), "no such path") {
+			return homeTarget{}, derr
+		}
+		return homeTarget{docID: newDocID()}, nil
+	}
+	if existing == "" {
 		return homeTarget{docID: newDocID()}, nil
 	}
 	res, qerr := d.query(ctx, key, `SELECT root_chunk_id FROM documents WHERE id = ?`, existing)

--- a/internal/tools/builtin/document_fact_home_test.go
+++ b/internal/tools/builtin/document_fact_home_test.go
@@ -1,0 +1,168 @@
+package builtin
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/channels"
+	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+	"os"
+)
+
+// The end-to-end behaviour of subject homing is pinned in internal/api/http, through
+// the endpoint an operator actually calls. THESE exist for the tier: the migration
+// rewrites document_id and parent_id directly, and the postgres tier is where a
+// portability difference would hide — a count returned as int64, a NULL parent, a
+// statement the rebind mangles. The sqlite half runs everywhere; the postgres half is
+// on the allowlist the pg job runs.
+
+// homedShape reports where every chunk ended up, as id -> (document, parent).
+func homedShape(t *testing.T, d *Document, ctx context.Context, key sqlmem.ScopeKey) map[string][2]string {
+	t.Helper()
+	res, err := d.query(ctx, key, `SELECT id, document_id, coalesce(parent_id, '') FROM chunks`)
+	if err != nil {
+		t.Fatalf("shape: %v", err)
+	}
+	out := map[string][2]string{}
+	for _, row := range res.Rows {
+		out[asStr(row[0])] = [2]string{asStr(row[1]), asStr(row[2])}
+	}
+	return out
+}
+
+// seedOldShape writes the pre-subject-homing layout: one shared document holding a
+// subject node, a fact about it, and a fact about nobody.
+func seedOldShape(t *testing.T, d *Document, ctx context.Context) (shared, subj, fact, orphan string) {
+	t.Helper()
+	out, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Entities","path":"/memory/entities"}`)
+	if r.IsError {
+		t.Fatalf("create shared: %s", r.Text)
+	}
+	shared, _ = out["document_id"].(string)
+	sub, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+shared+
+		`","natural_key":"person:denn","title":"Denn","type":"person","subject":"Denn"}`)
+	if r.IsError {
+		t.Fatalf("subject: %s", r.Text)
+	}
+	subj, _ = sub["id"].(string)
+	f, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+shared+
+		`","natural_key":"memory/fact/denn-writes-go","title":"Denn writes Go.","body":"Denn writes Go.","type":"fact"}`)
+	if r.IsError {
+		t.Fatalf("fact: %s", r.Text)
+	}
+	fact, _ = f["id"].(string)
+	o, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+shared+
+		`","natural_key":"memory/fact/releases-friday","title":"Releases ship Friday.","body":"Releases ship on Friday.","type":"fact"}`)
+	if r.IsError {
+		t.Fatalf("orphan fact: %s", r.Text)
+	}
+	orphan, _ = o["id"].(string)
+	if _, r := docExec(t, d, ctx, `{"op":"link_chunks","scope":"user","from_id":"`+fact+
+		`","to_id":"`+subj+`","kind":"about"}`); r.IsError {
+		t.Fatalf("about edge: %s", r.Text)
+	}
+	return shared, subj, fact, orphan
+}
+
+// assertHomed is the postcondition, shared by both tiers: the subject IS the new
+// document's root (same chunk, so the unique key never moves and the edge never has to
+// be re-pointed), its fact is its child, and the fact about nobody stays where it was.
+func assertHomed(t *testing.T, d *Document, ctx context.Context, key sqlmem.ScopeKey,
+	rep FactHomingReport, shared, subj, fact, orphan string) {
+	t.Helper()
+	if rep.SubjectsHomed != 1 || rep.FactsMoved != 1 || rep.DocumentsCreated != 1 {
+		t.Fatalf("report = %+v, want one subject homed into one new document", rep)
+	}
+	if rep.FactsWithoutSubject != 1 {
+		t.Errorf("facts_without_subject = %d, want 1", rep.FactsWithoutSubject)
+	}
+	shape := homedShape(t, d, ctx, key)
+	subjAt, ok := shape[subj]
+	if !ok {
+		t.Fatalf("the subject node is gone — it must MOVE, not be re-created")
+	}
+	if subjAt[0] == shared {
+		t.Error("the subject node did not leave the shared document")
+	}
+	if subjAt[1] != "" {
+		t.Errorf("the subject's parent is %q, want none — it is a document root now", subjAt[1])
+	}
+	if got := shape[fact]; got[0] != subjAt[0] || got[1] != subj {
+		t.Errorf("fact sits at %v, want document %q under the subject %q", got, subjAt[0], subj)
+	}
+	if got := shape[orphan]; got[0] != shared {
+		t.Errorf("the subject-less fact moved to %q — it has no subject to be homed under", got[0])
+	}
+	// The documents row agrees: root_chunk_id is the subject, not a leftover.
+	res, err := d.query(ctx, key, `SELECT root_chunk_id FROM documents WHERE id = ?`, subjAt[0])
+	if err != nil {
+		t.Fatalf("root: %v", err)
+	}
+	if len(res.Rows) != 1 || asStr(res.Rows[0][0]) != subj {
+		t.Errorf("documents.root_chunk_id = %v, want the subject node %q", res.Rows, subj)
+	}
+	// And the key still has exactly one holder, which is the invariant that makes
+	// moving the node the only workable implementation.
+	kres, err := d.query(ctx, key, `SELECT chunk_id FROM chunk_memory_meta WHERE natural_key = ?`, "person:denn")
+	if err != nil {
+		t.Fatalf("keys: %v", err)
+	}
+	if len(kres.Rows) != 1 || asStr(kres.Rows[0][0]) != subj {
+		t.Errorf("chunks claiming person:denn = %v, want only %q", kres.Rows, subj)
+	}
+}
+
+func TestHomeFactsUnderSubjects_MovesTheSubjectAndItsFacts(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	shared, subj, fact, orphan := seedOldShape(t, d, ctx)
+
+	rep, err := d.HomeFactsUnderSubjects(ctx, "tnt", store.MemoryScopeUser, "u1", false)
+	if err != nil {
+		t.Fatalf("home: %v", err)
+	}
+	assertHomed(t, d, ctx, sidecarScope(t, d, ctx), rep, shared, subj, fact, orphan)
+}
+
+// TestHomeFactsUnderSubjects_PostgresTierParity runs the same postconditions against
+// postgres. The migration is raw UPDATEs over document_id/parent_id and a count read
+// back as an integer — all places the two tiers can differ, and none of them covered
+// by the sqlite fixture.
+func TestHomeFactsUnderSubjects_PostgresTierParity(t *testing.T) {
+	dsn := os.Getenv("LOOMCYCLE_TEST_SQLMEM_PG_DSN")
+	if dsn == "" {
+		t.Skip("set LOOMCYCLE_TEST_SQLMEM_PG_DSN to run the subject-homing postgres-tier parity test")
+	}
+	raw, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("open raw: %v", err)
+	}
+	dropAllSqlmemScopes(t, raw)
+	mgr, err := sqlmem.NewPostgres(context.Background(), sqlmem.Config{PgDSN: dsn, StatementTimeoutMS: 30000, MaxRows: 1000})
+	if err != nil {
+		t.Fatalf("NewPostgres: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = mgr.Close()
+		dropAllSqlmemScopes(t, raw)
+		_ = raw.Close()
+	})
+	st, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	d := &Document{Store: st, SqlMem: mgr, Bus: channels.NewBus()}
+	ctx := tools.WithAgentName(context.Background(), "pg-homing")
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a", UserID: "u1", TenantID: "tnt"})
+
+	shared, subj, fact, orphan := seedOldShape(t, d, ctx)
+	rep, err := d.HomeFactsUnderSubjects(ctx, "tnt", store.MemoryScopeUser, "u1", false)
+	if err != nil {
+		t.Fatalf("home: %v", err)
+	}
+	assertHomed(t, d, ctx, sidecarScope(t, d, ctx), rep, shared, subj, fact, orphan)
+}


### PR DESCRIPTION
## Why

#1203 made a subject its own document at `/facts/<slug>`. It did not move the facts that were already stored, and the reason that matters turned out to be larger than a migration.

`chunk_memory_meta.natural_key` is **UNIQUE per scope**. On any store whose subject nodes predate per-subject documents, the old node in `/memory/entities` holds `person:denn`, so the document claiming that key **cannot be created**. Measured against a real store, that has two consequences nothing in the suite caught:

1. **No `about` edge is written.** `subjectDoc` fails, so no subject node is resolved, so the fact is stored *unreachable from the person it is about* — the one failure the entity tier exists to prevent. The fact itself lands fine, which is why it was invisible.
2. **An orphaned document leaks per subject per pass.** `create_document` inserts the document and its root *before* the sidecar write that fails, and the dirent registration comes *after* — so each pass leaves one more empty, path-less document that nothing lists and nothing reaps. Seeded probe: 3 passes → 4 documents, 5 chunks.

## What

**`fix(document)` — a refused entity root leaves nothing behind.** The key is checked before anything is written, and the refusal names the chunk holding it and the migration that frees it. The write is also unwound if it fails anyway — the guard covers the knowable cause, the unwind covers the race, because the leak is what does the damage, not its reason. (An unwind rather than a transaction: the root's body row lives in the Memory k/v plane, a different database, the same constraint `delete_chunk` works under.)

**`fix(memory)` — an unmigrated subject still gets its edge.** `mirrorEntity` now asks `homeFor()`, which always answers if the graph can be written at all: the subject's own document when it can be had, otherwise the shared entity document with the subject as a sibling — the shape that scope is already in, entire. Self-retiring: after migration the preferred path succeeds and it never fires. A successful fallback is **not** counted as a failed graph write; the pass reports it on its own line and names the operation that ends it.

**`feat(memory)` — `POST /v1/_memory/home_facts`.** Moves facts into `/facts/<subject-slug>`, root = the entity.

- **It moves the subject too**, and that is what makes the rest simple. The subject node *becomes* the new root rather than being re-created beside it, so it keeps its chunk id — sidecar, unique key, body and every edge travel with it. Nothing is copied, nothing re-pointed, and the unique key is never held twice, which is the constraint that makes the obvious implementation impossible. `document_id` + `parent_id` is exactly the pair `move_chunk` refuses to change, so this cannot be tool calls.
- **The unit of refusal is the subject, not the scope** — the opposite of `collapse_facts` (#1196), and for the reason that made the collapse refuse everything: the collapse *deleted*. Nothing here is deleted but an empty placeholder root, so an unhomeable subject is left where it is, reported with the reason, and picked up next run.
- **Adopts** the leaked strays rather than forking a second document the Path tree cannot name.
- A fact about **nobody stays put** — inventing a subject is how two different things end up on one node. `remember` facts stay too (no subject node, so no key to follow; deriving one would mean a Go twin of the bundle's slug).
- `dry_run` defaults true; an admin must name the tenant; gated `substrate:tenant`, tenant-confined in the handler.

## What was tested

`go test ./...` clean (101 packages).

- `TestCreateDocument_RefusesAHeldNaturalKeyAndLeavesNothingBehind` — asserts document/chunk **counts** after three refused creates. Fail-before (behaviour only reverted): **4 documents, 5 chunks** where 1 and 2 are correct.
- `TestConsolidator_AnUnmigratedSubjectStillGetsItsEdge` — new `failSubjectDocs` knob models the one real state (`create_document` refused, `upsert_chunk` fine), which `failEntityKeys` cannot express because it fails both. Fail-before: **0 `about` edges** where 1 is correct.
- Six behaviours in `memory_home_facts_test.go`: the move (chunk ids survive, the subject *is* the root, the edge still points at it, one holder per key), the subject-less fact left behind, adoption of a leaked stray, idempotency, dry-run inertness, admin-must-name-the-tenant.

**Live end-to-end**, seeded old-shape store on a running server: the pre-fix `create_document` refusal reproduced and now names the remedy; dry run reported `2 subjects / 1 created / 1 adopted / 2 moved / 1 left` and changed nothing; the real run produced `/facts/denn` + `/facts/caroline` with the original subject chunks as their roots, facts as children, the stray's placeholder root gone, `path ls /facts` an entity directory, `export_md` a one-read dossier, exactly one holder per natural key, and a second run a no-op.

## Not in this PR

The reader contract (a relation-fact reachable from every subject it references) — nothing *produces* a multi-subject fact yet, so it would be scaffolding. `remember` subject-homing, which needs the slug question settled first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8