### PR TITLE
feat(memory): a fact is reachable from every subject it is about (completes P3)

### DIFF
--- a/adapters/ts/src/types.ts
+++ b/adapters/ts/src/types.ts
@@ -1748,6 +1748,13 @@ export type DocumentToolInput = {
    *  sync reconciles — so a reading or coverage surface wants this on, and a
    *  federation one does not. */
   claims_only?: boolean;
+  /** list_facts: the facts about ONE SUBJECT — the subject's entity chunk id (a
+   *  subject document's `root_chunk_id`, from get_document). Returns the facts filed
+   *  under it AND the facts filed elsewhere that reference it: filing is
+   *  single-parent, so a fact about two things lives in one of their documents and
+   *  only points at the other, and a document filter would lose it from the second
+   *  subject entirely. */
+  about?: string;
   /** remember: a statement to store as a fact that cites ITSELF — the text becomes both
    *  the claim and its source span, so write what you want recorded rather than an
    *  instruction about it. Additive only; it is never a way to delete. */

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -103,6 +103,7 @@ const documentInputSchema = `{
 		"text":        {"type": "string", "description": "remember: the statement to store, as ONE self-contained sentence. It is stored verbatim AND becomes its own source span, so what you type is both the fact and the evidence for it — write what you mean recorded, not an instruction about it."},
 		"min_score":   {"type": "number", "description": "verbatim_answer: how close a match must be before it can be quoted as an answer (default 0.6). Cosine scale is a property of the embedding model, so tune this against your own — the response always reports the actual score, including when it refuses."},
 		"include_refuted": {"type": "boolean", "description": "list_facts / graph_recall: also return facts a judge marked unsupported. They are withheld by default and never deleted, so this is how you read what was refused and why (each carries judge_reason)."},
+		"about":       {"type": "string", "description": "list_facts: the facts about ONE SUBJECT — pass the subject's entity chunk id (a subject document's root_chunk_id, from get_document). Returns the facts filed under it AND the facts filed elsewhere that reference it, because a fact about two things lives in one of their documents and points at the other: filtering by document alone would lose it from the second subject entirely."},
 		"claims_only": {"type": "boolean", "description": "list_facts: return only CLAIMS, dropping the entity identity nodes (the subject a fact is about — 'Ollama', 'the user'). A claim carries a sentence and can carry a source span; an identity node is a name and never can, so a listing meant for reading or for verification coverage wants this on. Off by default because the default listing is every chunk carrying entity metadata, which is what document sync reconciles."},
 		"verdict":      {"type": "string", "enum": ["supported","unclear","unsupported","mistyped"], "description": "judge_fact: whether the fact's recorded source span supports it. supported = the span carries the claim; unclear = it partly does; unsupported = it does not; mistyped = the span DOES support the claim but it is filed under a type the ontology does not say it is (the fix is to retype it, not to drop it, so it stays visible). The confidence each maps to is set by the server, and an unsupported fact stops being returned by the fact surfaces without being deleted."},
 		"reason":       {"type": "string", "description": "judge_fact: one sentence on WHY, quoted back to the operator. A verdict nobody can act on is a verdict nobody trusts."},
@@ -189,6 +190,11 @@ type docInput struct {
 	// IncludeRefuted surfaces facts a judge refused. Off by default and available on
 	// purpose: "quarantine, never delete" is only meaningful if the quarantine can be read.
 	IncludeRefuted bool `json:"include_refuted"`
+	// About narrows a fact listing to ONE SUBJECT, by its entity chunk id. It is not
+	// a document filter and must not become one: a subject's facts are the ones filed
+	// under it PLUS the ones filed elsewhere that reference it, and a relation-fact is
+	// only ever filed under one of the two subjects it names.
+	About string `json:"about,omitempty"`
 	// ClaimsOnly drops entity IDENTITY nodes from a fact listing, leaving the claims.
 	// Opt-in rather than the default because list_facts' contract is "chunks that carry
 	// entity metadata", and the document-federation reconcile depends on that breadth —
@@ -1779,6 +1785,28 @@ func (d *Document) getDocument(ctx context.Context, key sqlmem.ScopeKey, mscope 
 		resp["color_enabled"] = enabled
 		if len(scheme) > 0 {
 			resp["color_scheme"] = scheme
+		}
+		// WHAT THE TREE CANNOT REACH. When this document's root is a subject, a fact
+		// about it AND about something else is filed under the other one — the tree
+		// holds each chunk once — so walking this document answers only half of "what
+		// do we know about X". These are the other half, and they are reported HERE
+		// rather than in export_md because that output round-trips through import_md:
+		// an edge whose far end is in another document would either be dropped on
+		// import or re-created pointing at nothing.
+		//
+		// Not gated on "is this an entity". An ordinary document's root is the target
+		// of no `about` edge, so the indexed probe returns nothing and the block is
+		// omitted — a gate would cost a query to save one.
+		refs, refsTruncated, rerr := d.inboundSubjectRefs(ctx, key, rootID, docID)
+		if rerr != nil {
+			return errResult("get_document: references: " + rerr.Error()), nil
+		}
+		if len(refs) > 0 {
+			resp["references"] = refs
+			if refsTruncated {
+				resp["references_truncated"] = true
+				resp["references_note"] = subjectRefsNote(rootID)
+			}
 		}
 	}
 	return jsonResult(resp)

--- a/internal/tools/builtin/document_entity.go
+++ b/internal/tools/builtin/document_entity.go
@@ -406,6 +406,28 @@ func (d *Document) listFacts(ctx context.Context, key sqlmem.ScopeKey, in docInp
 		where = append(where, "c.document_id = ?")
 		args = append(args, in.DocumentID)
 	}
+	// THE SUBJECT FILTER, which document_id deliberately is NOT. Filing is
+	// single-parent, so "Dave works at the shop" lives in Dave's document and only
+	// points at the shop; a document filter would answer "what do we know about the
+	// shop" without it, and the second subject would silently lose every relation
+	// fact it is named in. Children UNION inbound references — one document read
+	// plus one indexed probe, not a traversal.
+	if in.About != "" {
+		docID, ok, derr := d.documentOfChunk(ctx, key, in.About)
+		if derr != nil {
+			return errResult("list_facts: about: " + derr.Error()), nil
+		}
+		if !ok {
+			// Reported rather than answered with an empty list: a filter naming a
+			// chunk that does not exist is a caller mistake, and "no facts about it"
+			// is indistinguishable from "that subject has none".
+			return errResult("list_facts: no such chunk: " + in.About +
+				" (about takes a SUBJECT's entity chunk id — a subject document's root_chunk_id)"), nil
+		}
+		frag, fargs := factsAboutSubjectSQL(in.About, docID)
+		where = append(where, frag)
+		args = append(args, fargs...)
+	}
 	// Reuse graph_recall's temporal filter so "currently true" means the same
 	// thing on both surfaces. The INNER JOIN makes m.chunk_id non-null, so the
 	// clause's `m.chunk_id IS NULL OR ...` disjunct is inert here (which is

--- a/internal/tools/builtin/document_subject_refs.go
+++ b/internal/tools/builtin/document_subject_refs.go
@@ -1,0 +1,113 @@
+package builtin
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
+)
+
+// document_subject_refs.go — the reader contract: a fact is reachable from EVERY
+// subject it is about, not only the one it is filed under.
+//
+// Subject-homing files a fact under one subject, because containment is
+// single-parent: the tree needs exactly one place for each chunk, and that is what
+// makes a dossier one read. A fact about two things — "Dave works at the shop" —
+// therefore lives in Dave's document and REFERENCES the shop. Read Dave and you see
+// it; read the shop by walking its tree and you do not, even though the edge saying
+// so has been there all along.
+//
+// That asymmetry is accepted by design and has to be PAID FOR by the readers. A
+// subject's facts are its children PLUS the facts that reference it: one document
+// read plus one indexed query, not a traversal. `chunk_edges_to_kind` (to_id, kind)
+// exists for exactly this direction.
+//
+// WHY BOTH HALVES, and not the edge alone. Every fact the consolidation pass files
+// also gets an `about` edge to its home subject, so edges alone would nearly always
+// do. Nearly: the edge write is deliberately best-effort — "an unreachable fact is a
+// retrieval gap, a missing fact is data loss, and only the second may fail a write"
+// — and a `remember`-written fact carries its subject on the chunk itself and has no
+// edge at all. Containment catches both. Using only containment loses the relation
+// fact; using only the edge loses the operator's. The union is the honest answer.
+
+// subjectRef is one fact that references a subject from outside its document.
+type subjectRef struct {
+	ID         string `json:"id"`
+	Title      string `json:"title,omitempty"`
+	Type       string `json:"type,omitempty"`
+	DocumentID string `json:"document_id"`
+	Kind       string `json:"kind"`
+}
+
+// subjectRefsCap bounds the reference block a document read carries. It is a
+// SUMMARY — "these facts elsewhere are about this subject" — so it is capped low
+// and says so when it clips; the caller that wants the whole set has
+// `list_facts about:<entity chunk id>`, which pages.
+const subjectRefsCap = 100
+
+// documentOfChunk resolves the document a chunk belongs to. Returns ok=false when
+// the chunk does not exist, which callers report rather than treating as an empty
+// result: a filter naming a chunk that is not there is a caller mistake, and
+// answering it with "no facts" hides that.
+func (d *Document) documentOfChunk(ctx context.Context, key sqlmem.ScopeKey, chunkID string) (string, bool, error) {
+	res, err := d.query(ctx, key, `SELECT document_id FROM chunks WHERE id = ?`, chunkID)
+	if err != nil {
+		return "", false, err
+	}
+	if len(res.Rows) == 0 {
+		return "", false, nil
+	}
+	return asStr(res.Rows[0][0]), true, nil
+}
+
+// factsAboutSubjectSQL is the predicate "this chunk is a fact about that subject",
+// stated once so the listing and any later reader cannot disagree about what a
+// subject's facts are. Takes the subject's entity chunk id and the document it
+// roots; returns the fragment and its arguments in placeholder order.
+func factsAboutSubjectSQL(entityChunkID, documentID string) (string, []any) {
+	return `(c.document_id = ? OR EXISTS (SELECT 1 FROM chunk_edges e ` +
+			`WHERE e.from_id = c.id AND e.to_id = ? AND e.kind = ?))`,
+		[]any{documentID, entityChunkID, aboutEdgeKind}
+}
+
+// inboundSubjectRefs lists the facts that reference this subject from ANOTHER
+// document — the half of its fact set that walking its tree cannot reach.
+//
+// Same-document references are excluded deliberately: they are the subject's own
+// children, already in the dossier, and repeating them would make the block read as
+// "extra" when it is not.
+func (d *Document) inboundSubjectRefs(ctx context.Context, key sqlmem.ScopeKey,
+	entityChunkID, documentID string) ([]subjectRef, bool, error) {
+
+	res, err := d.query(ctx, key,
+		`SELECT c.id, coalesce(c.title, ''), coalesce(c.type, ''), c.document_id, e.kind
+		   FROM chunk_edges e JOIN chunks c ON c.id = e.from_id
+		  WHERE e.to_id = ? AND e.kind = ? AND c.document_id <> ?
+		  ORDER BY c.id LIMIT ?`,
+		entityChunkID, aboutEdgeKind, documentID, subjectRefsCap+1)
+	if err != nil {
+		return nil, false, err
+	}
+	rows := res.Rows
+	truncated := len(rows) > subjectRefsCap || res.Truncated
+	if len(rows) > subjectRefsCap {
+		rows = rows[:subjectRefsCap]
+	}
+	out := make([]subjectRef, 0, len(rows))
+	for _, r := range rows {
+		if len(r) < 5 {
+			continue
+		}
+		out = append(out, subjectRef{
+			ID: asStr(r[0]), Title: asStr(r[1]), Type: asStr(r[2]),
+			DocumentID: asStr(r[3]), Kind: asStr(r[4]),
+		})
+	}
+	return out, truncated, nil
+}
+
+// subjectRefsNote is what a clipped reference block tells the caller to do about it.
+func subjectRefsNote(entityChunkID string) string {
+	return fmt.Sprintf("more than %d facts reference this subject from other documents; "+
+		"list them all with list_facts about:%s", subjectRefsCap, entityChunkID)
+}

--- a/internal/tools/builtin/document_subject_refs_test.go
+++ b/internal/tools/builtin/document_subject_refs_test.go
@@ -1,0 +1,275 @@
+package builtin
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// The reader contract: a relation-fact is reachable from EVERY subject it names.
+//
+// Subject-homing files a fact under one subject because containment is
+// single-parent. "Dave works at the shop" therefore lives in Dave's document and
+// references the shop. Read Dave and it is there; read the shop by its tree and it
+// is not — so every reader of a subject's facts has to add the inbound references,
+// or the second subject silently loses every relation it is named in.
+
+// subjectFixture builds two subject documents and the three facts that make the
+// contract testable: one about Dave alone, one about the shop alone, and one about
+// BOTH — filed under Dave, referencing the shop.
+type subjectFixture struct {
+	t                          *testing.T
+	d                          *Document
+	ctx                        contextT
+	daveDoc, daveRoot          string
+	shopDoc, shopRoot          string
+	daveOnly, shopOnly, shared string
+}
+
+func newSubjectFixture(t *testing.T) *subjectFixture {
+	t.Helper()
+	d, ctx, _ := documentFixture(t)
+	f := &subjectFixture{t: t, d: d, ctx: ctx}
+	f.daveDoc, f.daveRoot = f.subjectDoc("Dave", "person:dave", "/facts/dave")
+	f.shopDoc, f.shopRoot = f.subjectDoc("Shop", "organization:shop", "/facts/shop")
+
+	f.daveOnly = f.fact(f.daveDoc, f.daveRoot, "memory/fact/dave-writes-go", "Dave writes Go.", nil)
+	f.shopOnly = f.fact(f.shopDoc, f.shopRoot, "memory/fact/shop-opens-nine", "The shop opens at nine.", nil)
+	// THE RELATION FACT. Filed under Dave — the tree gives it one home — and
+	// referencing the shop, which is the only trace of the second subject.
+	f.shared = f.fact(f.daveDoc, f.daveRoot, "memory/fact/dave-works-at-shop",
+		"Dave works at the shop.", []string{f.shopRoot})
+	return f
+}
+
+// subjectDoc creates a subject's document the way subject-homing does: the ROOT
+// chunk is the entity node.
+func (f *subjectFixture) subjectDoc(name, key, path string) (docID, rootID string) {
+	f.t.Helper()
+	out, r := docExec(f.t, f.d, f.ctx, `{"op":"create_document","scope":"user","title":"`+name+
+		`","path":"`+path+`","type":"person","subject":"`+name+`","natural_key":"`+key+`"}`)
+	if r.IsError {
+		f.t.Fatalf("create %s: %s", path, r.Text)
+	}
+	docID, _ = out["document_id"].(string)
+	rootID, _ = out["root_chunk_id"].(string)
+	if docID == "" || rootID == "" {
+		f.t.Fatalf("create %s returned %v", path, out)
+	}
+	return docID, rootID
+}
+
+// fact files a fact under its home subject and links it to every subject it is
+// about — including its home, which is what the consolidation pass does.
+func (f *subjectFixture) fact(docID, homeRoot, key, text string, alsoAbout []string) string {
+	f.t.Helper()
+	out, r := docExec(f.t, f.d, f.ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+docID+
+		`","parent_id":"`+homeRoot+`","natural_key":"`+key+`","title":"`+text+
+		`","body":"`+text+`","type":"fact"}`)
+	if r.IsError {
+		f.t.Fatalf("fact %s: %s", key, r.Text)
+	}
+	id, _ := out["id"].(string)
+	for _, to := range append([]string{homeRoot}, alsoAbout...) {
+		if _, r := docExec(f.t, f.d, f.ctx, `{"op":"link_chunks","scope":"user","from_id":"`+id+
+			`","to_id":"`+to+`","kind":"about"}`); r.IsError {
+			f.t.Fatalf("about edge %s->%s: %s", id, to, r.Text)
+		}
+	}
+	return id
+}
+
+// factIDs runs list_facts and returns the ids it reported.
+func (f *subjectFixture) factIDs(input string) map[string]bool {
+	f.t.Helper()
+	out, r := docExec(f.t, f.d, f.ctx, input)
+	if r.IsError {
+		f.t.Fatalf("list_facts: %s", r.Text)
+	}
+	raw, _ := json.Marshal(out["facts"])
+	var rows []struct {
+		ID string `json:"id"`
+	}
+	_ = json.Unmarshal(raw, &rows)
+	got := map[string]bool{}
+	for _, row := range rows {
+		got[row.ID] = true
+	}
+	return got
+}
+
+// TestListFacts_ARelationFactIsListedUnderBothItsSubjects is the contract itself.
+func TestListFacts_ARelationFactIsListedUnderBothItsSubjects(t *testing.T) {
+	f := newSubjectFixture(t)
+
+	dave := f.factIDs(`{"op":"list_facts","scope":"user","about":"` + f.daveRoot + `","claims_only":true}`)
+	if !dave[f.shared] {
+		t.Error("the relation fact is missing from its HOME subject's listing")
+	}
+	if !dave[f.daveOnly] {
+		t.Error("Dave's own fact is missing from his listing")
+	}
+	if dave[f.shopOnly] {
+		t.Error("a fact about the shop alone was listed under Dave")
+	}
+
+	shop := f.factIDs(`{"op":"list_facts","scope":"user","about":"` + f.shopRoot + `","claims_only":true}`)
+	if !shop[f.shared] {
+		t.Error("THE CONTRACT: the relation fact is unreachable from the subject it references " +
+			"but is not filed under — filing is single-parent, so a document filter loses it")
+	}
+	if !shop[f.shopOnly] {
+		t.Error("the shop's own fact is missing from its listing")
+	}
+	if shop[f.daveOnly] {
+		t.Error("a fact about Dave alone was listed under the shop")
+	}
+}
+
+// TestListFacts_ASubjectsOwnFactsAreListedWithoutAnEdge. The `about` edge is
+// written best-effort — "an unreachable fact is a retrieval gap, a missing fact is
+// data loss, and only the second may fail a write" — and a `remember`-written fact
+// carries its subject on the chunk and has no edge at all. Containment is what
+// catches both, so the union is not redundancy.
+func TestListFacts_ASubjectsOwnFactsAreListedWithoutAnEdge(t *testing.T) {
+	f := newSubjectFixture(t)
+	// A fact filed under Dave whose edge write never happened.
+	out, r := docExec(t, f.d, f.ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+f.daveDoc+
+		`","parent_id":"`+f.daveRoot+`","natural_key":"memory/operator/dave-likes-tea",`+
+		`"title":"Dave likes tea.","body":"Dave likes tea.","type":"fact"}`)
+	if r.IsError {
+		t.Fatalf("edgeless fact: %s", r.Text)
+	}
+	edgeless, _ := out["id"].(string)
+
+	if got := f.factIDs(`{"op":"list_facts","scope":"user","about":"` + f.daveRoot + `"}`); !got[edgeless] {
+		t.Error("a fact filed under the subject with no `about` edge was dropped — the edge is " +
+			"best-effort, so containment has to carry it")
+	}
+}
+
+// TestGetDocument_ADossierReportsWhatItsTreeCannotReach. export_md must NOT carry
+// these (it round-trips through import_md, and an edge whose far end is in another
+// document would be dropped or re-created pointing at nothing), so the document read
+// is where a reader learns the tree is not the whole answer.
+func TestGetDocument_ADossierReportsWhatItsTreeCannotReach(t *testing.T) {
+	f := newSubjectFixture(t)
+
+	out, r := docExec(t, f.d, f.ctx, `{"op":"get_document","scope":"user","path":"/facts/shop"}`)
+	if r.IsError {
+		t.Fatalf("get_document: %s", r.Text)
+	}
+	raw, _ := json.Marshal(out["references"])
+	var refs []subjectRef
+	_ = json.Unmarshal(raw, &refs)
+	if len(refs) != 1 {
+		t.Fatalf("references = %v, want the one relation fact filed in Dave's document", refs)
+	}
+	if refs[0].ID != f.shared {
+		t.Errorf("reference = %q, want the relation fact %q", refs[0].ID, f.shared)
+	}
+	if refs[0].DocumentID != f.daveDoc {
+		t.Errorf("reference lives in %q, want Dave's document %q — a same-document fact is a "+
+			"child and is already in the tree", refs[0].DocumentID, f.daveDoc)
+	}
+	if refs[0].Kind != "about" {
+		t.Errorf("reference kind = %q, want about", refs[0].Kind)
+	}
+
+	// Dave's dossier has NO references block: both his facts are his own children,
+	// so a block there would report the tree back to itself as though it were extra.
+	out, r = docExec(t, f.d, f.ctx, `{"op":"get_document","scope":"user","path":"/facts/dave"}`)
+	if r.IsError {
+		t.Fatalf("get_document dave: %s", r.Text)
+	}
+	if _, present := out["references"]; present {
+		t.Errorf("Dave's dossier carries a references block for facts already in its tree: %v", out["references"])
+	}
+}
+
+// TestGetDocument_AnOrdinaryDocumentCarriesNoReferences. The probe is unconditional,
+// so the guarantee that it costs an ordinary document nothing visible is a test.
+func TestGetDocument_AnOrdinaryDocumentCarriesNoReferences(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	if _, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Notes","path":"/docs/notes"}`); r.IsError {
+		t.Fatalf("create: %s", r.Text)
+	}
+	out, r := docExec(t, d, ctx, `{"op":"get_document","scope":"user","path":"/docs/notes"}`)
+	if r.IsError {
+		t.Fatalf("get_document: %s", r.Text)
+	}
+	if _, present := out["references"]; present {
+		t.Errorf("an ordinary document reported references: %v", out["references"])
+	}
+}
+
+// TestListFacts_AboutAnUnknownChunkIsReportedNotAnsweredEmpty. "No facts about it"
+// and "that subject does not exist" are different answers, and returning the first
+// for the second hides a caller's mistake behind a plausible result.
+func TestListFacts_AboutAnUnknownChunkIsReportedNotAnsweredEmpty(t *testing.T) {
+	f := newSubjectFixture(t)
+	_, r := docExec(t, f.d, f.ctx, `{"op":"list_facts","scope":"user","about":"no-such-chunk"}`)
+	if !r.IsError {
+		t.Fatal("list_facts about an unknown chunk succeeded — an empty list reads as 'nothing known'")
+	}
+}
+
+// TestMarkdownRoundTrip_ASubjectDossier is the other half of the same decision.
+//
+// References are reported by get_document and NOT by export_md, and the reason is
+// this: the Markdown round-trips. A subject's dossier carries an edge whose far end
+// is a chunk in ANOTHER document — the relation fact pointing at the other subject —
+// and on re-import those ids name nothing. Re-creating them would fabricate edges to
+// chunks that are not there; emitting inbound ones too would make it worse.
+//
+// So the contract is: the chunk TREE comes back identical, the same-document edges
+// come back, and the cross-document one is dropped rather than invented.
+func TestMarkdownRoundTrip_ASubjectDossier(t *testing.T) {
+	f := newSubjectFixture(t)
+
+	md, r := docExec(t, f.d, f.ctx, `{"op":"export_md","scope":"user","id":"`+f.daveDoc+`"}`)
+	if r.IsError {
+		t.Fatalf("export: %s", r.Text)
+	}
+	exported := asStr(md["markdown"])
+	// The trailer must actually contain the cross-document edge, or this test proves
+	// nothing about how import handles one.
+	if !strings.Contains(exported, f.shared+" -> "+f.shopRoot+" [about]") {
+		t.Fatalf("the dossier's trailer does not carry the cross-document reference, so the "+
+			"round-trip below is vacuous:\n%s", exported)
+	}
+
+	ij, _ := json.Marshal(exported)
+	out, r2 := docExec(t, f.d, f.ctx, `{"op":"import_md","scope":"user","markdown":`+string(ij)+`}`)
+	if r2.IsError {
+		t.Fatalf("import: %s", r2.Text)
+	}
+	// Dave's root + his two facts.
+	if n := asInt(out["chunks_created"]); n != 3 {
+		t.Errorf("re-import created %d chunks, want 3 (the entity root and its two facts)", n)
+	}
+	newDoc, _ := out["document_id"].(string)
+
+	// The same-document edges came back — so the trailer is being read, not ignored.
+	edges, r3 := docExec(t, f.d, f.ctx, `{"op":"get_edges","scope":"user","document_id":"`+newDoc+`"}`)
+	if r3.IsError {
+		t.Fatalf("get_edges: %s", r3.Text)
+	}
+	raw, _ := json.Marshal(edges["edges"])
+	var got []struct {
+		FromID string `json:"from_id"`
+		ToID   string `json:"to_id"`
+		Kind   string `json:"kind"`
+	}
+	_ = json.Unmarshal(raw, &got)
+	if len(got) != 2 {
+		t.Errorf("the imported dossier has %d edges, want 2 — its two facts' `about` edges to "+
+			"their own root, and NOT the one whose far end is in another document: %v", len(got), got)
+	}
+	for _, e := range got {
+		if e.ToID == f.shopRoot {
+			t.Errorf("import re-created the cross-document reference %v — on import those ids "+
+				"name nothing in the new document, so the edge would point outside it", e)
+		}
+	}
+}


### PR DESCRIPTION
## Why

Subject-homing files a fact under **one** subject, because containment is single-parent — the tree needs exactly one place for each chunk, and that is what makes a dossier one read. So "Dave works at the shop" lives in one of their documents and merely *references* the other.

Measured on a real store, right after running the homing migration from #1205:

```
/facts/shop   Shop            ROOT
              Dave works at the shop.    ← the relation fact landed here
              The shop opens at nine.
/facts/dave   Dave            ROOT       ← zero children
```

`export_md` on `/facts/dave` returns `# Dave` and nothing else, while a fact about Dave exists two documents away. That's RFC CV's accepted asymmetry, and the RFC is explicit that the readers have to pay for it — *"this is a test, not a note: a relation-fact must be reachable from both subjects."*

## What

**Two of the four named readers already paid**, verified live rather than assumed:

- `graph_recall` unions both edge directions — *"an entity is as related to the fact that points at it as to the ones it points at."* Reaches the fact from Dave.
- `get_edges` returns every edge with an **endpoint** in the document, which is what the memory-view's detail panel calls. Returns the inbound edge with both endpoints enriched.

**The other two now do:**

- **`list_facts` gains `about`** — a *subject's* entity chunk id, not a document. Returns the facts filed under it **and** the ones filed elsewhere that reference it. `document_id` deliberately stays a document filter; silently widening it would change its meaning for every ordinary document too.
- **`get_document` reports `references`** — the facts about this subject living in another document, the half its tree cannot reach. Capped, and it names `list_facts about:` when it clips.

### Two decisions worth the review

**Not in `export_md`,** where a reader might expect them. That output round-trips through `import_md`, and an edge whose far end is in another document names nothing on import — it would be dropped, or worse, re-created pointing outside the document. References belong in the JSON read. `TestMarkdownRoundTrip_ASubjectDossier` pins this: it asserts the trailer *really carries* a cross-document edge before checking that import drops rather than fabricates it.

**Containment *and* the edge**, even though the pass writes both. The edge write is deliberately best-effort — *"an unreachable fact is a retrieval gap, a missing fact is data loss, and only the second may fail a write"* — and a `remember`-written fact carries its subject on the chunk with no edge at all. Containment catches those; the edge catches the relation fact. Neither half alone is honest.

## What was tested

`go test ./...` clean (101 packages); TS adapter builds.

- `TestListFacts_ARelationFactIsListedUnderBothItsSubjects` — the contract. **Fail-before** with only the behaviour reverted (subject filter degraded to a document filter): *"the relation fact is unreachable from the subject it references"*, and `get_document`'s block empty.
- `TestListFacts_ASubjectsOwnFactsAreListedWithoutAnEdge` — the edgeless/`remember` case that containment exists for.
- `TestListFacts_AboutAnUnknownChunkIsReportedNotAnsweredEmpty` — "no facts about it" and "that subject doesn't exist" are different answers.
- `TestGetDocument_ADossierReportsWhatItsTreeCannotReach` + `_AnOrdinaryDocumentCarriesNoReferences` — the probe is ungated, so its being free for ordinary documents is a test.
- `TestMarkdownRoundTrip_ASubjectDossier` — the other RFC CV P3 structural criterion, which had no coverage for a dossier.

**Live end-to-end** on a store migrated by `home_facts`: `export_md` on Dave returns his title alone; `get_document` names the relation fact and the document it lives in; `list_facts about:Dave` → the relation fact; `list_facts about:Shop` → both its own and the shared one; `graph_recall` reaches it from Dave; `get_edges` returns the inbound edge.

## This completes P3

| RFC CV P3 | state |
|---|---|
| `/facts/<slug>` per subject, root = entity node | #1203 |
| facts filed as children | #1203 (new) + #1205 (existing) |
| `path ls /facts` is an entity directory | verified live |
| **reader contract** | **this PR** |
| gate: OQ1 (rename) decided, OQ2 (`ls` pagination) landed | ✅ |

Next by the RFC: **P4** (tenant entity registry) — gated on OQ6, the last open question, concurrent `position` assignment under one shared parent. P0/RFC CW remains the large accuracy item and is still blocked on the extractor-prompt baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8