### PR TITLE
feat(teamdef): a promoted team runs itself — armed subscriptions, one per cluster

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -2815,6 +2815,47 @@ func main() {
 		}()
 	}
 
+	// RFC CY L5: the armed-subscription sweep. A PROMOTED team whose entry
+	// state is a Starter runs on its own when its source channel has work.
+	//
+	// DEFAULT OFF, deliberately. This is the only part of the runtime that
+	// starts agent runs unprompted — turning it on turns the definition plane
+	// into a spend commitment, because every message on a subscribed source
+	// becomes a wave of runs. An operator should arrive at that on purpose.
+	//
+	// The sweep needs no arm/disarm bookkeeping: each tick asks the store which
+	// teams are promoted, so promote arms and retire/delete disarm with no
+	// runtime state to leak or reconcile after a crash.
+	if cfg.Env.TeamSubscriptions && srv != nil && storeIface != nil {
+		if advisoryLock != nil {
+			// Cluster singleton per TEAM (not per process): exactly one replica
+			// drives a given team at a time, and the lock is held across the
+			// whole walk so a second tick cannot start a concurrent one.
+			srv.SetAdvisoryLock(advisoryLock)
+		}
+		tick := time.Duration(cfg.Env.TeamSubscriptionsTickSeconds) * time.Second
+		go func() {
+			t := time.NewTicker(tick)
+			defer t.Stop()
+			for {
+				select {
+				case <-bgCtx.Done():
+					return
+				case <-t.C:
+					started, err := srv.SweepTeamSubscriptions(bgCtx)
+					if err != nil {
+						log.Printf("team-subscriptions: sweep: %v", err)
+						continue
+					}
+					if started > 0 {
+						log.Printf("team-subscriptions: started %d walk(s)", started)
+					}
+				}
+			}
+		}()
+		log.Printf("team-subscriptions: enabled (tick=%s, cluster_gated=%v)", tick, advisoryLock != nil)
+	}
+
 	// RFC BL P1: reconcile the boot-time help-topic search index. The go:embed
 	// help corpus is immutable in-process (no hot-reload), so this is one-shot at
 	// boot. Content-hash gated — an unchanged corpus re-embeds nothing; only

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1426,6 +1426,34 @@ base — and built-in agents — **without a source checkout**. Two kinds:
   `LOOMCYCLE_SKILLS_ROOT`. A bundle may also ship pure *declarations* rather
   than agents — `system-channels` is one.
 
+### Armed subscriptions — a promoted team that runs itself
+
+`LOOMCYCLE_TEAM_SUBSCRIPTIONS=1` (default **off**) drives a **promoted** team
+whose entry state is a `starter`: when its source channel has work, the walk
+starts, with nobody asking for it.
+
+⚠️ **This is the only part of the runtime that starts agent runs unprompted.**
+Turning it on turns the definition plane into a spend commitment — every message
+on a subscribed source becomes a wave of agent runs. Arrive at it deliberately.
+
+- **Promote arms, retire disarms.** There is no arming bookkeeping: each tick
+  asks the store what is promoted, so a retired, deleted or unpromoted team is
+  simply not in the answer — nothing to leak, nothing to reconcile after a
+  crash. `TeamDef op=retire` reports `sources_released` so you can see which
+  wires the workflow was reading.
+- **The source must be `scope: tenant` or `scope: global`.** A sweep has no user
+  and no agent, so an `agent`- or `user`-scoped source is refused rather than
+  guessed at — picking one of its per-user queues would silently drive one and
+  let every other accumulate.
+- **One replica at a time.** Cluster deployments gate each team behind a
+  Postgres advisory lock held for the whole walk, so two replicas never dispatch
+  the same wave concurrently. Single-replica needs no coordinator.
+- **A failing walk backs off** (exponential, capped at 10 minutes, cleared by a
+  success). A failed walk does not ack its source, so without this a poison
+  message would drive the same failure every tick.
+- `LOOMCYCLE_TEAM_SUBSCRIPTIONS_TICK_SECONDS` (default 15) is the worst-case
+  latency between a message landing and its wave starting.
+
 **`system-channels` — the runtime's own `_system/*` channels.** Declares the
 five a workflow can actually read, so a Starter can source a clock or an
 interruption feed without hand-written yaml:

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -160,6 +160,17 @@ type Server struct {
 	// the walk.
 	breakpointReg *breakpoints.Registry
 
+	// advisoryLock, when set, gates the team-subscription sweep so exactly one
+	// replica drives a given promoted team at a time. nil = single-process
+	// (or no Postgres): the sweep drives every team itself, which is correct
+	// for one replica and is why a single-node deployment needs no coordinator
+	// to run its workflows.
+	advisoryLock *coord.AdvisoryLock
+
+	// subBackoff holds off a subscribed team whose walk just failed, so a
+	// poison message cannot drive the same failure every tick.
+	subBackoff subscriptionBackoff
+
 	// residentReg maps a resident interactive sub-agent's run_id → its live
 	// handle (RFC BK). In-process (P1 single-replica). Non-nil after New();
 	// drives Agent op=open/send/close + the idle sweeper + parent-teardown reap.
@@ -899,6 +910,11 @@ func (s *Server) SetScheduleDefTool(t tools.Tool) {
 // Connector.TeamDef + POST /v1/_teamdef + the LoomCycle MCP meta-tool all refuse
 // with "not configured". The tool only needs the store + byte caps, so it can be
 // constructed alongside ScheduleDef in main.go.
+// SetAdvisoryLock wires the cluster singleton coordinator used by the
+// team-subscription sweep. Mirrors the scheduler's SetFanoutCoordination:
+// optional, and absent means single-process.
+func (s *Server) SetAdvisoryLock(l *coord.AdvisoryLock) { s.advisoryLock = l }
+
 func (s *Server) SetTeamDefTool(t tools.Tool) {
 	// Wire execution into the tool: op=run walks a team's graph, spawning each
 	// state's agent via the same runSubAgent path the Agent tool uses — it

--- a/internal/api/http/teamsubscriptions.go
+++ b/internal/api/http/teamsubscriptions.go
@@ -1,0 +1,314 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/channels"
+	"github.com/denn-gubsky/loomcycle/internal/coord"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/teamgraph"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// Armed subscriptions: a promoted team whose ENTRY state is a Starter runs on
+// its own when its source channel has work.
+//
+// WHY A SWEEP AND NOT A LONG-LIVED SUBSCRIBER. The design called for arming on
+// promote and disarming on retire, and warned that "an armed subscription for a
+// retired workflow is a silent resource leak". A sweep removes the leak by
+// removing the state: there is nothing armed to forget to disarm. Each tick
+// asks the store which teams are promoted, so retiring one — or deleting it, or
+// promoting a version whose entry is no longer a Starter — stops it being
+// driven, with no lifecycle to get wrong and nothing to reconcile after a
+// crash. The verification the design asked for still holds, and two of its
+// three items become free: killing the replica that was driving a team means
+// the next tick elsewhere picks it up, because picking it up is all there ever
+// was.
+//
+// WHAT IT COSTS, stated plainly: this is the one part of the runtime that
+// starts agent runs with no human in the loop. That is why it is default-OFF
+// behind LOOMCYCLE_TEAM_SUBSCRIPTIONS, why it holds a per-team lock across the
+// whole walk rather than just the decision to start one, and why it peeks
+// before it walks — an idle team must cost a query, not a run.
+
+// teamSubscription is one promoted team the sweep may drive.
+type teamSubscription struct {
+	DefID    string
+	TenantID string
+	Name     string
+	Source   string // the entry Starter's source channel
+}
+
+// SweepTeamSubscriptions runs one tick: drive every promoted team whose entry
+// state is a Starter and whose source has messages waiting.
+//
+// Returns how many walks it started, for the caller's log. An error is returned
+// only for a failure that stopped the sweep itself — a single team failing is
+// logged and the sweep continues, because one broken workflow must not stop
+// every other one from running.
+func (s *Server) SweepTeamSubscriptions(ctx context.Context) (started int, err error) {
+	if s.store == nil {
+		return 0, nil
+	}
+	subs, err := s.listTeamSubscriptions(ctx)
+	if err != nil {
+		return 0, err
+	}
+	for _, sub := range subs {
+		ran, rerr := s.driveTeamSubscription(ctx, sub)
+		if rerr != nil {
+			// Logged, not returned: a team whose channel is undeclared or
+			// whose def stopped parsing must not silence the rest.
+			log.Printf("team-subscriptions: %s/%s: %v", sub.TenantID, sub.Name, rerr)
+			continue
+		}
+		if ran {
+			started++
+		}
+	}
+	return started, nil
+}
+
+// listTeamSubscriptions enumerates the promoted teams that are driveable.
+//
+// The enumeration IS the arming. A team appears here because its active pointer
+// names a live version whose entry is a Starter — so promote arms it, retire
+// and delete disarm it, and promoting a version with a different entry changes
+// what is driven, all without a single piece of runtime state.
+func (s *Server) listTeamSubscriptions(ctx context.Context) ([]teamSubscription, error) {
+	names, err := s.store.TeamDefListNames(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list teams: %w", err)
+	}
+	var out []teamSubscription
+	for _, n := range names {
+		// No active pointer = nothing promoted. A retired active version is
+		// NOT driven: soft-retire is how an operator takes a workflow out of
+		// service, and it would be a poor take-out-of-service that kept
+		// running it.
+		if n.ActiveDefID == "" || n.ActiveRetired {
+			continue
+		}
+		row, err := s.store.TeamDefGet(ctx, n.ActiveDefID)
+		if err != nil {
+			log.Printf("team-subscriptions: %s/%s: read active def: %v", n.TenantID, n.Name, err)
+			continue
+		}
+		def, err := teamgraph.Parse(row.Definition)
+		if err != nil {
+			log.Printf("team-subscriptions: %s/%s: parse: %v", n.TenantID, n.Name, err)
+			continue
+		}
+		entry, ok := teamgraph.StateByID(def, def.Entry)
+		if !ok || entry.Handler.Kind != teamgraph.HandlerStarter || entry.Handler.Source == nil {
+			continue // not a subscriber — an ordinary team runs when asked
+		}
+		out = append(out, teamSubscription{
+			DefID: row.DefID, TenantID: row.TenantID, Name: row.Name,
+			Source: entry.Handler.Source.Channel,
+		})
+	}
+	// Deterministic order so a log reads the same way twice and a test can
+	// assert on it.
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].TenantID != out[j].TenantID {
+			return out[i].TenantID < out[j].TenantID
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out, nil
+}
+
+// driveTeamSubscription runs one team's walk if its source has work, under the
+// team's own advisory lock so exactly one replica drives it at a time.
+//
+// Reports whether a walk was started. Not started is the common case and is not
+// an error: most ticks find an empty channel.
+func (s *Server) driveTeamSubscription(ctx context.Context, sub teamSubscription) (bool, error) {
+	if !s.subBackoff.ready(sub.DefID) {
+		return false, nil // failing; not yet time to try again
+	}
+	started := false
+	run := func(c context.Context) error {
+		has, err := s.sourceHasWork(c, sub)
+		if err != nil || !has {
+			return err
+		}
+		started = true
+		return s.runSubscribedTeam(c, sub)
+	}
+	// No cluster coordinator = single process; drive it directly. A
+	// single-replica deployment must not need Postgres to run its workflows.
+	if s.advisoryLock == nil {
+		return started, run(ctx)
+	}
+	// TryRun holds the lock for the whole of run — the peek AND the walk — so
+	// a second replica (or this replica's next tick) cannot start a concurrent
+	// walk over the same source. A lost race returns (false, nil): another
+	// replica has it, which is the expected case and not worth logging.
+	if _, err := s.advisoryLock.TryRun(ctx, coord.TeamSubscriptionLockKey(sub.DefID), run); err != nil {
+		return started, err
+	}
+	return started, nil
+}
+
+// sourceHasWork peeks the entry Starter's source. A peek, not a read: the walk
+// itself moves the cursor, and a sweep that consumed would eat the very message
+// it was starting the walk for.
+func (s *Server) sourceHasWork(ctx context.Context, sub teamSubscription) (bool, error) {
+	def, ok := s.ResolveChannelScope(ctx, sub.Source)
+	if !ok {
+		return false, fmt.Errorf("source channel %q is not declared", sub.Source)
+	}
+	scope, scopeID, err := subscriptionScope(def.Scope, sub.Source)
+	if err != nil {
+		return false, err
+	}
+	msgs, err := s.store.ChannelPeek(ctx, sub.TenantID, sub.Source, scope, scopeID, "", 1)
+	if err != nil {
+		return false, fmt.Errorf("peek %q: %w", sub.Source, err)
+	}
+	return len(msgs) > 0, nil
+}
+
+// subscriptionScope resolves where a subscribed team reads from.
+//
+// A sweep has no user and no agent, so it can drive only a channel whose
+// declared scope needs neither. That is a REFUSAL rather than a guess: an
+// agent- or user-scoped channel has a separate queue per agent or per user, and
+// picking one would silently drive a single arbitrary queue while every other
+// one accumulated unread — a workflow that looks like it is running and is
+// quietly ignoring most of its work.
+//
+// tenant and global both work: a tenant-scoped source reads under the team's
+// own tenant (the store's tenant column isolates it), and a global one is the
+// single shared queue.
+func subscriptionScope(declared, channel string) (store.MemoryScope, string, error) {
+	switch declared {
+	case "global":
+		return store.MemoryScopeGlobal, "", nil
+	case "tenant":
+		return store.MemoryScopeTenant, "", nil
+	case "agent", "user":
+		return "", "", fmt.Errorf(
+			"source channel %q is scope=%s, which has a separate queue per %s — "+
+				"a subscribed team has no %s to read as. Declare the source scope: tenant or global",
+			channel, declared, declared, declared)
+	default:
+		return "", "", fmt.Errorf("source channel %q has unknown scope %q", channel, declared)
+	}
+}
+
+// subscriptionCtx stamps the identity a subscribed walk runs under.
+//
+// THE TEAM'S OWN TENANT, never an admin. op=run resolves a def_id under the
+// caller's tenant and folds a mismatch into an opaque not-found — so a sweep
+// running under the empty tenant cannot even see the team it is trying to
+// drive. (It could not, until this existed: every drive failed `def_id … not
+// found`, which is also exactly the refusal a cross-tenant caller gets, so the
+// message was telling the truth.) Taking the tenant from the def ROW keeps the
+// authority model intact: it is the authoritative owner, not something the
+// sweep chose.
+//
+// The user is `_system`, the same attribution internal publishes carry, so a
+// run started by nobody is not attributed to somebody.
+func (s *Server) subscriptionCtx(ctx context.Context, sub teamSubscription) context.Context {
+	return tools.WithRunIdentity(ctx, tools.RunIdentityValue{
+		TenantID: sub.TenantID,
+		UserID:   channels.SystemPublisherUserID,
+		AgentID:  "team:" + sub.Name,
+	})
+}
+
+// backoff decides whether a team that FAILED recently may be driven again yet,
+// and records the outcome.
+//
+// An autonomous driver needs this and a human-triggered run does not. A walk
+// that fails does not ack its source — `after_results` is at-least-once by
+// design, so the batch redelivers — which under a person means "they see the
+// error and fix it", and under a sweep means the same wave every tick forever.
+// A poison message would burn tokens at tick rate until someone noticed.
+//
+// Exponential, capped, and reset by any success. In-memory and per-replica on
+// purpose: another replica may retry sooner, which is right — a failure local
+// to one process must not take a workflow out of service cluster-wide.
+//
+// The ZERO VALUE works. A Server assembled without a constructor — every test
+// fixture in this package does that — would otherwise carry a nil backoff and
+// silently lose the protection, which is the worst way to lose it. The maps are
+// built on first use under the lock.
+type subscriptionBackoff struct {
+	mu    sync.Mutex
+	until map[string]time.Time
+	fails map[string]int
+}
+
+// maxSubscriptionBackoff caps the delay. Long enough that a broken workflow is
+// cheap, short enough that a fixed one recovers without a restart.
+const maxSubscriptionBackoff = 10 * time.Minute
+
+func (b *subscriptionBackoff) ready(defID string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return !time.Now().Before(b.until[defID]) // a nil map reads as the zero Time
+}
+
+func (b *subscriptionBackoff) record(defID string, walkErr error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if walkErr == nil {
+		delete(b.until, defID)
+		delete(b.fails, defID)
+		return
+	}
+	if b.until == nil {
+		b.until, b.fails = map[string]time.Time{}, map[string]int{}
+	}
+	b.fails[defID]++
+	d := time.Duration(1<<min(b.fails[defID], 10)) * time.Second
+	if d > maxSubscriptionBackoff {
+		d = maxSubscriptionBackoff
+	}
+	b.until[defID] = time.Now().Add(d)
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// runSubscribedTeam starts the walk through the same op=run an operator uses,
+// so a subscribed run and a manual one take ONE code path — admission, the
+// breakpoint set, the run row and its finish are all identical, and a bug fixed
+// in one is fixed in both.
+func (s *Server) runSubscribedTeam(ctx context.Context, sub teamSubscription) error {
+	input, err := json.Marshal(map[string]any{"op": "run", "def_id": sub.DefID})
+	if err != nil {
+		return err
+	}
+	res, err := s.TeamDef(s.subscriptionCtx(ctx, sub), input)
+	if err != nil {
+		s.subBackoff.record(sub.DefID, err)
+		return err
+	}
+	if res.IsError {
+		// A failed walk does NOT ack its source, so without a backoff the same
+		// message drives the same failure on the very next tick.
+		s.subBackoff.record(sub.DefID, fmt.Errorf("%s", res.Text))
+		// The walk ran and failed — the workflow's own outcome, not a sweep
+		// fault, and already recorded on its run. Logged so an operator
+		// watching the sweep sees it without reading the runs list.
+		log.Printf("team-subscriptions: %s/%s walk failed (backing off): %s", sub.TenantID, sub.Name, res.Text)
+		return nil
+	}
+	s.subBackoff.record(sub.DefID, nil)
+	return nil
+}

--- a/internal/api/http/teamsubscriptions_test.go
+++ b/internal/api/http/teamsubscriptions_test.go
@@ -75,6 +75,15 @@ func TestListTeamSubscriptions_TheEnumerationIsTheArming(t *testing.T) {
 		`{"state":"done","handler":{"kind":"terminal"}}],`+
 		`"transitions":[{"from":"a","to":"done","on":"success"}]}`, true, false)
 
+	// A malformed def: kind=agent but carrying a source. Validation refuses to
+	// author this, so it can only arrive from an older row or a direct write —
+	// and the KIND check is the only thing standing between it and being driven
+	// as though it were a Starter.
+	seedTeam(t, srv, "agent-with-source", `{"entry":"a","states":[`+
+		`{"state":"a","handler":{"kind":"agent","agent":"x","source":{"channel":"c1"}}},`+
+		`{"state":"done","handler":{"kind":"terminal"}}],`+
+		`"transitions":[{"from":"a","to":"done","on":"success"}]}`, true, false)
+
 	subs, err := srv.listTeamSubscriptions(context.Background())
 	if err != nil {
 		t.Fatalf("list: %v", err)

--- a/internal/api/http/teamsubscriptions_test.go
+++ b/internal/api/http/teamsubscriptions_test.go
@@ -1,0 +1,285 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/teamgraph"
+)
+
+const subStarterGraph = `{"entry":"wave","states":[` +
+	`{"state":"wave","handler":{"kind":"starter","source":{"channel":"c1"},` +
+	`"fanout":{"agent":"reviewer","per":"message","max":2},"sink":{"channel":"c2"}}},` +
+	`{"state":"done","handler":{"kind":"terminal"}}],` +
+	`"transitions":[{"from":"wave","to":"done","on":"success"}],` +
+	`"channels":{"publish":["c2"],"subscribe":["c1"]}}`
+
+// seedTeam writes a team and optionally promotes it, bypassing the tool so a
+// test can build states the tool would refuse to author.
+func seedTeam(t *testing.T, srv *Server, name, defJSON string, promote, retired bool) string {
+	t.Helper()
+	ctx := context.Background()
+	def, err := teamgraph.Parse([]byte(defJSON))
+	if err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	row, err := srv.store.TeamDefCreate(ctx, store.TeamDefRow{
+		DefID: "tdf_" + name, Name: name, Definition: json.RawMessage(defJSON),
+		ContentSHA256: teamgraph.Sign(name, def),
+	})
+	if err != nil {
+		t.Fatalf("seed %s: %v", name, err)
+	}
+	if promote {
+		if err := srv.store.TeamDefSetActive(ctx, "", name, row.DefID, "a_test"); err != nil {
+			t.Fatalf("promote %s: %v", name, err)
+		}
+	}
+	if retired {
+		if err := srv.store.TeamDefSetRetired(ctx, row.DefID, true); err != nil {
+			t.Fatalf("retire %s: %v", name, err)
+		}
+	}
+	return row.DefID
+}
+
+func subNames(subs []teamSubscription) []string {
+	out := make([]string, 0, len(subs))
+	for _, s := range subs {
+		out = append(out, s.Name)
+	}
+	return out
+}
+
+// TestListTeamSubscriptions_TheEnumerationIsTheArming is the property that
+// replaces arm-on-promote / disarm-on-retire.
+//
+// The design warned that "an armed subscription for a retired workflow is a
+// silent resource leak". There is nothing armed to leak: each tick asks the
+// store what is promoted, so an unpromoted, retired or non-Starter team simply
+// is not in the answer. If this test ever passes for one of those, the sweep
+// has started driving something nobody asked it to.
+func TestListTeamSubscriptions_TheEnumerationIsTheArming(t *testing.T) {
+	srv, cleanup := channelFanFixture(t)
+	defer cleanup()
+
+	seedTeam(t, srv, "promoted", subStarterGraph, true, false)
+	seedTeam(t, srv, "unpromoted", subStarterGraph, false, false) // authored, never promoted
+	seedTeam(t, srv, "retired", subStarterGraph, true, true)      // taken out of service
+	seedTeam(t, srv, "not-a-starter", `{"entry":"a","states":[`+  // an ordinary team
+		`{"state":"a","handler":{"kind":"agent","agent":"x"}},`+
+		`{"state":"done","handler":{"kind":"terminal"}}],`+
+		`"transitions":[{"from":"a","to":"done","on":"success"}]}`, true, false)
+
+	subs, err := srv.listTeamSubscriptions(context.Background())
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	got := subNames(subs)
+	if len(got) != 1 || got[0] != "promoted" {
+		t.Fatalf("subscriptions = %v, want just [promoted]", got)
+	}
+	if subs[0].Source != "c1" {
+		t.Errorf("source = %q, want c1 (the ENTRY starter's channel)", subs[0].Source)
+	}
+}
+
+// TestListTeamSubscriptions_RetiringDisarms: the same team, before and after
+// retire. This is the leak the design was worried about, made executable.
+func TestListTeamSubscriptions_RetiringDisarms(t *testing.T) {
+	srv, cleanup := channelFanFixture(t)
+	defer cleanup()
+	defID := seedTeam(t, srv, "triage", subStarterGraph, true, false)
+
+	subs, _ := srv.listTeamSubscriptions(context.Background())
+	if len(subs) != 1 {
+		t.Fatalf("want 1 subscription before retire, got %v", subNames(subs))
+	}
+	if err := srv.store.TeamDefSetRetired(context.Background(), defID, true); err != nil {
+		t.Fatalf("retire: %v", err)
+	}
+	subs, _ = srv.listTeamSubscriptions(context.Background())
+	if len(subs) != 0 {
+		t.Errorf("a RETIRED team is still driven: %v — retire must take a workflow out of service", subNames(subs))
+	}
+}
+
+// TestSubscriptionScope_RefusesAPerUserSource: a sweep has no user and no
+// agent. Driving an agent- or user-scoped channel would mean picking ONE of its
+// per-user queues and silently ignoring every other — a workflow that looks
+// like it is running while most of its work accumulates unread.
+func TestSubscriptionScope_RefusesAPerUserSource(t *testing.T) {
+	for _, tc := range []struct {
+		scope   string
+		wantErr string
+	}{
+		{"global", ""},
+		{"tenant", ""},
+		{"user", "separate queue per user"},
+		{"agent", "separate queue per agent"},
+		{"nonsense", "unknown scope"},
+	} {
+		gotScope, gotID, err := subscriptionScope(tc.scope, "c1")
+		if tc.wantErr == "" {
+			if err != nil {
+				t.Errorf("scope %q: unexpected refusal %v", tc.scope, err)
+			}
+			if gotID != "" {
+				t.Errorf("scope %q: scope_id = %q, want empty (a shared queue)", tc.scope, gotID)
+			}
+			if string(gotScope) != tc.scope {
+				t.Errorf("scope %q resolved to %q", tc.scope, gotScope)
+			}
+			continue
+		}
+		if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+			t.Errorf("scope %q: err = %v, want one mentioning %q", tc.scope, err, tc.wantErr)
+		}
+	}
+}
+
+// TestSweepTeamSubscriptions_IdleSourceStartsNothing: the sweep must cost a
+// query, not a run. An autonomous driver that started a walk per tick on an
+// empty channel would burn tokens forever on a workflow with nothing to do.
+func TestSweepTeamSubscriptions_IdleSourceStartsNothing(t *testing.T) {
+	srv, cleanup := channelFanFixture(t)
+	defer cleanup()
+	seedTeam(t, srv, "triage", subStarterGraph, true, false)
+
+	started, err := srv.SweepTeamSubscriptions(context.Background())
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if started != 0 {
+		t.Errorf("started %d walk(s) on an EMPTY source, want 0", started)
+	}
+}
+
+// TestSweepTeamSubscriptions_OneBadTeamDoesNotStopTheRest: a team whose source
+// is undeclared fails its own drive. The sweep must keep going — one broken
+// workflow silencing every other one is how an operator loses a fleet to a
+// typo.
+func TestSweepTeamSubscriptions_OneBadTeamDoesNotStopTheRest(t *testing.T) {
+	srv, cleanup := channelFanFixture(t)
+	defer cleanup()
+	// c1 is declared by the fixture; "nowhere" is not.
+	seedTeam(t, srv, "broken", strings.Replace(subStarterGraph, `"channel":"c1"`, `"channel":"nowhere"`, 1), true, false)
+	seedTeam(t, srv, "healthy", subStarterGraph, true, false)
+
+	if _, err := srv.SweepTeamSubscriptions(context.Background()); err != nil {
+		t.Fatalf("one undeclared source must not fail the whole sweep: %v", err)
+	}
+	subs, _ := srv.listTeamSubscriptions(context.Background())
+	if len(subs) != 2 {
+		t.Errorf("both teams should still be enumerated: %v", subNames(subs))
+	}
+}
+
+// TestDriveTeamSubscription_WorkOnTheSourceStartsAWalk closes the loop the
+// other tests leave open: a message on the source must actually reach the run
+// path. With no TeamDef tool wired the run refuses by name, which is exactly
+// the evidence wanted — the sweep got past the peek and tried to walk.
+func TestDriveTeamSubscription_WorkOnTheSourceStartsAWalk(t *testing.T) {
+	srv, cleanup := channelFanFixture(t)
+	defer cleanup()
+	seedTeam(t, srv, "triage", subStarterGraph, true, false)
+	ctx := context.Background()
+
+	subs, _ := srv.listTeamSubscriptions(ctx)
+	if len(subs) != 1 {
+		t.Fatalf("want one subscription, got %v", subNames(subs))
+	}
+
+	// Empty source: no attempt at all.
+	started, err := srv.driveTeamSubscription(ctx, subs[0])
+	if started || err != nil {
+		t.Fatalf("empty source: started=%v err=%v, want false/nil", started, err)
+	}
+
+	// Put work on it. c1 is scope:global in the fixture, so the sweep can read
+	// it without a user.
+	if _, err := srv.systemPublisher.PublishNow(ctx, "c1", "",
+		store.MemoryScopeGlobal, "", json.RawMessage(`{"pr":1}`), "_system", 0, 0); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	started, err = srv.driveTeamSubscription(ctx, subs[0])
+	if !started {
+		t.Fatal("a message on the source did not start a walk — the peek gate never opened")
+	}
+	if err == nil || !strings.Contains(err.Error(), "SetTeamDefTool") {
+		t.Errorf("err = %v, want the not-configured refusal proving the run path was reached", err)
+	}
+
+	// And the peek did NOT consume it — the walk owns the cursor, and a sweep
+	// that ate the message would start a wave with nothing to work on.
+	msgs, perr := srv.store.ChannelPeek(ctx, "", "c1", store.MemoryScopeGlobal, "", "", 10)
+	if perr != nil || len(msgs) != 1 {
+		t.Errorf("after the sweep the source holds %d message(s) (err=%v), want 1 — the peek must not consume", len(msgs), perr)
+	}
+}
+
+// TestSubscriptionBackoff_PacesAFailingTeam: a failed walk does NOT ack its
+// source, so without a backoff the same message drives the same failure on the
+// very next tick — a poison message burning tokens at tick rate until someone
+// notices. This is the guard an autonomous driver needs and a human-triggered
+// run does not.
+func TestSubscriptionBackoff_PacesAFailingTeam(t *testing.T) {
+	var b subscriptionBackoff // the ZERO value must work — Servers are built without a constructor here
+	if !b.ready("t1") {
+		t.Fatal("a team with no history must be ready")
+	}
+	b.record("t1", context.DeadlineExceeded)
+	if b.ready("t1") {
+		t.Error("a team that just failed was immediately retried")
+	}
+	// Another team is unaffected — one broken workflow must not pace the rest.
+	if !b.ready("t2") {
+		t.Error("a failure on one team held back another")
+	}
+	// Success clears it, so a fixed workflow recovers without a restart.
+	b.record("t1", nil)
+	if !b.ready("t1") {
+		t.Error("a success did not clear the backoff")
+	}
+	// And it is bounded: repeated failures must not grow without limit.
+	for i := 0; i < 40; i++ {
+		b.record("t3", context.DeadlineExceeded)
+	}
+	b.mu.Lock()
+	wait := time.Until(b.until["t3"])
+	b.mu.Unlock()
+	if wait > maxSubscriptionBackoff {
+		t.Errorf("backoff grew to %s, past the %s cap — a team must stay recoverable", wait, maxSubscriptionBackoff)
+	}
+}
+
+// TestListTeamSubscriptions_AnyReplicaCanDriveAnyTeam: the enumeration is
+// derived entirely from the shared store, so every replica sees the same
+// driveable set. That is what makes losing a replica a non-event — there is no
+// ownership to hand over, and the next replica to tick simply picks the team
+// up. Two Servers over one store stand in for two replicas.
+func TestListTeamSubscriptions_AnyReplicaCanDriveAnyTeam(t *testing.T) {
+	srvA, cleanup := channelFanFixture(t)
+	defer cleanup()
+	seedTeam(t, srvA, "triage", subStarterGraph, true, false)
+
+	// A second Server over the SAME store — what a second replica is.
+	srvB := &Server{store: srvA.store, cfgHolder: srvA.cfgHolder}
+
+	subsA, err := srvA.listTeamSubscriptions(context.Background())
+	if err != nil {
+		t.Fatalf("A: %v", err)
+	}
+	subsB, err := srvB.listTeamSubscriptions(context.Background())
+	if err != nil {
+		t.Fatalf("B: %v", err)
+	}
+	if len(subsA) != 1 || len(subsB) != 1 || subsA[0].DefID != subsB[0].DefID {
+		t.Fatalf("replicas disagree on what is driveable: A=%v B=%v", subNames(subsA), subNames(subsB))
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2934,6 +2934,24 @@ type Env struct {
 	// LOOMCYCLE_RESUME_FANOUT=1; should be on at BOTH the capturing and
 	// restoring instances for a cross-instance hand-off.
 	ResumeFanout bool
+	// TeamSubscriptions enables the armed-subscription sweep: a PROMOTED team
+	// whose entry state is a Starter is driven automatically when its source
+	// channel has work, with no human asking for each run.
+	//
+	// Default OFF, and this one earns the gate rather than inheriting it. It is
+	// the only part of the runtime that starts agent runs unprompted, so
+	// turning it on turns a definition plane into a spend commitment: every
+	// message on a subscribed source becomes a wave of agent runs. An operator
+	// should arrive at that deliberately. Unset, the sweep never ticks and a
+	// promoted team runs only when something asks it to — exactly as before.
+	//
+	// LOOMCYCLE_TEAM_SUBSCRIPTIONS=1.
+	TeamSubscriptions bool
+	// TeamSubscriptionsTickSeconds is how often the sweep looks for work.
+	// 0 = the code default (15s). The tick is the worst-case latency between a
+	// message landing on a source and its wave starting; it is not a poll of
+	// every channel, but one peek per subscribed team.
+	TeamSubscriptionsTickSeconds int
 	// MaxInteractiveChildren caps how many resident interactive sub-agents (RFC
 	// BK Agent op=open) one run may hold open at once. 0 = the code default (8).
 	// Exceeding it fails op=open (the parent must close one first).
@@ -3937,6 +3955,7 @@ func LoadLayers(layers ...Layer) (*Config, error) {
 		ProvisionIdentityDocs:       getenvBool("LOOMCYCLE_MEMORY_PROVISION_IDENTITY_DOCS", true),
 		HTTPCallerAuthoritative:     os.Getenv("LOOMCYCLE_HTTP_CALLER_AUTHORITATIVE") == "1",
 		ResumeFanout:                os.Getenv("LOOMCYCLE_RESUME_FANOUT") == "1",
+		TeamSubscriptions:           os.Getenv("LOOMCYCLE_TEAM_SUBSCRIPTIONS") == "1",
 		MaxInteractiveChildren:      getenvInt("LOOMCYCLE_MAX_INTERACTIVE_CHILDREN", 0),
 		InteractiveChildIdleTTLMs:   getenvInt("LOOMCYCLE_INTERACTIVE_CHILD_IDLE_TTL_MS", 0),
 		BraveAPIKey:                 os.Getenv("BRAVE_API_KEY"),
@@ -4581,6 +4600,15 @@ func LoadLayers(layers ...Layer) (*Config, error) {
 	if v := os.Getenv("LOOMCYCLE_SCHEDULER_TICK_SECONDS"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			cfg.Env.SchedulerTickSeconds = n
+		}
+	}
+	// RFC CY L5: the armed-subscription sweep. Default 15s — the worst-case
+	// latency between a message landing on a subscribed source and its wave
+	// starting. Only read when TeamSubscriptions is on.
+	cfg.Env.TeamSubscriptionsTickSeconds = 15
+	if v := os.Getenv("LOOMCYCLE_TEAM_SUBSCRIPTIONS_TICK_SECONDS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.Env.TeamSubscriptionsTickSeconds = n
 		}
 	}
 	cfg.Env.SchedulerFireTimeoutSeconds = 600

--- a/internal/coord/advisory_lock.go
+++ b/internal/coord/advisory_lock.go
@@ -163,6 +163,28 @@ var (
 	LockKeyDeadLinkGC int64
 )
 
+// TeamSubscriptionLockKey derives a team's subscription-sweep key from its
+// DEF ID, so exactly one replica drives that team's entry Starter at a time.
+//
+// PER-DEF, and held for the WHOLE walk rather than just the decision to start
+// one. A single process-wide key would make two subscribed teams collide every
+// tick, and the loser would forfeit its cadence to whichever team the sweep
+// reached first — the same trap MemoryConsolidatorLockKey documents below.
+// Releasing before the walk finishes would be worse: the next tick would start
+// a SECOND walk over the same source while the first still ran, and the two
+// would compete for one cursor. That is not corruption (a channel cursor has no
+// subscriber dimension, so each message still goes to exactly one reader) but
+// it is a spend amplifier, which is the thing an autonomous subscriber must
+// never be.
+//
+// The cost of holding it is one pinned pgx connection per team with work in
+// flight. Bounded by the number of subscribed teams, and only while a walk is
+// actually running — an idle team takes the lock, finds nothing, and releases
+// within a query.
+func TeamSubscriptionLockKey(defID string) int64 {
+	return fnvKey("team_subscription:" + defID)
+}
+
 // MemoryConsolidatorLockKey derives the RFC BL P2 consolidation fan-out's
 // advisory-lock key from the SCHEDULE DEF id, so only one replica per tick
 // enumerates that schedule's targets and dispatches their runs.

--- a/internal/tools/builtin/teamdef.go
+++ b/internal/tools/builtin/teamdef.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -537,7 +538,38 @@ func (t *TeamDef) execRetire(ctx context.Context, in teamDefInput) (tools.Result
 	if err := t.Store.TeamDefSetRetired(ctx, in.DefID, *in.Retired); err != nil {
 		return errResult(fmt.Sprintf("retire: %s", err)), nil
 	}
-	return okJSON(map[string]any{"def_id": in.DefID, "retired": *in.Retired})
+	out := map[string]any{"def_id": in.DefID, "retired": *in.Retired}
+	// Name the channels this version subscribed to.
+	//
+	// A retired workflow stops being swept, so nothing keeps reading its
+	// source — but the operator cannot SEE that from a bare {def_id, retired}.
+	// An unattended subscription is the failure mode this phase is most likely
+	// to produce, and the cheapest guard against it is telling the person who
+	// retired the team exactly which wires it was on, so they can check that
+	// nothing is still accumulating there.
+	if def, perr := teamgraph.Parse(row.Definition); perr == nil {
+		var sources []string
+		seen := map[string]bool{}
+		for _, ref := range teamgraph.ChannelRefs(def) {
+			if ref.Side != teamgraph.SideSubscribe || seen[ref.Channel] {
+				continue
+			}
+			seen[ref.Channel] = true
+			sources = append(sources, ref.Channel)
+		}
+		if len(sources) > 0 {
+			sort.Strings(sources)
+			// `released` when retiring, `resumed` when un-retiring: the same
+			// list means opposite things, and a caller reading one field name
+			// for both would have to know the verb to interpret it.
+			key := "sources_released"
+			if !*in.Retired {
+				key = "sources_resumed"
+			}
+			out[key] = sources
+		}
+	}
+	return okJSON(out)
 }
 
 // execDelete hard-deletes a team by name (all versions + active pointer). Teams

--- a/internal/tools/builtin/teamdef_preflight_test.go
+++ b/internal/tools/builtin/teamdef_preflight_test.go
@@ -314,3 +314,45 @@ func TestTeamDefVerify_UndeployedTeamIsUnchanged(t *testing.T) {
 		t.Errorf("an undeployed team must not claim a runnable verdict: %v", out)
 	}
 }
+
+// TestTeamDefVerify_RetireNamesTheChannelsItReleased: retiring a subscribed
+// workflow stops it being driven, but a bare {def_id, retired} does not let the
+// operator SEE that. An unattended subscription is the failure this phase is
+// most likely to produce, so retire names the wires the team was on.
+func TestTeamDefVerify_RetireNamesTheChannelsItReleased(t *testing.T) {
+	tool, ctx, cleanup := teamDefFixture(t)
+	defer cleanup()
+	tool.ChannelCatalog = declared("pr-events", "verdicts")
+	actx := authoringCtx([]string{"verdicts"}, []string{"pr-events"})
+	created := createTeam(t, tool, actx, "triage", fullACL())
+	defID, _ := created["def_id"].(string)
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"retire","def_id":"`+defID+`","retired":true}`))
+	if res.IsError {
+		t.Fatalf("retire: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	if out["retired"] != true {
+		t.Fatalf("retired = %v", out["retired"])
+	}
+	srcs, _ := out["sources_released"].([]any)
+	if len(srcs) != 1 || srcs[0] != "pr-events" {
+		t.Errorf("sources_released = %v, want [pr-events] — the SOURCE, not the sink", out["sources_released"])
+	}
+	// The sink is not a subscription and must not be reported as released.
+	if strings.Contains(res.Text, "verdicts") {
+		t.Errorf("retire named the sink channel; only sources are subscriptions: %s", res.Text)
+	}
+
+	// Un-retiring says the opposite thing under a different key — the same list
+	// with one name would need the caller to know the verb to read it.
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"retire","def_id":"`+defID+`","retired":false}`))
+	out = decodeResult(t, res.Text)
+	if _, wrong := out["sources_released"]; wrong {
+		t.Error("un-retire reported sources_released")
+	}
+	resumed, _ := out["sources_resumed"].([]any)
+	if len(resumed) != 1 || resumed[0] != "pr-events" {
+		t.Errorf("sources_resumed = %v, want [pr-events]", out["sources_resumed"])
+	}
+}


### PR DESCRIPTION
## Why

The design calls this the operationally riskiest piece in the RFC, and it is: **this is the only part of the runtime that starts agent runs with nobody asking.** Behind `LOOMCYCLE_TEAM_SUBSCRIPTIONS` (default **off**), a promoted team whose entry state is a Starter is driven when its source channel has work.

## A sweep, not a long-lived subscriber — a deliberate deviation

The plan said *"arm on promote, disarm on retire"* and warned that *"an armed subscription for a retired workflow is a silent resource leak"*.

A sweep removes the leak by removing the state. Each tick asks the store what is promoted, so an unpromoted, retired, deleted or no-longer-Starter team simply is not in the answer — no lifecycle to get wrong, nothing to reconcile after a crash. Two of the plan's three verification items become free: losing the replica that was driving a team is a non-event, because picking it up is all there ever was.

## One replica at a time

Each team is gated behind its **own** Postgres advisory lock, held across the **whole walk** rather than just the decision to start one.

- **Per-def, not process-wide** — two subscribed teams would otherwise collide every tick and the loser would forfeit its cadence.
- **Not released early** — the next tick would start a second walk over the same source while the first still ran. Not corruption (a channel cursor has no subscriber dimension, so each message still goes to exactly one reader) but a **spend amplifier**, which is the one thing an autonomous driver must never be.

## Two bugs the unit tests could not see

Both found by running **two replicas against one Postgres**, and both are why that test was worth doing:

1. **The sweep drove nothing.** `op=run` resolves a `def_id` under the *caller's* tenant and folds a mismatch into an opaque not-found — so a sweep running under the empty tenant could not see the team it was driving. Every drive failed `def_id … not found`, which is also exactly what a cross-tenant caller gets, so the message was telling the truth. The walk now runs under the team's own tenant, taken from the def row (the authoritative owner, not something the sweep chose), attributed to `_system`.
2. **A failing walk re-fired every tick, forever.** `ack: after_results` is at-least-once by design, so a failed walk does not ack its source. Under a person that means "they see the error and fix it"; under a sweep it means the same poison message burning tokens at tick rate until someone notices. Failures now back off exponentially, capped at 10 minutes, cleared by any success — in-memory and per-replica on purpose, so a failure local to one process does not take a workflow out of service cluster-wide.

## Other decisions

- **A source must be `scope: tenant` or `global`.** A sweep has no user and no agent, so an agent- or user-scoped source is **refused, not guessed at** — picking one of its per-user queues would silently drive that one while every other accumulated unread.
- **It peeks before it walks.** An idle team must cost a query, not a run. The peek does not consume: the walk owns the cursor.
- **One team failing is logged and the sweep continues** — one broken workflow silencing every other is how an operator loses a fleet to a typo.
- **It runs through the same `op=run` an operator uses**, so a subscribed run and a manual one take one code path: admission, breakpoints, the run row, the finish.
- **`op=retire` now reports `sources_released`** (and `sources_resumed` on un-retire — the same list means opposite things, and one field name for both would need the reader to know the verb). An unattended subscription is the failure this phase is most likely to produce.
- **`subscriptionBackoff`'s zero value works.** Every `Server` in these tests is assembled without a constructor, and a nil backoff would silently lose the protection — the worst way to lose it.

## Tested

`go build ./...`, `go vet ./...`, `gofmt -l` clean, **`go test ./...` green (111 packages)**.

**Two replicas against one Postgres** — the plan's headline verification:

```
replica-8921  team-subscriptions: enabled (tick=3s, cluster_gated=true)
replica-8922  team-subscriptions: enabled (tick=3s, cluster_gated=true)

one message published →
  overlapping walk pairs: 0        ← the property the lock must guarantee
  6 run(s) in the shared store, under the team's tenant
  the sweep read the source and dispatched a wave
```

Six sequential, backoff-paced drives of the same team across both replicas, **never two at once**. (The walks fail in that throwaway config because its mock provider resolves no model — the sweep, the lock, the tenant and the backoff are what was under test, and the repeats are the backoff doing its job.)

**Fail-before, six claims, each red against its own break:** a retired team still driven · a non-Starter entry driven · a per-user source silently driven · the sweep walking an empty source · one bad team aborting the sweep · no backoff.

**Two were vacuous on the first attempt.** The enumeration test passed against a removed kind check, because every non-Starter fixture also had a nil source — so the redundant half did the work. It now includes a malformed def (kind=agent carrying a source), which validation refuses to author and which only the kind check excludes.

Docs: `docs/CONFIGURATION.md` gains the section, led by what turning it on commits you to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD