### PR TITLE
feat(memory): reach from a fact through to the turn it came from (RFC CV P1)

### DIFF
--- a/adapters/ts/src/types.ts
+++ b/adapters/ts/src/types.ts
@@ -1795,12 +1795,26 @@ export type HistoryToolInput = {
     | "pin"
     | "archive"
     | "recap"
-    | "resume";
+    | "resume"
+    // `related` predates this union's last update and was missing from it; `window`
+    // is new. The wire passthrough carries any `op` verbatim, so the union is for
+    // type-completeness rather than enforcement — which is exactly why it drifts.
+    | "related"
+    | "window";
   /** Whose chats: self = this caller's agent; user = this end-user's; tenant =
    *  this tenant's; global = all tenants (admin only). Default self. */
   scope?: "self" | "user" | "tenant" | "global";
-  /** get/rename/annotate/pin/archive/recap/resume: the chat (session) id. */
+  /** get/rename/annotate/pin/archive/recap/resume/window: the chat (session) id.
+   *  For `window`, the session a recalled fact reported as its source. */
   session_id?: string;
+  /** window: the fact's source span — the verbatim text it was distilled from,
+   *  which recall returns as `source`. It anchors the window to the turn the fact
+   *  came from, rather than the start of the chat. */
+  quote?: string;
+  /** window: how many turns either side of the match to return (default 2, max
+   *  10). A distilled fact loses what its turn's neighbours carry — a bare date, a
+   *  pronoun — which is what these recover. */
+  context?: number;
   /** list/search: filter by derived chat status (running/completed/failed/cancelled). */
   status?: string;
   /** list/search: RFC3339 lower bound on last activity. */

--- a/internal/tools/builtin/history.go
+++ b/internal/tools/builtin/history.go
@@ -85,6 +85,9 @@ func (h *History) Description() string {
 		"recap (refresh the chat's stored one-or-two-sentence summary — idempotent, safe on a live/parked chat), " +
 		"resume (return a handle for continuing the chat in a new run), " +
 		"related (find chats similar in meaning to a given chat (session_id) or a free-text query — needs an embedder). " +
+		"window (the conversation AROUND the turn a stored fact came from: pass the fact's session_id and its " +
+		"source span as quote, and get that turn plus a few neighbours instead of the whole chat — use it when a " +
+		"recalled fact is too summarised to answer the question and you need the original wording). " +
 		"scope selects whose chats: self = this agent's, user = this end-user's, tenant = this tenant's, " +
 		"global = all tenants (admin only). The owner is resolved server-side from the run identity, never the wire; " +
 		"cross-scope reads fold to an opaque not-found. Per-chat token/cost/run-count stats are included. " +
@@ -98,9 +101,9 @@ func (h *History) Description() string {
 const historyInputSchema = `{
 	"type": "object",
 	"properties": {
-		"op":              {"type": "string", "enum": ["list","get","search","rename","annotate","pin","archive","recap","resume","related"]},
+		"op":              {"type": "string", "enum": ["list","get","search","rename","annotate","pin","archive","recap","resume","related","window"]},
 		"scope":           {"type": "string", "enum": ["self","user","tenant","global"], "description": "Whose chats: self = this agent's; user = this end-user's; tenant = this tenant's; global = all tenants (admin only). Default self. The owner id is resolved server-side from the run identity, never the wire."},
-		"session_id":      {"type": "string", "description": "get/rename/annotate/pin/archive/recap/resume: the chat (session) id to target. related: find chats similar to THIS chat (its title+summary is the source; it is excluded from results)."},
+		"session_id":      {"type": "string", "description": "get/rename/annotate/pin/archive/recap/resume/window: the chat (session) id to target — for window, the session recall reported on the fact. related: find chats similar to THIS chat (its title+summary is the source; it is excluded from results)."},
 		"status":          {"type": "string", "description": "list/search: filter by derived chat status (running/completed/failed/cancelled)."},
 		"from":            {"type": "string", "description": "list/search: RFC3339 lower bound on last activity."},
 		"to":              {"type": "string", "description": "list/search: RFC3339 upper bound on last activity."},
@@ -116,6 +119,8 @@ const historyInputSchema = `{
 		"title":           {"type": "string", "description": "rename: the new title."},
 		"description":     {"type": "string", "description": "annotate: the new description."},
 		"tags":            {"type": "array", "items": {"type": "string"}, "description": "annotate: the new tag set (replaces the existing set)."},
+		"quote":           {"type": "string", "description": "window: the fact's source span — the verbatim text it was distilled from, which recall returns as its source field. It is what anchors the fact to a turn, so the window is the conversation AROUND the thing the fact was derived from rather than the start of the chat."},
+		"context":         {"type": "integer", "description": "window: how many turns either side of the match to return (default 2, max 10). A distilled fact loses the specifics its own turn's neighbours carry — a bare date, a pronoun — which is what these recover."},
 		"pinned":          {"type": "boolean", "description": "pin: true pins (default), false unpins."},
 		"archived":        {"type": "boolean", "description": "archive: true archives (default), false unarchives."}
 	},
@@ -137,6 +142,8 @@ type historyInput struct {
 	PinnedOnly      bool   `json:"pinned_only"`
 	IncludeArchived bool   `json:"include_archived"`
 	IncludeInternal bool   `json:"include_internal"`
+	Quote           string `json:"quote"`
+	Context         *int   `json:"context"`
 	Limit           int    `json:"limit"`
 	Offset          int    `json:"offset"`
 	Format          string `json:"format"`
@@ -187,8 +194,10 @@ func (h *History) Execute(ctx context.Context, raw json.RawMessage) (tools.Resul
 		return h.resume(ctx, scope, in)
 	case "related":
 		return h.related(ctx, scope, in)
+	case "window":
+		return h.window(ctx, scope, in)
 	default:
-		return errResult(fmt.Sprintf("unknown op %q (want one of: list, get, search, rename, annotate, pin, archive, recap, resume, related)", in.Op)), nil
+		return errResult(fmt.Sprintf("unknown op %q (want one of: list, get, search, rename, annotate, pin, archive, recap, resume, related, window)", in.Op)), nil
 	}
 }
 
@@ -898,12 +907,40 @@ type conversationBlock struct {
 // looking for durable facts wants all of them — the summary would be a lossy
 // paraphrase of content still sitting right there.
 func renderConversationMarkdown(events []store.Event) string {
-	var b, asst strings.Builder
+	var b strings.Builder
+	for _, t := range conversationTurns(events) {
+		fmt.Fprintf(&b, "### %s\n\n%s\n\n", t.Speaker, t.Text)
+	}
+	return b.String()
+}
+
+// conversationTurn is one speaker's turn, as the conversation rendering sees it.
+type conversationTurn struct {
+	Speaker string `json:"speaker"`
+	Text    string `json:"text"`
+	// Seq is the transcript sequence the turn STARTS at — enough to order turns
+	// and to say where in the chat a match sits, without pretending to a
+	// per-turn identity the event log does not carry.
+	Seq int64 `json:"seq"`
+}
+
+// conversationTurns segments a transcript into speaker turns.
+//
+// SHARED WITH THE RENDERER ON PURPOSE, not duplicated. A distilled fact's source
+// span was quoted out of the conversation rendering, so a window that segmented
+// turns even slightly differently would fail to find spans that are really there —
+// and the failure would look like "no source recorded" rather than like a bug.
+// One segmentation, two consumers.
+func conversationTurns(events []store.Event) []conversationTurn {
+	var out []conversationTurn
+	var asst strings.Builder
+	asstSeq := int64(0)
 	flushAssistant := func() {
 		if text := strings.TrimSpace(asst.String()); text != "" {
-			fmt.Fprintf(&b, "### assistant\n\n%s\n\n", text)
+			out = append(out, conversationTurn{Speaker: "assistant", Text: text, Seq: asstSeq})
 		}
 		asst.Reset()
+		asstSeq = 0
 	}
 	for _, ev := range events {
 		switch ev.Type {
@@ -912,13 +949,16 @@ func renderConversationMarkdown(events []store.Event) string {
 			// operator steer (which the runner persists in this same shape).
 			flushAssistant()
 			if text := userTurnText(ev.Payload); text != "" {
-				fmt.Fprintf(&b, "### user\n\n%s\n\n", text)
+				out = append(out, conversationTurn{Speaker: "user", Text: text, Seq: ev.Seq})
 			}
 		case "text":
 			// Assistant text is persisted one row PER STREAMED DELTA, so these
 			// accumulate into a single turn instead of becoming a section each.
 			var pe providers.Event
 			if err := json.Unmarshal(ev.Payload, &pe); err == nil {
+				if asst.Len() == 0 {
+					asstSeq = ev.Seq
+				}
 				asst.WriteString(pe.Text)
 			}
 		case "done":
@@ -933,7 +973,7 @@ func renderConversationMarkdown(events []store.Event) string {
 		}
 	}
 	flushAssistant()
-	return b.String()
+	return out
 }
 
 // userTurnText pulls the human's own words out of a persisted `user_input`

--- a/internal/tools/builtin/history_window.go
+++ b/internal/tools/builtin/history_window.go
@@ -1,0 +1,155 @@
+package builtin
+
+import (
+	"context"
+	"strings"
+	"unicode"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// history_window.go — RFC CV P1: reach through from a fact to the turn it came from.
+//
+// A distilled fact is a sentence. The question it was distilled from often is not:
+// "we moved the release to the 14th because Maria was out" becomes "the release moved",
+// and the date and the reason are gone. Measured on the paired corpus, the answerer
+// declines ~two thirds of questions because the fact it retrieved does not carry the
+// specific the question asks for — while the turn it came from does, and is still in
+// the database.
+//
+// Every memory system that scores on long-conversation QA keeps that reachable:
+// Graphiti's facts point at their source episode, MemGPT's recall memory IS the
+// transcript. loomcycle writes the pointer already (`recall` returns the span and the
+// session it came from); what was missing is a way to FOLLOW it that does not mean
+// reading the whole chat back. On the benchmark corpus a conversation is 419 turns —
+// a reach-through that returns all of them is not a reach-through.
+//
+// SO IT IS A WINDOW, ANCHORED ON THE SPAN. The fact carries the exact text it was
+// derived from, so the turn containing that text is the turn to return, plus a few
+// neighbours for the context a single turn usually lacks ("the 14th" means nothing
+// without the message before it).
+//
+// WHY NOT event_seq, which is what the plan named. The sidecar reserves the column and
+// NOTHING WRITES IT — verified against the store: session_id is populated, run_id is
+// populated, event_seq is only ever carried forward from a previous revision, so it is
+// null on every fact. The span is what actually exists, and anchoring on it needs no
+// migration and works on every fact already stored.
+
+// windowDefaultContext is how many turns either side of the match come back. Two is
+// enough for a pronoun or a bare date to resolve and small enough that a handful of
+// reach-throughs still fit a context window.
+const windowDefaultContext = 2
+
+// windowMaxContext bounds what a caller can ask for. A window wide enough to be the
+// whole chat defeats the point of not returning the whole chat.
+const windowMaxContext = 10
+
+// window returns the conversation turns around the one a fact was distilled from.
+func (h *History) window(ctx context.Context, scope string, in historyInput) (tools.Result, error) {
+	quote := strings.TrimSpace(in.Quote)
+	if quote == "" {
+		return errResult("history: window requires quote — the fact's source span, which is what " +
+			"anchors it to a turn (recall returns it as `source`)"), nil
+	}
+	sess, err := h.loadSessionInScope(ctx, scope, "window", in.SessionID)
+	if err != nil {
+		// An ARCHIVED OR ERASED SOURCE IS NOT A FAULT. Retention snapshots the span onto
+		// the fact before it removes the session, so the caller still holds the evidence;
+		// what it has lost is the surrounding context. Saying which of the two happened
+		// is the difference between "look elsewhere" and "this is broken".
+		return errResult("history: window: " + err.Error() + " — the fact's span survives on " +
+			"the fact itself; only the surrounding turns are gone"), nil
+	}
+	events, err := h.Store.GetTranscript(ctx, sess.ID)
+	if err != nil {
+		return errResult("history: window: transcript: " + err.Error()), nil
+	}
+	turns := conversationTurns(events)
+
+	idx := matchTurn(turns, quote)
+	if idx < 0 {
+		// REPORTED, NOT GUESSED. Returning the first turns of the chat when the span
+		// cannot be located would look like a successful reach-through and quietly
+		// answer from the wrong place.
+		return okJSON(map[string]any{
+			"scope": scope, "session_id": sess.ID, "turns": []any{}, "matched": false,
+			"total_turns": len(turns),
+			"note": "the span was not found in this conversation — it may have been reworded " +
+				"before it was stored, or the turn it came from has been redacted",
+		})
+	}
+
+	n := windowDefaultContext
+	if in.Context != nil {
+		n = *in.Context
+		if n < 0 {
+			n = 0
+		}
+		if n > windowMaxContext {
+			n = windowMaxContext
+		}
+	}
+	lo, hi := idx-n, idx+n
+	if lo < 0 {
+		lo = 0
+	}
+	if hi >= len(turns) {
+		hi = len(turns) - 1
+	}
+	out := turns[lo : hi+1]
+	var md strings.Builder
+	for _, t := range out {
+		md.WriteString("### " + t.Speaker + "\n\n" + t.Text + "\n\n")
+	}
+	return okJSON(map[string]any{
+		"scope": scope, "session_id": sess.ID,
+		"matched": true, "matched_turn": idx, "total_turns": len(turns),
+		"first_turn": lo, "turns": out, "markdown": md.String(),
+	})
+}
+
+// matchTurn finds the turn a span came from, or -1.
+//
+// Exact containment first, because a span is copied verbatim at write time and should
+// match exactly. The fallback is containment after whitespace and case folding, which
+// covers the ways a span picks up cosmetic differences on its way through a model and
+// two stores — a collapsed newline, a normalised quote mark. Nothing looser: a fuzzy
+// match that lands on the wrong turn is worse than no match, because the caller cannot
+// tell it happened.
+func matchTurn(turns []conversationTurn, quote string) int {
+	for i, t := range turns {
+		if strings.Contains(t.Text, quote) {
+			return i
+		}
+	}
+	nq := foldForMatch(quote)
+	if nq == "" {
+		return -1
+	}
+	for i, t := range turns {
+		if strings.Contains(foldForMatch(t.Text), nq) {
+			return i
+		}
+	}
+	return -1
+}
+
+// foldForMatch collapses a string to lower case with runs of whitespace reduced to one
+// space, so a span that differs only cosmetically still finds its turn.
+func foldForMatch(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	space := false
+	for _, r := range strings.ToLower(s) {
+		if unicode.IsSpace(r) {
+			space = true
+			continue
+		}
+		if space && b.Len() > 0 {
+			b.WriteByte(' ')
+		}
+		space = false
+		b.WriteRune(r)
+	}
+	return b.String()
+}

--- a/internal/tools/builtin/history_window_test.go
+++ b/internal/tools/builtin/history_window_test.go
@@ -1,0 +1,213 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// The reach-through (RFC CV P1): a distilled fact is a sentence, and the turn it came
+// from usually carries the specific the sentence dropped. These pin that following the
+// pointer returns the RIGHT turn with its neighbours, and that every way it can fail
+// says so rather than answering from the wrong place.
+
+// seedConversation writes a chat of alternating turns and returns its session id.
+func seedConversation(t *testing.T, s store.Store, turns ...string) string {
+	t.Helper()
+	bg := context.Background()
+	id := seedChat(t, s, "t1", "agentA", "alice")
+	run, err := s.CreateRun(bg, id, store.RunIdentity{AgentID: "a_run", UserID: "alice", TenantID: "t1"})
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	for i, text := range turns {
+		tj, _ := json.Marshal(text)
+		if i%2 == 0 {
+			// A user turn is a []PromptSegment, which is what userTurnText parses.
+			seg := fmt.Sprintf(`[{"role":"user","content":[{"type":"text","text":%s}]}]`, string(tj))
+			_ = s.AppendEvent(bg, run.ID, "user_input", []byte(seg))
+			continue
+		}
+		_ = s.AppendEvent(bg, run.ID, "text", []byte(fmt.Sprintf(`{"text":%s}`, string(tj))))
+		// `done` is what closes an assistant turn — without it the deltas accumulate
+		// into one turn and the window would return a different shape than the
+		// conversation rendering the span was quoted from.
+		_ = s.AppendEvent(bg, run.ID, "done", []byte(`{}`))
+	}
+	if err := s.FinishRun(bg, run.ID, store.RunCompleted, "end_turn", store.Usage{}, ""); err != nil {
+		t.Fatalf("FinishRun: %v", err)
+	}
+	return id
+}
+
+func windowResult(t *testing.T, h *History, sessionID, quote string, contextN int) map[string]any {
+	t.Helper()
+	req := fmt.Sprintf(`{"op":"window","scope":"self","session_id":%q,"quote":%q,"context":%d}`,
+		sessionID, quote, contextN)
+	res, _ := h.Execute(histCtx([]string{"self"}, "agentA", "alice", "t1"), json.RawMessage(req))
+	if res.IsError {
+		t.Fatalf("window: %s", res.Text)
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(res.Text), &out); err != nil {
+		t.Fatalf("decode: %v (%s)", err, res.Text)
+	}
+	return out
+}
+
+// TestHistoryWindow_ReturnsTheTurnAFactCameFromAndItsNeighbours is the reach-through.
+//
+// The fact would have been distilled to "the release moved" — the date and the reason
+// live in the turn and the turn beside it, which is the whole point.
+func TestHistoryWindow_ReturnsTheTurnAFactCameFromAndItsNeighbours(t *testing.T) {
+	h, s := historyFixture(t)
+	id := seedConversation(t, s,
+		"morning — anything on the calendar?",
+		"standup at ten, then the release review.",
+		"we moved the release to the 14th because Maria is out.",
+		"noted, I will tell the team.",
+		"thanks.",
+	)
+
+	got := windowResult(t, h, id, "we moved the release to the 14th because Maria is out.", 1)
+	if got["matched"] != true {
+		t.Fatalf("the span was not located: %v", got)
+	}
+	if n, _ := got["matched_turn"].(float64); int(n) != 2 {
+		t.Errorf("matched turn %v, want 2", got["matched_turn"])
+	}
+	md, _ := got["markdown"].(string)
+	// The turn itself...
+	if !strings.Contains(md, "the 14th") {
+		t.Errorf("the window does not contain the fact's own turn: %q", md)
+	}
+	// ...and its neighbours, which carry what a distilled sentence drops.
+	if !strings.Contains(md, "release review") {
+		t.Errorf("the preceding turn is missing, so a bare date has nothing to resolve against: %q", md)
+	}
+	if !strings.Contains(md, "tell the team") {
+		t.Errorf("the following turn is missing: %q", md)
+	}
+	// And NOT the whole chat: a reach-through that returns 419 turns is not one.
+	if strings.Contains(md, "morning") {
+		t.Errorf("the window reached past its context bound: %q", md)
+	}
+}
+
+// TestHistoryWindow_ASpanItCannotLocateIsReportedNotGuessed. Returning the start of
+// the chat would look like a successful reach-through and answer from the wrong place —
+// the failure mode that makes a retrieval surface untrustworthy rather than merely
+// incomplete.
+func TestHistoryWindow_ASpanItCannotLocateIsReportedNotGuessed(t *testing.T) {
+	h, s := historyFixture(t)
+	id := seedConversation(t, s, "hello", "hi there", "what is for lunch?")
+
+	got := windowResult(t, h, id, "a sentence nobody in this chat ever said", 2)
+	if got["matched"] != false {
+		t.Fatalf("an unlocatable span reported a match: %v", got)
+	}
+	if turns, _ := got["turns"].([]any); len(turns) != 0 {
+		t.Errorf("turns returned for an unmatched span: %v", turns)
+	}
+	if note, _ := got["note"].(string); note == "" {
+		t.Error("an unmatched span must say why, or it is indistinguishable from an empty chat")
+	}
+}
+
+// TestHistoryWindow_MatchesASpanThatDiffersOnlyCosmetically. A span crosses a model
+// and two stores on its way to the sidecar and can pick up a collapsed newline or a
+// changed case. Refusing those would report "no source" for facts whose source is
+// right there.
+func TestHistoryWindow_MatchesASpanThatDiffersOnlyCosmetically(t *testing.T) {
+	h, s := historyFixture(t)
+	id := seedConversation(t, s, "we ship on\n   Fridays, always", "understood")
+
+	got := windowResult(t, h, id, "We ship on Fridays, always", 0)
+	if got["matched"] != true {
+		t.Fatalf("a span differing only in whitespace and case was not matched: %v", got)
+	}
+}
+
+// TestHistoryWindow_RefusesWithoutAQuote. The span is the anchor; without it there is
+// no window to compute, and defaulting to the start of the chat would be the guess the
+// design refuses to make.
+func TestHistoryWindow_RefusesWithoutAQuote(t *testing.T) {
+	h, s := historyFixture(t)
+	id := seedConversation(t, s, "hello", "hi")
+	req := fmt.Sprintf(`{"op":"window","scope":"self","session_id":%q}`, id)
+	res, _ := h.Execute(histCtx([]string{"self"}, "agentA", "alice", "t1"), json.RawMessage(req))
+	if !res.IsError {
+		t.Fatal("window without a quote should refuse")
+	}
+}
+
+// TestHistoryWindow_AnArchivedSourceSaysTheSpanSurvives. Retention snapshots the span
+// onto the fact BEFORE removing the session, so the evidence outlives the transcript.
+// What is lost is the surrounding context, and the message has to say which — "not
+// found" alone reads as data loss.
+func TestHistoryWindow_AnArchivedSourceSaysTheSpanSurvives(t *testing.T) {
+	h, _ := historyFixture(t)
+	req := `{"op":"window","scope":"self","session_id":"s_gone","quote":"anything"}`
+	res, _ := h.Execute(histCtx([]string{"self"}, "agentA", "alice", "t1"), json.RawMessage(req))
+	if !res.IsError {
+		t.Fatal("a window into a session that is not there should refuse")
+	}
+	if !strings.Contains(res.Text, "span survives") {
+		t.Errorf("the refusal must distinguish an archived source from data loss: %q", res.Text)
+	}
+}
+
+// TestHistoryWindow_IsScopeGatedLikeEveryOtherTranscriptRead. The op reads a
+// conversation, so it inherits History's own gate rather than introducing a second
+// one — a fact id is a coordinate, never an authorisation.
+func TestHistoryWindow_IsScopeGatedLikeEveryOtherTranscriptRead(t *testing.T) {
+	h, s := historyFixture(t)
+	id := seedConversation(t, s, "a secret", "noted")
+
+	// A DIFFERENT agent, granted only its own chats.
+	req := fmt.Sprintf(`{"op":"window","scope":"self","session_id":%q,"quote":"a secret"}`, id)
+	res, _ := h.Execute(histCtx([]string{"self"}, "agentB", "alice", "t1"), json.RawMessage(req))
+	if !res.IsError {
+		t.Fatalf("another agent's chat was readable through window: %s", res.Text)
+	}
+}
+
+// TestHistoryWindow_SegmentsTurnsExACTLYAsTheConversationRenderingDoes.
+//
+// This is the invariant the whole reach-through rests on, and it is quiet enough to
+// break unnoticed. A fact's source span was quoted out of the CONVERSATION rendering —
+// that is the text the extractor reads — so if the window segmented turns even slightly
+// differently, spans that are really there would stop being found. The failure would
+// surface as "no source recorded", which reads as missing data rather than as a bug.
+//
+// So both consumers go through one segmentation, and this asserts they agree.
+func TestHistoryWindow_SegmentsTurnsExactlyAsTheConversationRenderingDoes(t *testing.T) {
+	h, s := historyFixture(t)
+	id := seedConversation(t, s,
+		"first question",
+		"first answer",
+		"second question",
+		"second answer",
+	)
+
+	// The conversation rendering, which is what a fact's span is quoted from.
+	req := fmt.Sprintf(`{"op":"get","scope":"self","session_id":%q,"format":"conversation"}`, id)
+	res, _ := h.Execute(histCtx([]string{"self"}, "agentA", "alice", "t1"), json.RawMessage(req))
+	if res.IsError {
+		t.Fatalf("get: %s", res.Text)
+	}
+	var got map[string]any
+	_ = json.Unmarshal([]byte(res.Text), &got)
+	rendered, _ := got["markdown"].(string)
+
+	// A window wide enough to cover the whole chat must reproduce it verbatim.
+	win := windowResult(t, h, id, "first question", windowMaxContext)
+	if md, _ := win["markdown"].(string); md != rendered {
+		t.Errorf("the window and the conversation rendering disagree about turn boundaries.\n"+
+			"window:\n%q\nrendering:\n%q", md, rendered)
+	}
+}

--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -1786,6 +1786,15 @@ func (m *Memory) execRecall(ctx context.Context, scope store.MemoryScope, scopeI
 			if sp.RunID != "" {
 				mem["source_run_id"] = sp.RunID
 			}
+			// THE SESSION IS THE FOLLOWABLE HALF. run_id identifies the pass that
+			// ingested the fact; the CHAT is where the words were said, and it is what
+			// `History op=window` takes — with this span — to hand back the turn the
+			// fact was distilled from and the turns around it. That is the reach-through
+			// the answerer needs when the distilled sentence dropped the specific the
+			// question asks for.
+			if sp.SessionID != "" {
+				mem["source_session_id"] = sp.SessionID
+			}
 		}
 		// Omitted when the backend could not classify the row — see RecallFact.Kind.
 		// An absent kind means "unknown", which is why this is not defaulted.

--- a/internal/tools/builtin/memory_fact_identity_test.go
+++ b/internal/tools/builtin/memory_fact_identity_test.go
@@ -93,3 +93,42 @@ func TestChunkLabelsFor_ToleratesAChunkWithNoSidecar(t *testing.T) {
 		}
 	}
 }
+
+// TestSourceSpansFor_CarriesTheSessionSoThePointerIsFollowable (RFC CV P1).
+//
+// The span answers "what was said"; the SESSION answers "where is the rest of it",
+// and only the second is followable. `History op=window` takes the pair and hands back
+// the turn the fact was distilled from with its neighbours — which is what the
+// answerer needs when the distilled sentence dropped the specific being asked for.
+//
+// This was 0% populated when the span lookup was first written, so it deliberately
+// projected the span alone; the entity writer fills it now, from the consolidator and
+// from the drained pending row. The plan's reach-through finally has data behind it,
+// and a regression here would silently take it away again — the recall still answers,
+// just with nowhere to go.
+func TestSourceSpansFor_CarriesTheSessionSoThePointerIsFollowable(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	doc := newEntityDoc(t, d, ctx)
+
+	if _, r := docExec(t, d, ctx, `{"op":"upsert_chunk","scope":"user","document_id":"`+doc+`",
+		"natural_key":"memory/fact/release-moved","title":"The release moved",
+		"body":"The release moved.","type":"fact",
+		"source_quote":"we moved the release to the 14th because Maria is out",
+		"source_session_id":"s_the_chat"}`); r.IsError {
+		t.Fatalf("upsert_chunk: %s", r.Text)
+	}
+
+	got := SourceSpansFor(ctx, d.SqlMem, "tnt", store.MemoryScopeUser, "u1",
+		[]string{"memory/fact/release-moved"})
+	src, ok := got["memory/fact/release-moved"]
+	if !ok {
+		t.Fatal("the fact reported no source at all")
+	}
+	if !strings.Contains(src.Span, "the 14th") {
+		t.Errorf("span = %q, want the verbatim wording the fact was derived from", src.Span)
+	}
+	if src.SessionID != "s_the_chat" {
+		t.Errorf("session = %q, want s_the_chat — without it the span is quotable but not "+
+			"followable, and the surrounding turns are unreachable", src.SessionID)
+	}
+}

--- a/internal/tools/builtin/memory_source_span.go
+++ b/internal/tools/builtin/memory_source_span.go
@@ -59,6 +59,15 @@ const maxSourceSpanLookup = 64
 type FactSource struct {
 	Span  string
 	RunID string
+	// SessionID is the CHAT the fact was distilled from, and it is what makes the
+	// pointer followable: History window takes it plus the span and returns the turn
+	// the fact came from with its neighbours.
+	//
+	// It was 0% populated when this file was written, which is why the first slice
+	// projected the span alone. It is populated now — the entity writer takes
+	// source_session_id from the consolidator and from the drained pending row — so
+	// the reach-through the plan asked for has data behind it at last.
+	SessionID string
 }
 
 func SourceSpansFor(ctx context.Context, sm *sqlmem.Manager, tenantID string,
@@ -91,7 +100,7 @@ func SourceSpansFor(ctx context.Context, sm *sqlmem.Manager, tenantID string,
 	// followable even when the span was never derived, which is the common shape
 	// before a verification pass runs. The old query required a non-empty span
 	// and so hid those rows entirely.
-	stmt := `SELECT natural_key, coalesce(source_quote, ''), coalesce(run_id, '') FROM chunk_memory_meta ` +
+	stmt := `SELECT natural_key, coalesce(source_quote, ''), coalesce(run_id, ''), coalesce(session_id, '') FROM chunk_memory_meta ` +
 		`WHERE natural_key IN (` +
 		strings.TrimSuffix(strings.Repeat("?,", len(keys)), ",") + `)`
 	res, err := sm.Query(ctx, key, sm.Rebind(stmt), keys)
@@ -100,16 +109,16 @@ func SourceSpansFor(ctx context.Context, sm *sqlmem.Manager, tenantID string,
 	}
 	out := make(map[string]FactSource, len(res.Rows))
 	for _, row := range res.Rows {
-		if len(row) < 3 {
+		if len(row) < 4 {
 			continue
 		}
-		nk, span, runID := asStr(row[0]), asStr(row[1]), asStr(row[2])
+		nk, span, runID, sessionID := asStr(row[0]), asStr(row[1]), asStr(row[2]), asStr(row[3])
 		// A row with neither a span nor a pointer says nothing, so it is dropped;
-		// either one alone is still useful and is kept.
-		if nk == "" || (span == "" && runID == "") {
+		// any one of them alone is still useful and is kept.
+		if nk == "" || (span == "" && runID == "" && sessionID == "") {
 			continue
 		}
-		out[nk] = FactSource{Span: span, RunID: runID}
+		out[nk] = FactSource{Span: span, RunID: runID, SessionID: sessionID}
 	}
 	return out
 }


### PR DESCRIPTION
## Why

A distilled fact is a sentence, and the turn it came from usually carries the specific the sentence dropped. "we moved the release to the 14th because Maria is out" becomes "the release moved" — date and reason gone. The answerer declines ~two thirds of questions for exactly this reason, while the turn that would answer them is still in the database.

Every system that scores on long-conversation QA keeps that reachable — Graphiti's facts point at their source episode, MemGPT's recall memory *is* the transcript. The RFC calls it "not one feature among several — it is the consensus architecture."

loomcycle already writes the pointer and already returns the span. What was missing is a way to **follow** it that isn't "read the whole chat back": on the benchmark corpus a conversation is 419 turns, and a reach-through returning all of them is not a reach-through.

## What

- **`History op=window`** returns the turn plus a few neighbours, **anchored on the span**. The fact carries the exact text it came from, so that's the turn; neighbours supply what a single turn lacks (a bare date means nothing without the message before it). Default 2 either side, capped at 10.
- **`recall` reports `source_session_id`** beside the span it already returned. The span says *what was said*; the session is what makes it *followable*.

### Two things worth review

**Not `event_seq`, which is what the plan named.** The sidecar reserves the column and **nothing writes it** — verified against the store, it's only ever carried forward from a previous revision, so it's null on every fact. `session_id` *is* populated (my P2 work wired the entity writer to take it from the consolidator and the drained pending row) and the span is stored — so anchoring on those needs no migration and works on every fact already written. This is the second time the RFC's stated pointer hasn't matched the store; the file already carried a warning about the first.

**The turn segmentation is shared with the conversation rendering, not duplicated** — and that's load-bearing, not tidiness. A span was quoted *out of* that rendering, so a window that segmented turns even slightly differently would fail to find spans that are really there, and the failure would read as "no source recorded" rather than as a bug. One segmentation, two consumers, asserted by a test.

Every failure says which it is: an unlocatable span reports `matched:false` rather than returning the head of the chat, and an archived session says the span survives on the fact — because it does; the retention sweeper snapshots it before removing the source (OQ7, already shipped in `snapshot_span.go`).

## What was tested

`go test ./...` clean (101 packages); TS adapter builds.

Seven behaviours: the right turn with neighbours and *not* the whole chat; an unlocatable span reported not guessed; a cosmetically-differing span still matched; no quote refuses; an archived source distinguished from data loss; scope-gated like every other transcript read; segmentation identical to the conversation rendering.

**Fail-before on both halves.** Without the session projection the fact is quotable but not followable. Without span anchoring the window returns the head of the chat **while reporting `matched:true`** — the successful-looking-but-wrong reach-through the design exists to prevent.

**Live:** a six-turn chat; the window anchored on the middle turn returned turn 2 of 6 with one neighbour either side; an absent span was reported rather than guessed.

## What this does NOT claim

P1's gate is a **paired accuracy delta**, and this PR does not claim one. It builds the mechanism; the measurement is the next step, and it needs a fresh baseline first — the RFC is explicit that the 0.157 starting point moved to ~0.22–0.27 on runtime fixes alone. The delta could come back flat, which is what the gate is for.

Also not here: making the benchmark answerer *use* the reach-through, which is harness work, and evaluating recall-augmented distillation as default-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8