### PR TITLE
fix(store): the wave correlation was being dropped on write; watch a walk live

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1426,6 +1426,28 @@ base — and built-in agents — **without a source checkout**. Two kinds:
   `LOOMCYCLE_SKILLS_ROOT`. A bundle may also ship pure *declarations* rather
   than agents — `system-channels` is one.
 
+### Watching a team walk live
+
+A team walk is a run, and its **`run_id` is also its walk id** — the correlation
+stamped on the `parent_context` of every agent run the walk spawns. So one
+handle answers "which walk is this" everywhere:
+
+```sh
+# start it and keep the handle
+curl -XPOST …/v1/_teamdef -d '{"op":"run","name":"triage","mode":"detach"}'
+# → {"run_id":"r_4325…","status":"running"}
+
+# watch that walk's agents appear and finish, live
+curl -N "…/v1/users/{user_id}/agents/stream?walk_id=r_4325…"
+```
+
+The same filter is on the `stream_user_run_states` MCP tool (`walk_id`). The
+`stream_open` event echoes `filter_walk_id`, so a mistyped id shows up as a
+wrong echo rather than as a workflow that quietly produced nothing.
+
+Each event's `parent_context` carries `walk_id`, `wave_id` and `wave_index`, so
+a client can group a fan-out by wave and order it by position.
+
 ### Armed subscriptions — a promoted team that runs itself
 
 `LOOMCYCLE_TEAM_SUBSCRIPTIONS=1` (default **off**) drives a **promoted** team

--- a/internal/api/http/connector_impl_n8n.go
+++ b/internal/api/http/connector_impl_n8n.go
@@ -188,6 +188,13 @@ func (s *Server) StreamUserRunStates(ctx context.Context, req connector.StreamUs
 			if req.Agent != "" && evt.Agent != req.Agent {
 				continue
 			}
+			// A run with no parent context cannot belong to a walk, so an
+			// unstamped event is filtered out rather than passed through — a
+			// walk view that also showed unrelated runs would not be a walk
+			// view.
+			if !walkIDMatches(req.WalkID, evt.ParentContext) {
+				continue
+			}
 			if len(statusSet) > 0 && !statusSet[evt.Status] {
 				continue
 			}
@@ -199,6 +206,19 @@ func (s *Server) StreamUserRunStates(ctx context.Context, req connector.StreamUs
 			}
 		}
 	}
+}
+
+// walkIDMatches reports whether an event belongs to the filtered walk.
+//
+// An empty filter matches everything — the whole-user stream is unchanged for
+// every caller that does not ask for a walk. A run with NO parent context
+// cannot belong to any walk, so it is EXCLUDED rather than passed through: a
+// walk view that also showed unrelated runs would not be a walk view.
+func walkIDMatches(want string, pc *store.ParentContext) bool {
+	if want == "" {
+		return true
+	}
+	return pc != nil && pc.WalkID == want
 }
 
 func runStateEventToConnector(e runstate.RunStateEvent) connector.RunStateEvent {

--- a/internal/api/http/runs_stream.go
+++ b/internal/api/http/runs_stream.go
@@ -64,6 +64,10 @@ func parseStreamFilter(userID string, q map[string][]string) connector.StreamUse
 	if vals := q["agent"]; len(vals) > 0 {
 		out.Agent = strings.TrimSpace(vals[0])
 	}
+	// `?walk_id=<run_id of the walk>` — watch one team walk's agents live.
+	if vals := q["walk_id"]; len(vals) > 0 {
+		out.WalkID = strings.TrimSpace(vals[0])
+	}
 	return out
 }
 
@@ -122,9 +126,14 @@ func (s *Server) handleStreamUserAgents(w http.ResponseWriter, r *http.Request) 
 	// n8n's trigger-setup phase where the workflow waits for the
 	// credential test before arming.
 	stream.sendRaw("stream_open", map[string]any{
-		"user_id":            userID,
-		"filter_status":      sortedCopy(req.Statuses),
-		"filter_agent":       req.Agent,
+		"user_id":       userID,
+		"filter_status": sortedCopy(req.Statuses),
+		"filter_agent":  req.Agent,
+		// Echoed so a client can confirm its filter was understood. A
+		// mistyped param would otherwise look like a workflow that simply
+		// produced no events, which is the same thing a working filter looks
+		// like right up until it isn't.
+		"filter_walk_id":     req.WalkID,
 		"keepalive_interval": int(streamKeepaliveInterval.Seconds()),
 	})
 

--- a/internal/api/http/runs_stream_walk_test.go
+++ b/internal/api/http/runs_stream_walk_test.go
@@ -1,0 +1,46 @@
+package http
+
+import (
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// TestParseStreamFilter_WalkID: the query param a canvas watches a workflow
+// with.
+func TestParseStreamFilter_WalkID(t *testing.T) {
+	got := parseStreamFilter("u1", map[string][]string{"walk_id": {" r_abc "}})
+	if got.WalkID != "r_abc" {
+		t.Errorf("WalkID = %q, want r_abc (trimmed)", got.WalkID)
+	}
+	// Absent means no narrowing — the whole-user stream is unchanged.
+	if got := parseStreamFilter("u1", map[string][]string{}); got.WalkID != "" {
+		t.Errorf("WalkID = %q with no param, want empty", got.WalkID)
+	}
+}
+
+// TestStreamFilter_WalkIDMatchesOnParentContext pins the matching rule,
+// including the case that is easy to get wrong: a run with NO parent context
+// cannot belong to a walk, so it must be filtered OUT rather than passed
+// through. A walk view that also showed unrelated runs would not be a walk
+// view.
+func TestStreamFilter_WalkIDMatchesOnParentContext(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		filter string
+		pc     *store.ParentContext
+		want   bool
+	}{
+		{"no filter passes everything", "", nil, true},
+		{"no filter passes a stamped run", "", &store.ParentContext{WalkID: "r_a"}, true},
+		{"matching walk passes", "r_a", &store.ParentContext{WalkID: "r_a"}, true},
+		{"another walk is excluded", "r_a", &store.ParentContext{WalkID: "r_b"}, false},
+		{"an UNSTAMPED run is excluded", "r_a", nil, false},
+		{"a stamped-but-empty run is excluded", "r_a", &store.ParentContext{}, false},
+	} {
+		got := walkIDMatches(tc.filter, tc.pc)
+		if got != tc.want {
+			t.Errorf("%s: match = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/internal/api/mcp/handlers.go
+++ b/internal/api/mcp/handlers.go
@@ -928,6 +928,7 @@ type streamUserRunStatesArgs struct {
 	UserID    string   `json:"user_id"`
 	Statuses  []string `json:"statuses,omitempty"`
 	Agent     string   `json:"agent,omitempty"`
+	WalkID    string   `json:"walk_id,omitempty"`
 	MaxEvents int      `json:"max_events,omitempty"`
 	TimeoutMS int      `json:"timeout_ms,omitempty"`
 }
@@ -988,6 +989,7 @@ func handleStreamUserRunStates(ctx context.Context, env *handlerEnv, args json.R
 		UserID:   a.UserID,
 		Statuses: a.Statuses,
 		Agent:    a.Agent,
+		WalkID:   a.WalkID,
 	}, visit)
 	if err != nil {
 		return toolErr("stream_user_run_states: " + err.Error()), nil

--- a/internal/api/mcp/tools.go
+++ b/internal/api/mcp/tools.go
@@ -510,7 +510,7 @@ func toolDescriptors() []loommcp.ToolDescriptor {
 		},
 		{
 			Name:        "stream_user_run_states",
-			Description: "Subscribe to run state transitions for one user_id. Returns {events: [RunStateEvent...], count}. When the session opted into capabilities.loomcycle.runEvents=true, each matching event also arrives as a notifications/loomcycle/run_state notification and the response carries an empty events array (count only). Filters: statuses (e.g. ['completed','failed']) and agent (exact name). max_events caps the response at N events; timeout_ms bounds the blocking wait.",
+			Description: "Subscribe to run state transitions for one user_id. Returns {events: [RunStateEvent...], count}. When the session opted into capabilities.loomcycle.runEvents=true, each matching event also arrives as a notifications/loomcycle/run_state notification and the response carries an empty events array (count only). Filters: statuses (e.g. ['completed','failed']), agent (exact name), and walk_id — the runs one team walk spawned, matched on parent_context.walk_id. A team walk's own run_id IS its walk_id, so filtering by the id a detached run returned gives a live view of that workflow's agents. max_events caps the response at N events; timeout_ms bounds the blocking wait.",
 			InputSchema: rawJSON(`{
 				"type": "object",
 				"required": ["user_id"],
@@ -518,6 +518,7 @@ func toolDescriptors() []loommcp.ToolDescriptor {
 					"user_id":    {"type": "string"},
 					"statuses":   {"type": "array", "items": {"type": "string"}},
 					"agent":      {"type": "string"},
+					"walk_id":    {"type": "string", "description": "Only runs spawned by this team walk (its run_id)."},
 					"max_events": {"type": "integer", "minimum": 1, "default": 16},
 					"timeout_ms": {"type": "integer", "minimum": 100, "default": 30000}
 				}

--- a/internal/connector/types.go
+++ b/internal/connector/types.go
@@ -716,6 +716,14 @@ type StreamUserRunStatesRequest struct {
 	UserID   string   `json:"user_id"`
 	Statuses []string `json:"statuses,omitempty"`
 	Agent    string   `json:"agent,omitempty"`
+	// WalkID narrows the stream to the runs ONE team walk spawned, matched
+	// against each event's parent_context.walk_id.
+	//
+	// The walk's own run id IS that walk id, so a caller that started a team
+	// with mode=detach filters by exactly the handle it already holds — no
+	// second identifier, and no mapping to look up. This is what makes a live
+	// canvas view of a running workflow a filter rather than a feature.
+	WalkID string `json:"walk_id,omitempty"`
 	// TenantID + TenantScoped enforce RFC L/N tenant isolation on the stream.
 	// When TenantScoped is true, only events whose run TenantID == TenantID are
 	// yielded (a tenant principal must not see another tenant's run

--- a/internal/store/parent_context_iszero_test.go
+++ b/internal/store/parent_context_iszero_test.go
@@ -1,0 +1,94 @@
+package store
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestParentContext_IsZeroCoversEveryField is the guard on a silent-drop bug.
+//
+// EncodeParentContext writes NULL when IsZero says so, so a field IsZero does
+// not mention makes a context carrying only that field vanish on write — every
+// run, no error, nothing to point at. The wave correlation was added to the
+// struct and not to IsZero, and every run a Starter spawned stored a NULL
+// parent_context as a result.
+//
+// This derives the field list from the STRUCT, so adding one and forgetting
+// IsZero reds here instead of silently dropping data.
+func TestParentContext_IsZeroCoversEveryField(t *testing.T) {
+	rt := reflect.TypeOf(ParentContext{})
+	for i := 0; i < rt.NumField(); i++ {
+		f := rt.Field(i)
+		p := &ParentContext{}
+		v := reflect.ValueOf(p).Elem().Field(i)
+		// Set this field alone to a non-zero value.
+		switch f.Type.Kind() {
+		case reflect.String:
+			v.SetString("x")
+		case reflect.Int, reflect.Int64:
+			v.SetInt(7)
+		case reflect.Bool:
+			v.SetBool(true)
+		default:
+			t.Logf("field %s has kind %s — extend this test for it", f.Name, f.Type.Kind())
+			continue
+		}
+		if p.IsZero() {
+			t.Errorf("ParentContext{%s: set} reports IsZero — EncodeParentContext would write NULL "+
+				"and the value would be dropped silently on every run. Add %s to IsZero.", f.Name, f.Name)
+		}
+		// And it must actually survive a round trip.
+		enc, ok, err := EncodeParentContext(p)
+		if err != nil {
+			t.Fatalf("%s: encode: %v", f.Name, err)
+		}
+		if !ok || enc == "" {
+			t.Errorf("%s: encode reported nothing to store", f.Name)
+			continue
+		}
+		back, err := DecodeParentContext(enc)
+		if err != nil || back == nil {
+			t.Fatalf("%s: decode: %v", f.Name, err)
+		}
+		if !reflect.DeepEqual(*back, *p) {
+			t.Errorf("%s: round trip changed the value: %+v -> %+v", f.Name, *p, *back)
+		}
+	}
+
+	// The genuinely empty case still encodes to nothing, so an ordinary run
+	// keeps its NULL column rather than storing an empty object.
+	if _, ok, _ := EncodeParentContext(&ParentContext{}); ok {
+		t.Error("an empty ParentContext encoded something — ordinary runs must keep a NULL column")
+	}
+	if !(*ParentContext)(nil).IsZero() {
+		t.Error("a nil ParentContext must be zero")
+	}
+}
+
+// TestParentContext_WaveIndexZeroSurvives: index 0 is a real position in a
+// wave. With omitempty it vanished, making the FIRST run of every wave
+// indistinguishable from a run that carries no index — which is precisely the
+// run a canvas draws first.
+func TestParentContext_WaveIndexZeroSurvives(t *testing.T) {
+	p := &ParentContext{WalkID: "r_a", WaveID: "wav_1", WaveIndex: 0}
+	enc, ok, err := EncodeParentContext(p)
+	if err != nil || !ok {
+		t.Fatalf("encode: ok=%v err=%v", ok, err)
+	}
+	if !contains(enc, `"wave_index":0`) {
+		t.Errorf("encoded %s — index 0 was dropped", enc)
+	}
+	back, err := DecodeParentContext(enc)
+	if err != nil || back == nil || back.WaveIndex != 0 || back.WalkID != "r_a" {
+		t.Errorf("round trip lost the position: %+v (err=%v)", back, err)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -857,9 +857,14 @@ type ParentContext struct {
 	// restarted mid-wave rebuilds the wave the same way, which is what lets the
 	// deferred sink publish stay a deferral rather than a second copy of the
 	// results. Empty for every non-wave run.
-	WalkID    string `json:"walk_id,omitempty"`
-	WaveID    string `json:"wave_id,omitempty"`
-	WaveIndex int    `json:"wave_index,omitempty"`
+	WalkID string `json:"walk_id,omitempty"`
+	WaveID string `json:"wave_id,omitempty"`
+	// No omitempty: index 0 is a REAL position in a wave, and dropping it
+	// makes the first run of every wave indistinguishable from a run with no
+	// index at all. It is only ever written alongside WalkID/WaveID, so this
+	// adds a field to an object that was already being stored rather than
+	// creating new rows.
+	WaveIndex int `json:"wave_index"`
 }
 
 // WaveTask is the Starter wave a spawned run belongs to, carried on ctx from
@@ -893,9 +898,19 @@ func WaveTaskFromContext(ctx context.Context) (WaveTask, bool) {
 // IsZero reports whether every field is empty (no meaningful tracking
 // context). Wire entry points normalise a zero struct to nil so
 // back-compat decode paths stay clean.
+// EVERY field must be listed. A field added to ParentContext and not added
+// here makes a context carrying ONLY that field encode as zero — the column is
+// written NULL and the value is dropped silently, on every run, with nothing
+// to point at.
+//
+// That is not hypothetical: the wave correlation (WalkID/WaveID/WaveIndex)
+// was added without being listed, so every run a Starter spawned stored a NULL
+// parent_context and the join the design was built on never existed. It looked
+// correct everywhere except in the database.
 func (p *ParentContext) IsZero() bool {
 	return p == nil || (p.RootAgentRunID == "" && p.FunctionKey == "" && p.TierAtRun == "" &&
-		p.BoardScope == "" && p.BoardChunkID == "" && p.BoardDocumentID == "")
+		p.BoardScope == "" && p.BoardChunkID == "" && p.BoardDocumentID == "" &&
+		p.WalkID == "" && p.WaveID == "" && p.WaveIndex == 0)
 }
 
 // Clone returns a deep copy (nil-safe) so a parent's ParentContext can

--- a/internal/tools/builtin/teamdef.go
+++ b/internal/tools/builtin/teamdef.go
@@ -892,6 +892,19 @@ func (t *TeamDef) execRun(ctx context.Context, in teamDefInput) (tools.Result, e
 	}
 
 	task := &teamrun.Task{Input: in.Input}
+	// ONE HANDLE FOR THE WHOLE WALK. teamrun mints a walk id only when the task
+	// does not carry one, so the walk's own run id becomes the correlation key
+	// stamped on every run it spawns.
+	//
+	// Without this there were two ids and no way to get from one to the other:
+	// a caller held the run_id that mode=detach returned, while the spawned
+	// runs carried an internal `wlk_…` nobody had ever seen. Watching a walk
+	// meant knowing an id the API never handed out. Now `run_id` is the answer
+	// to "which walk is this" everywhere — the response, the run row, the
+	// parent_context of every agent the walk starts, and the stream filter.
+	if runID != "" {
+		task.WalkID = runID
+	}
 
 	// Assemble walk options. When neither feature is used, opts is empty and Walk
 	// runs with no options → the ephemeral Phase-1 behaviour is byte-identical.

--- a/internal/tools/builtin/teamdef_walkrun_test.go
+++ b/internal/tools/builtin/teamdef_walkrun_test.go
@@ -232,9 +232,15 @@ func TestTeamDefTool_Run_WalkIDIsTheRunID(t *testing.T) {
 	rec := &walkRunRecorder{}
 	tool.WalkRun = rec.open
 
+	// WaveContext is called from EVERY dispatch goroutine, so the recorder has
+	// to be guarded — a fan-out fixture that collects unguarded is a data race
+	// the -race build catches and a plain run does not.
+	var mu sync.Mutex
 	var seenWalks []string
 	tool.WaveContext = func(c context.Context, walkID, waveID string, index int) context.Context {
+		mu.Lock()
 		seenWalks = append(seenWalks, walkID)
+		mu.Unlock()
 		return c
 	}
 
@@ -246,6 +252,8 @@ func TestTeamDefTool_Run_WalkIDIsTheRunID(t *testing.T) {
 	if runID == "" {
 		t.Fatal("no run_id on the response")
 	}
+	mu.Lock()
+	defer mu.Unlock()
 	if len(seenWalks) == 0 {
 		t.Fatal("no wave was dispatched — nothing stamped a walk id")
 	}
@@ -265,15 +273,20 @@ func TestTeamDefTool_Run_WalkIDFallsBackWhenThereIsNoRun(t *testing.T) {
 	defer done()
 	tool.WalkRun = nil
 
+	var mu sync.Mutex
 	var seen []string
 	tool.WaveContext = func(c context.Context, walkID, _ string, _ int) context.Context {
+		mu.Lock()
 		seen = append(seen, walkID)
+		mu.Unlock()
 		return c
 	}
 	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"run","name":"triage","input":"x"}`))
 	if res.IsError {
 		t.Fatalf("run: %s", res.Text)
 	}
+	mu.Lock()
+	defer mu.Unlock()
 	if len(seen) == 0 || seen[0] == "" {
 		t.Fatalf("spawned runs went unstamped with no run tracking: %v", seen)
 	}

--- a/internal/tools/builtin/teamdef_walkrun_test.go
+++ b/internal/tools/builtin/teamdef_walkrun_test.go
@@ -215,3 +215,66 @@ func waitFor(t *testing.T, cond func() bool) {
 	}
 	t.Fatal("condition not met within 3s")
 }
+
+// TestTeamDefTool_Run_WalkIDIsTheRunID is what makes a live view of a running
+// workflow possible at all.
+//
+// A walk stamps its id on the parent_context of every run it spawns, and a
+// caller holds the run_id that op=run returned. Until these were the same
+// value, watching a walk meant knowing an id the API never handed out: the
+// caller had a run_id, the spawned runs carried an internal `wlk_…`, and
+// nothing connected them. Now one handle answers "which walk is this"
+// everywhere — the response, the run row, every spawned run, and the stream
+// filter.
+func TestTeamDefTool_Run_WalkIDIsTheRunID(t *testing.T) {
+	tool, ctx, _, _, done := breakFixture(t)
+	defer done()
+	rec := &walkRunRecorder{}
+	tool.WalkRun = rec.open
+
+	var seenWalks []string
+	tool.WaveContext = func(c context.Context, walkID, waveID string, index int) context.Context {
+		seenWalks = append(seenWalks, walkID)
+		return c
+	}
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"run","name":"triage","input":"x"}`))
+	if res.IsError {
+		t.Fatalf("run: %s", res.Text)
+	}
+	runID, _ := decodeResult(t, res.Text)["run_id"].(string)
+	if runID == "" {
+		t.Fatal("no run_id on the response")
+	}
+	if len(seenWalks) == 0 {
+		t.Fatal("no wave was dispatched — nothing stamped a walk id")
+	}
+	for i, got := range seenWalks {
+		if got != runID {
+			t.Errorf("spawn %d carried walk_id %q, but the caller was given run_id %q — "+
+				"a caller cannot filter the stream by an id it was never told", i, got, runID)
+		}
+	}
+}
+
+// TestTeamDefTool_Run_WalkIDFallsBackWhenThereIsNoRun: with no run tracking
+// wired the walk still needs an id for its own correlation, so teamrun mints
+// one. The absence of a run must not leave spawned runs unstamped.
+func TestTeamDefTool_Run_WalkIDFallsBackWhenThereIsNoRun(t *testing.T) {
+	tool, ctx, _, _, done := breakFixture(t)
+	defer done()
+	tool.WalkRun = nil
+
+	var seen []string
+	tool.WaveContext = func(c context.Context, walkID, _ string, _ int) context.Context {
+		seen = append(seen, walkID)
+		return c
+	}
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"run","name":"triage","input":"x"}`))
+	if res.IsError {
+		t.Fatalf("run: %s", res.Text)
+	}
+	if len(seen) == 0 || seen[0] == "" {
+		t.Fatalf("spawned runs went unstamped with no run tracking: %v", seen)
+	}
+}


### PR DESCRIPTION
## The bug P10 found

P10 asked for a `walk_id` filter on the run-state stream, "cheap because the correlation is already stamped". **It was not stamped. It had never reached the database.**

`ParentContext.IsZero()` did not list `WalkID`, `WaveID` or `WaveIndex`. `EncodeParentContext` writes NULL when `IsZero` says so, so a context carrying **only** wave correlation encoded as zero — and every run a Starter spawned stored a `NULL` parent_context. Silently, on every run, with nothing to point at.

It looked correct in the code, in the ctx, and at the stamping site. I only found it by running a walk and querying the rows:

```
before:  r_7cd4…|team:triage|NULL
         r_bbd4…|a_15d2…   |NULL      ← the wave correlation, gone
after:   r_4325…|team:triage|-
         r_d378…|a_…       |walk_id=r_4325…  wave_index=0
         r_4fd7…|a_…       |walk_id=r_4325…  wave_index=1
         r_f6eb…|a_…       |walk_id=r_4325…  wave_index=2
```

The guard is now **derived from the struct**: a field added to `ParentContext` and forgotten in `IsZero` reds `TestParentContext_IsZeroCoversEveryField` instead of dropping data.

`WaveIndex` also loses its `omitempty`. Index 0 is a real position, and dropping it made the **first** run of every wave indistinguishable from a run with no index — exactly the run a canvas draws first. It's only ever written beside `WalkID`/`WaveID`, so this adds a field to an object already being stored.

## One handle for the walk

`teamrun` mints a walk id only when the task has none, so `op=run` now seeds it with the walk's **own run id**.

Until this there were two ids and no way between them: the caller held the `run_id` that `mode:"detach"` returned, the spawned runs carried an internal `wlk_…` nobody had ever seen, and "watch this walk" required an id the API never handed out. Now `run_id` is the answer everywhere — the response, the run row, every spawned run's `parent_context`, and the stream filter.

## The filter

```sh
curl -XPOST …/v1/_teamdef -d '{"op":"run","name":"triage","mode":"detach"}'
# → {"run_id":"r_4325…","status":"running"}

curl -N "…/v1/users/{user_id}/agents/stream?walk_id=r_4325…"
```

Same filter on the `stream_user_run_states` MCP tool. A run with **no** parent context is **excluded** rather than passed through — a walk view that also showed unrelated runs would not be a walk view. `stream_open` echoes `filter_walk_id`, so a mistyped id shows as a wrong echo rather than as a workflow that quietly produced nothing:

```
event: stream_open
data: {"filter_agent":"rev","filter_status":null,"filter_walk_id":"r_abc",…}
```

## Tested

`go build ./...`, `go vet ./...`, `gofmt -l` clean, **`go test ./...` green (111 packages)**.

**Fail-before, five claims, each red against its own break:**

| break | test that reds |
|---|---|
| `IsZero` forgets the wave fields again | `TestParentContext_IsZeroCoversEveryField` |
| `wave_index` regains `omitempty` | `TestParentContext_WaveIndexZeroSurvives` |
| the walk id is not the run id | `TestTeamDefTool_Run_WalkIDIsTheRunID` |
| an unstamped run leaks into a filtered stream | `TestStreamFilter_WalkIDMatchesOnParentContext` |
| the query param is dropped | `TestParseStreamFilter_WalkID` |

Verified live end to end, including that `wave_index=0` now survives.

Docs: `docs/CONFIGURATION.md` gains "Watching a team walk live".

## Note

This closes L7, and with it the RFC CY implementation plan — P1–P10 plus the L4 line. The two things the RFC records as deliberately open are unchanged: **no resume-after-restart** for a parked walk, and breakpoint arming is **single-replica** (`404 no_live_walk` elsewhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD