### PR TITLE
feat(memory): a run knows its chat — and P1's reach-through measures +10.7pp (p=0.0005)

### DIFF
--- a/bench/cmd/locomo/answer.go
+++ b/bench/cmd/locomo/answer.go
@@ -429,6 +429,48 @@ func ingestLayer(ctx context.Context, mc *MCPClient, conv Conversation, stdout i
 	return len(sessions), nil
 }
 
+// ingestChats writes one conversation into the store AS CHATS — one loomcycle
+// session per LoCoMo session, one turn per message — instead of onto the
+// consolidation queue.
+//
+// WHY BOTH PATHS EXIST. The queue path is the deterministic default and it is
+// the right ingest for measuring retrieval: turns go in verbatim, nothing
+// interprets them. But it produces facts with NOTHING TO FOLLOW BACK TO — there
+// is no conversation in the store behind them — so it cannot measure the
+// reach-through, where a recalled fact hands back the turn it was distilled
+// from. This path makes the corpus a real transcript so that relation exists.
+//
+// EVERY TURN IS POSTED AS A USER MESSAGE, including the second speaker's. A turn
+// already carries "[date] Speaker: text" in its body, so the speaker is not lost
+// — only the role label is — and the alternative (getting a model to utter the
+// other side verbatim) would measure that model's transcription fidelity, which
+// is the reason this harness refuses to prompt an agent to store turns.
+//
+// The scribe agent should do as little as possible: its replies become assistant
+// turns in the transcript, and a chatty one dilutes what the extractor reads.
+func ingestChats(ctx context.Context, mc *MCPClient, conv Conversation, scribe, userID string, stdout io.Writer) (int, error) {
+	sessions := conv.LayerMessages()
+	turns := 0
+	for i, msgs := range sessions {
+		if err := ctx.Err(); err != nil {
+			return i, err
+		}
+		sessionID := ""
+		for j, m := range msgs {
+			rr, err := mc.SpawnTurn(ctx, scribe, userID, sessionID, m.Content)
+			if err != nil {
+				return i, fmt.Errorf("chat ingest (session %d/%d, turn %d/%d): %w",
+					i+1, len(sessions), j+1, len(msgs), err)
+			}
+			sessionID = rr.SessionID
+			turns++
+		}
+	}
+	fmt.Fprintf(stdout, "  wrote %d chat(s) holding %d turn(s) — the corpus is a transcript, so a "+
+		"distilled fact can be followed back to the turn it came from\n", len(sessions), turns)
+	return len(sessions), nil
+}
+
 // consolidateDrain runs consolidation passes until the queue is empty.
 //
 // The pass reports what it did in prose, including "queued items N, acked M",
@@ -722,7 +764,13 @@ func doAnswerAxis(ctx context.Context, convs []Conversation, defects *Defects, o
 				}
 				rep.SeededTurns += n
 			}
-			ingested, err := ingestLayer(ctx, mc, conv, stdout)
+			var ingested int
+			var err error
+			if opts.ingestAsChats {
+				ingested, err = ingestChats(ctx, mc, conv, opts.scribe, userID, stdout)
+			} else {
+				ingested, err = ingestLayer(ctx, mc, conv, stdout)
+			}
 			if err != nil {
 				return err
 			}

--- a/bench/cmd/locomo/main.go
+++ b/bench/cmd/locomo/main.go
@@ -81,6 +81,12 @@ type options struct {
 	// and 8). With the corpus fixed, the only variable left is the projection
 	// under test, and a repeat run measures ANSWERER variance alone.
 	answerOnly bool
+	// ingestAsChats writes the corpus as real chats instead of queue items, so a
+	// distilled fact has a conversation to point back at. Off by default: the
+	// queue path is the deterministic ingest every other axis measures against.
+	ingestAsChats bool
+	// scribe is the agent whose runs carry the turns when ingestAsChats is set.
+	scribe     string
 	runTimeout time.Duration
 }
 
@@ -88,31 +94,33 @@ func run(args []string, stdout, stderr io.Writer) error {
 	fs := flag.NewFlagSet("locomo", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	var (
-		mode        = fs.String("mode", "convert", "convert | ingest | search | all | purge | answer")
-		data        = fs.String("data", "", "path to the dataset json (required; not vendored — see README)")
-		dataset     = fs.String("dataset", "locomo", "which corpus the -data file is: locomo | longmemeval")
-		instance    = fs.String("loomcycle", "http://127.0.0.1:8787", "base URL of the running loomcycle")
-		scope       = fs.String("scope", "agent", "memory scope to write/read (agent|user|tenant)")
-		topK        = fs.Int("top-k", 10, "retrieval depth metrics are computed at")
-		categories  = fs.String("categories", "1,2,3,4", "LoCoMo categories to score (5 is adversarial and has no ground truth)")
-		convLimit   = fs.Int("conversations", 0, "only the first N conversations (0 = all)")
-		concurrency = fs.Int("concurrency", 4, "parallel requests during ingest")
-		out         = fs.String("out", "", "output directory (default: bench/results/locomo-<timestamp>)")
-		dryRun      = fs.Bool("dry-run", false, "parse and report, write nothing")
-		noEmbed     = fs.Bool("no-embed", false, "skip embedding on ingest (use /v1/_memory/backfill_embeddings after)")
-		unit        = fs.String("unit", "turn", "row granularity: turn|session (RFC CM-1)")
-		dated       = fs.Bool("dated", false, "stamp observed_at from each row's session date (RFC CL)")
-		onlyDated   = fs.Bool("only-date-questions", false, "grade ONLY questions naming an absolute date/window (RFC CL slice)")
-		injectWhen  = fs.Bool("inject-when", false, "resolve the question date phrase and hand the answerer a when window")
-		allowShared = fs.Bool("allow-shared-tenant", false, "permit writing into the default/legacy tenant (NOT isolated)")
-		timeout     = fs.Duration("timeout", 60*time.Second, "per-request timeout")
-		answerer    = fs.String("answerer", "locomo/answerer", "agent that answers from memory (answer axis)")
-		judge       = fs.String("judge", "locomo/judge", "agent that grades an answer against gold (answer axis)")
-		sampleQ     = fs.Int("sample-questions", 0, "answer axis: grade only N questions, stratified by category (0 = all)")
-		consPasses  = fs.Int("consolidate-passes", 12, "answer axis: max consolidation passes per conversation (0 = skip consolidation entirely)")
-		answerOnly  = fs.Bool("answer-only", false, "answer axis: grade the EXISTING store — skip flush/purge/seed/ingest/consolidate. For measuring a retrieval-side change with the corpus held constant; the empty-store guard still applies")
-		seedTurns   = fs.Bool("seed-turns", false, "answer axis: also write one embedded row per TURN into the partition the answerer reads, so it answers from conversation content rather than only from distilled facts (this is what the published systems do)")
-		runTimeout  = fs.Duration("run-timeout", 10*time.Minute, "answer axis: per-run timeout (agent runs are slower than REST calls)")
+		mode          = fs.String("mode", "convert", "convert | ingest | search | all | purge | answer")
+		data          = fs.String("data", "", "path to the dataset json (required; not vendored — see README)")
+		dataset       = fs.String("dataset", "locomo", "which corpus the -data file is: locomo | longmemeval")
+		instance      = fs.String("loomcycle", "http://127.0.0.1:8787", "base URL of the running loomcycle")
+		scope         = fs.String("scope", "agent", "memory scope to write/read (agent|user|tenant)")
+		topK          = fs.Int("top-k", 10, "retrieval depth metrics are computed at")
+		categories    = fs.String("categories", "1,2,3,4", "LoCoMo categories to score (5 is adversarial and has no ground truth)")
+		convLimit     = fs.Int("conversations", 0, "only the first N conversations (0 = all)")
+		concurrency   = fs.Int("concurrency", 4, "parallel requests during ingest")
+		out           = fs.String("out", "", "output directory (default: bench/results/locomo-<timestamp>)")
+		dryRun        = fs.Bool("dry-run", false, "parse and report, write nothing")
+		noEmbed       = fs.Bool("no-embed", false, "skip embedding on ingest (use /v1/_memory/backfill_embeddings after)")
+		unit          = fs.String("unit", "turn", "row granularity: turn|session (RFC CM-1)")
+		dated         = fs.Bool("dated", false, "stamp observed_at from each row's session date (RFC CL)")
+		onlyDated     = fs.Bool("only-date-questions", false, "grade ONLY questions naming an absolute date/window (RFC CL slice)")
+		injectWhen    = fs.Bool("inject-when", false, "resolve the question date phrase and hand the answerer a when window")
+		allowShared   = fs.Bool("allow-shared-tenant", false, "permit writing into the default/legacy tenant (NOT isolated)")
+		timeout       = fs.Duration("timeout", 60*time.Second, "per-request timeout")
+		answerer      = fs.String("answerer", "locomo/answerer", "agent that answers from memory (answer axis)")
+		judge         = fs.String("judge", "locomo/judge", "agent that grades an answer against gold (answer axis)")
+		sampleQ       = fs.Int("sample-questions", 0, "answer axis: grade only N questions, stratified by category (0 = all)")
+		consPasses    = fs.Int("consolidate-passes", 12, "answer axis: max consolidation passes per conversation (0 = skip consolidation entirely)")
+		ingestAsChats = fs.Bool("ingest-as-chats", false, "answer axis: write the corpus as real chats (one per session, one turn per message) instead of onto the consolidation queue, so a distilled fact can be followed back to the turn it came from. Needs -scribe")
+		scribe        = fs.String("scribe", "locomo/scribe", "answer axis: the agent whose runs carry the turns under -ingest-as-chats; it should reply as briefly as possible, since its replies become assistant turns in the transcript")
+		answerOnly    = fs.Bool("answer-only", false, "answer axis: grade the EXISTING store — skip flush/purge/seed/ingest/consolidate. For measuring a retrieval-side change with the corpus held constant; the empty-store guard still applies")
+		seedTurns     = fs.Bool("seed-turns", false, "answer axis: also write one embedded row per TURN into the partition the answerer reads, so it answers from conversation content rather than only from distilled facts (this is what the published systems do)")
+		runTimeout    = fs.Duration("run-timeout", 10*time.Minute, "answer axis: per-run timeout (agent runs are slower than REST calls)")
 	)
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -132,7 +140,9 @@ func run(args []string, stdout, stderr io.Writer) error {
 		allowSharedTenant: *allowShared, timeout: *timeout,
 		answerer: *answerer, judge: *judge, sampleQuestions: *sampleQ,
 		consolidatePasses: *consPasses, runTimeout: *runTimeout, seedTurns: *seedTurns,
-		answerOnly: *answerOnly,
+		answerOnly:    *answerOnly,
+		ingestAsChats: *ingestAsChats,
+		scribe:        *scribe,
 	}
 	if opts.concurrency < 1 {
 		opts.concurrency = 1

--- a/bench/cmd/locomo/mcp.go
+++ b/bench/cmd/locomo/mcp.go
@@ -180,6 +180,7 @@ func (c *MCPClient) CallTool(ctx context.Context, name string, args map[string]a
 // RunResult is the subset of a spawn_run ack this harness reads.
 type RunResult struct {
 	RunID      string `json:"run_id"`
+	SessionID  string `json:"session_id"`
 	Status     string `json:"status"`
 	StopReason string `json:"stop_reason"`
 	FinalText  string `json:"final_text"`
@@ -218,6 +219,51 @@ func (c *MCPClient) SpawnRun(ctx context.Context, agent, userID, prompt string) 
 	}
 	if rr.Status != "completed" {
 		return rr, fmt.Errorf("run %s: status=%s %s", rr.RunID, rr.Status, truncate(rr.Error, 200))
+	}
+	return rr, nil
+}
+
+// SpawnTurn posts ONE conversation turn. With sessionID empty it opens a new
+// chat and returns the id; with it set the turn continues that chat.
+//
+// This is what makes the corpus a CONVERSATION rather than a pile of queue
+// items. It matters for the fact->source relation: a fact distilled from a chat
+// carries the chat it came from, and a fact distilled from a queued Memory-add
+// carries nothing to follow — the consolidator passes an empty source id on the
+// batched path by design ("batching costs the per-item provenance"), and an
+// off-run MCP caller has no session to record in the first place. Measured on
+// this benchmark before the change: 8 of 215 facts carried a session, and all 8
+// came from the harness's own answerer and judge rather than from the corpus.
+func (c *MCPClient) SpawnTurn(ctx context.Context, agent, userID, sessionID, text string) (RunResult, error) {
+	args := map[string]any{
+		"segments": []any{map[string]any{
+			"role":    "user",
+			"content": []any{map[string]any{"type": "trusted-text", "text": text}},
+		}},
+	}
+	if sessionID != "" {
+		// A continuation takes the session and ignores the agent — the session's
+		// stored agent is authoritative.
+		args["session_id"] = sessionID
+	} else {
+		args["agent"] = agent
+	}
+	if userID != "" {
+		args["user_id"] = userID
+	}
+	txt, err := c.CallTool(ctx, "spawn_run", args)
+	if err != nil {
+		return RunResult{}, err
+	}
+	var rr RunResult
+	if err := json.Unmarshal([]byte(txt), &rr); err != nil {
+		return RunResult{}, fmt.Errorf("spawn_run: decode ack: %w (got %s)", err, truncate(txt, 200))
+	}
+	if rr.Status != "completed" {
+		return rr, fmt.Errorf("run %s: status=%s %s", rr.RunID, rr.Status, truncate(rr.Error, 200))
+	}
+	if rr.SessionID == "" {
+		return rr, fmt.Errorf("spawn_run returned no session id, so the next turn cannot continue this chat")
 	}
 	return rr, nil
 }

--- a/internal/api/http/resume.go
+++ b/internal/api/http/resume.go
@@ -245,7 +245,8 @@ func (s *Server) resumePausedRun(ctx context.Context, run store.Run) error {
 		UserID:        run.UserID,
 		TenantID:      run.TenantID,
 		AgentID:       run.AgentID,
-		RootRunID:     run.ID, // RFC AH Phase 2b: resumed run roots its own tree
+		RootRunID:     run.ID,        // RFC AH Phase 2b: resumed run roots its own tree
+		SessionID:     run.SessionID, // restored from the run row, like every other durable field here
 		UserTier:      run.UserTier,
 		ParentContext: run.ParentContext,
 		// UserBearer / UserCredentials are intentionally absent — secrets are

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2677,7 +2677,8 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 		UserID:                effectiveUserID,
 		TenantID:              effectiveTenantID, // RFC L: authoritative tenant (memory tenancy key)
 		AgentID:               agentID,
-		RootRunID:             runID, // RFC AH Phase 2b: top-level run roots its own spawn tree
+		RootRunID:             runID,     // RFC AH Phase 2b: top-level run roots its own spawn tree
+		SessionID:             sessionID, // the chat a run-time write records itself against
 		UserTier:              in.UserTier,
 		UserBearer:            in.UserBearer,      // v0.8.x: per-run MCP bearer
 		UserCredentials:       in.UserCredentials, // v1.x RFC F: per-tool named credentials
@@ -4321,7 +4322,8 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		UserID:                req.UserID,
 		TenantID:              req.TenantID, // RFC L: authoritative tenant (memory tenancy key)
 		AgentID:               agentID,
-		RootRunID:             runID, // RFC AH Phase 2b: top-level run roots its own spawn tree
+		RootRunID:             runID,     // RFC AH Phase 2b: top-level run roots its own spawn tree
+		SessionID:             sessionID, // the chat a run-time write records itself against
 		UserTier:              req.UserTier,
 		UserBearer:            req.UserBearer,      // v0.8.x: per-run MCP bearer
 		UserCredentials:       req.UserCredentials, // v1.x RFC F: per-tool named credentials
@@ -4931,6 +4933,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		TenantID:              sess.TenantID, // RFC L: tenant from the session (authoritative at creation)
 		AgentID:               agentID,
 		RootRunID:             run.ID, // RFC AH Phase 2b: continuation roots its own spawn tree
+		SessionID:             id,     // the chat a run-time write records itself against
 		UserTier:              body.UserTier,
 		UserBearer:            body.UserBearer,      // v0.8.x: per-run MCP bearer
 		UserCredentials:       body.UserCredentials, // v1.x RFC F: per-tool named credentials
@@ -6307,6 +6310,7 @@ func (s *Server) prepareSubRunValues(ctx context.Context, name, systemExtra, pro
 		TenantID:        parentIdentity.TenantID, // RFC L: sub-agents inherit the parent's authoritative tenant (same isolation boundary)
 		AgentID:         subAgentID,
 		RootRunID:       parentIdentity.RootRunID,             // RFC AH Phase 2b: INHERIT the tree's root id (do NOT overwrite)
+		SessionID:       subSessionID,                         // its OWN chat, not the parent's — a sub-agent gets a session of its own
 		UserTier:        parentIdentity.UserTier,              // v0.8.2: sub-agents inherit parent's user_tier
 		AgentDefID:      defID,                                // v0.8.7: surface pinned def_id via Context.self
 		UserBearer:      parentIdentity.UserBearer,            // v0.8.x: bearer inherited identically (same end-user)

--- a/internal/memory/backends/inprocess/inprocess.go
+++ b/internal/memory/backends/inprocess/inprocess.go
@@ -456,11 +456,16 @@ func (b *Backend) Add(ctx context.Context, scope store.MemoryScope, scopeID stri
 			// consolidated fact's provenance is resolved FROM, so a forgeable one
 			// would let an agent dictate how its own writes are labelled.
 			Origin: store.PendingOriginAgentExplicit,
-			// No session-id ctx helper today (RunIdentityValue carries no
-			// session id), so SourceSessionID stays empty; SourceRunID is enough
-			// to correlate the enqueue back to the run that produced it.
-			SourceRunID: tools.RunID(ctx),
-			CreatedAt:   time.Now().UTC(),
+			// WHERE THE WORDS WERE SAID, so the fact distilled from this item can
+			// be followed back to the turn it came from. It stayed empty while
+			// RunIdentityValue carried no session id, and the cost was not
+			// cosmetic: every fact from a queued item was unreachable from its
+			// source, measured at 8 of 215 on a benchmark store — and those 8 came
+			// from the harness's own agents rather than the corpus. Empty for an
+			// off-run caller, which is honest: there is no conversation behind it.
+			SourceSessionID: tools.RunIdentity(ctx).SessionID,
+			SourceRunID:     tools.RunID(ctx),
+			CreatedAt:       time.Now().UTC(),
 		}
 		if err := b.store.MemoryPendingEnqueue(ctx, row); err != nil {
 			return memory.AddResult{}, fmt.Errorf("add: enqueue pending: %w", err)

--- a/internal/memory/backends/inprocess/inprocess_test.go
+++ b/internal/memory/backends/inprocess/inprocess_test.go
@@ -15,6 +15,7 @@ import (
 	lcotel "github.com/denn-gubsky/loomcycle/internal/otel"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
 
 	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -1149,4 +1150,45 @@ func mustJSON(t *testing.T, v string) json.RawMessage {
 		t.Fatalf("marshal: %v", err)
 	}
 	return raw
+}
+
+// TestAdd_EnqueuesWithTheSessionSoTheFactCanBeFollowedBack (RFC CV P1).
+//
+// A fact distilled from a queued item inherits the item's provenance, and the
+// SESSION is the half that makes it followable: recall reports it, and the
+// History window op takes it with the fact's span to return the turn the fact
+// came from.
+//
+// It was empty for as long as RunIdentityValue carried no session id — the
+// enqueue said so in a comment — and the consequence was invisible because the
+// fact still stored fine. Measured on a benchmark store before the fix: 8 of 215
+// facts carried a session, and all 8 came from the harness's own agents rather
+// than from the corpus under test.
+func TestAdd_EnqueuesWithTheSessionSoTheFactCanBeFollowedBack(t *testing.T) {
+	s, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	b := inprocess.New(s, nil)
+
+	ctx := tools.WithRunIdentity(context.Background(), tools.RunIdentityValue{
+		UserID: "u1", TenantID: "t1", SessionID: "s_the_chat",
+	})
+	if _, err := b.Add(ctx, store.MemoryScopeUser, "u1",
+		[]memory.LayerMessage{{Role: "user", Content: "we moved the release to the 14th"}},
+		memory.AddOptions{Infer: true}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	rows, err := s.MemoryPendingDrain(context.Background(), "t1", store.MemoryScopeUser, "u1", 10)
+	if err != nil {
+		t.Fatalf("pending list: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("enqueued %d rows, want 1", len(rows))
+	}
+	if got := rows[0].SourceSessionID; got != "s_the_chat" {
+		t.Errorf("SourceSessionID = %q, want s_the_chat — without it every fact distilled "+
+			"from this item is unreachable from the conversation it came from", got)
+	}
 }

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -416,6 +416,21 @@ type RunIdentityValue struct {
 	// completes. Empty for a run started outside the volume-aware run-start
 	// path (the ephemeral VolumeDef create op then refuses — no active run).
 	RootRunID string
+	// SessionID is the CHAT this run belongs to. It exists so a write made
+	// during a run can record WHERE it came from: `Memory op=add` enqueues a
+	// consolidation item, the fact distilled from it inherits the pointer, and a
+	// recalled fact can then hand back the turn it was derived from.
+	//
+	// It used to be absent, and the absence was load-bearing in the wrong
+	// direction — the enqueue path said so in a comment ("No session-id ctx
+	// helper today … so SourceSessionID stays empty") and every fact distilled
+	// from a queued item was therefore unreachable from its source. Measured on a
+	// benchmark store: 8 of 215 facts carried a session, and all 8 came from the
+	// harness's own agents rather than from the corpus.
+	//
+	// A sub-agent gets its OWN session, so this is NOT inherited like TenantID —
+	// runSubAgent stamps the child's.
+	SessionID string
 	// TenantID is the RFC L authoritative data-isolation boundary. On
 	// authenticated routes it is set from the resolved auth.Principal's
 	// TenantID (which overrides the wire tenant_id); for legacy /


### PR DESCRIPTION
## The result first

One frozen 67-fact store, 150 questions, `-answer-only` so the corpus never moves:

| arm | accuracy | NOT_FOUND |
|---|---|---|
| A — Memory only, 6 iterations | 0.2953 | 0.557 |
| A' — Memory only, 8 iterations (**control**) | 0.3067 | 0.557 |
| B — Memory + `History op=window` | **0.4161** | **0.161** |

**B vs A', iteration budget held equal: +10.7pp, discordant 22/4, McNemar exact two-sided p = 0.0005.**
A' vs A is +1.0pp at p = 0.5078 — the extra budget explains none of it.

Abstention collapsing 0.557 → 0.161 is the predicted mechanism: the answerer stops saying NOT_FOUND because it can reach past the distilled sentence to the turn that still holds the detail. Confirmed in use — **129 `window` calls across 88 of the 150 runs**, carrying real spans and session ids.

## Why two changes were needed to get there

The reach-through (#1213) shipped with nothing to follow, for two independent reasons.

**1. A queued fact carried no session, because the enqueue had none to record** — and it said so in a comment: *"No session-id ctx helper today (RunIdentityValue carries no session id), so SourceSessionID stays empty."* Measured: 8 of 215 facts carried a session, and all 8 came from the harness's own answerer and judge rather than the corpus.

`RunIdentityValue` gains `SessionID`, stamped at every run-start site — fresh run, connector run, continuation, resume (restored from the run row), and the sub-agent, which gets its **own** session rather than inheriting the parent's. The inprocess enqueue sets `SourceSessionID` from it. An off-run caller still records nothing, which is honest: there is no conversation behind it.

**2. The benchmark's corpus never became a conversation.** The harness hands turns to `Memory op=add` over MCP, so there was no transcript to point at regardless. `-ingest-as-chats` writes it as real chats — one per LoCoMo session, continued by `session_id` — **off by default**, since the queue path is the deterministic ingest every other axis measures against.

Every turn posts as a user message, the second speaker included: a turn already carries `[date] Speaker: text` in its body, so nothing is lost but the role label, and the alternative (getting a model to utter the other side verbatim) would measure that model's transcription fidelity — the thing this harness exists to avoid.

Pointer coverage went **3.7% → 87%**, and the sessions are now the corpus's own chats rather than the benchmark's machinery.

## What I checked before believing it

- **The mechanism is actually used** — 129 window calls over 88/150 runs. ⚠️ `events.payload` is `bytea`: `payload::text LIKE '%window%'` matches the hex form and returns 0. I briefly concluded the tool was never called.
- **The one confound I introduced** — arm B raised `max_iterations` 6→8. Control arm A' isolates it: +1.0pp, not significant. The tool and the prompt that drives it are not separable and shouldn't be; the budget is, and it does nothing.
- **Unparsed verdicts excluded from both sides** of every pairing, so an instrument failure is never graded as a memory miss.

## What this does NOT claim

Nothing about the queue-ingested baseline (0.3506, qwen3.6, 120 facts) versus this store (0.2953 on arm A, qwen3.8, 67 facts). Those differ in ingest, extractor **and** fact count — three variables at once. Only the A/A'/B comparison on the single frozen store is interpretable, and that is the only comparison made.

Two rig notes for whoever runs this next: an `internal: true` scribe is invisible to the consolidator (19 chats, 419 turns → 0 facts; the harness's empty-store guard caught it), and chat-ingest tells the extractor *"This conversation took place on <today>"* since the chat is created now — turns keep their own `[date]` prefixes, but that fallback may bias the temporal slice.

`go test ./...` clean (101 packages), plus `TestAdd_EnqueuesWithTheSessionSoTheFactCanBeFollowedBack`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8