### PR TITLE
feat(presets): a system-channels bundle — declare only what something publishes

### DIFF
--- a/bundles/system-channels/loomcycle.yaml
+++ b/bundles/system-channels/loomcycle.yaml
@@ -1,0 +1,93 @@
+# Embedded bundle: system-channels
+#
+# The runtime's own `_system/*` channels, declared so a workflow can read them
+# without an operator hand-writing the yaml. Selected via
+# `LOOMCYCLE_PRESETS=…,system-channels`.
+#
+# WHY A BUNDLE AND NOT AN ALWAYS-ON DEFAULT. Declaring a channel is free;
+# TICKING one is not. A heartbeat writes a row every period, on every
+# deployment, forever — including the laptops and the TrueNAS app — whether or
+# not anything reads it. That cost is worth paying once a workflow sources a
+# Starter from a tick, and not before, so it is opted into rather than
+# inherited. One env var replaces the yaml an operator would otherwise write by
+# hand, which was the actual friction.
+#
+# WHAT IS DECLARED IS WHAT SOMETHING PUBLISHES. Every name below has a real
+# publisher in the runtime today:
+#
+#   heartbeat-{1m,5m,1h}   internal/channels/heartbeat.go, one goroutine per
+#                          declared cadence channel
+#   interrupts/pending     Interruption `ask` (internal/tools/builtin)
+#   interrupts/resolved    the resolve endpoint + the interrupt sweeper
+#
+# Names with NO publisher are deliberately absent — declaring them would ship
+# channels that can only ever be empty, which reads as a broken feature rather
+# than an unused one. `_system/runtime-state` and `_system/provider-events` are
+# in the runtime's event-driven registry but nothing writes them (see the note
+# there); the `alarms/*` set never had a publisher either.
+#
+# Agents cannot publish to a `_system/` channel regardless of ACL — the prefix
+# is reserved for the internal publisher and the admin endpoint. A team or an
+# agent SUBSCRIBES to these; it never writes them.
+
+channels:
+  # ---- cadence: a Starter's clock ----
+  #
+  # TTL is 2x the period, not longer, on purpose. A heartbeat means "now" — the
+  # runner's own comment says it represents the moment rather than history — and
+  # a long TTL would let a Starter that has been down fire immediately on a
+  # stale tick it was never meant to see. Two periods is enough that a tick is
+  # never lost to a razor-thin race between publish and read, and short enough
+  # that nothing old is ever waiting.
+  _system/heartbeat-1m:
+    description: "One-minute tick. A Starter sourcing this runs its wave every minute."
+    scope: global
+    publisher: system
+    period: 1m
+    default_ttl: 120
+    max_messages: 5
+    semantic: broadcast
+
+  _system/heartbeat-5m:
+    description: "Five-minute tick."
+    scope: global
+    publisher: system
+    period: 5m
+    default_ttl: 600
+    max_messages: 5
+    semantic: broadcast
+
+  _system/heartbeat-1h:
+    description: "Hourly tick."
+    scope: global
+    publisher: system
+    period: 1h
+    default_ttl: 7200
+    max_messages: 5
+    semantic: broadcast
+
+  # ---- event-driven: published when the event happens, never on a clock ----
+  #
+  # scope: user, matching what the publishers actually pass — an interruption
+  # belongs to the user whose run raised it, and a global declaration would put
+  # every tenant's pending asks on one wire.
+  #
+  # These cost nothing when idle: no goroutine, no tick, a row only when an
+  # interruption is actually raised or answered. They are here rather than
+  # always-on only because a deployment that reads neither should not accrue
+  # rows it never asked for.
+  _system/interrupts/pending:
+    description: "An Interruption ask is waiting for a human. Lets an external dashboard or agent answer one without polling."
+    scope: user
+    publisher: system
+    default_ttl: 86400
+    max_messages: 1000
+    semantic: broadcast
+
+  _system/interrupts/resolved:
+    description: "An Interruption ask was answered, timed out or cancelled."
+    scope: user
+    publisher: system
+    default_ttl: 86400
+    max_messages: 1000
+    semantic: broadcast

--- a/cmd/loomcycle/embedded/bundles/system-channels.yaml
+++ b/cmd/loomcycle/embedded/bundles/system-channels.yaml
@@ -1,0 +1,93 @@
+# Embedded bundle: system-channels
+#
+# The runtime's own `_system/*` channels, declared so a workflow can read them
+# without an operator hand-writing the yaml. Selected via
+# `LOOMCYCLE_PRESETS=…,system-channels`.
+#
+# WHY A BUNDLE AND NOT AN ALWAYS-ON DEFAULT. Declaring a channel is free;
+# TICKING one is not. A heartbeat writes a row every period, on every
+# deployment, forever — including the laptops and the TrueNAS app — whether or
+# not anything reads it. That cost is worth paying once a workflow sources a
+# Starter from a tick, and not before, so it is opted into rather than
+# inherited. One env var replaces the yaml an operator would otherwise write by
+# hand, which was the actual friction.
+#
+# WHAT IS DECLARED IS WHAT SOMETHING PUBLISHES. Every name below has a real
+# publisher in the runtime today:
+#
+#   heartbeat-{1m,5m,1h}   internal/channels/heartbeat.go, one goroutine per
+#                          declared cadence channel
+#   interrupts/pending     Interruption `ask` (internal/tools/builtin)
+#   interrupts/resolved    the resolve endpoint + the interrupt sweeper
+#
+# Names with NO publisher are deliberately absent — declaring them would ship
+# channels that can only ever be empty, which reads as a broken feature rather
+# than an unused one. `_system/runtime-state` and `_system/provider-events` are
+# in the runtime's event-driven registry but nothing writes them (see the note
+# there); the `alarms/*` set never had a publisher either.
+#
+# Agents cannot publish to a `_system/` channel regardless of ACL — the prefix
+# is reserved for the internal publisher and the admin endpoint. A team or an
+# agent SUBSCRIBES to these; it never writes them.
+
+channels:
+  # ---- cadence: a Starter's clock ----
+  #
+  # TTL is 2x the period, not longer, on purpose. A heartbeat means "now" — the
+  # runner's own comment says it represents the moment rather than history — and
+  # a long TTL would let a Starter that has been down fire immediately on a
+  # stale tick it was never meant to see. Two periods is enough that a tick is
+  # never lost to a razor-thin race between publish and read, and short enough
+  # that nothing old is ever waiting.
+  _system/heartbeat-1m:
+    description: "One-minute tick. A Starter sourcing this runs its wave every minute."
+    scope: global
+    publisher: system
+    period: 1m
+    default_ttl: 120
+    max_messages: 5
+    semantic: broadcast
+
+  _system/heartbeat-5m:
+    description: "Five-minute tick."
+    scope: global
+    publisher: system
+    period: 5m
+    default_ttl: 600
+    max_messages: 5
+    semantic: broadcast
+
+  _system/heartbeat-1h:
+    description: "Hourly tick."
+    scope: global
+    publisher: system
+    period: 1h
+    default_ttl: 7200
+    max_messages: 5
+    semantic: broadcast
+
+  # ---- event-driven: published when the event happens, never on a clock ----
+  #
+  # scope: user, matching what the publishers actually pass — an interruption
+  # belongs to the user whose run raised it, and a global declaration would put
+  # every tenant's pending asks on one wire.
+  #
+  # These cost nothing when idle: no goroutine, no tick, a row only when an
+  # interruption is actually raised or answered. They are here rather than
+  # always-on only because a deployment that reads neither should not accrue
+  # rows it never asked for.
+  _system/interrupts/pending:
+    description: "An Interruption ask is waiting for a human. Lets an external dashboard or agent answer one without polling."
+    scope: user
+    publisher: system
+    default_ttl: 86400
+    max_messages: 1000
+    semantic: broadcast
+
+  _system/interrupts/resolved:
+    description: "An Interruption ask was answered, timed out or cancelled."
+    scope: user
+    publisher: system
+    default_ttl: 86400
+    max_messages: 1000
+    semantic: broadcast

--- a/cmd/loomcycle/presets_system_channels_test.go
+++ b/cmd/loomcycle/presets_system_channels_test.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/channels"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+)
+
+// TestSystemChannelsBundle_SourceMatchesEmbedded: the bundle exists twice — the
+// readable source tree and the flat file the binary go:embeds. Only the
+// EMBEDDED copy ships, so editing the source alone changes nothing at runtime
+// while looking, in a diff, like it changed everything.
+func TestSystemChannelsBundle_SourceMatchesEmbedded(t *testing.T) {
+	src, err := os.ReadFile(filepath.Join("..", "..", "bundles", "system-channels", "loomcycle.yaml"))
+	if err != nil {
+		t.Fatalf("read bundle source: %v", err)
+	}
+	embeddedCopy, err := os.ReadFile(filepath.Join("embedded", "bundles", "system-channels.yaml"))
+	if err != nil {
+		t.Fatalf("read embedded bundle: %v", err)
+	}
+	if !bytes.Equal(src, embeddedCopy) {
+		t.Error("bundles/system-channels/loomcycle.yaml and cmd/loomcycle/embedded/bundles/system-channels.yaml differ — only the embedded copy ships, so copy the source over it")
+	}
+}
+
+// heartbeatSpecsFor mirrors main.go's adapter into channels.LoadHeartbeatSpecs,
+// so these tests exercise the same path production takes rather than a
+// reimplementation of the rule.
+func heartbeatSpecsFor(t *testing.T, cfg *config.Config) []channels.HeartbeatSpec {
+	t.Helper()
+	in := map[string]struct {
+		Period      string
+		Publisher   string
+		DefaultTTL  int
+		MaxMessages int
+	}{}
+	for name, ch := range cfg.Channels {
+		in[name] = struct {
+			Period      string
+			Publisher   string
+			DefaultTTL  int
+			MaxMessages int
+		}{ch.Period, ch.Publisher, ch.DefaultTTL, ch.MaxMessages}
+	}
+	specs, err := channels.LoadHeartbeatSpecs(in)
+	if err != nil {
+		t.Fatalf("LoadHeartbeatSpecs: %v", err)
+	}
+	return specs
+}
+
+func systemChannelsConfig(t *testing.T) *config.Config {
+	t.Helper()
+	t.Setenv("LOOMCYCLE_SKILLS_ROOT", "")
+	cfg, err := config.LoadLayers(layersFor(t, "base", "system-channels")...)
+	if err != nil {
+		t.Fatalf("base + system-channels must load + validate cleanly: %v", err)
+	}
+	return cfg
+}
+
+// TestSystemChannelsBundle_DeclaresOnlyWhatSomethingPublishes is the rule this
+// bundle exists under, made executable.
+//
+// A declared channel nothing writes is worse than an absent one: it reads as a
+// broken feature rather than an unused one, and a consumer wired against it
+// waits forever. `_system/runtime-state` and `_system/provider-events` are in
+// the runtime's event-driven registry and have NO publisher — a sweep of every
+// SystemPublisher call site finds only the interrupts pair — so they must not
+// appear here. Neither must the `alarms/*` set, which never had one either.
+func TestSystemChannelsBundle_DeclaresOnlyWhatSomethingPublishes(t *testing.T) {
+	cfg := systemChannelsConfig(t)
+
+	want := map[string]bool{
+		"_system/heartbeat-1m":        true,
+		"_system/heartbeat-5m":        true,
+		"_system/heartbeat-1h":        true,
+		"_system/interrupts/pending":  true,
+		"_system/interrupts/resolved": true,
+	}
+	for name := range want {
+		if _, ok := cfg.Channels[name]; !ok {
+			t.Errorf("bundle does not declare %q", name)
+		}
+	}
+	for name := range cfg.Channels {
+		if len(name) > 8 && name[:8] == "_system/" && !want[name] {
+			t.Errorf("bundle declares %q, which has no publisher in the runtime — a channel nothing writes reads as a broken feature", name)
+		}
+	}
+}
+
+// TestSystemChannelsBundle_HeartbeatTTLsAreTwoPeriods: a heartbeat means "now".
+// A TTL longer than a couple of periods lets a Starter that has been down fire
+// immediately on a stale tick it was never meant to see — the tick would be
+// read as "it is time" when the time has passed.
+func TestSystemChannelsBundle_HeartbeatTTLsAreTwoPeriods(t *testing.T) {
+	cfg := systemChannelsConfig(t)
+	for _, name := range []string{"_system/heartbeat-1m", "_system/heartbeat-5m", "_system/heartbeat-1h"} {
+		ch, ok := cfg.Channels[name]
+		if !ok {
+			t.Fatalf("%s is not declared", name)
+		}
+		period, err := ch.PeriodDuration()
+		if err != nil || period == 0 {
+			t.Fatalf("%s: period %q does not parse to a cadence: %v", name, ch.Period, err)
+		}
+		if want := 2 * int(period.Seconds()); ch.DefaultTTL != want {
+			t.Errorf("%s: default_ttl = %d, want %d (2x the %s period)", name, ch.DefaultTTL, want, ch.Period)
+		}
+		if ch.MaxMessages == 0 || ch.MaxMessages > 10 {
+			t.Errorf("%s: max_messages = %d, want a small bound — a clock keeps no history", name, ch.MaxMessages)
+		}
+	}
+}
+
+// TestSystemChannelsBundle_InterruptScopeMatchesThePublisher: the publishers
+// pass store.MemoryScopeUser with the run's user id. A `global` declaration
+// would put every tenant's pending asks on one wire, and a `agent` one would
+// hide them from the user who has to answer.
+func TestSystemChannelsBundle_InterruptScopeMatchesThePublisher(t *testing.T) {
+	cfg := systemChannelsConfig(t)
+	for _, name := range []string{"_system/interrupts/pending", "_system/interrupts/resolved"} {
+		ch := cfg.Channels[name]
+		if ch.Scope != "user" {
+			t.Errorf("%s: scope = %q, want user — the publishers pass MemoryScopeUser with the run's user id", name, ch.Scope)
+		}
+		if ch.Period != "" {
+			t.Errorf("%s: has a period %q — it publishes on an EVENT, never on a clock", name, ch.Period)
+		}
+	}
+}
+
+// TestSystemChannelsBundle_EveryChannelIsSystemPublished: agents must not be
+// able to forge a heartbeat or a resolved-interrupt. The `_system/` prefix is
+// reserved at the tool layer too, so this is belt to that brace — and it is the
+// declaration an operator reads.
+func TestSystemChannelsBundle_EveryChannelIsSystemPublished(t *testing.T) {
+	cfg := systemChannelsConfig(t)
+	for name, ch := range cfg.Channels {
+		if len(name) > 8 && name[:8] == "_system/" && ch.Publisher != "system" {
+			t.Errorf("%s: publisher = %q, want system", name, ch.Publisher)
+		}
+	}
+}
+
+// TestSystemChannelsBundle_TickersLoadAsHeartbeatSpecs closes the loop from the
+// declaration to the goroutine that acts on it: the three cadence channels must
+// produce runnable specs, and the event-driven pair must produce none.
+//
+// Without this the bundle could declare a period the runner never reads and
+// look correct in every other test.
+func TestSystemChannelsBundle_TickersLoadAsHeartbeatSpecs(t *testing.T) {
+	cfg := systemChannelsConfig(t)
+	specs := heartbeatSpecsFor(t, cfg)
+	got := map[string]int{}
+	for _, s := range specs {
+		got[s.Name] = int(s.Period.Seconds())
+	}
+	for name, wantSec := range map[string]int{
+		"_system/heartbeat-1m": 60, "_system/heartbeat-5m": 300, "_system/heartbeat-1h": 3600,
+	} {
+		if got[name] != wantSec {
+			t.Errorf("heartbeat spec for %s = %ds, want %ds", name, got[name], wantSec)
+		}
+	}
+	for _, name := range []string{"_system/interrupts/pending", "_system/interrupts/resolved"} {
+		if _, ticking := got[name]; ticking {
+			t.Errorf("%s produced a heartbeat spec — an event-driven channel must never tick", name)
+		}
+	}
+	if len(specs) != 3 {
+		t.Errorf("loaded %d heartbeat specs, want exactly 3", len(specs))
+	}
+}
+
+// TestSystemChannelsBundle_IsOptIn pins the cost decision: a deployment that
+// does NOT select the bundle gets no `_system/` channels and therefore no
+// ticker, so it never writes a row a minute for something nothing reads.
+func TestSystemChannelsBundle_IsOptIn(t *testing.T) {
+	t.Setenv("LOOMCYCLE_SKILLS_ROOT", "")
+	cfg, err := config.LoadLayers(layersFor(t, "base")...)
+	if err != nil {
+		t.Fatalf("base alone must load: %v", err)
+	}
+	for name := range cfg.Channels {
+		if len(name) > 8 && name[:8] == "_system/" {
+			t.Errorf("base alone declares %q — the tickers must be opted into, not inherited", name)
+		}
+	}
+	if n := len(heartbeatSpecsFor(t, cfg)); n != 0 {
+		t.Errorf("base alone loaded %d heartbeat specs, want 0", n)
+	}
+}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1423,7 +1423,37 @@ base — and built-in agents — **without a source checkout**. Two kinds:
 - **Bundles** — a preset that *also* defines an agent and its skills **inline**
   (the top-level `skills:` map, §7). `document-agent` ships the `doc/manager`
   Document Assistant agent + its four skills — no skills directory, no
-  `LOOMCYCLE_SKILLS_ROOT`.
+  `LOOMCYCLE_SKILLS_ROOT`. A bundle may also ship pure *declarations* rather
+  than agents — `system-channels` is one.
+
+**`system-channels` — the runtime's own `_system/*` channels.** Declares the
+five a workflow can actually read, so a Starter can source a clock or an
+interruption feed without hand-written yaml:
+
+| channel | kind | publisher |
+|---|---|---|
+| `_system/heartbeat-1m` / `-5m` / `-1h` | cadence, `period:` | the heartbeat goroutine |
+| `_system/interrupts/pending` | event | `Interruption` op=ask |
+| `_system/interrupts/resolved` | event | the resolve endpoint + sweeper |
+
+⚠️ **A ticker writes a row every period, on every deployment, forever** — the
+1-minute one is 1,440 rows a day whether or not anything reads it. That is why
+this is a bundle rather than an always-on default: `LOOMCYCLE_PRESETS=base,system-channels`
+opts in, and an install that never selects it starts no heartbeat goroutine and
+declares no `_system/` channel. Each ticker's `default_ttl` is **twice its
+period** and `max_messages` is 5, so a clock keeps no history — a heartbeat
+means *now*, and a long TTL would let a Starter that was down fire immediately
+on a stale tick.
+
+Agents can never publish to a `_system/` channel regardless of ACL; the prefix
+is reserved for the internal publisher and the admin endpoint. Declare a
+consumer, not a producer.
+
+Two names in the runtime's event-driven registry are deliberately **absent**:
+`_system/runtime-state` and `_system/provider-events` have no publisher in the
+runtime today, so declaring them would ship channels that can only ever be
+empty — which reads as a broken feature rather than an unused one. They stay
+reserved; wire a publisher before wiring a consumer.
 
 List + read them (works on any install, no source tree):
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5870,10 +5870,21 @@ var validChannelSemantics = map[string]bool{
 // channels; loop / runner / pause-state handlers for event-driven
 // channels).
 var eventDrivenSystemChannels = map[string]bool{
-	"_system/runtime-state":       true, // v0.8.9 pause/resume/restore
-	"_system/provider-events":     true, // provider fallback / cache-invalidated
-	"_system/interrupts/pending":  true, // v0.8.16 Interruption.ask publishes
-	"_system/interrupts/resolved": true, // v0.8.16 resolve endpoint + sweeper publishes
+	// PUBLISHED today — the call sites are real.
+	"_system/interrupts/pending":  true, // Interruption `ask` (internal/tools/builtin/interruption.go)
+	"_system/interrupts/resolved": true, // the resolve endpoint + the interrupt sweeper
+
+	// RESERVED, NOT PUBLISHED. Nothing in the runtime writes these: a sweep of
+	// every SystemPublisher call site finds only the two above. They stay in
+	// the set so an operator who declares one still gets a config that loads
+	// (removing them would turn a working-but-silent declaration into a fatal
+	// "requires a period"), and so the names stay claimed.
+	//
+	// Their comments used to read like the publishers existed, which is worse
+	// than no comment: the next person to wire a consumer would have believed
+	// them. Declare a consumer against these only after wiring the publisher.
+	"_system/runtime-state":   true, // intended: pause/resume/restore transitions
+	"_system/provider-events": true, // intended: provider fallback / cache-invalidated
 }
 
 // eventDrivenSystemChannelNames returns the deterministic list for


### PR DESCRIPTION
## Why

Now that a Starter can source its cadence from a channel, the runtime's own `_system/*` channels should be reachable without an operator hand-writing the yaml.

```sh
LOOMCYCLE_PRESETS=base,system-channels
```

| channel | kind | publisher |
|---|---|---|
| `_system/heartbeat-1m` / `-5m` / `-1h` | cadence (`period:`) | the heartbeat goroutine |
| `_system/interrupts/pending` | event | `Interruption` op=ask |
| `_system/interrupts/resolved` | event | the resolve endpoint + the sweeper |

## Two decisions worth reviewing

### A bundle, not an always-on default

Declaring a channel is free; **ticking** one is not. A 1-minute heartbeat is 1,440 rows a day on every deployment, forever — laptops and the TrueNAS app included — whether or not anything reads it.

The plan called for "enabled defaults" and, in the same breath, said the cost "is only worth paying once something reads it". Those pull apart. A bundle resolves them honestly: nothing is paid until an operator opts in, and opting in is one env var rather than yaml written by hand — which was the actual friction. An install that never selects it starts no goroutine and declares no `_system/` channel, pinned by `TestSystemChannelsBundle_IsOptIn`.

### Declare only what something publishes — which cut the list

The plan's own rule. A publisher census over **every** `SystemPublisher` call site found exactly two event-driven names being written: the interrupts pair.

So **`_system/runtime-state` and `_system/provider-events` are not declared.** They sit in the runtime's `eventDrivenSystemChannels` registry with comments reading as though publishers existed — *"v0.8.9 pause/resume/restore"*, *"provider fallback / cache-invalidated"* — and nothing writes them. Declaring them would ship channels that can only ever be empty, which reads as a broken feature rather than an unused one; the same reason `alarms/*` is absent.

**Those comments are corrected in place** rather than left to mislead the next person wiring a consumer. The entries stay — removing one would turn a working-but-silent declaration into a fatal *"requires a period"* — now marked `RESERVED, NOT PUBLISHED`.

### Two settings that are judgement, not convention

- **Each ticker's TTL is twice its period**, not longer. A heartbeat means *now* — the runner's own comment says it represents the moment, not history — so a long TTL would let a Starter that had been down fire immediately on a stale tick it was never meant to see. Two periods is enough that a tick is never lost to a race between publish and read, and short enough that nothing old is ever waiting. `max_messages: 5`.
- **The interrupts pair is `scope: user`**, matching what the publishers actually pass (`MemoryScopeUser` with the run's user id). A `global` declaration would put every tenant's pending asks on one wire.

## Tested

`go build ./...`, `go vet ./...`, `gofmt -l` clean, **`go test ./...` green (111 packages)**.

**`loomcycle validate` passes for every combination:** `base` · `+system-channels` · `+agent-teams` · `+chat` · `+agent-teams,team-examples` · `+local,memory` · `+document-agent,sandbox`.

**Live, on a running instance:**

```
with the bundle:     system channels: starting 3 heartbeat goroutine(s)
                     channels: configured 5 — _system/heartbeat-1h / -1m / -5m /
                                              _system/interrupts/{pending,resolved}
  after 65s:         _system/heartbeat-1m holds exactly 1 tick
                     {"ts":"…","version":"unknown","uptime_s":60}

without the bundle:  0 heartbeat goroutines, 0 channels configured
```

**Fail-before, five claims, each red against its own break:**

| break | test that reds |
|---|---|
| add a publisher-less name to the bundle | `_DeclaresOnlyWhatSomethingPublishes` |
| a ticker TTL of 86400 instead of 2× period | `_HeartbeatTTLsAreTwoPeriods` |
| the interrupts pair declared `global` | `_InterruptScopeMatchesThePublisher` |
| source and embedded copies drift | `_SourceMatchesEmbedded` |
| give an event channel a `period:` | `_TickersLoadAsHeartbeatSpecs` |

`_TickersLoadAsHeartbeatSpecs` goes through `main.go`'s own adapter into `channels.LoadHeartbeatSpecs`, so it walks the production path rather than a reimplementation of the rule.

Docs: `docs/CONFIGURATION.md` §9f gains the bundle, the per-period row cost stated plainly, and why the two publisher-less names are absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD