### PR TITLE
feat(memory): window the extractor by default — 8 turns, guarded on short sources (CW-OQ5)

### DIFF
--- a/bundles/memory/loomcycle.yaml
+++ b/bundles/memory/loomcycle.yaml
@@ -348,12 +348,34 @@ agents:
         // the system prompt, the temporal rule (~1.4k chars), the owner line, the
         // rolling context, and the REPLY the model still has to generate.
         context_reserve_pct: 40,
-        // extract_window_turns is the extraction GRANULARITY knob. 0 keeps the
-        // historical behaviour exactly — parts are packed to the character budget
-        // alone, which for a normal chat means ONE call for the whole transcript.
-        // N > 0 closes a part after N turns, so N=1 is per-message extraction and
-        // N=4..6 the short sliding window, with max_part_chars still a hard
-        // ceiling above it.
+        // extract_window_turns is the extraction GRANULARITY knob, and it is ON.
+        // N closes a part after N turns, so N=1 is per-message extraction and
+        // N=4..8 a sliding window, with max_part_chars still a hard ceiling above
+        // it. 0 restores the historical behaviour — one call for the whole
+        // transcript — for an operator who wants it.
+        //
+        // WHY 8, AND WHY ON AT ALL. Measured on a 419-turn conversation corpus:
+        // reading a whole chat scores 0.2867-0.3732 and EVERY window from 8 down
+        // to 1 scores 0.5175-0.5764. Whole-chat → 8 messages is +23.6pp, 34 vs 11
+        // discordant, p=0.0008. But 8 → 1 is 13 vs 14 discordant, p=1.0000: the
+        // effect is "window at all", not "window at N", and the whole 8..1 band
+        // sits INSIDE the control arm's own 8.7pp run-to-run spread. So accuracy
+        // does not choose the number and cost does — 8 messages costs 56 extractor
+        // calls for the accuracy that per-message buys with 419.
+        //
+        // Facts do NOT peak where accuracy does: they rise monotonically as the
+        // window narrows (199 → 245 → 323 → 366). Choosing N to maximise fact
+        // count would pick the most expensive point on a flat curve, which is the
+        // trap the extractor-model measurement already walked into — 42% more
+        // facts for a non-significant +4.2pp.
+        //
+        // SAFE ON SHORT SOURCES BY CONSTRUCTION, which is what makes this a
+        // default rather than a knob. min_turns_to_window below means a source
+        // shorter than 20 turns is extracted whole however this is set, so
+        // windowing can only fire where sources are long — which is exactly where
+        // it was measured to help. On a short multi-session corpus the two
+        // settings are the SAME configuration: measured, 0 of 4 instances
+        // windowed and fact counts matching the unwindowed arm.
         //
         // ⚠️ IT INTERACTS WITH max_parts_per_pass, WHICH BOUNDS A PASS'S TOTAL
         // SWEEP IF LEFT AT 4. A 22-turn chat at N=1 is 22 parts; the cap keeps the
@@ -365,7 +387,7 @@ agents:
         // calls per chat by the turn count, and a pass must still clear its chats
         // inside run_timeout_seconds (1500) which must stay under lease_ttl_ms
         // (1800000) or another worker re-claims the queue.
-        extract_window_turns: 0,
+        extract_window_turns: 8,
         // Windowing FRAGMENTS a small source below the size at which the
         // extractor finds anything, so it is applied only to a source with at
         // least this many turns.

--- a/cmd/loomcycle/embedded/bundles/memory.yaml
+++ b/cmd/loomcycle/embedded/bundles/memory.yaml
@@ -348,12 +348,34 @@ agents:
         // the system prompt, the temporal rule (~1.4k chars), the owner line, the
         // rolling context, and the REPLY the model still has to generate.
         context_reserve_pct: 40,
-        // extract_window_turns is the extraction GRANULARITY knob. 0 keeps the
-        // historical behaviour exactly — parts are packed to the character budget
-        // alone, which for a normal chat means ONE call for the whole transcript.
-        // N > 0 closes a part after N turns, so N=1 is per-message extraction and
-        // N=4..6 the short sliding window, with max_part_chars still a hard
-        // ceiling above it.
+        // extract_window_turns is the extraction GRANULARITY knob, and it is ON.
+        // N closes a part after N turns, so N=1 is per-message extraction and
+        // N=4..8 a sliding window, with max_part_chars still a hard ceiling above
+        // it. 0 restores the historical behaviour — one call for the whole
+        // transcript — for an operator who wants it.
+        //
+        // WHY 8, AND WHY ON AT ALL. Measured on a 419-turn conversation corpus:
+        // reading a whole chat scores 0.2867-0.3732 and EVERY window from 8 down
+        // to 1 scores 0.5175-0.5764. Whole-chat → 8 messages is +23.6pp, 34 vs 11
+        // discordant, p=0.0008. But 8 → 1 is 13 vs 14 discordant, p=1.0000: the
+        // effect is "window at all", not "window at N", and the whole 8..1 band
+        // sits INSIDE the control arm's own 8.7pp run-to-run spread. So accuracy
+        // does not choose the number and cost does — 8 messages costs 56 extractor
+        // calls for the accuracy that per-message buys with 419.
+        //
+        // Facts do NOT peak where accuracy does: they rise monotonically as the
+        // window narrows (199 → 245 → 323 → 366). Choosing N to maximise fact
+        // count would pick the most expensive point on a flat curve, which is the
+        // trap the extractor-model measurement already walked into — 42% more
+        // facts for a non-significant +4.2pp.
+        //
+        // SAFE ON SHORT SOURCES BY CONSTRUCTION, which is what makes this a
+        // default rather than a knob. min_turns_to_window below means a source
+        // shorter than 20 turns is extracted whole however this is set, so
+        // windowing can only fire where sources are long — which is exactly where
+        // it was measured to help. On a short multi-session corpus the two
+        // settings are the SAME configuration: measured, 0 of 4 instances
+        // windowed and fact counts matching the unwindowed arm.
         //
         // ⚠️ IT INTERACTS WITH max_parts_per_pass, WHICH BOUNDS A PASS'S TOTAL
         // SWEEP IF LEFT AT 4. A 22-turn chat at N=1 is 22 parts; the cap keeps the
@@ -365,7 +387,7 @@ agents:
         // calls per chat by the turn count, and a pass must still clear its chats
         // inside run_timeout_seconds (1500) which must stay under lease_ttl_ms
         // (1800000) or another worker re-claims the queue.
-        extract_window_turns: 0,
+        extract_window_turns: 8,
         // Windowing FRAGMENTS a small source below the size at which the
         // extractor finds anything, so it is applied only to a source with at
         // least this many turns.

--- a/cmd/loomcycle/presets_memory_codejs_test.go
+++ b/cmd/loomcycle/presets_memory_codejs_test.go
@@ -668,17 +668,21 @@ func okResult(v any) (tools.Result, error) {
 
 // runConsolidator drives the SHIPPED code-js body through the real loop against
 // the scripted toolset and returns the run result.
+// runConsolidator runs the pass AS SHIPPED — whatever extract_window_turns the
+// bundle carries. It used to pass 0, which silently made every caller a test of
+// the unwindowed path; that is no longer the default, so a test that needs the
+// unwindowed path asks for it with runConsolidatorWindow(t, f, 0).
 func runConsolidator(t *testing.T, f *fakeToolset) loop.RunResult {
 	t.Helper()
-	return runConsolidatorWindow(t, f, 0)
+	return runConsolidatorWindow(t, f, -1)
 }
 
 // runConsolidatorWindow runs the pass with the extraction granularity knob set.
 //
 // The knob is patched in the CODE BODY rather than exposed as a test hook,
-// because the body is what ships: rewriting the literal proves the shipped
-// default is 0 (the replacement must match exactly, or the test fails loudly)
-// and exercises the same path an operator gets by editing the bundle.
+// because the body is what ships: rewriting the literal exercises the same path
+// an operator gets by editing the bundle. windowTurns < 0 leaves the shipped
+// value in place; 0 turns windowing explicitly OFF.
 func runConsolidatorWindow(t *testing.T, f *fakeToolset, windowTurns int) loop.RunResult {
 	t.Helper()
 	cfg := memoryBundleConfig(t)
@@ -687,14 +691,21 @@ func runConsolidatorWindow(t *testing.T, f *fakeToolset, windowTurns int) loop.R
 		t.Fatalf("memory/consolidator not registered (agents: %v)", agentNames(cfg))
 	}
 	body := agent.Code
-	if windowTurns > 0 {
-		const shipped = "extract_window_turns: 0,"
-		if strings.Count(body, shipped) != 1 {
-			t.Fatalf("expected exactly one %q in the shipped body (found %d) — the default "+
-				"changed or the knob was renamed", shipped, strings.Count(body, shipped))
+	// windowTurns < 0 means "leave the shipped default alone"; 0 means "explicitly
+	// OFF". A test that wants no windowing has to SAY so, because the shipped
+	// default is now 8 — inheriting it from the default is how three tests here
+	// came to assert the old value without mentioning it.
+	if windowTurns >= 0 {
+		// Matched by SHAPE, not by the shipped value. This used to hard-code
+		// "extract_window_turns: 0," and so encoded the default it was meant to be
+		// independent of — the day the default moved, every windowing test failed
+		// for a reason unrelated to what it asserts.
+		re := regexp.MustCompile(`extract_window_turns: \d+,`)
+		if n := len(re.FindAllString(body, -1)); n != 1 {
+			t.Fatalf("expected exactly one extract_window_turns literal in the shipped body "+
+				"(found %d) — the knob was renamed or duplicated", n)
 		}
-		body = strings.Replace(body, shipped,
-			"extract_window_turns: "+strconv.Itoa(windowTurns)+",", 1)
+		body = re.ReplaceAllString(body, "extract_window_turns: "+strconv.Itoa(windowTurns)+",")
 	}
 	agent.Code = body
 	return runConsolidatorBody(t, f, agent)
@@ -4286,7 +4297,9 @@ func TestConsolidator_JudgeCallsAreBatchedAndBounded(t *testing.T) {
 	f.factsJSON = "[" + strings.Join(facts, ",") + "]"
 	f.factsByNeedle = []needleReply{{Needle: "BEGIN CANDIDATES", Reply: `[]`}}
 
-	runConsolidator(t, f)
+	// Windowing OFF: this asserts how the JUDGE batches a fixed candidate set, and
+	// granularity changes how many candidates there are to batch.
+	runConsolidatorWindow(t, f, 0)
 
 	prompts := judgePrompts(f)
 	if len(prompts) != 2 {
@@ -5736,7 +5749,9 @@ func TestConsolidator_QueuedPathHonoursTheExtractionWindow(t *testing.T) {
 	}
 
 	wide := newFixture()
-	runConsolidator(t, wide)
+	// Windowing explicitly OFF: this is the control the narrow arm is measured
+	// against, so it must not inherit whatever the shipped default happens to be.
+	runConsolidatorWindow(t, wide, 0)
 	wideCalls := len(extractorPrompts(wide))
 
 	narrow := newFixture()
@@ -5788,7 +5803,9 @@ func TestConsolidator_QueuedWindowSplitsBYMESSAGENotJustByItem(t *testing.T) {
 	}
 
 	wide := newFixture()
-	runConsolidator(t, wide)
+	// Windowing explicitly OFF: this is the CONTROL the narrow arm is measured
+	// against, so it must not inherit whatever the shipped default happens to be.
+	runConsolidatorWindow(t, wide, 0)
 	wideCalls := len(extractorPrompts(wide))
 
 	narrow := newFixture()
@@ -5796,7 +5813,7 @@ func TestConsolidator_QueuedWindowSplitsBYMESSAGENotJustByItem(t *testing.T) {
 	narrowCalls := len(extractorPrompts(narrow))
 
 	if wideCalls != 1 {
-		t.Fatalf("default made %d calls for one queued item, want 1", wideCalls)
+		t.Fatalf("unwindowed control made %d calls for one queued item, want 1", wideCalls)
 	}
 	if narrowCalls < 4 {
 		t.Errorf("per-message window made %d call(s) for a single 24-message item, want one per "+
@@ -5893,6 +5910,11 @@ func TestConsolidator_ASmallExtractorContextClampsThePartBudget(t *testing.T) {
 		}
 		agent.Code = strings.Replace(agent.Code, shipped,
 			"extractor_context_tokens: "+strconv.Itoa(ctxTokens)+",", 1)
+		// Windowing OFF. This asserts that the CHARACTER ceiling tracks the
+		// extractor's context; with a turn window on, parts close on the turn count
+		// long before the char budget binds, so the clamp under test never fires.
+		agent.Code = regexp.MustCompile(`extract_window_turns: \d+,`).
+			ReplaceAllString(agent.Code, "extract_window_turns: 0,")
 		runConsolidatorBody(t, f, agent)
 
 		var out []int
@@ -6018,5 +6040,40 @@ func TestConsolidator_MultiLineMessagesCountAsONETurn(t *testing.T) {
 		"Line three adds detail.\nLine four ends it.") {
 		t.Errorf("a message was split across windows — a fact derived here could be handed a span "+
 			"that stops mid-sentence:\n%s", joined[:min(400, len(joined))])
+	}
+}
+
+// TestConsolidator_TheSHIPPEDDefaultWindowsALongChatAndLeavesAShortOneWhole.
+//
+// The windowing default rests on two measurements that pull in opposite
+// directions: on a long conversation corpus, windowing is worth +23.6pp
+// (p=0.0008); on a short multi-session one it is unresolved at +3.2pp (p=0.34),
+// and without a guard it was actively destructive — one slice went to 0.0000 and
+// half the corpus produced no facts at all.
+//
+// What makes the default safe is that min_turns_to_window keeps it from firing on
+// exactly the sources where its benefit is unproven. That is a claim about the
+// SHIPPED configuration, so it is asserted against the shipped body rather than
+// against a window the test sets itself.
+func TestConsolidator_TheSHIPPEDDefaultWindowsALongChatAndLeavesAShortOneWhole(t *testing.T) {
+	longChat := newFakeToolset()
+	longChat.sessions = []map[string]any{scanRow("sess-a", "2026-07-01T10:00:00Z")}
+	longChat.transcript = historyTranscript(40, 200) // 40 turns, past the guard
+	longChat.factsJSON = `[]`
+	runConsolidator(t, longChat)
+	if n := len(extractorPrompts(longChat)); n < 2 {
+		t.Errorf("a 40-turn chat produced %d extractor call(s) — the shipped default must "+
+			"WINDOW a long source, which is where windowing was measured to help", n)
+	}
+
+	shortChat := newFakeToolset()
+	shortChat.sessions = []map[string]any{scanRow("sess-b", "2026-07-01T10:00:00Z")}
+	shortChat.transcript = historyTranscript(8, 200) // 8 turns, under the guard
+	shortChat.factsJSON = `[]`
+	runConsolidator(t, shortChat)
+	if n := len(extractorPrompts(shortChat)); n != 1 {
+		t.Errorf("an 8-turn chat produced %d extractor calls — a source under "+
+			"min_turns_to_window must be extracted WHOLE however the window is set, or "+
+			"each piece is too thin to carry a fact and the item stalls unacked", n)
 	}
 }


### PR DESCRIPTION
## The change

`extract_window_turns: 0 → 8`. Reading a whole chat into one extractor call is what the consolidator has always done, and stopping is worth ~20 accuracy points.

| window | extractor calls | facts | accuracy |
|---|---|---|---|
| whole chat | 10 | 82–104 | 0.2867 / 0.3404 / 0.3732 |
| **8 messages** | **56** | **199** | **0.5336** |
| 5 messages | 89 | 245 | 0.5764 |
| 3 messages | ~140 | 323 | 0.5175 |
| per message | 419 | 366 | 0.5414 |

Whole-chat → 8 is **+23.6pp, 34 vs 11 discordant, McNemar p=0.0008**.

**Eight is chosen by cost, not accuracy.** 8 → 1 is 13 vs 14 discordant, **p=1.0000** — the effect is "window at all", not "window at N", and the whole 8..1 band sits *inside* the control arm's own 8.7pp run-to-run spread. So cost decides: 8 turns costs **56 calls for the accuracy per-message buys with 419**.

Facts do **not** peak where accuracy does — they rise monotonically as the window narrows (199 → 245 → 323 → 366). Picking N to maximise fact count would choose the most expensive point on a flat curve, which is exactly the trap the extractor-model measurement already walked into (42% more facts for a non-significant +4.2pp).

## Why this is safe as a default — the question that held it back

CW-OQ5 was open because the two harnesses disagreed: +23.6pp (p=0.0008) on long episodic conversations vs +3.2pp (p=0.34) on short multi-session ones. The RFC's preferred resolution was to power up the second arm to ~500 instances.

**That experiment cannot resolve anything, and I measured why before running it.** The consolidation queue's unit is one enqueued payload; those sources are ~12 turns median (only 7 of 948 sessions reach 20); and `min_turns_to_window: 20` extracts them **whole however this knob is set**.

Measured on that corpus with the window live: **0 of 4 instances windowed**, every one reporting "extracted whole (too short to window)", fact counts matching the unwindowed arm (13,22 vs 11,23). The two settings are *the same configuration* there. A 500-instance run would have spent ~24h confirming a null guaranteed by the guard rather than by the absence of an effect.

So **the guard bounds the risk, not a hoped-for measurement**: windowing can only fire where sources are long, which is exactly where it was measured to help. Wall clock is bounded independently by `max_parts_per_pass: 40` — ~10 min at a slow local model's 15 s/call, against `run_timeout_seconds: 1500`.

## A test helper that encoded the old default

`runConsolidatorWindow` matched the literal `"extract_window_turns: 0,"`, so the shipped value was baked into every windowing test — and **three tests were asserting the unwindowed path without saying so**. `runConsolidator` now runs **as shipped**; a test that wants windowing off asks for it explicitly. The three now pin their own control: the granularity test's wide arm, judge-batching (granularity changes how many candidates there are to batch), and the part-budget test (a turn window closes a part before the char ceiling can bind, so the clamp under test never fires).

Same class as the placement-fixture problem: a control inherited from a default is not a control.

## Tested

`TestConsolidator_TheSHIPPEDDefaultWindowsALongChatAndLeavesAShortOneWhole` asserts both halves against the **shipped** body, since the safety claim is about what ships. Fail-before: with the default back at 0, the 40-turn chat produces 1 call where 2+ are correct.

`go test ./...` clean (101 packages).

## One thing I could not reproduce

The RFC's own w3-with-guard LongMemEval row reports **1692 facts vs 619 baseline** (2.7×), which is incompatible with windowing being inert on that corpus. I could not reproduce it — either the guard wasn't active in that run or the ingest unit differed. I've flagged it in my notes as not-to-be-built-on rather than assuming my result supersedes it. Worth re-deriving if anyone plans further work on that table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cr9aYJNPecpG8zA1Bk7B8