### PR TITLE
feat(agentdef): record whether an OPERATOR wrote a definition

### DIFF
--- a/internal/agents/sign_operator_authored_test.go
+++ b/internal/agents/sign_operator_authored_test.go
@@ -1,0 +1,44 @@
+package agents
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestSign_AuthorshipIsNotContent pins the promise the operator_authored
+// migration was written under: adding the flag must not move a single existing
+// agent's content hash.
+//
+// The hash is what a fork verifies across deployments, so a change would make
+// every stored agent report as drifted the moment the column landed — and an
+// operator would have no way to tell a real edit from the migration.
+//
+// The literal was computed on origin/main BEFORE this change and re-computed
+// after it — identical both times. It is the hash of this exact content. If a change to AgentContent
+// moves it, that is a real fork of EVERY existing row and the diff must say so.
+// The number is the assertion, not decoration.
+func TestSign_AuthorshipIsNotContent(t *testing.T) {
+	const want = "sha256:0d5ea67cfbfa7a386e9b8eedcd3739a7cc779b8f62f5be9121787a55d076519d"
+	got := Sign(AgentContent{Name: "reviewer", SystemPrompt: "You review.", Tier: "middle"})
+	if got != want {
+		t.Errorf("the agent content hash MOVED:\n  want %s\n  got  %s\n"+
+			"If this was deliberate, every existing agent_defs row now reports as drifted — "+
+			"say so in the change and update this literal. If it was not, something joined "+
+			"the hash input that should not have.", want, got)
+	}
+}
+
+// TestAgentContent_CarriesNoAuthorshipField: the hash input is a WHITELIST, and
+// authorship must never join it. Derived from the struct so a future field
+// named for authorship reds here rather than silently forking every row.
+func TestAgentContent_CarriesNoAuthorshipField(t *testing.T) {
+	rt := reflect.TypeOf(AgentContent{})
+	for i := 0; i < rt.NumField(); i++ {
+		name := rt.Field(i).Name
+		if strings.Contains(strings.ToLower(name), "author") || strings.Contains(strings.ToLower(name), "operator") {
+			t.Errorf("AgentContent declares %q — authorship is AUTHORITY, not content; "+
+				"hashing it would fork every existing agent row", name)
+		}
+	}
+}

--- a/internal/api/http/resume.go
+++ b/internal/api/http/resume.go
@@ -298,6 +298,7 @@ func (s *Server) resumePausedRun(ctx context.Context, run store.Run) error {
 	// stamped for sub-agent inheritance.
 	loopCtx = tools.WithCompactionPolicy(loopCtx, agentDef.Compaction)
 	loopCtx = tools.WithChannelPolicy(loopCtx, s.channelPolicyForAgent(loopCtx, agentDef))
+	loopCtx = tools.WithOperatorAuthored(loopCtx, agentDef.OperatorAuthored)
 	// Volume confinement re-derived from the agent def (RFC AH attach-gap fix):
 	// a resumed run is top-level (no parent), so its policy is the agent's own.
 	// Without this a volume-bound agent would resume into the legacy jail — a

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2754,6 +2754,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	// top-level runs (the load-bearing isolation property).
 	loopCtx = tools.WithEphemeralVolumes(loopCtx, tools.NewEphemeralVolumeSet())
 	loopCtx = tools.WithChannelPolicy(loopCtx, s.channelPolicyForAgent(loopCtx, agentDef))
+	loopCtx = tools.WithOperatorAuthored(loopCtx, agentDef.OperatorAuthored)
 	loopCtx = tools.WithEventEmitter(loopCtx, emit)
 	adPolicy, evPolicy := s.substratePoliciesForAgent(agentDef, effectiveAgentName)
 	loopCtx = tools.WithAgentDefPolicy(loopCtx, adPolicy)
@@ -4391,6 +4392,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	// sub-agents via ctx; never shared across top-level runs).
 	loopCtx = tools.WithEphemeralVolumes(loopCtx, tools.NewEphemeralVolumeSet())
 	loopCtx = tools.WithChannelPolicy(loopCtx, s.channelPolicyForAgent(loopCtx, agentDef))
+	loopCtx = tools.WithOperatorAuthored(loopCtx, agentDef.OperatorAuthored)
 	loopCtx = tools.WithEventEmitter(loopCtx, emit)
 	adPolicy, evPolicy := s.substratePoliciesForAgent(agentDef, req.Agent)
 	loopCtx = tools.WithAgentDefPolicy(loopCtx, adPolicy)
@@ -4993,6 +4995,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	// sub-agents via ctx; never shared across top-level runs).
 	loopCtx = tools.WithEphemeralVolumes(loopCtx, tools.NewEphemeralVolumeSet())
 	loopCtx = tools.WithChannelPolicy(loopCtx, s.channelPolicyForAgent(loopCtx, agentDef))
+	loopCtx = tools.WithOperatorAuthored(loopCtx, agentDef.OperatorAuthored)
 	loopCtx = tools.WithEventEmitter(loopCtx, emit)
 	adPolicy, evPolicy := s.substratePoliciesForAgent(agentDef, sess.Agent)
 	loopCtx = tools.WithAgentDefPolicy(loopCtx, adPolicy)
@@ -6401,6 +6404,7 @@ func (s *Server) prepareSubRunValues(ctx context.Context, name, systemExtra, pro
 	// state, not agent state. The ALLOWLISTS (publish / subscribe)
 	// come from the child's yaml.
 	subCtx = tools.WithChannelPolicy(subCtx, s.channelPolicyForAgent(subCtx, def))
+	subCtx = tools.WithOperatorAuthored(subCtx, def.OperatorAuthored)
 	// Sub-agent event emitter writes to the SUB's transcript (per
 	// subEmit above). Channel-tool publishes from inside the sub
 	// surface on the sub's SSE stream, not the parent's.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -940,6 +940,20 @@ type UserTier struct {
 
 // AgentDef is one agent the API can address by name.
 type AgentDef struct {
+	// OperatorAuthored reports whether an OPERATOR wrote this definition —
+	// their yaml, or an off-run call under an operator token — rather than an
+	// agent writing it at runtime. Resolved, never authored: `json:"-"` and no
+	// yaml tag, so it is neither persisted nor hashed nor settable from a
+	// definition body. lookup sets it from the source it resolved the agent
+	// from; a static cfg.Agents entry is operator-authored by construction,
+	// because it IS the operator's yaml.
+	//
+	// It gates only the WIDENED prompt-expansion families, never the ones that
+	// already existed — gating those would strip expansion from every
+	// agent-authored def the moment the migration ran, and a guard that breaks
+	// working defs on upgrade is an outage, not a guard.
+	OperatorAuthored bool `json:"-" yaml:"-"`
+
 	Provider string `yaml:"provider"` // optional override of Defaults
 	Model    string `yaml:"model"`    // alias or full model ID
 	// Code is the inline code-js orchestrator source (RFC J). When set

--- a/internal/lookup/agent.go
+++ b/internal/lookup/agent.go
@@ -110,6 +110,8 @@ func Agent(ctx context.Context, s AgentStore, cfg *config.Config, tenantID, name
 	// 2. Static cfg.Agents — the shared operator base.
 	if cfg != nil {
 		if def, ok := cfg.Agents[name]; ok {
+			// The operator's own yaml, by construction.
+			def.OperatorAuthored = true
 			return def, true
 		}
 	}
@@ -159,6 +161,10 @@ func resolveDynamic(ctx context.Context, s AgentStore, tenantID, name string) (c
 	}
 	def := sd.ToConfigDef()
 	NormalizeAgentDef(&def)
+	// From the ROW, not the definition body: authorship is authority and is
+	// deliberately not part of the persisted def (nor of its content hash), so
+	// a def cannot claim it by containing it.
+	def.OperatorAuthored = activeRow.OperatorAuthored
 	return def, true
 }
 

--- a/internal/lookup/agent_roundtrip_test.go
+++ b/internal/lookup/agent_roundtrip_test.go
@@ -30,6 +30,7 @@ func TestSubstrateAgentDef_ConfigRoundTripCoversEveryField(t *testing.T) {
 		"SystemPromptFile": "a load-time path read from disk; a runtime-authored def has no filesystem to read",
 		"DisableContext":   "load-time only — it suppresses the default-add of the Context tool and bakes into Tools before anything resolves",
 		"SkillDefScopes":   "removed-field tombstone (RFC BA); skill authoring is governed by the skills: allowlist, and carrying it would resurrect a dead gate",
+		"OperatorAuthored": "AUTHORITY, not content. It lives on the agent_defs ROW and is stamped from the ctx at the write site; carrying it through the definition body would let a def claim its own authorship — and would put it in the content hash, forking every existing row",
 	}
 
 	var full config.AgentDef

--- a/internal/store/postgres/migrations/0076_agent_defs_operator_authored.down.sql
+++ b/internal/store/postgres/migrations/0076_agent_defs_operator_authored.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE agent_defs DROP COLUMN IF EXISTS operator_authored;

--- a/internal/store/postgres/migrations/0076_agent_defs_operator_authored.up.sql
+++ b/internal/store/postgres/migrations/0076_agent_defs_operator_authored.up.sql
@@ -1,0 +1,19 @@
+-- 0076_agent_defs_operator_authored.up.sql — RFC CY item 8: who wrote this def.
+--
+-- Distinguishes a definition an OPERATOR authored (their yaml, or an off-run
+-- call under an operator token) from one an AGENT authored at runtime. It is
+-- the gate the widened prompt-expansion families sit behind: those families
+-- resolve under the RUNTIME's authority rather than the agent's, so widening
+-- them for a def an agent wrote itself would hand a model an ungated read
+-- primitive it could aim.
+--
+-- AUTHORITY, NOT CONTENT. Deliberately absent from content_sha256 (the same
+-- treatment *_def_scopes and the RFC AX restriction bit get), so every
+-- existing row keeps its hash byte-for-byte and a fork across deployments
+-- still verifies.
+--
+-- Default FALSE, and that is the safe direction: a legacy row reads as NOT
+-- operator-authored, so nothing gains authority by having predated the column.
+-- It also means the guard must only gate what it ADDS — gating an existing
+-- family would strip expansion from every legacy def the moment this runs.
+ALTER TABLE agent_defs ADD COLUMN IF NOT EXISTS operator_authored BOOLEAN NOT NULL DEFAULT FALSE;

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -2026,7 +2026,7 @@ func (s *Store) SnapshotReadAgentDefs(ctx context.Context) ([]store.AgentDefRow,
 	rows, err := s.pool.Query(ctx,
 		`SELECT def_id, name, version, parent_def_id, definition::text, description,
 		        created_at, created_by_agent_id, created_by_run_id,
-		        retired, bootstrapped_from_static, tenant_id
+		        retired, bootstrapped_from_static, tenant_id, operator_authored
 		 FROM agent_defs
 		 ORDER BY tenant_id ASC, name ASC, version ASC`,
 	)
@@ -2048,7 +2048,7 @@ func (s *Store) SnapshotReadAgentDefs(ctx context.Context) ([]store.AgentDefRow,
 			&r.DefID, &r.Name, &r.Version, &parentDefID,
 			&definition, &description,
 			&r.CreatedAt, &createdBy, &createdRun,
-			&r.Retired, &r.BootstrappedFromStatic, &r.TenantID,
+			&r.Retired, &r.BootstrappedFromStatic, &r.TenantID, &r.OperatorAuthored,
 		); err != nil {
 			return nil, fmt.Errorf("scan agent_def: %w", err)
 		}
@@ -2637,14 +2637,15 @@ func (s *Store) SnapshotRestoreAgentDef(ctx context.Context, r store.AgentDefRow
 		`INSERT INTO agent_defs(
 			def_id, name, version, parent_def_id, definition, description,
 			created_at, created_by_agent_id, created_by_run_id,
-			retired, bootstrapped_from_static, content_sha256, tenant_id
-		) VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10, $11, $12, $13)
+			retired, bootstrapped_from_static, content_sha256, tenant_id,
+			operator_authored
+		) VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10, $11, $12, $13, $14)
 		 ON CONFLICT (def_id) DO NOTHING`,
 		r.DefID, r.Name, r.Version, nullIfEmpty(r.ParentDefID),
 		string(r.Definition), nullIfEmpty(r.Description),
 		createdAt, nullIfEmpty(r.CreatedByAgentID), nullIfEmpty(r.CreatedByRunID),
 		r.Retired, r.BootstrappedFromStatic,
-		nullIfEmpty(r.ContentSHA256), r.TenantID,
+		nullIfEmpty(r.ContentSHA256), r.TenantID, r.OperatorAuthored,
 	)
 	if err != nil {
 		return false, fmt.Errorf("snapshot restore agent_def: %w", err)
@@ -5264,14 +5265,16 @@ func (s *Store) AgentDefCreate(ctx context.Context, row store.AgentDefRow) (stor
 		INSERT INTO agent_defs (
 			def_id, name, version, parent_def_id, definition, description,
 			created_at, created_by_agent_id, created_by_run_id,
-			retired, bootstrapped_from_static, content_sha256, tenant_id
-		) VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10, $11, $12, $13)`,
+			retired, bootstrapped_from_static, content_sha256, tenant_id,
+			operator_authored
+		) VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
 		row.DefID, row.Name, row.Version, nullableString(row.ParentDefID),
 		string(row.Definition), nullableString(row.Description),
 		row.CreatedAt,
 		nullableString(row.CreatedByAgentID), nullableString(row.CreatedByRunID),
 		row.Retired, row.BootstrappedFromStatic,
 		nullableString(row.ContentSHA256), row.TenantID,
+		row.OperatorAuthored,
 	); err != nil {
 		return store.AgentDefRow{}, fmt.Errorf("agent_def insert: %w", err)
 	}
@@ -5535,7 +5538,8 @@ const agentDefSelect = `SELECT
 	retired,
 	bootstrapped_from_static,
 	COALESCE(content_sha256, ''),
-	tenant_id
+	tenant_id,
+	operator_authored
 FROM agent_defs`
 
 func (s *Store) scanAgentDef(row pgx.Row) (store.AgentDefRow, error) {
@@ -5553,6 +5557,7 @@ func (s *Store) scanAgentDef(row pgx.Row) (store.AgentDefRow, error) {
 		&out.Retired, &out.BootstrappedFromStatic,
 		&out.ContentSHA256,
 		&out.TenantID,
+		&out.OperatorAuthored,
 	)
 	if err != nil {
 		return store.AgentDefRow{}, err
@@ -5578,6 +5583,7 @@ func (s *Store) scanAgentDefRows(rows pgx.Rows) ([]store.AgentDefRow, error) {
 			&r.Retired, &r.BootstrappedFromStatic,
 			&r.ContentSHA256,
 			&r.TenantID,
+			&r.OperatorAuthored,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/store/sqlite/operator_authored_upgrade_test.go
+++ b/internal/store/sqlite/operator_authored_upgrade_test.go
@@ -1,0 +1,108 @@
+package sqlite
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// TestMigrate_LegacyAgentDefReadsAsNotOperatorAuthored is the upgrade case, and
+// it is the one a fresh-DB test cannot see.
+//
+// A deployment that upgrades has rows written before the column existed. They
+// must read as NOT operator-authored — the safe direction, because the flag is
+// what gates the widened prompt-expansion families: a row that defaulted the
+// other way would hand every pre-existing agent-authored def an authority it
+// was never granted.
+//
+// Builds the pre-column schema on disk, writes a row into it, then reopens so
+// the ALTER runs against real legacy data.
+func TestMigrate_LegacyAgentDefReadsAsNotOperatorAuthored(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy_authorship.db")
+	ctx := context.Background()
+
+	// 1. Stand up the schema as it was BEFORE operator_authored, and put a row
+	//    in it the way a pre-upgrade deployment would have.
+	{
+		s, err := Open(path)
+		if err != nil {
+			t.Fatalf("initial open: %v", err)
+		}
+		for _, stmt := range []string{
+			`DROP TABLE agent_def_active`,
+			`DROP TABLE agent_defs`,
+			`CREATE TABLE agent_defs (
+				def_id                    TEXT    PRIMARY KEY,
+				name                      TEXT    NOT NULL,
+				version                   INTEGER NOT NULL,
+				parent_def_id             TEXT    REFERENCES agent_defs(def_id),
+				definition                TEXT    NOT NULL,
+				description               TEXT,
+				created_at                INTEGER NOT NULL,
+				created_by_agent_id       TEXT,
+				created_by_run_id         TEXT,
+				retired                   INTEGER NOT NULL DEFAULT 0,
+				bootstrapped_from_static  INTEGER NOT NULL DEFAULT 0,
+				content_sha256            TEXT,
+				tenant_id                 TEXT    NOT NULL DEFAULT '',
+				UNIQUE(tenant_id, name, version)
+			)`,
+			`CREATE TABLE agent_def_active (
+				tenant_id             TEXT    NOT NULL DEFAULT '',
+				name                  TEXT    NOT NULL,
+				def_id                TEXT    NOT NULL REFERENCES agent_defs(def_id),
+				promoted_at           INTEGER NOT NULL,
+				promoted_by_agent_id  TEXT,
+				PRIMARY KEY (tenant_id, name)
+			)`,
+			`INSERT INTO agent_defs(def_id, name, version, definition, created_at, tenant_id)
+			 VALUES ('adf_legacy', 'legacy-agent', 1, '{"tier":"middle"}', 1, '')`,
+		} {
+			if _, err := s.db.ExecContext(ctx, stmt); err != nil {
+				t.Fatalf("legacy schema %q: %v", stmt[:40], err)
+			}
+		}
+		if err := s.Close(); err != nil {
+			t.Fatalf("close: %v", err)
+		}
+	}
+
+	// 2. Reopen — the ALTER runs against a table that already holds a row.
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("reopen (the migration): %v", err)
+	}
+	defer s.Close()
+
+	row, err := s.AgentDefGet(ctx, "adf_legacy")
+	if err != nil {
+		t.Fatalf("read the legacy row after migrating: %v", err)
+	}
+	if row.OperatorAuthored {
+		t.Error("a PRE-MIGRATION row reads as operator-authored — nothing may gain authority " +
+			"by having predated the column")
+	}
+	if row.Name != "legacy-agent" {
+		t.Errorf("the migration disturbed the row: name = %q", row.Name)
+	}
+
+	// 3. And a row written AFTER the migration still records authorship, so the
+	//    ALTER did not leave the column write-only.
+	created, err := s.AgentDefCreate(ctx, store.AgentDefRow{
+		DefID: "adf_new", Name: "new-agent", Definition: json.RawMessage(`{"tier":"middle"}`),
+		OperatorAuthored: true,
+	})
+	if err != nil {
+		t.Fatalf("create after migrating: %v", err)
+	}
+	back, err := s.AgentDefGet(ctx, created.DefID)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if !back.OperatorAuthored {
+		t.Error("a row written after the migration lost its authorship — the column is write-only")
+	}
+}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -435,6 +435,7 @@ func (s *Store) migrate(ctx context.Context) error {
 			bootstrapped_from_static  INTEGER NOT NULL DEFAULT 0,
 			content_sha256            TEXT,
 			tenant_id                 TEXT    NOT NULL DEFAULT '',
+			operator_authored         INTEGER NOT NULL DEFAULT 0,
 			UNIQUE(tenant_id, name, version)
 		)`,
 		`CREATE INDEX IF NOT EXISTS agent_defs_by_name   ON agent_defs(name, version DESC)`,
@@ -1105,6 +1106,10 @@ func (s *Store) migrate(ctx context.Context) error {
 		// (tenant_id=''); see the CREATE TABLE notes for the isolation
 		// caveat. DEFAULT '' backfills existing rows to the shared tenant.
 		`ALTER TABLE agent_defs ADD COLUMN tenant_id TEXT NOT NULL DEFAULT ''`,
+		// RFC CY item 8. Default 0 so a legacy row reads as NOT
+		// operator-authored — the safe direction: nothing gains authority by
+		// having predated the column.
+		`ALTER TABLE agent_defs ADD COLUMN operator_authored INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE agent_def_active ADD COLUMN tenant_id TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE dynamic_agents ADD COLUMN tenant_id TEXT NOT NULL DEFAULT ''`,
 		// RFC N — tenant-scope the skill definition plane (mirror of the
@@ -3194,7 +3199,7 @@ func (s *Store) SnapshotReadAgentDefs(ctx context.Context) ([]store.AgentDefRow,
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT def_id, name, version, parent_def_id, definition, description,
 		        created_at, created_by_agent_id, created_by_run_id,
-		        retired, bootstrapped_from_static, tenant_id
+		        retired, bootstrapped_from_static, tenant_id, operator_authored
 		 FROM agent_defs
 		 ORDER BY tenant_id ASC, name ASC, version ASC`,
 	)
@@ -3205,21 +3210,22 @@ func (s *Store) SnapshotReadAgentDefs(ctx context.Context) ([]store.AgentDefRow,
 	var out []store.AgentDefRow
 	for rows.Next() {
 		var (
-			r           store.AgentDefRow
-			createdNs   int64
-			parentDefID sql.NullString
-			description sql.NullString
-			createdBy   sql.NullString
-			createdRun  sql.NullString
-			definition  string
-			retiredInt  int
-			bootstrap   int
+			r            store.AgentDefRow
+			createdNs    int64
+			parentDefID  sql.NullString
+			description  sql.NullString
+			createdBy    sql.NullString
+			createdRun   sql.NullString
+			definition   string
+			retiredInt   int
+			bootstrap    int
+			operatorAuth int
 		)
 		if err := rows.Scan(
 			&r.DefID, &r.Name, &r.Version, &parentDefID,
 			&definition, &description,
 			&createdNs, &createdBy, &createdRun,
-			&retiredInt, &bootstrap, &r.TenantID,
+			&retiredInt, &bootstrap, &r.TenantID, &operatorAuth,
 		); err != nil {
 			return nil, fmt.Errorf("scan agent_def: %w", err)
 		}
@@ -3238,6 +3244,7 @@ func (s *Store) SnapshotReadAgentDefs(ctx context.Context) ([]store.AgentDefRow,
 			r.CreatedByRunID = createdRun.String
 		}
 		r.Retired = retiredInt != 0
+		r.OperatorAuthored = operatorAuth != 0
 		r.BootstrappedFromStatic = bootstrap != 0
 		out = append(out, r)
 	}
@@ -3861,13 +3868,15 @@ func (s *Store) SnapshotRestoreAgentDef(ctx context.Context, r store.AgentDefRow
 		`INSERT OR IGNORE INTO agent_defs(
 			def_id, name, version, parent_def_id, definition, description,
 			created_at, created_by_agent_id, created_by_run_id,
-			retired, bootstrapped_from_static, content_sha256, tenant_id
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			retired, bootstrapped_from_static, content_sha256, tenant_id,
+			operator_authored
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		r.DefID, r.Name, r.Version, nilIfEmpty(r.ParentDefID),
 		string(r.Definition), nilIfEmpty(r.Description),
 		createdNs, nilIfEmpty(r.CreatedByAgentID), nilIfEmpty(r.CreatedByRunID),
 		boolToInt(r.Retired), boolToInt(r.BootstrappedFromStatic),
 		nilIfEmpty(r.ContentSHA256), r.TenantID,
+		boolToInt(r.OperatorAuthored),
 	)
 	if err != nil {
 		return false, fmt.Errorf("snapshot restore agent_def: %w", err)
@@ -6030,14 +6039,16 @@ func (s *Store) AgentDefCreate(ctx context.Context, row store.AgentDefRow) (stor
 		`INSERT INTO agent_defs (
 			def_id, name, version, parent_def_id, definition, description,
 			created_at, created_by_agent_id, created_by_run_id,
-			retired, bootstrapped_from_static, content_sha256, tenant_id
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			retired, bootstrapped_from_static, content_sha256, tenant_id,
+			operator_authored
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		row.DefID, row.Name, row.Version, nilIfEmpty(row.ParentDefID),
 		string(row.Definition), nilIfEmpty(row.Description),
 		row.CreatedAt.UnixNano(),
 		nilIfEmpty(row.CreatedByAgentID), nilIfEmpty(row.CreatedByRunID),
 		boolToInt(row.Retired), boolToInt(row.BootstrappedFromStatic),
 		nilIfEmpty(row.ContentSHA256), row.TenantID,
+		boolToInt(row.OperatorAuthored),
 	); err != nil {
 		return store.AgentDefRow{}, err
 	}
@@ -6310,16 +6321,18 @@ const agentDefSelect = `SELECT
 	retired,
 	bootstrapped_from_static,
 	COALESCE(content_sha256, ''),
-	tenant_id
+	tenant_id,
+	operator_authored
 FROM agent_defs`
 
 func (s *Store) scanAgentDef(row *sql.Row) (store.AgentDefRow, error) {
 	var (
-		out        store.AgentDefRow
-		definition string
-		createdAt  int64
-		retired    int
-		bootstrap  int
+		out              store.AgentDefRow
+		definition       string
+		createdAt        int64
+		retired          int
+		bootstrap        int
+		operatorAuthored int
 	)
 	err := row.Scan(
 		&out.DefID, &out.Name, &out.Version,
@@ -6331,6 +6344,7 @@ func (s *Store) scanAgentDef(row *sql.Row) (store.AgentDefRow, error) {
 		&retired, &bootstrap,
 		&out.ContentSHA256,
 		&out.TenantID,
+		&operatorAuthored,
 	)
 	if err != nil {
 		return store.AgentDefRow{}, err
@@ -6339,6 +6353,7 @@ func (s *Store) scanAgentDef(row *sql.Row) (store.AgentDefRow, error) {
 	out.CreatedAt = time.Unix(0, createdAt)
 	out.Retired = retired != 0
 	out.BootstrappedFromStatic = bootstrap != 0
+	out.OperatorAuthored = operatorAuthored != 0
 	return out, nil
 }
 
@@ -6346,11 +6361,12 @@ func (s *Store) scanAgentDefRows(rows *sql.Rows) ([]store.AgentDefRow, error) {
 	var out []store.AgentDefRow
 	for rows.Next() {
 		var (
-			r          store.AgentDefRow
-			definition string
-			createdAt  int64
-			retired    int
-			bootstrap  int
+			r                store.AgentDefRow
+			definition       string
+			createdAt        int64
+			retired          int
+			bootstrap        int
+			operatorAuthored int
 		)
 		if err := rows.Scan(
 			&r.DefID, &r.Name, &r.Version,
@@ -6362,6 +6378,7 @@ func (s *Store) scanAgentDefRows(rows *sql.Rows) ([]store.AgentDefRow, error) {
 			&retired, &bootstrap,
 			&r.ContentSHA256,
 			&r.TenantID,
+			&operatorAuthored,
 		); err != nil {
 			return nil, err
 		}
@@ -6369,6 +6386,7 @@ func (s *Store) scanAgentDefRows(rows *sql.Rows) ([]store.AgentDefRow, error) {
 		r.CreatedAt = time.Unix(0, createdAt)
 		r.Retired = retired != 0
 		r.BootstrappedFromStatic = bootstrap != 0
+		r.OperatorAuthored = operatorAuthored != 0
 		out = append(out, r)
 	}
 	return out, rows.Err()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -3943,6 +3943,23 @@ type AgentDefRow struct {
 	// content_sha256. Set from the authoritative principal at the write
 	// site; never from the wire.
 	TenantID string `json:"tenant_id,omitempty"`
+	// OperatorAuthored records whether an OPERATOR wrote this definition —
+	// their yaml, or an off-run call under an operator token — rather than an
+	// agent writing it at runtime.
+	//
+	// Stamped from tools.IsSubstrateOperator(ctx), NOT from CreatedByAgentID:
+	// a run supplies its own agent id, so a def that claimed authorship by
+	// naming an operator-looking agent would grant itself the authority this
+	// gates.
+	//
+	// AUTHORITY, NOT CONTENT — absent from content_sha256 (the same treatment
+	// *_def_scopes and the RFC AX restriction bit get), so an existing row
+	// keeps its hash byte-for-byte and a fork still verifies across
+	// deployments.
+	//
+	// A legacy row reads FALSE, which is the safe direction: nothing gains
+	// authority by having predated the column.
+	OperatorAuthored bool `json:"operator_authored,omitempty"`
 }
 
 // AgentDefNameSummary is one entry of AgentDefListNames' output.

--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -295,6 +295,11 @@ func (a *AgentDef) execCreate(ctx context.Context, policy tools.AgentDefPolicyVa
 		CreatedByAgentID: ident.AgentID,
 		ContentSHA256:    contentSHA,
 		TenantID:         tenantID,
+		// Authority comes from the CTX, never from the def or the identity a
+		// run supplies: CreatedByAgentID is whatever the caller says it is, so
+		// deriving authorship from it would let a def grant itself the
+		// authority this gates by naming an operator-looking agent.
+		OperatorAuthored: tools.IsSubstrateOperator(ctx),
 		// CreatedByRunID stays empty here — there's no run_id on
 		// RunIdentityValue today; carried via the run ctx separately.
 	}
@@ -471,6 +476,11 @@ func (a *AgentDef) execFork(ctx context.Context, policy tools.AgentDefPolicyValu
 		CreatedByAgentID: ident.AgentID,
 		ContentSHA256:    signFromMergedDef(in.Name, def),
 		TenantID:         tenantID,
+		// The FORKER's authority, never the parent's. A fork may change the
+		// body, so inheriting the parent's flag would let an agent launder an
+		// operator-authored def into an agent-authored one that still carries
+		// operator authority.
+		OperatorAuthored: tools.IsSubstrateOperator(ctx),
 	}
 	created, err := a.Store.AgentDefCreate(ctx, row)
 	if err != nil {
@@ -921,6 +931,12 @@ func (a *AgentDef) bootstrapStatic(ctx context.Context, name string, static conf
 		CreatedByAgentID:       ident.AgentID,
 		BootstrappedFromStatic: true,
 		ContentSHA256:          signFromMergedDef(name, def),
+		// TRUE regardless of who triggered the bootstrap. The body is the
+		// operator's own cfg.Agents yaml — an agent forking a static name
+		// merely causes the lineage root to be materialised; it did not write
+		// it. (The FORK that follows is stamped from its own caller, so an
+		// agent still cannot inherit this by forking.)
+		OperatorAuthored: true,
 		// RFC N: the bootstrapped lineage root lives in the forking
 		// caller's tenant (static cfg.Agents is the shared base; the
 		// fork that triggers bootstrap is per-tenant). "" = shared.

--- a/internal/tools/builtin/agentdef_operator_authored_test.go
+++ b/internal/tools/builtin/agentdef_operator_authored_test.go
@@ -1,0 +1,120 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// asOperator marks the fixture's ctx as an operator's own off-run call — what
+// substrateAdminCtx and the MCP operator plane do in production. Derived from
+// the fixture's ctx so it keeps the def-authoring policy; only the AUTHORITY
+// differs, which is the axis under test.
+func asOperator(ctx context.Context) context.Context {
+	return tools.WithSubstrateOperator(ctx)
+}
+
+// asAgent is the fixture's ctx unchanged — a run authoring a def at runtime,
+// with the same policy and a plausible agent id.
+func asAgent(ctx context.Context, agentID string) context.Context {
+	return tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: agentID})
+}
+
+// TestAgentDef_OperatorAuthoredRoundTrips is the core claim: who wrote a def is
+// recorded, and it comes from the CTX rather than from anything the caller can
+// put in the body or the identity.
+func TestAgentDef_OperatorAuthoredRoundTrips(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		as   func(context.Context) context.Context
+		want bool
+	}{
+		{"an operator's own call", asOperator, true},
+		{"an agent at runtime", func(c context.Context) context.Context { return asAgent(c, "a_some_agent") }, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tool, base, cleanup := agentDefFixture(t)
+			defer cleanup()
+			ctx := tc.as(base)
+
+			res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"rev","overlay":{"tier":"middle"}}`))
+			if res.IsError {
+				t.Fatalf("create: %s", res.Text)
+			}
+			defID, _ := decodeResult(t, res.Text)["def_id"].(string)
+
+			row, err := tool.Store.AgentDefGet(ctx, defID)
+			if err != nil {
+				t.Fatalf("read back: %v", err)
+			}
+			if row.OperatorAuthored != tc.want {
+				t.Errorf("operator_authored = %v, want %v", row.OperatorAuthored, tc.want)
+			}
+		})
+	}
+}
+
+// TestAgentDef_AuthorshipCannotBeClaimedByTheBody: the flag is stamped from the
+// ctx, so a def that names itself operator-authored in its overlay — or names
+// an operator-looking agent as its author — gains nothing.
+func TestAgentDef_AuthorshipCannotBeClaimedByTheBody(t *testing.T) {
+	tool, base, cleanup := agentDefFixture(t)
+	defer cleanup()
+	// An AGENT's ctx, with an operator-LOOKING agent id and an overlay that
+	// tries to assert authorship directly.
+	ctx := asAgent(base, "a_operator")
+
+	res, _ := tool.Execute(ctx, json.RawMessage(
+		`{"op":"create","name":"sneaky","overlay":{"tier":"middle","operator_authored":true}}`))
+	if res.IsError {
+		t.Fatalf("create: %s", res.Text)
+	}
+	defID, _ := decodeResult(t, res.Text)["def_id"].(string)
+	row, _ := tool.Store.AgentDefGet(ctx, defID)
+	if row.OperatorAuthored {
+		t.Error("a def claimed operator authorship from its own body or agent id — " +
+			"authority must come from the ctx alone")
+	}
+}
+
+// TestAgentDef_ForkDoesNotInheritAuthorship: a fork may change the body, so
+// inheriting the parent's flag would launder an operator-authored def into an
+// agent-authored one that still carried operator authority.
+func TestAgentDef_ForkDoesNotInheritAuthorship(t *testing.T) {
+	tool, base, cleanup := agentDefFixture(t)
+	defer cleanup()
+
+	opCtx := asOperator(base)
+	res, _ := tool.Execute(opCtx, json.RawMessage(`{"op":"create","name":"base","overlay":{"tier":"middle"}}`))
+	if res.IsError {
+		t.Fatalf("create: %s", res.Text)
+	}
+	parentID, _ := decodeResult(t, res.Text)["def_id"].(string)
+	parent, _ := tool.Store.AgentDefGet(opCtx, parentID)
+	if !parent.OperatorAuthored {
+		t.Fatal("the operator-authored parent was not stamped")
+	}
+
+	// An AGENT forks it.
+	agentCtx := asAgent(base, "a_agent")
+	res, _ = tool.Execute(agentCtx, json.RawMessage(`{"op":"fork","name":"base","overlay":{"tier":"high"}}`))
+	if res.IsError {
+		t.Fatalf("fork: %s", res.Text)
+	}
+	forkID, _ := decodeResult(t, res.Text)["def_id"].(string)
+	fork, _ := tool.Store.AgentDefGet(agentCtx, forkID)
+	if fork.OperatorAuthored {
+		t.Error("an agent's fork inherited the parent's operator authorship — " +
+			"a fork may change the body, so authority must be re-earned")
+	}
+
+	// And the operator forking their own def keeps it.
+	res, _ = tool.Execute(opCtx, json.RawMessage(`{"op":"fork","name":"base","overlay":{"tier":"low"}}`))
+	opForkID, _ := decodeResult(t, res.Text)["def_id"].(string)
+	opFork, _ := tool.Store.AgentDefGet(opCtx, opForkID)
+	if !opFork.OperatorAuthored {
+		t.Error("an operator's own fork lost its authorship")
+	}
+}

--- a/internal/tools/builtin/context.go
+++ b/internal/tools/builtin/context.go
@@ -262,6 +262,16 @@ func (c *Context) execSelf(ctx context.Context) (tools.Result, error) {
 		// started outside the loop's stamping path (e.g. some tests).
 		"provider": tools.ResolvedProvider(ctx),
 		"model":    tools.ResolvedModel(ctx),
+		// operator_authored says whether a PERSON wrote this agent's
+		// definition — the operator's yaml, or an off-run call under an
+		// operator token — rather than an agent writing it at runtime.
+		//
+		// Worth answering on its own: "who wrote me" is a question a
+		// self-evolving agent, and an operator auditing one, both ask. It is
+		// also the bit that decides which prompt-expansion families this
+		// agent's definition may use, so an agent seeing an expansion refused
+		// can tell WHY rather than guessing.
+		"operator_authored": tools.OperatorAuthored(ctx),
 	}
 	// sampling: the resolved LLM sampling params (temperature, top_p, …) in
 	// effect for this run (per-run > per-agent). Non-secret — the agent is

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -1118,6 +1118,26 @@ func CompactionOverride(ctx context.Context) *config.Compaction {
 type ctxKeyResolvedProvider struct{}
 type ctxKeyResolvedModel struct{}
 
+type ctxKeyOperatorAuthored struct{}
+
+// WithOperatorAuthored records whether the agent this run resolved was written
+// by an OPERATOR rather than by an agent at runtime.
+//
+// Stamped from the RESOLVED definition at loop-ctx assembly, beside the other
+// per-agent policies, so a tool can ask without re-reading the definition
+// plane. Absent means false — a run whose ctx was never stamped has not proved
+// operator authorship, which is the safe direction.
+func WithOperatorAuthored(ctx context.Context, v bool) context.Context {
+	return context.WithValue(ctx, ctxKeyOperatorAuthored{}, v)
+}
+
+// OperatorAuthored reports whether this run's agent definition was
+// operator-authored. False for an unstamped ctx.
+func OperatorAuthored(ctx context.Context) bool {
+	v, _ := ctx.Value(ctxKeyOperatorAuthored{}).(bool)
+	return v
+}
+
 // WithResolvedProvider attaches the resolved provider id to ctx.
 func WithResolvedProvider(ctx context.Context, providerID string) context.Context {
 	if providerID == "" {


### PR DESCRIPTION
## Why

RFC CY item 8, and the gate Track A's widening sits behind. The widened prompt-expansion families resolve under the **runtime's** authority rather than the agent's, so widening them for a def an agent wrote itself would hand a model an ungated read primitive it could aim. That needs a trustworthy answer to "who wrote this", and there wasn't one.

P2 (the widening) depends on this and is next.

## Stamped from the ctx, never from the caller

`tools.IsSubstrateOperator(ctx)` at create and fork — **not** `CreatedByAgentID`, which a run supplies itself. A def that names `a_operator` as its author *and* asserts `operator_authored: true` in its own overlay still lands **false**. Both attack shapes are tested.

All three `AgentDefRow` literals are covered:

| site | value | why |
|---|---|---|
| `create` | the authoring ctx | — |
| `fork` | the **forker's** ctx, never the parent's | a fork may change the body, so inheriting would launder an operator-authored def into an agent-authored one that kept the authority |
| `bootstrapStatic` | **true** unconditionally | the body *is* the operator's `cfg.Agents` yaml, whoever triggered materialisation. The fork that follows is stamped from its own caller, so an agent still can't inherit it by forking |

## Authority, not content — verified, not asserted

Absent from `content_sha256`, the same treatment `*_def_scopes` and the RFC AX restriction bit get. I checked rather than claimed it: the hash of a fixed `AgentContent` computed on **`origin/main`** and on this branch is byte-identical (`sha256:0d5ea67c…`), and that literal is pinned with a message saying a change means every existing row now reports as drifted. A second test derives from the struct and fails if any authorship-named field ever joins the hash input.

**The three-way drift test did its job** and refused the change until the exemption carried a justification:

```
AgentDef.OperatorAuthored does not survive config -> substrate -> config
Either wire it through both converters OR add it to exempt with a justification.
```

Its exempt branch also asserts the field comes back **zero** through the round trip — so it now permanently enforces that a definition cannot carry its own authorship.

## Resolution and a consumer

`config.AgentDef` gains the field as `json:"-" yaml:"-"` — neither persisted, nor hashed, nor settable from a body. `lookup` sets it from whichever source it resolved from (a static `cfg.Agents` entry is operator-authored by construction, because it *is* the operator's yaml), and all **five** agent-def-aware loop-ctx sites stamp `tools.WithOperatorAuthored`.

**A consumer in the same PR**, because a flag nothing reads is dead code: `Context op=self` reports `operator_authored`. "Who wrote me" is worth answering on its own, and it's how an agent refused an expansion in P2 can tell *why* rather than guessing.

## Legacy rows, tested on the upgrade path

Legacy rows read **false** — the safe direction, since nothing should gain authority by having predated the column.

Tested on the **upgrade** path, not a fresh DB: the pre-column schema is built on disk, a row written into it, and the store reopened so the `ALTER` runs against real legacy data. A fresh-DB test cannot see that case at all, and a row defaulting the other way would hand every pre-existing agent-authored def an authority it was never granted.

## Tested

`go build ./...`, `go vet ./...`, `gofmt -l` clean, **`go test -race ./...` green (111 packages)** — the flags CI actually uses.

**Against a real Postgres:** migration `0076` applies (`boolean NOT NULL DEFAULT false`), the down statement drops it, and the up is idempotent on re-run.

**Fail-before, five claims, each red against its own break:**

| break | test that reds |
|---|---|
| authorship from the caller's agent id | `TestAgentDef_AuthorshipCannotBeClaimedByTheBody` |
| a fork inherits the parent's flag | `TestAgentDef_ForkDoesNotInheritAuthorship` |
| authorship joins the content hash | `TestAgentContent_CarriesNoAuthorshipField` |
| the legacy default flipped to 1 | `TestMigrate_LegacyAgentDefReadsAsNotOperatorAuthored` |
| the flag dropped on store read | `TestAgentDef_OperatorAuthoredRoundTrips` |

One was **vacuous on the first attempt** — the perturbation hit the fork literal while the test exercises create, so it passed. Re-targeted at the create site, it reds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD