### PR TITLE
feat(memory): the tenant entity registry is curator-gated (RFC CV P4, OQ6 answered)

### DIFF
--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -617,6 +617,7 @@ agents:
           placement_displace_failed: 0,
           placement_moved_keys: {}, // key -> target scope, for the displaced-twin retire
           placement_error: "",
+          unadopted_subjects: {},   // subject -> true, for the ones the tenant does not know yet
           placement_asked: {},      // type|subject already asked about, so batches don't re-ask
           subject_types: {},        // scope + slug -> the type this subject is ALREADY filed under
           type_stabilised: 0,       // times the extractor's guess was overridden by the existing type
@@ -2153,6 +2154,14 @@ agents:
             var row = rows[r];
             if (row && row.moved && row.scope) {
               st.placement[row.type + "\u0000" + row.subject] = row.scope;
+            } else if (row && row.subject && typeof row.reason === "string" &&
+                       row.reason.indexOf("does not yet know the subject") !== -1) {
+              // A SUBJECT AWAITING ADOPTION. The declaration says its facts are shared,
+              // and the server declined to mint the entity from one user's transcript —
+              // so the fact stays here and a curator has something to act on. Reported
+              // rather than logged: this is the only place an operator learns which
+              // names are waiting, and a silent gate reads as a broken declaration.
+              st.unadopted_subjects[row.subject] = true;
             }
           }
         } catch (e) {
@@ -3284,6 +3293,17 @@ agents:
         }
         // Said out loud rather than swallowed: the pass stored everything in this scope,
         // which is correct behaviour but NOT the behaviour a declaring operator expects.
+        var unadopted = Object.keys(st.unadopted_subjects);
+        if (unadopted.length > 0) {
+          // Named, up to a few: "3 subjects" sends an operator looking, the names let
+          // them act. Bounded because a pass meeting a hundred new subjects would
+          // otherwise bury the rest of the report.
+          var shown = unadopted.slice(0, 8).join(", ");
+          parts.push("subjects the tenant does not know yet, so their facts stayed here: " +
+            unadopted.length + " (" + shown +
+            (unadopted.length > 8 ? ", …" : "") +
+            ") — create the entity in tenant scope once to share what is learned about it");
+        }
         if (st.placement_error) {
           parts.push("scope placement unavailable (" + st.placement_error +
             ") — everything stayed in " + CONFIG.scope + " scope");

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -617,6 +617,7 @@ agents:
           placement_displace_failed: 0,
           placement_moved_keys: {}, // key -> target scope, for the displaced-twin retire
           placement_error: "",
+          unadopted_subjects: {},   // subject -> true, for the ones the tenant does not know yet
           placement_asked: {},      // type|subject already asked about, so batches don't re-ask
           subject_types: {},        // scope + slug -> the type this subject is ALREADY filed under
           type_stabilised: 0,       // times the extractor's guess was overridden by the existing type
@@ -2153,6 +2154,14 @@ agents:
             var row = rows[r];
             if (row && row.moved && row.scope) {
               st.placement[row.type + "\u0000" + row.subject] = row.scope;
+            } else if (row && row.subject && typeof row.reason === "string" &&
+                       row.reason.indexOf("does not yet know the subject") !== -1) {
+              // A SUBJECT AWAITING ADOPTION. The declaration says its facts are shared,
+              // and the server declined to mint the entity from one user's transcript —
+              // so the fact stays here and a curator has something to act on. Reported
+              // rather than logged: this is the only place an operator learns which
+              // names are waiting, and a silent gate reads as a broken declaration.
+              st.unadopted_subjects[row.subject] = true;
             }
           }
         } catch (e) {
@@ -3284,6 +3293,17 @@ agents:
         }
         // Said out loud rather than swallowed: the pass stored everything in this scope,
         // which is correct behaviour but NOT the behaviour a declaring operator expects.
+        var unadopted = Object.keys(st.unadopted_subjects);
+        if (unadopted.length > 0) {
+          // Named, up to a few: "3 subjects" sends an operator looking, the names let
+          // them act. Bounded because a pass meeting a hundred new subjects would
+          // otherwise bury the rest of the report.
+          var shown = unadopted.slice(0, 8).join(", ");
+          parts.push("subjects the tenant does not know yet, so their facts stayed here: " +
+            unadopted.length + " (" + shown +
+            (unadopted.length > 8 ? ", …" : "") +
+            ") — create the entity in tenant scope once to share what is learned about it");
+        }
         if (st.placement_error) {
           parts.push("scope placement unavailable (" + st.placement_error +
             ") — everything stayed in " + CONFIG.scope + " scope");

--- a/cmd/loomcycle/presets_memory_codejs_test.go
+++ b/cmd/loomcycle/presets_memory_codejs_test.go
@@ -57,8 +57,11 @@ type fakeToolset struct {
 	// in. Empty (the default, and the real default) means the ontology declares nothing
 	// and every fact stays in the caller's scope. placementFails makes the op error, which
 	// is what a deployment without SQL Memory or with an unreadable ontology looks like.
-	placements     map[string]string
-	placementFails bool
+	placements map[string]string
+	// unadoptedSubjects names the subjects the tenant registry does not hold, so the
+	// server's curator gate declines to place their facts (RFC CV decision 6).
+	unadoptedSubjects map[string]bool
+	placementFails    bool
 	// failTypeLookup makes the canonical-type query error, so a lookup failure can be told
 	// apart from a chunk-write failure in the report.
 	failTypeLookup bool
@@ -171,18 +174,19 @@ type fakeToolset struct {
 
 func newFakeToolset() *fakeToolset {
 	return &fakeToolset{
-		leaseAcquired:   true,
-		bands:           map[string]any{"merge_threshold": 0.9, "related_threshold": 0.5},
-		chunks:          map[string]string{},
-		subjectDocs:     map[string]string{},
-		chunkScopes:     map[string]string{},
-		chunkTypes:      map[string]string{},
-		chunkSpans:      map[string]string{},
-		chunkRows:       map[string]map[string]any{},
-		verdicts:        map[string]string{},
-		failEntityKeys:  map[string]bool{},
-		failSubjectDocs: map[string]bool{},
-		proposedTypes:   map[string]bool{},
+		leaseAcquired:     true,
+		bands:             map[string]any{"merge_threshold": 0.9, "related_threshold": 0.5},
+		chunks:            map[string]string{},
+		subjectDocs:       map[string]string{},
+		chunkScopes:       map[string]string{},
+		chunkTypes:        map[string]string{},
+		chunkSpans:        map[string]string{},
+		chunkRows:         map[string]map[string]any{},
+		verdicts:          map[string]string{},
+		failEntityKeys:    map[string]bool{},
+		failSubjectDocs:   map[string]bool{},
+		unadoptedSubjects: map[string]bool{},
+		proposedTypes:     map[string]bool{},
 		// Source of truth for this format: formatSubAgentOutput in
 		// internal/api/http/resume.go. Nothing links them — grep that name.
 		subAgentHeader: "[sub-agent agent_id=a_test000000000000]\n",
@@ -274,8 +278,19 @@ func (m *fakeMemory) Execute(_ context.Context, raw json.RawMessage) (tools.Resu
 			if got, ok := m.f.placements[typ+"\x00"+subj]; ok {
 				target = got
 			}
+			reason := "test"
+			// The server's curator gate: a subject the tenant has not adopted keeps its
+			// fact in the caller's scope and says so. Modelled by the REASON TEXT the
+			// bundle matches on, because that string is the whole contract between the
+			// two — a double that invented its own wording would let the bundle drift
+			// away from the server and still pass.
+			if m.f.unadoptedSubjects[subj] {
+				target = caller
+				reason = "left in " + caller + " scope: the tenant does not yet know the subject " +
+					subj + ", and a subject read from one user's transcript is proposed rather than minted."
+			}
 			row := map[string]any{"type": typ, "subject": subj, "scope": target,
-				"moved": target != caller, "reason": "test"}
+				"moved": target != caller, "reason": reason}
 			if target != caller {
 				moved++
 			}
@@ -4995,6 +5010,46 @@ func TestConsolidator_NoDeclarationLeavesEveryFactInTheCallersScope(t *testing.T
 
 // TestConsolidator_PlacementIsAskedOncePerPass: the op is a batch for a reason. Asking per
 // fact would put a tool call in front of every write.
+// TestConsolidator_AnUnadoptedSubjectIsNamedForTheOperator.
+//
+// The tenant registry is curator-only (RFC CV decision 6): a subject read from one
+// user's transcript is proposed, not minted, so its facts stay in the user's scope
+// until an operator adopts it. That is the right default and a SILENT one — the
+// operator declared that this type's facts are shared, and they are not being shared,
+// with nothing on any surface saying why.
+//
+// So the pass names them. Without this the gate reads as a broken declaration, and
+// the first thing an operator would do is go looking for a fault in placement.
+func TestConsolidator_AnUnadoptedSubjectIsNamedForTheOperator(t *testing.T) {
+	f := newFakeToolset()
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	f.transcript = "### user\n\nThe checkout API owns payments. The billing worker retries."
+	f.factsJSON = `[
+		{"text":"The checkout API owns payments.","class":"fact","type":"service","subject":"checkout-api"},
+		{"text":"The billing worker retries failed charges.","class":"fact","type":"service","subject":"billing-worker"}
+	]`
+	// checkout-api is adopted and places; billing-worker is not.
+	f.placements = map[string]string{
+		"service\x00checkout-api":   "tenant",
+		"service\x00billing-worker": "tenant",
+	}
+	f.unadoptedSubjects = map[string]bool{"billing-worker": true}
+
+	res := runConsolidator(t, f)
+
+	if !strings.Contains(res.FinalText, "billing-worker") {
+		t.Errorf("the report must NAME the subject awaiting adoption — a count sends an "+
+			"operator looking, a name lets them act: %s", res.FinalText)
+	}
+	if !strings.Contains(res.FinalText, "tenant scope") {
+		t.Errorf("the report must say what to do about it: %s", res.FinalText)
+	}
+	// The adopted one is not named, or the list is noise rather than a work queue.
+	if strings.Contains(res.FinalText, "checkout-api") {
+		t.Errorf("a subject that placed fine was listed as awaiting adoption: %s", res.FinalText)
+	}
+}
+
 func TestConsolidator_PlacementIsAskedOncePerPass(t *testing.T) {
 	f := newFakeToolset()
 	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}

--- a/internal/memory/placement.go
+++ b/internal/memory/placement.go
@@ -83,6 +83,16 @@ type PlacementInput struct {
 	// Only consulted for a tenant target. Document leaves agent and user scope ungated,
 	// so a user placement needs nothing here.
 	GrantedSqlScopes []string
+
+	// SubjectKnownToTenant reports whether the tenant registry ALREADY holds this
+	// subject. A pass may add facts about a subject the tenant knows; minting the
+	// subject itself is a different act, and the one that shapes what every other
+	// user's facts attach to.
+	SubjectKnownToTenant bool
+	// CuratorWrite marks a write from the operator plane — no run, so no transcript
+	// behind it. Server-derived and unforgeable: it comes from the absence of a run
+	// id, which no caller can fake.
+	CuratorWrite bool
 }
 
 // PlacementDecision is where the fact goes and why.
@@ -158,6 +168,26 @@ func ResolvePlacement(in PlacementInput) PlacementDecision {
 	if target == MemoryScopeTenantName && !grants(in.GrantedSqlScopes, target) {
 		return stay("this agent has memory_scopes: [tenant] but not sql_scopes: [tenant], " +
 			"and a tenant fact needs both — its chunk mirror is a Document write")
+	}
+
+	// THE CURATOR GATE. A tenant entity is what every user's facts about that thing
+	// attach to, so whoever mints one shapes everybody's memory — and the subject's
+	// NAME comes from a model reading one user's untrusted transcript. The control
+	// flow being deterministic does not help here: the consolidator is trustworthy
+	// code carrying an untrustworthy string.
+	//
+	// So adding facts about a subject the tenant already knows is ordinary work, and
+	// minting the subject is a curator's act. A pass that meets an unknown one leaves
+	// the fact in its own scope — nothing is lost, nothing is shared, and the reason
+	// names the subject so an operator can adopt it.
+	//
+	// FAILS CLOSED, like every other guard here: an unreadable registry reads as
+	// "unknown", which keeps the fact at home rather than placing it on a guess.
+	if target == MemoryScopeTenantName && !in.SubjectKnownToTenant && !in.CuratorWrite {
+		return stay("left in " + in.CallerScope + " scope: the tenant does not yet know the subject " +
+			strings.TrimSpace(in.Subject) + ", and a subject read from one user's transcript is " +
+			"proposed rather than minted. An operator adopts it by creating the entity in tenant " +
+			"scope once; facts about it place automatically after that")
 	}
 
 	if target == MemoryScopeTenantName && in.Isolated {

--- a/internal/memory/placement_test.go
+++ b/internal/memory/placement_test.go
@@ -38,6 +38,11 @@ func base(in PlacementInput) PlacementInput {
 	if in.GrantedSqlScopes == nil {
 		in.GrantedSqlScopes = []string{"agent", "user", "tenant"}
 	}
+	// And the fixture's subjects are ALREADY ADOPTED, for the same reason: the curator
+	// gate would otherwise fire first and every test below would report it instead of
+	// the guard it is named for. TestResolvePlacement_AnUnadoptedSubjectIsNotMinted
+	// covers the gate, and builds its input directly so it can say false.
+	in.SubjectKnownToTenant = true
 	return in
 }
 
@@ -279,6 +284,8 @@ func TestResolvePlacement_TenantNeedsBothGrants(t *testing.T) {
 		Terms: placementOntology(), CallerScope: "user", UserID: "u_alice",
 		GrantedScopes:    []string{"user", "tenant"}, // k/v yes...
 		GrantedSqlScopes: []string{"user"},           // ...SQL no
+		// Adopted, so this test reports the grant and not the curator gate.
+		SubjectKnownToTenant: true,
 	}
 	got := ResolvePlacement(in)
 	if got.Moved || got.Scope != "user" {
@@ -303,5 +310,71 @@ func TestResolvePlacement_TenantNeedsBothGrants(t *testing.T) {
 	}
 	if got := ResolvePlacement(userTarget); got.Scope != "user" || !got.Moved {
 		t.Errorf("a user-scope placement must not need sql_scopes: %+v", got)
+	}
+}
+
+// TestResolvePlacement_AnUnadoptedSubjectIsNotMinted is the curator gate.
+//
+// A tenant entity is what every user's facts about that thing attach to, so whoever
+// mints one shapes everybody's memory — and the subject's NAME arrives from a model
+// reading one user's untrusted transcript. That the consolidator is deterministic
+// code does not help: it is trustworthy code carrying an untrustworthy string.
+//
+// So the split is between ADDING to a subject the tenant already knows, which is
+// ordinary work, and MINTING one, which is a curator's act. The unadopted fact is not
+// refused and not lost — it stays in the caller's own scope, exactly as every other
+// placement guard leaves it.
+func TestResolvePlacement_AnUnadoptedSubjectIsNotMinted(t *testing.T) {
+	unadopted := PlacementInput{
+		DeclaredType: "service", Subject: "checkout-api",
+		Terms: placementOntology(), CallerScope: "user", UserID: "u_alice",
+		GrantedScopes:    []string{"user", "tenant"},
+		GrantedSqlScopes: []string{"user", "tenant"},
+		// The whole point: everything else permits the move.
+		SubjectKnownToTenant: false,
+	}
+
+	got := ResolvePlacement(unadopted)
+	if got.Moved || got.Scope != "user" {
+		t.Fatalf("a subject the tenant has never seen was minted from one user's transcript: %+v", got)
+	}
+	// The reason has to name the subject and the remedy, or an operator cannot act on
+	// it — a fact that quietly stays home is indistinguishable from one nothing declared.
+	if !strings.Contains(got.Reason, "checkout-api") {
+		t.Errorf("the reason must name the subject to adopt, got %q", got.Reason)
+	}
+	if !strings.Contains(got.Reason, "adopts") {
+		t.Errorf("the reason must say how to adopt it, got %q", got.Reason)
+	}
+
+	// ADOPTED: the same fact places.
+	adopted := unadopted
+	adopted.SubjectKnownToTenant = true
+	if got := ResolvePlacement(adopted); !got.Moved || got.Scope != "tenant" {
+		t.Errorf("an adopted subject's fact should place: %+v", got)
+	}
+
+	// THE CURATOR PATH: an operator-plane write has no transcript behind it, so it
+	// mints. This is what makes adoption possible at all.
+	curator := unadopted
+	curator.CuratorWrite = true
+	if got := ResolvePlacement(curator); !got.Moved || got.Scope != "tenant" {
+		t.Errorf("a curator must be able to place a subject the tenant does not know yet: %+v", got)
+	}
+}
+
+// TestResolvePlacement_TheCuratorGateDoesNotReachTheUserPlane. The gate is about the
+// SHARED plane — a type declaring `user` scope routes a fact within the caller's own
+// world, where there is no registry to poison and nobody else to affect.
+func TestResolvePlacement_TheCuratorGateDoesNotReachTheUserPlane(t *testing.T) {
+	got := ResolvePlacement(PlacementInput{
+		DeclaredType: "person", Subject: "Maria",
+		Terms: placementOntology(), CallerScope: "agent", UserID: "u_alice",
+		GrantedScopes:        []string{"agent", "user"},
+		GrantedSqlScopes:     []string{"agent", "user"},
+		SubjectKnownToTenant: false,
+	})
+	if !got.Moved || got.Scope != "user" {
+		t.Errorf("a user-scope placement was blocked by a gate meant for the tenant plane: %+v", got)
 	}
 }

--- a/internal/tools/builtin/document_concurrent_append_test.go
+++ b/internal/tools/builtin/document_concurrent_append_test.go
@@ -1,0 +1,98 @@
+package builtin
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// OQ6 — write contention on a shared subject document, ANSWERED BY MEASUREMENT.
+//
+// The question: after subject-homing, many users' consolidators append facts under
+// ONE parent — the tenant entity node — and create_chunk's append path reads
+// max(position) and then inserts, outside a transaction. Two writers read the same
+// max and both take it.
+//
+// The answer: a position TIE, and nothing else. Measured at 8 writers × 6 facts —
+// 48/48 landed, zero errors, 7 positions shared by two chunks. No write is lost, no
+// caller sees an error, and every reader is deterministic anyway because the orders
+// that matter tiebreak on id (export_md is `ORDER BY parent_id, position, id`).
+// reorder_chunk renumbers a sibling list to a contiguous 0..n-1 and so heals ties as
+// a side effect of ordinary use.
+//
+// SO IT IS LEFT ALONE, deliberately. Serialising the read-and-insert would cost a
+// transaction per fact — two extra round trips on the hottest write in a
+// consolidation pass — to prevent an outcome with no observable consequence. The
+// order of a subject's facts carries no meaning; the order of a document's sections
+// does, and that path (create_chunk with after_id) is ALREADY transactional.
+//
+// This test exists so the reasoning is executable: if a tie ever starts costing a
+// write or breaking a read, it fails here rather than in a store.
+func TestConcurrentAppends_ContendOnPositionButNeverOnContent(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	out, r := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Denn","path":"/facts/denn",
+		"type":"person","subject":"Denn","natural_key":"person:denn"}`)
+	if r.IsError {
+		t.Fatalf("create: %s", r.Text)
+	}
+	docID, _ := out["document_id"].(string)
+	root, _ := out["root_chunk_id"].(string)
+
+	const writers, each = 8, 6
+	var wg sync.WaitGroup
+	errs := make(chan string, writers*each)
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < each; i++ {
+				body := fmt.Sprintf(`{"op":"upsert_chunk","scope":"user","document_id":%q,"parent_id":%q,
+					"natural_key":"memory/fact/w%d-f%d","title":"f","body":"a fact","type":"fact"}`,
+					docID, root, w, i)
+				res, err := d.Execute(ctx, json.RawMessage(body))
+				switch {
+				case err != nil:
+					errs <- "exec: " + err.Error()
+				case res.IsError:
+					errs <- res.Text
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+	close(errs)
+	for e := range errs {
+		t.Errorf("a concurrent append failed: %s", e)
+	}
+
+	key := sidecarScope(t, d, ctx)
+	// EVERY WRITE LANDED. This is the assertion that matters: contention may reorder,
+	// it may not lose.
+	cnt, err := d.query(ctx, key, `SELECT count(*) FROM chunks WHERE parent_id = ?`, root)
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n := asInt(cnt.Rows[0][0]); n != writers*each {
+		t.Errorf("%d facts under the subject, want %d — concurrent appends lost writes", n, writers*each)
+	}
+
+	// AND EVERY READ IS DETERMINISTIC. Ties are expected; an order that depends on
+	// which row the database happens to return is not, so the tiebreak is asserted by
+	// reading twice and requiring the same answer.
+	const stmt = `SELECT id FROM chunks WHERE parent_id = ? ORDER BY position, id`
+	first, err := d.query(ctx, key, stmt, root)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	second, err := d.query(ctx, key, stmt, root)
+	if err != nil {
+		t.Fatalf("re-read: %v", err)
+	}
+	for i := range first.Rows {
+		if asStr(first.Rows[i][0]) != asStr(second.Rows[i][0]) {
+			t.Fatalf("two reads of the same sibling list disagree at %d — a position tie is only "+
+				"harmless while the order is settled by the id tiebreak", i)
+		}
+	}
+}

--- a/internal/tools/builtin/memory_placement.go
+++ b/internal/tools/builtin/memory_placement.go
@@ -64,9 +64,16 @@ func (m *Memory) execPlacement(ctx context.Context, callerScope store.MemoryScop
 	// self guard needs to tell a fact about them from a fact about a colleague; a
 	// per-item read would repeat the same export for every fact in the pass.
 	selfNames := m.selfNames(ctx)
+	// A WRITE WITH NO RUN IS THE OPERATOR PLANE, which is what makes it a curator —
+	// there is no transcript behind it. Derived exactly as originForEntityWrite
+	// derives `operator`, so the two cannot disagree about who is acting, and
+	// unforgeable for the same reason: a caller cannot manufacture the absence of a
+	// run id.
+	curator := tools.RunID(ctx) == ""
 	out := make([]map[string]any, 0, len(in.Items))
 	moved := 0
 	subjectTypes := map[string][]string{}
+	knownToTenant := map[string]bool{}
 
 	for _, it := range in.Items {
 		row := map[string]any{
@@ -86,6 +93,9 @@ func (m *Memory) execPlacement(ctx context.Context, callerScope store.MemoryScop
 		subj := strings.ToLower(strings.TrimSpace(it.Subject))
 		if _, seen := subjectTypes[subj]; !seen && subj != "" {
 			subjectTypes[subj] = m.typesForSubject(ctx, callerScope, callerScopeID, it.Subject)
+			// Memoised beside it and for the same reason: a pass writes several facts
+			// about the same handful of subjects, and this is one query per subject.
+			knownToTenant[subj] = m.subjectKnownToTenant(ctx, it.Subject)
 		}
 		d := memrank.ResolvePlacement(memrank.PlacementInput{
 			DeclaredType:  it.Type,
@@ -100,6 +110,9 @@ func (m *Memory) execPlacement(ctx context.Context, callerScope store.MemoryScop
 			// sql_scopes too: a tenant placement also writes the chunk mirror, which is a
 			// Document write and gated on both planes.
 			GrantedSqlScopes: tools.SqlMemPolicy(ctx).AllowedScopes,
+			// The curator gate's two inputs (RFC CV decision 6).
+			SubjectKnownToTenant: knownToTenant[subj],
+			CuratorWrite:         curator,
 		})
 		row["scope"], row["moved"], row["reason"] = d.Scope, d.Moved, d.Reason
 		if d.Advisory != "" {
@@ -131,6 +144,41 @@ func (m *Memory) placementOntology(ctx context.Context) (terms []memrank.Ontolog
 	}
 	d := &Document{Store: m.Store, SqlMem: m.SqlMem}
 	return d.tenantOntologyState(ctx)
+}
+
+// subjectKnownToTenant reports whether the TENANT registry already holds an entity
+// node for this subject — the question the curator gate turns on.
+//
+// FAILS CLOSED. Every error path returns false, which reads as "unknown" and keeps
+// the fact in the caller's own scope. That is the safe direction: the cost of a false
+// negative is a fact that stays home and a subject an operator adopts by hand; the
+// cost of a false positive is a subject minted from one user's transcript that every
+// other user's facts then attach to.
+//
+// Matched on the identity node's TITLE, the same way typesForSubject does, because a
+// live store holds nodes titled "user", "loomboard", "git configuration" — the
+// natural key's slug is derived from that title by the bundle and is not something
+// this side should re-derive.
+func (m *Memory) subjectKnownToTenant(ctx context.Context, subject string) bool {
+	if m.SqlMem == nil || strings.TrimSpace(subject) == "" {
+		return false
+	}
+	d := &Document{Store: m.Store, SqlMem: m.SqlMem}
+	tenant := sqlScopeTenant(ctx)
+	// The two planes key a tenant differently — SQL Memory carries it in the scope id,
+	// the k/v plane leaves it empty — so this asks docScopeKeyFor rather than building
+	// the key by hand, which is the seam the three-keying-planes review flagged.
+	key, ok := docScopeKeyFor(tools.RunIdentity(ctx).TenantID, store.MemoryScopeTenant, tenant)
+	if !ok {
+		return false
+	}
+	res, err := d.query(ctx, key,
+		`SELECT 1 FROM chunks c JOIN chunk_memory_meta mm ON mm.chunk_id = c.id
+		  WHERE lower(coalesce(c.title, '')) = lower(?) LIMIT 1`, subject)
+	if err != nil || res == nil {
+		return false
+	}
+	return len(res.Rows) > 0
 }
 
 // typesForSubject returns the entity types this subject is already recorded under, in the

--- a/internal/tools/builtin/memory_placement_test.go
+++ b/internal/tools/builtin/memory_placement_test.go
@@ -71,12 +71,40 @@ func placementFixture(t *testing.T, confirmed bool, scopes ...string) (*Memory, 
 	// SAME TENANT as the fixture that authored the ontology ("tnt"). The reader keys the
 	// ontology on the run's tenant, so a mismatch here would read an empty plane and
 	// every assertion below would pass or fail for the wrong reason.
+	// A RUN ID, because a consolidation pass HAS one and the curator gate keys on its
+	// absence. Without it the fixture modelled an operator acting by hand, so every
+	// test below would take the curator path and silently stop exercising the gate it
+	// is named for — passing for a reason unrelated to its assertion.
+	ctx = tools.WithRunID(ctx, "run-placement")
 	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a", UserID: "u_alice", TenantID: "tnt"})
+	// And the fixture's subjects are ADOPTED — the tenant registry already holds them —
+	// so each test reports the guard it is about rather than the curator gate.
+	// TestMemoryPlacement_AnUnadoptedSubjectStaysHome covers the gate itself.
+	adoptTenantSubjects(t, d, dctx, "checkout-api", "Cluj-Napoca", "Maria", "Ada Lovelace", "ada", "user", "u_alice", "s")
 	ctx = tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{AllowedScopes: scopes})
 	// sql_scopes mirrors memory_scopes here: a tenant placement needs both, because the
 	// fact's chunk mirror is a Document write. The both-grants case has its own test.
 	ctx = tools.WithSqlMemPolicy(ctx, tools.SqlMemPolicyValue{AllowedScopes: scopes})
 	return &Memory{Store: d.Store, SqlMem: d.SqlMem}, ctx
+}
+
+// adoptTenantSubjects records each name as an entity the TENANT already knows — what
+// a curator does once, by hand, before a pass may place facts about it.
+func adoptTenantSubjects(t *testing.T, d *Document, dctx context.Context, names ...string) {
+	t.Helper()
+	out, r := docExec(t, d, dctx, `{"op":"create_document","scope":"tenant","title":"Registry","path":"/facts/_registry"}`)
+	if r.IsError {
+		t.Fatalf("registry document: %s", r.Text)
+	}
+	docID, _ := out["document_id"].(string)
+	for i, n := range names {
+		nj, _ := json.Marshal(n)
+		if _, r := docExec(t, d, dctx, fmt.Sprintf(
+			`{"op":"upsert_chunk","scope":"tenant","document_id":%q,"natural_key":"seed:%d","title":%s,"type":"object","subject":%s}`,
+			docID, i, string(nj), string(nj))); r.IsError {
+			t.Fatalf("adopt %s: %s", n, r.Text)
+		}
+	}
 }
 
 func placements(t *testing.T, m *Memory, ctx context.Context, body string) []map[string]any {
@@ -297,5 +325,71 @@ func TestMemoryPlacement_TenantNeedsSqlScopesToo(t *testing.T) {
 	}
 	if s, _ := got[0]["reason"].(string); !strings.Contains(s, "sql_scopes") {
 		t.Errorf("the reason must name sql_scopes, got %q", s)
+	}
+}
+
+// TestMemoryPlacement_AnUnadoptedSubjectStaysHome is the curator gate END TO END —
+// the wiring, not the decision (internal/memory covers that).
+//
+// Two things are derived server-side and neither can be supplied by a caller: whether
+// this is a curator (no run id ⇒ the operator plane, no transcript behind it) and
+// whether the tenant registry already holds the subject. A pass that meets an unknown
+// one leaves the fact in its own scope and says which subject to adopt.
+func TestMemoryPlacement_AnUnadoptedSubjectStaysHome(t *testing.T) {
+	m, ctx := placementFixture(t, true)
+
+	// `payments-api` is declared `service` (→ tenant) but was never adopted.
+	got := placements(t, m, ctx, `{"op":"placement","scope":"user","items":[
+		{"type":"service","subject":"payments-api"}]}`)
+	if len(got) != 1 {
+		t.Fatalf("want one placement, got %v", got)
+	}
+	if got[0]["moved"] == true || got[0]["scope"] != "user" {
+		t.Fatalf("a subject the tenant has never seen was minted from a pass: %v", got[0])
+	}
+	reason, _ := got[0]["reason"].(string)
+	if !strings.Contains(reason, "payments-api") || !strings.Contains(reason, "adopts") {
+		t.Errorf("the reason must name the subject and how to adopt it, got %q", reason)
+	}
+
+	// The ADOPTED sibling moves in the same call, which is what proves the registry
+	// lookup is doing the deciding rather than something about this fixture.
+	both := placements(t, m, ctx, `{"op":"placement","scope":"user","items":[
+		{"type":"service","subject":"payments-api"},
+		{"type":"service","subject":"checkout-api"}]}`)
+	if len(both) != 2 {
+		t.Fatalf("want two placements, got %v", both)
+	}
+	if both[0]["moved"] == true {
+		t.Errorf("the unadopted subject moved: %v", both[0])
+	}
+	if both[1]["moved"] != true || both[1]["scope"] != "tenant" {
+		t.Errorf("the adopted subject did not move: %v", both[1])
+	}
+}
+
+// TestMemoryPlacement_ACuratorMintsWhatAPassMayNot. Adoption has to be possible or the
+// gate is a wall: an operator acting by hand carries no run, and that absence is what
+// the server reads as "no transcript behind this".
+func TestMemoryPlacement_ACuratorMintsWhatAPassMayNot(t *testing.T) {
+	m, ctx := placementFixture(t, true)
+
+	// The same unadopted subject, asked by an OPERATOR — same grants, no run.
+	operator := tools.WithMemoryPolicy(context.Background(), tools.MemoryPolicyValue{
+		AllowedScopes: []string{"agent", "user", "tenant"}})
+	operator = tools.WithSqlMemPolicy(operator, tools.SqlMemPolicyValue{
+		AllowedScopes: []string{"agent", "user", "tenant"}})
+	operator = tools.WithRunIdentity(operator, tools.RunIdentityValue{UserID: "u_alice", TenantID: "tnt"})
+
+	got := placements(t, m, operator, `{"op":"placement","scope":"user","items":[
+		{"type":"service","subject":"payments-api"}]}`)
+	if len(got) != 1 || got[0]["moved"] != true || got[0]["scope"] != "tenant" {
+		t.Fatalf("a curator could not place a subject the tenant does not know yet: %v", got)
+	}
+
+	// And the pass still cannot, so the difference really is the identity.
+	if p := placements(t, m, ctx, `{"op":"placement","scope":"user","items":[
+		{"type":"service","subject":"payments-api"}]}`); p[0]["moved"] == true {
+		t.Errorf("the pass placed it too — the gate is not keying on the caller: %v", p[0])
 	}
 }


### PR DESCRIPTION
## OQ6, answered by measurement

P4's stated gate. After subject-homing, many users' consolidators append facts under **one** parent, and `create_chunk`'s append path reads `max(position)` then inserts *outside* a transaction.

**Measured, 8 writers × 6 facts: 48/48 landed, zero errors, 7 positions shared by two chunks.** A tie, and nothing else — no lost write, no error. Nothing constrains `position` to be unique and nothing needs it to be: the orders that matter tiebreak on id (`export_md` is `ORDER BY parent_id, position, id`), and `reorder_chunk` renumbers a sibling list to contiguous `0..n-1`, so ordinary use heals ties.

**So it's left alone, deliberately.** Serialising the read-and-insert costs a transaction — two extra round trips — on the hottest write in a consolidation pass, to prevent an outcome with no observable consequence. A subject's facts have no meaningful order; a document's sections do, and that path (`create_chunk` with `after_id`) is *already* transactional. `TestConcurrentAppends_ContendOnPositionButNeverOnContent` makes the reasoning executable rather than a comment.

## The write gate

Placement already lets a pass create tenant entities: a type declared `@memory_scope tenant` routes its facts to the shared plane, and the subject node is created wherever the fact lands.

The existing answer to *who* may write there is the scope grant, and an agent holding tenant on both planes **is** the operator's designated curator. That's the right rule for *who*, and it doesn't cover *what*: the subject's **name** arrives from a model reading one user's untrusted transcript. The consolidator being deterministic code doesn't help — it's trustworthy code carrying an untrustworthy string.

So the split is **adding** facts about a subject the tenant already knows (ordinary work) vs **minting** the subject (a curator's act):

- `ResolvePlacement` gains a guard: a tenant target whose subject isn't in the registry, from a non-curator, stays in the caller's own scope — refused the way every other guard here refuses, by leaving the fact at home. Nothing lost, nothing shared.
- **Both inputs are server-derived and unforgeable.** `curator` is the absence of a run id, exactly as `originForEntityWrite` derives `operator`, so the two can't disagree about who is acting. Registry membership **fails closed** — every error path reads as "unknown", keeping the fact home. A false negative costs a subject an operator adopts by hand; a false positive is the thing this prevents.
- The gate doesn't reach the **user** plane — a type declaring `user` scope routes within the caller's own world, where there's no registry to poison.

**And the pass names them.** The gate is otherwise silent: the operator declared these facts shared, they aren't being shared, and nothing says why. The report lists the subjects awaiting adoption — named and bounded, not counted — and says to create the entity in tenant scope once.

## Two fixture changes that are load-bearing

Worth a look, because both were hiding something:

- The pure fixture marks its subjects adopted, so each test reports **its own** guard rather than the new one (the same pattern `base()` already used for grants).
- **The tool fixture gains a run id.** Without one it modelled an operator acting by hand — so after this change every test there would have taken the *curator* path and silently stopped exercising the guard it is named for. That's a vacuous pass, and it only surfaced because the gate made the omission load-bearing.

## What was tested

`go test ./...` clean (101 packages).

- **Decision** (`internal/memory`): unadopted stays, adopted places, curator mints, user plane untouched.
- **Wiring** (`internal/tools/builtin`): a pass refused where an operator *with the same grants* succeeds — the RFC's "tested from a non-curator identity".
- **Report** (consolidator suite): the subject awaiting adoption is named; one that placed fine is not.
- **Fail-before on all three.** Without the guard an unadopted subject is minted from a pass at both levels, and the pass reports `placed in a declared scope 1` with no hint the other was declined.

**Live on a running server:** a code-js agent's pass got both subjects refused with the reason naming each → a curator created `/facts/checkout-api` in tenant scope by hand → the same pass re-run placed `checkout-api` to tenant and still left `payments-api` at home.

## What remains in P4

The RFC's own dependency line says P4 comes *"after CW's extractor emits proposals for unknown subjects"*, and that isn't met — so this delivers the half that stands alone (the gate the RFC names, plus OQ6). Still open:

- **Proposal storage.** Adoption today is an operator creating the entity by hand, prompted by the pass's report. The inert-candidate surface decision 6 mentions is CW's extractor half plus a curation surface.
- **Cross-scope fan-out** with a tolerant reader — it has nothing to resolve until references actually cross scopes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8