### PR TITLE
fix(eval): pin the sampling — the extractor gate was measuring a coin flip

### DIFF
--- a/internal/cli/memory_eval_live.go
+++ b/internal/cli/memory_eval_live.go
@@ -76,6 +76,8 @@ func RunMemoryEvalLive(args []string, stdout, stderr io.Writer) int {
 		"which fixture set to score: default | hierarchy. hierarchy measures whether the "+
 			"model picks the most specific type that fits, and REQUIRES an -ontology-terms "+
 			"carrying the matching hierarchy (it is defaulted for you when omitted)")
+	temperature := fs.Float64("temperature", -1, "pin the sampling temperature (default -1 = the provider's own default). Pinning is what makes two runs of this eval comparable: unpinned, the violation count swings by tens of points between runs and no prompt change is measurable underneath it")
+	seed := fs.Int("seed", 0, "pin the sampling seed (0 = unset). Use with --temperature 0 when you need a run someone else can reproduce")
 	showFacts := fs.Bool("show-facts", false, "print every case's emitted facts, including the ones that passed")
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -162,6 +164,8 @@ func RunMemoryEvalLive(args []string, stdout, stderr io.Writer) int {
 		Model:        *model,
 		Effort:       *effort,
 		MaxTokens:    *maxTokens,
+		Temperature:  temperatureOrNil(*temperature),
+		Seed:         seedOrNil(*seed),
 	})
 	if err != nil {
 		return failOp(stderr, "memory-eval-live: %v", err)
@@ -503,3 +507,22 @@ func expandEvalPlaceholders(prompt, tenantTerms string) (string, error) {
 
 // unexpandedPlaceholder matches any surviving {{...}} of either family.
 var unexpandedPlaceholder = regexp.MustCompile(`\{\{\s*(memory|tool)\s*:[^}]*\}\}`)
+
+// temperatureOrNil maps the sentinel -1 to "leave the provider's default alone".
+// A literal 0.0 is a REAL value here — it is the whole point of pinning — so the
+// absent case cannot be the zero value.
+func temperatureOrNil(v float64) *float64 {
+	if v < 0 {
+		return nil
+	}
+	return &v
+}
+
+// seedOrNil maps 0 to unset. Ollama treats seed 0 as "pick one", so there is no
+// value lost by spending it as the sentinel.
+func seedOrNil(v int) *int {
+	if v == 0 {
+		return nil
+	}
+	return &v
+}

--- a/internal/memory/eval/extraction-baseline.json
+++ b/internal/memory/eval/extraction-baseline.json
@@ -84,6 +84,29 @@
         "temporal": 0,
         "update": 0
       }
+    },
+    {
+      "provider": "ollama-local",
+      "model": "qwen3.8:latest",
+      "effort": "low",
+      "system_prompt_sha256": "a83db4c1298b52b9bee50e35c3f521d17943b0383e27d1fbaf001a655a149a63",
+      "corpus_sha256": "41e21b803e0b40a27ebd328135e780a7b6f774ef3b823384372f4a4c9938310e",
+      "measured_at": "2026-09-12T06:16:39Z",
+      "recall": {
+        "extraction": 1,
+        "property": 0.8,
+        "temporal": 1,
+        "update": 1
+      },
+      "violations": {
+        "abstention": 0,
+        "extraction": 0,
+        "property": 0,
+        "temporal": 0,
+        "update": 0
+      },
+      "temperature": 0,
+      "seed": 7
     }
   ]
 }

--- a/internal/memory/eval/extraction.go
+++ b/internal/memory/eval/extraction.go
@@ -218,9 +218,14 @@ type ExtractionReport struct {
 	// or editing a case moves every recall figure just as surely as editing the
 	// prompt does, so it belongs in the baseline key for the same reason — see
 	// Baseline's header.
-	CorpusSHA256 string         `json:"corpus_sha256"`
-	Cases        []CaseResult   `json:"cases"`
-	Abilities    []AbilityScore `json:"abilities"`
+	CorpusSHA256 string `json:"corpus_sha256"`
+	// Temperature and Seed record how this run was SAMPLED — absent means the
+	// provider's default, which is one draw from a distribution rather than a
+	// number anyone can reproduce.
+	Temperature *float64       `json:"temperature,omitempty"`
+	Seed        *int           `json:"seed,omitempty"`
+	Cases       []CaseResult   `json:"cases"`
+	Abilities   []AbilityScore `json:"abilities"`
 	// TotalViolations across every ability — the headline safety number.
 	TotalViolations int `json:"total_violations"`
 	// TotalErrors counts cases that never produced an answer. Non-zero means the
@@ -304,6 +309,20 @@ type ExtractionInput struct {
 	Model     string
 	Effort    string
 	MaxTokens int
+	// Temperature and Seed PIN THE SAMPLING, and without them this harness is
+	// measuring a random variable while its gate demands a single clean run.
+	//
+	// Measured, shipped prompt, qwen3.8, effort=low: 7 of 12 runs clean, and a
+	// candidate prompt 12 of 16 — Fisher p=0.43, so the wording difference is
+	// invisible underneath the sampling noise. Worse, the gate refuses to record a
+	// run with any violation, so "record a clean baseline" on a ~60%-clean model is
+	// drawing until you like the number, which is the cherry-picking the refusal
+	// exists to prevent.
+	//
+	// Nil leaves the provider's own default, which is what every baseline recorded
+	// before this was measured under — so an old entry keeps meaning what it meant.
+	Temperature *float64
+	Seed        *int
 	// CaseTimeout bounds ONE case's call. Zero = no per-case bound (the caller's
 	// ctx is the only limit).
 	//
@@ -332,6 +351,8 @@ func RunExtraction(ctx context.Context, c Caller, in ExtractionInput) (Extractio
 		Effort:             in.Effort,
 		SystemPromptSHA256: sha256Hex(in.SystemPrompt),
 		CorpusSHA256:       in.Corpus.Digest(),
+		Temperature:        in.Temperature,
+		Seed:               in.Seed,
 	}
 
 	// Canary first.
@@ -469,6 +490,11 @@ func runCase(ctx context.Context, c Caller, in ExtractionInput, cs ExtractionCas
 	if in.MaxTokens > 0 {
 		req.MaxTokens = in.MaxTokens
 	}
+	// Passed through unconditionally when set: a pinned run must be pinned on
+	// EVERY case, or the cases differ in how they were measured and the total is
+	// not a number about one configuration.
+	req.Temperature = in.Temperature
+	req.Seed = in.Seed
 
 	if in.CaseTimeout > 0 {
 		var cancel context.CancelFunc
@@ -837,3 +863,6 @@ func truncate(s string, n int) string {
 	}
 	return s[:cut] + "…"
 }
+
+// Sampling reports how this run was sampled (nil = the provider's default).
+func (r ExtractionReport) Sampling() (*float64, *int) { return r.Temperature, r.Seed }

--- a/internal/memory/eval/extraction_baseline.go
+++ b/internal/memory/eval/extraction_baseline.go
@@ -43,6 +43,9 @@ type Measured interface {
 	// Incomplete reports (errors, harnessFault) — why a run's numbers may not be
 	// recordable.
 	Incomplete() (int, string)
+	// Sampling returns how the run was sampled, so the recorded entry says whether
+	// its numbers can be reproduced or were one draw from a distribution.
+	Sampling() (*float64, *int)
 }
 
 // BaselineEntry is one measured run's scores.
@@ -62,6 +65,23 @@ type BaselineEntry struct {
 	Recall map[string]float64 `json:"recall,omitempty"`
 	// Violations per ability. Present even at 0, because 0 is the interesting value.
 	Violations map[string]int `json:"violations"`
+	// Temperature and Seed record HOW the run was sampled, and an entry without
+	// them was measured on the provider's own default — which is to say, on one
+	// draw from a distribution.
+	//
+	// Measured: unpinned, this corpus returns 7 clean runs in 12 on the shipped
+	// prompt; pinned at temperature 0 with a seed, six consecutive runs were
+	// identical on every ability. So an entry that does not say how it was sampled
+	// cannot be reproduced, and the refusal to record a violating run gives false
+	// comfort: whoever re-drew until the number came out clean recorded something
+	// that looks exactly like this.
+	//
+	// NOT part of Key(). The key identifies what was scored — provider, model,
+	// effort, prompt, corpus — and adding sampling to it would make a pinned entry
+	// fail to match an unpinned lookup, silently un-gating the model it was
+	// recorded for.
+	Temperature *float64 `json:"temperature,omitempty"`
+	Seed        *int     `json:"seed,omitempty"`
 }
 
 // Key identifies the run this entry describes.
@@ -258,6 +278,7 @@ func SaveBaselineEntry(path string, r Measured) error {
 		Recall:             map[string]float64{},
 		Violations:         map[string]int{},
 	}
+	entry.Temperature, entry.Seed = r.Sampling()
 	for _, s := range abilities {
 		if s.Recall >= 0 {
 			entry.Recall[string(s.Ability)] = s.Recall

--- a/internal/memory/eval/extraction_test.go
+++ b/internal/memory/eval/extraction_test.go
@@ -1378,3 +1378,59 @@ func TestMatchExpected_TypeIsAHardFilter(t *testing.T) {
 		}
 	}
 }
+
+// TestRunExtraction_PinnedSamplingReachesEveryCall.
+//
+// Without this the harness measures a SAMPLED model while its gate demands a
+// single run with zero violations — so "record a clean baseline" is drawing until
+// the number comes out right, which is exactly the cherry-picking that
+// SaveBaselineEntry's refusal exists to prevent. Measured on the shipped prompt at
+// qwen3.8/effort=low: 7 of 12 unpinned runs were clean, and six consecutive pinned
+// runs were identical on every ability.
+//
+// EVERY call, not just the first: cases measured under different sampling do not
+// add up to a number about one configuration, and the canary runs ahead of the
+// rest so it is the easiest one to miss.
+func TestRunExtraction_PinnedSamplingReachesEveryCall(t *testing.T) {
+	corpus := ExtractionFixture()
+	replies := map[string]string{}
+	for _, c := range corpus.Cases {
+		replies[c.Name] = `[]`
+	}
+	rec := &samplingRecorder{replies: replies, corpus: corpus}
+	temp, seed := 0.0, 7
+	if _, err := RunExtraction(context.Background(), rec, ExtractionInput{
+		Corpus: corpus, SystemPrompt: "you extract durable facts",
+		Provider: "p", Model: "m", Temperature: &temp, Seed: &seed,
+	}); err != nil {
+		t.Fatalf("RunExtraction: %v", err)
+	}
+	if rec.calls == 0 {
+		t.Fatal("no calls were made, so this asserts nothing")
+	}
+	if rec.unpinned > 0 {
+		t.Errorf("%d of %d calls went out without the pinned sampling — a run is only "+
+			"reproducible if every case was measured the same way", rec.unpinned, rec.calls)
+	}
+}
+
+// samplingRecorder answers every case and counts how many calls carried the
+// sampling it was given.
+type samplingRecorder struct {
+	replies  map[string]string
+	corpus   ExtractionCorpus
+	calls    int
+	unpinned int
+}
+
+func (s *samplingRecorder) Call(_ context.Context, req providers.Request) (<-chan providers.Event, error) {
+	s.calls++
+	if req.Temperature == nil || *req.Temperature != 0.0 || req.Seed == nil || *req.Seed != 7 {
+		s.unpinned++
+	}
+	ch := make(chan providers.Event, 2)
+	ch <- providers.Event{Type: providers.EventText, Text: `[]`}
+	ch <- providers.Event{Type: providers.EventDone}
+	close(ch)
+	return ch, nil
+}

--- a/internal/memory/eval/judge.go
+++ b/internal/memory/eval/judge.go
@@ -562,3 +562,8 @@ func ParseJudgeReply(raw string) ([]JudgeVerdictEntry, bool) {
 	}
 	return out, true
 }
+
+// Sampling reports how this run was sampled. The judge axis does not pin it
+// today, so it is always the provider's default — reported as such rather than
+// left to the reader to assume, which is the whole point of the field.
+func (r JudgeReport) Sampling() (*float64, *int) { return nil, nil }


### PR DESCRIPTION
## The standing diagnosis was wrong

The extractor-prompt gate has been stuck: any edit reds the suite until a baseline entry exists for the new digest, `SaveBaselineEntry` rightly refuses to record a run with violations, and the shipped config kept producing one. The recorded explanation was that the prompt makes the model invent an entity for a fact about nobody, and that the prompt had to be fixed first.

Measurement says otherwise:

| prompt | clean runs | |
|---|---|---|
| shipped | 7 / 12 | |
| candidate (adds the missing negative example) | 12 / 16 | Fisher exact **p = 0.43** |

The wording is invisible underneath the noise. I ran the candidate's first six runs **6/6 clean** — convincing enough to ship on — and the next batch immediately produced violations. That near-miss is what prompted looking at the measurement instead of the prompt.

## The harness never pinned the sampling

`ExtractionInput` carried Provider, Model, Effort, MaxTokens — and no temperature or seed. So every run drew afresh while the gate demanded **a single run at zero violations**. On a ~60%-clean model, "record a clean baseline" is drawing until you like the number: the exact cherry-picking the refusal exists to prevent, wearing the costume of having obeyed it.

**Pinned at temperature 0 with a seed, six consecutive runs were byte-identical** on every ability — same violations, same recall, same subject rate — and clean. The shipped prompt is not the problem; the numbers it was judged on were never reproducible.

## What changed

- `ExtractionInput` gains `Temperature` + `Seed`, applied on **every** case (the canary runs ahead of the rest and is the easiest to miss).
- `memory-eval-live` gains `--temperature` / `--seed`, both defaulting to unset, so entries recorded before this keep meaning what they meant.
- The report and the baseline entry **record the sampling** — an entry that doesn't say how it was measured can't be reproduced, and given the refusal above it gives false comfort about how it was obtained. Deliberately **not** part of `Key()`: the key identifies *what* was scored, and adding sampling would make a pinned entry miss an unpinned lookup and silently un-gate the model it was recorded for.
- The baseline gains a clean, pinned, **effort=low** entry for the shipped prompt — closing a real gap, since the only entry for this prompt was recorded at effort=**medium** while the extractor ships at low.

**No prompt change.** The bundle is untouched.

## Verified end to end

Edit the prompt → the gate fails and names the new digest → rebuild → record → the gate passes.

⚠️ **The rebuild is required and not obvious.** Presets are `go:embed`ed, so `memory-eval-live` from a stale binary measures the **old** prompt and records the old digest against it. The gate caught it, which is how I found it — worth knowing for anyone doing this next.

## Two things I want on the record

The candidate prompt is **not** in this PR. It isn't significant, and its negative example was the same *kind* of case as the `durable-but-nobodys` fixture — so adopting it would have quietly turned that fixture from a test of whether the model generalises the rule into a test of whether it follows an explicit instruction. With sampling pinned, a future prompt change can now be evaluated properly instead.

The recorded note that `subj` predicts the violation perfectly (5/5) **does not hold at larger n** — across 28 runs there are clean runs at `subj` 1.00 and violating runs at 0.60. That was a small-sample artifact and I've corrected it in my notes.

`go test ./...` clean (101 packages), plus `TestRunExtraction_PinnedSamplingReachesEveryCall` with a fail-before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8