### PR TITLE
feat(teamdef): a team walk is a run, and can be started detached

### DIFF
--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -935,6 +935,14 @@ func (s *Server) SetTeamDefTool(t tools.Tool) {
 				return nil
 			}
 		}
+		if td.WalkRun == nil {
+			// A team walk becomes a real run, so every run-scoped surface —
+			// breakpoints, the Interruption ask a pause is answered through,
+			// cancel — has a handle to reach it by. Without it, op=run over the
+			// substrate route had no run id and no Interruption policy, and an
+			// armed breakpoint aborted the walk instead of pausing it.
+			td.WalkRun = s.openTeamWalkRun
+		}
 		if td.LiveBreakpoints == nil {
 			// Ad-hoc Run → Debug: the walk reads its arming from a set this
 			// server can still write to, so a state can be armed after the run

--- a/internal/api/http/teamwalk_run.go
+++ b/internal/api/http/teamwalk_run.go
@@ -1,0 +1,81 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// A team walk is a RUN.
+//
+// Everything that makes a walk observable or controllable from outside is
+// addressed by run id — the breakpoint set, the Interruption ask a pause is
+// answered through, cancel, the event stream. A walk that had no run had no
+// handle, so none of them could reach it. That was not a gap in any one of
+// them; it was the walk not being a first-class unit of work.
+//
+// The concrete failure this fixes: loomboard drives loomcycle through the TS
+// adapter over `POST /v1/_teamdef {op:"run"}`, which dispatches under
+// substrateAdminCtx — no run id, no Interruption policy. A breakpoint armed
+// there could not be answered, and a pause that cannot be answered fails safe
+// to ABORT, so arming one killed the walk instead of pausing it.
+
+// teamWalkAgentPrefix names the synthetic agent a walk's run is filed under, so
+// the runs list shows `team:triage` rather than a bare id. It is a run's
+// `agent` label, never a resolvable AgentDef — the walk spawns its members
+// through their own defs.
+const teamWalkAgentPrefix = "team:"
+
+// openTeamWalkRun gives one op=run walk its own run. Wired into the TeamDef
+// tool by SetTeamDefTool.
+//
+// detach decides the ctx's lifetime, not the run's identity: a detached walk
+// keeps the request's ctx VALUES (auth principal, tenant, admission) but is not
+// cancelled when the handler returns, mirroring how an interactive run survives
+// the client navigating away.
+func (s *Server) openTeamWalkRun(ctx context.Context, teamName string, detach bool) (context.Context, string, func(error), error) {
+	if s.store == nil {
+		return ctx, "", func(error) {}, fmt.Errorf("run tracking requires a store")
+	}
+	ident := tools.RunIdentity(ctx)
+	agent := teamWalkAgentPrefix + teamName
+	_, runID, err := s.openOrCreateSessionAndRun(ctx, "", agent, ident.TenantID, ident.UserID, store.RunIdentity{
+		AgentID: agent,
+		UserID:  ident.UserID,
+	})
+	if err != nil {
+		return ctx, "", func(error) {}, err
+	}
+
+	walkCtx := ctx
+	if detach {
+		walkCtx = context.WithoutCancel(ctx)
+	}
+	walkCtx = tools.WithRunID(walkCtx, runID)
+	// The pause machinery is the Interruption tool's `ask`, which is gated on
+	// the CALLING AGENT's policy. A walk has no AgentDef to carry one, so the
+	// grant is made here, narrowed to the one kind a breakpoint uses: a
+	// question. Without it every pause errors, and a pause that cannot be
+	// answered aborts the walk.
+	walkCtx = tools.WithInterruptionPolicy(walkCtx, tools.InterruptionPolicyValue{
+		Enabled: true,
+		Kinds:   []string{"question"},
+	})
+
+	finish := func(walkErr error) {
+		status, msg := store.RunCompleted, ""
+		if walkErr != nil {
+			status, msg = store.RunFailed, walkErr.Error()
+		}
+		// A survival ctx: the run row must be closed even when the walk failed
+		// because its ctx was cancelled, or a cancelled walk would sit in the
+		// runs list as running forever.
+		if ferr := s.store.FinishRun(context.WithoutCancel(walkCtx), runID, status, "", store.Usage{}, msg); ferr != nil {
+			log.Printf("teamdef: finish walk run %s: %v", runID, ferr)
+		}
+	}
+	return walkCtx, runID, finish, nil
+}

--- a/internal/api/http/teamwalk_run_test.go
+++ b/internal/api/http/teamwalk_run_test.go
@@ -1,0 +1,111 @@
+package http
+
+import (
+	"context"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// TestOpenTeamWalkRun_GrantsWhatThePauseMachineryNeeds is the regression for
+// the defect this whole change exists to fix.
+//
+// loomboard drives loomcycle over POST /v1/_teamdef, which dispatches under
+// substrateAdminCtx — a plane with NO run id and NO Interruption policy. A
+// breakpoint armed there could not be answered, and a pause that cannot be
+// answered fails safe to ABORT, so arming one killed the walk instead of
+// pausing it. Both halves are asserted because either one alone still aborts.
+func TestOpenTeamWalkRun_GrantsWhatThePauseMachineryNeeds(t *testing.T) {
+	srv, cleanup := channelFanFixture(t)
+	defer cleanup()
+
+	// The plane the canvas actually arrives on.
+	base := substrateAdminCtx(context.Background())
+	if tools.RunID(base) != "" {
+		t.Fatal("the substrate plane already had a run id — this test no longer covers the gap")
+	}
+	if tools.InterruptionPolicy(base).Enabled {
+		t.Fatal("the substrate plane already granted Interruption — this test no longer covers the gap")
+	}
+
+	walkCtx, runID, finish, err := srv.openTeamWalkRun(base, "triage", false)
+	if err != nil {
+		t.Fatalf("openTeamWalkRun: %v", err)
+	}
+	if runID == "" {
+		t.Fatal("no run id — the breakpoint set and the ask are both keyed on it")
+	}
+	if got := tools.RunID(walkCtx); got != runID {
+		t.Errorf("ctx run id = %q, want %q", got, runID)
+	}
+	pol := tools.InterruptionPolicy(walkCtx)
+	if !pol.Enabled {
+		t.Error("Interruption is not enabled on the walk ctx — every pause would error, and an unanswerable pause ABORTS the walk")
+	}
+	if len(pol.Kinds) != 1 || pol.Kinds[0] != "question" {
+		t.Errorf("Interruption kinds = %v, want just [question] — a breakpoint asks nothing else", pol.Kinds)
+	}
+
+	// The run is real and addressable, filed under the team.
+	run, err := srv.store.GetRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("the walk's run row is not readable: %v", err)
+	}
+	if run.AgentID != teamWalkAgentPrefix+"triage" {
+		t.Errorf("run agent = %q, want %q", run.AgentID, teamWalkAgentPrefix+"triage")
+	}
+	if run.Status != store.RunRunning {
+		t.Errorf("run status = %q, want running", run.Status)
+	}
+
+	// And finishing records the outcome, so a failed walk is never left looking
+	// like one still going.
+	finish(context.DeadlineExceeded)
+	run, err = srv.store.GetRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("GetRun after finish: %v", err)
+	}
+	if run.Status != store.RunFailed {
+		t.Errorf("status after a failed walk = %q, want failed", run.Status)
+	}
+	// The message the walk failed with reaches the row, so a failed walk is
+	// never indistinguishable from one still going.
+	if run.ErrorMsg == "" {
+		t.Error("the walk's error was not recorded on the run")
+	}
+}
+
+// TestOpenTeamWalkRun_DetachSurvivesTheRequestCtx: a detached walk must keep
+// the request's ctx VALUES (auth principal, tenant, admission) while no longer
+// dying when the handler returns — the same trade an interactive run makes.
+func TestOpenTeamWalkRun_DetachSurvivesTheRequestCtx(t *testing.T) {
+	srv, cleanup := channelFanFixture(t)
+	defer cleanup()
+
+	reqCtx, cancel := context.WithCancel(substrateAdminCtx(context.Background()))
+	walkCtx, _, _, err := srv.openTeamWalkRun(reqCtx, "triage", true)
+	if err != nil {
+		t.Fatalf("openTeamWalkRun: %v", err)
+	}
+	cancel() // the handler returns
+	if walkCtx.Err() != nil {
+		t.Fatal("a detached walk ctx died with the request — the walk would be killed the moment the caller got its run id")
+	}
+	// Values survive: the identity the walk spawns its members under.
+	if tools.RunIdentity(walkCtx).AgentID == "" {
+		t.Error("the detached ctx lost its run identity")
+	}
+
+	// A NON-detached walk keeps the request's lifetime, so a disconnect still
+	// tears it down.
+	reqCtx2, cancel2 := context.WithCancel(substrateAdminCtx(context.Background()))
+	walkCtx2, _, _, err := srv.openTeamWalkRun(reqCtx2, "triage", false)
+	if err != nil {
+		t.Fatalf("openTeamWalkRun: %v", err)
+	}
+	cancel2()
+	if walkCtx2.Err() == nil {
+		t.Error("a synchronous walk outlived its request ctx")
+	}
+}

--- a/internal/tools/builtin/teamdef.go
+++ b/internal/tools/builtin/teamdef.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 
@@ -113,6 +114,29 @@ type TeamDef struct {
 	// is omitted from the report rather than reported as failing.
 	AgentExists func(ctx context.Context, name string) bool
 
+	// WalkRun, if set, gives an op=run walk its OWN run: a session, a `runs`
+	// row, a run id on ctx, and the Interruption policy the pause machinery
+	// needs. It returns the walk's ctx, the run id, and the finish to call when
+	// the walk ends.
+	//
+	// WHY A WALK IS A RUN. Everything that makes a walk observable or
+	// controllable from outside is addressed by run id — the breakpoint set,
+	// the Interruption ask a pause is answered through, cancel, the event
+	// stream. A walk that had no run had no handle, so none of them could reach
+	// it. That was not a gap in any one of them; it was the walk not being a
+	// first-class unit of work.
+	//
+	// It also fixes the thing no amount of endpoint-adding could: over HTTP,
+	// op=run is synchronous, so a caller learned nothing until the walk was
+	// over. With a run and `mode:"detach"` the run id comes back immediately
+	// and the caller holds a handle WHILE the walk runs, which is what a
+	// debugger needs and what live status will need next.
+	//
+	// nil = the walk runs under the caller's own ctx (an in-band agent run
+	// already has a run id; a direct API call gets none, and its breakpoints
+	// are unaddressable — the behaviour before this existed).
+	WalkRun func(ctx context.Context, teamName string, detach bool) (walkCtx context.Context, runID string, finish func(error), err error)
+
 	// LiveBreakpoints, if set, opens the MUTABLE armed set for this run's walk,
 	// seeded with the run argument, and returns it plus the release to call when
 	// the walk ends.
@@ -158,7 +182,8 @@ const teamDefDescription = `Author, fork, promote, retire, and inspect team work
 	`(success to advance, pushback to loop back for rework) — output threads to the next state, until a ` +
 	`terminal state. run may OPTIONALLY bind to a Document chunk board (board_chunk_id) so progress persists ` +
 	`as chunk.status and resumes across runs, and may escalate an iteration cap to a human (interrupt_on_cap) ` +
-	`instead of aborting. create and fork PREFLIGHT a definition's channel references — a channel the team's own ACL ` +
+	`instead of aborting. A run is a first-class unit of work: it gets its own run_id (returned either way), so it can be ` +
+	`addressed while it runs — mode=detach returns that id immediately instead of waiting for the walk. create and fork PREFLIGHT a definition's channel references — a channel the team's own ACL ` +
 	`does not grant, or one that is not declared at all, is refused with the exact block to add, rather than ` +
 	`failing later at the state that needed it. verify reports the content hash AND sweeps what the stored ` +
 	`definition references but does not contain (channels deleted, ACL gaps, members retired) as issues[] with ` +
@@ -197,6 +222,7 @@ const teamDefInputSchema = `{
     "board_chunk_id": {"type": "string", "description": "run (optional): bind the walk to a Document chunk task board. Each state transition persists chunk.status = the current team state (durable progress), and a later run RESUMES from the persisted status. Omit for an ephemeral run (default)."},
     "board_scope":    {"type": "string", "enum": ["agent","user"], "description": "run (optional): the Document scope of board_chunk_id (default user)."},
     "interrupt_on_cap": {"type": "boolean", "description": "run (optional): when a state hits its iteration cap, ask a human (Interruption) whether to continue / reroute:<state> / abort instead of returning the iteration_cap outcome. An unanswered/timed-out/declined ask aborts (still terminates). Default false."},
+    "mode":             {"type": "string", "enum": ["detach"], "description": "run (optional): omit to wait for the walk and get its trace. \"detach\" returns {run_id, status:\"running\"} immediately and the walk continues in the background — use it when you need a handle WHILE the walk runs, to arm a breakpoint, answer a pause, or watch progress. Either way the response carries run_id."},
     "breakpoints":      {"type": "array", "items": {"type": "string"}, "description": "run (optional): debug mode. Each entry is a starter state id — \"review\" pauses both phases, \"review:before_dispatch\" or \"review:after_collection\" pauses one. At before_dispatch the wave is composed but nothing has run; at after_collection the runs are done but nothing has reached the sink. Each pause asks a human (Interruption) to reply 'continue' (release all), 'release:<n>' (release n and pause again), or 'abort'. An unanswered/declined ask aborts. A run-time argument, never part of the definition: debugging a team must not change what the team IS."}
   },
   "required": ["op"]
@@ -219,6 +245,7 @@ type teamDefInput struct {
 	BoardScope     string          `json:"board_scope,omitempty"`      // run: board_chunk_id's Document scope (agent|user, default user)
 	InterruptOnCap bool            `json:"interrupt_on_cap,omitempty"` // run: escalate an iteration cap to a human instead of aborting
 	Breakpoints    []string        `json:"breakpoints,omitempty"`      // run: starter states to pause at (debug mode)
+	Mode           string          `json:"mode,omitempty"`             // run: "" (wait for the walk) | "detach" (return the run id now)
 }
 
 // Name implements tools.Tool.
@@ -810,6 +837,28 @@ func (t *TeamDef) execRun(ctx context.Context, in teamDefInput) (tools.Result, e
 		}
 	}
 
+	detach := in.Mode == "detach"
+	if in.Mode != "" && !detach {
+		return errResult(fmt.Sprintf("run: unknown mode %q (only \"detach\")", in.Mode)), nil
+	}
+	// The walk becomes a RUN — after admission, so a refused request never
+	// mints a row. From here on walkCtx carries the run id, which is what makes
+	// the walk addressable: breakpoints, the Interruption ask a pause is
+	// answered through, and cancel all key on it.
+	runID := ""
+	finishRun := func(error) {}
+	if t.WalkRun != nil {
+		var werr error
+		walkCtx, runID, finishRun, werr = t.WalkRun(walkCtx, row.Name, detach)
+		if werr != nil {
+			return errResult(fmt.Sprintf("run: %s", werr)), nil
+		}
+	} else if detach {
+		// Refused, not silently run inline: a caller that asked for a handle
+		// and got a completed walk instead has no way to notice.
+		return errResult("run: mode=detach requires run tracking, which is not wired on this server"), nil
+	}
+
 	task := &teamrun.Task{Input: in.Input}
 
 	// Assemble walk options. When neither feature is used, opts is empty and Walk
@@ -915,12 +964,19 @@ func (t *TeamDef) execRun(ctx context.Context, in teamDefInput) (tools.Result, e
 	//
 	// An empty set answers false for every state, so a walk nobody arms takes
 	// the same path it took before any of this existed.
+	releaseBreakpoints := func() {}
 	if t.AskHuman != nil {
-		src, release, serr := t.openBreakpoints(ctx, in.Breakpoints)
+		// Opened on the WALK ctx, which now carries the run id — that is the key
+		// the arming endpoint addresses. Opening it on the caller's ctx would
+		// register the set under whatever run the CALLER is in, or under none.
+		src, release, serr := t.openBreakpoints(walkCtx, in.Breakpoints)
 		if serr != nil {
 			return errResult(fmt.Sprintf("run: %s", serr)), nil
 		}
-		defer release()
+		// NOT a defer: a detached walk outlives this function, and releasing
+		// here would unregister the armed set the moment the caller got its run
+		// id back — leaving a running walk nobody could arm.
+		releaseBreakpoints = release
 		runnerOpts = append(runnerOpts, teamrun.WithBreakpoints(src,
 			func(c context.Context, bp teamrun.Breakpoint) (teamrun.BreakDecision, error) {
 				breaks++
@@ -949,7 +1005,36 @@ func (t *TeamDef) execRun(ctx context.Context, in teamDefInput) (tools.Result, e
 	if t.MaxWave > 0 {
 		runnerOpts = append(runnerOpts, teamrun.WithMaxWave(t.MaxWave))
 	}
-	trace, walkErr := teamrun.Walk(walkCtx, def, task, teamrun.NewAgentRunner(t.Spawn, runnerOpts...), opts...)
+	runner := teamrun.NewAgentRunner(t.Spawn, runnerOpts...)
+	walk := func() ([]teamrun.StepRecord, error) {
+		defer releaseBreakpoints()
+		trace, werr := teamrun.Walk(walkCtx, def, task, runner, opts...)
+		finishRun(werr)
+		return trace, werr
+	}
+
+	if detach {
+		// The caller gets its handle NOW and the walk continues behind it. This
+		// is the whole point of the mode: a synchronous op=run tells the caller
+		// nothing until it is over, so there is no moment at which it can arm a
+		// breakpoint, read a pause, or watch progress.
+		//
+		// walkCtx is already detached from the request by WalkRun, so the walk
+		// survives this handler returning; only cancel stops it.
+		go func() {
+			if _, werr := walk(); werr != nil {
+				log.Printf("teamdef: detached walk %q (run %s): %v", row.Name, runID, werr)
+			}
+		}()
+		return okJSON(map[string]any{
+			"name":   row.Name,
+			"def_id": row.DefID,
+			"run_id": runID,
+			"status": "running",
+		})
+	}
+
+	trace, walkErr := walk()
 
 	steps := make([]map[string]any, 0, len(trace))
 	for _, s := range trace {
@@ -966,6 +1051,12 @@ func (t *TeamDef) execRun(ctx context.Context, in teamDefInput) (tools.Result, e
 	// the relevant feature was used, keeping the default ephemeral response shape
 	// byte-identical for existing callers.
 	annotate := func(m map[string]any) map[string]any {
+		if runID != "" {
+			// Reported on the synchronous path as well: a caller holding a
+			// second connection can still arm this walk while it runs, and the
+			// id is what every run surface keys on afterwards.
+			m["run_id"] = runID
+		}
 		if boardBound {
 			m["board_chunk_id"] = in.BoardChunkID
 			m["board_scope"] = boardScope

--- a/internal/tools/builtin/teamdef_walkrun_test.go
+++ b/internal/tools/builtin/teamdef_walkrun_test.go
@@ -1,0 +1,217 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/teamrun"
+)
+
+// walkRunRecorder stands in for the server's run opener.
+type walkRunRecorder struct {
+	mu       sync.Mutex
+	opened   int
+	finished int
+	lastErr  error
+	detach   bool
+}
+
+func (w *walkRunRecorder) open(ctx context.Context, _ string, detach bool) (context.Context, string, func(error), error) {
+	w.mu.Lock()
+	w.opened++
+	w.detach = detach
+	w.mu.Unlock()
+	// Detached in the same way the server does it, so a test that outlives the
+	// caller's ctx behaves like production.
+	if detach {
+		ctx = context.WithoutCancel(ctx)
+	}
+	return ctx, "r_walk1", func(err error) {
+		w.mu.Lock()
+		w.finished++
+		w.lastErr = err
+		w.mu.Unlock()
+	}, nil
+}
+
+func (w *walkRunRecorder) counts() (int, int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.opened, w.finished
+}
+
+// TestTeamDefTool_Run_CarriesARunID: a walk is a run, so every run-scoped
+// surface has a handle to reach it by. Reported on the synchronous path too —
+// a caller holding a second connection can still arm this walk while it runs.
+func TestTeamDefTool_Run_CarriesARunID(t *testing.T) {
+	tool, ctx, _, _, done := breakFixture(t)
+	defer done()
+	rec := &walkRunRecorder{}
+	tool.WalkRun = rec.open
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"run","name":"triage","input":"x"}`))
+	if res.IsError {
+		t.Fatalf("run: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	if out["run_id"] != "r_walk1" {
+		t.Errorf("run_id = %v, want r_walk1", out["run_id"])
+	}
+	if opened, finished := rec.counts(); opened != 1 || finished != 1 {
+		t.Errorf("opened=%d finished=%d, want 1/1", opened, finished)
+	}
+	if rec.detach {
+		t.Error("a plain run asked for a detached ctx")
+	}
+}
+
+// TestTeamDefTool_Run_DetachReturnsTheHandleBeforeTheWalkFinishes is the shape
+// the canvas needs: over HTTP op=run is synchronous, so without this there is
+// no moment at which a caller holds an identity for a walk that is still
+// running — nothing to arm, nothing to answer, nothing to watch.
+func TestTeamDefTool_Run_DetachReturnsTheHandleBeforeTheWalkFinishes(t *testing.T) {
+	tool, ctx, io, _, done := breakFixture(t)
+	defer done()
+	rec := &walkRunRecorder{}
+	tool.WalkRun = rec.open
+
+	release := make(chan struct{})
+	spawned := make(chan struct{}, 8)
+	tool.Spawn = func(context.Context, string, teamrun.Prompt, string) (string, error) {
+		spawned <- struct{}{}
+		<-release // hold the walk open
+		return "reviewed", nil
+	}
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"run","name":"triage","input":"x","mode":"detach"}`))
+	if res.IsError {
+		t.Fatalf("detach: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	if out["run_id"] != "r_walk1" || out["status"] != "running" {
+		t.Fatalf("detach response = %v, want {run_id, status:running}", out)
+	}
+	// Execute RETURNED while the walk is still in flight — that is the point.
+	<-spawned
+	if _, finished := rec.counts(); finished != 0 {
+		t.Errorf("the walk finished before Execute returned — it was not detached")
+	}
+	if io.count() != 0 {
+		t.Errorf("the walk had already published before the handle came back")
+	}
+	if !rec.detach {
+		t.Error("detach did not ask for a detached ctx — the walk would die with the request")
+	}
+
+	close(release)
+	waitFor(t, func() bool { _, f := rec.counts(); return f == 1 })
+	if io.count() != 2 {
+		t.Errorf("the detached walk published %d sink messages, want 2", io.count())
+	}
+}
+
+// TestTeamDefTool_Run_DetachReleasesBreakpointsWhenTheWALKEnds pins the bug
+// that a `defer` would have caused: a detached walk outlives Execute, so
+// releasing the armed set on return would unregister it the moment the caller
+// got its run id — leaving a running walk nobody could arm.
+func TestTeamDefTool_Run_DetachReleasesBreakpointsWhenTheWALKEnds(t *testing.T) {
+	tool, ctx, _, _, done := breakFixture(t)
+	defer done()
+	rec := &walkRunRecorder{}
+	tool.WalkRun = rec.open
+	tool.AskHuman = func(context.Context, string) (string, error) { return "continue", nil }
+
+	var mu sync.Mutex
+	released := 0
+	tool.LiveBreakpoints = func(_ context.Context, seed []string) (teamrun.BreakpointSource, func(), error) {
+		src, err := teamrun.NewStaticBreakpoints(seed)
+		return src, func() { mu.Lock(); released++; mu.Unlock() }, err
+	}
+	gate := make(chan struct{})
+	tool.Spawn = func(context.Context, string, teamrun.Prompt, string) (string, error) {
+		<-gate
+		return "reviewed", nil
+	}
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"run","name":"triage","input":"x","mode":"detach"}`))
+	if res.IsError {
+		t.Fatalf("detach: %s", res.Text)
+	}
+	mu.Lock()
+	early := released
+	mu.Unlock()
+	if early != 0 {
+		t.Fatal("the armed set was released when Execute returned — a detached walk would be unarmable")
+	}
+	close(gate)
+	waitFor(t, func() bool { mu.Lock(); defer mu.Unlock(); return released == 1 })
+}
+
+// TestTeamDefTool_Run_DetachRefusedWithoutRunTracking: a caller that asked for
+// a handle and silently got a completed walk instead has no way to notice.
+func TestTeamDefTool_Run_DetachRefusedWithoutRunTracking(t *testing.T) {
+	tool, ctx, _, spawned, done := breakFixture(t)
+	defer done()
+	tool.WalkRun = nil
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"run","name":"triage","input":"x","mode":"detach"}`))
+	if !res.IsError || !strings.Contains(res.Text, "run tracking") {
+		t.Fatalf("want a refusal naming the missing wiring, got IsError=%v: %s", res.IsError, res.Text)
+	}
+	if *spawned != 0 {
+		t.Errorf("a refused detach ran the walk anyway: spawned=%d", *spawned)
+	}
+}
+
+func TestTeamDefTool_Run_UnknownModeIsRefused(t *testing.T) {
+	tool, ctx, _, spawned, done := breakFixture(t)
+	defer done()
+	tool.WalkRun = (&walkRunRecorder{}).open
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"run","name":"triage","input":"x","mode":"bogus"}`))
+	if !res.IsError || !strings.Contains(res.Text, "unknown mode") {
+		t.Fatalf("want a refusal, got IsError=%v: %s", res.IsError, res.Text)
+	}
+	if *spawned != 0 {
+		t.Errorf("a refused mode ran the walk anyway: spawned=%d", *spawned)
+	}
+}
+
+// TestTeamDefTool_Run_FinishCarriesTheWalkError: the run row must record WHY a
+// walk failed, or a failed detached walk is indistinguishable from one still
+// going.
+func TestTeamDefTool_Run_FinishCarriesTheWalkError(t *testing.T) {
+	tool, ctx, _, _, done := breakFixture(t)
+	defer done()
+	rec := &walkRunRecorder{}
+	tool.WalkRun = rec.open
+	tool.Channels = nil // a starter with no channel executor fails the walk
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"run","name":"triage","input":"x"}`))
+	if !res.IsError {
+		t.Fatalf("expected the walk to fail: %s", res.Text)
+	}
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	if rec.finished != 1 || rec.lastErr == nil {
+		t.Errorf("finish called %d times with err=%v, want 1 and an error", rec.finished, rec.lastErr)
+	}
+}
+
+// waitFor polls a condition rather than sleeping a fixed interval, so the test
+// is neither flaky on a slow machine nor slow on a fast one.
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatal("condition not met within 3s")
+}


### PR DESCRIPTION
## Why this exists as its own PR

**#1204's squash-merge dropped its last commit.** The branch had three; `a9d3ed2f` on main carries two. The live-arming half landed, the walk-is-a-run half did not — so `WalkRun`, `openTeamWalkRun`, `teamwalk_run.go` and `mode:"detach"` are all absent from main.

That leaves the headline defect **unfixed on main**: over the transport loomboard uses, arming a breakpoint still aborts the walk.

```
POST /v1/_teamdef {"op":"run","name":"triage","breakpoints":["wave"]}
→ "run: teamrun: state \"wave\" … wave: aborted at the breakpoint"
```

This is a straight cherry-pick of `e25dbddf`, unmodified, onto current main.

## What it restores

`POST /v1/_teamdef {op:"run"}` dispatches under `substrateAdminCtx` — **no run id, no Interruption policy**. A pause asks through `Interruption op=ask`, which needs both, so the ask errors, and by design an unanswerable pause fails safe to abort.

Underneath that, `op=run` over HTTP is **synchronous**: the caller learns nothing until the walk is over, so it never holds a handle for a walk still running. No endpoint fixes that.

**A walk is a run.** `op=run` opens a session and a `runs` row (filed `team:<name>`), stamps the run id on the walk ctx, grants the Interruption policy narrowed to `question`, and finishes the row with the walk's status and error. Everything run-scoped — the breakpoint set, the ask, cancel, the event stream — then has a handle to reach a walk by. It is also the handle L7 live status needs next.

**`mode: "detach"`** returns `{run_id, status:"running"}` immediately and continues the walk behind the caller, detached with `context.WithoutCancel` so it keeps the request's values without dying when the handler returns. Omitting `mode` keeps the synchronous behaviour *and* still returns `run_id`.

Two things that needed care, unchanged from the original commit:

- **The breakpoint release is not deferred.** A detached walk outlives `Execute`; releasing on return would unregister the armed set the moment the caller got its run id — leaving a running walk nobody could arm.
- **`mode=detach` without run tracking is refused**, not run inline: a caller that asked for a handle and got a finished walk cannot notice.

## Tested

Re-verified on **current main** (which has moved on by four commits since the original branch): `go build ./...`, `go vet ./...`, `gofmt -l` clean, **`go test ./...` green (111 packages)**.

Fail-before on the original branch, six claims, each red against its own break: no Interruption grant · no run id on the walk ctx · detach not detaching the ctx · detach running inline · a deferred breakpoint release · detach silently degrading.

Verified live over the canvas's own transport: detach returns a handle, the walk **parks instead of aborting**, `GET /v1/runs/{id}/interrupts` carries the pause with each composed prompt, and `release:1` dispatches exactly one and parks again at 1 pending.

Tests: `TestTeamDefTool_Run_CarriesARunID`, `_DetachReturnsTheHandleBeforeTheWalkFinishes`, `_DetachReleasesBreakpointsWhenTheWALKEnds`, `_DetachRefusedWithoutRunTracking`, `_UnknownModeIsRefused`, `_FinishCarriesTheWalkError`; `TestOpenTeamWalkRun_GrantsWhatThePauseMachineryNeeds`, `_DetachSurvivesTheRequestCtx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD