### PR TITLE
feat(memory): a fact references every subject it names (RFC CW Probe 3, consumer half)

### DIFF
--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -641,6 +641,7 @@ agents:
           owner_names: null,        // the target's DECLARED names, resolved once per pass
           entity_nodes: 0,          // distinct subjects given an entity chunk
           subject_doc_unavailable: 0, // subjects filed in the shared document instead of their own
+          subject_refs: 0,          // extra subjects a fact REFERENCES beyond the one it is homed under
           entity_facts: 0,          // facts mirrored into the graph
           // The judge's candidates, in WRITE ORDER. An array rather than a map
           // because this body re-executes from the top on every turn and must be a
@@ -1318,7 +1319,21 @@ agents:
           // there is nothing to name a node after, and the orphan kind would reach
           // the judge's mistyping check, which needs the pair to mean anything.
           var typ = (typeof f.type === "string") ? f.type.trim().toLowerCase() : "";
-          var subj = (typeof f.subject === "string") ? f.subject.trim() : "";
+          // EVERY thing the fact is about, not just the first. A relation names two
+          // — "Dave works at the shop" — and a single field forced the extractor to
+          // pick one, so the fact became about Dave and merely mentioned the shop.
+          // Read the shop and it was not there.
+          //
+          // `subject` survives as the HOME: the tree needs exactly one parent, and
+          // every other consumer (placement, the judge's mistyping pair, the report)
+          // asks about the one subject a fact is filed under. So the list is read
+          // here, the home is its first entry, and only mirrorEntity looks wider.
+          //
+          // A legacy string `subject` is still accepted: a tenant may override this
+          // prompt, and an extractor that answers the older schema must not have its
+          // facts silently stripped of their subject.
+          var subjects = normaliseSubjects(f);
+          var subj = subjects.length > 0 ? subjects[0] : "";
           if (!subj) { typ = ""; }
           // The validity interval is OPTIONAL and validated shallowly: an
           // unparseable or reversed interval is dropped while the FACT is kept,
@@ -1332,8 +1347,8 @@ agents:
           // what `Memory when=` narrows on. Validated by the same RFC3339-or-nothing
           // rule and carried separately, so a dropped interval never takes it with it.
           var oa = tsOrEmpty(f.observed_at);
-          out.push({ text: text, cls: cls, type: typ, subject: subj, quote: "",
-                     observed_at: oa, valid_at: va, invalid_at: iva });
+          out.push({ text: text, cls: cls, type: typ, subject: subj, subjects: subjects,
+                     quote: "", observed_at: oa, valid_at: va, invalid_at: iva });
         }
         return out;
       }
@@ -2577,6 +2592,47 @@ agents:
         return { doc: sharedDoc, root: id };
       }
 
+      // MAX_SUBJECTS bounds what one fact may be about.
+      //
+      // Each extra subject costs an entity node, an edge and a placement question, and
+      // a fact about more than a handful of things is a fact that should have been
+      // split. Four covers every relation shape the corpus actually produces ("Gina
+      // and Jon agreed to cover Dave's shift" is three) and stops a confused model
+      // turning one sentence into a hub that every traversal runs through.
+      var MAX_SUBJECTS = 4;
+
+      // normaliseSubjects reads EVERY thing a fact is about, from either schema.
+      //
+      // The list form is what the extractor is asked for now; the bare string is the
+      // older shape and is still accepted, because a tenant may override the prompt
+      // and a fact whose subject was silently dropped is unreachable from the thing
+      // it is about — the failure the entity tier exists to prevent.
+      //
+      // Deduplicated case-insensitively on the NORMALISED name, because "Dave" and
+      // "dave" slug to one node: two edges to the same node is not a second
+      // reference, it is the same one written twice.
+      function normaliseSubjects(f) {
+        var raw = [];
+        if (f && Object.prototype.toString.call(f.subjects) === "[object Array]") {
+          raw = f.subjects;
+        } else if (f && typeof f.subjects === "string") {
+          // A model asked for a list sometimes sends one string anyway.
+          raw = [f.subjects];
+        }
+        if (raw.length === 0 && f && typeof f.subject === "string") { raw = [f.subject]; }
+        var out = [], seen = {};
+        for (var i = 0; i < raw.length && out.length < MAX_SUBJECTS; i++) {
+          if (typeof raw[i] !== "string") { continue; }
+          var name = raw[i].trim();
+          if (!name) { continue; }
+          var k = slug(normalizeSubject(name));
+          if (!k || seen[k]) { continue; }
+          seen[k] = true;
+          out.push(name);
+        }
+        return out;
+      }
+
       // nonEmpty reports a USABLE string field — present, a string, and not merely
       // whitespace. The extractor omits a key, sends null, and sends "" for the same
       // "I do not know", so all three have to read the same way.
@@ -2777,6 +2833,37 @@ agents:
           } catch (e) {
             st.entity_failed++; // the nodes exist; only the edge is missing
             if (!st.entity_error) { st.entity_error = errText(e); }
+          }
+        }
+
+        // EVERY OTHER THING THE FACT IS ABOUT. It is HOMED under the first subject —
+        // the tree needs exactly one parent — and REFERENCES the rest, which is the
+        // whole difference between containment and reference: read the shop and the
+        // fact filed under Dave is still reachable, through an edge rather than
+        // through the tree.
+        //
+        // Same best-effort posture as the home edge: a reference that fails to write
+        // costs reachability from that one subject and never the fact.
+        if (subjID && fact.subjects && fact.subjects.length > 1) {
+          for (var si = 1; si < fact.subjects.length; si++) {
+            var alsoName = fact.subjects[si];
+            if (!nonEmpty(alsoName)) { continue; }
+            // The SAME type arbitration as the home subject: canonicalType keeps one
+            // subject on one node however many kinds the extractor spells it, and the
+            // fallback covers a kind the tenant does not declare. Without this a
+            // referenced subject would be minted under whatever the fact's own type
+            // happened to be, which is the fact's kind and not the subject's.
+            var alsoType = canonicalType(st, scope, ENTITY_FALLBACK_TYPE, alsoName);
+            var alsoHome = homeFor(st, scope, docID, alsoType, alsoName);
+            if (!alsoHome || !alsoHome.root) { continue; }
+            try {
+              Document({ op: "link_chunks", scope: scope,
+                         from_id: factID, to_id: alsoHome.root, kind: "about" });
+              st.subject_refs++;
+            } catch (e2) {
+              st.entity_failed++;
+              if (!st.entity_error) { st.entity_error = errText(e2); }
+            }
           }
         }
         // The FACT CHUNK landed. The edge may not have, and that stays best-effort:
@@ -3407,6 +3494,9 @@ agents:
             ent += ", " + st.entity_failed + " graph write(s) failed";
             // The reason, because the transcript of an internal agent cannot be read back.
             if (st.entity_error) { ent += " (first: " + String(st.entity_error).slice(0, 220) + ")"; }
+          }
+          if (st.subject_refs) {
+            ent += ", " + st.subject_refs + " reference(s) to a second subject a fact is also about";
           }
           if (st.subject_doc_unavailable) {
             ent += ", " + st.subject_doc_unavailable + " subject(s) still filed in the shared " +

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -641,6 +641,7 @@ agents:
           owner_names: null,        // the target's DECLARED names, resolved once per pass
           entity_nodes: 0,          // distinct subjects given an entity chunk
           subject_doc_unavailable: 0, // subjects filed in the shared document instead of their own
+          subject_refs: 0,          // extra subjects a fact REFERENCES beyond the one it is homed under
           entity_facts: 0,          // facts mirrored into the graph
           // The judge's candidates, in WRITE ORDER. An array rather than a map
           // because this body re-executes from the top on every turn and must be a
@@ -1318,7 +1319,21 @@ agents:
           // there is nothing to name a node after, and the orphan kind would reach
           // the judge's mistyping check, which needs the pair to mean anything.
           var typ = (typeof f.type === "string") ? f.type.trim().toLowerCase() : "";
-          var subj = (typeof f.subject === "string") ? f.subject.trim() : "";
+          // EVERY thing the fact is about, not just the first. A relation names two
+          // — "Dave works at the shop" — and a single field forced the extractor to
+          // pick one, so the fact became about Dave and merely mentioned the shop.
+          // Read the shop and it was not there.
+          //
+          // `subject` survives as the HOME: the tree needs exactly one parent, and
+          // every other consumer (placement, the judge's mistyping pair, the report)
+          // asks about the one subject a fact is filed under. So the list is read
+          // here, the home is its first entry, and only mirrorEntity looks wider.
+          //
+          // A legacy string `subject` is still accepted: a tenant may override this
+          // prompt, and an extractor that answers the older schema must not have its
+          // facts silently stripped of their subject.
+          var subjects = normaliseSubjects(f);
+          var subj = subjects.length > 0 ? subjects[0] : "";
           if (!subj) { typ = ""; }
           // The validity interval is OPTIONAL and validated shallowly: an
           // unparseable or reversed interval is dropped while the FACT is kept,
@@ -1332,8 +1347,8 @@ agents:
           // what `Memory when=` narrows on. Validated by the same RFC3339-or-nothing
           // rule and carried separately, so a dropped interval never takes it with it.
           var oa = tsOrEmpty(f.observed_at);
-          out.push({ text: text, cls: cls, type: typ, subject: subj, quote: "",
-                     observed_at: oa, valid_at: va, invalid_at: iva });
+          out.push({ text: text, cls: cls, type: typ, subject: subj, subjects: subjects,
+                     quote: "", observed_at: oa, valid_at: va, invalid_at: iva });
         }
         return out;
       }
@@ -2577,6 +2592,47 @@ agents:
         return { doc: sharedDoc, root: id };
       }
 
+      // MAX_SUBJECTS bounds what one fact may be about.
+      //
+      // Each extra subject costs an entity node, an edge and a placement question, and
+      // a fact about more than a handful of things is a fact that should have been
+      // split. Four covers every relation shape the corpus actually produces ("Gina
+      // and Jon agreed to cover Dave's shift" is three) and stops a confused model
+      // turning one sentence into a hub that every traversal runs through.
+      var MAX_SUBJECTS = 4;
+
+      // normaliseSubjects reads EVERY thing a fact is about, from either schema.
+      //
+      // The list form is what the extractor is asked for now; the bare string is the
+      // older shape and is still accepted, because a tenant may override the prompt
+      // and a fact whose subject was silently dropped is unreachable from the thing
+      // it is about — the failure the entity tier exists to prevent.
+      //
+      // Deduplicated case-insensitively on the NORMALISED name, because "Dave" and
+      // "dave" slug to one node: two edges to the same node is not a second
+      // reference, it is the same one written twice.
+      function normaliseSubjects(f) {
+        var raw = [];
+        if (f && Object.prototype.toString.call(f.subjects) === "[object Array]") {
+          raw = f.subjects;
+        } else if (f && typeof f.subjects === "string") {
+          // A model asked for a list sometimes sends one string anyway.
+          raw = [f.subjects];
+        }
+        if (raw.length === 0 && f && typeof f.subject === "string") { raw = [f.subject]; }
+        var out = [], seen = {};
+        for (var i = 0; i < raw.length && out.length < MAX_SUBJECTS; i++) {
+          if (typeof raw[i] !== "string") { continue; }
+          var name = raw[i].trim();
+          if (!name) { continue; }
+          var k = slug(normalizeSubject(name));
+          if (!k || seen[k]) { continue; }
+          seen[k] = true;
+          out.push(name);
+        }
+        return out;
+      }
+
       // nonEmpty reports a USABLE string field — present, a string, and not merely
       // whitespace. The extractor omits a key, sends null, and sends "" for the same
       // "I do not know", so all three have to read the same way.
@@ -2777,6 +2833,37 @@ agents:
           } catch (e) {
             st.entity_failed++; // the nodes exist; only the edge is missing
             if (!st.entity_error) { st.entity_error = errText(e); }
+          }
+        }
+
+        // EVERY OTHER THING THE FACT IS ABOUT. It is HOMED under the first subject —
+        // the tree needs exactly one parent — and REFERENCES the rest, which is the
+        // whole difference between containment and reference: read the shop and the
+        // fact filed under Dave is still reachable, through an edge rather than
+        // through the tree.
+        //
+        // Same best-effort posture as the home edge: a reference that fails to write
+        // costs reachability from that one subject and never the fact.
+        if (subjID && fact.subjects && fact.subjects.length > 1) {
+          for (var si = 1; si < fact.subjects.length; si++) {
+            var alsoName = fact.subjects[si];
+            if (!nonEmpty(alsoName)) { continue; }
+            // The SAME type arbitration as the home subject: canonicalType keeps one
+            // subject on one node however many kinds the extractor spells it, and the
+            // fallback covers a kind the tenant does not declare. Without this a
+            // referenced subject would be minted under whatever the fact's own type
+            // happened to be, which is the fact's kind and not the subject's.
+            var alsoType = canonicalType(st, scope, ENTITY_FALLBACK_TYPE, alsoName);
+            var alsoHome = homeFor(st, scope, docID, alsoType, alsoName);
+            if (!alsoHome || !alsoHome.root) { continue; }
+            try {
+              Document({ op: "link_chunks", scope: scope,
+                         from_id: factID, to_id: alsoHome.root, kind: "about" });
+              st.subject_refs++;
+            } catch (e2) {
+              st.entity_failed++;
+              if (!st.entity_error) { st.entity_error = errText(e2); }
+            }
           }
         }
         // The FACT CHUNK landed. The edge may not have, and that stays best-effort:
@@ -3407,6 +3494,9 @@ agents:
             ent += ", " + st.entity_failed + " graph write(s) failed";
             // The reason, because the transcript of an internal agent cannot be read back.
             if (st.entity_error) { ent += " (first: " + String(st.entity_error).slice(0, 220) + ")"; }
+          }
+          if (st.subject_refs) {
+            ent += ", " + st.subject_refs + " reference(s) to a second subject a fact is also about";
           }
           if (st.subject_doc_unavailable) {
             ent += ", " + st.subject_doc_unavailable + " subject(s) still filed in the shared " +

--- a/cmd/loomcycle/presets_memory_codejs_test.go
+++ b/cmd/loomcycle/presets_memory_codejs_test.go
@@ -3402,6 +3402,99 @@ func TestConsolidator_ASubjectWithNoTypeIsFiledUnderTheFallbackType(t *testing.T
 	}
 }
 
+// TestConsolidator_ARelationFactReferencesEverySubjectItNames.
+//
+// The extractor used to emit ONE subject, so "Dave works at the shop" became a fact
+// about Dave that merely mentioned the shop — read the shop and half its relations
+// were missing. Containment cannot fix that: the tree needs exactly one parent.
+//
+// So the fact is HOMED under the first subject and REFERENCES the rest. That is the
+// producer half of the reader contract: `list_facts about:<shop>` and the shop
+// dossier's references block both read the inbound `about` edge this writes.
+func TestConsolidator_ARelationFactReferencesEverySubjectItNames(t *testing.T) {
+	f := newFakeToolset()
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	f.transcript = "### user\n\nDave started at the corner shop."
+	f.factsJSON = `[{"text":"Dave works at the corner shop.","class":"fact","type":"person",
+	                 "subjects":["Dave","the corner shop"]}]`
+
+	runConsolidator(t, f)
+
+	// One fact, homed once.
+	if n := factWriteCount(f); n != 1 {
+		t.Fatalf("fact writes = %d, want 1 — a fact about two things is still ONE fact", n)
+	}
+	// An `about` edge to EACH subject: one home, one reference.
+	links := callsWithOp(f, "Document.link_chunks")
+	if len(links) != 2 {
+		t.Fatalf("about edges = %d, want 2 (Dave and the shop) — a relation fact is "+
+			"unreachable from the subject it is not filed under without the second", len(links))
+	}
+	to := map[string]bool{}
+	for _, c := range links {
+		id, _ := c.Input["to_id"].(string)
+		to[id] = true
+	}
+	if len(to) != 2 {
+		t.Errorf("both edges point at the same node: %v", to)
+	}
+	// Both subjects exist as nodes, and the referenced one is NOT typed as the fact's
+	// own kind by accident.
+	keys := map[string]bool{}
+	for _, c := range subjectWrites(f) {
+		k, _ := c.Input["natural_key"].(string)
+		keys[k] = true
+	}
+	if !keys["person:dave"] {
+		t.Errorf("Dave got no node under his own type; keys=%v", keys)
+	}
+	if len(keys) != 2 {
+		t.Errorf("subject nodes = %v, want two (the home and the referenced one)", keys)
+	}
+}
+
+// TestConsolidator_TheSameSubjectNamedTwiceIsOneReference. "Dave" and "dave" slug to
+// one node, so two edges to it would be the same reference written twice — and the
+// duplicate would inflate the report's count of what a fact is about.
+func TestConsolidator_TheSameSubjectNamedTwiceIsOneReference(t *testing.T) {
+	f := newFakeToolset()
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	f.transcript = "### user\n\nDave prefers Go."
+	f.factsJSON = `[{"text":"Dave prefers Go.","class":"preference","type":"person",
+	                 "subjects":["Dave","dave","  Dave  "]}]`
+
+	runConsolidator(t, f)
+
+	if n := len(callsWithOp(f, "Document.link_chunks")); n != 1 {
+		t.Errorf("about edges = %d, want 1 — one subject spelled three ways is one node", n)
+	}
+}
+
+// TestConsolidator_ALegacySingleSubjectStillLands. A tenant may override the
+// extractor prompt, and an extractor answering the older schema must not have its
+// facts silently stripped of the subject they name.
+func TestConsolidator_ALegacySingleSubjectStillLands(t *testing.T) {
+	f := newFakeToolset()
+	f.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	f.transcript = "### user\n\nDave prefers Go."
+	f.factsJSON = `[{"text":"Dave prefers Go.","class":"preference","type":"person","subject":"Dave"}]`
+
+	runConsolidator(t, f)
+
+	if n := len(callsWithOp(f, "Document.link_chunks")); n != 1 {
+		t.Fatalf("about edges = %d, want 1 — the older schema still names a subject", n)
+	}
+	found := false
+	for _, c := range subjectWrites(f) {
+		if k, _ := c.Input["natural_key"].(string); k == "person:dave" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("a legacy single `subject` produced no subject node")
+	}
+}
+
 // TestConsolidator_AnUnmigratedSubjectStillGetsItsEdge.
 //
 // A scope written before subject-homing CANNOT adopt it on its own: natural_key is


### PR DESCRIPTION
## Why

The extractor emits one `subject`, so a relation is half-lost: "Dave works at the shop" becomes a fact **about Dave** that merely mentions the shop, and reading the shop doesn't find it. Containment can't fix that — the tree needs exactly one parent — which is why the reader contract (#1209) shipped `list_facts about:` and a dossier `references` block reading inbound `about` edges.

**Nothing produced those edges for a second subject**, so that half has been scaffolding. This is the producer.

## What

The consolidator reads a `subjects` **list**: the fact is **homed** under the first (one parent, one dossier) and **references** the rest with an `about` edge each.

- **Legacy `subject` string still accepted** — a tenant may override the extractor prompt, and an extractor answering the older schema must not have its facts silently stripped of the subject they name.
- **Deduplicated on the normalised name** — "Dave" and "dave" slug to one node, so two edges is the same reference written twice, and it would inflate what the report says a fact is about.
- **Capped at four.** Each extra subject costs a node, an edge and a placement question; a fact about more than a handful of things should have been split, and an unbounded list lets a confused model mint a hub every traversal runs through.
- **A referenced subject is typed against the fallback, not the fact's own `type`.** The fact's kind describes the fact — minting "the shop" as a `person` because the fact was about Dave is exactly the mis-typing the ontology guard exists to absorb.

## Checked the model first, not a stub

RFC CW carries a hard-won rule: a stub that always cooperates cannot test compliance, and Probe 1 was mis-read for exactly that reason. So before designing around a list, I asked the real extractor. qwen3.8 given the `subjects` schema on a relation transcript returns `["Dave","the corner shop"]` and `["Gina","Jon","Dave"]` — **5 seeds of 5**, identical.

(The RFC also says a raw-output probe is an *existence* check and worthless as a *frequency* check, which is why it's 5 seeds and why the real gate is the paired LoCoMo run below, not this.)

## The prompt is NOT changed here, deliberately

Asking for `subjects` moves the prompt digest, and the eval gate refuses a new baseline until sampling can be pinned — that fix is #1216, still in review. Stacking branches is something this project has been bitten by repeatedly, so this lands the **consumer**: inert for the shipped prompt, live for any extractor that already emits a list.

The schema change follows once #1216 lands, with its recorded baseline and its paired measurement (multi-hop slice, same-binary replicate per arm, per the RFC's methodology).

## Tested

Three behaviours: the relation fact gets an edge to each subject and a node for each; the same subject spelled three ways is one reference; a legacy single `subject` still lands.

**Fail-before on both halves** — without the reference loop the relation fact has 1 edge where 2 are correct; without normalised dedup "Dave"/"dave" produce 2 where 1 is correct.

`go test ./...` clean (101 packages).

## Where RFC CW stands

Probes 1, 1b and 2 are done: facts-arm accuracy **0.157 → ~0.52–0.58**, temporal **0.036 → 0.667**, abstention **76% → 31%** — the gap to Mem0/Zep (~0.67) is ~9pp, not ~51pp. Probe 3 is the last of the three mechanisms. Still open after it: **CW-OQ5** (is windowing safe as a shipped default — currently off), **CW-OQ4** (sweep on a second extractor), and Probe 4 only if a gap remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8